### PR TITLE
fix(memory): bounded ANN wait in recall with lexical fallback (#836)

### DIFF
--- a/crates/khive-pack-memory/src/ann.rs
+++ b/crates/khive-pack-memory/src/ann.rs
@@ -403,6 +403,21 @@ async fn model_warm_lock(ann: &SharedAnn, key: &AnnKey) -> Arc<tokio::sync::Mute
         .clone()
 }
 
+/// #836 test seam: acquire and hold `key`'s per-model warm single-flight
+/// lock, the same one `ensure_ann_for_model` blocks on when a concurrent
+/// caller (e.g. the daemon's boot-time `warm_existing_memory_indexes`) is
+/// mid-build. Returning the owned guard lets a test simulate "boot warm is
+/// building this model from scratch" without depending on real build
+/// latency — the guard is simply held for as long as the test wants, then
+/// dropped to release it.
+#[cfg(test)]
+pub(crate) async fn hold_model_warm_lock_for_test(
+    ann: &SharedAnn,
+    key: &AnnKey,
+) -> tokio::sync::OwnedMutexGuard<()> {
+    model_warm_lock(ann, key).await.lock_owned().await
+}
+
 #[cfg(test)]
 impl AnnState {
     pub(crate) fn warm_route_count(&self) -> usize {

--- a/crates/khive-pack-memory/src/config.rs
+++ b/crates/khive-pack-memory/src/config.rs
@@ -94,6 +94,18 @@ pub struct RecallConfig {
     /// exhausted. When `None`, falls back to the `ANN_OVERFETCH_MAX_ROUNDS`
     /// env var (default 3). Pass `Some(1)` to disable widening entirely.
     pub ann_overfetch_max_rounds: Option<usize>,
+
+    /// Bounded wait (milliseconds) for a cold-miss `ensure_ann_for_model`
+    /// call on the recall path before degrading that model's contribution
+    /// to FTS-only (#836). Recall and the daemon's boot-time background
+    /// warm (`warm_existing_memory_indexes`) both funnel through
+    /// `ensure_ann_for_model`'s per-model single-flight lock; without a
+    /// bound, a recall landing while boot warm holds that lock for a
+    /// from-scratch corpus build waits out the full build (300s+ observed
+    /// in production). When `None`, falls back to the
+    /// `KHIVE_MEMORY_ANN_READY_TIMEOUT_MS` env var (default 8000ms — see
+    /// `handlers::common::ann_ready_timeout_ms`).
+    pub ann_ready_timeout_ms: Option<u64>,
 }
 
 /// Brain-profile hint for score boosting during recall.
@@ -394,6 +406,7 @@ impl Default for RecallConfig {
             brain_profile: None,
             fts_gather: RecallFtsGatherConfig::default(),
             ann_overfetch_max_rounds: None,
+            ann_ready_timeout_ms: None,
         }
     }
 }

--- a/crates/khive-pack-memory/src/handlers/common.rs
+++ b/crates/khive-pack-memory/src/handlers/common.rs
@@ -1031,23 +1031,65 @@ impl MemoryPack {
                 // lock the daemon's boot-time `warm_existing_memory_indexes`
                 // holds for the duration of a from-scratch corpus build
                 // (300s+ observed in production). Bound the wait: past
-                // `ann_ready_timeout_ms`, abandon this attempt and degrade
-                // this model's vector leg to FTS-only for this recall
-                // instead of blocking on the build. The build itself is
-                // untouched — it keeps running (or keeps holding the lock)
-                // in the background, and a later recall benefits once it
-                // installs.
+                // `ann_ready_timeout_ms`, abandon WAITING for this attempt and
+                // degrade this model's vector leg to FTS-only for this recall.
+                //
+                // #836 review: the build itself must never be dropped on
+                // timeout. In the CONTENDED case (some other holder — e.g.
+                // boot warm — already owns `ensure_ann_for_model`'s per-model
+                // `model_warm_lock`) that other holder's own call keeps
+                // running unaffected either way. But on a genuine SELF-BUILD
+                // (no other holder — a cold embedded runtime, or a new model
+                // introduced over a big corpus after boot) this call IS the
+                // only build in flight: dropping the bare timed-out future
+                // used to abandon it mid-build after it had already emitted
+                // `PhaseStarted`, so the matching `PhaseCompleted`/
+                // `PhaseCancelled` never fired (breaking the phase-span
+                // invariant), and left nothing running in the background —
+                // every later recall repeated the same doomed from-scratch
+                // build and timed out again, forever.
+                //
+                // Fix: spawn the `ensure_ann_for_model` call onto a tracked
+                // background task (same `khive_runtime::track_background_task`
+                // `ensure_ann_background` uses, so daemon shutdown's drain()
+                // waits for it) and race a completion signal against the
+                // deadline instead of racing the build itself. On timeout,
+                // only the receiving half is dropped — the sender side (the
+                // spawned task, and the `ensure_ann_for_model` call inside
+                // it) runs to completion regardless, so the phase-event pair
+                // always closes and a later recall finds a warm index.
+                // `ensure_ann_for_model`'s own per-model `model_warm_lock`
+                // single-flights every caller against the same key (spawned
+                // or not), so a second concurrent detach here just blocks on
+                // that lock and returns `AlreadyLoaded` once the first
+                // finishes — it can never start a second build for the same
+                // model.
                 let mut model_ann_timed_out = false;
                 let initial_raw_hits: Option<Vec<(Uuid, f32)>> = match search_result {
                     Ok(Some(hits)) => Some(hits),
                     Ok(None) => {
+                        let (done_tx, done_rx) = tokio::sync::oneshot::channel();
+                        let rt_detached = self.runtime.clone();
+                        let token_detached = token.clone();
+                        let ann_detached = self.ann.clone();
+                        let model_detached = model_name.clone();
+                        khive_runtime::track_background_task(async move {
+                            let result = ann::ensure_ann_for_model(
+                                &rt_detached,
+                                &token_detached,
+                                &ann_detached,
+                                &model_detached,
+                            )
+                            .await;
+                            let _ = done_tx.send(result);
+                        });
                         match tokio::time::timeout(
                             std::time::Duration::from_millis(ann_ready_timeout_ms),
-                            ann::ensure_ann_for_model(&self.runtime, token, &self.ann, &model_name),
+                            done_rx,
                         )
                         .await
                         {
-                            Ok(Ok(status)) => {
+                            Ok(Ok(Ok(status))) => {
                                 tracing::debug!(
                                     ?status,
                                     model = %model_name,
@@ -1056,14 +1098,36 @@ impl MemoryPack {
                                 );
                                 ann::search_loaded(&self.ann, &key, &vec, ann_fetch_limit).await?
                             }
-                            Ok(Err(e)) => return Err(e),
+                            Ok(Ok(Err(e))) => return Err(e),
+                            Ok(Err(_sender_dropped)) => {
+                                // The tracked task's sender was dropped
+                                // without sending — only reachable if that
+                                // task itself panicked (its
+                                // `BackgroundTaskGuard` still decrements the
+                                // shared counter on unwind). Degrade this
+                                // model's vector leg rather than surfacing a
+                                // different task's panic as this recall's
+                                // own error.
+                                tracing::warn!(
+                                    model = %model_name,
+                                    namespace = %ns,
+                                    "memory ANN detached build task ended \
+                                     without a result; degrading recall to \
+                                     FTS-only for this model (#836)"
+                                );
+                                model_ann_timed_out = true;
+                                ann_degraded = true;
+                                None
+                            }
                             Err(_elapsed) => {
                                 tracing::warn!(
                                     model = %model_name,
                                     namespace = %ns,
                                     timeout_ms = ann_ready_timeout_ms,
                                     "memory ANN not ready within bounded wait; \
-                                     degrading recall to FTS-only for this model (#836)"
+                                     degrading recall to FTS-only for this \
+                                     model and detaching the build to finish \
+                                     in the background (#836)"
                                 );
                                 model_ann_timed_out = true;
                                 ann_degraded = true;

--- a/crates/khive-pack-memory/src/handlers/common.rs
+++ b/crates/khive-pack-memory/src/handlers/common.rs
@@ -63,6 +63,30 @@ pub(super) fn ann_overfetch_max_rounds() -> usize {
     })
 }
 
+/// #836: bounded wait, in milliseconds, for a cold-miss `ensure_ann_for_model`
+/// call on the recall path before that model's vector leg degrades to
+/// FTS-only. 8s sits in the middle of the 5-10s range judged long enough to
+/// absorb a snapshot-restore warm (the common cold-miss case) while still
+/// being far short of a from-scratch corpus rebuild (300s+ observed in
+/// production — the #836 hang). Overridable per-request via
+/// `RecallConfig::ann_ready_timeout_ms`; this env fallback covers callers
+/// that never set it.
+pub(super) fn ann_ready_timeout_ms() -> u64 {
+    static TIMEOUT_MS: std::sync::OnceLock<u64> = std::sync::OnceLock::new();
+    *TIMEOUT_MS.get_or_init(|| {
+        const DEFAULT_ANN_READY_TIMEOUT_MS: u64 = 8_000;
+        let ms = std::env::var("KHIVE_MEMORY_ANN_READY_TIMEOUT_MS")
+            .ok()
+            .and_then(|v| v.parse().ok())
+            .unwrap_or(DEFAULT_ANN_READY_TIMEOUT_MS);
+        khive_runtime::config_ledger::record_config_locked(
+            "KHIVE_MEMORY_ANN_READY_TIMEOUT_MS",
+            ms.to_string(),
+        );
+        ms
+    })
+}
+
 #[inline(always)]
 pub(super) fn plog(call_id: u64, stage: &str, us: u128) {
     eprintln!(r#"{{"c":{},"s":"{}","us":{}}}"#, call_id, stage, us);
@@ -395,6 +419,9 @@ pub(super) struct RecallCandidateSet {
     pub(super) multilingual_routed: bool,
     /// The caller's full visible namespace set (primary + any explicit extras).
     pub(super) visible_namespaces: Vec<String>,
+    /// #836: true when at least one model's vector leg degraded to FTS-only
+    /// after hitting the bounded ANN readiness wait.
+    pub(super) ann_degraded: bool,
 }
 
 impl RecallCandidateSet {
@@ -460,6 +487,11 @@ pub(super) struct RecallCandidateParams<'a> {
     /// `RecallConfig::ann_overfetch_max_rounds` (with OnceLock env fallback)
     /// so tests can drive both branches in-process without env mutation.
     pub(super) ann_overfetch_max_rounds: usize,
+    /// #836: bounded wait (ms) for a cold-miss `ensure_ann_for_model` before
+    /// degrading that model to FTS-only. Threaded from
+    /// `RecallConfig::ann_ready_timeout_ms` (with OnceLock env fallback) so
+    /// tests can force the timeout branch deterministically.
+    pub(super) ann_ready_timeout_ms: u64,
 }
 
 pub(super) struct RecallVectorCandidateParams<'a> {
@@ -478,11 +510,19 @@ pub(super) struct RecallVectorCandidateParams<'a> {
     /// Passed explicitly so tests can drive both branches in-process without
     /// mutating the process-wide env.
     pub(super) ann_overfetch_max_rounds: usize,
+    /// #836: bounded wait (ms) for a cold-miss `ensure_ann_for_model` before
+    /// degrading that model to FTS-only. See `RecallCandidateParams`'s field
+    /// of the same name.
+    pub(super) ann_ready_timeout_ms: u64,
 }
 
 pub(super) struct RecallVectorCandidateResult {
     pub(super) vector_hits_per_model: Vec<(String, Vec<VectorSearchHit>)>,
     pub(super) multilingual_routed: bool,
+    /// #836: true when at least one model's vector leg hit the bounded ANN
+    /// readiness wait and was served FTS-only for this recall. The ANN
+    /// build itself keeps running in the background unaffected.
+    pub(super) ann_degraded: bool,
 }
 
 pub(super) fn retrieval_hybrid_config(strategy: &FusionStrategy, limit: usize) -> HybridConfig {
@@ -740,6 +780,7 @@ impl MemoryPack {
             snippet_policy,
             fts_gather,
             ann_overfetch_max_rounds,
+            ann_ready_timeout_ms,
         } = opts;
 
         // FTS recall uses the single shared fts_notes table (V4 migration). Namespace
@@ -776,6 +817,7 @@ impl MemoryPack {
                 scoring_cfg,
                 visible_namespaces: visible.clone(),
                 ann_overfetch_max_rounds,
+                ann_ready_timeout_ms,
             },
         );
         let (text_hits, vector_result) = tokio::try_join!(text_fut, vector_fut)?;
@@ -785,6 +827,7 @@ impl MemoryPack {
             vector_hits_per_model: vector_result.vector_hits_per_model,
             multilingual_routed: vector_result.multilingual_routed,
             visible_namespaces: visible,
+            ann_degraded: vector_result.ann_degraded,
         })
     }
 
@@ -814,6 +857,7 @@ impl MemoryPack {
             scoring_cfg,
             visible_namespaces,
             ann_overfetch_max_rounds,
+            ann_ready_timeout_ms,
         } = opts;
 
         // Over-fetch factor for the ANN path: F=4, M=32.
@@ -827,6 +871,7 @@ impl MemoryPack {
         let call_id = PROF_CID.with(|c| c.get());
 
         let mut multilingual_routed = false;
+        let mut ann_degraded = false;
         let model_names: Vec<String> = if let Some(m) = embedding_model {
             vec![m.to_string()]
         } else {
@@ -980,19 +1025,51 @@ impl MemoryPack {
                 if !cache_fresh && matches!(search_result, Ok(Some(_))) {
                     ann::ensure_ann_background(&self.runtime, token, &self.ann, &model_name).await;
                 }
+                // #836: a genuine cache miss (nothing installed for this
+                // model at all) still pays for an inline `ensure_ann_for_model`,
+                // but that call contends on the same per-model single-flight
+                // lock the daemon's boot-time `warm_existing_memory_indexes`
+                // holds for the duration of a from-scratch corpus build
+                // (300s+ observed in production). Bound the wait: past
+                // `ann_ready_timeout_ms`, abandon this attempt and degrade
+                // this model's vector leg to FTS-only for this recall
+                // instead of blocking on the build. The build itself is
+                // untouched — it keeps running (or keeps holding the lock)
+                // in the background, and a later recall benefits once it
+                // installs.
+                let mut model_ann_timed_out = false;
                 let initial_raw_hits: Option<Vec<(Uuid, f32)>> = match search_result {
                     Ok(Some(hits)) => Some(hits),
                     Ok(None) => {
-                        let status =
-                            ann::ensure_ann_for_model(&self.runtime, token, &self.ann, &model_name)
-                                .await?;
-                        tracing::debug!(
-                            ?status,
-                            model = %model_name,
-                            namespace = %ns,
-                            "memory ANN ensured on recall miss"
-                        );
-                        ann::search_loaded(&self.ann, &key, &vec, ann_fetch_limit).await?
+                        match tokio::time::timeout(
+                            std::time::Duration::from_millis(ann_ready_timeout_ms),
+                            ann::ensure_ann_for_model(&self.runtime, token, &self.ann, &model_name),
+                        )
+                        .await
+                        {
+                            Ok(Ok(status)) => {
+                                tracing::debug!(
+                                    ?status,
+                                    model = %model_name,
+                                    namespace = %ns,
+                                    "memory ANN ensured on recall miss"
+                                );
+                                ann::search_loaded(&self.ann, &key, &vec, ann_fetch_limit).await?
+                            }
+                            Ok(Err(e)) => return Err(e),
+                            Err(_elapsed) => {
+                                tracing::warn!(
+                                    model = %model_name,
+                                    namespace = %ns,
+                                    timeout_ms = ann_ready_timeout_ms,
+                                    "memory ANN not ready within bounded wait; \
+                                     degrading recall to FTS-only for this model (#836)"
+                                );
+                                model_ann_timed_out = true;
+                                ann_degraded = true;
+                                None
+                            }
+                        }
                     }
                     Err(e) => {
                         tracing::warn!(
@@ -1005,6 +1082,17 @@ impl MemoryPack {
                         None
                     }
                 };
+
+                if model_ann_timed_out {
+                    // FTS-only degraded fallback: contribute zero vector
+                    // candidates for this model rather than falling through
+                    // to the sqlite-vec exact-search branch below, which is
+                    // itself an O(corpus) scan unsuited to a bounded-latency
+                    // fallback. `fuse_candidates` degenerates to the lexical
+                    // (FTS) arm for this model's contribution.
+                    results.push((model_name, Vec::new()));
+                    continue;
+                }
 
                 if let Some(first_raw) = initial_raw_hits {
                     // Bounded retry: widen fetch window if visible-namespace survivors
@@ -1149,6 +1237,7 @@ impl MemoryPack {
         Ok(RecallVectorCandidateResult {
             vector_hits_per_model,
             multilingual_routed,
+            ann_degraded,
         })
     }
 

--- a/crates/khive-pack-memory/src/handlers/recall.rs
+++ b/crates/khive-pack-memory/src/handlers/recall.rs
@@ -231,6 +231,12 @@ impl MemoryPack {
             .ann_overfetch_max_rounds
             .unwrap_or_else(super::common::ann_overfetch_max_rounds);
 
+        // #836: bounded wait for a cold-miss `ensure_ann_for_model` on this
+        // recall's own vector leg before it degrades to FTS-only.
+        let ann_ready_timeout_ms = cfg
+            .ann_ready_timeout_ms
+            .unwrap_or_else(super::common::ann_ready_timeout_ms);
+
         // #430: the FTS/vector candidate cap (`candidate_limit`) is applied over all
         // note kinds, not just `memory` rows, so a query pool dominated by higher-ranking
         // non-memory notes can starve out eligible memories before hydration ever sees
@@ -253,6 +259,7 @@ impl MemoryPack {
                     snippet_policy: TextSnippetPolicy::Omit,
                     fts_gather: &effective_fts_gather,
                     ann_overfetch_max_rounds,
+                    ann_ready_timeout_ms,
                 },
             )
             .await?;
@@ -291,6 +298,7 @@ impl MemoryPack {
                         snippet_policy: TextSnippetPolicy::Omit,
                         fts_gather: &effective_fts_gather,
                         ann_overfetch_max_rounds,
+                        ann_ready_timeout_ms,
                     },
                 )
                 .await?;
@@ -317,6 +325,9 @@ impl MemoryPack {
         }
 
         let actual_multilingual_routed = candidates.multilingual_routed;
+        // #836: at least one embedding model's vector leg hit the bounded
+        // ANN readiness wait and was served FTS-only for this recall.
+        let ann_degraded = candidates.ann_degraded;
 
         if prof {
             if let Some(ref t) = t_stage {
@@ -731,6 +742,13 @@ impl MemoryPack {
                 if actual_multilingual_routed {
                     result["multilingual_routed"] = json!(true);
                 }
+                if ann_degraded {
+                    // #836: this recall's ANN leg degraded to FTS-only after
+                    // hitting the bounded readiness wait — stamped per result
+                    // (same convention as `multilingual_routed`) so a plain,
+                    // non-verbose response array still carries the signal.
+                    result["degraded"] = json!("ann_unavailable");
+                }
                 result
             })
             .collect();
@@ -1066,6 +1084,190 @@ mod tests {
             "#569 memory.recall must fail loud when the FTS leg errors on a residual \
              FTS5 char ('@'), not silently degrade to vector-only results, got: {:?}",
             result.ok()
+        );
+    }
+
+    // ── #836: bounded ANN readiness wait + FTS-only degraded fallback ─────────
+
+    /// #836 regression: `memory.recall`'s vector leg must not block on
+    /// `ensure_ann_for_model`'s per-model single-flight lock for longer than
+    /// the configured `ann_ready_timeout_ms` bound. A concurrent holder of
+    /// that lock (mirroring the daemon's boot-time
+    /// `warm_existing_memory_indexes` mid-build) previously meant the recall
+    /// waited out the full build duration (300s+ observed in production);
+    /// this asserts the bounded wait fires instead and the recall serves
+    /// FTS-only results, marked `"degraded": "ann_unavailable"`.
+    ///
+    /// Fail-on-revert proof: reverting the `tokio::time::timeout` wrap in
+    /// `collect_recall_vector_hits` (handlers/common.rs) back to a bare
+    /// `.await` on `ensure_ann_for_model` makes this test hang until the
+    /// held lock guard is dropped (it never is, within the test), so it
+    /// would fail on the `elapsed < ...` bound (or time out entirely under
+    /// `cargo test`'s own test-thread deadline).
+    #[tokio::test]
+    #[serial(background_tasks)]
+    async fn recall_836_degrades_to_fts_only_when_ann_lock_is_held() {
+        const MODEL: &str = "recall-836-ann-timeout-model";
+        const DIMS: usize = 16;
+        const NOTE_TEXT: &str = "issue 836 bounded ann acquire recall fts fallback note";
+
+        let rt = KhiveRuntime::memory().expect("in-memory runtime");
+        rt.register_embedder(HashVecProvider {
+            model_name: MODEL.to_owned(),
+            dims: DIMS,
+        });
+
+        let ns = Namespace::parse("local").expect("local namespace");
+        let token = rt.authorize(ns).expect("authorize local");
+
+        rt.create_note(&token, "memory", None, NOTE_TEXT, Some(0.7), None, vec![])
+            .await
+            .expect("create note");
+
+        let pack = MemoryPack::new(rt.clone());
+        let ann_handle = pack.ann.clone();
+
+        let mut builder = VerbRegistryBuilder::new();
+        builder.register(KgPack::new(rt.clone()));
+        builder.register(pack);
+        let registry = builder.build().expect("registry");
+
+        // Simulate the daemon's boot-time background warm holding the
+        // per-model single-flight lock mid-build (ann.rs `model_warm_lock`),
+        // exactly the contention #836 diagnosed.
+        let key = crate::ann::AnnKey::new("local", MODEL);
+        let _held = crate::ann::hold_model_warm_lock_for_test(&ann_handle, &key).await;
+
+        let start = std::time::Instant::now();
+        let result = registry
+            .dispatch(
+                "memory.recall",
+                serde_json::json!({
+                    "query": "836 bounded ann acquire",
+                    "limit": 10,
+                    "config": { "ann_ready_timeout_ms": 100 }
+                }),
+            )
+            .await
+            .expect("recall must not error when the ANN leg times out");
+        let elapsed = start.elapsed();
+
+        assert!(
+            elapsed < std::time::Duration::from_secs(3),
+            "#836 recall must return within the bounded ANN wait, took {elapsed:?}"
+        );
+
+        let results = result.as_array().expect("recall result must be an array");
+        assert!(
+            !results.is_empty(),
+            "FTS leg must still surface the seeded note when the ANN leg degrades"
+        );
+        for r in results {
+            assert_eq!(
+                r.get("degraded").and_then(Value::as_str),
+                Some("ann_unavailable"),
+                "#836 degraded result must carry the ann_unavailable marker, got: {r:?}"
+            );
+        }
+    }
+
+    /// #836: the normal, uncontended recall path must be byte-identical to
+    /// pre-fix behavior — no `degraded` marker when the ANN leg warms (or
+    /// serves from cache) within the bounded wait.
+    #[tokio::test]
+    #[serial(background_tasks)]
+    async fn recall_836_normal_path_has_no_degraded_marker() {
+        const MODEL: &str = "recall-836-ann-normal-model";
+        const DIMS: usize = 16;
+        const NOTE_TEXT: &str = "issue 836 normal path recall without any ann contention";
+
+        let rt = KhiveRuntime::memory().expect("in-memory runtime");
+        rt.register_embedder(HashVecProvider {
+            model_name: MODEL.to_owned(),
+            dims: DIMS,
+        });
+
+        let ns = Namespace::parse("local").expect("local namespace");
+        let token = rt.authorize(ns).expect("authorize local");
+
+        rt.create_note(&token, "memory", None, NOTE_TEXT, Some(0.7), None, vec![])
+            .await
+            .expect("create note");
+
+        let mut builder = VerbRegistryBuilder::new();
+        builder.register(KgPack::new(rt.clone()));
+        builder.register(MemoryPack::new(rt.clone()));
+        let registry = builder.build().expect("registry");
+
+        let result = registry
+            .dispatch(
+                "memory.recall",
+                serde_json::json!({
+                    "query": "836 normal path recall",
+                    "limit": 10
+                }),
+            )
+            .await
+            .expect("recall must succeed on the normal, uncontended path");
+
+        let results = result.as_array().expect("recall result must be an array");
+        assert!(
+            !results.is_empty(),
+            "normal recall must surface the seeded note"
+        );
+        for r in results {
+            assert!(
+                r.get("degraded").is_none(),
+                "normal recall must not carry a degraded marker, got: {r:?}"
+            );
+        }
+    }
+
+    /// #836: an ANN-degraded recall whose FTS leg also has nothing to match
+    /// must resolve to an empty result, not an error — the timeout path
+    /// must never surface as a hard failure even with zero candidates from
+    /// either leg.
+    #[tokio::test]
+    async fn recall_836_degraded_with_zero_fts_hits_returns_empty_not_error() {
+        const MODEL: &str = "recall-836-ann-timeout-empty-model";
+        const DIMS: usize = 16;
+
+        let rt = KhiveRuntime::memory().expect("in-memory runtime");
+        rt.register_embedder(HashVecProvider {
+            model_name: MODEL.to_owned(),
+            dims: DIMS,
+        });
+
+        // Deliberately no notes seeded: the FTS leg has nothing to match, so
+        // an ANN-degraded recall must still resolve to an empty array rather
+        // than propagating an error.
+        let pack = MemoryPack::new(rt.clone());
+        let ann_handle = pack.ann.clone();
+
+        let mut builder = VerbRegistryBuilder::new();
+        builder.register(KgPack::new(rt.clone()));
+        builder.register(pack);
+        let registry = builder.build().expect("registry");
+
+        let key = crate::ann::AnnKey::new("local", MODEL);
+        let _held = crate::ann::hold_model_warm_lock_for_test(&ann_handle, &key).await;
+
+        let result = registry
+            .dispatch(
+                "memory.recall",
+                serde_json::json!({
+                    "query": "no such content exists anywhere",
+                    "limit": 10,
+                    "config": { "ann_ready_timeout_ms": 100 }
+                }),
+            )
+            .await
+            .expect("recall must not error when both legs come up empty under ANN degradation");
+
+        assert_eq!(
+            result,
+            serde_json::json!([]),
+            "#836 degraded recall with no FTS hits must return an empty array, not an error"
         );
     }
 

--- a/crates/khive-pack-memory/src/handlers/recall.rs
+++ b/crates/khive-pack-memory/src/handlers/recall.rs
@@ -1271,6 +1271,127 @@ mod tests {
         );
     }
 
+    /// #836 review fix: on a genuine SELF-BUILD timeout — no other holder of
+    /// the per-model `model_warm_lock` (unlike
+    /// `recall_836_degrades_to_fts_only_when_ann_lock_is_held` above, which
+    /// simulates a concurrent holder), this recall's own
+    /// `ensure_ann_for_model` call is the ONLY build in flight — the timed-out
+    /// build must not be dropped. This asserts the detached background build
+    /// eventually installs a fresh ANN index and a later recall takes the
+    /// vector path (no `ann_unavailable` marker), instead of every recall
+    /// restarting and re-timing-out on the same doomed build forever.
+    ///
+    /// A near-zero `ann_ready_timeout_ms` deterministically forces the bounded
+    /// wait to expire on its very first poll (the freshly spawned detached
+    /// task cannot have sent its result yet), without needing an artificially
+    /// large corpus to slow the real build down.
+    ///
+    /// Fail-on-revert proof: reverting `collect_recall_vector_hits`'s detach
+    /// (handlers/common.rs) back to a bare `tokio::time::timeout` wrapping
+    /// `ensure_ann_for_model(...)` directly drops that future on timeout —
+    /// the model never warms, so the `is_current` poll loop below exhausts
+    /// its budget and `warmed` stays `false`, and the second recall keeps
+    /// carrying the `ann_unavailable` marker forever.
+    #[tokio::test]
+    #[serial(background_tasks)]
+    async fn recall_836_self_build_timeout_detaches_build_instead_of_dropping_it() {
+        const MODEL: &str = "recall-836-self-build-detach-model";
+        const DIMS: usize = 16;
+        const NOTE_TEXT: &str = "issue 836 self build detach recall regression note";
+
+        let rt = KhiveRuntime::memory().expect("in-memory runtime");
+        rt.register_embedder(HashVecProvider {
+            model_name: MODEL.to_owned(),
+            dims: DIMS,
+        });
+
+        let ns = Namespace::parse("local").expect("local namespace");
+        let token = rt.authorize(ns).expect("authorize local");
+
+        rt.create_note(&token, "memory", None, NOTE_TEXT, Some(0.7), None, vec![])
+            .await
+            .expect("create note");
+
+        let pack = MemoryPack::new(rt.clone());
+        let ann_handle = pack.ann.clone();
+
+        let mut builder = VerbRegistryBuilder::new();
+        builder.register(KgPack::new(rt.clone()));
+        builder.register(pack);
+        let registry = builder.build().expect("registry");
+
+        // Deliberately no lock held here — this is the self-build case: this
+        // recall's own detached `ensure_ann_for_model` call is the only
+        // build in flight for this model.
+        let result = registry
+            .dispatch(
+                "memory.recall",
+                serde_json::json!({
+                    "query": "836 self build detach",
+                    "limit": 10,
+                    "config": { "ann_ready_timeout_ms": 0 }
+                }),
+            )
+            .await
+            .expect("recall must not error when the self-build ANN leg times out");
+
+        let results = result.as_array().expect("recall result must be an array");
+        assert!(
+            !results.is_empty(),
+            "FTS leg must still surface the seeded note while the ANN leg degrades"
+        );
+        for r in results {
+            assert_eq!(
+                r.get("degraded").and_then(Value::as_str),
+                Some("ann_unavailable"),
+                "first recall must still degrade to FTS-only within the \
+                 near-zero timeout, got: {r:?}"
+            );
+        }
+
+        // The detached build must keep running after the timed-out recall
+        // returns — poll the ANN cache directly (mirrors ann.rs's own
+        // #812/#844 convergence tests) rather than sleeping a fixed amount.
+        let key = crate::ann::AnnKey::new("local", MODEL);
+        let mut warmed = false;
+        for _ in 0..300 {
+            if crate::ann::is_current(&ann_handle, &key).await {
+                warmed = true;
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        }
+        assert!(
+            warmed,
+            "the detached build must eventually install a fresh ANN index for \
+             {MODEL} instead of being dropped on timeout (#836 review)"
+        );
+
+        // A later recall must now take the vector path — no degraded marker.
+        let result2 = registry
+            .dispatch(
+                "memory.recall",
+                serde_json::json!({
+                    "query": "836 self build detach",
+                    "limit": 10
+                }),
+            )
+            .await
+            .expect("recall must succeed once the detached build has warmed the index");
+        let results2 = result2.as_array().expect("recall result must be an array");
+        assert!(
+            !results2.is_empty(),
+            "warmed recall must still surface the seeded note"
+        );
+        for r in results2 {
+            assert!(
+                r.get("degraded").is_none(),
+                "a recall issued after the detached build completes must take \
+                 the vector path, not degrade, got: {r:?}"
+            );
+        }
+    }
+
     // ── ADR-081 §5 (#394): recall serve-time attribution + ledger append ──────
 
     fn build_full_rt_with_brain() -> khive_runtime::KhiveRuntime {

--- a/crates/khive-pack-memory/src/handlers/sub_handlers.rs
+++ b/crates/khive-pack-memory/src/handlers/sub_handlers.rs
@@ -107,6 +107,9 @@ impl MemoryPack {
         let ann_overfetch_max_rounds_cand = cfg
             .ann_overfetch_max_rounds
             .unwrap_or_else(super::common::ann_overfetch_max_rounds);
+        let ann_ready_timeout_ms_cand = cfg
+            .ann_ready_timeout_ms
+            .unwrap_or_else(super::common::ann_ready_timeout_ms);
 
         let candidates = self
             .collect_recall_candidates(
@@ -123,6 +126,7 @@ impl MemoryPack {
                     },
                     fts_gather: &effective_fts_gather_cand,
                     ann_overfetch_max_rounds: ann_overfetch_max_rounds_cand,
+                    ann_ready_timeout_ms: ann_ready_timeout_ms_cand,
                 },
             )
             .await?;
@@ -221,6 +225,9 @@ impl MemoryPack {
         let ann_overfetch_max_rounds_fuse = cfg
             .ann_overfetch_max_rounds
             .unwrap_or_else(super::common::ann_overfetch_max_rounds);
+        let ann_ready_timeout_ms_fuse = cfg
+            .ann_ready_timeout_ms
+            .unwrap_or_else(super::common::ann_ready_timeout_ms);
 
         let candidates = self
             .collect_recall_candidates(
@@ -237,6 +244,7 @@ impl MemoryPack {
                     },
                     fts_gather: &effective_fts_gather_fuse,
                     ann_overfetch_max_rounds: ann_overfetch_max_rounds_fuse,
+                    ann_ready_timeout_ms: ann_ready_timeout_ms_fuse,
                 },
             )
             .await?;

--- a/crates/khive-pack-memory/src/handlers/tests.rs
+++ b/crates/khive-pack-memory/src/handlers/tests.rs
@@ -291,6 +291,7 @@ fn fusion_strategy_change_produces_observable_ordering_difference() {
         vector_hits_per_model: vec![("mock".to_string(), vector_hits.clone())],
         multilingual_routed: false,
         visible_namespaces: vec!["local".to_string()],
+        ann_degraded: false,
     };
     let cfg_rrf = RecallConfig {
         fuse_strategy: FusionStrategy::Rrf { k: 60 },
@@ -305,6 +306,7 @@ fn fusion_strategy_change_produces_observable_ordering_difference() {
         vector_hits_per_model: vec![("mock".to_string(), vector_hits)],
         multilingual_routed: false,
         visible_namespaces: vec!["local".to_string()],
+        ann_degraded: false,
     };
     let cfg_weighted = RecallConfig {
         fuse_strategy: FusionStrategy::Weighted {
@@ -646,6 +648,7 @@ fn vector_candidates_per_model_shape_is_array_of_model_objects() {
         ],
         multilingual_routed: false,
         visible_namespaces: vec!["test".to_string()],
+        ann_degraded: false,
     };
 
     let per_model: Vec<Value> = candidates


### PR DESCRIPTION
## Summary

`memory.recall` timed out at the 300s MCP ceiling on three independent occasions in production on 2026-07-11. In each case the stall was isolated to the memory-pack semantic recall path; every other verb on the same warm daemon (`knowledge.search`, `gtd.tasks`, ~20 create/link/update writes) returned in under a second.

## Root cause

`collect_recall_vector_hits` (`crates/khive-pack-memory/src/handlers/common.rs`) calls `ensure_ann_for_model` on a cold cache miss for a model's vector index. That call acquires a per-model single-flight lock (`ann.rs::model_warm_lock`) before it will do anything. The daemon's boot-time background warm (`warm_existing_memory_indexes`, triggered from `crates/khive-runtime/src/daemon.rs`) holds that same lock for the full duration of a from-scratch corpus build. A recall landing while boot warm is still building therefore blocked on lock acquisition for the entire build, with no bound.

This is distinct from the write-triggered rebuild path ADR-107 already covers (a write bumping a model's generation counter and re-triggering a background rebuild does not block recall). The gap was specifically the synchronous cold-miss path, which had no timeout at all.

## Fix

`collect_recall_vector_hits` now wraps the `ensure_ann_for_model` await in a bounded `tokio::time::timeout` (default 8s). The bound is tunable per request via `RecallConfig.ann_ready_timeout_ms`, or process-wide via `KHIVE_MEMORY_ANN_READY_TIMEOUT_MS`.

On timeout, that model's vector leg contributes zero candidates for this recall and the hybrid pipeline degenerates to its lexical (FTS) arm instead of falling through to the sqlite-vec exact-search fallback (which is itself an O(corpus) scan, unsuited to a bounded-latency path). Each result in a degraded response is stamped `"degraded": "ann_unavailable"`, following the same per-result convention already used for `multilingual_routed`. A degraded recall with zero FTS hits still returns an empty array, not an error.

The ANN build itself, the boot-time warm task, and ADR-107's invalidation/generation semantics are unchanged. A later recall against the same model benefits from the build once it installs, exactly as before.

## Tests

Three new regression tests in `khive-pack-memory` (`handlers/recall.rs`):
- a recall issued while the model's warm lock is held (simulating boot warm mid-build) returns within the bounded wait, with FTS-only results marked `degraded: "ann_unavailable"`
- the normal, uncontended path is unchanged: no `degraded` marker
- a degraded recall whose FTS leg also has no matches returns an empty array, not an error

`cargo test -p khive-pack-memory`: 323 passed, 0 failed.
`cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets -- -D warnings`, and `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps -p khive-pack-memory` all pass clean.

## Test plan

- [x] `cargo test -p khive-pack-memory` (323 passed)
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps -p khive-pack-memory`

Closes #836.

🤖 Generated with [Claude Code](https://claude.com/claude-code)