### PR TITLE
feat(perf): shared MCP measurement client (benchmark program PR2)

### DIFF
--- a/scripts/perf/bench_load_harness.py
+++ b/scripts/perf/bench_load_harness.py
@@ -52,8 +52,6 @@ import json
 import os
 import pathlib
 import random
-import socket as socketlib
-import struct
 import subprocess
 import sys
 import tempfile
@@ -64,11 +62,12 @@ from concurrent.futures import TimeoutError as FutureTimeoutError
 
 sys.path.insert(0, str(pathlib.Path(__file__).parent))
 import bench_pipeline_daemon as bpd  # noqa: E402  (reuse framing/lifecycle helpers)
+import mcp_bench_client as mbc  # noqa: E402  (shared MCP/daemon client plumbing, PR2)
 
 REPO_ROOT = pathlib.Path(__file__).parent.parent.parent
 
 # ── Wire protocol constants (mirrors crates/khive-runtime/src/daemon.rs) ──────
-PROTOCOL_VERSION = 3
+PROTOCOL_VERSION = mbc.PROTOCOL_VERSION
 # Pack posture for the spawned scratch daemon (feeds KHIVE_PACKS). Pinned explicitly here rather
 # than reused from bpd._DEFAULT_PACKS so the config_id/registry surface is stated, not inherited.
 #
@@ -153,123 +152,14 @@ def release_metal_gpu_lock(fh) -> None:
 # Every other channel goes through the existing front-end binary (stdio MCP).
 # This is the one place we speak the daemon's Unix-socket wire protocol
 # directly in Python, because the oracle channel needs a `metrics_only` frame
-# field that the stdio/MCP surface has no verb for (it isn't merged yet).
+# field the stdio/MCP surface has no verb for. Implementation now lives in
+# mcp_bench_client.py (PR2 shared client module); these names stay so the rest
+# of this file (and any external caller) is unaffected by the move.
 
-
-def _recv_exact(sock: socketlib.socket, n: int) -> bytes:
-    buf = b""
-    while len(buf) < n:
-        chunk = sock.recv(n - len(buf))
-        if not chunk:
-            raise RuntimeError("daemon socket closed mid-frame")
-        buf += chunk
-    return buf
-
-
-def _raw_daemon_roundtrip(sock_path: str, frame: dict, timeout_s: float = 5.0) -> dict:
-    s = socketlib.socket(socketlib.AF_UNIX, socketlib.SOCK_STREAM)
-    s.settimeout(timeout_s)
-    try:
-        s.connect(sock_path)
-        payload = json.dumps(frame).encode()
-        s.sendall(struct.pack(">I", len(payload)) + payload)
-        len_buf = _recv_exact(s, 4)
-        (length,) = struct.unpack(">I", len_buf)
-        raw = _recv_exact(s, length)
-        return json.loads(raw)
-    finally:
-        s.close()
-
-
-def _base_daemon_frame(ops: str, config_id: str, probe_only: bool) -> dict:
-    """Build a DaemonRequestFrame JSON payload. `presentation` /
-    `presentation_per_op` / `namespace` have no serde default on the Rust
-    struct (unlike the rest), so they must always be present in the wire
-    payload or the daemon silently drops the connection.
-    """
-    return {
-        "ops": ops,
-        "presentation": None,
-        "presentation_per_op": None,
-        "namespace": "local",
-        "actor_id": None,
-        "visible_namespaces": [],
-        "config_id": config_id,
-        "protocol_version": PROTOCOL_VERSION,
-        "probe_only": probe_only,
-        "format": None,
-        "format_per_op": None,
-        "from_wire": False,
-    }
-
-
-def probe_oracle_channel(sock_path: str) -> dict:
-    """Two-step probe against the daemon-frame snapshot channel.
-
-    Step 1 — config_id discovery: send an intentionally WRONG config_id as a
-    probe_only frame. The daemon computes and echoes `served_config_id` on
-    EVERY response, including a `config_mismatch` one, so this harvests the
-    daemon's real config_id without reimplementing its Rust-side computation
-    in Python.
-
-    Step 2 — metrics support probe: resend with the correct config_id and an
-    extra `metrics_only: true` field (the field name the not-yet-merged
-    metrics-frame PR is expected to define). Today this field is unknown to
-    the server and silently ignored (serde ignores unrecognized JSON keys by
-    default), so the request just dispatches `ops` normally and the response
-    carries no `metrics` key — that absence IS the "PENDING" signal. Once the
-    metrics PR merges, a `metrics` key appearing in the response flips this to
-    "LIVE" with no code change required here.
-
-    Never raises: any failure degrades to PENDING with the reason recorded.
-    """
-    try:
-        resp1 = _raw_daemon_roundtrip(
-            sock_path, _base_daemon_frame("", "__loadharness_discovery_probe__", True)
-        )
-    except Exception as exc:
-        return {"oracle": "PENDING", "config_id": None, "detail": f"discovery round-trip failed: {exc!r}"}
-
-    real_config_id = resp1.get("served_config_id")
-    if not real_config_id:
-        return {
-            "oracle": "PENDING",
-            "config_id": None,
-            "detail": f"no served_config_id in discovery response: {resp1}",
-        }
-
-    metrics_frame = _base_daemon_frame("stats()", real_config_id, False)
-    metrics_frame["metrics_only"] = True
-    try:
-        resp2 = _raw_daemon_roundtrip(sock_path, metrics_frame)
-    except Exception as exc:
-        return {
-            "oracle": "PENDING",
-            "config_id": real_config_id,
-            "detail": f"metrics probe round-trip failed: {exc!r}",
-        }
-
-    if resp2.get("config_mismatch"):
-        return {
-            "oracle": "PENDING",
-            "config_id": real_config_id,
-            "detail": f"config_mismatch on metrics probe (unexpected race): {resp2}",
-        }
-    if resp2.get("metrics") is not None:
-        return {
-            "oracle": "LIVE",
-            "config_id": real_config_id,
-            "detail": "response carries a populated `metrics` key",
-            "metrics": resp2["metrics"],
-        }
-    return {
-        "oracle": "PENDING",
-        "config_id": real_config_id,
-        "detail": (
-            "no `metrics` key in response — this daemon predates the metrics-frame "
-            "PR (metrics_only was ignored as an unknown field)"
-        ),
-    }
+_recv_exact = mbc.recv_exact
+_raw_daemon_roundtrip = mbc.raw_daemon_roundtrip
+_base_daemon_frame = mbc.base_daemon_frame
+probe_oracle_channel = mbc.probe_metrics_snapshot
 
 
 # ── generic nested-value lookup (attribution readback, dim 8) ────────────────

--- a/scripts/perf/bench_pipeline_daemon.py
+++ b/scripts/perf/bench_pipeline_daemon.py
@@ -40,11 +40,13 @@ import itertools
 import json
 import os
 import pathlib
-import signal
 import subprocess
 import sys
 import tempfile
 import time
+
+sys.path.insert(0, str(pathlib.Path(__file__).parent))
+import mcp_bench_client as mbc  # noqa: E402  (shared MCP/daemon client plumbing, PR2)
 
 # ── Tunables ──────────────────────────────────────────────────────────────────
 
@@ -76,8 +78,8 @@ ANN_SETTLE_POLL_S = 0.25
 
 # Default production pack set (must match RuntimeConfig::default().packs in
 # crates/khive-runtime/src/config.rs so config_id agrees between front-end
-# and daemon child).
-_DEFAULT_PACKS = "kg,gtd,memory,brain,comm,schedule,knowledge,session,git,code"
+# and daemon child). Shared with bench_load_harness.py via mcp_bench_client.py.
+_DEFAULT_PACKS = mbc.DEFAULT_PACKS
 
 TOPICS = [
     ("knowledge graph", ["entity", "edge", "relation", "graph", "node", "ontology", "triple", "schema", "link", "concept"]),
@@ -143,72 +145,11 @@ def _make_sentinel_content():
     """
     return f"__khive_bench_settle_sentinel_pid{os.getpid()}_seq{next(_SENTINEL_SEQ)}__"
 
-# ── MCP stdio driver (mirrors smoke_test.py pattern) ─────────────────────────
+# ── MCP stdio driver (shared plumbing, mcp_bench_client.py, PR2) ─────────────
 
-_request_id = 0
-
-def _next_id():
-    global _request_id
-    _request_id += 1
-    return _request_id
-
-
-def _send(proc, method, params=None):
-    msg = {"jsonrpc": "2.0", "id": _next_id(), "method": method}
-    if params is not None:
-        msg["params"] = params
-    proc.stdin.write((json.dumps(msg) + "\n").encode())
-    proc.stdin.flush()
-
-
-def _recv(proc):
-    line = proc.stdout.readline()
-    if not line:
-        raise RuntimeError("MCP binary closed stdout unexpectedly")
-    return json.loads(line)
-
-
-def _call_request(proc, ops_string):
-    _send(proc, "tools/call", {"name": "request", "arguments": {"ops": ops_string}})
-    resp = _recv(proc)
-    if "error" in resp:
-        raise RuntimeError(f"MCP RPC error: {resp['error']}")
-    result = resp.get("result", {})
-    if result.get("isError"):
-        content = result.get("content", [])
-        text = content[0]["text"] if content else "(no text)"
-        raise RuntimeError(f"request returned protocol error: {text}")
-    content = result.get("content", [])
-    text = content[0]["text"] if content else ""
-    return json.loads(text) if text else None
-
-
-def _call_verb(proc, verb, args):
-    ops = json.dumps([{"tool": verb, "args": args}])
-    body = _call_request(proc, ops)
-    if body is None:
-        raise RuntimeError(f"Empty response for verb {verb}")
-    results = body.get("results") or []
-    if not results:
-        raise RuntimeError(f"No results in response for verb {verb}: {body}")
-    first = results[0]
-    if not first.get("ok", False):
-        raise RuntimeError(f"Verb {verb} failed: {first.get('error', '<no error>')}")
-    return first.get("result")
-
-
-def _handshake(proc):
-    _send(proc, "initialize", {
-        "protocolVersion": "2024-11-05",
-        "capabilities": {},
-        "clientInfo": {"name": "bench-pipeline", "version": "1.0.0"},
-    })
-    init = _recv(proc)
-    if "error" in init:
-        raise RuntimeError(f"initialize failed: {init['error']}")
-    notify = {"jsonrpc": "2.0", "method": "notifications/initialized"}
-    proc.stdin.write((json.dumps(notify) + "\n").encode())
-    proc.stdin.flush()
+_call_request = mbc.call_request
+_call_verb = mbc.call_verb
+_handshake = mbc.handshake
 
 # ── Quality ───────────────────────────────────────────────────────────────────
 
@@ -220,144 +161,14 @@ def precision_at_k(contents, expected_topic):
         return 0.0
     return sum(1 for c in contents if expected_topic in c) / TOP_K
 
-# ── Daemon engagement assertions ──────────────────────────────────────────────
+# ── Daemon engagement assertions (shared plumbing, mcp_bench_client.py, PR2)
 
-def _read_pid_file(pid_path):
-    """Return (pid:int, raw:str) from pid file, or (None, None) if absent/bad."""
-    try:
-        raw = pathlib.Path(pid_path).read_text().strip()
-        return int(raw), raw
-    except Exception:
-        return None, None
-
-
-def _pid_alive(pid):
-    """Return True if the process is alive (signal 0)."""
-    try:
-        os.kill(pid, 0)
-        return True
-    except (ProcessLookupError, PermissionError):
-        return False
-
-
-def _argv_is_khive_daemon(pid):
-    """Return True if ps shows this PID running kkernel (or kkernel-bench) mcp --daemon."""
-    try:
-        out = subprocess.check_output(
-            ["ps", "-p", str(pid), "-o", "args="],
-            stderr=subprocess.DEVNULL,
-        ).decode().strip()
-        tokens = out.split()
-        if not tokens:
-            return False
-        basename = os.path.basename(tokens[0])
-        # Accept kkernel (production) or kkernel-bench (bench binary, which spawns
-        # itself as the daemon via current_exe() in spawn_daemon()).
-        if basename not in ("kkernel", "kkernel-bench"):
-            return False
-        rest = tokens[1:]
-        return "mcp" in rest and "--daemon" in rest
-    except Exception:
-        return False
-
-
-def _lsof_has_bench_db(pid, bench_db):
-    """Return True if the process has bench_db open (best-effort, skips if lsof absent)."""
-    try:
-        out = subprocess.check_output(
-            ["lsof", "-p", str(pid)],
-            stderr=subprocess.DEVNULL,
-        ).decode()
-        bench_db_real = str(pathlib.Path(bench_db).resolve())
-        return bench_db_real in out
-    except FileNotFoundError:
-        print("[SKIP] lsof not available — skipping open-file sub-check", flush=True)
-        return None  # None means skipped, not False
-    except Exception:
-        return False
-
-
-def assert_daemon_engaged(sock_path, pid_path, bench_db, label="main"):
-    """Assert all three daemon-engagement checks pass. Exit non-zero on failure."""
-    errors = []
-
-    # Check 1: socket file exists
-    if not pathlib.Path(sock_path).exists():
-        errors.append(
-            f"[DAEMON-CHECK-{label}] FAIL: bench socket {sock_path!r} does not exist. "
-            "The front-end must have silently fallen back to local dispatch."
-        )
-    else:
-        print(f"[DAEMON-CHECK-{label}] PASS: bench socket {sock_path!r} exists", flush=True)
-
-    # Check 2: PID file exists, PID is alive, and argv is kkernel mcp --daemon
-    pid, _ = _read_pid_file(pid_path)
-    if pid is None:
-        errors.append(
-            f"[DAEMON-CHECK-{label}] FAIL: bench PID file {pid_path!r} absent or unreadable."
-        )
-    elif not _pid_alive(pid):
-        errors.append(
-            f"[DAEMON-CHECK-{label}] FAIL: PID {pid} from {pid_path!r} is not alive."
-        )
-    elif not _argv_is_khive_daemon(pid):
-        try:
-            argv_out = subprocess.check_output(
-                ["ps", "-p", str(pid), "-o", "args="], stderr=subprocess.DEVNULL
-            ).decode().strip()
-        except Exception:
-            argv_out = "<ps failed>"
-        errors.append(
-            f"[DAEMON-CHECK-{label}] FAIL: PID {pid} is alive but argv does not match "
-            f"'kkernel mcp --daemon'. Got: {argv_out!r}"
-        )
-    else:
-        print(
-            f"[DAEMON-CHECK-{label}] PASS: PID {pid} is a live kkernel mcp --daemon process",
-            flush=True,
-        )
-
-        # Check 3: that daemon has bench.db open (best-effort)
-        db_open = _lsof_has_bench_db(pid, bench_db)
-        if db_open is None:
-            pass  # skipped
-        elif db_open:
-            print(
-                f"[DAEMON-CHECK-{label}] PASS: PID {pid} has {bench_db!r} open (lsof confirmed)",
-                flush=True,
-            )
-        else:
-            errors.append(
-                f"[DAEMON-CHECK-{label}] FAIL: PID {pid} is 'kkernel mcp --daemon' but does NOT "
-                f"have {bench_db!r} open. It may be attached to the live DB instead."
-            )
-
-    if errors:
-        for msg in errors:
-            print(msg, file=sys.stderr, flush=True)
-        print(
-            f"FATAL: daemon-engagement assertions failed ({label} run). "
-            "The gate CANNOT rely on this run's P@K. Exiting.",
-            file=sys.stderr,
-            flush=True,
-        )
-        sys.exit(1)
-
-
-def assert_no_daemon_spawned(sock_path, label="nodaemon"):
-    """Assert no bench daemon was spawned (KHIVE_NO_DAEMON control run)."""
-    if pathlib.Path(sock_path).exists():
-        print(
-            f"[DAEMON-CHECK-{label}] FAIL: bench socket {sock_path!r} exists when "
-            "KHIVE_NO_DAEMON=1 was set — something spawned a daemon unexpectedly.",
-            file=sys.stderr,
-            flush=True,
-        )
-        sys.exit(1)
-    print(
-        f"[DAEMON-CHECK-{label}] PASS: no bench socket with KHIVE_NO_DAEMON=1 (correct)",
-        flush=True,
-    )
+_read_pid_file = mbc.read_pid_file
+_pid_alive = mbc.pid_alive
+_argv_is_khive_daemon = mbc.argv_is_khive_daemon
+_lsof_has_bench_db = mbc.lsof_has_bench_db
+assert_daemon_engaged = mbc.assert_daemon_engaged
+assert_no_daemon_spawned = mbc.assert_no_daemon_spawned
 
 
 # ── Provenance ────────────────────────────────────────────────────────────────
@@ -436,29 +247,11 @@ def _read_baseline_p50():
         return None
     return rows[0] if rows else None
 
-# ── Safety guard ──────────────────────────────────────────────────────────────
+# ── Safety guard + percentile (shared plumbing, mcp_bench_client.py, PR2) ────
 
-_LIVE_DB_PATHS = frozenset([
-    os.path.expanduser("~/.khive/khive.db"),
-    os.path.expanduser("~/.khive/khive-graph.db"),
-])
-
-
-def _assert_not_live_db(path):
-    resolved = str(pathlib.Path(path).resolve())
-    for live in _LIVE_DB_PATHS:
-        live_resolved = str(pathlib.Path(live).resolve())
-        if resolved == live_resolved or resolved.startswith(str(pathlib.Path(live).parent.resolve())):
-            print(f"FATAL: bench DB path {path!r} resolves to live DB location. Aborting.", file=sys.stderr)
-            sys.exit(2)
-
-# ── Percentile ────────────────────────────────────────────────────────────────
-
-def _pct(sorted_list, p):
-    if not sorted_list:
-        return 0.0
-    idx = min(int(len(sorted_list) * p), len(sorted_list) - 1)
-    return sorted_list[idx]
+_LIVE_DB_PATHS = mbc.LIVE_DB_PATHS
+_assert_not_live_db = mbc.assert_not_live_db
+_pct = mbc.pct
 
 # ── Ingest ────────────────────────────────────────────────────────────────────
 
@@ -574,26 +367,9 @@ def _wait_for_ann_convergence(
     )
 
 
-# ── Daemon teardown helper ────────────────────────────────────────────────────
+# ── Daemon teardown helper (shared plumbing, mcp_bench_client.py, PR2) ───────
 
-def _teardown_daemon(pid_path, tmpdir):
-    """SIGTERM the bench daemon (if any), then rmtree the tmpdir."""
-    import shutil
-    pid, _ = _read_pid_file(pid_path)
-    if pid is not None and _pid_alive(pid) and _argv_is_khive_daemon(pid):
-        try:
-            os.kill(pid, signal.SIGTERM)
-            # Give it a moment to exit cleanly.
-            for _ in range(20):
-                time.sleep(0.1)
-                if not _pid_alive(pid):
-                    break
-        except Exception:
-            pass
-    try:
-        shutil.rmtree(tmpdir, ignore_errors=True)
-    except Exception:
-        pass
+_teardown_daemon = mbc.teardown_daemon
 
 # ── No-daemon control run ─────────────────────────────────────────────────────
 

--- a/scripts/perf/mcp_bench_client.py
+++ b/scripts/perf/mcp_bench_client.py
@@ -499,12 +499,14 @@ def _classify_bad_response(resp: dict, frame: dict) -> str | None:
     WITHOUT dispatching when the frame's `config_id` disagrees with its own
     (`crates/khive-runtime/src/daemon.rs` around 799-810), so a stale or
     mismatched daemon would otherwise produce a plausible-but-wrong
-    fast-rejection latency. `metrics_only` frames are exempt: the daemon
-    answers them before the config_id check (namespace/config-agnostic gauge
-    read), so `served_config_id` there is not a dispatch-identity guarantee.
+    fast-rejection latency. `metrics_only` frames are rejected outright: they
+    are a daemon-metrics gauge probe, answered before the config_id check
+    (namespace/config-agnostic read), never a dispatch measurement, so their
+    elapsed time must never enter the success latency population regardless
+    of what `served_config_id` they carry.
     """
     if frame.get("metrics_only"):
-        return None
+        return "metrics_only"
     if resp.get("config_mismatch"):
         return "config_mismatch"
     if resp.get("version_mismatch"):

--- a/scripts/perf/mcp_bench_client.py
+++ b/scripts/perf/mcp_bench_client.py
@@ -1,0 +1,563 @@
+#!/usr/bin/env python3
+"""Shared stdio-MCP / daemon client plumbing for the perf scripts (stdlib-only).
+
+Extracted from `bench_pipeline_daemon.py` (the stdio MCP handshake/`tools/call`
+layer, daemon-engagement proof, live-DB safety guard, and process teardown)
+and from `bench_load_harness.py` (the raw daemon-socket frame protocol used
+by its metrics-snapshot oracle channel), per the benchmark-overhaul DESIGN.md
+PR 2 slice ("one reusable real-MCP client and daemon lifecycle module").
+
+Both scripts import this module instead of re-implementing the same wire
+protocol twice. This is a pure extraction: no CLI, no output shape, and no
+existing script's observable behavior changes as a result of this module
+existing. `bench_pipeline_daemon.py` and `bench_load_harness.py` re-export
+the names their own module-level code already referenced (e.g.
+`bench_pipeline_daemon._call_verb`), so neither script's internals had to
+change beyond the import.
+
+Three layers live here:
+
+  1. Stdio MCP transport: JSON-RPC `initialize`/`tools/call` framing over a
+     subprocess's stdin/stdout pipes (`handshake`, `call_request`,
+     `call_verb`).
+  2. Daemon-engagement proof: positively confirms a spawned front-end
+     routed traffic through a live `kkernel mcp --daemon` child bound to the
+     expected bench socket/DB, per the Coverage definition's rule that a
+     local-dispatch fallback is a failed scenario, not a sample
+     (`assert_daemon_engaged`, `assert_no_daemon_spawned`).
+  3. Raw daemon-socket framing: speaks the daemon's length-prefixed Unix
+     socket protocol directly (`raw_daemon_roundtrip`, `base_daemon_frame`),
+     used for the F10 diagnostic frame floor and the `metrics_only` gauge
+     snapshot. This bypasses the stdio front-end entirely, so it is a lower
+     attribution layer, not a Coverage-definition-compliant E2E measurement
+     (see `measure_concurrent_frames`'s docstring).
+
+`measure_concurrent_frames` and its two convenience wrappers
+(`measure_probe_only_floor`, `measure_stats_dispatch_floor`) are new in this
+module: deadline-aware concurrent raw-frame requests with timeout censoring,
+the F10 "raw frame control" and "MCP `stats()` floor" pieces from
+DESIGN.md's PR 2 slice that do not require PR 1's flagship manifest/schema
+files. They return a plain percentile/timeout dict, not the versioned
+`FlagshipRecord`/`Distribution` contract (that schema is owned by PR 1's
+`schemas/flagship-result-v1.json`).
+"""
+
+from __future__ import annotations
+
+import concurrent.futures
+import json
+import os
+import pathlib
+import signal
+import socket as socketlib
+import struct
+import subprocess
+import sys
+import time
+
+# ── Wire protocol constants (mirrors crates/khive-runtime/src/daemon.rs) ──────
+
+PROTOCOL_VERSION = 3
+
+# Default production pack set (must match RuntimeConfig::default().packs in
+# crates/khive-runtime/src/config.rs so config_id agrees between front-end
+# and daemon child).
+DEFAULT_PACKS = "kg,gtd,memory,brain,comm,schedule,knowledge,session,git,code"
+
+# ── Live-DB safety guard ──────────────────────────────────────────────────────
+
+LIVE_DB_PATHS = frozenset([
+    os.path.expanduser("~/.khive/khive.db"),
+    os.path.expanduser("~/.khive/khive-graph.db"),
+])
+
+
+def assert_not_live_db(path):
+    """Exit the process if `path` resolves to a live production DB location."""
+    resolved = str(pathlib.Path(path).resolve())
+    for live in LIVE_DB_PATHS:
+        live_resolved = str(pathlib.Path(live).resolve())
+        if resolved == live_resolved or resolved.startswith(str(pathlib.Path(live).parent.resolve())):
+            print(f"FATAL: bench DB path {path!r} resolves to live DB location. Aborting.", file=sys.stderr)
+            sys.exit(2)
+
+
+# ── Stdio MCP transport ───────────────────────────────────────────────────────
+
+_request_id = 0
+
+
+def _next_id():
+    global _request_id
+    _request_id += 1
+    return _request_id
+
+
+def send(proc, method, params=None):
+    """Write one JSON-RPC request line to `proc`'s stdin."""
+    msg = {"jsonrpc": "2.0", "id": _next_id(), "method": method}
+    if params is not None:
+        msg["params"] = params
+    proc.stdin.write((json.dumps(msg) + "\n").encode())
+    proc.stdin.flush()
+
+
+def recv(proc):
+    """Read and decode one JSON-RPC response line from `proc`'s stdout."""
+    line = proc.stdout.readline()
+    if not line:
+        raise RuntimeError("MCP binary closed stdout unexpectedly")
+    return json.loads(line)
+
+
+def call_request(proc, ops_string):
+    """Send one `request(ops=ops_string)` `tools/call` and return the decoded body."""
+    send(proc, "tools/call", {"name": "request", "arguments": {"ops": ops_string}})
+    resp = recv(proc)
+    if "error" in resp:
+        raise RuntimeError(f"MCP RPC error: {resp['error']}")
+    result = resp.get("result", {})
+    if result.get("isError"):
+        content = result.get("content", [])
+        text = content[0]["text"] if content else "(no text)"
+        raise RuntimeError(f"request returned protocol error: {text}")
+    content = result.get("content", [])
+    text = content[0]["text"] if content else ""
+    return json.loads(text) if text else None
+
+
+def call_verb(proc, verb, args):
+    """Call a single verb through `request` and return its unwrapped result."""
+    ops = json.dumps([{"tool": verb, "args": args}])
+    body = call_request(proc, ops)
+    if body is None:
+        raise RuntimeError(f"Empty response for verb {verb}")
+    results = body.get("results") or []
+    if not results:
+        raise RuntimeError(f"No results in response for verb {verb}: {body}")
+    first = results[0]
+    if not first.get("ok", False):
+        raise RuntimeError(f"Verb {verb} failed: {first.get('error', '<no error>')}")
+    return first.get("result")
+
+
+def handshake(proc, client_name="bench-pipeline", client_version="1.0.0"):
+    """Perform the MCP `initialize` / `notifications/initialized` round trip."""
+    send(proc, "initialize", {
+        "protocolVersion": "2024-11-05",
+        "capabilities": {},
+        "clientInfo": {"name": client_name, "version": client_version},
+    })
+    init = recv(proc)
+    if "error" in init:
+        raise RuntimeError(f"initialize failed: {init['error']}")
+    notify = {"jsonrpc": "2.0", "method": "notifications/initialized"}
+    proc.stdin.write((json.dumps(notify) + "\n").encode())
+    proc.stdin.flush()
+
+
+# ── Daemon-engagement proof ────────────────────────────────────────────────────
+
+def read_pid_file(pid_path):
+    """Return (pid:int, raw:str) from pid file, or (None, None) if absent/bad."""
+    try:
+        raw = pathlib.Path(pid_path).read_text().strip()
+        return int(raw), raw
+    except Exception:
+        return None, None
+
+
+def pid_alive(pid):
+    """Return True if the process is alive (signal 0)."""
+    try:
+        os.kill(pid, 0)
+        return True
+    except (ProcessLookupError, PermissionError):
+        return False
+
+
+def argv_is_khive_daemon(pid):
+    """Return True if ps shows this PID running kkernel (or kkernel-bench) mcp --daemon."""
+    try:
+        out = subprocess.check_output(
+            ["ps", "-p", str(pid), "-o", "args="],
+            stderr=subprocess.DEVNULL,
+        ).decode().strip()
+        tokens = out.split()
+        if not tokens:
+            return False
+        basename = os.path.basename(tokens[0])
+        # Accept kkernel (production) or kkernel-bench (bench binary, which spawns
+        # itself as the daemon via current_exe() in spawn_daemon()).
+        if basename not in ("kkernel", "kkernel-bench"):
+            return False
+        rest = tokens[1:]
+        return "mcp" in rest and "--daemon" in rest
+    except Exception:
+        return False
+
+
+def lsof_has_bench_db(pid, bench_db):
+    """Return True if the process has bench_db open (best-effort, skips if lsof absent)."""
+    try:
+        out = subprocess.check_output(
+            ["lsof", "-p", str(pid)],
+            stderr=subprocess.DEVNULL,
+        ).decode()
+        bench_db_real = str(pathlib.Path(bench_db).resolve())
+        return bench_db_real in out
+    except FileNotFoundError:
+        print("[SKIP] lsof not available — skipping open-file sub-check", flush=True)
+        return None  # None means skipped, not False
+    except Exception:
+        return False
+
+
+def assert_daemon_engaged(sock_path, pid_path, bench_db, label="main"):
+    """Assert all three daemon-engagement checks pass. Exit non-zero on failure."""
+    errors = []
+
+    # Check 1: socket file exists
+    if not pathlib.Path(sock_path).exists():
+        errors.append(
+            f"[DAEMON-CHECK-{label}] FAIL: bench socket {sock_path!r} does not exist. "
+            "The front-end must have silently fallen back to local dispatch."
+        )
+    else:
+        print(f"[DAEMON-CHECK-{label}] PASS: bench socket {sock_path!r} exists", flush=True)
+
+    # Check 2: PID file exists, PID is alive, and argv is kkernel mcp --daemon
+    pid, _ = read_pid_file(pid_path)
+    if pid is None:
+        errors.append(
+            f"[DAEMON-CHECK-{label}] FAIL: bench PID file {pid_path!r} absent or unreadable."
+        )
+    elif not pid_alive(pid):
+        errors.append(
+            f"[DAEMON-CHECK-{label}] FAIL: PID {pid} from {pid_path!r} is not alive."
+        )
+    elif not argv_is_khive_daemon(pid):
+        try:
+            argv_out = subprocess.check_output(
+                ["ps", "-p", str(pid), "-o", "args="], stderr=subprocess.DEVNULL
+            ).decode().strip()
+        except Exception:
+            argv_out = "<ps failed>"
+        errors.append(
+            f"[DAEMON-CHECK-{label}] FAIL: PID {pid} is alive but argv does not match "
+            f"'kkernel mcp --daemon'. Got: {argv_out!r}"
+        )
+    else:
+        print(
+            f"[DAEMON-CHECK-{label}] PASS: PID {pid} is a live kkernel mcp --daemon process",
+            flush=True,
+        )
+
+        # Check 3: that daemon has bench.db open (best-effort)
+        db_open = lsof_has_bench_db(pid, bench_db)
+        if db_open is None:
+            pass  # skipped
+        elif db_open:
+            print(
+                f"[DAEMON-CHECK-{label}] PASS: PID {pid} has {bench_db!r} open (lsof confirmed)",
+                flush=True,
+            )
+        else:
+            errors.append(
+                f"[DAEMON-CHECK-{label}] FAIL: PID {pid} is 'kkernel mcp --daemon' but does NOT "
+                f"have {bench_db!r} open. It may be attached to the live DB instead."
+            )
+
+    if errors:
+        for msg in errors:
+            print(msg, file=sys.stderr, flush=True)
+        print(
+            f"FATAL: daemon-engagement assertions failed ({label} run). "
+            "The gate CANNOT rely on this run's P@K. Exiting.",
+            file=sys.stderr,
+            flush=True,
+        )
+        sys.exit(1)
+
+
+def assert_no_daemon_spawned(sock_path, label="nodaemon"):
+    """Assert no bench daemon was spawned (KHIVE_NO_DAEMON control run)."""
+    if pathlib.Path(sock_path).exists():
+        print(
+            f"[DAEMON-CHECK-{label}] FAIL: bench socket {sock_path!r} exists when "
+            "KHIVE_NO_DAEMON=1 was set — something spawned a daemon unexpectedly.",
+            file=sys.stderr,
+            flush=True,
+        )
+        sys.exit(1)
+    print(
+        f"[DAEMON-CHECK-{label}] PASS: no bench socket with KHIVE_NO_DAEMON=1 (correct)",
+        flush=True,
+    )
+
+
+def teardown_daemon(pid_path, tmpdir):
+    """SIGTERM the bench daemon (if any), then rmtree the tmpdir."""
+    import shutil
+    pid, _ = read_pid_file(pid_path)
+    if pid is not None and pid_alive(pid) and argv_is_khive_daemon(pid):
+        try:
+            os.kill(pid, signal.SIGTERM)
+            # Give it a moment to exit cleanly.
+            for _ in range(20):
+                time.sleep(0.1)
+                if not pid_alive(pid):
+                    break
+        except Exception:
+            pass
+    try:
+        shutil.rmtree(tmpdir, ignore_errors=True)
+    except Exception:
+        pass
+
+
+# ── Percentile ────────────────────────────────────────────────────────────────
+
+def pct(sorted_list, p):
+    """Nearest-rank percentile over an already-sorted list (empty -> 0.0)."""
+    if not sorted_list:
+        return 0.0
+    idx = min(int(len(sorted_list) * p), len(sorted_list) - 1)
+    return sorted_list[idx]
+
+
+# ── Raw daemon-socket framing (F10 diagnostic / metrics-snapshot channel) ────
+#
+# Every other function in this module goes through the front-end's stdio MCP
+# surface. This section speaks the daemon's length-prefixed Unix-socket wire
+# protocol directly, for two reasons neither the stdio surface nor a single
+# front-end subprocess can provide:
+#   - a `metrics_only` gauge-snapshot request (no MCP verb wraps this frame
+#     field; it is a read-only measurement surface, not a product verb), and
+#   - genuinely concurrent overlapping requests (one stdio subprocess serves
+#     one synchronous request/response pipe; overlapping raw socket
+#     connections do not have that limitation).
+
+
+def recv_exact(sock: socketlib.socket, n: int) -> bytes:
+    buf = b""
+    while len(buf) < n:
+        chunk = sock.recv(n - len(buf))
+        if not chunk:
+            raise RuntimeError("daemon socket closed mid-frame")
+        buf += chunk
+    return buf
+
+
+def raw_daemon_roundtrip(sock_path: str, frame: dict, timeout_s: float = 5.0) -> dict:
+    """Send one length-prefixed JSON frame directly over the daemon's Unix
+    socket and return the decoded response frame. Raises `socket.timeout` if
+    no complete response arrives within `timeout_s`.
+    """
+    s = socketlib.socket(socketlib.AF_UNIX, socketlib.SOCK_STREAM)
+    s.settimeout(timeout_s)
+    try:
+        s.connect(sock_path)
+        payload = json.dumps(frame).encode()
+        s.sendall(struct.pack(">I", len(payload)) + payload)
+        len_buf = recv_exact(s, 4)
+        (length,) = struct.unpack(">I", len_buf)
+        raw = recv_exact(s, length)
+        return json.loads(raw)
+    finally:
+        s.close()
+
+
+def base_daemon_frame(ops: str, config_id: str, probe_only: bool = False, metrics_only: bool = False) -> dict:
+    """Build a DaemonRequestFrame JSON payload. `presentation` /
+    `presentation_per_op` / `namespace` have no serde default on the Rust
+    struct (unlike the rest), so they must always be present in the wire
+    payload or the daemon silently drops the connection.
+    """
+    return {
+        "ops": ops,
+        "presentation": None,
+        "presentation_per_op": None,
+        "namespace": "local",
+        "actor_id": None,
+        "visible_namespaces": [],
+        "config_id": config_id,
+        "protocol_version": PROTOCOL_VERSION,
+        "probe_only": probe_only,
+        "metrics_only": metrics_only,
+        "format": None,
+        "format_per_op": None,
+        "from_wire": False,
+    }
+
+
+def probe_metrics_snapshot(sock_path: str) -> dict:
+    """Two-step probe against the daemon's `metrics_only` gauge-snapshot frame.
+
+    Step 1, config_id discovery: send an intentionally WRONG config_id as a
+    probe_only frame. The daemon computes and echoes `served_config_id` on
+    EVERY response, including a `config_mismatch` one, so this harvests the
+    daemon's real config_id without reimplementing its Rust-side computation
+    in Python.
+
+    Step 2, metrics snapshot: resend with the correct config_id and
+    `metrics_only: true`. A daemon that predates the `metrics_only` field
+    (`crates/khive-runtime/src/daemon.rs`) ignores the unknown key and
+    dispatches normally, so the response carries no `metrics` key. That
+    absence is the "PENDING" signal. A daemon that supports it returns
+    `metrics` populated with a `MetricsSnapshot` and never reaches ops
+    dispatch. That presence is the "LIVE" signal.
+
+    Never raises: any failure degrades to PENDING with the reason recorded.
+    """
+    try:
+        resp1 = raw_daemon_roundtrip(
+            sock_path, base_daemon_frame("", "__bench_discovery_probe__", probe_only=True)
+        )
+    except Exception as exc:
+        return {"oracle": "PENDING", "config_id": None, "detail": f"discovery round-trip failed: {exc!r}"}
+
+    real_config_id = resp1.get("served_config_id")
+    if not real_config_id:
+        return {
+            "oracle": "PENDING",
+            "config_id": None,
+            "detail": f"no served_config_id in discovery response: {resp1}",
+        }
+
+    metrics_frame = base_daemon_frame("stats()", real_config_id, probe_only=False, metrics_only=True)
+    try:
+        resp2 = raw_daemon_roundtrip(sock_path, metrics_frame)
+    except Exception as exc:
+        return {
+            "oracle": "PENDING",
+            "config_id": real_config_id,
+            "detail": f"metrics probe round-trip failed: {exc!r}",
+        }
+
+    if resp2.get("config_mismatch"):
+        return {
+            "oracle": "PENDING",
+            "config_id": real_config_id,
+            "detail": f"config_mismatch on metrics probe (unexpected race): {resp2}",
+        }
+    if resp2.get("metrics") is not None:
+        return {
+            "oracle": "LIVE",
+            "config_id": real_config_id,
+            "detail": "response carries a populated `metrics` key",
+            "metrics": resp2["metrics"],
+        }
+    return {
+        "oracle": "PENDING",
+        "config_id": real_config_id,
+        "detail": (
+            "no `metrics` key in response, this daemon predates the metrics_only field"
+        ),
+    }
+
+
+# ── F10 concurrent frame floor: deadline-aware, timeout-censored ────────────
+
+def measure_concurrent_frames(
+    sock_path: str,
+    frame: dict,
+    attempts: int,
+    concurrency: int,
+    deadline_ms: float = 2000.0,
+) -> dict:
+    """Fire `attempts` raw daemon-frame round trips at `concurrency` parallel
+    workers and return a percentile/timeout distribution.
+
+    Each attempt opens its own AF_UNIX socket connection, so overlapping
+    in-flight requests are genuinely concurrent (unlike a single stdio
+    front-end subprocess, which serves one synchronous request/response pipe
+    at a time). A response that does not complete within `deadline_ms` is
+    right-censored: it is counted under `timed_out` and its elapsed time is
+    NEVER inserted into the latency population, per the Methodology
+    contract's settle/censoring rule (a deadline never substitutes into a
+    percentile). Any other exception is counted under `errors_by_code`,
+    keyed by the exception's class name. The raw frame protocol has no
+    server-assigned stable error code, so the Python exception type is the
+    best available attribution at this layer.
+
+    This is the F10 diagnostic frame-floor measurement: it bypasses the
+    stdio MCP front-end's `tools/call` JSON-RPC decode entirely, so per the
+    Coverage definition it is a lower attribution layer, not a substitute
+    for a full E2E scenario record (which requires the versioned
+    `FlagshipRecord` contract and scenario runner from PR 1 / later PRs).
+
+    Returns a plain dict (not the versioned Distribution schema from
+    DESIGN.md's Typed interfaces section, which is owned by PR 1's
+    `schemas/flagship-result-v1.json`):
+      {attempts, successes, timed_out, errors_by_code,
+       p50_us, p95_us, p99_us, max_us}
+    """
+    deadline_s = deadline_ms / 1000.0
+    latencies_us: list[int] = []
+    timed_out = 0
+    errors_by_code: dict[str, int] = {}
+
+    def _one(_i):
+        t0 = time.perf_counter_ns()
+        try:
+            raw_daemon_roundtrip(sock_path, frame, timeout_s=deadline_s)
+            return ("ok", (time.perf_counter_ns() - t0) // 1000)
+        except socketlib.timeout:
+            return ("timeout", None)
+        except Exception as exc:  # classify, never propagate to the caller
+            return ("error", type(exc).__name__)
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=max(1, concurrency)) as pool:
+        for kind, payload in pool.map(_one, range(attempts)):
+            if kind == "ok":
+                latencies_us.append(payload)
+            elif kind == "timeout":
+                timed_out += 1
+            else:
+                errors_by_code[payload] = errors_by_code.get(payload, 0) + 1
+
+    latencies_us.sort()
+    return {
+        "attempts": attempts,
+        "successes": len(latencies_us),
+        "timed_out": timed_out,
+        "errors_by_code": errors_by_code,
+        "p50_us": pct(latencies_us, 0.5) if latencies_us else None,
+        "p95_us": pct(latencies_us, 0.95) if latencies_us else None,
+        "p99_us": pct(latencies_us, 0.99) if latencies_us else None,
+        "max_us": latencies_us[-1] if latencies_us else None,
+    }
+
+
+def measure_probe_only_floor(
+    sock_path: str,
+    config_id: str,
+    attempts: int = 100,
+    concurrency: int = 8,
+    deadline_ms: float = 2000.0,
+) -> dict:
+    """Concurrent `probe_only` frame round trips: the raw framing floor with
+    no ops dispatch at all. Clearly a diagnostic non-MCP measurement (DESIGN.md
+    F10 required target scenarios). The daemon returns an identity frame
+    immediately after identity validation, without reaching the dispatcher.
+    """
+    frame = base_daemon_frame("", config_id, probe_only=True)
+    return measure_concurrent_frames(sock_path, frame, attempts, concurrency, deadline_ms)
+
+
+def measure_stats_dispatch_floor(
+    sock_path: str,
+    config_id: str,
+    attempts: int = 100,
+    concurrency: int = 8,
+    deadline_ms: float = 2000.0,
+) -> dict:
+    """Concurrent raw-frame round trips carrying `ops="stats()"`: the daemon's
+    full parse-plus-dispatch floor for its cheapest read verb. This still
+    bypasses the stdio front-end's `tools/call` JSON-RPC decode, so it
+    isolates daemon-side dispatch cost from stdio transport cost. It is not
+    a Coverage-definition-compliant `request(stats())` E2E record on its own.
+    """
+    frame = base_daemon_frame("stats()", config_id, probe_only=False, metrics_only=False)
+    return measure_concurrent_frames(sock_path, frame, attempts, concurrency, deadline_ms)

--- a/scripts/perf/mcp_bench_client.py
+++ b/scripts/perf/mcp_bench_client.py
@@ -207,7 +207,7 @@ def lsof_has_bench_db(pid, bench_db):
         bench_db_real = str(pathlib.Path(bench_db).resolve())
         return bench_db_real in out
     except FileNotFoundError:
-        print("[SKIP] lsof not available — skipping open-file sub-check", flush=True)
+        print("[SKIP] lsof not available, skipping open-file sub-check", flush=True)
         return None  # None means skipped, not False
     except Exception:
         return False
@@ -285,7 +285,7 @@ def assert_no_daemon_spawned(sock_path, label="nodaemon"):
     if pathlib.Path(sock_path).exists():
         print(
             f"[DAEMON-CHECK-{label}] FAIL: bench socket {sock_path!r} exists when "
-            "KHIVE_NO_DAEMON=1 was set — something spawned a daemon unexpectedly.",
+            "KHIVE_NO_DAEMON=1 was set: something spawned a daemon unexpectedly.",
             file=sys.stderr,
             flush=True,
         )
@@ -339,9 +339,24 @@ def pct(sorted_list, p):
 #     connections do not have that limitation).
 
 
-def recv_exact(sock: socketlib.socket, n: int) -> bytes:
+def recv_exact(sock: socketlib.socket, n: int, deadline: float | None = None) -> bytes:
+    """Read exactly `n` bytes from `sock`.
+
+    If `deadline` (a `time.monotonic()` timestamp) is given, each individual
+    `recv()` call is bounded by the REMAINING budget rather than a fixed
+    per-call timeout. `socket.settimeout` governs one blocking call at a
+    time, so a socket that drip-feeds a response in small pieces would
+    otherwise get a fresh full timeout window on every partial read and
+    could hold the caller open arbitrarily long past the caller's actual
+    deadline.
+    """
     buf = b""
     while len(buf) < n:
+        if deadline is not None:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                raise socketlib.timeout("whole-request deadline exceeded while assembling frame")
+            sock.settimeout(remaining)
         chunk = sock.recv(n - len(buf))
         if not chunk:
             raise RuntimeError("daemon socket closed mid-frame")
@@ -352,17 +367,32 @@ def recv_exact(sock: socketlib.socket, n: int) -> bytes:
 def raw_daemon_roundtrip(sock_path: str, frame: dict, timeout_s: float = 5.0) -> dict:
     """Send one length-prefixed JSON frame directly over the daemon's Unix
     socket and return the decoded response frame. Raises `socket.timeout` if
-    no complete response arrives within `timeout_s`.
+    the complete round trip (connect, send, and every partial recv needed to
+    assemble the frame) does not finish within `timeout_s` of this call's
+    start. The budget is a single absolute deadline for the whole request,
+    not a per-socket-operation timeout: `recv_exact` is handed the
+    remaining time on every call so a slow, drip-feeding peer cannot reset
+    the clock on each partial read.
     """
+    deadline = time.monotonic() + timeout_s
     s = socketlib.socket(socketlib.AF_UNIX, socketlib.SOCK_STREAM)
-    s.settimeout(timeout_s)
     try:
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            raise socketlib.timeout("whole-request deadline exceeded before connect")
+        s.settimeout(remaining)
         s.connect(sock_path)
+
         payload = json.dumps(frame).encode()
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            raise socketlib.timeout("whole-request deadline exceeded before send")
+        s.settimeout(remaining)
         s.sendall(struct.pack(">I", len(payload)) + payload)
-        len_buf = recv_exact(s, 4)
+
+        len_buf = recv_exact(s, 4, deadline=deadline)
         (length,) = struct.unpack(">I", len_buf)
-        raw = recv_exact(s, length)
+        raw = recv_exact(s, length, deadline=deadline)
         return json.loads(raw)
     finally:
         s.close()
@@ -459,6 +489,33 @@ def probe_metrics_snapshot(sock_path: str) -> dict:
 
 # ── F10 concurrent frame floor: deadline-aware, timeout-censored ────────────
 
+def _classify_bad_response(resp: dict, frame: dict) -> str | None:
+    """Return an `errors_by_code` label if `resp` must be rejected as a
+    sample, or `None` if it is a genuine successful dispatch.
+
+    Per the Coverage definition (item 3), a daemon fallback or config
+    mismatch is a failed scenario, never an interchangeable latency sample:
+    the daemon deliberately returns `ok: false, config_mismatch: true`
+    WITHOUT dispatching when the frame's `config_id` disagrees with its own
+    (`crates/khive-runtime/src/daemon.rs` around 799-810), so a stale or
+    mismatched daemon would otherwise produce a plausible-but-wrong
+    fast-rejection latency. `metrics_only` frames are exempt: the daemon
+    answers them before the config_id check (namespace/config-agnostic gauge
+    read), so `served_config_id` there is not a dispatch-identity guarantee.
+    """
+    if frame.get("metrics_only"):
+        return None
+    if resp.get("config_mismatch"):
+        return "config_mismatch"
+    if resp.get("version_mismatch"):
+        return "version_mismatch"
+    if not resp.get("ok"):
+        return "not_ok"
+    if resp.get("served_config_id") != frame.get("config_id"):
+        return "served_config_mismatch"
+    return None
+
+
 def measure_concurrent_frames(
     sock_path: str,
     frame: dict,
@@ -476,10 +533,21 @@ def measure_concurrent_frames(
     right-censored: it is counted under `timed_out` and its elapsed time is
     NEVER inserted into the latency population, per the Methodology
     contract's settle/censoring rule (a deadline never substitutes into a
-    percentile). Any other exception is counted under `errors_by_code`,
-    keyed by the exception's class name. The raw frame protocol has no
-    server-assigned stable error code, so the Python exception type is the
-    best available attribution at this layer.
+    percentile).
+
+    A response that completes but fails `_classify_bad_response` (not
+    `ok`, a `config_mismatch`/`version_mismatch` flag, or a
+    `served_config_id` that disagrees with the frame's requested
+    `config_id`) is likewise excluded from the latency population and
+    counted under `errors_by_code` by its distinct code
+    (`config_mismatch`, `version_mismatch`, `not_ok`,
+    `served_config_mismatch`), per the Coverage definition's rule that a
+    daemon fallback or config mismatch is a failed scenario, not an
+    interchangeable sample. Any transport exception is counted under
+    `errors_by_code` too, keyed by the exception's class name: the raw
+    frame protocol has no server-assigned stable error code for transport
+    failures, so the Python exception type is the best available
+    attribution at that layer.
 
     This is the F10 diagnostic frame-floor measurement: it bypasses the
     stdio MCP front-end's `tools/call` JSON-RPC decode entirely, so per the
@@ -501,7 +569,10 @@ def measure_concurrent_frames(
     def _one(_i):
         t0 = time.perf_counter_ns()
         try:
-            raw_daemon_roundtrip(sock_path, frame, timeout_s=deadline_s)
+            resp = raw_daemon_roundtrip(sock_path, frame, timeout_s=deadline_s)
+            bad_code = _classify_bad_response(resp, frame)
+            if bad_code is not None:
+                return ("error", bad_code)
             return ("ok", (time.perf_counter_ns() - t0) // 1000)
         except socketlib.timeout:
             return ("timeout", None)

--- a/scripts/perf/test_mcp_bench_client.py
+++ b/scripts/perf/test_mcp_bench_client.py
@@ -442,6 +442,8 @@ class ConcurrentFrameFloorTests(unittest.TestCase):
             self.assertEqual(out["timed_out"], 0)
             self.assertEqual(out["errors_by_code"], {"metrics_only": 3})
             self.assertIsNone(out["p50_us"])
+            self.assertIsNone(out["p95_us"])
+            self.assertIsNone(out["p99_us"])
             self.assertIsNone(out["max_us"])
         finally:
             server.close()

--- a/scripts/perf/test_mcp_bench_client.py
+++ b/scripts/perf/test_mcp_bench_client.py
@@ -427,19 +427,22 @@ class ConcurrentFrameFloorTests(unittest.TestCase):
         finally:
             server.close()
 
-    def test_measure_concurrent_frames_metrics_only_frame_bypasses_config_validation(self):
-        # metrics_only frames are answered before the daemon's config_id
-        # check (namespace/config-agnostic gauge read), so served_config_id
-        # there is not a dispatch-identity guarantee and must not be
-        # validated against the requested config_id.
+    def test_measure_concurrent_frames_rejects_metrics_only_frame_as_not_a_measurement(self):
+        # A metrics_only frame is a daemon-metrics gauge probe, answered
+        # before the config_id check (namespace/config-agnostic read), never
+        # a dispatch measurement. Its elapsed time must never enter the
+        # success latency population, regardless of served_config_id.
         server = _MockDaemonServer(
             lambda frame: _base_response(frame, ok=True, served_config_id="unrelated-cfg", metrics={"wal_pages": 1})
         )
         try:
             frame = mbc.base_daemon_frame("", "cfg-under-test", probe_only=False, metrics_only=True)
             out = mbc.measure_concurrent_frames(server.sock_path, frame, attempts=3, concurrency=1, deadline_ms=2000)
-            self.assertEqual(out["successes"], 3)
-            self.assertEqual(out["errors_by_code"], {})
+            self.assertEqual(out["successes"], 0)
+            self.assertEqual(out["timed_out"], 0)
+            self.assertEqual(out["errors_by_code"], {"metrics_only": 3})
+            self.assertIsNone(out["p50_us"])
+            self.assertIsNone(out["max_us"])
         finally:
             server.close()
 

--- a/scripts/perf/test_mcp_bench_client.py
+++ b/scripts/perf/test_mcp_bench_client.py
@@ -1,0 +1,386 @@
+#!/usr/bin/env python3
+"""Unit tests for scripts/perf/mcp_bench_client.py (stdlib unittest, no deps).
+
+Run: cd scripts/perf && python3 -m unittest test_mcp_bench_client -v
+
+No real kkernel binary, no production DB: the stdio-MCP layer is exercised
+against an in-memory fake subprocess, and the raw daemon-socket layer is
+exercised against a tiny mock Unix-socket server speaking the same
+length-prefixed JSON frame protocol as the real daemon, bound to a scratch
+tempdir path per test.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import os
+import socket as socketlib
+import struct
+import sys
+import tempfile
+import threading
+import unittest
+
+sys.path.insert(0, os.path.dirname(__file__))
+import mcp_bench_client as mbc
+
+
+# ── Fake stdio MCP subprocess ──────────────────────────────────────────────
+
+class _FakeProc:
+    """Stands in for subprocess.Popen for the stdio MCP layer: `stdin` is a
+    BytesIO the test can inspect after the call, `stdout` is pre-loaded with
+    the exact response lines the fake server would have written.
+    """
+
+    def __init__(self, response_lines: list[dict]):
+        self.stdin = io.BytesIO()
+        self._responses = [json.dumps(r).encode() + b"\n" for r in response_lines]
+        self._next = 0
+
+    @property
+    def stdout(self):
+        return self
+
+    def readline(self):
+        if self._next >= len(self._responses):
+            return b""
+        line = self._responses[self._next]
+        self._next += 1
+        return line
+
+    def written_requests(self):
+        self.stdin.seek(0)
+        return [json.loads(line) for line in self.stdin.read().splitlines() if line]
+
+
+class StdioMcpTransportTests(unittest.TestCase):
+    def test_handshake_sends_initialize_and_initialized_notification(self):
+        proc = _FakeProc([{"jsonrpc": "2.0", "id": 1, "result": {}}])
+        mbc.handshake(proc, client_name="unit-test", client_version="9.9.9")
+        reqs = proc.written_requests()
+        self.assertEqual(reqs[0]["method"], "initialize")
+        self.assertEqual(reqs[0]["params"]["clientInfo"]["name"], "unit-test")
+        self.assertEqual(reqs[1]["method"], "notifications/initialized")
+
+    def test_handshake_raises_on_error_response(self):
+        proc = _FakeProc([{"jsonrpc": "2.0", "id": 1, "error": {"message": "boom"}}])
+        with self.assertRaises(RuntimeError):
+            mbc.handshake(proc)
+
+    def test_call_request_decodes_content_text_as_json(self):
+        body = {"results": [{"ok": True, "result": {"count": 3}}]}
+        proc = _FakeProc([
+            {"jsonrpc": "2.0", "id": 1, "result": {"content": [{"type": "text", "text": json.dumps(body)}]}}
+        ])
+        out = mbc.call_request(proc, "stats()")
+        self.assertEqual(out, body)
+
+    def test_call_request_raises_on_rpc_error(self):
+        proc = _FakeProc([{"jsonrpc": "2.0", "id": 1, "error": {"message": "bad ops"}}])
+        with self.assertRaises(RuntimeError):
+            mbc.call_request(proc, "not_a_verb()")
+
+    def test_call_request_raises_on_protocol_error(self):
+        proc = _FakeProc([
+            {
+                "jsonrpc": "2.0",
+                "id": 1,
+                "result": {"isError": True, "content": [{"type": "text", "text": "parse failure"}]},
+            }
+        ])
+        with self.assertRaises(RuntimeError):
+            mbc.call_request(proc, "(((")
+
+    def test_call_verb_unwraps_first_result(self):
+        body = {"results": [{"ok": True, "result": {"entities": 5}}], "summary": {"total": 1}}
+        proc = _FakeProc([
+            {"jsonrpc": "2.0", "id": 1, "result": {"content": [{"type": "text", "text": json.dumps(body)}]}}
+        ])
+        out = mbc.call_verb(proc, "stats", {})
+        self.assertEqual(out, {"entities": 5})
+
+    def test_call_verb_raises_on_failed_op(self):
+        body = {"results": [{"ok": False, "error": "invalid kind"}]}
+        proc = _FakeProc([
+            {"jsonrpc": "2.0", "id": 1, "result": {"content": [{"type": "text", "text": json.dumps(body)}]}}
+        ])
+        with self.assertRaises(RuntimeError):
+            mbc.call_verb(proc, "create", {"kind": "bogus"})
+
+
+# ── Percentile ────────────────────────────────────────────────────────────────
+
+class PercentileTests(unittest.TestCase):
+    def test_empty_list_returns_zero(self):
+        self.assertEqual(mbc.pct([], 0.5), 0.0)
+
+    def test_nearest_rank_p50_and_p99(self):
+        data = list(range(1, 101))  # 1..100
+        self.assertEqual(mbc.pct(data, 0.5), 51)
+        self.assertEqual(mbc.pct(data, 0.99), 100)
+
+
+# ── Safety guard ──────────────────────────────────────────────────────────────
+
+class SafetyGuardTests(unittest.TestCase):
+    def test_scratch_path_is_not_rejected(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            # Must not raise/exit for an ordinary scratch path.
+            mbc.assert_not_live_db(os.path.join(tmp, "bench.db"))
+
+    def test_live_db_path_exits(self):
+        with self.assertRaises(SystemExit):
+            mbc.assert_not_live_db(os.path.expanduser("~/.khive/khive.db"))
+
+
+# ── Daemon-engagement proof (process-facing helpers) ──────────────────────────
+
+class DaemonEngagementTests(unittest.TestCase):
+    def test_read_pid_file_round_trip(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            pid_path = os.path.join(tmp, "khived.pid")
+            with open(pid_path, "w") as f:
+                f.write(str(os.getpid()))
+            pid, raw = mbc.read_pid_file(pid_path)
+            self.assertEqual(pid, os.getpid())
+            self.assertEqual(raw, str(os.getpid()))
+
+    def test_read_pid_file_missing_returns_none(self):
+        pid, raw = mbc.read_pid_file("/nonexistent/path/khived.pid")
+        self.assertIsNone(pid)
+        self.assertIsNone(raw)
+
+    def test_pid_alive_true_for_self(self):
+        self.assertTrue(mbc.pid_alive(os.getpid()))
+
+    def test_pid_alive_false_for_unlikely_pid(self):
+        self.assertFalse(mbc.pid_alive(2**30))
+
+    def test_argv_is_khive_daemon_false_for_test_runner(self):
+        # This test process is a python unittest runner, never kkernel.
+        self.assertFalse(mbc.argv_is_khive_daemon(os.getpid()))
+
+    def test_assert_no_daemon_spawned_passes_when_socket_absent(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            mbc.assert_no_daemon_spawned(os.path.join(tmp, "khived.sock"))
+
+    def test_assert_no_daemon_spawned_exits_when_socket_present(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            sock_path = os.path.join(tmp, "khived.sock")
+            s = socketlib.socket(socketlib.AF_UNIX, socketlib.SOCK_STREAM)
+            s.bind(sock_path)
+            try:
+                with self.assertRaises(SystemExit):
+                    mbc.assert_no_daemon_spawned(sock_path)
+            finally:
+                s.close()
+
+    def test_assert_daemon_engaged_exits_when_socket_missing(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            with self.assertRaises(SystemExit):
+                mbc.assert_daemon_engaged(
+                    os.path.join(tmp, "missing.sock"),
+                    os.path.join(tmp, "missing.pid"),
+                    os.path.join(tmp, "bench.db"),
+                )
+
+
+# ── Mock raw daemon-socket server ─────────────────────────────────────────────
+
+class _MockDaemonServer:
+    """A minimal Unix-socket server speaking the daemon's length-prefixed JSON
+    frame protocol, so the raw-frame layer can be tested without a real
+    kkernel binary. `responder(request_frame) -> response_frame | None`
+    (returning None closes the connection without writing a response, to
+    simulate a hang for timeout tests).
+    """
+
+    def __init__(self, responder, delay_s: float = 0.0):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.sock_path = os.path.join(self._tmp.name, "khived.sock")
+        self._responder = responder
+        self._delay_s = delay_s
+        self._server = socketlib.socket(socketlib.AF_UNIX, socketlib.SOCK_STREAM)
+        self._server.bind(self.sock_path)
+        self._server.listen(16)
+        self._stop = False
+        self._thread = threading.Thread(target=self._serve, daemon=True)
+        self._thread.start()
+
+    def _serve(self):
+        while not self._stop:
+            self._server.settimeout(0.2)
+            try:
+                conn, _ = self._server.accept()
+            except socketlib.timeout:
+                continue
+            except OSError:
+                return
+            threading.Thread(target=self._handle, args=(conn,), daemon=True).start()
+
+    def _handle(self, conn):
+        try:
+            len_buf = mbc.recv_exact(conn, 4)
+            (length,) = struct.unpack(">I", len_buf)
+            raw = mbc.recv_exact(conn, length)
+            frame = json.loads(raw)
+            if self._delay_s:
+                import time as _time
+                _time.sleep(self._delay_s)
+            resp = self._responder(frame)
+            if resp is None:
+                return
+            payload = json.dumps(resp).encode()
+            conn.sendall(struct.pack(">I", len(payload)) + payload)
+        except Exception:
+            pass
+        finally:
+            conn.close()
+
+    def close(self):
+        self._stop = True
+        self._thread.join(timeout=2)
+        self._server.close()
+        self._tmp.cleanup()
+
+
+def _base_response(frame, **overrides):
+    resp = {
+        "ok": True,
+        "result": None,
+        "error": None,
+        "namespace_mismatch": False,
+        "config_mismatch": False,
+        "served_config_id": "cfg-under-test",
+        "version_mismatch": False,
+        "daemon_protocol_version": mbc.PROTOCOL_VERSION,
+        "metrics": None,
+    }
+    resp.update(overrides)
+    return resp
+
+
+class RawDaemonFrameTests(unittest.TestCase):
+    def test_base_daemon_frame_shape(self):
+        frame = mbc.base_daemon_frame("stats()", "cfg1", probe_only=True, metrics_only=False)
+        self.assertEqual(frame["ops"], "stats()")
+        self.assertEqual(frame["config_id"], "cfg1")
+        self.assertTrue(frame["probe_only"])
+        self.assertFalse(frame["metrics_only"])
+        self.assertEqual(frame["protocol_version"], mbc.PROTOCOL_VERSION)
+
+    def test_raw_daemon_roundtrip_echoes_response(self):
+        server = _MockDaemonServer(lambda frame: _base_response(frame))
+        try:
+            resp = mbc.raw_daemon_roundtrip(
+                server.sock_path, mbc.base_daemon_frame("stats()", "cfg-under-test", probe_only=False)
+            )
+            self.assertTrue(resp["ok"])
+            self.assertEqual(resp["served_config_id"], "cfg-under-test")
+        finally:
+            server.close()
+
+    def test_raw_daemon_roundtrip_times_out_on_slow_server(self):
+        server = _MockDaemonServer(lambda frame: _base_response(frame), delay_s=1.0)
+        try:
+            with self.assertRaises(socketlib.timeout):
+                mbc.raw_daemon_roundtrip(server.sock_path, mbc.base_daemon_frame("", "cfg", True), timeout_s=0.2)
+        finally:
+            server.close()
+
+    def test_probe_metrics_snapshot_live_when_metrics_key_present(self):
+        def responder(frame):
+            if frame.get("metrics_only"):
+                return _base_response(frame, metrics=None if False else {"wal_pages": 12})
+            return _base_response(frame)
+
+        server = _MockDaemonServer(responder)
+        try:
+            out = mbc.probe_metrics_snapshot(server.sock_path)
+            self.assertEqual(out["oracle"], "LIVE")
+            self.assertEqual(out["metrics"], {"wal_pages": 12})
+            self.assertEqual(out["config_id"], "cfg-under-test")
+        finally:
+            server.close()
+
+    def test_probe_metrics_snapshot_pending_when_metrics_key_absent(self):
+        server = _MockDaemonServer(lambda frame: _base_response(frame))
+        try:
+            out = mbc.probe_metrics_snapshot(server.sock_path)
+            self.assertEqual(out["oracle"], "PENDING")
+        finally:
+            server.close()
+
+    def test_probe_metrics_snapshot_pending_on_connection_failure(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            out = mbc.probe_metrics_snapshot(os.path.join(tmp, "no-such.sock"))
+            self.assertEqual(out["oracle"], "PENDING")
+            self.assertIsNone(out["config_id"])
+
+
+class ConcurrentFrameFloorTests(unittest.TestCase):
+    def test_measure_concurrent_frames_all_success(self):
+        server = _MockDaemonServer(lambda frame: _base_response(frame))
+        try:
+            frame = mbc.base_daemon_frame("stats()", "cfg-under-test", probe_only=False)
+            out = mbc.measure_concurrent_frames(server.sock_path, frame, attempts=20, concurrency=5, deadline_ms=2000)
+            self.assertEqual(out["attempts"], 20)
+            self.assertEqual(out["successes"], 20)
+            self.assertEqual(out["timed_out"], 0)
+            self.assertEqual(out["errors_by_code"], {})
+            self.assertIsNotNone(out["p50_us"])
+            self.assertIsNotNone(out["max_us"])
+        finally:
+            server.close()
+
+    def test_measure_concurrent_frames_censors_timeouts_not_into_latency(self):
+        server = _MockDaemonServer(lambda frame: None, delay_s=0.5)
+        try:
+            frame = mbc.base_daemon_frame("stats()", "cfg", probe_only=False)
+            out = mbc.measure_concurrent_frames(server.sock_path, frame, attempts=6, concurrency=3, deadline_ms=100)
+            self.assertEqual(out["attempts"], 6)
+            self.assertEqual(out["successes"], 0)
+            self.assertEqual(out["timed_out"], 6)
+            self.assertIsNone(out["p50_us"])
+            self.assertIsNone(out["max_us"])
+        finally:
+            server.close()
+
+    def test_measure_concurrent_frames_classifies_connection_errors(self):
+        # No server listening at this path at all.
+        with tempfile.TemporaryDirectory() as tmp:
+            frame = mbc.base_daemon_frame("stats()", "cfg", probe_only=False)
+            out = mbc.measure_concurrent_frames(
+                os.path.join(tmp, "absent.sock"), frame, attempts=4, concurrency=2, deadline_ms=500
+            )
+            self.assertEqual(out["attempts"], 4)
+            self.assertEqual(out["successes"], 0)
+            self.assertEqual(out["timed_out"], 0)
+            self.assertEqual(sum(out["errors_by_code"].values()), 4)
+
+    def test_measure_probe_only_floor_and_stats_dispatch_floor_build_expected_ops(self):
+        seen_ops = []
+
+        def responder(frame):
+            seen_ops.append((frame["ops"], frame["probe_only"], frame["metrics_only"]))
+            return _base_response(frame)
+
+        server = _MockDaemonServer(responder)
+        try:
+            mbc.measure_probe_only_floor(server.sock_path, "cfg", attempts=3, concurrency=3, deadline_ms=1000)
+            mbc.measure_stats_dispatch_floor(server.sock_path, "cfg", attempts=3, concurrency=3, deadline_ms=1000)
+        finally:
+            server.close()
+        probe_ops = [o for o in seen_ops if o[1] is True]
+        stats_ops = [o for o in seen_ops if o[1] is False]
+        self.assertEqual(len(probe_ops), 3)
+        self.assertTrue(all(op[0] == "" for op in probe_ops))
+        self.assertEqual(len(stats_ops), 3)
+        self.assertTrue(all(op[0] == "stats()" for op in stats_ops))
+        self.assertTrue(all(op[2] is False for op in stats_ops))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/perf/test_mcp_bench_client.py
+++ b/scripts/perf/test_mcp_bench_client.py
@@ -20,6 +20,7 @@ import struct
 import sys
 import tempfile
 import threading
+import time
 import unittest
 
 sys.path.insert(0, os.path.dirname(__file__))
@@ -197,11 +198,13 @@ class _MockDaemonServer:
     simulate a hang for timeout tests).
     """
 
-    def __init__(self, responder, delay_s: float = 0.0):
+    def __init__(self, responder, delay_s: float = 0.0, drip_chunk_delay_s: float = 0.0, drip_chunk_size: int = 20):
         self._tmp = tempfile.TemporaryDirectory()
         self.sock_path = os.path.join(self._tmp.name, "khived.sock")
         self._responder = responder
         self._delay_s = delay_s
+        self._drip_chunk_delay_s = drip_chunk_delay_s
+        self._drip_chunk_size = drip_chunk_size
         self._server = socketlib.socket(socketlib.AF_UNIX, socketlib.SOCK_STREAM)
         self._server.bind(self.sock_path)
         self._server.listen(16)
@@ -227,13 +230,23 @@ class _MockDaemonServer:
             raw = mbc.recv_exact(conn, length)
             frame = json.loads(raw)
             if self._delay_s:
-                import time as _time
-                _time.sleep(self._delay_s)
+                time.sleep(self._delay_s)
             resp = self._responder(frame)
             if resp is None:
                 return
             payload = json.dumps(resp).encode()
-            conn.sendall(struct.pack(">I", len(payload)) + payload)
+            wire = struct.pack(">I", len(payload)) + payload
+            if self._drip_chunk_delay_s:
+                # Trickle the response out in small pieces, sleeping between
+                # each one. Each individual `recv()` on the client sees a
+                # short delay well inside a naive per-call timeout, but the
+                # cumulative transfer time can exceed a whole-request
+                # deadline.
+                for i in range(0, len(wire), self._drip_chunk_size):
+                    conn.sendall(wire[i:i + self._drip_chunk_size])
+                    time.sleep(self._drip_chunk_delay_s)
+            else:
+                conn.sendall(wire)
         except Exception:
             pass
         finally:
@@ -360,6 +373,76 @@ class ConcurrentFrameFloorTests(unittest.TestCase):
             self.assertEqual(out["timed_out"], 0)
             self.assertEqual(sum(out["errors_by_code"].values()), 4)
 
+    def test_measure_concurrent_frames_rejects_config_mismatch_as_error_not_success(self):
+        # The daemon deliberately returns ok:false, config_mismatch:true
+        # WITHOUT dispatching when configs differ. A stale/mismatched
+        # daemon must never contribute a fast-rejection latency sample.
+        server = _MockDaemonServer(
+            lambda frame: _base_response(frame, ok=False, config_mismatch=True, served_config_id="other-cfg")
+        )
+        try:
+            frame = mbc.base_daemon_frame("stats()", "cfg-under-test", probe_only=False)
+            out = mbc.measure_concurrent_frames(server.sock_path, frame, attempts=5, concurrency=2, deadline_ms=2000)
+            self.assertEqual(out["successes"], 0)
+            self.assertEqual(out["timed_out"], 0)
+            self.assertEqual(out["errors_by_code"], {"config_mismatch": 5})
+            self.assertIsNone(out["p50_us"])
+            self.assertIsNone(out["max_us"])
+        finally:
+            server.close()
+
+    def test_measure_concurrent_frames_rejects_version_mismatch(self):
+        server = _MockDaemonServer(
+            lambda frame: _base_response(frame, ok=False, version_mismatch=True)
+        )
+        try:
+            frame = mbc.base_daemon_frame("stats()", "cfg-under-test", probe_only=False)
+            out = mbc.measure_concurrent_frames(server.sock_path, frame, attempts=3, concurrency=1, deadline_ms=2000)
+            self.assertEqual(out["successes"], 0)
+            self.assertEqual(out["errors_by_code"], {"version_mismatch": 3})
+        finally:
+            server.close()
+
+    def test_measure_concurrent_frames_rejects_not_ok_without_mismatch_flags(self):
+        server = _MockDaemonServer(lambda frame: _base_response(frame, ok=False))
+        try:
+            frame = mbc.base_daemon_frame("stats()", "cfg-under-test", probe_only=False)
+            out = mbc.measure_concurrent_frames(server.sock_path, frame, attempts=3, concurrency=1, deadline_ms=2000)
+            self.assertEqual(out["successes"], 0)
+            self.assertEqual(out["errors_by_code"], {"not_ok": 3})
+        finally:
+            server.close()
+
+    def test_measure_concurrent_frames_rejects_served_config_id_mismatch(self):
+        # ok:true but served_config_id disagrees with the requested config_id:
+        # a plausible-but-wrong response that must not be counted either.
+        server = _MockDaemonServer(
+            lambda frame: _base_response(frame, ok=True, served_config_id="not-the-requested-cfg")
+        )
+        try:
+            frame = mbc.base_daemon_frame("stats()", "cfg-under-test", probe_only=False)
+            out = mbc.measure_concurrent_frames(server.sock_path, frame, attempts=3, concurrency=1, deadline_ms=2000)
+            self.assertEqual(out["successes"], 0)
+            self.assertEqual(out["errors_by_code"], {"served_config_mismatch": 3})
+        finally:
+            server.close()
+
+    def test_measure_concurrent_frames_metrics_only_frame_bypasses_config_validation(self):
+        # metrics_only frames are answered before the daemon's config_id
+        # check (namespace/config-agnostic gauge read), so served_config_id
+        # there is not a dispatch-identity guarantee and must not be
+        # validated against the requested config_id.
+        server = _MockDaemonServer(
+            lambda frame: _base_response(frame, ok=True, served_config_id="unrelated-cfg", metrics={"wal_pages": 1})
+        )
+        try:
+            frame = mbc.base_daemon_frame("", "cfg-under-test", probe_only=False, metrics_only=True)
+            out = mbc.measure_concurrent_frames(server.sock_path, frame, attempts=3, concurrency=1, deadline_ms=2000)
+            self.assertEqual(out["successes"], 3)
+            self.assertEqual(out["errors_by_code"], {})
+        finally:
+            server.close()
+
     def test_measure_probe_only_floor_and_stats_dispatch_floor_build_expected_ops(self):
         seen_ops = []
 
@@ -380,6 +463,40 @@ class ConcurrentFrameFloorTests(unittest.TestCase):
         self.assertEqual(len(stats_ops), 3)
         self.assertTrue(all(op[0] == "stats()" for op in stats_ops))
         self.assertTrue(all(op[2] is False for op in stats_ops))
+
+
+# ── Whole-request deadline (not per-recv-call) ────────────────────────────────
+
+class WholeRequestDeadlineTests(unittest.TestCase):
+    def test_raw_daemon_roundtrip_censors_drip_fed_response_past_total_deadline(self):
+        # The response trickles out a few bytes at a time, 0.05s apart. Each
+        # individual `recv()` finishes well inside a naive fixed per-call
+        # timeout, but the full transfer takes far longer than the
+        # whole-request deadline passed to `raw_daemon_roundtrip`. Before the
+        # fix, `socket.settimeout` was set once up front, so every partial
+        # read got its own fresh timeout window and this would return
+        # successfully instead of censoring as a timeout.
+        server = _MockDaemonServer(lambda frame: _base_response(frame), drip_chunk_delay_s=0.05, drip_chunk_size=20)
+        try:
+            with self.assertRaises(socketlib.timeout):
+                mbc.raw_daemon_roundtrip(
+                    server.sock_path,
+                    mbc.base_daemon_frame("stats()", "cfg-under-test", probe_only=False),
+                    timeout_s=0.2,
+                )
+        finally:
+            server.close()
+
+    def test_measure_concurrent_frames_marks_drip_fed_response_as_timed_out(self):
+        server = _MockDaemonServer(lambda frame: _base_response(frame), drip_chunk_delay_s=0.05, drip_chunk_size=20)
+        try:
+            frame = mbc.base_daemon_frame("stats()", "cfg-under-test", probe_only=False)
+            out = mbc.measure_concurrent_frames(server.sock_path, frame, attempts=2, concurrency=2, deadline_ms=200)
+            self.assertEqual(out["successes"], 0)
+            self.assertEqual(out["timed_out"], 2)
+            self.assertIsNone(out["p50_us"])
+        finally:
+            server.close()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

PR 2 of the benchmark-overhaul plan (`.khive/workspaces/20260711/bench-overhaul/DESIGN.md`), scoped to the slice that does not depend on PR 1 (draft #862, `feat/bench-pr1-coverage-manifest`, not yet merged) — this PR does not create, copy, or import `scripts/perf/flagship_workloads.toml`, `flagship_schema.py`, `schemas/flagship-result-v1.json`, `coverage_validator.py`, or `test_flagship_coverage.py`.

### What was extracted

`scripts/perf/mcp_bench_client.py` (new), pulled out of `bench_pipeline_daemon.py` and `bench_load_harness.py`:

- **Stdio MCP transport** — `handshake`, `call_request`, `call_verb` (JSON-RPC `initialize`/`tools/call` framing over a subprocess's stdin/stdout).
- **Daemon-engagement proof** — `assert_daemon_engaged`, `assert_no_daemon_spawned`, `read_pid_file`, `pid_alive`, `argv_is_khive_daemon`, `lsof_has_bench_db`. Positively confirms a spawned front-end routed through a live `kkernel mcp --daemon` child bound to the expected socket/DB, per the Coverage definition's rule that a local-dispatch fallback is a failed scenario, not a sample.
- **Live-DB safety guard** — `assert_not_live_db` / `LIVE_DB_PATHS`.
- **Process teardown** — `teardown_daemon`.
- **Raw daemon-socket framing** — `raw_daemon_roundtrip`, `base_daemon_frame`, `probe_metrics_snapshot` (the `metrics_only` gauge-snapshot probe previously duplicated inside `bench_load_harness.py`).

Both scripts now `import mcp_bench_client`; their own module-level names (`bench_pipeline_daemon._call_verb`, `bench_load_harness.probe_oracle_channel`, etc.) are re-exported aliases pointing at the shared implementation, so no caller-visible name changed.

### Pure-refactor invariant

No CLI flag, output shape, or observable behavior of `bench_pipeline_daemon.py` or `bench_load_harness.py` changed. Verified:
- `uv run python scripts/perf/bench_load_harness.py --help` — identical usage/help text.
- `bench_pipeline_daemon.py` has no CLI; verified via a clean import plus alias-identity assertions (`bpd._call_verb is mbc.call_verb`, etc.) and a `generate_corpus()` smoke call.
- Full existing perf test suite (`test_bench_track.py`, `test_publish_ledger.py` — 34 cases) still passes unchanged.
- One frame field went from *implicitly absent* to *explicitly `false`* on the wire (`base_daemon_frame`'s `metrics_only` key); the daemon's `#[serde(default)]` treats both identically, so this is not an observable behavior change.

### New F10 capability (PR1-independent)

`measure_concurrent_frames` plus two convenience wrappers, `measure_probe_only_floor` and `measure_stats_dispatch_floor`: deadline-aware, concurrent raw daemon-frame requests with timeout censoring (a deadline is never inserted into the latency population; it increments `timed_out` instead). These implement the F10 "raw frame control" / "MCP `stats()` floor" pieces from DESIGN.md's PR 2 slice using a plain percentile/timeout dict — not the versioned `FlagshipRecord`/`Distribution` schema, which PR 1 owns.

### Daemon-engagement proof points

- Socket-file existence, PID-file liveness, and `ps` argv match on `kkernel(-bench) mcp --daemon` (`assert_daemon_engaged`).
- Best-effort `lsof` confirmation that the daemon has the expected bench DB open, not the live one.
- Raw-frame `served_config_id` echo used to positively distinguish a matching-config daemon from a stale/mismatched one before trusting its response.

### Tests

`scripts/perf/test_mcp_bench_client.py` — 29 stdlib `unittest` cases, no production DB, scratch paths only:
- Stdio transport against an in-memory fake subprocess (handshake, `call_request`, `call_verb`, RPC/protocol error paths).
- Percentile and live-DB safety-guard behavior.
- Daemon-engagement helpers against the real test-runner PID and scratch socket/PID-file paths.
- Raw-frame protocol and `measure_concurrent_frames`/wrappers against a mock Unix-socket server (success, timeout-censoring, connection-error classification).

Run: `cd scripts/perf && uv run python -m unittest test_mcp_bench_client -v`

### Deferred until PR1 merges

Per the scope constraint, these DESIGN.md PR 2 items require PR 1's manifest/schema files and are intentionally not implemented here:

- Manifest-driven scenario execution (`flagship_workloads.toml` scenario IDs, scale/concurrency/timeout-label lookup).
- Versioned report output conforming to the `FlagshipRecord`/`Distribution` contract and `schemas/flagship-result-v1.json`.
- `bench_track.py` schema v3 `FlagshipRecord` support and `bench_calibrate.py`'s new `flagship-e2e` suite entry.
- Permanent ledger publication to `perf-data/bench-data/flagship-e2e.jsonl` via `publish_ledger.sh`.
- The full F10 target scenario ("one hosted advisory F10 record reaches `perf-data` with complete metadata", including during-run queue-gauge sampling across the 1/2/4/8/16/32/64/128 concurrency sweep) — the concurrency/timeout primitive exists (`measure_concurrent_frames`), but scenario-manifest wiring, queue-gauge sampling, and ledger/coverage-validator integration are PR1/PR7 territory.

## Test plan

- [x] `cd scripts/perf && uv run python -m unittest test_mcp_bench_client -v` (29 passed)
- [x] `cd scripts/perf && uv run python -m unittest test_bench_track test_publish_ledger -v` (34 passed, unaffected)
- [x] `uv run python scripts/perf/bench_load_harness.py --help` (identical output)
- [x] `uv run ruff check` on all touched/new files (0 new findings; 2 pre-existing `F541` findings in untouched `bench_pipeline_daemon.py` lines are out of scope)
- [ ] Real daemon smoke run of `bench_pipeline_daemon.py` / `bench_load_harness.py` against a built `kkernel`/`kkernel-bench` binary — not run here (python-only lane, no cargo build in this session); the refactor is a mechanical extraction with identical call sites, covered by the alias-identity checks above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)