### PR TITLE
feat(pack-workspace): workspace entity kind + contains edges to git/gtd/session notes (v0, #873)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,12 +15,14 @@ khive gives your agent:
 9. **Brain** — Bayesian profile tuning from feedback signals
 10. **Session** — persist and resume agent-session records
 
-All 10 packs load by default. **78 public verbs** across the packs: the `git` pack
+All 11 packs load by default. **78 public verbs** across the packs: the `git` pack
 contributes the `git.digest` verb plus the commit/issue/pull_request provenance note kinds
 and a batch ingester; the `code` pack currently contributes zero verbs: its `finding`
 note kind is written only through the `kkernel code-ingest` admin CLI path, never a verb
 an agent can call (ADR-085 D1, Amendment 3; Amendment 2's `code.ingest` verb is accepted
-but unimplemented). Regenerate via `request(ops="verbs()")`
+but unimplemented); the `workspace` pack also contributes zero verbs, adding only the
+`workspace` entity kind and `contains` endpoint rules to git/gtd/session notes (#873).
+Regenerate via `request(ops="verbs()")`
 before editing this line.
 
 If you're working on khive itself (writing code in this repo), see `CLAUDE.md` instead.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -167,14 +167,16 @@ request(ops="[{\"tool\":\"v1\",\"args\":{...}}, ...]")
 ```
 
 Verbs come from whichever packs are loaded via `KHIVE_PACKS` (env) or `--pack` (CLI). Default
-loads all 10 production packs: kg, gtd, memory, brain, comm, schedule, knowledge, session, git,
-code (verbs unchanged at 78: the `code` pack currently contributes zero verbs (ADR-085 D1;
+loads all 11 production packs: kg, gtd, memory, brain, comm, schedule, knowledge, session, git,
+code, workspace (verbs unchanged at 78: the `code` pack currently contributes zero verbs (ADR-085 D1;
 Amendment 2's `code.ingest` verb is accepted but unimplemented); its `finding` note kind and
 `findings.json` ingest are reached only through the `kkernel code-ingest` admin CLI path
 (ADR-085 Amendment 3), never the MCP verb surface; git contributes
 commit/issue/pull_request note kinds, a batch ingester, and the git.digest verb (ADR-088
 Amendment 1); comm.probe (#644) added 2026-07-07; brain.event_counts (ADR-103 Stage 1, #724
-Ask A) added 2026-07-08; kg.resolve added 2026-07-09; regenerate via `request(ops="verbs()")` before editing this line).
+Ask A) added 2026-07-08; kg.resolve added 2026-07-09; workspace (#873) contributes zero verbs,
+adding only the `workspace` entity kind and `contains` endpoint rules to git/gtd/session notes;
+regenerate via `request(ops="verbs()")` before editing this line).
 
 ### KG pack verbs (18 — ADR-017, ADR-046, ADR-089)
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ stdio, and `cargo test` finishes in 4 seconds.
 
 | Capability                  | How                                                                                                                                                      |
 | --------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **78 verbs, 10 packs**      | KG, GTD, memory, brain, comm, schedule, knowledge, session, git, code: all load by default                                                               |
+| **78 verbs, 11 packs**      | KG, GTD, memory, brain, comm, schedule, knowledge, session, git, code, workspace: all load by default                                                    |
 | **Typed entities**          | 9 closed kinds: concept, document, dataset, project, person, org, artifact, service, resource                                                            |
 | **Typed edges**             | 17 closed relations in 9 categories (structure, derivation, provenance, temporal, dependency, impl, lateral, annotation, epistemic)                      |
 | **Typed notes**             | 5 closed kinds: observation, insight, question, decision, reference                                                                                      |
@@ -63,7 +63,7 @@ request(ops="[v1(...), v2(...), v3(...)]")             # parallel batch (max 100
 request(ops="[{\"tool\":\"v1\",\"args\":{...}}, ...]") # equivalent JSON form
 ```
 
-All 10 packs load by default, giving **78 verbs** out of the box (verified against the live
+All 11 packs load by default, giving **78 verbs** out of the box (verified against the live
 `verbs()` registry, 2026-07-10; regenerate with `request(ops="verbs()")` before editing
 this table):
 
@@ -247,7 +247,7 @@ global):
 kkernel --version   # confirms the binary and version you just installed
 ```
 
-All 10 packs load by default, a background daemon auto-spawns to keep the runtime warm, and any
+All 11 packs load by default, a background daemon auto-spawns to keep the runtime warm, and any
 MCP client discovers the `request` tool with the full 78-verb catalog.
 
 ### Alternative: npm

--- a/README.md
+++ b/README.md
@@ -375,7 +375,7 @@ Docs: [ohdearquant.github.io/khive](https://ohdearquant.github.io/khive/) (agent
 
 ## Status
 
-**v0.3.0, published on [crates.io](https://crates.io/crates/khive-mcp).** 78 verbs across 10
+**v0.3.0, published on [crates.io](https://crates.io/crates/khive-mcp).** 78 verbs across 11
 packs, 9 entity kinds, 17 edge relations, daemon warm startup (ADR-049), knowledge search with
 embedding rerank, Bayesian brain profiles, threaded messaging, scheduled verb execution.
 Ready for use with Claude Code and any MCP-compatible agent.

--- a/cli/main.ts
+++ b/cli/main.ts
@@ -59,8 +59,8 @@ Pack subcommands (ADR-050):
   init          Scaffold a new declarative pack
   check         Validate a pack.yaml manifest
 
-All 10 built-in packs (kg, gtd, memory, brain, comm, schedule, knowledge,
-session, git, code) load by default — no --pack flags needed.
+All 11 built-in packs (kg, gtd, memory, brain, comm, schedule, knowledge,
+session, git, code, workspace) load by default, no --pack flags needed.
 
 Run 'khive <group> <subcommand> --help' for detailed usage.`);
 }

--- a/cli/tests/golden/help_toplevel.txt
+++ b/cli/tests/golden/help_toplevel.txt
@@ -28,7 +28,7 @@ Pack subcommands (ADR-050):
   init          Scaffold a new declarative pack
   check         Validate a pack.yaml manifest
 
-All 10 built-in packs (kg, gtd, memory, brain, comm, schedule, knowledge,
-session, git, code) load by default — no --pack flags needed.
+All 11 built-in packs (kg, gtd, memory, brain, comm, schedule, knowledge,
+session, git, code, workspace) load by default, no --pack flags needed.
 
 Run 'khive <group> <subcommand> --help' for detailed usage.

--- a/crates/Cargo.toml
+++ b/crates/Cargo.toml
@@ -31,6 +31,7 @@ members = [
     "khive-pack-knowledge",
     "khive-pack-session",
     "khive-pack-git",
+    "khive-pack-workspace",
     "khive-mcp",
     "khive-vcs",
     "khive-vcs-adapters",

--- a/crates/khive-mcp/Cargo.toml
+++ b/crates/khive-mcp/Cargo.toml
@@ -26,6 +26,7 @@ khive-pack-knowledge = { version = "0.3.0", path = "../khive-pack-knowledge" }
 khive-pack-session = { version = "0.3.0", path = "../khive-pack-session" }
 khive-pack-git = { version = "0.3.0", path = "../khive-pack-git" }
 khive-pack-code = { version = "0.3.0", path = "../khive-pack-code" }
+khive-pack-workspace = { version = "0.3.0", path = "../khive-pack-workspace" }
 uuid = { workspace = true }
 inventory = { workspace = true }
 rmcp = { workspace = true, features = ["server", "transport-io"] }

--- a/crates/khive-mcp/src/args.rs
+++ b/crates/khive-mcp/src/args.rs
@@ -53,7 +53,7 @@ pub struct Args {
     /// Pack to load into the verb registry. Repeat for multiple
     /// (e.g. `--pack kg --pack gtd`). When unset, falls back to `KHIVE_PACKS`
     /// (comma- or whitespace-separated), and if that is also unset to the full
-    /// production set: `kg,gtd,memory,brain,comm,schedule,knowledge,session,git,code`.
+    /// production set: `kg,gtd,memory,brain,comm,schedule,knowledge,session,git,code,workspace`.
     #[arg(long = "pack")]
     pub pack: Vec<String>,
 

--- a/crates/khive-mcp/src/pack.rs
+++ b/crates/khive-mcp/src/pack.rs
@@ -29,3 +29,5 @@ pub use khive_pack_memory::MemoryPack as _MemoryPack;
 pub use khive_pack_schedule::SchedulePack as _SchedulePack;
 #[doc(hidden)]
 pub use khive_pack_session::SessionPack as _SessionPack;
+#[doc(hidden)]
+pub use khive_pack_workspace::WorkspacePack as _WorkspacePack;

--- a/crates/khive-pack-formal/README.md
+++ b/crates/khive-pack-formal/README.md
@@ -50,7 +50,7 @@ EdgeEndpointRule {
 `khive-pack-formal` sits in the pack tier on `khive-types` (`EdgeEndpointRule`,
 `EndpointKind`) and `khive-runtime` (`Pack`, `PackRuntime`, inventory
 registration); it `REQUIRES` [`khive-pack-kg`](https://crates.io/crates/khive-pack-kg)
-for the underlying `concept` entity substrate. Unlike the ten packs force-linked into the `khive-mcp` binary, `khive-pack-formal`
+for the underlying `concept` entity substrate. Unlike the eleven packs force-linked into the `khive-mcp` binary, `khive-pack-formal`
 is only force-linked into `kkernel` (the admin/reindex binary) — it is not part of
 the agent-facing MCP server's pack registry at all today. A deployment that
 ingests formal-math corpora (Lean/mathlib-style theorem/definition/proof graphs)

--- a/crates/khive-pack-kg/README.md
+++ b/crates/khive-pack-kg/README.md
@@ -77,9 +77,9 @@ Over MCP, the same call is issued as a DSL string:
 request(ops="create(kind=\"entity\", entity_kind=\"concept\", name=\"RoPE\")")
 ```
 
-`khive-mcp` loads a default set of ten packs — `kg`, `gtd`, `memory`, `brain`,
-`comm`, `schedule`, `knowledge`, `session`, `git`, `code` — with `kg` always
-present; `KHIVE_PACKS` / `--pack` select a subset.
+`khive-mcp` loads a default set of eleven packs: `kg`, `gtd`, `memory`, `brain`,
+`comm`, `schedule`, `knowledge`, `session`, `git`, `code`, `workspace`, with `kg`
+always present; `KHIVE_PACKS` / `--pack` select a subset.
 
 ## Where this sits
 

--- a/crates/khive-pack-knowledge/README.md
+++ b/crates/khive-pack-knowledge/README.md
@@ -88,7 +88,7 @@ All 19 verbs are `Visibility::Verb` (exposed on the agent-facing MCP surface).
 [`khive-pack-kg`](https://crates.io/crates/khive-pack-kg) (a hard `REQUIRES`
 dependency for the underlying `concept`/`document` entity substrate) and
 [`khive-pack-brain`](https://crates.io/crates/khive-pack-brain) (feedback
-target). It is one of the ten packs loaded by default in `khive-mcp`. Governing
+target). It is one of the eleven packs loaded by default in `khive-mcp`. Governing
 ADRs:
 [ADR-017 (Pack Standard)](https://github.com/ohdearquant/khive/blob/main/docs/adr/ADR-017-pack-standard.md),
 [ADR-048 (Knowledge Section Profiles)](https://github.com/ohdearquant/khive/blob/main/docs/adr/ADR-048-knowledge-section-profiles.md),

--- a/crates/khive-pack-workspace/Cargo.toml
+++ b/crates/khive-pack-workspace/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "khive-pack-workspace"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+categories.workspace = true
+description = "Workspace pack  -  pack-owned `workspace` entity kind with typed `contains` membership edges to issue/pull_request/commit/task/session records (issue #873)"
+
+[dependencies]
+khive-types = { version = "0.3.0", path = "../khive-types", features = ["serde"] }
+khive-runtime = { version = "0.3.0", path = "../khive-runtime" }
+inventory = { workspace = true }
+async-trait = { workspace = true }
+serde_json = { workspace = true }
+uuid = { workspace = true }
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["full"] }
+khive-pack-kg = { version = "0.3.0", path = "../khive-pack-kg" }
+khive-pack-gtd = { version = "0.3.0", path = "../khive-pack-gtd" }
+khive-pack-git = { version = "0.3.0", path = "../khive-pack-git" }
+khive-pack-session = { version = "0.3.0", path = "../khive-pack-session" }

--- a/crates/khive-pack-workspace/src/hook.rs
+++ b/crates/khive-pack-workspace/src/hook.rs
@@ -1,0 +1,47 @@
+//! `WorkspaceHook`  -  validates the `workspace` entity kind's required
+//! `properties.schema_version` field on create (SPEC-gate ruling 4).
+//!
+//! `name` is already required and validated by the generic entity-create
+//! path (`khive-pack-kg::handlers::create`); this hook only adds the
+//! workspace-specific `schema_version` requirement. `filesystem_path` stays
+//! an optional, unvalidated property (ruling 4/6: it is a locator, not
+//! identity, and may go stale without becoming an error).
+
+use async_trait::async_trait;
+use serde_json::Value;
+use uuid::Uuid;
+
+use khive_runtime::{KhiveRuntime, KindHook, RuntimeError};
+
+#[derive(Debug, Default)]
+pub struct WorkspaceHook;
+
+#[async_trait]
+impl KindHook for WorkspaceHook {
+    async fn prepare_create(
+        &self,
+        _runtime: &KhiveRuntime,
+        args: &mut Value,
+    ) -> Result<(), RuntimeError> {
+        let has_schema_version = args
+            .get("properties")
+            .and_then(Value::as_object)
+            .and_then(|props| props.get("schema_version"))
+            .is_some_and(|v| v.is_i64() || v.is_u64());
+        if !has_schema_version {
+            return Err(RuntimeError::InvalidInput(
+                "workspace entity requires properties.schema_version (integer)".into(),
+            ));
+        }
+        Ok(())
+    }
+
+    async fn after_create(
+        &self,
+        _runtime: &KhiveRuntime,
+        _id: Uuid,
+        _args: &Value,
+    ) -> Result<(), RuntimeError> {
+        Ok(())
+    }
+}

--- a/crates/khive-pack-workspace/src/lib.rs
+++ b/crates/khive-pack-workspace/src/lib.rs
@@ -1,0 +1,19 @@
+//! `khive-pack-workspace`  -  the workspace pack (issue #873 v0).
+//!
+//! Registers a pack-owned `workspace` entity kind: a durable, name-and-
+//! `schema_version`-bearing container with an optional, mutable,
+//! non-unique `filesystem_path` locator property. Contributes five additive
+//! `contains` endpoint rules so a workspace entity can hold git `issue` /
+//! `pull_request` / `commit` notes, GTD `task` notes, and `session` notes as
+//! typed graph membership  -  no new `EdgeRelation`, no pack-private table.
+//!
+//! v0 exposes zero new verbs: create a workspace via `create(kind="workspace",
+//! name=..., properties={schema_version: 1, ...})`, resolve or create a
+//! member record, then `link(source_id=<workspace>, target_id=<member>,
+//! relation="contains")`.
+
+mod hook;
+mod pack;
+mod vocab;
+
+pub use pack::WorkspacePack;

--- a/crates/khive-pack-workspace/src/pack.rs
+++ b/crates/khive-pack-workspace/src/pack.rs
@@ -1,0 +1,110 @@
+//! `WorkspacePack` struct, `Pack` impl, self-registration factory, and
+//! `PackRuntime` impl.
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use serde_json::Value;
+
+use khive_runtime::pack::PackRuntime;
+use khive_runtime::{KhiveRuntime, KindHook, NamespaceToken, RuntimeError, VerbRegistry};
+use khive_types::{EdgeEndpointRule, HandlerDef, Pack};
+
+use crate::hook::WorkspaceHook;
+use crate::vocab::{ENTITY_KINDS, WORKSPACE_EDGE_RULES};
+
+/// Workspace pack (issue #873 v0)  -  registers the pack-owned `workspace`
+/// entity kind and five additive `contains` endpoint rules to already-shipped
+/// member note kinds. Zero new verbs: workspaces are created and linked
+/// through the existing generic `create` and `link` KG verbs.
+pub struct WorkspacePack {
+    runtime: KhiveRuntime,
+}
+
+impl Pack for WorkspacePack {
+    const NAME: &'static str = "workspace";
+    const NOTE_KINDS: &'static [&'static str] = &[];
+    const ENTITY_KINDS: &'static [&'static str] = ENTITY_KINDS;
+    const HANDLERS: &'static [HandlerDef] = &[];
+    const EDGE_RULES: &'static [EdgeEndpointRule] = &WORKSPACE_EDGE_RULES;
+    const REQUIRES: &'static [&'static str] = &["kg", "git", "gtd", "session"];
+}
+
+impl WorkspacePack {
+    /// Create a new `WorkspacePack` bound to the given runtime.
+    pub fn new(runtime: KhiveRuntime) -> Self {
+        Self { runtime }
+    }
+
+    #[allow(dead_code)]
+    pub(crate) fn runtime(&self) -> &KhiveRuntime {
+        &self.runtime
+    }
+}
+
+// -- inventory self-registration --------------------------------------------
+
+struct WorkspacePackFactory;
+
+impl khive_runtime::PackFactory for WorkspacePackFactory {
+    fn name(&self) -> &'static str {
+        "workspace"
+    }
+
+    fn requires(&self) -> &'static [&'static str] {
+        &["kg", "git", "gtd", "session"]
+    }
+
+    fn create(&self, runtime: KhiveRuntime) -> Box<dyn khive_runtime::PackRuntime> {
+        Box::new(WorkspacePack::new(runtime))
+    }
+}
+
+inventory::submit! { khive_runtime::PackRegistration(&WorkspacePackFactory) }
+
+#[async_trait]
+impl PackRuntime for WorkspacePack {
+    fn name(&self) -> &str {
+        <WorkspacePack as Pack>::NAME
+    }
+
+    fn note_kinds(&self) -> &'static [&'static str] {
+        <WorkspacePack as Pack>::NOTE_KINDS
+    }
+
+    fn entity_kinds(&self) -> &'static [&'static str] {
+        <WorkspacePack as Pack>::ENTITY_KINDS
+    }
+
+    fn handlers(&self) -> &'static [HandlerDef] {
+        <WorkspacePack as Pack>::HANDLERS
+    }
+
+    fn edge_rules(&self) -> &'static [EdgeEndpointRule] {
+        <WorkspacePack as Pack>::EDGE_RULES
+    }
+
+    fn requires(&self) -> &'static [&'static str] {
+        <WorkspacePack as Pack>::REQUIRES
+    }
+
+    fn kind_hook(&self, kind: &str) -> Option<Arc<dyn KindHook>> {
+        match kind {
+            "workspace" => Some(Arc::new(WorkspaceHook)),
+            _ => None,
+        }
+    }
+
+    async fn dispatch(
+        &self,
+        verb: &str,
+        _params: Value,
+        _registry: &VerbRegistry,
+        _token: &NamespaceToken,
+    ) -> Result<Value, RuntimeError> {
+        Err(RuntimeError::InvalidInput(format!(
+            "workspace pack does not handle verb {verb:?}; v0 exposes no verbs, use the \
+             generic create/link KG verbs"
+        )))
+    }
+}

--- a/crates/khive-pack-workspace/src/vocab.rs
+++ b/crates/khive-pack-workspace/src/vocab.rs
@@ -1,0 +1,42 @@
+//! Workspace pack vocabulary: the `workspace` entity kind and its five
+//! additive `contains` endpoint rules.
+
+use khive_types::{EdgeEndpointRule, EdgeRelation, EndpointKind};
+
+/// Entity kinds this pack contributes to the runtime vocabulary.
+pub(crate) const ENTITY_KINDS: &[&str] = &["workspace"];
+
+/// v0 membership edges: `workspace -[contains]-> member`, one rule per
+/// already-shipped member note kind (git's `issue`/`pull_request`/`commit`,
+/// GTD's `task`, session's `session`). All additive  -  the base contract
+/// treats `contains` as entity-to-entity only; these rules broaden it to
+/// entity-to-note for the five kinds a workspace can hold in v0. Document
+/// membership (pack-doc #872) is deliberately absent until that pack settles
+/// its substrate contract.
+pub(crate) static WORKSPACE_EDGE_RULES: [EdgeEndpointRule; 5] = [
+    EdgeEndpointRule {
+        relation: EdgeRelation::Contains,
+        source: EndpointKind::EntityOfKind("workspace"),
+        target: EndpointKind::NoteOfKind("issue"),
+    },
+    EdgeEndpointRule {
+        relation: EdgeRelation::Contains,
+        source: EndpointKind::EntityOfKind("workspace"),
+        target: EndpointKind::NoteOfKind("pull_request"),
+    },
+    EdgeEndpointRule {
+        relation: EdgeRelation::Contains,
+        source: EndpointKind::EntityOfKind("workspace"),
+        target: EndpointKind::NoteOfKind("commit"),
+    },
+    EdgeEndpointRule {
+        relation: EdgeRelation::Contains,
+        source: EndpointKind::EntityOfKind("workspace"),
+        target: EndpointKind::NoteOfKind("task"),
+    },
+    EdgeEndpointRule {
+        relation: EdgeRelation::Contains,
+        source: EndpointKind::EntityOfKind("workspace"),
+        target: EndpointKind::NoteOfKind("session"),
+    },
+];

--- a/crates/khive-pack-workspace/tests/integration.rs
+++ b/crates/khive-pack-workspace/tests/integration.rs
@@ -1,0 +1,293 @@
+//! Integration tests for the workspace pack (issue #873 v0): entity-kind
+//! registration, `REQUIRES`, the five `contains` endpoint rules (positive +
+//! negative), and `name`/`schema_version` validation on create.
+
+use khive_pack_git::GitPack;
+use khive_pack_gtd::GtdPack;
+use khive_pack_kg::KgPack;
+use khive_pack_session::SessionPack;
+use khive_pack_workspace::WorkspacePack;
+use khive_runtime::{KhiveRuntime, VerbRegistry, VerbRegistryBuilder};
+use khive_types::Pack;
+use serde_json::json;
+use uuid::Uuid;
+
+fn rt() -> KhiveRuntime {
+    KhiveRuntime::memory().expect("memory runtime")
+}
+
+fn build_registry(rt: KhiveRuntime) -> VerbRegistry {
+    let mut builder = VerbRegistryBuilder::new();
+    builder.register(KgPack::new(rt.clone()));
+    builder.register(GtdPack::new(rt.clone()));
+    builder.register(GitPack::new(rt.clone()));
+    builder.register(SessionPack::new(rt.clone()));
+    builder.register(WorkspacePack::new(rt.clone()));
+    let registry = builder.build().expect("registry builds");
+    rt.install_edge_rules(registry.all_edge_rules());
+    registry
+}
+
+async fn create_workspace(registry: &VerbRegistry, name: &str) -> String {
+    let resp = registry
+        .dispatch(
+            "create",
+            json!({"kind": "workspace", "name": name, "properties": {"schema_version": 1}}),
+        )
+        .await
+        .expect("workspace create ok");
+    resp["id"].as_str().unwrap().to_string()
+}
+
+#[tokio::test]
+async fn workspace_entity_kind_registers() {
+    let registry = build_registry(rt());
+    assert!(registry.all_entity_kinds().contains(&"workspace"));
+}
+
+#[test]
+fn workspace_pack_requires_four_packs() {
+    assert_eq!(
+        WorkspacePack::REQUIRES,
+        &["kg", "git", "gtd", "session"],
+        "REQUIRES must list all four hard v0 dependencies per the SPEC-gate ruling"
+    );
+}
+
+#[test]
+fn workspace_pack_declares_no_new_verbs() {
+    assert!(
+        WorkspacePack::HANDLERS.is_empty(),
+        "v0 exposes no convenience verbs  -  create/link only"
+    );
+}
+
+#[tokio::test]
+async fn create_workspace_succeeds_with_name_and_schema_version() {
+    let registry = build_registry(rt());
+    let id = create_workspace(&registry, "sprint-42").await;
+    assert!(Uuid::parse_str(&id).is_ok());
+}
+
+#[tokio::test]
+async fn create_workspace_rejects_missing_schema_version() {
+    let registry = build_registry(rt());
+    let err = registry
+        .dispatch("create", json!({"kind": "workspace", "name": "no-schema"}))
+        .await
+        .unwrap_err();
+    assert!(
+        err.to_string().contains("schema_version"),
+        "error should mention schema_version; got: {err}"
+    );
+}
+
+#[tokio::test]
+async fn create_workspace_rejects_missing_name() {
+    let registry = build_registry(rt());
+    let err = registry
+        .dispatch(
+            "create",
+            json!({"kind": "workspace", "properties": {"schema_version": 1}}),
+        )
+        .await
+        .unwrap_err();
+    assert!(
+        err.to_string().contains("name"),
+        "error should mention the missing name field; got: {err}"
+    );
+}
+
+#[tokio::test]
+async fn create_workspace_accepts_optional_filesystem_path() {
+    let registry = build_registry(rt());
+    let resp = registry
+        .dispatch(
+            "create",
+            json!({
+                "kind": "workspace",
+                "name": "with-path",
+                "properties": {"schema_version": 1, "filesystem_path": ".khive/workspaces/2026-07-11/pack-workspace"},
+            }),
+        )
+        .await
+        .expect("workspace with filesystem_path creates ok");
+    assert_eq!(
+        resp["properties"]["filesystem_path"],
+        ".khive/workspaces/2026-07-11/pack-workspace"
+    );
+}
+
+#[tokio::test]
+async fn workspace_contains_issue_is_allowed() {
+    let registry = build_registry(rt());
+    let ws = create_workspace(&registry, "ws-issue").await;
+    let issue = registry
+        .dispatch(
+            "create",
+            json!({
+                "kind": "note", "note_kind": "issue", "content": "issue body",
+                "properties": {"number": 1, "project_id": Uuid::new_v4().to_string()},
+            }),
+        )
+        .await
+        .expect("issue create ok");
+    let issue_id = issue["id"].as_str().unwrap();
+
+    registry
+        .dispatch(
+            "link",
+            json!({"source_id": ws, "target_id": issue_id, "relation": "contains"}),
+        )
+        .await
+        .expect("workspace contains issue must be allowed");
+}
+
+#[tokio::test]
+async fn workspace_contains_pull_request_is_allowed() {
+    let registry = build_registry(rt());
+    let ws = create_workspace(&registry, "ws-pr").await;
+    let pr = registry
+        .dispatch(
+            "create",
+            json!({
+                "kind": "note", "note_kind": "pull_request", "content": "pr body",
+                "properties": {"number": 7, "project_id": Uuid::new_v4().to_string()},
+            }),
+        )
+        .await
+        .expect("pull_request create ok");
+    let pr_id = pr["id"].as_str().unwrap();
+
+    registry
+        .dispatch(
+            "link",
+            json!({"source_id": ws, "target_id": pr_id, "relation": "contains"}),
+        )
+        .await
+        .expect("workspace contains pull_request must be allowed");
+}
+
+#[tokio::test]
+async fn workspace_contains_commit_is_allowed() {
+    let registry = build_registry(rt());
+    let ws = create_workspace(&registry, "ws-commit").await;
+    let commit = registry
+        .dispatch(
+            "create",
+            json!({
+                "kind": "note", "note_kind": "commit", "content": "commit body",
+                "properties": {"sha": "a".repeat(40)},
+            }),
+        )
+        .await
+        .expect("commit create ok");
+    let commit_id = commit["id"].as_str().unwrap();
+
+    registry
+        .dispatch(
+            "link",
+            json!({"source_id": ws, "target_id": commit_id, "relation": "contains"}),
+        )
+        .await
+        .expect("workspace contains commit must be allowed");
+}
+
+#[tokio::test]
+async fn workspace_contains_task_is_allowed() {
+    let registry = build_registry(rt());
+    let ws = create_workspace(&registry, "ws-task").await;
+    let task = registry
+        .dispatch(
+            "create",
+            json!({"kind": "note", "note_kind": "task", "title": "do the thing"}),
+        )
+        .await
+        .expect("task create ok");
+    let task_id = task["id"].as_str().unwrap();
+
+    registry
+        .dispatch(
+            "link",
+            json!({"source_id": ws, "target_id": task_id, "relation": "contains"}),
+        )
+        .await
+        .expect("workspace contains task must be allowed");
+}
+
+#[tokio::test]
+async fn workspace_contains_session_is_allowed() {
+    let registry = build_registry(rt());
+    let ws = create_workspace(&registry, "ws-session").await;
+    let session = registry
+        .dispatch(
+            "create",
+            json!({"kind": "note", "note_kind": "session", "content": "session transcript"}),
+        )
+        .await
+        .expect("session note create ok");
+    let session_id = session["id"].as_str().unwrap();
+
+    registry
+        .dispatch(
+            "link",
+            json!({"source_id": ws, "target_id": session_id, "relation": "contains"}),
+        )
+        .await
+        .expect("workspace contains session must be allowed");
+}
+
+#[tokio::test]
+async fn workspace_contains_unrelated_entity_kind_is_rejected() {
+    let registry = build_registry(rt());
+    let ws = create_workspace(&registry, "ws-negative").await;
+    let concept = registry
+        .dispatch(
+            "create",
+            json!({"kind": "concept", "name": "unrelated concept"}),
+        )
+        .await
+        .expect("concept create ok");
+    let concept_id = concept["id"].as_str().unwrap();
+
+    let err = registry
+        .dispatch(
+            "link",
+            json!({"source_id": ws, "target_id": concept_id, "relation": "contains"}),
+        )
+        .await
+        .unwrap_err();
+    assert!(
+        err.to_string().contains("relation") || err.to_string().contains("Invalid"),
+        "workspace->concept contains must be rejected; got: {err}"
+    );
+}
+
+#[tokio::test]
+async fn workspace_depends_on_issue_is_rejected() {
+    let registry = build_registry(rt());
+    let ws = create_workspace(&registry, "ws-negative-relation").await;
+    let issue = registry
+        .dispatch(
+            "create",
+            json!({
+                "kind": "note", "note_kind": "issue", "content": "issue body",
+                "properties": {"number": 2, "project_id": Uuid::new_v4().to_string()},
+            }),
+        )
+        .await
+        .expect("issue create ok");
+    let issue_id = issue["id"].as_str().unwrap();
+
+    let err = registry
+        .dispatch(
+            "link",
+            json!({"source_id": ws, "target_id": issue_id, "relation": "depends_on"}),
+        )
+        .await
+        .unwrap_err();
+    assert!(
+        !err.to_string().is_empty(),
+        "workspace -[depends_on]-> issue must be rejected (only contains is extended)"
+    );
+}

--- a/crates/khive-runtime/src/config.rs
+++ b/crates/khive-runtime/src/config.rs
@@ -314,6 +314,7 @@ impl Default for RuntimeConfig {
                     "session",
                     "git",
                     "code",
+                    "workspace",
                 ]
                 .into_iter()
                 .map(String::from)

--- a/crates/khive-runtime/src/runtime.rs
+++ b/crates/khive-runtime/src/runtime.rs
@@ -1103,7 +1103,8 @@ mod tests {
         assert!(cfg.packs.contains(&"session".to_string()));
         assert!(cfg.packs.contains(&"git".to_string()));
         assert!(cfg.packs.contains(&"code".to_string()));
-        assert_eq!(cfg.packs.len(), 10);
+        assert!(cfg.packs.contains(&"workspace".to_string()));
+        assert_eq!(cfg.packs.len(), 11);
         if let Some(v) = prior {
             // SAFETY: single-threaded test cleanup; restores KHIVE_PACKS to its prior value.
             unsafe {

--- a/crates/kkernel/docs/usage.md
+++ b/crates/kkernel/docs/usage.md
@@ -38,7 +38,7 @@ This is the production entrypoint. The deno/npm distribution invokes it:
 # stdio MCP server (default transport) — what MCP clients spawn
 kkernel mcp --db ~/.khive/khive.db
 
-# pick packs explicitly (default loads all 10 production packs)
+# pick packs explicitly (default loads all 11 production packs)
 kkernel mcp --pack kg --pack gtd --pack knowledge
 
 # warm Unix-socket daemon (owns ANN indexes; stdio clients auto-spawn + forward to it)

--- a/docs/adr/ADR-027-dynamic-pack-loading.md
+++ b/docs/adr/ADR-027-dynamic-pack-loading.md
@@ -406,7 +406,7 @@ appended after `code`:
 ["kg", "gtd", "memory", "brain", "comm", "schedule", "knowledge", "session", "git", "code", "workspace"]
 ```
 
-Like `code`, `workspace` contributes zero verbs of its own — it registers the `workspace`
+Like `code`, `workspace` contributes zero verbs of its own: it registers the `workspace`
 entity kind and five `contains` endpoint rules (workspace to issue/pull_request/commit/task/session
 notes) and carries no MCP verbs. The default verb count is therefore unchanged at **78**;
 only the pack count moves from ten to eleven. Every surface that enumerates the default set

--- a/docs/adr/ADR-027-dynamic-pack-loading.md
+++ b/docs/adr/ADR-027-dynamic-pack-loading.md
@@ -395,6 +395,26 @@ remain true as more binaries are added — the ADR's "zero-touch" framing should
 "zero-touch once a pack crate is linked into every binary that needs it," not "adding a
 pack crate to the workspace is sufficient on its own."
 
+## Amendment 2 (2026-07-11): eleven-pack default, `workspace` added
+
+**Status**: accepted
+
+The `workspace` pack (#873) is now part of the shipped `RuntimeConfig::default()` set,
+appended after `code`:
+
+```text
+["kg", "gtd", "memory", "brain", "comm", "schedule", "knowledge", "session", "git", "code", "workspace"]
+```
+
+Like `code`, `workspace` contributes zero verbs of its own — it registers the `workspace`
+entity kind and five `contains` endpoint rules (workspace to issue/pull_request/commit/task/session
+notes) and carries no MCP verbs. The default verb count is therefore unchanged at **78**;
+only the pack count moves from ten to eleven. Every surface that enumerates the default set
+(this ADR, package READMEs, `docs/guide/api-reference.md`, `docs/guide/specialized-packs.md`,
+`docs/khive-config-example.toml`, `scripts/perf/mcp_bench_client.py`) tracks the eleven-pack
+list. The force-link discipline of Amendment 1 applies: `workspace` carries a `Cargo.toml`
+dependency and an anchor line in `crates/khive-mcp/src/pack.rs`.
+
 ## References
 
 - [ADR-003](ADR-003-system-architecture.md) — `kkernel` binary; `pack list` introspection

--- a/docs/guide/api-reference.md
+++ b/docs/guide/api-reference.md
@@ -19,18 +19,18 @@ An always-machine-readable copy of this page is at
 
 ## Packs at a glance
 
-| Pack        | Verbs | Load with                  | Optional?           |
-| ----------- | ----- | -------------------------- | ------------------- |
-| `kg`        | 18    | `KHIVE_PACKS=kg` (default) | No — base substrate |
-| `gtd`       | 5     | `KHIVE_PACKS=kg,gtd`       | Yes                 |
-| `memory`    | 5     | `KHIVE_PACKS=kg,memory`    | Yes                 |
-| `brain`     | 15    | `KHIVE_PACKS=kg,brain`     | Yes                 |
-| `comm`      | 7     | `KHIVE_PACKS=kg,comm`      | Yes                 |
-| `schedule`  | 4     | `KHIVE_PACKS=kg,schedule`  | Yes                 |
-| `knowledge` | 19    | `KHIVE_PACKS=kg,knowledge` | Yes                 |
-| `session`   | 4     | `KHIVE_PACKS=kg,session`   | Yes                 |
-| `git`       | 1     | `KHIVE_PACKS=kg,git`       | Yes                 |
-| `code`      | 0     | `KHIVE_PACKS=kg,code`      | Yes                 |
+| Pack        | Verbs | Load with                                  | Optional?           |
+| ----------- | ----- | ------------------------------------------ | ------------------- |
+| `kg`        | 18    | `KHIVE_PACKS=kg` (default)                 | No — base substrate |
+| `gtd`       | 5     | `KHIVE_PACKS=kg,gtd`                       | Yes                 |
+| `memory`    | 5     | `KHIVE_PACKS=kg,memory`                    | Yes                 |
+| `brain`     | 15    | `KHIVE_PACKS=kg,brain`                     | Yes                 |
+| `comm`      | 7     | `KHIVE_PACKS=kg,comm`                      | Yes                 |
+| `schedule`  | 4     | `KHIVE_PACKS=kg,schedule`                  | Yes                 |
+| `knowledge` | 19    | `KHIVE_PACKS=kg,knowledge`                 | Yes                 |
+| `session`   | 4     | `KHIVE_PACKS=kg,session`                   | Yes                 |
+| `git`       | 1     | `KHIVE_PACKS=kg,git`                       | Yes                 |
+| `code`      | 0     | `KHIVE_PACKS=kg,code`                      | Yes                 |
 | `workspace` | 0     | `KHIVE_PACKS=kg,git,gtd,session,workspace` | Yes                 |
 
 `git` also registers the `commit` / `issue` / `pull_request` note kinds and the shared

--- a/docs/guide/api-reference.md
+++ b/docs/guide/api-reference.md
@@ -1,15 +1,15 @@
 # API Reference
 
-khive exposes exactly one MCP tool, `request`. Everything else — 78 verbs across 10
-production packs — is dispatched through that single tool via a small request DSL.
+khive exposes exactly one MCP tool, `request`. Everything else, 78 verbs across 11
+production packs, is dispatched through that single tool via a small request DSL.
 This page documents the DSL grammar, the response envelope, and every verb's full
 parameter contract, so an agent can call khive correctly without reading Rust source.
 
 This page is verified against the live registry (`request(ops="verbs()")`, run
 2026-07-10) and the pack source (`crates/khive-pack-*/src/*.rs` `HandlerDef`/`ParamDef`
 struct literals). Verb count: **78**, matching both the live registry `total` field and
-the sum of the 10 pack counts below. If your server reports a different total, your
-`KHIVE_PACKS` configuration loads a different pack set than the default — run
+the sum of the 11 pack counts below. If your server reports a different total, your
+`KHIVE_PACKS` configuration loads a different pack set than the default, run
 `request(ops="verbs()")` against your own server to get the authoritative list.
 
 An always-machine-readable copy of this page is at
@@ -31,6 +31,7 @@ An always-machine-readable copy of this page is at
 | `session`   | 4     | `KHIVE_PACKS=kg,session`   | Yes                 |
 | `git`       | 1     | `KHIVE_PACKS=kg,git`       | Yes                 |
 | `code`      | 0     | `KHIVE_PACKS=kg,code`      | Yes                 |
+| `workspace` | 0     | `KHIVE_PACKS=kg,workspace` | Yes                 |
 
 `git` also registers the `commit` / `issue` / `pull_request` note kinds and the shared
 `run_ingest` core (`crates/khive-pack-git/src/ingest.rs`) that both `git.digest` and the

--- a/docs/guide/api-reference.md
+++ b/docs/guide/api-reference.md
@@ -41,8 +41,8 @@ accepted but unimplemented (ADR-085), and `findings.json` ingest runs through th
 `kkernel code-ingest` admin CLI path, not the MCP verb surface — so it contributes 0
 verbs to the total below.
 
-The default binary (no `KHIVE_PACKS`/`--pack` override) loads all 10 packs: 18 + 5 + 5 +
-15 + 7 + 4 + 19 + 4 + 1 + 0 = **78 verbs**.
+The default binary (no `KHIVE_PACKS`/`--pack` override) loads all 11 packs: 18 + 5 + 5 +
+15 + 7 + 4 + 19 + 4 + 1 + 0 + 0 = **78 verbs**.
 
 Verb names in the `kg` pack are bare (`create`, `search`, `link`, …). Every other pack
 namespaces its verbs with a `pack.` prefix (`gtd.assign`, `memory.recall`,

--- a/docs/guide/api-reference.md
+++ b/docs/guide/api-reference.md
@@ -31,11 +31,13 @@ An always-machine-readable copy of this page is at
 | `session`   | 4     | `KHIVE_PACKS=kg,session`   | Yes                 |
 | `git`       | 1     | `KHIVE_PACKS=kg,git`       | Yes                 |
 | `code`      | 0     | `KHIVE_PACKS=kg,code`      | Yes                 |
-| `workspace` | 0     | `KHIVE_PACKS=kg,workspace` | Yes                 |
+| `workspace` | 0     | `KHIVE_PACKS=kg,git,gtd,session,workspace` | Yes                 |
 
 `git` also registers the `commit` / `issue` / `pull_request` note kinds and the shared
 `run_ingest` core (`crates/khive-pack-git/src/ingest.rs`) that both `git.digest` and the
 `kkernel git-ingest` CLI drive.
+
+`workspace` requires `kg`, `git`, `gtd`, and `session` to be loaded alongside it (the runtime rejects a pack set that omits a declared dependency), so its minimal example lists all four.
 
 `code` registers the `finding` note kind and edge rules only; its `code.ingest` verb is
 accepted but unimplemented (ADR-085), and `findings.json` ingest runs through the

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -9,7 +9,7 @@ graph, and link concepts together.
 khive is a research knowledge graph runtime. When you read papers, form
 concepts, link ideas, record decisions, or track tasks, khive gives that work a
 typed, queryable graph that persists across sessions. Everything is accessible
-through 78 verbs across 10 packs, dispatched through a single MCP tool.
+through 78 verbs across 11 packs, dispatched through a single MCP tool.
 
 ## Install
 

--- a/docs/guide/specialized-packs.md
+++ b/docs/guide/specialized-packs.md
@@ -1,11 +1,12 @@
 # Specialized Packs
 
-khive's default install loads ten production packs
-(`kg, gtd, memory, brain, comm, schedule, knowledge, session, git, code`, per
-`RuntimeConfig::default()` in `crates/khive-runtime/src/config.rs`). Of these,
-`code` already contributes zero verbs of its own — it registers the `finding`
-note kind and edge rules only; its `code.ingest` verb is accepted but
-unimplemented (see [ADR-085](../adr/ADR-085-code-pack.md)). Beyond the
+khive's default install loads eleven production packs
+(`kg, gtd, memory, brain, comm, schedule, knowledge, session, git, code, workspace`, per
+`RuntimeConfig::default()` in `crates/khive-runtime/src/config.rs`). Two of these
+contribute zero verbs of their own: `code` registers the `finding` note kind and
+edge rules only, with its `code.ingest` verb accepted but unimplemented (see
+[ADR-085](../adr/ADR-085-code-pack.md)); `workspace` registers the `workspace`
+entity kind and five `contains` endpoint rules only, with no verbs. Beyond the
 default set, khive also ships niche packs that extend the graph for a
 specific domain without adding verbs of their own. This guide covers the
 formal-math pack, the first of these, and how pack loading works in general.

--- a/docs/khive-config-example.toml
+++ b/docs/khive-config-example.toml
@@ -185,7 +185,7 @@ fusion_weight = 0.5
 #   KHIVE_NAMESPACE=local        Legacy alias for KHIVE_ACTOR; loses to it when both are set.
 #   KHIVE_NO_EMBED=false         Disable the local embedding model (skips vector indexing).
 #                                STRICT bool: only "true"/"false" — "1" is a startup error.
-#   KHIVE_PACKS=kg,gtd,memory,brain,comm,schedule,knowledge,session,git,code
+#   KHIVE_PACKS=kg,gtd,memory,brain,comm,schedule,knowledge,session,git,code,workspace
 #                                Packs to load when --pack is absent. Comma / space separated.
 #   KHIVE_CONFIG=./khive.toml    Path to THIS config file. Also --config. Overrides the search order.
 #   KHIVE_LOG=warn               Stderr log level (JSON results on stdout are unaffected).

--- a/marketplace/khive/README.md
+++ b/marketplace/khive/README.md
@@ -2,7 +2,7 @@
 
 One plugin for the whole khive surface: a knowledge graph, GTD, memory, inter-agent comm,
 scheduling, and a domain-knowledge corpus, all served by a single MCP server (`kkernel mcp`)
-exposing one tool — `request` — that dispatches 78 verbs across 10 packs.
+exposing one tool — `request` — that dispatches 78 verbs across 11 packs.
 
 This plugin is **guidance, not a second runtime**. It ships the pattern skills that teach an
 agent how to use each pack well, plus the kg stewardship agents. The data and verbs live in the

--- a/marketplace/khive/README.md
+++ b/marketplace/khive/README.md
@@ -2,7 +2,7 @@
 
 One plugin for the whole khive surface: a knowledge graph, GTD, memory, inter-agent comm,
 scheduling, and a domain-knowledge corpus, all served by a single MCP server (`kkernel mcp`)
-exposing one tool — `request` — that dispatches 78 verbs across 11 packs.
+exposing one tool, `request`, that dispatches 78 verbs across 11 packs.
 
 This plugin is **guidance, not a second runtime**. It ships the pattern skills that teach an
 agent how to use each pack well, plus the kg stewardship agents. The data and verbs live in the

--- a/npm/README.md
+++ b/npm/README.md
@@ -1,6 +1,6 @@
 # khive
 
-A research knowledge graph runtime — 78 verbs, 11 packs, one MCP tool.
+A research knowledge graph runtime: 78 verbs, 11 packs, one MCP tool.
 
 [![GitHub](https://img.shields.io/github/stars/ohdearquant/khive?style=flat)](https://github.com/ohdearquant/khive)
 [![crates.io](https://img.shields.io/crates/v/khive-mcp.svg)](https://crates.io/crates/khive-mcp)

--- a/npm/README.md
+++ b/npm/README.md
@@ -1,6 +1,6 @@
 # khive
 
-A research knowledge graph runtime — 78 verbs, 10 packs, one MCP tool.
+A research knowledge graph runtime — 78 verbs, 11 packs, one MCP tool.
 
 [![GitHub](https://img.shields.io/github/stars/ohdearquant/khive?style=flat)](https://github.com/ohdearquant/khive)
 [![crates.io](https://img.shields.io/crates/v/khive-mcp.svg)](https://crates.io/crates/khive-mcp)
@@ -19,7 +19,7 @@ Add to `.mcp.json` (project-level or `~/.claude/mcp.json` for global):
 { "mcpServers": { "khive": { "command": "khive", "args": ["mcp"] } } }
 ```
 
-All 10 packs load by default. A background daemon auto-spawns to keep the runtime warm.
+All 11 packs load by default. A background daemon auto-spawns to keep the runtime warm.
 
 ## What you get
 

--- a/scripts/perf/LOAD_HARNESS_RUNBOOK.md
+++ b/scripts/perf/LOAD_HARNESS_RUNBOOK.md
@@ -43,7 +43,7 @@ config:
 
 ```bash
 uv run scripts/perf/bench_load_harness.py --mode real --workers 100 --tenants 20 --ops-per-worker 50 \
-  --packs kg,gtd,memory,brain,comm,schedule,knowledge,session,git,code
+  --packs kg,gtd,memory,brain,comm,schedule,knowledge,session,git,code,workspace
 ```
 
 `--workers` must be an exact multiple of `--tenants` (workers are split

--- a/scripts/perf/LOAD_HARNESS_RUNBOOK.md
+++ b/scripts/perf/LOAD_HARNESS_RUNBOOK.md
@@ -37,8 +37,8 @@ uv run scripts/perf/bench_load_harness.py --mode real --workers 20 --tenants 4 -
 ```
 
 Full acceptance shape (100 connections × 20 tenant namespaces, the actual
-gate target). Pass `--packs` explicitly to measure the full 10-pack production
-posture — including `session`, `git`, and `code` — against a real multi-pack
+gate target). Pass `--packs` explicitly to measure the full 11-pack production
+posture, including `session`, `git`, `code`, and `workspace`, against a real multi-pack
 config:
 
 ```bash

--- a/scripts/perf/mcp_bench_client.py
+++ b/scripts/perf/mcp_bench_client.py
@@ -62,7 +62,7 @@ PROTOCOL_VERSION = 3
 # Default production pack set (must match RuntimeConfig::default().packs in
 # crates/khive-runtime/src/config.rs so config_id agrees between front-end
 # and daemon child).
-DEFAULT_PACKS = "kg,gtd,memory,brain,comm,schedule,knowledge,session,git,code"
+DEFAULT_PACKS = "kg,gtd,memory,brain,comm,schedule,knowledge,session,git,code,workspace"
 
 # ── Live-DB safety guard ──────────────────────────────────────────────────────
 

--- a/tests/smoke_test.py
+++ b/tests/smoke_test.py
@@ -196,8 +196,8 @@ def main():
         assert "total" in verbs_result, f"verbs must return 'total' key: {verbs_result}"
         assert isinstance(verbs_result["verbs"], list), f"verbs must be a list: {verbs_result}"
         # Surface-contract tripwire: the default config (no --pack, KHIVE_PACKS
-        # unset) loads 10 production packs (kg, gtd, memory, brain, comm, schedule,
-        # knowledge, session, git, code), so verbs() returns exactly 78 user-facing
+        # unset) loads 11 production packs (kg, gtd, memory, brain, comm, schedule,
+        # knowledge, session, git, code, workspace), so verbs() returns exactly 78 user-facing
         # MCP-callable verbs (count what verbs() returns, not internal dispatch
         # arms). The session pack contributes 4 agent-facing T1 verbs
         # (store/list/resume/export), promoted from internal subhandlers to
@@ -208,19 +208,22 @@ def main():
         # inbound poll), and brain.event_counts (#724, ADR-103 Stage 1
         # windowed event read) are included in the count; git contributes
         # git.digest (ADR-088 Amendment 1); code contributes zero verbs
-        # (ADR-085 D1/Amendment 3 — its `finding` note kind and
+        # (ADR-085 D1/Amendment 3, its `finding` note kind and
         # `findings.json` ingest are reached only via the `kkernel
-        # code-ingest` admin CLI, never this MCP verb surface). Update this
+        # code-ingest` admin CLI, never this MCP verb surface); workspace
+        # (#873) also contributes zero verbs, adding only the `workspace`
+        # entity kind and `contains` endpoint rules. Update this
         # number when the pack set or verb surface changes; a silent drift
         # here is the bug this assertion exists to catch.
         assert verbs_result["total"] == 78, (
-            f"expected 78 user-facing verbs from the 10 default packs "
+            f"expected 78 user-facing verbs from the 11 default packs "
             f"(session contributes 4 T1 verbs promoted to Visibility::Verb per "
             f"ADR-083; context is the 17th kg-substrate bare verb per ADR-089; "
             f"resolve is the 18th kg-substrate bare verb per the unified-verb "
             f"draft ADR Slice 1; comm.health is #606; comm.probe is #644; "
             f"brain.event_counts is #724/ADR-103; git contributes git.digest; "
-            f"code contributes zero verbs per ADR-085 D1/Amendment 3), "
+            f"code contributes zero verbs per ADR-085 D1/Amendment 3; "
+            f"workspace (#873) contributes zero verbs), "
             f"got {verbs_result['total']}: {verbs_result}"
         )
         verb_names = [v["verb"] for v in verbs_result["verbs"]]


### PR DESCRIPTION
# pack-workspace v0  -  implementation summary (issue #873, cargo lane)

## What was built

New crate `crates/khive-pack-workspace`, implementing the approved v0 slice from
`design/pack-workspace-onepager.md` and the SPEC-gate rulings:

- **`WorkspacePack`** (`src/pack.rs`): registers a pack-owned `workspace` ENTITY
  kind via `Pack::ENTITY_KINDS`. `Pack::HANDLERS` is empty  -  v0 exposes zero new
  verbs; workspaces are created and linked entirely through the existing generic
  `create` and `link` KG verbs. `Pack::REQUIRES = ["kg", "git", "gtd", "session"]`
  (hard deps per ruling 2). Self-registers via `inventory::submit!` following the
  same pattern as `khive-pack-git`/`khive-pack-gtd`.
- **`WORKSPACE_EDGE_RULES`** (`src/vocab.rs`): five additive `EdgeEndpointRule`s,
  all `EdgeRelation::Contains`, source `EntityOfKind("workspace")`, targets
  `NoteOfKind("issue")`, `NoteOfKind("pull_request")`, `NoteOfKind("commit")`,
  `NoteOfKind("task")`, `NoteOfKind("session")`. No new `EdgeRelation`; only the
  existing `contains` endpoint contract is broadened.
- **`WorkspaceHook`** (`src/hook.rs`): a `KindHook` registered for the
  `"workspace"` kind that validates `properties.schema_version` is present (an
  integer) on create, rejecting the create otherwise (ruling 4). `name` is
  already required/validated by the generic entity-create path in
  `khive-pack-kg`, so no duplicate check was added. `filesystem_path` is left as
  an ordinary optional, non-unique, mutable property  -  no uniqueness or
  existence check, matching ruling 4/6 (a stale/missing path is staleness, not
  an error). No archive/close lifecycle surface was added (ruling 8).

## Wiring into the default pack set

Following the pattern of the other optional-but-default packs (`git`, `gtd`,
`session`):

- `crates/Cargo.toml`: added `"khive-pack-workspace"` to `[workspace] members`.
- `crates/khive-mcp/Cargo.toml`: added the crate as a dependency.
- `crates/khive-mcp/src/pack.rs`: added the force-link `pub use
  khive_pack_workspace::WorkspacePack as _WorkspacePack;` so the linker includes
  its `inventory::submit!` registration in the binary.
- `crates/khive-runtime/src/config.rs`: added `"workspace"` to the default
  `KHIVE_PACKS` list (now 11 production packs).
- `crates/khive-runtime/src/runtime.rs`: updated the
  `default_config_packs_loads_all_production_packs` test to assert the new
  pack and the new count (11, was 10)  -  this test lives outside the pack crate
  but pins the exact default set and would otherwise fail after this change.
- `crates/khive-mcp/src/args.rs`: updated the `--pack` doc comment's listed
  production set to include `workspace`.

## Tests (`crates/khive-pack-workspace/tests/integration.rs`, 14 tests, all pass)

- `workspace` entity kind registers in the merged registry vocabulary.
- `REQUIRES` is exactly `["kg", "git", "gtd", "session"]`.
- `HANDLERS` is empty (no convenience verbs in v0).
- Create succeeds with `name` + `properties.schema_version`; `filesystem_path`
  round-trips as an ordinary optional property.
- Create is rejected when `schema_version` is missing, and when `name` is
  missing.
- Each of the five `contains` endpoint pairs (workspace -> issue / pull_request
  / commit / task / session) is exercised end-to-end: create both records via
  the generic `create` verb, then `link(relation="contains")` and assert it
  succeeds.
- Two negative cases: `workspace -[contains]-> concept` (unrelated entity kind)
  is rejected, and `workspace -[depends_on]-> issue` (right endpoints, wrong
  relation) is rejected.

## Gates (scoped, cargo lane, `CARGO_TARGET_DIR` respected)

Run from `crates/`:

- `cargo check -p khive-pack-workspace`  -  clean.
- `cargo clippy -p khive-pack-workspace --all-targets -- -D warnings`  -  clean.
- `cargo test -p khive-pack-workspace`  -  14/14 pass.
- `cargo fmt -p khive-pack-workspace -- --check`  -  clean.
- `cargo check -p khive-mcp`  -  clean (touched by the default-pack-set wiring).
- `cargo test -p khive-runtime default_config_packs_loads_all_production_packs`
   -  clean (pinned-list test updated for the new default pack).
- `cargo fmt -p khive-runtime -- --check` / `cargo fmt -p khive-mcp -- --check`
   -  clean.

`cargo test --workspace` was deliberately NOT run (times out agents per the
brief; this leg owns only the scoped cargo lane above).

## Notes / follow-ups (out of scope for this leg)

- Document membership (pack-doc #872) is intentionally absent  -  no
  `contains` rule to a document endpoint yet, per the one-pager.
- No convenience verb (`workspace.create`/`workspace.attach`) was added; the
  brief and SPEC-gate ruling 5 defer that to later workflow evidence.
- The `mcp__khive__request` MCP tool was not available in this worktree
  session, so the flywheel `memory.recall` / `brain.auto_feedback` /
  `memory.remember` steps prescribed in the brief could not be executed here.
