### PR TITLE
chore(release): 0.4.0 workspace bump + publish pipeline maintenance

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -174,7 +174,7 @@ jobs:
           # list synchronized with the semver-gate excludes in
           # scripts/publish.sh; drop each entry after its first crates.io
           # release so it is gated too.
-          exclude: khive-quant,khive-changeset,khive-pack-code,khive-pack-git,khive-pack-workspace
+          exclude: khive-changeset,khive-pack-code,khive-pack-git,khive-pack-workspace
 
   # ─────────────────────────────────────────────────────────────────────────
   # Phase 2: Publish all subpackages + umbrella atomically in a single job.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -169,10 +169,12 @@ jobs:
         uses: obi1kenobi/cargo-semver-checks-action@6b69fcf40e9b5fb17adeb57e4b6ecd020649a239 # v2.9
         with:
           manifest-path: crates/Cargo.toml
-          # khive-quant (SQ8 codecs) has never been published, so it has no
-          # crates.io baseline and makes the check un-runnable if left in scope.
-          # Drop it from `exclude:` once it is first published to gate it too.
-          exclude: khive-quant
+          # These crates have never been published, so they have no crates.io
+          # baseline and make the check un-runnable if left in scope. Keep this
+          # list synchronized with the semver-gate excludes in
+          # scripts/publish.sh; drop each entry after its first crates.io
+          # release so it is gated too.
+          exclude: khive-quant,khive-changeset,khive-pack-code,khive-pack-git,khive-pack-workspace
 
   # ─────────────────────────────────────────────────────────────────────────
   # Phase 2: Publish all subpackages + umbrella atomically in a single job.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -210,6 +210,24 @@ jobs:
         run: |
           echo "VERSION=${{ inputs.version }}" >> "$GITHUB_ENV"
 
+      # ADR-026 same-version pinning: the manual dispatch input is untrusted.
+      # Refuse to publish anything whose version does not match the checked-in
+      # sources: the Rust workspace version (what the binaries were built as)
+      # and the umbrella npm/package.json must both equal inputs.version.
+      - name: Guard - dispatch version must match checked-in sources
+        run: |
+          CARGO_VERSION=$(awk '/^\[workspace\.package\]/{f=1;next} /^\[/{f=0} f && /^version = /{gsub(/version = |"/,""); print; exit}' crates/Cargo.toml)
+          NPM_VERSION=$(node -p "require('./npm/package.json').version")
+          echo "inputs.version=${VERSION} crates/Cargo.toml=${CARGO_VERSION} npm/package.json=${NPM_VERSION}"
+          if [ "$VERSION" != "$CARGO_VERSION" ]; then
+            echo "::error::Dispatch version ${VERSION} does not match crates/Cargo.toml workspace version ${CARGO_VERSION}"
+            exit 1
+          fi
+          if [ "$VERSION" != "$NPM_VERSION" ]; then
+            echo "::error::Dispatch version ${VERSION} does not match npm/package.json version ${NPM_VERSION}"
+            exit 1
+          fi
+
       # Download all six platform artifacts into their respective directories.
       - name: Download all platform artifacts
         uses: actions/download-artifact@v4

--- a/README.md
+++ b/README.md
@@ -225,7 +225,7 @@ touching consumers.
 
 ## Quick start
 
-**1. Install** (from [crates.io](https://crates.io/crates/khive-mcp), currently at `0.3.1`):
+**1. Install** (from [crates.io](https://crates.io/crates/khive-mcp), currently at `0.4.0`):
 
 ```bash
 cargo install kkernel
@@ -375,7 +375,7 @@ Docs: [ohdearquant.github.io/khive](https://ohdearquant.github.io/khive/) (agent
 
 ## Status
 
-**v0.3.1, published on [crates.io](https://crates.io/crates/khive-mcp).** 78 verbs across 11
+**v0.4.0, published on [crates.io](https://crates.io/crates/khive-mcp).** 78 verbs across 11
 packs, 9 entity kinds, 17 edge relations, daemon warm startup (ADR-049), knowledge search with
 embedding rerank, Bayesian brain profiles, threaded messaging, scheduled verb execution.
 Ready for use with Claude Code and any MCP-compatible agent.

--- a/README.md
+++ b/README.md
@@ -225,7 +225,7 @@ touching consumers.
 
 ## Quick start
 
-**1. Install** (from [crates.io](https://crates.io/crates/khive-mcp), currently at `0.4.0`):
+**1. Install** (from [crates.io](https://crates.io/crates/khive-mcp), currently at `0.3.0`; `0.4.0` publishes with this release):
 
 ```bash
 cargo install kkernel
@@ -375,7 +375,7 @@ Docs: [ohdearquant.github.io/khive](https://ohdearquant.github.io/khive/) (agent
 
 ## Status
 
-**v0.4.0, published on [crates.io](https://crates.io/crates/khive-mcp).** 78 verbs across 11
+**v0.4.0 (publication pending; crates.io currently serves 0.3.0).** 78 verbs across 11
 packs, 9 entity kinds, 17 edge relations, daemon warm startup (ADR-049), knowledge search with
 embedding rerank, Bayesian brain profiles, threaded messaging, scheduled verb execution.
 Ready for use with Claude Code and any MCP-compatible agent.

--- a/README.md
+++ b/README.md
@@ -225,7 +225,7 @@ touching consumers.
 
 ## Quick start
 
-**1. Install** (from [crates.io](https://crates.io/crates/khive-mcp), currently at `0.3.0`):
+**1. Install** (from [crates.io](https://crates.io/crates/khive-mcp), currently at `0.3.1`):
 
 ```bash
 cargo install kkernel
@@ -375,7 +375,7 @@ Docs: [ohdearquant.github.io/khive](https://ohdearquant.github.io/khive/) (agent
 
 ## Status
 
-**v0.3.0, published on [crates.io](https://crates.io/crates/khive-mcp).** 78 verbs across 11
+**v0.3.1, published on [crates.io](https://crates.io/crates/khive-mcp).** 78 verbs across 11
 packs, 9 entity kinds, 17 edge relations, daemon warm startup (ADR-049), knowledge search with
 embedding rerank, Bayesian brain profiles, threaded messaging, scheduled verb execution.
 Ready for use with Claude Code and any MCP-compatible agent.

--- a/crates/Cargo.toml
+++ b/crates/Cargo.toml
@@ -49,7 +49,7 @@ exclude = ["khive-merge"]
 # keep this exclusion from members.
 
 [workspace.package]
-version = "0.3.1"
+version = "0.4.0"
 edition = "2021"
 # floor_char_boundary/ceil_char_boundary (round_char_boundary, rust-lang/rust#93743)
 # stabilized in 1.91.0; khive-pack-brain's persist.rs uses floor_char_boundary.

--- a/crates/Cargo.toml
+++ b/crates/Cargo.toml
@@ -49,7 +49,7 @@ exclude = ["khive-merge"]
 # keep this exclusion from members.
 
 [workspace.package]
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 # floor_char_boundary/ceil_char_boundary (round_char_boundary, rust-lang/rust#93743)
 # stabilized in 1.91.0; khive-pack-brain's persist.rs uses floor_char_boundary.

--- a/crates/khive-bm25/Cargo.toml
+++ b/crates/khive-bm25/Cargo.toml
@@ -15,7 +15,7 @@ description = "BM25 (Okapi BM25) keyword index with deterministic scoring"
 bench = false
 
 [dependencies]
-khive-score = { version = "0.3.1", path = "../khive-score" }
+khive-score = { version = "0.4.0", path = "../khive-score" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/khive-bm25/Cargo.toml
+++ b/crates/khive-bm25/Cargo.toml
@@ -15,7 +15,7 @@ description = "BM25 (Okapi BM25) keyword index with deterministic scoring"
 bench = false
 
 [dependencies]
-khive-score = { version = "0.3.0", path = "../khive-score" }
+khive-score = { version = "0.3.1", path = "../khive-score" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/khive-brain-core/Cargo.toml
+++ b/crates/khive-brain-core/Cargo.toml
@@ -15,7 +15,7 @@ description = "Brain primitives — Beta posteriors, section types, profile stat
 bench = false
 
 [dependencies]
-khive-runtime = { version = "0.3.0", path = "../khive-runtime" }
+khive-runtime = { version = "0.3.1", path = "../khive-runtime" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 uuid = { workspace = true }

--- a/crates/khive-brain-core/Cargo.toml
+++ b/crates/khive-brain-core/Cargo.toml
@@ -15,7 +15,7 @@ description = "Brain primitives — Beta posteriors, section types, profile stat
 bench = false
 
 [dependencies]
-khive-runtime = { version = "0.3.1", path = "../khive-runtime" }
+khive-runtime = { version = "0.4.0", path = "../khive-runtime" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 uuid = { workspace = true }

--- a/crates/khive-changeset/Cargo.toml
+++ b/crates/khive-changeset/Cargo.toml
@@ -12,7 +12,7 @@ categories.workspace = true
 description = "Producer-agnostic KG change-set op-list model and NDJSON-delta serialization"
 
 [dependencies]
-khive-types = { version = "0.3.0", path = "../khive-types", features = ["serde"] }
+khive-types = { version = "0.3.1", path = "../khive-types", features = ["serde"] }
 serde = { workspace = true }
 # float_roundtrip: the default float parser is a fast approximation that does
 # not always recover the exact f64 bits a prior serialize wrote (weight/

--- a/crates/khive-changeset/Cargo.toml
+++ b/crates/khive-changeset/Cargo.toml
@@ -12,7 +12,7 @@ categories.workspace = true
 description = "Producer-agnostic KG change-set op-list model and NDJSON-delta serialization"
 
 [dependencies]
-khive-types = { version = "0.3.1", path = "../khive-types", features = ["serde"] }
+khive-types = { version = "0.4.0", path = "../khive-types", features = ["serde"] }
 serde = { workspace = true }
 # float_roundtrip: the default float parser is a fast approximation that does
 # not always recover the exact f64 bits a prior serialize wrote (weight/

--- a/crates/khive-channel-email/Cargo.toml
+++ b/crates/khive-channel-email/Cargo.toml
@@ -12,7 +12,7 @@ categories.workspace = true
 description = "Email (SMTP/IMAP) channel adapter for khive (ADR-056)"
 
 [dependencies]
-khive-channel = { version = "0.3.0", path = "../khive-channel" }
+khive-channel = { version = "0.3.1", path = "../khive-channel" }
 async-trait = { workspace = true }
 thiserror = { workspace = true }
 serde = { workspace = true }

--- a/crates/khive-channel-email/Cargo.toml
+++ b/crates/khive-channel-email/Cargo.toml
@@ -12,7 +12,7 @@ categories.workspace = true
 description = "Email (SMTP/IMAP) channel adapter for khive (ADR-056)"
 
 [dependencies]
-khive-channel = { version = "0.3.1", path = "../khive-channel" }
+khive-channel = { version = "0.4.0", path = "../khive-channel" }
 async-trait = { workspace = true }
 thiserror = { workspace = true }
 serde = { workspace = true }

--- a/crates/khive-db/Cargo.toml
+++ b/crates/khive-db/Cargo.toml
@@ -15,9 +15,9 @@ description = "SQLite storage backend: entities, edges, notes, events, FTS5, sql
 bench = false
 
 [dependencies]
-khive-storage = { version = "0.3.1", path = "../khive-storage" }
-khive-score = { version = "0.3.1", path = "../khive-score" }
-khive-types = { version = "0.3.1", path = "../khive-types", features = ["serde"] }
+khive-storage = { version = "0.4.0", path = "../khive-storage" }
+khive-score = { version = "0.4.0", path = "../khive-score" }
+khive-types = { version = "0.4.0", path = "../khive-types", features = ["serde"] }
 tokio = { workspace = true }
 async-trait = { workspace = true }
 uuid = { workspace = true }
@@ -36,8 +36,8 @@ sqlite-vec = { workspace = true, optional = true }
 tokio = { workspace = true, features = ["full", "test-util"] }
 tempfile = { workspace = true }
 rusqlite = { workspace = true, features = ["bundled", "column_decltype"] }
-khive-storage = { version = "0.3.1", path = "../khive-storage" }
-khive-types = { version = "0.3.1", path = "../khive-types", features = ["serde"] }
+khive-storage = { version = "0.4.0", path = "../khive-storage" }
+khive-types = { version = "0.4.0", path = "../khive-types", features = ["serde"] }
 uuid = { workspace = true }
 criterion = { workspace = true }
 rand = { workspace = true }

--- a/crates/khive-db/Cargo.toml
+++ b/crates/khive-db/Cargo.toml
@@ -15,9 +15,9 @@ description = "SQLite storage backend: entities, edges, notes, events, FTS5, sql
 bench = false
 
 [dependencies]
-khive-storage = { version = "0.3.0", path = "../khive-storage" }
-khive-score = { version = "0.3.0", path = "../khive-score" }
-khive-types = { version = "0.3.0", path = "../khive-types", features = ["serde"] }
+khive-storage = { version = "0.3.1", path = "../khive-storage" }
+khive-score = { version = "0.3.1", path = "../khive-score" }
+khive-types = { version = "0.3.1", path = "../khive-types", features = ["serde"] }
 tokio = { workspace = true }
 async-trait = { workspace = true }
 uuid = { workspace = true }
@@ -36,8 +36,8 @@ sqlite-vec = { workspace = true, optional = true }
 tokio = { workspace = true, features = ["full", "test-util"] }
 tempfile = { workspace = true }
 rusqlite = { workspace = true, features = ["bundled", "column_decltype"] }
-khive-storage = { version = "0.3.0", path = "../khive-storage" }
-khive-types = { version = "0.3.0", path = "../khive-types", features = ["serde"] }
+khive-storage = { version = "0.3.1", path = "../khive-storage" }
+khive-types = { version = "0.3.1", path = "../khive-types", features = ["serde"] }
 uuid = { workspace = true }
 criterion = { workspace = true }
 rand = { workspace = true }

--- a/crates/khive-fold/Cargo.toml
+++ b/crates/khive-fold/Cargo.toml
@@ -21,10 +21,10 @@ default = ["serde"]
 serde = ["dep:serde"]
 
 [dependencies]
-khive-score = { version = "0.3.1", path = "../khive-score" }
+khive-score = { version = "0.4.0", path = "../khive-score" }
 # ADR-024 boundary: khive-types + khive-score only.
 # blake3 feature enables Hash32::from_blake3 for checkpoint hashing.
-khive-types = { version = "0.3.1", path = "../khive-types", features = ["blake3", "serde"] }
+khive-types = { version = "0.4.0", path = "../khive-types", features = ["blake3", "serde"] }
 # serde: optional, gated by the `serde` feature above.
 serde = { workspace = true, optional = true }
 # serde_json: kept direct — serde_json::Value is used in FoldContext.extra,

--- a/crates/khive-fold/Cargo.toml
+++ b/crates/khive-fold/Cargo.toml
@@ -21,10 +21,10 @@ default = ["serde"]
 serde = ["dep:serde"]
 
 [dependencies]
-khive-score = { version = "0.3.0", path = "../khive-score" }
+khive-score = { version = "0.3.1", path = "../khive-score" }
 # ADR-024 boundary: khive-types + khive-score only.
 # blake3 feature enables Hash32::from_blake3 for checkpoint hashing.
-khive-types = { version = "0.3.0", path = "../khive-types", features = ["blake3", "serde"] }
+khive-types = { version = "0.3.1", path = "../khive-types", features = ["blake3", "serde"] }
 # serde: optional, gated by the `serde` feature above.
 serde = { workspace = true, optional = true }
 # serde_json: kept direct — serde_json::Value is used in FoldContext.extra,

--- a/crates/khive-fusion/Cargo.toml
+++ b/crates/khive-fusion/Cargo.toml
@@ -15,7 +15,7 @@ description = "Rank fusion strategies (RRF, Weighted, Union) with deterministic 
 bench = false
 
 [dependencies]
-khive-score = { version = "0.3.1", path = "../khive-score" }
+khive-score = { version = "0.4.0", path = "../khive-score" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 

--- a/crates/khive-fusion/Cargo.toml
+++ b/crates/khive-fusion/Cargo.toml
@@ -15,7 +15,7 @@ description = "Rank fusion strategies (RRF, Weighted, Union) with deterministic 
 bench = false
 
 [dependencies]
-khive-score = { version = "0.3.0", path = "../khive-score" }
+khive-score = { version = "0.3.1", path = "../khive-score" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 

--- a/crates/khive-gate-rego/Cargo.toml
+++ b/crates/khive-gate-rego/Cargo.toml
@@ -13,12 +13,12 @@ description = "Rego (Open Policy Agent) backend for khive-gate, powered by regor
 readme = "README.md"
 
 [dependencies]
-khive-gate = { version = "0.3.0", path = "../khive-gate" }
+khive-gate = { version = "0.3.1", path = "../khive-gate" }
 serde_json = { workspace = true }
 tracing = { workspace = true }
 
 regorus = { workspace = true }
 
 [dev-dependencies]
-khive-types = { version = "0.3.0", path = "../khive-types", features = ["serde"] }
+khive-types = { version = "0.3.1", path = "../khive-types", features = ["serde"] }
 tracing-subscriber = { workspace = true }

--- a/crates/khive-gate-rego/Cargo.toml
+++ b/crates/khive-gate-rego/Cargo.toml
@@ -13,12 +13,12 @@ description = "Rego (Open Policy Agent) backend for khive-gate, powered by regor
 readme = "README.md"
 
 [dependencies]
-khive-gate = { version = "0.3.1", path = "../khive-gate" }
+khive-gate = { version = "0.4.0", path = "../khive-gate" }
 serde_json = { workspace = true }
 tracing = { workspace = true }
 
 regorus = { workspace = true }
 
 [dev-dependencies]
-khive-types = { version = "0.3.1", path = "../khive-types", features = ["serde"] }
+khive-types = { version = "0.4.0", path = "../khive-types", features = ["serde"] }
 tracing-subscriber = { workspace = true }

--- a/crates/khive-gate/Cargo.toml
+++ b/crates/khive-gate/Cargo.toml
@@ -12,7 +12,7 @@ categories.workspace = true
 description = "Pluggable authorization gate trait + default AllowAllGate impl for khive verb dispatch."
 
 [dependencies]
-khive-types = { version = "0.3.1", path = "../khive-types", features = ["serde"] }
+khive-types = { version = "0.4.0", path = "../khive-types", features = ["serde"] }
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/khive-gate/Cargo.toml
+++ b/crates/khive-gate/Cargo.toml
@@ -12,7 +12,7 @@ categories.workspace = true
 description = "Pluggable authorization gate trait + default AllowAllGate impl for khive verb dispatch."
 
 [dependencies]
-khive-types = { version = "0.3.0", path = "../khive-types", features = ["serde"] }
+khive-types = { version = "0.3.1", path = "../khive-types", features = ["serde"] }
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/khive-hnsw/Cargo.toml
+++ b/crates/khive-hnsw/Cargo.toml
@@ -15,9 +15,9 @@ description = "HNSW (Hierarchical Navigable Small World) vector index with INT8 
 bench = false
 
 [dependencies]
-khive-score = { version = "0.3.0", path = "../khive-score" }
-khive-types = { version = "0.3.0", path = "../khive-types", features = ["serde"] }
-khive-fold = { version = "0.3.0", path = "../khive-fold", optional = true }
+khive-score = { version = "0.3.1", path = "../khive-score" }
+khive-types = { version = "0.3.1", path = "../khive-types", features = ["serde"] }
+khive-fold = { version = "0.3.1", path = "../khive-fold", optional = true }
 lattice-embed = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/khive-hnsw/Cargo.toml
+++ b/crates/khive-hnsw/Cargo.toml
@@ -15,9 +15,9 @@ description = "HNSW (Hierarchical Navigable Small World) vector index with INT8 
 bench = false
 
 [dependencies]
-khive-score = { version = "0.3.1", path = "../khive-score" }
-khive-types = { version = "0.3.1", path = "../khive-types", features = ["serde"] }
-khive-fold = { version = "0.3.1", path = "../khive-fold", optional = true }
+khive-score = { version = "0.4.0", path = "../khive-score" }
+khive-types = { version = "0.4.0", path = "../khive-types", features = ["serde"] }
+khive-fold = { version = "0.4.0", path = "../khive-fold", optional = true }
 lattice-embed = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/khive-mcp/Cargo.toml
+++ b/crates/khive-mcp/Cargo.toml
@@ -12,22 +12,22 @@ categories.workspace = true
 description = "khive MCP server library — served via the kkernel binary"
 
 [dependencies]
-khive-db = { version = "0.3.0", path = "../khive-db" }
-khive-runtime = { version = "0.3.0", path = "../khive-runtime" }
-khive-storage = { version = "0.3.0", path = "../khive-storage" }
-khive-types = { version = "0.3.0", path = "../khive-types", features = ["serde"] }
-khive-request = { version = "0.3.0", path = "../khive-request" }
-khive-pack-kg = { version = "0.3.0", path = "../khive-pack-kg" }
-khive-pack-gtd = { version = "0.3.0", path = "../khive-pack-gtd" }
-khive-pack-memory = { version = "0.3.0", path = "../khive-pack-memory" }
-khive-pack-brain = { version = "0.3.0", path = "../khive-pack-brain" }
-khive-pack-comm = { version = "0.3.0", path = "../khive-pack-comm" }
-khive-pack-schedule = { version = "0.3.0", path = "../khive-pack-schedule" }
-khive-pack-knowledge = { version = "0.3.0", path = "../khive-pack-knowledge" }
-khive-pack-session = { version = "0.3.0", path = "../khive-pack-session" }
-khive-pack-git = { version = "0.3.0", path = "../khive-pack-git" }
-khive-pack-code = { version = "0.3.0", path = "../khive-pack-code" }
-khive-pack-workspace = { version = "0.3.0", path = "../khive-pack-workspace" }
+khive-db = { version = "0.3.1", path = "../khive-db" }
+khive-runtime = { version = "0.3.1", path = "../khive-runtime" }
+khive-storage = { version = "0.3.1", path = "../khive-storage" }
+khive-types = { version = "0.3.1", path = "../khive-types", features = ["serde"] }
+khive-request = { version = "0.3.1", path = "../khive-request" }
+khive-pack-kg = { version = "0.3.1", path = "../khive-pack-kg" }
+khive-pack-gtd = { version = "0.3.1", path = "../khive-pack-gtd" }
+khive-pack-memory = { version = "0.3.1", path = "../khive-pack-memory" }
+khive-pack-brain = { version = "0.3.1", path = "../khive-pack-brain" }
+khive-pack-comm = { version = "0.3.1", path = "../khive-pack-comm" }
+khive-pack-schedule = { version = "0.3.1", path = "../khive-pack-schedule" }
+khive-pack-knowledge = { version = "0.3.1", path = "../khive-pack-knowledge" }
+khive-pack-session = { version = "0.3.1", path = "../khive-pack-session" }
+khive-pack-git = { version = "0.3.1", path = "../khive-pack-git" }
+khive-pack-code = { version = "0.3.1", path = "../khive-pack-code" }
+khive-pack-workspace = { version = "0.3.1", path = "../khive-pack-workspace" }
 uuid = { workspace = true }
 inventory = { workspace = true }
 rmcp = { workspace = true, features = ["server", "transport-io"] }
@@ -45,8 +45,8 @@ sha2 = { workspace = true }
 chrono = { workspace = true }
 tempfile = { workspace = true }
 lattice-embed = { workspace = true, optional = true }
-khive-channel = { version = "0.3.0", path = "../khive-channel", optional = true }
-khive-channel-email = { version = "0.3.0", path = "../khive-channel-email", optional = true }
+khive-channel = { version = "0.3.1", path = "../khive-channel", optional = true }
+khive-channel-email = { version = "0.3.1", path = "../khive-channel-email", optional = true }
 
 [features]
 # bench-embedder: inject deterministic FNV-1a hash embedder into the serve path.
@@ -61,5 +61,5 @@ tokio = { workspace = true, features = ["test-util"] }
 rmcp = { workspace = true, features = ["server", "transport-io", "client"] }
 async-trait = { workspace = true }
 serial_test = { workspace = true }
-khive-pack-knowledge = { version = "0.3.0", path = "../khive-pack-knowledge" }
+khive-pack-knowledge = { version = "0.3.1", path = "../khive-pack-knowledge" }
 rusqlite = { workspace = true, features = ["bundled"] }

--- a/crates/khive-mcp/Cargo.toml
+++ b/crates/khive-mcp/Cargo.toml
@@ -12,22 +12,22 @@ categories.workspace = true
 description = "khive MCP server library — served via the kkernel binary"
 
 [dependencies]
-khive-db = { version = "0.3.1", path = "../khive-db" }
-khive-runtime = { version = "0.3.1", path = "../khive-runtime" }
-khive-storage = { version = "0.3.1", path = "../khive-storage" }
-khive-types = { version = "0.3.1", path = "../khive-types", features = ["serde"] }
-khive-request = { version = "0.3.1", path = "../khive-request" }
-khive-pack-kg = { version = "0.3.1", path = "../khive-pack-kg" }
-khive-pack-gtd = { version = "0.3.1", path = "../khive-pack-gtd" }
-khive-pack-memory = { version = "0.3.1", path = "../khive-pack-memory" }
-khive-pack-brain = { version = "0.3.1", path = "../khive-pack-brain" }
-khive-pack-comm = { version = "0.3.1", path = "../khive-pack-comm" }
-khive-pack-schedule = { version = "0.3.1", path = "../khive-pack-schedule" }
-khive-pack-knowledge = { version = "0.3.1", path = "../khive-pack-knowledge" }
-khive-pack-session = { version = "0.3.1", path = "../khive-pack-session" }
-khive-pack-git = { version = "0.3.1", path = "../khive-pack-git" }
-khive-pack-code = { version = "0.3.1", path = "../khive-pack-code" }
-khive-pack-workspace = { version = "0.3.1", path = "../khive-pack-workspace" }
+khive-db = { version = "0.4.0", path = "../khive-db" }
+khive-runtime = { version = "0.4.0", path = "../khive-runtime" }
+khive-storage = { version = "0.4.0", path = "../khive-storage" }
+khive-types = { version = "0.4.0", path = "../khive-types", features = ["serde"] }
+khive-request = { version = "0.4.0", path = "../khive-request" }
+khive-pack-kg = { version = "0.4.0", path = "../khive-pack-kg" }
+khive-pack-gtd = { version = "0.4.0", path = "../khive-pack-gtd" }
+khive-pack-memory = { version = "0.4.0", path = "../khive-pack-memory" }
+khive-pack-brain = { version = "0.4.0", path = "../khive-pack-brain" }
+khive-pack-comm = { version = "0.4.0", path = "../khive-pack-comm" }
+khive-pack-schedule = { version = "0.4.0", path = "../khive-pack-schedule" }
+khive-pack-knowledge = { version = "0.4.0", path = "../khive-pack-knowledge" }
+khive-pack-session = { version = "0.4.0", path = "../khive-pack-session" }
+khive-pack-git = { version = "0.4.0", path = "../khive-pack-git" }
+khive-pack-code = { version = "0.4.0", path = "../khive-pack-code" }
+khive-pack-workspace = { version = "0.4.0", path = "../khive-pack-workspace" }
 uuid = { workspace = true }
 inventory = { workspace = true }
 rmcp = { workspace = true, features = ["server", "transport-io"] }
@@ -45,8 +45,8 @@ sha2 = { workspace = true }
 chrono = { workspace = true }
 tempfile = { workspace = true }
 lattice-embed = { workspace = true, optional = true }
-khive-channel = { version = "0.3.1", path = "../khive-channel", optional = true }
-khive-channel-email = { version = "0.3.1", path = "../khive-channel-email", optional = true }
+khive-channel = { version = "0.4.0", path = "../khive-channel", optional = true }
+khive-channel-email = { version = "0.4.0", path = "../khive-channel-email", optional = true }
 
 [features]
 # bench-embedder: inject deterministic FNV-1a hash embedder into the serve path.
@@ -61,5 +61,5 @@ tokio = { workspace = true, features = ["test-util"] }
 rmcp = { workspace = true, features = ["server", "transport-io", "client"] }
 async-trait = { workspace = true }
 serial_test = { workspace = true }
-khive-pack-knowledge = { version = "0.3.1", path = "../khive-pack-knowledge" }
+khive-pack-knowledge = { version = "0.4.0", path = "../khive-pack-knowledge" }
 rusqlite = { workspace = true, features = ["bundled"] }

--- a/crates/khive-merge/Cargo.toml
+++ b/crates/khive-merge/Cargo.toml
@@ -5,7 +5,7 @@
 # [workspace.package] below declares the shared version for this standalone workspace.
 
 [workspace.package]
-version = "0.3.1"
+version = "0.4.0"
 
 [package]
 name = "khive-merge"
@@ -18,8 +18,8 @@ homepage = "https://github.com/ohdearquant"
 description = "KG three-way merge with conflict detection (ADR-039)"
 
 [dependencies]
-khive-runtime = { version = "0.3.1", path = "../khive-runtime" }
-khive-storage = { version = "0.3.1", path = "../khive-storage" }
+khive-runtime = { version = "0.4.0", path = "../khive-runtime" }
+khive-storage = { version = "0.4.0", path = "../khive-storage" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 thiserror = "2.0"

--- a/crates/khive-merge/Cargo.toml
+++ b/crates/khive-merge/Cargo.toml
@@ -5,7 +5,7 @@
 # [workspace.package] below declares the shared version for this standalone workspace.
 
 [workspace.package]
-version = "0.3.0"
+version = "0.3.1"
 
 [package]
 name = "khive-merge"
@@ -18,8 +18,8 @@ homepage = "https://github.com/ohdearquant"
 description = "KG three-way merge with conflict detection (ADR-039)"
 
 [dependencies]
-khive-runtime = { version = "0.3.0", path = "../khive-runtime" }
-khive-storage = { version = "0.3.0", path = "../khive-storage" }
+khive-runtime = { version = "0.3.1", path = "../khive-runtime" }
+khive-storage = { version = "0.3.1", path = "../khive-storage" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 thiserror = "2.0"

--- a/crates/khive-pack-brain/Cargo.toml
+++ b/crates/khive-pack-brain/Cargo.toml
@@ -15,18 +15,18 @@ description = "Brain pack — profile-oriented orchestration via Fold + Objectiv
 bench = false
 
 [dependencies]
-khive-brain-core = { version = "0.3.0", path = "../khive-brain-core" }
-khive-types = { version = "0.3.0", path = "../khive-types", features = ["serde"] }
-khive-runtime = { version = "0.3.0", path = "../khive-runtime" }
-khive-fold = { version = "0.3.0", path = "../khive-fold" }
-khive-storage = { version = "0.3.0", path = "../khive-storage" }
+khive-brain-core = { version = "0.3.1", path = "../khive-brain-core" }
+khive-types = { version = "0.3.1", path = "../khive-types", features = ["serde"] }
+khive-runtime = { version = "0.3.1", path = "../khive-runtime" }
+khive-fold = { version = "0.3.1", path = "../khive-fold" }
+khive-storage = { version = "0.3.1", path = "../khive-storage" }
 # ADR-081 §2/§6 (codex round 2, findings 1+2): the fold gate needs the event
 # append on the SAME held `SqlWriter` transaction as the dedup claim + mass
 # fold, so it calls khive-db's transaction-enlisted `append_event_on_writer`
 # seam directly rather than going through the higher-level `EventStore`
 # trait (which always opens its own transaction). No cycle: khive-db does not
 # depend on this crate.
-khive-db = { version = "0.3.0", path = "../khive-db" }
+khive-db = { version = "0.3.1", path = "../khive-db" }
 inventory = { workspace = true }
 async-trait = { workspace = true }
 lattice-fann = { workspace = true, optional = true }
@@ -46,12 +46,12 @@ lattice-router = ["dep:lattice-fann"]
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["test-util"] }
-khive-pack-kg = { version = "0.3.0", path = "../khive-pack-kg" }
+khive-pack-kg = { version = "0.3.1", path = "../khive-pack-kg" }
 # Dev-only: exercises the real memory.recall -> BrainPack dispatch-hook path
 # (issue #459 regression). khive-pack-memory already carries khive-pack-brain
 # as a dev-dependency for its own tests; Cargo permits cyclic dev-dependencies
 # since neither crate's normal (non-dev) dependency graph is affected.
-khive-pack-memory = { version = "0.3.0", path = "../khive-pack-memory" }
+khive-pack-memory = { version = "0.3.1", path = "../khive-pack-memory" }
 criterion = { workspace = true }
 tempfile = { workspace = true }
 serial_test = { workspace = true }

--- a/crates/khive-pack-brain/Cargo.toml
+++ b/crates/khive-pack-brain/Cargo.toml
@@ -15,18 +15,18 @@ description = "Brain pack — profile-oriented orchestration via Fold + Objectiv
 bench = false
 
 [dependencies]
-khive-brain-core = { version = "0.3.1", path = "../khive-brain-core" }
-khive-types = { version = "0.3.1", path = "../khive-types", features = ["serde"] }
-khive-runtime = { version = "0.3.1", path = "../khive-runtime" }
-khive-fold = { version = "0.3.1", path = "../khive-fold" }
-khive-storage = { version = "0.3.1", path = "../khive-storage" }
+khive-brain-core = { version = "0.4.0", path = "../khive-brain-core" }
+khive-types = { version = "0.4.0", path = "../khive-types", features = ["serde"] }
+khive-runtime = { version = "0.4.0", path = "../khive-runtime" }
+khive-fold = { version = "0.4.0", path = "../khive-fold" }
+khive-storage = { version = "0.4.0", path = "../khive-storage" }
 # ADR-081 §2/§6 (codex round 2, findings 1+2): the fold gate needs the event
 # append on the SAME held `SqlWriter` transaction as the dedup claim + mass
 # fold, so it calls khive-db's transaction-enlisted `append_event_on_writer`
 # seam directly rather than going through the higher-level `EventStore`
 # trait (which always opens its own transaction). No cycle: khive-db does not
 # depend on this crate.
-khive-db = { version = "0.3.1", path = "../khive-db" }
+khive-db = { version = "0.4.0", path = "../khive-db" }
 inventory = { workspace = true }
 async-trait = { workspace = true }
 lattice-fann = { workspace = true, optional = true }
@@ -46,12 +46,12 @@ lattice-router = ["dep:lattice-fann"]
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["test-util"] }
-khive-pack-kg = { version = "0.3.1", path = "../khive-pack-kg" }
+khive-pack-kg = { version = "0.4.0", path = "../khive-pack-kg" }
 # Dev-only: exercises the real memory.recall -> BrainPack dispatch-hook path
 # (issue #459 regression). khive-pack-memory already carries khive-pack-brain
 # as a dev-dependency for its own tests; Cargo permits cyclic dev-dependencies
 # since neither crate's normal (non-dev) dependency graph is affected.
-khive-pack-memory = { version = "0.3.1", path = "../khive-pack-memory" }
+khive-pack-memory = { version = "0.4.0", path = "../khive-pack-memory" }
 criterion = { workspace = true }
 tempfile = { workspace = true }
 serial_test = { workspace = true }

--- a/crates/khive-pack-code/Cargo.toml
+++ b/crates/khive-pack-code/Cargo.toml
@@ -12,9 +12,9 @@ categories.workspace = true
 description = "Code ontology pack - typed edge rules and audit findings vocabulary"
 
 [dependencies]
-khive-types = { version = "0.3.0", path = "../khive-types", features = ["serde"] }
-khive-runtime = { version = "0.3.0", path = "../khive-runtime" }
-khive-storage = { version = "0.3.0", path = "../khive-storage" }
+khive-types = { version = "0.3.1", path = "../khive-types", features = ["serde"] }
+khive-runtime = { version = "0.3.1", path = "../khive-runtime" }
+khive-storage = { version = "0.3.1", path = "../khive-storage" }
 inventory = { workspace = true }
 async-trait = { workspace = true }
 chrono = { workspace = true }
@@ -24,5 +24,5 @@ thiserror = { workspace = true }
 uuid = { workspace = true }
 
 [dev-dependencies]
-khive-pack-kg = { version = "0.3.0", path = "../khive-pack-kg" }
+khive-pack-kg = { version = "0.3.1", path = "../khive-pack-kg" }
 tokio = { workspace = true, features = ["full"] }

--- a/crates/khive-pack-code/Cargo.toml
+++ b/crates/khive-pack-code/Cargo.toml
@@ -12,9 +12,9 @@ categories.workspace = true
 description = "Code ontology pack - typed edge rules and audit findings vocabulary"
 
 [dependencies]
-khive-types = { version = "0.3.1", path = "../khive-types", features = ["serde"] }
-khive-runtime = { version = "0.3.1", path = "../khive-runtime" }
-khive-storage = { version = "0.3.1", path = "../khive-storage" }
+khive-types = { version = "0.4.0", path = "../khive-types", features = ["serde"] }
+khive-runtime = { version = "0.4.0", path = "../khive-runtime" }
+khive-storage = { version = "0.4.0", path = "../khive-storage" }
 inventory = { workspace = true }
 async-trait = { workspace = true }
 chrono = { workspace = true }
@@ -24,5 +24,5 @@ thiserror = { workspace = true }
 uuid = { workspace = true }
 
 [dev-dependencies]
-khive-pack-kg = { version = "0.3.1", path = "../khive-pack-kg" }
+khive-pack-kg = { version = "0.4.0", path = "../khive-pack-kg" }
 tokio = { workspace = true, features = ["full"] }

--- a/crates/khive-pack-comm/Cargo.toml
+++ b/crates/khive-pack-comm/Cargo.toml
@@ -15,9 +15,9 @@ description = "Communication pack — inter-agent messaging (send, inbox, read, 
 bench = false
 
 [dependencies]
-khive-types = { version = "0.3.0", path = "../khive-types", features = ["serde"] }
-khive-runtime = { version = "0.3.0", path = "../khive-runtime" }
-khive-storage = { version = "0.3.0", path = "../khive-storage" }
+khive-types = { version = "0.3.1", path = "../khive-types", features = ["serde"] }
+khive-runtime = { version = "0.3.1", path = "../khive-runtime" }
+khive-storage = { version = "0.3.1", path = "../khive-storage" }
 inventory = { workspace = true }
 async-trait = { workspace = true }
 serde = { workspace = true }
@@ -28,11 +28,11 @@ tracing = { workspace = true }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["full"] }
-khive-pack-kg = { version = "0.3.0", path = "../khive-pack-kg" }
-khive-db = { version = "0.3.0", path = "../khive-db" }
+khive-pack-kg = { version = "0.3.1", path = "../khive-pack-kg" }
+khive-db = { version = "0.3.1", path = "../khive-db" }
 criterion = { workspace = true }
 toml = { workspace = true }
-khive-runtime = { version = "0.3.0", path = "../khive-runtime", features = ["fault-injection"] }
+khive-runtime = { version = "0.3.1", path = "../khive-runtime", features = ["fault-injection"] }
 lattice-embed = { workspace = true }
 rusqlite = { workspace = true, features = ["bundled", "column_decltype"] }
 tempfile = { workspace = true }

--- a/crates/khive-pack-comm/Cargo.toml
+++ b/crates/khive-pack-comm/Cargo.toml
@@ -15,9 +15,9 @@ description = "Communication pack — inter-agent messaging (send, inbox, read, 
 bench = false
 
 [dependencies]
-khive-types = { version = "0.3.1", path = "../khive-types", features = ["serde"] }
-khive-runtime = { version = "0.3.1", path = "../khive-runtime" }
-khive-storage = { version = "0.3.1", path = "../khive-storage" }
+khive-types = { version = "0.4.0", path = "../khive-types", features = ["serde"] }
+khive-runtime = { version = "0.4.0", path = "../khive-runtime" }
+khive-storage = { version = "0.4.0", path = "../khive-storage" }
 inventory = { workspace = true }
 async-trait = { workspace = true }
 serde = { workspace = true }
@@ -28,11 +28,11 @@ tracing = { workspace = true }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["full"] }
-khive-pack-kg = { version = "0.3.1", path = "../khive-pack-kg" }
-khive-db = { version = "0.3.1", path = "../khive-db" }
+khive-pack-kg = { version = "0.4.0", path = "../khive-pack-kg" }
+khive-db = { version = "0.4.0", path = "../khive-db" }
 criterion = { workspace = true }
 toml = { workspace = true }
-khive-runtime = { version = "0.3.1", path = "../khive-runtime", features = ["fault-injection"] }
+khive-runtime = { version = "0.4.0", path = "../khive-runtime", features = ["fault-injection"] }
 lattice-embed = { workspace = true }
 rusqlite = { workspace = true, features = ["bundled", "column_decltype"] }
 tempfile = { workspace = true }

--- a/crates/khive-pack-formal/Cargo.toml
+++ b/crates/khive-pack-formal/Cargo.toml
@@ -12,8 +12,8 @@ categories.workspace = true
 description = "Formal-math ontology pack — typed edge rules for theorem/definition/structure/instance/axiom/goal subtypes"
 
 [dependencies]
-khive-types = { version = "0.3.0", path = "../khive-types", features = ["serde"] }
-khive-runtime = { version = "0.3.0", path = "../khive-runtime" }
+khive-types = { version = "0.3.1", path = "../khive-types", features = ["serde"] }
+khive-runtime = { version = "0.3.1", path = "../khive-runtime" }
 inventory = { workspace = true }
 async-trait = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/khive-pack-formal/Cargo.toml
+++ b/crates/khive-pack-formal/Cargo.toml
@@ -12,8 +12,8 @@ categories.workspace = true
 description = "Formal-math ontology pack — typed edge rules for theorem/definition/structure/instance/axiom/goal subtypes"
 
 [dependencies]
-khive-types = { version = "0.3.1", path = "../khive-types", features = ["serde"] }
-khive-runtime = { version = "0.3.1", path = "../khive-runtime" }
+khive-types = { version = "0.4.0", path = "../khive-types", features = ["serde"] }
+khive-runtime = { version = "0.4.0", path = "../khive-runtime" }
 inventory = { workspace = true }
 async-trait = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/khive-pack-git/Cargo.toml
+++ b/crates/khive-pack-git/Cargo.toml
@@ -12,10 +12,10 @@ categories.workspace = true
 description = "Git-lifecycle pack — commit/issue/pull_request provenance notes over the notes substrate (ADR-088)"
 
 [dependencies]
-khive-types = { version = "0.3.0", path = "../khive-types", features = ["serde"] }
-khive-runtime = { version = "0.3.0", path = "../khive-runtime" }
+khive-types = { version = "0.3.1", path = "../khive-types", features = ["serde"] }
+khive-runtime = { version = "0.3.1", path = "../khive-runtime" }
 inventory = { workspace = true }
-khive-storage = { version = "0.3.0", path = "../khive-storage" }
+khive-storage = { version = "0.3.1", path = "../khive-storage" }
 async-trait = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
@@ -29,7 +29,7 @@ blake3 = { workspace = true }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["full"] }
-khive-pack-kg = { version = "0.3.0", path = "../khive-pack-kg" }
+khive-pack-kg = { version = "0.3.1", path = "../khive-pack-kg" }
 tempfile = { workspace = true }
-khive-runtime = { version = "0.3.0", path = "../khive-runtime", features = ["fault-injection"] }
+khive-runtime = { version = "0.3.1", path = "../khive-runtime", features = ["fault-injection"] }
 lattice-embed = { workspace = true }

--- a/crates/khive-pack-git/Cargo.toml
+++ b/crates/khive-pack-git/Cargo.toml
@@ -12,10 +12,10 @@ categories.workspace = true
 description = "Git-lifecycle pack — commit/issue/pull_request provenance notes over the notes substrate (ADR-088)"
 
 [dependencies]
-khive-types = { version = "0.3.1", path = "../khive-types", features = ["serde"] }
-khive-runtime = { version = "0.3.1", path = "../khive-runtime" }
+khive-types = { version = "0.4.0", path = "../khive-types", features = ["serde"] }
+khive-runtime = { version = "0.4.0", path = "../khive-runtime" }
 inventory = { workspace = true }
-khive-storage = { version = "0.3.1", path = "../khive-storage" }
+khive-storage = { version = "0.4.0", path = "../khive-storage" }
 async-trait = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
@@ -29,7 +29,7 @@ blake3 = { workspace = true }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["full"] }
-khive-pack-kg = { version = "0.3.1", path = "../khive-pack-kg" }
+khive-pack-kg = { version = "0.4.0", path = "../khive-pack-kg" }
 tempfile = { workspace = true }
-khive-runtime = { version = "0.3.1", path = "../khive-runtime", features = ["fault-injection"] }
+khive-runtime = { version = "0.4.0", path = "../khive-runtime", features = ["fault-injection"] }
 lattice-embed = { workspace = true }

--- a/crates/khive-pack-gtd/Cargo.toml
+++ b/crates/khive-pack-gtd/Cargo.toml
@@ -15,10 +15,10 @@ description = "GTD verb pack — task lifecycle (assign/next/complete/transition
 bench = false
 
 [dependencies]
-khive-types = { version = "0.3.1", path = "../khive-types", features = ["serde"] }
-khive-runtime = { version = "0.3.1", path = "../khive-runtime" }
+khive-types = { version = "0.4.0", path = "../khive-types", features = ["serde"] }
+khive-runtime = { version = "0.4.0", path = "../khive-runtime" }
 inventory = { workspace = true }
-khive-storage = { version = "0.3.1", path = "../khive-storage" }
+khive-storage = { version = "0.4.0", path = "../khive-storage" }
 async-trait = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
@@ -28,7 +28,7 @@ tracing = { workspace = true }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["full"] }
-khive-pack-kg = { version = "0.3.1", path = "../khive-pack-kg" }
+khive-pack-kg = { version = "0.4.0", path = "../khive-pack-kg" }
 criterion = { workspace = true }
 
 [[bench]]

--- a/crates/khive-pack-gtd/Cargo.toml
+++ b/crates/khive-pack-gtd/Cargo.toml
@@ -15,10 +15,10 @@ description = "GTD verb pack — task lifecycle (assign/next/complete/transition
 bench = false
 
 [dependencies]
-khive-types = { version = "0.3.0", path = "../khive-types", features = ["serde"] }
-khive-runtime = { version = "0.3.0", path = "../khive-runtime" }
+khive-types = { version = "0.3.1", path = "../khive-types", features = ["serde"] }
+khive-runtime = { version = "0.3.1", path = "../khive-runtime" }
 inventory = { workspace = true }
-khive-storage = { version = "0.3.0", path = "../khive-storage" }
+khive-storage = { version = "0.3.1", path = "../khive-storage" }
 async-trait = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
@@ -28,7 +28,7 @@ tracing = { workspace = true }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["full"] }
-khive-pack-kg = { version = "0.3.0", path = "../khive-pack-kg" }
+khive-pack-kg = { version = "0.3.1", path = "../khive-pack-kg" }
 criterion = { workspace = true }
 
 [[bench]]

--- a/crates/khive-pack-kg/Cargo.toml
+++ b/crates/khive-pack-kg/Cargo.toml
@@ -15,11 +15,11 @@ description = "KG verb pack — entity/note CRUD, graph traversal, hybrid search
 bench = false
 
 [dependencies]
-khive-types = { version = "0.3.1", path = "../khive-types", features = ["serde"] }
-khive-runtime = { version = "0.3.1", path = "../khive-runtime" }
-khive-query = { version = "0.3.1", path = "../khive-query" }
+khive-types = { version = "0.4.0", path = "../khive-types", features = ["serde"] }
+khive-runtime = { version = "0.4.0", path = "../khive-runtime" }
+khive-query = { version = "0.4.0", path = "../khive-query" }
 inventory = { workspace = true }
-khive-storage = { version = "0.3.1", path = "../khive-storage" }
+khive-storage = { version = "0.4.0", path = "../khive-storage" }
 async-trait = { workspace = true }
 chrono = { workspace = true }
 serde = { workspace = true }
@@ -31,8 +31,8 @@ tracing = { workspace = true }
 tokio = { workspace = true, features = ["test-util"] }
 criterion = { workspace = true }
 serde_json = { workspace = true }
-khive-pack-formal = { version = "0.3.1", path = "../khive-pack-formal" }
-khive-pack-gtd = { version = "0.3.1", path = "../khive-pack-gtd" }
+khive-pack-formal = { version = "0.4.0", path = "../khive-pack-formal" }
+khive-pack-gtd = { version = "0.4.0", path = "../khive-pack-gtd" }
 
 [[test]]
 name = "integration"

--- a/crates/khive-pack-kg/Cargo.toml
+++ b/crates/khive-pack-kg/Cargo.toml
@@ -15,11 +15,11 @@ description = "KG verb pack — entity/note CRUD, graph traversal, hybrid search
 bench = false
 
 [dependencies]
-khive-types = { version = "0.3.0", path = "../khive-types", features = ["serde"] }
-khive-runtime = { version = "0.3.0", path = "../khive-runtime" }
-khive-query = { version = "0.3.0", path = "../khive-query" }
+khive-types = { version = "0.3.1", path = "../khive-types", features = ["serde"] }
+khive-runtime = { version = "0.3.1", path = "../khive-runtime" }
+khive-query = { version = "0.3.1", path = "../khive-query" }
 inventory = { workspace = true }
-khive-storage = { version = "0.3.0", path = "../khive-storage" }
+khive-storage = { version = "0.3.1", path = "../khive-storage" }
 async-trait = { workspace = true }
 chrono = { workspace = true }
 serde = { workspace = true }
@@ -31,8 +31,8 @@ tracing = { workspace = true }
 tokio = { workspace = true, features = ["test-util"] }
 criterion = { workspace = true }
 serde_json = { workspace = true }
-khive-pack-formal = { version = "0.3.0", path = "../khive-pack-formal" }
-khive-pack-gtd = { version = "0.3.0", path = "../khive-pack-gtd" }
+khive-pack-formal = { version = "0.3.1", path = "../khive-pack-formal" }
+khive-pack-gtd = { version = "0.3.1", path = "../khive-pack-gtd" }
 
 [[test]]
 name = "integration"

--- a/crates/khive-pack-knowledge/Cargo.toml
+++ b/crates/khive-pack-knowledge/Cargo.toml
@@ -15,14 +15,14 @@ description = "Knowledge verb pack — lore corpus (atoms/domains), TF-IDF retri
 bench = false
 
 [dependencies]
-khive-types = { version = "0.3.0", path = "../khive-types", features = ["serde"] }
-khive-brain-core = { version = "0.3.0", path = "../khive-brain-core" }
-khive-runtime = { version = "0.3.0", path = "../khive-runtime" }
-khive-storage = { version = "0.3.0", path = "../khive-storage" }
-khive-fold = { version = "0.3.0", path = "../khive-fold" }
-khive-fusion = { version = "0.3.0", path = "../khive-fusion" }
-khive-score = { version = "0.3.0", path = "../khive-score" }
-khive-vamana = { version = "0.3.0", path = "../khive-vamana" }
+khive-types = { version = "0.3.1", path = "../khive-types", features = ["serde"] }
+khive-brain-core = { version = "0.3.1", path = "../khive-brain-core" }
+khive-runtime = { version = "0.3.1", path = "../khive-runtime" }
+khive-storage = { version = "0.3.1", path = "../khive-storage" }
+khive-fold = { version = "0.3.1", path = "../khive-fold" }
+khive-fusion = { version = "0.3.1", path = "../khive-fusion" }
+khive-score = { version = "0.3.1", path = "../khive-score" }
+khive-vamana = { version = "0.3.1", path = "../khive-vamana" }
 inventory = { workspace = true }
 tokio = { workspace = true }
 async-trait = { workspace = true }
@@ -34,9 +34,9 @@ chrono = { workspace = true }
 sha2 = { workspace = true }
 
 [dev-dependencies]
-khive-pack-kg = { version = "0.3.0", path = "../khive-pack-kg" }
-khive-pack-brain = { version = "0.3.0", path = "../khive-pack-brain" }
-khive-storage = { version = "0.3.0", path = "../khive-storage" }
+khive-pack-kg = { version = "0.3.1", path = "../khive-pack-kg" }
+khive-pack-brain = { version = "0.3.1", path = "../khive-pack-brain" }
+khive-storage = { version = "0.3.1", path = "../khive-storage" }
 tokio = { workspace = true, features = ["test-util"] }
 lattice-embed = { workspace = true }
 criterion = { workspace = true }

--- a/crates/khive-pack-knowledge/Cargo.toml
+++ b/crates/khive-pack-knowledge/Cargo.toml
@@ -15,14 +15,14 @@ description = "Knowledge verb pack — lore corpus (atoms/domains), TF-IDF retri
 bench = false
 
 [dependencies]
-khive-types = { version = "0.3.1", path = "../khive-types", features = ["serde"] }
-khive-brain-core = { version = "0.3.1", path = "../khive-brain-core" }
-khive-runtime = { version = "0.3.1", path = "../khive-runtime" }
-khive-storage = { version = "0.3.1", path = "../khive-storage" }
-khive-fold = { version = "0.3.1", path = "../khive-fold" }
-khive-fusion = { version = "0.3.1", path = "../khive-fusion" }
-khive-score = { version = "0.3.1", path = "../khive-score" }
-khive-vamana = { version = "0.3.1", path = "../khive-vamana" }
+khive-types = { version = "0.4.0", path = "../khive-types", features = ["serde"] }
+khive-brain-core = { version = "0.4.0", path = "../khive-brain-core" }
+khive-runtime = { version = "0.4.0", path = "../khive-runtime" }
+khive-storage = { version = "0.4.0", path = "../khive-storage" }
+khive-fold = { version = "0.4.0", path = "../khive-fold" }
+khive-fusion = { version = "0.4.0", path = "../khive-fusion" }
+khive-score = { version = "0.4.0", path = "../khive-score" }
+khive-vamana = { version = "0.4.0", path = "../khive-vamana" }
 inventory = { workspace = true }
 tokio = { workspace = true }
 async-trait = { workspace = true }
@@ -34,9 +34,9 @@ chrono = { workspace = true }
 sha2 = { workspace = true }
 
 [dev-dependencies]
-khive-pack-kg = { version = "0.3.1", path = "../khive-pack-kg" }
-khive-pack-brain = { version = "0.3.1", path = "../khive-pack-brain" }
-khive-storage = { version = "0.3.1", path = "../khive-storage" }
+khive-pack-kg = { version = "0.4.0", path = "../khive-pack-kg" }
+khive-pack-brain = { version = "0.4.0", path = "../khive-pack-brain" }
+khive-storage = { version = "0.4.0", path = "../khive-storage" }
 tokio = { workspace = true, features = ["test-util"] }
 lattice-embed = { workspace = true }
 criterion = { workspace = true }

--- a/crates/khive-pack-memory/Cargo.toml
+++ b/crates/khive-pack-memory/Cargo.toml
@@ -15,16 +15,16 @@ description = "Memory verb pack — remember/recall semantics with decay-aware r
 bench = false
 
 [dependencies]
-khive-types = { version = "0.3.0", path = "../khive-types", features = ["serde"] }
-khive-runtime = { version = "0.3.0", path = "../khive-runtime" }
-khive-fusion = { version = "0.3.0", path = "../khive-fusion" }
-khive-retrieval = { version = "0.3.0", path = "../khive-retrieval" }
-khive-score = { version = "0.3.0", path = "../khive-score" }
-khive-brain-core = { version = "0.3.0", path = "../khive-brain-core" }
-khive-vamana = { version = "0.3.0", path = "../khive-vamana" }
+khive-types = { version = "0.3.1", path = "../khive-types", features = ["serde"] }
+khive-runtime = { version = "0.3.1", path = "../khive-runtime" }
+khive-fusion = { version = "0.3.1", path = "../khive-fusion" }
+khive-retrieval = { version = "0.3.1", path = "../khive-retrieval" }
+khive-score = { version = "0.3.1", path = "../khive-score" }
+khive-brain-core = { version = "0.3.1", path = "../khive-brain-core" }
+khive-vamana = { version = "0.3.1", path = "../khive-vamana" }
 blake3 = { workspace = true }
 inventory = { workspace = true }
-khive-storage = { version = "0.3.0", path = "../khive-storage" }
+khive-storage = { version = "0.3.1", path = "../khive-storage" }
 async-trait = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
@@ -36,9 +36,9 @@ lru = { workspace = true }
 parking_lot = { workspace = true }
 
 [dev-dependencies]
-khive-db = { version = "0.3.0", path = "../khive-db" }
-khive-pack-kg = { version = "0.3.0", path = "../khive-pack-kg" }
-khive-pack-brain = { version = "0.3.0", path = "../khive-pack-brain" }
+khive-db = { version = "0.3.1", path = "../khive-db" }
+khive-pack-kg = { version = "0.3.1", path = "../khive-pack-kg" }
+khive-pack-brain = { version = "0.3.1", path = "../khive-pack-brain" }
 tokio = { workspace = true, features = ["test-util"] }
 lattice-embed = { workspace = true }
 async-trait = { workspace = true }

--- a/crates/khive-pack-memory/Cargo.toml
+++ b/crates/khive-pack-memory/Cargo.toml
@@ -15,16 +15,16 @@ description = "Memory verb pack — remember/recall semantics with decay-aware r
 bench = false
 
 [dependencies]
-khive-types = { version = "0.3.1", path = "../khive-types", features = ["serde"] }
-khive-runtime = { version = "0.3.1", path = "../khive-runtime" }
-khive-fusion = { version = "0.3.1", path = "../khive-fusion" }
-khive-retrieval = { version = "0.3.1", path = "../khive-retrieval" }
-khive-score = { version = "0.3.1", path = "../khive-score" }
-khive-brain-core = { version = "0.3.1", path = "../khive-brain-core" }
-khive-vamana = { version = "0.3.1", path = "../khive-vamana" }
+khive-types = { version = "0.4.0", path = "../khive-types", features = ["serde"] }
+khive-runtime = { version = "0.4.0", path = "../khive-runtime" }
+khive-fusion = { version = "0.4.0", path = "../khive-fusion" }
+khive-retrieval = { version = "0.4.0", path = "../khive-retrieval" }
+khive-score = { version = "0.4.0", path = "../khive-score" }
+khive-brain-core = { version = "0.4.0", path = "../khive-brain-core" }
+khive-vamana = { version = "0.4.0", path = "../khive-vamana" }
 blake3 = { workspace = true }
 inventory = { workspace = true }
-khive-storage = { version = "0.3.1", path = "../khive-storage" }
+khive-storage = { version = "0.4.0", path = "../khive-storage" }
 async-trait = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
@@ -36,9 +36,9 @@ lru = { workspace = true }
 parking_lot = { workspace = true }
 
 [dev-dependencies]
-khive-db = { version = "0.3.1", path = "../khive-db" }
-khive-pack-kg = { version = "0.3.1", path = "../khive-pack-kg" }
-khive-pack-brain = { version = "0.3.1", path = "../khive-pack-brain" }
+khive-db = { version = "0.4.0", path = "../khive-db" }
+khive-pack-kg = { version = "0.4.0", path = "../khive-pack-kg" }
+khive-pack-brain = { version = "0.4.0", path = "../khive-pack-brain" }
 tokio = { workspace = true, features = ["test-util"] }
 lattice-embed = { workspace = true }
 async-trait = { workspace = true }

--- a/crates/khive-pack-schedule/Cargo.toml
+++ b/crates/khive-pack-schedule/Cargo.toml
@@ -15,10 +15,10 @@ description = "Schedule pack — time-triggered intent storage (remind, schedule
 bench = false
 
 [dependencies]
-khive-types = { version = "0.3.0", path = "../khive-types", features = ["serde"] }
-khive-runtime = { version = "0.3.0", path = "../khive-runtime" }
-khive-storage = { version = "0.3.0", path = "../khive-storage" }
-khive-request = { version = "0.3.0", path = "../khive-request" }
+khive-types = { version = "0.3.1", path = "../khive-types", features = ["serde"] }
+khive-runtime = { version = "0.3.1", path = "../khive-runtime" }
+khive-storage = { version = "0.3.1", path = "../khive-storage" }
+khive-request = { version = "0.3.1", path = "../khive-request" }
 inventory = { workspace = true }
 async-trait = { workspace = true }
 serde = { workspace = true }
@@ -29,8 +29,8 @@ tracing = { workspace = true }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["full"] }
-khive-pack-kg = { version = "0.3.0", path = "../khive-pack-kg" }
-khive-pack-brain = { version = "0.3.0", path = "../khive-pack-brain" }
+khive-pack-kg = { version = "0.3.1", path = "../khive-pack-kg" }
+khive-pack-brain = { version = "0.3.1", path = "../khive-pack-brain" }
 criterion = { workspace = true }
 
 [[bench]]

--- a/crates/khive-pack-schedule/Cargo.toml
+++ b/crates/khive-pack-schedule/Cargo.toml
@@ -15,10 +15,10 @@ description = "Schedule pack — time-triggered intent storage (remind, schedule
 bench = false
 
 [dependencies]
-khive-types = { version = "0.3.1", path = "../khive-types", features = ["serde"] }
-khive-runtime = { version = "0.3.1", path = "../khive-runtime" }
-khive-storage = { version = "0.3.1", path = "../khive-storage" }
-khive-request = { version = "0.3.1", path = "../khive-request" }
+khive-types = { version = "0.4.0", path = "../khive-types", features = ["serde"] }
+khive-runtime = { version = "0.4.0", path = "../khive-runtime" }
+khive-storage = { version = "0.4.0", path = "../khive-storage" }
+khive-request = { version = "0.4.0", path = "../khive-request" }
 inventory = { workspace = true }
 async-trait = { workspace = true }
 serde = { workspace = true }
@@ -29,8 +29,8 @@ tracing = { workspace = true }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["full"] }
-khive-pack-kg = { version = "0.3.1", path = "../khive-pack-kg" }
-khive-pack-brain = { version = "0.3.1", path = "../khive-pack-brain" }
+khive-pack-kg = { version = "0.4.0", path = "../khive-pack-kg" }
+khive-pack-brain = { version = "0.4.0", path = "../khive-pack-brain" }
 criterion = { workspace = true }
 
 [[bench]]

--- a/crates/khive-pack-schedule/README.md
+++ b/crates/khive-pack-schedule/README.md
@@ -60,12 +60,12 @@ let registry = builder.build()?;
 registry
     .dispatch(
         "schedule.remind",
-        json!({"content": "Ship the 0.3.0 release", "at": "2026-07-05T09:00:00Z"}),
+        json!({"content": "Ship the 0.3.1 release", "at": "2026-07-05T09:00:00Z"}),
     )
     .await?;
 ```
 
-Over MCP: `request(ops="schedule.remind(content=\"Ship the 0.3.0 release\", at=\"2026-07-05T09:00:00Z\")")`.
+Over MCP: `request(ops="schedule.remind(content=\"Ship the 0.3.1 release\", at=\"2026-07-05T09:00:00Z\")")`.
 
 ## Where this sits
 

--- a/crates/khive-pack-schedule/README.md
+++ b/crates/khive-pack-schedule/README.md
@@ -60,12 +60,12 @@ let registry = builder.build()?;
 registry
     .dispatch(
         "schedule.remind",
-        json!({"content": "Ship the 0.3.1 release", "at": "2026-07-05T09:00:00Z"}),
+        json!({"content": "Ship the 0.4.0 release", "at": "2026-07-05T09:00:00Z"}),
     )
     .await?;
 ```
 
-Over MCP: `request(ops="schedule.remind(content=\"Ship the 0.3.1 release\", at=\"2026-07-05T09:00:00Z\")")`.
+Over MCP: `request(ops="schedule.remind(content=\"Ship the 0.4.0 release\", at=\"2026-07-05T09:00:00Z\")")`.
 
 ## Where this sits
 

--- a/crates/khive-pack-session/Cargo.toml
+++ b/crates/khive-pack-session/Cargo.toml
@@ -12,10 +12,10 @@ categories.workspace = true
 description = "Session verb pack - store/list/resume/export over the notes substrate"
 
 [dependencies]
-khive-types = { version = "0.3.0", path = "../khive-types", features = ["serde"] }
-khive-runtime = { version = "0.3.0", path = "../khive-runtime" }
+khive-types = { version = "0.3.1", path = "../khive-types", features = ["serde"] }
+khive-runtime = { version = "0.3.1", path = "../khive-runtime" }
 inventory = { workspace = true }
-khive-storage = { version = "0.3.0", path = "../khive-storage" }
+khive-storage = { version = "0.3.1", path = "../khive-storage" }
 async-trait = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
@@ -26,7 +26,7 @@ tokio = { workspace = true }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["full"] }
-khive-pack-kg = { version = "0.3.0", path = "../khive-pack-kg" }
+khive-pack-kg = { version = "0.3.1", path = "../khive-pack-kg" }
 tempfile = { workspace = true }
 # Test-only: builds a bare `PoolConfig { write_queue_enabled: true, .. }` +
 # `SqlBridge` directly (no `KhiveRuntime`, no `KHIVE_WRITE_QUEUE` env var) for
@@ -34,4 +34,4 @@ tempfile = { workspace = true }
 # established pattern in khive-pack-brain's `fold_gate.rs` and `persist.rs`
 # (documented there: env-var mutation races other tests' `KhiveRuntime::new`
 # calls in the same binary; a literal `PoolConfig` sidesteps that).
-khive-db = { version = "0.3.0", path = "../khive-db" }
+khive-db = { version = "0.3.1", path = "../khive-db" }

--- a/crates/khive-pack-session/Cargo.toml
+++ b/crates/khive-pack-session/Cargo.toml
@@ -12,10 +12,10 @@ categories.workspace = true
 description = "Session verb pack - store/list/resume/export over the notes substrate"
 
 [dependencies]
-khive-types = { version = "0.3.1", path = "../khive-types", features = ["serde"] }
-khive-runtime = { version = "0.3.1", path = "../khive-runtime" }
+khive-types = { version = "0.4.0", path = "../khive-types", features = ["serde"] }
+khive-runtime = { version = "0.4.0", path = "../khive-runtime" }
 inventory = { workspace = true }
-khive-storage = { version = "0.3.1", path = "../khive-storage" }
+khive-storage = { version = "0.4.0", path = "../khive-storage" }
 async-trait = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
@@ -26,7 +26,7 @@ tokio = { workspace = true }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["full"] }
-khive-pack-kg = { version = "0.3.1", path = "../khive-pack-kg" }
+khive-pack-kg = { version = "0.4.0", path = "../khive-pack-kg" }
 tempfile = { workspace = true }
 # Test-only: builds a bare `PoolConfig { write_queue_enabled: true, .. }` +
 # `SqlBridge` directly (no `KhiveRuntime`, no `KHIVE_WRITE_QUEUE` env var) for
@@ -34,4 +34,4 @@ tempfile = { workspace = true }
 # established pattern in khive-pack-brain's `fold_gate.rs` and `persist.rs`
 # (documented there: env-var mutation races other tests' `KhiveRuntime::new`
 # calls in the same binary; a literal `PoolConfig` sidesteps that).
-khive-db = { version = "0.3.1", path = "../khive-db" }
+khive-db = { version = "0.4.0", path = "../khive-db" }

--- a/crates/khive-pack-template/Cargo.toml
+++ b/crates/khive-pack-template/Cargo.toml
@@ -12,12 +12,12 @@ categories.workspace = true
 description = "Reference template for new khive packs (ADR-023 §8). Copy this crate to get a working pack scaffold."
 
 [dependencies]
-khive-types = { version = "0.3.0", path = "../khive-types", features = ["serde"] }
-khive-runtime = { version = "0.3.0", path = "../khive-runtime" }
+khive-types = { version = "0.3.1", path = "../khive-types", features = ["serde"] }
+khive-runtime = { version = "0.3.1", path = "../khive-runtime" }
 inventory = { workspace = true }
 async-trait = { workspace = true }
 serde_json = { workspace = true }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["test-util"] }
-khive-pack-kg = { version = "0.3.0", path = "../khive-pack-kg" }
+khive-pack-kg = { version = "0.3.1", path = "../khive-pack-kg" }

--- a/crates/khive-pack-template/Cargo.toml
+++ b/crates/khive-pack-template/Cargo.toml
@@ -12,12 +12,12 @@ categories.workspace = true
 description = "Reference template for new khive packs (ADR-023 §8). Copy this crate to get a working pack scaffold."
 
 [dependencies]
-khive-types = { version = "0.3.1", path = "../khive-types", features = ["serde"] }
-khive-runtime = { version = "0.3.1", path = "../khive-runtime" }
+khive-types = { version = "0.4.0", path = "../khive-types", features = ["serde"] }
+khive-runtime = { version = "0.4.0", path = "../khive-runtime" }
 inventory = { workspace = true }
 async-trait = { workspace = true }
 serde_json = { workspace = true }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["test-util"] }
-khive-pack-kg = { version = "0.3.1", path = "../khive-pack-kg" }
+khive-pack-kg = { version = "0.4.0", path = "../khive-pack-kg" }

--- a/crates/khive-pack-workspace/Cargo.toml
+++ b/crates/khive-pack-workspace/Cargo.toml
@@ -11,8 +11,8 @@ categories.workspace = true
 description = "Workspace pack  -  pack-owned `workspace` entity kind with typed `contains` membership edges to issue/pull_request/commit/task/session records (issue #873)"
 
 [dependencies]
-khive-types = { version = "0.3.0", path = "../khive-types", features = ["serde"] }
-khive-runtime = { version = "0.3.0", path = "../khive-runtime" }
+khive-types = { version = "0.3.1", path = "../khive-types", features = ["serde"] }
+khive-runtime = { version = "0.3.1", path = "../khive-runtime" }
 inventory = { workspace = true }
 async-trait = { workspace = true }
 serde_json = { workspace = true }
@@ -20,7 +20,7 @@ uuid = { workspace = true }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["full"] }
-khive-pack-kg = { version = "0.3.0", path = "../khive-pack-kg" }
-khive-pack-gtd = { version = "0.3.0", path = "../khive-pack-gtd" }
-khive-pack-git = { version = "0.3.0", path = "../khive-pack-git" }
-khive-pack-session = { version = "0.3.0", path = "../khive-pack-session" }
+khive-pack-kg = { version = "0.3.1", path = "../khive-pack-kg" }
+khive-pack-gtd = { version = "0.3.1", path = "../khive-pack-gtd" }
+khive-pack-git = { version = "0.3.1", path = "../khive-pack-git" }
+khive-pack-session = { version = "0.3.1", path = "../khive-pack-session" }

--- a/crates/khive-pack-workspace/Cargo.toml
+++ b/crates/khive-pack-workspace/Cargo.toml
@@ -11,8 +11,8 @@ categories.workspace = true
 description = "Workspace pack  -  pack-owned `workspace` entity kind with typed `contains` membership edges to issue/pull_request/commit/task/session records (issue #873)"
 
 [dependencies]
-khive-types = { version = "0.3.1", path = "../khive-types", features = ["serde"] }
-khive-runtime = { version = "0.3.1", path = "../khive-runtime" }
+khive-types = { version = "0.4.0", path = "../khive-types", features = ["serde"] }
+khive-runtime = { version = "0.4.0", path = "../khive-runtime" }
 inventory = { workspace = true }
 async-trait = { workspace = true }
 serde_json = { workspace = true }
@@ -20,7 +20,7 @@ uuid = { workspace = true }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["full"] }
-khive-pack-kg = { version = "0.3.1", path = "../khive-pack-kg" }
-khive-pack-gtd = { version = "0.3.1", path = "../khive-pack-gtd" }
-khive-pack-git = { version = "0.3.1", path = "../khive-pack-git" }
-khive-pack-session = { version = "0.3.1", path = "../khive-pack-session" }
+khive-pack-kg = { version = "0.4.0", path = "../khive-pack-kg" }
+khive-pack-gtd = { version = "0.4.0", path = "../khive-pack-gtd" }
+khive-pack-git = { version = "0.4.0", path = "../khive-pack-git" }
+khive-pack-session = { version = "0.4.0", path = "../khive-pack-session" }

--- a/crates/khive-query/Cargo.toml
+++ b/crates/khive-query/Cargo.toml
@@ -15,7 +15,7 @@ description = "GQL and SPARQL parsers with SQL compiler for knowledge graph quer
 bench = false
 
 [dependencies]
-khive-types = { version = "0.3.0", path = "../khive-types" }
+khive-types = { version = "0.3.1", path = "../khive-types" }
 thiserror = { workspace = true }
 
 [dev-dependencies]

--- a/crates/khive-query/Cargo.toml
+++ b/crates/khive-query/Cargo.toml
@@ -15,7 +15,7 @@ description = "GQL and SPARQL parsers with SQL compiler for knowledge graph quer
 bench = false
 
 [dependencies]
-khive-types = { version = "0.3.1", path = "../khive-types" }
+khive-types = { version = "0.4.0", path = "../khive-types" }
 thiserror = { workspace = true }
 
 [dev-dependencies]

--- a/crates/khive-request/Cargo.toml
+++ b/crates/khive-request/Cargo.toml
@@ -15,7 +15,7 @@ description = "Request DSL — parses verb-dispatch strings (function-call, JSON
 bench = false
 
 [dependencies]
-khive-types = { version = "0.3.0", path = "../khive-types" }
+khive-types = { version = "0.3.1", path = "../khive-types" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 

--- a/crates/khive-request/Cargo.toml
+++ b/crates/khive-request/Cargo.toml
@@ -15,7 +15,7 @@ description = "Request DSL — parses verb-dispatch strings (function-call, JSON
 bench = false
 
 [dependencies]
-khive-types = { version = "0.3.1", path = "../khive-types" }
+khive-types = { version = "0.4.0", path = "../khive-types" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 

--- a/crates/khive-retrieval/Cargo.toml
+++ b/crates/khive-retrieval/Cargo.toml
@@ -15,15 +15,15 @@ description = "Hybrid retrieval composer (HNSW + BM25 + fusion + graph + cross-e
 bench = false
 
 [dependencies]
-khive-hnsw    = { version = "0.3.1", path = "../khive-hnsw" }
-khive-bm25    = { version = "0.3.1", path = "../khive-bm25" }
-khive-fusion  = { version = "0.3.1", path = "../khive-fusion" }
-khive-score   = { version = "0.3.1", path = "../khive-score" }
-khive-types   = { version = "0.3.1", path = "../khive-types" }
-khive-fold    = { version = "0.3.1", path = "../khive-fold", optional = true }
-khive-storage = { version = "0.3.1", path = "../khive-storage", optional = true }
-khive-db      = { version = "0.3.1", path = "../khive-db" }
-khive-gate    = { version = "0.3.1", path = "../khive-gate", optional = true }
+khive-hnsw    = { version = "0.4.0", path = "../khive-hnsw" }
+khive-bm25    = { version = "0.4.0", path = "../khive-bm25" }
+khive-fusion  = { version = "0.4.0", path = "../khive-fusion" }
+khive-score   = { version = "0.4.0", path = "../khive-score" }
+khive-types   = { version = "0.4.0", path = "../khive-types" }
+khive-fold    = { version = "0.4.0", path = "../khive-fold", optional = true }
+khive-storage = { version = "0.4.0", path = "../khive-storage", optional = true }
+khive-db      = { version = "0.4.0", path = "../khive-db" }
+khive-gate    = { version = "0.4.0", path = "../khive-gate", optional = true }
 lattice-embed = { workspace = true }
 
 serde = { workspace = true }
@@ -62,8 +62,8 @@ embed = []
 
 [dev-dependencies]
 criterion = { workspace = true }
-khive-score = { version = "0.3.1", path = "../khive-score" }
-khive-fusion = { version = "0.3.1", path = "../khive-fusion" }
+khive-score = { version = "0.4.0", path = "../khive-score" }
+khive-fusion = { version = "0.4.0", path = "../khive-fusion" }
 
 [[bench]]
 name = "fusion_bench"

--- a/crates/khive-retrieval/Cargo.toml
+++ b/crates/khive-retrieval/Cargo.toml
@@ -15,15 +15,15 @@ description = "Hybrid retrieval composer (HNSW + BM25 + fusion + graph + cross-e
 bench = false
 
 [dependencies]
-khive-hnsw    = { version = "0.3.0", path = "../khive-hnsw" }
-khive-bm25    = { version = "0.3.0", path = "../khive-bm25" }
-khive-fusion  = { version = "0.3.0", path = "../khive-fusion" }
-khive-score   = { version = "0.3.0", path = "../khive-score" }
-khive-types   = { version = "0.3.0", path = "../khive-types" }
-khive-fold    = { version = "0.3.0", path = "../khive-fold", optional = true }
-khive-storage = { version = "0.3.0", path = "../khive-storage", optional = true }
-khive-db      = { version = "0.3.0", path = "../khive-db" }
-khive-gate    = { version = "0.3.0", path = "../khive-gate", optional = true }
+khive-hnsw    = { version = "0.3.1", path = "../khive-hnsw" }
+khive-bm25    = { version = "0.3.1", path = "../khive-bm25" }
+khive-fusion  = { version = "0.3.1", path = "../khive-fusion" }
+khive-score   = { version = "0.3.1", path = "../khive-score" }
+khive-types   = { version = "0.3.1", path = "../khive-types" }
+khive-fold    = { version = "0.3.1", path = "../khive-fold", optional = true }
+khive-storage = { version = "0.3.1", path = "../khive-storage", optional = true }
+khive-db      = { version = "0.3.1", path = "../khive-db" }
+khive-gate    = { version = "0.3.1", path = "../khive-gate", optional = true }
 lattice-embed = { workspace = true }
 
 serde = { workspace = true }
@@ -62,8 +62,8 @@ embed = []
 
 [dev-dependencies]
 criterion = { workspace = true }
-khive-score = { version = "0.3.0", path = "../khive-score" }
-khive-fusion = { version = "0.3.0", path = "../khive-fusion" }
+khive-score = { version = "0.3.1", path = "../khive-score" }
+khive-fusion = { version = "0.3.1", path = "../khive-fusion" }
 
 [[bench]]
 name = "fusion_bench"

--- a/crates/khive-runtime/Cargo.toml
+++ b/crates/khive-runtime/Cargo.toml
@@ -15,14 +15,14 @@ description = "Composable Service API: entity/note CRUD, graph traversal, hybrid
 fault-injection = []
 
 [dependencies]
-khive-types = { version = "0.3.0", path = "../khive-types", features = ["serde"] }
-khive-storage = { version = "0.3.0", path = "../khive-storage" }
-khive-score = { version = "0.3.0", path = "../khive-score" }
-khive-fusion = { version = "0.3.0", path = "../khive-fusion" }
-khive-fold = { version = "0.3.0", path = "../khive-fold" }
-khive-db = { version = "0.3.0", path = "../khive-db", features = ["vectors"] }
-khive-query = { version = "0.3.0", path = "../khive-query" }
-khive-gate = { version = "0.3.0", path = "../khive-gate" }
+khive-types = { version = "0.3.1", path = "../khive-types", features = ["serde"] }
+khive-storage = { version = "0.3.1", path = "../khive-storage" }
+khive-score = { version = "0.3.1", path = "../khive-score" }
+khive-fusion = { version = "0.3.1", path = "../khive-fusion" }
+khive-fold = { version = "0.3.1", path = "../khive-fold" }
+khive-db = { version = "0.3.1", path = "../khive-db", features = ["vectors"] }
+khive-query = { version = "0.3.1", path = "../khive-query" }
+khive-gate = { version = "0.3.1", path = "../khive-gate" }
 inventory = { workspace = true }
 tokio = { workspace = true }
 async-trait = { workspace = true }
@@ -40,7 +40,7 @@ libc = { workspace = true }
 anyhow = { workspace = true }
 
 [dev-dependencies]
-khive-gate-rego = { version = "0.3.0", path = "../khive-gate-rego" }
+khive-gate-rego = { version = "0.3.1", path = "../khive-gate-rego" }
 tokio = { workspace = true, features = ["test-util"] }
 tempfile = { workspace = true }
 tracing-subscriber = { workspace = true }

--- a/crates/khive-runtime/Cargo.toml
+++ b/crates/khive-runtime/Cargo.toml
@@ -15,14 +15,14 @@ description = "Composable Service API: entity/note CRUD, graph traversal, hybrid
 fault-injection = []
 
 [dependencies]
-khive-types = { version = "0.3.1", path = "../khive-types", features = ["serde"] }
-khive-storage = { version = "0.3.1", path = "../khive-storage" }
-khive-score = { version = "0.3.1", path = "../khive-score" }
-khive-fusion = { version = "0.3.1", path = "../khive-fusion" }
-khive-fold = { version = "0.3.1", path = "../khive-fold" }
-khive-db = { version = "0.3.1", path = "../khive-db", features = ["vectors"] }
-khive-query = { version = "0.3.1", path = "../khive-query" }
-khive-gate = { version = "0.3.1", path = "../khive-gate" }
+khive-types = { version = "0.4.0", path = "../khive-types", features = ["serde"] }
+khive-storage = { version = "0.4.0", path = "../khive-storage" }
+khive-score = { version = "0.4.0", path = "../khive-score" }
+khive-fusion = { version = "0.4.0", path = "../khive-fusion" }
+khive-fold = { version = "0.4.0", path = "../khive-fold" }
+khive-db = { version = "0.4.0", path = "../khive-db", features = ["vectors"] }
+khive-query = { version = "0.4.0", path = "../khive-query" }
+khive-gate = { version = "0.4.0", path = "../khive-gate" }
 inventory = { workspace = true }
 tokio = { workspace = true }
 async-trait = { workspace = true }
@@ -40,7 +40,7 @@ libc = { workspace = true }
 anyhow = { workspace = true }
 
 [dev-dependencies]
-khive-gate-rego = { version = "0.3.1", path = "../khive-gate-rego" }
+khive-gate-rego = { version = "0.4.0", path = "../khive-gate-rego" }
 tokio = { workspace = true, features = ["test-util"] }
 tempfile = { workspace = true }
 tracing-subscriber = { workspace = true }

--- a/crates/khive-score/Cargo.toml
+++ b/crates/khive-score/Cargo.toml
@@ -18,7 +18,7 @@ default = ["serde"]
 serde = ["dep:serde"]
 
 [dependencies]
-khive-types = { version = "0.3.0", path = "../khive-types" }
+khive-types = { version = "0.3.1", path = "../khive-types" }
 serde = { workspace = true, optional = true, features = ["derive"] }
 
 [dev-dependencies]

--- a/crates/khive-score/Cargo.toml
+++ b/crates/khive-score/Cargo.toml
@@ -18,7 +18,7 @@ default = ["serde"]
 serde = ["dep:serde"]
 
 [dependencies]
-khive-types = { version = "0.3.1", path = "../khive-types" }
+khive-types = { version = "0.4.0", path = "../khive-types" }
 serde = { workspace = true, optional = true, features = ["derive"] }
 
 [dev-dependencies]

--- a/crates/khive-storage/Cargo.toml
+++ b/crates/khive-storage/Cargo.toml
@@ -13,8 +13,8 @@ categories.workspace = true
 [dependencies]
 async-trait = { workspace = true }
 chrono = { workspace = true }
-khive-score = { version = "0.3.0", path = "../khive-score" }
-khive-types = { version = "0.3.0", path = "../khive-types", features = ["serde"] }
+khive-score = { version = "0.3.1", path = "../khive-score" }
+khive-types = { version = "0.3.1", path = "../khive-types", features = ["serde"] }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/khive-storage/Cargo.toml
+++ b/crates/khive-storage/Cargo.toml
@@ -13,8 +13,8 @@ categories.workspace = true
 [dependencies]
 async-trait = { workspace = true }
 chrono = { workspace = true }
-khive-score = { version = "0.3.1", path = "../khive-score" }
-khive-types = { version = "0.3.1", path = "../khive-types", features = ["serde"] }
+khive-score = { version = "0.4.0", path = "../khive-score" }
+khive-types = { version = "0.4.0", path = "../khive-types", features = ["serde"] }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/khive-text/Cargo.toml
+++ b/crates/khive-text/Cargo.toml
@@ -20,7 +20,7 @@ rust-stemmers = { workspace = true, optional = true }
 
 [dev-dependencies]
 criterion = { workspace = true }
-khive-bm25 = { version = "0.3.0", path = "../khive-bm25" }
+khive-bm25 = { version = "0.3.1", path = "../khive-bm25" }
 
 [features]
 default = []

--- a/crates/khive-text/Cargo.toml
+++ b/crates/khive-text/Cargo.toml
@@ -20,7 +20,7 @@ rust-stemmers = { workspace = true, optional = true }
 
 [dev-dependencies]
 criterion = { workspace = true }
-khive-bm25 = { version = "0.3.1", path = "../khive-bm25" }
+khive-bm25 = { version = "0.4.0", path = "../khive-bm25" }
 
 [features]
 default = []

--- a/crates/khive-vamana/Cargo.toml
+++ b/crates/khive-vamana/Cargo.toml
@@ -21,7 +21,7 @@ rand = { workspace = true }
 serde = { workspace = true }
 thiserror = { workspace = true }
 blake3 = { workspace = true }
-khive-quant = { version = "0.3.1", path = "../khive-quant" }
+khive-quant = { version = "0.4.0", path = "../khive-quant" }
 
 [dev-dependencies]
 blake3 = { workspace = true }

--- a/crates/khive-vamana/Cargo.toml
+++ b/crates/khive-vamana/Cargo.toml
@@ -21,7 +21,7 @@ rand = { workspace = true }
 serde = { workspace = true }
 thiserror = { workspace = true }
 blake3 = { workspace = true }
-khive-quant = { version = "0.3.0", path = "../khive-quant" }
+khive-quant = { version = "0.3.1", path = "../khive-quant" }
 
 [dev-dependencies]
 blake3 = { workspace = true }

--- a/crates/khive-vcs-adapters/Cargo.toml
+++ b/crates/khive-vcs-adapters/Cargo.toml
@@ -10,7 +10,7 @@ homepage.workspace = true
 description = "KG import/export format adapters — CSV, JSON, and future format support (ADR-036)"
 
 [dependencies]
-khive-types = { version = "0.3.1", path = "../khive-types" }
+khive-types = { version = "0.4.0", path = "../khive-types" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/khive-vcs-adapters/Cargo.toml
+++ b/crates/khive-vcs-adapters/Cargo.toml
@@ -10,7 +10,7 @@ homepage.workspace = true
 description = "KG import/export format adapters — CSV, JSON, and future format support (ADR-036)"
 
 [dependencies]
-khive-types = { version = "0.3.0", path = "../khive-types" }
+khive-types = { version = "0.3.1", path = "../khive-types" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/khive-vcs/Cargo.toml
+++ b/crates/khive-vcs/Cargo.toml
@@ -10,9 +10,9 @@ homepage.workspace = true
 description = "KG versioning — git-native core types, canonical hash, and NDJSON-to-SQLite sync (ADR-010/ADR-020)"
 
 [dependencies]
-khive-runtime = { version = "0.3.0", path = "../khive-runtime" }
-khive-storage = { version = "0.3.0", path = "../khive-storage" }
-khive-types = { version = "0.3.0", path = "../khive-types" }
+khive-runtime = { version = "0.3.1", path = "../khive-runtime" }
+khive-storage = { version = "0.3.1", path = "../khive-storage" }
+khive-types = { version = "0.3.1", path = "../khive-types" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
@@ -26,5 +26,5 @@ tempfile = { workspace = true }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["rt", "macros"] }
-khive-vcs-adapters = { version = "0.3.0", path = "../khive-vcs-adapters" }
-khive-db = { version = "0.3.0", path = "../khive-db" }
+khive-vcs-adapters = { version = "0.3.1", path = "../khive-vcs-adapters" }
+khive-db = { version = "0.3.1", path = "../khive-db" }

--- a/crates/khive-vcs/Cargo.toml
+++ b/crates/khive-vcs/Cargo.toml
@@ -10,9 +10,9 @@ homepage.workspace = true
 description = "KG versioning — git-native core types, canonical hash, and NDJSON-to-SQLite sync (ADR-010/ADR-020)"
 
 [dependencies]
-khive-runtime = { version = "0.3.1", path = "../khive-runtime" }
-khive-storage = { version = "0.3.1", path = "../khive-storage" }
-khive-types = { version = "0.3.1", path = "../khive-types" }
+khive-runtime = { version = "0.4.0", path = "../khive-runtime" }
+khive-storage = { version = "0.4.0", path = "../khive-storage" }
+khive-types = { version = "0.4.0", path = "../khive-types" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
@@ -26,5 +26,5 @@ tempfile = { workspace = true }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["rt", "macros"] }
-khive-vcs-adapters = { version = "0.3.1", path = "../khive-vcs-adapters" }
-khive-db = { version = "0.3.1", path = "../khive-db" }
+khive-vcs-adapters = { version = "0.4.0", path = "../khive-vcs-adapters" }
+khive-db = { version = "0.4.0", path = "../khive-db" }

--- a/crates/kkernel/Cargo.toml
+++ b/crates/kkernel/Cargo.toml
@@ -12,27 +12,27 @@ categories.workspace = true
 description = "khive kernel — stdio MCP server binary and admin CLI (sync, pack introspection, db ops)"
 
 [dependencies]
-khive-runtime = { version = "0.3.1", path = "../khive-runtime" }
-khive-mcp = { version = "0.3.1", path = "../khive-mcp" }
-khive-score = { version = "0.3.1", path = "../khive-score" }
-khive-db = { version = "0.3.1", path = "../khive-db" }
-khive-storage = { version = "0.3.1", path = "../khive-storage" }
-khive-types = { version = "0.3.1", path = "../khive-types" }
-khive-vcs = { version = "0.3.1", path = "../khive-vcs" }
-khive-vcs-adapters = { version = "0.3.1", path = "../khive-vcs-adapters" }
-khive-pack-kg = { version = "0.3.1", path = "../khive-pack-kg" }
-khive-pack-gtd = { version = "0.3.1", path = "../khive-pack-gtd" }
-khive-pack-memory = { version = "0.3.1", path = "../khive-pack-memory" }
-khive-pack-brain = { version = "0.3.1", path = "../khive-pack-brain" }
-khive-pack-comm = { version = "0.3.1", path = "../khive-pack-comm" }
-khive-pack-schedule = { version = "0.3.1", path = "../khive-pack-schedule" }
-khive-pack-formal = { version = "0.3.1", path = "../khive-pack-formal" }
-khive-pack-code = { version = "0.3.1", path = "../khive-pack-code" }
-khive-pack-knowledge = { version = "0.3.1", path = "../khive-pack-knowledge" }
-khive-pack-session = { version = "0.3.1", path = "../khive-pack-session" }
-khive-pack-git = { version = "0.3.1", path = "../khive-pack-git" }
-khive-request = { version = "0.3.1", path = "../khive-request" }
-khive-changeset = { version = "0.3.1", path = "../khive-changeset" }
+khive-runtime = { version = "0.4.0", path = "../khive-runtime" }
+khive-mcp = { version = "0.4.0", path = "../khive-mcp" }
+khive-score = { version = "0.4.0", path = "../khive-score" }
+khive-db = { version = "0.4.0", path = "../khive-db" }
+khive-storage = { version = "0.4.0", path = "../khive-storage" }
+khive-types = { version = "0.4.0", path = "../khive-types" }
+khive-vcs = { version = "0.4.0", path = "../khive-vcs" }
+khive-vcs-adapters = { version = "0.4.0", path = "../khive-vcs-adapters" }
+khive-pack-kg = { version = "0.4.0", path = "../khive-pack-kg" }
+khive-pack-gtd = { version = "0.4.0", path = "../khive-pack-gtd" }
+khive-pack-memory = { version = "0.4.0", path = "../khive-pack-memory" }
+khive-pack-brain = { version = "0.4.0", path = "../khive-pack-brain" }
+khive-pack-comm = { version = "0.4.0", path = "../khive-pack-comm" }
+khive-pack-schedule = { version = "0.4.0", path = "../khive-pack-schedule" }
+khive-pack-formal = { version = "0.4.0", path = "../khive-pack-formal" }
+khive-pack-code = { version = "0.4.0", path = "../khive-pack-code" }
+khive-pack-knowledge = { version = "0.4.0", path = "../khive-pack-knowledge" }
+khive-pack-session = { version = "0.4.0", path = "../khive-pack-session" }
+khive-pack-git = { version = "0.4.0", path = "../khive-pack-git" }
+khive-request = { version = "0.4.0", path = "../khive-request" }
+khive-changeset = { version = "0.4.0", path = "../khive-changeset" }
 tokio = { workspace = true }
 async-trait = { workspace = true }
 serde = { workspace = true }

--- a/crates/kkernel/Cargo.toml
+++ b/crates/kkernel/Cargo.toml
@@ -12,27 +12,27 @@ categories.workspace = true
 description = "khive kernel — stdio MCP server binary and admin CLI (sync, pack introspection, db ops)"
 
 [dependencies]
-khive-runtime = { version = "0.3.0", path = "../khive-runtime" }
-khive-mcp = { version = "0.3.0", path = "../khive-mcp" }
-khive-score = { version = "0.3.0", path = "../khive-score" }
-khive-db = { version = "0.3.0", path = "../khive-db" }
-khive-storage = { version = "0.3.0", path = "../khive-storage" }
-khive-types = { version = "0.3.0", path = "../khive-types" }
-khive-vcs = { version = "0.3.0", path = "../khive-vcs" }
-khive-vcs-adapters = { version = "0.3.0", path = "../khive-vcs-adapters" }
-khive-pack-kg = { version = "0.3.0", path = "../khive-pack-kg" }
-khive-pack-gtd = { version = "0.3.0", path = "../khive-pack-gtd" }
-khive-pack-memory = { version = "0.3.0", path = "../khive-pack-memory" }
-khive-pack-brain = { version = "0.3.0", path = "../khive-pack-brain" }
-khive-pack-comm = { version = "0.3.0", path = "../khive-pack-comm" }
-khive-pack-schedule = { version = "0.3.0", path = "../khive-pack-schedule" }
-khive-pack-formal = { version = "0.3.0", path = "../khive-pack-formal" }
-khive-pack-code = { version = "0.3.0", path = "../khive-pack-code" }
-khive-pack-knowledge = { version = "0.3.0", path = "../khive-pack-knowledge" }
-khive-pack-session = { version = "0.3.0", path = "../khive-pack-session" }
-khive-pack-git = { version = "0.3.0", path = "../khive-pack-git" }
-khive-request = { version = "0.3.0", path = "../khive-request" }
-khive-changeset = { version = "0.3.0", path = "../khive-changeset" }
+khive-runtime = { version = "0.3.1", path = "../khive-runtime" }
+khive-mcp = { version = "0.3.1", path = "../khive-mcp" }
+khive-score = { version = "0.3.1", path = "../khive-score" }
+khive-db = { version = "0.3.1", path = "../khive-db" }
+khive-storage = { version = "0.3.1", path = "../khive-storage" }
+khive-types = { version = "0.3.1", path = "../khive-types" }
+khive-vcs = { version = "0.3.1", path = "../khive-vcs" }
+khive-vcs-adapters = { version = "0.3.1", path = "../khive-vcs-adapters" }
+khive-pack-kg = { version = "0.3.1", path = "../khive-pack-kg" }
+khive-pack-gtd = { version = "0.3.1", path = "../khive-pack-gtd" }
+khive-pack-memory = { version = "0.3.1", path = "../khive-pack-memory" }
+khive-pack-brain = { version = "0.3.1", path = "../khive-pack-brain" }
+khive-pack-comm = { version = "0.3.1", path = "../khive-pack-comm" }
+khive-pack-schedule = { version = "0.3.1", path = "../khive-pack-schedule" }
+khive-pack-formal = { version = "0.3.1", path = "../khive-pack-formal" }
+khive-pack-code = { version = "0.3.1", path = "../khive-pack-code" }
+khive-pack-knowledge = { version = "0.3.1", path = "../khive-pack-knowledge" }
+khive-pack-session = { version = "0.3.1", path = "../khive-pack-session" }
+khive-pack-git = { version = "0.3.1", path = "../khive-pack-git" }
+khive-request = { version = "0.3.1", path = "../khive-request" }
+khive-changeset = { version = "0.3.1", path = "../khive-changeset" }
 tokio = { workspace = true }
 async-trait = { workspace = true }
 serde = { workspace = true }

--- a/marketplace/INSTALL.md
+++ b/marketplace/INSTALL.md
@@ -7,7 +7,7 @@ correctly to a running `kkernel mcp` server.
 
 | Plugin | Version | kkernel |
 | ------ | ------- | ------- |
-| khive  | 0.3.0   | ≥ 0.2.4 |
+| khive  | 0.3.1   | ≥ 0.2.4 |
 
 `khive` is a single umbrella plugin — one pattern skill per pack plus the kg stewardship agents,
 all over the one `kkernel mcp` server.

--- a/marketplace/INSTALL.md
+++ b/marketplace/INSTALL.md
@@ -7,7 +7,7 @@ correctly to a running `kkernel mcp` server.
 
 | Plugin | Version | kkernel |
 | ------ | ------- | ------- |
-| khive  | 0.3.1   | ≥ 0.2.4 |
+| khive  | 0.4.0   | ≥ 0.2.4 |
 
 `khive` is a single umbrella plugin — one pattern skill per pack plus the kg stewardship agents,
 all over the one `kkernel mcp` server.

--- a/marketplace/khive/.claude-plugin/plugin.json
+++ b/marketplace/khive/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "khive",
   "description": "khive for AI agents — knowledge graph, GTD, memory, inter-agent comm, scheduling, and domain knowledge over one MCP server. One pattern skill per pack, plus the kg stewardship agents.",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "author": {
     "name": "khive maintainers",
     "url": "https://github.com/ohdearquant"

--- a/marketplace/khive/.claude-plugin/plugin.json
+++ b/marketplace/khive/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "khive",
   "description": "khive for AI agents — knowledge graph, GTD, memory, inter-agent comm, scheduling, and domain knowledge over one MCP server. One pattern skill per pack, plus the kg stewardship agents.",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "author": {
     "name": "khive maintainers",
     "url": "https://github.com/ohdearquant"

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "khive",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Research knowledge graph runtime over MCP stdio, with typed entities, closed ontology, and hybrid search for AI research agents.",
   "license": "Apache-2.0",
   "repository": {
@@ -35,11 +35,11 @@
     "node": ">=18"
   },
   "optionalDependencies": {
-    "@khive-ai/kernel-darwin-arm64": "0.3.0",
-    "@khive-ai/kernel-darwin-x64": "0.3.0",
-    "@khive-ai/kernel-linux-x64-gnu": "0.3.0",
-    "@khive-ai/kernel-linux-x64-musl": "0.3.0",
-    "@khive-ai/kernel-linux-arm64": "0.3.0",
-    "@khive-ai/kernel-win32-x64": "0.3.0"
+    "@khive-ai/kernel-darwin-arm64": "0.3.1",
+    "@khive-ai/kernel-darwin-x64": "0.3.1",
+    "@khive-ai/kernel-linux-x64-gnu": "0.3.1",
+    "@khive-ai/kernel-linux-x64-musl": "0.3.1",
+    "@khive-ai/kernel-linux-arm64": "0.3.1",
+    "@khive-ai/kernel-win32-x64": "0.3.1"
   }
 }

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "khive",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "description": "Research knowledge graph runtime over MCP stdio, with typed entities, closed ontology, and hybrid search for AI research agents.",
   "license": "Apache-2.0",
   "repository": {
@@ -35,11 +35,11 @@
     "node": ">=18"
   },
   "optionalDependencies": {
-    "@khive-ai/kernel-darwin-arm64": "0.3.1",
-    "@khive-ai/kernel-darwin-x64": "0.3.1",
-    "@khive-ai/kernel-linux-x64-gnu": "0.3.1",
-    "@khive-ai/kernel-linux-x64-musl": "0.3.1",
-    "@khive-ai/kernel-linux-arm64": "0.3.1",
-    "@khive-ai/kernel-win32-x64": "0.3.1"
+    "@khive-ai/kernel-darwin-arm64": "0.4.0",
+    "@khive-ai/kernel-darwin-x64": "0.4.0",
+    "@khive-ai/kernel-linux-x64-gnu": "0.4.0",
+    "@khive-ai/kernel-linux-x64-musl": "0.4.0",
+    "@khive-ai/kernel-linux-arm64": "0.4.0",
+    "@khive-ai/kernel-win32-x64": "0.4.0"
   }
 }

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -62,9 +62,12 @@ CRATES=(
     khive-retrieval
     khive-vcs-adapters
     khive-vcs
+    khive-changeset      # needs khive-types (above); never published, no crates.io baseline yet
     # khive-merge — excluded from workspace (ADR-043 forward-deployed, ahead of khive-vcs)
     khive-pack-formal    # needs khive-runtime + khive-types (both above); dev-dep of khive-pack-kg, so publish first
     khive-pack-kg
+    khive-pack-git       # needs khive-runtime/storage + khive-pack-kg (all above); never published, no baseline yet
+    khive-pack-code      # needs khive-runtime/storage + khive-pack-kg (all above); never published, no baseline yet
     khive-pack-gtd
     khive-brain-core
     khive-pack-brain
@@ -73,6 +76,7 @@ CRATES=(
     khive-pack-schedule
     khive-pack-knowledge
     khive-pack-session   # needs khive-pack-kg + khive-runtime/storage/types (all above)
+    khive-pack-workspace # needs khive-pack-kg/gtd/git/session (all above); never published, no baseline yet
     khive-pack-template
     khive-channel        # no khive-* deps; transport abstraction
     khive-channel-email  # needs khive-channel (above); optional dep of khive-mcp
@@ -91,8 +95,10 @@ DELAY=10  # seconds to wait for crates.io index between publishes
 # `make publish-dry` validates SemVer before any real publish. Crates with no
 # crates.io baseline yet (never published) have nothing to diff against and are
 # excluded until their first publish: khive-quant, plus the crates first shipped
-# in this release — khive-channel, khive-channel-email, khive-pack-formal,
-# khive-pack-session. Drop an exclusion once that crate has one published version.
+# in the 0.3.0 release (khive-channel, khive-channel-email, khive-pack-formal,
+# khive-pack-session), plus the crates added since 0.3.0 that are still never
+# published (khive-changeset, khive-pack-code, khive-pack-git,
+# khive-pack-workspace). Drop an exclusion once that crate has one published version.
 echo ""
 echo "--- SemVer gate (cargo-semver-checks vs crates.io baseline) ---"
 if ! command -v cargo-semver-checks >/dev/null 2>&1; then
@@ -105,7 +111,11 @@ cargo semver-checks check-release --workspace \
     --exclude khive-channel \
     --exclude khive-channel-email \
     --exclude khive-pack-formal \
-    --exclude khive-pack-session
+    --exclude khive-pack-session \
+    --exclude khive-changeset \
+    --exclude khive-pack-code \
+    --exclude khive-pack-git \
+    --exclude khive-pack-workspace
 echo "    SemVer gate OK"
 
 for crate in "${CRATES[@]}"; do

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -94,11 +94,11 @@ DELAY=10  # seconds to wait for crates.io index between publishes
 # (which is why it is NOT a per-PR CI gate). Runs in preflight and live alike so
 # `make publish-dry` validates SemVer before any real publish. Crates with no
 # crates.io baseline yet (never published) have nothing to diff against and are
-# excluded until their first publish: khive-quant, plus the crates first shipped
-# in the 0.3.0 release (khive-channel, khive-channel-email, khive-pack-formal,
-# khive-pack-session), plus the crates added since 0.3.0 that are still never
-# published (khive-changeset, khive-pack-code, khive-pack-git,
-# khive-pack-workspace). Drop an exclusion once that crate has one published version.
+# excluded until their first publish. As of the 0.4.0 cycle that is exactly the
+# four crates added since 0.3.0: khive-changeset, khive-pack-code, khive-pack-git,
+# khive-pack-workspace. Every other workspace crate, including khive-quant and the
+# crates first shipped in 0.3.0, has a published 0.3.0 baseline and MUST be
+# checked. Drop an exclusion once that crate has one published version.
 echo ""
 echo "--- SemVer gate (cargo-semver-checks vs crates.io baseline) ---"
 if ! command -v cargo-semver-checks >/dev/null 2>&1; then
@@ -107,11 +107,6 @@ if ! command -v cargo-semver-checks >/dev/null 2>&1; then
     exit 1
 fi
 cargo semver-checks check-release --workspace \
-    --exclude khive-quant \
-    --exclude khive-channel \
-    --exclude khive-channel-email \
-    --exclude khive-pack-formal \
-    --exclude khive-pack-session \
     --exclude khive-changeset \
     --exclude khive-pack-code \
     --exclude khive-pack-git \


### PR DESCRIPTION
Retargets the release prep from 0.3.1 to 0.4.0 and repairs the publish pipeline.

**Why 0.4.0, not 0.3.1**: cargo-semver-checks reports real breaking API changes in 16 crates since the 0.3.0 crates.io baseline (merge_entity arity, list_edges arity, DaemonDispatch::dispatch arity, new EventKind variants, removed kkernel module, among others). Cargo's 0.x caret semantics treat 0.3.1 as compatible, so a patch release would silently break dependents; this repo's own release gate (scripts/publish.sh) requires the minor bump.

**Publish pipeline maintenance**: khive-changeset, khive-pack-code, khive-pack-git, and khive-pack-workspace (new since 0.3.0, never published) were missing from both the semver-gate exclude list and the CRATES publish-order array, hard-erroring publish-dry. Both registered, order verified against each crate's dependencies.

**Validation**: cargo check --workspace green at 0.4.0; make publish-dry exits 0 end to end (semver gate OK, all 38 workspace crates package-preflight clean, workspace all-targets check pass).
