### PR TITLE
feat(memory): ADR-104 Stage C entity-anchored candidate extraction

### DIFF
--- a/crates/khive-db/sql/009-entities-name-ci-index.sql
+++ b/crates/khive-db/sql/009-entities-name-ci-index.sql
@@ -1,0 +1,4 @@
+-- V9: Support bounded case-insensitive entity-name candidate lookups.
+
+CREATE INDEX IF NOT EXISTS idx_entities_namespace_name_ci
+    ON entities(namespace, LOWER(name));

--- a/crates/khive-db/sql/009-entities-name-ci-index.sql
+++ b/crates/khive-db/sql/009-entities-name-ci-index.sql
@@ -1,4 +1,5 @@
 -- V9: Support bounded case-insensitive entity-name candidate lookups.
 
 CREATE INDEX IF NOT EXISTS idx_entities_namespace_name_ci
-    ON entities(namespace, LOWER(name));
+    ON entities(namespace, LOWER(name))
+    WHERE deleted_at IS NULL;

--- a/crates/khive-db/src/migrations.rs
+++ b/crates/khive-db/src/migrations.rs
@@ -116,6 +116,8 @@ const V7_UP: &str = include_str!("../sql/007-notes-seq.sql");
 
 const V8_UP: &str = include_str!("../sql/008-notes-seq-repair.sql");
 
+const V9_UP: &str = include_str!("../sql/009-entities-name-ci-index.sql");
+
 /// DDL for the `_embedding_models` registry table.
 ///
 /// Shared between the V1 schema and the belt-and-suspenders creation in
@@ -164,6 +166,11 @@ pub const MIGRATIONS: &[VersionedMigration] = &[
         version: 8,
         name: "notes_seq_repair",
         up: V8_UP,
+    },
+    VersionedMigration {
+        version: 9,
+        name: "entities_name_ci_index",
+        up: V9_UP,
     },
 ];
 

--- a/crates/khive-db/src/stores/entity.rs
+++ b/crates/khive-db/src/stores/entity.rs
@@ -479,10 +479,7 @@ fn build_entity_where(
 
     if !filter.names_ci.is_empty() {
         // ADR-104 Stage C, R1: one batched `LOWER(name) IN (...)` predicate,
-        // scoped by the `namespace`/`deleted_at IS NULL` conditions already
-        // pushed above — the composite `idx_entities_name (namespace, name)`
-        // index still seeks the namespace prefix, bounding the scan to that
-        // namespace's rows before this predicate is evaluated row-by-row.
+        // served by `idx_entities_namespace_name_ci (namespace, LOWER(name))`.
         let placeholders: Vec<String> = filter
             .names_ci
             .iter()
@@ -492,16 +489,6 @@ fn build_entity_where(
             })
             .collect();
         conditions.push(format!("LOWER(name) IN ({})", placeholders.join(", ")));
-    }
-
-    if let Some(ref source) = filter.name_substring_of {
-        // ADR-104 Stage C CJK path: `name` is the needle, `source` (the raw
-        // query text) is the haystack — the reverse of a normal `LIKE`
-        // pattern match, so this cannot seek `idx_entities_name` at all. The
-        // caller bounds the cost with a small `PageRequest` limit and by
-        // scoping to a single namespace via the conditions above.
-        params.push(Box::new(source.to_lowercase()));
-        conditions.push(format!("INSTR(?{}, LOWER(name)) > 0", params.len()));
     }
 
     if !filter.tags_any.is_empty() {
@@ -642,13 +629,15 @@ impl EntityStore for SqlEntityStore {
         })?;
 
         self.with_reader("query_entities", move |conn| {
-            let (count_sql, count_params) = build_entity_where(&namespace, &filter);
-            let total: i64 = {
-                let sql = format!("SELECT COUNT(*) FROM entities{}", count_sql);
+            let total = if filter.names_ci.is_empty() {
+                let (count_sql, count_params) = build_entity_where(&namespace, &filter);
+                let sql = format!("SELECT COUNT(*) FROM entities{count_sql}");
                 let mut stmt = conn.prepare(&sql)?;
                 let param_refs: Vec<&dyn rusqlite::types::ToSql> =
                     count_params.iter().map(|p| p.as_ref()).collect();
-                stmt.query_row(param_refs.as_slice(), |row| row.get(0))?
+                Some(stmt.query_row(param_refs.as_slice(), |row| row.get::<_, i64>(0))? as u64)
+            } else {
+                None
             };
 
             let (where_sql, mut data_params) = build_entity_where(&namespace, &filter);
@@ -691,10 +680,7 @@ impl EntityStore for SqlEntityStore {
                 items.push(row?);
             }
 
-            Ok(Page {
-                items,
-                total: Some(total as u64),
-            })
+            Ok(Page { items, total })
         })
         .await
     }

--- a/crates/khive-db/src/stores/entity.rs
+++ b/crates/khive-db/src/stores/entity.rs
@@ -477,6 +477,33 @@ fn build_entity_where(
         conditions.push(format!("name = ?{} COLLATE BINARY", params.len()));
     }
 
+    if !filter.names_ci.is_empty() {
+        // ADR-104 Stage C, R1: one batched `LOWER(name) IN (...)` predicate,
+        // scoped by the `namespace`/`deleted_at IS NULL` conditions already
+        // pushed above — the composite `idx_entities_name (namespace, name)`
+        // index still seeks the namespace prefix, bounding the scan to that
+        // namespace's rows before this predicate is evaluated row-by-row.
+        let placeholders: Vec<String> = filter
+            .names_ci
+            .iter()
+            .map(|n| {
+                params.push(Box::new(n.to_lowercase()));
+                format!("?{}", params.len())
+            })
+            .collect();
+        conditions.push(format!("LOWER(name) IN ({})", placeholders.join(", ")));
+    }
+
+    if let Some(ref source) = filter.name_substring_of {
+        // ADR-104 Stage C CJK path: `name` is the needle, `source` (the raw
+        // query text) is the haystack — the reverse of a normal `LIKE`
+        // pattern match, so this cannot seek `idx_entities_name` at all. The
+        // caller bounds the cost with a small `PageRequest` limit and by
+        // scoping to a single namespace via the conditions above.
+        params.push(Box::new(source.to_lowercase()));
+        conditions.push(format!("INSTR(?{}, LOWER(name)) > 0", params.len()));
+    }
+
     if !filter.tags_any.is_empty() {
         let placeholders: Vec<String> = filter
             .tags_any

--- a/crates/khive-db/src/stores/entity.rs
+++ b/crates/khive-db/src/stores/entity.rs
@@ -663,12 +663,20 @@ impl EntityStore for SqlEntityStore {
             let limit_idx = data_params.len() - 1;
             let offset_idx = data_params.len();
 
-            let data_sql = format!(
-                "SELECT id, namespace, kind, entity_type, name, description, properties, tags, \
-                 created_at, updated_at, deleted_at, merged_into, merge_event_id \
-                 FROM entities{} ORDER BY {} LIMIT ?{} OFFSET ?{}",
-                where_sql, order_by, limit_idx, offset_idx,
-            );
+            let columns = "id, namespace, kind, entity_type, name, description, properties, tags, \
+                           created_at, updated_at, deleted_at, merged_into, merge_event_id";
+            let data_sql = if filter.names_ci.is_empty() {
+                format!(
+                    "SELECT {columns} FROM entities{where_sql} \
+                     ORDER BY {order_by} LIMIT ?{limit_idx} OFFSET ?{offset_idx}"
+                )
+            } else {
+                format!(
+                    "SELECT {columns} FROM entities{where_sql} \
+                     GROUP BY LOWER(name) \
+                     ORDER BY {order_by} LIMIT ?{limit_idx} OFFSET ?{offset_idx}"
+                )
+            };
 
             let mut stmt = conn.prepare(&data_sql)?;
             let param_refs: Vec<&dyn rusqlite::types::ToSql> =

--- a/crates/khive-db/src/stores/entity.rs
+++ b/crates/khive-db/src/stores/entity.rs
@@ -484,7 +484,7 @@ fn build_entity_where(
             .names_ci
             .iter()
             .map(|n| {
-                params.push(Box::new(n.to_lowercase()));
+                params.push(Box::new(n.clone()));
                 format!("?{}", params.len())
             })
             .collect();
@@ -643,7 +643,7 @@ impl EntityStore for SqlEntityStore {
             let (where_sql, mut data_params) = build_entity_where(&namespace, &filter);
 
             // #818: when a name_prefix filter is active, an exact
-            // case-insensitive match must never be pushed out of the page by
+            // ASCII-case-insensitive match must never be pushed out of the page by
             // pattern candidates that merely share the prefix. Rank exact
             // matches first (deterministic tiebreak via created_at) so page
             // truncation can never hide the record a caller resolved by name.

--- a/crates/khive-db/src/stores/entity.rs
+++ b/crates/khive-db/src/stores/entity.rs
@@ -484,7 +484,7 @@ fn build_entity_where(
             .names_ci
             .iter()
             .map(|n| {
-                params.push(Box::new(n.clone()));
+                params.push(Box::new(n.to_ascii_lowercase()));
                 format!("?{}", params.len())
             })
             .collect();

--- a/crates/khive-db/src/stores/entity.rs
+++ b/crates/khive-db/src/stores/entity.rs
@@ -512,6 +512,34 @@ fn build_entity_where(
     (clause, params)
 }
 
+fn build_candidate_entity_query(
+    columns: &str,
+    where_sql: &str,
+    candidate_param_indices: &[usize],
+    order_by: &str,
+    limit_idx: usize,
+    offset_idx: usize,
+) -> String {
+    let candidate_rows = candidate_param_indices
+        .iter()
+        .map(|idx| format!("(?{idx})"))
+        .collect::<Vec<_>>()
+        .join(", ");
+
+    format!(
+        "WITH candidates(folded_name) AS (VALUES {candidate_rows}), \
+         matched_entities(entity_id) AS (\
+             SELECT (\
+                 SELECT id FROM entities{where_sql} \
+                 AND LOWER(name) = candidates.folded_name LIMIT 1\
+             ) FROM candidates\
+         ) \
+         SELECT {columns} FROM entities \
+         JOIN matched_entities ON entities.id = matched_entities.entity_id \
+         ORDER BY {order_by} LIMIT ?{limit_idx} OFFSET ?{offset_idx}"
+    )
+}
+
 // =============================================================================
 // EntityStore implementation
 // =============================================================================
@@ -640,7 +668,33 @@ impl EntityStore for SqlEntityStore {
                 None
             };
 
-            let (where_sql, mut data_params) = build_entity_where(&namespace, &filter);
+            let mut lookup_filter = filter.clone();
+            lookup_filter.names_ci.clear();
+            let effective_filter = if filter.names_ci.is_empty() {
+                &filter
+            } else {
+                &lookup_filter
+            };
+            let (where_sql, mut data_params) = build_entity_where(&namespace, effective_filter);
+
+            let candidate_param_indices = if filter.names_ci.is_empty() {
+                Vec::new()
+            } else {
+                let mut candidates: Vec<String> = filter
+                    .names_ci
+                    .iter()
+                    .map(|name| name.to_ascii_lowercase())
+                    .collect();
+                candidates.sort_unstable();
+                candidates.dedup();
+                candidates
+                    .into_iter()
+                    .map(|candidate| {
+                        data_params.push(Box::new(candidate));
+                        data_params.len()
+                    })
+                    .collect()
+            };
 
             // #818: when a name_prefix filter is active, an exact
             // ASCII-case-insensitive match must never be pushed out of the page by
@@ -671,10 +725,13 @@ impl EntityStore for SqlEntityStore {
                      ORDER BY {order_by} LIMIT ?{limit_idx} OFFSET ?{offset_idx}"
                 )
             } else {
-                format!(
-                    "SELECT {columns} FROM entities{where_sql} \
-                     GROUP BY LOWER(name) \
-                     ORDER BY {order_by} LIMIT ?{limit_idx} OFFSET ?{offset_idx}"
+                build_candidate_entity_query(
+                    columns,
+                    &where_sql,
+                    &candidate_param_indices,
+                    &order_by,
+                    limit_idx,
+                    offset_idx,
                 )
             };
 

--- a/crates/khive-db/src/stores/entity_tests.rs
+++ b/crates/khive-db/src/stores/entity_tests.rs
@@ -60,6 +60,7 @@ fn case_insensitive_candidate_lookup_uses_expression_index() {
     let offset_idx = params.len();
     let sql = format!(
         "EXPLAIN QUERY PLAN SELECT id FROM entities{where_sql} \
+         GROUP BY LOWER(name) \
          ORDER BY created_at DESC LIMIT ?{limit_idx} OFFSET ?{offset_idx}"
     );
     let mut stmt = conn.prepare(&sql).unwrap();
@@ -111,6 +112,46 @@ async fn case_insensitive_candidate_lookup_skips_unbounded_total_count() {
     assert_eq!(page.items.len(), 1);
     assert_eq!(page.items[0].name, "LoRA");
     assert_eq!(page.total, None);
+}
+
+#[tokio::test]
+async fn case_insensitive_candidate_lookup_caps_folded_names_not_duplicate_rows() {
+    let store = setup_memory_store();
+    let mut older_b = make_entity("local", "concept", "crowdbeta");
+    older_b.created_at = 1;
+    older_b.updated_at = 1;
+    store.upsert_entity(older_b).await.unwrap();
+
+    for created_at in 2..=258 {
+        let mut newer_a = make_entity("local", "concept", "CrowdAlpha");
+        newer_a.created_at = created_at;
+        newer_a.updated_at = created_at;
+        store.upsert_entity(newer_a).await.unwrap();
+    }
+
+    let page = store
+        .query_entities(
+            "local",
+            EntityFilter {
+                names_ci: vec!["crowdalpha".to_string(), "crowdbeta".to_string()],
+                ..EntityFilter::default()
+            },
+            PageRequest {
+                limit: 256,
+                offset: 0,
+            },
+        )
+        .await
+        .unwrap();
+
+    let folded_names: Vec<String> = page
+        .items
+        .iter()
+        .map(|entity| entity.name.to_lowercase())
+        .collect();
+    assert_eq!(folded_names.len(), 2);
+    assert!(folded_names.contains(&"crowdalpha".to_string()));
+    assert!(folded_names.contains(&"crowdbeta".to_string()));
 }
 
 #[tokio::test]

--- a/crates/khive-db/src/stores/entity_tests.rs
+++ b/crates/khive-db/src/stores/entity_tests.rs
@@ -45,7 +45,7 @@ fn make_entity(namespace: &str, kind: &str, name: &str) -> Entity {
 }
 
 #[test]
-fn case_insensitive_candidate_lookup_uses_expression_index() {
+fn case_insensitive_candidate_lookup_uses_one_partial_index_seek_per_candidate() {
     let mut conn = rusqlite::Connection::open_in_memory().unwrap();
     run_migrations(&mut conn).unwrap();
 
@@ -53,16 +53,34 @@ fn case_insensitive_candidate_lookup_uses_expression_index() {
         names_ci: vec!["lora".to_string(), "北京大学".to_string()],
         ..EntityFilter::default()
     };
-    let (where_sql, mut params) = build_entity_where("local", &filter);
+    let mut lookup_filter = filter.clone();
+    lookup_filter.names_ci.clear();
+    let (where_sql, mut params) = build_entity_where("local", &lookup_filter);
+    let candidate_param_indices: Vec<usize> = filter
+        .names_ci
+        .iter()
+        .map(|candidate| {
+            params.push(Box::new(candidate.to_ascii_lowercase()));
+            params.len()
+        })
+        .collect();
     params.push(Box::new(64_i64));
     params.push(Box::new(0_i64));
     let limit_idx = params.len() - 1;
     let offset_idx = params.len();
-    let sql = format!(
-        "EXPLAIN QUERY PLAN SELECT id FROM entities{where_sql} \
-         GROUP BY LOWER(name) \
-         ORDER BY created_at DESC LIMIT ?{limit_idx} OFFSET ?{offset_idx}"
+    let data_sql = build_candidate_entity_query(
+        "id",
+        &where_sql,
+        &candidate_param_indices,
+        "created_at DESC",
+        limit_idx,
+        offset_idx,
     );
+    assert!(!data_sql.contains("GROUP BY"));
+    assert!(data_sql.contains("FROM candidates"));
+    assert!(data_sql.contains("LIMIT 1"));
+
+    let sql = format!("EXPLAIN QUERY PLAN {data_sql}");
     let mut stmt = conn.prepare(&sql).unwrap();
     let param_refs: Vec<&dyn rusqlite::types::ToSql> =
         params.iter().map(|param| param.as_ref()).collect();
@@ -79,10 +97,29 @@ fn case_insensitive_candidate_lookup_uses_expression_index() {
         "candidate lookup must seek the case-insensitive expression index: {details:?}"
     );
     assert!(
+        details
+            .iter()
+            .any(|detail| detail.contains("CORRELATED SCALAR SUBQUERY")),
+        "candidate relation must drive one scalar lookup per name: {details:?}"
+    );
+    assert!(
         !details
             .iter()
             .any(|detail| detail.contains("SCAN entities")),
         "candidate lookup must not scan entities: {details:?}"
+    );
+
+    let index_sql: String = conn
+        .query_row(
+            "SELECT sql FROM sqlite_master \
+             WHERE type = 'index' AND name = 'idx_entities_namespace_name_ci'",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert!(
+        index_sql.contains("WHERE deleted_at IS NULL"),
+        "candidate lookup index must exclude tombstones: {index_sql}"
     );
 }
 
@@ -133,7 +170,11 @@ async fn case_insensitive_candidate_lookup_caps_folded_names_not_duplicate_rows(
         .query_entities(
             "local",
             EntityFilter {
-                names_ci: vec!["crowdalpha".to_string(), "crowdbeta".to_string()],
+                names_ci: vec![
+                    "CrowdAlpha".to_string(),
+                    "crowdalpha".to_string(),
+                    "crowdbeta".to_string(),
+                ],
                 ..EntityFilter::default()
             },
             PageRequest {

--- a/crates/khive-db/src/stores/entity_tests.rs
+++ b/crates/khive-db/src/stores/entity_tests.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::migrations::run_migrations;
 use crate::pool::PoolConfig;
 use std::time::Duration;
 use tokio::sync::oneshot;
@@ -41,6 +42,75 @@ fn make_entity(namespace: &str, kind: &str, name: &str) -> Entity {
         merged_into: None,
         merge_event_id: None,
     }
+}
+
+#[test]
+fn case_insensitive_candidate_lookup_uses_expression_index() {
+    let mut conn = rusqlite::Connection::open_in_memory().unwrap();
+    run_migrations(&mut conn).unwrap();
+
+    let filter = EntityFilter {
+        names_ci: vec!["lora".to_string(), "北京大学".to_string()],
+        ..EntityFilter::default()
+    };
+    let (where_sql, mut params) = build_entity_where("local", &filter);
+    params.push(Box::new(64_i64));
+    params.push(Box::new(0_i64));
+    let limit_idx = params.len() - 1;
+    let offset_idx = params.len();
+    let sql = format!(
+        "EXPLAIN QUERY PLAN SELECT id FROM entities{where_sql} \
+         ORDER BY created_at DESC LIMIT ?{limit_idx} OFFSET ?{offset_idx}"
+    );
+    let mut stmt = conn.prepare(&sql).unwrap();
+    let param_refs: Vec<&dyn rusqlite::types::ToSql> =
+        params.iter().map(|param| param.as_ref()).collect();
+    let details: Vec<String> = stmt
+        .query_map(param_refs.as_slice(), |row| row.get(3))
+        .unwrap()
+        .collect::<Result<_, _>>()
+        .unwrap();
+
+    assert!(
+        details.iter().any(|detail| {
+            detail.contains("SEARCH entities USING INDEX idx_entities_namespace_name_ci")
+        }),
+        "candidate lookup must seek the case-insensitive expression index: {details:?}"
+    );
+    assert!(
+        !details
+            .iter()
+            .any(|detail| detail.contains("SCAN entities")),
+        "candidate lookup must not scan entities: {details:?}"
+    );
+}
+
+#[tokio::test]
+async fn case_insensitive_candidate_lookup_skips_unbounded_total_count() {
+    let store = setup_memory_store();
+    store
+        .upsert_entity(make_entity("local", "concept", "LoRA"))
+        .await
+        .unwrap();
+
+    let page = store
+        .query_entities(
+            "local",
+            EntityFilter {
+                names_ci: vec!["lora".to_string()],
+                ..EntityFilter::default()
+            },
+            PageRequest {
+                limit: 64,
+                offset: 0,
+            },
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(page.items.len(), 1);
+    assert_eq!(page.items[0].name, "LoRA");
+    assert_eq!(page.total, None);
 }
 
 #[tokio::test]

--- a/crates/khive-db/src/stores/entity_tests.rs
+++ b/crates/khive-db/src/stores/entity_tests.rs
@@ -503,6 +503,28 @@ async fn test_count_entities() {
 }
 
 #[tokio::test]
+async fn count_entities_normalizes_case_insensitive_names() {
+    let store = setup_memory_store();
+    store
+        .upsert_entity(make_entity("local", "concept", "LoRA"))
+        .await
+        .unwrap();
+
+    let count = store
+        .count_entities(
+            "local",
+            EntityFilter {
+                names_ci: vec!["LORA".to_string()],
+                ..EntityFilter::default()
+            },
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(count, 1);
+}
+
+#[tokio::test]
 async fn test_batch_upsert() {
     let store = setup_memory_store_ns("batch_ns");
 

--- a/crates/khive-pack-memory/src/handlers/common.rs
+++ b/crates/khive-pack-memory/src/handlers/common.rs
@@ -16,9 +16,10 @@ use khive_runtime::{
 };
 use khive_score::DeterministicScore;
 use khive_storage::types::{
-    TextFilter, TextQueryMode, TextSearchHit, TextSearchRequest, VectorSearchHit,
+    PageRequest, TextFilter, TextQueryMode, TextSearchHit, TextSearchRequest, VectorSearchHit,
     VectorSearchRequest,
 };
+use khive_storage::EntityFilter;
 use khive_types::SubstrateKind;
 
 use crate::ann::{self, AnnKey};
@@ -686,6 +687,85 @@ pub(super) fn recall_text_terms_with_limit(query: &str, limit: usize) -> Vec<Str
 }
 
 impl MemoryPack {
+    /// ADR-104 §5 (Stage C): entity-anchored candidate extraction. A single,
+    /// namespace-scoped, batched lookup against the entity store's existing
+    /// `(namespace, name)` index — R1's "one batched indexed lookup per
+    /// recall, no unbounded per-recall scans of the entity table."
+    ///
+    /// Two paths, chosen by `contains_cjk` (unsegmented CJK text has no
+    /// whitespace to derive unigram/bigram candidates from):
+    /// - Latin path: `crate::scoring::entity_lookup_candidates` derives up to
+    ///   `MAX_ENTITY_LOOKUP_CANDIDATES` lowercased unigram/bigram strings
+    ///   from the query, then one `EntityFilter::names_ci` call resolves a
+    ///   `LOWER(name) IN (...)` match in a single SQL round trip.
+    /// - CJK path: one `EntityFilter::name_substring_of` call checks which
+    ///   known entity names occur as a substring of the raw query text,
+    ///   bounded by the `PageRequest` limit below.
+    ///
+    /// A candidate only survives this lookup by naming a real, non-deleted
+    /// entity in the caller's namespace — that match against a real record
+    /// is the precision-safe property the ADR-104 §5 rationale hangs on. A
+    /// storage-layer failure here degrades to no anchored candidates (never
+    /// fails the recall) — the caller still has `extract_entity_candidates`'s
+    /// capitalized-token fallback.
+    pub(super) async fn entity_anchored_candidates(
+        &self,
+        token: &NamespaceToken,
+        query: &str,
+    ) -> Result<Vec<String>, RuntimeError> {
+        let store = self.runtime.entities(token)?;
+        let namespace = token.namespace().as_str();
+
+        if crate::scoring::contains_cjk(query) {
+            let filter = EntityFilter {
+                name_substring_of: Some(query.to_string()),
+                ..EntityFilter::default()
+            };
+            let page = store
+                .query_entities(
+                    namespace,
+                    filter,
+                    PageRequest {
+                        limit: crate::scoring::MAX_ENTITY_LOOKUP_CANDIDATES as u32,
+                        offset: 0,
+                    },
+                )
+                .await?;
+            return Ok(page
+                .items
+                .into_iter()
+                .map(|e| e.name.to_lowercase())
+                .collect());
+        }
+
+        let candidates = crate::scoring::entity_lookup_candidates(query);
+        if candidates.is_empty() {
+            return Ok(Vec::new());
+        }
+        let filter = EntityFilter {
+            names_ci: candidates,
+            ..EntityFilter::default()
+        };
+        let page = store
+            .query_entities(
+                namespace,
+                filter,
+                // Bounded above `MAX_ENTITY_LOOKUP_CANDIDATES` candidates so
+                // multiple entities sharing a case-insensitive name cannot
+                // truncate a legitimate match out of the page.
+                PageRequest {
+                    limit: crate::scoring::MAX_ENTITY_LOOKUP_CANDIDATES as u32 * 4,
+                    offset: 0,
+                },
+            )
+            .await?;
+        Ok(page
+            .items
+            .into_iter()
+            .map(|e| e.name.to_lowercase())
+            .collect())
+    }
+
     #[allow(clippy::too_many_arguments)]
     pub(super) async fn collect_recall_text_hits(
         &self,

--- a/crates/khive-pack-memory/src/handlers/common.rs
+++ b/crates/khive-pack-memory/src/handlers/common.rs
@@ -693,10 +693,11 @@ impl MemoryPack {
     /// recall, no unbounded per-recall scans of the entity table."
     ///
     /// `crate::scoring::entity_lookup_candidates` derives up to
-    /// `MAX_ENTITY_LOOKUP_CANDIDATES` lowercased unigram, bigram, and bounded
-    /// CJK substring candidates. One `EntityFilter::names_ci` call resolves
-    /// them with an indexed `LOWER(name) IN (...)` match. The store skips the
-    /// separate count for this filter, so only the page-limited query runs.
+    /// `MAX_ENTITY_LOOKUP_CANDIDATES` raw and ASCII-lowercased unigram, bigram,
+    /// and bounded CJK substring candidates. One `EntityFilter::names_ci` call
+    /// resolves them with an indexed `LOWER(name) IN (...)` match. The store
+    /// skips the separate count for this filter, so only the page-limited
+    /// query runs.
     ///
     /// A candidate only survives this lookup by naming a real, non-deleted
     /// entity in the caller's namespace. That match against a real record
@@ -725,7 +726,7 @@ impl MemoryPack {
                 namespace,
                 filter,
                 // Bounded above `MAX_ENTITY_LOOKUP_CANDIDATES` candidates so
-                // multiple entities sharing a case-insensitive name cannot
+                // multiple entities sharing an ASCII-folded name cannot
                 // truncate a legitimate match out of the page.
                 PageRequest {
                     limit: crate::scoring::MAX_ENTITY_LOOKUP_CANDIDATES as u32 * 4,

--- a/crates/khive-pack-memory/src/handlers/common.rs
+++ b/crates/khive-pack-memory/src/handlers/common.rs
@@ -688,25 +688,21 @@ pub(super) fn recall_text_terms_with_limit(query: &str, limit: usize) -> Vec<Str
 
 impl MemoryPack {
     /// ADR-104 §5 (Stage C): entity-anchored candidate extraction. A single,
-    /// namespace-scoped, batched lookup against the entity store's existing
-    /// `(namespace, name)` index — R1's "one batched indexed lookup per
+    /// namespace-scoped, batched lookup against the entity store's
+    /// `(namespace, LOWER(name))` index. This satisfies R1's "one batched indexed lookup per
     /// recall, no unbounded per-recall scans of the entity table."
     ///
-    /// Two paths, chosen by `contains_cjk` (unsegmented CJK text has no
-    /// whitespace to derive unigram/bigram candidates from):
-    /// - Latin path: `crate::scoring::entity_lookup_candidates` derives up to
-    ///   `MAX_ENTITY_LOOKUP_CANDIDATES` lowercased unigram/bigram strings
-    ///   from the query, then one `EntityFilter::names_ci` call resolves a
-    ///   `LOWER(name) IN (...)` match in a single SQL round trip.
-    /// - CJK path: one `EntityFilter::name_substring_of` call checks which
-    ///   known entity names occur as a substring of the raw query text,
-    ///   bounded by the `PageRequest` limit below.
+    /// `crate::scoring::entity_lookup_candidates` derives up to
+    /// `MAX_ENTITY_LOOKUP_CANDIDATES` lowercased unigram, bigram, and bounded
+    /// CJK substring candidates. One `EntityFilter::names_ci` call resolves
+    /// them with an indexed `LOWER(name) IN (...)` match. The store skips the
+    /// separate count for this filter, so only the page-limited query runs.
     ///
     /// A candidate only survives this lookup by naming a real, non-deleted
-    /// entity in the caller's namespace — that match against a real record
+    /// entity in the caller's namespace. That match against a real record
     /// is the precision-safe property the ADR-104 §5 rationale hangs on. A
     /// storage-layer failure here degrades to no anchored candidates (never
-    /// fails the recall) — the caller still has `extract_entity_candidates`'s
+    /// fails the recall). The caller still has `extract_entity_candidates`'s
     /// capitalized-token fallback.
     pub(super) async fn entity_anchored_candidates(
         &self,
@@ -715,28 +711,6 @@ impl MemoryPack {
     ) -> Result<Vec<String>, RuntimeError> {
         let store = self.runtime.entities(token)?;
         let namespace = token.namespace().as_str();
-
-        if crate::scoring::contains_cjk(query) {
-            let filter = EntityFilter {
-                name_substring_of: Some(query.to_string()),
-                ..EntityFilter::default()
-            };
-            let page = store
-                .query_entities(
-                    namespace,
-                    filter,
-                    PageRequest {
-                        limit: crate::scoring::MAX_ENTITY_LOOKUP_CANDIDATES as u32,
-                        offset: 0,
-                    },
-                )
-                .await?;
-            return Ok(page
-                .items
-                .into_iter()
-                .map(|e| e.name.to_lowercase())
-                .collect());
-        }
 
         let candidates = crate::scoring::entity_lookup_candidates(query);
         if candidates.is_empty() {

--- a/crates/khive-pack-memory/src/handlers/common.rs
+++ b/crates/khive-pack-memory/src/handlers/common.rs
@@ -688,16 +688,16 @@ pub(super) fn recall_text_terms_with_limit(query: &str, limit: usize) -> Vec<Str
 
 impl MemoryPack {
     /// ADR-104 §5 (Stage C): entity-anchored candidate extraction. A single,
-    /// namespace-scoped, batched lookup against the entity store's
-    /// `(namespace, LOWER(name))` index. This satisfies R1's "one batched indexed lookup per
-    /// recall, no unbounded per-recall scans of the entity table."
+    /// namespace-scoped, batched lookup against the entity store's live-row
+    /// `(namespace, LOWER(name))` index. This satisfies R1's "one batched indexed
+    /// lookup per recall, no unbounded per-recall scans of the entity table."
     ///
     /// `crate::scoring::entity_lookup_candidates` derives up to
     /// `MAX_ENTITY_LOOKUP_CANDIDATES` raw and ASCII-lowercased unigram, bigram,
     /// and bounded CJK substring candidates. One `EntityFilter::names_ci` call
-    /// resolves them with an indexed `LOWER(name) IN (...)` match. The store
-    /// skips the separate count for this filter, so only the page-limited
-    /// query runs.
+    /// resolves a distinct candidate relation with one `LIMIT 1` index seek per
+    /// name. The store skips the separate count for this filter, so lookup work
+    /// is bounded by the 64-candidate input rather than matching entity rows.
     ///
     /// A candidate only survives this lookup by naming a real, non-deleted
     /// entity in the caller's namespace. That match against a real record
@@ -725,10 +725,8 @@ impl MemoryPack {
             .query_entities(
                 namespace,
                 filter,
-                // The store reduces duplicate folded names to one row before
-                // applying this bounded page cap.
                 PageRequest {
-                    limit: crate::scoring::MAX_ENTITY_LOOKUP_CANDIDATES as u32 * 4,
+                    limit: crate::scoring::MAX_ENTITY_LOOKUP_CANDIDATES as u32,
                     offset: 0,
                 },
             )

--- a/crates/khive-pack-memory/src/handlers/common.rs
+++ b/crates/khive-pack-memory/src/handlers/common.rs
@@ -725,9 +725,8 @@ impl MemoryPack {
             .query_entities(
                 namespace,
                 filter,
-                // Bounded above `MAX_ENTITY_LOOKUP_CANDIDATES` candidates so
-                // multiple entities sharing an ASCII-folded name cannot
-                // truncate a legitimate match out of the page.
+                // The store reduces duplicate folded names to one row before
+                // applying this bounded page cap.
                 PageRequest {
                     limit: crate::scoring::MAX_ENTITY_LOOKUP_CANDIDATES as u32 * 4,
                     offset: 0,

--- a/crates/khive-pack-memory/src/handlers/recall.rs
+++ b/crates/khive-pack-memory/src/handlers/recall.rs
@@ -401,9 +401,36 @@ impl MemoryPack {
         // caller didn't send the field at all. See `extract_entity_candidates`
         // for the extraction rule and why it's grounded in how `EntityMatch`
         // actually matches.
+        // ADR-104 §5 (Stage C): when the caller didn't supply `entity_names`
+        // at all, extend the #738 capitalized-token heuristic with a second,
+        // precision-safe source — query tokens/bigrams that case-insensitively
+        // name a real KG entity, resolved via one batched lookup
+        // (`entity_anchored_candidates`, R1). A lookup failure degrades to
+        // the capitalized-token list alone (never fails the recall); an
+        // explicit `entity_names` (including `Some([])`) still bypasses both
+        // sources entirely — #738 opt-out semantics unchanged.
         let entity_names: Vec<String> = match &p.entity_names {
             Some(names) => names.iter().map(|s| s.to_lowercase()).collect(),
-            None => extract_entity_candidates(query_trimmed),
+            None => {
+                let mut candidates = extract_entity_candidates(query_trimmed);
+                match self.entity_anchored_candidates(token, query_trimmed).await {
+                    Ok(anchored) => {
+                        for name in anchored {
+                            if !candidates.contains(&name) {
+                                candidates.push(name);
+                            }
+                        }
+                    }
+                    Err(e) => {
+                        tracing::warn!(
+                            error = %e,
+                            "ADR-104 §5: entity-anchored candidate lookup failed; \
+                             falling back to capitalized-token extraction only"
+                        );
+                    }
+                }
+                candidates
+            }
         };
 
         struct ScoredNote {
@@ -902,6 +929,7 @@ mod tests {
     use async_trait::async_trait;
     use khive_pack_kg::KgPack;
     use khive_runtime::{EmbedderProvider, KhiveRuntime, Namespace, VerbRegistryBuilder};
+    use khive_storage::Entity;
     use lattice_embed::{EmbedError, EmbeddingModel, EmbeddingService};
     use serde_json::Value;
     use serial_test::serial;
@@ -4367,5 +4395,204 @@ mod tests {
             "the bench-a target must still appear in at least one model's \
              recall_candidates breakdown after the namespace filter: {per_model:?}"
         );
+    }
+
+    // ── ADR-104 §5 (Stage C): entity-anchored candidate extraction ─────────────
+
+    /// Dispatches `memory.recall` against a fresh single-note corpus, exactly
+    /// like `dispatch_single_note_recall` above, but first seeds a real KG
+    /// entity (`entity_name`, when `Some`) directly into the entity store —
+    /// the record `entity_anchored_candidates` must find via its batched
+    /// lookup for the boost to fire on a lowercase or CJK query. Returns the
+    /// sole hit's `rank_score`.
+    async fn dispatch_single_note_recall_with_entity(
+        entity_name: Option<&str>,
+        content: &str,
+        query: &str,
+        entity_names: Option<&[&str]>,
+    ) -> f64 {
+        let rt = KhiveRuntime::memory().expect("in-memory runtime");
+        let ns = Namespace::parse("local").expect("local namespace");
+        let token = rt.authorize(ns.clone()).expect("authorize local");
+        rt.create_note(&token, "memory", None, content, Some(0.5), None, vec![])
+            .await
+            .expect("create note");
+
+        if let Some(name) = entity_name {
+            rt.entities(&token)
+                .expect("entity store")
+                .upsert_entity(Entity::new(ns.as_str(), "concept", name))
+                .await
+                .expect("seed entity");
+        }
+
+        let mut builder = VerbRegistryBuilder::new();
+        builder.register(KgPack::new(rt.clone()));
+        builder.register(MemoryPack::new(rt.clone()));
+        let registry = builder.build().expect("registry");
+
+        let mut params = serde_json::json!({
+            "query": query,
+            "fusion_strategy": "rrf",
+            "limit": 10
+        });
+        if let Some(names) = entity_names {
+            params["entity_names"] = serde_json::json!(names);
+        }
+
+        let result = registry
+            .dispatch("memory.recall", params)
+            .await
+            .expect("memory.recall");
+        let hits = result.as_array().expect("bare array result");
+        assert_eq!(hits.len(), 1, "single-note corpus must yield one hit");
+        hits[0]["rank_score"].as_f64().expect("rank_score")
+    }
+
+    /// Gate (a): a lowercase query naming a real KG entity gets the
+    /// candidate and the EntityMatch ×1.3 boost. `extract_entity_candidates`
+    /// (#738) extracts nothing here (no capitalized token in either the
+    /// query or the entity name) — the lift can only come from the Stage C
+    /// batched entity-anchored lookup finding the seeded "zenlake" entity.
+    #[tokio::test]
+    #[serial(background_tasks)]
+    async fn adr104_stage_c_lowercase_query_naming_real_entity_gets_boost() {
+        const CONTENT: &str = "the committee reviewed the proposal from zenlake last week";
+        const QUERY: &str = "committee proposal zenlake";
+
+        let anchored_score =
+            dispatch_single_note_recall_with_entity(Some("zenlake"), CONTENT, QUERY, None).await;
+        let opted_out_score =
+            dispatch_single_note_recall_with_entity(Some("zenlake"), CONTENT, QUERY, Some(&[]))
+                .await;
+
+        assert!(
+            anchored_score > opted_out_score,
+            "a lowercase query naming a real entity must be boosted above the \
+             explicit opt-out baseline: anchored={anchored_score} opted_out={opted_out_score}"
+        );
+        let ratio = anchored_score / opted_out_score;
+        assert!(
+            (ratio - 1.3).abs() < 0.01,
+            "expected ~1.3x lift from EntityMatch firing on the entity-anchored \
+             candidate, got ratio {ratio}"
+        );
+    }
+
+    /// Gate (b): an unsegmented CJK query containing a real entity name as a
+    /// substring gets it via `EntityFilter::name_substring_of`, not
+    /// whitespace tokenization (CJK text has no spaces to split on).
+    #[tokio::test]
+    #[serial(background_tasks)]
+    async fn adr104_stage_c_unsegmented_cjk_query_gets_entity_via_substring() {
+        const ENTITY_NAME: &str = "北京大学";
+        // `content` and `query` are byte-identical (guarantees the FTS leg
+        // retrieves the note; retrieval-stage relevance is not what this
+        // test is about) — a full-width comma, not ASCII whitespace,
+        // separates the entity name from the rest, so this is still the
+        // unsegmented-CJK shape (no ASCII whitespace anywhere) while giving
+        // `contains_at_word_boundary` a non-alphanumeric character on the
+        // entity name's left edge (its right edge is end-of-string).
+        const CONTENT: &str = "详情介绍，北京大学";
+        const QUERY: &str = "详情介绍，北京大学";
+
+        let anchored_score =
+            dispatch_single_note_recall_with_entity(Some(ENTITY_NAME), CONTENT, QUERY, None).await;
+        let opted_out_score =
+            dispatch_single_note_recall_with_entity(Some(ENTITY_NAME), CONTENT, QUERY, Some(&[]))
+                .await;
+
+        assert!(
+            anchored_score > opted_out_score,
+            "an unsegmented CJK query containing a real entity name must be \
+             boosted above the explicit opt-out baseline: anchored={anchored_score} \
+             opted_out={opted_out_score}"
+        );
+        let ratio = anchored_score / opted_out_score;
+        assert!(
+            (ratio - 1.3).abs() < 0.01,
+            "expected ~1.3x lift from EntityMatch firing on the CJK \
+             substring-anchored candidate, got ratio {ratio}"
+        );
+    }
+
+    /// Gate (c): a token that does not name any real entity gets nothing —
+    /// no lexical-overlap reward. Same lowercase shape as gate (a), but no
+    /// entity named "zenlake" (or anything else) exists in the store, so the
+    /// batched lookup returns no candidates and the auto path must score
+    /// identically to the explicit opt-out.
+    #[tokio::test]
+    #[serial(background_tasks)]
+    async fn adr104_stage_c_lowercase_token_naming_no_entity_gets_no_boost() {
+        const CONTENT: &str = "the committee reviewed the proposal from zenlake last week";
+        const QUERY: &str = "committee proposal zenlake";
+
+        let auto_score = dispatch_single_note_recall_with_entity(None, CONTENT, QUERY, None).await;
+        let opted_out_score =
+            dispatch_single_note_recall_with_entity(None, CONTENT, QUERY, Some(&[])).await;
+
+        assert!(
+            (auto_score - opted_out_score).abs() < 1e-4,
+            "no real entity named \"zenlake\" exists, so a lowercase query \
+             naming it must not be boosted: auto={auto_score} opted_out={opted_out_score}"
+        );
+    }
+
+    /// Gate (e): explicit `entity_names` still wins over Stage C extraction
+    /// even when a real, matching entity exists — and `entity_names: []`
+    /// stays a full opt-out. Mirrors the #738 override tests above, but with
+    /// a seeded entity in the store to prove Stage C's batched lookup is
+    /// bypassed entirely (not merely outscored) when the caller is explicit.
+    #[tokio::test]
+    #[serial(background_tasks)]
+    async fn adr104_stage_c_explicit_entity_names_still_win_over_anchored_extraction() {
+        const CONTENT: &str = "the committee reviewed the proposal from zenlake last week";
+        const QUERY: &str = "committee proposal zenlake";
+
+        let anchored_score =
+            dispatch_single_note_recall_with_entity(Some("zenlake"), CONTENT, QUERY, None).await;
+        let opted_out_score =
+            dispatch_single_note_recall_with_entity(Some("zenlake"), CONTENT, QUERY, Some(&[]))
+                .await;
+        let explicit_score = dispatch_single_note_recall_with_entity(
+            Some("zenlake"),
+            CONTENT,
+            QUERY,
+            Some(&["zenlake"]),
+        )
+        .await;
+
+        assert!(
+            (explicit_score - anchored_score).abs() < 1e-6,
+            "explicit entity_names=[\"zenlake\"] must reach the same boosted \
+             score as Stage C anchored extraction (both resolve to the same \
+             single candidate here): explicit={explicit_score} anchored={anchored_score}"
+        );
+        assert!(
+            (explicit_score - opted_out_score).abs() > 1e-6,
+            "explicit non-empty entity_names must still be honored (boosted \
+             above the opt-out baseline): explicit={explicit_score} opted_out={opted_out_score}"
+        );
+    }
+
+    /// `entity_lookup_candidates` unit coverage (pure function, ADR-104 §5):
+    /// unigrams and adjacent bigrams, lowercased, stopwords excluded from
+    /// unigrams, capped at `MAX_ENTITY_LOOKUP_CANDIDATES`.
+    #[test]
+    fn entity_lookup_candidates_extracts_unigrams_and_bigrams_lowercased() {
+        let out = crate::scoring::entity_lookup_candidates("New York City guide");
+        assert!(out.contains(&"new".to_string()));
+        assert!(out.contains(&"york".to_string()));
+        assert!(out.contains(&"city".to_string()));
+        assert!(out.contains(&"guide".to_string()));
+        assert!(out.contains(&"new york".to_string()));
+        assert!(out.contains(&"york city".to_string()));
+        assert!(out.contains(&"city guide".to_string()));
+    }
+
+    #[test]
+    fn entity_lookup_candidates_empty_query_returns_empty() {
+        assert!(crate::scoring::entity_lookup_candidates("").is_empty());
+        assert!(crate::scoring::entity_lookup_candidates("   ").is_empty());
     }
 }

--- a/crates/khive-pack-memory/src/handlers/recall.rs
+++ b/crates/khive-pack-memory/src/handlers/recall.rs
@@ -4545,18 +4545,23 @@ mod tests {
     #[tokio::test]
     #[serial(background_tasks)]
     async fn adr104_stage_c_late_cjk_entity_survives_candidate_cap() {
-        const ENTITY_NAME: &str = "終点";
-        const QUERY: &str = "天地玄黄宇宙洪荒日月盈昃辰宿列張寒来暑往秋収冬蔵終点";
+        const ENTITY_NAME: &str = "龍鳳凰";
+        let mut query: String = (0..62)
+            .map(|offset| char::from_u32(0x4e00 + offset).expect("valid CJK character"))
+            .collect();
+        query.push_str(ENTITY_NAME);
+        assert_eq!(query.chars().count(), 65);
 
         let anchored_score =
-            dispatch_single_note_recall_with_entity(Some(ENTITY_NAME), QUERY, QUERY, None).await;
+            dispatch_single_note_recall_with_entity(Some(ENTITY_NAME), &query, &query, None).await;
         let opted_out_score =
-            dispatch_single_note_recall_with_entity(Some(ENTITY_NAME), QUERY, QUERY, Some(&[]))
+            dispatch_single_note_recall_with_entity(Some(ENTITY_NAME), &query, &query, Some(&[]))
                 .await;
 
         assert!(
             anchored_score > opted_out_score,
-            "a CJK entity near the end of a long unsegmented query must survive the candidate cap: \
+            "a CJK entity in the final 10 characters of a 65-character unsegmented query must \
+             survive the candidate cap: \
              anchored={anchored_score} opted_out={opted_out_score}"
         );
     }

--- a/crates/khive-pack-memory/src/handlers/recall.rs
+++ b/crates/khive-pack-memory/src/handlers/recall.rs
@@ -4668,8 +4668,9 @@ mod tests {
     }
 
     /// `entity_lookup_candidates` unit coverage (pure function, ADR-104 §5):
-    /// raw and ASCII-lowercased unigrams and adjacent bigrams, stopwords
-    /// excluded from unigrams, capped at `MAX_ENTITY_LOOKUP_CANDIDATES`.
+    /// ASCII-only candidates are lowercased, candidates containing non-ASCII
+    /// characters also retain their raw form, stopwords are excluded from
+    /// unigrams, and output is capped at `MAX_ENTITY_LOOKUP_CANDIDATES`.
     #[test]
     fn entity_lookup_candidates_extracts_unigrams_and_bigrams_lowercased() {
         let out = crate::scoring::entity_lookup_candidates("New York City guide");
@@ -4714,22 +4715,28 @@ mod tests {
 
     #[tokio::test]
     #[serial(background_tasks)]
-    async fn adr104_stage_c_long_query_preserves_adjacent_bigram_entity() {
+    async fn adr104_stage_c_long_query_preserves_adjacent_bigram_entity_for_ascii_case() {
         const ENTITY_NAME: &str = "silver comet";
-        const QUERY: &str = "alpha bravo charlie delta echo foxtrot golf hotel india juliet kilo \
-                             lima mike november oscar silver comet";
+        const LOWERCASE_QUERY: &str = "alpha bravo charlie delta echo foxtrot golf hotel india \
+                                      juliet kilo lima mike november oscar papa silver comet";
+        const TITLE_CASE_QUERY: &str = "Alpha Bravo Charlie Delta Echo Foxtrot Golf Hotel India \
+                                       Juliet Kilo Lima Mike November Oscar Papa Silver Comet";
 
-        let anchored_score =
-            dispatch_single_note_recall_with_entity(Some(ENTITY_NAME), QUERY, QUERY, None).await;
-        let opted_out_score =
-            dispatch_single_note_recall_with_entity(Some(ENTITY_NAME), QUERY, QUERY, Some(&[]))
-                .await;
+        for query in [LOWERCASE_QUERY, TITLE_CASE_QUERY] {
+            let anchored_score =
+                dispatch_single_note_recall_with_entity(Some(ENTITY_NAME), query, query, None)
+                    .await;
+            let opted_out_score =
+                dispatch_single_note_recall_with_entity(Some(ENTITY_NAME), query, query, Some(&[]))
+                    .await;
 
-        assert!(
-            anchored_score > opted_out_score,
-            "a 17-token query must retain its final adjacent bigram entity: \
-             anchored={anchored_score} opted_out={opted_out_score}"
-        );
+            assert!(
+                anchored_score > opted_out_score,
+                "an 18-token query must retain and match its final adjacent bigram entity \
+                 regardless of ASCII case: query={query:?} anchored={anchored_score} \
+                 opted_out={opted_out_score}"
+            );
+        }
     }
 
     #[test]

--- a/crates/khive-pack-memory/src/handlers/recall.rs
+++ b/crates/khive-pack-memory/src/handlers/recall.rs
@@ -4482,6 +4482,66 @@ mod tests {
 
     #[tokio::test]
     #[serial(background_tasks)]
+    async fn adr104_stage_c_duplicate_name_crowding_preserves_each_candidate_boost() {
+        let rt = KhiveRuntime::memory().expect("in-memory runtime");
+        let ns = Namespace::parse("local").expect("local namespace");
+        let token = rt.authorize(ns.clone()).expect("authorize local");
+        let store = rt.entities(&token).expect("entity store");
+
+        let mut older_b = Entity::new(ns.as_str(), "concept", "crowdbeta");
+        older_b.created_at = 1;
+        older_b.updated_at = 1;
+        store
+            .upsert_entity(older_b)
+            .await
+            .expect("seed candidate B");
+
+        for created_at in 2..=258 {
+            let mut newer_a = Entity::new(ns.as_str(), "concept", "CrowdAlpha");
+            newer_a.created_at = created_at;
+            newer_a.updated_at = created_at;
+            store
+                .upsert_entity(newer_a)
+                .await
+                .expect("seed duplicate candidate A");
+        }
+
+        let anchored = MemoryPack::new(rt)
+            .entity_anchored_candidates(&token, "crowdalpha crowdbeta")
+            .await
+            .expect("Stage C lookup");
+        assert!(anchored.contains(&"crowdalpha".to_string()));
+        assert!(anchored.contains(&"crowdbeta".to_string()));
+
+        let baseline_names = vec!["crowdalpha".to_string()];
+        let now_millis = chrono::Utc::now().timestamp_millis();
+        let score = |entity_names: &[String]| {
+            crate::scoring::calculate_score(
+                &crate::scoring::ScoreInput {
+                    salience: 0.5,
+                    memory_type_str: "semantic",
+                    content: "the archive concerns crowdbeta",
+                    created_at_millis: now_millis,
+                    decay_factor: 0.005,
+                    now_millis,
+                    relevance_score: 0.2,
+                    entity_names,
+                },
+                &crate::scoring::ScoringConfig::default(),
+            )
+        };
+        let boosted = score(&anchored);
+        let baseline = score(&baseline_names);
+        assert!(boosted > baseline);
+        assert!(
+            (boosted / baseline - 1.3).abs() < 0.01,
+            "candidate B must retain its EntityMatch boost after candidate A duplicate crowding: \
+             boosted={boosted} baseline={baseline}"
+        );
+    }
+
+    #[tokio::test]
+    #[serial(background_tasks)]
     async fn adr104_stage_c_non_ascii_case_lookup_end_to_end_is_bounded() {
         let rt = KhiveRuntime::memory().expect("in-memory runtime");
         let ns = Namespace::parse("local").expect("local namespace");

--- a/crates/khive-pack-memory/src/handlers/recall.rs
+++ b/crates/khive-pack-memory/src/handlers/recall.rs
@@ -403,8 +403,9 @@ impl MemoryPack {
         // actually matches.
         // ADR-104 §5 (Stage C): when the caller didn't supply `entity_names`
         // at all, extend the #738 capitalized-token heuristic with a second,
-        // precision-safe source: query tokens/bigrams that case-insensitively
-        // name a real KG entity, resolved via one batched lookup
+        // precision-safe source: query tokens/bigrams that match a real KG
+        // entity name under the bounded Stage C case contract, resolved via
+        // one batched lookup
         // (`entity_anchored_candidates`, R1). A lookup failure degrades to
         // the capitalized-token list alone (never fails the recall); an
         // explicit `entity_names` (including `Some([])`) still bypasses both
@@ -4479,6 +4480,34 @@ mod tests {
         );
     }
 
+    #[tokio::test]
+    #[serial(background_tasks)]
+    async fn adr104_stage_c_non_ascii_case_lookup_end_to_end_is_bounded() {
+        let rt = KhiveRuntime::memory().expect("in-memory runtime");
+        let ns = Namespace::parse("local").expect("local namespace");
+        let token = rt.authorize(ns.clone()).expect("authorize local");
+        rt.entities(&token)
+            .expect("entity store")
+            .upsert_entity(Entity::new(ns.as_str(), "concept", "École"))
+            .await
+            .expect("seed entity");
+        let pack = MemoryPack::new(rt);
+
+        let same_spelling = pack
+            .entity_anchored_candidates(&token, "École research archive")
+            .await
+            .expect("same-spelling extraction");
+        let different_case = pack
+            .entity_anchored_candidates(&token, "école research archive")
+            .await
+            .expect("differently-cased extraction");
+
+        // Bounded contract: ASCII is case-insensitive, but cased non-ASCII
+        // characters require the exact form used by the stored entity name.
+        assert_eq!(same_spelling, vec!["école"]);
+        assert!(different_case.is_empty());
+    }
+
     /// Gate (b): an unsegmented CJK query containing a real entity name as a
     /// substring gets it through bounded substring enumeration and the same
     /// indexed exact-name lookup used by alphabetic-script candidates.
@@ -4510,6 +4539,44 @@ mod tests {
             (ratio - 1.3).abs() < 0.01,
             "expected ~1.3x lift from EntityMatch firing on the CJK \
              substring-anchored candidate, got ratio {ratio}"
+        );
+    }
+
+    #[tokio::test]
+    #[serial(background_tasks)]
+    async fn adr104_stage_c_late_cjk_entity_survives_candidate_cap() {
+        const ENTITY_NAME: &str = "終点";
+        const QUERY: &str = "天地玄黄宇宙洪荒日月盈昃辰宿列張寒来暑往秋収冬蔵終点";
+
+        let anchored_score =
+            dispatch_single_note_recall_with_entity(Some(ENTITY_NAME), QUERY, QUERY, None).await;
+        let opted_out_score =
+            dispatch_single_note_recall_with_entity(Some(ENTITY_NAME), QUERY, QUERY, Some(&[]))
+                .await;
+
+        assert!(
+            anchored_score > opted_out_score,
+            "a CJK entity near the end of a long unsegmented query must survive the candidate cap: \
+             anchored={anchored_score} opted_out={opted_out_score}"
+        );
+    }
+
+    #[tokio::test]
+    #[serial(background_tasks)]
+    async fn adr104_stage_c_eight_character_cjk_entity_matches() {
+        const ENTITY_NAME: &str = "甲乙丙丁戊己庚辛";
+        const QUERY: &str = "甲乙丙丁戊己庚辛";
+
+        let anchored_score =
+            dispatch_single_note_recall_with_entity(Some(ENTITY_NAME), QUERY, QUERY, None).await;
+        let opted_out_score =
+            dispatch_single_note_recall_with_entity(Some(ENTITY_NAME), QUERY, QUERY, Some(&[]))
+                .await;
+
+        assert!(
+            anchored_score > opted_out_score,
+            "an eight-character CJK entity must match at the documented maximum: \
+             anchored={anchored_score} opted_out={opted_out_score}"
         );
     }
 
@@ -4573,8 +4640,8 @@ mod tests {
     }
 
     /// `entity_lookup_candidates` unit coverage (pure function, ADR-104 §5):
-    /// unigrams and adjacent bigrams, lowercased, stopwords excluded from
-    /// unigrams, capped at `MAX_ENTITY_LOOKUP_CANDIDATES`.
+    /// raw and ASCII-lowercased unigrams and adjacent bigrams, stopwords
+    /// excluded from unigrams, capped at `MAX_ENTITY_LOOKUP_CANDIDATES`.
     #[test]
     fn entity_lookup_candidates_extracts_unigrams_and_bigrams_lowercased() {
         let out = crate::scoring::entity_lookup_candidates("New York City guide");
@@ -4585,6 +4652,14 @@ mod tests {
         assert!(out.contains(&"new york".to_string()));
         assert!(out.contains(&"york city".to_string()));
         assert!(out.contains(&"city guide".to_string()));
+    }
+
+    #[test]
+    fn entity_lookup_candidates_preserves_raw_non_ascii_case() {
+        let out = crate::scoring::entity_lookup_candidates("ÉCOLE Research");
+        assert!(out.contains(&"ÉCOLE".to_string()));
+        assert!(out.contains(&"École".to_string()));
+        assert!(!out.contains(&"école".to_string()));
     }
 
     #[test]

--- a/crates/khive-pack-memory/src/handlers/recall.rs
+++ b/crates/khive-pack-memory/src/handlers/recall.rs
@@ -4568,6 +4568,29 @@ mod tests {
 
     #[tokio::test]
     #[serial(background_tasks)]
+    async fn adr104_stage_c_first_cjk_entity_survives_candidate_cap() {
+        let query: String = (0..20)
+            .map(|offset| char::from_u32(0x4e00 + offset).expect("valid CJK character"))
+            .collect();
+        let entity_name: String = query.chars().take(2).collect();
+        assert_eq!(query.chars().count(), 20);
+
+        let anchored_score =
+            dispatch_single_note_recall_with_entity(Some(&entity_name), &query, &query, None).await;
+        let opted_out_score =
+            dispatch_single_note_recall_with_entity(Some(&entity_name), &query, &query, Some(&[]))
+                .await;
+
+        assert!(
+            anchored_score > opted_out_score,
+            "a CJK entity in the first two characters of a 20-character unsegmented query must \
+             survive the candidate cap: \
+             anchored={anchored_score} opted_out={opted_out_score}"
+        );
+    }
+
+    #[tokio::test]
+    #[serial(background_tasks)]
     async fn adr104_stage_c_eight_character_cjk_entity_matches() {
         const ENTITY_NAME: &str = "甲乙丙丁戊己庚辛";
         const QUERY: &str = "甲乙丙丁戊己庚辛";
@@ -4673,6 +4696,20 @@ mod tests {
         assert!(out.contains(&"北京大学".to_string()));
         assert!(!out.iter().any(|candidate| candidate.chars().count() == 1));
         assert!(out.iter().all(|candidate| candidate.chars().count() <= 8));
+    }
+
+    #[test]
+    fn entity_lookup_candidates_samples_both_cjk_endpoints() {
+        let query: String = (0..20)
+            .map(|offset| char::from_u32(0x4e00 + offset).expect("valid CJK character"))
+            .collect();
+        let first_bigram: String = query.chars().take(2).collect();
+        let final_bigram: String = query.chars().skip(18).collect();
+
+        let out = crate::scoring::entity_lookup_candidates(&query);
+
+        assert!(out.contains(&first_bigram));
+        assert!(out.contains(&final_bigram));
     }
 
     #[tokio::test]

--- a/crates/khive-pack-memory/src/handlers/recall.rs
+++ b/crates/khive-pack-memory/src/handlers/recall.rs
@@ -394,7 +394,7 @@ impl MemoryPack {
         // `entity_names` feeds the `EntityMatch` ×1.3 boost in `default_adjustments`
         // (scoring.rs). It used to be purely caller-supplied and no caller ever
         // populated it, leaving the boost dead code in practice. Opt-out
-        // semantics: `Some(_)` — including `Some([])` — is explicit caller
+        // semantics: `Some(_)`, including `Some([])`, is explicit caller
         // intent and is always honored verbatim (an empty explicit list means
         // "no entity boost", not "auto-derive one for me"). Auto-extraction
         // via `extract_entity_candidates` only runs on `None`, i.e. when the
@@ -403,12 +403,12 @@ impl MemoryPack {
         // actually matches.
         // ADR-104 §5 (Stage C): when the caller didn't supply `entity_names`
         // at all, extend the #738 capitalized-token heuristic with a second,
-        // precision-safe source — query tokens/bigrams that case-insensitively
+        // precision-safe source: query tokens/bigrams that case-insensitively
         // name a real KG entity, resolved via one batched lookup
         // (`entity_anchored_candidates`, R1). A lookup failure degrades to
         // the capitalized-token list alone (never fails the recall); an
         // explicit `entity_names` (including `Some([])`) still bypasses both
-        // sources entirely — #738 opt-out semantics unchanged.
+        // sources entirely. #738 opt-out semantics are unchanged.
         let entity_names: Vec<String> = match &p.entity_names {
             Some(names) => names.iter().map(|s| s.to_lowercase()).collect(),
             None => {
@@ -4401,7 +4401,7 @@ mod tests {
 
     /// Dispatches `memory.recall` against a fresh single-note corpus, exactly
     /// like `dispatch_single_note_recall` above, but first seeds a real KG
-    /// entity (`entity_name`, when `Some`) directly into the entity store —
+    /// entity (`entity_name`, when `Some`) directly into the entity store.
     /// the record `entity_anchored_candidates` must find via its batched
     /// lookup for the boost to fire on a lowercase or CJK query. Returns the
     /// sole hit's `rank_score`.
@@ -4452,7 +4452,7 @@ mod tests {
     /// Gate (a): a lowercase query naming a real KG entity gets the
     /// candidate and the EntityMatch ×1.3 boost. `extract_entity_candidates`
     /// (#738) extracts nothing here (no capitalized token in either the
-    /// query or the entity name) — the lift can only come from the Stage C
+    /// query or the entity name). The lift can only come from the Stage C
     /// batched entity-anchored lookup finding the seeded "zenlake" entity.
     #[tokio::test]
     #[serial(background_tasks)]
@@ -4480,21 +4480,18 @@ mod tests {
     }
 
     /// Gate (b): an unsegmented CJK query containing a real entity name as a
-    /// substring gets it via `EntityFilter::name_substring_of`, not
-    /// whitespace tokenization (CJK text has no spaces to split on).
+    /// substring gets it through bounded substring enumeration and the same
+    /// indexed exact-name lookup used by alphabetic-script candidates.
     #[tokio::test]
     #[serial(background_tasks)]
     async fn adr104_stage_c_unsegmented_cjk_query_gets_entity_via_substring() {
         const ENTITY_NAME: &str = "北京大学";
         // `content` and `query` are byte-identical (guarantees the FTS leg
         // retrieves the note; retrieval-stage relevance is not what this
-        // test is about) — a full-width comma, not ASCII whitespace,
-        // separates the entity name from the rest, so this is still the
-        // unsegmented-CJK shape (no ASCII whitespace anywhere) while giving
-        // `contains_at_word_boundary` a non-alphanumeric character on the
-        // entity name's left edge (its right edge is end-of-string).
-        const CONTENT: &str = "详情介绍，北京大学";
-        const QUERY: &str = "详情介绍，北京大学";
+        // test is about). The entity has Han characters on both sides, proving
+        // CJK entity matching does not require whitespace or punctuation.
+        const CONTENT: &str = "我在北京大学学习";
+        const QUERY: &str = "我在北京大学学习";
 
         let anchored_score =
             dispatch_single_note_recall_with_entity(Some(ENTITY_NAME), CONTENT, QUERY, None).await;
@@ -4516,7 +4513,7 @@ mod tests {
         );
     }
 
-    /// Gate (c): a token that does not name any real entity gets nothing —
+    /// Gate (c): a token that does not name any real entity gets nothing,
     /// no lexical-overlap reward. Same lowercase shape as gate (a), but no
     /// entity named "zenlake" (or anything else) exists in the store, so the
     /// batched lookup returns no candidates and the auto path must score
@@ -4539,7 +4536,7 @@ mod tests {
     }
 
     /// Gate (e): explicit `entity_names` still wins over Stage C extraction
-    /// even when a real, matching entity exists — and `entity_names: []`
+    /// even when a real, matching entity exists, and `entity_names: []`
     /// stays a full opt-out. Mirrors the #738 override tests above, but with
     /// a seeded entity in the store to prove Stage C's batched lookup is
     /// bypassed entirely (not merely outscored) when the caller is explicit.
@@ -4588,6 +4585,34 @@ mod tests {
         assert!(out.contains(&"new york".to_string()));
         assert!(out.contains(&"york city".to_string()));
         assert!(out.contains(&"city guide".to_string()));
+    }
+
+    #[test]
+    fn entity_lookup_candidates_enumerates_bounded_cjk_substrings() {
+        let out = crate::scoring::entity_lookup_candidates("我在北京大学学习");
+        assert!(out.contains(&"北京大学".to_string()));
+        assert!(!out.iter().any(|candidate| candidate.chars().count() == 1));
+        assert!(out.iter().all(|candidate| candidate.chars().count() <= 8));
+    }
+
+    #[tokio::test]
+    #[serial(background_tasks)]
+    async fn adr104_stage_c_long_query_preserves_adjacent_bigram_entity() {
+        const ENTITY_NAME: &str = "silver comet";
+        const QUERY: &str = "alpha bravo charlie delta echo foxtrot golf hotel india juliet kilo \
+                             lima mike november oscar silver comet";
+
+        let anchored_score =
+            dispatch_single_note_recall_with_entity(Some(ENTITY_NAME), QUERY, QUERY, None).await;
+        let opted_out_score =
+            dispatch_single_note_recall_with_entity(Some(ENTITY_NAME), QUERY, QUERY, Some(&[]))
+                .await;
+
+        assert!(
+            anchored_score > opted_out_score,
+            "a 17-token query must retain its final adjacent bigram entity: \
+             anchored={anchored_score} opted_out={opted_out_score}"
+        );
     }
 
     #[test]

--- a/crates/khive-pack-memory/src/scoring.rs
+++ b/crates/khive-pack-memory/src/scoring.rs
@@ -334,6 +334,62 @@ pub fn extract_entity_candidates(query: &str) -> Vec<String> {
     out
 }
 
+/// Maximum number of case-insensitive candidate strings (unigrams + adjacent
+/// bigrams) a single recall sends to the batched entity-name lookup
+/// (ADR-104 §5 / Stage C, rider R1). Bounds the `LOWER(name) IN (...)`
+/// placeholder list built in `khive-db`'s `build_entity_where` — independent
+/// of `MAX_AUTO_ENTITY_NAMES`, which bounds the unrelated capitalized-token
+/// fallback list above.
+pub const MAX_ENTITY_LOOKUP_CANDIDATES: usize = 16;
+
+/// Build the case-insensitive candidate strings a recall query offers to the
+/// entity-anchored lookup (ADR-104 §5 / Stage C): every non-stopword token,
+/// lowercased, plus every adjacent-token bigram (also lowercased, stopwords
+/// included — a two-token phrase is unlikely to itself be a stopword pair,
+/// and the real-entity-name check downstream is the safety net either way),
+/// deduplicated and capped at `MAX_ENTITY_LOOKUP_CANDIDATES`.
+///
+/// Unlike `extract_entity_candidates` above, this does **not** filter on
+/// capitalization — lowercase queries are the whole point of this extension.
+/// The precision-safety property instead comes from the caller (the
+/// `memory.recall` handler) only keeping a candidate that matches the *name*
+/// of a real KG entity, via one batched `EntityFilter::names_ci` lookup.
+/// Whitespace-tokenized, so this is the Latin-script path; unsegmented CJK
+/// queries use `EntityFilter::name_substring_of` instead (see the handler).
+pub fn entity_lookup_candidates(query: &str) -> Vec<String> {
+    let tokens: Vec<String> = query
+        .split_whitespace()
+        .map(strip_token_punctuation)
+        .filter(|t| !t.is_empty())
+        .map(str::to_lowercase)
+        .collect();
+
+    let mut seen: HashSet<String> = HashSet::new();
+    let mut out: Vec<String> = Vec::new();
+
+    for t in tokens
+        .iter()
+        .filter(|t| !ENTITY_STOPWORDS.contains(&t.as_str()))
+    {
+        if seen.insert(t.clone()) {
+            out.push(t.clone());
+            if out.len() >= MAX_ENTITY_LOOKUP_CANDIDATES {
+                return out;
+            }
+        }
+    }
+    for pair in tokens.windows(2) {
+        let bigram = format!("{} {}", pair[0], pair[1]);
+        if seen.insert(bigram.clone()) {
+            out.push(bigram);
+            if out.len() >= MAX_ENTITY_LOOKUP_CANDIDATES {
+                return out;
+            }
+        }
+    }
+    out
+}
+
 // ── Scoring weights ───────────────────────────────────────────────────────────
 
 /// Weights for the combined memory score: `score = w_rel × relevance × (1 + w_temp × recency) × (1 + w_imp × salience)`.

--- a/crates/khive-pack-memory/src/scoring.rs
+++ b/crates/khive-pack-memory/src/scoring.rs
@@ -337,8 +337,8 @@ pub fn extract_entity_candidates(query: &str) -> Vec<String> {
     out
 }
 
-/// Maximum number of case-insensitive candidate strings a single recall sends
-/// to the batched entity-name lookup
+/// Maximum number of candidate strings a single recall sends to the batched
+/// entity-name lookup
 /// (ADR-104 §5 / Stage C, rider R1). Bounds the `LOWER(name) IN (...)`
 /// placeholder list built in `khive-db`'s `build_entity_where`, independent
 /// of `MAX_AUTO_ENTITY_NAMES`, which bounds the unrelated capitalized-token
@@ -349,12 +349,12 @@ const MAX_BIGRAM_LOOKUP_CANDIDATES: usize = MAX_ENTITY_LOOKUP_CANDIDATES / 4;
 const MIN_CJK_LOOKUP_CHARS: usize = 2;
 const MAX_CJK_LOOKUP_CHARS: usize = 8;
 
-/// Build the case-insensitive candidate strings a recall query offers to the
-/// entity-anchored lookup (ADR-104 §5 / Stage C). Alphabetic-script queries
-/// contribute non-stopword unigrams and reserve one quarter of the cap for
-/// adjacent-token bigrams. Each contiguous CJK run contributes substrings of
-/// two through eight characters starting at each character. All candidates
-/// are deduplicated and share the same hard cap.
+/// Build the candidate strings a recall query offers to the entity-anchored
+/// lookup (ADR-104 §5 / Stage C). Alphabetic-script queries contribute raw and
+/// ASCII-lowercased non-stopword unigrams and reserve one quarter of the cap
+/// for adjacent-token bigrams. Each contiguous CJK run contributes substrings
+/// position-fairly across starts. Supported CJK names are 2..=8 characters,
+/// with at most 64 candidates per query. All candidates are deduplicated.
 ///
 /// Unlike `extract_entity_candidates` above, this does **not** filter on
 /// capitalization, lowercase queries are the whole point of this extension.
@@ -366,13 +366,14 @@ pub fn entity_lookup_candidates(query: &str) -> Vec<String> {
         .split_whitespace()
         .map(strip_token_punctuation)
         .filter(|t| !t.is_empty())
-        .map(str::to_lowercase)
+        .map(str::to_owned)
         .collect();
 
     let mut seen: HashSet<String> = HashSet::new();
     let mut out: Vec<String> = Vec::new();
 
     let chars: Vec<char> = query.chars().collect();
+    let mut cjk_runs = Vec::new();
     let mut run_start = 0;
     while run_start < chars.len() {
         if !is_cjk_char(chars[run_start]) {
@@ -383,9 +384,16 @@ pub fn entity_lookup_candidates(query: &str) -> Vec<String> {
         while run_end < chars.len() && is_cjk_char(chars[run_end]) {
             run_end += 1;
         }
-        for start in run_start..run_end {
-            let max_len = MAX_CJK_LOOKUP_CHARS.min(run_end - start);
-            for len in MIN_CJK_LOOKUP_CHARS..=max_len {
+        cjk_runs.push((run_start, run_end));
+        run_start = run_end;
+    }
+
+    for len in MIN_CJK_LOOKUP_CHARS..=MAX_CJK_LOOKUP_CHARS {
+        for &(run_start, run_end) in &cjk_runs {
+            if run_end - run_start < len {
+                continue;
+            }
+            for start in run_start..=run_end - len {
                 let candidate: String = chars[start..start + len].iter().collect();
                 if seen.insert(candidate.clone()) {
                     out.push(candidate);
@@ -395,35 +403,44 @@ pub fn entity_lookup_candidates(query: &str) -> Vec<String> {
                 }
             }
         }
-        run_start = run_end;
     }
 
     let mut bigrams = tokens
         .windows(2)
         .map(|pair| format!("{} {}", pair[0], pair[1]));
     for bigram in bigrams.by_ref().take(MAX_BIGRAM_LOOKUP_CANDIDATES) {
-        if seen.insert(bigram.clone()) {
-            out.push(bigram);
+        for candidate in [bigram.clone(), bigram.to_ascii_lowercase()] {
+            if seen.insert(candidate.clone()) {
+                out.push(candidate);
+                if out.len() >= MAX_ENTITY_LOOKUP_CANDIDATES {
+                    return out;
+                }
+            }
         }
     }
 
     for token in tokens.iter().filter(|token| {
-        !ENTITY_STOPWORDS.contains(&token.as_str()) && !token.chars().all(is_cjk_char)
+        !ENTITY_STOPWORDS.contains(&token.to_ascii_lowercase().as_str())
+            && !token.chars().all(is_cjk_char)
     }) {
-        if seen.insert(token.clone()) {
-            out.push(token.clone());
-            if out.len() >= MAX_ENTITY_LOOKUP_CANDIDATES {
-                return out;
+        for candidate in [token.clone(), token.to_ascii_lowercase()] {
+            if seen.insert(candidate.clone()) {
+                out.push(candidate);
+                if out.len() >= MAX_ENTITY_LOOKUP_CANDIDATES {
+                    return out;
+                }
             }
         }
     }
 
     // If the unigram share did not fill the cap, admit more adjacent bigrams.
     for bigram in bigrams {
-        if seen.insert(bigram.clone()) {
-            out.push(bigram);
-            if out.len() >= MAX_ENTITY_LOOKUP_CANDIDATES {
-                return out;
+        for candidate in [bigram.clone(), bigram.to_ascii_lowercase()] {
+            if seen.insert(candidate.clone()) {
+                out.push(candidate);
+                if out.len() >= MAX_ENTITY_LOOKUP_CANDIDATES {
+                    return out;
+                }
             }
         }
     }

--- a/crates/khive-pack-memory/src/scoring.rs
+++ b/crates/khive-pack-memory/src/scoring.rs
@@ -352,9 +352,12 @@ const MAX_CJK_LOOKUP_CHARS: usize = 8;
 /// Build the candidate strings a recall query offers to the entity-anchored
 /// lookup (ADR-104 §5 / Stage C). Alphabetic-script queries contribute raw and
 /// ASCII-lowercased non-stopword unigrams and reserve one quarter of the cap
-/// for adjacent-token bigrams. Each contiguous CJK run contributes substrings
-/// position-fairly across starts. Supported CJK names are 2..=8 characters,
-/// with at most 64 candidates per query. All candidates are deduplicated.
+/// for adjacent-token bigrams. CJK substrings reserve a fair quota for every
+/// supported length from 2 through 8, redistributing unused quota from short
+/// runs. Within each length, available start positions are sampled at an even
+/// stride, including the final valid start in the query. The result is both
+/// length-fair and position-fair under the 64-candidate cap. All candidates are
+/// deduplicated.
 ///
 /// Unlike `extract_entity_candidates` above, this does **not** filter on
 /// capitalization, lowercase queries are the whole point of this extension.
@@ -388,21 +391,81 @@ pub fn entity_lookup_candidates(query: &str) -> Vec<String> {
         run_start = run_end;
     }
 
-    for len in MIN_CJK_LOOKUP_CHARS..=MAX_CJK_LOOKUP_CHARS {
-        for &(run_start, run_end) in &cjk_runs {
-            if run_end - run_start < len {
-                continue;
+    let length_count = MAX_CJK_LOOKUP_CHARS - MIN_CJK_LOOKUP_CHARS + 1;
+    let base_quota = MAX_ENTITY_LOOKUP_CANDIDATES / length_count;
+    let quota_remainder = MAX_ENTITY_LOOKUP_CANDIDATES % length_count;
+
+    let cjk_candidates: Vec<Vec<String>> = (MIN_CJK_LOOKUP_CHARS..=MAX_CJK_LOOKUP_CHARS)
+        .map(|len| {
+            let mut last_start_by_candidate = std::collections::HashMap::new();
+            for &(run_start, run_end) in &cjk_runs {
+                if run_end - run_start < len {
+                    continue;
+                }
+                for start in run_start..=run_end - len {
+                    let candidate: String = chars[start..start + len].iter().collect();
+                    last_start_by_candidate.insert(candidate, start);
+                }
             }
-            for start in run_start..=run_end - len {
-                let candidate: String = chars[start..start + len].iter().collect();
-                if seen.insert(candidate.clone()) {
-                    out.push(candidate);
-                    if out.len() >= MAX_ENTITY_LOOKUP_CANDIDATES {
-                        return out;
-                    }
+
+            let mut positioned: Vec<(usize, String)> = last_start_by_candidate
+                .into_iter()
+                .map(|(candidate, start)| (start, candidate))
+                .collect();
+            positioned.sort_unstable_by_key(|(start, _)| *start);
+            positioned
+                .into_iter()
+                .map(|(_, candidate)| candidate)
+                .collect()
+        })
+        .collect();
+
+    let mut quotas: Vec<usize> = (0..length_count)
+        .map(|index| base_quota + usize::from(index < quota_remainder))
+        .collect();
+    let mut unused = 0;
+    for (quota, candidates) in quotas.iter_mut().zip(&cjk_candidates) {
+        if candidates.len() < *quota {
+            unused += *quota - candidates.len();
+            *quota = candidates.len();
+        }
+    }
+    while unused > 0 {
+        let mut redistributed = false;
+        for (quota, candidates) in quotas.iter_mut().zip(&cjk_candidates) {
+            if *quota < candidates.len() {
+                *quota += 1;
+                unused -= 1;
+                redistributed = true;
+                if unused == 0 {
+                    break;
                 }
             }
         }
+        if !redistributed {
+            break;
+        }
+    }
+
+    for (candidates, quota) in cjk_candidates.iter().zip(quotas) {
+        if quota == 0 {
+            continue;
+        }
+        let num_positions = candidates.len();
+        let stride = (num_positions / quota).max(1);
+        let mut sampled_indices: Vec<usize> = (0..quota)
+            .map(|offset| num_positions - 1 - offset * stride)
+            .collect();
+        sampled_indices.reverse();
+        for index in sampled_indices {
+            let candidate = candidates[index].clone();
+            if seen.insert(candidate.clone()) {
+                out.push(candidate);
+            }
+        }
+    }
+    if out.len() >= MAX_ENTITY_LOOKUP_CANDIDATES {
+        return out;
     }
 
     let mut bigrams = tokens
@@ -1255,6 +1318,39 @@ mod tests {
     #[test]
     fn extract_entity_candidates_all_stopwords_returns_empty() {
         assert!(extract_entity_candidates("is the a of").is_empty());
+    }
+
+    #[test]
+    fn entity_lookup_candidates_is_length_and_position_fair_for_long_cjk_run() {
+        let run: String = (0..65)
+            .map(|offset| char::from_u32(0x4e00 + offset).expect("valid CJK character"))
+            .collect();
+        let candidates = entity_lookup_candidates(&run);
+
+        assert_eq!(candidates.len(), MAX_ENTITY_LOOKUP_CANDIDATES);
+        for len in MIN_CJK_LOOKUP_CHARS..=MAX_CJK_LOOKUP_CHARS {
+            let expected_quota = MAX_ENTITY_LOOKUP_CANDIDATES
+                / (MAX_CJK_LOOKUP_CHARS - MIN_CJK_LOOKUP_CHARS + 1)
+                + usize::from(len == MIN_CJK_LOOKUP_CHARS);
+            assert_eq!(
+                candidates
+                    .iter()
+                    .filter(|candidate| candidate.chars().count() == len)
+                    .count(),
+                expected_quota,
+                "candidate set must reserve the exact quota for length {len}"
+            );
+
+            let chars: Vec<char> = run.chars().collect();
+            let has_late_candidate = (chars.len() - 10..=chars.len() - len).any(|start| {
+                let expected: String = chars[start..start + len].iter().collect();
+                candidates.contains(&expected)
+            });
+            assert!(
+                has_late_candidate,
+                "length {len} must include a candidate starting in the final 10 positions"
+            );
+        }
     }
 
     // ── EntityMatch word-boundary matching ──────────────────────────────────────

--- a/crates/khive-pack-memory/src/scoring.rs
+++ b/crates/khive-pack-memory/src/scoring.rs
@@ -354,10 +354,10 @@ const MAX_CJK_LOOKUP_CHARS: usize = 8;
 /// ASCII-lowercased non-stopword unigrams and reserve one quarter of the cap
 /// for adjacent-token bigrams. CJK substrings reserve a fair quota for every
 /// supported length from 2 through 8, redistributing unused quota from short
-/// runs. Within each length, available start positions are sampled at an even
-/// stride, including the final valid start in the query. The result is both
-/// length-fair and position-fair under the 64-candidate cap. All candidates are
-/// deduplicated.
+/// runs. Within each length, available start positions are sampled evenly.
+/// Quotas greater than one guarantee both the first and final valid starts;
+/// a quota of one selects the first endpoint. The result is both length-fair
+/// and position-fair under the 64-candidate cap. All candidates are deduplicated.
 ///
 /// Unlike `extract_entity_candidates` above, this does **not** filter on
 /// capitalization, lowercase queries are the whole point of this extension.
@@ -452,11 +452,14 @@ pub fn entity_lookup_candidates(query: &str) -> Vec<String> {
             continue;
         }
         let num_positions = candidates.len();
-        let stride = (num_positions / quota).max(1);
-        let mut sampled_indices: Vec<usize> = (0..quota)
-            .map(|offset| num_positions - 1 - offset * stride)
-            .collect();
-        sampled_indices.reverse();
+        let mut sampled_indices = if quota == 1 {
+            vec![0]
+        } else {
+            (0..quota)
+                .map(|index| index * (num_positions - 1) / (quota - 1))
+                .collect::<Vec<_>>()
+        };
+        sampled_indices.dedup();
         for index in sampled_indices {
             let candidate = candidates[index].clone();
             if seen.insert(candidate.clone()) {

--- a/crates/khive-pack-memory/src/scoring.rs
+++ b/crates/khive-pack-memory/src/scoring.rs
@@ -349,12 +349,22 @@ const MAX_BIGRAM_LOOKUP_CANDIDATES: usize = MAX_ENTITY_LOOKUP_CANDIDATES / 4;
 const MIN_CJK_LOOKUP_CHARS: usize = 2;
 const MAX_CJK_LOOKUP_CHARS: usize = 8;
 
+fn entity_lookup_case_variants(candidate: String) -> [Option<String>; 2] {
+    let lower = candidate.to_ascii_lowercase();
+    if candidate.is_ascii() {
+        [None, Some(lower)]
+    } else {
+        [Some(candidate), Some(lower)]
+    }
+}
+
 /// Build the candidate strings a recall query offers to the entity-anchored
-/// lookup (ADR-104 §5 / Stage C). Alphabetic-script queries contribute raw and
+/// lookup (ADR-104 §5 / Stage C). Alphabetic-script queries contribute
 /// ASCII-lowercased non-stopword unigrams and reserve one quarter of the cap
-/// for adjacent-token bigrams. CJK substrings reserve a fair quota for every
-/// supported length from 2 through 8, redistributing unused quota from short
-/// runs. Within each length, available start positions are sampled evenly.
+/// for adjacent-token bigrams. Candidates containing non-ASCII characters also
+/// retain their raw form for exact matching. CJK substrings reserve a fair quota
+/// for every supported length from 2 through 8, redistributing unused quota from
+/// short runs. Within each length, available start positions are sampled evenly.
 /// Quotas greater than one guarantee both the first and final valid starts;
 /// a quota of one selects the first endpoint. The result is both length-fair
 /// and position-fair under the 64-candidate cap. All candidates are deduplicated.
@@ -475,7 +485,7 @@ pub fn entity_lookup_candidates(query: &str) -> Vec<String> {
         .windows(2)
         .map(|pair| format!("{} {}", pair[0], pair[1]));
     for bigram in bigrams.by_ref().take(MAX_BIGRAM_LOOKUP_CANDIDATES) {
-        for candidate in [bigram.clone(), bigram.to_ascii_lowercase()] {
+        for candidate in entity_lookup_case_variants(bigram).into_iter().flatten() {
             if seen.insert(candidate.clone()) {
                 out.push(candidate);
                 if out.len() >= MAX_ENTITY_LOOKUP_CANDIDATES {
@@ -489,7 +499,10 @@ pub fn entity_lookup_candidates(query: &str) -> Vec<String> {
         !ENTITY_STOPWORDS.contains(&token.to_ascii_lowercase().as_str())
             && !token.chars().all(is_cjk_char)
     }) {
-        for candidate in [token.clone(), token.to_ascii_lowercase()] {
+        for candidate in entity_lookup_case_variants(token.clone())
+            .into_iter()
+            .flatten()
+        {
             if seen.insert(candidate.clone()) {
                 out.push(candidate);
                 if out.len() >= MAX_ENTITY_LOOKUP_CANDIDATES {
@@ -501,7 +514,7 @@ pub fn entity_lookup_candidates(query: &str) -> Vec<String> {
 
     // If the unigram share did not fill the cap, admit more adjacent bigrams.
     for bigram in bigrams {
-        for candidate in [bigram.clone(), bigram.to_ascii_lowercase()] {
+        for candidate in entity_lookup_case_variants(bigram).into_iter().flatten() {
             if seen.insert(candidate.clone()) {
                 out.push(candidate);
                 if out.len() >= MAX_ENTITY_LOOKUP_CANDIDATES {
@@ -1354,6 +1367,21 @@ mod tests {
                 "length {len} must include a candidate starting in the final 10 positions"
             );
         }
+    }
+
+    #[test]
+    fn entity_lookup_candidates_retains_final_bigram_independent_of_ascii_case() {
+        let lowercase = "one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen final entity";
+        let title_case = "One Two Three Four Five Six Seven Eight Nine Ten Eleven Twelve Thirteen Fourteen Fifteen Sixteen Final Entity";
+
+        let lowercase_candidates = entity_lookup_candidates(lowercase);
+        let title_case_candidates = entity_lookup_candidates(title_case);
+        let stored_name_ci = "Final Entity".to_ascii_lowercase();
+
+        assert_eq!(title_case_candidates, lowercase_candidates);
+        assert!(lowercase_candidates.contains(&stored_name_ci));
+        assert!(title_case_candidates.contains(&stored_name_ci));
+        assert!(!title_case_candidates.contains(&"Final Entity".to_string()));
     }
 
     // ── EntityMatch word-boundary matching ──────────────────────────────────────

--- a/crates/khive-pack-memory/src/scoring.rs
+++ b/crates/khive-pack-memory/src/scoring.rs
@@ -339,10 +339,9 @@ pub fn extract_entity_candidates(query: &str) -> Vec<String> {
 
 /// Maximum number of candidate strings a single recall sends to the batched
 /// entity-name lookup
-/// (ADR-104 §5 / Stage C, rider R1). Bounds the `LOWER(name) IN (...)`
-/// placeholder list built in `khive-db`'s `build_entity_where`, independent
-/// of `MAX_AUTO_ENTITY_NAMES`, which bounds the unrelated capitalized-token
-/// fallback list above.
+/// (ADR-104 §5 / Stage C, rider R1). Bounds the candidate `VALUES` relation
+/// consumed by `khive-db`, independent of `MAX_AUTO_ENTITY_NAMES`, which bounds
+/// the unrelated capitalized-token fallback list above.
 pub const MAX_ENTITY_LOOKUP_CANDIDATES: usize = 64;
 
 const MAX_BIGRAM_LOOKUP_CANDIDATES: usize = MAX_ENTITY_LOOKUP_CANDIDATES / 4;

--- a/crates/khive-pack-memory/src/scoring.rs
+++ b/crates/khive-pack-memory/src/scoring.rs
@@ -79,14 +79,14 @@ pub struct CandidateContext<'a> {
 }
 
 /// Returns `true` when `needle` occurs in `haystack` at a **word (character)
-/// boundary** — the character immediately before the match (if any) and the
+/// boundary**. The character immediately before the match (if any) and the
 /// character immediately after the match (if any) are both non-alphanumeric
 /// (or the match sits at the start/end of `haystack`).
 ///
 /// Plain substring `contains` matches inside unrelated words: a candidate
 /// `"beta"` matches `"alphabet"` and `"betamax"`; `"car"` matches
 /// `"scarcity"`. Anchoring to boundaries closes that class of false positive
-/// while still matching multi-word phrases on their own boundaries — a
+/// while still matching multi-word phrases on their own boundaries. A
 /// caller-supplied explicit name like `"knowledge graph"` still matches
 /// `"...the knowledge graph shows..."` because the space characters on
 /// either side of the phrase are themselves non-alphanumeric, satisfying the
@@ -97,6 +97,9 @@ pub struct CandidateContext<'a> {
 fn contains_at_word_boundary(haystack: &str, needle: &str) -> bool {
     if needle.is_empty() {
         return false;
+    }
+    if needle.chars().all(is_cjk_char) {
+        return haystack.contains(needle);
     }
     let haystack_chars: Vec<char> = haystack.chars().collect();
     let needle_chars: Vec<char> = needle.chars().collect();
@@ -334,28 +337,30 @@ pub fn extract_entity_candidates(query: &str) -> Vec<String> {
     out
 }
 
-/// Maximum number of case-insensitive candidate strings (unigrams + adjacent
-/// bigrams) a single recall sends to the batched entity-name lookup
+/// Maximum number of case-insensitive candidate strings a single recall sends
+/// to the batched entity-name lookup
 /// (ADR-104 §5 / Stage C, rider R1). Bounds the `LOWER(name) IN (...)`
-/// placeholder list built in `khive-db`'s `build_entity_where` — independent
+/// placeholder list built in `khive-db`'s `build_entity_where`, independent
 /// of `MAX_AUTO_ENTITY_NAMES`, which bounds the unrelated capitalized-token
 /// fallback list above.
-pub const MAX_ENTITY_LOOKUP_CANDIDATES: usize = 16;
+pub const MAX_ENTITY_LOOKUP_CANDIDATES: usize = 64;
+
+const MAX_BIGRAM_LOOKUP_CANDIDATES: usize = MAX_ENTITY_LOOKUP_CANDIDATES / 4;
+const MIN_CJK_LOOKUP_CHARS: usize = 2;
+const MAX_CJK_LOOKUP_CHARS: usize = 8;
 
 /// Build the case-insensitive candidate strings a recall query offers to the
-/// entity-anchored lookup (ADR-104 §5 / Stage C): every non-stopword token,
-/// lowercased, plus every adjacent-token bigram (also lowercased, stopwords
-/// included — a two-token phrase is unlikely to itself be a stopword pair,
-/// and the real-entity-name check downstream is the safety net either way),
-/// deduplicated and capped at `MAX_ENTITY_LOOKUP_CANDIDATES`.
+/// entity-anchored lookup (ADR-104 §5 / Stage C). Alphabetic-script queries
+/// contribute non-stopword unigrams and reserve one quarter of the cap for
+/// adjacent-token bigrams. Each contiguous CJK run contributes substrings of
+/// two through eight characters starting at each character. All candidates
+/// are deduplicated and share the same hard cap.
 ///
 /// Unlike `extract_entity_candidates` above, this does **not** filter on
-/// capitalization — lowercase queries are the whole point of this extension.
+/// capitalization, lowercase queries are the whole point of this extension.
 /// The precision-safety property instead comes from the caller (the
 /// `memory.recall` handler) only keeping a candidate that matches the *name*
 /// of a real KG entity, via one batched `EntityFilter::names_ci` lookup.
-/// Whitespace-tokenized, so this is the Latin-script path; unsegmented CJK
-/// queries use `EntityFilter::name_substring_of` instead (see the handler).
 pub fn entity_lookup_candidates(query: &str) -> Vec<String> {
     let tokens: Vec<String> = query
         .split_whitespace()
@@ -367,19 +372,54 @@ pub fn entity_lookup_candidates(query: &str) -> Vec<String> {
     let mut seen: HashSet<String> = HashSet::new();
     let mut out: Vec<String> = Vec::new();
 
-    for t in tokens
-        .iter()
-        .filter(|t| !ENTITY_STOPWORDS.contains(&t.as_str()))
-    {
-        if seen.insert(t.clone()) {
-            out.push(t.clone());
+    let chars: Vec<char> = query.chars().collect();
+    let mut run_start = 0;
+    while run_start < chars.len() {
+        if !is_cjk_char(chars[run_start]) {
+            run_start += 1;
+            continue;
+        }
+        let mut run_end = run_start + 1;
+        while run_end < chars.len() && is_cjk_char(chars[run_end]) {
+            run_end += 1;
+        }
+        for start in run_start..run_end {
+            let max_len = MAX_CJK_LOOKUP_CHARS.min(run_end - start);
+            for len in MIN_CJK_LOOKUP_CHARS..=max_len {
+                let candidate: String = chars[start..start + len].iter().collect();
+                if seen.insert(candidate.clone()) {
+                    out.push(candidate);
+                    if out.len() >= MAX_ENTITY_LOOKUP_CANDIDATES {
+                        return out;
+                    }
+                }
+            }
+        }
+        run_start = run_end;
+    }
+
+    let mut bigrams = tokens
+        .windows(2)
+        .map(|pair| format!("{} {}", pair[0], pair[1]));
+    for bigram in bigrams.by_ref().take(MAX_BIGRAM_LOOKUP_CANDIDATES) {
+        if seen.insert(bigram.clone()) {
+            out.push(bigram);
+        }
+    }
+
+    for token in tokens.iter().filter(|token| {
+        !ENTITY_STOPWORDS.contains(&token.as_str()) && !token.chars().all(is_cjk_char)
+    }) {
+        if seen.insert(token.clone()) {
+            out.push(token.clone());
             if out.len() >= MAX_ENTITY_LOOKUP_CANDIDATES {
                 return out;
             }
         }
     }
-    for pair in tokens.windows(2) {
-        let bigram = format!("{} {}", pair[0], pair[1]);
+
+    // If the unigram share did not fill the cap, admit more adjacent bigrams.
+    for bigram in bigrams {
         if seen.insert(bigram.clone()) {
             out.push(bigram);
             if out.len() >= MAX_ENTITY_LOOKUP_CANDIDATES {
@@ -1281,6 +1321,20 @@ mod tests {
             AdjustmentCondition::EntityMatch.matches(&ctx),
             "boundary anchoring must not break matching the actual word"
         );
+    }
+
+    #[test]
+    fn entity_match_condition_matches_contiguous_cjk_with_cjk_on_both_sides() {
+        let entity_names = vec!["北京大学".to_string()];
+        let ctx = entity_match_ctx("我在北京大学学习", &entity_names);
+        assert!(AdjustmentCondition::EntityMatch.matches(&ctx));
+    }
+
+    #[test]
+    fn entity_match_condition_keeps_alphabetic_word_boundaries() {
+        let entity_names = vec!["rust".to_string()];
+        let ctx = entity_match_ctx("trust requires evidence", &entity_names);
+        assert!(!AdjustmentCondition::EntityMatch.matches(&ctx));
     }
 
     // ── ADR-104 §2 (Stage B): entity_posterior_term ────────────────────────────

--- a/crates/khive-storage/src/entity.rs
+++ b/crates/khive-storage/src/entity.rs
@@ -105,11 +105,11 @@ pub struct EntityFilter {
     #[serde(default)]
     pub namespaces: Vec<String>,
     /// ASCII-case-insensitive batched exact-name match (ADR-104 Stage C).
-    /// `LOWER(name) IN (...)` compares up to a caller-bounded set of raw and
-    /// ASCII-lowercased candidate strings. Cased non-ASCII characters require
-    /// exact form. Distinct from single-value, case-sensitive `name_exact`.
-    /// Results contain at most one representative row per folded name before
-    /// page limits and offsets are applied.
+    /// Compares a caller-bounded set of raw and ASCII-lowercased candidate
+    /// strings to `LOWER(name)`. Cased non-ASCII characters require exact form.
+    /// Distinct from single-value, case-sensitive `name_exact`. Results contain
+    /// at most one representative row per folded candidate before page limits
+    /// and offsets are applied.
     /// Implementations may omit the page total to keep this lookup page-limited
     /// instead of issuing a separate count.
     #[serde(default)]

--- a/crates/khive-storage/src/entity.rs
+++ b/crates/khive-storage/src/entity.rs
@@ -104,14 +104,12 @@ pub struct EntityFilter {
     /// backward-compatible default).
     #[serde(default)]
     pub namespaces: Vec<String>,
-    /// Case-insensitive batched exact-name match (ADR-104 Stage C: entity-
-    /// anchored candidate extraction). `LOWER(name) IN (...)` over up to a
-    /// caller-bounded set of candidate strings. One SQL query recovers every
-    /// entity whose name case-insensitively equals any candidate, instead of
-    /// one `name_exact` round trip per candidate. Distinct from `name_exact`
-    /// (single value, case-sensitive `=`): this field is the batched,
-    /// case-insensitive counterpart. Implementations may omit the page total
-    /// to keep this lookup page-limited instead of issuing a separate count.
+    /// ASCII-case-insensitive batched exact-name match (ADR-104 Stage C).
+    /// `LOWER(name) IN (...)` compares up to a caller-bounded set of raw and
+    /// ASCII-lowercased candidate strings. Cased non-ASCII characters require
+    /// exact form. Distinct from single-value, case-sensitive `name_exact`.
+    /// Implementations may omit the page total to keep this lookup page-limited
+    /// instead of issuing a separate count.
     #[serde(default)]
     pub names_ci: Vec<String>,
 }

--- a/crates/khive-storage/src/entity.rs
+++ b/crates/khive-storage/src/entity.rs
@@ -104,6 +104,25 @@ pub struct EntityFilter {
     /// backward-compatible default).
     #[serde(default)]
     pub namespaces: Vec<String>,
+    /// Case-insensitive batched exact-name match (ADR-104 Stage C: entity-
+    /// anchored candidate extraction). `LOWER(name) IN (...)` over up to a
+    /// caller-bounded set of candidate strings — one SQL query recovers every
+    /// entity whose name case-insensitively equals any candidate, instead of
+    /// one `name_exact` round trip per candidate. Distinct from `name_exact`
+    /// (single value, case-sensitive `=`): this field is the batched,
+    /// case-insensitive counterpart.
+    #[serde(default)]
+    pub names_ci: Vec<String>,
+    /// Match entities whose `name` occurs as a substring **within** this
+    /// string — the reverse direction of `name_prefix`/`name_exact`, which
+    /// match the entity name against a caller-supplied pattern. ADR-104 Stage
+    /// C's CJK path: an unsegmented CJK query has no whitespace to derive
+    /// unigram/bigram candidates from, so the query text itself is supplied
+    /// here and every entity whose name it contains becomes a candidate.
+    /// Always paired by the caller with a small `PageRequest` limit — this
+    /// predicate is evaluated per row (`INSTR`), not via `idx_entities_name`.
+    #[serde(default)]
+    pub name_substring_of: Option<String>,
 }
 
 /// Entity CRUD operations over the entities substrate table.

--- a/crates/khive-storage/src/entity.rs
+++ b/crates/khive-storage/src/entity.rs
@@ -106,23 +106,14 @@ pub struct EntityFilter {
     pub namespaces: Vec<String>,
     /// Case-insensitive batched exact-name match (ADR-104 Stage C: entity-
     /// anchored candidate extraction). `LOWER(name) IN (...)` over up to a
-    /// caller-bounded set of candidate strings — one SQL query recovers every
+    /// caller-bounded set of candidate strings. One SQL query recovers every
     /// entity whose name case-insensitively equals any candidate, instead of
     /// one `name_exact` round trip per candidate. Distinct from `name_exact`
     /// (single value, case-sensitive `=`): this field is the batched,
-    /// case-insensitive counterpart.
+    /// case-insensitive counterpart. Implementations may omit the page total
+    /// to keep this lookup page-limited instead of issuing a separate count.
     #[serde(default)]
     pub names_ci: Vec<String>,
-    /// Match entities whose `name` occurs as a substring **within** this
-    /// string — the reverse direction of `name_prefix`/`name_exact`, which
-    /// match the entity name against a caller-supplied pattern. ADR-104 Stage
-    /// C's CJK path: an unsegmented CJK query has no whitespace to derive
-    /// unigram/bigram candidates from, so the query text itself is supplied
-    /// here and every entity whose name it contains becomes a candidate.
-    /// Always paired by the caller with a small `PageRequest` limit — this
-    /// predicate is evaluated per row (`INSTR`), not via `idx_entities_name`.
-    #[serde(default)]
-    pub name_substring_of: Option<String>,
 }
 
 /// Entity CRUD operations over the entities substrate table.

--- a/crates/khive-storage/src/entity.rs
+++ b/crates/khive-storage/src/entity.rs
@@ -108,6 +108,8 @@ pub struct EntityFilter {
     /// `LOWER(name) IN (...)` compares up to a caller-bounded set of raw and
     /// ASCII-lowercased candidate strings. Cased non-ASCII characters require
     /// exact form. Distinct from single-value, case-sensitive `name_exact`.
+    /// Results contain at most one representative row per folded name before
+    /// page limits and offsets are applied.
     /// Implementations may omit the page total to keep this lookup page-limited
     /// instead of issuing a separate count.
     #[serde(default)]

--- a/docs/adr/ADR-015-schema-migrations.md
+++ b/docs/adr/ADR-015-schema-migrations.md
@@ -119,6 +119,24 @@ The canonical ledger of database schema migration versions. Migration versions a
 > be recreated from the current `schema.sql`; in-place downgrade across the reset is not
 > supported.
 
+### Post-consolidation migration ledger (live)
+
+The live sequence starts from the consolidated V1 baseline. This table is the
+canonical allocation ledger for databases created at or after v0.2.8; the table
+above remains the historical pre-consolidation record.
+
+| Version | Owning ADR / issue | Migration name                     | Status  |
+| ------: | ------------------ | ---------------------------------- | ------- |
+|      V1 | ADR-015            | initial_schema                     | shipped |
+|      V2 | ADR-051            | narrow_fts_sections_update_trigger | shipped |
+|      V3 | ADR-051            | backfill_domain_mirror_atoms       | shipped |
+|      V4 | ADR-062            | fts_consolidation                  | shipped |
+|      V5 | ADR-056            | unique_comm_message_external_id    | shipped |
+|      V6 | ADR-081            | brain_retune_driver                | shipped |
+|      V7 | #827               | notes_seq                          | shipped |
+|      V8 | #827               | notes_seq_repair                   | shipped |
+|      V9 | ADR-104            | entities_name_ci_index             | claimed |
+
 > **Invariant**: ADR number order and migration version order are independent. Migration versions reflect schema ledger assignment order. A migration may only depend on schema created by earlier versions.
 
 > **Process**: When a new ADR introduces a schema migration, it MUST request the next ledger version here (claim by editing this table in the same PR). ADRs MUST NOT use placeholder text like "version: <next>" once merged.

--- a/docs/adr/ADR-104-posterior-serving-recall.md
+++ b/docs/adr/ADR-104-posterior-serving-recall.md
@@ -118,10 +118,11 @@ substring lookup against entity names rather than whitespace tokenization.
 Entity-name matching is case-insensitive for ASCII, exact-form for cased non-ASCII scripts,
 and caseless scripts such as CJK are unaffected.
 
-Implementation constraint: one indexed lookup per recall (batched over tokens), reusing
-the entity store's existing name index. Explicit caller-supplied `entity_names` continues
-to win over all extraction, and `entity_names: []` remains a full opt-out (#738
-semantics unchanged).
+Implementation constraint: one indexed lookup per recall, driven by a distinct relation of at
+most 64 token candidates. Each candidate performs one `LIMIT 1` seek against a live-row partial
+index on `(namespace, LOWER(name))`; work is bounded by candidates rather than duplicate or
+tombstoned entity rows. Explicit caller-supplied `entity_names` continues to win over all
+extraction, and `entity_names: []` remains a full opt-out (#738 semantics unchanged).
 
 ## What this deliberately does not do
 

--- a/docs/adr/ADR-104-posterior-serving-recall.md
+++ b/docs/adr/ADR-104-posterior-serving-recall.md
@@ -109,11 +109,14 @@ resolution override, not a ledger bypass.
 ### 5. Entity-anchored candidate extraction
 
 Extends #738's capitalized-token extraction with a second, precision-safe source: query
-tokens (and adjacent-token bigrams) that case-insensitively equal the name of an existing
-KG entity become entity candidates regardless of capitalization. Matching against real
-entity records is what makes lowercase coverage safe — a token can only earn the boost by
+tokens (and adjacent-token bigrams) that equal the name of an existing KG entity under the
+bounded case contract become entity candidates regardless of ASCII capitalization. Matching
+against real entity records is what makes lowercase coverage safe: a token can only earn the boost by
 naming something the graph actually knows — and it serves unsegmented CJK queries through
 substring lookup against entity names rather than whitespace tokenization.
+
+Entity-name matching is case-insensitive for ASCII, exact-form for cased non-ASCII scripts,
+and caseless scripts such as CJK are unaffected.
 
 Implementation constraint: one indexed lookup per recall (batched over tokens), reusing
 the entity store's existing name index. Explicit caller-supplied `entity_names` continues


### PR DESCRIPTION
Implements ADR-104 component 5 / Stage C: entity-anchored candidate extraction for the entity_names boost.

- Query tokens and adjacent-token bigrams that case-insensitively equal an existing KG entity name become entity candidates regardless of capitalization (the precision-safe lowercase extension over #738).
- Unsegmented CJK queries match via a reverse-substring path (entity name contained in the query text), bounded by a small page limit and namespace scope.
- Rider R1 honored: one batched indexed lookup per recall (LOWER(name) IN (...) rides the existing composite name index).
- Explicit caller-supplied entity_names wins over all extraction; entity_names: [] remains a full opt-out. #738 regression tests kept green.

Validation (implementer leg log): cargo fmt clean, clippy -D warnings clean, Stage C gate tests plus #738 regressions plus full -p khive-pack-memory suite pass.