### PR TITLE
chore(deps): bump lattice-embed and lattice-fann to 0.6.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -341,7 +341,7 @@ cd crates && cargo test --workspace
 make ci  # Full CI: fmt, clippy, test, build
 ```
 
-Prerequisites: Rust 1.91+ (workspace MSRV) (via [rustup](https://rustup.rs)),
+Prerequisites: Rust 1.93+ (workspace MSRV) (via [rustup](https://rustup.rs)),
 Deno 2.x (for the TypeScript CLI layer, optional)
 
 - Node.js 20+ and pnpm (for frontend, optional)

--- a/crates/Cargo.toml
+++ b/crates/Cargo.toml
@@ -51,11 +51,9 @@ exclude = ["khive-merge"]
 [workspace.package]
 version = "0.4.0"
 edition = "2021"
-# floor_char_boundary/ceil_char_boundary (round_char_boundary, rust-lang/rust#93743)
-# stabilized in 1.91.0; khive-pack-brain's persist.rs uses floor_char_boundary.
-# Verified by compiling a minimal probe against installed 1.90.0 (E0658,
-# unstable) vs 1.91.0 (compiles); see issue #398.
-rust-version = "1.91.0"
+# lattice-embed and lattice-fann 0.6 require Rust 1.93, setting the workspace MSRV.
+# The previous 1.91 floor came from floor_char_boundary use (issue #398).
+rust-version = "1.93.0"
 authors = ["Ocean <ocean@lionagi.ai>"]
 license = "Apache-2.0"
 repository = "https://github.com/ohdearquant/khive"

--- a/crates/Cargo.toml
+++ b/crates/Cargo.toml
@@ -83,8 +83,8 @@ chrono = { version = "0.4", default-features = false, features = ["serde", "cloc
 async-trait = "0.1"
 clap = { version = "4.5", features = ["derive", "env"] }
 dotenvy = "0.15"
-lattice-embed = "0.4.2"
-lattice-fann = "0.4.2"
+lattice-embed = "0.6.0"
+lattice-fann = "0.6.0"
 parking_lot = "0.12"
 rand = "0.8"
 rand_distr = "0.4"

--- a/crates/khive-runtime/src/retrieval.rs
+++ b/crates/khive-runtime/src/retrieval.rs
@@ -1507,6 +1507,140 @@ mod tests {
 
     // ---- embed intent tests ----
 
+    struct CapturingEmbeddingService {
+        captured: std::sync::Arc<std::sync::Mutex<Vec<Vec<String>>>>,
+    }
+
+    #[async_trait::async_trait]
+    impl EmbeddingService for CapturingEmbeddingService {
+        async fn embed(
+            &self,
+            texts: &[String],
+            _model: EmbeddingModel,
+        ) -> std::result::Result<Vec<Vec<f32>>, lattice_embed::EmbedError> {
+            self.captured.lock().unwrap().push(texts.to_vec());
+            Ok(texts.iter().map(|_| vec![1.0]).collect())
+        }
+
+        fn supports_model(&self, _model: EmbeddingModel) -> bool {
+            true
+        }
+
+        fn name(&self) -> &'static str {
+            "capturing-embedding-service"
+        }
+    }
+
+    struct CapturingEmbedderProvider {
+        name: String,
+        captured: std::sync::Arc<std::sync::Mutex<Vec<Vec<String>>>>,
+    }
+
+    #[async_trait::async_trait]
+    impl EmbedderProvider for CapturingEmbedderProvider {
+        fn name(&self) -> &str {
+            &self.name
+        }
+
+        fn dimensions(&self) -> usize {
+            1
+        }
+
+        async fn build(&self) -> crate::error::RuntimeResult<std::sync::Arc<dyn EmbeddingService>> {
+            Ok(std::sync::Arc::new(CapturingEmbeddingService {
+                captured: std::sync::Arc::clone(&self.captured),
+            }))
+        }
+    }
+
+    fn runtime_with_capturing_embedder(
+        model: EmbeddingModel,
+    ) -> (
+        KhiveRuntime,
+        std::sync::Arc<std::sync::Mutex<Vec<Vec<String>>>>,
+    ) {
+        let runtime = KhiveRuntime::memory().unwrap();
+        let captured = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+        runtime.register_embedder(CapturingEmbedderProvider {
+            name: model.to_string(),
+            captured: std::sync::Arc::clone(&captured),
+        });
+        (runtime, captured)
+    }
+
+    #[tokio::test]
+    async fn bge_query_paths_pass_raw_unprefixed_text() {
+        const BGE_QUERY_INSTRUCTION: &str =
+            "Represent this sentence for searching relevant passages: ";
+        let single = "single raw query";
+        let batch = vec![
+            "first raw query".to_string(),
+            "second raw query".to_string(),
+        ];
+
+        for model in [
+            EmbeddingModel::BgeSmallEnV15,
+            EmbeddingModel::BgeBaseEnV15,
+            EmbeddingModel::BgeLargeEnV15,
+        ] {
+            let (runtime, captured) = runtime_with_capturing_embedder(model);
+            runtime
+                .embed_query_with_model(&model.to_string(), single)
+                .await
+                .unwrap();
+            runtime
+                .embed_query_batch_with_model(&model.to_string(), &batch)
+                .await
+                .unwrap();
+
+            let calls = captured.lock().unwrap().clone();
+            assert_eq!(
+                calls,
+                vec![vec![single.to_string()], batch.clone()],
+                "{model} must receive raw query text through single and batch paths"
+            );
+            assert!(
+                calls
+                    .iter()
+                    .flatten()
+                    .all(|text| !text.contains(BGE_QUERY_INSTRUCTION)),
+                "{model} must not receive the BGE retrieval instruction"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn e5_query_paths_apply_query_prefix() {
+        let model = EmbeddingModel::MultilingualE5Small;
+        let single = "single raw query";
+        let batch = vec![
+            "first raw query".to_string(),
+            "second raw query".to_string(),
+        ];
+        let (runtime, captured) = runtime_with_capturing_embedder(model);
+
+        runtime
+            .embed_query_with_model(&model.to_string(), single)
+            .await
+            .unwrap();
+        runtime
+            .embed_query_batch_with_model(&model.to_string(), &batch)
+            .await
+            .unwrap();
+
+        assert_eq!(
+            captured.lock().unwrap().as_slice(),
+            [
+                vec!["query: single raw query".to_string()],
+                vec![
+                    "query: first raw query".to_string(),
+                    "query: second raw query".to_string(),
+                ],
+            ],
+            "E5 must receive its query prefix through single and batch paths"
+        );
+    }
+
     #[test]
     #[ignore = "loads ~80 MB model; run with --include-ignored"]
     fn minilm_document_and_query_embed_are_identical_no_prefix_model() {

--- a/crates/khive-runtime/src/retrieval.rs
+++ b/crates/khive-runtime/src/retrieval.rs
@@ -2,6 +2,7 @@
 
 use std::collections::{HashMap, HashSet};
 
+use lattice_embed::EmbeddingModel;
 use uuid::Uuid;
 
 use crate::config::{parse_embedding_model_alias, sanitize_key};
@@ -132,10 +133,9 @@ impl KhiveRuntime {
 
     /// Embed a query string for retrieval using the named model.
     ///
-    /// Applies `EmbeddingService::embed_query`, which prepends the model's
-    /// `query_instruction()` prefix when defined (e.g. `"query: "` for
-    /// multilingual-e5). For models with no query prefix (MiniLM, BGE) this
-    /// is identical to [`Self::embed_with_model`].
+    /// Applies the pre-0.6 query-role behavior. E5 and Qwen models retain
+    /// their query instructions, while BGE and custom providers receive the
+    /// original unprefixed query text.
     ///
     /// Use this for all search/recall/suggest query embedding paths so that
     /// instruction-tuned models land in the correct side of their retrieval
@@ -149,10 +149,15 @@ impl KhiveRuntime {
     ) -> RuntimeResult<Vec<f32>> {
         let model = parse_embedding_model_alias(model_name);
         let service = self.embedder(model_name).await?;
+        let texts = [text.to_string()];
         let emb_model = model.unwrap_or_default();
-        service
-            .embed_query(&[text.to_string()], emb_model)
-            .await?
+        let embeddings = match emb_model {
+            EmbeddingModel::BgeSmallEnV15
+            | EmbeddingModel::BgeBaseEnV15
+            | EmbeddingModel::BgeLargeEnV15 => service.embed(&texts, emb_model).await?,
+            _ => service.embed_query(&texts, emb_model).await?,
+        };
+        embeddings
             .into_iter()
             .next()
             .ok_or_else(|| RuntimeError::Internal("embed_query returned empty vec".into()))
@@ -265,8 +270,8 @@ impl KhiveRuntime {
 
     /// Embed a batch of queries for retrieval using the named model.
     ///
-    /// Applies `EmbeddingService::embed_query`. Use for bulk query-side
-    /// operations where multiple queries need instruction-tuned prefixing.
+    /// Applies the same pre-0.6 query-role compatibility behavior as
+    /// [`Self::embed_query_with_model`].
     ///
     /// Returns `UnknownModel` if `model_name` is not registered.
     pub async fn embed_query_batch_with_model(
@@ -280,7 +285,12 @@ impl KhiveRuntime {
         let model = parse_embedding_model_alias(model_name);
         let service = self.embedder(model_name).await?;
         let emb_model = model.unwrap_or_default();
-        Ok(service.embed_query(texts, emb_model).await?)
+        match emb_model {
+            EmbeddingModel::BgeSmallEnV15
+            | EmbeddingModel::BgeBaseEnV15
+            | EmbeddingModel::BgeLargeEnV15 => Ok(service.embed(texts, emb_model).await?),
+            _ => Ok(service.embed_query(texts, emb_model).await?),
+        }
     }
 
     /// Search vectors using either a caller-provided embedding or query text.


### PR DESCRIPTION
Bumps lattice-embed and lattice-fann from 0.4.2 to 0.6.0 (pre-0.4.0-publish requirement).

## Semantic compatibility shim

lattice-embed 0.6 added a BGE query instruction ("Represent this sentence for searching relevant passages: ") to `embed_query`, which 0.4.2 did not apply. The stored recall calibration (fusion weights, posteriors, test fixtures) was tuned against unprefixed BGE queries, so this PR pins the pre-0.6 behavior in `khive-runtime::retrieval`: BGE models (including the `default()` BgeSmallEnV15 fallback) embed queries unprefixed via `embed`, while E5 and Qwen models keep their query instructions (unchanged in 0.6). Adopting the BGE query prefix is deliberately out of scope; it changes ranking behavior and should land as its own measured change.

Version pins use caret semantics, so the additive 0.6.1 (wasm SIMD128 kernels) is picked up automatically when it ships.