### PR TITLE
ci(docs): lint ADR title references against ADR H1 titles

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -54,6 +54,12 @@ repos:
         language: system
         files: ^crates/.*\.sql$
         pass_filenames: false
+      - id: lint-adr-refs
+        name: lint ADR references
+        entry: sh scripts/lint-adr-refs.sh
+        language: system
+        files: ^(docs/.*\.md|crates/(.*/docs/.*\.md|.*/design[^/]*\.md))$
+        pass_filenames: false
 
   # TypeScript / Next.js: eslint + prettier (run via pnpm)
   - repo: local

--- a/crates/khive-bm25/docs/design.md
+++ b/crates/khive-bm25/docs/design.md
@@ -5,7 +5,7 @@
 ### BM25 Configuration Defaults (ADR-030)
 
 - This crate implements the BM25 (Okapi BM25) keyword index with the Robertson-Walker IDF
-  variant, ported as part of the `khive-retrieval` stack (ADR-030: Retrieval Stack Port).
+  variant, ported as part of the `khive-retrieval` stack (ADR-030).
 - Default parameters: `k1 = 1.2` (term saturation), `b = 0.75` (length normalization).
 - These defaults reflect the canonical IR literature recommendations and are validated on
   construction — invalid (non-finite, negative `k1`, or out-of-range `b`) values are rejected.

--- a/crates/khive-bm25/docs/design.md
+++ b/crates/khive-bm25/docs/design.md
@@ -2,7 +2,7 @@
 
 ## ADR Compliance
 
-### ADR-030: BM25 Configuration Defaults
+### BM25 Configuration Defaults (ADR-030)
 
 - This crate implements the BM25 (Okapi BM25) keyword index with the Robertson-Walker IDF
   variant, ported as part of the `khive-retrieval` stack (ADR-030: Retrieval Stack Port).

--- a/crates/khive-db/docs/design.md
+++ b/crates/khive-db/docs/design.md
@@ -2,7 +2,7 @@
 
 ## ADR Compliance
 
-### ADR-009: Graph Edge Routing
+### Graph Edge Routing (ADR-009)
 
 - `graph_edges` carries a `target_backend` column added in V9 that enables
   backend-specific routing for edge traversal.
@@ -15,7 +15,7 @@
   correctly without whitespace-based tokenization. All `text()` and
   `text_with_tokenizer()` backends default to `trigram`.
 
-### ADR-015: Schema Migration System
+### Schema Migration System (ADR-015)
 
 - `migrations.rs` contains all versioned DDL in a single file — splitting
   across files would make migration sequencing harder to verify.
@@ -27,7 +27,7 @@
 - V6/V7/V8 are frozen no-op slots; their `name` strings appear in the
   production `_schema_migrations` table and must not change.
 
-### ADR-017: Pack Standard — Pack-Auxiliary Schema
+### Pack Standard — Pack-Auxiliary Schema (ADR-017)
 
 - `apply_pack_ddl_statements` runs pack DDL idempotently without version
   tracking. Pack auxiliary tables use `CREATE TABLE IF NOT EXISTS` and are
@@ -35,11 +35,11 @@
 - The `SchemaPlan` type lives in `khive-runtime` (above this crate); this
   method accepts `&[&'static str]` to avoid a circular dependency.
 
-### ADR-031: SparseStore
+### SparseStore (ADR-031)
 
 - `stores/sparse.rs` implements the SQLite-backed `SparseStore` trait.
 
-### ADR-043: Embedding Model Registry
+### Embedding Model Registry (ADR-043)
 
 - `_embedding_models` table (created in V14) tracks which embedding model
   is active per vector engine with a canonical key for deduplication.
@@ -52,32 +52,32 @@
   a preserving rebuild of vec0 virtual tables to add the same column without
   data loss.
 
-### ADR-044: Old-Schema Vec0 Detection
+### Old-Schema Vec0 Detection (ADR-044)
 
 - At vector store open time, `pragma_table_info` inspects whether the `field`
   column exists. Tables predating the field column are flagged with an error
   after V17 (the silent-drop path was removed in V17).
 
-### ADR-046: Event-Sourced Proposals
+### Event-Sourced Proposals (ADR-046)
 
 - V15 creates `proposals_open`, a fold-derived projection of proposal events
   that makes `list(kind=proposal, status="open")` an index scan.
 - V18 adds `'applying'` to the `proposals_open` status CHECK constraint to
   handle the apply/withdraw race condition.
 
-### ADR-047: Entity Domain Filter Case Sensitivity
+### Entity Domain Filter Case Sensitivity (ADR-047)
 
 - The tags/domain filter in `SqlEntityStore` normalizes values to lowercase
   before comparison so that domain filtering is case-insensitive.
 
-### ADR-048: Brain Pack + Knowledge Sections
+### Brain Pack + Knowledge Sections (ADR-048)
 
 - V20 creates `brain_profile_snapshots` and `brain_event_log` tables for
   the brain pack (Phase 1).
 - V21 creates `knowledge_sections` with a 10-value SectionType enum, FK to
   `knowledge_atoms`, and UNIQUE(atom_id, section_type) (Phase 2).
 
-### ADR-049: Daemon & Warm Startup
+### Daemon & Warm Startup (ADR-049)
 
 - V22 extends `knowledge_atoms`, `knowledge_sections`, and `knowledge_domains`
   with a `status` column (NOT NULL DEFAULT 'draft'), plus `source_uri` and

--- a/crates/khive-fold/docs/design.md
+++ b/crates/khive-fold/docs/design.md
@@ -36,7 +36,7 @@
 
 ## ADR Compliance
 
-### ADR-024: Fold Cognitive Primitives (no-clock rule)
+### Fold Cognitive Primitives (no-clock rule) (ADR-024)
 
 `FoldContext` and `ObjectiveContext` both default `as_of` to `DateTime::<Utc>::default()`
 (Unix epoch) rather than calling `Utc::now()`. This is deliberate: the foundation layer must

--- a/crates/khive-fusion/docs/design.md
+++ b/crates/khive-fusion/docs/design.md
@@ -2,25 +2,25 @@
 
 ## ADR Compliance
 
-### ADR-006: Deterministic Scoring — RRF rank indexing convention
+### Deterministic Scoring — RRF rank indexing convention (ADR-006)
 
 - The RRF implementation uses 1-indexed ranks throughout. Position 0 in an input list maps to
   rank 1 in the RRF formula, consistent with the `rrf_score` function in `khive-score`
   (ADR-006: Deterministic Scoring).
 
-### ADR-012: Retrieval Composition
+### Retrieval Composition (ADR-012)
 
 - This crate provides the fusion layer that combines ranked result lists from multiple retrieval
   sources. It is consumed by higher-level retrieval pipelines to aggregate dense (vector) and
   lexical (BM25) signals into a single ranked output.
 
-### ADR-030: Hybrid Retrieval
+### Hybrid Retrieval (ADR-030)
 
 - The five `FusionStrategy` variants (RRF, Weighted, Union, VectorOnly, KeywordOnly) implement
   the hybrid retrieval strategy options specified for the system. RRF is the default as it is
   robust to score distribution differences between sources.
 
-### ADR-031: Multi-Engine Retrieval
+### Multi-Engine Retrieval (ADR-031)
 
 - The `fuse()` dispatcher accepts results from any number of retrieval sources and routes them
   through the appropriate strategy. VectorOnly and KeywordOnly are single-source passthrough

--- a/crates/khive-gate/docs/design.md
+++ b/crates/khive-gate/docs/design.md
@@ -38,7 +38,7 @@ This crate implements the public types and default gate defined by ADR-018:
   `input.verb`, `input.args`) are the policy input contract (e.g., for Rego). Any
   field rename is a breaking change.
 
-### ADR-007: Namespace
+### Namespace (ADR-007)
 
 `GateRequest.namespace` must reflect exactly what the runtime sees, with no coercion
 at the gate layer. Coercing an empty namespace to a default inside the gate would

--- a/crates/khive-hnsw/docs/design.md
+++ b/crates/khive-hnsw/docs/design.md
@@ -2,7 +2,7 @@
 
 ## ADR Compliance
 
-### ADR-011: SIMD Foundation Layer
+### SIMD Foundation Layer (ADR-011)
 
 - Distance computation (`src/distance.rs`) delegates all vector math to `lattice-embed::simd`
   (ADR-011: Embedding and Inference — `lattice-embed` is the SIMD and quantization foundation).
@@ -10,7 +10,7 @@
 - INT8 dot product (`int8_dot_product_raw`) also routes through `lattice_embed::simd::dot_product_i8_raw`.
 - The HNSW crate itself contains no SIMD code; it is purely algorithmic.
 
-### ADR-030: HNSW Index Management Strategy
+### HNSW Index Management Strategy (ADR-030)
 
 - Default parameters: M=20, ef_construction=200, ef_search=80, dimensions=384
   - M=20 is empirically optimal for k=10 recall at 384d

--- a/crates/khive-hnsw/docs/design.md
+++ b/crates/khive-hnsw/docs/design.md
@@ -5,7 +5,7 @@
 ### SIMD Foundation Layer (ADR-011)
 
 - Distance computation (`src/distance.rs`) delegates all vector math to `lattice-embed::simd`
-  (ADR-011: Embedding and Inference — `lattice-embed` is the SIMD and quantization foundation).
+  (ADR-011 — `lattice-embed` is the SIMD and quantization foundation).
 - Cosine, Dot, and L2 metrics use NEON/AVX2/AVX-512 dispatch from the lattice-embed crate.
 - INT8 dot product (`int8_dot_product_raw`) also routes through `lattice_embed::simd::dot_product_i8_raw`.
 - The HNSW crate itself contains no SIMD code; it is purely algorithmic.

--- a/crates/khive-mcp/docs/design.md
+++ b/crates/khive-mcp/docs/design.md
@@ -2,7 +2,7 @@
 
 ## ADR Compliance
 
-### ADR-016: Request DSL — Single `request` Tool
+### Request DSL — Single `request` Tool (ADR-016)
 
 - The MCP server exposes exactly one tool named `request`. All verbs are dispatched
   through it using the function-call DSL or JSON form.
@@ -18,7 +18,7 @@
 - Invalid DSL (parse/lex failure) returns an RPC-level `invalid_params` error.
   Per-verb validation failure returns a per-op `{ok: false, error: "..."}` entry.
 
-### ADR-017: Pack Standard — Vocabulary, Visibility, and Schema Plans
+### Pack Standard — Vocabulary, Visibility, and Schema Plans (ADR-017)
 
 - Subhandler verbs are operator-only and are blocked at the MCP wire boundary.
   Exception: `help=true` is short-circuited in `VerbRegistry::dispatch` before
@@ -29,7 +29,7 @@
 - `register_embedders` is called on every pack after the registry is built so
   custom embedding providers are available before the first `remember`/`recall`.
 
-### ADR-027: Dynamic Pack Loading
+### Dynamic Pack Loading (ADR-027)
 
 - `builtin_pack_names()` is sourced from `PackRegistry::discovered_names()` so
   the list always reflects whichever pack crates are linked into the binary.
@@ -38,7 +38,7 @@
 - `pack.rs` force-references one public symbol per pack crate so the linker
   includes their `inventory::submit!` constructors in the final binary.
 
-### ADR-031: Multi-Engine Retrieval — Edge Endpoint Rules and Embedder Registration
+### Multi-Engine Retrieval — Edge Endpoint Rules and Embedder Registration (ADR-031)
 
 - After the registry is built, `install_edge_rules` aggregates pack-declared
   edge endpoint rules into the runtime so `validate_edge_relation_endpoints`
@@ -46,7 +46,7 @@
 - `call_register_embedders` is invoked after registry construction, before any
   verb dispatch, to wire custom embedding providers from each pack.
 
-### ADR-018: Authorization Gate and Audit Persistence
+### Authorization Gate and Audit Persistence (ADR-018)
 
 - The authorization gate from `runtime.config().gate` is threaded into the
   registry. Gate decisions are hard-enforcing — a `Deny` result blocks pack
@@ -54,7 +54,7 @@
 - The `EventStore` is wired into the registry via `builder.with_event_store` for
   audit persistence of all dispatched operations.
 
-### ADR-038: Write-Key Conflict Detection
+### Write-Key Conflict Detection (ADR-038)
 
 - Before parallel/single dispatch, operations targeting the same write key in
   the same batch are detected and receive per-op error entries.
@@ -62,7 +62,7 @@
 - `results.length == summary.total` is preserved (the response envelope contract
   is never violated by conflict detection).
 
-### ADR-045: Presentation Transforms
+### Presentation Transforms (ADR-045)
 
 - Presentation transforms are applied per-op AFTER dispatch, at the response
   envelope boundary. Chain `$prev` substitution uses canonical (verbose) handler
@@ -74,7 +74,7 @@
 - Known presentation mode strings: `"agent"` (default, token-efficient),
   `"verbose"` (full canonical shape), `"human"` (same as verbose at runtime).
 
-### ADR-049: Daemon — Warm Pack Registry
+### Daemon — Warm Pack Registry (ADR-049)
 
 - The `daemon.rs` module provides the client side: `forward_or_spawn` connects
   to a warm daemon, auto-spawns it on first use, and maps responses to MCP
@@ -86,7 +86,7 @@
 - `DaemonDispatch` is implemented on `KhiveMcpServer` so the runtime daemon
   server can call back into the MCP server's local dispatch path.
 
-### ADR-014: Fail-Fast Pack Validation
+### Fail-Fast Pack Validation (ADR-014)
 
 - Pack registration is fail-fast: unknown names or unsatisfied dependencies
   abort construction and return the original runtime so callers can recover.

--- a/crates/khive-merge/docs/design.md
+++ b/crates/khive-merge/docs/design.md
@@ -8,7 +8,7 @@ integration layer is extended to expose snapshot ancestry for LCA walks.
 
 ## ADR Compliance
 
-### ADR-010: KG Versioning
+### KG Versioning (ADR-010)
 
 - The v1 merge path is a line-merge on sorted NDJSON, implemented in `khive-vcs`.
 - `khive-merge` provides the v2 semantic merge that understands entity identity, field-level
@@ -16,7 +16,7 @@ integration layer is extended to expose snapshot ancestry for LCA walks.
 - Promotion to a workspace member depends on the VCS layer exposing snapshot ancestry via a
   `SnapshotReader`-compatible API.
 
-### ADR-020: VCS Integration Layer
+### VCS Integration Layer (ADR-020)
 
 - `khive-merge` is not yet registered in any pack; the VCS integration surface must be extended
   before the `ThreeWayMergeEngine` can be wired into production.

--- a/crates/khive-pack-brain/docs/design.md
+++ b/crates/khive-pack-brain/docs/design.md
@@ -2,7 +2,7 @@
 
 ## ADR Compliance
 
-### ADR-032 (Brain Pack)
+### Brain Pack (ADR-032)
 
 The brain pack implements profile-oriented Bayesian auto-tuning over the shared event log.
 
@@ -40,7 +40,7 @@ system-default fallback for `consumer_kind="recall"` when no explicit binding ma
 `FeedbackExplicit` event emitter. `brain.emit` predates this design and its log entries are
 treated as `Irrelevant` to avoid spurious updates during event replay.
 
-### ADR-048 (Section Posteriors)
+### Section Posteriors (ADR-048)
 
 Section posteriors track per-section relevance weights within a knowledge atom. Each profile
 maintains a `SectionPosteriorState` keyed by `SectionType` (10 canonical types: Overview,

--- a/crates/khive-pack-comm/docs/design.md
+++ b/crates/khive-pack-comm/docs/design.md
@@ -2,7 +2,7 @@
 
 ## ADR Compliance
 
-### ADR-040: Communication Pack
+### Communication Pack (ADR-040)
 
 This crate is the primary implementation of ADR-040. It provides five `comm.*` verbs over the
 standard `message` note kind stored in the notes table.
@@ -32,7 +32,7 @@ Key design decisions from ADR-040:
 - **`read()` is a recipient-only action**: marking an outbound (sent) message as read is rejected.
   Only inbound messages (direction=inbound) can be marked read.
 
-### ADR-025: Verb Categories
+### Verb Categories (ADR-025)
 
 Handler definitions in `vocab.rs` assign each verb a `VerbCategory` matching the speech-act
 taxonomy from ADR-025. The mapping is enforced by the `verb_categories_match_spec` unit test.

--- a/crates/khive-pack-gtd/docs/design.md
+++ b/crates/khive-pack-gtd/docs/design.md
@@ -2,14 +2,14 @@
 
 ## ADR Compliance
 
-### ADR-002: Edge Ontology (17 edge relations — closed set; 15 base + 2 epistemic via ADR-055)
+### Edge Ontology (17 edge relations — closed set; 15 base + 2 epistemic via ADR-055) (ADR-002)
 
 - The GTD pack does NOT add new edge relation variants; `depends_on` is already in the base set.
 - The pack additively extends the _endpoint contract_ to allow `depends_on` between two `task`
   notes (base contract restricts it to entity→entity). This is pack-extensible per ADR-017 rules.
 - Edge relation enum remains closed; packs may only extend endpoint pairs, not add new relations.
 
-### ADR-004: NoteKindSpec lifecycle declaration
+### NoteKindSpec lifecycle declaration (ADR-004)
 
 - `GtdPack` declares a `NoteKindSpec` for the `task` note kind.
 - Lifecycle field is named `kind_status` (NOT `status`) to avoid semantic collision with
@@ -20,7 +20,7 @@
   This is intentional and differs from the original ADR-019 draft which considered reopen semantics.
   The no-reopen rule is authoritative; use `gtd.assign` to create a new task instead.
 
-### ADR-017: Pack Standard (Pack trait, `EDGE_RULES`, pack-extensible edge endpoints)
+### Pack Standard (Pack trait, `EDGE_RULES`, pack-extensible edge endpoints) (ADR-017)
 
 - `GtdPack` implements the `Pack` trait and `PackRuntime` trait.
 - Declares vocabulary via constants: `NOTE_KINDS`, `ENTITY_KINDS`, `HANDLERS`, `EDGE_RULES`,
@@ -30,7 +30,7 @@
 - `EDGE_RULES` contains one rule: `depends_on` between two `task` notes (task→task).
 - Endpoint rules are additive only — this pack cannot tighten the base contract.
 
-### ADR-019: GTD lifecycle contract
+### GTD lifecycle contract (ADR-019)
 
 - Five verbs: `gtd.assign`, `gtd.next`, `gtd.complete`, `gtd.tasks`, `gtd.transition`.
 - Lifecycle states: `inbox → next | waiting | someday | active | done | cancelled`.
@@ -42,7 +42,7 @@
 - `depends_on` property stores UUIDs of blocking tasks; `gtd.next` excludes tasks whose
   blockers are not in `done` state (scenario-gtd C2).
 
-### ADR-025: Illocutionary verb classification (Searle 1976)
+### Illocutionary verb classification (Searle 1976) (ADR-025)
 
 - `gtd.assign` → Directive (directs an actor to perform work)
 - `gtd.next` → Assertive (retrieves actionable task state)
@@ -50,20 +50,20 @@
 - `gtd.complete` → Declaration (changes task institutional status to terminal)
 - `gtd.transition` → Declaration (changes task lifecycle status by fiat)
 
-### ADR-027: Inventory self-registration
+### Inventory self-registration (ADR-027)
 
 - `GtdPack` self-registers via `inventory::submit!` so it can be loaded dynamically from
   the pack registry by name (`"gtd"`) without a hard compile-time dependency in the MCP binary.
 - Requires `"kg"` pack as a dependency (`REQUIRES = &["kg"]`).
 
-### ADR-019: Non-propagating after_create failures
+### Non-propagating after_create failures (ADR-019)
 
 - If `depends_on` edge creation fails after the task note is successfully written,
   the error is logged and swallowed. A `properties["depends_on"]` key captures the same
   dependency information for queries that bypass the graph layer.
 - This avoids misleading the caller with `ok: false` for a task that is already on disk.
 
-### ADR-017: Pack-extensible edge rule for task blockers
+### Pack-extensible edge rule for task blockers (ADR-017)
 
 - The GTD pack's `EDGE_RULES` extends the base `depends_on` endpoint contract to allow
   task-note→task-note links (ADR-017 Pack Standard §"Pack-extensible edge endpoints").

--- a/crates/khive-pack-knowledge/docs/design.md
+++ b/crates/khive-pack-knowledge/docs/design.md
@@ -13,7 +13,7 @@
 
 ## ADR Compliance
 
-### ADR-047: Knowledge Pack Verb Surface
+### Knowledge Pack Verb Surface (ADR-047)
 
 - This pack implements the 18 verb corpus surface: atoms/domains CRUD, TF-IDF search with
   embedding rerank, fold, import, edit, challenge, adjudicate, and concept-tier sugar.
@@ -21,7 +21,7 @@
   and comparison. The same normalized value is used in `properties.domain`, promoted tags,
   and response bodies so all three surfaces agree.
 
-### ADR-048: Section Profiles and Vamana ANN Integration
+### Section Profiles and Vamana ANN Integration (ADR-048)
 
 - The `SectionType` enum is a closed 10-value set. Headings in atlas markdown files are mapped
   to canonical section types via `from_str_loose`, which accepts common heading aliases.
@@ -32,7 +32,7 @@
   fused via RRF (k=60). The index lifecycle is owned by `knowledge/vamana.rs`: warm-load from
   persistent snapshot, fingerprint validation, rebuild from sqlite-vec corpus on stale/miss.
 
-### ADR-047: Section Review Lifecycle
+### Section Review Lifecycle (ADR-047)
 
 - `knowledge.challenge` marks a section as disputed and increments `dispute_count` on the parent
   atom. `knowledge.adjudicate` resolves the dispute: `accept` → `verified`, `reject` → `reviewed`.
@@ -40,17 +40,17 @@
 - The Vamana warm-start protocol (`ensure_ann_background`) fires at most once per
   `{namespace, model}` key using a `Mutex<HashSet>` single-flight guard.
 
-### ADR-027: Pack Self-Registration
+### Pack Self-Registration (ADR-027)
 
 - `KnowledgePackFactory` is submitted via `inventory::submit!` so the runtime can discover and
   load this pack by name without explicit wiring. `REQUIRES = ["kg"]` declares the dependency.
 
-### ADR-002: Edge Ontology
+### Edge Ontology (ADR-002)
 
 - `knowledge.cite` creates an `introduced_by` edge from a concept entity to a source entity
   (document, person, or org). The edge direction is concept → source.
 
-### ADR-015: Schema Migration
+### Schema Migration (ADR-015)
 
 - Corpus tables (`knowledge_atoms`, `knowledge_domains`) are added in V19 migration.
 - Section table (`knowledge_sections`) is added in a subsequent migration.

--- a/crates/khive-pack-memory/docs/design.md
+++ b/crates/khive-pack-memory/docs/design.md
@@ -2,7 +2,7 @@
 
 ## ADR Compliance
 
-### ADR-021: Memory Pack (remember / recall verbs)
+### Memory Pack (remember / recall verbs) (ADR-021)
 
 - Implements `memory.remember` (commissive — creates a memory note with salience and decay)
   and `memory.recall` (assertive — retrieves memory notes via decay-aware hybrid ranking).
@@ -19,20 +19,20 @@
 - `decay_factor` must be finite and `>= 0`; no upper clamp is required.
 - Final composite score must be in `[0, 1]`.
 
-### ADR-025: Illocutionary Verb Classification
+### Illocutionary Verb Classification (ADR-025)
 
 - `memory.remember` — Commissive: commits the caller to a persistent change in the namespace.
 - `memory.recall` — Assertive: retrieves and presents the current state of affairs.
 - Sub-handlers (`recall_embed`, `recall_candidates`, `recall_fuse`, `recall_rerank`, `recall_score`)
   are all Assertive.
 
-### ADR-027: Inventory Self-Registration
+### Inventory Self-Registration (ADR-027)
 
 - `MemoryPackFactory` is submitted via `inventory::submit!` so the pack is auto-discovered at
   startup without requiring explicit registration at the call site.
 - The factory declares `requires = ["kg"]` so the runtime enforces dependency ordering.
 
-### ADR-032: Brain-Tunable Parameters
+### Brain-Tunable Parameters (ADR-032)
 
 - `MemoryPack` implements `PackTunable` so the brain pack can adjust recall scoring weights
   based on observed usage patterns.
@@ -40,7 +40,7 @@
   `memory::temporal_weight`) correspond to the three Beta posteriors in `BalancedRecallState`.
   Posterior means flow directly into `RecallConfig`.
 
-### ADR-033: Recall Reranking and Weighted Fusion
+### Recall Reranking and Weighted Fusion (ADR-033)
 
 - A rerank stage sits between fusion and final scoring in the recall pipeline.
 - When `reranker_weights` is non-empty in `RecallConfig`, weighted reranking replaces the
@@ -49,7 +49,7 @@
   config (`RecallConfig.reranker_weights`), not from the incoming request body.
 - Sub-handler `memory.recall_rerank` exposes the rerank stage as a dotted sub-verb.
 
-### ADR-043: CJK Routing for Multilingual Embedding
+### CJK Routing for Multilingual Embedding (ADR-043)
 
 - When the recall query is primarily CJK text and a multilingual embedding model is registered,
   that model is preferred over other registered models.
@@ -58,7 +58,7 @@
 - The model preference is configured via `ScoringConfig.multilingual_model` or by matching
   registered model names against known multilingual substrings.
 
-### ADR-002: Edge Ontology — Supersedes Suppression
+### Edge Ontology — Supersedes Suppression (ADR-002)
 
 - Memory recall suppresses candidates that have an inbound `supersedes` edge (i.e., the memory
   has been explicitly superseded by a newer one).
@@ -67,7 +67,7 @@
 - A property shortcut (`superseded_by` in `properties`) provides a secondary suppression path
   for archive-import compatibility when graph edges are not available.
 
-### ADR-023: Dotted Sub-Handler Naming
+### Dotted Sub-Handler Naming (ADR-023)
 
 - Recall pipeline stages are exposed as sub-handlers using dotted names:
   `memory.recall_embed`, `memory.recall_candidates`, `memory.recall_fuse`,

--- a/crates/khive-pack-schedule/docs/design.md
+++ b/crates/khive-pack-schedule/docs/design.md
@@ -128,7 +128,7 @@ The pack self-registers via `inventory::submit!`. It declares `REQUIRES = ["kg"]
 ensuring the kg pack is loaded before this pack during boot-time dependency
 resolution.
 
-### ADR-025: Verb Speech Acts
+### Verb Speech Acts (ADR-025)
 
 - `schedule.remind` and `schedule.schedule` are commissive (create future intent).
 - `schedule.agenda` is assertive (query state without side effects).

--- a/crates/khive-pack-template/docs/design.md
+++ b/crates/khive-pack-template/docs/design.md
@@ -54,7 +54,7 @@ docs/
   - `Visibility::Subhandler` — internal / CLI-only; not on the MCP wire.
 - Pack dependencies are declared in `Pack::REQUIRES`; the runtime validates they are loaded.
 
-### ADR-027: Dynamic pack loading via inventory self-registration
+### Dynamic pack loading via inventory self-registration (ADR-027)
 
 - Each pack crate must call `inventory::submit! { khive_runtime::PackRegistration(&Factory) }`
   exactly once. This causes the linker to include the pack factory in the binary's startup inventory.

--- a/crates/khive-query/docs/design.md
+++ b/crates/khive-query/docs/design.md
@@ -9,9 +9,9 @@ has no dependency on storage, DB, or runtime crates.
 ## ADR Links
 
 - [ADR-001: Entity Kind Taxonomy](../../../docs/adr/ADR-001-entity-kind-taxonomy.md)
-- [ADR-002: Edge Ontology](../../../docs/adr/ADR-002-edge-ontology.md)
+- [ADR-002: Closed Edge Ontology](../../../docs/adr/ADR-002-edge-ontology.md)
 - [ADR-008: Query Layer Separation](../../../docs/adr/ADR-008-query-layer-separation.md)
-- [ADR-041: Event Provenance Projection](../../../docs/adr/ADR-041-event-provenance-projection.md)
+- [ADR-041: Event Provenance Projection — Hybrid Log + Graph Edges](../../../docs/adr/ADR-041-event-provenance-projection.md)
 
 ## Modules
 
@@ -71,7 +71,7 @@ ADR-008. It is intentionally split into three stages:
   text. Any attempt to set `namespace` in a query node property or WHERE condition
   is rejected at validation time.
 
-### ADR-041: Synthetic Observation Edge Paths
+### Synthetic Observation Edge Paths (ADR-041)
 
 Relations prefixed `observed_as_*` (specifically: `observed_as_candidate`,
 `observed_as_selected`, `observed_as_target`, `observed_as_signal`) are synthetic

--- a/crates/khive-request/docs/design.md
+++ b/crates/khive-request/docs/design.md
@@ -17,7 +17,7 @@ This crate is the primary implementation of the request DSL.
 - Chain mode uses `$prev` / `$prev.dotted.path` references that are substituted
   at dispatch time — the parser validates their form but not their values.
 
-### ADR-038: Write-Key Conflict Detection
+### Write-Key Conflict Detection (ADR-038)
 
 Parallel-batch preflight check to prevent two ops in the same batch from
 targeting the same record for mutation.

--- a/crates/khive-retrieval/docs/design.md
+++ b/crates/khive-retrieval/docs/design.md
@@ -2,7 +2,7 @@
 
 ## ADR Compliance
 
-### ADR-004: Graph Traversal Algorithms
+### Graph Traversal Algorithms (ADR-004)
 
 - The legacy `graph` module (the `graph-legacy` feature) was removed (#58). It predated the
   `GraphStore` trait and duplicated traversal that now lives canonically in `khive-runtime`
@@ -18,7 +18,7 @@
 - This guarantees cross-platform ranking identity (x86_64, ARM64, WASM) and enables
   `Ord` + `Hash` on ranked results.
 
-### ADR-012: Retrieval as Composition of Storage-Capability Signals
+### Retrieval as Composition of Storage-Capability Signals (ADR-012)
 
 - `khive-retrieval` materialises the composition layer described in ADR-012.
 - `VectorSearch`, `KeywordSearch`, `HybridSearcher`, and `Reranker` are independent traits.
@@ -28,7 +28,7 @@
   Per-namespace filtering helpers (`filter_atoms_by_namespace`) are provided for callers
   operating below the runtime trust boundary.
 
-### ADR-030: Feature Flag Policy
+### Feature Flag Policy (ADR-030)
 
 - `replay/engine_replay.rs` is co-located with its SQL schema helpers because all five
   replay primitives share a single SQLite connection type and the same `weight_events`

--- a/crates/khive-runtime/docs/design.md
+++ b/crates/khive-runtime/docs/design.md
@@ -2,7 +2,7 @@
 
 ## ADR Compliance
 
-### ADR-002: Edge Ontology
+### Edge Ontology (ADR-002)
 
 - 17 closed edge relations (15 base relations plus 2 epistemic relations added by ADR-055);
   endpoint contract enforced at the runtime layer in `operations.rs`
@@ -14,13 +14,13 @@
 - `dependency_kind` metadata key is only valid on `depends_on` edges
 - Pack-declared edge endpoint rules are additive only; packs cannot tighten the base contract
 
-### ADR-004 / ADR-005: Event and Storage Capability Traits
+### Event and Storage Capability Traits (ADR-004, ADR-005)
 
 - `EventStore::append` is called after each authorized dispatch to record audit events
 - The audit payload field holds the full `AuditEvent` envelope (not a bare verb result)
 - Top-level event fields follow the ADR-004/ADR-005 schema
 
-### ADR-007: Namespace Strategy (Rev 6)
+### Namespace Strategy (Rev 6) (ADR-007)
 
 - Namespace is attribution and gate-policy input, not a storage partition; it is not a
   by-ID access control boundary
@@ -35,21 +35,21 @@
   scope produced at the gate boundary; it is not a by-ID access guard (historical:
   earlier ADR-007 revisions described it as the storage trust boundary — superseded)
 
-### ADR-009 / ADR-028: Multi-Backend Deployment
+### Multi-Backend Deployment (ADR-009, ADR-028)
 
 - `BackendId` identifies a named backend in multi-backend deployments; single-backend uses `"main"`
 - `KhiveRuntime::from_backend` is the preferred boot path for multi-backend deployments
 - Cross-backend `merge_entity` is unsupported in v1; both entities must reside on the same backend
 - `db_path` and `embedding_model` on `RuntimeConfig` are deprecated in favour of the external-backend path
 
-### ADR-010: KG Versioning / Portability
+### KG Versioning / Portability (ADR-010)
 
 - Export format is `"khive-kg"` version `"0.1"` (stable identifier for archive parsers)
 - Embeddings are excluded from archives (regenerable from text + model)
 - Edges are collected by source entity, not by namespace scan, to capture cross-entity relationships
 - `edge_id` field on `ExportedEdge` is stable across export/import cycles; old archives without it receive a fresh UUID on import
 
-### ADR-013 / ADR-024: Note Kinds and Annotation
+### Note Kinds and Annotation (ADR-013, ADR-024)
 
 - `annotates` edges targeting a note are validated before any write (atomicity)
 - `annotates` targets can be entity, note, edge, or event (cross-substrate by design)
@@ -86,7 +86,7 @@
 - `VerbRegistry` emits one `gate.check` info trace event per dispatch for observability
 - Obligations on `GateDecision::Allow` are serialized as an empty array when there are none
 
-### ADR-002 / ADR-019: Note and Edge Operations
+### Note and Edge Operations (ADR-002, ADR-019)
 
 - Three-case relation contract for link operations: annotates, supersedes, and entity→entity base rules
   (ADR-002: Edge Ontology governs the endpoint contract; ADR-019: GTD Pack extends it for task notes).
@@ -98,39 +98,39 @@
 - Default decay rate: 0.01 (~69-day half-life)
 - Per-note `decay_factor` is used by `DecayAwareSalienceObjective` rather than the objective's own rate
 
-### ADR-023: Declarative Pack Format
+### Declarative Pack Format (ADR-023)
 
 - Verb surface and visibility are declared per-pack; only `Visibility::Verb` entries appear in `help=true` envelopes
 - `all_verbs` returns only public verb entries; internal subhandlers require `all_handlers_with_names`
 
-### ADR-025: Pack Dispatch Trait
+### Pack Dispatch Trait (ADR-025)
 
 - `PackRuntime::dispatch` is the async per-verb entry point for each pack
 - Packs that do not use an embedder registry may ignore the `register_embedders` hook
 
-### ADR-027: Dynamic Pack Loading
+### Dynamic Pack Loading (ADR-027)
 
 - Pack factories are discovered via `inventory` at link time; missing dependencies are a boot error
 - Missing dependencies are not silently auto-added; the requested set must be explicit
 - `PackRegistry` performs topological sort of packs using Kahn's algorithm
 
-### ADR-029: Gate Authorization
+### Gate Authorization (ADR-029)
 
 - `RuntimeConfig::gate` defaults to `AllowAllGate`; production deployments plug in a policy-backed impl
 
-### ADR-030: Layered Retrieval Architecture
+### Layered Retrieval Architecture (ADR-030)
 
 - `KindHook` provides per-kind specialization for shared CRUD operations
 - The retrieval pipeline composes signal objectives without IO; the runtime layer materialises signal data
 
-### ADR-031: Pack-Extensible Embedder Registry
+### Pack-Extensible Embedder Registry (ADR-031)
 
 - Pack-declared embedder providers are registered via `PackRuntime::register_embedders`
 - Pack-extensible edge endpoint rules are shared across clones via `Arc<RwLock<_>>`
 - Base ADR-002 rules apply independently; pack rules are additive
 - `KhiveRuntime::install_edge_rules` is called once by the transport after `VerbRegistry` is built
 
-### ADR-033: Recall Pipeline
+### Recall Pipeline (ADR-033)
 
 - `NoteCandidate` carries pre-computed signals; objectives are pure functions with no IO
 - `MemoryRecallPipeline::default()` uses the ADR-021 default decay parameters
@@ -143,38 +143,38 @@
 - `GraphPatch` is a deferred stub; the auto-fix write path is not yet implemented
 - Violations are grouped by rule ID and sorted canonically
 
-### ADR-037: Inter-Pack Dependencies
+### Inter-Pack Dependencies (ADR-037)
 
 - Missing pack dependencies are collected and reported as a single `MissingPackDependencies` error
 - Circular dependencies are detected during topological sort and reported as `CircularPackDependency`
 - Remote resolution errors (`UnknownRemote`, `RemoteCacheMissing`) are part of the same error family
 
-### ADR-049: ANN Warmup
+### ANN Warmup (ADR-049)
 
 - `KhiveRuntime::warm_ann_index` is intended to run once at startup as a background task.
   The warm-start protocol is owned by the daemon (ADR-049: khived daemon); the runtime
   exposes the `warm_ann_index` hook for the daemon to invoke during startup.
 - Warm startup sequence follows steps 2–4 from the ANN warmup spec.
 
-### ADR-045: Verb Response Presentation
+### Verb Response Presentation (ADR-045)
 
 - `micros_to_iso` is the single conversion point from internal `i64` microsecond timestamps to ISO-8601
 - `Agent` mode: short UUIDs (8-char), relative timestamps within 24h, lifecycle nulls preserved, scores truncated to 3 sig-figs
 - `Human` mode at the MCP layer is identical to `Verbose`; terminal formatting is applied by the CLI layer
 - `full_id` is explicitly excluded from UUID shortening in Agent mode to preserve chaining handles
 
-### ADR-020: Stable Edge Identity
+### Stable Edge Identity (ADR-020)
 
 - `ExportedEdge::edge_id` carries the stable `LinkId` UUID across export/import cycles,
   as specified in ADR-020 (Git-Native KG Implementation) §edge_id.
 - Old archives (pre-0.2) omit `edge_id`; `serde(default)` assigns a fresh UUID on import.
 
-### ADR-049: Persistent Daemon
+### Persistent Daemon (ADR-049)
 
 - `khived` is a persistent warm runtime over a Unix socket
 - `PackRuntime::warm` is invoked on every registered pack during daemon startup
 
-### ADR-050: Namespace Token Contract
+### Namespace Token Contract (ADR-050)
 
 - `NamespaceToken` is sealed to prevent external construction without gate authorization
 - Namespace authority governs which namespace(s) a dispatch can read/write (minted at

--- a/crates/khive-runtime/docs/design.md
+++ b/crates/khive-runtime/docs/design.md
@@ -89,7 +89,7 @@
 ### Note and Edge Operations (ADR-002, ADR-019)
 
 - Three-case relation contract for link operations: annotates, supersedes, and entity→entity base rules
-  (ADR-002: Edge Ontology governs the endpoint contract; ADR-019: GTD Pack extends it for task notes).
+  (ADR-002 governs the endpoint contract; ADR-019 extends it for task notes).
 - The endpoint validation path is centralized in `operations.rs` so both `link` and `update_edge` share the same contract.
 
 ### ADR-021: Memory Pack
@@ -152,7 +152,7 @@
 ### ANN Warmup (ADR-049)
 
 - `KhiveRuntime::warm_ann_index` is intended to run once at startup as a background task.
-  The warm-start protocol is owned by the daemon (ADR-049: khived daemon); the runtime
+  The warm-start protocol is owned by the daemon (ADR-049); the runtime
   exposes the `warm_ann_index` hook for the daemon to invoke during startup.
 - Warm startup sequence follows steps 2–4 from the ANN warmup spec.
 

--- a/crates/khive-score/docs/design.md
+++ b/crates/khive-score/docs/design.md
@@ -22,7 +22,7 @@ Key design decisions and constraints:
 - The custom `Deserialize` impl rejects `i64::MIN` with an error, enforcing the proof boundary at
   the serialization boundary.
 
-### ADR-012: Retrieval Composition
+### Retrieval Composition (ADR-012)
 
 This crate provides the scoring primitives consumed by all retrieval backends (HNSW, Vamana,
 flat-scan). The distance-to-similarity conversion functions (`try_score_from_distance`,

--- a/crates/khive-storage/docs/design.md
+++ b/crates/khive-storage/docs/design.md
@@ -26,7 +26,7 @@ an error (`Sql`, `Notes`, `Entities`, `Graph`, `Events`, `Vectors`, `Sparse`,
 `khive-storage` depends on neither `rusqlite` nor `khive-db`, preserving the
 trait-only boundary. Backends implement these traits in their own crates.
 
-### [ADR-031: Multi-Engine Retrieval](../../../docs/adr/ADR-031-multi-engine-retrieval.md)
+### [ADR-031: Multi-Engine Retrieval — Embedder Trait, Registry, Configuration, and Pack Orchestration](../../../docs/adr/ADR-031-multi-engine-retrieval.md)
 
 `SparseStore` defines the sparse vector capability surface over the
 `SparseVector` type (parallel `indices`/`values` arrays). `TextSearch` defines
@@ -36,7 +36,7 @@ Non-default gather options return `StorageError::Unsupported` on backends that d
 not override the method. Term-level document-frequency statistics are exposed via
 `term_stats`, also optional (`Unsupported` by default).
 
-### [ADR-041: Event Provenance Projection](../../../docs/adr/ADR-041-event-provenance-projection.md) / [ADR-044: Vector Store Extensions](../../../docs/adr/ADR-044-vector-store-extensions.md)
+### [ADR-041: Event Provenance Projection — Hybrid Log + Graph Edges](../../../docs/adr/ADR-041-event-provenance-projection.md) / [ADR-044: Vector Store Extensions — Capabilities, Metadata Filter, Batched Search, Update, Orphan Sweep](../../../docs/adr/ADR-044-vector-store-extensions.md)
 
 `VectorStoreCapabilities` is returned by `VectorStore::capabilities()` and
 introspected by the retrieval layer at construction time to select code paths

--- a/crates/khive-types/docs/design.md
+++ b/crates/khive-types/docs/design.md
@@ -14,17 +14,17 @@ types for proposals, events, and namespace isolation.
 ## Relevant ADRs
 
 - [ADR-001: Entity Kind Taxonomy](../../../docs/adr/ADR-001-entity-kind-taxonomy.md)
-- [ADR-002: Edge Ontology](../../../docs/adr/ADR-002-edge-ontology.md)
+- [ADR-002: Closed Edge Ontology](../../../docs/adr/ADR-002-edge-ontology.md)
 - [ADR-004: Substrate Observables](../../../docs/adr/ADR-004-substrate-observables.md)
 - [ADR-013: Note Kind Taxonomy](../../../docs/adr/ADR-013-note-kind-taxonomy.md)
 - [ADR-017: Pack Standard](../../../docs/adr/ADR-017-pack-standard.md)
 - [ADR-019: GTD Pack](../../../docs/adr/ADR-019-gtd-pack.md)
 - [ADR-021: Memory Pack](../../../docs/adr/ADR-021-memory-pack.md)
-- [ADR-023: Declarative Pack Format](../../../docs/adr/ADR-023-declarative-pack-format.md)
-- [ADR-025: Verb Speech Acts](../../../docs/adr/ADR-025-verb-speech-acts.md)
+- [ADR-023: Pack Verb Surface, Visibility, and Composition](../../../docs/adr/ADR-023-declarative-pack-format.md)
+- [ADR-025: Verb Surface as Speech-Act Taxonomy](../../../docs/adr/ADR-025-verb-speech-acts.md)
 - [ADR-034: KG Validation Pipelines](../../../docs/adr/ADR-034-kg-validation-pipelines.md)
-- [ADR-045: Verb Response Presentation](../../../docs/adr/ADR-045-verb-response-presentation.md)
-- [ADR-046: Event-Sourced Proposals](../../../docs/adr/ADR-046-event-sourced-proposals.md)
+- [ADR-045: Verb Response Presentation Modes](../../../docs/adr/ADR-045-verb-response-presentation.md)
+- [ADR-046: Event-Sourced Agent KG Proposals](../../../docs/adr/ADR-046-event-sourced-proposals.md)
 
 ## Primary Modules
 
@@ -84,7 +84,7 @@ types for proposals, events, and namespace isolation.
 - `Entity.entity_type` holds the pack-governed subtype token; ontology type
   strings must not be stored raw in `properties`.
 
-### ADR-002: Edge Ontology
+### Edge Ontology (ADR-002)
 
 - `EdgeRelation` is a closed enum with exactly 17 canonical relations (15 base
   per ADR-002 + 2 epistemic `supports`/`refutes` added by ADR-055).
@@ -98,7 +98,7 @@ types for proposals, events, and namespace isolation.
 - Symmetric relations (`competes_with`, `composed_with`) are identified via
   `is_symmetric()`.
 
-### ADR-004: Substrate Model
+### Substrate Model (ADR-004)
 
 - Three substrates: `Note`, `Entity`, `Event` -- represented by `SubstrateKind`.
 - `SUBSTRATE_COUNT` is a compile-time constant (3).
@@ -117,7 +117,7 @@ types for proposals, events, and namespace isolation.
   This crate only carries the `Note` struct with a free-form `kind: String`
   validated at the pack boundary.
 
-### ADR-017: Pack-Extensible Edge Endpoints
+### Pack-Extensible Edge Endpoints (ADR-017)
 
 - `EdgeEndpointRule` declares the types allowed at each end of an edge for a
   specific relation.
@@ -138,7 +138,7 @@ types for proposals, events, and namespace isolation.
 - The `EdgeRelation` enum is the closed set -- not extensible. Only the
   per-relation endpoint contract (via `EdgeEndpointRule`) is extensible by packs.
 
-### ADR-023: Handler Visibility and Discovery
+### Handler Visibility and Discovery (ADR-023)
 
 - `HandlerDef` replaces the deprecated `VerbDef` type alias.
 - `Visibility::Verb` entries are surfaced on the MCP wire; `Visibility::Subhandler`
@@ -147,7 +147,7 @@ types for proposals, events, and namespace isolation.
   Empty (`&[]`) is the correct default for handlers without a fixed parameter
   schema.
 
-### ADR-025: Speech-Act Taxonomy for Verbs
+### Speech-Act Taxonomy for Verbs (ADR-025)
 
 - `VerbCategory` classifies verbs by illocutionary force: `Assertive`,
   `Directive`, `Commissive`, `Declaration`. `Expressive` is intentionally
@@ -156,13 +156,13 @@ types for proposals, events, and namespace isolation.
   permission checking, transport routing, or return-shape selection.
 - Every `Visibility::Verb` handler MUST carry a category.
 
-### ADR-034: Pack Validation Rules
+### Pack Validation Rules (ADR-034)
 
 - `Pack::VALIDATION_RULES` is a declarative catalog of rule identifiers
   contributed by a pack. Rule IDs are namespaced `<pack-name>/<rule-id>`. Actual
   rule implementations live in `khive-runtime`; this const is metadata-only.
 
-### ADR-045: Verb Presentation Policy
+### Verb Presentation Policy (ADR-045)
 
 - `VerbPresentationPolicy` controls whether a verb's response can be trimmed by
   agent-mode transforms.
@@ -176,7 +176,7 @@ types for proposals, events, and namespace isolation.
   the response into subsequent feedback or profile queries; an 8-char prefix is
   ambiguous.
 
-### ADR-046: Proposal Lifecycle
+### Proposal Lifecycle (ADR-046)
 
 - `EventKind` includes `ProposalCreated`, `ProposalReviewed`,
   `ProposalApplied`, `ProposalWithdrawn` for the event-sourced proposal state

--- a/crates/khive-vamana/docs/design.md
+++ b/crates/khive-vamana/docs/design.md
@@ -10,9 +10,9 @@ graph-based retrieval engine (ADR-048).
   -- recall/latency targets, snapshot validation, production defaults
 - [ADR-009: Backend Architecture](../../../docs/adr/ADR-009-backend-architecture.md)
   -- in-process retrieval engine boundary
-- [ADR-012: Retrieval Composition](../../../docs/adr/ADR-012-retrieval-composition.md)
+- [ADR-012: Retrieval Composition (High-Level Composition Layer)](../../../docs/adr/ADR-012-retrieval-composition.md)
   -- hybrid retrieval stack integration
-- [ADR-030: Retrieval Stack Port](../../../docs/adr/ADR-030-retrieval-stack-port.md)
+- [ADR-030: Retrieval Stack Port — khive-retrieval](../../../docs/adr/ADR-030-retrieval-stack-port.md)
   -- Rust retrieval layer
 
 **Primary modules:**
@@ -48,7 +48,7 @@ graph-based retrieval engine (ADR-048).
 
 ## ADR Compliance
 
-### ADR-048: Vamana ANN Engine
+### Vamana ANN Engine (ADR-048)
 
 This crate implements the Vamana ANN index as the knowledge-pack approximate
 nearest-neighbor engine.

--- a/crates/khive-vcs-adapters/docs/design.md
+++ b/crates/khive-vcs-adapters/docs/design.md
@@ -2,7 +2,7 @@
 
 ## ADR Compliance
 
-### ADR-036: KG Import/Export Adapters
+### KG Import/Export Adapters (ADR-036)
 
 - This crate implements the format adapter layer of the two-stage KG import pipeline.
 - Adapters are pure transforms: they parse a source format and produce `EntityRecord`/`EdgeRecord`
@@ -18,7 +18,7 @@
 - Phase P0 formats: `csv`, `tsv`, `json`, `ndjson`. Deferred to P1/P2: BibTeX, Turtle,
   JSON-LD, streaming JSON, GraphML, GEXF, Markdown.
 
-### ADR-020: Git-Native KG Implementation (field shapes)
+### Git-Native KG Implementation (field shapes) (ADR-020)
 
 - `EntityRecord` and `EdgeRecord` follow the wire shapes specified for the import pipeline.
 - `EntityRecord` carries `id`, `kind`, `name`, `description?`, `properties`, `tags`.
@@ -35,7 +35,7 @@
 - Unknown kinds produce `AdapterError::UnknownKind` — never silently defaulted.
 - Missing `kind` is a fatal `AdapterError::MissingField`.
 
-### ADR-002: Edge Ontology
+### Edge Ontology (ADR-002)
 
 - `EdgeRecord.relation` must be one of the 15 canonical edge relations.
 - Validation uses `khive_types::EdgeRelation::from_str` at parse time.

--- a/crates/khive-vcs/docs/design.md
+++ b/crates/khive-vcs/docs/design.md
@@ -2,7 +2,7 @@
 
 ## ADR Compliance
 
-### ADR-010: KG Versioning (git-native v1)
+### KG Versioning (git-native v1) (ADR-010)
 
 - KG state is stored as sorted NDJSON files in a git repository, not in a custom
   versioning system.
@@ -14,7 +14,7 @@
 - Snapshot coverage v1: entities and edges only. Notes are excluded until note packs
   define versioned export, import, privacy/redaction, and merge semantics.
 
-### ADR-020: Git-native sync, validate-first gate
+### Git-native sync, validate-first gate (ADR-020)
 
 - `run_sync` rebuilds the SQLite working database from `.khive/kg/entities.ndjson` and
   `edges.ndjson` atomically: the database is built in a `.tmp` sibling file and renamed
@@ -32,20 +32,20 @@
 - Custom push/pull error variants (`RemoteUnreachable`, `AuthFailed`, `NonFastForward`,
   `MergeRequired`) were removed; git is the remote protocol.
 
-### ADR-035: Vector embeddings are local-only derived state
+### Vector embeddings are local-only derived state (ADR-035)
 
 - `run_sync` intentionally skips vector embedding during import. Vectors are local-only
   derived state computed lazily via `kkernel kg embed` when needed.
 - FTS5 text index is populated during sync so that text search works immediately
   after sync without a separate embedding pass.
 
-### ADR-036: Validation pipeline
+### Validation pipeline (ADR-036)
 
 - The validate-first gate in `run_sync` implements the validation pipeline constraint:
   all edge relations are validated before any DB write, ensuring a clean error path
   that leaves the existing database intact.
 
-### ADR-037: Remote archive fetch with SHA-256 pin verification
+### Remote archive fetch with SHA-256 pin verification (ADR-037)
 
 - `run_sync_remote` fetches a remote KG archive via `git clone --depth=1` into a
   temporary staging directory, then sparse-checks out only the NDJSON files.
@@ -58,7 +58,7 @@
   caller to write back to `schema.yaml`. The hash is always computed and written to
   `meta.json` for auditability even when no pin is present.
 
-### ADR-020: Canonical hash algorithm
+### Canonical hash algorithm (ADR-020)
 
 - Canonical JSON sort order for hashing (ADR-020: Git-Native KG Implementation
   §canonical NDJSON record shape and snapshot hash):

--- a/crates/kkernel/docs/design.md
+++ b/crates/kkernel/docs/design.md
@@ -4,7 +4,7 @@
 
 ## ADR Compliance
 
-### ADR-003: System Architecture (kernel/MCP split)
+### System Architecture (kernel/MCP split) (ADR-003)
 
 - `kkernel` is the admin/management binary; `khive-mcp` is the MCP stdio server.
 - They share the `khive-runtime` crate but have separate entry points.
@@ -13,14 +13,14 @@
 - The anti-pattern of packs depending on the coordinator is explicitly guarded by the
   module boundary: `coordinator` is `kkernel`-internal.
 
-### ADR-009 / ADR-028: Multi-backend configuration
+### Multi-backend configuration (ADR-009, ADR-028)
 
 - `BackendRegistry` holds registered backends. Constructed at boot from `khive.toml`.
 - `kkernel backend list` and `kkernel backend info` expose the registry to operators.
 - Current v1 implementation exposes a single default backend. Full `khive.toml`-driven
   multi-backend enumeration is deferred to a follow-up milestone.
 
-### ADR-010 / ADR-020: VCS and sync
+### VCS and sync (ADR-010, ADR-020)
 
 - `kkernel sync` delegates to `khive_vcs::sync::run_sync` — the NDJSON-to-SQLite
   rebuild logic is owned by `khive-vcs`, not by `kkernel`.
@@ -34,14 +34,14 @@
 - `kkernel db migrate` wraps this; `kkernel db check` uses a read-only runtime to
   report schema state without writing.
 
-### ADR-017: Pack standard (vocabulary + handlers)
+### Pack standard (vocabulary + handlers) (ADR-017)
 
 - `pack_introspect` module builds an in-memory `VerbRegistry` from all `inventory!`-
   registered packs and exposes `list_packs()` and `pack_handler(name)`.
 - Handler `visibility` distinguishes MCP-exposed `Verb` entries from internal
   `Subhandler` entries (e.g. `memory.recall_embed`).
 
-### ADR-023: Verb namespace contract
+### Verb namespace contract (ADR-023)
 
 - The kg substrate pack owns 17 bare verb names (no dot prefix): `create`, `get`,
   `list`, `stats`, `update`, `delete`, `search`, `link`, `neighbors`, `traverse`,
@@ -51,14 +51,14 @@
   `memory.recall.embed`.
 - Enforced by the integration test in `tests/verb_namespace_contract.rs`.
 
-### ADR-027: Dynamic pack loading (self-registration via inventory!)
+### Dynamic pack loading (self-registration via inventory!) (ADR-027)
 
 - Pack crates self-register using `inventory::submit!`. The linker drops crates whose
   symbols aren't referenced, so `kkernel/lib.rs` and the contract test binary both
   include explicit `use PackName as _` anchors to prevent dead-stripping.
 - `PackRegistry::discovered_names()` returns all self-registered pack names at runtime.
 
-### ADR-029: SubstrateCoordinator
+### SubstrateCoordinator (ADR-029)
 
 - `coordinator/mod.rs` implements D1 (BackendRegistry), D2 (LocatorCache), and D3
   (fan-out search with RRF).
@@ -66,35 +66,35 @@
   deferred; sub-modules (`edges`, `traversal`, `curation`, `health`) are reserved.
 - See `docs/coordinator.md` for implementation phase detail.
 
-### ADR-034 / ADR-035: KG validation and init
+### KG validation and init (ADR-034, ADR-035)
 
 - `kkernel kg validate` runs three built-in structural checks (duplicate UUIDs, sort
   order, referential integrity) plus configurable rules from `rules.toml`.
 - `kkernel kg init` creates `.khive/kg/` and writes `khive.toml` with defaults.
 - See `docs/kg-rules.md` for the rule TOML format.
 
-### ADR-036 / ADR-037: KG status and fetch/sync alias
+### KG status and fetch/sync alias (ADR-036, ADR-037)
 
 - `kkernel kg status` computes a content hash of the DB state and the NDJSON files and
   reports whether they match.
 - `kkernel kg fetch` has a `visible_alias = "sync"` so `kkernel kg sync --repin <remote>`
   reaches the same handler.
 
-### ADR-043: Embedding model lifecycle
+### Embedding model lifecycle (ADR-043)
 
 - `kkernel engine list/status` expose `_embedding_models` table data.
 - `kkernel engine migrate` and `kkernel engine drift-check` are deferred to follow-up
   #380 (EmbedMigrationWorker and lattice_transport integration).
 - No MCP verbs are exposed for engine management — these are operator-only commands.
 
-### ADR-044: Vector store capabilities and orphan sweep
+### Vector store capabilities and orphan sweep (ADR-044)
 
 - `kkernel vector capabilities` emits the sqlite-vec baseline capability flags.
   Values match `SqliteVecStore::capabilities()` in `khive-db`.
 - `kkernel vector sweep` is deferred to follow-up #381; `SqliteVecStore` returns
   `Unsupported` for the orphan-sweep operation.
 
-### ADR-046: Proposal lifecycle
+### Proposal lifecycle (ADR-046)
 
 - The kg pack exposes `propose`, `review`, and `withdraw` verbs as part of the
   17 kg-substrate bare verbs. These are validated by the contract test.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -6,23 +6,23 @@ For historical context, see [v0 archive](../_archive/adr_v0/README.md). v0 ADRs 
 
 ## Foundation
 
-| #                                               | Title                                                                                     |
-| ----------------------------------------------- | ----------------------------------------------------------------------------------------- |
-| [ADR-001](ADR-001-entity-kind-taxonomy.md)      | Entity Kind Taxonomy                                                                      |
-| [ADR-002](ADR-002-edge-ontology.md)             | Closed Edge Ontology                                                                      |
-| [ADR-003](ADR-003-system-architecture.md)       | System Architecture                                                                       |
-| [ADR-004](ADR-004-substrate-observables.md)     | Substrate Observables                                                                     |
-| [ADR-005](ADR-005-storage-capability-traits.md) | Storage Capability Traits                                                                 |
-| [ADR-006](ADR-006-deterministic-scoring.md)     | Deterministic Scoring                                                                     |
-| [ADR-007](ADR-007-namespace.md)                 | Namespace (Rev 6 — attribution-only, dumb storage, single Gate, per-actor episodic write) |
-| [ADR-008](ADR-008-query-layer-separation.md)    | Query Layer Separation                                                                    |
-| [ADR-009](ADR-009-backend-architecture.md)      | Backend Architecture                                                                      |
-| [ADR-010](ADR-010-kg-versioning.md)             | KG Versioning Strategy                                                                    |
-| [ADR-011](ADR-011-embedding-and-inference.md)   | Embedding and Inference Architecture                                                      |
-| [ADR-012](ADR-012-retrieval-composition.md)     | Retrieval Composition                                                                     |
-| [ADR-013](ADR-013-note-kind-taxonomy.md)        | Note Kind Taxonomy                                                                        |
-| [ADR-014](ADR-014-curation-operations.md)       | Curation Operations                                                                       |
-| [ADR-015](ADR-015-schema-migrations.md)         | Schema Migrations                                                                         |
+| #                                               | Title                                                                                                      |
+| ----------------------------------------------- | ---------------------------------------------------------------------------------------------------------- |
+| [ADR-001](ADR-001-entity-kind-taxonomy.md)      | Entity Kind Taxonomy                                                                                       |
+| [ADR-002](ADR-002-edge-ontology.md)             | Closed Edge Ontology                                                                                       |
+| [ADR-003](ADR-003-system-architecture.md)       | System Architecture                                                                                        |
+| [ADR-004](ADR-004-substrate-observables.md)     | Substrate Observables                                                                                      |
+| [ADR-005](ADR-005-storage-capability-traits.md) | Storage Capability Traits                                                                                  |
+| [ADR-006](ADR-006-deterministic-scoring.md)     | Deterministic Scoring                                                                                      |
+| [ADR-007](ADR-007-namespace.md)                 | Namespace as Attribution-Only Open String — Dumb Storage, Single Gate, Operator-Configured Read Visibility |
+| [ADR-008](ADR-008-query-layer-separation.md)    | Query Layer Separation                                                                                     |
+| [ADR-009](ADR-009-backend-architecture.md)      | Backend Architecture                                                                                       |
+| [ADR-010](ADR-010-kg-versioning.md)             | KG Versioning Strategy                                                                                     |
+| [ADR-011](ADR-011-embedding-and-inference.md)   | Embedding and Inference Architecture                                                                       |
+| [ADR-012](ADR-012-retrieval-composition.md)     | Retrieval Composition (High-Level Composition Layer)                                                       |
+| [ADR-013](ADR-013-note-kind-taxonomy.md)        | Note Kind Taxonomy                                                                                         |
+| [ADR-014](ADR-014-curation-operations.md)       | Curation Operations                                                                                        |
+| [ADR-015](ADR-015-schema-migrations.md)         | Schema Migrations                                                                                          |
 
 ## MCP / Pack Surface
 
@@ -70,66 +70,66 @@ For historical context, see [v0 archive](../_archive/adr_v0/README.md). v0 ADRs 
 
 ## New v1 Surfaces
 
-| #                                                            | Title                                                                                                           |
-| ------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------- |
-| [ADR-040](ADR-040-communication-and-schedule-packs.md)       | Communication and Schedule Packs                                                                                |
-| [ADR-041](ADR-041-event-provenance-projection.md)            | Event Provenance Projection — Hybrid Log + Graph Edges                                                          |
-| [ADR-042](ADR-042-local-rerank-via-lattice-inference.md)     | Composable Rerank Pipeline (local cross-encoder + salience + graph-proximity)                                   |
-| [ADR-043](ADR-043-embedding-model-migration.md)              | Embedding Model Migration                                                                                       |
-| [ADR-044](ADR-044-vector-store-extensions.md)                | Vector Store Extensions — Capabilities, Metadata Filter, Batched Search, Update, Orphan Sweep                   |
-| [ADR-045](ADR-045-verb-response-presentation.md)             | Verb Response Presentation Modes                                                                                |
-| [ADR-046](ADR-046-event-sourced-proposals.md)                | Event-Sourced Agent KG Proposals                                                                                |
-| [ADR-047](ADR-047-knowledge-pack.md)                         | Knowledge Pack — Concept Registration, Citation, and Topic Search                                               |
-| [ADR-048](ADR-048-knowledge-section-profiles.md)             | Knowledge Section Profiles                                                                                      |
-| [ADR-049](ADR-049-khived-daemon.md)                          | khived Daemon — Persistent Warm Runtime over a Unix Socket                                                      |
-| [ADR-050](ADR-050-kg-token-namespace-contract.md)            | KG Token Namespace Contract (Accepted -- partially superseded by ADR-007 Rev 3)                                 |
-| [ADR-051](ADR-051-section-embeddings-hybrid-compose.md)      | Section-Level Embeddings and Hybrid Compose Scoring (Accepted)                                                  |
-| [ADR-052](ADR-052-ann-production-lifecycle.md)               | ANN Production Lifecycle — SQ8 Quantization, Tombstone Delete, Consolidation, Crash-Safe Persistence (Accepted) |
-| [ADR-053](ADR-053-authorization-gate.md)                     | Authorization Gate — ActorStore, SessionStore, and Caller Propagation (Proposed)                                |
-| [ADR-054](ADR-054-ann-build-strategy-scaling-limits.md)      | ANN Build Strategy and Scaling Limits (Proposed)                                                                |
-| [ADR-055](ADR-055-epistemic-edge-relations.md)               | Epistemic Edge Relations — `supports` and `refutes` (Accepted)                                                  |
-| [ADR-056](ADR-056-channel-transport-layer.md)                | Channel Transport Layer — `khive-channel` and External Messaging Adapters (Proposed)                            |
-| [ADR-057](ADR-057-comm-actor-addressed-delivery.md)          | Comm Actor-Addressed Delivery (Accepted)                                                                        |
-| [ADR-058](ADR-058-brain-posterior-read-path.md)              | Brain Posterior Read Path — Wiring Profile Posteriors into Recall Ranking (Proposed)                            |
-| [ADR-059](ADR-059-namespace-write-tiers.md)                  | Namespace Write Tiers and Cross-Namespace Link Access Control (Withdrawn — superseded by ADR-007 Rev 2)         |
-| [ADR-061](ADR-061-pack-extensible-by-id-resolution.md)       | Pack-Extensible by-ID Resolution (Accepted)                                                                     |
-| [ADR-062](ADR-062-fts-ann-consolidation.md)                  | FTS and ANN Consolidation -- Unified Search Tables (Schema V4) (Accepted)                                       |
-| [ADR-066](ADR-066-autonomous-merge-pipeline.md)              | Autonomous Merge Pipeline — Gate Wall as Reviewer, Human Gate at Release (Proposed)                             |
-| [ADR-067](ADR-067-write-owner-daemon.md)                     | Write-Owner Daemon — Single-Writer Task and Write Queue (Accepted)                                              |
-| [ADR-068](ADR-068-process-isolation-topology.md)             | Per-Process Isolation Topology (Proposed)                                                                       |
-| [ADR-069](ADR-069-subject-model.md)                          | Subject Model — Domain-Ontology Ingestion and Map Pipeline (Proposed)                                           |
-| [ADR-071](ADR-071-backend-pluggable-runtime.md)              | Backend-Pluggable Runtime — Polystore Restoration (Accepted)                                                    |
-| [ADR-072](ADR-072-subject-ontologyspec-as-data.md)           | Subject OntologySpec as Runtime Data — Verbless Verticals and Pack Retirement (Proposed)                        |
-| [ADR-073](ADR-073-pack-core-backend-accessor.md)             | Pack Core-Backend Accessor (Accepted)                                                                           |
-| [ADR-074](ADR-074-graph-aware-recall.md)                     | Graph-Aware Recall — Graph-Proximity Signal in Memory Retrieval (Proposed)                                      |
-| [ADR-075](ADR-075-owl-rdf-interoperability.md)               | OWL/RDF Interoperability — Publishing the khive Vocabulary and Aligning with External Ontologies (Draft)        |
-| [ADR-076](ADR-076-relation-calculability-and-system-role.md) | Relation-Set Calculability — System Role and the Non-Redundancy Certificate (Proposed)                          |
-| [ADR-078](ADR-078-output-format-shape-aware-rendering.md)    | Output Format and Shape-Aware Rendering (Proposed)                                                              |
-| [ADR-079](ADR-079-ann-persistence-warm-path-integration.md)  | ANN Persistence Warm-Path Integration — Wiring v2 Persistence into the Daemon (Proposed)                        |
-| [ADR-080](ADR-080-session-pack-oss-storage-mechanism.md)     | Session Pack — OSS Storage Mechanism (Accepted, amended 2026-07-02)                                             |
-| [ADR-082](ADR-082-retrieval-quality-measurement-loop.md)     | Retrieval Quality Measurement Loop (Proposed)                                                                   |
-| [ADR-083](ADR-083-session-pack-t1-verbs.md)                  | Session Pack T1 Verb Surface (Accepted)                                                                         |
-| [ADR-084](ADR-084-verb-surface-consistency.md)               | Verb-Surface Consistency Contract and Live Ontology Introspection (Proposed)                                    |
-| [ADR-085](ADR-085-code-pack.md)                              | Code Pack — Source-Code Ontology and Audit-Finding Vocabulary (Accepted)                                        |
-| [ADR-086](ADR-086-doc-file-pack.md)                          | Document/File Modeling — Content on the Existing `document` Entity Kind (Proposed)                              |
-| [ADR-087](ADR-087-workspace-mirror.md)                       | Workspace Mirror — Folding `.khive/` Into the Graph Substrate (Proposed)                                        |
-| [ADR-088](ADR-088-git-lifecycle-pack.md)                     | Git-Lifecycle Pack — Commit and Issue Note Kinds (Proposed)                                                     |
-| [ADR-088 Amendment 1](ADR-088-amendment-1-git-digest.md)     | `git.digest` — Agent-Facing Digest Verb with Remote-URL Support (Accepted)                                      |
-| [ADR-089](ADR-089-context-verb.md)                           | Context Verb — Entity-Anchored Graph Context in One Call (Proposed)                                             |
-| [ADR-090](ADR-090-docs-site-standard.md)                     | Docs Site Standard — Navigation, Agent md/txt Surfaces, Visual Style (Proposed)                                 |
-| [ADR-091](ADR-091-wal-snapshot-lifetime.md)                  | Bounded Read-Transaction Lifetime and WAL Checkpoint Escalation (Accepted)                                      |
-| [ADR-092](ADR-092-context-composer.md)                       | Cross-Substrate Context Composer — ContextContributor Trait + `context.assemble` (Proposed)                     |
-| [ADR-093](ADR-093-sessions-raw-zstd-compression.md)          | zstd Compression for Session-Mirror Raw Storage (Proposed)                                                      |
-| [ADR-094](ADR-094-lifecycle-telemetry-events.md)             | Sequencing-Assertable Lifecycle Telemetry Events (Proposed)                                                     |
-| [ADR-095](ADR-095-verb-surface-consolidation.md)             | Verb-Surface Consolidation and Field-Validation Governance (Proposed)                                           |
-| [ADR-096](ADR-096-warm-daemon-per-request-identity.md)       | Warm Daemon Per-Request Identity — Serving Many Attribution Identities Over One Shared Backend (Accepted)       |
-| [ADR-099](ADR-099-bulk-apply-atomic-units.md)                | Cross-Op Atomicity for Bulk Apply — Prepared Write Plans over the Single-Writer Seam (Accepted)                 |
-| [ADR-100](ADR-100-store-backup-replication.md)               | Store Backup and Replication — Scheduled Differential Sync with Tiered Recovery Objectives (Proposed)           |
-| [ADR-101](ADR-101-kg-changeset-model.md)                     | KG Change-Set Model — Producer-Agnostic Op-List with Stage-Time Stable IDs (Proposed)                           |
-| [ADR-102](ADR-102-tiered-validate-and-merge.md)              | Tiered Validate-and-Merge — Rule-Gated Fast Path and Reviewed Change-Set Path (Proposed)                        |
-| [ADR-106](ADR-106-schedule-pack-executor.md)                 | Schedule Pack Executor — Daemon-Resident Tick for the Pending-Event Drain (Accepted)                            |
-| [ADR-108](ADR-108-git-write-surface.md)                      | Git Write Surface Through khive (Phase B) (Proposed)                                                            |
-| [ADR-109](ADR-109-sandboxed-kkernel-gateway.md)              | Sandboxed kkernel Gateway for Untrusted Execution (Phase C) (Proposed)                                          |
+| #                                                            | Title                                                                                                 |
+| ------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------- |
+| [ADR-040](ADR-040-communication-and-schedule-packs.md)       | Communication and Schedule Packs                                                                      |
+| [ADR-041](ADR-041-event-provenance-projection.md)            | Event Provenance Projection — Hybrid Log + Graph Edges                                                |
+| [ADR-042](ADR-042-local-rerank-via-lattice-inference.md)     | Composable Rerank Pipeline (local cross-encoder + salience + graph-proximity)                         |
+| [ADR-043](ADR-043-embedding-model-migration.md)              | Embedding Model Migration                                                                             |
+| [ADR-044](ADR-044-vector-store-extensions.md)                | Vector Store Extensions — Capabilities, Metadata Filter, Batched Search, Update, Orphan Sweep         |
+| [ADR-045](ADR-045-verb-response-presentation.md)             | Verb Response Presentation Modes                                                                      |
+| [ADR-046](ADR-046-event-sourced-proposals.md)                | Event-Sourced Agent KG Proposals                                                                      |
+| [ADR-047](ADR-047-knowledge-pack.md)                         | Knowledge Pack                                                                                        |
+| [ADR-048](ADR-048-knowledge-section-profiles.md)             | Knowledge Section Profiles                                                                            |
+| [ADR-049](ADR-049-khived-daemon.md)                          | khived daemon — persistent warm runtime over a Unix socket                                            |
+| [ADR-050](ADR-050-kg-token-namespace-contract.md)            | KG Token Namespace Contract                                                                           |
+| [ADR-051](ADR-051-section-embeddings-hybrid-compose.md)      | Section-level embeddings and hybrid compose scoring                                                   |
+| [ADR-052](ADR-052-ann-production-lifecycle.md)               | ANN Production Lifecycle -- SQ8 Quantization, Tombstone Delete, Consolidation, Crash-Safe Persistence |
+| [ADR-053](ADR-053-authorization-gate.md)                     | Authorization Gate -- ActorStore, SessionStore, and Caller Propagation                                |
+| [ADR-054](ADR-054-ann-build-strategy-scaling-limits.md)      | ANN Build Strategy and Scaling Limits                                                                 |
+| [ADR-055](ADR-055-epistemic-edge-relations.md)               | Epistemic Edge Relations — `supports` and `refutes`                                                   |
+| [ADR-056](ADR-056-channel-transport-layer.md)                | Channel Transport Layer -- `khive-channel` and External Messaging Adapters                            |
+| [ADR-057](ADR-057-comm-actor-addressed-delivery.md)          | Comm Actor-Addressed Delivery                                                                         |
+| [ADR-058](ADR-058-brain-posterior-read-path.md)              | Brain Posterior Read Path — Wiring Profile Posteriors into Recall Ranking                             |
+| [ADR-059](ADR-059-namespace-write-tiers.md)                  | Namespace Write Tiers and Cross-Namespace Link Access Control                                         |
+| [ADR-061](ADR-061-pack-extensible-by-id-resolution.md)       | Pack-Extensible by-ID Resolution                                                                      |
+| [ADR-062](ADR-062-fts-ann-consolidation.md)                  | FTS and ANN Consolidation -- Unified Search Tables (Schema V4)                                        |
+| [ADR-066](ADR-066-autonomous-merge-pipeline.md)              | Autonomous Merge Pipeline — Gate Wall as Reviewer                                                     |
+| [ADR-067](ADR-067-write-owner-daemon.md)                     | Write-Owner Daemon — Single-Writer Task and Write Queue                                               |
+| [ADR-068](ADR-068-process-isolation-topology.md)             | Per-Process Isolation Topology                                                                        |
+| [ADR-069](ADR-069-subject-model.md)                          | The Subject Model -- Domain-Ontology Ingestion and Map Pipeline                                       |
+| [ADR-071](ADR-071-backend-pluggable-runtime.md)              | Backend-Pluggable Runtime — Polystore Restoration                                                     |
+| [ADR-072](ADR-072-subject-ontologyspec-as-data.md)           | Subject OntologySpec as Runtime Data -- Verbless Verticals and Pack Retirement                        |
+| [ADR-073](ADR-073-pack-core-backend-accessor.md)             | Pack Core-Backend Accessor                                                                            |
+| [ADR-074](ADR-074-graph-aware-recall.md)                     | Graph-Aware Recall — Graph-Proximity Signal in Memory Retrieval                                       |
+| [ADR-075](ADR-075-owl-rdf-interoperability.md)               | OWL/RDF Interoperability -- Publishing the khive Vocabulary and Aligning with External Ontologies     |
+| [ADR-076](ADR-076-relation-calculability-and-system-role.md) | Relation-Set Calculability — System Role and the Non-Redundancy Certificate                           |
+| [ADR-078](ADR-078-output-format-shape-aware-rendering.md)    | Output Format and Shape-Aware Rendering                                                               |
+| [ADR-079](ADR-079-ann-persistence-warm-path-integration.md)  | ANN Persistence Warm-Path Integration — Wiring v2 Persistence into the Daemon                         |
+| [ADR-080](ADR-080-session-pack-oss-storage-mechanism.md)     | Session Pack — OSS Storage Mechanism                                                                  |
+| [ADR-082](ADR-082-retrieval-quality-measurement-loop.md)     | Retrieval Quality Measurement Loop                                                                    |
+| [ADR-083](ADR-083-session-pack-t1-verbs.md)                  | Session Pack T1 Verb Surface                                                                          |
+| [ADR-084](ADR-084-verb-surface-consistency.md)               | Verb-Surface Consistency Contract and Live Ontology Introspection                                     |
+| [ADR-085](ADR-085-code-pack.md)                              | Code Pack — Source-Code Ontology and Audit-Finding Vocabulary                                         |
+| [ADR-086](ADR-086-doc-file-pack.md)                          | Document/File Modeling — Content on the Existing `document` Entity Kind                               |
+| [ADR-087](ADR-087-workspace-mirror.md)                       | Workspace Mirror — Folding `.khive/` Into the Graph Substrate                                         |
+| [ADR-088](ADR-088-git-lifecycle-pack.md)                     | Git-Lifecycle Pack — Commit and Issue Note Kinds                                                      |
+| [ADR-088 Amendment 1](ADR-088-amendment-1-git-digest.md)     | `git.digest` — Agent-Facing Digest Verb with Remote-URL Support (Accepted)                            |
+| [ADR-089](ADR-089-context-verb.md)                           | `context` verb — entity-anchored graph context in one call                                            |
+| [ADR-090](ADR-090-docs-site-standard.md)                     | Docs site standard — navigation, agent md/txt surfaces, visual style                                  |
+| [ADR-091](ADR-091-wal-snapshot-lifetime.md)                  | Bounded read-transaction lifetime and WAL checkpoint escalation                                       |
+| [ADR-092](ADR-092-context-composer.md)                       | Cross-substrate context composer — ContextContributor trait + `context.assemble`                      |
+| [ADR-093](ADR-093-sessions-raw-zstd-compression.md)          | zstd Compression for Session-Mirror Raw Storage                                                       |
+| [ADR-094](ADR-094-lifecycle-telemetry-events.md)             | Sequencing-Assertable Lifecycle Telemetry Events                                                      |
+| [ADR-095](ADR-095-verb-surface-consolidation.md)             | Verb-Surface Consolidation and Field-Validation Governance                                            |
+| [ADR-096](ADR-096-warm-daemon-per-request-identity.md)       | warm daemon per-request identity — serving many attribution identities over one shared backend        |
+| [ADR-099](ADR-099-bulk-apply-atomic-units.md)                | Cross-Op Atomicity for Bulk Apply — Prepared Write Plans over the Single-Writer Seam                  |
+| [ADR-100](ADR-100-store-backup-replication.md)               | Store backup and replication                                                                          |
+| [ADR-101](ADR-101-kg-changeset-model.md)                     | KG Change-Set Model — Producer-Agnostic Op-List with Stage-Time Stable IDs                            |
+| [ADR-102](ADR-102-tiered-validate-and-merge.md)              | Tiered Validate-and-Merge — Rule-Gated Fast Path and Reviewed Change-Set Path                         |
+| [ADR-106](ADR-106-schedule-pack-executor.md)                 | Schedule Pack Executor — Daemon-Resident Tick for the Pending-Event Drain                             |
+| [ADR-108](ADR-108-git-write-surface.md)                      | Git Write Surface Through khive (Phase B)                                                             |
+| [ADR-109](ADR-109-sandboxed-kkernel-gateway.md)              | Sandboxed kkernel Gateway for Untrusted Execution (Phase C)                                           |
 
 ## Closed Taxonomies — Quick Reference
 

--- a/docs/guide/api-reference.md
+++ b/docs/guide/api-reference.md
@@ -1441,4 +1441,4 @@ request(ops="git.digest(source=\"https://github.com/org/repo\", max_items=500)")
 - [GTD Task Management](tasks.html): task lifecycle in depth.
 - [Prompt Cookbook](prompt-cookbook.html): ready-to-use verb patterns.
 - [ADR-016: request DSL](https://github.com/ohdearquant/khive/blob/main/docs/adr/ADR-016-request-dsl.md)
-- [ADR-002: edge ontology](https://github.com/ohdearquant/khive/blob/main/docs/adr/ADR-002-edge-ontology.md)
+- [ADR-002: Closed Edge Ontology](https://github.com/ohdearquant/khive/blob/main/docs/adr/ADR-002-edge-ontology.md)

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -20,6 +20,9 @@ sh "$SCRIPT_DIR/lint-sql.sh"
 echo "=== ADR Reference Lint ==="
 sh "$SCRIPT_DIR/lint-adr-refs.sh"
 
+echo "=== ADR Reference Lint Self-Test ==="
+sh "$SCRIPT_DIR/lint-adr-refs.sh" --self-test
+
 echo "=== No-Stub Guard (clippy restriction lints) ==="
 # AST-aware "No stubs. Ever." enforcement. clippy parses the macros, so it is
 # immune to the grep failure modes (spacing like `todo !()`, brace forms like

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -17,6 +17,9 @@ cargo fmt --all -- --check
 echo "=== SQL Lint ==="
 sh "$SCRIPT_DIR/lint-sql.sh"
 
+echo "=== ADR Reference Lint ==="
+sh "$SCRIPT_DIR/lint-adr-refs.sh"
+
 echo "=== No-Stub Guard (clippy restriction lints) ==="
 # AST-aware "No stubs. Ever." enforcement. clippy parses the macros, so it is
 # immune to the grep failure modes (spacing like `todo !()`, brace forms like

--- a/scripts/lint-adr-refs.sh
+++ b/scripts/lint-adr-refs.sh
@@ -3,7 +3,83 @@
 set -eu
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-ROOT="$SCRIPT_DIR/.."
+
+# `--self-test`: exercise the parenthetical-prose-citation extraction (the
+# `ADR-NNN: <title>` form embedded in plain prose, e.g. inside a crate's
+# docs/design.md "ADR Compliance" section) against synthetic fixtures rather
+# than the live repo, since the real corpus only carries a handful of these.
+# Regression case 1 reproduces the bm25 design.md drift this was added for
+# (PR #886 review r1): a parenthetical citation that echoes a truncated ADR
+# title must fail. Regression case 2 asserts a bare "(ADR-030)" reference
+# with no restated title never false-positives.
+self_test() {
+    tmp="$(mktemp -d)"
+    trap 'rm -rf "$tmp"' EXIT
+
+    mkdir -p "$tmp/case-fail/docs/adr" "$tmp/case-fail/crates/fixture-crate/docs"
+    mkdir -p "$tmp/case-pass/docs/adr" "$tmp/case-pass/crates/fixture-crate/docs"
+
+    for case in case-fail case-pass; do
+        cat > "$tmp/$case/docs/adr/ADR-030-retrieval-stack-port.md" <<'FIXTURE'
+# ADR-030: Retrieval Stack Port — khive-retrieval
+
+**Status**: accepted
+FIXTURE
+        cat > "$tmp/$case/docs/adr/README.md" <<'FIXTURE'
+# ADR Index
+
+| ADR | Title |
+| --- | --- |
+FIXTURE
+    done
+
+    cat > "$tmp/case-fail/crates/fixture-crate/docs/design.md" <<'FIXTURE'
+# fixture-crate Design
+
+## ADR Compliance
+
+- ported as part of the retrieval stack (ADR-030: Retrieval Stack Port).
+FIXTURE
+
+    cat > "$tmp/case-pass/crates/fixture-crate/docs/design.md" <<'FIXTURE'
+# fixture-crate Design
+
+## ADR Compliance
+
+- ported as part of the retrieval stack (ADR-030).
+FIXTURE
+
+    status=0
+
+    if sh "$SCRIPT_DIR/lint-adr-refs.sh" "$tmp/case-fail" > "$tmp/fail.log" 2>&1; then
+        echo "self-test FAILED: drifted parenthetical prose citation (ADR-030: Retrieval Stack Port, missing the '-- khive-retrieval' suffix) was not caught"
+        cat "$tmp/fail.log"
+        status=1
+    elif ! grep -q "ADR-030 title mismatch" "$tmp/fail.log"; then
+        echo "self-test FAILED: lint failed, but not for the expected reason:"
+        cat "$tmp/fail.log"
+        status=1
+    else
+        echo "self-test OK: drifted parenthetical prose citation caught"
+    fi
+
+    if ! sh "$SCRIPT_DIR/lint-adr-refs.sh" "$tmp/case-pass" > "$tmp/pass.log" 2>&1; then
+        echo "self-test FAILED: bare ADR-030 reference (no restated title) should not trip the lint"
+        cat "$tmp/pass.log"
+        status=1
+    else
+        echo "self-test OK: bare ADR reference does not false-positive"
+    fi
+
+    return "$status"
+}
+
+if [ "${1:-}" = "--self-test" ]; then
+    self_test
+    exit $?
+fi
+
+ROOT="${1:-$SCRIPT_DIR/..}"
 
 python3 - "$ROOT" <<'PY'
 from __future__ import annotations
@@ -70,6 +146,49 @@ def parenthesized_title(line: str, match: re.Match[str]) -> str | None:
     if closing is None:
         return None
     return line[opening + 1 : closing]
+
+
+def top_level_parens(line: str) -> list[tuple[int, int]]:
+    spans: list[tuple[int, int]] = []
+    index = 0
+    while index < len(line):
+        if line[index] == "(":
+            closing = closing_delimiter(line, index, "(", ")")
+            if closing is None:
+                index += 1
+                continue
+            spans.append((index, closing))
+            index = closing + 1
+        else:
+            index += 1
+    return spans
+
+
+def prose_parenthetical_references(line: str) -> list[tuple[str, str]]:
+    # Titled ADR references embedded in plain prose, e.g. "(ADR-030: Retrieval
+    # Stack Port)" -- distinct from headings and Markdown link labels, which
+    # are handled separately. Bounded to matching parens so trailing sentence
+    # content never leaks into the captured title (unlike a naive end-of-line
+    # capture). Only fires on the colon-titled form -- a bare "(ADR-030)" or a
+    # descriptive gloss like "(ADR-030, hybrid retrieval)" never matches
+    # colon_ref_re, so it is left alone.
+    references: list[tuple[str, str]] = []
+    for open_idx, close_idx in top_level_parens(line):
+        inner = line[open_idx + 1 : close_idx]
+        inner_matches = list(colon_ref_re.finditer(inner))
+        for match_index, inner_match in enumerate(inner_matches):
+            end = (
+                inner_matches[match_index + 1].start()
+                if match_index + 1 < len(inner_matches)
+                else len(inner)
+            )
+            title = inner[inner_match.end() : end].split(";", 1)[0].strip()
+            if not title or title[0].isdigit():
+                # Empty capture, or a section/line locator like "ADR-017:451-480"
+                # rather than a titled reference.
+                continue
+            references.append((inner_match.group("number"), title))
+    return references
 
 
 def titled_references(label: str) -> list[tuple[str, str]]:
@@ -159,9 +278,18 @@ scan_paths = set((root / "docs").glob("**/*.md"))
 scan_paths.update((root / "crates").glob("**/docs/**/*.md"))
 scan_paths.update((root / "crates").glob("**/design*.md"))
 
+adr_dir_resolved = adr_dir.resolve()
+
 reference_count = 0
 for path in sorted(scan_paths):
     relative = path.relative_to(root)
+    # docs/adr/**/*.md itself is excluded from prose-citation scanning: ADR
+    # bodies routinely cross-reference sibling ADRs with a deliberately
+    # abbreviated gloss ("(ADR-002: Edge Ontology governs the endpoint
+    # contract)", "(ADR-001: Artifact entities)") rather than a literal title
+    # restatement -- an established, reviewed convention, not drift. Headings
+    # and links are still checked everywhere, including docs/adr/.
+    prose_eligible = adr_dir_resolved not in path.resolve().parents
     in_fence = False
     with path.open(encoding="utf-8") as handle:
         for line_number, raw_line in enumerate(handle, 1):
@@ -188,6 +316,11 @@ for path in sorted(scan_paths):
             references: list[tuple[str, str]] = []
             for label in labels:
                 for reference in titled_references(label):
+                    if reference not in references:
+                        references.append(reference)
+
+            if heading_match is None and prose_eligible:
+                for reference in prose_parenthetical_references(line):
                     if reference not in references:
                         references.append(reference)
 

--- a/scripts/lint-adr-refs.sh
+++ b/scripts/lint-adr-refs.sh
@@ -1,0 +1,218 @@
+#!/bin/sh
+# Validate titled ADR references against the authoritative ADR H1 headings.
+set -eu
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$SCRIPT_DIR/.."
+
+python3 - "$ROOT" <<'PY'
+from __future__ import annotations
+
+import re
+import sys
+import unicodedata
+from pathlib import Path
+
+
+root = Path(sys.argv[1]).resolve()
+adr_dir = root / "docs" / "adr"
+adr_file_re = re.compile(r"^ADR-(\d{3})-.*\.md$", re.IGNORECASE)
+h1_re = re.compile(
+    r"^#\s+ADR-(?P<number>\d{3})(?:\s+Rev\s+\d+)?\s*:\s*(?P<title>.+?)\s*#*\s*$",
+    re.IGNORECASE,
+)
+colon_ref_re = re.compile(r"\bADR-(?P<number>\d{3})\s*:\s*", re.IGNORECASE)
+paren_ref_re = re.compile(r"\bADR-(?P<number>\d{3})\s+\(", re.IGNORECASE)
+dash_ref_re = re.compile(r"\bADR-(?P<number>\d{3})\s+(?:--?|–|—)\s+", re.IGNORECASE)
+heading_re = re.compile(r"^\s{0,3}#{1,6}\s+(?P<body>.+?)\s*#*\s*$")
+link_re = re.compile(r"\[(?P<label>[^]\n]+)\]\((?P<target>[^\n)]+)\)")
+adr_led_re = re.compile(r"^(?:\[)?ADR-\d{3}\b", re.IGNORECASE)
+index_row_re = re.compile(
+    r"^\|\s*\[ADR-(?P<number>\d{3})\]\((?P<target>[^)]+)\)\s*"
+    r"\|\s*(?P<title>.*?)\s*\|\s*$",
+    re.IGNORECASE,
+)
+edge_punctuation = " \t\r\n`*_~\\\"'“”‘’[]{}<>:;,.!?()#-–—"
+
+
+def normalize(title: str) -> str:
+    title = unicodedata.normalize("NFKC", title)
+    previous = None
+    while title != previous:
+        previous = title
+        title = re.sub(r"\s+", " ", title).strip(edge_punctuation)
+    return title.casefold()
+
+
+def first_h1(path: Path) -> tuple[int, str] | None:
+    with path.open(encoding="utf-8") as handle:
+        for line_number, line in enumerate(handle, 1):
+            if line.startswith("# "):
+                return line_number, line.rstrip("\n")
+    return None
+
+
+def closing_delimiter(line: str, start: int, opening: str, closing: str) -> int | None:
+    depth = 0
+    for index in range(start, len(line)):
+        if line[index] == opening:
+            depth += 1
+        elif line[index] == closing:
+            depth -= 1
+            if depth == 0:
+                return index
+    return None
+
+
+def parenthesized_title(line: str, match: re.Match[str]) -> str | None:
+    opening = match.end() - 1
+    closing = closing_delimiter(line, opening, "(", ")")
+    if closing is None:
+        return None
+    return line[opening + 1 : closing]
+
+
+def titled_references(label: str) -> list[tuple[str, str]]:
+    references: list[tuple[str, str]] = []
+    for match in colon_ref_re.finditer(label):
+        references.append((match.group("number"), label[match.end() :]))
+    for match in paren_ref_re.finditer(label):
+        title = parenthesized_title(label, match)
+        if title is not None:
+            references.append((match.group("number"), title))
+    for match in dash_ref_re.finditer(label):
+        references.append((match.group("number"), label[match.end() :]))
+    return references
+
+
+def is_local_adr_link(source: Path, target: str) -> bool:
+    target = target.split("#", 1)[0]
+    if re.match(r"^[a-z]+://", target, re.IGNORECASE):
+        return bool(
+            re.search(
+                r"github\.com/ohdearquant/khive/(?:blob|tree)/[^/]+/docs/adr/ADR-",
+                target,
+                re.IGNORECASE,
+            )
+        )
+    resolved = (source.parent / target).resolve()
+    return resolved.parent == adr_dir.resolve() and resolved.name.upper().startswith("ADR-")
+
+
+errors: list[str] = []
+titles: dict[str, tuple[str, Path]] = {}
+
+for path in sorted(adr_dir.glob("ADR-*.md")):
+    file_match = adr_file_re.match(path.name)
+    if file_match is None or re.match(r"^ADR-\d{3}-amendment-", path.name, re.IGNORECASE):
+        continue
+    h1 = first_h1(path)
+    relative = path.relative_to(root)
+    if h1 is None:
+        errors.append(f"{relative}: missing ADR H1 heading")
+        continue
+    line_number, heading = h1
+    heading_match = h1_re.match(heading)
+    if heading_match is None:
+        errors.append(f"{relative}:{line_number}: malformed ADR H1: {heading!r}")
+        continue
+    file_number = file_match.group(1)
+    heading_number = heading_match.group("number")
+    if file_number != heading_number:
+        errors.append(
+            f"{relative}:{line_number}: filename ADR-{file_number} does not match H1 ADR-{heading_number}"
+        )
+        continue
+    if file_number in titles:
+        other = titles[file_number][1].relative_to(root)
+        errors.append(f"{relative}:{line_number}: duplicate ADR-{file_number}; also defined by {other}")
+        continue
+    titles[file_number] = (heading_match.group("title"), path)
+
+index_path = adr_dir / "README.md"
+with index_path.open(encoding="utf-8") as handle:
+    for line_number, line in enumerate(handle, 1):
+        match = index_row_re.match(line.rstrip("\n"))
+        if match is None:
+            continue
+        number = match.group("number")
+        relative = index_path.relative_to(root)
+        canonical = titles.get(number)
+        if canonical is None:
+            errors.append(f"{relative}:{line_number}: ADR-{number} index entry has no authoritative file")
+            continue
+        expected, expected_path = canonical
+        target_path = (adr_dir / match.group("target")).resolve()
+        if target_path != expected_path.resolve():
+            errors.append(
+                f"{relative}:{line_number}: ADR-{number} index target mismatch; "
+                f'expected "{expected_path.name}", found "{match.group("target")}"'
+            )
+        found = match.group("title")
+        if normalize(found) != normalize(expected):
+            errors.append(
+                f'{relative}:{line_number}: ADR-{number} index title mismatch; '
+                f'expected "{expected}", found "{found}"'
+            )
+
+scan_paths = set((root / "docs").glob("**/*.md"))
+scan_paths.update((root / "crates").glob("**/docs/**/*.md"))
+scan_paths.update((root / "crates").glob("**/design*.md"))
+
+reference_count = 0
+for path in sorted(scan_paths):
+    relative = path.relative_to(root)
+    in_fence = False
+    with path.open(encoding="utf-8") as handle:
+        for line_number, raw_line in enumerate(handle, 1):
+            line = raw_line.rstrip("\n")
+            if re.match(r"^\s*(```|~~~)", line):
+                in_fence = not in_fence
+                continue
+            if in_fence:
+                continue
+
+            labels: list[str] = []
+            heading_match = heading_re.match(line)
+            if heading_match is not None:
+                body = heading_match.group("body")
+                if not body.startswith("[") and adr_led_re.match(body):
+                    labels.append(body)
+            labels.extend(
+                match.group("label")
+                for match in link_re.finditer(line)
+                if adr_led_re.match(match.group("label"))
+                and is_local_adr_link(path, match.group("target"))
+            )
+
+            references: list[tuple[str, str]] = []
+            for label in labels:
+                for reference in titled_references(label):
+                    if reference not in references:
+                        references.append(reference)
+
+            for number, found in references:
+                reference_count += 1
+                canonical = titles.get(number)
+                if canonical is None:
+                    errors.append(
+                        f'{relative}:{line_number}: ADR-{number} has no authoritative file; found title "{found.strip()}"'
+                    )
+                    continue
+                expected = canonical[0]
+                if normalize(found) != normalize(expected):
+                    errors.append(
+                        f'{relative}:{line_number}: ADR-{number} title mismatch; expected "{expected}", found "{found.strip()}"'
+                    )
+
+if errors:
+    for error in errors:
+        print(error)
+    print(f"\nADR reference lint: {len(errors)} issue(s)")
+    raise SystemExit(1)
+
+print(
+    f"ADR reference lint: {len(scan_paths)} file(s), "
+    f"{reference_count} titled reference(s) OK"
+)
+PY


### PR DESCRIPTION
Closes #547.

Adds `scripts/lint-adr-refs.sh`: validates every titled `ADR-NNN` reference (`ADR-NNN: <title>`, `ADR-NNN (<title>)`, headings) in crate design docs and `docs/` against the authoritative H1 titles of `docs/adr/ADR-*.md`. Bare `ADR-NNN` references are not flagged; unknown ADR numbers and mismatched titles fail with expected-vs-found output. Wired into `scripts/ci.sh` and pre-commit alongside the SQL lint.

The lint pass over the current tree surfaced and fixes genuine drifted titles across 28 design/doc files (the exact recurring mislabel class behind the #32 reopen), including the `docs/adr/README.md` index rows.

Verification: `bash scripts/lint-adr-refs.sh` passes (201 files, 156 titled references); deliberately corrupting a title fails loud.