### PR TITLE
fix(runtime): token-boundary trigger matching in secret gate to stop path-slug false positives

### DIFF
--- a/crates/khive-runtime/src/secret_gate.rs
+++ b/crates/khive-runtime/src/secret_gate.rs
@@ -916,7 +916,9 @@ fn has_assignment_credential_trigger(low_text: &str) -> bool {
             .rsplit(|c: char| !c.is_ascii_alphanumeric() && c != '_')
             .next()
             .unwrap_or_default();
-        contains_compound_trigger(label)
+        COMPOUND_TRIGGER_WORDS
+            .iter()
+            .any(|needle| label.contains(needle))
             || TRIGGER_WORDS
                 .iter()
                 .any(|tw| contains_bounded_word(label, tw))
@@ -941,7 +943,9 @@ fn has_inline_credential_trigger(raw_token: &str) -> bool {
 
     !low.contains(['/', '-', '.'])
         && low.contains('_')
-        && (contains_compound_trigger(&low)
+        && (COMPOUND_TRIGGER_WORDS
+            .iter()
+            .any(|needle| low.contains(needle))
             || TRIGGER_WORDS
                 .iter()
                 .any(|tw| contains_bounded_word(&low, tw)))
@@ -3359,6 +3363,14 @@ mod tests {
                 );
             }
         }
+
+        let prefixed = "xapi_keyv2=Xk9mZ2vQpLrT8nJwYuAeHfBsDcGiONvMabcdef"; // gitleaks:allow
+        assert!(
+            check(prefixed).is_err(),
+            "prefix-bearing compound credential assignment must be blocked: \
+             {prefixed:?}, got {:?}",
+            scan(prefixed)
+        );
     }
 
     #[test]

--- a/crates/khive-runtime/src/secret_gate.rs
+++ b/crates/khive-runtime/src/secret_gate.rs
@@ -82,15 +82,15 @@
 //!   `check_entropy_heuristic`.
 //!
 //! Trigger-word matching only fires on genuine mentions, not substring
-//! collisions: bare trigger words (`key`, `secret`, `password`, `passwd`,
+//! collisions: trigger words (`key`, `secret`, `password`, `passwd`,
 //! `credential`, `bearer`, `auth`, `apikey`) are matched at a word boundary
 //! (`contains_bounded_word`), so `auth` does not fire inside `authorized` or
-//! `authentication`, nor `key` inside `monkey`/`keyword`. The three compound
-//! entries that already embed an underscore (`api_key`, `access_key`,
-//! `private_key`) are matched as a plain substring instead, since the
-//! underscore already disambiguates them and word-boundary matching would
-//! only weaken them (e.g. `secret_access_key` no longer needs the bare
-//! `secret`/`key` matches once `access_key` fires on its own).
+//! `authentication`, nor `key` inside `monkey`/`keyword`. The candidate token
+//! is excluded from its own surrounding context. This prevents an internal
+//! path segment such as `cli-auth-and-kg` from making the path self-trigger.
+//! Assignment-shaped candidates such as `auth=<value>` and `api_key=<value>`
+//! are checked separately so the exclusion does not weaken credential-shaped
+//! writes.
 //!
 //! A structured-identifier-shaped token sitting near a **genuinely standalone**
 //! trigger word (e.g. `auth work saved at .../repo-audit.md`, where `auth` is
@@ -114,10 +114,9 @@
 //! lets common underscore-joined credential-config compounds keep firing:
 //! `SECRET_KEY=...` (Django/Flask-style config), `auth_token=...`,
 //! `session_secret_...`, `signing_key=...` all match on the `secret`/`key`/
-//! `auth` half even though none of them is in `COMPOUND_TRIGGER_WORDS`. This
-//! is implemented by parameterizing the boundary rule (`contains_word`'s
-//! `underscore_is_word_char` argument) rather than sharing one rule between
-//! the two callers.
+//! `auth` half. This is implemented by parameterizing the boundary rule
+//! (`contains_word`'s `underscore_is_word_char` argument) rather than sharing
+//! one rule between the two callers.
 //!
 //! A production-corpus replay harness (`corpus_replay`, `#[ignore]`d, run via
 //! `KHIVE_REPLAY_DB=<path> cargo test ... -- --ignored --nocapture`) measures
@@ -639,16 +638,6 @@ const TRIGGER_WORDS: &[&str] = &[
     "apikey",
 ];
 
-/// Trigger words checked as a plain substring (unchanged behavior) rather than
-/// a bounded word — these already embed the underscore separator that
-/// disambiguates them from ordinary prose (`secret_access_key`, `api_key`),
-/// so word-boundary matching would only weaken detection: an attacker who
-/// glues the compound onto a longer identifier (`secret_access_key_v2`) or
-/// composes it inside another compound (`aws_secret_access_key`) must still
-/// trip the gate. Do not move an entry here unless it structurally requires
-/// an underscore to make sense as a trigger.
-const COMPOUND_TRIGGER_WORDS: &[&str] = &["api_key", "access_key", "private_key"];
-
 /// Minimum token length to apply the entropy check.
 const MIN_ENTROPY_LEN: usize = 24;
 
@@ -717,16 +706,17 @@ fn check_entropy_heuristic(text: &str, from: usize) -> Option<(&str, &'static st
         let window_start = floor_char_boundary(text, tok_offset.saturating_sub(TRIGGER_WINDOW));
         let window_end = floor_char_boundary(text, tok_offset + raw_token.len() + TRIGGER_WINDOW);
         let window = &text[window_start..window_end];
-        let low_window = window.to_ascii_lowercase();
+        let raw_start = tok_offset - window_start;
+        let raw_end = raw_start + raw_token.len();
 
-        let near_trigger = COMPOUND_TRIGGER_WORDS
-            .iter()
-            .any(|tw| low_window.contains(tw))
-            || TRIGGER_WORDS
-                .iter()
-                .any(|tw| contains_bounded_word(&low_window, tw))
-            || has_standalone_token(&low_window)
-            || has_token_assignment(&low_window);
+        // A high-entropy candidate must not provide its own surrounding
+        // trigger context. This matters for paths whose slugs contain a real
+        // trigger token, such as `ADR-051-cli-auth-and-kg-git-workflow.md`.
+        // Search the prose on either side independently, then preserve inline
+        // credential shapes through a focused assignment/config check.
+        let near_trigger = contains_trigger(&window[..raw_start])
+            || contains_trigger(&window[raw_end..])
+            || has_inline_credential_trigger(raw_token);
 
         // UUID canonical form and sha-prefixed base64 content hashes (SRI /
         // npm lockfile integrity) are allowlisted only outside trigger
@@ -869,6 +859,53 @@ fn contains_word(low_window: &str, needle: &str, underscore_is_word_char: bool) 
 /// collisions like `authorized`/`authentication`/`monkey`/`keyword` do not.
 fn contains_bounded_word(low_window: &str, needle: &str) -> bool {
     contains_word(low_window, needle, false)
+}
+
+/// Returns `true` when `text` contains a boundary-delimited credential trigger.
+fn contains_trigger(text: &str) -> bool {
+    let low = text.to_ascii_lowercase();
+    TRIGGER_WORDS
+        .iter()
+        .any(|tw| contains_bounded_word(&low, tw))
+        || has_standalone_token(&low)
+        || has_token_assignment(&low)
+}
+
+/// Detect credential labels embedded in the same whitespace token as a value.
+///
+/// The surrounding-context scan deliberately excludes the candidate token so
+/// a trigger word inside a path cannot make that path self-trigger. Credential
+/// assignments still need to fire when no whitespace separates label and
+/// value, including JSON-like forms. Underscore-delimited config identifiers
+/// without an assignment are retained for compatibility with shapes such as
+/// `session_secret_<value>`.
+fn has_inline_credential_trigger(raw_token: &str) -> bool {
+    let low = raw_token.to_ascii_lowercase();
+
+    let has_assignment_label = low.char_indices().any(|(index, ch)| {
+        if !matches!(ch, '=' | ':') {
+            return false;
+        }
+        let before =
+            low[..index].trim_end_matches(|c: char| !c.is_ascii_alphanumeric() && c != '_');
+        let label = before
+            .rsplit(|c: char| !c.is_ascii_alphanumeric() && c != '_')
+            .next()
+            .unwrap_or_default();
+        TRIGGER_WORDS
+            .iter()
+            .any(|tw| contains_bounded_word(label, tw))
+            || label == "token"
+    });
+    if has_assignment_label {
+        return true;
+    }
+
+    !low.contains(['/', '-', '.'])
+        && low.contains('_')
+        && TRIGGER_WORDS
+            .iter()
+            .any(|tw| contains_bounded_word(&low, tw))
 }
 
 /// Returns `true` when `low_window` contains the word `token` as a standalone
@@ -3196,6 +3233,35 @@ mod tests {
     // ── Trigger word-boundary matching ──────────────────────────────────────
 
     #[test]
+    fn allows_trigger_substrings_inside_benign_path_slugs() {
+        let paths = [
+            "docs/_archive/adr_v0/ADR-051-cli-auth-and-kg-git-workflow.md",
+            "docs/platform/oauth-callback-docs-and-redirect-handling-v2.md",
+            "docs/research/author-attribution-and-collaboration-notes.md",
+            "docs/security/passwordless-authentication-overview-v3.md",
+            "docs/platform/private_keynote-authoring-guide-v2.md",
+        ];
+        for path in paths {
+            assert!(
+                check(path).is_ok(),
+                "trigger substring inside a benign path slug must not make the path \
+                 its own credential context: {path:?}, got {:?}",
+                scan(path)
+            );
+        }
+    }
+
+    #[test]
+    fn blocks_inline_auth_assignment_with_high_entropy_value() {
+        let content = "auth=Xk9mZ2vQpLrT8nJwYuAeHfBsDcGiONvMabcdef"; // gitleaks:allow
+        assert!(
+            check(content).is_err(),
+            "auth=<high-entropy-value> must still be blocked; got {:?}",
+            scan(content)
+        );
+    }
+
+    #[test]
     fn allows_authorized_and_authentication_prose_near_uuid() {
         // The word-boundary fix directly: "auth" no longer matches the
         // substring inside "authorized"/"authentication", so ordinary prose
@@ -3306,9 +3372,9 @@ mod tests {
         // directly to a trigger word must not be exempted just because it is
         // path-shaped (separator-delimited, word-shaped runs) and looks
         // superficially like the accepted-FP repro paths above. The compound
-        // entry `api_key` is a plain substring match regardless of
-        // word-boundary rules, and the structured-identifier exemption is
-        // unconditionally dropped in trigger context, so this must block.
+        // label `api_key` is assignment-shaped, and the structured-identifier
+        // exemption is unconditionally dropped in trigger context, so this
+        // must block.
         let content = "api_key=/home/user/workspaces/2026/topic-name-example/SECRET_VALUE_HERE.md";
         assert!(
             check(content).is_err(),
@@ -3321,14 +3387,9 @@ mod tests {
     #[test]
     fn blocks_secret_access_key_bypass_compound_entry_unaffected_by_round5() {
         // Adversarial negative: a separator-split bypass shape must still be
-        // blocked. It fires via TWO independent paths: the compound
-        // `access_key` entry (`COMPOUND_TRIGGER_WORDS`, plain substring,
-        // always matched regardless of word-boundary rules), AND the bare
-        // `secret` entry, because underscore is a BOUNDARY for bare
-        // `TRIGGER_WORDS`: so `secret` in `secret_access_key` is itself a
-        // bounded word (bounded by the following `_`), not merely a
-        // substring collision. Either path alone is sufficient; this asserts
-        // the end-to-end outcome.
+        // blocked. The `secret` and `key` entries both match because underscore
+        // is a boundary for bare `TRIGGER_WORDS`. This asserts the end-to-end
+        // outcome.
         let content = "secret_access_key abcdefghij/klmnopqrst/uvwxyzabcd/efghijk.md";
         assert!(
             check(content).is_err(),

--- a/crates/khive-runtime/src/secret_gate.rs
+++ b/crates/khive-runtime/src/secret_gate.rs
@@ -89,8 +89,8 @@
 //! is excluded from its own surrounding context. This prevents an internal
 //! path segment such as `cli-auth-and-kg` from making the path self-trigger.
 //! Assignment-shaped candidates such as `auth=<value>` and `api_key=<value>`
-//! are checked separately so the exclusion does not weaken credential-shaped
-//! writes.
+//! are checked separately, including when whitespace splits the label from the
+//! value, so the exclusion does not weaken credential-shaped writes.
 //!
 //! A structured-identifier-shaped token sitting near a **genuinely standalone**
 //! trigger word (e.g. `auth work saved at .../repo-audit.md`, where `auth` is
@@ -874,6 +874,33 @@ fn contains_trigger(text: &str) -> bool {
         .any(|tw| contains_bounded_word(&low, tw))
         || has_standalone_token(&low)
         || has_token_assignment(&low)
+        || has_assignment_credential_trigger(&low)
+}
+
+/// Detect a credential-bearing assignment label before an `=` or `:`.
+///
+/// The separator may be preceded by whitespace or a JSON quote. Compound
+/// triggers deliberately retain substring matching inside the label so common
+/// version suffixes such as `api_keyv2` remain protected.
+fn has_assignment_credential_trigger(low_text: &str) -> bool {
+    low_text.char_indices().any(|(index, ch)| {
+        if !matches!(ch, '=' | ':') {
+            return false;
+        }
+        let before =
+            low_text[..index].trim_end_matches(|c: char| !c.is_ascii_alphanumeric() && c != '_');
+        let label = before
+            .rsplit(|c: char| !c.is_ascii_alphanumeric() && c != '_')
+            .next()
+            .unwrap_or_default();
+        ASSIGNMENT_COMPOUND_TRIGGERS
+            .iter()
+            .any(|tw| label.contains(tw))
+            || TRIGGER_WORDS
+                .iter()
+                .any(|tw| contains_bounded_word(label, tw))
+            || label == "token"
+    })
 }
 
 /// Detect credential labels embedded in the same whitespace token as a value.
@@ -887,25 +914,7 @@ fn contains_trigger(text: &str) -> bool {
 fn has_inline_credential_trigger(raw_token: &str) -> bool {
     let low = raw_token.to_ascii_lowercase();
 
-    let has_assignment_label = low.char_indices().any(|(index, ch)| {
-        if !matches!(ch, '=' | ':') {
-            return false;
-        }
-        let before =
-            low[..index].trim_end_matches(|c: char| !c.is_ascii_alphanumeric() && c != '_');
-        let label = before
-            .rsplit(|c: char| !c.is_ascii_alphanumeric() && c != '_')
-            .next()
-            .unwrap_or_default();
-        ASSIGNMENT_COMPOUND_TRIGGERS
-            .iter()
-            .any(|tw| label.contains(tw))
-            || TRIGGER_WORDS
-                .iter()
-                .any(|tw| contains_bounded_word(label, tw))
-            || label == "token"
-    });
-    if has_assignment_label {
+    if has_assignment_credential_trigger(&low) {
         return true;
     }
 
@@ -3286,6 +3295,26 @@ mod tests {
                  {content:?}, got {:?}",
                 scan(content)
             );
+        }
+    }
+
+    #[test]
+    fn blocks_spaced_suffix_bearing_compound_credential_assignments() {
+        let opaque = "Xk9mZ2vQpLrT8nJwYuAeHfBsDcGiONvMabcdef"; // gitleaks:allow
+        for label in ["api_keyv2", "access_keyv2", "private_keyv2"] {
+            let cases = [
+                format!("{label} = {opaque}"),
+                format!("{label} : {opaque}"),
+                format!(r#"{{"{label}": "{opaque}"}}"#),
+            ];
+            for content in &cases {
+                assert!(
+                    check(content).is_err(),
+                    "spaced suffix-bearing compound credential assignment must be \
+                     blocked: {content:?}, got {:?}",
+                    scan(content)
+                );
+            }
         }
     }
 

--- a/crates/khive-runtime/src/secret_gate.rs
+++ b/crates/khive-runtime/src/secret_gate.rs
@@ -638,10 +638,10 @@ const TRIGGER_WORDS: &[&str] = &[
     "apikey",
 ];
 
-/// Compound triggers that retain substring matching inside assignment labels.
+/// Compound triggers that retain suffix matching inside credential labels.
 /// Their underscore separator disambiguates them from ordinary prose, and
 /// suffixes are common in versioned credential names such as `api_keyv2`.
-const ASSIGNMENT_COMPOUND_TRIGGERS: &[&str] = &["api_key", "access_key", "private_key"];
+const COMPOUND_TRIGGER_WORDS: &[&str] = &["api_key", "access_key", "private_key"];
 
 /// Minimum token length to apply the entropy check.
 const MIN_ENTROPY_LEN: usize = 24;
@@ -866,12 +866,35 @@ fn contains_bounded_word(low_window: &str, needle: &str) -> bool {
     contains_word(low_window, needle, false)
 }
 
+/// Returns `true` when a compound credential label begins at an identifier
+/// boundary. The trailing edge is deliberately unbounded so version suffixes
+/// and larger underscore-composed labels remain protected.
+fn contains_compound_trigger(low_text: &str) -> bool {
+    COMPOUND_TRIGGER_WORDS.iter().any(|needle| {
+        let mut start = 0;
+        while let Some(rel) = low_text[start..].find(needle) {
+            let abs = start + rel;
+            let before_ok = abs == 0
+                || low_text[..abs]
+                    .chars()
+                    .next_back()
+                    .is_none_or(|c| !c.is_ascii_alphanumeric());
+            if before_ok {
+                return true;
+            }
+            start = abs + needle.len();
+        }
+        false
+    })
+}
+
 /// Returns `true` when `text` contains a boundary-delimited credential trigger.
 fn contains_trigger(text: &str) -> bool {
     let low = text.to_ascii_lowercase();
     TRIGGER_WORDS
         .iter()
         .any(|tw| contains_bounded_word(&low, tw))
+        || contains_compound_trigger(&low)
         || has_standalone_token(&low)
         || has_token_assignment(&low)
         || has_assignment_credential_trigger(&low)
@@ -893,9 +916,7 @@ fn has_assignment_credential_trigger(low_text: &str) -> bool {
             .rsplit(|c: char| !c.is_ascii_alphanumeric() && c != '_')
             .next()
             .unwrap_or_default();
-        ASSIGNMENT_COMPOUND_TRIGGERS
-            .iter()
-            .any(|tw| label.contains(tw))
+        contains_compound_trigger(label)
             || TRIGGER_WORDS
                 .iter()
                 .any(|tw| contains_bounded_word(label, tw))
@@ -920,9 +941,10 @@ fn has_inline_credential_trigger(raw_token: &str) -> bool {
 
     !low.contains(['/', '-', '.'])
         && low.contains('_')
-        && TRIGGER_WORDS
-            .iter()
-            .any(|tw| contains_bounded_word(&low, tw))
+        && (contains_compound_trigger(&low)
+            || TRIGGER_WORDS
+                .iter()
+                .any(|tw| contains_bounded_word(&low, tw)))
 }
 
 /// Returns `true` when `low_window` contains the word `token` as a standalone
@@ -3313,6 +3335,27 @@ mod tests {
                     "spaced suffix-bearing compound credential assignment must be \
                      blocked: {content:?}, got {:?}",
                     scan(content)
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn blocks_suffix_bearing_compound_credentials_without_assignment_separator() {
+        let opaque = "Xk9mZ2vQpLrT8nJwYuAeHfBsDcGiONvMabcdef"; // gitleaks:allow
+        for label in ["api_keyv2", "access_keyv2", "private_keyv2"] {
+            let cases = [format!("{label} {opaque}"), format!("{label}{opaque}")];
+            for content in &cases {
+                assert!(
+                    check(content).is_err(),
+                    "suffix-bearing compound credential without an assignment separator must be \
+                     blocked: {content:?}, got {:?}",
+                    scan(content)
+                );
+                assert!(
+                    mask_secrets(content).contains(REDACTION_MARKER),
+                    "shared secret masker must redact separator-free compound credential: \
+                     {content:?}"
                 );
             }
         }

--- a/crates/khive-runtime/src/secret_gate.rs
+++ b/crates/khive-runtime/src/secret_gate.rs
@@ -638,6 +638,11 @@ const TRIGGER_WORDS: &[&str] = &[
     "apikey",
 ];
 
+/// Compound triggers that retain substring matching inside assignment labels.
+/// Their underscore separator disambiguates them from ordinary prose, and
+/// suffixes are common in versioned credential names such as `api_keyv2`.
+const ASSIGNMENT_COMPOUND_TRIGGERS: &[&str] = &["api_key", "access_key", "private_key"];
+
 /// Minimum token length to apply the entropy check.
 const MIN_ENTROPY_LEN: usize = 24;
 
@@ -892,9 +897,12 @@ fn has_inline_credential_trigger(raw_token: &str) -> bool {
             .rsplit(|c: char| !c.is_ascii_alphanumeric() && c != '_')
             .next()
             .unwrap_or_default();
-        TRIGGER_WORDS
+        ASSIGNMENT_COMPOUND_TRIGGERS
             .iter()
-            .any(|tw| contains_bounded_word(label, tw))
+            .any(|tw| label.contains(tw))
+            || TRIGGER_WORDS
+                .iter()
+                .any(|tw| contains_bounded_word(label, tw))
             || label == "token"
     });
     if has_assignment_label {
@@ -3259,6 +3267,26 @@ mod tests {
             "auth=<high-entropy-value> must still be blocked; got {:?}",
             scan(content)
         );
+    }
+
+    #[test]
+    fn blocks_suffix_bearing_compound_credential_assignments() {
+        let opaque = "Xk9mZ2vQpLrT8nJwYuAeHfBsDcGiONvMabcdef"; // gitleaks:allow
+        let cases = [
+            format!("api_keyv2={opaque}"),
+            format!("access_keyv2={opaque}"),
+            format!("private_keyv2={opaque}"),
+            format!("API_KEYV2={opaque}"),
+            format!(r#"{{"private_keyv2":"{opaque}"}}"#),
+        ];
+        for content in &cases {
+            assert!(
+                check(content).is_err(),
+                "suffix-bearing compound credential assignment must be blocked: \
+                 {content:?}, got {:?}",
+                scan(content)
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
Closes #870.

The secret gate's trigger-word scan matched substrings anywhere in a token, so benign path slugs (e.g. `docs/api-key-rotation.md`) self-triggered the gate. This change moves trigger matching to token boundaries and adds an inline-credential check (trigger + assignment + high-entropy value) so true positives are preserved.

- `contains_trigger`: token-boundary matching instead of raw substring
- `has_inline_credential_trigger`: keeps blocking real `key=<entropy>` assignments
- Regression tests in both directions: benign slugs pass, inline credentials still block

🤖 Generated with [Claude Code](https://claude.com/claude-code)