### PR TITLE
fix(db): key batched neighbors results by requested node

### DIFF
--- a/crates/khive-db/src/stores/graph.rs
+++ b/crates/khive-db/src/stores/graph.rs
@@ -1,5 +1,6 @@
 //! SQL-backed `GraphStore`: edge CRUD, neighbor queries, and recursive CTE traversal.
 
+use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
 use async_trait::async_trait;
@@ -1273,35 +1274,18 @@ impl GraphStore for SqlGraphStore {
         if sources.is_empty() {
             return Ok(Vec::new());
         }
-        // Compute a per-call chunk size that keeps the total bound parameter count
-        // safely under SQLITE_MAX_VARIABLE_NUMBER (999).
-        //
-        // Variable budget:
-        //   1  = namespace (?1, shared across all halves of a UNION ALL)
-        //   1  = limit (optional, worst-case reserve)
-        //   halves × (src_count + per_half_filter) = the IN-list + filter params
-        //
-        // For Direction::Both the UNION ALL doubles the source IN-list and filter
-        // params (each half is a fully independent positional-parameter block).
-        // For Out/In there is only one half.
-        //
-        // We target 950 total to leave a comfortable margin below 999, then cap at
-        // 880 to preserve the existing ceiling for the single-direction common case.
-        let per_half_filter =
-            query.relations.as_ref().map_or(0, |r| r.len()) + query.min_weight.is_some() as usize;
-        let halves: usize = if query.direction == Direction::Both {
-            2
-        } else {
-            1
-        };
-        let fixed = 1 /*ns*/ + 1 /*limit*/ + halves * per_half_filter;
-        let max_src = (950usize.saturating_sub(fixed) / halves).max(1);
-        let chunk_size = max_src.min(880);
+        let mut seen_sources = HashSet::with_capacity(sources.len());
+        let unique_sources: Vec<Uuid> = sources
+            .iter()
+            .copied()
+            .filter(|source| seen_sources.insert(*source))
+            .collect();
+        const CHUNK_SIZE: usize = 880;
 
         let namespace = self.namespace.clone();
         let mut result: Vec<(Uuid, NeighborHit)> = Vec::new();
 
-        for chunk in sources.chunks(chunk_size) {
+        for chunk in unique_sources.chunks(CHUNK_SIZE) {
             let chunk_owned: Vec<Uuid> = chunk.to_vec();
             let query_clone = query.clone();
             let ns = namespace.clone();
@@ -1310,30 +1294,23 @@ impl GraphStore for SqlGraphStore {
                 .with_reader("batch_neighbors", move |conn| {
                     let src_strs: Vec<String> = chunk_owned.iter().map(|u| u.to_string()).collect();
 
-                    // Build the inner SELECT for one direction, using positional
-                    // params starting at `first_src_param` for the source IN-list.
-                    // Returns (sql_fragment, extra_param_values) where extra_param_values
-                    // covers relations and min_weight filters only (NOT the limit).
+                    let sources_json = serde_json::to_string(&src_strs).map_err(|error| {
+                        rusqlite::Error::ToSqlConversionFailure(Box::new(error))
+                    })?;
+
                     let build_inner_sql =
                         |direction_out: bool,
-                         first_src_param: usize,
                          q: &NeighborQuery|
                          -> (String, Vec<String>, Option<f64>) {
-                            let placeholders: Vec<String> = (first_src_param
-                                ..first_src_param + src_strs.len())
-                                .map(|i| format!("?{i}"))
-                                .collect();
-                            let in_list = placeholders.join(",");
-
-                            let (origin_col, filter_col, node_col) = if direction_out {
-                                ("source_id", "source_id", "target_id")
+                            let (filter_col, node_col) = if direction_out {
+                                ("source_id", "target_id")
                             } else {
-                                ("target_id", "target_id", "source_id")
+                                ("target_id", "source_id")
                             };
 
                             let mut rel_params: Vec<String> = Vec::new();
                             let mut conditions: Vec<String> = Vec::new();
-                            let mut param_idx = first_src_param + src_strs.len();
+                            let mut param_idx = 3;
 
                             if let Some(ref rels) = q.relations {
                                 if !rels.is_empty() {
@@ -1346,14 +1323,15 @@ impl GraphStore for SqlGraphStore {
                                             p
                                         })
                                         .collect();
-                                    conditions.push(format!("relation IN ({})", ps.join(",")));
+                                    conditions
+                                        .push(format!("edges.relation IN ({})", ps.join(",")));
                                 }
                             }
 
                             // min_weight is returned separately so it can be added to
                             // all_params AFTER the rel_params block, at the right index.
                             let min_weight_val = if let Some(min_w) = q.min_weight {
-                                conditions.push(format!("weight >= ?{param_idx}"));
+                                conditions.push(format!("edges.weight >= ?{param_idx}"));
                                 Some(min_w)
                             } else {
                                 None
@@ -1366,91 +1344,42 @@ impl GraphStore for SqlGraphStore {
                             };
 
                             let sql = format!(
-                                "SELECT {origin_col} AS origin_id, {node_col} AS node_id, \
-                             id AS edge_id, relation, weight \
-                             FROM graph_edges \
-                             WHERE namespace = ?1 AND {filter_col} IN ({in_list}) \
-                               AND deleted_at IS NULL{where_extra}",
+                                "SELECT requested.origin_id, edges.{node_col} AS node_id, \
+                                 edges.id AS edge_id, edges.relation, edges.weight \
+                                 FROM requested CROSS JOIN graph_edges AS edges \
+                                   ON edges.{filter_col} = requested.origin_id \
+                                 WHERE edges.namespace = ?1 \
+                                   AND edges.deleted_at IS NULL{where_extra}",
                             );
                             (sql, rel_params, min_weight_val)
                         };
 
-                    // For Direction::Both we need to build a UNION ALL of both inner
-                    // selects and then apply the per-source ROW_NUMBER limit ONCE over
-                    // the combined set.  This matches the single-source neighbors()
-                    // behaviour where Both uses a single UNION ALL + one outer LIMIT.
-                    //
-                    // Param layout:
-                    //   Out/In:  ?1=ns  ?2..?N+1=srcs  ?extras...  [?limit]
-                    //   Both:    ?1=ns  ?2..?N+1=out_srcs  out_extras...
-                    //                   ?M..?M+N=in_srcs   in_extras...  [?limit]
-                    //
-                    // `build_inner_sql` receives `first_src_param` so it generates the
-                    // correct placeholder indices for each half.
-
                     let mut all_params: Vec<Box<dyn rusqlite::types::ToSql>> = Vec::new();
-                    all_params.push(Box::new(ns.to_string())); // ?1
+                    all_params.push(Box::new(ns.to_string()));
+                    all_params.push(Box::new(sources_json));
 
-                    let combined_inner: String;
-                    let limit_param_idx: usize;
-
-                    match query_clone.direction {
-                        Direction::Out | Direction::In => {
-                            let direction_out = matches!(query_clone.direction, Direction::Out);
-                            let (sql, rel_params, min_weight_val) =
-                                build_inner_sql(direction_out, 2, &query_clone);
-                            combined_inner = sql;
-
-                            // Bind: ?1=ns (done), ?2..?N+1=srcs, rel_params, [min_weight]
-                            for s in &src_strs {
-                                all_params.push(Box::new(s.clone()));
-                            }
-                            for r in rel_params {
-                                all_params.push(Box::new(r));
-                            }
-                            if let Some(mw) = min_weight_val {
-                                all_params.push(Box::new(mw));
-                            }
-                            limit_param_idx = all_params.len() + 1;
-                        }
+                    let (combined_inner, rel_params, min_weight_val) = match query_clone.direction {
+                        Direction::Out => build_inner_sql(true, &query_clone),
+                        Direction::In => build_inner_sql(false, &query_clone),
                         Direction::Both => {
-                            // Out half: src params at ?2..?N+1
-                            let (out_sql, out_rels, out_mw) =
-                                build_inner_sql(true, 2, &query_clone);
-                            let after_out_srcs = 2 + src_strs.len();
-                            let after_out_rels = after_out_srcs + out_rels.len();
-                            let after_out_mw =
-                                after_out_rels + if out_mw.is_some() { 1 } else { 0 };
-                            let in_first = after_out_mw;
-
-                            // In half: src params start at `in_first`
-                            let (in_sql, in_rels, in_mw) =
-                                build_inner_sql(false, in_first, &query_clone);
-
-                            combined_inner = format!("{out_sql} UNION ALL {in_sql}");
-
-                            // Bind layout: ns | out_srcs | out_rels | [out_mw] | in_srcs | in_rels | [in_mw]
-                            for s in &src_strs {
-                                all_params.push(Box::new(s.clone())); // out sources
-                            }
-                            for r in out_rels {
-                                all_params.push(Box::new(r));
-                            }
-                            if let Some(mw) = out_mw {
-                                all_params.push(Box::new(mw));
-                            }
-                            for s in &src_strs {
-                                all_params.push(Box::new(s.clone())); // in sources
-                            }
-                            for r in in_rels {
-                                all_params.push(Box::new(r));
-                            }
-                            if let Some(mw) = in_mw {
-                                all_params.push(Box::new(mw));
-                            }
-                            limit_param_idx = all_params.len() + 1;
+                            let (out_sql, rel_params, min_weight_val) =
+                                build_inner_sql(true, &query_clone);
+                            let (in_sql, _, _) = build_inner_sql(false, &query_clone);
+                            (
+                                format!("{out_sql} UNION ALL {in_sql}"),
+                                rel_params,
+                                min_weight_val,
+                            )
                         }
+                    };
+
+                    for relation in rel_params {
+                        all_params.push(Box::new(relation));
                     }
+                    if let Some(min_weight) = min_weight_val {
+                        all_params.push(Box::new(min_weight));
+                    }
+                    let limit_param_idx = all_params.len() + 1;
 
                     // Wrap combined inner with per-source ROW_NUMBER limit if needed.
                     //
@@ -1462,14 +1391,18 @@ impl GraphStore for SqlGraphStore {
                     let full_sql = if let Some(lim) = query_clone.limit {
                         all_params.push(Box::new(lim as i64));
                         format!(
-                            "SELECT origin_id, node_id, edge_id, relation, weight \
+                            "WITH requested(origin_id) AS (\
+                               SELECT value FROM json_each(?2)\
+                             ) SELECT origin_id, node_id, edge_id, relation, weight \
                              FROM (SELECT *, ROW_NUMBER() OVER (PARTITION BY origin_id \
                                    ORDER BY weight DESC, node_id ASC) AS rn \
                                    FROM ({combined_inner})) WHERE rn <= ?{limit_param_idx}",
                         )
                     } else {
                         format!(
-                            "SELECT origin_id, node_id, edge_id, relation, weight \
+                            "WITH requested(origin_id) AS (\
+                               SELECT value FROM json_each(?2)\
+                             ) SELECT origin_id, node_id, edge_id, relation, weight \
                              FROM ({combined_inner})",
                         )
                     };
@@ -1518,7 +1451,33 @@ impl GraphStore for SqlGraphStore {
                 .await?;
             result.extend(pairs);
         }
-        Ok(result)
+
+        let requested: HashSet<Uuid> = unique_sources.iter().copied().collect();
+        let mut grouped: HashMap<Uuid, Vec<NeighborHit>> =
+            HashMap::with_capacity(unique_sources.len());
+        for (origin, hit) in result {
+            if !requested.contains(&origin) {
+                return Err(StorageError::Internal(format!(
+                    "batch_neighbors returned unrequested origin {origin}"
+                )));
+            }
+            grouped.entry(origin).or_default().push(hit);
+        }
+
+        let mut ordered = Vec::new();
+        for source in unique_sources {
+            if let Some(mut hits) = grouped.remove(&source) {
+                hits.sort_by(|a, b| {
+                    b.weight
+                        .partial_cmp(&a.weight)
+                        .unwrap_or(std::cmp::Ordering::Equal)
+                        .then(a.node_id.cmp(&b.node_id))
+                        .then(a.edge_id.cmp(&b.edge_id))
+                });
+                ordered.extend(hits.into_iter().map(|hit| (source, hit)));
+            }
+        }
+        Ok(ordered)
     }
 
     async fn delete_edge(&self, id: LinkId, mode: DeleteMode) -> Result<bool, StorageError> {

--- a/crates/khive-db/src/stores/graph.rs
+++ b/crates/khive-db/src/stores/graph.rs
@@ -1464,17 +1464,20 @@ impl GraphStore for SqlGraphStore {
             grouped.entry(origin).or_default().push(hit);
         }
 
+        for hits in grouped.values_mut() {
+            hits.sort_by(|a, b| {
+                b.weight
+                    .partial_cmp(&a.weight)
+                    .unwrap_or(std::cmp::Ordering::Equal)
+                    .then(a.node_id.cmp(&b.node_id))
+                    .then(a.edge_id.cmp(&b.edge_id))
+            });
+        }
+
         let mut ordered = Vec::new();
-        for source in unique_sources {
-            if let Some(mut hits) = grouped.remove(&source) {
-                hits.sort_by(|a, b| {
-                    b.weight
-                        .partial_cmp(&a.weight)
-                        .unwrap_or(std::cmp::Ordering::Equal)
-                        .then(a.node_id.cmp(&b.node_id))
-                        .then(a.edge_id.cmp(&b.edge_id))
-                });
-                ordered.extend(hits.into_iter().map(|hit| (source, hit)));
+        for &source in sources {
+            if let Some(hits) = grouped.get(&source) {
+                ordered.extend(hits.iter().cloned().map(|hit| (source, hit)));
             }
         }
         Ok(ordered)

--- a/crates/khive-db/src/stores/graph_tests.rs
+++ b/crates/khive-db/src/stores/graph_tests.rs
@@ -2,7 +2,7 @@ use super::*;
 use crate::pool::PoolConfig;
 use khive_storage::types::{Direction, TraversalOptions};
 use serial_test::serial;
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 
 /// Deterministic barrier at the exact insert-to-probe seam
 /// [`edge_insert_guarded`] calls into (via `#[cfg(test)] hook(...)`) after a
@@ -1407,6 +1407,173 @@ fn single_neighbour_set(hits: &[NeighborHit]) -> HashSet<Uuid> {
     hits.iter().map(|h| h.node_id).collect()
 }
 
+fn grouped_neighbor_rows(
+    hits: Vec<(Uuid, NeighborHit)>,
+) -> HashMap<Uuid, HashSet<(Uuid, Uuid, EdgeRelation)>> {
+    let mut grouped: HashMap<Uuid, HashSet<(Uuid, Uuid, EdgeRelation)>> = HashMap::new();
+    for (origin, hit) in hits {
+        grouped
+            .entry(origin)
+            .or_default()
+            .insert((hit.node_id, hit.edge_id, hit.relation));
+    }
+    grouped
+}
+
+#[tokio::test]
+async fn batch_neighbors_keeps_exact_rows_grouped_by_requested_node() {
+    let store = setup_memory_store();
+    let root_a = Uuid::new_v4();
+    let root_b = Uuid::new_v4();
+    let root_c = Uuid::new_v4();
+    let shared = Uuid::new_v4();
+    let only_a = Uuid::new_v4();
+    let only_b = Uuid::new_v4();
+    let only_c = Uuid::new_v4();
+
+    let edges = vec![
+        make_edge(root_a, shared, EdgeRelation::Extends, 0.9),
+        make_edge(root_a, only_a, EdgeRelation::DependsOn, 0.8),
+        make_edge(root_b, shared, EdgeRelation::Extends, 0.7),
+        make_edge(root_b, only_b, EdgeRelation::DependsOn, 0.6),
+        make_edge(root_c, only_c, EdgeRelation::Extends, 0.5),
+        make_edge(shared, root_a, EdgeRelation::Extends, 0.4),
+        make_edge(only_a, root_a, EdgeRelation::DependsOn, 0.3),
+        make_edge(shared, root_b, EdgeRelation::DependsOn, 0.4),
+        make_edge(only_b, root_b, EdgeRelation::Extends, 0.3),
+        make_edge(shared, root_c, EdgeRelation::Extends, 0.4),
+        make_edge(only_c, root_c, EdgeRelation::DependsOn, 0.3),
+    ];
+    let edge_ids: Vec<Uuid> = edges.iter().map(|edge| Uuid::from(edge.id)).collect();
+    for edge in edges {
+        store.upsert_edge(edge).await.unwrap();
+    }
+
+    let sources = [root_c, root_a, root_b];
+    let outgoing_hits = store
+        .batch_neighbors(
+            &sources,
+            NeighborQuery {
+                direction: Direction::Out,
+                relations: Some(vec![EdgeRelation::Extends]),
+                limit: None,
+                min_weight: None,
+            },
+        )
+        .await
+        .unwrap();
+    assert_eq!(
+        outgoing_hits
+            .iter()
+            .map(|(origin, _)| *origin)
+            .collect::<Vec<_>>(),
+        vec![root_c, root_a, root_b]
+    );
+    let outgoing = grouped_neighbor_rows(outgoing_hits);
+    assert_eq!(
+        outgoing,
+        HashMap::from([
+            (
+                root_a,
+                HashSet::from([(shared, edge_ids[0], EdgeRelation::Extends)]),
+            ),
+            (
+                root_b,
+                HashSet::from([(shared, edge_ids[2], EdgeRelation::Extends)]),
+            ),
+            (
+                root_c,
+                HashSet::from([(only_c, edge_ids[4], EdgeRelation::Extends)]),
+            ),
+        ])
+    );
+
+    let incoming_hits = store
+        .batch_neighbors(
+            &sources,
+            NeighborQuery {
+                direction: Direction::In,
+                relations: Some(vec![EdgeRelation::DependsOn]),
+                limit: None,
+                min_weight: None,
+            },
+        )
+        .await
+        .unwrap();
+    assert_eq!(
+        incoming_hits
+            .iter()
+            .map(|(origin, _)| *origin)
+            .collect::<Vec<_>>(),
+        vec![root_c, root_a, root_b]
+    );
+    let incoming = grouped_neighbor_rows(incoming_hits);
+    assert_eq!(
+        incoming,
+        HashMap::from([
+            (
+                root_a,
+                HashSet::from([(only_a, edge_ids[6], EdgeRelation::DependsOn)]),
+            ),
+            (
+                root_b,
+                HashSet::from([(shared, edge_ids[7], EdgeRelation::DependsOn)]),
+            ),
+            (
+                root_c,
+                HashSet::from([(only_c, edge_ids[10], EdgeRelation::DependsOn)]),
+            ),
+        ])
+    );
+
+    let both_hits = store
+        .batch_neighbors(
+            &sources,
+            NeighborQuery {
+                direction: Direction::Both,
+                relations: Some(vec![EdgeRelation::Extends]),
+                limit: None,
+                min_weight: None,
+            },
+        )
+        .await
+        .unwrap();
+    assert_eq!(
+        both_hits
+            .iter()
+            .map(|(origin, _)| *origin)
+            .collect::<Vec<_>>(),
+        vec![root_c, root_c, root_a, root_a, root_b, root_b]
+    );
+    let both = grouped_neighbor_rows(both_hits);
+    assert_eq!(
+        both,
+        HashMap::from([
+            (
+                root_a,
+                HashSet::from([
+                    (shared, edge_ids[0], EdgeRelation::Extends),
+                    (shared, edge_ids[5], EdgeRelation::Extends),
+                ]),
+            ),
+            (
+                root_b,
+                HashSet::from([
+                    (shared, edge_ids[2], EdgeRelation::Extends),
+                    (only_b, edge_ids[8], EdgeRelation::Extends),
+                ]),
+            ),
+            (
+                root_c,
+                HashSet::from([
+                    (only_c, edge_ids[4], EdgeRelation::Extends),
+                    (shared, edge_ids[9], EdgeRelation::Extends),
+                ]),
+            ),
+        ])
+    );
+}
+
 /// PARITY REGRESSION GUARD — the critical bug (HIGH).
 /// For Direction::Both + limit=Some(1), batch_neighbors must return AT MOST
 /// `limit` hits per source, not up to 2× (one per direction).
@@ -1829,14 +1996,9 @@ async fn get_edges_chunk_boundary() {
 
 /// batch_neighbors Direction::Both chunk-boundary test.
 ///
-/// With the old const CHUNK=880, Direction::Both would bind ~1761 variables
-/// (1 ns + 880 out_srcs + 880 in_srcs) into a single SQLite statement,
-/// blowing past SQLITE_MAX_VARIABLE_NUMBER=999 and returning an error.
-///
-/// This test uses 500 source nodes — enough that a single Both chunk would
-/// have exceeded 999 variables under the old constant.  After the fix the
-/// computed chunk_size for Both (no filters, no limit) is ~474, so the 500
-/// sources are split into two chunks, each staying within budget.
+/// Source IDs are bound once as a JSON array, so Direction::Both does not
+/// duplicate one SQL parameter per source for each UNION arm. This test crosses
+/// the 880-source chunk boundary and verifies that grouping remains exact.
 ///
 /// Correctness: for a random sample of sources, batch result must equal the
 /// per-source neighbors() result.
@@ -1846,8 +2008,8 @@ async fn get_edges_chunk_boundary() {
 async fn batch_neighbors_both_chunk_boundary() {
     let store = setup_memory_store();
 
-    // Create 500 source nodes, each with one outgoing and one incoming edge.
-    let source_count = 500usize;
+    // Create 900 source nodes, each with one outgoing and one incoming edge.
+    let source_count = 900usize;
     let mut sources: Vec<Uuid> = Vec::with_capacity(source_count);
     for _ in 0..source_count {
         let centre = Uuid::new_v4();

--- a/crates/khive-db/src/stores/graph_tests.rs
+++ b/crates/khive-db/src/stores/graph_tests.rs
@@ -1407,15 +1407,10 @@ fn single_neighbour_set(hits: &[NeighborHit]) -> HashSet<Uuid> {
     hits.iter().map(|h| h.node_id).collect()
 }
 
-fn grouped_neighbor_rows(
-    hits: Vec<(Uuid, NeighborHit)>,
-) -> HashMap<Uuid, HashSet<(Uuid, Uuid, EdgeRelation)>> {
-    let mut grouped: HashMap<Uuid, HashSet<(Uuid, Uuid, EdgeRelation)>> = HashMap::new();
+fn neighbor_edge_multiset(hits: &[(Uuid, NeighborHit)]) -> HashMap<(Uuid, Uuid), usize> {
+    let mut grouped = HashMap::new();
     for (origin, hit) in hits {
-        grouped
-            .entry(origin)
-            .or_default()
-            .insert((hit.node_id, hit.edge_id, hit.relation));
+        *grouped.entry((*origin, hit.edge_id)).or_default() += 1;
     }
     grouped
 }
@@ -1425,37 +1420,22 @@ async fn batch_neighbors_keeps_exact_rows_grouped_by_requested_node() {
     let store = setup_memory_store();
     let root_a = Uuid::new_v4();
     let root_b = Uuid::new_v4();
-    let root_c = Uuid::new_v4();
-    let shared = Uuid::new_v4();
-    let only_a = Uuid::new_v4();
-    let only_b = Uuid::new_v4();
-    let only_c = Uuid::new_v4();
-
-    let edges = vec![
-        make_edge(root_a, shared, EdgeRelation::Extends, 0.9),
-        make_edge(root_a, only_a, EdgeRelation::DependsOn, 0.8),
-        make_edge(root_b, shared, EdgeRelation::Extends, 0.7),
-        make_edge(root_b, only_b, EdgeRelation::DependsOn, 0.6),
-        make_edge(root_c, only_c, EdgeRelation::Extends, 0.5),
-        make_edge(shared, root_a, EdgeRelation::Extends, 0.4),
-        make_edge(only_a, root_a, EdgeRelation::DependsOn, 0.3),
-        make_edge(shared, root_b, EdgeRelation::DependsOn, 0.4),
-        make_edge(only_b, root_b, EdgeRelation::Extends, 0.3),
-        make_edge(shared, root_c, EdgeRelation::Extends, 0.4),
-        make_edge(only_c, root_c, EdgeRelation::DependsOn, 0.3),
-    ];
-    let edge_ids: Vec<Uuid> = edges.iter().map(|edge| Uuid::from(edge.id)).collect();
-    for edge in edges {
+    let root_without_edges = Uuid::new_v4();
+    let joined = make_edge(root_a, root_b, EdgeRelation::Extends, 0.9);
+    let self_loop = make_edge(root_b, root_b, EdgeRelation::DependsOn, 0.8);
+    let joined_id = Uuid::from(joined.id);
+    let self_loop_id = Uuid::from(self_loop.id);
+    for edge in [joined, self_loop] {
         store.upsert_edge(edge).await.unwrap();
     }
 
-    let sources = [root_c, root_a, root_b];
+    let sources = [root_a, root_b, root_without_edges];
     let outgoing_hits = store
         .batch_neighbors(
             &sources,
             NeighborQuery {
                 direction: Direction::Out,
-                relations: Some(vec![EdgeRelation::Extends]),
+                relations: None,
                 limit: None,
                 min_weight: None,
             },
@@ -1463,29 +1443,8 @@ async fn batch_neighbors_keeps_exact_rows_grouped_by_requested_node() {
         .await
         .unwrap();
     assert_eq!(
-        outgoing_hits
-            .iter()
-            .map(|(origin, _)| *origin)
-            .collect::<Vec<_>>(),
-        vec![root_c, root_a, root_b]
-    );
-    let outgoing = grouped_neighbor_rows(outgoing_hits);
-    assert_eq!(
-        outgoing,
-        HashMap::from([
-            (
-                root_a,
-                HashSet::from([(shared, edge_ids[0], EdgeRelation::Extends)]),
-            ),
-            (
-                root_b,
-                HashSet::from([(shared, edge_ids[2], EdgeRelation::Extends)]),
-            ),
-            (
-                root_c,
-                HashSet::from([(only_c, edge_ids[4], EdgeRelation::Extends)]),
-            ),
-        ])
+        neighbor_edge_multiset(&outgoing_hits),
+        HashMap::from([((root_a, joined_id), 1), ((root_b, self_loop_id), 1),])
     );
 
     let incoming_hits = store
@@ -1493,7 +1452,7 @@ async fn batch_neighbors_keeps_exact_rows_grouped_by_requested_node() {
             &sources,
             NeighborQuery {
                 direction: Direction::In,
-                relations: Some(vec![EdgeRelation::DependsOn]),
+                relations: None,
                 limit: None,
                 min_weight: None,
             },
@@ -1501,29 +1460,8 @@ async fn batch_neighbors_keeps_exact_rows_grouped_by_requested_node() {
         .await
         .unwrap();
     assert_eq!(
-        incoming_hits
-            .iter()
-            .map(|(origin, _)| *origin)
-            .collect::<Vec<_>>(),
-        vec![root_c, root_a, root_b]
-    );
-    let incoming = grouped_neighbor_rows(incoming_hits);
-    assert_eq!(
-        incoming,
-        HashMap::from([
-            (
-                root_a,
-                HashSet::from([(only_a, edge_ids[6], EdgeRelation::DependsOn)]),
-            ),
-            (
-                root_b,
-                HashSet::from([(shared, edge_ids[7], EdgeRelation::DependsOn)]),
-            ),
-            (
-                root_c,
-                HashSet::from([(only_c, edge_ids[10], EdgeRelation::DependsOn)]),
-            ),
-        ])
+        neighbor_edge_multiset(&incoming_hits),
+        HashMap::from([((root_b, joined_id), 1), ((root_b, self_loop_id), 1),])
     );
 
     let both_hits = store
@@ -1531,7 +1469,7 @@ async fn batch_neighbors_keeps_exact_rows_grouped_by_requested_node() {
             &sources,
             NeighborQuery {
                 direction: Direction::Both,
-                relations: Some(vec![EdgeRelation::Extends]),
+                relations: None,
                 limit: None,
                 min_weight: None,
             },
@@ -1539,38 +1477,47 @@ async fn batch_neighbors_keeps_exact_rows_grouped_by_requested_node() {
         .await
         .unwrap();
     assert_eq!(
+        neighbor_edge_multiset(&both_hits),
+        HashMap::from([
+            ((root_a, joined_id), 1),
+            ((root_b, joined_id), 1),
+            ((root_b, self_loop_id), 2),
+        ])
+    );
+    assert!(
         both_hits
             .iter()
-            .map(|(origin, _)| *origin)
-            .collect::<Vec<_>>(),
-        vec![root_c, root_c, root_a, root_a, root_b, root_b]
+            .all(|(origin, _)| *origin != root_without_edges),
+        "the requested zero-edge root must not acquire another root's rows"
     );
-    let both = grouped_neighbor_rows(both_hits);
+}
+
+#[tokio::test]
+async fn batch_neighbors_preserves_duplicate_requested_sources() {
+    let store = setup_memory_store();
+    let root = Uuid::new_v4();
+    let target = Uuid::new_v4();
+    let edge = make_edge(root, target, EdgeRelation::Extends, 1.0);
+    let edge_id = Uuid::from(edge.id);
+    store.upsert_edge(edge).await.unwrap();
+
+    let hits = store
+        .batch_neighbors(
+            &[root, root],
+            NeighborQuery {
+                direction: Direction::Out,
+                relations: None,
+                limit: None,
+                min_weight: None,
+            },
+        )
+        .await
+        .unwrap();
+
     assert_eq!(
-        both,
-        HashMap::from([
-            (
-                root_a,
-                HashSet::from([
-                    (shared, edge_ids[0], EdgeRelation::Extends),
-                    (shared, edge_ids[5], EdgeRelation::Extends),
-                ]),
-            ),
-            (
-                root_b,
-                HashSet::from([
-                    (shared, edge_ids[2], EdgeRelation::Extends),
-                    (only_b, edge_ids[8], EdgeRelation::Extends),
-                ]),
-            ),
-            (
-                root_c,
-                HashSet::from([
-                    (only_c, edge_ids[4], EdgeRelation::Extends),
-                    (shared, edge_ids[9], EdgeRelation::Extends),
-                ]),
-            ),
-        ])
+        neighbor_edge_multiset(&hits),
+        HashMap::from([((root, edge_id), 2)]),
+        "the optimized override must match the trait default's per-occurrence output"
     );
 }
 

--- a/crates/khive-mcp/tests/integration.rs
+++ b/crates/khive-mcp/tests/integration.rs
@@ -215,6 +215,67 @@ async fn parallel_batch_of_independent_creates_all_succeed() -> anyhow::Result<(
 }
 
 #[tokio::test]
+async fn parallel_neighbors_results_echo_their_resolved_origin() -> anyhow::Result<()> {
+    let client = connect().await?;
+    let root_a = ok_one(
+        &client,
+        r#"create(kind="entity", entity_kind="concept", name="neighbors-root-a")"#,
+    )
+    .await?;
+    let root_b = ok_one(
+        &client,
+        r#"create(kind="entity", entity_kind="concept", name="neighbors-root-b")"#,
+    )
+    .await?;
+    let leaf = ok_one(
+        &client,
+        r#"create(kind="entity", entity_kind="concept", name="neighbors-leaf")"#,
+    )
+    .await?;
+    let root_a_id = root_a["id"].as_str().expect("root A id");
+    let root_b_id = root_b["id"].as_str().expect("root B id");
+    let leaf_id = leaf["id"].as_str().expect("leaf id");
+
+    ok_one(
+        &client,
+        &format!(r#"link(source_id="{root_a_id}", target_id="{root_b_id}", relation="extends")"#),
+    )
+    .await?;
+    ok_one(
+        &client,
+        &format!(r#"link(source_id="{root_b_id}", target_id="{leaf_id}", relation="extends")"#),
+    )
+    .await?;
+
+    let response = call(
+        &client,
+        "request",
+        json!({
+            "ops": format!(
+                r#"[neighbors(node_id="{root_a_id}", direction="out"), neighbors(node_id="{root_b_id}", direction="out")]"#
+            ),
+            "presentation": "verbose"
+        }),
+    )
+    .await?;
+    let body: Value = serde_json::from_str(&first_text(&response))?;
+    let results = body["results"].as_array().expect("results array");
+    assert_eq!(results.len(), 2);
+
+    for (result, (expected_origin, expected_neighbor)) in results
+        .iter()
+        .zip([(root_a_id, root_b_id), (root_b_id, leaf_id)])
+    {
+        assert_eq!(result["ok"], json!(true), "neighbors op failed: {result}");
+        let hits = result["result"].as_array().expect("neighbors result array");
+        assert_eq!(hits.len(), 1, "unexpected neighbors result: {result}");
+        assert_eq!(hits[0]["origin_id"], expected_origin);
+        assert_eq!(hits[0]["id"], expected_neighbor);
+    }
+    Ok(())
+}
+
+#[tokio::test]
 async fn create_then_list_across_separate_request_calls() -> anyhow::Result<()> {
     // Create-then-read requires two `request` calls because operations inside
     // a single batch run in parallel and have no ordering guarantee

--- a/crates/khive-pack-kg/src/handler_defs.rs
+++ b/crates/khive-pack-kg/src/handler_defs.rs
@@ -532,7 +532,7 @@ pub(crate) static KG_HANDLERS: [HandlerDef; 18] = [
     // Assertive: retrieves immediate graph neighbors
     HandlerDef {
         name: "neighbors",
-        description: "Immediate graph neighbors",
+        description: "Immediate graph neighbors; each hit includes origin_id for the queried node",
         visibility: Visibility::Verb,
         category: VerbCategory::Assertive,
         params: &[

--- a/crates/khive-pack-kg/src/handlers/graph.rs
+++ b/crates/khive-pack-kg/src/handlers/graph.rs
@@ -1,15 +1,24 @@
 //! `neighbors`, `traverse`, and `query` verb handlers.
 
+use serde::Serialize;
 use serde_json::Value;
+use uuid::Uuid;
 
 use khive_runtime::{NamespaceToken, RuntimeError};
-use khive_storage::types::{NeighborQuery, TraversalOptions, TraversalRequest};
+use khive_storage::types::{NeighborHit, NeighborQuery, TraversalOptions, TraversalRequest};
 
 use super::common::{
     deser, parse_direction, parse_relation, render_query_result, resolve_uuid_async, to_json,
     NeighborsParams, QueryParams, TraverseParams, HARD_CAP,
 };
 use crate::KgPack;
+
+#[derive(Serialize)]
+struct NeighborHitResponse {
+    origin_id: Uuid,
+    #[serde(flatten)]
+    hit: NeighborHit,
+}
 
 impl KgPack {
     pub(crate) async fn handle_neighbors(
@@ -49,7 +58,15 @@ impl KgPack {
                 hit.entity_type = None;
             }
         }
-        to_json(&hits)
+        to_json(
+            &hits
+                .into_iter()
+                .map(|hit| NeighborHitResponse {
+                    origin_id: node_id,
+                    hit,
+                })
+                .collect::<Vec<_>>(),
+        )
     }
 
     pub(crate) async fn handle_traverse(

--- a/docs/guide/api-reference.md
+++ b/docs/guide/api-reference.md
@@ -315,6 +315,9 @@ request(ops="link(source_id=\"<uuid-a>\", target_id=\"<uuid-b>\", relation=\"ext
 
 Immediate graph neighbors.
 
+Each returned hit includes `origin_id`, the resolved queried node. This lets
+batch callers verify that every result is associated with the submitted root.
+
 | Param        | Type            | Required | Notes                                            |
 | ------------ | --------------- | -------- | ------------------------------------------------ |
 | `node_id`    | uuid            | yes      | Node whose neighbors to return.                  |


### PR DESCRIPTION
Closes #869.

The batched neighbors query grouped rows incorrectly when multiple roots were requested, attributing edges to the wrong node. This keys the result map by the requested node id and adds a 3-node regression covering mixed in/out edges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)