### PR TITLE
feat(query): GQL WHERE operators CONTAINS, STARTS WITH, IN, IS NOT NULL

### DIFF
--- a/crates/khive-query/docs/design.md
+++ b/crates/khive-query/docs/design.md
@@ -65,6 +65,10 @@ ADR-008. It is intentionally split into three stages:
   preserving SQL OR/AND connectives rather than flattening to AND-only.
 - GQL WHERE grammar: `where_expr = and_expr ('OR' and_expr)*` where
   `and_expr = condition ('AND' condition)*`. AND binds tighter than OR.
+- GQL WHERE conditions support `=`, `!=`, `>`, `<`, `>=`, `<=`, `LIKE`,
+  `CONTAINS`, `STARTS WITH`, `IN` with a list literal, and `IS NOT NULL`.
+  `CONTAINS` and `STARTS WITH` treat `%`, `_`, and `\` as literal characters.
+  All condition values are emitted as bound SQL parameters.
 - Node kind strings are pack-agnostic and pass through the query layer unchanged.
   Kind validation is a pack-handler concern, not a query-layer concern.
 - `namespace` is always injected via `CompileOptions.scopes`, never from query

--- a/crates/khive-query/src/ast.rs
+++ b/crates/khive-query/src/ast.rs
@@ -153,7 +153,7 @@ pub enum EdgeDirection {
     Both,
 }
 
-/// A scalar comparison in the WHERE clause: `variable.property op value`.
+/// A predicate in the WHERE clause: `variable.property op value`.
 #[derive(Debug, Clone)]
 pub struct Condition {
     pub variable: String,
@@ -172,6 +172,10 @@ pub enum CompareOp {
     Gte,
     Lte,
     Like,
+    Contains,
+    StartsWith,
+    In,
+    IsNotNull,
 }
 
 /// Right-hand side value in a WHERE condition.
@@ -187,4 +191,8 @@ pub enum ConditionValue {
     /// A float literal (decimal point present in the source lexeme).
     Number(f64),
     Bool(bool),
+    /// A list literal used by the `IN` operator.
+    List(Vec<ConditionValue>),
+    /// The operand marker for the operand-free `IS NOT NULL` operator.
+    Null,
 }

--- a/crates/khive-query/src/compilers/sql.rs
+++ b/crates/khive-query/src/compilers/sql.rs
@@ -297,6 +297,11 @@ fn compile_property_equality(
             params.push(QueryValue::Float(*n));
         }
         ConditionValue::Bool(b) => params.push(QueryValue::Integer(if *b { 1 } else { 0 })),
+        ConditionValue::List(_) | ConditionValue::Null => {
+            return Err(QueryError::Validation(
+                "list and null operands are not valid in inline property maps".into(),
+            ));
+        }
     }
     let collate = if is_string { " COLLATE NOCASE" } else { "" };
     Ok(match text_column {
@@ -818,30 +823,16 @@ fn compile_single_condition(
         },
     };
 
-    let op_str = match cond.op {
-        CompareOp::Eq => "=",
-        CompareOp::Neq => "!=",
-        CompareOp::Gt => ">",
-        CompareOp::Lt => "<",
-        CompareOp::Gte => ">=",
-        CompareOp::Lte => "<=",
-        CompareOp::Like => "LIKE",
-    };
+    compile_condition_predicate(&col_expr, cond, params)
+}
 
-    let sql = match &cond.value {
-        ConditionValue::String(s) => {
-            params.push(QueryValue::Text(s.clone()));
-            let collate = if matches!(cond.op, CompareOp::Eq | CompareOp::Like) {
-                " COLLATE NOCASE"
-            } else {
-                ""
-            };
-            format!("{col_expr} {op_str} ?{}{}", params.len(), collate)
-        }
-        ConditionValue::Integer(n) => {
-            params.push(QueryValue::Integer(*n));
-            format!("{col_expr} {op_str} ?{}", params.len())
-        }
+fn bind_condition_value(
+    value: &ConditionValue,
+    params: &mut Vec<QueryValue>,
+) -> Result<usize, QueryError> {
+    match value {
+        ConditionValue::String(s) => params.push(QueryValue::Text(s.clone())),
+        ConditionValue::Integer(n) => params.push(QueryValue::Integer(*n)),
         ConditionValue::Number(n) => {
             if !n.is_finite() {
                 return Err(QueryError::InvalidInput(
@@ -849,14 +840,106 @@ fn compile_single_condition(
                 ));
             }
             params.push(QueryValue::Float(*n));
-            format!("{col_expr} {op_str} ?{}", params.len())
         }
         ConditionValue::Bool(b) => {
             params.push(QueryValue::Integer(if *b { 1 } else { 0 }));
-            format!("{col_expr} {op_str} ?{}", params.len())
         }
-    };
-    Ok(sql)
+        ConditionValue::List(_) | ConditionValue::Null => {
+            return Err(QueryError::Validation(
+                "operator requires a scalar value".into(),
+            ));
+        }
+    }
+    Ok(params.len())
+}
+
+fn escape_like_literal(value: &str) -> String {
+    let mut escaped = String::with_capacity(value.len());
+    for ch in value.chars() {
+        if matches!(ch, '\\' | '%' | '_') {
+            escaped.push('\\');
+        }
+        escaped.push(ch);
+    }
+    escaped
+}
+
+fn compile_condition_predicate(
+    col_expr: &str,
+    cond: &Condition,
+    params: &mut Vec<QueryValue>,
+) -> Result<String, QueryError> {
+    match cond.op {
+        CompareOp::Contains | CompareOp::StartsWith => {
+            let ConditionValue::String(value) = &cond.value else {
+                return Err(QueryError::Validation(
+                    "CONTAINS and STARTS WITH require a string literal".into(),
+                ));
+            };
+            let escaped = escape_like_literal(value);
+            let pattern = if cond.op == CompareOp::Contains {
+                format!("%{escaped}%")
+            } else {
+                format!("{escaped}%")
+            };
+            params.push(QueryValue::Text(pattern));
+            Ok(format!(
+                "{col_expr} LIKE ?{} COLLATE NOCASE ESCAPE '\\'",
+                params.len()
+            ))
+        }
+        CompareOp::In => {
+            let ConditionValue::List(values) = &cond.value else {
+                return Err(QueryError::Validation("IN requires a list literal".into()));
+            };
+            if values.is_empty() {
+                return Ok("0".into());
+            }
+            let all_strings = values
+                .iter()
+                .all(|value| matches!(value, ConditionValue::String(_)));
+            let placeholders = values
+                .iter()
+                .map(|value| bind_condition_value(value, params).map(|index| format!("?{index}")))
+                .collect::<Result<Vec<_>, _>>()?;
+            let collate = if all_strings { " COLLATE NOCASE" } else { "" };
+            Ok(format!(
+                "{col_expr}{collate} IN ({})",
+                placeholders.join(", ")
+            ))
+        }
+        CompareOp::IsNotNull => {
+            if !matches!(cond.value, ConditionValue::Null) {
+                return Err(QueryError::Validation(
+                    "IS NOT NULL does not accept a value".into(),
+                ));
+            }
+            Ok(format!("{col_expr} IS NOT NULL"))
+        }
+        op => {
+            let op_str = match op {
+                CompareOp::Eq => "=",
+                CompareOp::Neq => "!=",
+                CompareOp::Gt => ">",
+                CompareOp::Lt => "<",
+                CompareOp::Gte => ">=",
+                CompareOp::Lte => "<=",
+                CompareOp::Like => "LIKE",
+                CompareOp::Contains
+                | CompareOp::StartsWith
+                | CompareOp::In
+                | CompareOp::IsNotNull => unreachable!(),
+            };
+            let is_string = matches!(cond.value, ConditionValue::String(_));
+            let param_index = bind_condition_value(&cond.value, params)?;
+            let collate = if is_string && matches!(op, CompareOp::Eq | CompareOp::Like) {
+                " COLLATE NOCASE"
+            } else {
+                ""
+            };
+            Ok(format!("{col_expr} {op_str} ?{param_index}{collate}"))
+        }
+    }
 }
 
 fn expr_endpoint_set(
@@ -949,44 +1032,7 @@ fn compile_var_len_condition(
             )
         };
 
-    let op_str = match cond.op {
-        CompareOp::Eq => "=",
-        CompareOp::Neq => "!=",
-        CompareOp::Gt => ">",
-        CompareOp::Lt => "<",
-        CompareOp::Gte => ">=",
-        CompareOp::Lte => "<=",
-        CompareOp::Like => "LIKE",
-    };
-
-    let sql = match &cond.value {
-        ConditionValue::String(s) => {
-            params.push(QueryValue::Text(s.clone()));
-            let collate = if matches!(cond.op, CompareOp::Eq | CompareOp::Like) {
-                " COLLATE NOCASE"
-            } else {
-                ""
-            };
-            format!("{col_expr} {op_str} ?{}{collate}", params.len())
-        }
-        ConditionValue::Integer(n) => {
-            params.push(QueryValue::Integer(*n));
-            format!("{col_expr} {op_str} ?{}", params.len())
-        }
-        ConditionValue::Number(n) => {
-            if !n.is_finite() {
-                return Err(QueryError::InvalidInput(
-                    "non-finite float (NaN or Infinity) is not a valid query parameter".into(),
-                ));
-            }
-            params.push(QueryValue::Float(*n));
-            format!("{col_expr} {op_str} ?{}", params.len())
-        }
-        ConditionValue::Bool(b) => {
-            params.push(QueryValue::Integer(if *b { 1 } else { 0 }));
-            format!("{col_expr} {op_str} ?{}", params.len())
-        }
-    };
+    let sql = compile_condition_predicate(&col_expr, cond, params)?;
     Ok((sql, col_alias))
 }
 

--- a/crates/khive-query/src/compilers/sql.rs
+++ b/crates/khive-query/src/compilers/sql.rs
@@ -895,14 +895,14 @@ fn compile_condition_predicate(
             if values.is_empty() {
                 return Ok("0".into());
             }
-            let all_strings = values
+            let has_string = values
                 .iter()
-                .all(|value| matches!(value, ConditionValue::String(_)));
+                .any(|value| matches!(value, ConditionValue::String(_)));
             let placeholders = values
                 .iter()
                 .map(|value| bind_condition_value(value, params).map(|index| format!("?{index}")))
                 .collect::<Result<Vec<_>, _>>()?;
-            let collate = if all_strings { " COLLATE NOCASE" } else { "" };
+            let collate = if has_string { " COLLATE NOCASE" } else { "" };
             Ok(format!(
                 "{col_expr}{collate} IN ({})",
                 placeholders.join(", ")

--- a/crates/khive-query/src/parsers/gql.rs
+++ b/crates/khive-query/src/parsers/gql.rs
@@ -225,6 +225,22 @@ impl Parser {
         Ok(props)
     }
 
+    fn parse_list_literal(&mut self) -> Result<Vec<ConditionValue>, QueryError> {
+        self.expect_char('[')?;
+        let mut values = Vec::new();
+        loop {
+            self.skip_whitespace();
+            if self.peek() == Some(']') {
+                self.advance();
+                return Ok(values);
+            }
+            if !values.is_empty() {
+                self.expect_char(',')?;
+            }
+            values.push(self.parse_value()?);
+        }
+    }
+
     fn parse_node_pattern(&mut self) -> Result<NodePattern, QueryError> {
         self.expect_char('(')?;
         self.skip_whitespace();
@@ -429,6 +445,17 @@ impl Parser {
             _ => {
                 if self.try_keyword("LIKE") {
                     Ok(CompareOp::Like)
+                } else if self.try_keyword("CONTAINS") {
+                    Ok(CompareOp::Contains)
+                } else if self.try_keyword("STARTS") {
+                    self.expect_keyword("WITH")?;
+                    Ok(CompareOp::StartsWith)
+                } else if self.try_keyword("IN") {
+                    Ok(CompareOp::In)
+                } else if self.try_keyword("IS") {
+                    self.expect_keyword("NOT")?;
+                    self.expect_keyword("NULL")?;
+                    Ok(CompareOp::IsNotNull)
                 } else {
                     Err(self.err("expected comparison operator"))
                 }
@@ -442,7 +469,18 @@ impl Parser {
         self.expect_char('.')?;
         let property = self.parse_ident()?;
         let op = self.parse_compare_op()?;
-        let value = self.parse_value()?;
+        let value = match op {
+            CompareOp::In => ConditionValue::List(self.parse_list_literal()?),
+            CompareOp::IsNotNull => ConditionValue::Null,
+            CompareOp::Contains | CompareOp::StartsWith => {
+                let value = self.parse_value()?;
+                if !matches!(value, ConditionValue::String(_)) {
+                    return Err(self.err("CONTAINS and STARTS WITH require a string literal"));
+                }
+                value
+            }
+            _ => self.parse_value()?,
+        };
         Ok(Condition {
             variable,
             property,
@@ -663,6 +701,56 @@ mod tests {
             matches!(&q.where_clause, WhereExpr::Or(_, _)),
             "top-level should be Or"
         );
+    }
+
+    #[test]
+    fn where_clause_extended_operators() {
+        let q = parse(
+            "MATCH (n:entity) WHERE n.name CONTAINS '%_' AND n.name STARTS WITH 'pre' \
+             AND n.kind IN ['concept', 'document'] AND n.domain IS NOT NULL RETURN n",
+        )
+        .unwrap();
+        let conds: Vec<_> = q.where_clause.conditions().collect();
+        assert_eq!(conds.len(), 4);
+        assert_eq!(conds[0].op, CompareOp::Contains);
+        assert_eq!(conds[0].value, ConditionValue::String("%_".into()));
+        assert_eq!(conds[1].op, CompareOp::StartsWith);
+        assert_eq!(conds[2].op, CompareOp::In);
+        assert_eq!(
+            conds[2].value,
+            ConditionValue::List(vec![
+                ConditionValue::String("concept".into()),
+                ConditionValue::String("document".into()),
+            ])
+        );
+        assert_eq!(conds[3].op, CompareOp::IsNotNull);
+        assert_eq!(conds[3].value, ConditionValue::Null);
+    }
+
+    #[test]
+    fn where_in_accepts_scalar_list_and_empty_list() {
+        let q = parse("MATCH (n) WHERE n.value IN ['x', 1, 2.5, true] OR n.value IN [] RETURN n")
+            .unwrap();
+        let conds: Vec<_> = q.where_clause.conditions().collect();
+        assert_eq!(
+            conds[0].value,
+            ConditionValue::List(vec![
+                ConditionValue::String("x".into()),
+                ConditionValue::Integer(1),
+                ConditionValue::Number(2.5),
+                ConditionValue::Bool(true),
+            ])
+        );
+        assert_eq!(conds[1].value, ConditionValue::List(vec![]));
+    }
+
+    #[test]
+    fn contains_and_starts_with_require_strings() {
+        let contains = parse("MATCH (n) WHERE n.name CONTAINS 1 RETURN n").unwrap_err();
+        assert!(contains.to_string().contains("require a string literal"));
+
+        let starts = parse("MATCH (n) WHERE n.name STARTS WITH true RETURN n").unwrap_err();
+        assert!(starts.to_string().contains("require a string literal"));
     }
 
     #[test]

--- a/crates/khive-query/src/validate.rs
+++ b/crates/khive-query/src/validate.rs
@@ -5,7 +5,7 @@ use std::str::FromStr;
 
 use khive_types::EdgeRelation;
 
-use crate::ast::{Condition, ConditionValue, GqlQuery, PatternElement};
+use crate::ast::{CompareOp, Condition, ConditionValue, GqlQuery, PatternElement};
 use crate::error::QueryError;
 
 /// Valid synthetic relations; unknown `observed_as_*` strings are rejected.
@@ -209,10 +209,33 @@ fn validate_condition(cond: &mut Condition, is_edge: bool) -> Result<(), QueryEr
         )),
         "kind" if !is_edge => Ok(()),
         "relation" if is_edge => {
-            if let ConditionValue::String(ref mut s) = cond.value {
+            let normalize = |s: &mut String| -> Result<(), QueryError> {
                 let parsed = EdgeRelation::from_str(s)
                     .map_err(|err| QueryError::Validation(err.to_string()))?;
                 *s = parsed.as_str().to_string();
+                Ok(())
+            };
+            if matches!(
+                cond.op,
+                CompareOp::Contains | CompareOp::StartsWith | CompareOp::IsNotNull
+            ) {
+                return Ok(());
+            }
+            match &mut cond.value {
+                ConditionValue::String(s) => normalize(s)?,
+                ConditionValue::List(values) => {
+                    for value in values {
+                        match value {
+                            ConditionValue::String(s) => normalize(s)?,
+                            _ => {
+                                return Err(QueryError::Validation(
+                                    "relation IN list values must be strings".into(),
+                                ));
+                            }
+                        }
+                    }
+                }
+                _ => {}
             }
             Ok(())
         }

--- a/crates/khive-query/src/validate_tests.rs
+++ b/crates/khive-query/src/validate_tests.rs
@@ -104,6 +104,32 @@ fn rejects_unknown_relation_in_where() {
 }
 
 #[test]
+fn where_relation_in_validates_every_list_member() {
+    let mut valid =
+        gql::parse("MATCH (a)-[e]->(b) WHERE e.relation IN ['extends', 'variant_of'] RETURN a")
+            .unwrap();
+    assert!(validate(&mut valid).is_ok());
+
+    let mut invalid =
+        gql::parse("MATCH (a)-[e]->(b) WHERE e.relation IN ['extends', 'not_real'] RETURN a")
+            .unwrap();
+    let err = validate(&mut invalid).unwrap_err();
+    assert!(err.to_string().contains("not_real"), "msg: {err}");
+
+    let mut non_string =
+        gql::parse("MATCH (a)-[e]->(b) WHERE e.relation IN ['extends', 1] RETURN a").unwrap();
+    let err = validate(&mut non_string).unwrap_err();
+    assert!(err.to_string().contains("must be strings"), "msg: {err}");
+}
+
+#[test]
+fn where_relation_contains_is_not_exact_relation_validation() {
+    let mut q =
+        gql::parse("MATCH (a)-[e]->(b) WHERE e.relation CONTAINS 'extend' RETURN a").unwrap();
+    assert!(validate(&mut q).is_ok());
+}
+
+#[test]
 fn query_edge_relation_bang_rejected() {
     // Regression for #471: relation filters with punctuation must be
     // rejected as Validation errors, not silently normalised into a

--- a/crates/khive-query/tests/compile_integration.rs
+++ b/crates/khive-query/tests/compile_integration.rs
@@ -1114,6 +1114,30 @@ fn extended_where_operators_compile_for_variable_length_patterns() {
 }
 
 #[test]
+fn mixed_type_in_with_string_compiles_case_insensitive() {
+    let q = parse(
+        QueryLanguage::Gql,
+        "MATCH (n) WHERE n.kind IN ['CONCEPT', 1] RETURN n",
+    )
+    .unwrap();
+    let compiled = compile(&q, &opts()).unwrap();
+
+    assert!(
+        compiled.sql.contains("n0.kind COLLATE NOCASE IN (?1, ?2)"),
+        "sql: {}",
+        compiled.sql
+    );
+    assert!(matches!(
+        compiled.params.as_slice(),
+        [
+            QueryValue::Text(kind),
+            QueryValue::Integer(1),
+            QueryValue::Integer(_),
+        ] if kind == "CONCEPT"
+    ));
+}
+
+#[test]
 fn empty_in_list_compiles_to_false_without_value_parameters() {
     let q = parse(QueryLanguage::Gql, "MATCH (n) WHERE n.name IN [] RETURN n").unwrap();
     let compiled = compile(&q, &opts()).unwrap();
@@ -1284,6 +1308,19 @@ mod substrate_labels {
         let mut rows = run(&conn, &compiled);
         rows.sort();
         assert_eq!(rows, vec!["e-percent", "e-quote", "e-underscore"]);
+    }
+
+    #[test]
+    fn mixed_type_in_preserves_case_insensitive_string_matching_end_to_end() {
+        let conn = fixture_db();
+        let q = parse(
+            QueryLanguage::Gql,
+            "MATCH (e:entity) WHERE e.kind IN ['CONCEPT', 1] RETURN e.id",
+        )
+        .unwrap();
+        let compiled = compile(&q, &opts()).unwrap();
+
+        assert_eq!(run(&conn, &compiled), vec!["e-fixture-1"]);
     }
 
     #[test]

--- a/crates/khive-query/tests/compile_integration.rs
+++ b/crates/khive-query/tests/compile_integration.rs
@@ -1025,6 +1025,106 @@ fn gql_inline_property_map_well_formed_float_still_parses() {
         .any(|p| matches!(p, QueryValue::Float(n) if *n == 1.5)));
 }
 
+// --- GQL extended WHERE operators (#804, #864) ---
+
+#[test]
+fn extended_where_operators_compile_with_bound_parameters() {
+    let q = parse(
+        QueryLanguage::Gql,
+        r#"MATCH (n) WHERE n.name CONTAINS "%_\' OR 1=1 --" AND n.name STARTS WITH "pre%_\" AND n.kind IN ["concept", "' OR 1=1 --"] AND n.domain IS NOT NULL RETURN n"#,
+    )
+    .unwrap();
+    let compiled = compile(&q, &opts()).unwrap();
+
+    assert!(
+        compiled.sql.contains("LIKE ?1 COLLATE NOCASE ESCAPE '\\'"),
+        "sql: {}",
+        compiled.sql
+    );
+    assert!(
+        compiled.sql.contains("LIKE ?2 COLLATE NOCASE ESCAPE '\\'"),
+        "sql: {}",
+        compiled.sql
+    );
+    assert!(
+        compiled.sql.contains("n0.kind COLLATE NOCASE IN (?3, ?4)"),
+        "sql: {}",
+        compiled.sql
+    );
+    assert!(
+        compiled
+            .sql
+            .contains("json_extract(n0.properties, '$.domain') IS NOT NULL"),
+        "sql: {}",
+        compiled.sql
+    );
+    assert!(
+        !compiled.sql.contains("OR 1=1"),
+        "injection-shaped data must not appear in SQL: {}",
+        compiled.sql
+    );
+    assert!(matches!(
+        compiled.params.as_slice(),
+        [
+            QueryValue::Text(contains),
+            QueryValue::Text(starts),
+            QueryValue::Text(first),
+            QueryValue::Text(second),
+            QueryValue::Integer(_),
+        ] if contains == r#"%\%\_\\' OR 1=1 --%"#
+            && starts == r#"pre\%\_\\%"#
+            && first == "concept"
+            && second == "' OR 1=1 --"
+    ));
+}
+
+#[test]
+fn extended_where_operators_compile_for_variable_length_patterns() {
+    let q = parse(
+        QueryLanguage::Gql,
+        "MATCH (a)-[:extends*1..2]->(b) WHERE a.name CONTAINS 'Lo' \
+         AND a.name STARTS WITH 'L' AND b.kind IN ['concept', 'document'] \
+         AND b.domain IS NOT NULL RETURN b",
+    )
+    .unwrap();
+    let compiled = compile(&q, &opts()).unwrap();
+
+    assert!(
+        compiled.sql.contains("s.name LIKE ?"),
+        "sql: {}",
+        compiled.sql
+    );
+    assert!(
+        compiled.sql.contains("s.name LIKE ?") && compiled.sql.contains("ESCAPE '\\'"),
+        "sql: {}",
+        compiled.sql
+    );
+    assert!(
+        compiled.sql.contains("r.kind COLLATE NOCASE IN ("),
+        "sql: {}",
+        compiled.sql
+    );
+    assert!(
+        compiled
+            .sql
+            .contains("json_extract(r.properties, '$.domain') IS NOT NULL"),
+        "sql: {}",
+        compiled.sql
+    );
+}
+
+#[test]
+fn empty_in_list_compiles_to_false_without_value_parameters() {
+    let q = parse(QueryLanguage::Gql, "MATCH (n) WHERE n.name IN [] RETURN n").unwrap();
+    let compiled = compile(&q, &opts()).unwrap();
+    assert!(compiled.sql.contains("WHERE") && compiled.sql.contains(" AND 0 LIMIT"));
+    assert_eq!(
+        compiled.params.len(),
+        1,
+        "only the LIMIT parameter is expected"
+    );
+}
+
 // --- Issue #849: substrate node labels (entity/note) must be satisfiable ---
 //
 // Stored `kind` values are always granular (concept/document/task/...); the
@@ -1117,6 +1217,93 @@ mod substrate_labels {
             .unwrap()
             .collect::<Result<_, _>>()
             .unwrap()
+    }
+
+    fn insert_entity(conn: &Connection, id: &str, name: &str, properties: &str) {
+        conn.execute(
+            "INSERT INTO entities
+                (id, namespace, kind, name, description, properties, tags,
+                 created_at, updated_at, deleted_at, entity_type)
+             VALUES (?1, 'local', 'concept', ?2, NULL, ?3, '[]', 0, 0, NULL, NULL)",
+            rusqlite::params![id, name, properties],
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn contains_escapes_wildcards_backslash_and_quote_end_to_end() {
+        let conn = fixture_db();
+        insert_entity(&conn, "e-literal", r#"prefix%_\' OR 1=1 --suffix"#, "{}");
+        insert_entity(
+            &conn,
+            "e-wildcard-distractor",
+            r#"prefixAB\' OR 1=1 --suffix"#,
+            "{}",
+        );
+        let q = parse(
+            QueryLanguage::Gql,
+            r#"MATCH (e:entity) WHERE e.name CONTAINS "%_\' OR 1=1 --" RETURN e.id"#,
+        )
+        .unwrap();
+        let compiled = compile(&q, &opts()).unwrap();
+
+        assert!(!compiled.sql.contains("OR 1=1"), "sql: {}", compiled.sql);
+        assert_eq!(run(&conn, &compiled), vec!["e-literal"]);
+    }
+
+    #[test]
+    fn starts_with_escapes_wildcards_and_backslash_end_to_end() {
+        let conn = fixture_db();
+        insert_entity(&conn, "e-prefix", r#"pre%_\suffix"#, "{}");
+        insert_entity(&conn, "e-prefix-distractor", r#"preAB\suffix"#, "{}");
+        let q = parse(
+            QueryLanguage::Gql,
+            r#"MATCH (e:entity) WHERE e.name STARTS WITH "pre%_\" RETURN e.id"#,
+        )
+        .unwrap();
+        let compiled = compile(&q, &opts()).unwrap();
+
+        assert_eq!(run(&conn, &compiled), vec!["e-prefix"]);
+    }
+
+    #[test]
+    fn in_list_binds_injection_shaped_strings_end_to_end() {
+        let conn = fixture_db();
+        insert_entity(&conn, "e-percent", "%", "{}");
+        insert_entity(&conn, "e-underscore", "_", "{}");
+        insert_entity(&conn, "e-quote", "' OR 1=1 --", "{}");
+        insert_entity(&conn, "e-other", "not a match", "{}");
+        let q = parse(
+            QueryLanguage::Gql,
+            r#"MATCH (e:entity) WHERE e.name IN ["%", "_", "' OR 1=1 --"] RETURN e.id"#,
+        )
+        .unwrap();
+        let compiled = compile(&q, &opts()).unwrap();
+        assert!(!compiled.sql.contains("OR 1=1"), "sql: {}", compiled.sql);
+
+        let mut rows = run(&conn, &compiled);
+        rows.sort();
+        assert_eq!(rows, vec!["e-percent", "e-quote", "e-underscore"]);
+    }
+
+    #[test]
+    fn is_not_null_filters_json_property_presence_end_to_end() {
+        let conn = fixture_db();
+        insert_entity(
+            &conn,
+            "e-with-domain",
+            "with domain",
+            r#"{"domain":"attention"}"#,
+        );
+        insert_entity(&conn, "e-without-domain", "without domain", "{}");
+        let q = parse(
+            QueryLanguage::Gql,
+            "MATCH (e:entity) WHERE e.domain IS NOT NULL RETURN e.id",
+        )
+        .unwrap();
+        let compiled = compile(&q, &opts()).unwrap();
+
+        assert_eq!(run(&conn, &compiled), vec!["e-with-domain"]);
     }
 
     /// `fixture_db()` plus a second entity and a `graph_edges` row connecting

--- a/docs/adr/ADR-008-query-layer-separation.md
+++ b/docs/adr/ADR-008-query-layer-separation.md
@@ -137,9 +137,11 @@ The compiler rejects queries exceeding this depth at AST validation time.
 
 ### GQL WHERE expression
 
-GQL `WHERE` clauses require `OR` and `IN` AST nodes for non-trivial filtering. The
-query parser must support these in addition to `AND`, equality, and comparison predicates.
-Without `OR`/`IN`, multi-value filters require N separate queries or caller-side UNION.
+GQL `WHERE` clauses support `AND` and `OR` expression nodes plus `=`, `!=`, `>`, `<`,
+`>=`, `<=`, `LIKE`, `CONTAINS`, `STARTS WITH`, `IN` list literals, and `IS NOT NULL`
+predicates. `CONTAINS` and `STARTS WITH` compile to escaped, parameterized `LIKE`
+predicates. `IN` values are individually bound. Without `OR`/`IN`, multi-value filters
+require N separate queries or caller-side UNION.
 
 ### Read-only constraint
 

--- a/docs/adr/ADR-008-query-layer-separation.md
+++ b/docs/adr/ADR-008-query-layer-separation.md
@@ -140,8 +140,11 @@ The compiler rejects queries exceeding this depth at AST validation time.
 GQL `WHERE` clauses support `AND` and `OR` expression nodes plus `=`, `!=`, `>`, `<`,
 `>=`, `<=`, `LIKE`, `CONTAINS`, `STARTS WITH`, `IN` list literals, and `IS NOT NULL`
 predicates. `CONTAINS` and `STARTS WITH` compile to escaped, parameterized `LIKE`
-predicates. `IN` values are individually bound. Without `OR`/`IN`, multi-value filters
-require N separate queries or caller-side UNION.
+predicates. `IN` list items may be string, integer, finite float, or boolean scalars, and
+lists may mix those types. Values are individually bound, and a list containing any string
+uses case-insensitive string collation. An empty list compiles to match nothing without
+binding value parameters. `NULL` is not a valid list item and is rejected during parsing.
+Without `OR`/`IN`, multi-value filters require N separate queries or caller-side UNION.
 
 ### Read-only constraint
 


### PR DESCRIPTION
Closes #864. Closes #804.

Full vertical for four GQL WHERE operators: lexer tokens, AST nodes, validation, and SQL compilation with parameterized values and %/_ escaping for the LIKE-backed forms. Includes the small ADR-008 operator-table update that documents the contract (kept in this PR because the table is the normative surface for the same change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)