### PR TITLE
test(kg): exact-name lookup regressions for CJK and spaced names (#849)

### DIFF
--- a/crates/khive-pack-kg/src/dispatch.rs
+++ b/crates/khive-pack-kg/src/dispatch.rs
@@ -1532,6 +1532,25 @@ mod tests {
                 Some(0.98)
             );
         }
+
+        let whitespace_variant = registry
+            .dispatch(
+                "resolve",
+                json!({"refs": ["Entity  Name With Spaces"], "kind": "entity"}),
+            )
+            .await
+            .expect("whitespace-variant resolve must succeed");
+        let whitespace_results = whitespace_variant
+            .get("results")
+            .and_then(|v| v.as_array())
+            .unwrap();
+        assert_ne!(
+            whitespace_results[0]
+                .get("confidence")
+                .and_then(|v| v.as_f64()),
+            Some(0.98),
+            "interior whitespace must be preserved by exact-name lookup: {whitespace_results:?}"
+        );
     }
 
     /// The storage exact-name tier is case-sensitive. A case-only variant

--- a/crates/khive-pack-kg/src/dispatch.rs
+++ b/crates/khive-pack-kg/src/dispatch.rs
@@ -1472,6 +1472,116 @@ mod tests {
         );
     }
 
+    /// Exact-name storage lookup is Unicode-safe and does not tokenize names.
+    /// CJK and embedded spaces therefore resolve with the same confidence as
+    /// an ASCII single-token name.
+    #[tokio::test]
+    async fn resolve_exact_name_handles_cjk_and_spaces() {
+        let rt = KhiveRuntime::memory().expect("in-memory runtime");
+        let direct_tok = rt.authorize(Namespace::local()).unwrap();
+        let cjk = rt
+            .create_entity(
+                &direct_tok,
+                "concept",
+                None,
+                "知识 图谱",
+                None,
+                None,
+                vec![],
+            )
+            .await
+            .expect("direct CJK entity create must succeed");
+        let spaced = rt
+            .create_entity(
+                &direct_tok,
+                "concept",
+                None,
+                "Entity Name With Spaces",
+                None,
+                None,
+                vec![],
+            )
+            .await
+            .expect("direct spaced-name entity create must succeed");
+
+        let mut builder = VerbRegistryBuilder::new();
+        builder.with_default_namespace("local");
+        builder.register(KgPack::new(rt.clone()));
+        let registry = builder.build().expect("registry build");
+
+        let result = registry
+            .dispatch(
+                "resolve",
+                json!({"refs": ["知识 图谱", "Entity Name With Spaces"], "kind": "entity"}),
+            )
+            .await
+            .expect("resolve must succeed");
+        let results = result.get("results").and_then(|v| v.as_array()).unwrap();
+        assert_eq!(results.len(), 2);
+        for (result, expected_id) in results.iter().zip([cjk.id, spaced.id]) {
+            assert_eq!(
+                result.get("status").and_then(|v| v.as_str()),
+                Some("resolved")
+            );
+            assert_eq!(
+                result.get("id").and_then(|v| v.as_str()),
+                Some(expected_id.to_string().as_str())
+            );
+            assert_eq!(
+                result.get("confidence").and_then(|v| v.as_f64()),
+                Some(0.98)
+            );
+        }
+    }
+
+    /// The storage exact-name tier is case-sensitive. A case-only variant
+    /// can still resolve through case-insensitive hybrid search, but it must
+    /// not receive the exact tier's 0.98 confidence.
+    #[tokio::test]
+    async fn resolve_case_variant_uses_hybrid_fallback() {
+        let rt = KhiveRuntime::memory().expect("in-memory runtime");
+        let direct_tok = rt.authorize(Namespace::local()).unwrap();
+        let entity = rt
+            .create_entity(
+                &direct_tok,
+                "concept",
+                None,
+                "Case Sensitive Entity",
+                None,
+                None,
+                vec![],
+            )
+            .await
+            .expect("direct entity create must succeed");
+
+        let mut builder = VerbRegistryBuilder::new();
+        builder.with_default_namespace("local");
+        builder.register(KgPack::new(rt.clone()));
+        let registry = builder.build().expect("registry build");
+
+        let result = registry
+            .dispatch("resolve", json!({"refs": ["case sensitive entity"]}))
+            .await
+            .expect("resolve must succeed");
+        let results = result.get("results").and_then(|v| v.as_array()).unwrap();
+        assert_eq!(
+            results[0].get("status").and_then(|v| v.as_str()),
+            Some("resolved"),
+            "case-only variant should remain discoverable through hybrid search: {results:?}"
+        );
+        assert_eq!(
+            results[0].get("id").and_then(|v| v.as_str()),
+            Some(entity.id.to_string().as_str())
+        );
+        assert!(
+            results[0]
+                .get("confidence")
+                .and_then(|v| v.as_f64())
+                .is_some_and(|confidence| confidence < 0.98),
+            "case-only variant must not be reported as an exact-name hit: {results:?}"
+        );
+    }
+
     /// Two entities sharing the exact same name resolve as `Ambiguous`,
     /// never a silent pick, mirroring the ring's duplicate-name contract.
     #[tokio::test]

--- a/crates/khive-query/tests/compile_integration.rs
+++ b/crates/khive-query/tests/compile_integration.rs
@@ -1084,6 +1084,10 @@ mod substrate_labels {
                  created_at, updated_at, deleted_at, entity_type)
             VALUES
                 ('e-fixture-1', 'local', 'concept', 'X', NULL, '{}', '[]',
+                 0, 0, NULL, NULL),
+                ('e-fixture-spaces', 'local', 'project', 'Mixed Case Entity',
+                 NULL, '{}', '[]', 0, 0, NULL, NULL),
+                ('e-fixture-cjk', 'local', 'document', '知识 图谱', NULL, '{}', '[]',
                  0, 0, NULL, NULL);
             INSERT INTO notes
                 (id, namespace, kind, status, name, content, salience,
@@ -1171,6 +1175,36 @@ mod substrate_labels {
             "MATCH (e:entity) WHERE e.name = 'X' must return the existing entity row; sql: {}",
             compiled.sql
         );
+    }
+
+    #[test]
+    fn entity_name_equality_handles_case_spaces_and_cjk() {
+        let conn = fixture_db();
+        let cases = [
+            ("Mixed Case Entity", "e-fixture-spaces"),
+            ("mixed case entity", "e-fixture-spaces"),
+            ("知识 图谱", "e-fixture-cjk"),
+        ];
+
+        for (name, expected_id) in cases {
+            let q = parse(
+                QueryLanguage::Gql,
+                &format!(r#"MATCH (e:entity) WHERE e.name = "{name}" RETURN e.id"#),
+            )
+            .unwrap();
+            let compiled = compile(&q, &opts()).unwrap();
+            assert!(
+                compiled.sql.contains("COLLATE NOCASE"),
+                "GQL string equality must remain case-insensitive; sql: {}",
+                compiled.sql
+            );
+            assert_eq!(
+                run(&conn, &compiled),
+                vec![expected_id.to_string()],
+                "name equality must find {name:?}; sql: {}",
+                compiled.sql
+            );
+        }
     }
 
     #[test]

--- a/crates/khive-query/tests/compile_integration.rs
+++ b/crates/khive-query/tests/compile_integration.rs
@@ -1198,6 +1198,24 @@ mod substrate_labels {
                 "GQL string equality must remain case-insensitive; sql: {}",
                 compiled.sql
             );
+            assert!(
+                compiled.sql.contains(".name = ?"),
+                "GQL name equality must use a SQL placeholder; sql: {}",
+                compiled.sql
+            );
+            assert!(
+                compiled
+                    .params
+                    .iter()
+                    .any(|param| matches!(param, QueryValue::Text(value) if value == name)),
+                "name {name:?} must be passed as a bound text parameter; params: {:?}",
+                compiled.params
+            );
+            assert!(
+                !compiled.sql.contains(name),
+                "name {name:?} must not be interpolated into SQL: {}",
+                compiled.sql
+            );
             assert_eq!(
                 run(&conn, &compiled),
                 vec![expected_id.to_string()],

--- a/docs/guide/api-reference.md
+++ b/docs/guide/api-reference.md
@@ -399,7 +399,8 @@ GQL or SPARQL pattern matching (read-only). Write-shaped input (SPARQL
 INSERT/DELETE/LOAD/WITH…DELETE, GQL/Cypher CREATE/DELETE/DETACH DELETE/SET/MERGE) is
 rejected — use `create`/`update`/`link`/`merge`/`delete` to mutate the graph. Queries
 that mix fixed-length and variable-length chains are not compiled in one call; split
-them into separate `query()` calls.
+them into separate `query()` calls. GQL string equality uses SQLite `COLLATE NOCASE`,
+so `WHERE e.name = "LoRA"` matches both `LoRA` and ASCII case variants such as `lora`.
 
 | Param   | Type    | Required | Notes                                    |
 | ------- | ------- | -------- | ---------------------------------------- |
@@ -460,15 +461,16 @@ request(ops="withdraw(id=\"<proposal-id>\")")
 
 Resolve natural-language references to ids. Each ref in `refs` is resolved through:
 (1) id-string passthrough (UUID or 8+ hex prefix) via the existing by-ID path; (2) this
-actor's recently-referenced ring; (3) hybrid search over the namespace. Returns one of
+actor's recently-referenced ring; (3) a case-sensitive exact match on `entities.name`;
+(4) hybrid search over the namespace. Returns one of
 `Resolved{id,confidence}` | `Ambiguous{candidates}` | `NotFound` per ref — never a
 silent pick among close candidates. Read-only: performs no mutation.
 
-| Param   | Type            | Required | Notes                                                                                                        |
-| ------- | --------------- | -------- | ------------------------------------------------------------------------------------------------------------ |
-| `refs`  | array\<string\> | yes      | Natural-language references to resolve (UUID, hex prefix, exact entity name, or free text).                  |
-| `kind`  | string          | no       | Restricts the hybrid-search fallback (stage 3) to an entity kind. No effect on the id-string or ring stages. |
-| `limit` | integer         | no       | Max candidates returned per ref from the hybrid-search fallback. Default 5, max 20.                          |
+| Param   | Type            | Required | Notes                                                                                                           |
+| ------- | --------------- | -------- | --------------------------------------------------------------------------------------------------------------- |
+| `refs`  | array\<string\> | yes      | Natural-language references to resolve (UUID, hex prefix, exact entity name, or free text).                     |
+| `kind`  | string          | no       | Restricts the exact-name and hybrid-search stages to an entity kind. No effect on the id-string or ring stages. |
+| `limit` | integer         | no       | Max candidates returned per ref from the stage 4 hybrid-search fallback. Default 5, max 20.                     |
 
 ```
 request(ops="resolve(refs=[\"the old record\", \"<uuid>\"])")


### PR DESCRIPTION
Closes #849.

Investigation outcome: the reported name-equality failures are not reproducible on main — the resolve exact-name tier and GQL name comparison handle CJK and spaced names correctly. This PR pins that behavior with regression tests (resolve exact-name tier: CJK + spaces + case-variant hybrid fallback; GQL compile integration for name equality) and clarifies the documented semantics in the API reference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)