### PR TITLE
fix(schedule): deliver fired reminders to the creating actor's inbox

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -152,12 +152,12 @@ or `comm.thread`.
 
 ### Schedule pack — 4 verbs (`schedule.` prefix)
 
-| Verb                | What it does                     | When to use                                    |
-| ------------------- | -------------------------------- | ---------------------------------------------- |
-| `schedule.remind`   | Create a time-triggered reminder | "Remind me to X at Y"                          |
-| `schedule.schedule` | Schedule a future verb dispatch  | Deferred actions (action is a DSL verb string) |
-| `schedule.agenda`   | List upcoming scheduled events   | "What's on the calendar?"                      |
-| `schedule.cancel`   | Cancel a scheduled event         | Remove a pending reminder/action               |
+| Verb                | What it does                                  | When to use                                                   |
+| ------------------- | --------------------------------------------- | ------------------------------------------------------------- |
+| `schedule.remind`   | Deliver a reminder to your inbox at fire time | "Remind me to X at Y"                                         |
+| `schedule.schedule` | Schedule a future verb dispatch               | Deferred or cross-actor actions (action is a DSL verb string) |
+| `schedule.agenda`   | List upcoming scheduled events                | "What's on the calendar?"                                     |
+| `schedule.cancel`   | Cancel a scheduled event                      | Remove a pending reminder/action                              |
 
 ### Knowledge pack — 19 verbs (`knowledge.` prefix)
 

--- a/crates/khive-mcp/src/pending_events.rs
+++ b/crates/khive-mcp/src/pending_events.rs
@@ -1570,12 +1570,43 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn fired_reminder_delivers_to_the_creating_actor_inbox() {
+    async fn fired_reminder_delivers_to_creator_after_daemon_actor_changes() {
         let (_tmp, db_path) = tmp_db();
-        let actor = "lambda:reminder-owner";
-        let rt = make_rt_with_actor(&db_path, Some(actor)).await;
-        let server = KhiveMcpServer::new(rt.clone()).expect("server");
-        let id = create_scheduled_event(&rt, "local", &due_rfc3339(), None, None, "remind").await;
+        let creator = "lambda:reminder-owner";
+        let daemon_actor = "lambda:replacement-daemon";
+        let id = {
+            let creator_rt = make_rt_with_actor(&db_path, Some(creator)).await;
+            let creator_server = KhiveMcpServer::new(creator_rt.clone()).expect("creator server");
+            let remind_ops = serde_json::to_string(&json!([{
+                "tool": "schedule.remind",
+                "args": {
+                    "content": "test reminder",
+                    "at": "2099-01-01T00:00:00Z"
+                }
+            }]))
+            .expect("serialize reminder op");
+            let result = creator_server
+                .dispatch_request_local(RequestParams {
+                    ops: remind_ops,
+                    ..Default::default()
+                })
+                .await
+                .expect("create reminder through schedule.remind");
+            let result: Value = serde_json::from_str(&result).expect("reminder result JSON");
+            assert_eq!(result["results"][0]["ok"], true, "{result}");
+            let id = result["results"][0]["result"]["full_id"]
+                .as_str()
+                .expect("reminder full_id")
+                .parse()
+                .expect("reminder UUID");
+            let props = get_note_props(&creator_rt, id).await;
+            assert_eq!(props["created_by_actor"], creator, "{props}");
+            make_repeat_due_again(&creator_rt, id).await;
+            id
+        };
+
+        let rt = make_rt_with_actor(&db_path, Some(daemon_actor)).await;
+        let server = KhiveMcpServer::new(rt.clone()).expect("replacement daemon server");
 
         let summary = run_pending_events_on(&rt, &server, false)
             .await
@@ -1583,12 +1614,20 @@ mod tests {
 
         assert_eq!(summary.fired, 1);
         assert_eq!(summary.failed, 0);
-        let messages = inbound_reminder_messages(&rt, actor).await;
-        assert_eq!(messages.len(), 1, "one inbound delivery");
+        let messages = inbound_reminder_messages(&rt, creator).await;
+        let daemon_messages = inbound_reminder_messages(&rt, daemon_actor).await;
+        let local_messages = inbound_reminder_messages(&rt, "local").await;
+        assert_eq!(
+            messages.len(),
+            1,
+            "one inbound delivery for the creator; daemon={daemon_messages:?}, local={local_messages:?}"
+        );
         assert_eq!(messages[0].0, "test reminder");
         assert_eq!(messages[0].1["direction"], "inbound");
-        assert_eq!(messages[0].1["to_actor"], actor);
+        assert_eq!(messages[0].1["to_actor"], creator);
         assert_eq!(messages[0].1["subject"], "[Reminder] test reminder");
+        assert!(daemon_messages.is_empty());
+        assert!(local_messages.is_empty());
         let props = get_note_props(&rt, id).await;
         assert_eq!(props["status"], "fired");
         assert!(props["fired_at"].as_str().is_some());
@@ -1625,20 +1664,46 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn reminder_delivery_failure_is_persisted_and_audited() {
+    async fn reminder_delivery_failure_is_persisted_audited_and_drain_continues() {
         let (_tmp, db_path) = tmp_db();
         let actor = "lambda:failure-owner";
         let rt = make_rt_with_actor(&db_path, Some(actor)).await;
         let packs = vec!["kg".to_string(), "schedule".to_string()];
         let server = KhiveMcpServer::with_packs(rt.clone(), &packs).expect("server without comm");
         let id = create_scheduled_event(&rt, "local", &due_rfc3339(), None, None, "remind").await;
+        let action_id = create_scheduled_event(
+            &rt,
+            "local",
+            &due_rfc3339(),
+            Some("stats()"),
+            None,
+            "schedule",
+        )
+        .await;
+        let mut writer = rt.sql().writer().await.expect("open SQL writer");
+        let reordered = writer
+            .execute(SqlStatement {
+                sql: "UPDATE notes SET created_at = CASE id WHEN ?1 THEN 1 WHEN ?2 THEN 2 END \
+                      WHERE id IN (?1, ?2)"
+                    .to_string(),
+                params: vec![
+                    SqlValue::Text(id.to_string()),
+                    SqlValue::Text(action_id.to_string()),
+                ],
+                label: Some("test_reminder_failure_precedes_valid_action".into()),
+            })
+            .await
+            .expect("order reminder before action");
+        assert_eq!(reordered, 2);
+        drop(writer);
 
         let summary = run_pending_events_on(&rt, &server, false)
             .await
             .expect("drain continues after failure");
 
+        assert_eq!(summary.scanned, 2);
         assert_eq!(summary.failed, 1);
-        assert_eq!(summary.fired, 1);
+        assert_eq!(summary.fired, 2);
         assert!(inbound_reminder_messages(&rt, actor).await.is_empty());
         let props = get_note_props(&rt, id).await;
         assert!(
@@ -1648,6 +1713,9 @@ mod tests {
             "delivery error must be visible on the reminder row: {props:?}"
         );
         assert!(props["delivery_failed_at"].as_str().is_some());
+        let action_props = get_note_props(&rt, action_id).await;
+        assert_eq!(action_props["status"], "fired");
+        assert!(action_props["fired_at"].as_str().is_some());
 
         let token = rt.authorize(Namespace::local()).expect("authorize");
         let events = rt

--- a/crates/khive-mcp/src/pending_events.rs
+++ b/crates/khive-mcp/src/pending_events.rs
@@ -1382,10 +1382,25 @@ pub async fn schedule_tick_loop(
 mod tests {
     use super::*;
     use chrono::FixedOffset;
-    use khive_runtime::RuntimeConfig;
+    use khive_runtime::{Gate, GateDecision, GateError, GateRequest, RuntimeConfig};
     use khive_storage::event::EventFilter;
     use khive_storage::types::PageRequest;
     use tempfile::NamedTempFile;
+
+    #[derive(Debug)]
+    struct DenyCommSendGate;
+
+    impl Gate for DenyCommSendGate {
+        fn check(&self, request: &GateRequest) -> Result<GateDecision, GateError> {
+            if request.verb == "comm.send" {
+                Ok(GateDecision::deny(
+                    "comm.send denied by delivery-failure test",
+                ))
+            } else {
+                Ok(GateDecision::allow())
+            }
+        }
+    }
 
     fn tmp_db() -> (NamedTempFile, String) {
         let f = NamedTempFile::new().expect("tempfile");
@@ -1667,9 +1682,19 @@ mod tests {
     async fn reminder_delivery_failure_is_persisted_audited_and_drain_continues() {
         let (_tmp, db_path) = tmp_db();
         let actor = "lambda:failure-owner";
-        let rt = make_rt_with_actor(&db_path, Some(actor)).await;
-        let packs = vec!["kg".to_string(), "schedule".to_string()];
-        let server = KhiveMcpServer::with_packs(rt.clone(), &packs).expect("server without comm");
+        let cfg = RuntimeConfig {
+            db_path: Some(std::path::PathBuf::from(&db_path)),
+            default_namespace: Namespace::parse("local").unwrap(),
+            embedding_model: None,
+            additional_embedding_models: vec![],
+            gate: std::sync::Arc::new(DenyCommSendGate),
+            actor_id: Some(actor.to_string()),
+            ..Default::default()
+        };
+        let rt = KhiveRuntime::new(cfg).expect("runtime");
+        let packs = vec!["kg".to_string(), "comm".to_string(), "schedule".to_string()];
+        let server = KhiveMcpServer::with_packs(rt.clone(), &packs)
+            .expect("server with required reminder delivery pack");
         let id = create_scheduled_event(&rt, "local", &due_rfc3339(), None, None, "remind").await;
         let action_id = create_scheduled_event(
             &rt,
@@ -1709,7 +1734,7 @@ mod tests {
         assert!(
             props["delivery_error"]
                 .as_str()
-                .is_some_and(|error| error.contains("unknown verb")),
+                .is_some_and(|error| error.contains("denied by delivery-failure test")),
             "delivery error must be visible on the reminder row: {props:?}"
         );
         assert!(props["delivery_failed_at"].as_str().is_some());

--- a/crates/khive-mcp/src/pending_events.rs
+++ b/crates/khive-mcp/src/pending_events.rs
@@ -2,10 +2,11 @@
 //! daemon-resident tick (ADR-106, [`schedule_tick_loop`]).
 //!
 //! Scans all `scheduled_event` notes with `status="pending"` whose `trigger_at`
-//! is at or before now, fires their stored action through the registry in the
-//! event's own namespace, marks each as `"fired"`, and advances repeating events
-//! to their next occurrence. Events overdue by more than the configured grace
-//! window are never dispatched — see "Missed-event policy" below.
+//! is at or before now, dispatches scheduled actions or delivers reminders to
+//! their creating actors through `comm.send`, marks each as `"fired"`, and
+//! advances repeating events to their next occurrence. Events overdue by more
+//! than the configured grace window are never dispatched. See "Missed-event
+//! policy" below.
 //!
 //! This module lives in `khive-mcp` (not `kkernel`, where it originated)
 //! because the daemon tick loop needs to call it in-process from
@@ -73,6 +74,7 @@ use crate::server::KhiveMcpServer;
 use crate::tools::request::RequestParams;
 use khive_runtime::{KhiveRuntime, Namespace};
 use khive_storage::types::{SqlStatement, SqlValue};
+use khive_types::{EventKind, EventOutcome, SubstrateKind};
 
 /// A `scheduled_event` row stuck in `status="firing"` for longer than this is
 /// considered abandoned by a drain process that crashed or was killed between
@@ -125,7 +127,7 @@ pub struct DrainSummary {
 ///
 /// - Scans for `scheduled_event` notes with `status="pending"` and
 ///   `trigger_at <= now`.
-/// - Dispatches the stored action DSL in the event's namespace.
+/// - Dispatches the stored action DSL or reminder inbox delivery in the event's namespace.
 /// - Marks fired events: status → `"fired"`, `fired_at` → now.
 /// - For repeating events with named aliases (`"daily"` / `"weekly"` /
 ///   `"monthly"`), resets status to `"pending"` and advances `trigger_at`.
@@ -346,7 +348,7 @@ pub async fn run_pending_events_on(
                 // unparseable `trigger_at` at write time, so this only
                 // matters for a hand-written or pre-validation row.
                 None => (
-                    "SELECT id, properties, created_at FROM notes \
+                    "SELECT id, content, properties, created_at FROM notes \
                      WHERE namespace = ?1 AND kind = 'scheduled_event' \
                        AND deleted_at IS NULL \
                        AND json_extract(properties, '$.status') = 'pending' \
@@ -363,7 +365,7 @@ pub async fn run_pending_events_on(
                     ],
                 ),
                 Some((c_created_at, c_id)) => (
-                    "SELECT id, properties, created_at FROM notes \
+                    "SELECT id, content, properties, created_at FROM notes \
                      WHERE namespace = ?1 AND kind = 'scheduled_event' \
                        AND deleted_at IS NULL \
                        AND json_extract(properties, '$.status') = 'pending' \
@@ -470,6 +472,18 @@ pub async fn run_pending_events_on(
                         continue;
                     }
                 };
+                let content = match row.get("content") {
+                    Some(SqlValue::Text(s)) => s.clone(),
+                    other => {
+                        tracing::error!(
+                            scheduled_event_id = %id,
+                            content_column = ?other,
+                            "pending-events: scheduled event has invalid content"
+                        );
+                        summary.failed += 1;
+                        continue;
+                    }
+                };
 
                 summary.scanned += 1;
 
@@ -513,20 +527,39 @@ pub async fn run_pending_events_on(
                     .and_then(Value::as_str)
                     .unwrap_or("remind");
 
-                let action_dsl: Option<String> = if event_type == "schedule" && !is_missed {
+                let reminder_actor = if event_type == "remind" && !is_missed {
+                    let stored_actor = properties
+                        .as_ref()
+                        .and_then(|p| p.get("created_by_actor"))
+                        .and_then(Value::as_str);
+                    if stored_actor.is_none() {
+                        tracing::warn!(
+                            scheduled_event_id = %id,
+                            "pending-events: legacy reminder has no created_by_actor; using the \
+                             scheduler actor"
+                        );
+                    }
+                    Some(
+                        stored_actor
+                            .or_else(|| server.actor_id())
+                            .unwrap_or("local")
+                            .to_string(),
+                    )
+                } else {
+                    None
+                };
+                let action_dsl: Option<String> = if is_missed {
+                    None
+                } else if event_type == "schedule" {
                     properties
                         .as_ref()
                         .and_then(|p| p.get("payload"))
                         .and_then(Value::as_str)
                         .map(str::to_string)
                 } else {
-                    // remind events: no DSL action to dispatch. We mark as fired
-                    // to acknowledge the trigger. The notification channel (comm,
-                    // channel transport, etc.) is out of scope for this drain.
-                    // Missed `schedule` events take this branch too: the whole
-                    // point of the missed policy is that the action is never
-                    // dispatched.
-                    None
+                    reminder_actor
+                        .as_deref()
+                        .map(|actor| reminder_delivery_action(actor, &content))
                 };
 
                 // ── Determine repeat (read before claim; only informs which
@@ -633,13 +666,33 @@ pub async fn run_pending_events_on(
                 }
 
                 // ── Dispatch the action ──────────────────────────────────
+                let mut reminder_delivery_error = None;
                 if let Some(dsl) = &action_dsl {
                     let dispatch_result = dispatch_action(dsl, ns_str, server, verbose).await;
                     if let Err(e) = dispatch_result {
+                        tracing::error!(
+                            scheduled_event_id = %id,
+                            event_type,
+                            recipient_actor = reminder_actor.as_deref(),
+                            error = %e,
+                            "pending-events: scheduled event delivery failed"
+                        );
                         if verbose {
                             eprintln!("[pending-events] dispatch failed for note {id}: {e}");
                         }
                         summary.failed += 1;
+                        if event_type == "remind" {
+                            let error = e.to_string();
+                            append_reminder_delivery_failure_event(
+                                server,
+                                ns_str,
+                                id,
+                                reminder_actor.as_deref().unwrap_or("local"),
+                                &error,
+                            )
+                            .await;
+                            reminder_delivery_error = Some(error);
+                        }
                         // Per-event failure does NOT abort the drain. Continue.
                         // Still mark as fired so the drain doesn't retry infinitely
                         // on a permanently broken action. The error is reported
@@ -651,6 +704,15 @@ pub async fn run_pending_events_on(
 
                 let fired_at_rfc = Utc::now().to_rfc3339();
                 let mut props = properties.clone().unwrap_or_else(|| json!({}));
+                if event_type == "remind" {
+                    if let Some(error) = reminder_delivery_error {
+                        props["delivery_error"] = json!(error);
+                        props["delivery_failed_at"] = json!(fired_at_rfc);
+                    } else if let Some(obj) = props.as_object_mut() {
+                        obj.remove("delivery_error");
+                        obj.remove("delivery_failed_at");
+                    }
+                }
                 let updated_at;
 
                 match next_trigger_at(&repeat, trigger_at) {
@@ -964,6 +1026,65 @@ fn advance_repeat_past_missed(
     }
 }
 
+fn reminder_delivery_action(actor: &str, content: &str) -> String {
+    let action = json!([{
+        "tool": "comm.send",
+        "args": {
+            "to": actor,
+            "subject": reminder_subject(content),
+            "content": content,
+        }
+    }]);
+    serde_json::to_string(&action).expect("reminder delivery action is JSON-serializable")
+}
+
+fn reminder_subject(content: &str) -> String {
+    const MAX_HEAD_CHARS: usize = 80;
+    let collapsed = content.split_whitespace().collect::<Vec<_>>().join(" ");
+    let mut chars = collapsed.chars();
+    let head: String = chars.by_ref().take(MAX_HEAD_CHARS).collect();
+    if chars.next().is_some() {
+        format!("[Reminder] {head}…")
+    } else if head.is_empty() {
+        "[Reminder]".to_string()
+    } else {
+        format!("[Reminder] {head}")
+    }
+}
+
+async fn append_reminder_delivery_failure_event(
+    server: &KhiveMcpServer,
+    namespace: &str,
+    scheduled_event_id: uuid::Uuid,
+    recipient_actor: &str,
+    error: &str,
+) {
+    let Some(store) = server.event_store() else {
+        return;
+    };
+    let event = khive_storage::Event::new(
+        namespace,
+        "schedule.remind.fire",
+        EventKind::Audit,
+        SubstrateKind::Note,
+        recipient_actor,
+    )
+    .with_outcome(EventOutcome::Error)
+    .with_target(scheduled_event_id)
+    .with_payload(json!({
+        "scheduled_event_id": scheduled_event_id,
+        "recipient_actor": recipient_actor,
+        "error": error,
+    }));
+    if let Err(trace_error) = store.append_event(event).await {
+        tracing::error!(
+            scheduled_event_id = %scheduled_event_id,
+            error = %trace_error,
+            "pending-events: reminder delivery failure event append failed"
+        );
+    }
+}
+
 /// Dispatch a DSL action string in the given namespace.
 ///
 /// The action is wrapped as a JSON-form batch with `namespace` injected into
@@ -1262,6 +1383,7 @@ mod tests {
     use super::*;
     use chrono::FixedOffset;
     use khive_runtime::RuntimeConfig;
+    use khive_storage::event::EventFilter;
     use khive_storage::types::PageRequest;
     use tempfile::NamedTempFile;
 
@@ -1292,11 +1414,16 @@ mod tests {
     }
 
     async fn make_rt(db_path: &str) -> KhiveRuntime {
+        make_rt_with_actor(db_path, None).await
+    }
+
+    async fn make_rt_with_actor(db_path: &str, actor_id: Option<&str>) -> KhiveRuntime {
         let cfg = RuntimeConfig {
             db_path: Some(std::path::PathBuf::from(db_path)),
             default_namespace: Namespace::parse("local").unwrap(),
             embedding_model: None,
             additional_embedding_models: vec![],
+            actor_id: actor_id.map(str::to_string),
             ..Default::default()
         };
         KhiveRuntime::new(cfg).expect("runtime")
@@ -1339,20 +1466,18 @@ mod tests {
         repeat: Option<&str>,
         event_type: &str,
     ) -> uuid::Uuid {
+        let ns = Namespace::parse(namespace).expect("ns");
+        let token = rt.authorize(ns).expect("authorize");
         let props = json!({
             "trigger_at": trigger_at,
             "repeat": repeat,
             "status": "pending",
             "event_type": event_type,
+            "created_by_actor": token.actor().id.clone(),
             "payload": action_dsl,
             "fired_at": null,
             "cancelled_at": null,
         });
-
-        let ns = Namespace::parse(namespace).expect("ns");
-        // We need a NamespaceToken. In tests within `khive-runtime`, `for_namespace`
-        // is pub(crate). External crates use `rt.authorize()`.
-        let token = rt.authorize(ns).expect("authorize");
 
         let content = action_dsl.unwrap_or("test reminder");
         let note = rt
@@ -1382,6 +1507,168 @@ mod tests {
             .expect("get_note")
             .expect("note exists");
         note.properties.unwrap_or(json!({}))
+    }
+
+    async fn inbound_reminder_messages(rt: &KhiveRuntime, actor: &str) -> Vec<(String, Value)> {
+        let mut reader = rt.sql().reader().await.expect("open SQL reader");
+        let rows = reader
+            .query_all(SqlStatement {
+                sql: "SELECT content, properties FROM notes \
+                      WHERE kind = 'message' \
+                        AND json_extract(properties, '$.direction') = 'inbound' \
+                        AND json_extract(properties, '$.to_actor') = ?1 \
+                      ORDER BY created_at ASC, id ASC"
+                    .to_string(),
+                params: vec![SqlValue::Text(actor.to_string())],
+                label: Some("test_inbound_reminder_messages".into()),
+            })
+            .await
+            .expect("query reminder messages");
+        rows.into_iter()
+            .map(|row| {
+                let content = match row.get("content") {
+                    Some(SqlValue::Text(value)) => value.clone(),
+                    other => panic!("unexpected content column: {other:?}"),
+                };
+                let properties = match row.get("properties") {
+                    Some(SqlValue::Text(value)) => {
+                        serde_json::from_str(value).expect("message properties JSON")
+                    }
+                    other => panic!("unexpected properties column: {other:?}"),
+                };
+                (content, properties)
+            })
+            .collect()
+    }
+
+    async fn make_repeat_due_again(rt: &KhiveRuntime, id: uuid::Uuid) {
+        let mut writer = rt.sql().writer().await.expect("open SQL writer");
+        let rows = writer
+            .execute(SqlStatement {
+                sql: "UPDATE notes \
+                      SET properties = json_set(properties, '$.trigger_at', ?1) \
+                      WHERE id = ?2"
+                    .to_string(),
+                params: vec![
+                    SqlValue::Text(due_rfc3339()),
+                    SqlValue::Text(id.to_string()),
+                ],
+                label: Some("test_repeat_due_again".into()),
+            })
+            .await
+            .expect("make repeat due again");
+        assert_eq!(rows, 1, "repeat fixture row updated");
+    }
+
+    #[test]
+    fn reminder_subject_marks_and_truncates_the_content_head() {
+        let content = format!("  {}\n tail", "x".repeat(90));
+        let subject = reminder_subject(&content);
+        assert!(subject.starts_with("[Reminder] "));
+        assert!(subject.ends_with('…'));
+        assert_eq!(subject.chars().count(), "[Reminder] ".chars().count() + 81);
+    }
+
+    #[tokio::test]
+    async fn fired_reminder_delivers_to_the_creating_actor_inbox() {
+        let (_tmp, db_path) = tmp_db();
+        let actor = "lambda:reminder-owner";
+        let rt = make_rt_with_actor(&db_path, Some(actor)).await;
+        let server = KhiveMcpServer::new(rt.clone()).expect("server");
+        let id = create_scheduled_event(&rt, "local", &due_rfc3339(), None, None, "remind").await;
+
+        let summary = run_pending_events_on(&rt, &server, false)
+            .await
+            .expect("drain");
+
+        assert_eq!(summary.fired, 1);
+        assert_eq!(summary.failed, 0);
+        let messages = inbound_reminder_messages(&rt, actor).await;
+        assert_eq!(messages.len(), 1, "one inbound delivery");
+        assert_eq!(messages[0].0, "test reminder");
+        assert_eq!(messages[0].1["direction"], "inbound");
+        assert_eq!(messages[0].1["to_actor"], actor);
+        assert_eq!(messages[0].1["subject"], "[Reminder] test reminder");
+        let props = get_note_props(&rt, id).await;
+        assert_eq!(props["status"], "fired");
+        assert!(props["fired_at"].as_str().is_some());
+    }
+
+    #[tokio::test]
+    async fn repeating_reminder_delivers_on_consecutive_fires() {
+        let (_tmp, db_path) = tmp_db();
+        let actor = "lambda:repeat-owner";
+        let rt = make_rt_with_actor(&db_path, Some(actor)).await;
+        let server = KhiveMcpServer::new(rt.clone()).expect("server");
+        let id =
+            create_scheduled_event(&rt, "local", &due_rfc3339(), None, Some("daily"), "remind")
+                .await;
+
+        let first = run_pending_events_on(&rt, &server, false)
+            .await
+            .expect("first drain");
+        assert_eq!(first.advanced, 1);
+        assert_eq!(inbound_reminder_messages(&rt, actor).await.len(), 1);
+
+        make_repeat_due_again(&rt, id).await;
+        let second = run_pending_events_on(&rt, &server, false)
+            .await
+            .expect("second drain");
+
+        assert_eq!(second.advanced, 1);
+        assert_eq!(second.failed, 0);
+        assert_eq!(
+            inbound_reminder_messages(&rt, actor).await.len(),
+            2,
+            "each fire delivers one inbound message"
+        );
+    }
+
+    #[tokio::test]
+    async fn reminder_delivery_failure_is_persisted_and_audited() {
+        let (_tmp, db_path) = tmp_db();
+        let actor = "lambda:failure-owner";
+        let rt = make_rt_with_actor(&db_path, Some(actor)).await;
+        let packs = vec!["kg".to_string(), "schedule".to_string()];
+        let server = KhiveMcpServer::with_packs(rt.clone(), &packs).expect("server without comm");
+        let id = create_scheduled_event(&rt, "local", &due_rfc3339(), None, None, "remind").await;
+
+        let summary = run_pending_events_on(&rt, &server, false)
+            .await
+            .expect("drain continues after failure");
+
+        assert_eq!(summary.failed, 1);
+        assert_eq!(summary.fired, 1);
+        assert!(inbound_reminder_messages(&rt, actor).await.is_empty());
+        let props = get_note_props(&rt, id).await;
+        assert!(
+            props["delivery_error"]
+                .as_str()
+                .is_some_and(|error| error.contains("unknown verb")),
+            "delivery error must be visible on the reminder row: {props:?}"
+        );
+        assert!(props["delivery_failed_at"].as_str().is_some());
+
+        let token = rt.authorize(Namespace::local()).expect("authorize");
+        let events = rt
+            .events(&token)
+            .expect("event store")
+            .query_events(
+                EventFilter {
+                    verbs: vec!["schedule.remind.fire".to_string()],
+                    ..Default::default()
+                },
+                PageRequest {
+                    limit: 10,
+                    offset: 0,
+                },
+            )
+            .await
+            .expect("query reminder failure events");
+        assert!(events
+            .items
+            .iter()
+            .any(|event| { event.outcome == EventOutcome::Error && event.target_id == Some(id) }));
     }
 
     #[tokio::test]

--- a/crates/khive-mcp/tests/integration.rs
+++ b/crates/khive-mcp/tests/integration.rs
@@ -437,7 +437,8 @@ async fn pack_gtd_without_kg_fails_at_boot() {
 }
 
 #[tokio::test]
-async fn pack_schedule_without_comm_fails_at_boot() {
+async fn pack_schedule_without_comm_rejects_only_remind_before_persisting() -> anyhow::Result<()> {
+    disable_daemon();
     let config = RuntimeConfig {
         db_path: None,
         default_namespace: Namespace::parse("test").unwrap(),
@@ -446,21 +447,53 @@ async fn pack_schedule_without_comm_fails_at_boot() {
         packs: vec!["kg".to_string(), "schedule".to_string()],
         ..RuntimeConfig::default()
     };
-    let runtime = KhiveRuntime::new(config).unwrap();
-    match KhiveMcpServer::new(runtime) {
-        Ok(_) => panic!("schedule without comm must fail at boot"),
-        Err(error) => {
-            let message = error.to_string();
-            assert!(
-                message.contains("schedule"),
-                "error must name the dependent pack: {message}"
-            );
-            assert!(
-                message.contains("comm"),
-                "error must name the missing dependency: {message}"
-            );
+    let runtime = KhiveRuntime::new(config).expect("kg+schedule runtime");
+    let server = KhiveMcpServer::new(runtime).expect("kg+schedule server builds without comm");
+    let (server_transport, client_transport) = tokio::io::duplex(65536);
+    tokio::spawn(async move {
+        if let Ok(svc) = server.serve(server_transport).await {
+            let _ = svc.waiting().await;
         }
-    }
+    });
+    let client = DummyClient.serve(client_transport).await?;
+
+    let result = call(
+        &client,
+        "request",
+        json!({
+            "ops": r#"schedule.remind(content="must not persist", at="2099-01-01T00:00:00Z")"#,
+            "presentation": "verbose"
+        }),
+    )
+    .await?;
+    let body: Value = serde_json::from_str(&first_text(&result))?;
+    let failed = &body["results"][0];
+    assert_eq!(failed["ok"], json!(false), "remind must fail: {failed}");
+    let error = failed["error"].as_str().unwrap_or_default();
+    assert!(
+        error.contains("comm.send") && error.contains("delivery"),
+        "error must name the missing comm delivery capability: {error}"
+    );
+
+    let notes = ok_one(&client, r#"list(kind="note")"#).await?;
+    assert_eq!(notes, json!([]), "failed remind must persist no note");
+    let empty_agenda = ok_one(&client, "schedule.agenda()").await?;
+    assert_eq!(empty_agenda["count"], json!(0));
+
+    let scheduled = ok_one(
+        &client,
+        r#"schedule.schedule(action="schedule.agenda()", at="2099-01-02T00:00:00Z")"#,
+    )
+    .await?;
+    let full_id = scheduled["full_id"]
+        .as_str()
+        .expect("schedule.schedule returns full_id");
+    let agenda = ok_one(&client, "schedule.agenda()").await?;
+    assert_eq!(agenda["count"], json!(1));
+    let cancelled = ok_one(&client, &format!(r#"schedule.cancel(id="{full_id}")"#)).await?;
+    assert_eq!(cancelled["status"], json!("cancelled"));
+
+    Ok(())
 }
 
 #[tokio::test]

--- a/crates/khive-mcp/tests/integration.rs
+++ b/crates/khive-mcp/tests/integration.rs
@@ -437,6 +437,33 @@ async fn pack_gtd_without_kg_fails_at_boot() {
 }
 
 #[tokio::test]
+async fn pack_schedule_without_comm_fails_at_boot() {
+    let config = RuntimeConfig {
+        db_path: None,
+        default_namespace: Namespace::parse("test").unwrap(),
+        embedding_model: None,
+        additional_embedding_models: vec![],
+        packs: vec!["kg".to_string(), "schedule".to_string()],
+        ..RuntimeConfig::default()
+    };
+    let runtime = KhiveRuntime::new(config).unwrap();
+    match KhiveMcpServer::new(runtime) {
+        Ok(_) => panic!("schedule without comm must fail at boot"),
+        Err(error) => {
+            let message = error.to_string();
+            assert!(
+                message.contains("schedule"),
+                "error must name the dependent pack: {message}"
+            );
+            assert!(
+                message.contains("comm"),
+                "error must name the missing dependency: {message}"
+            );
+        }
+    }
+}
+
+#[tokio::test]
 async fn pack_gtd_with_kg_explicit_works() {
     // When both kg and gtd are listed, gtd's requires=["kg"] is satisfied.
     let config = RuntimeConfig {
@@ -3397,24 +3424,24 @@ async fn send_returns_iso8601_timestamps() -> anyhow::Result<()> {
     Ok(())
 }
 
-fn make_schedule_server_only() -> KhiveMcpServer {
+fn make_schedule_server() -> KhiveMcpServer {
     disable_daemon();
     let config = RuntimeConfig {
         db_path: None,
         default_namespace: Namespace::parse("schedtest").unwrap(),
         embedding_model: None,
         additional_embedding_models: vec![],
-        packs: vec!["kg".to_string(), "schedule".to_string()],
+        packs: vec!["kg".to_string(), "comm".to_string(), "schedule".to_string()],
         ..RuntimeConfig::default()
     };
-    let runtime = KhiveRuntime::new(config).expect("kg+schedule runtime");
-    KhiveMcpServer::new(runtime).expect("server builds with kg+schedule")
+    let runtime = KhiveRuntime::new(config).expect("kg+comm+schedule runtime");
+    KhiveMcpServer::new(runtime).expect("server builds with kg+comm+schedule")
 }
 
-async fn connect_schedule_only(
+async fn connect_schedule(
 ) -> anyhow::Result<impl std::ops::Deref<Target = rmcp::service::Peer<rmcp::RoleClient>>> {
     let (server_transport, client_transport) = tokio::io::duplex(65536);
-    let server = make_schedule_server_only();
+    let server = make_schedule_server();
     tokio::spawn(async move {
         if let Ok(svc) = server.serve(server_transport).await {
             let _ = svc.waiting().await;
@@ -3427,7 +3454,7 @@ async fn connect_schedule_only(
 /// `remind` creates a scheduled_event note; `agenda` returns ISO-8601 timestamps.
 #[tokio::test]
 async fn agenda_returns_iso8601_timestamps() -> anyhow::Result<()> {
-    let client = connect_schedule_only().await?;
+    let client = connect_schedule().await?;
 
     ok_one(
         &client,
@@ -3602,7 +3629,7 @@ async fn send_rejects_unknown_kwarg() -> anyhow::Result<()> {
 /// `agenda(unknownkw="x")` (schedule) must return `ok: false`.
 #[tokio::test]
 async fn agenda_rejects_unknown_kwarg() -> anyhow::Result<()> {
-    let client = connect_schedule_only().await?;
+    let client = connect_schedule().await?;
 
     let result = call(
         &client,
@@ -3883,7 +3910,7 @@ async fn exec_output_valid_json_with_backslash_escape_content() -> anyhow::Resul
 /// `properties` — the full ISO-8601 string must round-trip verbatim (#546).
 #[tokio::test]
 async fn schedule_agenda_agent_preserves_properties_trigger_at_verbatim() -> anyhow::Result<()> {
-    let client = connect_schedule_only().await?;
+    let client = connect_schedule().await?;
     let trigger_at = "2099-01-01T00:00:00Z";
 
     ok_one(

--- a/crates/khive-pack-comm/README.md
+++ b/crates/khive-pack-comm/README.md
@@ -110,7 +110,8 @@ Over MCP: `request(ops="comm.send(to=\"lambda:leo\", content=\"PR #372 is ready 
 
 `khive-pack-comm` sits alongside `khive-pack-gtd`, `khive-pack-memory`, and
 `khive-pack-schedule` in the pack layer, depending on `khive-pack-kg` for the
-note substrate. The schedule pack in turn requires `comm` for reminder delivery.
+note substrate. The schedule pack's `schedule.remind` verb requires the registered `comm.send`
+delivery capability at creation time; the schedule pack itself requires only `kg`.
 Both register into `khive-runtime`'s `VerbRegistry`, consumed by `khive-mcp`.
 Governing ADRs:
 [ADR-040](https://github.com/ohdearquant/khive/blob/main/docs/adr/ADR-040-communication-and-schedule-packs.md) (communication and schedule packs),

--- a/crates/khive-pack-comm/README.md
+++ b/crates/khive-pack-comm/README.md
@@ -110,8 +110,9 @@ Over MCP: `request(ops="comm.send(to=\"lambda:leo\", content=\"PR #372 is ready 
 
 `khive-pack-comm` sits alongside `khive-pack-gtd`, `khive-pack-memory`, and
 `khive-pack-schedule` in the pack layer, depending on `khive-pack-kg` for the
-note substrate and registering into `khive-runtime`'s `VerbRegistry`, consumed
-by `khive-mcp`. Governing ADRs:
+note substrate. The schedule pack in turn requires `comm` for reminder delivery.
+Both register into `khive-runtime`'s `VerbRegistry`, consumed by `khive-mcp`.
+Governing ADRs:
 [ADR-040](https://github.com/ohdearquant/khive/blob/main/docs/adr/ADR-040-communication-and-schedule-packs.md) (communication and schedule packs),
 [ADR-057](https://github.com/ohdearquant/khive/blob/main/docs/adr/ADR-057-comm-actor-addressed-delivery.md) (actor-addressed delivery),
 built on [ADR-017](https://github.com/ohdearquant/khive/blob/main/docs/adr/ADR-017-pack-standard.md) (pack standard).

--- a/crates/khive-pack-kg/README.md
+++ b/crates/khive-pack-kg/README.md
@@ -85,8 +85,9 @@ always present; `KHIVE_PACKS` / `--pack` select a subset.
 
 `khive-pack-kg` depends directly on `khive-types`, `khive-runtime`,
 `khive-query`, and `khive-storage`, and is registered into the pack runtime that
-`khive-mcp` serves. Every other pack in this workspace requires `kg`; schedule
-additionally requires `comm` so reminders always have an inbox-delivery path.
+`khive-mcp` serves. Every other pack in this workspace requires `kg`; the schedule pack's
+`schedule.remind` verb additionally requires the registered `comm.send` delivery
+capability at creation time, while the rest of the schedule pack works without `comm`.
 Governing ADRs:
 [ADR-001](https://github.com/ohdearquant/khive/blob/main/docs/adr/ADR-001-entity-kind-taxonomy.md) (entity kinds),
 [ADR-002](https://github.com/ohdearquant/khive/blob/main/docs/adr/ADR-002-edge-ontology.md) (edge relations),

--- a/crates/khive-pack-kg/README.md
+++ b/crates/khive-pack-kg/README.md
@@ -85,10 +85,8 @@ always present; `KHIVE_PACKS` / `--pack` select a subset.
 
 `khive-pack-kg` depends directly on `khive-types`, `khive-runtime`,
 `khive-query`, and `khive-storage`, and is registered into the pack runtime that
-`khive-mcp` serves. Every other pack in this workspace declares
-`REQUIRES = ["kg"]` — `gtd`, `memory`, `brain`, `comm`, `schedule`, `knowledge`,
-`session`, `git`, `code`, plus `formal` and `template` — so each depends on
-`kg` being loaded.
+`khive-mcp` serves. Every other pack in this workspace requires `kg`; schedule
+additionally requires `comm` so reminders always have an inbox-delivery path.
 Governing ADRs:
 [ADR-001](https://github.com/ohdearquant/khive/blob/main/docs/adr/ADR-001-entity-kind-taxonomy.md) (entity kinds),
 [ADR-002](https://github.com/ohdearquant/khive/blob/main/docs/adr/ADR-002-edge-ontology.md) (edge relations),

--- a/crates/khive-pack-schedule/Cargo.toml
+++ b/crates/khive-pack-schedule/Cargo.toml
@@ -30,6 +30,7 @@ tracing = { workspace = true }
 [dev-dependencies]
 tokio = { workspace = true, features = ["full"] }
 khive-pack-kg = { version = "0.4.0", path = "../khive-pack-kg" }
+khive-pack-comm = { version = "0.4.0", path = "../khive-pack-comm" }
 khive-pack-brain = { version = "0.4.0", path = "../khive-pack-brain" }
 criterion = { workspace = true }
 

--- a/crates/khive-pack-schedule/README.md
+++ b/crates/khive-pack-schedule/README.md
@@ -43,9 +43,10 @@ the pending-event runner).
 
 ## Usage
 
-`SchedulePack` requires the `kg` and `comm` packs
-(`REQUIRES = ["kg", "comm"]`): `kg` provides the notes substrate, and `comm`
-provides the delivery path for `schedule.remind`:
+`SchedulePack` requires only the `kg` pack (`REQUIRES = ["kg"]`) for the notes
+substrate. `schedule.remind` additionally requires the `comm.send` delivery
+capability at creation time; without it, the call fails before any
+`scheduled_event` note is persisted. Include `CommPack` when creating reminders:
 
 ```rust
 use khive_pack_kg::KgPack;
@@ -78,8 +79,8 @@ Over MCP: `request(ops="schedule.remind(content=\"Ship the 0.4.0 release\", at=\
 and `khive-pack-comm` in the pack layer, depending on `khive-pack-kg` for the
 note substrate and on `khive-request` to validate `schedule.schedule`'s
 DSL payload, registering into `khive-runtime`'s `VerbRegistry`, consumed by
-`khive-mcp`. The schedule pack also requires `khive-pack-comm` so every accepted
-reminder has a registered inbox-delivery verb. Governing ADR:
+`khive-mcp`. The pack can load without `khive-pack-comm`; only
+`schedule.remind` requires a registered `comm.send` delivery verb. Governing ADR:
 [ADR-040](https://github.com/ohdearquant/khive/blob/main/docs/adr/ADR-040-communication-and-schedule-packs.md) (communication and schedule packs),
 built on [ADR-017](https://github.com/ohdearquant/khive/blob/main/docs/adr/ADR-017-pack-standard.md) (pack standard).
 

--- a/crates/khive-pack-schedule/README.md
+++ b/crates/khive-pack-schedule/README.md
@@ -7,7 +7,7 @@ The schedule pack for khive — time-triggered intent storage (`remind`,
 
 | Verb                | What it does                                                            |
 | ------------------- | ----------------------------------------------------------------------- |
-| `schedule.remind`   | Create a time-triggered reminder                                        |
+| `schedule.remind`   | Deliver a time-triggered reminder to your inbox                         |
 | `schedule.schedule` | Schedule a future verb dispatch (a DSL string, validated at write time) |
 | `schedule.agenda`   | List upcoming scheduled events, optionally within a time window         |
 | `schedule.cancel`   | Cancel a scheduled event                                                |
@@ -21,9 +21,11 @@ next occurrence.
 
 ## Semantics
 
-This pack is **intent storage only**. It creates and queries
-`scheduled_event` notes; it does not itself evaluate triggers. `schedule.remind`
-stores a plain reminder payload, while `schedule.schedule`'s `action` parameter
+This pack creates and queries `scheduled_event` notes; the daemon or pending-event
+runner evaluates their triggers. At fire time, `schedule.remind` delivers its
+content to the creating actor's inbox through the same dual-write path as
+`comm.send`. Use `schedule.schedule(action="comm.send(...)")` when the recipient
+is a different actor. `schedule.schedule`'s `action` parameter
 is a full verb-dispatch string (e.g.
 `"schedule.remind(content=\"hello\", at=\"2099-06-01T09:00:00Z\")"`) that must
 satisfy a stricter *replayable* contract, validated at write time (issue
@@ -35,9 +37,9 @@ inner call must itself be independently valid, because `kkernel`'s
 pending-events runner re-parses and re-dispatches the stored string
 unmodified at trigger time. An `action` that fails any of these checks is
 rejected before the event is stored, not at trigger time. Reading pending
-events and dispatching their stored payload at `trigger_at` is the execution
-environment's responsibility (a `kkernel scheduler` daemon, or an external
-cron / cloud scheduler invoking the runtime).
+events and dispatching at `trigger_at` is the execution environment's
+responsibility (the daemon tick or an external cron / cloud scheduler invoking
+the pending-event runner).
 
 ## Usage
 

--- a/crates/khive-pack-schedule/README.md
+++ b/crates/khive-pack-schedule/README.md
@@ -43,11 +43,13 @@ the pending-event runner).
 
 ## Usage
 
-`SchedulePack` requires the `kg` pack (`REQUIRES = ["kg"]`) for the notes
-substrate:
+`SchedulePack` requires the `kg` and `comm` packs
+(`REQUIRES = ["kg", "comm"]`): `kg` provides the notes substrate, and `comm`
+provides the delivery path for `schedule.remind`:
 
 ```rust
 use khive_pack_kg::KgPack;
+use khive_pack_comm::CommPack;
 use khive_pack_schedule::SchedulePack;
 use khive_runtime::{KhiveRuntime, RuntimeConfig, VerbRegistryBuilder};
 use serde_json::json;
@@ -56,6 +58,7 @@ let runtime = KhiveRuntime::new(RuntimeConfig::default())?;
 
 let mut builder = VerbRegistryBuilder::new();
 builder.register(KgPack::new(runtime.clone()));
+builder.register(CommPack::new(runtime.clone()));
 builder.register(SchedulePack::new(runtime));
 let registry = builder.build()?;
 
@@ -75,7 +78,8 @@ Over MCP: `request(ops="schedule.remind(content=\"Ship the 0.4.0 release\", at=\
 and `khive-pack-comm` in the pack layer, depending on `khive-pack-kg` for the
 note substrate and on `khive-request` to validate `schedule.schedule`'s
 DSL payload, registering into `khive-runtime`'s `VerbRegistry`, consumed by
-`khive-mcp`. Governing ADR:
+`khive-mcp`. The schedule pack also requires `khive-pack-comm` so every accepted
+reminder has a registered inbox-delivery verb. Governing ADR:
 [ADR-040](https://github.com/ohdearquant/khive/blob/main/docs/adr/ADR-040-communication-and-schedule-packs.md) (communication and schedule packs),
 built on [ADR-017](https://github.com/ohdearquant/khive/blob/main/docs/adr/ADR-017-pack-standard.md) (pack standard).
 

--- a/crates/khive-pack-schedule/benches/schedule_bench.rs
+++ b/crates/khive-pack-schedule/benches/schedule_bench.rs
@@ -17,6 +17,7 @@ fn build_fixture() -> Fixture {
     let khive_rt = KhiveRuntime::memory().expect("in-memory runtime");
     let mut builder = VerbRegistryBuilder::new();
     builder.register(KgPack::new(khive_rt.clone()));
+    builder.register(khive_pack_comm::CommPack::new(khive_rt.clone()));
     builder.register(SchedulePack::new(khive_rt.clone()));
     let registry = builder.build().expect("registry builds");
     Fixture { registry, rt }

--- a/crates/khive-pack-schedule/docs/design.md
+++ b/crates/khive-pack-schedule/docs/design.md
@@ -34,21 +34,25 @@ following `properties` shape:
   "repeat": "daily",
   "status": "pending",
   "event_type": "remind",
+  "created_by_actor": "lambda:owner",
   "payload": null,
   "fired_at": null,
   "cancelled_at": null
 }
 ```
 
-`event_type` distinguishes `remind` (no action payload; fires a notification)
-from `schedule` (stores a serialized verb+args payload for replay). `payload`
-is null for reminders and a JSON-encoded verb call string for scheduled dispatch.
+`event_type` distinguishes `remind` (no action payload; delivers its content to
+the `created_by_actor` inbox) from `schedule` (stores a serialized verb+args
+payload for replay). `payload` is null for reminders and a JSON-encoded verb
+call string for scheduled dispatch. Reminder delivery uses the same dual-write
+path as `comm.send`. Use `schedule.schedule(action="comm.send(...)")` for
+delivery to an actor other than the creator.
 
 **Four verbs:**
 
 | Verb | Speech act | Args | What it does |
 |------|-----------|------|-------------|
-| `schedule.remind` | commissive | `content`, `at`, `repeat?` | Create a `scheduled_event` with `event_type="remind"` |
+| `schedule.remind` | commissive | `content`, `at`, `repeat?` | Create a `scheduled_event` that delivers `content` to the creating actor's inbox at fire time |
 | `schedule.schedule` | commissive | `action`, `at`, `repeat?` | Create a `scheduled_event` with `event_type="schedule"`; `action` is a DSL verb string |
 | `schedule.agenda` | assertive | `from?`, `to?`, `limit?` | List pending `scheduled_event` notes ordered by `trigger_at` ascending |
 | `schedule.cancel` | declaration | `id` | Set `properties.status = "cancelled"`, record `cancelled_at` |

--- a/crates/khive-pack-schedule/docs/design.md
+++ b/crates/khive-pack-schedule/docs/design.md
@@ -22,7 +22,7 @@ not performed by this pack in process. Two supported execution modes exist:
 - Name: `schedule`
 - Note kinds: `["scheduled_event"]`
 - Entity kinds: `[]`
-- Requires: `["kg", "comm"]`
+- Requires: `["kg"]`; `schedule.remind` requires `comm.send` at creation time
 - Verbs: `schedule.remind`, `schedule.schedule`, `schedule.agenda`, `schedule.cancel`
 
 **Notes-as-scheduled-events.** A `scheduled_event` is a note stored with the
@@ -128,10 +128,10 @@ time when no observer is present.
 
 ### ADR-017: Pack Standard
 
-The pack self-registers via `inventory::submit!`. It declares
-`REQUIRES = ["kg", "comm"]`, ensuring the notes substrate and the
-`schedule.remind` inbox-delivery verb are both available before the schedule
-pack loads.
+The pack self-registers via `inventory::submit!`. It declares `REQUIRES = ["kg"]`,
+ensuring the notes substrate is available before the schedule pack loads.
+`schedule.remind` separately verifies that `comm.send` is registered before
+persisting a reminder; the other three schedule verbs do not require `comm`.
 
 ### ADR-025: Verb Speech Acts
 

--- a/crates/khive-pack-schedule/docs/design.md
+++ b/crates/khive-pack-schedule/docs/design.md
@@ -22,7 +22,7 @@ not performed by this pack in process. Two supported execution modes exist:
 - Name: `schedule`
 - Note kinds: `["scheduled_event"]`
 - Entity kinds: `[]`
-- Requires: `["kg"]`
+- Requires: `["kg", "comm"]`
 - Verbs: `schedule.remind`, `schedule.schedule`, `schedule.agenda`, `schedule.cancel`
 
 **Notes-as-scheduled-events.** A `scheduled_event` is a note stored with the
@@ -128,9 +128,10 @@ time when no observer is present.
 
 ### ADR-017: Pack Standard
 
-The pack self-registers via `inventory::submit!`. It declares `REQUIRES = ["kg"]`,
-ensuring the kg pack is loaded before this pack during boot-time dependency
-resolution.
+The pack self-registers via `inventory::submit!`. It declares
+`REQUIRES = ["kg", "comm"]`, ensuring the notes substrate and the
+`schedule.remind` inbox-delivery verb are both available before the schedule
+pack loads.
 
 ### ADR-025: Verb Speech Acts
 

--- a/crates/khive-pack-schedule/src/handlers.rs
+++ b/crates/khive-pack-schedule/src/handlers.rs
@@ -803,6 +803,7 @@ pub(crate) async fn handle_remind(
         "repeat": p.repeat,
         "status": "pending",
         "event_type": "remind",
+        "created_by_actor": token.actor().id.clone(),
         "payload": null,
         "fired_at": null,
         "cancelled_at": null,

--- a/crates/khive-pack-schedule/src/handlers.rs
+++ b/crates/khive-pack-schedule/src/handlers.rs
@@ -774,8 +774,16 @@ pub(crate) struct CancelParams {
 pub(crate) async fn handle_remind(
     runtime: &KhiveRuntime,
     token: &NamespaceToken,
+    registry: &VerbRegistry,
     params: Value,
 ) -> Result<Value, RuntimeError> {
+    if registry.describe_verb("comm.send").is_err() {
+        return Err(RuntimeError::InvalidInput(
+            "schedule.remind requires the comm delivery capability `comm.send`; load the `comm` pack"
+                .into(),
+        ));
+    }
+
     let p: RemindParams = deser(params)?;
     if p.content.trim().is_empty() {
         return Err(RuntimeError::InvalidInput(

--- a/crates/khive-pack-schedule/src/lib.rs
+++ b/crates/khive-pack-schedule/src/lib.rs
@@ -1,6 +1,8 @@
 //! Schedule pack — `schedule.remind`, `schedule.schedule`, `schedule.agenda`, `schedule.cancel`.
 //!
-//! All verbs operate on `scheduled_event` notes; trigger evaluation is the execution environment's responsibility.
+//! All verbs operate on `scheduled_event` notes. At fire time, the execution
+//! environment delivers reminders to the creating actor's inbox and dispatches
+//! scheduled actions.
 pub mod handlers;
 mod pack;
 mod tests;

--- a/crates/khive-pack-schedule/src/pack.rs
+++ b/crates/khive-pack-schedule/src/pack.rs
@@ -13,8 +13,8 @@ use crate::vocab::{SCHEDULE_HANDLERS, SCHEDULE_SCHEMA_PLAN_STMTS};
 /// Schedule pack — stores time-triggered reminders and verb dispatches.
 ///
 /// Intent storage only: the pack creates and queries `scheduled_event` notes.
-/// Trigger evaluation (reading pending events and dispatching their payloads)
-/// is the responsibility of the runtime or an external scheduler — not this pack.
+/// The execution environment delivers reminder content to the creating actor's
+/// inbox and dispatches scheduled payloads when their triggers become due.
 pub struct SchedulePack {
     runtime: KhiveRuntime,
 }

--- a/crates/khive-pack-schedule/src/pack.rs
+++ b/crates/khive-pack-schedule/src/pack.rs
@@ -24,7 +24,7 @@ impl Pack for SchedulePack {
     const NOTE_KINDS: &'static [&'static str] = &["scheduled_event"];
     const ENTITY_KINDS: &'static [&'static str] = &[];
     const HANDLERS: &'static [HandlerDef] = &SCHEDULE_HANDLERS;
-    const REQUIRES: &'static [&'static str] = &["kg"];
+    const REQUIRES: &'static [&'static str] = &["kg", "comm"];
 }
 
 impl SchedulePack {
@@ -46,7 +46,7 @@ impl khive_runtime::PackFactory for SchedulePackFactory {
     }
 
     fn requires(&self) -> &'static [&'static str] {
-        &["kg"]
+        <SchedulePack as Pack>::REQUIRES
     }
 
     fn create(&self, runtime: KhiveRuntime) -> Box<dyn khive_runtime::PackRuntime> {

--- a/crates/khive-pack-schedule/src/pack.rs
+++ b/crates/khive-pack-schedule/src/pack.rs
@@ -24,7 +24,7 @@ impl Pack for SchedulePack {
     const NOTE_KINDS: &'static [&'static str] = &["scheduled_event"];
     const ENTITY_KINDS: &'static [&'static str] = &[];
     const HANDLERS: &'static [HandlerDef] = &SCHEDULE_HANDLERS;
-    const REQUIRES: &'static [&'static str] = &["kg", "comm"];
+    const REQUIRES: &'static [&'static str] = &["kg"];
 }
 
 impl SchedulePack {
@@ -93,7 +93,9 @@ impl PackRuntime for SchedulePack {
         token: &NamespaceToken,
     ) -> Result<Value, RuntimeError> {
         match verb {
-            "schedule.remind" => handlers::handle_remind(self.runtime(), token, params).await,
+            "schedule.remind" => {
+                handlers::handle_remind(self.runtime(), token, registry, params).await
+            }
             "schedule.schedule" => {
                 handlers::handle_schedule(self.runtime(), token, registry, params).await
             }

--- a/crates/khive-pack-schedule/src/vocab.rs
+++ b/crates/khive-pack-schedule/src/vocab.rs
@@ -19,7 +19,7 @@ pub(crate) static SCHEDULE_SCHEMA_PLAN_STMTS: [&str; 1] =
 pub(crate) static SCHEDULE_HANDLERS: [HandlerDef; 4] = [
     HandlerDef {
         name: "schedule.remind",
-        description: "Create a time-triggered reminder.",
+        description: "Deliver a time-triggered reminder to the creating actor's inbox.",
         visibility: Visibility::Verb,
         category: khive_types::VerbCategory::Commissive,
         params: &[

--- a/crates/khive-pack-schedule/tests/agenda.rs
+++ b/crates/khive-pack-schedule/tests/agenda.rs
@@ -7,6 +7,7 @@ fn build_registry() -> (VerbRegistry, KhiveRuntime) {
     let runtime = KhiveRuntime::memory().expect("in-memory runtime");
     let mut builder = VerbRegistryBuilder::new();
     builder.register(khive_pack_kg::KgPack::new(runtime.clone()));
+    builder.register(khive_pack_comm::CommPack::new(runtime.clone()));
     builder.register(SchedulePack::new(runtime.clone()));
     let registry = builder.build().expect("registry builds");
     (registry, runtime)
@@ -194,6 +195,7 @@ async fn h2_agenda_finds_valid_event_past_corrupt_legacy_rows() {
     let runtime = KhiveRuntime::memory().expect("in-memory runtime");
     let mut builder = VerbRegistryBuilder::new();
     builder.register(khive_pack_kg::KgPack::new(runtime.clone()));
+    builder.register(khive_pack_comm::CommPack::new(runtime.clone()));
     builder.register(SchedulePack::new(runtime.clone()));
     let registry = builder.build().expect("registry builds");
 

--- a/crates/khive-pack-schedule/tests/cancel.rs
+++ b/crates/khive-pack-schedule/tests/cancel.rs
@@ -7,6 +7,7 @@ fn build_registry() -> (VerbRegistry, KhiveRuntime) {
     let runtime = KhiveRuntime::memory().expect("in-memory runtime");
     let mut builder = VerbRegistryBuilder::new();
     builder.register(khive_pack_kg::KgPack::new(runtime.clone()));
+    builder.register(khive_pack_comm::CommPack::new(runtime.clone()));
     builder.register(SchedulePack::new(runtime.clone()));
     let registry = builder.build().expect("registry builds");
     (registry, runtime)
@@ -105,6 +106,7 @@ async fn cancel_rejects_fired_event_without_clobbering_fired_at() {
     let runtime = KhiveRuntime::memory().expect("in-memory runtime");
     let mut builder = khive_runtime::VerbRegistryBuilder::new();
     builder.register(khive_pack_kg::KgPack::new(runtime.clone()));
+    builder.register(khive_pack_comm::CommPack::new(runtime.clone()));
     builder.register(SchedulePack::new(runtime.clone()));
     let registry = builder.build().expect("registry builds");
 
@@ -189,6 +191,7 @@ async fn cancel_rejects_non_pending_statuses() {
         let runtime = KhiveRuntime::memory().expect("in-memory runtime");
         let mut builder = khive_runtime::VerbRegistryBuilder::new();
         builder.register(khive_pack_kg::KgPack::new(runtime.clone()));
+        builder.register(khive_pack_comm::CommPack::new(runtime.clone()));
         builder.register(SchedulePack::new(runtime.clone()));
         let registry = builder.build().expect("registry builds");
 
@@ -257,6 +260,7 @@ async fn sch_aud_001_cancel_with_string_properties_returns_error() {
     let runtime = KhiveRuntime::memory().expect("in-memory runtime");
     let mut builder = khive_runtime::VerbRegistryBuilder::new();
     builder.register(khive_pack_kg::KgPack::new(runtime.clone()));
+    builder.register(khive_pack_comm::CommPack::new(runtime.clone()));
     builder.register(SchedulePack::new(runtime.clone()));
     let registry = builder.build().expect("registry builds");
 

--- a/crates/khive-pack-schedule/tests/create_validation.rs
+++ b/crates/khive-pack-schedule/tests/create_validation.rs
@@ -7,6 +7,7 @@ fn build_registry() -> (VerbRegistry, KhiveRuntime) {
     let runtime = KhiveRuntime::memory().expect("in-memory runtime");
     let mut builder = VerbRegistryBuilder::new();
     builder.register(khive_pack_kg::KgPack::new(runtime.clone()));
+    builder.register(khive_pack_comm::CommPack::new(runtime.clone()));
     builder.register(SchedulePack::new(runtime.clone()));
     let registry = builder.build().expect("registry builds");
     (registry, runtime)
@@ -16,6 +17,7 @@ fn build_registry_with_brain() -> (VerbRegistry, KhiveRuntime) {
     let runtime = KhiveRuntime::memory().expect("in-memory runtime");
     let mut builder = VerbRegistryBuilder::new();
     builder.register(khive_pack_kg::KgPack::new(runtime.clone()));
+    builder.register(khive_pack_comm::CommPack::new(runtime.clone()));
     builder.register(khive_pack_brain::BrainPack::new(runtime.clone()));
     builder.register(SchedulePack::new(runtime.clone()));
     let registry = builder.build().expect("registry builds");
@@ -48,6 +50,7 @@ async fn remind_persists_the_creating_actor_for_delivery() {
     let mut builder = VerbRegistryBuilder::new();
     builder.with_actor_id(Some("lambda:reminder-owner".to_string()));
     builder.register(khive_pack_kg::KgPack::new(runtime.clone()));
+    builder.register(khive_pack_comm::CommPack::new(runtime.clone()));
     builder.register(SchedulePack::new(runtime.clone()));
     let registry = builder.build().expect("registry builds");
 

--- a/crates/khive-pack-schedule/tests/create_validation.rs
+++ b/crates/khive-pack-schedule/tests/create_validation.rs
@@ -43,6 +43,50 @@ async fn remind_creates_pending_event() {
 }
 
 #[tokio::test]
+async fn remind_persists_the_creating_actor_for_delivery() {
+    let runtime = KhiveRuntime::memory().expect("in-memory runtime");
+    let mut builder = VerbRegistryBuilder::new();
+    builder.with_actor_id(Some("lambda:reminder-owner".to_string()));
+    builder.register(khive_pack_kg::KgPack::new(runtime.clone()));
+    builder.register(SchedulePack::new(runtime.clone()));
+    let registry = builder.build().expect("registry builds");
+
+    let result = registry
+        .dispatch(
+            "schedule.remind",
+            serde_json::json!({
+                "content": "check status",
+                "at": "2099-06-01T09:00:00Z"
+            }),
+        )
+        .await
+        .expect("remind succeeds");
+
+    let id = result["full_id"]
+        .as_str()
+        .expect("full_id present")
+        .parse()
+        .expect("full_id is a UUID");
+    let token = runtime
+        .authorize(khive_runtime::Namespace::local())
+        .expect("authorize");
+    let note = runtime
+        .notes(&token)
+        .expect("notes")
+        .get_note(id)
+        .await
+        .expect("read reminder")
+        .expect("reminder exists");
+
+    assert_eq!(
+        note.properties
+            .as_ref()
+            .and_then(|props| props["created_by_actor"].as_str()),
+        Some("lambda:reminder-owner")
+    );
+}
+
+#[tokio::test]
 async fn schedule_creates_pending_event_with_action() {
     let (registry, _rt) = build_registry();
 

--- a/crates/khive-pack-schedule/tests/integration.rs
+++ b/crates/khive-pack-schedule/tests/integration.rs
@@ -30,8 +30,8 @@ fn schedule_pack_declares_four_handlers() {
 }
 
 #[test]
-fn schedule_pack_requires_kg_and_comm() {
-    assert_eq!(SchedulePack::REQUIRES, &["kg", "comm"]);
+fn schedule_pack_requires_kg() {
+    assert_eq!(SchedulePack::REQUIRES, &["kg"]);
 }
 
 #[tokio::test]

--- a/crates/khive-pack-schedule/tests/integration.rs
+++ b/crates/khive-pack-schedule/tests/integration.rs
@@ -8,6 +8,7 @@ fn build_registry() -> (VerbRegistry, KhiveRuntime) {
     let runtime = KhiveRuntime::memory().expect("in-memory runtime");
     let mut builder = VerbRegistryBuilder::new();
     builder.register(khive_pack_kg::KgPack::new(runtime.clone()));
+    builder.register(khive_pack_comm::CommPack::new(runtime.clone()));
     builder.register(SchedulePack::new(runtime.clone()));
     let registry = builder.build().expect("registry builds");
     (registry, runtime)
@@ -29,8 +30,8 @@ fn schedule_pack_declares_four_handlers() {
 }
 
 #[test]
-fn schedule_pack_requires_kg() {
-    assert_eq!(SchedulePack::REQUIRES, &["kg"]);
+fn schedule_pack_requires_kg_and_comm() {
+    assert_eq!(SchedulePack::REQUIRES, &["kg", "comm"]);
 }
 
 #[tokio::test]
@@ -733,6 +734,7 @@ async fn h2_agenda_finds_valid_event_past_corrupt_legacy_rows() {
     let runtime = KhiveRuntime::memory().expect("in-memory runtime");
     let mut builder = VerbRegistryBuilder::new();
     builder.register(khive_pack_kg::KgPack::new(runtime.clone()));
+    builder.register(khive_pack_comm::CommPack::new(runtime.clone()));
     builder.register(SchedulePack::new(runtime.clone()));
     let registry = builder.build().expect("registry builds");
 
@@ -1034,6 +1036,7 @@ async fn sch_aud_001_cancel_with_string_properties_returns_error() {
     let runtime = KhiveRuntime::memory().expect("in-memory runtime");
     let mut builder = khive_runtime::VerbRegistryBuilder::new();
     builder.register(khive_pack_kg::KgPack::new(runtime.clone()));
+    builder.register(khive_pack_comm::CommPack::new(runtime.clone()));
     builder.register(SchedulePack::new(runtime.clone()));
     let registry = builder.build().expect("registry builds");
 

--- a/crates/khive-pack-schedule/tests/pack_registration.rs
+++ b/crates/khive-pack-schedule/tests/pack_registration.rs
@@ -20,8 +20,30 @@ fn schedule_pack_declares_four_handlers() {
 }
 
 #[test]
-fn schedule_pack_requires_kg() {
-    assert_eq!(SchedulePack::REQUIRES, &["kg"]);
+fn schedule_pack_requires_kg_and_comm() {
+    assert_eq!(SchedulePack::REQUIRES, &["kg", "comm"]);
+}
+
+#[test]
+fn schedule_pack_rejects_registry_without_comm() {
+    let runtime = KhiveRuntime::memory().expect("in-memory runtime");
+    let mut builder = VerbRegistryBuilder::new();
+    builder.register(khive_pack_kg::KgPack::new(runtime.clone()));
+    builder.register(SchedulePack::new(runtime));
+
+    let err = match builder.build() {
+        Ok(_) => panic!("kg + schedule must not build without comm"),
+        Err(err) => err,
+    };
+    let message = err.to_string();
+    assert!(
+        message.contains("schedule"),
+        "error must name schedule: {message}"
+    );
+    assert!(
+        message.contains("comm"),
+        "error must name missing comm: {message}"
+    );
 }
 
 #[tokio::test]
@@ -61,6 +83,7 @@ async fn verb_registry_aggregates_schedule_schema_plan() {
     let runtime = KhiveRuntime::memory().expect("in-memory runtime");
     let mut builder = VerbRegistryBuilder::new();
     builder.register(khive_pack_kg::KgPack::new(runtime.clone()));
+    builder.register(khive_pack_comm::CommPack::new(runtime.clone()));
     builder.register(SchedulePack::new(runtime.clone()));
     let registry = builder.build().expect("registry builds");
 

--- a/crates/khive-pack-schedule/tests/pack_registration.rs
+++ b/crates/khive-pack-schedule/tests/pack_registration.rs
@@ -20,30 +20,17 @@ fn schedule_pack_declares_four_handlers() {
 }
 
 #[test]
-fn schedule_pack_requires_kg_and_comm() {
-    assert_eq!(SchedulePack::REQUIRES, &["kg", "comm"]);
+fn schedule_pack_requires_kg() {
+    assert_eq!(SchedulePack::REQUIRES, &["kg"]);
 }
 
 #[test]
-fn schedule_pack_rejects_registry_without_comm() {
+fn schedule_pack_builds_registry_without_comm() {
     let runtime = KhiveRuntime::memory().expect("in-memory runtime");
     let mut builder = VerbRegistryBuilder::new();
     builder.register(khive_pack_kg::KgPack::new(runtime.clone()));
     builder.register(SchedulePack::new(runtime));
-
-    let err = match builder.build() {
-        Ok(_) => panic!("kg + schedule must not build without comm"),
-        Err(err) => err,
-    };
-    let message = err.to_string();
-    assert!(
-        message.contains("schedule"),
-        "error must name schedule: {message}"
-    );
-    assert!(
-        message.contains("comm"),
-        "error must name missing comm: {message}"
-    );
+    builder.build().expect("kg + schedule registry builds");
 }
 
 #[tokio::test]
@@ -83,7 +70,6 @@ async fn verb_registry_aggregates_schedule_schema_plan() {
     let runtime = KhiveRuntime::memory().expect("in-memory runtime");
     let mut builder = VerbRegistryBuilder::new();
     builder.register(khive_pack_kg::KgPack::new(runtime.clone()));
-    builder.register(khive_pack_comm::CommPack::new(runtime.clone()));
     builder.register(SchedulePack::new(runtime.clone()));
     let registry = builder.build().expect("registry builds");
 

--- a/docs/adr/ADR-027-dynamic-pack-loading.md
+++ b/docs/adr/ADR-027-dynamic-pack-loading.md
@@ -193,7 +193,7 @@ kg:     REQUIRES []           → loads first
 gtd:    REQUIRES ["kg"]       → loads after kg
 memory: REQUIRES ["kg"]       → loads after kg
 brain:  REQUIRES ["memory"]   → loads after memory
-schedule: REQUIRES ["kg", "comm"] → loads after kg and comm
+schedule: REQUIRES ["kg"]     → loads after kg (remind checks comm.send per verb)
 ```
 
 `khive-fold` (ADR-024) and `khive-retrieval` (ADR-030) are foundation/runtime crates,

--- a/docs/adr/ADR-027-dynamic-pack-loading.md
+++ b/docs/adr/ADR-027-dynamic-pack-loading.md
@@ -193,7 +193,7 @@ kg:     REQUIRES []           → loads first
 gtd:    REQUIRES ["kg"]       → loads after kg
 memory: REQUIRES ["kg"]       → loads after kg
 brain:  REQUIRES ["memory"]   → loads after memory
-schedule: REQUIRES ["kg"]     → loads after kg (parallel with gtd, memory)
+schedule: REQUIRES ["kg", "comm"] → loads after kg and comm
 ```
 
 `khive-fold` (ADR-024) and `khive-retrieval` (ADR-030) are foundation/runtime crates,

--- a/docs/adr/ADR-040-communication-and-schedule-packs.md
+++ b/docs/adr/ADR-040-communication-and-schedule-packs.md
@@ -257,7 +257,7 @@ impl Pack for SchedulePack {
     ];
     // ADR-023 §4: pack-prefixed verb names — `schedule.remind` / `schedule.schedule` / `schedule.agenda` / `schedule.cancel`
     const EDGE_RULES:   &'static [EdgeEndpointRule] = &[];
-    const REQUIRES:     &'static [&'static str] = &["kg"];
+    const REQUIRES:     &'static [&'static str] = &["kg", "comm"];
 }
 ```
 
@@ -371,9 +371,11 @@ Both packs compose with the existing pack set:
 auto-transitions a task to active at the scheduled time. No coupling at the pack level —
 the interaction is at the `action` payload level.
 
-**Schedule + Comm**: a scheduled message is a `scheduled_event` with
+**Schedule + Comm**: `schedule` declares `comm` as a pack dependency because
+`schedule.remind` always delivers through `comm.send`. A scheduled message is a
+`scheduled_event` with
 `action="comm.send(to='agent:ops', content='weekly status update')"`. At trigger time the
-execution environment dispatches the `comm.send` verb. No coupling at the pack level.
+execution environment dispatches the `comm.send` verb.
 
 **Comm + KG**: messages attach to KG entities via `link(message_id, entity_id, annotates)`.
 The `annotates` relation from ADR-002 accepts any note → any substrate; no new edge endpoint
@@ -395,20 +397,22 @@ inventory::submit!(Box::new(CommPack::default()) as Box<dyn Pack>);
 inventory::submit!(Box::new(SchedulePack::default()) as Box<dyn Pack>);
 ```
 
-Both declare `REQUIRES = ["kg"]` — the kg pack must be loaded first (ADR-017 boot-time
-dependency check). Both use `default_backend = "main"` — no separate backend.
+`comm` declares `REQUIRES = ["kg"]`; `schedule` declares
+`REQUIRES = ["kg", "comm"]` so a reminder can never be accepted without its
+inbox-delivery verb. The ADR-017 boot-time dependency check enforces both requirements.
+Both use `default_backend = "main"` — no separate backend.
 
 Loading is opt-in via `RuntimeConfig::packs`:
 
 ```bash
 KHIVE_PACKS=kg,comm          kkernel mcp   # communication only
-KHIVE_PACKS=kg,schedule      kkernel mcp   # scheduling only
+KHIVE_PACKS=kg,comm,schedule kkernel mcp   # scheduling + reminder delivery
 KHIVE_PACKS=kg,gtd,comm,schedule kkernel mcp   # full stack
 ```
 
-ADR-016's dynamic verb catalog reflects exactly what is loaded; agents that do not load
-`comm` see no `send`/`inbox`/`read`/`reply`/`thread` verbs, and agents that do not load
-`schedule` see no `remind`/`schedule`/`agenda`/`cancel` verbs.
+ADR-016's dynamic verb catalog reflects exactly what is loaded. Agents that do not load
+`schedule` see no `remind`/`schedule`/`agenda`/`cancel` verbs; loading `schedule`
+without `comm` is rejected at boot.
 
 ## Rationale
 

--- a/docs/adr/ADR-040-communication-and-schedule-packs.md
+++ b/docs/adr/ADR-040-communication-and-schedule-packs.md
@@ -257,7 +257,7 @@ impl Pack for SchedulePack {
     ];
     // ADR-023 §4: pack-prefixed verb names — `schedule.remind` / `schedule.schedule` / `schedule.agenda` / `schedule.cancel`
     const EDGE_RULES:   &'static [EdgeEndpointRule] = &[];
-    const REQUIRES:     &'static [&'static str] = &["kg", "comm"];
+    const REQUIRES:     &'static [&'static str] = &["kg"];
 }
 ```
 
@@ -371,9 +371,10 @@ Both packs compose with the existing pack set:
 auto-transitions a task to active at the scheduled time. No coupling at the pack level —
 the interaction is at the `action` payload level.
 
-**Schedule + Comm**: `schedule` declares `comm` as a pack dependency because
-`schedule.remind` always delivers through `comm.send`. A scheduled message is a
-`scheduled_event` with
+**Schedule + Comm**: `schedule.remind` requires `comm.send` at creation time because
+reminders deliver through the comm inbox path. If that capability is not registered,
+the handler rejects the call before persisting a note; the rest of the schedule pack
+remains available. A scheduled message is a `scheduled_event` with
 `action="comm.send(to='agent:ops', content='weekly status update')"`. At trigger time the
 execution environment dispatches the `comm.send` verb.
 
@@ -397,22 +398,24 @@ inventory::submit!(Box::new(CommPack::default()) as Box<dyn Pack>);
 inventory::submit!(Box::new(SchedulePack::default()) as Box<dyn Pack>);
 ```
 
-`comm` declares `REQUIRES = ["kg"]`; `schedule` declares
-`REQUIRES = ["kg", "comm"]` so a reminder can never be accepted without its
-inbox-delivery verb. The ADR-017 boot-time dependency check enforces both requirements.
-Both use `default_backend = "main"` — no separate backend.
+Both packs declare `REQUIRES = ["kg"]`, and the ADR-017 boot-time dependency check
+enforces that shared substrate requirement. `schedule.remind` separately checks for
+the registered `comm.send` delivery capability at creation time and rejects before
+writing when it is absent. Both use `default_backend = "main"` — no separate backend.
 
 Loading is opt-in via `RuntimeConfig::packs`:
 
 ```bash
 KHIVE_PACKS=kg,comm          kkernel mcp   # communication only
-KHIVE_PACKS=kg,comm,schedule kkernel mcp   # scheduling + reminder delivery
+KHIVE_PACKS=kg,schedule      kkernel mcp   # scheduling without reminder creation
+KHIVE_PACKS=kg,comm,schedule kkernel mcp   # scheduling with reminder creation
 KHIVE_PACKS=kg,gtd,comm,schedule kkernel mcp   # full stack
 ```
 
 ADR-016's dynamic verb catalog reflects exactly what is loaded. Agents that do not load
-`schedule` see no `remind`/`schedule`/`agenda`/`cancel` verbs; loading `schedule`
-without `comm` is rejected at boot.
+`schedule` see no `remind`/`schedule`/`agenda`/`cancel` verbs. Loading `schedule`
+without `comm` leaves all four verbs registered, but `schedule.remind` rejects at creation
+before persistence until `comm.send` is available.
 
 ## Rationale
 

--- a/docs/adr/ADR-106-schedule-pack-executor.md
+++ b/docs/adr/ADR-106-schedule-pack-executor.md
@@ -791,8 +791,9 @@ one-shot becomes `fired`; a named repeat is re-armed), preventing an indefinitel
 retrying permanently broken delivery. A later successful occurrence clears stale
 `delivery_error` and `delivery_failed_at` properties.
 
-Because reminder delivery is part of the public `schedule.remind` contract, the
-schedule pack declares `REQUIRES = ["kg", "comm"]`. A pack selection that includes
-`schedule` without `comm` is rejected during boot, before a reminder can be persisted.
-The per-event failure behavior above therefore covers dispatch failures after a valid
-registry has loaded, not a permanently missing delivery verb.
+Because reminder delivery is part of the public `schedule.remind` contract, reminder
+creation checks that the registry provides `comm.send`. If it does not, the handler
+rejects the call before persisting a note. The schedule pack itself still declares only
+`REQUIRES = ["kg"]`, so `schedule.schedule`, `schedule.agenda`, and `schedule.cancel`
+remain available without `comm`. The per-event failure behavior above covers dispatch
+failures after a reminder has passed that creation-time capability check.

--- a/docs/adr/ADR-106-schedule-pack-executor.md
+++ b/docs/adr/ADR-106-schedule-pack-executor.md
@@ -2,7 +2,8 @@
 
 **Status**: Accepted
 **Date**: 2026-07-09
-**Amended**: 2026-07-09 (missed-event grace policy, Amendment A; implementation note, Amendment B)
+**Amended**: 2026-07-12 (missed-event grace policy, Amendment A; implementation note,
+Amendment B; reminder delivery and failure observability, Amendment C)
 **Depends on**: [ADR-040](ADR-040-communication-and-schedule-packs.md) (schedule pack
 verbs and `scheduled_event` note kind), [ADR-049](ADR-049-khived-daemon.md) (warm daemon
 process model), [ADR-016](ADR-016-request-dsl.md) (request DSL, replayed at fire time)
@@ -411,19 +412,11 @@ unaffected by this ADR.
 
 ## Explicitly Deferred
 
-The following are real, identified gaps in the schedule pack's execution story but are
-out of scope for this ADR, which is limited to wiring the existing drain into a
-daemon-resident tick:
+Reminder delivery and structured reminder-failure observability were implemented as
+follow-on work and are now part of the accepted contract; see Amendment C.
 
-- **Delivery of fired `schedule.remind` events.** The drain's own dispatch logic
-  treats `event_type != "schedule"` as a no-op today: a fired reminder is marked
-  `fired` but nothing reads its content or delivers it anywhere. Building an
-  owner/actor attribution field on `scheduled_event` and wiring fired reminders to an
-  inbound delivery path is separate follow-on work.
-- **Structured per-row failure reason.** A dispatch failure is currently visible only
-  in the drain's own aggregate summary counter and verbose logging output; the
-  `scheduled_event` note itself carries no persisted failure detail. Adding a
-  dispatch-error property to the row is separate follow-on work.
+The following identified gaps remain out of scope for this ADR:
+
 - **`agenda()` visibility into non-pending state.** `schedule.agenda` filters to
   `status = "pending"` only and does not distinguish an overdue-but-undrained row from
   a genuinely future one. Extending `agenda` (or adding a history-style query) is
@@ -775,3 +768,25 @@ trait seam with tracked, graceful shutdown and `DrainSummary`/`DrainError` owned
 `khive-runtime` — remains open follow-on work, tracked separately from the missed-event
 policy (Amendment A) and the runtime-targeting/cadence/pagination fixes (this fix-round)
 this ADR has delivered so far.
+
+## Amendment C: Reminder delivery and failure observability (2026-07-12)
+
+`schedule.remind` persists the creating actor's identity in the scheduled-event row as
+`created_by_actor`. When an in-grace reminder fires, the drain reads that stored value
+and dispatches `comm.send(to=<created_by_actor>, ...)`, producing an inbound message in
+the creator's actor-addressed inbox. Delivery therefore remains attributed to the
+creator across daemon restarts and changes in the daemon's own actor identity. Rows
+created before `created_by_actor` existed are the only exception: the drain logs a
+warning and falls back to the current server actor, then to `local` when the server has
+no configured actor.
+
+A reminder-delivery failure is observable through the drain and persisted state. The
+drain logs the error, increments `DrainSummary.failed`, and persists `delivery_error` plus
+`delivery_failed_at` on the `scheduled_event` row. It also appends an error-outcome
+audit event with verb `schedule.remind.fire`, the scheduled-event note as its target,
+and the intended recipient actor and error text in its payload. Failure remains
+per-event: it does not abort the drain or prevent later due rows from dispatching in
+the same pass. The failed reminder is still finalized according to its cadence (a
+one-shot becomes `fired`; a named repeat is re-armed), preventing an indefinitely
+retrying permanently broken delivery. A later successful occurrence clears stale
+`delivery_error` and `delivery_failed_at` properties.

--- a/docs/adr/ADR-106-schedule-pack-executor.md
+++ b/docs/adr/ADR-106-schedule-pack-executor.md
@@ -790,3 +790,9 @@ the same pass. The failed reminder is still finalized according to its cadence (
 one-shot becomes `fired`; a named repeat is re-armed), preventing an indefinitely
 retrying permanently broken delivery. A later successful occurrence clears stale
 `delivery_error` and `delivery_failed_at` properties.
+
+Because reminder delivery is part of the public `schedule.remind` contract, the
+schedule pack declares `REQUIRES = ["kg", "comm"]`. A pack selection that includes
+`schedule` without `comm` is rejected during boot, before a reminder can be persisted.
+The per-event failure behavior above therefore covers dispatch failures after a valid
+registry has loaded, not a permanently missing delivery verb.

--- a/docs/guide/api-reference.md
+++ b/docs/guide/api-reference.md
@@ -26,7 +26,7 @@ An always-machine-readable copy of this page is at
 | `memory`    | 5     | `KHIVE_PACKS=kg,memory`                    | Yes                 |
 | `brain`     | 15    | `KHIVE_PACKS=kg,brain`                     | Yes                 |
 | `comm`      | 7     | `KHIVE_PACKS=kg,comm`                      | Yes                 |
-| `schedule`  | 4     | `KHIVE_PACKS=kg,schedule`                  | Yes                 |
+| `schedule`  | 4     | `KHIVE_PACKS=kg,comm,schedule`             | Yes                 |
 | `knowledge` | 19    | `KHIVE_PACKS=kg,knowledge`                 | Yes                 |
 | `session`   | 4     | `KHIVE_PACKS=kg,session`                   | Yes                 |
 | `git`       | 1     | `KHIVE_PACKS=kg,git`                       | Yes                 |
@@ -38,6 +38,9 @@ An always-machine-readable copy of this page is at
 `kkernel git-ingest` CLI drive.
 
 `workspace` requires `kg`, `git`, `gtd`, and `session` to be loaded alongside it (the runtime rejects a pack set that omits a declared dependency), so its minimal example lists all four.
+
+`schedule` requires both `kg` and `comm`; the runtime rejects a schedule pack set
+without `comm` so accepted reminders always have an inbox-delivery path.
 
 `code` registers the `finding` note kind and edge rules only; its `code.ingest` verb is
 accepted but unimplemented (ADR-085), and `findings.json` ingest runs through the
@@ -1003,7 +1006,7 @@ request(ops="comm.health()")
 ## `schedule` pack — 4 verbs
 
 Time-triggered reminders and deferred verb dispatch. Optional; load with
-`KHIVE_PACKS=kg,schedule`.
+`KHIVE_PACKS=kg,comm,schedule`.
 
 ### `schedule.remind` — Commissive
 

--- a/docs/guide/api-reference.md
+++ b/docs/guide/api-reference.md
@@ -26,7 +26,7 @@ An always-machine-readable copy of this page is at
 | `memory`    | 5     | `KHIVE_PACKS=kg,memory`                    | Yes                 |
 | `brain`     | 15    | `KHIVE_PACKS=kg,brain`                     | Yes                 |
 | `comm`      | 7     | `KHIVE_PACKS=kg,comm`                      | Yes                 |
-| `schedule`  | 4     | `KHIVE_PACKS=kg,comm,schedule`             | Yes                 |
+| `schedule`  | 4     | `KHIVE_PACKS=kg,schedule`                  | Yes                 |
 | `knowledge` | 19    | `KHIVE_PACKS=kg,knowledge`                 | Yes                 |
 | `session`   | 4     | `KHIVE_PACKS=kg,session`                   | Yes                 |
 | `git`       | 1     | `KHIVE_PACKS=kg,git`                       | Yes                 |
@@ -39,8 +39,9 @@ An always-machine-readable copy of this page is at
 
 `workspace` requires `kg`, `git`, `gtd`, and `session` to be loaded alongside it (the runtime rejects a pack set that omits a declared dependency), so its minimal example lists all four.
 
-`schedule` requires both `kg` and `comm`; the runtime rejects a schedule pack set
-without `comm` so accepted reminders always have an inbox-delivery path.
+`schedule` requires `kg`. `schedule.remind` additionally requires `comm.send` at
+creation time and persists nothing when that delivery capability is absent; the other
+three schedule verbs remain available without `comm`.
 
 `code` registers the `finding` note kind and edge rules only; its `code.ingest` verb is
 accepted but unimplemented (ADR-085), and `findings.json` ingest runs through the
@@ -1006,7 +1007,7 @@ request(ops="comm.health()")
 ## `schedule` pack — 4 verbs
 
 Time-triggered reminders and deferred verb dispatch. Optional; load with
-`KHIVE_PACKS=kg,comm,schedule`.
+`KHIVE_PACKS=kg,schedule`. Add `comm` to create reminders.
 
 ### `schedule.remind` — Commissive
 

--- a/tests/smoke_schedule.py
+++ b/tests/smoke_schedule.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """Smoke + behavioural tests for the khive-mcp schedule pack over stdio MCP.
 
-Spawns the binary with an in-memory DB, --pack kg --pack schedule, sends
+Spawns the binary with an in-memory DB, --pack kg --pack comm --pack schedule, sends
 JSON-RPC requests, and verifies all four verbs (schedule.remind,
 schedule.schedule, schedule.agenda, schedule.cancel) across happy paths
 and error cases.
@@ -104,11 +104,11 @@ def call_verb_expect_error(proc, name, args):
 
 
 def spawn_proc():
-    """Spawn a fresh khive-mcp process with kg + schedule packs."""
+    """Spawn a fresh khive-mcp process with kg + comm + schedule packs."""
     return subprocess.Popen(
         [
             BINARY, "mcp", "--db", ":memory:", "--no-embed", "--log", "error",
-            "--pack", "kg", "--pack", "schedule",
+            "--pack", "kg", "--pack", "comm", "--pack", "schedule",
         ],
         stdin=subprocess.PIPE,
         stdout=subprocess.PIPE,

--- a/tests/smoke_test.py
+++ b/tests/smoke_test.py
@@ -1179,7 +1179,7 @@ def schedule_smoke():
 
     schedule.remind requires the registered comm.send delivery capability at
     creation time (khive-pack-schedule/README.md "Usage"; khive-pack-comm/README.md
-    "Architecture"): the schedule pack itself only requires kg, but remind
+    "Where this sits"): the schedule pack itself only requires kg, but remind
     specifically fails fast without comm loaded. Verify both sides of that
     contract -- the loud rejection with kg+schedule only, and the happy path
     with kg+comm+schedule.


### PR DESCRIPTION
Closes #884.

schedule.remind fires previously produced no visible delivery. Fired reminders now deliver a message to the creating actor's inbox (option (a) per triage), repeats deliver on every fire, and delivery failure is loud. Docs updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)