### PR TITLE
fix(release): topological publish order + path-only cyclic dev-deps

### DIFF
--- a/crates/khive-pack-brain/Cargo.toml
+++ b/crates/khive-pack-brain/Cargo.toml
@@ -51,7 +51,8 @@ khive-pack-kg = { version = "0.4.0", path = "../khive-pack-kg" }
 # (issue #459 regression). khive-pack-memory already carries khive-pack-brain
 # as a dev-dependency for its own tests; Cargo permits cyclic dev-dependencies
 # since neither crate's normal (non-dev) dependency graph is affected.
-khive-pack-memory = { version = "0.4.0", path = "../khive-pack-memory" }
+# Path-only: cyclic dev-dep pair with khive-pack-memory; cargo strips it at publish.
+khive-pack-memory = { path = "../khive-pack-memory" }
 criterion = { workspace = true }
 tempfile = { workspace = true }
 serial_test = { workspace = true }

--- a/crates/khive-pack-kg/Cargo.toml
+++ b/crates/khive-pack-kg/Cargo.toml
@@ -32,7 +32,8 @@ tokio = { workspace = true, features = ["test-util"] }
 criterion = { workspace = true }
 serde_json = { workspace = true }
 khive-pack-formal = { version = "0.4.0", path = "../khive-pack-formal" }
-khive-pack-gtd = { version = "0.4.0", path = "../khive-pack-gtd" }
+# Path-only: cyclic dev-dep pair with khive-pack-gtd; cargo strips it at publish.
+khive-pack-gtd = { path = "../khive-pack-gtd" }
 
 [[test]]
 name = "integration"

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -48,9 +48,9 @@ CRATES=(
     khive-quant
     khive-vamana
     khive-fold
-    khive-text
     khive-storage
     khive-bm25
+    khive-text          # dev-dep on khive-bm25 (versioned), so publish after it
     khive-fusion
     khive-db
     khive-hnsw


### PR DESCRIPTION
Unblocks the 0.4.0 crates.io publish.

Live publish failed at khive-text (dev-dep khive-bm25 ^0.4.0 not yet published at its slot). Full topological validation found two additional violations that reordering cannot fix: cyclic versioned dev-dep pairs khive-pack-kg/khive-pack-gtd and khive-pack-brain/khive-pack-memory.

Changes:
- scripts/publish.sh: khive-text moved after khive-bm25.
- khive-pack-kg, khive-pack-brain: the forward edge of each cyclic dev-dep pair is now path-only; cargo strips path-only dev-dependencies at packaging (standard cyclic dev-dep resolution). Workspace tests unaffected.

Validation: topological re-check of all 38 publish-list crates against cargo metadata (path-only dev-deps excluded) reports zero violations. Crates already published at 0.4.0 (types, score, quant, vamana, fold) are skipped by the existing already-on-crates.io guard on re-run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)