### PR TITLE
fix(pack-git): apply masking uniformly to all external-origin ingest fields

### DIFF
--- a/crates/khive-pack-git/src/ingest.rs
+++ b/crates/khive-pack-git/src/ingest.rs
@@ -891,6 +891,60 @@ fn truncated_embedding_head(content: &str) -> Option<&str> {
     Some(&content[..end])
 }
 
+/// Every `RawCommit` string field funnels through this constructor before it
+/// can reach `properties` or the note `name`. `new` destructures `RawCommit`
+/// exhaustively (no `..`), so a future new field on `RawCommit` forces a
+/// compile error here before it can silently skip this boundary -- the same
+/// discipline `MaskedIssueFields` (below) already applies to `GhIssue`
+/// (issue #841, mirroring the #835 review's fix direction: "one sanitization
+/// boundary that masks every externally controlled string before
+/// constructing properties, so omissions are structurally hard").
+///
+/// `sha`/`short_sha`/`committed_at`/`parents` are git-computed hashes and an
+/// RFC3339 timestamp -- not attacker-authored free text -- so they pass
+/// through unchanged, matching how `MaskedIssueFields` leaves its own
+/// timestamp fields to a separate canonicalization step rather than masking
+/// them. `author`, `author_email`, `subject`, and `body` are git-config- and
+/// commit-message-controlled prose and go through the same `mask_secrets`
+/// gate `content` already used -- closing the gap where the commit note
+/// `name` (built from the raw subject) and its `author`/`author_email`
+/// properties skipped masking entirely.
+struct MaskedCommitFields {
+    sha: String,
+    short_sha: String,
+    author: String,
+    author_email: String,
+    committed_at: String,
+    parents: Vec<String>,
+    subject: String,
+    body: String,
+}
+
+impl MaskedCommitFields {
+    fn new(commit: &RawCommit) -> Self {
+        let RawCommit {
+            sha,
+            short_sha,
+            author,
+            author_email,
+            committed_at,
+            parents,
+            subject,
+            body,
+        } = commit;
+        Self {
+            sha: sha.clone(),
+            short_sha: short_sha.clone(),
+            author: secret_gate::mask_secrets(author).into_owned(),
+            author_email: secret_gate::mask_secrets(author_email).into_owned(),
+            committed_at: committed_at.clone(),
+            parents: parents.clone(),
+            subject: secret_gate::mask_secrets(subject).into_owned(),
+            body: secret_gate::mask_secrets(body).into_owned(),
+        }
+    }
+}
+
 #[allow(clippy::too_many_arguments)]
 async fn ingest_commits(
     runtime: &KhiveRuntime,
@@ -948,12 +1002,12 @@ async fn ingest_commits(
             break;
         }
 
-        let raw_content = if c.body.trim().is_empty() {
-            c.subject.clone()
+        let masked = MaskedCommitFields::new(c);
+        let content = if masked.body.trim().is_empty() {
+            masked.subject.clone()
         } else {
-            format!("{}\n\n{}", c.subject, c.body)
+            format!("{}\n\n{}", masked.subject, masked.body)
         };
-        let content = secret_gate::mask_secrets(&raw_content).into_owned();
 
         let mut annotates = vec![project_id.to_string()];
 
@@ -988,15 +1042,18 @@ async fn ingest_commits(
         }
 
         let properties = json!({
-            "sha": c.sha,
-            "short_sha": c.short_sha,
-            "author": c.author,
-            "author_email": c.author_email,
-            "committed_at": c.committed_at,
-            "parents": c.parents,
+            "sha": masked.sha,
+            "short_sha": masked.short_sha,
+            "author": masked.author,
+            "author_email": masked.author_email,
+            "committed_at": masked.committed_at,
+            "parents": masked.parents,
         });
 
-        let name = refs::truncate_chars(&format!("{} {}", c.short_sha, c.subject), NAME_MAX_CHARS);
+        let name = refs::truncate_chars(
+            &format!("{} {}", masked.short_sha, masked.subject),
+            NAME_MAX_CHARS,
+        );
         let embedding_head = truncated_embedding_head(&content);
 
         let mut create_request = json!({
@@ -1383,6 +1440,70 @@ fn fetch_issue_page(repo: &Path, floor: Option<&str>) -> Result<Vec<GhIssue>> {
     serde_json::from_str(&raw).context("parsing gh issue list --json")
 }
 
+/// Every `GhPr` field funnels through this constructor before it can reach
+/// `properties`/`content`/the note `name`/the in-memory PR-linking maps.
+/// `new` consumes `GhPr` by value and destructures it exhaustively (no
+/// `..`), so the original `pr` binding no longer exists after the call and a
+/// future new `GhPr` field forces a compile error here before it can
+/// silently skip this boundary -- the same discipline `MaskedIssueFields`
+/// applies to `GhIssue` (issue #841: PR author, base ref, and head ref were
+/// the residual raw fields after #835's title fix; mirrors the #835 review's
+/// fix direction of one sanitization boundary per record type).
+///
+/// `number`, `created_at`/`merged_at`/`closed_at`/`updated_at`, and
+/// `merge_commit`'s `oid` are GitHub-generated (not attacker-authored free
+/// text) and pass through unchanged, matching how `MaskedIssueFields`
+/// leaves its own timestamp fields to canonicalization rather than masking.
+/// `title`, `body`, the author login, and both ref names are
+/// contributor-controlled prose and go through the same `mask_secrets` gate
+/// `content`/`title` already used for PRs.
+struct MaskedPrFields {
+    number: u64,
+    title: String,
+    body: String,
+    author_login: Option<String>,
+    created_at: Option<String>,
+    merged_at: Option<String>,
+    closed_at: Option<String>,
+    updated_at: Option<String>,
+    base_ref_name: Option<String>,
+    head_ref_name: Option<String>,
+    merge_commit_oid: Option<String>,
+}
+
+impl MaskedPrFields {
+    fn new(pr: GhPr) -> Self {
+        let GhPr {
+            number,
+            title,
+            author,
+            created_at,
+            merged_at,
+            closed_at,
+            updated_at,
+            base_ref_name,
+            head_ref_name,
+            merge_commit,
+            body,
+        } = pr;
+        Self {
+            number,
+            title: secret_gate::mask_secrets(&title).into_owned(),
+            body: secret_gate::mask_secrets(&body.unwrap_or_default()).into_owned(),
+            author_login: author
+                .and_then(|a| a.login)
+                .map(|login| secret_gate::mask_secrets(&login).into_owned()),
+            created_at,
+            merged_at,
+            closed_at,
+            updated_at,
+            base_ref_name: base_ref_name.map(|r| secret_gate::mask_secrets(&r).into_owned()),
+            head_ref_name: head_ref_name.map(|r| secret_gate::mask_secrets(&r).into_owned()),
+            merge_commit_oid: merge_commit.and_then(|m| m.oid),
+        }
+    }
+}
+
 #[allow(clippy::too_many_arguments)]
 async fn ingest_prs(
     runtime: &KhiveRuntime,
@@ -1457,22 +1578,23 @@ async fn ingest_prs(
                 break;
             }
 
-            let raw_body = pr.body.unwrap_or_default();
-            let content = secret_gate::mask_secrets(&raw_body).into_owned();
-            let safe_title = secret_gate::mask_secrets(&pr.title).into_owned();
+            let masked = MaskedPrFields::new(pr);
+            let content = masked.body;
             let properties = json!({
-                "number": pr.number,
-                "title": safe_title,
-                "author": pr.author.and_then(|a| a.login),
-                "created_at": pr.created_at,
-                "merged_at": pr.merged_at,
-                "closed_at": pr.closed_at,
-                "base_ref": pr.base_ref_name,
-                "head_ref": pr.head_ref_name,
+                "number": masked.number,
+                "title": masked.title,
+                "author": masked.author_login,
+                "created_at": masked.created_at,
+                "merged_at": masked.merged_at,
+                "closed_at": masked.closed_at,
+                "base_ref": masked.base_ref_name,
+                "head_ref": masked.head_ref_name,
                 "project_id": project_id.to_string(),
             });
-            let name =
-                refs::truncate_chars(&format!("#{} {}", pr.number, safe_title), NAME_MAX_CHARS);
+            let name = refs::truncate_chars(
+                &format!("#{} {}", masked.number, masked.title),
+                NAME_MAX_CHARS,
+            );
 
             budget.try_consume();
             let result = match registry
@@ -1492,7 +1614,7 @@ async fn ingest_prs(
                 Err(e) => {
                     report
                         .warnings
-                        .push(format!("create pull_request #{}: {e}", pr.number));
+                        .push(format!("create pull_request #{}: {e}", masked.number));
                     cursor_stalled = true;
                     continue;
                 }
@@ -1503,8 +1625,8 @@ async fn ingest_prs(
                 .and_then(|v| v.as_str())
                 .and_then(|s| Uuid::parse_str(s).ok())
             {
-                number_to_pr.insert(pr.number, id);
-                if let Some(oid) = pr.merge_commit.and_then(|m| m.oid) {
+                number_to_pr.insert(masked.number, id);
+                if let Some(oid) = masked.merge_commit_oid {
                     merge_sha_to_pr.insert(oid, id);
                 }
                 new_records.push(NewRecordForRef {
@@ -1514,7 +1636,7 @@ async fn ingest_prs(
             }
             report.prs_ingested += 1;
             if !cursor_stalled {
-                if let Some(u) = &pr.updated_at {
+                if let Some(u) = &masked.updated_at {
                     if max_updated
                         .as_deref()
                         .map(|m| u.as_str() > m)

--- a/crates/khive-pack-git/tests/acceptance.rs
+++ b/crates/khive-pack-git/tests/acceptance.rs
@@ -3847,3 +3847,596 @@ async fn ingest_resolves_over_cap_commit_reference_beyond_the_embedding_cap() {
     assert_eq!(hits.len(), 1, "{hits:?}");
     assert_eq!(hits[0]["kind"], "commit");
 }
+
+// ── Issue #841: residual unmasked ingest fields ─────────────────────────────
+//
+// Follow-up from PR #835's review: `ingest_masks_secrets_in_commit_message`
+// and the PR-title/body tests above already cover `content`/`title`
+// masking. These tests cover the fields #841 found still passed raw into
+// gated `properties`/the note `name`: the commit note `name` (built from the
+// raw subject), commit `author`/`author_email`, and PR `author`/`base_ref`/
+// `head_ref`. Each fix pairs a credential-shaped positive (record must not
+// be dropped, field must be masked) with a clean-input regression guard
+// (field must survive byte-for-byte unchanged).
+
+/// The commit note `name` was built from the raw (unmasked) commit subject
+/// even though `content` already masked the same text — a credential-shaped
+/// subject line tripped the runtime's `secret_gate::check(name)` call and
+/// silently dropped the whole commit, despite `content` being safe.
+#[tokio::test]
+async fn ingest_masks_credential_shaped_commit_subject_in_name_without_dropping_note() {
+    let _guard = ENV_MUTEX.lock().await;
+    let (rt, token, registry) = fixture().await;
+
+    let project_id = create(
+        &registry,
+        json!({"kind": "project", "name": "commit-subject-credential-repo"}),
+    )
+    .await;
+
+    let dir = tempfile::tempdir().expect("tempdir");
+    let repo = dir.path();
+    init_repo(repo);
+
+    let fake_token = "ghp_EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE";
+    write(repo, "README.md", "hello\n");
+    commit(repo, &["README.md"], fake_token);
+
+    let report = run_ingest(
+        &rt,
+        &token,
+        &registry,
+        IngestOptions::unbounded(repo.to_path_buf(), project_id.to_string()),
+    )
+    .await
+    .expect("ingest ok");
+
+    assert_eq!(
+        report.commits_ingested, 1,
+        "the commit must not be dropped: {report:?}"
+    );
+    assert!(
+        report.warnings.iter().all(|w| !w.contains("create commit")),
+        "no silent-drop warning may be reported: {:?}",
+        report.warnings
+    );
+
+    let list = registry
+        .dispatch("list", json!({"kind": "commit", "limit": 10}))
+        .await
+        .expect("list ok");
+    let items = list.as_array().expect("array");
+    assert_eq!(items.len(), 1);
+    let stored_name = items[0]["name"].as_str().expect("name is string");
+    assert!(
+        !stored_name.contains(fake_token),
+        "raw token must not survive into the stored name: {stored_name:?}"
+    );
+    assert!(
+        stored_name.contains("***MASKED***"),
+        "masked marker must be present in name: {stored_name:?}"
+    );
+}
+
+/// The commit `author` field entered gated `properties` raw — a
+/// credential-shaped `git config user.name` silently dropped the commit via
+/// the runtime's recursive `properties` secret scan.
+#[tokio::test]
+async fn ingest_masks_credential_shaped_commit_author_without_dropping_note() {
+    let _guard = ENV_MUTEX.lock().await;
+    let (rt, token, registry) = fixture().await;
+
+    let project_id = create(
+        &registry,
+        json!({"kind": "project", "name": "commit-author-credential-repo"}),
+    )
+    .await;
+
+    let dir = tempfile::tempdir().expect("tempdir");
+    let repo = dir.path();
+    init_repo(repo);
+
+    let fake_token = "ghp_FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF";
+    git(repo, &["config", "user.name", fake_token]);
+    write(repo, "README.md", "hello\n");
+    commit(repo, &["README.md"], "Normal commit message");
+
+    let report = run_ingest(
+        &rt,
+        &token,
+        &registry,
+        IngestOptions::unbounded(repo.to_path_buf(), project_id.to_string()),
+    )
+    .await
+    .expect("ingest ok");
+
+    assert_eq!(
+        report.commits_ingested, 1,
+        "the commit must not be dropped: {report:?}"
+    );
+    assert!(
+        report.warnings.iter().all(|w| !w.contains("create commit")),
+        "no silent-drop warning may be reported: {:?}",
+        report.warnings
+    );
+
+    let list = registry
+        .dispatch("list", json!({"kind": "commit", "limit": 10}))
+        .await
+        .expect("list ok");
+    let items = list.as_array().expect("array");
+    assert_eq!(items.len(), 1);
+    let stored_author = items[0]["properties"]["author"]
+        .as_str()
+        .expect("properties.author is string");
+    assert!(
+        !stored_author.contains(fake_token),
+        "raw token must not survive into properties.author: {stored_author:?}"
+    );
+    assert!(
+        stored_author.contains("***MASKED***"),
+        "masked marker must be present in properties.author: {stored_author:?}"
+    );
+}
+
+/// The commit `author_email` field entered gated `properties` raw — a
+/// credential-shaped `git config user.email` silently dropped the commit via
+/// the runtime's recursive `properties` secret scan.
+#[tokio::test]
+async fn ingest_masks_credential_shaped_commit_author_email_without_dropping_note() {
+    let _guard = ENV_MUTEX.lock().await;
+    let (rt, token, registry) = fixture().await;
+
+    let project_id = create(
+        &registry,
+        json!({"kind": "project", "name": "commit-author-email-credential-repo"}),
+    )
+    .await;
+
+    let dir = tempfile::tempdir().expect("tempdir");
+    let repo = dir.path();
+    init_repo(repo);
+
+    let fake_token = "ghp_GGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGG";
+    git(
+        repo,
+        &["config", "user.email", &format!("{fake_token}@example.com")],
+    );
+    write(repo, "README.md", "hello\n");
+    commit(repo, &["README.md"], "Normal commit message");
+
+    let report = run_ingest(
+        &rt,
+        &token,
+        &registry,
+        IngestOptions::unbounded(repo.to_path_buf(), project_id.to_string()),
+    )
+    .await
+    .expect("ingest ok");
+
+    assert_eq!(
+        report.commits_ingested, 1,
+        "the commit must not be dropped: {report:?}"
+    );
+    assert!(
+        report.warnings.iter().all(|w| !w.contains("create commit")),
+        "no silent-drop warning may be reported: {:?}",
+        report.warnings
+    );
+
+    let list = registry
+        .dispatch("list", json!({"kind": "commit", "limit": 10}))
+        .await
+        .expect("list ok");
+    let items = list.as_array().expect("array");
+    assert_eq!(items.len(), 1);
+    let stored_email = items[0]["properties"]["author_email"]
+        .as_str()
+        .expect("properties.author_email is string");
+    assert!(
+        !stored_email.contains(fake_token),
+        "raw token must not survive into properties.author_email: {stored_email:?}"
+    );
+    assert!(
+        stored_email.contains("***MASKED***"),
+        "masked marker must be present in properties.author_email: {stored_email:?}"
+    );
+}
+
+/// Regression guard: clean (non-credential-shaped) commit author, email, and
+/// subject must survive byte-for-byte unchanged — the fix above must not
+/// become an over-aggressive masking regression.
+#[tokio::test]
+async fn ingest_leaves_clean_commit_author_and_subject_unmasked() {
+    let _guard = ENV_MUTEX.lock().await;
+    let (rt, token, registry) = fixture().await;
+
+    let project_id = create(
+        &registry,
+        json!({"kind": "project", "name": "commit-clean-fields-repo"}),
+    )
+    .await;
+
+    let dir = tempfile::tempdir().expect("tempdir");
+    let repo = dir.path();
+    init_repo(repo);
+    git(repo, &["config", "user.name", "Ada Lovelace"]);
+    git(repo, &["config", "user.email", "ada@example.com"]);
+    write(repo, "README.md", "hello\n");
+    commit(repo, &["README.md"], "Add README with usage notes");
+
+    let report = run_ingest(
+        &rt,
+        &token,
+        &registry,
+        IngestOptions::unbounded(repo.to_path_buf(), project_id.to_string()),
+    )
+    .await
+    .expect("ingest ok");
+    assert_eq!(report.commits_ingested, 1, "{report:?}");
+
+    let list = registry
+        .dispatch("list", json!({"kind": "commit", "limit": 10}))
+        .await
+        .expect("list ok");
+    let items = list.as_array().expect("array");
+    assert_eq!(items.len(), 1);
+    let item = &items[0];
+    let stored_author = item["properties"]["author"]
+        .as_str()
+        .expect("author is string");
+    let stored_email = item["properties"]["author_email"]
+        .as_str()
+        .expect("author_email is string");
+    let stored_name = item["name"].as_str().expect("name is string");
+    assert_eq!(
+        stored_author, "Ada Lovelace",
+        "clean author must be stored unchanged"
+    );
+    assert_eq!(
+        stored_email, "ada@example.com",
+        "clean author_email must be stored unchanged"
+    );
+    assert!(
+        stored_name.ends_with("Add README with usage notes"),
+        "clean subject must survive unmodified in name: {stored_name:?}"
+    );
+    assert!(
+        !stored_author.contains("***MASKED***")
+            && !stored_email.contains("***MASKED***")
+            && !stored_name.contains("***MASKED***"),
+        "no masking marker may appear on clean input: author={stored_author:?} email={stored_email:?} name={stored_name:?}"
+    );
+}
+
+/// The PR `author` field entered gated `properties` raw — a credential-shaped
+/// GitHub login silently dropped the PR via the runtime's recursive
+/// `properties` secret scan (the sibling of the already-fixed issue
+/// `author_login` bug).
+#[tokio::test]
+async fn ingest_masks_credential_shaped_pr_author_login_without_dropping_note() {
+    let _guard = ENV_MUTEX.lock().await;
+    let (rt, token, registry) = fixture().await;
+
+    let project_id = create(
+        &registry,
+        json!({"kind": "project", "name": "pr-author-credential-repo"}),
+    )
+    .await;
+
+    let dir = tempfile::tempdir().expect("tempdir");
+    let repo: PathBuf = dir.path().join("repo");
+    std::fs::create_dir_all(&repo).expect("mk repo dir");
+    init_repo(&repo);
+    write(&repo, "README.md", "hello\n");
+    commit(&repo, &["README.md"], "Initial commit");
+
+    let bin_dir = dir.path().join("bin");
+    std::fs::create_dir_all(&bin_dir).expect("mk bin dir");
+    let log_dir = dir.path().join("log");
+    std::fs::create_dir_all(&log_dir).expect("mk log dir");
+
+    let fake_token = "ghp_HHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHH";
+    let pr_json = json!([{
+        "number": 55,
+        "title": "Fix pagination edge case",
+        "author": {"login": fake_token},
+        "createdAt": "2026-01-01T00:00:00Z",
+        "mergedAt": null,
+        "closedAt": null,
+        "updatedAt": "2026-01-01T00:00:00Z",
+        "baseRefName": "main",
+        "headRefName": "fix/pagination",
+        "mergeCommit": null,
+        "body": ""
+    }])
+    .to_string();
+
+    write_fake_gh(&bin_dir, &log_dir, &pr_json, "[]");
+    let _path_guard = PathGuard::install(&bin_dir);
+
+    let report = run_ingest(
+        &rt,
+        &token,
+        &registry,
+        IngestOptions::unbounded(repo.clone(), project_id.to_string()),
+    )
+    .await
+    .expect("ingest ok");
+
+    assert_eq!(
+        report.prs_ingested, 1,
+        "the PR must not be dropped: {report:?}"
+    );
+    assert!(
+        report.warnings.iter().all(|w| !w.contains("pull_request")),
+        "no silent-drop warning may be reported: {:?}",
+        report.warnings
+    );
+
+    let prs_list = registry
+        .dispatch("list", json!({"kind": "pull_request", "limit": 10}))
+        .await
+        .expect("list prs ok");
+    let items = prs_list.as_array().expect("array");
+    assert_eq!(items.len(), 1);
+    let stored_author = items[0]["properties"]["author"]
+        .as_str()
+        .expect("properties.author is string");
+    assert!(
+        !stored_author.contains(fake_token),
+        "raw credential must not survive into properties.author: {stored_author:?}"
+    );
+    assert!(
+        stored_author.contains("***MASKED***"),
+        "masked marker must be present in properties.author: {stored_author:?}"
+    );
+}
+
+/// The PR `base_ref` field entered gated `properties` raw — a
+/// credential-shaped base branch name silently dropped the PR.
+#[tokio::test]
+async fn ingest_masks_credential_shaped_pr_base_ref_without_dropping_note() {
+    let _guard = ENV_MUTEX.lock().await;
+    let (rt, token, registry) = fixture().await;
+
+    let project_id = create(
+        &registry,
+        json!({"kind": "project", "name": "pr-base-ref-credential-repo"}),
+    )
+    .await;
+
+    let dir = tempfile::tempdir().expect("tempdir");
+    let repo: PathBuf = dir.path().join("repo");
+    std::fs::create_dir_all(&repo).expect("mk repo dir");
+    init_repo(&repo);
+    write(&repo, "README.md", "hello\n");
+    commit(&repo, &["README.md"], "Initial commit");
+
+    let bin_dir = dir.path().join("bin");
+    std::fs::create_dir_all(&bin_dir).expect("mk bin dir");
+    let log_dir = dir.path().join("log");
+    std::fs::create_dir_all(&log_dir).expect("mk log dir");
+
+    let fake_token = "ghp_IIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIII";
+    let pr_json = json!([{
+        "number": 56,
+        "title": "Retarget release branch",
+        "author": {"login": "octocat"},
+        "createdAt": "2026-01-01T00:00:00Z",
+        "mergedAt": null,
+        "closedAt": null,
+        "updatedAt": "2026-01-01T00:00:00Z",
+        "baseRefName": fake_token,
+        "headRefName": "release/next",
+        "mergeCommit": null,
+        "body": ""
+    }])
+    .to_string();
+
+    write_fake_gh(&bin_dir, &log_dir, &pr_json, "[]");
+    let _path_guard = PathGuard::install(&bin_dir);
+
+    let report = run_ingest(
+        &rt,
+        &token,
+        &registry,
+        IngestOptions::unbounded(repo.clone(), project_id.to_string()),
+    )
+    .await
+    .expect("ingest ok");
+
+    assert_eq!(
+        report.prs_ingested, 1,
+        "the PR must not be dropped: {report:?}"
+    );
+    assert!(
+        report.warnings.iter().all(|w| !w.contains("pull_request")),
+        "no silent-drop warning may be reported: {:?}",
+        report.warnings
+    );
+
+    let prs_list = registry
+        .dispatch("list", json!({"kind": "pull_request", "limit": 10}))
+        .await
+        .expect("list prs ok");
+    let items = prs_list.as_array().expect("array");
+    assert_eq!(items.len(), 1);
+    let stored_base_ref = items[0]["properties"]["base_ref"]
+        .as_str()
+        .expect("properties.base_ref is string");
+    assert!(
+        !stored_base_ref.contains(fake_token),
+        "raw credential must not survive into properties.base_ref: {stored_base_ref:?}"
+    );
+    assert!(
+        stored_base_ref.contains("***MASKED***"),
+        "masked marker must be present in properties.base_ref: {stored_base_ref:?}"
+    );
+}
+
+/// The PR `head_ref` field entered gated `properties` raw — a
+/// credential-shaped head branch name (realistic for a fork PR, where the
+/// contributor fully controls the branch name) silently dropped the PR.
+#[tokio::test]
+async fn ingest_masks_credential_shaped_pr_head_ref_without_dropping_note() {
+    let _guard = ENV_MUTEX.lock().await;
+    let (rt, token, registry) = fixture().await;
+
+    let project_id = create(
+        &registry,
+        json!({"kind": "project", "name": "pr-head-ref-credential-repo"}),
+    )
+    .await;
+
+    let dir = tempfile::tempdir().expect("tempdir");
+    let repo: PathBuf = dir.path().join("repo");
+    std::fs::create_dir_all(&repo).expect("mk repo dir");
+    init_repo(&repo);
+    write(&repo, "README.md", "hello\n");
+    commit(&repo, &["README.md"], "Initial commit");
+
+    let bin_dir = dir.path().join("bin");
+    std::fs::create_dir_all(&bin_dir).expect("mk bin dir");
+    let log_dir = dir.path().join("log");
+    std::fs::create_dir_all(&log_dir).expect("mk log dir");
+
+    let fake_token = "ghp_JJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJ";
+    let pr_json = json!([{
+        "number": 57,
+        "title": "Fork contribution",
+        "author": {"login": "octocat"},
+        "createdAt": "2026-01-01T00:00:00Z",
+        "mergedAt": null,
+        "closedAt": null,
+        "updatedAt": "2026-01-01T00:00:00Z",
+        "baseRefName": "main",
+        "headRefName": fake_token,
+        "mergeCommit": null,
+        "body": ""
+    }])
+    .to_string();
+
+    write_fake_gh(&bin_dir, &log_dir, &pr_json, "[]");
+    let _path_guard = PathGuard::install(&bin_dir);
+
+    let report = run_ingest(
+        &rt,
+        &token,
+        &registry,
+        IngestOptions::unbounded(repo.clone(), project_id.to_string()),
+    )
+    .await
+    .expect("ingest ok");
+
+    assert_eq!(
+        report.prs_ingested, 1,
+        "the PR must not be dropped: {report:?}"
+    );
+    assert!(
+        report.warnings.iter().all(|w| !w.contains("pull_request")),
+        "no silent-drop warning may be reported: {:?}",
+        report.warnings
+    );
+
+    let prs_list = registry
+        .dispatch("list", json!({"kind": "pull_request", "limit": 10}))
+        .await
+        .expect("list prs ok");
+    let items = prs_list.as_array().expect("array");
+    assert_eq!(items.len(), 1);
+    let stored_head_ref = items[0]["properties"]["head_ref"]
+        .as_str()
+        .expect("properties.head_ref is string");
+    assert!(
+        !stored_head_ref.contains(fake_token),
+        "raw credential must not survive into properties.head_ref: {stored_head_ref:?}"
+    );
+    assert!(
+        stored_head_ref.contains("***MASKED***"),
+        "masked marker must be present in properties.head_ref: {stored_head_ref:?}"
+    );
+}
+
+/// Regression guard: clean (non-credential-shaped) PR author, base ref, and
+/// head ref must survive byte-for-byte unchanged.
+#[tokio::test]
+async fn ingest_leaves_clean_pr_author_and_refs_unmasked() {
+    let _guard = ENV_MUTEX.lock().await;
+    let (rt, token, registry) = fixture().await;
+
+    let project_id = create(
+        &registry,
+        json!({"kind": "project", "name": "pr-clean-author-refs-repo"}),
+    )
+    .await;
+
+    let dir = tempfile::tempdir().expect("tempdir");
+    let repo: PathBuf = dir.path().join("repo");
+    std::fs::create_dir_all(&repo).expect("mk repo dir");
+    init_repo(&repo);
+    write(&repo, "README.md", "hello\n");
+    commit(&repo, &["README.md"], "Initial commit");
+
+    let bin_dir = dir.path().join("bin");
+    std::fs::create_dir_all(&bin_dir).expect("mk bin dir");
+    let log_dir = dir.path().join("log");
+    std::fs::create_dir_all(&log_dir).expect("mk log dir");
+
+    let pr_json = json!([{
+        "number": 58,
+        "title": "Improve README clarity",
+        "author": {"login": "octocat"},
+        "createdAt": "2026-01-01T00:00:00Z",
+        "mergedAt": null,
+        "closedAt": null,
+        "updatedAt": "2026-01-01T00:00:00Z",
+        "baseRefName": "main",
+        "headRefName": "docs/readme-clarity",
+        "mergeCommit": null,
+        "body": ""
+    }])
+    .to_string();
+
+    write_fake_gh(&bin_dir, &log_dir, &pr_json, "[]");
+    let _path_guard = PathGuard::install(&bin_dir);
+
+    let report = run_ingest(
+        &rt,
+        &token,
+        &registry,
+        IngestOptions::unbounded(repo.clone(), project_id.to_string()),
+    )
+    .await
+    .expect("ingest ok");
+    assert_eq!(report.prs_ingested, 1, "{report:?}");
+
+    let prs_list = registry
+        .dispatch("list", json!({"kind": "pull_request", "limit": 10}))
+        .await
+        .expect("list prs ok");
+    let items = prs_list.as_array().expect("array");
+    assert_eq!(items.len(), 1);
+    let item = &items[0];
+    let stored_author = item["properties"]["author"]
+        .as_str()
+        .expect("author is string");
+    let stored_base_ref = item["properties"]["base_ref"]
+        .as_str()
+        .expect("base_ref is string");
+    let stored_head_ref = item["properties"]["head_ref"]
+        .as_str()
+        .expect("head_ref is string");
+    assert_eq!(stored_author, "octocat", "clean author must be unchanged");
+    assert_eq!(stored_base_ref, "main", "clean base_ref must be unchanged");
+    assert_eq!(
+        stored_head_ref, "docs/readme-clarity",
+        "clean head_ref must be unchanged"
+    );
+    assert!(
+        !stored_author.contains("***MASKED***")
+            && !stored_base_ref.contains("***MASKED***")
+            && !stored_head_ref.contains("***MASKED***"),
+        "no masking marker may appear on clean input: author={stored_author:?} base_ref={stored_base_ref:?} head_ref={stored_head_ref:?}"
+    );
+}


### PR DESCRIPTION
Closes #841

## Root cause

Follow-up from PR #835's review, which introduced `MaskedIssueFields` — an
exhaustive-destructure sanitization boundary for `GhIssue` — after a
credential-shaped issue title silently dropped the issue note via the
runtime's recursive `properties` secret scan (`secret_gate::check`/
`check_json`, called on `name`/`properties` at every `create`). #835 fixed
issue title/label/author-login and PR title/body via the same masking, but
did not apply the same boundary to every field. #841 named three residual
raw-string fields:

- Commit note `name`, built from the raw commit subject
  (`ingest.rs:998` at filing time) even though `content` already masked the
  same text via `secret_gate::mask_secrets`.
- Commit `author` and `author_email`, entering gated `properties` raw
  (`ingest.rs:989`).
- PR `author`, `base_ref`, and `head_ref`, entering gated `properties` raw
  (`ingest.rs:1346`).

Any of these being credential-shaped — a fork PR's attacker-controlled
branch name is the realistic case for `head_ref` — trips the write-time
secret gate on `create` and silently drops the whole record (warned, not
counted, cursor stalled for retry), the same failure mode #801/#835 already
fixed for issue titles and PR title/body.

## Fix

Adds two sanitization boundaries mirroring the existing `MaskedIssueFields`
pattern (`crates/khive-pack-git/src/ingest.rs`):

- **`MaskedCommitFields::new(&RawCommit) -> Self`** — exhaustively
  destructures `RawCommit` (no `..`), so a future new field forces a
  compile error here before it can silently skip the boundary.
- **`MaskedPrFields::new(GhPr) -> Self`** — exhaustively destructures `GhPr`
  by value, same guarantee.

Both apply `secret_gate::mask_secrets` to every contributor-controlled
free-text field and pass through git-/GitHub-generated non-free-text fields
(hashes, timestamps) unchanged — the same split `MaskedIssueFields` already
makes between its masked fields (title/body/author_login/labels) and its
canonicalized-not-masked timestamp fields.

### Full field inventory (positive verification, not grep)

**Commit (`RawCommit` → `MaskedCommitFields`):**

| Field | Treatment | Reason |
|---|---|---|
| `subject` | `mask_secrets` | commit-message-controlled; feeds both `content` and the note `name` (the #841 bug: `name` previously used the raw value) |
| `body` | `mask_secrets` | commit-message-controlled; feeds `content` |
| `author` | `mask_secrets` | `git config user.name`-controlled; feeds `properties.author` (the #841 bug) |
| `author_email` | `mask_secrets` | `git config user.email`-controlled; feeds `properties.author_email` (the #841 bug) |
| `sha` | pass-through | git-computed SHA-1 hash, not free text |
| `short_sha` | pass-through | git-computed SHA-1 prefix, not free text |
| `committed_at` | pass-through | git-generated RFC3339 timestamp, not free text |
| `parents` | pass-through | git-computed SHA-1 hashes, not free text |

**PR (`GhPr` → `MaskedPrFields`):**

| Field | Treatment | Reason |
|---|---|---|
| `title` | `mask_secrets` | contributor-controlled (already masked pre-#841, kept in the new boundary) |
| `body` | `mask_secrets` | contributor-controlled (already masked pre-#841, kept in the new boundary) |
| `author.login` | `mask_secrets` | GitHub-login-controlled; feeds `properties.author` (the #841 bug) |
| `base_ref_name` | `mask_secrets` | repo-branch-name-controlled; feeds `properties.base_ref` (the #841 bug) |
| `head_ref_name` | `mask_secrets` | fork-branch-name-controlled (fully attacker-controlled on a fork PR); feeds `properties.head_ref` (the #841 bug) |
| `number` | pass-through | GitHub-assigned integer |
| `created_at`/`merged_at`/`closed_at`/`updated_at` | pass-through | GitHub-generated RFC3339 timestamps, not free text |
| `merge_commit.oid` | pass-through | git-computed SHA-1 hash, not free text |

Issue labels and author login for issues were already fixed on the #835
branch round 2 (unchanged here).

## Regression tests

`crates/khive-pack-git/tests/acceptance.rs`, one credential-shaped positive
test per previously-unmasked field plus two clean-input guards:

- `ingest_masks_credential_shaped_commit_subject_in_name_without_dropping_note`
- `ingest_masks_credential_shaped_commit_author_without_dropping_note`
- `ingest_masks_credential_shaped_commit_author_email_without_dropping_note`
- `ingest_leaves_clean_commit_author_and_subject_unmasked`
- `ingest_masks_credential_shaped_pr_author_login_without_dropping_note`
- `ingest_masks_credential_shaped_pr_base_ref_without_dropping_note`
- `ingest_masks_credential_shaped_pr_head_ref_without_dropping_note`
- `ingest_leaves_clean_pr_author_and_refs_unmasked`

Each positive test asserts: the record is not dropped (`commits_ingested`/
`prs_ingested` still increments, no drop warning), the raw credential does
not survive into the stored field, and the `***MASKED***` marker is
present. Each clean-input test asserts the field survives byte-for-byte
unchanged, guarding against an over-aggressive masking regression.

## Test evidence

```
cargo test -p khive-pack-git      # 74 unit + 49 acceptance passed, 0 failed
cargo clippy -p khive-pack-git --all-targets -- -D warnings   # clean
cargo fmt --all -- --check         # clean
```