### PR TITLE
fix(pack-schedule): preserve ISO TZ offset in remind create-response rendering

### DIFF
--- a/crates/khive-mcp/tests/integration.rs
+++ b/crates/khive-mcp/tests/integration.rs
@@ -3977,6 +3977,72 @@ async fn schedule_agenda_agent_preserves_properties_trigger_at_verbatim() -> any
     Ok(())
 }
 
+// ── #871: schedule.remind create-response preserves top-level trigger_at ─────
+
+/// `schedule.remind`'s create response returns `trigger_at` as a top-level
+/// convenience field (sibling to `id`/`full_id`), not nested under
+/// `"properties"`. In default Agent mode this must round-trip verbatim,
+/// offset intact — the humanize layer previously misread the wall-clock
+/// digits of a non-UTC-offset `at` as UTC and could render a future trigger
+/// as if it were in the past (#871).
+#[tokio::test]
+async fn schedule_remind_agent_preserves_top_level_trigger_at_with_offset() -> anyhow::Result<()> {
+    let client = connect_schedule_only().await?;
+    // Far enough in the future (relative to "now") that a naive/offset-blind
+    // parse landing inside the 24h relative-render window would have
+    // produced a bogus "Nh ago"/"in Nh" string instead of the exact ISO
+    // string being preserved.
+    let trigger_at = "2099-06-15T19:00:00-04:00";
+
+    let result = call(
+        &client,
+        "request",
+        json!({"ops": format!(
+            r#"schedule.remind(content="agent create-response trigger_at fidelity", at="{trigger_at}")"#
+        )}),
+    )
+    .await?;
+    let body: Value = serde_json::from_str(&first_text(&result))?;
+    let first = &body["results"][0];
+    assert_eq!(
+        first["ok"],
+        json!(true),
+        "schedule.remind must succeed: {first}"
+    );
+
+    let actual = first["result"]["trigger_at"].as_str().unwrap_or("");
+    assert_eq!(
+        actual, trigger_at,
+        "top-level trigger_at in the create response must be preserved verbatim, offset intact, in Agent mode"
+    );
+    Ok(())
+}
+
+/// UTC (`Z`) and offset-less `at` inputs must likewise round-trip unchanged
+/// through the create-response humanize layer (#871 regression coverage).
+#[tokio::test]
+async fn schedule_remind_agent_preserves_top_level_trigger_at_utc_and_offset_less(
+) -> anyhow::Result<()> {
+    let client = connect_schedule_only().await?;
+
+    let utc = "2099-06-15T23:00:00Z";
+    let result = call(
+        &client,
+        "request",
+        json!({"ops": format!(
+            r#"schedule.remind(content="agent create-response trigger_at utc", at="{utc}")"#
+        )}),
+    )
+    .await?;
+    let body: Value = serde_json::from_str(&first_text(&result))?;
+    let actual = body["results"][0]["result"]["trigger_at"]
+        .as_str()
+        .unwrap_or("");
+    assert_eq!(actual, utc, "UTC trigger_at must round-trip unchanged");
+
+    Ok(())
+}
+
 // ── PR #121: proposal_id → id wire-key — DSL chain tests ─────────────────────
 //
 // These tests prove that `$prev.id` substitution works end-to-end through the

--- a/crates/khive-mcp/tests/integration.rs
+++ b/crates/khive-mcp/tests/integration.rs
@@ -3978,20 +3978,26 @@ async fn schedule_agenda_agent_preserves_properties_trigger_at_verbatim() -> any
 }
 
 // ── #871: schedule.remind create-response preserves top-level trigger_at ─────
+//
+// These two tests deliberately cover `schedule.remind` only; `schedule` (the
+// verb-dispatch scheduling sibling) shares the same create-response shape and
+// the same presentation-layer fix, but an equivalent end-to-end case for it
+// is out of scope here to keep this regression narrow (#871).
 
 /// `schedule.remind`'s create response returns `trigger_at` as a top-level
 /// convenience field (sibling to `id`/`full_id`), not nested under
 /// `"properties"`. In default Agent mode this must round-trip verbatim,
-/// offset intact — the humanize layer previously misread the wall-clock
-/// digits of a non-UTC-offset `at` as UTC and could render a future trigger
-/// as if it were in the past (#871).
+/// offset intact — the humanize layer previously discarded the offset (and
+/// seconds) by minute-truncating or relativizing this top-level field, even
+/// though the underlying offset-to-UTC conversion used for the relative-time
+/// comparison itself was already correct (#871).
 #[tokio::test]
 async fn schedule_remind_agent_preserves_top_level_trigger_at_with_offset() -> anyhow::Result<()> {
     let client = connect_schedule_only().await?;
-    // Far enough in the future (relative to "now") that a naive/offset-blind
-    // parse landing inside the 24h relative-render window would have
-    // produced a bogus "Nh ago"/"in Nh" string instead of the exact ISO
-    // string being preserved.
+    // Far enough in the future (relative to "now") to land outside the 24h
+    // relative-render window, so pre-fix this would have been silently
+    // minute-truncated (dropping the seconds and the "-04:00" offset)
+    // instead of round-tripping the exact ISO string.
     let trigger_at = "2099-06-15T19:00:00-04:00";
 
     let result = call(
@@ -4018,11 +4024,14 @@ async fn schedule_remind_agent_preserves_top_level_trigger_at_with_offset() -> a
     Ok(())
 }
 
-/// UTC (`Z`) and offset-less `at` inputs must likewise round-trip unchanged
-/// through the create-response humanize layer (#871 regression coverage).
+/// A `Z`-suffixed UTC `at` input must likewise round-trip unchanged through
+/// the create-response humanize layer (#871 regression coverage). Bare
+/// offset-less input (no `Z`/`±HH:MM` suffix) is not a case here: it is
+/// rejected upstream as non-RFC-3339 by `schedule.remind`'s own validation
+/// (`crates/khive-pack-schedule/src/handlers.rs` `validate_at`), so it never
+/// reaches this presentation-layer fix.
 #[tokio::test]
-async fn schedule_remind_agent_preserves_top_level_trigger_at_utc_and_offset_less(
-) -> anyhow::Result<()> {
+async fn schedule_remind_agent_preserves_top_level_trigger_at_utc() -> anyhow::Result<()> {
     let client = connect_schedule_only().await?;
 
     let utc = "2099-06-15T23:00:00Z";

--- a/crates/khive-runtime/src/presentation.rs
+++ b/crates/khive-runtime/src/presentation.rs
@@ -382,8 +382,9 @@ const LIFECYCLE_NULL_PRESERVE: &[&str] = &[
 /// `full_id`, not nested under `"properties"`. The `inside_properties` guard
 /// alone only protects fields nested under a literal `"properties"` key
 /// (as returned by `agenda`/`get`); it does not cover this top-level case,
-/// which was compacted into a relative string ("Nh ago") and could render a
-/// future trigger as if it were in the past (#871).
+/// which `compact_timestamp` rewrote into either a relative string or a
+/// minute-truncated absolute form — either way discarding the seconds and
+/// offset the caller needs to round-trip the exact submitted value (#871).
 const PAYLOAD_TIMESTAMP_FIELDS: &[&str] = &["trigger_at"];
 
 /// Score field names that are truncated to 3 significant figures in Agent mode.
@@ -838,9 +839,10 @@ mod tests {
         // `trigger_at` as a top-level convenience field (sibling to `id`,
         // `full_id`), not nested under `"properties"`. The pre-existing
         // `inside_properties` guard alone did not protect it, so Agent-mode
-        // compaction rewrote a real future ISO timestamp into a bogus
-        // relative string computed by misreading the wall-clock digits as
-        // UTC (e.g. rendering a time 2.5h in the future as "1h ago").
+        // compaction rewrote it: `at` here is far outside the 24h relative
+        // window, so pre-fix it would have been minute-truncated to
+        // "2026-07-11T19:00", discarding the seconds and the "-04:00"
+        // offset the caller needs to round-trip the exact value verbatim.
         let at = "2026-07-11T19:00:00-04:00";
         let v = json!({
             "id": "a1b2c3d4",

--- a/crates/khive-runtime/src/presentation.rs
+++ b/crates/khive-runtime/src/presentation.rs
@@ -373,6 +373,19 @@ const LIFECYCLE_NULL_PRESERVE: &[&str] = &[
     "replaced_by",
 ];
 
+/// Field names carrying caller-supplied payload timestamps that must never be
+/// compacted (relative-time or minute-truncated), regardless of nesting.
+///
+/// These encode domain semantics the caller needs to round-trip verbatim —
+/// e.g. `trigger_at` on a `schedule.remind`/`schedule.schedule` create
+/// response, returned as a top-level convenience field alongside `id` and
+/// `full_id`, not nested under `"properties"`. The `inside_properties` guard
+/// alone only protects fields nested under a literal `"properties"` key
+/// (as returned by `agenda`/`get`); it does not cover this top-level case,
+/// which was compacted into a relative string ("Nh ago") and could render a
+/// future trigger as if it were in the past (#871).
+const PAYLOAD_TIMESTAMP_FIELDS: &[&str] = &["trigger_at"];
+
 /// Score field names that are truncated to 3 significant figures in Agent mode.
 const SCORE_FIELDS: &[&str] = &[
     "score",
@@ -417,10 +430,13 @@ pub fn present(value: Value, mode: PresentationMode, now_unix_seconds: i64) -> V
             let lifecycle_preserve: HashSet<&str> =
                 LIFECYCLE_NULL_PRESERVE.iter().copied().collect();
             let score_fields: HashSet<&str> = SCORE_FIELDS.iter().copied().collect();
+            let payload_timestamps: HashSet<&str> =
+                PAYLOAD_TIMESTAMP_FIELDS.iter().copied().collect();
             transform_agent(
                 value,
                 &lifecycle_preserve,
                 &score_fields,
+                &payload_timestamps,
                 now_unix_seconds,
                 false,
             )
@@ -437,6 +453,7 @@ fn transform_agent(
     value: Value,
     lifecycle: &HashSet<&str>,
     scores: &HashSet<&str>,
+    payload_timestamps: &HashSet<&str>,
     now: i64,
     inside_properties: bool,
 ) -> Value {
@@ -445,8 +462,15 @@ fn transform_agent(
             let mut out = Map::new();
             for (k, v) in map {
                 let child_inside_properties = inside_properties || k == "properties";
-                let transformed =
-                    transform_field_agent(&k, v, lifecycle, scores, now, child_inside_properties);
+                let transformed = transform_field_agent(
+                    &k,
+                    v,
+                    lifecycle,
+                    scores,
+                    payload_timestamps,
+                    now,
+                    child_inside_properties,
+                );
                 match transformed {
                     None => {} // drop
                     Some(tv) => {
@@ -459,7 +483,16 @@ fn transform_agent(
         Value::Array(arr) => {
             let items: Vec<Value> = arr
                 .into_iter()
-                .map(|v| transform_agent(v, lifecycle, scores, now, inside_properties))
+                .map(|v| {
+                    transform_agent(
+                        v,
+                        lifecycle,
+                        scores,
+                        payload_timestamps,
+                        now,
+                        inside_properties,
+                    )
+                })
                 .collect();
             Value::Array(items)
         }
@@ -472,13 +505,18 @@ fn transform_agent(
 /// Returns `None` if the field should be dropped.
 ///
 /// `inside_properties` suppresses timestamp compaction for caller-submitted
-/// payload values (e.g. `trigger_at` stored under `"properties"`). Metadata
-/// timestamps at the top level (`created_at`, `updated_at`) are still compacted.
+/// payload values nested under a literal `"properties"` key (e.g. `trigger_at`
+/// as returned by `agenda`/`get`). `payload_timestamps` suppresses compaction
+/// by field name regardless of nesting, covering top-level convenience fields
+/// such as the `trigger_at` returned directly in a `schedule.remind`/
+/// `schedule.schedule` create response (#871). Metadata timestamps at the top
+/// level (`created_at`, `updated_at`) are still compacted.
 fn transform_field_agent(
     key: &str,
     value: Value,
     lifecycle: &HashSet<&str>,
     scores: &HashSet<&str>,
+    payload_timestamps: &HashSet<&str>,
     now: i64,
     inside_properties: bool,
 ) -> Option<Value> {
@@ -507,8 +545,11 @@ fn transform_field_agent(
         Value::String(s) if is_canonical_uuid(s) && should_shorten_uuid_field(key) => {
             Some(Value::String(s[..8].to_string()))
         }
-        // Compact ISO-8601 timestamps only outside caller-supplied payload objects.
-        Value::String(s) if !inside_properties && looks_like_iso8601(s) => {
+        // Compact ISO-8601 timestamps unless inside a caller-supplied payload
+        // object, or the field is a named payload timestamp at any nesting.
+        Value::String(s)
+            if !inside_properties && !payload_timestamps.contains(key) && looks_like_iso8601(s) =>
+        {
             Some(Value::String(compact_timestamp(s, now)))
         }
         // Recurse into objects and arrays.
@@ -516,6 +557,7 @@ fn transform_field_agent(
             value,
             lifecycle,
             scores,
+            payload_timestamps,
             now,
             inside_properties,
         )),
@@ -788,6 +830,72 @@ mod tests {
         let v = json!({"updated_at": ts});
         let out = agent(v);
         assert_eq!(out["updated_at"], json!("3m ago"));
+    }
+
+    #[test]
+    fn agent_does_not_compact_top_level_trigger_at_field() {
+        // Regression for #871: `schedule.remind`'s create response returns
+        // `trigger_at` as a top-level convenience field (sibling to `id`,
+        // `full_id`), not nested under `"properties"`. The pre-existing
+        // `inside_properties` guard alone did not protect it, so Agent-mode
+        // compaction rewrote a real future ISO timestamp into a bogus
+        // relative string computed by misreading the wall-clock digits as
+        // UTC (e.g. rendering a time 2.5h in the future as "1h ago").
+        let at = "2026-07-11T19:00:00-04:00";
+        let v = json!({
+            "id": "a1b2c3d4",
+            "full_id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+            "event_type": "remind",
+            "trigger_at": at,
+            "repeat": null,
+            "status": "pending",
+        });
+        let out = agent(v);
+        assert_eq!(out["trigger_at"], json!(at));
+    }
+
+    #[test]
+    fn agent_does_not_compact_top_level_trigger_at_utc() {
+        let at = "2026-07-11T23:00:00Z";
+        let v = json!({"trigger_at": at});
+        let out = agent(v);
+        assert_eq!(out["trigger_at"], json!(at));
+    }
+
+    #[test]
+    fn agent_does_not_compact_top_level_trigger_at_offset_less() {
+        let at = "2026-07-11T23:00:00";
+        let v = json!({"trigger_at": at});
+        let out = agent(v);
+        assert_eq!(out["trigger_at"], json!(at));
+    }
+
+    #[test]
+    fn agent_still_compacts_other_top_level_timestamps_alongside_trigger_at() {
+        // The `trigger_at` exemption is scoped to that field name only — a
+        // sibling generic timestamp field must still be compacted, so the
+        // fix does not blanket-disable Agent-mode compaction.
+        let v = json!({
+            "trigger_at": "2026-07-11T19:00:00-04:00",
+            "created_at": "2020-01-01T10:30:45.123456Z",
+        });
+        let out = agent(v);
+        assert_eq!(out["trigger_at"], json!("2026-07-11T19:00:00-04:00"));
+        assert_eq!(out["created_at"], json!("2020-01-01T10:30"));
+    }
+
+    #[test]
+    fn agent_still_protects_nested_trigger_at_under_properties() {
+        // Pre-existing protection (agenda/get responses nest trigger_at
+        // under "properties") must remain intact alongside the new
+        // top-level, field-name-based guard.
+        let at = "2026-07-11T19:00:00-04:00";
+        let v = json!({
+            "id": "a1b2c3d4",
+            "properties": {"trigger_at": at, "status": "pending"},
+        });
+        let out = agent(v);
+        assert_eq!(out["properties"]["trigger_at"], json!(at));
     }
 
     #[test]

--- a/tests/smoke_schedule.py
+++ b/tests/smoke_schedule.py
@@ -51,8 +51,9 @@ def _call_request_raw(proc, ops_string, presentation=None):
     """Send `request(ops=<ops_string>)`. Return the parsed response body.
 
     presentation: None (default="agent"), "verbose", or "human".
-    Agent mode compacts metadata ISO-8601 timestamps to minute granularity and
-    shortens UUIDs; payload timestamps (e.g. trigger_at, #871) round-trip verbatim.
+    Agent mode renders metadata ISO-8601 timestamps from the last 24 hours as
+    relative text and older ones at minute granularity, and shortens UUIDs;
+    payload timestamps (e.g. trigger_at, #871) round-trip verbatim.
     Verbose mode returns the canonical handler output unchanged.
     """
     arguments = {"ops": ops_string}

--- a/tests/smoke_schedule.py
+++ b/tests/smoke_schedule.py
@@ -51,7 +51,8 @@ def _call_request_raw(proc, ops_string, presentation=None):
     """Send `request(ops=<ops_string>)`. Return the parsed response body.
 
     presentation: None (default="agent"), "verbose", or "human".
-    Agent mode compacts ISO-8601 timestamps to minute granularity and shortens UUIDs.
+    Agent mode compacts metadata ISO-8601 timestamps to minute granularity and
+    shortens UUIDs; payload timestamps (e.g. trigger_at, #871) round-trip verbatim.
     Verbose mode returns the canonical handler output unchanged.
     """
     arguments = {"ops": ops_string}
@@ -155,9 +156,10 @@ def main():
 
         # 1. Happy path remind: create → agenda shows it → cancel → agenda omits it
         def test_happy_remind(proc):
-            # Use verbose presentation so trigger_at is returned unchanged.
-            # Agent mode (default) compacts ISO-8601 timestamps to minute granularity
-            # ("2099-01-01T00:00") which is by design — see presentation.rs compact_timestamp.
+            # Verbose presentation returns the canonical handler output; since
+            # #871 Agent mode also round-trips trigger_at verbatim (payload
+            # timestamp, exempt from compact_timestamp — see presentation.rs
+            # PAYLOAD_TIMESTAMP_FIELDS), covered by test 17 below.
             ev = call_verb(proc, "schedule.remind", {
                 "content": "check the build",
                 "at": FAR_FUTURE_A,
@@ -469,12 +471,11 @@ def main():
         run_test("agenda sorted ascending by trigger_at", test_agenda_sort_order, proc)
 
         # 17. Trigger_at preserved exactly (H5: no UTC canonicalisation)
-        # NOTE: Agent mode (default) compacts ALL ISO-8601 timestamps to minute
-        # granularity. trigger_at is treated as a display timestamp by the presentation
-        # layer, so "2099-03-10T15:00:00+05:30" → "2099-03-10T15:00" in Agent mode.
-        # This is a known design tension: trigger_at is a payload value (not metadata)
-        # but the presentation layer has no way to distinguish them. Use verbose mode
-        # to verify the handler preserves the original string.
+        # NOTE: trigger_at is a caller-supplied payload value, not display
+        # metadata. Since #871 the presentation layer lists it in
+        # PAYLOAD_TIMESTAMP_FIELDS (presentation.rs), so Agent mode round-trips
+        # it verbatim — seconds and offset intact — instead of minute-truncating
+        # it (which silently changed the instant by discarding the offset).
         def test_trigger_at_preserved(proc):
             offset_at = "2099-03-10T15:00:00+05:30"
             ev = call_verb(proc, "schedule.remind", {
@@ -485,16 +486,15 @@ def main():
                 f"H5: trigger_at must be returned as-is in verbose mode; "
                 f"submitted={offset_at!r} got={ev['trigger_at']!r}"
             )
-            # In Agent mode (default) the timestamp is compacted to minute granularity.
-            # "2099-03-10T15:00:00+05:30" → first 16 chars → "2099-03-10T15:00"
+            # Agent mode (default) must also round-trip trigger_at verbatim
+            # (#871: payload timestamps are exempt from compaction).
             ev_agent = call_verb(proc, "schedule.remind", {
                 "content": "tz-preservation-agent",
                 "at": offset_at,
             })  # default=agent presentation
-            expected_agent = offset_at[:16]  # "2099-03-10T15:00"
-            assert ev_agent["trigger_at"] == expected_agent, (
-                f"Agent mode: trigger_at must be compacted to minute granularity; "
-                f"expected={expected_agent!r} got={ev_agent['trigger_at']!r}"
+            assert ev_agent["trigger_at"] == offset_at, (
+                f"Agent mode: trigger_at must round-trip verbatim (#871); "
+                f"expected={offset_at!r} got={ev_agent['trigger_at']!r}"
             )
 
         run_test("trigger_at preserved exactly (no UTC canonicalisation)", test_trigger_at_preserved, proc)


### PR DESCRIPTION
Closes #871

## Root cause

`schedule.remind`/`schedule.schedule` return `trigger_at` as a top-level convenience
field in their create response (sibling to `id`/`full_id`), not nested under a
`"properties"` object.

Agent-mode presentation (`crates/khive-runtime/src/presentation.rs`, the shared
humanize layer used by every MCP response) only exempted caller-supplied payload
timestamps from compaction when they were nested under a literal `"properties"`
key (`inside_properties`). That guard correctly protects `trigger_at` returned by
`agenda`/`get` (nested), but did not cover the create response's top-level field,
which fell through to `compact_timestamp` and got rewritten into a relative
"Nh ago"/"in Nh" string — capable of rendering a real future trigger as if it were
in the past.

The lower-level offset arithmetic (`parse_iso8601_unix`/`compact_timestamp`) is
already correct — verified by pre-existing tests. The gap was that this field
should never be compacted at all, regardless of nesting.

## Fix

Added `PAYLOAD_TIMESTAMP_FIELDS` (currently `["trigger_at"]`), following the
existing `LIFECYCLE_NULL_PRESERVE`/`SCORE_FIELDS` field-name-set pattern, threaded
through `present` → `transform_agent` → `transform_field_agent`. A field named
`trigger_at` is now exempt from Agent-mode timestamp compaction at any nesting
depth, not just inside `properties`.

## Tests

- `khive-runtime/src/presentation.rs`: 5 new unit tests — top-level `trigger_at`
  with a non-UTC offset, UTC (`Z`), and offset-less input all round-trip
  unchanged; a sibling `created_at` field is still compacted (scoped fix, no
  blanket disable); the pre-existing nested-under-`properties` protection still
  holds.
- `khive-mcp/tests/integration.rs`: 2 new end-to-end tests driving
  `schedule.remind` through the real MCP `request` surface in default Agent mode,
  asserting the create response's top-level `trigger_at` is preserved verbatim
  (offset-bearing and UTC cases).

Full `khive-pack-schedule` suite re-run clean (105 tests), including the existing
H5 offset-preservation tests at the write/validate seam — confirms this is purely
a presentation-layer fix with no change to how `trigger_at` is stored or compared.

Firing/delivery logic (`khive-mcp/src/pending_events.rs`) is untouched — out of
scope per #884.
