### PR TITLE
fix(pack-schedule): isolate pack tests from the live store

### DIFF
--- a/crates/khive-pack-schedule/tests/agenda.rs
+++ b/crates/khive-pack-schedule/tests/agenda.rs
@@ -3,8 +3,10 @@
 use khive_pack_schedule::SchedulePack;
 use khive_runtime::{KhiveRuntime, VerbRegistry, VerbRegistryBuilder};
 
+mod support;
+
 fn build_registry() -> (VerbRegistry, KhiveRuntime) {
-    let runtime = KhiveRuntime::memory().expect("in-memory runtime");
+    let runtime = support::memory_runtime();
     let mut builder = VerbRegistryBuilder::new();
     builder.register(khive_pack_kg::KgPack::new(runtime.clone()));
     builder.register(SchedulePack::new(runtime.clone()));
@@ -191,7 +193,7 @@ async fn h2_agenda_finds_valid_event_past_corrupt_legacy_rows() {
     use khive_storage::Note;
     use serde_json::json;
 
-    let runtime = KhiveRuntime::memory().expect("in-memory runtime");
+    let runtime = support::memory_runtime();
     let mut builder = VerbRegistryBuilder::new();
     builder.register(khive_pack_kg::KgPack::new(runtime.clone()));
     builder.register(SchedulePack::new(runtime.clone()));

--- a/crates/khive-pack-schedule/tests/cancel.rs
+++ b/crates/khive-pack-schedule/tests/cancel.rs
@@ -3,8 +3,10 @@
 use khive_pack_schedule::SchedulePack;
 use khive_runtime::{KhiveRuntime, VerbRegistry, VerbRegistryBuilder};
 
+mod support;
+
 fn build_registry() -> (VerbRegistry, KhiveRuntime) {
-    let runtime = KhiveRuntime::memory().expect("in-memory runtime");
+    let runtime = support::memory_runtime();
     let mut builder = VerbRegistryBuilder::new();
     builder.register(khive_pack_kg::KgPack::new(runtime.clone()));
     builder.register(SchedulePack::new(runtime.clone()));
@@ -102,7 +104,7 @@ async fn cancel_rejects_already_cancelled_event() {
 async fn cancel_rejects_fired_event_without_clobbering_fired_at() {
     use khive_storage::Note;
 
-    let runtime = KhiveRuntime::memory().expect("in-memory runtime");
+    let runtime = support::memory_runtime();
     let mut builder = khive_runtime::VerbRegistryBuilder::new();
     builder.register(khive_pack_kg::KgPack::new(runtime.clone()));
     builder.register(SchedulePack::new(runtime.clone()));
@@ -186,7 +188,7 @@ async fn cancel_rejects_non_pending_statuses() {
     use khive_storage::Note;
 
     for status in ["fired", "cancelled", "bogus-status"] {
-        let runtime = KhiveRuntime::memory().expect("in-memory runtime");
+        let runtime = support::memory_runtime();
         let mut builder = khive_runtime::VerbRegistryBuilder::new();
         builder.register(khive_pack_kg::KgPack::new(runtime.clone()));
         builder.register(SchedulePack::new(runtime.clone()));
@@ -254,7 +256,7 @@ async fn cancel_rejects_non_pending_statuses() {
 async fn sch_aud_001_cancel_with_string_properties_returns_error() {
     use khive_storage::Note;
 
-    let runtime = KhiveRuntime::memory().expect("in-memory runtime");
+    let runtime = support::memory_runtime();
     let mut builder = khive_runtime::VerbRegistryBuilder::new();
     builder.register(khive_pack_kg::KgPack::new(runtime.clone()));
     builder.register(SchedulePack::new(runtime.clone()));

--- a/crates/khive-pack-schedule/tests/create_validation.rs
+++ b/crates/khive-pack-schedule/tests/create_validation.rs
@@ -3,8 +3,10 @@
 use khive_pack_schedule::SchedulePack;
 use khive_runtime::{KhiveRuntime, VerbRegistry, VerbRegistryBuilder};
 
+mod support;
+
 fn build_registry() -> (VerbRegistry, KhiveRuntime) {
-    let runtime = KhiveRuntime::memory().expect("in-memory runtime");
+    let runtime = support::memory_runtime();
     let mut builder = VerbRegistryBuilder::new();
     builder.register(khive_pack_kg::KgPack::new(runtime.clone()));
     builder.register(SchedulePack::new(runtime.clone()));
@@ -13,7 +15,7 @@ fn build_registry() -> (VerbRegistry, KhiveRuntime) {
 }
 
 fn build_registry_with_brain() -> (VerbRegistry, KhiveRuntime) {
-    let runtime = KhiveRuntime::memory().expect("in-memory runtime");
+    let runtime = support::memory_runtime();
     let mut builder = VerbRegistryBuilder::new();
     builder.register(khive_pack_kg::KgPack::new(runtime.clone()));
     builder.register(khive_pack_brain::BrainPack::new(runtime.clone()));

--- a/crates/khive-pack-schedule/tests/integration.rs
+++ b/crates/khive-pack-schedule/tests/integration.rs
@@ -4,8 +4,10 @@ use khive_pack_schedule::SchedulePack;
 use khive_runtime::{KhiveRuntime, VerbRegistry, VerbRegistryBuilder};
 use khive_types::Pack;
 
+mod support;
+
 fn build_registry() -> (VerbRegistry, KhiveRuntime) {
-    let runtime = KhiveRuntime::memory().expect("in-memory runtime");
+    let runtime = support::memory_runtime();
     let mut builder = VerbRegistryBuilder::new();
     builder.register(khive_pack_kg::KgPack::new(runtime.clone()));
     builder.register(SchedulePack::new(runtime.clone()));
@@ -730,7 +732,7 @@ async fn h2_agenda_finds_valid_event_past_corrupt_legacy_rows() {
     use khive_storage::Note;
     use serde_json::json;
 
-    let runtime = KhiveRuntime::memory().expect("in-memory runtime");
+    let runtime = support::memory_runtime();
     let mut builder = VerbRegistryBuilder::new();
     builder.register(khive_pack_kg::KgPack::new(runtime.clone()));
     builder.register(SchedulePack::new(runtime.clone()));
@@ -843,7 +845,7 @@ async fn h2_agenda_finds_valid_event_past_corrupt_legacy_rows() {
 #[tokio::test]
 async fn schedule_pack_exposes_non_empty_schema_plan() {
     use khive_runtime::PackRuntime;
-    let runtime = KhiveRuntime::memory().expect("in-memory runtime");
+    let runtime = support::memory_runtime();
     let pack = SchedulePack::new(runtime);
     let plan = pack.schema_plan();
 
@@ -1028,10 +1030,9 @@ async fn sch_aud_003_agenda_limit_boundary_values_accepted() {
 
 #[tokio::test]
 async fn sch_aud_001_cancel_with_string_properties_returns_error() {
-    use khive_runtime::KhiveRuntime;
     use khive_storage::Note;
 
-    let runtime = KhiveRuntime::memory().expect("in-memory runtime");
+    let runtime = support::memory_runtime();
     let mut builder = khive_runtime::VerbRegistryBuilder::new();
     builder.register(khive_pack_kg::KgPack::new(runtime.clone()));
     builder.register(SchedulePack::new(runtime.clone()));

--- a/crates/khive-pack-schedule/tests/pack_registration.rs
+++ b/crates/khive-pack-schedule/tests/pack_registration.rs
@@ -1,8 +1,10 @@
 //! Pack registration and schema plan tests.
 
 use khive_pack_schedule::SchedulePack;
-use khive_runtime::{KhiveRuntime, VerbRegistryBuilder};
+use khive_runtime::VerbRegistryBuilder;
 use khive_types::Pack;
+
+mod support;
 
 #[test]
 fn schedule_pack_declares_scheduled_event_note_kind() {
@@ -27,7 +29,7 @@ fn schedule_pack_requires_kg() {
 #[tokio::test]
 async fn schedule_pack_exposes_non_empty_schema_plan() {
     use khive_runtime::PackRuntime;
-    let runtime = KhiveRuntime::memory().expect("in-memory runtime");
+    let runtime = support::memory_runtime();
     let pack = SchedulePack::new(runtime);
     let plan = pack.schema_plan();
 
@@ -58,7 +60,7 @@ async fn schedule_pack_exposes_non_empty_schema_plan() {
 
 #[tokio::test]
 async fn verb_registry_aggregates_schedule_schema_plan() {
-    let runtime = KhiveRuntime::memory().expect("in-memory runtime");
+    let runtime = support::memory_runtime();
     let mut builder = VerbRegistryBuilder::new();
     builder.register(khive_pack_kg::KgPack::new(runtime.clone()));
     builder.register(SchedulePack::new(runtime.clone()));

--- a/crates/khive-pack-schedule/tests/support/mod.rs
+++ b/crates/khive-pack-schedule/tests/support/mod.rs
@@ -1,0 +1,43 @@
+//! Shared test-only helpers for khive-pack-schedule's integration tests.
+//!
+//! Issue #779: 8 (then 14, then 42, accelerating) year-2099 sentinel fixture
+//! rows from schedule pack fixture content ("check the build", "repeat=daily",
+//! "window-early", "sort-order-jan", ...) were found parked in a real,
+//! on-disk store. Every test in this crate already constructs its own
+//! `KhiveRuntime` explicitly rather than resolving one from ambient CLI
+//! args/env/config discovery, but that invariant lived only as an unenforced
+//! convention duplicated across five separate test files (`agenda.rs`,
+//! `cancel.rs`, `create_validation.rs`, `integration.rs`,
+//! `pack_registration.rs`) -- nothing stopped a future edit from silently
+//! swapping in an ambiently-resolved runtime.
+//!
+//! `memory_runtime` is the single choke point every one of those files now
+//! routes through: it constructs the in-memory runtime AND asserts the
+//! resulting backend is not file-backed, so a regression fails the test
+//! immediately (in-process, no I/O against any real path) instead of quietly
+//! writing fixtures into whatever store the environment happens to resolve.
+//! This is a test-only helper -- it is compiled only into the `tests/*`
+//! integration test binaries, never into the shipped crate.
+
+use khive_runtime::KhiveRuntime;
+
+/// Construct an in-memory `KhiveRuntime` for schedule pack tests, and refuse
+/// to hand back anything file-backed.
+///
+/// `KhiveRuntime::memory()` always resolves to `db_path: None` (a true
+/// SQLite `:memory:` connection, never a file literally named `:memory:`) by
+/// construction, so this assertion should never trip today. It exists to
+/// catch a future regression -- e.g. a call site switched to
+/// `KhiveRuntime::new(RuntimeConfig::default())` or another path that goes
+/// through ambient config/env/cwd resolution -- before it can write a single
+/// fixture row into a real database.
+pub fn memory_runtime() -> KhiveRuntime {
+    let runtime = KhiveRuntime::memory().expect("in-memory runtime");
+    assert!(
+        !runtime.backend().is_file_backed(),
+        "khive-pack-schedule tests must construct an in-memory KhiveRuntime, \
+         never a file-backed one (issue #779) -- a file-backed backend here \
+         means test fixtures would be written into a real, on-disk store"
+    );
+    runtime
+}

--- a/tests/smoke_schedule.py
+++ b/tests/smoke_schedule.py
@@ -103,13 +103,38 @@ def call_verb_expect_error(proc, name, args):
     return first.get("error", "<no error string>")
 
 
+# Issue #779: 8 (then 14, then 42, accelerating) year-2099 schedule-pack
+# fixture rows -- matching this file's exact test content ("check the build",
+# "repeat=daily", "window-early", "sort-order-jan", ...) -- were found parked
+# in a real, on-disk store. This script's fixtures must only ever land in an
+# ephemeral store; ISOLATION_DB is the single source of truth for that, and
+# spawn_proc asserts its own argv actually carries it before returning the
+# process, so a future edit that drops or changes the `--db` flag fails this
+# script immediately instead of silently writing into whatever store the
+# environment resolves.
+ISOLATION_DB = ":memory:"
+
+
 def spawn_proc():
-    """Spawn a fresh khive-mcp process with kg + schedule packs."""
+    """Spawn a fresh khive-mcp process with kg + schedule packs.
+
+    Always isolated: `--db :memory:` is non-negotiable for this script, so we
+    build argv from ISOLATION_DB and assert it landed exactly where expected
+    rather than trusting the literal below never drifts.
+    """
+    argv = [
+        BINARY, "mcp", "--db", ISOLATION_DB, "--no-embed", "--log", "error",
+        "--pack", "kg", "--pack", "schedule",
+    ]
+    db_flag_index = argv.index("--db")
+    assert argv[db_flag_index + 1] == ISOLATION_DB, (
+        "refusing to spawn: --db must be an ephemeral store "
+        f"({ISOLATION_DB!r}), got {argv[db_flag_index + 1]!r} -- this guard "
+        "exists so this script can never silently write schedule pack "
+        "fixtures into a real database (issue #779)"
+    )
     return subprocess.Popen(
-        [
-            BINARY, "mcp", "--db", ":memory:", "--no-embed", "--log", "error",
-            "--pack", "kg", "--pack", "schedule",
-        ],
+        argv,
         stdin=subprocess.PIPE,
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,


### PR DESCRIPTION
Closes #779

## Root cause

Every `khive-pack-schedule` Rust test already constructs its own `KhiveRuntime::memory()` (`db_path: None` -> a true in-memory SQLite connection, bypassing ambient CLI/env/config discovery entirely), and `tests/smoke_schedule.py` already spawns its binary with an explicit `--db :memory:` on every invocation. Neither path resolves an ambient or live store as currently written on `main`.

What was missing was an *enforced* invariant: nothing stopped a future edit to any of the five schedule test files from silently swapping in a file-backed or ambiently-resolved runtime, and nothing in the smoke test asserted its own isolation flag actually landed in the spawned argv. Given that review, the most plausible source of the observed live-store rows (8 -> 14 -> 42, accelerating) is out-of-band: fixture content copied into a live MCP session, or a stale/globally-installed `kkernel` binary invoked outside this repo's own build, while manually exercising the schedule pack -- not a `cargo test` or `python3 tests/smoke_schedule.py` run of the code as it exists on `main`.

## Changes

- New `crates/khive-pack-schedule/tests/support/mod.rs`: a single `memory_runtime()` choke point every one of the five schedule test files (`agenda`, `cancel`, `create_validation`, `integration`, `pack_registration`) now routes through. It constructs the in-memory runtime and asserts the resulting backend is not file-backed, so a future regression fails the test immediately -- in-process, no I/O against any real path -- instead of silently writing fixtures into whatever store the environment resolves.
- `tests/smoke_schedule.py`: `spawn_proc()` now builds argv from a named `ISOLATION_DB` constant and asserts `--db` landed on it before spawning, so a future edit that drops or changes the flag fails loud instead of quietly running against a default/live database.

## Out of scope

The one-time curation of the fixture rows already parked in the live database needs direct access to that store, which this change deliberately never touches (per safety constraints on this task). Flagging as a follow-up for whoever holds that access.

## Test plan

- [x] `cargo test -p khive-pack-schedule` -- 105 tests, 0 failed
- [x] `cargo clippy -p khive-pack-schedule --all-targets -- -D warnings` -- clean
- [x] `cargo fmt --all` -- no diff
- [x] `KKERNEL_BINARY=<local build> python3 tests/smoke_schedule.py` -- all 20 scenarios pass against a real built binary, confirming the new `ISOLATION_DB` guard doesn't regress behavior
