### PR TITLE
fix(pack-memory): bound memory.recall with a fail-soft deadline

### DIFF
--- a/crates/khive-pack-memory/src/handlers/recall.rs
+++ b/crates/khive-pack-memory/src/handlers/recall.rs
@@ -929,7 +929,9 @@ mod tests {
 
     use async_trait::async_trait;
     use khive_pack_kg::KgPack;
-    use khive_runtime::{EmbedderProvider, KhiveRuntime, Namespace, VerbRegistryBuilder};
+    use khive_runtime::{
+        EmbedderProvider, KhiveRuntime, Namespace, RuntimeError, VerbRegistryBuilder,
+    };
     use khive_storage::Entity;
     use lattice_embed::{EmbedError, EmbeddingModel, EmbeddingService};
     use serde_json::Value;
@@ -4803,5 +4805,160 @@ mod tests {
     fn entity_lookup_candidates_empty_query_returns_empty() {
         assert!(crate::scoring::entity_lookup_candidates("").is_empty());
         assert!(crate::scoring::entity_lookup_candidates("   ").is_empty());
+    }
+
+    /// #889: an absurdly small deadline override (1ms) must abort
+    /// `handle_recall` with a typed `DeadlineExceeded` error rather than let
+    /// the caller wait for the pipeline to finish. 1ms is comfortably below
+    /// this uncontended in-memory pipeline's minimum real wall time on any
+    /// machine, so the timeout branch fires deterministically without needing
+    /// to hold a lock or otherwise force contention (contrast with the #836
+    /// tests above, which simulate a specific held lock to force their
+    /// narrower ANN-wait timeout). Proves the wrap actually races the
+    /// deadline against the real pipeline and returns promptly on the
+    /// timeout branch, not just that the code compiles.
+    #[tokio::test]
+    async fn recall_889_deadline_exceeded_returns_typed_error_not_hang() {
+        let rt = KhiveRuntime::memory().expect("in-memory runtime");
+        let ns = Namespace::parse("local").expect("local namespace");
+        let token = rt.authorize(ns).expect("authorize local");
+
+        rt.create_note(
+            &token,
+            "memory",
+            None,
+            "issue 889 deadline exceeded test note",
+            Some(0.7),
+            None,
+            vec![],
+        )
+        .await
+        .expect("create note");
+
+        let mut builder = VerbRegistryBuilder::new();
+        builder.register(KgPack::new(rt.clone()));
+        builder.register(MemoryPack::new(rt.clone()));
+        let registry = builder.build().expect("registry");
+
+        let start = std::time::Instant::now();
+        let result = registry
+            .dispatch(
+                "memory.recall",
+                serde_json::json!({
+                    "query": "889 deadline exceeded test",
+                    "limit": 10,
+                    "config": { "recall_deadline_ms": 1 }
+                }),
+            )
+            .await;
+        let elapsed = start.elapsed();
+
+        assert!(
+            elapsed < std::time::Duration::from_secs(5),
+            "#889 a timed-out recall must return promptly, never hang toward \
+             an upstream client-side ceiling (300s observed in production); \
+             took {elapsed:?}"
+        );
+
+        match result {
+            Err(RuntimeError::DeadlineExceeded {
+                operation,
+                budget_ms,
+                ..
+            }) => {
+                assert_eq!(operation, "memory.recall");
+                assert_eq!(budget_ms, 1);
+            }
+            other => panic!("#889 expected DeadlineExceeded, got: {other:?}"),
+        }
+    }
+
+    /// #889: the default (generous, 30s) deadline must not affect a normal,
+    /// fast, uncontended recall — no new error, no behavior change on the
+    /// happy path relative to pre-#889 behavior.
+    #[tokio::test]
+    async fn recall_889_normal_path_succeeds_within_default_deadline() {
+        let rt = KhiveRuntime::memory().expect("in-memory runtime");
+        let ns = Namespace::parse("local").expect("local namespace");
+        let token = rt.authorize(ns).expect("authorize local");
+
+        rt.create_note(
+            &token,
+            "memory",
+            None,
+            "issue 889 normal path recall note",
+            Some(0.7),
+            None,
+            vec![],
+        )
+        .await
+        .expect("create note");
+
+        let mut builder = VerbRegistryBuilder::new();
+        builder.register(KgPack::new(rt.clone()));
+        builder.register(MemoryPack::new(rt.clone()));
+        let registry = builder.build().expect("registry");
+
+        let result = registry
+            .dispatch(
+                "memory.recall",
+                serde_json::json!({
+                    "query": "889 normal path recall",
+                    "limit": 10
+                }),
+            )
+            .await
+            .expect("recall must succeed within the default deadline");
+
+        let results = result.as_array().expect("recall result must be an array");
+        assert!(
+            !results.is_empty(),
+            "normal recall must surface the seeded note"
+        );
+    }
+
+    /// #889: a generous per-request override (well above real wall time) must
+    /// behave identically to the default — the override path is symmetric,
+    /// not "only ever tightens".
+    #[tokio::test]
+    async fn recall_889_generous_override_succeeds() {
+        let rt = KhiveRuntime::memory().expect("in-memory runtime");
+        let ns = Namespace::parse("local").expect("local namespace");
+        let token = rt.authorize(ns).expect("authorize local");
+
+        rt.create_note(
+            &token,
+            "memory",
+            None,
+            "issue 889 generous override recall note",
+            Some(0.7),
+            None,
+            vec![],
+        )
+        .await
+        .expect("create note");
+
+        let mut builder = VerbRegistryBuilder::new();
+        builder.register(KgPack::new(rt.clone()));
+        builder.register(MemoryPack::new(rt.clone()));
+        let registry = builder.build().expect("registry");
+
+        let result = registry
+            .dispatch(
+                "memory.recall",
+                serde_json::json!({
+                    "query": "889 generous override recall",
+                    "limit": 10,
+                    "config": { "recall_deadline_ms": 120_000 }
+                }),
+            )
+            .await
+            .expect("recall must succeed under a generous override");
+
+        let results = result.as_array().expect("recall result must be an array");
+        assert!(
+            !results.is_empty(),
+            "normal recall must surface the seeded note under a generous override"
+        );
     }
 }

--- a/crates/khive-pack-memory/src/handlers/recall.rs
+++ b/crates/khive-pack-memory/src/handlers/recall.rs
@@ -936,6 +936,7 @@ mod tests {
     use lattice_embed::{EmbedError, EmbeddingModel, EmbeddingService};
     use serde_json::Value;
     use serial_test::serial;
+    use tokio::sync::Notify;
     use uuid::Uuid;
 
     use crate::MemoryPack;
@@ -4807,18 +4808,138 @@ mod tests {
         assert!(crate::scoring::entity_lookup_candidates("   ").is_empty());
     }
 
-    /// #889: an absurdly small deadline override (1ms) must abort
-    /// `handle_recall` with a typed `DeadlineExceeded` error rather than let
-    /// the caller wait for the pipeline to finish. 1ms is comfortably below
-    /// this uncontended in-memory pipeline's minimum real wall time on any
-    /// machine, so the timeout branch fires deterministically without needing
-    /// to hold a lock or otherwise force contention (contrast with the #836
-    /// tests above, which simulate a specific held lock to force their
-    /// narrower ANN-wait timeout). Proves the wrap actually races the
-    /// deadline against the real pipeline and returns promptly on the
-    /// timeout branch, not just that the code compiles.
+    // ── #889 codex r1 [Med 2]: a genuinely held embed stage ────────────────
+    //
+    // A `1ms` deadline racing the real uncontended in-memory pipeline (the
+    // original version of this test suite) proves the wrap *can* fire, but
+    // whether the real pipeline actually takes more than 1ms is host/load
+    // dependent — not a deterministic regression proof for the deadline
+    // behavior under the contention that caused #889. `SlowEmbedService`
+    // gives the deadline tests below a real, host-independent contention
+    // point: its `embed()` blocks on a `Notify` the test controls directly,
+    // mirroring the `#836` tests' held-ANN-lock technique but for the
+    // query-embed stage specifically.
+
+    struct SlowEmbedService {
+        hold: Arc<Notify>,
+    }
+
+    #[async_trait]
+    impl EmbeddingService for SlowEmbedService {
+        async fn embed(
+            &self,
+            texts: &[String],
+            _model: EmbeddingModel,
+        ) -> Result<Vec<Vec<f32>>, EmbedError> {
+            self.hold.notified().await;
+            Ok(texts.iter().map(|_| vec![0.0_f32; 8]).collect())
+        }
+
+        fn supports_model(&self, _model: EmbeddingModel) -> bool {
+            true
+        }
+
+        fn name(&self) -> &'static str {
+            "slow-notify"
+        }
+    }
+
+    struct SlowEmbedProvider {
+        model_name: String,
+        hold: Arc<Notify>,
+    }
+
+    #[async_trait]
+    impl EmbedderProvider for SlowEmbedProvider {
+        fn name(&self) -> &str {
+            &self.model_name
+        }
+
+        fn dimensions(&self) -> usize {
+            8
+        }
+
+        async fn build(&self) -> Result<Arc<dyn EmbeddingService>, khive_runtime::RuntimeError> {
+            Ok(Arc::new(SlowEmbedService {
+                hold: self.hold.clone(),
+            }))
+        }
+    }
+
+    /// #889 codex r1 [Med 1]: pure unit coverage for
+    /// `parse_recall_deadline_override`'s precedence and validation — an
+    /// absent or explicit-`null` override falls through (returns `None`,
+    /// signaling "use the process default"), a valid positive value wins,
+    /// and zero/negative/non-numeric values are all rejected as
+    /// `InvalidInput` rather than silently coerced.
+    #[test]
+    fn recall_889_parse_deadline_override_precedence_and_validation() {
+        use crate::pack::parse_recall_deadline_override as parse_override;
+
+        assert_eq!(
+            parse_override(&serde_json::json!({ "query": "x", "limit": 5 })).unwrap(),
+            None,
+            "absent config.recall_deadline_ms must fall through to the process default"
+        );
+        assert_eq!(
+            parse_override(&serde_json::json!({
+                "config": { "recall_deadline_ms": Value::Null }
+            }))
+            .unwrap(),
+            None,
+            "an explicit JSON null override must fall through like an absent one"
+        );
+        assert_eq!(
+            parse_override(&serde_json::json!({ "config": { "recall_deadline_ms": 5000 } }))
+                .unwrap(),
+            Some(5000),
+            "a valid positive override must win over the process default"
+        );
+
+        for bad in [
+            serde_json::json!({ "config": { "recall_deadline_ms": 0 } }),
+            serde_json::json!({ "config": { "recall_deadline_ms": -5 } }),
+            serde_json::json!({ "config": { "recall_deadline_ms": "not-a-number" } }),
+            serde_json::json!({ "config": { "recall_deadline_ms": [1, 2] } }),
+        ] {
+            match parse_override(&bad) {
+                Err(RuntimeError::InvalidInput(_)) => {}
+                other => {
+                    panic!("expected InvalidInput for a malformed override {bad:?}, got: {other:?}")
+                }
+            }
+        }
+    }
+
+    /// #889 codex r1 [Med 1]: pure unit coverage for
+    /// `parse_recall_deadline_env` — unlike the per-request override path,
+    /// an absent, zero, negative, or non-numeric env value must all fall
+    /// back to the 30s default rather than erroring (a malformed operator
+    /// env var must not brick every `memory.recall` call on the daemon).
+    #[test]
+    fn recall_889_env_deadline_ms_validates_and_falls_back_to_default() {
+        use crate::pack::parse_recall_deadline_env as parse_env;
+
+        const DEFAULT_MS: u64 = 30_000;
+        assert_eq!(parse_env(None), DEFAULT_MS);
+        assert_eq!(parse_env(Some("5000")), 5000);
+
+        for bad in ["0", "-5", "not-a-number", ""] {
+            assert_eq!(
+                parse_env(Some(bad)),
+                DEFAULT_MS,
+                "invalid env value {bad:?} must fall back to the default, not brick the daemon"
+            );
+        }
+    }
+
+    /// #889 codex r1 [Med 1]: an invalid per-request `recall_deadline_ms`
+    /// override (zero) must surface as a per-op `InvalidInput` error
+    /// through the full `memory.recall` dispatch, not silently fall through
+    /// to the process default (which a bare `0` would otherwise turn into
+    /// an always-immediate timeout) and not hang.
     #[tokio::test]
-    async fn recall_889_deadline_exceeded_returns_typed_error_not_hang() {
+    async fn recall_889_zero_deadline_override_returns_invalid_input_via_dispatch() {
         let rt = KhiveRuntime::memory().expect("in-memory runtime");
         let ns = Namespace::parse("local").expect("local namespace");
         let token = rt.authorize(ns).expect("authorize local");
@@ -4827,7 +4948,74 @@ mod tests {
             &token,
             "memory",
             None,
-            "issue 889 deadline exceeded test note",
+            "issue 889 zero deadline override validation note",
+            Some(0.7),
+            None,
+            vec![],
+        )
+        .await
+        .expect("create note");
+
+        let mut builder = VerbRegistryBuilder::new();
+        builder.register(KgPack::new(rt.clone()));
+        builder.register(MemoryPack::new(rt.clone()));
+        let registry = builder.build().expect("registry");
+
+        let result = registry
+            .dispatch(
+                "memory.recall",
+                serde_json::json!({
+                    "query": "889 zero deadline override validation",
+                    "limit": 10,
+                    "config": { "recall_deadline_ms": 0 }
+                }),
+            )
+            .await;
+
+        match result {
+            Err(RuntimeError::InvalidInput(msg)) => {
+                assert!(
+                    msg.contains("recall_deadline_ms"),
+                    "InvalidInput message should name the offending field, got: {msg:?}"
+                );
+            }
+            other => panic!("expected InvalidInput for a zero deadline override, got: {other:?}"),
+        }
+    }
+
+    /// #889 codex r1 [Med 2]: with the query-embed stage genuinely held (not
+    /// racing incidental wall time), a comfortably-sized 50ms deadline must
+    /// still return `DeadlineExceeded` promptly. Fail-on-revert proof:
+    /// reverting `handle_recall_with_deadline`'s `tokio::time::timeout` wrap
+    /// back to a bare `.await` makes this test hang for the lifetime of the
+    /// held `Notify` (never signaled until after the assertion), so it
+    /// would fail on the `elapsed < ...` bound or the test binary's own
+    /// deadline.
+    #[tokio::test]
+    async fn recall_889_deadline_exceeded_with_held_embed_stage_returns_typed_error_promptly() {
+        const MODEL: &str = "recall-889-slow-model";
+        let hold = Arc::new(Notify::new());
+
+        let rt = KhiveRuntime::memory().expect("in-memory runtime");
+        rt.register_embedder(SlowEmbedProvider {
+            model_name: MODEL.to_owned(),
+            hold: hold.clone(),
+        });
+
+        let ns = Namespace::parse("local").expect("local namespace");
+        let token = rt.authorize(ns).expect("authorize local");
+
+        // Pre-store one permit so the note-creation embed call below (which
+        // shares the same `hold`) completes immediately instead of hanging
+        // setup; the recall's own query-embed call is the *next*
+        // `.notified()` call, which genuinely blocks since no permit
+        // remains.
+        hold.notify_one();
+        rt.create_note(
+            &token,
+            "memory",
+            None,
+            "issue 889 held embed stage test note",
             Some(0.7),
             None,
             vec![],
@@ -4845,18 +5033,23 @@ mod tests {
             .dispatch(
                 "memory.recall",
                 serde_json::json!({
-                    "query": "889 deadline exceeded test",
+                    "query": "889 held embed stage test",
                     "limit": 10,
-                    "config": { "recall_deadline_ms": 1 }
+                    "config": { "recall_deadline_ms": 50 }
                 }),
             )
             .await;
         let elapsed = start.elapsed();
 
+        // Release the now-stuck spawn_blocking thread so it can finish and
+        // free its blocking-pool slot; the outer timeout has already fired
+        // and dropped the awaiting future well before this point.
+        hold.notify_one();
+
         assert!(
             elapsed < std::time::Duration::from_secs(5),
-            "#889 a timed-out recall must return promptly, never hang toward \
-             an upstream client-side ceiling (300s observed in production); \
+            "#889 a timed-out recall must return promptly even while its embed \
+             stage is genuinely held, not wait for the held stage to release; \
              took {elapsed:?}"
         );
 
@@ -4867,10 +5060,99 @@ mod tests {
                 ..
             }) => {
                 assert_eq!(operation, "memory.recall");
-                assert_eq!(budget_ms, 1);
+                assert_eq!(budget_ms, 50);
             }
-            other => panic!("#889 expected DeadlineExceeded, got: {other:?}"),
+            other => {
+                panic!("#889 expected DeadlineExceeded with the embed stage held, got: {other:?}")
+            }
         }
+    }
+
+    /// #889 codex r1 [Med 2]: a deadline-exceeded op must not affect a
+    /// concurrently-dispatched sibling — mirrors the isolation the MCP
+    /// layer's parallel-batch executor already provides
+    /// (`khive-mcp/src/server.rs`: each op independently mapped to
+    /// `{ok, tool, error}` and joined via `futures::future::join_all`,
+    /// never abort-on-failure). `khive-pack-memory` has no dependency on
+    /// `khive-mcp` to drive an actual MCP wire round-trip, so this exercises
+    /// the same property one layer down, at the `VerbRegistry` dispatch
+    /// boundary the MCP executor sits on top of: two independent
+    /// `registry.dispatch` futures run concurrently via `tokio::join!`, one
+    /// held past its deadline and one a normal fast op, and both must
+    /// resolve to their own independent outcome.
+    #[tokio::test]
+    async fn recall_889_deadline_exceeded_does_not_affect_concurrent_sibling_op() {
+        const MODEL: &str = "recall-889-slow-sibling-model";
+        let hold = Arc::new(Notify::new());
+
+        let rt = KhiveRuntime::memory().expect("in-memory runtime");
+        rt.register_embedder(SlowEmbedProvider {
+            model_name: MODEL.to_owned(),
+            hold: hold.clone(),
+        });
+
+        let ns = Namespace::parse("local").expect("local namespace");
+        let token = rt.authorize(ns).expect("authorize local");
+
+        hold.notify_one();
+        rt.create_note(
+            &token,
+            "memory",
+            None,
+            "issue 889 sibling isolation held note",
+            Some(0.7),
+            None,
+            vec![],
+        )
+        .await
+        .expect("create note");
+
+        let mut builder = VerbRegistryBuilder::new();
+        builder.register(KgPack::new(rt.clone()));
+        builder.register(MemoryPack::new(rt.clone()));
+        let registry = builder.build().expect("registry");
+
+        let slow_recall = registry.dispatch(
+            "memory.recall",
+            serde_json::json!({
+                "query": "889 sibling isolation held note",
+                "limit": 10,
+                "config": { "recall_deadline_ms": 50 }
+            }),
+        );
+        // `stats` touches no embedder and no held model, so it must
+        // complete quickly regardless of the sibling recall's fate.
+        let sibling_stats = registry.dispatch("stats", serde_json::json!({}));
+
+        let (slow_result, sibling_result) = tokio::join!(slow_recall, sibling_stats);
+        hold.notify_one();
+
+        let slow_err = slow_result.expect_err("expected the held-stage recall to time out");
+        match &slow_err {
+            RuntimeError::DeadlineExceeded {
+                operation,
+                budget_ms,
+                ..
+            } => {
+                assert_eq!(operation, "memory.recall");
+                assert_eq!(*budget_ms, 50);
+            }
+            other => panic!("expected DeadlineExceeded, got: {other:?}"),
+        }
+        let slow_err_text = slow_err.to_string();
+        assert!(
+            slow_err_text.to_lowercase().contains("deadline"),
+            "DeadlineExceeded display text must name the deadline for operator/CLI \
+             visibility, got: {slow_err_text:?}"
+        );
+
+        assert!(
+            sibling_result.is_ok(),
+            "a concurrently-dispatched sibling op must succeed independently of a \
+             sibling deadline timeout — isolation must hold at the VerbRegistry \
+             dispatch boundary the MCP parallel-batch executor sits on top of; got: {:?}",
+            sibling_result.err()
+        );
     }
 
     /// #889: the default (generous, 30s) deadline must not affect a normal,

--- a/crates/khive-pack-memory/src/pack.rs
+++ b/crates/khive-pack-memory/src/pack.rs
@@ -493,24 +493,26 @@ impl MemoryPack {
     /// The deadline is read from `params.config.recall_deadline_ms` when
     /// present (a per-request override, checked here rather than inside
     /// `handle_recall` because the wrap has to start before that function's
-    /// own `deser(params)` runs) with a defensive, non-strict lookup — an
-    /// absent or malformed override just falls through to the process-wide
-    /// `recall_deadline_ms()` default/env value, exactly like `handle_recall`
-    /// itself already falls through to `ann_ready_timeout_ms()`. This never
-    /// tightens or duplicates `RecallParams`'s own validation of `params`;
-    /// `handle_recall` still parses (and rejects, if malformed) the full
-    /// params normally.
+    /// own `deser(params)` runs); an absent or explicit-`null` value falls
+    /// through to the process-wide `recall_deadline_ms()` default/env value,
+    /// exactly like `handle_recall` itself already falls through to
+    /// `ann_ready_timeout_ms()`. A *present*, non-null value must be a
+    /// strictly positive integer — see `parse_recall_deadline_override`
+    /// (#889 codex r1 [Med 1]: a zero or malformed override is a per-op
+    /// `InvalidInput` error, not a silent coercion to the default). This
+    /// never tightens or duplicates `RecallParams`'s own validation of
+    /// `params`; `handle_recall` still parses (and rejects, if malformed)
+    /// the full params normally.
     async fn handle_recall_with_deadline(
         &self,
         token: &NamespaceToken,
         params: Value,
         registry: &VerbRegistry,
     ) -> Result<Value, RuntimeError> {
-        let budget_ms = params
-            .get("config")
-            .and_then(|c| c.get("recall_deadline_ms"))
-            .and_then(|v| v.as_u64())
-            .unwrap_or_else(recall_deadline_ms);
+        let budget_ms = match parse_recall_deadline_override(&params)? {
+            Some(ms) => ms,
+            None => recall_deadline_ms(),
+        };
         let start = std::time::Instant::now();
         match tokio::time::timeout(
             std::time::Duration::from_millis(budget_ms),
@@ -528,6 +530,76 @@ impl MemoryPack {
     }
 }
 
+/// #889 codex r1 [Med 1]: parse and validate an optional per-request
+/// `config.recall_deadline_ms` override. `None` (the key absent, or present
+/// as JSON `null`) means "no override" and the caller falls through to the
+/// process-wide `recall_deadline_ms()` default/env value. A *present*,
+/// non-null value must be a strictly positive integer — matching
+/// ADR-033's invalid-config contract ("Invalid configs ... are caught at
+/// handler entry and return a per-op `{ok: false, error: ...}` response;
+/// the batch does not abort"), this returns `InvalidInput` rather than
+/// silently coercing a malformed override to the default. Silent coercion
+/// would otherwise turn a caller's `0` into an always-immediate timeout, or
+/// swallow a caller's negative/non-numeric typo into an unnoticed default.
+pub(crate) fn parse_recall_deadline_override(params: &Value) -> Result<Option<u64>, RuntimeError> {
+    let Some(raw) = params
+        .get("config")
+        .and_then(|c| c.get("recall_deadline_ms"))
+    else {
+        return Ok(None);
+    };
+    if raw.is_null() {
+        return Ok(None);
+    }
+    match raw.as_u64() {
+        Some(ms) if ms > 0 => Ok(Some(ms)),
+        _ => Err(RuntimeError::InvalidInput(format!(
+            "config.recall_deadline_ms must be a positive integer milliseconds value, got {raw}"
+        ))),
+    }
+}
+
+/// #889 codex r1 [Med 1]: pure parse/validate step for
+/// `KHIVE_MEMORY_RECALL_DEADLINE_MS`, split out of `recall_deadline_ms`'s
+/// `OnceLock` closure so it is unit-testable without touching real process
+/// environment state or the process-lifetime-cached `OnceLock` (which, once
+/// initialized by any test in this binary, can never re-observe a
+/// different env value for the rest of that test run).
+///
+/// An absent, zero, negative, or non-numeric env value all fall back to the
+/// default and log a warning — unlike an invalid *per-request* override
+/// (`parse_recall_deadline_override`), which is a hard per-op error. This
+/// asymmetry is deliberate: a caller's malformed request is a caller bug
+/// that should surface immediately; a malformed *operator* env value must
+/// not brick every `memory.recall` call on the daemon.
+pub(crate) fn parse_recall_deadline_env(raw: Option<&str>) -> u64 {
+    const DEFAULT_RECALL_DEADLINE_MS: u64 = 30_000;
+    let Some(raw) = raw else {
+        return DEFAULT_RECALL_DEADLINE_MS;
+    };
+    match raw.parse::<u64>() {
+        Ok(ms) if ms > 0 => ms,
+        Ok(_) => {
+            tracing::warn!(
+                raw = %raw,
+                default_ms = DEFAULT_RECALL_DEADLINE_MS,
+                "KHIVE_MEMORY_RECALL_DEADLINE_MS=0 is not a valid recall deadline; \
+                 falling back to the default (#889 codex r1)"
+            );
+            DEFAULT_RECALL_DEADLINE_MS
+        }
+        Err(_) => {
+            tracing::warn!(
+                raw = %raw,
+                default_ms = DEFAULT_RECALL_DEADLINE_MS,
+                "KHIVE_MEMORY_RECALL_DEADLINE_MS is not a valid positive integer; \
+                 falling back to the default (#889 codex r1)"
+            );
+            DEFAULT_RECALL_DEADLINE_MS
+        }
+    }
+}
+
 /// #889: bounded end-to-end deadline, in milliseconds, for the entire
 /// `memory.recall` pipeline. 30s sits comfortably above every latency this
 /// pipeline needs under normal-to-heavy load (single-digit-to-low-hundreds
@@ -536,14 +608,11 @@ impl MemoryPack {
 /// staying far short of the 300s client-side ceiling the deadline exists to
 /// preempt. Overridable via env for operators who need to tune it for a
 /// larger corpus or heavier sustained concurrency than the repro covered.
-fn recall_deadline_ms() -> u64 {
+pub(crate) fn recall_deadline_ms() -> u64 {
     static DEADLINE_MS: std::sync::OnceLock<u64> = std::sync::OnceLock::new();
     *DEADLINE_MS.get_or_init(|| {
-        const DEFAULT_RECALL_DEADLINE_MS: u64 = 30_000;
-        let ms = std::env::var("KHIVE_MEMORY_RECALL_DEADLINE_MS")
-            .ok()
-            .and_then(|v| v.parse().ok())
-            .unwrap_or(DEFAULT_RECALL_DEADLINE_MS);
+        let raw = std::env::var("KHIVE_MEMORY_RECALL_DEADLINE_MS").ok();
+        let ms = parse_recall_deadline_env(raw.as_deref());
         khive_runtime::config_ledger::record_config_locked(
             "KHIVE_MEMORY_RECALL_DEADLINE_MS",
             ms.to_string(),

--- a/crates/khive-pack-memory/src/pack.rs
+++ b/crates/khive-pack-memory/src/pack.rs
@@ -458,7 +458,10 @@ impl PackRuntime for MemoryPack {
         match verb {
             "memory.remember" => self.handle_remember(token, params).await,
             "memory.feedback" => self.handle_feedback(token, params, registry).await,
-            "memory.recall" => self.handle_recall(token, params, registry).await,
+            "memory.recall" => {
+                self.handle_recall_with_deadline(token, params, registry)
+                    .await
+            }
             "memory.recall_embed" => self.handle_recall_embed(params).await,
             "memory.recall_candidates" => self.handle_recall_candidates(token, params).await,
             "memory.recall_fuse" => self.handle_recall_fuse(token, params, registry).await,
@@ -471,6 +474,82 @@ impl PackRuntime for MemoryPack {
             ))),
         }
     }
+}
+
+impl MemoryPack {
+    /// #889: wraps `handle_recall` in a bounded end-to-end deadline so a
+    /// caller under sustained concurrent-load contention gets a fast, typed
+    /// error instead of hanging until an upstream client-side ceiling fires
+    /// (300s observed in production incidents on 2026-07-12). This bounds the
+    /// *entire* pipeline (profile resolution, FTS + vector candidate gather
+    /// and its ANN-overfetch retry loop, hydration, fusion/scoring, MMR, and
+    /// supersedes suppression) — distinct from (and layered on top of)
+    /// `#836`'s narrower `ann_ready_timeout_ms`, which bounds only a single
+    /// cold-miss ANN-build wait inside the vector leg and degrades in-band to
+    /// an FTS-only result. A timeout here does not cancel any in-flight
+    /// storage work still owned by the runtime; it only bounds how long this
+    /// call waits for a response.
+    ///
+    /// The deadline is read from `params.config.recall_deadline_ms` when
+    /// present (a per-request override, checked here rather than inside
+    /// `handle_recall` because the wrap has to start before that function's
+    /// own `deser(params)` runs) with a defensive, non-strict lookup — an
+    /// absent or malformed override just falls through to the process-wide
+    /// `recall_deadline_ms()` default/env value, exactly like `handle_recall`
+    /// itself already falls through to `ann_ready_timeout_ms()`. This never
+    /// tightens or duplicates `RecallParams`'s own validation of `params`;
+    /// `handle_recall` still parses (and rejects, if malformed) the full
+    /// params normally.
+    async fn handle_recall_with_deadline(
+        &self,
+        token: &NamespaceToken,
+        params: Value,
+        registry: &VerbRegistry,
+    ) -> Result<Value, RuntimeError> {
+        let budget_ms = params
+            .get("config")
+            .and_then(|c| c.get("recall_deadline_ms"))
+            .and_then(|v| v.as_u64())
+            .unwrap_or_else(recall_deadline_ms);
+        let start = std::time::Instant::now();
+        match tokio::time::timeout(
+            std::time::Duration::from_millis(budget_ms),
+            self.handle_recall(token, params, registry),
+        )
+        .await
+        {
+            Ok(result) => result,
+            Err(_) => Err(RuntimeError::DeadlineExceeded {
+                operation: "memory.recall".to_string(),
+                budget_ms,
+                elapsed_ms: start.elapsed().as_millis() as u64,
+            }),
+        }
+    }
+}
+
+/// #889: bounded end-to-end deadline, in milliseconds, for the entire
+/// `memory.recall` pipeline. 30s sits comfortably above every latency this
+/// pipeline needs under normal-to-heavy load (single-digit-to-low-hundreds
+/// of milliseconds per stage even at 20-way concurrency in the #889
+/// load-harness repro, `.khive/workspaces/20260712/889-recall-stall/`) while
+/// staying far short of the 300s client-side ceiling the deadline exists to
+/// preempt. Overridable via env for operators who need to tune it for a
+/// larger corpus or heavier sustained concurrency than the repro covered.
+fn recall_deadline_ms() -> u64 {
+    static DEADLINE_MS: std::sync::OnceLock<u64> = std::sync::OnceLock::new();
+    *DEADLINE_MS.get_or_init(|| {
+        const DEFAULT_RECALL_DEADLINE_MS: u64 = 30_000;
+        let ms = std::env::var("KHIVE_MEMORY_RECALL_DEADLINE_MS")
+            .ok()
+            .and_then(|v| v.parse().ok())
+            .unwrap_or(DEFAULT_RECALL_DEADLINE_MS);
+        khive_runtime::config_ledger::record_config_locked(
+            "KHIVE_MEMORY_RECALL_DEADLINE_MS",
+            ms.to_string(),
+        );
+        ms
+    })
 }
 
 /// Check that the unified FTS tables are adequately populated relative to the

--- a/crates/khive-runtime/src/error.rs
+++ b/crates/khive-runtime/src/error.rs
@@ -266,6 +266,26 @@ pub enum RuntimeError {
     /// Store a pointer (env-var name, keychain item) rather than the raw value.
     #[error("write blocked: {0}")]
     SecretDetected(crate::secret_gate::SecretMatch),
+
+    /// A bounded per-operation deadline elapsed before the operation
+    /// completed (#889). The operation may still be running in the
+    /// background (this is a client-observable timeout, not a cancellation
+    /// signal to the underlying work) — callers should treat this as "no
+    /// answer within budget", not "the operation failed or was rolled back".
+    ///
+    /// Distinct from `#836`'s narrower `ann_ready_timeout_ms`, which bounds
+    /// only a single cold-miss ANN-build wait inside the recall vector leg
+    /// and degrades to an in-band FTS-only result. This variant bounds the
+    /// *entire* operation end-to-end and is surfaced as a typed error so a
+    /// caller under sustained contention gets a fast, clear answer instead
+    /// of hanging until an upstream client-side ceiling (observed at 300s in
+    /// production, #889) fires instead.
+    #[error("{operation} exceeded its {budget_ms}ms deadline (elapsed {elapsed_ms}ms)")]
+    DeadlineExceeded {
+        operation: String,
+        budget_ms: u64,
+        elapsed_ms: u64,
+    },
 }
 
 /// Resolve an FTS text-leg search result, failing loud on parser syntax


### PR DESCRIPTION
## Summary

`memory.recall` has no end-to-end deadline. Under sustained load the full pipeline
(profile resolution, FTS + vector candidate gather with its ANN-overfetch retry loop,
hydration, fusion/scoring, MMR, and supersedes suppression) can run long enough that
MCP clients hit their own upstream ceiling (300s observed in production, #889) while
the call is still in flight server-side.

- Wraps `memory.recall` in a bounded `tokio::time::timeout` via a new
  `handle_recall_with_deadline` dispatch wrapper in `khive-pack-memory`.
- On timeout, the call now returns a typed `RuntimeError::DeadlineExceeded` error
  immediately instead of hanging toward the client-side ceiling.
- Budget defaults to 30s (`KHIVE_MEMORY_RECALL_DEADLINE_MS` env, or a
  `params.config.recall_deadline_ms` per-request override) — well above every
  per-stage latency observed in the #889 load-harness repro (single-digit-to-
  low-hundreds of milliseconds per stage at 20-way concurrency) and well short
  of the 300s ceiling it exists to preempt.
- This is layered on top of, and distinct from, `#836`'s `ann_ready_timeout_ms`,
  which bounds only a single cold-miss ANN-build wait inside the vector leg and
  degrades in-band to an FTS-only result. This deadline bounds the *entire*
  pipeline end to end.

## Root-cause investigation (honest state)

Repro work in `.khive/workspaces/20260712/889-recall-stall/` (three load-harness
runs against scratch databases, `search`/`get`/`neighbors` used as the healthy
comparator per the reported symptom) found:

- The previously-suspected sqlite-vec KNN IN-subquery bug is **not** the current
  mechanism — ruled out by reading `VectorStore::search` at current HEAD.
- `memory.recall` is structurally and measurably slower than `kg search(kind=entity)`
  under concurrent load: a consistent ~1.7-2.2x p50 gap at every tested concurrency
  level (N=1 through N=20), confirmed at two different corpus configurations
  (15x size-asymmetric and exactly-equal), ruling out corpus size as the sole cause.
- The ANN-overfetch retry loop and the embed/vector leg both stayed cheap throughout
  and were ruled out as the dominant contributor at repro scale.
- The leading structural explanation: `khive-pack-brain`'s `BrainPack` holds a single
  process-wide `std::sync::Mutex<BrainState>` covering all profiles/bindings/namespaces.
  `memory.recall` makes two `registry.dispatch()` hops into it on every call
  (`brain.resolve` then `brain.profile`) that `kg search` never makes at all — consistent
  with the `profile_resolve` stage showing the most erratic p50-to-tail spread of any
  stage under concurrency in both full sweeps.
- A targeted cold-vs-warm-connection test (checking whether the symptom is tied to the
  first call of a fresh session/connection rather than raw concurrency) did **not**
  reproduce a cold-call penalty at repro scale — an honest negative result.
- The worst latency reproduced (~1.5s p99 at N=20) is roughly two orders of magnitude
  short of the reported 300s incidents. The magnitude gap is most plausibly explained by
  production-scale corpus size and/or daemon-lifecycle events not triggered by this
  repro (a WAL checkpoint spike to 2.5x+ the TRUNCATE threshold was found independently
  in daemon logs from an incident window; the `config_id`-mismatch/respawn path in
  `daemon.rs`'s `forward_or_spawn`/`kill_and_respawn` is verb-agnostic and untested by
  this repro's setup, and is the strongest remaining unconfirmed lead).

Given that gap, this PR ships the fail-soft mitigation only (bounds the symptom
regardless of mechanism, matches the pattern `#836` already established for the
narrower ANN-wait case). The `Mutex` contention finding is real but not confirmed as
the sole or dominant cause of the acute 300s cases, so a structural fix (sharding or
replacing that lock) is intentionally left as a follow-up pending stronger evidence
rather than attempted in this PR.

## Tests

Three new regression tests in `khive-pack-memory/src/handlers/recall.rs`:

- `recall_889_deadline_exceeded_returns_typed_error_not_hang` — 1ms override, proves
  the deadline actually races the real pipeline and returns promptly (elapsed < 5s)
  with a typed `DeadlineExceeded { operation: "memory.recall", budget_ms: 1, .. }`,
  not just that the code compiles.
- `recall_889_normal_path_succeeds_within_default_deadline` — no-regression check on
  the happy path under the default 30s budget.
- `recall_889_generous_override_succeeds` — a 120s override succeeds identically to
  the default, proving the override is symmetric (not only-ever-tightens).

## Gates (scoped to the two touched crates, run from `crates/` with a shared
`CARGO_TARGET_DIR` given lane contention)

- `cargo check -p khive-pack-memory -p khive-runtime` — clean
- `cargo test -p khive-pack-memory recall_889` — 3 passed, 0 failed
- `cargo clippy -p khive-pack-memory -p khive-runtime --all-targets -- -D warnings` — clean
- `cargo fmt -p khive-pack-memory -p khive-runtime -- --check` — clean
- `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps -p khive-pack-memory -p khive-runtime` — clean

Full workspace `cargo test` was not run given shared-lane build contention at the time
of this PR; the scoped gates above cover every file this PR touches.

Ref #889