### PR TITLE
fix(db): ADR-091 Plank 1 background age sweep over tx_registry

### DIFF
--- a/crates/khive-db/src/checkpoint.rs
+++ b/crates/khive-db/src/checkpoint.rs
@@ -34,7 +34,9 @@
 //! high-water snapshot enumeration) ride the SAME crossing gates — they are
 //! not independently rate-limited, so they never repeat on consecutive ticks
 //! that remain above a threshold. Only the per-tick `debug!` trace of the
-//! oldest open entry fires unconditionally.
+//! oldest open entry, and the ADR-091 Plank 1 age sweep below, run
+//! unconditionally on every tick — including a Skipped one; the sweep's own
+//! emissions stay edge-triggered per rung via `TxAgeSweepState`.
 //!
 //! ADR-091 Plank 2: rare TRUNCATE escalation. The periodic tick above stays
 //! PASSIVE-only and non-blocking; on top of it, `checkpoint_once` also
@@ -67,14 +69,19 @@
 //! is the ADR's own named follow-up ("closure-scoped transaction API"),
 //! already delivered for writes by a later ADR. What ships here instead is
 //! the part of Plank 1 that still applies to every registered span
-//! regardless of which mechanism created it: on each observed tick,
-//! `TxAgeSweepState` checks `khive_storage::tx_registry::oldest()`'s age
-//! against `tx_warn_secs`/`tx_max_age_secs` and escalates to `warn!`/`error!`
-//! on each below→above crossing (same debounce idiom as the WAL-pressure
-//! ladder — a sustained stale span logs once per rung, not once per tick).
-//! This is visibility, not reclamation: nothing here force-closes a stale
-//! span, matching the ADR's own accepted gap for a transaction "held idle
-//! across an await with no further calls."
+//! regardless of which mechanism created it: on EVERY tick — Skipped as well
+//! as Observed, since a registered `WriterGuard::transaction` span holds the
+//! writer mutex for its whole lifetime and would otherwise make the busiest,
+//! most relevant tick invisible to this sweep — `TxAgeSweepState` checks
+//! `khive_storage::tx_registry::oldest()`'s age against
+//! `tx_warn_secs`/`tx_max_age_secs` and escalates to `warn!`/`error!` on each
+//! below→above crossing (same debounce idiom as the WAL-pressure ladder — a
+//! sustained stale span logs once per rung, not once per tick), also
+//! re-arming both rungs if the oldest entry's identity changes between ticks
+//! so a departed span's latched state cannot suppress its replacement. This
+//! is visibility, not reclamation: nothing here force-closes a stale span,
+//! matching the ADR's own accepted gap for a transaction "held idle across
+//! an await with no further calls."
 
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
@@ -285,9 +292,10 @@ pub struct CheckpointConfig {
     /// shared open-transaction registry (`khive_storage::tx_registry`,
     /// covering every registered span regardless of which call site created
     /// it) is surfaced at `tracing::warn!` on the background sweep this
-    /// module runs every observed tick, independent of WAL page pressure —
-    /// a registered span can go stale while `wal_pages` sits well under
-    /// `warn_pages`.
+    /// module runs on EVERY tick — Skipped as well as Observed — independent
+    /// of WAL page pressure: a registered span can go stale while
+    /// `wal_pages` sits well under `warn_pages`, or while the writer is busy
+    /// and no WAL page count is sampled at all this tick.
     ///
     /// Overridable via `KHIVE_TX_WARN_SECS`.
     /// Default: 30 seconds.
@@ -404,6 +412,29 @@ impl CheckpointConfig {
                     cfg.tx_max_age_secs = Duration::from_secs(n);
                 }
             }
+        }
+
+        // The severity ladder assumes tx_warn_secs < tx_max_age_secs (Warn
+        // fires before Stale as an entry ages). A reversed or equal pair —
+        // whether from one misconfigured var or the interaction of both —
+        // would invert or collapse that ordering (e.g. WARN_SECS=120,
+        // MAX_AGE_SECS=30 emits Stale at 30s and never reaches the Warn
+        // crossing until 120s), so both are rejected together rather than
+        // silently honored. Resetting both to their defaults (rather than
+        // just clamping one) avoids guessing which of the two the operator
+        // actually meant to change.
+        if cfg.tx_warn_secs >= cfg.tx_max_age_secs {
+            let default = Self::default();
+            tracing::warn!(
+                configured_tx_warn_secs = cfg.tx_warn_secs.as_secs_f64(),
+                configured_tx_max_age_secs = cfg.tx_max_age_secs.as_secs_f64(),
+                fallback_tx_warn_secs = default.tx_warn_secs.as_secs_f64(),
+                fallback_tx_max_age_secs = default.tx_max_age_secs.as_secs_f64(),
+                "KHIVE_TX_WARN_SECS must be strictly less than KHIVE_TX_MAX_AGE_SECS; \
+                 both transaction-age thresholds were rejected and reset to their defaults"
+            );
+            cfg.tx_warn_secs = default.tx_warn_secs;
+            cfg.tx_max_age_secs = default.tx_max_age_secs;
         }
 
         cfg
@@ -578,34 +609,54 @@ pub struct TxAgeSweepState {
     /// Whether the previous observed tick's oldest entry was at/above
     /// `tx_max_age_secs`. Drives the below→above edge that fires `Stale`.
     was_above_max_age: bool,
+    /// Identity of the entry the previous observed tick reported as oldest,
+    /// or `None` if the registry was empty. Tracked separately from the two
+    /// latches above so a change in *which span* is oldest can be detected
+    /// even when both latches are already `true` (see [`Self::observe`]).
+    tracked_id: Option<khive_storage::tx_registry::TxId>,
 }
 
 impl TxAgeSweepState {
     /// Advance by one observed tick given the registry's current oldest
-    /// entry (or `None` if the registry is empty). Returns zero, one, or two
-    /// emissions: an entry can cross both rungs on the same tick if it was
-    /// already stale the first time this sweep observed it (e.g. right after
-    /// process start).
+    /// entry (identity, age, label), or `None` if the registry is empty.
+    /// Returns zero, one, or two emissions: an entry can cross both rungs on
+    /// the same tick if it was already stale the first time this sweep
+    /// observed it in that identity — e.g. right after process start, or
+    /// right after it became the new oldest entry by replacing a
+    /// since-closed span.
     ///
-    /// A below-threshold oldest entry (or no entry at all — the previously
-    /// stale span closed and either nothing or a fresher span is now
-    /// oldest) resets both latches, so a future stale span re-arms both
-    /// rungs. This is computed directly from the current oldest entry's own
-    /// age every tick, so no separate "did the registry change identity"
-    /// tracking is needed: a fresher oldest entry naturally reads as
-    /// below-threshold and clears the latch.
+    /// A below-threshold oldest entry (or no entry at all) resets both
+    /// latches, so a future stale span re-arms both rungs. Identity is also
+    /// tracked explicitly: if the oldest entry's [`TxId`](khive_storage::tx_registry::TxId)
+    /// differs from the previous tick's, both latches are force-reset before
+    /// re-evaluating the new entry's age, even though this happens on the
+    /// SAME tick as the age check (not a separate below-threshold tick in
+    /// between). Without this, an already-latched-`true` state from the
+    /// *departed* entry would silently suppress the crossing for a
+    /// *different* span that replaced it while already stale — naming
+    /// nobody at exactly the moment a new long-lived span starts pinning the
+    /// database, which is the scenario this sweep exists to catch. A merely
+    /// fresher replacement still reads as below-threshold either way, so the
+    /// identity check changes behavior only for an already-stale successor.
     pub fn observe(
         &mut self,
-        oldest: Option<(Duration, Option<String>)>,
+        oldest: Option<(khive_storage::tx_registry::TxId, Duration, Option<String>)>,
         config: &CheckpointConfig,
     ) -> Vec<TxAgeEmission> {
         let mut emissions = Vec::new();
 
-        let Some((age, label)) = oldest else {
+        let Some((id, age, label)) = oldest else {
             self.was_above_warn = false;
             self.was_above_max_age = false;
+            self.tracked_id = None;
             return emissions;
         };
+
+        if self.tracked_id != Some(id) {
+            self.was_above_warn = false;
+            self.was_above_max_age = false;
+        }
+        self.tracked_id = Some(id);
 
         let above_warn = age >= config.tx_warn_secs;
         let above_max_age = age >= config.tx_max_age_secs;
@@ -728,6 +779,26 @@ pub async fn run_checkpoint_task(
         }
 
         let tick = checkpoint_once(&pool, &config, &mut truncate_state);
+
+        // ADR-091 Plank 1: age-based sweep over the registry's oldest entry
+        // MUST run on every tick, including a Skipped one — deliberately
+        // BEFORE the Skipped early-continue below. A registered
+        // `WriterGuard::transaction` span (`pool.rs`) holds the writer mutex
+        // for its entire registered lifetime, so exactly the long-running
+        // transaction this sweep exists to name is the one that makes an
+        // ordinary checkpoint tick observe `Skipped` — gating the sweep on
+        // `Observed` would silence it for precisely that scenario, defeating
+        // the WAL-independent diagnostic the ADR specifies. Independent of
+        // WAL page pressure by the same design: a registered span can go
+        // stale (KHIVE_TX_WARN_SECS / KHIVE_TX_MAX_AGE_SECS) while
+        // wal_pages sits well under warn_pages, or isn't sampled at all this
+        // tick. Edge-triggered per rung, same debounce idiom as the severity
+        // ladder below, so a sustained stale span logs once per rung rather
+        // than once per tick.
+        for emission in tx_age_state.observe(khive_storage::tx_registry::oldest(), &config) {
+            log_tx_age_emission(&emission);
+        }
+
         // Skipped ticks leave crossing state unchanged — a busy tick must not
         // re-arm the rate limit while WAL pressure is still elevated.
         let wal_pages = match tick {
@@ -744,16 +815,6 @@ pub async fn run_checkpoint_task(
         // gated on the SAME crossing state as the WAL-threshold WARNs above,
         // so sustained pressure logs once per crossing, not once per tick.
         log_tx_registry_oldest_debug(wal_pages);
-
-        // ADR-091 Plank 1: age-based sweep over the registry's oldest entry,
-        // independent of WAL page pressure — a registered span can go stale
-        // (KHIVE_TX_WARN_SECS / KHIVE_TX_MAX_AGE_SECS) while wal_pages sits
-        // well under warn_pages. Edge-triggered per rung, same debounce
-        // idiom as the severity ladder below, so a sustained stale span logs
-        // once per rung rather than once per tick.
-        for emission in tx_age_state.observe(khive_storage::tx_registry::oldest(), &config) {
-            log_tx_age_emission(&emission);
-        }
 
         // ADR-091 severity ladder: INFO on the first below→above crossing,
         // WARN once `warn_sustained_cycles` consecutive ticks stay elevated.
@@ -880,7 +941,7 @@ async fn append_checkpoint_lifecycle_event<P: serde::Serialize>(
 /// crossing rather than once per tick. Observe only: this never enforces or
 /// force-closes anything.
 fn log_tx_registry_oldest_debug(wal_pages: u64) {
-    if let Some((age, label)) = khive_storage::tx_registry::oldest() {
+    if let Some((_id, age, label)) = khive_storage::tx_registry::oldest() {
         tracing::debug!(
             wal_pages,
             oldest_tx_age_secs = age.as_secs_f64(),
@@ -896,7 +957,7 @@ fn log_tx_registry_oldest_debug(wal_pages: u64) {
 /// `crossing_warn`) — it is not rate-limited internally, so calling it every
 /// tick would reproduce the log-spam bug this rewrite fixes.
 fn log_tx_registry_oldest_warn(wal_pages: u64) {
-    if let Some((age, label)) = khive_storage::tx_registry::oldest() {
+    if let Some((_id, age, label)) = khive_storage::tx_registry::oldest() {
         tracing::warn!(
             wal_pages,
             oldest_tx_age_secs = age.as_secs_f64(),
@@ -1244,7 +1305,7 @@ mod tests {
             khive_storage::tx_registry::register(Some("checkpoint_tick_test".to_string()));
 
         let expected_label = khive_storage::tx_registry::oldest()
-            .and_then(|(_, label)| label)
+            .and_then(|(_, _, label)| label)
             .unwrap_or_else(|| "<unlabeled>".to_string());
 
         tracing::subscriber::with_default(subscriber, || {
@@ -1742,6 +1803,65 @@ mod tests {
         assert_eq!(
             cfg.tx_max_age_secs, default.tx_max_age_secs,
             "zero tx_max_age_secs must fall back to default"
+        );
+    }
+
+    /// Round-2 fix (Medium finding 1): a reversed pair — `KHIVE_TX_WARN_SECS`
+    /// >= `KHIVE_TX_MAX_AGE_SECS` — must not be honored independently. Before
+    /// this fix, WARN_SECS=120 / MAX_AGE_SECS=30 parsed both values
+    /// successfully (each is independently positive) and produced a sweep
+    /// that emits `Stale` at 30s while never reaching the `Warn` crossing
+    /// until 120s — inverting the intended severity ladder. Both thresholds
+    /// must instead fall back to their defaults together.
+    #[test]
+    #[serial]
+    fn checkpoint_config_rejects_reversed_tx_thresholds() {
+        let default = CheckpointConfig::default();
+        std::env::set_var("KHIVE_TX_WARN_SECS", "120");
+        std::env::set_var("KHIVE_TX_MAX_AGE_SECS", "30");
+
+        let cfg = CheckpointConfig::from_env();
+
+        std::env::remove_var("KHIVE_TX_WARN_SECS");
+        std::env::remove_var("KHIVE_TX_MAX_AGE_SECS");
+
+        assert_eq!(
+            cfg.tx_warn_secs, default.tx_warn_secs,
+            "a reversed pair must fall back tx_warn_secs to its default, got: {:?}",
+            cfg.tx_warn_secs
+        );
+        assert_eq!(
+            cfg.tx_max_age_secs, default.tx_max_age_secs,
+            "a reversed pair must fall back tx_max_age_secs to its default, got: {:?}",
+            cfg.tx_max_age_secs
+        );
+    }
+
+    /// Same invariant, the degenerate equal case: WARN_SECS == MAX_AGE_SECS
+    /// would make an entry cross both rungs on the exact same tick every
+    /// time, collapsing the two-rung severity ladder into one. Must also
+    /// fall back to defaults, not merely reject a strictly-reversed pair.
+    #[test]
+    #[serial]
+    fn checkpoint_config_rejects_equal_tx_thresholds() {
+        let default = CheckpointConfig::default();
+        std::env::set_var("KHIVE_TX_WARN_SECS", "60");
+        std::env::set_var("KHIVE_TX_MAX_AGE_SECS", "60");
+
+        let cfg = CheckpointConfig::from_env();
+
+        std::env::remove_var("KHIVE_TX_WARN_SECS");
+        std::env::remove_var("KHIVE_TX_MAX_AGE_SECS");
+
+        assert_eq!(
+            cfg.tx_warn_secs, default.tx_warn_secs,
+            "an equal pair must fall back tx_warn_secs to its default, got: {:?}",
+            cfg.tx_warn_secs
+        );
+        assert_eq!(
+            cfg.tx_max_age_secs, default.tx_max_age_secs,
+            "an equal pair must fall back tx_max_age_secs to its default, got: {:?}",
+            cfg.tx_max_age_secs
         );
     }
 
@@ -2296,6 +2416,14 @@ mod tests {
         }
     }
 
+    /// Synthetic identity for `TxAgeSweepState::observe`'s pure unit tests
+    /// below, which exercise identity-change detection without paying for a
+    /// real `tx_registry::register` call. `TxId`'s wrapped value is public
+    /// exactly to support this (see its doc comment in `khive-storage`).
+    fn tx_id(n: u64) -> khive_storage::tx_registry::TxId {
+        khive_storage::tx_registry::TxId(n)
+    }
+
     /// No open entry: nothing fires, and any prior latch state clears.
     #[test]
     fn tx_age_sweep_empty_registry_emits_nothing() {
@@ -2313,7 +2441,11 @@ mod tests {
         let mut state = TxAgeSweepState::default();
 
         let emissions = state.observe(
-            Some((Duration::from_secs(5), Some("fresh_span".to_string()))),
+            Some((
+                tx_id(1),
+                Duration::from_secs(5),
+                Some("fresh_span".to_string()),
+            )),
             &config,
         );
         assert!(emissions.is_empty(), "a fresh entry must emit nothing");
@@ -2328,7 +2460,11 @@ mod tests {
         let mut state = TxAgeSweepState::default();
 
         let tick1 = state.observe(
-            Some((Duration::from_secs(45), Some("stale_span".to_string()))),
+            Some((
+                tx_id(1),
+                Duration::from_secs(45),
+                Some("stale_span".to_string()),
+            )),
             &config,
         );
         assert_eq!(
@@ -2342,7 +2478,11 @@ mod tests {
         );
 
         let tick2 = state.observe(
-            Some((Duration::from_secs(50), Some("stale_span".to_string()))),
+            Some((
+                tx_id(1),
+                Duration::from_secs(50),
+                Some("stale_span".to_string()),
+            )),
             &config,
         );
         assert!(
@@ -2362,6 +2502,7 @@ mod tests {
         // progression (an entry ages through the warn band before the max).
         state.observe(
             Some((
+                tx_id(1),
                 Duration::from_secs(45),
                 Some("stuck_writer_task_tx".to_string()),
             )),
@@ -2370,6 +2511,7 @@ mod tests {
 
         let tick = state.observe(
             Some((
+                tx_id(1),
                 Duration::from_secs(130),
                 Some("stuck_writer_task_tx".to_string()),
             )),
@@ -2387,6 +2529,7 @@ mod tests {
 
         let tick_repeat = state.observe(
             Some((
+                tx_id(1),
                 Duration::from_secs(200),
                 Some("stuck_writer_task_tx".to_string()),
             )),
@@ -2407,7 +2550,11 @@ mod tests {
         let mut state = TxAgeSweepState::default();
 
         let tick = state.observe(
-            Some((Duration::from_secs(300), Some("ancient_tx".to_string()))),
+            Some((
+                tx_id(1),
+                Duration::from_secs(300),
+                Some("ancient_tx".to_string()),
+            )),
             &config,
         );
         assert_eq!(
@@ -2436,7 +2583,11 @@ mod tests {
         let mut state = TxAgeSweepState::default();
 
         state.observe(
-            Some((Duration::from_secs(150), Some("first_span".to_string()))),
+            Some((
+                tx_id(1),
+                Duration::from_secs(150),
+                Some("first_span".to_string()),
+            )),
             &config,
         );
 
@@ -2446,14 +2597,22 @@ mod tests {
 
         // A fresh entry (unrelated span) is now oldest — still below threshold.
         let fresh = state.observe(
-            Some((Duration::from_secs(2), Some("second_span".to_string()))),
+            Some((
+                tx_id(2),
+                Duration::from_secs(2),
+                Some("second_span".to_string()),
+            )),
             &config,
         );
         assert!(fresh.is_empty(), "a fresh oldest entry must emit nothing");
 
         // That second span goes stale in turn — must WARN again (re-armed).
         let rewarn = state.observe(
-            Some((Duration::from_secs(35), Some("second_span".to_string()))),
+            Some((
+                tx_id(2),
+                Duration::from_secs(35),
+                Some("second_span".to_string()),
+            )),
             &config,
         );
         assert_eq!(
@@ -2464,6 +2623,62 @@ mod tests {
                 label: Some("second_span".to_string()),
             }],
             "a fresh stale episode after a clear must Warn again"
+        );
+    }
+
+    /// Round-2 fix (Medium finding 2): a stale entry (A) that closes and is
+    /// immediately replaced by an ALREADY-stale entry (B) on the very next
+    /// observed tick — no intervening below-threshold or empty tick, unlike
+    /// `tx_age_sweep_rearms_after_entry_clears` above — must still emit both
+    /// rungs for B. Before the identity-tracking fix, `was_above_warn` and
+    /// `was_above_max_age` were already `true` from A, so B's crossing was
+    /// silently swallowed: the alert stayed latched to a departed caller
+    /// while a different long-lived span was now pinning the database.
+    #[test]
+    fn tx_age_sweep_stale_replacement_without_intervening_clear_still_names_new_entry() {
+        let config = tx_age_test_config();
+        let mut state = TxAgeSweepState::default();
+
+        let tick_a = state.observe(
+            Some((
+                tx_id(1),
+                Duration::from_secs(300),
+                Some("stale_entry_a".to_string()),
+            )),
+            &config,
+        );
+        assert_eq!(
+            tick_a.len(),
+            2,
+            "entry A must cross both rungs on its first observed tick, got: {tick_a:?}"
+        );
+
+        // B replaces A as the oldest entry on the VERY NEXT tick — already
+        // stale itself, with no intervening None/below-threshold tick.
+        let tick_b = state.observe(
+            Some((
+                tx_id(2),
+                Duration::from_secs(400),
+                Some("stale_entry_b".to_string()),
+            )),
+            &config,
+        );
+        assert_eq!(
+            tick_b,
+            vec![
+                TxAgeEmission {
+                    rung: TxAgeRung::Warn,
+                    age: Duration::from_secs(400),
+                    label: Some("stale_entry_b".to_string()),
+                },
+                TxAgeEmission {
+                    rung: TxAgeRung::Stale,
+                    age: Duration::from_secs(400),
+                    label: Some("stale_entry_b".to_string()),
+                },
+            ],
+            "a same-tick identity change to an already-stale successor must re-emit both \
+             rungs naming the NEW entry, got: {tick_b:?}"
         );
     }
 
@@ -2482,7 +2697,11 @@ mod tests {
         let mut state = TxAgeSweepState::default();
 
         let tick = state.observe(
-            Some((Duration::from_millis(5), Some("fast_cap_span".to_string()))),
+            Some((
+                tx_id(1),
+                Duration::from_millis(5),
+                Some("fast_cap_span".to_string()),
+            )),
             &config,
         );
         assert_eq!(
@@ -2811,5 +3030,213 @@ mod tests {
             .await
             .expect("checkpoint task should exit within 1s")
             .expect("checkpoint task panicked");
+    }
+
+    // Round-2 fix (Medium finding 4 + High finding): task-level regressions
+    // that actually spawn `run_checkpoint_task` and capture its `tracing`
+    // output, so the wiring at the `tx_age_state.observe(...)` call site
+    // itself is under test — the pure `TxAgeSweepState` unit tests above
+    // stay green even if that call site is deleted; these do not. All three
+    // share `#[serial(tx_registry, checkpoint_skip_metrics)]`: `tx_registry`
+    // because they read the process-wide registry singleton (see the
+    // `log_tx_registry_oldest_debug_reports_oldest_open_entry` doc comment
+    // above for why other tests in this same binary can transiently touch
+    // it too), `checkpoint_skip_metrics` because they spawn the real task
+    // that updates the module's skip-tracking atomics.
+
+    /// (1) A stale labeled entry with a healthy WAL: the spawned task itself
+    /// must sweep and escalate it to `Stale`, with WAL-pressure thresholds
+    /// set unreachably high so only the age sweep — never the WAL-pressure
+    /// ladder — could be responsible for the captured emission.
+    #[tokio::test]
+    #[serial(tx_registry, checkpoint_skip_metrics)]
+    async fn checkpoint_task_sweeps_stale_registry_entry_while_wal_is_healthy() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("tx_age_sweep_task_healthy_wal.db");
+        let pool = file_pool(&path);
+
+        let buffer = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+        let subscriber = CaptureSubscriber {
+            events: std::sync::Arc::clone(&buffer),
+        };
+        let _tracing_guard = tracing::subscriber::set_default(subscriber);
+
+        let _tx_handle = khive_storage::tx_registry::register(Some(
+            "checkpoint_task_healthy_wal_sweep_test".to_string(),
+        ));
+
+        let cfg = CheckpointConfig {
+            interval: Duration::from_millis(10),
+            warn_pages: u64::MAX,
+            high_water_pages: u64::MAX,
+            truncate_high_water_pages: u64::MAX,
+            tx_warn_secs: Duration::from_millis(1),
+            tx_max_age_secs: Duration::from_millis(1),
+            ..CheckpointConfig::default()
+        };
+
+        let (shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(());
+        let handle = tokio::spawn(run_checkpoint_task(
+            pool,
+            cfg,
+            None,
+            "local".to_string(),
+            shutdown_rx,
+        ));
+
+        tokio::time::sleep(Duration::from_millis(60)).await;
+        shutdown_tx.send(()).expect("send shutdown signal");
+        tokio::time::timeout(Duration::from_secs(1), handle)
+            .await
+            .expect("checkpoint task should exit within 1s")
+            .expect("checkpoint task panicked");
+
+        drop(_tx_handle);
+
+        let events = buffer.lock().unwrap();
+        assert!(
+            events.iter().any(|e| {
+                e.tx_label.as_deref() == Some("checkpoint_task_healthy_wal_sweep_test")
+                    && e.message
+                        .as_deref()
+                        .is_some_and(|m| m.contains("stale-op cap"))
+            }),
+            "expected the spawned task to sweep and escalate the stale registry entry \
+             to Stale on its own, got: {events:?}"
+        );
+    }
+
+    /// (2) An empty registry must never produce a Plank 1 age emission from
+    /// the real spawned task, mirroring the pure
+    /// `tx_age_sweep_empty_registry_emits_nothing` unit test above.
+    #[tokio::test]
+    #[serial(tx_registry, checkpoint_skip_metrics)]
+    async fn checkpoint_task_emits_no_age_alert_for_an_empty_registry() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("tx_age_sweep_task_empty_registry.db");
+        let pool = file_pool(&path);
+
+        let buffer = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+        let subscriber = CaptureSubscriber {
+            events: std::sync::Arc::clone(&buffer),
+        };
+        let _tracing_guard = tracing::subscriber::set_default(subscriber);
+
+        let cfg = CheckpointConfig {
+            interval: Duration::from_millis(10),
+            tx_warn_secs: Duration::from_millis(1),
+            tx_max_age_secs: Duration::from_millis(1),
+            ..CheckpointConfig::default()
+        };
+
+        let (shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(());
+        let handle = tokio::spawn(run_checkpoint_task(
+            pool,
+            cfg,
+            None,
+            "local".to_string(),
+            shutdown_rx,
+        ));
+
+        tokio::time::sleep(Duration::from_millis(40)).await;
+        shutdown_tx.send(()).expect("send shutdown signal");
+        tokio::time::timeout(Duration::from_secs(1), handle)
+            .await
+            .expect("checkpoint task should exit within 1s")
+            .expect("checkpoint task panicked");
+
+        let events = buffer.lock().unwrap();
+        assert!(
+            events.iter().all(|e| e
+                .message
+                .as_deref()
+                .is_none_or(|m| !m.contains("ADR-091 Plank 1"))),
+            "an empty registry must never produce a Plank 1 age emission, got: {events:?}"
+        );
+    }
+
+    /// (3) High-finding regression: a writer-busy tick must NOT silence the
+    /// age sweep. Holds the pool's writer mutex (via `pool.try_writer()`,
+    /// never released for the task's entire run) across several checkpoint
+    /// intervals alongside a stale registered entry, and asserts the age
+    /// alert still fires even though `checkpoint_once` observes
+    /// `CheckpointTick::Skipped` on every single tick. Before the fix, the
+    /// sweep call sat after the `Skipped` early-continue and never ran here.
+    #[tokio::test]
+    #[serial(tx_registry, checkpoint_skip_metrics)]
+    async fn checkpoint_task_sweeps_stale_entry_even_when_writer_is_busy_every_tick() {
+        reset_checkpoint_metrics_for_tests();
+
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("tx_age_sweep_task_writer_busy.db");
+        let pool = file_pool(&path);
+        {
+            let writer = pool.try_writer().unwrap();
+            writer
+                .conn()
+                .execute_batch("CREATE TABLE IF NOT EXISTS t (x INTEGER);")
+                .unwrap();
+        }
+
+        let buffer = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+        let subscriber = CaptureSubscriber {
+            events: std::sync::Arc::clone(&buffer),
+        };
+        let _tracing_guard = tracing::subscriber::set_default(subscriber);
+
+        let _tx_handle = khive_storage::tx_registry::register(Some(
+            "checkpoint_task_writer_busy_sweep_test".to_string(),
+        ));
+
+        // Held for the checkpoint task's entire run, acquired BEFORE spawn
+        // (and with no `.await` in between) so the task cannot possibly
+        // observe a free writer on any tick.
+        let _writer_guard = pool.try_writer().expect("acquire writer for busy hold");
+
+        let cfg = CheckpointConfig {
+            interval: Duration::from_millis(10),
+            tx_warn_secs: Duration::from_millis(1),
+            tx_max_age_secs: Duration::from_millis(1),
+            ..CheckpointConfig::default()
+        };
+
+        let (shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(());
+        let handle = tokio::spawn(run_checkpoint_task(
+            Arc::clone(&pool),
+            cfg,
+            None,
+            "local".to_string(),
+            shutdown_rx,
+        ));
+
+        // Several 10ms intervals, every one of them writer-busy.
+        tokio::time::sleep(Duration::from_millis(60)).await;
+
+        assert!(
+            checkpoint_skipped_ticks() > 0,
+            "test setup must actually drive at least one Skipped tick for this \
+             regression to mean anything"
+        );
+
+        shutdown_tx.send(()).expect("send shutdown signal");
+        tokio::time::timeout(Duration::from_secs(1), handle)
+            .await
+            .expect("checkpoint task should exit within 1s")
+            .expect("checkpoint task panicked");
+
+        drop(_writer_guard);
+        drop(_tx_handle);
+
+        let events = buffer.lock().unwrap();
+        assert!(
+            events.iter().any(|e| {
+                e.tx_label.as_deref() == Some("checkpoint_task_writer_busy_sweep_test")
+                    && e.message
+                        .as_deref()
+                        .is_some_and(|m| m.contains("stale-op cap"))
+            }),
+            "expected the age sweep to fire even though every tick's writer checkout \
+             was skipped, got: {events:?}"
+        );
     }
 }

--- a/crates/khive-db/src/checkpoint.rs
+++ b/crates/khive-db/src/checkpoint.rs
@@ -54,8 +54,27 @@
 //! TRUNCATE runs under a temporarily shortened `busy_timeout`
 //! (`truncate_busy_timeout`), restored on the writer connection immediately
 //! after the attempt, win or lose. No transaction is ever killed or aborted
-//! here — the tx_registry is only read for diagnostics (Plank 1 owns
-//! enforcement).
+//! here — the tx_registry is only read for diagnostics; Plank 1 (below) owns
+//! the registry's own bound.
+//!
+//! ADR-091 Plank 1: age-based background sweep, not per-statement rejection.
+//! The ADR's original text describes a "cooperative stale-op guard" that
+//! rejects further statements and rolls back a late `commit()` on a
+//! `SqliteTransaction`/`begin_tx` span past `KHIVE_TX_MAX_AGE_SECS`. That API
+//! no longer exists in this codebase: ADR-067's `atomic_unit` replaced every
+//! production write-transaction path with a closure that structurally cannot
+//! outlive its own call (single-poll-enforced on the write-queue path), which
+//! is the ADR's own named follow-up ("closure-scoped transaction API"),
+//! already delivered for writes by a later ADR. What ships here instead is
+//! the part of Plank 1 that still applies to every registered span
+//! regardless of which mechanism created it: on each observed tick,
+//! `TxAgeSweepState` checks `khive_storage::tx_registry::oldest()`'s age
+//! against `tx_warn_secs`/`tx_max_age_secs` and escalates to `warn!`/`error!`
+//! on each below→above crossing (same debounce idiom as the WAL-pressure
+//! ladder — a sustained stale span logs once per rung, not once per tick).
+//! This is visibility, not reclamation: nothing here force-closes a stale
+//! span, matching the ADR's own accepted gap for a transaction "held idle
+//! across an await with no further calls."
 
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
@@ -261,6 +280,35 @@ pub struct CheckpointConfig {
     /// Overridable via `KHIVE_WAL_TRUNCATE_BUSY_MS`.
     /// Default: 2000 ms.
     pub truncate_busy_timeout: Duration,
+
+    /// ADR-091 Plank 1 soft cap: age past which the oldest entry in the
+    /// shared open-transaction registry (`khive_storage::tx_registry`,
+    /// covering every registered span regardless of which call site created
+    /// it) is surfaced at `tracing::warn!` on the background sweep this
+    /// module runs every observed tick, independent of WAL page pressure —
+    /// a registered span can go stale while `wal_pages` sits well under
+    /// `warn_pages`.
+    ///
+    /// Overridable via `KHIVE_TX_WARN_SECS`.
+    /// Default: 30 seconds.
+    pub tx_warn_secs: Duration,
+
+    /// ADR-091 Plank 1 cooperative-stale-op-guard threshold: age past which
+    /// the same sweep escalates the oldest registry entry to
+    /// `tracing::error!`. This module has no per-statement hook back into a
+    /// registered span's own caller to reject further statements or force a
+    /// rollback the way the ADR's original text describes — that mechanism
+    /// targeted `SqliteTransaction`/`begin_tx`, which ADR-067's `atomic_unit`
+    /// closure API has since replaced for every production write path (a
+    /// closure that structurally cannot outlive its own call is the ADR's
+    /// own named follow-up, already delivered for writes by a later ADR).
+    /// So past this age the sweep can only make a stale span maximally
+    /// visible — not force-close it — exactly the accepted gap the ADR
+    /// itself documents under Failure modes.
+    ///
+    /// Overridable via `KHIVE_TX_MAX_AGE_SECS`.
+    /// Default: 120 seconds.
+    pub tx_max_age_secs: Duration,
 }
 
 impl Default for CheckpointConfig {
@@ -273,6 +321,8 @@ impl Default for CheckpointConfig {
             truncate_high_water_pages: 20_000,
             truncate_min_interval: Duration::from_secs(300),
             truncate_busy_timeout: Duration::from_millis(2000),
+            tx_warn_secs: Duration::from_secs(30),
+            tx_max_age_secs: Duration::from_secs(120),
         }
     }
 }
@@ -336,6 +386,22 @@ impl CheckpointConfig {
             if let Ok(n) = v.parse::<u64>() {
                 if n > 0 {
                     cfg.truncate_busy_timeout = Duration::from_millis(n);
+                }
+            }
+        }
+
+        if let Ok(v) = std::env::var("KHIVE_TX_WARN_SECS") {
+            if let Ok(n) = v.parse::<u64>() {
+                if n > 0 {
+                    cfg.tx_warn_secs = Duration::from_secs(n);
+                }
+            }
+        }
+
+        if let Ok(v) = std::env::var("KHIVE_TX_MAX_AGE_SECS") {
+            if let Ok(n) = v.parse::<u64>() {
+                if n > 0 {
+                    cfg.tx_max_age_secs = Duration::from_secs(n);
                 }
             }
         }
@@ -467,6 +533,130 @@ impl CheckpointSeverityState {
     }
 }
 
+/// ADR-091 Plank 1 rung for the open-transaction registry's background age
+/// sweep: independent of the WAL-pressure ladder above, keyed purely off how
+/// long the registry's oldest entry has been open.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TxAgeRung {
+    /// The oldest registry entry's age crossed `tx_warn_secs`.
+    Warn,
+    /// The oldest registry entry's age crossed `tx_max_age_secs` — the ADR's
+    /// "cooperative stale-op guard" cap. No in-process mechanism force-closes
+    /// it (see [`CheckpointConfig::tx_max_age_secs`]); this rung is the
+    /// sweep's strongest available signal.
+    Stale,
+}
+
+/// One emission produced by a single [`TxAgeSweepState::observe`] call.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TxAgeEmission {
+    pub rung: TxAgeRung,
+    pub age: Duration,
+    pub label: Option<String>,
+}
+
+/// ADR-091 Plank 1 background-sweep state, carried across ticks by the
+/// caller alongside [`CheckpointSeverityState`] and [`TruncateState`]. Pure
+/// state machine: no I/O, no logging — callers turn the returned emissions
+/// into `tracing` calls, mirroring [`CheckpointSeverityState`]'s shape.
+///
+/// Keyed off `khive_storage::tx_registry::oldest()` — the single oldest
+/// entry across every registered span, regardless of which call site
+/// (`atomic_unit`, `WriterGuard::transaction`, a store's own batch-upsert
+/// helper, or `graph.rs`'s chunked-traversal read snapshot) created it. This
+/// is deliberately a different signal from the WAL-pressure ladder: a
+/// registered span can go stale while `wal_pages` sits well under
+/// `warn_pages` (nothing has pinned the checkpoint boundary yet), and
+/// conversely `wal_pages` can be elevated with an empty registry (the pin,
+/// if any, is outside this process — see the ADR's own "route reads through
+/// the daemon" alternative, out of scope here).
+#[derive(Debug, Default, Clone)]
+pub struct TxAgeSweepState {
+    /// Whether the previous observed tick's oldest entry was at/above
+    /// `tx_warn_secs`. Drives the below→above edge that fires `Warn`.
+    was_above_warn: bool,
+    /// Whether the previous observed tick's oldest entry was at/above
+    /// `tx_max_age_secs`. Drives the below→above edge that fires `Stale`.
+    was_above_max_age: bool,
+}
+
+impl TxAgeSweepState {
+    /// Advance by one observed tick given the registry's current oldest
+    /// entry (or `None` if the registry is empty). Returns zero, one, or two
+    /// emissions: an entry can cross both rungs on the same tick if it was
+    /// already stale the first time this sweep observed it (e.g. right after
+    /// process start).
+    ///
+    /// A below-threshold oldest entry (or no entry at all — the previously
+    /// stale span closed and either nothing or a fresher span is now
+    /// oldest) resets both latches, so a future stale span re-arms both
+    /// rungs. This is computed directly from the current oldest entry's own
+    /// age every tick, so no separate "did the registry change identity"
+    /// tracking is needed: a fresher oldest entry naturally reads as
+    /// below-threshold and clears the latch.
+    pub fn observe(
+        &mut self,
+        oldest: Option<(Duration, Option<String>)>,
+        config: &CheckpointConfig,
+    ) -> Vec<TxAgeEmission> {
+        let mut emissions = Vec::new();
+
+        let Some((age, label)) = oldest else {
+            self.was_above_warn = false;
+            self.was_above_max_age = false;
+            return emissions;
+        };
+
+        let above_warn = age >= config.tx_warn_secs;
+        let above_max_age = age >= config.tx_max_age_secs;
+
+        if above_warn && !self.was_above_warn {
+            emissions.push(TxAgeEmission {
+                rung: TxAgeRung::Warn,
+                age,
+                label: label.clone(),
+            });
+        }
+        if above_max_age && !self.was_above_max_age {
+            emissions.push(TxAgeEmission {
+                rung: TxAgeRung::Stale,
+                age,
+                label,
+            });
+        }
+
+        self.was_above_warn = above_warn;
+        self.was_above_max_age = above_max_age;
+        emissions
+    }
+}
+
+/// ADR-091 Plank 1: turn a [`TxAgeEmission`] into the appropriate `tracing`
+/// call. Extracted from `run_checkpoint_task` so tests can drive the same
+/// logging path `CaptureSubscriber`-style without spinning up the async task
+/// (mirrors [`log_tx_registry_oldest_warn`]/[`log_tx_registry_snapshot_warn`]).
+fn log_tx_age_emission(emission: &TxAgeEmission) {
+    let label = emission.label.as_deref().unwrap_or("<unlabeled>");
+    match emission.rung {
+        TxAgeRung::Warn => {
+            tracing::warn!(
+                tx_age_secs = emission.age.as_secs_f64(),
+                tx_label = label,
+                "ADR-091 Plank 1: open transaction registry entry exceeded soft-cap age"
+            );
+        }
+        TxAgeRung::Stale => {
+            tracing::error!(
+                tx_age_secs = emission.age.as_secs_f64(),
+                tx_label = label,
+                "ADR-091 Plank 1: open transaction registry entry exceeded the cooperative \
+                 stale-op cap; no in-process mechanism can force-close it — investigate the \
+                 labeled caller directly"
+            );
+        }
+    }
+}
+
 /// Run the WAL checkpoint background task.
 ///
 /// This is a long-running async task that should be spawned with
@@ -518,6 +708,7 @@ pub async fn run_checkpoint_task(
     let mut interval = tokio::time::interval(config.interval);
     interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
     let mut severity_state = CheckpointSeverityState::default();
+    let mut tx_age_state = TxAgeSweepState::default();
     let mut was_above_high_water = false;
     let mut truncate_state = TruncateState::default();
     // Independent of `severity_state` (which owns the WARN-episode ladder
@@ -553,6 +744,16 @@ pub async fn run_checkpoint_task(
         // gated on the SAME crossing state as the WAL-threshold WARNs above,
         // so sustained pressure logs once per crossing, not once per tick.
         log_tx_registry_oldest_debug(wal_pages);
+
+        // ADR-091 Plank 1: age-based sweep over the registry's oldest entry,
+        // independent of WAL page pressure — a registered span can go stale
+        // (KHIVE_TX_WARN_SECS / KHIVE_TX_MAX_AGE_SECS) while wal_pages sits
+        // well under warn_pages. Edge-triggered per rung, same debounce
+        // idiom as the severity ladder below, so a sustained stale span logs
+        // once per rung rather than once per tick.
+        for emission in tx_age_state.observe(khive_storage::tx_registry::oldest(), &config) {
+            log_tx_age_emission(&emission);
+        }
 
         // ADR-091 severity ladder: INFO on the first below→above crossing,
         // WARN once `warn_sustained_cycles` consecutive ticks stay elevated.
@@ -1134,6 +1335,51 @@ mod tests {
         );
     }
 
+    /// ADR-091 Plank 1: `log_tx_age_emission` emits the correct message text
+    /// and carries the entry's label, for both the `Warn` and `Stale` rungs.
+    #[test]
+    fn log_tx_age_emission_carries_label_for_both_rungs() {
+        let buffer = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+        let subscriber = CaptureSubscriber {
+            events: std::sync::Arc::clone(&buffer),
+        };
+
+        tracing::subscriber::with_default(subscriber, || {
+            log_tx_age_emission(&TxAgeEmission {
+                rung: TxAgeRung::Warn,
+                age: Duration::from_secs(45),
+                label: Some("plank1_warn_test".to_string()),
+            });
+            log_tx_age_emission(&TxAgeEmission {
+                rung: TxAgeRung::Stale,
+                age: Duration::from_secs(150),
+                label: Some("plank1_stale_test".to_string()),
+            });
+        });
+
+        let events = buffer.lock().unwrap();
+        assert!(
+            events.iter().any(|e| {
+                e.message.as_deref()
+                    == Some(
+                        "ADR-091 Plank 1: open transaction registry entry exceeded soft-cap age",
+                    )
+                    && e.tx_label.as_deref() == Some("plank1_warn_test")
+            }),
+            "expected a Warn-rung log line naming the entry, got: {events:?}"
+        );
+        assert!(
+            events.iter().any(|e| {
+                e.message.as_deref().is_some_and(|m| {
+                    m.starts_with(
+                        "ADR-091 Plank 1: open transaction registry entry exceeded the cooperative",
+                    )
+                }) && e.tx_label.as_deref() == Some("plank1_stale_test")
+            }),
+            "expected a Stale-rung log line naming the entry, got: {events:?}"
+        );
+    }
+
     fn file_pool(path: &std::path::Path) -> Arc<ConnectionPool> {
         let cfg = PoolConfig {
             path: Some(path.to_path_buf()),
@@ -1292,6 +1538,8 @@ mod tests {
         std::env::set_var("KHIVE_WAL_TRUNCATE_HIGH_WATER_PAGES", "12000");
         std::env::set_var("KHIVE_WAL_TRUNCATE_MIN_INTERVAL_SECS", "60");
         std::env::set_var("KHIVE_WAL_TRUNCATE_BUSY_MS", "500");
+        std::env::set_var("KHIVE_TX_WARN_SECS", "15");
+        std::env::set_var("KHIVE_TX_MAX_AGE_SECS", "90");
 
         let cfg = CheckpointConfig::from_env();
 
@@ -1301,6 +1549,8 @@ mod tests {
         std::env::remove_var("KHIVE_WAL_TRUNCATE_HIGH_WATER_PAGES");
         std::env::remove_var("KHIVE_WAL_TRUNCATE_MIN_INTERVAL_SECS");
         std::env::remove_var("KHIVE_WAL_TRUNCATE_BUSY_MS");
+        std::env::remove_var("KHIVE_TX_WARN_SECS");
+        std::env::remove_var("KHIVE_TX_MAX_AGE_SECS");
 
         assert_eq!(cfg.interval, Duration::from_millis(250));
         assert_eq!(cfg.warn_pages, 1500);
@@ -1308,6 +1558,8 @@ mod tests {
         assert_eq!(cfg.truncate_high_water_pages, 12000);
         assert_eq!(cfg.truncate_min_interval, Duration::from_secs(60));
         assert_eq!(cfg.truncate_busy_timeout, Duration::from_millis(500));
+        assert_eq!(cfg.tx_warn_secs, Duration::from_secs(15));
+        assert_eq!(cfg.tx_max_age_secs, Duration::from_secs(90));
     }
 
     #[test]
@@ -1321,6 +1573,8 @@ mod tests {
         std::env::set_var("KHIVE_WAL_TRUNCATE_HIGH_WATER_PAGES", "not_a_number");
         std::env::set_var("KHIVE_WAL_TRUNCATE_MIN_INTERVAL_SECS", "");
         std::env::set_var("KHIVE_WAL_TRUNCATE_BUSY_MS", "0");
+        std::env::set_var("KHIVE_TX_WARN_SECS", "not_a_number");
+        std::env::set_var("KHIVE_TX_MAX_AGE_SECS", "0");
 
         let cfg = CheckpointConfig::from_env();
 
@@ -1330,6 +1584,8 @@ mod tests {
         std::env::remove_var("KHIVE_WAL_TRUNCATE_HIGH_WATER_PAGES");
         std::env::remove_var("KHIVE_WAL_TRUNCATE_MIN_INTERVAL_SECS");
         std::env::remove_var("KHIVE_WAL_TRUNCATE_BUSY_MS");
+        std::env::remove_var("KHIVE_TX_WARN_SECS");
+        std::env::remove_var("KHIVE_TX_MAX_AGE_SECS");
 
         assert_eq!(cfg.interval, default.interval);
         assert_eq!(cfg.warn_pages, default.warn_pages);
@@ -1340,6 +1596,8 @@ mod tests {
         );
         assert_eq!(cfg.truncate_min_interval, default.truncate_min_interval);
         assert_eq!(cfg.truncate_busy_timeout, default.truncate_busy_timeout);
+        assert_eq!(cfg.tx_warn_secs, default.tx_warn_secs);
+        assert_eq!(cfg.tx_max_age_secs, default.tx_max_age_secs);
     }
 
     /// Regression: a high-water tick must NOT block behind an active read transaction.
@@ -1439,6 +1697,8 @@ mod tests {
         std::env::set_var("KHIVE_WAL_TRUNCATE_HIGH_WATER_PAGES", "0");
         std::env::set_var("KHIVE_WAL_TRUNCATE_MIN_INTERVAL_SECS", "0");
         std::env::set_var("KHIVE_WAL_TRUNCATE_BUSY_MS", "0");
+        std::env::set_var("KHIVE_TX_WARN_SECS", "0");
+        std::env::set_var("KHIVE_TX_MAX_AGE_SECS", "0");
 
         let cfg = CheckpointConfig::from_env();
 
@@ -1448,6 +1708,8 @@ mod tests {
         std::env::remove_var("KHIVE_WAL_TRUNCATE_HIGH_WATER_PAGES");
         std::env::remove_var("KHIVE_WAL_TRUNCATE_MIN_INTERVAL_SECS");
         std::env::remove_var("KHIVE_WAL_TRUNCATE_BUSY_MS");
+        std::env::remove_var("KHIVE_TX_WARN_SECS");
+        std::env::remove_var("KHIVE_TX_MAX_AGE_SECS");
 
         assert_eq!(
             cfg.interval, default.interval,
@@ -1472,6 +1734,14 @@ mod tests {
         assert_eq!(
             cfg.truncate_busy_timeout, default.truncate_busy_timeout,
             "zero truncate_busy_timeout must fall back to default"
+        );
+        assert_eq!(
+            cfg.tx_warn_secs, default.tx_warn_secs,
+            "zero tx_warn_secs must fall back to default"
+        );
+        assert_eq!(
+            cfg.tx_max_age_secs, default.tx_max_age_secs,
+            "zero tx_max_age_secs must fall back to default"
         );
     }
 
@@ -2013,6 +2283,302 @@ mod tests {
                 "observe_wal_pages must never emit the ALARM rung, got: {emissions:?}"
             );
         }
+    }
+
+    // ADR-091 Plank 1: `TxAgeSweepState` background-sweep state-machine tests.
+    // Pure unit tests mirroring the severity-ladder tests above — no I/O.
+
+    fn tx_age_test_config() -> CheckpointConfig {
+        CheckpointConfig {
+            tx_warn_secs: Duration::from_secs(30),
+            tx_max_age_secs: Duration::from_secs(120),
+            ..CheckpointConfig::default()
+        }
+    }
+
+    /// No open entry: nothing fires, and any prior latch state clears.
+    #[test]
+    fn tx_age_sweep_empty_registry_emits_nothing() {
+        let config = tx_age_test_config();
+        let mut state = TxAgeSweepState::default();
+
+        let emissions = state.observe(None, &config);
+        assert!(emissions.is_empty(), "no open entry must emit nothing");
+    }
+
+    /// A fresh entry (age below both thresholds) emits nothing.
+    #[test]
+    fn tx_age_sweep_fresh_entry_emits_nothing() {
+        let config = tx_age_test_config();
+        let mut state = TxAgeSweepState::default();
+
+        let emissions = state.observe(
+            Some((Duration::from_secs(5), Some("fresh_span".to_string()))),
+            &config,
+        );
+        assert!(emissions.is_empty(), "a fresh entry must emit nothing");
+    }
+
+    /// Below→above crossing of `tx_warn_secs` fires exactly one `Warn`
+    /// emission carrying the entry's label; it must not repeat on a second
+    /// tick that is still above `tx_warn_secs` but below `tx_max_age_secs`.
+    #[test]
+    fn tx_age_sweep_warn_fires_once_on_crossing() {
+        let config = tx_age_test_config();
+        let mut state = TxAgeSweepState::default();
+
+        let tick1 = state.observe(
+            Some((Duration::from_secs(45), Some("stale_span".to_string()))),
+            &config,
+        );
+        assert_eq!(
+            tick1,
+            vec![TxAgeEmission {
+                rung: TxAgeRung::Warn,
+                age: Duration::from_secs(45),
+                label: Some("stale_span".to_string()),
+            }],
+            "crossing tx_warn_secs must emit exactly one Warn"
+        );
+
+        let tick2 = state.observe(
+            Some((Duration::from_secs(50), Some("stale_span".to_string()))),
+            &config,
+        );
+        assert!(
+            tick2.is_empty(),
+            "Warn must not repeat while the entry stays in the warn band"
+        );
+    }
+
+    /// Crossing `tx_max_age_secs` fires `Stale`; a further tick still above
+    /// the cap must not repeat it.
+    #[test]
+    fn tx_age_sweep_stale_fires_once_on_crossing() {
+        let config = tx_age_test_config();
+        let mut state = TxAgeSweepState::default();
+
+        // Drive through the warn crossing first, matching real elapsed-time
+        // progression (an entry ages through the warn band before the max).
+        state.observe(
+            Some((
+                Duration::from_secs(45),
+                Some("stuck_writer_task_tx".to_string()),
+            )),
+            &config,
+        );
+
+        let tick = state.observe(
+            Some((
+                Duration::from_secs(130),
+                Some("stuck_writer_task_tx".to_string()),
+            )),
+            &config,
+        );
+        assert_eq!(
+            tick,
+            vec![TxAgeEmission {
+                rung: TxAgeRung::Stale,
+                age: Duration::from_secs(130),
+                label: Some("stuck_writer_task_tx".to_string()),
+            }],
+            "crossing tx_max_age_secs must emit exactly one Stale"
+        );
+
+        let tick_repeat = state.observe(
+            Some((
+                Duration::from_secs(200),
+                Some("stuck_writer_task_tx".to_string()),
+            )),
+            &config,
+        );
+        assert!(
+            tick_repeat.is_empty(),
+            "Stale must not repeat while the entry stays above tx_max_age_secs"
+        );
+    }
+
+    /// An entry already stale the first time the sweep observes it (e.g.
+    /// right after process start with a pre-existing registry entry) crosses
+    /// both rungs on the same tick.
+    #[test]
+    fn tx_age_sweep_already_stale_entry_emits_both_rungs_same_tick() {
+        let config = tx_age_test_config();
+        let mut state = TxAgeSweepState::default();
+
+        let tick = state.observe(
+            Some((Duration::from_secs(300), Some("ancient_tx".to_string()))),
+            &config,
+        );
+        assert_eq!(
+            tick,
+            vec![
+                TxAgeEmission {
+                    rung: TxAgeRung::Warn,
+                    age: Duration::from_secs(300),
+                    label: Some("ancient_tx".to_string()),
+                },
+                TxAgeEmission {
+                    rung: TxAgeRung::Stale,
+                    age: Duration::from_secs(300),
+                    label: Some("ancient_tx".to_string()),
+                },
+            ],
+            "an already-stale entry must cross both rungs on its first observed tick"
+        );
+    }
+
+    /// Re-arm: once the stale entry closes (registry reports a fresher
+    /// oldest entry, or none at all), a future stale span must fire again.
+    #[test]
+    fn tx_age_sweep_rearms_after_entry_clears() {
+        let config = tx_age_test_config();
+        let mut state = TxAgeSweepState::default();
+
+        state.observe(
+            Some((Duration::from_secs(150), Some("first_span".to_string()))),
+            &config,
+        );
+
+        // The stale span closed; nothing is open now.
+        let cleared = state.observe(None, &config);
+        assert!(cleared.is_empty(), "a clearing tick must emit nothing");
+
+        // A fresh entry (unrelated span) is now oldest — still below threshold.
+        let fresh = state.observe(
+            Some((Duration::from_secs(2), Some("second_span".to_string()))),
+            &config,
+        );
+        assert!(fresh.is_empty(), "a fresh oldest entry must emit nothing");
+
+        // That second span goes stale in turn — must WARN again (re-armed).
+        let rewarn = state.observe(
+            Some((Duration::from_secs(35), Some("second_span".to_string()))),
+            &config,
+        );
+        assert_eq!(
+            rewarn,
+            vec![TxAgeEmission {
+                rung: TxAgeRung::Warn,
+                age: Duration::from_secs(35),
+                label: Some("second_span".to_string()),
+            }],
+            "a fresh stale episode after a clear must Warn again"
+        );
+    }
+
+    /// `KHIVE_TX_WARN_SECS` / `KHIVE_TX_MAX_AGE_SECS` are read into the
+    /// config `from_env` reads at `run_checkpoint_task` construction time,
+    /// so this closes the loop from env var to the actual emitted rung
+    /// (the earlier `checkpoint_config_env_override` test only asserts the
+    /// config fields themselves).
+    #[test]
+    fn tx_age_sweep_uses_configured_thresholds_not_hardcoded_defaults() {
+        let config = CheckpointConfig {
+            tx_warn_secs: Duration::from_millis(1),
+            tx_max_age_secs: Duration::from_millis(2),
+            ..CheckpointConfig::default()
+        };
+        let mut state = TxAgeSweepState::default();
+
+        let tick = state.observe(
+            Some((Duration::from_millis(5), Some("fast_cap_span".to_string()))),
+            &config,
+        );
+        assert_eq!(
+            tick.len(),
+            2,
+            "a millisecond-scale cap must cross both rungs immediately, got: {tick:?}"
+        );
+    }
+
+    /// Integration-level regression for the incident this ADR fixes: a real
+    /// `BEGIN DEFERRED` reader pins a WAL snapshot (exactly like
+    /// `checkpoint_high_water_does_not_block_behind_reader` above) while also
+    /// being registered in the shared `tx_registry` (simulating an
+    /// instrumented long-lived-reader call site such as
+    /// `graph.rs`'s `graph_traverse_read`), writes drive `wal_pages` past
+    /// `high_water_pages`, and — with a millisecond-scale `tx_max_age_secs`
+    /// so the test does not sleep for real minutes — the Plank 1 sweep
+    /// escalates to `Stale` naming that exact reader, alongside the existing
+    /// Plank 0 high-water WARN. This is the "detection works, mitigation
+    /// missing" gap from the incident: the sweep now gives the operator the
+    /// specific, escalating, un-silenced signal that a single one-shot
+    /// high-water WARN does not.
+    #[test]
+    #[serial(tx_registry, checkpoint_skip_metrics)]
+    fn tx_age_sweep_names_long_lived_reader_pinning_wal_past_high_water() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("tx_age_sweep_reader_pin.db");
+        let pool = file_pool(&path);
+
+        {
+            let writer = pool.try_writer().unwrap();
+            writer
+                .conn()
+                .execute_batch(
+                    "CREATE TABLE IF NOT EXISTS t (x INTEGER); INSERT INTO t VALUES (1);",
+                )
+                .unwrap();
+        }
+
+        // Open a real read transaction so it holds a WAL snapshot (same
+        // isomorphism as `checkpoint_high_water_does_not_block_behind_reader`),
+        // AND register it in tx_registry — the telemetry a real long-lived
+        // reader call site (e.g. `graph_traverse_read`) is expected to carry.
+        let reader = pool.reader().expect("reader");
+        reader
+            .execute_batch("BEGIN DEFERRED; SELECT * FROM t;")
+            .expect("begin read tx");
+        let _tx_handle =
+            khive_storage::tx_registry::register(Some("tx_age_sweep_reader_pin_test".to_string()));
+
+        // Drive writes past high_water_pages while the reader snapshot pins
+        // the WAL tail — PASSIVE cannot reclaim these frames.
+        let config = CheckpointConfig {
+            high_water_pages: 1,
+            tx_warn_secs: Duration::from_millis(1),
+            tx_max_age_secs: Duration::from_millis(1),
+            ..CheckpointConfig::default()
+        };
+        {
+            let writer = pool.try_writer().unwrap();
+            for i in 0..50 {
+                writer
+                    .conn()
+                    .execute_batch(&format!("INSERT INTO t VALUES ({i});"))
+                    .unwrap();
+            }
+        }
+
+        let tick = checkpoint_once(&pool, &config, &mut TruncateState::default());
+        let wal_pages = match tick {
+            CheckpointTick::Observed(n) => n,
+            CheckpointTick::Skipped => panic!("writer must not be busy in this test"),
+        };
+        assert!(
+            wal_pages >= config.high_water_pages,
+            "test setup must actually drive wal_pages ({wal_pages}) past high_water_pages \
+             ({}) for this regression to mean anything",
+            config.high_water_pages
+        );
+
+        // The Plank 1 sweep, given the SAME registry state, must name the
+        // pinning reader at the Stale rung (millisecond-scale caps mean the
+        // freshly-registered handle is already "stale" by the time we
+        // observe it here, exactly like the always-stale-on-first-tick case
+        // covered by the pure unit test above).
+        let mut tx_age_state = TxAgeSweepState::default();
+        let emissions = tx_age_state.observe(khive_storage::tx_registry::oldest(), &config);
+        assert!(
+            emissions.iter().any(|e| e.rung == TxAgeRung::Stale
+                && e.label.as_deref() == Some("tx_age_sweep_reader_pin_test")),
+            "expected a Stale emission naming the pinning reader, got: {emissions:?}"
+        );
+
+        reader.execute_batch("COMMIT;").ok();
+        drop(reader);
+        drop(_tx_handle);
     }
 
     /// `KHIVE_WAL_WARN_SUSTAINED_CYCLES` overrides the default and rejects 0.

--- a/crates/khive-runtime/src/daemon.rs
+++ b/crates/khive-runtime/src/daemon.rs
@@ -697,7 +697,7 @@ fn build_metrics_snapshot<D: DaemonDispatch>(dispatcher: &D) -> MetricsSnapshot 
     let open_tx_count = khive_storage::tx_registry::snapshot().len();
     let (oldest_pinned_tx_micros, oldest_pinned_tx_label) =
         match khive_storage::tx_registry::oldest() {
-            Some((age, label)) => (Some(age.as_micros() as u64), label),
+            Some((_id, age, label)) => (Some(age.as_micros() as u64), label),
             None => (None, None),
         };
 

--- a/crates/khive-storage/src/tx_registry.rs
+++ b/crates/khive-storage/src/tx_registry.rs
@@ -13,8 +13,16 @@ use std::sync::{LazyLock, Mutex};
 use std::time::{Duration, Instant};
 
 /// Identifier for one registered transaction span.
+///
+/// The wrapped value is public so consumers of [`oldest`] can detect when the
+/// registry's oldest entry has *changed identity* between two observations —
+/// distinct from "is it still above a threshold" — without needing a live
+/// registration of their own (e.g. `khive-db`'s `TxAgeSweepState` pure
+/// state-machine unit tests construct synthetic ids directly). Equality is
+/// the only operation this type supports; the numeric value carries no
+/// meaning beyond "same span" vs. "different span".
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
-pub struct TxId(u64);
+pub struct TxId(pub u64);
 
 #[derive(Clone, Debug)]
 struct TxMeta {
@@ -63,19 +71,27 @@ pub fn register(label: Option<String>) -> TxHandle {
     TxHandle { id }
 }
 
-/// Age and label of the oldest currently-open registry entry, if any.
+/// Identity, age, and label of the oldest currently-open registry entry, if
+/// any.
+///
+/// The [`TxId`] lets callers distinguish "the same span is still oldest and
+/// still above a threshold" from "a *different* span became oldest between
+/// two observations" — the latter must re-arm any latched escalation state,
+/// since a departed entry's threshold-crossing history says nothing about
+/// its replacement (`khive-db`'s `TxAgeSweepState` is the consumer this
+/// exists for).
 ///
 /// Recovers a poisoned lock via `into_inner()` (see [`register`]) instead of
 /// returning `None`, which would otherwise read identically to "no open
 /// transactions" — indistinguishable from the genuinely-empty case.
-pub fn oldest() -> Option<(Duration, Option<String>)> {
+pub fn oldest() -> Option<(TxId, Duration, Option<String>)> {
     let registry = REGISTRY
         .lock()
         .unwrap_or_else(|poisoned| poisoned.into_inner());
     registry
-        .values()
-        .min_by_key(|meta| meta.opened_at)
-        .map(|meta| (meta.opened_at.elapsed(), meta.label.clone()))
+        .iter()
+        .min_by_key(|(_, meta)| meta.opened_at)
+        .map(|(id, meta)| (*id, meta.opened_at.elapsed(), meta.label.clone()))
 }
 
 /// Age and label of every currently-open registry entry.
@@ -108,7 +124,7 @@ mod tests {
     fn register_reports_oldest_with_label() {
         let _guard = TEST_LOCK.lock().unwrap();
         let handle = register(Some("test_span".to_string()));
-        let (_, label) = oldest().expect("expected an open entry");
+        let (_, _, label) = oldest().expect("expected an open entry");
         assert_eq!(label.as_deref(), Some("test_span"));
         drop(handle);
     }
@@ -134,11 +150,15 @@ mod tests {
         let first = register(Some("first".to_string()));
         std::thread::sleep(Duration::from_millis(5));
         let second = register(Some("second".to_string()));
-        let (_, label) = oldest().expect("expected an open entry");
+        let (first_id, _, label) = oldest().expect("expected an open entry");
         assert_eq!(label.as_deref(), Some("first"));
         drop(first);
-        let (_, label) = oldest().expect("expected an open entry");
+        let (second_id, _, label) = oldest().expect("expected an open entry");
         assert_eq!(label.as_deref(), Some("second"));
+        assert_ne!(
+            first_id, second_id,
+            "distinct registrations must carry distinct TxIds"
+        );
         drop(second);
     }
 

--- a/docs/adr/ADR-091-wal-snapshot-lifetime.md
+++ b/docs/adr/ADR-091-wal-snapshot-lifetime.md
@@ -304,6 +304,20 @@ transaction regardless of which mechanism created it:
   the original "hard cap" language overclaimed).** Once a registry entry's
   `opened_at.elapsed()` exceeds `KHIVE_TX_MAX_AGE_SECS` (default **120s**; provisional, see
   Plank 0):
+  - **SUPERSEDED (see the 2026-07-12 amendment at the end of this ADR) — historical design
+    intent, not shipped behavior.** The three sub-bullets immediately below (per-statement
+    reject, `commit()`-past-cap rollback, and their raw-`SqlWriter` mirror) targeted
+    `SqliteTransaction`/`begin_tx`, an API this codebase no longer has: ADR-067's
+    `atomic_unit` closure replaced every production write-transaction path with a span that
+    structurally cannot outlive its own call, which is exactly the "closure-scoped
+    transaction API" follow-up named two paragraphs below — already delivered, for writes,
+    by a later ADR. What actually shipped is the fourth sub-bullet only (the background
+    registry sweep), generalized to run independently of `run_checkpoint_task`'s
+    Observed/Skipped WAL-checkpoint outcome and to cover every registered span, not only
+    `SqliteTransaction`/raw-`SqlWriter` sites. No reject-on-statement or rollback-on-commit
+    mechanism exists anywhere in the shipped code; a stale span is surfaced, never
+    force-closed. Kept verbatim below for the historical record of what this ADR originally
+    specified.
   - For `SqliteTransaction`: subsequent `execute`/`query_row`/`query_all` calls on that
     transaction return an error instead of running the statement, forcing the caller's own
     error-handling path to abort and drop the transaction. This is a **guard against a
@@ -323,15 +337,17 @@ transaction regardless of which mechanism created it:
       has already been flagged as stale. This closes the previously unspecified
       "`commit()` after the cap" gap: legitimate long-running batches that hit this will
       have their work rolled back and must retry in smaller chunks (see Failure modes).
-    - **Background registry sweep (Plank 0's checkpoint tick, extended):** on each
-      `run_checkpoint_task` tick, any registry entry whose `opened_at.elapsed()` exceeds
-      `KHIVE_TX_MAX_AGE_SECS` is logged at `tracing::warn!` (escalating in severity the
-      longer it persists) even if the owning caller never issues another statement or
-      calls `commit()`. This does **not** force-close the connection (that would require
-      unsafe cross-thread manipulation of a connection another task owns); it makes a
-      stuck transaction visible to an operator via the checkpoint tick's existing log
-      line, the same visibility-over-guaranteed-reclamation posture Plank 2 takes for
-      sustained TRUNCATE failure (see the severity ladder amendment below).
+    - **Background registry sweep (Plank 0's checkpoint tick, extended) — this sub-bullet is
+      the part that shipped, generalized (2026-07-12) to run on every tick regardless of
+      Observed/Skipped:** any registry entry whose `opened_at.elapsed()` exceeds
+      `KHIVE_TX_MAX_AGE_SECS` is logged (`tracing::warn!` past `KHIVE_TX_WARN_SECS`,
+      `tracing::error!` past `KHIVE_TX_MAX_AGE_SECS` — escalating in severity the longer it
+      persists) even if the owning caller never issues another statement or calls
+      `commit()`. This does **not** force-close the connection (that would require unsafe
+      cross-thread manipulation of a connection another task owns); it makes a stuck
+      transaction visible to an operator via the checkpoint tick's existing log line, the
+      same visibility-over-guaranteed-reclamation posture Plank 2 takes for sustained
+      TRUNCATE failure (see the severity ladder amendment below).
   - For raw `SqlWriter` sites, the same `commit()`-past-cap and background-sweep behavior
     apply at the registry level; each site's existing commit call is wrapped to check the
     registry entry's age before issuing `COMMIT` and to `ROLLBACK` instead past the cap,
@@ -457,16 +473,16 @@ expressed in the former, page-count, unit.
 
 ### Config summary
 
-| Key                                    | Default | Plank | Purpose                                                                                       | Status                                          |
-| -------------------------------------- | ------- | ----- | --------------------------------------------------------------------------------------------- | ----------------------------------------------- |
-| `KHIVE_TX_WARN_SECS`                   | 30      | 1     | Soft-cap WARN on a registry entry's age (`begin_tx` or raw `SqlWriter` transaction)           | Implemented, adapted — see 2026-07-12 amendment |
-| `KHIVE_TX_MAX_AGE_SECS`                | 120     | 1     | Cooperative stale-op guard: reject further statements / roll back on `commit()` past this age | Implemented, adapted — see 2026-07-12 amendment |
-| `KHIVE_READER_MAX_AGE_SECS`            | 300     | 1     | Recycle a pooled reader connection past this age on return (in-memory/test pool only)         | Carried over, scope narrowed                    |
-| `KHIVE_READER_MAX_OPS`                 | 5000    | 1     | Recycle a pooled reader connection past this op count on return (in-memory/test pool only)    | Carried over, scope narrowed                    |
-| `KHIVE_READER_CHECKOUT_WARN_SECS`      | 10      | 1     | WARN when the oldest outstanding pooled checkout exceeds this age (in-memory/test pool only)  | Carried over, scope narrowed                    |
-| `KHIVE_WAL_TRUNCATE_HIGH_WATER_PAGES`  | 20000   | 2     | WAL page count that arms a TRUNCATE attempt                                                   | Carried over                                    |
-| `KHIVE_WAL_TRUNCATE_MIN_INTERVAL_SECS` | 300     | 2     | Minimum spacing between successful TRUNCATE attempts                                          | Carried over                                    |
-| `KHIVE_WAL_TRUNCATE_BUSY_MS`           | 2000    | 2     | Temporary busy_timeout override during a TRUNCATE attempt                                     | Carried over                                    |
+| Key                                    | Default | Plank | Purpose                                                                                                                                                                        | Status                                          |
+| -------------------------------------- | ------- | ----- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ----------------------------------------------- |
+| `KHIVE_TX_WARN_SECS`                   | 30      | 1     | Background sweep: `tracing::warn!` once the shared registry's oldest entry's age exceeds this cap (any `khive_storage::tx_registry`-registered span, logging only)             | Implemented, adapted — see 2026-07-12 amendment |
+| `KHIVE_TX_MAX_AGE_SECS`                | 120     | 1     | Background sweep: `tracing::error!` once the same entry's age exceeds this cap (logging only — no per-statement reject or `commit()` rollback ships; see 2026-07-12 amendment) | Implemented, adapted — see 2026-07-12 amendment |
+| `KHIVE_READER_MAX_AGE_SECS`            | 300     | 1     | Recycle a pooled reader connection past this age on return (in-memory/test pool only)                                                                                          | Carried over, scope narrowed                    |
+| `KHIVE_READER_MAX_OPS`                 | 5000    | 1     | Recycle a pooled reader connection past this op count on return (in-memory/test pool only)                                                                                     | Carried over, scope narrowed                    |
+| `KHIVE_READER_CHECKOUT_WARN_SECS`      | 10      | 1     | WARN when the oldest outstanding pooled checkout exceeds this age (in-memory/test pool only)                                                                                   | Carried over, scope narrowed                    |
+| `KHIVE_WAL_TRUNCATE_HIGH_WATER_PAGES`  | 20000   | 2     | WAL page count that arms a TRUNCATE attempt                                                                                                                                    | Carried over                                    |
+| `KHIVE_WAL_TRUNCATE_MIN_INTERVAL_SECS` | 300     | 2     | Minimum spacing between successful TRUNCATE attempts                                                                                                                           | Carried over                                    |
+| `KHIVE_WAL_TRUNCATE_BUSY_MS`           | 2000    | 2     | Temporary busy_timeout override during a TRUNCATE attempt                                                                                                                      | Carried over                                    |
 
 Existing, unchanged: `KHIVE_CHECKPOINT_INTERVAL_MS` (500), `KHIVE_WAL_WARN_PAGES` (2000),
 `KHIVE_WAL_HIGH_WATER_PAGES` (6000), `KHIVE_JOURNAL_SIZE_LIMIT_BYTES` (64MiB),
@@ -502,6 +518,14 @@ Existing, unchanged: `KHIVE_CHECKPOINT_INTERVAL_MS` (500), `KHIVE_WAL_WARN_PAGES
 
 ## Failure modes
 
+- **SUPERSEDED — historical, not a real failure mode of the shipped code (see the
+  2026-07-12 amendment).** The following two bullets described failure modes of the
+  per-statement reject / `commit()`-rollback enforcement Plank 1 originally specified
+  against `SqliteTransaction`/`begin_tx`. That API and that enforcement do not exist in
+  the shipped code; kept for the historical record, not as a description of current
+  behavior. The failure mode that actually applies to what shipped is the THIRD bullet
+  below ("no in-process mechanism can force-close a stale span"), which now covers every
+  registered span, not only an idle-between-statements one.
 - **Stale-op guard rejection / commit-time rollback during a legitimate long-running
   batch.** If a future caller (via `begin_tx` or a raw `SqlWriter` transaction)
   legitimately needs a transaction open longer than `KHIVE_TX_MAX_AGE_SECS` (120s
@@ -521,6 +545,18 @@ Existing, unchanged: `KHIVE_CHECKPOINT_INTERVAL_MS` (500), `KHIVE_WAL_WARN_PAGES
   first iteration, not a silent one: the closure-scoped transaction API follow-up (Plank 1)
   is the structural fix, deferred pending Plank 0 telemetry showing whether this actually
   occurs.
+- **No in-process mechanism force-closes any stale span (what actually shipped).** Every
+  span registered in `khive_storage::tx_registry` — not only an idle-between-statements
+  one, since no per-statement or per-commit check exists at all — gets a `warn!` past
+  `KHIVE_TX_WARN_SECS` and an `error!` past `KHIVE_TX_MAX_AGE_SECS` from the background
+  sweep (every `run_checkpoint_task` tick, Observed or Skipped) and nothing more: no
+  reject, no rollback, no kill. This is the accepted gap this ADR's first shipped
+  iteration lands on. ADR-067's `atomic_unit` already eliminates the "held past the
+  return of an async function" class of risk for every production write path, which is
+  most of what the deferred closure-scoped-API follow-up would have targeted; the
+  remaining un-bounded spans are `graph.rs`'s chunked-traversal read snapshot
+  (`graph_traverse_read`) and any future caller of a registry-registered span this ADR
+  did not anticipate.
 - **TRUNCATE contention**: bounded to `truncate_busy_timeout` (default 2s) per attempt,
   at most once per `truncate_min_interval` under normal conditions (see the flap/backoff
   note: a skipped attempt due to writer contention does not consume the interval).
@@ -542,15 +578,20 @@ Existing, unchanged: `KHIVE_CHECKPOINT_INTERVAL_MS` (500), `KHIVE_WAL_WARN_PAGES
 - The false premise from the original draft (idle pooled readers pin production WAL) is
   retracted; this ADR no longer claims a fix for a mechanism that does not exist in the
   production code path.
-- WAL growth now has a cooperative age guard covering every caller-controllable
-  transaction mechanism this review confirmed exists: `begin_tx`'s `SqliteTransaction`
-  **and** the raw `SqlWriter`-held transactions in `khive-pack-brain` (`fold_gate.rs`,
-  `persist.rs`), `sql_bridge.rs`'s own writer implementations, `curation.rs`'s
-  `merge_entity`, every store's batch-upsert method, and `khive-vcs`'s chunked sync
-  writes, all sharing one open-transaction registry. This guard rejects further
-  statements and rolls back a stale `commit()` past `KHIVE_TX_MAX_AGE_SECS`; it does not
-  (yet) force-close a transaction held idle across an await with no further calls, an
-  accepted gap tracked as a follow-up (see Failure modes).
+- WAL growth now has a visibility sweep (SUPERSEDED description below — see the
+  2026-07-12 amendment) covering every caller-controllable transaction mechanism this
+  review confirmed exists: `begin_tx`'s `SqliteTransaction` **and** the raw
+  `SqlWriter`-held transactions in `khive-pack-brain` (`fold_gate.rs`, `persist.rs`),
+  `sql_bridge.rs`'s own writer implementations, `curation.rs`'s `merge_entity`, every
+  store's batch-upsert method, and `khive-vcs`'s chunked sync writes, all sharing one
+  open-transaction registry (in practice, today, `atomic_unit`'s registered span for
+  every production write path). The shipped guard **escalates a stale span to
+  `tracing::warn!`/`error!` (background sweep, every checkpoint tick); it does not reject
+  statements, roll back a `commit()`, or force-close a connection held idle across an
+  await with no further calls** — visibility only, an accepted gap tracked as a
+  follow-up (see Failure modes). The originally-specified per-statement reject and
+  commit-time rollback against `SqliteTransaction`/`begin_tx` were never built against
+  that API before ADR-067's `atomic_unit` superseded it for writes.
 - Plank 0's instrumentation is the load-bearing deliverable of this ADR's first
   iteration: it converts "we don't know what's pinning the WAL" into a concrete,
   loggable answer the next time sustained WAL pressure occurs, which Plank 1's
@@ -563,11 +604,13 @@ Existing, unchanged: `KHIVE_CHECKPOINT_INTERVAL_MS` (500), `KHIVE_WAL_WARN_PAGES
   drain failure, and `truncate_high_water_pages` arming the TRUNCATE escalation is the
   ALARM tier. `high_water_pages` crossing remains a shipped intermediate log, not a ladder
   tier on its own.
-- Two new config knobs for the shared transaction-registry guard (Plank 1), covering both
-  `begin_tx` and raw `SqlWriter` transactions, three carried-over knobs narrowed in scope,
-  three for TRUNCATE escalation (Plank 2); the two new keys are explicitly marked
-  provisional pending one cycle of production telemetry rather than presented as tuned
-  defaults.
+- Two new config knobs for the shared transaction-registry sweep (Plank 1), covering
+  every `khive_storage::tx_registry`-registered span — `begin_tx`'s historical
+  `SqliteTransaction` target no longer exists; the real coverage today is `atomic_unit`'s
+  registered span for every production write path, plus `graph.rs`'s chunked-traversal
+  read snapshot — three carried-over knobs narrowed in scope, three for TRUNCATE
+  escalation (Plank 2); the two new keys are explicitly marked provisional pending one
+  cycle of production telemetry rather than presented as tuned defaults.
 - `SqlTxOptions`/`SqlStatement`'s existing `label: Option<String>` field
   (`khive-storage/src/types/sql.rs:66-69`) is reused for registry entries; no new field or
   schema change is introduced by this ADR.
@@ -599,16 +642,25 @@ Plank 1's stale-op guard was designed to catch.
 
 What shipped for this amendment (`crates/khive-db/src/checkpoint.rs`, `TxAgeSweepState`):
 `KHIVE_TX_WARN_SECS`/`KHIVE_TX_MAX_AGE_SECS` are implemented as **config knobs feeding a
-background sweep**, not a per-statement guard. On every observed checkpoint tick, independent
-of WAL page pressure, the sweep checks `khive_storage::tx_registry::oldest()`'s age against
-both thresholds and escalates to `tracing::warn!`/`tracing::error!` on each below→above
-crossing (edge-triggered, same debounce idiom as the WAL-pressure severity ladder — a sustained
-stale span logs once per rung, not once per tick). This is Plank 1's registry-driven half,
-applied uniformly to every registered span regardless of which mechanism created it, exactly as
-originally specified ("applied uniformly to every registered transaction regardless of which
-mechanism created it"). It is visibility, not reclamation: no per-statement rejection or
-commit-time rollback is implemented, because there is no live call site left that holds a
-caller-controlled handle across multiple statements for such a check to intercept.
+background sweep**, not a per-statement guard. On every checkpoint tick — including a tick
+where `checkpoint_once` observes `CheckpointTick::Skipped` because the writer mutex is busy,
+independent of WAL page pressure either way — the sweep checks
+`khive_storage::tx_registry::oldest()`'s age against both thresholds and escalates to
+`tracing::warn!`/`tracing::error!` on each below→above crossing (edge-triggered, same debounce
+idiom as the WAL-pressure severity ladder — a sustained stale span logs once per rung, not once
+per tick). Round-2 fix (2026-07-12, same day): the sweep originally ran only on an Observed
+tick, which meant a registered `WriterGuard::transaction` span — holding the writer mutex for
+its entire registered lifetime — made the checkpoint tick observe `Skipped` and silently
+bypassed the sweep for exactly the scenario it exists to catch. The sweep now runs
+unconditionally before that early-continue, and additionally tracks the oldest entry's identity
+(not just its age) so a stale span that is immediately replaced by an already-stale successor
+re-arms and re-emits for the new span rather than staying latched to the departed one. This is
+Plank 1's registry-driven half, applied uniformly to every registered span regardless of which
+mechanism created it, exactly as originally specified ("applied uniformly to every registered
+transaction regardless of which mechanism created it"). It is visibility, not reclamation: no
+per-statement rejection or commit-time rollback is implemented, because there is no live call
+site left that holds a caller-controlled handle across multiple statements for such a check to
+intercept.
 
 This does **not** by itself explain or fix #580's specific 2026-07-12 recurrence. The one
 remaining candidate this review turned up that fits "long-lived reader holding a chunked span

--- a/docs/adr/ADR-091-wal-snapshot-lifetime.md
+++ b/docs/adr/ADR-091-wal-snapshot-lifetime.md
@@ -457,16 +457,16 @@ expressed in the former, page-count, unit.
 
 ### Config summary
 
-| Key                                    | Default | Plank | Purpose                                                                                       | Status                                     |
-| -------------------------------------- | ------- | ----- | --------------------------------------------------------------------------------------------- | ------------------------------------------ |
-| `KHIVE_TX_WARN_SECS`                   | 30      | 1     | Soft-cap WARN on a registry entry's age (`begin_tx` or raw `SqlWriter` transaction)           | New, provisional pending Plank 0 telemetry |
-| `KHIVE_TX_MAX_AGE_SECS`                | 120     | 1     | Cooperative stale-op guard: reject further statements / roll back on `commit()` past this age | New, provisional pending Plank 0 telemetry |
-| `KHIVE_READER_MAX_AGE_SECS`            | 300     | 1     | Recycle a pooled reader connection past this age on return (in-memory/test pool only)         | Carried over, scope narrowed               |
-| `KHIVE_READER_MAX_OPS`                 | 5000    | 1     | Recycle a pooled reader connection past this op count on return (in-memory/test pool only)    | Carried over, scope narrowed               |
-| `KHIVE_READER_CHECKOUT_WARN_SECS`      | 10      | 1     | WARN when the oldest outstanding pooled checkout exceeds this age (in-memory/test pool only)  | Carried over, scope narrowed               |
-| `KHIVE_WAL_TRUNCATE_HIGH_WATER_PAGES`  | 20000   | 2     | WAL page count that arms a TRUNCATE attempt                                                   | Carried over                               |
-| `KHIVE_WAL_TRUNCATE_MIN_INTERVAL_SECS` | 300     | 2     | Minimum spacing between successful TRUNCATE attempts                                          | Carried over                               |
-| `KHIVE_WAL_TRUNCATE_BUSY_MS`           | 2000    | 2     | Temporary busy_timeout override during a TRUNCATE attempt                                     | Carried over                               |
+| Key                                    | Default | Plank | Purpose                                                                                       | Status                                          |
+| -------------------------------------- | ------- | ----- | --------------------------------------------------------------------------------------------- | ----------------------------------------------- |
+| `KHIVE_TX_WARN_SECS`                   | 30      | 1     | Soft-cap WARN on a registry entry's age (`begin_tx` or raw `SqlWriter` transaction)           | Implemented, adapted — see 2026-07-12 amendment |
+| `KHIVE_TX_MAX_AGE_SECS`                | 120     | 1     | Cooperative stale-op guard: reject further statements / roll back on `commit()` past this age | Implemented, adapted — see 2026-07-12 amendment |
+| `KHIVE_READER_MAX_AGE_SECS`            | 300     | 1     | Recycle a pooled reader connection past this age on return (in-memory/test pool only)         | Carried over, scope narrowed                    |
+| `KHIVE_READER_MAX_OPS`                 | 5000    | 1     | Recycle a pooled reader connection past this op count on return (in-memory/test pool only)    | Carried over, scope narrowed                    |
+| `KHIVE_READER_CHECKOUT_WARN_SECS`      | 10      | 1     | WARN when the oldest outstanding pooled checkout exceeds this age (in-memory/test pool only)  | Carried over, scope narrowed                    |
+| `KHIVE_WAL_TRUNCATE_HIGH_WATER_PAGES`  | 20000   | 2     | WAL page count that arms a TRUNCATE attempt                                                   | Carried over                                    |
+| `KHIVE_WAL_TRUNCATE_MIN_INTERVAL_SECS` | 300     | 2     | Minimum spacing between successful TRUNCATE attempts                                          | Carried over                                    |
+| `KHIVE_WAL_TRUNCATE_BUSY_MS`           | 2000    | 2     | Temporary busy_timeout override during a TRUNCATE attempt                                     | Carried over                                    |
 
 Existing, unchanged: `KHIVE_CHECKPOINT_INTERVAL_MS` (500), `KHIVE_WAL_WARN_PAGES` (2000),
 `KHIVE_WAL_HIGH_WATER_PAGES` (6000), `KHIVE_JOURNAL_SIZE_LIMIT_BYTES` (64MiB),
@@ -577,3 +577,51 @@ Existing, unchanged: `KHIVE_CHECKPOINT_INTERVAL_MS` (500), `KHIVE_WAL_WARN_PAGES
   amendment narrowing or retuning Plank 1 rather than re-guessing from static code reading
   again. The closure-scoped transaction API (Plank 1's named follow-up) is also tracked
   here as a candidate future ADR.
+
+### 2026-07-12 amendment: Plank 1 implemented as a background age sweep, not per-statement rejection
+
+Live incident (2026-07-12): the daemon logged `WAL high-water mark exceeded; sustained WAL
+pressure — a long-lived reader may be pinning an old snapshot that PASSIVE cannot reclaim
+wal_pages=52054 high_water=6000` — Plank 0 detection fired correctly, but `wal_pages` sat at
+~8.7x `high_water_pages` with no further mitigation surfaced after the one-shot crossing WARN.
+Closing the gap required re-reading this ADR against current `main` (commit `85d30db9`), which
+surfaced a codebase change this ADR predates: **ADR-067 (`write-owner-daemon`) introduced
+`SqlAccess::atomic_unit`**, a closure-scoped write API where the caller's closure runs inside
+the writer task's own transaction and must complete on its first poll (enforced at runtime on
+the write-queue path). This is, in substance, the "closure-scoped transaction API" this ADR
+named as a future follow-up in Plank 1 above — already delivered, for writes, by a later ADR.
+`SqliteTransaction`/`begin_tx` (the API Plank 1's per-statement reject/rollback text was written
+against) no longer exists in this codebase; every production write path this ADR's Inventory
+(2)/(2b) named (`fold_gate.rs`, `persist.rs`, `sql_bridge.rs`'s writer impls, `curation.rs`,
+every store's batch-upsert method, `khive-vcs/sync.rs`) is a synchronous, single-closure-scoped
+span bounded to one `spawn_blocking` call — none can be "held across an await" in the sense
+Plank 1's stale-op guard was designed to catch.
+
+What shipped for this amendment (`crates/khive-db/src/checkpoint.rs`, `TxAgeSweepState`):
+`KHIVE_TX_WARN_SECS`/`KHIVE_TX_MAX_AGE_SECS` are implemented as **config knobs feeding a
+background sweep**, not a per-statement guard. On every observed checkpoint tick, independent
+of WAL page pressure, the sweep checks `khive_storage::tx_registry::oldest()`'s age against
+both thresholds and escalates to `tracing::warn!`/`tracing::error!` on each below→above
+crossing (edge-triggered, same debounce idiom as the WAL-pressure severity ladder — a sustained
+stale span logs once per rung, not once per tick). This is Plank 1's registry-driven half,
+applied uniformly to every registered span regardless of which mechanism created it, exactly as
+originally specified ("applied uniformly to every registered transaction regardless of which
+mechanism created it"). It is visibility, not reclamation: no per-statement rejection or
+commit-time rollback is implemented, because there is no live call site left that holds a
+caller-controlled handle across multiple statements for such a check to intercept.
+
+This does **not** by itself explain or fix #580's specific 2026-07-12 recurrence. The one
+remaining candidate this review turned up that fits "long-lived reader holding a chunked span
+open" is `crates/khive-db/src/stores/graph.rs`'s `traverse`, which opens a deferred read
+transaction and holds it across a `roots.chunks(400)` loop — already registered in `tx_registry`
+(its own comment names it "the most WAL-pin-relevant span in the store") and now covered by this
+sweep's _visibility_, but this ADR's original Inventory item (3) ("a pathologically long single
+closure... cannot be fully ruled out for pathological queries") explicitly left any enforcement
+for that case as an open question, not a specified mechanism. Bounding or aborting that
+traversal past an age cap is a genuine new design decision (which cap, whether a partial-result
+error is acceptable to callers, whether other single-closure spans need the same treatment) and
+is out of scope for this amendment — tracked as a follow-up rather than invented here. The other
+possibility this ADR's own Alternatives section already named — the pin is outside this process
+entirely (a separate `kkernel mcp` stdio session's own connection; `tx_registry` is
+process-local and cannot see it) — remains unruled-out and is exactly the "route reads through
+the daemon" alternative this ADR already deferred.


### PR DESCRIPTION
## Summary

Closes the implementation gap between ADR-091 and current `khive-db` for issue #580. Live incident tonight: the daemon logged

```
WARN khive_db::checkpoint: WAL high-water mark exceeded; sustained WAL pressure — a long-lived
reader may be pinning an old snapshot that PASSIVE cannot reclaim wal_pages=52054 high_water=6000
```

Detection fired correctly (8.7x the 6000-page ceiling), but nothing escalated further — Plank 1 (bounded transaction lifetime) had never actually been built.

## Gap table (ADR-091 vs. `crates/khive-db/src/checkpoint.rs` @ `85d30db9`)

| ADR-091 mandate | Status before this PR | Status after |
|---|---|---|
| **Plank 0** — open-transaction registry (`tx_registry`), per-tick oldest-entry debug trace, WARN on `warn_pages`/`high_water_pages` crossing naming the pinning caller | **Shipped.** `khive-storage/src/tx_registry.rs` registers at all 7 stores + `sql_bridge.rs` + `pool.rs` + `writer_task.rs`; `checkpoint.rs`'s `log_tx_registry_oldest_warn`/`log_tx_registry_snapshot_warn` fire on crossing; also exposed on the daemon metrics-read surface (`daemon.rs` `build_metrics_snapshot`). | Unchanged. |
| **Severity ladder** (INFO → WARN → ALARM, khive#617) | **Shipped.** `CheckpointSeverityState` implements the full 3-cycle-sustained-pressure ladder. | Unchanged. |
| **Plank 2** — TRUNCATE escalation past `truncate_high_water_pages`, rate-limited, backoff on writer-busy skip | **Shipped.** `maybe_truncate`, `note_truncate_outcome`, the whole `KHIVE_WAL_TRUNCATE_*` knob set. | Unchanged. |
| **Plank 1** — bounded caller-controllable transaction lifetime: `KHIVE_TX_WARN_SECS`/`KHIVE_TX_MAX_AGE_SECS`, soft-cap WARN, "cooperative stale-op guard" (reject further statements / roll back a late `commit()`), background registry sweep logging any stale entry every tick | **Not built.** `tx_registry.rs`'s own module doc: *"This is observe-only: no enforcement reads the registry in this plank."* Zero occurrences of either env var in the tree. This is the gap tonight's incident exposed: after the one-shot high-water WARN, sustained pressure went silent. | **Partially built, adapted** (see below). |

### Why "adapted," not a literal transplant

Plank 1's per-statement guard ("reject further `execute`/`query_row`/`query_all` calls; roll back a `commit()` past the cap") was designed against `SqliteTransaction`/`begin_tx`. **That API no longer exists in this codebase** — ADR-067 (`write-owner-daemon`, landed after ADR-091) introduced `SqlAccess::atomic_unit`, a closure-scoped write API where the caller's closure runs inside the writer task's own transaction and must complete on its first poll (enforced at runtime on the write-queue path). This *is*, in substance, Plank 1's own named follow-up ("closure-scoped transaction API... eliminating the 'held across an await' class of risk entirely... tracked here as a candidate future ADR") — already delivered for every production write path by a later ADR. There is no live call site left holding a caller-controlled handle across multiple statements for a per-statement reject to intercept.

**What ships in this PR**: the part of Plank 1 that still applies verbatim — "applied uniformly to every registered transaction regardless of which mechanism created it." `TxAgeSweepState` (`checkpoint.rs`) checks `tx_registry::oldest()`'s age against `KHIVE_TX_WARN_SECS` (default 30s) / `KHIVE_TX_MAX_AGE_SECS` (default 120s) on every observed checkpoint tick, independent of WAL page pressure, and escalates to `warn!`/`error!` on each below→above crossing — same debounce idiom as the existing WAL-pressure severity ladder, so a sustained stale span logs once per rung rather than spamming every 500ms tick. This is visibility, not reclamation, matching the ADR's own accepted gap ("a transaction... held idle across an await with no further calls... does not force-close the connection").

### What's still open (named, not invented)

`crates/khive-db/src/stores/graph.rs`'s `traverse` opens a deferred read transaction and holds it across a `roots.chunks(400)` loop — its own comment already calls it "the most WAL-pin-relevant span in the store," and it's registered in `tx_registry`, so this PR's sweep does surface it. But *bounding or aborting* that traversal past an age cap is a genuine new design decision (which cap, whether a partial-result error is acceptable to callers) that ADR-091's own Inventory item (3) explicitly left as an open question, not a specified mechanism — so it is **not** implemented here; it's recorded as a follow-up in the ADR amendment. Also un-ruled-out: the pin may be outside this process entirely (a separate `kkernel mcp` stdio session), which `tx_registry` — a process-local singleton — structurally cannot see; that's the ADR's own already-deferred "route reads through the daemon" alternative.

## Changes

- `crates/khive-db/src/checkpoint.rs`: `CheckpointConfig::{tx_warn_secs, tx_max_age_secs}` (+ env parsing), `TxAgeRung`/`TxAgeEmission`/`TxAgeSweepState` (pure state machine, mirrors `CheckpointSeverityState`), `log_tx_age_emission`, wired into `run_checkpoint_task`'s tick loop. Module-level doc updated to explain the Plank-1-vs-`atomic_unit` divergence.
- `docs/adr/ADR-091-wal-snapshot-lifetime.md`: Config-summary status updated for the two knobs; new "2026-07-12 amendment" section recording the `atomic_unit` divergence and the open `graph.rs traverse` / cross-process follow-ups.

## Tests (8 new, `-p khive-db`)

- `tx_age_sweep_empty_registry_emits_nothing`, `tx_age_sweep_fresh_entry_emits_nothing` — no false positives.
- `tx_age_sweep_warn_fires_once_on_crossing`, `tx_age_sweep_stale_fires_once_on_crossing` — edge-triggered, no per-tick spam.
- `tx_age_sweep_already_stale_entry_emits_both_rungs_same_tick`, `tx_age_sweep_rearms_after_entry_clears` — boundary + re-arm.
- `tx_age_sweep_uses_configured_thresholds_not_hardcoded_defaults` — closes the env-var-to-emitted-rung loop.
- `log_tx_age_emission_carries_label_for_both_rungs` — `CaptureSubscriber`-based, asserts actual message text + label.
- `tx_age_sweep_names_long_lived_reader_pinning_wal_past_high_water` — **the incident regression**: opens a real `BEGIN DEFERRED` reader pinning a WAL snapshot (same isomorphism as the existing `checkpoint_high_water_does_not_block_behind_reader` test), registers it in `tx_registry`, drives writes past `high_water_pages`, and asserts the sweep escalates to `Stale` naming that exact reader.

## Gate table

| Gate | Result |
|---|---|
| `cargo test -p khive-db --lib checkpoint::` | 37 passed |
| `cargo test -p khive-db` (full) | 289 unit + 10 contract + 0 doctest, all passed |
| `cargo clippy -p khive-db --all-targets -- -D warnings` | clean |
| `cargo fmt --all -- --check` (via pre-commit) | clean |
| `deno fmt` (ADR doc) | clean |

All run with `CARGO_TARGET_DIR=/private/tmp/khive-shared-target`, `cargo` invoked from `crates/`.

## Test plan

- [x] Unit tests for `TxAgeSweepState` cover empty/fresh/warn-crossing/stale-crossing/both-same-tick/re-arm.
- [x] Integration test reproduces the incident shape (real pinned reader + writes past high-water) and asserts the new mitigation fires.
- [x] Full `khive-db` suite green, no regressions.
- [ ] Deploy + watch the daemon's own logs for the new `ADR-091 Plank 1` warn/error lines under real production WAL pressure (orchestrator follow-up, not verifiable from a PR).

Refs #580, ADR-091.

🤖 Generated with [Claude Code](https://claude.com/claude-code)