### PR TITLE
feat(storage): BlobStore content-addressed blob capability (ADR-111)

### DIFF
--- a/crates/Cargo.toml
+++ b/crates/Cargo.toml
@@ -98,6 +98,11 @@ lru = "0.12"
 sha2 = "0.10"
 hex = "0.4"
 blake3 = { version = "1", default-features = false }
+# Cross-platform filesystem free-space query for BlobStore's fail-closed
+# floor check (khive#292). Pure Rust (rustix on Unix, windows-sys on
+# Windows) — no libc statvfs FFI to hand-maintain across the release
+# matrix's win32-x64 target.
+fs4 = "1.1"
 regorus = "0.10"
 rmcp = "1.7"
 futures = "0.3"

--- a/crates/khive-db/Cargo.toml
+++ b/crates/khive-db/Cargo.toml
@@ -31,10 +31,12 @@ crossbeam-queue = { workspace = true }
 parking_lot = { workspace = true }
 sha2 = { workspace = true }
 sqlite-vec = { workspace = true, optional = true }
+blake3 = { workspace = true }
+fs4 = { workspace = true }
+tempfile = { workspace = true }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["full", "test-util"] }
-tempfile = { workspace = true }
 rusqlite = { workspace = true, features = ["bundled", "column_decltype"] }
 khive-storage = { version = "0.4.0", path = "../khive-storage" }
 khive-types = { version = "0.4.0", path = "../khive-types", features = ["serde"] }

--- a/crates/khive-db/sql/010-entities-content-ref.sql
+++ b/crates/khive-db/sql/010-entities-content-ref.sql
@@ -1,0 +1,12 @@
+-- V10: BlobStore content_ref reference column on entities (khive#292).
+--
+-- Nullable, indexed pointer into a BlobStore (khive-storage::BlobStore) —
+-- a hex BLAKE3 digest, not a key buried in `properties`, so orphan-GC can
+-- join on it cheaply. Storage does not validate that the referenced blob
+-- exists; callers publish the blob before setting this column.
+
+ALTER TABLE entities ADD COLUMN content_ref TEXT;
+
+CREATE INDEX IF NOT EXISTS idx_entities_content_ref
+    ON entities(content_ref)
+    WHERE content_ref IS NOT NULL;

--- a/crates/khive-db/sql/entities-ddl.sql
+++ b/crates/khive-db/sql/entities-ddl.sql
@@ -14,7 +14,8 @@ CREATE TABLE IF NOT EXISTS entities (
     updated_at     INTEGER NOT NULL,
     deleted_at     INTEGER,
     merged_into    TEXT,
-    merge_event_id TEXT
+    merge_event_id TEXT,
+    content_ref    TEXT
 );
 
 CREATE INDEX IF NOT EXISTS idx_entities_namespace ON entities(namespace);
@@ -23,3 +24,8 @@ CREATE INDEX IF NOT EXISTS idx_entities_kind_entity_type ON entities(namespace, 
 CREATE INDEX IF NOT EXISTS idx_entities_name ON entities(namespace, name);
 CREATE INDEX IF NOT EXISTS idx_entities_created ON entities(created_at DESC);
 CREATE INDEX IF NOT EXISTS idx_entities_merged_into ON entities(namespace, merged_into);
+-- BlobStore content_ref reference (khive#292) — mirrors migration 010 for
+-- callers that create the table via ensure_entities_schema() without ever
+-- running the versioned migration chain (e.g. StorageBackend::memory() test
+-- setups that apply ENTITIES_DDL directly).
+CREATE INDEX IF NOT EXISTS idx_entities_content_ref ON entities(content_ref) WHERE content_ref IS NOT NULL;

--- a/crates/khive-db/src/backend.rs
+++ b/crates/khive-db/src/backend.rs
@@ -13,7 +13,7 @@ use rusqlite::OptionalExtension;
 use crate::error::SqliteError;
 use crate::pool::{ConnectionPool, PoolConfig};
 use crate::sql_bridge::SqlBridge;
-use crate::stores::{entity, event, graph, note, sparse, text, vectors};
+use crate::stores::{blob, entity, event, graph, note, sparse, text, vectors};
 
 /// Concrete storage backend providing capability traits.
 pub struct StorageBackend {
@@ -574,6 +574,23 @@ impl StorageBackend {
         )))
     }
 
+    /// Get a `BlobStore` rooted per khive#292's precedence chain:
+    /// `KHIVE_BLOB_ROOT` env var > `config_root` (a caller-resolved
+    /// `khive.toml` override — `khive-db` has no TOML parser of its own) >
+    /// beside this backend's database directory. `floor_bytes` overrides the
+    /// default 100 GB fail-closed free-space floor (`None` keeps the
+    /// default). Errors if none of the three roots apply — e.g. an in-memory
+    /// backend with no override and no env var has nowhere to default to.
+    pub fn blob_store(
+        &self,
+        config_root: Option<&Path>,
+        floor_bytes: Option<u64>,
+    ) -> Result<Arc<dyn khive_storage::BlobStore>, SqliteError> {
+        let root = blob::resolve_blob_root(self.data_dir().as_deref(), config_root)?;
+        let floor = floor_bytes.unwrap_or(blob::FsBlobStore::DEFAULT_FLOOR_BYTES);
+        Ok(Arc::new(blob::FsBlobStore::new(root, floor)?))
+    }
+
     /// Is this a file-backed backend?
     pub fn is_file_backed(&self) -> bool {
         self.is_file_backed
@@ -1014,6 +1031,51 @@ mod tests {
             result.is_err(),
             "upsert_document on a read-only backend must reject, not silently no-op"
         );
+    }
+
+    #[tokio::test]
+    async fn blob_store_roundtrip_via_public_api() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("blob_backend.db");
+        let backend = StorageBackend::sqlite(&path).unwrap();
+
+        // Explicit floor_bytes=0, not the default 100GB — the free space on
+        // whatever volume runs this test is not this test's concern (and a
+        // dev machine or CI runner legitimately may not clear 100GB free).
+        let store = backend.blob_store(None, Some(0)).unwrap();
+        let bytes = b"backend-level blob roundtrip".to_vec();
+        let content_ref = store.put(bytes.clone()).await.unwrap();
+        assert_eq!(store.get(&content_ref).await.unwrap(), bytes);
+    }
+
+    #[test]
+    fn blob_store_defaults_root_beside_db_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("blob_default.db");
+        let backend = StorageBackend::sqlite(&path).unwrap();
+
+        // `blob_store` creates the root directory eagerly (`FsBlobStore::new`),
+        // so its existence at the expected default path is directly
+        // observable without reaching into the trait object.
+        let _store = backend.blob_store(None, None).unwrap();
+        assert!(
+            dir.path().join("blobs").is_dir(),
+            "default root must be created beside the database file"
+        );
+    }
+
+    #[test]
+    fn blob_store_errors_for_in_memory_backend_with_no_override() {
+        let backend = StorageBackend::memory().unwrap();
+        assert!(backend.blob_store(None, None).is_err());
+    }
+
+    #[test]
+    fn blob_store_accepts_explicit_root_for_in_memory_backend() {
+        let dir = tempfile::tempdir().unwrap();
+        let backend = StorageBackend::memory().unwrap();
+        let store = backend.blob_store(Some(dir.path()), None);
+        assert!(store.is_ok());
     }
 
     #[test]

--- a/crates/khive-db/src/migrations.rs
+++ b/crates/khive-db/src/migrations.rs
@@ -118,6 +118,8 @@ const V8_UP: &str = include_str!("../sql/008-notes-seq-repair.sql");
 
 const V9_UP: &str = include_str!("../sql/009-entities-name-ci-index.sql");
 
+const V10_UP: &str = include_str!("../sql/010-entities-content-ref.sql");
+
 /// DDL for the `_embedding_models` registry table.
 ///
 /// Shared between the V1 schema and the belt-and-suspenders creation in
@@ -171,6 +173,11 @@ pub const MIGRATIONS: &[VersionedMigration] = &[
         version: 9,
         name: "entities_name_ci_index",
         up: V9_UP,
+    },
+    VersionedMigration {
+        version: 10,
+        name: "entities_content_ref",
+        up: V10_UP,
     },
 ];
 

--- a/crates/khive-db/src/migrations_tests.rs
+++ b/crates/khive-db/src/migrations_tests.rs
@@ -608,3 +608,56 @@ fn v6_implicit_mass_upsert_on_conflict() {
         .expect("count rows");
     assert_eq!(count, 1, "upsert must not create a second row");
 }
+
+// ── V10: entities.content_ref (khive#292) ───────────────────────────────────
+
+#[test]
+fn v10_adds_content_ref_column_and_partial_index() {
+    let mut conn = open_memory();
+    run_migrations(&mut conn).expect("migrations should succeed");
+    assert!(
+        column_exists(&conn, "entities", "content_ref"),
+        "V10 must add entities.content_ref"
+    );
+    assert!(
+        index_exists(&conn, "idx_entities_content_ref"),
+        "V10 must create idx_entities_content_ref"
+    );
+}
+
+#[test]
+fn v10_content_ref_defaults_null_and_accepts_a_value() {
+    let mut conn = open_memory();
+    run_migrations(&mut conn).expect("migrations should succeed");
+
+    conn.execute(
+        "INSERT INTO entities (id, namespace, kind, name, tags, created_at, updated_at) \
+         VALUES ('e1', 'local', 'concept', 'NullRef', '[]', 0, 0)",
+        [],
+    )
+    .expect("insert without content_ref");
+    let null_ref: Option<String> = conn
+        .query_row(
+            "SELECT content_ref FROM entities WHERE id = 'e1'",
+            [],
+            |row| row.get(0),
+        )
+        .expect("read content_ref");
+    assert_eq!(null_ref, None, "content_ref must default to NULL");
+
+    let digest = "a".repeat(64);
+    conn.execute(
+        "INSERT INTO entities (id, namespace, kind, name, tags, created_at, updated_at, content_ref) \
+         VALUES ('e2', 'local', 'concept', 'WithRef', '[]', 0, 0, ?1)",
+        rusqlite::params![digest],
+    )
+    .expect("insert with content_ref");
+    let stored_ref: Option<String> = conn
+        .query_row(
+            "SELECT content_ref FROM entities WHERE id = 'e2'",
+            [],
+            |row| row.get(0),
+        )
+        .expect("read content_ref");
+    assert_eq!(stored_ref, Some(digest));
+}

--- a/crates/khive-db/src/stores/blob.rs
+++ b/crates/khive-db/src/stores/blob.rs
@@ -271,9 +271,34 @@ impl BlobStore for FsBlobStore {
         let owned_guard = self.write_lock.clone().lock_owned().await;
         let root = self.root.clone();
         let floor_bytes = self.floor_bytes;
+        // Round-3 Medium (codex r3, PR #922): `sync_hook::take` is the
+        // test-only seam that lets regression tests observe/control
+        // exactly when this call is inside the guarded section, replacing
+        // fixed-sleep/fixed-duration-poll timing assumptions with
+        // deterministic, event-driven synchronization. `#[cfg(test)]`-
+        // gated end to end -- zero effect on non-test builds.
+        #[cfg(test)]
+        let hook = sync_hook::take(&root);
         tokio::task::spawn_blocking(move || {
-            let _owned_guard = owned_guard;
-            put_blocking(&root, floor_bytes, bytes)
+            // The guard lives in this inner block so it is dropped BEFORE
+            // the test hook's `done` signal fires below -- a test that
+            // waits on `done` and then immediately asserts the lock is
+            // free needs that ordering to hold exactly, not "usually".
+            #[cfg_attr(not(test), allow(clippy::let_and_return))]
+            let result = {
+                let _owned_guard = owned_guard;
+                #[cfg(test)]
+                if let Some(h) = &hook {
+                    let _ = h.reached.send(());
+                    let _ = h.release.recv();
+                }
+                put_blocking(&root, floor_bytes, bytes)
+            };
+            #[cfg(test)]
+            if let Some(h) = &hook {
+                let _ = h.done.send(());
+            }
+            result
         })
         .await
         .map_err(|e| StorageError::driver(StorageCapability::Blob, "put", e))?
@@ -356,6 +381,76 @@ impl BlobStore for FsBlobStore {
     }
 }
 
+/// Test-only synchronization seam into `put`'s write-lock-guarded critical
+/// section (round-3 Medium finding, codex r3 on PR #922).
+///
+/// The round-2 regression tests proved mutual exclusion and cancellation-
+/// safety with a fixed sleep before racing/aborting and a fixed-duration
+/// poll loop waiting for the lock to free -- timing-dependent, and the poll
+/// loop actually failed once in codex's own required-suite run (a flaky
+/// gate, not a real regression). This seam replaces both edges of the race
+/// with event-driven coordination: a one-shot hook, queued per canonical
+/// root, signals `reached` the instant execution is inside the guarded
+/// closure (the owned guard already moved in) and blocks there until the
+/// test sends `release`; `done` fires only after the guard has actually
+/// been dropped (see `put`'s inner-block scoping of `_owned_guard`).
+/// `#[cfg(test)]`-gated end to end -- zero effect on non-test builds.
+#[cfg(test)]
+mod sync_hook {
+    use std::collections::{HashMap, VecDeque};
+    use std::path::{Path, PathBuf};
+    use std::sync::mpsc::{Receiver, Sender};
+    use std::sync::{Mutex as StdMutex, OnceLock};
+
+    pub(super) struct Hook {
+        pub(super) reached: Sender<()>,
+        pub(super) release: Receiver<()>,
+        pub(super) done: Sender<()>,
+    }
+
+    fn registry() -> &'static StdMutex<HashMap<PathBuf, VecDeque<Hook>>> {
+        static REGISTRY: OnceLock<StdMutex<HashMap<PathBuf, VecDeque<Hook>>>> = OnceLock::new();
+        REGISTRY.get_or_init(|| StdMutex::new(HashMap::new()))
+    }
+
+    /// Queue a one-shot hook for the NEXT `put` against `root`'s canonical
+    /// path. Consumed exactly once, FIFO -- a test expecting several
+    /// sequential puts to each pause installs several hooks.
+    pub(super) fn install(root: &Path) -> (Receiver<()>, Sender<()>, Receiver<()>) {
+        let canonical = root
+            .canonicalize()
+            .expect("root must exist before installing a sync_hook");
+        let (reached_tx, reached_rx) = std::sync::mpsc::channel();
+        let (release_tx, release_rx) = std::sync::mpsc::channel();
+        let (done_tx, done_rx) = std::sync::mpsc::channel();
+        registry()
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .entry(canonical)
+            .or_default()
+            .push_back(Hook {
+                reached: reached_tx,
+                release: release_rx,
+                done: done_tx,
+            });
+        (reached_rx, release_tx, done_rx)
+    }
+
+    /// Pop the next queued hook for `root`'s canonical path, if any (`None`
+    /// for every ordinary, non-instrumented test -- `put` runs completely
+    /// unaffected). `root` need not be pre-canonicalized by the caller --
+    /// both `install` and `take` canonicalize, matching how
+    /// `write_lock_for_root` keys the shared lock registry.
+    pub(super) fn take(root: &Path) -> Option<Hook> {
+        let canonical = root.canonicalize().ok()?;
+        registry()
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .get_mut(&canonical)
+            .and_then(VecDeque::pop_front)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -365,6 +460,34 @@ mod tests {
         let root = dir.path().join("blobs");
         let store = FsBlobStore::new(root, floor_bytes).unwrap();
         (dir, store)
+    }
+
+    /// Block on `rx.recv()` on a dedicated thread so a `#[tokio::test]`
+    /// (current-thread runtime) doesn't stall other spawned tasks while
+    /// waiting on a `sync_hook` signal. Round-3 Medium: the deterministic,
+    /// event-driven replacement for fixed-sleep / fixed-duration-poll
+    /// assertions.
+    async fn recv_blocking(rx: std::sync::mpsc::Receiver<()>) -> bool {
+        tokio::task::spawn_blocking(move || rx.recv().is_ok())
+            .await
+            .expect("recv_blocking thread panicked")
+    }
+
+    /// Bounded-wait variant, used ONLY as a failure backstop proving a
+    /// signal did NOT arrive within a generous window -- never as the
+    /// positive correctness proof (that is always an unbounded
+    /// `recv_blocking`). Returns the receiver back so the caller can keep
+    /// waiting on it afterward.
+    async fn recv_timeout_blocking(
+        rx: std::sync::mpsc::Receiver<()>,
+        timeout: std::time::Duration,
+    ) -> (bool, std::sync::mpsc::Receiver<()>) {
+        tokio::task::spawn_blocking(move || {
+            let arrived = rx.recv_timeout(timeout).is_ok();
+            (arrived, rx)
+        })
+        .await
+        .expect("recv_timeout_blocking thread panicked")
     }
 
     #[tokio::test]
@@ -589,40 +712,92 @@ mod tests {
         // store's `write_lock` was its own independent `Mutex`, and this
         // exact scenario would have let both puts pass the same free-space
         // snapshot.
+        //
+        // Round-3 Medium (codex r3): the earlier version of this test let
+        // two real `tokio::spawn`ed puts race with no control over
+        // interleaving -- it could PASS on the round-2 per-instance-mutex
+        // bug purely because the blocking thread pool happened to run them
+        // sequentially, which is not a deterministic regression guard.
+        //
+        // The first attempt at a `sync_hook`-driven fix kept proving
+        // exclusion INDIRECTLY, through a free-space floor sized to admit
+        // exactly one `payload_len` write -- but this dev box's real
+        // `fs4::available_space` swings by many tens to hundreds of MB in
+        // either direction over the several-second window the hook
+        // orchestration takes (concurrent fleet `cargo clean`/build
+        // activity), and no floor margin proved robust: it was observed to
+        // both under-shoot (store_a's own write refused; available_bytes
+        // 25521500160 vs floor_bytes 25517096960, a ~60 MiB drop) and
+        // over-shoot (store_b's write unexpectedly SUCCEEDED after
+        // store_a's landed, meaning available space had *grown* by more
+        // than the margin during the test) in back-to-back runs.
+        //
+        // Lock sharing is orthogonal to floor arithmetic -- the same
+        // `crosses_floor`/`put_blocking` path runs regardless of which
+        // `FsBlobStore` instance calls it, and that arithmetic is already
+        // covered, disk-noise-tolerantly, by
+        // `concurrent_puts_cannot_jointly_breach_the_floor_via_a_stale_snapshot`
+        // (same-instance) and the pure `crosses_floor` unit tests above.
+        // So this test proves ONLY the lock-sharing property, directly and
+        // deterministically via the `sync_hook` seam's reached/release
+        // ordering, with `floor_bytes = 0` -- zero dependence on real disk
+        // space, hence zero exposure to this host's volatility.
         let dir = tempfile::tempdir().unwrap();
         let root = dir.path().join("blobs");
         fs::create_dir_all(&root).unwrap();
-        let available = fs4::available_space(&root).unwrap();
-        let payload_len: u64 = 64 * 1024 * 1024;
-        let floor = available.saturating_sub(payload_len);
+        let canonical_root = root.canonicalize().unwrap();
 
         // Two INDEPENDENT `FsBlobStore::new` calls for the identical root --
         // exactly what `StorageBackend::blob_store` does on repeat calls.
-        let store_a = std::sync::Arc::new(FsBlobStore::new(root.clone(), floor).unwrap());
-        let store_b = std::sync::Arc::new(FsBlobStore::new(root, floor).unwrap());
+        let store_a = std::sync::Arc::new(FsBlobStore::new(root.clone(), 0).unwrap());
+        let store_b = std::sync::Arc::new(FsBlobStore::new(root, 0).unwrap());
 
-        let a = tokio::spawn(async move { store_a.put(vec![5u8; payload_len as usize]).await });
-        let b = tokio::spawn(async move { store_b.put(vec![6u8; payload_len as usize]).await });
-        let (result_a, result_b) = (a.await.unwrap(), b.await.unwrap());
+        let (a_reached, a_release, _a_done) = sync_hook::install(&canonical_root);
+        let a = {
+            let store_a = store_a.clone();
+            tokio::spawn(async move { store_a.put(b"store_a payload".to_vec()).await })
+        };
+        assert!(
+            recv_blocking(a_reached).await,
+            "store_a's put must reach the sync_hook checkpoint"
+        );
 
-        let successes = [&result_a, &result_b]
-            .into_iter()
-            .filter(|r| r.is_ok())
-            .count();
-        let floor_rejections = [&result_a, &result_b]
-            .into_iter()
-            .filter(|r| matches!(r, Err(StorageError::CapacityFloor { .. })))
-            .count();
+        // While A is paused (owned guard held, not yet released), queue B's
+        // own hook and spawn B. If the two stores truly share one lock, B
+        // cannot even enter its guarded closure yet, so it cannot possibly
+        // reach its own checkpoint within a generous bounded window -- a
+        // failure backstop, not the primary proof (the primary proof is
+        // that B's checkpoint fires only AFTER A releases, asserted below).
+        let (b_reached, b_release, _b_done) = sync_hook::install(&canonical_root);
+        let b = {
+            let store_b = store_b.clone();
+            tokio::spawn(async move { store_b.put(b"store_b payload".to_vec()).await })
+        };
+        let (b_reached_early, b_reached) =
+            recv_timeout_blocking(b_reached, std::time::Duration::from_millis(200)).await;
         assert!(
-            successes <= 1,
-            "two independently constructed FsBlobStore instances for the SAME root must \
-             still share one write lock -- both puts landed: {result_a:?} / {result_b:?}"
+            !b_reached_early,
+            "store_b reached the sync_hook checkpoint while store_a still held the write \
+             lock -- the two independently constructed stores do NOT share one lock"
         );
+
+        // Release A and let it finish. Awaiting A's outer task
+        // deterministically waits for the guard to be dropped too (see
+        // `put`'s inner-block scoping).
+        a_release.send(()).unwrap();
+        let result_a = a.await.unwrap();
+        assert!(result_a.is_ok(), "store_a's put must succeed: {result_a:?}");
+
+        // NOW B can enter its own critical section and reach its
+        // checkpoint -- proves the ordering directly, not by inferring it
+        // from a disk-capacity side effect.
         assert!(
-            floor_rejections >= 1,
-            "two payload_len writes cannot both fit in a payload_len-sized budget: \
-             {result_a:?} / {result_b:?}"
+            recv_blocking(b_reached).await,
+            "store_b's put must reach the sync_hook checkpoint once store_a released the lock"
         );
+        b_release.send(()).unwrap();
+        let result_b = b.await.unwrap();
+        assert!(result_b.is_ok(), "store_b's put must succeed: {result_b:?}");
     }
 
     #[tokio::test]
@@ -636,29 +811,34 @@ mod tests {
         // a second put could then pass its floor check while the first
         // write was still landing.
         //
-        // White-box check (via the same private `write_lock_for_root` the
-        // fix itself uses) rather than an indirect two-store race: abort
-        // the outer task a few milliseconds into a large write (long
-        // enough that the write is almost certainly still in flight,
-        // comfortably past the near-instantaneous lock-acquire-and-dispatch
-        // step), then confirm the shared per-root lock is STILL held
-        // immediately afterward -- only possible if the guard moved into
-        // the detached `spawn_blocking` closure rather than living in the
-        // now-dropped outer frame. Finally confirm the lock does eventually
-        // free (the closure was never leaked, just outlived the cancelled
-        // future).
+        // Round-3 Medium (codex r3): the earlier version of this test
+        // proved the fix with a fixed 10ms sleep before abort and a fixed
+        // 500x10ms poll loop waiting for the lock to free -- and the poll
+        // loop actually FAILED once in codex's own required-suite run (a
+        // flaky gate, not a regression). This version uses the `sync_hook`
+        // seam instead: `reached` fires only once execution is genuinely
+        // inside the guarded closure (owned guard already moved in) and
+        // blocks there until released; `done` fires only after the guard
+        // has actually been dropped (see `put`'s inner-block scoping) --
+        // both edges event-driven, no sleeps, no polling.
         let dir = tempfile::tempdir().unwrap();
         let root = dir.path().join("blobs");
         fs::create_dir_all(&root).unwrap();
         let canonical_root = root.canonicalize().unwrap();
-        let payload_len = 256 * 1024 * 1024; // large enough to still be writing a few ms in
 
         let store = std::sync::Arc::new(FsBlobStore::new(root, 0).unwrap());
+        let (reached, release, done) = sync_hook::install(&canonical_root);
         let handle = {
             let store = store.clone();
-            tokio::spawn(async move { store.put(vec![4u8; payload_len]).await })
+            tokio::spawn(async move { store.put(b"cancellation race payload".to_vec()).await })
         };
-        tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+
+        assert!(
+            recv_blocking(reached).await,
+            "put must reach the sync_hook checkpoint -- owned guard already moved into the \
+             closure -- before this test can mean anything"
+        );
+
         handle.abort();
         let abort_result = handle.await;
         match &abort_result {
@@ -677,20 +857,18 @@ mod tests {
              the aborted frame instead of moving into the spawn_blocking closure"
         );
 
-        // The detached write must still run to completion and release the
-        // lock itself -- it was cancelled from the caller's point of view,
-        // not killed.
-        let mut freed = false;
-        for _ in 0..500 {
-            if shared_lock.try_lock().is_ok() {
-                freed = true;
-                break;
-            }
-            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
-        }
+        // Let the detached write proceed and finish, then wait for its
+        // explicit completion signal -- no polling, no fixed durations.
+        // `done` only fires after the guard is actually dropped (see
+        // `put`), so the very next check is race-free.
+        release.send(()).unwrap();
         assert!(
-            freed,
-            "the detached write must eventually release the guard"
+            recv_blocking(done).await,
+            "the detached write must signal completion once it actually persists"
+        );
+        assert!(
+            shared_lock.try_lock().is_ok(),
+            "the guard must be free once the detached write's completion was observed"
         );
     }
 

--- a/crates/khive-db/src/stores/blob.rs
+++ b/crates/khive-db/src/stores/blob.rs
@@ -1,0 +1,450 @@
+//! Filesystem-backed `BlobStore` — content-addressed, BLAKE3-sharded on disk.
+//!
+//! Layout: `<root>/<hex[0..2]>/<hex[2..4]>/<hex>`, a two-level shard identical
+//! in shape to git's loose-object store, so a root holding millions of blobs
+//! never puts more than a few thousand entries in one directory. Writes are
+//! atomic-publish (khive#292): bytes land in a `tempfile` in the SAME shard
+//! directory as the final path (guaranteeing same-filesystem rename), the
+//! written length is checked against the input length, then
+//! `NamedTempFile::persist` performs the rename — crash-safe (a crash mid-write
+//! leaves an orphaned temp file, never a partially-committed blob).
+
+use std::fs;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+
+use async_trait::async_trait;
+
+use khive_storage::blob::{BlobOrphanSweepConfig, BlobOrphanSweepResult, BlobStore, ContentRef};
+use khive_storage::error::StorageError;
+use khive_storage::types::StorageResult;
+use khive_storage::StorageCapability;
+
+use crate::error::SqliteError;
+
+fn map_io_err(e: std::io::Error, op: &'static str) -> StorageError {
+    StorageError::driver(StorageCapability::Blob, op, e)
+}
+
+fn shard_path(root: &Path, content_ref: &ContentRef) -> PathBuf {
+    let hex = content_ref.as_str();
+    root.join(&hex[0..2]).join(&hex[2..4]).join(hex)
+}
+
+/// Resolve the blob store root directory.
+///
+/// Precedence (khive#292, SPEC-gate ruling): `KHIVE_BLOB_ROOT` env var >
+/// caller-supplied `config_root` (resolved from `khive.toml` by a layer above
+/// this crate — `khive-db` cannot parse TOML itself without an upward
+/// dependency) > beside the database directory (`<db_dir>/blobs`). Errors
+/// when none apply — an in-memory backend with no override and no env var has
+/// no directory to default beside.
+pub fn resolve_blob_root(
+    db_dir: Option<&Path>,
+    config_root: Option<&Path>,
+) -> Result<PathBuf, SqliteError> {
+    if let Ok(env_root) = std::env::var("KHIVE_BLOB_ROOT") {
+        if !env_root.trim().is_empty() {
+            return Ok(PathBuf::from(env_root));
+        }
+    }
+    if let Some(root) = config_root {
+        return Ok(root.to_path_buf());
+    }
+    if let Some(dir) = db_dir {
+        return Ok(dir.join("blobs"));
+    }
+    Err(SqliteError::InvalidData(
+        "cannot resolve a blob store root: no KHIVE_BLOB_ROOT env var, no configured \
+         root, and the database has no on-disk directory to default beside (in-memory \
+         backend)"
+            .to_string(),
+    ))
+}
+
+fn put_blocking(root: &Path, floor_bytes: u64, bytes: Vec<u8>) -> StorageResult<ContentRef> {
+    let digest = blake3::hash(&bytes);
+    let content_ref = ContentRef::from_digest_bytes(digest.as_bytes());
+    let target = shard_path(root, &content_ref);
+
+    // Content-addressed: identical bytes already on disk means this put is a
+    // no-op (BlobStore::put's documented dedup contract) — skip the floor
+    // check and the write entirely.
+    if target.exists() {
+        return Ok(content_ref);
+    }
+
+    let available = fs4::available_space(root).map_err(|e| map_io_err(e, "put_check_space"))?;
+    if available < floor_bytes {
+        return Err(StorageError::CapacityFloor {
+            capability: StorageCapability::Blob,
+            volume: root.display().to_string(),
+            available_bytes: available,
+            floor_bytes,
+        });
+    }
+
+    let shard_dir = target
+        .parent()
+        .expect("shard_path always nests under two directory levels");
+    fs::create_dir_all(shard_dir).map_err(|e| map_io_err(e, "put_mkdir"))?;
+
+    let mut tmp = tempfile::Builder::new()
+        .prefix(".tmp-")
+        .tempfile_in(shard_dir)
+        .map_err(|e| map_io_err(e, "put_tempfile"))?;
+    tmp.write_all(&bytes)
+        .map_err(|e| map_io_err(e, "put_write"))?;
+    tmp.flush().map_err(|e| map_io_err(e, "put_flush"))?;
+    tmp.as_file()
+        .sync_all()
+        .map_err(|e| map_io_err(e, "put_fsync"))?;
+
+    let written_len = tmp
+        .as_file()
+        .metadata()
+        .map_err(|e| map_io_err(e, "put_verify"))?
+        .len();
+    if written_len != bytes.len() as u64 {
+        return Err(map_io_err(
+            std::io::Error::other(format!(
+                "temp file length {written_len} does not match {} written bytes",
+                bytes.len()
+            )),
+            "put_verify",
+        ));
+    }
+
+    tmp.persist(&target)
+        .map_err(|e| map_io_err(e.error, "put_persist"))?;
+
+    Ok(content_ref)
+}
+
+fn walk_blob_files(root: &Path) -> std::io::Result<Vec<(ContentRef, PathBuf)>> {
+    let mut out = Vec::new();
+    if !root.exists() {
+        return Ok(out);
+    }
+    for l1 in fs::read_dir(root)? {
+        let l1 = l1?;
+        if !l1.file_type()?.is_dir() {
+            continue;
+        }
+        for l2 in fs::read_dir(l1.path())? {
+            let l2 = l2?;
+            if !l2.file_type()?.is_dir() {
+                continue;
+            }
+            for entry in fs::read_dir(l2.path())? {
+                let entry = entry?;
+                if !entry.file_type()?.is_file() {
+                    continue;
+                }
+                // Non-hex names (in-flight `.tmp-*` files from a concurrent
+                // `put`, or anything else that landed under `root`) are
+                // silently skipped, never swept — orphan_sweep only ever acts
+                // on names that already round-trip through `ContentRef`.
+                let Some(name) = entry.file_name().to_str().map(str::to_string) else {
+                    continue;
+                };
+                if let Ok(content_ref) = ContentRef::from_hex(name) {
+                    out.push((content_ref, entry.path()));
+                }
+            }
+        }
+    }
+    Ok(out)
+}
+
+/// A `BlobStore` backed by a BLAKE3-sharded directory tree.
+pub struct FsBlobStore {
+    root: PathBuf,
+    floor_bytes: u64,
+}
+
+impl FsBlobStore {
+    /// Default fail-closed free-space floor (khive#292 SPEC-gate ruling):
+    /// 100 GB. Config-overridable via the `floor_bytes` constructor argument.
+    pub const DEFAULT_FLOOR_BYTES: u64 = 100_000_000_000;
+
+    /// Create a store rooted at `root`, creating the directory if absent.
+    pub fn new(root: PathBuf, floor_bytes: u64) -> Result<Self, SqliteError> {
+        fs::create_dir_all(&root)?;
+        Ok(Self { root, floor_bytes })
+    }
+
+    /// The resolved root directory this store writes under.
+    pub fn root(&self) -> &Path {
+        &self.root
+    }
+}
+
+#[async_trait]
+impl BlobStore for FsBlobStore {
+    async fn put(&self, bytes: Vec<u8>) -> StorageResult<ContentRef> {
+        let root = self.root.clone();
+        let floor_bytes = self.floor_bytes;
+        tokio::task::spawn_blocking(move || put_blocking(&root, floor_bytes, bytes))
+            .await
+            .map_err(|e| StorageError::driver(StorageCapability::Blob, "put", e))?
+    }
+
+    async fn get(&self, content_ref: &ContentRef) -> StorageResult<Vec<u8>> {
+        let path = shard_path(&self.root, content_ref);
+        let key = content_ref.to_string();
+        tokio::task::spawn_blocking(move || {
+            fs::read(&path).map_err(|e| {
+                if e.kind() == std::io::ErrorKind::NotFound {
+                    StorageError::NotFound {
+                        capability: StorageCapability::Blob,
+                        resource: "blob",
+                        key,
+                    }
+                } else {
+                    map_io_err(e, "get")
+                }
+            })
+        })
+        .await
+        .map_err(|e| StorageError::driver(StorageCapability::Blob, "get", e))?
+    }
+
+    async fn exists(&self, content_ref: &ContentRef) -> StorageResult<bool> {
+        let path = shard_path(&self.root, content_ref);
+        tokio::task::spawn_blocking(move || Ok(path.exists()))
+            .await
+            .map_err(|e| StorageError::driver(StorageCapability::Blob, "exists", e))?
+    }
+
+    async fn delete(&self, content_ref: &ContentRef) -> StorageResult<bool> {
+        let path = shard_path(&self.root, content_ref);
+        tokio::task::spawn_blocking(move || match fs::remove_file(&path) {
+            Ok(()) => Ok(true),
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(false),
+            Err(e) => Err(map_io_err(e, "delete")),
+        })
+        .await
+        .map_err(|e| StorageError::driver(StorageCapability::Blob, "delete", e))?
+    }
+
+    async fn orphan_sweep(
+        &self,
+        config: &BlobOrphanSweepConfig,
+    ) -> StorageResult<BlobOrphanSweepResult> {
+        let root = self.root.clone();
+        let live_refs = config.live_refs.clone();
+        let dry_run = config.dry_run;
+        tokio::task::spawn_blocking(move || {
+            let files = walk_blob_files(&root).map_err(|e| map_io_err(e, "orphan_sweep_walk"))?;
+            let mut scanned = 0u64;
+            let mut deleted = 0u64;
+            let mut would_delete = 0u64;
+            for (content_ref, path) in files {
+                scanned += 1;
+                if live_refs.contains(&content_ref) {
+                    continue;
+                }
+                would_delete += 1;
+                if !dry_run {
+                    fs::remove_file(&path).map_err(|e| map_io_err(e, "orphan_sweep_delete"))?;
+                    deleted += 1;
+                }
+            }
+            Ok(BlobOrphanSweepResult {
+                scanned,
+                deleted,
+                would_delete,
+            })
+        })
+        .await
+        .map_err(|e| StorageError::driver(StorageCapability::Blob, "orphan_sweep", e))?
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn store(floor_bytes: u64) -> (tempfile::TempDir, FsBlobStore) {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path().join("blobs");
+        let store = FsBlobStore::new(root, floor_bytes).unwrap();
+        (dir, store)
+    }
+
+    #[tokio::test]
+    async fn put_get_roundtrip() {
+        let (_dir, store) = store(0);
+        let bytes = b"hello blob store".to_vec();
+        let content_ref = store.put(bytes.clone()).await.unwrap();
+        let fetched = store.get(&content_ref).await.unwrap();
+        assert_eq!(fetched, bytes);
+    }
+
+    #[tokio::test]
+    async fn put_content_ref_matches_blake3_digest() {
+        let (_dir, store) = store(0);
+        let bytes = b"digest check".to_vec();
+        let content_ref = store.put(bytes.clone()).await.unwrap();
+        let expected = ContentRef::from_digest_bytes(blake3::hash(&bytes).as_bytes());
+        assert_eq!(content_ref, expected);
+    }
+
+    #[tokio::test]
+    async fn put_dedups_identical_content() {
+        let (_dir, store) = store(0);
+        let bytes = b"same bytes twice".to_vec();
+        let first = store.put(bytes.clone()).await.unwrap();
+        let second = store.put(bytes.clone()).await.unwrap();
+        assert_eq!(first, second);
+        assert_eq!(store.get(&first).await.unwrap(), bytes);
+    }
+
+    #[tokio::test]
+    async fn exists_reflects_put_and_delete() {
+        let (_dir, store) = store(0);
+        let bytes = b"exists check".to_vec();
+        let content_ref = store.put(bytes).await.unwrap();
+        assert!(store.exists(&content_ref).await.unwrap());
+
+        assert!(store.delete(&content_ref).await.unwrap());
+        assert!(!store.exists(&content_ref).await.unwrap());
+    }
+
+    #[tokio::test]
+    async fn delete_missing_content_ref_returns_false() {
+        let (_dir, store) = store(0);
+        let missing = ContentRef::from_hex("f".repeat(64)).unwrap();
+        assert!(!store.delete(&missing).await.unwrap());
+    }
+
+    #[tokio::test]
+    async fn get_missing_content_ref_returns_not_found() {
+        let (_dir, store) = store(0);
+        let missing = ContentRef::from_hex("e".repeat(64)).unwrap();
+        let err = store.get(&missing).await.unwrap_err();
+        assert!(matches!(err, StorageError::NotFound { .. }));
+    }
+
+    #[tokio::test]
+    async fn put_refuses_below_free_space_floor() {
+        // A floor no real disk clears -> put must fail closed, not silently
+        // degrade or spill elsewhere (khive#292 SPEC-gate ruling).
+        let (_dir, store) = store(u64::MAX);
+        let err = store.put(b"too big a floor".to_vec()).await.unwrap_err();
+        match err {
+            StorageError::CapacityFloor {
+                floor_bytes,
+                available_bytes,
+                ..
+            } => {
+                assert_eq!(floor_bytes, u64::MAX);
+                assert!(available_bytes < u64::MAX);
+            }
+            other => panic!("expected CapacityFloor, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn capacity_floor_error_names_the_floor_and_volume() {
+        let (_dir, store) = store(u64::MAX);
+        let err = store.put(b"x".to_vec()).await.unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains(&u64::MAX.to_string()),
+            "must name the floor: {msg}"
+        );
+        assert!(msg.contains("Blob"), "must name the capability: {msg}");
+    }
+
+    #[tokio::test]
+    async fn orphan_sweep_dry_run_reports_without_deleting() {
+        let (_dir, store) = store(0);
+        let live = store.put(b"keep me".to_vec()).await.unwrap();
+        let orphan = store.put(b"orphaned".to_vec()).await.unwrap();
+
+        let mut live_refs = std::collections::HashSet::new();
+        live_refs.insert(live.clone());
+        let result = store
+            .orphan_sweep(&BlobOrphanSweepConfig {
+                live_refs,
+                dry_run: true,
+            })
+            .await
+            .unwrap();
+
+        assert_eq!(result.scanned, 2);
+        assert_eq!(result.would_delete, 1);
+        assert_eq!(result.deleted, 0);
+        assert!(
+            store.exists(&orphan).await.unwrap(),
+            "dry run must not delete"
+        );
+        assert!(store.exists(&live).await.unwrap());
+    }
+
+    #[tokio::test]
+    async fn orphan_sweep_real_run_deletes_only_unreferenced_blobs() {
+        let (_dir, store) = store(0);
+        let live = store.put(b"keep me".to_vec()).await.unwrap();
+        let orphan = store.put(b"orphaned".to_vec()).await.unwrap();
+
+        let mut live_refs = std::collections::HashSet::new();
+        live_refs.insert(live.clone());
+        let result = store
+            .orphan_sweep(&BlobOrphanSweepConfig {
+                live_refs,
+                dry_run: false,
+            })
+            .await
+            .unwrap();
+
+        assert_eq!(result.scanned, 2);
+        assert_eq!(result.would_delete, 1);
+        assert_eq!(result.deleted, 1);
+        assert!(!store.exists(&orphan).await.unwrap());
+        assert!(
+            store.exists(&live).await.unwrap(),
+            "live blob must survive sweep"
+        );
+    }
+
+    #[test]
+    fn resolve_blob_root_prefers_env_var() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        std::env::set_var("KHIVE_BLOB_ROOT", "/tmp/env-override-root");
+        let resolved = resolve_blob_root(Some(Path::new("/db/dir")), Some(Path::new("/cfg/root")));
+        std::env::remove_var("KHIVE_BLOB_ROOT");
+        assert_eq!(resolved.unwrap(), PathBuf::from("/tmp/env-override-root"));
+    }
+
+    #[test]
+    fn resolve_blob_root_prefers_config_over_default() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        std::env::remove_var("KHIVE_BLOB_ROOT");
+        let resolved = resolve_blob_root(Some(Path::new("/db/dir")), Some(Path::new("/cfg/root")));
+        assert_eq!(resolved.unwrap(), PathBuf::from("/cfg/root"));
+    }
+
+    #[test]
+    fn resolve_blob_root_defaults_beside_db_dir() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        std::env::remove_var("KHIVE_BLOB_ROOT");
+        let resolved = resolve_blob_root(Some(Path::new("/db/dir")), None);
+        assert_eq!(resolved.unwrap(), PathBuf::from("/db/dir/blobs"));
+    }
+
+    #[test]
+    fn resolve_blob_root_errors_with_no_env_config_or_db_dir() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        std::env::remove_var("KHIVE_BLOB_ROOT");
+        let resolved = resolve_blob_root(None, None);
+        assert!(resolved.is_err());
+    }
+
+    // `std::env::set_var`/`remove_var` mutate real process-global state, so the
+    // four `resolve_blob_root` env-precedence tests must not interleave under
+    // the crate's default parallel test runner.
+    static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+}

--- a/crates/khive-db/src/stores/blob.rs
+++ b/crates/khive-db/src/stores/blob.rs
@@ -473,23 +473,6 @@ mod tests {
             .expect("recv_blocking thread panicked")
     }
 
-    /// Bounded-wait variant, used ONLY as a failure backstop proving a
-    /// signal did NOT arrive within a generous window -- never as the
-    /// positive correctness proof (that is always an unbounded
-    /// `recv_blocking`). Returns the receiver back so the caller can keep
-    /// waiting on it afterward.
-    async fn recv_timeout_blocking(
-        rx: std::sync::mpsc::Receiver<()>,
-        timeout: std::time::Duration,
-    ) -> (bool, std::sync::mpsc::Receiver<()>) {
-        tokio::task::spawn_blocking(move || {
-            let arrived = rx.recv_timeout(timeout).is_ok();
-            (arrived, rx)
-        })
-        .await
-        .expect("recv_timeout_blocking thread panicked")
-    }
-
     #[tokio::test]
     async fn put_get_roundtrip() {
         let (_dir, store) = store(0);
@@ -719,9 +702,9 @@ mod tests {
         // bug purely because the blocking thread pool happened to run them
         // sequentially, which is not a deterministic regression guard.
         //
-        // The first attempt at a `sync_hook`-driven fix kept proving
-        // exclusion INDIRECTLY, through a free-space floor sized to admit
-        // exactly one `payload_len` write -- but this dev box's real
+        // The first `sync_hook`-driven attempt kept proving exclusion
+        // INDIRECTLY, through a free-space floor sized to admit exactly one
+        // `payload_len` write -- but this dev box's real
         // `fs4::available_space` swings by many tens to hundreds of MB in
         // either direction over the several-second window the hook
         // orchestration takes (concurrent fleet `cargo clean`/build
@@ -729,8 +712,7 @@ mod tests {
         // both under-shoot (store_a's own write refused; available_bytes
         // 25521500160 vs floor_bytes 25517096960, a ~60 MiB drop) and
         // over-shoot (store_b's write unexpectedly SUCCEEDED after
-        // store_a's landed, meaning available space had *grown* by more
-        // than the margin during the test) in back-to-back runs.
+        // store_a's landed) in back-to-back runs.
         //
         // Lock sharing is orthogonal to floor arithmetic -- the same
         // `crosses_floor`/`put_blocking` path runs regardless of which
@@ -738,10 +720,24 @@ mod tests {
         // covered, disk-noise-tolerantly, by
         // `concurrent_puts_cannot_jointly_breach_the_floor_via_a_stale_snapshot`
         // (same-instance) and the pure `crosses_floor` unit tests above.
-        // So this test proves ONLY the lock-sharing property, directly and
-        // deterministically via the `sync_hook` seam's reached/release
-        // ordering, with `floor_bytes = 0` -- zero dependence on real disk
-        // space, hence zero exposure to this host's volatility.
+        //
+        // Round-4 Medium (codex r4): the round-3 fix's negative proof (B
+        // must not reach its own checkpoint) still leaned on a 200ms
+        // `recv_timeout` as the CORRECTNESS decision -- under sufficiently
+        // delayed scheduling, old per-instance-mutex code's B could simply
+        // arrive after the window and every assertion would still pass,
+        // silently defeating the regression guard. Fix: assert directly
+        // and immediately (no timeout, no second hook, no second
+        // `tokio::spawn` racing at all) that `store_b.write_lock` -- a
+        // private field, reachable here because `tests` is a child module
+        // of the module that declares it -- is ALREADY held the instant
+        // store_a's put holds ITS guard. Under the fixed canonical-root
+        // registry this is the exact same `Arc` store_a's own `write_lock`
+        // resolves to, so `try_lock()` fails with zero timing dependence;
+        // under the old per-instance-mutex code, `store_b.write_lock` is a
+        // completely independent, unheld `Mutex`, so `try_lock()` would
+        // succeed immediately, pinning the defect on the spot regardless
+        // of scheduling.
         let dir = tempfile::tempdir().unwrap();
         let root = dir.path().join("blobs");
         fs::create_dir_all(&root).unwrap();
@@ -762,23 +758,14 @@ mod tests {
             "store_a's put must reach the sync_hook checkpoint"
         );
 
-        // While A is paused (owned guard held, not yet released), queue B's
-        // own hook and spawn B. If the two stores truly share one lock, B
-        // cannot even enter its guarded closure yet, so it cannot possibly
-        // reach its own checkpoint within a generous bounded window -- a
-        // failure backstop, not the primary proof (the primary proof is
-        // that B's checkpoint fires only AFTER A releases, asserted below).
-        let (b_reached, b_release, _b_done) = sync_hook::install(&canonical_root);
-        let b = {
-            let store_b = store_b.clone();
-            tokio::spawn(async move { store_b.put(b"store_b payload".to_vec()).await })
-        };
-        let (b_reached_early, b_reached) =
-            recv_timeout_blocking(b_reached, std::time::Duration::from_millis(200)).await;
+        // The deterministic proof: store_b's OWN write_lock field must
+        // already be unavailable while store_a holds its guard -- true
+        // only if the two independently constructed stores share one
+        // Arc<Mutex<()>>. No timeout, no scheduling dependence.
         assert!(
-            !b_reached_early,
-            "store_b reached the sync_hook checkpoint while store_a still held the write \
-             lock -- the two independently constructed stores do NOT share one lock"
+            store_b.write_lock.try_lock().is_err(),
+            "store_b's write_lock was NOT held while store_a's put held its guard -- the two \
+             independently constructed stores do NOT share one lock"
         );
 
         // Release A and let it finish. Awaiting A's outer task
@@ -788,15 +775,9 @@ mod tests {
         let result_a = a.await.unwrap();
         assert!(result_a.is_ok(), "store_a's put must succeed: {result_a:?}");
 
-        // NOW B can enter its own critical section and reach its
-        // checkpoint -- proves the ordering directly, not by inferring it
-        // from a disk-capacity side effect.
-        assert!(
-            recv_blocking(b_reached).await,
-            "store_b's put must reach the sync_hook checkpoint once store_a released the lock"
-        );
-        b_release.send(()).unwrap();
-        let result_b = b.await.unwrap();
+        // Liveness coverage: an ordinary put on store_b succeeds once
+        // store_a has released the (shared) lock.
+        let result_b = store_b.put(b"store_b payload".to_vec()).await;
         assert!(result_b.is_ok(), "store_b's put must succeed: {result_b:?}");
     }
 

--- a/crates/khive-db/src/stores/blob.rs
+++ b/crates/khive-db/src/stores/blob.rs
@@ -62,6 +62,23 @@ pub fn resolve_blob_root(
     ))
 }
 
+/// Whether writing `required_write_bytes` more bytes to a volume currently
+/// reporting `available` free bytes would leave it below `floor_bytes`.
+///
+/// Pure and filesystem-independent on purpose (round-2 High finding): the
+/// exact boundary this guards — `available == floor_bytes + 1` must still
+/// refuse a 2-byte write, because a floor-only check (`available <
+/// floor_bytes`) does not account for the pending write's own size — is unit
+/// tested directly against this function rather than against the real
+/// filesystem's `fs4::available_space`, which fluctuates under concurrent
+/// build/agent activity on a shared machine and made an earlier
+/// exact-boundary integration test flaky. `saturating_sub` avoids underflow
+/// when `required_write_bytes` exceeds `available` outright — that case
+/// still correctly refuses for any nonzero floor.
+fn crosses_floor(available: u64, required_write_bytes: u64, floor_bytes: u64) -> bool {
+    available.saturating_sub(required_write_bytes) < floor_bytes
+}
+
 fn put_blocking(root: &Path, floor_bytes: u64, bytes: Vec<u8>) -> StorageResult<ContentRef> {
     let digest = blake3::hash(&bytes);
     let content_ref = ContentRef::from_digest_bytes(digest.as_bytes());
@@ -74,8 +91,9 @@ fn put_blocking(root: &Path, floor_bytes: u64, bytes: Vec<u8>) -> StorageResult<
         return Ok(content_ref);
     }
 
+    let required_write_bytes = bytes.len() as u64;
     let available = fs4::available_space(root).map_err(|e| map_io_err(e, "put_check_space"))?;
-    if available < floor_bytes {
+    if crosses_floor(available, required_write_bytes, floor_bytes) {
         return Err(StorageError::CapacityFloor {
             capability: StorageCapability::Blob,
             volume: root.display().to_string(),
@@ -161,6 +179,18 @@ fn walk_blob_files(root: &Path) -> std::io::Result<Vec<(ContentRef, PathBuf)>> {
 pub struct FsBlobStore {
     root: PathBuf,
     floor_bytes: u64,
+    /// Serializes the check-then-publish critical section of `put` per root
+    /// (round-2 High finding): without this, two concurrent puts can each
+    /// observe the same pre-write `available_space` snapshot, each pass
+    /// their own write-size-aware floor check against it, and then both
+    /// write — jointly pushing the volume under the floor even though
+    /// neither write looked unsafe in isolation. Held across the whole
+    /// `spawn_blocking` call (check, write, fsync, persist), so the second
+    /// of two racing puts always observes the first's write already landed.
+    /// A per-root async mutex is adequate at this write rate; it is not
+    /// meant to defend against another process (only within-process
+    /// `FsBlobStore` callers).
+    write_lock: tokio::sync::Mutex<()>,
 }
 
 impl FsBlobStore {
@@ -171,7 +201,11 @@ impl FsBlobStore {
     /// Create a store rooted at `root`, creating the directory if absent.
     pub fn new(root: PathBuf, floor_bytes: u64) -> Result<Self, SqliteError> {
         fs::create_dir_all(&root)?;
-        Ok(Self { root, floor_bytes })
+        Ok(Self {
+            root,
+            floor_bytes,
+            write_lock: tokio::sync::Mutex::new(()),
+        })
     }
 
     /// The resolved root directory this store writes under.
@@ -183,6 +217,7 @@ impl FsBlobStore {
 #[async_trait]
 impl BlobStore for FsBlobStore {
     async fn put(&self, bytes: Vec<u8>) -> StorageResult<ContentRef> {
+        let _write_guard = self.write_lock.lock().await;
         let root = self.root.clone();
         let floor_bytes = self.floor_bytes;
         tokio::task::spawn_blocking(move || put_blocking(&root, floor_bytes, bytes))
@@ -228,6 +263,11 @@ impl BlobStore for FsBlobStore {
         .map_err(|e| StorageError::driver(StorageCapability::Blob, "delete", e))?
     }
 
+    // Offline-maintenance-only — see `BlobStore::orphan_sweep`'s doc comment
+    // for the concurrency hazard (`config.live_refs` is a snapshot; a
+    // `content_ref` that becomes live after the snapshot is deleted anyway).
+    // This method performs no DB coordination; it only compares against
+    // whatever set the caller handed it.
     async fn orphan_sweep(
         &self,
         config: &BlobOrphanSweepConfig,
@@ -356,6 +396,177 @@ mod tests {
             "must name the floor: {msg}"
         );
         assert!(msg.contains("Blob"), "must name the capability: {msg}");
+    }
+
+    #[test]
+    fn crosses_floor_is_write_size_aware_at_the_exact_boundary() {
+        // Round-2 High, codex's own example verbatim: `available ==
+        // floor_bytes + 1` must still refuse a 2-byte write. A floor-only
+        // check (`available < floor_bytes`) would NOT catch this — 101 is
+        // not below 100 — but the write's own size must be subtracted first.
+        assert!(crosses_floor(101, 2, 100));
+        assert!(!crosses_floor(101, 1, 100));
+    }
+
+    #[test]
+    fn crosses_floor_accepts_a_write_that_lands_exactly_on_the_floor() {
+        assert!(!crosses_floor(100, 0, 100));
+    }
+
+    #[test]
+    fn crosses_floor_rejects_a_write_that_lands_one_byte_under_the_floor() {
+        assert!(crosses_floor(100, 1, 100));
+    }
+
+    #[test]
+    fn crosses_floor_saturates_instead_of_underflowing_when_write_exceeds_available() {
+        assert!(crosses_floor(10, 100, 50));
+        // floor_bytes == 0 means "no floor enforced" (the convention every
+        // other test in this file uses via `store(0)`) — even a write far
+        // exceeding available space is not refused by the floor check itself
+        // in that case; `saturating_sub` floors the subtraction at 0, and
+        // `0 < 0` is false.
+        assert!(!crosses_floor(10, 100, 0));
+    }
+
+    #[tokio::test]
+    async fn put_refuses_a_write_that_would_cross_the_floor_even_though_available_alone_clears_it()
+    {
+        // Integration-level companion to the pure `crosses_floor` tests
+        // above: proves `FsBlobStore::put` actually wires the write-size-
+        // aware check through end-to-end. Uses a generous margin/cushion
+        // (128 MiB total) rather than an exact boundary, because an earlier
+        // version of this test pinned the floor to the exact
+        // `fs4::available_space` reading and flaked: on this shared,
+        // heavily-loaded dev machine, `fs4::available_space` was observed to
+        // shift by tens of MB between two calls milliseconds apart (other
+        // agents' concurrent builds). A floor-only check would still pass
+        // here (available comfortably clears the floor by MARGIN bytes);
+        // the write-size-aware check must reject once the payload's own
+        // CUSHION-sized excess is subtracted.
+        const MARGIN: u64 = 64 * 1024 * 1024;
+        const CUSHION: u64 = 64 * 1024 * 1024;
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path().join("blobs");
+        fs::create_dir_all(&root).unwrap();
+        let available = fs4::available_space(&root).unwrap();
+        let floor = available.saturating_sub(MARGIN);
+        let store = FsBlobStore::new(root, floor).unwrap();
+
+        let err = store
+            .put(vec![7u8; (MARGIN + CUSHION) as usize])
+            .await
+            .unwrap_err();
+        assert!(
+            matches!(err, StorageError::CapacityFloor { .. }),
+            "a write-size-aware floor check must reject a write that pushes the volume \
+             below the floor even though available space alone still clears it: {err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn concurrent_puts_cannot_jointly_breach_the_floor_via_a_stale_snapshot() {
+        // Round-2 High: pin the floor so at most ONE `payload_len`-sized
+        // write may land before the floor is crossed. Fire two DIFFERENT
+        // (non-deduping) payloads of that size concurrently. Before the
+        // per-root `write_lock`, both puts could independently read the SAME
+        // pre-write `available_space` snapshot, both pass their own
+        // write-size-aware check against it (neither sees the other's
+        // pending write), and both actually write — jointly breaching the
+        // floor. With serialization, the second put's check only runs after
+        // the first put's write has actually landed on disk, so it observes
+        // the reduced space. The decisive, noise-tolerant invariant is that
+        // BOTH can never succeed (under the pre-fix code, both reliably
+        // would, since the floor is deliberately set a full `payload_len`
+        // below the pre-test reading and neither write's own size was
+        // subtracted): assert at most one success and at least one
+        // rejection, rather than pinning an exact 1-success/1-reject split,
+        // since which side of the boundary a given put lands on is
+        // legitimately sensitive to real, unrelated disk churn on a shared
+        // dev/CI box. `payload_len` (64 MiB) is chosen to dwarf the few-MB
+        // swings observed in this environment.
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path().join("blobs");
+        fs::create_dir_all(&root).unwrap();
+        let available = fs4::available_space(&root).unwrap();
+        let payload_len: u64 = 64 * 1024 * 1024;
+        let floor = available.saturating_sub(payload_len);
+        let store = std::sync::Arc::new(FsBlobStore::new(root, floor).unwrap());
+
+        let a = {
+            let store = store.clone();
+            tokio::spawn(async move { store.put(vec![1u8; payload_len as usize]).await })
+        };
+        let b = {
+            let store = store.clone();
+            tokio::spawn(async move { store.put(vec![2u8; payload_len as usize]).await })
+        };
+        let (result_a, result_b) = (a.await.unwrap(), b.await.unwrap());
+
+        let successes = [&result_a, &result_b]
+            .into_iter()
+            .filter(|r| r.is_ok())
+            .count();
+        let floor_rejections = [&result_a, &result_b]
+            .into_iter()
+            .filter(|r| matches!(r, Err(StorageError::CapacityFloor { .. })))
+            .count();
+        assert!(
+            successes <= 1,
+            "both concurrent puts landed -- the floor was jointly breached by a stale \
+             snapshot race: {result_a:?} / {result_b:?}"
+        );
+        assert!(
+            floor_rejections >= 1,
+            "two payload_len writes cannot both fit in a payload_len-sized budget -- at \
+             least one rejection is expected: {result_a:?} / {result_b:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn orphan_sweep_race_demonstrates_the_documented_quiescence_requirement() {
+        // Round-2 High: `orphan_sweep` and `delete` are documented
+        // (`BlobStore::orphan_sweep`'s doc comment, ADR-111 §8) as
+        // offline-maintenance-only APIs that require the caller to quiesce
+        // entity writes for the duration of snapshot-plus-sweep, because
+        // `live_refs` is a snapshot with no database coordination. This test
+        // reproduces the exact hazard in code rather than leaving it as
+        // prose: a blob that becomes newly "live" AFTER the caller's
+        // `live_refs` snapshot was taken, but BEFORE the sweep runs, is
+        // deleted anyway. That is the documented boundary, not a bug in this
+        // test — it exists so a future change that silently narrows this
+        // hazard (without updating the docs) breaks a test instead of
+        // shipping a doc/behavior mismatch.
+        let (_dir, store) = store(0);
+        let blob = store
+            .put(b"about to become live mid-sweep".to_vec())
+            .await
+            .unwrap();
+
+        // The caller's live_refs snapshot was taken before an entity write
+        // referencing `blob` landed (represented here by simply never adding
+        // it to the snapshot — orphan_sweep has no other way to learn about
+        // it).
+        let live_refs_snapshot = std::collections::HashSet::new();
+
+        let result = store
+            .orphan_sweep(&BlobOrphanSweepConfig {
+                live_refs: live_refs_snapshot,
+                dry_run: false,
+            })
+            .await
+            .unwrap();
+
+        assert_eq!(
+            result.deleted, 1,
+            "the now-live blob is deleted anyway: this is the documented hazard"
+        );
+        assert!(
+            !store.exists(&blob).await.unwrap(),
+            "orphan_sweep is unsafe against a content_ref that becomes live after the \
+             snapshot was taken — callers MUST quiesce entity writes before running it \
+             (ADR-111 §8)"
+        );
     }
 
     #[tokio::test]

--- a/crates/khive-db/src/stores/blob.rs
+++ b/crates/khive-db/src/stores/blob.rs
@@ -9,9 +9,11 @@
 //! `NamedTempFile::persist` performs the rename — crash-safe (a crash mid-write
 //! leaves an orphaned temp file, never a partially-committed blob).
 
+use std::collections::HashMap;
 use std::fs;
 use std::io::Write;
 use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex as StdMutex, OnceLock};
 
 use async_trait::async_trait;
 
@@ -175,22 +177,61 @@ fn walk_blob_files(root: &Path) -> std::io::Result<Vec<(ContentRef, PathBuf)>> {
     Ok(out)
 }
 
+/// Process-wide registry of per-canonical-root write locks.
+///
+/// A `Mutex` field scoped to one `FsBlobStore` instance does NOT serialize
+/// writes across independently constructed stores for the same root — and
+/// callers construct fresh stores for the same root routinely
+/// (`StorageBackend::blob_store` builds a new `FsBlobStore` on every call;
+/// round-2 High finding). Keying a shared `Arc<tokio::sync::Mutex<()>>` by
+/// the filesystem's own canonical path closes that gap: every `FsBlobStore`
+/// for the same root, however many separate `new` calls produced them,
+/// resolves to the exact same lock.
+fn root_write_locks() -> &'static StdMutex<HashMap<PathBuf, Arc<tokio::sync::Mutex<()>>>> {
+    static REGISTRY: OnceLock<StdMutex<HashMap<PathBuf, Arc<tokio::sync::Mutex<()>>>>> =
+        OnceLock::new();
+    REGISTRY.get_or_init(|| StdMutex::new(HashMap::new()))
+}
+
+/// Look up (or create) the shared write lock for `root`'s canonical path.
+///
+/// `root` must already exist when this is called — `FsBlobStore::new`
+/// creates it first, and `Path::canonicalize` requires the path to exist.
+/// The lookup-or-insert happens under the registry's own (synchronous, very
+/// briefly held) lock, so two `FsBlobStore::new` calls racing for the same
+/// root cannot each install a different `Arc` and defeat the sharing this
+/// exists for.
+fn write_lock_for_root(root: &Path) -> std::io::Result<Arc<tokio::sync::Mutex<()>>> {
+    let canonical = root.canonicalize()?;
+    let mut locks = root_write_locks()
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    Ok(locks
+        .entry(canonical)
+        .or_insert_with(|| Arc::new(tokio::sync::Mutex::new(())))
+        .clone())
+}
+
 /// A `BlobStore` backed by a BLAKE3-sharded directory tree.
 pub struct FsBlobStore {
     root: PathBuf,
     floor_bytes: u64,
-    /// Serializes the check-then-publish critical section of `put` per root
-    /// (round-2 High finding): without this, two concurrent puts can each
-    /// observe the same pre-write `available_space` snapshot, each pass
-    /// their own write-size-aware floor check against it, and then both
-    /// write — jointly pushing the volume under the floor even though
-    /// neither write looked unsafe in isolation. Held across the whole
-    /// `spawn_blocking` call (check, write, fsync, persist), so the second
-    /// of two racing puts always observes the first's write already landed.
-    /// A per-root async mutex is adequate at this write rate; it is not
-    /// meant to defend against another process (only within-process
-    /// `FsBlobStore` callers).
-    write_lock: tokio::sync::Mutex<()>,
+    /// Shared per-canonical-root guard (see `write_lock_for_root`) that
+    /// serializes the check-then-publish critical section of `put` — round-2
+    /// High finding: without this, two puts (whether on the same
+    /// `FsBlobStore` instance or two independently constructed ones for the
+    /// same root) can each observe the same pre-write `available_space`
+    /// snapshot, each pass their own write-size-aware floor check against
+    /// it, and then both write, jointly pushing the volume under the floor.
+    /// `put` acquires this as an OWNED guard (`lock_owned`) and MOVES it
+    /// into the `spawn_blocking` closure rather than borrowing it across the
+    /// closure's `.await` — cancelling/dropping the outer `put` future then
+    /// cannot release the guard before the underlying blocking write (which
+    /// keeps running on its own thread regardless of the outer future's
+    /// fate) actually finishes. A per-root async mutex is adequate at this
+    /// write rate; it is not meant to defend against another OS process
+    /// writing the same volume.
+    write_lock: Arc<tokio::sync::Mutex<()>>,
 }
 
 impl FsBlobStore {
@@ -201,10 +242,11 @@ impl FsBlobStore {
     /// Create a store rooted at `root`, creating the directory if absent.
     pub fn new(root: PathBuf, floor_bytes: u64) -> Result<Self, SqliteError> {
         fs::create_dir_all(&root)?;
+        let write_lock = write_lock_for_root(&root)?;
         Ok(Self {
             root,
             floor_bytes,
-            write_lock: tokio::sync::Mutex::new(()),
+            write_lock,
         })
     }
 
@@ -217,12 +259,24 @@ impl FsBlobStore {
 #[async_trait]
 impl BlobStore for FsBlobStore {
     async fn put(&self, bytes: Vec<u8>) -> StorageResult<ContentRef> {
-        let _write_guard = self.write_lock.lock().await;
+        // OWNED guard, MOVED into the blocking closure below (round-2 High
+        // finding, part 2): a guard merely borrowed here and held in this
+        // async fn's own stack frame would be released the instant the
+        // *outer* `put` future is cancelled or dropped, while an
+        // already-started `spawn_blocking` closure keeps running on its own
+        // thread regardless — letting a second `put` pass its check against
+        // an unprotected in-flight write. Moving the owned guard into the
+        // closure ties its lifetime to the blocking work itself, not to
+        // whether anyone is still awaiting this future.
+        let owned_guard = self.write_lock.clone().lock_owned().await;
         let root = self.root.clone();
         let floor_bytes = self.floor_bytes;
-        tokio::task::spawn_blocking(move || put_blocking(&root, floor_bytes, bytes))
-            .await
-            .map_err(|e| StorageError::driver(StorageCapability::Blob, "put", e))?
+        tokio::task::spawn_blocking(move || {
+            let _owned_guard = owned_guard;
+            put_blocking(&root, floor_bytes, bytes)
+        })
+        .await
+        .map_err(|e| StorageError::driver(StorageCapability::Blob, "put", e))?
     }
 
     async fn get(&self, content_ref: &ContentRef) -> StorageResult<Vec<u8>> {
@@ -520,6 +574,123 @@ mod tests {
             floor_rejections >= 1,
             "two payload_len writes cannot both fit in a payload_len-sized budget -- at \
              least one rejection is expected: {result_a:?} / {result_b:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn concurrent_puts_from_two_independently_constructed_stores_share_the_root_lock() {
+        // Round-2 High, part 1 -- the actual gap in the round-2 fix: the
+        // test above uses ONE `FsBlobStore` behind a shared `Arc`, so it
+        // exercises only the per-instance mutex and cannot catch a missing
+        // cross-instance guarantee. `StorageBackend::blob_store` constructs
+        // a FRESH `FsBlobStore` on every call, even for the same root -- so
+        // the real regression is two SEPARATELY CONSTRUCTED stores for the
+        // same root. Before the shared canonical-root registry, each
+        // store's `write_lock` was its own independent `Mutex`, and this
+        // exact scenario would have let both puts pass the same free-space
+        // snapshot.
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path().join("blobs");
+        fs::create_dir_all(&root).unwrap();
+        let available = fs4::available_space(&root).unwrap();
+        let payload_len: u64 = 64 * 1024 * 1024;
+        let floor = available.saturating_sub(payload_len);
+
+        // Two INDEPENDENT `FsBlobStore::new` calls for the identical root --
+        // exactly what `StorageBackend::blob_store` does on repeat calls.
+        let store_a = std::sync::Arc::new(FsBlobStore::new(root.clone(), floor).unwrap());
+        let store_b = std::sync::Arc::new(FsBlobStore::new(root, floor).unwrap());
+
+        let a = tokio::spawn(async move { store_a.put(vec![5u8; payload_len as usize]).await });
+        let b = tokio::spawn(async move { store_b.put(vec![6u8; payload_len as usize]).await });
+        let (result_a, result_b) = (a.await.unwrap(), b.await.unwrap());
+
+        let successes = [&result_a, &result_b]
+            .into_iter()
+            .filter(|r| r.is_ok())
+            .count();
+        let floor_rejections = [&result_a, &result_b]
+            .into_iter()
+            .filter(|r| matches!(r, Err(StorageError::CapacityFloor { .. })))
+            .count();
+        assert!(
+            successes <= 1,
+            "two independently constructed FsBlobStore instances for the SAME root must \
+             still share one write lock -- both puts landed: {result_a:?} / {result_b:?}"
+        );
+        assert!(
+            floor_rejections >= 1,
+            "two payload_len writes cannot both fit in a payload_len-sized budget: \
+             {result_a:?} / {result_b:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn aborting_the_outer_put_future_does_not_release_the_guard_before_persist_completes() {
+        // Round-2 High, part 2: the round-2 fix held the write guard only
+        // in `put`'s own async stack frame (`let _write_guard = ...
+        // .lock().await`) while the `spawn_blocking` closure captured just
+        // root/floor_bytes/bytes. Cancelling/dropping the outer `put`
+        // future released that borrowed guard immediately, even though an
+        // already-started blocking write kept running on its own thread --
+        // a second put could then pass its floor check while the first
+        // write was still landing.
+        //
+        // White-box check (via the same private `write_lock_for_root` the
+        // fix itself uses) rather than an indirect two-store race: abort
+        // the outer task a few milliseconds into a large write (long
+        // enough that the write is almost certainly still in flight,
+        // comfortably past the near-instantaneous lock-acquire-and-dispatch
+        // step), then confirm the shared per-root lock is STILL held
+        // immediately afterward -- only possible if the guard moved into
+        // the detached `spawn_blocking` closure rather than living in the
+        // now-dropped outer frame. Finally confirm the lock does eventually
+        // free (the closure was never leaked, just outlived the cancelled
+        // future).
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path().join("blobs");
+        fs::create_dir_all(&root).unwrap();
+        let canonical_root = root.canonicalize().unwrap();
+        let payload_len = 256 * 1024 * 1024; // large enough to still be writing a few ms in
+
+        let store = std::sync::Arc::new(FsBlobStore::new(root, 0).unwrap());
+        let handle = {
+            let store = store.clone();
+            tokio::spawn(async move { store.put(vec![4u8; payload_len]).await })
+        };
+        tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        handle.abort();
+        let abort_result = handle.await;
+        match &abort_result {
+            Err(e) if e.is_cancelled() => {}
+            other => panic!(
+                "the outer task must actually have been cancelled for this test to be \
+                 meaningful: {other:?}"
+            ),
+        }
+
+        let shared_lock = write_lock_for_root(&canonical_root).unwrap();
+        assert!(
+            shared_lock.try_lock().is_err(),
+            "the guard must still be held by the detached blocking write immediately after \
+             the outer future was cancelled -- if this is free, the guard was released with \
+             the aborted frame instead of moving into the spawn_blocking closure"
+        );
+
+        // The detached write must still run to completion and release the
+        // lock itself -- it was cancelled from the caller's point of view,
+        // not killed.
+        let mut freed = false;
+        for _ in 0..500 {
+            if shared_lock.try_lock().is_ok() {
+                freed = true;
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        }
+        assert!(
+            freed,
+            "the detached write must eventually release the guard"
         );
     }
 

--- a/crates/khive-db/src/stores/entity.rs
+++ b/crates/khive-db/src/stores/entity.rs
@@ -50,8 +50,8 @@ pub fn entity_upsert_statement(entity: &Entity) -> SqlStatement {
     SqlStatement {
         sql: "INSERT OR REPLACE INTO entities \
               (id, namespace, kind, entity_type, name, description, properties, tags, \
-               created_at, updated_at, deleted_at, merged_into, merge_event_id) \
-              VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13)"
+               created_at, updated_at, deleted_at, merged_into, merge_event_id, content_ref) \
+              VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14)"
             .to_string(),
         params: vec![
             SqlValue::Text(entity.id.to_string()),
@@ -83,6 +83,10 @@ pub fn entity_upsert_statement(entity: &Entity) -> SqlStatement {
             },
             match entity.merge_event_id {
                 Some(u) => SqlValue::Text(u.to_string()),
+                None => SqlValue::Null,
+            },
+            match &entity.content_ref {
+                Some(c) => SqlValue::Text(c.clone()),
                 None => SqlValue::Null,
             },
         ],
@@ -255,6 +259,7 @@ fn read_entity(row: &rusqlite::Row<'_>) -> Result<Entity, rusqlite::Error> {
     let deleted_at: Option<i64> = row.get(10)?;
     let merged_into_str: Option<String> = row.get(11)?;
     let merge_event_id_str: Option<String> = row.get(12)?;
+    let content_ref: Option<String> = row.get(13)?;
 
     let id = parse_uuid(&id_str)?;
 
@@ -304,6 +309,7 @@ fn read_entity(row: &rusqlite::Row<'_>) -> Result<Entity, rusqlite::Error> {
         deleted_at,
         merged_into,
         merge_event_id,
+        content_ref,
     })
 }
 
@@ -338,8 +344,8 @@ fn batch_upsert_entities(
         match conn.execute(
             "INSERT OR REPLACE INTO entities \
              (id, namespace, kind, entity_type, name, description, properties, tags, \
-              created_at, updated_at, deleted_at, merged_into, merge_event_id) \
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13)",
+              created_at, updated_at, deleted_at, merged_into, merge_event_id, content_ref) \
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14)",
             rusqlite::params![
                 id_str,
                 &entity.namespace,
@@ -354,6 +360,7 @@ fn batch_upsert_entities(
                 entity.deleted_at,
                 merged_into_str,
                 merge_event_id_str,
+                entity.content_ref,
             ],
         ) {
             Ok(_) => affected += 1,
@@ -603,7 +610,7 @@ impl EntityStore for SqlEntityStore {
         self.with_reader("get_entity", move |conn| {
             let mut stmt = conn.prepare(
                 "SELECT id, namespace, kind, entity_type, name, description, properties, tags, \
-                 created_at, updated_at, deleted_at, merged_into, merge_event_id \
+                 created_at, updated_at, deleted_at, merged_into, merge_event_id, content_ref \
                  FROM entities WHERE id = ?1 AND deleted_at IS NULL",
             )?;
             let mut rows = stmt.query(rusqlite::params![id_str])?;
@@ -718,7 +725,7 @@ impl EntityStore for SqlEntityStore {
             let offset_idx = data_params.len();
 
             let columns = "id, namespace, kind, entity_type, name, description, properties, tags, \
-                           created_at, updated_at, deleted_at, merged_into, merge_event_id";
+                           created_at, updated_at, deleted_at, merged_into, merge_event_id, content_ref";
             let data_sql = if filter.names_ci.is_empty() {
                 format!(
                     "SELECT {columns} FROM entities{where_sql} \
@@ -756,7 +763,7 @@ impl EntityStore for SqlEntityStore {
         self.with_reader("get_entity_including_deleted", move |conn| {
             let mut stmt = conn.prepare(
                 "SELECT id, namespace, kind, entity_type, name, description, properties, tags, \
-                 created_at, updated_at, deleted_at, merged_into, merge_event_id \
+                 created_at, updated_at, deleted_at, merged_into, merge_event_id, content_ref \
                  FROM entities WHERE id = ?1",
             )?;
             let mut rows = stmt.query(rusqlite::params![id_str])?;

--- a/crates/khive-db/src/stores/entity_tests.rs
+++ b/crates/khive-db/src/stores/entity_tests.rs
@@ -41,6 +41,7 @@ fn make_entity(namespace: &str, kind: &str, name: &str) -> Entity {
         deleted_at: None,
         merged_into: None,
         merge_event_id: None,
+        content_ref: None,
     }
 }
 
@@ -746,6 +747,7 @@ async fn test_same_id_upsert_replaces_row() {
         deleted_at: None,
         merged_into: None,
         merge_event_id: None,
+        content_ref: None,
     };
     store.upsert_entity(entity_a).await.unwrap();
 
@@ -769,6 +771,7 @@ async fn test_same_id_upsert_replaces_row() {
         deleted_at: None,
         merged_into: None,
         merge_event_id: None,
+        content_ref: None,
     };
     store.upsert_entity(entity_b).await.unwrap();
 
@@ -1208,4 +1211,66 @@ async fn upsert_entity_routes_through_writer_task_when_flag_enabled() {
         "entity must be committed and readable after queuing behind the occupier"
     );
     assert_eq!(fetched.unwrap().name, "RoPE");
+}
+
+// ── content_ref (khive#292) ─────────────────────────────────────────────────
+
+#[tokio::test]
+async fn test_content_ref_roundtrip() {
+    let store = setup_memory_store();
+
+    let digest = "a".repeat(64);
+    let entity = Entity::new("default", "document", "SourcePdf").with_content_ref(digest.clone());
+    let id = entity.id;
+
+    store.upsert_entity(entity).await.unwrap();
+
+    let fetched = store.get_entity(id).await.unwrap().unwrap();
+    assert_eq!(fetched.content_ref, Some(digest));
+}
+
+#[tokio::test]
+async fn test_content_ref_defaults_to_none() {
+    let store = setup_memory_store();
+
+    let entity = Entity::new("default", "concept", "NoBlob");
+    let id = entity.id;
+    store.upsert_entity(entity).await.unwrap();
+
+    let fetched = store.get_entity(id).await.unwrap().unwrap();
+    assert_eq!(fetched.content_ref, None);
+}
+
+#[tokio::test]
+async fn test_content_ref_survives_query_entities() {
+    let store = setup_memory_store_ns("blob_ns");
+    let digest = "b".repeat(64);
+    let entity = Entity::new("blob_ns", "document", "QueriedPdf").with_content_ref(digest.clone());
+    store.upsert_entity(entity).await.unwrap();
+
+    let page = store
+        .query_entities("blob_ns", EntityFilter::default(), PageRequest::default())
+        .await
+        .unwrap();
+    assert_eq!(page.items.len(), 1);
+    assert_eq!(page.items[0].content_ref, Some(digest));
+}
+
+#[tokio::test]
+async fn test_content_ref_survives_batch_upsert() {
+    let store = setup_memory_store();
+    let digest = "c".repeat(64);
+    let entities = vec![
+        Entity::new("default", "document", "Batch1").with_content_ref(digest.clone()),
+        Entity::new("default", "document", "Batch2"),
+    ];
+    let ids: Vec<Uuid> = entities.iter().map(|e| e.id).collect();
+
+    let summary = store.upsert_entities(entities).await.unwrap();
+    assert_eq!(summary.affected, 2);
+
+    let with_ref = store.get_entity(ids[0]).await.unwrap().unwrap();
+    assert_eq!(with_ref.content_ref, Some(digest));
+    let without_ref = store.get_entity(ids[1]).await.unwrap().unwrap();
+    assert_eq!(without_ref.content_ref, None);
 }

--- a/crates/khive-db/src/stores/mod.rs
+++ b/crates/khive-db/src/stores/mod.rs
@@ -3,6 +3,7 @@
 //! Each module provides a concrete store struct implementing one or more
 //! `khive-storage` capability traits against the shared connection pool.
 
+pub mod blob;
 pub mod entity;
 pub mod event;
 pub mod graph;

--- a/crates/khive-runtime/src/curation.rs
+++ b/crates/khive-runtime/src/curation.rs
@@ -901,7 +901,7 @@ fn read_merge_entity(
     let id_str = id.to_string();
     let mut stmt = conn.prepare(
         "SELECT id, namespace, kind, entity_type, name, description, properties, tags, \
-         created_at, updated_at, deleted_at, merged_into, merge_event_id \
+         created_at, updated_at, deleted_at, merged_into, merge_event_id, content_ref \
          FROM entities WHERE id = ?1 AND deleted_at IS NULL",
     )?;
     let mut rows = stmt.query(rusqlite::params![id_str])?;
@@ -922,6 +922,7 @@ fn read_merge_entity(
     let deleted_at: Option<i64> = row.get(10)?;
     let merged_into_str: Option<String> = row.get(11)?;
     let merge_event_id_str: Option<String> = row.get(12)?;
+    let content_ref: Option<String> = row.get(13)?;
 
     if ns != namespace {
         return Err(SqliteError::InvalidData(format!(
@@ -962,6 +963,7 @@ fn read_merge_entity(
         deleted_at,
         merged_into,
         merge_event_id,
+        content_ref,
     })
 }
 
@@ -1282,6 +1284,7 @@ fn merge_entity_sql(
         deleted_at: into_entity.deleted_at,
         merged_into: None,
         merge_event_id: None,
+        content_ref: into_entity.content_ref,
     };
 
     Ok((

--- a/crates/khive-runtime/src/portability.rs
+++ b/crates/khive-runtime/src/portability.rs
@@ -224,6 +224,7 @@ impl KhiveRuntime {
                 deleted_at: None,
                 merged_into: None,
                 merge_event_id: None,
+                content_ref: None,
             };
             store.upsert_entity(entity.clone()).await?;
             // Reindex so imported entities are searchable via hybrid_search immediately.

--- a/crates/khive-storage/src/blob.rs
+++ b/crates/khive-storage/src/blob.rs
@@ -1,0 +1,265 @@
+//! Blob storage capability — content-addressed binary object CRUD.
+//!
+//! `BlobStore` is the trait family added by khive#292: bytes that do not
+//! belong inside the primary SQLite database (source PDFs, images, large
+//! opaque payloads) are stored by a dedicated backend and referenced from
+//! the graph by an opaque [`ContentRef`]. Per ADR-005's "zero
+//! implementations" constraint, this module defines the contract only — the
+//! first backend (filesystem, BLAKE3-addressed) lives in `khive-db`.
+
+use std::collections::HashSet;
+
+use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
+
+use crate::capability::StorageCapability;
+use crate::error::StorageError;
+use crate::types::StorageResult;
+
+/// Number of hex characters in a BLAKE3-256 digest (32 bytes -> 64 hex chars).
+const CONTENT_REF_HEX_LEN: usize = 64;
+
+/// An opaque, content-addressed reference to a stored blob.
+///
+/// Backed by a lowercase-hex BLAKE3 digest of the blob's bytes: identical
+/// content always produces the same `ContentRef`, so storing the same bytes
+/// twice is a no-op after the first write. Callers must treat the value as
+/// opaque — the backend, not the caller, decides how a `ContentRef` maps to
+/// physical storage (a filesystem path, an object-store key, etc.).
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct ContentRef(String);
+
+impl ContentRef {
+    /// Parse a `ContentRef` from a caller-supplied hex string.
+    ///
+    /// Rejects anything that is not exactly 64 lowercase hex characters.
+    /// Rejecting uppercase (rather than lowercase-normalizing) keeps a
+    /// single canonical string form per digest, since the value doubles as
+    /// a filesystem path component in the shipped filesystem backend —
+    /// accepting both cases would let two `ContentRef` values that compare
+    /// unequal as `String`s resolve to the same bytes.
+    pub fn from_hex(hex: impl Into<String>) -> Result<Self, String> {
+        let hex = hex.into();
+        if hex.len() != CONTENT_REF_HEX_LEN {
+            return Err(format!(
+                "content_ref must be {CONTENT_REF_HEX_LEN} hex characters, got length {} ({hex:?})",
+                hex.len()
+            ));
+        }
+        if !hex
+            .bytes()
+            .all(|b| b.is_ascii_digit() || (b.is_ascii_lowercase() && b.is_ascii_hexdigit()))
+        {
+            return Err(format!(
+                "content_ref must be lowercase hex (0-9, a-f), got {hex:?}"
+            ));
+        }
+        Ok(Self(hex))
+    }
+
+    /// Construct a `ContentRef` directly from a BLAKE3 digest's raw bytes.
+    pub fn from_digest_bytes(digest: &[u8; 32]) -> Self {
+        Self(hex_encode(digest))
+    }
+
+    /// Borrow the underlying hex string.
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl std::fmt::Display for ContentRef {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl AsRef<str> for ContentRef {
+    fn as_ref(&self) -> &str {
+        &self.0
+    }
+}
+
+fn hex_encode(bytes: &[u8]) -> String {
+    const HEX: &[u8; 16] = b"0123456789abcdef";
+    let mut out = String::with_capacity(bytes.len() * 2);
+    for &b in bytes {
+        out.push(HEX[(b >> 4) as usize] as char);
+        out.push(HEX[(b & 0x0f) as usize] as char);
+    }
+    out
+}
+
+/// Configuration for [`BlobStore::orphan_sweep`].
+///
+/// `BlobStore` has no visibility into SQL substrates (ADR-005 constraint 4:
+/// a trait instance talks to exactly one backend), so it cannot itself
+/// discover which content refs are still referenced by, e.g., the
+/// `entities.content_ref` column. The caller assembles that set and passes
+/// it in — the blob backend then owns the actual comparison and deletion,
+/// per the operating rule that `BlobStore` is the *only* deletion path
+/// besides an explicit [`BlobStore::delete`] (no consumer deletes blobs
+/// directly).
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+pub struct BlobOrphanSweepConfig {
+    /// Content refs currently referenced by at least one live row somewhere
+    /// in the system. Anything this backend stores that is NOT in this set
+    /// is orphaned.
+    pub live_refs: HashSet<ContentRef>,
+    /// When `true`, report what would be deleted without deleting anything.
+    pub dry_run: bool,
+}
+
+/// Result of a [`BlobStore::orphan_sweep`] call.
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+pub struct BlobOrphanSweepResult {
+    /// Total objects examined in this backend.
+    pub scanned: u64,
+    /// Objects actually deleted (always 0 when `dry_run = true`).
+    pub deleted: u64,
+    /// Objects that are orphaned (would be deleted whether or not `dry_run`
+    /// is set — populated in both modes so a dry run reports the same count
+    /// a real run would delete).
+    pub would_delete: u64,
+}
+
+/// Content-addressed binary object CRUD.
+///
+/// Every method is backend-agnostic: the filesystem backend
+/// (`khive-db::stores::blob::FsBlobStore`) is the first implementation, and
+/// any future backend (object storage, a different CAS layout) implements
+/// the same operations. Per ADR-005 constraint 4, a `BlobStore` instance
+/// talks to exactly one backend.
+#[async_trait]
+pub trait BlobStore: Send + Sync + 'static {
+    /// Store `bytes`, returning the content-addressed reference under which
+    /// they are now retrievable. Storing byte-identical content more than
+    /// once returns the same `ContentRef` and does not re-write the object.
+    async fn put(&self, bytes: Vec<u8>) -> StorageResult<ContentRef>;
+
+    /// Fetch the bytes stored under `content_ref`.
+    ///
+    /// Returns `StorageError::NotFound` (capability `Blob`) if no object
+    /// exists for this reference.
+    async fn get(&self, content_ref: &ContentRef) -> StorageResult<Vec<u8>>;
+
+    /// Whether an object currently exists for `content_ref`.
+    async fn exists(&self, content_ref: &ContentRef) -> StorageResult<bool>;
+
+    /// Remove the object stored under `content_ref`.
+    ///
+    /// Returns `true` when an object was actually removed, `false` when
+    /// none existed — deleting an absent object is not an error.
+    async fn delete(&self, content_ref: &ContentRef) -> StorageResult<bool>;
+
+    /// Enumerate every object this backend holds and delete (or, in
+    /// `dry_run` mode, report) those absent from `config.live_refs`.
+    ///
+    /// This is the operator-side GC path (khive#292 deliverable 5) — an
+    /// admin-side operation, not an MCP verb, mirroring
+    /// `VectorStore::orphan_sweep`'s CLI-only precedent (ADR-044). Default
+    /// returns `StorageError::Unsupported`; the filesystem backend
+    /// overrides it with a real directory walk. No silent no-op.
+    async fn orphan_sweep(
+        &self,
+        config: &BlobOrphanSweepConfig,
+    ) -> StorageResult<BlobOrphanSweepResult> {
+        let _ = config;
+        Err(StorageError::Unsupported {
+            capability: StorageCapability::Blob,
+            operation: "orphan_sweep".into(),
+            message: "this backend does not support orphan sweep".into(),
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn from_hex_accepts_valid_lowercase_digest() {
+        let hex = "a".repeat(64);
+        let cref = ContentRef::from_hex(hex.clone()).unwrap();
+        assert_eq!(cref.as_str(), hex);
+        assert_eq!(cref.to_string(), hex);
+    }
+
+    #[test]
+    fn from_hex_rejects_short_string() {
+        let err = ContentRef::from_hex("abc").unwrap_err();
+        assert!(
+            err.contains("64"),
+            "error must mention expected length: {err}"
+        );
+    }
+
+    #[test]
+    fn from_hex_rejects_long_string() {
+        let err = ContentRef::from_hex("a".repeat(65)).unwrap_err();
+        assert!(
+            err.contains("64"),
+            "error must mention expected length: {err}"
+        );
+    }
+
+    #[test]
+    fn from_hex_rejects_uppercase() {
+        let err = ContentRef::from_hex("A".repeat(64)).unwrap_err();
+        assert!(
+            err.contains("lowercase"),
+            "error must mention lowercase requirement: {err}"
+        );
+    }
+
+    #[test]
+    fn from_hex_rejects_non_hex_characters() {
+        let mut hex = "a".repeat(63);
+        hex.push('z');
+        let err = ContentRef::from_hex(hex).unwrap_err();
+        assert!(
+            err.contains("lowercase hex"),
+            "error must mention hex requirement: {err}"
+        );
+    }
+
+    #[test]
+    fn from_digest_bytes_matches_known_blake3_hash() {
+        // BLAKE3("") -> af1349b9f5f9a1a6a0404dea36dcc9499bcb25c9adc112b7cc9a93cae41f3262
+        let hash = blake3_hash_of_empty();
+        let cref = ContentRef::from_digest_bytes(&hash);
+        assert_eq!(
+            cref.as_str(),
+            "af1349b9f5f9a1a6a0404dea36dcc9499bcb25c9adc112b7cc9a93cae41f3262"
+        );
+    }
+
+    // khive-storage has zero heavy dependencies (ADR-005) so this test hand-rolls
+    // the one known BLAKE3("") vector instead of pulling in the `blake3` crate
+    // just to exercise `hex_encode`.
+    fn blake3_hash_of_empty() -> [u8; 32] {
+        let hex = "af1349b9f5f9a1a6a0404dea36dcc9499bcb25c9adc112b7cc9a93cae41f3262";
+        let mut out = [0u8; 32];
+        for (i, chunk) in hex.as_bytes().chunks(2).enumerate() {
+            let s = std::str::from_utf8(chunk).unwrap();
+            out[i] = u8::from_str_radix(s, 16).unwrap();
+        }
+        out
+    }
+
+    #[test]
+    fn content_ref_equality_and_hash_are_string_based() {
+        let a = ContentRef::from_hex("b".repeat(64)).unwrap();
+        let b = ContentRef::from_hex("b".repeat(64)).unwrap();
+        let c = ContentRef::from_hex("c".repeat(64)).unwrap();
+        assert_eq!(a, b);
+        assert_ne!(a, c);
+
+        use std::collections::HashSet;
+        let mut set = HashSet::new();
+        set.insert(a.clone());
+        assert!(set.contains(&b));
+        assert!(!set.contains(&c));
+    }
+}

--- a/crates/khive-storage/src/blob.rs
+++ b/crates/khive-storage/src/blob.rs
@@ -26,9 +26,25 @@ const CONTENT_REF_HEX_LEN: usize = 64;
 /// twice is a no-op after the first write. Callers must treat the value as
 /// opaque — the backend, not the caller, decides how a `ContentRef` maps to
 /// physical storage (a filesystem path, an object-store key, etc.).
-#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+///
+/// `Deserialize` is implemented by hand (below), routing every input through
+/// [`ContentRef::from_hex`] — deriving it under `#[serde(transparent)]` would
+/// construct a `ContentRef` from any string, including one that is not 64
+/// lowercase hex characters (round-2 codex High finding: an unvalidated
+/// value reaching `shard_path`'s `[0..2]`/`[2..4]` slices panics).
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize)]
 #[serde(transparent)]
 pub struct ContentRef(String);
+
+impl<'de> Deserialize<'de> for ContentRef {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let raw = String::deserialize(deserializer)?;
+        ContentRef::from_hex(raw).map_err(serde::de::Error::custom)
+    }
+}
 
 impl ContentRef {
     /// Parse a `ContentRef` from a caller-supplied hex string.
@@ -101,11 +117,17 @@ fn hex_encode(bytes: &[u8]) -> String {
 /// per the operating rule that `BlobStore` is the *only* deletion path
 /// besides an explicit [`BlobStore::delete`] (no consumer deletes blobs
 /// directly).
+///
+/// `live_refs` is a point-in-time snapshot, not a live query — see
+/// [`BlobStore::orphan_sweep`]'s doc comment for the concurrency hazard this
+/// implies (offline-maintenance-only; requires quiesced entity writes).
 #[derive(Clone, Debug, Default, Serialize, Deserialize)]
 pub struct BlobOrphanSweepConfig {
     /// Content refs currently referenced by at least one live row somewhere
-    /// in the system. Anything this backend stores that is NOT in this set
-    /// is orphaned.
+    /// in the system, as of when the caller assembled this set. Anything
+    /// this backend stores that is NOT in this set is treated as orphaned
+    /// and deleted (or reported, in `dry_run` mode) — including a
+    /// `content_ref` that becomes live after this snapshot was taken.
     pub live_refs: HashSet<ContentRef>,
     /// When `true`, report what would be deleted without deleting anything.
     pub dry_run: bool,
@@ -151,6 +173,18 @@ pub trait BlobStore: Send + Sync + 'static {
     ///
     /// Returns `true` when an object was actually removed, `false` when
     /// none existed — deleting an absent object is not an error.
+    ///
+    /// # Concurrency hazard — offline-maintenance-only (ADR-111 §8, amended
+    /// round 2)
+    ///
+    /// `delete` performs an unconditional physical removal with **no
+    /// coordination against any entity that might reference
+    /// `content_ref`**. It is safe to call only when the caller has
+    /// independently ensured — outside this trait, typically by quiescing
+    /// whatever writer could attach a new `content_ref` to an entity — that
+    /// nothing live references `content_ref` for the duration of the call. A
+    /// caller that races an entity write against a `delete` can dangle a
+    /// live reference; this trait does not detect or prevent that.
     async fn delete(&self, content_ref: &ContentRef) -> StorageResult<bool>;
 
     /// Enumerate every object this backend holds and delete (or, in
@@ -161,6 +195,25 @@ pub trait BlobStore: Send + Sync + 'static {
     /// `VectorStore::orphan_sweep`'s CLI-only precedent (ADR-044). Default
     /// returns `StorageError::Unsupported`; the filesystem backend
     /// overrides it with a real directory walk. No silent no-op.
+    ///
+    /// # Concurrency hazard — offline-maintenance-only (ADR-111 §8, amended
+    /// round 2)
+    ///
+    /// `config.live_refs` is a **snapshot** the caller assembled before this
+    /// call. `orphan_sweep` has no way to detect a `content_ref` that
+    /// becomes newly live — an entity write lands referencing it — between
+    /// when that snapshot was taken and when this sweep runs; such a
+    /// reference is deleted anyway (see `khive-db`'s
+    /// `orphan_sweep_race_demonstrates_the_documented_quiescence_requirement`
+    /// test, which reproduces exactly this in code). This trait provides no
+    /// transactional coordination with an entity writer. **Callers MUST
+    /// quiesce entity writes** (nothing may create a new `content_ref`
+    /// reference) for the duration of snapshot-plus-sweep — a maintenance
+    /// window, a single-writer admin CLI invocation with no live traffic, or
+    /// equivalent. A DB-coordinated, transactional sweep (select-and-delete
+    /// under the entity writer's own transactional boundary) would close
+    /// this hazard properly; that is a larger design tracked as a follow-up
+    /// (khive#924), not built in this round.
     async fn orphan_sweep(
         &self,
         config: &BlobOrphanSweepConfig,
@@ -246,6 +299,50 @@ mod tests {
             out[i] = u8::from_str_radix(s, 16).unwrap();
         }
         out
+    }
+
+    #[test]
+    fn deserialize_accepts_a_valid_lowercase_digest() {
+        let hex = "d".repeat(64);
+        let json = serde_json::to_string(&hex).unwrap();
+        let cref: ContentRef = serde_json::from_str(&json).unwrap();
+        assert_eq!(cref.as_str(), hex);
+    }
+
+    #[test]
+    fn deserialize_rejects_short_string() {
+        // The exact repro from the round-2 codex finding: a naive derived
+        // `Deserialize` would construct `ContentRef("x")` here, and any
+        // caller passing it to `get`/`exists`/`delete` would then panic in
+        // `shard_path`'s `[0..2]`/`[2..4]` slices.
+        let err = serde_json::from_str::<ContentRef>("\"x\"").unwrap_err();
+        assert!(
+            err.to_string().contains("64"),
+            "deserialize error must mention the expected length: {err}"
+        );
+    }
+
+    #[test]
+    fn deserialize_rejects_uppercase() {
+        let hex = "A".repeat(64);
+        let json = serde_json::to_string(&hex).unwrap();
+        let err = serde_json::from_str::<ContentRef>(&json).unwrap_err();
+        assert!(
+            err.to_string().contains("lowercase"),
+            "deserialize error must mention the lowercase requirement: {err}"
+        );
+    }
+
+    #[test]
+    fn deserialize_rejects_non_hex_characters() {
+        let mut hex = "a".repeat(63);
+        hex.push('z');
+        let json = serde_json::to_string(&hex).unwrap();
+        let err = serde_json::from_str::<ContentRef>(&json).unwrap_err();
+        assert!(
+            err.to_string().contains("lowercase hex"),
+            "deserialize error must mention the hex requirement: {err}"
+        );
     }
 
     #[test]

--- a/crates/khive-storage/src/capability.rs
+++ b/crates/khive-storage/src/capability.rs
@@ -11,4 +11,6 @@ pub enum StorageCapability {
     Vectors,
     Sparse,
     Text,
+    /// Content-addressed binary object storage (`BlobStore`, khive#292).
+    Blob,
 }

--- a/crates/khive-storage/src/entity.rs
+++ b/crates/khive-storage/src/entity.rs
@@ -27,6 +27,12 @@ pub struct Entity {
     pub merged_into: Option<Uuid>,
     /// Opaque event ID for the merge that tombstoned this entity.
     pub merge_event_id: Option<Uuid>,
+    /// Content-addressed reference into a `BlobStore` (khive#292), stored as
+    /// the raw hex digest string. `None` when this entity has no attached
+    /// binary payload. Storage does not validate that the referenced blob
+    /// actually exists — callers publish the blob before setting this field
+    /// (see `docs/adr` BlobStore ADR "publish-then-reference" ordering).
+    pub content_ref: Option<String>,
 }
 
 impl Entity {
@@ -51,7 +57,14 @@ impl Entity {
             deleted_at: None,
             merged_into: None,
             merge_event_id: None,
+            content_ref: None,
         }
+    }
+
+    /// Set the content-addressed blob reference (khive#292).
+    pub fn with_content_ref(mut self, content_ref: impl Into<String>) -> Self {
+        self.content_ref = Some(content_ref.into());
+        self
     }
 
     /// Set the pack-governed entity subtype token.

--- a/crates/khive-storage/src/error.rs
+++ b/crates/khive-storage/src/error.rs
@@ -108,6 +108,22 @@ pub enum StorageError {
         "KHIVE_WRITE_QUEUE=1 but no Tokio runtime context is available to spawn the writer task"
     )]
     WriterTaskNoRuntime,
+
+    /// A filesystem-backed capability (e.g. `BlobStore`) refused a write
+    /// because `volume`'s available space, after accounting for the pending
+    /// write, would drop below the configured free-space floor. Carries the
+    /// floor and the volume so callers can surface a precise message without
+    /// re-deriving them (khive#292).
+    #[error(
+        "refusing write on {capability:?} at {volume}: {available_bytes} bytes available, \
+         below the {floor_bytes}-byte floor"
+    )]
+    CapacityFloor {
+        capability: StorageCapability,
+        volume: String,
+        available_bytes: u64,
+        floor_bytes: u64,
+    },
 }
 
 impl StorageError {
@@ -134,7 +150,8 @@ impl StorageError {
             | Self::Unsupported { capability, .. }
             | Self::Serialization { capability, .. }
             | Self::IndexMaintenance { capability, .. }
-            | Self::Driver { capability, .. } => Some(*capability),
+            | Self::Driver { capability, .. }
+            | Self::CapacityFloor { capability, .. } => Some(*capability),
             Self::Pool { .. }
             | Self::Timeout { .. }
             | Self::Transaction { .. }

--- a/crates/khive-storage/src/lib.rs
+++ b/crates/khive-storage/src/lib.rs
@@ -1,5 +1,6 @@
-//! Storage capability traits: `SqlAccess`, `VectorStore`, `TextSearch`, `GraphStore`, `NoteStore`, `EventStore`.
+//! Storage capability traits: `SqlAccess`, `VectorStore`, `TextSearch`, `GraphStore`, `NoteStore`, `EventStore`, `BlobStore`.
 
+pub mod blob;
 pub mod capability;
 pub mod entity;
 pub mod error;
@@ -14,6 +15,7 @@ pub mod tx_registry;
 pub mod types;
 pub mod vectors;
 
+pub use blob::{BlobOrphanSweepConfig, BlobOrphanSweepResult, BlobStore, ContentRef};
 pub use capability::StorageCapability;
 pub use entity::{Entity, EntityFilter, EntityStore};
 pub use error::StorageError;

--- a/crates/khive-vcs/src/sync.rs
+++ b/crates/khive-vcs/src/sync.rs
@@ -982,6 +982,7 @@ async fn upsert_entities(
                 deleted_at: None,
                 merge_event_id: None,
                 merged_into: None,
+                content_ref: None,
             };
             // Use the canonical FTS document constructor so sync, create, update,
             // merge, and reindex all produce identical document shapes.
@@ -2493,6 +2494,7 @@ mod tests {
             deleted_at: None,
             merge_event_id: None,
             merged_into: None,
+            content_ref: None,
         };
 
         let doc = entity_fts_document(&entity);

--- a/docs/adr/ADR-111-blob-store.md
+++ b/docs/adr/ADR-111-blob-store.md
@@ -46,10 +46,30 @@ mapping to a capability trait (ADR-005 §2).
 ### 2. `ContentRef` — the opaque, content-addressed key
 
 ```rust
-#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize)]
 #[serde(transparent)]
 pub struct ContentRef(String);
+
+impl<'de> Deserialize<'de> for ContentRef {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let raw = String::deserialize(deserializer)?;
+        ContentRef::from_hex(raw).map_err(serde::de::Error::custom)
+    }
+}
 ```
+
+`ContentRef` derives only `Serialize` — under `#[serde(transparent)]` that just emits the inner hex
+string, which is always already valid since the type's only constructors (`from_hex`,
+`from_digest_bytes`) validate on the way in. `Deserialize` is implemented by hand, routing every
+input through `ContentRef::from_hex`, so a malformed serialized value (wrong length, uppercase,
+non-hex characters) is rejected at deserialization instead of silently constructing an invalid
+`ContentRef` that would later panic in the filesystem backend's shard-path slicing. **This is
+deliberate, not incidental: deriving `Deserialize` here — the combination this ADR's Decision
+section showed until round 2 of PR #922's review — was exactly the round-1 codex High finding.**
+Do not "simplify" this back to a derive.
 
 Backed by a lowercase-hex BLAKE3-256 digest (64 characters) of the blob's bytes. Identical content
 always produces the same `ContentRef`; storing the same bytes twice is a no-op after the first
@@ -113,15 +133,31 @@ finding):** the original implementation compared `available` directly against th
 accounting for the write's own size — `available == floor_bytes + 1` admitted a write of any size,
 including one that would leave the volume below the floor. The check is now write-size-aware.
 
-`FsBlobStore` also serializes the whole check-then-publish critical section of `put` per store
-instance (a `tokio::sync::Mutex<()>` held across the entire `spawn_blocking` call, from the
-availability check through `persist`). **Amended 2026-07-13:** without this, two concurrent puts
-could each observe the same pre-write availability snapshot, each individually pass a write-size-
-aware check against it, and both proceed to write — jointly pushing the volume under the floor even
-though neither write looked unsafe in isolation, since neither observed the other's pending write.
-A per-root async mutex is adequate at `BlobStore`'s expected write rate; it defends only against
-concurrent `FsBlobStore` callers within one process, not against another process writing to the
-same volume. Below the floor, `put` refuses with a new error variant:
+`FsBlobStore` also serializes the whole check-then-publish critical section of `put` per
+**canonical root** (a process-wide registry maps each canonicalized root path to one shared
+`Arc<tokio::sync::Mutex<()>>`, held across the entire `spawn_blocking` call, from the availability
+check through `persist`). **Amended 2026-07-13 (round-2 codex High finding):** without this, two
+concurrent puts could each observe the same pre-write availability snapshot, each individually pass
+a write-size-aware check against it, and both proceed to write — jointly pushing the volume under
+the floor even though neither write looked unsafe in isolation, since neither observed the other's
+pending write. A per-root async mutex is adequate at `BlobStore`'s expected write rate; it defends
+only against concurrent `FsBlobStore` callers within one process, not against another process
+writing to the same volume.
+
+**Amended 2026-07-13, round 2 of round-2 (a focused re-review, "H2", of the same finding): the
+first attempt at this fix scoped the mutex to one `FsBlobStore` instance** (`tokio::sync::Mutex<()>`
+as a plain struct field) **and borrowed the guard across `put`'s own async stack frame.** Both were
+insufficient: (a) `StorageBackend::blob_store` constructs a fresh `FsBlobStore` on every call, even
+for the same root, so two independently obtained stores for one root had independent locks and
+could still both pass the same snapshot; (b) cancelling or dropping the outer `put` future released
+the borrowed guard immediately, while an already-started `spawn_blocking` write kept running
+unprotected on its own thread — a second `put` could pass its check mid-persist. The fix now (1)
+keys the shared `Arc<tokio::sync::Mutex<()>>` by the filesystem's own canonicalized root path in a
+process-wide registry, so every `FsBlobStore` for the same root shares one lock regardless of how
+many separate `new` calls constructed them, and (2) acquires an **owned** guard (`lock_owned`) that
+is **moved into** the `spawn_blocking` closure rather than borrowed across its `.await`, so the
+guard's lifetime is tied to the blocking work itself, not to whether the outer future is still being
+polled. Below the floor, `put` refuses with a new error variant:
 
 ```rust
 #[error(
@@ -292,13 +328,21 @@ misses.
 - **Round-2 amendments (2026-07-13, PR #922 codex review):** `ContentRef` no longer derives
   `Deserialize` — it is hand-implemented to route every input through `from_hex`, so a malformed
   serialized value is rejected at deserialization instead of later panicking in `shard_path`.
-  `FsBlobStore::put`'s floor check now accounts for the pending write's own size and serializes its
-  check-then-publish critical section per store instance via a `tokio::sync::Mutex`. `delete` and
+  `FsBlobStore::put`'s floor check now accounts for the pending write's own size. `delete` and
   `orphan_sweep` are now explicitly documented (trait doc comments, §8 above) as
   offline-maintenance-only, requiring quiesced entity writes — a real, undefended concurrency hazard
   the original §8 text incorrectly described as absent. A DB-coordinated transactional sweep that
   would close that hazard is tracked as a follow-up, not built here:
   [khive#924](https://github.com/ohdearquant/khive/issues/924).
+- **Further round-2 amendment (same date, a focused "H2" re-review of the concurrency-guard
+  finding):** the first pass at serializing `put` scoped its `tokio::sync::Mutex` to one
+  `FsBlobStore` instance and borrowed the guard across the async fn's own frame — insufficient,
+  because `StorageBackend::blob_store` builds a fresh `FsBlobStore` per call (so independently
+  constructed stores for the same root had independent locks) and because cancelling the outer
+  `put` future released a merely-borrowed guard while an already-dispatched blocking write kept
+  running unprotected. §5 now describes the corrected design: one shared, canonical-root-keyed
+  `Arc<tokio::sync::Mutex<()>>` per root, with an **owned** guard moved into the `spawn_blocking`
+  closure rather than borrowed across it.
 
 ---
 
@@ -309,7 +353,9 @@ misses.
 - `crates/khive-storage/src/capability.rs` — `StorageCapability::Blob`.
 - `crates/khive-storage/src/error.rs` — `StorageError::CapacityFloor`.
 - `crates/khive-storage/src/entity.rs` — `Entity::content_ref`, `Entity::with_content_ref`.
-- `crates/khive-db/src/stores/blob.rs` — `FsBlobStore`, `resolve_blob_root`.
+- `crates/khive-db/src/stores/blob.rs` — `FsBlobStore`, `resolve_blob_root`,
+  `write_lock_for_root`/`root_write_locks` (the canonical-root-keyed shared-lock registry),
+  `crosses_floor` (the pure write-size-aware floor comparison).
 - `crates/khive-db/src/backend.rs` — `StorageBackend::blob_store`.
 - `crates/khive-db/sql/010-entities-content-ref.sql` — migration V10.
 - `crates/khive-db/sql/entities-ddl.sql` — mirrored `content_ref` column + index.
@@ -326,5 +372,8 @@ misses.
 - `fs4` crate (`https://crates.io/crates/fs4`) — cross-platform free-space query.
 - PR #922 codex round-1 review (`.khive/codex_reviews/codex_review_pr922_round1.md`) — source of
   the three round-2 High findings this ADR was amended to address.
+- PR #922 codex round-2 review (`.khive/codex_reviews/codex_review_pr922_round2.md`) — focused
+  re-review confirming the deserialization fix and finding the floor-guard fix incomplete (not
+  actually per-root, not cancellation-safe) and this ADR's `ContentRef` example stale.
 - [khive#924](https://github.com/ohdearquant/khive/issues/924) — follow-up: transactional,
   DB-coordinated `BlobStore` orphan sweep.

--- a/docs/adr/ADR-111-blob-store.md
+++ b/docs/adr/ADR-111-blob-store.md
@@ -1,0 +1,272 @@
+# ADR-111: BlobStore — Content-Addressed Binary Object Storage
+
+**Status**: accepted
+**Date**: 2026-07-12
+**Authors**: khive maintainers
+**Depends on**:
+
+- [ADR-005](ADR-005-storage-capability-traits.md) — Storage Capability Traits (trait-only capability
+  surface this ADR extends with a ninth capability)
+- [ADR-015](ADR-015-schema-migrations.md) — Schema Migrations (the versioned migration this ADR uses
+  to add `entities.content_ref`)
+- [ADR-044](ADR-044-vector-store-extensions.md) — Vector Store Extensions (the `orphan_sweep`
+  CLI-only precedent this ADR mirrors for `BlobStore`)
+- [ADR-086](ADR-086-doc-file-pack.md) — Doc/File Pack (deferred `StorageCapability::Blob` to "a real
+  consumer" — this ADR is that amendment)
+
+---
+
+## Context
+
+khive's primary substrate (SQLite, via `khive-db`) is good at typed, queryable, small-to-medium
+records. It is not the right place for opaque binary payloads: source PDFs, images, and other
+large blobs that a downstream consumer (the planned doc/file pack, ADR-086) wants to store and
+reference from the graph, without inflating `khive.db` itself or forcing every KG query to page
+through blob bytes it never asked for.
+
+ADR-005 defines eight storage capability traits (`Sql`, `Notes`, `Entities`, `Graph`, `Events`,
+`Vectors`, `Sparse`, `Text`) under a "zero implementation, trait-only" constraint for
+`khive-storage`. ADR-086 explicitly deferred adding a blob capability until a real consumer needed
+it, and named `StorageCapability::Blob` as the natural v2 amendment. This ADR is that amendment
+(khive#292): a `BlobStore` trait plus its first (filesystem) implementation, so the doc/file pack
+and any future blob-shaped consumer have a typed, content-addressed storage seam to build on.
+
+This ADR does not implement the doc/file pack itself — only the storage-layer capability it will
+consume.
+
+---
+
+## Decision
+
+### 1. `StorageCapability::Blob` — the ninth capability
+
+`khive-storage::StorageCapability` gains a `Blob` variant, following the existing enum's 1:1
+mapping to a capability trait (ADR-005 §2).
+
+### 2. `ContentRef` — the opaque, content-addressed key
+
+```rust
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct ContentRef(String);
+```
+
+Backed by a lowercase-hex BLAKE3-256 digest (64 characters) of the blob's bytes. Identical content
+always produces the same `ContentRef`; storing the same bytes twice is a no-op after the first
+write. `ContentRef::from_hex` rejects anything that is not exactly 64 lowercase hex characters —
+uppercase is rejected rather than normalized, because the value doubles as a filesystem path
+component in the shipped backend, and accepting both cases would let two `ContentRef` values that
+compare unequal as `String`s resolve to the same bytes.
+
+`khive-storage` has zero heavy dependencies (ADR-005 constraint), so `ContentRef` does not depend
+on the `blake3` crate itself — `from_digest_bytes(&[u8; 32])` accepts a digest computed by the
+caller (the filesystem backend, which does depend on `blake3`), and the trait's own hex-encoder is
+hand-rolled (7 lines, tested against BLAKE3's own published test vector for `BLAKE3("")`).
+
+### 3. `BlobStore` trait
+
+```rust
+#[async_trait]
+pub trait BlobStore: Send + Sync + 'static {
+    async fn put(&self, bytes: Vec<u8>) -> StorageResult<ContentRef>;
+    async fn get(&self, content_ref: &ContentRef) -> StorageResult<Vec<u8>>;
+    async fn exists(&self, content_ref: &ContentRef) -> StorageResult<bool>;
+    async fn delete(&self, content_ref: &ContentRef) -> StorageResult<bool>;
+    async fn orphan_sweep(
+        &self,
+        config: &BlobOrphanSweepConfig,
+    ) -> StorageResult<BlobOrphanSweepResult> { /* default: Unsupported */ }
+}
+```
+
+`get` returns `StorageError::NotFound` (capability `Blob`) for an absent reference. `delete`
+returns `Ok(false)` (not an error) when nothing existed to remove — deleting an absent object is
+not a failure. `orphan_sweep` defaults to `StorageError::Unsupported`, following `VectorStore`'s
+precedent (ADR-044): a backend opts in by overriding it.
+
+### 4. `FsBlobStore` — the filesystem backend (`khive-db`)
+
+The first (and, at time of writing, only) `BlobStore` implementation is a BLAKE3-sharded directory
+tree: `<root>/<hex[0..2]>/<hex[2..4]>/<hex>` — two levels of shard directories, the same shape as
+git's loose-object store, so a root holding millions of blobs never puts more than a few thousand
+entries in one directory.
+
+**Atomic publish.** `put` writes to a `tempfile::NamedTempFile` created in the _same_ shard
+directory as the final path (guaranteeing a same-filesystem rename), flushes and `fsync`s it,
+verifies the written length matches the input length, then calls `NamedTempFile::persist` to
+rename it into place. A crash mid-write leaves an orphaned temp file — never a partially-committed
+blob — and `orphan_sweep`'s directory walk only ever recognizes filenames that parse as a
+64-character hex `ContentRef`, so stray `.tmp-*` files are silently skipped, never treated as
+either live or orphaned data.
+
+**Dedup.** `put` computes the BLAKE3 digest of the input bytes first (a pure in-memory operation),
+then checks whether the target path already exists. If it does, `put` returns the existing
+`ContentRef` immediately without touching the filesystem again — no free-space check, no write.
+
+### 5. Free-space fail-closed floor
+
+Before writing a new object (never on a dedup hit), `put` queries the target volume's available
+space via the `fs4` crate and compares it against a configured floor. Below the floor, `put`
+refuses with a new error variant:
+
+```rust
+#[error(
+    "refusing write on {capability:?} at {volume}: {available_bytes} bytes available, \
+     below the {floor_bytes}-byte floor"
+)]
+CapacityFloor {
+    capability: StorageCapability,
+    volume: String,
+    available_bytes: u64,
+    floor_bytes: u64,
+},
+```
+
+This is a hard refusal: no silent degrade, no auto-spill to another volume (SPEC-gate ruling,
+2026-07-12). The default floor is 100 GB (`FsBlobStore::DEFAULT_FLOOR_BYTES = 100_000_000_000`),
+config-overridable via `StorageBackend::blob_store`'s `floor_bytes` parameter.
+
+`fs4` (not a hand-rolled `libc::statvfs` call) was chosen specifically because khive's release
+pipeline (`release.yml`) cross-builds for a `windows-latest` target; `fs4::available_space` is
+unconditionally cross-platform (rustix on Unix, windows-sys on Windows), so the free-space check
+does not need a maintainer-authored Windows FFI path.
+
+### 6. Blob root resolution
+
+`khive-db` cannot parse `khive.toml` itself without introducing an upward dependency (it sits
+below `khive-runtime` in the crate chain). `StorageBackend::blob_store` therefore resolves the
+root directory in this precedence order:
+
+1. `KHIVE_BLOB_ROOT` environment variable (process-global, safe to read directly at any layer).
+2. `config_root` — an explicit override the caller passes in, expected to be resolved from
+   `khive.toml`'s `[storage.blob] root` by a layer above `khive-db` (e.g. `khive-runtime` or
+   `kkernel`).
+3. Default: beside the database file, at `<db_dir>/blobs`.
+
+An in-memory backend with no `config_root` and no environment variable has no directory to default
+beside, and `resolve_blob_root` returns an error rather than picking an arbitrary path.
+
+### 7. `entities.content_ref` — the reference column
+
+A new nullable, indexed column on `entities` (migration V10,
+`crates/khive-db/sql/010-entities-content-ref.sql`):
+
+```sql
+ALTER TABLE entities ADD COLUMN content_ref TEXT;
+
+CREATE INDEX IF NOT EXISTS idx_entities_content_ref
+    ON entities(content_ref)
+    WHERE content_ref IS NOT NULL;
+```
+
+`content_ref` is a first-class column, not a key buried inside `properties` — this lets orphan-GC
+(deliverable 5, below) join against it cheaply instead of scanning and parsing JSON. Storage does
+not validate that the referenced blob actually exists; publish-then-reference is the caller's
+responsibility (an entity can legally reference a `content_ref` before, concurrently with, or
+instead of an actual `BlobStore::put`, the same way `merged_into` can reference an entity ID with
+no read-side existence check).
+
+The same DDL is mirrored into `sql/entities-ddl.sql` (the non-versioned schema some callers apply
+directly via `ensure_entities_schema`, e.g. `StorageBackend::memory()` test setups) — unlike V9's
+index, which was not mirrored, a new _column_ referenced by `Entity`'s Rust struct fields and every
+`SELECT`/`INSERT` in `khive-db`'s and `khive-runtime`'s entity code paths must exist under both
+DDL sources, or any caller that never runs the versioned migration chain breaks with "no such
+column: content_ref".
+
+### 8. Orphan GC — the only deletion path besides explicit `delete`
+
+`BlobStore::orphan_sweep` is the ninth capability's mirror of `VectorStore::orphan_sweep`
+(ADR-044): an admin-side operation, not an MCP verb (adding one would be a wire-surface change
+requiring its own ADR amendment, per ADR-023). The caller (an admin CLI, not a live consumer path)
+assembles the set of live `content_ref`s — e.g. `SELECT DISTINCT content_ref FROM entities WHERE
+content_ref IS NOT NULL AND deleted_at IS NULL` — and passes it in `BlobOrphanSweepConfig`;
+`FsBlobStore` walks its shard tree and reports (`dry_run: true`) or deletes (`dry_run: false`)
+everything not in that set.
+
+This is deliberately the _only_ deletion path a consumer has besides an explicit
+`BlobStore::delete(content_ref)` call (SPEC-gate ruling, 2026-07-12): a future doc/file pack never
+deletes blob files directly, so a blob referenced from two places (or briefly orphaned mid-write by
+some other in-flight operation) is never removed out from under a concurrent reader by a
+consumer-side heuristic. `BlobStore` owns the deletion policy; consumers only ever add references
+and let GC reconcile.
+
+---
+
+## Alternatives Considered
+
+**`object_store` crate as the backend.** khive#292's issue text names the `object_store` crate
+("Filesystem-first; S3-standard for cloud") as the intended backend. This ADR does not use it.
+`BlobStore` (this ADR's own trait) is already the backend-swap seam `object_store` would provide —
+introducing a second abstraction layer underneath a trait whose entire purpose is abstracting the
+backend adds a dependency and an indirection with no current consumer that needs it. ADR-086's
+"defer until a real consumer needs it" discipline, which produced this ADR's own trait in the first
+place, applies again one layer down: an S3-compatible backend can be added as a second `BlobStore`
+implementation (mirroring `FsBlobStore`) exactly when a consumer needs cloud storage, without
+touching the trait or any existing caller. This is a known, deliberate delta from the issue's
+literal text, flagged here per the issue's own "flag any place you diverge" instruction.
+
+**Non-configurable 100 GB floor.** An earlier downstream design draft (the doc/file pack's ADR
+draft, not yet accepted) describes "the non-configurable internal free-space floor" at 100 GB. This
+ADR makes the floor config-overridable (default 100 GB) — the SPEC-gate ruling that produced §5
+above did not revisit that point, and a hard-coded floor with no override would force every
+deployment (including CI, sandboxes, and constrained environments) onto the same number with no
+escape hatch. This is a known delta between this ADR and that unratified draft, to be reconciled
+when the doc/file pack's own ADR is authored.
+
+**Full re-hash verification after write.** Rather than re-reading and re-hashing the temp file
+after writing it (double I/O per `put`), `FsBlobStore` verifies only the written byte length
+against the input length. A length mismatch reliably catches truncated writes (disk full mid-write,
+process killed mid-write); re-hashing bytes that are provably the same bytes the caller supplied
+(safe Rust, no interior mutability) does not catch any additional failure mode a length check
+misses.
+
+---
+
+## Consequences
+
+- `khive-storage` grows one new module (`blob.rs`) and one new `StorageCapability` variant; no
+  existing trait or type changes shape.
+- `khive-db` grows one new store module (`stores/blob.rs`, `FsBlobStore`), one new
+  `StorageBackend::blob_store` factory method, and one new migration (V10). No existing migration
+  is edited.
+- `Entity` (the `khive-storage` flat/SQL-facing struct, not `khive_types::entity::Entity`) grows a
+  `content_ref: Option<String>` field. Every call site constructing an `Entity` literal
+  (`khive-db`, `khive-runtime`, `khive-vcs`) needed updating; all currently set `content_ref: None`
+  except the SQL-backed CRUD paths in `khive-db::stores::entity`, which thread the real value
+  through.
+- The pre-existing entity-merge SQL path in `khive-runtime::curation::merge_entity_sql`'s `INSERT
+  OR REPLACE` already omits `entity_type` from its column list (a pre-existing gap, not introduced
+  by this ADR) — merging an entity through that path resets `entity_type` to `NULL` in the stored
+  row today. `content_ref` was deliberately left out of that same `INSERT OR REPLACE` for
+  consistency with the existing (undocumented) behavior rather than silently fixing one field and
+  not the other; the in-memory `MergeResult`'s returned `Entity` does still carry the "into"
+  entity's `content_ref` forward, matching how it already carries `entity_type` forward in memory
+  despite the DB row losing it. This existing gap should be fixed in its own change, not folded
+  into this ADR's scope.
+- No MCP wire-surface change: `blob_store` is reached only through `StorageBackend`, not through
+  any pack verb. A future doc/file pack ADR will define what (if anything) becomes MCP-visible.
+
+---
+
+## Implementation Notes
+
+- `crates/khive-storage/src/blob.rs` — `ContentRef`, `BlobOrphanSweepConfig`,
+  `BlobOrphanSweepResult`, `BlobStore`.
+- `crates/khive-storage/src/capability.rs` — `StorageCapability::Blob`.
+- `crates/khive-storage/src/error.rs` — `StorageError::CapacityFloor`.
+- `crates/khive-storage/src/entity.rs` — `Entity::content_ref`, `Entity::with_content_ref`.
+- `crates/khive-db/src/stores/blob.rs` — `FsBlobStore`, `resolve_blob_root`.
+- `crates/khive-db/src/backend.rs` — `StorageBackend::blob_store`.
+- `crates/khive-db/sql/010-entities-content-ref.sql` — migration V10.
+- `crates/khive-db/sql/entities-ddl.sql` — mirrored `content_ref` column + index.
+- `crates/khive-db/src/stores/entity.rs` — `content_ref` threaded through
+  `entity_upsert_statement`, `batch_upsert_entities`, `read_entity`, and all three `SELECT` column
+  lists.
+
+## References
+
+- khive issue #292.
+- [ADR-005](ADR-005-storage-capability-traits.md) — Storage Capability Traits.
+- [ADR-044](ADR-044-vector-store-extensions.md) — `orphan_sweep` precedent.
+- [ADR-086](ADR-086-doc-file-pack.md) — deferred `StorageCapability::Blob`.
+- `fs4` crate (`https://crates.io/crates/fs4`) — cross-platform free-space query.

--- a/docs/adr/ADR-111-blob-store.md
+++ b/docs/adr/ADR-111-blob-store.md
@@ -1,7 +1,7 @@
 # ADR-111: BlobStore — Content-Addressed Binary Object Storage
 
 **Status**: accepted
-**Date**: 2026-07-12
+**Date**: 2026-07-12 (amended 2026-07-13 — round-2 codex review, PR #922)
 **Authors**: khive maintainers
 **Depends on**:
 
@@ -106,8 +106,22 @@ then checks whether the target path already exists. If it does, `put` returns th
 ### 5. Free-space fail-closed floor
 
 Before writing a new object (never on a dedup hit), `put` queries the target volume's available
-space via the `fs4` crate and compares it against a configured floor. Below the floor, `put`
-refuses with a new error variant:
+space via the `fs4` crate, subtracts the size of the pending write, and compares the result
+against a configured floor — `remaining_after_write = available.saturating_sub(bytes.len())`,
+refuse when `remaining_after_write < floor_bytes`. **Amended 2026-07-13 (round-2 codex High
+finding):** the original implementation compared `available` directly against the floor, with no
+accounting for the write's own size — `available == floor_bytes + 1` admitted a write of any size,
+including one that would leave the volume below the floor. The check is now write-size-aware.
+
+`FsBlobStore` also serializes the whole check-then-publish critical section of `put` per store
+instance (a `tokio::sync::Mutex<()>` held across the entire `spawn_blocking` call, from the
+availability check through `persist`). **Amended 2026-07-13:** without this, two concurrent puts
+could each observe the same pre-write availability snapshot, each individually pass a write-size-
+aware check against it, and both proceed to write — jointly pushing the volume under the floor even
+though neither write looked unsafe in isolation, since neither observed the other's pending write.
+A per-root async mutex is adequate at `BlobStore`'s expected write rate; it defends only against
+concurrent `FsBlobStore` callers within one process, not against another process writing to the
+same volume. Below the floor, `put` refuses with a new error variant:
 
 ```rust
 #[error(
@@ -185,10 +199,40 @@ everything not in that set.
 
 This is deliberately the _only_ deletion path a consumer has besides an explicit
 `BlobStore::delete(content_ref)` call (SPEC-gate ruling, 2026-07-12): a future doc/file pack never
-deletes blob files directly, so a blob referenced from two places (or briefly orphaned mid-write by
-some other in-flight operation) is never removed out from under a concurrent reader by a
-consumer-side heuristic. `BlobStore` owns the deletion policy; consumers only ever add references
-and let GC reconcile.
+deletes blob files directly, so a blob referenced from two places is never removed out from under a
+concurrent reader by a consumer-side heuristic. `BlobStore` owns the deletion policy; consumers only
+ever add references and let GC reconcile.
+
+**Concurrency guarantee — offline-maintenance-only (amended 2026-07-13, round-2 codex High
+finding).** The paragraph above, as originally written, claimed this design "is never removed out
+from under a concurrent reader" — that claim was not true of the shipped implementation and has
+been corrected here rather than left standing. Both `delete` and `orphan_sweep` are
+**offline-maintenance-only** APIs, not safe to run against a live entity writer:
+
+- `orphan_sweep`'s `live_refs` set is a **snapshot** the caller assembles before the call. Nothing
+  in `BlobStore` detects a `content_ref` that becomes newly live — an entity write lands
+  referencing it — between when that snapshot was taken and when the sweep runs; such a blob is
+  deleted anyway. `khive-db`'s
+  `orphan_sweep_race_demonstrates_the_documented_quiescence_requirement` test reproduces this
+  exactly, so the hazard is pinned in code, not just prose.
+- `delete` is an unconditional physical removal with the same class of hazard: any caller can
+  delete a `content_ref` an entity write races into existence a moment later, with no coordination
+  from this trait.
+
+The actual guarantee is narrower than the original text implied: **run `orphan_sweep` and `delete`
+only when writes that could create a new `content_ref` reference are quiesced** — a maintenance
+window, a single-writer admin CLI invocation with no live traffic, or equivalent. `BlobStore` has no
+visibility into the entity substrate (ADR-005 constraint 4) and therefore cannot enforce this
+itself; it is a caller obligation, now stated explicitly on `BlobStore::delete` and
+`BlobStore::orphan_sweep`'s doc comments.
+
+A transactional, DB-coordinated sweep — selecting and deleting live/orphaned blobs under the entity
+writer's own transactional boundary, so the sweep is safe to run concurrently with normal traffic —
+would close this hazard properly. That is a larger design (does it live in `khive-storage` as a new
+capability, or in `khive-runtime` orchestrating `BlobStore` + `SqlAccess`/`GraphStore` together?)
+left to a follow-up: [khive#924](https://github.com/ohdearquant/khive/issues/924). It is
+**deliberately not built in this round** — the smaller, honest fix here is making the existing
+hazard explicit and tested, not attempting a bigger coordination design under review pressure.
 
 ---
 
@@ -245,6 +289,16 @@ misses.
   into this ADR's scope.
 - No MCP wire-surface change: `blob_store` is reached only through `StorageBackend`, not through
   any pack verb. A future doc/file pack ADR will define what (if anything) becomes MCP-visible.
+- **Round-2 amendments (2026-07-13, PR #922 codex review):** `ContentRef` no longer derives
+  `Deserialize` — it is hand-implemented to route every input through `from_hex`, so a malformed
+  serialized value is rejected at deserialization instead of later panicking in `shard_path`.
+  `FsBlobStore::put`'s floor check now accounts for the pending write's own size and serializes its
+  check-then-publish critical section per store instance via a `tokio::sync::Mutex`. `delete` and
+  `orphan_sweep` are now explicitly documented (trait doc comments, §8 above) as
+  offline-maintenance-only, requiring quiesced entity writes — a real, undefended concurrency hazard
+  the original §8 text incorrectly described as absent. A DB-coordinated transactional sweep that
+  would close that hazard is tracked as a follow-up, not built here:
+  [khive#924](https://github.com/ohdearquant/khive/issues/924).
 
 ---
 
@@ -270,3 +324,7 @@ misses.
 - [ADR-044](ADR-044-vector-store-extensions.md) — `orphan_sweep` precedent.
 - [ADR-086](ADR-086-doc-file-pack.md) — deferred `StorageCapability::Blob`.
 - `fs4` crate (`https://crates.io/crates/fs4`) — cross-platform free-space query.
+- PR #922 codex round-1 review (`.khive/codex_reviews/codex_review_pr922_round1.md`) — source of
+  the three round-2 High findings this ADR was amended to address.
+- [khive#924](https://github.com/ohdearquant/khive/issues/924) — follow-up: transactional,
+  DB-coordinated `BlobStore` orphan sweep.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -131,6 +131,7 @@ For historical context, see [v0 archive](../_archive/adr_v0/README.md). v0 ADRs 
 | [ADR-108](ADR-108-git-write-surface.md)                      | Git Write Surface Through khive (Phase B)                                                             |
 | [ADR-109](ADR-109-sandboxed-kkernel-gateway.md)              | Sandboxed kkernel Gateway for Untrusted Execution (Phase C)                                           |
 | [ADR-110](ADR-110-vamana-wasm.md)                            | WebAssembly Support for khive-vamana                                                                  |
+| [ADR-111](ADR-111-blob-store.md)                             | BlobStore — Content-Addressed Binary Object Storage                                                   |
 
 ## Closed Taxonomies — Quick Reference
 


### PR DESCRIPTION
## Summary

Closes #292. Adds a `BlobStore` capability trait (ADR-005 family) for storing large opaque payloads outside the core SQLite DB, addressed by content hash, plus a filesystem-backed implementation and an `entities.content_ref` reference column.

- `BlobStore` trait in `khive-storage`: `put` / `get` / `exists` / `delete`, content-addressed by **blake3** (`ContentRef`, canonical lowercase 64-hex). New `StorageCapability::Blob` variant.
- `FsBlobStore` in `khive-db`: 2-level hex-sharded filesystem layout; atomic publish via `tempfile::NamedTempFile` (same shard dir) → write + fsync + length-verify → `.persist()`; hash-first dedup on `put` (identical bytes never re-write).
- **Fail-closed free-space floor**: default 100GB, configurable, checked via `fs4::available_space` before any write. Refuses with `StorageError::CapacityFloor { capability, volume, available_bytes, floor_bytes }` — no silent degrade, no auto-spill.
- **Blob root resolution**: `KHIVE_BLOB_ROOT` env > caller-supplied `config_root` > default `<db_dir>/blobs`. Errors when none apply (e.g. in-memory backend with no override).
- `entities.content_ref`: new indexed column via migration **V10** (`010-entities-content-ref.sql`, additive `ALTER TABLE` + partial index), mirrored in the non-versioned `entities-ddl.sql` path. `Entity` struct + every read/write call site updated (khive-db entity store, khive-runtime curation/portability, khive-vcs sync).
- **Orphan GC**: `orphan_sweep` (dry_run + real) mirrors the existing ADR-044 `orphan_sweep` pattern — admin/CLI-only, deliberately **no MCP verb**. This is the only deletion path besides an explicit `delete(content_ref)`.
- **ADR-111** (`docs/adr/ADR-111-blob-store.md`) records the full design and two deliberate deltas from the issue's proposal:
  1. Hand-rolled `std::fs` + `tempfile` + `blake3` filesystem backend instead of the `object_store` crate — `BlobStore` is already the backend-swap seam, and ADR-086 set a defer-until-a-real-consumer-needs-it precedent for exactly this kind of abstraction.
  2. A pre-existing gap in `khive-runtime::curation::merge_entity_sql`'s `INSERT OR REPLACE` (it already drops `entity_type` on entity merge) is flagged but not fixed here — `content_ref` is deliberately left out of that same statement for consistency; the in-memory merge result struct still carries it forward.

## Test plan

- [x] `cargo test -p khive-storage -p khive-db` — 413 tests, 0 failures (includes new `FsBlobStore` unit tests: put/get/exists/delete round-trip, blake3 digest verification, dedup, capacity-floor refusal + error contents, orphan_sweep dry_run/real, blob-root resolution precedence; plus `content_ref` round-trip/default/query/batch-upsert tests and two migration tests for V10).
- [x] `cargo clippy -p khive-storage -p khive-db --all-targets -- -D warnings` — clean
- [x] `cargo clippy -p khive-runtime -p khive-vcs --all-targets -- -D warnings` — clean (ripple-site scope from the `content_ref` field addition)
- [x] `cargo fmt --all -- --check` — clean
- [x] `scripts/lint-sql.sh` — clean
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps -p khive-storage -p khive-db` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)