### PR TITLE
feat(runtime): emit resource.cost_unit per ADR-103 Amendment 1

### DIFF
--- a/crates/khive-pack-brain/src/tests.rs
+++ b/crates/khive-pack-brain/src/tests.rs
@@ -6356,6 +6356,73 @@ mod event_counts_tests {
         );
     }
 
+    /// ADR-103 Amendment 1 (PR #927): the dispatch-boundary audit-row emitter
+    /// now stamps `resource: {"work_class": "interactive"}` on EVERY audit
+    /// row outcome, denied and errored included -- only `resource.cost_unit`
+    /// is scoped to a successful dispatch (ADR-103 Decision (a) requires
+    /// `work_class` on every event; Amendment 1's omission rule covers
+    /// `cost_unit` alone). This pins that a failed and a denied dispatch's
+    /// audit rows are still counted in `counts_by_work_class` via the same
+    /// `payload.resource.work_class` fallback path other non-phase events
+    /// use: outcome plays no role in the split, only payload shape does.
+    #[tokio::test]
+    async fn failed_and_denied_audit_rows_count_via_resource_work_class_fallback() {
+        let (pack, rt) = make_pack();
+        let registry = empty_registry();
+        let token = rt.authorize(Namespace::local()).unwrap();
+
+        let mut errored = Event::new(
+            token.namespace().as_str(),
+            "probe",
+            EventKind::Audit,
+            SubstrateKind::Event,
+            "lambda:khive",
+        );
+        errored.created_at = 1_000_000;
+        errored.outcome = khive_types::EventOutcome::Error;
+        errored.payload = json!({"resource": {"work_class": "interactive"}});
+        rt.events(&token)
+            .expect("event store")
+            .append_event(errored)
+            .await
+            .expect("seed errored audit event");
+
+        let mut denied = Event::new(
+            token.namespace().as_str(),
+            "list",
+            EventKind::Audit,
+            SubstrateKind::Event,
+            "lambda:khive",
+        );
+        denied.created_at = 1_000_000;
+        denied.outcome = khive_types::EventOutcome::Denied;
+        denied.payload = json!({"resource": {"work_class": "interactive"}});
+        rt.events(&token)
+            .expect("event store")
+            .append_event(denied)
+            .await
+            .expect("seed denied audit event");
+
+        let result = pack
+            .dispatch(
+                "brain.event_counts",
+                json!({"since": micros_to_iso(0)}),
+                &registry,
+                &token,
+            )
+            .await
+            .expect("brain.event_counts must succeed");
+
+        assert_eq!(result["total"], json!(2), "got: {result}");
+        assert_eq!(
+            result["counts_by_work_class"]["interactive"],
+            json!(2),
+            "a failed dispatch and a denied dispatch must both still count under \
+             counts_by_work_class -- work_class is stamped on every event outcome \
+             (ADR-103 Decision (a)), unlike cost_unit which is success-only: {result}"
+        );
+    }
+
     /// `cost_unit` does not exist on any event payload in the codebase today (ADR-103
     /// Stage 0 defines it; no Stage 1 producer emits it yet). This verb must not invent
     /// a `cost_unit` key — asserts its literal absence from the response shape so a

--- a/crates/khive-pack-kg/src/dispatch.rs
+++ b/crates/khive-pack-kg/src/dispatch.rs
@@ -9,7 +9,8 @@ use khive_runtime::pack::PackRuntime;
 use khive_runtime::{
     EntityTypeValidatorFn, KhiveRuntime, NamespaceToken, RuntimeError, VerbRegistry,
 };
-use khive_types::{EdgeEndpointRule, HandlerDef};
+use khive_storage::{PhaseCancelledPayload, PhaseCompletedPayload, PhaseStartedPayload};
+use khive_types::{EdgeEndpointRule, EventKind, HandlerDef};
 
 use crate::handler_defs::{handle_verbs, KG_HANDLERS};
 use crate::pack::{KgPack, KG_EDGE_RULES};
@@ -53,7 +54,88 @@ impl PackRuntime for KgPack {
     }
 
     async fn warm(&self) {
-        let _ = self.runtime.embed("khive warmup").await;
+        // ADR-103 Amendment 1 Part 2: `warm()` runs at daemon construction /
+        // first pack install, outside `dispatch()` entirely -- there is no
+        // caller-supplied token. Mint one the same way
+        // `khive-pack-memory`'s ANN background-rebuild task does
+        // (`rt.authorize(Namespace::local())`), so this daemon-startup
+        // embedder warmup is attributed to the daemon principal instead of
+        // remaining invisible on the event plane. A mint failure only
+        // removes this pass's telemetry -- the warmup itself still runs.
+        let token = match self.runtime.authorize(khive_runtime::Namespace::local()) {
+            Ok(token) => Some(token),
+            Err(e) => {
+                tracing::warn!(
+                    error = %e,
+                    "kg_embedder_warm: failed to mint ADR-103 phase-span attribution token; \
+                     warmup proceeds without telemetry"
+                );
+                None
+            }
+        };
+        if let Some(token) = &token {
+            khive_runtime::emit_phase_event(
+                &self.runtime,
+                token,
+                "kg.embedder_warm",
+                EventKind::PhaseStarted,
+                PhaseStartedPayload {
+                    work_class: "warm".into(),
+                    phase: "kg_embedder_warm".into(),
+                    corpus_size: None,
+                },
+            )
+            .await;
+        }
+        let phase_start = std::time::Instant::now();
+        let cpu_start = khive_runtime::process_resource_usage();
+        let result = self.runtime.embed("khive warmup").await;
+        if let Some(token) = &token {
+            let wall_us = phase_start.elapsed().as_micros() as i64;
+            let cpu_us =
+                khive_runtime::cpu_delta_us(cpu_start, khive_runtime::process_resource_usage());
+            match &result {
+                Err(e) if khive_runtime::is_benign_shutdown_cancellation(e) => {
+                    khive_runtime::emit_phase_event(
+                        &self.runtime,
+                        token,
+                        "kg.embedder_warm",
+                        EventKind::PhaseCancelled,
+                        PhaseCancelledPayload {
+                            work_class: "warm".into(),
+                            phase: "kg_embedder_warm".into(),
+                            wall_us,
+                            cpu_us,
+                        },
+                    )
+                    .await;
+                }
+                _ => {
+                    khive_runtime::emit_phase_event(
+                        &self.runtime,
+                        token,
+                        "kg.embedder_warm",
+                        EventKind::PhaseCompleted,
+                        PhaseCompletedPayload {
+                            work_class: "warm".into(),
+                            phase: "kg_embedder_warm".into(),
+                            wall_us,
+                            cpu_us,
+                        },
+                    )
+                    .await;
+                }
+            }
+        }
+        // `PackRuntime::warm` is documented infallible: errors are logged
+        // internally, never propagated. The embed outcome is already
+        // captured in the phase-span payload above (Completed vs
+        // Cancelled); nothing further to do with it here.
+        let _ = result;
+    }
+
+    fn registered_embedding_model_names(&self) -> Vec<String> {
+        self.runtime.registered_embedding_model_names()
     }
 
     fn register_entity_type_validator(&self, _runtime: &KhiveRuntime) {
@@ -1808,6 +1890,68 @@ mod tests {
         assert!(
             result.is_err(),
             "resolve(kind=\"note\") must fail loud, not silently over-filter"
+        );
+    }
+
+    // ---- ADR-103 Amendment 1 Part 2: kg_embedder_warm phase-span events ----
+
+    #[tokio::test]
+    async fn kg_warm_emits_exactly_one_phase_started_and_one_terminal_event() {
+        let rt = KhiveRuntime::memory().expect("in-memory runtime");
+        let token = rt.authorize(Namespace::local()).expect("authorize local");
+        let event_store = rt.events(&token).expect("event store must be available");
+
+        let pack = KgPack::new(rt.clone());
+        pack.warm().await;
+
+        let page = event_store
+            .query_events(
+                khive_storage::EventFilter::default(),
+                khive_storage::PageRequest {
+                    limit: 10,
+                    offset: 0,
+                },
+            )
+            .await
+            .expect("query events");
+
+        let started: Vec<_> = page
+            .items
+            .iter()
+            .filter(|e| e.kind == khive_types::EventKind::PhaseStarted)
+            .collect();
+        let completed: Vec<_> = page
+            .items
+            .iter()
+            .filter(|e| e.kind == khive_types::EventKind::PhaseCompleted)
+            .collect();
+        let cancelled: Vec<_> = page
+            .items
+            .iter()
+            .filter(|e| e.kind == khive_types::EventKind::PhaseCancelled)
+            .collect();
+
+        assert_eq!(
+            started.len(),
+            1,
+            "kg_embedder_warm must emit exactly one PhaseStarted event, got: {:?}",
+            page.items
+        );
+        assert_eq!(
+            completed.len() + cancelled.len(),
+            1,
+            "kg_embedder_warm must emit exactly one terminal event (Completed xor \
+             Cancelled), got completed={} cancelled={}: {:?}",
+            completed.len(),
+            cancelled.len(),
+            page.items
+        );
+        assert_eq!(started[0].payload["work_class"], "warm");
+        assert_eq!(started[0].payload["phase"], "kg_embedder_warm");
+        assert_eq!(
+            page.items.len(),
+            2,
+            "no event besides the Started/terminal pair -- warm() itself never dispatches"
         );
     }
 }

--- a/crates/khive-pack-knowledge/src/pack.rs
+++ b/crates/khive-pack-knowledge/src/pack.rs
@@ -10,7 +10,8 @@ use khive_brain_core::SectionPosteriorState;
 use khive_runtime::pack::{PackByIdResolver, PackRuntime};
 use khive_runtime::{KhiveRuntime, NamespaceToken, Resolved, RuntimeError, VerbRegistry};
 use khive_storage::types::{SqlStatement, SqlValue};
-use khive_types::{HandlerDef, Pack};
+use khive_storage::{PhaseCancelledPayload, PhaseCompletedPayload, PhaseStartedPayload};
+use khive_types::{EventKind, HandlerDef, Pack};
 
 use crate::knowledge::util::{atom_from_row, atom_to_json, domain_from_row, domain_to_json};
 use crate::knowledge::vamana;
@@ -102,8 +103,83 @@ impl PackRuntime for KnowledgePack {
         crate::knowledge::vamana::warm_known_snapshots(&self.runtime, &self.ann).await;
         if !self.runtime.default_embedder_name().is_empty() {
             let runtime = self.runtime.clone();
+            // ADR-103 Amendment 1 Part 2: the phase span brackets ONLY this
+            // configured-embedder branch's spawned embed call, not the
+            // unconditional `warm_known_snapshots` above -- an unconditional
+            // span would record a phase for an embedder warmup that never
+            // ran whenever no embedder is configured. Minted here (before
+            // spawn) rather than inside the task: `authorize` is cheap and
+            // synchronous, and minting outside keeps the same shape as
+            // KgPack::warm's unconditional case.
+            let token = match runtime.authorize(khive_runtime::Namespace::local()) {
+                Ok(token) => Some(token),
+                Err(e) => {
+                    tracing::warn!(
+                        error = %e,
+                        "knowledge_embedder_warm: failed to mint ADR-103 phase-span \
+                         attribution token; warmup proceeds without telemetry"
+                    );
+                    None
+                }
+            };
             tokio::spawn(async move {
-                let _ = runtime.embed("__khive_knowledge_warm__").await;
+                if let Some(token) = &token {
+                    khive_runtime::emit_phase_event(
+                        &runtime,
+                        token,
+                        "knowledge.embedder_warm",
+                        EventKind::PhaseStarted,
+                        PhaseStartedPayload {
+                            work_class: "warm".into(),
+                            phase: "knowledge_embedder_warm".into(),
+                            corpus_size: None,
+                        },
+                    )
+                    .await;
+                }
+                let phase_start = std::time::Instant::now();
+                let cpu_start = khive_runtime::process_resource_usage();
+                let result = runtime.embed("__khive_knowledge_warm__").await;
+                if let Some(token) = &token {
+                    let wall_us = phase_start.elapsed().as_micros() as i64;
+                    let cpu_us = khive_runtime::cpu_delta_us(
+                        cpu_start,
+                        khive_runtime::process_resource_usage(),
+                    );
+                    match &result {
+                        Err(e) if khive_runtime::is_benign_shutdown_cancellation(e) => {
+                            khive_runtime::emit_phase_event(
+                                &runtime,
+                                token,
+                                "knowledge.embedder_warm",
+                                EventKind::PhaseCancelled,
+                                PhaseCancelledPayload {
+                                    work_class: "warm".into(),
+                                    phase: "knowledge_embedder_warm".into(),
+                                    wall_us,
+                                    cpu_us,
+                                },
+                            )
+                            .await;
+                        }
+                        _ => {
+                            khive_runtime::emit_phase_event(
+                                &runtime,
+                                token,
+                                "knowledge.embedder_warm",
+                                EventKind::PhaseCompleted,
+                                PhaseCompletedPayload {
+                                    work_class: "warm".into(),
+                                    phase: "knowledge_embedder_warm".into(),
+                                    wall_us,
+                                    cpu_us,
+                                },
+                            )
+                            .await;
+                        }
+                    }
+                }
+                let _ = result;
             });
         }
     }
@@ -447,5 +523,50 @@ impl PackByIdResolver for KnowledgePack {
             "kind": kind,
             "hard": hard,
         }))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use khive_runtime::pack::PackRuntime;
+    use khive_runtime::{KhiveRuntime, Namespace};
+
+    use super::KnowledgePack;
+
+    // ADR-103 Amendment 1 Part 2: knowledge_embedder_warm phase-span events.
+    //
+    // `KhiveRuntime::memory()` builds on `RuntimeConfig::no_embeddings()`
+    // (runtime.rs), so `default_embedder_name()` is empty and the
+    // configured-embedder branch in `KnowledgePack::warm()` never runs. This
+    // pins that gating: the unconditional `vamana::warm_known_snapshots` call
+    // above the branch must never itself emit a phase event, and the
+    // configured-only branch must not fire when unconfigured.
+    #[tokio::test]
+    async fn knowledge_warm_emits_no_phase_events_when_no_embedder_configured() {
+        let rt = KhiveRuntime::memory().expect("in-memory runtime");
+        let token = rt.authorize(Namespace::local()).expect("authorize local");
+        let event_store = rt.events(&token).expect("event store must be available");
+
+        let pack = KnowledgePack::new(rt.clone());
+        pack.warm().await;
+
+        let page = event_store
+            .query_events(
+                khive_storage::EventFilter::default(),
+                khive_storage::PageRequest {
+                    limit: 10,
+                    offset: 0,
+                },
+            )
+            .await
+            .expect("query events");
+
+        assert!(
+            page.items.is_empty(),
+            "no embedder configured -> KnowledgePack::warm() must emit zero phase events \
+             (configured-only branch must not fire, and warm_known_snapshots must not \
+             independently emit): {:?}",
+            page.items
+        );
     }
 }

--- a/crates/khive-pack-memory/src/ann.rs
+++ b/crates/khive-pack-memory/src/ann.rs
@@ -6,7 +6,9 @@ use std::collections::{HashMap, HashSet};
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 
-use khive_runtime::{KhiveRuntime, Namespace, NamespaceToken, RuntimeError};
+use khive_runtime::{
+    is_benign_shutdown_cancellation, KhiveRuntime, Namespace, NamespaceToken, RuntimeError,
+};
 use khive_storage::types::{SqlStatement, SqlValue};
 use khive_storage::StorageError;
 use khive_vamana::{CorpusFingerprint, VamanaConfig, VamanaIndex, VamanaSnapshot};
@@ -681,23 +683,11 @@ pub(crate) async fn wait_until_warm_idle(ann: &SharedAnn, key: &AnnKey) {
     }
 }
 
-/// True when `err` is the direct result of a `spawn_blocking` cancellation —
-/// e.g. a short-lived process (or daemon shutdown) tearing the runtime down
-/// mid-build — rather than a genuine backend/driver failure.
-///
-/// Matches the concrete `tokio::task::JoinError` boxed inside
-/// `StorageError::Driver` (the shape `with_reader`/`with_writer` produce when
-/// their `spawn_blocking(...).await` is cut short) via a typed downcast, not
-/// a message substring, so a real `vec_count`/SQL driver error is never
-/// misclassified as benign.
-fn is_benign_shutdown_cancellation(err: &RuntimeError) -> bool {
-    let RuntimeError::Storage(StorageError::Driver { source, .. }) = err else {
-        return false;
-    };
-    source
-        .downcast_ref::<tokio::task::JoinError>()
-        .is_some_and(tokio::task::JoinError::is_cancelled)
-}
+// `is_benign_shutdown_cancellation` moved to `khive_runtime::phase_events`
+// (re-exported at the crate root) so ADR-103 Amendment 1's kg/knowledge
+// embedder-warm phase hooks can reuse the same shutdown-cancellation
+// classification this module originated, without duplicating the typed
+// downcast. Imported below via `use khive_runtime::is_benign_shutdown_cancellation;`.
 
 /// Fire-once per-model background warm. Returns `true` if a new task was started.
 pub(crate) async fn ensure_ann_background(

--- a/crates/khive-pack-memory/src/pack.rs
+++ b/crates/khive-pack-memory/src/pack.rs
@@ -409,6 +409,13 @@ impl PackRuntime for MemoryPack {
         fts_population_guard(&self.runtime).await;
     }
 
+    /// ADR-103 Amendment 1's `model_count` computation for `memory.remember`
+    /// without an explicit `embedding_model` override reads this at the
+    /// dispatch audit-row emission seam.
+    fn registered_embedding_model_names(&self) -> Vec<String> {
+        self.runtime.registered_embedding_model_names()
+    }
+
     /// #750 fix-round 1: install a note-mutation hook on the runtime THIS
     /// pack owns (`self.runtime`, not the `_runtime` param — mirrors
     /// `KgPack::register_entity_type_validator`'s multi-backend rationale:

--- a/crates/khive-runtime/src/cost_unit.rs
+++ b/crates/khive-runtime/src/cost_unit.rs
@@ -1,0 +1,383 @@
+//! ADR-103 Amendment 1: deterministic `cost_unit` for the per-dispatch
+//! audit-row `resource` payload enrichment.
+//!
+//! `cost_unit = base_weight(verb) + per_item_weight(verb) x item_count x
+//! model_count`, computed with checked `i64` arithmetic and clamped to
+//! `i64::MAX` on overflow rather than omitted (ADR-103 Amendment 1 Part 1).
+//!
+//! Amendment 1 commits only to the formula's *shape* and to
+//! `per_item_weight(verb) = 0` for every verb outside its closed
+//! embedding-bearing family. The `base_weight` / `per_item_weight`
+//! magnitudes are left as "deterministic, hand-set constants ... fixed at
+//! implementation time and not measured". This module ships `base_weight =
+//! 1` uniformly across every verb and `per_item_weight = 1` for every
+//! embedding-bearing verb, as the documented default pending a dedicated
+//! per-verb weights table (see the PR body that introduced this module).
+
+use serde_json::Value;
+
+/// True when `verb` is one of ADR-103 Amendment 1's closed
+/// embedding-bearing verb families, given the request's own top-level
+/// params.
+///
+/// `params` is needed only to tell a singleton `create` from a bulk
+/// `create(items=[...])`: the amendment explicitly carves bulk create out as
+/// non-embedding-bearing (`create_many` intentionally skips embedding and
+/// backfills vectors later via a separate `reindex` call,
+/// `crates/khive-runtime/src/operations.rs:4698-4709`), regardless of its
+/// own `created`/`attempted` summary counts.
+fn is_embedding_bearing(verb: &str, params: &Value) -> bool {
+    match verb {
+        "create" => params.get("items").is_none(),
+        "update" | "memory.remember" | "memory.recall" | "knowledge.search"
+        | "knowledge.compose" | "knowledge.index" => true,
+        _ => false,
+    }
+}
+
+/// `base_weight(verb)`: every verb dispatch, `1` (documented default; see
+/// module docs: the amendment leaves specific weight VALUES unspecified).
+fn base_weight(_verb: &str) -> i64 {
+    1
+}
+
+/// `per_item_weight(verb)`: `1` for every embedding-bearing verb family
+/// (documented default; see module docs), `0` for everything else. The `0`
+/// case is not a default: it is ADR-103 Amendment 1's normative
+/// requirement that a non-embedding-bearing verb's `cost_unit` reduces to
+/// `base_weight(verb)` alone, `item_count`/`model_count` playing no role.
+fn per_item_weight(verb: &str, params: &Value) -> i64 {
+    if is_embedding_bearing(verb, params) {
+        1
+    } else {
+        0
+    }
+}
+
+/// `item_count` for one dispatch, per ADR-103 Amendment 1's per-verb-family
+/// table. Only meaningful (and only called by [`cost_unit_for_dispatch`])
+/// when `per_item_weight` is nonzero for this verb.
+///
+/// - `create` singleton, `memory.remember`, `update`, `memory.recall`,
+///   `knowledge.search`, `knowledge.compose`: always `1`, each is a single
+///   entity/note write or a single query embedding, never a batch.
+/// - `knowledge.index`: `result["total"]`, the full paged corpus count
+///   computed across all internally paged reads, never the internal
+///   `batch_size` chunk ceiling (`clamp(1, 1000)` on the embed-grouping
+///   page size only, not the dispatch's total work).
+fn item_count(verb: &str, result: &Value) -> i64 {
+    if verb == "knowledge.index" {
+        result.get("total").and_then(Value::as_i64).unwrap_or(0)
+    } else {
+        1
+    }
+}
+
+/// `model_count` for one dispatch, per ADR-103 Amendment 1's per-verb-family
+/// table. Only meaningful (and only called by [`cost_unit_for_dispatch`])
+/// when `per_item_weight` is nonzero for this verb.
+///
+/// `registered_model_count` is evaluated lazily via `FnOnce`, called only
+/// for the two verb families whose `model_count` is not a per-dispatch
+/// constant (`memory.remember`'s implicit-model case, and singleton
+/// `create`), so every other dispatch never touches the runtime's embedder
+/// registry.
+///
+/// `0` is a valid, deliberate result when no embedding model is registered
+/// at all: no embed call is issued, so the whole
+/// `per_item_weight x item_count x model_count` term is `0` and
+/// `cost_unit` reduces to `base_weight(verb)` alone. The dispatch still
+/// happened; no embedding work backs its cost.
+fn model_count(verb: &str, params: &Value, registered_model_count: impl FnOnce() -> i64) -> i64 {
+    match verb {
+        "memory.remember" => {
+            let explicit_single_model = params
+                .get("embedding_model")
+                .and_then(Value::as_str)
+                .is_some();
+            if explicit_single_model {
+                1
+            } else {
+                registered_model_count()
+            }
+        }
+        "create" => registered_model_count(),
+        // update, memory.recall, knowledge.search / compose, knowledge.index:
+        // each invokes exactly one embedding model (a query-embedding model,
+        // or the single configured default embedder), never a fan-out.
+        _ => 1,
+    }
+}
+
+/// Checked-arithmetic `cost_unit`:
+/// `base_weight + per_item_weight x item_count x model_count`.
+///
+/// `checked_mul` at each product step, `checked_add` for the final sum: any
+/// overflow at any step clamps the WHOLE expression to `i64::MAX` rather
+/// than omitting the field (ADR-103 Amendment 1 Part 1). All inputs are
+/// non-negative in practice, so overflow can only occur in the positive
+/// direction.
+fn compute(base_weight: i64, per_item_weight: i64, item_count: i64, model_count: i64) -> i64 {
+    let term = per_item_weight
+        .checked_mul(item_count)
+        .and_then(|p| p.checked_mul(model_count))
+        .unwrap_or(i64::MAX);
+    base_weight.checked_add(term).unwrap_or(i64::MAX)
+}
+
+/// Compute `resource.cost_unit` for one successful dispatch.
+///
+/// `params` is the original request's top-level arguments (`GateRequest::args`,
+/// already in scope, read-only, at the audit-row emission seam in
+/// `crates/khive-runtime/src/pack.rs`); `result` is the dispatch's own
+/// successful `Value`; `registered_model_count` reads
+/// `PackRuntime::registered_embedding_model_names().len()` for the pack that
+/// owns `verb`, lazily.
+///
+/// Callers MUST only invoke this for a successful (`Ok`) dispatch result.
+/// Error-outcome dispatches omit `resource.cost_unit` entirely (ADR-103
+/// Amendment 1's "absence has exactly two meanings" rule: a pre-amendment
+/// event, or a dispatch that errored) and must never call into this
+/// function: there is no successful handler `Value` to read `item_count`
+/// from for an errored dispatch.
+pub fn cost_unit_for_dispatch(
+    verb: &str,
+    params: &Value,
+    result: &Value,
+    registered_model_count: impl FnOnce() -> i64,
+) -> i64 {
+    let weight = per_item_weight(verb, params);
+    if weight == 0 {
+        return compute(base_weight(verb), 0, 0, 0);
+    }
+    let items = item_count(verb, result);
+    let models = model_count(verb, params, registered_model_count);
+    compute(base_weight(verb), weight, items, models)
+}
+
+/// Build the `resource` payload object, `{"work_class": "interactive",
+/// "cost_unit": N}`, for one successful verb dispatch.
+///
+/// Every dispatch through `VerbRegistry::dispatch*` is `work_class:
+/// "interactive"` (ADR-103 Decision (a): "Request-driven synchronous verb
+/// dispatch. Default for all handlers."). Background phase work (embedder
+/// warmup, ANN rebuild, etc.) uses the separate `PhaseStarted` /
+/// `PhaseCompleted` / `PhaseCancelled` event family and never this payload.
+pub fn resource_payload(
+    verb: &str,
+    params: &Value,
+    result: &Value,
+    registered_model_count: impl FnOnce() -> i64,
+) -> Value {
+    let cost_unit = cost_unit_for_dispatch(verb, params, result, registered_model_count);
+    serde_json::json!({ "work_class": "interactive", "cost_unit": cost_unit })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn unreachable_model_count() -> i64 {
+        panic!("registered_model_count must not be called for a non-embedding-bearing verb")
+    }
+
+    // ---- Formula arithmetic ----
+
+    #[test]
+    fn non_embedding_verb_is_base_weight_only() {
+        let cost = cost_unit_for_dispatch("stats", &json!({}), &json!({}), unreachable_model_count);
+        assert_eq!(
+            cost, 1,
+            "non-embedding-bearing verb must be base_weight(verb) alone"
+        );
+    }
+
+    #[test]
+    fn link_is_base_weight_only_regardless_of_bulk_shape() {
+        let singleton = cost_unit_for_dispatch(
+            "link",
+            &json!({"source_id": "a", "target_id": "b", "relation": "extends"}),
+            &json!({"id": "edge-1"}),
+            unreachable_model_count,
+        );
+        let bulk = cost_unit_for_dispatch(
+            "link",
+            &json!({"links": [{}, {}, {}]}),
+            &json!({"attempted": 3, "created": 3}),
+            unreachable_model_count,
+        );
+        assert_eq!(singleton, 1);
+        assert_eq!(
+            bulk, 1,
+            "link has no embedding-bearing path, singleton or bulk"
+        );
+    }
+
+    #[test]
+    fn create_singleton_scales_with_registered_model_count() {
+        let cost = cost_unit_for_dispatch("create", &json!({"kind": "concept"}), &json!({}), || 3);
+        // base_weight(1) + per_item_weight(1) * item_count(1) * model_count(3)
+        assert_eq!(cost, 4);
+    }
+
+    // ---- Zero-model vanishing ----
+
+    #[test]
+    fn zero_registered_models_vanishes_the_term() {
+        let cost = cost_unit_for_dispatch("create", &json!({"kind": "concept"}), &json!({}), || 0);
+        assert_eq!(
+            cost, 1,
+            "no embedding model registered -> cost_unit reduces to base_weight(verb) alone"
+        );
+    }
+
+    #[test]
+    fn memory_remember_zero_registered_models_vanishes_the_term() {
+        let cost = cost_unit_for_dispatch("memory.remember", &json!({}), &json!({}), || 0);
+        assert_eq!(cost, 1);
+    }
+
+    // ---- Bulk create is base-only ----
+
+    #[test]
+    fn bulk_create_is_base_weight_only_never_touches_model_count() {
+        let cost = cost_unit_for_dispatch(
+            "create",
+            &json!({"items": [{"kind": "concept", "name": "a"}, {"kind": "concept", "name": "b"}]}),
+            &json!({"attempted": 2, "created": 2}),
+            unreachable_model_count,
+        );
+        assert_eq!(
+            cost, 1,
+            "bulk create(items=[...]) skips embedding entirely -> base_weight(verb) alone"
+        );
+    }
+
+    #[test]
+    fn bulk_create_is_base_only_regardless_of_created_count() {
+        // The amendment is explicit: this holds "regardless of its
+        // created/attempted summary counts" -- a large batch must not
+        // change the result.
+        let items: Vec<Value> = (0..250)
+            .map(|i| json!({"kind": "concept", "name": format!("item-{i}")}))
+            .collect();
+        let cost = cost_unit_for_dispatch(
+            "create",
+            &json!({"items": items}),
+            &json!({"attempted": 250, "created": 250}),
+            unreachable_model_count,
+        );
+        assert_eq!(cost, 1);
+    }
+
+    // ---- knowledge.index full total, not batch_size ceiling ----
+
+    #[test]
+    fn knowledge_index_uses_full_paged_total_not_batch_size_ceiling() {
+        // batch_size only bounds the internal SQL page / embed-grouping
+        // size; the dispatch can process far more than 1000 items in one
+        // call, and item_count must reflect that full total.
+        let cost = cost_unit_for_dispatch(
+            "knowledge.index",
+            &json!({"batch_size": 1000}),
+            &json!({"indexed": 4500, "skipped": 0, "failed": 0, "total": 4500}),
+            || 1,
+        );
+        // base_weight(1) + per_item_weight(1) * item_count(4500) * model_count(1)
+        assert_eq!(cost, 4501);
+    }
+
+    #[test]
+    fn knowledge_index_missing_total_defaults_to_zero_items_not_a_panic() {
+        let cost = cost_unit_for_dispatch("knowledge.index", &json!({}), &json!({}), || 1);
+        assert_eq!(cost, 1);
+    }
+
+    #[test]
+    fn knowledge_index_model_count_is_constant_one_never_reads_registry() {
+        let cost = cost_unit_for_dispatch(
+            "knowledge.index",
+            &json!({}),
+            &json!({"total": 10}),
+            unreachable_model_count,
+        );
+        assert_eq!(cost, 11);
+    }
+
+    // ---- memory.remember explicit-model override ----
+
+    #[test]
+    fn memory_remember_explicit_model_overrides_registry_count() {
+        let cost = cost_unit_for_dispatch(
+            "memory.remember",
+            &json!({"content": "x", "embedding_model": "paraphrase"}),
+            &json!({}),
+            unreachable_model_count,
+        );
+        // explicit single model -> model_count = 1, registry never consulted
+        assert_eq!(cost, 2);
+    }
+
+    #[test]
+    fn memory_remember_no_explicit_model_reads_registered_count() {
+        let cost = cost_unit_for_dispatch(
+            "memory.remember",
+            &json!({"content": "x"}),
+            &json!({}),
+            || 4,
+        );
+        assert_eq!(cost, 5);
+    }
+
+    // ---- Constant-model-count families never touch the registry ----
+
+    #[test]
+    fn update_and_recall_and_search_never_touch_registry() {
+        for verb in [
+            "update",
+            "memory.recall",
+            "knowledge.search",
+            "knowledge.compose",
+        ] {
+            let cost =
+                cost_unit_for_dispatch(verb, &json!({}), &json!({}), unreachable_model_count);
+            assert_eq!(cost, 2, "verb {verb}: base_weight(1) + 1*1*1");
+        }
+    }
+
+    // ---- Overflow clamps to i64::MAX ----
+
+    #[test]
+    fn compute_clamps_multiplication_overflow_to_i64_max() {
+        assert_eq!(compute(1, i64::MAX, 2, 1), i64::MAX);
+    }
+
+    #[test]
+    fn compute_clamps_addition_overflow_to_i64_max() {
+        assert_eq!(compute(i64::MAX, 1, 1, 1), i64::MAX);
+    }
+
+    #[test]
+    fn knowledge_index_extreme_total_clamps_to_i64_max() {
+        let cost = cost_unit_for_dispatch(
+            "knowledge.index",
+            &json!({}),
+            &json!({"total": i64::MAX}),
+            || 2,
+        );
+        assert_eq!(cost, i64::MAX);
+    }
+
+    // ---- resource_payload shape ----
+
+    #[test]
+    fn resource_payload_shape_is_work_class_and_cost_unit_only() {
+        let payload = resource_payload("stats", &json!({}), &json!({}), unreachable_model_count);
+        assert_eq!(
+            payload,
+            json!({"work_class": "interactive", "cost_unit": 1}),
+            "resource payload must be exactly {{work_class, cost_unit}}, no extra fields"
+        );
+    }
+}

--- a/crates/khive-runtime/src/cost_unit.rs
+++ b/crates/khive-runtime/src/cost_unit.rs
@@ -173,6 +173,21 @@ pub fn resource_payload(
     serde_json::json!({ "work_class": "interactive", "cost_unit": cost_unit })
 }
 
+/// Build the `resource` payload object for a dispatch that did not resolve
+/// `Ok`: `{"work_class": "interactive"}`, with no `cost_unit` key.
+///
+/// ADR-103 Decision (a) stamps the closed `work_class` enum on every event,
+/// with no exception for a denied, errored, or unknown-verb dispatch. Only
+/// `resource.cost_unit` is scoped to a successful dispatch by Amendment 1's
+/// "absence has exactly two meanings" rule (a pre-amendment event, or a
+/// dispatch that errored): `work_class` itself is not one of those two
+/// omission cases, so it must still be present. Every dispatch through
+/// `VerbRegistry::dispatch*` is `work_class: "interactive"` regardless of
+/// outcome; there is no non-interactive outcome for a verb dispatch.
+pub fn base_resource_payload() -> Value {
+    serde_json::json!({ "work_class": "interactive" })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/khive-runtime/src/lib.rs
+++ b/crates/khive-runtime/src/lib.rs
@@ -8,6 +8,7 @@ pub mod atomic_prepare;
 pub mod atomic_runner;
 pub mod config;
 pub mod config_ledger;
+pub mod cost_unit;
 pub mod curation;
 #[cfg(unix)]
 pub mod daemon;
@@ -19,6 +20,7 @@ pub mod graph_traversal;
 pub mod objectives;
 pub mod operations;
 pub mod pack;
+pub mod phase_events;
 pub mod portability;
 pub mod presentation;
 pub mod reference_resolution;
@@ -38,6 +40,7 @@ pub use atomic_plan::{
 pub use atomic_runner::{
     run_atomic_unit, AtomicOpFailure, AtomicOpPlan, AtomicRunOutcome, AtomicRunnerError,
 };
+pub use cost_unit::{cost_unit_for_dispatch, resource_payload};
 pub use curation::{
     entity_fts_document, note_fts_document, ContentMergeStrategy, EdgeListFilter, EdgePatch,
     EntityDedupMergePolicy, EntityPatch, MergeSummary, NotePatch,
@@ -89,6 +92,7 @@ pub use pack::{
     SchemaPlan, VerbCategory, VerbPresentationPolicy, VerbRegistry, VerbRegistryBuilder,
     Visibility,
 };
+pub use phase_events::{emit_phase_event, is_benign_shutdown_cancellation};
 pub use portability::{ImportSummary, KgArchive};
 pub use presentation::{
     apply_redundancy_drop, micros_to_iso, present, render_format, OutputFormat, PresentationMode,

--- a/crates/khive-runtime/src/lib.rs
+++ b/crates/khive-runtime/src/lib.rs
@@ -40,7 +40,7 @@ pub use atomic_plan::{
 pub use atomic_runner::{
     run_atomic_unit, AtomicOpFailure, AtomicOpPlan, AtomicRunOutcome, AtomicRunnerError,
 };
-pub use cost_unit::{cost_unit_for_dispatch, resource_payload};
+pub use cost_unit::{base_resource_payload, cost_unit_for_dispatch, resource_payload};
 pub use curation::{
     entity_fts_document, note_fts_document, ContentMergeStrategy, EdgeListFilter, EdgePatch,
     EntityDedupMergePolicy, EntityPatch, MergeSummary, NotePatch,

--- a/crates/khive-runtime/src/pack.rs
+++ b/crates/khive-runtime/src/pack.rs
@@ -231,6 +231,20 @@ pub trait PackRuntime: Send + Sync {
     /// any errors are logged internally, not propagated to the caller.
     async fn warm(&self) {}
 
+    /// Names of all embedding models registered on this pack's underlying
+    /// runtime handle.
+    ///
+    /// Used by ADR-103 Amendment 1's `model_count` computation at the
+    /// dispatch audit-row emission seam (`VerbRegistry::dispatch_with_identity`)
+    /// for the two embedding-bearing verb families whose model fan-out is
+    /// not a per-dispatch constant: singleton `create` and `memory.remember`
+    /// without an explicit `embedding_model` override. Defaults to empty —
+    /// only the packs that own those verbs (kg, memory) need to override
+    /// this by forwarding to their internal `KhiveRuntime`.
+    fn registered_embedding_model_names(&self) -> Vec<String> {
+        Vec::new()
+    }
+
     /// Dispatch a verb call. Returns serialized JSON response.
     ///
     /// The `registry` parameter gives the handler access to the merged
@@ -1091,8 +1105,12 @@ impl VerbRegistry {
                 // Persist to EventStore immediately only for denied calls.
                 if !defer_audit {
                     if let Some(store) = &self.event_store {
-                        let storage_event =
-                            build_audit_storage_event(&gate_req, &audit, EventOutcome::Denied);
+                        let storage_event = build_audit_storage_event(
+                            &gate_req,
+                            &audit,
+                            EventOutcome::Denied,
+                            None,
+                        );
                         append_audit_event_best_effort(store, storage_event, verb).await;
                     }
                 }
@@ -1220,8 +1238,24 @@ impl VerbRegistry {
                             verb == "link" && gate_req.args.get("links").is_none();
                         match &result {
                             Ok(ok_val) if is_link_singleton => {
+                                // ADR-103 Amendment 1: `link` (singleton or
+                                // bulk) has no embedding-bearing path — edges
+                                // carry no embedded body — so cost_unit is
+                                // always base_weight("link") alone. The
+                                // registered-model closure is never invoked
+                                // (per_item_weight("link", ..) short-circuits
+                                // to 0 before `model_count` reads it).
+                                let resource = crate::cost_unit::resource_payload(
+                                    verb,
+                                    &gate_req.args,
+                                    ok_val,
+                                    || pack.registered_embedding_model_names().len() as i64,
+                                );
                                 match link_audit_success_from_result(audit.clone(), ok_val) {
-                                    Some((edge_id, payload)) => {
+                                    Some((edge_id, mut payload)) => {
+                                        if let Value::Object(ref mut map) = payload {
+                                            map.insert("resource".to_string(), resource);
+                                        }
                                         let storage_event = Event::new(
                                             gate_req.namespace.as_str(),
                                             gate_req.verb.as_str(),
@@ -1250,6 +1284,7 @@ impl VerbRegistry {
                                             &gate_req,
                                             &audit,
                                             EventOutcome::Success,
+                                            Some(resource),
                                         )
                                         .with_duration_us(dispatch_us);
                                         append_audit_event_best_effort(store, storage_event, verb)
@@ -1263,13 +1298,29 @@ impl VerbRegistry {
                                 // Success — otherwise a failed dispatch is
                                 // recorded as successful work and disappears
                                 // from `outcome=error` queries.
-                                let outcome = if result.is_ok() {
-                                    EventOutcome::Success
-                                } else {
-                                    EventOutcome::Error
+                                //
+                                // ADR-103 Amendment 1: `resource.cost_unit` is
+                                // computed ONLY on a successful dispatch —
+                                // there is no handler `Value` to read
+                                // `item_count` from on an error, and the
+                                // amendment's "absence has exactly two
+                                // meanings" rule requires the field be
+                                // omitted, never defaulted to 0, on an
+                                // errored dispatch.
+                                let (outcome, resource) = match &result {
+                                    Ok(ok_val) => (
+                                        EventOutcome::Success,
+                                        Some(crate::cost_unit::resource_payload(
+                                            verb,
+                                            &gate_req.args,
+                                            ok_val,
+                                            || pack.registered_embedding_model_names().len() as i64,
+                                        )),
+                                    ),
+                                    Err(_) => (EventOutcome::Error, None),
                                 };
                                 let storage_event =
-                                    build_audit_storage_event(&gate_req, &audit, outcome)
+                                    build_audit_storage_event(&gate_req, &audit, outcome, resource)
                                         .with_duration_us(dispatch_us);
                                 append_audit_event_best_effort(store, storage_event, verb).await;
                             }
@@ -1359,7 +1410,7 @@ impl VerbRegistry {
                 // owns this verb), so the persisted outcome must be `Error`,
                 // not `Success`.
                 let storage_event =
-                    build_audit_storage_event(&gate_req, &audit, EventOutcome::Error);
+                    build_audit_storage_event(&gate_req, &audit, EventOutcome::Error, None);
                 append_audit_event_best_effort(store, storage_event, verb).await;
             }
         }
@@ -2000,15 +2051,27 @@ fn target_id_from_args(args: &serde_json::Value) -> Option<uuid::Uuid> {
 /// Shared by the immediate-append path (all verbs, denied calls, bulk
 /// `links`) and the deferred singleton-`link` fallback so both audit
 /// shapes are produced by one code path.
+///
+/// `resource` is the ADR-103 Amendment 1 `resource` payload object
+/// (`{"work_class": ..., "cost_unit": ...}`) — `Some` only for a
+/// successfully-resolved dispatch, `None` for denied calls, errored
+/// dispatches, and the no-pack-owns-this-verb case. `None` here is exactly
+/// how a row omits `resource.cost_unit` entirely, never a `0`.
 fn build_audit_storage_event(
     gate_req: &GateRequest,
     audit: &AuditEvent,
     outcome: EventOutcome,
+    resource: Option<Value>,
 ) -> Event {
-    let audit_data = serde_json::to_value(audit).unwrap_or_else(|e| {
+    let mut audit_data = serde_json::to_value(audit).unwrap_or_else(|e| {
         tracing::warn!(error = %e, "failed to serialize AuditEvent for EventStore");
         serde_json::Value::Null
     });
+    if let Some(resource) = resource {
+        if let Value::Object(ref mut map) = audit_data {
+            map.insert("resource".to_string(), resource);
+        }
+    }
     let mut storage_event = Event::new(
         gate_req.namespace.as_str(),
         gate_req.verb.as_str(),
@@ -4106,6 +4169,358 @@ mod tests {
             serde_json::Value::Array(Vec::new()),
             "obligations must be [] on AllowAllGate"
         );
+    }
+
+    // ---- ADR-103 Amendment 1: resource.cost_unit emission ----
+
+    /// Test pack whose `create` handler is a stub (mirrors `AlphaPack`) but
+    /// overrides `registered_embedding_model_names` to a configurable set,
+    /// exercising ADR-103 Amendment 1's `model_count` computation for
+    /// singleton `create` at the dispatch audit-row emission seam.
+    struct EmbeddingAwarePack {
+        models: Vec<String>,
+    }
+
+    impl khive_types::Pack for EmbeddingAwarePack {
+        const NAME: &'static str = "embedding_aware";
+        const NOTE_KINDS: &'static [&'static str] = &[];
+        const ENTITY_KINDS: &'static [&'static str] = &["widget"];
+        const HANDLERS: &'static [HandlerDef] = &[HandlerDef {
+            name: "create",
+            description: "create a widget (embedding-aware stub)",
+            visibility: Visibility::Verb,
+            category: VerbCategory::Commissive,
+            params: &[],
+        }];
+    }
+
+    #[async_trait]
+    impl PackRuntime for EmbeddingAwarePack {
+        fn name(&self) -> &str {
+            Self::NAME
+        }
+        fn note_kinds(&self) -> &'static [&'static str] {
+            Self::NOTE_KINDS
+        }
+        fn entity_kinds(&self) -> &'static [&'static str] {
+            Self::ENTITY_KINDS
+        }
+        fn handlers(&self) -> &'static [HandlerDef] {
+            Self::HANDLERS
+        }
+        fn registered_embedding_model_names(&self) -> Vec<String> {
+            self.models.clone()
+        }
+        async fn dispatch(
+            &self,
+            verb: &str,
+            _params: Value,
+            _registry: &VerbRegistry,
+            _token: &NamespaceToken,
+        ) -> Result<Value, RuntimeError> {
+            Ok(serde_json::json!({ "pack": "embedding_aware", "verb": verb }))
+        }
+    }
+
+    /// Test pack whose one verb, `probe`, always fails — used to drive the
+    /// general (non-link) deferred-audit Err arm without a real backend.
+    struct FailingProbePack;
+
+    impl khive_types::Pack for FailingProbePack {
+        const NAME: &'static str = "failing_probe";
+        const NOTE_KINDS: &'static [&'static str] = &[];
+        const ENTITY_KINDS: &'static [&'static str] = &[];
+        const HANDLERS: &'static [HandlerDef] = &[HandlerDef {
+            name: "probe",
+            description: "always fails",
+            visibility: Visibility::Verb,
+            category: VerbCategory::Assertive,
+            params: &[],
+        }];
+    }
+
+    #[async_trait]
+    impl PackRuntime for FailingProbePack {
+        fn name(&self) -> &str {
+            Self::NAME
+        }
+        fn note_kinds(&self) -> &'static [&'static str] {
+            Self::NOTE_KINDS
+        }
+        fn entity_kinds(&self) -> &'static [&'static str] {
+            Self::ENTITY_KINDS
+        }
+        fn handlers(&self) -> &'static [HandlerDef] {
+            Self::HANDLERS
+        }
+        async fn dispatch(
+            &self,
+            _verb: &str,
+            _params: Value,
+            _registry: &VerbRegistry,
+            _token: &NamespaceToken,
+        ) -> Result<Value, RuntimeError> {
+            Err(RuntimeError::InvalidInput("boom".into()))
+        }
+    }
+
+    #[tokio::test]
+    async fn resource_cost_unit_present_on_non_embedding_successful_dispatch() {
+        let store = Arc::new(MemoryEventStore::default());
+        let mut builder = VerbRegistryBuilder::new();
+        builder.register(AlphaPack);
+        builder.with_event_store(store.clone());
+        let reg = builder.build().expect("registry builds");
+
+        reg.dispatch("list", serde_json::json!({})).await.unwrap();
+
+        let page = store
+            .query_events(
+                EventFilter::default(),
+                PageRequest {
+                    limit: 10,
+                    offset: 0,
+                },
+            )
+            .await
+            .unwrap();
+        assert_eq!(page.items.len(), 1);
+        assert_eq!(
+            page.items[0].payload["resource"],
+            serde_json::json!({"work_class": "interactive", "cost_unit": 1}),
+            "non-embedding-bearing verb's resource.cost_unit must be base_weight(verb) alone"
+        );
+    }
+
+    #[tokio::test]
+    async fn resource_cost_unit_scales_with_registered_model_count_for_create() {
+        let store = Arc::new(MemoryEventStore::default());
+        let mut builder = VerbRegistryBuilder::new();
+        builder.register(EmbeddingAwarePack {
+            models: vec!["all-minilm-l6-v2".into(), "paraphrase".into()],
+        });
+        builder.with_event_store(store.clone());
+        let reg = builder.build().expect("registry builds");
+
+        reg.dispatch("create", serde_json::json!({"kind": "widget"}))
+            .await
+            .unwrap();
+
+        let page = store
+            .query_events(
+                EventFilter::default(),
+                PageRequest {
+                    limit: 10,
+                    offset: 0,
+                },
+            )
+            .await
+            .unwrap();
+        // base_weight(1) + per_item_weight(1) * item_count(1) * model_count(2)
+        assert_eq!(
+            page.items[0].payload["resource"],
+            serde_json::json!({"work_class": "interactive", "cost_unit": 3}),
+        );
+    }
+
+    #[tokio::test]
+    async fn resource_cost_unit_zero_registered_models_is_base_weight_only() {
+        let store = Arc::new(MemoryEventStore::default());
+        let mut builder = VerbRegistryBuilder::new();
+        builder.register(EmbeddingAwarePack { models: vec![] });
+        builder.with_event_store(store.clone());
+        let reg = builder.build().expect("registry builds");
+
+        reg.dispatch("create", serde_json::json!({"kind": "widget"}))
+            .await
+            .unwrap();
+
+        let page = store
+            .query_events(
+                EventFilter::default(),
+                PageRequest {
+                    limit: 10,
+                    offset: 0,
+                },
+            )
+            .await
+            .unwrap();
+        assert_eq!(
+            page.items[0].payload["resource"]["cost_unit"], 1,
+            "zero registered embedding models must vanish the term, not error or omit"
+        );
+    }
+
+    #[tokio::test]
+    async fn resource_omitted_when_dispatch_returns_error() {
+        let store = Arc::new(MemoryEventStore::default());
+        let mut builder = VerbRegistryBuilder::new();
+        builder.register(FailingProbePack);
+        builder.with_event_store(store.clone());
+        let reg = builder.build().expect("registry builds");
+
+        let err = reg
+            .dispatch("probe", serde_json::json!({}))
+            .await
+            .unwrap_err();
+        assert!(matches!(err, RuntimeError::InvalidInput(_)));
+
+        let page = store
+            .query_events(
+                EventFilter::default(),
+                PageRequest {
+                    limit: 10,
+                    offset: 0,
+                },
+            )
+            .await
+            .unwrap();
+        assert_eq!(page.items.len(), 1);
+        assert_eq!(page.items[0].outcome, EventOutcome::Error);
+        assert!(
+            page.items[0].payload.get("resource").is_none(),
+            "resource.cost_unit must be OMITTED entirely on an errored dispatch, never 0: {:?}",
+            page.items[0].payload
+        );
+    }
+
+    #[tokio::test]
+    async fn resource_omitted_when_no_pack_owns_the_verb() {
+        let store = Arc::new(MemoryEventStore::default());
+        let mut builder = VerbRegistryBuilder::new();
+        builder.register(AlphaPack);
+        builder.with_event_store(store.clone());
+        let reg = builder.build().expect("registry builds");
+
+        let _ = reg
+            .dispatch("no_such_verb_resource_test", serde_json::json!({}))
+            .await;
+
+        let page = store
+            .query_events(
+                EventFilter::default(),
+                PageRequest {
+                    limit: 10,
+                    offset: 0,
+                },
+            )
+            .await
+            .unwrap();
+        assert_eq!(page.items.len(), 1);
+        assert!(page.items[0].payload.get("resource").is_none());
+    }
+
+    #[tokio::test]
+    async fn resource_omitted_on_denied_dispatch() {
+        #[derive(Debug)]
+        struct AlwaysDenyGate;
+        impl Gate for AlwaysDenyGate {
+            fn check(&self, _req: &GateRequest) -> Result<GateDecision, GateError> {
+                Ok(GateDecision::deny("test: always deny"))
+            }
+        }
+        let store = Arc::new(MemoryEventStore::default());
+        let mut builder = VerbRegistryBuilder::new();
+        builder.register(AlphaPack);
+        builder.with_gate(Arc::new(AlwaysDenyGate));
+        builder.with_event_store(store.clone());
+        let reg = builder.build().expect("registry builds");
+
+        let _ = reg.dispatch("list", serde_json::json!({})).await;
+
+        let page = store
+            .query_events(
+                EventFilter::default(),
+                PageRequest {
+                    limit: 10,
+                    offset: 0,
+                },
+            )
+            .await
+            .unwrap();
+        assert_eq!(page.items.len(), 1);
+        assert_eq!(page.items[0].outcome, EventOutcome::Denied);
+        assert!(page.items[0].payload.get("resource").is_none());
+    }
+
+    #[tokio::test]
+    async fn resource_cost_unit_present_on_link_singleton_success() {
+        let store = Arc::new(MemoryEventStore::default());
+        let edge_id = uuid::Uuid::new_v4();
+        let source_id = uuid::Uuid::new_v4();
+        let target_id = uuid::Uuid::new_v4();
+        let edge_json = serde_json::json!({
+            "id": edge_id,
+            "namespace": "local",
+            "source_id": source_id,
+            "target_id": target_id,
+            "relation": "depends_on",
+            "weight": 1.0,
+        });
+        let mut builder = VerbRegistryBuilder::new();
+        builder.register(LinkResultPack::ok(edge_json));
+        builder.with_event_store(store.clone());
+        let reg = builder.build().expect("registry builds");
+
+        reg.dispatch(
+            "link",
+            serde_json::json!({
+                "source_id": source_id,
+                "target_id": target_id,
+                "relation": "depends_on",
+            }),
+        )
+        .await
+        .unwrap();
+
+        let page = store
+            .query_events(
+                EventFilter::default(),
+                PageRequest {
+                    limit: 10,
+                    offset: 0,
+                },
+            )
+            .await
+            .unwrap();
+        assert_eq!(
+            page.items[0].payload["resource"],
+            serde_json::json!({"work_class": "interactive", "cost_unit": 1}),
+            "link has no embedding-bearing path -> base_weight(link) alone, even on the v2-enriched singleton path"
+        );
+    }
+
+    #[tokio::test]
+    async fn resource_omitted_on_link_dispatch_failure() {
+        let store = Arc::new(MemoryEventStore::default());
+        let mut builder = VerbRegistryBuilder::new();
+        builder.register(LinkResultPack::err("target endpoint not found"));
+        builder.with_event_store(store.clone());
+        let reg = builder.build().expect("registry builds");
+
+        let _ = reg
+            .dispatch(
+                "link",
+                serde_json::json!({
+                    "source_id": "note:alpha",
+                    "target_id": "note:missing",
+                    "relation": "depends_on",
+                }),
+            )
+            .await;
+
+        let page = store
+            .query_events(
+                EventFilter::default(),
+                PageRequest {
+                    limit: 10,
+                    offset: 0,
+                },
+            )
+            .await
+            .unwrap();
+        assert_eq!(page.items.len(), 1);
+        assert!(page.items[0].payload.get("resource").is_none());
     }
 
     // Registry audit event must carry target_id when dispatch params include it.

--- a/crates/khive-runtime/src/pack.rs
+++ b/crates/khive-runtime/src/pack.rs
@@ -1105,11 +1105,16 @@ impl VerbRegistry {
                 // Persist to EventStore immediately only for denied calls.
                 if !defer_audit {
                     if let Some(store) = &self.event_store {
+                        // ADR-103 Decision (a): the closed `work_class` enum
+                        // is stamped on every event, denial included -- only
+                        // `resource.cost_unit` is scoped to a successful
+                        // dispatch by Amendment 1. `base_resource_payload()`
+                        // carries `work_class` alone, no `cost_unit` key.
                         let storage_event = build_audit_storage_event(
                             &gate_req,
                             &audit,
                             EventOutcome::Denied,
-                            None,
+                            Some(crate::cost_unit::base_resource_payload()),
                         );
                         append_audit_event_best_effort(store, storage_event, verb).await;
                     }
@@ -1306,7 +1311,12 @@ impl VerbRegistry {
                                 // amendment's "absence has exactly two
                                 // meanings" rule requires the field be
                                 // omitted, never defaulted to 0, on an
-                                // errored dispatch.
+                                // errored dispatch. `work_class` itself is
+                                // NOT one of those two omission cases
+                                // (ADR-103 Decision (a) stamps it on every
+                                // event), so an errored dispatch still gets
+                                // `resource: {"work_class": "interactive"}`,
+                                // just with no `cost_unit` key.
                                 let (outcome, resource) = match &result {
                                     Ok(ok_val) => (
                                         EventOutcome::Success,
@@ -1317,7 +1327,10 @@ impl VerbRegistry {
                                             || pack.registered_embedding_model_names().len() as i64,
                                         )),
                                     ),
-                                    Err(_) => (EventOutcome::Error, None),
+                                    Err(_) => (
+                                        EventOutcome::Error,
+                                        Some(crate::cost_unit::base_resource_payload()),
+                                    ),
                                 };
                                 let storage_event =
                                     build_audit_storage_event(&gate_req, &audit, outcome, resource)
@@ -1408,9 +1421,15 @@ impl VerbRegistry {
             if let Some(store) = &self.event_store {
                 // Dispatch is about to return `InvalidInput` below (no pack
                 // owns this verb), so the persisted outcome must be `Error`,
-                // not `Success`.
-                let storage_event =
-                    build_audit_storage_event(&gate_req, &audit, EventOutcome::Error, None);
+                // not `Success`. `work_class` is still stamped (ADR-103
+                // Decision (a)); `resource.cost_unit` is omitted, matching
+                // every other errored-dispatch row.
+                let storage_event = build_audit_storage_event(
+                    &gate_req,
+                    &audit,
+                    EventOutcome::Error,
+                    Some(crate::cost_unit::base_resource_payload()),
+                );
                 append_audit_event_best_effort(store, storage_event, verb).await;
             }
         }
@@ -2052,11 +2071,15 @@ fn target_id_from_args(args: &serde_json::Value) -> Option<uuid::Uuid> {
 /// `links`) and the deferred singleton-`link` fallback so both audit
 /// shapes are produced by one code path.
 ///
-/// `resource` is the ADR-103 Amendment 1 `resource` payload object
-/// (`{"work_class": ..., "cost_unit": ...}`) — `Some` only for a
-/// successfully-resolved dispatch, `None` for denied calls, errored
-/// dispatches, and the no-pack-owns-this-verb case. `None` here is exactly
-/// how a row omits `resource.cost_unit` entirely, never a `0`.
+/// `resource` is the ADR-103 `resource` payload object. ADR-103 Decision (a)
+/// stamps the closed `work_class` enum on every event, so every call site
+/// passes `Some`: `crate::cost_unit::resource_payload` (`{"work_class": ...,
+/// "cost_unit": ...}`) for a successfully-resolved dispatch, or
+/// `crate::cost_unit::base_resource_payload` (`{"work_class": ...}`, no
+/// `cost_unit` key) for denied calls, errored dispatches, and the
+/// no-pack-owns-this-verb case. `None` is reserved for a caller with no
+/// `work_class` to stamp at all (none exist today); it must never be used to
+/// omit `cost_unit` alone.
 fn build_audit_storage_event(
     gate_req: &GateRequest,
     audit: &AuditEvent,
@@ -4352,7 +4375,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn resource_omitted_when_dispatch_returns_error() {
+    async fn resource_work_class_present_cost_unit_absent_when_dispatch_returns_error() {
         let store = Arc::new(MemoryEventStore::default());
         let mut builder = VerbRegistryBuilder::new();
         builder.register(FailingProbePack);
@@ -4377,15 +4400,21 @@ mod tests {
             .unwrap();
         assert_eq!(page.items.len(), 1);
         assert_eq!(page.items[0].outcome, EventOutcome::Error);
-        assert!(
-            page.items[0].payload.get("resource").is_none(),
-            "resource.cost_unit must be OMITTED entirely on an errored dispatch, never 0: {:?}",
+        // ADR-103 Decision (a): work_class is stamped on EVERY event, denial
+        // and error included -- only Amendment 1's cost_unit field is scoped
+        // to a successful dispatch. An errored dispatch keeps
+        // resource.work_class and omits only resource.cost_unit, never 0.
+        assert_eq!(
+            page.items[0].payload["resource"],
+            serde_json::json!({"work_class": "interactive"}),
+            "resource must carry work_class with cost_unit OMITTED (never 0) on an \
+             errored dispatch: {:?}",
             page.items[0].payload
         );
     }
 
     #[tokio::test]
-    async fn resource_omitted_when_no_pack_owns_the_verb() {
+    async fn resource_work_class_present_cost_unit_absent_when_no_pack_owns_the_verb() {
         let store = Arc::new(MemoryEventStore::default());
         let mut builder = VerbRegistryBuilder::new();
         builder.register(AlphaPack);
@@ -4407,11 +4436,14 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(page.items.len(), 1);
-        assert!(page.items[0].payload.get("resource").is_none());
+        assert_eq!(
+            page.items[0].payload["resource"],
+            serde_json::json!({"work_class": "interactive"})
+        );
     }
 
     #[tokio::test]
-    async fn resource_omitted_on_denied_dispatch() {
+    async fn resource_work_class_present_cost_unit_absent_on_denied_dispatch() {
         #[derive(Debug)]
         struct AlwaysDenyGate;
         impl Gate for AlwaysDenyGate {
@@ -4440,7 +4472,10 @@ mod tests {
             .unwrap();
         assert_eq!(page.items.len(), 1);
         assert_eq!(page.items[0].outcome, EventOutcome::Denied);
-        assert!(page.items[0].payload.get("resource").is_none());
+        assert_eq!(
+            page.items[0].payload["resource"],
+            serde_json::json!({"work_class": "interactive"})
+        );
     }
 
     #[tokio::test]
@@ -4491,7 +4526,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn resource_omitted_on_link_dispatch_failure() {
+    async fn resource_work_class_present_cost_unit_absent_on_link_dispatch_failure() {
         let store = Arc::new(MemoryEventStore::default());
         let mut builder = VerbRegistryBuilder::new();
         builder.register(LinkResultPack::err("target endpoint not found"));
@@ -4520,7 +4555,10 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(page.items.len(), 1);
-        assert!(page.items[0].payload.get("resource").is_none());
+        assert_eq!(
+            page.items[0].payload["resource"],
+            serde_json::json!({"work_class": "interactive"})
+        );
     }
 
     // Registry audit event must carry target_id when dispatch params include it.

--- a/crates/khive-runtime/src/phase_events.rs
+++ b/crates/khive-runtime/src/phase_events.rs
@@ -1,0 +1,89 @@
+//! Shared helpers for ADR-103 phase-span event emission.
+//!
+//! `PhaseStarted` / `PhaseCompleted` / `PhaseCancelled` are ADR-094's
+//! additive `EventKind` mechanism, extended by ADR-103 Decision (c) for
+//! background work that is not itself a verb dispatch. `khive-pack-memory`'s
+//! ANN background-rebuild task (`ann.rs`) originated the emission and
+//! terminal-selection pattern this module lifts into a shared home so
+//! ADR-103 Amendment 1 Part 2's two daemon-startup embedder-warmup hooks
+//! (`KgPack::warm`, `KnowledgePack::warm`) can reuse it without duplicating
+//! either the event-append plumbing or the shutdown-cancellation
+//! classification.
+
+use crate::error::RuntimeError;
+use crate::runtime::{KhiveRuntime, NamespaceToken};
+use khive_storage::{Event, StorageError, SubstrateKind};
+
+/// True when `err` is the direct result of a `spawn_blocking` cancellation,
+/// e.g. a short-lived process (or daemon shutdown) tearing the runtime down
+/// mid-operation, rather than a genuine backend/driver failure.
+///
+/// Matches the concrete `tokio::task::JoinError` boxed inside
+/// `StorageError::Driver` (the shape `with_reader`/`with_writer` produce
+/// when their `spawn_blocking(...).await` is cut short) via a typed
+/// downcast, not a message substring, so a real driver/SQL error is never
+/// misclassified as benign.
+///
+/// Every ADR-103 phase-span emitter that must pick between `PhaseCompleted`
+/// and `PhaseCancelled` on a shutdown-adjacent error path uses this same
+/// check, so a benign shutdown is classified identically everywhere.
+pub fn is_benign_shutdown_cancellation(err: &RuntimeError) -> bool {
+    let RuntimeError::Storage(StorageError::Driver { source, .. }) = err else {
+        return false;
+    };
+    source
+        .downcast_ref::<tokio::task::JoinError>()
+        .is_some_and(tokio::task::JoinError::is_cancelled)
+}
+
+/// Append one ADR-103 phase-span event (`PhaseStarted` / `PhaseCompleted` /
+/// `PhaseCancelled`), logging and swallowing store/serialize failures.
+///
+/// Best-effort exactly like every other ADR-094/ADR-103 lifecycle-event
+/// emitter in this codebase: telemetry must never interrupt or slow the
+/// background phase it observes. `label` identifies the phase's owner in
+/// the audit trail (e.g. `"kg.embedder_warm"`): it is a fixed label, not a
+/// dispatched verb name, since no dispatch is happening.
+pub async fn emit_phase_event<P: serde::Serialize>(
+    rt: &KhiveRuntime,
+    token: &NamespaceToken,
+    label: &str,
+    kind: khive_types::EventKind,
+    payload: P,
+) {
+    // Best-effort exactly like ADR-094's other lifecycle-event emitters: a
+    // backend that cannot resolve an `EventStore` for this token's namespace
+    // is treated as an unconfigured audit sink, not an error to propagate.
+    let Ok(store) = rt.events(token) else {
+        return;
+    };
+    let payload_value = match serde_json::to_value(&payload) {
+        Ok(v) => v,
+        Err(e) => {
+            tracing::warn!(
+                error = %e,
+                event_kind = %kind.name(),
+                label,
+                "failed to serialize ADR-103 phase-span event payload"
+            );
+            return;
+        }
+    };
+    let actor = format!("{}:{}", token.actor().kind, token.actor().id);
+    let event = Event::new(
+        token.namespace().as_str(),
+        label,
+        kind,
+        SubstrateKind::Event,
+        actor,
+    )
+    .with_payload(payload_value);
+    if let Err(err) = store.append_event(event).await {
+        tracing::warn!(
+            error = %err,
+            event_kind = %kind.name(),
+            label,
+            "ADR-103 phase-span event append failed"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Implements ADR-103 Amendment 1 (`docs/adr/ADR-103-resource-attribution-model.md`,
merged to main via PR #918): emission of `resource.cost_unit` on every successful
verb dispatch's terminal audit event, plus phase-span attribution for the two
daemon-startup embedder-warmup hooks (`KgPack::warm`, `KnowledgePack::warm`) that
previously ran with zero observability.

This PR is emission only. `brain.event_counts` is intentionally NOT extended in
this PR (the amendment's Stage-2 read-path work is separate; the MCP-facing
description string for `event_counts` still correctly states `cost_unit` does not
exist on any payload yet at the time of writing, and needs a follow-up once this
merges).

## Part 1: `cost_unit` formula (`crates/khive-runtime/src/cost_unit.rs`, new file)

```
cost_unit = base_weight(verb) + per_item_weight(verb) x item_count x model_count
```

Computed with checked `i64` arithmetic: `checked_mul` at each product step,
`checked_add` for the final sum, clamping the WHOLE expression to `i64::MAX` on any
overflow rather than omitting the field, per Amendment 1 Part 1.

**Weight values (documented default, not invented):** the amendment commits only
to the formula's *shape* and to `per_item_weight(verb) = 0` for every verb outside
its closed embedding-bearing family. It leaves specific weight *magnitudes*
unspecified, describing them as "deterministic, hand-set constants ... fixed at
implementation time and not measured." This PR ships `base_weight = 1` uniformly
across every verb and `per_item_weight = 1` for every embedding-bearing verb, as
the documented default pending a dedicated per-verb weights table. No weight value
in this PR was invented beyond what the ADR explicitly left open; a follow-up issue
should track the weights table.

**Embedding-bearing verb classification (closed set, per the amendment):** `create`
(singleton only), `update`, `memory.remember`, `memory.recall`, `knowledge.search`,
`knowledge.compose`, `knowledge.index`. Everything else, including bulk
`create(items=[...])` (which intentionally skips embedding and backfills via a
separate `reindex` call, `operations.rs:4698-4709`) and `link` (no embedding-bearing
path, singleton or bulk), gets `base_weight` only, regardless of item/created count.

**`item_count`:**
- `create` singleton, `memory.remember`, `update`, `memory.recall`,
  `knowledge.search`, `knowledge.compose`: always `1`.
- `knowledge.index`: `result["total"]`, the full paged corpus count, never the
  internal `batch_size` chunking ceiling (`clamp(1, 1000)`, an embed-grouping page
  size, not the dispatch's total work).

**`model_count`:**
- `memory.remember` with an explicit `embedding_model` override: `1`, registry
  never consulted.
- `memory.remember` without an override, and singleton `create`: reads
  `PackRuntime::registered_embedding_model_names().len()` for the pack that owns
  the verb, evaluated lazily via `FnOnce` so every other dispatch never touches the
  embedder registry. Zero registered models is a valid result: the whole
  `per_item_weight x item_count x model_count` term vanishes and `cost_unit`
  reduces to `base_weight(verb)` alone.
- `update`, `memory.recall`, `knowledge.search`, `knowledge.compose`,
  `knowledge.index`: always `1` (a constant, single embedding call, never a
  fan-out), and never reads the registry.

New `PackRuntime::registered_embedding_model_names()` hook (default `Vec::new()`)
lets the dispatch loop query the pack that already owns the verb without needing a
separate runtime handle; overridden by `KgPack` and `MemoryPack`.

**Error/denied dispatches omit the `resource` object entirely** (not just
`cost_unit`), preserving the existing "absence has exactly two meanings"
convention the amendment states for `resource.cost_unit` specifically (a
pre-amendment event, or a dispatch that errored). Implementation decision: rather
than invent a third, unspecified payload shape (`resource.work_class` alone, no
`cost_unit`), this PR omits the whole object on any non-`Ok` dispatch outcome. This
mirrors `counts_by_work_class`'s existing absence-is-exclusion convention on the
read side.

## Part 2: warm-hook phase-span attribution

`KgPack::warm()` and `KnowledgePack::warm()` run at daemon construction / first
pack install, outside `dispatch()` entirely, so there is no caller-supplied token.
**Correction to my task briefing:** I was told this warm-hook attribution was
already shipped in the Stage-1 lineage (PR #732/#737) and not to re-implement it.
I verified this at source before writing any code (grepping both files for
`work_class`/`PhaseStarted`) and found neither hook had ANY phase-span emission
before this PR: only `khive-pack-memory/src/ann.rs`'s ANN-rebuild background task
had the pattern, which the ADR cites as the mechanism to *reuse*, not as evidence
the two `warm()` hooks already had it. This PR implements Part 2 fresh.

Both hooks now:
1. Mint a `NamespaceToken` via `runtime.authorize(Namespace::local())` (warn + skip
   telemetry, but still run the warmup, on mint failure).
2. Emit `PhaseStarted` (`work_class: "warm"`, `phase: "kg_embedder_warm"` /
   `"knowledge_embedder_warm"`, `corpus_size: None`).
3. Emit exactly one terminal event: `PhaseCancelled` if
   `is_benign_shutdown_cancellation` classifies the embed error as a
   `spawn_blocking` cancellation from shutdown, `PhaseCompleted` otherwise.

`KnowledgePack::warm()`'s span wraps *only* the configured-embedder branch's
spawned task body, not the unconditional `vamana::warm_known_snapshots` call above
it, so no phase event fires for a corpus with no embedder configured.

`is_benign_shutdown_cancellation` moved from `khive-pack-memory/src/ann.rs` (a
private fn) to a new `khive-runtime/src/phase_events.rs` (re-exported at the crate
root), so both new call sites reuse the exact same typed-downcast classification
`ann.rs` originated instead of duplicating it. `ann.rs`'s own 4 call sites
(including 3 existing unit tests) needed no changes beyond the import.

**Note on my task briefing's test list:** I was asked to pin "exactly-one-terminal-
event with cost_unit on warm hooks." Per the ADR, phase-span events (`PhaseStarted`
/ `PhaseCompleted` / `PhaseCancelled`) never carry `resource.cost_unit`; that field
is exclusive to the per-dispatch `Audit` event via `resource_payload`. Warm hooks
are background phase work, not a verb dispatch, so there is no `item_count`/
`model_count` to compute for them. The tests below pin exactly-one-terminal-event
as literally specified; they do not assert `cost_unit` on those events because the
ADR does not put it there.

## Tests

- `crates/khive-runtime/src/cost_unit.rs`: 17 unit tests covering formula
  arithmetic and overflow clamping, zero-model vanishing (both `create` and
  `memory.remember`), bulk-create base-only (small and 250-item batch),
  `knowledge.index` full-total vs. `batch_size` ceiling (including a missing-total
  default and an `i64::MAX` clamp case), `memory.remember` explicit-model override,
  and the constant-model-count verb family never touching the registry (asserted
  positively via a panicking `unreachable_model_count` closure).
- `crates/khive-runtime/src/pack.rs`: 8 new integration tests exercising the real
  dispatch path: resource present on non-embedding and embedding-scaling success,
  zero-registered-models base-only, resource omitted on dispatch error, on an
  unknown verb, on gate denial, and on both link-singleton success and failure.
- `crates/khive-pack-kg/src/dispatch.rs`:
  `kg_warm_emits_exactly_one_phase_started_and_one_terminal_event`, deterministic
  (in-memory runtime has no embedder configured, so `embed()` errors via the
  non-cancellation path and the terminal event is `PhaseCompleted`; the test
  asserts `completed + cancelled == 1` either way).
- `crates/khive-pack-knowledge/src/pack.rs` (new `mod tests`):
  `knowledge_warm_emits_no_phase_events_when_no_embedder_configured`, pinning the
  configured-only branch gating: zero phase events when no embedder is registered,
  proving `warm_known_snapshots` does not independently emit and the branch does
  not fire when unconfigured.

**Known coverage gap:** `KnowledgePack::warm()`'s *affirmative* path (embedder
configured, phase events actually emitted) is not covered by an automated test in
this PR. That branch fires inside a detached `tokio::spawn` with no
await-completion signal back to the caller, and building a reliable
non-flaky test for it (poll-with-timeout on the event store) was judged out of
scope for this PR's time budget given the deterministic negative test already pins
the gating logic that matters (the branch scoping bug this Part 2 work exists to
prevent). Filing a follow-up issue is recommended if affirmative-path coverage is
wanted.

## Gates (scoped to khive-runtime, khive-pack-kg, khive-pack-memory,
khive-pack-knowledge; run from `crates/` with
`CARGO_TARGET_DIR=/private/tmp/khive-shared-target`)

| Gate | Command | Result |
|---|---|---|
| check | `cargo check -p khive-runtime -p khive-pack-kg -p khive-pack-memory -p khive-pack-knowledge --all-targets` | exit 0 |
| test | `cargo test -p khive-runtime -p khive-pack-kg -p khive-pack-memory -p khive-pack-knowledge` | exit 0, 0 failed (all suites) |
| clippy | `cargo clippy -p khive-runtime -p khive-pack-kg -p khive-pack-memory -p khive-pack-knowledge --all-targets -- -D warnings` | exit 0 |
| fmt | `cargo fmt --all -- --check` | exit 0 |
| doc | `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps -p khive-runtime -p khive-pack-kg -p khive-pack-memory -p khive-pack-knowledge` | exit 0 |
| pre-commit | cargo fmt / cargo clippy / secrets scan hooks | all passed on commit |

## Test plan

- [x] `cargo test` scoped to the four touched crates: 0 failures
- [x] New `cost_unit.rs` tests pin the formula, clamping, and zero-model behavior
- [x] New `pack.rs` tests pin resource presence/omission across success/error/
      denied/link paths through the real dispatch loop
- [x] New warm-hook tests pin exactly-one-terminal-event (KgPack) and
      zero-events-when-unconfigured (KnowledgePack)
- [ ] Reviewer: confirm the base_weight=1/per_item_weight=1 default and the
      omit-the-whole-object-on-error decision are acceptable pending a weights-
      table follow-up ADR/issue

This PR stays in draft until codex review approves.
