### PR TITLE
feat(runtime): add atomic proposal create plans (#904)

### DIFF
--- a/crates/khive-db/src/stores/text.rs
+++ b/crates/khive-db/src/stores/text.rs
@@ -39,6 +39,40 @@ pub fn delete_document_statement(table: &str, namespace: &str, subject_id: Uuid)
     }
 }
 
+/// The exact `INSERT` half of `upsert_document_dml`'s delete-then-insert
+/// shape, for a given FTS table (same `table`-is-trusted caveat as
+/// `delete_document_statement` above). Used by `khive-runtime`'s atomic
+/// `AddEntity`/`AddNote` prepare (ADR-104) to write a freshly created
+/// record's FTS document inside the same transaction as its row insert —
+/// there is no pre-existing row to delete first, so callers pair this with
+/// `delete_document_statement` only when upsert (not plain insert) semantics
+/// are required.
+pub fn insert_document_statement(table: &str, document: &TextDocument) -> SqlStatement {
+    let tags_json = tags_to_json(&document.tags);
+    let metadata_json = document.metadata.as_ref().map(|v| v.to_string());
+    SqlStatement {
+        sql: format!(
+            "INSERT INTO {table} \
+             (subject_id, kind, title, body, tags, namespace, metadata, updated_at) \
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)"
+        ),
+        params: vec![
+            SqlValue::Text(document.subject_id.to_string()),
+            SqlValue::Text(document.kind.to_string()),
+            SqlValue::Text(document.title.clone().unwrap_or_default()),
+            SqlValue::Text(document.body.clone()),
+            SqlValue::Text(tags_json),
+            SqlValue::Text(document.namespace.clone()),
+            match metadata_json {
+                Some(m) => SqlValue::Text(m),
+                None => SqlValue::Null,
+            },
+            SqlValue::Integer(dt_to_micros(&document.updated_at)),
+        ],
+        label: Some(format!("fts-insert-{table}")),
+    }
+}
+
 /// Ensure the FTS5 virtual table for `table_key` exists.
 ///
 /// Used in tests to set up an in-memory FTS5 table without the full `StorageBackend`.

--- a/crates/khive-db/src/stores/text.rs
+++ b/crates/khive-db/src/stores/text.rs
@@ -39,14 +39,10 @@ pub fn delete_document_statement(table: &str, namespace: &str, subject_id: Uuid)
     }
 }
 
-/// The exact `INSERT` half of `upsert_document_dml`'s delete-then-insert
-/// shape, for a given FTS table (same `table`-is-trusted caveat as
-/// `delete_document_statement` above). Used by `khive-runtime`'s atomic
-/// `AddEntity`/`AddNote` prepare (ADR-104) to write a freshly created
-/// record's FTS document inside the same transaction as its row insert —
-/// there is no pre-existing row to delete first, so callers pair this with
-/// `delete_document_statement` only when upsert (not plain insert) semantics
-/// are required.
+/// Build the `INSERT` half of the FTS delete-then-insert upsert.
+///
+/// `table` must be a trusted, sanitized table name because SQL identifiers
+/// cannot be bound as parameters.
 pub fn insert_document_statement(table: &str, document: &TextDocument) -> SqlStatement {
     let tags_json = tags_to_json(&document.tags);
     let metadata_json = document.metadata.as_ref().map(|v| v.to_string());
@@ -658,39 +654,15 @@ fn upsert_document_dml(
     table: &str,
     document: &TextDocument,
 ) -> Result<(), rusqlite::Error> {
-    let namespace = &document.namespace;
-
-    let del_sql = format!(
-        "DELETE FROM {} WHERE namespace = ?1 AND subject_id = ?2",
-        table
-    );
-    conn.execute(
-        &del_sql,
-        rusqlite::params![namespace, document.subject_id.to_string()],
-    )?;
-
-    let ins_sql = format!(
-        "INSERT INTO {} \
-         (subject_id, kind, title, body, tags, namespace, metadata, updated_at) \
-         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
-        table
-    );
-    let tags_json = tags_to_json(&document.tags);
-    let metadata_json: Option<String> = document.metadata.as_ref().map(|v| v.to_string());
-
-    conn.execute(
-        &ins_sql,
-        rusqlite::params![
-            document.subject_id.to_string(),
-            document.kind.to_string(),
-            document.title.as_deref().unwrap_or(""),
-            document.body,
-            tags_json,
-            namespace,
-            metadata_json,
-            dt_to_micros(&document.updated_at),
-        ],
-    )?;
+    let statements = [
+        delete_document_statement(table, &document.namespace, document.subject_id),
+        insert_document_statement(table, document),
+    ];
+    for statement in statements {
+        let mut stmt = conn.prepare(&statement.sql)?;
+        bind_params(&mut stmt, &statement.params)?;
+        stmt.raw_execute()?;
+    }
     Ok(())
 }
 

--- a/crates/khive-pack-kg/src/apply_worker/tests.rs
+++ b/crates/khive-pack-kg/src/apply_worker/tests.rs
@@ -108,6 +108,186 @@ async fn seed_proposal_created_event(
 }
 
 #[tokio::test]
+async fn changeset_adapter_builds_atomic_plans_for_supported_proposal_writes() {
+    let (rt, tok) = setup();
+    ensure_schema(&rt).await;
+    let source = rt
+        .create_entity(&tok, "concept", None, "Source", None, None, vec![])
+        .await
+        .expect("create source");
+    let target = rt
+        .create_entity(&tok, "concept", None, "Target", None, None, vec![])
+        .await
+        .expect("create target");
+    let registry = build_registry(&rt);
+    let worker = ProposalApplyWorker::new(rt);
+
+    let cases = [
+        (
+            ProposalChangeset::AddEntity {
+                entity: EntityDraft {
+                    kind: "concept".to_string(),
+                    name: "PlannedEntity".to_string(),
+                    description: None,
+                    properties: None,
+                    tags: vec![],
+                },
+            },
+            "add_entity",
+        ),
+        (
+            ProposalChangeset::AddNote {
+                note: NoteDraft {
+                    kind: "observation".to_string(),
+                    name: None,
+                    content: "Planned note".to_string(),
+                    properties: None,
+                },
+            },
+            "add_note",
+        ),
+        (
+            ProposalChangeset::UpdateEntity {
+                id: Id128::from_u128(source.id.as_u128()),
+                patch: khive_types::ProposalEntityPatch {
+                    name: Some("UpdatedSource".to_string()),
+                    description: None,
+                    properties: None,
+                    tags: None,
+                },
+            },
+            "update",
+        ),
+        (
+            ProposalChangeset::AddEdge {
+                source: Id128::from_u128(source.id.as_u128()),
+                target: Id128::from_u128(target.id.as_u128()),
+                relation: khive_types::EdgeRelation::Extends,
+                weight: Some(0.8),
+            },
+            "link",
+        ),
+        (
+            ProposalChangeset::SupersedeEntity {
+                old: Id128::from_u128(source.id.as_u128()),
+                new: Id128::from_u128(target.id.as_u128()),
+            },
+            "link",
+        ),
+    ];
+
+    for (changeset, expected) in cases {
+        let prepared = worker
+            .prepare_changeset(&tok, &changeset, &registry, &mut WriteBudget::new(None))
+            .await
+            .expect("prepare changeset");
+        let super::worker::PreparedApply::Atomic { plans, .. } = prepared else {
+            panic!("expected atomic prepared apply for {expected}");
+        };
+        assert_eq!(plans.len(), 1);
+        let actual = match &plans[0] {
+            khive_runtime::AtomicOpPlan::AddEntity(_) => "add_entity",
+            khive_runtime::AtomicOpPlan::AddNote(_) => "add_note",
+            khive_runtime::AtomicOpPlan::Update(_) => "update",
+            khive_runtime::AtomicOpPlan::Link(_) => "link",
+            other => panic!("unexpected plan for {expected}: {other:?}"),
+        };
+        assert_eq!(actual, expected);
+    }
+}
+
+#[tokio::test]
+async fn apply_worker_atomic_update_preserves_explicit_description_clear() {
+    let (rt, tok) = setup();
+    ensure_schema(&rt).await;
+    let entity = rt
+        .create_entity(
+            &tok,
+            "concept",
+            None,
+            "ClearDescription",
+            Some("remove me"),
+            None,
+            vec![],
+        )
+        .await
+        .expect("create entity");
+    let proposal_id = Uuid::new_v4();
+    let changeset = ProposalChangeset::UpdateEntity {
+        id: Id128::from_u128(entity.id.as_u128()),
+        patch: khive_types::ProposalEntityPatch {
+            name: None,
+            description: Some(None),
+            properties: None,
+            tags: None,
+        },
+    };
+    seed_proposal_created_event(&rt, &tok, proposal_id, changeset).await;
+    insert_projection_row(&rt, &tok, proposal_id, "approved").await;
+
+    let registry = build_registry(&rt);
+    ProposalApplyWorker::new(rt.clone())
+        .maybe_apply(&tok, proposal_id, &registry, None)
+        .await
+        .expect("apply proposal");
+
+    let updated = rt
+        .get_entity(&tok, entity.id)
+        .await
+        .expect("get updated entity");
+    assert_eq!(updated.description, None);
+}
+
+#[tokio::test]
+async fn apply_worker_atomic_note_plan_commits_note_and_fts_document() {
+    let (rt, tok) = setup();
+    ensure_schema(&rt).await;
+    let proposal_id = Uuid::new_v4();
+    let changeset = ProposalChangeset::AddNote {
+        note: NoteDraft {
+            kind: "observation".to_string(),
+            name: Some("AtomicProposalNote".to_string()),
+            content: "Committed through the proposal plan".to_string(),
+            properties: None,
+        },
+    };
+    seed_proposal_created_event(&rt, &tok, proposal_id, changeset).await;
+    insert_projection_row(&rt, &tok, proposal_id, "approved").await;
+
+    let registry = build_registry(&rt);
+    ProposalApplyWorker::new(rt.clone())
+        .maybe_apply(&tok, proposal_id, &registry, None)
+        .await
+        .expect("apply proposal");
+
+    let notes = rt
+        .notes(&tok)
+        .expect("notes store")
+        .query_notes(
+            tok.namespace().as_str(),
+            None,
+            PageRequest {
+                offset: 0,
+                limit: 100,
+            },
+        )
+        .await
+        .expect("query notes");
+    let note = notes
+        .items
+        .iter()
+        .find(|note| note.name.as_deref() == Some("AtomicProposalNote"))
+        .expect("created note");
+    let document = rt
+        .text_for_notes(&tok)
+        .expect("note text store")
+        .get_document(tok.namespace().as_str(), note.id)
+        .await
+        .expect("get FTS document");
+    assert!(document.is_some());
+}
+
+#[tokio::test]
 async fn apply_worker_applies_add_edge_changeset() {
     let (rt, tok) = setup();
     ensure_schema(&rt).await;

--- a/crates/khive-pack-kg/src/apply_worker/worker.rs
+++ b/crates/khive-pack-kg/src/apply_worker/worker.rs
@@ -3,18 +3,43 @@
 use uuid::Uuid;
 
 use khive_runtime::{
+    atomic_prepare::{
+        apply_post_commit_effects, prepare_add_entity, prepare_add_note, prepare_op,
+        prepare_update_entity_plan,
+    },
     curation::{ContentMergeStrategy, EntityDedupMergePolicy, EntityPatch},
-    KhiveRuntime, NamespaceToken, RuntimeError, VerbRegistry,
+    AtomicOpPlan, AtomicRunOutcome, EdgeListFilter, KhiveRuntime, NamespaceToken, RuntimeError,
+    VerbRegistry,
 };
 use khive_storage::types::PageRequest;
 use khive_storage::{EdgeRelation, EventFilter};
 use khive_types::{
-    ApplyResult, EntityDraft, EventKind, Id128, NoteDraft, ProposalAppliedPayload,
-    ProposalChangeset, ProposalCreatedPayload, ProposalEntityPatch, Timestamp,
+    ApplyResult, EventKind, Id128, ProposalAppliedPayload, ProposalChangeset,
+    ProposalCreatedPayload, Timestamp,
 };
 
 use super::budget::{count_new_entries, has_multi_step_compound, WriteBudget};
 use crate::projection_worker::ProposalsProjectionWorker;
+
+pub(super) enum PreparedApply {
+    Atomic {
+        plans: Vec<AtomicOpPlan>,
+        created_records: Vec<PendingCreatedRecord>,
+    },
+    CanonicalMerge {
+        into_id: Uuid,
+        from_id: Uuid,
+    },
+}
+
+pub(super) enum PendingCreatedRecord {
+    Id(Uuid),
+    Edge {
+        source_id: Uuid,
+        target_id: Uuid,
+        relation: EdgeRelation,
+    },
+}
 
 /// Worker that applies approved proposal changesets.
 pub struct ProposalApplyWorker {
@@ -197,24 +222,103 @@ impl ProposalApplyWorker {
         Ok(payload.changeset)
     }
 
-    /// Apply a single changeset arm, or recursively for `Compound`. Box-pinned for recursion.
-    fn apply_changeset<'a>(
+    async fn apply_changeset(
+        &self,
+        token: &NamespaceToken,
+        changeset: &ProposalChangeset,
+        registry: &VerbRegistry,
+        budget: &mut WriteBudget,
+    ) -> Result<Vec<Uuid>, RuntimeError> {
+        match self
+            .prepare_changeset(token, changeset, registry, budget)
+            .await?
+        {
+            PreparedApply::Atomic {
+                plans,
+                created_records,
+            } => {
+                let outcome = khive_runtime::run_atomic_unit(self.runtime.sql().as_ref(), plans)
+                    .await
+                    .map_err(|error| RuntimeError::Storage(error.0))?;
+                match outcome {
+                    AtomicRunOutcome::Committed { post_commit } => {
+                        apply_post_commit_effects(&self.runtime, token, post_commit).await?;
+                        self.resolve_created_records(token, created_records).await
+                    }
+                    AtomicRunOutcome::RolledBack {
+                        failed_op_index,
+                        failure,
+                    } => Err(RuntimeError::Internal(format!(
+                        "atomic proposal apply rolled back at plan {failed_op_index}: {failure:?}"
+                    ))),
+                }
+            }
+            PreparedApply::CanonicalMerge { into_id, from_id } => {
+                self.runtime
+                    .merge_entity(
+                        token,
+                        into_id,
+                        from_id,
+                        EntityDedupMergePolicy::PreferInto,
+                        ContentMergeStrategy::Append,
+                        false,
+                    )
+                    .await?;
+                Ok(vec![])
+            }
+        }
+    }
+
+    pub(super) fn prepare_changeset<'a>(
         &'a self,
         token: &'a NamespaceToken,
         changeset: &'a ProposalChangeset,
         registry: &'a VerbRegistry,
         budget: &'a mut WriteBudget,
     ) -> std::pin::Pin<
-        Box<dyn std::future::Future<Output = Result<Vec<Uuid>, RuntimeError>> + Send + 'a>,
+        Box<dyn std::future::Future<Output = Result<PreparedApply, RuntimeError>> + Send + 'a>,
     > {
         Box::pin(async move {
             match changeset {
                 ProposalChangeset::AddEntity { entity } => {
-                    self.apply_add_entity(token, entity, registry, budget).await
+                    let kind =
+                        crate::handlers::canonical_entity_kind(entity.kind.as_str(), registry)?;
+                    budget.consume_new_entry()?;
+                    let args = serde_json::json!({
+                        "kind": kind,
+                        "name": entity.name,
+                        "description": entity.description,
+                        "properties": entity.properties,
+                        "tags": entity.tags,
+                    });
+                    let plan = prepare_add_entity(&self.runtime, token, &args).await?;
+                    let entity_id = match &plan {
+                        AtomicOpPlan::AddEntity(plan) => plan.entity_id,
+                        _ => unreachable!("prepare_add_entity returned a different plan variant"),
+                    };
+                    Ok(PreparedApply::Atomic {
+                        plans: vec![plan],
+                        created_records: vec![PendingCreatedRecord::Id(entity_id)],
+                    })
                 }
                 ProposalChangeset::UpdateEntity { id, patch } => {
-                    self.apply_update_entity(token, *id, patch).await?;
-                    Ok(vec![])
+                    let entity_id = Uuid::from_u128(id.to_u128());
+                    let plan = prepare_update_entity_plan(
+                        &self.runtime,
+                        token,
+                        entity_id,
+                        EntityPatch {
+                            name: patch.name.clone(),
+                            description: patch.description.clone(),
+                            properties: patch.properties.clone(),
+                            tags: patch.tags.clone(),
+                        },
+                    )
+                    .await?;
+                    Ok(PreparedApply::Atomic {
+                        plans: vec![plan],
+                        created_records: vec![],
+                    })
                 }
                 ProposalChangeset::AddEdge {
                     source,
@@ -222,168 +326,124 @@ impl ProposalApplyWorker {
                     relation,
                     weight,
                 } => {
-                    let edge_id = self
-                        .apply_add_edge(token, *source, *target, *relation, *weight)
-                        .await?;
-                    Ok(vec![edge_id])
+                    let source_id = Uuid::from_u128(source.to_u128());
+                    let target_id = Uuid::from_u128(target.to_u128());
+                    let relation = crate::handlers::parse_relation(relation.as_str())?;
+                    let args = serde_json::json!({
+                        "source_id": source_id,
+                        "target_id": target_id,
+                        "relation": relation.as_str(),
+                        "weight": weight.map(f64::from),
+                    });
+                    let plan = prepare_op(&self.runtime, token, "link", &args).await?;
+                    let (source_id, target_id) = match &plan {
+                        AtomicOpPlan::Link(plan) => (plan.source_id, plan.target_id),
+                        _ => unreachable!("link prepare returned a different plan variant"),
+                    };
+                    Ok(PreparedApply::Atomic {
+                        plans: vec![plan],
+                        created_records: vec![PendingCreatedRecord::Edge {
+                            source_id,
+                            target_id,
+                            relation,
+                        }],
+                    })
                 }
                 ProposalChangeset::AddNote { note } => {
-                    self.apply_add_note(token, note, registry, budget).await
+                    let kind =
+                        crate::handlers::canonical_note_kind(note.kind.as_str(), registry)?;
+                    budget.consume_new_entry()?;
+                    let args = serde_json::json!({
+                        "kind": kind,
+                        "name": note.name,
+                        "content": note.content,
+                        "properties": note.properties,
+                    });
+                    let plan = prepare_add_note(&self.runtime, token, &args).await?;
+                    let note_id = match &plan {
+                        AtomicOpPlan::AddNote(plan) => plan.note_id,
+                        _ => unreachable!("prepare_add_note returned a different plan variant"),
+                    };
+                    Ok(PreparedApply::Atomic {
+                        plans: vec![plan],
+                        created_records: vec![PendingCreatedRecord::Id(note_id)],
+                    })
                 }
                 ProposalChangeset::MergeEntities { into, from } => {
-                    self.apply_merge_entities(token, *into, *from).await?;
-                    Ok(vec![])
+                    Ok(PreparedApply::CanonicalMerge {
+                        into_id: Uuid::from_u128(into.to_u128()),
+                        from_id: Uuid::from_u128(from.to_u128()),
+                    })
                 }
                 ProposalChangeset::SupersedeEntity { old, new } => {
-                    self.apply_supersede_entity(token, *old, *new).await?;
-                    Ok(vec![])
+                    let old_id = Uuid::from_u128(old.to_u128());
+                    let new_id = Uuid::from_u128(new.to_u128());
+                    let args = serde_json::json!({
+                        "source_id": new_id,
+                        "target_id": old_id,
+                        "relation": EdgeRelation::Supersedes.as_str(),
+                    });
+                    let plan = prepare_op(&self.runtime, token, "link", &args).await?;
+                    Ok(PreparedApply::Atomic {
+                        plans: vec![plan],
+                        created_records: vec![],
+                    })
                 }
-                ProposalChangeset::Compound { steps } => {
-                    let mut all_created = Vec::new();
-                    for step in steps {
-                        let created = self.apply_changeset(token, step, registry, budget).await?;
-                        all_created.extend(created);
-                    }
-                    Ok(all_created)
-                }
+                ProposalChangeset::Compound { steps } => match steps.as_slice() {
+                    [] => Ok(PreparedApply::Atomic {
+                        plans: vec![],
+                        created_records: vec![],
+                    }),
+                    [step] => self.prepare_changeset(token, step, registry, budget).await,
+                    _ => Err(RuntimeError::InvalidInput(
+                        "multi-step Compound proposals are not supported until atomic proposal apply is available"
+                            .to_string(),
+                    )),
+                },
             }
         })
     }
 
-    /// Apply `AddEntity`: create the entity from the structured draft.
-    async fn apply_add_entity(
+    async fn resolve_created_records(
         &self,
         token: &NamespaceToken,
-        draft: &EntityDraft,
-        registry: &VerbRegistry,
-        budget: &mut WriteBudget,
+        records: Vec<PendingCreatedRecord>,
     ) -> Result<Vec<Uuid>, RuntimeError> {
-        let kind = crate::handlers::canonical_entity_kind(draft.kind.as_str(), registry)?;
-        if draft.name.trim().is_empty() {
-            return Err(RuntimeError::InvalidInput("name must not be empty".into()));
+        let mut ids = Vec::with_capacity(records.len());
+        for record in records {
+            match record {
+                PendingCreatedRecord::Id(id) => ids.push(id),
+                PendingCreatedRecord::Edge {
+                    source_id,
+                    target_id,
+                    relation,
+                } => {
+                    let edge = self
+                        .runtime
+                        .list_edges(
+                            token,
+                            EdgeListFilter {
+                                source_id: Some(source_id),
+                                target_id: Some(target_id),
+                                relations: vec![relation],
+                                ..Default::default()
+                            },
+                            1,
+                            0,
+                        )
+                        .await?
+                        .into_iter()
+                        .next()
+                        .ok_or_else(|| {
+                            RuntimeError::Internal(
+                                "committed proposal edge was not found by natural key".to_string(),
+                            )
+                        })?;
+                    ids.push(edge.id.0);
+                }
+            }
         }
-        budget.consume_new_entry()?;
-        let entity = self
-            .runtime
-            .create_entity(
-                token,
-                kind.as_str(),
-                None,
-                draft.name.as_str(),
-                draft.description.as_deref(),
-                draft.properties.clone(),
-                draft.tags.clone(),
-            )
-            .await?;
-        Ok(vec![entity.id])
-    }
-
-    /// Apply `UpdateEntity`: apply the structured patch to the entity.
-    async fn apply_update_entity(
-        &self,
-        token: &NamespaceToken,
-        id: Id128,
-        proposal_patch: &ProposalEntityPatch,
-    ) -> Result<(), RuntimeError> {
-        let entity_id = Uuid::from_u128(id.to_u128());
-        let patch = EntityPatch {
-            name: proposal_patch.name.clone(),
-            description: proposal_patch.description.clone(),
-            properties: proposal_patch.properties.clone(),
-            tags: proposal_patch.tags.clone(),
-        };
-        self.runtime.update_entity(token, entity_id, patch).await?;
-        Ok(())
-    }
-
-    /// Apply `AddEdge`: link source→target with the given relation.
-    async fn apply_add_edge(
-        &self,
-        token: &NamespaceToken,
-        source: Id128,
-        target: Id128,
-        relation: khive_types::EdgeRelation,
-        weight: Option<f32>,
-    ) -> Result<Uuid, RuntimeError> {
-        let source_id = Uuid::from_u128(source.to_u128());
-        let target_id = Uuid::from_u128(target.to_u128());
-        let storage_relation = crate::handlers::parse_relation(relation.as_str())?;
-        let edge = self
-            .runtime
-            .link(
-                token,
-                source_id,
-                target_id,
-                storage_relation,
-                weight.unwrap_or(1.0) as f64,
-                None,
-            )
-            .await?;
-        Ok(edge.id.0)
-    }
-
-    /// Apply `AddNote`: create the note from the structured draft.
-    async fn apply_add_note(
-        &self,
-        token: &NamespaceToken,
-        draft: &NoteDraft,
-        registry: &VerbRegistry,
-        budget: &mut WriteBudget,
-    ) -> Result<Vec<Uuid>, RuntimeError> {
-        let kind = draft.kind.as_str();
-        let canonical_kind = crate::handlers::canonical_note_kind(kind, registry)?;
-        budget.consume_new_entry()?;
-        let note = self
-            .runtime
-            .create_note(
-                token,
-                &canonical_kind,
-                draft.name.as_deref(),
-                draft.content.as_str(),
-                None,
-                draft.properties.clone(),
-                vec![],
-            )
-            .await?;
-        Ok(vec![note.id])
-    }
-
-    /// Apply `MergeEntities`: merge `from` into `into`.
-    async fn apply_merge_entities(
-        &self,
-        token: &NamespaceToken,
-        into: Id128,
-        from: Id128,
-    ) -> Result<(), RuntimeError> {
-        let into_id = Uuid::from_u128(into.to_u128());
-        let from_id = Uuid::from_u128(from.to_u128());
-        self.runtime
-            .merge_entity(
-                token,
-                into_id,
-                from_id,
-                EntityDedupMergePolicy::PreferInto,
-                ContentMergeStrategy::Append,
-                false,
-            )
-            .await?;
-        Ok(())
-    }
-
-    /// Apply `SupersedeEntity`: add a `supersedes` edge from `new` → `old`.
-    async fn apply_supersede_entity(
-        &self,
-        token: &NamespaceToken,
-        old: Id128,
-        new: Id128,
-    ) -> Result<(), RuntimeError> {
-        let old_id = Uuid::from_u128(old.to_u128());
-        let new_id = Uuid::from_u128(new.to_u128());
-        let relation = EdgeRelation::Supersedes;
-        self.runtime
-            .link(token, new_id, old_id, relation, 1.0, None)
-            .await?;
-        Ok(())
+        Ok(ids)
     }
 
     /// Emit a `ProposalApplied` event with a success result.

--- a/crates/khive-runtime/src/atomic_plan.rs
+++ b/crates/khive-runtime/src/atomic_plan.rs
@@ -196,6 +196,42 @@ pub struct UpdatePlan {
     pub edge_natural_key: Option<EdgeNaturalKey>,
 }
 
+/// Write plan for an `AddEntity` op (ADR-046 proposal changeset / ADR-104
+/// atomic create): a fresh entity row plus its FTS document, both inside the
+/// atomic unit. Canonical `create_entity` appends no event and this plan
+/// matches that — the only deferred work is vector embedding
+/// (`post_commit`), which needs a suspending model call and so cannot run
+/// inside the transaction (ADR-104, C-ADR-014 §3 item 3).
+#[derive(Debug, Clone)]
+pub struct AddEntityPlan {
+    /// The freshly generated id of the entity being created.
+    pub entity_id: Uuid,
+    /// Row + FTS insert statements to apply inside the atomic unit, in
+    /// order. The row-insert statement carries the existence guard; the
+    /// FTS-insert statement that follows it is unguarded (an ordinary
+    /// `INSERT` into a virtual table with no conflicting row).
+    pub statements: Vec<PlanStatement>,
+    /// Always `ReindexEntity` — a created entity's vector row(s) are written
+    /// post-commit from the now-committed row content, the same shape
+    /// `update`'s text-changed case already uses.
+    pub post_commit: PostCommitEffect,
+}
+
+/// Write plan for an `AddNote` op (ADR-046 proposal changeset / ADR-104
+/// atomic create): a fresh note row plus its FTS document, both inside the
+/// atomic unit. Mirrors [`AddEntityPlan`]; canonical `create_note` likewise
+/// appends no event.
+#[derive(Debug, Clone)]
+pub struct AddNotePlan {
+    /// The freshly generated id of the note being created.
+    pub note_id: Uuid,
+    /// Row + FTS insert statements to apply inside the atomic unit, in
+    /// order, mirroring [`AddEntityPlan::statements`].
+    pub statements: Vec<PlanStatement>,
+    /// Always `ReindexNote` — mirrors [`AddEntityPlan::post_commit`].
+    pub post_commit: PostCommitEffect,
+}
+
 /// Write plan for a `delete` op (soft or hard).
 #[derive(Debug, Clone)]
 pub struct DeletePlan {
@@ -521,6 +557,43 @@ mod tests {
             assert_eq!(plan.op, op);
             assert!(plan.statements[0].guard.is_some());
         }
+    }
+
+    #[test]
+    fn add_entity_plan_guard_is_anchored_to_the_row_statement_not_the_fts_mirror() {
+        let id = Uuid::new_v4();
+        let plan = AddEntityPlan {
+            entity_id: id,
+            statements: vec![
+                guarded("entity-insert", AffectedRowGuard::exactly(1)),
+                unguarded("entity-fts-insert"),
+            ],
+            post_commit: PostCommitEffect::ReindexEntity { entity_id: id },
+        };
+        assert_eq!(plan.entity_id, id);
+        assert_eq!(plan.statements[0].guard, Some(AffectedRowGuard::exactly(1)));
+        assert_eq!(plan.statements[1].guard, None);
+        assert_eq!(
+            plan.post_commit,
+            PostCommitEffect::ReindexEntity { entity_id: id }
+        );
+    }
+
+    #[test]
+    fn add_note_plan_guard_is_anchored_to_the_row_statement_not_the_fts_mirror() {
+        let id = Uuid::new_v4();
+        let plan = AddNotePlan {
+            note_id: id,
+            statements: vec![
+                guarded("note-insert", AffectedRowGuard::exactly(1)),
+                unguarded("note-fts-insert"),
+            ],
+            post_commit: PostCommitEffect::ReindexNote { note_id: id },
+        };
+        assert_eq!(plan.note_id, id);
+        assert_eq!(plan.statements[0].guard, Some(AffectedRowGuard::exactly(1)));
+        assert_eq!(plan.statements[1].guard, None);
+        assert_eq!(plan.post_commit, PostCommitEffect::ReindexNote { note_id: id });
     }
 
     #[test]

--- a/crates/khive-runtime/src/atomic_plan.rs
+++ b/crates/khive-runtime/src/atomic_plan.rs
@@ -196,12 +196,9 @@ pub struct UpdatePlan {
     pub edge_natural_key: Option<EdgeNaturalKey>,
 }
 
-/// Write plan for an `AddEntity` op (ADR-046 proposal changeset / ADR-104
-/// atomic create): a fresh entity row plus its FTS document, both inside the
-/// atomic unit. Canonical `create_entity` appends no event and this plan
-/// matches that — the only deferred work is vector embedding
-/// (`post_commit`), which needs a suspending model call and so cannot run
-/// inside the transaction (ADR-104, C-ADR-014 §3 item 3).
+/// Write plan for an `AddEntity` proposal change: a fresh entity row plus its
+/// FTS document in the same atomic unit. Vector indexing remains a deferred
+/// effect because embedding may suspend.
 #[derive(Debug, Clone)]
 pub struct AddEntityPlan {
     /// The freshly generated id of the entity being created.
@@ -211,16 +208,12 @@ pub struct AddEntityPlan {
     /// FTS-insert statement that follows it is unguarded (an ordinary
     /// `INSERT` into a virtual table with no conflicting row).
     pub statements: Vec<PlanStatement>,
-    /// Always `ReindexEntity` — a created entity's vector row(s) are written
-    /// post-commit from the now-committed row content, the same shape
-    /// `update`'s text-changed case already uses.
+    /// Reindex the committed entity after the transaction closes.
     pub post_commit: PostCommitEffect,
 }
 
-/// Write plan for an `AddNote` op (ADR-046 proposal changeset / ADR-104
-/// atomic create): a fresh note row plus its FTS document, both inside the
-/// atomic unit. Mirrors [`AddEntityPlan`]; canonical `create_note` likewise
-/// appends no event.
+/// Write plan for an `AddNote` proposal change: a fresh note row plus its FTS
+/// document in the same atomic unit.
 #[derive(Debug, Clone)]
 pub struct AddNotePlan {
     /// The freshly generated id of the note being created.
@@ -228,7 +221,7 @@ pub struct AddNotePlan {
     /// Row + FTS insert statements to apply inside the atomic unit, in
     /// order, mirroring [`AddEntityPlan::statements`].
     pub statements: Vec<PlanStatement>,
-    /// Always `ReindexNote` — mirrors [`AddEntityPlan::post_commit`].
+    /// Reindex the committed note after the transaction closes.
     pub post_commit: PostCommitEffect,
 }
 
@@ -593,7 +586,10 @@ mod tests {
         assert_eq!(plan.note_id, id);
         assert_eq!(plan.statements[0].guard, Some(AffectedRowGuard::exactly(1)));
         assert_eq!(plan.statements[1].guard, None);
-        assert_eq!(plan.post_commit, PostCommitEffect::ReindexNote { note_id: id });
+        assert_eq!(
+            plan.post_commit,
+            PostCommitEffect::ReindexNote { note_id: id }
+        );
     }
 
     #[test]

--- a/crates/khive-runtime/src/atomic_prepare.rs
+++ b/crates/khive-runtime/src/atomic_prepare.rs
@@ -1,9 +1,11 @@
 //! ADR-099: the per-verb async prepare pass for the KG-substrate v1
-//! admissible verbs (`update`, `delete`, `link`, `merge`). Each `prepare_*`
-//! function reads current state (async, outside any transaction) and
-//! returns a plain-data [`crate::atomic_runner::AtomicOpPlan`]
-//! ([`crate::atomic_plan`]) for the synchronous commit pass
-//! ([`crate::atomic_runner::run_atomic_unit`]) to apply.
+//! admissible verbs (`update`, `delete`, `link`, `merge`), plus (ADR-104)
+//! [`prepare_add_entity`]/[`prepare_add_note`] for the ADR-046 proposal
+//! changeset `AddEntity`/`AddNote` arms. Each `prepare_*` function reads
+//! current state (async, outside any transaction) and returns a plain-data
+//! [`crate::atomic_runner::AtomicOpPlan`] ([`crate::atomic_plan`]) for the
+//! synchronous commit pass ([`crate::atomic_runner::run_atomic_unit`]) to
+//! apply.
 //!
 //! `gtd.transition` / `gtd.complete` prepare is deliberately **not** here:
 //! their lifecycle vocabulary (`is_terminal`, `can_transition`, ...) lives in
@@ -42,10 +44,11 @@ use khive_storage::{EdgeRelation, SqlStatement};
 use khive_types::{EventKind, SubstrateKind};
 
 use crate::atomic_plan::{
-    AffectedRowGuard, DeletePlan, EdgeNaturalKey, LinkPlan, MergePlan, PlanStatement,
-    PostCommitEffect, UpdatePlan,
+    AddEntityPlan, AddNotePlan, AffectedRowGuard, DeletePlan, EdgeNaturalKey, LinkPlan, MergePlan,
+    PlanStatement, PostCommitEffect, UpdatePlan,
 };
 use crate::atomic_runner::AtomicOpPlan;
+use crate::curation::{entity_fts_document, note_fts_document};
 use crate::error::{RuntimeError, RuntimeResult};
 use crate::operations::{
     canonical_edge_endpoints, merge_dependency_kind, validate_edge_metadata, validate_edge_weight,
@@ -66,6 +69,7 @@ use khive_db::stores::graph::{
 use khive_db::stores::note::{
     note_hard_delete_statement, note_soft_delete_statement, note_upsert_statement,
 };
+use khive_db::stores::text::insert_document_statement;
 
 // ---------------------------------------------------------------------------
 // arg extraction helpers
@@ -403,6 +407,128 @@ fn prepare_governance_unimplemented(tool: &str) -> RuntimeResult<AtomicOpPlan> {
          prepare for it is tracked as ADR-099 follow-up work, not implemented \
          in slice B3. No write was attempted."
     )))
+}
+
+// ---------------------------------------------------------------------------
+// create (AddEntity / AddNote — ADR-104, alongside the update/delete/link/
+// merge plans above)
+// ---------------------------------------------------------------------------
+
+/// Build the prepared plan for creating an entity (ADR-046 proposal
+/// changeset `AddEntity`). Mirrors `KhiveRuntime::create_entity`'s
+/// validation and row shape exactly, up to the point where canonical fans
+/// out to embedding: the FTS document is written inside the transaction
+/// (same SQLite database, same writer connection — C-ADR-014 §3 item 2),
+/// but vector materialization is deferred to `PostCommitEffect::
+/// ReindexEntity`, since embedding needs a suspending model call and the
+/// atomic unit permits none (C-ADR-014 §3 item 3). `kind` is expected
+/// already canonicalized by the caller — the same split `prepare_update`/
+/// `prepare_delete` use: pack-aware kind resolution needs a `VerbRegistry`,
+/// unreachable from this crate.
+pub async fn prepare_add_entity(
+    runtime: &KhiveRuntime,
+    token: &NamespaceToken,
+    args: &Value,
+) -> RuntimeResult<AtomicOpPlan> {
+    let kind = require_str(args, "kind")?;
+    let name = require_str(args, "name")?;
+    runtime.validate_entity_kind(kind)?;
+
+    let description = optional_str(args, "description").map(str::to_string);
+    let properties = optional_properties(args, "properties")?;
+    let tags = optional_tags(args)?.unwrap_or_default();
+
+    crate::secret_gate::check(name)?;
+    if let Some(ref d) = description {
+        crate::secret_gate::check(d)?;
+    }
+    if let Some(ref p) = properties {
+        crate::secret_gate::check_json(p)?;
+    }
+    crate::secret_gate::check_tags(&tags)?;
+
+    let ns = token.namespace().as_str();
+    let mut entity = khive_storage::Entity::new(ns, kind, name);
+    if let Some(d) = description {
+        entity = entity.with_description(d);
+    }
+    if let Some(p) = properties {
+        entity = entity.with_properties(p);
+    }
+    if !tags.is_empty() {
+        entity = entity.with_tags(tags);
+    }
+
+    let statements = vec![
+        PlanStatement {
+            statement: entity_upsert_statement(&entity),
+            guard: Some(AffectedRowGuard::exactly(1)),
+        },
+        PlanStatement {
+            statement: insert_document_statement("fts_entities", &entity_fts_document(&entity)),
+            guard: None,
+        },
+    ];
+
+    Ok(AtomicOpPlan::AddEntity(AddEntityPlan {
+        entity_id: entity.id,
+        statements,
+        post_commit: PostCommitEffect::ReindexEntity {
+            entity_id: entity.id,
+        },
+    }))
+}
+
+/// Build the prepared plan for creating a note (ADR-046 proposal changeset
+/// `AddNote`). Mirrors [`prepare_add_entity`]'s shape and the same
+/// `kind`-already-canonicalized split. `annotates` is out of scope: the
+/// proposal `NoteDraft` this backs carries no annotates targets, unlike
+/// `KhiveRuntime::create_note`'s general-purpose signature.
+pub async fn prepare_add_note(
+    runtime: &KhiveRuntime,
+    token: &NamespaceToken,
+    args: &Value,
+) -> RuntimeResult<AtomicOpPlan> {
+    let kind = require_str(args, "kind")?;
+    let content = require_str(args, "content")?;
+    runtime.validate_note_kind(kind)?;
+
+    let name = optional_str(args, "name").map(str::to_string);
+    let properties = optional_properties(args, "properties")?;
+
+    crate::secret_gate::check(content)?;
+    if let Some(ref n) = name {
+        crate::secret_gate::check(n)?;
+    }
+    if let Some(ref p) = properties {
+        crate::secret_gate::check_json(p)?;
+    }
+
+    let ns = token.namespace().as_str();
+    let mut note = khive_storage::note::Note::new(ns, kind, content);
+    if let Some(n) = name {
+        note = note.with_name(n);
+    }
+    if let Some(p) = properties {
+        note = note.with_properties(p);
+    }
+
+    let statements = vec![
+        PlanStatement {
+            statement: note_upsert_statement(&note),
+            guard: Some(AffectedRowGuard::exactly(1)),
+        },
+        PlanStatement {
+            statement: insert_document_statement("fts_notes", &note_fts_document(&note)),
+            guard: None,
+        },
+    ];
+
+    Ok(AtomicOpPlan::AddNote(AddNotePlan {
+        note_id: note.id,
+        statements,
+        post_commit: PostCommitEffect::ReindexNote { note_id: note.id },
+    }))
 }
 
 // ---------------------------------------------------------------------------
@@ -3120,5 +3246,253 @@ mod tests {
             "link must append no event; found: {:?}",
             page.items
         );
+    }
+
+    // ------------------------------------------------------------------
+    // ADR-104: AddEntity / AddNote plans, alongside update/delete/link
+    // ------------------------------------------------------------------
+
+    /// Acceptance criterion (issue #904): a `create + edge + note` plan
+    /// commits the entity, the edge, the note, AND their FTS documents
+    /// together — one `run_atomic_unit` call, one SQLite transaction (the
+    /// FTS insert statements `prepare_add_entity`/`prepare_add_note` build
+    /// are applied inside the SAME unit as the row inserts, not deferred).
+    /// Vector materialization is the one piece of work post-commit
+    /// (`PostCommitEffect::ReindexEntity`/`ReindexNote`), since embedding
+    /// needs a suspending model call.
+    #[tokio::test]
+    async fn atomic_add_entity_link_add_note_plan_commits_entity_edge_note_and_fts_together() {
+        let runtime = scratch_runtime();
+        runtime.register_embedder(StubProvider);
+        let token = runtime
+            .authorize(Namespace::parse("local").expect("ns"))
+            .expect("authorize");
+        let entities = runtime.entities(&token).expect("entities store");
+        let a = khive_storage::Entity::new("local", "concept", "Adr104LinkA");
+        let b = khive_storage::Entity::new("local", "concept", "Adr104LinkB");
+        let (a_id, b_id) = (a.id, b.id);
+        entities.upsert_entity(a).await.expect("seed a");
+        entities.upsert_entity(b).await.expect("seed b");
+
+        let add_entity_plan = prepare_add_entity(
+            &runtime,
+            &token,
+            &json!({"kind": "concept", "name": "Adr104NewEntity", "description": "created atomically"}),
+        )
+        .await
+        .expect("prepare add_entity");
+        let link_plan = prepare_link(
+            &runtime,
+            &token,
+            &json!({"source_id": a_id.to_string(), "target_id": b_id.to_string(), "relation": "extends"}),
+        )
+        .await
+        .expect("prepare link");
+        let add_note_plan = prepare_add_note(
+            &runtime,
+            &token,
+            &json!({"kind": "observation", "content": "created atomically alongside the entity"}),
+        )
+        .await
+        .expect("prepare add_note");
+
+        let entity_id = match &add_entity_plan {
+            AtomicOpPlan::AddEntity(p) => p.entity_id,
+            other => panic!("expected an AddEntity plan, got {other:?}"),
+        };
+        let note_id = match &add_note_plan {
+            AtomicOpPlan::AddNote(p) => p.note_id,
+            other => panic!("expected an AddNote plan, got {other:?}"),
+        };
+
+        let outcome = crate::atomic_runner::run_atomic_unit(
+            runtime.sql().as_ref(),
+            vec![add_entity_plan, link_plan, add_note_plan],
+        )
+        .await
+        .expect("seam call ok");
+        let post_commit = match outcome {
+            crate::atomic_runner::AtomicRunOutcome::Committed { post_commit } => post_commit,
+            other => panic!("expected the whole unit to commit: {other:?}"),
+        };
+        apply_post_commit_effects(&runtime, &token, post_commit)
+            .await
+            .expect("apply post-commit effects");
+
+        let entity = runtime
+            .get_entity(&token, entity_id)
+            .await
+            .expect("get_entity")
+            .expect("entity must exist after commit");
+        assert_eq!(entity.name, "Adr104NewEntity");
+        assert!(
+            runtime
+                .text(&token)
+                .expect("text store")
+                .get_document("local", entity_id)
+                .await
+                .expect("get_document")
+                .is_some(),
+            "entity's FTS document must exist after commit"
+        );
+
+        let (edge_count, _, _, edge_deleted_at) =
+            probe_edge_natural_key(&runtime, "local", a_id, b_id, "extends").await;
+        assert_eq!(edge_count, 1, "the edge must be committed alongside the entity/note");
+        assert!(edge_deleted_at.is_none());
+
+        let note = runtime
+            .get_note(&token, note_id)
+            .await
+            .expect("get_note")
+            .expect("note must exist after commit");
+        assert_eq!(note.content, "created atomically alongside the entity");
+        assert!(
+            runtime
+                .text_for_notes(&token)
+                .expect("text store")
+                .get_document("local", note_id)
+                .await
+                .expect("get_document")
+                .is_some(),
+            "note's FTS document must exist after commit"
+        );
+
+        let vec_store = runtime
+            .vectors_for_model(&token, STUB_MODEL)
+            .expect("vec store");
+        assert_eq!(
+            vec_store.count().await.expect("count after"),
+            2,
+            "post-commit reindex must have embedded both the new entity and the new note"
+        );
+    }
+
+    /// Acceptance criterion (issue #904): a failing later SQL/validation
+    /// guard restores the pre-run SQLite AND FTS state. Plan:
+    /// `[AddEntity(C), AddNote(N), delete(X, hard), link(A, X)]` — the
+    /// trailing `link` fails its endpoint-existence guard once `X` is gone
+    /// (deleted by the op immediately before it, in the SAME unit), so the
+    /// whole unit rolls back: C and N must leave zero trace (no row, no FTS
+    /// document), and X's delete must be undone too (ADR-099 D1 "the whole
+    /// unit rolls back" applied to the new create plans).
+    #[tokio::test]
+    async fn atomic_add_entity_and_add_note_roll_back_on_later_link_failure_leaving_zero_trace() {
+        let runtime = scratch_runtime();
+        let token = runtime
+            .authorize(Namespace::parse("local").expect("ns"))
+            .expect("authorize");
+        let entities = runtime.entities(&token).expect("entities store");
+        let a = khive_storage::Entity::new("local", "concept", "Adr104RollbackA");
+        let x = khive_storage::Entity::new("local", "concept", "Adr104RollbackX");
+        let (a_id, x_id) = (a.id, x.id);
+        entities.upsert_entity(a).await.expect("seed a");
+        entities.upsert_entity(x.clone()).await.expect("seed x");
+
+        let add_entity_plan = prepare_add_entity(
+            &runtime,
+            &token,
+            &json!({"kind": "concept", "name": "Adr104RollbackNewEntity"}),
+        )
+        .await
+        .expect("prepare add_entity");
+        let add_note_plan = prepare_add_note(
+            &runtime,
+            &token,
+            &json!({"kind": "observation", "content": "must not survive the rollback"}),
+        )
+        .await
+        .expect("prepare add_note");
+        let delete_plan = prepare_delete(&runtime, &token, &json!({"id": x_id.to_string(), "hard": true}), None)
+            .await
+            .expect("prepare delete x");
+        // Endpoint validation runs against CURRENT (pre-transaction) state,
+        // where x still exists — same setup as atomic_runner's own
+        // dangling-edge test, replayed here against the real entity
+        // substrate with two leading create plans.
+        let link_plan = prepare_link(
+            &runtime,
+            &token,
+            &json!({"source_id": a_id.to_string(), "target_id": x_id.to_string(), "relation": "extends"}),
+        )
+        .await
+        .expect("prepare link (endpoint still exists at prepare time)");
+
+        let entity_id = match &add_entity_plan {
+            AtomicOpPlan::AddEntity(p) => p.entity_id,
+            other => panic!("expected an AddEntity plan, got {other:?}"),
+        };
+        let note_id = match &add_note_plan {
+            AtomicOpPlan::AddNote(p) => p.note_id,
+            other => panic!("expected an AddNote plan, got {other:?}"),
+        };
+
+        let outcome = crate::atomic_runner::run_atomic_unit(
+            runtime.sql().as_ref(),
+            vec![add_entity_plan, add_note_plan, delete_plan, link_plan],
+        )
+        .await
+        .expect("the seam call itself must not error — the unit rolls back cleanly");
+        match outcome {
+            crate::atomic_runner::AtomicRunOutcome::RolledBack {
+                failed_op_index, ..
+            } => {
+                assert_eq!(
+                    failed_op_index, 3,
+                    "the trailing link (index 3) must be the op whose guard fails"
+                );
+            }
+            other => panic!("expected the whole unit to roll back, got {other:?}"),
+        }
+
+        assert!(
+            runtime
+                .get_entity_including_deleted(&token, entity_id)
+                .await
+                .expect("get_entity_including_deleted")
+                .is_none(),
+            "the new entity must leave zero trace after rollback"
+        );
+        assert!(
+            runtime
+                .text(&token)
+                .expect("text store")
+                .get_document("local", entity_id)
+                .await
+                .expect("get_document")
+                .is_none(),
+            "the new entity's FTS document must leave zero trace after rollback"
+        );
+        assert!(
+            runtime
+                .get_note_including_deleted(&token, note_id)
+                .await
+                .expect("get_note_including_deleted")
+                .is_none(),
+            "the new note must leave zero trace after rollback"
+        );
+        assert!(
+            runtime
+                .text_for_notes(&token)
+                .expect("text store")
+                .get_document("local", note_id)
+                .await
+                .expect("get_document")
+                .is_none(),
+            "the new note's FTS document must leave zero trace after rollback"
+        );
+
+        let x_after = runtime
+            .get_entity_including_deleted(&token, x_id)
+            .await
+            .expect("get_entity_including_deleted")
+            .expect("x must still be present — its delete rolled back too");
+        assert!(
+            x_after.deleted_at.is_none(),
+            "x's delete must have rolled back along with the failed link"
+        );
+
+        let (edge_count, _, _, _) = probe_edge_natural_key(&runtime, "local", a_id, x_id, "extends").await;
+        assert_eq!(edge_count, 0, "no edge may have been committed");
     }
 }

--- a/crates/khive-runtime/src/atomic_prepare.rs
+++ b/crates/khive-runtime/src/atomic_prepare.rs
@@ -97,6 +97,16 @@ fn optional_str<'a>(args: &'a Value, key: &str) -> Option<&'a str> {
     obj(args).ok()?.get(key).and_then(|v| v.as_str())
 }
 
+fn optional_create_string(args: &Value, key: &str) -> RuntimeResult<Option<String>> {
+    match obj(args)?.get(key) {
+        None | Some(Value::Null) => Ok(None),
+        Some(Value::String(value)) => Ok(Some(value.clone())),
+        Some(other) => Err(RuntimeError::InvalidInput(format!(
+            "{key} must be a string or null, got: {other}"
+        ))),
+    }
+}
+
 /// Nullable-string patch semantics mirroring the actually-reachable behavior
 /// of `khive-pack-kg::handlers::common::optional_string_patch`/
 /// `description_patch`, reimplemented here rather than imported (that
@@ -426,8 +436,13 @@ pub async fn prepare_add_entity(
     let kind = require_str(args, "kind")?;
     let name = require_str(args, "name")?;
     runtime.validate_entity_kind(kind)?;
+    if name.trim().is_empty() {
+        return Err(RuntimeError::InvalidInput(
+            "name must not be empty".to_string(),
+        ));
+    }
 
-    let description = optional_str(args, "description").map(str::to_string);
+    let description = optional_create_string(args, "description")?;
     let properties = optional_properties(args, "properties")?;
     let tags = optional_tags(args)?.unwrap_or_default();
 
@@ -486,7 +501,7 @@ pub async fn prepare_add_note(
     let content = require_str(args, "content")?;
     runtime.validate_note_kind(kind)?;
 
-    let name = optional_str(args, "name").map(str::to_string);
+    let name = optional_create_string(args, "name")?;
     let properties = optional_properties(args, "properties")?;
 
     crate::secret_gate::check(content)?;
@@ -680,50 +695,18 @@ pub async fn prepare_update(
             let properties = optional_properties(args, "properties")?;
             let tags = optional_tags(args)?;
 
-            let (entity, text_changed, changed_fields) = runtime
-                .prepare_update_entity(
-                    token,
-                    id,
-                    crate::curation::EntityPatch {
-                        name,
-                        description,
-                        properties,
-                        tags,
-                    },
-                )
-                .await?;
-
-            let mut statements = vec![PlanStatement {
-                statement: entity_upsert_statement(&entity),
-                guard: Some(AffectedRowGuard::exactly(1)),
-            }];
-            // curation.rs's `update_entity` appends an `EntityUpdated` event
-            // unconditionally after `upsert_entity` succeeds, regardless of
-            // `text_changed`: match that here, not just on the
-            // reindex-triggering subset of updates.
-            statements.extend(event_append_statements(
-                &entity.namespace,
-                "update",
-                EventKind::EntityUpdated,
-                SubstrateKind::Entity,
+            prepare_update_entity_plan(
+                runtime,
+                token,
                 id,
-                serde_json::json!({
-                    "id": id,
-                    "namespace": entity.namespace,
-                    "changed_fields": changed_fields,
-                }),
-            )?);
-            let post_commit = if text_changed {
-                PostCommitEffect::ReindexEntity { entity_id: id }
-            } else {
-                PostCommitEffect::None
-            };
-            Ok(AtomicOpPlan::Update(UpdatePlan {
-                target_id: id,
-                statements,
-                post_commit,
-                edge_natural_key: None,
-            }))
+                crate::curation::EntityPatch {
+                    name,
+                    description,
+                    properties,
+                    tags,
+                },
+            )
+            .await
         }
         Some(Resolved::Note(note)) => {
             match &expected_kind {
@@ -807,6 +790,46 @@ pub async fn prepare_update(
             },
         },
     }
+}
+
+/// Build an entity update plan from a typed patch. Proposal changesets use
+/// this entry point so their explicit `description: null` clear operation is
+/// preserved instead of being collapsed by raw verb deserialization.
+pub async fn prepare_update_entity_plan(
+    runtime: &KhiveRuntime,
+    token: &NamespaceToken,
+    id: Uuid,
+    patch: crate::curation::EntityPatch,
+) -> RuntimeResult<AtomicOpPlan> {
+    let (entity, text_changed, changed_fields) =
+        runtime.prepare_update_entity(token, id, patch).await?;
+    let mut statements = vec![PlanStatement {
+        statement: entity_upsert_statement(&entity),
+        guard: Some(AffectedRowGuard::exactly(1)),
+    }];
+    statements.extend(event_append_statements(
+        &entity.namespace,
+        "update",
+        EventKind::EntityUpdated,
+        SubstrateKind::Entity,
+        id,
+        serde_json::json!({
+            "id": id,
+            "namespace": entity.namespace,
+            "changed_fields": changed_fields,
+        }),
+    )?);
+    let post_commit = if text_changed {
+        PostCommitEffect::ReindexEntity { entity_id: id }
+    } else {
+        PostCommitEffect::None
+    };
+    Ok(AtomicOpPlan::Update(UpdatePlan {
+        target_id: id,
+        statements,
+        post_commit,
+        edge_natural_key: None,
+    }))
 }
 
 /// Edge branch of `prepare_update`. Mirrors
@@ -3244,6 +3267,66 @@ mod tests {
     // ------------------------------------------------------------------
     // AddEntity and AddNote plans alongside link
     // ------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn prepare_add_entity_rejects_whitespace_only_name() {
+        let runtime = scratch_runtime();
+        let token = runtime
+            .authorize(Namespace::parse("local").expect("ns"))
+            .expect("authorize");
+
+        let err = prepare_add_entity(&runtime, &token, &json!({"kind": "concept", "name": "   "}))
+            .await
+            .expect_err("whitespace-only entity name must fail prepare");
+
+        assert!(matches!(
+            err,
+            RuntimeError::InvalidInput(message) if message.contains("name must not be empty")
+        ));
+    }
+
+    #[tokio::test]
+    async fn prepare_add_entity_rejects_non_string_description() {
+        let runtime = scratch_runtime();
+        let token = runtime
+            .authorize(Namespace::parse("local").expect("ns"))
+            .expect("authorize");
+
+        let err = prepare_add_entity(
+            &runtime,
+            &token,
+            &json!({"kind": "concept", "name": "Valid", "description": 42}),
+        )
+        .await
+        .expect_err("non-string entity description must fail prepare");
+
+        assert!(matches!(
+            err,
+            RuntimeError::InvalidInput(message)
+                if message.contains("description must be a string or null")
+        ));
+    }
+
+    #[tokio::test]
+    async fn prepare_add_note_rejects_non_string_name() {
+        let runtime = scratch_runtime();
+        let token = runtime
+            .authorize(Namespace::parse("local").expect("ns"))
+            .expect("authorize");
+
+        let err = prepare_add_note(
+            &runtime,
+            &token,
+            &json!({"kind": "observation", "content": "Valid", "name": 42}),
+        )
+        .await
+        .expect_err("non-string note name must fail prepare");
+
+        assert!(matches!(
+            err,
+            RuntimeError::InvalidInput(message) if message.contains("name must be a string or null")
+        ));
+    }
 
     #[tokio::test]
     async fn atomic_add_entity_link_add_note_plan_commits_entity_edge_note_and_fts_together() {

--- a/crates/khive-runtime/src/atomic_prepare.rs
+++ b/crates/khive-runtime/src/atomic_prepare.rs
@@ -1,5 +1,5 @@
 //! ADR-099: the per-verb async prepare pass for the KG-substrate v1
-//! admissible verbs (`update`, `delete`, `link`, `merge`), plus (ADR-104)
+//! admissible verbs (`update`, `delete`, `link`, `merge`), plus
 //! [`prepare_add_entity`]/[`prepare_add_note`] for the ADR-046 proposal
 //! changeset `AddEntity`/`AddNote` arms. Each `prepare_*` function reads
 //! current state (async, outside any transaction) and returns a plain-data
@@ -410,21 +410,14 @@ fn prepare_governance_unimplemented(tool: &str) -> RuntimeResult<AtomicOpPlan> {
 }
 
 // ---------------------------------------------------------------------------
-// create (AddEntity / AddNote — ADR-104, alongside the update/delete/link/
-// merge plans above)
+// create (AddEntity / AddNote)
 // ---------------------------------------------------------------------------
 
-/// Build the prepared plan for creating an entity (ADR-046 proposal
-/// changeset `AddEntity`). Mirrors `KhiveRuntime::create_entity`'s
-/// validation and row shape exactly, up to the point where canonical fans
-/// out to embedding: the FTS document is written inside the transaction
-/// (same SQLite database, same writer connection — C-ADR-014 §3 item 2),
-/// but vector materialization is deferred to `PostCommitEffect::
-/// ReindexEntity`, since embedding needs a suspending model call and the
-/// atomic unit permits none (C-ADR-014 §3 item 3). `kind` is expected
-/// already canonicalized by the caller — the same split `prepare_update`/
-/// `prepare_delete` use: pack-aware kind resolution needs a `VerbRegistry`,
-/// unreachable from this crate.
+/// Build the prepared plan for an `AddEntity` proposal change. The entity
+/// row and FTS document are committed together; vector indexing is deferred
+/// until after commit because embedding may suspend. `kind` must already be
+/// canonicalized by the caller because pack-aware resolution requires a
+/// `VerbRegistry`.
 pub async fn prepare_add_entity(
     runtime: &KhiveRuntime,
     token: &NamespaceToken,
@@ -479,8 +472,8 @@ pub async fn prepare_add_entity(
     }))
 }
 
-/// Build the prepared plan for creating a note (ADR-046 proposal changeset
-/// `AddNote`). Mirrors [`prepare_add_entity`]'s shape and the same
+/// Build the prepared plan for an `AddNote` proposal change. Mirrors
+/// [`prepare_add_entity`]'s shape and the same
 /// `kind`-already-canonicalized split. `annotates` is out of scope: the
 /// proposal `NoteDraft` this backs carries no annotates targets, unlike
 /// `KhiveRuntime::create_note`'s general-purpose signature.
@@ -3249,17 +3242,9 @@ mod tests {
     }
 
     // ------------------------------------------------------------------
-    // ADR-104: AddEntity / AddNote plans, alongside update/delete/link
+    // AddEntity and AddNote plans alongside link
     // ------------------------------------------------------------------
 
-    /// Acceptance criterion (issue #904): a `create + edge + note` plan
-    /// commits the entity, the edge, the note, AND their FTS documents
-    /// together — one `run_atomic_unit` call, one SQLite transaction (the
-    /// FTS insert statements `prepare_add_entity`/`prepare_add_note` build
-    /// are applied inside the SAME unit as the row inserts, not deferred).
-    /// Vector materialization is the one piece of work post-commit
-    /// (`PostCommitEffect::ReindexEntity`/`ReindexNote`), since embedding
-    /// needs a suspending model call.
     #[tokio::test]
     async fn atomic_add_entity_link_add_note_plan_commits_entity_edge_note_and_fts_together() {
         let runtime = scratch_runtime();
@@ -3268,8 +3253,8 @@ mod tests {
             .authorize(Namespace::parse("local").expect("ns"))
             .expect("authorize");
         let entities = runtime.entities(&token).expect("entities store");
-        let a = khive_storage::Entity::new("local", "concept", "Adr104LinkA");
-        let b = khive_storage::Entity::new("local", "concept", "Adr104LinkB");
+        let a = khive_storage::Entity::new("local", "concept", "ProposalPlanLinkA");
+        let b = khive_storage::Entity::new("local", "concept", "ProposalPlanLinkB");
         let (a_id, b_id) = (a.id, b.id);
         entities.upsert_entity(a).await.expect("seed a");
         entities.upsert_entity(b).await.expect("seed b");
@@ -3277,7 +3262,7 @@ mod tests {
         let add_entity_plan = prepare_add_entity(
             &runtime,
             &token,
-            &json!({"kind": "concept", "name": "Adr104NewEntity", "description": "created atomically"}),
+            &json!({"kind": "concept", "name": "ProposalPlanNewEntity", "description": "created atomically"}),
         )
         .await
         .expect("prepare add_entity");
@@ -3315,16 +3300,14 @@ mod tests {
             crate::atomic_runner::AtomicRunOutcome::Committed { post_commit } => post_commit,
             other => panic!("expected the whole unit to commit: {other:?}"),
         };
-        apply_post_commit_effects(&runtime, &token, post_commit)
-            .await
-            .expect("apply post-commit effects");
-
         let entity = runtime
-            .get_entity(&token, entity_id)
+            .entities(&token)
+            .expect("entities store")
+            .get_entity(entity_id)
             .await
             .expect("get_entity")
             .expect("entity must exist after commit");
-        assert_eq!(entity.name, "Adr104NewEntity");
+        assert_eq!(entity.name, "ProposalPlanNewEntity");
         assert!(
             runtime
                 .text(&token)
@@ -3338,11 +3321,16 @@ mod tests {
 
         let (edge_count, _, _, edge_deleted_at) =
             probe_edge_natural_key(&runtime, "local", a_id, b_id, "extends").await;
-        assert_eq!(edge_count, 1, "the edge must be committed alongside the entity/note");
+        assert_eq!(
+            edge_count, 1,
+            "the edge must be committed alongside the entity/note"
+        );
         assert!(edge_deleted_at.is_none());
 
         let note = runtime
-            .get_note(&token, note_id)
+            .notes(&token)
+            .expect("notes store")
+            .get_note(note_id)
             .await
             .expect("get_note")
             .expect("note must exist after commit");
@@ -3358,6 +3346,10 @@ mod tests {
             "note's FTS document must exist after commit"
         );
 
+        apply_post_commit_effects(&runtime, &token, post_commit)
+            .await
+            .expect("apply post-commit effects");
+
         let vec_store = runtime
             .vectors_for_model(&token, STUB_MODEL)
             .expect("vec store");
@@ -3368,14 +3360,6 @@ mod tests {
         );
     }
 
-    /// Acceptance criterion (issue #904): a failing later SQL/validation
-    /// guard restores the pre-run SQLite AND FTS state. Plan:
-    /// `[AddEntity(C), AddNote(N), delete(X, hard), link(A, X)]` — the
-    /// trailing `link` fails its endpoint-existence guard once `X` is gone
-    /// (deleted by the op immediately before it, in the SAME unit), so the
-    /// whole unit rolls back: C and N must leave zero trace (no row, no FTS
-    /// document), and X's delete must be undone too (ADR-099 D1 "the whole
-    /// unit rolls back" applied to the new create plans).
     #[tokio::test]
     async fn atomic_add_entity_and_add_note_roll_back_on_later_link_failure_leaving_zero_trace() {
         let runtime = scratch_runtime();
@@ -3383,8 +3367,8 @@ mod tests {
             .authorize(Namespace::parse("local").expect("ns"))
             .expect("authorize");
         let entities = runtime.entities(&token).expect("entities store");
-        let a = khive_storage::Entity::new("local", "concept", "Adr104RollbackA");
-        let x = khive_storage::Entity::new("local", "concept", "Adr104RollbackX");
+        let a = khive_storage::Entity::new("local", "concept", "ProposalPlanRollbackA");
+        let x = khive_storage::Entity::new("local", "concept", "ProposalPlanRollbackX");
         let (a_id, x_id) = (a.id, x.id);
         entities.upsert_entity(a).await.expect("seed a");
         entities.upsert_entity(x.clone()).await.expect("seed x");
@@ -3392,7 +3376,7 @@ mod tests {
         let add_entity_plan = prepare_add_entity(
             &runtime,
             &token,
-            &json!({"kind": "concept", "name": "Adr104RollbackNewEntity"}),
+            &json!({"kind": "concept", "name": "ProposalPlanRollbackNewEntity"}),
         )
         .await
         .expect("prepare add_entity");
@@ -3403,13 +3387,16 @@ mod tests {
         )
         .await
         .expect("prepare add_note");
-        let delete_plan = prepare_delete(&runtime, &token, &json!({"id": x_id.to_string(), "hard": true}), None)
-            .await
-            .expect("prepare delete x");
-        // Endpoint validation runs against CURRENT (pre-transaction) state,
-        // where x still exists — same setup as atomic_runner's own
-        // dangling-edge test, replayed here against the real entity
-        // substrate with two leading create plans.
+        let delete_plan = prepare_delete(
+            &runtime,
+            &token,
+            &json!({"id": x_id.to_string(), "hard": true}),
+            None,
+        )
+        .await
+        .expect("prepare delete x");
+        // Prepare sees x before the transaction; the guarded link must detect
+        // that the preceding hard delete removed it inside the transaction.
         let link_plan = prepare_link(
             &runtime,
             &token,
@@ -3432,7 +3419,7 @@ mod tests {
             vec![add_entity_plan, add_note_plan, delete_plan, link_plan],
         )
         .await
-        .expect("the seam call itself must not error — the unit rolls back cleanly");
+        .expect("the seam call itself must not error; the unit rolls back cleanly");
         match outcome {
             crate::atomic_runner::AtomicRunOutcome::RolledBack {
                 failed_op_index, ..
@@ -3486,13 +3473,14 @@ mod tests {
             .get_entity_including_deleted(&token, x_id)
             .await
             .expect("get_entity_including_deleted")
-            .expect("x must still be present — its delete rolled back too");
+            .expect("x must still be present because its delete rolled back too");
         assert!(
             x_after.deleted_at.is_none(),
             "x's delete must have rolled back along with the failed link"
         );
 
-        let (edge_count, _, _, _) = probe_edge_natural_key(&runtime, "local", a_id, x_id, "extends").await;
+        let (edge_count, _, _, _) =
+            probe_edge_natural_key(&runtime, "local", a_id, x_id, "extends").await;
         assert_eq!(edge_count, 0, "no edge may have been committed");
     }
 }

--- a/crates/khive-runtime/src/atomic_runner.rs
+++ b/crates/khive-runtime/src/atomic_runner.rs
@@ -52,8 +52,8 @@ use std::sync::{Arc, Mutex};
 use khive_storage::{AtomicUnitOp, SqlAccess, SqlStatement, SqlWriter, StorageError};
 
 use crate::atomic_plan::{
-    AffectedRowGuard, DeletePlan, GovernancePlan, GtdCompletePlan, GtdTransitionPlan, LinkPlan,
-    MergePlan, PlanStatement, PostCommitEffect, UpdatePlan,
+    AddEntityPlan, AddNotePlan, AffectedRowGuard, DeletePlan, GovernancePlan, GtdCompletePlan,
+    GtdTransitionPlan, LinkPlan, MergePlan, PlanStatement, PostCommitEffect, UpdatePlan,
 };
 
 /// One admissible op's prepared write plan (ADR-099 D3's v1 admissible verb
@@ -64,6 +64,8 @@ use crate::atomic_plan::{
 /// (`post_commit_effect`).
 #[derive(Debug, Clone)]
 pub enum AtomicOpPlan {
+    AddEntity(AddEntityPlan),
+    AddNote(AddNotePlan),
     Update(UpdatePlan),
     Delete(DeletePlan),
     Link(LinkPlan),
@@ -84,6 +86,8 @@ impl AtomicOpPlan {
     /// variant already carries a flat `Vec<PlanStatement>` in apply order.
     fn plan_statements(&self) -> Vec<PlanStatement> {
         match self {
+            AtomicOpPlan::AddEntity(p) => p.statements.clone(),
+            AtomicOpPlan::AddNote(p) => p.statements.clone(),
             AtomicOpPlan::Update(p) => p.statements.clone(),
             AtomicOpPlan::Delete(p) => p.statements.clone(),
             AtomicOpPlan::Link(p) => vec![p.statement.clone()],
@@ -120,6 +124,12 @@ impl AtomicOpPlan {
     /// carries no `post_commit` field, so this runner records none for it.
     fn post_commit_effect(&self) -> Option<PostCommitEffect> {
         match self {
+            AtomicOpPlan::AddEntity(p) if p.post_commit != PostCommitEffect::None => {
+                Some(p.post_commit.clone())
+            }
+            AtomicOpPlan::AddNote(p) if p.post_commit != PostCommitEffect::None => {
+                Some(p.post_commit.clone())
+            }
             AtomicOpPlan::Update(p) if p.post_commit != PostCommitEffect::None => {
                 Some(p.post_commit.clone())
             }

--- a/crates/khive-runtime/src/lib.rs
+++ b/crates/khive-runtime/src/lib.rs
@@ -32,8 +32,9 @@ pub mod validation;
 
 pub use actor_identity::{actor_is_unattributed, resolve_actor, should_warn_unattributed_actor};
 pub use atomic_plan::{
-    AffectedRowGuard, DeletePlan, GovernanceOp, GovernancePlan, GtdCompletePlan, GtdTransitionPlan,
-    LinkPlan, MergePlan, PlanPredicate, PlanStatement, PostCommitEffect, UpdatePlan,
+    AddEntityPlan, AddNotePlan, AffectedRowGuard, DeletePlan, GovernanceOp, GovernancePlan,
+    GtdCompletePlan, GtdTransitionPlan, LinkPlan, MergePlan, PlanPredicate, PlanStatement,
+    PostCommitEffect, UpdatePlan,
 };
 pub use atomic_runner::{
     run_atomic_unit, AtomicOpFailure, AtomicOpPlan, AtomicRunOutcome, AtomicRunnerError,


### PR DESCRIPTION
## Summary

- Add atomic plan variants for proposal entity and note creation, with existing guarded link plans covering proposal edge creation.
- Wire approved single-step proposal entity, note, update, edge, and supersede writes through the atomic prepare, commit, and post-commit path.
- Commit entity and note rows with their FTS documents in one suspend-free writer transaction.
- Defer embedding and vector reindexing until after commit.
- Reuse the same parameterized FTS insert builder in canonical and atomic write paths.
- Reject whitespace-only entity names and malformed optional create strings during prepare.
- Keep both multi-step Compound admission checks unchanged.
- Keep proposal merges on the canonical transactional merge path because the current atomic merge plan is intentionally incomplete.

## Why

Proposal creation writes now use the transaction-ready plan path in production proposal application. This closes the missing caller gap without adding another transaction abstraction or holding the writer across suspending work. The multi-step admission guard remains until every proposal arm has full atomic-plan parity.

## Testing

- `CARGO_TARGET_DIR=/private/tmp/khive-shared-target RUSTC_WRAPPER= cargo clippy -p khive-runtime -p khive-pack-kg --all-targets -- -D warnings`
- `CARGO_TARGET_DIR=/private/tmp/khive-shared-target RUSTC_WRAPPER= cargo test -p khive-runtime -p khive-pack-kg`
- `CARGO_TARGET_DIR=/private/tmp/khive-shared-target RUSTC_WRAPPER= cargo fmt --all -- --check`
- `CARGO_TARGET_DIR=/private/tmp/khive-shared-target RUSTC_WRAPPER= cargo check --workspace`

Closes #904
