### PR TITLE
fix(khive-db): sanitize FTS5 metacharacter queries (#916)

### DIFF
--- a/crates/khive-db/src/stores/text.rs
+++ b/crates/khive-db/src/stores/text.rs
@@ -356,6 +356,35 @@ fn sanitize_fts5_phrase_literal(token: &str) -> Option<String> {
 /// split segment at or below this length as trigram-unsafe.
 const FTS5_TRIGRAM_MIN_SAFE_LEN: usize = 3;
 
+/// True if every character in `s` is safe to emit unquoted at any bareword
+/// position in an FTS5 MATCH expression.
+///
+/// Verified empirically (2026-07-13, khive #916) by feeding `"a<char>b"` as
+/// a bound MATCH argument for every printable ASCII character 0x21-0x7e to
+/// a live `tokenize='trigram'` table: only ASCII alphanumerics and `_` were
+/// error-free *and* matched as plain substring text in every position.
+/// Every other punctuation character is unsafe as a bareword — most raise a
+/// direct `fts5: syntax error near "<char>"` (`#`, `%`, `=`, `&`, `;`, `<`,
+/// `>`, `?`, `@`, `[`, `\`, `]`, `` ` ``, `|`, `!`, `$`, `'`, `"`, `,`, `.`,
+/// `/`, `(`, `)`, `~`), while `-`, `:`, `{`, `}` are instead silently
+/// reinterpreted as FTS5's column-filter syntax (`col: term`, `{col1
+/// col2}: term`) — just as wrong for a content-matching query, since it
+/// changes what the expression means rather than erroring. `*`, `+`, `^`
+/// are individually error-free too, but [`sanitize_fts5_query`]'s Pass 2
+/// already strips them out of every string this helper is called on, so it
+/// does not need to special-case them.
+///
+/// This is an allowlist, not a denylist, precisely because the denylist
+/// approach ([`sanitize_fts5_query`]'s Pass 2) has needed a new character
+/// added on every prior FTS5-syntax-error report (`$` in #388, `'` in
+/// #570, `#`/`%`/`=` in #916) and will keep needing one for whatever
+/// punctuation the next query happens to contain. An allowlist converges:
+/// nothing reaches an unquoted bareword position unless it is provably
+/// safe.
+fn is_fts5_bareword_safe(s: &str) -> bool {
+    !s.is_empty() && s.chars().all(|c| c.is_ascii_alphanumeric() || c == '_')
+}
+
 /// Sanitize a single whitespace-isolated raw token into an FTS5
 /// match-expression fragment.
 ///
@@ -395,28 +424,47 @@ const FTS5_TRIGRAM_MIN_SAFE_LEN: usize = 3;
 ///   requiring adjacency for that token, which is the trade-off intended
 ///   by the finding this fixes (khive #397 Finding 2): correctness over a
 ///   marginally more lenient match.
+/// - (#916) `sanitize_fts5_query`'s Pass 1/2 only reroute a *curated* set of
+///   punctuation characters (grouping chars to spaces, a handful of FTS5
+///   operator chars removed outright) — anything outside that set, e.g.
+///   `#682`, `B=128`, `Min-K%Prob`'s `%`, reaches this function's split and
+///   merged forms unchanged and is an invalid FTS5 bareword. Every bareword
+///   alternative (the split AND-group and the legacy merge) is now gated on
+///   [`is_fts5_bareword_safe`] before being emitted; when a term fails that
+///   check, the alternative is dropped rather than emitted broken, and the
+///   quoted-phrase alternative below — which FTS5 accepts literally,
+///   verified for every ASCII punctuation character (#916) — is what
+///   carries that token instead. A single-term token that sanitizes to one
+///   unsafe bareword (`#682`) now falls through to the same alternative
+///   pipeline the multi-term case already used, rather than returning the
+///   raw bareword unconditionally.
 ///
 /// All emitted readings are additive OR-alternatives otherwise — the result
 /// is never a narrower match than any single (safe) form alone.
 ///
-/// Returns `None` if the token sanitizes to nothing.
+/// Returns `None` if the token sanitizes to nothing, or if every candidate
+/// alternative was unsafe to emit (only reachable when the raw token
+/// consists solely of characters `sanitize_fts5_phrase_literal` also
+/// strips — quotes, `*`, NUL, control characters).
 fn sanitize_fts5_token_group(token: &str) -> Option<String> {
     let split = sanitize_fts5_query(token);
     let split_terms: Vec<&str> = split.split_whitespace().collect();
     if split_terms.is_empty() {
         return None;
     }
-    if split_terms.len() == 1 {
-        return Some(split_terms[0].to_string());
-    }
 
+    let all_bareword_safe = split_terms.iter().all(|t| is_fts5_bareword_safe(t));
     let has_trigram_unsafe_segment = split_terms
         .iter()
         .any(|t| t.chars().count() < FTS5_TRIGRAM_MIN_SAFE_LEN);
 
     let mut alternatives = Vec::new();
-    if !has_trigram_unsafe_segment {
-        alternatives.push(format!("({})", split_terms.join(" ")));
+    if all_bareword_safe {
+        if split_terms.len() == 1 {
+            alternatives.push(split_terms[0].to_string());
+        } else if !has_trigram_unsafe_segment {
+            alternatives.push(format!("({})", split_terms.join(" ")));
+        }
     }
 
     // An operator-bearing token (e.g. `NEAR(alpha-beta,5)`) can make the
@@ -431,6 +479,8 @@ fn sanitize_fts5_token_group(token: &str) -> Option<String> {
     // here whenever the merge is multi-term.
     let merged = sanitize_fts5_query_legacy_merged(token);
     let merged_terms: Vec<&str> = merged.split_whitespace().collect();
+    let merged_all_bareword_safe =
+        !merged_terms.is_empty() && merged_terms.iter().all(|t| is_fts5_bareword_safe(t));
     let merged_has_unsafe_segment = merged_terms.len() > 1
         && merged_terms
             .iter()
@@ -446,7 +496,12 @@ fn sanitize_fts5_token_group(token: &str) -> Option<String> {
     let phrase = sanitize_fts5_phrase_literal(token);
     let duplicates_split = merged == split_terms.join(" ");
     let duplicates_phrase = phrase.as_deref() == Some(merged.as_str());
-    if !merged.is_empty() && !duplicates_split && !duplicates_phrase && !merged_has_unsafe_segment {
+    if merged_all_bareword_safe
+        && !merged.is_empty()
+        && !duplicates_split
+        && !duplicates_phrase
+        && !merged_has_unsafe_segment
+    {
         alternatives.push(merged);
     }
 
@@ -455,7 +510,7 @@ fn sanitize_fts5_token_group(token: &str) -> Option<String> {
     }
 
     match alternatives.len() {
-        0 => Some(format!("({})", split_terms.join(" "))),
+        0 => None,
         1 => alternatives.into_iter().next(),
         _ => Some(format!("({})", alternatives.join(" OR "))),
     }

--- a/crates/khive-db/src/stores/text.rs
+++ b/crates/khive-db/src/stores/text.rs
@@ -327,19 +327,26 @@ fn sanitize_fts5_query_legacy_merged(query: &str) -> String {
         .join(" ")
 }
 
-/// Strip a raw token down to what is safe inside a double-quoted FTS5 phrase:
-/// the closing delimiter (`"`), the trailing-`*` prefix-query trigger, and
-/// control characters. Everything else — including `-`, `.`, `:`, `$`, `'`,
-/// digits — passes through literally, since FTS5 phrase text is matched
+/// Escape a raw token for use inside a double-quoted FTS5 phrase. Embedded
+/// double quotes are doubled; the trailing-`*` prefix-query trigger and
+/// control characters are removed. Everything else, including punctuation,
+/// passes through literally, since FTS5 phrase text is matched
 /// against the column's own tokenization of that literal text (word-exact
 /// under `unicode61`, substring-exact under `trigram`), not re-sanitized.
 ///
 /// Returns `None` if nothing survives the filter.
 fn sanitize_fts5_phrase_literal(token: &str) -> Option<String> {
-    let literal: String = token
+    let mut literal = String::with_capacity(token.len());
+    for c in token
         .chars()
-        .filter(|c| !matches!(c, '"' | '*' | '\0') && !c.is_control())
-        .collect();
+        .filter(|c| !matches!(c, '*' | '\0') && !c.is_control())
+    {
+        if c == '"' {
+            literal.push_str("\"\"");
+        } else {
+            literal.push(c);
+        }
+    }
     if literal.is_empty() {
         None
     } else {
@@ -356,31 +363,9 @@ fn sanitize_fts5_phrase_literal(token: &str) -> Option<String> {
 /// split segment at or below this length as trigram-unsafe.
 const FTS5_TRIGRAM_MIN_SAFE_LEN: usize = 3;
 
-/// True if every character in `s` is safe to emit unquoted at any bareword
-/// position in an FTS5 MATCH expression.
-///
-/// Verified empirically (2026-07-13, khive #916) by feeding `"a<char>b"` as
-/// a bound MATCH argument for every printable ASCII character 0x21-0x7e to
-/// a live `tokenize='trigram'` table: only ASCII alphanumerics and `_` were
-/// error-free *and* matched as plain substring text in every position.
-/// Every other punctuation character is unsafe as a bareword — most raise a
-/// direct `fts5: syntax error near "<char>"` (`#`, `%`, `=`, `&`, `;`, `<`,
-/// `>`, `?`, `@`, `[`, `\`, `]`, `` ` ``, `|`, `!`, `$`, `'`, `"`, `,`, `.`,
-/// `/`, `(`, `)`, `~`), while `-`, `:`, `{`, `}` are instead silently
-/// reinterpreted as FTS5's column-filter syntax (`col: term`, `{col1
-/// col2}: term`) — just as wrong for a content-matching query, since it
-/// changes what the expression means rather than erroring. `*`, `+`, `^`
-/// are individually error-free too, but [`sanitize_fts5_query`]'s Pass 2
-/// already strips them out of every string this helper is called on, so it
-/// does not need to special-case them.
-///
-/// This is an allowlist, not a denylist, precisely because the denylist
-/// approach ([`sanitize_fts5_query`]'s Pass 2) has needed a new character
-/// added on every prior FTS5-syntax-error report (`$` in #388, `'` in
-/// #570, `#`/`%`/`=` in #916) and will keep needing one for whatever
-/// punctuation the next query happens to contain. An allowlist converges:
-/// nothing reaches an unquoted bareword position unless it is provably
-/// safe.
+/// FTS5 reserves punctuation in barewords for query syntax, including some
+/// forms that change query meaning without producing an error. Keep bareword
+/// alternatives to the conservative ASCII set and quote everything else.
 fn is_fts5_bareword_safe(s: &str) -> bool {
     !s.is_empty() && s.chars().all(|c| c.is_ascii_alphanumeric() || c == '_')
 }
@@ -424,28 +409,15 @@ fn is_fts5_bareword_safe(s: &str) -> bool {
 ///   requiring adjacency for that token, which is the trade-off intended
 ///   by the finding this fixes (khive #397 Finding 2): correctness over a
 ///   marginally more lenient match.
-/// - (#916) `sanitize_fts5_query`'s Pass 1/2 only reroute a *curated* set of
-///   punctuation characters (grouping chars to spaces, a handful of FTS5
-///   operator chars removed outright) — anything outside that set, e.g.
-///   `#682`, `B=128`, `Min-K%Prob`'s `%`, reaches this function's split and
-///   merged forms unchanged and is an invalid FTS5 bareword. Every bareword
-///   alternative (the split AND-group and the legacy merge) is now gated on
-///   [`is_fts5_bareword_safe`] before being emitted; when a term fails that
-///   check, the alternative is dropped rather than emitted broken, and the
-///   quoted-phrase alternative below — which FTS5 accepts literally,
-///   verified for every ASCII punctuation character (#916) — is what
-///   carries that token instead. A single-term token that sanitizes to one
-///   unsafe bareword (`#682`) now falls through to the same alternative
-///   pipeline the multi-term case already used, rather than returning the
-///   raw bareword unconditionally.
+/// - Punctuation outside the legacy sanitizer, such as `#`, `%`, and `=`,
+///   is invalid or meaningful FTS5 bareword syntax. Bareword alternatives
+///   are emitted only when every term is safe; the quoted phrase preserves
+///   the literal spelling for all other input.
 ///
 /// All emitted readings are additive OR-alternatives otherwise — the result
 /// is never a narrower match than any single (safe) form alone.
 ///
-/// Returns `None` if the token sanitizes to nothing, or if every candidate
-/// alternative was unsafe to emit (only reachable when the raw token
-/// consists solely of characters `sanitize_fts5_phrase_literal` also
-/// strips — quotes, `*`, NUL, control characters).
+/// Returns `None` if the token sanitizes to nothing.
 fn sanitize_fts5_token_group(token: &str) -> Option<String> {
     let split = sanitize_fts5_query(token);
     let split_terms: Vec<&str> = split.split_whitespace().collect();
@@ -454,17 +426,17 @@ fn sanitize_fts5_token_group(token: &str) -> Option<String> {
     }
 
     let all_bareword_safe = split_terms.iter().all(|t| is_fts5_bareword_safe(t));
+    if split_terms.len() == 1 && is_fts5_bareword_safe(token) {
+        return Some(split_terms[0].to_string());
+    }
+
     let has_trigram_unsafe_segment = split_terms
         .iter()
         .any(|t| t.chars().count() < FTS5_TRIGRAM_MIN_SAFE_LEN);
 
     let mut alternatives = Vec::new();
-    if all_bareword_safe {
-        if split_terms.len() == 1 {
-            alternatives.push(split_terms[0].to_string());
-        } else if !has_trigram_unsafe_segment {
-            alternatives.push(format!("({})", split_terms.join(" ")));
-        }
+    if all_bareword_safe && !has_trigram_unsafe_segment {
+        alternatives.push(format!("({})", split_terms.join(" ")));
     }
 
     // An operator-bearing token (e.g. `NEAR(alpha-beta,5)`) can make the

--- a/crates/khive-db/src/stores/text_tests.rs
+++ b/crates/khive-db/src/stores/text_tests.rs
@@ -1300,10 +1300,6 @@ async fn test_search_slash_query_excludes_merged_alias_all_modes_and_tokenizers(
         .await;
 }
 
-/// #916 unit coverage for the allowlist helper itself: only ASCII
-/// alphanumerics and `_` are bareword-safe; every metacharacter named in the
-/// issue (`#`, `%`, `=`), plus the wider FTS5 punctuation set the empirical
-/// probe found unsafe, must be rejected.
 #[test]
 fn test_is_fts5_bareword_safe() {
     assert!(is_fts5_bareword_safe("hello"));
@@ -1322,11 +1318,6 @@ fn test_is_fts5_bareword_safe() {
     }
 }
 
-/// #916 regression: `#682` (a bare issue-number query, e.g. from an agent
-/// recalling "#682 Stage 2") must not crash the FTS5 leg. Previously `#` was
-/// untouched by `sanitize_fts5_query`, so a single-token query reached
-/// `sanitize_fts5_token_group`'s old unconditional `split_terms.len() == 1`
-/// shortcut and hit FTS5 raw, producing `fts5: syntax error near "#"`.
 #[tokio::test]
 async fn test_search_with_hash_sign_does_not_crash_and_matches() {
     let store = setup_trigram_store("hash_sign_query");
@@ -1363,9 +1354,6 @@ async fn test_search_with_hash_sign_does_not_crash_and_matches() {
     }
 }
 
-/// #916 regression: `B=128` (an equals-bearing token from a technical query
-/// like "chunkwise B=128 traffic") must not crash the FTS5 leg. `=` was
-/// previously untouched by `sanitize_fts5_query`.
 #[tokio::test]
 async fn test_search_with_equals_sign_does_not_crash_and_matches() {
     let store = setup_trigram_store("equals_sign_query");
@@ -1402,11 +1390,6 @@ async fn test_search_with_equals_sign_does_not_crash_and_matches() {
     }
 }
 
-/// #916 regression: `Min-K%Prob` (a percent-bearing punctuated identifier,
-/// verbatim from the issue's live-log evidence) must not crash the FTS5 leg.
-/// `%` was previously untouched by `sanitize_fts5_query`, and the hyphen
-/// split it into a multi-term group whose second term (`K%Prob`) carried the
-/// unsanitized `%` straight into a bareword position.
 #[tokio::test]
 async fn test_search_with_percent_sign_does_not_crash_and_matches() {
     let store = setup_trigram_store("percent_sign_query");
@@ -1443,12 +1426,54 @@ async fn test_search_with_percent_sign_does_not_crash_and_matches() {
     }
 }
 
-/// #916 regression: a realistic multi-token query mixing FTS5-unsafe
-/// punctuated tokens with ordinary barewords (verbatim shape from the
-/// issue's live-log evidence: `"#682 Stage 2: MoE expert-cache prefetch"`)
-/// must not crash the FTS5 leg and must preserve AND-like discrimination —
-/// an unrelated document that only shares the plain bareword terms must not
-/// match.
+#[tokio::test]
+async fn test_search_with_embedded_quote_preserves_literal_match() {
+    let store = setup_trigram_store("embedded_quote_query");
+    let target_id = Uuid::new_v4();
+    let unquoted_id = Uuid::new_v4();
+
+    store
+        .upsert_document(make_document(
+            target_id,
+            "quoted identifier",
+            "the foo\"bar identifier appears here",
+        ))
+        .await
+        .unwrap();
+    store
+        .upsert_document(make_document(
+            unquoted_id,
+            "unquoted identifier",
+            "the foobar identifier appears here",
+        ))
+        .await
+        .unwrap();
+
+    for mode in [
+        TextQueryMode::Plain,
+        TextQueryMode::AnyTerm,
+        TextQueryMode::Phrase,
+    ] {
+        let hits = store
+            .search(TextSearchRequest {
+                query: "foo\"bar".to_string(),
+                mode: mode.clone(),
+                filter: Some(ns_filter("test_ns")),
+                top_k: 10,
+                snippet_chars: 64,
+            })
+            .await
+            .unwrap();
+        let hit_ids: std::collections::HashSet<_> =
+            hits.into_iter().map(|hit| hit.subject_id).collect();
+
+        assert!(
+            hit_ids.contains(&target_id),
+            "{mode:?} must preserve an embedded quote as literal query text; got {hit_ids:?}"
+        );
+    }
+}
+
 #[tokio::test]
 async fn test_search_with_mixed_punctuated_and_plain_tokens_does_not_crash() {
     let store = setup_trigram_store("mixed_punctuated_plain_query");
@@ -1476,7 +1501,7 @@ async fn test_search_with_mixed_punctuated_and_plain_tokens_does_not_crash() {
     for mode in [TextQueryMode::Plain, TextQueryMode::AnyTerm] {
         let result = store
             .search(TextSearchRequest {
-                query: "#682 Stage".to_string(),
+                query: "#682 Stage 2".to_string(),
                 mode: mode.clone(),
                 filter: Some(ns_filter("test_ns")),
                 top_k: 10,

--- a/crates/khive-db/src/stores/text_tests.rs
+++ b/crates/khive-db/src/stores/text_tests.rs
@@ -1300,6 +1300,203 @@ async fn test_search_slash_query_excludes_merged_alias_all_modes_and_tokenizers(
         .await;
 }
 
+/// #916 unit coverage for the allowlist helper itself: only ASCII
+/// alphanumerics and `_` are bareword-safe; every metacharacter named in the
+/// issue (`#`, `%`, `=`), plus the wider FTS5 punctuation set the empirical
+/// probe found unsafe, must be rejected.
+#[test]
+fn test_is_fts5_bareword_safe() {
+    assert!(is_fts5_bareword_safe("hello"));
+    assert!(is_fts5_bareword_safe("hello123"));
+    assert!(is_fts5_bareword_safe("_prefixed"));
+    assert!(is_fts5_bareword_safe("682"));
+    assert!(!is_fts5_bareword_safe(""));
+    for bad in [
+        "#682", "B=128", "K%Prob", "a&b", "a;b", "a<b", "a>b", "a?b", "a@b", "a[b", "a\\b", "a]b",
+        "a`b", "a{b", "a|b", "a}b", "a:b", "a-b",
+    ] {
+        assert!(
+            !is_fts5_bareword_safe(bad),
+            "{bad:?} must not be treated as a bareword-safe token"
+        );
+    }
+}
+
+/// #916 regression: `#682` (a bare issue-number query, e.g. from an agent
+/// recalling "#682 Stage 2") must not crash the FTS5 leg. Previously `#` was
+/// untouched by `sanitize_fts5_query`, so a single-token query reached
+/// `sanitize_fts5_token_group`'s old unconditional `split_terms.len() == 1`
+/// shortcut and hit FTS5 raw, producing `fts5: syntax error near "#"`.
+#[tokio::test]
+async fn test_search_with_hash_sign_does_not_crash_and_matches() {
+    let store = setup_trigram_store("hash_sign_query");
+
+    store
+        .upsert_document(make_document(
+            Uuid::new_v4(),
+            "issue tracker",
+            "tracking #682 Stage 2: MoE expert-cache prefetch work",
+        ))
+        .await
+        .unwrap();
+
+    for mode in [TextQueryMode::Plain, TextQueryMode::AnyTerm] {
+        let result = store
+            .search(TextSearchRequest {
+                query: "#682".to_string(),
+                mode: mode.clone(),
+                filter: Some(ns_filter("test_ns")),
+                top_k: 10,
+                snippet_chars: 64,
+            })
+            .await;
+        assert!(
+            result.is_ok(),
+            "#916 {mode:?} hash-sign query must not crash FTS5, got: {:?}",
+            result.err()
+        );
+        assert_eq!(
+            result.unwrap().len(),
+            1,
+            "#916 {mode:?} hash-sign query must still match the seeded document"
+        );
+    }
+}
+
+/// #916 regression: `B=128` (an equals-bearing token from a technical query
+/// like "chunkwise B=128 traffic") must not crash the FTS5 leg. `=` was
+/// previously untouched by `sanitize_fts5_query`.
+#[tokio::test]
+async fn test_search_with_equals_sign_does_not_crash_and_matches() {
+    let store = setup_trigram_store("equals_sign_query");
+
+    store
+        .upsert_document(make_document(
+            Uuid::new_v4(),
+            "benchmark notes",
+            "chunkwise B=128 traffic arithmetic simdgroup_matrix DPLR",
+        ))
+        .await
+        .unwrap();
+
+    for mode in [TextQueryMode::Plain, TextQueryMode::AnyTerm] {
+        let result = store
+            .search(TextSearchRequest {
+                query: "B=128".to_string(),
+                mode: mode.clone(),
+                filter: Some(ns_filter("test_ns")),
+                top_k: 10,
+                snippet_chars: 64,
+            })
+            .await;
+        assert!(
+            result.is_ok(),
+            "#916 {mode:?} equals-sign query must not crash FTS5, got: {:?}",
+            result.err()
+        );
+        assert_eq!(
+            result.unwrap().len(),
+            1,
+            "#916 {mode:?} equals-sign query must still match the seeded document"
+        );
+    }
+}
+
+/// #916 regression: `Min-K%Prob` (a percent-bearing punctuated identifier,
+/// verbatim from the issue's live-log evidence) must not crash the FTS5 leg.
+/// `%` was previously untouched by `sanitize_fts5_query`, and the hyphen
+/// split it into a multi-term group whose second term (`K%Prob`) carried the
+/// unsanitized `%` straight into a bareword position.
+#[tokio::test]
+async fn test_search_with_percent_sign_does_not_crash_and_matches() {
+    let store = setup_trigram_store("percent_sign_query");
+
+    store
+        .upsert_document(make_document(
+            Uuid::new_v4(),
+            "sampling notes",
+            "evaluated with the Min-K%Prob membership inference method",
+        ))
+        .await
+        .unwrap();
+
+    for mode in [TextQueryMode::Plain, TextQueryMode::AnyTerm] {
+        let result = store
+            .search(TextSearchRequest {
+                query: "Min-K%Prob".to_string(),
+                mode: mode.clone(),
+                filter: Some(ns_filter("test_ns")),
+                top_k: 10,
+                snippet_chars: 64,
+            })
+            .await;
+        assert!(
+            result.is_ok(),
+            "#916 {mode:?} percent-sign query must not crash FTS5, got: {:?}",
+            result.err()
+        );
+        assert_eq!(
+            result.unwrap().len(),
+            1,
+            "#916 {mode:?} percent-sign query must still match the seeded document"
+        );
+    }
+}
+
+/// #916 regression: a realistic multi-token query mixing FTS5-unsafe
+/// punctuated tokens with ordinary barewords (verbatim shape from the
+/// issue's live-log evidence: `"#682 Stage 2: MoE expert-cache prefetch"`)
+/// must not crash the FTS5 leg and must preserve AND-like discrimination —
+/// an unrelated document that only shares the plain bareword terms must not
+/// match.
+#[tokio::test]
+async fn test_search_with_mixed_punctuated_and_plain_tokens_does_not_crash() {
+    let store = setup_trigram_store("mixed_punctuated_plain_query");
+
+    let target_id = Uuid::new_v4();
+    store
+        .upsert_document(make_document(
+            target_id,
+            "issue tracker",
+            "tracking #682 Stage 2: MoE expert-cache prefetch work",
+        ))
+        .await
+        .unwrap();
+
+    let unrelated_id = Uuid::new_v4();
+    store
+        .upsert_document(make_document(
+            unrelated_id,
+            "doc",
+            "completely unrelated content about gardening Stage props",
+        ))
+        .await
+        .unwrap();
+
+    for mode in [TextQueryMode::Plain, TextQueryMode::AnyTerm] {
+        let result = store
+            .search(TextSearchRequest {
+                query: "#682 Stage".to_string(),
+                mode: mode.clone(),
+                filter: Some(ns_filter("test_ns")),
+                top_k: 10,
+                snippet_chars: 64,
+            })
+            .await;
+        assert!(
+            result.is_ok(),
+            "#916 {mode:?} mixed punctuated+plain query must not crash FTS5, got: {:?}",
+            result.err()
+        );
+        let hit_ids: std::collections::HashSet<_> =
+            result.unwrap().into_iter().map(|h| h.subject_id).collect();
+        assert!(
+            hit_ids.contains(&target_id),
+            "#916 {mode:?} mixed query must match the seeded document; got {hit_ids:?}"
+        );
+    }
+}
+
 #[tokio::test]
 async fn test_score_is_bounded() {
     let store = setup_memory_store("score_bounds");

--- a/crates/khive-pack-kg/src/dispatch.rs
+++ b/crates/khive-pack-kg/src/dispatch.rs
@@ -1035,17 +1035,8 @@ mod tests {
         );
     }
 
-    /// #916 regression: `search(kind="note", ...)` must succeed on a query
-    /// containing `@`, exercised end to end through verb dispatch.
-    ///
-    /// `@` used to reach SQLite FTS5's bareword parser raw (`sanitize_fts5_query`
-    /// did not strip it) and crash it, which `search_notes`
-    /// (khive-runtime/operations.rs) surfaced as `RuntimeError::InvalidInput`
-    /// per #569's fail-loud policy. `sanitize_fts5_token_group`'s
-    /// bareword-safety gate (#916) now routes `@` through the quoted-phrase
-    /// alternative instead, so the query succeeds and finds the seeded note.
     #[tokio::test]
-    async fn handler_search_note_residual_fts5_char_now_sanitized() {
+    async fn handler_search_note_sanitizes_fts5_metacharacters() {
         let rt = KhiveRuntime::memory().expect("in-memory runtime");
         let tok = rt.authorize(Namespace::local()).unwrap();
 
@@ -1054,39 +1045,44 @@ mod tests {
         let registry = builder.build().expect("registry build");
         let pack = KgPack::new(rt.clone());
 
-        pack.dispatch(
-            "create",
-            json!({
-                "kind": "observation",
-                "content": "use foo@bar to chain calls"
-            }),
-            &registry,
-            &tok,
-        )
-        .await
-        .expect("note create must succeed");
-
-        let result = pack
-            .dispatch(
-                "search",
+        for (query, content) in [
+            ("#682", "tracking #682 Stage 2 work"),
+            ("B=128", "chunkwise B=128 traffic"),
+            ("Min-K%Prob", "evaluate Min-K%Prob membership inference"),
+            ("foo\"bar", "the foo\"bar identifier"),
+            ("foo@bar", "use foo@bar to chain calls"),
+        ] {
+            pack.dispatch(
+                "create",
                 json!({
-                    "kind": "note",
-                    "query": "foo@bar",
-                    "limit": 10
+                    "kind": "observation",
+                    "content": content
                 }),
                 &registry,
                 &tok,
             )
-            .await;
+            .await
+            .expect("note create must succeed");
 
-        let value = result.unwrap_or_else(|e| {
-            panic!("#916 search(kind=\"note\") must not fail on an '@'-bearing query, got: {e:?}")
-        });
-        let hits = value.as_array().expect("search must return an array");
-        assert!(
-            !hits.is_empty(),
-            "#916 '@'-bearing query must still find the seeded 'foo@bar' note; got {hits:?}"
-        );
+            let value = pack
+                .dispatch(
+                    "search",
+                    json!({
+                        "kind": "note",
+                        "query": query,
+                        "limit": 10
+                    }),
+                    &registry,
+                    &tok,
+                )
+                .await
+                .unwrap_or_else(|e| panic!("search must accept query {query:?}, got: {e:?}"));
+            let hits = value.as_array().expect("search must return an array");
+            assert!(
+                !hits.is_empty(),
+                "query {query:?} must find the seeded note; got {hits:?}"
+            );
+        }
     }
 
     // ---- `resolve` verb (unified-verb draft ADR, Slice 1) ----

--- a/crates/khive-pack-kg/src/dispatch.rs
+++ b/crates/khive-pack-kg/src/dispatch.rs
@@ -1035,19 +1035,17 @@ mod tests {
         );
     }
 
-    /// #569 regression: `search(kind="note", ...)` must fail loud on a residual
-    /// FTS5 metacharacter, exercised end to end through verb dispatch.
+    /// #916 regression: `search(kind="note", ...)` must succeed on a query
+    /// containing `@`, exercised end to end through verb dispatch.
     ///
-    /// `sanitize_fts5_query` (khive-db) strips known-unsafe characters like `$`,
-    /// but by design stays minimal — it does not strip every character SQLite
-    /// FTS5's bareword parser rejects. `@` is one residual character that still
-    /// crashes the parser. `search_notes` (khive-runtime/operations.rs) now
-    /// surfaces that FTS parser error as `RuntimeError::InvalidInput` instead
-    /// of silently degrading to vector-only results (#569). This assertion
-    /// fails against the pre-#569 fail-open behavior (which returned `Ok`
-    /// here) and passes once the FTS leg fails closed.
+    /// `@` used to reach SQLite FTS5's bareword parser raw (`sanitize_fts5_query`
+    /// did not strip it) and crash it, which `search_notes`
+    /// (khive-runtime/operations.rs) surfaced as `RuntimeError::InvalidInput`
+    /// per #569's fail-loud policy. `sanitize_fts5_token_group`'s
+    /// bareword-safety gate (#916) now routes `@` through the quoted-phrase
+    /// alternative instead, so the query succeeds and finds the seeded note.
     #[tokio::test]
-    async fn handler_search_note_residual_fts5_char_fails_loud() {
+    async fn handler_search_note_residual_fts5_char_now_sanitized() {
         let rt = KhiveRuntime::memory().expect("in-memory runtime");
         let tok = rt.authorize(Namespace::local()).unwrap();
 
@@ -1081,11 +1079,13 @@ mod tests {
             )
             .await;
 
+        let value = result.unwrap_or_else(|e| {
+            panic!("#916 search(kind=\"note\") must not fail on an '@'-bearing query, got: {e:?}")
+        });
+        let hits = value.as_array().expect("search must return an array");
         assert!(
-            result.is_err(),
-            "#569 search(kind=\"note\") must fail loud on a residual FTS5 char ('@'), \
-             not silently degrade to vector-only results, got: {:?}",
-            result.ok()
+            !hits.is_empty(),
+            "#916 '@'-bearing query must still find the seeded 'foo@bar' note; got {hits:?}"
         );
     }
 

--- a/crates/khive-pack-memory/src/handlers/recall.rs
+++ b/crates/khive-pack-memory/src/handlers/recall.rs
@@ -1055,20 +1055,18 @@ mod tests {
         }
     }
 
-    /// #569 regression: unlike `$`, `@` is NOT stripped by `sanitize_fts5_query`
-    /// (by design — the sanitizer stays minimal per #388 scope). SQLite FTS5's
-    /// bareword parser still rejects `@` unconditionally, so this query reaches
-    /// the `Err` arm in `collect_recall_text_hits`
-    /// (khive-pack-memory/handlers/common.rs), which must now fail loud
-    /// instead of degrading to vector-only results as it did before #569.
-    /// This assertion fails against the pre-#569 fail-open behavior (which
-    /// returned `Ok` with a non-empty result here) and passes once the FTS
-    /// leg fails closed.
+    /// #916 regression: `@` used to reach SQLite FTS5's bareword parser raw
+    /// (`sanitize_fts5_query` did not strip it) and crash it, so this query
+    /// used to reach the `Err` arm in `collect_recall_text_hits`
+    /// (khive-pack-memory/handlers/common.rs), which failed loud per #569.
+    /// `sanitize_fts5_token_group`'s bareword-safety gate (#916) now routes
+    /// `@` through the quoted-phrase alternative instead, so `memory.recall`
+    /// succeeds end to end through verb dispatch.
     // `#[serial(background_tasks)]`: kept to match the fixture setup used by
     // the sibling dollar-sign test above.
     #[tokio::test]
     #[serial(background_tasks)]
-    async fn recall_with_residual_fts5_char_fails_loud() {
+    async fn recall_with_residual_fts5_char_now_sanitized() {
         const MODEL: &str = "recall-residual-char-test-model";
         const DIMS: usize = 32;
         const NOTE_TEXT: &str = "foo@bar chain call helper note";
@@ -1108,11 +1106,13 @@ mod tests {
             )
             .await;
 
+        let value = result.unwrap_or_else(|e| {
+            panic!("#916 memory.recall must not fail on an '@'-bearing query, got: {e:?}")
+        });
+        let hits = value.as_array().expect("recall result must be an array");
         assert!(
-            result.is_err(),
-            "#569 memory.recall must fail loud when the FTS leg errors on a residual \
-             FTS5 char ('@'), not silently degrade to vector-only results, got: {:?}",
-            result.ok()
+            !hits.is_empty(),
+            "#916 '@'-bearing query must still find the seeded note; got {value:?}"
         );
     }
 
@@ -3983,7 +3983,7 @@ mod tests {
         // path fans out to every *registered* model when the field is
         // omitted (`resolve_embedding_model` only accepts lattice aliases —
         // an explicit custom provider name here would hit `UnknownModel`,
-        // same gotcha documented on `recall_with_residual_fts5_char_fails_loud`
+        // same gotcha documented on `recall_with_residual_fts5_char_now_sanitized`
         // above). `NS733_ANN_MODEL` is the only model registered on this
         // runtime, so auto-detect resolves to exactly it.
         for i in 0..NS733_FILLER_COUNT {

--- a/crates/khive-runtime/src/fusion.rs
+++ b/crates/khive-runtime/src/fusion.rs
@@ -444,12 +444,13 @@ mod tests {
         );
     }
 
-    // 11. Unlike `$`, `@` is not stripped by sanitize_fts5_query (kept minimal by
-    // design), and SQLite FTS5's bareword parser rejects it unconditionally. That
-    // parser error must surface as RuntimeError::InvalidInput rather than silently
-    // degrading to vector-only fusion.
+    // 11. #916: `@` used to reach SQLite FTS5's bareword parser raw and error,
+    // surfacing as RuntimeError::InvalidInput per #569's fail-loud policy.
+    // sanitize_fts5_token_group's bareword-safety gate now routes it through the
+    // quoted-phrase alternative instead, so the query succeeds and the fail-loud
+    // arm is no longer reached for ordinary punctuation.
     #[tokio::test]
-    async fn hybrid_search_with_strategy_residual_fts5_char_fails_loud() {
+    async fn hybrid_search_with_strategy_residual_fts5_char_now_sanitized() {
         let rt = KhiveRuntime::memory().unwrap();
         let tok = NamespaceToken::local();
         rt.create_entity(
@@ -468,16 +469,15 @@ mod tests {
             .hybrid_search_with_strategy(&tok, "foo@bar", None, FusionStrategy::default(), 10)
             .await;
 
+        let hits = result.unwrap_or_else(|e| {
+            panic!(
+                "#916 hybrid_search_with_strategy must not fail on an '@'-bearing query, got: {e:?}"
+            )
+        });
         assert!(
-            result.is_err(),
-            "#569 hybrid_search_with_strategy must fail loud when the FTS leg errors \
-             on a residual FTS5 char ('@'), not silently degrade to vector-only fusion, \
-             got: {:?}",
-            result.ok()
-        );
-        assert!(
-            matches!(result.unwrap_err(), RuntimeError::InvalidInput(_)),
-            "residual FTS5 parser failure must surface as RuntimeError::InvalidInput"
+            !hits.is_empty(),
+            "#916 '@'-bearing query must still find the seeded 'foo@bar' content via the \
+             quoted-phrase alternative"
         );
     }
 }

--- a/crates/khive-runtime/src/operations.rs
+++ b/crates/khive-runtime/src/operations.rs
@@ -6021,14 +6021,14 @@ mod tests {
         );
     }
 
-    /// Regression: unlike `$`, `@` is NOT stripped by `sanitize_fts5_query`
-    /// (by design: the sanitizer stays minimal). SQLite FTS5's bareword
-    /// parser still rejects `@` unconditionally, so this query reaches the
-    /// runtime-level `Err` arm in `search_notes`, which must fail loud
-    /// (`RuntimeError::InvalidInput`) instead of silently degrading to
-    /// vector-only fusion.
+    /// #916: `@` used to reach SQLite FTS5's bareword parser raw and error
+    /// (`sanitize_fts5_query` did not strip it), surfacing as
+    /// `RuntimeError::InvalidInput` per #569's fail-loud policy.
+    /// `sanitize_fts5_token_group`'s bareword-safety gate now routes it
+    /// through the quoted-phrase alternative instead, so `search_notes`
+    /// succeeds and finds the seeded content.
     #[tokio::test]
-    async fn search_notes_with_residual_fts5_char_fails_loud() {
+    async fn search_notes_with_residual_fts5_char_now_sanitized() {
         let rt = rt();
         let tok = NamespaceToken::local();
         rt.create_note(
@@ -6047,15 +6047,13 @@ mod tests {
             .search_notes(&tok, "foo@bar", None, 10, None, false, &[], None)
             .await;
 
+        let hits = result.unwrap_or_else(|e| {
+            panic!("#916 search_notes must not fail on an '@'-bearing query, got: {e:?}")
+        });
         assert!(
-            result.is_err(),
-            "#569 search_notes must fail loud when the FTS leg errors on a residual \
-             FTS5 char ('@'), not silently degrade to vector-only fusion, got: {:?}",
-            result.ok()
-        );
-        assert!(
-            matches!(result.unwrap_err(), RuntimeError::InvalidInput(_)),
-            "residual FTS5 parser failure must surface as RuntimeError::InvalidInput"
+            !hits.is_empty(),
+            "#916 '@'-bearing query must still find the seeded 'foo@bar' content via the \
+             quoted-phrase alternative"
         );
     }
 

--- a/crates/khive-runtime/src/retrieval.rs
+++ b/crates/khive-runtime/src/retrieval.rs
@@ -1307,7 +1307,8 @@ mod tests {
     /// `hybrid_search` must not hard-fail on a query containing FTS5 metacharacters
     /// like `$` (e.g. the DSL doc query `$prev.id`). `sanitize_fts5_query` (khive-db)
     /// strips `$`, so this exercises the sanitizer path and takes the `Ok` arm; see
-    /// `hybrid_search_with_residual_fts5_char_fails_loud` below for the fail-loud arm.
+    /// `hybrid_search_with_residual_fts5_char_now_sanitized` below for the character
+    /// class #916 closed (previously the fail-loud arm, prior to #916).
     #[tokio::test]
     async fn hybrid_search_with_dollar_sign_query_does_not_error() {
         let rt = KhiveRuntime::memory().unwrap();
@@ -1335,13 +1336,16 @@ mod tests {
         );
     }
 
-    /// Unlike `$`, `@` is NOT stripped by `sanitize_fts5_query` (the sanitizer stays
-    /// minimal by design). SQLite FTS5's bareword parser still rejects `@`
-    /// unconditionally, so this query reaches the runtime-level `Err` arm in
-    /// `hybrid_search`, which must fail loud (`RuntimeError::InvalidInput`) instead
-    /// of silently degrading to vector-only fusion.
+    /// #916: `@` was previously NOT stripped by `sanitize_fts5_query` and SQLite
+    /// FTS5's bareword parser rejected it unconditionally, so this query used to
+    /// reach the runtime-level fail-loud arm (`RuntimeError::InvalidInput`, #569).
+    /// `sanitize_fts5_token_group`'s bareword-safety gate now recognizes `@` (and
+    /// every other ASCII punctuation character not already handled) as unsafe for
+    /// an unquoted bareword position and routes it through the quoted-phrase
+    /// alternative instead — which FTS5 always accepts literally — so the query
+    /// now succeeds and finds the seeded content rather than erroring.
     #[tokio::test]
-    async fn hybrid_search_with_residual_fts5_char_fails_loud() {
+    async fn hybrid_search_with_residual_fts5_char_now_sanitized() {
         let rt = KhiveRuntime::memory().unwrap();
         let tok = NamespaceToken::local();
         rt.create_entity(
@@ -1360,16 +1364,76 @@ mod tests {
             .hybrid_search(&tok, "foo@bar", None, 10, None, None, &[], None)
             .await;
 
+        let hits = result.unwrap_or_else(|e| {
+            panic!("#916 hybrid_search must not fail on an '@'-bearing query, got: {e:?}")
+        });
         assert!(
-            result.is_err(),
-            "#569 hybrid_search must fail loud when the FTS leg errors on a residual \
-             FTS5 char ('@'), not silently degrade to vector-only fusion, got: {:?}",
-            result.ok()
+            !hits.is_empty(),
+            "#916 '@'-bearing query must still find the seeded 'foo@bar' content via the \
+             quoted-phrase alternative"
         );
-        assert!(
-            matches!(result.unwrap_err(), RuntimeError::InvalidInput(_)),
-            "residual FTS5 parser failure must surface as RuntimeError::InvalidInput"
-        );
+    }
+
+    /// #916 end-to-end regression, using the exact character classes from the
+    /// issue's live-log evidence (`#682 Stage 2`, `Min-K%Prob`, `B=128`):
+    /// `hybrid_search`'s FTS leg must not lose its lexical signal to a parser
+    /// syntax error on `#`, `%`, or `=`. Each query below must both succeed
+    /// and actually surface a `Text`/`Both`-sourced hit — proving the FTS leg
+    /// contributed, not just that the vector leg papered over a degraded
+    /// text leg.
+    #[tokio::test]
+    async fn hybrid_search_with_916_issue_characters_finds_text_leg_hits() {
+        let rt = KhiveRuntime::memory().unwrap();
+        let tok = NamespaceToken::local();
+
+        rt.create_entity(
+            &tok,
+            "concept",
+            None,
+            "issue tracker",
+            Some("tracking #682 Stage 2: MoE expert-cache prefetch work"),
+            None,
+            vec![],
+        )
+        .await
+        .unwrap();
+        rt.create_entity(
+            &tok,
+            "concept",
+            None,
+            "benchmark notes",
+            Some("chunkwise B=128 traffic arithmetic simdgroup_matrix DPLR"),
+            None,
+            vec![],
+        )
+        .await
+        .unwrap();
+        rt.create_entity(
+            &tok,
+            "concept",
+            None,
+            "sampling notes",
+            Some("evaluated with the Min-K%Prob membership inference method"),
+            None,
+            vec![],
+        )
+        .await
+        .unwrap();
+
+        for query in ["#682 Stage 2", "B=128", "Min-K%Prob"] {
+            let result = rt
+                .hybrid_search(&tok, query, None, 10, None, None, &[], None)
+                .await;
+            let hits = result.unwrap_or_else(|e| {
+                panic!("#916 hybrid_search must not fail on query {query:?}, got: {e:?}")
+            });
+            assert!(
+                hits.iter()
+                    .any(|h| matches!(h.source, SearchSource::Text | SearchSource::Both)),
+                "#916 query {query:?} must surface a Text/Both-sourced hit \
+                 (the FTS leg must contribute, not just the vector leg); got {hits:?}"
+            );
+        }
     }
 
     // ---- predicate pushdown before truncation ----

--- a/crates/khive-runtime/src/retrieval.rs
+++ b/crates/khive-runtime/src/retrieval.rs
@@ -1342,7 +1342,7 @@ mod tests {
     /// `sanitize_fts5_token_group`'s bareword-safety gate now recognizes `@` (and
     /// every other ASCII punctuation character not already handled) as unsafe for
     /// an unquoted bareword position and routes it through the quoted-phrase
-    /// alternative instead — which FTS5 always accepts literally — so the query
+    /// alternative instead, which FTS5 accepts literally, so the query
     /// now succeeds and finds the seeded content rather than erroring.
     #[tokio::test]
     async fn hybrid_search_with_residual_fts5_char_now_sanitized() {
@@ -1378,7 +1378,7 @@ mod tests {
     /// issue's live-log evidence (`#682 Stage 2`, `Min-K%Prob`, `B=128`):
     /// `hybrid_search`'s FTS leg must not lose its lexical signal to a parser
     /// syntax error on `#`, `%`, or `=`. Each query below must both succeed
-    /// and actually surface a `Text`/`Both`-sourced hit — proving the FTS leg
+    /// and actually surface a `Text`/`Both`-sourced hit, proving the FTS leg
     /// contributed, not just that the vector leg papered over a degraded
     /// text leg.
     #[tokio::test]


### PR DESCRIPTION
## Summary

- Restrict unquoted FTS5 barewords to a conservative safe character set and route punctuation-bearing terms through quoted phrase expressions.
- Escape embedded double quotes so trigram search preserves the literal query text.
- Preserve the safe single-term path so production-shaped queries such as `#682 Stage 2` keep their lexical hits.
- Cover `#`, `%`, `=`, quotes, and other punctuation through storage and KG dispatch tests.
- Keep genuine storage and backend failures on the existing fail-loud path.

## Testing

- `CARGO_TARGET_DIR=/private/tmp/khive-shared-target RUSTC_WRAPPER= cargo clippy -p khive-db -p khive-pack-kg --all-targets -- -D warnings`
- `CARGO_TARGET_DIR=/private/tmp/khive-shared-target RUSTC_WRAPPER= cargo test -p khive-db -p khive-pack-kg`
- `CARGO_TARGET_DIR=/private/tmp/khive-shared-target RUSTC_WRAPPER= cargo fmt --all -- --check`
- `CARGO_TARGET_DIR=/private/tmp/khive-shared-target RUSTC_WRAPPER= cargo check --workspace`

Closes #916