### PR TITLE
chore: rename 24 test fns to behavior-descriptive names (#935)

### DIFF
--- a/crates/khive-pack-memory/src/pack.rs
+++ b/crates/khive-pack-memory/src/pack.rs
@@ -924,7 +924,7 @@ mod note_mutation_hook_tests {
     /// pattern. Also returns the `MemoryPack`'s `SharedAnn` handle (cloned
     /// before the pack is moved into the builder) so tests can assert
     /// `ann::is_current` directly.
-    fn fr1_build_registry(rt: &KhiveRuntime) -> (khive_runtime::VerbRegistry, SharedAnn) {
+    fn build_note_hook_registry(rt: &KhiveRuntime) -> (khive_runtime::VerbRegistry, SharedAnn) {
         let mut builder = VerbRegistryBuilder::new();
         builder.register(KgPack::new(rt.clone()));
         let memory_pack = MemoryPack::new(rt.clone());
@@ -935,7 +935,7 @@ mod note_mutation_hook_tests {
         (registry, ann)
     }
 
-    fn fr1_key() -> ann::AnnKey {
+    fn mutation_hook_ann_key() -> ann::AnnKey {
         ann::AnnKey::new("local", FR1_MODEL)
     }
 
@@ -945,7 +945,7 @@ mod note_mutation_hook_tests {
     /// single recall is enough to guarantee the index is installed. Returns
     /// the seeded note's id and asserts the cache is current before the
     /// caller's mutation under test.
-    async fn fr1_seed_and_warm(
+    async fn seed_and_warm_ann(
         rt: &KhiveRuntime,
         registry: &khive_runtime::VerbRegistry,
         ann: &SharedAnn,
@@ -982,7 +982,7 @@ mod note_mutation_hook_tests {
             .expect("warm recall");
 
         assert!(
-            ann::is_current(ann, &fr1_key()).await,
+            ann::is_current(ann, &mutation_hook_ann_key()).await,
             "sanity: warm-up recall must leave the ANN cache current before \
              the mutation under test"
         );
@@ -991,11 +991,11 @@ mod note_mutation_hook_tests {
 
     #[tokio::test]
     #[serial(background_tasks)]
-    async fn fr1_prune_invalidates_warm_ann_without_subsequent_remember() {
+    async fn prune_invalidates_warm_ann_without_subsequent_remember() {
         let rt = KhiveRuntime::memory().expect("in-memory runtime");
-        let (registry, ann) = fr1_build_registry(&rt);
+        let (registry, ann) = build_note_hook_registry(&rt);
 
-        fr1_seed_and_warm(&rt, &registry, &ann, "fr1 prune target content", 0.9).await;
+        seed_and_warm_ann(&rt, &registry, &ann, "fr1 prune target content", 0.9).await;
 
         // `min_salience: 1.0` is strictly above the seeded note's 0.9
         // salience, so it is the one candidate. No `memory.remember` call
@@ -1013,7 +1013,7 @@ mod note_mutation_hook_tests {
         );
 
         assert!(
-            !ann::is_current(&ann, &fr1_key()).await,
+            !ann::is_current(&ann, &mutation_hook_ann_key()).await,
             "memory.prune deleting a candidate must invalidate the warm ANN \
              generation for affected models (#750)"
         );
@@ -1021,11 +1021,11 @@ mod note_mutation_hook_tests {
 
     #[tokio::test]
     #[serial(background_tasks)]
-    async fn fr1_kg_update_reindex_invalidates_warm_ann_without_subsequent_remember() {
+    async fn kg_update_reindex_invalidates_warm_ann_without_subsequent_remember() {
         let rt = KhiveRuntime::memory().expect("in-memory runtime");
-        let (registry, ann) = fr1_build_registry(&rt);
+        let (registry, ann) = build_note_hook_registry(&rt);
 
-        let id = fr1_seed_and_warm(&rt, &registry, &ann, "fr1 update target content", 0.7).await;
+        let id = seed_and_warm_ann(&rt, &registry, &ann, "fr1 update target content", 0.7).await;
 
         // KG's generic `update` verb — NOT `memory.remember` — changes the
         // note's content. Same call shape `khive-pack-kg/src/handlers/
@@ -1040,7 +1040,7 @@ mod note_mutation_hook_tests {
             .expect("kg update on memory-kind note");
 
         assert!(
-            !ann::is_current(&ann, &fr1_key()).await,
+            !ann::is_current(&ann, &mutation_hook_ann_key()).await,
             "a KG `update` that changes a memory-kind note's content must \
              invalidate the warm ANN generation (#750)"
         );
@@ -1048,11 +1048,11 @@ mod note_mutation_hook_tests {
 
     #[tokio::test]
     #[serial(background_tasks)]
-    async fn fr1_kg_delete_invalidates_warm_ann_without_subsequent_remember() {
+    async fn kg_delete_invalidates_warm_ann_without_subsequent_remember() {
         let rt = KhiveRuntime::memory().expect("in-memory runtime");
-        let (registry, ann) = fr1_build_registry(&rt);
+        let (registry, ann) = build_note_hook_registry(&rt);
 
-        let id = fr1_seed_and_warm(&rt, &registry, &ann, "fr1 delete target content", 0.7).await;
+        let id = seed_and_warm_ann(&rt, &registry, &ann, "fr1 delete target content", 0.7).await;
 
         // KG's generic `delete` verb (soft delete by default) — NOT any
         // memory-pack verb.
@@ -1067,7 +1067,7 @@ mod note_mutation_hook_tests {
         );
 
         assert!(
-            !ann::is_current(&ann, &fr1_key()).await,
+            !ann::is_current(&ann, &mutation_hook_ann_key()).await,
             "a KG `delete` on a memory-kind note must invalidate the warm \
              ANN generation (#750)"
         );
@@ -1080,7 +1080,7 @@ mod note_mutation_hook_tests {
     /// above.
     ///
     /// Both notes are seeded and the cache is warmed only ONCE, AFTER both
-    /// exist — NOT via `fr1_seed_and_warm` for the first note followed by a
+    /// exist — NOT via `seed_and_warm_ann` for the first note followed by a
     /// second `memory.remember` for the second, because `memory.remember`'s
     /// own handler already calls `ann::bump_generation` on every create
     /// (`handlers/remember.rs`). Warming before the second note existed
@@ -1091,9 +1091,9 @@ mod note_mutation_hook_tests {
     /// call commented out).
     #[tokio::test]
     #[serial(background_tasks)]
-    async fn fr2_kg_merge_invalidates_warm_ann_without_subsequent_remember() {
+    async fn kg_merge_invalidates_warm_ann_without_subsequent_remember() {
         let rt = KhiveRuntime::memory().expect("in-memory runtime");
-        let (registry, ann) = fr1_build_registry(&rt);
+        let (registry, ann) = build_note_hook_registry(&rt);
 
         rt.register_embedder(Fr1FixedVecProvider {
             model_name: FR1_MODEL.to_string(),
@@ -1143,9 +1143,9 @@ mod note_mutation_hook_tests {
         // single-flight `warming` guard for this key to clear before
         // trusting `is_current` — the guard is only released once every
         // in-flight rebuild for this key has actually finished.
-        ann::wait_until_warm_idle(&ann, &fr1_key()).await;
+        ann::wait_until_warm_idle(&ann, &mutation_hook_ann_key()).await;
         assert!(
-            ann::is_current(&ann, &fr1_key()).await,
+            ann::is_current(&ann, &mutation_hook_ann_key()).await,
             "sanity: warm-up recall must leave the ANN cache current before \
              the merge under test"
         );
@@ -1163,7 +1163,7 @@ mod note_mutation_hook_tests {
             .expect("kg merge on memory-kind notes");
 
         assert!(
-            !ann::is_current(&ann, &fr1_key()).await,
+            !ann::is_current(&ann, &mutation_hook_ann_key()).await,
             "a KG `merge` of two memory-kind notes must invalidate the warm \
              ANN generation (#750)"
         );

--- a/crates/khive-pack-memory/src/pack.rs
+++ b/crates/khive-pack-memory/src/pack.rs
@@ -1076,11 +1076,11 @@ mod note_mutation_hook_tests {
     /// #750: `merge_note`'s non-dry-run
     /// success path reindexes the surviving note (a corpus change exactly
     /// like `update_note`'s `text_changed` branch) but never fired the
-    /// note-mutation hook. Same white-box shape as the three fr1 tests
-    /// above.
+    /// note-mutation hook. Same white-box shape as the three ANN-invalidation
+    /// tests above.
     ///
     /// Both notes are seeded and the cache is warmed only ONCE, AFTER both
-    /// exist — NOT via `seed_and_warm_ann` for the first note followed by a
+    /// exist, NOT via `seed_and_warm_ann` for the first note followed by a
     /// second `memory.remember` for the second, because `memory.remember`'s
     /// own handler already calls `ann::bump_generation` on every create
     /// (`handlers/remember.rs`). Warming before the second note existed

--- a/crates/khive-pack-schedule/tests/create_validation.rs
+++ b/crates/khive-pack-schedule/tests/create_validation.rs
@@ -1325,7 +1325,7 @@ async fn schedule_schedule_rejects_entity_type_under_resource_kind_bulk() {
 /// instead of silently reproducing a false-rejection bug like the one
 /// found before.
 #[tokio::test]
-async fn gap1_every_real_registry_subtype_is_accepted_by_schedule() {
+async fn schedule_accepts_every_registered_entity_subtype() {
     use khive_pack_kg::EntityTypeRegistry;
     use khive_types::EntityKind;
 

--- a/crates/khive-runtime/src/secret_gate.rs
+++ b/crates/khive-runtime/src/secret_gate.rs
@@ -2623,7 +2623,7 @@ mod tests {
     // they block near a trigger word.
 
     #[test]
-    fn blocks_file_path_near_secret_word_accepted_fp_round4() {
+    fn blocks_high_entropy_file_path_near_secret_word() {
         // Full-token entropy 4.5994 > ENTROPY_THRESHOLD (4.5).
         let content =
             "workspace path fable-ops/ADR-DRAFT-adr079-slices234.md for the secret gate bug";
@@ -2636,7 +2636,7 @@ mod tests {
     }
 
     #[test]
-    fn blocks_workspace_path_near_key_word_accepted_fp_round4() {
+    fn blocks_high_entropy_workspace_path_near_key_word() {
         // Full-token entropy 4.7938 > 4.5.
         let content = "key: see internal/workspaces/20260701/adr079-slices234/PACKET.md";
         assert!(
@@ -2648,7 +2648,7 @@ mod tests {
     }
 
     #[test]
-    fn blocks_short_run_path_near_auth_word_accepted_fp_round4() {
+    fn blocks_high_entropy_short_run_path_near_auth_word() {
         // Full-token entropy 4.5955 > 4.5.
         let content =
             "auth work saved at internal/workspaces/20260701/cloud-rebuild/R1-repo-audit.md";
@@ -2854,7 +2854,7 @@ mod tests {
     }
 
     #[test]
-    fn blocks_round1_bypass_strings_still_without_extension() {
+    fn blocks_unsuffixed_separator_split_credential_bypasses() {
         let cases = [
             "secret_access_key abcdefghij/klmnopqrst/uvwxyzabcd/efghijk",
             "token=zxkqwmvbpl/trfhysjgnc/dweiaoutkz-mnbvcxzlk",
@@ -2884,7 +2884,7 @@ mod tests {
     }
 
     #[test]
-    fn blocks_round3_padding_run_bypass_attempts() {
+    fn blocks_low_entropy_padding_run_bypass_attempts() {
         // A low-entropy padding run (`aaaa`) inserted before short/digit-shaped
         // runs would drag any AVERAGE per-run entropy signal below its
         // threshold. With the exemption dropped entirely, these must be
@@ -2982,7 +2982,7 @@ mod tests {
     }
 
     #[test]
-    fn accepted_false_positive_r1_repo_audit_path_near_trigger() {
+    fn blocks_high_entropy_repo_audit_path_near_api_key() {
         // Same tradeoff as above: full-token entropy 4.5955 > 4.5.
         let content =
             "api_key handling in internal/workspaces/20260701/cloud-rebuild/R1-repo-audit.md";
@@ -3052,7 +3052,7 @@ mod tests {
     }
 
     #[test]
-    fn allows_internal_area_id_uuid_near_auth_substring_round5() {
+    fn allows_area_id_uuid_near_authorized_substring() {
         // An internal task `area_id` UUID field sitting within the trigger
         // window of the SUBSTRING "auth" inside
         // `authorized_write_requires_dominance` is not a genuine mention of
@@ -3412,7 +3412,7 @@ mod tests {
     }
 
     #[test]
-    fn blocks_standalone_auth_and_key_words_unchanged_by_round5() {
+    fn blocks_opaque_tokens_near_standalone_trigger_words() {
         // Word-boundary matching only removes SUBSTRING collisions; a genuine
         // standalone trigger word must still dominate exactly as before.
         let opaque = "Xk9mZ2vQpLrT8nJwYuAeHfBsDcGiONvMabcdef"; // gitleaks:allow
@@ -3432,7 +3432,7 @@ mod tests {
     }
 
     #[test]
-    fn accepted_false_positive_workspace_artifact_path_near_standalone_secret_round5() {
+    fn blocks_workspace_artifact_path_near_standalone_secret() {
         // A dot-prefixed root + date segment + hyphenated topic dir +
         // SCREAMING_SNAKE filename, discussed in prose that genuinely (not by
         // substring collision) mentions "secret". `secret` here is a real
@@ -3451,7 +3451,7 @@ mod tests {
     }
 
     #[test]
-    fn accepted_false_positive_archive_doc_path_near_standalone_secret_round5() {
+    fn blocks_archive_doc_path_near_standalone_secret() {
         // An archive-style doc path discussed near a genuine standalone
         // "secret" mention.
         let content =
@@ -3465,7 +3465,7 @@ mod tests {
     }
 
     #[test]
-    fn accepted_false_positive_absolute_path_near_standalone_auth_round5() {
+    fn blocks_absolute_path_near_standalone_auth() {
         // An absolute path written as one unbroken token, with the
         // surrounding message genuinely (not via substring collision)
         // discussing "auth".
@@ -3497,7 +3497,7 @@ mod tests {
     }
 
     #[test]
-    fn blocks_secret_access_key_bypass_compound_entry_unaffected_by_round5() {
+    fn blocks_separator_split_secret_access_key_compound() {
         // Adversarial negative: a separator-split bypass shape must still be
         // blocked. The `secret` and `key` entries both match because underscore
         // is a boundary for bare `TRIGGER_WORDS`. This asserts the end-to-end
@@ -3527,7 +3527,7 @@ mod tests {
     // rule (the `tokenizer`/`next_token`/`token_count` exemption) unchanged.
 
     #[test]
-    fn blocks_django_style_secret_key_assignment_round5b() {
+    fn blocks_secret_key_assignment_when_underscore_bounds_trigger() {
         // `SECRET_KEY=<value>` must block via the plain-substring `secret`
         // trigger even though `secret` is followed by `_` rather than a
         // non-word-char boundary.
@@ -3541,7 +3541,7 @@ mod tests {
     }
 
     #[test]
-    fn blocks_auth_token_assignment_round5b() {
+    fn blocks_auth_token_assignment_when_underscore_bounds_trigger() {
         let opaque = "Xk9mZ2vQpLrT8nJwYuAeHfBsDcGiONvMabcdef"; // gitleaks:allow
         let content = format!("auth_token={opaque}");
         assert!(
@@ -3552,7 +3552,7 @@ mod tests {
     }
 
     #[test]
-    fn blocks_session_secret_and_signing_key_compounds_round5b() {
+    fn blocks_underscore_joined_session_secret_and_signing_key_compounds() {
         let opaque = "Xk9mZ2vQpLrT8nJwYuAeHfBsDcGiONvMabcdef"; // gitleaks:allow
         let cases = [
             format!("session_secret_{opaque}"),
@@ -3569,7 +3569,7 @@ mod tests {
     }
 
     #[test]
-    fn allows_authorized_authentication_keyword_prose_unaffected_by_round5b() {
+    fn allows_letter_joined_trigger_substrings_in_benign_prose() {
         // The letter-joined substring-collision exemption must survive the
         // underscore-as-boundary change, since that change only affects the
         // underscore character, not letter-joined words.


### PR DESCRIPTION
## Summary

Rename-only change for issue #935. No assertions, inputs, comments other than a direct helper-name reference, or behavior changed.

### crates/khive-runtime/src/secret_gate.rs

- `blocks_file_path_near_secret_word_accepted_fp_round4` -> `blocks_high_entropy_file_path_near_secret_word`
- `blocks_workspace_path_near_key_word_accepted_fp_round4` -> `blocks_high_entropy_workspace_path_near_key_word`
- `blocks_short_run_path_near_auth_word_accepted_fp_round4` -> `blocks_high_entropy_short_run_path_near_auth_word`
- `blocks_round1_bypass_strings_still_without_extension` -> `blocks_unsuffixed_separator_split_credential_bypasses`
- `blocks_round3_padding_run_bypass_attempts` -> `blocks_low_entropy_padding_run_bypass_attempts`
- `accepted_false_positive_r1_repo_audit_path_near_trigger` -> `blocks_high_entropy_repo_audit_path_near_api_key`
- `allows_internal_area_id_uuid_near_auth_substring_round5` -> `allows_area_id_uuid_near_authorized_substring`
- `blocks_standalone_auth_and_key_words_unchanged_by_round5` -> `blocks_opaque_tokens_near_standalone_trigger_words`
- `accepted_false_positive_workspace_artifact_path_near_standalone_secret_round5` -> `blocks_workspace_artifact_path_near_standalone_secret`
- `accepted_false_positive_archive_doc_path_near_standalone_secret_round5` -> `blocks_archive_doc_path_near_standalone_secret`
- `accepted_false_positive_absolute_path_near_standalone_auth_round5` -> `blocks_absolute_path_near_standalone_auth`
- `blocks_secret_access_key_bypass_compound_entry_unaffected_by_round5` -> `blocks_separator_split_secret_access_key_compound`
- `blocks_django_style_secret_key_assignment_round5b` -> `blocks_secret_key_assignment_when_underscore_bounds_trigger`
- `blocks_auth_token_assignment_round5b` -> `blocks_auth_token_assignment_when_underscore_bounds_trigger`
- `blocks_session_secret_and_signing_key_compounds_round5b` -> `blocks_underscore_joined_session_secret_and_signing_key_compounds`
- `allows_authorized_authentication_keyword_prose_unaffected_by_round5b` -> `allows_letter_joined_trigger_substrings_in_benign_prose`

### crates/khive-pack-memory/src/pack.rs

- `fr1_build_registry` -> `build_note_hook_registry`
- `fr1_key` -> `mutation_hook_ann_key`
- `fr1_seed_and_warm` -> `seed_and_warm_ann`
- `fr1_prune_invalidates_warm_ann_without_subsequent_remember` -> `prune_invalidates_warm_ann_without_subsequent_remember`
- `fr1_kg_update_reindex_invalidates_warm_ann_without_subsequent_remember` -> `kg_update_reindex_invalidates_warm_ann_without_subsequent_remember`
- `fr1_kg_delete_invalidates_warm_ann_without_subsequent_remember` -> `kg_delete_invalidates_warm_ann_without_subsequent_remember`
- `fr2_kg_merge_invalidates_warm_ann_without_subsequent_remember` -> `kg_merge_invalidates_warm_ann_without_subsequent_remember`

### crates/khive-pack-schedule/tests/create_validation.rs

- `gap1_every_real_registry_subtype_is_accepted_by_schedule` -> `schedule_accepts_every_registered_entity_subtype`

## Validation

- `cargo test -p khive-runtime -p khive-pack-memory -p khive-pack-schedule`
- `cargo fmt --all -- --check`
- Declaration scan: 24 removed and 24 added function declarations
