### PR TITLE
fix(db): deterministic age in tx_age_sweep reader-pin test

### DIFF
--- a/crates/khive-db/src/checkpoint.rs
+++ b/crates/khive-db/src/checkpoint.rs
@@ -2783,10 +2783,12 @@ mod tests {
         );
 
         // The Plank 1 sweep, given the SAME registry state, must name the
-        // pinning reader at the Stale rung (millisecond-scale caps mean the
-        // freshly-registered handle is already "stale" by the time we
-        // observe it here, exactly like the always-stale-on-first-tick case
-        // covered by the pure unit test above).
+        // pinning reader at the Stale rung. The handle's age must exceed the
+        // 1ms `tx_max_age_secs` cap deterministically: the inserts plus one
+        // PASSIVE checkpoint above can complete in under a millisecond on a
+        // warm page cache (#934), so sleep past the cap instead of assuming
+        // the elapsed work already crossed it.
+        std::thread::sleep(Duration::from_millis(5));
         let mut tx_age_state = TxAgeSweepState::default();
         let emissions = tx_age_state.observe(khive_storage::tx_registry::oldest(), &config);
         assert!(

--- a/crates/khive-db/src/checkpoint.rs
+++ b/crates/khive-db/src/checkpoint.rs
@@ -2786,7 +2786,7 @@ mod tests {
         // pinning reader at the Stale rung. The handle's age must exceed the
         // 1ms `tx_max_age_secs` cap deterministically: the inserts plus one
         // PASSIVE checkpoint above can complete in under a millisecond on a
-        // warm page cache (#934), so sleep past the cap instead of assuming
+        // warm page cache, so sleep past the cap instead of assuming
         // the elapsed work already crossed it.
         std::thread::sleep(Duration::from_millis(5));
         let mut tx_age_state = TxAgeSweepState::default();


### PR DESCRIPTION
Fixes #934.

## What changed

One test-only change in `crates/khive-db/src/checkpoint.rs`: `tx_age_sweep_names_long_lived_reader_pinning_wal_past_high_water` now sleeps 5ms before the `observe` call, and the adjacent doc comment is rewritten to state the determinism guarantee instead of the old assumption.

## Why

The test set `tx_warn_secs` and `tx_max_age_secs` to 1ms and assumed the span between `tx_registry::register` and `observe` (50 inserts plus one PASSIVE checkpoint) always exceeds 1ms. On a warm page cache that span can complete in under a millisecond, so `observe` returns an empty vec and the test panics with `expected a Stale emission naming the pinning reader, got: []` (seen on the macOS CI leg of PR #897). Sleeping 5ms past the 1ms cap makes the age precondition deterministic; the sweep logic under test is unchanged. Clock injection was considered but `tx_registry::register` stamps `Instant::now()` internally, so a test-only backdate API would be new surface for one test.

## Verification

- `cargo test -p khive-db --lib checkpoint::tests::tx_age`: 9 passed, run 5 consecutive times, 0 failures
- `cargo fmt --all -- --check`: clean

Diff shape: 1 file, +6/-4 — one added sleep line plus the rewritten 5-line comment block. No production code, assertions, or inputs changed.