### PR TITLE
fix(ci): per-component bench job timeout so packs trend data flows again

### DIFF
--- a/.github/workflows/bench-component.yml
+++ b/.github/workflows/bench-component.yml
@@ -11,6 +11,14 @@ on:
         description: Space-separated Criterion crate packages in this component
         required: true
         type: string
+      timeout_minutes:
+        description: >-
+          Job timeout in minutes. Components whose bench-target compile is
+          heavier than the default budget (packs: ~16m compile alone) pass a
+          larger value so the Criterion step keeps its full 10-minute bound.
+        required: false
+        type: number
+        default: 20
 
 env:
   CARGO_TERM_COLOR: always
@@ -22,7 +30,7 @@ jobs:
   criterion:
     name: Criterion quick profile
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: ${{ inputs.timeout_minutes }}
 
     steps:
       - uses: actions/checkout@v7

--- a/.github/workflows/bench-track.yml
+++ b/.github/workflows/bench-track.yml
@@ -206,6 +206,10 @@ jobs:
     with:
       component: packs
       crates: khive-pack-gtd khive-pack-kg khive-pack-knowledge khive-pack-memory khive-pack-schedule
+      # The packs bench-target compile alone runs ~16m (issue #940); the
+      # default 20m budget killed the Criterion step mid-run on every main
+      # push and the ledger steps skipped, leaving the trend data packs-blind.
+      timeout_minutes: 40
 
   # ─────────────────────────────────────────────────────────────────────────
   # e2e benches: the pipeline daemon suite (bench_calibrate's `pipeline`


### PR DESCRIPTION
Minimal unblock for #940 (does not close it — the compile-cache investigation and informed split/trim follow once full runs land).

## What changed

Two workflow files, +13/-1:

- `.github/workflows/bench-component.yml`: new optional `timeout_minutes` workflow_call input (number, default 20) consumed by the criterion job's `timeout-minutes`. All existing callers keep the 20m default.
- `.github/workflows/bench-track.yml`: the packs component invocation passes `timeout_minutes: 40`, with a comment citing the evidence.

## Why

Step-level timing from the killed job (86767889183, main push): the packs bench-target compile alone takes 16m23s (vs 2m07s for scoring-retrieval in the same run, both with 4s cache restores), so the 10-minute-bounded Criterion step was killed at 3m36s by the 20m job cap and the ledger record/publish steps skipped. Result: 27 of the last 30 main trend runs conclude cancelled and the trend ledger has been silently packs-blind. 40m = 16m compile + 10m Criterion bound + setup/publish headroom.

## Verification

- No behavior change for scoring-retrieval / ann-query / storage-brain / e2e paths (default preserved).
- Real verification is the first post-merge main push: the packs job should complete and 'Record component trend ledger entry' + 'Publish ledger to perf-data branch' should run instead of skip.