### PR TITLE
fix(brain): normalize event_counts actor filter + add counts_by_verb (#943)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -108,23 +108,23 @@ Composite scores are always in [0,1]. Typical production floor: 0.3-0.7.
 
 ### Brain pack — 15 verbs (`brain.` prefix)
 
-| Verb                     | What it does                                                      | When to use                                                |
-| ------------------------ | ----------------------------------------------------------------- | ---------------------------------------------------------- |
-| `brain.event_counts`     | Windowed event counts by kind/actor (+ feedback by_profile split) | Flywheel metrics, feedback-coverage reporting              |
-| `brain.profiles`         | List profiles (optionally filtered by lifecycle)                  | See what profiles exist                                    |
-| `brain.profile`          | Full detail: metadata, snapshot, state summary                    | Inspect a specific profile                                 |
-| `brain.create_profile`   | Create a new profile with optional seed priors                    | Custom tuning for a new consumer                           |
-| `brain.resolve`          | Which profile serves a given consumer context?                    | Before recall — check active tuning                        |
-| `brain.activate`         | Start live update loop for a profile                              | Enable feedback-driven tuning                              |
-| `brain.deactivate`       | Stop live updates, retain state                                   | Pause tuning without losing progress                       |
-| `brain.archive`          | Read-only, audit-retained                                         | Retire a profile permanently                               |
-| `brain.reset`            | Reset posteriors to priors (preserves event history)              | Start tuning fresh                                         |
-| `brain.feedback`         | Emit explicit feedback event                                      | Rate a recall result as useful/not_useful/wrong            |
-| `brain.auto_feedback`    | Emit implicit feedback for recall results                         | Convenience: agents call after memory.recall               |
-| `brain.bind`             | Bind a profile to an actor + consumer                             | Route a specific caller to a specific profile              |
-| `brain.unbind`           | Remove a binding                                                  | Stop routing                                               |
-| `brain.bindings`         | List binding rows                                                 | Audit profile routing                                      |
-| `brain.register_adapter` | Register an adapter integrity record                              | Gate adapter composition to the active base-model revision |
+| Verb                     | What it does                                                           | When to use                                                |
+| ------------------------ | ---------------------------------------------------------------------- | ---------------------------------------------------------- |
+| `brain.event_counts`     | Windowed event counts by kind/actor/verb (+ feedback by_profile split) | Flywheel metrics, feedback-coverage reporting              |
+| `brain.profiles`         | List profiles (optionally filtered by lifecycle)                       | See what profiles exist                                    |
+| `brain.profile`          | Full detail: metadata, snapshot, state summary                         | Inspect a specific profile                                 |
+| `brain.create_profile`   | Create a new profile with optional seed priors                         | Custom tuning for a new consumer                           |
+| `brain.resolve`          | Which profile serves a given consumer context?                         | Before recall — check active tuning                        |
+| `brain.activate`         | Start live update loop for a profile                                   | Enable feedback-driven tuning                              |
+| `brain.deactivate`       | Stop live updates, retain state                                        | Pause tuning without losing progress                       |
+| `brain.archive`          | Read-only, audit-retained                                              | Retire a profile permanently                               |
+| `brain.reset`            | Reset posteriors to priors (preserves event history)                   | Start tuning fresh                                         |
+| `brain.feedback`         | Emit explicit feedback event                                           | Rate a recall result as useful/not_useful/wrong            |
+| `brain.auto_feedback`    | Emit implicit feedback for recall results                              | Convenience: agents call after memory.recall               |
+| `brain.bind`             | Bind a profile to an actor + consumer                                  | Route a specific caller to a specific profile              |
+| `brain.unbind`           | Remove a binding                                                       | Stop routing                                               |
+| `brain.bindings`         | List binding rows                                                      | Audit profile routing                                      |
+| `brain.register_adapter` | Register an adapter integrity record                                   | Gate adapter composition to the active base-model revision |
 
 ### Comm pack — 7 verbs (`comm.` prefix)
 

--- a/crates/khive-pack-brain/src/handlers.rs
+++ b/crates/khive-pack-brain/src/handlers.rs
@@ -70,8 +70,8 @@ pub(crate) static BRAIN_HANDLERS: &[HandlerDef] = &[
     },
     HandlerDef {
         name: "brain.event_counts",
-        description: "Windowed event counts grouped by kind and actor over the event plane \
-            (ADR-103 Stage 1, #724 Ask A); feedback_explicit events additionally split by \
+        description: "Windowed event counts grouped by kind, actor, and verb over the event \
+            plane (ADR-103 Stage 1, #724 Ask A); feedback_explicit events additionally split by \
             served_by_profile_id; events carrying a work_class (today: phase_started / \
             phase_completed / phase_cancelled payloads, checked before any future \
             payload.resource.work_class) split by counts_by_work_class. cost_unit is not \
@@ -96,7 +96,10 @@ pub(crate) static BRAIN_HANDLERS: &[HandlerDef] = &[
                 name: "actor",
                 param_type: "string",
                 required: false,
-                description: "Filter to a single actor (e.g. \"lambda:khive\"). Omit for all actors.",
+                description: "Filter to a single actor. Stored actor strings are prefixed \
+                    (e.g. \"actor:lambda:khive\"); pass either the bare seat form \
+                    (\"lambda:khive\") or the stored prefixed form — both match. Omit for all \
+                    actors.",
             },
             khive_types::ParamDef {
                 name: "kind",
@@ -667,8 +670,8 @@ impl BrainPack {
 
     // ── brain.event_counts ──────────────────────────────────────────────────
     //
-    // ADR-103 Stage 1 (#724 Ask A): a windowed, per-actor, per-kind read verb
-    // over the event plane, additionally surfacing `work_class`
+    // ADR-103 Stage 1 (#724 Ask A): a windowed, per-actor, per-kind, per-verb
+    // read verb over the event plane, additionally surfacing `work_class`
     // (ADR-103-resource-attribution-model.md:303) via `counts_by_work_class`.
     // `work_class` is read from `payload.work_class` first — the shape the
     // three Phase* events (`PhaseStarted`/`PhaseCompleted`/`PhaseCancelled`,
@@ -698,8 +701,8 @@ impl BrainPack {
     /// Cap on events aggregated by a single `brain.event_counts` window query.
     /// `EventStore` has no SQL-side grouped-count primitive today (`count_events`
     /// returns one scalar per filter, not a GROUP BY), so this verb fetches a
-    /// bounded page via `query_events` and aggregates by kind/actor/profile in
-    /// the handler. A window wider than this cap still returns counts up to the
+    /// bounded page via `query_events` and aggregates by kind/actor/verb/profile
+    /// in the handler. A window wider than this cap still returns counts up to the
     /// cap and sets `truncated: true` plus the true `window_event_total` rather
     /// than silently reporting a partial total as complete. At current event
     /// volumes this bound is not expected to bind in practice; widening the
@@ -747,9 +750,20 @@ impl BrainPack {
             None => None,
         };
 
+        // Stored actor strings are prefixed (`actor:<kind>:<id>`). Callers naturally pass the
+        // bare seat form (e.g. "lambda:khive"), which would silently match nothing against an
+        // exact-match filter. Match either spelling by expanding the filter to both forms —
+        // `EventFilter.actors` is an IN-list, so this is a pure OR, never a guess. A caller who
+        // already passes the stored `actor:`-prefixed form keeps exact-match behavior.
+        let actor_filters: Vec<String> = match p.actor.as_deref() {
+            Some(a) if a.starts_with("actor:") => vec![a.to_string()],
+            Some(a) => vec![a.to_string(), format!("actor:{a}")],
+            None => Vec::new(),
+        };
+
         let store = self.runtime.events(token)?;
         let filter = EventFilter {
-            actors: p.actor.iter().cloned().collect(),
+            actors: actor_filters,
             kinds: kind_filter.into_iter().collect(),
             // Half-open window [since, until): `EventFilter.after` is a strict
             // `created_at > after`, so subtracting one microsecond from `since`
@@ -778,6 +792,8 @@ impl BrainPack {
             std::collections::BTreeMap::new();
         let mut counts_by_actor: std::collections::BTreeMap<String, u64> =
             std::collections::BTreeMap::new();
+        let mut counts_by_verb: std::collections::BTreeMap<String, u64> =
+            std::collections::BTreeMap::new();
         let mut by_profile: std::collections::BTreeMap<String, u64> =
             std::collections::BTreeMap::new();
         let mut counts_by_work_class: std::collections::BTreeMap<String, u64> =
@@ -788,6 +804,7 @@ impl BrainPack {
                 .entry(event.kind.name().to_string())
                 .or_insert(0) += 1;
             *counts_by_actor.entry(event.actor.clone()).or_insert(0) += 1;
+            *counts_by_verb.entry(event.verb.clone()).or_insert(0) += 1;
             if event.kind == khive_types::EventKind::FeedbackExplicit {
                 let profile = event
                     .payload
@@ -812,6 +829,7 @@ impl BrainPack {
             "total": page.items.len() as u64,
             "counts_by_kind": counts_by_kind,
             "counts_by_actor": counts_by_actor,
+            "counts_by_verb": counts_by_verb,
             "truncated": truncated,
             "window_event_total": window_event_total,
         });

--- a/crates/khive-pack-brain/src/tests.rs
+++ b/crates/khive-pack-brain/src/tests.rs
@@ -5958,6 +5958,7 @@ mod event_counts_tests {
         assert_eq!(result["total"], json!(0));
         assert_eq!(result["counts_by_kind"], json!({}));
         assert_eq!(result["counts_by_actor"], json!({}));
+        assert_eq!(result["counts_by_verb"], json!({}));
         assert!(
             result.get("by_profile").is_none(),
             "by_profile must be omitted when no feedback events are in the window: {result}"
@@ -6052,6 +6053,136 @@ mod event_counts_tests {
         assert_eq!(result["total"], json!(1));
         assert_eq!(result["counts_by_actor"]["lambda:b"], json!(1));
         assert!(result["counts_by_actor"].get("lambda:a").is_none());
+    }
+
+    /// #943: stored actor strings are prefixed (`actor:<kind>:<id>`), but the
+    /// verb's own param doc example is the bare seat form (`"lambda:khive"`).
+    /// The bare form must match the prefixed stored form, and the prefixed
+    /// form must keep matching exactly as before.
+    #[tokio::test]
+    async fn actor_filter_matches_bare_and_prefixed_spelling() {
+        let (pack, rt) = make_pack();
+        let registry = empty_registry();
+        let token = rt.authorize(Namespace::local()).unwrap();
+
+        seed_event(
+            &rt,
+            &token,
+            "search",
+            EventKind::SearchExecuted,
+            "actor:lambda:atlas",
+            1_000_000,
+            json!({}),
+        )
+        .await;
+        seed_event(
+            &rt,
+            &token,
+            "search",
+            EventKind::SearchExecuted,
+            "actor:lambda:khive",
+            1_000_000,
+            json!({}),
+        )
+        .await;
+
+        // Bare seat spelling must match the prefixed stored form.
+        let bare = pack
+            .dispatch(
+                "brain.event_counts",
+                json!({
+                    "since": micros_to_iso(0),
+                    "actor": "lambda:atlas",
+                }),
+                &registry,
+                &token,
+            )
+            .await
+            .expect("brain.event_counts must succeed");
+        assert_eq!(
+            bare["total"],
+            json!(1),
+            "bare seat spelling must match the actor:-prefixed stored form: {bare}"
+        );
+        assert_eq!(bare["counts_by_actor"]["actor:lambda:atlas"], json!(1));
+        assert!(bare["counts_by_actor"].get("actor:lambda:khive").is_none());
+
+        // Already-prefixed spelling must keep matching exactly (no false widening).
+        let prefixed = pack
+            .dispatch(
+                "brain.event_counts",
+                json!({
+                    "since": micros_to_iso(0),
+                    "actor": "actor:lambda:khive",
+                }),
+                &registry,
+                &token,
+            )
+            .await
+            .expect("brain.event_counts must succeed");
+        assert_eq!(
+            prefixed["total"],
+            json!(1),
+            "already-prefixed actor spelling must keep exact-match behavior: {prefixed}"
+        );
+        assert_eq!(prefixed["counts_by_actor"]["actor:lambda:khive"], json!(1));
+        assert!(prefixed["counts_by_actor"]
+            .get("actor:lambda:atlas")
+            .is_none());
+    }
+
+    /// #943: `counts_by_verb` aggregates `event.verb` over the page with the
+    /// same truncation semantics as `counts_by_kind`/`counts_by_actor`.
+    #[tokio::test]
+    async fn counts_by_verb_aggregates_per_verb() {
+        let (pack, rt) = make_pack();
+        let registry = empty_registry();
+        let token = rt.authorize(Namespace::local()).unwrap();
+
+        seed_event(
+            &rt,
+            &token,
+            "search",
+            EventKind::SearchExecuted,
+            "lambda:a",
+            1_000_000,
+            json!({}),
+        )
+        .await;
+        seed_event(
+            &rt,
+            &token,
+            "search",
+            EventKind::SearchExecuted,
+            "lambda:a",
+            1_000_000,
+            json!({}),
+        )
+        .await;
+        seed_event(
+            &rt,
+            &token,
+            "recall",
+            EventKind::RecallExecuted,
+            "lambda:a",
+            1_000_000,
+            json!({}),
+        )
+        .await;
+
+        let result = pack
+            .dispatch(
+                "brain.event_counts",
+                json!({"since": micros_to_iso(0)}),
+                &registry,
+                &token,
+            )
+            .await
+            .expect("brain.event_counts must succeed");
+
+        assert_eq!(result["total"], json!(3));
+        assert_eq!(result["counts_by_verb"]["search"], json!(2));
+        assert_eq!(result["counts_by_verb"]["recall"], json!(1));
     }
 
     #[tokio::test]

--- a/docs/guide/api-reference.md
+++ b/docs/guide/api-reference.md
@@ -687,19 +687,20 @@ caller. Optional; load with `KHIVE_PACKS=kg,brain`.
 
 ### `brain.event_counts` — Assertive
 
-Windowed event counts grouped by kind and actor over the event plane (ADR-103 Stage 1,
-#724 Ask A). `feedback_explicit` events are additionally split by `served_by_profile_id`.
-Events carrying a `work_class` (today: `phase_started`/`phase_completed`/`phase_cancelled`
-payloads) split by `counts_by_work_class`. `cost_unit` is not surfaced: it does not exist
-on any event payload yet (ADR-103 Stage 0 is design-only) and will be added once a
-resource payload carries it.
+Windowed event counts grouped by kind, actor, and verb over the event plane (ADR-103
+Stage 1, #724 Ask A). `feedback_explicit` events are additionally split by
+`served_by_profile_id`. Events carrying a `work_class` (today:
+`phase_started`/`phase_completed`/`phase_cancelled` payloads) split by
+`counts_by_work_class`. `cost_unit` is not surfaced: it does not exist on any event
+payload yet (ADR-103 Stage 0 is design-only) and will be added once a resource payload
+carries it.
 
-| Param   | Type   | Required | Notes                                                                  |
-| ------- | ------ | -------- | ---------------------------------------------------------------------- |
-| `since` | string | yes      | Window start, ISO-8601/RFC-3339 datetime. Inclusive.                   |
-| `until` | string | no       | Window end, ISO-8601/RFC-3339 datetime. Exclusive. Defaults to now.    |
-| `actor` | string | no       | Filter to a single actor. Omit for all actors.                         |
-| `kind`  | string | no       | Filter to a single EventKind (e.g. `"recall_executed"`). Omit for all. |
+| Param   | Type   | Required | Notes                                                                                                                                                       |
+| ------- | ------ | -------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `since` | string | yes      | Window start, ISO-8601/RFC-3339 datetime. Inclusive.                                                                                                        |
+| `until` | string | no       | Window end, ISO-8601/RFC-3339 datetime. Exclusive. Defaults to now.                                                                                         |
+| `actor` | string | no       | Filter to a single actor. Stored actor strings are prefixed (`actor:lambda:khive`); bare (`lambda:khive`) or prefixed form both match. Omit for all actors. |
+| `kind`  | string | no       | Filter to a single EventKind (e.g. `"recall_executed"`). Omit for all.                                                                                      |
 
 ```
 request(ops="brain.event_counts(since=\"2026-07-01T00:00:00Z\")")


### PR DESCRIPTION
## Summary

Two read-surface fixes to `brain.event_counts` (ADR-103 Stage 1), scoped to `crates/khive-pack-brain/src/handlers.rs::handle_event_counts` + its param docs + tests, per #943. No schema change, no new event emission, no other verb touched.

### 1. Actor filter now accepts both spellings

Stored actor strings are prefixed: `actor:<kind>:<id>` (e.g. `actor:lambda:khive`). The filter was exact-match only, so the param doc's own example (`"lambda:khive"`) silently matched nothing.

Repro from the issue: `actor="lambda:atlas"` returned `total: 0` over a window where `actor="actor:lambda:atlas"` returned 9,445 — the worst failure shape for a metrics verb, since it reads as "this seat did nothing" instead of "your filter didn't match."

Fix: when the caller-supplied `actor` does not already start with `actor:`, the filter now matches *either* spelling — `EventFilter.actors` is an IN-list under the hood (`push_in_clause` in `khive-db/src/stores/event.rs`), so widening it to both forms is a pure OR, not a guess. Callers who already pass the stored `actor:`-prefixed form keep exact-match behavior (no widening). The param doc's example is now truthful.

### 2. `counts_by_verb` added to the response

The handler aggregated `counts_by_kind` / `counts_by_actor` / `by_profile` / `counts_by_work_class` but never `event.verb`, so consumers couldn't separate KG writes (create/link/update/merge) from reads (search/get/neighbors) without raw event access.

Fix: one more `BTreeMap<String, u64>` following the existing pattern, aggregated over the same page, included unconditionally in the response (same as `counts_by_kind`/`counts_by_actor` — not gated on non-empty like `by_profile`/`counts_by_work_class`).

### Docs

- Param doc for `actor` and the verb description updated to describe both accepted spellings / the verb groupings (kind, actor, verb).
- `AGENTS.md` and `docs/guide/api-reference.md` groupings line updated (`by kind/actor` → `by kind/actor/verb`); `CLAUDE.md`'s mention of `brain.event_counts` doesn't enumerate groupings, so left untouched.

## Tests

Extended `crates/khive-pack-brain/src/tests.rs::event_counts_tests`:
- `actor_filter_matches_bare_and_prefixed_spelling` — bare seat spelling (`lambda:atlas`) matches events stored under `actor:lambda:atlas`; already-prefixed spelling (`actor:lambda:khive`) still matches exactly and does not also pick up other actors.
- `counts_by_verb_aggregates_per_verb` — seeds `search`/`search`/`recall` events, asserts `counts_by_verb` reports `{search: 2, recall: 1}`.
- `empty_window_returns_zero_counts_not_error` extended to assert `counts_by_verb` is `{}` (not omitted) on an empty window, consistent with `counts_by_kind`/`counts_by_actor`.

## Gate results (from `crates/`, `CARGO_TARGET_DIR=.ctarget`)

- `cargo fmt --all` — clean (ran hand-in-hand with the pre-commit `deno fmt` doc-table pass)
- `cargo clippy -p khive-pack-brain --all-targets -- -D warnings` — clean, no warnings
- `cargo test -p khive-pack-brain` — **225 passed**, 0 failed (219 unit + 6 dispatch_hook + 3 resolve_actor + 4 secret_gate + 0 doc-tests); `event_counts` subset specifically: **15 passed**, 0 failed (13 pre-existing + 2 new)

Closes #943