### PR TITLE
fix(daemon): strict mode fails request on fallback (#947)

### DIFF
--- a/crates/khive-mcp/docs/design.md
+++ b/crates/khive-mcp/docs/design.md
@@ -78,7 +78,11 @@
 
 - The `daemon.rs` module provides the client side: `forward_or_spawn` connects
   to a warm daemon, auto-spawns it on first use, and maps responses to MCP
-  error types. Any failure falls back to `None` so the caller dispatches locally.
+  error types. Ordinary fallback paths return `None` so the caller dispatches
+  locally. `KHIVE_DAEMON_STRICT=1` (#947) turns a recordable fallback into a
+  caller-visible per-op error instead of completing it locally; `KHIVE_NO_DAEMON`
+  and the `request` tool's `save_to` bypass remain intentional local paths,
+  unaffected by strict mode.
 - The daemon is bound to `~/.khive/khived.sock`. Namespace mismatches trigger
   local-dispatch fallback.
 - `warm_all` is called in a background task after the daemon socket is bound so

--- a/crates/khive-mcp/src/daemon.rs
+++ b/crates/khive-mcp/src/daemon.rs
@@ -5,7 +5,7 @@
 //! first use, and maps responses to MCP error types. Ordinary fallback paths
 //! return `None` so the caller can dispatch locally. `KHIVE_DAEMON_STRICT=1`
 //! (#947) is the exception: it turns a recordable fallback into a
-//! caller-visible per-op error instead, via [`fallback_or_reject`].
+//! caller-visible per-op error instead, via `fallback_or_reject`.
 //! `KHIVE_NO_DAEMON` and `crate::server`'s `save_to` bypass remain
 //! intentional, unconditional local paths — neither is affected by strict
 //! mode, since nothing is ever recorded or falls back for them.
@@ -215,7 +215,7 @@ enum FallbackSeverity {
 /// structured event plus a dedicated violation counter (D2-R1) — see
 /// [`record_fallback`]. It also, independent of severity, rejects the request
 /// outright instead of letting it complete through local dispatch (#947) —
-/// see [`fallback_or_reject`]. Together these make an illegitimate mismatch
+/// see `fallback_or_reject`. Together these make an illegitimate mismatch
 /// impossible to miss AND make "strict mode active" a sound proof that no
 /// request in the window was served off the local fallback path.
 ///
@@ -320,7 +320,7 @@ pub(crate) fn reset_fallback_counters() {
 /// (D2-R3 — strict mode keys on `FallbackReason`, never on "did a fallback
 /// happen at all"). This function only records; it never decides whether the
 /// caller proceeds locally — every call site pairs it with
-/// [`fallback_or_reject`] (#947), which is what converts a strict-mode
+/// `fallback_or_reject` (#947), which is what converts a strict-mode
 /// fallback into a hard error instead of a local dispatch.
 fn record_fallback(
     reason: FallbackReason,
@@ -1738,7 +1738,7 @@ async fn wait_for_boot_quiescence_then_reprobe(frame: &DaemonRequestFrame) -> Bo
 /// already decided at the daemon and the caller must not dispatch locally.
 ///
 /// #947: under `KHIVE_DAEMON_STRICT=1`, the `NoSocket` case is instead
-/// `Some(Err(..))` — see [`fallback_or_reject`] — so it no longer joins
+/// `Some(Err(..))` — see `fallback_or_reject` — so it no longer joins
 /// `KHIVE_NO_DAEMON` as a safe-to-dispatch-locally outcome. `KHIVE_NO_DAEMON`
 /// itself is unaffected: it is the caller's explicit, unconditional opt-out
 /// of the daemon (not a fallback — nothing is ever recorded or counted for

--- a/crates/khive-mcp/src/daemon.rs
+++ b/crates/khive-mcp/src/daemon.rs
@@ -207,10 +207,12 @@ enum FallbackSeverity {
 
 /// `KHIVE_DAEMON_STRICT=1` elevates `Illegitimate`-severity fallbacks
 /// (`ConfigMismatch`, `NamespaceMismatch`) from a WARN to an error-level
-/// structured event plus a dedicated violation counter (D2-R1). It never
-/// disables the fallback itself — the request still completes locally so the
-/// caller is never dropped (SPEC_DRAFT §3 D2) — it only makes an illegitimate
-/// mismatch impossible to miss.
+/// structured event plus a dedicated violation counter (D2-R1) — see
+/// [`record_fallback`]. It also, independent of severity, rejects the request
+/// outright instead of letting it complete through local dispatch (#947) —
+/// see [`fallback_or_reject`]. Together these make an illegitimate mismatch
+/// impossible to miss AND make "strict mode active" a sound proof that no
+/// request in the window was served off the local fallback path.
 ///
 /// No hosted-vs-local auto-detection signal exists in this codebase (there is
 /// no build-time or runtime "is this the hosted fleet image" flag anywhere in
@@ -311,8 +313,10 @@ pub(crate) fn reset_fallback_counters() {
 /// every other case (non-strict mode, or a `RolloutTransient`/`NoDaemon`
 /// reason regardless of mode) logs at `warn!`, exactly as before this change
 /// (D2-R3 — strict mode keys on `FallbackReason`, never on "did a fallback
-/// happen at all"). The fallback itself is never disabled either way — the
-/// caller always proceeds to dispatch locally after this call returns.
+/// happen at all"). This function only records; it never decides whether the
+/// caller proceeds locally — every call site pairs it with
+/// [`fallback_or_reject`] (#947), which is what converts a strict-mode
+/// fallback into a hard error instead of a local dispatch.
 fn record_fallback(
     reason: FallbackReason,
     config_id_client: &str,
@@ -347,6 +351,40 @@ fn record_fallback(
             "daemon_fallback"
         );
     }
+}
+
+/// #947: the single decision point for what a caller sees when a request
+/// would fall back to local dispatch. Always records `reason` via
+/// [`record_fallback`] first — counters and the graduated WARN/ERROR log stay
+/// exactly as they were (D2-R1/D2-R3 are untouched by this function). Then,
+/// under `KHIVE_DAEMON_STRICT=1`, rejects the request instead of letting it
+/// complete locally: the interim daemon-engagement proof in Benchmark SPEC
+/// Amendment 1 §3 ("strict mode active AND daemon_fallback_count == 0") is
+/// only sound if a fallback that DID happen can never be reported back as a
+/// successful, locally-served response. Every `FallbackReason` is rejected
+/// here, not just the `Illegitimate` tier — that tier only governs the WARN
+/// vs ERROR log level inside `record_fallback`, an orthogonal concern.
+///
+/// Call exactly where the caller was about to `return None` (local dispatch)
+/// after a fallback; every production call site returns this directly.
+fn fallback_or_reject(
+    reason: FallbackReason,
+    config_id_client: &str,
+    config_id_daemon: Option<&str>,
+    namespace_client: &str,
+) -> Option<Result<String, McpError>> {
+    record_fallback(reason, config_id_client, config_id_daemon, namespace_client);
+    if is_daemon_strict_mode() {
+        return Some(Err(McpError::internal_error(
+            format!(
+                "daemon fallback rejected under KHIVE_DAEMON_STRICT=1: reason={}; \
+                 refusing to complete the request via local dispatch",
+                reason.as_str()
+            ),
+            None,
+        )));
+    }
+    None
 }
 
 // ── DaemonDispatch impl ───────────────────────────────────────────────────────
@@ -514,34 +552,31 @@ fn map_response(
     }
 
     if resp.namespace_mismatch {
-        record_fallback(
+        return fallback_or_reject(
             FallbackReason::NamespaceMismatch,
             expected_config_id,
             resp.served_config_id.as_deref(),
             namespace_client,
         );
-        return None;
     }
     if resp.config_mismatch {
-        record_fallback(
+        return fallback_or_reject(
             FallbackReason::ConfigMismatch,
             expected_config_id,
             resp.served_config_id.as_deref(),
             namespace_client,
         );
-        return None;
     }
     // Fail closed: only trust a result the daemon positively confirms it served
     // under our exact config. A legacy daemon omits `served_config_id` (→ None)
     // and a config-drifted daemon echoes a different id — both fall back local.
     if resp.served_config_id.as_deref() != Some(expected_config_id) {
-        record_fallback(
+        return fallback_or_reject(
             FallbackReason::ConfigMismatch,
             expected_config_id,
             resp.served_config_id.as_deref(),
             namespace_client,
         );
-        return None;
     }
     if resp.ok {
         Some(Ok(resp.result.unwrap_or_default()))
@@ -1686,6 +1721,13 @@ async fn wait_for_boot_quiescence_then_reprobe(frame: &DaemonRequestFrame) -> Bo
 /// has been written. `Some(Ok)` / `Some(Err)` both mean the request's fate is
 /// already decided at the daemon and the caller must not dispatch locally.
 ///
+/// #947: under `KHIVE_DAEMON_STRICT=1`, the `NoSocket` case is instead
+/// `Some(Err(..))` — see [`fallback_or_reject`] — so it no longer joins
+/// `KHIVE_NO_DAEMON` as a safe-to-dispatch-locally outcome. `KHIVE_NO_DAEMON`
+/// itself is unaffected: it is the caller's explicit, unconditional opt-out
+/// of the daemon (not a fallback — nothing is ever recorded or counted for
+/// it), so it is not a case strict mode has any basis to override.
+///
 /// The real (possibly mutating) request frame is written to the daemon socket
 /// at most once per call. A `NoSocket` outcome never writes anything, so it is
 /// safe to establish or recover the daemon (via `kill_and_respawn`, which
@@ -1749,13 +1791,12 @@ pub async fn forward_or_spawn(frame: &DaemonRequestFrame) -> Option<Result<Strin
     match kill_and_respawn(&frame.config_id, &frame.namespace).await {
         Err(e) => {
             tracing::warn!(error = %e, "failed to spawn/recover the daemon; falling back to local dispatch");
-            record_fallback(
+            return fallback_or_reject(
                 FallbackReason::NoSocket,
                 &frame.config_id,
                 None,
                 &frame.namespace,
             );
-            return None;
         }
         Ok(RecoveryOutcome::Skipped) => {
             // A concurrent client already has a live matching daemon ready.
@@ -1795,13 +1836,12 @@ pub async fn forward_or_spawn(frame: &DaemonRequestFrame) -> Option<Result<Strin
                     // and send it now that boot has quiesced.
                 }
                 BootFenceOutcome::SafeLocalFallback => {
-                    record_fallback(
+                    return fallback_or_reject(
                         FallbackReason::NoSocket,
                         &frame.config_id,
                         None,
                         &frame.namespace,
                     );
-                    return None;
                 }
                 BootFenceOutcome::HardError(err) => return Some(Err(err)),
             }
@@ -2412,6 +2452,73 @@ mod tests {
         );
     }
 
+    // ── fallback_or_reject: strict mode fails the request (#947) ──────────────
+    //
+    // #947: `KHIVE_DAEMON_STRICT=1` must turn a would-be fallback into a
+    // caller-visible error naming the reason, for EVERY `FallbackReason` —
+    // not just the `Illegitimate` tier that `record_fallback`'s WARN/ERROR
+    // log-level graduation (D2-R1) cares about. These tests exercise the
+    // decision function directly, at the same private-fn level as the
+    // `record_fallback_*` tests above, so they run in milliseconds instead of
+    // needing a real unreachable-socket round trip.
+
+    #[test]
+    #[serial]
+    fn fallback_or_reject_non_strict_returns_none_and_still_counts() {
+        with_daemon_strict(None, || {
+            reset_fallback_counters();
+            let out = fallback_or_reject(FallbackReason::NoSocket, CFG, None, NS);
+            assert!(
+                out.is_none(),
+                "non-strict mode must keep completing locally, unchanged by #947"
+            );
+            assert_eq!(fallback_count(FallbackReason::NoSocket), 1);
+        });
+    }
+
+    #[test]
+    #[serial]
+    fn fallback_or_reject_strict_no_socket_errors_naming_the_reason() {
+        with_daemon_strict(Some("1"), || {
+            reset_fallback_counters();
+            match fallback_or_reject(FallbackReason::NoSocket, CFG, None, NS) {
+                Some(Err(McpError { message, .. })) => {
+                    assert!(
+                        message.contains("no_socket"),
+                        "error must name the fallback reason: {message}"
+                    );
+                    assert!(
+                        message.contains("KHIVE_DAEMON_STRICT"),
+                        "error should point at the mode that caused the rejection: {message}"
+                    );
+                }
+                other => panic!("strict mode must reject the request, got {other:?}"),
+            }
+            // Counters/telemetry are untouched by this change — still exactly
+            // what `record_fallback` alone would have produced.
+            assert_eq!(fallback_count(FallbackReason::NoSocket), 1);
+            assert_eq!(fallback_total(), 1);
+        });
+    }
+
+    #[test]
+    #[serial]
+    fn fallback_or_reject_strict_config_mismatch_errors_naming_the_reason() {
+        with_daemon_strict(Some("1"), || {
+            reset_fallback_counters();
+            match fallback_or_reject(FallbackReason::ConfigMismatch, CFG, Some("other-cfg"), NS) {
+                Some(Err(McpError { message, .. })) => {
+                    assert!(message.contains("config_mismatch"), "{message}");
+                }
+                other => panic!("strict mode must reject the request, got {other:?}"),
+            }
+            // An `Illegitimate`-tier reason still bumps the pre-existing
+            // strict-violations counter exactly as it did before #947 — this
+            // change only affects the return value, never the telemetry.
+            assert_eq!(fallback_strict_violations(), 1);
+        });
+    }
+
     // ── forward_or_spawn fallback (env-mutating → serial) ─────────────────────
 
     #[tokio::test]
@@ -2450,6 +2557,103 @@ mod tests {
         assert_eq!(fallback_total(), 0);
 
         clear_daemon_env();
+    }
+
+    // #947: genuine daemon-unreachable fallback (no `KHIVE_NO_DAEMON` opt-out)
+    // must still complete locally in non-strict mode, and must reject the
+    // request in strict mode. `spawn_daemon()` really runs here (`SPAWN_COUNT`
+    // bumps) but the spawned process is this same test binary re-invoked with
+    // unrecognized args, so it never binds the socket and the daemon
+    // genuinely never becomes reachable — the same way
+    // `forward_or_spawn_blocks_on_boot_quiescence_before_local_fallback` below
+    // forces this path without a fake daemon. Each run pays the ~5s forward
+    // deadline plus the boot-quiescence reprobe.
+
+    fn unreachable_daemon_frame(config_id: &str) -> DaemonRequestFrame {
+        DaemonRequestFrame {
+            ops: "stats()".to_string(),
+            presentation: None,
+            presentation_per_op: None,
+            namespace: "test".to_string(),
+            actor_id: None,
+            visible_namespaces: Vec::new(),
+            config_id: config_id.to_string(),
+            protocol_version: PROTOCOL_VERSION,
+            probe_only: false,
+            metrics_only: false,
+            format: None,
+            format_per_op: None,
+            from_wire: false,
+        }
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn forward_or_spawn_non_strict_falls_back_locally_when_daemon_unreachable() {
+        clear_daemon_env();
+        reset_fallback_counters();
+        let dir = tempfile::tempdir().expect("tempdir");
+        std::env::set_var("KHIVE_SOCKET", dir.path().join("khived.sock"));
+        std::env::set_var("KHIVE_PID", dir.path().join("khived.pid"));
+        std::env::set_var("KHIVE_LOCK", dir.path().join("khived.recovery.lock"));
+        std::env::remove_var("KHIVE_NO_DAEMON");
+        std::env::remove_var("KHIVE_DAEMON_STRICT");
+
+        let frame = unreachable_daemon_frame(CFG);
+        let out = forward_or_spawn(&frame).await;
+
+        assert!(
+            out.is_none(),
+            "non-strict mode must still complete the request via local dispatch \
+             when the daemon is genuinely unreachable, got {out:?}"
+        );
+        assert_eq!(fallback_count(FallbackReason::NoSocket), 1);
+
+        reset_fallback_counters();
+        clear_daemon_env();
+        std::env::remove_var("KHIVE_LOCK");
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn forward_or_spawn_strict_mode_errors_when_daemon_unreachable() {
+        clear_daemon_env();
+        reset_fallback_counters();
+        let dir = tempfile::tempdir().expect("tempdir");
+        std::env::set_var("KHIVE_SOCKET", dir.path().join("khived.sock"));
+        std::env::set_var("KHIVE_PID", dir.path().join("khived.pid"));
+        std::env::set_var("KHIVE_LOCK", dir.path().join("khived.recovery.lock"));
+        std::env::remove_var("KHIVE_NO_DAEMON");
+        std::env::set_var("KHIVE_DAEMON_STRICT", "1");
+
+        let frame = unreachable_daemon_frame(CFG);
+        let out = forward_or_spawn(&frame).await;
+
+        match out {
+            Some(Err(McpError { message, .. })) => {
+                assert!(
+                    message.contains("no_socket"),
+                    "strict-mode error must name the fallback reason: {message}"
+                );
+                assert!(
+                    message.contains("KHIVE_DAEMON_STRICT"),
+                    "strict-mode error should name the mode that rejected the \
+                     request: {message}"
+                );
+            }
+            other => panic!(
+                "KHIVE_DAEMON_STRICT=1 must reject the request instead of completing \
+                 it locally when the daemon is unreachable, got {other:?}"
+            ),
+        }
+        // Counters/telemetry stay exactly as they were before #947 — this
+        // change only affects what the caller gets back.
+        assert_eq!(fallback_count(FallbackReason::NoSocket), 1);
+
+        reset_fallback_counters();
+        clear_daemon_env();
+        std::env::remove_var("KHIVE_LOCK");
+        std::env::remove_var("KHIVE_DAEMON_STRICT");
     }
 
     // ── daemon socket round-trip (env-mutating → serial) ─────────────────────

--- a/crates/khive-mcp/src/daemon.rs
+++ b/crates/khive-mcp/src/daemon.rs
@@ -2,8 +2,13 @@
 //!
 //! The daemon server lives in `khive-runtime::daemon`. This module provides the
 //! client side: [`forward_or_spawn`] connects to the daemon, auto-spawns it on
-//! first use, and maps responses to MCP error types. Every failure path falls
-//! back to `None` so the caller can dispatch locally.
+//! first use, and maps responses to MCP error types. Ordinary fallback paths
+//! return `None` so the caller can dispatch locally. `KHIVE_DAEMON_STRICT=1`
+//! (#947) is the exception: it turns a recordable fallback into a
+//! caller-visible per-op error instead, via [`fallback_or_reject`].
+//! `KHIVE_NO_DAEMON` and `crate::server`'s `save_to` bypass remain
+//! intentional, unconditional local paths — neither is affected by strict
+//! mode, since nothing is ever recorded or falls back for them.
 //!
 //! Also provides the [`khive_runtime::daemon::DaemonDispatch`] impl for [`crate::server::KhiveMcpServer`].
 
@@ -365,6 +370,14 @@ fn record_fallback(
 /// here, not just the `Illegitimate` tier — that tier only governs the WARN
 /// vs ERROR log level inside `record_fallback`, an orthogonal concern.
 ///
+/// `data` marker on a strict-fallback rejection's [`McpError`] (#947 Medium
+/// finding): `request()` in `server.rs` inspects this to tell "the daemon was
+/// never reached and strict mode rejected the fallback" apart from every
+/// other daemon-forward `McpError` (protocol mismatch, oversized frame,
+/// ambiguous post-write outcome), which stay RPC-level errors. Kept as a
+/// shared constant so the tag and the check can never drift independently.
+pub(crate) const STRICT_FALLBACK_MARKER: &str = "khive_strict_daemon_fallback";
+
 /// Call exactly where the caller was about to `return None` (local dispatch)
 /// after a fallback; every production call site returns this directly.
 fn fallback_or_reject(
@@ -381,7 +394,10 @@ fn fallback_or_reject(
                  refusing to complete the request via local dispatch",
                 reason.as_str()
             ),
-            None,
+            Some(serde_json::json!({
+                STRICT_FALLBACK_MARKER: true,
+                "reason": reason.as_str(),
+            })),
         )));
     }
     None

--- a/crates/khive-mcp/src/server.rs
+++ b/crates/khive-mcp/src/server.rs
@@ -1490,11 +1490,91 @@ result (e.g. create then link with the new entity's id)."#)]
         if p.save_to.is_none() {
             let frame = self.wire_daemon_frame(&p);
             if let Some(res) = crate::daemon::forward_or_spawn(&frame).await {
-                return res;
+                return match res {
+                    Ok(s) => Ok(s),
+                    // #947: a strict-mode fallback rejection is tagged with
+                    // `daemon::STRICT_FALLBACK_MARKER` so it can be reshaped
+                    // into the normal per-op envelope instead of surfacing as
+                    // an RPC-level error. Every other daemon-forward error
+                    // (protocol mismatch, oversized frame, ambiguous
+                    // post-write outcome) is untagged and passes through
+                    // unchanged.
+                    Err(e) => match strict_fallback_reason(&e) {
+                        Some(reason) => strict_fallback_envelope_response(&p, reason),
+                        None => Err(e),
+                    },
+                };
             }
         }
         self.dispatch_request_wire(p).await
     }
+}
+
+/// Extract the fallback-reason string from a strict-mode rejection's
+/// [`McpError`] (#947), or `None` if `e` is not tagged with
+/// [`crate::daemon::STRICT_FALLBACK_MARKER`] — i.e. some other daemon-forward
+/// error that must stay an RPC-level error.
+fn strict_fallback_reason(e: &McpError) -> Option<String> {
+    let data = e.data.as_ref()?;
+    if data.get(crate::daemon::STRICT_FALLBACK_MARKER)?.as_bool() != Some(true) {
+        return None;
+    }
+    data.get("reason")
+        .and_then(Value::as_str)
+        .map(str::to_string)
+}
+
+/// Build the wire-contract failed-op envelope for a strict-mode daemon
+/// fallback rejection (#947 Medium finding).
+///
+/// The request was never attempted — locally or on the daemon — but the wire
+/// response must still be a normal per-op envelope
+/// (`{"results": [...], "summary": {...}}`) reporting the fallback reason as
+/// each op's `error`, not an RPC-level `McpError`. Chain mode aborts after the
+/// first op, matching `run_parsed`'s `Chain` arm and the wire contract's
+/// documented abort-on-failure behavior for `|`-chained ops.
+fn strict_fallback_envelope_response(
+    p: &RequestParams,
+    reason: String,
+) -> Result<String, McpError> {
+    let parsed = parse_request(&p.ops).map_err(dsl_err_to_mcp)?;
+    let total = parsed.ops.len();
+    let error_msg = format!(
+        "daemon fallback rejected under KHIVE_DAEMON_STRICT=1: reason={reason}; \
+         refusing to complete the request via local dispatch"
+    );
+
+    let results: Vec<Value> = match parsed.mode {
+        ExecutionMode::Chain => parsed
+            .ops
+            .iter()
+            .enumerate()
+            .map(|(i, op)| {
+                if i == 0 {
+                    json!({ "ok": false, "tool": op.tool, "error": error_msg })
+                } else {
+                    json!({ "ok": false, "tool": op.tool, "aborted": true })
+                }
+            })
+            .collect(),
+        ExecutionMode::Single | ExecutionMode::Parallel => parsed
+            .ops
+            .iter()
+            .map(|op| json!({ "ok": false, "tool": op.tool, "error": error_msg }))
+            .collect(),
+    };
+
+    let aborted = if parsed.mode == ExecutionMode::Chain {
+        total.saturating_sub(1)
+    } else {
+        0
+    };
+    let failed = total - aborted;
+    Ok(serde_json::to_string(&json!({
+        "results": results,
+        "summary": { "total": total, "succeeded": 0, "failed": failed, "aborted": aborted },
+    }))
+    .expect("envelope of string/bool JSON values always serializes"))
 }
 
 impl KhiveMcpServer {
@@ -2420,6 +2500,171 @@ mod tests {
         );
 
         let _ = tokio::time::timeout(std::time::Duration::from_secs(2), fake_handle).await;
+        clear_daemon_env();
+    }
+
+    // ── #947 Medium regression: strict fallback lands as a per-op envelope ──
+    //
+    // Before this fix, `request()` returned `forward_or_spawn`'s strict-mode
+    // rejection as a raw `Err(McpError)`, bypassing the per-op `{ok, tool,
+    // result/error}` / `summary` wire contract every other failure mode goes
+    // through. This drives `request()` end to end with a genuinely
+    // unreachable daemon under `KHIVE_DAEMON_STRICT=1` and asserts: (1) the
+    // response is `Ok(envelope_json)`, never an RPC error; (2) each shape
+    // (single op, parallel batch, chain) reports the fallback reason as a
+    // normal failed-op `error`, with chain aborting the remaining ops exactly
+    // like a real op failure would (`run_parsed`'s `Chain` arm); (3) summary
+    // counts match `results`; and (4) none of the ops ever ran locally (a
+    // `stats()` snapshot taken via the trusted `dispatch_request_local` path
+    // is unchanged after all three calls).
+    #[tokio::test]
+    #[serial]
+    async fn request_strict_fallback_lands_as_failed_op_envelope_not_rpc_error() {
+        clear_daemon_env();
+        crate::daemon::reset_fallback_counters();
+        let dir = tempfile::tempdir().expect("tempdir");
+        // Never bound by anything in this test — the daemon is genuinely
+        // unreachable, exactly like `daemon::forward_or_spawn_strict_mode_errors_when_daemon_unreachable`.
+        std::env::set_var("KHIVE_SOCKET", dir.path().join("khived.sock"));
+        std::env::set_var("KHIVE_PID", dir.path().join("khived.pid"));
+        std::env::set_var("KHIVE_LOCK", dir.path().join("khived.recovery.lock"));
+        std::env::remove_var("KHIVE_NO_DAEMON");
+        std::env::set_var("KHIVE_DAEMON_STRICT", "1");
+
+        let config = RuntimeConfig {
+            db_path: None,
+            default_namespace: Namespace::parse("test").unwrap(),
+            embedding_model: None,
+            additional_embedding_models: vec![],
+            packs: vec!["kg".to_string(), "comm".to_string()],
+            ..RuntimeConfig::default()
+        };
+        let runtime = KhiveRuntime::new(config).expect("in-memory runtime");
+        let server = KhiveMcpServer::new(runtime).expect("server builds with kg + comm");
+
+        let baseline = server
+            .dispatch_request_local(RequestParams {
+                ops: "stats()".to_string(),
+                presentation: None,
+                presentation_per_op: None,
+                save_to: None,
+                format: None,
+                format_per_op: None,
+            })
+            .await
+            .expect("baseline stats() must succeed");
+
+        fn assert_fallback_error(entry: &Value, tool: &str) {
+            assert_eq!(entry["ok"], json!(false), "entry: {entry}");
+            assert_eq!(entry["tool"], json!(tool), "entry: {entry}");
+            let msg = entry["error"].as_str().expect("error must be a string");
+            assert!(
+                msg.contains("KHIVE_DAEMON_STRICT"),
+                "error must name the strict mode that rejected the fallback: {msg}"
+            );
+            assert!(
+                msg.contains("no_socket"),
+                "error must name the fallback reason: {msg}"
+            );
+        }
+
+        // ── single op ──────────────────────────────────────────────────────
+        let single_resp = server
+            .request(Parameters(RequestParams {
+                ops: "comm.send(to=\"bob\", content=\"strict-single-probe\")".to_string(),
+                presentation: None,
+                presentation_per_op: None,
+                save_to: None,
+                format: None,
+                format_per_op: None,
+            }))
+            .await
+            .expect("strict fallback must land as a normal Ok(envelope), not Err(McpError)");
+        let single: Value =
+            serde_json::from_str(&single_resp).expect("response must be the request envelope");
+        assert_eq!(
+            single["results"].as_array().expect("results array").len(),
+            1
+        );
+        assert_fallback_error(&single["results"][0], "comm.send");
+        assert_eq!(
+            single["summary"],
+            json!({ "total": 1, "succeeded": 0, "failed": 1, "aborted": 0 })
+        );
+
+        // ── parallel batch ─────────────────────────────────────────────────
+        let batch_resp = server
+            .request(Parameters(RequestParams {
+                ops: "[comm.send(to=\"bob\", content=\"strict-batch-1\"), \
+                       comm.send(to=\"bob\", content=\"strict-batch-2\")]"
+                    .to_string(),
+                presentation: None,
+                presentation_per_op: None,
+                save_to: None,
+                format: None,
+                format_per_op: None,
+            }))
+            .await
+            .expect("strict fallback must land as a normal Ok(envelope), not Err(McpError)");
+        let batch: Value =
+            serde_json::from_str(&batch_resp).expect("response must be the request envelope");
+        let batch_results = batch["results"].as_array().expect("results array");
+        assert_eq!(batch_results.len(), 2);
+        for entry in batch_results {
+            assert_fallback_error(entry, "comm.send");
+        }
+        assert_eq!(
+            batch["summary"],
+            json!({ "total": 2, "succeeded": 0, "failed": 2, "aborted": 0 })
+        );
+
+        // ── chain (must abort remaining ops per the wire contract) ─────────
+        let chain_resp = server
+            .request(Parameters(RequestParams {
+                ops: "comm.send(to=\"bob\", content=\"strict-chain-1\") | \
+                      comm.send(to=\"bob\", content=\"strict-chain-2\")"
+                    .to_string(),
+                presentation: None,
+                presentation_per_op: None,
+                save_to: None,
+                format: None,
+                format_per_op: None,
+            }))
+            .await
+            .expect("strict fallback must land as a normal Ok(envelope), not Err(McpError)");
+        let chain: Value =
+            serde_json::from_str(&chain_resp).expect("response must be the request envelope");
+        let chain_results = chain["results"].as_array().expect("results array");
+        assert_eq!(chain_results.len(), 2);
+        assert_fallback_error(&chain_results[0], "comm.send");
+        assert_eq!(
+            chain_results[1],
+            json!({ "ok": false, "tool": "comm.send", "aborted": true })
+        );
+        assert_eq!(
+            chain["summary"],
+            json!({ "total": 2, "succeeded": 0, "failed": 1, "aborted": 1 })
+        );
+
+        // ── no local dispatch ever happened for any of the three calls ─────
+        let after = server
+            .dispatch_request_local(RequestParams {
+                ops: "stats()".to_string(),
+                presentation: None,
+                presentation_per_op: None,
+                save_to: None,
+                format: None,
+                format_per_op: None,
+            })
+            .await
+            .expect("post-request stats() must succeed");
+        assert_eq!(
+            after, baseline,
+            "no comm.send op must ever have run locally under strict-mode fallback \
+             rejection — a local dispatch would mutate local state here"
+        );
+
+        crate::daemon::reset_fallback_counters();
         clear_daemon_env();
     }
 }


### PR DESCRIPTION
## Summary

`KHIVE_DAEMON_STRICT=1` is documented as making daemon fallback an explicit failure, but it previously only logged the fallback (elevating `config_mismatch`/`namespace_mismatch` to `error!` + a dedicated violation counter, per the graduated fail-loud policy from bba4c4a7) and still let the request complete through local dispatch. A strict-mode caller could therefore get a successful response that actually executed on the local path, not the daemon.

This PR makes every fallback path in `crates/khive-mcp/src/daemon.rs` reject the request outright under `KHIVE_DAEMON_STRICT=1`, naming the fallback reason in the error, instead of logging and completing locally. Non-strict behavior is unchanged.

## Why

Benchmark Program SPEC Amendment 1 §3 (signed 2026-07-13) makes daemon-engagement proof a coverage requirement for flagship measurements. The interim v0 proof is "strict mode active AND `daemon_fallback_count == 0`" — sound only if strict mode genuinely prevents a fallback-satisfied request from being reported as success. Before this fix, a strict-mode benchmark run could silently measure local dispatch and attribute the numbers to the daemon path.

This is the same graduated fail-loud pattern established by the config_id topology parity fix (bba4c4a7, "eliminate silent local-dispatch fallback"): that commit added `KHIVE_DAEMON_STRICT` and elevated `Illegitimate`-severity fallbacks (`ConfigMismatch`/`NamespaceMismatch`) to an `error!` log + `FALLBACK_STRICT_VIOLATIONS` counter, but explicitly kept the fallback itself always-on ("the fallback is never disabled"). This PR is the next graduation step: strict mode now also rejects the request, for every `FallbackReason` (not just the `Illegitimate` tier — that tier still only governs the WARN vs ERROR log level, which is untouched).

## Behavior

| Fallback reason | Non-strict (default) | Strict (`KHIVE_DAEMON_STRICT=1`) |
|---|---|---|
| `no_socket` (daemon unreachable) | Completes locally (`None`) | `Some(Err(..))` naming `no_socket` |
| `config_mismatch` | Completes locally (`None`) | `Some(Err(..))` naming `config_mismatch` |
| `namespace_mismatch` | Completes locally (`None`) | `Some(Err(..))` naming `namespace_mismatch` |
| `KHIVE_NO_DAEMON=1` (explicit opt-out) | Completes locally (`None`) | Completes locally (`None`) — unaffected; it's a deliberate opt-out, not a fallback, and nothing is recorded for it |

Fallback counters and the graduated WARN/ERROR structured log (`record_fallback`, D2-R1/D2-R3) are untouched — they still increment/log exactly as before. The new `fallback_or_reject` helper wraps `record_fallback` and is the single point that decides `None` vs `Some(Err(..))` at every one of the five call sites (`map_response` ×3, `forward_or_spawn` ×2).

## Test evidence

Added to `crates/khive-mcp/src/daemon.rs`:
- 3 fast unit tests against `fallback_or_reject` directly (non-strict returns `None` and still counts; strict `no_socket`/`config_mismatch` errors and names the reason + `KHIVE_DAEMON_STRICT` in the message).
- 2 integration tests driving `forward_or_spawn` against a genuinely unreachable daemon (no `KHIVE_NO_DAEMON` opt-out): non-strict still completes locally, strict mode rejects with the reason named.
- All env-var-reading tests use `#[serial]` (existing crate pattern via `serial_test`), robust to parallel test execution.

```
cargo fmt --all -- --check         → clean
cargo clippy -p khive-mcp --all-targets -- -D warnings → clean
cargo test -p khive-mcp            → 211 lib tests + 113 integration tests passed, 0 failed
```

Closes #947