### PR TITLE
fix(perf): flagship manifest corrections per Benchmark SPEC Amendment 1

### DIFF
--- a/scripts/perf/flagship_workloads.toml
+++ b/scripts/perf/flagship_workloads.toml
@@ -25,7 +25,7 @@
 # both are reported in a separate admin-surface coverage class and never
 # count toward the real-MCP percentage. No other exception exists unless
 # added by signed amendment.
-oq1_admin_ingest_surface = "admin_cli/raw_daemon_control exception bounded to exactly two scenarios per Amendment 1 §2: F6 git-ingest/code-ingest (admin CLI is the product surface for it) and the F10 daemon-control probe; reported as a separate admin-surface coverage class, never counted toward the real-MCP percentage"
+oq1_admin_ingest_surface = "admin_cli/raw_daemon_control exception bounded to exactly two exception classes per Amendment 1 §2 - F6 git-ingest/code-ingest (admin CLI is the product surface for it, two scenario rows) and the F10 daemon-control probe (one scenario row), three scenario ids total; reported as a separate admin-surface coverage class, never counted toward the real-MCP percentage"
 # Amendment 1 §2 admin-surface coverage class membership (exhaustive; every
 # other scenario_id in this manifest is real-MCP coverage by default via
 # its surface = "mcp_daemon" declaration).

--- a/scripts/perf/flagship_workloads.toml
+++ b/scripts/perf/flagship_workloads.toml
@@ -4,6 +4,8 @@
 # THE PLAN: .khive/workspaces/20260711/bench-overhaul/DESIGN.md
 # (Typed interfaces > Scenario contract; Coverage definition; PR 1 slice).
 # Signed decisions: .khive/workspaces/20260710/bench-program/SPEC-draft.md
+# Amendment (binding, supersedes conflicting DESIGN.md/SPEC-draft.md text):
+# .khive/workspaces/20260710/bench-program/AMENDMENT-1-flagship-measurement-contract.md
 #
 # This manifest is data only. It declares every required F1-F10 scenario,
 # its measured surface, scale tier, cold/warm obligation, required
@@ -15,14 +17,33 @@
 # scenario_id convention: f<N>.<verb>.<arm>.<embedder> (N = F1..F10).
 
 [oq_rulings]
-# OQ1 (admin-ingest surface conflict): APPROVED CLI-boundary exception
-# (DESIGN.md D5). git-ingest and code-ingest are measured at the real CLI
-# process boundary (surface = "admin_cli"), not as new MCP verbs.
-oq1_admin_ingest_surface = "admin_cli exception approved for git-ingest and code-ingest (D5)"
+# OQ1 (admin-ingest surface conflict): RESOLVED by Amendment 1 §2 "Surface
+# rule" - this replaces the prior silent "approved" marker (DESIGN.md D5).
+# Real MCP tools/call through the daemon (surface = "mcp_daemon") is the
+# default and only surface that counts toward real-MCP coverage. Exactly
+# two admin-surface exceptions are named and bounded by the amendment;
+# both are reported in a separate admin-surface coverage class and never
+# count toward the real-MCP percentage. No other exception exists unless
+# added by signed amendment.
+oq1_admin_ingest_surface = "admin_cli/raw_daemon_control exception bounded to exactly two scenarios per Amendment 1 §2: F6 git-ingest/code-ingest (admin CLI is the product surface for it) and the F10 daemon-control probe; reported as a separate admin-surface coverage class, never counted toward the real-MCP percentage"
+# Amendment 1 §2 admin-surface coverage class membership (exhaustive; every
+# other scenario_id in this manifest is real-MCP coverage by default via
+# its surface = "mcp_daemon" declaration).
+oq1_admin_surface_scenario_ids = [
+    "f6.git_ingest.cli.production",
+    "f6.code_ingest.cli.production",
+    "f10.daemon.probe_only.floor",
+]
 # OQ2 (production request deadline): no product SLO exists. The harness
 # uses a labeled measurement-censoring safety cap, not a timeout claim.
-oq2_measurement_deadline_ms = 30000
-oq2_measurement_deadline_label = "harness safety cap for measurement censoring, not a product SLO"
+# Amendment 1 §2 "Deadline classifiability": the client-side censor must
+# strictly exceed the server-side recall deadline (30000 ms per #919) so a
+# timeout is attributable to exactly one deadline - the manifest's prior
+# 30000/30000 race is fixed by raising the harness censor to 45000 ms.
+oq2_measurement_deadline_ms = 45000
+oq2_measurement_deadline_label = "harness safety cap for measurement censoring, not a product SLO; set to 45000 ms to strictly exceed the 30000 ms server-side recall deadline (#919) per Amendment 1 §2"
+oq2_server_recall_deadline_ms = 30000
+oq2_server_recall_deadline_note = "server-side recall deadline default (#919), distinct from the harness measurement-censoring cap above; the two must never be equal (Amendment 1 §2)"
 oq2_mcp_client_default_timeout_ms = 300000
 oq2_mcp_client_default_note = "MCP client default request timeout, recorded as reference only, not the scenario deadline"
 # OQ7 (freshness window): approved per-runner-class staleness bound used by
@@ -44,8 +65,8 @@ settle = "explicit_lifecycle_predicate"
 attempts = 128
 concurrency = 128
 required_percentiles = ["p50", "p95", "p99"]
-request_deadline_ms = 30000
-request_deadline_provenance = "harness measurement-censoring safety cap, not a product SLO (OQ2 ruling); the MCP client's own request-timeout default is 300000 ms (300s), recorded here for reference only, see [oq_rulings] above"
+request_deadline_ms = 45000
+request_deadline_provenance = "harness measurement-censoring safety cap, set to strictly exceed the server-side recall deadline (30000 ms per #919) so a timeout is attributable to exactly one deadline (Amendment 1 §2); not a product SLO (OQ2 ruling); the MCP client's own request-timeout default is 300000 ms (300s), recorded here for reference only, see [oq_rulings] above"
 runner_class = "self_hosted_real_embedder"
 
 [[scenario]]
@@ -62,8 +83,8 @@ settle = "sequential_sentinel"
 attempts = 1000
 concurrency = 1
 required_percentiles = ["p50", "p95", "p99"]
-request_deadline_ms = 30000
-request_deadline_provenance = "harness measurement-censoring safety cap, not a product SLO (OQ2 ruling); the MCP client's own request-timeout default is 300000 ms (300s), recorded here for reference only, see [oq_rulings] above"
+request_deadline_ms = 45000
+request_deadline_provenance = "harness measurement-censoring safety cap, set to strictly exceed the server-side recall deadline (30000 ms per #919) so a timeout is attributable to exactly one deadline (Amendment 1 §2); not a product SLO (OQ2 ruling); the MCP client's own request-timeout default is 300000 ms (300s), recorded here for reference only, see [oq_rulings] above"
 runner_class = "self_hosted_real_embedder"
 
 [[scenario]]
@@ -80,8 +101,8 @@ settle = "sequential_sentinel"
 attempts = 1000
 concurrency = 1
 required_percentiles = ["p50", "p95", "p99"]
-request_deadline_ms = 30000
-request_deadline_provenance = "harness measurement-censoring safety cap, not a product SLO (OQ2 ruling); the MCP client's own request-timeout default is 300000 ms (300s), recorded here for reference only, see [oq_rulings] above"
+request_deadline_ms = 45000
+request_deadline_provenance = "harness measurement-censoring safety cap, set to strictly exceed the server-side recall deadline (30000 ms per #919) so a timeout is attributable to exactly one deadline (Amendment 1 §2); not a product SLO (OQ2 ruling); the MCP client's own request-timeout default is 300000 ms (300s), recorded here for reference only, see [oq_rulings] above"
 runner_class = "hosted_hash"
 
 [[scenario]]
@@ -98,8 +119,8 @@ settle = "sequential_sentinel"
 attempts = 1000
 concurrency = 1
 required_percentiles = ["p50", "p95", "p99"]
-request_deadline_ms = 30000
-request_deadline_provenance = "harness measurement-censoring safety cap, not a product SLO (OQ2 ruling); the MCP client's own request-timeout default is 300000 ms (300s), recorded here for reference only, see [oq_rulings] above"
+request_deadline_ms = 45000
+request_deadline_provenance = "harness measurement-censoring safety cap, set to strictly exceed the server-side recall deadline (30000 ms per #919) so a timeout is attributable to exactly one deadline (Amendment 1 §2); not a product SLO (OQ2 ruling); the MCP client's own request-timeout default is 300000 ms (300s), recorded here for reference only, see [oq_rulings] above"
 runner_class = "hosted_hash"
 
 [[scenario]]
@@ -116,8 +137,8 @@ settle = "sequential_sentinel"
 attempts = 1000
 concurrency = 1
 required_percentiles = ["p50", "p95", "p99"]
-request_deadline_ms = 30000
-request_deadline_provenance = "harness measurement-censoring safety cap, not a product SLO (OQ2 ruling); the MCP client's own request-timeout default is 300000 ms (300s), recorded here for reference only, see [oq_rulings] above"
+request_deadline_ms = 45000
+request_deadline_provenance = "harness measurement-censoring safety cap, set to strictly exceed the server-side recall deadline (30000 ms per #919) so a timeout is attributable to exactly one deadline (Amendment 1 §2); not a product SLO (OQ2 ruling); the MCP client's own request-timeout default is 300000 ms (300s), recorded here for reference only, see [oq_rulings] above"
 runner_class = "hosted_hash"
 
 [[scenario]]
@@ -134,8 +155,8 @@ settle = "sequential_sentinel"
 attempts = 1000
 concurrency = 1
 required_percentiles = ["p50", "p95", "p99"]
-request_deadline_ms = 30000
-request_deadline_provenance = "harness measurement-censoring safety cap, not a product SLO (OQ2 ruling); the MCP client's own request-timeout default is 300000 ms (300s), recorded here for reference only, see [oq_rulings] above"
+request_deadline_ms = 45000
+request_deadline_provenance = "harness measurement-censoring safety cap, set to strictly exceed the server-side recall deadline (30000 ms per #919) so a timeout is attributable to exactly one deadline (Amendment 1 §2); not a product SLO (OQ2 ruling); the MCP client's own request-timeout default is 300000 ms (300s), recorded here for reference only, see [oq_rulings] above"
 runner_class = "self_hosted_real_embedder"
 
 [[scenario]]
@@ -152,8 +173,26 @@ settle = "sequential_sentinel"
 attempts = 1000
 concurrency = 1
 required_percentiles = ["p50", "p95", "p99"]
-request_deadline_ms = 30000
-request_deadline_provenance = "harness measurement-censoring safety cap, not a product SLO (OQ2 ruling); the MCP client's own request-timeout default is 300000 ms (300s), recorded here for reference only, see [oq_rulings] above"
+request_deadline_ms = 45000
+request_deadline_provenance = "harness measurement-censoring safety cap, set to strictly exceed the server-side recall deadline (30000 ms per #919) so a timeout is attributable to exactly one deadline (Amendment 1 §2); not a product SLO (OQ2 ruling); the MCP client's own request-timeout default is 300000 ms (300s), recorded here for reference only, see [oq_rulings] above"
+runner_class = "self_hosted_real_embedder"
+
+[[scenario]]
+scenario_id = "f1.recall.warm.real.n500k"
+feature = "F1"
+surface = "mcp_daemon"
+operation = "memory.recall"
+fixture = "memory_n500k_sentinel_settled"
+fixture_hash = "sha256:74f191649fb33fe1a406f23dfddedb8eac0ee045d4a74926d300cdadb7bb0beb"
+scale = { memories = 500000 }
+embedder = "production"
+state = "warm"
+settle = "sequential_sentinel"
+attempts = 1000
+concurrency = 1
+required_percentiles = ["p50", "p95", "p99"]
+request_deadline_ms = 45000
+request_deadline_provenance = "harness measurement-censoring safety cap, set to strictly exceed the server-side recall deadline (30000 ms per #919) so a timeout is attributable to exactly one deadline (Amendment 1 §2); not a product SLO (OQ2 ruling); the MCP client's own request-timeout default is 300000 ms (300s), recorded here for reference only, see [oq_rulings] above"
 runner_class = "self_hosted_real_embedder"
 
 [[scenario]]
@@ -170,8 +209,8 @@ settle = "sequential_sentinel"
 attempts = 1000
 concurrency = 1
 required_percentiles = ["p50", "p95", "p99"]
-request_deadline_ms = 30000
-request_deadline_provenance = "harness measurement-censoring safety cap, not a product SLO (OQ2 ruling); the MCP client's own request-timeout default is 300000 ms (300s), recorded here for reference only, see [oq_rulings] above"
+request_deadline_ms = 45000
+request_deadline_provenance = "harness measurement-censoring safety cap, set to strictly exceed the server-side recall deadline (30000 ms per #919) so a timeout is attributable to exactly one deadline (Amendment 1 §2); not a product SLO (OQ2 ruling); the MCP client's own request-timeout default is 300000 ms (300s), recorded here for reference only, see [oq_rulings] above"
 runner_class = "self_hosted_real_embedder"
 
 [[scenario]]
@@ -188,8 +227,8 @@ settle = "sequential_sentinel"
 attempts = 1000
 concurrency = 1
 required_percentiles = ["p50", "p95", "p99"]
-request_deadline_ms = 30000
-request_deadline_provenance = "harness measurement-censoring safety cap, not a product SLO (OQ2 ruling); the MCP client's own request-timeout default is 300000 ms (300s), recorded here for reference only, see [oq_rulings] above"
+request_deadline_ms = 45000
+request_deadline_provenance = "harness measurement-censoring safety cap, set to strictly exceed the server-side recall deadline (30000 ms per #919) so a timeout is attributable to exactly one deadline (Amendment 1 §2); not a product SLO (OQ2 ruling); the MCP client's own request-timeout default is 300000 ms (300s), recorded here for reference only, see [oq_rulings] above"
 runner_class = "self_hosted_real_embedder"
 
 [[scenario]]
@@ -206,8 +245,8 @@ settle = "sequential_sentinel"
 attempts = 1000
 concurrency = 1
 required_percentiles = ["p50", "p95", "p99"]
-request_deadline_ms = 30000
-request_deadline_provenance = "harness measurement-censoring safety cap, not a product SLO (OQ2 ruling); the MCP client's own request-timeout default is 300000 ms (300s), recorded here for reference only, see [oq_rulings] above"
+request_deadline_ms = 45000
+request_deadline_provenance = "harness measurement-censoring safety cap, set to strictly exceed the server-side recall deadline (30000 ms per #919) so a timeout is attributable to exactly one deadline (Amendment 1 §2); not a product SLO (OQ2 ruling); the MCP client's own request-timeout default is 300000 ms (300s), recorded here for reference only, see [oq_rulings] above"
 runner_class = "self_hosted_real_embedder"
 
 [[scenario]]
@@ -224,8 +263,8 @@ settle = "sequential_sentinel"
 attempts = 1000
 concurrency = 1
 required_percentiles = ["p50", "p95", "p99"]
-request_deadline_ms = 30000
-request_deadline_provenance = "harness measurement-censoring safety cap, not a product SLO (OQ2 ruling); the MCP client's own request-timeout default is 300000 ms (300s), recorded here for reference only, see [oq_rulings] above"
+request_deadline_ms = 45000
+request_deadline_provenance = "harness measurement-censoring safety cap, set to strictly exceed the server-side recall deadline (30000 ms per #919) so a timeout is attributable to exactly one deadline (Amendment 1 §2); not a product SLO (OQ2 ruling); the MCP client's own request-timeout default is 300000 ms (300s), recorded here for reference only, see [oq_rulings] above"
 runner_class = "self_hosted_real_embedder"
 
 [[scenario]]
@@ -242,8 +281,8 @@ settle = "sequential_sentinel"
 attempts = 1000
 concurrency = 1
 required_percentiles = ["p50", "p95", "p99"]
-request_deadline_ms = 30000
-request_deadline_provenance = "harness measurement-censoring safety cap, not a product SLO (OQ2 ruling); the MCP client's own request-timeout default is 300000 ms (300s), recorded here for reference only, see [oq_rulings] above"
+request_deadline_ms = 45000
+request_deadline_provenance = "harness measurement-censoring safety cap, set to strictly exceed the server-side recall deadline (30000 ms per #919) so a timeout is attributable to exactly one deadline (Amendment 1 §2); not a product SLO (OQ2 ruling); the MCP client's own request-timeout default is 300000 ms (300s), recorded here for reference only, see [oq_rulings] above"
 runner_class = "self_hosted_real_embedder"
 
 [[scenario]]
@@ -260,8 +299,8 @@ settle = "sequential_sentinel"
 attempts = 1000
 concurrency = 1
 required_percentiles = ["p50", "p95", "p99"]
-request_deadline_ms = 30000
-request_deadline_provenance = "harness measurement-censoring safety cap, not a product SLO (OQ2 ruling); the MCP client's own request-timeout default is 300000 ms (300s), recorded here for reference only, see [oq_rulings] above"
+request_deadline_ms = 45000
+request_deadline_provenance = "harness measurement-censoring safety cap, set to strictly exceed the server-side recall deadline (30000 ms per #919) so a timeout is attributable to exactly one deadline (Amendment 1 §2); not a product SLO (OQ2 ruling); the MCP client's own request-timeout default is 300000 ms (300s), recorded here for reference only, see [oq_rulings] above"
 runner_class = "self_hosted_real_embedder"
 
 [[scenario]]
@@ -278,8 +317,8 @@ settle = "sequential_sentinel"
 attempts = 1000
 concurrency = 1
 required_percentiles = ["p50", "p95", "p99"]
-request_deadline_ms = 30000
-request_deadline_provenance = "harness measurement-censoring safety cap, not a product SLO (OQ2 ruling); the MCP client's own request-timeout default is 300000 ms (300s), recorded here for reference only, see [oq_rulings] above"
+request_deadline_ms = 45000
+request_deadline_provenance = "harness measurement-censoring safety cap, set to strictly exceed the server-side recall deadline (30000 ms per #919) so a timeout is attributable to exactly one deadline (Amendment 1 §2); not a product SLO (OQ2 ruling); the MCP client's own request-timeout default is 300000 ms (300s), recorded here for reference only, see [oq_rulings] above"
 runner_class = "self_hosted_real_embedder"
 
 [[scenario]]
@@ -296,8 +335,8 @@ settle = "sequential_sentinel"
 attempts = 1000
 concurrency = 1
 required_percentiles = ["p50", "p95", "p99"]
-request_deadline_ms = 30000
-request_deadline_provenance = "harness measurement-censoring safety cap, not a product SLO (OQ2 ruling); the MCP client's own request-timeout default is 300000 ms (300s), recorded here for reference only, see [oq_rulings] above"
+request_deadline_ms = 45000
+request_deadline_provenance = "harness measurement-censoring safety cap, set to strictly exceed the server-side recall deadline (30000 ms per #919) so a timeout is attributable to exactly one deadline (Amendment 1 §2); not a product SLO (OQ2 ruling); the MCP client's own request-timeout default is 300000 ms (300s), recorded here for reference only, see [oq_rulings] above"
 runner_class = "hosted_hash"
 
 [[scenario]]
@@ -314,8 +353,8 @@ settle = "sequential_sentinel"
 attempts = 1000
 concurrency = 1
 required_percentiles = ["p50", "p95", "p99"]
-request_deadline_ms = 30000
-request_deadline_provenance = "harness measurement-censoring safety cap, not a product SLO (OQ2 ruling); the MCP client's own request-timeout default is 300000 ms (300s), recorded here for reference only, see [oq_rulings] above"
+request_deadline_ms = 45000
+request_deadline_provenance = "harness measurement-censoring safety cap, set to strictly exceed the server-side recall deadline (30000 ms per #919) so a timeout is attributable to exactly one deadline (Amendment 1 §2); not a product SLO (OQ2 ruling); the MCP client's own request-timeout default is 300000 ms (300s), recorded here for reference only, see [oq_rulings] above"
 runner_class = "hosted_hash"
 
 [[scenario]]
@@ -332,8 +371,8 @@ settle = "sequential_sentinel"
 attempts = 1000
 concurrency = 1
 required_percentiles = ["p50", "p95", "p99"]
-request_deadline_ms = 30000
-request_deadline_provenance = "harness measurement-censoring safety cap, not a product SLO (OQ2 ruling); the MCP client's own request-timeout default is 300000 ms (300s), recorded here for reference only, see [oq_rulings] above"
+request_deadline_ms = 45000
+request_deadline_provenance = "harness measurement-censoring safety cap, set to strictly exceed the server-side recall deadline (30000 ms per #919) so a timeout is attributable to exactly one deadline (Amendment 1 §2); not a product SLO (OQ2 ruling); the MCP client's own request-timeout default is 300000 ms (300s), recorded here for reference only, see [oq_rulings] above"
 runner_class = "hosted_hash"
 
 [[scenario]]
@@ -350,8 +389,8 @@ settle = "sequential_sentinel"
 attempts = 1000
 concurrency = 1
 required_percentiles = ["p50", "p95", "p99"]
-request_deadline_ms = 30000
-request_deadline_provenance = "harness measurement-censoring safety cap, not a product SLO (OQ2 ruling); the MCP client's own request-timeout default is 300000 ms (300s), recorded here for reference only, see [oq_rulings] above"
+request_deadline_ms = 45000
+request_deadline_provenance = "harness measurement-censoring safety cap, set to strictly exceed the server-side recall deadline (30000 ms per #919) so a timeout is attributable to exactly one deadline (Amendment 1 §2); not a product SLO (OQ2 ruling); the MCP client's own request-timeout default is 300000 ms (300s), recorded here for reference only, see [oq_rulings] above"
 runner_class = "hosted_hash"
 
 [[scenario]]
@@ -368,8 +407,8 @@ settle = "sequential_sentinel"
 attempts = 1000
 concurrency = 1
 required_percentiles = ["p50", "p95", "p99"]
-request_deadline_ms = 30000
-request_deadline_provenance = "harness measurement-censoring safety cap, not a product SLO (OQ2 ruling); the MCP client's own request-timeout default is 300000 ms (300s), recorded here for reference only, see [oq_rulings] above"
+request_deadline_ms = 45000
+request_deadline_provenance = "harness measurement-censoring safety cap, set to strictly exceed the server-side recall deadline (30000 ms per #919) so a timeout is attributable to exactly one deadline (Amendment 1 §2); not a product SLO (OQ2 ruling); the MCP client's own request-timeout default is 300000 ms (300s), recorded here for reference only, see [oq_rulings] above"
 runner_class = "hosted_hash"
 
 [[scenario]]
@@ -386,8 +425,8 @@ settle = "sequential_sentinel"
 attempts = 1000
 concurrency = 1
 required_percentiles = ["p50", "p95", "p99"]
-request_deadline_ms = 30000
-request_deadline_provenance = "harness measurement-censoring safety cap, not a product SLO (OQ2 ruling); the MCP client's own request-timeout default is 300000 ms (300s), recorded here for reference only, see [oq_rulings] above"
+request_deadline_ms = 45000
+request_deadline_provenance = "harness measurement-censoring safety cap, set to strictly exceed the server-side recall deadline (30000 ms per #919) so a timeout is attributable to exactly one deadline (Amendment 1 §2); not a product SLO (OQ2 ruling); the MCP client's own request-timeout default is 300000 ms (300s), recorded here for reference only, see [oq_rulings] above"
 runner_class = "hosted_hash"
 
 [[scenario]]
@@ -404,8 +443,8 @@ settle = "sequential_sentinel"
 attempts = 1000
 concurrency = 1
 required_percentiles = ["p50", "p95", "p99"]
-request_deadline_ms = 30000
-request_deadline_provenance = "harness measurement-censoring safety cap, not a product SLO (OQ2 ruling); the MCP client's own request-timeout default is 300000 ms (300s), recorded here for reference only, see [oq_rulings] above"
+request_deadline_ms = 45000
+request_deadline_provenance = "harness measurement-censoring safety cap, set to strictly exceed the server-side recall deadline (30000 ms per #919) so a timeout is attributable to exactly one deadline (Amendment 1 §2); not a product SLO (OQ2 ruling); the MCP client's own request-timeout default is 300000 ms (300s), recorded here for reference only, see [oq_rulings] above"
 runner_class = "self_hosted_real_embedder"
 
 [[scenario]]
@@ -422,8 +461,8 @@ settle = "sequential_sentinel"
 attempts = 1000
 concurrency = 1
 required_percentiles = ["p50", "p95", "p99"]
-request_deadline_ms = 30000
-request_deadline_provenance = "harness measurement-censoring safety cap, not a product SLO (OQ2 ruling); the MCP client's own request-timeout default is 300000 ms (300s), recorded here for reference only, see [oq_rulings] above"
+request_deadline_ms = 45000
+request_deadline_provenance = "harness measurement-censoring safety cap, set to strictly exceed the server-side recall deadline (30000 ms per #919) so a timeout is attributable to exactly one deadline (Amendment 1 §2); not a product SLO (OQ2 ruling); the MCP client's own request-timeout default is 300000 ms (300s), recorded here for reference only, see [oq_rulings] above"
 runner_class = "self_hosted_real_embedder"
 
 [[scenario]]
@@ -440,8 +479,8 @@ settle = "sequential_sentinel"
 attempts = 1000
 concurrency = 1
 required_percentiles = ["p50", "p95", "p99"]
-request_deadline_ms = 30000
-request_deadline_provenance = "harness measurement-censoring safety cap, not a product SLO (OQ2 ruling); the MCP client's own request-timeout default is 300000 ms (300s), recorded here for reference only, see [oq_rulings] above"
+request_deadline_ms = 45000
+request_deadline_provenance = "harness measurement-censoring safety cap, set to strictly exceed the server-side recall deadline (30000 ms per #919) so a timeout is attributable to exactly one deadline (Amendment 1 §2); not a product SLO (OQ2 ruling); the MCP client's own request-timeout default is 300000 ms (300s), recorded here for reference only, see [oq_rulings] above"
 runner_class = "self_hosted_real_embedder"
 
 [[scenario]]
@@ -458,8 +497,8 @@ settle = "sequential_sentinel"
 attempts = 1000
 concurrency = 1
 required_percentiles = ["p50", "p95", "p99"]
-request_deadline_ms = 30000
-request_deadline_provenance = "harness measurement-censoring safety cap, not a product SLO (OQ2 ruling); the MCP client's own request-timeout default is 300000 ms (300s), recorded here for reference only, see [oq_rulings] above"
+request_deadline_ms = 45000
+request_deadline_provenance = "harness measurement-censoring safety cap, set to strictly exceed the server-side recall deadline (30000 ms per #919) so a timeout is attributable to exactly one deadline (Amendment 1 §2); not a product SLO (OQ2 ruling); the MCP client's own request-timeout default is 300000 ms (300s), recorded here for reference only, see [oq_rulings] above"
 runner_class = "self_hosted_real_embedder"
 
 [[scenario]]
@@ -476,8 +515,8 @@ settle = "sequential_sentinel"
 attempts = 1000
 concurrency = 1
 required_percentiles = ["p50", "p95", "p99"]
-request_deadline_ms = 30000
-request_deadline_provenance = "harness measurement-censoring safety cap, not a product SLO (OQ2 ruling); the MCP client's own request-timeout default is 300000 ms (300s), recorded here for reference only, see [oq_rulings] above"
+request_deadline_ms = 45000
+request_deadline_provenance = "harness measurement-censoring safety cap, set to strictly exceed the server-side recall deadline (30000 ms per #919) so a timeout is attributable to exactly one deadline (Amendment 1 §2); not a product SLO (OQ2 ruling); the MCP client's own request-timeout default is 300000 ms (300s), recorded here for reference only, see [oq_rulings] above"
 runner_class = "self_hosted_real_embedder"
 
 [[scenario]]
@@ -494,8 +533,8 @@ settle = "sequential_sentinel"
 attempts = 1000
 concurrency = 1
 required_percentiles = ["p50", "p95", "p99"]
-request_deadline_ms = 30000
-request_deadline_provenance = "harness measurement-censoring safety cap, not a product SLO (OQ2 ruling); the MCP client's own request-timeout default is 300000 ms (300s), recorded here for reference only, see [oq_rulings] above"
+request_deadline_ms = 45000
+request_deadline_provenance = "harness measurement-censoring safety cap, set to strictly exceed the server-side recall deadline (30000 ms per #919) so a timeout is attributable to exactly one deadline (Amendment 1 §2); not a product SLO (OQ2 ruling); the MCP client's own request-timeout default is 300000 ms (300s), recorded here for reference only, see [oq_rulings] above"
 runner_class = "self_hosted_real_embedder"
 
 [[scenario]]
@@ -512,8 +551,8 @@ settle = "sequential_sentinel"
 attempts = 1000
 concurrency = 1
 required_percentiles = ["p50", "p95", "p99"]
-request_deadline_ms = 30000
-request_deadline_provenance = "harness measurement-censoring safety cap, not a product SLO (OQ2 ruling); the MCP client's own request-timeout default is 300000 ms (300s), recorded here for reference only, see [oq_rulings] above"
+request_deadline_ms = 45000
+request_deadline_provenance = "harness measurement-censoring safety cap, set to strictly exceed the server-side recall deadline (30000 ms per #919) so a timeout is attributable to exactly one deadline (Amendment 1 §2); not a product SLO (OQ2 ruling); the MCP client's own request-timeout default is 300000 ms (300s), recorded here for reference only, see [oq_rulings] above"
 runner_class = "self_hosted_real_embedder"
 
 [[scenario]]
@@ -530,8 +569,8 @@ settle = "sequential_sentinel"
 attempts = 1000
 concurrency = 1
 required_percentiles = ["p50", "p95", "p99"]
-request_deadline_ms = 30000
-request_deadline_provenance = "harness measurement-censoring safety cap, not a product SLO (OQ2 ruling); the MCP client's own request-timeout default is 300000 ms (300s), recorded here for reference only, see [oq_rulings] above"
+request_deadline_ms = 45000
+request_deadline_provenance = "harness measurement-censoring safety cap, set to strictly exceed the server-side recall deadline (30000 ms per #919) so a timeout is attributable to exactly one deadline (Amendment 1 §2); not a product SLO (OQ2 ruling); the MCP client's own request-timeout default is 300000 ms (300s), recorded here for reference only, see [oq_rulings] above"
 runner_class = "self_hosted_real_embedder"
 
 [[scenario]]
@@ -548,8 +587,8 @@ settle = "sequential_sentinel"
 attempts = 1000
 concurrency = 1
 required_percentiles = ["p50", "p95", "p99"]
-request_deadline_ms = 30000
-request_deadline_provenance = "harness measurement-censoring safety cap, not a product SLO (OQ2 ruling); the MCP client's own request-timeout default is 300000 ms (300s), recorded here for reference only, see [oq_rulings] above"
+request_deadline_ms = 45000
+request_deadline_provenance = "harness measurement-censoring safety cap, set to strictly exceed the server-side recall deadline (30000 ms per #919) so a timeout is attributable to exactly one deadline (Amendment 1 §2); not a product SLO (OQ2 ruling); the MCP client's own request-timeout default is 300000 ms (300s), recorded here for reference only, see [oq_rulings] above"
 runner_class = "self_hosted_real_embedder"
 
 [[scenario]]
@@ -566,8 +605,8 @@ settle = "sequential_sentinel"
 attempts = 1000
 concurrency = 1
 required_percentiles = ["p50", "p95", "p99"]
-request_deadline_ms = 30000
-request_deadline_provenance = "harness measurement-censoring safety cap, not a product SLO (OQ2 ruling); the MCP client's own request-timeout default is 300000 ms (300s), recorded here for reference only, see [oq_rulings] above"
+request_deadline_ms = 45000
+request_deadline_provenance = "harness measurement-censoring safety cap, set to strictly exceed the server-side recall deadline (30000 ms per #919) so a timeout is attributable to exactly one deadline (Amendment 1 §2); not a product SLO (OQ2 ruling); the MCP client's own request-timeout default is 300000 ms (300s), recorded here for reference only, see [oq_rulings] above"
 runner_class = "self_hosted_real_embedder"
 
 [[scenario]]
@@ -584,8 +623,8 @@ settle = "sequential_sentinel"
 attempts = 1000
 concurrency = 1
 required_percentiles = ["p50", "p95", "p99"]
-request_deadline_ms = 30000
-request_deadline_provenance = "harness measurement-censoring safety cap, not a product SLO (OQ2 ruling); the MCP client's own request-timeout default is 300000 ms (300s), recorded here for reference only, see [oq_rulings] above"
+request_deadline_ms = 45000
+request_deadline_provenance = "harness measurement-censoring safety cap, set to strictly exceed the server-side recall deadline (30000 ms per #919) so a timeout is attributable to exactly one deadline (Amendment 1 §2); not a product SLO (OQ2 ruling); the MCP client's own request-timeout default is 300000 ms (300s), recorded here for reference only, see [oq_rulings] above"
 runner_class = "self_hosted_real_embedder"
 
 [[scenario]]
@@ -602,8 +641,8 @@ settle = "sequential_sentinel"
 attempts = 1000
 concurrency = 1
 required_percentiles = ["p50", "p95", "p99"]
-request_deadline_ms = 30000
-request_deadline_provenance = "harness measurement-censoring safety cap, not a product SLO (OQ2 ruling); the MCP client's own request-timeout default is 300000 ms (300s), recorded here for reference only, see [oq_rulings] above"
+request_deadline_ms = 45000
+request_deadline_provenance = "harness measurement-censoring safety cap, set to strictly exceed the server-side recall deadline (30000 ms per #919) so a timeout is attributable to exactly one deadline (Amendment 1 §2); not a product SLO (OQ2 ruling); the MCP client's own request-timeout default is 300000 ms (300s), recorded here for reference only, see [oq_rulings] above"
 runner_class = "self_hosted_real_embedder"
 
 [[scenario]]
@@ -620,8 +659,8 @@ settle = "sequential_sentinel"
 attempts = 1000
 concurrency = 1
 required_percentiles = ["p50", "p95", "p99"]
-request_deadline_ms = 30000
-request_deadline_provenance = "harness measurement-censoring safety cap, not a product SLO (OQ2 ruling); the MCP client's own request-timeout default is 300000 ms (300s), recorded here for reference only, see [oq_rulings] above"
+request_deadline_ms = 45000
+request_deadline_provenance = "harness measurement-censoring safety cap, set to strictly exceed the server-side recall deadline (30000 ms per #919) so a timeout is attributable to exactly one deadline (Amendment 1 §2); not a product SLO (OQ2 ruling); the MCP client's own request-timeout default is 300000 ms (300s), recorded here for reference only, see [oq_rulings] above"
 runner_class = "hosted_hash"
 
 [[scenario]]
@@ -638,8 +677,8 @@ settle = "sequential_sentinel"
 attempts = 1000
 concurrency = 1
 required_percentiles = ["p50", "p95", "p99"]
-request_deadline_ms = 30000
-request_deadline_provenance = "harness measurement-censoring safety cap, not a product SLO (OQ2 ruling); the MCP client's own request-timeout default is 300000 ms (300s), recorded here for reference only, see [oq_rulings] above"
+request_deadline_ms = 45000
+request_deadline_provenance = "harness measurement-censoring safety cap, set to strictly exceed the server-side recall deadline (30000 ms per #919) so a timeout is attributable to exactly one deadline (Amendment 1 §2); not a product SLO (OQ2 ruling); the MCP client's own request-timeout default is 300000 ms (300s), recorded here for reference only, see [oq_rulings] above"
 runner_class = "hosted_hash"
 
 [[scenario]]
@@ -656,8 +695,8 @@ settle = "sequential_sentinel"
 attempts = 1000
 concurrency = 1
 required_percentiles = ["p50", "p95", "p99"]
-request_deadline_ms = 30000
-request_deadline_provenance = "harness measurement-censoring safety cap, not a product SLO (OQ2 ruling); the MCP client's own request-timeout default is 300000 ms (300s), recorded here for reference only, see [oq_rulings] above"
+request_deadline_ms = 45000
+request_deadline_provenance = "harness measurement-censoring safety cap, set to strictly exceed the server-side recall deadline (30000 ms per #919) so a timeout is attributable to exactly one deadline (Amendment 1 §2); not a product SLO (OQ2 ruling); the MCP client's own request-timeout default is 300000 ms (300s), recorded here for reference only, see [oq_rulings] above"
 runner_class = "hosted_hash"
 
 [[scenario]]
@@ -674,8 +713,8 @@ settle = "sequential_sentinel"
 attempts = 1000
 concurrency = 1
 required_percentiles = ["p50", "p95", "p99"]
-request_deadline_ms = 30000
-request_deadline_provenance = "harness measurement-censoring safety cap, not a product SLO (OQ2 ruling); the MCP client's own request-timeout default is 300000 ms (300s), recorded here for reference only, see [oq_rulings] above"
+request_deadline_ms = 45000
+request_deadline_provenance = "harness measurement-censoring safety cap, set to strictly exceed the server-side recall deadline (30000 ms per #919) so a timeout is attributable to exactly one deadline (Amendment 1 §2); not a product SLO (OQ2 ruling); the MCP client's own request-timeout default is 300000 ms (300s), recorded here for reference only, see [oq_rulings] above"
 runner_class = "hosted_hash"
 
 [[scenario]]
@@ -692,8 +731,8 @@ settle = "sequential_sentinel"
 attempts = 1000
 concurrency = 1
 required_percentiles = ["p50", "p95", "p99"]
-request_deadline_ms = 30000
-request_deadline_provenance = "harness measurement-censoring safety cap, not a product SLO (OQ2 ruling); the MCP client's own request-timeout default is 300000 ms (300s), recorded here for reference only, see [oq_rulings] above"
+request_deadline_ms = 45000
+request_deadline_provenance = "harness measurement-censoring safety cap, set to strictly exceed the server-side recall deadline (30000 ms per #919) so a timeout is attributable to exactly one deadline (Amendment 1 §2); not a product SLO (OQ2 ruling); the MCP client's own request-timeout default is 300000 ms (300s), recorded here for reference only, see [oq_rulings] above"
 runner_class = "self_hosted_real_embedder"
 
 [[scenario]]
@@ -710,8 +749,26 @@ settle = "sequential_sentinel"
 attempts = 1000
 concurrency = 1
 required_percentiles = ["p50", "p95", "p99"]
-request_deadline_ms = 30000
-request_deadline_provenance = "harness measurement-censoring safety cap, not a product SLO (OQ2 ruling); the MCP client's own request-timeout default is 300000 ms (300s), recorded here for reference only, see [oq_rulings] above"
+request_deadline_ms = 45000
+request_deadline_provenance = "harness measurement-censoring safety cap, set to strictly exceed the server-side recall deadline (30000 ms per #919) so a timeout is attributable to exactly one deadline (Amendment 1 §2); not a product SLO (OQ2 ruling); the MCP client's own request-timeout default is 300000 ms (300s), recorded here for reference only, see [oq_rulings] above"
+runner_class = "self_hosted_real_embedder"
+
+[[scenario]]
+scenario_id = "f4.traverse.powerlaw.n500000.depth3.real"
+feature = "F4"
+surface = "mcp_daemon"
+operation = "traverse"
+fixture = "kg_graph_powerlaw"
+fixture_hash = "sha256:e679da8c661b7f9e927183e45c739a7573fb4fdd64d6886e03616026eb7fe62a"
+scale = { nodes = 500000, depth = 3 }
+embedder = "production"
+state = "warm"
+settle = "sequential_sentinel"
+attempts = 1000
+concurrency = 1
+required_percentiles = ["p50", "p95", "p99"]
+request_deadline_ms = 45000
+request_deadline_provenance = "harness measurement-censoring safety cap, set to strictly exceed the server-side recall deadline (30000 ms per #919) so a timeout is attributable to exactly one deadline (Amendment 1 §2); not a product SLO (OQ2 ruling); the MCP client's own request-timeout default is 300000 ms (300s), recorded here for reference only, see [oq_rulings] above"
 runner_class = "self_hosted_real_embedder"
 
 [[scenario]]
@@ -728,8 +785,8 @@ settle = "sequential_sentinel"
 attempts = 1000
 concurrency = 1
 required_percentiles = ["p50", "p95", "p99"]
-request_deadline_ms = 30000
-request_deadline_provenance = "harness measurement-censoring safety cap, not a product SLO (OQ2 ruling); the MCP client's own request-timeout default is 300000 ms (300s), recorded here for reference only, see [oq_rulings] above"
+request_deadline_ms = 45000
+request_deadline_provenance = "harness measurement-censoring safety cap, set to strictly exceed the server-side recall deadline (30000 ms per #919) so a timeout is attributable to exactly one deadline (Amendment 1 §2); not a product SLO (OQ2 ruling); the MCP client's own request-timeout default is 300000 ms (300s), recorded here for reference only, see [oq_rulings] above"
 runner_class = "self_hosted_real_embedder"
 
 [[scenario]]
@@ -746,8 +803,8 @@ settle = "sequential_sentinel"
 attempts = 1000
 concurrency = 1
 required_percentiles = ["p50", "p95", "p99"]
-request_deadline_ms = 30000
-request_deadline_provenance = "harness measurement-censoring safety cap, not a product SLO (OQ2 ruling); the MCP client's own request-timeout default is 300000 ms (300s), recorded here for reference only, see [oq_rulings] above"
+request_deadline_ms = 45000
+request_deadline_provenance = "harness measurement-censoring safety cap, set to strictly exceed the server-side recall deadline (30000 ms per #919) so a timeout is attributable to exactly one deadline (Amendment 1 §2); not a product SLO (OQ2 ruling); the MCP client's own request-timeout default is 300000 ms (300s), recorded here for reference only, see [oq_rulings] above"
 runner_class = "hosted_hash"
 
 [[scenario]]
@@ -764,8 +821,8 @@ settle = "sequential_sentinel"
 attempts = 1000
 concurrency = 1
 required_percentiles = ["p50", "p95", "p99"]
-request_deadline_ms = 30000
-request_deadline_provenance = "harness measurement-censoring safety cap, not a product SLO (OQ2 ruling); the MCP client's own request-timeout default is 300000 ms (300s), recorded here for reference only, see [oq_rulings] above"
+request_deadline_ms = 45000
+request_deadline_provenance = "harness measurement-censoring safety cap, set to strictly exceed the server-side recall deadline (30000 ms per #919) so a timeout is attributable to exactly one deadline (Amendment 1 §2); not a product SLO (OQ2 ruling); the MCP client's own request-timeout default is 300000 ms (300s), recorded here for reference only, see [oq_rulings] above"
 runner_class = "self_hosted_real_embedder"
 
 [[scenario]]
@@ -782,8 +839,8 @@ settle = "sequential_sentinel"
 attempts = 1000
 concurrency = 1
 required_percentiles = ["p50", "p95", "p99"]
-request_deadline_ms = 30000
-request_deadline_provenance = "harness measurement-censoring safety cap, not a product SLO (OQ2 ruling); the MCP client's own request-timeout default is 300000 ms (300s), recorded here for reference only, see [oq_rulings] above"
+request_deadline_ms = 45000
+request_deadline_provenance = "harness measurement-censoring safety cap, set to strictly exceed the server-side recall deadline (30000 ms per #919) so a timeout is attributable to exactly one deadline (Amendment 1 §2); not a product SLO (OQ2 ruling); the MCP client's own request-timeout default is 300000 ms (300s), recorded here for reference only, see [oq_rulings] above"
 runner_class = "hosted_hash"
 
 [[scenario]]
@@ -800,8 +857,8 @@ settle = "sequential_sentinel"
 attempts = 1000
 concurrency = 1
 required_percentiles = ["p50", "p95", "p99"]
-request_deadline_ms = 30000
-request_deadline_provenance = "harness measurement-censoring safety cap, not a product SLO (OQ2 ruling); the MCP client's own request-timeout default is 300000 ms (300s), recorded here for reference only, see [oq_rulings] above"
+request_deadline_ms = 45000
+request_deadline_provenance = "harness measurement-censoring safety cap, set to strictly exceed the server-side recall deadline (30000 ms per #919) so a timeout is attributable to exactly one deadline (Amendment 1 §2); not a product SLO (OQ2 ruling); the MCP client's own request-timeout default is 300000 ms (300s), recorded here for reference only, see [oq_rulings] above"
 runner_class = "hosted_hash"
 
 [[scenario]]
@@ -818,8 +875,8 @@ settle = "sequential_sentinel"
 attempts = 1000
 concurrency = 1
 required_percentiles = ["p50", "p95", "p99"]
-request_deadline_ms = 30000
-request_deadline_provenance = "harness measurement-censoring safety cap, not a product SLO (OQ2 ruling); the MCP client's own request-timeout default is 300000 ms (300s), recorded here for reference only, see [oq_rulings] above"
+request_deadline_ms = 45000
+request_deadline_provenance = "harness measurement-censoring safety cap, set to strictly exceed the server-side recall deadline (30000 ms per #919) so a timeout is attributable to exactly one deadline (Amendment 1 §2); not a product SLO (OQ2 ruling); the MCP client's own request-timeout default is 300000 ms (300s), recorded here for reference only, see [oq_rulings] above"
 runner_class = "hosted_hash"
 
 [[scenario]]
@@ -836,8 +893,8 @@ settle = "sequential_sentinel"
 attempts = 1000
 concurrency = 1
 required_percentiles = ["p50", "p95", "p99"]
-request_deadline_ms = 30000
-request_deadline_provenance = "harness measurement-censoring safety cap, not a product SLO (OQ2 ruling); the MCP client's own request-timeout default is 300000 ms (300s), recorded here for reference only, see [oq_rulings] above"
+request_deadline_ms = 45000
+request_deadline_provenance = "harness measurement-censoring safety cap, set to strictly exceed the server-side recall deadline (30000 ms per #919) so a timeout is attributable to exactly one deadline (Amendment 1 §2); not a product SLO (OQ2 ruling); the MCP client's own request-timeout default is 300000 ms (300s), recorded here for reference only, see [oq_rulings] above"
 runner_class = "hosted_hash"
 
 [[scenario]]
@@ -854,8 +911,8 @@ settle = "sequential_sentinel"
 attempts = 1000
 concurrency = 1
 required_percentiles = ["p50", "p95", "p99"]
-request_deadline_ms = 30000
-request_deadline_provenance = "harness measurement-censoring safety cap, not a product SLO (OQ2 ruling); the MCP client's own request-timeout default is 300000 ms (300s), recorded here for reference only, see [oq_rulings] above"
+request_deadline_ms = 45000
+request_deadline_provenance = "harness measurement-censoring safety cap, set to strictly exceed the server-side recall deadline (30000 ms per #919) so a timeout is attributable to exactly one deadline (Amendment 1 §2); not a product SLO (OQ2 ruling); the MCP client's own request-timeout default is 300000 ms (300s), recorded here for reference only, see [oq_rulings] above"
 runner_class = "hosted_hash"
 
 [[scenario]]
@@ -872,8 +929,8 @@ settle = "sequential_sentinel"
 attempts = 1000
 concurrency = 1
 required_percentiles = ["p50", "p95", "p99"]
-request_deadline_ms = 30000
-request_deadline_provenance = "harness measurement-censoring safety cap, not a product SLO (OQ2 ruling); the MCP client's own request-timeout default is 300000 ms (300s), recorded here for reference only, see [oq_rulings] above"
+request_deadline_ms = 45000
+request_deadline_provenance = "harness measurement-censoring safety cap, set to strictly exceed the server-side recall deadline (30000 ms per #919) so a timeout is attributable to exactly one deadline (Amendment 1 §2); not a product SLO (OQ2 ruling); the MCP client's own request-timeout default is 300000 ms (300s), recorded here for reference only, see [oq_rulings] above"
 runner_class = "hosted_hash"
 
 [[scenario]]
@@ -890,8 +947,8 @@ settle = "sequential_sentinel"
 attempts = 1000
 concurrency = 1
 required_percentiles = ["p50", "p95", "p99"]
-request_deadline_ms = 30000
-request_deadline_provenance = "harness measurement-censoring safety cap, not a product SLO (OQ2 ruling); the MCP client's own request-timeout default is 300000 ms (300s), recorded here for reference only, see [oq_rulings] above"
+request_deadline_ms = 45000
+request_deadline_provenance = "harness measurement-censoring safety cap, set to strictly exceed the server-side recall deadline (30000 ms per #919) so a timeout is attributable to exactly one deadline (Amendment 1 §2); not a product SLO (OQ2 ruling); the MCP client's own request-timeout default is 300000 ms (300s), recorded here for reference only, see [oq_rulings] above"
 runner_class = "hosted_hash"
 
 [[scenario]]
@@ -908,8 +965,8 @@ settle = "sequential_sentinel"
 attempts = 1000
 concurrency = 1
 required_percentiles = ["p50", "p95", "p99"]
-request_deadline_ms = 30000
-request_deadline_provenance = "harness measurement-censoring safety cap, not a product SLO (OQ2 ruling); the MCP client's own request-timeout default is 300000 ms (300s), recorded here for reference only, see [oq_rulings] above"
+request_deadline_ms = 45000
+request_deadline_provenance = "harness measurement-censoring safety cap, set to strictly exceed the server-side recall deadline (30000 ms per #919) so a timeout is attributable to exactly one deadline (Amendment 1 §2); not a product SLO (OQ2 ruling); the MCP client's own request-timeout default is 300000 ms (300s), recorded here for reference only, see [oq_rulings] above"
 runner_class = "hosted_hash"
 
 [[scenario]]
@@ -926,8 +983,8 @@ settle = "sequential_sentinel"
 attempts = 1000
 concurrency = 1
 required_percentiles = ["p50", "p95", "p99"]
-request_deadline_ms = 30000
-request_deadline_provenance = "harness measurement-censoring safety cap, not a product SLO (OQ2 ruling); the MCP client's own request-timeout default is 300000 ms (300s), recorded here for reference only, see [oq_rulings] above"
+request_deadline_ms = 45000
+request_deadline_provenance = "harness measurement-censoring safety cap, set to strictly exceed the server-side recall deadline (30000 ms per #919) so a timeout is attributable to exactly one deadline (Amendment 1 §2); not a product SLO (OQ2 ruling); the MCP client's own request-timeout default is 300000 ms (300s), recorded here for reference only, see [oq_rulings] above"
 runner_class = "hosted_hash"
 
 [[scenario]]
@@ -944,8 +1001,8 @@ settle = "sequential_sentinel"
 attempts = 1000
 concurrency = 1
 required_percentiles = ["p50", "p95", "p99"]
-request_deadline_ms = 30000
-request_deadline_provenance = "harness measurement-censoring safety cap, not a product SLO (OQ2 ruling); the MCP client's own request-timeout default is 300000 ms (300s), recorded here for reference only, see [oq_rulings] above"
+request_deadline_ms = 45000
+request_deadline_provenance = "harness measurement-censoring safety cap, set to strictly exceed the server-side recall deadline (30000 ms per #919) so a timeout is attributable to exactly one deadline (Amendment 1 §2); not a product SLO (OQ2 ruling); the MCP client's own request-timeout default is 300000 ms (300s), recorded here for reference only, see [oq_rulings] above"
 runner_class = "hosted_hash"
 
 [[scenario]]
@@ -962,8 +1019,8 @@ settle = "none"
 attempts = 200
 concurrency = 1
 required_percentiles = ["p50", "p95", "p99"]
-request_deadline_ms = 30000
-request_deadline_provenance = "harness measurement-censoring safety cap, not a product SLO (OQ2 ruling); the MCP client's own request-timeout default is 300000 ms (300s), recorded here for reference only, see [oq_rulings] above"
+request_deadline_ms = 45000
+request_deadline_provenance = "harness measurement-censoring safety cap, set to strictly exceed the server-side recall deadline (30000 ms per #919) so a timeout is attributable to exactly one deadline (Amendment 1 §2); not a product SLO (OQ2 ruling); the MCP client's own request-timeout default is 300000 ms (300s), recorded here for reference only, see [oq_rulings] above"
 runner_class = "hosted_hash"
 
 [[scenario]]
@@ -980,8 +1037,8 @@ settle = "none"
 attempts = 200
 concurrency = 1
 required_percentiles = ["p50", "p95", "p99"]
-request_deadline_ms = 30000
-request_deadline_provenance = "harness measurement-censoring safety cap, not a product SLO (OQ2 ruling); the MCP client's own request-timeout default is 300000 ms (300s), recorded here for reference only, see [oq_rulings] above"
+request_deadline_ms = 45000
+request_deadline_provenance = "harness measurement-censoring safety cap, set to strictly exceed the server-side recall deadline (30000 ms per #919) so a timeout is attributable to exactly one deadline (Amendment 1 §2); not a product SLO (OQ2 ruling); the MCP client's own request-timeout default is 300000 ms (300s), recorded here for reference only, see [oq_rulings] above"
 runner_class = "self_hosted_real_embedder"
 
 [[scenario]]
@@ -998,8 +1055,8 @@ settle = "none"
 attempts = 200
 concurrency = 1
 required_percentiles = ["p50", "p95", "p99"]
-request_deadline_ms = 30000
-request_deadline_provenance = "harness measurement-censoring safety cap, not a product SLO (OQ2 ruling); the MCP client's own request-timeout default is 300000 ms (300s), recorded here for reference only, see [oq_rulings] above"
+request_deadline_ms = 45000
+request_deadline_provenance = "harness measurement-censoring safety cap, set to strictly exceed the server-side recall deadline (30000 ms per #919) so a timeout is attributable to exactly one deadline (Amendment 1 §2); not a product SLO (OQ2 ruling); the MCP client's own request-timeout default is 300000 ms (300s), recorded here for reference only, see [oq_rulings] above"
 runner_class = "hosted_hash"
 
 [[scenario]]
@@ -1016,8 +1073,8 @@ settle = "none"
 attempts = 200
 concurrency = 1
 required_percentiles = ["p50", "p95", "p99"]
-request_deadline_ms = 30000
-request_deadline_provenance = "harness measurement-censoring safety cap, not a product SLO (OQ2 ruling); the MCP client's own request-timeout default is 300000 ms (300s), recorded here for reference only, see [oq_rulings] above"
+request_deadline_ms = 45000
+request_deadline_provenance = "harness measurement-censoring safety cap, set to strictly exceed the server-side recall deadline (30000 ms per #919) so a timeout is attributable to exactly one deadline (Amendment 1 §2); not a product SLO (OQ2 ruling); the MCP client's own request-timeout default is 300000 ms (300s), recorded here for reference only, see [oq_rulings] above"
 runner_class = "self_hosted_real_embedder"
 
 [[scenario]]
@@ -1034,8 +1091,8 @@ settle = "none"
 attempts = 200
 concurrency = 1
 required_percentiles = ["p50", "p95", "p99"]
-request_deadline_ms = 30000
-request_deadline_provenance = "harness measurement-censoring safety cap, not a product SLO (OQ2 ruling); the MCP client's own request-timeout default is 300000 ms (300s), recorded here for reference only, see [oq_rulings] above"
+request_deadline_ms = 45000
+request_deadline_provenance = "harness measurement-censoring safety cap, set to strictly exceed the server-side recall deadline (30000 ms per #919) so a timeout is attributable to exactly one deadline (Amendment 1 §2); not a product SLO (OQ2 ruling); the MCP client's own request-timeout default is 300000 ms (300s), recorded here for reference only, see [oq_rulings] above"
 runner_class = "hosted_hash"
 
 [[scenario]]
@@ -1052,8 +1109,8 @@ settle = "none"
 attempts = 200
 concurrency = 1
 required_percentiles = ["p50", "p95", "p99"]
-request_deadline_ms = 30000
-request_deadline_provenance = "harness measurement-censoring safety cap, not a product SLO (OQ2 ruling); the MCP client's own request-timeout default is 300000 ms (300s), recorded here for reference only, see [oq_rulings] above"
+request_deadline_ms = 45000
+request_deadline_provenance = "harness measurement-censoring safety cap, set to strictly exceed the server-side recall deadline (30000 ms per #919) so a timeout is attributable to exactly one deadline (Amendment 1 §2); not a product SLO (OQ2 ruling); the MCP client's own request-timeout default is 300000 ms (300s), recorded here for reference only, see [oq_rulings] above"
 runner_class = "hosted_hash"
 
 [[scenario]]
@@ -1070,8 +1127,8 @@ settle = "none"
 attempts = 200
 concurrency = 1
 required_percentiles = ["p50", "p95", "p99"]
-request_deadline_ms = 30000
-request_deadline_provenance = "harness measurement-censoring safety cap, not a product SLO (OQ2 ruling); the MCP client's own request-timeout default is 300000 ms (300s), recorded here for reference only, see [oq_rulings] above"
+request_deadline_ms = 45000
+request_deadline_provenance = "harness measurement-censoring safety cap, set to strictly exceed the server-side recall deadline (30000 ms per #919) so a timeout is attributable to exactly one deadline (Amendment 1 §2); not a product SLO (OQ2 ruling); the MCP client's own request-timeout default is 300000 ms (300s), recorded here for reference only, see [oq_rulings] above"
 runner_class = "self_hosted_real_embedder"
 
 [[scenario]]
@@ -1088,8 +1145,8 @@ settle = "none"
 attempts = 200
 concurrency = 1
 required_percentiles = ["p50", "p95", "p99"]
-request_deadline_ms = 30000
-request_deadline_provenance = "harness measurement-censoring safety cap, not a product SLO (OQ2 ruling); the MCP client's own request-timeout default is 300000 ms (300s), recorded here for reference only, see [oq_rulings] above"
+request_deadline_ms = 45000
+request_deadline_provenance = "harness measurement-censoring safety cap, set to strictly exceed the server-side recall deadline (30000 ms per #919) so a timeout is attributable to exactly one deadline (Amendment 1 §2); not a product SLO (OQ2 ruling); the MCP client's own request-timeout default is 300000 ms (300s), recorded here for reference only, see [oq_rulings] above"
 runner_class = "hosted_hash"
 
 [[scenario]]
@@ -1106,8 +1163,8 @@ settle = "none"
 attempts = 200
 concurrency = 1
 required_percentiles = ["p50", "p95", "p99"]
-request_deadline_ms = 30000
-request_deadline_provenance = "harness measurement-censoring safety cap, not a product SLO (OQ2 ruling); the MCP client's own request-timeout default is 300000 ms (300s), recorded here for reference only, see [oq_rulings] above"
+request_deadline_ms = 45000
+request_deadline_provenance = "harness measurement-censoring safety cap, set to strictly exceed the server-side recall deadline (30000 ms per #919) so a timeout is attributable to exactly one deadline (Amendment 1 §2); not a product SLO (OQ2 ruling); the MCP client's own request-timeout default is 300000 ms (300s), recorded here for reference only, see [oq_rulings] above"
 runner_class = "hosted_hash"
 
 [[scenario]]
@@ -1124,11 +1181,15 @@ settle = "none"
 attempts = 200
 concurrency = 1
 required_percentiles = ["p50", "p95", "p99"]
-request_deadline_ms = 30000
-request_deadline_provenance = "harness measurement-censoring safety cap, not a product SLO (OQ2 ruling); the MCP client's own request-timeout default is 300000 ms (300s), recorded here for reference only, see [oq_rulings] above"
+request_deadline_ms = 45000
+request_deadline_provenance = "harness measurement-censoring safety cap, set to strictly exceed the server-side recall deadline (30000 ms per #919) so a timeout is attributable to exactly one deadline (Amendment 1 §2); not a product SLO (OQ2 ruling); the MCP client's own request-timeout default is 300000 ms (300s), recorded here for reference only, see [oq_rulings] above"
 runner_class = "self_hosted_real_embedder"
 
 [[scenario]]
+# Amendment 1 §2 "Surface rule": F6 git-ingest/code-ingest admin-surface
+# exception (admin CLI is the product surface for it) - admin-surface
+# coverage class, excluded from real-MCP coverage (see
+# oq1_admin_surface_scenario_ids above).
 scenario_id = "f6.git_ingest.cli.production"
 feature = "F6"
 surface = "admin_cli"
@@ -1143,7 +1204,7 @@ attempts = 20
 concurrency = 1
 required_percentiles = ["p50", "p95", "p99"]
 request_deadline_ms = 300000
-request_deadline_provenance = "admin_cli surface: process wall-clock safety cap for a single CLI invocation, not a product SLO (OQ2 ruling); the MCP per-request cap of 30000 ms does not apply to this surface, see [oq_rulings] above"
+request_deadline_provenance = "admin_cli surface: process wall-clock safety cap for a single CLI invocation, not a product SLO (OQ2 ruling); the MCP per-request cap of 45000 ms does not apply to this surface, see [oq_rulings] above"
 runner_class = "self_hosted_real_embedder"
 
 [[scenario]]
@@ -1161,7 +1222,7 @@ attempts = 20
 concurrency = 1
 required_percentiles = ["p50", "p95", "p99"]
 request_deadline_ms = 300000
-request_deadline_provenance = "admin_cli surface: process wall-clock safety cap for a single CLI invocation, not a product SLO (OQ2 ruling); the MCP per-request cap of 30000 ms does not apply to this surface, see [oq_rulings] above"
+request_deadline_provenance = "admin_cli surface: process wall-clock safety cap for a single CLI invocation, not a product SLO (OQ2 ruling); the MCP per-request cap of 45000 ms does not apply to this surface, see [oq_rulings] above"
 runner_class = "self_hosted_real_embedder"
 
 [[scenario]]
@@ -1178,8 +1239,8 @@ settle = "none"
 attempts = 500
 concurrency = 1
 required_percentiles = ["p50", "p95", "p99"]
-request_deadline_ms = 30000
-request_deadline_provenance = "harness measurement-censoring safety cap, not a product SLO (OQ2 ruling); the MCP client's own request-timeout default is 300000 ms (300s), recorded here for reference only, see [oq_rulings] above"
+request_deadline_ms = 45000
+request_deadline_provenance = "harness measurement-censoring safety cap, set to strictly exceed the server-side recall deadline (30000 ms per #919) so a timeout is attributable to exactly one deadline (Amendment 1 §2); not a product SLO (OQ2 ruling); the MCP client's own request-timeout default is 300000 ms (300s), recorded here for reference only, see [oq_rulings] above"
 runner_class = "hosted_hash"
 
 [[scenario]]
@@ -1196,8 +1257,8 @@ settle = "none"
 attempts = 500
 concurrency = 1
 required_percentiles = ["p50", "p95", "p99"]
-request_deadline_ms = 30000
-request_deadline_provenance = "harness measurement-censoring safety cap, not a product SLO (OQ2 ruling); the MCP client's own request-timeout default is 300000 ms (300s), recorded here for reference only, see [oq_rulings] above"
+request_deadline_ms = 45000
+request_deadline_provenance = "harness measurement-censoring safety cap, set to strictly exceed the server-side recall deadline (30000 ms per #919) so a timeout is attributable to exactly one deadline (Amendment 1 §2); not a product SLO (OQ2 ruling); the MCP client's own request-timeout default is 300000 ms (300s), recorded here for reference only, see [oq_rulings] above"
 runner_class = "hosted_hash"
 
 [[scenario]]
@@ -1214,8 +1275,8 @@ settle = "none"
 attempts = 500
 concurrency = 1
 required_percentiles = ["p50", "p95", "p99"]
-request_deadline_ms = 30000
-request_deadline_provenance = "harness measurement-censoring safety cap, not a product SLO (OQ2 ruling); the MCP client's own request-timeout default is 300000 ms (300s), recorded here for reference only, see [oq_rulings] above"
+request_deadline_ms = 45000
+request_deadline_provenance = "harness measurement-censoring safety cap, set to strictly exceed the server-side recall deadline (30000 ms per #919) so a timeout is attributable to exactly one deadline (Amendment 1 §2); not a product SLO (OQ2 ruling); the MCP client's own request-timeout default is 300000 ms (300s), recorded here for reference only, see [oq_rulings] above"
 runner_class = "self_hosted_real_embedder"
 
 [[scenario]]
@@ -1232,8 +1293,8 @@ settle = "none"
 attempts = 500
 concurrency = 32
 required_percentiles = ["p50", "p95", "p99"]
-request_deadline_ms = 30000
-request_deadline_provenance = "harness measurement-censoring safety cap, not a product SLO (OQ2 ruling); the MCP client's own request-timeout default is 300000 ms (300s), recorded here for reference only, see [oq_rulings] above"
+request_deadline_ms = 45000
+request_deadline_provenance = "harness measurement-censoring safety cap, set to strictly exceed the server-side recall deadline (30000 ms per #919) so a timeout is attributable to exactly one deadline (Amendment 1 §2); not a product SLO (OQ2 ruling); the MCP client's own request-timeout default is 300000 ms (300s), recorded here for reference only, see [oq_rulings] above"
 runner_class = "self_hosted_real_embedder"
 
 [[scenario]]
@@ -1250,8 +1311,8 @@ settle = "sequential_sentinel"
 attempts = 1000
 concurrency = 1
 required_percentiles = ["p50", "p95", "p99"]
-request_deadline_ms = 30000
-request_deadline_provenance = "harness measurement-censoring safety cap, not a product SLO (OQ2 ruling); the MCP client's own request-timeout default is 300000 ms (300s), recorded here for reference only, see [oq_rulings] above"
+request_deadline_ms = 45000
+request_deadline_provenance = "harness measurement-censoring safety cap, set to strictly exceed the server-side recall deadline (30000 ms per #919) so a timeout is attributable to exactly one deadline (Amendment 1 §2); not a product SLO (OQ2 ruling); the MCP client's own request-timeout default is 300000 ms (300s), recorded here for reference only, see [oq_rulings] above"
 runner_class = "hosted_hash"
 
 [[scenario]]
@@ -1268,8 +1329,8 @@ settle = "sequential_sentinel"
 attempts = 1000
 concurrency = 1
 required_percentiles = ["p50", "p95", "p99"]
-request_deadline_ms = 30000
-request_deadline_provenance = "harness measurement-censoring safety cap, not a product SLO (OQ2 ruling); the MCP client's own request-timeout default is 300000 ms (300s), recorded here for reference only, see [oq_rulings] above"
+request_deadline_ms = 45000
+request_deadline_provenance = "harness measurement-censoring safety cap, set to strictly exceed the server-side recall deadline (30000 ms per #919) so a timeout is attributable to exactly one deadline (Amendment 1 §2); not a product SLO (OQ2 ruling); the MCP client's own request-timeout default is 300000 ms (300s), recorded here for reference only, see [oq_rulings] above"
 runner_class = "hosted_hash"
 
 [[scenario]]
@@ -1286,8 +1347,8 @@ settle = "sequential_sentinel"
 attempts = 1000
 concurrency = 1
 required_percentiles = ["p50", "p95", "p99"]
-request_deadline_ms = 30000
-request_deadline_provenance = "harness measurement-censoring safety cap, not a product SLO (OQ2 ruling); the MCP client's own request-timeout default is 300000 ms (300s), recorded here for reference only, see [oq_rulings] above"
+request_deadline_ms = 45000
+request_deadline_provenance = "harness measurement-censoring safety cap, set to strictly exceed the server-side recall deadline (30000 ms per #919) so a timeout is attributable to exactly one deadline (Amendment 1 §2); not a product SLO (OQ2 ruling); the MCP client's own request-timeout default is 300000 ms (300s), recorded here for reference only, see [oq_rulings] above"
 runner_class = "self_hosted_real_embedder"
 
 [[scenario]]
@@ -1304,8 +1365,8 @@ settle = "sequential_sentinel"
 attempts = 1000
 concurrency = 1
 required_percentiles = ["p50", "p95", "p99"]
-request_deadline_ms = 30000
-request_deadline_provenance = "harness measurement-censoring safety cap, not a product SLO (OQ2 ruling); the MCP client's own request-timeout default is 300000 ms (300s), recorded here for reference only, see [oq_rulings] above"
+request_deadline_ms = 45000
+request_deadline_provenance = "harness measurement-censoring safety cap, set to strictly exceed the server-side recall deadline (30000 ms per #919) so a timeout is attributable to exactly one deadline (Amendment 1 §2); not a product SLO (OQ2 ruling); the MCP client's own request-timeout default is 300000 ms (300s), recorded here for reference only, see [oq_rulings] above"
 runner_class = "self_hosted_real_embedder"
 
 [[scenario]]
@@ -1322,8 +1383,8 @@ settle = "sequential_sentinel"
 attempts = 1000
 concurrency = 1
 required_percentiles = ["p50", "p95", "p99"]
-request_deadline_ms = 30000
-request_deadline_provenance = "harness measurement-censoring safety cap, not a product SLO (OQ2 ruling); the MCP client's own request-timeout default is 300000 ms (300s), recorded here for reference only, see [oq_rulings] above"
+request_deadline_ms = 45000
+request_deadline_provenance = "harness measurement-censoring safety cap, set to strictly exceed the server-side recall deadline (30000 ms per #919) so a timeout is attributable to exactly one deadline (Amendment 1 §2); not a product SLO (OQ2 ruling); the MCP client's own request-timeout default is 300000 ms (300s), recorded here for reference only, see [oq_rulings] above"
 runner_class = "self_hosted_real_embedder"
 
 [[scenario]]
@@ -1340,8 +1401,8 @@ settle = "sequential_sentinel"
 attempts = 1000
 concurrency = 1
 required_percentiles = ["p50", "p95", "p99"]
-request_deadline_ms = 30000
-request_deadline_provenance = "harness measurement-censoring safety cap, not a product SLO (OQ2 ruling); the MCP client's own request-timeout default is 300000 ms (300s), recorded here for reference only, see [oq_rulings] above"
+request_deadline_ms = 45000
+request_deadline_provenance = "harness measurement-censoring safety cap, set to strictly exceed the server-side recall deadline (30000 ms per #919) so a timeout is attributable to exactly one deadline (Amendment 1 §2); not a product SLO (OQ2 ruling); the MCP client's own request-timeout default is 300000 ms (300s), recorded here for reference only, see [oq_rulings] above"
 runner_class = "self_hosted_real_embedder"
 
 [[scenario]]
@@ -1358,8 +1419,8 @@ settle = "sequential_sentinel"
 attempts = 1000
 concurrency = 1
 required_percentiles = ["p50", "p95", "p99"]
-request_deadline_ms = 30000
-request_deadline_provenance = "harness measurement-censoring safety cap, not a product SLO (OQ2 ruling); the MCP client's own request-timeout default is 300000 ms (300s), recorded here for reference only, see [oq_rulings] above"
+request_deadline_ms = 45000
+request_deadline_provenance = "harness measurement-censoring safety cap, set to strictly exceed the server-side recall deadline (30000 ms per #919) so a timeout is attributable to exactly one deadline (Amendment 1 §2); not a product SLO (OQ2 ruling); the MCP client's own request-timeout default is 300000 ms (300s), recorded here for reference only, see [oq_rulings] above"
 runner_class = "self_hosted_real_embedder"
 
 [[scenario]]
@@ -1376,8 +1437,8 @@ settle = "sequential_sentinel"
 attempts = 1000
 concurrency = 1
 required_percentiles = ["p50", "p95", "p99"]
-request_deadline_ms = 30000
-request_deadline_provenance = "harness measurement-censoring safety cap, not a product SLO (OQ2 ruling); the MCP client's own request-timeout default is 300000 ms (300s), recorded here for reference only, see [oq_rulings] above"
+request_deadline_ms = 45000
+request_deadline_provenance = "harness measurement-censoring safety cap, set to strictly exceed the server-side recall deadline (30000 ms per #919) so a timeout is attributable to exactly one deadline (Amendment 1 §2); not a product SLO (OQ2 ruling); the MCP client's own request-timeout default is 300000 ms (300s), recorded here for reference only, see [oq_rulings] above"
 runner_class = "self_hosted_real_embedder"
 
 [[scenario]]
@@ -1394,8 +1455,8 @@ settle = "none"
 attempts = 500
 concurrency = 1
 required_percentiles = ["p50", "p95", "p99"]
-request_deadline_ms = 30000
-request_deadline_provenance = "harness measurement-censoring safety cap, not a product SLO (OQ2 ruling); the MCP client's own request-timeout default is 300000 ms (300s), recorded here for reference only, see [oq_rulings] above"
+request_deadline_ms = 45000
+request_deadline_provenance = "harness measurement-censoring safety cap, set to strictly exceed the server-side recall deadline (30000 ms per #919) so a timeout is attributable to exactly one deadline (Amendment 1 §2); not a product SLO (OQ2 ruling); the MCP client's own request-timeout default is 300000 ms (300s), recorded here for reference only, see [oq_rulings] above"
 runner_class = "hosted_hash"
 
 [[scenario]]
@@ -1412,8 +1473,8 @@ settle = "none"
 attempts = 500
 concurrency = 1
 required_percentiles = ["p50", "p95", "p99"]
-request_deadline_ms = 30000
-request_deadline_provenance = "harness measurement-censoring safety cap, not a product SLO (OQ2 ruling); the MCP client's own request-timeout default is 300000 ms (300s), recorded here for reference only, see [oq_rulings] above"
+request_deadline_ms = 45000
+request_deadline_provenance = "harness measurement-censoring safety cap, set to strictly exceed the server-side recall deadline (30000 ms per #919) so a timeout is attributable to exactly one deadline (Amendment 1 §2); not a product SLO (OQ2 ruling); the MCP client's own request-timeout default is 300000 ms (300s), recorded here for reference only, see [oq_rulings] above"
 runner_class = "hosted_hash"
 
 [[scenario]]
@@ -1430,8 +1491,8 @@ settle = "none"
 attempts = 500
 concurrency = 1
 required_percentiles = ["p50", "p95", "p99"]
-request_deadline_ms = 30000
-request_deadline_provenance = "harness measurement-censoring safety cap, not a product SLO (OQ2 ruling); the MCP client's own request-timeout default is 300000 ms (300s), recorded here for reference only, see [oq_rulings] above"
+request_deadline_ms = 45000
+request_deadline_provenance = "harness measurement-censoring safety cap, set to strictly exceed the server-side recall deadline (30000 ms per #919) so a timeout is attributable to exactly one deadline (Amendment 1 §2); not a product SLO (OQ2 ruling); the MCP client's own request-timeout default is 300000 ms (300s), recorded here for reference only, see [oq_rulings] above"
 runner_class = "hosted_hash"
 
 [[scenario]]
@@ -1448,8 +1509,8 @@ settle = "none"
 attempts = 500
 concurrency = 1
 required_percentiles = ["p50", "p95", "p99"]
-request_deadline_ms = 30000
-request_deadline_provenance = "harness measurement-censoring safety cap, not a product SLO (OQ2 ruling); the MCP client's own request-timeout default is 300000 ms (300s), recorded here for reference only, see [oq_rulings] above"
+request_deadline_ms = 45000
+request_deadline_provenance = "harness measurement-censoring safety cap, set to strictly exceed the server-side recall deadline (30000 ms per #919) so a timeout is attributable to exactly one deadline (Amendment 1 §2); not a product SLO (OQ2 ruling); the MCP client's own request-timeout default is 300000 ms (300s), recorded here for reference only, see [oq_rulings] above"
 runner_class = "hosted_hash"
 
 [[scenario]]
@@ -1466,8 +1527,8 @@ settle = "none"
 attempts = 500
 concurrency = 1
 required_percentiles = ["p50", "p95", "p99"]
-request_deadline_ms = 30000
-request_deadline_provenance = "harness measurement-censoring safety cap, not a product SLO (OQ2 ruling); the MCP client's own request-timeout default is 300000 ms (300s), recorded here for reference only, see [oq_rulings] above"
+request_deadline_ms = 45000
+request_deadline_provenance = "harness measurement-censoring safety cap, set to strictly exceed the server-side recall deadline (30000 ms per #919) so a timeout is attributable to exactly one deadline (Amendment 1 §2); not a product SLO (OQ2 ruling); the MCP client's own request-timeout default is 300000 ms (300s), recorded here for reference only, see [oq_rulings] above"
 runner_class = "self_hosted_real_embedder"
 
 [[scenario]]
@@ -1484,11 +1545,15 @@ settle = "none"
 attempts = 500
 concurrency = 16
 required_percentiles = ["p50", "p95", "p99"]
-request_deadline_ms = 30000
-request_deadline_provenance = "harness measurement-censoring safety cap, not a product SLO (OQ2 ruling); the MCP client's own request-timeout default is 300000 ms (300s), recorded here for reference only, see [oq_rulings] above"
+request_deadline_ms = 45000
+request_deadline_provenance = "harness measurement-censoring safety cap, set to strictly exceed the server-side recall deadline (30000 ms per #919) so a timeout is attributable to exactly one deadline (Amendment 1 §2); not a product SLO (OQ2 ruling); the MCP client's own request-timeout default is 300000 ms (300s), recorded here for reference only, see [oq_rulings] above"
 runner_class = "self_hosted_real_embedder"
 
 [[scenario]]
+# Amendment 1 §2 "Surface rule": this is "the F10 daemon-control probe"
+# named exception - admin-surface coverage class, excluded from real-MCP
+# coverage (see oq1_admin_surface_scenario_ids above). surface =
+# "raw_daemon_control" (not "mcp_daemon") reflects that classification.
 scenario_id = "f10.daemon.probe_only.floor"
 feature = "F10"
 surface = "raw_daemon_control"
@@ -1502,8 +1567,8 @@ settle = "none"
 attempts = 1000
 concurrency = 1
 required_percentiles = ["p50", "p95", "p99"]
-request_deadline_ms = 30000
-request_deadline_provenance = "harness measurement-censoring safety cap, not a product SLO (OQ2 ruling); the MCP client's own request-timeout default is 300000 ms (300s), recorded here for reference only, see [oq_rulings] above"
+request_deadline_ms = 45000
+request_deadline_provenance = "harness measurement-censoring safety cap, set to strictly exceed the server-side recall deadline (30000 ms per #919) so a timeout is attributable to exactly one deadline (Amendment 1 §2); not a product SLO (OQ2 ruling); the MCP client's own request-timeout default is 300000 ms (300s), recorded here for reference only, see [oq_rulings] above"
 runner_class = "hosted_hash"
 
 [[scenario]]
@@ -1520,8 +1585,8 @@ settle = "none"
 attempts = 1000
 concurrency = 1
 required_percentiles = ["p50", "p95", "p99"]
-request_deadline_ms = 30000
-request_deadline_provenance = "harness measurement-censoring safety cap, not a product SLO (OQ2 ruling); the MCP client's own request-timeout default is 300000 ms (300s), recorded here for reference only, see [oq_rulings] above"
+request_deadline_ms = 45000
+request_deadline_provenance = "harness measurement-censoring safety cap, set to strictly exceed the server-side recall deadline (30000 ms per #919) so a timeout is attributable to exactly one deadline (Amendment 1 §2); not a product SLO (OQ2 ruling); the MCP client's own request-timeout default is 300000 ms (300s), recorded here for reference only, see [oq_rulings] above"
 runner_class = "hosted_hash"
 
 [[scenario]]
@@ -1538,8 +1603,8 @@ settle = "none"
 attempts = 1000
 concurrency = 1
 required_percentiles = ["p50", "p95", "p99"]
-request_deadline_ms = 30000
-request_deadline_provenance = "harness measurement-censoring safety cap, not a product SLO (OQ2 ruling); the MCP client's own request-timeout default is 300000 ms (300s), recorded here for reference only, see [oq_rulings] above"
+request_deadline_ms = 45000
+request_deadline_provenance = "harness measurement-censoring safety cap, set to strictly exceed the server-side recall deadline (30000 ms per #919) so a timeout is attributable to exactly one deadline (Amendment 1 §2); not a product SLO (OQ2 ruling); the MCP client's own request-timeout default is 300000 ms (300s), recorded here for reference only, see [oq_rulings] above"
 runner_class = "hosted_hash"
 
 [[scenario]]
@@ -1556,8 +1621,8 @@ settle = "none"
 attempts = 1000
 concurrency = 1
 required_percentiles = ["p50", "p95", "p99"]
-request_deadline_ms = 30000
-request_deadline_provenance = "harness measurement-censoring safety cap, not a product SLO (OQ2 ruling); the MCP client's own request-timeout default is 300000 ms (300s), recorded here for reference only, see [oq_rulings] above"
+request_deadline_ms = 45000
+request_deadline_provenance = "harness measurement-censoring safety cap, set to strictly exceed the server-side recall deadline (30000 ms per #919) so a timeout is attributable to exactly one deadline (Amendment 1 §2); not a product SLO (OQ2 ruling); the MCP client's own request-timeout default is 300000 ms (300s), recorded here for reference only, see [oq_rulings] above"
 runner_class = "hosted_hash"
 
 [[scenario]]
@@ -1574,8 +1639,8 @@ settle = "none"
 attempts = 1000
 concurrency = 2
 required_percentiles = ["p50", "p95", "p99"]
-request_deadline_ms = 30000
-request_deadline_provenance = "harness measurement-censoring safety cap, not a product SLO (OQ2 ruling); the MCP client's own request-timeout default is 300000 ms (300s), recorded here for reference only, see [oq_rulings] above"
+request_deadline_ms = 45000
+request_deadline_provenance = "harness measurement-censoring safety cap, set to strictly exceed the server-side recall deadline (30000 ms per #919) so a timeout is attributable to exactly one deadline (Amendment 1 §2); not a product SLO (OQ2 ruling); the MCP client's own request-timeout default is 300000 ms (300s), recorded here for reference only, see [oq_rulings] above"
 runner_class = "hosted_hash"
 
 [[scenario]]
@@ -1592,8 +1657,8 @@ settle = "none"
 attempts = 1000
 concurrency = 4
 required_percentiles = ["p50", "p95", "p99"]
-request_deadline_ms = 30000
-request_deadline_provenance = "harness measurement-censoring safety cap, not a product SLO (OQ2 ruling); the MCP client's own request-timeout default is 300000 ms (300s), recorded here for reference only, see [oq_rulings] above"
+request_deadline_ms = 45000
+request_deadline_provenance = "harness measurement-censoring safety cap, set to strictly exceed the server-side recall deadline (30000 ms per #919) so a timeout is attributable to exactly one deadline (Amendment 1 §2); not a product SLO (OQ2 ruling); the MCP client's own request-timeout default is 300000 ms (300s), recorded here for reference only, see [oq_rulings] above"
 runner_class = "hosted_hash"
 
 [[scenario]]
@@ -1610,8 +1675,8 @@ settle = "none"
 attempts = 1000
 concurrency = 8
 required_percentiles = ["p50", "p95", "p99"]
-request_deadline_ms = 30000
-request_deadline_provenance = "harness measurement-censoring safety cap, not a product SLO (OQ2 ruling); the MCP client's own request-timeout default is 300000 ms (300s), recorded here for reference only, see [oq_rulings] above"
+request_deadline_ms = 45000
+request_deadline_provenance = "harness measurement-censoring safety cap, set to strictly exceed the server-side recall deadline (30000 ms per #919) so a timeout is attributable to exactly one deadline (Amendment 1 §2); not a product SLO (OQ2 ruling); the MCP client's own request-timeout default is 300000 ms (300s), recorded here for reference only, see [oq_rulings] above"
 runner_class = "hosted_hash"
 
 [[scenario]]
@@ -1628,8 +1693,8 @@ settle = "none"
 attempts = 1000
 concurrency = 16
 required_percentiles = ["p50", "p95", "p99"]
-request_deadline_ms = 30000
-request_deadline_provenance = "harness measurement-censoring safety cap, not a product SLO (OQ2 ruling); the MCP client's own request-timeout default is 300000 ms (300s), recorded here for reference only, see [oq_rulings] above"
+request_deadline_ms = 45000
+request_deadline_provenance = "harness measurement-censoring safety cap, set to strictly exceed the server-side recall deadline (30000 ms per #919) so a timeout is attributable to exactly one deadline (Amendment 1 §2); not a product SLO (OQ2 ruling); the MCP client's own request-timeout default is 300000 ms (300s), recorded here for reference only, see [oq_rulings] above"
 runner_class = "hosted_hash"
 
 [[scenario]]
@@ -1646,8 +1711,8 @@ settle = "none"
 attempts = 1000
 concurrency = 32
 required_percentiles = ["p50", "p95", "p99"]
-request_deadline_ms = 30000
-request_deadline_provenance = "harness measurement-censoring safety cap, not a product SLO (OQ2 ruling); the MCP client's own request-timeout default is 300000 ms (300s), recorded here for reference only, see [oq_rulings] above"
+request_deadline_ms = 45000
+request_deadline_provenance = "harness measurement-censoring safety cap, set to strictly exceed the server-side recall deadline (30000 ms per #919) so a timeout is attributable to exactly one deadline (Amendment 1 §2); not a product SLO (OQ2 ruling); the MCP client's own request-timeout default is 300000 ms (300s), recorded here for reference only, see [oq_rulings] above"
 runner_class = "self_hosted_real_embedder"
 
 [[scenario]]
@@ -1664,8 +1729,8 @@ settle = "none"
 attempts = 1000
 concurrency = 64
 required_percentiles = ["p50", "p95", "p99"]
-request_deadline_ms = 30000
-request_deadline_provenance = "harness measurement-censoring safety cap, not a product SLO (OQ2 ruling); the MCP client's own request-timeout default is 300000 ms (300s), recorded here for reference only, see [oq_rulings] above"
+request_deadline_ms = 45000
+request_deadline_provenance = "harness measurement-censoring safety cap, set to strictly exceed the server-side recall deadline (30000 ms per #919) so a timeout is attributable to exactly one deadline (Amendment 1 §2); not a product SLO (OQ2 ruling); the MCP client's own request-timeout default is 300000 ms (300s), recorded here for reference only, see [oq_rulings] above"
 runner_class = "self_hosted_real_embedder"
 
 [[scenario]]
@@ -1682,6 +1747,6 @@ settle = "none"
 attempts = 1000
 concurrency = 128
 required_percentiles = ["p50", "p95", "p99"]
-request_deadline_ms = 30000
-request_deadline_provenance = "harness measurement-censoring safety cap, not a product SLO (OQ2 ruling); the MCP client's own request-timeout default is 300000 ms (300s), recorded here for reference only, see [oq_rulings] above"
+request_deadline_ms = 45000
+request_deadline_provenance = "harness measurement-censoring safety cap, set to strictly exceed the server-side recall deadline (30000 ms per #919) so a timeout is attributable to exactly one deadline (Amendment 1 §2); not a product SLO (OQ2 ruling); the MCP client's own request-timeout default is 300000 ms (300s), recorded here for reference only, see [oq_rulings] above"
 runner_class = "self_hosted_real_embedder"

--- a/scripts/perf/flagship_workloads.toml
+++ b/scripts/perf/flagship_workloads.toml
@@ -1589,14 +1589,66 @@ request_deadline_ms = 45000
 request_deadline_provenance = "harness measurement-censoring safety cap, set to strictly exceed the server-side recall deadline (30000 ms per #919) so a timeout is attributable to exactly one deadline (Amendment 1 §2); not a product SLO (OQ2 ruling); the MCP client's own request-timeout default is 300000 ms (300s), recorded here for reference only, see [oq_rulings] above"
 runner_class = "hosted_hash"
 
+# Amendment 1 §4 "Scenario executability": the former
+# "f10.daemon.payload_size_curve.mcp" scenario is REMOVED. Its independent
+# variable (payload_bytes_max, declared up to 65536 bytes against an 8 MiB
+# daemon frame cap) was not generatable through its declared surface -
+# public `stats` has no payload-size control at all, so the scenario could
+# never actually vary the thing it claimed to measure. §4 replaces it with
+# two scenarios on genuinely payload-varying surfaces:
+#   1. Response-size sensitivity: the "f10.list.limit_sweep.*.mcp" cohort
+#      family below sweeps `list`'s `limit` param through a fixed 50k-entity
+#      corpus (reusing the read-only "kg_search_relevance_entity" fixture
+#      from F2, legal per §6 fixture-reuse-for-read-only), which does
+#      genuinely change response payload size end to end.
+#   2. The daemon frame cap itself: probed only in the admin-surface class
+#      by "f10.daemon.probe_only.floor" above (already the named §2
+#      admin-surface exception for the F10 daemon-control probe - no
+#      second scenario is added here).
 [[scenario]]
-scenario_id = "f10.daemon.payload_size_curve.mcp"
+scenario_id = "f10.list.limit_sweep.small.mcp"
 feature = "F10"
 surface = "mcp_daemon"
-operation = "stats"
-fixture = "daemon_idle_payload_curve"
-fixture_hash = "sha256:2d5fae7aeda7dacf9a63e51150b5862e2078617e02b44adc6d076ac35edcfa6a"
-scale = { payload_bytes_max = 65536 }
+operation = "list"
+fixture = "kg_search_relevance_entity"
+fixture_hash = "sha256:2cd9c5a27aead8d701a9f000447e9529a4f2ef038d4966071d6f28dcd39a0eda"
+scale = { entities = 50000, limit = 10 }
+embedder = "none"
+state = "warm"
+settle = "none"
+attempts = 1000
+concurrency = 1
+required_percentiles = ["p50", "p95", "p99"]
+request_deadline_ms = 45000
+request_deadline_provenance = "harness measurement-censoring safety cap, set to strictly exceed the server-side recall deadline (30000 ms per #919) so a timeout is attributable to exactly one deadline (Amendment 1 §2); not a product SLO (OQ2 ruling); the MCP client's own request-timeout default is 300000 ms (300s), recorded here for reference only, see [oq_rulings] above"
+runner_class = "hosted_hash"
+
+[[scenario]]
+scenario_id = "f10.list.limit_sweep.medium.mcp"
+feature = "F10"
+surface = "mcp_daemon"
+operation = "list"
+fixture = "kg_search_relevance_entity"
+fixture_hash = "sha256:2cd9c5a27aead8d701a9f000447e9529a4f2ef038d4966071d6f28dcd39a0eda"
+scale = { entities = 50000, limit = 100 }
+embedder = "none"
+state = "warm"
+settle = "none"
+attempts = 1000
+concurrency = 1
+required_percentiles = ["p50", "p95", "p99"]
+request_deadline_ms = 45000
+request_deadline_provenance = "harness measurement-censoring safety cap, set to strictly exceed the server-side recall deadline (30000 ms per #919) so a timeout is attributable to exactly one deadline (Amendment 1 §2); not a product SLO (OQ2 ruling); the MCP client's own request-timeout default is 300000 ms (300s), recorded here for reference only, see [oq_rulings] above"
+runner_class = "hosted_hash"
+
+[[scenario]]
+scenario_id = "f10.list.limit_sweep.large.mcp"
+feature = "F10"
+surface = "mcp_daemon"
+operation = "list"
+fixture = "kg_search_relevance_entity"
+fixture_hash = "sha256:2cd9c5a27aead8d701a9f000447e9529a4f2ef038d4966071d6f28dcd39a0eda"
+scale = { entities = 50000, limit = 1000 }
 embedder = "none"
 state = "warm"
 settle = "none"

--- a/scripts/perf/test_flagship_coverage.py
+++ b/scripts/perf/test_flagship_coverage.py
@@ -157,6 +157,40 @@ class ManifestTests(unittest.TestCase):
         self.assertEqual(scale_by_id.get("f1.recall.warm.real.n500k", {}).get("memories"), 500000)
         self.assertEqual(scale_by_id.get("f4.traverse.powerlaw.n500000.depth3.real", {}).get("nodes"), 500000)
 
+    def test_f10_payload_size_curve_scenario_is_absent(self):
+        """khive#950 Amendment 1 §4 "Scenario executability": the F10 `stats`
+        payload curve is inadmissible - public `stats` has no payload-size
+        control (declared max 64 KiB vs the 8 MiB daemon frame cap) - and is
+        removed, never re-added under this or any other scenario_id."""
+        data, _ = coverage_validator.load_manifest(MANIFEST_PATH)
+        ids = {sc["scenario_id"] for sc in data["scenario"]}
+        self.assertNotIn("f10.daemon.payload_size_curve.mcp", ids)
+        for scenario_id in ids:
+            self.assertNotIn("payload_size_curve", scenario_id)
+
+    def test_f10_response_size_sensitivity_replacement_present(self):
+        """khive#950 Amendment 1 §4: response-size sensitivity is instead
+        measured through a surface that genuinely varies payload (`list`/
+        `traverse` with limit sweeps) - a real-MCP `list` limit-sweep cohort
+        family replaces the removed `stats` payload curve."""
+        data, _ = coverage_validator.load_manifest(MANIFEST_PATH)
+        by_id = {sc["scenario_id"]: sc for sc in data["scenario"]}
+        limit_sweep_ids = {
+            "f10.list.limit_sweep.small.mcp",
+            "f10.list.limit_sweep.medium.mcp",
+            "f10.list.limit_sweep.large.mcp",
+        }
+        limits = []
+        for scenario_id in limit_sweep_ids:
+            self.assertIn(scenario_id, by_id, f"{scenario_id} missing - §4 replacement not wired")
+            sc = by_id[scenario_id]
+            self.assertEqual(sc["feature"], "F10")
+            self.assertEqual(sc["surface"], "mcp_daemon")
+            self.assertEqual(sc["operation"], "list")
+            self.assertGreaterEqual(sc["request_deadline_ms"], 45000)
+            limits.append(sc["scale"]["limit"])
+        self.assertEqual(len(set(limits)), 3, "limit sweep must vary the limit param across cohorts")
+
     def test_every_timed_scenario_client_censor_exceeds_server_deadline(self):
         """Amendment 1 §2 "Deadline classifiability": client-side censor
         must strictly exceed the 30000 ms server-side recall deadline

--- a/scripts/perf/test_flagship_coverage.py
+++ b/scripts/perf/test_flagship_coverage.py
@@ -197,14 +197,17 @@ class ManifestTests(unittest.TestCase):
         (#919) so a timeout is attributable to exactly one deadline."""
         data, _ = coverage_validator.load_manifest(MANIFEST_PATH)
         server_deadline_ms = data["oq_rulings"]["oq2_server_recall_deadline_ms"]
+        censor_floor_ms = data["oq_rulings"]["oq2_measurement_deadline_ms"]
+        self.assertEqual(censor_floor_ms, 45000)
+        self.assertGreater(censor_floor_ms, server_deadline_ms)
         for sc in data["scenario"]:
             if sc["surface"] == "admin_cli":
                 continue
-            self.assertGreater(
+            self.assertGreaterEqual(
                 sc["request_deadline_ms"],
-                server_deadline_ms,
-                f"{sc['scenario_id']}: request_deadline_ms {sc['request_deadline_ms']} must strictly exceed "
-                f"the {server_deadline_ms} ms server-side recall deadline",
+                censor_floor_ms,
+                f"{sc['scenario_id']}: request_deadline_ms {sc['request_deadline_ms']} must meet "
+                f"the {censor_floor_ms} ms client-censor floor (Amendment 1 section 2)",
             )
 
     def _write_manifest(self, tmp: pathlib.Path, scenarios: list[dict]) -> pathlib.Path:

--- a/scripts/perf/test_flagship_coverage.py
+++ b/scripts/perf/test_flagship_coverage.py
@@ -121,10 +121,57 @@ class ManifestTests(unittest.TestCase):
     def test_oq_rulings_present(self):
         data, _ = coverage_validator.load_manifest(MANIFEST_PATH)
         rulings = data["oq_rulings"]
-        self.assertEqual(rulings["oq2_measurement_deadline_ms"], 30000)
+        # khive#946 Amendment 1 §2: client censor must strictly exceed the
+        # 30000 ms server-side recall deadline (#919), so the harness cap is
+        # 45000 ms, not 30000 ms.
+        self.assertEqual(rulings["oq2_measurement_deadline_ms"], 45000)
+        self.assertEqual(rulings["oq2_server_recall_deadline_ms"], 30000)
         self.assertEqual(rulings["oq2_mcp_client_default_timeout_ms"], 300000)
         self.assertEqual(rulings["oq7_freshness_days_self_hosted"], 14)
         self.assertEqual(rulings["oq7_freshness_days_hosted"], 7)
+
+    def test_oq1_admin_surface_scenario_ids_match_manifest(self):
+        """khive#946 Amendment 1 §2: exactly two admin-surface exceptions are
+        named and bounded (F6 git-ingest/code-ingest, F10 daemon-control
+        probe) - every other scenario is real-MCP coverage by default."""
+        data, _ = coverage_validator.load_manifest(MANIFEST_PATH)
+        rulings = data["oq_rulings"]
+        admin_surface_ids = set(rulings["oq1_admin_surface_scenario_ids"])
+        self.assertEqual(
+            admin_surface_ids,
+            {"f6.git_ingest.cli.production", "f6.code_ingest.cli.production", "f10.daemon.probe_only.floor"},
+        )
+        by_id = {sc["scenario_id"]: sc for sc in data["scenario"]}
+        for scenario_id in admin_surface_ids:
+            self.assertIn(scenario_id, by_id)
+            self.assertIn(by_id[scenario_id]["surface"], ("admin_cli", "raw_daemon_control"))
+        for scenario_id, sc in by_id.items():
+            if scenario_id not in admin_surface_ids:
+                self.assertEqual(sc["surface"], "mcp_daemon", f"{scenario_id} is not in the admin-surface exception list but is not mcp_daemon either")
+
+    def test_f1_and_f4_have_500k_cohort(self):
+        """Amendment 1 §7: F1 and F4 scenario sets gain a 500K cohort before
+        any "exact cohort" claim is made."""
+        data, _ = coverage_validator.load_manifest(MANIFEST_PATH)
+        scale_by_id = {sc["scenario_id"]: sc["scale"] for sc in data["scenario"]}
+        self.assertEqual(scale_by_id.get("f1.recall.warm.real.n500k", {}).get("memories"), 500000)
+        self.assertEqual(scale_by_id.get("f4.traverse.powerlaw.n500000.depth3.real", {}).get("nodes"), 500000)
+
+    def test_every_timed_scenario_client_censor_exceeds_server_deadline(self):
+        """Amendment 1 §2 "Deadline classifiability": client-side censor
+        must strictly exceed the 30000 ms server-side recall deadline
+        (#919) so a timeout is attributable to exactly one deadline."""
+        data, _ = coverage_validator.load_manifest(MANIFEST_PATH)
+        server_deadline_ms = data["oq_rulings"]["oq2_server_recall_deadline_ms"]
+        for sc in data["scenario"]:
+            if sc["surface"] == "admin_cli":
+                continue
+            self.assertGreater(
+                sc["request_deadline_ms"],
+                server_deadline_ms,
+                f"{sc['scenario_id']}: request_deadline_ms {sc['request_deadline_ms']} must strictly exceed "
+                f"the {server_deadline_ms} ms server-side recall deadline",
+            )
 
     def _write_manifest(self, tmp: pathlib.Path, scenarios: list[dict]) -> pathlib.Path:
         lines = []


### PR DESCRIPTION
## Summary

Implements the flagship manifest correction mandated by the signed Benchmark Program SPEC Amendment 1 §10 item 4:
`.khive/workspaces/20260710/bench-program/AMENDMENT-1-flagship-measurement-contract.md`

Five corrections, each verified against the amendment text:

1. **500K cohorts (§7)** — added `f1.recall.warm.real.n500k` (`scale.memories = 500000`) and `f4.traverse.powerlaw.n500000.depth3.real` (`scale.nodes = 500000`), the exact cohorts the amendment names as missing ("F1 and F4 scenario sets gain a 500K cohort before any 'exact cohort' claim is made"). No other cohorts were invented.

2. **Client-side censor ≥ 45s (§2 "Deadline classifiability")** — bumped every timed, non-`admin_cli` scenario's `request_deadline_ms` from `30000` to `45000` (92 scenarios), and `oq_rulings.oq2_measurement_deadline_ms` to match, so the harness measurement-censoring cap strictly exceeds the 30000 ms server-side recall deadline (#919) instead of racing it 30s/30s. The two `admin_cli` process-wall-clock scenarios (`f6.git_ingest.cli.production`, `f6.code_ingest.cli.production`) already had `request_deadline_ms = 300000` and are unaffected — added `oq_rulings.oq2_server_recall_deadline_ms = 30000` to make the two deadlines an explicit, checkable pair.

3. **OQ1 resolved (§2 "Surface rule")** — replaced the manifest's silent `admin_cli` "approved" marker (which only covered git-ingest/code-ingest) with the amendment's explicit, exhaustive two-exception surface ruling. `oq1_admin_ingest_surface` now cites Amendment 1 §2 by name; added `oq1_admin_surface_scenario_ids` as the exhaustive list.

4. **F10 removed from real-MCP coverage (§2 "Surface rule")** — documented `f10.daemon.probe_only.floor` (the named "F10 daemon-control probe") as a bounded admin-surface exception alongside F6 git-ingest/code-ingest, reported in a separate admin-surface coverage class and never counted toward real-MCP percentage. Its `surface = "raw_daemon_control"` was already correctly distinct from `mcp_daemon`; the ruling documenting that exclusion is now explicit in `oq_rulings.oq1_admin_surface_scenario_ids` plus an inline comment at its declaration site. Scoped narrowly to the probe scenario per the amendment's precise wording — the separate §4 "F10 payload curve removed" executability item is handled in correction 5 below.

5. **F10 payload curve removed / §4 replacement wired (§4 "Scenario executability")** — removed `f10.daemon.payload_size_curve.mcp`: its independent variable (`scale.payload_bytes_max`, declared up to 65536 bytes vs the 8 MiB daemon frame cap) was never generatable through its declared surface — public `stats` has no payload-size control at all. Checked the manifest for an existing `list`/`traverse` limit-sweep that genuinely varies response payload; none existed (`traverse` only varies node count/depth, no scenario used a `limit` param), so added a minimal real-MCP replacement cohort family: `f10.list.limit_sweep.{small,medium,large}.mcp` (`operation = "list"`, `surface = "mcp_daemon"`, `scale.limit` = 10/100/1000), reusing the existing read-only `kg_search_relevance_entity` fixture from F2 (legal fixture reuse per §6). The daemon frame cap itself continues to be probed only in the admin-surface class by the existing `f10.daemon.probe_only.floor` scenario — already the named §2 admin-surface exception, so no second admin-surface probe was added. An inline comment at the F10 section marks both replacement scenarios and their §4 provenance.

Test fixtures (`test_flagship_coverage.py`) updated to match: the `oq_rulings` deadline assertion now expects 45000/30000, plus five new regression tests covering the 500K cohorts, the admin-surface exception list, the 45s-over-30s censor invariant across every timed scenario, the removed payload-curve scenario's absence (by id and by substring, so it can't silently reappear under a new id), and the §4 replacement cohort family's presence/shape.

No Rust code touched. The amendment file itself was not modified.

## Test plan

- [x] `uv run python -m pytest scripts/perf/test_flagship_coverage.py scripts/perf/test_mcp_bench_client.py -q` — **130 passed**
- [x] Focused `coverage_validator.load_manifest()` run over the edited manifest — **96 scenarios, 0 structural errors**
- [x] `coverage_validator.py --strict` CLI run — exit 0, 0% measured (expected with no records dir, by design)
- [x] Focused clean-load proof confirming `f10.daemon.payload_size_curve.mcp` absent and all three `f10.list.limit_sweep.*.mcp` present

🤖 Generated with [Claude Code](https://claude.com/claude-code)
