### PR TITLE
feat(daemon): request correlation id across daemon frames and audit events (#948)

### DIFF
--- a/crates/khive-mcp/src/coordinator.rs
+++ b/crates/khive-mcp/src/coordinator.rs
@@ -307,6 +307,7 @@ pub(crate) mod tests {
                 save_to: None,
                 format: None,
                 format_per_op: None,
+                request_id: None,
             })
             .await;
 
@@ -336,6 +337,7 @@ pub(crate) mod tests {
                 save_to: None,
                 format: None,
                 format_per_op: None,
+                request_id: None,
             })
             .await;
 
@@ -374,6 +376,7 @@ pub(crate) mod tests {
                 save_to: None,
                 format: None,
                 format_per_op: None,
+                request_id: None,
             })
             .await
             .expect("T6d: dispatch must not return an MCP-level error");
@@ -437,6 +440,7 @@ pub(crate) mod tests {
                     save_to: None,
                     format: None,
                     format_per_op: None,
+                    request_id: None,
                 })
                 .await
                 .unwrap_or_else(|e| panic!("T6e case {label}: dispatch must not MCP-error: {e}"));
@@ -500,6 +504,7 @@ pub(crate) mod tests {
                     save_to: None,
                     format: None,
                     format_per_op: None,
+                    request_id: None,
                 })
                 .await
                 .unwrap_or_else(|e| panic!("T6f case {label}: dispatch must not MCP-error: {e}"));
@@ -557,6 +562,7 @@ pub(crate) mod tests {
                 save_to: None,
                 format: None,
                 format_per_op: None,
+                request_id: None,
             })
             .await;
 
@@ -595,6 +601,7 @@ pub(crate) mod tests {
                 save_to: None,
                 format: None,
                 format_per_op: None,
+                request_id: None,
             })
             .await
             .expect("T6e: dispatch must not return an MCP-level error");
@@ -643,6 +650,7 @@ pub(crate) mod tests {
                 save_to: None,
                 format: None,
                 format_per_op: None,
+                request_id: None,
             })
             .await
             .expect("T6e: dispatch must not return an MCP-level error");

--- a/crates/khive-mcp/src/daemon.rs
+++ b/crates/khive-mcp/src/daemon.rs
@@ -424,6 +424,7 @@ impl daemon::DaemonDispatch for crate::server::KhiveMcpServer {
             save_to: None,
             format,
             format_per_op,
+            request_id: None,
         };
         // Honor the frame's origin: a wire-origin request enforces verb
         // visibility even when served by the daemon; an operator request does not.
@@ -914,6 +915,7 @@ async fn probe_daemon_identity(config_id: &str, namespace: &str, timeout_ms: u64
         format: None,
         format_per_op: None,
         from_wire: false,
+        request_id: None,
     };
     let deadline = std::time::Duration::from_millis(timeout_ms);
     match tokio::time::timeout(deadline, try_forward_inner(&probe)).await {
@@ -2017,6 +2019,7 @@ mod tests {
             version_mismatch: false,
             daemon_protocol_version: PROTOCOL_VERSION,
             metrics: None,
+            request_id: None,
         }
     }
 
@@ -2031,6 +2034,7 @@ mod tests {
             version_mismatch: false,
             daemon_protocol_version: PROTOCOL_VERSION,
             metrics: None,
+            request_id: None,
         }
     }
 
@@ -2053,6 +2057,7 @@ mod tests {
             version_mismatch: false,
             daemon_protocol_version: PROTOCOL_VERSION,
             metrics: None,
+            request_id: None,
         };
         assert!(map_response(resp, CFG, NS).is_none());
         assert_eq!(fallback_count(FallbackReason::NamespaceMismatch), 1);
@@ -2074,6 +2079,7 @@ mod tests {
             version_mismatch: false,
             daemon_protocol_version: PROTOCOL_VERSION,
             metrics: None,
+            request_id: None,
         };
         assert!(map_response(resp, CFG, NS).is_none());
         assert_eq!(fallback_count(FallbackReason::ConfigMismatch), 1);
@@ -2097,6 +2103,7 @@ mod tests {
             version_mismatch: false,
             daemon_protocol_version: 0,
             metrics: None,
+            request_id: None,
         };
         assert!(map_response(resp, CFG, NS).is_none());
         // The served_config_id-echo path is bucketed under config_mismatch —
@@ -2124,6 +2131,7 @@ mod tests {
             version_mismatch: false,
             daemon_protocol_version: PROTOCOL_VERSION,
             metrics: None,
+            request_id: None,
         };
         assert!(map_response(resp, CFG, NS).is_none());
         assert_eq!(fallback_count(FallbackReason::ConfigMismatch), 1);
@@ -2150,6 +2158,7 @@ mod tests {
             version_mismatch: false,
             daemon_protocol_version: PROTOCOL_VERSION,
             metrics: None,
+            request_id: None,
         };
         match map_response(resp, CFG, NS) {
             Some(Ok(s)) => assert_eq!(s, ""),
@@ -2193,6 +2202,7 @@ mod tests {
             version_mismatch: true,
             daemon_protocol_version: PROTOCOL_VERSION,
             metrics: None,
+            request_id: None,
         };
         match map_response(resp, CFG, NS) {
             Some(Err(McpError { message, .. })) => {
@@ -2221,6 +2231,7 @@ mod tests {
             version_mismatch: true,
             daemon_protocol_version: 99,
             metrics: None,
+            request_id: None,
         };
         match map_response(resp, CFG, NS) {
             Some(Err(McpError { message, .. })) => {
@@ -2562,6 +2573,7 @@ mod tests {
             format: None,
             format_per_op: None,
             from_wire: false,
+            request_id: None,
         };
         let out = forward_or_spawn(&frame).await;
         assert!(out.is_none());
@@ -2600,6 +2612,7 @@ mod tests {
             format: None,
             format_per_op: None,
             from_wire: false,
+            request_id: None,
         }
     }
 
@@ -2711,6 +2724,7 @@ mod tests {
             format: None,
             format_per_op: None,
             from_wire: false,
+            request_id: None,
         };
         let resp = exchange(&sock, &req).await;
         assert!(resp.ok, "valid op must succeed; error={:?}", resp.error);
@@ -2732,6 +2746,7 @@ mod tests {
                 save_to: None,
                 format: None,
                 format_per_op: None,
+                request_id: None,
             })
             .await
             .expect("local dispatch of stats() must succeed");
@@ -2756,6 +2771,7 @@ mod tests {
             format: None,
             format_per_op: None,
             from_wire: false,
+            request_id: None,
         };
         let resp_other = exchange(&sock, &other).await;
         assert!(
@@ -2792,6 +2808,7 @@ mod tests {
             format: None,
             format_per_op: None,
             from_wire: false,
+            request_id: None,
         };
         let resp_cfg = exchange(&sock, &mismatched_config).await;
         assert!(
@@ -2816,6 +2833,7 @@ mod tests {
             format: None,
             format_per_op: None,
             from_wire: false,
+            request_id: None,
         };
         let resp_ver = exchange(&sock, &wrong_version).await;
         assert!(
@@ -2897,6 +2915,7 @@ mod tests {
             format: None,
             format_per_op: None,
             from_wire: false,
+            request_id: None,
         };
         let bob_frame = DaemonRequestFrame {
             ops: "comm.send(to=\"alice\", content=\"hello from bob\")".to_string(),
@@ -2912,6 +2931,7 @@ mod tests {
             format: None,
             format_per_op: None,
             from_wire: false,
+            request_id: None,
         };
 
         let resp_alice = exchange(&sock, &alice_frame).await;
@@ -3025,6 +3045,7 @@ mod tests {
             format: None,
             format_per_op: None,
             from_wire: false,
+            request_id: None,
         };
 
         let seed_a = exchange(
@@ -3124,6 +3145,7 @@ mod tests {
                 save_to: None,
                 format: None,
                 format_per_op: None,
+                request_id: None,
             })
             .await
             .expect("local dispatch of comm.send must succeed");
@@ -3180,6 +3202,7 @@ mod tests {
             format: None,
             format_per_op: None,
             from_wire,
+            request_id: None,
         };
 
         // (a) from_wire=true → daemon applies the wire visibility gate:
@@ -3281,6 +3304,7 @@ mod tests {
             version_mismatch: false,
             daemon_protocol_version: 0,
             metrics: None,
+            request_id: None,
         }
     }
 
@@ -3342,6 +3366,7 @@ mod tests {
             format: None,
             format_per_op: None,
             from_wire: false,
+            request_id: None,
         };
 
         let result = forward_or_spawn(&frame).await;
@@ -3449,6 +3474,7 @@ mod tests {
             format: None,
             format_per_op: None,
             from_wire: false,
+            request_id: None,
         };
 
         // Call try_forward_inner directly to assert the discriminant.
@@ -3756,6 +3782,7 @@ mod tests {
             format: None,
             format_per_op: None,
             from_wire: false,
+            request_id: None,
         };
 
         let result = forward_or_spawn(&frame).await;
@@ -3976,6 +4003,7 @@ mod tests {
             format: None,
             format_per_op: None,
             from_wire: false,
+            request_id: None,
         };
         let fwd = try_forward_inner(&real_frame).await;
         assert!(
@@ -4022,6 +4050,7 @@ mod tests {
                 version_mismatch: false,
                 daemon_protocol_version: PROTOCOL_VERSION,
                 metrics: None,
+                request_id: None,
             };
             if let Ok(payload) = serde_json::to_vec(&response) {
                 let _ = write_frame(&mut stream, &payload).await;
@@ -4384,6 +4413,7 @@ mod tests {
             version_mismatch: false,
             daemon_protocol_version: PROTOCOL_VERSION,
             metrics: None,
+            request_id: None,
         }
     }
 
@@ -4531,6 +4561,7 @@ mod tests {
             format: None,
             format_per_op: None,
             from_wire: false,
+            request_id: None,
         };
 
         let result = forward_or_spawn(&frame).await;
@@ -4591,6 +4622,7 @@ mod tests {
             version_mismatch: true,
             daemon_protocol_version: 0,
             metrics: None,
+            request_id: None,
         }
     }
 
@@ -4629,6 +4661,7 @@ mod tests {
             format: None,
             format_per_op: None,
             from_wire: false,
+            request_id: None,
         };
 
         let outcome = try_forward_inner(&frame).await;
@@ -4672,6 +4705,7 @@ mod tests {
             version_mismatch: true,
             daemon_protocol_version: PROTOCOL_VERSION + 1,
             metrics: None,
+            request_id: None,
         }
     }
 
@@ -4709,6 +4743,7 @@ mod tests {
             format: None,
             format_per_op: None,
             from_wire: false,
+            request_id: None,
         };
 
         let outcome = try_forward_inner(&frame).await;
@@ -4799,6 +4834,7 @@ mod tests {
             format: None,
             format_per_op: None,
             from_wire: false,
+            request_id: None,
         };
 
         let result = forward_or_spawn(&frame).await;
@@ -4902,6 +4938,7 @@ mod tests {
             format: None,
             format_per_op: None,
             from_wire: false,
+            request_id: None,
         };
 
         let result = forward_or_spawn(&frame).await;
@@ -4980,6 +5017,7 @@ mod tests {
                     version_mismatch: false,
                     daemon_protocol_version: PROTOCOL_VERSION,
                     metrics: None,
+                    request_id: None,
                 };
                 let payload = serde_json::to_vec(&resp).expect("serialize response frame");
                 let _ = write_frame(&mut stream, &payload).await;
@@ -5000,6 +5038,7 @@ mod tests {
             format: None,
             format_per_op: None,
             from_wire: false,
+            request_id: None,
         };
 
         let result = forward_or_spawn(&frame).await;
@@ -5121,6 +5160,7 @@ mod tests {
             format: None,
             format_per_op: None,
             from_wire: false,
+            request_id: None,
         };
 
         let started = std::time::Instant::now();

--- a/crates/khive-mcp/src/pending_events.rs
+++ b/crates/khive-mcp/src/pending_events.rs
@@ -1143,6 +1143,7 @@ async fn dispatch_action(
             save_to: None,
             format: None,
             format_per_op: None,
+            request_id: None,
         })
         .await
         .map_err(|e| anyhow::anyhow!("pending-events: dispatch error: {e}"))?;
@@ -2270,6 +2271,7 @@ mod tests {
                 save_to: None,
                 format: None,
                 format_per_op: None,
+                request_id: None,
             })
             .await
             .expect("dispatch_request_local must not error at the RPC layer");
@@ -2612,6 +2614,7 @@ mod tests {
                 save_to: None,
                 format: None,
                 format_per_op: None,
+                request_id: None,
             })
             .await
             .expect("dispatch_request_local must not error at the RPC layer");

--- a/crates/khive-mcp/src/serve.rs
+++ b/crates/khive-mcp/src/serve.rs
@@ -3132,6 +3132,7 @@ id = "lambda:project-actor"
                 save_to: None,
                 format: None,
                 format_per_op: None,
+                request_id: None,
             })
             .await
             .expect("kg dispatch must not error");
@@ -3155,6 +3156,7 @@ id = "lambda:project-actor"
                 save_to: None,
                 format: None,
                 format_per_op: None,
+                request_id: None,
             })
             .await
             .expect("comm dispatch must not error");
@@ -3574,6 +3576,7 @@ id = "lambda:project-actor"
                         save_to: None,
                         format: None,
                         format_per_op: None,
+                        request_id: None,
                     })
                     .await
                     .expect("dispatch must not error");
@@ -4144,6 +4147,7 @@ id = "lambda:project-actor"
                         save_to: None,
                         format: None,
                         format_per_op: None,
+                        request_id: None,
                     })
                     .await
                     .expect("dispatch must not error")

--- a/crates/khive-mcp/src/server.rs
+++ b/crates/khive-mcp/src/server.rs
@@ -1609,6 +1609,9 @@ impl KhiveMcpServer {
             format: p.format.clone(),
             format_per_op: p.format_per_op.clone(),
             from_wire: true,
+            // khive#948: forwarded unchanged from the tool caller's params.
+            // `None` when the caller supplied no id (pre-#948 client).
+            request_id: p.request_id,
         }
     }
 
@@ -2319,6 +2322,29 @@ mod tests {
         std::env::remove_var("KHIVE_LOCK");
     }
 
+    /// khive#948: `wire_daemon_frame` forwards `RequestParams::request_id`
+    /// onto the `DaemonRequestFrame` unchanged, and defaults to `None` when
+    /// the caller supplied none.
+    #[test]
+    fn wire_daemon_frame_forwards_request_id() {
+        let server = make_daemon_save_to_test_server();
+
+        let with_id = RequestParams {
+            ops: "stats()".to_string(),
+            request_id: Some(123),
+            ..Default::default()
+        };
+        let frame = server.wire_daemon_frame(&with_id);
+        assert_eq!(frame.request_id, Some(123));
+
+        let without_id = RequestParams {
+            ops: "stats()".to_string(),
+            ..Default::default()
+        };
+        let frame = server.wire_daemon_frame(&without_id);
+        assert_eq!(frame.request_id, None);
+    }
+
     async fn connect_when_daemon_ready(sock: &std::path::Path) {
         let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(5);
         loop {
@@ -2370,6 +2396,7 @@ mod tests {
                 save_to: Some(sink_path.to_string_lossy().to_string()),
                 format: None,
                 format_per_op: None,
+                request_id: None,
             }))
             .await
             .expect("request with save_to must succeed even with a warm daemon reachable");
@@ -2451,6 +2478,7 @@ mod tests {
                 save_to: None,
                 format: None,
                 format_per_op: None,
+                request_id: None,
             })
             .await
             .expect("baseline stats() must succeed");
@@ -2463,6 +2491,7 @@ mod tests {
                 save_to: None,
                 format: None,
                 format_per_op: None,
+                request_id: None,
             }))
             .await;
 
@@ -2490,6 +2519,7 @@ mod tests {
                 save_to: None,
                 format: None,
                 format_per_op: None,
+                request_id: None,
             })
             .await
             .expect("post-request stats() must succeed");
@@ -2550,6 +2580,7 @@ mod tests {
                 save_to: None,
                 format: None,
                 format_per_op: None,
+                request_id: None,
             })
             .await
             .expect("baseline stats() must succeed");
@@ -2577,6 +2608,7 @@ mod tests {
                 save_to: None,
                 format: None,
                 format_per_op: None,
+                request_id: None,
             }))
             .await
             .expect("strict fallback must land as a normal Ok(envelope), not Err(McpError)");
@@ -2603,6 +2635,7 @@ mod tests {
                 save_to: None,
                 format: None,
                 format_per_op: None,
+                request_id: None,
             }))
             .await
             .expect("strict fallback must land as a normal Ok(envelope), not Err(McpError)");
@@ -2629,6 +2662,7 @@ mod tests {
                 save_to: None,
                 format: None,
                 format_per_op: None,
+                request_id: None,
             }))
             .await
             .expect("strict fallback must land as a normal Ok(envelope), not Err(McpError)");
@@ -2655,6 +2689,7 @@ mod tests {
                 save_to: None,
                 format: None,
                 format_per_op: None,
+                request_id: None,
             })
             .await
             .expect("post-request stats() must succeed");

--- a/crates/khive-mcp/src/server.rs
+++ b/crates/khive-mcp/src/server.rs
@@ -1623,8 +1623,11 @@ impl KhiveMcpServer {
     /// (or sets `from_wire` on the daemon frame), which enforces verb visibility.
     ///
     /// Pure local dispatch: no [`khive_runtime::RequestIdentity`] override is
-    /// applied (ADR-096 Fork 1) — this server's own construction-baked
-    /// identity is used, unchanged from before per-request identity existed.
+    /// applied by this caller (ADR-096 Fork 1) — this server's own
+    /// construction-baked namespace/actor/visibility is used, unchanged from
+    /// before per-request identity existed. `dispatch_request_inner` (khive#948)
+    /// may still synthesize an identity carrying those same baked scalars if
+    /// `p.request_id` is set, purely so the audit row is correlatable.
     pub async fn dispatch_request_local(&self, p: RequestParams) -> Result<String, McpError> {
         self.dispatch_request_inner(p, false, None).await
     }
@@ -1643,6 +1646,17 @@ impl KhiveMcpServer {
     /// frame (ADR-096 Fork 1, see `crate::daemon`'s `DaemonDispatch` impl).
     /// `None` for every local (non-daemon-served) call — this server's own
     /// baked identity applies, exactly as before this parameter existed.
+    ///
+    /// khive#948: when `identity` is `None` (every local-dispatch call —
+    /// `KHIVE_NO_DAEMON`/soft daemon-fallback and the `save_to` bypass both
+    /// route here via `dispatch_request_wire`) and the caller supplied a
+    /// `request_id`, a `RequestIdentity` is synthesized so the audit row
+    /// stamped by this dispatch is still correlatable. The synthesized
+    /// identity mirrors this server's own baked `default_namespace` /
+    /// `actor_id` / `visible_namespaces` exactly — it changes no dispatch
+    /// semantics, only adds the correlation id — so a request with no
+    /// `request_id` still dispatches through the untouched `identity = None`
+    /// path.
     pub(crate) async fn dispatch_request_inner(
         &self,
         p: RequestParams,
@@ -1650,6 +1664,19 @@ impl KhiveMcpServer {
         identity: Option<khive_runtime::RequestIdentity>,
     ) -> Result<String, McpError> {
         let save_to = p.save_to.clone();
+        let identity = identity.or_else(|| {
+            p.request_id
+                .map(|request_id| khive_runtime::RequestIdentity {
+                    namespace: self.default_namespace.clone(),
+                    actor_id: self.actor_id().map(str::to_string),
+                    visible_namespaces: self
+                        .visible_namespaces()
+                        .iter()
+                        .map(|ns| ns.as_str().to_string())
+                        .collect(),
+                    request_id: Some(request_id),
+                })
+        });
         let parsed = parse_request(&p.ops).map_err(dsl_err_to_mcp)?;
 
         // Parse presentation strings → PresentationMode.
@@ -1934,6 +1961,7 @@ impl ServerHandler for KhiveMcpServer {
 mod tests {
     use super::*;
     use khive_runtime::Namespace;
+    use khive_storage::{EventFilter, PageRequest};
     use serial_test::serial;
 
     fn t(pack: &str, verb: &str, desc: &str) -> (String, String, String) {
@@ -2343,6 +2371,103 @@ mod tests {
         };
         let frame = server.wire_daemon_frame(&without_id);
         assert_eq!(frame.request_id, None);
+    }
+
+    /// Query every persisted audit event and find the one whose
+    /// `resource.request_id` matches `id`, if any.
+    async fn find_audit_event_with_request_id(
+        store: &Arc<dyn khive_storage::EventStore>,
+        id: u64,
+    ) -> Option<khive_storage::Event> {
+        let page = store
+            .query_events(
+                EventFilter::default(),
+                PageRequest {
+                    limit: 50,
+                    offset: 0,
+                },
+            )
+            .await
+            .expect("query_events must succeed");
+        page.items
+            .into_iter()
+            .find(|ev| ev.payload["resource"]["request_id"] == json!(id))
+    }
+
+    /// khive#948: `request_id` was previously dropped on the
+    /// `KHIVE_NO_DAEMON`/soft-fallback local dispatch path because
+    /// `dispatch_request_wire` always passed `identity = None`. This drives
+    /// `request()` end-to-end under `KHIVE_NO_DAEMON=1` and inspects the
+    /// persisted audit event, proving the id now survives to
+    /// `resource.request_id` on the local-dispatch path too, not just the
+    /// daemon-forward path.
+    #[tokio::test]
+    #[serial]
+    async fn request_no_daemon_fallback_preserves_request_id_in_audit_event() {
+        clear_daemon_env();
+        std::env::set_var("KHIVE_NO_DAEMON", "1");
+
+        let server = make_daemon_save_to_test_server();
+        server
+            .request(Parameters(RequestParams {
+                // Explicit `namespace="local"` so the write lands in the
+                // same namespace the server's audit `EventStore` handle is
+                // scoped to at construction (`Namespace::local()`), matching
+                // `find_audit_event_with_request_id`'s read scope.
+                ops: "stats(namespace=\"local\")".to_string(),
+                request_id: Some(9001),
+                ..Default::default()
+            }))
+            .await
+            .expect("request() must succeed via local dispatch under KHIVE_NO_DAEMON");
+
+        let store = server
+            .event_store()
+            .expect("in-memory runtime must configure an EventStore");
+        let matched = find_audit_event_with_request_id(&store, 9001).await;
+        assert!(
+            matched.is_some(),
+            "KHIVE_NO_DAEMON local dispatch must stamp request_id onto the persisted \
+             audit event"
+        );
+
+        clear_daemon_env();
+    }
+
+    /// khive#948: the `save_to` bypass (MCP-AUD-002) also routes through
+    /// `dispatch_request_wire`'s local dispatch — this proves the id
+    /// survives that path too.
+    #[tokio::test]
+    #[serial]
+    async fn request_save_to_bypass_preserves_request_id_in_audit_event() {
+        clear_daemon_env();
+        let dir = tempfile::tempdir().expect("tempdir");
+        std::env::set_var("KHIVE_SAVE_TO_ROOT", dir.path());
+
+        let server = make_daemon_save_to_test_server();
+        let sink_path = dir.path().join("out.jsonl");
+        server
+            .request(Parameters(RequestParams {
+                ops: "stats(namespace=\"local\")".to_string(),
+                save_to: Some(sink_path.to_string_lossy().to_string()),
+                request_id: Some(9002),
+                ..Default::default()
+            }))
+            .await
+            .expect("request() with save_to must succeed");
+
+        let store = server
+            .event_store()
+            .expect("in-memory runtime must configure an EventStore");
+        let matched = find_audit_event_with_request_id(&store, 9002).await;
+        assert!(
+            matched.is_some(),
+            "save_to local-dispatch bypass must stamp request_id onto the persisted \
+             audit event"
+        );
+
+        clear_daemon_env();
+        std::env::remove_var("KHIVE_SAVE_TO_ROOT");
     }
 
     async fn connect_when_daemon_ready(sock: &std::path::Path) {

--- a/crates/khive-mcp/src/tools/request.rs
+++ b/crates/khive-mcp/src/tools/request.rs
@@ -89,4 +89,16 @@ pub struct RequestParams {
     #[serde(default)]
     #[schemars(description = "Per-op output format override (optional)")]
     pub format_per_op: Option<Vec<Option<String>>>,
+
+    /// Caller-supplied correlation id (khive#948), forwarded unchanged onto
+    /// the daemon request frame and echoed back on the response so a
+    /// benchmark harness can join its own pre-send sample to the server-side
+    /// audit row for this request. Purely a correlation label — it never
+    /// changes how a request is dispatched. When omitted, the request
+    /// carries no id and its audit row has no `request_id` key.
+    #[serde(default)]
+    #[schemars(
+        description = "Caller-supplied correlation id, echoed back and stamped into the audit event (optional)"
+    )]
+    pub request_id: Option<u64>,
 }

--- a/crates/khive-mcp/tests/integration.rs
+++ b/crates/khive-mcp/tests/integration.rs
@@ -2150,6 +2150,7 @@ async fn subhandler_verbs_are_allowed_on_operator_path() -> anyhow::Result<()> {
                 save_to: None,
                 format: None,
                 format_per_op: None,
+                request_id: None,
             })
             .await
             .expect("operator dispatch must not RPC-fail");
@@ -3925,6 +3926,7 @@ async fn exec_output_valid_json_with_backslash_escape_content() -> anyhow::Resul
             save_to: None,
             format: None,
             format_per_op: None,
+            request_id: None,
         })
         .await
         .expect("dispatch must succeed");
@@ -3944,6 +3946,7 @@ async fn exec_output_valid_json_with_backslash_escape_content() -> anyhow::Resul
             save_to: None,
             format: None,
             format_per_op: None,
+            request_id: None,
         })
         .await
         .expect("get dispatch must succeed");
@@ -3982,6 +3985,7 @@ async fn exec_output_valid_json_with_backslash_escape_content() -> anyhow::Resul
             save_to: None,
             format: None,
             format_per_op: None,
+            request_id: None,
         })
         .await
         .expect("update dispatch must succeed");
@@ -4445,6 +4449,7 @@ async fn dispatch_honors_explicit_namespace_else_local_adr007() {
                 save_to: None,
                 format: None,
                 format_per_op: None,
+                request_id: None,
             })
             .await
             .expect("dispatch must not error at the MCP level");
@@ -4571,6 +4576,7 @@ async fn format_auto_mixed_ok_error_batch_error_stays_compact() {
         save_to: None,
         format: Some("auto".to_string()),
         format_per_op: None,
+        request_id: None,
     };
 
     let raw = server
@@ -4636,6 +4642,7 @@ async fn format_per_op_override_selects_format_per_position() {
             Some("json".to_string()), // op0 → json (compact, parseable)
             None,                     // op1 → inherits batch "auto"
         ]),
+        request_id: None,
     };
 
     let raw = server
@@ -4699,6 +4706,7 @@ async fn presentation_per_op_verbose_preserves_full_id_namespace_and_props() {
         save_to: None,
         format: None,
         format_per_op: None,
+        request_id: None,
     };
     let create_raw = server
         .dispatch_request_local(create_params)
@@ -4726,6 +4734,7 @@ async fn presentation_per_op_verbose_preserves_full_id_namespace_and_props() {
         save_to: None,
         format: Some("auto".to_string()),
         format_per_op: None,
+        request_id: None,
     };
 
     let raw = server
@@ -4816,6 +4825,7 @@ async fn format_auto_always_verbose_verb_skips_redundancy_drop_without_override(
         save_to: None,
         format: None,
         format_per_op: None,
+        request_id: None,
     };
     let create_raw = server
         .dispatch_request_local(create_params)
@@ -4837,6 +4847,7 @@ async fn format_auto_always_verbose_verb_skips_redundancy_drop_without_override(
         save_to: None,
         format: Some("auto".to_string()),
         format_per_op: None,
+        request_id: None,
     };
     let raw = server
         .dispatch_request_local(get_params)

--- a/crates/khive-runtime/src/cost_unit.rs
+++ b/crates/khive-runtime/src/cost_unit.rs
@@ -163,14 +163,28 @@ pub fn cost_unit_for_dispatch(
 /// dispatch. Default for all handlers."). Background phase work (embedder
 /// warmup, ANN rebuild, etc.) uses the separate `PhaseStarted` /
 /// `PhaseCompleted` / `PhaseCancelled` event family and never this payload.
+///
+/// `request_id` (khive#948) is the caller-supplied correlation id threaded in
+/// from the daemon frame via `RequestIdentity`, stamped alongside
+/// `work_class`/`cost_unit` when the caller supplied one. Its absence has
+/// exactly one meaning (no id was supplied, e.g. a pre-#948 client or an
+/// internal/non-benchmark caller) — unlike `cost_unit`, it is never
+/// conditionally omitted on an otherwise-successful row.
 pub fn resource_payload(
     verb: &str,
     params: &Value,
     result: &Value,
     registered_model_count: impl FnOnce() -> i64,
+    request_id: Option<u64>,
 ) -> Value {
     let cost_unit = cost_unit_for_dispatch(verb, params, result, registered_model_count);
-    serde_json::json!({ "work_class": "interactive", "cost_unit": cost_unit })
+    let mut payload = serde_json::json!({ "work_class": "interactive", "cost_unit": cost_unit });
+    if let Some(id) = request_id {
+        if let Value::Object(ref mut map) = payload {
+            map.insert("request_id".to_string(), serde_json::json!(id));
+        }
+    }
+    payload
 }
 
 /// Build the `resource` payload object for a dispatch that did not resolve
@@ -184,8 +198,18 @@ pub fn resource_payload(
 /// omission cases, so it must still be present. Every dispatch through
 /// `VerbRegistry::dispatch*` is `work_class: "interactive"` regardless of
 /// outcome; there is no non-interactive outcome for a verb dispatch.
-pub fn base_resource_payload() -> Value {
-    serde_json::json!({ "work_class": "interactive" })
+///
+/// `request_id` (khive#948) is stamped the same way on this payload as on
+/// [`resource_payload`]'s: failure rows must be joinable by the same key as
+/// success rows.
+pub fn base_resource_payload(request_id: Option<u64>) -> Value {
+    let mut payload = serde_json::json!({ "work_class": "interactive" });
+    if let Some(id) = request_id {
+        if let Value::Object(ref mut map) = payload {
+            map.insert("request_id".to_string(), serde_json::json!(id));
+        }
+    }
+    payload
 }
 
 #[cfg(test)]
@@ -388,11 +412,49 @@ mod tests {
 
     #[test]
     fn resource_payload_shape_is_work_class_and_cost_unit_only() {
-        let payload = resource_payload("stats", &json!({}), &json!({}), unreachable_model_count);
+        let payload = resource_payload(
+            "stats",
+            &json!({}),
+            &json!({}),
+            unreachable_model_count,
+            None,
+        );
         assert_eq!(
             payload,
             json!({"work_class": "interactive", "cost_unit": 1}),
-            "resource payload must be exactly {{work_class, cost_unit}}, no extra fields"
+            "resource payload must be exactly {{work_class, cost_unit}}, no request_id key \
+             when the caller supplied none"
+        );
+    }
+
+    #[test]
+    fn resource_payload_stamps_request_id_when_supplied() {
+        let payload = resource_payload(
+            "stats",
+            &json!({}),
+            &json!({}),
+            unreachable_model_count,
+            Some(42),
+        );
+        assert_eq!(
+            payload,
+            json!({"work_class": "interactive", "cost_unit": 1, "request_id": 42}),
+        );
+    }
+
+    #[test]
+    fn base_resource_payload_omits_request_id_when_absent() {
+        assert_eq!(
+            base_resource_payload(None),
+            json!({"work_class": "interactive"}),
+        );
+    }
+
+    #[test]
+    fn base_resource_payload_stamps_request_id_when_supplied() {
+        assert_eq!(
+            base_resource_payload(Some(7)),
+            json!({"work_class": "interactive", "request_id": 7}),
         );
     }
 }

--- a/crates/khive-runtime/src/daemon.rs
+++ b/crates/khive-runtime/src/daemon.rs
@@ -341,10 +341,20 @@ pub struct DaemonRequestFrame {
     /// key on transport.
     #[serde(default)]
     pub from_wire: bool,
+    /// Caller-supplied correlation id (khive#948): a `u64` from the caller's
+    /// own process-local monotonic counter, echoed back unchanged on
+    /// [`DaemonResponseFrame::request_id`] and stamped into the dispatch's
+    /// audit event (`resource.request_id`) so a benchmark harness can join
+    /// its own pre-send sample to the server-side audit row for the same
+    /// request. Purely additive — `#[serde(default)]` matches
+    /// `metrics_only`/`format`/`format_per_op` precedent, no
+    /// `PROTOCOL_VERSION` bump. `None` means the caller supplied no id.
+    #[serde(default)]
+    pub request_id: Option<u64>,
 }
 
 /// Response frame sent from the daemon back to a client.
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Debug)]
 pub struct DaemonResponseFrame {
     pub ok: bool,
     pub result: Option<String>,
@@ -381,6 +391,14 @@ pub struct DaemonResponseFrame {
     /// `served_config_id`'s upgrade-window handling above).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub metrics: Option<MetricsSnapshot>,
+    /// Echo of the request's `request_id` (khive#948), present whenever the
+    /// frame that produced this response carried one — including on every
+    /// error/denied arm, not only success, so a client can join a failure
+    /// the same way it joins a success. `#[serde(default)]` so an older
+    /// daemon's response (predating this field) deserializes to `None`
+    /// rather than a parse error.
+    #[serde(default)]
+    pub request_id: Option<u64>,
 }
 
 /// Point-in-time snapshot of the daemon's server-side gauges — the
@@ -760,6 +778,7 @@ async fn handle_conn<D: DaemonDispatch>(mut stream: UnixStream, dispatcher: D) {
             version_mismatch: true,
             daemon_protocol_version: PROTOCOL_VERSION,
             metrics: None,
+            request_id: frame.request_id,
         }
     } else if frame.metrics_only {
         // Process-global gauge read: namespace/config-agnostic, so this is
@@ -778,6 +797,7 @@ async fn handle_conn<D: DaemonDispatch>(mut stream: UnixStream, dispatcher: D) {
             version_mismatch: false,
             daemon_protocol_version: PROTOCOL_VERSION,
             metrics: Some(build_metrics_snapshot(&dispatcher)),
+            request_id: frame.request_id,
         }
     // There is no `frame.namespace != dispatcher.namespace()` reject here.
     // The daemon accepts and serves the request under the frame's own
@@ -799,6 +819,7 @@ async fn handle_conn<D: DaemonDispatch>(mut stream: UnixStream, dispatcher: D) {
             version_mismatch: false,
             daemon_protocol_version: PROTOCOL_VERSION,
             metrics: None,
+            request_id: frame.request_id,
         }
     } else if frame.probe_only {
         // Probe-only request: identity checks passed; return immediately without
@@ -814,6 +835,7 @@ async fn handle_conn<D: DaemonDispatch>(mut stream: UnixStream, dispatcher: D) {
             version_mismatch: false,
             daemon_protocol_version: PROTOCOL_VERSION,
             metrics: None,
+            request_id: frame.request_id,
         }
     } else {
         // Build the per-request identity context from the frame so the
@@ -828,6 +850,7 @@ async fn handle_conn<D: DaemonDispatch>(mut stream: UnixStream, dispatcher: D) {
             namespace: frame.namespace.clone(),
             actor_id: frame.actor_id.clone(),
             visible_namespaces: frame.visible_namespaces.clone(),
+            request_id: frame.request_id,
         };
         match dispatcher
             .dispatch(
@@ -851,6 +874,7 @@ async fn handle_conn<D: DaemonDispatch>(mut stream: UnixStream, dispatcher: D) {
                 version_mismatch: false,
                 daemon_protocol_version: PROTOCOL_VERSION,
                 metrics: None,
+                request_id: frame.request_id,
             },
             Err(e) => DaemonResponseFrame {
                 ok: false,
@@ -862,6 +886,7 @@ async fn handle_conn<D: DaemonDispatch>(mut stream: UnixStream, dispatcher: D) {
                 version_mismatch: false,
                 daemon_protocol_version: PROTOCOL_VERSION,
                 metrics: None,
+                request_id: frame.request_id,
             },
         }
     };
@@ -894,6 +919,7 @@ async fn handle_conn<D: DaemonDispatch>(mut stream: UnixStream, dispatcher: D) {
                     version_mismatch: false,
                     daemon_protocol_version: PROTOCOL_VERSION,
                     metrics: None,
+                    request_id: resp.request_id,
                 };
                 if let Ok(err_payload) = serde_json::to_vec(&err_resp) {
                     if let Err(e) = write_frame(&mut stream, &err_payload).await {
@@ -1588,6 +1614,10 @@ mod tests {
         config_id: String,
         dispatch_calls: Arc<std::sync::atomic::AtomicUsize>,
         pool: Option<Arc<ConnectionPool>>,
+        /// When `Some(msg)`, `dispatch` returns `Err(msg)` instead of the
+        /// default `Ok("{}")` — lets a test drive `handle_conn`'s real
+        /// dispatch-error arm (khive#948 request_id echo coverage).
+        dispatch_err: Option<String>,
     }
 
     #[async_trait]
@@ -1604,7 +1634,10 @@ mod tests {
         ) -> Result<String, String> {
             self.dispatch_calls
                 .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            Ok("{}".to_string())
+            match &self.dispatch_err {
+                Some(msg) => Err(msg.clone()),
+                None => Ok("{}".to_string()),
+            }
         }
 
         async fn warm_all(&self) {}
@@ -1637,6 +1670,7 @@ mod tests {
             format: None,
             format_per_op: None,
             from_wire: false,
+            request_id: None,
         }
     }
 
@@ -1670,6 +1704,7 @@ mod tests {
             config_id: "cfg-a".to_string(),
             dispatch_calls: Arc::clone(&dispatch_calls),
             pool: None,
+            dispatch_err: None,
         };
 
         let mut metrics_req = base_request_frame("cfg-a");
@@ -1752,6 +1787,7 @@ mod tests {
             config_id: "cfg-wal".to_string(),
             dispatch_calls: Arc::new(std::sync::atomic::AtomicUsize::new(0)),
             pool: Some(pool),
+            dispatch_err: None,
         };
 
         let snapshot = build_metrics_snapshot(&dispatcher);
@@ -1784,6 +1820,7 @@ mod tests {
             config_id: "cfg-tx".to_string(),
             dispatch_calls: Arc::new(std::sync::atomic::AtomicUsize::new(0)),
             pool: None,
+            dispatch_err: None,
         };
 
         let before = build_metrics_snapshot(&dispatcher).open_tx_count;
@@ -1838,6 +1875,7 @@ mod tests {
             config_id: "cfg-wq-on".to_string(),
             dispatch_calls: Arc::new(std::sync::atomic::AtomicUsize::new(0)),
             pool: Some(enabled_pool),
+            dispatch_err: None,
         };
         let snapshot_on = build_metrics_snapshot(&enabled_dispatcher);
         assert!(
@@ -1859,6 +1897,7 @@ mod tests {
             config_id: "cfg-wq-off".to_string(),
             dispatch_calls: Arc::new(std::sync::atomic::AtomicUsize::new(0)),
             pool: Some(disabled_pool),
+            dispatch_err: None,
         };
         let snapshot_off = build_metrics_snapshot(&disabled_dispatcher);
         assert!(
@@ -1873,6 +1912,7 @@ mod tests {
             config_id: "cfg-no-pool".to_string(),
             dispatch_calls: Arc::new(std::sync::atomic::AtomicUsize::new(0)),
             pool: None,
+            dispatch_err: None,
         };
         let snapshot_no_pool = build_metrics_snapshot(&no_pool_dispatcher);
         assert!(snapshot_no_pool.write_queue_depth.is_none());
@@ -1905,6 +1945,10 @@ mod tests {
             !frame.metrics_only,
             "metrics_only must default to false when absent from the wire payload"
         );
+        assert_eq!(
+            frame.request_id, None,
+            "request_id must default to None when absent from the wire payload (khive#948)"
+        );
 
         let resp_json = serde_json::json!({
             "ok": true,
@@ -1921,6 +1965,72 @@ mod tests {
         assert!(
             resp.metrics.is_none(),
             "metrics must default to None when absent from the wire payload"
+        );
+        assert_eq!(
+            resp.request_id, None,
+            "request_id must default to None when absent from the wire payload (khive#948)"
+        );
+    }
+
+    /// khive#948: a request carrying `request_id: Some(n)` gets back a
+    /// response with `request_id: Some(n)` on both the success and the
+    /// error/denied dispatch arms — the echo must survive every branch of
+    /// `handle_conn`, not only the happy path.
+    #[tokio::test]
+    async fn request_id_echoed_on_success_and_error_arms() {
+        let dispatcher = MockDispatch {
+            namespace: "local".to_string(),
+            config_id: "cfg-a".to_string(),
+            dispatch_calls: Arc::new(std::sync::atomic::AtomicUsize::new(0)),
+            pool: None,
+            dispatch_err: None,
+        };
+        let mut ok_req = base_request_frame("cfg-a");
+        ok_req.request_id = Some(42);
+        let ok_resp = round_trip(dispatcher, &ok_req).await;
+        assert!(ok_resp.ok, "expected successful dispatch: {ok_resp:?}");
+        assert_eq!(
+            ok_resp.request_id,
+            Some(42),
+            "request_id must be echoed back on a successful dispatch response"
+        );
+
+        // config_mismatch is a rejection arm that never reaches dispatch —
+        // must still echo the id so the client can join the failure.
+        let mismatched_dispatcher = MockDispatch {
+            namespace: "local".to_string(),
+            config_id: "cfg-a".to_string(),
+            dispatch_calls: Arc::new(std::sync::atomic::AtomicUsize::new(0)),
+            pool: None,
+            dispatch_err: None,
+        };
+        let mut mismatch_req = base_request_frame("cfg-WRONG");
+        mismatch_req.request_id = Some(99);
+        let mismatch_resp = round_trip(mismatched_dispatcher, &mismatch_req).await;
+        assert!(mismatch_resp.config_mismatch);
+        assert_eq!(
+            mismatch_resp.request_id,
+            Some(99),
+            "request_id must be echoed on the config_mismatch rejection arm too"
+        );
+
+        // The real ops-dispatch error arm (`Err(e)` from `dispatcher.dispatch`)
+        // must echo the id as well, not only the pre-dispatch rejection arms.
+        let erroring_dispatcher = MockDispatch {
+            namespace: "local".to_string(),
+            config_id: "cfg-a".to_string(),
+            dispatch_calls: Arc::new(std::sync::atomic::AtomicUsize::new(0)),
+            pool: None,
+            dispatch_err: Some("simulated dispatch error".to_string()),
+        };
+        let mut err_req = base_request_frame("cfg-a");
+        err_req.request_id = Some(7);
+        let err_resp = round_trip(erroring_dispatcher, &err_req).await;
+        assert!(!err_resp.ok, "expected a dispatch error: {err_resp:?}");
+        assert_eq!(
+            err_resp.request_id,
+            Some(7),
+            "request_id must be echoed on the real ops-dispatch error arm"
         );
     }
 

--- a/crates/khive-runtime/src/pack.rs
+++ b/crates/khive-runtime/src/pack.rs
@@ -848,6 +848,14 @@ pub struct RequestIdentity {
     /// failing the whole request — a single malformed visibility entry from a
     /// caller-supplied frame must not block dispatch.
     pub visible_namespaces: Vec<String>,
+    /// Caller-supplied correlation id for this request (khive#948), carried
+    /// unchanged from the daemon frame's `request_id` field. Stamped into the
+    /// audit event's `resource.request_id` on every outcome (success, error,
+    /// and denied) so a client can join its own pre-send sample to the
+    /// server-side audit row for the same request. `None` means the caller
+    /// supplied no id (a pre-#948 client, or an internal/non-benchmark
+    /// caller) — the audit row then carries no `request_id` key at all.
+    pub request_id: Option<u64>,
 }
 
 /// Error returned by [`VerbRegistry::apply_schema_plans_with_map`] when two
@@ -1082,6 +1090,10 @@ impl VerbRegistry {
         // coordinator intercept via `resolve_explicit_namespace` so every MCP
         // ingress path applies the same fail-closed rule.
         let explicit_namespace = params.get("namespace").is_some_and(Value::is_string);
+        // The caller-supplied correlation id (khive#948), if any. Read once
+        // here so it is in scope for every audit-append site below,
+        // including the ones that run before pack dispatch is attempted.
+        let request_id: Option<u64> = identity.as_ref().and_then(|id| id.request_id);
         // A supplied per-request identity overrides the baked
         // default_namespace/actor_id/visible_namespaces for this call only.
         let default_namespace_str: &str = identity
@@ -1173,7 +1185,7 @@ impl VerbRegistry {
                             &gate_req,
                             &audit,
                             EventOutcome::Denied,
-                            Some(crate::cost_unit::base_resource_payload()),
+                            Some(crate::cost_unit::base_resource_payload(request_id)),
                         );
                         append_audit_event_best_effort(store, storage_event, verb).await;
                     }
@@ -1314,6 +1326,7 @@ impl VerbRegistry {
                                     &gate_req.args,
                                     ok_val,
                                     || pack.registered_embedding_model_names().len() as i64,
+                                    request_id,
                                 );
                                 match link_audit_success_from_result(audit.clone(), ok_val) {
                                     Some((edge_id, mut payload)) => {
@@ -1384,11 +1397,12 @@ impl VerbRegistry {
                                             &gate_req.args,
                                             ok_val,
                                             || pack.registered_embedding_model_names().len() as i64,
+                                            request_id,
                                         )),
                                     ),
                                     Err(_) => (
                                         EventOutcome::Error,
-                                        Some(crate::cost_unit::base_resource_payload()),
+                                        Some(crate::cost_unit::base_resource_payload(request_id)),
                                     ),
                                 };
                                 let storage_event =
@@ -1487,7 +1501,7 @@ impl VerbRegistry {
                     &gate_req,
                     &audit,
                     EventOutcome::Error,
-                    Some(crate::cost_unit::base_resource_payload()),
+                    Some(crate::cost_unit::base_resource_payload(request_id)),
                 );
                 append_audit_event_best_effort(store, storage_event, verb).await;
             }

--- a/crates/khive-runtime/src/pack.rs
+++ b/crates/khive-runtime/src/pack.rs
@@ -5199,6 +5199,248 @@ mod tests {
             "a non-UUID id must not enrich"
         );
     }
+
+    // ---- khive#948: request_id survives to the persisted audit event ----
+    //
+    // The pure `resource_payload`/`base_resource_payload` helpers are unit
+    // tested in `cost_unit.rs`; these tests prove the id actually reaches
+    // `resource.request_id` on a persisted `Event` through every one of
+    // `dispatch_with_identity`'s four audit-append sites (denied, ordinary
+    // success/error, singleton-link v2 success and its v1 fallback, and the
+    // unknown-verb error path), plus the "no id supplied" omission case.
+
+    async fn first_event(store: &Arc<MemoryEventStore>) -> Event {
+        let page = store
+            .query_events(
+                EventFilter::default(),
+                PageRequest {
+                    limit: 10,
+                    offset: 0,
+                },
+            )
+            .await
+            .unwrap();
+        assert_eq!(
+            page.items.len(),
+            1,
+            "expected exactly one persisted audit event"
+        );
+        page.items[0].clone()
+    }
+
+    #[tokio::test]
+    async fn dispatch_with_identity_stamps_request_id_on_success() {
+        let store = Arc::new(MemoryEventStore::default());
+        let mut builder = VerbRegistryBuilder::new();
+        builder.register(AlphaPack);
+        builder.with_event_store(store.clone());
+        let reg = builder.build().expect("registry builds");
+
+        reg.dispatch_with_identity(
+            "list",
+            serde_json::json!({"namespace": "test-ns"}),
+            Some(RequestIdentity {
+                request_id: Some(101),
+                ..Default::default()
+            }),
+        )
+        .await
+        .unwrap();
+
+        let ev = first_event(&store).await;
+        assert_eq!(ev.outcome, EventOutcome::Success);
+        assert_eq!(ev.payload["resource"]["request_id"], serde_json::json!(101));
+    }
+
+    #[tokio::test]
+    async fn dispatch_with_identity_stamps_request_id_on_dispatch_error() {
+        let store = Arc::new(MemoryEventStore::default());
+        let mut builder = VerbRegistryBuilder::new();
+        builder.register(FailingProbePack);
+        builder.with_event_store(store.clone());
+        let reg = builder.build().expect("registry builds");
+
+        let err = reg
+            .dispatch_with_identity(
+                "probe",
+                serde_json::json!({"namespace": "test-ns"}),
+                Some(RequestIdentity {
+                    request_id: Some(102),
+                    ..Default::default()
+                }),
+            )
+            .await
+            .unwrap_err();
+        assert!(matches!(err, RuntimeError::InvalidInput(_)));
+
+        let ev = first_event(&store).await;
+        assert_eq!(ev.outcome, EventOutcome::Error);
+        assert_eq!(ev.payload["resource"]["request_id"], serde_json::json!(102));
+    }
+
+    #[tokio::test]
+    async fn dispatch_with_identity_stamps_request_id_on_denied() {
+        #[derive(Debug)]
+        struct AlwaysDenyGate;
+        impl Gate for AlwaysDenyGate {
+            fn check(&self, _req: &GateRequest) -> Result<GateDecision, GateError> {
+                Ok(GateDecision::deny("denied by test"))
+            }
+        }
+
+        let store = Arc::new(MemoryEventStore::default());
+        let mut builder = VerbRegistryBuilder::new();
+        builder.register(AlphaPack);
+        builder.with_gate(Arc::new(AlwaysDenyGate));
+        builder.with_event_store(store.clone());
+        let reg = builder.build().expect("registry builds");
+
+        let err = reg
+            .dispatch_with_identity(
+                "list",
+                serde_json::json!({"namespace": "test-ns"}),
+                Some(RequestIdentity {
+                    request_id: Some(103),
+                    ..Default::default()
+                }),
+            )
+            .await
+            .unwrap_err();
+        assert!(matches!(err, RuntimeError::PermissionDenied { .. }));
+
+        let ev = first_event(&store).await;
+        assert_eq!(ev.payload["resource"]["request_id"], serde_json::json!(103));
+    }
+
+    #[tokio::test]
+    async fn dispatch_with_identity_stamps_request_id_on_link_v2_success() {
+        let store = Arc::new(MemoryEventStore::default());
+        let edge_id = uuid::Uuid::new_v4();
+        let source_id = uuid::Uuid::new_v4();
+        let target_id = uuid::Uuid::new_v4();
+        let edge_json = serde_json::json!({
+            "id": edge_id,
+            "namespace": "local",
+            "source_id": source_id,
+            "target_id": target_id,
+            "relation": "depends_on",
+            "weight": 1.0,
+        });
+        let mut builder = VerbRegistryBuilder::new();
+        builder.register(LinkResultPack::ok(edge_json));
+        builder.with_event_store(store.clone());
+        builder.with_default_namespace("test-ns");
+        let reg = builder.build().expect("registry builds");
+
+        reg.dispatch_with_identity(
+            "link",
+            serde_json::json!({
+                "source_id": source_id,
+                "target_id": target_id,
+                "relation": "depends_on",
+            }),
+            Some(RequestIdentity {
+                namespace: "test-ns".to_string(),
+                request_id: Some(104),
+                ..Default::default()
+            }),
+        )
+        .await
+        .unwrap();
+
+        let ev = first_event(&store).await;
+        assert_eq!(
+            ev.payload_schema_version, 2,
+            "successful singleton link uses audit schema v2"
+        );
+        assert_eq!(ev.payload["resource"]["request_id"], serde_json::json!(104));
+    }
+
+    #[tokio::test]
+    async fn dispatch_with_identity_stamps_request_id_on_link_v1_fallback() {
+        let store = Arc::new(MemoryEventStore::default());
+        let mut builder = VerbRegistryBuilder::new();
+        builder.register(LinkResultPack::err("target endpoint not found"));
+        builder.with_event_store(store.clone());
+        builder.with_default_namespace("test-ns");
+        let reg = builder.build().expect("registry builds");
+
+        let err = reg
+            .dispatch_with_identity(
+                "link",
+                serde_json::json!({
+                    "source_id": "note:alpha",
+                    "target_id": "note:missing",
+                    "relation": "depends_on",
+                }),
+                Some(RequestIdentity {
+                    namespace: "test-ns".to_string(),
+                    request_id: Some(105),
+                    ..Default::default()
+                }),
+            )
+            .await
+            .unwrap_err();
+        assert!(matches!(err, RuntimeError::InvalidInput(_)));
+
+        let ev = first_event(&store).await;
+        assert_eq!(
+            ev.payload_schema_version, 1,
+            "failed link keeps the v1 audit shape"
+        );
+        assert_eq!(ev.payload["resource"]["request_id"], serde_json::json!(105));
+    }
+
+    #[tokio::test]
+    async fn dispatch_with_identity_stamps_request_id_on_unknown_verb() {
+        let store = Arc::new(MemoryEventStore::default());
+        let mut builder = VerbRegistryBuilder::new();
+        builder.register(AlphaPack);
+        builder.with_event_store(store.clone());
+        let reg = builder.build().expect("registry builds");
+
+        let err = reg
+            .dispatch_with_identity(
+                "no_such_verb",
+                serde_json::json!({}),
+                Some(RequestIdentity {
+                    namespace: Namespace::local().as_str().to_string(),
+                    request_id: Some(106),
+                    ..Default::default()
+                }),
+            )
+            .await
+            .unwrap_err();
+        assert!(matches!(err, RuntimeError::InvalidInput(_)));
+
+        let ev = first_event(&store).await;
+        assert_eq!(ev.outcome, EventOutcome::Error);
+        assert_eq!(ev.payload["resource"]["request_id"], serde_json::json!(106));
+    }
+
+    #[tokio::test]
+    async fn dispatch_with_identity_omits_request_id_key_when_absent() {
+        let store = Arc::new(MemoryEventStore::default());
+        let mut builder = VerbRegistryBuilder::new();
+        builder.register(AlphaPack);
+        builder.with_event_store(store.clone());
+        let reg = builder.build().expect("registry builds");
+
+        // No identity at all — the pre-#948 call shape.
+        reg.dispatch("list", serde_json::json!({"namespace": "test-ns"}))
+            .await
+            .unwrap();
+
+        let ev = first_event(&store).await;
+        let resource = ev.payload["resource"]
+            .as_object()
+            .expect("resource must be an object");
+        assert!(
+            !resource.contains_key("request_id"),
+            "request_id key must be entirely absent when no id is supplied, \
+             not present as null or 0: got {resource:?}"
+        );
+    }
 }
 
 // ---- Inter-pack dependency checking ----

--- a/crates/kkernel/src/coordinator/tests.rs
+++ b/crates/kkernel/src/coordinator/tests.rs
@@ -1033,6 +1033,7 @@ async fn t7a_multi_backend_search_populates_real_entity_kind() {
             save_to: None,
             format: None,
             format_per_op: None,
+            request_id: None,
         })
         .await
         .expect("T7a: dispatch");
@@ -1123,6 +1124,7 @@ async fn t7b_multi_backend_search_kind_filter_excludes_off_kind() {
             save_to: None,
             format: None,
             format_per_op: None,
+            request_id: None,
         })
         .await
         .expect("T7b: dispatch");
@@ -1185,6 +1187,7 @@ async fn t7c_multi_backend_search_min_score_applied() {
             save_to: None,
             format: None,
             format_per_op: None,
+            request_id: None,
         })
         .await
         .expect("T7c: dispatch");
@@ -1245,6 +1248,7 @@ async fn t7d_multi_backend_search_session_kind_routes_to_note_substrate() {
             save_to: None,
             format: None,
             format_per_op: None,
+            request_id: None,
         })
         .await
         .expect("T7d: dispatch");

--- a/crates/kkernel/src/exec.rs
+++ b/crates/kkernel/src/exec.rs
@@ -346,6 +346,7 @@ async fn apply_ops_file(
             save_to: None,
             format: None,
             format_per_op: None,
+            request_id: None,
         };
 
         let raw = server
@@ -609,6 +610,7 @@ async fn run_exec_inline_with_forward(
             // `kkernel exec` is a trusted operator surface: subhandler verbs are
             // allowed. Only the agent-facing MCP `request` tool sets this true.
             from_wire: false,
+            request_id: None,
         };
         if let Some(res) = forward_fn(&frame).await {
             let output = res.map_err(|e| anyhow::anyhow!("{}", e.message))?;
@@ -635,6 +637,7 @@ async fn run_exec_inline_with_forward(
         // Tier-1: CLI --output-format overrides the server default (env/builtin).
         format: output_format,
         format_per_op: None,
+        request_id: None,
     };
 
     let output = server
@@ -1269,6 +1272,7 @@ default = true
                 save_to: None,
                 format: None,
                 format_per_op: None,
+                request_id: None,
             })
             .await
             .expect("comm.send must dispatch");
@@ -1299,6 +1303,7 @@ default = true
                     save_to: None,
                     format: None,
                     format_per_op: None,
+                    request_id: None,
                 })
                 .await
                 .expect("list must dispatch");
@@ -1416,6 +1421,7 @@ default = true
                     save_to: None,
                     format: None,
                     format_per_op: None,
+                    request_id: None,
                 };
                 let raw = server
                     .dispatch_request_local(params)
@@ -1652,6 +1658,7 @@ default = true
             save_to: None,
             format: None,
             format_per_op: None,
+            request_id: None,
         };
         let raw = server.dispatch_request_local(params).await.unwrap();
         let resp: serde_json::Value = serde_json::from_str(&raw).unwrap();
@@ -1692,6 +1699,7 @@ default = true
                 save_to: None,
                 format: None,
                 format_per_op: None,
+                request_id: None,
             };
             let raw = server
                 .dispatch_request_local(params)
@@ -1822,6 +1830,7 @@ default = true
             save_to: None,
             format: None,
             format_per_op: None,
+            request_id: None,
         };
         let raw = server.dispatch_request_local(params).await.unwrap();
         let resp: serde_json::Value = serde_json::from_str(&raw).unwrap();
@@ -2285,6 +2294,7 @@ backend = "sessions"
             save_to: None,
             format: None,
             format_per_op: None,
+            request_id: None,
         };
         let raw = server.dispatch_request_local(params).await.unwrap();
         let resp: serde_json::Value = serde_json::from_str(&raw).unwrap();
@@ -2320,6 +2330,7 @@ backend = "sessions"
             save_to: None,
             format: None,
             format_per_op: None,
+            request_id: None,
         };
         let raw = server.dispatch_request_local(params).await.unwrap();
         serde_json::from_str(&raw).unwrap()

--- a/crates/kkernel/src/main.rs
+++ b/crates/kkernel/src/main.rs
@@ -1251,6 +1251,7 @@ mod tests {
                         save_to: None,
                         format: None,
                         format_per_op: None,
+                        request_id: None,
                     })
                     .await
                     .expect("dispatch must not error");

--- a/crates/kkernel/tests/mcp_bridge_reexec_protocol_mismatch.rs
+++ b/crates/kkernel/tests/mcp_bridge_reexec_protocol_mismatch.rs
@@ -95,6 +95,7 @@ fn stale_daemon_response() -> DaemonResponseFrame {
         version_mismatch: false,
         daemon_protocol_version: 0,
         metrics: None,
+        request_id: None,
     }
 }
 
@@ -109,6 +110,7 @@ fn healed_daemon_response() -> DaemonResponseFrame {
         version_mismatch: false,
         daemon_protocol_version: khive_runtime::daemon::PROTOCOL_VERSION,
         metrics: None,
+        request_id: None,
     }
 }
 

--- a/scripts/perf/mcp_bench_client.py
+++ b/scripts/perf/mcp_bench_client.py
@@ -398,11 +398,23 @@ def raw_daemon_roundtrip(sock_path: str, frame: dict, timeout_s: float = 5.0) ->
         s.close()
 
 
-def base_daemon_frame(ops: str, config_id: str, probe_only: bool = False, metrics_only: bool = False) -> dict:
+def base_daemon_frame(
+    ops: str,
+    config_id: str,
+    probe_only: bool = False,
+    metrics_only: bool = False,
+    request_id: int | None = None,
+) -> dict:
     """Build a DaemonRequestFrame JSON payload. `presentation` /
     `presentation_per_op` / `namespace` have no serde default on the Rust
     struct (unlike the rest), so they must always be present in the wire
     payload or the daemon silently drops the connection.
+
+    `request_id` (khive#948) is the caller's own process-local monotonic
+    counter value for this request, echoed back on the response and stamped
+    into the dispatch's audit event so `join_request_ids` below can pair a
+    client-side sample with its server-side audit row. `None` (the default)
+    sends no id, matching a pre-#948 caller.
     """
     return {
         "ops": ops,
@@ -418,7 +430,73 @@ def base_daemon_frame(ops: str, config_id: str, probe_only: bool = False, metric
         "format": None,
         "format_per_op": None,
         "from_wire": False,
+        "request_id": request_id,
     }
+
+
+# ── Client-side request_id join (khive#948 design note §4) ──────────────────
+
+
+def join_request_ids(samples: list[dict], audit_events: list[dict]) -> list[dict]:
+    """Join client-side per-request samples to server-side audit events by
+    `request_id`, per the khive#948 design note's §4 client-side join
+    procedure.
+
+    `samples`: one dict per request the harness sent, each carrying at least
+    `request_id` (the value the harness generated and put on the frame) and
+    `client_send_ts`/`client_recv_ts` (or any other client-measured fields —
+    this function does not read them, only passes them through unchanged).
+
+    `audit_events`: the persisted audit rows read back for the run's
+    namespace/verb/time window (e.g. via `brain.event_counts` or a direct
+    event-store query). Each event's `resource.request_id` (if present) is
+    the correlation key; `duration_us` is the server-side dispatch time to
+    pull across for the client/server latency decomposition.
+
+    Returns one dict per input sample, `{**sample, "server_duration_us":
+    int | None, "join_status": str}`:
+      - `"joined"`: exactly one audit event carried this `request_id`;
+        `server_duration_us` is that event's `duration_us`.
+      - `"no_audit_row"`: no audit event in the window carried this
+        `request_id` (talking to a pre-#948 daemon, or the row hasn't landed
+        yet / fell outside the query window). `server_duration_us` is `None`.
+      - `"duplicate_request_id"`: MORE THAN ONE audit event in the window
+        carries this `request_id`. Binding sign-off condition (design note
+        §4 item 7): a process-local counter restarts at the same values
+        across harness restarts, so two runs inside one query window can
+        collide on ids. This is the never-pick-a-row guard — silently
+        joining to either candidate row would be exactly the heuristic join
+        the benchmark Amendment 1 §3 forbids. `server_duration_us` is `None`
+        even though duration data technically exists on the ambiguous rows:
+        it is unattributable, not merely absent.
+
+    A sample with no `request_id` at all (the harness sent the request
+    without one) is not joinable by definition and is returned with
+    `"no_audit_row"` — the same "unavailable" outcome as a request_id that
+    matched nothing, since neither case has an unambiguous server-side row.
+    """
+    matches_by_id: dict[int, list[dict]] = {}
+    for event in audit_events:
+        rid = (event.get("resource") or {}).get("request_id")
+        if rid is None:
+            continue
+        matches_by_id.setdefault(rid, []).append(event)
+
+    joined = []
+    for sample in samples:
+        rid = sample.get("request_id")
+        matches = matches_by_id.get(rid, []) if rid is not None else []
+        if rid is None or not matches:
+            status = "no_audit_row"
+            server_duration_us = None
+        elif len(matches) > 1:
+            status = "duplicate_request_id"
+            server_duration_us = None
+        else:
+            status = "joined"
+            server_duration_us = matches[0].get("duration_us")
+        joined.append({**sample, "server_duration_us": server_duration_us, "join_status": status})
+    return joined
 
 
 def probe_metrics_snapshot(sock_path: str) -> dict:

--- a/scripts/perf/test_mcp_bench_client.py
+++ b/scripts/perf/test_mcp_bench_client.py
@@ -504,5 +504,83 @@ class WholeRequestDeadlineTests(unittest.TestCase):
             server.close()
 
 
+
+# ── request_id join (khive#948 design note §4) ────────────────────────────────
+
+class JoinRequestIdsTests(unittest.TestCase):
+    def test_joins_unique_request_id_to_its_audit_event(self):
+        samples = [{"request_id": 1, "client_send_ts": 100.0}]
+        audit_events = [{"resource": {"request_id": 1}, "duration_us": 4200}]
+        joined = mbc.join_request_ids(samples, audit_events)
+        self.assertEqual(joined, [{
+            "request_id": 1,
+            "client_send_ts": 100.0,
+            "server_duration_us": 4200,
+            "join_status": "joined",
+        }])
+
+    def test_no_matching_audit_event_is_unavailable_not_an_error(self):
+        samples = [{"request_id": 2}]
+        joined = mbc.join_request_ids(samples, audit_events=[])
+        self.assertEqual(joined[0]["join_status"], "no_audit_row")
+        self.assertIsNone(joined[0]["server_duration_us"])
+
+    def test_sample_with_no_request_id_is_unavailable(self):
+        samples = [{"request_id": None}]
+        audit_events = [{"resource": {"request_id": 1}, "duration_us": 100}]
+        joined = mbc.join_request_ids(samples, audit_events)
+        self.assertEqual(joined[0]["join_status"], "no_audit_row")
+        self.assertIsNone(joined[0]["server_duration_us"])
+
+    def test_duplicate_request_id_in_window_marks_unavailable_never_picks_a_row(self):
+        """Binding sign-off condition (design note §4 item 7): a process-local
+        counter restarts at the same values across harness restarts, so two
+        runs inside one query window can collide on `request_id`. The join
+        must detect this and mark the sample's server-duration field
+        unavailable rather than silently picking either candidate row —
+        that heuristic pick is exactly what Amendment 1 §3 forbids.
+
+        Fixture: two distinct audit events (different `duration_us`, as they
+        would be from two different harness runs) both carry
+        `request_id: 5`.
+        """
+        samples = [{"request_id": 5, "run": "second-run"}]
+        audit_events = [
+            {"resource": {"request_id": 5}, "duration_us": 1000},  # from an earlier, colliding run
+            {"resource": {"request_id": 5}, "duration_us": 2000},  # this run's own row
+        ]
+        joined = mbc.join_request_ids(samples, audit_events)
+        self.assertEqual(len(joined), 1)
+        self.assertEqual(joined[0]["join_status"], "duplicate_request_id")
+        self.assertIsNone(
+            joined[0]["server_duration_us"],
+            "must never pick either candidate row's duration_us on a request_id collision",
+        )
+
+    def test_duplicate_guard_does_not_affect_other_samples_unique_ids(self):
+        samples = [{"request_id": 5}, {"request_id": 6}]
+        audit_events = [
+            {"resource": {"request_id": 5}, "duration_us": 1000},
+            {"resource": {"request_id": 5}, "duration_us": 2000},
+            {"resource": {"request_id": 6}, "duration_us": 300},
+        ]
+        joined = mbc.join_request_ids(samples, audit_events)
+        by_id = {j["request_id"]: j for j in joined}
+        self.assertEqual(by_id[5]["join_status"], "duplicate_request_id")
+        self.assertIsNone(by_id[5]["server_duration_us"])
+        self.assertEqual(by_id[6]["join_status"], "joined")
+        self.assertEqual(by_id[6]["server_duration_us"], 300)
+
+    def test_audit_event_with_no_request_id_key_is_ignored_not_a_none_match(self):
+        # A pre-#948 audit row (or a non-benchmark caller's row) carries no
+        # `request_id` key at all in its `resource` object. It must never be
+        # treated as matching a sample whose own request_id happens to be
+        # absent/None.
+        samples = [{"request_id": 7}]
+        audit_events = [{"resource": {"work_class": "interactive"}, "duration_us": 999}]
+        joined = mbc.join_request_ids(samples, audit_events)
+        self.assertEqual(joined[0]["join_status"], "no_audit_row")
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Implements #948 per the SIGNED design note at
`.khive/workspaces/20260713/948-correlation-id/DESIGN-NOTE.md` (gates
Benchmark Program SPEC Amendment 1 §3).

## Conformance to the design note, point by point

- **§2.1 id type**: `request_id: Option<u64>`, a plain caller-supplied value
  (not daemon-minted, not a UUID). No new type introduced.
- **§2.2 caller-supplied**: `DaemonRequestFrame.request_id` is set by the
  caller and echoed back unchanged on `DaemonResponseFrame.request_id` —
  never daemon-assigned.
- **§2.3 versioning**: `#[serde(default)]` on both frame fields, matching the
  `metrics_only`/`format`/`format_per_op` (request) and
  `metrics`/`served_config_id` (response) precedent. `PROTOCOL_VERSION`
  stays at 3 — no bump. Verified in both directions: old-client → new-daemon
  (`frame_serde_defaults_metrics_fields_when_absent` extended to assert
  `request_id` defaults to `None`) and the new field round-trips when
  present (`request_id_echoed_on_success_and_error_arms`).
- **§2.4 MetricsSnapshot excluded**: no `request_id`-shaped field added to
  `MetricsSnapshot` — a `metrics_only` probe never reaches ops-dispatch and
  has no single request to attribute a gauge read to.
- **§3 audit-event payload shape**: `request_id` threaded into
  `RequestIdentity` (`crates/khive-runtime/src/pack.rs`) and read once at the
  top of `dispatch_with_identity`, then passed into
  `crate::cost_unit::resource_payload` / `base_resource_payload` so it lands
  in `resource.request_id` next to `work_class`/`cost_unit`. Stamped on all
  four §3 audit-append sites: denied (`EventOutcome::Denied`), the ordinary
  success/error deferred append, the singleton-`link` v2-enrichment success
  path (and its v1 fallback), and the no-pack-owns-this-verb error path.
  Absence has exactly one meaning (no id supplied) — never conditionally
  omitted on an otherwise-successful row, unlike `cost_unit`.
- **§4 client join procedure**: added `join_request_ids(samples,
  audit_events)` to the shared bench client module
  (`scripts/perf/mcp_bench_client.py`), plus `request_id` support in
  `base_daemon_frame`.
  - **§4 item 7, binding sign-off condition**: the join detects a
    `request_id` matching more than one audit event in the query window and
    marks those samples' `server_duration_us` unavailable (`join_status:
    "duplicate_request_id"`) rather than picking either row. Test fixture
    `test_duplicate_request_id_in_window_marks_unavailable_never_picks_a_row`
    in `scripts/perf/test_mcp_bench_client.py` constructs two audit events
    sharing one `request_id` (simulating a counter collision across harness
    restarts) and asserts the guard fires; a companion test proves the guard
    is scoped to the colliding id only and does not affect other samples'
    unique ids.
- **§5 non-goals**: no distributed tracing, no cross-process propagation, no
  new persistence (rides inside the existing audit event's `resource`
  object), no multiplexed/pipelined transport change — none of this PR's
  code introduces any of these.
- **§6 implementation plan / one-PR shape**: this PR covers the
  `khive-runtime`/`khive-mcp` frame + audit-stamping + client-plumbing
  changes as one cohesive wire-format change, per the note's stated PR
  shape. `wire_daemon_frame` (`khive-mcp/src/server.rs`) reads
  `RequestParams::request_id` (a new optional tool-param field) onto the
  frame; `try_forward_inner`/`map_response`
  (`khive-mcp/src/daemon.rs`) pass the field through unchanged (no new
  logic needed beyond the struct field existing); `probe_daemon_identity`'s
  probe frames leave `request_id: None`, matching the note. The bench-join
  `join_request_ids` helper (harness-side, §4/§6) is included here rather
  than deferred, since the design note's binding sign-off condition (item 7)
  specifically requires a proven test fixture — it doesn't touch the actual
  `bench_pipeline_daemon.py`/`bench_load_harness.py` driver loops (counter
  wiring into the live driver scripts remains the follow-up per §6's
  sequencing note).

## Gates (run from `crates/`, `CARGO_TARGET_DIR` exported)

- `cargo fmt --all -- --check` — clean
- `cargo clippy -p khive-mcp --all-targets -- -D warnings` — clean
- `cargo clippy --workspace --all-targets -- -D warnings` — clean (kkernel
  also constructs these frame/param types at ~20 call sites; updated for the
  new field)
- `cargo test -p khive-mcp` — 213 lib + 113 integration, all pass
- `cargo test -p khive-runtime` — 840 + 2 + 69 pass, 5 ignored (pre-existing)
- `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps -p khive-mcp` and
  `-p khive-runtime` — clean
- `uv run python -m pytest scripts/perf/test_mcp_bench_client.py` (also ran
  via stdlib `unittest`) — 42 passed, including 6 new `join_request_ids`
  tests

## Test plan

- [x] `daemon.rs` round-trip: `request_id: Some(n)` echoed on success, the
      real ops-dispatch error arm, and the `config_mismatch` rejection arm
- [x] `daemon.rs` serde back-compat: absent `request_id` decodes to `None`
      on both frame types
- [x] `pack.rs`/`cost_unit.rs`: `resource.request_id` present/absent exactly
      matching the supplied id, across success, link-success, error, and
      denied outcomes
- [x] `server.rs`: `wire_daemon_frame` unit test forwarding `request_id`
- [x] `mcp_bench_client.py`: duplicate-`request_id` guard fixture (binding
      sign-off condition)

Head SHA: `bed89675`
