### PR TITLE
fix(ci): harden reliability and reduce PR cost

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -45,6 +45,7 @@ jobs:
   enable-auto-merge:
     name: Enable auto-merge
     runs-on: ubuntu-latest
+    timeout-minutes: 5
 
     # Guard: only bot-authored, non-draft PRs when the variable is set.
     # Ocean flips LEO_AUTOMERGE_ENABLED to activate; flip back to deactivate.

--- a/.github/workflows/bench-1m.yml
+++ b/.github/workflows/bench-1m.yml
@@ -66,6 +66,7 @@ jobs:
   ann-ci-gate:
     name: ANN structural regression gate (synthetic, hermetic)
     runs-on: ubuntu-latest
+    timeout-minutes: 20
 
     # BLOCKING: this gate must not be bypassed. Structural ANN regression
     # (recall collapse, broken build) must block the PR. Infra failures
@@ -120,6 +121,7 @@ jobs:
   bench-1m-sift:
     name: Vamana SIFT-1M scale-proof (banked, manual)
     runs-on: ubuntu-latest
+    timeout-minutes: 180
 
     # This job is workflow_dispatch-only (see 'on' triggers above, which do
     # not include pull_request/push for this job path). It runs gracefully

--- a/.github/workflows/bench-pipeline.yml
+++ b/.github/workflows/bench-pipeline.yml
@@ -36,6 +36,7 @@ jobs:
   pipeline-gate:
     name: Pipeline Regression Gate
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     defaults:
       run:
         working-directory: crates

--- a/.github/workflows/bench-track.yml
+++ b/.github/workflows/bench-track.yml
@@ -47,12 +47,12 @@ env:
   BENCH_BOT_EMAIL: khive-bench-bot@users.noreply.github.com
 
 concurrency:
-  group: bench-track-${{ github.event_name }}-${{ github.ref }}
-  # Main runs are never cancelled in progress. GitHub keeps at most one
-  # pending run per group, so merge bursts collapse queued runs to the latest
-  # main commit; that latest commit gets the full pass when the active run
-  # finishes instead of every new merge starving the suite indefinitely.
-  # Superseded PR measurements may be cancelled to avoid wasting runners.
+  # A main/release push owns a SHA-specific group so a merge burst cannot
+  # replace an older pending data point. The publisher already retries
+  # perf-data push races, so overlapping push runs remain lossless. PR runs
+  # stay ref-grouped and superseded measurements may be cancelled to avoid
+  # wasting runners.
+  group: bench-track-${{ github.event_name }}-${{ github.event_name == 'pull_request' && github.ref || github.sha }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:

--- a/.github/workflows/ci-infra-retry.yml
+++ b/.github/workflows/ci-infra-retry.yml
@@ -1,0 +1,155 @@
+name: CI infra retry
+
+# Retry only a first-attempt CI failure on a trusted main push when every
+# failing leaf job died in runner setup before repository code ran. Code/test
+# failures are deliberately excluded: a green retry must not hide a flake.
+# If matrix fail-fast cancelled a sibling, rerun the whole workflow so that
+# cancellation cannot leave main red after the failed job recovers.
+on:
+  workflow_run:
+    workflows: [CI]
+    types: [completed]
+    branches: [main]
+
+permissions:
+  actions: write
+  contents: read
+
+concurrency:
+  group: ci-infra-retry-${{ github.event.workflow_run.id }}
+  cancel-in-progress: false
+
+jobs:
+  retry-failed-jobs:
+    name: Retry first-attempt infrastructure failures
+    if: >-
+      github.event.workflow_run.event == 'push' &&
+      github.event.workflow_run.conclusion == 'failure' &&
+      github.event.workflow_run.head_branch == 'main' &&
+      github.event.workflow_run.run_attempt == 1
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Inspect failed jobs and retry setup-only failures once
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPOSITORY: ${{ github.repository }}
+          RUN_ID: ${{ github.event.workflow_run.id }}
+        run: |
+          set -euo pipefail
+
+          api_version="2026-03-10"
+          run_json="$(gh api \
+            -H "X-GitHub-Api-Version: ${api_version}" \
+            "repos/${REPOSITORY}/actions/runs/${RUN_ID}")"
+          attempt="$(jq -r '.run_attempt' <<<"$run_json")"
+          if [ "$attempt" != "1" ]; then
+            echo "Run ${RUN_ID} is attempt ${attempt}; retry budget is exhausted."
+            exit 0
+          fi
+
+          jobs_json="$(gh api \
+            -H "X-GitHub-Api-Version: ${api_version}" \
+            "repos/${REPOSITORY}/actions/runs/${RUN_ID}/attempts/${attempt}/jobs?per_page=100")"
+
+          # CI gate is an aggregate consequence, not a leaf failure. An
+          # infrastructure-shaped leaf has no steps, or exactly one failed
+          # internal "Set up job" step. Any repository/action step failure
+          # makes this run ineligible for automatic recovery.
+          failed_count="$(jq '[
+            .jobs[]
+            | select(.conclusion == "failure" and .name != "CI gate")
+          ] | length' <<<"$jobs_json")"
+          infra_count="$(jq '[
+            .jobs[]
+            | select(.conclusion == "failure" and .name != "CI gate")
+            | select(
+                ((.steps // []) | length) == 0
+                or (
+                  ((.steps // []) | length) == 1
+                  and .steps[0].name == "Set up job"
+                  and .steps[0].conclusion == "failure"
+                )
+              )
+          ] | length' <<<"$jobs_json")"
+          gate_failed_count="$(jq '[
+            .jobs[]
+            | select(.conclusion == "failure" and .name == "CI gate")
+          ] | length' <<<"$jobs_json")"
+          gate_infra_count="$(jq '[
+            .jobs[]
+            | select(.conclusion == "failure" and .name == "CI gate")
+            | select(
+                ((.steps // []) | length) == 0
+                or (
+                  ((.steps // []) | length) == 1
+                  and .steps[0].name == "Set up job"
+                  and .steps[0].conclusion == "failure"
+                )
+              )
+          ] | length' <<<"$jobs_json")"
+          cancelled_count="$(jq '[
+            .jobs[]
+            | select(.conclusion == "cancelled" and .name != "CI gate")
+          ] | length' <<<"$jobs_json")"
+          failed_names="$(jq -r '[
+            .jobs[]
+            | select(.conclusion == "failure")
+            | .name
+          ] | join(", ")' <<<"$jobs_json")"
+          infra_names="$(jq -r '[
+            .jobs[]
+            | select(.conclusion == "failure")
+            | select(
+                ((.steps // []) | length) == 0
+                or (
+                  ((.steps // []) | length) == 1
+                  and .steps[0].name == "Set up job"
+                  and .steps[0].conclusion == "failure"
+                )
+              )
+            | .name
+          ] | join(", ")' <<<"$jobs_json")"
+
+          # A normally failing CI gate only reflects a failed dependency and
+          # is ignored. If it is the sole failure and itself dies in setup,
+          # however, it is the infrastructure failure that needs recovery.
+          eligible=false
+          if [ "$failed_count" -gt 0 ] \
+            && [ "$failed_count" -eq "$infra_count" ]; then
+            eligible=true
+          elif [ "$failed_count" -eq 0 ] \
+            && [ "$gate_failed_count" -gt 0 ] \
+            && [ "$gate_failed_count" -eq "$gate_infra_count" ]; then
+            eligible=true
+          fi
+
+          if [ "$eligible" != true ]; then
+            {
+              echo "### CI infra retry: no automatic retry"
+              echo
+              echo "Run ${RUN_ID} had ${failed_count} failed leaf job(s), ${infra_count} setup-only leaf failure(s), ${gate_infra_count}/${gate_failed_count} setup-only CI gate failure(s), and ${cancelled_count} cancelled leaf job(s)."
+              echo "Failed jobs: ${failed_names:-none}."
+            } >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
+          if [ "$cancelled_count" -eq 0 ]; then
+            rerun_endpoint="rerun-failed-jobs"
+            rerun_scope="failed jobs"
+          else
+            # GitHub's failed-jobs endpoint does not include jobs cancelled by
+            # matrix fail-fast. A full rerun restores that lost sibling lane.
+            rerun_endpoint="rerun"
+            rerun_scope="the full workflow (${cancelled_count} cancelled leaf job(s))"
+          fi
+
+          gh api --method POST \
+            -H "X-GitHub-Api-Version: ${api_version}" \
+            "repos/${REPOSITORY}/actions/runs/${RUN_ID}/${rerun_endpoint}"
+          {
+            echo "### CI infra retry requested"
+            echo
+            echo "Re-running ${rerun_scope} for run ${RUN_ID} after setup-only failure(s): ${infra_names}."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,23 +3,109 @@ name: CI
 on:
   push:
     branches: [main, "integration/**"]
+  # Keep pull_request (not pull_request_target): GitHub's first-time-contributor
+  # approval gate must remain in front of workflows from external forks.
   pull_request:
     branches: [main, "integration/**"]
+  workflow_dispatch:
+  schedule:
+    - cron: "17 6 * * *"
 
 env:
   CARGO_TERM_COLOR: always
 
 jobs:
+  # timeout-minutes starts after a runner is assigned; it bounds stuck execution,
+  # but GitHub does not apply it while a job is still queued.
+  automerge-push-guard:
+    name: Auto-merge push guard
+    # Run immediately from the synchronize payload. Comparing enabledAt with
+    # the push-time PR update makes reruns idempotent and prevents a request
+    # deliberately re-armed after review from being disabled by a delayed
+    # runner. CI gate depends on this job, so mutation failure is fail-closed.
+    if: >-
+      github.event_name == 'pull_request' &&
+      github.event.action == 'synchronize' &&
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      github.event.pull_request.user.type == 'User' &&
+      github.event.pull_request.auto_merge != null
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Disable stale auto-merge request
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPOSITORY_OWNER: ${{ github.repository_owner }}
+          REPOSITORY_NAME: ${{ github.event.repository.name }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PUSH_UPDATED_AT: ${{ github.event.pull_request.updated_at }}
+        run: |
+          set -euo pipefail
+
+          # Re-read current state because the request may have been disabled or
+          # deliberately re-armed while this job waited for a runner.
+          # shellcheck disable=SC2016
+          pr_json="$(gh api graphql \
+            -f query='query($owner: String!, $name: String!, $number: Int!) {
+              repository(owner: $owner, name: $name) {
+                pullRequest(number: $number) {
+                  id
+                  autoMergeRequest { enabledAt }
+                }
+              }
+            }' \
+            -f owner="$REPOSITORY_OWNER" \
+            -f name="$REPOSITORY_NAME" \
+            -F number="$PR_NUMBER")"
+
+          current_enabled_at="$(jq -r '.data.repository.pullRequest.autoMergeRequest.enabledAt // empty' <<<"$pr_json")"
+          if [ -z "$current_enabled_at" ]; then
+            echo "Auto-merge is already disabled for PR #${PR_NUMBER}."
+            exit 0
+          fi
+          enabled_epoch="$(date --date="$current_enabled_at" +%s)"
+          push_epoch="$(date --date="$PUSH_UPDATED_AT" +%s)"
+          if [ "$enabled_epoch" -gt "$push_epoch" ]; then
+            echo "Auto-merge was re-armed after this push; preserving the reviewed request."
+            exit 0
+          fi
+
+          pull_request_id="$(jq -r '.data.repository.pullRequest.id' <<<"$pr_json")"
+          # shellcheck disable=SC2016
+          gh api graphql \
+            -f query='mutation($pullRequestId: ID!) {
+              disablePullRequestAutoMerge(input: {pullRequestId: $pullRequestId}) {
+                pullRequest { number }
+              }
+            }' \
+            -f pullRequestId="$pull_request_id" >/dev/null
+
+          {
+            echo "### Auto-merge disabled"
+            echo
+            echo "PR #${PR_NUMBER} received a new push. Re-review it before arming auto-merge again."
+          } >> "$GITHUB_STEP_SUMMARY"
+
   ci:
     name: CI
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 45
     strategy:
+      # A fast failure cancels the sibling OS to control runner cost. The tradeoff
+      # is that a macOS-only failure may need a second run after Linux is fixed.
+      fail-fast: true
       matrix:
         os: [ubuntu-latest, macos-latest]
     defaults:
       run:
         working-directory: crates
     env:
+      # PRs use a focused macOS portability lane. Push, nightly, and manually
+      # dispatched runs retain the full suite on both operating systems.
+      CI_SUITE: ${{ github.event_name == 'pull_request' && matrix.os == 'macos-latest' && 'macos-pr' || 'full' }}
       # CI gates do not need full debuginfo. line-tables-only keeps file:line
       # in test backtraces while cutting most of the target-dir and linker
       # footprint that filled the ubuntu runner disk (ENOSPC surfaces as
@@ -52,26 +138,68 @@ jobs:
           # line-tables-only profile; restoring them would defeat the disk cap.
           key: line-tables
       - uses: denoland/setup-deno@v2
+        if: env.CI_SUITE == 'full'
         with:
           deno-version: v2.x
       - uses: astral-sh/setup-uv@v5
-      - run: ../scripts/ci.sh
+        if: env.CI_SUITE == 'full'
+      - name: macOS PR compile check
+        if: env.CI_SUITE == 'macos-pr'
+        run: ../scripts/ci.sh macos-pr-check
+      - name: macOS PR platform tests
+        if: env.CI_SUITE == 'macos-pr'
+        run: ../scripts/ci.sh macos-pr-tests
+      - name: Forward-deployed crate checks
+        if: env.CI_SUITE == 'full'
+        run: ../scripts/ci.sh forward-deployed
+      - name: Format, SQL, and ADR lints
+        if: env.CI_SUITE == 'full'
+        run: ../scripts/ci.sh lint
+      - name: No-stub guard
+        if: env.CI_SUITE == 'full'
+        run: ../scripts/ci.sh no-stubs
+      - name: Clippy
+        if: env.CI_SUITE == 'full'
+        run: ../scripts/ci.sh clippy
+      # Rustdoc is already the separately gated doc-build job below; keep it in
+      # ci.sh's local all-mode without paying for duplicate per-OS CI builds.
+      - name: Workspace tests
+        if: env.CI_SUITE == 'full'
+        run: ../scripts/ci.sh tests
+      - name: Channel-email feature tests
+        if: env.CI_SUITE == 'full'
+        run: ../scripts/ci.sh channel-email
+      - name: No-default-features check
+        if: env.CI_SUITE == 'full'
+        run: ../scripts/ci.sh no-default-features
+      - name: Release build
+        if: env.CI_SUITE == 'full'
+        run: ../scripts/ci.sh release
+      - name: Contract tests
+        if: env.CI_SUITE == 'full'
+        run: ../scripts/ci.sh contract-tests
+      - name: Deno tests
+        if: env.CI_SUITE == 'full'
+        run: ../scripts/ci.sh deno-tests
+      - name: Smoke tests
+        if: env.CI_SUITE == 'full'
+        run: ../scripts/ci.sh smoke-tests
+      - name: Vector smoke test
+        if: env.CI_SUITE == 'full'
+        run: ../scripts/ci.sh vector-smoke
+      - name: khive-contract suite
+        if: env.CI_SUITE == 'full'
+        run: ../scripts/ci.sh contract-suite
 
   supply-chain:
     name: Supply-chain (cargo-deny)
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v7
-      - uses: EmbarkStudios/cargo-deny-action@v2
-        with:
-          manifest-path: crates/Cargo.toml
-          command: check bans licenses sources
-      # Advisory/CVE gate: cargo-deny 0.19.9+ parses CVSS 4.0 entries in the 2026
-      # RustSec DB (0.18.x fails to load the DB entirely). cargo-deny-action@v2
-      # bakes 0.19.8 into its image and exposes NO input to override the binary
-      # version (it has no `deny-version` input), so we install the pinned binary
-      # ourselves rather than depend on the image version.
-      #
+      # cargo-deny 0.19.9+ parses CVSS 4.0 entries in the 2026 RustSec DB;
+      # 0.18.x fails to load the DB entirely. One pinned binary runs every check
+      # class so the supply-chain gate cannot drift between two implementations.
       # The installer action is pinned to an immutable commit SHA (not the mutable
       # @v2 tag), and the next step ASSERTS the resolved version is exactly 0.19.9
       # before gating. In an autonomous-merge model logs are not review: if the
@@ -82,14 +210,15 @@ jobs:
         uses: taiki-e/install-action@9e1e5806d4a4822de933115878265be9aaa786d9 # v2.82.2
         with:
           tool: cargo-deny@0.19.9
-      - name: cargo-deny advisories (hard gate)
+      - name: cargo-deny 0.19.9 (hard gate)
         run: |
           test "$(cargo-deny --version)" = "cargo-deny 0.19.9"
-          cargo deny --manifest-path crates/Cargo.toml check advisories
+          cargo deny --manifest-path crates/Cargo.toml --all-features check bans licenses sources advisories
 
   data-leak-guard:
     name: JSON/JSONL data-leak guard
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v7
       - name: Scan whole tree for corpus files
@@ -98,6 +227,7 @@ jobs:
   secret-scan:
     name: Secret scan (gitleaks)
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v7
         with:
@@ -112,6 +242,7 @@ jobs:
   docs:
     name: Docs lint
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v7
       - uses: denoland/setup-deno@v2
@@ -123,6 +254,7 @@ jobs:
   marketplace:
     name: Marketplace example validator
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-python@v6
@@ -134,6 +266,7 @@ jobs:
   doc-build:
     name: Doc build (-D warnings)
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     defaults:
       run:
         working-directory: crates
@@ -150,6 +283,7 @@ jobs:
   dependency-review:
     name: Dependency review
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     # Declare the read scope the action needs explicitly so the gate does not
     # depend on ambient GITHUB_TOKEN defaults (an org policy could tighten them).
     # No pull-requests:write — comment-summary-in-pr is not enabled.
@@ -184,6 +318,7 @@ jobs:
   wasm-parity:
     name: wasm-parity (khive-changeset)
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     defaults:
       run:
         working-directory: crates
@@ -239,6 +374,7 @@ jobs:
   vamana-portability:
     name: vamana portability (ADR-110 Layer A)
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     defaults:
       run:
         working-directory: crates
@@ -259,6 +395,7 @@ jobs:
   coverage-ratchet:
     name: Coverage ratchet
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     # Read-only gate: fails a PR whose line coverage regresses below the committed
     # baseline (coverage-baseline.txt). It does NOT push to main — the baseline is
     # raised only by an explicit PR that edits coverage-baseline.txt, so every
@@ -319,7 +456,9 @@ jobs:
   ci-gate:
     name: CI gate
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     needs:
+      - automerge-push-guard
       - ci
       - supply-chain
       - data-leak-guard

--- a/crates/Cargo.toml
+++ b/crates/Cargo.toml
@@ -72,7 +72,7 @@ async-imap = "0.9"
 async-native-tls = "0.5"
 mail-parser = "0.9"
 rusqlite = { version = "0.33" }
-anyhow = "1.0"
+anyhow = "1.0.103"
 thiserror = "2.0"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
@@ -89,7 +89,7 @@ rand_distr = "0.4"
 toml = "0.8"
 criterion = { version = "0.5", features = ["html_reports", "async_tokio"] }
 rayon = "1.10"
-memmap2 = "0.9"
+memmap2 = "0.9.11"
 bytemuck = "1.16"
 unicode-segmentation = "1.11"
 rust-stemmers = "1.2"

--- a/crates/khive-db/src/stores/blob.rs
+++ b/crates/khive-db/src/stores/blob.rs
@@ -81,7 +81,15 @@ fn crosses_floor(available: u64, required_write_bytes: u64, floor_bytes: u64) ->
     available.saturating_sub(required_write_bytes) < floor_bytes
 }
 
-fn put_blocking(root: &Path, floor_bytes: u64, bytes: Vec<u8>) -> StorageResult<ContentRef> {
+fn put_blocking_with_space_probe<F>(
+    root: &Path,
+    floor_bytes: u64,
+    bytes: Vec<u8>,
+    available_space: F,
+) -> StorageResult<ContentRef>
+where
+    F: FnOnce(&Path) -> std::io::Result<u64>,
+{
     let digest = blake3::hash(&bytes);
     let content_ref = ContentRef::from_digest_bytes(digest.as_bytes());
     let target = shard_path(root, &content_ref);
@@ -94,7 +102,7 @@ fn put_blocking(root: &Path, floor_bytes: u64, bytes: Vec<u8>) -> StorageResult<
     }
 
     let required_write_bytes = bytes.len() as u64;
-    let available = fs4::available_space(root).map_err(|e| map_io_err(e, "put_check_space"))?;
+    let available = available_space(root).map_err(|e| map_io_err(e, "put_check_space"))?;
     if crosses_floor(available, required_write_bytes, floor_bytes) {
         return Err(StorageError::CapacityFloor {
             capability: StorageCapability::Blob,
@@ -139,6 +147,10 @@ fn put_blocking(root: &Path, floor_bytes: u64, bytes: Vec<u8>) -> StorageResult<
         .map_err(|e| map_io_err(e.error, "put_persist"))?;
 
     Ok(content_ref)
+}
+
+fn put_blocking(root: &Path, floor_bytes: u64, bytes: Vec<u8>) -> StorageResult<ContentRef> {
+    put_blocking_with_space_probe(root, floor_bytes, bytes, |path| fs4::available_space(path))
 }
 
 fn walk_blob_files(root: &Path) -> std::io::Result<Vec<(ContentRef, PathBuf)>> {
@@ -589,34 +601,19 @@ mod tests {
         assert!(!crosses_floor(10, 100, 0));
     }
 
-    #[tokio::test]
-    async fn put_refuses_a_write_that_would_cross_the_floor_even_though_available_alone_clears_it()
-    {
-        // Integration-level companion to the pure `crosses_floor` tests
-        // above: proves `FsBlobStore::put` actually wires the write-size-
-        // aware check through end-to-end. Uses a generous margin/cushion
-        // (128 MiB total) rather than an exact boundary, because an earlier
-        // version of this test pinned the floor to the exact
-        // `fs4::available_space` reading and flaked: on this shared,
-        // heavily-loaded dev machine, `fs4::available_space` was observed to
-        // shift by tens of MB between two calls milliseconds apart (other
-        // agents' concurrent builds). A floor-only check would still pass
-        // here (available comfortably clears the floor by MARGIN bytes);
-        // the write-size-aware check must reject once the payload's own
-        // CUSHION-sized excess is subtracted.
-        const MARGIN: u64 = 64 * 1024 * 1024;
-        const CUSHION: u64 = 64 * 1024 * 1024;
+    #[test]
+    fn put_refuses_a_write_that_would_cross_the_floor_even_though_available_alone_clears_it() {
         let dir = tempfile::tempdir().unwrap();
         let root = dir.path().join("blobs");
         fs::create_dir_all(&root).unwrap();
-        let available = fs4::available_space(&root).unwrap();
-        let floor = available.saturating_sub(MARGIN);
-        let store = FsBlobStore::new(root, floor).unwrap();
 
-        let err = store
-            .put(vec![7u8; (MARGIN + CUSHION) as usize])
-            .await
-            .unwrap_err();
+        // Use the same blocking path as `FsBlobStore::put`, with a fixed
+        // capacity snapshot: 101 bytes clears a 100-byte floor by itself,
+        // but a pending two-byte write would leave only 99 bytes. Sampling
+        // the host-wide APFS free-space gauge here made the old test flaky:
+        // unrelated cleanup could legitimately replenish more than its
+        // 64 MiB cushion between the test's sample and the put's sample.
+        let err = put_blocking_with_space_probe(&root, 100, vec![7u8; 2], |_| Ok(101)).unwrap_err();
         assert!(
             matches!(err, StorageError::CapacityFloor { .. }),
             "a write-size-aware floor check must reject a write that pushes the volume \
@@ -624,62 +621,29 @@ mod tests {
         );
     }
 
-    #[tokio::test]
-    async fn concurrent_puts_cannot_jointly_breach_the_floor_via_a_stale_snapshot() {
-        // Pin the floor so at most ONE `payload_len`-sized
-        // write may land before the floor is crossed. Fire two DIFFERENT
-        // (non-deduping) payloads of that size concurrently. Before the
-        // per-root `write_lock`, both puts could independently read the SAME
-        // pre-write `available_space` snapshot, both pass their own
-        // write-size-aware check against it (neither sees the other's
-        // pending write), and both actually write — jointly breaching the
-        // floor. With serialization, the second put's check only runs after
-        // the first put's write has actually landed on disk, so it observes
-        // the reduced space. The decisive, noise-tolerant invariant is that
-        // BOTH can never succeed (under the pre-fix code, both reliably
-        // would, since the floor is deliberately set a full `payload_len`
-        // below the pre-test reading and neither write's own size was
-        // subtracted): assert at most one success and at least one
-        // rejection, rather than pinning an exact 1-success/1-reject split,
-        // since which side of the boundary a given put lands on is
-        // legitimately sensitive to real, unrelated disk churn on a shared
-        // dev/CI box. `payload_len` (64 MiB) is chosen to dwarf the few-MB
-        // swings observed in this environment.
+    #[test]
+    fn a_later_put_checks_a_fresh_capacity_snapshot() {
         let dir = tempfile::tempdir().unwrap();
         let root = dir.path().join("blobs");
         fs::create_dir_all(&root).unwrap();
-        let available = fs4::available_space(&root).unwrap();
-        let payload_len: u64 = 64 * 1024 * 1024;
-        let floor = available.saturating_sub(payload_len);
-        let store = std::sync::Arc::new(FsBlobStore::new(root, floor).unwrap());
 
-        let a = {
-            let store = store.clone();
-            tokio::spawn(async move { store.put(vec![1u8; payload_len as usize]).await })
-        };
-        let b = {
-            let store = store.clone();
-            tokio::spawn(async move { store.put(vec![2u8; payload_len as usize]).await })
-        };
-        let (result_a, result_b) = (a.await.unwrap(), b.await.unwrap());
+        // Model the two snapshots observed by serialized puts without tying
+        // the assertion to a host-wide free-space gauge. The first two-byte
+        // write may land exactly on the 100-byte floor from a 102-byte
+        // snapshot. A later, different write sees 101 bytes and must refuse.
+        // Mutual exclusion itself is covered deterministically below by the
+        // shared-root lock test; together the tests prove the stale-snapshot
+        // race is closed without relying on unrelated filesystem activity.
+        let first = put_blocking_with_space_probe(&root, 100, vec![1u8; 2], |_| Ok(102));
+        let second = put_blocking_with_space_probe(&root, 100, vec![2u8; 2], |_| Ok(101));
 
-        let successes = [&result_a, &result_b]
-            .into_iter()
-            .filter(|r| r.is_ok())
-            .count();
-        let floor_rejections = [&result_a, &result_b]
-            .into_iter()
-            .filter(|r| matches!(r, Err(StorageError::CapacityFloor { .. })))
-            .count();
         assert!(
-            successes <= 1,
-            "both concurrent puts landed -- the floor was jointly breached by a stale \
-             snapshot race: {result_a:?} / {result_b:?}"
+            first.is_ok(),
+            "the first put may land on the floor: {first:?}"
         );
         assert!(
-            floor_rejections >= 1,
-            "two payload_len writes cannot both fit in a payload_len-sized budget -- at \
-             least one rejection is expected: {result_a:?} / {result_b:?}"
+            matches!(second, Err(StorageError::CapacityFloor { .. })),
+            "the later put must use its lower capacity snapshot: {second:?}"
         );
     }
 
@@ -717,9 +681,8 @@ mod tests {
         // Lock sharing is orthogonal to floor arithmetic -- the same
         // `crosses_floor`/`put_blocking` path runs regardless of which
         // `FsBlobStore` instance calls it, and that arithmetic is already
-        // covered, disk-noise-tolerantly, by
-        // `concurrent_puts_cannot_jointly_breach_the_floor_via_a_stale_snapshot`
-        // (same-instance) and the pure `crosses_floor` unit tests above.
+        // covered deterministically by `a_later_put_checks_a_fresh_capacity_snapshot`
+        // and the pure `crosses_floor` unit tests above.
         //
         // The prior fix's negative proof (B
         // must not reach its own checkpoint) still leaned on a 200ms

--- a/crates/khive-runtime/src/daemon.rs
+++ b/crates/khive-runtime/src/daemon.rs
@@ -1768,17 +1768,13 @@ mod tests {
         );
     }
 
-    /// Test 3: the tx-pin oracle. Uses a
-    /// before/after delta rather than asserting a global `open_tx_count==0`
-    /// baseline — `tx_registry` is a process-wide singleton shared with every
-    /// other test in this binary (including write-path tests elsewhere in
-    /// this crate that register short-lived entries), the same reason
-    /// `track_background_task_count_returns_to_zero_after_completion` above
-    /// asserts a before/after delta on `background_task_count()` rather than
-    /// an absolute value.
-    #[tokio::test]
+    /// Test 3: the tx-pin oracle. The registry is process-global, so an
+    /// unrelated transaction can depart between snapshots and exactly offset
+    /// this test's registration. Keep an owned handle live and assert the
+    /// resulting count floor instead of comparing two points in time.
+    #[test]
     #[serial(tx_registry)]
-    async fn metrics_snapshot_reflects_open_transaction_registry() {
+    fn metrics_snapshot_reflects_open_transaction_registry() {
         let dispatcher = MockDispatch {
             namespace: "local".to_string(),
             config_id: "cfg-tx".to_string(),
@@ -1786,14 +1782,22 @@ mod tests {
             pool: None,
         };
 
+        let departing_handle = khive_storage::tx_registry::register(Some(
+            "daemon_metrics_snapshot_departing_test_tx".to_string(),
+        ));
         let before = build_metrics_snapshot(&dispatcher).open_tx_count;
+        assert!(before >= 1);
 
-        let handle = khive_storage::tx_registry::register(Some("metrics_test_tx".to_string()));
+        let handle = khive_storage::tx_registry::register(Some(
+            "daemon_metrics_snapshot_owned_test_tx".to_string(),
+        ));
+        drop(departing_handle);
+
         let during = build_metrics_snapshot(&dispatcher);
         assert!(
-            during.open_tx_count > before,
-            "open_tx_count must reflect the freshly registered transaction: \
-             before={before} during={}",
+            during.open_tx_count >= 1,
+            "open_tx_count must reflect the live owned transaction despite registry churn: \
+             churn_baseline={before} during={}",
             during.open_tx_count
         );
         assert!(
@@ -1802,19 +1806,12 @@ mod tests {
         );
 
         drop(handle);
-
-        let mut after = during.open_tx_count;
-        for _ in 0..20 {
-            after = build_metrics_snapshot(&dispatcher).open_tx_count;
-            if after <= before {
-                break;
-            }
-            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
-        }
         assert!(
-            after <= before,
-            "open_tx_count must drop back down after the transaction handle is dropped: \
-             before={before} after={after}"
+            !khive_storage::tx_registry::snapshot()
+                .iter()
+                .any(|(_, label)| label.as_deref()
+                    == Some("daemon_metrics_snapshot_owned_test_tx")),
+            "the owned registry entry must disappear when its handle is dropped"
         );
     }
 

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -4,88 +4,193 @@ set -e
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 cd "$SCRIPT_DIR/../crates"
 
-echo "=== Forward-Deployed Crates Check ==="
-# Excluded workspace crates (forward-deployed infrastructure) must still compile,
-# pass clippy under -D warnings across all targets, and pass their test suite.
-RUSTFLAGS="-D warnings" cargo check --manifest-path "$SCRIPT_DIR/../crates/khive-merge/Cargo.toml" --all-targets
-cargo clippy --manifest-path "$SCRIPT_DIR/../crates/khive-merge/Cargo.toml" --all-targets -- -D warnings
-cargo test --manifest-path "$SCRIPT_DIR/../crates/khive-merge/Cargo.toml"
+phase_forward_deployed() {
+    echo "=== Forward-Deployed Crates Check ==="
+    # Excluded workspace crates (forward-deployed infrastructure) must still compile,
+    # pass clippy under -D warnings across all targets, and pass their test suite.
+    RUSTFLAGS="-D warnings" cargo check --manifest-path "$SCRIPT_DIR/../crates/khive-merge/Cargo.toml" --all-targets
+    cargo clippy --manifest-path "$SCRIPT_DIR/../crates/khive-merge/Cargo.toml" --all-targets -- -D warnings
+    cargo test --manifest-path "$SCRIPT_DIR/../crates/khive-merge/Cargo.toml"
+}
 
-echo "=== Format Check ==="
-cargo fmt --all -- --check
+phase_lint() {
+    echo "=== Format Check ==="
+    cargo fmt --all -- --check
 
-echo "=== SQL Lint ==="
-sh "$SCRIPT_DIR/lint-sql.sh"
+    echo "=== SQL Lint ==="
+    sh "$SCRIPT_DIR/lint-sql.sh"
 
-echo "=== ADR Reference Lint ==="
-sh "$SCRIPT_DIR/lint-adr-refs.sh"
+    echo "=== ADR Reference Lint ==="
+    sh "$SCRIPT_DIR/lint-adr-refs.sh"
 
-echo "=== ADR Reference Lint Self-Test ==="
-sh "$SCRIPT_DIR/lint-adr-refs.sh" --self-test
+    echo "=== ADR Reference Lint Self-Test ==="
+    sh "$SCRIPT_DIR/lint-adr-refs.sh" --self-test
+}
 
-echo "=== No-Stub Guard (clippy restriction lints) ==="
-# AST-aware "No stubs. Ever." enforcement. clippy parses the macros, so it is
-# immune to the grep failure modes (spacing like `todo !()`, brace forms like
-# `unimplemented!{}`, macro names inside comments or string literals). Scoped to
-# --lib --bins = shipping source only (excludes tests/benches/examples), matching
-# the prior policy. khive-merge is excluded from the workspace (forward-deployed),
-# so it gets its own pass to preserve coverage.
-NOSTUB_LINTS="-Dclippy::todo -Dclippy::unimplemented -Dclippy::dbg_macro"
-# shellcheck disable=SC2086
-cargo clippy --workspace --lib --bins -- $NOSTUB_LINTS
-# shellcheck disable=SC2086
-cargo clippy --manifest-path "$SCRIPT_DIR/../crates/khive-merge/Cargo.toml" --lib --bins -- $NOSTUB_LINTS
+phase_no_stubs() {
+    echo "=== No-Stub Guard (clippy restriction lints) ==="
+    # AST-aware "No stubs. Ever." enforcement. clippy parses the macros, so it is
+    # immune to the grep failure modes (spacing like `todo !()`, brace forms like
+    # `unimplemented!{}`, macro names inside comments or string literals). Scoped to
+    # --lib --bins = shipping source only (excludes tests/benches/examples), matching
+    # the prior policy. khive-merge is excluded from the workspace (forward-deployed),
+    # so it gets its own pass to preserve coverage.
+    NOSTUB_LINTS="-Dclippy::todo -Dclippy::unimplemented -Dclippy::dbg_macro"
+    # shellcheck disable=SC2086
+    cargo clippy --workspace --lib --bins -- $NOSTUB_LINTS
+    # shellcheck disable=SC2086
+    cargo clippy --manifest-path "$SCRIPT_DIR/../crates/khive-merge/Cargo.toml" --lib --bins -- $NOSTUB_LINTS
+}
 
-echo "=== Clippy ==="
-cargo clippy --workspace --all-targets --all-features -- -D warnings
+phase_clippy() {
+    echo "=== Clippy ==="
+    cargo clippy --workspace --all-targets --all-features -- -D warnings
+}
 
-echo "=== Doc Build (-D warnings) ==="
-# Mirrors the "Doc build" CI job (.github/workflows/ci.yml): intra-doc link
-# breakage and other rustdoc lints are a distinct gate that check/clippy/test
-# do not cover.
-RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --workspace
+phase_docs() {
+    echo "=== Doc Build (-D warnings) ==="
+    # Mirrors the "Doc build" CI job (.github/workflows/ci.yml): intra-doc link
+    # breakage and other rustdoc lints are a distinct gate that check/clippy/test
+    # do not cover.
+    RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --workspace
+}
 
-echo "=== Tests ==="
-cargo test --workspace
+phase_tests() {
+    echo "=== Tests ==="
+    cargo test --workspace
+}
 
-echo "=== Channel-Email Feature Tests (channel-email feature) ==="
-# `--workspace` alone never runs any of the several `#[cfg(feature =
-# "channel-email")]` test modules in khive-mcp (ADR-094 channel lifecycle
-# sequencing, issue #449 cursor_commit gating, bootstrap-floor regressions,
-# etc.) -- the all-features clippy pass above only type-checks them. A prior
-# name filter here (`channel_lifecycle`) ran only one of those modules and
-# silently skipped the rest, including the daemon's durable-cursor
-# regression tests. Run the whole crate under the feature, unfiltered, so
-# every one of those modules fails CI on a regression.
-cargo test -p khive-mcp --features channel-email
+phase_channel_email() {
+    echo "=== Channel-Email Feature Tests (channel-email feature) ==="
+    # `--workspace` alone never runs any of the several `#[cfg(feature =
+    # "channel-email")]` test modules in khive-mcp (ADR-094 channel lifecycle
+    # sequencing, issue #449 cursor_commit gating, bootstrap-floor regressions,
+    # etc.) -- the all-features clippy pass above only type-checks them. A prior
+    # name filter here (`channel_lifecycle`) ran only one of those modules and
+    # silently skipped the rest, including the daemon's durable-cursor
+    # regression tests. Run the whole crate under the feature, unfiltered, so
+    # every one of those modules fails CI on a regression.
+    cargo test -p khive-mcp --features channel-email
+}
 
-echo "=== No-Default-Features Check ==="
-cargo check --workspace --no-default-features
+phase_no_default_features() {
+    echo "=== No-Default-Features Check ==="
+    cargo check --workspace --no-default-features
+}
 
-echo "=== Build (release) ==="
-cargo build --workspace --release
+phase_release() {
+    echo "=== Build (release) ==="
+    cargo build --workspace --release
+}
 
-echo "=== Contract Tests ==="
-python3 "$SCRIPT_DIR/../tests/contract_test.py"
+phase_contract_tests() {
+    echo "=== Contract Tests ==="
+    python3 "$SCRIPT_DIR/../tests/contract_test.py"
+}
 
-echo "=== Deno Tests ==="
-(cd "$SCRIPT_DIR/../cli" && deno test --allow-all .)
+phase_deno_tests() {
+    echo "=== Deno Tests ==="
+    (cd "$SCRIPT_DIR/../cli" && deno test --allow-all .)
+}
 
-echo "=== Smoke Test ==="
-python3 "$SCRIPT_DIR/../tests/smoke_test.py"
-python3 "$SCRIPT_DIR/../tests/smoke_brain.py"
-python3 "$SCRIPT_DIR/../tests/smoke_comm.py"
-python3 "$SCRIPT_DIR/../tests/smoke_knowledge.py"
-python3 "$SCRIPT_DIR/../tests/smoke_schedule.py"
+phase_smoke_tests() {
+    echo "=== Smoke Test ==="
+    python3 "$SCRIPT_DIR/../tests/smoke_test.py"
+    python3 "$SCRIPT_DIR/../tests/smoke_brain.py"
+    python3 "$SCRIPT_DIR/../tests/smoke_comm.py"
+    python3 "$SCRIPT_DIR/../tests/smoke_knowledge.py"
+    python3 "$SCRIPT_DIR/../tests/smoke_schedule.py"
+}
 
-echo "=== Vector Smoke (embed/recall path gate) ==="
-# smoke_vector.py self-guards empirically: it spawns kkernel, attempts one
-# memory.remember, and prints "SKIP: ..." + exits 0 when the embedder is not
-# usable (model weights absent or no engine resolves).  GitHub Actions runners
-# that lack the model weights are unaffected.  Set KHIVE_NO_EMBED=1 to bypass.
-python3 "$SCRIPT_DIR/../tests/smoke_vector.py"
+phase_vector_smoke() {
+    echo "=== Vector Smoke (embed/recall path gate) ==="
+    # smoke_vector.py self-guards empirically: it spawns kkernel, attempts one
+    # memory.remember, and prints "SKIP: ..." + exits 0 when the embedder is not
+    # usable (model weights absent or no engine resolves). GitHub Actions runners
+    # that lack the model weights are unaffected. Set KHIVE_NO_EMBED=1 to bypass.
+    python3 "$SCRIPT_DIR/../tests/smoke_vector.py"
+}
 
-echo "=== Contract Suite (khive-contract) ==="
-(cd "$SCRIPT_DIR/../tests/khive-contract" && uv run pytest -q)
+phase_contract_suite() {
+    echo "=== Contract Suite (khive-contract) ==="
+    (cd "$SCRIPT_DIR/../tests/khive-contract" && uv run pytest -q)
+}
 
-echo "=== CI Passed ==="
+phase_macos_pr_check() {
+    echo "=== macOS PR Compile Check ==="
+    # PRs keep cross-platform compile coverage without paying for the full lint,
+    # release, and end-to-end suite twice. The excluded khive-merge crate needs an
+    # explicit check because it is not a workspace member.
+    cargo check --workspace --all-targets --all-features
+    RUSTFLAGS="-D warnings" cargo check --manifest-path "$SCRIPT_DIR/../crates/khive-merge/Cargo.toml" --all-targets
+}
+
+phase_macos_pr_tests() {
+    echo "=== macOS PR Platform Tests ==="
+    # These crates own the SQLite/filesystem, daemon/process, and native CLI
+    # boundaries where macOS behavior has historically differed from Linux.
+    cargo test -p khive-db -p khive-runtime -p khive-mcp -p khive-pack-git -p kkernel --features khive-mcp/channel-email
+}
+
+run_phase() {
+    case "$1" in
+        forward-deployed) phase_forward_deployed ;;
+        lint) phase_lint ;;
+        no-stubs) phase_no_stubs ;;
+        clippy) phase_clippy ;;
+        docs) phase_docs ;;
+        tests) phase_tests ;;
+        channel-email) phase_channel_email ;;
+        no-default-features) phase_no_default_features ;;
+        release) phase_release ;;
+        contract-tests) phase_contract_tests ;;
+        deno-tests) phase_deno_tests ;;
+        smoke-tests) phase_smoke_tests ;;
+        vector-smoke) phase_vector_smoke ;;
+        contract-suite) phase_contract_suite ;;
+        macos-pr-check) phase_macos_pr_check ;;
+        macos-pr-tests) phase_macos_pr_tests ;;
+        *)
+            echo "Unknown CI phase: $1" >&2
+            echo "Valid phases: forward-deployed lint no-stubs clippy docs tests channel-email no-default-features release contract-tests deno-tests smoke-tests vector-smoke contract-suite macos-pr-check macos-pr-tests" >&2
+            exit 2
+            ;;
+    esac
+}
+
+run_all() {
+    for phase in \
+        forward-deployed \
+        lint \
+        no-stubs \
+        clippy \
+        docs \
+        tests \
+        channel-email \
+        no-default-features \
+        release \
+        contract-tests \
+        deno-tests \
+        smoke-tests \
+        vector-smoke \
+        contract-suite
+    do
+        run_phase "$phase"
+    done
+    echo "=== CI Passed ==="
+}
+
+case "$#" in
+    0) run_all ;;
+    1)
+        if [ "$1" = "all" ]; then
+            run_all
+        else
+            run_phase "$1"
+        fi
+        ;;
+    *)
+        echo "Usage: $0 [phase|all]" >&2
+        exit 2
+        ;;
+esac


### PR DESCRIPTION
> AI-assisted contribution: Codex generated this change and PR description.

## Summary

- Fixes the shared-state daemon metrics flake from run [29248620259](https://github.com/ohdearquant/khive/actions/runs/29248620259) and makes two additional filesystem-capacity tests deterministic.
- Hardens CI against setup-only GitHub outages, cargo-deny action drift, opaque monolithic logs, dropped benchmark data points, unbounded execution, and excessive macOS PR cost.
- Adds a fail-closed stale-auto-merge guard without broadening fork execution, bot automation, or `pull_request_target` permissions.

## Root causes and changes

### Test reliability

- `metrics_snapshot_reflects_open_transaction_registry` compared two snapshots of a process-global registry. An unrelated handle could depart between them and exactly offset the test's new registration. The test now holds its own uniquely labelled handle, asserts live invariants, and verifies that exact entry disappears on drop.
- Full-workspace validation exposed two blob-floor tests whose assertions treated host-wide APFS free-space deltas as test-owned state. Unrelated cleanup could add more than their 64 MiB cushion. A private capacity-probe seam now gives those tests deterministic 2-byte boundary snapshots; production still calls `fs4::available_space`, and the existing event-driven shared-root lock test still proves mutual exclusion.

### Infrastructure-only retry

- Adds `CI infra retry`, triggered only after a failed first-attempt CI run from a trusted `main` push.
- It retries only when every failed leaf job has no executed steps or exactly one failed `Set up job` step. A setup-only failure of `CI gate` itself is also eligible.
- It reruns failed jobs normally; if matrix fail-fast cancelled a sibling, it reruns the full workflow so the cancelled lane is restored.
- Repository/action/test failures are never retried, and the second attempt is a hard stop.

Live classifier replay:

- run 29253301895: setup-only coverage failure -> eligible
- run 29248620259: test failure plus cancelled sibling -> ineligible
- run 29240258302: cargo-deny command failure -> ineligible

### Supply chain

The floating `EmbarkStudios/cargo-deny-action@v2` resolved to a changed action entrypoint/bundled cargo-deny combination that treated `warn` as a subcommand. It duplicated the repository's explicit pin. This removes that layer and runs bans, licenses, sources, and advisories through one asserted cargo-deny 0.19.9 binary.

The current advisory database also required fixed dependency floors:

- `anyhow >= 1.0.103` for RUSTSEC-2026-0190
- `memmap2 >= 0.9.11` for RUSTSEC-2026-0186

### CI visibility and macOS tiering

- `scripts/ci.sh` now exposes named phases while no-argument and `all` modes preserve the existing local gate and phase order.
- GitHub Actions invokes phases as named steps, giving focused logs and timing.
- Pull requests retain full Linux coverage but use a focused macOS portability lane: all-target/all-feature compilation plus the database, runtime, MCP, git-pack, and CLI boundary tests.
- Main/integration pushes, the daily 06:17 UTC run, and manual dispatch retain the full suite on both operating systems.
- Matrix fail-fast remains enabled to control cost; the workflow comment documents that a macOS-only failure may surface one round trip after a fast Linux failure.
- `CI gate` keeps its required name and remains the aggregate check.

### Benchmark and timeout reliability

- Main/release bench tracking now uses SHA-specific concurrency groups, so merge bursts cannot replace pending per-commit data points. PR runs remain ref-grouped and cancellable.
- Explicit execution timeouts now cover CI, the reusable component benchmarks, pipeline/ANN benchmarks, and auto-merge.
- This deliberately does not claim to solve a job orphaned before runner assignment: GitHub job timeouts start only after assignment.

### Stale auto-merge guard

A dependency-free `pull_request/synchronize` job checks same-repository, human-authored PRs only. It never checks out PR code and has job-scoped `pull-requests: write`.

- If the current auto-merge request predates the synchronize event, it disables it.
- If a reviewer deliberately re-arms auto-merge afterward, the later GraphQL `enabledAt` timestamp preserves that request.
- Reruns are idempotent.
- `CI gate` depends on the guard, so API/mutation failure blocks the required aggregate instead of failing open.
- Bot-authored PRs remain under the separately audited autonomous workflow; fork PRs retain the existing manual-approval/read-only boundary.

## Test plan

- [x] `cargo test --manifest-path crates/Cargo.toml --workspace` — complete workspace and doctest pass, zero failures
- [x] `cargo clippy --manifest-path crates/Cargo.toml --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- [x] `actionlint -no-color`
- [x] `shellcheck scripts/ci.sh` and `sh -n scripts/ci.sh`
- [x] `deno fmt --check` for all changed workflows
- [x] asserted cargo-deny 0.19.9 with `--all-features check bans licenses sources advisories`
- [x] `python3 -m unittest scripts.perf.test_publish_ledger -v` — 3/3
- [x] daemon focused test plus five full `khive-runtime` repetitions — 4,180/4,180
- [x] blob module repeated 25 times — 575/575; full `khive-db` library — 334/334
- [x] reduced macOS PR compile and platform-test phases
- [x] pre-commit hooks

## ADR

n/a — operational CI/test fixes; no product or typed-graph contract changes.

## AI-assisted contribution checklist

- [x] Every claim in this PR description matches the actual diff
- [x] Any agent-authored comment / PR body starts with an attribution line
- [x] `cargo test` output included for behavior-changing code
- [x] No typed relation, entity/note kind, supersession, annotation, or namespace behavior changes

## Out of scope

- No blanket nextest migration or automatic test retries. Process-per-test is promising for shared globals, but this workspace has 263 `#[serial]` uses whose in-process locks would not coordinate across nextest processes, plus separate doctest/wasm/coverage contracts. That needs a focused resource-isolation audit; retries should start at zero and become evidence-based rather than masking flakes.
- No privileged scheduled watchdog for pre-run queued/orphaned jobs. The Actions API cannot reliably distinguish an orphan from legitimate runner scarcity, and an automatic cancel/rerun loop would add write authority and runner cost. Existing bounded manual observation remains the fallback for that GitHub-side edge case.
- No required-check rename, ruleset mutation, proactive fork execution, or broadening of the existing bot auto-merge workflow.
