### PR TITLE
fix(gtd): preserve RFC 3339 due fidelity in agent-mode presentation

### DIFF
--- a/crates/khive-pack-gtd/tests/assign.rs
+++ b/crates/khive-pack-gtd/tests/assign.rs
@@ -162,6 +162,56 @@ async fn assign_due_free_text_rejected() {
 }
 
 #[tokio::test]
+async fn assign_due_survives_agent_mode_presentation_round_trip() {
+    // The top-level `due` convenience field returned by gtd.assign (and
+    // echoed by gtd.tasks/gtd.next) must survive Agent-mode presentation
+    // verbatim, not get minute-truncated like a generic top-level timestamp.
+    let pack = pack(rt());
+    let resp = assign(
+        &pack,
+        json!({"title": "ship release", "status": "next", "due": "2026-08-01T09:30:15-04:00"}),
+    )
+    .await;
+    let due = resp["due"]
+        .as_str()
+        .expect("due must be a string")
+        .to_string();
+    chrono::DateTime::parse_from_rfc3339(&due)
+        .unwrap_or_else(|e| panic!("due not RFC 3339: {due}, error: {e}"));
+
+    let presented_assign =
+        khive_runtime::present(resp.clone(), khive_runtime::PresentationMode::Agent, 0);
+    assert_eq!(
+        presented_assign["due"],
+        json!(due),
+        "gtd.assign due must round-trip verbatim through Agent-mode presentation"
+    );
+
+    let tasks = pack
+        .dispatch("gtd.tasks", json!({"status": "next"}))
+        .await
+        .expect("tasks ok");
+    let presented_tasks = khive_runtime::present(tasks, khive_runtime::PresentationMode::Agent, 0);
+    let via_tasks = presented_tasks
+        .as_array()
+        .expect("gtd.tasks response is an array")
+        .iter()
+        .find(|t| t["title"] == "ship release")
+        .expect("assigned task present in gtd.tasks");
+    assert_eq!(via_tasks["due"], json!(due));
+
+    let next = pack.dispatch("gtd.next", json!({})).await.expect("next ok");
+    let presented_next = khive_runtime::present(next, khive_runtime::PresentationMode::Agent, 0);
+    let via_next = presented_next
+        .as_array()
+        .expect("gtd.next response is an array")
+        .iter()
+        .find(|t| t["title"] == "ship release")
+        .expect("assigned task present in gtd.next");
+    assert_eq!(via_next["due"], json!(due));
+}
+
+#[tokio::test]
 async fn assign_due_natural_language_rejected() {
     let pack = pack(rt());
     let err = pack

--- a/crates/khive-runtime/src/presentation.rs
+++ b/crates/khive-runtime/src/presentation.rs
@@ -385,7 +385,11 @@ const LIFECYCLE_NULL_PRESERVE: &[&str] = &[
 /// which `compact_timestamp` rewrote into either a relative string or a
 /// minute-truncated absolute form — either way discarding the seconds and
 /// offset the caller needs to round-trip the exact submitted value (#871).
-const PAYLOAD_TIMESTAMP_FIELDS: &[&str] = &["trigger_at"];
+///
+/// `due` on `gtd.assign`/`gtd.tasks`/`gtd.next` responses is the same shape:
+/// a top-level convenience field mirroring `properties.due`, which
+/// `parse_due` already normalizes to full RFC 3339.
+const PAYLOAD_TIMESTAMP_FIELDS: &[&str] = &["trigger_at", "due"];
 
 /// Score field names that are truncated to 3 significant figures in Agent mode.
 const SCORE_FIELDS: &[&str] = &[
@@ -884,6 +888,18 @@ mod tests {
         let out = agent(v);
         assert_eq!(out["trigger_at"], json!("2026-07-11T19:00:00-04:00"));
         assert_eq!(out["created_at"], json!("2020-01-01T10:30"));
+    }
+
+    #[test]
+    fn agent_does_not_compact_top_level_due() {
+        // gtd.assign/gtd.tasks/gtd.next return the caller-supplied `due` as
+        // a top-level convenience field mirroring `properties.due`; it must
+        // round-trip verbatim through Agent-mode presentation, the same
+        // guarantee already given to `trigger_at`.
+        let due = "2026-08-01T09:30:15-04:00";
+        let v = json!({"due": due});
+        let out = agent(v);
+        assert_eq!(out["due"], json!(due));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fixes #912. `gtd.assign` returns the normalized `properties.due` as a top-level `due` convenience field. Agent-mode presentation (`crates/khive-runtime/src/presentation.rs`) compacts every top-level ISO-like string except field names in `PAYLOAD_TIMESTAMP_FIELDS`, and that allowlist held only `trigger_at` (added for the same defect class in a prior fix). A future task's `due` was therefore minute-truncated (`YYYY-MM-DDTHH:MM`) on the way out, even though `parse_due` already guarantees a full RFC 3339 value with seconds and offset. The nested `properties.due` was unaffected since the `inside_properties` guard protects it separately.

**Root cause**: presentation layer only — not the parser (`parse_due` already normalizes correctly) and not storage (`properties.due` round-trips fine). The loss happens exclusively in `present()`'s Agent-mode timestamp-compaction pass, which treats an unlisted top-level ISO-like field the same as a generic timestamp.

**Fix**: add `"due"` to `PAYLOAD_TIMESTAMP_FIELDS` in `crates/khive-runtime/src/presentation.rs`, mirroring the existing `trigger_at` entry. Minimal, single allowlist addition; no change to parsing, storage, or the render shape for tasks without `due`.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy -p khive-pack-gtd -p khive-runtime --all-targets -- -D warnings`
- [x] `cargo test -p khive-pack-gtd` (includes new `assign_due_survives_agent_mode_presentation_round_trip`: assigns a task with an offset-bearing RFC 3339 `due`, reads it back via `gtd.tasks` and `gtd.next`, re-applies Agent-mode presentation, asserts verbatim round-trip)
- [x] `cargo test -p khive-runtime presentation::` (includes new `agent_does_not_compact_top_level_due` unit test)
- [x] `cargo check --workspace`

🤖 Generated with [Claude Code](https://claude.com/claude-code)