### PR TITLE
chore(release): v0.5.0 workspace bump + CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,137 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.0] - 2026-07-13
+
+### Added
+
+- BlobStore content-addressed blob capability (ADR-111, #922).
+- GQL WHERE operators `CONTAINS`, `STARTS WITH`, `IN`, `IS NOT NULL` (#892).
+- ADR-104 Stage C entity-anchored recall candidate extraction (#881).
+- `resource.cost_unit` emission on runtime operations (ADR-103 Amendment 1, #927).
+- Atomic proposal create plans in `khive-runtime` (#904, #928).
+- Pack-declared entity-type subtype composition at boot (ADR-017, #925).
+- Vamana ADR-110 Layer A feature-gated parallelism with deterministic serial fallback (#896).
+- Request correlation id threaded across daemon frames and audit events (#948, #951).
+- Slow-request and timeout logging for `knowledge` pack compose (#915).
+
+### Changed
+
+- Daemon strict mode now fails a request on fallback instead of degrading silently (#947, #949).
+- Publish pipeline uses topological crate order with path-only cyclic dev-deps (#901).
+- `lattice-embed` and `lattice-fann` dependencies bumped to 0.6.0 (#885).
+
+### Fixed
+
+- `gtd` preserves RFC 3339 due-date fidelity in agent-mode presentation (#956).
+- `brain.event_counts` normalizes the actor filter and adds `counts_by_verb` (#943, #944).
+- `pack-kg` exposes effective list limits (#894, #930).
+- `memory.recall` emits `recall_executed` events (#866, #929).
+- FTS5 metacharacters sanitized in `khive-db` query construction (#916, #932).
+- Fired schedule reminders deliver to the creating actor's inbox (#897).
+- ADR-091 Plank 1 background age sweep over `tx_registry` (#921).
+- `memory.recall` bounded by a fail-soft deadline (#919).
+- `pack-comm` health and probe honor the injected namespace (#914).
+- `pack-schedule` preserves the ISO timezone offset in remind create-response rendering (#911).
+- `pack-kg` create help schema includes the `resource` entity kind (#909).
+- `pack-git` masking applied uniformly to all external-origin ingest fields (#910).
+- Secret gate uses token-boundary trigger matching to stop path-slug false positives (#888).
+- Batched `neighbors` results keyed by the requested node (#891).
+
+## [0.4.0] - 2026-07-12
+
+Published to crates.io on 2026-07-12; backfilled here as the tag and changelog entry did
+not accompany that publish.
+
+### Added
+
+- Workspace entity kind with `contains` edges to git/gtd/session notes (#873, #874).
+- `khive-pack-code` v0 admin-only code-ingest path (ADR-085 Amendment 3, #848).
+- Daemon-resident schedule drain tick with missed-event policy (#782).
+- `resolve_reference` capability and recently-referenced ring (#762).
+- `git.digest` paged ingest with URL clone cache (ADR-088 Amendment 1, #761).
+- ADR-104 Stage A/B serve-time profile projection and bounded per-entity posterior term in
+  recall scoring (#743, #745).
+- Auto-extraction of `entity_names` from the recall query when the caller omits them (#738).
+- `brain.event_counts` windowed event-counts read verb (ADR-103 Stage 1, #737).
+- Daemon audit `duration_us` and phase telemetry, plus `comm.health` resource self-report
+  (ADR-103 Stage 1, #732).
+- MCP bridge protocol mismatch self-heal via in-place re-exec (#731).
+- `khive-changeset` op-list model and NDJSON-delta codec (ADR-101, #715), with envelope
+  `batch_id` and field-scoped update preimage (#725) and a `kg commit` tier-2 primitive (#721).
+- Five configurable rule classes for `kg validate` (#712).
+- Lifecycle events, checkpoint pressure telemetry, severity ladder, and link-verb audit
+  enrichment (#703).
+- `khive-pack-git` v0: commit/issue/PR ingestion with provenance edges (ADR-088, #692).
+- Store backup tooling (ADR-100, #677) with per-job retention knobs (#684).
+- ADR-099 atomic CLI surface for `kkernel exec --ops-file` (B1-B3, #678, #680).
+- Single-writer `WriterTask` core with a bounded write queue; all write paths route through it
+  (ADR-067 Component A, #670).
+- Per-request identity served over one warm daemon registry (ADR-096 Fork 1, #660).
+- Read-only `comm.health()` verb with daemon-persisted heartbeat rows (#615).
+- ADR-091 Plank 0/2: open-transaction registry, WAL checkpoint instrumentation, and WAL
+  TRUNCATE escalation with rate-limited guards (#591, #593).
+- `context` verb: entity-anchored graph context in one call (ADR-089, #588).
+- Recall serve-time attribution wired into the serve ledger (ADR-081 §5, #583).
+- ADR-081 retune-driver substrate: implicit weight, bounded-mass fold gate, serve ledger (#497).
+- `khive-pack-session` T1 verb surface (store/list/resume/export) and a ChatGPT export mirror
+  source (#411, #525).
+
+### Changed
+
+- `khive-runtime`, `khive-db`, and `kkernel` share canonical/atomic decision-step and DML code
+  paths across the ADR-099 B3 series, closing duplication between the two execution modes.
+- `begin_tx` retired; session ingest routes through `atomic_unit` (ADR-099 D5, #673).
+- Edge-relation error hints now derive from installed pack `EDGE_RULES` (#621).
+
+### Fixed
+
+- FTS5 metacharacters sanitized in recall/search query construction (#880).
+- Malformed-policy output masked from Gate deny reasons and audit logs (#853).
+- Typed validation errors instead of panics on invalid `khive-quant` train/encode shapes (#854).
+- `resource` entity kind accepted in JSON/NDJSON import adapters (#856).
+- Every published crate declares `rust-version` (MSRV 1.91.0) (#855).
+- Bounded ANN wait in `memory.recall` with lexical fallback (#859).
+- Exact-name entity lookup checked before hybrid fallback in `resolve` (#852).
+- Substrate node labels (`entity`/`note`) made satisfiable in GQL/SPARQL (#857).
+- `pack-git` scratch-cache ENOENT race closed on the macOS flake family (#847).
+- `link()`/`link_many()` guarded against concurrent hard-delete (#826).
+- LIKE wildcards escaped in entity name-prefix resolution and Vamana snapshot invalidation
+  (#834, #824).
+- `FeedbackExplicit` signal observation decoded from `target_id` (#831).
+- Credentials masked in `pack-git` issue titles and PR notes without dropping content
+  (#835, #785).
+- Daemon confirms a dead process before killing it, closing a recovery race (#838).
+- `comm.probe` cursor made commit-order safe (#827).
+- DSL container-nesting depth and input length bounded (#823).
+- `gtd` next/tasks push status/assignee/priority filters into SQL (#825).
+- Unreachable strong-count checkpoint exit replaced with a watch signal (#822).
+- Stale ANN served during rebuild so the recall request path is not blocked (#812).
+- Compact hex prefixes normalized before LIKE-scanning hyphenated ids (#816).
+- Generation-check on ANN install closes a stale-build race (#815).
+- `ensure_clone` refuses unowned cache-key directories (#788).
+- IMAP UID cursor progress persisted for the email channel (#784).
+- GQL result truncation warns at the 500-row cap (#802).
+- Punctuated identifiers split correctly in FTS5 query sanitization (#790).
+- RFC 3339 timezone offsets honored in relative-time display (#800).
+- OAuth token refresh bounded by a timeout under the cache lock (#787).
+- Over-cap commit embeddings truncated in `pack-git` (#789).
+- Comm/GTD backlog burn: inbox sender filters, thread cursor pagination, message tags (#757).
+- `brain.resolve` defaults the actor from the caller's dispatch identity (#742).
+- Exactly-once forwarding, stale-daemon recovery, and cold-boot FTS guard in the daemon (#698).
+- Tier-2 actor+namespace bindings resolved on the `brain` feedback path (#699).
+- Multi-backend `annotates`→edge resolution, tier-3 config anchor, curation merge SQL
+  unification (#695).
+- Silent local-dispatch fallback eliminated; config_id topology parity with graduated
+  fail-loud behavior (#698).
+
+### Performance
+
+- Shared MCP measurement client for the benchmark program (#865).
+- Flagship coverage manifest and validator for benchmark tracking (#862).
+- Throwaway readiness socket dropped and unknown-verb listing cached (#647).
+- Neighbor queries for `direction=both` halved via a single `UNION ALL` expansion (#648).
+
 ## [0.3.0] - 2026-07-01
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -225,7 +225,7 @@ touching consumers.
 
 ## Quick start
 
-**1. Install** (from [crates.io](https://crates.io/crates/khive-mcp), currently at `0.3.0`; `0.4.0` publishes with this release):
+**1. Install** (from [crates.io](https://crates.io/crates/khive-mcp), currently at `0.4.0`; `0.5.0` publishes with this release):
 
 ```bash
 cargo install kkernel
@@ -375,7 +375,7 @@ Docs: [ohdearquant.github.io/khive](https://ohdearquant.github.io/khive/) (agent
 
 ## Status
 
-**v0.4.0 (publication pending; crates.io currently serves 0.3.0).** 78 verbs across 11
+**v0.5.0 (publication pending; crates.io currently serves 0.4.0).** 78 verbs across 11
 packs, 9 entity kinds, 17 edge relations, daemon warm startup (ADR-049), knowledge search with
 embedding rerank, Bayesian brain profiles, threaded messaging, scheduled verb execution.
 Ready for use with Claude Code and any MCP-compatible agent.

--- a/crates/Cargo.toml
+++ b/crates/Cargo.toml
@@ -49,7 +49,7 @@ exclude = ["khive-merge"]
 # keep this exclusion from members.
 
 [workspace.package]
-version = "0.4.0"
+version = "0.5.0"
 edition = "2021"
 # lattice-embed and lattice-fann 0.6 require Rust 1.93, setting the workspace MSRV.
 # The previous 1.91 floor came from floor_char_boundary use (issue #398).

--- a/crates/khive-bm25/Cargo.toml
+++ b/crates/khive-bm25/Cargo.toml
@@ -15,7 +15,7 @@ description = "BM25 (Okapi BM25) keyword index with deterministic scoring"
 bench = false
 
 [dependencies]
-khive-score = { version = "0.4.0", path = "../khive-score" }
+khive-score = { version = "0.5.0", path = "../khive-score" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/khive-brain-core/Cargo.toml
+++ b/crates/khive-brain-core/Cargo.toml
@@ -15,7 +15,7 @@ description = "Brain primitives — Beta posteriors, section types, profile stat
 bench = false
 
 [dependencies]
-khive-runtime = { version = "0.4.0", path = "../khive-runtime" }
+khive-runtime = { version = "0.5.0", path = "../khive-runtime" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 uuid = { workspace = true }

--- a/crates/khive-changeset/Cargo.toml
+++ b/crates/khive-changeset/Cargo.toml
@@ -12,7 +12,7 @@ categories.workspace = true
 description = "Producer-agnostic KG change-set op-list model and NDJSON-delta serialization"
 
 [dependencies]
-khive-types = { version = "0.4.0", path = "../khive-types", features = ["serde"] }
+khive-types = { version = "0.5.0", path = "../khive-types", features = ["serde"] }
 serde = { workspace = true }
 # float_roundtrip: the default float parser is a fast approximation that does
 # not always recover the exact f64 bits a prior serialize wrote (weight/

--- a/crates/khive-channel-email/Cargo.toml
+++ b/crates/khive-channel-email/Cargo.toml
@@ -12,7 +12,7 @@ categories.workspace = true
 description = "Email (SMTP/IMAP) channel adapter for khive (ADR-056)"
 
 [dependencies]
-khive-channel = { version = "0.4.0", path = "../khive-channel" }
+khive-channel = { version = "0.5.0", path = "../khive-channel" }
 async-trait = { workspace = true }
 thiserror = { workspace = true }
 serde = { workspace = true }

--- a/crates/khive-db/Cargo.toml
+++ b/crates/khive-db/Cargo.toml
@@ -15,9 +15,9 @@ description = "SQLite storage backend: entities, edges, notes, events, FTS5, sql
 bench = false
 
 [dependencies]
-khive-storage = { version = "0.4.0", path = "../khive-storage" }
-khive-score = { version = "0.4.0", path = "../khive-score" }
-khive-types = { version = "0.4.0", path = "../khive-types", features = ["serde"] }
+khive-storage = { version = "0.5.0", path = "../khive-storage" }
+khive-score = { version = "0.5.0", path = "../khive-score" }
+khive-types = { version = "0.5.0", path = "../khive-types", features = ["serde"] }
 tokio = { workspace = true }
 async-trait = { workspace = true }
 uuid = { workspace = true }
@@ -38,8 +38,8 @@ tempfile = { workspace = true }
 [dev-dependencies]
 tokio = { workspace = true, features = ["full", "test-util"] }
 rusqlite = { workspace = true, features = ["bundled", "column_decltype"] }
-khive-storage = { version = "0.4.0", path = "../khive-storage" }
-khive-types = { version = "0.4.0", path = "../khive-types", features = ["serde"] }
+khive-storage = { version = "0.5.0", path = "../khive-storage" }
+khive-types = { version = "0.5.0", path = "../khive-types", features = ["serde"] }
 uuid = { workspace = true }
 criterion = { workspace = true }
 rand = { workspace = true }

--- a/crates/khive-fold/Cargo.toml
+++ b/crates/khive-fold/Cargo.toml
@@ -21,10 +21,10 @@ default = ["serde"]
 serde = ["dep:serde"]
 
 [dependencies]
-khive-score = { version = "0.4.0", path = "../khive-score" }
+khive-score = { version = "0.5.0", path = "../khive-score" }
 # ADR-024 boundary: khive-types + khive-score only.
 # blake3 feature enables Hash32::from_blake3 for checkpoint hashing.
-khive-types = { version = "0.4.0", path = "../khive-types", features = ["blake3", "serde"] }
+khive-types = { version = "0.5.0", path = "../khive-types", features = ["blake3", "serde"] }
 # serde: optional, gated by the `serde` feature above.
 serde = { workspace = true, optional = true }
 # serde_json: kept direct — serde_json::Value is used in FoldContext.extra,

--- a/crates/khive-fusion/Cargo.toml
+++ b/crates/khive-fusion/Cargo.toml
@@ -15,7 +15,7 @@ description = "Rank fusion strategies (RRF, Weighted, Union) with deterministic 
 bench = false
 
 [dependencies]
-khive-score = { version = "0.4.0", path = "../khive-score" }
+khive-score = { version = "0.5.0", path = "../khive-score" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 

--- a/crates/khive-gate-rego/Cargo.toml
+++ b/crates/khive-gate-rego/Cargo.toml
@@ -13,12 +13,12 @@ description = "Rego (Open Policy Agent) backend for khive-gate, powered by regor
 readme = "README.md"
 
 [dependencies]
-khive-gate = { version = "0.4.0", path = "../khive-gate" }
+khive-gate = { version = "0.5.0", path = "../khive-gate" }
 serde_json = { workspace = true }
 tracing = { workspace = true }
 
 regorus = { workspace = true }
 
 [dev-dependencies]
-khive-types = { version = "0.4.0", path = "../khive-types", features = ["serde"] }
+khive-types = { version = "0.5.0", path = "../khive-types", features = ["serde"] }
 tracing-subscriber = { workspace = true }

--- a/crates/khive-gate/Cargo.toml
+++ b/crates/khive-gate/Cargo.toml
@@ -12,7 +12,7 @@ categories.workspace = true
 description = "Pluggable authorization gate trait + default AllowAllGate impl for khive verb dispatch."
 
 [dependencies]
-khive-types = { version = "0.4.0", path = "../khive-types", features = ["serde"] }
+khive-types = { version = "0.5.0", path = "../khive-types", features = ["serde"] }
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/khive-hnsw/Cargo.toml
+++ b/crates/khive-hnsw/Cargo.toml
@@ -15,9 +15,9 @@ description = "HNSW (Hierarchical Navigable Small World) vector index with INT8 
 bench = false
 
 [dependencies]
-khive-score = { version = "0.4.0", path = "../khive-score" }
-khive-types = { version = "0.4.0", path = "../khive-types", features = ["serde"] }
-khive-fold = { version = "0.4.0", path = "../khive-fold", optional = true }
+khive-score = { version = "0.5.0", path = "../khive-score" }
+khive-types = { version = "0.5.0", path = "../khive-types", features = ["serde"] }
+khive-fold = { version = "0.5.0", path = "../khive-fold", optional = true }
 lattice-embed = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/khive-mcp/Cargo.toml
+++ b/crates/khive-mcp/Cargo.toml
@@ -12,22 +12,22 @@ categories.workspace = true
 description = "khive MCP server library — served via the kkernel binary"
 
 [dependencies]
-khive-db = { version = "0.4.0", path = "../khive-db" }
-khive-runtime = { version = "0.4.0", path = "../khive-runtime" }
-khive-storage = { version = "0.4.0", path = "../khive-storage" }
-khive-types = { version = "0.4.0", path = "../khive-types", features = ["serde"] }
-khive-request = { version = "0.4.0", path = "../khive-request" }
-khive-pack-kg = { version = "0.4.0", path = "../khive-pack-kg" }
-khive-pack-gtd = { version = "0.4.0", path = "../khive-pack-gtd" }
-khive-pack-memory = { version = "0.4.0", path = "../khive-pack-memory" }
-khive-pack-brain = { version = "0.4.0", path = "../khive-pack-brain" }
-khive-pack-comm = { version = "0.4.0", path = "../khive-pack-comm" }
-khive-pack-schedule = { version = "0.4.0", path = "../khive-pack-schedule" }
-khive-pack-knowledge = { version = "0.4.0", path = "../khive-pack-knowledge" }
-khive-pack-session = { version = "0.4.0", path = "../khive-pack-session" }
-khive-pack-git = { version = "0.4.0", path = "../khive-pack-git" }
-khive-pack-code = { version = "0.4.0", path = "../khive-pack-code" }
-khive-pack-workspace = { version = "0.4.0", path = "../khive-pack-workspace" }
+khive-db = { version = "0.5.0", path = "../khive-db" }
+khive-runtime = { version = "0.5.0", path = "../khive-runtime" }
+khive-storage = { version = "0.5.0", path = "../khive-storage" }
+khive-types = { version = "0.5.0", path = "../khive-types", features = ["serde"] }
+khive-request = { version = "0.5.0", path = "../khive-request" }
+khive-pack-kg = { version = "0.5.0", path = "../khive-pack-kg" }
+khive-pack-gtd = { version = "0.5.0", path = "../khive-pack-gtd" }
+khive-pack-memory = { version = "0.5.0", path = "../khive-pack-memory" }
+khive-pack-brain = { version = "0.5.0", path = "../khive-pack-brain" }
+khive-pack-comm = { version = "0.5.0", path = "../khive-pack-comm" }
+khive-pack-schedule = { version = "0.5.0", path = "../khive-pack-schedule" }
+khive-pack-knowledge = { version = "0.5.0", path = "../khive-pack-knowledge" }
+khive-pack-session = { version = "0.5.0", path = "../khive-pack-session" }
+khive-pack-git = { version = "0.5.0", path = "../khive-pack-git" }
+khive-pack-code = { version = "0.5.0", path = "../khive-pack-code" }
+khive-pack-workspace = { version = "0.5.0", path = "../khive-pack-workspace" }
 uuid = { workspace = true }
 inventory = { workspace = true }
 rmcp = { workspace = true, features = ["server", "transport-io"] }
@@ -45,8 +45,8 @@ sha2 = { workspace = true }
 chrono = { workspace = true }
 tempfile = { workspace = true }
 lattice-embed = { workspace = true, optional = true }
-khive-channel = { version = "0.4.0", path = "../khive-channel", optional = true }
-khive-channel-email = { version = "0.4.0", path = "../khive-channel-email", optional = true }
+khive-channel = { version = "0.5.0", path = "../khive-channel", optional = true }
+khive-channel-email = { version = "0.5.0", path = "../khive-channel-email", optional = true }
 
 [features]
 # bench-embedder: inject deterministic FNV-1a hash embedder into the serve path.
@@ -61,5 +61,5 @@ tokio = { workspace = true, features = ["test-util"] }
 rmcp = { workspace = true, features = ["server", "transport-io", "client"] }
 async-trait = { workspace = true }
 serial_test = { workspace = true }
-khive-pack-knowledge = { version = "0.4.0", path = "../khive-pack-knowledge" }
+khive-pack-knowledge = { version = "0.5.0", path = "../khive-pack-knowledge" }
 rusqlite = { workspace = true, features = ["bundled"] }

--- a/crates/khive-merge/Cargo.toml
+++ b/crates/khive-merge/Cargo.toml
@@ -5,7 +5,7 @@
 # [workspace.package] below declares the shared version for this standalone workspace.
 
 [workspace.package]
-version = "0.4.0"
+version = "0.5.0"
 
 [package]
 name = "khive-merge"
@@ -18,8 +18,8 @@ homepage = "https://github.com/ohdearquant"
 description = "KG three-way merge with conflict detection (ADR-039)"
 
 [dependencies]
-khive-runtime = { version = "0.4.0", path = "../khive-runtime" }
-khive-storage = { version = "0.4.0", path = "../khive-storage" }
+khive-runtime = { version = "0.5.0", path = "../khive-runtime" }
+khive-storage = { version = "0.5.0", path = "../khive-storage" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 thiserror = "2.0"

--- a/crates/khive-pack-brain/Cargo.toml
+++ b/crates/khive-pack-brain/Cargo.toml
@@ -15,18 +15,18 @@ description = "Brain pack — profile-oriented orchestration via Fold + Objectiv
 bench = false
 
 [dependencies]
-khive-brain-core = { version = "0.4.0", path = "../khive-brain-core" }
-khive-types = { version = "0.4.0", path = "../khive-types", features = ["serde"] }
-khive-runtime = { version = "0.4.0", path = "../khive-runtime" }
-khive-fold = { version = "0.4.0", path = "../khive-fold" }
-khive-storage = { version = "0.4.0", path = "../khive-storage" }
+khive-brain-core = { version = "0.5.0", path = "../khive-brain-core" }
+khive-types = { version = "0.5.0", path = "../khive-types", features = ["serde"] }
+khive-runtime = { version = "0.5.0", path = "../khive-runtime" }
+khive-fold = { version = "0.5.0", path = "../khive-fold" }
+khive-storage = { version = "0.5.0", path = "../khive-storage" }
 # ADR-081 §2/§6 (findings 1+2): the fold gate needs the event
 # append on the SAME held `SqlWriter` transaction as the dedup claim + mass
 # fold, so it calls khive-db's transaction-enlisted `append_event_on_writer`
 # seam directly rather than going through the higher-level `EventStore`
 # trait (which always opens its own transaction). No cycle: khive-db does not
 # depend on this crate.
-khive-db = { version = "0.4.0", path = "../khive-db" }
+khive-db = { version = "0.5.0", path = "../khive-db" }
 inventory = { workspace = true }
 async-trait = { workspace = true }
 lattice-fann = { workspace = true, optional = true }
@@ -40,7 +40,7 @@ lattice-router = ["dep:lattice-fann"]
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["test-util"] }
-khive-pack-kg = { version = "0.4.0", path = "../khive-pack-kg" }
+khive-pack-kg = { version = "0.5.0", path = "../khive-pack-kg" }
 # Dev-only: exercises the real memory.recall -> BrainPack dispatch-hook path
 # (issue #459 regression). khive-pack-memory already carries khive-pack-brain
 # as a dev-dependency for its own tests; Cargo permits cyclic dev-dependencies

--- a/crates/khive-pack-code/Cargo.toml
+++ b/crates/khive-pack-code/Cargo.toml
@@ -12,9 +12,9 @@ categories.workspace = true
 description = "Code ontology pack - typed edge rules and audit findings vocabulary"
 
 [dependencies]
-khive-types = { version = "0.4.0", path = "../khive-types", features = ["serde"] }
-khive-runtime = { version = "0.4.0", path = "../khive-runtime" }
-khive-storage = { version = "0.4.0", path = "../khive-storage" }
+khive-types = { version = "0.5.0", path = "../khive-types", features = ["serde"] }
+khive-runtime = { version = "0.5.0", path = "../khive-runtime" }
+khive-storage = { version = "0.5.0", path = "../khive-storage" }
 inventory = { workspace = true }
 async-trait = { workspace = true }
 chrono = { workspace = true }
@@ -24,5 +24,5 @@ thiserror = { workspace = true }
 uuid = { workspace = true }
 
 [dev-dependencies]
-khive-pack-kg = { version = "0.4.0", path = "../khive-pack-kg" }
+khive-pack-kg = { version = "0.5.0", path = "../khive-pack-kg" }
 tokio = { workspace = true, features = ["full"] }

--- a/crates/khive-pack-comm/Cargo.toml
+++ b/crates/khive-pack-comm/Cargo.toml
@@ -15,9 +15,9 @@ description = "Communication pack — inter-agent messaging (send, inbox, read, 
 bench = false
 
 [dependencies]
-khive-types = { version = "0.4.0", path = "../khive-types", features = ["serde"] }
-khive-runtime = { version = "0.4.0", path = "../khive-runtime" }
-khive-storage = { version = "0.4.0", path = "../khive-storage" }
+khive-types = { version = "0.5.0", path = "../khive-types", features = ["serde"] }
+khive-runtime = { version = "0.5.0", path = "../khive-runtime" }
+khive-storage = { version = "0.5.0", path = "../khive-storage" }
 inventory = { workspace = true }
 async-trait = { workspace = true }
 serde = { workspace = true }
@@ -28,11 +28,11 @@ tracing = { workspace = true }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["full"] }
-khive-pack-kg = { version = "0.4.0", path = "../khive-pack-kg" }
-khive-db = { version = "0.4.0", path = "../khive-db" }
+khive-pack-kg = { version = "0.5.0", path = "../khive-pack-kg" }
+khive-db = { version = "0.5.0", path = "../khive-db" }
 criterion = { workspace = true }
 toml = { workspace = true }
-khive-runtime = { version = "0.4.0", path = "../khive-runtime", features = ["fault-injection"] }
+khive-runtime = { version = "0.5.0", path = "../khive-runtime", features = ["fault-injection"] }
 lattice-embed = { workspace = true }
 rusqlite = { workspace = true, features = ["bundled", "column_decltype"] }
 tempfile = { workspace = true }

--- a/crates/khive-pack-formal/Cargo.toml
+++ b/crates/khive-pack-formal/Cargo.toml
@@ -12,8 +12,8 @@ categories.workspace = true
 description = "Formal-math ontology pack — typed edge rules for theorem/definition/structure/instance/axiom/goal subtypes"
 
 [dependencies]
-khive-types = { version = "0.4.0", path = "../khive-types", features = ["serde"] }
-khive-runtime = { version = "0.4.0", path = "../khive-runtime" }
+khive-types = { version = "0.5.0", path = "../khive-types", features = ["serde"] }
+khive-runtime = { version = "0.5.0", path = "../khive-runtime" }
 inventory = { workspace = true }
 async-trait = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/khive-pack-git/Cargo.toml
+++ b/crates/khive-pack-git/Cargo.toml
@@ -12,10 +12,10 @@ categories.workspace = true
 description = "Git-lifecycle pack — commit/issue/pull_request provenance notes over the notes substrate (ADR-088)"
 
 [dependencies]
-khive-types = { version = "0.4.0", path = "../khive-types", features = ["serde"] }
-khive-runtime = { version = "0.4.0", path = "../khive-runtime" }
+khive-types = { version = "0.5.0", path = "../khive-types", features = ["serde"] }
+khive-runtime = { version = "0.5.0", path = "../khive-runtime" }
 inventory = { workspace = true }
-khive-storage = { version = "0.4.0", path = "../khive-storage" }
+khive-storage = { version = "0.5.0", path = "../khive-storage" }
 async-trait = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
@@ -29,7 +29,7 @@ blake3 = { workspace = true }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["full"] }
-khive-pack-kg = { version = "0.4.0", path = "../khive-pack-kg" }
+khive-pack-kg = { version = "0.5.0", path = "../khive-pack-kg" }
 tempfile = { workspace = true }
-khive-runtime = { version = "0.4.0", path = "../khive-runtime", features = ["fault-injection"] }
+khive-runtime = { version = "0.5.0", path = "../khive-runtime", features = ["fault-injection"] }
 lattice-embed = { workspace = true }

--- a/crates/khive-pack-gtd/Cargo.toml
+++ b/crates/khive-pack-gtd/Cargo.toml
@@ -15,10 +15,10 @@ description = "GTD verb pack — task lifecycle (assign/next/complete/transition
 bench = false
 
 [dependencies]
-khive-types = { version = "0.4.0", path = "../khive-types", features = ["serde"] }
-khive-runtime = { version = "0.4.0", path = "../khive-runtime" }
+khive-types = { version = "0.5.0", path = "../khive-types", features = ["serde"] }
+khive-runtime = { version = "0.5.0", path = "../khive-runtime" }
 inventory = { workspace = true }
-khive-storage = { version = "0.4.0", path = "../khive-storage" }
+khive-storage = { version = "0.5.0", path = "../khive-storage" }
 async-trait = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
@@ -28,7 +28,7 @@ tracing = { workspace = true }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["full"] }
-khive-pack-kg = { version = "0.4.0", path = "../khive-pack-kg" }
+khive-pack-kg = { version = "0.5.0", path = "../khive-pack-kg" }
 criterion = { workspace = true }
 
 [[bench]]

--- a/crates/khive-pack-kg/Cargo.toml
+++ b/crates/khive-pack-kg/Cargo.toml
@@ -15,11 +15,11 @@ description = "KG verb pack — entity/note CRUD, graph traversal, hybrid search
 bench = false
 
 [dependencies]
-khive-types = { version = "0.4.0", path = "../khive-types", features = ["serde"] }
-khive-runtime = { version = "0.4.0", path = "../khive-runtime" }
-khive-query = { version = "0.4.0", path = "../khive-query" }
+khive-types = { version = "0.5.0", path = "../khive-types", features = ["serde"] }
+khive-runtime = { version = "0.5.0", path = "../khive-runtime" }
+khive-query = { version = "0.5.0", path = "../khive-query" }
 inventory = { workspace = true }
-khive-storage = { version = "0.4.0", path = "../khive-storage" }
+khive-storage = { version = "0.5.0", path = "../khive-storage" }
 async-trait = { workspace = true }
 chrono = { workspace = true }
 serde = { workspace = true }
@@ -31,7 +31,7 @@ tracing = { workspace = true }
 tokio = { workspace = true, features = ["test-util"] }
 criterion = { workspace = true }
 serde_json = { workspace = true }
-khive-pack-formal = { version = "0.4.0", path = "../khive-pack-formal" }
+khive-pack-formal = { version = "0.5.0", path = "../khive-pack-formal" }
 # Path-only: cyclic dev-dep pair with khive-pack-gtd; cargo strips it at publish.
 khive-pack-gtd = { path = "../khive-pack-gtd" }
 

--- a/crates/khive-pack-knowledge/Cargo.toml
+++ b/crates/khive-pack-knowledge/Cargo.toml
@@ -15,14 +15,14 @@ description = "Knowledge verb pack — lore corpus (atoms/domains), TF-IDF retri
 bench = false
 
 [dependencies]
-khive-types = { version = "0.4.0", path = "../khive-types", features = ["serde"] }
-khive-brain-core = { version = "0.4.0", path = "../khive-brain-core" }
-khive-runtime = { version = "0.4.0", path = "../khive-runtime" }
-khive-storage = { version = "0.4.0", path = "../khive-storage" }
-khive-fold = { version = "0.4.0", path = "../khive-fold" }
-khive-fusion = { version = "0.4.0", path = "../khive-fusion" }
-khive-score = { version = "0.4.0", path = "../khive-score" }
-khive-vamana = { version = "0.4.0", path = "../khive-vamana" }
+khive-types = { version = "0.5.0", path = "../khive-types", features = ["serde"] }
+khive-brain-core = { version = "0.5.0", path = "../khive-brain-core" }
+khive-runtime = { version = "0.5.0", path = "../khive-runtime" }
+khive-storage = { version = "0.5.0", path = "../khive-storage" }
+khive-fold = { version = "0.5.0", path = "../khive-fold" }
+khive-fusion = { version = "0.5.0", path = "../khive-fusion" }
+khive-score = { version = "0.5.0", path = "../khive-score" }
+khive-vamana = { version = "0.5.0", path = "../khive-vamana" }
 inventory = { workspace = true }
 tokio = { workspace = true }
 async-trait = { workspace = true }
@@ -34,9 +34,9 @@ chrono = { workspace = true }
 sha2 = { workspace = true }
 
 [dev-dependencies]
-khive-pack-kg = { version = "0.4.0", path = "../khive-pack-kg" }
-khive-pack-brain = { version = "0.4.0", path = "../khive-pack-brain" }
-khive-storage = { version = "0.4.0", path = "../khive-storage" }
+khive-pack-kg = { version = "0.5.0", path = "../khive-pack-kg" }
+khive-pack-brain = { version = "0.5.0", path = "../khive-pack-brain" }
+khive-storage = { version = "0.5.0", path = "../khive-storage" }
 tokio = { workspace = true, features = ["test-util"] }
 lattice-embed = { workspace = true }
 criterion = { workspace = true }

--- a/crates/khive-pack-memory/Cargo.toml
+++ b/crates/khive-pack-memory/Cargo.toml
@@ -15,16 +15,16 @@ description = "Memory verb pack — remember/recall semantics with decay-aware r
 bench = false
 
 [dependencies]
-khive-types = { version = "0.4.0", path = "../khive-types", features = ["serde"] }
-khive-runtime = { version = "0.4.0", path = "../khive-runtime" }
-khive-fusion = { version = "0.4.0", path = "../khive-fusion" }
-khive-retrieval = { version = "0.4.0", path = "../khive-retrieval" }
-khive-score = { version = "0.4.0", path = "../khive-score" }
-khive-brain-core = { version = "0.4.0", path = "../khive-brain-core" }
-khive-vamana = { version = "0.4.0", path = "../khive-vamana" }
+khive-types = { version = "0.5.0", path = "../khive-types", features = ["serde"] }
+khive-runtime = { version = "0.5.0", path = "../khive-runtime" }
+khive-fusion = { version = "0.5.0", path = "../khive-fusion" }
+khive-retrieval = { version = "0.5.0", path = "../khive-retrieval" }
+khive-score = { version = "0.5.0", path = "../khive-score" }
+khive-brain-core = { version = "0.5.0", path = "../khive-brain-core" }
+khive-vamana = { version = "0.5.0", path = "../khive-vamana" }
 blake3 = { workspace = true }
 inventory = { workspace = true }
-khive-storage = { version = "0.4.0", path = "../khive-storage" }
+khive-storage = { version = "0.5.0", path = "../khive-storage" }
 async-trait = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
@@ -36,9 +36,9 @@ lru = { workspace = true }
 parking_lot = { workspace = true }
 
 [dev-dependencies]
-khive-db = { version = "0.4.0", path = "../khive-db" }
-khive-pack-kg = { version = "0.4.0", path = "../khive-pack-kg" }
-khive-pack-brain = { version = "0.4.0", path = "../khive-pack-brain" }
+khive-db = { version = "0.5.0", path = "../khive-db" }
+khive-pack-kg = { version = "0.5.0", path = "../khive-pack-kg" }
+khive-pack-brain = { version = "0.5.0", path = "../khive-pack-brain" }
 tokio = { workspace = true, features = ["test-util"] }
 lattice-embed = { workspace = true }
 async-trait = { workspace = true }

--- a/crates/khive-pack-schedule/Cargo.toml
+++ b/crates/khive-pack-schedule/Cargo.toml
@@ -15,10 +15,10 @@ description = "Schedule pack — time-triggered intent storage (remind, schedule
 bench = false
 
 [dependencies]
-khive-types = { version = "0.4.0", path = "../khive-types", features = ["serde"] }
-khive-runtime = { version = "0.4.0", path = "../khive-runtime" }
-khive-storage = { version = "0.4.0", path = "../khive-storage" }
-khive-request = { version = "0.4.0", path = "../khive-request" }
+khive-types = { version = "0.5.0", path = "../khive-types", features = ["serde"] }
+khive-runtime = { version = "0.5.0", path = "../khive-runtime" }
+khive-storage = { version = "0.5.0", path = "../khive-storage" }
+khive-request = { version = "0.5.0", path = "../khive-request" }
 inventory = { workspace = true }
 async-trait = { workspace = true }
 serde = { workspace = true }
@@ -29,10 +29,10 @@ tracing = { workspace = true }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["full"] }
-khive-pack-kg = { version = "0.4.0", path = "../khive-pack-kg" }
-khive-pack-comm = { version = "0.4.0", path = "../khive-pack-comm" }
-khive-pack-brain = { version = "0.4.0", path = "../khive-pack-brain" }
-khive-pack-git = { version = "0.4.0", path = "../khive-pack-git" }
+khive-pack-kg = { version = "0.5.0", path = "../khive-pack-kg" }
+khive-pack-comm = { version = "0.5.0", path = "../khive-pack-comm" }
+khive-pack-brain = { version = "0.5.0", path = "../khive-pack-brain" }
+khive-pack-git = { version = "0.5.0", path = "../khive-pack-git" }
 criterion = { workspace = true }
 
 [[bench]]

--- a/crates/khive-pack-session/Cargo.toml
+++ b/crates/khive-pack-session/Cargo.toml
@@ -12,10 +12,10 @@ categories.workspace = true
 description = "Session verb pack - store/list/resume/export over the notes substrate"
 
 [dependencies]
-khive-types = { version = "0.4.0", path = "../khive-types", features = ["serde"] }
-khive-runtime = { version = "0.4.0", path = "../khive-runtime" }
+khive-types = { version = "0.5.0", path = "../khive-types", features = ["serde"] }
+khive-runtime = { version = "0.5.0", path = "../khive-runtime" }
 inventory = { workspace = true }
-khive-storage = { version = "0.4.0", path = "../khive-storage" }
+khive-storage = { version = "0.5.0", path = "../khive-storage" }
 async-trait = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
@@ -26,7 +26,7 @@ tokio = { workspace = true }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["full"] }
-khive-pack-kg = { version = "0.4.0", path = "../khive-pack-kg" }
+khive-pack-kg = { version = "0.5.0", path = "../khive-pack-kg" }
 tempfile = { workspace = true }
 # Test-only: builds a bare `PoolConfig { write_queue_enabled: true, .. }` +
 # `SqlBridge` directly (no `KhiveRuntime`, no `KHIVE_WRITE_QUEUE` env var) for
@@ -34,4 +34,4 @@ tempfile = { workspace = true }
 # established pattern in khive-pack-brain's `fold_gate.rs` and `persist.rs`
 # (documented there: env-var mutation races other tests' `KhiveRuntime::new`
 # calls in the same binary; a literal `PoolConfig` sidesteps that).
-khive-db = { version = "0.4.0", path = "../khive-db" }
+khive-db = { version = "0.5.0", path = "../khive-db" }

--- a/crates/khive-pack-template/Cargo.toml
+++ b/crates/khive-pack-template/Cargo.toml
@@ -12,12 +12,12 @@ categories.workspace = true
 description = "Reference template for new khive packs (ADR-023 §8). Copy this crate to get a working pack scaffold."
 
 [dependencies]
-khive-types = { version = "0.4.0", path = "../khive-types", features = ["serde"] }
-khive-runtime = { version = "0.4.0", path = "../khive-runtime" }
+khive-types = { version = "0.5.0", path = "../khive-types", features = ["serde"] }
+khive-runtime = { version = "0.5.0", path = "../khive-runtime" }
 inventory = { workspace = true }
 async-trait = { workspace = true }
 serde_json = { workspace = true }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["test-util"] }
-khive-pack-kg = { version = "0.4.0", path = "../khive-pack-kg" }
+khive-pack-kg = { version = "0.5.0", path = "../khive-pack-kg" }

--- a/crates/khive-pack-workspace/Cargo.toml
+++ b/crates/khive-pack-workspace/Cargo.toml
@@ -11,8 +11,8 @@ categories.workspace = true
 description = "Workspace pack  -  pack-owned `workspace` entity kind with typed `contains` membership edges to issue/pull_request/commit/task/session records (issue #873)"
 
 [dependencies]
-khive-types = { version = "0.4.0", path = "../khive-types", features = ["serde"] }
-khive-runtime = { version = "0.4.0", path = "../khive-runtime" }
+khive-types = { version = "0.5.0", path = "../khive-types", features = ["serde"] }
+khive-runtime = { version = "0.5.0", path = "../khive-runtime" }
 inventory = { workspace = true }
 async-trait = { workspace = true }
 serde_json = { workspace = true }
@@ -20,7 +20,7 @@ uuid = { workspace = true }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["full"] }
-khive-pack-kg = { version = "0.4.0", path = "../khive-pack-kg" }
-khive-pack-gtd = { version = "0.4.0", path = "../khive-pack-gtd" }
-khive-pack-git = { version = "0.4.0", path = "../khive-pack-git" }
-khive-pack-session = { version = "0.4.0", path = "../khive-pack-session" }
+khive-pack-kg = { version = "0.5.0", path = "../khive-pack-kg" }
+khive-pack-gtd = { version = "0.5.0", path = "../khive-pack-gtd" }
+khive-pack-git = { version = "0.5.0", path = "../khive-pack-git" }
+khive-pack-session = { version = "0.5.0", path = "../khive-pack-session" }

--- a/crates/khive-query/Cargo.toml
+++ b/crates/khive-query/Cargo.toml
@@ -15,7 +15,7 @@ description = "GQL and SPARQL parsers with SQL compiler for knowledge graph quer
 bench = false
 
 [dependencies]
-khive-types = { version = "0.4.0", path = "../khive-types" }
+khive-types = { version = "0.5.0", path = "../khive-types" }
 thiserror = { workspace = true }
 
 [dev-dependencies]

--- a/crates/khive-request/Cargo.toml
+++ b/crates/khive-request/Cargo.toml
@@ -15,7 +15,7 @@ description = "Request DSL — parses verb-dispatch strings (function-call, JSON
 bench = false
 
 [dependencies]
-khive-types = { version = "0.4.0", path = "../khive-types" }
+khive-types = { version = "0.5.0", path = "../khive-types" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 

--- a/crates/khive-retrieval/Cargo.toml
+++ b/crates/khive-retrieval/Cargo.toml
@@ -15,15 +15,15 @@ description = "Hybrid retrieval composer (HNSW + BM25 + fusion + graph + cross-e
 bench = false
 
 [dependencies]
-khive-hnsw    = { version = "0.4.0", path = "../khive-hnsw" }
-khive-bm25    = { version = "0.4.0", path = "../khive-bm25" }
-khive-fusion  = { version = "0.4.0", path = "../khive-fusion" }
-khive-score   = { version = "0.4.0", path = "../khive-score" }
-khive-types   = { version = "0.4.0", path = "../khive-types" }
-khive-fold    = { version = "0.4.0", path = "../khive-fold", optional = true }
-khive-storage = { version = "0.4.0", path = "../khive-storage", optional = true }
-khive-db      = { version = "0.4.0", path = "../khive-db" }
-khive-gate    = { version = "0.4.0", path = "../khive-gate", optional = true }
+khive-hnsw    = { version = "0.5.0", path = "../khive-hnsw" }
+khive-bm25    = { version = "0.5.0", path = "../khive-bm25" }
+khive-fusion  = { version = "0.5.0", path = "../khive-fusion" }
+khive-score   = { version = "0.5.0", path = "../khive-score" }
+khive-types   = { version = "0.5.0", path = "../khive-types" }
+khive-fold    = { version = "0.5.0", path = "../khive-fold", optional = true }
+khive-storage = { version = "0.5.0", path = "../khive-storage", optional = true }
+khive-db      = { version = "0.5.0", path = "../khive-db" }
+khive-gate    = { version = "0.5.0", path = "../khive-gate", optional = true }
 lattice-embed = { workspace = true }
 
 serde = { workspace = true }
@@ -62,8 +62,8 @@ embed = []
 
 [dev-dependencies]
 criterion = { workspace = true }
-khive-score = { version = "0.4.0", path = "../khive-score" }
-khive-fusion = { version = "0.4.0", path = "../khive-fusion" }
+khive-score = { version = "0.5.0", path = "../khive-score" }
+khive-fusion = { version = "0.5.0", path = "../khive-fusion" }
 
 [[bench]]
 name = "fusion_bench"

--- a/crates/khive-runtime/Cargo.toml
+++ b/crates/khive-runtime/Cargo.toml
@@ -15,14 +15,14 @@ description = "Composable Service API: entity/note CRUD, graph traversal, hybrid
 fault-injection = []
 
 [dependencies]
-khive-types = { version = "0.4.0", path = "../khive-types", features = ["serde"] }
-khive-storage = { version = "0.4.0", path = "../khive-storage" }
-khive-score = { version = "0.4.0", path = "../khive-score" }
-khive-fusion = { version = "0.4.0", path = "../khive-fusion" }
-khive-fold = { version = "0.4.0", path = "../khive-fold" }
-khive-db = { version = "0.4.0", path = "../khive-db", features = ["vectors"] }
-khive-query = { version = "0.4.0", path = "../khive-query" }
-khive-gate = { version = "0.4.0", path = "../khive-gate" }
+khive-types = { version = "0.5.0", path = "../khive-types", features = ["serde"] }
+khive-storage = { version = "0.5.0", path = "../khive-storage" }
+khive-score = { version = "0.5.0", path = "../khive-score" }
+khive-fusion = { version = "0.5.0", path = "../khive-fusion" }
+khive-fold = { version = "0.5.0", path = "../khive-fold" }
+khive-db = { version = "0.5.0", path = "../khive-db", features = ["vectors"] }
+khive-query = { version = "0.5.0", path = "../khive-query" }
+khive-gate = { version = "0.5.0", path = "../khive-gate" }
 inventory = { workspace = true }
 tokio = { workspace = true }
 async-trait = { workspace = true }
@@ -40,7 +40,7 @@ libc = { workspace = true }
 anyhow = { workspace = true }
 
 [dev-dependencies]
-khive-gate-rego = { version = "0.4.0", path = "../khive-gate-rego" }
+khive-gate-rego = { version = "0.5.0", path = "../khive-gate-rego" }
 tokio = { workspace = true, features = ["test-util"] }
 tempfile = { workspace = true }
 tracing-subscriber = { workspace = true }

--- a/crates/khive-score/Cargo.toml
+++ b/crates/khive-score/Cargo.toml
@@ -18,7 +18,7 @@ default = ["serde"]
 serde = ["dep:serde"]
 
 [dependencies]
-khive-types = { version = "0.4.0", path = "../khive-types" }
+khive-types = { version = "0.5.0", path = "../khive-types" }
 serde = { workspace = true, optional = true, features = ["derive"] }
 
 [dev-dependencies]

--- a/crates/khive-storage/Cargo.toml
+++ b/crates/khive-storage/Cargo.toml
@@ -13,8 +13,8 @@ categories.workspace = true
 [dependencies]
 async-trait = { workspace = true }
 chrono = { workspace = true }
-khive-score = { version = "0.4.0", path = "../khive-score" }
-khive-types = { version = "0.4.0", path = "../khive-types", features = ["serde"] }
+khive-score = { version = "0.5.0", path = "../khive-score" }
+khive-types = { version = "0.5.0", path = "../khive-types", features = ["serde"] }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/khive-text/Cargo.toml
+++ b/crates/khive-text/Cargo.toml
@@ -20,7 +20,7 @@ rust-stemmers = { workspace = true, optional = true }
 
 [dev-dependencies]
 criterion = { workspace = true }
-khive-bm25 = { version = "0.4.0", path = "../khive-bm25" }
+khive-bm25 = { version = "0.5.0", path = "../khive-bm25" }
 
 [features]
 default = []

--- a/crates/khive-vamana/Cargo.toml
+++ b/crates/khive-vamana/Cargo.toml
@@ -26,7 +26,7 @@ rand = { version = "0.8", default-features = false, features = ["std_rng"] }
 serde = { workspace = true }
 thiserror = { workspace = true }
 blake3 = { workspace = true }
-khive-quant = { version = "0.4.0", path = "../khive-quant", default-features = false }
+khive-quant = { version = "0.5.0", path = "../khive-quant", default-features = false }
 
 [dev-dependencies]
 blake3 = { workspace = true }

--- a/crates/khive-vcs-adapters/Cargo.toml
+++ b/crates/khive-vcs-adapters/Cargo.toml
@@ -10,7 +10,7 @@ homepage.workspace = true
 description = "KG import/export format adapters — CSV, JSON, and future format support (ADR-036)"
 
 [dependencies]
-khive-types = { version = "0.4.0", path = "../khive-types" }
+khive-types = { version = "0.5.0", path = "../khive-types" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/khive-vcs/Cargo.toml
+++ b/crates/khive-vcs/Cargo.toml
@@ -10,9 +10,9 @@ homepage.workspace = true
 description = "KG versioning — git-native core types, canonical hash, and NDJSON-to-SQLite sync (ADR-010/ADR-020)"
 
 [dependencies]
-khive-runtime = { version = "0.4.0", path = "../khive-runtime" }
-khive-storage = { version = "0.4.0", path = "../khive-storage" }
-khive-types = { version = "0.4.0", path = "../khive-types" }
+khive-runtime = { version = "0.5.0", path = "../khive-runtime" }
+khive-storage = { version = "0.5.0", path = "../khive-storage" }
+khive-types = { version = "0.5.0", path = "../khive-types" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
@@ -26,5 +26,5 @@ tempfile = { workspace = true }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["rt", "macros"] }
-khive-vcs-adapters = { version = "0.4.0", path = "../khive-vcs-adapters" }
-khive-db = { version = "0.4.0", path = "../khive-db" }
+khive-vcs-adapters = { version = "0.5.0", path = "../khive-vcs-adapters" }
+khive-db = { version = "0.5.0", path = "../khive-db" }

--- a/crates/kkernel/Cargo.toml
+++ b/crates/kkernel/Cargo.toml
@@ -12,27 +12,27 @@ categories.workspace = true
 description = "khive kernel — stdio MCP server binary and admin CLI (sync, pack introspection, db ops)"
 
 [dependencies]
-khive-runtime = { version = "0.4.0", path = "../khive-runtime" }
-khive-mcp = { version = "0.4.0", path = "../khive-mcp" }
-khive-score = { version = "0.4.0", path = "../khive-score" }
-khive-db = { version = "0.4.0", path = "../khive-db" }
-khive-storage = { version = "0.4.0", path = "../khive-storage" }
-khive-types = { version = "0.4.0", path = "../khive-types" }
-khive-vcs = { version = "0.4.0", path = "../khive-vcs" }
-khive-vcs-adapters = { version = "0.4.0", path = "../khive-vcs-adapters" }
-khive-pack-kg = { version = "0.4.0", path = "../khive-pack-kg" }
-khive-pack-gtd = { version = "0.4.0", path = "../khive-pack-gtd" }
-khive-pack-memory = { version = "0.4.0", path = "../khive-pack-memory" }
-khive-pack-brain = { version = "0.4.0", path = "../khive-pack-brain" }
-khive-pack-comm = { version = "0.4.0", path = "../khive-pack-comm" }
-khive-pack-schedule = { version = "0.4.0", path = "../khive-pack-schedule" }
-khive-pack-formal = { version = "0.4.0", path = "../khive-pack-formal" }
-khive-pack-code = { version = "0.4.0", path = "../khive-pack-code" }
-khive-pack-knowledge = { version = "0.4.0", path = "../khive-pack-knowledge" }
-khive-pack-session = { version = "0.4.0", path = "../khive-pack-session" }
-khive-pack-git = { version = "0.4.0", path = "../khive-pack-git" }
-khive-request = { version = "0.4.0", path = "../khive-request" }
-khive-changeset = { version = "0.4.0", path = "../khive-changeset" }
+khive-runtime = { version = "0.5.0", path = "../khive-runtime" }
+khive-mcp = { version = "0.5.0", path = "../khive-mcp" }
+khive-score = { version = "0.5.0", path = "../khive-score" }
+khive-db = { version = "0.5.0", path = "../khive-db" }
+khive-storage = { version = "0.5.0", path = "../khive-storage" }
+khive-types = { version = "0.5.0", path = "../khive-types" }
+khive-vcs = { version = "0.5.0", path = "../khive-vcs" }
+khive-vcs-adapters = { version = "0.5.0", path = "../khive-vcs-adapters" }
+khive-pack-kg = { version = "0.5.0", path = "../khive-pack-kg" }
+khive-pack-gtd = { version = "0.5.0", path = "../khive-pack-gtd" }
+khive-pack-memory = { version = "0.5.0", path = "../khive-pack-memory" }
+khive-pack-brain = { version = "0.5.0", path = "../khive-pack-brain" }
+khive-pack-comm = { version = "0.5.0", path = "../khive-pack-comm" }
+khive-pack-schedule = { version = "0.5.0", path = "../khive-pack-schedule" }
+khive-pack-formal = { version = "0.5.0", path = "../khive-pack-formal" }
+khive-pack-code = { version = "0.5.0", path = "../khive-pack-code" }
+khive-pack-knowledge = { version = "0.5.0", path = "../khive-pack-knowledge" }
+khive-pack-session = { version = "0.5.0", path = "../khive-pack-session" }
+khive-pack-git = { version = "0.5.0", path = "../khive-pack-git" }
+khive-request = { version = "0.5.0", path = "../khive-request" }
+khive-changeset = { version = "0.5.0", path = "../khive-changeset" }
 tokio = { workspace = true }
 async-trait = { workspace = true }
 serde = { workspace = true }

--- a/marketplace/INSTALL.md
+++ b/marketplace/INSTALL.md
@@ -7,7 +7,7 @@ correctly to a running `kkernel mcp` server.
 
 | Plugin | Version | kkernel |
 | ------ | ------- | ------- |
-| khive  | 0.4.0   | ≥ 0.2.4 |
+| khive  | 0.5.0   | ≥ 0.2.4 |
 
 `khive` is a single umbrella plugin — one pattern skill per pack plus the kg stewardship agents,
 all over the one `kkernel mcp` server.

--- a/marketplace/khive/.claude-plugin/plugin.json
+++ b/marketplace/khive/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "khive",
   "description": "khive for AI agents — knowledge graph, GTD, memory, inter-agent comm, scheduling, and domain knowledge over one MCP server. One pattern skill per pack, plus the kg stewardship agents.",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "author": {
     "name": "khive maintainers",
     "url": "https://github.com/ohdearquant"

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "khive",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Research knowledge graph runtime over MCP stdio, with typed entities, closed ontology, and hybrid search for AI research agents.",
   "license": "Apache-2.0",
   "repository": {
@@ -35,11 +35,11 @@
     "node": ">=18"
   },
   "optionalDependencies": {
-    "@khive-ai/kernel-darwin-arm64": "0.4.0",
-    "@khive-ai/kernel-darwin-x64": "0.4.0",
-    "@khive-ai/kernel-linux-x64-gnu": "0.4.0",
-    "@khive-ai/kernel-linux-x64-musl": "0.4.0",
-    "@khive-ai/kernel-linux-arm64": "0.4.0",
-    "@khive-ai/kernel-win32-x64": "0.4.0"
+    "@khive-ai/kernel-darwin-arm64": "0.5.0",
+    "@khive-ai/kernel-darwin-x64": "0.5.0",
+    "@khive-ai/kernel-linux-x64-gnu": "0.5.0",
+    "@khive-ai/kernel-linux-x64-musl": "0.5.0",
+    "@khive-ai/kernel-linux-arm64": "0.5.0",
+    "@khive-ai/kernel-win32-x64": "0.5.0"
   }
 }

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -94,7 +94,7 @@ DELAY=10  # seconds to wait for crates.io index between publishes
 # (which is why it is NOT a per-PR CI gate). Runs in preflight and live alike so
 # `make publish-dry` validates SemVer before any real publish. Crates with no
 # crates.io baseline yet (never published) have nothing to diff against and are
-# excluded until their first publish. As of the 0.4.0 cycle that is exactly the
+# excluded until their first publish. As of the 0.5.0 cycle that is exactly the
 # four crates added since 0.3.0: khive-changeset, khive-pack-code, khive-pack-git,
 # khive-pack-workspace. Every other workspace crate, including khive-quant and the
 # crates first shipped in 0.3.0, has a published 0.3.0 baseline and MUST be


### PR DESCRIPTION
## Summary

This is a release-prep PR only. It does not tag, publish, or trigger any release workflow.

- Bumps the workspace version from `0.4.0` to `0.5.0` (`crates/Cargo.toml`
  `workspace.package.version`), and mirrors that bump across every crate's inter-crate
  dependency version pins, `khive-merge`'s standalone `[workspace.package]` version (it is
  excluded from the main Cargo workspace, ADR-043), `npm/package.json`, the umbrella plugin
  manifest (`marketplace/khive/.claude-plugin/plugin.json`), `marketplace/INSTALL.md`, and the
  version references in `README.md` and `scripts/publish.sh`.
- Adds a `CHANGELOG.md` entry for `[0.5.0]` covering the ~40 commits merged since the last
  version bump commit, and backfills a `[0.4.0]` entry covering the ~244 commits in the range
  before it.

### Why a 0.4.0 backfill

`0.4.0` was already published to crates.io on 2026-07-12 (all workspace crates, via
`make publish`), but that release was never given a git tag, a changelog entry, or a GitHub
release. This PR backfills the changelog record for that release alongside the new `0.5.0`
entry so the changelog accurately reflects what is actually live on crates.io.

### Not in this PR (gated, separate step after approval)

- Creating the `v0.4.0` tag (backfilled against the commit that bumped the workspace to
  0.4.0) and the `v0.5.0` tag.
- Running `make publish` for the `0.5.0` crates.io release.
- Creating the GitHub releases for either version.

Those steps require explicit approval and will be done in a follow-up once this PR merges.

## Test plan

- [ ] `grep "^version" crates/Cargo.toml` reads `0.5.0`
- [ ] No stray khive-crate `0.4.0` version pins remain (third-party deps unaffected)
- [ ] CHANGELOG has both new `[0.5.0]` and `[0.4.0]` sections above `[0.3.0]`, with
      `[Unreleased]` left empty
- [ ] CI passes (no cargo build/publish is expected or required for this PR)
