### PR TITLE
test(khive-db): fix flaky tx-age sweep via tx_registry serial group

### DIFF
--- a/crates/khive-db/src/writer_task.rs
+++ b/crates/khive-db/src/writer_task.rs
@@ -420,6 +420,7 @@ async fn run_writer_task(
 mod tests {
     use super::*;
     use crate::pool::PoolConfig;
+    use serial_test::serial;
     use std::sync::atomic::{AtomicBool, Ordering};
     use std::sync::Arc;
     use std::time::Duration;
@@ -432,7 +433,14 @@ mod tests {
         ConnectionPool::new(cfg).expect("pool open")
     }
 
+    // `#[serial(tx_registry)]`: `run_writer_task` registers a `writer_task_tx`
+    // handle in the process-wide `tx_registry` singleton for the life of each
+    // `BEGIN IMMEDIATE`. Tests that observe the registry (the checkpoint
+    // `tx_age_sweep_*` group) read `tx_registry::oldest()`; an un-serialized
+    // spawning test here would leak a longer-lived `writer_task_tx` into that
+    // read and make the sweep name the wrong transaction. Share the key.
     #[tokio::test]
+    #[serial(tx_registry)]
     async fn begin_immediate_failure_replies_error_without_running_op() {
         // Real lock contention, not a simulation: hold the database-level
         // write lock from the pool's own writer connection (the unmigrated
@@ -504,7 +512,11 @@ mod tests {
         );
     }
 
+    // `#[serial(tx_registry)]`: shares the key with the checkpoint
+    // `tx_age_sweep_*` tests — see the note on
+    // `begin_immediate_failure_replies_error_without_running_op`.
     #[tokio::test]
+    #[serial(tx_registry)]
     async fn writer_task_executes_op_and_commits() {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("writer_task_commit.db");
@@ -627,7 +639,13 @@ mod tests {
         first.abort();
     }
 
+    // `#[serial(tx_registry)]`: this test deliberately keeps a request (and
+    // thus its `writer_task_tx` registry handle) alive past a timeout, so it is
+    // the worst polluter of the checkpoint `tx_age_sweep_*` reads if left
+    // un-serialized. Shares the key — see the note on
+    // `begin_immediate_failure_replies_error_without_running_op`.
     #[tokio::test]
+    #[serial(tx_registry)]
     async fn send_with_timeout_returns_op_result_when_op_outlives_the_timeout() {
         // `send_with_timeout`'s timeout must bound ONLY the enqueue step —
         // never the reply-wait. An accepted request (channel not full) must


### PR DESCRIPTION
## Fix flaky `tx_age_sweep_names_long_lived_reader_pinning_wal_past_high_water`

`checkpoint::tests::tx_age_sweep_*` read the process-wide `tx_registry`
singleton via `tx_registry::oldest()` and run under `#[serial(tx_registry)]`.
`run_writer_task` (ADR-067 Component A, khive-db) registers a `writer_task_tx`
handle in that same singleton for the life of each `BEGIN IMMEDIATE`. The
`writer_task.rs` tests that spawn a writer task were not part of the
`tx_registry` serial group, so a concurrent spawning test leaked a longer-lived
`writer_task_tx` into the sweep's `oldest()` read. The sweep then named that
transaction instead of the reader the test registered, and the assertion
failed. It was intermittent (the leak only overlaps the sweep on some
schedules), which is why main CI alternated red/green.

### Change
Add `#[serial(tx_registry)]` to the three `writer_task.rs` tests that spawn a
writer task (the only ones that register `writer_task_tx`), joining the
existing serial group. No production code changes.

### Verification
Ran the full `cargo test -p khive-db --lib` suite (default parallel threading,
the condition that surfaces the race) 5 consecutive times: all green,
`tx_age_sweep_*` passing every run. `cargo fmt --check` and
`cargo clippy -p khive-db --all-targets -- -D warnings` clean.
