### PR TITLE
fix: compile khive-runtime daemon subsystem on windows (0.5.0 release blocker)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -392,6 +392,28 @@ jobs:
       - name: Native sequential and owned-storage tests
         run: cargo test -p khive-quant -p khive-vamana --no-default-features
 
+  check-windows:
+    name: Windows compile check
+    runs-on: windows-latest
+    timeout-minutes: 30
+    defaults:
+      run:
+        working-directory: crates
+    steps:
+      - uses: actions/checkout@v7
+      - uses: dtolnay/rust-toolchain@1.94.1
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: crates
+          cache-on-failure: true
+      # 0.5.0 release blocker: khive-runtime/khive-mcp's daemon subsystem must
+      # compile on x86_64-pc-windows-msvc (the npm package's Windows target).
+      # Not (yet) a required check in branch protection — plain `cargo check`
+      # (no --all-targets) keeps this fast while the Windows lane is new;
+      # widen once it has proven stable.
+      - name: cargo check --workspace (Windows)
+        run: cargo check --workspace
+
   coverage-ratchet:
     name: Coverage ratchet
     runs-on: ubuntu-latest

--- a/crates/khive-mcp/src/server.rs
+++ b/crates/khive-mcp/src/server.rs
@@ -258,7 +258,12 @@ pub fn builtin_pack_names() -> Vec<&'static str> {
 }
 
 /// Which MCP handshake mode [`KhiveMcpServer::serve_stdio`] should use for
-/// this process instance (#714).
+/// this process instance (#714). Unix-only: the resumed-generation self-heal
+/// re-exec this decides between requires `crate::daemon`'s Unix-only
+/// mismatch-recovery machinery (in turn only ever armed by a Unix-domain-socket
+/// daemon-forwarding protocol mismatch); non-Unix `serve_stdio` always takes
+/// the plain handshake path (see its `#[cfg(not(unix))]` variant below).
+#[cfg(unix)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum StdioServeMode {
     /// Normal MCP `initialize` handshake — the overwhelmingly common case.
@@ -271,6 +276,7 @@ enum StdioServeMode {
 /// Pure decision behind [`StdioServeMode`], factored out so it is
 /// unit-testable without driving real stdio I/O. `resumed_generation` is
 /// [`crate::daemon::resumed_generation`]'s return value.
+#[cfg(unix)]
 fn stdio_serve_mode_for(resumed_generation: Option<u32>) -> StdioServeMode {
     match resumed_generation {
         Some(_) => StdioServeMode::Resumed,
@@ -547,6 +553,7 @@ impl KhiveMcpServer {
     /// edge that fires an armed self-heal re-exec (or drain-and-exit) only
     /// once a message has genuinely finished flushing to the client, never
     /// on a fixed timer that could race a slow or backpressured stdout.
+    #[cfg(unix)]
     pub async fn serve_stdio(self) -> anyhow::Result<()> {
         use rmcp::transport::{async_rw::AsyncRwTransport, stdio};
 
@@ -565,6 +572,23 @@ impl KhiveMcpServer {
                 service.waiting().await?;
             }
         }
+        Ok(())
+    }
+
+    /// Non-Unix stdio serving. The #714 self-heal re-exec mechanism
+    /// (`crate::daemon`'s `SelfHealOnFlushTransport`/resumed-generation
+    /// machinery) requires `exec()` (POSIX-only) and is only ever armed by a
+    /// Unix-domain-socket daemon-forwarding protocol mismatch — there is
+    /// nothing to self-heal from on this target (`--daemon` mode itself is
+    /// Unix-only, see `serve.rs::serve_server`), so this path always runs the
+    /// normal MCP `initialize` handshake directly over the raw stdio
+    /// transport, with no resumed-generation skip and no flush-triggered hook.
+    #[cfg(not(unix))]
+    pub async fn serve_stdio(self) -> anyhow::Result<()> {
+        use rmcp::transport::stdio;
+
+        let service = self.serve(stdio()).await?;
+        service.waiting().await?;
         Ok(())
     }
 
@@ -1514,6 +1538,7 @@ result (e.g. create then link with the new entity's id)."#)]
 /// [`McpError`] (#947), or `None` if `e` is not tagged with
 /// [`crate::daemon::STRICT_FALLBACK_MARKER`] — i.e. some other daemon-forward
 /// error that must stay an RPC-level error.
+#[cfg(unix)]
 fn strict_fallback_reason(e: &McpError) -> Option<String> {
     let data = e.data.as_ref()?;
     if data.get(crate::daemon::STRICT_FALLBACK_MARKER)?.as_bool() != Some(true) {
@@ -1533,6 +1558,7 @@ fn strict_fallback_reason(e: &McpError) -> Option<String> {
 /// each op's `error`, not an RPC-level `McpError`. Chain mode aborts after the
 /// first op, matching `run_parsed`'s `Chain` arm and the wire contract's
 /// documented abort-on-failure behavior for `|`-chained ops.
+#[cfg(unix)]
 fn strict_fallback_envelope_response(
     p: &RequestParams,
     reason: String,
@@ -1970,11 +1996,13 @@ mod tests {
 
     // ── serve_stdio handshake-mode decision (#714) ────────────────────────────
 
+    #[cfg(unix)]
     #[test]
     fn stdio_serve_mode_cold_start_uses_handshake() {
         assert_eq!(stdio_serve_mode_for(None), StdioServeMode::Handshake);
     }
 
+    #[cfg(unix)]
     #[test]
     fn stdio_serve_mode_resumed_generation_skips_handshake() {
         assert_eq!(stdio_serve_mode_for(Some(1)), StdioServeMode::Resumed);
@@ -2353,6 +2381,7 @@ mod tests {
     /// khive#948: `wire_daemon_frame` forwards `RequestParams::request_id`
     /// onto the `DaemonRequestFrame` unchanged, and defaults to `None` when
     /// the caller supplied none.
+    #[cfg(unix)]
     #[test]
     fn wire_daemon_frame_forwards_request_id() {
         let server = make_daemon_save_to_test_server();
@@ -2470,6 +2499,7 @@ mod tests {
         std::env::remove_var("KHIVE_SAVE_TO_ROOT");
     }
 
+    #[cfg(unix)]
     async fn connect_when_daemon_ready(sock: &std::path::Path) {
         let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(5);
         loop {
@@ -2491,6 +2521,7 @@ mod tests {
     /// `save_to` request must still take the local path and return the
     /// manifest with the file actually written — proving the daemon was
     /// bypassed rather than silently dropping the sink.
+    #[cfg(unix)]
     #[tokio::test]
     #[serial]
     async fn request_save_to_bypasses_daemon_forwarding_and_writes_manifest() {
@@ -2562,6 +2593,7 @@ mod tests {
     // mid-dispatch would) and proves both that the caller sees the
     // ambiguous-forward error verbatim AND that the mutating op never actually
     // ran locally.
+    #[cfg(unix)]
     #[tokio::test]
     #[serial]
     async fn request_returns_ambiguous_forward_error_without_local_double_dispatch() {
@@ -2672,6 +2704,7 @@ mod tests {
     // counts match `results`; and (4) none of the ops ever ran locally (a
     // `stats()` snapshot taken via the trusted `dispatch_request_local` path
     // is unchanged after all three calls).
+    #[cfg(unix)]
     #[tokio::test]
     #[serial]
     async fn request_strict_fallback_lands_as_failed_op_envelope_not_rpc_error() {

--- a/crates/khive-runtime/src/daemon.rs
+++ b/crates/khive-runtime/src/daemon.rs
@@ -8,24 +8,31 @@
 //! The client side (forwarding, auto-spawn) lives in the transport crate
 //! (e.g. `khive-mcp`), not here.
 
-use std::io::Write as _;
-use std::path::PathBuf;
 use std::sync::Arc;
 
+#[cfg(unix)]
+use std::io::Write as _;
 #[cfg(unix)]
 use std::os::unix::fs::PermissionsExt;
 #[cfg(unix)]
 use std::os::unix::io::AsRawFd;
+#[cfg(unix)]
+use std::path::PathBuf;
 
+#[cfg(unix)]
 use async_trait::async_trait;
 #[cfg(unix)]
 use libc;
 use serde::{Deserialize, Serialize};
+#[cfg(unix)]
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
+#[cfg(unix)]
 use tokio::net::{UnixListener, UnixStream};
 
+#[cfg(unix)]
 use khive_db::{run_checkpoint_task, CheckpointConfig, ConnectionPool};
 
+#[cfg(unix)]
 use crate::pack::RequestIdentity;
 
 /// Maximum frame size accepted in either direction.
@@ -49,10 +56,12 @@ pub const MAX_FRAME_BYTES: usize = 8 * 1024 * 1024;
 ///       `config_id` equality reject stays hard)
 pub const PROTOCOL_VERSION: u32 = 3;
 
+#[cfg(unix)]
 const DEFAULT_DRAIN_TIMEOUT_SECS: u64 = 10;
 
 // ── paths ─────────────────────────────────────────────────────────────────────
 
+#[cfg(unix)]
 fn khive_dir() -> PathBuf {
     let home = std::env::var("HOME").unwrap_or_else(|_| ".".into());
     PathBuf::from(home).join(".khive")
@@ -61,6 +70,7 @@ fn khive_dir() -> PathBuf {
 /// Unix socket path the daemon binds and clients connect to.
 ///
 /// Overridable via the `KHIVE_SOCKET` env var (for tests and ops).
+#[cfg(unix)]
 pub fn socket_path() -> PathBuf {
     if let Ok(p) = std::env::var("KHIVE_SOCKET") {
         if !p.is_empty() {
@@ -73,6 +83,7 @@ pub fn socket_path() -> PathBuf {
 /// PID file path written by the daemon.
 ///
 /// Overridable via the `KHIVE_PID` env var.
+#[cfg(unix)]
 pub fn pid_path() -> PathBuf {
     if let Ok(p) = std::env::var("KHIVE_PID") {
         if !p.is_empty() {
@@ -86,6 +97,7 @@ pub fn pid_path() -> PathBuf {
 /// clients (flock on the file; released when the lock file handle is dropped).
 ///
 /// Overridable via the `KHIVE_LOCK` env var (for tests).
+#[cfg(unix)]
 pub fn lock_path() -> PathBuf {
     if let Ok(p) = std::env::var("KHIVE_LOCK") {
         if !p.is_empty() {
@@ -104,6 +116,7 @@ pub fn lock_path() -> PathBuf {
 /// lock for that whole span would.
 ///
 /// Overridable via the `KHIVE_RECOVERER_LOCK` env var (for tests).
+#[cfg(unix)]
 pub fn recoverer_lock_path() -> PathBuf {
     if let Ok(p) = std::env::var("KHIVE_RECOVERER_LOCK") {
         if !p.is_empty() {
@@ -462,6 +475,7 @@ pub struct MetricsSnapshot {
 // ── framing ───────────────────────────────────────────────────────────────────
 
 /// Read one length-prefixed frame (4-byte BE u32 length + JSON bytes).
+#[cfg(unix)]
 pub async fn read_frame(stream: &mut UnixStream) -> std::io::Result<Vec<u8>> {
     let mut len_buf = [0u8; 4];
     stream.read_exact(&mut len_buf).await?;
@@ -478,6 +492,7 @@ pub async fn read_frame(stream: &mut UnixStream) -> std::io::Result<Vec<u8>> {
 }
 
 /// Write one length-prefixed frame.
+#[cfg(unix)]
 pub async fn write_frame(stream: &mut UnixStream, payload: &[u8]) -> std::io::Result<()> {
     if payload.len() > MAX_FRAME_BYTES {
         return Err(std::io::Error::new(
@@ -503,6 +518,7 @@ pub async fn write_frame(stream: &mut UnixStream, payload: &[u8]) -> std::io::Re
 /// while honoring [`DaemonRequestFrame::from_wire`] (so subhandler visibility is
 /// gated by request origin, not by transport); any future transport can do the
 /// same.
+#[cfg(unix)]
 #[async_trait]
 pub trait DaemonDispatch: Clone + Send + Sync + 'static {
     /// Dispatch a verb-DSL request string and return the rendered result.
@@ -711,6 +727,7 @@ pub fn active_phase_names() -> Vec<String> {
 /// anywhere this accept loop can reach. `write_queue_depth`/`_capacity`
 /// (ADR-067 Component A) come from the dispatcher's own pool, if any, and
 /// are `None` unless `KHIVE_WRITE_QUEUE=1` actually spawned a writer task.
+#[cfg(unix)]
 fn build_metrics_snapshot<D: DaemonDispatch>(dispatcher: &D) -> MetricsSnapshot {
     let open_tx_count = khive_storage::tx_registry::snapshot().len();
     let (oldest_pinned_tx_micros, oldest_pinned_tx_label) =
@@ -740,6 +757,7 @@ fn build_metrics_snapshot<D: DaemonDispatch>(dispatcher: &D) -> MetricsSnapshot 
     }
 }
 
+#[cfg(unix)]
 async fn handle_conn<D: DaemonDispatch>(mut stream: UnixStream, dispatcher: D) {
     let raw = match read_frame(&mut stream).await {
         Ok(r) => r,
@@ -948,11 +966,9 @@ async fn handle_conn<D: DaemonDispatch>(mut stream: UnixStream, dispatcher: D) {
 /// no separate boot-guard window to protect — but it still acquires the boot
 /// guard fatally (never proceeds unguarded), so the cleanup→bind→pid-write
 /// race surface is always mutually excluded.
+#[cfg(unix)]
 pub async fn run_daemon<D: DaemonDispatch>(dispatcher: D) -> anyhow::Result<()> {
-    #[cfg(unix)]
     let boot_guard = Some(acquire_daemon_boot_guard()?);
-    #[cfg(not(unix))]
-    let boot_guard = None;
     run_daemon_with_boot_guard(dispatcher, boot_guard).await
 }
 
@@ -976,6 +992,7 @@ pub async fn run_daemon<D: DaemonDispatch>(dispatcher: D) -> anyhow::Result<()> 
 /// `run_daemon`'s inline lock used to be, then dropped — see the "Deadlock
 /// note" below for why the caller must not still be holding a *different*
 /// handle to the same lock file at that point.
+#[cfg(unix)]
 pub async fn run_daemon_with_boot_guard<D: DaemonDispatch>(
     dispatcher: D,
     boot_guard: Option<std::fs::File>,
@@ -985,7 +1002,6 @@ pub async fn run_daemon_with_boot_guard<D: DaemonDispatch>(
 
     if let Some(parent) = sock.parent() {
         std::fs::create_dir_all(parent)?;
-        #[cfg(unix)]
         if let Err(e) = std::fs::set_permissions(parent, std::fs::Permissions::from_mode(0o700)) {
             tracing::warn!(error = %e, path = ?parent, "failed to chmod 0700 khive dir");
         }
@@ -1012,17 +1028,14 @@ pub async fn run_daemon_with_boot_guard<D: DaemonDispatch>(
     }
 
     let listener = UnixListener::bind(&sock)?;
-    #[cfg(unix)]
     if let Err(e) = std::fs::set_permissions(&sock, std::fs::Permissions::from_mode(0o600)) {
         tracing::warn!(error = %e, path = ?sock, "failed to chmod 0600 socket");
     }
     // Captured while still holding the startup lock, immediately after
     // bind, so shutdown cleanup can later prove "this is still the same socket
     // I bound" rather than trusting the path alone.
-    #[cfg(unix)]
     let bound_identity = socket_identity(&sock);
 
-    #[cfg(unix)]
     if let Err(e) = write_pid_file_exclusive(&pid_file) {
         if e.kind() == std::io::ErrorKind::AlreadyExists {
             // A PID file appeared between our own `cleanup_stale_daemon`
@@ -1049,12 +1062,9 @@ pub async fn run_daemon_with_boot_guard<D: DaemonDispatch>(
         }
         return Err(e.into());
     }
-    #[cfg(not(unix))]
-    write_pid_file_exclusive(&pid_file)?;
     // Release the startup lock now: the listener is bound and the PID file is
     // written.  Any concurrent client or daemon startup will observe a live
     // socket+pid and take the non-recovery path.
-    #[cfg(unix)]
     drop(_startup_lock);
     tracing::info!(socket = ?sock, pid = std::process::id(), "khived listening");
 
@@ -1138,24 +1148,16 @@ pub async fn run_daemon_with_boot_guard<D: DaemonDispatch>(
     // `sock` is still the exact one this daemon bound — otherwise a
     // replacement daemon owns those paths now and unlinking would delete its
     // live socket/PID out from under it.
-    #[cfg(unix)]
-    {
-        match acquire_recovery_lock() {
-            Some(_shutdown_lock) => {
-                shutdown_cleanup_if_owned(&sock, &pid_file, bound_identity);
-            }
-            None => {
-                tracing::warn!(
-                    "could not acquire recovery lock for shutdown cleanup; \
-                     skipping unlink to avoid deleting a replacement daemon's paths"
-                );
-            }
+    match acquire_recovery_lock() {
+        Some(_shutdown_lock) => {
+            shutdown_cleanup_if_owned(&sock, &pid_file, bound_identity);
         }
-    }
-    #[cfg(not(unix))]
-    {
-        let _ = std::fs::remove_file(&sock);
-        let _ = std::fs::remove_file(&pid_file);
+        None => {
+            tracing::warn!(
+                "could not acquire recovery lock for shutdown cleanup; \
+                 skipping unlink to avoid deleting a replacement daemon's paths"
+            );
+        }
     }
     tracing::info!("khived stopped");
     Ok(())
@@ -1198,6 +1200,7 @@ fn shutdown_cleanup_if_owned(
 // ── helpers ───────────────────────────────────────────────────────────────────
 
 /// Liveness verdict for a `kill(pid, 0)` probe.
+#[cfg(unix)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum PidLiveness {
     /// errno 0 — signal delivery succeeded, the process exists and this
@@ -1212,6 +1215,7 @@ enum PidLiveness {
     PermissionDenied,
 }
 
+#[cfg(unix)]
 impl PidLiveness {
     fn is_running(self) -> bool {
         !matches!(self, PidLiveness::Dead)
@@ -1221,6 +1225,7 @@ impl PidLiveness {
 /// Maps a `kill(pid, 0)` outcome (return code + errno) to a [`PidLiveness`].
 /// Pure and side-effect-free so the errno mapping can be unit tested without
 /// a real process probe.
+#[cfg(unix)]
 fn classify_kill_result(rc: i32, errno: i32) -> PidLiveness {
     if rc == 0 {
         return PidLiveness::Alive;
@@ -1231,6 +1236,7 @@ fn classify_kill_result(rc: i32, errno: i32) -> PidLiveness {
     }
 }
 
+#[cfg(unix)]
 fn is_process_running(pid: u32) -> bool {
     let Ok(pid) = i32::try_from(pid) else {
         return false;
@@ -1244,6 +1250,7 @@ fn is_process_running(pid: u32) -> bool {
     classify_kill_result(rc, errno).is_running()
 }
 
+#[cfg(unix)]
 async fn cleanup_stale_daemon(sock: &std::path::Path, pid_file: &std::path::Path) -> bool {
     if let Ok(pid_str) = std::fs::read_to_string(pid_file) {
         if let Ok(pid) = pid_str.trim().parse::<u32>() {
@@ -1279,14 +1286,12 @@ async fn cleanup_stale_daemon(sock: &std::path::Path, pid_file: &std::path::Path
 /// the defense that holds even if the lock itself is unavailable to one side:
 /// the loser observes `ErrorKind::AlreadyExists` instead of clobbering the
 /// winner's PID out from under it.
+#[cfg(unix)]
 fn write_pid_file_exclusive(pid_file: &std::path::Path) -> std::io::Result<()> {
+    use std::os::unix::fs::OpenOptionsExt;
+
     let mut opts = std::fs::OpenOptions::new();
-    opts.write(true).create_new(true);
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::OpenOptionsExt;
-        opts.mode(0o600);
-    }
+    opts.write(true).create_new(true).mode(0o600);
     let mut f = opts.open(pid_file)?;
     f.write_all(std::process::id().to_string().as_bytes())?;
     Ok(())
@@ -1313,6 +1318,7 @@ async fn pid_file_names_a_reachable_daemon(
         && UnixStream::connect(sock).await.is_ok()
 }
 
+#[cfg(unix)]
 async fn drain(active: &std::sync::atomic::AtomicUsize) {
     use std::sync::atomic::Ordering;
     let remaining = || active.load(Ordering::Relaxed) + background_task_count();
@@ -1333,6 +1339,7 @@ async fn drain(active: &std::sync::atomic::AtomicUsize) {
     }
 }
 
+#[cfg(unix)]
 fn drain_timeout() -> std::time::Duration {
     let secs = std::env::var("KHIVE_DRAIN_TIMEOUT_SECS")
         .ok()
@@ -1342,6 +1349,7 @@ fn drain_timeout() -> std::time::Duration {
 }
 
 /// Returns `true` for non-empty env values that are not `"0"` or `"false"`.
+#[cfg(unix)]
 pub fn env_truthy(key: &str) -> bool {
     std::env::var(key)
         .map(|v| {
@@ -1351,7 +1359,7 @@ pub fn env_truthy(key: &str) -> bool {
         .unwrap_or(false)
 }
 
-#[cfg(test)]
+#[cfg(all(test, unix))]
 mod tests {
     use super::*;
     use serial_test::serial;

--- a/crates/khive-runtime/src/lib.rs
+++ b/crates/khive-runtime/src/lib.rs
@@ -10,7 +10,6 @@ pub mod config;
 pub mod config_ledger;
 pub mod cost_unit;
 pub mod curation;
-#[cfg(unix)]
 pub mod daemon;
 pub mod embedder_registry;
 pub mod engine_config;
@@ -47,11 +46,10 @@ pub use curation::{
     EntityDedupMergePolicy, EntityPatch, MergeSummary, NotePatch,
 };
 #[cfg(unix)]
-pub use daemon::acquire_recovery_lock;
+pub use daemon::{acquire_recovery_lock, pid_path, run_daemon, socket_path, DaemonDispatch};
 pub use daemon::{
-    active_phase_names, background_task_count, pid_path, register_active_phase, run_daemon,
-    socket_path, track_background_task, DaemonDispatch, DaemonRequestFrame, DaemonResponseFrame,
-    PhaseGuard, PROTOCOL_VERSION,
+    active_phase_names, background_task_count, register_active_phase, track_background_task,
+    DaemonRequestFrame, DaemonResponseFrame, PhaseGuard, PROTOCOL_VERSION,
 };
 pub use embedder_registry::{EmbedderProvider, EmbedderRegistry, LatticeEmbedderProvider};
 pub use engine_config::{

--- a/crates/khive-runtime/tests/cold_boot_fts_race.rs
+++ b/crates/khive-runtime/tests/cold_boot_fts_race.rs
@@ -18,6 +18,12 @@
 //! (real threads + the real lock primitive, not a mocked scheduler), but
 //! here the "critical section" is a real cold-boot migration run plus real
 //! writes instead of a synthetic counter.
+//!
+//! Unix-only: drives `khive_runtime::daemon::acquire_recovery_lock`, gated
+//! `#[cfg(unix)]` (advisory `flock`-based boot/recovery locking has no
+//! non-Unix equivalent in this crate).
+
+#![cfg(unix)]
 
 use khive_runtime::{KhiveRuntime, Namespace, RuntimeConfig};
 use khive_storage::types::SqlStatement;

--- a/crates/kkernel/tests/mcp_bridge_reexec_protocol_mismatch.rs
+++ b/crates/kkernel/tests/mcp_bridge_reexec_protocol_mismatch.rs
@@ -42,6 +42,12 @@
 //! marker can ever emit, and the only way that marker exists is a completed
 //! `exec()` (this test never spawns a second process itself).
 
+//! Unix-only: drives `khive_runtime::daemon::{read_frame, write_frame}` and
+//! `tokio::net::UnixListener`, both gated `#[cfg(unix)]`, and exercises the
+//! real `exec()`-based bridge self-heal path, which is POSIX-only.
+
+#![cfg(unix)]
+
 use std::process::Stdio;
 use std::time::Duration;
 


### PR DESCRIPTION
## Summary

The 0.5.0 npm release broke on `x86_64-pc-windows-msvc` with E0432 unresolved
imports. `crates/khive-runtime/src/lib.rs` gated `pub mod daemon;` behind
`#[cfg(unix)]` but re-exported several of `daemon.rs`'s public symbols
ungated, and those symbols are consumed unconditionally cross-platform by
`khive-pack-memory`, `kkernel/src/exec.rs`, and `khive-mcp/src/server.rs`.

- Split `crates/khive-runtime/src/daemon.rs` at the item level into
  cross-platform wire types/counters (`MAX_FRAME_BYTES`, `PROTOCOL_VERSION`,
  `DaemonRequestFrame`, `DaemonResponseFrame`, `MetricsSnapshot`,
  `track_background_task`/`background_task_count`/`BackgroundTaskGuard`,
  `active_phase_names`/`register_active_phase`/`PhaseGuard`) vs. the
  Unix-domain-socket daemon machinery (`UnixListener`/`UnixStream`,
  `flock`-based paths, `DaemonDispatch`, `run_daemon`,
  PID/process-liveness), gating the latter `#[cfg(unix)]`.
- Un-gated `pub mod daemon;` in `lib.rs` and split its re-export block into
  a `#[cfg(unix)]` group and a cross-platform group.
- Found and fixed a second, unplanned break: `khive-mcp/src/server.rs`'s
  `serve_stdio()` — the actual Windows MCP entry point, since `--daemon`
  mode is already Unix-only — unconditionally referenced the
  already-Unix-gated `khive-mcp::daemon` module's #714 self-heal machinery
  (`SelfHealOnFlushTransport`, `resumed_generation()`). Split `serve_stdio`
  and its supporting `StdioServeMode`/`stdio_serve_mode_for` into
  `#[cfg(unix)]`/`#[cfg(not(unix))]` variants; the non-Unix path serves the
  raw stdio transport directly, since there is no Unix daemon-forwarding
  protocol mismatch to self-heal from on that target.
- Gated the two Unix-only integration test files
  (`crates/khive-runtime/tests/cold_boot_fts_race.rs`,
  `crates/kkernel/tests/mcp_bridge_reexec_protocol_mismatch.rs`) with
  `#![cfg(unix)]`, and `daemon.rs`'s unit test module with
  `#[cfg(all(test, unix))]`.
- Added a new `check-windows` CI job (`windows-latest`, `cargo check
  --workspace`) to catch this class of break going forward. Not added as a
  required branch-protection check yet — kept minimal (`cargo check`, not
  `--all-targets`) while the Windows lane proves out.

No behavior change on Unix/macOS.

## Verification

From `crates/`, all green:
- `cargo check --workspace` — pass
- `cargo clippy --workspace --all-targets -- -D warnings` — pass
- `cargo fmt --all -- --check` — pass
- `cargo test -p khive-runtime -p khive-mcp -p kkernel` — 1512 tests passed, 0 failed, 7 ignored (doc-tests), across all 16 test binaries in the three touched crates

Windows compilation itself is **not** locally verified (no MSVC toolchain
available in this environment) — that's deferred to the new `check-windows`
CI job on this PR. Manually traced the three previously-failing import
chains against the final diff:
- `khive-pack-memory` → `track_background_task` — left ungated (cross-platform)
- `kkernel/src/exec.rs` → `DaemonRequestFrame` + `PROTOCOL_VERSION` — left ungated (cross-platform)
- `khive-mcp/src/server.rs` → `DaemonRequestFrame` — left ungated (cross-platform)

None of the three reference anything still gated `#[cfg(unix)]`.

## Test plan

- [ ] CI green on this PR (including the new, non-required `check-windows` job)
- [ ] Confirm `check-windows` job actually compiles clean on `windows-latest` once CI runs
- [ ] Do not merge until Windows CI is confirmed green

🤖 Generated with [Claude Code](https://claude.com/claude-code)