### PR TITLE
chore: gitignore agent workflow scratch notes (implementation_notes.md)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -87,6 +87,10 @@ npm/bin/khive-*
 # Codex review artifacts (local working notes, not part of the codebase)
 codex_review_*.md
 
+# Agent workflow scratch notes (some review/fix legs write these at the repo
+# root as process notes; they are never part of the source tree)
+implementation_notes.md
+
 # Real-data recall benchmark corpus (extracted from khive-graph.db, never commit)
 crates/khive-pack-memory/tests/fixtures/
 


### PR DESCRIPTION
Some review and fix legs write an `implementation_notes.md` file at the repo root as process notes, and a batch of them recently leaked into open PRs. This adds the pattern to `.gitignore`, next to the existing `codex_review_*.md` entry.

A tracked ignore is the guarantee for fresh clones (external contributors, CI); a local ignore only covers existing local clones. Hygiene-only, no code change.