### PR TITLE
ci: reclaim runner disk in coverage-ratchet job before llvm-cov

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -428,6 +428,18 @@ jobs:
     # rejected and fail the job on every merge.
     steps:
       - uses: actions/checkout@v7
+      # `cargo llvm-cov --workspace` is the disk-heaviest command in CI: it
+      # instruments every crate and emits per-object profraw files on top of the
+      # normal target dir, overflowing the ubuntu runner's ~21GB and surfacing as
+      # `No space left on device`. The matrix `ci` job already purges the unused
+      # preinstalled toolchains to reclaim ~25GB; this gate needs the same purge.
+      - name: Free runner disk (Linux)
+        if: runner.os == 'Linux'
+        run: |
+          df -h /
+          sudo rm -rf /usr/local/lib/android /usr/share/dotnet /opt/ghc /usr/local/.ghcup /opt/hostedtoolcache/CodeQL
+          sudo docker image prune --all --force || true
+          df -h /
       - uses: dtolnay/rust-toolchain@1.94.1
         with:
           components: llvm-tools-preview


### PR DESCRIPTION
## Problem

The required **CI gate** aggregate depends on the `coverage-ratchet` job, which runs `cargo llvm-cov --workspace`. That is the disk-heaviest command in CI: full-workspace instrumentation plus per-object `.profraw` files on top of the normal target dir overflow the ubuntu runner's ~21GB and surface as `System.IO.IOException: No space left on device`. The job then fails as `Coverage ratchet: failure`, which fails the required gate.

Because it depends on how full the runner happens to be, the failure is non-deterministic: an identical branch (including docs-only PRs that add zero code) can pass or fail the ratchet run to run.

## Fix

The matrix `ci` job already purges the unused preinstalled toolchains (Android, .NET, GHC, CodeQL, docker images) to reclaim ~25GB before building. The `coverage-ratchet` job was missing that step even though it runs the single heaviest command. This PR adds the identical purge right after checkout so the llvm-cov pass has headroom and the gate becomes deterministic.

No change to what the ratchet measures or the baseline — purely a runner-disk headroom fix.