### PR TITLE
test(pack-git): lock in ingest masking for uuid-near-trigger FP (#977)

### DIFF
--- a/crates/khive-pack-git/tests/acceptance.rs
+++ b/crates/khive-pack-git/tests/acceptance.rs
@@ -690,6 +690,166 @@ async fn ingest_masks_credential_shaped_issue_title_without_dropping_note() {
     );
 }
 
+/// Issue #977: a legitimate issue whose title mentions a credential-like
+/// word (e.g. "key", "auth", "token") while the body separately contains an
+/// unrelated full UUID must not be write-blocked by the `uuid-near-trigger`
+/// heuristic. `MaskedIssueFields` masks `title` and `body` independently
+/// before the note is ever created, so a trigger word in one field cannot
+/// "arm" a UUID in the other -- covers the exact cross-field shape reported
+/// live against `git.digest`.
+#[tokio::test]
+async fn ingest_does_not_block_issue_with_credential_word_in_title_and_uuid_in_body() {
+    let _guard = ENV_MUTEX.lock().await;
+    let (rt, token, registry) = fixture().await;
+
+    let project_id = create(
+        &registry,
+        json!({"kind": "project", "name": "issue-977-cross-field-repo"}),
+    )
+    .await;
+
+    let dir = tempfile::tempdir().expect("tempdir");
+    let repo: PathBuf = dir.path().join("repo");
+    std::fs::create_dir_all(&repo).expect("mk repo dir");
+    init_repo(&repo);
+    write(&repo, "README.md", "hello\n");
+    commit(&repo, &["README.md"], "Initial commit");
+
+    let bin_dir = dir.path().join("bin");
+    std::fs::create_dir_all(&bin_dir).expect("mk bin dir");
+    let log_dir = dir.path().join("log");
+    std::fs::create_dir_all(&log_dir).expect("mk log dir");
+
+    let issue_json = json!([{
+        "number": 977,
+        "title": "Rotate the api_key configuration",
+        "author": {"login": "octocat"},
+        "createdAt": "2026-01-01T00:00:00Z",
+        "closedAt": null,
+        "updatedAt": "2026-01-01T00:00:00Z",
+        "labels": [],
+        "stateReason": "",
+        "body": "See tracking record 550e8400-e29b-41d4-a716-446655440000 for details."
+    }])
+    .to_string();
+
+    write_fake_gh(&bin_dir, &log_dir, "[]", &issue_json);
+    let _path_guard = PathGuard::install(&bin_dir);
+
+    let report = run_ingest(
+        &rt,
+        &token,
+        &registry,
+        IngestOptions::unbounded(repo.clone(), project_id.to_string()),
+    )
+    .await
+    .expect("ingest ok");
+
+    assert_eq!(
+        report.issues_ingested, 1,
+        "the issue must not be dropped: {report:?}"
+    );
+    assert!(
+        report.warnings.iter().all(|w| !w.contains("issue #977")),
+        "no silent-drop warning may be reported: {:?}",
+        report.warnings
+    );
+
+    let issues_list = registry
+        .dispatch("list", json!({"kind": "issue", "limit": 10}))
+        .await
+        .expect("list issues ok");
+    let items = issues_list.as_array().expect("array");
+    assert_eq!(items.len(), 1);
+    let stored_content = items[0]["content"].as_str().expect("content is string");
+    assert!(
+        stored_content.contains("550e8400-e29b-41d4-a716-446655440000"),
+        "an unrelated UUID with no trigger word nearby in its own field must \
+         survive verbatim, not be masked away: {stored_content:?}"
+    );
+}
+
+/// Issue #977 sibling case: the credential-like word and the UUID appear
+/// together in the SAME field (the body). `mask_secrets` -- not the hard
+/// `check()` gate -- is what `ingest_issues` applies to `body`, so the
+/// ambiguous span is redacted in place and the issue still lands, rather
+/// than the whole note being dropped with "reword the source" advice that
+/// makes no sense for content the ingester does not own.
+#[tokio::test]
+async fn ingest_masks_credential_word_and_uuid_co_occurring_in_issue_body() {
+    let _guard = ENV_MUTEX.lock().await;
+    let (rt, token, registry) = fixture().await;
+
+    let project_id = create(
+        &registry,
+        json!({"kind": "project", "name": "issue-977-same-field-repo"}),
+    )
+    .await;
+
+    let dir = tempfile::tempdir().expect("tempdir");
+    let repo: PathBuf = dir.path().join("repo");
+    std::fs::create_dir_all(&repo).expect("mk repo dir");
+    init_repo(&repo);
+    write(&repo, "README.md", "hello\n");
+    commit(&repo, &["README.md"], "Initial commit");
+
+    let bin_dir = dir.path().join("bin");
+    std::fs::create_dir_all(&bin_dir).expect("mk bin dir");
+    let log_dir = dir.path().join("log");
+    std::fs::create_dir_all(&log_dir).expect("mk log dir");
+
+    let issue_json = json!([{
+        "number": 978,
+        "title": "Investigate flaky ingest",
+        "author": {"login": "octocat"},
+        "createdAt": "2026-01-01T00:00:00Z",
+        "closedAt": null,
+        "updatedAt": "2026-01-01T00:00:00Z",
+        "labels": [],
+        "stateReason": "",
+        "body": "We rotated the auth key, tracking record 550e8400-e29b-41d4-a716-446655440000 for details."
+    }])
+    .to_string();
+
+    write_fake_gh(&bin_dir, &log_dir, "[]", &issue_json);
+    let _path_guard = PathGuard::install(&bin_dir);
+
+    let report = run_ingest(
+        &rt,
+        &token,
+        &registry,
+        IngestOptions::unbounded(repo.clone(), project_id.to_string()),
+    )
+    .await
+    .expect("ingest ok");
+
+    assert_eq!(
+        report.issues_ingested, 1,
+        "the issue must not be dropped: {report:?}"
+    );
+    assert!(
+        report.warnings.iter().all(|w| !w.contains("issue #978")),
+        "no silent-drop warning may be reported: {:?}",
+        report.warnings
+    );
+
+    let issues_list = registry
+        .dispatch("list", json!({"kind": "issue", "limit": 10}))
+        .await
+        .expect("list issues ok");
+    let items = issues_list.as_array().expect("array");
+    assert_eq!(items.len(), 1);
+    let stored_content = items[0]["content"].as_str().expect("content is string");
+    assert!(
+        !stored_content.contains("550e8400-e29b-41d4-a716-446655440000"),
+        "the ambiguous UUID-near-trigger span must be masked, not stored raw: {stored_content:?}"
+    );
+    assert!(
+        stored_content.contains("***MASKED***"),
+        "masked marker must be present in place of the ambiguous span: {stored_content:?}"
+    );
+}
+
 /// A clean (non-credential) issue title and an empty body must pass through
 /// `ingest_issues` unchanged -- guards against a future over-aggressive
 /// masking regression that the detector-positive test above cannot catch.


### PR DESCRIPTION
## Summary

- Investigated the false positive reported in #977: a legitimate GitHub issue whose title mentions a credential-like word (e.g. `key`, `auth`) while the body separately contains an unrelated UUID was reported to trip the `uuid-near-trigger` heuristic and cause `git.digest` to write-block the whole issue.
- Traced through `khive-pack-git`'s ingest path (`ingest_issues` / `MaskedIssueFields`) and confirmed the fix is already in place: `title` and `body` are each passed through `secret_gate::mask_secrets` (not the hard `check()` gate) before the note is ever created. This landed via #835/#910, both merged before #977 was filed.
- Verified empirically (including a batch of trigger-word/UUID combinations, cross-field and same-field) that the reported scenario no longer write-blocks: the ambiguous span is masked in place and the issue note still lands.
- Added two regression tests to `khive-pack-git/tests/acceptance.rs` that lock in this behavior so it cannot silently regress:
  - `ingest_does_not_block_issue_with_credential_word_in_title_and_uuid_in_body` — trigger word in title, UUID in body (different fields); the unrelated UUID must survive verbatim.
  - `ingest_masks_credential_word_and_uuid_co_occurring_in_issue_body` — trigger word and UUID in the same field; the ambiguous span must be masked, not block the write.

No production code changes were needed — the masking behavior these tests exercise already exists on `main`.

## Test plan

- [x] `cargo test -p khive-pack-git` — 74 unit tests + 54 acceptance tests pass (including the 2 new regression tests)
- [x] `cargo clippy -p khive-pack-git --all-targets -- -D warnings` — clean
- [x] `cargo fmt -p khive-pack-git -- --check` — clean

Closes #977

🤖 Generated with [Claude Code](https://claude.com/claude-code)