### PR TITLE
docs(guide): communication feature-area user guide (rustdoc condensation)

### DIFF
--- a/docs/guide/communication.md
+++ b/docs/guide/communication.md
@@ -22,6 +22,7 @@ request(ops="comm.send(to=\"another-actor\", subject=\"Review needed\", content=
 
 The recipient checks its inbox. It returns inbound messages addressed to the
 calling actor; unread is the default view.
+For compatibility, legacy messages without `to_actor` remain visible.
 
 ```text
 request(ops="comm.inbox(status=\"unread\", limit=10)")
@@ -71,15 +72,16 @@ Inspect the response `namespace`: a non-local scoped call can validly return
 When the optional email channel is configured, it uses the same comm message
 model. Address a new email as `email:person@example.com` and provide a
 `subject` conventionally, but it is optional; when omitted, the channel
-delivers `(no subject)`. The channel delivers stored outbound messages
-asynchronously. Reply to an inbound email with `comm.reply` to preserve its
-conversation linkage.
+delivers `(no subject)`. The daemon asynchronously delivers eligible stored
+outbound messages. Recipients must be in its configured outbound allowlist,
+which defaults to the maintainer address. Reply to an inbound email with
+`comm.reply` to preserve its conversation linkage.
 See [Configuration](../configuration.md) for email-channel setup.
 
 ## Gotchas
 
 - A send to your own configured actor address is refused unless you explicitly
-  pass `self_send=true`.
+  pass `self_send=true`; the anonymous `local` fallback is exempt.
 - An email `subject` is conventional but optional; an omitted subject is
   delivered as `(no subject)`.
 - An inbox is scoped to the calling actor address. If an expected message is

--- a/docs/guide/communication.md
+++ b/docs/guide/communication.md
@@ -1,294 +1,81 @@
 # Communication and Email
 
-This guide covers the comm pack: actor-addressed messaging inside khive, and
-the optional email channel that bridges that same messaging model to an
-external mailbox.
+The comm pack provides actor-addressed messaging with an inbox model. Use it
+when one actor needs to send another a directed message, follow up on it, and
+keep the exchange together as a thread. Messages are not a shared chat stream:
+each actor reads the inbound messages addressed to its own actor address.
 
-## What messages are
+Full parameter signatures live in the [comm pack rustdoc](../../crates/khive-pack-comm/src/vocab.rs).
+This page describes the working flow rather than duplicating that reference.
 
-Messages are notes with `kind=message`, managed by the comm pack
-(`crates/khive-pack-comm/`). `comm.send` writes both an outbound copy (in the
-sender's namespace) and an inbound copy (addressed to the recipient), so a
-send always produces two notes and no cross-namespace write occurs even when
-`to` names a different actor.
+## Send, receive, and act
 
-## Actor addressing
+Start with `comm.send`. A send is a dual-write: the sender gets an outbound
+copy and the addressed actor gets an inbound copy. That makes delivery
+cross-actor while keeping the recipient's inbox actor-filtered.
 
-Actors are labeled strings such as `lambda:leo` or `lambda:khive`. `comm.send`
-stores the caller's actor label as `from_actor` and the `to` argument as
-`to_actor` on both the outbound and inbound copies.
-
-```
-request(ops="comm.send(to=\"lambda:leo\", content=\"PR #610 merged\")")
+```text
+request(ops="comm.send(to=\"another-actor\", subject=\"Review needed\", content=\"Please review the change set.\")")
 ```
 
-`comm.inbox` filters by `to_actor` for the calling actor. Legacy messages
-written before actor addressing existed have no `to_actor` field and remain
-visible to every actor (an `EqOrMissing` match), so older history is not
-hidden by the newer filter.
+The recipient checks its inbox. It returns inbound messages addressed to the
+calling actor; unread is the default view.
 
-### Send
-
-| Param       | Type   | Required | Notes                                                                                                                                                                                           |
-| ----------- | ------ | -------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `to`        | string | yes      | Actor label, e.g. `"lambda:leo"`.                                                                                                                                                               |
-| `content`   | string | yes      | Message body. Must not be empty.                                                                                                                                                                |
-| `subject`   | string | no       | Optional subject line.                                                                                                                                                                          |
-| `thread_id` | uuid   | no       | Groups the message into an existing thread.                                                                                                                                                     |
-| `self_send` | bool   | no       | Default false. Required when `to` matches the configured sender actor; otherwise the send is rejected. The anonymous `local` fallback is exempt. Use true only for an intentional note to self. |
-
-A configured actor that addresses itself must opt in with `self_send=true`. If the
-target was meant to be a distinct parent or sub-agent, configure distinct actor identities
-instead of opting in; the rejection is intended to expose that identity collapse.
-
-### Inbox
-
-| Param    | Type    | Required | Notes                                        |
-| -------- | ------- | -------- | -------------------------------------------- |
-| `limit`  | integer | no       | Default 20, max 200.                         |
-| `status` | string  | no       | `"unread"` (default) \| `"read"` \| `"all"`. |
-
-```
-request(ops="comm.inbox(limit=10)")
-request(ops="comm.inbox(status=\"all\")")
+```text
+request(ops="comm.inbox(status=\"unread\", limit=10)")
 ```
 
-### Read
+After acting on a message, reply and then mark that same inbound message as
+read. Repeat the inbox message ID in both operations: `comm.reply` returns an
+outbound message ID, which is not valid input to `comm.read`.
 
-Marks an inbound message read. Outbound messages cannot be marked read.
-
-```
-request(ops="comm.read(id=\"<message_id_or_prefix>\")")
-```
-
-`id` accepts either a full UUID or a short 8-character hex prefix.
-
-### Reply
-
-Replies thread against the original message. If the original had no subject,
-the reply carries no subject either; otherwise the reply subject is prefixed
-`Re:` (and not re-prefixed if it already starts with `Re:`).
-
-```
-request(ops="comm.reply(id=\"<message_id_or_prefix>\", content=\"Thanks, following up now\")")
+```text
+request(ops="comm.reply(id=\"<inbound-message-id>\", content=\"I will review it today.\") | comm.read(id=\"<inbound-message-id>\")")
 ```
 
-### Thread
+`comm.read` is for received (inbound) messages only. Do not mark a message
+read before you have handled it; an outbound copy cannot be marked read.
 
-Retrieves every message in a conversation thread, ordered chronologically,
-given the thread root's id.
+## Follow a conversation
 
-```
-request(ops="comm.thread(id=\"<root_message_id_or_prefix>\", limit=50)")
-```
+Replies retain the conversation's thread automatically. To inspect it, call
+`comm.thread` with an `id` for a message in the conversation. Both
+`comm.reply` and `comm.thread` take a message ID in the parameter named `id`,
+not a `thread_id`; the thread operation resolves the conversation root.
 
-`limit` defaults to 100 and caps at 500.
+Use `comm.inbox(status="all")` when you need a message ID from older inbox
+history. Thread results are chronological by default; the signature reference
+documents pagination and ordering options.
 
-### Health
+## Polling and channel status
 
-`comm.health()` is a read-only, no-argument verb that reports per-channel
-polling state, keyed by `(channel_kind, channel_slug)`. It never returns a
-computed `healthy` boolean: staleness and alerting judgment stay with the
-caller, not the pack.
+`comm.probe` is a read-only poll for newly arrived inbound-message metadata
+and the count of stale unread messages. Supply the actor address being watched
+and round-trip the returned `cursor_us` unchanged as the next `since_us`.
+That cursor is opaque, not a timestamp, and probing never changes read flags.
 
-```
-request(ops="comm.health()")
-```
+`comm.health()` is a read-only, per-channel heartbeat snapshot. Its channel
+rows report poll timestamps and consecutive failure counts; it deliberately
+does not make a health judgment. Decide staleness or alerting in the caller.
 
-Each entry in the returned `channels` array carries:
+## Email
 
-| Field                  | Notes                                                                                                                                                    |
-| ---------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `channel_kind`         | e.g. `"email"`.                                                                                                                                          |
-| `channel_slug`         | Per-credential identifier (the configured mailbox address for the email channel), so two accounts of the same `channel_kind` get distinct rows.          |
-| `last_success_at`      | Timestamp of the most recent successful poll attempt, or `null`.                                                                                         |
-| `last_failure_at`      | Timestamp of the most recent failed poll attempt, or `null`.                                                                                             |
-| `last_poll_attempt_at` | Timestamp of the most recent poll attempt regardless of outcome.                                                                                         |
-| `last_error`           | `{class, message, at}` of the most recent failure. `class` is one of `auth`, `transport`, `config` (an open enum; callers must tolerate unknown values). |
-| `consecutive_failures` | Resets to 0 on success, increments on failure.                                                                                                           |
+When the optional email channel is configured, it uses the same comm message
+model. Address a new email as `email:person@example.com` and provide a
+`subject`; the channel delivers stored outbound messages asynchronously. Reply
+to an inbound email with `comm.reply` to preserve its conversation linkage.
+See [Configuration](../configuration.md) for email-channel setup.
 
-`last_error` is retained after a later success: a success updates
-`last_success_at` and resets `consecutive_failures` to 0 but never clears
-`last_error`. Compare `last_error.at` against `last_success_at` to tell a
-resolved failure from one that is still live.
+## Gotchas
 
-Heartbeat rows are always persisted to the fixed `local` operational
-namespace by `comm.heartbeat`, regardless of the caller's own namespace or
-`KHIVE_EMAIL_INGEST_NAMESPACE` — that write path is intentionally pinned,
-since heartbeat rows are an operational surface, not message data.
-`comm.health` itself is not pinned (khive #877): it reads from the caller's
-injected namespace, the same `namespace=` escape / `"local"` default every
-other comm verb resolves. An unscoped call still defaults to `"local"` and
-so still sees what `comm.heartbeat` wrote; a call with an explicit non-local
-`namespace=` reads only that namespace's rows, never `"local"`'s. The
-response carries a `namespace` field naming the namespace actually read.
-
-The `role` field is `"daemon"` (with `source: "daemon-heartbeat"`) whenever
-any persisted heartbeat row exists **in the namespace read**, and `"client"`
-with an empty `channels` array otherwise. This distinguishes who owns the
-channel loops, not which process answered the call: any persisted row means
-some daemon owns the loops, even when this particular call was served by a
-different, non-daemon process.
-
-**Known ambiguity:** an empty `channels` array cannot distinguish "no daemon
-has ever run" from "channels are configured but a poll has never completed."
-The comm pack has no visibility into channel configuration (that lives in
-`khive-mcp` / `khive-channel-email`), so `role: "client"` with an empty
-`channels` array means only "no daemon heartbeat state exists in the
-namespace read," not "nothing is configured." The `namespace` field
-disambiguates which namespace that is: since the shipped OSS
-`comm.heartbeat` only ever writes to `"local"`, a call scoped to a non-local
-`namespace=` is expected to return `role: "client"` with empty `channels`
-even while a daemon is actively heartbeating under `"local"` — check the
-response's `namespace` field before reading that as "no daemon running."
-Producing heartbeat rows under a non-local namespace (e.g. per-tenant
-channel state on a cloud deployment) has no supported writer yet; it is
-tracked as separate follow-up work, not a `comm.health` read-path gap.
-
-Results are capped at 200 channels. A full page logs a `tracing::debug!`
-line noting that results may be silently truncated.
-
-## The email channel
-
-The email channel (`crates/khive-channel-email/`) bridges `comm.send` /
-`comm.inbox` to a real mailbox over SMTP and IMAP. It is not part of the
-default build; see [Feature gating](#feature-gating) below.
-
-### Addressing an email recipient
-
-Send to an email address by prefixing `to` with `email:` and passing an
-explicit `subject`. Because the outbox loop reads `subject` off the stored
-note, a mail sent without `subject` goes out with `(no subject)` in the
-subject line.
-
-```
-request(ops="comm.send(to=\"email:prof.sheng@example.edu\", subject=\"Draft ready for review\", content=\"...\")")
-```
-
-### How outbound delivery works
-
-`comm.send` itself only writes the note; it does not talk to SMTP directly.
-A background outbox loop polls every 5 seconds for undelivered outbound
-notes:
-
-```
-list(namespace=<ingest_namespace>, kind="message", direction="outbound", delivered=false, limit=200)
-```
-
-For each note returned, the loop keeps only those where `to_actor` starts
-with `email:` and the note is not already delivered, then checks the
-recipient against the allowlist (`KHIVE_EMAIL_SEND_ALLOWED_RECIPIENTS`, or the
-channel's maintainer address if that variable is unset). Passing notes are
-sent over SMTP, using the note's `subject`, `content`, and any
-`thread_id`/`in_reply_to_message_id`/`references_chain` properties to set the
-RFC 822 `Message-ID`, `In-Reply-To`, and `References` headers so replies group
-correctly in native mail clients.
-
-### How inbound ingestion works
-
-A separate poll loop reads the IMAP mailbox every 5 seconds and, for each new
-message, calls the pack-internal `comm.ingest` subhandler (not callable
-directly over the MCP wire) with the parsed envelope: `from`, `to`, `content`,
-`subject`, `channel_kind`, `external_id` (an IMAP-derived dedup key of the
-form `imap:{host}:{uidvalidity}:{uid}`), `sent_at`, and the wire threading
-fields `wire_message_id` / `wire_references`. Duplicate `external_id` values
-are ignored, making re-delivery idempotent.
-
-### Configuration
-
-`EmailChannelConfig::from_env` reads configuration exclusively from
-environment variables; there is no file-based config for this channel. See
-[Configuration](../configuration.md) for the full khive-wide environment
-variable reference. The email-specific variables are:
-
-Required:
-
-- `KHIVE_EMAIL_SMTP_HOST`
-- `KHIVE_EMAIL_IMAP_HOST`
-- `KHIVE_EMAIL_USERNAME`
-- `KHIVE_EMAIL_MAINTAINER_ADDRESS` (comma-separated; the first entry is
-  primary and used for outbound-allowlist defaulting)
-- `KHIVE_EMAIL_AUTHSERV_ID` (the trust anchor for validating inbound
-  `Authentication-Results` headers; the reserved value
-  `!topmost-no-authserv-id` selects trust of the topmost header when the
-  receiving boundary emits no `authserv-id` at all, as with Exchange Online's
-  internal-hop stamp)
-
-Auth mode (choose one):
-
-- Basic: `KHIVE_EMAIL_PASSWORD`
-- OAuth (Exchange Online app-only client-credentials flow):
-  `KHIVE_EMAIL_OAUTH_CLIENT_ID`, `KHIVE_EMAIL_OAUTH_TENANT_ID`,
-  `KHIVE_EMAIL_OAUTH_CLIENT_SECRET` (all three required together; a partial
-  set is a config error, never a silent fallback to Basic)
-
-Optional, with defaults:
-
-- `KHIVE_EMAIL_SMTP_PORT` (default `587`)
-- `KHIVE_EMAIL_IMAP_PORT` (default `993`)
-- `KHIVE_EMAIL_MAILBOX` (default: same as `KHIVE_EMAIL_USERNAME`)
-- `KHIVE_EMAIL_QUARANTINE_STORE` (default `true`; when a message fails the
-  sender-authentication or allowlist gate, store it as an unattributed
-  quarantine record instead of dropping it)
-- `KHIVE_EMAIL_INGEST_NAMESPACE` (default `local`; target namespace for
-  ingested messages)
-- `KHIVE_EMAIL_DEFAULT_ACTOR` (default `lambda:leo`; inbound actor assigned to
-  fresh, uncorrelated email messages)
-- `KHIVE_EMAIL_SEND_ALLOWED_RECIPIENTS` (comma-separated outbound allowlist;
-  falls back to the maintainer address when unset)
-
-### Feature gating
-
-`channel-email` is an optional Cargo feature
-(`crates/khive-mcp/Cargo.toml`), not compiled into the plain
-`cargo build --workspace --release` invocation used by `make build` or by any
-release/CI workflow. It is enabled explicitly by `make local`
-(`cargo build --release --features channel-email`). A binary built without
-this feature has no email channel code at all: `to="email:..."` sends still
-write a note (the comm pack has no awareness of channels), but nothing polls
-IMAP or drains the outbox, so the message is never delivered.
-
-### Daemon-only channel loops
-
-The email poll loop and the outbox loop are spawned only by the persistent
-daemon process (`kkernel mcp --daemon`), never by a plain stdio `kkernel mcp`
-client. This is a deliberate role gate (issue #602): before it existed, every
-stdio client process spawned its own independent IMAP poll loop against the
-same mailbox, and nine concurrent pollers exhausted Exchange Online's
-per-mailbox connection slots, taking inbound email down for about 19 hours on
-2026-07-04.
-
-The gate logs one line at startup either way, so the decision is observable:
-
-```
-email channel loops: spawning (daemon role)
-email channel loops: skipped (client role; daemon owns channel loops)
-```
-
-If the ingest namespace fails authorization, the loops are not started at all
-(fail-closed) and this is logged separately:
-
-```
-email channel loops NOT started: ingest namespace authorization failed (fail-closed)
-```
-
-If no daemon is running, mail is simply not polled until one starts. That is
-the intended behavior, not a silent failure.
-
-## Limitations
-
-Actor addressing (`to_actor` filtering on `comm.send`/`comm.inbox`) is a
-view-layer convention for cooperating, co-located actors, not a security
-boundary ([ADR-063](../adr/ADR-063-comm-principal-model.md)). Any process
-with access to the underlying SQLite store can read every message row
-regardless of `to_actor`, and there is no per-principal storage partition on
-the local backend. Where authorization is enforced, it lives at a single
-seam, the Gate ([ADR-018](../adr/ADR-018-authorization-gate.md)), not at the
-comm pack's inbox filter.
+- A send to your own configured actor address is refused unless you explicitly
+  pass `self_send=true`.
+- A new email send needs a `subject`.
+- An inbox is scoped to the calling actor address. If an expected message is
+  absent, check which actor is making the request and the address used in
+  `comm.send(to=...)`.
 
 ## See also
 
-- [Agent Sessions and Data Ingest](sessions-and-ingest.md): a different
-  ingestion path, transcript mirroring rather than message channels.
-- [Configuration](../configuration.md): the full environment variable
-  reference.
+- [API Reference](api-reference.md): full verb catalog and response shapes.
+- [Prompt Cookbook](prompt-cookbook.md): additional `request(ops="...")` patterns.

--- a/docs/guide/communication.md
+++ b/docs/guide/communication.md
@@ -4,6 +4,8 @@ The comm pack provides actor-addressed messaging with an inbox model. Use it
 when one actor needs to send another a directed message, follow up on it, and
 keep the exchange together as a thread. Messages are not a shared chat stream:
 each actor reads the inbound messages addressed to its own actor address.
+Actor addressing routes and filters inbox views in the shared local store; it is
+not a security boundary or a substitute for principal-isolated transport.
 
 Full parameter signatures live in the [comm pack rustdoc](../../crates/khive-pack-comm/src/vocab.rs).
 This page describes the working flow rather than duplicating that reference.
@@ -43,34 +45,43 @@ Replies retain the conversation's thread automatically. To inspect it, call
 `comm.reply` and `comm.thread` take a message ID in the parameter named `id`,
 not a `thread_id`; the thread operation resolves the conversation root.
 
-Use `comm.inbox(status="all")` when you need a message ID from older inbox
-history. Thread results are chronological by default; the signature reference
-documents pagination and ordering options.
+Use `comm.inbox(status="all", limit=200)` for recent inbox history when you
+need a message ID; the maximum limit is 200. Thread results are chronological
+by default; the signature reference documents pagination and ordering options.
 
 ## Polling and channel status
 
 `comm.probe` is a read-only poll for newly arrived inbound-message metadata
-and the count of stale unread messages. Supply the actor address being watched
-and round-trip the returned `cursor_us` unchanged as the next `since_us`.
-That cursor is opaque, not a timestamp, and probing never changes read flags.
+and the count of stale unread messages. Supply the required actor address and
+optionally set `stale_minutes` (default 20), then round-trip the returned
+`cursor_us` unchanged as the next `since_us`. That cursor is opaque, not a
+timestamp, and probing never changes read flags. A response contains at most
+the 100 newest matching messages, so use `comm.inbox` or the appropriate
+history workflow for complete or backlog history rather than treating probe as
+a paginated feed.
 
 `comm.health()` is a read-only, per-channel heartbeat snapshot. Its channel
 rows report poll timestamps and consecutive failure counts; it deliberately
 does not make a health judgment. Decide staleness or alerting in the caller.
+Inspect the response `namespace`: a non-local scoped call can validly return
+`role: "client"` and empty `channels` while the local daemon is active.
 
 ## Email
 
 When the optional email channel is configured, it uses the same comm message
 model. Address a new email as `email:person@example.com` and provide a
-`subject`; the channel delivers stored outbound messages asynchronously. Reply
-to an inbound email with `comm.reply` to preserve its conversation linkage.
+`subject` conventionally, but it is optional; when omitted, the channel
+delivers `(no subject)`. The channel delivers stored outbound messages
+asynchronously. Reply to an inbound email with `comm.reply` to preserve its
+conversation linkage.
 See [Configuration](../configuration.md) for email-channel setup.
 
 ## Gotchas
 
 - A send to your own configured actor address is refused unless you explicitly
   pass `self_send=true`.
-- A new email send needs a `subject`.
+- An email `subject` is conventional but optional; an omitted subject is
+  delivered as `(no subject)`.
 - An inbox is scoped to the calling actor address. If an expected message is
   absent, check which actor is making the request and the address used in
   `comm.send(to=...)`.


### PR DESCRIPTION
Condenses the khive-pack-comm rustdoc into a task-oriented communication guide page under docs/guide, per the ADR-090 one-source docs shape. Docs-only: no source .rs changed. Verb signatures stay in rustdoc; this page links to them.