### PR TITLE
docs(guide): memory feature-area user guide (rustdoc condensation)

### DIFF
--- a/docs/guide/memory.md
+++ b/docs/guide/memory.md
@@ -2,14 +2,16 @@
 
 The memory pack keeps durable context that should be useful beyond the current
 session. A memory is a note with an importance (`salience`) and an age-based
-decay rate. Recall searches memories by meaning and keywords, then weighs the
-match against their decayed importance and recency.
+decay rate. When an embedding model and ANN are available, recall searches by
+meaning and keywords; otherwise, including its bounded ANN warm-up fallback,
+it uses full-text retrieval only. It then weighs matches against their decayed
+importance and recency.
 
 Use it for session conclusions, handoffs, corrections, preferences, and
 reusable operational knowledge. Use the knowledge graph for durable things and
-their relationships: entities, documents, projects, and explicit edges. A
-memory can point back to a graph record with `source_id` when the context needs
-both kinds of persistence.
+their relationships: entities, documents, projects, and explicit edges.
+Supplying `source_id` creates an `annotates` edge from the new memory to the
+source entity or note; omitting it creates no provenance edge.
 
 Complete verb signatures and the current parameter contract live in the
 [memory pack handler declarations](../../crates/khive-pack-memory/src/pack.rs)
@@ -35,6 +37,10 @@ request(ops="memory.remember(content=\"The release checklist requires a migratio
 `working` type. Choose `episodic` for time-bound session context and `semantic`
 for knowledge expected to remain useful across many sessions.
 
+Namespace defaults depend on type: semantic writes use the shared `local` pool,
+while episodic writes use the caller's actor namespace. An explicit `namespace`
+overrides either default.
+
 When omitted, the defaults are type-specific:
 
 | Type       | Salience | Decay factor | Intended lifetime             |
@@ -52,7 +58,7 @@ important, it stops distinguishing what matters.
 request(ops="memory.recall(query=\"release documentation decisions\", memory_type=\"semantic\", tags=[\"release\", \"docs\"], tag_mode=\"all\", min_score=0.35, min_salience=0.6, limit=5)")
 ```
 
-Recall combines full-text search and vector search. Its hybrid fusion supports
+When hybrid retrieval is available, its full-text/vector fusion supports
 reciprocal-rank fusion (RRF), as well as configured weighted fusion, before
 decay-weighted ranking. It is therefore not merely a chronological list: a
 strong, recent, relevant memory can outrank an older one with similar text.
@@ -71,18 +77,22 @@ request(ops="memory.recall(query=\"release documentation decisions\", limit=1) |
 
 This chains the first returned memory into automatic positive feedback. For an
 explicit rating or correction, use `memory.feedback` with the recalled memory
-ID and the appropriate signal. Feedback updates the recall posteriors; it is a
-ranking signal, not a rewrite of the memory's content.
+ID and the appropriate signal. `memory.feedback.target_id` must be the recalled
+memory's full UUID, not its short display ID. Feedback updates the recall
+posteriors; it is a ranking signal, not a rewrite of the memory's content.
 
 ## Maintenance
 
 `memory.prune` soft-deletes memories selected by low salience and/or expiry.
-Run it with `dry_run=true` first, inspect `would_prune`, then repeat without the
-flag only when the selection is correct. `memory.vacuum` reclaims database space
-after soft deletion; it does not choose memories to remove.
+When omitted, `before` defaults to now (so expired memories are selected) and
+`namespace` defaults to `local`; use `before=0` to prune by salience only. With
+`dry_run=true`, `would_prune` is a count, not the candidate identities. Make the
+cutoff and namespace explicit before repeating without the flag.
+`memory.vacuum` reclaims database space after soft deletion; it does not choose
+memories to remove.
 
 ```text
-request(ops="memory.prune(min_salience=0.2, dry_run=true)")
+request(ops="memory.prune(min_salience=0.2, before=0, namespace=\"local\", dry_run=true)")
 ```
 
 ## Gotchas

--- a/docs/guide/memory.md
+++ b/docs/guide/memory.md
@@ -1,214 +1,111 @@
 # Memory and Recall
 
-This guide covers how the memory pack works in khive: how to store memories with
-appropriate salience, how decay affects recall ranking, and patterns for
-effective cross-session recall.
+The memory pack keeps durable context that should be useful beyond the current
+session. A memory is a note with an importance (`salience`) and an age-based
+decay rate. Recall searches memories by meaning and keywords, then weighs the
+match against their decayed importance and recency.
 
-## Two memory types
+Use it for session conclusions, handoffs, corrections, preferences, and
+reusable operational knowledge. Use the knowledge graph for durable things and
+their relationships: entities, documents, projects, and explicit edges. A
+memory can point back to a graph record with `source_id` when the context needs
+both kinds of persistence.
 
-khive supports two memory types:
+Complete verb signatures and the current parameter contract live in the
+[memory pack handler declarations](../../crates/khive-pack-memory/src/pack.rs)
+and the [API reference](api-reference.md#memory-pack--5-verbs). This page
+covers the working loop and the behaviour that is easy to miss.
 
-| Type       | What it stores                                  | When to use                                        |
-| ---------- | ----------------------------------------------- | -------------------------------------------------- |
-| `episodic` | Session events, conversations, task completions | Default. Context that happened at a specific time. |
-| `semantic` | Patterns, insights, reusable knowledge          | Facts and rules that are useful across sessions.   |
+## The remember and recall loop
 
-These are the only valid values. There is no `procedural` or `working` memory
-type.
+1. Store the conclusion rather than a raw transcript. State what changed, why
+   it matters, and any next constraint.
+2. Recall relevant context before resuming related work.
+3. Give feedback after using a result so subsequent recall can tune its
+   posteriors.
+4. Periodically review low-value or expired memories before pruning them.
 
-## Storing memories
+### Store a durable conclusion
 
-### Basic remember
-
-```
-request(ops="memory.remember(content=\"khive uses RRF fusion for hybrid search scoring\", salience=0.8, memory_type=\"semantic\")")
-```
-
-### Parameters
-
-| Parameter      | Type   | Default                          | Description                                                               |
-| -------------- | ------ | -------------------------------- | ------------------------------------------------------------------------- |
-| `content`      | string | required                         | The memory content                                                        |
-| `salience`     | float  | episodic: 0.3 / semantic: 0.5    | Importance weight for recall ranking (0.0-1.0)                            |
-| `decay_factor` | float  | episodic: 0.02 / semantic: 0.005 | Higher = faster decay. 0.02 ≈ 35-day half-life; 0.005 ≈ 139-day half-life |
-| `memory_type`  | string | "episodic"                       | `episodic` or `semantic`                                                  |
-| `source_id`    | uuid   | none                             | Entity or note this memory annotates                                      |
-
-### Salience calibration
-
-Salience determines how prominently a memory surfaces during recall. Use these
-ranges:
-
-| Salience | Use for                                      | Example                                     |
-| -------- | -------------------------------------------- | ------------------------------------------- |
-| 0.85-1.0 | Critical directives, safety constraints      | "Never delete the production database"      |
-| 0.7-0.8  | Key insights, reusable patterns, corrections | "RRF scoring requires cosine normalization" |
-| 0.5-0.7  | Session summaries, routine context           | "Completed attention benchmark run"         |
-| < 0.5    | Low-value, ephemeral, auto-generated         | Routine status updates                      |
-
-A common mistake is inflating salience: if everything is 0.9+, the scoring
-signal is lost and recall becomes unranked.
-
-### Linking memories to entities
-
-```
-request(ops="memory.remember(content=\"FlashAttention-3 uses asynchronous tiling on H100\", salience=0.7, source_id=\"<entity_id>\")")
+```text
+request(ops="memory.remember(content=\"The release checklist requires a migration note before the documentation change is merged.\", memory_type=\"semantic\", salience=0.75, tags=[\"release\", \"docs\"])")
 ```
 
-The `source_id` creates an `annotates` edge from the memory note to the
-specified entity. This makes the memory discoverable via `neighbors` on that
-entity.
+`memory_type` is exactly `episodic` or `semantic`; there is no `procedural` or
+`working` type. Choose `episodic` for time-bound session context and `semantic`
+for knowledge expected to remain useful across many sessions.
 
-## Recalling memories
+When omitted, the defaults are type-specific:
 
-### Basic recall
+| Type       | Salience | Decay factor | Intended lifetime             |
+| ---------- | -------: | -----------: | ----------------------------- |
+| `episodic` |      0.3 |         0.02 | Short-lived session context   |
+| `semantic` |      0.5 |        0.005 | Durable facts and conclusions |
 
-```
-request(ops="memory.recall(query=\"attention optimization\", limit=5)")
-```
+Higher salience makes a memory more prominent in recall. Higher decay makes it
+lose importance more quickly. Treat high salience as scarce: if every memory is
+important, it stops distinguishing what matters.
 
-Returns a scored list of matching memories:
+### Recall focused context
 
-```json
-[
-  {"id": "...", "content": "FlashAttention-3 uses async tiling...", "score": 0.72, "salience": 0.7, ...},
-  {"id": "...", "content": "PagedAttention reduces KV cache...", "score": 0.58, "salience": 0.6, ...}
-]
-```
-
-### Recall parameters
-
-| Parameter      | Type   | Default  | Description                                |
-| -------------- | ------ | -------- | ------------------------------------------ |
-| `query`        | string | required | Search query                               |
-| `limit`        | int    | 10       | Max results                                |
-| `min_score`    | float  | none     | Minimum composite score threshold          |
-| `min_salience` | float  | none     | Minimum salience filter                    |
-| `memory_type`  | string | none     | Filter by memory type                      |
-| `tags`         | list   | none     | Filter by tags                             |
-| `tag_mode`     | string | "any"    | `any` (OR) or `all` (AND) for tag matching |
-
-### Tag-filtered recall
-
-```
-request(ops="memory.recall(query=\"search optimization\", tags=[\"khive\", \"retrieval\"], tag_mode=\"any\")")
+```text
+request(ops="memory.recall(query=\"release documentation decisions\", memory_type=\"semantic\", tags=[\"release\", \"docs\"], tag_mode=\"all\", min_score=0.35, min_salience=0.6, limit=5)")
 ```
 
-## Scoring formula
+Recall combines full-text search and vector search. Its hybrid fusion supports
+reciprocal-rank fusion (RRF), as well as configured weighted fusion, before
+decay-weighted ranking. It is therefore not merely a chronological list: a
+strong, recent, relevant memory can outrank an older one with similar text.
 
-Recall ranking uses a composite score:
+Use `min_score` to discard weak matches and `min_salience` to exclude memories
+that were stored as less important. `tags` is a stored-memory filter;
+`tag_mode="any"` matches one or more supplied tags, while `"all"` requires
+every supplied tag. Filter by `memory_type` when you know whether you need
+session context or durable knowledge.
 
-$$\text{composite} = 0.70 \cdot \text{retrieval} + 0.20 \cdot \text{salience} \cdot \text{decay} + 0.10 \cdot \text{temporal}$$
+### Credit a useful result
 
-Where:
-
-- **retrieval_score** (70% weight): RRF fusion of FTS5 keyword match and vector
-  similarity
-- **salience * decay_weight** (20% weight): the memory's importance, decayed
-  over time
-- **temporal_score** (10% weight): recency bonus
-
-### Decay math
-
-Decay follows an exponential curve:
-
-$$w_{\text{decay}} = e^{-\lambda \cdot t}$$
-
-where $\lambda$ is `decay_factor` and $t$ is age in days.
-
-With the episodic default `decay_factor=0.02`:
-
-- After 1 day: 98% of original salience
-- After 7 days: 87%
-- After 35 days: 50% (half-life)
-- After 69 days: 25%
-- After 180 days: 3%
-
-With the semantic default `decay_factor=0.005`:
-
-- After 1 day: 99.5% of original salience
-- After 30 days: 86%
-- After 139 days: 50% (half-life)
-- After 365 days: 16%
-
-Higher `decay_factor` means faster decay:
-
-- `0.001`: very slow (693-day half-life), for permanent reference memories
-- `0.005`: slow (139-day half-life), semantic default, good for durable facts
-- `0.02`: moderate (35-day half-life), episodic default, good for session context
-- `0.05`: fast (14-day half-life), for session-specific context
-- `0.1`: very fast (7-day half-life), for truly ephemeral context
-
-## Brain integration
-
-The Brain pack provides Bayesian profile tuning based on feedback signals. After
-recalling memories, you can feed back which results were useful:
-
-### Auto-feedback (recommended)
-
-```
-request(ops="brain.auto_feedback(results=[{\"id\": \"<mem1_uuid>\", \"used\": true}, {\"id\": \"<mem2_uuid>\", \"used\": false}])")
+```text
+request(ops="memory.recall(query=\"release documentation decisions\", limit=1) | brain.auto_feedback(query=\"release documentation decisions\", results=[{\"id\": $prev[0].id}])")
 ```
 
-Call this after `memory.recall` to automatically signal which results you
-actually used. The brain profile adjusts its tuning over time.
+This chains the first returned memory into automatic positive feedback. For an
+explicit rating or correction, use `memory.feedback` with the recalled memory
+ID and the appropriate signal. Feedback updates the recall posteriors; it is a
+ranking signal, not a rewrite of the memory's content.
 
-### Manual feedback
+## Maintenance
 
-```
-request(ops="brain.feedback(target_id=\"<full_uuid>\", signal=\"useful\")")
-```
+`memory.prune` soft-deletes memories selected by low salience and/or expiry.
+Run it with `dry_run=true` first, inspect `would_prune`, then repeat without the
+flag only when the selection is correct. `memory.vacuum` reclaims database space
+after soft deletion; it does not choose memories to remove.
 
-Signals: `useful`, `not_useful`, `wrong`, `explicit_positive`,
-`explicit_negative`, `correction`.
-
-Note: `target_id` must be a full UUID (not a short prefix).
-
-## Usage patterns
-
-### Session summary
-
-At the end of a work session, store key findings:
-
-```
-request(ops="memory.remember(content=\"SESSION: Completed FlashAttention-3 benchmark. Key finding: 2.3x speedup over FA2 on H100, but no improvement on A100 due to async tile dependency.\", salience=0.65, memory_type=\"episodic\")")
+```text
+request(ops="memory.prune(min_salience=0.2, dry_run=true)")
 ```
 
-### Key insight
+## Gotchas
 
-When you discover something reusable:
-
-```
-request(ops="memory.remember(content=\"INSIGHT: knowledge.search with rerank=true gives normalized 0-1 scores vs raw RRF ~0.016. Always use rerank for score comparison.\", salience=0.75, memory_type=\"semantic\")")
-```
-
-### Session start recall
-
-At the beginning of a session, recall recent context:
-
-```
-request(ops="memory.recall(query=\"recent session work progress\", limit=5, memory_type=\"episodic\")")
-```
-
-Then make targeted recalls based on what you are about to work on:
-
-```
-request(ops="memory.recall(query=\"FlashAttention benchmark results\", limit=5)")
-```
-
-### Agent handoff
-
-When handing off work to another agent:
-
-```
-request(ops="memory.remember(content=\"HANDOFF: Attention benchmark suite is ready at benchmarks/attention/. Next step: run on H100 cluster. Contact: agent:platform for GPU allocation.\", salience=0.8, memory_type=\"episodic\")")
-```
+- A fresh write is stored immediately, but its vector/ANN index warms
+  asynchronously. It may not be semantically recallable right away; retry
+  later instead of treating an initial miss as a failed write.
+- Decay changes recall rank, not whether a memory exists. Use pruning when you
+  want to remove stale material.
+- `min_score` filters the composite recall rank; use it as a quality floor, not
+  as a statement of exact semantic similarity.
+- Tags only filter memories that were stored with tags. `tag_mode` has no
+  effect without a non-empty `tags` filter.
+- Feedback belongs to a result you actually evaluated. A correction is useful
+  when the remembered claim is wrong; update or supersede the memory separately
+  when its content must change.
 
 ## See also
 
-- [Search and Retrieval](search.md): how hybrid search and RRF fusion work
-- [Prompt Cookbook](prompt-cookbook.md): memory verb patterns
-- [GTD Task Management](tasks.md): task lifecycle (often paired with memory
-  for context)
-- [Agent Sessions and Data Ingest](sessions-and-ingest.md): a separate,
-  session-scoped persistence model for transcripts and provider mirrors
+- [Knowledge Graph Modeling](knowledge-graph.md): model durable entities and
+  relationships
+- [Search and Retrieval](search.md): retrieval and query behaviour
+- [GTD Task Management](tasks.md): task state, which is distinct from retained
+  context
+- [Memory API reference](api-reference.md#memory-pack--5-verbs): full verb
+  signatures and parameter details


### PR DESCRIPTION
Condenses the khive-pack-memory rustdoc into a task-oriented memory guide page under docs/guide, per the ADR-090 one-source docs shape. Docs-only: no source .rs changed. Verb signatures stay in rustdoc; this page links to them.