### PR TITLE
docs(adr): flip Status to Accepted for 17 ratified ADRs

### DIFF
--- a/docs/adr/ADR-058-brain-posterior-read-path.md
+++ b/docs/adr/ADR-058-brain-posterior-read-path.md
@@ -16,12 +16,20 @@
 
 ---
 
-## Seed-readiness notice
+## Seed-readiness notice (resolved)
 
-Until this ADR is implemented, **"profile-tuned recall" and "self-improving recall" must not be
-claimed in any pitch deck, investor README, or product copy.** The posteriors are written and
-persisted correctly; the read path that would make them steer ranking does not exist. This ADR
-is the plan to make the claim true — it is not yet true.
+This notice was written while this ADR was a plan and the posterior read path did not yet
+exist. The read path is now implemented: at serve time recall projects the resolved profile's
+posterior means into its scoring weights (see
+[ADR-104](ADR-104-posterior-serving-recall.md) §1 and
+`crates/khive-pack-memory/src/handlers/recall.rs`). The historical warning is retained below
+for context.
+
+Until this ADR was implemented, **"profile-tuned recall" and "self-improving recall" could not
+be claimed** in any pitch deck, investor README, or product copy: the posteriors were written
+and persisted correctly, but the read path that would make them steer ranking did not exist.
+The Context and design sections below describe that design-time gap; they are the point-in-time
+record of the decision, not a description of current behavior.
 
 ---
 

--- a/docs/adr/ADR-058-brain-posterior-read-path.md
+++ b/docs/adr/ADR-058-brain-posterior-read-path.md
@@ -1,6 +1,6 @@
 # ADR-058: Brain Posterior Read Path — Wiring Profile Posteriors into Recall Ranking
 
-**Status**: Proposed\
+**Status**: Accepted\
 **Date**: 2026-06-15 (updated 2026-06-23)\
 **Authors**: khive maintainers
 **Depends on**:

--- a/docs/adr/ADR-069-subject-model.md
+++ b/docs/adr/ADR-069-subject-model.md
@@ -1,6 +1,6 @@
 # ADR-069: The Subject Model -- Domain-Ontology Ingestion and Map Pipeline
 
-**Status**: Proposed\
+**Status**: Accepted\
 **Date**: 2026-06-23\
 **Authors**: khive maintainers
 **Depends on**: ADR-001 (Entity Kind Taxonomy), ADR-002 (Edge Ontology), ADR-013 (Note Kind

--- a/docs/adr/ADR-076-relation-calculability-and-system-role.md
+++ b/docs/adr/ADR-076-relation-calculability-and-system-role.md
@@ -1,6 +1,6 @@
 # ADR-076: Relation-Set Calculability — System Role and the Non-Redundancy Certificate
 
-**Status**: proposed\
+**Status**: Accepted\
 **Date**: 2026-06-26\
 **Authors**: khive maintainers
 **Amends**: [ADR-002](ADR-002-edge-ontology.md) — corrects the `contains`/`part_of` "inverse"

--- a/docs/adr/ADR-078-output-format-shape-aware-rendering.md
+++ b/docs/adr/ADR-078-output-format-shape-aware-rendering.md
@@ -1,6 +1,6 @@
 # ADR-078: Output Format and Shape-Aware Rendering
 
-**Status**: proposed
+**Status**: Accepted
 **Date**: 2026-06-27
 **Authors**: khive maintainers
 **Depends on**:

--- a/docs/adr/ADR-079-ann-persistence-warm-path-integration.md
+++ b/docs/adr/ADR-079-ann-persistence-warm-path-integration.md
@@ -1,6 +1,6 @@
 # ADR-079: ANN Persistence Warm-Path Integration — Wiring v2 Persistence into the Daemon
 
-**Status**: proposed
+**Status**: Accepted
 **Date**: 2026-06-28
 **Authors**: khive maintainers
 

--- a/docs/adr/ADR-081-recall-retune-driver.md
+++ b/docs/adr/ADR-081-recall-retune-driver.md
@@ -1,6 +1,6 @@
 # ADR-081: Recall Retune Driver — Governed Ingestion of Implicit Feedback
 
-**Status**: Proposed\
+**Status**: Accepted\
 **Date**: 2026-07-02\
 **Authors**: khive maintainers
 **Measurement evidence**: hook scorer v0 dry run over 19 serve ledgers, 7 sessions (2026-07-02)\

--- a/docs/adr/ADR-087-workspace-mirror.md
+++ b/docs/adr/ADR-087-workspace-mirror.md
@@ -1,6 +1,6 @@
 # ADR-087: Workspace Mirror — Folding `.khive/` Into the Graph Substrate
 
-**Status**: Proposed\
+**Status**: Accepted\
 **Date**: 2026-07-03\
 **Authors**: khive maintainers
 **Depends on**: ADR-086 (Document/File Modeling — the `document`-entity shape this mirror

--- a/docs/adr/ADR-088-git-lifecycle-pack.md
+++ b/docs/adr/ADR-088-git-lifecycle-pack.md
@@ -1,6 +1,6 @@
 # ADR-088: Git-Lifecycle Pack — Commit and Issue Note Kinds
 
-**Status**: Proposed\
+**Status**: Accepted\
 **Date**: 2026-07-03\
 **Authors**: khive maintainers
 **Depends on**: ADR-001 (Entity Kind Taxonomy — `project` as the repo anchor), ADR-002

--- a/docs/adr/ADR-089-context-verb.md
+++ b/docs/adr/ADR-089-context-verb.md
@@ -1,6 +1,6 @@
 # ADR-089: `context` verb — entity-anchored graph context in one call
 
-**Status**: Proposed
+**Status**: Accepted
 **Date**: 2026-07-04
 **Depends on**: ADR-002 (edge ontology), ADR-016 (request DSL), ADR-017 (pack standard), ADR-049 (daemon warm state), ADR-081 (recall retune driver)
 

--- a/docs/adr/ADR-090-docs-site-standard.md
+++ b/docs/adr/ADR-090-docs-site-standard.md
@@ -1,6 +1,6 @@
 # ADR-090: Docs site standard — navigation, agent md/txt surfaces, visual style
 
-**Status**: Proposed
+**Status**: Accepted
 **Date**: 2026-07-04
 **Depends on**: none (governs `.github/workflows/pages.yml` and `docs/guide/*.md`)
 

--- a/docs/adr/ADR-094-lifecycle-telemetry-events.md
+++ b/docs/adr/ADR-094-lifecycle-telemetry-events.md
@@ -1,6 +1,6 @@
 # ADR-094: Sequencing-Assertable Lifecycle Telemetry Events
 
-**Status**: Proposed
+**Status**: Accepted
 **Date**: 2026-07-04
 **Depends on**: ADR-002 (edge ontology, unrelated substrate but same repo conventions),
 ADR-041 (event provenance projection), ADR-091 (WAL snapshot lifetime, severity ladder

--- a/docs/adr/ADR-100-store-backup-replication.md
+++ b/docs/adr/ADR-100-store-backup-replication.md
@@ -1,6 +1,6 @@
 # ADR-100: Store backup and replication
 
-**Status**: Proposed
+**Status**: Accepted
 **Date**: 2026-07-06
 **Depends on**: ADR-067 (single-writer WriterTask), ADR-079 (ANN index persistence), ADR-091 (WAL checkpoint lifecycle)
 

--- a/docs/adr/ADR-101-kg-changeset-model.md
+++ b/docs/adr/ADR-101-kg-changeset-model.md
@@ -1,6 +1,6 @@
 # ADR-101: KG Change-Set Model — Producer-Agnostic Op-List with Stage-Time Stable IDs
 
-**Status**: Proposed
+**Status**: Accepted
 **Date**: 2026-07-08
 **Depends on**: ADR-002 (edge ontology), ADR-016 (request DSL — the op shape this format serializes), ADR-017 (pack standard), ADR-020 (git-native KG implementation — `KgArchive` as the import/export envelope this ADR does not replace)
 **Related**: ADR-088 (git-lifecycle pack — the future-work loop below), ADR-100 (store backup and replication — whole-graph snapshots, a different artifact from the change-set this ADR defines)

--- a/docs/adr/ADR-102-tiered-validate-and-merge.md
+++ b/docs/adr/ADR-102-tiered-validate-and-merge.md
@@ -1,6 +1,6 @@
 # ADR-102: Tiered Validate-and-Merge — Rule-Gated Fast Path and Reviewed Change-Set Path
 
-**Status**: Proposed
+**Status**: Accepted
 **Date**: 2026-07-08
 **Amends**: [ADR-020](ADR-020-git-native-kg-implementation.md) (restores the `kg commit` CLI
 primitive to the `kkernel kg` subcommand surface; see "Amendment to ADR-020" below)

--- a/docs/adr/ADR-103-resource-attribution-model.md
+++ b/docs/adr/ADR-103-resource-attribution-model.md
@@ -1,6 +1,6 @@
 # ADR-103: Resource Attribution Model
 
-**Status**: Proposed
+**Status**: Accepted
 **Date**: 2026-07-08
 **Depends on**: ADR-018 (Authorization Gate), ADR-094 (Sequencing-Assertable Lifecycle
 Telemetry Events), ADR-091 (WAL Snapshot Lifetime)

--- a/docs/adr/ADR-107-memory-ann-lifecycle.md
+++ b/docs/adr/ADR-107-memory-ann-lifecycle.md
@@ -10,8 +10,8 @@
 [ADR-021](ADR-021-memory-pack.md) specifies `memory.recall`'s scoring and candidate-scoping
 contract but does not address ANN cache freshness — recall is defined as if the index were
 always current. [ADR-079](ADR-079-ann-persistence-warm-path-integration.md) defines a warm/stale/cold
-serving model with a durable content-hash restart check, but it is Proposed, scoped to the
-knowledge pack's v2 segment format, and explicitly excludes memory-pack migration from its
+serving model with a durable content-hash restart check, but it is scoped to the
+knowledge pack's v2 segment format and explicitly excludes memory-pack migration from its
 scope.
 
 Issue #791 found that `memory.recall` could hang for the full rebuild duration: a write
@@ -261,5 +261,5 @@ leaking through.
 
 ## Status
 
-Proposed. Implemented by PR #812 (issue #791), most recently on
+Accepted. Implemented by PR #812 (issue #791), most recently on
 `fix/791-recall-ann-rebuild-blocking`.

--- a/docs/adr/ADR-107-memory-ann-lifecycle.md
+++ b/docs/adr/ADR-107-memory-ann-lifecycle.md
@@ -1,6 +1,6 @@
 # ADR-107: Memory ANN Lifecycle — Eventual Consistency Contract
 
-**Status**: Proposed
+**Status**: Accepted
 **Date**: 2026-07-10
 **Depends on**: [ADR-021](ADR-021-memory-pack.md) (Memory Pack), [ADR-079](ADR-079-ann-persistence-warm-path-integration.md) (ANN persistence warm-path integration, knowledge pack scope)
 **References**: issue #791, PR #812

--- a/docs/adr/ADR-108-git-write-surface.md
+++ b/docs/adr/ADR-108-git-write-surface.md
@@ -1,6 +1,6 @@
 # ADR-108: Git Write Surface Through khive (Phase B)
 
-**Status**: Proposed\
+**Status**: Accepted\
 **Date**: 2026-07-11\
 **Authors**: khive maintainers\
 **Depends on**: ADR-088 (Git-Lifecycle Pack) and its Amendment 1 (`git.digest`), ADR-018


### PR DESCRIPTION
## Summary
- Per-ADR, evidence-based sweep: flips Status: Proposed -> Accepted for 17 ADRs with confirmed ratification evidence (body language, implementation history, code/test citations).
- Leaves 14 genuinely-still-open proposals as Proposed (explicit rationale per ADR).
- Leaves ADR-086 as Proposed (rejected/redesigned; out of scope to invent a Rejected status here).
- Flags ADR-051, ADR-105, ADR-110 as missing a Status line entirely (not edited, flagged only).
- No accepted-date field invented: the ADR header template carries only a proposal Date, not an accepted-date.

## Test plan
- [x] git status --porcelain confirmed only docs/adr/*.md changed
- [x] Static review pass (docs-only, verify no ADR mis-stamped)
- [ ] Approving review + auto-merge on clean review outcome

Generated with Claude Code