### PR TITLE
docs(khive-pack-memory): condense inline rustdoc

### DIFF
--- a/crates/khive-pack-memory/docs/config-reference.md
+++ b/crates/khive-pack-memory/docs/config-reference.md
@@ -1,0 +1,13 @@
+# Recall Config Reference
+
+Design rationale extracted from `crates/khive-pack-memory/src/config.rs` doc-comments. The
+doc-comments in source remain the complete field contract (type, default, env-var fallback);
+this file only records why a given bound exists.
+
+## `ann_ready_timeout_ms`
+
+Recall and the daemon's boot-time background warm (`warm_existing_memory_indexes`) both funnel
+through `ensure_ann_for_model`'s per-model single-flight lock. Without a bound, a recall landing
+while boot warm holds that lock for a from-scratch corpus build would wait out the full build —
+300s+ observed in production (#836). This field bounds that wait so the recall degrades to
+FTS-only instead of hanging.

--- a/crates/khive-pack-memory/docs/design.md
+++ b/crates/khive-pack-memory/docs/design.md
@@ -88,3 +88,6 @@
 - `brain_profile` integration in `RecallConfig` is partially implemented: the configuration
   field is live but the runtime lookup (cross-pack call to `brain.profile`) is not yet wired
   at the handler level. See TODO(#484).
+- `scoring.rs` bundles `ScoringConfig`, all normalization helpers, CJK routing, and the full
+  test suite for the scoring pipeline. The tests require access to module-private helpers;
+  splitting would require `pub(crate)` promotion of private fns.

--- a/crates/khive-pack-memory/docs/scoring.md
+++ b/crates/khive-pack-memory/docs/scoring.md
@@ -1,0 +1,41 @@
+# Recall Scoring
+
+Design rationale and algorithmic detail extracted from `crates/khive-pack-memory/src/scoring.rs`
+doc-comments. The doc-comments in source remain the complete API contract; this file is
+background only.
+
+## Entity Candidate Extraction
+
+`extract_entity_candidates` (khive #dead-parameter defect): `entity_names` was originally a
+caller-supplied request field feeding the `EntityMatch` adjustment, but no caller ever populated
+it, so the ×1.3 boost in `default_adjustments` never fired in practice. The function derives
+candidates server-side from the query text instead, so the boost has something to match against.
+
+Capitalization is the only signal used because it is the sole low-noise proper-noun indicator
+available without an NER model or a lookup against known entity records. `EntityMatch::matches`
+does a free-text boundary-anchored match against raw memory content — not something anchored to
+actual KG entity references — so admitting ordinary lowercase content words as candidates
+degenerates the boost into a second, redundant lexical-overlap signal on top of retrieval-stage
+relevance. Review confirmed that realistic score inputs clamp at the `[0, 1]` ceiling and flatten
+top-rank ordering when generic query words are treated as entity candidates.
+
+Many recall callers — agents in particular — pass fully lowercase queries. The function
+deliberately returns an empty list for them rather than guessing at content words. Covering that
+case precisely would require anchoring candidates against known entity records (e.g. resolving
+query tokens against the KG) rather than lexical heuristics over the query string; that is out of
+scope for this function, and is instead addressed by `entity_lookup_candidates` below.
+
+## Entity Lookup Candidate Sampling
+
+`entity_lookup_candidates` (ADR-104 §5 / Stage C, rider R1) exists because the capitalization
+gate above returns nothing for lowercase queries, and precision there instead comes from the
+caller (`memory.recall`) only keeping a candidate that matches the *name* of a real KG entity via
+one batched `EntityFilter::names_ci` lookup — so this function can afford to sample broadly.
+
+Sampling algorithm: CJK substrings reserve a fair quota for every supported length from
+`MIN_CJK_LOOKUP_CHARS` (2) through `MAX_CJK_LOOKUP_CHARS` (8), redistributing unused quota from
+short runs that don't have enough substrings to fill their share. Within each length, available
+start positions are sampled evenly: a quota greater than one guarantees both the first and final
+valid starts are included; a quota of exactly one selects the first endpoint. The result is both
+length-fair (no single substring length dominates) and position-fair (no single region of the
+query dominates) under the `MAX_ENTITY_LOOKUP_CANDIDATES` (64) cap.

--- a/crates/khive-pack-memory/src/config.rs
+++ b/crates/khive-pack-memory/src/config.rs
@@ -87,24 +87,21 @@ pub struct RecallConfig {
     pub fts_gather: RecallFtsGatherConfig,
 
     // --- ANN over-fetch retry ---
-    /// Maximum rounds for the ANN namespace over-fetch retry loop.
-    ///
-    /// Round 1 is the initial over-fetch; rounds 2–N double the fetch window
-    /// until enough visible-namespace candidates are found or the corpus is
-    /// exhausted. When `None`, falls back to the `ANN_OVERFETCH_MAX_ROUNDS`
-    /// env var (default 3). Pass `Some(1)` to disable widening entirely.
+    /// Maximum rounds for the ANN namespace over-fetch retry loop. Round 1 is
+    /// the initial over-fetch; rounds 2–N double the fetch window until enough
+    /// visible-namespace candidates are found or the corpus is exhausted. When
+    /// `None`, falls back to the `ANN_OVERFETCH_MAX_ROUNDS` env var (default 3).
+    /// Pass `Some(1)` to disable widening entirely.
     pub ann_overfetch_max_rounds: Option<usize>,
 
-    /// Bounded wait (milliseconds) for a cold-miss `ensure_ann_for_model`
-    /// call on the recall path before degrading that model's contribution
-    /// to FTS-only (#836). Recall and the daemon's boot-time background
-    /// warm (`warm_existing_memory_indexes`) both funnel through
-    /// `ensure_ann_for_model`'s per-model single-flight lock; without a
-    /// bound, a recall landing while boot warm holds that lock for a
-    /// from-scratch corpus build waits out the full build (300s+ observed
-    /// in production). When `None`, falls back to the
+    /// Bounded wait (milliseconds) for a cold-miss `ensure_ann_for_model` call
+    /// on the recall path before degrading that model's contribution to
+    /// FTS-only (#836). When `None`, falls back to the
     /// `KHIVE_MEMORY_ANN_READY_TIMEOUT_MS` env var (default 8000ms — see
     /// `handlers::common::ann_ready_timeout_ms`).
+    ///
+    /// See crates/khive-pack-memory/docs/config-reference.md#ann_ready_timeout_ms
+    /// for why this bound exists.
     pub ann_ready_timeout_ms: Option<u64>,
 }
 

--- a/crates/khive-pack-memory/src/scoring.rs
+++ b/crates/khive-pack-memory/src/scoring.rs
@@ -9,10 +9,6 @@
 //!   6. `is_meaningful_query` — noise gate before embedding compute.
 //!   7. `contains_cjk` — CJK routing decision.
 //!   8. `needs_multilingual` — broad multilingual routing gate (non-ASCII alphabetic script).
-// FILE SIZE JUSTIFICATION: scoring.rs bundles ScoringConfig, all normalization helpers,
-// CJK routing, and the full test suite for the scoring pipeline. The tests require access
-// to module-private helpers; splitting would require pub(crate) promotion of private fns.
-
 use std::collections::{HashMap, HashSet};
 
 use serde::{Deserialize, Serialize};
@@ -279,38 +275,19 @@ fn strip_token_punctuation(token: &str) -> &str {
 }
 
 /// Auto-extract entity-name candidates from a recall query when the caller
-/// does not supply `entity_names` explicitly.
+/// does not supply `entity_names` explicitly, for the `EntityMatch` boost in
+/// `default_adjustments`.
 ///
-/// Context (khive #dead-parameter defect): `entity_names` was a
-/// caller-supplied request field that fed `EntityMatch` — but no caller ever
-/// populated it, so the ×1.3 boost in `default_adjustments` never fired in
-/// practice. This function derives candidates server-side from the query
-/// text so the boost has something to match against.
+/// A token qualifies iff, after stripping surrounding punctuation
+/// (`strip_token_punctuation`), it is not an `ENTITY_STOPWORDS` entry and
+/// starts with an uppercase letter. Queries with no capitalized tokens
+/// return an empty list — this never falls back to lowercase content words.
+/// Returned names are lowercased (matching `EntityMatch`'s own
+/// lowercase-both-sides contract), deduplicated preserving first-seen
+/// order, and capped at `MAX_AUTO_ENTITY_NAMES`.
 ///
-/// **Capitalized tokens only.** A query token qualifies iff, after stripping
-/// surrounding punctuation, it is not a stopword and starts with an
-/// uppercase letter. Capitalization is the only signal used here because it
-/// is the sole low-noise proper-noun indicator available without an NER
-/// model or a lookup against known entity records — `EntityMatch::matches`
-/// (above) does a free-text boundary-anchored match against raw memory
-/// content, not something anchored to actual KG entity references, so
-/// admitting ordinary lowercase content words as candidates degenerates the
-/// boost into a second, redundant lexical-overlap signal on top of
-/// retrieval-stage relevance (confirmed by review: realistic score inputs
-/// clamp at the `[0, 1]` ceiling and flatten top-rank ordering when generic
-/// query words are treated as entity candidates).
-///
-/// **Queries with no capitalization extract nothing.** Many recall callers —
-/// agents in particular — pass fully lowercase queries, and this function
-/// deliberately returns an empty list for them rather than guessing at
-/// content words. Covering that case precisely requires anchoring candidates
-/// against known entity records (e.g. resolving query tokens against the KG)
-/// rather than lexical heuristics over the query string; that is out of
-/// scope here.
-///
-/// Returned names are lowercased (matching `EntityMatch`'s own lowercasing
-/// of both sides before the boundary-anchored match), deduplicated
-/// preserving first-seen order, and capped at `MAX_AUTO_ENTITY_NAMES`.
+/// See crates/khive-pack-memory/docs/scoring.md#entity-candidate-extraction
+/// for why capitalization-only was chosen over an NER model or KG lookup.
 pub fn extract_entity_candidates(query: &str) -> Vec<String> {
     let mut seen: HashSet<String> = HashSet::new();
     let mut out: Vec<String> = Vec::new();
@@ -359,20 +336,21 @@ fn entity_lookup_case_variants(candidate: String) -> [Option<String>; 2] {
 
 /// Build the candidate strings a recall query offers to the entity-anchored
 /// lookup (ADR-104 §5 / Stage C). Alphabetic-script queries contribute
-/// ASCII-lowercased non-stopword unigrams and reserve one quarter of the cap
-/// for adjacent-token bigrams. Candidates containing non-ASCII characters also
-/// retain their raw form for exact matching. CJK substrings reserve a fair quota
-/// for every supported length from 2 through 8, redistributing unused quota from
-/// short runs. Within each length, available start positions are sampled evenly.
-/// Quotas greater than one guarantee both the first and final valid starts;
-/// a quota of one selects the first endpoint. The result is both length-fair
-/// and position-fair under the 64-candidate cap. All candidates are deduplicated.
+/// ASCII-lowercased non-stopword unigrams plus adjacent-token bigrams
+/// (reserved to one quarter of `MAX_ENTITY_LOOKUP_CANDIDATES`); non-ASCII
+/// candidates also retain their raw form for exact matching. CJK substrings
+/// of length `MIN_CJK_LOOKUP_CHARS..=MAX_CJK_LOOKUP_CHARS` are sampled under
+/// a fair per-length quota. Output is deduplicated and capped at
+/// `MAX_ENTITY_LOOKUP_CANDIDATES`.
 ///
 /// Unlike `extract_entity_candidates` above, this does **not** filter on
-/// capitalization, lowercase queries are the whole point of this extension.
-/// The precision-safety property instead comes from the caller (the
-/// `memory.recall` handler) only keeping a candidate that matches the *name*
-/// of a real KG entity, via one batched `EntityFilter::names_ci` lookup.
+/// capitalization — lowercase queries are the whole point of this path.
+/// Precision instead comes from the caller (`memory.recall`) only keeping a
+/// candidate that matches the *name* of a real KG entity, via one batched
+/// `EntityFilter::names_ci` lookup.
+///
+/// See crates/khive-pack-memory/docs/scoring.md#entity-lookup-candidate-sampling
+/// for the quota-redistribution and position-fairness sampling algorithm.
 pub fn entity_lookup_candidates(query: &str) -> Vec<String> {
     let tokens: Vec<String> = query
         .split_whitespace()


### PR DESCRIPTION
This pull request adds detailed design documentation for the recall configuration and scoring logic, and improves the clarity and maintainability of code and comments related to entity candidate extraction and lookup. The most important changes are grouped below by theme.

**Documentation Additions:**

* Added `config-reference.md` documenting the rationale for recall configuration bounds, specifically the need for the `ann_ready_timeout_ms` bound to prevent long waits during ANN index warmup.
* Added `scoring.md` explaining the design and algorithmic decisions behind entity candidate extraction and lookup, including why capitalization is used and how CJK substring sampling is performed.
* Updated `design.md` to document the contents and test structure of `scoring.rs`.

**Code Comment and Doc Improvements:**

* Improved doc-comments for `extract_entity_candidates` and `entity_lookup_candidates` in `scoring.rs` to clarify their behavior, rationale, and reference the new documentation for further details. [[1]](diffhunk://#diff-3bd7ffbc0c66deea38b74e98baedef8b010f87216b318cb5c698229b1c705bedL282-R290) [[2]](diffhunk://#diff-3bd7ffbc0c66deea38b74e98baedef8b010f87216b318cb5c698229b1c705bedL362-R353)
* Updated the doc-comment for the `ann_ready_timeout_ms` field in `RecallConfig` to reference the new documentation and clarify its purpose.

**Codebase Maintenance:**

* Removed a redundant file-size justification comment from `scoring.rs` now that this rationale is documented elsewhere.