### PR TITLE
docs(rustdoc): condense inline docs + extract to guides (khive-db,khive-types)

### DIFF
--- a/crates/khive-db/docs/checkpoint-internals.md
+++ b/crates/khive-db/docs/checkpoint-internals.md
@@ -1,0 +1,160 @@
+# Checkpoint task internals
+
+Long-form rationale extracted from `src/checkpoint.rs` doc-comments (ADR-091:
+WAL checkpoint pressure telemetry + TRUNCATE escalation + tx-age sweep).
+Public-item contracts stay complete in the source; this file carries the
+"why", design history, and cross-references.
+
+## Module overview (ADR-091 Planks 0/1/2)
+
+See `crates/khive-db/src/checkpoint.rs` module doc.
+
+The periodic task issues `PRAGMA wal_checkpoint(PASSIVE)` on every tick,
+including when the WAL page count exceeds the high-water mark. Ordinary
+ticks stay PASSIVE-only and non-blocking; a rare, separately-gated escalation
+may additionally run `PRAGMA wal_checkpoint(TRUNCATE)` under the same writer
+guard with a shortened busy timeout (Plank 2, below).
+
+**Non-contending design**: `checkpoint_once` uses `try_writer_nowait`
+(zero-wait `try_lock`) so a tick is skipped immediately when any writer holds
+the mutex, rather than blocking for up to `checkout_timeout`. The checkpoint
+task must never stall active write traffic — a skipped tick is always
+preferable.
+
+**Why TRUNCATE is excluded from every ordinary tick**: TRUNCATE inherits
+RESTART semantics — it waits for active readers to release their WAL
+snapshots and invokes the busy handler before acquiring the exclusive lock
+needed to reset the WAL file. With `PoolConfig`'s 30s `busy_timeout`, blindly
+running it every tick could sit inside SQLite holding the sole writer
+connection for up to 30s, stalling all normal write traffic. PASSIVE never
+waits for readers; it checkpoints as many frames as currently possible and
+returns promptly. When WAL pressure is sustained (`high_water_pages`
+exceeded), the task emits a WARNING; once WAL pressure reaches the much
+higher `truncate_high_water_pages` mark, the rare Plank 2 escalation may
+additionally attempt a bounded, rate-limited TRUNCATE under a deliberately
+shortened busy timeout — replacing what used to be a purely
+operator-scheduled manual step.
+
+**Threshold-crossing WARN semantics**: both the `warn_pages` and
+`high_water_pages` warnings fire at most once per below→above crossing.
+Skipped ticks (writer busy) leave the crossing state unchanged so that a
+skip cannot spuriously re-arm the rate limit while WAL pressure is still
+elevated. The ADR-091 Plank 0 open-transaction-registry WARNs (oldest-entry
+escalation and the high-water snapshot enumeration) ride the SAME crossing
+gates — they are not independently rate-limited, so they never repeat on
+consecutive ticks that remain above a threshold. Only the per-tick `debug!`
+trace of the oldest open entry, and the Plank 1 age sweep, run
+unconditionally on every tick — including a Skipped one; the sweep's own
+emissions stay edge-triggered per rung via `TxAgeSweepState`.
+
+### Plank 2: rare TRUNCATE escalation
+
+The periodic tick stays PASSIVE-only and non-blocking; on top of it,
+`checkpoint_once` also evaluates a much rarer escalation to `PRAGMA
+wal_checkpoint(TRUNCATE)` once the WAL has grown past
+`truncate_high_water_pages` and at least `truncate_min_interval` has elapsed
+since the last TRUNCATE *attempt* (not the last successful reclaim).
+
+This is a **single writer checkout per tick**: PASSIVE and any due TRUNCATE
+both run under the one guard `checkpoint_once` already holds — there is
+never a second concurrent checkout for TRUNCATE. If the writer mutex is
+busy, both PASSIVE and any due TRUNCATE are skipped for that tick, and
+`last_truncate_attempt` is left untouched so the next tick where the writer
+is free is immediately eligible rather than waiting out the full interval
+again. `last_truncate_attempt` only advances on a tick that actually
+attempted TRUNCATE (writer held, threshold crossed, interval elapsed) —
+never on a skip for any reason (writer busy, below threshold, interval not
+yet up).
+
+TRUNCATE runs under a temporarily shortened `busy_timeout`
+(`truncate_busy_timeout`), restored on the writer connection immediately
+after the attempt, win or lose. No transaction is ever killed or aborted
+here — the tx_registry is only read for diagnostics; Plank 1 owns the
+registry's own bound.
+
+### Plank 1: age-based background sweep, not per-statement rejection
+
+The ADR's original text describes a "cooperative stale-op guard" that
+rejects further statements and rolls back a late `commit()` on a
+`SqliteTransaction`/`begin_tx` span past `KHIVE_TX_MAX_AGE_SECS`. That API no
+longer exists in this codebase: ADR-067's `atomic_unit` replaced every
+production write-transaction path with a closure that structurally cannot
+outlive its own call (single-poll-enforced on the write-queue path), which
+is the ADR's own named follow-up ("closure-scoped transaction API"), already
+delivered for writes by a later ADR.
+
+What ships here instead is the part of Plank 1 that still applies to every
+registered span regardless of which mechanism created it: on EVERY tick —
+Skipped as well as Observed, since a registered `WriterGuard::transaction`
+span holds the writer mutex for its whole lifetime and would otherwise make
+the busiest, most relevant tick invisible to this sweep — `TxAgeSweepState`
+checks `khive_storage::tx_registry::oldest()`'s age against
+`tx_warn_secs`/`tx_max_age_secs` and escalates to `warn!`/`error!` on each
+below→above crossing (same debounce idiom as the WAL-pressure ladder — a
+sustained stale span logs once per rung, not once per tick), also re-arming
+both rungs if the oldest entry's identity changes between ticks so a
+departed span's latched state cannot suppress its replacement. This is
+visibility, not reclamation: nothing here force-closes a stale span,
+matching the ADR's own accepted gap for a transaction "held idle across an
+await with no further calls."
+
+## Metrics read-surface (load/perf harness)
+
+See `crates/khive-db/src/checkpoint.rs` — the module-scoped `AtomicU64`
+statics (`LAST_WAL_PAGES`, `TRUNCATE_ATTEMPTS`, etc.) and their accessors.
+
+Mirrors the fallback-counter pattern in `khive-mcp/src/daemon.rs`
+(`FALLBACK_*` statics + their `pub(crate)` accessors): the checkpoint task is
+a single fire-and-forget `tokio::spawn` with no handle retained anywhere the
+daemon's connection-accept loop can reach, so these are plain module-scoped
+atomics rather than a struct threaded through every `checkpoint_once`/
+`maybe_truncate`/`note_truncate_outcome` call site (and, transitively, every
+existing test call site). Read-only surface: nothing here is ever reset
+outside `#[cfg(test)]`, and nothing reachable over the daemon wire can reset
+them either (see `khive_runtime::daemon::DaemonRequestFrame::metrics_only`).
+
+## `run_checkpoint_task` — shutdown design history
+
+See `crates/khive-db/src/checkpoint.rs` — `run_checkpoint_task`.
+
+An earlier version of this task used `Arc::strong_count(&pool) <= 1` as its
+exit condition instead of an explicit signal. That check is unreachable
+whenever a sibling owner holds its own clone of `pool` for the task's
+lifetime — which the production boot path does: `event_store`
+(`Option<Arc<dyn EventStore>>`), when `Some`, is a `SqlEventStore` that
+retains its own `Arc::clone` of the same pool, so the task always observed
+`strong_count == 2` and never exited via that mechanism (issue #774). The
+explicit `watch` channel does not depend on how many other owners exist.
+
+## Private tx-registry logging helpers (Plank 0)
+
+See `crates/khive-db/src/checkpoint.rs` — `log_tx_registry_oldest_debug`,
+`log_tx_registry_oldest_warn`, `log_tx_registry_snapshot_warn`.
+
+All three read `khive_storage::tx_registry` and are observe-only — none
+enforces or force-closes anything. `log_tx_registry_oldest_debug` runs
+unconditionally every tick (unrated-limited, debug-level). The two `warn!`
+variants (`log_tx_registry_oldest_warn` for the single oldest entry,
+`log_tx_registry_snapshot_warn` to enumerate every open entry — the "which
+caller is holding the pin" answer ADR-091's static reading could not
+produce) are NOT internally rate-limited: callers MUST gate them on a
+below→above crossing (`warn_pages` / `high_water_pages` respectively, via
+`crossing_warn`) or they reproduce the log-spam bug this rewrite fixes.
+
+## `maybe_truncate` — TRUNCATE attempt gating (Plank 2)
+
+See `crates/khive-db/src/checkpoint.rs` — private fn `maybe_truncate`.
+
+Runs under the writer guard the caller already holds — never performs its
+own checkout. No-ops unless BOTH `wal_pages >= truncate_high_water_pages`
+AND no prior attempt or `truncate_min_interval` has elapsed since the last
+one. `truncate_state.last_attempt` is stamped ONLY immediately before the
+TRUNCATE pragma itself runs (writer held, threshold crossed, interval
+elapsed, AND the temporary busy_timeout override successfully applied) —
+every earlier return is a skip, not an attempt, and never touches it,
+matching the ADR's "skip must not stamp" requirement. The oldest-pinning
+snapshot is logged (reusing Plank 0's `tx_registry`) before the attempt.
+`busy_timeout` is temporarily lowered to `truncate_busy_timeout` for the
+PRAGMA call and restored immediately after, regardless of outcome. No
+transaction is ever killed here — enforcement is Plank 1's job, not this
+one's.

--- a/crates/khive-db/docs/pool-writer-backend-internals.md
+++ b/crates/khive-db/docs/pool-writer-backend-internals.md
@@ -1,0 +1,46 @@
+# Pool / writer-task / backend internals
+
+Long-form rationale extracted from `src/pool.rs` doc-comments. Public-item
+contracts stay complete in the source; this file carries the "why" and
+cross-references.
+
+## `ConnectionPool::writer_task_handle` — single-writer-task rationale
+
+See `crates/khive-db/src/pool.rs` — `writer_task_handle`.
+
+Exactly one writer task exists per `ConnectionPool` (per DB file) no matter
+how many stores or namespaces are constructed over it: the `OnceLock` runs
+its init closure at most once, so concurrent callers either race to run it
+once or block on the in-flight init and then all receive a clone of the same
+resulting handle. This is what makes the write queue an actual
+single-writer core rather than one writer task per store — a per-store
+writer task would let concurrent migrated stores over the same pool spawn
+independent writer connections that contend with each other at `BEGIN
+IMMEDIATE`, defeating the point of ADR-067 Component A.
+
+## `pool.rs` tests
+
+### `writer_guard_transaction_registers_during_closure_only`
+
+ADR-091 Plank 0: `WriterGuard::transaction` registers an entry with the
+shared open-transaction registry for the duration of the closure, and
+deregisters it once the closure (and its commit/rollback) completes.
+
+`#[serial(tx_registry)]`: the open-transaction registry is a process-wide
+singleton (`khive_storage::tx_registry`) shared across every test in this
+binary. This test filters by its own unique label so it is not vulnerable to
+another test's entry being reported as "oldest", but it still shares the
+same `tx_registry` serial group as `checkpoint.rs`'s and `sql_bridge.rs`'s
+registry tests for defense-in-depth against cross-test interference.
+
+### `writer_task_handle_fails_loud_without_tokio_runtime`
+
+ADR-067 Component A runtime-handle guard: `write_queue_enabled` is set but
+the calling thread has no Tokio runtime context, so spawning the writer task
+(which requires `tokio::spawn`) is impossible. `writer_task_handle` must
+return a clean typed error instead of panicking.
+
+Deliberately a plain `#[test]` (no Tokio runtime) — mirrors
+`writer_task::spawn_fails_on_in_memory_pool`'s shape: the failure must be
+observable without ever entering an async context, since entering one here
+would defeat the point of the test.

--- a/crates/khive-db/docs/test-notes.md
+++ b/crates/khive-db/docs/test-notes.md
@@ -1,0 +1,139 @@
+# Test rationale notes
+
+Long-form test rationale extracted from `#[cfg(test)]` doc-comments across
+khive-db. Test code doesn't render on docs.rs, so in-source comments were
+trimmed to short summaries; this file keeps the full "why" for each test —
+what regression/incident it guards, what edge case it covers, and any
+non-obvious setup detail.
+
+## `checkpoint.rs` tests
+
+### `log_tx_registry_oldest_debug_reports_oldest_open_entry`
+
+`#[serial(tx_registry)]`: the registry is a process-wide singleton shared
+across every test in this binary — see `pool.rs`'s and `sql_bridge.rs`'s
+registry tests, which share this same serial group (these three were
+previously unserialized and could race, corrupting each other's
+`oldest()`/`snapshot()` reads).
+
+This test does NOT hardcode "checkpoint_tick_test" as the expected label:
+production write paths elsewhere in this same test binary (vectors/graph/text
+stores) also register short-lived registry entries while their own tests
+run, and `serial(tx_registry)` only serializes against the OTHER tests in
+that same group, not against every write path in the crate. Instead it
+samples `oldest()` itself immediately before invoking the function under
+test and asserts the logged label matches whatever the registry considers
+oldest at that instant — deterministic regardless of unrelated concurrent
+registry churn, while still verifying `log_tx_registry_oldest_debug`
+correctly surfaces the registry's own `oldest()` answer.
+
+### `checkpoint_task_exits_via_shutdown_signal_with_live_event_store_pool_clone`
+
+Regression for issue #774: on the production boot path, the daemon passes
+`run_checkpoint_task` both `pool` directly and an `event_store` that
+internally retains its own `Arc::clone` of the same pool
+(`SqlEventStore::new_scoped`). A strong-count-based exit condition can never
+fire in that shape, because the task always observes at least two live
+clones — its own `pool` argument plus the one buried in `event_store`. This
+test reproduces that exact ownership shape (a real `SqlEventStore` holding a
+sibling clone) and asserts the task still exits promptly via the
+watch-channel signal, proving the fix does not depend on `Arc::strong_count`
+at all.
+
+### `checkpoint_high_water_does_not_block_behind_reader`
+
+Regression: a high-water tick must NOT block behind an active read
+transaction.
+
+Isomorphism guarantee: this test FAILS if `checkpoint_once` regresses to
+`PRAGMA wal_checkpoint(TRUNCATE)`. Confirmed by reasoning: TRUNCATE inherits
+RESTART semantics and will invoke the busy handler (sleeping up to
+`busy_timeout`) while waiting for the open reader snapshot to release. With
+`busy_timeout = 2000ms` a TRUNCATE regression causes the call to take
+~2000ms, blowing the <500ms assertion. PASSIVE returns in <1ms even with an
+open reader, because PASSIVE never waits for readers.
+
+Why `busy_timeout = 2000ms` and threshold `< 500ms`: the original 200ms
+busy_timeout / 50ms threshold was too tight for contended CI runners where
+PASSIVE legitimately takes 50-200ms under parallel-test load. Raising the
+busy_timeout to 2000ms keeps the PASSIVE path well below 500ms while a
+TRUNCATE regression blocks for ~2000ms — a 4x safety margin on both sides.
+
+An idle reader connection (no `BEGIN`) does NOT pin frames and would not
+cause TRUNCATE to wait — an actual open read transaction is required for
+the isomorphism to hold.
+
+### `checkpoint_config_rejects_reversed_tx_thresholds`
+
+Fix: a reversed pair — `KHIVE_TX_WARN_SECS` >= `KHIVE_TX_MAX_AGE_SECS` —
+must not be honored independently. Before this fix, WARN_SECS=120 /
+MAX_AGE_SECS=30 parsed both values successfully (each is independently
+positive) and produced a sweep that emits `Stale` at 30s while never
+reaching the `Warn` crossing until 120s — inverting the intended severity
+ladder. Both thresholds must instead fall back to their defaults together.
+
+### `checkpoint_config_rejects_equal_tx_thresholds`
+
+Same invariant, the degenerate equal case: WARN_SECS == MAX_AGE_SECS would
+make an entry cross both rungs on the exact same tick every time,
+collapsing the two-rung severity ladder into one. Must also fall back to
+defaults, not merely reject a strictly-reversed pair.
+
+### `skipped_tick_does_not_reset_high_water_crossing_state`
+
+Regression: a Skipped tick must NOT reset `was_above_high_water`.
+
+Before the fix, `checkpoint_once` returned `0` on both a genuinely-empty WAL
+and a writer-busy skip. The task treated `0` as an observed page count and
+reset `was_above_high_water`, re-arming the rate limit on every busy tick.
+With the fix, `CheckpointTick::Skipped` leaves crossing state unchanged.
+
+This test drives `crossing_warn` directly (the pure function that owns the
+decision) rather than going through the async task, which would require a
+logging harness.
+
+### `tx_age_sweep_stale_replacement_without_intervening_clear_still_names_new_entry`
+
+Fix: a stale entry (A) that closes and is immediately replaced by an
+ALREADY-stale entry (B) on the very next observed tick — no intervening
+below-threshold or empty tick, unlike `tx_age_sweep_rearms_after_entry_clears`
+— must still emit both rungs for B. Before the identity-tracking fix,
+`was_above_warn` and `was_above_max_age` were already `true` from A, so B's
+crossing was silently swallowed: the alert stayed latched to a departed
+caller while a different long-lived span was now pinning the database.
+
+### `tx_age_sweep_uses_configured_thresholds_not_hardcoded_defaults`
+
+`KHIVE_TX_WARN_SECS` / `KHIVE_TX_MAX_AGE_SECS` are read into the config via
+`from_env` at `run_checkpoint_task` construction time, so this closes the
+loop from env var to the actual emitted rung (the earlier
+`checkpoint_config_env_override` test only asserts the config fields
+themselves).
+
+### `tx_age_sweep_names_long_lived_reader_pinning_wal_past_high_water`
+
+Integration-level regression for the incident this ADR fixes: a real `BEGIN
+DEFERRED` reader pins a WAL snapshot (exactly like
+`checkpoint_high_water_does_not_block_behind_reader`) while also being
+registered in the shared `tx_registry` (simulating an instrumented
+long-lived-reader call site such as `graph.rs`'s `graph_traverse_read`),
+writes drive `wal_pages` past `high_water_pages`, and — with a
+millisecond-scale `tx_max_age_secs` so the test does not sleep for real
+minutes — the Plank 1 sweep escalates to `Stale` naming that exact reader,
+alongside the existing Plank 0 high-water WARN. This is the "detection
+works, mitigation missing" gap from the incident: the sweep now gives the
+operator the specific, escalating, un-silenced signal that a single
+one-shot high-water WARN does not.
+
+### `tx_age_sweep_own_entry_survives_concurrent_older_registration`
+
+Regression for #926: reproduces the exact race that made
+`tx_age_sweep_names_long_lived_reader_pinning_wal_past_high_water` flaky,
+directly rather than hoping cargo's test scheduler happens to interleave two
+unrelated tests. `tx_registry` is a process-wide singleton; a decoy entry
+registered before this test's own entry is genuinely older, so raw
+`oldest()` cannot return the test fixture — exactly what an unrelated,
+concurrently-running write path (e.g. `graph_upsert_edges`) could do in the
+real suite. The fix (looking up this test's own entry by label via
+`snapshot()` instead of trusting global `oldest()`) must still correctly
+name and escalate THIS entry despite that older decoy.

--- a/crates/khive-db/docs/vectors-internals.md
+++ b/crates/khive-db/docs/vectors-internals.md
@@ -1,0 +1,193 @@
+# Vector store internals
+
+Long-form rationale extracted from `src/stores/vectors.rs` doc-comments
+(sqlite-vec backed `VectorStore`). Public-item contracts stay complete in
+the source; this file carries the "why", design history, and
+cross-references for non-public helpers and tests.
+
+## `with_writer` / `with_writer_unmanaged` — WriterTask routing (ADR-067 Component A, Fork C slice 2)
+
+See `crates/khive-db/src/stores/vectors.rs` — private methods `with_writer`,
+`with_writer_unmanaged`.
+
+`with_writer` routes a single-row write through the pool-wide `WriterTask`
+when `KHIVE_WRITE_QUEUE=1` and a handle is available; otherwise it falls
+back to the legacy pool-mutex path (`with_writer_unmanaged`).
+
+This is the routing point for callers whose closure is DML-only
+(`delete`/`vec_delete`, `delete_subjects`/`vec_delete_subjects`): on the
+flag-on path the closure runs inside the WriterTask's own transaction, so a
+bare `BEGIN IMMEDIATE` (or an inner `conn.unchecked_transaction()`) would
+violate SQLite's nested-transaction rule. `insert`/`update` (which need
+their own delete-then-insert atomicity), `insert_batch` (the batch method),
+and `orphan_sweep` (ADR-067 Amendment 1) each do their own flag check and
+return early on `Some`, routing a DML-only closure directly through the
+WriterTask instead — their fallback calls into `with_writer` only ever
+execute on the flag-off path (`self.writer_task` is `None` by construction
+whenever those calls are reached), so there is no double-routing.
+
+`with_writer_unmanaged` bypasses the WriterTask channel unconditionally
+regardless of `KHIVE_WRITE_QUEUE`. Reserved for closures that manage their
+own transaction — those cannot be sent through the WriterTask channel, which
+already wraps every request in its own transaction. `orphan_sweep`'s
+flag-off path (`Transaction::new_unchecked`, its own manual `BEGIN
+IMMEDIATE`) is the only caller — on the flag-on path `orphan_sweep` routes a
+DML-only closure directly through the WriterTask instead, since routing a
+`Transaction::new_unchecked` through the channel would nest a transaction
+inside the WriterTask's own transaction.
+
+## `replace_vector_row_dml` — shared DELETE-then-INSERT replacement (#546)
+
+See `crates/khive-db/src/stores/vectors.rs` — private fn `replace_vector_row_dml`.
+
+`vec0` virtual tables do not support `INSERT OR REPLACE`, so every
+replacement path (single-record insert/update, batch insert, and the
+WriterTask-routed atomic upsert) deletes the prior row for `(subject_id,
+namespace)` then inserts the new one. This function issues no
+`BEGIN`/`COMMIT`/`SAVEPOINT` itself — the caller owns the enclosing
+transaction or savepoint and its rollback semantics, so this can run equally
+inside a plain `Connection`, an `unchecked_transaction()`, or a named
+`SAVEPOINT`.
+
+`failpoint_flag`, when `Some` in a `cfg(test)` build, is checked between the
+DELETE and the INSERT so tests can force an error at that exact point and
+assert the caller's rollback restores the prior row (no-worse-than-stale
+guarantee). It is inert in release builds.
+
+## `insert_batch` / `update` savepoint-rollback tests
+
+### `insert_batch_savepoint_rollback_on_pk_conflict_preserves_stale`
+
+Tests the SAVEPOINT/ROLLBACK path — INSERT failure inside the savepoint. The
+existing wrong-dimension tests
+(`insert_batch_failed_record_preserves_prior_vector`) hit the pre-savepoint
+`continue` guard and never reach the SAVEPOINT/ROLLBACK sequence. This test
+forces a genuine INSERT failure inside the savepoint by exploiting vec0's
+single-column PRIMARY KEY (`subject_id TEXT PRIMARY KEY`, NOT scoped to
+namespace).
+
+Mechanism: store a stale row for `(id_X, ns:a)`. Submit a batch with one
+record for `(id_X, ns:b)`. The DELETE step targets `WHERE namespace = 'ns:b'`
+and finds nothing (stale is in ns:a), so nothing is removed. The INSERT then
+tries to write `id_X` into vec0's `_rowids` shadow table, but `id_X` already
+occupies it (from the ns:a stale row). The UNIQUE constraint fires — INSERT
+fails — ROLLBACK TO SAVEPOINT executes — stale row in ns:a survives intact.
+
+NOTE: removing `ROLLBACK TO SAVEPOINT` would NOT change the outcome for this
+specific test, because the DELETE was a no-op (different namespace). This
+test is NOT the rollback sentinel — it covers the PK-conflict path and
+verifies that the outer COMMIT succeeds. For the true sentinel (DELETE
+succeeds then INSERT is injected to fail), see
+`insert_batch_rollback_restores_deleted_stale_after_post_delete_insert_failure`.
+
+Additionally: insert_batch must count the record as `failed` and must not
+abort the outer `BEGIN IMMEDIATE` transaction (the COMMIT must succeed).
+
+### `insert_batch_rollback_does_not_corrupt_subsequent_record`
+
+Two-record batch where the first record's SAVEPOINT rolls back (PK
+conflict) and the second record succeeds, proving the rollback on record 1
+does not corrupt the state seen by record 2.
+
+Scenario: stale = `(id_X, ns:a, stale_vec)` in DB.
+- Record A — `(id_X, ns:b)`: SAVEPOINT; DELETE WHERE ns=ns:b (nothing);
+  INSERT id_X → PK conflict (stale holds it) → ROLLBACK TO SAVEPOINT.
+  failed=1. Stale untouched.
+- Record B — `(id_X, ns:a, new_vec)`: SAVEPOINT; DELETE WHERE ns=ns:a
+  removes stale (PK freed); INSERT id_X succeeds. RELEASE. affected=1.
+
+Final state: `(id_X, ns:a, new_vec)`. The search with new_vec yields ~1.0,
+confirming Record A's rolled-back SAVEPOINT did not corrupt what Record B
+wrote.
+
+NOTE: Record A's DELETE is a no-op (different namespace), so removing
+`ROLLBACK TO SAVEPOINT` would NOT change this test's outcome. The true
+sentinel is `insert_batch_rollback_restores_deleted_stale_after_post_delete_insert_failure`.
+
+### `update_pk_conflict_rolls_back_transaction_preserves_stale`
+
+`update`'s single-record path wraps DELETE+INSERT in `unchecked_transaction`.
+Wrong-dim tests fail in the outer Rust guard, before the transaction opens.
+This test forces an INSERT failure inside the transaction on a
+correctly-dimensioned finite vector by calling `update` with a namespace
+that does NOT match the stored row.
+
+Mechanism: stale row is `(id_X, ns:a)`. Call `update(id_X, ns:b, ...)`.
+- DELETE WHERE ns=ns:b finds nothing.
+- INSERT (id_X, ns:b) hits vec0 PK constraint (id_X in `_rowids` held by
+  ns:a).
+- `unchecked_transaction()` rolls back.
+- Stale row in ns:a survives intact.
+
+NOTE: the DELETE is a no-op (different namespace), so removing the
+transaction rollback would NOT change this test's outcome. The true
+sentinel is `update_rollback_restores_deleted_stale_after_post_delete_insert_failure`.
+
+### True ROLLBACK TO SAVEPOINT sentinels (failpoint-driven)
+
+The PK-conflict tests above exercise the SAVEPOINT path, but the DELETE is a
+no-op in those tests (different namespace). Removing the `ROLLBACK TO
+SAVEPOINT vec_batch_record` line from `insert_batch`, or the transaction
+rollback from `update`, would NOT make those tests fail.
+
+The sentinel tests (`insert_batch_rollback_restores_deleted_stale_after_post_delete_insert_failure`
+and its `update` counterpart) use a `cfg(test)` failpoint that fires AFTER a
+successful same-namespace DELETE and BEFORE the INSERT. This means:
+- The stale row is genuinely gone from the DB when the error fires.
+- Only a correct ROLLBACK TO SAVEPOINT (or `tx.rollback`) restores it.
+- Removing those rollback lines WILL make these tests fail.
+
+Value-level failures (dim/finite/count) are rejected before the SAVEPOINT
+opens, so there is no natural same-namespace path to reach a post-DELETE
+INSERT failure through the public API. The failpoint is the only way to
+produce this condition in a unit test without modifying production logic.
+
+### `insert_batch_rollback_restores_deleted_stale_after_post_delete_insert_failure`
+
+SENTINEL — stale row is restored when DELETE succeeds but INSERT is forced
+to fail via the `cfg(test)` failpoint.
+
+Setup: insert stale `(id_X, ns:a, vec1)`. Failpoint `FAIL_AFTER_DELETE` is
+armed before the batch call. Batch: one record `(id_X, ns:a, vec2)` — same
+namespace, correct dims, all finite — so the production DELETE genuinely
+removes the stale row, then the failpoint fires before INSERT.
+
+Expected: `ROLLBACK TO SAVEPOINT vec_batch_record` restores the stale row —
+`batch_exists` finds id_X in ns:a, search with vec1 returns similarity
+> 0.999 (not vec2), and `BatchWriteSummary` reports attempted=1, affected=0,
+failed=1.
+
+FAILURE MODE: deleting the `ROLLBACK TO SAVEPOINT vec_batch_record` line
+from `insert_batch` makes this test fail — the stale row is gone.
+
+### `update_rollback_restores_deleted_stale_after_post_delete_insert_failure`
+
+SENTINEL — stale row is restored when DELETE succeeds but INSERT is forced
+to fail via the `cfg(test)` failpoint.
+
+Setup: insert stale `(id_X, ns:a, vec1)`. Failpoint `FAIL_AFTER_DELETE` is
+armed before the update call. Call `update(id_X, ns:a, vec2)` — same
+namespace, correct dims, finite: DELETE removes the stale row, then the
+failpoint fires before INSERT.
+
+Expected: `unchecked_transaction` rolls back, restoring the stale row —
+`batch_exists` finds id_X in ns:a, search with vec1 returns similarity
+> 0.999 (not vec2), and `update` returns `Err` (the injected error
+propagates out).
+
+FAILURE MODE: removing the transaction's rollback from `update` makes this
+test fail — the stale row is gone.
+
+### `insert_rollback_restores_deleted_stale_after_post_delete_insert_failure`
+
+#546: the flag-off single-record `insert` path previously ran its own
+inline DELETE+INSERT with no failpoint hook at all, so the post-delete
+rollback guarantee was never exercised on this path (only `update` and the
+batch/atomic-upsert helpers were covered). Now that `insert` routes through
+the shared `replace_vector_row_dml` helper, the same failpoint must fire
+here too and `unchecked_transaction` must roll back the DELETE, restoring
+the stale row.
+
+FAILURE MODE (pre-#546): this test could not even be written against the
+old `insert` body — there was no failpoint hook to arm. Removing the shared
+helper (or its transaction rollback) makes this fail.

--- a/crates/khive-db/src/checkpoint.rs
+++ b/crates/khive-db/src/checkpoint.rs
@@ -1,87 +1,27 @@
-//! Periodic WAL checkpoint task for the connection pool.
+//! Periodic WAL checkpoint task for the connection pool (ADR-091).
 //!
-//! Issues `PRAGMA wal_checkpoint(PASSIVE)` on every tick — including when the
-//! WAL page count exceeds the high-water mark. Ordinary ticks stay
-//! PASSIVE-only and non-blocking; a rare, separately-gated escalation may
-//! additionally run `PRAGMA wal_checkpoint(TRUNCATE)` under the same writer
-//! guard with a shortened busy timeout — see the ADR-091 Plank 2 doc below
-//! for the escalation's own gating.
+//! Issues `PRAGMA wal_checkpoint(PASSIVE)` on every tick — non-blocking, never
+//! waits for readers. A rare, separately-gated escalation may additionally run
+//! `PRAGMA wal_checkpoint(TRUNCATE)` once WAL pressure crosses
+//! `truncate_high_water_pages` and `truncate_min_interval` has elapsed since
+//! the last attempt (Plank 2); both run under the single writer checkout
+//! `checkpoint_once` holds for that tick. `checkpoint_once` uses
+//! `try_writer_nowait` (zero-wait `try_lock`) so a tick is skipped immediately
+//! when the writer mutex is held, rather than blocking — a skipped tick is
+//! always preferable to stalling write traffic.
 //!
-//! Non-contending design: `checkpoint_once` uses `try_writer_nowait` (zero-wait
-//! `try_lock`) so a tick is skipped immediately when any writer holds the mutex,
-//! rather than blocking for up to `checkout_timeout`. The checkpoint task must
-//! never stall active write traffic — a skipped tick is always preferable.
+//! `warn_pages` / `high_water_pages` WARNs fire at most once per below→above
+//! crossing; a skipped tick leaves crossing state unchanged. An age-based
+//! background sweep (Plank 1) additionally checks the oldest span in
+//! `khive_storage::tx_registry` against `tx_warn_secs`/`tx_max_age_secs` on
+//! every tick (Skipped or Observed) and escalates to `warn!`/`error!` on each
+//! below→above crossing — visibility only, nothing here force-closes a stale
+//! span.
 //!
-//! Why TRUNCATE is excluded from *every ordinary* tick: TRUNCATE inherits
-//! RESTART semantics — it waits for active readers to release their WAL
-//! snapshots and invokes the busy handler before acquiring the exclusive lock
-//! needed to reset the WAL file. With PoolConfig's 30 s busy_timeout, blindly
-//! running it every tick could sit inside SQLite holding the sole writer
-//! connection for up to 30 s, stalling all normal write traffic. PASSIVE never
-//! waits for readers; it checkpoints as many frames as currently possible and
-//! returns promptly. When WAL pressure is sustained (high_water_pages
-//! exceeded), the task emits a WARNING; once WAL pressure reaches the much
-//! higher `truncate_high_water_pages` mark, the rare Plank 2 escalation below
-//! may additionally attempt a bounded, rate-limited TRUNCATE under a
-//! deliberately shortened busy timeout — replacing what used to be a purely
-//! operator-scheduled manual step.
-//!
-//! Threshold-crossing WARN semantics: both the `warn_pages` and `high_water_pages`
-//! warnings fire at most once per below→above crossing. Skipped ticks (writer
-//! busy) leave the crossing state unchanged so that a skip cannot spuriously
-//! re-arm the rate limit while WAL pressure is still elevated. The ADR-091
-//! Plank 0 open-transaction-registry WARNs (oldest-entry escalation and the
-//! high-water snapshot enumeration) ride the SAME crossing gates — they are
-//! not independently rate-limited, so they never repeat on consecutive ticks
-//! that remain above a threshold. Only the per-tick `debug!` trace of the
-//! oldest open entry, and the ADR-091 Plank 1 age sweep below, run
-//! unconditionally on every tick — including a Skipped one; the sweep's own
-//! emissions stay edge-triggered per rung via `TxAgeSweepState`.
-//!
-//! ADR-091 Plank 2: rare TRUNCATE escalation. The periodic tick above stays
-//! PASSIVE-only and non-blocking; on top of it, `checkpoint_once` also
-//! evaluates a much rarer escalation to `PRAGMA wal_checkpoint(TRUNCATE)`
-//! once the WAL has grown past `truncate_high_water_pages` and at least
-//! `truncate_min_interval` has elapsed since the last TRUNCATE *attempt*
-//! (not the last successful reclaim). This is a **single writer checkout per
-//! tick**: PASSIVE and any due TRUNCATE both run under the one guard
-//! `checkpoint_once` already holds — there is never a second concurrent
-//! checkout for TRUNCATE. If the writer mutex is busy, both PASSIVE and any
-//! due TRUNCATE are skipped for that tick, and `last_truncate_attempt` is
-//! left untouched so the next tick where the writer is free is immediately
-//! eligible rather than waiting out the full interval again.
-//! `last_truncate_attempt` only advances on a tick that actually attempted
-//! TRUNCATE (writer held, threshold crossed, interval elapsed) — never on a
-//! skip for any reason (writer busy, below threshold, interval not yet up).
-//! TRUNCATE runs under a temporarily shortened `busy_timeout`
-//! (`truncate_busy_timeout`), restored on the writer connection immediately
-//! after the attempt, win or lose. No transaction is ever killed or aborted
-//! here — the tx_registry is only read for diagnostics; Plank 1 (below) owns
-//! the registry's own bound.
-//!
-//! ADR-091 Plank 1: age-based background sweep, not per-statement rejection.
-//! The ADR's original text describes a "cooperative stale-op guard" that
-//! rejects further statements and rolls back a late `commit()` on a
-//! `SqliteTransaction`/`begin_tx` span past `KHIVE_TX_MAX_AGE_SECS`. That API
-//! no longer exists in this codebase: ADR-067's `atomic_unit` replaced every
-//! production write-transaction path with a closure that structurally cannot
-//! outlive its own call (single-poll-enforced on the write-queue path), which
-//! is the ADR's own named follow-up ("closure-scoped transaction API"),
-//! already delivered for writes by a later ADR. What ships here instead is
-//! the part of Plank 1 that still applies to every registered span
-//! regardless of which mechanism created it: on EVERY tick — Skipped as well
-//! as Observed, since a registered `WriterGuard::transaction` span holds the
-//! writer mutex for its whole lifetime and would otherwise make the busiest,
-//! most relevant tick invisible to this sweep — `TxAgeSweepState` checks
-//! `khive_storage::tx_registry::oldest()`'s age against
-//! `tx_warn_secs`/`tx_max_age_secs` and escalates to `warn!`/`error!` on each
-//! below→above crossing (same debounce idiom as the WAL-pressure ladder — a
-//! sustained stale span logs once per rung, not once per tick), also
-//! re-arming both rungs if the oldest entry's identity changes between ticks
-//! so a departed span's latched state cannot suppress its replacement. This
-//! is visibility, not reclamation: nothing here force-closes a stale span,
-//! matching the ADR's own accepted gap for a transaction "held idle across
-//! an await with no further calls."
+//! See crates/khive-db/docs/checkpoint-internals.md#module-overview-adr-091-planks-012
+//! for full ADR-091 Plank 0/1/2 design rationale (why TRUNCATE is excluded
+//! from ordinary ticks, the single-writer-checkout invariant, and why Plank 1
+//! is a sweep rather than the ADR's originally-described per-statement guard).
 
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
@@ -90,18 +30,8 @@ use std::time::{Duration, Instant};
 use crate::pool::{ConnectionPool, WriterGuard};
 
 // ── metrics read-surface (load/perf harness) ─────────────────────────────
-//
-// Process-wide gauges mirroring the fallback-counter pattern in
-// `khive-mcp/src/daemon.rs` (`FALLBACK_*` statics + their `pub(crate)`
-// accessors): the checkpoint task is a single fire-and-forget
-// `tokio::spawn` with no handle retained anywhere the daemon's
-// connection-accept loop can reach, so these are plain module-scoped
-// atomics rather than a struct threaded through every `checkpoint_once`/
-// `maybe_truncate`/`note_truncate_outcome` call site (and, transitively,
-// every existing test call site). Read-only surface: nothing here is ever
-// reset outside `#[cfg(test)]`, and nothing reachable over the daemon wire
-// can reset them either (see `khive_runtime::daemon::DaemonRequestFrame::
-// metrics_only`).
+// Read-only process-wide gauges (never reset outside #[cfg(test)]). See
+// crates/khive-db/docs/checkpoint-internals.md#metrics-read-surface-loadperf-harness
 
 /// Last-observed WAL page count (`query_wal_pages`'s return value on its
 /// most recent call, from either `checkpoint_once` or `maybe_truncate`).
@@ -710,45 +640,31 @@ fn log_tx_age_emission(emission: &TxAgeEmission) {
 
 /// Run the WAL checkpoint background task.
 ///
-/// This is a long-running async task that should be spawned with
-/// `tokio::spawn`. It loops until `shutdown_rx` observes a change (or its
-/// sender is dropped), at which point it exits on its next `select!` wakeup.
-/// Callers should hold the paired `tokio::sync::watch::Sender` for the
-/// daemon's run scope and send on it as part of the shutdown sequence.
+/// Long-running async task — spawn with `tokio::spawn`. Loops until
+/// `shutdown_rx` observes a change (or its sender is dropped), exiting on its
+/// next `select!` wakeup; callers should hold the paired
+/// `tokio::sync::watch::Sender` for the daemon's run scope and send on it as
+/// part of the shutdown sequence (do not rely on `pool`'s `Arc` refcount
+/// reaching zero — see the guide for why that doesn't work here).
 ///
-/// An earlier version of this task used `Arc::strong_count(&pool) <= 1` as
-/// its exit condition instead of an explicit signal. That check is
-/// unreachable whenever a sibling owner holds its own clone of `pool` for
-/// the task's lifetime — which the production boot path does: `event_store`
-/// (`Option<Arc<dyn EventStore>>`), when `Some`, is a `SqlEventStore` that
-/// retains its own `Arc::clone` of the same pool, so the task always
-/// observed `strong_count == 2` and never exited via that mechanism
-/// (issue #774). The explicit watch channel does not depend on how many
-/// other owners exist.
+/// Issues `PRAGMA wal_checkpoint(PASSIVE)` on every tick via
+/// `try_writer_nowait` (zero-wait try-lock): a busy writer causes the current
+/// tick to be skipped rather than stalling write traffic; see the
+/// module-level doc for the rare Plank 2 TRUNCATE escalation
+/// `checkpoint_once` may additionally run. A WARNING is emitted once on
+/// threshold crossing (wal_pages transitions from below a threshold to
+/// at/above) rather than on every tick; skipped ticks leave both
+/// crossing-state flags unchanged so a skip cannot spuriously re-arm the rate
+/// limit while WAL pressure is still elevated.
 ///
-/// The task issues `PRAGMA wal_checkpoint(PASSIVE)` on every tick — ordinary
-/// ticks stay PASSIVE-only and non-blocking; see the module-level doc for the
-/// rare Plank 2 TRUNCATE escalation `checkpoint_once` may additionally run
-/// under the same writer guard when WAL pressure is sustained past
-/// `truncate_high_water_pages`. A WARNING is emitted once on threshold
-/// crossing (wal_pages transitions from below a threshold to at/above) rather
-/// than on every tick, preventing log spam when a long-lived reader pins a
-/// WAL snapshot.
-///
-/// Skipped ticks (writer mutex busy) leave both crossing-state flags unchanged
-/// so that a skip cannot spuriously re-arm the rate limit while WAL pressure is
-/// still elevated.
-///
-/// Uses `try_writer_nowait` (zero-wait try-lock) so a busy writer causes the
-/// current tick to be skipped rather than stalling write traffic.
-///
-/// `event_store` (ADR-094): when `Some`, this task appends a best-effort
+/// `event_store` (ADR-094): when `Some`, appends a best-effort
 /// `CheckpointOutcomeRecorded` lifecycle event on every tick where WAL
 /// pressure is at/above `warn_pages`, plus exactly one drain row on the tick
 /// that observes pressure fall back below `warn_pages` after an elevated
-/// episode — never on every ordinary below-warn tick. `namespace` is
-/// stamped on those rows. `None` makes event emission a pure no-op, exactly
-/// like an unconfigured audit sink elsewhere in the runtime.
+/// episode — never on every ordinary below-warn tick. `namespace` is stamped
+/// on those rows. `None` makes event emission a pure no-op. See
+/// crates/khive-db/docs/checkpoint-internals.md#run_checkpoint_task--shutdown-design-history
+/// for the issue #774 shutdown-mechanism history.
 pub async fn run_checkpoint_task(
     pool: Arc<ConnectionPool>,
     config: CheckpointConfig,
@@ -936,10 +852,8 @@ async fn append_checkpoint_lifecycle_event<P: serde::Serialize>(
 /// the WAL frame count at `debug!`, on EVERY tick regardless of threshold
 /// state. This is the low-volume per-tick trace; the WARN-level escalations
 /// live in [`log_tx_registry_oldest_warn`] and
-/// [`log_tx_registry_snapshot_warn`], both of which are gated on threshold
-/// *crossing* by the caller (`run_checkpoint_task`) so they fire once per
-/// crossing rather than once per tick. Observe only: this never enforces or
-/// force-closes anything.
+/// debug-level, unconditional per-tick trace. See
+/// crates/khive-db/docs/checkpoint-internals.md#private-tx-registry-logging-helpers-plank-0
 fn log_tx_registry_oldest_debug(wal_pages: u64) {
     if let Some((_id, age, label)) = khive_storage::tx_registry::oldest() {
         tracing::debug!(
@@ -951,11 +865,9 @@ fn log_tx_registry_oldest_debug(wal_pages: u64) {
     }
 }
 
-/// ADR-091 Plank 0: escalate the oldest open registry entry to `warn!`.
-///
-/// Callers MUST gate this on a below→above `warn_pages` crossing (via
-/// `crossing_warn`) — it is not rate-limited internally, so calling it every
-/// tick would reproduce the log-spam bug this rewrite fixes.
+/// Escalates the oldest open registry entry to `warn!`. NOT internally
+/// rate-limited — caller MUST gate on a below→above `warn_pages` crossing
+/// (`crossing_warn`) or every tick reproduces the log-spam bug this fixes.
 fn log_tx_registry_oldest_warn(wal_pages: u64) {
     if let Some((_id, age, label)) = khive_storage::tx_registry::oldest() {
         tracing::warn!(
@@ -967,14 +879,9 @@ fn log_tx_registry_oldest_warn(wal_pages: u64) {
     }
 }
 
-/// ADR-091 Plank 0: enumerate every open registry entry at `warn!` — the
-/// "which caller is holding the pin" answer this ADR's static reading could
-/// not produce.
-///
-/// Callers MUST gate this on a below→above `high_water_pages` crossing (via
-/// `crossing_warn`) — it is not rate-limited internally, so calling it every
-/// tick would repeat the full snapshot enumeration every tick under
-/// sustained pressure.
+/// Enumerates every open registry entry at `warn!`. NOT internally
+/// rate-limited — caller MUST gate on a below→above `high_water_pages`
+/// crossing (`crossing_warn`) or every tick repeats the full enumeration.
 fn log_tx_registry_snapshot_warn(wal_pages: u64) {
     for (age, label) in khive_storage::tx_registry::snapshot() {
         tracing::warn!(
@@ -1031,29 +938,10 @@ pub fn checkpoint_once(
     CheckpointTick::Observed(wal_pages)
 }
 
-/// ADR-091 Plank 2: evaluate and, if due, attempt a TRUNCATE escalation.
-///
-/// Runs under the writer guard the caller already holds — never performs its
-/// own checkout. Returns immediately (a no-op) unless BOTH:
-/// - `wal_pages >= config.truncate_high_water_pages`, and
-/// - no prior attempt (`truncate_state.last_attempt.is_none()`) OR at least
-///   `config.truncate_min_interval` has elapsed since the last attempt.
-///
-/// `truncate_state.last_attempt` is stamped ONLY immediately before the
-/// TRUNCATE pragma itself runs (writer held, threshold crossed, interval
-/// elapsed, AND the temporary busy_timeout override successfully applied) —
-/// every earlier return (below threshold, interval not elapsed, or the
-/// busy_timeout override failing to apply) is a skip, not an attempt, and
-/// never touches it, matching the ADR's "skip must not stamp" requirement.
-///
-/// The oldest-pinning-transaction snapshot is logged (reusing Plank 0's
-/// `tx_registry`) before the attempt, so an operator can see what is
-/// (potentially) pinning the WAL even if the attempt goes on to succeed.
-/// `busy_timeout` is temporarily lowered to `config.truncate_busy_timeout` for
-/// the PRAGMA call and restored to the pool's configured value immediately
-/// after, regardless of outcome. No transaction is ever killed here — this is
-/// read-only diagnostics plus the TRUNCATE pragma itself; enforcement is
-/// Plank 1's job, not this one's.
+/// Evaluate and, if due, attempt a TRUNCATE escalation under the writer
+/// guard the caller already holds (never its own checkout). `last_attempt`
+/// is stamped ONLY on an actual attempt, never on a skip. See
+/// crates/khive-db/docs/checkpoint-internals.md#maybe_truncate--truncate-attempt-gating-plank-2
 fn maybe_truncate(
     pool: &ConnectionPool,
     writer: &WriterGuard<'_>,
@@ -1273,26 +1161,8 @@ mod tests {
         fn exit(&self, _: &tracing::span::Id) {}
     }
 
-    /// ADR-091 Plank 0: `log_tx_registry_oldest_debug` emits a debug-level log
-    /// naming the oldest open registry entry's label, on every call.
-    ///
-    /// `#[serial(tx_registry)]`: the registry is a process-wide singleton
-    /// shared across every test in this binary — see `pool.rs`'s and
-    /// `sql_bridge.rs`'s registry tests, which share this same serial group
-    /// (these three were previously unserialized and could
-    /// race, corrupting each other's `oldest()`/`snapshot()` reads).
-    ///
-    /// This test does NOT hardcode "checkpoint_tick_test" as the expected
-    /// label: production write paths elsewhere in this same test binary
-    /// (vectors/graph/text stores) also register short-lived registry
-    /// entries while their own tests run, and `serial(tx_registry)` only
-    /// serializes against the OTHER tests in that same group, not against
-    /// every write path in the crate. Instead it samples `oldest()` itself
-    /// immediately before invoking the function under test and asserts the
-    /// logged label matches whatever the registry considers oldest at that
-    /// instant — deterministic regardless of unrelated concurrent registry
-    /// churn, while still verifying `log_tx_registry_oldest_debug` correctly
-    /// surfaces the registry's own `oldest()` answer.
+    /// `log_tx_registry_oldest_debug` names the oldest open registry entry.
+    /// See crates/khive-db/docs/test-notes.md#log_tx_registry_oldest_debug_reports_oldest_open_entry
     #[test]
     #[serial(tx_registry)]
     fn log_tx_registry_oldest_debug_reports_oldest_open_entry() {
@@ -1527,16 +1397,9 @@ mod tests {
             .expect("checkpoint task panicked");
     }
 
-    /// Regression for issue #774: on the production boot path, the daemon
-    /// passes `run_checkpoint_task` both `pool` directly and an
-    /// `event_store` that internally retains its own `Arc::clone` of the
-    /// same pool (`SqlEventStore::new_scoped`). A strong-count-based exit
-    /// condition can never fire in that shape, because the task always
-    /// observes at least two live clones — its own `pool` argument plus the
-    /// one buried in `event_store`. This test reproduces that exact
-    /// ownership shape (a real `SqlEventStore` holding a sibling clone) and
-    /// asserts the task still exits promptly via the watch-channel signal,
-    /// proving the fix does not depend on `Arc::strong_count` at all.
+    /// Regression #774: exits via watch-signal even with a live event_store
+    /// pool clone (rules out a strong-count-based exit condition). See
+    /// crates/khive-db/docs/test-notes.md#checkpoint_task_exits_via_shutdown_signal_with_live_event_store_pool_clone
     #[tokio::test]
     #[serial(checkpoint_skip_metrics)]
     async fn checkpoint_task_exits_via_shutdown_signal_with_live_event_store_pool_clone() {
@@ -1661,21 +1524,10 @@ mod tests {
         assert_eq!(cfg.tx_max_age_secs, default.tx_max_age_secs);
     }
 
-    /// Regression: a high-water tick must NOT block behind an active read transaction.
-    ///
-    /// Isomorphism guarantee: this test FAILS if `checkpoint_once` regresses to
-    /// `PRAGMA wal_checkpoint(TRUNCATE)`. Confirmed by reasoning: TRUNCATE inherits
-    /// RESTART semantics and will invoke the busy handler (sleeping up to
-    /// `busy_timeout`) while waiting for the open reader snapshot to release.
-    /// With `busy_timeout = 2000ms` a TRUNCATE regression causes the call to take
-    /// ~2000ms, blowing the <500ms assertion. PASSIVE returns in <1ms even with an
-    /// open reader, because PASSIVE never waits for readers.
-    ///
-    /// Why `busy_timeout = 2000ms` and threshold `< 500ms`: the original 200ms
-    /// busy_timeout / 50ms threshold was too tight for contended CI runners where
-    /// PASSIVE legitimately takes 50-200ms under parallel-test load. Raising the
-    /// busy_timeout to 2000ms keeps the PASSIVE path well below 500ms while a
-    /// TRUNCATE regression blocks for ~2000ms — a 4x safety margin on both sides.
+    /// Regression: a high-water tick must NOT block behind an active read
+    /// transaction (isomorphism guarantee — fails if `checkpoint_once`
+    /// regresses to TRUNCATE). See
+    /// crates/khive-db/docs/test-notes.md#checkpoint_high_water_does_not_block_behind_reader
     #[test]
     #[serial(checkpoint_skip_metrics)]
     fn checkpoint_high_water_does_not_block_behind_reader() {
@@ -1806,13 +1658,8 @@ mod tests {
         );
     }
 
-    /// Fix: a reversed pair — `KHIVE_TX_WARN_SECS`
-    /// >= `KHIVE_TX_MAX_AGE_SECS` — must not be honored independently. Before
-    /// this fix, WARN_SECS=120 / MAX_AGE_SECS=30 parsed both values
-    /// successfully (each is independently positive) and produced a sweep
-    /// that emits `Stale` at 30s while never reaching the `Warn` crossing
-    /// until 120s — inverting the intended severity ladder. Both thresholds
-    /// must instead fall back to their defaults together.
+    /// Fix: a reversed threshold pair must not be honored independently. See
+    /// crates/khive-db/docs/test-notes.md#checkpoint_config_rejects_reversed_tx_thresholds
     #[test]
     #[serial]
     fn checkpoint_config_rejects_reversed_tx_thresholds() {
@@ -1837,10 +1684,8 @@ mod tests {
         );
     }
 
-    /// Same invariant, the degenerate equal case: WARN_SECS == MAX_AGE_SECS
-    /// would make an entry cross both rungs on the exact same tick every
-    /// time, collapsing the two-rung severity ladder into one. Must also
-    /// fall back to defaults, not merely reject a strictly-reversed pair.
+    /// Degenerate equal-thresholds case; see
+    /// crates/khive-db/docs/test-notes.md#checkpoint_config_rejects_equal_tx_thresholds
     #[test]
     #[serial]
     fn checkpoint_config_rejects_equal_tx_thresholds() {
@@ -1865,17 +1710,8 @@ mod tests {
         );
     }
 
-    /// Regression: a Skipped tick must NOT reset was_above_high_water.
-    ///
-    /// Before the fix, `checkpoint_once` returned `0` on both a genuinely-empty
-    /// WAL and a writer-busy skip. The task treated `0` as an observed page count
-    /// and reset `was_above_high_water`, re-arming the rate limit on every busy
-    /// tick. With the fix, `CheckpointTick::Skipped` leaves crossing state
-    /// unchanged.
-    ///
-    /// This test drives `crossing_warn` directly (the pure function that owns the
-    /// decision) rather than going through the async task, which would require a
-    /// logging harness.
+    /// Regression: a Skipped tick must NOT reset `was_above_high_water`. See
+    /// crates/khive-db/docs/test-notes.md#skipped_tick_does_not_reset_high_water_crossing_state
     #[test]
     fn skipped_tick_does_not_reset_high_water_crossing_state() {
         let mut was_above = false;
@@ -2626,14 +2462,9 @@ mod tests {
         );
     }
 
-    /// Fix: a stale entry (A) that closes and is
-    /// immediately replaced by an ALREADY-stale entry (B) on the very next
-    /// observed tick — no intervening below-threshold or empty tick, unlike
-    /// `tx_age_sweep_rearms_after_entry_clears` above — must still emit both
-    /// rungs for B. Before the identity-tracking fix, `was_above_warn` and
-    /// `was_above_max_age` were already `true` from A, so B's crossing was
-    /// silently swallowed: the alert stayed latched to a departed caller
-    /// while a different long-lived span was now pinning the database.
+    /// Fix: an already-stale entry replacing a stale one on the next tick,
+    /// with no intervening clear, must still emit both rungs. See
+    /// crates/khive-db/docs/test-notes.md#tx_age_sweep_stale_replacement_without_intervening_clear_still_names_new_entry
     #[test]
     fn tx_age_sweep_stale_replacement_without_intervening_clear_still_names_new_entry() {
         let config = tx_age_test_config();
@@ -2682,11 +2513,8 @@ mod tests {
         );
     }
 
-    /// `KHIVE_TX_WARN_SECS` / `KHIVE_TX_MAX_AGE_SECS` are read into the
-    /// config `from_env` reads at `run_checkpoint_task` construction time,
-    /// so this closes the loop from env var to the actual emitted rung
-    /// (the earlier `checkpoint_config_env_override` test only asserts the
-    /// config fields themselves).
+    /// Closes the loop from env var to actual emitted rung. See
+    /// crates/khive-db/docs/test-notes.md#tx_age_sweep_uses_configured_thresholds_not_hardcoded_defaults
     #[test]
     fn tx_age_sweep_uses_configured_thresholds_not_hardcoded_defaults() {
         let config = CheckpointConfig {
@@ -2711,19 +2539,8 @@ mod tests {
         );
     }
 
-    /// Integration-level regression for the incident this ADR fixes: a real
-    /// `BEGIN DEFERRED` reader pins a WAL snapshot (exactly like
-    /// `checkpoint_high_water_does_not_block_behind_reader` above) while also
-    /// being registered in the shared `tx_registry` (simulating an
-    /// instrumented long-lived-reader call site such as
-    /// `graph.rs`'s `graph_traverse_read`), writes drive `wal_pages` past
-    /// `high_water_pages`, and — with a millisecond-scale `tx_max_age_secs`
-    /// so the test does not sleep for real minutes — the Plank 1 sweep
-    /// escalates to `Stale` naming that exact reader, alongside the existing
-    /// Plank 0 high-water WARN. This is the "detection works, mitigation
-    /// missing" gap from the incident: the sweep now gives the operator the
-    /// specific, escalating, un-silenced signal that a single one-shot
-    /// high-water WARN does not.
+    /// Integration-level regression for the incident this ADR fixes. See
+    /// crates/khive-db/docs/test-notes.md#tx_age_sweep_names_long_lived_reader_pinning_wal_past_high_water
     #[test]
     #[serial(tx_registry, checkpoint_skip_metrics)]
     fn tx_age_sweep_names_long_lived_reader_pinning_wal_past_high_water() {
@@ -2816,17 +2633,8 @@ mod tests {
         drop(_tx_handle);
     }
 
-    /// Regression for #926: reproduces the exact race that made
-    /// `tx_age_sweep_names_long_lived_reader_pinning_wal_past_high_water`
-    /// flaky, directly rather than hoping cargo's test scheduler happens to
-    /// interleave two unrelated tests. `tx_registry` is a process-wide
-    /// singleton; a decoy entry registered before this test's own entry is
-    /// genuinely older, so raw `oldest()` cannot return the test fixture —
-    /// exactly what an unrelated, concurrently-running write path (e.g.
-    /// `graph_upsert_edges`) could do in the real suite. The fix (looking up
-    /// this test's own entry by label via `snapshot()` instead of trusting
-    /// global `oldest()`) must still correctly name and escalate THIS entry
-    /// despite that older decoy.
+    /// Regression #926: reproduces the exact tx_registry race directly. See
+    /// crates/khive-db/docs/test-notes.md#tx_age_sweep_own_entry_survives_concurrent_older_registration
     #[test]
     #[serial(tx_registry, checkpoint_skip_metrics)]
     fn tx_age_sweep_own_entry_survives_concurrent_older_registration() {

--- a/crates/khive-db/src/pool.rs
+++ b/crates/khive-db/src/pool.rs
@@ -404,17 +404,10 @@ impl ConnectionPool {
 
     /// Return the pool-wide ADR-067 Component A writer task, spawning it
     /// lazily on first access if `PoolConfig::write_queue_enabled` is set.
-    ///
-    /// Exactly one writer task exists per `ConnectionPool` (per DB file) no
-    /// matter how many stores or namespaces are constructed over it: the
-    /// `OnceLock` runs its init closure at most once, so concurrent callers
-    /// either race to run it once or block on the in-flight init and then
-    /// all receive a clone of the same resulting handle. This is what makes
-    /// the write queue an actual single-writer core rather than one writer
-    /// task per store — a per-store writer task would let concurrent
-    /// migrated stores over the same pool spawn independent writer
-    /// connections that contend with each other at `BEGIN IMMEDIATE`,
-    /// defeating the point of Component A.
+    /// Exactly one writer task exists per `ConnectionPool` (per DB file); see
+    /// crates/khive-db/docs/pool-writer-backend-internals.md#connectionpoolwriter_task_handle--single-writer-task-rationale
+    /// for why a per-store writer task would defeat the single-writer
+    /// guarantee.
     ///
     /// Returns `Ok(None)` if the flag is off, or if the writer task failed to
     /// spawn for a reason other than a missing runtime (for example, an
@@ -893,17 +886,9 @@ mod tests {
             .expect("second writer checkout should succeed");
     }
 
-    /// ADR-091 Plank 0: `WriterGuard::transaction` registers an entry with the
-    /// shared open-transaction registry for the duration of the closure, and
-    /// deregisters it once the closure (and its commit/rollback) completes.
-    ///
-    /// `#[serial(tx_registry)]`: the open-transaction registry is a
-    /// process-wide singleton (`khive_storage::tx_registry`) shared across
-    /// every test in this binary. This test filters by its own unique label
-    /// so it is not vulnerable to another test's entry being reported as
-    /// "oldest", but it still shares the same `tx_registry` serial group as
-    /// `checkpoint.rs`'s and `sql_bridge.rs`'s registry tests for
-    /// defense-in-depth against cross-test interference.
+    /// ADR-091 Plank 0: `WriterGuard::transaction` registers/deregisters a
+    /// tx_registry entry around the closure. See
+    /// crates/khive-db/docs/pool-writer-backend-internals.md#writer_guard_transaction_registers_during_closure_only
     #[test]
     #[serial(tx_registry)]
     fn writer_guard_transaction_registers_during_closure_only() {
@@ -935,16 +920,9 @@ mod tests {
         );
     }
 
-    /// ADR-067 Component A runtime-handle guard: `write_queue_enabled` is set
-    /// but the calling thread has no Tokio runtime context, so spawning the
-    /// writer task (which requires `tokio::spawn`) is impossible.
-    /// `writer_task_handle` must return a clean typed error instead of
-    /// panicking.
-    ///
-    /// Deliberately a plain `#[test]` (no Tokio runtime) — mirrors
-    /// `writer_task::spawn_fails_on_in_memory_pool`'s shape: the failure must
-    /// be observable without ever entering an async context, since entering
-    /// one here would defeat the point of the test.
+    /// ADR-067 Component A: `writer_task_handle` must fail loud (typed
+    /// error, not panic) with no Tokio runtime available. See
+    /// crates/khive-db/docs/pool-writer-backend-internals.md#writer_task_handle_fails_loud_without_tokio_runtime
     #[test]
     fn writer_task_handle_fails_loud_without_tokio_runtime() {
         let dir = tempfile::tempdir().unwrap();

--- a/crates/khive-db/src/stores/vectors.rs
+++ b/crates/khive-db/src/stores/vectors.rs
@@ -253,22 +253,9 @@ impl SqliteVecStore {
         Ok(conn)
     }
 
-    /// Route a single-row write through the pool-wide `WriterTask` when
-    /// `KHIVE_WRITE_QUEUE=1` and a handle is available; otherwise fall back
-    /// to the legacy pool-mutex path (ADR-067 Component A, Fork C slice 2).
-    ///
-    /// This is the routing point for `with_writer` callers whose closure is
-    /// DML-only (`delete`/`vec_delete`, `delete_subjects`/
-    /// `vec_delete_subjects`): on the flag-on path the closure runs inside
-    /// the WriterTask's own transaction, so a bare `BEGIN IMMEDIATE` (or an
-    /// inner `conn.unchecked_transaction()`) would violate SQLite's
-    /// nested-transaction rule. `insert`/`update` (which need their own
-    /// delete-then-insert atomicity), `insert_batch` (the batch method), and
-    /// `orphan_sweep` (ADR-067 Amendment 1) each do their own flag check and
-    /// return early on `Some`, routing a DML-only closure directly through
-    /// the WriterTask instead — their fallback calls into this helper only
-    /// ever execute on the flag-off path (`self.writer_task` is `None` by
-    /// construction whenever those calls are reached) — no double-routing.
+    /// Route a single-row DML-only write through the pool-wide `WriterTask`
+    /// when available, else fall back to `with_writer_unmanaged`. See
+    /// crates/khive-db/docs/vectors-internals.md#with_writer--with_writer_unmanaged--writertask-routing-adr-067-component-a-fork-c-slice-2
     async fn with_writer<F, R>(&self, op: &'static str, f: F) -> Result<R, StorageError>
     where
         F: FnOnce(&rusqlite::Connection) -> Result<R, rusqlite::Error> + Send + 'static,
@@ -283,17 +270,10 @@ impl SqliteVecStore {
         self.with_writer_unmanaged(op, f).await
     }
 
-    /// Legacy pool-mutex write path, bypassing the WriterTask channel
-    /// unconditionally regardless of `KHIVE_WRITE_QUEUE`.
-    ///
-    /// Reserved for closures that manage their own transaction — those
-    /// cannot be sent through the WriterTask channel, which already wraps
-    /// every request in its own transaction. `orphan_sweep`'s flag-off path
-    /// (`Transaction::new_unchecked`, its own manual `BEGIN IMMEDIATE`) is
-    /// the only caller — on the flag-on path `orphan_sweep` routes a
-    /// DML-only closure directly through the WriterTask instead, since
-    /// routing a `Transaction::new_unchecked` through the channel would nest
-    /// a transaction inside the WriterTask's own transaction.
+    /// Legacy pool-mutex write path; bypasses the WriterTask channel
+    /// unconditionally. Reserved for closures that manage their own
+    /// transaction. See
+    /// crates/khive-db/docs/vectors-internals.md#with_writer--with_writer_unmanaged--writertask-routing-adr-067-component-a-fork-c-slice-2
     async fn with_writer_unmanaged<F, R>(&self, op: &'static str, f: F) -> Result<R, StorageError>
     where
         F: FnOnce(&rusqlite::Connection) -> Result<R, rusqlite::Error> + Send + 'static,
@@ -342,21 +322,9 @@ struct VectorRowRef<'a> {
     embedding: &'a [f32],
 }
 
-/// Shared DELETE-then-INSERT replacement DML for a single vector row (#546).
-///
-/// `vec0` virtual tables do not support `INSERT OR REPLACE`, so every
-/// replacement path (single-record insert/update, batch insert, and the
-/// WriterTask-routed atomic upsert) deletes the prior row for
-/// `(subject_id, namespace)` then inserts the new one. This function issues
-/// no `BEGIN`/`COMMIT`/`SAVEPOINT` itself — the caller owns the enclosing
-/// transaction or savepoint and its rollback semantics, so this can run
-/// equally inside a plain `Connection`, an `unchecked_transaction()`, or a
-/// named `SAVEPOINT`.
-///
-/// `failpoint_flag`, when `Some` in a `cfg(test)` build, is checked between
-/// the DELETE and the INSERT so tests can force an error at that exact point
-/// and assert the caller's rollback restores the prior row (no-worse-than-
-/// stale guarantee). It is inert in release builds.
+/// Shared DELETE-then-INSERT replacement DML for a single vector row (#546);
+/// caller owns the enclosing transaction/savepoint. See
+/// crates/khive-db/docs/vectors-internals.md#replace_vector_row_dml--shared-delete-then-insert-replacement-546
 fn replace_vector_row_dml(
     conn: &rusqlite::Connection,
     table: &str,
@@ -2027,30 +1995,9 @@ mod atomic_replace_tests {
         );
     }
 
-    /// insert_batch: SAVEPOINT/ROLLBACK path — INSERT failure inside the savepoint.
-    ///
-    /// The existing wrong-dimension tests (`insert_batch_failed_record_preserves_prior_vector`)
-    /// hit the pre-savepoint `continue` guard and never reach the SAVEPOINT/ROLLBACK
-    /// sequence.  This test forces a genuine INSERT failure inside the savepoint by
-    /// exploiting vec0's single-column PRIMARY KEY (`subject_id TEXT PRIMARY KEY`,
-    /// NOT scoped to namespace).
-    ///
-    /// Mechanism: store a stale row for `(id_X, ns:a)`.  Submit a batch with one
-    /// record for `(id_X, ns:b)`.  The DELETE step targets `WHERE namespace = 'ns:b'`
-    /// and finds nothing (stale is in ns:a), so nothing is removed.  The INSERT then
-    /// tries to write `id_X` into vec0's `_rowids` shadow table, but `id_X` already
-    /// occupies it (from the ns:a stale row).  The UNIQUE constraint fires — INSERT
-    /// fails — ROLLBACK TO SAVEPOINT executes — stale row in ns:a survives intact.
-    ///
-    /// NOTE: removing `ROLLBACK TO SAVEPOINT` would NOT change the outcome for this
-    /// specific test, because the DELETE was a no-op (different namespace).  This test
-    /// is NOT the rollback sentinel — it covers the PK-conflict path and verifies
-    /// that the outer COMMIT succeeds.  For the true sentinel (DELETE succeeds then
-    /// INSERT is injected to fail), see
-    /// `insert_batch_rollback_restores_deleted_stale_after_post_delete_insert_failure`.
-    ///
-    /// Additionally: insert_batch must count the record as `failed` and must not
-    /// abort the outer `BEGIN IMMEDIATE` transaction (the COMMIT must succeed).
+    /// insert_batch: SAVEPOINT/ROLLBACK path — INSERT failure inside the
+    /// savepoint via a PK conflict. See
+    /// crates/khive-db/docs/vectors-internals.md#insert_batch_savepoint_rollback_on_pk_conflict_preserves_stale
     #[tokio::test]
     async fn insert_batch_savepoint_rollback_on_pk_conflict_preserves_stale() {
         let pool = make_vec_pool();
@@ -2145,26 +2092,9 @@ mod atomic_replace_tests {
         );
     }
 
-    /// insert_batch: two-record batch where the first record's SAVEPOINT rolls back
-    /// (PK conflict) and the second record succeeds, proving the rollback on record 1
-    /// does not corrupt the state seen by record 2.
-    ///
-    /// Scenario:
-    ///   stale = (id_X, ns:a, stale_vec) in DB.
-    ///
-    ///   Record A — (id_X, ns:b): SAVEPOINT; DELETE WHERE ns=ns:b (nothing);
-    ///     INSERT id_X → PK conflict (stale holds it) → ROLLBACK TO SAVEPOINT.
-    ///     failed=1.  Stale untouched.
-    ///
-    ///   Record B — (id_X, ns:a, new_vec): SAVEPOINT; DELETE WHERE ns=ns:a removes
-    ///     stale (PK freed); INSERT id_X succeeds. RELEASE. affected=1.
-    ///
-    /// Final state: (id_X, ns:a, new_vec).  The search with new_vec yields ~1.0,
-    /// confirming Record A's rolled-back SAVEPOINT did not corrupt what Record B wrote.
-    ///
-    /// NOTE: Record A's DELETE is a no-op (different namespace), so removing
-    /// `ROLLBACK TO SAVEPOINT` would NOT change this test's outcome.  The true
-    /// sentinel is `insert_batch_rollback_restores_deleted_stale_after_post_delete_insert_failure`.
+    /// insert_batch: a rolled-back first record must not corrupt a
+    /// successful second record. See
+    /// crates/khive-db/docs/vectors-internals.md#insert_batch_rollback_does_not_corrupt_subsequent_record
     #[tokio::test]
     async fn insert_batch_rollback_does_not_corrupt_subsequent_record() {
         let pool = make_vec_pool();
@@ -2256,21 +2186,9 @@ mod atomic_replace_tests {
         );
     }
 
-    /// update: the single-record path wraps DELETE+INSERT in `unchecked_transaction`.
-    /// Wrong-dim tests fail in the outer Rust guard, before the transaction opens.
-    /// This test forces an INSERT failure inside the transaction on a correctly-
-    /// dimensioned finite vector by calling `update` with a namespace that does NOT
-    /// match the stored row.
-    ///
-    /// Mechanism: stale row is `(id_X, ns:a)`.  Call `update(id_X, ns:b, ...)`.
-    ///   - DELETE WHERE ns=ns:b finds nothing.
-    ///   - INSERT (id_X, ns:b) hits vec0 PK constraint (id_X in _rowids held by ns:a).
-    ///   - `unchecked_transaction()` rolls back.
-    ///   - Stale row in ns:a survives intact.
-    ///
-    /// NOTE: the DELETE is a no-op (different namespace), so removing the transaction
-    /// rollback would NOT change this test's outcome.  The true sentinel is
-    /// `update_rollback_restores_deleted_stale_after_post_delete_insert_failure`.
+    /// update: PK-conflict INSERT inside `unchecked_transaction` rolls back
+    /// and preserves the stale row. See
+    /// crates/khive-db/docs/vectors-internals.md#update_pk_conflict_rolls_back_transaction_preserves_stale
     #[tokio::test]
     async fn update_pk_conflict_rolls_back_transaction_preserves_stale() {
         let pool = make_vec_pool();
@@ -2357,42 +2275,12 @@ mod atomic_replace_tests {
         );
     }
 
-    // -----------------------------------------------------------------------
-    // True ROLLBACK TO SAVEPOINT sentinels (failpoint-driven)
-    //
-    // The PK-conflict tests above exercise the SAVEPOINT path, but the DELETE
-    // is a no-op in those tests (different namespace).  Removing the
-    // `ROLLBACK TO SAVEPOINT vec_batch_record` line from insert_batch, or the
-    // transaction rollback from update, would NOT make those tests fail.
-    //
-    // The two tests below use a cfg(test) failpoint that fires AFTER a
-    // successful same-namespace DELETE and BEFORE the INSERT.  This means:
-    //   - The stale row is genuinely gone from the DB when the error fires.
-    //   - Only a correct ROLLBACK TO SAVEPOINT (or tx.rollback) restores it.
-    //   - Removing those rollback lines WILL make these tests fail.
-    //
-    // Value-level failures (dim/finite/count) are rejected before the
-    // SAVEPOINT opens, so there is no natural same-namespace path to reach
-    // a post-DELETE INSERT failure through the public API.  The failpoint is
-    // the only way to produce this condition in a unit test without modifying
-    // production logic.
-    // -----------------------------------------------------------------------
+    // True ROLLBACK TO SAVEPOINT sentinels (failpoint-driven) — see
+    // crates/khive-db/docs/vectors-internals.md#true-rollback-to-savepoint-sentinels-failpoint-driven
 
-    /// SENTINEL — insert_batch: stale row is restored when DELETE succeeds but
-    /// INSERT is forced to fail via the cfg(test) failpoint.
-    ///
-    /// Setup: insert stale `(id_X, ns:a, vec1)`.
-    /// Failpoint: `FAIL_AFTER_DELETE` is armed before the batch call.
-    /// Batch: one record `(id_X, ns:a, vec2)` — same namespace, correct dims,
-    ///        all finite — so the production DELETE genuinely removes the stale
-    ///        row, then the failpoint fires before INSERT.
-    /// Expected: `ROLLBACK TO SAVEPOINT vec_batch_record` restores the stale row.
-    ///   - `batch_exists` finds id_X in ns:a.
-    ///   - Search with vec1 returns similarity > 0.999 (not vec2).
-    ///   - BatchWriteSummary: attempted=1, affected=0, failed=1.
-    ///
-    /// FAILURE MODE: delete line 320 (`ROLLBACK TO SAVEPOINT vec_batch_record`)
-    /// from insert_batch and this test fails — the stale row is gone.
+    /// SENTINEL — insert_batch: stale row is restored when DELETE succeeds
+    /// but INSERT is forced to fail via the cfg(test) failpoint. See
+    /// crates/khive-db/docs/vectors-internals.md#insert_batch_rollback_restores_deleted_stale_after_post_delete_insert_failure
     #[tokio::test]
     async fn insert_batch_rollback_restores_deleted_stale_after_post_delete_insert_failure() {
         let pool = make_vec_pool();
@@ -2511,20 +2399,9 @@ mod atomic_replace_tests {
         );
     }
 
-    /// SENTINEL — update: stale row is restored when DELETE succeeds but INSERT
-    /// is forced to fail via the cfg(test) failpoint.
-    ///
-    /// Setup: insert stale `(id_X, ns:a, vec1)`.
-    /// Failpoint: `FAIL_AFTER_DELETE` is armed before the update call.
-    /// Call: `update(id_X, ns:a, vec2)` — same namespace, correct dims, finite.
-    ///       DELETE removes the stale row, then the failpoint fires before INSERT.
-    /// Expected: `unchecked_transaction` rolls back, restoring the stale row.
-    ///   - `batch_exists` finds id_X in ns:a.
-    ///   - Search with vec1 returns similarity > 0.999 (not vec2).
-    ///   - `update` returns Err (the injected error propagates out).
-    ///
-    /// FAILURE MODE: remove the transaction's DROP/rollback from update and
-    /// this test fails — the stale row is gone.
+    /// SENTINEL — update: stale row is restored when DELETE succeeds but
+    /// INSERT is forced to fail via the cfg(test) failpoint. See
+    /// crates/khive-db/docs/vectors-internals.md#update_rollback_restores_deleted_stale_after_post_delete_insert_failure
     #[tokio::test]
     async fn update_rollback_restores_deleted_stale_after_post_delete_insert_failure() {
         let pool = make_vec_pool();
@@ -2607,17 +2484,10 @@ mod atomic_replace_tests {
         );
     }
 
-    /// #546: the flag-off single-record `insert` path previously ran its own
-    /// inline DELETE+INSERT with no failpoint hook at all, so the post-delete
-    /// rollback guarantee was never exercised on this path (only `update` and
-    /// the batch/atomic-upsert helpers were covered). Now that `insert` routes
-    /// through the shared `replace_vector_row_dml` helper, the same failpoint
-    /// must fire here too and `unchecked_transaction` must roll back the
-    /// DELETE, restoring the stale row.
-    ///
-    /// FAILURE MODE (pre-#546): this test could not even be written against
-    /// the old `insert` body — there was no failpoint hook to arm. Removing
-    /// the shared helper (or its transaction rollback) makes this fail.
+    /// #546: `insert` now routes through the shared `replace_vector_row_dml`
+    /// helper, so the same post-delete-failpoint rollback guarantee that
+    /// covers `update` must also cover `insert`. See
+    /// crates/khive-db/docs/vectors-internals.md#insert_rollback_restores_deleted_stale_after_post_delete_insert_failure
     #[tokio::test]
     async fn insert_rollback_restores_deleted_stale_after_post_delete_insert_failure() {
         let pool = make_vec_pool();

--- a/crates/khive-types/docs/pack-error-internals.md
+++ b/crates/khive-types/docs/pack-error-internals.md
@@ -1,0 +1,104 @@
+# Pack + error internals
+
+Long-form rationale extracted from `src/pack.rs` and `src/khive_error.rs` doc-comments.
+Public-item contracts stay complete in the source; this file carries the
+"why", design history, and cross-references.
+
+## `pack.rs`
+
+### ADR-099 D3 atomic-admissibility rejection classes
+
+See `crates/khive-types/src/pack.rs` — `ATOMIC_KNOWN_UNIMPLEMENTED_VERBS`.
+
+`propose` / `review` / `withdraw` and `merge` are all members of
+`ATOMIC_ADMISSIBLE_VERBS` (ADR-099 D3 intends every one of them to eventually
+gain a prepare/apply seam), but none has a full-parity seam implemented yet,
+so they are rejected up front rather than admitted with a silent gap:
+
+- `propose` / `review` / `withdraw` (ADR-046's event-sourced change-proposal
+  lifecycle): their apply path is a changeset-interpreter over a dedicated
+  `proposals_open` table, not a small number of guarded DML statements — no
+  prepare implementation exists at all.
+- `merge`: a full-parity atomic prepare (field folding, survivor FTS/vector
+  reindex, loser index purge, merge provenance, same-kind rejection, graceful
+  edge-conflict resolution — see `curation::merge_entity_sql`) was drafted
+  and unit-tested for B3, but deferred rather than shipped:
+  `curation.rs`'s edge-rewire conflict handling does per-row procedural
+  branching (read, canonicalize, probe for a conflicting triple,
+  delete-and-refresh vs. update-in-place) that cannot be expressed as
+  ADR-099 D1's static predicate/guard plan shape. Full parity is not
+  achievable without either accepting a documented behavioral gap or a
+  design change to the plan model — bias toward deferral over shipping a
+  partially scoped atomic merge. `merge` stays admissible under the
+  *non-atomic* verb path.
+
+ADR-099 B3 (governance verbs) note: this set previously passed the static
+pre-runtime admissibility check (since it's a subset of
+`ATOMIC_ADMISSIBLE_VERBS`) and only failed later, inside
+`atomic_prepare::prepare_op`, AFTER `KhiveRuntime::new` had already run.
+`atomic_admissibility` now checks this set FIRST so the CLI boundary
+(`khive_request::atomic::check_atomic_admissible`) rejects these verbs before
+any runtime is built or any write attempted — the same before-any-write
+guarantee every other rejection class gets.
+
+The `atomic_admissible_list_matches_adr` test in `pack.rs` pins the exact
+`ATOMIC_ADMISSIBLE_VERBS` set as a drift-pin against ADR-099 D3's literal
+list, so an edit to the const forces the editor to also touch the test and
+its ADR citation.
+
+### `ATOMIC_MAX_OPS_DEFAULT` = 2000 — rationale
+
+See `crates/khive-types/src/pack.rs` — `ATOMIC_MAX_OPS_DEFAULT`.
+
+ADR-099 migration step 7 / B3. The ADR does not pin an exact number — D2
+defers the precise threshold to harness measurement ("a recommended default
+on the order of a few thousand ops ... configurable with a conservative
+default", Open Question 2), so this constant is an explicit interim choice,
+not a value read directly out of the ADR text.
+
+Rationale for 2000 specifically:
+- inside D2's "a few thousand" band
+- comfortably bounds the duration of the single cross-process `BEGIN
+  IMMEDIATE` hold an atomic unit takes on the daemon's writer lock (ADR-099
+  D5 daemon-coexistence)
+- cheap to override per invocation (`kkernel exec --atomic --atomic-max-ops
+  N`) without touching this default
+
+Revisit once the load-harness (ADR-067 Component A) has real
+per-op-count latency data under contention.
+
+## `khive_error.rs`
+
+### `Details::build` — bounding/truncation algorithm
+
+See `crates/khive-types/src/khive_error.rs` — private fn `Details::build`.
+
+Takes `ordinary` (already capped at 8 entries, with `total_ordinary` the true
+pre-cap count) plus a reserved-key `collisions` count, and produces the wire
+shape: at most 8 entries, with a `DETAILS_TRUNCATED_KEY` indicator entry
+appended whenever anything was dropped (either overflow past 7 ordinary
+pairs, or a stripped reserved-key collision). This is the shared
+bounding/truncation logic used by both the public `Details::new` constructor
+and the `serde::Deserialize` impl.
+
+### `Details` deserialization — round-trip detection of self-truncated maps
+
+See `crates/khive-types/src/khive_error.rs` — `impl<'de> Visitor<'de> for
+DetailsVisitor` / `visit_map`.
+
+The map visitor drains to completion regardless of size (fixes #487: a naive
+early-exit once 8 entries are collected leaves trailing map bytes unconsumed
+and corrupts the surrounding deserializer). Only the first 8 ordinary pairs
+are retained in memory as they arrive; pairs beyond that are counted, not
+stored, so an adversarially large map can't inflate memory.
+
+`DETAILS_TRUNCATED_KEY` is reserved (PR #549): it is never stored as an
+ordinary entry. Instead the visitor tracks whether the wire map looks
+*exactly* like khive's own truncated serialization — the reserved key
+appears exactly once, as the very last pair, immediately after exactly 7
+ordinary pairs, with a value that parses as a count — and if so, restores
+that as the trusted drop count (a round-trip of a `Details` khive truncated
+itself). Any other occurrence (wrong position, duplicated, or paired with an
+ordinary count that isn't 7) is treated as a client-supplied collision:
+stripped and folded into `Details::build`'s drop accounting like any other
+reserved-key collision.

--- a/crates/khive-types/src/khive_error.rs
+++ b/crates/khive-types/src/khive_error.rs
@@ -263,11 +263,8 @@ impl Details {
         Self::build(ordinary, total_ordinary, collisions)
     }
 
-    /// Bound `ordinary` (already capped at 8 entries, `total_ordinary` the
-    /// true count before capping) plus a reserved-key `collisions` count to
-    /// the wire shape: at most 8 entries, with a [`DETAILS_TRUNCATED_KEY`]
-    /// indicator appended whenever anything was dropped (either overflow
-    /// past 7 ordinary pairs, or a stripped reserved-key collision).
+    /// Bounding/truncation core. See
+    /// crates/khive-types/docs/pack-error-internals.md#detailsbuild--boundingtruncation-algorithm
     fn build(
         ordinary: alloc::vec::Vec<(Cow<'static, str>, Cow<'static, str>)>,
         total_ordinary: usize,
@@ -345,25 +342,11 @@ impl<'de> Deserialize<'de> for Details {
             }
 
             fn visit_map<A: MapAccess<'de>>(self, mut map: A) -> Result<Details, A::Error> {
-                // Drain to completion regardless of size (#487: a naive early-exit
-                // once 8 entries are collected leaves trailing map bytes unconsumed
-                // and corrupts the surrounding deserializer). Only the first 8
-                // ordinary pairs are retained in memory as they arrive; pairs
-                // beyond that are counted, not stored, so an adversarially
-                // large map can't inflate memory.
-                //
-                // `DETAILS_TRUNCATED_KEY` is reserved (PR #549):
-                // it is never stored as an ordinary entry. Instead we track
-                // whether the wire map looks exactly like our own truncated
-                // serialization — the reserved key appears exactly once, as
-                // the very last pair, immediately after exactly 7 ordinary
-                // pairs, with a value that parses as a count — and if so,
-                // restore that as the trusted drop count (round-trip of a
-                // `Details` we truncated ourselves). Any other occurrence
-                // (wrong position, duplicated, or paired with an ordinary
-                // count that isn't 7) is treated as a client-supplied
-                // collision: stripped and folded into `Details::build`'s
-                // drop accounting like any other reserved-key collision.
+                // Drains to completion regardless of size (fixes #487: early-exit
+                // at 8 entries left trailing map bytes unconsumed). Detects a
+                // round-tripped self-truncated map vs. a client-supplied
+                // DETAILS_TRUNCATED_KEY collision — see
+                // crates/khive-types/docs/pack-error-internals.md#details-deserialization--round-trip-detection-of-self-truncated-maps
                 let mut ordinary: alloc::vec::Vec<(Cow<'static, str>, Cow<'static, str>)> =
                     alloc::vec::Vec::new();
                 let mut total_ordinary: usize = 0;

--- a/crates/khive-types/src/pack.rs
+++ b/crates/khive-types/src/pack.rs
@@ -136,12 +136,6 @@ impl HandlerDef {
     /// New verbs that need this override must be added here; omission from the
     /// list means `Standard` applies.
     pub fn presentation_policy(&self) -> VerbPresentationPolicy {
-        // AlwaysVerbose verbs bypass agent-mode transforms entirely.
-        //
-        // `link` is AlwaysVerbose because the edge ID returned is the only handle
-        // for follow-up `neighbors`/`traverse` calls. At scale, two edges can share
-        // the same 8-char prefix (birthday collision ~65K edges), so shortening the
-        // edge ID in agent mode breaks downstream chaining.
         match self.name {
             "get" | "link" | "query" | "traverse" | "neighbors" | "brain.feedback" => {
                 VerbPresentationPolicy::AlwaysVerbose
@@ -385,36 +379,12 @@ const ATOMIC_EMBEDDING_BEARING_VERBS: &[&str] = &[
     "comm.ingest",
 ];
 
-/// Verbs that ADR-099 D3 lists as conceptually admissible (they remain on
-/// [`ATOMIC_ADMISSIBLE_VERBS`] — the ADR intends each to eventually gain a
-/// prepare/apply seam) but for which no *full-parity* seam exists yet in this
-/// slice, so they are rejected up front rather than admitted with a gap:
-///
-/// - `propose` / `review` / `withdraw` (ADR-046's event-sourced change-proposal
-///   lifecycle): their apply path is a changeset-interpreter over a dedicated
-///   `proposals_open` table, not a small number of guarded DML statements —
-///   no prepare implementation exists at all.
-/// - `merge`: a full-parity atomic prepare (field folding, survivor FTS/vector
-///   reindex, loser index purge, merge provenance, same-kind rejection,
-///   graceful edge-conflict resolution — see `curation::merge_entity_sql`) was
-///   drafted and unit-tested for B3, but deferred rather than
-///   shipped: `curation.rs`'s edge-rewire conflict handling does per-row
-///   procedural branching (read, canonicalize, probe for a conflicting
-///   triple, delete-and-refresh vs. update-in-place) that cannot be expressed
-///   as ADR-099 D1's static predicate/guard plan shape, so full parity is not
-///   achievable without either accepting a documented behavioral gap or a
-///   design change to the plan model; bias toward deferral over shipping a
-///   partially scoped atomic merge.
-///   `merge` stays admissible under the *non-atomic* verb.
-///
-/// ADR-099 B3 (governance verbs): this set
-/// previously passed the static pre-runtime admissibility check (since it's a
-/// subset of `ATOMIC_ADMISSIBLE_VERBS`) and only failed later, inside
-/// `atomic_prepare::prepare_op`, AFTER `KhiveRuntime::new` had already run.
-/// `atomic_admissibility` now checks this set FIRST so the CLI boundary
-/// (`khive_request::atomic::check_atomic_admissible`) rejects these verbs
-/// before any runtime is built or any write attempted — the same
-/// before-any-write guarantee every other rejection class gets.
+/// Verbs on [`ATOMIC_ADMISSIBLE_VERBS`] (ADR-099 D3 conceptually admissible)
+/// that have no *full-parity* prepare/apply seam yet, so they are rejected up
+/// front (checked BEFORE the general admissible-list check) rather than
+/// admitted with a silent gap. See
+/// crates/khive-types/docs/pack-error-internals.md#adr-099-d3-atomic-admissibility-rejection-classes
+/// for why each verb is deferred and the ADR-099 B3 ordering rationale.
 pub const ATOMIC_KNOWN_UNIMPLEMENTED_VERBS: &[&str] = &["propose", "review", "withdraw", "merge"];
 
 /// Read verbs rejected under `--atomic` — they produce no write plan to apply
@@ -433,17 +403,10 @@ const ATOMIC_READ_VERBS: &[&str] = &[
 ];
 
 /// Conservative default maximum op count for one `--atomic` unit (ADR-099
-/// migration step 7 / B3). The ADR does not pin an exact number — D2 defers
-/// the precise threshold to harness measurement ("a recommended default on
-/// the order of a few thousand ops ... configurable with a conservative
-/// default", Open Question 2) — so this constant is an explicit interim
-/// choice, not a value read out of the ADR text. Rationale for 2000: it is
-/// inside D2's "a few thousand" band, comfortably bounds the duration of the
-/// single cross-process `BEGIN IMMEDIATE` hold an atomic unit takes on the
-/// daemon's writer lock (ADR-099 D5 daemon-coexistence), and is cheap to
-/// override per invocation (`kkernel exec --atomic --atomic-max-ops N`)
-/// without touching this default. Revisit once the load-harness (ADR-067
-/// Component A) has real per-op-count latency data under contention.
+/// migration step 7 / B3). Override per invocation with
+/// `kkernel exec --atomic --atomic-max-ops N`. See
+/// crates/khive-types/docs/pack-error-internals.md#atomic_max_ops_default--2000--rationale
+/// for why 2000 specifically was chosen and when to revisit it.
 pub const ATOMIC_MAX_OPS_DEFAULT: usize = 2000;
 
 /// Why a verb was rejected from an `--atomic` op list (ADR-099 D3, migration


### PR DESCRIPTION
## What

Condense verbose inline doc-comments in `khive-db,khive-types` and relocate long-form rationale, algorithm walkthroughs, and background prose into per-crate `docs/*.md` guides. Part of the rustdoc condense-and-extract pass.

## Preserved (information relocation, not deletion)

- Public API doc-comments stay **complete and standalone** — the docs.rs reference is intact; a caller can use each public item from its doc-comment alone.
- No `# Safety`, invariant, ordering, precision, or error-enumeration docs were thinned.
- schemars/clap product-surface doc-comments (MCP tool schema, CLI `--help`) left verbatim.
- Every substantive fact removed from a `.rs` doc-comment was moved into a crate guide under the crate's `docs/` directory, not dropped.

## Scope

Only the `src` and `docs` trees of the crates above. Diffstat: 8 files changed, 724 insertions(+), 504 deletions(-).

Branch forked before recent doc merges; will be updated onto main and code-reviewed before marking ready.