### PR TITLE
docs(rustdoc): condense inline docs + extract to guides (khive-runtime)

### DIFF
--- a/crates/khive-runtime/docs/atomic_prepare.md
+++ b/crates/khive-runtime/docs/atomic_prepare.md
@@ -1,0 +1,63 @@
+# atomic_prepare.rs — extended rationale
+
+Long-form rationale extracted from `crates/khive-runtime/src/atomic_prepare.rs` doc-comments
+during the rustdoc condense pass.
+
+## module-scope
+
+`gtd.transition` / `gtd.complete` prepare is deliberately **not** here: their lifecycle
+vocabulary (`is_terminal`, `can_transition`, ...) lives in `khive-pack-gtd`, which depends on
+`khive-runtime` — not the other way around. Reproducing that dependency here would invert the
+crate graph, so their prepare functions live in `kkernel` (which already depends on both crates),
+calling back into the plain `PlanStatement`/`AffectedRowGuard` shapes exported from this module's
+sibling, `crate::atomic_plan`.
+
+`propose` / `review` / `withdraw` (the event-sourced governance lifecycle) are on the v1
+admissible list (`khive_types::pack::ATOMIC_ADMISSIBLE_VERBS`) but have no prepare implementation
+here: their apply path is a changeset-interpreter (`apply_worker`) over a dedicated
+`proposals_open` table, not a small number of guarded DML statements — a faithful, non-stub
+atomic prepare for them is separate follow-on work. `prepare_governance_unimplemented` fails
+loudly, before any write, naming this as a known scope gap rather than silently no-opping.
+
+`merge` is likewise on the v1 admissible list but is deferred: full-parity field folding,
+survivor index reindex, loser index purge, provenance, and same-kind rejection are achievable as
+static DML, but `curation::merge_entity_sql`'s graceful edge-conflict resolution is not (it is
+per-row procedural, incompatible with the static predicate/guard plan shape): rather than ship a
+partially-scoped atomic merge, it is rejected at the same pre-runtime static guard as governance
+(`khive_types::pack::ATOMIC_KNOWN_UNIMPLEMENTED_VERBS`). `prepare_merge` is therefore unreachable
+through `--atomic`; it remains only as the earlier direct-prepare implementation, exercised by
+this module's own tests, and as defense in depth.
+
+## prepare_update_edge
+
+Mirrors `khive-runtime::operations::KhiveRuntime::update_edge`'s patch semantics exactly:
+`relation`/`weight`/`properties` are the only applicable fields
+(`reject_inapplicable_update_fields`'s `"edge"` arm enforces this before any mutation), a changed
+`relation` is endpoint-validated first, `weight` is range-checked, and `properties` REPLACES
+`metadata` wholesale (no merge — `update_edge` does `edge.metadata = Some(props)`, unlike the
+entity/note branches' `merge_properties`).
+
+DML shape:
+- non-symmetric relation: a single `edge_upsert_statement` call on the patched `Edge` — the same
+  builder `update_edge`'s own non-symmetric branch calls via `graph.upsert_edge(edge.clone())`
+  (`khive-db::stores::graph::SqlGraphStore::upsert_edge`), so parity is exact by construction.
+- symmetric relation (`competes_with`, `composed_with`): `update_edge` does NOT use the upsert
+  builder here, because `upsert_edge` resolves `ON CONFLICT(namespace, id)` first and cannot
+  detect a natural-key collision with a *different* id. Canonical (`update_edge_symmetric_dml`)
+  runs a conflict probe and branches in Rust inside a single uninterrupted transaction, which is
+  safe there. This atomic path cannot do that (see the in-source invariant note on
+  `prepare_update_edge`).
+
+## event_append_statements
+
+Builds the `Event` exactly as each canonical site does and turns it into plain-data
+`SqlStatement`s via `khive_db::stores::event::event_insert_statements`: the same builder the async
+execution path every canonical `event_store.append_event(...)` call reaches uses. There is exactly
+one place that knows the `events`/`event_observations` insert shape; this function only adapts its
+output into unguarded `PlanStatement`s for the atomic-unit plan.
+
+This is a `PlanStatement` inside the atomic unit, not a `PostCommitEffect` (reserved for
+best-effort or non-SQL work): the insert is a small number of plain, deterministic `INSERT`s
+computed entirely from data already on hand at prepare time, unlike the
+`ReindexEntity`/`ReindexNote` post-commit effects this module defers because those need an
+embedding call.

--- a/crates/khive-runtime/docs/daemon.md
+++ b/crates/khive-runtime/docs/daemon.md
@@ -1,0 +1,33 @@
+# daemon.rs — extended rationale
+
+Long-form rationale extracted from `crates/khive-runtime/src/daemon.rs` doc-comments during the
+rustdoc condense pass.
+
+## protocol_version
+
+Version history for `PROTOCOL_VERSION`:
+- 1 — initial versioned framing (added `protocol_version` + `version_mismatch`); added
+  `probe_only` request field + probe-ack sentinel shape in response
+- 2 — gate subhandler verbs by wire origin (`from_wire` request field)
+- 3 — added per-request identity context to the request frame (`actor_id`,
+  `visible_namespaces`); the daemon now serves a request under the frame's identity instead of
+  rejecting on `namespace_mismatch` (the `config_id` equality reject stays hard)
+
+## try_acquire_flock_until
+
+Unlike `acquire_recovery_lock`/`acquire_daemon_boot_guard` (unbounded blocking `flock`, correct
+for the daemon's own boot sequence where waiting until quiescence IS the desired behavior), a
+caller only trying to *detect* whether a lock is currently free — without committing to wait
+forever for a possibly-wedged holder — needs a deadline instead.
+
+## build_metrics_snapshot
+
+`tx_registry` (ADR-091 Plank 0) is a process-global singleton reachable directly, with no plumbing
+through `dispatcher`. `wal_pages` and the TRUNCATE counters (ADR-091 Plank 2) are read from
+`khive_db::checkpoint`'s module-scoped atomics, updated wherever the checkpoint task already calls
+`query_wal_pages`/`note_truncate_outcome` — mirroring the fallback-counter pattern in
+`khive-mcp/src/daemon.rs` rather than threading a metrics handle through every checkpoint call
+site, since the checkpoint task itself is a fire-and-forget `tokio::spawn` with no handle retained
+anywhere this accept loop can reach. `write_queue_depth`/`_capacity` (ADR-067 Component A) come
+from the dispatcher's own pool, if any, and are `None` unless `KHIVE_WRITE_QUEUE=1` actually
+spawned a writer task.

--- a/crates/khive-runtime/docs/pack.md
+++ b/crates/khive-runtime/docs/pack.md
@@ -1,0 +1,126 @@
+# pack.rs — extended rationale
+
+Long-form rationale extracted from `crates/khive-runtime/src/pack.rs` doc-comments during the
+rustdoc condense pass. Each section links back to the item whose in-source doc-comment now
+carries only the standalone contract plus a one-line pointer here.
+
+## register_embedders
+
+`PackRuntime::register_embedders` is called by the transport during pack initialisation, before
+the first verb dispatch, so that `KhiveRuntime::embedder(name)` resolves provider names declared
+here. Implement it to contribute non-lattice embedding backends:
+
+```ignore
+fn register_embedders(&self, runtime: &KhiveRuntime) {
+    runtime.register_embedder(MyCustomProvider::new());
+}
+```
+
+The default no-op preserves backwards compatibility — packs that only use built-in lattice models
+do not need to override this method.
+
+## register_entity_type_validator
+
+`PackRuntime::register_entity_type_validator` is called by the transport during pack
+initialisation, after the registry is built and before the first verb dispatch, so that
+`create_many` and `create_entity` reject unregistered `entity_type` values at the runtime layer
+in addition to the handler layer. Packs that own `EntityTypeRegistry` vocabularies (e.g.
+`KgPack`) should override this to install their registry's `resolve` function. The default no-op
+leaves the runtime validator absent (skip-when-None), which is the correct behaviour for bare
+runtimes without packs.
+
+This single-argument hook is intentionally left unchanged (not widened) so an out-of-tree pack
+that already overrides it keeps compiling even if it declares no entity types. A pack that needs
+the boot-time composed pack vocabulary should override `register_entity_type_validator_with_types`
+instead — `call_register_entity_type_validators` calls that hook, not this one.
+
+`register_entity_type_validator_with_types` receives the boot-time composed set of every loaded
+pack's `ENTITY_TYPES` (`VerbRegistry::all_entity_types`) — the same aggregate every pack in the
+loaded set receives, mirroring how `EDGE_RULES` are aggregated once and consulted by every pack.
+It defaults to calling `register_entity_type_validator` with just the runtime, so a pack that
+overrides only the older, simpler hook — or overrides neither — keeps compiling and behaving
+exactly as before. `call_register_entity_type_validators` calls this hook, not the older one, so
+a pack that wants the composed vocabulary must override this one. Packs that own
+`EntityTypeRegistry` vocabularies should override this hook to compose
+`EntityTypeRegistry::with_extra(pack_entity_types)` and install its `resolve` function.
+
+## register_note_mutation_hook
+
+Called by the transport during pack initialisation, after the registry is built and before the
+first verb dispatch — same timing as `register_entity_type_validator`. Packs that cache derived
+state keyed by note content (e.g. `khive-pack-memory`'s warm ANN index) should override this to
+install a hook via `KhiveRuntime::install_note_mutation_hook`, so `update_note`/`delete_note`
+notify them even when the mutation arrived through a different pack's verb that has no
+dependency on the reacting pack (e.g. KG's `update`/`delete` on a `kind="memory"` note). The
+default no-op leaves the runtime hook absent (skip-when-None), which is the correct behaviour for
+packs that don't cache note-derived state and for bare runtimes without packs.
+
+## registered_embedding_model_names
+
+Used by ADR-103 Amendment 1's `model_count` computation at the dispatch audit-row emission seam
+(`VerbRegistry::dispatch_with_identity`) for the two embedding-bearing verb families whose model
+fan-out is not a per-dispatch constant: singleton `create` and `memory.remember` without an
+explicit `embedding_model` override. Defaults to empty — only the packs that own those verbs (kg,
+memory) need to override this by forwarding to their internal `KhiveRuntime`.
+
+## dispatch_as
+
+For embedding hosts (gateways, servers, or other processes that embed this runtime as a library)
+that authenticate a principal through their own channel — not through the request DSL — and then
+need that principal to be the effective actor for one dispatch. `verified_actor` is a typed
+Rust-side argument: it can only be supplied by code holding a `VerbRegistry` handle. `dispatch_as`
+never reads `params["actor"]` to derive the effective actor; individual verbs may still accept an
+`actor` field for their own documented business semantics, unrelated to the acting principal.
+
+`verified_actor` is a `VerifiedActor`, whose constructor rejects blank identifiers. This keeps an
+authentication-integration failure (an empty subject from the host's own auth channel) from
+silently downgrading to the anonymous/local actor — the failure surfaces at `VerifiedActor::new`
+instead of being laundered into a valid dispatch.
+
+Every pack handler that reads "who is calling" (for example, a proposal review's `reviewer`
+field) resolves it from the `NamespaceToken` the dispatch boundary mints, so `verified_actor`
+becomes exactly the principal those handlers observe.
+
+## dispatch_with_identity
+
+`identity = None` behaves exactly like `VerbRegistry::dispatch`. `identity = Some(id)` uses
+`id.namespace` / `id.actor_id` / `id.visible_namespaces` in place of `self.default_namespace` /
+`self.actor_id` / `self.visible_namespaces` for this call's namespace resolution, gate request,
+and token minting — the registry's own fields are never mutated, so concurrent calls with
+different (or no) identity are independent. This is what lets one warm registry correctly serve
+requests from many attribution identities over the same shared backend (same db, same warm ANN
+indexes) instead of rejecting or silently dispatching under its own baked identity (ADR-096 Fork
+1).
+
+## build_audit_storage_event
+
+Shared by the immediate-append path (all verbs, denied calls, bulk `links`) and the deferred
+singleton-`link` fallback so both audit shapes are produced by one code path.
+
+`resource` is the ADR-103 `resource` payload object. ADR-103 Decision (a) stamps the closed
+`work_class` enum on every event, so every call site passes `Some`:
+`crate::cost_unit::resource_payload` (`{"work_class": ..., "cost_unit": ...}`) for a
+successfully-resolved dispatch, or `crate::cost_unit::base_resource_payload` (`{"work_class":
+...}`, no `cost_unit` key) for denied calls, errored dispatches, and the no-pack-owns-this-verb
+case. `None` is reserved for a caller with no `work_class` to stamp at all (none exist today); it
+must never be used to omit `cost_unit` alone.
+
+## LinkAuditSuccessV2
+
+Schema v2 audit payload for a successful singleton `link` call. Additive over the v1 `AuditEvent`
+shape: every v1 field is preserved via `#[serde(flatten)]`, and the edge identity/relation/weight
+the caller created or resolved are added at the top level.
+
+## link_audit_success_from_result
+
+Extracts the edge fields needed to enrich a successful singleton `link` audit row from the
+handler's returned JSON. Returns `None` (rather than a `Result`) on any missing/malformed field —
+the caller treats that as "cannot enrich" and falls back to the v1 audit shape instead of failing
+the already-succeeded `link` call.
+
+## resolve_explicit_namespace
+
+This is the single chokepoint both `VerbRegistry::dispatch` (single-backend and JSON-form
+ingress) and the multi-backend coordinator intercept (`dispatch_via_coordinator_inner` in
+`khive-mcp`) call into, so no ingress path can bypass the fail-closed rule by routing around
+`dispatch`.

--- a/crates/khive-runtime/docs/secret_gate.md
+++ b/crates/khive-runtime/docs/secret_gate.md
@@ -1,0 +1,175 @@
+# secret_gate.rs — extended rationale
+
+Long-form rationale extracted from `crates/khive-runtime/src/secret_gate.rs` doc-comments during
+the rustdoc condense pass. The module-level doc-comment in the source now carries a concise
+summary plus a pointer to this file; this is the full algorithm spec.
+
+## Module-level detection algorithm
+
+Allowlist (false-positive suppression) — **all of the following are prose-context exemptions,
+not unconditional passes: a credential trigger word in the surrounding window always dominates.**
+A UUID or a sha-prefixed content hash sitting directly beside "api_key"/"secret"/"auth" is exactly
+as ambiguous as any other high-entropy candidate and falls through to explicit detection instead
+of being silently allowed.
+
+- Pure hex strings (sha256, git SHA) — passed when not near a trigger.
+- UUID canonical form (`xxxxxxxx-xxxx-…`) — passed when not near a trigger.
+- Base64/base64url content hashes with an explicit `sha<N>-` prefix (SRI hashes, npm lockfile
+  integrity) — passed when not near a trigger and not preceded by a known-vendor prefix. Bare
+  base64 tokens without the `sha<N>-` prefix are NOT passed.
+- Strings that are entirely ASCII punctuation/whitespace (e.g. code) — not subject to the entropy
+  heuristic, only the literal-prefix checks apply.
+- Non-ASCII characters (CJK prose, accented text, emoji) act as token delimiters for the entropy
+  heuristic: only maximal ASCII runs are entropy-checked. Real base64/hex/base64url credentials
+  are ASCII, and `shannon_entropy` runs over UTF-8 bytes — multibyte codepoints inflate the
+  byte-wise entropy and false-positive on natural-language non-Latin content. Treating non-ASCII
+  as a delimiter (rather than skipping any whitespace token that merely contains it) keeps CJK
+  prose unflagged while still catching an ASCII credential glued to CJK text/punctuation/fullwidth
+  whitespace. The literal-prefix checks (Layer 1) treat any non-ASCII-alphanumeric char (CJK,
+  accented text, emoji) as a token boundary, so a known-prefix secret is caught whether the
+  adjacent non-ASCII sits before the prefix (`数据AKIA…`) or after it (`AKIA…数据`).
+- Structured identifiers: a token is only considered for this exemption when it contains at least
+  one of `/`, `-`, `_`, or `.` (the gate); it is then decomposed into maximal alphanumeric runs by
+  splitting on *every* non-alphanumeric character (not just the four gating separators — any other
+  ASCII punctuation glued into the same whitespace token, e.g. a stray `:` or `,`, also acts as a
+  run boundary). A token exempts when it decomposes into two or more such runs and every run is
+  letters-then-digits or pure digits, at most 24 chars long, with a low case-transition density.
+  This covers content like `fable-ops/ADR-DRAFT-adr079.md` or `local workspace artifact`, which is
+  otherwise indistinguishable from a high-entropy secret once glued into one whitespace token.
+  Random base64/base62 secrets do not decompose this way: their case and digit placement is
+  effectively uniform rather than word-shaped, so a hyphenated or underscored secret still fails
+  this check and remains subject to the entropy heuristic below.
+
+  **This exemption applies ONLY outside an explicit credential trigger context.** Signals that
+  measure Shannon entropy over an attacker-chosen run boundary (e.g. requiring a trailing file
+  extension, or an average per-run letter entropy below a threshold) are not sound near a trigger
+  word: an attacker who controls where a credential's separators fall can always choose run
+  lengths whose entropy reads no higher than an ordinary short English path segment, since the
+  measure only sees a character-frequency histogram, never word semantics. So near a trigger word,
+  a structured-identifier-shaped token gets no exemption at all and falls through to the entropy
+  heuristic like any other token. This is an accepted false-positive tradeoff on a small number of
+  genuine paths/doc-slugs that happen to sit near a trigger word AND read above the entropy
+  threshold on their own — see `accepted_false_positive_adr_draft_path_near_trigger` and its
+  siblings for the specific repro cases this blocks, and the call site in
+  `check_entropy_heuristic`.
+
+Trigger-word matching only fires on genuine mentions, not substring collisions: trigger words
+(`key`, `secret`, `password`, `passwd`, `credential`, `bearer`, `auth`, `apikey`) are matched at a
+word boundary (`contains_bounded_word`), so `auth` does not fire inside `authorized` or
+`authentication`, nor `key` inside `monkey`/`keyword`. The candidate token is excluded from its
+own surrounding context. This prevents an internal path segment such as `cli-auth-and-kg` from
+making the path self-trigger. Assignment-shaped candidates such as `auth=<value>` and
+`api_key=<value>` are checked separately, including when whitespace splits the label from the
+value, so the exclusion does not weaken credential-shaped writes.
+
+A structured-identifier-shaped token sitting near a **genuinely standalone** trigger word (e.g.
+`auth work saved at .../repo-audit.md`, where `auth` is an actual topical mention rather than a
+substring collision) is an accepted false positive: no window-narrowing or exemption-widening
+scheme survives the adversarial regression corpus without also reopening a real bypass, because
+the caller (or an attacker) fully controls the prose between a trigger word and a payload:
+narrowing `TRIGGER_WINDOW` or reinstating the structured-identifier exemption near "bare" trigger
+mentions both fail the same known bypass strings that motivated closing them.
+
+The word-boundary rule above treats underscore as a BOUNDARY for bare `TRIGGER_WORDS`
+(`contains_bounded_word`): deliberately different from `has_standalone_token`'s rule for the word
+`token`, which treats underscore as a continuation so `tokenizer`/`next_token`/`token_count` stay
+exempt. Treating underscore as a boundary for the bare set is what lets common underscore-joined
+credential-config compounds keep firing: `SECRET_KEY=...` (Django/Flask-style config),
+`auth_token=...`, `session_secret_...`, `signing_key=...` all match on the `secret`/`key`/`auth`
+half. This is implemented by parameterizing the boundary rule (`contains_word`'s
+`underscore_is_word_char` argument) rather than sharing one rule between the two callers.
+
+## value_candidates
+
+Yields every candidate value that an assignment/wrapper-glued whitespace token could contain, so
+shape allowlists that require an EXACT match (`is_uuid_canonical`, `is_base64_content_hash`) still
+recognize the credential once it is glued to normal storage syntax: `key=value`, `(value)`,
+`{"key":"value"}`, `key1=key2=value`, a trailing sentence period, or a label itself containing
+`:`/`=` (`{"api:key":"value"}`). Used only to derive candidates for the near-trigger
+UUID/content-hash checks in `check_entropy_heuristic` — it does NOT replace `token` for the
+entropy, hex, or structured-identifier paths, none of which require an exact shape match.
+
+Strips wrapper punctuation from both ends first, then yields the wrapper-stripped whole token,
+plus the wrapper-stripped suffix after EVERY internal `=`/`:` occurrence (skipping empty
+suffixes). No single separator position can be assumed correct: the true key/value or JSON-label
+boundary might be the first separator (`secret=sha256-...`), but a base64/base64url value can
+itself end in `=` padding — for a padded content hash that padding IS the last `=` in the token,
+so a last-separator split would land on the padding boundary instead. A label can also itself
+contain `:`/`=` (`{"api:key":"<uuid>"}`) or the assignment can be doubled
+(`key=label=<uuid>`), so neither "first" nor "last" is a sound single choice. Emitting every
+suffix and letting the caller test each one is the only choice that is sound in all these shapes:
+the true value always appears as *some* suffix, and a `=`/`:` that lands inside padding or a label
+simply yields a non-matching suffix that the caller's shape check harmlessly rejects.
+
+Byte-scan via `char_indices` over an already-short token (whitespace-delimited, so bounded by
+realistic line length) — no allocation, since this runs in the hot scan path.
+
+## contains_word
+
+`underscore_is_word_char` selects which of two, deliberately different, boundary rules the caller
+needs:
+- `true` (used by `has_standalone_token` / `has_token_assignment` for `token`): underscore is a
+  continuation of the same identifier, so `next_token`, `tokenizer`, and `token_count` do NOT
+  match — a prior, deliberate decision that must not change.
+- `false` (used by `contains_bounded_word` for the bare `TRIGGER_WORDS`): underscore IS a
+  boundary, so `secret_key=`/`auth_token=`/`signing_key=` still match on the
+  `secret`/`auth`/`key` half of the compound — these underscore-joined credential-config
+  compounds (Django/Flask `SECRET_KEY`, OAuth `auth_token`, JWT `signing_key`) are exactly the
+  shape a credential trigger must not lose. Only *letter*-joined collisions (`authorized`,
+  `authentication`, `monkey`, `keyword`) are meant to stop matching.
+
+CJK/accented prose always counts as a boundary in both modes (only ASCII alphanumerics — plus
+underscore when `underscore_is_word_char` is `true` — are treated as word characters).
+
+## mask_secrets
+
+A transcript line cannot be rejected wholesale, so each credential span is replaced in place
+while the surrounding prose is preserved. Spans are discovered left to right against the ORIGINAL
+text via `scan_from`: each scan advances a `from` cursor past the previous span but always
+evaluates trigger context over the full input. This closes the entropy-context gap — a
+high-entropy value whose only trigger word sits to the left of an earlier-redacted secret is
+still detected, because the trigger window is never sliced away. The known-prefix detectors (real
+API keys: `sk-ant-`, `sk-proj-`, `AKIA`/`ASIA`, GitHub, Stripe, …) are context-free and matched the
+same way.
+
+## trigger_words
+
+Bare English words that can otherwise appear as a pure substring collision inside unrelated
+identifiers or prose: `auth` inside `authorized`/`authentication`, `key` inside
+`monkey`/`turkey`/`keyword`, `secret` inside `secretary`. Design decision (see the module doc): a
+substring collision like this poisons the trigger window on prose that never mentions credentials
+at all, which is a distinct failure mode from a genuine (if topical) mention of the word — see
+issues #577 / #632. Matching these words at a word boundary removes the substring-collision false
+positives while changing nothing about detection of a genuine standalone mention: `auth` as its
+own word (`auth header`, `auth:`) still triggers exactly as before.
+
+The bare substring `token` is NOT in this list because it fires on benign terms like `tokenizer`,
+`token_count`, and `next_token`. Instead the dedicated boundary-aware helpers `has_standalone_token`
+(standalone word) and `has_token_assignment` (`token=` / `token:` with word boundary before) are
+used.
+
+## is_base64_content_hash
+
+Criteria:
+- Token starts with `sha<digits>-` (e.g. `sha256-`, `sha384-`, `sha512-`).
+- The body after the prefix matches a SHA-family length (43, 64, or 86–88 unpadded chars).
+- Every byte in the body is a standard-base64 or URL-safe-base64 character.
+- Does NOT start with a known vendor-token prefix (those are credentials regardless of alphabet).
+
+Bare base64 tokens of those lengths WITHOUT the `sha<N>-` prefix are NOT allowlisted here — a
+43-char base64url API token near the word "key" is indistinguishable from a sha256 hash body
+without the prefix, so the explicit prefix is required to avoid false-negative credential
+escapes.
+
+## is_structured_identifier
+
+A structured identifier decomposes into two or more maximal ASCII-alphanumeric "runs" separated
+by `/`, `-`, `_`, or `.`, where every run is word-shaped: letters-then-digits (`adr079`,
+`slices234`, `R1`) or pure digits (`20260701`), at most `MAX_RUN_LEN` chars, with a low
+case-transition density in the letter portion. Random base64/base62 secrets glued between
+separators reliably fail this shape check: their case and digit placement is essentially uniform
+rather than word-like, so a run either exceeds the length cap or mixes case too densely to pass.
+
+Outside credential-trigger context this shape check alone is sufficient to exempt a token from
+the entropy heuristic. In trigger context the caller grants NO exemption at all: see the module
+doc and the call site in `check_entropy_heuristic`.

--- a/crates/khive-runtime/src/atomic_prepare.rs
+++ b/crates/khive-runtime/src/atomic_prepare.rs
@@ -7,34 +7,14 @@
 //! synchronous commit pass ([`crate::atomic_runner::run_atomic_unit`]) to
 //! apply.
 //!
-//! `gtd.transition` / `gtd.complete` prepare is deliberately **not** here:
-//! their lifecycle vocabulary (`is_terminal`, `can_transition`, ...) lives in
-//! `khive-pack-gtd`, which depends on `khive-runtime`: not the other way
-//! around. Reproducing that dependency here would invert the crate graph, so
-//! their prepare functions live in `kkernel` (which already depends on both
-//! crates), calling back into the plain [`PlanStatement`]/[`AffectedRowGuard`]
-//! shapes exported from this module's sibling, [`crate::atomic_plan`].
-//!
-//! `propose` / `review` / `withdraw` (the event-sourced governance lifecycle)
-//! are on the v1 admissible list ([`khive_types::pack::
-//! ATOMIC_ADMISSIBLE_VERBS`]) but have no prepare implementation here: their
-//! apply path is a changeset-interpreter (`apply_worker`) over a dedicated
-//! `proposals_open` table, not a small number of guarded DML statements — a
-//! faithful, non-stub atomic prepare for them is separate follow-on work.
-//! `prepare_governance_unimplemented` fails loudly, before any write, naming
-//! this as a known scope gap rather than silently no-opping.
-//!
-//! `merge` is likewise on the v1 admissible list but is deferred: full-parity
-//! field folding, survivor index reindex, loser index purge, provenance, and
-//! same-kind rejection are achievable as static DML, but
-//! `curation::merge_entity_sql`'s graceful edge-conflict resolution is not
-//! (it is per-row procedural, incompatible with the static predicate/guard
-//! plan shape): rather than ship a partially-scoped atomic merge, it is
-//! rejected at the same pre-runtime static guard as governance
-//! ([`khive_types::pack::ATOMIC_KNOWN_UNIMPLEMENTED_VERBS`]). `prepare_merge`
-//! below is therefore unreachable through `--atomic`; it remains only as the
-//! earlier direct-prepare implementation, exercised by this module's
-//! own tests, and as defense in depth.
+//! `gtd.transition`/`gtd.complete` prepare is deliberately not here (lives in
+//! `kkernel` instead), and `propose`/`review`/`withdraw`/`merge` are on the
+//! v1 admissible list but have no working prepare implementation in this
+//! module (`prepare_governance_unimplemented` fails loudly rather than
+//! silently no-opping; `prepare_merge` is unreachable through `--atomic` and
+//! kept only for its own tests and as defense in depth). See
+//! `docs/atomic_prepare.md#module-scope` for why each of these is excluded
+//! and what would be required to admit them.
 
 use serde_json::Value;
 use uuid::Uuid;
@@ -319,29 +299,16 @@ async fn push_index_purge_statements(
 /// `EntityUpdated`, `delete_entity` -> `EntityDeleted`, `delete_note` ->
 /// `NoteDeleted`, `update_edge` -> `EdgeUpdated`, `delete_edge` ->
 /// `EdgeDeleted`. `update_note` and `link` append no event and must never
-/// call this.
+/// call this. See `docs/atomic_prepare.md#event_append_statements` for why
+/// this is a `PlanStatement` rather than a `PostCommitEffect`.
 ///
-/// Builds the `Event` exactly as each canonical site does and turns it into
-/// plain-data `SqlStatement`s via
-/// [`khive_db::stores::event::event_insert_statements`]: the same builder
-/// the async execution path every canonical `event_store.append_event(...)`
-/// call reaches uses. There is exactly one place that knows the
-/// `events`/`event_observations` insert shape; this function only adapts its
-/// output into unguarded [`PlanStatement`]s for the atomic-unit plan.
-///
-/// This is a `PlanStatement` inside the atomic unit, not a `PostCommitEffect`
-/// (reserved for best-effort or non-SQL work): the insert is a small number
-/// of plain, deterministic `INSERT`s computed entirely from data already on
-/// hand at prepare time, unlike the `ReindexEntity`/`ReindexNote`
-/// post-commit effects this module defers because those need an embedding
-/// call. Committing the event row atomically with the mutation it describes
-/// strengthens canonical's guarantee: the non-atomic handlers write the
-/// event in a separate transaction, ordered but not atomic with the row
+/// Invariant: returned statements are unguarded — appended after the plan's
+/// own guarded row statement, so [`apply_plan`]'s stop-on-first-failure
+/// contract means they are only reached once that row mutation's guard has
+/// already held. Committing the event row atomically with the mutation it
+/// describes strengthens canonical's guarantee: the non-atomic handlers write
+/// the event in a separate transaction, ordered but not atomic with the row
 /// mutation.
-///
-/// Returned statements are unguarded — appended after the plan's own guarded
-/// row statement, so [`apply_plan`]'s stop-on-first-failure contract means
-/// they are only reached once that row mutation's guard has already held.
 fn event_append_statements(
     namespace: &str,
     verb: &str,
@@ -832,41 +799,25 @@ pub async fn prepare_update_entity_plan(
     }))
 }
 
-/// Edge branch of `prepare_update`. Mirrors
-/// `khive-runtime::operations::KhiveRuntime::update_edge`'s patch semantics
-/// exactly: `relation`/`weight`/`properties` are the only applicable fields
-/// (`reject_inapplicable_update_fields`'s `"edge"` arm enforces this before
-/// any mutation), a changed `relation` is endpoint-validated first, `weight`
-/// is range-checked, and `properties` REPLACES `metadata` wholesale (no
-/// merge — `update_edge` does `edge.metadata = Some(props)`, unlike the
-/// entity/note branches' `merge_properties`).
+/// Edge branch of `prepare_update`. Mirrors `KhiveRuntime::update_edge`'s
+/// patch semantics: `relation`/`weight`/`properties` are the only applicable
+/// fields, a changed `relation` is endpoint-validated first, `weight` is
+/// range-checked, and `properties` REPLACES `metadata` wholesale (no merge).
+/// See `docs/atomic_prepare.md#prepare_update_edge` for the DML-shape parity
+/// detail with `update_edge`.
 ///
-/// DML shape:
-/// - non-symmetric relation: a single [`edge_upsert_statement`] call on the
-///   patched `Edge`: the same builder `update_edge`'s own non-symmetric
-///   branch calls via `graph.upsert_edge(edge.clone())`
-///   (`khive-db::stores::graph::SqlGraphStore::upsert_edge`), so parity is
-///   exact by construction.
-/// - symmetric relation (`competes_with`, `composed_with`): `update_edge`
-///   does NOT use the upsert builder here, because `upsert_edge` resolves
-///   `ON CONFLICT(namespace, id)` first and cannot detect a natural-key
-///   collision with a *different* id. Canonical (`update_edge_symmetric_dml`)
-///   runs a conflict probe and branches in Rust inside a single
-///   uninterrupted transaction, which is safe there. This atomic path
-///   cannot branch on a prepare-time probe: the prepare/commit phase split
-///   means a different op in the same atomic unit could change the
-///   conflict landscape between probe and commit, so a Rust-level branch
-///   here would be stale by construction. Instead it always emits BOTH
-///   statements from [`edge_symmetric_delete_if_conflict_statement`] and
-///   [`edge_symmetric_refresh_or_update_inplace_statement`] — each carries
-///   its own commit-time `WHERE`/`CASE WHEN` predicate that re-evaluates the
-///   conflict condition fresh inside the transaction, so the write is
-///   correct regardless of prepare-time state. This function reads no state
-///   to guess a surviving id; the plan instead carries `edge_natural_key`
-///   (the canonicalized endpoints/relation this update targets), letting a
-///   post-commit caller derive the actual surviving id from the committed
-///   row, never from a value computed before the rest of this atomic unit
-///   has even run.
+/// Invariant (symmetric relations `competes_with`/`composed_with`): this
+/// function must never branch on a prepare-time conflict probe — a different
+/// op in the same atomic unit could change the conflict landscape between
+/// probe and commit, making any such branch stale by construction. It always
+/// emits BOTH statements from [`edge_symmetric_delete_if_conflict_statement`]
+/// and [`edge_symmetric_refresh_or_update_inplace_statement`], each carrying
+/// its own commit-time `WHERE`/`CASE WHEN` predicate that re-evaluates the
+/// conflict condition fresh inside the transaction. This function reads no
+/// state to guess a surviving id; the plan instead carries `edge_natural_key`
+/// so a post-commit caller derives the actual surviving id from the
+/// committed row, never from a value computed before the rest of this atomic
+/// unit has even run.
 async fn prepare_update_edge(
     runtime: &KhiveRuntime,
     id: Uuid,

--- a/crates/khive-runtime/src/daemon.rs
+++ b/crates/khive-runtime/src/daemon.rs
@@ -45,15 +45,7 @@ pub const MAX_FRAME_BYTES: usize = 8 * 1024 * 1024;
 /// in every request; the daemon rejects mismatches with an explicit error
 /// that names both sides so the operator knows exactly what to do
 /// (`make local` rebuilds the client binary).
-///
-/// Version history:
-///   1 — initial versioned framing (added `protocol_version` + `version_mismatch`);
-///       added `probe_only` request field + probe-ack sentinel shape in response
-///   2 — gate subhandler verbs by wire origin (`from_wire` request field)
-///   3 — added per-request identity context to the request frame (`actor_id`,
-///       `visible_namespaces`); the daemon now serves a request under the
-///       frame's identity instead of rejecting on `namespace_mismatch` (the
-///       `config_id` equality reject stays hard)
+/// See `docs/daemon.md#protocol_version` for the version-by-version history.
 pub const PROTOCOL_VERSION: u32 = 3;
 
 #[cfg(unix)]
@@ -168,18 +160,16 @@ pub fn acquire_recovery_lock() -> Option<std::fs::File> {
 }
 
 /// Attempt to acquire an exclusive advisory flock on `path`, retrying with a
-/// non-blocking `flock(LOCK_NB)` until `deadline` elapses.
+/// non-blocking `flock(LOCK_NB)` until `deadline` elapses. Bounded alternative
+/// to `acquire_recovery_lock`/`acquire_daemon_boot_guard`'s unbounded blocking
+/// flock — see `docs/daemon.md#try_acquire_flock_until` for why a caller
+/// merely detecting lock freedom needs a deadline instead.
 ///
-/// Unlike [`acquire_recovery_lock`]/[`acquire_daemon_boot_guard`] (unbounded
-/// blocking `flock`, correct for the daemon's own boot sequence where waiting
-/// until quiescence IS the desired behavior), a caller only trying to *detect*
-/// whether a lock is currently free — without committing to wait forever for
-/// a possibly-wedged holder: needs a deadline instead. Returns:
-///   - `Ok(Some(file))` — the lock was free within the deadline.
-///   - `Ok(None)` — `deadline` elapsed while the lock stayed held; an
-///     explicit "could not confirm" outcome, distinct from a hard I/O error.
-///   - `Err(_)` — the lock file could not be opened, or `flock` failed for a
-///     reason other than contention.
+/// - `Ok(Some(file))` — the lock was free within the deadline.
+/// - `Ok(None)` — `deadline` elapsed while the lock stayed held; an explicit
+///   "could not confirm" outcome, distinct from a hard I/O error.
+/// - `Err(_)` — the lock file could not be opened, or `flock` failed for a
+///   reason other than contention.
 ///
 /// Blocking (paces retries with `std::thread::sleep`) — async callers must
 /// run this via `spawn_blocking`.
@@ -715,18 +705,8 @@ pub fn active_phase_names() -> Vec<String> {
 /// Build a point-in-time [`MetricsSnapshot`] of this process's server-side
 /// gauges. Called only from `handle_conn`'s `metrics_only` arm — a
 /// process-global, read-only assembly with no side effects of its own.
-///
-/// `tx_registry` (ADR-091 Plank 0) is a process-global singleton reachable
-/// directly, with no plumbing through `dispatcher`. `wal_pages` and the
-/// TRUNCATE counters (ADR-091 Plank 2) are read from `khive_db::checkpoint`'s
-/// module-scoped atomics, updated wherever the checkpoint task already calls
-/// `query_wal_pages`/`note_truncate_outcome` — mirroring the fallback-counter
-/// pattern in `khive-mcp/src/daemon.rs` rather than threading a metrics
-/// handle through every checkpoint call site, since the checkpoint task
-/// itself is a fire-and-forget `tokio::spawn` with no handle retained
-/// anywhere this accept loop can reach. `write_queue_depth`/`_capacity`
-/// (ADR-067 Component A) come from the dispatcher's own pool, if any, and
-/// are `None` unless `KHIVE_WRITE_QUEUE=1` actually spawned a writer task.
+/// See `docs/daemon.md#build_metrics_snapshot` for where each gauge is sourced
+/// from and why.
 #[cfg(unix)]
 fn build_metrics_snapshot<D: DaemonDispatch>(dispatcher: &D) -> MetricsSnapshot {
     let open_tx_count = khive_storage::tx_registry::snapshot().len();
@@ -955,17 +935,13 @@ async fn handle_conn<D: DaemonDispatch>(mut stream: UnixStream, dispatcher: D) {
 /// Run the daemon: bind the socket, warm in the background, serve request
 /// frames until SIGTERM/SIGINT.
 ///
-/// Fatally acquires its own startup lock. This only protects
-/// cleanup→bind→pid-write; by the time this function runs, `dispatcher` (a
-/// `DaemonDispatch` built from a `KhiveMcpServer`) has *already* run
-/// migrations and applied pack schema plans while constructing itself,
-/// unguarded. Production boot must go through
-/// [`run_daemon_with_boot_guard`] instead, which extends the same lock back
-/// over that construction step. This entry point remains for callers (and
-/// tests) that build the dispatcher and start serving as one atomic step with
-/// no separate boot-guard window to protect — but it still acquires the boot
-/// guard fatally (never proceeds unguarded), so the cleanup→bind→pid-write
-/// race surface is always mutually excluded.
+/// Fatally acquires its own startup lock, which only protects
+/// cleanup→bind→pid-write — `dispatcher` has already run migrations and
+/// applied pack schema plans while constructing itself, unguarded. Production
+/// boot must go through [`run_daemon_with_boot_guard`] instead, which extends
+/// the same lock back over construction. This entry point is for callers
+/// (and tests) that build the dispatcher and start serving as one atomic
+/// step with no separate boot-guard window to protect.
 #[cfg(unix)]
 pub async fn run_daemon<D: DaemonDispatch>(dispatcher: D) -> anyhow::Result<()> {
     let boot_guard = Some(acquire_daemon_boot_guard()?);
@@ -973,25 +949,17 @@ pub async fn run_daemon<D: DaemonDispatch>(dispatcher: D) -> anyhow::Result<()> 
 }
 
 /// Run the daemon using a startup lock acquired by the caller *before*
-/// building `dispatcher`.
+/// building `dispatcher`, so a second process racing to boot (e.g. two
+/// `kkernel mcp --daemon` spawns before either has bound its socket) cannot
+/// run migrations/FTS DDL concurrently against the same database file.
+/// `boot_guard` is only `None` on non-unix targets, where there is no
+/// advisory boot lock to hold in the first place; every unix daemon-mode
+/// caller passes `Some`.
 ///
-/// Cold-boot schema initialization (migrations, pack schema plans / FTS DDL)
-/// happens while `dispatcher` is being constructed, i.e. before this
-/// function is ever called. Passing an already-held `boot_guard` in lets the
-/// caller extend that same lock backward over construction, so a second
-/// process racing to boot (e.g. two `kkernel mcp --daemon` spawns before
-/// either has bound its socket) cannot run migrations/FTS DDL concurrently
-/// against the same database file. On unix every daemon-mode
-/// caller passes `Some` — `run_daemon` and the production entry points
-/// (`serve.rs`, `kkernel`) all acquire the guard fatally via
-/// `acquire_daemon_boot_guard` before constructing `dispatcher`. `boot_guard`
-/// is only `None` on non-unix targets, where there is no advisory boot lock to
-/// hold in the first place.
-///
-/// The guard is held across cleanup → bind → pid-write, exactly as
-/// `run_daemon`'s inline lock used to be, then dropped — see the "Deadlock
-/// note" below for why the caller must not still be holding a *different*
-/// handle to the same lock file at that point.
+/// The guard is held across cleanup → bind → pid-write, then dropped. The
+/// caller must not still be holding a *different* handle to the same lock
+/// file when this function is entered — see the "Deadlock note" on the
+/// `_startup_lock` binding below for why that would self-deadlock on `flock`.
 #[cfg(unix)]
 pub async fn run_daemon_with_boot_guard<D: DaemonDispatch>(
     dispatcher: D,

--- a/crates/khive-runtime/src/pack.rs
+++ b/crates/khive-runtime/src/pack.rs
@@ -179,63 +179,26 @@ pub trait PackRuntime: Send + Sync {
         &[]
     }
 
-    /// Register custom embedding providers with the runtime.
-    ///
-    /// Called by the transport during pack initialisation, before the first verb
-    /// dispatch, so that `KhiveRuntime::embedder(name)` resolves provider names
-    /// declared here.
-    ///
-    /// Implement this method to contribute non-lattice embedding backends:
-    ///
-    /// ```ignore
-    /// fn register_embedders(&self, runtime: &KhiveRuntime) {
-    ///     runtime.register_embedder(MyCustomProvider::new());
-    /// }
-    /// ```
-    ///
-    /// The default no-op preserves backwards compatibility — packs that only
-    /// use built-in lattice models do not need to override this method.
+    /// Register custom embedding providers with the runtime. Called during pack
+    /// initialisation, before the first verb dispatch, so `KhiveRuntime::embedder(name)`
+    /// resolves provider names declared here. Default no-op — packs that only use
+    /// built-in lattice models do not need to override this.
+    /// See `docs/pack.md#register_embedders` for a usage example.
     fn register_embedders(&self, _runtime: &KhiveRuntime) {}
 
-    /// Install a pack-owned entity-type validator on the runtime.
-    ///
-    /// Called by the transport during pack initialisation, after the registry
-    /// is built and before the first verb dispatch, so that `create_many` and
-    /// `create_entity` reject unregistered `entity_type` values at the runtime
-    /// layer in addition to the handler layer.
-    ///
-    /// Packs that own `EntityTypeRegistry` vocabularies (e.g. `KgPack`) should
-    /// override this to install their registry's `resolve` function.  The
-    /// default no-op leaves the runtime validator absent (skip-when-None), which
-    /// is the correct behaviour for bare runtimes without packs.
-    ///
-    /// This single-argument hook is intentionally left unchanged (not
-    /// widened) so an out-of-tree pack that already overrides it keeps
-    /// compiling even if it declares no entity types. A pack that needs the
-    /// boot-time composed pack vocabulary should override
-    /// [`register_entity_type_validator_with_types`](Self::register_entity_type_validator_with_types)
-    /// instead — `call_register_entity_type_validators` calls that hook, not
-    /// this one.
+    /// Install a pack-owned entity-type validator on the runtime, called during pack
+    /// initialisation (after the registry is built, before the first dispatch) so
+    /// `create_many`/`create_entity` reject unregistered `entity_type` values at the
+    /// runtime layer. Default no-op leaves the validator absent (skip-when-None).
+    /// See `docs/pack.md#register_entity_type_validator` for the two-hook compatibility contract.
     fn register_entity_type_validator(&self, _runtime: &KhiveRuntime) {}
 
-    /// Install a pack-owned entity-type validator that also receives the
-    /// boot-time composed set of every loaded pack's `ENTITY_TYPES`
-    /// ([`VerbRegistry::all_entity_types`]) — the same aggregate every pack
-    /// in the loaded set receives, mirroring how `EDGE_RULES` are aggregated
-    /// once and consulted by every pack.
-    ///
-    /// Defaults to calling
-    /// [`register_entity_type_validator`](Self::register_entity_type_validator)
-    /// with just the runtime, so a pack that overrides only the older,
-    /// simpler hook — or overrides neither — keeps compiling and behaving
-    /// exactly as before. `call_register_entity_type_validators` calls this
-    /// hook, not the older one, so a pack that wants the composed vocabulary
-    /// must override this one.
-    ///
-    /// Packs that own `EntityTypeRegistry` vocabularies (e.g. `KgPack`)
-    /// should override this hook to compose
-    /// `EntityTypeRegistry::with_extra(pack_entity_types)` and install its
-    /// `resolve` function.
+    /// Install a pack-owned entity-type validator that also receives the boot-time
+    /// composed set of every loaded pack's `ENTITY_TYPES` ([`VerbRegistry::all_entity_types`]).
+    /// Defaults to calling [`register_entity_type_validator`](Self::register_entity_type_validator)
+    /// with just the runtime. `call_register_entity_type_validators` calls this hook, not
+    /// the simpler one — override this to receive the composed vocabulary.
+    /// See `docs/pack.md#register_entity_type_validator` for the two-hook compatibility contract.
     fn register_entity_type_validator_with_types(
         &self,
         runtime: &KhiveRuntime,
@@ -244,44 +207,23 @@ pub trait PackRuntime: Send + Sync {
         self.register_entity_type_validator(runtime);
     }
 
-    /// Install a pack-owned note-mutation hook on the runtime.
-    ///
-    /// Called by the transport during pack initialisation, after the registry
-    /// is built and before the first verb dispatch — same timing as
-    /// `register_entity_type_validator`. Packs that cache derived state keyed
-    /// by note content (e.g. `khive-pack-memory`'s warm ANN index) should
-    /// override this to install a hook via `KhiveRuntime::install_note_mutation_hook`,
-    /// so `update_note`/`delete_note` notify them even when the mutation
-    /// arrived through a different pack's verb that has no dependency on the
-    /// reacting pack (e.g. KG's `update`/`delete` on a `kind="memory"` note).
-    ///
-    /// The default no-op leaves the runtime hook absent (skip-when-None),
-    /// which is the correct behaviour for packs that don't cache note-derived
-    /// state and for bare runtimes without packs.
+    /// Install a pack-owned note-mutation hook on the runtime, called during pack
+    /// initialisation with the same timing as `register_entity_type_validator`. Packs
+    /// that cache derived state keyed by note content (e.g. `khive-pack-memory`'s warm
+    /// ANN index) override this to install a hook via
+    /// `KhiveRuntime::install_note_mutation_hook`. Default no-op leaves the hook absent.
+    /// See `docs/pack.md#register_note_mutation_hook` for cross-pack notification rationale.
     fn register_note_mutation_hook(&self, _runtime: &KhiveRuntime) {}
 
-    /// Warm up any in-memory state from persisted snapshots (optional).
-    ///
-    /// Called by the transport after all packs are registered but before
-    /// serving the first request, giving packs a chance to pre-load expensive
-    /// in-memory structures (e.g. ANN indexes) so that the first query does
-    /// not incur rebuild latency.
-    ///
-    /// The default no-op is correct for all packs that have no warm-start
-    /// state. Packs that override this must make it idempotent and infallible:
-    /// any errors are logged internally, not propagated to the caller.
+    /// Warm up any in-memory state from persisted snapshots (optional). Called after
+    /// all packs are registered but before serving the first request. Must be
+    /// idempotent and infallible — errors are logged internally, never propagated.
     async fn warm(&self) {}
 
-    /// Names of all embedding models registered on this pack's underlying
-    /// runtime handle.
-    ///
-    /// Used by ADR-103 Amendment 1's `model_count` computation at the
-    /// dispatch audit-row emission seam (`VerbRegistry::dispatch_with_identity`)
-    /// for the two embedding-bearing verb families whose model fan-out is
-    /// not a per-dispatch constant: singleton `create` and `memory.remember`
-    /// without an explicit `embedding_model` override. Defaults to empty —
-    /// only the packs that own those verbs (kg, memory) need to override
-    /// this by forwarding to their internal `KhiveRuntime`.
+    /// Names of all embedding models registered on this pack's underlying runtime
+    /// handle. Defaults to empty — only packs that own embedding-bearing verbs
+    /// (kg, memory) need to override this.
+    /// See `docs/pack.md#registered_embedding_model_names` for the ADR-103 consumer.
     fn registered_embedding_model_names(&self) -> Vec<String> {
         Vec::new()
     }
@@ -1099,12 +1041,10 @@ impl VerbRegistry {
     /// Some(id)` uses `id.namespace` / `id.actor_id` / `id.visible_namespaces`
     /// in place of `self.default_namespace` / `self.actor_id` /
     /// `self.visible_namespaces` for this call's namespace resolution, gate
-    /// request, and token minting — the registry's own fields are never
-    /// mutated, so concurrent calls with different (or no) identity are
-    /// independent. This is what lets one warm registry correctly serve
-    /// requests from many attribution identities over the same shared
-    /// backend (same db, same warm ANN indexes) instead of rejecting or
-    /// silently dispatching under its own baked identity.
+    /// request, and token minting. The registry's own fields are never mutated,
+    /// so concurrent calls with different (or no) identity are independent.
+    /// See `docs/pack.md#dispatch_with_identity` for why this enables one warm
+    /// registry to serve many attribution identities over a shared backend.
     pub async fn dispatch_with_identity(
         &self,
         verb: &str,
@@ -1554,34 +1494,21 @@ impl VerbRegistry {
 
     /// Dispatch a verb under an out-of-band verified actor identity.
     ///
-    /// For embedding hosts (gateways, servers, or other processes that embed
-    /// this runtime as a library) that authenticate a principal through their
-    /// own channel — not through the request DSL — and then need that
-    /// principal to be the effective actor for one dispatch. `verified_actor`
-    /// is a typed Rust-side argument: it can only be supplied by code holding
-    /// a `VerbRegistry` handle. `dispatch_as` never reads `params["actor"]`
-    /// to derive the effective actor; individual verbs may still accept an
-    /// `actor` field for their own documented business semantics, unrelated
-    /// to the acting principal.
+    /// `verified_actor` is a typed [`VerifiedActor`] (constructor rejects blank
+    /// identifiers) — only code holding a `VerbRegistry` handle can supply it.
+    /// `dispatch_as` never reads `params["actor"]` to derive the effective actor;
+    /// individual verbs may still accept an `actor` field for their own documented
+    /// business semantics, unrelated to the acting principal. Every pack handler
+    /// that reads "who is calling" resolves it from the `NamespaceToken` the
+    /// dispatch boundary mints, so `verified_actor` becomes exactly the principal
+    /// those handlers observe.
     ///
-    /// `verified_actor` is a [`VerifiedActor`], whose constructor rejects
-    /// blank identifiers. This keeps an authentication-integration failure
-    /// (an empty subject from the host's own auth channel) from silently
-    /// downgrading to the anonymous/local actor — the failure surfaces at
-    /// `VerifiedActor::new` instead of being laundered into a valid dispatch.
-    ///
-    /// Every pack handler that reads "who is calling" (for example, a
-    /// proposal review's `reviewer` field) resolves it from the
-    /// `NamespaceToken` the dispatch boundary mints, so `verified_actor`
-    /// becomes exactly the principal those handlers observe.
-    ///
-    /// Equivalent to `dispatch_with_identity(verb, params, Some(identity))`
-    /// with `identity.actor_id = Some(verified_actor)` and every other
-    /// identity scalar (namespace, visible namespaces) left at this
-    /// registry's construction-baked value — only the acting principal
-    /// changes for this one call. [`Self::dispatch`] and
-    /// [`Self::dispatch_with_identity`] are unaffected: this is a purely
-    /// additive entry point.
+    /// Equivalent to `dispatch_with_identity(verb, params, Some(identity))` with
+    /// `identity.actor_id = Some(verified_actor)` and every other identity scalar
+    /// (namespace, visible namespaces) left at this registry's construction-baked
+    /// value. [`Self::dispatch`] and [`Self::dispatch_with_identity`] are unaffected.
+    /// See `docs/pack.md#dispatch_as` for the embedding-host use case and the
+    /// blank-identifier safety rationale.
     pub async fn dispatch_as(
         &self,
         verb: &str,
@@ -2243,20 +2170,7 @@ fn target_id_from_args(args: &serde_json::Value) -> Option<uuid::Uuid> {
 }
 
 /// Build a v1-shape audit storage event from a gate check outcome.
-///
-/// Shared by the immediate-append path (all verbs, denied calls, bulk
-/// `links`) and the deferred singleton-`link` fallback so both audit
-/// shapes are produced by one code path.
-///
-/// `resource` is the ADR-103 `resource` payload object. ADR-103 Decision (a)
-/// stamps the closed `work_class` enum on every event, so every call site
-/// passes `Some`: `crate::cost_unit::resource_payload` (`{"work_class": ...,
-/// "cost_unit": ...}`) for a successfully-resolved dispatch, or
-/// `crate::cost_unit::base_resource_payload` (`{"work_class": ...}`, no
-/// `cost_unit` key) for denied calls, errored dispatches, and the
-/// no-pack-owns-this-verb case. `None` is reserved for a caller with no
-/// `work_class` to stamp at all (none exist today); it must never be used to
-/// omit `cost_unit` alone.
+/// See `docs/pack.md#build_audit_storage_event` for the `resource` payload contract.
 fn build_audit_storage_event(
     gate_req: &GateRequest,
     audit: &AuditEvent,
@@ -2301,11 +2215,8 @@ async fn append_audit_event_best_effort(store: &Arc<dyn EventStore>, event: Even
     }
 }
 
-/// Schema v2 audit payload for a successful singleton `link` call.
-///
-/// Additive over the v1 `AuditEvent` shape: every v1 field is preserved via
-/// `#[serde(flatten)]`, and the edge identity/relation/weight the caller
-/// created or resolved are added at the top level.
+/// Schema v2 audit payload for a successful singleton `link` call — additive
+/// over v1 via `#[serde(flatten)]`. See `docs/pack.md#linkauditsuccessv2`.
 #[derive(Debug, Clone, serde::Serialize)]
 struct LinkAuditSuccessV2 {
     #[serde(flatten)]
@@ -2317,12 +2228,9 @@ struct LinkAuditSuccessV2 {
     weight: f64,
 }
 
-/// Extract the edge fields needed to enrich a successful singleton `link`
-/// audit row from the handler's returned JSON.
-///
-/// Returns `None` (rather than a `Result`) on any missing/malformed field —
-/// the caller treats that as "cannot enrich" and falls back to the v1 audit
-/// shape instead of failing the already-succeeded `link` call.
+/// Extract edge fields to enrich a successful singleton `link` audit row.
+/// Returns `None` on any missing/malformed field (falls back to v1 shape).
+/// See `docs/pack.md#link_audit_success_from_result`.
 fn link_audit_success_from_result(
     audit: AuditEvent,
     result: &serde_json::Value,
@@ -2362,10 +2270,8 @@ fn link_audit_success_from_result(
 ///   a malformed explicit value must never be silently coerced to the
 ///   default namespace.
 ///
-/// This is the single chokepoint both `VerbRegistry::dispatch` (single-backend
-/// and JSON-form ingress) and the multi-backend coordinator intercept
-/// (`dispatch_via_coordinator_inner` in `khive-mcp`) call into, so no ingress
-/// path can bypass the fail-closed rule by routing around `dispatch`.
+/// Single chokepoint for both `VerbRegistry::dispatch` and the multi-backend
+/// coordinator intercept — see `docs/pack.md#resolve_explicit_namespace`.
 pub fn resolve_explicit_namespace(
     params: &Value,
     default_namespace: &str,

--- a/crates/khive-runtime/src/secret_gate.rs
+++ b/crates/khive-runtime/src/secret_gate.rs
@@ -1,122 +1,37 @@
 //! Write-time secret detection gate.
 //!
-//! Scans caller-supplied content strings before any storage write.  A match
+//! Scans caller-supplied content strings before any storage write. A match
 //! causes a hard `RuntimeError::SecretDetected` that names the detector and
 //! carries a masked excerpt — it never echoes the full candidate back.
 //!
 //! Scope: **credentials only** — API keys, tokens, private keys, passwords,
-//! and connection strings with embedded credentials.  General PII such as
-//! email addresses, phone numbers, and company names is intentionally NOT
-//! blocked; those are normal knowledge-graph content.
+//! and connection strings with embedded credentials. General PII (emails,
+//! phone numbers, company names) is intentionally NOT blocked.
 //!
 //! Detection is layered, cheap-first:
-//!
 //! 1. **Known-prefix / known-shape patterns** — AWS AKIA/ASIA, GitHub tokens,
 //!    OpenAI `sk-proj-`, Anthropic `sk-ant-`, Stripe live keys, Fly.io tokens,
-//!    Vercel secrets, Slack `xox*`, JWT triples, PEM private-key headers,
-//!    Age secret keys, URL userinfo (`scheme://user:pass@`).
-//!    Bare `sk-` is also checked but only when NOT followed by a known safe
-//!    word boundary (e.g. `sk-learn`, `sk-image`).
+//!    Vercel secrets, Slack `xox*`, JWT triples, PEM private-key headers, Age
+//!    secret keys, URL userinfo (`scheme://user:pass@`).
 //! 2. **High-entropy token heuristic** — base64/hex/base64url runs ≥ 24 chars
 //!    near a trigger word (key, secret, password, credential, bearer, auth,
-//!    apikey, api_key, access_key, private_key).  The word `token` alone is NOT
-//!    a trigger to avoid blocking `tokenizer_*`, `token_count`, etc.
+//!    apikey, api_key, access_key, private_key). The word `token` alone is
+//!    NOT a trigger, to avoid blocking `tokenizer_*`, `token_count`, etc.
 //!
-//! Allowlist (false-positive suppression) — **all of the following are
-//! prose-context exemptions, not unconditional passes: a credential trigger
-//! word in the surrounding window always dominates.** A UUID or a
-//! sha-prefixed content hash sitting directly beside "api_key"/"secret"/"auth"
-//! is exactly as ambiguous as any other high-entropy candidate and falls
-//! through to explicit detection instead of being silently allowed.
-//! - Pure hex strings (sha256, git SHA) — passed when not near a trigger.
-//! - UUID canonical form (`xxxxxxxx-xxxx-…`) — passed when not near a trigger.
-//! - Base64/base64url content hashes with an explicit `sha<N>-` prefix (SRI
-//!   hashes, npm lockfile integrity) — passed when not near a trigger and not
-//!   preceded by a known-vendor prefix.  Bare base64 tokens without the
-//!   `sha<N>-` prefix are NOT passed.
-//! - Strings that are entirely ASCII punctuation/whitespace (e.g. code) — not
-//!   subject to the entropy heuristic, only the literal-prefix checks apply.
-//! - Non-ASCII characters (CJK prose, accented text, emoji) act as token
-//!   delimiters for the entropy heuristic: only maximal ASCII runs are
-//!   entropy-checked.  Real base64/hex/base64url credentials are ASCII, and
-//!   `shannon_entropy` runs over UTF-8 bytes — multibyte codepoints inflate the
-//!   byte-wise entropy and false-positive on natural-language non-Latin content.
-//!   Treating non-ASCII as a delimiter (rather than skipping any whitespace
-//!   token that merely contains it) keeps CJK prose unflagged while still
-//!   catching an ASCII credential glued to CJK text/punctuation/fullwidth
-//!   whitespace.  The literal-prefix checks (Layer 1) treat any
-//!   non-ASCII-alphanumeric char (CJK, accented text, emoji) as a token
-//!   boundary, so a known-prefix secret is caught whether the adjacent
-//!   non-ASCII sits before the prefix (`数据AKIA…`) or after it (`AKIA…数据`).
-//! - Structured identifiers: a token is only considered for this exemption
-//!   when it contains at least one of `/`, `-`, `_`, or `.` (the gate); it is
-//!   then decomposed into maximal alphanumeric runs by splitting on *every*
-//!   non-alphanumeric character (not just the four gating separators — any
-//!   other ASCII punctuation glued into the same whitespace token, e.g. a
-//!   stray `:` or `,`, also acts as a run boundary).  A token exempts when it
-//!   decomposes into two or more such runs and every run is letters-then-digits
-//!   or pure digits, at most 24 chars long, with a low case-transition density.
-//!   This covers content like `fable-ops/ADR-DRAFT-adr079.md` or
-//!   `local workspace artifact`, which is otherwise
-//!   indistinguishable from a high-entropy secret once glued into one
-//!   whitespace token.  Random base64/base62 secrets do not decompose this
-//!   way: their case and digit placement is effectively uniform rather than
-//!   word-shaped, so a hyphenated or underscored secret still fails this
-//!   check and remains subject to the entropy heuristic below.
+//! A credential trigger word in the surrounding window always dominates the
+//! allowlist below — no exemption is unconditional near a trigger.
 //!
-//!   **This exemption applies ONLY outside an explicit credential trigger
-//!   context.** Signals that measure Shannon entropy over an attacker-chosen
-//!   run boundary (e.g. requiring a trailing file extension, or an average
-//!   per-run letter entropy below a threshold) are not sound near a trigger
-//!   word: an attacker who controls where a credential's separators fall can
-//!   always choose run lengths whose entropy reads no higher than an ordinary
-//!   short English path segment, since the measure only sees a
-//!   character-frequency histogram, never word semantics. So near a trigger
-//!   word, a structured-identifier-shaped token gets no exemption at all and
-//!   falls through to the entropy heuristic like any other token. This is an
-//!   accepted false-positive tradeoff on a small number of genuine
-//!   paths/doc-slugs that happen to sit near a trigger word AND read above
-//!   the entropy threshold on their own — see
-//!   `accepted_false_positive_adr_draft_path_near_trigger` and its siblings
-//!   for the specific repro cases this blocks, and the call site in
-//!   `check_entropy_heuristic`.
-//!
-//! Trigger-word matching only fires on genuine mentions, not substring
-//! collisions: trigger words (`key`, `secret`, `password`, `passwd`,
-//! `credential`, `bearer`, `auth`, `apikey`) are matched at a word boundary
-//! (`contains_bounded_word`), so `auth` does not fire inside `authorized` or
-//! `authentication`, nor `key` inside `monkey`/`keyword`. The candidate token
-//! is excluded from its own surrounding context. This prevents an internal
-//! path segment such as `cli-auth-and-kg` from making the path self-trigger.
-//! Assignment-shaped candidates such as `auth=<value>` and `api_key=<value>`
-//! are checked separately, including when whitespace splits the label from the
-//! value, so the exclusion does not weaken credential-shaped writes.
-//!
-//! A structured-identifier-shaped token sitting near a **genuinely standalone**
-//! trigger word (e.g. `auth work saved at .../repo-audit.md`, where `auth` is
-//! an actual topical mention rather than a substring collision) is an accepted
-//! false positive: no window-narrowing or exemption-widening scheme survives
-//! the adversarial regression corpus without also reopening a real bypass,
-//! because the caller (or an attacker) fully controls the prose between a
-//! trigger word and a payload: narrowing `TRIGGER_WINDOW` or reinstating the
-//! structured-identifier exemption near "bare" trigger mentions both fail the
-//! same known bypass strings that motivated closing them.
+//! Full exemption rules (hex/UUID/SRI-hash passes, non-ASCII token
+//! delimiting, structured-identifier decomposition, trigger word-boundary
+//! matching, the underscore-boundary asymmetry between bare trigger words and
+//! the word `token`, and the adversarial-corpus rationale for why some
+//! false positives are accepted) are documented in full in
+//! `docs/secret_gate.md#module-level-detection-algorithm` — read that before
+//! changing any detection or exemption logic in this file.
 //!
 //! The caller-visible block message (`SecretMatch`'s `Display` impl) also
 //! carries actionable guidance (`block_guidance`) to split or reword the
 //! flagged token.
-//!
-//! The word-boundary rule above treats underscore as a BOUNDARY for bare
-//! `TRIGGER_WORDS` (`contains_bounded_word`): deliberately different from
-//! `has_standalone_token`'s rule for the word `token`, which treats
-//! underscore as a continuation so `tokenizer`/`next_token`/`token_count`
-//! stay exempt. Treating underscore as a boundary for the bare set is what
-//! lets common underscore-joined credential-config compounds keep firing:
-//! `SECRET_KEY=...` (Django/Flask-style config), `auth_token=...`,
-//! `session_secret_...`, `signing_key=...` all match on the `secret`/`key`/
-//! `auth` half. This is implemented by parameterizing the boundary rule
-//! (`contains_word`'s `underscore_is_word_char` argument) rather than sharing
-//! one rule between the two callers.
 //!
 //! A production-corpus replay harness (`corpus_replay`, `#[ignore]`d, run via
 //! `KHIVE_REPLAY_DB=<path> cargo test ... -- --ignored --nocapture`) measures
@@ -304,20 +219,16 @@ fn scan(text: &str) -> Option<SecretMatch> {
 ///
 /// This is the masking counterpart to [`check`]: where `check` hard-blocks a
 /// write on the first match, `mask_secrets` is for content that must be STORED
-/// with credentials stripped (the session mirror). A transcript line cannot be
-/// rejected wholesale, so each credential span is replaced in place while the
-/// surrounding prose is preserved. It reuses the SAME canonical detector set as
-/// `check`/`scan`, so callers must never maintain a second, weaker masker.
+/// with credentials stripped (the session mirror). It reuses the SAME
+/// canonical detector set as `check`/`scan`, so callers must never maintain a
+/// second, weaker masker.
 ///
 /// Returns `Cow::Borrowed` when no secret is present (the common case), avoiding
-/// an allocation. Spans are discovered left to right against the ORIGINAL text
-/// via `scan_from`: each scan advances a `from` cursor past the previous span
-/// but always evaluates trigger context over the full input. This closes the
-/// entropy-context gap — a high-entropy value whose only trigger word sits to
-/// the left of an earlier-redacted secret is still detected, because the trigger
-/// window is never sliced away. The known-prefix detectors (real API keys:
-/// `sk-ant-`, `sk-proj-`, `AKIA`/`ASIA`, GitHub, Stripe, …) are context-free and
-/// matched the same way.
+/// an allocation. Spans are discovered left to right against the ORIGINAL text,
+/// always evaluating trigger context over the full input — a high-entropy value
+/// whose only trigger word sits to the left of an earlier-redacted secret is
+/// still detected. See `docs/secret_gate.md#mask_secrets` for the scan-cursor
+/// mechanics.
 pub fn mask_secrets(text: &str) -> std::borrow::Cow<'_, str> {
     let base = text.as_ptr() as usize;
     // Collect every secret span (absolute byte offsets into `text`) before
@@ -611,22 +522,10 @@ fn find_url_userinfo(text: &str) -> Option<&str> {
 // ─── Layer 2: entropy heuristic ─────────────────────────────────────────────
 
 /// Trigger words checked as a bounded standalone word (see
-/// [`contains_bounded_word`]) — bare English words that can otherwise appear
-/// as a pure substring collision inside unrelated identifiers or prose:
-/// `auth` inside `authorized`/`authentication`, `key` inside
-/// `monkey`/`turkey`/`keyword`, `secret` inside `secretary`.  Design decision
-/// (see the module doc): a substring collision like this poisons the trigger
-/// window on prose that never mentions credentials at all, which is a
-/// distinct failure mode from a genuine (if topical) mention of the word —
-/// see issues #577 / #632.  Matching these words at a word boundary removes
-/// the substring-collision false positives while changing nothing about
-/// detection of a genuine standalone mention: `auth` as its own word (`auth
-/// header`, `auth:`) still triggers exactly as before.
-///
-/// The bare substring `token` is NOT in this list because it fires on benign
-/// terms like `tokenizer`, `token_count`, and `next_token`.  Instead we use
-/// the dedicated boundary-aware helpers `has_standalone_token` (standalone word)
-/// and `has_token_assignment` (`token=` / `token:` with word boundary before).
+/// [`contains_bounded_word`]). `token` is deliberately excluded — see
+/// `has_standalone_token`/`has_token_assignment` instead.
+/// See `docs/secret_gate.md#trigger_words` for the substring-collision
+/// rationale (issues #577 / #632).
 const TRIGGER_WORDS: &[&str] = &[
     "key",
     "secret",
@@ -813,26 +712,11 @@ fn check_entropy_heuristic(text: &str, from: usize) -> Option<(&str, &'static st
 }
 
 /// Returns `true` when `low_window` contains `needle` as a standalone word —
-/// bounded on both sides by a character outside the caller-supplied word-char
-/// set (or start/end of string) — rather than merely as a substring.
-///
-/// `underscore_is_word_char` selects which of two, deliberately different,
-/// boundary rules the caller needs:
-/// - `true` (used by [`has_standalone_token`] / [`has_token_assignment`] for
-///   `token`): underscore is a continuation of the same identifier, so
-///   `next_token`, `tokenizer`, and `token_count` do NOT match — a prior,
-///   deliberate decision that must not change.
-/// - `false` (used by [`contains_bounded_word`] for the bare `TRIGGER_WORDS`):
-///   underscore IS a boundary, so `secret_key=`/`auth_token=`/`signing_key=`
-///   still match on the `secret`/`auth`/`key` half of the compound — these
-///   underscore-joined credential-config compounds (Django/Flask `SECRET_KEY`,
-///   OAuth `auth_token`, JWT `signing_key`) are exactly the shape a credential
-///   trigger must not lose. Only *letter*-joined collisions (`authorized`,
-///   `authentication`, `monkey`, `keyword`) are meant to stop matching.
-///
-/// CJK/accented prose always counts as a boundary in both modes (only ASCII
-/// alphanumerics — plus underscore when `underscore_is_word_char` is `true`
-/// — are treated as word characters).
+/// bounded on both sides by a character outside the word-char set (or
+/// start/end of string) — rather than merely as a substring.
+/// `underscore_is_word_char` selects the boundary rule the caller needs; see
+/// `docs/secret_gate.md#contains_word` for the two deliberately different
+/// rules and why each caller needs its own.
 fn contains_word(low_window: &str, needle: &str, underscore_is_word_char: bool) -> bool {
     let is_word_char = |c: char| c.is_ascii_alphanumeric() || (underscore_is_word_char && c == '_');
     let mut start = 0;
@@ -1018,19 +902,9 @@ fn is_pure_hex(token: &str) -> bool {
 
 /// Returns `true` for tokens that are unambiguous base64/base64url content
 /// hashes with an explicit `sha<N>-` prefix (SRI hash, npm lockfile integrity).
-///
-/// Criteria:
-/// - Token starts with `sha<digits>-` (e.g. `sha256-`, `sha384-`, `sha512-`).
-/// - The body after the prefix matches a SHA-family length (43, 64, or 86–88
-///   unpadded chars).
-/// - Every byte in the body is a standard-base64 or URL-safe-base64 character.
-/// - Does NOT start with a known vendor-token prefix (those are credentials
-///   regardless of alphabet).
-///
-/// Bare base64 tokens of those lengths WITHOUT the `sha<N>-` prefix are NOT
-/// allowlisted here — a 43-char base64url API token near the word "key" is
-/// indistinguishable from a sha256 hash body without the prefix, so we require
-/// the explicit prefix to avoid false-negative credential escapes.
+/// Bare base64 of the same length WITHOUT the prefix is NOT allowlisted — see
+/// `docs/secret_gate.md#is_base64_content_hash` for the full criteria list and
+/// why the explicit prefix is required.
 fn is_base64_content_hash(token: &str) -> bool {
     // Known vendor prefixes — never allowlist even if they look like base64.
     // Includes bare `sk-` to prevent OpenAI-shaped tokens from being allowlisted.
@@ -1109,21 +983,10 @@ const DENSITY_EXEMPT_LETTER_LEN: usize = 4;
 const MAX_CASE_TRANSITION_DENSITY: f64 = 0.3;
 
 /// Returns `true` when `token` is shaped like a file path, branch name, or
-/// other structured identifier rather than a high-entropy secret.
-///
-/// A structured identifier decomposes into two or more maximal
-/// ASCII-alphanumeric "runs" separated by `/`, `-`, `_`, or `.`, where every
-/// run is word-shaped: letters-then-digits (`adr079`, `slices234`, `R1`) or
-/// pure digits (`20260701`), at most [`MAX_RUN_LEN`] chars, with a low
-/// case-transition density in the letter portion. Random base64/base62
-/// secrets glued between separators reliably fail this shape check: their
-/// case and digit placement is essentially uniform rather than word-like, so
-/// a run either exceeds the length cap or mixes case too densely to pass.
-///
-/// Outside credential-trigger context this shape check alone is sufficient to
-/// exempt a token from the entropy heuristic. In trigger context the caller
-/// grants NO exemption at all: see the module doc and the call site in
-/// [`check_entropy_heuristic`].
+/// other structured identifier rather than a high-entropy secret (word-shaped
+/// runs separated by `/`, `-`, `_`, `.`). Exempts from the entropy heuristic
+/// ONLY outside trigger context — see the module doc and
+/// `docs/secret_gate.md#is_structured_identifier` for the run-shape criteria.
 fn is_structured_identifier(token: &str) -> bool {
     if !token.contains(|c: char| STRUCTURAL_SEPARATORS.contains(&c)) {
         return false;
@@ -1227,36 +1090,10 @@ fn wrapper_strip_repeated(token: &str) -> &str {
     }
 }
 
-/// Yield every candidate value that an assignment/wrapper-glued whitespace
-/// token could contain, so shape allowlists that require an EXACT match
-/// (`is_uuid_canonical`, `is_base64_content_hash`) still recognize the
-/// credential once it is glued to normal storage syntax: `key=value`,
-/// `(value)`, `{"key":"value"}`, `key1=key2=value`, a trailing sentence
-/// period, or a label itself containing `:`/`=` (`{"api:key":"value"}`).
-/// Used only to derive candidates for the near-trigger UUID/content-hash
-/// checks in `check_entropy_heuristic` — it does NOT replace `token` for
-/// the entropy, hex, or structured-identifier paths, none of which require
-/// an exact shape match and so are unaffected by this extraction.
-///
-/// Strips wrapper punctuation from both ends first, then yields the
-/// wrapper-stripped whole token, plus the wrapper-stripped suffix after
-/// EVERY internal `=`/`:` occurrence (skipping empty suffixes). No single
-/// separator position can be assumed correct: the true key/value or
-/// JSON-label boundary might be the first separator (`secret=sha256-...`),
-/// but a base64/base64url value can itself end in `=` padding — for a
-/// padded content hash that padding IS the last `=` in the token, so a
-/// last-separator split would land on the padding boundary instead. A
-/// label can also itself contain `:`/`=` (`{"api:key":"<uuid>"}`) or the
-/// assignment can be doubled (`key=label=<uuid>`), so neither "first" nor
-/// "last" is a sound single choice. Emitting every suffix and letting the
-/// caller test each one is the only choice that is sound in all these
-/// shapes: the true value always appears as *some* suffix, and a `=`/`:`
-/// that lands inside padding or a label simply yields a non-matching
-/// suffix that the caller's shape check harmlessly rejects.
-///
-/// Byte-scan via `char_indices` over an already-short token (whitespace-
-/// delimited, so bounded by realistic line length) — no allocation, since
-/// this runs in the hot scan path.
+/// Yields every candidate value an assignment/wrapper-glued token could
+/// contain, for the near-trigger UUID/content-hash exact-shape checks only.
+/// See `docs/secret_gate.md#value_candidates` for why every `=`/`:` suffix
+/// must be tried rather than just the first or last.
 fn value_candidates(token: &str) -> impl Iterator<Item = &str> {
     let cur = wrapper_strip_repeated(token);
     std::iter::once(cur).chain(cur.char_indices().filter_map(move |(i, c)| {


### PR DESCRIPTION
## What

Condense verbose inline doc-comments in `khive-runtime` and relocate long-form rationale, algorithm walkthroughs, and background prose into per-crate `docs/*.md` guides. Part of the rustdoc condense-and-extract pass.

## Preserved (information relocation, not deletion)

- Public API doc-comments stay **complete and standalone** — the docs.rs reference is intact; a caller can use each public item from its doc-comment alone.
- No `# Safety`, invariant, ordering, precision, or error-enumeration docs were thinned.
- schemars/clap product-surface doc-comments (MCP tool schema, CLI `--help`) left verbatim.
- Every substantive fact removed from a `.rs` doc-comment was moved into a crate guide under the crate's `docs/` directory, not dropped.

## Scope

Only the `src` and `docs` trees of the crates above. Diffstat: 8 files changed, 559 insertions(+), 500 deletions(-).

Branch forked before recent doc merges; will be updated onto main and code-reviewed before marking ready.