### PR TITLE
docs(rustdoc): condense inline docs + extract to guides (khive-pack-gtd,khive-pack-schedule khive-quant,khive-vcs)

### DIFF
--- a/crates/khive-pack-gtd/docs/handlers-internals.md
+++ b/crates/khive-pack-gtd/docs/handlers-internals.md
@@ -1,0 +1,55 @@
+# Handler internals — rationale for `src/handlers.rs`
+
+Background for maintainers; not part of the published API contract (each linked
+item's doc-comment carries the complete caller-facing contract already).
+
+## `ensure_audit_schema` — why per-call, not `OnceLock`
+
+The DDL (`CREATE TABLE IF NOT EXISTS gtd_lifecycle_audit` + index) is applied on
+every call rather than gated behind a global `OnceLock`, because each
+`KhiveRuntime::memory()` in tests creates a fresh in-memory database that needs
+its own schema bootstrap. In production the DDL is idempotent and cheap (SQLite
+skips `IF NOT EXISTS` tables instantly).
+
+### Why `pub`
+
+Unlike every other helper in this file, `ensure_audit_schema` and
+`write_audit_record` are `pub` (not module-private): the ADR-099 `--atomic` CLI
+surface's `gtd.transition`/`gtd.complete` prepare functions live in `kkernel` (a
+crate that already depends on both `khive-runtime` and `khive-pack-gtd` — see
+that crate's `atomic_apply` module doc for the crate-direction rationale), and
+the B3 GAP-5 fix applies this exact function as a deferred post-commit effect so
+atomic transitions/completes write the same best-effort lifecycle audit row the
+canonical handlers do, rather than re-deriving the DDL/INSERT a second time.
+
+## `CompleteParams` / `TransitionParams` — why `pub` with private fields
+
+ADR-099 B3: these structs are `pub` (not module-private) specifically so
+`kkernel`'s `--atomic` validation seam (`atomic_apply::validate_atomic_args`) can
+deserialize an op's args through the same canonical struct `handle_complete`/
+`handle_transition` use, reproducing `deny_unknown_fields` rejection with zero
+duplicated field lists. Fields stay private — the atomic seam only needs the
+`Result<_, _>` outcome, never field access.
+
+## `fetch_all_matching_tasks` — bounded single-snapshot scan (issue #772, #825)
+
+Fetches every `task` note matching `property_filters` in a single bounded
+snapshot query, instead of pre-fetching a fixed-size unfiltered window. The
+predicate is pushed into SQL via `query_notes_filtered_bounded`, so the
+candidate set returned is bounded by how many tasks actually match — not by how
+many task notes of any status exist (issue #772: a fixed unfiltered window
+could be entirely filled by newer non-matching churn, hiding older matching
+tasks regardless of priority).
+
+`query_notes_filtered_bounded` fetches at most `TASK_SCAN_MAX_ROWS + 1` rows in
+one SQL statement with deterministic ordering — one consistent snapshot, not a
+`COUNT(*)` followed by independent paged reads that a concurrent insert could
+split across (issue #825: the prior page-loop version re-queried the store per
+page with no transaction spanning them, so a row inserted between pages could
+appear duplicated across a page boundary, or the scan could hit its cap and
+still return `Ok` with an incomplete set). If `TASK_SCAN_MAX_ROWS + 1` rows come
+back, this returns `Err(InvalidInput)` instead of ever returning a possibly
+truncated result — callers must narrow the filters (e.g. add `assignee`) so the
+result stays complete.
+
+Source: `crates/khive-pack-gtd/src/handlers.rs`.

--- a/crates/khive-pack-gtd/src/handlers.rs
+++ b/crates/khive-pack-gtd/src/handlers.rs
@@ -32,23 +32,13 @@ use crate::GtdPack;
 
 /// Ensure `gtd_lifecycle_audit` and its index exist on the given runtime.
 ///
-/// Idempotent (`CREATE TABLE IF NOT EXISTS`).  Applied lazily on the first
-/// `transition` or `complete` call.  Logs a warning and continues if the DDL
-/// fails (e.g. read-only replica) — the audit is best-effort, not load-bearing.
-///
-/// We intentionally apply the DDL on each call rather than using a global
-/// `OnceLock`, because each `KhiveRuntime::memory()` in tests creates a fresh
-/// in-memory database that needs its own schema bootstrap.  In production the
-/// DDL is idempotent and cheap (SQLite skips `IF NOT EXISTS` tables instantly).
-/// `pub` (rather than the module-private visibility every other helper in
-/// this file uses): the ADR-099 `--atomic` CLI surface's `gtd.transition`/
-/// `gtd.complete` prepare functions live in `kkernel` (a crate that already
-/// depends on both `khive-runtime` and `khive-pack-gtd` — see that crate's
-/// `atomic_apply` module doc for the crate-direction rationale), and the B3
-/// GAP-5 applies this exact function as a deferred post-commit
-/// effect so atomic transitions/completes write the same best-effort
-/// lifecycle audit row the canonical handlers do, rather than re-deriving
-/// the DDL/INSERT here a second time.
+/// Idempotent (`CREATE TABLE IF NOT EXISTS`). Applied lazily on the first
+/// `transition` or `complete` call, on every call rather than gated by a
+/// `OnceLock` (fresh in-memory test runtimes each need their own bootstrap).
+/// Logs a warning and continues if the DDL fails (e.g. read-only replica) —
+/// the audit is best-effort, not load-bearing. `pub`: also called from
+/// `kkernel`'s ADR-099 `--atomic` seam. See
+/// `docs/handlers-internals.md#ensure_audit_schema--why-per-call-not-oncelock`.
 pub async fn ensure_audit_schema(runtime: &KhiveRuntime) {
     let Ok(mut w) = runtime.sql().writer().await else {
         tracing::warn!("gtd: failed to acquire SQL writer for audit schema (non-fatal)");
@@ -98,12 +88,9 @@ pub async fn ensure_audit_schema(runtime: &KhiveRuntime) {
 
 /// Append one row to `gtd_lifecycle_audit`.
 ///
-/// Best-effort: failures are logged and swallowed.  The note's successful
-/// write has already happened; a missing audit row is degraded, not a failure.
-///
-/// `pub` for the same reason as `ensure_audit_schema` above — the ADR-099
-/// `--atomic` surface's `kkernel`-side post-commit pass calls this directly
-/// (ADR-099 B3, GAP-5) rather than re-deriving the INSERT.
+/// Best-effort: failures are logged and swallowed. The note's successful
+/// write has already happened; a missing audit row is degraded, not a
+/// failure. `pub` for the same reason as `ensure_audit_schema` above.
 pub async fn write_audit_record(
     runtime: &KhiveRuntime,
     note_id: Uuid,
@@ -192,12 +179,10 @@ struct NextParams {
     assignee: Option<String>,
 }
 
-/// ADR-099 B3: `pub` (not module-private) SPECIFICALLY so `kkernel`'s
-/// `--atomic` validation seam (`atomic_apply::validate_atomic_args`) can
-/// deserialize an op's args through the SAME canonical struct
-/// `handle_complete` uses, reproducing `deny_unknown_fields` rejection with
-/// zero duplicated field lists. Fields stay private — the atomic seam only
-/// needs the `Result<_, _>` outcome, never field access.
+/// `handle_complete`'s deserialization target. `pub` with private fields:
+/// `kkernel`'s ADR-099 `--atomic` validation seam reuses this exact struct to
+/// validate `gtd.complete` args, needing only the `Result<_, _>` outcome. See
+/// `docs/handlers-internals.md#completeparams--transitionparams--why-pub-with-private-fields`.
 #[derive(Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct CompleteParams {
@@ -451,25 +436,11 @@ fn ts_to_rfc(micros: i64) -> String {
 /// task that fell outside the scan window.
 const TASK_SCAN_MAX_ROWS: u32 = 20_000;
 
-/// Fetch every `task` note matching `property_filters` in a single bounded
-/// snapshot query, instead of pre-fetching a fixed-size unfiltered window.
-/// The predicate is pushed into SQL via `query_notes_filtered_bounded`, so
-/// the candidate set this returns is bounded by how many tasks actually
-/// match — not by how many task notes of any status exist (the #772 bug: a
-/// fixed unfiltered window could be entirely filled by newer non-matching
-/// churn, hiding older matching tasks regardless of priority).
-///
-/// `query_notes_filtered_bounded` fetches at most `TASK_SCAN_MAX_ROWS + 1`
-/// rows in one SQL statement with deterministic ordering — one consistent
-/// snapshot, not a `COUNT(*)` followed by independent paged reads that a
-/// concurrent insert could split across (issue #825: the prior
-/// page-loop version re-queried the store per page with no transaction
-/// spanning them, so a row inserted between pages could appear duplicated
-/// across a page boundary, or the scan could hit its cap and still return
-/// `Ok` with an incomplete set). If `TASK_SCAN_MAX_ROWS + 1` rows come back,
-/// this returns `Err(InvalidInput)` instead of ever returning a possibly
-/// truncated result — callers must narrow the filters (e.g. add `assignee`)
-/// so the result stays complete.
+/// Fetches every `task` note matching `property_filters` in one bounded
+/// snapshot query (not a fixed-size unfiltered window — issue #772/#825).
+/// Returns `Err(InvalidInput)` rather than a possibly-truncated result if
+/// more than `TASK_SCAN_MAX_ROWS` rows match. See
+/// `docs/handlers-internals.md#fetch_all_matching_tasks--bounded-single-snapshot-scan-issue-772-825`.
 async fn fetch_all_matching_tasks(
     runtime: &KhiveRuntime,
     token: &NamespaceToken,

--- a/crates/khive-pack-schedule/docs/replay-validation.md
+++ b/crates/khive-pack-schedule/docs/replay-validation.md
@@ -1,0 +1,166 @@
+# Schedule replay validation
+
+Internal notes for the write-time validators in `src/handlers.rs` that guarantee a
+scheduled `schedule.schedule` action can be replayed exactly as stored (issue #461).
+None of these functions are public API — this is background for maintainers reading
+`src/handlers.rs`.
+
+## `validate_at` — future-timestamp check
+
+Accepts any RFC 3339 string chrono can parse as `DateTime<Utc>` (e.g.
+`"2027-01-01T00:00:00Z"` or with a numeric offset). Returns the parsed UTC instant so
+callers can compare without re-parsing; the original string is preserved by callers
+who want to store it as-is. Rejects unparseable strings and timestamps in the past
+relative to `Utc::now()`.
+
+## `validate_repeat` — cron-lite repeat spec
+
+Accepts the literals `daily`, `weekly`, `monthly`, and a limited five-field form
+`MIN HOUR DOM MON DOW` where each field is `*` or one non-negative integer within:
+MIN 0–59, HOUR 0–23, DOM 1–31, MON 1–12, DOW 0–7.
+
+Standard cron operators (steps `*/15`, ranges `9-17`, lists `0,30`) are NOT accepted
+(issue #481): `kkernel`'s pending-events runner does not yet compute next-fire times
+for cron-form repeats (it fires them one-shot), so accepting full cron syntax would
+imply recurrence semantics that don't exist yet. Use `daily`/`weekly`/`monthly` for
+recurring runtime advancement until cron next-fire support lands. Malformed fields
+(non-numeric, out-of-range, or a cron operator) are rejected rather than silently
+accepted.
+
+## `validate_action` — DSL parseability
+
+Validates that `action` parses via `khive_request::parse_request`, catching garbage
+like `"x"` or `"bogus-not-a-valid-verb()"` at write time rather than at trigger time,
+when nobody is watching.
+
+## `validate_replayable_single_action` — replay-safety gate (issue #461)
+
+The pending-events runner reparses the stored DSL at trigger time and dispatches it
+through the normal request surface. For that replay to succeed, the stored action
+must be:
+
+- A single op against an exactly-registered handler name (not a bare shorthand
+  resolved via a `schedule.{tool}` fallback).
+- Built from literal argument values only (no `$prev` references — those are only
+  meaningful inside a chain the replay path does not reconstruct).
+- Complete with respect to all required handler parameters.
+
+Rejecting anything else at write time prevents storing an action that is guaranteed
+to fail (and be silently marked "fired") when it comes due.
+
+It also rejects any handler whose schema declares `namespace` as a business param
+(issue #461/#462): `dispatch_action` in `pending_events.rs` unconditionally injects
+the firing event's routing namespace into every op's args, and the registry passes
+it through unchanged whenever the handler declares `namespace`
+(`khive-runtime/src/pack.rs`). For handlers that treat `namespace` as a business
+param (e.g. `brain.bind`, `brain.resolve`), that silently changes the business value
+on replay — even when the *stored* action omitted `namespace` entirely (e.g.
+`brain.bind` defaults an omitted `namespace` to the wildcard `"*"` at write time;
+replay would instead bind it to whatever namespace the event happens to fire from).
+Replay cannot yet carry routing-namespace and arg-namespace as separate concepts, so
+this is rejected at write time based on the handler's schema alone, regardless of
+whether the stored args happen to include `namespace`.
+
+## `validate_conditional_requirements` — hard-coded conditional-required-param cases (issue #461)
+
+`validate_args_against_help` only enforces metadata-declared `required:true` params.
+Some handlers accept one of several alternative arg sets (e.g. `create` requires
+`kind` unless bulk `items` is given), so neither alternative is marked required in
+metadata and both can be omitted at write time — then fail at trigger-time replay.
+This function hard-codes the known cases; it is not a general
+conditional-requirements mechanism (there is no metadata surface for that yet), so
+it does not guarantee every handler-internal semantic precondition is caught.
+
+For `tool == "create"`, this mirrors the singleton branches of the KG pack's own
+`handle_create` (`khive-pack-kg/src/handlers/create.rs`): entity/granular-entity
+creates require `name`, note/granular-note creates require `content`, and a bare
+`kind="entity"` requires an `entity_kind` (or a granular entity kind) to resolve a
+concrete kind. It also validates `entity_type` against the KG entity-type/subtype
+registry when present — see `validate_entity_type_for_replay` below.
+`khive-pack-schedule` does not depend on `khive-pack-kg` in production (only as a
+dev-dependency for tests), so this reimplements the classification using
+`VerbRegistry::all_entity_kinds`/`all_note_kinds` — the same data `resolve_kind_spec`
+consults — rather than importing the KG pack's private helpers.
+
+## `classify_create_kind` — mirrors `khive-pack-kg::handlers::common::resolve_kind_spec`
+
+Classification order: literal substrate keywords first, then base-8-kind aliases
+(`khive_types::EntityKind`, e.g. `"paper"` -> `document` — a real, non-dev dependency
+already shared with khive-pack-kg, so this is genuine reuse, not a hand-copy), then
+the pack-local `resource`-kind alias set (`"atom"`, `"runbook"`, etc. -> `resource`,
+ADR-048; hand-copied via `resource_alias_for_replay` since
+`khive-pack-kg::vocab::EntityKind` is pack-private — see below), then the registry's
+merged entity/note-kind vocabulary (the same final fallback `resolve_kind_spec`
+uses). Returns an error for any `kind` guaranteed to fail replay outright: `edge`
+(create edges via `link`), `event` (immutable), `proposal` (create via `propose`),
+or an unrecognized kind string.
+
+The pre-fix version skipped alias resolution entirely, causing schedule-time false
+rejections (not a security hole) for legitimate KG-accepted spellings like `"paper"`
+and `"atom"`.
+
+## `canonical_entity_kind_for_replay` / `canonical_note_kind_for_replay`
+
+Mirror `khive-pack-kg::handlers::common::canonical_entity_kind`/
+`canonical_note_kind`. The entity variant tries the base `khive_types::EntityKind`
+parser (8 base kinds + common aliases, e.g. `"paper"` -> `document`), then the
+pack-local `resource` alias set, then the registry's merged entity-kind vocabulary
+(covers further pack-declared additions). The pre-fix version resolved neither
+alias set, causing the same class of false rejections noted above. Note kinds carry
+no alias set beyond their 5 canonical names (ADR-013), so the note variant is
+exactly the registry's merged note-kind vocabulary check.
+
+## `resource_alias_for_replay` — hand-copied ADR-048 alias set
+
+Mirrors `khive-pack-kg::vocab::EntityKind`'s `FromStr` arm `"resource" | "atom" |
+"runbook" | "template" | "prompt" | "skill" | "tool"` (`khive-pack-kg/src/vocab.rs`).
+That type is `pub(crate)` to `khive-pack-kg`, and `khive-pack-schedule` does not
+depend on `khive-pack-kg` in production (dev-dependency only, for tests), so this
+hand-copies just the alias set — six short strings — rather than the type.
+`normalized` must already be trimmed + lowercased. Kept in sync by
+`entity_kind_resource_aliases_match_real_vocab` in `create_validation.rs`, which
+asserts this list against the live `khive-pack-kg` vocab (via the dev-dependency) so
+drift is caught in CI rather than silently reproducing a similar false rejection.
+
+## `validate_entity_type_for_replay`
+
+Mirrors `khive-pack-kg::handlers::common::validate_entity_type`: parses
+`canonical_kind_name` into the base `khive_types::EntityKind` first, then resolves
+the subtype against the boot-time composed registry (builtin subtypes plus every
+loaded pack's `ENTITY_TYPES`, `VerbRegistry::all_entity_types`) — NOT the
+builtin-only `EntityTypeRegistry::global()`. KG create validation and schedule
+replay validation resolve against the exact same composed set, so this cannot drift
+from the real handler's vocabulary, and a scheduled `create` naming a pack-declared
+subtype (e.g. git's `adr` Document subtype) is accepted at schedule time exactly
+when the real handler would accept it at trigger time.
+
+The kind-parse step is exactly what makes a pack-owned kind like `"resource"` reject
+*any* non-`None` `entity_type` outright: `resource` has no variant in the base
+8-kind enum, so parsing `canonical_kind_name` fails before the subtype table is even
+consulted — the real handler has this same short-circuit
+(`khive-pack-kg/src/handlers/common.rs`, `validate_entity_type`), verified live via
+`kkernel exec` against a scratch DB. This mirrors that behavior rather than
+"fixing" it: the contract here is bit-for-bit replay parity with the real handler,
+not what the real handler arguably should do.
+
+## `reconcile_specific_for_replay`
+
+Reconciles a granular `kind`'s resolved `specific` value against a legacy
+`entity_kind`/`note_kind` argument, mirroring
+`khive-pack-kg::handlers::common::reconcile_specific` exactly (including the
+contradiction error shape) so a scheduled action that the real KG `create` handler
+would reject for a kind/legacy-kind contradiction is rejected at schedule time too,
+not only discovered at trigger-time replay. `context` prefixes error messages (e.g.
+`"items[3] "` for a bulk entry, `""` for the singleton path).
+
+## `ScheduleBulkCreateEntryCheck` / `validate_create_bulk_items`
+
+`ScheduleBulkCreateEntryCheck` mirrors
+`khive-pack-kg::handlers::params::BulkCreateEntry`'s exact field set (including
+`#[serde(deny_unknown_fields)]`) so schedule-time validation rejects the same
+malformed entries the real bulk handler would. `validate_create_bulk_items`
+validates a `create(items=[...])` bulk payload the way `handle_create`'s bulk path
+would: `items` must parse into that shape (required `kind` + `name`,
+deny-unknown-fields), and bulk create only supports entity kinds (never note kinds).
+
+Source: `crates/khive-pack-schedule/src/handlers.rs`.

--- a/crates/khive-pack-schedule/src/handlers.rs
+++ b/crates/khive-pack-schedule/src/handlers.rs
@@ -61,18 +61,9 @@ fn deser<T: serde::de::DeserializeOwned>(params: Value) -> Result<T, RuntimeErro
         .map_err(|e| RuntimeError::InvalidInput(format!("bad params: {e}")))
 }
 
-/// Validate that `at` is a valid RFC 3339 timestamp and lies in the future.
-///
-/// Accepts any RFC 3339 string that `chrono` can parse as a `DateTime<Utc>`
-/// (e.g. "2027-01-01T00:00:00Z" or "2027-01-01T00:00:00+05:30").
-///
-/// Returns the parsed UTC instant so callers can use it for comparisons
-/// without re-parsing. The original string is preserved by callers who want
-/// to store it as-is (see H5 fix below).
-///
-/// Rejects:
-/// - Unparseable strings (not RFC 3339).
-/// - Timestamps that lie in the past relative to `Utc::now()`.
+/// Validates `at` is an RFC 3339 timestamp lying in the future; returns the
+/// parsed instant. See `docs/replay-validation.md#validate_at` for accepted
+/// formats and rationale.
 fn validate_at(verb: &str, at: &str) -> Result<DateTime<Utc>, RuntimeError> {
     let parsed = at.parse::<DateTime<Utc>>().map_err(|_| {
         RuntimeError::InvalidInput(format!(
@@ -88,27 +79,10 @@ fn validate_at(verb: &str, at: &str) -> Result<DateTime<Utc>, RuntimeError> {
     Ok(parsed)
 }
 
-/// Validate a repeat spec: named aliases or a limited five-field form.
-///
-/// Accepts the literals `daily`, `weekly`, `monthly`, and a limited five-field
-/// form `MIN HOUR DOM MON DOW`, where each field is exactly `*` or one
-/// non-negative integer within the accepted range:
-/// - MIN  0–59
-/// - HOUR 0–23
-/// - DOM  1–31
-/// - MON  1–12
-/// - DOW  0–7
-///
-/// Standard cron operators such as steps (`*/15`), ranges (`9-17`), and lists
-/// (`0,30`) are NOT accepted (issue #481): `kkernel`'s pending-events runner
-/// does not yet compute next-fire times for cron-form repeats (it fires them
-/// one-shot), so advertising and accepting full cron syntax here would imply
-/// recurrence semantics that do not exist yet. Use `daily` / `weekly` /
-/// `monthly` for recurring runtime advancement until cron next-fire support
-/// lands.
-///
-/// Malformed fields (non-numeric, out-of-range, or a cron operator) are
-/// rejected with `RuntimeError::InvalidInput` rather than silently accepted.
+/// Validates a repeat spec: `daily`/`weekly`/`monthly`, or a limited 5-field
+/// `MIN HOUR DOM MON DOW` cron-lite form (no steps/ranges/lists — issue
+/// #481). See `docs/replay-validation.md#validate_repeat` for field ranges
+/// and rationale.
 fn validate_repeat(repeat: &str) -> Result<(), RuntimeError> {
     match repeat {
         "daily" | "weekly" | "monthly" => return Ok(()),
@@ -156,11 +130,9 @@ fn validate_repeat(repeat: &str) -> Result<(), RuntimeError> {
     Ok(())
 }
 
-/// Validate that `action` is parseable DSL via `khive_request::parse_request`.
-///
-/// This catches garbage like `"x"` or `"bogus-not-a-valid-verb()"` at write
-/// time rather than at trigger time, when nobody is watching. Returns the
-/// parsed request so callers can inspect the verb names without re-parsing.
+/// Validates `action` parses as DSL via `khive_request::parse_request`,
+/// catching garbage at write time rather than trigger time. Returns the
+/// parsed request so callers can inspect verb names without re-parsing.
 fn validate_action(action: &str) -> Result<khive_request::ParsedRequest, RuntimeError> {
     khive_request::parse_request(action).map_err(|e| {
         RuntimeError::InvalidInput(format!(
@@ -170,18 +142,11 @@ fn validate_action(action: &str) -> Result<khive_request::ParsedRequest, Runtime
     })
 }
 
-/// Validate that a parsed `schedule.schedule` action can be replayed exactly
-/// as stored (issue #461).
-///
-/// The pending-events runner reparses the stored DSL at trigger time and
-/// dispatches it through the normal request surface. For that replay to
-/// succeed it must be a single op against an exactly-registered handler name
-/// (not a bare shorthand resolved via a `schedule.{tool}` fallback), with
-/// only literal argument values (no `$prev` references, which are only
-/// meaningful inside a chain the replay path does not reconstruct) and all
-/// required handler parameters present. Rejecting anything else here, at
-/// write time, prevents storing an action that is guaranteed to fail (and be
-/// silently marked "fired") when it comes due.
+/// Validates a parsed `schedule.schedule` action can be replayed exactly as
+/// stored (issue #461): single op, exactly-registered handler, literal args
+/// only, all required params present, and no handler that treats
+/// `namespace` as a business arg (issue #461/#462). See
+/// `docs/replay-validation.md#validate_replayable_single_action`.
 fn validate_replayable_single_action(
     parsed: &khive_request::ParsedRequest,
     registry: &VerbRegistry,
@@ -215,20 +180,8 @@ fn validate_replayable_single_action(
         }
     }
 
-    // Reject any handler whose schema declares `namespace` as a business
-    // param (issue #461/#462). `dispatch_action` in `pending_events.rs`
-    // unconditionally injects the firing event's routing namespace into
-    // every op's args, and the registry passes it through unchanged
-    // whenever the handler declares `namespace` (`khive-runtime/src/pack.rs`).
-    // For handlers that treat `namespace` as a business param (e.g.
-    // `brain.bind`, `brain.resolve`), that silently changes the business
-    // value on replay — even when the *stored* action omitted `namespace`
-    // entirely (e.g. `brain.bind` defaults an omitted `namespace` to the
-    // wildcard `"*"` at write time; replay would instead bind it to
-    // whatever namespace the event happens to fire from). Replay cannot yet
-    // carry routing-namespace and arg-namespace as separate concepts, so
-    // reject at write time based on the handler's schema alone, regardless
-    // of whether the stored args happen to include `namespace`.
+    // Reject handlers whose schema declares `namespace` as a business param
+    // (issue #461/#462) — see docs/replay-validation.md#validate_replayable_single_action.
     let handler_accepts_namespace =
         help.get("params")
             .and_then(Value::as_array)
@@ -251,31 +204,11 @@ fn validate_replayable_single_action(
     validate_conditional_requirements(&op.tool, &op.args, registry)
 }
 
-/// Reject scheduled actions known to fail a handler's *conditional* required
-/// param even though `describe_verb` marks none of the alternatives
-/// `required:true` (issue #461).
-///
-/// `validate_args_against_help` only enforces metadata-declared
-/// `required:true` params. Some handlers accept one of several alternative
-/// arg sets (e.g. `create` requires `kind` unless bulk `items` is given), so
-/// neither alternative is marked required in metadata and both can be
-/// omitted at write time — then fail at trigger-time replay. This function
-/// hard-codes the known cases; it is not a general conditional-requirements
-/// mechanism (there is no metadata surface for that yet), so it does not
-/// guarantee every handler-internal semantic precondition is caught.
-///
-/// For `tool == "create"`, this mirrors the singleton branches of the KG
-/// pack's own `handle_create` (`khive-pack-kg/src/handlers/create.rs`):
-/// entity/granular-entity creates require `name`, note/granular-note creates
-/// require `content`, and a bare `kind="entity"` requires an `entity_kind`
-/// (or a granular entity kind) to resolve a concrete kind. It also validates
-/// `entity_type` against the KG entity-type/subtype registry when present
-/// — see `validate_entity_type_for_replay`.
-/// `khive-pack-schedule` does not depend on `khive-pack-kg` (only as a
-/// dev-dependency for tests), so this reimplements the classification using
-/// `VerbRegistry::all_entity_kinds` / `all_note_kinds` — the same data
-/// `resolve_kind_spec` consults — rather than importing the KG pack's
-/// private helpers.
+/// Rejects scheduled actions known to fail a handler's *conditional*
+/// required param even though `describe_verb` marks none of the
+/// alternatives `required:true` (issue #461) — hard-codes the `create`
+/// kind/name/content cases. See
+/// `docs/replay-validation.md#validate_conditional_requirements`.
 fn validate_conditional_requirements(
     tool: &str,
     args: &std::collections::BTreeMap<String, khive_request::ArgValue>,
@@ -395,23 +328,10 @@ enum CreateKindClass {
     Note { specific: Option<String> },
 }
 
-/// Classify a `create(kind=...)` value the same way
-/// `khive-pack-kg::handlers::common::resolve_kind_spec` does: literal
-/// substrate keywords first, then base-8-kind aliases (`khive_types::EntityKind`,
-/// e.g. `"paper"` -> `document` — a real, non-dev dependency already shared
-/// with khive-pack-kg, so this is genuine reuse, not a hand-copy), then the
-/// pack-local `resource`-kind alias set (`"atom"`, `"runbook"`, etc. ->
-/// `resource`, ADR-048; hand-copied via `resource_alias_for_replay` since
-/// `khive-pack-kg::vocab::EntityKind` is pack-private — see that function's
-/// doc comment), then the registry's merged entity/note-kind vocabulary (the
-/// same final fallback `resolve_kind_spec` uses). Returns an error for any
-/// `kind` that is guaranteed to fail replay outright: `edge` (create edges
-/// via `link`), `event` (immutable), `proposal` (create via `propose`), or
-/// an unrecognized kind string.
-///
-/// The pre-fix version skipped alias resolution
-/// entirely, causing schedule-time false rejections (not a security hole)
-/// for legitimate KG-accepted spellings like `"paper"` and `"atom"`.
+/// Classifies a `create(kind=...)` value mirroring
+/// `khive-pack-kg::handlers::common::resolve_kind_spec`; errors on any kind
+/// guaranteed to fail replay (`edge`, `event`, `proposal`, unrecognized). See
+/// `docs/replay-validation.md#classify_create_kind`.
 fn classify_create_kind(
     raw: &str,
     registry: &VerbRegistry,
@@ -471,21 +391,9 @@ fn classify_create_kind(
     )))
 }
 
-/// Canonicalize a legacy `entity_kind` value the same way
-/// `khive-pack-kg::handlers::common::canonical_entity_kind` does: try the
-/// base `khive_types::EntityKind` parser (the 8 base kinds plus its common
-/// aliases, e.g. `"paper"` -> `document`; a real, non-dev dependency already
-/// shared with khive-pack-kg — genuine reuse, not a hand-copy), then the
-/// pack-local `resource`-kind alias set (`"atom"`, `"runbook"`, etc. ->
-/// `resource`, ADR-048; hand-copied via `resource_alias_for_replay` since
-/// `khive-pack-kg::vocab::EntityKind` is pack-private and
-/// `khive-pack-schedule` does not depend on `khive-pack-kg` in production —
-/// dev-dependency only, for tests), then fall back to the registry's merged
-/// entity-kind vocabulary (covers any further pack-declared additions).
-///
-/// The pre-fix version resolved neither alias
-/// set, causing schedule-time false rejections (not a security hole) for
-/// legitimate KG-accepted spellings like `"paper"` and `"atom"`.
+/// Canonicalizes a legacy `entity_kind` value mirroring
+/// `khive-pack-kg::handlers::common::canonical_entity_kind`. See
+/// `docs/replay-validation.md#canonical_entity_kind_for_replay-canonical_note_kind_for_replay`.
 fn canonical_entity_kind_for_replay(
     raw: &str,
     registry: &VerbRegistry,
@@ -508,10 +416,9 @@ fn canonical_entity_kind_for_replay(
     )))
 }
 
-/// Canonicalize a legacy `note_kind` value the same way
-/// `khive-pack-kg::handlers::common::canonical_note_kind` does. Note kinds
-/// carry no alias set beyond their 5 canonical names (ADR-013), so this is
-/// exactly the registry's merged note-kind vocabulary check.
+/// Canonicalizes a legacy `note_kind` value mirroring
+/// `khive-pack-kg::handlers::common::canonical_note_kind`; note kinds carry
+/// no alias set beyond their 5 canonical names (ADR-013).
 fn canonical_note_kind_for_replay(
     raw: &str,
     registry: &VerbRegistry,
@@ -528,19 +435,11 @@ fn canonical_note_kind_for_replay(
     )))
 }
 
-/// Pack-local `resource`-kind aliases (ADR-048), mirroring
-/// `khive-pack-kg::vocab::EntityKind`'s `FromStr` arm `"resource" | "atom" |
-/// "runbook" | "template" | "prompt" | "skill" | "tool"`
-/// (`khive-pack-kg/src/vocab.rs`). That type is `pub(crate)` to
-/// `khive-pack-kg` and `khive-pack-schedule` does not depend on
-/// `khive-pack-kg` in production (dev-dependency only, for tests), so this
-/// hand-copies just the alias set — six short strings — rather than the
-/// type. `normalized` must already be trimmed + lowercased (callers already
-/// compute this for the registry-vocabulary fallback). Kept in sync by
-/// `entity_kind_resource_aliases_match_real_vocab` in `create_validation.rs`,
-/// which asserts this list against the live `khive-pack-kg` vocab (via the
-/// dev-dependency) so drift is caught in CI rather than silently reproducing
-/// a similar false rejection.
+/// Hand-copied ADR-048 `resource`-kind alias set mirroring
+/// `khive-pack-kg::vocab::EntityKind`'s `FromStr` arm (that type is
+/// pack-private). `normalized` must already be trimmed + lowercased. Kept in
+/// sync with the CI-checked `entity_kind_resource_aliases_match_real_vocab`
+/// test. See `docs/replay-validation.md#resource_alias_for_replay`.
 fn resource_alias_for_replay(normalized: &str) -> bool {
     matches!(
         normalized,
@@ -548,27 +447,12 @@ fn resource_alias_for_replay(normalized: &str) -> bool {
     )
 }
 
-/// Validate an `entity_type` value the same way
-/// `khive-pack-kg::handlers::common::validate_entity_type` does: parse
-/// `canonical_kind_name` into the base `khive_types::EntityKind` first, then
-/// resolve the subtype against the boot-time composed registry (builtin
-/// subtypes plus every loaded pack's `ENTITY_TYPES`, `VerbRegistry::
-/// all_entity_types`) — NOT the builtin-only `EntityTypeRegistry::global()`.
-/// KG create validation and schedule replay validation resolve against the
-/// exact same composed set, so this cannot drift from the real handler's
-/// vocabulary, and a scheduled `create` naming a pack-declared subtype (e.g.
-/// git's `adr` Document subtype) is accepted at schedule time exactly when
-/// the real handler would accept it at trigger time.
-///
-/// The kind-parse step is exactly what makes a pack-owned kind like
-/// `"resource"` reject *any* non-`None` `entity_type` outright: `resource`
-/// has no variant in the base 8-kind enum, so parsing `canonical_kind_name`
-/// fails before the subtype table is even consulted — the real handler has
-/// this same short-circuit (`khive-pack-kg/src/handlers/common.rs`,
-/// `validate_entity_type`), verified live via `kkernel exec` against a
-/// scratch DB. This mirrors that behavior rather than "fixing" it: the
-/// contract here is bit-for-bit replay parity with the real handler, not
-/// what the real handler arguably should do.
+/// Validates an `entity_type` value mirroring bit-for-bit
+/// `khive-pack-kg::handlers::common::validate_entity_type`'s replay parity,
+/// resolving subtypes against the boot-time composed registry (builtin +
+/// every loaded pack's `ENTITY_TYPES`), not the builtin-only
+/// `EntityTypeRegistry::global()`. See
+/// `docs/replay-validation.md#validate_entity_type_for_replay`.
 fn validate_entity_type_for_replay(
     canonical_kind_name: &str,
     entity_type: Option<&str>,
@@ -588,14 +472,11 @@ fn validate_entity_type_for_replay(
         .map_err(RuntimeError::from)
 }
 
-/// Reconcile a granular `kind`'s resolved `specific` value against a legacy
+/// Reconciles a granular `kind`'s resolved `specific` value against a legacy
 /// `entity_kind`/`note_kind` argument, mirroring
-/// `khive-pack-kg::handlers::common::reconcile_specific` exactly (including
-/// the contradiction error shape) so a scheduled action that the real KG
-/// `create` handler would reject for a kind/legacy-kind contradiction is
-/// rejected at schedule time too, not only discovered at trigger-time replay.
-/// `context` prefixes error messages (e.g. `"items[3] "` for a bulk entry,
-/// `""` for the singleton path).
+/// `khive-pack-kg::handlers::common::reconcile_specific` exactly. `context`
+/// prefixes error messages (e.g. `"items[3] "` for a bulk entry). See
+/// `docs/replay-validation.md#reconcile_specific_for_replay`.
 fn reconcile_specific_for_replay(
     context: &str,
     spec_specific: Option<String>,

--- a/crates/khive-quant/docs/design-notes.md
+++ b/crates/khive-quant/docs/design-notes.md
@@ -1,0 +1,16 @@
+# Design notes
+
+Background for maintainers on design decisions behind the public codecs in
+`src/lib.rs`. The doc-comments on those types carry the complete API contract
+already — this file is historical/rationale context only.
+
+## `GsSq8Codec` — why global-scale, not per-dimension anisotropy gating
+
+The predecessor per-dim codec required `approx_l2_sq_fast` plus an anisotropy
+gate (ratio ≤ 4.0) to achieve the integer-only hot path. The gate was
+calibrated on an LCG corpus that gave ratio ≈ 4.0; real transformer embeddings
+have rogue dimensions (ratio 10–32) that silently fell back to the full
+residual path, defeating the purpose. Global-scale eliminates the gate
+entirely — see ADR-052.
+
+Source: `crates/khive-quant/src/lib.rs`.

--- a/crates/khive-quant/src/lib.rs
+++ b/crates/khive-quant/src/lib.rs
@@ -616,13 +616,9 @@ impl Sq8Codec {
 /// the original f32 L2² can reach ~15% for anisotropic or out-of-distribution data.
 /// Recall safety must be established by probe (see `sq8_recall_parity_vs_f32_oracle`
 /// and `sq8_ood_fallback_deterministic_ranking_flip`), not by an exactness argument.
-/// No residual pass, no gate, no silent fallback for anisotropic data.
-///
-/// Historical note: the predecessor per-dim codec required `approx_l2_sq_fast` + an
-/// anisotropy gate (ratio ≤ 4.0) to achieve the integer-only hot path. The gate was
-/// calibrated on an LCG corpus that gave ratio ≈ 4.0; real transformer embeddings
-/// have rogue dimensions (ratio 10–32) that silently fell back to the full residual
-/// path, defeating the purpose. Global-scale eliminates the gate entirely — see ADR-052.
+/// No residual pass, no gate, no silent fallback for anisotropic data. See
+/// `docs/design-notes.md#gssq8codec--why-global-scale-not-per-dimension-anisotropy-gating`
+/// for why this replaced the earlier per-dim anisotropy-gated design.
 #[derive(Debug, Clone)]
 pub struct GsSq8Codec {
     /// Per-dimension minimum values.

--- a/crates/khive-vcs/docs/test-rationale.md
+++ b/crates/khive-vcs/docs/test-rationale.md
@@ -1,0 +1,61 @@
+# Test rationale — `src/sync.rs` regression tests
+
+Background for maintainers reading the `#[cfg(test)] mod tests` block in
+`src/sync.rs`. None of this is public API; it explains why specific
+regression tests exist.
+
+## `sync_chunk_boundary_round_trip`
+
+Chunk-boundary round-trip: writes N > `SYNC_CHUNK_SIZE` entities and edges so
+the batching path exercises at least two transaction boundaries, then
+verifies the full count and spot-checks the last record of the final chunk.
+In test builds `SYNC_CHUNK_SIZE = 5`, so N = 11 produces three chunks
+(5 + 5 + 1) for both entities and edges.
+
+## `run_sync_remote_cannot_be_constructed_with_invalid_name`
+
+Issue #474: `run_sync_remote("../evil" | "/tmp/evil" | "safe/name")` must be
+impossible to even construct — `RemoteConfig::name` is a `RemoteName`, and
+`RemoteName::parse` is its only constructor — so these names never reach
+`run_sync_remote`'s cache-directory join. Confirms both the construction-time
+rejection AND (via filesystem check) that nothing was created at the
+traversal targets or under `.khive/kg/remotes/`.
+
+## `public_error_redacts_https_credential_url`
+
+git echoes credential-bearing HTTPS URLs in its stderr on auth failure, e.g.:
+`fatal: Authentication failed for 'https://user:token@host/repo.git'`. The
+sanitiser must strip that before it reaches the caller; this test confirms an
+HTTPS URL with embedded `user:pass` credentials never appears in the public
+error string produced by a clone failure.
+
+## `public_error_redacts_scp_style_remote`
+
+Exercises the FAIL-before/PASS-after property of the scp-style credential
+fix: the sanitiser is called on the raw git stderr, which git may populate
+with lines like `fatal: Could not read from remote repository.` that do NOT
+contain the URL — so for scp remotes that fail at DNS/SSH level the URL is
+not re-echoed by git. What this test asserts is that the sanitiser IS wired
+into the error path and that the rendered error does not include the scp
+token (`git@host:org/repo.git`) from any source. The companion unit tests
+`redact_strips_scp_style_remote` and `redact_strips_user_at_host_colon_path`
+directly verify the sanitiser strips scp tokens from git stderr strings;
+this test confirms the wiring.
+
+## `sync_fts_document_matches_entity_fts_document`
+
+Regression: the VCS sync FTS document must be field-identical to
+`entity_fts_document` output for the same entity. Before this fix,
+`upsert_entities` built a `TextDocument` inline with slightly different field
+mapping than the canonical helper, which could produce divergent FTS shapes
+when the helper is updated.
+
+## `wal_checkpoint_truncate_via_plain_execute_script_fails_with_write_queue_enabled`
+
+Revert-and-confirm-fails companion: the OLD (broken) call shape — plain
+`execute_script`, which wraps the pragma in the WriterTask's `BEGIN
+IMMEDIATE` — must fail under the write queue. This proves the paired
+"succeeds" test is actually exercising the regression fix, not passing
+vacuously.
+
+Source: `crates/khive-vcs/src/sync.rs`.

--- a/crates/khive-vcs/src/sync.rs
+++ b/crates/khive-vcs/src/sync.rs
@@ -1213,12 +1213,8 @@ mod tests {
         assert_eq!(alpha.kind, "concept");
     }
 
-    /// Chunk-boundary round-trip: write N > SYNC_CHUNK_SIZE entities and edges
-    /// so the batching path exercises at least two transaction boundaries, then
-    /// verify the full count and spot-check the last record of the final chunk.
-    ///
-    /// In test builds SYNC_CHUNK_SIZE = 5, so N = 11 produces three chunks
-    /// (5 + 5 + 1) for both entities and edges.
+    /// Chunk-boundary round-trip across `SYNC_CHUNK_SIZE`. See
+    /// `docs/test-rationale.md#sync_chunk_boundary_round_trip`.
     #[tokio::test]
     async fn sync_chunk_boundary_round_trip() {
         const N: usize = 11; // > SYNC_CHUNK_SIZE (5 in test mode)
@@ -1820,12 +1816,8 @@ mod tests {
         }
     }
 
-    /// #474: `run_sync_remote("../evil" | "/tmp/evil" | "safe/name")` must be
-    /// impossible to even construct — `RemoteConfig::name` is a `RemoteName`,
-    /// and `RemoteName::parse` is its only constructor — so these names never
-    /// reach `run_sync_remote`'s cache-directory join. Confirm both the
-    /// construction-time rejection AND (via filesystem check) that nothing
-    /// was created at the traversal targets or under `.khive/kg/remotes/`.
+    /// Issue #474: path-traversal remote names must be unconstructable. See
+    /// `docs/test-rationale.md#run_sync_remote_cannot_be_constructed_with_invalid_name`.
     #[tokio::test]
     async fn run_sync_remote_cannot_be_constructed_with_invalid_name() {
         let repo_dir = TempDir::new().unwrap();
@@ -2368,12 +2360,8 @@ mod tests {
     // combined with these wiring tests that confirm the sanitised output is what
     // the caller actually sees in `err.to_string()`.
 
-    /// HTTPS URL with embedded `user:pass` credentials must not appear in the
-    /// public error string produced by a clone failure.
-    ///
-    /// git echoes credential-bearing HTTPS URLs in its stderr on auth failure,
-    /// e.g.: `fatal: Authentication failed for 'https://user:token@host/repo.git'`
-    /// The sanitiser must strip that before it reaches the caller.
+    /// Credential-bearing HTTPS URLs must not leak into the public error
+    /// string. See `docs/test-rationale.md#public_error_redacts_https_credential_url`.
     #[tokio::test]
     async fn public_error_redacts_https_credential_url() {
         let repo_dir = tempfile::TempDir::new().unwrap();
@@ -2411,20 +2399,8 @@ mod tests {
         );
     }
 
-    /// scp-style `git@host:org/repo.git` must not leak through the sanitiser
-    /// into the public error string.
-    ///
-    /// This test exercises the FAIL-before/PASS-after property of the scp fix:
-    /// the sanitiser is called on the raw git stderr, which git may populate with
-    /// lines like `fatal: Could not read from remote repository.` that do NOT
-    /// contain the URL — so for scp remotes that fail at DNS/SSH level the URL
-    /// is not re-echoed by git.  What we assert here is that the sanitiser IS
-    /// wired into the error path and that the rendered error does not include the
-    /// scp token from any source.
-    ///
-    /// The companion unit tests `redact_strips_scp_style_remote` and
-    /// `redact_strips_user_at_host_colon_path` directly verify the sanitiser
-    /// strips scp tokens from git stderr strings; this test confirms the wiring.
+    /// scp-style `git@host:org/repo.git` must not leak through the sanitiser.
+    /// See `docs/test-rationale.md#public_error_redacts_scp_style_remote`.
     #[tokio::test]
     async fn public_error_redacts_scp_style_remote() {
         let repo_dir = tempfile::TempDir::new().unwrap();
@@ -2467,10 +2443,8 @@ mod tests {
     }
 
     /// Regression: VCS sync FTS document must be field-identical to
-    /// `entity_fts_document` output for the same entity.  Before this fix,
-    /// `upsert_entities` built a `TextDocument` inline with slightly different
-    /// field mapping than the canonical helper, which could produce divergent
-    /// FTS shapes when the helper is updated.
+    /// `entity_fts_document`'s output. See
+    /// `docs/test-rationale.md#sync_fts_document_matches_entity_fts_document`.
     #[test]
     fn sync_fts_document_matches_entity_fts_document() {
         use khive_runtime::entity_fts_document;
@@ -2606,11 +2580,8 @@ mod checkpoint_wal_write_queue_tests {
         );
     }
 
-    /// Revert-and-confirm-fails companion: the OLD (broken) call shape —
-    /// plain `execute_script`, which wraps the pragma in the WriterTask's
-    /// `BEGIN IMMEDIATE` — must fail under the write queue. This proves the
-    /// test above is actually exercising the regression, not passing
-    /// vacuously.
+    /// Revert-and-confirm-fails companion to the test above. See
+    /// `docs/test-rationale.md#wal_checkpoint_truncate_via_plain_execute_script_fails_with_write_queue_enabled`.
     #[tokio::test]
     async fn wal_checkpoint_truncate_via_plain_execute_script_fails_with_write_queue_enabled() {
         let dir = tempfile::tempdir().expect("tempdir");


### PR DESCRIPTION
## What

Condense verbose inline doc-comments in `khive-pack-gtd,khive-pack-schedule khive-quant,khive-vcs` and relocate long-form rationale, algorithm walkthroughs, and background prose into per-crate `docs/*.md` guides. Part of the rustdoc condense-and-extract pass.

## Preserved (information relocation, not deletion)

- Public API doc-comments stay **complete and standalone** — the docs.rs reference is intact; a caller can use each public item from its doc-comment alone.
- No `# Safety`, invariant, ordering, precision, or error-enumeration docs were thinned.
- schemars/clap product-surface doc-comments (MCP tool schema, CLI `--help`) left verbatim.
- Every substantive fact removed from a `.rs` doc-comment was moved into a crate guide under the crate's `docs/` directory, not dropped.

## Scope

Only the `src` and `docs` trees of the crates above. Diffstat: 8 files changed, 379 insertions(+), 262 deletions(-).

Branch forked before recent doc merges; will be updated onto main and code-reviewed before marking ready.