### PR TITLE
docs(rustdoc): condense inline docs + extract to guides (khive-channel-email,khive-pack-brain khive-pack-knowledge)

### DIFF
--- a/crates/khive-channel-email/docs/auth-results-parsing.md
+++ b/crates/khive-channel-email/docs/auth-results-parsing.md
@@ -1,0 +1,106 @@
+# `Authentication-Results` header parsing (RFC 8601 structural subset)
+
+Source: `crates/khive-channel-email/src/auth_results.rs` (all items in this module are
+`pub(crate)`/private — internal to the crate, not part of the published API).
+
+## Why this module exists
+
+`mail-parser` has no structured support for the `Authentication-Results` header — it is
+not one of the RFC 5322 shapes it recognizes, so it always falls through to
+`HeaderValue::Text` (or `TextList` when duplicated) via the generic `Other` header path.
+This module hand-parses only what the attribution gate needs: the `authserv-id`, and the
+`dmarc`/`spf`/`dkim` method verdicts plus the `header.d` / `smtp.mailfrom` / `header.from`
+alignment properties.
+
+## Segment splitting (`split_top_level_segments`)
+
+The top-level split into `resinfo` segments is CFWS-aware: it walks the raw header value
+once, tracking quoted-string state (honoring `\` escapes) and `(...)` comment nesting
+(RFC 5322 comments nest), and only treats a `;` as a segment boundary when it appears
+outside both. Comments are stripped entirely before segment text is retained;
+quoted-string content is kept verbatim (including any `;` or `=` it contains) as part of
+the single segment it belongs to. This guarantees a `;` inside a `reason="..."` quoted
+pvalue or inside a `(...)` comment can never manufacture an additional, unintended
+`method=result` segment — see `parse_header_reason_quoted_semicolon_does_not_forge_dmarc_pass`
+and `parse_header_comment_semicolon_does_not_forge_dmarc_pass` in the test module. It does
+not attempt full ABNF conformance beyond that (e.g. `ptype.property` values containing bare
+`=`) — those are tolerated as harmless unmatched tokens, never as false positives against
+the three keys this module actually reads.
+
+## Whitespace tokenizing (`split_top_level_ws`)
+
+The second of two delimiter layers: the segment scanner above finds `;` boundaries; this
+one finds whitespace boundaries within a segment. Both share the same quoted-pair
+semantics (`\` plus the following character is one atomic unit, regardless of what that
+character is), but this layer never sees `(...)` comments — those were already discarded
+by the segment scanner. A token is returned verbatim, including any retained quote and
+backslash characters; it is never unquoted.
+
+Malformed input (an unmatched `"`, or a `\` as the final character while quoted) is
+handled conservatively: the remainder of the segment is retained as one atomic token
+through EOF rather than resuming whitespace splitting, so a malformed quoted tail can
+never be reinterpreted as additional tokens — see
+`split_top_level_ws_keeps_malformed_quoted_tail_atomic`.
+
+## `contains_unquoted`
+
+Returns true if `target` occurs anywhere in `token` *outside* of a quoted-string span,
+using the same quoted-pair (`\`) escaping semantics as `split_top_level_ws`. A plain
+`str::contains` would treat a `=` inside a quoted value (e.g. a quoted `authserv-id` like
+`"id=foo"`, which RFC 8601 §2.2 permits as a valid `value`) the same as an unquoted `=`,
+even though the tokenizer that produced `token` already knows the difference — this keeps
+the classification consistent with that state.
+
+## `parse_header`
+
+Detects two shapes for the first `resinfo`-or-authserv-id segment:
+
+- **RFC 8601 form**: the first whitespace token of the first top-level segment is the
+  `authserv-id` (a dot-atom/value that can never contain an unquoted `=`). The remaining
+  segments are parsed as `resinfo` entries.
+- **No-authserv-id form** (observed from Exchange Online's internal-hop stamp): the first
+  whitespace token of the first segment itself contains an unquoted `=`, which is
+  impossible for a valid authserv-id and unambiguous for a `resinfo`
+  (`method[/version]=result`). In this case `authserv_id` is set to `None` and segment 0
+  is parsed as a `resinfo` entry through the *same* loop as every other segment — it is
+  never discarded as a (nonexistent) authserv-id.
+
+Returns `None` when no signal can be extracted at all: an empty/whitespace header (no
+first token), or — in the no-authserv-id form only — a header whose segments contain no
+recognized `dmarc`/`spf`/`dkim` method entry anywhere. In the RFC 8601 form, a non-empty
+authserv-id with no method the gate recognizes still parses successfully to an
+`AuthResults` with empty method vectors (unchanged from prior behavior) — the gate treats
+"no recognized passing method" uniformly regardless of which of those it was.
+
+The unquoted-`=` detection (`is_no_authserv_id_form`) must use the same quote-state
+machine as `split_top_level_ws` (via `contains_unquoted`), not a raw `str::contains`: RFC
+8601 §2.2 permits a quoted-string `authserv-id` value, and a `=` sealed inside that
+quoting is not a resinfo delimiter — treating it as one would let a quoted authserv-id be
+misclassified as the no-authserv-id form, which `TrustAnchor::TopmostNoAuthservId` treats
+as a strictly weaker, position-only trust signal than a real authserv-id match.
+
+The optional method-version suffix (`method/version=result`, RFC 8601 §2.2) is supported
+only for version `1` (absent suffix is implicitly version 1); §2.6 requires consumers to
+IGNORE resinfo for a method version they do not support, so anything else skips the whole
+segment rather than being silently trusted as the current version.
+
+## `select_trusted`
+
+Selects the trusted `Authentication-Results` header per the configured `TrustAnchor`
+(ADR-056 Amendment 2026-07-03, "EXO no-authserv-id trust anchor"):
+
+- `TrustAnchor::AuthservId`: the first (topmost) header, in document order, whose
+  `authserv-id` matches the configured id (case-insensitive). Topmost wins: a receiving
+  MTA prepends its own stamp on each hop, so the header nearest the top of the document is
+  the one added by the final, trusted receiving boundary — PROVIDED that boundary strips
+  or renames any pre-existing header already claiming its own `authserv-id` before adding
+  its stamp. That stripping is an operational precondition of the receiving MTA, verified
+  by deployment configuration, not re-derived from message content here.
+- `TrustAnchor::TopmostNoAuthservId`: the boundary emits no authserv-id at all (e.g.
+  Exchange Online's internal-hop stamp), so position is the *sole* discriminator. Only the
+  literal topmost `Authentication-Results` header (`raw_headers[0]`) is ever considered —
+  never a later one, even if the topmost fails to parse. It is trusted only if it parses
+  AND is itself in the no-authserv-id form (`authserv_id.is_none()`); if the topmost
+  carries any authserv-id, or fails to parse, that violates the invariant that this
+  boundary's own stamp is topmost and unadorned, so the message quarantines (fails closed)
+  rather than falling through to a lower header.

--- a/crates/khive-channel-email/docs/backoff-and-retry.md
+++ b/crates/khive-channel-email/docs/backoff-and-retry.md
@@ -1,0 +1,47 @@
+# IMAP backoff classification
+
+Source: `crates/khive-channel-email/src/backoff.rs`
+
+## Why this module exists
+
+Per-credential IMAP guardrail: single-flight connection cap + jittered exponential
+backoff on connect/auth failure (#605).
+
+The 2026-07-04 inbound-email outage (#602) was amplified by the poll loop's flat ~5s
+retry cadence with no per-credential concurrency cap: nine concurrent pollers on
+`recipient@example.com` exhausted Exchange Online's per-mailbox connection slots, and the
+flat retry hammer kept the slots saturated for ~19h. `#602`/`#610` fixed the multi-process
+spawn that caused the concurrency; the types here make the channel degrade gracefully if
+polling pressure ever returns.
+
+## `ImapBackoff::record_failure` clamp regression guard
+
+`delay` is clamped to `max` (regression guard): jitter is additive noise on top of
+`step`, but `step` itself can already equal `max` once escalation saturates, so an
+unclamped `step + jitter` would let a "~10min cap" reach 750s at the default 25% jitter
+window. Clamping keeps `delay <= max` a hard invariant regardless of where jitter lands.
+
+## `is_backoff_eligible`
+
+Classifies whether a `ChannelError` from an IMAP poll represents connect/auth pressure
+that should back off, versus a failure that should keep the normal poll cadence.
+
+Grounded in the actual errors `crates/khive-channel-email`'s IMAP connect/auth flow
+produces (see `connector/imap.rs::LiveImap::connect` and `fetch_since`):
+
+- `ChannelError::Auth` — TLS handshake, `LOGIN`, and `XOAUTH2` failures. This is exactly
+  the credential/slot-exhaustion class from the 2026-07-04 outage ("User is authenticated
+  but not connected" surfaces here when Exchange rejects the handshake outright).
+- `ChannelError::Transport` — TCP connect, greeting read, `SELECT`, `UID SEARCH`, and
+  `UID FETCH` failures. Exchange's connection-slot exhaustion can also surface here (a
+  post-login command failing because the mailbox has no free slot), so this class backs
+  off too.
+
+Not backoff-eligible:
+
+- `ChannelError::Config` — static misconfiguration; backing off would only delay an
+  operator noticing and fixing it faster.
+- `ChannelError::UnauthorizedSender` — a per-message attribution gate failure, not a
+  connectivity failure; never produced by `poll`/`connect`.
+- `ChannelError::InvalidEnvelope` — malformed data, not connectivity; never produced by
+  `poll`/`connect`.

--- a/crates/khive-channel-email/docs/oauth-notes.md
+++ b/crates/khive-channel-email/docs/oauth-notes.md
@@ -1,0 +1,15 @@
+# OAuth2 / XOAUTH2 internals
+
+Source: `crates/khive-channel-email/src/oauth.rs`
+
+## `xoauth2_sasl` (test-only reference implementation)
+
+Production code uses `lettre` and `async-imap` directly, not this helper — it exists in
+tests to verify the wire encoding matches what those libraries actually send.
+
+For SMTP, `lettre`'s `Mechanism::Xoauth2` constructs the same raw bytes internally via
+`Credentials::new(mailbox, access_token)`.
+
+For IMAP, `XOAuth2Authenticator::process` returns the **raw** bytes; async-imap 0.9
+base64-encodes them before sending (see `do_auth_handshake` in async-imap
+`client.rs:282`). Both paths are therefore wire-equivalent.

--- a/crates/khive-channel-email/src/auth_results.rs
+++ b/crates/khive-channel-email/src/auth_results.rs
@@ -1,27 +1,13 @@
 //! RFC 8601 `Authentication-Results` header parsing (structural subset).
 //!
-//! `mail-parser` has no structured support for this header -- it is not one of
-//! the RFC 5322 shapes it recognizes, so it always falls through to
-//! `HeaderValue::Text` (or `TextList` when duplicated) via the generic `Other`
-//! header path. This module hand-parses only what the attribution gate needs:
-//! the `authserv-id`, and the `dmarc`/`spf`/`dkim` method verdicts plus the
-//! `header.d` / `smtp.mailfrom` / `header.from` alignment properties.
-//!
-//! The top-level split into `resinfo` segments is CFWS-aware: it walks the raw
-//! header value once, tracking quoted-string state (honoring `\` escapes) and
-//! `(...)` comment nesting (RFC 5322 comments nest), and only treats a `;` as a
-//! segment boundary when it appears outside both. Comments are stripped
-//! entirely before segment text is retained; quoted-string content is kept
-//! verbatim (including any `;` or `=` it contains) as part of the single
-//! segment it belongs to. This guarantees a `;` inside a `reason="..."`
-//! quoted pvalue or inside a `(...)` comment can never manufacture an
-//! additional, unintended `method=result` segment -- see
-//! `parse_header_reason_quoted_semicolon_does_not_forge_dmarc_pass` and
-//! `parse_header_comment_semicolon_does_not_forge_dmarc_pass` below. It does
-//! not attempt full ABNF conformance beyond that (e.g. `ptype.property`
-//! values containing bare `=`) -- those are tolerated as harmless unmatched
-//! tokens, never as false positives against the three keys this module
-//! actually reads.
+//! Hand-parsed because `mail-parser` has no structured support for this header.
+//! Extracts only what the attribution gate needs: `authserv-id`, and the
+//! `dmarc`/`spf`/`dkim` verdicts plus their `header.d` / `smtp.mailfrom` /
+//! `header.from` alignment properties. CFWS-aware (quoted strings, nested
+//! comments) so a `;` or `=` inside a quoted pvalue or comment can never forge
+//! an extra segment. See crates/khive-channel-email/docs/auth-results-parsing.md
+//! for the full parsing walkthrough and the two-shapes (RFC 8601 /
+//! no-authserv-id) detection rationale.
 
 use std::collections::HashMap;
 
@@ -125,13 +111,8 @@ fn domain_of(value: &str) -> String {
     }
 }
 
-/// Split a raw `Authentication-Results` header value into top-level
-/// `resinfo` segments on `;`, tracking RFC 5322 quoted-string state (with `\`
-/// escapes) and `(...)` comment nesting so a `;` inside either is never
-/// treated as a segment boundary. Comment text is stripped entirely (CFWS is
-/// insignificant for token purposes); quoted-string text -- including any `;`
-/// or `=` inside it -- is preserved verbatim as part of its enclosing
-/// segment.
+/// Split a raw header value into top-level `resinfo` segments on `;`,
+/// quote/comment-aware. See crates/khive-channel-email/docs/auth-results-parsing.md#segment-splitting-split_top_level_segments.
 fn split_top_level_segments(raw: &str) -> Vec<String> {
     let mut segments = Vec::new();
     let mut current = String::new();
@@ -185,25 +166,10 @@ fn split_top_level_segments(raw: &str) -> Vec<String> {
     segments
 }
 
-/// Split one top-level `resinfo` segment (already produced by
-/// [`split_top_level_segments`], so comments are already stripped and only
-/// quoted semicolons can remain) into whitespace-delimited tokens, tracking
-/// RFC 5322 quoted-string state (with `\` escapes) so quoted whitespace is
-/// never treated as a token boundary.
-///
-/// This is the second of two delimiter layers: the segment scanner above
-/// finds `;` boundaries; this one finds whitespace boundaries within a
-/// segment. Both share the same quoted-pair semantics (`\` plus the
-/// following character is one atomic unit, regardless of what that character
-/// is), but this layer never sees `(...)` comments -- those were already
-/// discarded by the segment scanner. A token is returned verbatim, including
-/// any retained quote and backslash characters; it is never unquoted.
-///
-/// Malformed input (an unmatched `"`, or a `\` as the final character while
-/// quoted) is handled conservatively: the remainder of the segment is
+/// Split one top-level `resinfo` segment (from [`split_top_level_segments`])
+/// into whitespace-delimited tokens, quote-aware. Malformed quoted input is
 /// retained as one atomic token through EOF rather than resuming whitespace
-/// splitting, so a malformed quoted tail can never be reinterpreted as
-/// additional tokens -- see `split_top_level_ws_keeps_malformed_quoted_tail_atomic`.
+/// splitting. See crates/khive-channel-email/docs/auth-results-parsing.md#whitespace-tokenizing-split_top_level_ws.
 fn split_top_level_ws(segment: &str) -> Vec<String> {
     let mut tokens = Vec::new();
     let mut current = String::new();
@@ -246,13 +212,10 @@ fn split_top_level_ws(segment: &str) -> Vec<String> {
     tokens
 }
 
-/// Returns true if `target` occurs anywhere in `token` *outside* of a
-/// quoted-string span, using the same quoted-pair (`\`) escaping semantics
-/// as [`split_top_level_ws`]. A plain `str::contains` would treat a `=`
-/// inside a quoted value (e.g. a quoted `authserv-id` like `"id=foo"`, which
-/// RFC 8601 §2.2 permits as a valid `value`) the same as an unquoted `=`,
-/// even though the tokenizer that produced `token` already knows the
-/// difference -- this keeps the classification consistent with that state.
+/// True if `target` occurs in `token` outside a quoted-string span (same
+/// quoted-pair semantics as [`split_top_level_ws`]) -- unlike `str::contains`,
+/// distinguishes a quoted `=` from an unquoted one. See
+/// crates/khive-channel-email/docs/auth-results-parsing.md#contains_unquoted.
 fn contains_unquoted(token: &str, target: char) -> bool {
     let mut in_quotes = false;
     let mut chars = token.chars();
@@ -281,26 +244,11 @@ fn contains_unquoted(token: &str, target: char) -> bool {
 
 /// Parse one raw `Authentication-Results` header value.
 ///
-/// Detects two shapes for the first `resinfo`-or-authserv-id segment:
-///
-/// - **RFC 8601 form**: the first whitespace token of the first top-level
-///   segment is the `authserv-id` (a dot-atom/value that can never contain an
-///   unquoted `=`). The remaining segments are parsed as `resinfo` entries.
-/// - **No-authserv-id form** (observed from Exchange Online's internal-hop
-///   stamp): the first whitespace token of the first segment itself contains
-///   an unquoted `=`, which is impossible for a valid authserv-id and
-///   unambiguous for a `resinfo` (`method[/version]=result`). In this case
-///   `authserv_id` is set to `None` and segment 0 is parsed as a `resinfo`
-///   entry through the *same* loop as every other segment -- it is never
-///   discarded as a (nonexistent) authserv-id.
-///
-/// Returns `None` when no signal can be extracted at all: an empty/whitespace
-/// header (no first token), or -- in the no-authserv-id form only -- a header
-/// whose segments contain no recognized `dmarc`/`spf`/`dkim` method entry
-/// anywhere. In the RFC 8601 form, a non-empty authserv-id with no method the
-/// gate recognizes still parses successfully to an `AuthResults` with empty
-/// method vectors (unchanged from prior behavior) -- the gate treats "no
-/// recognized passing method" uniformly regardless of which of those it was.
+/// Detects the RFC 8601 form (leading `authserv-id` token) vs. the
+/// no-authserv-id form (Exchange Online's internal-hop stamp, where the first
+/// token is itself a `resinfo`). Returns `None` only when no signal can be
+/// extracted at all -- see crates/khive-channel-email/docs/auth-results-parsing.md#parse_header
+/// for the full shape-detection contract and the empty-vs-zero-signal distinction.
 pub(crate) fn parse_header(raw: &str) -> Option<AuthResults> {
     let mut all_segments = split_top_level_segments(raw).into_iter();
     let first_segment = all_segments.next()?;
@@ -400,25 +348,15 @@ pub(crate) fn parse_header(raw: &str) -> Option<AuthResults> {
 /// [`TrustAnchor`] (ADR-056 Amendment 2026-07-03, "EXO no-authserv-id trust
 /// anchor").
 ///
-/// - [`TrustAnchor::AuthservId`]: the first (topmost) header, in document
-///   order, whose `authserv-id` matches the configured id (case-insensitive).
-///   Topmost wins: a receiving MTA prepends its own stamp on each hop, so the
-///   header nearest the top of the document is the one added by the final,
-///   trusted receiving boundary -- PROVIDED that boundary strips or renames
-///   any pre-existing header already claiming its own `authserv-id` before
-///   adding its stamp. That stripping is an operational precondition of the
-///   receiving MTA, verified by deployment configuration, not re-derived from
-///   message content here.
-/// - [`TrustAnchor::TopmostNoAuthservId`]: the boundary emits no authserv-id
-///   at all (e.g. Exchange Online's internal-hop stamp), so position is the
-///   *sole* discriminator. Only the literal topmost `Authentication-Results`
-///   header (`raw_headers[0]`) is ever considered -- never a later one, even
-///   if the topmost fails to parse. It is trusted only if it parses AND is
-///   itself in the no-authserv-id form (`authserv_id.is_none()`); if the
-///   topmost carries any authserv-id, or fails to parse, that violates the
-///   invariant that this boundary's own stamp is topmost and unadorned, so the
-///   message quarantines (fails closed) rather than falling through to a
-///   lower header.
+/// `TrustAnchor::AuthservId`: topmost header (document order) whose
+/// `authserv-id` matches the configured id, case-insensitive.
+/// `TrustAnchor::TopmostNoAuthservId`: ONLY `raw_headers[0]` is ever
+/// considered (position is the sole discriminator when no authserv-id
+/// exists); it is trusted only if it parses AND is itself in the
+/// no-authserv-id form -- any authserv-id on it, or a parse failure, fails
+/// closed to `None` rather than falling through to a lower header. See
+/// crates/khive-channel-email/docs/auth-results-parsing.md#select_trusted for
+/// the topmost-wins rationale and its receiving-MTA precondition.
 pub(crate) fn select_trusted(raw_headers: &[String], anchor: &TrustAnchor) -> Option<AuthResults> {
     match anchor {
         TrustAnchor::AuthservId(configured_id) => raw_headers

--- a/crates/khive-channel-email/src/backoff.rs
+++ b/crates/khive-channel-email/src/backoff.rs
@@ -1,13 +1,7 @@
 //! Per-credential IMAP guardrail: single-flight connection cap + jittered
-//! exponential backoff on connect/auth failure (#605).
-//!
-//! The 2026-07-04 inbound-email outage (#602) was amplified by the poll
-//! loop's flat ~5s retry cadence with no per-credential concurrency cap:
-//! nine concurrent pollers on `recipient@example.com` exhausted Exchange Online's
-//! per-mailbox connection slots, and the flat retry hammer kept the slots
-//! saturated for ~19h. `#602`/`#610` fixed the multi-process spawn that
-//! caused the concurrency; the types here make the channel degrade
-//! gracefully if polling pressure ever returns.
+//! exponential backoff on connect/auth failure (#605). See
+//! crates/khive-channel-email/docs/backoff-and-retry.md for the 2026-07-04
+//! outage (#602) this was built to prevent a recurrence of.
 
 use std::time::Duration;
 
@@ -104,12 +98,11 @@ impl ImapBackoff {
     /// step, and returns a [`BackoffTick`] carrying the jittered delay to
     /// sleep plus whether this is a new escalation edge worth a `warn!` log.
     ///
-    /// The jittered `delay` is clamped to `max` (regression guard): jitter is additive
-    /// noise on top of `step`, but `step`
-    /// itself can already equal `max` once escalation saturates, so an
-    /// unclamped `step + jitter` would let a "~10min cap" reach 750s at the
-    /// default 25% jitter window. Clamping here keeps `delay <= max` as a
-    /// hard invariant regardless of where jitter lands.
+    /// Invariant: `delay <= max` always, even once `step` has itself
+    /// saturated at `max` and jitter would otherwise push the sum over the
+    /// cap -- `delay` is explicitly clamped, not just additively jittered.
+    /// See crates/khive-channel-email/docs/backoff-and-retry.md for the
+    /// numeric example this regression guard prevents.
     pub fn record_failure(&mut self) -> BackoffTick {
         self.attempt = self.attempt.saturating_add(1);
         let step = self.step_for(self.attempt);
@@ -150,27 +143,15 @@ fn jitter(step: Duration) -> Duration {
 /// connect/auth pressure that should back off, versus a failure that should
 /// keep the normal poll cadence.
 ///
-/// Grounded in the actual errors `crates/khive-channel-email`'s IMAP
-/// connect/auth flow produces (see `connector/imap.rs::LiveImap::connect`
-/// and `fetch_since`):
-///
-/// - [`ChannelError::Auth`] -- TLS handshake, `LOGIN`, and `XOAUTH2`
-///   failures. This is exactly the credential/slot-exhaustion class from the
-///   2026-07-04 outage ("User is authenticated but not connected" surfaces
-///   here when Exchange rejects the handshake outright).
-/// - [`ChannelError::Transport`] -- TCP connect, greeting read, `SELECT`,
-///   `UID SEARCH`, and `UID FETCH` failures. Exchange's connection-slot
-///   exhaustion can also surface here (a post-login command failing because
-///   the mailbox has no free slot), so this class backs off too.
-///
-/// Not backoff-eligible:
-///
-/// - [`ChannelError::Config`] -- static misconfiguration; backing off would
-///   only delay an operator noticing and fixing it faster.
-/// - [`ChannelError::UnauthorizedSender`] -- a per-message attribution gate
-///   failure, not a connectivity failure; never produced by `poll`/`connect`.
-/// - [`ChannelError::InvalidEnvelope`] -- malformed data, not connectivity;
-///   never produced by `poll`/`connect`.
+/// Backoff-eligible: [`ChannelError::Auth`] (TLS/`LOGIN`/`XOAUTH2` failures)
+/// and [`ChannelError::Transport`] (TCP connect, greeting, `SELECT`,
+/// `UID SEARCH`/`FETCH` failures) — both can indicate connection-slot
+/// exhaustion. Not eligible: [`ChannelError::Config`] (static
+/// misconfiguration — backing off only delays the operator noticing),
+/// [`ChannelError::UnauthorizedSender`] and [`ChannelError::InvalidEnvelope`]
+/// (never produced by `poll`/`connect`). See
+/// crates/khive-channel-email/docs/backoff-and-retry.md for the incident
+/// grounding behind this classification.
 pub fn is_backoff_eligible(err: &ChannelError) -> bool {
     matches!(err, ChannelError::Auth(_) | ChannelError::Transport(_))
 }

--- a/crates/khive-channel-email/src/oauth.rs
+++ b/crates/khive-channel-email/src/oauth.rs
@@ -41,13 +41,9 @@ const ALLOWED_OAUTH_ERROR_CODES: &[&str] = &[
 ];
 
 /// Extract and allowlist an OAuth error code from a JSON error response body.
-///
-/// Parses the standardized `error` field from the response JSON.  If the field
-/// is present and its value appears in [`ALLOWED_OAUTH_ERROR_CODES`], that
-/// static string slice is returned.  Otherwise `"oauth_error"` is returned as
-/// an opaque, safe indicator.
-///
-/// The raw `body` string is **never** returned or interpolated.
+/// Returns `"oauth_error"` if the `error` field is absent or not in
+/// [`ALLOWED_OAUTH_ERROR_CODES`]. The raw `body` string is **never** returned
+/// or interpolated (see the allowlist doc above for why).
 fn sanitize_oauth_error(body: &str) -> &'static str {
     if let Ok(val) = serde_json::from_str::<serde_json::Value>(body) {
         if let Some(code) = val.get("error").and_then(|v| v.as_str()) {
@@ -65,23 +61,10 @@ fn sanitize_oauth_error(body: &str) -> &'static str {
 
 // ──────────────────────────────────────────────────── XOAUTH2 SASL helpers
 
-/// Return the XOAUTH2 SASL payload as a standard base64 string.
-///
-/// The raw SASL bytes are:
-/// ```text
-/// user=<mailbox>\x01auth=Bearer <token>\x01\x01
-/// ```
-/// which are base64-encoded before being sent on the wire.
-///
-/// For SMTP, `lettre`'s `Mechanism::Xoauth2` constructs the same raw bytes
-/// internally via `Credentials::new(mailbox, access_token)`.
-///
-/// For IMAP, `XOAuth2Authenticator::process` returns the **raw** bytes;
-/// async-imap 0.9 base64-encodes them before sending (see `do_auth_handshake`
-/// in async-imap client.rs:282).  Both paths are therefore wire-equivalent.
-///
-/// This helper is a reference implementation used in tests to verify the
-/// wire encoding.  Production code uses lettre and async-imap directly.
+/// Test-only reference implementation of the XOAUTH2 SASL wire encoding
+/// (`user=<mailbox>\x01auth=Bearer <token>\x01\x01`, base64). See
+/// crates/khive-channel-email/docs/oauth-notes.md#xoauth2_sasl for why this
+/// is wire-equivalent to what lettre/async-imap do in production.
 #[cfg(test)]
 pub(crate) fn xoauth2_sasl(mailbox: &str, token: &str) -> String {
     let raw = format!("user={mailbox}\x01auth=Bearer {token}\x01\x01");

--- a/crates/khive-pack-brain/docs/regression-notes.md
+++ b/crates/khive-pack-brain/docs/regression-notes.md
@@ -1,0 +1,88 @@
+# Regression test notes
+
+Source: `crates/khive-pack-brain/src/tests.rs` (private `mod tests`, internal to the crate).
+
+## `concurrent_cold_load_does_not_clobber_live_state`
+
+Deterministic interleaving test for the concurrent cold-load race. Interleaving
+manufactured by the test-only `POST_LOAD_HOOK` in `persist.rs`:
+
+1. Loader B is spawned; it calls `ensure_loaded` for "race-ns", completes the async DB
+   scan, then PAUSES at the hook before acquiring the final tracker lock (it signals
+   "reached" on a oneshot and awaits "proceed").
+2. While B is paused, the test task runs Loader A to completion (no hook active for A —
+   hook was already consumed by B's `.take()`). A publishes "race-ns" as active.
+3. The test task mutates state via `brain.bind` (adds one binding to A's namespace).
+   Binding count is now 1.
+4. The test task sends "proceed" to B. B resumes, enters the final tracker block, and:
+   - OLD code: sees `current_ns = Some("race-ns")`, takes the `swap_namespace` path, and
+     B's stale cold-loaded `brain_state` (binding count 0) overrides the live state. Final
+     binding count = 0. TEST FAILS.
+   - FIXED code: re-checks `is_active("race-ns")` — true — and returns early without
+     touching `*state`. Final binding count = 1. TEST PASSES.
+
+FAIL-before / PASS-after evidence is produced by running:
+```
+cargo test -p khive-pack-brain -- concurrent_cold_load_does_not_clobber_live_state
+```
+against the reverted commit and against the fixed commit.
+
+## `dispatch_gate_race_is_observable_without_gate`
+
+Proves the dispatch atomicity race EXISTS without the gate.
+
+Directly manufactures the interleaving that `dispatch()` without a gate would permit: A
+calls `ensure_loaded(ns-a)` → B calls `ensure_loaded(ns-b)` (swaps slot to ns-b) → A runs
+its handler against the now-ns-b slot.
+
+This test does NOT go through `dispatch()` — it manually sequences the `ensure_loaded` +
+handler steps in the exact order that a scheduler can produce, giving a deterministic
+reproduction of the race. It runs against the PRODUCTION code (not a simulated removal) by
+calling `ensure_loaded` and the handler directly, bypassing the gate — proving the gate is
+NECESSARY, not just incidental.
+
+Expected: A's `brain.bind` lands in the wrong namespace's bookkeeping. Since #457/#458,
+`handle_bind` durably persists through `persist_brain_state_mutation`, which also
+republishes `tracker.active_namespace` as `token.namespace()` (`bare-ns-a`) on success —
+even though the live state it mutated was actually ns-b's (loaded in step 2). That
+mislabels the save-restore bookkeeping, so the corruption now surfaces on the OPPOSITE
+side from before the durability fix: ns-b's slot comes back empty (its live content, plus
+A's leaked write, gets saved under the wrong namespace key), and A's leaked binding
+resurfaces under ns-a instead. The exact shape of the corruption changed; the underlying
+point — that bypassing the gate corrupts namespace isolation — still holds.
+
+## `dispatch_gate_prevents_cross_namespace_slot_swap`
+
+Proves the dispatch gate FIXES the race: with the gate held across `ensure_loaded` +
+handler, no concurrent namespace swap can occur between the two steps.
+
+Interleaving manufactured by `DISPATCH_INTERLEAVE_HOOK` in `pack.rs` (`cfg(test)` only),
+which fires inside `dispatch()` AFTER `ensure_loaded` returns and BEFORE the handler
+acquires `self.state`. While A is paused at the hook: with the gate, B is blocked on
+`dispatch_gate.lock().await`; without the gate, B would run and swap the slot.
+
+Test sequence: (1) A enters `dispatch()`, acquires gate, calls `ensure_loaded(ns-a)`,
+pauses. (2) B tries to enter `dispatch()` — blocked on the gate. (3) Test releases A — A's
+handler runs `brain.bind` for ns-a. (4) A completes, releases gate; B runs
+`ensure_loaded(ns-b)` + `brain.bind`. (5) Assert `bindings(ns-a) == 1`,
+`bindings(ns-b) == 1`.
+
+PASS (gate present): each namespace sees exactly its own binding. FAIL (gate absent): see
+`dispatch_gate_race_is_observable_without_gate` above.
+
+## `feedback_note_target_resolves_through_observed_as_signal` (#831)
+
+ADR-041 permits `brain.feedback` targets on entities AND notes, but the emitted event
+previously always carried `SubstrateKind::Event`, so the `event_observations` decoder
+hard-coded `ReferentKind::Entity` and the `observed_as_signal` synthetic-edge query
+lowering only admitted entity referents — a note target's signal observation existed in
+storage but was unreachable from `observed_as_signal`. This test feeds a REAL stored note
+through `brain.feedback` end-to-end and confirms it resolves via the canonical ADR-041 §11
+GQL query.
+
+## `ensure_loaded_publication_is_atomic`
+
+Tests the invariant by: (1) loading namespace A and writing a binding (observable state
+mutation), (2) loading namespace B — saves A's state, loads fresh B state, (3) switching
+back to namespace A — restores the saved state, (4) after each `ensure_loaded` call the
+tracker fields must be consistent.

--- a/crates/khive-pack-brain/src/tests.rs
+++ b/crates/khive-pack-brain/src/tests.rs
@@ -1458,15 +1458,9 @@ async fn w4_c4_feedback_accepts_valid_target_and_profile() {
     assert_eq!(result["signal"], json!("useful"));
 }
 
-/// Regression test (#831): ADR-041
-/// permits `brain.feedback` targets on entities AND notes, but the emitted
-/// event previously always carried `SubstrateKind::Event`, so the
-/// `event_observations` decoder hard-coded `ReferentKind::Entity` and the
-/// `observed_as_signal` synthetic-edge query lowering only admitted entity
-/// referents — a note target's signal observation existed in storage but
-/// was unreachable from `observed_as_signal`. Feed a REAL stored note
-/// through `brain.feedback` end-to-end and confirm it resolves via the
-/// canonical ADR-041 §11 GQL query.
+/// Regression (#831): a note-target `brain.feedback` signal must resolve via
+/// `observed_as_signal` (previously unreachable — the decoder hard-coded
+/// `ReferentKind::Entity`). See crates/khive-pack-brain/docs/regression-notes.md#feedback_note_target_resolves_through_observed_as_signal.
 #[tokio::test]
 async fn feedback_note_target_resolves_through_observed_as_signal() {
     let (pack, rt) = make_pack();
@@ -3571,15 +3565,11 @@ async fn crit1_create_profile_accepts_seed_priors_within_ess_cap() {
 // tracker lock is held, so a concurrent dispatch can never observe active=true
 // with stale state.
 
-/// After ensure_loaded returns, the tracker and shared state must be in a
-/// consistent three-way view: active_namespace == namespace, loaded_namespaces
-/// contains namespace, and the shared BrainState is the one for that namespace.
-///
-/// We test this by:
-///   1. Loading namespace A and writing a binding (observable state mutation).
-///   2. Loading namespace B — saves A's state, loads fresh B state.
-///   3. Switching back to namespace A — restores the saved state.
-///   4. After each ensure_loaded the tracker fields must be consistent.
+/// Invariant: after `ensure_loaded` returns, the tracker and shared state
+/// must be in a consistent three-way view: `active_namespace == namespace`,
+/// `loaded_namespaces` contains `namespace`, and the shared `BrainState` is
+/// the one for that namespace. Exercised across an A→B→A load sequence. See
+/// crates/khive-pack-brain/docs/regression-notes.md#ensure_loaded_publication_is_atomic.
 #[tokio::test]
 async fn ensure_loaded_publication_is_atomic() {
     use core::convert::TryFrom;
@@ -3826,31 +3816,9 @@ async fn ensure_loaded_cross_namespace_concurrent_does_not_corrupt_saved_states(
     );
 }
 
-/// Deterministic interleaving test for the concurrent cold-load race.
-///
-/// Interleaving manufactured by the test-only `POST_LOAD_HOOK` in persist.rs:
-///
-///   1. Loader B is spawned; it calls `ensure_loaded` for "race-ns", completes
-///      the async DB scan, then PAUSES at the hook before acquiring the final
-///      tracker lock (it signals "reached" on a oneshot and awaits "proceed").
-///   2. While B is paused, the test task runs Loader A to completion (no hook
-///      active for A — hook was already consumed by B's `.take()`).  A publishes
-///      "race-ns" as active.
-///   3. The test task mutates state via `brain.bind` (adds one binding to A's
-///      namespace).  Binding count is now 1.
-///   4. The test task sends "proceed" to B.  B resumes, enters the final
-///      tracker block, and:
-///        • OLD code: sees `current_ns = Some("race-ns")`, takes the
-///          `swap_namespace` path, and B's stale cold-loaded `brain_state`
-///          (binding count 0) overrides the live state.  Final binding
-///          count = 0.  TEST FAILS.
-///        • FIXED code: re-checks `is_active("race-ns")` — true — and
-///          returns early without touching `*state`.  Final binding
-///          count = 1.  TEST PASSES.
-///
-/// FAIL-before / PASS-after evidence is produced by running:
-///   cargo test -p khive-pack-brain -- concurrent_cold_load_does_not_clobber_live_state
-/// against the reverted commit and against the fixed commit.
+/// Deterministic interleaving test for the concurrent cold-load race, using
+/// the test-only `POST_LOAD_HOOK` in persist.rs to pause a loader mid-load.
+/// See crates/khive-pack-brain/docs/regression-notes.md#concurrent_cold_load_does_not_clobber_live_state.
 #[tokio::test]
 async fn concurrent_cold_load_does_not_clobber_live_state() {
     use core::convert::TryFrom;
@@ -3949,23 +3917,10 @@ async fn concurrent_cold_load_does_not_clobber_live_state() {
     );
 }
 
-/// Proves the dispatch atomicity race EXISTS without the gate.
-///
-/// Directly manufactures the interleaving that dispatch() without a gate
-/// would permit: A calls ensure_loaded(ns-a) → B calls ensure_loaded(ns-b)
-/// (swaps slot to ns-b) → A runs its handler against the now-ns-b slot.
-///
-/// This test does NOT go through dispatch() — it manually sequences the
-/// ensure_loaded + handler steps in the exact order that a scheduler can
-/// produce, giving a deterministic reproduction of the race.
-///
-/// Expected: A's brain.bind lands in the wrong namespace's bookkeeping.
-/// See the comment at the assertions below for the exact (durability-fix-era)
-/// shape of the corruption this produces.
-///
-/// This test runs against the PRODUCTION code (not a simulated removal)
-/// by calling ensure_loaded and the handler directly, bypassing the gate.
-/// It proves the gate is NECESSARY, not just incidental.
+/// Proves the dispatch atomicity race EXISTS without the gate: manually
+/// sequences ensure_loaded + handler calls (bypassing `dispatch()`'s gate)
+/// to deterministically reproduce a cross-namespace bookkeeping corruption.
+/// See crates/khive-pack-brain/docs/regression-notes.md#dispatch_gate_race_is_observable_without_gate.
 #[tokio::test]
 async fn dispatch_gate_race_is_observable_without_gate() {
     use core::convert::TryFrom;
@@ -4003,19 +3958,8 @@ async fn dispatch_gate_race_is_observable_without_gate() {
     .await
     .expect("handle_bind for a");
 
-    // Step 4: Assert the binding landed in the WRONG namespace slot.
-    //
-    // Since #457/#458, `handle_bind` durably persists through
-    // `persist_brain_state_mutation`, which also republishes
-    // `tracker.active_namespace` as `token.namespace()` (`bare-ns-a`) on
-    // success — even though the live state it mutated was actually ns-b's
-    // (loaded in step 2). That mislabels the save-restore bookkeeping, so
-    // the corruption now surfaces on the OPPOSITE side from before the
-    // durability fix: ns-b's slot comes back empty (its live content, plus
-    // A's leaked write, gets saved under the wrong namespace key), and A's
-    // leaked binding resurfaces under ns-a instead. The exact shape of the
-    // corruption changed; the underlying point — that bypassing the gate
-    // corrupts namespace isolation — still holds.
+    // Step 4: Assert the binding landed in the WRONG namespace slot (see
+    // guide for the #457/#458 durability-fix-era corruption shape).
     let bindings_b_now = pack
         .dispatch("brain.bindings", json!({}), &registry, &token_b)
         .await
@@ -4037,26 +3981,10 @@ async fn dispatch_gate_race_is_observable_without_gate() {
     );
 }
 
-/// Proves the dispatch gate FIXES the race: with the gate held across
-/// ensure_loaded + handler, no concurrent namespace swap can occur between
-/// the two steps.
-///
-/// Interleaving manufactured by DISPATCH_INTERLEAVE_HOOK in pack.rs
-/// (cfg(test) only), which fires inside dispatch() AFTER ensure_loaded
-/// returns and BEFORE the handler acquires self.state.  While A is paused
-/// at the hook:
-///   - With the gate: B is blocked on dispatch_gate.lock().await.
-///   - Without the gate: B would run and swap the slot.
-///
-/// Test sequence:
-///   1. A enters dispatch(), acquires gate, calls ensure_loaded(ns-a), pauses.
-///   2. B tries to enter dispatch() — blocked on the gate.
-///   3. Test releases A — A's handler runs brain.bind for ns-a.
-///   4. A completes, releases gate.  B runs: ensure_loaded(ns-b) + brain.bind.
-///   5. Assert bindings(ns-a) == 1, bindings(ns-b) == 1.
-///
-/// PASS (gate present): each namespace sees exactly its own binding.
-/// FAIL (gate absent): see dispatch_gate_race_is_observable_without_gate.
+/// Proves the dispatch gate FIXES the race from
+/// `dispatch_gate_race_is_observable_without_gate`: with the gate held
+/// across ensure_loaded + handler, no concurrent namespace swap can occur.
+/// See crates/khive-pack-brain/docs/regression-notes.md#dispatch_gate_prevents_cross_namespace_slot_swap.
 #[tokio::test]
 async fn dispatch_gate_prevents_cross_namespace_slot_swap() {
     use core::convert::TryFrom;

--- a/crates/khive-pack-knowledge/docs/compose-timing.md
+++ b/crates/khive-pack-knowledge/docs/compose-timing.md
@@ -1,0 +1,35 @@
+# `knowledge.compose` per-stage timing (`ComposeTiming`)
+
+Source: `crates/khive-pack-knowledge/src/knowledge/compose.rs` (`pub(super)`, internal to
+the crate).
+
+## Call-ordering contract
+
+`begin(phase)` must be called *before* that phase's work starts (in particular, before any
+`.await` the phase covers) — it closes out whichever phase was previously active
+(accumulating `last..now` into it) and opens `phase` as the new active phase. Because the
+active phase is known at every instant, `finish` and `Drop` can both flush an in-flight
+phase's partial duration into the breakdown rather than silently omitting it, which is
+what a slow-then-failing or cancelled-mid-phase request needs.
+
+`finish` must be the last thing called on every return path that completes the request
+(success or a business-logic error) — in particular, after the response `Value` is fully
+constructed, not before. Response-JSON assembly is real work and belongs inside whichever
+phase is still active, typically `Trim`. `finish` flushes the active phase, flags the
+timing as complete, and, if the total reaches `COMPOSE_SLOW_THRESHOLD_MS`, emits the
+slow-request WARN.
+
+If `finish` is never reached — because the enclosing future was dropped mid-poll (client
+disconnect, cancellation, or daemon shutdown drain) — `Drop` performs the same flush and
+emits a distinct "abandoned" WARN, so a request that never produces a response is not
+silently invisible.
+
+## Why `query_bytes` is stored eagerly
+
+Records the query's UTF-8 *byte* length, not a char count — `str::len()` reads a value the
+string already carries (O(1)), unlike `.chars().count()`'s O(n) UTF-8 walk. Because it is
+O(1), there is nothing to gain by deferring it to the rare emission path as one would for
+a genuinely O(n) computation: storing it eagerly costs the same as storing it lazily, and
+eager storage avoids holding a borrow of the caller's query string for the tracker's
+entire lifetime; `compose()` moves `raw_query` into the response body before calling
+`finish()`, so a borrowing field would not compile.

--- a/crates/khive-pack-knowledge/docs/regression-notes.md
+++ b/crates/khive-pack-knowledge/docs/regression-notes.md
@@ -1,0 +1,36 @@
+# Regression test notes
+
+Source: `crates/khive-pack-knowledge/src/handlers.rs` `#[cfg(test)]` module.
+
+## `resolve_compose_type_weights_reads_tuned_section_posteriors_at_tier3` (#346)
+
+`resolve_compose_type_weights` must read pack-local `section_posteriors` (Tier 3) rather
+than silently returning `SectionPosteriorState::default()` regardless of learned feedback.
+
+Setup: heavily skew `section_posteriors` toward `Formalism` and against
+`OperationalGuidance`. With an empty `VerbRegistry` (no brain pack), tiers 1 and 2 fall
+through and tier 3 must return the tuned weights — where formalism's weight now exceeds
+operational_guidance's, the opposite of the default prior (α_og=6,β_og=1.5 vs
+α_form=1.5,β_form=4).
+
+The old code path (`SectionPosteriorState::default()` inside `compose`) would always
+return weights reflecting the fresh priors, ignoring `section_posteriors` entirely — this
+test would fail against that behavior.
+
+## `resolve_compose_type_weights_reads_bound_profile_weights_at_tier2` (#346 Tier-2)
+
+`resolve_compose_type_weights` must read weights from a namespace-bound brain profile when
+one is registered via `brain.bind`.
+
+This test exercises `load_profile_type_weights` dispatching `brain.profile` across the
+pack boundary — the code path that had zero coverage after the Tier-3 test was added.
+
+Setup: register a brain profile with `seed_priors` that INVERT the default ordering
+(formalism high, operational_guidance low), bind it for `namespace="local"` +
+`consumer_kind="knowledge_compose"`, then call `resolve_compose_type_weights` with a
+registry that has `BrainPack` wired.
+
+With Tier 1 absent (`brain_profile=None`) and a real binding in Tier 2, the method must
+return the bound profile's weights — formalism dominant. If `load_profile_type_weights`
+returned `None` or mis-extracted, Tier 2 falls through to Tier 3/default and
+operational_guidance dominates → FAIL.

--- a/crates/khive-pack-knowledge/docs/vamana-internals.md
+++ b/crates/khive-pack-knowledge/docs/vamana-internals.md
@@ -1,0 +1,83 @@
+# Vamana ANN bridge internals
+
+Source: `crates/khive-pack-knowledge/src/knowledge/vamana.rs` (entire module is
+`pub(crate)` — internal to the crate, not part of the published API).
+
+## Module overview
+
+Wraps `khive_vamana::VamanaIndex` with an ID map (u32 → UUID) so search results can be
+fused with FTS5 candidates via RRF.
+
+Persistence (ADR-079): v2 binary segments are written to `data_dir/ann/<hex>/` on every
+cold-start rebuild or explicit reindex. `ensure_ann_for_model` checks the v2 segment
+directory first (content-hash gated), falling back to legacy v1 JSON rows in
+`retrieval_snapshots` for in-place upgrades, then rebuilds from the full sqlite-vec corpus
+on cache-miss. `kkernel reindex` re-persists v2 segments and calls `invalidate_snapshot` to
+clean up stale v1 rows.
+
+This module exceeds the 700-line soft target because it owns the complete Vamana ANN
+lifecycle for knowledge search: `SharedAnn` type, `AnnKey`, snapshot persistence
+(`warm_known_snapshots` / `ensure_ann_background`), index build (`build_ann`), search
+(`search_loaded`), and all associated SQL queries and serialization logic. These
+responsibilities are tightly coupled through the shared `AnnState` and cannot be split
+without breaking the atomic lock protocol. Refactoring is deferred until a stable snapshot
+format and the warm-start contract are defined.
+
+## `AnnState::generations` (per-namespace write-generation counter, issue #770)
+
+Bumped by `clear_namespace` whenever a corpus mutation invalidates a namespace's ANN
+slots. `ensure_ann_for_model` captures the current value for its namespace before doing
+anything else — including before its own "already loaded" fast path and before the corpus
+scan — and stamps it on the resulting `AnnBridge`. `install_if_fresher` then only replaces
+an already-installed entry when the candidate's generation is >= the installed entry's,
+instead of the old `entry(key).or_insert(...)`, which always kept whichever build reached
+the install site first even if it had scanned a corpus version predating a later
+invalidation. Keyed by namespace (not the full `AnnKey`) because `clear_namespace` only
+knows the namespace being invalidated, not which models have (or will have) a build in
+flight for it.
+
+## `save_atomic`
+
+Writes Vamana index segments via `VamanaIndex::save_atomic` (which commits a v2
+`KHVVAMG2` record in `metadata.bin` carrying a `content_hash`), then writes the id-map
+sidecar (`external_ids.bin`) atomically via a tmp-then-rename sequence, stamped with the
+corpus `content_hash` taken from the v2 commit record.
+
+## `ensure_ann_for_model` load order
+
+First hit wins:
+
+1. **Fast path** — already in the in-memory cache; return immediately.
+2. **v2 segment path** — if a `data_dir/ann/<hex>/` directory exists with a valid
+   `metadata.bin`, compare its `content_hash` against a freshly computed
+   `live_content_hash`. On match, load the Vamana binary segments directly via
+   `AnnBridge::load` (O(load), no rebuild). On mismatch, fall through.
+3. **v1 JSON snapshot path** — try `retrieval_snapshots`; on hit, validate the
+   `CorpusFingerprint` (count + dims) and restore from JSON. On miss / stale / corrupt,
+   fall through.
+4. **Rebuild fallthrough** — scan the full sqlite-vec corpus, build the index from
+   scratch, and atomically write a v2 segment directory so the next daemon restart can
+   use path 2. Write failures are logged and do not block search.
+
+## `install_if_fresher` (PR #815, covering issue #770's empty-slot scenario)
+
+Two independent fences, both evaluated while holding the write lock:
+
+1. `candidate.generation` must be >= the namespace's CURRENT generation. Comparing only
+   against an existing entry (the old behavior) has nothing to compare against once
+   `clear_namespace` has emptied the slot — a pre-invalidation candidate would install
+   unconditionally even though it scanned a corpus version the namespace has since
+   invalidated. `clear_namespace` bumps the generation counter inside this same
+   write-lock scope, so a candidate's read of the current generation here can never
+   observe a pre-bump value for a slot that has already been (or is about to be) evicted.
+2. `candidate.generation` must be >= any already-installed entry's generation, so a
+   slower-but-staler build can never clobber a faster build that already scanned a newer
+   corpus.
+
+## `clear_namespace` / `install_if_fresher` lock-scope invariant (PR #815)
+
+Eviction and the generation-counter bump happen inside the SAME write-lock scope.
+`install_if_fresher` takes this same lock before reading the namespace's current
+generation, so there is no window between "slot emptied" and "generation bumped" where a
+concurrent install could read a stale (pre-bump) generation and self-approve into the
+just-emptied slot.

--- a/crates/khive-pack-knowledge/src/handlers.rs
+++ b/crates/khive-pack-knowledge/src/handlers.rs
@@ -591,19 +591,8 @@ mod tests {
         );
     }
 
-    /// Regression for #346: `resolve_compose_type_weights` must read pack-local
-    /// `section_posteriors` (Tier 3) rather than silently returning
-    /// `SectionPosteriorState::default()` regardless of learned feedback.
-    ///
-    /// Setup: heavily skew `section_posteriors` toward `Formalism` and against
-    /// `OperationalGuidance`.  With an empty `VerbRegistry` (no brain pack), tiers
-    /// 1 and 2 fall through and tier 3 must return the tuned weights — where
-    /// formalism's weight now exceeds operational_guidance's, the opposite of the
-    /// default prior (α_og=6,β_og=1.5 vs α_form=1.5,β_form=4).
-    ///
-    /// The old code path (`SectionPosteriorState::default()` inside `compose`) would
-    /// always return weights reflecting the fresh priors, ignoring `section_posteriors`
-    /// entirely — this test would fail against that behavior.
+    /// Regression for #346: Tier 3 must read tuned `section_posteriors`, not a
+    /// fresh default. See crates/khive-pack-knowledge/docs/regression-notes.md.
     #[tokio::test]
     async fn resolve_compose_type_weights_reads_tuned_section_posteriors_at_tier3() {
         let rt = KhiveRuntime::memory().expect("in-memory runtime");
@@ -668,22 +657,9 @@ mod tests {
         );
     }
 
-    /// Regression for #346 Tier-2: `resolve_compose_type_weights` must read weights
-    /// from a namespace-bound brain profile when one is registered via `brain.bind`.
-    ///
-    /// This test exercises `load_profile_type_weights` dispatching `brain.profile`
-    /// across the pack boundary — the code path that had zero coverage after the
-    /// Tier-3 test was added.
-    ///
-    /// Setup: register a brain profile with `seed_priors` that INVERT the default
-    /// ordering (formalism high, operational_guidance low), bind it for
-    /// `namespace="local"` + `consumer_kind="knowledge_compose"`, then call
-    /// `resolve_compose_type_weights` with a registry that has `BrainPack` wired.
-    ///
-    /// With Tier 1 absent (`brain_profile=None`) and a real binding in Tier 2,
-    /// the method must return the bound profile's weights — formalism dominant.
-    /// If `load_profile_type_weights` returned `None` or mis-extracted, Tier 2
-    /// falls through to Tier 3/default and operational_guidance dominates → FAIL.
+    /// Regression for #346 Tier-2: must read weights from a namespace-bound
+    /// brain profile (`brain.bind`), not fall through to Tier 3/default. See
+    /// crates/khive-pack-knowledge/docs/regression-notes.md.
     #[tokio::test]
     async fn resolve_compose_type_weights_reads_bound_profile_weights_at_tier2() {
         use khive_pack_brain::BrainPack;

--- a/crates/khive-pack-knowledge/src/knowledge/compose.rs
+++ b/crates/khive-pack-knowledge/src/knowledge/compose.rs
@@ -398,37 +398,14 @@ impl Phase {
 
 /// Per-stage elapsed-time tracker for `knowledge.compose`.
 ///
-/// `begin(phase)` must be called *before* that phase's work starts (in
-/// particular, before any `.await` the phase covers) — it closes out
-/// whichever phase was previously active (accumulating `last..now` into it)
-/// and opens `phase` as the new active phase. Because the active phase is
-/// known at every instant, `finish` and `Drop` can both flush an in-flight
-/// phase's partial duration into the breakdown rather than silently omitting
-/// it, which is what a slow-then-failing or cancelled-mid-phase request
-/// needs.
-///
-/// `finish` must be the last thing called on every return path that
-/// completes the request (success or a business-logic error) — in
-/// particular, after the response `Value` is fully constructed, not before.
-/// Response-JSON assembly is real work and belongs inside whichever phase is
-/// still active, typically `Trim`.
-/// `finish` flushes the active phase, flags the timing as complete, and, if
-/// the total reaches [`COMPOSE_SLOW_THRESHOLD_MS`], emits the slow-request
-/// WARN. If `finish` is never reached — because the enclosing future was
-/// dropped mid-poll (client disconnect, cancellation, or daemon shutdown
-/// drain) — `Drop` performs the same flush and emits a distinct "abandoned"
-/// WARN, so a request that never produces a response is not silently
-/// invisible.
-///
-/// `query_bytes` records the query's UTF-8 *byte* length, not a char count —
-/// `str::len()` reads a value the string already carries (O(1)), unlike
-/// `.chars().count()`'s O(n) UTF-8 walk. Because it is O(1), there is nothing
-/// to gain by deferring it to the rare emission path as one would for a
-/// genuinely O(n) computation: storing it eagerly
-/// costs the same as storing it lazily, and eager storage avoids holding a
-/// borrow of the caller's query string for the tracker's entire lifetime;
-/// `compose()` moves `raw_query` into the response body before calling
-/// `finish()`, so a borrowing field would not compile.
+/// Ordering invariant: `begin(phase)` must be called before that phase's
+/// work starts (before any `.await` it covers), and `finish` must be the
+/// last call on every return path (after the response `Value` is built).
+/// `finish`/`Drop` both flush the active phase's partial duration -- `Drop`
+/// covers the cancelled-mid-poll case with a distinct "abandoned" WARN so a
+/// request that never responds is not silently invisible. See
+/// crates/khive-pack-knowledge/docs/compose-timing.md for the full
+/// call-ordering contract and the `query_bytes` eager-storage rationale.
 pub(super) struct ComposeTiming {
     start: Instant,
     last: Instant,

--- a/crates/khive-pack-knowledge/src/knowledge/vamana.rs
+++ b/crates/khive-pack-knowledge/src/knowledge/vamana.rs
@@ -9,14 +9,11 @@
 //! Vamana ANN bridge — parallel semantic signal for `knowledge.search`.
 //!
 //! Wraps `khive_vamana::VamanaIndex` with an ID map (u32 → UUID) so search
-//! results can be fused with FTS5 candidates via RRF.
-//!
-//! Persistence (ADR-079): v2 binary segments are written to `data_dir/ann/<hex>/`
-//! on every cold-start rebuild or explicit reindex.  `ensure_ann_for_model` checks
-//! the v2 segment directory first (content-hash gated), falling back to legacy v1
-//! JSON rows in `retrieval_snapshots` for in-place upgrades, then rebuilds from the
-//! full sqlite-vec corpus on cache-miss.  `kkernel reindex` re-persists v2 segments
-//! and calls `invalidate_snapshot` to clean up stale v1 rows.
+//! results can be fused with FTS5 candidates via RRF. Persistence (ADR-079):
+//! v2 binary segments under `data_dir/ann/<hex>/`, falling back to legacy v1
+//! JSON snapshot rows, then a full corpus rebuild on cache-miss. See
+//! crates/khive-pack-knowledge/docs/vamana-internals.md for the persistence
+//! fallback chain and the file-size/module-coupling rationale.
 
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
@@ -63,19 +60,10 @@ pub(crate) struct AnnState {
     /// Keys currently being warmed (or already warmed). `std::sync::Mutex`
     /// so the fire-and-check guard in `ensure_ann_background` stays sync.
     warming: std::sync::Mutex<HashSet<AnnKey>>,
-    /// Per-namespace write-generation counter (issue #770). Bumped by
-    /// `clear_namespace` whenever a corpus mutation invalidates a namespace's
-    /// ANN slots. `ensure_ann_for_model` captures the current value for its
-    /// namespace before doing anything else — including before its own
-    /// "already loaded" fast path and before the corpus scan — and stamps it
-    /// on the resulting `AnnBridge`. `install_if_fresher` then only replaces
-    /// an already-installed entry when the candidate's generation is >= the
-    /// installed entry's, instead of the old `entry(key).or_insert(...)`,
-    /// which always kept whichever build reached the install site first even
-    /// if it had scanned a corpus version predating a later invalidation.
-    /// Keyed by namespace (not the full `AnnKey`) because `clear_namespace`
-    /// only knows the namespace being invalidated, not which models have (or
-    /// will have) a build in flight for it.
+    /// Per-namespace write-generation counter (issue #770), keyed by
+    /// namespace (not the full `AnnKey`). Bumped by `clear_namespace`;
+    /// `install_if_fresher` uses it to reject stale builds. See
+    /// crates/khive-pack-knowledge/docs/vamana-internals.md#annstategenerations-per-namespace-write-generation-counter-issue-770.
     generations: std::sync::Mutex<HashMap<String, u64>>,
 }
 
@@ -118,21 +106,13 @@ pub(crate) fn current_generation(ann: &SharedAnn, namespace: &str) -> u64 {
 }
 
 /// Install `candidate` into the cache for `key` unless it is stale (PR #815,
-/// covering issue #770's empty-slot scenario). Two
-/// independent fences, both evaluated while holding the write lock:
-///
-/// 1. `candidate.generation` must be >= the namespace's CURRENT generation.
-///    Comparing only against an existing entry (the old behavior) has
-///    nothing to compare against once `clear_namespace` has emptied the
-///    slot — a pre-invalidation candidate would install unconditionally
-///    even though it scanned a corpus version the namespace has since
-///    invalidated. `clear_namespace` bumps the generation counter inside
-///    this same write-lock scope, so a candidate's read of the current
-///    generation here can never observe a pre-bump value for a slot that
-///    has already been (or is about to be) evicted.
-/// 2. `candidate.generation` must be >= any already-installed entry's
-///    generation, so a slower-but-staler build can never clobber a faster
-///    build that already scanned a newer corpus.
+/// covering issue #770's empty-slot scenario). Two independent fences, both
+/// evaluated while holding the write lock: candidate's generation must be at
+/// least the namespace's CURRENT generation (not just any already-installed
+/// entry's, since `clear_namespace` may have emptied the slot entirely), AND
+/// at least any already-installed entry's generation, so a slower-but-staler
+/// build can never clobber a faster build that scanned a newer corpus. See
+/// crates/khive-pack-knowledge/docs/vamana-internals.md#install_if_fresher-pr-815-covering-issue-770s-empty-slot-scenario.
 pub(crate) async fn install_if_fresher(ann: &SharedAnn, key: &AnnKey, candidate: AnnBridge) {
     let mut idxs = ann.indexes.write().await;
 
@@ -372,19 +352,14 @@ impl AnnBridge {
         })
     }
 
-    /// Save this bridge to `dir` atomically.
-    ///
-    /// Writes Vamana index segments via [`VamanaIndex::save_atomic`] (which commits
-    /// a v2 KHVVAMG2 record in `metadata.bin` carrying a `content_hash`), then writes
-    /// the id-map sidecar (`external_ids.bin`) atomically via a tmp-then-rename sequence.
-    /// The sidecar is stamped with the corpus `content_hash` taken from the v2 commit
-    /// record.
-    ///
-    /// Crash-safety rationale: the v2 segment commit gate is `metadata.bin`, and the
-    /// sidecar is written second. On any crash between the two writes the sidecar's
-    /// stamped hash will not match the new commit's hash, so the load-time cross-check
-    /// detects the torn pair and the caller rebuilds. Ordering alone is insufficient;
-    /// the cross-check is the guarantee.
+    /// Save this bridge to `dir` atomically: writes v2 Vamana segments (commits
+    /// `metadata.bin` with a `content_hash`), then the id-map sidecar
+    /// (`external_ids.bin`, tmp-then-rename) stamped with that same
+    /// `content_hash`. Crash-safety invariant: a crash between the two writes
+    /// leaves the sidecar's stamped hash mismatched against the commit's
+    /// hash, so the load-time cross-check detects the torn pair and the
+    /// caller rebuilds -- ordering alone is not the guarantee, the hash
+    /// cross-check is. See crates/khive-pack-knowledge/docs/vamana-internals.md#save_atomic.
     #[allow(dead_code)]
     pub fn save_atomic(&self, dir: &std::path::Path) -> Result<(), String> {
         let count = self.id_map.len();
@@ -988,21 +963,12 @@ pub(crate) fn ensure_ann_background(rt: &KhiveRuntime, token: &NamespaceToken, a
     });
 }
 
-/// Lazy warm-load for a specific `model`.
-///
-/// Load order (first hit wins):
-///
-/// 1. **Fast path** — already in the in-memory cache; return immediately.
-/// 2. **v2 segment path** — if a `data_dir/ann/<hex>/` directory exists with a
-///    valid `metadata.bin`, compare its `content_hash` against a freshly computed
-///    `live_content_hash`.  On match, load the Vamana binary segments directly via
-///    `AnnBridge::load` (O(load), no rebuild).  On mismatch, fall through.
-/// 3. **v1 JSON snapshot path** — try `retrieval_snapshots`; on hit, validate
-///    the `CorpusFingerprint` (count + dims) and restore from JSON.  On miss /
-///    stale / corrupt, fall through.
-/// 4. **Rebuild fallthrough** — scan the full sqlite-vec corpus, build the index
-///    from scratch, and atomically write a v2 segment directory so the next daemon
-///    restart can use path 2.  Write failures are logged and do not block search.
+/// Lazy warm-load for a specific `model`. Load order (first hit wins): (1)
+/// in-memory cache fast path, (2) v2 segment directory (content-hash gated),
+/// (3) legacy v1 JSON snapshot, (4) full corpus rebuild, atomically persisted
+/// as v2 for next restart. See
+/// crates/khive-pack-knowledge/docs/vamana-internals.md#ensure_ann_for_model-load-order
+/// for the per-step detail.
 pub(crate) async fn ensure_ann_for_model(
     rt: &KhiveRuntime,
     token: &NamespaceToken,


### PR DESCRIPTION
## What

Condense verbose inline doc-comments in `khive-channel-email,khive-pack-brain khive-pack-knowledge` and relocate long-form rationale, algorithm walkthroughs, and background prose into per-crate `docs/*.md` guides. Part of the rustdoc condense-and-extract pass.

## Preserved (information relocation, not deletion)

- Public API doc-comments stay **complete and standalone** — the docs.rs reference is intact; a caller can use each public item from its doc-comment alone.
- No `# Safety`, invariant, ordering, precision, or error-enumeration docs were thinned.
- schemars/clap product-surface doc-comments (MCP tool schema, CLI `--help`) left verbatim.
- Every substantive fact removed from a `.rs` doc-comment was moved into a crate guide under the crate's `docs/` directory, not dropped.

## Scope

Only the `src` and `docs` trees of the crates above. Diffstat: 14 files changed, 529 insertions(+), 370 deletions(-).

Branch forked before recent doc merges; will be updated onto main and code-reviewed before marking ready.