### PR TITLE
docs(rustdoc): condense inline docs + extract long-form to guides 

### DIFF
--- a/crates/khive-pack-git/docs/cache.md
+++ b/crates/khive-pack-git/docs/cache.md
@@ -1,0 +1,317 @@
+# Scratch-clone cache — design notes
+
+Long-form rationale extracted from `crates/khive-pack-git/src/cache.rs`
+doc-comments (ADR-088 Amendment 1, remote-URL mode for `git.digest`).
+
+## Module overview
+
+Clones/fetches into `~/.khive/scratch/git-digest/<cache_key>/`, keyed by
+canonical URL (`crate::source::cache_key`). An LRU cap evicts the
+least-recently-used clone (by a `.khive-last-used` marker file's mtime,
+touched on every successful `ensure_clone`) once the cache exceeds
+`digest_cache_max_repos` entries or `digest_cache_max_bytes` total size —
+eviction is safe because ingest cursors live in the database, not the clone.
+Eviction only ever removes entries it can *prove* it owns (`is_owned_entry`:
+a 16-hex cache-key directory name containing both a `.git` dir and the
+`.khive-last-used` marker) — a `KHIVE_GIT_DIGEST_SCRATCH_ROOT` override
+pointed at a broader or pre-existing directory must never lose unrelated
+operator data.
+
+A per-clone size cap (`digest_cache_clone_max_bytes`) rejects a clone/fetch
+that grows past its own budget *before* it ever enters the addressable cache
+slot: `ensure_clone` clones/fetches into a staging directory outside the
+cache root, measures it, and only moves it into `<root>/<cache_key>/` when
+it is under the cap. A too-large clone is deleted from staging and never
+touches `evict_lru`'s bookkeeping or the cache slot. This guarantees the cap
+is enforced before the clone enters the cache — it does NOT bound the
+transient disk usage of the clone/fetch child process itself while it runs
+in staging (`git` has no reliable pre-flight or mid-transfer size check for
+a partial `--filter=blob:none` clone); a single oversized `git clone` can
+still transiently consume disk in the staging directory before this check
+rejects and removes it.
+
+Config is env-var driven today (`KHIVE_GIT_DIGEST_CACHE_MAX_REPOS`,
+`KHIVE_GIT_DIGEST_CACHE_MAX_BYTES`, `KHIVE_GIT_DIGEST_CLONE_MAX_BYTES`,
+`KHIVE_GIT_DIGEST_SCRATCH_ROOT`) rather than a `[git]` TOML section.
+
+## `CacheError::UnsafeToReplace`
+
+A repair operation (refetch/reclone) would have to touch a path that does
+not prove itself an owned cache slot (`is_owned_entry`) or is not a direct
+child of the scratch root — refused rather than risking deletion of
+unrelated operator data under an overridden `KHIVE_GIT_DIGEST_SCRATCH_ROOT`.
+
+## `ensure_clone`
+
+An existing path at the cache-key slot is only ever treated as a fetchable
+cache slot when it already passes `is_owned_entry` — a `.git` directory
+sitting at that path without the `.khive-last-used` marker (a foreign
+directory that happens to collide with the cache key, or a directory a
+crashed prior run left in a pre-`touch` state) is refused with
+`CacheError::UnsafeToReplace` rather than fetched into or adopted (issue
+#765). A fresh clone is written into a private staging directory first
+(`git clone --filter=blob:none`), measured there, marked with
+`.khive-last-used` there, and only *moved* into the addressable
+`<root>/<cache_key>/` slot once it is under the cap and already carries its
+ownership marker — an oversized clone never enters the cache slot, never
+participates in `evict_lru`'s accounting, and is removed from staging
+immediately; a process interruption between the clone and the rename can
+never leave a live, markerless slot behind.
+
+A repo that grew past the per-clone cap since it was last fetched is
+evicted from the cache slot on the spot, through the same
+ownership-guarded `remove_owned_entry` every other repair path uses,
+propagating any cleanup/ownership failure instead of discarding it.
+
+Runs LRU eviction over the rest of the cache after a successful
+clone/fetch (this clone is exempt from its own eviction pass).
+
+## `refetch_clone`
+
+Re-fetches a corrupt-but-present cache slot with `git fetch --refetch`
+(issue #765): downloads a complete fresh filtered packfile rather than
+trusting the existing (possibly promisor-incomplete) object store,
+repairing a partial/pruned clone in place. Only ever operates on an
+existing slot — callers repair a slot only after a prior `ensure_clone`
+already produced one.
+
+Re-checks `is_owned_entry` immediately before fetching (issue #765
+follow-up PR #788): the gap between `ensure_clone`'s own ownership check
+and this repair running — project resolution and GitHub ingestion happen
+in between — is wide enough for the slot to go markerless or be replaced,
+so this function cannot rely on the caller having checked recently. There
+is no same-key serialization for cache mutation in this crate today (a
+concurrent `ensure_clone`/`reclone` racing this same slot is not otherwise
+excluded) — this re-check narrows the adoption bug but does not close a
+true concurrent-writer race.
+
+The over-cap cleanup path routes through the same ownership-guarded
+`remove_owned_entry` `reclone` uses, rather than a raw `remove_dir_all` — a
+repair primitive must never delete a path that doesn't prove itself an
+owned cache slot, even on the cap-exceeded cleanup path. A cleanup/ownership
+failure is propagated instead of discarding it.
+
+## `reclone`
+
+Evicts an owned cache slot (if present) and installs a fresh clone in its
+place (issue #765's fallback when a refetch cannot repair the slot).
+Refuses via `CacheError::UnsafeToReplace` when the existing path does not
+prove itself an owned cache slot — the same ownership guard `evict_lru`
+uses.
+
+## `install_fresh_clone`
+
+Shared staging-clone-then-move path for both a first-time `ensure_clone`
+and a `reclone` repair: clones into a private staging directory outside the
+cache root, measures it against the per-clone cap, writes the
+`.khive-last-used` ownership marker into the staging directory itself, and
+only then moves it into the addressable `<root>/<cache_key>/` slot — an
+oversized clone never enters the cache slot, and because the marker is
+written before the atomic rename, a process interruption between clone and
+rename can never leave a live, markerless slot at the cache-key path (issue
+#765).
+
+## `remove_owned_entry`
+
+Removes `repo_dir` only when it is a direct child of `root` AND passes
+`is_owned_entry` — refuses (`CacheError::UnsafeToReplace`) rather than
+deleting anything else, including a not-yet-existing or foreign-shaped
+path. A slot that does not currently exist is not an error: there is
+simply nothing to remove before installing a fresh clone.
+
+## `remove_dir_all_retrying`
+
+`std::fs::remove_dir_all` on a large git working tree can transiently fail
+with "directory not empty" when something else briefly touches the tree
+mid-removal (e.g. a filesystem indexer) — retry a few times before giving
+up, rather than letting a one-off transient race abort a repair that would
+otherwise succeed.
+
+## `clone` (git subprocess): `maintenance.auto=false`
+
+`-c maintenance.auto=false` on every clone/fetch into a cache slot, as
+defensive hardening. `git fetch` runs auto-maintenance after it finishes
+when `maintenance.auto` (default true) is set, and since git 2.47 that
+maintenance runs as a *detached background child*
+(`git maintenance run --auto --detach`) that can outlive the foreground
+command; on 2.46 and earlier it ran synchronously. The spawn is
+trace2-proven in both directions on the `fetch --refetch` path
+(`GIT_TRACE2_EVENT`, git 2.49: with default config the child forks; with
+`maintenance.auto=false` it does not). The same trace showed `clone`
+spawning no maintenance child; the flag is applied to the clone builder too
+purely as harmless defensive configuration, with no trace evidence claimed
+for that path. When one of the detached child's tasks fires it mutates the
+slot's `.git` tree (commit-graph writes, pack maintenance, lock files)
+concurrently with any `dir_size`/`evict_lru` walk of the same slot. Whether
+such a task actually fired in issue #842's historical macOS ENOENT failures
+is not proven — in small repos the child typically finds no task to run and
+exits quickly — so the load-bearing fix for that flake family is the
+descendant-vanish tolerance in `dir_size`; this flag removes the one
+background mutator git itself can fork into our cache slots. `gc.auto=0`
+alone does **not** suppress the child (trace2-verified); it is kept
+alongside because it disables `git gc --auto`'s separate opportunistic-gc
+check, harmless to also turn off here.
+
+This does not mean a cache slot is naturally garbage-collected some other
+way instead: no cache-slot repo is ever gc'd or maintenance'd by us. Growth
+is bounded by wholesale eviction, not in-place compaction —
+`ensure_clone`/`refetch_clone` delete a slot outright (`remove_owned_entry`)
+the moment it measures over `digest_cache_clone_max_bytes` after a fetch,
+and `evict_lru` deletes whole least-recently-used slot directories once the
+cache-wide `digest_cache_max_repos`/`digest_cache_max_bytes` caps are
+exceeded. A slot can be fetched into repeatedly, but it can never
+accumulate objects past its own size cap without being deleted and
+re-cloned fresh, so there is nothing for git's own gc/maintenance to
+usefully do in a cache slot.
+
+## `fetch_refetch`
+
+Issue #765 repair primitive: `git fetch --refetch origin` obtains a
+complete fresh filtered packfile instead of incrementally trusting the
+existing (possibly promisor-incomplete) object store — the documented fix
+for a partial clone that has dropped objects it should still have.
+
+## `io_err`
+
+Wraps an I/O error with the operation and path it happened on — a bare
+`CacheError::Io(e)` at these call sites used to surface as an opaque "No
+such file or directory" with no way to tell which of the many paths
+`dir_size`/`touch`/`evict_lru` touch actually disappeared.
+
+## `dir_size`
+
+Recursive directory size, following no symlinks (`symlink_metadata`
+throughout, so a symlink itself is sized but never traversed — clones
+never legitimately contain symlinked directories pointing outside the
+clone, and this avoids any possibility of a symlink loop).
+
+Tolerant of a *descendant* disappearing mid-walk (a vanished entry beneath
+an existing root contributes 0 bytes rather than aborting the whole size
+computation): a cache slot's `.git` tree can legitimately be mutated by
+something outside this function's control while it walks it — a concurrent
+`evict_lru`/`ensure_clone` repair on the same slot, or a background `git
+maintenance` child from before `maintenance.auto=false` applied to every
+command this crate issues. This accounting is inherently a snapshot of a
+possibly-changing tree, so "a thing under the root I was about to size is
+already gone" is not an error here.
+
+The walk **root** itself vanishing is different and is NOT tolerated — it
+surfaces as `CacheError::Io(NotFound)` rather than silently sizing to `0`. A
+caller that genuinely expects the root it's sizing to sometimes be absent
+(rather than an existing root racing a mid-walk mutation) must check for
+that error explicitly and decide its own semantics at that call site
+(`evict_lru` does this for a listed entry that a concurrent repair deleted
+between `read_dir` and this call); `dir_size` itself never launders a
+missing root into a bare `0`, which previously let `evict_lru` report
+success with a missing keep slot or count a phantom candidate and evict a
+valid one unnecessarily.
+
+## `is_owned_entry`
+
+Whether `path` is a directory `ensure_clone` could plausibly have created:
+a 16-lowercase-hex `cache_key`-shaped directory name (never a UUID staging
+dir, never an arbitrary operator directory), itself a real directory
+rather than a symlink (a symlink placed at the cache-key path pointing at
+an unrelated owned-looking or foreign directory must never be treated as
+an owned slot), containing both a `.git` entry and the `.khive-last-used`
+marker written by `touch`. Eviction (and any future scratch-root cleanup)
+must only ever remove entries that pass this check.
+
+## `evict_lru`
+
+Evicts least-recently-used clones under `root` (by `.khive-last-used`
+mtime) until both the repo-count cap and the total-byte cap are satisfied.
+`keep` (the clone `ensure_clone` just touched) is never evicted. Only
+removes paths that are direct children of `root` AND pass `is_owned_entry`
+— eviction never touches user-owned or non-cache paths.
+
+`keep`'s own `dir_size` call is deliberately NOT tolerant of `keep`
+vanishing: every caller touches (or freshly installs) `keep` immediately
+before calling `evict_lru` in the same synchronous call chain, so `keep`
+disappearing out from under this call is not an expected repair race — it
+is either a genuine bug or an external actor deleting our slot, and
+silently sizing it to `0` would let eviction report success while the slot
+the caller asked to keep is actually gone. A listed *candidate* entry is
+different — another `evict_lru`/`ensure_clone` repairing the same root can
+legitimately delete it between the `read_dir` listing and the `dir_size`
+call, so that vanish is tolerated by skipping the entry rather than
+aborting the whole pass.
+
+## `ENV_MUTEX`
+
+`scratch_root()` reads process-global env vars; serialize any in-crate
+test (in this module or elsewhere, e.g. `recovery_tests.rs`) that touches
+it, so the whole `cargo test` binary's parallel test threads never race on
+`KHIVE_GIT_DIGEST_SCRATCH_ROOT`/cache-cap env vars/`PATH`. A
+`tokio::sync::Mutex` rather than `std::sync::Mutex` so async tests can hold
+the guard across `.await` points (`blocking_lock()` for this module's plain
+sync `#[test]`s).
+
+## Test module notes
+
+- `ensure_clone_cleans_up_staging_dir_on_clone_failure`: a `git clone`
+  failure must not leave a `.staging-<uuid>` directory behind — `evict_lru`
+  deliberately never touches non-owned names, so a leaked staging dir
+  would otherwise accumulate forever across repeated failures.
+- `dir_size_errors_when_the_root_itself_is_missing` (PR #847): the walk
+  root vanishing must surface as an error, never a laundered `Ok(0)` —
+  distinct from a descendant vanishing beneath a still-existing root.
+- `evict_lru_errors_when_keep_itself_is_missing`: `evict_lru`'s `keep`
+  argument — every caller has just touched or freshly installed `keep`
+  immediately before calling `evict_lru`, so `keep` vanishing is a real
+  problem to surface, not a maybe-absent slot.
+- `dir_size_tolerates_a_subdirectory_removed_mid_walk`: issue #842's macOS
+  ENOENT flake family. This is a genuine cross-thread filesystem race, not
+  a fully deterministic single-shot repro — a `std::sync::Barrier` releases
+  both threads at the same instant, a wide fan of sibling subdirectories
+  gives the walk many entries to still be processing when the deleter
+  runs, and the whole race is repeated 200 times so the window is almost
+  certain to be hit at least once.
+- `dir_size_errors_when_the_root_is_removed_mid_walk`: companion test
+  pinning the other half of the PR #847 contract — when the vanishing path
+  is the walk root itself (not a descendant), `dir_size` must surface an
+  error. Same barrier-race harness, but `root` is left empty (an
+  empty-directory removal is a single `rmdir` syscall, the same order of
+  cost as the `symlink_metadata`/`read_dir` calls `dir_size` opens with —
+  a populated root, by contrast, has its own directory entry removed
+  *last* by `remove_dir_all` after every child, which would make the
+  root-vanish race effectively unreachable). Runs 500 iterations and
+  asserts the race was hit at least once.
+- `refetch_clone_updates_an_existing_slot_to_the_remote_tip`: the primary
+  #765 acceptance path — standing in for genuinely corrupt/incomplete
+  objects, which `git fetch --refetch` repairs the same way (re-obtaining a
+  complete fresh packfile from the remote).
+- `refetch_clone_over_cap_cleanup_never_deletes_an_unproven_slot`:
+  remediation (issue #765) — `refetch_clone`'s over-cap cleanup must go
+  through the same ownership guard `reclone` uses, not a raw
+  `remove_dir_all`, AND must propagate that guard's failure rather than
+  discarding it. Since a later fix added a pre-fetch ownership re-check,
+  this markerless slot is now refused before `fetch_refetch` even runs
+  (see the next test) rather than at the over-cap cleanup step this test
+  originally targeted — the assertions still hold, so this remains a
+  valid regression guard for the cleanup path once a slot somehow reaches
+  it un-owned.
+- `refetch_clone_refuses_a_markerless_slot_under_the_cap`: remediation
+  (issue #765 follow-up PR #788) — `refetch_clone` must refuse a
+  markerless slot *before* ever calling `fetch_refetch`. The origin is
+  given fresh history so a fetch that ran despite the missing marker would
+  be directly observable via a moved `HEAD`.
+- `reclone_replaces_a_slot_whose_refetch_cannot_succeed`: #765's fallback
+  path — a refetch that cannot repair the slot (simulated by pointing the
+  existing slot's `origin` remote at a nonexistent path so `git fetch
+  --refetch` itself fails) is followed by `reclone`, which ignores the
+  broken clone entirely and clones fresh from the still-good
+  `canonical_url`.
+- `reclone_refuses_to_replace_a_foreign_looking_directory`: ownership
+  guard (ADR-088 Amendment 1 / PR #761) — `reclone` must never delete a
+  directory that doesn't prove itself an owned cache slot, even though its
+  path is exactly where the cache key says the slot should be.
+- `ensure_clone_refuses_a_markerless_git_directory_at_the_cache_key_path`:
+  remediation (issue #765) — the directory is a genuine Git repository (so
+  the pre-fix `repo_dir.join(".git").exists()` check alone would have
+  accepted it) but is missing the `.khive-last-used` marker, standing in
+  for an operator's own repository landing on the same cache-key path
+  under an overridden `KHIVE_GIT_DIGEST_SCRATCH_ROOT`.
+- `ensure_clone_refuses_a_symlink_at_the_cache_key_path`: same guard,
+  symlink variant — `is_owned_entry` requires the cache-key path itself to
+  be a real directory, not a symlink to one.

--- a/crates/khive-pack-git/docs/handlers.md
+++ b/crates/khive-pack-git/docs/handlers.md
@@ -1,0 +1,21 @@
+# `git.digest` handler design notes
+
+Extracted from `crates/khive-pack-git/src/handlers.rs` doc-comments.
+
+## `RemoteRecoveryStage` / `RemoteCommitRecovery`
+
+Issue #765 remote-only repair policy: at most one `git fetch --refetch`,
+then at most one owned-cache reclone, bounded by `stage` so a persistent or
+recurring classified failure surfaces as a terminal error rather than
+looping. Local-path sources never construct this — they call public
+`run_ingest` directly, which never repairs anything (ADR-088 Amendment 1:
+the disposable scratch cache is remote-URL-mode-only).
+
+## `repair`
+
+Advances the bounded repair state machine by one step in response to a
+classified `GitLogError` (the caller has already verified
+`is_missing_promisor_object()`). Ignores `_repo` — both repair primitives
+operate on the cache slot for `canonical_url`, which is the same path
+`_repo` already names (`crate::cache`'s slot layout is keyed by URL, not
+passed through).

--- a/crates/khive-pack-git/docs/hooks.md
+++ b/crates/khive-pack-git/docs/hooks.md
@@ -1,0 +1,25 @@
+# Git pack `KindHook` design notes
+
+Extracted from `crates/khive-pack-git/src/hook.rs` doc-comments.
+
+## Module overview
+
+Validation only — this pack introduces no new edges at `after_create` time.
+Provenance edges (`annotates` -> project / document / merging PR) are
+supplied by the caller (the ingester, see `src/ingest.rs`) as part of the
+generic `create(kind=..., annotates=[...])` call; the runtime's own
+`create_note` path validates and links them atomically, so no
+`after_create` edge-creation logic is needed here (unlike gtd's
+`TaskHook::after_create`).
+
+## `IssueLikeHook`
+
+GitHub issue/PR numbers are repository-scoped, not globally unique — two
+different `project` entities in the same namespace can each have a `#1`.
+`properties.project_id` is the natural-key scoping field the ingester's
+`find_by_number` lookup filters on, so it is required and validated as a
+UUID here rather than left to the caller's discipline.
+
+`ISSUE_STATE_REASONS` is `pub(crate)` so `ingest::MaskedIssueFields` can
+classify against the same set at the masking boundary, before an ungoverned
+(possibly credential-shaped) raw value can reach this hook's error path.

--- a/crates/khive-pack-git/docs/ingest.md
+++ b/crates/khive-pack-git/docs/ingest.md
@@ -1,0 +1,295 @@
+# Batch git-history ingester — design notes
+
+Long-form rationale extracted from `crates/khive-pack-git/src/ingest.rs`
+doc-comments. Everything documented here is a non-public (private or
+`pub(crate)`) item — internal notes, not the published API reference (the
+crate's public surface — `IngestInclude`, `IngestOptions`, `IngestReport`,
+`run_ingest`, `resolve_project_id` — keeps its complete doc-comments in the
+source file itself).
+
+## Module overview
+
+One-shot: walks local git history plus (optionally) `gh`-fetched issues and
+pull requests, and writes `commit` / `issue` / `pull_request` notes through
+the standard `create` verb (so `KindHook` validation and `annotates` edge
+creation run exactly as they would for any other caller). Reuses ADR-087's
+operational pattern (cursor table, secret masking on ingest, cursor
+advances only on success) — NOT a daemon loop, NOT a webhook, NOT a poller:
+one pass per invocation.
+
+## `Budget`
+
+Bounds the number of new-record creation attempts across a `run_ingest`
+pass (ADR-088 Amendment 1 `max_items`). Only creation attempts (success or
+failure) consume budget — cheap natural-key "already exists" skips do not,
+since they are not the work the bound exists to limit.
+
+## `NewRecordForRef`
+
+A newly created note this pass, retained so the post-ingestion
+reference-extraction sweep (`link_references`) can resolve cross-references
+between records created in the *same* pass regardless of ingestion order
+(PRs and issues are ingested before commits) without re-reading them from
+storage.
+
+## `run_ingest_with_commit_recovery`
+
+Same one-shot ingest pass as `run_ingest`, but a classified
+missing-promisor-object failure while loading the commit-history snapshot
+(`GitLogError::is_missing_promisor_object`) is retried through `recover`
+instead of aborting the whole pass (issue #765). Issues and PRs still run
+exactly once regardless of whether recovery is later needed or invoked —
+only commit-snapshot acquisition (`walk_commits` + `touched_files`) is
+retried, inside this same invocation's `Budget`, `IngestReport`, PR/merge
+maps, and reference candidates (`new_records`); a repair never resets or
+replays any of them, and there is no second `run_ingest` pass hiding behind
+this one.
+
+`run_ingest` itself delegates to this with a recovery callback that never
+repairs anything — the CLI and any local-path caller has no disposable
+remote cache to repair (issue #765 self-heal is remote-URL mode only,
+ADR-088 Amendment 1), so a classified commit-snapshot failure here surfaces
+as an ordinary error, exactly as before this pass gained recovery support.
+Also: issues + PRs are ingested first (via `gh`, when available), then
+commits (via local `git log`) — PRs are ingested before commits so a
+commit's `annotates` list can reference an already-created merging-PR note
+(the generic `create` verb validates `annotates` targets exist before it
+writes — see `khive-runtime::operations::create_note_inner`).
+
+## `resolve_id`
+
+Resolves a full UUID or an 8+ hex prefix to a full UUID, unfiltered by
+namespace (matches the by-ID resolution contract used by `get`/`update`).
+
+## `link_references`
+
+Post-ingestion sweep (ADR-088 Amendment 1 ingest enrichment): extracts
+GitHub reference-grammar mentions from every note created *this pass*
+(commits, issues, PRs — order-independent, since all three are already in
+`new_records` by the time this runs) and materializes `annotates` edges to
+the referenced issue/PR note, carrying `ref_kind` ("closes" | "mentions")
+as edge metadata. Fail-open throughout: a malformed or unresolvable
+reference is skipped and counted, never aborts the pass.
+
+## `find_commit_by_sha` / `find_by_number`
+
+Natural-key idempotence lookups (dedupe-before-create). `find_by_number` is
+scoped by kind + namespace + `project_id` since GitHub issue/PR numbers are
+repository-scoped — a bare `kind`+`number` filter would incorrectly collide
+two different repos' `#1`.
+
+## `find_document_for_path`
+
+Finds an existing `document` entity whose `properties.source_uri` or
+`name` matches `path` (ADR-086 keying convention). Returns `None` when no
+match — v0 never creates documents on the ingester's behalf (skip the
+edge).
+
+Exact and suffix-`LIKE` candidates are selected in a single query/snapshot
+so a document inserted between an exact-match read and a fallback read can
+never be missed by the exact branch, and a wildcard-broadened match can
+never shadow an exact one: the `ORDER BY` ranks exact matches first, with
+`id` as a deterministic tiebreaker (PR #816 fixed a TOCTOU gap here, and a
+sibling bug where an unescaped path let `%`/`_` act as `LIKE` wildcards —
+see `find_document_for_path_tests`).
+
+## `write_cursor`
+
+Called once per section (commits/prs/issues) after that section's loop
+finishes, with a value that stops advancing at the first per-record create
+failure (see the `cursor_stalled` handling in each `ingest_*` loop) — so
+the next pass re-walks from before the failure and retries it, while
+records that already landed (including ones ingested later in a stalled
+pass) are no-ops via natural-key dedupe.
+
+## Issue #765: commit-snapshot recovery
+
+`GitLogPhase` distinguishes which `git log` pass a classified failure came
+from: the two passes fail independently (`walk_commits`'s plain metadata
+pass can succeed via cached commit data while `touched_files`'s
+`--name-only` pass needs a tree that the promisor cache dropped, or vice
+versa), so recovery needs to know which one to retry.
+
+`GitLogError` carries its phase and raw stderr so `is_missing_promisor_object`
+can classify it without losing the underlying diagnostic (surfaced verbatim
+in the final error when recovery is unavailable or exhausted). The
+classification is deliberately narrow (ASCII-case-insensitive `promisor`
+plus either `not in the object database` or `missing object`) so ordinary
+auth/network/`bad object`/spawn/local-source failures are never treated as
+corrupt-cache and never trigger a destructive repair.
+
+`walk_commits` shells out to `git log` with a stable, machine-parseable
+format (v0 choice per ADR-088 §5 — `git2`/`gix` are not workspace
+dependencies today, so shelling out avoids a new heavy dependency). Raw
+control-byte separators are embedded directly in the format string (not
+git's `%xHH` escape syntax) — passed as a single argv element (never
+through a shell), so the literal bytes survive intact and git's
+pretty-format engine emits any non-`%` character verbatim.
+
+`touched_files` is a separate `--name-only` pass, kept apart from
+`walk_commits`'s custom `--pretty=format` — interleaving file-name lines
+with the metadata format has no clean, unambiguous delimiter.
+
+`CommitSnapshot` bundles both passes so a classified failure in either one
+can be retried as a single unit. `load_commit_snapshot` mirrors
+`ingest_commits`'s original inline sequencing: `touched_files` (a second,
+unscoped `git log --name-only` pass over the whole history) is skipped
+entirely when `walk_commits` found no new commits, since there is nothing
+new to annotate with touched paths.
+
+`CacheRepairStrategy` records which repair `RemoteCommitRecovery`
+(`handlers.rs`) performed, so `recover_commit_snapshot` can report exactly
+one truthful success warning once the commit phase completes.
+`RecoveredRepo` carries the repo path and strategy a `recover` callback
+used to repair a classified `GitLogError` — `recover_commit_snapshot`
+retries the snapshot load against that path (the same cache slot for both
+strategies in `cache.rs`, but callers are not required to keep it
+identical).
+
+`recover_commit_snapshot` is bounded entirely by `recover`'s own return
+value: `Ok(Some(_))` retries the snapshot load against the recovered repo
+path, `Ok(None)` surfaces the original classified error (no more repair
+available), and any other error (including an unclassified `GitLogError` or
+a non-`GitLogError` failure) is returned immediately without ever calling
+`recover`. A later repair attempt's strategy replaces the pending warning
+rather than accumulating one per attempt, so exactly one success warning is
+ever returned — describing the *last* repair that was needed, not every
+one tried.
+
+## Masking boundaries (`MaskedCommitFields`, `MaskedIssueFields`, `MaskedPrFields`)
+
+Every raw git/`gh` record funnels through one constructor before it can
+reach `properties`/`content`/the note `name`/paging cursors. Each `new`
+destructures its source struct exhaustively (no `..`), so a future new
+field forces a compile error here before it can silently skip the masking
+boundary — the same one-boundary-per-record-type discipline across
+`MaskedCommitFields`, `MaskedIssueFields` (issue #841, following #835's
+pattern), and `MaskedPrFields` (issue #841: PR author, base ref, and head
+ref were the residual raw fields after #835's title fix).
+
+For `MaskedCommitFields`: `sha`/`short_sha`/`committed_at`/`parents` are
+git-computed hashes and an RFC3339 timestamp — not attacker-authored free
+text — so they pass through unchanged. `author`, `author_email`,
+`subject`, and `body` are git-config- and commit-message-controlled prose
+and go through the same `mask_secrets` gate `content` already used —
+closing the gap where the commit note `name` (built from the raw subject)
+and its `author`/`author_email` properties skipped masking entirely.
+
+For `MaskedPrFields`: `number`, the four timestamp fields, and
+`merge_commit`'s `oid` are GitHub-generated (not attacker-authored free
+text) and pass through unchanged. `title`, `body`, the author login, and
+both ref names are contributor-controlled prose and go through the same
+`mask_secrets` gate.
+
+`StateReasonField` is the classified outcome of parsing a raw `stateReason`
+string against the governed enum (`hook::ISSUE_STATE_REASONS`, ADR-088 §3)
+at the masking boundary. `Rejected` never carries the raw string forward —
+the ingest loop must reject the record with a warning that names only the
+field, never its value (a credential-shaped `stateReason` must never reach
+`report.warnings` or the hook's own error path).
+
+`canonical_issue_state_reason` normalizes case before the membership check
+(GitHub reports `stateReason` as `""` for open issues and an UPPERCASE enum
+value, e.g. `NOT_PLANNED`, for closed ones). A value that is present,
+non-empty, and not one of the four governed values is classified
+`Rejected`.
+
+`canonical_issue_timestamp` parses a GitHub issue timestamp into canonical
+RFC3339 form. GitHub's API always returns valid RFC3339 timestamps; a value
+that fails to parse is untrusted/malformed input (a credential-shaped
+string is exactly this case) and must never reach `properties` or the
+paging cursor as a raw string. On parse failure the field is rejected
+(becomes absent) and a warning is recorded — without the raw value, which
+may itself be secret-shaped. The issue itself is still ingested; only this
+one field is dropped.
+
+## Paging (`PageOutcome`, `decide_page_outcome`, `PAGE_LIMIT`)
+
+`PAGE_LIMIT` (1000) is the per-page fetch cap for both PR and issue paging.
+`gh {pr,issue} list --search` is backed by GitHub's search API, which never
+returns more than this many results for a single query regardless of
+`--limit` — paging works around that ceiling by advancing an `updated:>=`
+floor between calls, not by requesting more than one page can hold.
+
+`PageOutcome` is pure and unit-testable independent of `gh`, the database,
+or async machinery — the entire "was the remote window proven exhausted"
+decision lives here (ADR-088 Amendment 1): a single hard-coded `--limit
+1000` fetch could previously report `done: true` while a repo's remaining
+PRs/issues past position 1000 were never seen.
+
+- `WindowComplete`: the page held fewer than `PAGE_LIMIT` items — the
+  remote window is proven exhausted regardless of local budget state.
+- `StopBudgetExhausted`: the page was full and the local budget is
+  exhausted — stop paging, but the window is NOT proven exhausted.
+- `StopFloorStalled`: the page was full and the last item's `updated_at`
+  did not advance past the current floor (more than `PAGE_LIMIT` records
+  share one timestamp — an unresolvable pathological case) — stop paging
+  rather than loop forever. The window is NOT proven exhausted.
+- `Continue(floor)`: the page was full, the budget is not exhausted, and
+  the floor advanced — fetch the next page starting at this floor.
+
+Only `WindowComplete` lets `done` stay `true` on the local-budget question
+alone; every other outcome means more remote records may exist past the
+last fetched page.
+
+## `ingest_prs` / `ingest_issues` cursor semantics
+
+`cursor_stalled` mirrors `ingest_commits`: once one record fails to create,
+later records in this pass are still attempted (so every failure surfaces
+in this pass's warnings), but `max_updated` no longer advances past the
+stall point — the next pass re-fetches from before the failure and retries
+it, while already-landed records are no-ops via the natural key.
+
+Each page is already `sort:updated-asc` server-side, but `--search` makes
+no hard ordering guarantee across ties — both loops re-sort defensively so
+the frozen-cursor invariant (records walked in nondecreasing `updated_at`
+order) holds regardless. `is_new` is inclusive (`updated >= cursor`) for
+exactly the tie reason: a successful and a failing record sharing one
+`updated_at` must both be re-examined next pass until the cursor moves past
+that tie.
+
+In `ingest_issues`, the entire fetched page is classified (masked strings,
+canonicalized timestamps, governed-enum `state_reason`) before anything
+else — including the sort and the paging cursor derivation — touches it. A
+raw `GhIssue.updated_at` must never reach the sort comparator,
+`last_updated_at`, or (via `decide_page_outcome`'s `Continue`) a future `gh
+--search updated:>=` argument (a credential-shaped `updatedAt` could
+otherwise sort last and leak into process arguments through the paging
+floor). An ungoverned `stateReason` is rejected before the record is ever
+built or dispatched — the warning names only the field, never the raw
+(possibly credential-shaped) value, matching ADR-088's
+fail-closed/no-silent-coercion contract.
+
+Reported `done = false` whenever the remote window is not proven complete
+(`StopBudgetExhausted` / `StopFloorStalled`) — the local budget alone is
+not a complete signal.
+
+## Test module notes
+
+- `recovery_classifier_tests`: pure/synchronous `GitLogError`
+  classification + `recover_commit_snapshot` retry-loop tests. Lives here
+  (not in the sibling `recovery_tests` module) because these fields are
+  private to this module; `recovery_tests` drives the DB-backed acceptance
+  scenarios through the `pub(crate)` surface instead. Tests spawning real
+  `git` via bare `Command::new("git")` must hold the crate-wide
+  `cache::ENV_MUTEX` the `PATH`-shimming tests in `cache.rs` and
+  `recovery_tests.rs` hold while they swap `PATH` to a fake `git`, or a
+  test can spawn that shim instead of real git and misclassify a healthy
+  repo as corrupt.
+- `truncation_tests`: `truncated_embedding_head` boundary tests, including
+  a multibyte scalar (3-byte `€`) straddling the byte cap, which must roll
+  the boundary back to the nearest valid char boundary rather than
+  panicking or splitting the scalar.
+- `compact_prefix_resolver_tests` (PR #816): `resolve_id`/`resolve_project_id`
+  call the public `resolve_prefix_unfiltered` resolver without their own
+  all-hex gate, so a `%`-bearing (or otherwise non-hex) `project` argument
+  reached the bound `LIKE` pattern unfiltered. The runtime resolver
+  boundary (`resolve_prefix_inner`) now rejects non-hex/non-hyphen input
+  itself, so these callers inherit the fix without needing their own gate.
+- `find_document_for_path_tests` (PR #816): `find_document_for_path` bound
+  an unescaped path into a `LIKE` pattern (`%`/`_` in a filename became
+  pattern wildcards) and picked whichever candidate the unordered `LIMIT 1`
+  scan happened to return first, even when an exact match existed.
+  Resolution now happens in one query/snapshot: both candidates are
+  visible to the same `SELECT`, and the `ORDER BY` — not read ordering —
+  decides the exact match wins.

--- a/crates/khive-pack-git/docs/vocab.md
+++ b/crates/khive-pack-git/docs/vocab.md
@@ -1,0 +1,71 @@
+# Git pack vocabulary — design notes
+
+Long-form rationale extracted from `crates/khive-pack-git/src/vocab.rs` doc-comments.
+All items in that module are `pub(crate)` (the `vocab` module itself is
+`pub(crate)` in `lib.rs`), so none of this renders on docs.rs — it is kept
+here for future maintainers instead of inline.
+
+## Module overview
+
+ADR-088 v0 shipped with no `HANDLERS` and no `EDGE_RULES`: zero new verbs,
+relying exclusively on the base `annotates` contract (note -> any substrate)
+for provenance edges. ADR-088 Amendment 1 adds exactly one verb
+(`git.digest`) and one endpoint extension (`precedes` commit→commit, for
+parent→child commit lineage). See `crates/khive-pack-git/src/pack.rs` for
+how this vocabulary is wired into `GitPack`.
+
+## `GIT_LIFECYCLE`
+
+Lifecycle declaration shared by `issue` and `pull_request` — both track an
+open/closed state with the same posture as ADR-088's `finding` precedent:
+declared for introspection, not yet enforced by the runtime (Phase 1).
+
+## `GIT_NOTE_KIND_SPECS`
+
+`commit` deliberately has no entry: commits are immutable and carry no
+lifecycle field.
+
+## `GIT_SCHEMA_PLAN_STMTS`
+
+Pack-auxiliary schema: the git-ingest cursor table (ADR-088 §5, ADR-087
+operational pattern reused).
+
+Shape is intentionally generic across git record kinds within a project —
+`kind` distinguishes `commits` / `issues` / `prs` cursors so a follow-up pack
+(e.g. a code-review pack) can reuse this exact table for its own cursor rows
+without a schema change, keyed by its own `project_id`/`kind` pair.
+Idempotent (`CREATE TABLE IF NOT EXISTS`), applied once at pack registration
+time; not part of the core versioned migration chain.
+
+## `GIT_EDGE_RULES`
+
+ADR-088 Amendment 1 ingest enrichment: parent→child commit lineage as
+`precedes` edges. The base endpoint contract only allows `precedes` between
+five entity kinds (`document`, `dataset`, `artifact`, `service`, `project` —
+see `khive-runtime::operations::BASE_ENTITY_ENDPOINT_RULES`); it has no
+note→note case at all. This is the same additive-extension mechanism
+`khive-pack-gtd` uses for `depends_on` task→task.
+
+## `GIT_ENTITY_TYPES`
+
+Pack-declared `Document` entity-type subtype: Architecture Decision Records.
+
+`find_document_for_path` (`src/ingest.rs`) resolves pre-existing `document`
+entities by git-tracked file path (`properties.source_uri`) so commits/PRs
+can `annotates`-link to them; this pack never creates those document
+entities itself ("v0 never creates documents on the ingester's behalf"). The
+single most common git-tracked document kind ingesting agents attach to a
+repo's `document` entities is its ADR corpus (`docs/adr/*.md`) — but
+`EntityTypeRegistry::BUILTIN_DEFS` has no `adr` Document subtype, so any
+caller attempting `entity_type="adr"` was rejected at the handler layer, and
+callers omitted `entity_type` entirely rather than retry against an unknown
+value: a schema gap, not a data gap. Declaring it here (composed at boot via
+`VerbRegistry::all_entity_types`, ADR-017's additive pack-vocabulary
+pattern) makes ADR documents representable without editing the builtin
+registry.
+
+## `GIT_HANDLERS`
+
+Illocutionary classification (Searle 1976): `git.digest` commits data to the
+graph (ingests notes and edges), so it is `Commissive` — the same category
+`create`/`link`/`remember` use.

--- a/crates/khive-pack-git/src/cache.rs
+++ b/crates/khive-pack-git/src/cache.rs
@@ -1,36 +1,15 @@
 //! Scratch-clone cache for `git.digest`'s remote-URL mode (ADR-088
-//! Amendment 1).
-//!
-//! Clones/fetches into `~/.khive/scratch/git-digest/<cache_key>/`, keyed by
-//! canonical URL (`crate::source::cache_key`). An LRU cap evicts the
-//! least-recently-used clone (by a `.khive-last-used` marker file's mtime,
-//! touched on every successful `ensure_clone`) once the cache exceeds
-//! `digest_cache_max_repos` entries or `digest_cache_max_bytes` total size --
-//! eviction is safe because ingest cursors live in the database, not the
-//! clone (ADR-088 Amendment 1 §Remote-URL mode). Eviction only ever removes
-//! entries it can *prove* it owns (`is_owned_entry`: a 16-hex cache-key
-//! directory name containing both a `.git` dir and the `.khive-last-used`
-//! marker) -- a `KHIVE_GIT_DIGEST_SCRATCH_ROOT` override pointed at a broader
-//! or pre-existing directory must never lose unrelated operator data.
-//!
-//! A per-clone size cap (`digest_cache_clone_max_bytes`) rejects a clone/
-//! fetch that grows past its own budget *before* it ever enters the
-//! addressable cache slot: `ensure_clone` clones/fetches into a staging
-//! directory outside the cache root, measures it, and only moves it into
-//! `<root>/<cache_key>/` when it is under the cap. A too-large clone is
-//! deleted from staging and never touches `evict_lru`'s bookkeeping or the
-//! cache slot. This guarantees the cap is enforced before the clone enters
-//! the cache -- it does NOT bound the transient disk usage of the clone/
-//! fetch child process itself while it runs in staging (`git` has no
-//! reliable pre-flight or mid-transfer size check for a partial
-//! `--filter=blob:none` clone); a single oversized `git clone` can still
-//! transiently consume disk in the staging directory before this check
-//! rejects and removes it.
-//!
-//! Config is env-var driven today (`KHIVE_GIT_DIGEST_CACHE_MAX_REPOS`,
-//! `KHIVE_GIT_DIGEST_CACHE_MAX_BYTES`, `KHIVE_GIT_DIGEST_CLONE_MAX_BYTES`,
-//! `KHIVE_GIT_DIGEST_SCRATCH_ROOT`) rather than a `[git]` TOML section --
-//! see the implementation report for why.
+//! Amendment 1). Clones/fetches into
+//! `~/.khive/scratch/git-digest/<cache_key>/`, keyed by canonical URL
+//! (`crate::source::cache_key`). An LRU cap (env-var configured:
+//! `KHIVE_GIT_DIGEST_CACHE_MAX_REPOS`, `KHIVE_GIT_DIGEST_CACHE_MAX_BYTES`,
+//! `KHIVE_GIT_DIGEST_CLONE_MAX_BYTES`, `KHIVE_GIT_DIGEST_SCRATCH_ROOT`)
+//! evicts least-recently-used clones once the cache exceeds its repo-count
+//! or total-byte limit; a per-clone size cap rejects an oversized
+//! clone/fetch before it enters the addressable cache slot. See
+//! crates/khive-pack-git/docs/cache.md for the full design rationale
+//! (ownership-proof eviction, staging-then-move installation, per-clone cap
+//! enforcement).
 
 use std::path::{Path, PathBuf};
 use std::process::Command;
@@ -54,11 +33,9 @@ pub enum CacheError {
         bytes: u64,
         cap: u64,
     },
-    /// A repair operation (refetch/reclone) would have to touch a path that
-    /// does not prove itself an owned cache slot (`is_owned_entry`) or is
-    /// not a direct child of the scratch root — refused rather than risking
-    /// deletion of unrelated operator data under an overridden
-    /// `KHIVE_GIT_DIGEST_SCRATCH_ROOT`.
+    /// A repair operation would have to touch a path that does not prove
+    /// itself an owned cache slot. See
+    /// crates/khive-pack-git/docs/cache.md#cacheerrorunsafetoreplace.
     UnsafeToReplace(PathBuf),
 }
 
@@ -128,28 +105,16 @@ fn clone_max_bytes() -> u64 {
 /// Ensure a local clone of `canonical_url` exists and is up to date; returns
 /// the repo's local path.
 ///
-/// An existing path at the cache-key slot is only ever treated as a fetchable
-/// cache slot when it already passes `is_owned_entry` -- a `.git` directory
-/// sitting at that path without the `.khive-last-used` marker (a foreign
-/// directory that happens to collide with the cache key, or a directory a
-/// crashed prior run left in a pre-`touch` state) is refused with
-/// `CacheError::UnsafeToReplace` rather than fetched into or adopted (issue
-/// #765). A fresh clone is written into a private
-/// staging directory first (`git clone --filter=blob:none`), measured there,
-/// marked with `.khive-last-used` there, and only *moved* into the
-/// addressable `<root>/<cache_key>/` slot once it is under the cap and
-/// already carries its ownership marker -- an oversized clone never enters
-/// the cache slot, never participates in `evict_lru`'s accounting, and is
-/// removed from staging immediately; a process interruption between the
-/// clone and the rename can never leave a live, markerless slot behind.
-///
-/// A repo that grew past the per-clone cap since it was last fetched is
-/// evicted from the cache slot on the spot, through the same ownership-
-/// guarded `remove_owned_entry` every other repair path uses, propagating
-/// any cleanup/ownership failure instead of discarding it.
-///
-/// Runs LRU eviction over the rest of the cache after a successful
-/// clone/fetch (this clone is exempt from its own eviction pass).
+/// Fetches into the existing slot if one already proves itself owned
+/// (`is_owned_entry`); otherwise clones fresh into a private staging
+/// directory, enforces the per-clone size cap, and only then moves it into
+/// the addressable cache slot. Returns `CacheError::UnsafeToReplace` if a
+/// non-owned directory already occupies the cache-key path, and
+/// `CacheError::CloneTooLarge` if the clone/fetch exceeds
+/// `digest_cache_clone_max_bytes`. Runs LRU eviction over the rest of the
+/// cache after a successful clone/fetch (this clone is exempt from its own
+/// eviction pass). See crates/khive-pack-git/docs/cache.md#ensure_clone for
+/// the staging-then-move and ownership-guard rationale.
 pub fn ensure_clone(canonical_url: &str) -> Result<PathBuf, CacheError> {
     let root = scratch_root();
     std::fs::create_dir_all(&root)?;
@@ -182,16 +147,8 @@ pub fn ensure_clone(canonical_url: &str) -> Result<PathBuf, CacheError> {
 }
 
 /// Re-fetch a corrupt-but-present cache slot with `git fetch --refetch`
-/// (issue #765): downloads a complete fresh filtered packfile rather than
-/// trusting the existing (possibly promisor-incomplete) object store,
-/// repairing a partial/pruned clone in place. Only ever operates on an
-/// existing slot -- callers repair a slot only after a prior `ensure_clone`
-/// already produced one. Re-checks `is_owned_entry` immediately before
-/// fetching (issue #765 follow-up PR #788): the
-/// gap between `ensure_clone`'s own ownership check and this repair running
-/// -- project resolution and GitHub ingestion happen in between -- is wide
-/// enough for the slot to go markerless or be replaced, so this function
-/// cannot rely on the caller having checked recently.
+/// (issue #765), re-checking ownership immediately before fetching. See
+/// crates/khive-pack-git/docs/cache.md#refetch_clone.
 pub(crate) fn refetch_clone(canonical_url: &str) -> Result<PathBuf, CacheError> {
     let root = scratch_root();
     let key = cache_key(canonical_url);
@@ -203,18 +160,7 @@ pub(crate) fn refetch_clone(canonical_url: &str) -> Result<PathBuf, CacheError> 
         )));
     }
     // Re-check ownership immediately before mutating the slot (issue #765
-    // follow-up PR #788): the caller's own
-    // ownership check (`ensure_clone`, much earlier in `handle_digest`)
-    // happens before project resolution and potentially lengthy GitHub
-    // ingestion, so the slot can go markerless -- or be replaced by a
-    // foreign directory colliding with the cache key -- in that interval.
-    // Without this re-check, `fetch_refetch` below would mutate whatever
-    // sits at `repo_dir` and `touch` would mark it owned, making it eligible
-    // for later deletion. There is no same-key serialization for cache
-    // mutation in this crate today (a concurrent `ensure_clone`/`reclone`
-    // racing this same slot is not otherwise excluded) -- this re-check
-    // narrows the adoption bug but does not close a true concurrent-writer
-    // race.
+    // follow-up PR #788) — see crates/khive-pack-git/docs/cache.md#refetch_clone.
     if !is_owned_entry(&repo_dir) {
         return Err(CacheError::UnsafeToReplace(repo_dir));
     }
@@ -222,19 +168,10 @@ pub(crate) fn refetch_clone(canonical_url: &str) -> Result<PathBuf, CacheError> 
     fetch_refetch(&repo_dir)?;
 
     let cap = clone_max_bytes();
-    // Same reasoning as `ensure_clone`: `repo_dir`'s ownership was just
-    // re-checked and it was just fetched into, so a vanish here is a real
-    // problem to surface, not a maybe-absent slot to size as `0`.
     let size = dir_size(&repo_dir)?;
     if size > cap {
-        // Route through the same ownership-guarded removal `reclone` uses
-        // (issue #765 remediation) rather than a raw
-        // `remove_dir_all` -- a repair primitive must never delete a path
-        // that doesn't prove itself an owned cache slot, even on the cap-
-        // exceeded cleanup path. Propagate a cleanup/ownership failure
-        // instead of discarding it: a refused or
-        // failed removal must surface as its own error, not be silently
-        // swallowed behind `CloneTooLarge`.
+        // Ownership-guarded removal, not a raw `remove_dir_all` — see
+        // crates/khive-pack-git/docs/cache.md#refetch_clone.
         remove_owned_entry(&root, &repo_dir)?;
         return Err(CacheError::CloneTooLarge { bytes: size, cap });
     }
@@ -245,12 +182,8 @@ pub(crate) fn refetch_clone(canonical_url: &str) -> Result<PathBuf, CacheError> 
 }
 
 /// Evict an owned cache slot (if present) and install a fresh clone in its
-/// place (issue #765's fallback when a refetch cannot repair the slot).
-/// Refuses via `CacheError::UnsafeToReplace` when the existing path does not
-/// prove itself an owned cache slot -- the same ownership guard `evict_lru`
-/// uses, so a `KHIVE_GIT_DIGEST_SCRATCH_ROOT` override pointed at a broader
-/// or pre-existing directory can never lose unrelated operator data here
-/// either.
+/// place (issue #765's fallback when a refetch cannot repair the slot). See
+/// crates/khive-pack-git/docs/cache.md#reclone.
 pub(crate) fn reclone(canonical_url: &str) -> Result<PathBuf, CacheError> {
     let root = scratch_root();
     std::fs::create_dir_all(&root)?;
@@ -266,14 +199,8 @@ pub(crate) fn reclone(canonical_url: &str) -> Result<PathBuf, CacheError> {
 }
 
 /// Shared staging-clone-then-move path for both a first-time `ensure_clone`
-/// and a `reclone` repair: clones into a private staging directory outside
-/// the cache root, measures it against the per-clone cap, writes the
-/// `.khive-last-used` ownership marker into the staging directory itself,
-/// and only then moves it into the addressable `<root>/<cache_key>/` slot --
-/// an oversized clone never enters the cache slot, and because the marker is
-/// written before the atomic rename, a process interruption between clone
-/// and rename can never leave a live, markerless slot at the cache-key path
-/// (issue #765).
+/// and a `reclone` repair. See
+/// crates/khive-pack-git/docs/cache.md#install_fresh_clone.
 fn install_fresh_clone(
     canonical_url: &str,
     root: &Path,
@@ -308,10 +235,7 @@ fn install_fresh_clone(
 }
 
 /// Remove `repo_dir` only when it is a direct child of `root` AND passes
-/// `is_owned_entry` -- refuses (`CacheError::UnsafeToReplace`) rather than
-/// deleting anything else, including a not-yet-existing or foreign-shaped
-/// path. A slot that does not currently exist is not an error: there is
-/// simply nothing to remove before installing a fresh clone.
+/// `is_owned_entry`. A slot that does not currently exist is not an error.
 fn remove_owned_entry(root: &Path, repo_dir: &Path) -> Result<(), CacheError> {
     if !repo_dir.exists() {
         return Ok(());
@@ -323,11 +247,8 @@ fn remove_owned_entry(root: &Path, repo_dir: &Path) -> Result<(), CacheError> {
     Ok(())
 }
 
-/// `std::fs::remove_dir_all` on a large git working tree can transiently
-/// fail with "directory not empty" when something else briefly touches the
-/// tree mid-removal (e.g. a filesystem indexer) -- retry a few times before
-/// giving up, rather than letting a one-off transient race abort a repair
-/// that would otherwise succeed.
+/// Retries `remove_dir_all` a few times before giving up — see
+/// crates/khive-pack-git/docs/cache.md#remove_dir_all_retrying.
 fn remove_dir_all_retrying(path: &Path) -> std::io::Result<()> {
     let mut last_err = None;
     for attempt in 0..5 {
@@ -344,41 +265,11 @@ fn remove_dir_all_retrying(path: &Path) -> std::io::Result<()> {
     Err(last_err.expect("loop always sets last_err before exiting"))
 }
 
-/// `-c maintenance.auto=false` on every clone/fetch into a cache slot, as
-/// defensive hardening. `git fetch` runs auto-maintenance after it
-/// finishes when `maintenance.auto` (default true) is set, and since git
-/// 2.47 that maintenance runs as a *detached background child*
-/// (`git maintenance run --auto --detach`) that can outlive the foreground
-/// command; on 2.46 and earlier it ran synchronously. The spawn is
-/// trace2-proven in both directions on the `fetch --refetch` path
-/// (`GIT_TRACE2_EVENT`, git 2.49: with default config the child forks; with
-/// `maintenance.auto=false` it does not). The same trace showed `clone`
-/// spawning no maintenance child; the flag is applied to the clone builder
-/// too purely as harmless defensive configuration, with no trace evidence
-/// claimed for that path. When one of the detached child's tasks fires it
-/// mutates the slot's `.git` tree (commit-graph writes, pack maintenance,
-/// lock files) concurrently with any `dir_size`/`evict_lru` walk of the
-/// same slot. Whether such a task actually fired in issue #842's historical
-/// macOS ENOENT failures is not proven -- in small repos the child
-/// typically finds no task to run and exits quickly -- so the load-bearing
-/// fix for that flake family is the descendant-vanish tolerance in
-/// `dir_size`; this flag removes the one background mutator git itself can
-/// fork into our cache slots. `gc.auto=0` alone does **not** suppress the
-/// child (trace2-verified); it is kept alongside because it disables
-/// `git gc --auto`'s separate opportunistic-gc check, harmless to also turn
-/// off here.
-///
-/// This does not mean a cache slot is naturally garbage-collected some other
-/// way instead: no cache-slot repo is ever gc'd or maintenance'd by us.
-/// Growth is bounded by wholesale eviction, not in-place compaction --
-/// `ensure_clone`/`refetch_clone` delete a slot outright
-/// (`remove_owned_entry`) the moment it measures over
-/// `digest_cache_clone_max_bytes` after a fetch, and `evict_lru` deletes
-/// whole least-recently-used slot directories once the cache-wide
-/// `digest_cache_max_repos`/`digest_cache_max_bytes` caps are exceeded. A
-/// slot can be fetched into repeatedly, but it can never accumulate objects
-/// past its own size cap without being deleted and re-cloned fresh, so there
-/// is nothing for git's own gc/maintenance to usefully do in a cache slot.
+/// `-c maintenance.auto=false` on every clone/fetch into a cache slot: git
+/// can otherwise spawn a detached background maintenance child that mutates
+/// the slot's `.git` tree concurrently with a `dir_size`/`evict_lru` walk
+/// (issue #842 flake family). See
+/// crates/khive-pack-git/docs/cache.md#clone-git-subprocess-maintenanceautofalse.
 fn clone(url: &str, dest: &Path) -> Result<(), CacheError> {
     let status = Command::new("git")
         .arg("-c")
@@ -428,8 +319,7 @@ fn fetch(repo: &Path) -> Result<(), CacheError> {
 
 /// Issue #765 repair primitive: `git fetch --refetch origin` obtains a
 /// complete fresh filtered packfile instead of incrementally trusting the
-/// existing (possibly promisor-incomplete) object store -- the documented
-/// fix for a partial clone that has dropped objects it should still have.
+/// existing object store.
 fn fetch_refetch(repo: &Path) -> Result<(), CacheError> {
     let status = Command::new("git")
         .arg("-c")
@@ -455,10 +345,7 @@ fn fetch_refetch(repo: &Path) -> Result<(), CacheError> {
     Ok(())
 }
 
-/// Wrap an I/O error with the operation and path it happened on -- a bare
-/// `CacheError::Io(e)` at these call sites used to surface as an opaque
-/// "No such file or directory" with no way to tell which of the many paths
-/// `dir_size`/`touch`/`evict_lru` touch actually disappeared.
+/// Wraps an I/O error with the operation and path it happened on.
 fn io_err(op: &str, path: &Path, e: std::io::Error) -> CacheError {
     CacheError::Io(std::io::Error::new(
         e.kind(),
@@ -472,33 +359,11 @@ fn touch(repo_dir: &Path) -> Result<(), CacheError> {
     Ok(())
 }
 
-/// Recursive directory size, following no symlinks (`symlink_metadata`
-/// throughout, so a symlink itself is sized but never traversed -- clones
-/// never legitimately contain symlinked directories pointing outside the
-/// clone, and this avoids any possibility of a symlink loop).
-///
-/// Tolerant of a *descendant* disappearing mid-walk (a vanished entry
-/// beneath an existing root contributes 0 bytes rather than aborting the
-/// whole size computation): a cache slot's `.git` tree can legitimately be
-/// mutated by something outside this function's control while it walks it
-/// -- a concurrent `evict_lru`/`ensure_clone` repair on the same slot, or a
-/// background `git maintenance` child from before `maintenance.auto=false`
-/// applied to every command this crate issues. This accounting is
-/// inherently a snapshot of a possibly-changing tree (ADR-088 Amendment 1:
-/// eviction is safe because ingest cursors live in the database, not the
-/// clone), so "a thing under the root I was about to size is already gone"
-/// is not an error here.
-///
-/// The walk **root** itself vanishing is different and is NOT tolerated --
-/// it surfaces as `CacheError::Io(NotFound)` rather than silently sizing to
-/// `0`. A caller that genuinely expects the root it's sizing to sometimes be
-/// absent (rather than an existing root racing a mid-walk mutation) must
-/// check for that error explicitly and decide its own semantics at that call
-/// site (`evict_lru` does this for a listed entry that a concurrent repair
-/// deleted between `read_dir` and this call -- see there); `dir_size` itself
-/// never launders a missing root into a bare `0`, which previously let
-/// `evict_lru` report success with a missing keep slot or count a phantom
-/// candidate and evict a valid one unnecessarily.
+/// Recursive directory size, following no symlinks. Tolerant of a
+/// *descendant* disappearing mid-walk (contributes 0 bytes); the walk
+/// **root** itself vanishing is NOT tolerated and surfaces as
+/// `CacheError::Io(NotFound)`. See
+/// crates/khive-pack-git/docs/cache.md#dir_size.
 fn dir_size(path: &Path) -> Result<u64, CacheError> {
     let mut total = 0u64;
     let mut stack = vec![path.to_path_buf()];
@@ -530,16 +395,9 @@ fn dir_size(path: &Path) -> Result<u64, CacheError> {
 }
 
 /// Whether `path` is a directory `ensure_clone` could plausibly have
-/// created: a 16-lowercase-hex `cache_key`-shaped directory name (never a
-/// UUID staging dir, never an arbitrary operator directory), itself a real
-/// directory rather than a symlink (a symlink placed at the cache-key path
-/// pointing at an unrelated owned-looking or foreign directory must never be
-/// treated as an owned slot), containing both a `.git` entry and the
-/// `.khive-last-used` marker written by `touch`. Eviction (and any future
-/// scratch-root cleanup) must only ever remove entries that pass this check
-/// -- a `KHIVE_GIT_DIGEST_SCRATCH_ROOT` override pointed at a broader or
-/// pre-existing directory must never lose unrelated data sitting next to the
-/// cache slots.
+/// created: a 16-lowercase-hex `cache_key`-shaped real directory (not a
+/// symlink) containing both a `.git` entry and the `.khive-last-used`
+/// marker. See crates/khive-pack-git/docs/cache.md#is_owned_entry.
 fn is_owned_entry(path: &Path) -> bool {
     let name = match path.file_name().and_then(|n| n.to_str()) {
         Some(n) => n,
@@ -559,23 +417,11 @@ fn is_owned_entry(path: &Path) -> bool {
     path.join(".git").exists() && path.join(MARKER_FILE).exists()
 }
 
-/// Evict least-recently-used clones under `root` (by `.khive-last-used`
-/// mtime) until both the repo-count cap and the total-byte cap are
-/// satisfied. `keep` (the clone `ensure_clone` just touched) is never
-/// evicted. Only removes paths that are direct children of `root` AND pass
-/// `is_owned_entry` -- eviction never touches user-owned or non-cache paths.
-///
-/// `keep`'s own `dir_size` (below) is deliberately NOT tolerant of `keep`
-/// vanishing: every caller touches (or freshly installs) `keep` immediately
-/// before calling `evict_lru` in the same synchronous call chain, so `keep`
-/// disappearing out from under this call is not an expected repair race --
-/// it is either a genuine bug or an external actor deleting our slot, and
-/// silently sizing it to `0` would let eviction report success while the
-/// slot the caller asked to keep is actually gone. A listed *candidate*
-/// entry (below) is different -- another `evict_lru`/`ensure_clone`
-/// repairing the same root can legitimately delete it between the
-/// `read_dir` listing above and the `dir_size` call below, so that vanish is
-/// tolerated by skipping the entry rather than aborting the whole pass.
+/// Evict least-recently-used clones under `root` until both the
+/// repo-count cap and the total-byte cap are satisfied. `keep` is never
+/// evicted, and its own vanishing is NOT tolerated (propagates as an
+/// error); a listed candidate entry vanishing mid-walk IS tolerated
+/// (skipped). See crates/khive-pack-git/docs/cache.md#evict_lru.
 fn evict_lru(root: &Path, keep: &Path) -> Result<(), CacheError> {
     let mut entries: Vec<(PathBuf, SystemTime, u64)> = Vec::new();
     let read_dir =
@@ -625,13 +471,8 @@ fn evict_lru(root: &Path, keep: &Path) -> Result<(), CacheError> {
     Ok(())
 }
 
-/// `scratch_root()` reads process-global env vars; serialize any in-crate
-/// test (in this module or elsewhere, e.g. `recovery_tests.rs`) that touches
-/// it, so the whole `cargo test` binary's parallel test threads never race
-/// on `KHIVE_GIT_DIGEST_SCRATCH_ROOT`/cache-cap env vars/`PATH`. A
-/// `tokio::sync::Mutex` rather than `std::sync::Mutex` so async tests can
-/// hold the guard across `.await` points (`blocking_lock()` for this
-/// module's plain sync `#[test]`s).
+/// Serializes tests that touch process-global env vars (`scratch_root()`
+/// reads them). See crates/khive-pack-git/docs/cache.md#env_mutex.
 #[cfg(test)]
 pub(crate) static ENV_MUTEX: std::sync::LazyLock<tokio::sync::Mutex<()>> =
     std::sync::LazyLock::new(|| tokio::sync::Mutex::new(()));
@@ -640,9 +481,7 @@ pub(crate) static ENV_MUTEX: std::sync::LazyLock<tokio::sync::Mutex<()>> =
 mod tests {
     use super::*;
 
-    /// Build a directory shaped exactly like a real `ensure_clone` cache
-    /// slot: a 16-lowercase-hex name (a real `cache_key` output) containing
-    /// a `.git` dir and (optionally) the `.khive-last-used` marker.
+    /// Build a directory shaped exactly like a real `ensure_clone` cache slot.
     fn make_owned_entry(root: &Path, key: &str, with_marker: bool) -> PathBuf {
         assert_eq!(key.len(), 16, "test cache keys must be 16 hex chars");
         let p = root.join(key);
@@ -653,12 +492,7 @@ mod tests {
         p
     }
 
-    /// ADR-088 Amendment 1: a `git clone` failure (bad
-    /// source, no network needed -- a nonexistent local path fails
-    /// immediately) must not leave a `.staging-<uuid>` directory behind.
-    /// `evict_lru` deliberately never touches non-owned names, so a leaked
-    /// staging dir would otherwise accumulate forever across repeated
-    /// failures.
+    /// A `git clone` failure must not leave a `.staging-<uuid>` dir behind.
     #[test]
     fn ensure_clone_cleans_up_staging_dir_on_clone_failure() {
         let _guard = ENV_MUTEX.blocking_lock();
@@ -820,11 +654,7 @@ mod tests {
         assert_eq!(dir_size(dir.path()).unwrap(), 15);
     }
 
-    /// PR #847: the walk root vanishing must surface as an
-    /// error, never a laundered `Ok(0)` -- distinct from a descendant
-    /// vanishing beneath a still-existing root (see the Barrier tests
-    /// below). A root that was never there to begin with is the simplest,
-    /// fully deterministic instance of "the root itself is missing".
+    /// PR #847: walk root vanishing must error, never launder to `Ok(0)`.
     #[test]
     fn dir_size_errors_when_the_root_itself_is_missing() {
         let dir = tempfile::tempdir().expect("tempdir");
@@ -836,12 +666,7 @@ mod tests {
         );
     }
 
-    /// `evict_lru`'s `keep` argument: every caller (`ensure_clone`,
-    /// `refetch_clone`, `reclone`) has just touched or freshly installed
-    /// `keep` immediately before calling `evict_lru`, so `keep` vanishing is
-    /// a real problem to surface, not a maybe-absent slot -- `evict_lru`
-    /// must propagate `dir_size(keep)`'s error rather than treat it as an
-    /// empty, evictable-looking slot.
+    /// `keep` vanishing must propagate, not be treated as an empty slot.
     #[test]
     fn evict_lru_errors_when_keep_itself_is_missing() {
         let _guard = ENV_MUTEX.blocking_lock();
@@ -863,25 +688,9 @@ mod tests {
         std::env::remove_var("KHIVE_GIT_DIGEST_CACHE_MAX_BYTES");
     }
 
-    /// Issue #842's macOS ENOENT flake family: `dir_size` walks a tree that
-    /// can legitimately be mutated out from under it (git's own detached
-    /// background maintenance child, or a racing `evict_lru`/`ensure_clone`
-    /// repair on the same
-    /// slot) -- a subdirectory disappearing between `read_dir` listing it and
-    /// this walk descending into it must shrink the total, not abort the
-    /// whole computation with `CacheError::Io(NotFound)`.
-    ///
-    /// This is a genuine cross-thread filesystem race, not a fully
-    /// deterministic single-shot repro: a `std::sync::Barrier` releases both
-    /// threads at the same instant, a wide fan of sibling subdirectories
-    /// gives the walk many entries to still be processing when the deleter
-    /// runs, and the whole race is repeated many times so the window is
-    /// almost certain to be hit at least once across the loop. Pre-fix (see
-    /// the sabotage note on `dir_size` above), this reliably reproduces
-    /// `CacheError::Io` within a handful of iterations on this machine; it is
-    /// not a `sleep`-based synchronization, so it is not always the exact
-    /// same interleaving twice, but the failure is real and observable, not
-    /// theoretical.
+    /// Issue #842 macOS ENOENT flake family: a descendant disappearing
+    /// mid-walk must shrink the total, not abort with `NotFound`. See
+    /// crates/khive-pack-git/docs/cache.md#test-module-notes.
     #[test]
     fn dir_size_tolerates_a_subdirectory_removed_mid_walk() {
         for _ in 0..200 {
@@ -924,21 +733,9 @@ mod tests {
         }
     }
 
-    /// Companion to the test above, pinning the other half of the
-    /// contract (PR #847): when the vanishing path is the walk
-    /// **root** itself -- not a descendant beneath a still-existing root --
-    /// `dir_size` must surface an error rather than tolerate it. Same
-    /// barrier-race harness, but `root` is left empty (an empty-directory
-    /// removal is a single `rmdir` syscall, the same order of cost as the
-    /// `symlink_metadata`/`read_dir` calls `dir_size` opens with -- a
-    /// populated root, by contrast, has its own directory entry removed
-    /// *last* by `remove_dir_all` after every child, well after the
-    /// walker's first two syscalls would already have completed, which
-    /// would make the root-vanish race effectively unreachable). Pre-fix,
-    /// `dir_size` treated a disappearing root exactly like a disappearing
-    /// descendant and returned `Ok(0)`, which could let `evict_lru` report
-    /// success over a missing `keep` slot or count a phantom `0`-byte
-    /// candidate.
+    /// Companion to the test above (PR #847): the walk root itself
+    /// vanishing must error, not tolerate like a descendant. See
+    /// crates/khive-pack-git/docs/cache.md#test-module-notes.
     #[test]
     fn dir_size_errors_when_the_root_is_removed_mid_walk() {
         let mut saw_error = false;
@@ -994,10 +791,8 @@ mod tests {
         );
     }
 
-    /// A real local repo usable as an `ensure_clone`/`refetch_clone`/`reclone`
-    /// `canonical_url` (git accepts a plain filesystem path as a clone/fetch
-    /// source, same as the existing `ensure_clone_cleans_up_staging_dir_*`
-    /// test does for a failure case).
+    /// A real local repo usable as a `canonical_url` (git accepts a plain
+    /// filesystem path as a clone/fetch source).
     fn init_origin_with_one_commit(repo: &Path) {
         git(repo, &["init", "-q", "-b", "main"]);
         git(repo, &["config", "user.email", "test@example.com"]);
@@ -1023,11 +818,8 @@ mod tests {
         String::from_utf8_lossy(&out.stdout).trim().to_string()
     }
 
-    /// The primary #765 acceptance path: a slot already exists (via
-    /// `ensure_clone`); `refetch_clone` must pull history the slot doesn't
-    /// have yet (standing in for genuinely corrupt/incomplete objects, which
-    /// `git fetch --refetch` repairs the same way -- by re-obtaining a
-    /// complete fresh packfile from the remote).
+    /// Primary #765 acceptance path — see
+    /// crates/khive-pack-git/docs/cache.md#test-module-notes.
     #[test]
     fn refetch_clone_updates_an_existing_slot_to_the_remote_tip() {
         let _guard = ENV_MUTEX.blocking_lock();
@@ -1052,20 +844,8 @@ mod tests {
         std::env::remove_var("KHIVE_GIT_DIGEST_SCRATCH_ROOT");
     }
 
-    /// Remediation (issue #765): `refetch_clone`'s over-cap cleanup must go through
-    /// the same ownership guard `reclone` uses, not a raw `remove_dir_all`,
-    /// AND must propagate that guard's failure rather than discarding it --
-    /// a slot that has lost its `.khive-last-used` marker (simulating a
-    /// directory the guard cannot prove it owns) survives over-cap cleanup,
-    /// and the caller sees the ownership failure (`UnsafeToReplace`) that
-    /// actually occurred, not a laundered `CloneTooLarge`. Since a later
-    /// fix added a pre-fetch ownership re-check, this markerless
-    /// slot is now refused before `fetch_refetch` even runs (see
-    /// `refetch_clone_refuses_a_markerless_slot_under_the_cap` below) rather
-    /// than at the over-cap cleanup step this test originally targeted --
-    /// the assertions still hold (`UnsafeToReplace`, slot survives), so this
-    /// remains a valid regression guard for the cleanup path once a slot
-    /// somehow reaches it un-owned.
+    /// Remediation (issue #765) — see
+    /// crates/khive-pack-git/docs/cache.md#test-module-notes.
     #[test]
     fn refetch_clone_over_cap_cleanup_never_deletes_an_unproven_slot() {
         let _guard = ENV_MUTEX.blocking_lock();
@@ -1098,14 +878,8 @@ mod tests {
         std::env::remove_var("KHIVE_GIT_DIGEST_SCRATCH_ROOT");
     }
 
-    /// Remediation (issue #765 follow-up PR #788):
-    /// `refetch_clone` must refuse a markerless slot *before* ever calling
-    /// `fetch_refetch`, not only on the over-cap cleanup branch the previous
-    /// test exercises. Under the default (non-cap-exceeded) cap, a
-    /// pre-fetch ownership check is the only thing standing between a
-    /// markerless slot and a real fetch: the origin is given fresh history
-    /// so a fetch that ran despite the missing marker would be directly
-    /// observable via a moved `HEAD`.
+    /// Remediation (issue #765 follow-up PR #788) — see
+    /// crates/khive-pack-git/docs/cache.md#test-module-notes.
     #[test]
     fn refetch_clone_refuses_a_markerless_slot_under_the_cap() {
         let _guard = ENV_MUTEX.blocking_lock();
@@ -1159,11 +933,8 @@ mod tests {
         std::env::remove_var("KHIVE_GIT_DIGEST_SCRATCH_ROOT");
     }
 
-    /// #765's fallback path: a refetch that cannot repair the slot (here,
-    /// simulated by pointing the existing slot's `origin` remote at a
-    /// nonexistent path so `git fetch --refetch` itself fails) is followed by
-    /// `reclone`, which ignores the broken clone entirely and clones fresh
-    /// from the still-good `canonical_url`.
+    /// #765's fallback path — see
+    /// crates/khive-pack-git/docs/cache.md#test-module-notes.
     #[test]
     fn reclone_replaces_a_slot_whose_refetch_cannot_succeed() {
         let _guard = ENV_MUTEX.blocking_lock();
@@ -1208,11 +979,8 @@ mod tests {
         std::env::remove_var("KHIVE_GIT_DIGEST_SCRATCH_ROOT");
     }
 
-    /// Ownership guard (ADR-088 Amendment 1 / PR #761): `reclone` must never
-    /// delete a directory that doesn't prove itself an owned cache slot, even
-    /// though its path is exactly where the cache key says the slot should
-    /// be -- a `KHIVE_GIT_DIGEST_SCRATCH_ROOT` override pointed at a broader
-    /// directory must never lose unrelated operator data to a repair.
+    /// Ownership guard (ADR-088 Amendment 1 / PR #761) — see
+    /// crates/khive-pack-git/docs/cache.md#test-module-notes.
     #[test]
     fn reclone_refuses_to_replace_a_foreign_looking_directory() {
         let _guard = ENV_MUTEX.blocking_lock();
@@ -1240,9 +1008,7 @@ mod tests {
         std::env::remove_var("KHIVE_GIT_DIGEST_SCRATCH_ROOT");
     }
 
-    /// When no slot exists at all yet, `reclone` has nothing to remove and
-    /// simply installs a fresh clone -- the same fallback a first-ever
-    /// `ensure_clone` would have taken.
+    /// No slot exists yet: `reclone` simply installs a fresh clone.
     #[test]
     fn reclone_installs_fresh_when_no_slot_exists_yet() {
         let _guard = ENV_MUTEX.blocking_lock();
@@ -1259,16 +1025,8 @@ mod tests {
         std::env::remove_var("KHIVE_GIT_DIGEST_SCRATCH_ROOT");
     }
 
-    /// Remediation (issue #765): `ensure_clone` must
-    /// never adopt, fetch into, or touch a directory sitting at the
-    /// cache-key path that does not already prove itself owned via
-    /// `is_owned_entry`. Here the directory is a genuine Git repository (so
-    /// the pre-fix `repo_dir.join(".git").exists()` check alone would have
-    /// accepted it) but is missing the `.khive-last-used` marker -- standing
-    /// in for an operator's own repository that happens to land on the same
-    /// cache-key path under an overridden `KHIVE_GIT_DIGEST_SCRATCH_ROOT`.
-    /// The call must refuse with `UnsafeToReplace` and the sentinel operator
-    /// data inside must survive completely untouched.
+    /// Remediation (issue #765) — see
+    /// crates/khive-pack-git/docs/cache.md#test-module-notes.
     #[test]
     fn ensure_clone_refuses_a_markerless_git_directory_at_the_cache_key_path() {
         let _guard = ENV_MUTEX.blocking_lock();
@@ -1306,10 +1064,7 @@ mod tests {
         std::env::remove_var("KHIVE_GIT_DIGEST_SCRATCH_ROOT");
     }
 
-    /// Same guard, symlink variant: a symlink placed at the cache-key path
-    /// pointing at an unrelated owned-looking directory must not be treated
-    /// as an owned slot either -- `is_owned_entry` requires the cache-key
-    /// path itself to be a real directory, not a symlink to one.
+    /// Same guard, symlink variant.
     #[cfg(unix)]
     #[test]
     fn ensure_clone_refuses_a_symlink_at_the_cache_key_path() {

--- a/crates/khive-pack-git/src/handlers.rs
+++ b/crates/khive-pack-git/src/handlers.rs
@@ -22,12 +22,8 @@ use crate::ingest::{
 use crate::source::{parse_source, repo_basename, DigestSource};
 use crate::GitPack;
 
-/// Issue #765 remote-only repair policy: at most one `git fetch --refetch`,
-/// then at most one owned-cache reclone, bounded by `stage` so a persistent
-/// or recurring classified failure surfaces as a terminal error rather than
-/// looping. Local-path sources never construct this — they call public
-/// `run_ingest` directly, which never repairs anything (ADR-088 Amendment 1:
-/// the disposable scratch cache is remote-URL-mode-only).
+/// Issue #765 bounded repair policy: at most one refetch, then at most one
+/// reclone. See crates/khive-pack-git/docs/handlers.md#remoterecoverystage.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum RemoteRecoveryStage {
     Initial,
@@ -48,12 +44,8 @@ impl RemoteCommitRecovery {
         }
     }
 
-    /// Advance the bounded repair state machine by one step in response to a
-    /// classified `GitLogError` (the caller has already verified
-    /// `is_missing_promisor_object()`). Ignores `_repo` — both repair
-    /// primitives operate on the cache slot for `canonical_url`, which is
-    /// the same path `_repo` already names (`crate::cache`'s slot layout is
-    /// keyed by URL, not passed through).
+    /// Advance the repair state machine by one step for a classified
+    /// `GitLogError`. See crates/khive-pack-git/docs/handlers.md#repair.
     pub(crate) fn repair(
         &mut self,
         _repo: &Path,

--- a/crates/khive-pack-git/src/hook.rs
+++ b/crates/khive-pack-git/src/hook.rs
@@ -1,12 +1,8 @@
 //! `KindHook` implementations for the three note kinds this pack contributes.
-//!
-//! Validation only — this pack introduces no new edges at `after_create` time.
-//! Provenance edges (`annotates` -> project / document / merging PR) are
-//! supplied by the caller (the ingester, see `src/ingest.rs`) as part of the
-//! generic `create(kind=..., annotates=[...])` call; the runtime's own
-//! `create_note` path validates and links them atomically, so no
-//! `after_create` edge-creation logic is needed here (unlike gtd's
-//! `TaskHook::after_create`).
+//! Validation only — provenance edges are supplied by the caller and linked
+//! by the runtime's `create_note` path itself. See
+//! crates/khive-pack-git/docs/hooks.md for why no `after_create` edge work
+//! is needed here.
 
 use async_trait::async_trait;
 use serde_json::Value;
@@ -95,25 +91,19 @@ impl KindHook for CommitHook {
     }
 }
 
-/// The governed `state_reason` value set for `issue` (ADR-088 §3). `pub(crate)`
-/// so `ingest::MaskedIssueFields` can classify against the same set at the
-/// masking boundary, before an ungoverned (possibly credential-shaped) raw
-/// value can reach this hook's error path.
+/// The governed `state_reason` value set for `issue` (ADR-088 §3). See
+/// crates/khive-pack-git/docs/hooks.md#issuelikehook for why this is
+/// `pub(crate)`.
 pub(crate) const ISSUE_STATE_REASONS: &[&str] =
     &["completed", "not_planned", "reopened", "duplicate"];
 
 /// `KindHook` shared by `issue` and `pull_request` — both require
-/// `properties.number` and `properties.project_id`, and, when present,
-/// validate `properties.state_reason`. `issue`'s `state_reason` is governed
-/// to a fixed set (ADR-088 §3); v0 does not document a fixed set for
-/// `pull_request`'s `state_reason`, so it is only checked for non-emptiness
-/// there.
-///
-/// GitHub issue/PR numbers are repository-scoped, not globally unique — two
-/// different `project` entities in the same namespace can each have a `#1`.
-/// `properties.project_id` is the natural-key scoping field the ingester's
-/// `find_by_number` lookup filters on, so it is required and validated as a
-/// UUID here rather than left to the caller's discipline.
+/// `properties.number` (integer) and `properties.project_id` (UUID), and,
+/// when present, validate `properties.state_reason` (governed to a fixed
+/// set for `issue` per ADR-088 §3; only checked for non-emptiness for
+/// `pull_request`). See crates/khive-pack-git/docs/hooks.md#issuelikehook
+/// for why `project_id` is required here rather than left to caller
+/// discipline.
 #[derive(Debug)]
 pub struct IssueLikeHook {
     /// The note kind this instance validates: `"issue"` or `"pull_request"`.

--- a/crates/khive-pack-git/src/ingest.rs
+++ b/crates/khive-pack-git/src/ingest.rs
@@ -1,12 +1,8 @@
-//! Batch, cursor-based git-history ingester (ADR-088 §5).
-//!
-//! One-shot: walks local git history plus (optionally) `gh`-fetched issues
-//! and pull requests, and writes `commit` / `issue` / `pull_request` notes
-//! through the standard `create` verb (so `KindHook` validation and
-//! `annotates` edge creation run exactly as they would for any other
-//! caller). Reuses ADR-087's operational pattern (cursor table, secret
-//! masking on ingest, cursor advances only on success) — NOT a daemon loop,
-//! NOT a webhook, NOT a poller: one pass per invocation.
+//! Batch, cursor-based git-history ingester (ADR-088 §5). One-shot: walks
+//! local git history plus (optionally) `gh`-fetched issues and pull
+//! requests, and writes `commit` / `issue` / `pull_request` notes through
+//! the standard `create` verb. See crates/khive-pack-git/docs/ingest.md for
+//! the full module overview.
 
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
@@ -72,10 +68,8 @@ impl IngestOptions {
     }
 }
 
-/// Bounds the number of new-record creation attempts across a `run_ingest`
-/// pass (ADR-088 Amendment 1 `max_items`). Only creation attempts (success or
-/// failure) consume budget — cheap natural-key "already exists" skips do not,
-/// since they are not the work the bound exists to limit.
+/// Bounds new-record creation attempts across a `run_ingest` pass. See
+/// crates/khive-pack-git/docs/ingest.md#budget.
 struct Budget {
     remaining: Option<u64>,
 }
@@ -97,10 +91,9 @@ impl Budget {
     }
 }
 
-/// A newly created note this pass, retained so the post-ingestion reference-
-/// extraction sweep (`link_references`) can resolve cross-references between
-/// records created in the *same* pass regardless of ingestion order (PRs and
-/// issues are ingested before commits) without re-reading them from storage.
+/// A newly created note this pass, for `link_references`'s
+/// same-pass cross-reference resolution. See
+/// crates/khive-pack-git/docs/ingest.md#newrecordforref.
 struct NewRecordForRef {
     id: Uuid,
     text: String,
@@ -149,18 +142,14 @@ pub struct IngestReport {
     pub commit_embeddings_truncated: u64,
 }
 
-/// Run one ingest pass: issues + PRs first (via `gh`, when available), then
-/// commits (via local `git log`). PRs are ingested before commits so a
-/// commit's `annotates` list can reference an already-created merging-PR
-/// note (the generic `create` verb validates `annotates` targets exist
-/// before it writes — see `khive-runtime::operations::create_note_inner`).
-///
-/// Delegates to `run_ingest_with_commit_recovery` with a recovery callback
-/// that never repairs anything — the CLI and any local-path caller has no
-/// disposable remote cache to repair (issue #765 self-heal is remote-URL
-/// mode only, ADR-088 Amendment 1), so a classified commit-snapshot failure
-/// here surfaces as an ordinary error, exactly as before this pass gained
-/// recovery support.
+/// Run one ingest pass over `opts.repo`: issues + PRs first (via `gh`, when
+/// available), then commits (via local `git log`), each bounded by
+/// `opts.max_items` and cursor-resumable (call again while the returned
+/// `IngestReport.done` is `false`). Returns an error only for a failure that
+/// aborts the whole pass (e.g. an unresolvable `opts.project`); per-record
+/// failures are collected in `IngestReport.warnings` instead. See
+/// crates/khive-pack-git/docs/ingest.md#run_ingest_with_commit_recovery for
+/// why this has no self-healing recovery (unlike the verb-handler path).
 pub async fn run_ingest(
     runtime: &KhiveRuntime,
     token: &NamespaceToken,
@@ -170,16 +159,10 @@ pub async fn run_ingest(
     run_ingest_with_commit_recovery(runtime, token, registry, opts, |_repo, _err| Ok(None)).await
 }
 
-/// Same one-shot ingest pass as `run_ingest`, but a classified missing-
-/// promisor-object failure while loading the commit-history snapshot
-/// (`GitLogError::is_missing_promisor_object`) is retried through `recover`
-/// instead of aborting the whole pass (issue #765). Issues and PRs still run
-/// exactly once regardless of whether recovery is later needed or invoked —
-/// only commit-snapshot acquisition (`walk_commits` + `touched_files`) is
-/// retried, inside this same invocation's `Budget`, `IngestReport`, PR/merge
-/// maps, and reference candidates (`new_records`); a repair never resets or
-/// replays any of them, and there is no second `run_ingest` pass hiding
-/// behind this one.
+/// Same one-shot ingest pass as `run_ingest`, but a classified
+/// missing-promisor-object failure is retried through `recover` (issue
+/// #765) instead of aborting the whole pass. See
+/// crates/khive-pack-git/docs/ingest.md#run_ingest_with_commit_recovery.
 pub(crate) async fn run_ingest_with_commit_recovery(
     runtime: &KhiveRuntime,
     token: &NamespaceToken,
@@ -295,7 +278,7 @@ pub(crate) async fn run_ingest_with_commit_recovery(
 }
 
 /// Resolve a full UUID or an 8+ hex prefix to a full UUID, unfiltered by
-/// namespace (matches the by-ID resolution contract used by `get`/`update`).
+/// namespace.
 async fn resolve_id(
     runtime: &KhiveRuntime,
     _token: &NamespaceToken,
@@ -310,9 +293,10 @@ async fn resolve_id(
         .map_err(|e| anyhow!("{e}"))
 }
 
-/// Public wrapper for the `git.digest` verb handler, which needs to resolve
-/// (but never auto-create) an explicitly supplied `project` argument the same
-/// way `run_ingest` does.
+/// Resolve `raw` (a full UUID or an 8+ hex prefix) to an existing `project`
+/// entity id, unfiltered by namespace. Returns `Ok(None)` when no entity
+/// matches; never creates one. Used by the `git.digest` verb handler to
+/// resolve an explicitly supplied `project` argument.
 pub async fn resolve_project_id(runtime: &KhiveRuntime, raw: &str) -> Result<Option<Uuid>> {
     if let Ok(u) = Uuid::parse_str(raw) {
         return Ok(Some(u));
@@ -324,8 +308,7 @@ pub async fn resolve_project_id(runtime: &KhiveRuntime, raw: &str) -> Result<Opt
 }
 
 /// Find an existing `issue` or `pull_request` note by `properties.number`
-/// within `project_id` — GitHub numbers a repository's issues and PRs from
-/// one shared sequence, so a `#N` reference can resolve to either kind.
+/// within `project_id`.
 async fn find_issue_or_pr_by_number(
     runtime: &KhiveRuntime,
     token: &NamespaceToken,
@@ -338,13 +321,10 @@ async fn find_issue_or_pr_by_number(
     find_by_number(runtime, token, "pull_request", project_id, number).await
 }
 
-/// Post-ingestion sweep (ADR-088 Amendment 1 ingest enrichment): extract
-/// GitHub reference-grammar mentions from every note created *this pass*
-/// (commits, issues, PRs — order-independent, since all three are already in
-/// `new_records` by the time this runs) and materialize `annotates` edges to
-/// the referenced issue/PR note, carrying `ref_kind` ("closes" | "mentions")
-/// as edge metadata. Fail-open throughout: a malformed or unresolvable
-/// reference is skipped and counted, never aborts the pass.
+/// Post-ingestion sweep: extract GitHub reference-grammar mentions from
+/// every note created this pass and materialize `annotates` edges to the
+/// referenced issue/PR note. Fail-open. See
+/// crates/khive-pack-git/docs/ingest.md#link_references.
 async fn link_references(
     runtime: &KhiveRuntime,
     token: &NamespaceToken,
@@ -403,8 +383,7 @@ async fn link_references(
     }
 }
 
-/// `true` when `gh` is on PATH and can run inside `repo` (a lightweight
-/// `gh --version` probe — cheap and does not require network access).
+/// `true` when `gh` is on PATH and can run inside `repo`.
 fn gh_available(repo: &Path) -> bool {
     Command::new("gh")
         .arg("--version")
@@ -415,8 +394,7 @@ fn gh_available(repo: &Path) -> bool {
 }
 
 /// Look up an existing `commit` note by its `properties.sha` (natural-key
-/// idempotence — dedupe-before-create, matching the precedent used elsewhere
-/// in this codebase for `json_extract`-keyed lookups).
+/// idempotence — dedupe before create).
 async fn find_commit_by_sha(
     runtime: &KhiveRuntime,
     token: &NamespaceToken,
@@ -440,10 +418,9 @@ async fn find_commit_by_sha(
     Ok(row.and_then(|r| row_uuid(&r)))
 }
 
-/// Look up an existing `issue`/`pull_request` note by its `properties.number`
-/// (natural-key idempotence, scoped by kind + namespace + `project_id` —
-/// GitHub issue/PR numbers are repository-scoped, so a bare `kind`+`number`
-/// filter would incorrectly collide two different repos' `#1`).
+/// Look up an existing `issue`/`pull_request` note by its `properties.number`,
+/// scoped by kind + namespace + `project_id` (GitHub numbers are
+/// repository-scoped — see crates/khive-pack-git/docs/ingest.md).
 async fn find_by_number(
     runtime: &KhiveRuntime,
     token: &NamespaceToken,
@@ -480,9 +457,8 @@ fn row_uuid(row: &khive_storage::types::SqlRow) -> Option<Uuid> {
     }
 }
 
-/// Escape SQLite `LIKE` wildcard characters (`%`, `_`) and the escape
-/// character itself (`\`) so a caller-supplied path is matched literally
-/// under `LIKE ... ESCAPE '\'` rather than as a pattern.
+/// Escape SQLite `LIKE` wildcards (`%`, `_`, `\`) so a caller-supplied path
+/// matches literally under `LIKE ... ESCAPE '\'`.
 fn escape_like(input: &str) -> String {
     let mut out = String::with_capacity(input.len());
     for c in input.chars() {
@@ -494,15 +470,11 @@ fn escape_like(input: &str) -> String {
     out
 }
 
-/// Find an existing `document` entity whose `properties.source_uri` or `name`
-/// matches `path` (ADR-086 keying convention). Returns `None` when no match —
-/// v0 never creates documents on the ingester's behalf (skip the edge).
-///
-/// Exact and suffix-`LIKE` candidates are selected in a single query/snapshot
-/// so a document inserted between an exact-match read and a fallback read
-/// can never be missed by the exact branch, and a wildcard-broadened match
-/// can never shadow an exact one: the `ORDER BY` ranks exact matches first,
-/// with `id` as a deterministic tiebreaker.
+/// Find an existing `document` entity whose `properties.source_uri` or
+/// `name` matches `path` (ADR-086 keying convention); `None` when no match
+/// (v0 never creates documents on the ingester's behalf). See
+/// crates/khive-pack-git/docs/ingest.md#find_document_for_path for the
+/// single-query exact-vs-suffix-match ordering rationale.
 async fn find_document_for_path(
     runtime: &KhiveRuntime,
     token: &NamespaceToken,
@@ -566,13 +538,9 @@ async fn read_cursor(
     }))
 }
 
-/// Advance the `(project_id, kind)` cursor. Called once per section
-/// (commits/prs/issues) after that section's loop finishes, with a value
-/// that stops advancing at the first per-record create failure (see the
-/// `cursor_stalled` handling in each `ingest_*` loop) — so the next pass
-/// re-walks from before the failure and retries it, while records that
-/// already landed (including ones ingested later in a stalled pass) are
-/// no-ops via natural-key dedupe.
+/// Advance the `(project_id, kind)` cursor. See
+/// crates/khive-pack-git/docs/ingest.md#write_cursor for the
+/// stall-then-retry cursor semantics.
 async fn write_cursor(
     runtime: &KhiveRuntime,
     project_id: Uuid,
@@ -617,21 +585,16 @@ struct RawCommit {
     body: String,
 }
 
-/// Which `git log` pass a classified failure came from (issue #765): the
-/// two passes fail independently (`walk_commits`'s plain metadata pass can
-/// succeed via cached commit data while `touched_files`'s `--name-only` pass
-/// needs a tree that the promisor cache dropped, or vice versa), so recovery
-/// needs to know which one to retry.
+/// Which `git log` pass a classified failure came from (issue #765). See
+/// crates/khive-pack-git/docs/ingest.md#issue-765-commit-snapshot-recovery.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum GitLogPhase {
     Metadata,
     TouchedFiles,
 }
 
-/// A non-zero-exit `git log` failure, carrying its phase and raw stderr so
-/// `is_missing_promisor_object` can classify it without losing the
-/// underlying diagnostic (surfaced verbatim in the final error when
-/// recovery is unavailable or exhausted).
+/// A non-zero-exit `git log` failure, carrying its phase and raw stderr for
+/// classification by `is_missing_promisor_object`.
 #[derive(Debug)]
 pub(crate) struct GitLogError {
     phase: GitLogPhase,
@@ -653,10 +616,8 @@ impl std::error::Error for GitLogError {}
 impl GitLogError {
     /// `true` for exactly the class of failure issue #765 authorizes
     /// self-healing for: a missing-object diagnostic that names a promisor
-    /// remote. Deliberately narrow (ASCII-case-insensitive `promisor` plus
-    /// either `not in the object database` or `missing object`) so ordinary
-    /// auth/network/`bad object`/spawn/local-source failures are never
-    /// treated as corrupt-cache and never trigger a destructive repair.
+    /// remote. Deliberately narrow — see
+    /// crates/khive-pack-git/docs/ingest.md#issue-765-commit-snapshot-recovery.
     pub(crate) fn is_missing_promisor_object(&self) -> bool {
         let lower = self.stderr.to_ascii_lowercase();
         lower.contains("promisor")
@@ -665,8 +626,7 @@ impl GitLogError {
 }
 
 /// Walk local git history via `git log` with a stable, machine-parseable
-/// format (v0 choice per ADR-088 §5 — `git2`/`gix` are not workspace
-/// dependencies today, so shelling out avoids a new heavy dependency).
+/// format. See crates/khive-pack-git/docs/ingest.md#issue-765-commit-snapshot-recovery.
 fn walk_commits(repo: &Path, since_sha: Option<&str>) -> Result<Vec<RawCommit>> {
     // Raw control-byte separators embedded directly in the format string
     // (not git's `%xHH` escape syntax) — passed as a single argv element
@@ -730,9 +690,7 @@ fn walk_commits(repo: &Path, since_sha: Option<&str>) -> Result<Vec<RawCommit>> 
 }
 
 /// `sha -> \[touched paths\]` for every commit in `repo`'s history, via a
-/// separate `--name-only` pass (kept apart from `walk_commits`'s custom
-/// `--pretty=format` — interleaving file-name lines with the metadata format
-/// has no clean, unambiguous delimiter).
+/// separate `--name-only` pass.
 fn touched_files(repo: &Path) -> Result<HashMap<String, Vec<String>>> {
     let output = Command::new("git")
         .arg("-C")
@@ -760,18 +718,14 @@ fn touched_files(repo: &Path) -> Result<HashMap<String, Vec<String>>> {
 }
 
 /// The two `git log` passes a commit-ingest phase needs, loaded together so
-/// a classified failure in either one can be retried as a single unit
-/// (issue #765).
+/// a classified failure in either one can be retried as a single unit.
 struct CommitSnapshot {
     commits: Vec<RawCommit>,
     files_by_sha: HashMap<String, Vec<String>>,
 }
 
-/// Load one commit-history snapshot. Mirrors `ingest_commits`'s original
-/// inline sequencing: `touched_files` (a second, unscoped `git log
-/// --name-only` pass over the whole history) is skipped entirely when
-/// `walk_commits` found no new commits, since there is nothing new to
-/// annotate with touched paths.
+/// Load one commit-history snapshot; skips `touched_files` entirely when
+/// `walk_commits` found no new commits.
 fn load_commit_snapshot(repo: &Path, since_sha: Option<&str>) -> Result<CommitSnapshot> {
     let commits = walk_commits(repo, since_sha)?;
     if commits.is_empty() {
@@ -787,9 +741,8 @@ fn load_commit_snapshot(repo: &Path, since_sha: Option<&str>) -> Result<CommitSn
     })
 }
 
-/// Which repair `RemoteCommitRecovery` (`handlers.rs`) performed, so
-/// `recover_commit_snapshot` can report exactly one truthful success warning
-/// once the commit phase completes (issue #765).
+/// Which repair `RemoteCommitRecovery` (`handlers.rs`) performed. See
+/// crates/khive-pack-git/docs/ingest.md#issue-765-commit-snapshot-recovery.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum CacheRepairStrategy {
     Refetch,
@@ -797,9 +750,7 @@ pub(crate) enum CacheRepairStrategy {
 }
 
 /// The repo path and strategy a `recover` callback used to repair a
-/// classified `GitLogError` -- `recover_commit_snapshot` retries the
-/// snapshot load against `repo` (the same cache slot for both strategies in
-/// `cache.rs`, but callers are not required to keep it identical).
+/// classified `GitLogError`.
 pub(crate) struct RecoveredRepo {
     pub(crate) repo: PathBuf,
     pub(crate) strategy: CacheRepairStrategy,
@@ -817,17 +768,9 @@ fn cache_repair_warning(strategy: CacheRepairStrategy) -> String {
 }
 
 /// Load a commit-history snapshot, retrying through `recover` when the
-/// failure is a classified missing-promisor-object error (issue #765).
-///
-/// Bounded entirely by `recover`'s own return value: `Ok(Some(_))` retries
-/// the snapshot load against the recovered repo path, `Ok(None)` surfaces
-/// the original classified error (no more repair available), and any other
-/// error (including an unclassified `GitLogError` or a non-`GitLogError`
-/// failure) is returned immediately without ever calling `recover`. A later
-/// repair attempt's strategy replaces the pending warning rather than
-/// accumulating one per attempt, so exactly one success warning is ever
-/// returned -- describing the *last* repair that was needed, not every one
-/// tried.
+/// failure is a classified missing-promisor-object error (issue #765). See
+/// crates/khive-pack-git/docs/ingest.md#issue-765-commit-snapshot-recovery
+/// for the retry-bound semantics.
 fn recover_commit_snapshot(
     repo: &Path,
     since_sha: Option<&str>,
@@ -892,22 +835,9 @@ fn truncated_embedding_head(content: &str) -> Option<&str> {
 }
 
 /// Every `RawCommit` string field funnels through this constructor before it
-/// can reach `properties` or the note `name`. `new` destructures `RawCommit`
-/// exhaustively (no `..`), so a future new field on `RawCommit` forces a
-/// compile error here before it can silently skip this boundary -- the same
-/// discipline `MaskedIssueFields` (below) already applies to `GhIssue`
-/// (issue #841), following the same one-boundary-per-record approach as #835
-/// so omissions are structurally hard.
-///
-/// `sha`/`short_sha`/`committed_at`/`parents` are git-computed hashes and an
-/// RFC3339 timestamp -- not attacker-authored free text -- so they pass
-/// through unchanged, matching how `MaskedIssueFields` leaves its own
-/// timestamp fields to a separate canonicalization step rather than masking
-/// them. `author`, `author_email`, `subject`, and `body` are git-config- and
-/// commit-message-controlled prose and go through the same `mask_secrets`
-/// gate `content` already used -- closing the gap where the commit note
-/// `name` (built from the raw subject) and its `author`/`author_email`
-/// properties skipped masking entirely.
+/// can reach `properties` or the note `name`, masking secrets in
+/// caller-controlled prose fields. See
+/// crates/khive-pack-git/docs/ingest.md#masking-boundaries-maskedcommitfields-maskedissuefields-maskedprfields.
 struct MaskedCommitFields {
     sha: String,
     short_sha: String,
@@ -1196,12 +1126,8 @@ struct GhPr {
 }
 
 /// Every `GhIssue` field funnels through this constructor before it can
-/// reach `properties`/`content`/the note name/the paging cursor. `new`
-/// consumes `GhIssue` by value and destructures it exhaustively (no `..`),
-/// so the original `issue` binding no longer exists after the call -- a
-/// call site has no way to read a raw field back out, and a future new
-/// `GhIssue` field forces a compile error here before it can silently skip
-/// this boundary.
+/// reach `properties`/`content`/the note name/the paging cursor. See
+/// crates/khive-pack-git/docs/ingest.md#masking-boundaries-maskedcommitfields-maskedissuefields-maskedprfields.
 struct MaskedIssueFields {
     number: u64,
     title: String,
@@ -1214,12 +1140,9 @@ struct MaskedIssueFields {
     state_reason: StateReasonField,
 }
 
-/// The classified outcome of parsing a raw `stateReason` string against the
-/// governed enum (`hook::ISSUE_STATE_REASONS`, ADR-088 §3) at the masking
-/// boundary. `Rejected` never carries the raw string forward -- the ingest
-/// loop must reject the record with a warning that names only the field,
-/// never its value (a credential-shaped `stateReason`
-/// must never reach `report.warnings` or the hook's own error path).
+/// Classified outcome of parsing a raw `stateReason` against the governed
+/// enum. `Rejected` never carries the raw string forward. See
+/// crates/khive-pack-git/docs/ingest.md#masking-boundaries-maskedcommitfields-maskedissuefields-maskedprfields.
 #[derive(Debug, Clone, PartialEq, Eq)]
 enum StateReasonField {
     Absent,
@@ -1262,13 +1185,8 @@ impl MaskedIssueFields {
 }
 
 /// Classifies a raw `stateReason` string against the governed enum
-/// (`hook::ISSUE_STATE_REASONS`, ADR-088 §3) at the masking boundary. GitHub
-/// reports `stateReason` as `""` for open issues and an UPPERCASE enum value
-/// (e.g. `NOT_PLANNED`) for closed ones, so case is normalized before the
-/// membership check. A value that is present, non-empty, and not one of the
-/// four governed values is classified `Rejected` -- the caller must reject
-/// the whole record with a warning naming only the field, never echoing this
-/// (possibly credential-shaped) raw string.
+/// (`hook::ISSUE_STATE_REASONS`, ADR-088 §3), case-normalized first. See
+/// crates/khive-pack-git/docs/ingest.md#masking-boundaries-maskedcommitfields-maskedissuefields-maskedprfields.
 fn canonical_issue_state_reason(raw: Option<String>) -> StateReasonField {
     let Some(raw) = raw.filter(|r| !r.is_empty()) else {
         return StateReasonField::Absent;
@@ -1281,15 +1199,10 @@ fn canonical_issue_state_reason(raw: Option<String>) -> StateReasonField {
     }
 }
 
-/// Parses a GitHub issue timestamp into its canonical RFC3339 form. GitHub's
-/// API always returns valid RFC3339 timestamps; a value that fails to parse
-/// is untrusted/malformed input (a credential-shaped
-/// string is exactly this case) and must never reach `properties` or the
-/// paging cursor as a raw string. On parse failure the field is rejected
-/// (becomes absent) and a warning is recorded -- without the raw value,
-/// which may itself be secret-shaped -- rather than letting an unparseable
-/// string silently pass the generic recursive secret scan downstream. The
-/// issue itself is still ingested; only this one field is dropped.
+/// Parses a GitHub issue timestamp into canonical RFC3339 form; on parse
+/// failure the field is dropped (with a warning, never the raw value) and
+/// the issue is still ingested. See
+/// crates/khive-pack-git/docs/ingest.md#masking-boundaries-maskedcommitfields-maskedissuefields-maskedprfields.
 fn canonical_issue_timestamp(
     field: &'static str,
     number: u64,
@@ -1328,35 +1241,24 @@ fn gh_json(repo: &Path, args: &[&str]) -> Result<String> {
     Ok(String::from_utf8_lossy(&output.stdout).into_owned())
 }
 
-/// Per-page fetch cap for both PR and issue paging (ADR-088 Amendment 1).
-/// `gh {pr,issue} list --search` is backed by GitHub's
-/// search API, which never returns more than this many results for a single
-/// query regardless of `--limit` — paging works around that ceiling by
-/// advancing an `updated:>=` floor between calls, not by requesting more
-/// than one page can hold.
+/// Per-page fetch cap for both PR and issue paging — `gh {pr,issue} list
+/// --search` never returns more than this many results for a single query
+/// regardless of `--limit`. See
+/// crates/khive-pack-git/docs/ingest.md#paging-pageoutcome-decide_page_outcome-page_limit.
 const PAGE_LIMIT: usize = 1000;
 
-/// What a paging loop should do after processing one fetched page. Pure and
-/// unit-testable independent of `gh`, the database, or async machinery — the
-/// entire "was the remote window proven exhausted" decision lives here
-/// (ADR-088 Amendment 1): a single hard-coded `--limit 1000`
-/// fetch could previously report `done: true` while a repo's remaining
-/// PRs/issues past position 1000 were never seen).
+/// What a paging loop should do after processing one fetched page — the
+/// entire "was the remote window proven exhausted" decision lives here. See
+/// crates/khive-pack-git/docs/ingest.md#paging-pageoutcome-decide_page_outcome-page_limit.
 #[derive(Debug, Clone, PartialEq, Eq)]
 enum PageOutcome {
-    /// The page held fewer than `PAGE_LIMIT` items: the remote window is
-    /// proven exhausted regardless of local budget state.
+    /// Page held fewer than `PAGE_LIMIT` items: remote window proven exhausted.
     WindowComplete,
-    /// The page was full (`PAGE_LIMIT` items) and the local budget is
-    /// exhausted: stop paging, but the window is NOT proven exhausted.
+    /// Page was full and the local budget is exhausted: stop, not proven exhausted.
     StopBudgetExhausted,
-    /// The page was full and the last item's `updated_at` did not advance
-    /// past the current floor (more than `PAGE_LIMIT` records share one
-    /// timestamp — an unresolvable pathological case): stop paging rather
-    /// than loop forever. The window is NOT proven exhausted.
+    /// Page was full but the floor didn't advance: stop, not proven exhausted.
     StopFloorStalled,
-    /// The page was full, the budget is not exhausted, and the floor
-    /// advanced: fetch the next page starting at this floor.
+    /// Page was full, budget remains, floor advanced: fetch the next page.
     Continue(String),
 }
 
@@ -1378,11 +1280,7 @@ fn decide_page_outcome(
     }
 }
 
-/// `PageOutcome::WindowComplete` is the only outcome under which `done` can
-/// stay `true` on the local-budget question alone; every other outcome means
-/// more remote records may exist past the last fetched page. Test-only
-/// helper — production code matches on `PageOutcome` directly (see
-/// `ingest_prs`/`ingest_issues`'s paging loops).
+/// Test-only helper: production code matches on `PageOutcome` directly.
 #[cfg(test)]
 fn page_outcome_proves_window_complete(outcome: PageOutcome) -> bool {
     matches!(outcome, PageOutcome::WindowComplete)
@@ -1440,22 +1338,9 @@ fn fetch_issue_page(repo: &Path, floor: Option<&str>) -> Result<Vec<GhIssue>> {
 }
 
 /// Every `GhPr` field funnels through this constructor before it can reach
-/// `properties`/`content`/the note `name`/the in-memory PR-linking maps.
-/// `new` consumes `GhPr` by value and destructures it exhaustively (no
-/// `..`), so the original `pr` binding no longer exists after the call and a
-/// future new `GhPr` field forces a compile error here before it can
-/// silently skip this boundary -- the same discipline `MaskedIssueFields`
-/// applies to `GhIssue` (issue #841: PR author, base ref, and head ref were
-/// the residual raw fields after #835's title fix, using one sanitization
-/// boundary per record type).
-///
-/// `number`, `created_at`/`merged_at`/`closed_at`/`updated_at`, and
-/// `merge_commit`'s `oid` are GitHub-generated (not attacker-authored free
-/// text) and pass through unchanged, matching how `MaskedIssueFields`
-/// leaves its own timestamp fields to canonicalization rather than masking.
-/// `title`, `body`, the author login, and both ref names are
-/// contributor-controlled prose and go through the same `mask_secrets` gate
-/// `content`/`title` already used for PRs.
+/// `properties`/`content`/the note `name`/the in-memory PR-linking maps,
+/// masking secrets in contributor-controlled prose fields. See
+/// crates/khive-pack-git/docs/ingest.md#masking-boundaries-maskedcommitfields-maskedissuefields-maskedprfields.
 struct MaskedPrFields {
     number: u64,
     title: String,
@@ -1923,11 +1808,9 @@ mod paging_tests {
     }
 }
 
-/// Issue #765: `GitLogError` classification and the `recover_commit_snapshot`
-/// retry loop. Pure/synchronous (no runtime, no database) -- these fields
-/// are private to this module, so this lives here rather than in the
-/// sibling `recovery_tests` module (which drives the DB-backed acceptance
-/// scenarios through the `pub(crate)` surface instead).
+/// Issue #765: `GitLogError` classification + `recover_commit_snapshot`
+/// retry loop (pure/synchronous). See
+/// crates/khive-pack-git/docs/ingest.md#test-module-notes.
 #[cfg(test)]
 mod recovery_classifier_tests {
     use super::*;
@@ -1989,15 +1872,8 @@ mod recovery_classifier_tests {
         .is_missing_promisor_object());
     }
 
-    /// A healthy repo: the snapshot loads on the first try, no `recover`
-    /// call, no warning.
-    ///
-    /// Spawns real `git` via bare `Command::new("git")`, resolved through
-    /// the process-wide `PATH` -- must hold the same crate-wide
-    /// `cache::ENV_MUTEX` the `PATH`-shimming tests in `cache.rs` and
-    /// `recovery_tests.rs` hold while they swap `PATH` to a fake `git`, or
-    /// this test can spawn that shim instead of real git and misclassify a
-    /// healthy repo as corrupt.
+    /// Healthy repo: loads on first try, no recover call, no warning. Holds
+    /// `cache::ENV_MUTEX` — see crates/khive-pack-git/docs/ingest.md#test-module-notes.
     #[test]
     fn recover_commit_snapshot_returns_no_warning_when_healthy() {
         let _env = crate::cache::ENV_MUTEX.blocking_lock();
@@ -2014,12 +1890,8 @@ mod recovery_classifier_tests {
         assert_eq!(recover_calls, 0);
     }
 
-    /// An unclassified `git log` failure (nonexistent repo path -- a spawn-
-    /// level/`bad object`-shaped failure, not a promisor one) must never
-    /// reach `recover` at all, and must propagate as-is.
-    ///
-    /// Same crate-wide `ENV_MUTEX` requirement as the sibling test above --
-    /// `recover_commit_snapshot` spawns real `git log` through `PATH`.
+    /// An unclassified `git log` failure must never reach `recover` and
+    /// must propagate as-is. Same `ENV_MUTEX` requirement as above.
     #[test]
     fn recover_commit_snapshot_never_calls_recover_for_unclassified_failures() {
         let _env = crate::cache::ENV_MUTEX.blocking_lock();
@@ -2088,9 +1960,7 @@ mod truncation_tests {
         assert!(content.starts_with(head));
     }
 
-    /// A multibyte scalar (3-byte '€') straddling the byte cap must roll the
-    /// boundary back to the nearest valid char boundary rather than panicking
-    /// or splitting the scalar.
+    /// Multibyte scalar straddling the byte cap must roll back to a char boundary.
     #[test]
     fn multibyte_scalar_straddling_cap_rolls_back_to_char_boundary() {
         // Fill up to one byte short of the cap with ASCII, then place a
@@ -2111,12 +1981,8 @@ mod truncation_tests {
     }
 }
 
-/// PR #816: `resolve_id`/`resolve_project_id` call the
-/// public `resolve_prefix_unfiltered` resolver without their own all-hex
-/// gate, so a `%`-bearing (or otherwise non-hex) `project` argument reached
-/// the bound `LIKE` pattern unfiltered. The runtime resolver boundary
-/// (`resolve_prefix_inner`) now rejects non-hex/non-hyphen input itself, so
-/// these callers inherit the fix without needing their own gate.
+/// PR #816: `resolve_id`/`resolve_project_id` LIKE-wildcard-injection
+/// regression tests. See crates/khive-pack-git/docs/ingest.md#test-module-notes.
 #[cfg(test)]
 mod compact_prefix_resolver_tests {
     use super::*;
@@ -2171,10 +2037,8 @@ mod compact_prefix_resolver_tests {
     }
 }
 
-/// PR #816: `find_document_for_path` bound an unescaped
-/// path into a `LIKE` pattern (`%`/`_` in a filename became pattern
-/// wildcards) and picked whichever candidate the unordered `LIMIT 1` scan
-/// happened to return first, even when an exact match existed.
+/// PR #816: `find_document_for_path` LIKE-escaping + exact-match-ordering
+/// regression tests. See crates/khive-pack-git/docs/ingest.md#test-module-notes.
 #[cfg(test)]
 mod find_document_for_path_tests {
     use super::*;
@@ -2238,12 +2102,8 @@ mod find_document_for_path_tests {
         );
     }
 
-    /// PR #816: running the exact-match read and the
-    /// LIKE-fallback read as two separate awaited queries left a TOCTOU gap
-    /// where a document inserted between them could still lose to the
-    /// unordered fallback `LIMIT 1`. Resolution must now happen in one
-    /// query/snapshot: both candidates are visible to the same `SELECT`, and
-    /// the `ORDER BY` — not read ordering — decides the exact match wins.
+    /// PR #816: TOCTOU regression — single-query snapshot must still rank
+    /// the exact match first regardless of insertion order.
     #[tokio::test]
     async fn single_query_snapshot_prefers_exact_over_broadened() {
         let rt = KhiveRuntime::memory().unwrap();

--- a/crates/khive-pack-git/src/vocab.rs
+++ b/crates/khive-pack-git/src/vocab.rs
@@ -2,14 +2,8 @@
 //! declaration, the `precedes` commit→commit edge extension, and the
 //! pack-auxiliary cursor schema.
 //!
-//! ADR-088 v0 shipped with no `HANDLERS` and no `EDGE_RULES`: zero new verbs,
-//! relying exclusively on the base `annotates` contract (note -> any
-//! substrate) for provenance edges. ADR-088 Amendment 1 adds exactly one
-//! verb (`git.digest`) and one endpoint extension (`precedes` commit→commit,
-//! for parent→child commit lineage — the base contract only allows
-//! `precedes` between five entity kinds, never between notes; this pack
-//! extends it the same additive way `khive-pack-gtd` extends `depends_on` to
-//! task→task). See `crates/khive-pack-git/src/pack.rs`.
+//! See crates/khive-pack-git/docs/vocab.md for the ADR-088 v0 → Amendment 1
+//! rationale behind this module's design.
 
 use khive_runtime::{NoteKindSpec, NoteLifecycleSpec};
 use khive_types::{
@@ -17,9 +11,8 @@ use khive_types::{
     VerbCategory, Visibility,
 };
 
-/// Lifecycle declaration shared by `issue` and `pull_request` — both track an
-/// open/closed state with the same posture as ADR-088's `finding` precedent:
-/// declared for introspection, not yet enforced by the runtime (Phase 1).
+/// Shared open/closed lifecycle for `issue` and `pull_request`. See
+/// crates/khive-pack-git/docs/vocab.md#git_lifecycle.
 const GIT_LIFECYCLE: NoteLifecycleSpec = NoteLifecycleSpec {
     field: "kind_status",
     initial: "open",
@@ -44,15 +37,8 @@ pub(crate) static GIT_NOTE_KIND_SPECS: [NoteKindSpec; 2] = [
     },
 ];
 
-/// Pack-auxiliary schema: the git-ingest cursor table (ADR-088 §5, ADR-087
-/// operational pattern reused).
-///
-/// Shape is intentionally generic across git record kinds within a project —
-/// `kind` distinguishes `commits` / `issues` / `prs` cursors so a follow-up
-/// pack (e.g. a code-review pack) can reuse this exact table for its own
-/// cursor rows without a schema change, keyed by its own `project_id`/`kind`
-/// pair. Idempotent (`CREATE TABLE IF NOT EXISTS`), applied once at pack
-/// registration time; not part of the core versioned migration chain.
+/// Pack-auxiliary schema: the git-ingest cursor table (ADR-088 §5). See
+/// crates/khive-pack-git/docs/vocab.md#git_schema_plan_stmts.
 pub(crate) static GIT_SCHEMA_PLAN_STMTS: [&str; 2] = [
     "CREATE TABLE IF NOT EXISTS git_mirror_cursor (\
         project_id   TEXT NOT NULL,\
@@ -65,12 +51,8 @@ pub(crate) static GIT_SCHEMA_PLAN_STMTS: [&str; 2] = [
         ON git_mirror_cursor(updated_at DESC)",
 ];
 
-/// ADR-088 Amendment 1 ingest enrichment: parent→child commit lineage as
-/// `precedes` edges. The base endpoint contract only allows `precedes`
-/// between five entity kinds (`document`, `dataset`, `artifact`, `service`,
-/// `project` — see `khive-runtime::operations::BASE_ENTITY_ENDPOINT_RULES`);
-/// it has no note→note case at all. This is the same additive-extension
-/// mechanism `khive-pack-gtd` uses for `depends_on` task→task.
+/// ADR-088 Amendment 1: parent→child commit lineage as `precedes` edges
+/// (note→note extension). See crates/khive-pack-git/docs/vocab.md#git_edge_rules.
 pub(crate) static GIT_EDGE_RULES: [EdgeEndpointRule; 1] = [EdgeEndpointRule {
     relation: EdgeRelation::Precedes,
     source: EndpointKind::NoteOfKind("commit"),
@@ -78,22 +60,7 @@ pub(crate) static GIT_EDGE_RULES: [EdgeEndpointRule; 1] = [EdgeEndpointRule {
 }];
 
 /// Pack-declared `Document` entity-type subtype: Architecture Decision
-/// Records.
-///
-/// `find_document_for_path` (`src/ingest.rs`) resolves pre-existing
-/// `document` entities by git-tracked file path (`properties.source_uri`) so
-/// commits/PRs can `annotates`-link to them; this pack never creates those
-/// document entities itself ("v0 never creates documents on the ingester's
-/// behalf"). The single most common git-tracked document kind ingesting
-/// agents attach to a repo's `document` entities is its ADR corpus
-/// (`docs/adr/*.md`) — but `EntityTypeRegistry::BUILTIN_DEFS` has no `adr`
-/// Document subtype, so any caller attempting `entity_type="adr"` was
-/// rejected at the handler layer, and callers omitted `entity_type`
-/// entirely rather than retry against an unknown value: a schema gap, not a
-/// data gap. Declaring it here (composed at boot via
-/// `VerbRegistry::all_entity_types`, ADR-017's additive pack-vocabulary
-/// pattern) makes ADR documents representable without editing the builtin
-/// registry.
+/// Records. See crates/khive-pack-git/docs/vocab.md#git_entity_types.
 pub(crate) static GIT_ENTITY_TYPES: [EntityTypeDef; 1] = [EntityTypeDef {
     kind: EntityKind::Document,
     type_name: "adr",


### PR DESCRIPTION
This pull request adds comprehensive design documentation for the scratch-clone cache, `git.digest` handler, and Git pack `KindHook` modules in the `khive-pack-git` crate. The new documentation provides detailed rationales, design decisions, and operational notes, extracted from internal doc-comments, to clarify the cache management, repair logic, and validation hooks. These docs will help maintainers and contributors understand the intent, safety guarantees, and edge cases handled by these modules.

Documentation additions:

* Added a detailed design note (`cache.md`) covering the scratch-clone cache’s eviction policy, ownership model, error handling, and test rationale. This includes explanations of the LRU eviction, per-clone size caps, ownership markers, and concurrency/race condition handling.
* Added handler design notes (`handlers.md`) describing the remote-only repair policy, state machine for repairs, and the separation of local-path and remote-URL handling in the `git.digest` handler.
* Added hook design notes (`hooks.md`) explaining the validation-only nature of the Git pack `KindHook`, the rationale for project-scoped issue/PR numbers, and how state reasons are validated and shared between modules.