### PR TITLE
docs(rustdoc): condense inline docs + extract to guides (khive-brain-core,khive-fold khive-pack-comm,khive-pack-kg khive-pack-session,khive-vamana)

### DIFF
--- a/crates/khive-brain-core/docs/design-notes.md
+++ b/crates/khive-brain-core/docs/design-notes.md
@@ -1,0 +1,42 @@
+# khive-brain-core — design rationale
+
+Long-form "why this exists" background relocated from doc-comments per the
+rustdoc condense pass. Public item contracts stay complete in the `.rs`
+source; this file holds the extended rationale a caller doesn't need in
+order to call the function correctly.
+
+## `sort_fallback_candidates` — why it's a standalone helper
+
+Extracted into a standalone helper (rather than inlined into
+`BrainState::resolve_with_match`) so it can be unit-tested with intentionally
+unsorted input, providing fail-before/pass-after coverage that does not rely
+on `HashMap` randomization to expose non-determinism.
+
+## `validate_brain_state_snapshot_with_capacity` — `entity_posterior_order` version gating rationale
+
+The function rejects rather than silently repairs two shapes of corruption
+that `#[serde(default)]` would otherwise let through unnoticed:
+
+- **Version 0 with a non-empty order.** Version 0 is the legacy,
+  pre-ordering compatibility case and is only ever valid with an EMPTY
+  order — restore falls back to the deterministic ascending-`Uuid` order in
+  that case (see `EntityPosteriors::from_snapshot` in `posterior.rs`). A
+  version-0 snapshot with a non-empty order is not legacy compatibility
+  data; full-coverage order is only ever written under version 1, so a
+  non-empty order on version 0 is necessarily partial. Because
+  `entity_posteriors_version` silently resolves to `0` on an omitted JSON
+  field, this case must be caught explicitly rather than passed through to
+  restore, which would otherwise silently normalize e.g. `[A]` order over
+  `{A, B}` posteriors to `[A, B]` — masking data loss as a successful
+  restore.
+- **Version ≥ 1 with partial coverage.** Combined with the duplicate/unknown-id
+  checks (which already guarantee every order id is a distinct, valid map
+  key), requiring the order length to equal the `entity_posteriors` length
+  proves the id sets are identical — no `entity_posteriors` key is missing
+  from the order. A current-format snapshot with partial order is corruption,
+  not a compatibility case, and is rejected here rather than silently
+  normalized at restore.
+
+This is the capacity-aware counterpart to `validate_brain_state_snapshot`,
+used at the persistence load boundary, so a crafted or legacy oversized
+snapshot is rejected outright rather than silently truncated.

--- a/crates/khive-brain-core/docs/testing-notes.md
+++ b/crates/khive-brain-core/docs/testing-notes.md
@@ -1,0 +1,73 @@
+# khive-brain-core — regression test rationale
+
+Long-form rationale relocated from `#[cfg(test)]` doc-comments (non-public,
+does not render on docs.rs) per the rustdoc condense pass. Each heading names
+the test function and its source file; the `.rs` doc-comment now carries only
+a 1–3 line summary that links here.
+
+## `posterior.rs::snapshot_restore_eviction_equivalence` (BRAINCORE-AUD-001)
+
+Snapshot/restore must be eviction-equivalent to uninterrupted execution.
+Scenario: capacity 2, observe A then B, snapshot, restore, then observe C —
+the restored path must evict A (the oldest), not B, exactly like the live
+in-memory path would.
+
+## `posterior.rs::oversized_snapshot_restore_is_bounded_by_capacity` (BRAINCORE-AUD-001)
+
+A snapshot with more entries than the configured capacity must restore
+bounded, not exceed it.
+
+## `profile.rs::adr048_ess_cap_mean_shift_ge_0_3` (ADR-048 Phase-1 gate)
+
+ESS cap convergence: after 200 positive events followed by 200 opposing
+events, the salience posterior mean must shift by at least 0.3. This proves
+the ESS cap keeps the posterior responsive to new evidence rather than
+letting accumulated mass drown out a reversal.
+
+## `profile.rs::legacy_entity_posteriors_restore_uses_deterministic_order_and_capacity` (BRAINCORE-AUD-001)
+
+A legacy snapshot (version 0, no order metadata) with more entries than the
+configured capacity must restore bounded, using a deterministic
+ascending-`Uuid` compatibility order.
+
+## `brain_state.rs::sort_fallback_candidates_produces_created_at_then_id_order`
+
+`sort_fallback_candidates` must produce `(created_at ASC, id ASC)` order on
+an intentionally REVERSE-sorted input vector. This is a fail-before/pass-after
+unit test for the helper itself: the old `HashMap.values().find_map()`
+implementation would have returned the first element from HashMap iteration
+order (non-deterministic). The helper under test sorts its input in-place;
+passing a reverse-order slice guarantees the test would fail against any
+implementation that skips the sort.
+
+## `brain_state.rs::resolve_fallback_is_deterministic`
+
+End-to-end: `BrainState::resolve` must select the earliest-created profile
+regardless of HashMap insertion order. This is a secondary integration guard
+that complements the `sort_fallback_candidates` helper unit tests above.
+
+## `brain_state.rs::router_state_and_adapter_set_round_trip`
+
+`router_state` and `adapter_set` survive a `to_snapshot` / `from_snapshot`
+round-trip byte-for-byte. This is a fail-before/pass-after test: it would
+fail if either conversion dropped the new fields.
+
+## `brain_state.rs::snapshot_missing_router_and_adapter_fields_defaults_to_empty`
+
+Deserializing a `BrainStateSnapshot` JSON that omits `router_state` and
+`adapter_set` must succeed and yield empty maps (no migration required). The
+test serializes a fresh snapshot, strips both keys from the JSON object, then
+re-deserializes — proving that `#[serde(default)]` is wired correctly.
+
+## `brain_state.rs::validate_brain_state_snapshot_with_capacity_rejects_profile_state_over_capacity` (BRAINCORE-AUD-001)
+
+Capacity violation in a named `profile_states` entry (not just the default
+`balanced-recall-v1` profile) must also be rejected — the capacity bound
+applies per-profile, not just to the default.
+
+## `brain_state.rs::restore_to_snapshot_restore_idempotency`
+
+A validated snapshot must restore→re-snapshot→restore to the same state —
+the validation gate must not itself introduce drift, and a snapshot that
+passes validation once must keep passing after a round-trip through
+`BrainState`.

--- a/crates/khive-brain-core/src/brain_state.rs
+++ b/crates/khive-brain-core/src/brain_state.rs
@@ -12,9 +12,9 @@ use crate::section_state::{SectionPosteriorSnapshot, SectionPosteriorState};
 /// Sort a slice of profile candidates in ascending `(created_at, id)` order.
 ///
 /// This is the canonical fallback selection key: earliest creation time wins,
-/// with alphabetical `id` as a tiebreaker.  Extracted into a standalone helper
-/// so it can be unit-tested with intentionally unsorted input, providing
-/// fail-before/pass-after coverage that does not rely on `HashMap` randomisation.
+/// with alphabetical `id` as a tiebreaker. See
+/// crates/khive-brain-core/docs/design-notes.md#sort_fallback_candidates--why-its-a-standalone-helper
+/// for why this is a standalone helper rather than inlined.
 pub fn sort_fallback_candidates(candidates: &mut [&ProfileRecord]) {
     candidates.sort_by(|a, b| a.created_at.cmp(&b.created_at).then(a.id.cmp(&b.id)));
 }
@@ -300,23 +300,19 @@ pub fn validate_brain_state_snapshot(snapshot: &BrainStateSnapshot) -> Result<()
 /// Rejects a snapshot whose `balanced_recall` or any `profile_states` entry
 /// holds more entity posteriors than `entity_capacity`, and rejects
 /// `entity_posterior_order` values that contain duplicate ids or reference
-/// ids absent from `entity_posteriors`. This is the capacity-aware
-/// counterpart used at the persistence load boundary, so a crafted or legacy
-/// oversized snapshot is rejected outright rather than silently truncated.
+/// ids absent from `entity_posteriors`.
 ///
 /// `entity_posteriors_version` gates how strictly `entity_posterior_order` is
 /// checked:
 /// - version `0` (legacy, pre-ordering snapshots) — order MUST be empty;
 ///   restore falls back to the deterministic ascending-`Uuid` compatibility
-///   path in [`crate::posterior::EntityPosteriors::from_snapshot`]. A
-///   version-0 snapshot with a non-empty order is not legacy compatibility
-///   data — it is partial order metadata that `serde(default)` let through
-///   (an omitted or explicit-zero version field) and is rejected here.
+///   path in [`crate::posterior::EntityPosteriors::from_snapshot`].
 /// - version `1` (current) — order MUST cover every `entity_posteriors` key
-///   exactly (same length, no duplicates, no unknown ids). A partial order on
-///   a current-format snapshot is corruption, not a compatibility case, and is
-///   rejected here rather than silently normalized at restore.
+///   exactly (same length, no duplicates, no unknown ids).
 /// - any other version — rejected outright as unknown.
+///
+/// See crates/khive-brain-core/docs/design-notes.md#validate_brain_state_snapshot_with_capacity--entity_posterior_order-version-gating-rationale
+/// for why each of these is rejected outright rather than silently repaired.
 pub fn validate_brain_state_snapshot_with_capacity(
     snapshot: &BrainStateSnapshot,
     entity_capacity: usize,
@@ -357,27 +353,15 @@ pub fn validate_brain_state_snapshot_with_capacity(
             }
         }
 
-        // Version 0 is the legacy, pre-ordering compatibility case and is
-        // only valid with an EMPTY order — restore falls back to the
-        // deterministic ascending-`Uuid` order in that case. A version-0
-        // snapshot with a non-empty (necessarily partial, since full coverage
-        // is only ever written under version 1) order is not legacy
-        // compatibility data; it is corruption that `serde(default)` would
-        // otherwise let through unnoticed (a snapshot with an omitted or
-        // explicit-zero version field), and restore would silently normalize
-        // it by appending the missing keys (posterior.rs `from_snapshot`).
-        // Reject it outright rather than let it round-trip.
+        // Version 0 requires an EMPTY order; a non-empty order here is
+        // corruption, not compatibility data — see design-notes.md.
         if br.entity_posteriors_version == 0 && !br.entity_posterior_order.is_empty() {
             return Err(format!(
                 "{label}.entity_posterior_order: non-empty order requires entity_posteriors_version >= 1 (got version 0, the legacy empty-order compatibility version)",
             ));
         }
 
-        // Non-legacy (version >= 1) snapshots must have an order entry for
-        // every entity_posteriors key. Combined with the duplicate/unknown-id
-        // checks above (which already guarantee every order id is a distinct,
-        // valid map key), an equal length here proves the id sets are
-        // identical — no entity_posteriors key is missing from the order.
+        // Version >= 1 must have full order coverage — see design-notes.md.
         if br.entity_posteriors_version >= 1
             && br.entity_posterior_order.len() != br.entity_posteriors.len()
         {
@@ -425,14 +409,8 @@ mod tests {
         }
     }
 
-    /// `sort_fallback_candidates` must produce `(created_at ASC, id ASC)` order
-    /// on an intentionally REVERSE-sorted input vector.
-    ///
-    /// This is a fail-before/pass-after unit test for the helper itself: the old
-    /// `HashMap.values().find_map()` implementation would have returned the first
-    /// element from HashMap iteration order (non-deterministic).  The helper under
-    /// test sorts its input in-place; passing a reverse-order slice guarantees the
-    /// test would fail against any implementation that skips the sort.
+    /// `sort_fallback_candidates` produces `(created_at ASC, id ASC)` order.
+    /// See crates/khive-brain-core/docs/testing-notes.md#brain_staters-sort_fallback_candidates_produces_created_at_then_id_order
     #[test]
     fn sort_fallback_candidates_produces_created_at_then_id_order() {
         // Three profiles inserted in DESCENDING created_at order (worst case for
@@ -475,9 +453,8 @@ mod tests {
         assert_eq!(candidates[2].id, "z-profile");
     }
 
-    /// End-to-end: `BrainState::resolve` must select the earliest-created profile
-    /// regardless of HashMap insertion order.  This is a secondary integration guard
-    /// that complements the helper unit tests above.
+    /// `BrainState::resolve` selects the earliest-created profile regardless
+    /// of HashMap insertion order (integration guard on `sort_fallback_candidates`).
     #[test]
     fn resolve_fallback_is_deterministic() {
         let p_early = make_profile("alpha", "recall", 1_000);
@@ -517,11 +494,7 @@ mod tests {
         assert_eq!(id_a, id_b, "fallback resolution must be deterministic");
     }
 
-    /// `router_state` and `adapter_set` survive a `to_snapshot` / `from_snapshot`
-    /// round-trip byte-for-byte.
-    ///
-    /// This is a fail-before/pass-after test: it would fail if either conversion
-    /// dropped the new fields.
+    /// `router_state` and `adapter_set` survive a snapshot round-trip byte-for-byte.
     #[test]
     fn router_state_and_adapter_set_round_trip() {
         let mut state = BrainState::new(8);
@@ -558,12 +531,8 @@ mod tests {
         );
     }
 
-    /// Deserializing a `BrainStateSnapshot` JSON that omits `router_state` and
-    /// `adapter_set` must succeed and yield empty maps (no migration required).
-    ///
-    /// The test serializes a fresh snapshot, strips both keys from the JSON
-    /// object, then re-deserializes — proving that `#[serde(default)]` is wired
-    /// correctly.
+    /// Omitting `router_state`/`adapter_set` from JSON must deserialize to
+    /// empty maps via `#[serde(default)]`, with no migration required.
     #[test]
     fn snapshot_missing_router_and_adapter_fields_defaults_to_empty() {
         let state = BrainState::new(8);
@@ -618,9 +587,8 @@ mod tests {
         );
     }
 
-    /// BRAINCORE-AUD-001 regression: capacity violation in a named
-    /// `profile_states` entry (not just the default profile) must also be
-    /// rejected.
+    /// BRAINCORE-AUD-001: capacity violation in a named `profile_states`
+    /// entry (not just the default profile) must also be rejected.
     #[test]
     fn validate_brain_state_snapshot_with_capacity_rejects_profile_state_over_capacity() {
         use uuid::Uuid;
@@ -765,12 +733,8 @@ mod tests {
 
     #[test]
     fn validate_brain_state_snapshot_with_capacity_rejects_version_zero_with_partial_order() {
-        // PR #535: a version-0 snapshot with a
-        // non-empty (here: partial) order is NOT the legacy empty-order
-        // compatibility case. `serde(default)` lets `entity_posteriors_version`
-        // silently resolve to 0 on an omitted field, so this must be rejected
-        // outright rather than passed through to `restore`, which would
-        // silently normalize `[A]` order over `{A, B}` posteriors to `[A, B]`.
+        // PR #535: version-0 with a partial order is corruption, not legacy
+        // compatibility data — see design-notes.md.
         let capacity = 4;
         let mut snapshot = make_versioned_recall_snapshot(capacity, 2);
         snapshot.entity_posteriors_version = 0;
@@ -806,9 +770,7 @@ mod tests {
     }
 
     /// A validated snapshot must restore→re-snapshot→restore to the same
-    /// state — the validation gate must not itself introduce drift, and a
-    /// snapshot that passes validation once must keep passing after a
-    /// round-trip through `BrainState`.
+    /// state — the validation gate must not itself introduce drift.
     #[test]
     fn restore_to_snapshot_restore_idempotency() {
         let capacity = 4;

--- a/crates/khive-brain-core/src/posterior.rs
+++ b/crates/khive-brain-core/src/posterior.rs
@@ -488,10 +488,8 @@ mod tests {
         assert!(ep.get(&id3).is_some());
     }
 
-    /// BRAINCORE-AUD-001 regression: snapshot/restore must be eviction-equivalent
-    /// to uninterrupted execution. Capacity 2, observe A then B, snapshot, restore,
-    /// then observe C — the restored path must evict A (the oldest), not B, exactly
-    /// like the live in-memory path would.
+    /// BRAINCORE-AUD-001: eviction equivalence across snapshot/restore.
+    /// See crates/khive-brain-core/docs/testing-notes.md#posteriorrssnapshot_restore_eviction_equivalence-braincore-aud-001
     #[test]
     fn snapshot_restore_eviction_equivalence() {
         let capacity = 2;
@@ -521,8 +519,8 @@ mod tests {
         );
     }
 
-    /// BRAINCORE-AUD-001 regression: a snapshot with more entries than the
-    /// configured capacity must restore bounded, not exceed it.
+    /// BRAINCORE-AUD-001: oversized snapshot restore is bounded by capacity.
+    /// See crates/khive-brain-core/docs/testing-notes.md#posteriorrsoversized_snapshot_restore_is_bounded_by_capacity-braincore-aud-001
     #[test]
     fn oversized_snapshot_restore_is_bounded_by_capacity() {
         let capacity = 2;

--- a/crates/khive-brain-core/src/profile.rs
+++ b/crates/khive-brain-core/src/profile.rs
@@ -387,9 +387,8 @@ mod tests {
         );
     }
 
-    /// ADR-048 Phase-1 gate: ESS cap convergence — after 200 positive events
-    /// followed by 200 opposing events, the salience posterior mean must shift
-    /// by at least 0.3.
+    /// ADR-048 Phase-1 gate: ESS cap convergence must shift the mean by ≥0.3.
+    /// See crates/khive-brain-core/docs/testing-notes.md#profilersadr048_ess_cap_mean_shift_ge_0_3-adr-048-phase-1-gate
     #[test]
     fn adr048_ess_cap_mean_shift_ge_0_3() {
         let mut state = BalancedRecallState::new(200);
@@ -422,9 +421,8 @@ mod tests {
         );
     }
 
-    /// BRAINCORE-AUD-001 regression: a legacy snapshot (version 0, no order
-    /// metadata) with more entries than the configured capacity must restore
-    /// bounded, using a deterministic ascending-`Uuid` compatibility order.
+    /// BRAINCORE-AUD-001: legacy (version 0) oversized restore is bounded.
+    /// See crates/khive-brain-core/docs/testing-notes.md#profilerslegacy_entity_posteriors_restore_uses_deterministic_order_and_capacity-braincore-aud-001
     #[test]
     fn legacy_entity_posteriors_restore_uses_deterministic_order_and_capacity() {
         let capacity = 2;

--- a/crates/khive-fold/docs/design.md
+++ b/crates/khive-fold/docs/design.md
@@ -96,6 +96,55 @@ Inline test sections exceed 300 lines in `selector.rs`, `objective/mod.rs`, and
 `ordering/mod.rs` because they exercise private helpers or pub(crate) constants.
 See `// INLINE TEST JUSTIFICATION` comments in each file for specifics.
 
+## Rank-score precision (PR #535)
+
+`SelectorInput.rank_score` exists because callers that compute the effective score in
+`f64` (e.g. `ComposePipeline`, which multiplies an objective score by a precision weight)
+need more precision than the narrowed `score: f32` field can hold — two `f64` scores that
+differ by less than an `f32` ulp collapse to the same `f32` bit pattern before the selector
+ever compares them. Falling back to `score as f64` for plain callers (e.g.
+`khive-pack-knowledge`'s direct JSON-supplied candidates) is lossless, since those scores
+were never more precise than `f32` to begin with.
+
+Ranking runs through `DeterministicScore` (khive-score's i64 fixed-point contract), not raw
+`f32::total_cmp` — this matches the objective-path ranking pattern in
+`objective::traits::RankedIndex` and preserves precision that a caller-supplied `rank_score`
+(f64) carries past what `f32` can hold. `category_weights` multipliers must scale
+`rank_score` by the same weight applied to `score`, or rank comparisons see the unweighted
+value while `min_score` filtering sees the weighted one — this silently defeated
+`category_weights` for any candidate that set `rank_score` (khive PR #535).
+
+## Test rationale notes
+
+- `selector.rs::greedy_selector_handles_extreme_f32_products_without_overflow` — ranking in
+  f64/`DeterministicScore` rather than raw f32 arithmetic means `f32::MAX * f32::MAX`
+  (~1.15e77) no longer overflows to `f32::INFINITY` the way it did under the old f32-only
+  computation; it becomes a large-but-finite f64 value, saturated into `DeterministicScore`
+  rather than rejected. This is the precision upgrade FOLD-AUD (khive-score fixed-point
+  contract) requires: a real magnitude, not a spurious f32 rounding artifact, decides the
+  outcome.
+- `selector.rs::rank_score_saturates_at_deterministic_score_max_without_panic` — two
+  candidates whose `rank_score` both exceed `DeterministicScore`'s i64/2^32 representable
+  range must both saturate to MAX rather than panicking or overflowing, then fall back to
+  the deterministic size/id tie-break — same contract as `DeterministicScore`'s own
+  saturating arithmetic (khive-score `score.rs` `from_rounded_arithmetic`).
+- `selector.rs::rank_score_distinguishes_values_within_f32_ulp_of_one` — 1.0 and
+  1.00000004 collapse to the identical f32 bit pattern (delta is below the f32 ulp at
+  magnitude 1.0) but are distinct at the khive-score 2^32 fixed-point scale; `rank_score`
+  must be the value that decides ranking, not the narrowed `score` field.
+- `selector.rs::category_weights_reorder_candidates_when_rank_score_present` — regression
+  for PR #535: before the fix, rank comparisons read the unweighted `rank_score` (category
+  weights only ever touched `score`), so a low-weighted candidate could win despite a
+  high-weighted competitor. See "Rank-score precision" above.
+
+- `checkpoint.rs::sort_checkpoint_keys` is extracted as a standalone helper so it can be
+  unit-tested with intentionally unsorted input, giving fail-before/pass-after coverage
+  independent of `HashMap` randomization. The old `HashMap.keys().cloned().collect()` path
+  returned keys in HashMap iteration order (non-deterministic); the regression test
+  `sort_checkpoint_keys_produces_lexicographic_order` passes a reverse-sorted vector — the
+  worst case for an unsorted implementation — to guarantee it fails against any
+  implementation that skips the sort step.
+
 ## Failure Modes
 
 - `FoldError::Serialization` — state serialization failed during checkpoint save.

--- a/crates/khive-fold/src/checkpoint.rs
+++ b/crates/khive-fold/src/checkpoint.rs
@@ -230,10 +230,8 @@ impl<S: Clone + Send + Sync + Serialize + 'static> CheckpointStore<S>
 }
 
 /// Sort a `Vec<String>` of checkpoint IDs into lexicographic order.
-///
-/// Extracted as a standalone helper so it can be unit-tested with intentionally
-/// unsorted input, giving fail-before/pass-after coverage independent of
-/// `HashMap` randomisation.
+/// See crates/khive-fold/docs/design.md#test-rationale-notes for why this is
+/// a standalone helper.
 pub fn sort_checkpoint_keys(mut keys: Vec<String>) -> Vec<String> {
     keys.sort();
     keys
@@ -443,13 +441,8 @@ mod tests {
         assert_eq!(ids.len(), n, "expected {n} checkpoints, got {}", ids.len());
     }
 
-    /// `sort_checkpoint_keys` must return lexicographic order on an intentionally
-    /// reverse-sorted input.
-    ///
-    /// This is a fail-before/pass-after unit test for the ordering helper itself:
-    /// the old `HashMap.keys().cloned().collect()` path returned keys in HashMap
-    /// iteration order (non-deterministic).  Passing a reversed vector guarantees
-    /// the test fails against any implementation that skips the sort step.
+    // Reverse-sorted input is the worst case for an unsorted implementation;
+    // see design.md#test-rationale-notes.
     #[test]
     fn sort_checkpoint_keys_produces_lexicographic_order() {
         // Intentionally REVERSE alphabetical — worst case for unsorted implementations.

--- a/crates/khive-fold/src/selector.rs
+++ b/crates/khive-fold/src/selector.rs
@@ -27,26 +27,21 @@ pub struct SelectorInput<T> {
     pub category: Option<String>,
     /// Pre-computed information gain (KL divergence proxy) for this candidate.
     ///
-    /// Callers pre-compute this because the Selector is pure-math and has no
-    /// access to the embedding space required to estimate KL divergence. When
-    /// `None` (the default), the value is treated as 0.0. Only has an effect
-    /// when `SelectorWeights.epistemic_weight > 0.0`.
+    /// Defaults to 0.0 when `None`. Only affects selection when
+    /// `SelectorWeights.epistemic_weight > 0.0`. See
+    /// crates/khive-fold/docs/design.md#consistency-notes for why this is
+    /// caller-supplied rather than computed by the Selector.
     #[cfg_attr(feature = "serde", serde(default))]
     pub information_gain: Option<f32>,
     /// Higher-precision pre-conversion effective score used for rank
     /// comparisons, when available.
     ///
-    /// Callers that compute the score in `f64` (e.g. `ComposePipeline`, which
-    /// multiplies an objective score by a precision weight) should set this
-    /// instead of relying solely on the narrowed `score: f32` field — ranking
-    /// widens `score` back through `DeterministicScore::from_f32` when this is
-    /// `None`, but two `f64` scores that differ by less than an `f32` ulp would
-    /// otherwise collapse to the same `f32` bit pattern before the selector
-    /// ever compares them (khive-score contract: ADR fixed-point ranking).
-    /// Does not affect `min_score` filtering, which continues to operate on
-    /// `score`. `category_weights` multipliers DO scale `rank_score` (by the
-    /// same weight applied to `score`) so a caller-supplied high-precision
-    /// rank base still reflects category weighting during rank comparisons.
+    /// When `None`, ranking widens `score` back to `f64` via
+    /// `DeterministicScore::from_f32`. Does not affect `min_score` filtering,
+    /// which always operates on `score`. `category_weights` multipliers scale
+    /// `rank_score` by the same weight applied to `score`. See
+    /// crates/khive-fold/docs/design.md#rank-score-precision-pr-535 for why
+    /// callers need this instead of relying on the narrowed `score` field.
     #[cfg_attr(feature = "serde", serde(default))]
     pub rank_score: Option<f64>,
 }
@@ -103,37 +98,23 @@ pub trait Selector<T>: Send + Sync {
 /// Budget-constrained greedy packer.
 ///
 /// Filters by `SelectorWeights.min_score`, applies `category_weights` multipliers
-/// to adjust scores, then greedily packs until the budget is exhausted.
-///
-/// When `diversity_bias > 0`, uses a pick-best-remaining loop: at each step the
-/// item with the highest *effective* score (after diversity penalty) is selected.
-/// The penalty is `score * (1 - bias * n / (n + 1))` where `n` is the number of
-/// already-selected items in the same category. At bias=0 this collapses to a
-/// single-pass sort (backward-compatible).
-///
-/// Tie-breaking is deterministic: size ascending, then id ascending.
+/// to adjust scores, then greedily packs until the budget is exhausted. When
+/// `diversity_bias > 0`, uses a pick-best-remaining loop instead of a single
+/// sort pass. Tie-breaking is deterministic: effective score descending, size
+/// ascending, then id ascending. See
+/// crates/khive-fold/docs/design.md#adr-024-bayesian-extensions-selector-budget-packing-and-precision-weighted-scoring
+/// for the diversity-penalty formula.
 #[derive(Debug, Clone, Copy, Default)]
 pub struct GreedySelector;
 
-/// Widen `score` (and any `rank_score` override) into the `f64` domain used
-/// for rank-comparison arithmetic.
-///
-/// `rank_score`, when present, carries the caller's full-precision effective
-/// score (e.g. `ComposePipeline`'s `objective_score * precision` in `f64`
-/// before it was narrowed to `f32` for the `score` field). Falling back to
-/// `score as f64` for plain callers (e.g. `khive-pack-knowledge`'s direct
-/// JSON-supplied candidates) is lossless — those scores were never more
-/// precise than `f32` to begin with.
+/// Widen `score` (or `rank_score` if set) to `f64` for rank comparisons.
+/// See crates/khive-fold/docs/design.md#rank-score-precision-pr-535.
 #[inline]
 fn rank_base<T>(item: &SelectorInput<T>) -> f64 {
     item.rank_score.unwrap_or(item.score as f64)
 }
 
-/// Compute the base pragmatic score adjusted for epistemic weight, in `f64`.
-///
-/// `base` is the pragmatic score (after category-weight multipliers, which
-/// still apply to `score` before this is called). `epistemic_weight *
-/// information_gain` is the epistemic bonus.
+/// Pragmatic score plus the epistemic (information-gain) bonus, in `f64`.
 #[inline]
 fn pragmatic_plus_epistemic<T>(item: &SelectorInput<T>, epistemic_weight: f32) -> f64 {
     let base = rank_base(item);
@@ -218,12 +199,8 @@ impl<T: Clone> Selector<T> for GreedySelector {
         // Filter non-finite and below min_score.
         inputs.retain(|i| i.score.is_finite() && i.score >= weights.min_score);
 
-        // Apply category_weights multipliers. `rank_score`, when present, is
-        // the caller's higher-precision f64 rank base (see `rank_base` doc) —
-        // it must be scaled by the same weight or rank comparisons would see
-        // the unweighted value while `min_score` filtering sees the weighted
-        // one, silently defeating `category_weights` for any candidate that
-        // set `rank_score` (khive PR #535).
+        // rank_score must be scaled by the same category weight as score, or
+        // it silently defeats category_weights (khive PR #535; see design.md).
         if !weights.category_weights.is_empty() {
             for item in &mut inputs {
                 if let Some(ref cat) = item.category {
@@ -241,13 +218,8 @@ impl<T: Clone> Selector<T> for GreedySelector {
 
         let ew = weights.epistemic_weight;
 
-        // Initial sort: effective score (pragmatic + epistemic bonus) desc, size asc, id asc —
-        // deterministic across platforms. Non-finite effective scores are rejected rather
-        // than silently sorted, since a checked score can still overflow to non-finite.
-        // Comparisons run through `DeterministicScore` (khive-score's i64 fixed-point
-        // contract), not raw `f32::total_cmp` — matches the objective-path ranking
-        // pattern in `objective::traits::RankedIndex` and preserves precision that a
-        // caller-supplied `rank_score` (f64) carries past what `f32` can hold.
+        // Sort by effective score desc, size asc, id asc via DeterministicScore
+        // (not raw f32::total_cmp) — see design.md#rank-score-precision-pr-535.
         let mut ranked = Vec::with_capacity(inputs.len());
         for input in inputs {
             let effective = pragmatic_plus_epistemic(&input, ew);
@@ -795,13 +767,8 @@ mod tests {
 
     #[test]
     fn greedy_selector_handles_extreme_f32_products_without_overflow() {
-        // Ranking now runs in f64/DeterministicScore rather than raw f32
-        // arithmetic: `f32::MAX * f32::MAX` (~1.15e77) no longer overflows to
-        // `f32::INFINITY` the way it did under the old f32-only computation —
-        // it's a large-but-finite f64 value, saturated into DeterministicScore
-        // rather than rejected. This is exactly the precision upgrade FOLD-AUD
-        // (khive-score fixed-point contract) requires: a real magnitude, not a
-        // spurious f32 rounding artifact, decides the outcome.
+        // f64/DeterministicScore ranking no longer overflows on f32::MAX products
+        // (FOLD-AUD); see design.md#test-rationale-notes.
         let inputs = vec![input_with_gain("a", 100, f32::MAX, f32::MAX)];
         let w = SelectorWeights {
             epistemic_weight: f32::MAX,
@@ -828,11 +795,8 @@ mod tests {
 
     #[test]
     fn rank_score_saturates_at_deterministic_score_max_without_panic() {
-        // Two candidates whose rank_score both exceed DeterministicScore's
-        // i64/2^32 representable range must both saturate to MAX rather than
-        // panicking or overflowing, then fall back to the deterministic
-        // size/id tie-break — same contract as DeterministicScore's own
-        // saturating arithmetic (khive-score score.rs `from_rounded_arithmetic`).
+        // rank_score beyond DeterministicScore's range saturates to MAX rather
+        // than panicking; see design.md#test-rationale-notes.
         let mut big = input("big", 200, 0.0);
         big.rank_score = Some(f64::MAX);
         let mut small = input("small", 50, 0.0);
@@ -849,10 +813,8 @@ mod tests {
 
     #[test]
     fn rank_score_distinguishes_values_within_f32_ulp_of_one() {
-        // 1.0 and 1.00000004 collapse to the identical f32 bit pattern (delta
-        // is below the f32 ulp at magnitude 1.0) but are distinct at the
-        // khive-score 2^32 fixed-point scale — `rank_score` must be the value
-        // that decides ranking, not the narrowed `score` field.
+        // 1.0 vs 1.00000004 collapse to identical f32 bits but differ at
+        // khive-score's fixed-point scale; see design.md#test-rationale-notes.
         let a_score = 1.0_f32;
         let b_score = 1.0_f32; // identical f32 bits to a after narrowing
         assert_eq!(a_score.to_bits(), b_score.to_bits());
@@ -874,12 +836,8 @@ mod tests {
 
     #[test]
     fn category_weights_reorder_candidates_when_rank_score_present() {
-        // Same shape as `category_weights_boost_preferred_category`, but both
-        // candidates carry an explicit `rank_score` equal to `score` widened
-        // to f64. Before the fix, rank comparisons read the unweighted
-        // `rank_score` (weights only ever touched `score`), so "a" (raw 0.9,
-        // "low") would win despite "high" carrying a 2.0x weight. The fix
-        // must scale `rank_score` by the same weight so "b" still wins.
+        // Regression for PR #535: rank_score must be scaled by category
+        // weight too, or "a" wins despite "high"'s 2.0x weight.
         let mut a = input_cat("a", 100, 0.9, "low");
         a.rank_score = Some(0.9);
         let mut b = input_cat("b", 100, 0.5, "high");

--- a/crates/khive-pack-comm/docs/handlers.md
+++ b/crates/khive-pack-comm/docs/handlers.md
@@ -1,0 +1,565 @@
+# comm pack — internal handler notes
+
+Rationale, incident history, and algorithm detail relocated from `src/*.rs` doc
+comments during the rustdoc condense pass. These items are all `pub(crate)` or
+private — they never render on docs.rs — so their `.rs` doc comments now carry
+only a 1-3 line summary; this file is the durable home for the "why".
+
+## `lib.rs::CHANNEL_HEALTH_NAMESPACE` — rationale
+
+Channel heartbeat rows are an OPERATIONAL surface, not message data: the write
+must not follow `KHIVE_EMAIL_INGEST_NAMESPACE` (or any other caller-chosen
+namespace) — `handle_heartbeat` is the ONLY comm handler pinned to this
+constant (khive #606 design review Blocker fix, example actor 2026-07-04).
+
+`comm.health` no longer reads this constant unconditionally (khive #877): it
+resolves its read namespace from the dispatch token (`token.namespace()`), the
+same explicit `namespace=` escape / `"local"` default every other comm verb
+uses. An unscoped `comm.health()` call still defaults to `"local"` and so
+still observes rows this constant wrote — but a call with an explicit
+non-local `namespace=` reads that namespace instead, and must not fall back to
+this constant to find heartbeat state a single-namespace daemon wrote
+elsewhere.
+
+## `message.rs::resolve_id`
+
+Accepts a 36-char hyphenated UUID or an 8+ hex-char short prefix. The prefix
+is resolved via `runtime.resolve_prefix` (namespace-scoped).
+
+## `message.rs::rollback_outbound`
+
+Rolls back a partially-written outbound note after a later `dual_write_message`
+step fails (issue #460). Uses a row-first compensating delete so that a
+cleanup failure cannot leave the outbound row (and thus the failed send's live
+message) behind. Returns `original` unchanged when rollback fully succeeds;
+returns a composite `RuntimeError::Internal` naming both the original failure
+and the rollback cleanup failure when the row was removed but cleanup did not
+complete.
+
+## `message.rs::dual_write_message`
+
+Writes an outbound copy (caller namespace) and an inbound copy (recipient
+namespace), rolling back the outbound note if the inbound write fails
+(atomicity guarantee).
+
+`subject`, `thread_id` are optional. `sent_at` is the RFC3339 timestamp for
+both copies. `from_actor` and `to_actor` are optional actor labels (ADR-057)
+stored in properties.
+
+Cross-namespace thread root invariant: when a root message is sent (i.e.,
+`thread_id` is `None`), both the outbound and inbound copies must share the
+same canonical `thread_id` — the sender's outbound UUID. This ensures that
+`comm.thread(id=outbound_id)` can find replies written in any namespace,
+because all replies carry the same canonical thread_id regardless of which
+copy they were replying to.
+
+When `thread_id` is already supplied (reply path), it is forwarded unchanged
+to both copies.
+
+`in_reply_to_message_id` is the parent's wire Message-ID (angle-bracketed),
+when this write is a reply to a message with a known one (issue #403). It is
+stored verbatim on both copies as `in_reply_to_message_id`; the outbox
+delivery loop reads it back to set the RFC 822 `In-Reply-To` header for native
+MUA conversation grouping. `None` when there is no known parent Message-ID (a
+plain send, or a reply whose parent has none).
+
+`references_chain` is the full RFC 5322 `References` value for this reply: the
+parent's existing chain (if any) followed by the parent's Message-ID,
+space-separated angle-bracketed ids (issue #403 finding: References must
+preserve ancestry, not truncate to the immediate parent). Stored verbatim on
+both copies as `references_chain`; the outbox delivery loop reads it back to
+set the `References` header, and a further reply reads it back (direction-aware,
+via `parent_references_chain`) to extend the chain again. `None` when there is
+no known parent Message-ID (mirrors `in_reply_to_message_id`).
+
+## `handlers.rs::handle_send`
+
+Creates a message note in the caller's namespace (outbound) AND delivers an
+inbound copy addressed to the actor label supplied in `to` (ADR-057).
+
+Both copies land in the caller's namespace; no cross-namespace write occurs.
+`from_actor` is set to `token.namespace().as_str()`. `to_actor` is set to the
+`to` argument. When the caller's actor label is `"local"` (single-actor
+fallback), `comm.inbox` does not apply an actor filter, preserving backward
+compatibility.
+
+The routing `from` and `to` passed to `dual_write_message` are both set to the
+caller's namespace string so that `from == recipient_ns_str` is always true:
+this naturally bypasses the cross-namespace allowlist gate in
+`dual_write_message` (ADR-057 §"Interaction with ADR-040"). The actor labels
+are propagated via the `from_actor`/`to_actor` arguments and stored in message
+properties.
+
+### Self-send collapse guard (#820)
+
+A resolved target that equals the sender's own actor identity is, outside the
+anonymous single-tenant fallback ("local"), almost always a mis-resolution
+rather than intent — most commonly a sub-agent session spawned in the same
+project scope trying to reach a distinct parent orchestrator actor. Both
+processes resolve `[actor] id` from the same worktree-scoped `.khive/config.toml`
+(ADR-096 Fork 2's project-local `[actor]` injection tier is per-project, not
+per-session), so the sub-agent's `from_actor` and the parent label it names
+collapse onto the identical string with no error, no warning, and no distinct
+inbox: the message silently "delivers" to the sender's own attributed identity
+instead of a genuinely different principal. Rejected by default; a caller that
+truly means to message its own inbox (e.g. a personal reminder) must say so
+explicitly via `self_send=true`, turning the collapse loud instead of silent.
+`to_actor == "local"` is exempted: that is the anonymous single-tenant
+party-line default (both sender and recipient unattributed), not a collapsed
+distinct-principal address.
+
+### Unattributed-caller warning (#200)
+
+Addressed sends from an unattributed caller stamp `from_actor="local"`, which
+causes reply-threading collapse when multiple unconfigured actors interact.
+Known limitation pending issue #75 (actor identity per request). A visible
+warning is surfaced so operators can diagnose mis-attribution; the send
+proceeds rather than hard-erroring, to preserve backward compatibility with
+sessions that set `default_namespace` but not `actor_id`. Uses the shared
+actor-identity policy (#567) so this warning fires under exactly the same
+"unattributed" definition the gate and token minter use.
+
+## `handlers.rs::handle_inbox`
+
+Lists inbound messages for the caller's actor label (ADR-057).
+
+When the caller's actor label is `"local"` (single-actor fallback), no
+`to_actor` filter is applied and the inbox behaves as before (party-line).
+When the caller has a non-`"local"` actor label, only messages addressed to
+that actor are returned. Legacy messages without a `to_actor` field are
+visible regardless (Q3: OR IS NULL).
+
+`from_actor`/`from_prefix` (#493) sender filters are mutually exclusive.
+Direction + read-status + `to_actor` filters are pushed into SQL so
+`idx_comm_message_direction`/`idx_comm_message_to_actor` are usable; the read
+filter uses `json_type` to match the old `as_bool().unwrap_or(false)`
+semantics — only JSON boolean `true` counts as read, missing/false/string/
+integer all count as unread. `from_prefix` has no SQL `FilterOp`, so when a
+sender filter is supplied, pages are scanned in Rust (same unbounded-page-loop
+shape `handle_thread` uses) until `limit` matches are collected or the store is
+exhausted.
+
+## `handlers.rs::handle_read`
+
+Marks a message as read. Rejects `read()` on outbound messages — "read" is a
+recipient action; marking an outbound (sent) message as read corrupts the
+read/unread invariant and has no semantic meaning to the sender.
+
+Merges `read: true` into properties and patches in place via a real `UPDATE`
+(not `upsert_note`'s `INSERT OR REPLACE`): the latter silently deletes and
+re-inserts the row on a primary-key conflict (#780). The `comm.probe` cursor
+is keyed on `notes_seq.seq`, which is fixed at first insert and survives such
+churn, so this is defensive rather than load-bearing; a metadata patch should
+never rewrite the row regardless.
+
+## `handlers.rs::handle_reply`
+
+Replies to a message, threading linkage.
+
+- Issue #403: captures the parent's wire Message-ID so native mail clients
+  (not khive's own X-Khive-Thread-ID/external_id correlation) can group this
+  reply into the same conversation via In-Reply-To/References. `None` when
+  the parent has no wire Message-ID — the reply then sends without those
+  headers, exactly as before this feature. References must carry the FULL
+  ancestor chain per RFC 5322, not just the immediate parent: the parent's
+  existing chain (if any) followed by the parent's own Message-ID. Malformed
+  tokens in the parent's stored chain are individually skipped rather than
+  corrupting the header.
+- UE6-H2: `thread_id` must always be a full 36-char hyphenated UUID. If the
+  stored `thread_id` is a valid full UUID, use it; otherwise fall back to the
+  original message's own full UUID as the thread root.
+- ADR-057: prefer `from_actor`/`to_actor` fields when present (actor-addressed
+  messages); fall back to `from`/`to` namespace strings for legacy messages.
+- UE6-H1: routes the reply to the "other party" — not always to the original
+  sender. If the reply caller is the original sender (`from_actor` or `from`),
+  route to the original recipient; if the reply caller is the original
+  recipient, route back to the original sender.
+- ADR-057: always sets `from_actor`/`to_actor` on replies (fail-closed on
+  cross-namespace write). Both copies land in the caller's namespace
+  regardless of whether the original message carried actor labels. No legacy
+  code path can cause `dual_write_message` to mint a token in a foreign
+  namespace.
+
+## `handlers.rs::handle_thread`
+
+Retrieves all messages in a conversation thread, ordered chronologically:
+the originating message (the one whose `id` matches the `thread_id` root)
+plus all messages whose `properties.thread_id` equals the root UUID.
+
+Cross-namespace thread resolution: when the resolved note carries a
+`thread_id` in its properties that differs from its own UUID, that stored
+`thread_id` IS the canonical root (e.g. this is an inbound copy of the root,
+or a non-root message). `comm.thread` resolves to that canonical root so that
+`thread(id=id_A)` and `thread(id=id_B)` both return the full conversation
+regardless of which copy UUID the caller holds.
+
+The root ID is validated: it must exist in the caller namespace and its
+`kind` must be `"message"`.
+
+Missing/invalid `thread_id` (issue #479b — e.g. a legacy/imported root written
+before the canonical field existed) falls back to the passed note's own UUID,
+matching ADR-040: a target with no `thread_id` becomes the root for its chain.
+The SQL filter only matches `properties.thread_id == canonical_thread_id`,
+which misses a root note lacking a `thread_id` property at all, so the
+already-validated root note is explicitly appended when the query didn't
+already return it — `comm.thread(id=root)` never reports an empty/incomplete
+thread for a root that predates the canonical `thread_id` field.
+
+`order` (#494) is a closed set: `"asc"` (default) | `"desc"`. `after` (#494) is
+either a message id (short prefix or full UUID, resolved the same way `id` is)
+or an RFC 3339 timestamp. An id cursor resolves to the full `(created_at,
+full_id)` tuple of the referenced note so ties on equal microsecond timestamps
+are broken deterministically instead of being skipped or duplicated. A
+timestamp cursor is parsed to microseconds via chrono (matching the pattern in
+`khive-pack-brain/src/handlers.rs` and `khive-vcs/src/sync.rs`) rather than
+compared as a raw string, so non-canonical but valid RFC 3339 forms
+(whole-second `Z`, `+00:00` offsets, ...) compare correctly against khive's
+canonical microsecond timestamps. An `after` value that is neither a
+resolvable id nor a parseable RFC 3339 timestamp is a hard error — never
+silently coerced or treated as "no cursor". Two rows sharing a microsecond
+`created_at` (e.g. ADR-057 dual-write self-send copies) are ordered
+deterministically by `full_id`. Sorting on the `(created_at, full_id)` tuple
+(rather than timestamp alone) keeps ties stable across pages/backends.
+
+`ThreadRow` carries the sort/cursor key `(created_at, full_id)` alongside the
+already-rendered message JSON, so the total-order sort and cursor filter
+compare exact `(i64, Uuid)` tuples instead of re-parsing the ISO string
+embedded in the JSON. `AfterCursor::Id` carries the full tuple for
+tie-breaking; `AfterCursor::Timestamp` carries only the parsed microsecond
+value since there is no specific row to break ties against.
+
+## `handlers.rs::handle_ingest`
+
+Writes a single inbound message note from a channel adapter. This is a
+`Visibility::Subhandler` verb: not accessible via the MCP wire, only callable
+from within the process (e.g. the polling loop in `khive-mcp`). It is the
+authoritative write path for all channel-delivered messages; the polling loop
+must not bypass it.
+
+Issue #479a: a present, non-empty `thread_id` that is not a valid UUID must
+fail closed rather than being silently dropped and replaced with a fresh UUID,
+which would split the message into the wrong conversation. A blank/absent
+value is not an error — it just means "no caller-supplied thread_id".
+
+Thread resolution: when `correlation_external_id` is supplied, the handler
+queries for an existing message note whose `external_id` matches that value,
+reads its `thread_id`, and attaches the new note to the same thread, so
+replies route back to the actor who sent the original, not to the raw email
+address. Two-query fallback: `corr` may be either a Message-ID (matched via
+`$.external_id`) from a human webmail In-Reply-To header, OR a thread UUID
+(matched via `$.thread_id`) from a preserved X-Khive-Thread-ID header on our
+own outbound emails. External_id is tried first (preserves the In-Reply-To
+path); if that misses, thread_id is tried. Our own outbound mail stores its
+Message-ID in wire form `<id@domain>` (angle brackets included), while
+`mail_parser` strips the brackets from an inbound `In-Reply-To`, yielding
+`id@domain`. The correlation key is matched as received and in its
+bracket-toggled form so `<id>` and `id` correlate either way. Both passes are
+restricted to outbound notes so an inbound note's own external_id can never be
+matched as a threading parent. When a match is found but carries no valid
+`thread_id` (issue #479b, e.g. a legacy/imported outbound row), the matched
+note's own UUID becomes the canonical root per ADR-040.
+
+`thread_id` priority: caller-supplied > resolved from correlation > new root.
+`to_actor` priority: (1) `from_actor` of the correlated original (route reply
+back to the sending actor), (2) caller-supplied `default_inbound_actor` (fresh
+email landing actor), (3) `p.to.trim()` (back-compat: raw recipient address).
+
+Deduplication: when `external_id` is supplied, `try_create_note` uses a
+verify-after-insert check on the durable unique index on `external_id`. A
+confirmed duplicate returns `Ok(None)` without error; only an external_id
+collision is treated as dedup, other constraint violations surface as errors.
+
+Generic transport-layer metadata passthrough (issue #448): merged additively
+so it can never clobber the identity/routing fields (from, to, from_actor,
+to_actor, direction, read, thread_id, sent_at, subject, external_id,
+wire_message_id, wire_references, channel_kind) — a key already present
+always wins. The comm pack does not interpret any metadata key; the email
+channel happens to use it for quarantine markers.
+
+## `handlers.rs::heartbeat_note_id`
+
+Deterministic UUID identifying the `channel_health` row for one `(namespace,
+channel_kind, channel_slug)` triple (khive #606). Deterministic (not
+`Uuid::new_v4`) so `handle_heartbeat` can compute the same id on every poll
+tick and `upsert_note`'s `INSERT OR REPLACE` updates the same row instead of
+accumulating a new one per tick. Keying by slug in addition to kind is the
+point of #606's amendment 2: two accounts of the same kind (e.g. two
+mailboxes, both `kind() == "email"`) must not collapse into a single row.
+
+The three components are hashed as a JSON array of strings, NOT joined with a
+`:` delimiter. Namespaces may themselves contain `:` (hierarchical namespace
+strings are explicitly allowed), so a delimiter-joined
+`format!("...:{a}:{b}:{c}")` is not an injective encoding:
+`(namespace="a:b", channel_kind="c", channel_slug="d")` and
+`(namespace="a", channel_kind="b:c", channel_slug="d")` both produced the
+identical string `"khive:channel_health:a:b:c:d"` under the old scheme.
+`serde_json::to_vec` of an array of strings is unambiguous — each element is
+quoted and internal quotes/backslashes are escaped — so distinct triples
+always serialize to distinct byte sequences.
+
+## `handlers.rs::handle_heartbeat`
+
+Persists one poll attempt's outcome into the channel's heartbeat row (khive
+#606). Subhandler — only the daemon's channel poll loop
+(`crates/khive-mcp/src/serve.rs::channel_poll_loop`) calls this.
+
+Read-modify-write against the existing row (if any) so that:
+- `created_at` is preserved across updates (first-seen time), not reset every
+  tick.
+- `last_error` is RETAINED across a subsequent success (design review
+  amendment 3): callers compare `last_error.at` against
+  `last_success_at`/`last_failure_at` to tell a resolved issue from a live
+  one, so a success must never clear it.
+- `consecutive_failures` resets to 0 on success and increments on failure,
+  read from the prior row rather than any in-process counter, so it is
+  correct even across a daemon restart.
+
+Heartbeat rows are an OPERATIONAL surface, not message data (#606). Persists to
+`crate::CHANNEL_HEALTH_NAMESPACE` ALWAYS — never `token.namespace()` — so a
+poll loop configured with a non-local `KHIVE_EMAIL_INGEST_NAMESPACE` cannot
+cause heartbeat rows to land anywhere but this one fixed namespace. This is
+enforced here (not just at the serve.rs call site) so the guarantee holds even
+if a future caller passes a different `namespace` dispatch param.
+
+`handle_health` (khive #877) no longer mirrors this fixed pin: it reads from
+`token.namespace()`, which only resolves to this same constant for an
+unscoped (default-namespace) caller. An explicitly-scoped `comm.health` caller
+reads its own namespace, not wherever this handler wrote — do not reintroduce
+a `handle_health` read of this constant to "fix" that; it is the
+cross-namespace leak #877 closed.
+
+## `handlers.rs::channel_health_to_json`
+
+Projects a persisted `channel_health` note into the `comm.health()` channel
+entry shape. Missing fields (a row written before a given property existed)
+default to `null`/`0` rather than panicking — forward-compatible with rows
+written by an older heartbeat writer.
+
+## `handlers.rs::handle_health`
+
+Read-only per-channel health snapshot (khive #606).
+
+Reads the daemon-persisted `channel_health` rows from `token.namespace()`
+(khive #877) — the same injected-namespace resolution every other comm verb
+uses (ADR-007 Rev 6 Rule 3: `namespace=` is the caller's explicit escape;
+absent that, the token pins to `"local"`). Unscoped callers (single-tenant
+local daemon, the common case) see exactly what they saw before this fix,
+since heartbeat rows still land under `crate::CHANNEL_HEALTH_NAMESPACE`
+(`"local"`) and an unscoped token also resolves to `"local"`. A caller that
+passes an explicit non-local `namespace=` now reads that namespace's rows
+only — never `"local"`'s — closing the cross-namespace operational-surface
+leak that held this verb off the cloud data plane (#877).
+
+`role` answers "who owns the loops", not "whose memory answered": any
+persisted row means some daemon owns the channel loops, so `role` is reported
+as `"daemon"` with `source: "daemon-heartbeat"` regardless of whether THIS
+process is that daemon. `role: "client"` with an empty `channels` array is
+correct both when no daemon heartbeat state exists at all (fresh install, or a
+daemon that has never completed a poll tick) and when the caller's injected
+namespace has no heartbeat rows of its own — the comm pack has no visibility
+into which channels are configured (that lives in `khive-mcp`/
+`khive-channel-email`), so an empty result is the only fact-based response
+available at this layer.
+
+`namespace` in the response (khive #877) is the namespace actually read,
+echoed back so the shape is self-describing for both the unscoped and the
+explicitly-scoped case: `role: "client"` / empty `channels` is now ambiguous on
+its own, since it is also the correct, expected shape for a `namespace=`-scoped
+call in the shipped OSS build (`comm.heartbeat` only ever persists under
+`crate::CHANNEL_HEALTH_NAMESPACE`, and there is no OSS producer for
+tenant-scoped heartbeat rows yet — that is cloud-side follow-up). A caller
+reading `namespace: "tenant-a"` alongside `role: "client"` can tell "no daemon
+anywhere" (unscoped call, `namespace: "local"`) apart from "no rows written
+under my scope yet" (scoped call, `namespace: "tenant-a"`) without khive
+silently falling back to `"local"` to paper over the difference.
+
+Never returns a computed `healthy: bool` (design review amendment: "report
+timestamps only") — staleness/alerting judgment belongs to the caller.
+
+`resource` (ADR-103 Stage 1, issue #723 ask 2): a process-level self-report of
+this process's own cumulative CPU time and RSS (via `getrusage`,
+`khive_runtime::process_resource_usage`) plus the names of any background
+phases (e.g. `ann_warm`) currently in flight in this process
+(`khive_runtime::active_phase_names`). "This process" is, in the common case,
+the daemon itself: a client-role stdio session without an in-memory poll loop
+of its own still forwards `dispatch` calls to the daemon over its socket, so
+this handler body executes inside the daemon process, not the thin client.
+`cpu_us`/`rss_bytes` are `null` only if the underlying `getrusage` read is
+unavailable on this platform; `active_phases` is always present and empty
+when nothing is in flight. Raw observations only, per the same "no computed
+healthy bool" rule as the rest of this verb — attributing severity to a given
+CPU/RSS number is the caller's judgment, not this verb's.
+
+## `handlers.rs::PROBE_SQL`
+
+The single indexed read powering `comm.probe` (ADR-D5). `INDEXED BY
+idx_comm_message_to_actor` is a regression fence: if a custom bootstrap skips
+comm schema-plan application, this query fails loudly instead of silently
+degrading to a table scan.
+
+`cursor_us`/`since_us` are keyed on `notes_seq.seq`, not SQLite `rowid` and
+not `created_at` (#780, #827):
+
+- `created_at` is an application-clock read taken before a note's write
+  acquires the writer critical section, so two concurrent writers can commit
+  out of stamp order; a `created_at`-keyed cursor can then advance past a row
+  that committed *after* it, permanently hiding that row from every later
+  probe.
+- `notes.rowid` looked monotonic with commit order, but `notes` has a TEXT
+  PRIMARY KEY, so that rowid is *implicit*: SQLite may renumber it on
+  `VACUUM` (khive exposes `memory.vacuum`), and reuses the highest rowid once
+  that row is hard-deleted (khive exposes a public hard delete), either of
+  which can permanently exclude a later message whose rowid lands at or below
+  an already-issued cursor.
+
+`notes_seq.seq` fixes both: it is assigned once, inside the same writer
+transaction as the note's insert, from a dedicated `INTEGER PRIMARY KEY
+AUTOINCREMENT` sequence that VACUUM never renumbers and SQLite never reuses
+(see `sql/007-notes-seq.sql`). The wire field names keep the `_us` suffix
+(frozen contract, ADR-D5) but the value is an opaque monotonic token, not a
+microsecond timestamp; do not revert this to `created_at` or `rowid`.
+`created_at_us` on each `new_messages` entry is unaffected: it stays a real
+display timestamp, still ordered ascending by `created_at` for readability,
+and carries no cursor guarantee of its own.
+
+## `handlers.rs::notes_seq_high_water_mark`
+
+A caller-supplied `since_us` above `notes_seq`'s durable high-water mark
+(`sqlite_sequence.seq` for the `notes_seq` table) cannot be a genuine cursor —
+`notes_seq` starts at 1 and grows by exactly one per note ever inserted, so no
+value this store ever handed out can exceed the highest value it has ever
+assigned. Such a `since_us` is a pre-upgrade persisted-timestamp cursor
+(#827): a real Unix-microsecond timestamp from after 1970-01-12 already
+exceeds any realistic note count by orders of magnitude. Comparing against the
+actual high-water mark, instead of a fixed ceiling, keeps this correct forever
+as `notes_seq` grows — a fixed ceiling would eventually reset a legitimate
+high sequence value to baseline, contradicting `comm.probe`'s opaque
+round-trip contract.
+
+`query_probe`'s cursor clamp: never let the returned cursor regress below what
+the caller already holds (#827) — if the message that previously held the
+highest `notes_seq.seq` was hard-deleted since the last probe, `MAX(seq)`
+over the remaining rows can be smaller than a cursor already handed out.
+Clamping in Rust, rather than in SQL, keeps the single indexed query a pure
+aggregate with no extra branch.
+
+## `handlers.rs::handle_cursor_get` / `handle_cursor_commit`
+
+Read/persist the durable channel poll checkpoint for `(channel_kind,
+channel_slug)` (issue #449). Subhandlers — only the daemon's channel poll loop
+calls these, and `cursor_commit` only after every envelope in the page has
+returned `Ok` from `comm.ingest`. Both run the pack-owned
+`comm_channel_cursor` schema statement before the query/write so an
+in-memory/test runtime that never applied the boot-time schema plan still
+works (matches the repository's lazy pack-schema bootstrap convention).
+`cursor_get` returns JSON `null` when no row exists yet (first-run
+compatibility mode). `cursor_commit` replaces any prior row for that identity.
+
+## Message-ID / References header helpers (#403)
+
+- `message_id_match_candidates`: outbound mail stores its Message-ID in wire
+  form `<id@domain>` (angle brackets included); `mail_parser` strips those
+  brackets from an inbound `In-Reply-To`, yielding `id@domain`. To correlate a
+  reply back to the sending actor, both representations must be tried, so
+  this returns the key as received plus its bracket-toggled variant, exact
+  form first.
+- `wrap_message_id`: normalizes a stored Message-ID into RFC 5322 wire form
+  (angle-bracketed). Stored values may already be bracketed (an outbound
+  note's self-minted `external_id`, e.g. `<uuid@domain>`) or bracket-free (an
+  inbound note's `wire_message_id`, since `mail_parser` strips brackets when
+  parsing). This is the single place that normalizes to the wire form the
+  `In-Reply-To`/`References` headers require.
+- `parent_wire_message_id`: direction-aware — an outbound parent's own
+  Message-ID is self-minted into `external_id` at send time; an inbound
+  parent's Message-ID lives in `wire_message_id` instead, since an inbound
+  note's `external_id` is the IMAP UIDVALIDITY/UID dedup key, never a
+  Message-ID. Returns `None` when the parent carries no wire Message-ID at
+  all (e.g. a khive-internal parent, or an email parent the channel never
+  captured one for).
+- `parent_references_chain`: direction-aware — an inbound parent's chain (as
+  received over the wire) lives in `wire_references`; an outbound parent's
+  chain is whatever was persisted on it as `references_chain` when *it* was
+  sent (an outbound note that was a fresh send, not a reply, carries no
+  `references_chain`). Returns `None` when the parent has no chain to extend;
+  the caller then falls back to the parent's Message-ID alone, matching RFC
+  5322 (References = prior chain, if any, + parent Message-ID).
+- `sanitize_reference_token`: rejects anything containing CR or LF (header
+  injection guard) or without an `@` (not a plausible message id), then
+  normalizes to wire form. Returns `None` for a malformed token so the caller
+  can skip it rather than emit a corrupt header.
+- `bare_reference_id`: strips angle brackets and surrounding whitespace, for
+  use as a de-duplication comparison key only — callers keep pushing each
+  token's original serialization into the emitted header, never this bare
+  form.
+- `build_references_header`: builds the full `References` header value for a
+  reply — the parent's existing chain (each token individually sanitized;
+  malformed tokens skipped) followed by the parent's own Message-ID. Tokens
+  are whitespace-separated per RFC 5322. A stored chain can already contain an
+  equivalent of the parent's own id (e.g. tainted or legacy data); tokens are
+  de-duplicated by their bracket-stripped form, keeping first-seen order, so
+  the parent id is skipped rather than appended a second time when an
+  equivalent token is already present.
+
+## `vocab.rs::COMM_SCHEMA_PLAN_STMTS`
+
+Pack-auxiliary indexes for comm inbox and thread queries. Indexes use `WHERE
+deleted_at IS NULL` (not `WHERE kind = 'message'`) so that SQLite's index
+planner can match them when queries contain the parameterized `kind = ?N`
+predicate emitted by `build_note_filter_where`. A literal-value partial index
+(`WHERE kind = 'message'`) cannot be used for a parameterized comparison — the
+planner sees different predicates and falls back to a table scan.
+`deleted_at IS NULL` is always present in filtered queries, so the partial
+condition is always satisfied and the index is eligible. `kind` is included
+as an indexed column so the `kind = ?N` predicate is covered. Statements are
+idempotent (`CREATE INDEX IF NOT EXISTS`).
+
+The `idx_comm_message_external_id` UNIQUE index is NOT listed here; it is
+created by the V5 schema migration (`005-unique-comm-external-id.sql`), which
+is the sole durable authority for that index.
+
+## `vocab.rs::COMM_CHANNEL_CURSOR_SCHEMA_STMT`
+
+Pack-owned auxiliary cursor table for durable channel poll progress (issue
+#449): one row per `(channel_kind, channel_slug)`, holding the
+transport-neutral checkpoint fields from `khive_channel::ChannelCheckpoint`.
+For IMAP, `generation` is `UIDVALIDITY` and `high_water` is the greatest
+durably handled UID. `source` detects a host/port/mailbox/folder change under
+the same registry identity, so a stale checkpoint is never applied to a
+different configuration.
+
+Idempotent (`CREATE TABLE IF NOT EXISTS`), applied at boot via `schema_plan`
+and shared verbatim with `handle_cursor_get`/`handle_cursor_commit`'s lazy
+bootstrap for in-memory/test runtimes that never run the boot-time schema
+plan.
+
+## `params.rs` field notes
+
+- `SendParams::tags`: structured provenance tags (e.g. run id, job id, traffic
+  class), persisted verbatim to `properties["tags"]` on both the outbound and
+  inbound copies. Mirrors the shipped `memory.remember` `tags` precedent
+  (issue #495).
+- `SendParams::self_send`: explicit acknowledgment that `to` intentionally
+  names the sender's own resolved actor identity (khive #820). Required
+  whenever the resolved `to_actor` equals `from_actor`; without it such a send
+  is rejected rather than silently delivered, since a sub-agent session
+  addressing a distinct parent/orchestrator actor that happens to collapse
+  onto its own identity (both resolve `[actor] id` from the same
+  project-scoped `.khive/config.toml`, ADR-096 Fork 2) is a mis-resolution,
+  not intent.
+- `IngestParams`/`HeartbeatParams`: `deny_unknown_fields` is intentionally
+  absent — the polling loop may pass extra fields (including the `namespace`
+  routing key consumed by the dispatch layer) that future handler versions
+  can extend without breaking existing deployments. The `namespace` key is
+  consumed by `VerbRegistry::dispatch` to mint the `NamespaceToken` before the
+  handler is called; the handler uses `token` directly and does not read
+  `namespace` from the struct.
+- `IngestParams::metadata`: optional transport-layer metadata passthrough,
+  merged verbatim into the stored note's properties alongside the named
+  fields. Generic and channel-agnostic: the comm pack does not interpret any
+  key in this map, it only persists it. A channel adapter that needs to
+  attach adapter-specific markers (e.g. the email channel's quarantine flags,
+  ADR-056 Amendment 2026-07-02) sets `ChannelEnvelope.metadata`; the MCP poll
+  loop forwards it here unchanged. Absent metadata is today's behavior exactly
+  (issue #448).
+- `ProbeParams`: public polling contract (khive #667 daemon hardening slice) —
+  shape is frozen, see the comm pack README.

--- a/crates/khive-pack-comm/src/handlers.rs
+++ b/crates/khive-pack-comm/src/handlers.rs
@@ -40,19 +40,10 @@ fn validate_actor_label(verb: &str, label: &str, field: &str) -> Result<(), Runt
     Ok(())
 }
 
-/// `send` — create a message note in the caller's namespace (outbound) AND deliver
-/// an inbound copy addressed to the actor label supplied in `to` (ADR-057).
-///
+/// `send` — create a message note in the caller's namespace (outbound) AND
+/// deliver an inbound copy addressed to the actor label in `to` (ADR-057).
 /// Both copies land in the caller's namespace; no cross-namespace write occurs.
-/// `from_actor` is set to `token.namespace().as_str()`. `to_actor` is set to the
-/// `to` argument. When the caller's actor label is `"local"` (single-actor fallback),
-/// `comm.inbox` does not apply an actor filter, preserving backward compatibility.
-///
-/// The routing `from` and `to` passed to `dual_write_message` are both set to the
-/// caller's namespace string so that `from == recipient_ns_str` is always true: this
-/// naturally bypasses the cross-namespace allowlist gate in `dual_write_message`
-/// (ADR-057 §"Interaction with ADR-040"). The actor labels are propagated via the
-/// `from_actor`/`to_actor` arguments and stored in message properties.
+/// See crates/khive-pack-comm/docs/handlers.md#handlersrshandle_send
 pub(crate) async fn handle_send(
     runtime: &KhiveRuntime,
     token: &NamespaceToken,
@@ -78,22 +69,10 @@ pub(crate) async fn handle_send(
     let from_actor = token.actor().id.clone();
     let to_actor = p.to.trim().to_string();
 
-    // #820: a resolved target that equals the sender's own actor identity is,
-    // outside the anonymous single-tenant fallback ("local"), almost always a
-    // mis-resolution rather than intent -- most commonly a sub-agent session
-    // spawned in the same project scope trying to reach a distinct parent
-    // orchestrator actor. Both processes resolve `[actor] id` from the same
-    // worktree-scoped `.khive/config.toml` (ADR-096 Fork 2's project-local
-    // `[actor]` injection tier is per-project, not per-session), so the
-    // sub-agent's `from_actor` and the parent label it names collapse onto the
-    // identical string with no error, no warning, and no distinct inbox: the
-    // message silently "delivers" to the sender's own attributed identity
-    // instead of a genuinely different principal. Reject by default; a caller
-    // that truly means to message its own inbox (e.g. a personal reminder) must
-    // say so explicitly via `self_send=true`, turning the collapse loud instead
-    // of silent. `to_actor == "local"` is exempted: that is the anonymous
-    // single-tenant party-line default (both sender and recipient unattributed),
-    // not a collapsed distinct-principal address.
+    // #820: reject a target that collapses onto the sender's own actor identity
+    // unless self_send=true — usually a sub-agent/parent mis-resolution, not intent.
+    // "local" is exempt (anonymous single-tenant party-line default).
+    // See crates/khive-pack-comm/docs/handlers.md#handlersrshandle_send
     if to_actor == from_actor && to_actor != "local" && !p.self_send {
         return Err(RuntimeError::InvalidInput(format!(
             "send: `to` ({to_actor:?}) resolves to the sender's own actor identity \
@@ -107,15 +86,8 @@ pub(crate) async fn handle_send(
         )));
     }
 
-    // #200: addressed sends from an unattributed caller will stamp from_actor="local",
-    // which causes reply-threading collapse when multiple unconfigured actors interact.
-    // This is a known limitation pending issue #75 (actor identity per request).
-    // We surface a visible warning so operators can diagnose mis-attribution; the send
-    // proceeds rather than hard-erroring to preserve backward compatibility with
-    // sessions that set default_namespace but not actor_id.
-    //
-    // Uses the shared actor-identity policy (#567) so this warning fires under
-    // exactly the same "unattributed" definition the gate and token minter use.
+    // #200: unattributed callers stamp from_actor="local", corrupting reply-thread
+    // routing; warn (don't hard-error, for back-compat) rather than silently proceed.
     if khive_runtime::actor_is_unattributed(token.actor()) && to_actor != "local" {
         tracing::warn!(
             to_actor = %to_actor,
@@ -159,11 +131,7 @@ pub(crate) async fn handle_send(
 }
 
 /// `inbox` — list inbound messages for the caller's actor label (ADR-057).
-///
-/// When the caller's actor label is `"local"` (single-actor fallback), no `to_actor`
-/// filter is applied and the inbox behaves as before (party-line). When the caller has
-/// a non-`"local"` actor label, only messages addressed to that actor are returned.
-/// Legacy messages without a `to_actor` field are visible regardless (Q3: OR IS NULL).
+/// See crates/khive-pack-comm/docs/handlers.md#handlersrshandle_inbox
 pub(crate) async fn handle_inbox(
     runtime: &KhiveRuntime,
     token: &NamespaceToken,
@@ -194,9 +162,8 @@ pub(crate) async fn handle_inbox(
 
     let caller_actor = token.actor().id.clone();
 
-    // Push direction + read-status filters into SQL so idx_comm_message_direction is usable.
-    // Read filter uses json_type to match the old as_bool().unwrap_or(false) semantics:
-    // only JSON boolean `true` counts as read; missing/false/string/integer all count as unread.
+    // Push direction + read-status into SQL for idx_comm_message_direction; json_type
+    // read-check keeps only JSON boolean `true` as read (matches prior as_bool semantics).
     let mut property_filters = vec![PropertyFilter {
         json_path: "$.direction".to_string(),
         op: FilterOp::Eq,
@@ -216,16 +183,8 @@ pub(crate) async fn handle_inbox(
         _ => {} // "all" — no read-status filter
     }
 
-    // ADR-057 Q3: filter inbox by to_actor.
-    //
-    // When the caller has a configured actor label (non-"local"), apply an exact
-    // to_actor filter so each actor sees only their own messages. Legacy messages
-    // without a to_actor field (EqOrMissing) remain visible for the configured actor.
-    //
-    // When the caller is anonymous ("local") — the OSS single-tenant case — apply
-    // EqOrMissing("local") so the caller sees only party-line messages (to_actor=
-    // "local" or absent). This closes the #199 multi-actor read leak while preserving
-    // backward-compatible behavior for deployments where everyone is 'local'.
+    // ADR-057 Q3: to_actor filter, EqOrMissing so legacy to_actor-less messages stay
+    // visible; closes the #199 multi-actor read leak for non-"local" callers.
     property_filters.push(PropertyFilter {
         json_path: "$.to_actor".to_string(),
         op: FilterOp::EqOrMissing,
@@ -240,11 +199,8 @@ pub(crate) async fn handle_inbox(
     };
     let store = runtime.notes(token)?;
 
-    // #493: when a sender filter is supplied, apply it in Rust after the standard
-    // direction/status/to_actor filters (which stay pushed into SQL for index usage) —
-    // `FilterOp` has no prefix-match operator, so from_prefix cannot be pushed down.
-    // Pages beyond the first are scanned (same unbounded-page-loop shape `handle_thread`
-    // uses) until `limit` matches are collected or the store is exhausted.
+    // #493: `FilterOp` has no prefix-match op, so a sender filter is applied in Rust
+    // over paged results (see docs/handlers.md#handlersrshandle_inbox) instead of SQL.
     let messages: Vec<Value> = if p.from_actor.is_some() || p.from_prefix.is_some() {
         const PAGE_SIZE: u32 = 200;
         let mut collected: Vec<Value> = Vec::new();
@@ -345,13 +301,8 @@ pub(crate) async fn handle_read(
         )));
     }
 
-    // Merge `read: true` into properties and patch in place via a real
-    // `UPDATE` (not `upsert_note`'s `INSERT OR REPLACE`): the latter
-    // silently deletes and re-inserts the row on a primary-key conflict
-    // (#780). The `comm.probe` cursor is keyed on `notes_seq.seq`, which is
-    // fixed at first insert and survives such churn, so this is defensive
-    // rather than load-bearing; a metadata patch should never rewrite the
-    // row regardless.
+    // Patch via a real `UPDATE`, not `upsert_note`'s `INSERT OR REPLACE` (#780
+    // silently re-inserts the row on conflict). See docs/handlers.md#handlersrshandle_read
     let mut props = note.properties.clone().unwrap_or_else(|| json!({}));
     props["read"] = json!(true);
     let updated_at = Utc::now().timestamp_micros();
@@ -366,7 +317,8 @@ pub(crate) async fn handle_read(
     )
 }
 
-/// `reply` — reply to a message, threading linkage.
+/// `reply` — reply to a message, threading linkage. See
+/// crates/khive-pack-comm/docs/handlers.md#handlersrshandle_reply
 pub(crate) async fn handle_reply(
     runtime: &KhiveRuntime,
     token: &NamespaceToken,
@@ -405,25 +357,17 @@ pub(crate) async fn handle_reply(
         .cloned()
         .unwrap_or_else(|| json!({}));
 
-    // Issue #403: capture the parent's wire Message-ID so native mail clients
-    // (not khive's own X-Khive-Thread-ID/external_id correlation) can group this
-    // reply into the same conversation via In-Reply-To/References. `None` when
-    // the parent has no wire Message-ID -- the reply then sends without those
-    // headers, exactly as before this feature.
+    // Issue #403: parent's wire Message-ID drives In-Reply-To/References for native
+    // mail clients. `None` when the parent has none — see docs/handlers.md.
     let in_reply_to_message_id = parent_wire_message_id(&orig_props);
 
-    // References must carry the FULL ancestor chain per RFC 5322, not just the
-    // immediate parent: the parent's existing chain (if any) followed by the
-    // parent's own Message-ID. `None` when the parent has no wire Message-ID at
-    // all (mirrors `in_reply_to_message_id`); malformed tokens in the parent's
-    // stored chain are individually skipped rather than corrupting the header.
+    // References carries the FULL ancestor chain per RFC 5322, not just the parent.
     let references_chain = in_reply_to_message_id.as_deref().map(|parent_mid| {
         build_references_header(parent_references_chain(&orig_props), parent_mid)
     });
 
-    // UE6-H2: thread_id must always be a full 36-char hyphenated UUID.
-    // If the stored thread_id is a valid full UUID, use it; otherwise fall
-    // back to the original message's own full UUID as the thread root.
+    // UE6-H2: thread_id must be a full 36-char hyphenated UUID; falls back to the
+    // original message's own UUID as thread root when the stored value isn't one.
     let thread_id = orig_props
         .get("thread_id")
         .and_then(Value::as_str)
@@ -431,8 +375,7 @@ pub(crate) async fn handle_reply(
         .map(|u| u.as_hyphenated().to_string())
         .unwrap_or_else(|| original.id.as_hyphenated().to_string());
 
-    // ADR-057: prefer from_actor/to_actor fields when present (actor-addressed messages).
-    // Fall back to from/to namespace strings for legacy messages.
+    // ADR-057: prefer from_actor/to_actor; fall back to from/to for legacy messages.
     let original_from_actor = orig_props
         .get("from_actor")
         .and_then(Value::as_str)
@@ -468,10 +411,7 @@ pub(crate) async fn handle_reply(
     let from_actor_label = token.actor().id.clone();
     let sent_at = Utc::now().to_rfc3339();
 
-    // UE6-H1: route reply to the "other party" — not always to the original sender.
-    // If the reply caller is the original sender (from_actor or from), route to the
-    // original recipient. If the reply caller is the original recipient, route back
-    // to the original sender.
+    // UE6-H1: route to the "other party" — not always the original sender.
     let reply_to = if from_actor_label == original_from {
         original_to.clone()
     } else {
@@ -479,11 +419,7 @@ pub(crate) async fn handle_reply(
     };
 
     // ADR-057: always set from_actor/to_actor on replies (fail-closed on cross-namespace
-    // write). Both copies land in the caller's namespace regardless of whether the
-    // original message carried actor labels. The reply_to label is derived from the
-    // original's actor fields when present, else from the legacy from/to strings treated
-    // as labels. No legacy code path can cause dual_write_message to mint a token in a
-    // foreign namespace.
+    // write) — both copies land in the caller's namespace regardless of legacy labels.
     let reply_from_actor = from_actor_label.clone();
     let reply_to_actor = reply_to.clone();
 
@@ -524,23 +460,11 @@ pub(crate) async fn handle_reply(
     }))
 }
 
-/// `thread` — retrieve all messages in a conversation thread, ordered chronologically.
-///
-/// Returns the originating message (the one whose `id` matches the `thread_id`
-/// root) plus all messages whose `properties.thread_id` equals the root UUID,
-/// ordered by `created_at` ascending (chronological).
-///
-/// Cross-namespace thread resolution: when the resolved note carries a `thread_id`
-/// in its properties that differs from its own UUID, that stored `thread_id` IS the
-/// canonical root (e.g., this is an inbound copy of the root, or a non-root message).
-/// `comm.thread` resolves to that canonical root so that `thread(id=id_A)` and
-/// `thread(id=id_B)` both return the full conversation regardless of which copy UUID
-/// the caller holds.
-///
-/// The root ID is validated: it must exist in the caller namespace and its
-/// `kind` must be `"message"`. A full UUID that does not resolve, belongs to a
-/// different namespace, or has the wrong kind returns an error — the same
-/// behaviour as `read()` and `reply()`.
+/// `thread` — retrieve all messages in a conversation thread, ordered
+/// chronologically: the originating message plus all messages whose
+/// `properties.thread_id` equals the root UUID. The root ID is validated: it
+/// must exist in the caller namespace and its `kind` must be `"message"`.
+/// See crates/khive-pack-comm/docs/handlers.md#handlersrshandle_thread
 pub(crate) async fn handle_thread(
     runtime: &KhiveRuntime,
     token: &NamespaceToken,
@@ -584,16 +508,10 @@ pub(crate) async fn handle_thread(
             )));
         }
 
-        // Cross-namespace root resolution: if the note's properties.thread_id is a
-        // valid full UUID that differs from the note's own UUID, use that as the
-        // canonical thread_id.  This handles the case where the caller holds an
-        // inbound copy UUID (id_B) but the canonical root is the outbound UUID (id_A).
-        // Both copies were written with the same canonical thread_id by dual_write_message.
-        //
-        // Missing/invalid `thread_id` (issue #479b -- e.g. a legacy/imported root
-        // written before the canonical field existed) falls back to the passed
-        // note's own UUID, matching ADR-040: a target with no `thread_id` becomes
-        // the root for its chain.
+        // Cross-namespace root resolution: use the stored thread_id as canonical root
+        // when it differs from the note's own UUID (dual_write_message patches both
+        // copies to match); falls back to the note's own UUID otherwise (issue #479b,
+        // ADR-040). See crates/khive-pack-comm/docs/handlers.md#handlersrshandle_thread
         let canonical = match note
             .properties
             .as_ref()
@@ -611,8 +529,6 @@ pub(crate) async fn handle_thread(
     };
 
     // Push thread_id predicate into SQL so idx_comm_message_thread can be used.
-    // The root note always has properties.thread_id == own_uuid == canonical_thread_id
-    // (patched by dual_write_message), so it is captured by the same SQL filter as replies.
     let thread_store = runtime.notes(token)?;
     let thread_filter = NoteFilter {
         kind: Some("message".to_string()),
@@ -653,13 +569,8 @@ pub(crate) async fn handle_thread(
         db_offset += PAGE_SIZE;
     }
 
-    // Practical equivalent of `id == root OR properties.thread_id == root`
-    // (issue #479b): the SQL filter above only matches `properties.thread_id ==
-    // canonical_thread_id`, which misses a root note that lacks a `thread_id`
-    // property at all (e.g. legacy/imported data). Explicitly include the
-    // already-validated root note when the query didn't already return it, so
-    // `comm.thread(id=root)` never reports an empty/incomplete thread for a
-    // root that exists but predates the canonical `thread_id` field.
+    // Explicitly include the already-validated root when the SQL filter missed it
+    // (issue #479b: a root lacking a `thread_id` property, e.g. legacy/imported data).
     let root_already_present = rows.iter().any(|r| r.full_id == root_note.id);
     if !root_already_present {
         rows.push(ThreadRow {
@@ -669,17 +580,8 @@ pub(crate) async fn handle_thread(
         });
     }
 
-    // #494: `after` cursor — either a message id (short prefix or full
-    // UUID, resolved the same way `id` is) or an RFC 3339 timestamp. An id cursor
-    // resolves to the full `(created_at, full_id)` tuple of the referenced note so
-    // ties on equal microsecond timestamps are broken deterministically instead of
-    // being skipped or duplicated. A timestamp cursor is parsed to microseconds via
-    // chrono (matching the pattern in khive-pack-brain/src/handlers.rs and
-    // khive-vcs/src/sync.rs) rather than compared as a raw string, so non-canonical
-    // but valid RFC 3339 forms (whole-second `Z`, `+00:00` offsets, ...) compare
-    // correctly against khive's canonical microsecond timestamps. An `after` value
-    // that is neither a resolvable id nor a parseable RFC 3339 timestamp is a hard
-    // error — never silently coerced or treated as "no cursor".
+    // #494: `after` cursor — message id or RFC 3339 timestamp; a hard error if
+    // neither. See crates/khive-pack-comm/docs/handlers.md#handlersrshandle_thread
     let after_cursor: Option<AfterCursor> = match p.after.as_deref() {
         None => None,
         Some(raw) => {
@@ -716,10 +618,7 @@ pub(crate) async fn handle_thread(
     };
     if let Some(cursor) = &after_cursor {
         rows.retain(|r| match cursor {
-            // Tuple compare, not timestamp-only: two rows sharing a microsecond
-            // `created_at` (e.g. ADR-057 dual-write self-send copies) are ordered
-            // deterministically by `full_id`, so an id cursor sitting on one of them
-            // never skips or re-includes its tie.
+            // Tuple compare (not timestamp-only) breaks same-microsecond ties by `full_id`.
             AfterCursor::Id {
                 created_at,
                 full_id,
@@ -727,8 +626,7 @@ pub(crate) async fn handle_thread(
                 let row_key = (r.created_at, r.full_id);
                 let cursor_key = (*created_at, *full_id);
                 match order {
-                    // "after" in desc order means further along the desc sequence,
-                    // i.e. strictly older (smaller key) than the cursor.
+                    // desc "after" means further along the desc sequence (strictly older).
                     "desc" => row_key < cursor_key,
                     _ => row_key > cursor_key,
                 }
@@ -740,11 +638,8 @@ pub(crate) async fn handle_thread(
         });
     }
 
-    // Total order: sort by `(created_at, full_id)` — the same tuple the cursor
-    // filter above compares against — ascending for order="asc", reversed for
-    // "desc". Sorting on timestamp alone (prior behavior) left ties among
-    // same-microsecond rows in query-return order, which is not stable across
-    // pages/backends.
+    // Total order: sort by `(created_at, full_id)`, not timestamp alone, so ties
+    // are stable across pages/backends (matches the cursor filter's key above).
     rows.sort_by(|a, b| {
         let a_key = (a.created_at, a.full_id);
         let b_key = (b.created_at, b.full_id);
@@ -764,41 +659,26 @@ pub(crate) async fn handle_thread(
     }))
 }
 
-/// A thread row carries the sort/cursor key (`created_at`, `full_id`) alongside
-/// the already-rendered message JSON, so the total-order sort and cursor filter
-/// in `handle_thread` compare exact `(i64, Uuid)` tuples instead of re-parsing
-/// the ISO string embedded in the JSON.
+/// Sort/cursor key (`created_at`, `full_id`) plus rendered message JSON, so
+/// `handle_thread` compares exact tuples instead of re-parsing the ISO string.
 struct ThreadRow {
     created_at: i64,
     full_id: Uuid,
     json: Value,
 }
 
-/// `after` cursor resolved to a comparable key. An id cursor carries the full
-/// `(created_at, full_id)` tuple of the referenced message for tie-breaking; a
-/// timestamp cursor carries only the parsed microsecond value (there is no
-/// specific row to break ties against).
+/// `after` cursor resolved to a comparable key (id cursor: full tie-break tuple;
+/// timestamp cursor: parsed microseconds only).
 enum AfterCursor {
     Id { created_at: i64, full_id: Uuid },
     Timestamp { micros: i64 },
 }
 
 /// `ingest` — write a single inbound message note from a channel adapter.
-///
-/// This is a `Visibility::Subhandler` verb: it is not accessible via the MCP
-/// wire and is only callable from within the process (e.g. the polling loop in
-/// `khive-mcp`). It is the authoritative write path for all channel-delivered
-/// messages; the polling loop must not bypass it.
-///
-/// Thread resolution: when `correlation_external_id` is supplied, the handler
-/// queries for an existing message note whose `external_id` matches that value,
-/// reads its `thread_id`, and attaches the new note to the same thread.
-///
-/// Deduplication: when `external_id` is supplied, `try_create_note` uses
-/// a verify-after-insert check on the durable unique index on `external_id`.
-/// A confirmed duplicate returns `Ok(None)` without error; only an
-/// external_id collision is treated as dedup; other constraint violations
-/// surface as errors.
+/// `Visibility::Subhandler`: not accessible via the MCP wire, only callable
+/// in-process (e.g. the polling loop in `khive-mcp`); the authoritative write
+/// path for all channel-delivered messages. See
+/// crates/khive-pack-comm/docs/handlers.md#handlersrshandle_ingest
 pub(crate) async fn handle_ingest(
     runtime: &KhiveRuntime,
     token: &NamespaceToken,
@@ -823,11 +703,8 @@ pub(crate) async fn handle_ingest(
             "ingest: `content` must not be empty".into(),
         ));
     }
-    // Reject a malformed caller-supplied thread_id at the boundary (issue #479a):
-    // a present, non-empty `thread_id` that is not a valid UUID must fail closed
-    // rather than being silently dropped and replaced with a fresh UUID, which
-    // would split the message into the wrong conversation. A blank/absent value
-    // is not an error -- it just means "no caller-supplied thread_id".
+    // #479a: a non-empty malformed thread_id must fail closed, not silently get a
+    // fresh UUID (which would split the message into the wrong conversation).
     if let Some(tid) = p
         .thread_id
         .as_deref()
@@ -844,24 +721,12 @@ pub(crate) async fn handle_ingest(
     let ns = token.namespace().as_str();
     let store = runtime.notes(token)?;
 
-    // Thread resolution: if correlation_external_id is present, find the message it refers to
-    // and extract both its internal thread_id and the from_actor of the original sender so that
-    // replies route back to the actor who sent the original, not to the raw email address.
-    //
-    // Two-query fallback: `corr` may be either a Message-ID (matched via $.external_id) from
-    // a human webmail In-Reply-To header, OR a thread UUID (matched via $.thread_id) from
-    // a preserved X-Khive-Thread-ID header on our own outbound emails.  We try external_id
-    // first (preserves the In-Reply-To path); if that misses we fall back to thread_id.
+    // Thread resolution: resolve correlation_external_id to the original message's
+    // thread_id + from_actor. Two-query fallback (Message-ID pass, then thread-UUID
+    // pass) — see crates/khive-pack-comm/docs/handlers.md#handlersrshandle_ingest
     let resolved: Option<(String, String)> = if let Some(ref corr) = p.correlation_external_id {
         if !corr.is_empty() {
             // Pass 1: match by $.external_id (RFC 822 Message-ID, standard In-Reply-To path).
-            // Our own outbound mail stores its Message-ID in wire form `<id@domain>`
-            // (angle brackets included), while `mail_parser` strips the brackets from an
-            // inbound `In-Reply-To`, yielding `id@domain`. Match the correlation key as
-            // received and in its bracket-toggled form so `<id>` and `id` correlate either
-            // way; the exact form is tried first. Restricted to outbound notes (mirrors
-            // Pass 2) so an inbound note's own external_id can never be matched as a
-            // threading parent.
             let mut pass1 = None;
             for candidate in message_id_match_candidates(corr) {
                 let corr_filter = NoteFilter {
@@ -891,14 +756,8 @@ pub(crate) async fn handle_ingest(
                     )
                     .await?;
                 pass1 = corr_page.items.first().map(|n| {
-                    // Fall back to the matched note's own UUID as the canonical
-                    // root (issue #479b) when it carries no valid `thread_id` --
-                    // e.g. a legacy/imported outbound row written before the
-                    // canonical `thread_id` field existed. Per ADR-040, a
-                    // target message with no `thread_id` becomes the root for
-                    // the new chain, so replies stay attached to the right
-                    // conversation/actor instead of splitting into a fresh
-                    // thread routed to the default inbound actor.
+                    // Falls back to the matched note's own UUID as root (#479b, ADR-040)
+                    // when it carries no valid thread_id (e.g. legacy/imported row).
                     let thread_id = n
                         .properties
                         .as_ref()
@@ -1035,12 +894,8 @@ pub(crate) async fn handle_ingest(
     if let Some(ref kind) = p.channel_kind {
         props["channel_kind"] = json!(kind);
     }
-    // Generic transport-layer metadata passthrough (issue #448): merged
-    // additively so it can never clobber the identity/routing fields set above --
-    // a key already present (from, to, from_actor, to_actor, direction, read,
-    // thread_id, sent_at, subject, external_id, wire_message_id, wire_references,
-    // channel_kind) always wins. The comm pack does not interpret any metadata
-    // key; the email channel happens to use it for quarantine markers.
+    // Metadata passthrough (#448): merged additively so it never clobbers the
+    // identity/routing fields set above — a key already present always wins.
     if let Some(metadata) = p.metadata {
         if let Some(obj) = props.as_object_mut() {
             for (k, v) in metadata {
@@ -1083,25 +938,10 @@ pub(crate) async fn handle_ingest(
 }
 
 /// Deterministic UUID identifying the `channel_health` row for one
-/// `(namespace, channel_kind, channel_slug)` triple (khive #606).
-///
-/// Deterministic (not `Uuid::new_v4`) so `handle_heartbeat` can compute the
-/// same id on every poll tick and `upsert_note`'s `INSERT OR REPLACE` updates
-/// the same row instead of accumulating a new one per tick. Keying by slug in
-/// addition to kind is the point of #606's amendment 2: two accounts of the
-/// same kind (e.g. two mailboxes, both `kind() == "email"`) must not collapse
-/// into a single row.
-///
-/// The three components are hashed as a JSON array of strings, NOT joined
-/// with a `:` delimiter. Namespaces
-/// may themselves contain `:` (hierarchical namespace strings are explicitly
-/// allowed), so a delimiter-joined `format!("...:{a}:{b}:{c}")` is not an
-/// injective encoding: `(namespace="a:b", channel_kind="c", channel_slug="d")`
-/// and `(namespace="a", channel_kind="b:c", channel_slug="d")` both produced
-/// the identical string `"khive:channel_health:a:b:c:d"` under the old
-/// scheme. `serde_json::to_vec` of an array of strings is unambiguous —
-/// each element is quoted and internal quotes/backslashes are escaped — so
-/// distinct triples always serialize to distinct byte sequences.
+/// `(namespace, channel_kind, channel_slug)` triple (khive #606). Hashes the
+/// triple as a JSON array (not a `:`-joined string, which is not injective
+/// when a component itself contains `:`). See
+/// crates/khive-pack-comm/docs/handlers.md#handlersrsheartbeat_note_id
 fn heartbeat_note_id(namespace: &str, channel_kind: &str, channel_slug: &str) -> Uuid {
     let key = serde_json::to_vec(&(
         "khive:channel_health",
@@ -1115,26 +955,17 @@ fn heartbeat_note_id(namespace: &str, channel_kind: &str, channel_slug: &str) ->
 
 /// `heartbeat` — persist one poll attempt's outcome into the channel's
 /// heartbeat row (khive #606). Subhandler — only the daemon's channel poll
-/// loop (`crates/khive-mcp/src/serve.rs::channel_poll_loop`) calls this.
-///
-/// Read-modify-write against the existing row (if any) so that:
-/// - `created_at` is preserved across updates (first-seen time), not reset
-///   every tick.
-/// - `last_error` is RETAINED across a subsequent success (design review
-///   amendment 3): callers compare `last_error.at` against
-///   `last_success_at`/`last_failure_at` to tell a resolved issue from a live
-///   one, so a success must never clear it.
-/// - `consecutive_failures` resets to 0 on success and increments on failure,
-///   read from the prior row rather than any in-process counter, so it is
-///   correct even across a daemon restart.
+/// loop calls this. Read-modify-write: `created_at` is preserved across
+/// updates, `last_error` is RETAINED across a subsequent success (design
+/// review amendment 3), and `consecutive_failures` resets on success /
+/// increments on failure, read from the prior row (correct across restarts).
 pub(crate) async fn handle_heartbeat(
     runtime: &KhiveRuntime,
     token: &NamespaceToken,
     params: Value,
 ) -> Result<Value, RuntimeError> {
-    // Note: HeartbeatParams does not use deny_unknown_fields — mirrors
-    // IngestParams, since the poll loop passes `namespace` alongside these
-    // fields for VerbRegistry::dispatch to consume before the handler runs.
+    // HeartbeatParams omits deny_unknown_fields — mirrors IngestParams (dispatch
+    // consumes `namespace` before the handler runs).
     let p: HeartbeatParams = serde_json::from_value(params)
         .map_err(|e| RuntimeError::InvalidInput(format!("heartbeat: bad params: {e}")))?;
 
@@ -1168,21 +999,9 @@ pub(crate) async fn handle_heartbeat(
         ));
     }
 
-    // Issue #606: heartbeat rows are an
-    // OPERATIONAL surface, not message data. Persist to
-    // `crate::CHANNEL_HEALTH_NAMESPACE` ALWAYS — never `token.namespace()` —
-    // so a poll loop configured with a non-local `KHIVE_EMAIL_INGEST_NAMESPACE`
-    // cannot cause heartbeat rows to land anywhere but this one fixed
-    // namespace. This is enforced here (not just at the serve.rs call site)
-    // so the guarantee holds even if a future caller passes a different
-    // `namespace` dispatch param.
-    //
-    // `handle_health` (khive #877) no longer mirrors this fixed pin: it reads
-    // from `token.namespace()`, which only resolves to this same constant
-    // for an unscoped (default-namespace) caller. An explicitly-scoped
-    // `comm.health` caller reads its own namespace, not wherever this
-    // handler wrote — do not reintroduce a `handle_health` read of this
-    // constant to "fix" that; it is the cross-namespace leak #877 closed.
+    // #606: heartbeat rows are OPERATIONAL, not message data — always persist to
+    // `CHANNEL_HEALTH_NAMESPACE`, never `token.namespace()` (never read back by
+    // `handle_health`'s #877 namespace-scoped read either; see docs/handlers.md).
     let ns = crate::CHANNEL_HEALTH_NAMESPACE;
     let store = runtime.notes(token)?;
     let id = heartbeat_note_id(ns, &p.channel_kind, &p.channel_slug);
@@ -1282,61 +1101,17 @@ fn channel_health_to_json(note: &Note) -> Value {
     })
 }
 
-/// `health` — read-only per-channel health snapshot (khive #606).
+/// `health` — read-only per-channel health snapshot (khive #606). Reads
+/// `channel_health` rows from `token.namespace()` (khive #877 namespace
+/// scoping); never returns a computed `healthy: bool` — that judgment belongs
+/// to the caller. See crates/khive-pack-comm/docs/handlers.md#handlersrshandle_health
+/// for the `role`/`namespace`/`resource` field semantics (ADR-103 Stage 1).
 ///
-/// Reads the daemon-persisted `channel_health` rows from `token.namespace()`
-/// (khive #877) — the same injected-namespace resolution every other comm
-/// verb uses (ADR-007 Rev 6 Rule 3: `namespace=` is the caller's explicit
-/// escape; absent that, the token pins to `"local"`). Unscoped callers
-/// (single-tenant local daemon, the common case) see exactly what they saw
-/// before this fix, since heartbeat rows still land under
-/// `crate::CHANNEL_HEALTH_NAMESPACE` (`"local"`) and an unscoped token also
-/// resolves to `"local"`. A caller that passes an explicit non-local
-/// `namespace=` now reads that namespace's rows only — never `"local"`'s —
-/// closing the cross-namespace operational-surface leak that held this verb
-/// off the cloud data plane (#877). `role` answers "who owns the loops", not
-/// "whose memory answered": any persisted row means some daemon owns the
-/// channel loops, so `role` is reported as `"daemon"` with
-/// `source: "daemon-heartbeat"` regardless of whether THIS process is that
-/// daemon. `role: "client"` with an empty `channels` array is correct both
-/// when no daemon heartbeat state exists at all (fresh install, or a daemon
-/// that has never completed a poll tick) and when the caller's injected
-/// namespace has no heartbeat rows of its own — the comm pack has no
-/// visibility into which channels are configured (that lives in
-/// `khive-mcp`/`khive-channel-email`), so an empty result is the only
-/// fact-based response available at this layer.
-///
-/// `namespace` in the response (khive #877) is the namespace actually read —
-/// `token.namespace().as_str()`, echoed back so the shape is self-describing
-/// for both the unscoped and the explicitly-scoped case. This exists because
-/// `role: "client"` / empty `channels` is now ambiguous on its own: it is the
-/// correct, expected shape for a `namespace=`-scoped call in the shipped OSS
-/// build, since `comm.heartbeat` only ever persists under
-/// `crate::CHANNEL_HEALTH_NAMESPACE` (`"local"`) — there is no OSS producer
-/// for tenant-scoped heartbeat rows yet (that is cloud-side follow-up, not
-/// this handler's job). A caller reading `namespace: "tenant-a"` alongside
-/// `role: "client"` can tell "no daemon anywhere" (unscoped call, `namespace:
-/// "local"`) apart from "no rows written under my scope yet" (scoped call,
-/// `namespace: "tenant-a"`) without khive silently falling back to `"local"`
-/// to paper over the difference.
-///
-/// Never returns a computed `healthy: bool` (design review amendment: "report
-/// timestamps only") — staleness/alerting judgment belongs to the caller.
-///
-/// `resource` (ADR-103 Stage 1, issue #723 ask 2): a process-level self-report
-/// of this process's own cumulative CPU time and RSS (via `getrusage`,
-/// `khive_runtime::process_resource_usage`) plus the names of any background
-/// phases (e.g. `ann_warm`) currently in flight in this process
-/// (`khive_runtime::active_phase_names`). "This process" is, in the common
-/// case, the daemon itself: a client-role stdio session without an in-memory
-/// poll loop of its own still forwards `dispatch` calls to the daemon over
-/// its socket, so this handler body executes inside the daemon process, not
-/// the thin client. `cpu_us`/`rss_bytes` are `null` only if the underlying
-/// `getrusage` read is unavailable on this platform; `active_phases` is
-/// always present and empty when nothing is in flight. Raw observations
-/// only, per the same "no computed healthy bool" rule as the rest of this
-/// verb — attributing severity to a given CPU/RSS number is the caller's
-/// judgment, not this verb's.
+/// `resource` is a process-level self-report of this process's own CPU/RSS
+/// (via `getrusage`) plus in-flight background phase names. `cpu_us`/
+/// `rss_bytes` are `null` only if `getrusage` is unavailable; `active_phases`
+/// is always present and empty when nothing is in flight — raw observations
+/// only, same "no computed healthy bool" rule as the rest of this verb.
 pub(crate) async fn handle_health(
     runtime: &KhiveRuntime,
     token: &NamespaceToken,
@@ -1424,34 +1199,12 @@ pub(crate) struct ProbeMessage {
 }
 
 /// The single indexed read powering `comm.probe` (ADR-D5). `INDEXED BY
-/// idx_comm_message_to_actor` is a regression fence: if a custom bootstrap
-/// skips comm schema-plan application, this query fails loudly instead of
-/// silently degrading to a table scan.
-///
-/// `cursor_us`/`since_us` are keyed on `notes_seq.seq`, not SQLite `rowid`
-/// and not `created_at` (#780, #827):
-///
-/// - `created_at` is an application-clock read taken before a note's write
-///   acquires the writer critical section, so two concurrent writers can
-///   commit out of stamp order; a `created_at`-keyed cursor can then advance
-///   past a row that committed *after* it, permanently hiding that row from
-///   every later probe.
-/// - `notes.rowid` looked monotonic with commit order, but `notes` has a
-///   TEXT PRIMARY KEY, so that rowid is *implicit*: SQLite may renumber it
-///   on `VACUUM` (khive exposes `memory.vacuum`), and reuses the highest
-///   rowid once that row is hard-deleted (khive exposes a public hard
-///   delete), either of which can permanently exclude a later message whose
-///   rowid lands at or below an already-issued cursor.
-///
-/// `notes_seq.seq` fixes both: it is assigned once, inside the same writer
-/// transaction as the note's insert, from a dedicated `INTEGER PRIMARY KEY
-/// AUTOINCREMENT` sequence that VACUUM never renumbers and SQLite never
-/// reuses (see `sql/007-notes-seq.sql`). The wire field names keep the `_us`
-/// suffix (frozen contract, ADR-D5) but the value is an opaque monotonic
-/// token, not a microsecond timestamp; do not revert this to `created_at` or
-/// `rowid`. `created_at_us` on each `new_messages` entry is unaffected: it
-/// stays a real display timestamp, still ordered ascending by `created_at`
-/// for readability, and carries no cursor guarantee of its own.
+/// idx_comm_message_to_actor` is a regression fence against silent table scans.
+/// `cursor_us`/`since_us` are keyed on `notes_seq.seq`, NOT `created_at` or
+/// SQLite `rowid` — both can regress/collide across concurrent writers, VACUUM,
+/// or hard-delete. Do not revert to either. See
+/// crates/khive-pack-comm/docs/handlers.md#handlersrsprobe_sql for the full
+/// #780/#827 incident history.
 const PROBE_SQL: &str = "WITH \
 stats AS ( \
     SELECT \
@@ -1537,17 +1290,8 @@ pub(crate) async fn handle_probe(
 }
 
 /// A caller-supplied `since_us` above `notes_seq`'s durable high-water mark
-/// (`sqlite_sequence.seq` for the `notes_seq` table) cannot be a genuine
-/// cursor -- `notes_seq` starts at 1 and grows by exactly one per note ever
-/// inserted, so no value this store ever handed out can exceed the highest
-/// value it has ever assigned. Such a `since_us` is a pre-upgrade
-/// persisted-timestamp cursor (#827): a real Unix-microsecond timestamp from
-/// after 1970-01-12 already exceeds any realistic note count by orders of
-/// magnitude. Comparing against the actual high-water mark, instead of a
-/// fixed ceiling, keeps this correct forever as `notes_seq` grows -- a fixed
-/// ceiling would eventually reset a legitimate high sequence value to
-/// baseline, contradicting `comm.probe`'s opaque round-trip contract
-/// (`vocab.rs`).
+/// cannot be a genuine cursor — it must be a pre-upgrade persisted-timestamp
+/// cursor (#827). See crates/khive-pack-comm/docs/handlers.md#handlersrsnotes_seq_high_water_mark
 async fn notes_seq_high_water_mark(
     reader: &mut Box<dyn khive_storage::sql::SqlReader>,
 ) -> Result<i64, RuntimeError> {
@@ -1650,12 +1394,8 @@ async fn query_probe(
         });
     }
 
-    // Never let the returned cursor regress below what the caller already
-    // holds (#827): if the message that previously held the highest
-    // `notes_seq.seq` was hard-deleted since the last probe, `MAX(seq)` over
-    // the remaining rows can be smaller than a cursor already handed out.
-    // Clamping here, rather than in SQL, keeps the single indexed query a
-    // pure aggregate with no extra branch.
+    // #827: never let the returned cursor regress below what the caller already
+    // holds (a hard-deleted high-seq row can lower MAX(seq) below a prior cursor).
     if let Some(floor) = effective_since {
         if cursor_us < floor {
             cursor_us = floor;
@@ -1670,14 +1410,9 @@ async fn query_probe(
 }
 
 /// `cursor_get` — read the persisted channel poll checkpoint for
-/// `(channel_kind, channel_slug)` (issue #449). Subhandler — only the
-/// daemon's channel poll loop calls this. Returns JSON `null` when no row
-/// exists yet (first-run compatibility mode).
-///
-/// Runs the pack-owned `comm_channel_cursor` schema statement before the
-/// query so an in-memory/test runtime that never applied the boot-time
-/// schema plan still works (matches the repository's lazy pack-schema
-/// bootstrap convention).
+/// `(channel_kind, channel_slug)` (issue #449). Subhandler. Returns JSON
+/// `null` when no row exists yet. Runs the pack-owned schema statement first
+/// (lazy pack-schema bootstrap for in-memory/test runtimes).
 pub(crate) async fn handle_cursor_get(
     runtime: &KhiveRuntime,
     params: Value,
@@ -1844,13 +1579,9 @@ pub(crate) async fn handle_cursor_commit(
     }))
 }
 
-/// Candidate `$.external_id` values to match an inbound correlation key against.
-///
-/// Outbound mail stores its Message-ID in wire form `<id@domain>` (angle brackets
-/// included); `mail_parser` strips those brackets from an inbound `In-Reply-To`,
-/// yielding `id@domain`. To correlate a reply back to the sending actor we must
-/// match either representation, so this returns the key as received plus its
-/// bracket-toggled variant, exact form first.
+/// Candidate `$.external_id` values (as received, plus bracket-toggled) to
+/// match an inbound correlation key against. See
+/// crates/khive-pack-comm/docs/handlers.md#message-id--references-header-helpers-403
 fn message_id_match_candidates(corr: &str) -> Vec<String> {
     let bare = corr
         .strip_prefix('<')
@@ -1863,13 +1594,8 @@ fn message_id_match_candidates(corr: &str) -> Vec<String> {
     }
 }
 
-/// Normalize a stored Message-ID into RFC 5322 wire form (angle-bracketed).
-///
-/// Stored values may already be bracketed (an outbound note's self-minted
-/// `external_id`, e.g. `<uuid@domain>`) or bracket-free (an inbound note's
-/// `wire_message_id`, since `mail_parser` strips brackets when parsing). This is
-/// the single place that normalizes to the wire form the `In-Reply-To` /
-/// `References` headers require.
+/// Normalize a stored Message-ID into RFC 5322 wire form (angle-bracketed);
+/// the single place that does so for `In-Reply-To`/`References` headers.
 fn wrap_message_id(raw: &str) -> String {
     let trimmed = raw.trim();
     if trimmed.starts_with('<') && trimmed.ends_with('>') {
@@ -1879,16 +1605,10 @@ fn wrap_message_id(raw: &str) -> String {
     }
 }
 
-/// Resolve the parent message's wire Message-ID for an outbound reply's
-/// `In-Reply-To`/`References` headers (issue #403).
-///
-/// Direction-aware: an outbound parent's own Message-ID is self-minted into
-/// `external_id` at send time (e.g. `<uuid@domain>`). An inbound parent's
-/// Message-ID lives in `wire_message_id` instead -- an inbound note's
-/// `external_id` is the IMAP UIDVALIDITY/UID dedup key, never a Message-ID, and
-/// must not be read here. Returns `None` when the parent carries no wire
-/// Message-ID at all (e.g. a khive-internal parent, or an email parent the
-/// channel never captured one for).
+/// Resolve the parent message's wire Message-ID (issue #403), direction-aware:
+/// outbound parents read `external_id`, inbound parents read `wire_message_id`
+/// (never the reverse — `external_id` on an inbound note is the IMAP dedup
+/// key, not a Message-ID). `None` when the parent has no wire Message-ID.
 fn parent_wire_message_id(orig_props: &Value) -> Option<String> {
     let direction = orig_props.get("direction").and_then(Value::as_str);
     let raw = if direction == Some("outbound") {
@@ -1905,16 +1625,10 @@ fn parent_wire_message_id(orig_props: &Value) -> Option<String> {
 }
 
 /// Resolve the parent message's own `References` chain, direction-aware
-/// (issue #403 finding: References must carry the full ancestor chain, not
-/// just the immediate parent).
-///
-/// An inbound parent's chain (as received over the wire) lives in
-/// `wire_references`. An outbound parent's chain is whatever we persisted on
-/// it as `references_chain` when *it* was sent (i.e. the chain that reply
-/// itself extended) -- an outbound note that was a fresh send, not a reply,
-/// carries no `references_chain`. Returns `None` when the parent has no chain
-/// to extend; the caller then falls back to the parent's Message-ID alone,
-/// matching RFC 5322 (References = prior chain, if any, + parent Message-ID).
+/// (inbound: `wire_references`; outbound: `references_chain`). `None` when
+/// the parent has no chain to extend (RFC 5322: caller then falls back to the
+/// parent's Message-ID alone). See
+/// crates/khive-pack-comm/docs/handlers.md#message-id--references-header-helpers-403
 fn parent_references_chain(orig_props: &Value) -> Option<&str> {
     let direction = orig_props.get("direction").and_then(Value::as_str);
     let raw = if direction == Some("outbound") {
@@ -1963,16 +1677,10 @@ fn bare_reference_id(token: &str) -> String {
         .to_string()
 }
 
-/// Build the full `References` header value for a reply: the parent's existing
-/// chain (each token individually sanitized; malformed tokens skipped per
-/// issue #403 finding), followed by the parent's own Message-ID.
-///
-/// `parent_chain` tokens are whitespace-separated per RFC 5322. `parent_message_id`
-/// is expected already wire-wrapped (as returned by [`parent_wire_message_id`]).
-/// A stored chain can already contain an equivalent of the parent's own id (e.g.
-/// tainted or legacy data); tokens are de-duplicated by their bracket-stripped
-/// form, keeping first-seen order, so the parent id is skipped rather than
-/// appended a second time when an equivalent token is already present.
+/// Build the full `References` header value for a reply: the parent's
+/// existing chain (sanitized, malformed tokens skipped) followed by the
+/// parent's own Message-ID, de-duplicated by bracket-stripped form
+/// (first-seen order). `parent_message_id` is expected already wire-wrapped.
 fn build_references_header(parent_chain: Option<&str>, parent_message_id: &str) -> String {
     let chain_tokens = parent_chain
         .map(|chain| {

--- a/crates/khive-pack-comm/src/lib.rs
+++ b/crates/khive-pack-comm/src/lib.rs
@@ -8,20 +8,10 @@ pub(crate) mod vocab;
 
 pub use pack::CommPack;
 
-/// The namespace `comm.heartbeat` always writes to (khive #606 design review
-/// Blocker fix, example actor 2026-07-04).
-///
-/// Channel heartbeat rows are an OPERATIONAL surface, not message data: the
-/// write must not follow `KHIVE_EMAIL_INGEST_NAMESPACE` (or any other
-/// caller-chosen namespace) — `handle_heartbeat` is the ONLY comm handler
-/// pinned to this constant.
-///
-/// `comm.health` no longer reads this constant unconditionally (khive #877):
-/// it resolves its read namespace from the dispatch token
-/// (`token.namespace()`), the same explicit `namespace=` escape / `"local"`
-/// default every other comm verb uses. An unscoped `comm.health()` call
-/// still defaults to `"local"` and so still observes rows this constant
-/// wrote — but a call with an explicit non-local `namespace=` reads that
-/// namespace instead, and must not fall back to this constant to find
-/// heartbeat state a single-namespace daemon wrote elsewhere.
+/// The namespace `comm.heartbeat` always writes to, regardless of caller
+/// namespace — the only comm handler pinned to this constant. `comm.health`
+/// reads it only as the default when the caller passes no explicit
+/// `namespace=`; an explicitly-scoped call reads its own namespace instead.
+/// See crates/khive-pack-comm/docs/handlers.md#librschannel_health_namespace--rationale
+/// for the incident history (khive #606, #877).
 pub const CHANNEL_HEALTH_NAMESPACE: &str = "local";

--- a/crates/khive-pack-comm/src/message.rs
+++ b/crates/khive-pack-comm/src/message.rs
@@ -10,10 +10,7 @@ pub(crate) fn short_id(uuid: Uuid) -> String {
     uuid.as_hyphenated().to_string().chars().take(8).collect()
 }
 
-/// Resolve a raw id string to a full UUID.
-///
-/// Accepts a 36-char hyphenated UUID or an 8+ hex-char short prefix.
-/// The prefix is resolved via `runtime.resolve_prefix` (namespace-scoped).
+/// Resolve a raw id string (full UUID or 8+ hex-char short prefix) to a UUID.
 pub(crate) async fn resolve_id(
     runtime: &KhiveRuntime,
     token: &NamespaceToken,
@@ -36,13 +33,8 @@ pub(crate) async fn resolve_id(
     )))
 }
 
-/// Roll back a partially-written outbound note after a later `dual_write_message`
-/// step fails (issue #460). Uses a row-first compensating delete so that a
-/// cleanup failure cannot leave the outbound row (and thus the failed send's
-/// live message) behind. Returns `original` unchanged when rollback fully
-/// succeeds; returns a composite `RuntimeError::Internal` naming both the
-/// original failure and the rollback cleanup failure when the row was removed
-/// but cleanup did not complete.
+/// Rolls back a partially-written outbound note after a dual-write failure.
+/// See crates/khive-pack-comm/docs/handlers.md#messagersrollback_outbound
 async fn rollback_outbound(
     runtime: &KhiveRuntime,
     token: &NamespaceToken,
@@ -121,38 +113,17 @@ fn build_preview(content: &str) -> String {
     }
 }
 
-/// Write an outbound copy (caller namespace) and an inbound copy (recipient namespace),
-/// rolling back the outbound note if the inbound write fails (atomicity guarantee).
+/// Writes an outbound copy (caller namespace) and an inbound copy (recipient
+/// namespace), rolling back the outbound note if the inbound write fails
+/// (atomicity guarantee). Returns the outbound `Note` on success.
 ///
-/// `subject`, `thread_id` are optional. `sent_at` is the RFC3339 timestamp for both copies.
-/// `from_actor` and `to_actor` are optional actor labels (ADR-057) stored in properties.
+/// Invariant: when `thread_id` is `None` (root send), both copies are patched
+/// to share the sender's outbound UUID as their canonical `thread_id`, so
+/// `comm.thread` finds replies regardless of which copy they replied to. When
+/// `thread_id` is already supplied (reply path), it is forwarded unchanged.
 ///
-/// Cross-namespace thread root invariant: when a root message is sent (i.e., `thread_id`
-/// is `None`), both the outbound and inbound copies must share the same canonical
-/// `thread_id` — the sender's outbound UUID.  This ensures that
-/// `comm.thread(id=outbound_id)` can find replies written in any namespace, because all
-/// replies carry the same canonical thread_id regardless of which copy they were replying to.
-///
-/// When `thread_id` is already supplied (reply path), it is forwarded unchanged to both copies.
-///
-/// Returns the outbound `Note` on success.
-///
-/// `in_reply_to_message_id` is the parent's wire Message-ID (angle-bracketed),
-/// when this write is a reply to a message with a known one (issue #403). It is
-/// stored verbatim on both copies as `in_reply_to_message_id`; the outbox
-/// delivery loop reads it back to set the RFC 822 `In-Reply-To` header for
-/// native MUA conversation grouping. `None` when there is no known parent
-/// Message-ID (a plain send, or a reply whose parent has none).
-///
-/// `references_chain` is the full RFC 5322 `References` value for this reply:
-/// the parent's existing chain (if any) followed by the parent's Message-ID,
-/// space-separated angle-bracketed ids (issue #403 finding: References must
-/// preserve ancestry, not truncate to the immediate parent). Stored verbatim
-/// on both copies as `references_chain`; the outbox delivery loop reads it
-/// back to set the `References` header, and a further reply reads it back
-/// (direction-aware, via `parent_references_chain`) to extend the chain again.
-/// `None` when there is no known parent Message-ID (mirrors
-/// `in_reply_to_message_id`).
+/// See crates/khive-pack-comm/docs/handlers.md#messagersdual_write_message for
+/// the `in_reply_to_message_id`/`references_chain` header-threading contract.
 // REASON: dual_write_message mirrors the send wire shape exactly (from, to, subject,
 // content, thread_id, sent_at) plus the two context args (runtime, token). Grouping them into
 // a struct would not reduce overall complexity and would require an extra allocation on the

--- a/crates/khive-pack-comm/src/params.rs
+++ b/crates/khive-pack-comm/src/params.rs
@@ -15,18 +15,11 @@ pub(crate) struct SendParams {
     pub subject: Option<String>,
     #[serde(default)]
     pub thread_id: Option<String>,
-    /// Structured provenance tags (e.g. run id, job id, traffic class), persisted
-    /// verbatim to `properties["tags"]` on both the outbound and inbound copies.
-    /// Mirrors the shipped `memory.remember` `tags` precedent (issue #495).
+    /// Structured provenance tags, persisted verbatim on both copies (issue #495).
     #[serde(default)]
     pub tags: Option<Vec<String>>,
-    /// Explicit acknowledgment that `to` intentionally names the sender's own
-    /// resolved actor identity (khive #820). Required whenever the resolved
-    /// `to_actor` equals `from_actor`; without it such a send is rejected rather
-    /// than silently delivered, since a sub-agent session addressing a distinct
-    /// parent/orchestrator actor that happens to collapse onto its own identity
-    /// (both resolve `[actor] id` from the same project-scoped
-    /// `.khive/config.toml`, ADR-096 Fork 2) is a mis-resolution, not intent.
+    /// Opt-in to send to one's own actor identity (khive #820). See
+    /// crates/khive-pack-comm/docs/handlers.md#paramsrs-field-notes
     #[serde(default)]
     pub self_send: bool,
 }
@@ -73,32 +66,21 @@ pub(crate) struct ThreadParams {
     pub id: String,
     #[serde(default)]
     pub limit: Option<u32>,
-    /// Ordering of the returned messages: `"asc"` (default, chronological) |
-    /// `"desc"` (newest first). Truncation to `limit` applies after ordering,
-    /// so `order="desc"` returns the newest `limit` messages instead of the
-    /// oldest (issue #494 — long threads previously lost the tail).
+    /// `"asc"` (default) | `"desc"`. Truncation to `limit` applies after
+    /// ordering (issue #494 — long threads previously lost the tail).
     #[serde(default)]
     pub order: Option<String>,
-    /// Cursor: a message id (short prefix or full UUID) or an RFC 3339
-    /// timestamp. Id cursors compare on the total order `(created_at,
-    /// full_id)` so equal-timestamp messages are never skipped or duplicated;
-    /// timestamp cursors are parsed (any valid RFC 3339 form) rather than
-    /// string-compared. "After" is relative to the chosen `order` (for
-    /// `desc`, strictly older in the descending sequence). An unparseable or
-    /// unresolvable cursor is an error, never silently ignored.
+    /// Message id or RFC 3339 timestamp cursor. See
+    /// crates/khive-pack-comm/docs/handlers.md#handlersrshandle_thread
     #[serde(default)]
     pub after: Option<String>,
 }
 
-/// Parameters for `comm.ingest` — ingests a single inbound message from a channel adapter.
-///
-/// `deny_unknown_fields` is intentionally absent: the polling loop may pass extra fields
-/// (including the `namespace` routing key consumed by the dispatch layer) that future
-/// handler versions can extend without breaking existing deployments.
-///
-/// The `namespace` key is consumed by `VerbRegistry::dispatch` to mint the `NamespaceToken`
-/// before the handler is called; the handler uses `token` directly and does not read
-/// `namespace` from this struct.
+/// Parameters for `comm.ingest` — ingests a single inbound message from a
+/// channel adapter. `deny_unknown_fields` is intentionally absent (forward-
+/// compat with future handler fields); `namespace` is consumed by
+/// `VerbRegistry::dispatch`, not read from this struct. See
+/// crates/khive-pack-comm/docs/handlers.md#paramsrs-field-notes
 #[derive(Deserialize)]
 pub(crate) struct IngestParams {
     /// Sender address in `channel-kind:addr` form.
@@ -123,38 +105,27 @@ pub(crate) struct IngestParams {
     /// External correlation key for thread resolution (e.g. X-Khive-Thread-ID or In-Reply-To value).
     #[serde(default)]
     pub correlation_external_id: Option<String>,
-    /// Actor to route to when no correlation resolves a prior sender (e.g. `"lambda:leo"`).
-    /// When absent and no correlation match is found, falls back to `p.to.trim()`.
+    /// Actor to route to when no correlation resolves a prior sender. Falls
+    /// back to `p.to.trim()` when absent and no correlation match is found.
     #[serde(default)]
     pub default_inbound_actor: Option<String>,
-    /// This message's own RFC 822 Message-ID (including angle brackets), when the
-    /// channel adapter captured one. Distinct from `external_id` (the transport
-    /// dedup key). Persisted so a later reply to this note can set In-Reply-To /
-    /// References for native MUA conversation grouping.
+    /// This message's own RFC 822 Message-ID (angle brackets included), distinct
+    /// from `external_id` (the transport dedup key). Persisted for In-Reply-To/
+    /// References on a later reply.
     #[serde(default)]
     pub wire_message_id: Option<String>,
-    /// This message's own RFC 822 References header value, verbatim, when the
-    /// channel adapter captured one. Persisted so a later reply to this note can
-    /// extend the full ancestor chain instead of truncating it to this message's
-    /// own Message-ID (issue #403).
+    /// This message's own RFC 822 References header value, verbatim. Persisted
+    /// so a later reply can extend the full ancestor chain (issue #403).
     #[serde(default)]
     pub wire_references: Option<String>,
-    /// Optional transport-layer metadata passthrough, merged verbatim into the
-    /// stored note's properties alongside the fields above. Generic and
-    /// channel-agnostic: the comm pack does not interpret any key in this map,
-    /// it only persists it. A channel adapter that needs to attach adapter-specific
-    /// markers (e.g. the email channel's quarantine flags, ADR-056 Amendment
-    /// 2026-07-02) sets `ChannelEnvelope.metadata`; the MCP poll loop forwards it
-    /// here unchanged. Absent metadata is today's behavior exactly (issue #448).
+    /// Transport-layer metadata passthrough, merged verbatim into the stored
+    /// note's properties. Generic and channel-agnostic — see docs/handlers.md.
     #[serde(default)]
     pub metadata: Option<serde_json::Map<String, Value>>,
 }
 
 /// Parameters for `comm.heartbeat` — persists a per-channel-credential heartbeat row.
-///
-/// `deny_unknown_fields` is intentionally absent, matching `IngestParams`: the
-/// `namespace` routing key is consumed by `VerbRegistry::dispatch` before the
-/// handler sees `params`, not read from this struct.
+/// `deny_unknown_fields` is intentionally absent, matching `IngestParams`.
 #[derive(Deserialize)]
 pub(crate) struct HeartbeatParams {
     pub channel_kind: String,

--- a/crates/khive-pack-comm/src/vocab.rs
+++ b/crates/khive-pack-comm/src/vocab.rs
@@ -2,21 +2,10 @@
 
 use khive_types::{HandlerDef, ParamDef, Visibility};
 
-/// Pack-auxiliary indexes for comm inbox and thread queries.
-///
-/// Indexes use `WHERE deleted_at IS NULL` (not `WHERE kind = 'message'`) so that
-/// SQLite's index planner can match them when queries contain the parameterized
-/// `kind = ?N` predicate emitted by `build_note_filter_where`.  A literal-value
-/// partial index (`WHERE kind = 'message'`) cannot be used for a parameterized
-/// comparison — the planner sees different predicates and falls back to a table scan.
-/// `deleted_at IS NULL` is always present in filtered queries, so the partial
-/// condition is always satisfied and the index is eligible.
-/// `kind` is included as an indexed column so the `kind = ?N` predicate is covered.
-/// Statements are idempotent (`CREATE INDEX IF NOT EXISTS`).
-///
-/// The `idx_comm_message_external_id` UNIQUE index is NOT listed here; it is
-/// created by the V5 schema migration (`005-unique-comm-external-id.sql`), which
-/// is the sole durable authority for that index.
+/// Pack-auxiliary indexes for comm inbox and thread queries (idempotent). See
+/// crates/khive-pack-comm/docs/handlers.md#vocabrscomm_schema_plan_stmts for
+/// why they filter on `deleted_at IS NULL` rather than a literal `kind` value,
+/// and why `idx_comm_message_external_id` is deliberately absent from this list.
 pub(crate) static COMM_SCHEMA_PLAN_STMTS: [&str; 4] = [
     "CREATE INDEX IF NOT EXISTS idx_comm_message_direction \
         ON notes(namespace, kind, json_extract(properties, '$.direction'), \
@@ -35,18 +24,9 @@ pub(crate) static COMM_SCHEMA_PLAN_STMTS: [&str; 4] = [
     COMM_CHANNEL_CURSOR_SCHEMA_STMT,
 ];
 
-/// Pack-owned auxiliary cursor table for durable channel poll progress
-/// (issue #449): one row per `(channel_kind, channel_slug)`, holding the
-/// transport-neutral checkpoint fields from `khive_channel::ChannelCheckpoint`.
-/// For IMAP, `generation` is `UIDVALIDITY` and `high_water` is the greatest
-/// durably handled UID. `source` detects a host/port/mailbox/folder change
-/// under the same registry identity, so a stale checkpoint is never applied
-/// to a different configuration.
-///
-/// Idempotent (`CREATE TABLE IF NOT EXISTS`), applied at boot via
-/// `schema_plan` and shared verbatim with `handle_cursor_get`/
-/// `handle_cursor_commit`'s lazy bootstrap for in-memory/test runtimes that
-/// never run the boot-time schema plan.
+/// Pack-owned auxiliary cursor table for durable channel poll progress (issue
+/// #449), idempotent (`CREATE TABLE IF NOT EXISTS`). See
+/// crates/khive-pack-comm/docs/handlers.md#vocabrscomm_channel_cursor_schema_stmt
 pub(crate) const COMM_CHANNEL_CURSOR_SCHEMA_STMT: &str =
     "CREATE TABLE IF NOT EXISTS comm_channel_cursor (\
     channel_kind TEXT NOT NULL CHECK (length(trim(channel_kind)) > 0),\

--- a/crates/khive-pack-kg/docs/design.md
+++ b/crates/khive-pack-kg/docs/design.md
@@ -74,3 +74,73 @@ It is the first-party pack shipped with the khive binary.
   relations for the specific entity-kind pair.
 - **Proposal CAS miss**: returns success with `cas_hit: false`; no duplicate
   events are emitted.
+
+## `KG_EDGE_RULES` (pack.rs)
+
+Adds person→org, person→project, and org→org pairs to the base edge-endpoint allowlist.
+The person→project rows mirror person→org (issue #60): a person is a member of a project
+the same way they are a member of an org, so the same member-not-component semantic
+stretch accepted for person→org is extended here.
+
+Test rationale (`pack.rs::tests`):
+
+- `kg_pack_edge_rules_contain_no_duplicate_triples`: a duplicated `(relation, source,
+  target)` triple would be a no-op additive rule (adding the same endpoint pair a second
+  time changes nothing) and is a sign of a copy-paste error. Semantic similarity between
+  relations (e.g. multiple relations accepting `org→org`) is expected and correct; the
+  test checks only for exact-triple duplicates, not for shared per-relation endpoint sets.
+- `kg_pack_edge_rules_cover_expected_relations`: a deliberate-change tripwire over the
+  live `KG_EDGE_RULES`, complementing the ADR-076 §D2 non-redundancy certificate in the
+  certificate test suite. A change to the set of relations that get pack-level endpoint
+  extensions should be a deliberate, reviewed decision — not an accidental side effect.
+
+## `context` verb internals (handlers/context.rs)
+
+`relations_all_symmetric` mirrors `normalize_symmetric_direction` in
+`khive-runtime/src/operations.rs` (private to that crate) — kept in lockstep because
+`neighbors_with_query` forces `Direction::Both` under this exact condition regardless of
+the direction actually requested, and the handler must know that happened to tag
+direction correctly instead of issuing a second, redundant call.
+
+`fetch_directed_neighbors` fetches up to `fanout` neighbors of `node_id`, each tagged with
+its actual direction relative to `node_id` — it can't just trust a `direction` field on a
+plain `NeighborHit` because `neighbors_with_query_directed` only ever tags hits `Out`/`In`
+(`Both` never appears in a `DirectedNeighborHit`).
+
+`assemble_within_budget` is a deterministic-order budget walk: it appends anchor entity
+records and their neighbor records (each already produced in final display order) until
+the next record's compact-JSON Unicode-scalar length would push the running total past
+`budget`. Returns (assembled anchors, truncated, dropped anchors, dropped neighbors). A
+budget exactly equal to the cumulative size does NOT truncate — the stop condition is
+"would push the running total PAST budget", so a record landing exactly on the boundary
+still fits.
+
+### `handle_context` stage notes
+
+- **Directed-neighbor fetch**: a single UNION ALL query for both directions (ADR-089
+  context-verb optimization) instead of two separate direction-scoped calls — halves the
+  storage neighbor SELECT count for this branch. The op already returns hits in global
+  weight-descending, node_id-ascending order truncated to `fanout`, so no local
+  re-sort/truncate is needed.
+- **Stage 1 (anchor resolution)**: `entity_ids` is an explicit entity-anchor contract
+  (ADR-089 §1: "honored in full"). `resolve_uuid_async` accepts any syntactically valid
+  UUID without checking substrate or existence, so a random UUID, a note UUID, or an edge
+  UUID would otherwise resolve here and then silently vanish from the response in Stage
+  4's lenient "missing entity" fallback. The handler fails loudly instead: one batch
+  existence check names every offending id.
+- **Query-anchor overfetch**: fetches a larger candidate window than `limit` so that
+  anchors which collapse into `entity_ids` duplicates don't under-fill the query leg —
+  ADR-089 §1 promises search "fills up to `limit` additional anchors" after explicit ids,
+  which requires looking past the first `limit` hits when some of them overlap explicit
+  anchors. Bounded by a documented cap so a pathological overlap can't turn into an
+  unbounded search.
+- **Stage 2 (expansion), hop-1 stratum**: one stratum across all hop-1 parents under an
+  anchor, sorted by weight desc, then neighbor id, then parent id (the last key only
+  arbitrates true ties — same neighbor, same weight, different parent — so the "first
+  discovering parent" is deterministic).
+- **Stage 4 (assembly)**: explicit `entity_ids` anchors are already verified to exist in
+  Stage 1; the Stage 4 existence check only guards the residual race of an anchor deleted
+  concurrently between resolution and this fetch, or a neighbor entity that vanished the
+  same way. Neighbors get the same lenient "missing node reads as absent" convention
+  `neighbors_with_query` already applies (it returns an empty Vec rather than erroring on
+  a nonexistent `node_id`) — they never enter the budget accounting.

--- a/crates/khive-pack-kg/docs/dispatch-tests.md
+++ b/crates/khive-pack-kg/docs/dispatch-tests.md
@@ -1,0 +1,268 @@
+# dispatch.rs test-module rationale
+
+Source: `crates/khive-pack-kg/src/dispatch.rs`, `mod tests`. These are `#[cfg(test)]`
+regression tests — they never render on docs.rs. This guide preserves the rationale that
+used to live in their doc comments; the source now carries a one-line summary per test.
+
+## Namespace (ADR-007) regression suite
+
+### `kg_create_entity_honors_caller_namespace`
+
+PR-A1 (ADR-007): by-ID `get` returns a record regardless of the caller's namespace.
+Namespace on the returned record must still reflect the creator's namespace. list/search
+still filter by namespace (PR-B scope). Verifies: entity created under `tenant-a` is
+namespaced correctly; by-ID get is namespace-agnostic — tenant-b can fetch tenant-a's
+entity by UUID, and the namespace on the fetched record is still `tenant-a` (never
+rewritten to the caller's namespace).
+
+### `kg_oss_default_namespace_entities_colocate`
+
+Two creates with no explicit namespace land in the same `local` namespace.
+
+### `dispatch_list_honors_configured_visible_namespaces_adr007_rev4`
+
+ADR-007 Rev 4, Rule 3b: default read scope honors configured visible set. The dispatch
+token minted by VerbRegistry on the default (no explicit `namespace=`) path widens the
+read scope to `['local'] ∪ visible_namespaces`. Both the 'local' entity AND the entity
+written to a configured extra namespace must appear in a registry-dispatched list without
+any explicit `namespace=` parameter. This test verifies:
+
+1. Records written to "local" are visible in the list — the shared-brain property.
+2. A record written to a configured visible namespace (via a directly-minted token) ALSO
+   appears in the registry-dispatched list — the Rev 4 read-scope widening.
+
+### `dispatch_list_empty_visible_namespaces_scopes_to_local_only_adr007_rev4`
+
+ADR-007 Rev 4: backward-compat — with visible_namespaces UNSET, default read scope =
+['local'] only. A registry with no `visible_namespaces` configured has the same behavior
+as Rev 3: list returns only records in 'local'. A record written to a different namespace
+via a directly-minted token does NOT appear in the registry list.
+
+### `dispatch_list_local_always_included_when_visible_ns_set_adr007_rev4`
+
+ADR-007 Rev 4: 'local' is always included in the default read scope, even when
+visible_namespaces does not explicitly list it. Configuring visible_namespaces =
+["other-ns"] (without "local") must still return records from BOTH 'local' and
+'other-ns' in the registry list.
+
+### `dispatch_explicit_namespace_param_is_precise_not_widened_adr007_rev4`
+
+ADR-007 Rev 4: explicit namespace= param is a precise single-namespace escape, NOT
+widened. With visible_namespaces=["other-ns"] configured, a list(namespace="other-ns")
+call scopes to EXACTLY ["other-ns"] and does NOT include 'local' or the union set. This
+preserves the ability to read a single named set precisely.
+
+### `non_local_actor_config_does_not_route_storage_adr007_rule0`
+
+ADR-007 Rev 4, Rule 0 regression: non-local actor config does NOT route WRITE storage.
+Builds a VerbRegistry whose `default_namespace` is `"lambda:leo"` (simulating `[actor]
+id = "lambda:leo"` or `--actor lambda:leo`). Dispatches `create` and `list` through
+`VerbRegistry::dispatch` (the real MCP path — not `pack.dispatch`). Asserts:
+
+1. The created entity lands in `"local"`, not `"lambda:leo"`.
+2. A subsequent `list` via the registry returns the entity, proving write+read both
+   operate on `"local"` regardless of the non-local actor configuration.
+3. A direct-token `list` scoped to `"lambda:leo"` returns an empty set, proving the
+   storage was never written to the actor namespace.
+
+## Predicate-pushdown scan-cliff regressions (issue #225)
+
+### `handler_search_entity_tag_filter_beyond_scan_cliff`
+
+Handler-level regression for issue #225, entity branch, tag filter. 51 decoys rank above
+the target in FTS but lack the required tag. The target carries the required tag and sits
+at rank 52. With predicate pushdown the handler returns the target despite the cliff.
+
+### `handler_search_entity_props_filter_beyond_scan_cliff`
+
+Handler-level regression for issue #225, entity branch, properties filter. 51 decoys rank
+above the target in FTS but have the wrong property value. The target has the required
+property and sits at rank 52.
+
+### `handler_search_note_tag_filter_beyond_scan_cliff`
+
+Handler-level regression for issue #225, note branch, tag filter. 51 observation notes
+rank above the target in FTS but lack the required tag. The target carries the required
+tag and sits at rank 52.
+
+### `handler_search_note_props_filter_beyond_scan_cliff`
+
+Handler-level regression for issue #225, note branch, properties filter. 51 observation
+notes rank above the target in FTS but have the wrong property. The target has the
+required property value and sits at rank 52.
+
+### `handler_search_note_sanitizes_fts5_metacharacters`
+
+No extra rationale beyond the name — FTS5 metacharacter sanitization regression.
+
+## `resolve` verb regression suite
+
+### `resolve_id_string_passthrough_through_dispatch`
+
+A UUID ref resolves through the id-string passthrough stage, regardless of whether the
+entity was ever touched through this registry's ring — exercised end to end through verb
+dispatch.
+
+### `resolve_via_recently_referenced_ring_after_create`
+
+The dispatch-boundary ring admits `create`'s returned id under its name; a later
+`resolve(refs=[name])` call by the SAME actor resolves it via the ring stage without ever
+running hybrid search over a matching name. Proves the ring, not just the id-string
+passthrough.
+
+### `resolve_ambiguous_on_duplicate_ring_names`
+
+Two entities admitted to the ring under the exact same name resolve as `Ambiguous`, never
+a silent pick (F7 of the unified-verb draft ADR).
+
+### `resolve_not_found_when_nothing_matches`
+
+A ref that matches nothing in the ring or hybrid search is `NotFound`.
+
+### `resolve_search_result_sets_never_populate_the_ring`
+
+`search` result-sets never admit to the ring (gate condition, 2026-07-09): an entity that
+only ever went through `search` (never `create`/`get`/`update`/`delete`/`merge`/`link` on
+THIS registry) must not resolve via the ring's high-confidence exact-match stage. It is
+created directly on the runtime (bypassing dispatch, hence bypassing admission entirely)
+so the only way `resolve` can find it via the ring is stage 2 — proven by a confidence
+that never equals the ring's fixed 0.95 exact-match / 0.7 substring-match bands (it
+instead comes from the stage-3 exact-name storage lookup, #849, since the ref is this
+entity's exact name).
+
+### `resolve_via_ring_survives_non_local_default_namespace`
+
+Regression for the namespace-key mismatch: ring admission used the gate-resolved `ns`
+(which is the configured `default_namespace`, e.g. `"lambda:leo"`, on the default
+dispatch path) while `resolve_reference`'s ring lookup used `token.namespace()` (always
+`"local"` on that same path, per ADR-007 Rule 0/3b). With a non-local `default_namespace`,
+a `create` followed by a same-actor `resolve` on the same registry must still hit the
+ring — proving admission and lookup are keyed identically.
+
+### `resolve_id_string_passthrough_is_entity_only`
+
+Id-string passthrough is entity-scoped, identically for full UUIDs and short prefixes: a
+note's id-string is `NotFound` through `resolve`, even though `get` on the same id would
+succeed.
+
+### `resolve_appears_in_verbs_introspection`
+
+`resolve` is registered as a public verb and appears in `verbs()`.
+
+### `resolve_exact_name_hit_resolves_high_confidence`
+
+An entity that already exists but was never referenced through this registry's ring
+resolves via the new exact-name storage lookup, at `EXACT_NAME_CONFIDENCE` (0.98) — above
+the ring's bands, below the absolute certainty of an id-string passthrough (1.0). Also
+regression coverage for the literal #849 repro: `kind="entity"` is the bare substrate
+label (no filter), not a literal `entities.kind` value.
+
+### `resolve_exact_name_handles_cjk_and_spaces`
+
+Exact-name storage lookup is Unicode-safe and does not tokenize names. CJK and embedded
+spaces therefore resolve with the same confidence as an ASCII single-token name.
+
+### `resolve_case_variant_uses_hybrid_fallback`
+
+The storage exact-name tier is case-sensitive. A case-only variant can still resolve
+through case-insensitive hybrid search, but it must not receive the exact tier's 0.98
+confidence.
+
+### `resolve_exact_name_ambiguous_on_duplicate_names`
+
+Two entities sharing the exact same name resolve as `Ambiguous`, never a silent pick,
+mirroring the ring's duplicate-name contract.
+
+### `resolve_exact_name_miss_falls_through_to_hybrid_search`
+
+A ref with no exact-name storage match still falls through to the hybrid-search fallback
+(existing stage-4 behavior preserved): a partial-phrase query that cannot exact-match any
+name resolves via search, at a confidence below the exact-name stage's 0.98.
+
+### `resolve_exact_name_soft_deleted_entity_not_matched`
+
+A soft-deleted entity is invisible to the exact-name storage lookup (`deleted_at IS NULL`
+is baked into `query_entities`), matching the rest of the KG surface's soft-delete
+contract.
+
+### `resolve_exact_name_respects_kind_filter`
+
+A granular `kind` filter narrows the exact-name lookup: two entities with the exact same
+name but different entity kinds resolve deterministically to the one matching `kind`,
+instead of `Ambiguous`.
+
+### `resolve_kind_rejects_non_entity_kind`
+
+`resolve`'s `kind` param is entity-only, matching the id-string passthrough and ring
+stages: a note kind is rejected with a clear error rather than silently over-filtering to
+zero matches.
+
+## `warm()` telemetry
+
+### `kg_warm_emits_exactly_one_phase_started_and_one_terminal_event`
+
+Verifies the ADR-103 Amendment 1 Part 2 phase-span contract described in
+`KgPack::warm`'s doc comment: exactly one `PhaseStarted` and one terminal
+(`PhaseCompleted`/`PhaseCancelled`) event per `warm()` call.
+
+## Implementation notes (moved from inline `//` comments)
+
+### `warm-token-minting`
+
+ADR-103 Amendment 1 Part 2: `warm()` runs at daemon construction / first pack install,
+outside `dispatch()` entirely — there is no caller-supplied token. Mint one the same way
+`khive-pack-memory`'s ANN background-rebuild task does (`rt.authorize(Namespace::local())`),
+so this daemon-startup embedder warmup is attributed to the daemon principal instead of
+remaining invisible on the event plane. A mint failure only removes this pass's telemetry
+— the warmup itself still runs.
+
+### `entity-type-validator-installation`
+
+Installs the validator on the runtime this pack OWNS, not on the caller-supplied runtime.
+In a multi-backend deployment the pack is constructed with a per-pack runtime (see
+`PackRegistry::register_packs_with_runtimes`); `self.runtime` is that runtime. In a
+single-backend deployment `self.runtime` IS the single runtime, so behaviour is identical
+to the previous call-through. The validator is composed once from every loaded pack's
+`ENTITY_TYPES` (`VerbRegistry::all_entity_types`, threaded in by
+`call_register_entity_type_validators`) layered over the builtin registry, so
+pack-declared subtypes (e.g. git's `adr` Document subtype) validate here in addition to
+`EntityTypeRegistry::global()`'s builtin-only set.
+
+### `issue-225-scan-cliff-mechanics`
+
+These tests operate at the `pack.dispatch("search", ...)` level and prove the REAL
+handler cliff: with `limit=1` the handler sets `search_limit = (1 * 50).min(500) = 50`,
+which means only 50 candidates enter the runtime. To push the target BEYOND the pre-fix
+cliff the tests insert 51 non-matching decoys so that the target sits at rank 52 in the
+unfiltered FTS ordering.
+
+Without predicate pushdown into `hybrid_search` / `search_notes` the runtime received
+`search_limit = 50` candidates, all decoys, and never saw the target. With the fix the
+runtime applies the filter BEFORE truncation over all 200 candidates (50 ×
+CANDIDATE_MULTIPLIER = 4) and surfaces the target.
+
+Budget constants (from `handlers/search.rs` and `retrieval.rs`):
+
+- handler `search_limit = (limit * 50).min(500)` → limit=1 → 50
+- runtime candidates = `search_limit * 4` → 200
+- old cliff: rank 51 (beyond handler 50-record scan)
+- new cliff: rank 201 (beyond runtime 200-candidate budget)
+
+Corpus: 51 decoys (ranks 1-51 in FTS) + 1 target (rank 52). Target has the discriminating
+tag/property; decoys do not. `limit=1`.
+
+### `resolve-ring-admission-boundary`
+
+Ring admission happens at the `VerbRegistry::dispatch_with_identity` boundary (see
+`pack.rs`), not inside `KgPack::dispatch` — these tests go through
+`registry.dispatch(verb, params)` (not the direct `pack.dispatch(verb, params, &registry,
+&tok)` bypass most other tests in this module use) specifically so the admission hook
+fires.
+
+### `exact-name-storage-lookup-fixtures`
+
+These entities are created directly on the runtime (bypassing `registry.dispatch`, hence
+bypassing ring admission entirely — same technique as
+`resolve_search_result_sets_never_populate_the_ring`), so the only way `resolve` can find
+them is the exact-name storage lookup (or, for the fallback-preserved case, hybrid
+search).

--- a/crates/khive-pack-kg/docs/handlers-common.md
+++ b/crates/khive-pack-kg/docs/handlers-common.md
@@ -1,0 +1,117 @@
+# handlers/common.rs — internal rationale
+
+Source: `crates/khive-pack-kg/src/handlers/common.rs`. Most items here are `pub(crate)`
+(internal helpers, never rendered on docs.rs); a handful are re-exported as real `pub`
+paths from `handlers/mod.rs` for kkernel's `--atomic` seam (ADR-099 B3) and keep a full
+doc-comment contract in the source. This guide holds the non-public rationale.
+
+## ADR-099 B3 pub-widening rationale
+
+`KindSpec`, `resolve_kind_spec`, `resolve_uuid_unfiltered`,
+`resolve_uuid_unfiltered_including_deleted`, and `normalize_entity_timestamps` were
+widened from `pub(crate)` to `pub` under ADR-099 finding B3: `kkernel`'s `--atomic`
+validation/resolution seam reuses these exact functions so a caller-supplied
+`delete`/`update`/`link` request resolves kinds, ids, and result payloads through the
+SAME canonical logic the verb handlers use, instead of re-deriving or duplicating that
+logic. `kkernel` already depends on this crate directly, so this is not a crate-graph
+inversion.
+
+`resolve_uuid_unfiltered` implements the ADR-007 Rev 6 by-ID contract: UUID resolution
+for get/update/delete/merge is namespace-agnostic — the Gate is the authz seam, not
+storage-layer filtering. Full-UUID inputs were already unfiltered (`resolve_by_id`); this
+function closes the gap for the *prefix* form, which previously fell through to the
+primary-namespace-only `resolve_prefix` and was invisible for any row stamped with a
+non-primary namespace (#391 §3). It is an exact copy of `resolve_uuid_async` except the
+prefix-resolution branch.
+
+`resolve_uuid_unfiltered_including_deleted` is the same function again, but also matching
+soft-deleted rows — used by the hard-delete by-ID path (#391 §3).
+
+## `validate_entity_type`
+
+The composed registry is built from the builtin registry plus every loaded pack's
+declared `ENTITY_TYPES` (ADR-017 additive composition, mirroring `EDGE_RULES`) — NOT
+`EntityTypeRegistry::global()`, which only knows builtin subtypes and is blind to
+pack-declared extras (e.g. git's `adr` Document subtype).
+
+## `valid_relations_for_entity_pair`
+
+Derives valid relations for a `(src_kind, src_entity_type, tgt_kind, tgt_entity_type)`
+entity pair from the SAME sources `validate_edge_relation_endpoints` consults when
+accepting or rejecting a link (issue #543): the base entity endpoint allowlist
+(`khive_runtime::operations::base_entity_endpoint_rules`) plus the runtime's live
+composed pack `EDGE_RULES`, matched through
+`khive_runtime::operations::accepted_pack_relations_for_entities` — the same
+`endpoint_matches` semantics `pack_rule_allows` applies internally (`EntityOfKind`,
+`EntityOfType`, `NoteOfKind`). There is no separate hand-authored table and no local
+re-filter of endpoint kinds here: a hint can no longer diverge from what the validator
+itself accepts, including pack rules scoped to a granular `entity_type` (e.g.
+`khive-pack-formal`'s typed `theorem -> definition` `depends_on` rule).
+
+Note-scoped pack rules (e.g. GTD's `task` -> `task` `depends_on`, declared as
+`NoteOfKind`) cannot match here regardless of the shared matcher, because this function
+is only ever reached (via `enrich_allowlist_error`) after both endpoints have already
+been resolved as entities — a note/note mismatch produces a different validation error
+entirely ("must be an entity for relation ..."), not the base-allowlist error this
+function enriches.
+
+## `merge_note_tags`
+
+Merges the top-level `tags` create-param into `properties["tags"]` for a note. Notes have
+no dedicated tags column (see `search.rs`'s `tag_filter` handling) — `properties["tags"]`
+is the storage convention already used by `memory.remember`
+(`khive-pack-memory/src/handlers/remember.rs`) and by this pack's own `search`/`list`
+note-tag filters. Without this merge, `create(kind=note, tags=[...])` silently dropped
+the tags (#747).
+
+Precedence: an empty/absent `tags` param leaves `properties` untouched. A non-empty
+`tags` param always WINS over any `properties["tags"]` the caller also supplied — the
+top-level, typed param is the more explicit signal, so it overwrites rather than merges
+with a same-named nested key.
+
+## `reject_inapplicable_fields` (handlers/update.rs)
+
+Field applicability guard — authoritative field sets per substrate. Source of truth:
+`handler_defs.rs:241-243` + `EntityPatch`/`NotePatch`/`EdgePatch` in
+`crates/khive-runtime/src/curation.rs`:
+
+- Entity: `name`, `description`, `tags`, `properties`
+- Note: `name`, `content`, `salience`, `decay_factor`, `properties` (notes have NO
+  top-level tags column; tags live in `properties["tags"]`)
+- Edge: `relation`, `weight`, `properties`
+
+Any present-but-inapplicable field is rejected with a fail-loud error naming the
+offending field and listing the substrate's valid set. This function MUST be updated
+whenever `UpdateParams` or a patch struct changes.
+
+## `resolve` handler (handlers/resolve.rs)
+
+Thin and read-only: deserializes params, calls the runtime's `resolve_reference`
+capability once per ref, and renders each `ReferenceResolution` to its wire shape. All
+resolution logic (id-string passthrough, ring lookup, hybrid-search fallback) lives in
+`khive_runtime::reference_resolution` — this handler performs no mutation and no side
+effect beyond the ring reads/admissions `resolve_reference` and the dispatch boundary
+already make.
+
+`resolve`'s pipeline (id-string passthrough, ring, exact-name storage lookup, hybrid
+search) is entity-only, so `kind` here follows the same substrate-or-granular
+discriminant as `create`/`list`/`search` (see `resolve_kind_spec`): the bare substrate
+label `"entity"` means "no kind filter", not a literal `entities.kind` value. Forwarding
+the raw string as-is would filter every real match out (#849) — `entities.kind` only ever
+holds a granular value like `"concept"`, never `"entity"`.
+
+## `FILTERED_SCAN_CAP` and the scan-cliff widening (handlers/search.rs)
+
+Maximum candidate window used when property/tag filters are active. Predicates are
+applied BEFORE result truncation inside the runtime's candidate budget (`search_limit ×
+CANDIDATE_MULTIPLIER`). This constant widens the handler's initial `search_limit` so that
+sparse matches ranked just below the bare `limit` remain within the candidate window.
+Matches ranked beyond the overall budget may still be missed — use specific query text to
+keep target records near the top of the ranking.
+
+The entity and note search branches both widen the candidate window the same way so
+sparse matches ranked below the bare `limit` remain within the runtime's retrieval
+budget. Predicates are applied BEFORE result truncation (entity tags: SQL-level via
+`EntityFilter`; entity/note properties and note tags: Rust-level in the alive-set loop,
+since notes have no dedicated tag column — tags live in `properties["tags"]`). The cap
+bounds worst-case scan cost.

--- a/crates/khive-pack-kg/docs/handlers-tests.md
+++ b/crates/khive-pack-kg/docs/handlers-tests.md
@@ -1,0 +1,27 @@
+# handlers/tests.rs — internal rationale
+
+Source: `crates/khive-pack-kg/src/handlers/tests.rs` (`#[cfg(test)]`, never rendered on
+docs.rs). This guide holds rationale trimmed from oversized inline `//` comments.
+
+## Issue #543: hint/validator divergence sweep
+
+Hints must equal the validator's own acceptance set, not a separate hand-authored table
+(the person→project gap, issue #60, was exactly this divergence class).
+
+`valid_relations_hint_matches_real_validator_acceptance_across_all_entity_kind_pairs` is a
+generative cross-check: for EVERY (source_kind, target_kind) entity pair in the 9x9 closed
+entity-kind taxonomy, the hint set returned by `valid_relations_for_entity_pair` must equal
+the set of relations the REAL production validator (`KhiveRuntime::link` ->
+`validate_edge_relation_endpoints`) actually accepts for that pair. This calls production
+code on both sides — it never re-implements the rule check inline.
+
+Issue #621 flagged that a five-pair spot check missed an `EntityOfType`-scoped divergence
+(see `valid_relations_hint_covers_formal_pack_entity_of_type_rules`); this test sweeps the
+full closed kind space so a future divergence at any pair fails loudly rather than only at
+hand-picked pairs.
+
+`annotates` requires a note source (never an entity), so it can never be accepted for an
+entity→entity pair regardless of kind and is skipped (matches the hint function's own
+scope, which never emits "annotates"). `supersedes`/`supports`/`refutes` DO validate
+entity→entity pairs against the same base allowlist the hint function reads, so they stay
+in scope.

--- a/crates/khive-pack-kg/src/dispatch.rs
+++ b/crates/khive-pack-kg/src/dispatch.rs
@@ -54,14 +54,9 @@ impl PackRuntime for KgPack {
     }
 
     async fn warm(&self) {
-        // ADR-103 Amendment 1 Part 2: `warm()` runs at daemon construction /
-        // first pack install, outside `dispatch()` entirely -- there is no
-        // caller-supplied token. Mint one the same way
-        // `khive-pack-memory`'s ANN background-rebuild task does
-        // (`rt.authorize(Namespace::local())`), so this daemon-startup
-        // embedder warmup is attributed to the daemon principal instead of
-        // remaining invisible on the event plane. A mint failure only
-        // removes this pass's telemetry -- the warmup itself still runs.
+        // ADR-103 Amendment 1 Part 2: mint an attribution token for daemon-startup
+        // telemetry (see docs/dispatch-tests.md#warm-token-minting); a mint failure
+        // only drops telemetry, warmup still runs.
         let token = match self.runtime.authorize(khive_runtime::Namespace::local()) {
             Ok(token) => Some(token),
             Err(e) => {
@@ -127,10 +122,7 @@ impl PackRuntime for KgPack {
                 }
             }
         }
-        // `PackRuntime::warm` is documented infallible: errors are logged
-        // internally, never propagated. The embed outcome is already
-        // captured in the phase-span payload above (Completed vs
-        // Cancelled); nothing further to do with it here.
+        // `PackRuntime::warm` is documented infallible: errors are logged, never propagated.
         let _ = result;
     }
 
@@ -143,19 +135,9 @@ impl PackRuntime for KgPack {
         _runtime: &KhiveRuntime,
         pack_entity_types: &[khive_types::EntityTypeDef],
     ) {
-        // Install the validator on the runtime this pack OWNS, not on the
-        // caller-supplied runtime.  In a multi-backend deployment the pack
-        // is constructed with a per-pack runtime (see PackRegistry::
-        // register_packs_with_runtimes); `self.runtime` is that runtime.
-        // In a single-backend deployment `self.runtime` IS the single
-        // runtime, so behaviour is identical to the previous call-through.
-        //
-        // Composed once from every loaded pack's `ENTITY_TYPES`
-        // (`VerbRegistry::all_entity_types`, threaded in by
-        // `call_register_entity_type_validators`) layered over the builtin
-        // registry, so pack-declared subtypes (e.g. git's `adr` Document
-        // subtype) validate here in addition to `EntityTypeRegistry::global()`'s
-        // builtin-only set.
+        // Installs on the runtime this pack OWNS (`self.runtime`, not the caller-supplied
+        // one), composed over every loaded pack's ENTITY_TYPES layered on the builtin
+        // registry. See docs/dispatch-tests.md#entity-type-validator-installation.
         let composed = Arc::new(crate::entity_type_registry::EntityTypeRegistry::with_extra(
             pack_entity_types.iter().cloned(),
         ));
@@ -256,11 +238,7 @@ mod tests {
 
     use super::*;
 
-    /// Entity created under `tenant-a` is namespaced correctly; by-ID get is namespace-agnostic.
-    ///
-    /// PR-A1 (ADR-007): by-ID `get` returns a record regardless of the caller's namespace.
-    /// Namespace on the returned record must still reflect the creator's namespace.
-    /// list/search still filter by namespace (PR-B scope).
+    /// By-ID get is namespace-agnostic; namespace on the record reflects the creator, not the caller. See `docs/dispatch-tests.md`.
     #[tokio::test]
     async fn kg_create_entity_honors_caller_namespace() {
         let rt = KhiveRuntime::memory().expect("in-memory runtime");
@@ -355,7 +333,7 @@ mod tests {
         );
     }
 
-    /// Two creates with no explicit namespace land in the same `local` namespace.
+    /// Two creates with no explicit namespace land in the same `local` namespace. See `docs/dispatch-tests.md`.
     #[tokio::test]
     async fn kg_oss_default_namespace_entities_colocate() {
         let rt = KhiveRuntime::memory().expect("in-memory runtime");
@@ -400,18 +378,7 @@ mod tests {
             .expect("Beta must be retrievable via local token");
     }
 
-    /// ADR-007 Rev 4, Rule 3b: default read scope honors configured visible set.
-    ///
-    /// The dispatch token minted by VerbRegistry on the default (no explicit `namespace=`)
-    /// path widens the read scope to `['local'] ∪ visible_namespaces`. Both the 'local'
-    /// entity AND the entity written to a configured extra namespace must appear in a
-    /// registry-dispatched list without any explicit `namespace=` parameter.
-    ///
-    /// This test verifies:
-    ///
-    /// 1. Records written to "local" are visible in the list — the shared-brain property.
-    /// 2. A record written to a configured visible namespace (via a directly-minted token)
-    ///    ALSO appears in the registry-dispatched list — the Rev 4 read-scope widening.
+    /// ADR-007 Rev 4 Rule 3b: default list read scope widens to `['local'] ∪ visible_namespaces`. See `docs/dispatch-tests.md`.
     #[tokio::test]
     async fn dispatch_list_honors_configured_visible_namespaces_adr007_rev4() {
         let rt = KhiveRuntime::memory().expect("in-memory runtime");
@@ -498,11 +465,7 @@ mod tests {
         );
     }
 
-    /// ADR-007 Rev 4: backward-compat — with visible_namespaces UNSET, default read scope = ['local'] only.
-    ///
-    /// A registry with no `visible_namespaces` configured has the same behavior as Rev 3:
-    /// list returns only records in 'local'. A record written to a different namespace via
-    /// a directly-minted token does NOT appear in the registry list.
+    /// ADR-007 Rev 4 backward-compat: unset visible_namespaces scopes list reads to 'local' only. See `docs/dispatch-tests.md`.
     #[tokio::test]
     async fn dispatch_list_empty_visible_namespaces_scopes_to_local_only_adr007_rev4() {
         let rt = KhiveRuntime::memory().expect("in-memory runtime");
@@ -572,11 +535,7 @@ mod tests {
         );
     }
 
-    /// ADR-007 Rev 4: 'local' is always included in the default read scope,
-    /// even when visible_namespaces does not explicitly list it.
-    ///
-    /// Configuring visible_namespaces = ["other-ns"] (without "local") must still
-    /// return records from BOTH 'local' and 'other-ns' in the registry list.
+    /// ADR-007 Rev 4: 'local' is always in the default read scope even if not in visible_namespaces. See `docs/dispatch-tests.md`.
     #[tokio::test]
     async fn dispatch_list_local_always_included_when_visible_ns_set_adr007_rev4() {
         let rt = KhiveRuntime::memory().expect("in-memory runtime");
@@ -640,11 +599,7 @@ mod tests {
         );
     }
 
-    /// ADR-007 Rev 4: explicit namespace= param is a precise single-namespace escape, NOT widened.
-    ///
-    /// With visible_namespaces=["other-ns"] configured, a list(namespace="other-ns") call
-    /// scopes to EXACTLY ["other-ns"] and does NOT include 'local' or the union set.
-    /// This preserves the ability to read a single named set precisely.
+    /// ADR-007 Rev 4: an explicit `namespace=` param scopes precisely, never widened to the union set. See `docs/dispatch-tests.md`.
     #[tokio::test]
     async fn dispatch_explicit_namespace_param_is_precise_not_widened_adr007_rev4() {
         let rt = KhiveRuntime::memory().expect("in-memory runtime");
@@ -711,18 +666,7 @@ mod tests {
         );
     }
 
-    /// ADR-007 Rev 4, Rule 0 regression: non-local actor config does NOT route WRITE storage.
-    ///
-    /// Builds a VerbRegistry whose `default_namespace` is `"lambda:leo"` (simulating
-    /// `[actor] id = "lambda:leo"` or `--actor lambda:leo`).  Dispatches `create` and
-    /// `list` through `VerbRegistry::dispatch` (the real MCP path — not `pack.dispatch`).
-    ///
-    /// Asserts:
-    /// 1. The created entity lands in `"local"`, not `"lambda:leo"`.
-    /// 2. A subsequent `list` via the registry returns the entity, proving write+read both
-    ///    operate on `"local"` regardless of the non-local actor configuration.
-    /// 3. A direct-token `list` scoped to `"lambda:leo"` returns an empty set, proving the
-    ///    storage was never written to the actor namespace.
+    /// ADR-007 Rev 4 Rule 0: a non-local `default_namespace` actor config never routes write/read storage. See `docs/dispatch-tests.md`.
     #[tokio::test]
     async fn non_local_actor_config_does_not_route_storage_adr007_rule0() {
         let rt = KhiveRuntime::memory().expect("in-memory runtime");
@@ -807,32 +751,9 @@ mod tests {
     }
 
     // ---- Handler-level regression tests for issue #225 (filter-pushdown cliff) ----
-    //
-    // These tests operate at the `pack.dispatch("search", ...)` level and prove the
-    // REAL handler cliff: with `limit=1` the handler sets `search_limit =
-    // (1 * 50).min(500) = 50`, which means only 50 candidates enter the runtime.
-    // To push the target BEYOND the pre-fix cliff we insert 51 non-matching decoys
-    // so that the target sits at rank 52 in the unfiltered FTS ordering.
-    //
-    // Without predicate pushdown into `hybrid_search` / `search_notes` the runtime
-    // received `search_limit = 50` candidates, all decoys, and never saw the target.
-    // With the fix the runtime applies the filter BEFORE truncation over all 200
-    // candidates (50 × CANDIDATE_MULTIPLIER = 4) and surfaces the target.
-    //
-    // BUDGET CONSTANTS (from handlers/search.rs and retrieval.rs):
-    //   handler search_limit = (limit * 50).min(500)  → limit=1 → 50
-    //   runtime candidates   = search_limit * 4       → 200
-    //   old cliff: rank 51 (beyond handler 50-record scan)
-    //   new cliff: rank 201 (beyond runtime 200-candidate budget)
-    //
-    // Corpus: 51 decoys (ranks 1-51 in FTS) + 1 target (rank 52). Target has the
-    // discriminating tag/property; decoys do not. `limit=1`.
+    // See docs/dispatch-tests.md#issue-225-scan-cliff-mechanics for the budget math.
 
-    /// Handler-level regression for issue #225, entity branch, tag filter.
-    ///
-    /// 51 decoys rank above the target in FTS but lack the required tag.
-    /// The target carries the required tag and sits at rank 52.
-    /// With predicate pushdown the handler returns the target despite the cliff.
+    /// Issue #225 regression: entity tag filter finds a match past the FTS scan cliff via predicate pushdown. See `docs/dispatch-tests.md`.
     #[tokio::test]
     async fn handler_search_entity_tag_filter_beyond_scan_cliff() {
         let rt = KhiveRuntime::memory().expect("in-memory runtime");
@@ -910,10 +831,7 @@ mod tests {
         );
     }
 
-    /// Handler-level regression for issue #225, entity branch, properties filter.
-    ///
-    /// 51 decoys rank above the target in FTS but have the wrong property value.
-    /// The target has the required property and sits at rank 52.
+    /// Issue #225 regression: entity properties filter finds a match past the FTS scan cliff. See `docs/dispatch-tests.md`.
     #[tokio::test]
     async fn handler_search_entity_props_filter_beyond_scan_cliff() {
         let rt = KhiveRuntime::memory().expect("in-memory runtime");
@@ -985,10 +903,7 @@ mod tests {
         );
     }
 
-    /// Handler-level regression for issue #225, note branch, tag filter.
-    ///
-    /// 51 observation notes rank above the target in FTS but lack the required tag.
-    /// The target carries the required tag and sits at rank 52.
+    /// Issue #225 regression: note tag filter finds a match past the FTS scan cliff. See `docs/dispatch-tests.md`.
     #[tokio::test]
     async fn handler_search_note_tag_filter_beyond_scan_cliff() {
         let rt = KhiveRuntime::memory().expect("in-memory runtime");
@@ -1058,10 +973,7 @@ mod tests {
         );
     }
 
-    /// Handler-level regression for issue #225, note branch, properties filter.
-    ///
-    /// 51 observation notes rank above the target in FTS but have the wrong property.
-    /// The target has the required property value and sits at rank 52.
+    /// Issue #225 regression: note properties filter finds a match past the FTS scan cliff. See `docs/dispatch-tests.md`.
     #[tokio::test]
     async fn handler_search_note_props_filter_beyond_scan_cliff() {
         let rt = KhiveRuntime::memory().expect("in-memory runtime");
@@ -1182,16 +1094,9 @@ mod tests {
     }
 
     // ---- `resolve` verb (unified-verb draft ADR, Slice 1) ----
-    //
-    // Ring admission happens at the `VerbRegistry::dispatch_with_identity`
-    // boundary (see `pack.rs`), not inside `KgPack::dispatch` — these tests
-    // go through `registry.dispatch(verb, params)` (not the direct
-    // `pack.dispatch(verb, params, &registry, &tok)` bypass most other tests
-    // in this module use) specifically so the admission hook fires.
+    // See docs/dispatch-tests.md#resolve-ring-admission-boundary.
 
-    /// A UUID ref resolves through the id-string passthrough stage,
-    /// regardless of whether the entity was ever touched through this
-    /// registry's ring — exercised end to end through verb dispatch.
+    /// A UUID ref resolves via id-string passthrough regardless of prior ring exposure. See `docs/dispatch-tests.md`.
     #[tokio::test]
     async fn resolve_id_string_passthrough_through_dispatch() {
         let rt = KhiveRuntime::memory().expect("in-memory runtime");
@@ -1226,10 +1131,7 @@ mod tests {
         );
     }
 
-    /// The dispatch-boundary ring admits `create`'s returned id under its
-    /// name; a later `resolve(refs=[name])` call by the SAME actor resolves
-    /// it via the ring stage without ever running hybrid search over a
-    /// matching name. Proves the ring, not just the id-string passthrough.
+    /// `create`'s id admits to the ring under its name; a same-actor `resolve(refs=[name])` hits the ring, not hybrid search. See `docs/dispatch-tests.md`.
     #[tokio::test]
     async fn resolve_via_recently_referenced_ring_after_create() {
         let rt = KhiveRuntime::memory().expect("in-memory runtime");
@@ -1265,8 +1167,7 @@ mod tests {
         );
     }
 
-    /// Two entities admitted to the ring under the exact same name resolve
-    /// as `Ambiguous`, never a silent pick (F7 of the unified-verb draft ADR).
+    /// Two ring entries sharing a name resolve as `Ambiguous`, never a silent pick. See `docs/dispatch-tests.md`.
     #[tokio::test]
     async fn resolve_ambiguous_on_duplicate_ring_names() {
         let rt = KhiveRuntime::memory().expect("in-memory runtime");
@@ -1301,7 +1202,7 @@ mod tests {
         assert_eq!(candidates.len(), 2);
     }
 
-    /// A ref that matches nothing in the ring or hybrid search is `NotFound`.
+    /// A ref matching nothing in the ring or hybrid search is `NotFound`. See `docs/dispatch-tests.md`.
     #[tokio::test]
     async fn resolve_not_found_when_nothing_matches() {
         let rt = KhiveRuntime::memory().expect("in-memory runtime");
@@ -1324,16 +1225,7 @@ mod tests {
         );
     }
 
-    /// `search` result-sets never admit to the ring (gate condition,
-    /// 2026-07-09): an entity that only ever went through `search` (never
-    /// `create`/`get`/`update`/`delete`/`merge`/`link` on THIS registry) must
-    /// not resolve via the ring's high-confidence exact-match stage. It is
-    /// created directly on the runtime (bypassing dispatch, hence bypassing
-    /// admission entirely) so the only way `resolve` can find it via the ring
-    /// is stage 2 — proven by a confidence that never equals the ring's fixed
-    /// 0.95 exact-match / 0.7 substring-match bands (it instead comes from
-    /// the stage-3 exact-name storage lookup, #849, since the ref is this
-    /// entity's exact name).
+    /// `search` result-sets never admit to the ring (gate condition, 2026-07-09). See `docs/dispatch-tests.md`.
     #[tokio::test]
     async fn resolve_search_result_sets_never_populate_the_ring() {
         let rt = KhiveRuntime::memory().expect("in-memory runtime");
@@ -1389,14 +1281,7 @@ mod tests {
         );
     }
 
-    /// Regression for the namespace-key mismatch: ring admission used the
-    /// gate-resolved `ns` (which is the
-    /// configured `default_namespace`, e.g. `"lambda:leo"`, on the default
-    /// dispatch path) while `resolve_reference`'s ring lookup used
-    /// `token.namespace()` (always `"local"` on that same path, per ADR-007
-    /// Rule 0/3b). With a non-local `default_namespace`, a `create` followed
-    /// by a same-actor `resolve` on the same registry must still hit the
-    /// ring — proving admission and lookup are keyed identically.
+    /// Ring admission and lookup are keyed identically even under a non-local `default_namespace`. See `docs/dispatch-tests.md`.
     #[tokio::test]
     async fn resolve_via_ring_survives_non_local_default_namespace() {
         let rt = KhiveRuntime::memory().expect("in-memory runtime");
@@ -1433,10 +1318,7 @@ mod tests {
         );
     }
 
-    /// Id-string passthrough is entity-scoped, identically for full UUIDs
-    /// and short prefixes: a note's
-    /// id-string is `NotFound` through `resolve`, even though `get` on the
-    /// same id would succeed.
+    /// Id-string passthrough is entity-only: a note id-string is `NotFound` through `resolve`. See `docs/dispatch-tests.md`.
     #[tokio::test]
     async fn resolve_id_string_passthrough_is_entity_only() {
         let rt = KhiveRuntime::memory().expect("in-memory runtime");
@@ -1492,7 +1374,7 @@ mod tests {
         );
     }
 
-    /// `resolve` is registered as a public verb and appears in `verbs()`.
+    /// `resolve` is registered as a public verb and appears in `verbs()`. See `docs/dispatch-tests.md`.
     #[tokio::test]
     async fn resolve_appears_in_verbs_introspection() {
         let rt = KhiveRuntime::memory().expect("in-memory runtime");
@@ -1516,19 +1398,9 @@ mod tests {
     }
 
     // ---- exact-name storage lookup (stage 3, #849) ----
-    //
-    // These entities are created directly on the runtime (bypassing
-    // `registry.dispatch`, hence bypassing ring admission entirely — same
-    // technique as `resolve_search_result_sets_never_populate_the_ring`), so
-    // the only way `resolve` can find them is the exact-name storage lookup
-    // (or, for the fallback-preserved case, hybrid search).
+    // See docs/dispatch-tests.md#exact-name-storage-lookup-fixtures.
 
-    /// An entity that already exists but was never referenced through this
-    /// registry's ring resolves via the new exact-name storage lookup, at
-    /// `EXACT_NAME_CONFIDENCE` (0.98) — above the ring's bands, below the
-    /// absolute certainty of an id-string passthrough (1.0). Also regression
-    /// coverage for the literal #849 repro: `kind="entity"` is the bare
-    /// substrate label (no filter), not a literal `entities.kind` value.
+    /// An unreferenced existing entity resolves via exact-name storage lookup at `EXACT_NAME_CONFIDENCE` (0.98). See `docs/dispatch-tests.md`.
     #[tokio::test]
     async fn resolve_exact_name_hit_resolves_high_confidence() {
         let rt = KhiveRuntime::memory().expect("in-memory runtime");
@@ -1564,9 +1436,7 @@ mod tests {
         );
     }
 
-    /// Exact-name storage lookup is Unicode-safe and does not tokenize names.
-    /// CJK and embedded spaces therefore resolve with the same confidence as
-    /// an ASCII single-token name.
+    /// Exact-name storage lookup is Unicode-safe and untokenized: CJK/spaced names resolve at full confidence. See `docs/dispatch-tests.md`.
     #[tokio::test]
     async fn resolve_exact_name_handles_cjk_and_spaces() {
         let rt = KhiveRuntime::memory().expect("in-memory runtime");
@@ -1645,9 +1515,7 @@ mod tests {
         );
     }
 
-    /// The storage exact-name tier is case-sensitive. A case-only variant
-    /// can still resolve through case-insensitive hybrid search, but it must
-    /// not receive the exact tier's 0.98 confidence.
+    /// The exact-name tier is case-sensitive; a case-only variant falls back to hybrid search, not 0.98 confidence. See `docs/dispatch-tests.md`.
     #[tokio::test]
     async fn resolve_case_variant_uses_hybrid_fallback() {
         let rt = KhiveRuntime::memory().expect("in-memory runtime");
@@ -1693,8 +1561,7 @@ mod tests {
         );
     }
 
-    /// Two entities sharing the exact same name resolve as `Ambiguous`,
-    /// never a silent pick, mirroring the ring's duplicate-name contract.
+    /// Two entities sharing an exact name resolve as `Ambiguous`, mirroring the ring's contract. See `docs/dispatch-tests.md`.
     #[tokio::test]
     async fn resolve_exact_name_ambiguous_on_duplicate_names() {
         let rt = KhiveRuntime::memory().expect("in-memory runtime");
@@ -1734,10 +1601,7 @@ mod tests {
         assert_eq!(candidates.len(), 2);
     }
 
-    /// A ref with no exact-name storage match still falls through to the
-    /// hybrid-search fallback (existing stage-4 behavior preserved): a
-    /// partial-phrase query that cannot exact-match any name resolves via
-    /// search, at a confidence below the exact-name stage's 0.98.
+    /// A ref with no exact-name match falls through to hybrid search at lower confidence. See `docs/dispatch-tests.md`.
     #[tokio::test]
     async fn resolve_exact_name_miss_falls_through_to_hybrid_search() {
         let rt = KhiveRuntime::memory().expect("in-memory runtime");
@@ -1787,9 +1651,7 @@ mod tests {
         );
     }
 
-    /// A soft-deleted entity is invisible to the exact-name storage lookup
-    /// (`deleted_at IS NULL` is baked into `query_entities`), matching the
-    /// rest of the KG surface's soft-delete contract.
+    /// A soft-deleted entity is invisible to the exact-name storage lookup. See `docs/dispatch-tests.md`.
     #[tokio::test]
     async fn resolve_exact_name_soft_deleted_entity_not_matched() {
         let rt = KhiveRuntime::memory().expect("in-memory runtime");
@@ -1827,9 +1689,7 @@ mod tests {
         );
     }
 
-    /// A granular `kind` filter narrows the exact-name lookup: two entities
-    /// with the exact same name but different entity kinds resolve
-    /// deterministically to the one matching `kind`, instead of `Ambiguous`.
+    /// A granular `kind` filter disambiguates same-name entities of different kinds instead of `Ambiguous`. See `docs/dispatch-tests.md`.
     #[tokio::test]
     async fn resolve_exact_name_respects_kind_filter() {
         let rt = KhiveRuntime::memory().expect("in-memory runtime");
@@ -1883,9 +1743,7 @@ mod tests {
         );
     }
 
-    /// `resolve`'s `kind` param is entity-only, matching the id-string
-    /// passthrough and ring stages: a note kind is rejected with a clear
-    /// error rather than silently over-filtering to zero matches.
+    /// `resolve`'s `kind` param is entity-only; a note kind is rejected with a clear error. See `docs/dispatch-tests.md`.
     #[tokio::test]
     async fn resolve_kind_rejects_non_entity_kind() {
         let rt = KhiveRuntime::memory().expect("in-memory runtime");

--- a/crates/khive-pack-kg/src/handler_defs.rs
+++ b/crates/khive-pack-kg/src/handler_defs.rs
@@ -917,12 +917,8 @@ mod tests {
             .unwrap_or_else(|| panic!("handler {name:?} not found in KG_HANDLERS"))
     }
 
-    /// Regression for #899: `create.entity_kind` and `list.entity_kind` hand-write
-    /// the enumerated entity-kind list in their `help=true` description text. This
-    /// asserts every canonical name in `EntityKind::NAMES` (the actual vocabulary,
-    /// ADR-001 + ADR-048's 9-kind set) appears in both descriptions, so adding or
-    /// renaming an entity kind without updating the doc text fails loudly here
-    /// instead of shipping a stale `help=true` schema.
+    /// Regression for #899: `create.entity_kind`/`list.entity_kind` help text must list
+    /// every canonical `EntityKind::NAMES` entry, so a stale hand-written list fails loudly.
     #[test]
     fn entity_kind_param_descriptions_list_all_canonical_kinds() {
         for handler_name in ["create", "list"] {

--- a/crates/khive-pack-kg/src/handlers/common.rs
+++ b/crates/khive-pack-kg/src/handlers/common.rs
@@ -82,10 +82,8 @@ pub(crate) fn validate_entity_type(
     let kind = kind_name
         .parse::<khive_types::EntityKind>()
         .map_err(|_| RuntimeError::InvalidInput(format!("unknown entity kind {kind_name:?}")))?;
-    // Composed from the builtin registry plus every loaded pack's declared
-    // ENTITY_TYPES (ADR-017 additive composition, mirroring EDGE_RULES) —
-    // NOT `EntityTypeRegistry::global()`, which only knows builtin subtypes
-    // and is blind to pack-declared extras (e.g. git's `adr` Document subtype).
+    // ADR-017 additive composition (not `EntityTypeRegistry::global()`); see
+    // docs/handlers-common.md#validate_entity_type.
     let composed = EntityTypeRegistry::with_extra(registry.all_entity_types());
     let resolved = composed.resolve(kind, Some(raw))?;
     Ok(resolved.entity_type)
@@ -93,12 +91,9 @@ pub(crate) fn validate_entity_type(
 
 // ---- Granular `kind` discriminator ----
 
-/// Resolved shape of a `kind` discriminator string.
-///
-/// `pub` (widened from `pub(crate)`, ADR-099 B3): the
-/// `--atomic` seam in `kkernel` reuses [`resolve_kind_spec`] and this type to
-/// resolve a caller-supplied `delete(kind=...)` the SAME way `handle_delete`
-/// does, rather than re-deriving kind-vocabulary resolution.
+/// Resolved shape of a `kind` discriminator string: which substrate (entity, note,
+/// edge, event, proposal) it names, plus the specific granular kind if any.
+/// See `docs/handlers-common.md` for why this is `pub` rather than `pub(crate)`.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum KindSpec {
     Entity { specific: Option<String> },
@@ -120,10 +115,14 @@ impl KindSpec {
     }
 }
 
-/// Resolve a wire-level `kind` value into a [`KindSpec`].
+/// Resolve a wire-level `kind` value into a [`KindSpec`]. Accepts a bare substrate
+/// name (`entity`, `note`, `edge`, `event`, `proposal`) or a granular entity/note kind
+/// registered on `registry`.
 ///
-/// `pub` (widened from `pub(crate)`, ADR-099 B3),
-/// see [`KindSpec`]'s doc comment.
+/// # Errors
+///
+/// Returns [`RuntimeError::InvalidInput`] listing every valid value if `raw` matches
+/// neither a substrate name nor a registered granular kind.
 pub fn resolve_kind_spec(raw: &str, registry: &VerbRegistry) -> Result<KindSpec, RuntimeError> {
     let normalized = raw.trim().to_ascii_lowercase();
 
@@ -271,17 +270,16 @@ pub(crate) async fn resolve_uuid_async(
     resolve_name_async(s, runtime, token).await
 }
 
-/// By-ID contract (ADR-007 Rev 6): UUID resolution for get/update/delete/merge
-/// is namespace-agnostic — the Gate is the authz seam, not storage-layer
-/// filtering. Full-UUID inputs were already unfiltered (`resolve_by_id`); this
-/// closes the gap for the *prefix* form, which previously fell through to the
-/// primary-namespace-only `resolve_prefix` and was invisible for any row
-/// stamped with a non-primary namespace (#391 §3). Exact copy of
-/// `resolve_uuid_async` except the prefix branch.
+/// Resolve `s` (a full UUID, an 8+ hex-digit UUID prefix, or an entity name) to a
+/// [`Uuid`], namespace-agnostic (ADR-007 Rev 6 by-ID contract — no namespace filtering
+/// is applied to the prefix or full-UUID forms; name resolution still scopes to
+/// `token`'s namespace).
 ///
-/// `pub` (widened from `pub(crate)`, ADR-099 B3), so
-/// kkernel's `--atomic` seam can resolve KG ids (full UUID / 8+ hex prefix /
-/// entity-name) with the exact same semantics as the canonical handlers.
+/// # Errors
+///
+/// [`RuntimeError::InvalidInput`] if a hex-prefix matches no record;
+/// [`RuntimeError::NotFound`]/[`RuntimeError::Ambiguous`] from name resolution.
+/// See `docs/handlers-common.md` for the ADR-099 B3 pub-widening rationale.
 pub async fn resolve_uuid_unfiltered(
     s: &str,
     runtime: &KhiveRuntime,
@@ -304,13 +302,13 @@ pub async fn resolve_uuid_unfiltered(
     resolve_name_async(s, runtime, token).await
 }
 
-/// `resolve_uuid_unfiltered`, including soft-deleted rows — used by the
-/// hard-delete by-ID path (#391 §3). Exact copy of
-/// `resolve_uuid_including_deleted` except the prefix branch.
+/// Same as [`resolve_uuid_unfiltered`], but the prefix-resolution branch also matches
+/// soft-deleted rows. Used by the hard-delete by-ID path (#391 §3), which must be able
+/// to target a record regardless of its `deleted_at` state.
 ///
-/// `pub` (widened from `pub(crate)`, ADR-099 B3), for
-/// the same reason as `resolve_uuid_unfiltered` above; used by the atomic
-/// hard-delete id-resolution path.
+/// # Errors
+///
+/// Same error conditions as [`resolve_uuid_unfiltered`].
 pub async fn resolve_uuid_unfiltered_including_deleted(
     s: &str,
     runtime: &KhiveRuntime,
@@ -415,27 +413,9 @@ pub(crate) fn validate_weight(weight: Option<f64>) -> Result<f64, RuntimeError> 
     Ok(w)
 }
 
-/// Relations valid for a `(src_kind, src_entity_type, tgt_kind,
-/// tgt_entity_type)` entity pair, derived from the SAME sources
-/// `validate_edge_relation_endpoints` consults when accepting or rejecting a
-/// link (issue #543): the base entity endpoint allowlist
-/// (`khive_runtime::operations::base_entity_endpoint_rules`) plus the
-/// runtime's live composed pack `EDGE_RULES`, matched through
-/// `khive_runtime::operations::accepted_pack_relations_for_entities` — the
-/// same `endpoint_matches` semantics `pack_rule_allows` applies internally
-/// (`EntityOfKind`, `EntityOfType`, `NoteOfKind`). There is no separate
-/// hand-authored table and no local re-filter of endpoint kinds here: a hint
-/// can no longer diverge from what the validator itself accepts, including
-/// pack rules scoped to a granular `entity_type` (e.g. `khive-pack-formal`'s
-/// typed `theorem -> definition` `depends_on` rule).
-///
-/// Note-scoped pack rules (e.g. GTD's `task` -> `task` `depends_on`,
-/// declared as `NoteOfKind`) cannot match here regardless of the shared
-/// matcher, because this function is only ever reached (via
-/// `enrich_allowlist_error`) after both endpoints have already been resolved
-/// as entities — a note/note mismatch produces a different validation error
-/// entirely ("must be an entity for relation ..."), not the base-allowlist
-/// error this function enriches.
+/// Relations valid for an entity-kind pair, derived from the same allowlist +
+/// pack `EDGE_RULES` sources the real link validator consults (issue #543).
+/// See `docs/handlers-common.md#valid_relations_for_entity_pair`.
 pub(crate) fn valid_relations_for_entity_pair(
     runtime: &KhiveRuntime,
     src_kind: &str,
@@ -634,9 +614,10 @@ pub(crate) fn deser<T: serde::de::DeserializeOwned>(params: Value) -> Result<T, 
         .map_err(|e| RuntimeError::InvalidInput(format!("bad params: {e}")))
 }
 
-/// `pub` (widened from `pub(crate)`, ADR-099 B3), so
-/// kkernel's `--atomic` seam can render update/delete result payloads with
-/// the same timestamp normalization as the canonical handlers.
+/// Convert `created_at`/`updated_at`/`deleted_at`/`expires_at` fields on a JSON entity
+/// object from epoch-micros integers to ISO-8601 strings, in place. Fields that are
+/// absent or already non-integer are left untouched.
+/// See `docs/handlers-common.md` for the ADR-099 B3 pub-widening rationale.
 pub fn normalize_entity_timestamps(mut v: Value) -> Value {
     if let Some(obj) = v.as_object_mut() {
         for field in &["created_at", "updated_at", "deleted_at", "expires_at"] {
@@ -737,17 +718,9 @@ pub(crate) fn tags_match_any(entity_tags: &[String], wanted: &[String]) -> bool 
         .any(|tag| wanted.iter().any(|w| tag.eq_ignore_ascii_case(w)))
 }
 
-/// Merge the top-level `tags` create-param into `properties["tags"]` for a
-/// note. Notes have no dedicated tags column (see search.rs's `tag_filter`
-/// handling) — `properties["tags"]` is the storage convention already used
-/// by `memory.remember` (khive-pack-memory/src/handlers/remember.rs) and by
-/// this pack's own `search`/`list` note-tag filters. Without this merge,
-/// `create(kind=note, tags=[...])` silently dropped the tags (#747).
-///
-/// Precedence: an empty/absent `tags` param leaves `properties` untouched.
-/// A non-empty `tags` param always WINS over any `properties["tags"]` the
-/// caller also supplied — the top-level, typed param is the more explicit
-/// signal, so it overwrites rather than merges with a same-named nested key.
+/// Merge the top-level `tags` create-param into `properties["tags"]` for a note
+/// (#747). A non-empty `tags` param always wins over any `properties["tags"]` the
+/// caller also supplied. See `docs/handlers-common.md#merge_note_tags`.
 pub(crate) fn merge_note_tags(
     properties: Option<Value>,
     tags: Option<Vec<String>>,

--- a/crates/khive-pack-kg/src/handlers/context.rs
+++ b/crates/khive-pack-kg/src/handlers/context.rs
@@ -74,12 +74,7 @@ struct NeighborRecord {
     via: Option<Uuid>,
 }
 
-/// True iff every relation in the filter is a symmetric relation. Mirrors
-/// `normalize_symmetric_direction` in `khive-runtime/src/operations.rs`
-/// (private to that crate) — kept in lockstep because `neighbors_with_query`
-/// forces `Direction::Both` under this exact condition regardless of the
-/// direction actually requested, and the handler must know that happened to
-/// tag direction correctly instead of issuing a second, redundant call.
+/// True iff every relation in the filter is symmetric. See `docs/design.md#context-verb`.
 fn relations_all_symmetric(relations: Option<&[EdgeRelation]>) -> bool {
     match relations {
         None => false,
@@ -90,9 +85,8 @@ fn relations_all_symmetric(relations: Option<&[EdgeRelation]>) -> bool {
     }
 }
 
-/// Fetch up to `fanout` neighbors of `node_id`, each tagged with its actual
-/// direction relative to `node_id`. See module docs for why this can't just
-/// trust a `direction` field on a plain `NeighborHit`.
+/// Fetch up to `fanout` neighbors of `node_id`, each tagged with its actual direction.
+/// See `docs/design.md#context-verb`.
 async fn fetch_directed_neighbors(
     runtime: &KhiveRuntime,
     token: &NamespaceToken,
@@ -160,12 +154,7 @@ async fn fetch_directed_neighbors(
                 .collect())
         }
         Direction::Both => {
-            // Single UNION ALL query for both directions (ADR-089 context-verb
-            // optimization) instead of two separate direction-scoped calls —
-            // halves the storage neighbor SELECT count for this branch. The
-            // op already returns hits in global weight-descending,
-            // node_id-ascending order truncated to `fanout`, so no local
-            // re-sort/truncate is needed.
+            // ADR-089 UNION ALL optimization; see docs/design.md#context-verb-internals.
             let hits = runtime
                 .neighbors_with_query_directed(
                     token,
@@ -181,8 +170,7 @@ async fn fetch_directed_neighbors(
             Ok(hits
                 .into_iter()
                 .map(|(h, dir)| {
-                    // `neighbors_with_query_directed` only ever tags hits `Out`/`In`
-                    // (see `DirectedNeighborHit` doc comment) — `Both` never appears.
+                    // `neighbors_with_query_directed` only ever tags `Out`/`In`, never `Both`.
                     let tag = if dir == Direction::Out {
                         "outgoing"
                     } else {
@@ -260,13 +248,8 @@ impl KgPack {
                 }
             }
         }
-        // `entity_ids` is an explicit entity-anchor contract (ADR-089 §1: "honored
-        // in full"). `resolve_uuid_async` accepts any syntactically valid UUID
-        // without checking substrate or existence, so a random UUID, a note UUID,
-        // or an edge UUID would otherwise resolve here and then silently vanish
-        // from the response in Stage 4's lenient "missing entity" fallback. Fail
-        // loudly instead: one batch existence check naming every offending id
-        // Regression coverage.
+        // ADR-089 §1 explicit-anchor contract; fail loudly on bad ids instead of
+        // silently vanishing them in Stage 4. See docs/design.md#context-verb-internals.
         if !explicit_ids.is_empty() {
             let mut dedup_explicit = explicit_ids.clone();
             dedup_explicit.sort_unstable();
@@ -313,13 +296,8 @@ impl KgPack {
         let t1 = if prof { Some(Instant::now()) } else { None };
         if has_query {
             let q = p.query.as_deref().unwrap();
-            // Fetch a larger candidate window than `limit` so that anchors which
-            // collapse into `entity_ids` duplicates don't under-fill the query
-            // leg: ADR-089 §1 promises search "fills up to `limit` additional
-            // anchors" after explicit ids, which requires looking past the first
-            // `limit` hits when some of them overlap explicit anchors. Bounded
-            // by a documented cap so a pathological
-            // overlap can't turn into an unbounded search.
+            // Overfetch so entity_ids-overlap doesn't under-fill (ADR-089 §1); see
+            // docs/design.md#context-verb-internals.
             const QUERY_FILL_WINDOW_MULTIPLIER: u32 = 4;
             let fetch_n = limit
                 .saturating_add(explicit_ids.len() as u32)
@@ -400,10 +378,7 @@ impl KgPack {
                         hop2_pool.push((*parent, id, relation, weight, dir));
                     }
                 }
-                // One stratum across all hop-1 parents under this anchor: sort by
-                // weight desc, then neighbor id, then parent id (the last key only
-                // arbitrates true ties — same neighbor, same weight, different
-                // parent — so the "first discovering parent" is deterministic).
+                // Deterministic hop-1 stratum ordering; see docs/design.md#context-verb-internals.
                 hop2_pool.sort_by(|a, b| {
                     b.3.partial_cmp(&a.3)
                         .unwrap_or(std::cmp::Ordering::Equal)
@@ -474,13 +449,7 @@ impl KgPack {
 
         // ---- Stage 4: assembly with budget enforcement ----
         let t4 = if prof { Some(Instant::now()) } else { None };
-        // Explicit `entity_ids` anchors are already verified to exist in Stage 1
-        // This only guards the residual race of an
-        // anchor deleted concurrently between resolution and this fetch, or a
-        // neighbor entity that vanished the same way. Neighbors get the same
-        // lenient "missing node reads as absent" convention `neighbors_with_query`
-        // already applies (it returns an empty Vec rather than erroring on a
-        // nonexistent `node_id`) — they never enter the budget accounting below.
+        // Guards only the residual delete race; see docs/design.md#context-verb-internals.
         let mut blocks: Vec<AnchorBlock> = Vec::with_capacity(anchor_ids.len());
         for (i, anchor) in anchor_ids.iter().enumerate() {
             let Some(e) = entity_meta.get(anchor) else {
@@ -535,11 +504,7 @@ impl KgPack {
     }
 }
 
-/// Deterministic-order budget walk: append anchor entity records and their
-/// neighbor records (each already produced in final display order) until the
-/// next record's compact-JSON Unicode-scalar length would push the running
-/// total past `budget`. Returns (assembled anchors, truncated, dropped
-/// anchors, dropped neighbors).
+/// Deterministic-order budget walk over anchors + neighbors. See `docs/design.md#context-verb`.
 fn assemble_within_budget(
     blocks: &[AnchorBlock],
     budget: usize,

--- a/crates/khive-pack-kg/src/handlers/mod.rs
+++ b/crates/khive-pack-kg/src/handlers/mod.rs
@@ -17,19 +17,15 @@ mod update;
 
 pub(crate) use common::{canonical_entity_kind, canonical_note_kind, parse_relation};
 
-/// ADR-099 B3: re-exported as a real `pub` path (not `pub(crate)`) so
-/// `kkernel`'s `--atomic` validation seam can reach the SAME canonical
-/// param structs `handle_update`/`handle_delete`/`handle_link` deserialize
-/// through, reproducing their `#[serde(deny_unknown_fields)]` rejection
-/// without a duplicated per-verb key list. `kkernel` already depends on
-/// this crate directly (no crate-graph inversion); see
-/// `kkernel::atomic_apply::validate_atomic_args`.
+/// ADR-099 B3: real `pub` re-export so kkernel's `--atomic` seam validates through the
+/// SAME canonical param structs the handlers deserialize, reproducing
+/// `#[serde(deny_unknown_fields)]` rejection with no duplicated key list. See
+/// `docs/handlers-common.md` for the full ADR-099 B3 rationale.
 pub use params::{DeleteParams, LinkParams, UpdateParams};
 
-/// ADR-099 B3 (findings 1, 3, 4): re-exported as real `pub`
-/// paths so `kkernel`'s `--atomic` seam can resolve kinds/ids and render
-/// result payloads through the exact canonical logic `handle_update`/
-/// `handle_delete`/`handle_link` use, rather than reimplementing it.
+/// ADR-099 B3 (findings 1, 3, 4): real `pub` re-export so kkernel's `--atomic` seam
+/// resolves kinds/ids and renders results through the exact canonical logic the
+/// handlers use, rather than reimplementing it.
 pub use common::{
     normalize_entity_timestamps, resolve_kind_spec, resolve_uuid_unfiltered,
     resolve_uuid_unfiltered_including_deleted, KindSpec,

--- a/crates/khive-pack-kg/src/handlers/params.rs
+++ b/crates/khive-pack-kg/src/handlers/params.rs
@@ -95,12 +95,9 @@ pub(crate) struct ListParams {
 #[serde(deny_unknown_fields)]
 pub(crate) struct StatsParams {}
 
-/// ADR-099 B3: this struct is `pub` (not `pub(crate)`) SPECIFICALLY so
-/// `kkernel`'s `--atomic` validation seam (`atomic_apply::validate_atomic_args`)
-/// can deserialize an op's args through the SAME canonical struct
-/// `handle_update` uses, reproducing `deny_unknown_fields` rejection with
-/// zero duplicated field lists. Fields stay `pub(crate)` — the atomic seam
-/// only needs the `Result<_, _>` outcome, never field access.
+/// ADR-099 B3: `pub` so kkernel's `--atomic` seam can deserialize through this same
+/// canonical struct, reproducing `deny_unknown_fields` rejection. Fields stay
+/// `pub(crate)` — the atomic seam only needs the `Result<_, _>` outcome.
 #[derive(Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct UpdateParams {

--- a/crates/khive-pack-kg/src/handlers/resolve.rs
+++ b/crates/khive-pack-kg/src/handlers/resolve.rs
@@ -1,12 +1,5 @@
-//! `resolve` verb handler (unified-verb draft ADR, Slice 1).
-//!
-//! Thin and read-only: deserializes params, calls the runtime's
-//! `resolve_reference` capability once per ref, and renders each
-//! `ReferenceResolution` to its wire shape. All resolution logic (id-string
-//! passthrough, ring lookup, hybrid-search fallback) lives in
-//! `khive_runtime::reference_resolution` — this handler performs no mutation
-//! and no side effect beyond the ring reads/admissions `resolve_reference`
-//! and the dispatch boundary already make.
+//! `resolve` verb handler (unified-verb draft ADR, Slice 1). Thin and read-only — see
+//! `docs/handlers-common.md#resolve-handler-handlersresolveers`.
 
 use serde_json::{json, Value};
 
@@ -35,14 +28,8 @@ impl KgPack {
         let limit = p.limit.unwrap_or(DEFAULT_LIMIT).clamp(1, MAX_LIMIT);
         let ring = registry.reference_ring();
 
-        // `resolve`'s pipeline (id-string passthrough, ring, exact-name
-        // storage lookup, hybrid search) is entity-only, so `kind` here
-        // follows the same substrate-or-granular discriminant as
-        // `create`/`list`/`search` (see `resolve_kind_spec`): the bare
-        // substrate label `"entity"` means "no kind filter", not a literal
-        // `entities.kind` value. Forwarding the raw string as-is would filter
-        // every real match out (#849) — `entities.kind` only ever holds a
-        // granular value like `"concept"`, never `"entity"`.
+        // #849: bare "entity" means no kind filter, not a literal entities.kind value.
+        // See docs/handlers-common.md#resolve-handler-handlersresolveers.
         let entity_kind = match &p.kind {
             Some(raw) => match resolve_kind_spec(raw, registry)? {
                 KindSpec::Entity { specific } => specific,

--- a/crates/khive-pack-kg/src/handlers/search.rs
+++ b/crates/khive-pack-kg/src/handlers/search.rs
@@ -3,13 +3,7 @@
 use std::collections::HashMap;
 
 /// Maximum candidate window used when property/tag filters are active.
-///
-/// Predicates are applied BEFORE result truncation inside the runtime's
-/// candidate budget (`search_limit × CANDIDATE_MULTIPLIER`). This constant
-/// widens the handler's initial `search_limit` so that sparse matches ranked
-/// just below the bare `limit` remain within the candidate window.
-/// Matches ranked beyond the overall budget may still be missed — use
-/// specific query text to keep target records near the top of the ranking.
+/// See `docs/handlers-common.md#filtered_scan_cap-and-the-scan-cliff-widening-handlerssearchrs`.
 const FILTERED_SCAN_CAP: u32 = 500;
 
 use serde_json::Value;
@@ -62,11 +56,7 @@ impl KgPack {
                 });
                 let tag_filter = p.tags.as_ref().filter(|tags| !tags.is_empty());
                 let search_limit = if props_filter.is_some() || tag_filter.is_some() {
-                    // Widen the candidate window so sparse matches ranked below the
-                    // bare `limit` remain within the runtime's retrieval budget.
-                    // Predicates are applied BEFORE result truncation (entity tags:
-                    // SQL-level via EntityFilter; properties: Rust-level in alive-set
-                    // loop). The cap bounds worst-case scan cost.
+                    // See docs/handlers-common.md#filtered_scan_cap-and-the-scan-cliff-widening-handlerssearchrs.
                     (limit * 50).min(FILTERED_SCAN_CAP)
                 } else {
                     limit
@@ -169,12 +159,7 @@ impl KgPack {
                 });
                 let tag_filter = p.tags.as_ref().filter(|tags| !tags.is_empty());
                 let search_limit = if props_filter.is_some() || tag_filter.is_some() {
-                    // Widen the candidate window so sparse matches ranked below the
-                    // bare `limit` remain within the runtime's retrieval budget.
-                    // Predicates are applied BEFORE result truncation (note tags and
-                    // properties: Rust-level in the alive-set loop, since notes have
-                    // no dedicated tag column — tags live in `properties["tags"]`).
-                    // The cap bounds worst-case scan cost.
+                    // See docs/handlers-common.md#filtered_scan_cap-and-the-scan-cliff-widening-handlerssearchrs.
                     (limit * 50).min(FILTERED_SCAN_CAP)
                 } else {
                     limit

--- a/crates/khive-pack-kg/src/handlers/tests.rs
+++ b/crates/khive-pack-kg/src/handlers/tests.rs
@@ -17,14 +17,9 @@ fn parse_relation_error_lists_all_relations() {
     );
 }
 
-// Wire-level tri-state nullable f64 for `update`:
-//   absent  → outer None (preserve existing value)
-//   null    → Some(None) (clear the value)
-//   number  → Some(Some(v)) (set to v)
-//
-// Regression: the previous `Option<Value>` representation
-// collapsed absent and null into the same `None`, so JSON null could not
-// distinguish "clear" from "preserve" through the MCP wire surface.
+// Wire-level tri-state nullable f64 for `update`: absent→None (preserve), null→Some(None)
+// (clear), number→Some(Some(v)) (set). Regression: `Option<Value>` used to collapse
+// absent and null into the same None, so JSON null couldn't distinguish clear/preserve.
 #[test]
 fn update_params_tri_state_salience() {
     let absent: UpdateParams = serde_json::from_value(json!({"id": "x", "kind": "note"})).unwrap();
@@ -561,22 +556,7 @@ fn valid_relations_unsupported_pair_returns_empty() {
     );
 }
 
-// ---- Issue #543: hints must equal the validator's own acceptance set, not a
-// separate hand-authored table (the person->project gap, issue #60, was
-// exactly this divergence class) ----
-
-// Generative cross-check: for EVERY (source_kind, target_kind) entity pair in
-// the 9x9 closed entity-kind taxonomy, the hint set returned by
-// `valid_relations_for_entity_pair` must equal the set of relations the REAL
-// production validator (`KhiveRuntime::link` -> `validate_edge_relation_endpoints`)
-// actually accepts for that pair. This calls production code on both sides —
-// it never re-implements the rule check inline.
-//
-// #621 flagged that a five-pair spot check missed an
-// `EntityOfType`-scoped divergence (see
-// `valid_relations_hint_covers_formal_pack_entity_of_type_rules` below); this
-// sweeps the full closed kind space so a future divergence at any pair fails
-// loudly rather than only at hand-picked pairs.
+// Issue #543/#621: generative hint/validator divergence sweep. See docs/handlers-tests.md.
 #[tokio::test]
 async fn valid_relations_hint_matches_real_validator_acceptance_across_all_entity_kind_pairs() {
     use crate::vocab::EntityKind as KgEntityKind;
@@ -592,12 +572,7 @@ async fn valid_relations_hint_matches_real_validator_acceptance_across_all_entit
         let token = rt.authorize(Namespace::local()).unwrap();
         let mut accepted = Vec::new();
         for relation in EdgeRelation::ALL {
-            // `annotates` requires a note source (never an entity), so it can
-            // never be accepted for an entity->entity pair regardless of
-            // kind; skip it (matches the hint function's own scope, which
-            // never emits "annotates"). supersedes/supports/refutes DO
-            // validate entity->entity pairs against the same base allowlist
-            // the hint function reads, so they stay in scope here.
+            // annotates is entity-invalid; see docs/handlers-tests.md.
             if relation == EdgeRelation::Annotates {
                 continue;
             }

--- a/crates/khive-pack-kg/src/handlers/update.rs
+++ b/crates/khive-pack-kg/src/handlers/update.rs
@@ -15,21 +15,9 @@ use super::common::{
 };
 use crate::KgPack;
 
-// ---------------------------------------------------------------------------
-// Field applicability guard (authoritative field sets per substrate)
-//
-// Valid fields per substrate (source of truth: handler_defs.rs:241-243 +
-// EntityPatch / NotePatch / EdgePatch in crates/khive-runtime/src/curation.rs):
-//
-//   Entity: name, description, tags, properties
-//   Note:   name, content, salience, decay_factor, properties
-//           (notes have NO top-level tags column; tags live in properties["tags"])
-//   Edge:   relation, weight, properties
-//
-// Any present-but-inapplicable field is rejected with a fail-loud error naming
-// the offending field and listing the substrate's valid set.  This function
-// MUST be updated whenever UpdateParams or a patch struct changes.
-// ---------------------------------------------------------------------------
+// Field applicability guard, authoritative field sets per substrate — see
+// docs/handlers-common.md#reject_inapplicable_fields-handlersupdaters. MUST be updated
+// whenever UpdateParams or a patch struct changes.
 fn reject_inapplicable_fields(spec: &KindSpec, p: &UpdateParams) -> Result<(), RuntimeError> {
     let (bad_field, valid): (Option<&str>, &str) = match spec {
         KindSpec::Entity { .. } => {

--- a/crates/khive-pack-kg/src/pack.rs
+++ b/crates/khive-pack-kg/src/pack.rs
@@ -4,10 +4,8 @@ use khive_types::{EdgeEndpointRule, EdgeRelation, EndpointKind, HandlerDef, Pack
 
 use crate::handler_defs::KG_HANDLERS;
 
-/// Pack-extensible edge endpoint rules — adds person→org, person→project, and org→org
-/// pairs to the base allowlist. The person→project rows mirror person→org (issue #60):
-/// a person is a member of a project the same way they are a member of an org, so the
-/// same member-not-component semantic stretch accepted for person→org is extended here.
+/// Pack-extensible edge endpoint rules (person↔org, person↔project, org↔org).
+/// See `docs/design.md#kg_edge_rules`.
 pub(crate) static KG_EDGE_RULES: [EdgeEndpointRule; 9] = [
     EdgeEndpointRule {
         relation: EdgeRelation::PartOf,
@@ -90,7 +88,6 @@ mod tests {
     use super::*;
     use khive_types::EndpointKind;
 
-    /// Extract a comparable (source_str, target_str) pair from an EndpointKind.
     fn endpoint_str(ep: &EndpointKind) -> &'static str {
         match ep {
             EndpointKind::EntityOfKind(k) => k,
@@ -100,12 +97,6 @@ mod tests {
     }
 
     /// ADR-076 §D2: no duplicate (relation, source, target) triples in KG_EDGE_RULES.
-    ///
-    /// A duplicated triple would be a no-op additive rule (adding the same endpoint
-    /// pair a second time changes nothing) and is a sign of a copy-paste error.
-    /// Semantic similarity between relations (e.g. multiple relations accepting
-    /// `org→org`) is expected and correct; this test checks only for exact-triple
-    /// duplicates, not for shared per-relation endpoint sets.
     #[test]
     fn kg_pack_edge_rules_contain_no_duplicate_triples() {
         let triples: Vec<(&str, &str, &str)> = KG_EDGE_RULES
@@ -136,13 +127,7 @@ mod tests {
         );
     }
 
-    /// Regression: the KG_EDGE_RULES array has exactly the expected relations.
-    ///
-    /// This is a deliberate-change tripwire over the live KG_EDGE_RULES, complementing
-    /// the ADR-076 §D2 non-redundancy certificate in the certificate test suite.
-    ///
-    /// A change to the set of relations that get pack-level endpoint extensions
-    /// should be a deliberate, reviewed decision — not an accidental side effect.
+    /// Deliberate-change tripwire: KG_EDGE_RULES covers exactly this relation set.
     #[test]
     fn kg_pack_edge_rules_cover_expected_relations() {
         let mut seen: Vec<&str> = KG_EDGE_RULES.iter().map(|r| r.relation.as_str()).collect();

--- a/crates/khive-pack-session/docs/mirror-ingest.md
+++ b/crates/khive-pack-session/docs/mirror-ingest.md
@@ -1,0 +1,319 @@
+# Session mirror ingest — internal notes
+
+Source: `crates/khive-pack-session/src/mirror/ingest.rs`. This guide holds the
+long-form rationale that used to live inline as doc comments on non-public
+items; the `.rs` file keeps only the published contract for `mirror_file` and
+`mirror_chatgpt_export_file` plus short pointers back here.
+
+## Bounded tail-read algorithm (module overview)
+
+`mirror_file` reads new bytes from a JSONL file starting at `start_offset` via
+a buffered, line-at-a-time reader bounded by an internal per-pass byte/event
+cap AND a per-line byte cap, parses complete lines using the parser selected
+by `LineTailSource` (mapped internally to `MirrorSource`), and writes the
+resulting bounded chunk to the session mirror tables in a single transaction.
+A single call processes at most one bounded chunk — never the whole file at
+once — so the caller's polling loop advances the persisted cursor
+incrementally across multiple calls for large deltas. It is safe to call
+repeatedly on the same file; `INSERT OR IGNORE` keyed by the event UUID
+ensures idempotency.
+
+No single line, complete or partial, is ever buffered past
+`MirrorLimits::max_line_bytes` (see `read_line_bounded` below): a complete
+line over that cap is skipped with a `tracing::warn!` naming the file and
+byte offset, and the offset advances past it so ingestion never wedges on one
+oversized line. The pass cap is gated on at least one complete line (blank or
+not) having been consumed, and the cursor is persisted whenever a pass
+durably advances the offset even if it scanned zero parseable events — a long
+run of blank or oversized lines can no longer read to EOF unbounded, nor lose
+its cursor advance.
+
+A line that crosses `max_line_bytes` with no terminating `\n` yet — a
+still-growing file's in-progress final line, or a genuinely truncated /
+corrupt tail — is its own bounded case, distinct from the complete
+(terminated) oversized-line skip above: `read_line_bounded` reports
+`LineRead::OversizedUnterminated` as soon as one bounded read window crosses
+the cap without finding `\n`, instead of scanning onward to EOF looking for
+one. The cursor is intentionally left at that line's start (like an ordinary
+`Partial`), so the next poll — or the next daemon start — repeats the same
+bounded read rather than an unbounded tail scan; once the line eventually
+terminates (or the file stops growing and reaches true EOF mid-line), it
+resolves to the normal `Oversized` skip-and-advance path or stays a bounded
+`Partial`/`OversizedUnterminated` retry, never a full-file read in one call
+(PACKSESSION-AUD-003).
+
+## `MirrorLimits` / per-pass caps
+
+Per-call caps on how much of a file's delta `mirror_file` will read and parse
+before writing a bounded chunk. Production always uses
+`MirrorLimits::production`; tests use a much smaller cap to force multi-pass
+behavior without giant fixtures.
+
+- `MIRROR_MAX_BYTES_PER_PASS` (8 MiB) — ceiling on bytes read per
+  `mirror_file` call in production. Bounds worst-case memory use when a file
+  has accumulated a very large delta (e.g. after daemon downtime or a
+  multi-GB transcript).
+- `MIRROR_MAX_EVENTS_PER_PASS` (1024) — ceiling on parsed events collected
+  per `mirror_file` call in production.
+- `MIRROR_MAX_LINE_BYTES` (= `MIRROR_MAX_BYTES_PER_PASS`) — hard ceiling on a
+  single JSONL line's buffered size in production. Enforced by
+  `read_line_bounded` itself (never appended to past this many bytes),
+  independently of `max_bytes_per_pass` — a single oversized line must not be
+  able to allocate past this bound even as the very first line of a pass
+  (PACKSESSION-AUD-003).
+
+## `LineRead` / `read_line_bounded` — the PACKSESSION-AUD-003 bound
+
+`read_line_bounded` reads one line from `reader` into `buf`, never buffering
+more than `max_line_bytes` regardless of how long the underlying line turns
+out to be.
+
+This is the hard bound behind PACKSESSION-AUD-003: `BufRead::read_until`
+alone appends an entire line to its buffer before any cap check can run, so a
+single arbitrarily large complete line (or a line that starts below a
+per-pass threshold and ends far beyond it) can still allocate without limit
+before the calling loop ever inspects it. Reading via `fill_buf`/`consume`
+directly means a line longer than `max_line_bytes` is never appended to `buf`
+past the cap — bytes beyond it are scanned for `\n` and dropped immediately,
+bounding this function's own resident memory to `max_line_bytes` (plus one
+`BufRead` internal buffer) no matter how long the real line is.
+
+The same bound applies to the number of bytes *read* per call, not just
+buffered: once a line has crossed `max_line_bytes` without a terminating
+`\n`, the very next `fill_buf` window that still has no `\n` returns
+`OversizedUnterminated` immediately rather than looping `fill_buf`/`consume`
+onward in search of one. A line that is oversized but DOES terminate within
+that same window still comes back as `Oversized` (the existing skip-and-advance
+path) — only the no-terminator-in-this-window case is capped early. This
+means one call to `read_line_bounded` never reads more than `max_line_bytes`
+plus one `BufRead` internal buffer for a line with no discoverable `\n`,
+whether that line is still growing (append-in-progress) or truly unterminated
+at EOF — instead of scanning the remainder of the file (or forever, on a
+still-growing file) in a single pass.
+
+`LineRead` variants:
+- `Eof` — EOF with nothing read at all.
+- `Partial` — EOF reached before a terminating `\n`: an incomplete trailing
+  line, left for the next pass. No bytes are considered consumed by the
+  caller, regardless of how large the partial line has already grown.
+- `Complete { bytes }` — a complete line fit within `max_line_bytes`.
+- `Oversized { bytes }` — a complete line exceeded `max_line_bytes` before
+  the newline was found; bytes past the cap were scanned for `\n` and
+  discarded without buffering, so the caller must skip it, not parse `buf`.
+- `OversizedUnterminated { bytes }` — the line has already exceeded
+  `max_line_bytes` and no terminating `\n` has been found yet, but this is
+  NOT end-of-file. Unlike `Oversized`, the caller must not advance past it.
+
+## `read_bounded_chunk` — oversized-line handling
+
+Reads at most one bounded chunk of a file starting at `start_offset`, one
+complete line at a time via a buffered reader — never allocating more than
+`limits.max_line_bytes` for any single line. A partial trailing line (no
+terminating `\n`) is left for the next call.
+
+A complete line whose buffered size would exceed `limits.max_line_bytes` is
+rejected outright: it is never parsed, its bytes are counted and the offset
+advances past it (so ingestion does not wedge on it forever), and a
+`tracing::warn!` names the file and starting byte offset so an operator can
+find and inspect it (PACKSESSION-AUD-003 — no silent coercion).
+
+On `OversizedUnterminated`, the offset is intentionally NOT advanced past
+`line_offset` — the next call re-reads from the same `line_offset` and is
+bounded the same way, whether the file is still growing (a later pass will
+eventually see the terminator and fall into the `Oversized` skip-and-advance
+arm) or genuinely corrupt/truncated (every later poll or daemon restart
+repeats this same bounded read, never an unbounded tail scan).
+
+## ChatGPT export whole-file re-parse (`mirror_chatgpt_export_file`)
+
+Unlike `mirror_file` (append-only line-tail), a ChatGPT export is a single
+static JSON array with no stable "new bytes" boundary to tail, so
+`mirror_chatgpt_export_file` always re-reads and re-parses the whole file.
+`start_offset` is used only as a cheap re-poll guard: if the file has not
+grown past it, nothing is read or parsed. `new_offset` is set to the whole
+file's byte length only after a successful parse and commit — any IO, parse,
+or DB error leaves the persisted cursor untouched, so a partially-downloaded
+export is retried whole on the next tick, never half-consumed.
+
+`DEFAULT_CHATGPT_MAX_BYTES` (256 MiB), overridable via
+`KHIVE_MIRROR_CHATGPT_MAX_BYTES`: unlike the JSONL line-tail sources, this is
+a ceiling on the *entire file*, not a per-pass delta. An export over this
+size is skipped for that pass (loudly logged via `tracing::warn!`, never a
+crash or an unbounded `read_to_string`), and the cursor is left untouched so
+the oversized source keeps being retried — and re-warned — on every later
+tick instead of silently dropping forever (PACKSESSION-AUD-003).
+`chatgpt_max_bytes()` falls back to the default for missing, non-numeric, or
+zero env values (a zero ceiling would skip every export unconditionally,
+which is never useful, so it is treated the same as unset).
+
+## Write path: `write_events_and_cursor` and friends (ADR-099 D5)
+
+`write_events_and_cursor` is shared by `mirror_file`'s eventful line-tail
+path and `mirror_chatgpt_export_file`'s whole-file path, so the
+session/message row construction and cursor semantics (create-only sessions,
+`INSERT OR IGNORE` message dedup, monotonic `last_seen_at`, cursor advances
+only on success) live in exactly one place.
+
+Its closure is verified suspension-free (it drives only `writer` with
+inline-built `SqlStatement`s — session/message INSERTs, the count refresh,
+and the cursor UPDATE — with no embedding, no ANN warming, and no other
+`await` on an external service), so handing it to `atomic_unit` satisfies the
+atomic-unit suspend-free invariant identically on the single-writer and
+flag-off paths. This replaces the standalone `begin_tx` this function used
+before ADR-099: the whole sequence still commits once or rolls back as one
+unit, but no longer opens its own connection outside the writer task.
+
+`write_events_and_cursor_on_writer` is the synchronous-DML body, run inside
+one `atomic_unit` closure. It takes a plain `&mut dyn SqlWriter` (not `&mut
+dyn SqlTransaction`) because `atomic_unit` owns the transaction boundary
+entirely — this function must not, and does not, issue its own
+`BEGIN`/`COMMIT`/`ROLLBACK`. Per-section notes:
+
+- **sessions row (create-only)**: first sight of a session creates the row
+  (`first_seen_at = last_seen_at` = this event's timestamp). Replays are a
+  cheap no-op (`DO NOTHING`), so a pass that inserts no new messages writes
+  no session metadata at all — strict replay idempotency. `last_seen_at` is
+  advanced only when a genuinely new message lands.
+- **session_messages insert**: idempotent via `INSERT OR IGNORE` keyed by the
+  event UUID.
+- **advance session metadata only when a new message landed**: keeps
+  `last_seen_at` monotonic (`MAX`) so a timestamp-missing replay (whose
+  `created_at` fell back to `now_us`) cannot move it forward, and backfills
+  metadata that may have been NULL at create time. A pure replay
+  (`affected == 0`) touches nothing.
+- **refresh message_count for each distinct session**: in practice one file
+  maps to one session_id, but every session_id touched is refreshed to stay
+  correct even if that changes. Skipped entirely on a pure replay
+  (`inserted == 0`) since the counts cannot have changed.
+- **no explicit COMMIT**: `atomic_unit` owns the transaction boundary
+  entirely and commits once the closure returns `Ok`, or rolls back the whole
+  unit on `Err` — the same all-or-nothing contract the old
+  `begin_tx`/`tx.commit()` shape gave, now provided by the seam instead of a
+  manual transaction.
+
+`upsert_cursor_on_writer` issues the one `session_mirror_cursor` upsert
+statement inside the already-open `atomic_unit` transaction — no transaction
+control of its own. `write_cursor_only` is the standalone path used when a
+pass consumed bytes but produced no parseable events (blank/unparseable/
+skipped-oversized lines): it still must persist the advanced offset so the
+next poll does not re-read the same bytes, and a failure here must propagate
+— silently swallowing it would let the cursor and the already-consumed bytes
+drift apart.
+
+## Test suite notes
+
+### PACKSESSION-AUD-003 regression tests
+
+`mirror_file` used to allocate and read the entire file delta in one shot via
+`read_from_offset` (`Vec::with_capacity(file_len - offset)` + `read_to_end`),
+which could OOM or stall the daemon on a very large accumulated delta. The
+regression suite in `ingest.rs`'s `tests` module covers, with a tiny
+test-only byte cap forcing multi-pass behavior instead of giant fixtures:
+
+- **multi-pass bounded reads**: a multi-line file is consumed across multiple
+  bounded passes — each committing its own chunk and cursor advance — never
+  reading the whole file at once.
+- **oversized complete line**: a single complete line larger than
+  `max_line_bytes` must never be fully buffered and parsed — it is rejected
+  outright, the offset advances past it so ingestion does not wedge, and
+  surrounding valid lines in the same pass still land.
+- **line just under cap followed by an oversized line**: the old bound only
+  checked the pass cap before reading another line, so a line that starts
+  under the cap but is followed by one that balloons far beyond it could
+  still get fully buffered via `read_until` before any check ran. The
+  per-line bound must catch this regardless of where in the pass it happens.
+- **oversized-unterminated reads are capped per call**
+  (`CountingReader` — counts every byte pulled through `Read::read` so the
+  test can assert a hard ceiling independent of the backing buffer size): a
+  huge final line with no trailing `\n` used to be scanned all the way to EOF
+  in one `read_line_bounded` call even though the discarded bytes past the
+  cap were never buffered. The READ itself must be bounded too, not just the
+  buffered memory. A small, explicit `BufReader` capacity is used so the
+  bound is provable independent of the platform default (8 KiB).
+- **oversized-unterminated line leaves the cursor at line start and is
+  bounded on retry**: a single huge line with NO trailing newline (a
+  still-growing or corrupt final line) must not advance the cursor, and
+  repeated calls from the same persisted offset must each be bounded, not
+  replay an unbounded scan of the whole file every poll. Once the line
+  eventually completes, it must be recognized as the ordinary
+  complete-oversized-line skip and clear normally.
+- **still-growing partial line under the cap is unaffected**: guards that an
+  ordinary still-growing file whose latest line is under `max_line_bytes` and
+  has no newline yet still behaves as a plain `Partial` — this must not
+  regress from the new oversized-unterminated handling.
+- **large run of blank lines is bounded and persists the cursor**: a run of
+  blank lines used to bypass the pass cap (only nonblank `scanned` lines
+  tripped it) and, when a chunk scanned zero events, the cursor was never
+  persisted even though bytes had durably advanced. Both are fixed: the cap
+  trips on blank lines too, and the cursor is written whenever the pass
+  consumed any bytes.
+- **ChatGPT export over `max_bytes` is skipped without reading**: an export
+  over the configured ceiling must be skipped (not `read_to_string`'d, not
+  parsed, not erroring) and the cursor must stay untouched so the oversized
+  source is retried — and re-warned — on the next tick rather than silently
+  dropped.
+
+### Replay-idempotency invariant
+
+A timestamp-missing event's `created_at` falls back to `now_us`, which
+differs between calls. A pure replay (0 new messages) must NOT advance
+`last_seen_at` or otherwise touch the session row — verified by mirroring a
+no-timestamp line, then re-mirroring from offset 0 and asserting
+`last_seen_at` is byte-identical even though `now_us` has advanced.
+
+### ADR-099 D5 acceptance tests
+
+- **suspension-free under single-writer**: exercises the real production
+  closure (`write_events_and_cursor_on_writer` via `atomic_unit`) over a
+  write-queue-enabled pool built directly (`write_queue_pool` — a bare,
+  file-backed `SqlAccess` handle with no `KhiveRuntime` and no
+  `KHIVE_WRITE_QUEUE` env var, mirroring khive-pack-brain's
+  `fold_gate.rs`/`persist.rs` write-queue-routing tests: `PoolConfig` reads
+  that env var at construction time and it is process-global, so mutating it
+  would race every other test in the binary that calls `KhiveRuntime::new()`
+  — a `PoolConfig` literal with `write_queue_enabled: true` sidesteps that
+  entirely). Proves the actual shipped code never suspends: if it ever did,
+  `block_on_sync` would return the "future suspended" error and the call
+  would fail instead of returning `Ok`.
+- **single-writer concurrency, mandatory**: with the write queue enabled,
+  concurrent session-mirror ingest and normal write traffic through
+  `SqlBridge::writer()` must not contend at `BEGIN IMMEDIATE` — the converted
+  ingest path routes through the single writer task rather than opening its
+  own standalone transaction (the `begin_tx` hole this ADR closes). Uses the
+  same queue-depth + occupier-parked-on-oneshot technique as
+  khive-pack-brain's
+  `fold_gate_apply_routes_through_writer_task_when_flag_enabled` (a
+  wall-clock/timing probe would be indistinguishable from the flag-off
+  fallback, which also serializes via real SQLite file locking): while an
+  occupier deterministically holds the writer task's one drain slot open, the
+  ingest call must appear in the channel's queue depth rather than opening a
+  second, competing standalone `BEGIN IMMEDIATE`.
+- **revert-companion test**: the OLD shape — a closure that issues its own
+  `BEGIN IMMEDIATE` through the writer it was handed, instead of relying on
+  `atomic_unit`'s own transaction — must fail deterministically with a
+  nested-transaction error. This proves the suspension-free /
+  single-transaction-owner assertions above are non-vacuous: the
+  pre-conversion shape (a caller managing its own `BEGIN`/`COMMIT` inside the
+  seam) does NOT silently pass. Built over a write-queue-enabled pool so the
+  closure is deterministically driven through `block_on_sync`'s
+  `InlineWriter` on the real single-writer production path, not the flag-off
+  manual-transaction fallback.
+
+### `test_mid_transaction_db_error_leaves_no_partial_state_and_cursor_unadvanced`
+
+SS6 invariants #4 ("an ingest error never advances the cursor") and #5 ("one
+transaction per file pass") both rest on the same underlying contract
+`write_events_and_cursor` depends on: an `atomic_unit` whose closure returns
+`Err` before its final statement must leave no visible trace of ANY write it
+made in that pass — including the cursor upsert, which runs last, right
+before the closure returns `Ok`.
+
+The real ingest loop can't be driven into a mid-loop DB error through crafted
+event data: the `sessions` insert uses `ON CONFLICT(id) DO NOTHING` and the
+`session_messages` insert uses `INSERT OR IGNORE`, both of which swallow
+constraint violations by design (that's what makes re-ingest idempotent). So
+this test drives the same `atomic_unit`/`writer.execute`/`Err`-return path
+directly — the exact machinery `write_events_and_cursor`'s `?`-propagated
+errors rely on (ADR-099 D5) — and forces a genuine, non-suppressed SQL error
+(a `prepare()` failure on a nonexistent table) after a session write AND a
+cursor advance have already succeeded within the same open unit.

--- a/crates/khive-pack-session/docs/mirror-parse.md
+++ b/crates/khive-pack-session/docs/mirror-parse.md
@@ -1,0 +1,85 @@
+# Session mirror parse — internal notes
+
+Source: `crates/khive-pack-session/src/mirror/parse.rs`. Long-form rationale
+for non-public parsing helpers, relocated out of inline doc comments.
+
+## `parse_chatgpt_export` — DFS walk and per-conversation isolation
+
+Unlike `parse_cc_line`/`parse_codex_line` (one JSONL line in, one event out),
+a ChatGPT export is a single static JSON array of conversation objects — this
+function parses the whole file at once and returns every message-bearing
+event across every conversation it contains.
+
+Returns `None` when `content` is not valid JSON or the top level is not a
+JSON array. The caller treats that as a per-file error so the mirror cursor
+does not advance: a partially-downloaded export is retried whole on the next
+tick, never half-consumed. A malformed *conversation* inside an otherwise-valid
+array is skipped individually (`parse_conversation`) so one bad entry cannot
+sink the rest of the file.
+
+Each conversation's `mapping` forms a tree; events are emitted in
+deterministic DFS preorder from the root, following each node's `children`
+array order (never JSON object key order). Nodes off the `current_node`
+root-to-tip path are flagged `is_sidechain`, mirroring how Claude Code flags
+abandoned/regenerated branches.
+
+## `ConvContext`
+
+Context threaded through node visitation for one conversation — the pieces
+that don't change as the DFS walks the mapping tree: `mapping`,
+`current_path` (the current-node root-to-tip set), `session_id`,
+`conv_created_at_micros` (conversation-level `create_time` in micros, 0 if
+absent — the fallback used when a message's own `create_time` is
+null/absent), and `slug`.
+
+## `parse_conversation`
+
+Parses one ChatGPT export conversation object, appending its message-bearing
+nodes (deterministic DFS preorder from the mapping root) to `out`. Skips the
+whole conversation on a missing/empty `id` or missing `mapping` so one
+malformed entry cannot sink the rest of the file.
+
+- **current-path set**: walks `current_node` → `parent` → ... → root. Off-path
+  nodes (abandoned/regenerated branches) are flagged `is_sidechain`, mirroring
+  how Claude Code flags sidechains. A cycle guard (`current_path.insert`
+  returning `false`) protects against malformed mapping data.
+- **DFS preorder from the root, following `children` order**: uses an
+  explicit stack, not recursion — a long linear conversation can nest
+  thousands of turns deep and would risk overflowing a worker-thread stack.
+  Children are pushed in reverse so the first child in the array is popped
+  (and thus visited) first, preserving `children` order as preorder.
+
+## `build_chatgpt_event`
+
+Builds a `ParsedEvent` for a single message-bearing mapping node. Returns
+`None` when the message carries no `id`, or when the extracted text is
+empty/whitespace-only (ChatGPT scaffolding nodes, e.g. system prompts with
+`parts: [""]`).
+
+`parent_uuid` is `Some(parent_node_id)` only when that parent node itself
+carries a (non-null) message — the ChatGPT root is normally `message: null`,
+so its children correctly get `parent_uuid: None`. A parent that DOES carry a
+message but was itself skipped as an event (e.g. empty-parts scaffolding)
+still counts — this is provenance linkage, matching how CC parent chains can
+reference events that were never mirrored.
+
+## `extract_text` / `extract_block` (Claude Code + Codex block extraction)
+
+`extract_text` handles both the string form and the structured-block array
+form of a message `content` value.
+
+`extract_block` extracts a display string from a single content block:
+- `"text"` — Claude Code plain text block.
+- `"input_text"` / `"output_text"` — Codex user and assistant text blocks
+  (same field, `text`, as the Claude Code `"text"` block, hence shared
+  extraction logic).
+- `"tool_use"` — tool invocation (name + input JSON, truncated to 500 chars).
+- `"tool_result"` — tool output (content string, truncated to 500 chars).
+
+## `extract_chatgpt_text`
+
+Extracts display text from a ChatGPT message `content` object per its
+`content_type`: for `"text"`, joins string `parts` with `"\n"` (non-string
+parts ignored defensively); for anything else (`"code"`, `"execution_output"`,
+…), prefers `content.text` if present, else falls back to joined string
+`parts`, else `None`.

--- a/crates/khive-pack-session/src/mirror/ingest.rs
+++ b/crates/khive-pack-session/src/mirror/ingest.rs
@@ -1,39 +1,14 @@
 //! Idempotent file tail + upsert into the session mirror tables.
 //!
-//! `mirror_file` reads new bytes from a JSONL file starting at `start_offset`
-//! via a buffered, line-at-a-time reader bounded by an internal per-pass
-//! byte/event cap AND a per-line byte cap, parses complete lines using the
-//! parser selected by [`LineTailSource`] (mapped internally to
-//! [`MirrorSource`]), and writes the resulting bounded chunk to the session
-//! mirror tables in a single transaction.  A single call processes at most
-//! one bounded chunk — never the whole file at once — so the caller's
-//! polling loop advances the persisted cursor incrementally across multiple
-//! calls for large deltas.  It is safe to call repeatedly on the same file;
-//! `INSERT OR IGNORE` keyed by the event UUID ensures idempotency.
+//! `mirror_file` reads new bytes from a JSONL file starting at `start_offset`,
+//! parses complete lines via the parser selected by [`LineTailSource`], and
+//! writes one bounded chunk (never the whole file at once) to the session
+//! mirror tables per call — callers poll repeatedly to drain large deltas.
+//! `INSERT OR IGNORE` keyed by the event UUID makes replays idempotent.
 //!
-//! No single line, complete or partial, is ever buffered past
-//! `MirrorLimits::max_line_bytes` (see `read_line_bounded`): a complete
-//! line over that cap is skipped with a `tracing::warn!` naming the file and
-//! byte offset, and the offset advances past it so ingestion never wedges on
-//! one oversized line. The pass cap is gated on at least one complete line
-//! (blank or not) having been consumed, and the cursor is persisted whenever
-//! a pass durably advances the offset even if it scanned zero parseable
-//! events — a long run of blank or oversized lines can no longer read to EOF
-//! unbounded, nor lose its cursor advance.
-//!
-//! A line that crosses `max_line_bytes` with no terminating `\n` yet — a
-//! still-growing file's in-progress final line, or a genuinely truncated /
-//! corrupt tail — is its own bounded case, distinct from the complete
-//! (terminated) oversized-line skip above: `read_line_bounded` reports
-//! `LineRead::OversizedUnterminated` as soon as one bounded read window
-//! crosses the cap without finding `\n`, instead of scanning onward to EOF
-//! looking for one. The cursor is intentionally left at that line's start
-//! (like an ordinary `Partial`), so the next poll — or the next daemon
-//! start — repeats the same bounded read rather than an unbounded tail
-//! scan; once the line eventually terminates (or the file stops growing and
-//! reaches true EOF mid-line), it resolves to the normal `Oversized`
-//! skip-and-advance path or stays a bounded `Partial`/`OversizedUnterminated`
-//! retry, never a full-file read in one call (PACKSESSION-AUD-003).
+//! See `crates/khive-pack-session/docs/mirror-ingest.md` for the full bounded
+//! tail-read algorithm, the oversized/unterminated-line handling
+//! (PACKSESSION-AUD-003), and the write-path (ADR-099 D5) rationale.
 
 use std::io::{BufRead, Seek, SeekFrom};
 use std::path::{Path, PathBuf};
@@ -109,25 +84,21 @@ pub struct MirrorStats {
     pub new_offset: u64,
 }
 
-/// Ceiling on bytes read per `mirror_file` call in production. Bounds worst-case
-/// memory use when a file has accumulated a very large delta (e.g. after daemon
-/// downtime or a multi-GB transcript).
+/// Ceiling on bytes read per `mirror_file` call in production (8 MiB); bounds
+/// worst-case memory on a very large accumulated delta. See
+/// `crates/khive-pack-session/docs/mirror-ingest.md#mirrorlimits--per-pass-caps`.
 const MIRROR_MAX_BYTES_PER_PASS: usize = 8 * 1024 * 1024;
 
 /// Ceiling on parsed events collected per `mirror_file` call in production.
 const MIRROR_MAX_EVENTS_PER_PASS: usize = 1024;
 
-/// Hard ceiling on a single JSONL line's buffered size in production. This is
-/// enforced by `read_line_bounded` itself (never appended to past this many
-/// bytes), independently of `max_bytes_per_pass` — a single oversized line
-/// must not be able to allocate past this bound even as the very first line
-/// of a pass (PACKSESSION-AUD-003).
+/// Hard ceiling on a single JSONL line's buffered size, enforced by
+/// `read_line_bounded` independently of `max_bytes_per_pass` (PACKSESSION-AUD-003).
 const MIRROR_MAX_LINE_BYTES: usize = MIRROR_MAX_BYTES_PER_PASS;
 
-/// Per-call caps on how much of a file's delta `mirror_file` will read and
-/// parse before writing a bounded chunk. Production always uses
-/// [`MirrorLimits::production`]; tests use a much smaller cap to force
-/// multi-pass behavior without giant fixtures.
+/// Per-call caps on how much of a file's delta `mirror_file` reads/parses
+/// before writing a bounded chunk; tests use smaller caps to force multi-pass
+/// behavior without giant fixtures.
 #[derive(Clone, Copy, Debug)]
 struct MirrorLimits {
     max_bytes_per_pass: usize,
@@ -181,78 +152,36 @@ pub async fn mirror_file(
 }
 
 /// A single bounded read pass: at most `limits.max_bytes_per_pass` bytes and
-/// `limits.max_events_per_pass` parsed events, always stopping on a complete
-/// line boundary.
+/// `limits.max_events_per_pass` parsed events, stopping on a line boundary.
 struct MirrorChunk {
     events: Vec<parse::ParsedEvent>,
-    /// Complete, nonblank, non-oversized lines that were handed to the
-    /// per-source parser (whether or not the parser returned an event).
     scanned: u64,
     new_offset: u64,
 }
 
-/// Outcome of `read_line_bounded` for one line.
+/// Outcome of `read_line_bounded` for one line. See
+/// `crates/khive-pack-session/docs/mirror-ingest.md#lineread--read_line_bounded--the-packsession-aud-003-bound`
+/// for the full PACKSESSION-AUD-003 rationale.
 #[derive(Debug)]
 enum LineRead {
     /// EOF with nothing read at all.
     Eof,
-    /// EOF reached before a terminating `\n`: an incomplete trailing line,
-    /// left for the next pass. No bytes are considered consumed by the
-    /// caller (the offset does not advance), regardless of how large the
-    /// partial line has already grown.
+    /// EOF before a terminating `\n`; caller must not advance past it.
     Partial,
-    /// A complete line (through the terminating `\n`) fit within
-    /// `max_line_bytes`; `buf` holds the full line including the `\n`.
-    /// `bytes` is the total bytes consumed from the reader, used to advance
-    /// the caller's byte offset.
+    /// A complete line fit within `max_line_bytes`.
     Complete { bytes: usize },
-    /// A complete line (through the terminating `\n`) exceeded
-    /// `max_line_bytes` before the newline was found. `buf` was never fully
-    /// populated — bytes past the cap were scanned for `\n` and discarded
-    /// without buffering — so the caller must skip it, not parse `buf`.
-    /// `bytes` is the total bytes consumed from the reader.
+    /// A complete line exceeded `max_line_bytes`; caller must skip it, not
+    /// parse `buf` (never fully populated for this case).
     Oversized { bytes: usize },
-    /// The line has already exceeded `max_line_bytes` and no terminating
-    /// `\n` has been found yet, but this is NOT end-of-file — there may be
-    /// more bytes (a still-growing file) or a genuinely unterminated tail.
-    /// Unlike `Oversized`, the caller must not advance past it: `bytes` is
-    /// reported for logging only, and the reader is intentionally not
-    /// exhausted any further this call. This is the hard bound behind
-    /// PACKSESSION-AUD-003 — the loop below returns as soon as one
-    /// `fill_buf` window crosses the cap without a `\n`, instead of looping
-    /// `fill_buf`/`consume` all the way to EOF searching for a terminator
-    /// that may never come.
+    /// Exceeded `max_line_bytes` with no `\n` found yet, and NOT at EOF.
+    /// Unlike `Oversized`, the caller must not advance past it.
     OversizedUnterminated { bytes: usize },
 }
 
-/// Read one line from `reader` into `buf`, never buffering more than
-/// `max_line_bytes` regardless of how long the underlying line turns out to
-/// be.
-///
-/// This is the hard bound behind PACKSESSION-AUD-003: `BufRead::read_until`
-/// alone appends an entire line to its buffer before any cap check can run,
-/// so a single arbitrarily large complete line (or a line that starts below
-/// a per-pass threshold and ends far beyond it) can still allocate without
-/// limit before the calling loop ever inspects it. Reading via `fill_buf`/
-/// `consume` directly means a line longer than `max_line_bytes` is never
-/// appended to `buf` past the cap — bytes beyond it are scanned for `\n` and
-/// dropped immediately, bounding this function's own resident memory to
-/// `max_line_bytes` (plus one `BufRead` internal buffer) no matter how long
-/// the real line is.
-///
-/// The same bound applies to the number of bytes *read* per call, not just
-/// buffered (PACKSESSION-AUD-003): once a line has crossed
-/// `max_line_bytes` without a terminating `\n`, the very next `fill_buf`
-/// window that still has no `\n` returns `OversizedUnterminated` immediately
-/// rather than looping `fill_buf`/`consume` onward in search of one. A line
-/// that is oversized but DOES terminate within that same window still comes
-/// back as `Oversized` (the existing skip-and-advance path) — only the
-/// no-terminator-in-this-window case is capped early. This means one call to
-/// `read_line_bounded` never reads more than `max_line_bytes` plus one
-/// `BufRead` internal buffer for a line with no discoverable `\n`, whether
-/// that line is still growing (append-in-progress) or truly unterminated at
-/// EOF — instead of scanning the remainder of the file (or forever, on a
-/// still-growing file) in a single pass.
+/// Read one line from `reader` into `buf`, never buffering — or reading —
+/// more than `max_line_bytes` regardless of how long the underlying line
+/// turns out to be (the PACKSESSION-AUD-003 bound; see the docs guide above
+/// for why `BufRead::read_until` alone is unsafe here).
 fn read_line_bounded(
     reader: &mut impl BufRead,
     buf: &mut Vec<u8>,
@@ -305,16 +234,11 @@ fn read_line_bounded(
     }
 }
 
-/// Read at most one bounded chunk of `path` starting at `start_offset`, one
-/// complete line at a time via a buffered reader — never allocating more than
-/// `limits.max_line_bytes` for any single line. A partial trailing line (no
-/// terminating `\n`) is left for the next call.
-///
-/// A complete line whose buffered size would exceed `limits.max_line_bytes`
-/// is rejected outright: it is never parsed, its bytes are counted and the
-/// offset advances past it (so ingestion does not wedge on it forever), and
-/// a `tracing::warn!` names the file and starting byte offset so an operator
-/// can find and inspect it (PACKSESSION-AUD-003 — no silent coercion).
+/// Read at most one bounded chunk of `path` starting at `start_offset`. A
+/// complete line whose buffered size exceeds `limits.max_line_bytes` is
+/// skipped outright (bytes counted, offset advances past it, `tracing::warn!`
+/// names the file/offset — PACKSESSION-AUD-003, no silent coercion); a
+/// partial trailing line is left for the next call.
 fn read_bounded_chunk(
     path: &Path,
     start_offset: u64,
@@ -478,24 +402,18 @@ async fn mirror_file_with_limits(
     .await
 }
 
-/// Default ceiling on the byte length of a ChatGPT export `conversations.json`
-/// file read in one [`mirror_chatgpt_export_file`] pass. Overridable via
-/// `KHIVE_MIRROR_CHATGPT_MAX_BYTES` (see `chatgpt_max_bytes`).
-///
-/// Unlike the JSONL line-tail sources, a ChatGPT export has no incremental
-/// "new bytes" boundary — it is always read and parsed whole (see the
-/// function doc below) — so this is a ceiling on the *entire file*, not a
-/// per-pass delta. An export over this size is skipped for that pass
-/// (loudly logged via `tracing::warn!`, never a crash or an unbounded
-/// `read_to_string`), and the cursor is left untouched so the oversized
-/// source keeps being retried — and re-warned — on every later tick instead
-/// of silently dropping forever (PACKSESSION-AUD-003).
+/// Default ceiling (256 MiB) on a ChatGPT export `conversations.json` file
+/// read in one [`mirror_chatgpt_export_file`] pass — a ceiling on the entire
+/// file, not a per-pass delta (unlike the JSONL line-tail sources). An export
+/// over this size is skipped (warn-logged) and the cursor is left untouched
+/// so it is retried on every later tick rather than dropped (PACKSESSION-AUD-003).
+/// See `crates/khive-pack-session/docs/mirror-ingest.md#chatgpt-export-whole-file-re-parse-mirror_chatgpt_export_file`.
 const DEFAULT_CHATGPT_MAX_BYTES: u64 = 256 * 1024 * 1024;
 
 /// Resolve the ChatGPT export size ceiling from `KHIVE_MIRROR_CHATGPT_MAX_BYTES`,
 /// falling back to [`DEFAULT_CHATGPT_MAX_BYTES`] for missing, non-numeric, or
-/// zero values (a zero ceiling would skip every export unconditionally,
-/// which is never useful, so it is treated the same as unset).
+/// zero values (zero would skip every export unconditionally, so it is
+/// treated the same as unset).
 fn chatgpt_max_bytes() -> u64 {
     std::env::var("KHIVE_MIRROR_CHATGPT_MAX_BYTES")
         .ok()
@@ -505,23 +423,20 @@ fn chatgpt_max_bytes() -> u64 {
 }
 
 /// Read the whole ChatGPT export `conversations.json` at `path`, parse every
-/// conversation's mapping tree via [`parse::parse_chatgpt_export`], and upsert
-/// every message-bearing event idempotently into the session mirror tables in
-/// a single transaction.
+/// conversation's mapping tree via [`parse::parse_chatgpt_export`], and
+/// upsert every message-bearing event idempotently into the session mirror
+/// tables in a single transaction. Unlike `mirror_file`, this always
+/// re-reads and re-parses the whole file (a ChatGPT export has no stable
+/// "new bytes" boundary to tail) — `start_offset` is only a cheap
+/// re-poll guard: if the file has not grown past it, nothing is read.
 ///
-/// Unlike `mirror_file` (append-only line-tail), a ChatGPT export is a single
-/// static JSON array with no stable "new bytes" boundary to tail, so this
-/// function always re-reads and re-parses the whole file. `start_offset` is
-/// used only as a cheap re-poll guard: if the file has not grown past it,
-/// nothing is read or parsed. `new_offset` is set to the whole file's byte
-/// length only after a successful parse and commit — any IO, parse, or DB
-/// error leaves the persisted cursor untouched, so a partially-downloaded
-/// export is retried whole on the next tick, never half-consumed.
-///
-/// Before reading, the file is checked against `chatgpt_max_bytes`: an
-/// export over that ceiling is skipped (warn-logged) without ever calling
-/// `read_to_string`, so a very large export cannot materialize its full
-/// content (and, downstream, a full `Vec` of parsed events) in one pass.
+/// `new_offset` is set to the whole file's byte length only after a
+/// successful parse and commit; any IO, parse, or DB error leaves the
+/// persisted cursor untouched, so a partially-downloaded export is retried
+/// whole on the next tick, never half-consumed. An export over
+/// `chatgpt_max_bytes` is skipped (warn-logged) without ever calling
+/// `read_to_string`. See the docs guide linked above `chatgpt_max_bytes`
+/// for the full rationale.
 pub async fn mirror_chatgpt_export_file(
     runtime: &KhiveRuntime,
     path: &Path,
@@ -594,12 +509,10 @@ async fn mirror_chatgpt_export_file_with_max_bytes(
 }
 
 /// Upsert `events` and the mirror cursor for `path` in one transaction.
-///
-/// Shared by `mirror_file`'s eventful line-tail path and
-/// `mirror_chatgpt_export_file`'s whole-file path, so the session/message row
-/// construction and cursor semantics (create-only sessions, `INSERT OR
-/// IGNORE` message dedup, monotonic `last_seen_at`, cursor advances only on
-/// success) live in exactly one place.
+/// Shared by `mirror_file`'s line-tail path and `mirror_chatgpt_export_file`'s
+/// whole-file path. See
+/// `crates/khive-pack-session/docs/mirror-ingest.md#write-path-write_events_and_cursor-and-friends-adr-099-d5`
+/// for the ADR-099 D5 suspension-free rationale.
 async fn write_events_and_cursor(
     runtime: &KhiveRuntime,
     path: &Path,
@@ -611,16 +524,6 @@ async fn write_events_and_cursor(
     let now_us = Utc::now().timestamp_micros();
     let sql = runtime.sql();
 
-    // ADR-099 D5: this closure is verified suspension-free (it drives only
-    // `writer` with inline-built `SqlStatement`s — session/message INSERTs,
-    // the count refresh, and the cursor UPDATE — with no embedding, no ANN
-    // warming, and no other `await` on an external service), so handing it
-    // to `atomic_unit` satisfies the atomic-unit suspend-free invariant
-    // (`SqlAccess::atomic_unit`'s doc comment) identically on the
-    // single-writer and flag-off paths. This replaces the standalone
-    // `begin_tx` this function used before ADR-099: the whole sequence
-    // still commits once or rolls back as one unit, but no longer opens its
-    // own connection outside the writer task.
     let events_owned: Vec<parse::ParsedEvent> = events.to_vec();
     let path_owned: PathBuf = path.to_path_buf();
 
@@ -658,11 +561,10 @@ async fn write_events_and_cursor(
 }
 
 /// The synchronous-DML body of `write_events_and_cursor`, run inside one
-/// `atomic_unit` closure (see that function's doc comment for the
-/// suspension-free justification). Takes a plain `&mut dyn SqlWriter`
-/// (not `&mut dyn SqlTransaction`) because `atomic_unit` owns the
-/// transaction boundary entirely — this function must not, and does not,
-/// issue its own `BEGIN`/`COMMIT`/`ROLLBACK`.
+/// `atomic_unit` closure. Takes a plain `&mut dyn SqlWriter` (not `&mut dyn
+/// SqlTransaction`) because `atomic_unit` owns the transaction boundary
+/// entirely — this function must not, and does not, issue its own
+/// `BEGIN`/`COMMIT`/`ROLLBACK`.
 async fn write_events_and_cursor_on_writer(
     writer: &mut dyn SqlWriter,
     path: &Path,
@@ -682,13 +584,8 @@ async fn write_events_and_cursor_on_writer(
             now_us
         };
 
-        // ── sessions row: create-only ─────────────────────────────────────────
-        //
-        // First sight of a session creates the row (first_seen_at = last_seen_at =
-        // this event's timestamp). Replays are a cheap no-op (`DO NOTHING`), so a
-        // pass that inserts no new messages writes no session metadata at all —
-        // strict replay idempotency. `last_seen_at` is advanced below, but only
-        // when a genuinely new message lands.
+        // sessions row: create-only (see docs guide — replay is a no-op via
+        // `DO NOTHING`; `last_seen_at` advances below only on a new message).
         writer
             .execute(SqlStatement {
                 sql: format!(
@@ -726,7 +623,7 @@ async fn write_events_and_cursor_on_writer(
                 )
             })?;
 
-        // ── session_messages insert (idempotent) ──────────────────────────────
+        // session_messages insert, idempotent via INSERT OR IGNORE.
         let affected = writer
             .execute(SqlStatement {
                 sql: "INSERT OR IGNORE INTO session_messages \
@@ -767,12 +664,9 @@ async fn write_events_and_cursor_on_writer(
                 )
             })?;
 
-        // ── advance session metadata ONLY when a new message landed ────────────
-        //
-        // Keeps `last_seen_at` monotonic (`MAX`) so a timestamp-missing replay
-        // (whose `created_at` fell back to `now_us`) cannot move it forward, and
-        // backfills metadata that may have been NULL at create time. A pure
-        // replay (`affected == 0`) touches nothing.
+        // Advance session metadata only when a new message landed — keeps
+        // last_seen_at monotonic (MAX) and backfills NULL metadata; a pure
+        // replay (affected == 0) touches nothing (see docs guide).
         if affected > 0 {
             writer
                 .execute(SqlStatement {
@@ -815,12 +709,8 @@ async fn write_events_and_cursor_on_writer(
         last_session_id = Some(ev.session_id.clone());
     }
 
-    // ── refresh message_count for each distinct session ───────────────────────
-    //
-    // In practice one file maps to one session_id, but we refresh every
-    // session_id we touched to stay correct even if that changes. Skipped
-    // entirely on a pure replay (`inserted == 0`): the counts cannot have
-    // changed, so writing them would be needless churn.
+    // Refresh message_count for each distinct session touched; skipped on a
+    // pure replay (inserted == 0) since counts cannot have changed.
     if inserted > 0 {
         let mut seen_sessions: Vec<String> = events
             .iter()
@@ -853,13 +743,8 @@ async fn write_events_and_cursor_on_writer(
 
     upsert_cursor_on_writer(writer, path, last_session_id.as_deref(), new_offset, now_us).await?;
 
-    // ── commit ────────────────────────────────────────────────────────────────
-    //
-    // No explicit COMMIT here: `atomic_unit` owns the transaction boundary
-    // entirely (see this function's doc comment) and commits once this
-    // closure returns `Ok`, or rolls back the whole unit on `Err` — the
-    // same all-or-nothing contract the old `begin_tx`/`tx.commit()` shape
-    // gave, now provided by the seam instead of a manual transaction.
+    // No explicit COMMIT: `atomic_unit` owns the transaction boundary and
+    // commits on `Ok` / rolls back the whole unit on `Err`.
     Ok(MirrorStats {
         inserted,
         scanned,
@@ -868,9 +753,8 @@ async fn write_events_and_cursor_on_writer(
 }
 
 /// Upsert the `session_mirror_cursor` row for `path` inside the open
-/// `atomic_unit` transaction. Takes `&mut dyn SqlWriter` (see
-/// `write_events_and_cursor_on_writer`'s doc comment) — it issues only the
-/// one cursor DML statement, no transaction control of its own.
+/// `atomic_unit` transaction — issues only the one cursor DML statement, no
+/// transaction control of its own.
 async fn upsert_cursor_on_writer(
     writer: &mut dyn SqlWriter,
     path: &Path,
@@ -910,8 +794,10 @@ async fn upsert_cursor_on_writer(
     Ok(())
 }
 
-/// Write only the cursor row (no events).  Used when there are no parseable
-/// events so the offset still advances past blank/unparseable content.
+/// Write only the cursor row (no events); used when a pass consumed bytes
+/// but produced no parseable events, so the offset still advances past
+/// blank/unparseable content. A failure here must propagate — see
+/// `crates/khive-pack-session/docs/mirror-ingest.md#write-path-write_events_and_cursor-and-friends-adr-099-d5`.
 async fn write_cursor_only(
     runtime: &KhiveRuntime,
     path: &Path,
@@ -949,8 +835,6 @@ async fn write_cursor_only(
     Ok(())
 }
 
-// ── integration tests ─────────────────────────────────────────────────────────
-
 #[cfg(test)]
 mod tests {
     use std::io::Write;
@@ -965,13 +849,9 @@ mod tests {
     use super::*;
     use crate::vocab::SESSION_SCHEMA_PLAN_STMTS;
 
-    /// Build a file-backed runtime and apply the session schema.
-    ///
-    /// File-backed so tests exercise the same `atomic_unit` single-writer
-    /// path (`mirror_file` → `write_events_and_cursor` → `atomic_unit`,
-    /// ADR-099 D5) production runs against — an in-memory pool would take
-    /// `atomic_unit`'s pool-backed manual-transaction branch instead. The
-    /// caller must keep the returned `TempDir` alive for the test.
+    /// Build a file-backed runtime (exercises the real `atomic_unit`
+    /// single-writer path) and apply the session schema. Caller must keep
+    /// the returned `TempDir` alive.
     async fn setup() -> (KhiveRuntime, TempDir) {
         let dir = TempDir::new().expect("tempdir");
         let db_path = dir.path().join("test.db");
@@ -1130,13 +1010,7 @@ mod tests {
 
     #[tokio::test]
     async fn mirror_file_respects_low_test_cap_and_advances_over_multiple_passes() {
-        // Regression for PACKSESSION-AUD-003: `mirror_file` used to allocate
-        // and read the entire file delta in one shot via `read_from_offset`
-        // (`Vec::with_capacity(file_len - offset)` + `read_to_end`), which
-        // could OOM or stall the daemon on a very large accumulated delta.
-        // With a tiny test-only byte cap, a multi-line file must now be
-        // consumed across multiple bounded passes — each committing its own
-        // chunk and cursor advance — never reading the whole file at once.
+        // PACKSESSION-AUD-003 regression: multi-pass bounded reads (see docs guide).
         let (rt, _dir) = setup().await;
 
         let lines: Vec<String> = (0..6)
@@ -1233,11 +1107,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_oversized_line_is_skipped_and_offset_advances() {
-        // Regression for PACKSESSION-AUD-003 (High): a single complete line
-        // larger than `max_line_bytes` must never be fully buffered and
-        // parsed — it must be rejected outright, with the offset advancing
-        // past it so ingestion does not wedge, and surrounding valid lines
-        // in the same pass still land.
+        // PACKSESSION-AUD-003 regression: oversized complete line (see docs guide).
         let (rt, _dir) = setup().await;
 
         let small1 = user_line("uuid-small1", "sess-OV", "ok");
@@ -1287,12 +1157,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_line_just_under_cap_then_oversized_next_line_is_bounded() {
-        // Regression for PACKSESSION-AUD-003 (High): the old bound only
-        // checked the pass cap before reading another line, so a line that
-        // starts under the cap but is followed by one that balloons far
-        // beyond it could still get fully buffered via `read_until` before
-        // any check ran. The per-line bound must catch this regardless of
-        // where in the pass it happens.
+        // PACKSESSION-AUD-003 regression: under-cap line followed by an
+        // oversized one (see docs guide).
         let (rt, _dir) = setup().await;
 
         let max_line_bytes: usize = 256;
@@ -1342,10 +1208,8 @@ mod tests {
         assert_eq!(count_rows(&rt, "session_messages").await, 1);
     }
 
-    /// Counts every byte pulled through `Read::read`, so a test can assert a
-    /// hard ceiling on how much of the underlying source `read_line_bounded`
-    /// ever touches in one call — independent of how large the backing
-    /// buffer actually is.
+    /// Counts every byte pulled through `Read::read`, for asserting a hard
+    /// ceiling on `read_line_bounded`'s reads independent of buffer size.
     struct CountingReader<R> {
         inner: R,
         total_read: std::rc::Rc<std::cell::Cell<usize>>,
@@ -1361,13 +1225,8 @@ mod tests {
 
     #[test]
     fn test_read_line_bounded_oversized_unterminated_reads_are_capped_per_call() {
-        // Regression for PACKSESSION-AUD-003: a huge final
-        // line with no trailing `\n` used to be scanned all the way to EOF
-        // in one `read_line_bounded` call (`fill_buf`/`consume` looped until
-        // the reader ran dry), even though the discarded bytes past the cap
-        // were never buffered. The READ itself must be bounded too, not just
-        // the buffered memory. Use a small, explicit `BufReader` capacity so
-        // the bound is provable independent of the platform default (8KiB).
+        // PACKSESSION-AUD-003 regression: oversized-unterminated reads are
+        // capped per call, not just per buffered byte (see docs guide).
         let max_line_bytes: usize = 64;
         let buf_capacity: usize = 256;
         // Far larger than max_line_bytes + a handful of buffer refills, and
@@ -1416,11 +1275,8 @@ mod tests {
     #[tokio::test]
     async fn test_oversized_unterminated_line_leaves_cursor_at_line_start_and_is_bounded_on_retry()
     {
-        // Regression for PACKSESSION-AUD-003: a single huge
-        // line with NO trailing newline (a still-growing or corrupt final
-        // line) must not advance the cursor, and repeated calls from the
-        // same persisted offset must each be bounded, not replay an
-        // unbounded scan of the whole file every poll.
+        // PACKSESSION-AUD-003 regression: unterminated-oversized-line cursor
+        // handling and bounded retry (see docs guide).
         let (rt, _dir) = setup().await;
 
         let max_line_bytes: usize = 256;
@@ -1512,11 +1368,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_still_growing_partial_line_under_cap_is_unaffected() {
-        // Guard: an ordinary still-growing file whose latest line is under
-        // `max_line_bytes` and has no newline YET must still behave as a
-        // plain `Partial` — cursor does not advance past it, and once the
-        // line completes on a later pass it is picked up normally. This
-        // must not regress from the new oversized-unterminated handling.
+        // Guard: still-growing partial line under the cap must not regress
+        // from the oversized-unterminated handling (see docs guide).
         let (rt, _dir) = setup().await;
 
         let small1 = user_line("uuid-g1", "sess-GROW", "first");
@@ -1564,12 +1417,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_large_run_of_blank_lines_is_bounded_and_persists_cursor() {
-        // Regression for PACKSESSION-AUD-003 (Medium): a run of blank lines
-        // used to bypass the pass cap (only nonblank `scanned` lines tripped
-        // it) and, when a chunk scanned zero events, the cursor was never
-        // persisted even though bytes had durably advanced. Both must be
-        // fixed: the cap must trip on blank lines too, and the cursor must
-        // be written whenever the pass consumed any bytes.
+        // PACKSESSION-AUD-003 regression: blank-line runs are bounded and the
+        // cursor persists on every durable advance (see docs guide).
         let (rt, _dir) = setup().await;
 
         let mut file = NamedTempFile::new().expect("tmpfile");
@@ -1721,10 +1570,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_replay_does_not_mutate_session_metadata() {
-        // Regression for the replay-idempotency finding: a timestamp-missing
-        // event's `created_at` falls back to `now_us`, which differs between
-        // calls. A pure replay (0 new messages) must NOT advance `last_seen_at`
-        // or otherwise touch the session row.
+        // Replay-idempotency regression (see docs guide): a pure replay must
+        // not advance last_seen_at.
         let (rt, _dir) = setup().await;
 
         let line = user_line_no_ts("uuid-nts", "sess-NTS", "no timestamp here");
@@ -1781,9 +1628,9 @@ mod tests {
 
     // ── Codex source integration tests ────────────────────────────────────────
 
-    /// Build a minimal Codex response_item/message line. Block type mirrors the
-    /// real shape: `input_text` for user messages, `output_text` for assistant
-    /// messages (the generic `text` type does not occur in real Codex transcripts).
+    /// Build a minimal Codex response_item/message line (`input_text` for
+    /// user, `output_text` for assistant — the generic `text` type does not
+    /// occur in real Codex transcripts).
     fn codex_message_line(role: &str, text: &str) -> String {
         let block_type = if role == "assistant" {
             "output_text"
@@ -2370,11 +2217,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_chatgpt_export_over_max_bytes_is_skipped_without_reading() {
-        // Regression for PACKSESSION-AUD-003 (Medium, "adjacent unbounded
-        // external-file path"): an export over the configured ceiling must
-        // be skipped (not `read_to_string`'d, not parsed, not erroring) and
-        // the cursor must stay untouched so the oversized source is retried
-        // — and re-warned — on the next tick rather than silently dropped.
+        // PACKSESSION-AUD-003 regression: oversized ChatGPT exports are
+        // skipped without reading (see docs guide).
         let (rt, _dir) = setup().await;
         let (_file, path) = write_export_file("[]");
 
@@ -2480,24 +2324,10 @@ mod tests {
         );
     }
 
-    /// SS6 invariants #4 ("an ingest error never advances the cursor") and #5
-    /// ("one transaction per file pass") both rest on the same underlying
-    /// contract `write_events_and_cursor` depends on: an `atomic_unit` whose
-    /// closure returns `Err` before its final statement must leave no
-    /// visible trace of ANY write it made in that pass — including the
-    /// cursor upsert, which runs last, right before the closure returns
-    /// `Ok`.
-    ///
-    /// The real ingest loop can't be driven into a mid-loop DB error through
-    /// crafted event data: the `sessions` insert uses `ON CONFLICT(id) DO
-    /// NOTHING` and the `session_messages` insert uses `INSERT OR IGNORE`,
-    /// both of which swallow constraint violations by design (that's what
-    /// makes re-ingest idempotent). So this test drives the same
-    /// `atomic_unit`/`writer.execute`/`Err`-return path directly — the exact
-    /// machinery `write_events_and_cursor`'s `?`-propagated errors rely on
-    /// (ADR-099 D5) — and forces a genuine, non-suppressed SQL error (a
-    /// `prepare()` failure on a nonexistent table) after a session write AND
-    /// a cursor advance have already succeeded within the same open unit.
+    /// SS6 invariants #4/#5 (error never advances cursor; one transaction per
+    /// pass) — see
+    /// `crates/khive-pack-session/docs/mirror-ingest.md#test_mid_transaction_db_error_leaves_no_partial_state_and_cursor_unadvanced`
+    /// for why this drives `atomic_unit` directly instead of through crafted event data.
     #[tokio::test]
     async fn test_mid_transaction_db_error_leaves_no_partial_state_and_cursor_unadvanced() {
         let (rt, _dir) = setup().await;
@@ -2560,16 +2390,9 @@ mod tests {
         );
     }
 
-    /// Build a bare, file-backed, write-queue-enabled `SqlAccess` handle —
-    /// no `KhiveRuntime`, no `KHIVE_WRITE_QUEUE` env var. Mirrors
-    /// khive-pack-brain's `fold_gate.rs`/`persist.rs` write-queue-routing
-    /// tests: `PoolConfig::default()` reads `KHIVE_WRITE_QUEUE` at
-    /// construction time, and that env var is process-global, so mutating
-    /// it here would race every other test in this binary that calls
-    /// `KhiveRuntime::new()` (that binary-wide hazard is exactly what those
-    /// two tests' doc comments document having hit). A `PoolConfig` literal
-    /// with `write_queue_enabled: true` sidesteps it entirely — no
-    /// `#[serial]`, no risk to any other test in this crate.
+    /// Build a bare, file-backed, write-queue-enabled `SqlAccess` handle
+    /// (sidesteps the process-global `KHIVE_WRITE_QUEUE` env var race — see
+    /// docs guide ADR-099 D5 notes).
     fn write_queue_pool(db_path: std::path::PathBuf) -> Arc<khive_db::ConnectionPool> {
         let pool_cfg = khive_db::PoolConfig {
             path: Some(db_path),
@@ -2589,15 +2412,10 @@ mod tests {
         pool
     }
 
-    /// ADR-099 D5 acceptance: the converted `write_events_and_cursor`
-    /// closure is suspension-free — it drives only synchronous DML through
-    /// `writer`, so it resolves on its first poll and is `block_on_sync`-safe
-    /// on the single-writer path. Exercises the real production closure
-    /// (`write_events_and_cursor_on_writer` via `atomic_unit`) over a
-    /// write-queue-enabled pool built directly (see `write_queue_pool`), so
-    /// this proves the actual shipped code — not a stand-in — never
-    /// suspends: if it ever did, `block_on_sync` would return the "future
-    /// suspended" error and this call would fail instead of returning `Ok`.
+    /// ADR-099 D5 acceptance: `write_events_and_cursor_on_writer` is
+    /// suspension-free under `atomic_unit` on the real single-writer path
+    /// (see docs guide) — a suspending closure would fail `block_on_sync`
+    /// instead of returning `Ok`.
     #[tokio::test]
     async fn write_events_and_cursor_is_suspension_free_under_single_writer() {
         let dir = TempDir::new().expect("tempdir");
@@ -2667,21 +2485,10 @@ mod tests {
         }
     }
 
-    /// ADR-099 D5 acceptance ("single-writer concurrency test, mandatory"):
-    /// with the write queue enabled, concurrent session-mirror ingest
-    /// (`write_events_and_cursor_on_writer` via `atomic_unit`) and normal
-    /// write traffic through `SqlBridge::writer()` must not contend at
-    /// `BEGIN IMMEDIATE` — the converted ingest path routes through the
-    /// single writer task rather than opening its own standalone
-    /// transaction (the `begin_tx` hole this ADR closes). Uses the same
-    /// queue-depth + occupier-parked-on-oneshot technique as
-    /// khive-pack-brain's `fold_gate_apply_routes_through_writer_task_when_flag_enabled`
-    /// (a wall-clock/timing probe would be indistinguishable from the
-    /// flag-off fallback, which also serializes via real SQLite file
-    /// locking): while an occupier deterministically holds the writer
-    /// task's one drain slot open, the ingest call must appear in the
-    /// channel's queue depth rather than opening a second, competing
-    /// standalone `BEGIN IMMEDIATE`.
+    /// ADR-099 D5 acceptance ("single-writer concurrency, mandatory"):
+    /// session-mirror ingest must route through the shared writer task, not
+    /// open its own standalone `BEGIN IMMEDIATE` (see docs guide for the
+    /// queue-depth + occupier-parked-on-oneshot technique).
     #[tokio::test]
     async fn session_ingest_routes_through_writer_task_when_flag_enabled() {
         let dir = TempDir::new().expect("tempdir");
@@ -2784,17 +2591,10 @@ mod tests {
         assert_eq!(stats.inserted, 1, "the ingest event must be committed");
     }
 
-    /// ADR-099 acceptance ("revert-companion test"): the OLD shape — a
-    /// closure that issues its own `BEGIN IMMEDIATE` through the writer it
-    /// was handed, instead of relying on `atomic_unit`'s own transaction —
-    /// must fail deterministically with a nested-transaction error. This
-    /// proves the suspension-free / single-transaction-owner assertions
-    /// above are non-vacuous: the pre-conversion shape (a caller managing
-    /// its own `BEGIN`/`COMMIT` inside the seam) does NOT silently pass.
-    /// Built over a write-queue-enabled pool (see `write_queue_pool`) so the
-    /// closure is deterministically driven through `block_on_sync`'s
-    /// `InlineWriter` on the real single-writer production path, not the
-    /// flag-off manual-transaction fallback.
+    /// ADR-099 revert-companion test: the pre-conversion shape (a closure
+    /// issuing its own `BEGIN IMMEDIATE` inside `atomic_unit`) must fail
+    /// deterministically with a nested-transaction error — proves the
+    /// suspension-free assertions above are non-vacuous (see docs guide).
     #[tokio::test]
     async fn old_shape_manual_begin_immediate_inside_atomic_unit_fails() {
         let dir = TempDir::new().expect("tempdir");

--- a/crates/khive-pack-session/src/mirror/parse.rs
+++ b/crates/khive-pack-session/src/mirror/parse.rs
@@ -256,28 +256,19 @@ pub fn parse_codex_line(line: &str, session_id: &str, abs_byte_offset: u64) -> O
     }
 }
 
-/// Parse a ChatGPT data-export `conversations.json` file.
-///
-/// Unlike `parse_cc_line`/`parse_codex_line` (one JSONL line in, one event
-/// out), a ChatGPT export is a single static JSON array of conversation
-/// objects — this function parses the whole file at once and returns every
-/// message-bearing event across every conversation it contains.
+/// Parse a ChatGPT data-export `conversations.json` file: parses the whole
+/// file at once (unlike the line-at-a-time `parse_cc_line`/`parse_codex_line`)
+/// and returns every message-bearing event across every conversation, in
+/// deterministic DFS preorder per conversation.
 ///
 /// Returns `None` when `content` is not valid JSON or the top level is not a
-/// JSON array. The caller treats that as a per-file error so the mirror
-/// cursor does not advance: a partially-downloaded export is retried whole
-/// on the next tick, never half-consumed. A malformed *conversation* inside
-/// an otherwise-valid array is skipped individually (see `parse_conversation`)
-/// so one bad entry cannot sink the rest of the file.
-///
-/// Each conversation's `mapping` forms a tree; events are emitted in
-/// deterministic DFS preorder from the root, following each node's
-/// `children` array order (never JSON object key order). Nodes off the
-/// `current_node` root-to-tip path are flagged `is_sidechain`, mirroring how
-/// Claude Code flags abandoned/regenerated branches.
-///
-/// The returned `raw` and `text` fields have secrets masked, exactly like
-/// `parse_cc_line`/`parse_codex_line`.
+/// JSON array — the caller treats that as a per-file error so the mirror
+/// cursor does not advance. A malformed *conversation* inside an otherwise-
+/// valid array is skipped individually, not the whole file. The returned
+/// `raw` and `text` fields have secrets masked, exactly like
+/// `parse_cc_line`/`parse_codex_line`. See
+/// `crates/khive-pack-session/docs/mirror-parse.md` for the DFS/sidechain
+/// algorithm detail.
 pub fn parse_chatgpt_export(content: &str) -> Option<Vec<ParsedEvent>> {
     let value: Value = serde_json::from_str(content).ok()?;
     let conversations = value.as_array()?;
@@ -289,9 +280,8 @@ pub fn parse_chatgpt_export(content: &str) -> Option<Vec<ParsedEvent>> {
     Some(events)
 }
 
-/// Extract a display-friendly text string from a message `content` value.
-///
-/// Handles both the string form and the structured-block array form.
+/// Extract a display-friendly text string from a message `content` value
+/// (string form or structured-block array form).
 fn extract_text(content: Option<&Value>) -> Option<String> {
     match content? {
         Value::String(s) => Some(s.clone()),
@@ -307,13 +297,9 @@ fn extract_text(content: Option<&Value>) -> Option<String> {
     }
 }
 
-/// Extract a display string from a single content block.
-///
-/// Handled block types:
-/// - `"text"` — Claude Code plain text block.
-/// - `"input_text"` / `"output_text"` — Codex user and assistant text blocks.
-/// - `"tool_use"` — tool invocation (name + input JSON, truncated to 500 chars).
-/// - `"tool_result"` — tool output (content string, truncated to 500 chars).
+/// Extract a display string from a single content block (`"text"` /
+/// `"input_text"` / `"output_text"` / `"tool_use"` / `"tool_result"`). See
+/// `crates/khive-pack-session/docs/mirror-parse.md#extract_text--extract_block-claude-code--codex-block-extraction`.
 fn extract_block(block: &Value) -> Option<String> {
     let map = block.as_object()?;
     match map.get("type")?.as_str()? {
@@ -354,24 +340,20 @@ fn truncate(s: &str, max_chars: usize) -> String {
     }
 }
 
-/// Context threaded through node visitation for one conversation — the
-/// pieces that don't change as the DFS walks the mapping tree.
+/// Context threaded through one conversation's DFS walk. See
+/// `crates/khive-pack-session/docs/mirror-parse.md#convcontext`.
 struct ConvContext<'a> {
     mapping: &'a Map<String, Value>,
     current_path: &'a HashSet<String>,
     session_id: &'a str,
-    /// Conversation-level `create_time` in micros (0 if absent) — the
-    /// fallback used when a message's own `create_time` is null/absent.
     conv_created_at_micros: i64,
     slug: Option<&'a str>,
 }
 
-/// Parse one ChatGPT export conversation object, appending its
-/// message-bearing nodes (deterministic DFS preorder from the mapping root)
-/// to `out`.
-///
-/// Skips the whole conversation on a missing/empty `id` or missing `mapping`
-/// so one malformed entry cannot sink the rest of the file.
+/// Parse one ChatGPT export conversation object (skips the whole
+/// conversation on a missing/empty `id` or missing `mapping`), appending its
+/// message-bearing nodes to `out` in deterministic DFS preorder. See
+/// `crates/khive-pack-session/docs/mirror-parse.md#parse_conversation`.
 fn parse_conversation(conv: &Value, out: &mut Vec<ParsedEvent>) {
     let Some(conv_obj) = conv.as_object() else {
         return;
@@ -399,10 +381,8 @@ fn parse_conversation(conv: &Value, out: &mut Vec<ParsedEvent>) {
         .map(|secs| (secs * 1_000_000.0) as i64)
         .unwrap_or(0);
 
-    // ── current-path set: walk current_node -> parent -> ... -> root ────────
-    //
-    // Off-path nodes (abandoned/regenerated branches) are flagged
-    // is_sidechain, mirroring how Claude Code flags sidechains.
+    // current-path set: walk current_node -> parent -> ... -> root; off-path
+    // nodes are flagged is_sidechain (see docs guide).
     let mut current_path: HashSet<String> = HashSet::new();
     if let Some(current_node) = conv_obj.get("current_node").and_then(|v| v.as_str()) {
         let mut cursor = Some(current_node.to_string());
@@ -436,10 +416,7 @@ fn parse_conversation(conv: &Value, out: &mut Vec<ParsedEvent>) {
         slug: slug.as_deref(),
     };
 
-    // ── deterministic DFS preorder from the root, following `children` order ─
-    //
-    // Explicit stack, not recursion — a long linear conversation can nest
-    // thousands of turns deep and would risk overflowing a worker-thread stack.
+    // Deterministic DFS preorder, explicit stack (not recursion — see docs guide).
     let mut stack: Vec<String> = vec![root_id];
     let mut visited: HashSet<String> = HashSet::new();
 
@@ -471,11 +448,10 @@ fn parse_conversation(conv: &Value, out: &mut Vec<ParsedEvent>) {
     }
 }
 
-/// Build a `ParsedEvent` for a single message-bearing mapping node.
-///
-/// Returns `None` when the message carries no `id`, or when the extracted
-/// text is empty/whitespace-only (ChatGPT scaffolding nodes, e.g. system
-/// prompts with `parts: [""]`).
+/// Build a `ParsedEvent` for a single message-bearing mapping node; `None`
+/// on a missing `id` or empty/whitespace-only extracted text (ChatGPT
+/// scaffolding nodes). See
+/// `crates/khive-pack-session/docs/mirror-parse.md#build_chatgpt_event`.
 fn build_chatgpt_event(
     node_id: &str,
     node: &Map<String, Value>,
@@ -513,12 +489,8 @@ fn build_chatgpt_event(
         .map(|secs| (secs * 1_000_000.0) as i64)
         .unwrap_or(ctx.conv_created_at_micros);
 
-    // Some(parent_node_id) only when that parent node itself carries a
-    // (non-null) message — the ChatGPT root is normally message=null, so its
-    // children correctly get parent_uuid=None. A parent that DOES carry a
-    // message but was itself skipped as an event (e.g. empty-parts
-    // scaffolding) still counts — this is provenance linkage, matching how
-    // CC parent chains can reference events that were never mirrored.
+    // parent_uuid is Some only when the parent node itself carries a message
+    // (provenance linkage — see docs guide).
     let parent_uuid = node
         .get("parent")
         .and_then(|v| v.as_str())
@@ -555,12 +527,8 @@ fn build_chatgpt_event(
 }
 
 /// Extract display text from a ChatGPT message `content` object per its
-/// `content_type`.
-///
-/// - `"text"` — join string `parts` with `"\n"` (non-string parts ignored
-///   defensively).
-/// - anything else (`"code"`, `"execution_output"`, …) — `content.text` if
-///   present, else joined string `parts`, else `None`.
+/// `content_type`. See
+/// `crates/khive-pack-session/docs/mirror-parse.md#extract_chatgpt_text`.
 fn extract_chatgpt_text(
     content_type: &str,
     content: Option<&Map<String, Value>>,

--- a/crates/khive-vamana/docs/algorithm.md
+++ b/crates/khive-vamana/docs/algorithm.md
@@ -94,3 +94,62 @@ provides a well-connected starting node for search.
 - No duplicate neighbors. Enforced by `sort_dedup_u32` after pruning and in `from_snapshot`.
 - Degree bound: `adjacency[i].len() <= max_degree` after build and after loading.
 - Deterministic output: seeded RNG (`BUILD_SEED`) + deterministic sort order ensures identical graphs for identical inputs.
+
+---
+
+## Reverse-adjacency rebuild
+
+`VamanaGraph::rebuild_reverse_adj_from_adjacency` (`graph.rs`) rebuilds `reverse_adj`
+from scratch by scanning the current `adjacency`: O(N × R) where N is node count and
+R is average out-degree. Called after `build()` completes, and after `load` /
+`from_snapshot` restores adjacency from disk — the v1 on-disk format does not persist
+`reverse_adj`, so it must be reconstructed rather than loaded.
+
+## Tombstone defense-in-depth
+
+`greedy_search_inner` and `greedy_search_inner_sq8` (`graph.rs`) both take an optional
+`tombstones` bitvec. Under a correct Wolverine repair, no live forward edge should ever
+point at a tombstoned node — but this guard exists to catch crash-truncated repairs in
+the window before PR4 makes the invariant crash-safe:
+
+- If the medoid seed itself is tombstoned, the search returns an empty result rather
+  than surfacing a deleted node.
+- Neighbors are skipped during beam expansion if tombstoned.
+- The final result set is filtered against tombstones before `take(k)`.
+
+## SQ8 acquisition tier
+
+`VamanaGraph::build_sq8`, `greedy_search_inner_sq8`, and `robust_prune_inner_sq8`
+(ADR-052 §1, Step 2 — two-tier principle) route graph construction and search through
+`GsSq8Codec::l2_sq` (integer L2²) on pre-encoded corpus vectors instead of the f32
+kernel, for the frontier priority queue / candidate acquisition stage only:
+
+- `build_sq8` produces a graph topology equivalent to `build`; the caller trains the
+  codec and encodes the corpus before calling it.
+- `greedy_search_inner_sq8` re-scores every frontier candidate with exact f32 L2²
+  before final top-k selection (SQ8 for acquisition, exact f32 for final ranking).
+  Frontier ties on equal SQ8 codes are broken with exact f32 distance, since distinct
+  f32 vectors can map to the same u8 code (clamped or low-resolution dimensions).
+- `robust_prune_inner_sq8` scores and orders candidates with SQ8, tiebreaking equal
+  codes with exact f32 to match the search ordering — but the alpha diversity predicate
+  itself always uses exact f32 distances on both sides (node→candidate and
+  selected→candidate). This is deliberate: if node and candidate collide in code space
+  (e.g. both map to code 0), the SQ8 distance is 0, which would make
+  `alpha² * dist(selected, candidate) <= 0` vacuously true and incorrectly prune
+  candidates that exact f32 would keep. Selected neighbor IDs match the f32 variant on
+  the collision cases covered by tests; callers that need exact distances re-score
+  after prune.
+
+## Wolverine 2-hop repair
+
+`wolverine_repair` (`index.rs`, ADR-052 §2 steps 3-8) is the core soft-delete repair
+step, called from `VamanaIndex::tombstone` and `tombstone_batch`. For each live
+in-neighbor `p` of the deleted node, it rewires `p`'s adjacency by running RobustPrune
+over the union of the deleted node's out-neighbors and `p`'s current neighbors (minus
+the deleted node), with all tombstoned candidates excluded — this preserves
+monotonic-path reachability through `p`. `reverse_adj` is updated in lockstep on every
+rewire (the PR1 invariant).
+
+References:
+- Wolverine: PVLDB 18(7):2268-2280, VLDB 2025 (Liu/Zheng/Yue/Ruan/Zhou/Jensen)
+- FreshDiskANN: SIGMOD 2022 (>95% recall at 20% deletion with eager repair)

--- a/crates/khive-vamana/docs/design.md
+++ b/crates/khive-vamana/docs/design.md
@@ -105,6 +105,15 @@ Key design decisions and constraints:
 
 ---
 
+## Lifecycle fields
+
+`VamanaIndex`'s PR2 lifecycle fields (ADR-052 §2): `tombstones` is a `Vec<u64>`
+bit-packed bitvec with manual manipulation rather than a `bitvec` crate dependency
+(OQ3 resolution). `consolidation_tau` lives on `VamanaIndex`, not `VamanaConfig`,
+because it is operational policy (when to compact), not graph topology (OQ5).
+
+---
+
 ## Consistency Notes
 
 - The `Vec<Vec<u32>>` adjacency layout is intentional for build-phase pruning

--- a/crates/khive-vamana/docs/persistence.md
+++ b/crates/khive-vamana/docs/persistence.md
@@ -91,6 +91,66 @@ a single `VamanaGraph` refactor suffices.
 
 ---
 
+## v2 crash-safe save/load
+
+`VamanaIndex::save_atomic` writes `vectors.bin` and `graph.bin` (same formats as v1),
+then `lifecycle.bin` (tombstones, free_slots, reverse_adj, ops_since_consolidation),
+then atomically renames `metadata.bin.tmp` → `metadata.bin` as the commit record. If a
+crash interrupts before the rename, the previous `metadata.bin` (v1 or v2) is still
+valid — `load_or_build` never observes a torn v2 commit. Segments are staged under
+`.v2new` suffixes so a crash between segment write and metadata rename never corrupts
+a live v1-format segment set. The directory entry is fsynced after both the metadata
+rename (commit gate) and the final segment-promotion renames.
+
+`VamanaIndex::load_or_build` is the fingerprint-gated restore used by callers holding a
+live corpus. Decision tree:
+- `metadata.bin` with `KHVVAMG2` magic AND checksums valid AND fingerprint matches →
+  fast path (`load_v2_fast`, O(N) — no reverse_adj rebuild)
+- `KHVVAMG2` but checksum or fingerprint mismatch → rebuild from commit config, then
+  `save_atomic`
+- `metadata.bin` with `KHVVAMM1` (v1) → v1 `load`, then `save_atomic` upgrade
+- `metadata.bin` missing or corrupt → rebuild from `fallback_config`, then `save_atomic`
+
+`VamanaIndex::load_v2_raw` (private) is the non-rebuilding half of that fast path: it
+verifies the v2 commit magic, parses the commit record, checksum-verifies all three
+segments against the commit fingerprint, then restores via `load_v2_fast`. It returns
+`InvalidFormat` if `path` holds no valid v2 commit (absent, v1-format, torn, checksum
+mismatch, or an inconsistent lifecycle segment) rather than rebuilding — `load_or_build`
+is the entry point that decides whether to fall back to a rebuild; `VamanaIndex::load`
+surfaces the error directly to callers that don't hold a corpus to rebuild from.
+
+## lifecycle.bin format
+
+Written by `write_lifecycle` (`index.rs`) as part of the v2 segmented save. All
+fields little-endian:
+
+| Field              | Size                    | Type            |
+| ------------------ | ----------------------- | --------------- |
+| magic               | 8 B                     | bytes `KHVVLIF1` |
+| tombstone_words     | 8 B                     | u64 (count of u64 words) |
+| tombstone data      | N × 8 B                 | u64 words        |
+| free_slots_count    | 8 B                     | u64              |
+| free_slots data     | M × 4 B                 | u32 each         |
+| ops                 | 8 B                     | u64              |
+| rev_num_nodes       | 8 B                     | u64              |
+| reverse_adj records | varies, one per node    | degree (u32) + neighbors (degree × u32) |
+
+`reverse_adj` uses the same per-node record format as `graph.bin`'s adjacency
+(degree followed by that many neighbor IDs). `num_nodes` for the tombstone bitvec is
+derived from `tombstone_words`; the caller already knows `num_vectors` from
+`metadata.bin`.
+
+## v2 fast-load path
+
+`VamanaGraph::restore_reverse_adj` installs a previously serialized in-neighbor list
+as `reverse_adj` in O(1) (a move). This is safe to call without redoing the O(N×R)
+rebuild because the v2 fast-load path (`load_v2_fast` in `index.rs`) has already paid
+that cost validating bidirectional consistency between the loaded `reverse_adj` and
+the forward `adjacency` before calling it — the O(N×R) work isn't skipped, it just
+happens in the validation step rather than in `restore_reverse_adj` itself.
+
+---
+
 ## Safety note (mmap)
 
 The single `unsafe` block in `mmap_vectors` maps `vectors.bin` read-only.

--- a/crates/khive-vamana/docs/testing.md
+++ b/crates/khive-vamana/docs/testing.md
@@ -32,6 +32,19 @@
 
 ---
 
+## OQ1 no-repair control
+
+`VamanaIndex::tombstone_batch_no_repair` (`#[doc(hidden)]`, test support only) sets
+tombstone bits and clears each deleted node's own forward adjacency (updating
+`reverse_adj` in lockstep), but does NOT reselect in-neighbor lists via RobustPrune —
+no Wolverine rewiring. The medoid is re-elected once at the end if it falls in the
+batch. It builds a genuine no-repair control for the OQ1 empirical drift test: search
+still skips tombstoned nodes via the `Option<&[u64]>` guard in `greedy_search_inner`,
+but in-neighbors that previously pointed to deleted nodes are NOT rewired, so the graph
+retains dead-end paths that Wolverine repair would otherwise have bypassed.
+
+---
+
 ## Ignored / long-running tests
 
 `benchmark_random_5000x384_recall_at_10_at_least_85_percent` is marked

--- a/crates/khive-vamana/src/graph.rs
+++ b/crates/khive-vamana/src/graph.rs
@@ -128,11 +128,7 @@ impl VamanaGraph {
         })
     }
 
-    /// Rebuild `reverse_adj` from scratch by scanning the current `adjacency`.
-    ///
-    /// O(N × R) where N is node count and R is average out-degree. Called after
-    /// `build()` completes, and after `load` / `from_snapshot` restores adjacency
-    /// from disk (v1 format does not persist `reverse_adj`).
+    /// Rebuild `reverse_adj` from `adjacency`. See crates/khive-vamana/docs/algorithm.md#reverse-adjacency-rebuild for cost and call-site rationale.
     pub(crate) fn rebuild_reverse_adj_from_adjacency(&mut self) {
         let n = self.adjacency.len();
         let mut rev: Vec<Vec<u32>> = vec![Vec::new(); n];
@@ -276,11 +272,8 @@ impl VamanaGraph {
     }
 
     /// Build a Vamana graph using SQ8 acquisition-tier distances (ADR-052 §1, Step 2).
-    ///
-    /// Identical to `build` but routes greedy search and RobustPrune candidate scoring
-    /// through `GsSq8Codec::l2_sq` (integer L2²) instead of the f32 kernel. The graph
-    /// topology produced is equivalent; caller trains the codec and encodes the corpus
-    /// before calling this function.
+    /// Produces a topology equivalent to `build`; caller must train `codec` and encode
+    /// `vectors` into `encoded` first (see crates/khive-vamana/docs/algorithm.md#sq8-acquisition-tier).
     pub fn build_sq8(
         vectors: &[f32],
         encoded: &[GsEncodedVector],
@@ -454,11 +447,7 @@ impl VamanaGraph {
         &mut self.adjacency
     }
 
-    /// Install a previously serialized in-neighbor list as `reverse_adj`.
-    /// Called by the v2 fast-load path after `load_v2_fast` has already paid the O(N*R)
-    /// cost to validate bidirectional consistency against the forward adjacency; this call
-    /// itself is O(1) (a move). The O(N*R) work is not avoided — it is done by the
-    /// consistency check before this call, not here.
+    /// Install a pre-validated in-neighbor list as `reverse_adj`. See crates/khive-vamana/docs/persistence.md#v2-fast-load-path for the validation this relies on.
     pub(crate) fn restore_reverse_adj(&mut self, reverse_adj: Vec<Vec<u32>>) {
         self.reverse_adj = reverse_adj;
     }
@@ -468,10 +457,7 @@ impl VamanaGraph {
         (&mut self.adjacency, &mut self.reverse_adj)
     }
 
-    /// Replace `adjacency[node]` with `new_neighbors` and update `reverse_adj` in lockstep.
-    ///
-    /// For every node removed from the old list, `node` is removed from its `reverse_adj`
-    /// entry. For every node added, `node` is appended. Called by Wolverine repair.
+    /// Replace `adjacency[node]` with `new_neighbors`, updating `reverse_adj` in lockstep.
     pub(crate) fn replace_adjacency_and_update_reverse(
         &mut self,
         node: u32,
@@ -537,9 +523,9 @@ impl VamanaGraph {
 
     /// Run greedy beam search from the medoid and return the `k` nearest candidates.
     ///
-    /// `tombstones` is an optional bit-packed slice produced by `VamanaIndex`.
-    /// Tombstoned nodes are skipped during beam expansion (defense-in-depth for
-    /// the pre-PR4 window where the Wolverine invariant is not crash-safe).
+    /// `tombstones` is an optional bit-packed slice produced by `VamanaIndex`; when
+    /// present, tombstoned nodes are skipped during beam expansion and excluded from
+    /// results (see crates/khive-vamana/docs/algorithm.md#tombstone-defense-in-depth).
     // REASON: `tombstones` was added to the existing 7-parameter signature (PR2);
     // bundling params into a struct would add allocation overhead on the hot path.
     #[allow(clippy::too_many_arguments)]
@@ -806,11 +792,9 @@ pub(crate) fn robust_prune_inner(
     selected
 }
 
-/// SQ8 acquisition-tier greedy search (ADR-052 §1, two-tier principle).
-///
-/// Uses `GsSq8Codec::l2_sq` on pre-encoded corpus vectors for the frontier priority queue
-/// (candidate acquisition), then re-scores the final top-k with exact f32 L2².
-/// The caller is responsible for: tombstone filtering, dimension checks, k > 0 check.
+/// SQ8 acquisition-tier greedy search: two-tier candidate acquisition + exact re-score.
+/// See crates/khive-vamana/docs/algorithm.md#sq8-acquisition-tier. Caller must do
+/// tombstone filtering, dimension checks, and k > 0 check.
 // REASON: nine parameters mirror `greedy_search_inner`; the SQ8 codec + encoded slice
 // are the only additions. Bundling into a struct would add allocation overhead on the hot path.
 #[allow(clippy::too_many_arguments)]
@@ -930,14 +914,9 @@ pub(crate) fn greedy_search_inner_sq8(
     }
 }
 
-/// SQ8 acquisition-tier robust prune (ADR-052 §1, two-tier principle).
-///
-/// Uses `GsSq8Codec::l2_sq` on pre-encoded corpus vectors for candidate scoring and
-/// ordering; equal SQ8 scores are tiebroken by exact f32 distance. The alpha
-/// diversity predicate itself uses exact f32 distances on both sides (node→candidate
-/// and selected→candidate), so equal-code collisions cannot vacuously prune. Selected
-/// neighbor IDs match the f32 variant on the collision cases covered by tests; callers
-/// that need exact distances re-score after prune.
+/// SQ8 acquisition-tier robust prune: SQ8-scored candidates, exact-f32 alpha predicate.
+/// See crates/khive-vamana/docs/algorithm.md#sq8-acquisition-tier for why the predicate
+/// stays exact-f32 (SQ8 code collisions would otherwise vacuously prune).
 // REASON: mirrors robust_prune_inner signature with two additional SQ8 params (encoded, codec).
 #[allow(clippy::too_many_arguments)]
 pub(crate) fn robust_prune_inner_sq8(

--- a/crates/khive-vamana/src/index.rs
+++ b/crates/khive-vamana/src/index.rs
@@ -324,9 +324,8 @@ pub struct VamanaIndex {
     config: VamanaConfig,
     num_vectors: usize,
     dimensions: usize,
-    // ---- PR2: lifecycle fields (ADR-052 §2) ----
+    // ---- PR2: lifecycle fields (ADR-052 §2; see docs/design.md#lifecycle-fields) ----
     /// Bit-packed tombstone marks. Bit `i` set ⇒ node `i` is soft-deleted.
-    /// `Vec<u64>` with manual manipulation; no `bitvec` crate dependency (OQ3 resolution).
     tombstones: Vec<u64>,
     /// Count of currently tombstoned nodes.
     tombstone_count: usize,
@@ -334,8 +333,7 @@ pub struct VamanaIndex {
     ops_since_consolidation: usize,
     /// Recycled ordinal slots from previous tombstone calls; consumed by insert (PR3).
     free_slots: Vec<u32>,
-    /// Trigger tau for consolidation: fire when `ops_since_consolidation >= consolidation_tau`.
-    /// Field on `VamanaIndex`, not `VamanaConfig` — this is operational policy, not topology (OQ5).
+    /// Trigger tau: consolidation fires when `ops_since_consolidation >= consolidation_tau`.
     consolidation_tau: usize,
     // ---- SQ8 acquisition tier (ADR-052 §1, Step 2) ----
     /// Global-scale SQ8 codec trained over the build corpus; used for acquisition-tier distances.
@@ -352,10 +350,7 @@ struct IndexMetadata {
     alpha: f64,
 }
 
-/// Train a `GsSq8Codec` and encode `vectors` for the SQ8 acquisition tier.
-///
-/// Called by all index constructors (build, load, from_snapshot) so the codec
-/// is always consistent with the stored vectors.
+/// Train + encode the SQ8 acquisition-tier codec; called by every index constructor.
 fn train_codec_and_encode(vectors: &[f32], dims: usize) -> (GsSq8Codec, Vec<GsEncodedVector>) {
     let codec = GsSq8Codec::train_flat(vectors, dims);
     let codes = codec.encode_flat_par(vectors, dims);
@@ -646,12 +641,10 @@ impl VamanaIndex {
     }
 
     /// Load an index from a directory previously written by [`VamanaIndex::save`]
-    /// (v1 format) or [`VamanaIndex::save_atomic`] (v2 segmented format).
-    ///
-    /// The format is detected from `metadata.bin`'s magic: a v2 commit takes the raw
-    /// segment path (`load_v2_raw`); a legacy v1 metadata blob takes the path
-    /// below. Neither path rebuilds — a corrupt, torn, or absent index returns an error,
-    /// leaving the recovery decision to the caller (see [`Self::load_or_build`]).
+    /// (v1 format) or [`VamanaIndex::save_atomic`] (v2 segmented format); the format is
+    /// auto-detected from `metadata.bin`'s magic. Never rebuilds — a corrupt, torn, or
+    /// absent index returns an error, leaving the recovery decision to the caller (see
+    /// [`Self::load_or_build`] and crates/khive-vamana/docs/persistence.md#v2-crash-safe-save-load).
     #[cfg(feature = "mmap")]
     pub fn load(path: &Path) -> Result<Self> {
         let metadata_path = path.join("metadata.bin");
@@ -714,15 +707,12 @@ impl VamanaIndex {
         })
     }
 
-    /// Crash-safe v2 save. Writes vectors.bin and graph.bin (same formats as v1),
-    /// then lifecycle.bin (tombstones, free_slots, reverse_adj, ops_since_consolidation),
-    /// then atomically renames metadata.bin.tmp → metadata.bin as the commit record.
-    ///
-    /// If a crash interrupts before the rename the previous metadata.bin (v1 or v2) is
-    /// still valid. load_or_build never observes a torn v2 commit.
-    ///
-    /// Segments are staged under `.v2new` suffixes so a crash between segment write and
-    /// metadata rename does not corrupt a live v1-format set of segments.
+    /// Crash-safe v2 save: writes `vectors.bin`, `graph.bin`, and `lifecycle.bin`, then
+    /// atomically renames `metadata.bin.tmp` → `metadata.bin` as the commit record. A
+    /// crash at any point before that rename leaves the previous `metadata.bin` (v1 or
+    /// v2) valid and untouched — [`Self::load_or_build`] never observes a torn v2
+    /// commit. See crates/khive-vamana/docs/persistence.md#v2-crash-safe-save-load for
+    /// the staging/fsync sequence.
     #[cfg(feature = "mmap")]
     pub fn save_atomic(&self, path: &Path) -> Result<()> {
         fs::create_dir_all(path)?;
@@ -813,19 +803,12 @@ impl VamanaIndex {
         Ok(())
     }
 
-    /// Fingerprint-gated restore. On a corpus fingerprint match, loads all segments including
-    /// lifecycle state in O(N) without rebuilding reverse_adj. On mismatch or missing v2
-    /// commit, falls back to rebuild using `fallback_config`.
-    ///
-    /// `corpus_vectors` is the raw flat f32 slice from the caller's database layer.
-    /// `fallback_config` is used when no saved config is available (clean first run or total
-    /// corruption).
-    ///
-    /// Decision tree:
-    /// - metadata.bin with KHVVAMG2 magic AND checksums valid AND fingerprint matches → fast path
-    /// - metadata.bin with KHVVAMG2 but checksum or fingerprint mismatch → rebuild from commit config + save_atomic
-    /// - metadata.bin with KHVVAMM1 (v1) → v1 load + save_atomic upgrade
-    /// - metadata.bin missing or corrupt → rebuild from fallback_config + save_atomic
+    /// Fingerprint-gated restore. On a corpus fingerprint match, loads all segments
+    /// (including lifecycle state) in O(N) without rebuilding `reverse_adj`. On mismatch
+    /// or a missing/corrupt v2 commit, rebuilds from `corpus_vectors` (the caller's raw
+    /// flat f32 slice) using `fallback_config` or the commit's saved config, then
+    /// persists via `save_atomic`. Full decision tree:
+    /// crates/khive-vamana/docs/persistence.md#v2-crash-safe-save-load.
     #[cfg(feature = "mmap")]
     pub fn load_or_build(
         path: &Path,
@@ -1010,15 +993,10 @@ impl VamanaIndex {
         }
     }
 
-    /// Load a committed v2 index from `path` without a corpus and without rebuilding.
-    ///
-    /// Verifies the v2 commit magic, parses the commit record, reads and checksum-verifies
-    /// all three segments against the commit fingerprint, then restores the index (graph +
-    /// lifecycle) via [`Self::load_v2_fast`]. Returns an `InvalidFormat` error if `path`
-    /// holds no valid v2 commit — absent, v1-format, torn, checksum mismatch, or an
-    /// inconsistent lifecycle segment. Unlike [`Self::load_or_build`] it never rebuilds;
-    /// callers that hold a corpus decide whether to fall back. [`Self::load`] surfaces the
-    /// error directly.
+    /// Load a committed v2 index from `path` without a corpus and without rebuilding;
+    /// errors (never rebuilds) if no valid v2 commit is present. See
+    /// crates/khive-vamana/docs/persistence.md#v2-crash-safe-save-load for the full
+    /// decision tree shared with `load_or_build`.
     #[cfg(feature = "mmap")]
     fn load_v2_raw(path: &Path) -> Result<Self> {
         let metadata_bytes = fs::read(path.join("metadata.bin"))?;
@@ -1424,12 +1402,8 @@ impl VamanaIndex {
 
     // ---- PR3: Mmap-to-Owned promotion helper ----
 
-    /// Promote `VectorStorage::Mmap` to `Owned` by copying the mapping into a `Vec<f32>`.
-    ///
-    /// Called as the first statement of both `insert` and `consolidate` so that all
-    /// subsequent vector reads/writes operate on a mutable owned buffer. If already
-    /// `Owned`, this is a no-op. O(N × dim) once per promotion; the next `save`
-    /// creates a fresh mmap at next load.
+    /// Promote `VectorStorage::Mmap` to `Owned` (no-op if already `Owned`); called first
+    /// by both `insert` and `consolidate` so subsequent writes hit a mutable buffer.
     fn ensure_owned(&mut self) -> Result<()> {
         #[cfg(feature = "mmap")]
         if let VectorStorage::Mmap { .. } = &self.vectors {
@@ -1764,16 +1738,11 @@ impl VamanaIndex {
         Ok(new_to_old)
     }
 
-    /// Soft-delete the node at `node_id` with eager Wolverine 2-hop repair (ADR-052 §2).
-    ///
-    /// For each live in-neighbor `p` of `node_id`, the repair rebuilds `p`'s adjacency
-    /// by running RobustPrune over the union of `node_id`'s out-neighbors and `p`'s
-    /// current neighbors (minus `node_id`). All tombstoned candidates are excluded.
-    /// `reverse_adj` is updated in lockstep on every rewire.
-    ///
-    /// If `node_id` was the medoid, a new medoid is elected (centroid-nearest live node).
-    ///
-    /// Returns an error without mutating any state if the op would leave zero live nodes.
+    /// Soft-delete the node at `node_id` with eager Wolverine 2-hop repair (ADR-052 §2;
+    /// see crates/khive-vamana/docs/algorithm.md#wolverine-2-hop-repair for the rewire
+    /// mechanism). If `node_id` was the medoid, a new medoid is elected (centroid-nearest
+    /// live node). Returns an error without mutating any state if the op would leave zero
+    /// live nodes.
     pub fn tombstone(&mut self, node_id: u32) -> Result<()> {
         let idx = node_id as usize;
         if idx >= self.num_vectors {
@@ -1930,16 +1899,8 @@ impl VamanaIndex {
         Ok(())
     }
 
-    /// Tombstone a batch without Wolverine in-neighbor rewiring. Test support only.
-    ///
-    /// Sets tombstone bits and clears each deleted node's own forward adjacency (updating
-    /// `reverse_adj` in lockstep), but does NOT reselect in-neighbor lists via RobustPrune.
-    /// The medoid is re-elected once at the end if it falls in the batch.
-    ///
-    /// Used by the OQ1 empirical drift test to build a genuine no-repair control: search
-    /// still skips tombstoned nodes via the `Option<&[u64]>` guard in `greedy_search_inner`,
-    /// but in-neighbors that previously pointed to deleted nodes are NOT rewired, so the
-    /// graph retains dead-end paths that Wolverine would have bypassed.
+    /// Tombstone a batch without Wolverine rewiring — test support only, builds the OQ1
+    /// no-repair control. See crates/khive-vamana/docs/testing.md#oq1-no-repair-control.
     #[doc(hidden)]
     pub fn tombstone_batch_no_repair(&mut self, ordinals: &[u32]) -> Result<()> {
         if ordinals.is_empty() {
@@ -2025,16 +1986,10 @@ fn set_tombstone_bit(tombstones: &mut Vec<u64>, idx: usize) {
 
 // ---- PR2: Wolverine 2-hop repair (ADR-052 §2 steps 3-8) ----
 
-/// Core Wolverine repair: rewire each live in-neighbor of `deleted` so it bypasses
-/// the deleted node. Monotonic-path preservation: the new neighbor list is derived
-/// from a RobustPrune over `deleted`'s out-neighbors ∪ the in-neighbor's current
-/// neighbors (minus `deleted`), with all tombstoned candidates excluded.
-///
-/// `reverse_adj` is updated in lockstep on every rewire (the PR1 invariant).
-///
-/// # References
-/// - Wolverine: PVLDB 18(7):2268-2280, VLDB 2025 (Liu/Zheng/Yue/Ruan/Zhou/Jensen)
-/// - FreshDiskANN: SIGMOD 2022 (>95% recall at 20% deletion with eager repair)
+/// Core Wolverine repair: rewire each live in-neighbor of `deleted` to bypass it,
+/// updating `reverse_adj` in lockstep. See
+/// crates/khive-vamana/docs/algorithm.md#wolverine-2-hop-repair for the RobustPrune
+/// derivation and paper references.
 fn wolverine_repair(
     vectors: &[f32],
     dimensions: usize,
@@ -2706,21 +2661,8 @@ fn parse_v2_commit(data: &[u8]) -> Result<V2Commit> {
     })
 }
 
-/// Write lifecycle.bin.
-///
-/// Layout (all little-endian):
-///   magic            8 B   "KHVVLIF1"
-///   tombstone_words  8 B   (u64 count of u64 words)
-///   tombstone data   N × 8 B
-///   free_slots_count 8 B   (u64)
-///   free_slots data  M × 4 B (u32)
-///   ops              8 B   (u64)
-///   // reverse_adj: same format as graph.bin adjacency (per-node degree + neighbors)
-///   // num_nodes derived from tombstone_words (context: caller knows num_vectors)
-///   rev_num_nodes    8 B   (u64)
-///   for each node:
-///     degree         4 B   (u32)
-///     neighbors      degree × 4 B (u32 each)
+/// Write lifecycle.bin. See crates/khive-vamana/docs/persistence.md#lifecyclebin-format
+/// for the full byte layout.
 #[cfg(feature = "mmap")]
 fn write_lifecycle(
     path: &Path,


### PR DESCRIPTION
## What

Condense verbose inline doc-comments in `khive-brain-core,khive-fold khive-pack-comm,khive-pack-kg khive-pack-session,khive-vamana` and relocate long-form rationale, algorithm walkthroughs, and background prose into per-crate `docs/*.md` guides. Part of the rustdoc condense-and-extract pass.

## Preserved (information relocation, not deletion)

- Public API doc-comments stay **complete and standalone** — the docs.rs reference is intact.
- No `# Safety`, invariant, ordering, precision, or error-enumeration docs were thinned.
- schemars/clap product-surface doc-comments (MCP tool schema, CLI `--help`) left verbatim.
- Every substantive fact removed from a `.rs` doc-comment was moved into a crate guide, not dropped.

## Scope

Only the `src` and `docs` trees of the crates above. Diffstat: 39 files changed, 2312 insertions(+), 1633 deletions(-).

A follow-up pass on this branch restructures extracted content into topic-organized `docs/api/` reference docs with inline pointers, and runs per-crate verification, before this is marked ready.