### PR TITLE
docs(rustdoc): pass-2 — topic docs/api/ + inline refs, trim further (khive-runtime)

### DIFF
--- a/crates/khive-runtime/docs/api/atomic_prepare.md
+++ b/crates/khive-runtime/docs/api/atomic_prepare.md
@@ -1,9 +1,12 @@
-# atomic_prepare.rs — extended rationale
+# Atomic Prepare — DML Plan Builders
 
-Long-form rationale extracted from `crates/khive-runtime/src/atomic_prepare.rs` doc-comments
-during the rustdoc condense pass.
+`atomic_prepare.rs` turns a subset of verb calls into a static, guarded DML plan
+(`crate::atomic_plan::PlanStatement`s) that the `--atomic` execution path can run inside one
+transaction without invoking the normal async handler. This document covers which verbs are
+in scope, why some are deliberately excluded, and the DML-shape parity guarantees for the
+functions that build those plans.
 
-## module-scope
+## Scope: what is excluded and why
 
 `gtd.transition` / `gtd.complete` prepare is deliberately **not** here: their lifecycle
 vocabulary (`is_terminal`, `can_transition`, ...) lives in `khive-pack-gtd`, which depends on

--- a/crates/khive-runtime/docs/api/atomic_runner.md
+++ b/crates/khive-runtime/docs/api/atomic_runner.md
@@ -1,0 +1,45 @@
+# Atomic Runner — Commit-Pass Mechanism
+
+`atomic_runner.rs` is the synchronous commit-pass mechanism for the ADR-099 atomic-write
+migration: given an already-prepared sequence of write plans, it applies them as one
+`SqlAccess::atomic_unit`, under a per-op `SAVEPOINT`, committing every plan or rolling back the
+whole unit. This document covers the suspend-free safety argument, the three-phase shape the
+module is one piece of, and its current wiring status.
+
+## Wiring status (ADR-099 migration step 3, sub-slice B2)
+
+This module is the **mechanism only**. It has no production caller in B2 — no verb dispatch, no
+CLI `--atomic` surface, no daemon wiring. Tests in this file are the only consumer. Wiring a real
+per-verb `prepare` step (ops → `AtomicOpPlan`) and the `exec --ops-file --atomic` CLI surface is
+ADR-099 migration steps 1 (cont'd) and 4 — referred to throughout the source as the **B3 wiring
+point**.
+
+## Suspend-free invariant
+
+`run_atomic_unit` is the one place in this crate that builds an `AtomicUnitOp` closure and hands
+it to `SqlAccess::atomic_unit`. That trait method carries a hard contract (its own doc comment,
+`crates/khive-storage/src/sql.rs`, and `crates/khive-db/src/sql_bridge.rs` `block_on_sync`):
+**the closure's future must resolve on its first poll** — synchronous DML against the provided
+`&mut dyn SqlWriter` only, never a real `.await` on embedding, ANN warming, or any other
+suspending work.
+
+This module honors that invariant structurally, not by convention: every statement the
+commit-pass closure drives comes from `AtomicOpPlan::plan_statements` (private — the runner's own
+internal flattening step), which can only ever produce `PlanStatement`s — plain parameterized
+SQL, the same shape ADR-099 D1's prepare pass produces for the v1 DML-only admissible verb set
+(ADR-099 D3). There is no code path in this module that can hand `atomic_unit` an embedding call
+or any other suspending future.
+
+The paired suspend-trap tests at the bottom of the file check the two things this promise rests
+on: the real commit pass resolving on first poll (the happy-path proof), and a hand-built closure
+that deliberately suspends failing loudly through the exact same seam (the misuse-is-caught
+proof).
+
+## Two-phase shape (ADR-099 D1)
+
+Only the **commit pass** (phase 2) lives here: given an already-prepared `Vec<AtomicOpPlan>`
+(phase 1, the async prepare pass, is out of scope for B2 — a test-only caller constructs plans
+directly), `run_atomic_unit` opens one `atomic_unit`, applies each plan's statements under a
+named `SAVEPOINT`, and returns either every op's collected `PostCommitEffect`s (phase 3, the
+async post-commit pass — the B3 wiring point: nothing in B2 executes these effects, a test
+consumer only drains the returned list) or the first op's failure and its index.

--- a/crates/khive-runtime/docs/api/daemon.md
+++ b/crates/khive-runtime/docs/api/daemon.md
@@ -1,7 +1,10 @@
-# daemon.rs — extended rationale
+# Daemon Wire Protocol and Metrics
 
-Long-form rationale extracted from `crates/khive-runtime/src/daemon.rs` doc-comments during the
-rustdoc condense pass.
+`daemon.rs` implements the long-lived `kkernel mcp --daemon` process that keeps ANN/embedder
+state warm across MCP sessions (ADR-049): its framed request/response protocol, boot-time
+locking, and the metrics snapshot served to callers. This document covers the versioned wire
+protocol, the two lock-acquisition strategies the daemon uses, and where each metrics gauge is
+sourced from.
 
 ## protocol_version
 

--- a/crates/khive-runtime/docs/api/pack.md
+++ b/crates/khive-runtime/docs/api/pack.md
@@ -1,8 +1,11 @@
-# pack.rs — extended rationale
+# Pack Runtime Integration Points
 
-Long-form rationale extracted from `crates/khive-runtime/src/pack.rs` doc-comments during the
-rustdoc condense pass. Each section links back to the item whose in-source doc-comment now
-carries only the standalone contract plus a one-line pointer here.
+`pack.rs` defines the `PackRuntime` trait — the hooks a pack implements to integrate with a
+`KhiveRuntime` (embedders, entity-type validators, note-mutation notifications) — and the
+`VerbRegistry` dispatch surface that routes a verb call through gate, audit, and namespace
+resolution before reaching a pack handler. Each section below is the extended technical contract
+for one hook or dispatch-path function; the in-source doc-comment on each item carries only the
+concise standalone summary plus a pointer here.
 
 ## register_embedders
 

--- a/crates/khive-runtime/docs/api/secret_gate.md
+++ b/crates/khive-runtime/docs/api/secret_gate.md
@@ -1,8 +1,10 @@
-# secret_gate.rs — extended rationale
+# Secret Gate — Credential Detection Algorithm
 
-Long-form rationale extracted from `crates/khive-runtime/src/secret_gate.rs` doc-comments during
-the rustdoc condense pass. The module-level doc-comment in the source now carries a concise
-summary plus a pointer to this file; this is the full algorithm spec.
+`secret_gate.rs` scans transcript/audit text for accidentally-embedded credentials (API keys,
+tokens, passwords) before it is persisted or logged, and masks any it finds. This document is the
+full algorithm spec: the allowlist layers that suppress false positives, the trigger-word
+matching rules, and the per-function shape criteria used by the detection helpers. The in-source
+module doc-comment carries only a concise summary and points here.
 
 ## Module-level detection algorithm
 

--- a/crates/khive-runtime/docs/api/validation.md
+++ b/crates/khive-runtime/docs/api/validation.md
@@ -1,9 +1,8 @@
-# khive-runtime Validation Rules
+# KG Validation Pipeline
 
-## Purpose
-
-Describes the pack-contributed KG validation pipeline: how rules are declared, how
-severity overrides work, and where rule configuration lives.
+`validation.rs` defines the pack-contributed KG validation pipeline: how a pack declares a
+`ValidationRule`, how severity levels map to `kkernel kg validate` exit behavior, and where rule
+configuration is read from at runtime.
 
 ## ADR Links
 

--- a/crates/khive-runtime/docs/atomic-plan.md
+++ b/crates/khive-runtime/docs/atomic-plan.md
@@ -1,0 +1,15 @@
+# Atomic Plan — Prepared Write-Plan Shapes
+
+`atomic_plan.rs` (ADR-099, cross-op atomicity for bulk apply) defines the prepared write-plan
+*shapes* consumed by the atomic runner (`docs/api/atomic_runner.md`): one family per admissible
+verb group. This document covers why plans are structured the way they are — the design
+rationale behind guard placement is not obvious from the type shape alone.
+
+## Why guards are per-statement, not per-plan
+
+A guard is attached to the exact `PlanStatement` it validates, never to the plan as a whole:
+affected-row counts come back per-statement or as a batch total, so a plan-level guard field
+could not tell a runner which statement's count it is checking. Each plan therefore carries
+`Vec<PlanStatement>` (or, for `merge`, the split `rewires`/`lifecycle` fields), and the runner
+applies each statement individually, checking any present guard against that statement's own
+affected-row count before moving to the next.

--- a/crates/khive-runtime/src/atomic_plan.rs
+++ b/crates/khive-runtime/src/atomic_plan.rs
@@ -4,29 +4,20 @@
 //! transaction; commit later applies its statements as DML under a per-op
 //! SAVEPOINT. This module defines the plan *shapes* only, one family per
 //! admissible verb group (`update`, `delete`, `link`, `merge`,
-//! `gtd.transition`, `gtd.complete`, the governance verbs): not yet wired
-//! into a live handler or the dispatch path.
+//! `gtd.transition`, `gtd.complete`, the governance verbs) — not yet wired
+//! into a live handler or the dispatch path. Every plan is deliberately
+//! inert (plain data, no async, no embedding reference).
 //!
-//! Every plan is deliberately inert (plain data, no async, no embedding
-//! reference) and exists to satisfy two validation-staleness rules:
+//! Two validation-staleness invariants every plan must satisfy:
+//! 1. **Predicate-based plans** carry an "all rows matching a condition"
+//!    effect as a statement evaluated inside the transaction
+//!    (`PlanPredicate`), never as a prepare-time-enumerated row list.
+//! 2. **Affected-row guards** (`PlanStatement::guard`) are attached to the
+//!    exact statement they validate, checked in-transaction; a mismatch
+//!    fails the op and rolls back the whole unit.
 //!
-//! 1. **Predicate-based plans** — a plan whose effect covers "all rows
-//!    matching a condition" carries that condition as a statement evaluated
-//!    inside the transaction, never as a prepare-time-enumerated row list
-//!    (`PlanPredicate`).
-//! 2. **Affected-row guards** — any statement whose prepare-time validation
-//!    assumed a target row exists carries an expected-effect guard, checked
-//!    in-transaction; a mismatch fails the op and rolls back the whole unit
-//!    (`PlanStatement::guard`).
-//!
-//! A guard is attached to the exact [`PlanStatement`] it validates, never to
-//! the plan as a whole: affected-row counts come back per-statement or as a
-//! batch total, so a plan-level guard field could not tell a runner which
-//! statement's count it is checking. Each plan therefore carries
-//! `Vec<PlanStatement>` (or, for `merge`, the split `rewires`/`lifecycle`
-//! fields below), and the runner applies each statement individually,
-//! checking any present guard against that statement's own affected-row
-//! count before moving to the next.
+//! See `docs/atomic-plan.md` for why guards are per-statement rather than
+//! per-plan.
 
 use uuid::Uuid;
 

--- a/crates/khive-runtime/src/atomic_prepare.rs
+++ b/crates/khive-runtime/src/atomic_prepare.rs
@@ -13,7 +13,7 @@
 //! module (`prepare_governance_unimplemented` fails loudly rather than
 //! silently no-opping; `prepare_merge` is unreachable through `--atomic` and
 //! kept only for its own tests and as defense in depth). See
-//! `docs/atomic_prepare.md#module-scope` for why each of these is excluded
+//! `docs/api/atomic_prepare.md#scope-what-is-excluded-and-why` for why each of these is excluded
 //! and what would be required to admit them.
 
 use serde_json::Value;
@@ -299,7 +299,7 @@ async fn push_index_purge_statements(
 /// `EntityUpdated`, `delete_entity` -> `EntityDeleted`, `delete_note` ->
 /// `NoteDeleted`, `update_edge` -> `EdgeUpdated`, `delete_edge` ->
 /// `EdgeDeleted`. `update_note` and `link` append no event and must never
-/// call this. See `docs/atomic_prepare.md#event_append_statements` for why
+/// call this. See `docs/api/atomic_prepare.md#event_append_statements` for why
 /// this is a `PlanStatement` rather than a `PostCommitEffect`.
 ///
 /// Invariant: returned statements are unguarded — appended after the plan's
@@ -803,7 +803,7 @@ pub async fn prepare_update_entity_plan(
 /// patch semantics: `relation`/`weight`/`properties` are the only applicable
 /// fields, a changed `relation` is endpoint-validated first, `weight` is
 /// range-checked, and `properties` REPLACES `metadata` wholesale (no merge).
-/// See `docs/atomic_prepare.md#prepare_update_edge` for the DML-shape parity
+/// See `docs/api/atomic_prepare.md#prepare_update_edge` for the DML-shape parity
 /// detail with `update_edge`.
 ///
 /// Invariant (symmetric relations `competes_with`/`composed_with`): this

--- a/crates/khive-runtime/src/atomic_runner.rs
+++ b/crates/khive-runtime/src/atomic_runner.rs
@@ -4,47 +4,25 @@
 //! [`SqlAccess::atomic_unit`], under a per-op `SAVEPOINT`, committing every
 //! plan or rolling back the whole unit.
 //!
-//! This module is the **mechanism only**. It has no production caller in
-//! B2 — no verb dispatch, no CLI `--atomic` surface, no daemon wiring.
-//! Tests in this file are the only consumer; wiring a real per-verb
-//! `prepare` step (ops → [`AtomicOpPlan`]) and the `exec --ops-file
-//! --atomic` CLI surface is ADR-099 migration steps 1 (cont'd) and 4 — the
-//! **B3 wiring point** referenced throughout this file.
+//! This module is the **mechanism only**: no production caller yet (no verb
+//! dispatch, no CLI `--atomic` surface, no daemon wiring — tests here are the
+//! only consumer). See `docs/api/atomic_runner.md` for wiring status and the
+//! full two/three-phase shape (ADR-099 D1).
 //!
-//! # The atomic-unit suspend-free invariant, restated at this seam
+//! # Safety: suspend-free invariant
 //!
 //! [`run_atomic_unit`] is the one place in this crate that builds an
-//! [`AtomicUnitOp`] closure and hands it to [`SqlAccess::atomic_unit`]. That
-//! trait method carries a hard contract (its own doc comment,
-//! `crates/khive-storage/src/sql.rs`, and `crates/khive-db/src/sql_bridge.rs`
-//! `block_on_sync`): **the closure's future must resolve on its first
-//! poll** — synchronous DML against the provided `&mut dyn SqlWriter` only,
-//! never a real `.await` on embedding, ANN warming, or any other suspending
-//! work. This module honors that invariant structurally, not by convention:
-//! every statement the commit-pass closure below drives comes from
-//! `AtomicOpPlan::plan_statements` (private — the runner's own internal
-//! flattening step), which can only ever produce
-//! [`PlanStatement`]s — plain parameterized SQL, the same shape ADR-099 D1's
-//! prepare pass produces for the v1 DML-only admissible verb set (ADR-099
-//! D3). There is no code path in this module that can hand `atomic_unit` an
-//! embedding call or any other suspending future — see the paired
-//! suspend-trap tests at the bottom of this file for the two things this
-//! promise is checked against: the real commit pass resolving on first poll
-//! (the happy-path proof), and a hand-built closure that deliberately
-//! suspends failing loudly through the exact same seam (the misuse-is-caught
-//! proof).
-//!
-//! # Two-phase shape (ADR-099 D1)
-//!
-//! Only the **commit pass** (phase 2) lives here: given an already-prepared
-//! `Vec<AtomicOpPlan>` (phase 1, the async prepare pass, is out of scope for
-//! B2 — a test-only caller constructs plans directly), [`run_atomic_unit`]
-//! opens one `atomic_unit`, applies each plan's statements under a named
-//! `SAVEPOINT`, and returns either every op's collected
-//! [`PostCommitEffect`]s (phase 3, the async post-commit pass — this is the
-//! **B3 wiring point**: nothing in B2 executes these effects, a test
-//! consumer only drains the returned list) or the first op's failure and its
-//! index.
+//! [`AtomicUnitOp`] closure for [`SqlAccess::atomic_unit`], whose contract
+//! requires the closure's future to resolve on its first poll — synchronous
+//! DML against the provided `&mut dyn SqlWriter` only, never a suspending
+//! `.await`. Every statement driven here comes from
+//! `AtomicOpPlan::plan_statements`, which can only ever produce
+//! [`PlanStatement`]s (plain parameterized SQL), so no code path in this
+//! module can hand `atomic_unit` a suspending future. The paired
+//! suspend-trap tests at the bottom of this file check both the happy-path
+//! (real commit pass resolves on first poll) and the misuse-is-caught case
+//! (a hand-built suspending closure fails loudly through the same seam). See
+//! `docs/api/atomic_runner.md#suspend-free-invariant` for the full argument.
 
 use std::any::Any;
 use std::sync::{Arc, Mutex};

--- a/crates/khive-runtime/src/daemon.rs
+++ b/crates/khive-runtime/src/daemon.rs
@@ -45,7 +45,7 @@ pub const MAX_FRAME_BYTES: usize = 8 * 1024 * 1024;
 /// in every request; the daemon rejects mismatches with an explicit error
 /// that names both sides so the operator knows exactly what to do
 /// (`make local` rebuilds the client binary).
-/// See `docs/daemon.md#protocol_version` for the version-by-version history.
+/// See `docs/api/daemon.md#protocol_version` for the version-by-version history.
 pub const PROTOCOL_VERSION: u32 = 3;
 
 #[cfg(unix)]
@@ -162,7 +162,7 @@ pub fn acquire_recovery_lock() -> Option<std::fs::File> {
 /// Attempt to acquire an exclusive advisory flock on `path`, retrying with a
 /// non-blocking `flock(LOCK_NB)` until `deadline` elapses. Bounded alternative
 /// to `acquire_recovery_lock`/`acquire_daemon_boot_guard`'s unbounded blocking
-/// flock — see `docs/daemon.md#try_acquire_flock_until` for why a caller
+/// flock — see `docs/api/daemon.md#try_acquire_flock_until` for why a caller
 /// merely detecting lock freedom needs a deadline instead.
 ///
 /// - `Ok(Some(file))` — the lock was free within the deadline.
@@ -705,7 +705,7 @@ pub fn active_phase_names() -> Vec<String> {
 /// Build a point-in-time [`MetricsSnapshot`] of this process's server-side
 /// gauges. Called only from `handle_conn`'s `metrics_only` arm — a
 /// process-global, read-only assembly with no side effects of its own.
-/// See `docs/daemon.md#build_metrics_snapshot` for where each gauge is sourced
+/// See `docs/api/daemon.md#build_metrics_snapshot` for where each gauge is sourced
 /// from and why.
 #[cfg(unix)]
 fn build_metrics_snapshot<D: DaemonDispatch>(dispatcher: &D) -> MetricsSnapshot {

--- a/crates/khive-runtime/src/pack.rs
+++ b/crates/khive-runtime/src/pack.rs
@@ -183,14 +183,14 @@ pub trait PackRuntime: Send + Sync {
     /// initialisation, before the first verb dispatch, so `KhiveRuntime::embedder(name)`
     /// resolves provider names declared here. Default no-op — packs that only use
     /// built-in lattice models do not need to override this.
-    /// See `docs/pack.md#register_embedders` for a usage example.
+    /// See `docs/api/pack.md#register_embedders` for a usage example.
     fn register_embedders(&self, _runtime: &KhiveRuntime) {}
 
     /// Install a pack-owned entity-type validator on the runtime, called during pack
     /// initialisation (after the registry is built, before the first dispatch) so
     /// `create_many`/`create_entity` reject unregistered `entity_type` values at the
     /// runtime layer. Default no-op leaves the validator absent (skip-when-None).
-    /// See `docs/pack.md#register_entity_type_validator` for the two-hook compatibility contract.
+    /// See `docs/api/pack.md#register_entity_type_validator` for the two-hook compatibility contract.
     fn register_entity_type_validator(&self, _runtime: &KhiveRuntime) {}
 
     /// Install a pack-owned entity-type validator that also receives the boot-time
@@ -198,7 +198,7 @@ pub trait PackRuntime: Send + Sync {
     /// Defaults to calling [`register_entity_type_validator`](Self::register_entity_type_validator)
     /// with just the runtime. `call_register_entity_type_validators` calls this hook, not
     /// the simpler one — override this to receive the composed vocabulary.
-    /// See `docs/pack.md#register_entity_type_validator` for the two-hook compatibility contract.
+    /// See `docs/api/pack.md#register_entity_type_validator` for the two-hook compatibility contract.
     fn register_entity_type_validator_with_types(
         &self,
         runtime: &KhiveRuntime,
@@ -212,7 +212,7 @@ pub trait PackRuntime: Send + Sync {
     /// that cache derived state keyed by note content (e.g. `khive-pack-memory`'s warm
     /// ANN index) override this to install a hook via
     /// `KhiveRuntime::install_note_mutation_hook`. Default no-op leaves the hook absent.
-    /// See `docs/pack.md#register_note_mutation_hook` for cross-pack notification rationale.
+    /// See `docs/api/pack.md#register_note_mutation_hook` for cross-pack notification rationale.
     fn register_note_mutation_hook(&self, _runtime: &KhiveRuntime) {}
 
     /// Warm up any in-memory state from persisted snapshots (optional). Called after
@@ -223,7 +223,7 @@ pub trait PackRuntime: Send + Sync {
     /// Names of all embedding models registered on this pack's underlying runtime
     /// handle. Defaults to empty — only packs that own embedding-bearing verbs
     /// (kg, memory) need to override this.
-    /// See `docs/pack.md#registered_embedding_model_names` for the ADR-103 consumer.
+    /// See `docs/api/pack.md#registered_embedding_model_names` for the ADR-103 consumer.
     fn registered_embedding_model_names(&self) -> Vec<String> {
         Vec::new()
     }
@@ -1043,7 +1043,7 @@ impl VerbRegistry {
     /// `self.visible_namespaces` for this call's namespace resolution, gate
     /// request, and token minting. The registry's own fields are never mutated,
     /// so concurrent calls with different (or no) identity are independent.
-    /// See `docs/pack.md#dispatch_with_identity` for why this enables one warm
+    /// See `docs/api/pack.md#dispatch_with_identity` for why this enables one warm
     /// registry to serve many attribution identities over a shared backend.
     pub async fn dispatch_with_identity(
         &self,
@@ -1507,7 +1507,7 @@ impl VerbRegistry {
     /// `identity.actor_id = Some(verified_actor)` and every other identity scalar
     /// (namespace, visible namespaces) left at this registry's construction-baked
     /// value. [`Self::dispatch`] and [`Self::dispatch_with_identity`] are unaffected.
-    /// See `docs/pack.md#dispatch_as` for the embedding-host use case and the
+    /// See `docs/api/pack.md#dispatch_as` for the embedding-host use case and the
     /// blank-identifier safety rationale.
     pub async fn dispatch_as(
         &self,
@@ -2170,7 +2170,7 @@ fn target_id_from_args(args: &serde_json::Value) -> Option<uuid::Uuid> {
 }
 
 /// Build a v1-shape audit storage event from a gate check outcome.
-/// See `docs/pack.md#build_audit_storage_event` for the `resource` payload contract.
+/// See `docs/api/pack.md#build_audit_storage_event` for the `resource` payload contract.
 fn build_audit_storage_event(
     gate_req: &GateRequest,
     audit: &AuditEvent,
@@ -2216,7 +2216,7 @@ async fn append_audit_event_best_effort(store: &Arc<dyn EventStore>, event: Even
 }
 
 /// Schema v2 audit payload for a successful singleton `link` call — additive
-/// over v1 via `#[serde(flatten)]`. See `docs/pack.md#linkauditsuccessv2`.
+/// over v1 via `#[serde(flatten)]`. See `docs/api/pack.md#linkauditsuccessv2`.
 #[derive(Debug, Clone, serde::Serialize)]
 struct LinkAuditSuccessV2 {
     #[serde(flatten)]
@@ -2230,7 +2230,7 @@ struct LinkAuditSuccessV2 {
 
 /// Extract edge fields to enrich a successful singleton `link` audit row.
 /// Returns `None` on any missing/malformed field (falls back to v1 shape).
-/// See `docs/pack.md#link_audit_success_from_result`.
+/// See `docs/api/pack.md#link_audit_success_from_result`.
 fn link_audit_success_from_result(
     audit: AuditEvent,
     result: &serde_json::Value,
@@ -2271,7 +2271,7 @@ fn link_audit_success_from_result(
 ///   default namespace.
 ///
 /// Single chokepoint for both `VerbRegistry::dispatch` and the multi-backend
-/// coordinator intercept — see `docs/pack.md#resolve_explicit_namespace`.
+/// coordinator intercept — see `docs/api/pack.md#resolve_explicit_namespace`.
 pub fn resolve_explicit_namespace(
     params: &Value,
     default_namespace: &str,

--- a/crates/khive-runtime/src/secret_gate.rs
+++ b/crates/khive-runtime/src/secret_gate.rs
@@ -26,7 +26,7 @@
 //! matching, the underscore-boundary asymmetry between bare trigger words and
 //! the word `token`, and the adversarial-corpus rationale for why some
 //! false positives are accepted) are documented in full in
-//! `docs/secret_gate.md#module-level-detection-algorithm` — read that before
+//! `docs/api/secret_gate.md#module-level-detection-algorithm` — read that before
 //! changing any detection or exemption logic in this file.
 //!
 //! The caller-visible block message (`SecretMatch`'s `Display` impl) also
@@ -227,7 +227,7 @@ fn scan(text: &str) -> Option<SecretMatch> {
 /// an allocation. Spans are discovered left to right against the ORIGINAL text,
 /// always evaluating trigger context over the full input — a high-entropy value
 /// whose only trigger word sits to the left of an earlier-redacted secret is
-/// still detected. See `docs/secret_gate.md#mask_secrets` for the scan-cursor
+/// still detected. See `docs/api/secret_gate.md#mask_secrets` for the scan-cursor
 /// mechanics.
 pub fn mask_secrets(text: &str) -> std::borrow::Cow<'_, str> {
     let base = text.as_ptr() as usize;
@@ -524,7 +524,7 @@ fn find_url_userinfo(text: &str) -> Option<&str> {
 /// Trigger words checked as a bounded standalone word (see
 /// [`contains_bounded_word`]). `token` is deliberately excluded — see
 /// `has_standalone_token`/`has_token_assignment` instead.
-/// See `docs/secret_gate.md#trigger_words` for the substring-collision
+/// See `docs/api/secret_gate.md#trigger_words` for the substring-collision
 /// rationale (issues #577 / #632).
 const TRIGGER_WORDS: &[&str] = &[
     "key",
@@ -715,7 +715,7 @@ fn check_entropy_heuristic(text: &str, from: usize) -> Option<(&str, &'static st
 /// bounded on both sides by a character outside the word-char set (or
 /// start/end of string) — rather than merely as a substring.
 /// `underscore_is_word_char` selects the boundary rule the caller needs; see
-/// `docs/secret_gate.md#contains_word` for the two deliberately different
+/// `docs/api/secret_gate.md#contains_word` for the two deliberately different
 /// rules and why each caller needs its own.
 fn contains_word(low_window: &str, needle: &str, underscore_is_word_char: bool) -> bool {
     let is_word_char = |c: char| c.is_ascii_alphanumeric() || (underscore_is_word_char && c == '_');
@@ -903,7 +903,7 @@ fn is_pure_hex(token: &str) -> bool {
 /// Returns `true` for tokens that are unambiguous base64/base64url content
 /// hashes with an explicit `sha<N>-` prefix (SRI hash, npm lockfile integrity).
 /// Bare base64 of the same length WITHOUT the prefix is NOT allowlisted — see
-/// `docs/secret_gate.md#is_base64_content_hash` for the full criteria list and
+/// `docs/api/secret_gate.md#is_base64_content_hash` for the full criteria list and
 /// why the explicit prefix is required.
 fn is_base64_content_hash(token: &str) -> bool {
     // Known vendor prefixes — never allowlist even if they look like base64.
@@ -986,7 +986,7 @@ const MAX_CASE_TRANSITION_DENSITY: f64 = 0.3;
 /// other structured identifier rather than a high-entropy secret (word-shaped
 /// runs separated by `/`, `-`, `_`, `.`). Exempts from the entropy heuristic
 /// ONLY outside trigger context — see the module doc and
-/// `docs/secret_gate.md#is_structured_identifier` for the run-shape criteria.
+/// `docs/api/secret_gate.md#is_structured_identifier` for the run-shape criteria.
 fn is_structured_identifier(token: &str) -> bool {
     if !token.contains(|c: char| STRUCTURAL_SEPARATORS.contains(&c)) {
         return false;
@@ -1092,7 +1092,7 @@ fn wrapper_strip_repeated(token: &str) -> &str {
 
 /// Yields every candidate value an assignment/wrapper-glued token could
 /// contain, for the near-trigger UUID/content-hash exact-shape checks only.
-/// See `docs/secret_gate.md#value_candidates` for why every `=`/`:` suffix
+/// See `docs/api/secret_gate.md#value_candidates` for why every `=`/`:` suffix
 /// must be tried rather than just the first or last.
 fn value_candidates(token: &str) -> impl Iterator<Item = &str> {
     let cur = wrapper_strip_repeated(token);

--- a/crates/khive-runtime/src/validation.rs
+++ b/crates/khive-runtime/src/validation.rs
@@ -124,7 +124,7 @@ pub struct GraphPatch;
 /// A pack-contributed validation rule.
 ///
 /// Rule IDs must follow the `<pack>/<rule-id>` namespace convention.
-/// See `docs/validation.md` for declaration examples and severity override rules.
+/// See `docs/api/validation.md` for declaration examples and severity override rules.
 pub struct ValidationRule {
     /// Stable rule identifier in `<pack>/<rule-id>` format.
     pub id: RuleId,


### PR DESCRIPTION
## What

Pass-2 refinement of the khive-runtime rustdoc condensation: restructures the extracted markdown into proper topic-organized reference docs and trims inline doc-comments further.

- `crates/khive-runtime/docs/api/` — function-specific technical reference, one coherent topic doc per subsystem: `atomic_prepare`, `atomic_runner`, `daemon`, `pack`, `secret_gate`, `validation`.
- `crates/khive-runtime/docs/` — design/concept docs (`design.md`, `protocol.md`, `atomic-plan.md`).
- Inline rustdoc keeps a concise standalone contract per public item plus a plain-text pointer to the relevant `docs/api/` section; exhaustive considerations live in the api doc.

## Preserved

- Public API doc-comments remain complete and standalone on docs.rs.
- No `# Safety`, invariant, ordering, or error-enumeration docs thinned.
- All relocated content lands in the api/design docs — relocation, not deletion.

## Verification

`cargo clippy -p khive-runtime --all-targets -- -D warnings` and `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps -p khive-runtime` both clean at this head (single cherry-picked commit onto current main).