### PR TITLE
docs: pass-2 review-fix follow-up (runtime/vcs/hnsw) — findings from #1011-#1014 codex rounds

### DIFF
--- a/crates/khive-hnsw/docs/algorithm.md
+++ b/crates/khive-hnsw/docs/algorithm.md
@@ -37,7 +37,7 @@ Defaults are tuned for `m=20` which is optimal for k=10 recall at 384d (empirica
 improve cache locality during graph traversal. All nodes for a given layer are stored in a
 contiguous `Vec`, with inter-node references stored as integer indices rather than pointers.
 
-See `src/arena/` and `docs/arena.md` for full design rationale.
+See `src/arena/` and `docs/api/arena.md` for full design rationale.
 
 ## Tombstone Handling
 
@@ -52,7 +52,7 @@ edges. See `TombstoneStats` for monitoring.
 `HnswCheckpoint` stores the snapshot plus metadata for incremental recovery. Load a checkpoint
 with `HnswCheckpointStore::load` after crash or restart.
 
-See `docs/checkpoint.md` for tombstone tracking, determinism, and khive-fold integration.
+See `docs/api/checkpoint.md` for tombstone tracking, determinism, and khive-fold integration.
 
 ## Tests and Benchmarks
 

--- a/crates/khive-runtime/docs/api/atomic_runner.md
+++ b/crates/khive-runtime/docs/api/atomic_runner.md
@@ -8,7 +8,7 @@ module is one piece of, and its current wiring status.
 
 ## Wiring status (ADR-099 — B3 shipped)
 
-This module is the synchronous commit-pass piece of the shipped ADR-099 B3 flow. The production
+This module is the synchronous commit-pass piece of the shipped ADR-099 B3 flow. The ADR-099 B3
 caller is `kkernel exec --ops-file --atomic` (see `kkernel`'s `atomic_apply` module): it runs the
 parse-time admissibility check (B1), drives the async prepare pass (ops → `AtomicOpPlan`), calls
 `run_atomic_unit` here for the one synchronous commit pass (B2), then applies the async
@@ -18,6 +18,11 @@ governance verbs (`propose`, `review`, `withdraw`) remain conceptually admissibl
 ADR-099 D3 but are rejected up front as known-unimplemented (`ATOMIC_KNOWN_UNIMPLEMENTED_VERBS`
 in `khive-types`) — no full-parity prepare/apply seam exists for them yet. Embedding-bearing,
 read, or unlisted verbs are likewise rejected before any write.
+
+The CLI is not the runner's sole production consumer: runtime callers can also supply prepared
+plans directly — the hard-delete path (`atomic_hard_delete_with_edge_purge` in `operations.rs`)
+constructs a `DeletePlan` and invokes `run_atomic_unit` for its row-delete + incident-edge purge.
+Tests construct plans directly as well.
 
 ## Suspend-free invariant
 
@@ -43,8 +48,8 @@ proof).
 ## Two-phase shape (ADR-099 D1)
 
 Only the **commit pass** (phase 2) lives here: given an already-prepared `Vec<AtomicOpPlan>`
-(phase 1, the async prepare pass, is out of scope for B2 — a test-only caller constructs plans
-directly), `run_atomic_unit` opens one `atomic_unit`, applies each plan's statements under a
+(phase 1, the async prepare pass, is out of scope for B2), `run_atomic_unit` opens one
+`atomic_unit`, applies each plan's statements under a
 named `SAVEPOINT`, and returns either every op's collected `PostCommitEffect`s (phase 3, the
 async post-commit pass — the B3 wiring point: nothing in B2 executes these effects, a test
 consumer only drains the returned list) or the first op's failure and its index.

--- a/crates/khive-runtime/docs/api/atomic_runner.md
+++ b/crates/khive-runtime/docs/api/atomic_runner.md
@@ -12,9 +12,12 @@ This module is the synchronous commit-pass piece of the shipped ADR-099 B3 flow.
 caller is `kkernel exec --ops-file --atomic` (see `kkernel`'s `atomic_apply` module): it runs the
 parse-time admissibility check (B1), drives the async prepare pass (ops → `AtomicOpPlan`), calls
 `run_atomic_unit` here for the one synchronous commit pass (B2), then applies the async
-post-commit effects (reindex). Only the v1 admissible verb set (`update`, `delete`, `link`,
-`merge`, `gtd.transition`, `gtd.complete`) may appear in an atomic ops-file; embedding-bearing,
-read, or unlisted verbs are rejected before any write.
+post-commit effects (reindex). Only the currently executable verb set (`update`, `delete`,
+`link`, `gtd.transition`, `gtd.complete`) may appear in an atomic ops-file. `merge` and the
+governance verbs (`propose`, `review`, `withdraw`) remain conceptually admissible under
+ADR-099 D3 but are rejected up front as known-unimplemented (`ATOMIC_KNOWN_UNIMPLEMENTED_VERBS`
+in `khive-types`) — no full-parity prepare/apply seam exists for them yet. Embedding-bearing,
+read, or unlisted verbs are likewise rejected before any write.
 
 ## Suspend-free invariant
 

--- a/crates/khive-runtime/docs/api/atomic_runner.md
+++ b/crates/khive-runtime/docs/api/atomic_runner.md
@@ -6,13 +6,15 @@ migration: given an already-prepared sequence of write plans, it applies them as
 whole unit. This document covers the suspend-free safety argument, the three-phase shape the
 module is one piece of, and its current wiring status.
 
-## Wiring status (ADR-099 migration step 3, sub-slice B2)
+## Wiring status (ADR-099 — B3 shipped)
 
-This module is the **mechanism only**. It has no production caller in B2 — no verb dispatch, no
-CLI `--atomic` surface, no daemon wiring. Tests in this file are the only consumer. Wiring a real
-per-verb `prepare` step (ops → `AtomicOpPlan`) and the `exec --ops-file --atomic` CLI surface is
-ADR-099 migration steps 1 (cont'd) and 4 — referred to throughout the source as the **B3 wiring
-point**.
+This module is the synchronous commit-pass piece of the shipped ADR-099 B3 flow. The production
+caller is `kkernel exec --ops-file --atomic` (see `kkernel`'s `atomic_apply` module): it runs the
+parse-time admissibility check (B1), drives the async prepare pass (ops → `AtomicOpPlan`), calls
+`run_atomic_unit` here for the one synchronous commit pass (B2), then applies the async
+post-commit effects (reindex). Only the v1 admissible verb set (`update`, `delete`, `link`,
+`merge`, `gtd.transition`, `gtd.complete`) may appear in an atomic ops-file; embedding-bearing,
+read, or unlisted verbs are rejected before any write.
 
 ## Suspend-free invariant
 

--- a/crates/khive-runtime/docs/api/validation.md
+++ b/crates/khive-runtime/docs/api/validation.md
@@ -1,25 +1,45 @@
 # KG Validation Pipeline
 
-`validation.rs` defines the pack-contributed KG validation pipeline: how a pack declares a
-`ValidationRule`, how severity levels map to `kkernel kg validate` exit behavior, and where rule
-configuration is read from at runtime.
+`validation.rs` defines the pack-contributed KG validation API: the `ValidationRule` /
+`ValidationContext` / `Violation` types a pack declares through `PackRuntime::validation_rules()`.
+Two distinct validation surfaces exist under ADR-034, in different states of wiring — this
+document keeps them separate, because only one of them runs today.
 
 ## ADR Links
 
 - [ADR-034](../../../../docs/adr/ADR-034-kg-validation-pipelines.md) — KG validation pipelines specification
 
-## Rule Configuration File
+## 1. Shipped: the data-driven TOML RulePass
 
-Rules are configured at `.khive/kg/rules.toml` (TOML format, per ADR-034).
-The `ValidationContext::config` map is populated from that file at runtime.
+What `kkernel kg validate` actually executes today is the ADR-020 built-in structural checks
+plus an optional TOML RulePass: when `.khive/kg/rules.toml` exists and `--no-rules` is not set,
+each `[[rules]]` entry (`kind = "entity"` or `"edge"`, optional `condition`, optional
+`require_field`, `message` with `{id}` substitution) runs after the structural pass. Severity
+for these data-driven rules is configured per rule in `rules.toml`:
 
-## Rule Declaration
+- `Error` — `kkernel kg validate` exits with code 1.
+- `Warning` — reported; no exit-code effect unless `--strict`.
+- `Info` — informational; no exit-code effect.
+
+This TOML pass does not go through the Rust `ValidationRule` API below — it is a separate,
+data-driven runner.
+
+## 2. Declared but deferred: the Rust pack-validator API
+
+The types in `validation.rs` are shipped API surface, but **the CLI runner does not call them**
+(ADR-034 "What changes and what does not"): `kkernel kg validate` never invokes
+`PackRuntime::validation_rules()` against live corpus data, `VerbRegistry::all_validation_rules`
+currently has no non-test caller, no runtime-populated `ValidationContext` is constructed, and a
+declared rule cannot yet affect validation output, CLI exit status, or auto-fix behavior. Wiring
+this API into the CLI runner is explicitly deferred by ADR-034.
+
+### Rule Declaration
 
 Pack authors declare an array of `ValidationRule` in their `PackRuntime::validation_rules()`
-method. Rule IDs must follow `<pack>/<rule-id>` namespace convention. Built-in rules
+method. Rule IDs must follow the `<pack>/<rule-id>` namespace convention. Built-in rules
 use no pack prefix (e.g. `"min-edge-density"`).
 
-## Rule Shape
+### Rule Shape
 
 ```rust
 pub struct ValidationRule {
@@ -31,26 +51,22 @@ pub struct ValidationRule {
 }
 ```
 
-## Severity Levels
+The `Severity` values carry the same intended exit-code semantics as §1, but for
+pack-declared rules those semantics are design intent, not current behavior — nothing
+executes these rules yet.
 
-- `Error` — `kkernel kg validate` exits with code 1.
-- `Warning` — reported; no exit-code effect unless `--strict`.
-- `Info` — informational; no exit-code effect.
-
-Severity can be overridden per rule in `.khive/kg/rules.toml`.
-
-## GraphPatch
+### GraphPatch
 
 `GraphPatch` is a deferred stub (ADR-034 §auto-fix write path is deferred). The auto-fix
-write path is not yet implemented; `fix: Some(...)` is reserved for future use.
+write path is not implemented; `fix: Some(...)` is reserved for future use.
 
-## Invariants
+### Invariants (design contract for the deferred runner)
 
 - Rule IDs must be unique across all loaded packs.
 - Pack-contributed rules must carry the pack namespace prefix.
 - `CorpusCheck` receives a `GraphSnapshot`; it must not reach through to the storage layer.
 
-## Failure Modes
+### Failure Modes (apply once the runner is wired)
 
 | Condition           | Behaviour                                                 |
 | ------------------- | --------------------------------------------------------- |

--- a/crates/khive-runtime/docs/api/validation.md
+++ b/crates/khive-runtime/docs/api/validation.md
@@ -6,15 +6,12 @@ configuration is read from at runtime.
 
 ## ADR Links
 
-- [ADR-034](../../../docs/adr/ADR-034-kg-validation-pipelines.md) — KG validation pipelines specification
+- [ADR-034](../../../../docs/adr/ADR-034-kg-validation-pipelines.md) — KG validation pipelines specification
 
 ## Rule Configuration File
 
 Rules are configured at `.khive/kg/rules.toml` (TOML format, per ADR-034).
 The `ValidationContext::config` map is populated from that file at runtime.
-
-Note: source comments in `validation.rs` that reference `rules.yaml` are a documentation
-error; the canonical format is `.toml` per ADR-034.
 
 ## Rule Declaration
 

--- a/crates/khive-runtime/docs/api/validation.md
+++ b/crates/khive-runtime/docs/api/validation.md
@@ -14,8 +14,13 @@ document keeps them separate, because only one of them runs today.
 What `kkernel kg validate` actually executes today is the ADR-020 built-in structural checks
 plus an optional TOML RulePass: when `.khive/kg/rules.toml` exists and `--no-rules` is not set,
 each `[[rules]]` entry (`kind = "entity"` or `"edge"`, optional `condition`, optional
-`require_field`, `message` with `{id}` substitution) runs after the structural pass. Severity
-for these data-driven rules is configured per rule in `rules.toml`:
+`require_field`, `message` with `{id}` substitution) runs after the structural pass. The TOML
+file also accepts five opt-in named rule-class tables, evaluated after the generic `[[rules]]`
+entries: `edge_endpoint_types` (endpoint contract against the live pack/base allowlist),
+`edge_direction_conventions`, `dangling_refs`, `naming_conventions`, and `citation_date_lint`
+(full syntax: `RulesFile` in `crates/kkernel/src/kg/validate.rs` and the kg-rules guide,
+`crates/kkernel/docs/kg-rules.md`). Severity for these data-driven rules is configured per
+rule in `rules.toml`:
 
 - `Error` — `kkernel kg validate` exits with code 1.
 - `Warning` — reported; no exit-code effect unless `--strict`.

--- a/crates/khive-runtime/src/atomic_runner.rs
+++ b/crates/khive-runtime/src/atomic_runner.rs
@@ -4,10 +4,10 @@
 //! [`SqlAccess::atomic_unit`], under a per-op `SAVEPOINT`, committing every
 //! plan or rolling back the whole unit.
 //!
-//! This module is the **mechanism only**: no production caller yet (no verb
-//! dispatch, no CLI `--atomic` surface, no daemon wiring — tests here are the
-//! only consumer). See `docs/api/atomic_runner.md` for wiring status and the
-//! full two/three-phase shape (ADR-099 D1).
+//! Production caller: `kkernel exec --ops-file --atomic` (ADR-099 B3) — async
+//! prepare, then this runner's one synchronous commit pass, then async
+//! post-commit effects. See `docs/api/atomic_runner.md` for the full
+//! three-phase shape (ADR-099 D1).
 //!
 //! # Safety: suspend-free invariant
 //!

--- a/crates/khive-runtime/src/atomic_runner.rs
+++ b/crates/khive-runtime/src/atomic_runner.rs
@@ -4,9 +4,10 @@
 //! [`SqlAccess::atomic_unit`], under a per-op `SAVEPOINT`, committing every
 //! plan or rolling back the whole unit.
 //!
-//! Production caller: `kkernel exec --ops-file --atomic` (ADR-099 B3) — async
-//! prepare, then this runner's one synchronous commit pass, then async
-//! post-commit effects. See `docs/api/atomic_runner.md` for the full
+//! ADR-099 B3 caller: `kkernel exec --ops-file --atomic` — async prepare,
+//! then this runner's one synchronous commit pass, then async post-commit
+//! effects. Runtime callers also supply prepared plans directly (hard-delete
+//! in `operations.rs`). See `docs/api/atomic_runner.md` for the full
 //! three-phase shape (ADR-099 D1).
 //!
 //! # Safety: suspend-free invariant

--- a/crates/khive-runtime/src/validation.rs
+++ b/crates/khive-runtime/src/validation.rs
@@ -45,8 +45,10 @@ pub struct GraphSnapshot {
 
 /// Context passed to all rule implementations.
 ///
-/// Carries configuration overrides from `.khive/kg/rules.toml` merged with
-/// pack defaults. Rules read per-rule config from `config[rule_id]`.
+/// Design contract for the deferred pack-rule runner (ADR-034): once wired,
+/// it will carry configuration overrides from `.khive/kg/rules.toml` merged
+/// with pack defaults, read per-rule from `config[rule_id]`. No runtime code
+/// currently constructs a populated `ValidationContext`.
 #[non_exhaustive]
 pub struct ValidationContext<'a> {
     /// The corpus snapshot for whole-corpus rules.
@@ -106,8 +108,10 @@ pub type RuleFn = fn(&ValidationContext<'_>) -> Vec<Violation>;
 /// Optional auto-fix function type.
 ///
 /// Receives the context and violations emitted by the corresponding `RuleFn`.
-/// Returns a `GraphPatch` (opaque in v1 — see below) that the validator applies
-/// before writing NDJSON. Returning `None` leaves the graph unchanged.
+/// Returns a `GraphPatch` (opaque in v1 — see below). Applying patches is part
+/// of the deferred auto-fix write path (ADR-034) — no validator currently
+/// invokes fix functions or applies patches. Returning `None` leaves the graph
+/// unchanged.
 ///
 /// `GraphPatch` is a placeholder type in v1; the auto-fix write path is out of
 /// scope for this cluster.
@@ -126,11 +130,13 @@ pub struct GraphPatch;
 /// A pack-contributed validation rule.
 ///
 /// Rule IDs must follow the `<pack>/<rule-id>` namespace convention.
-/// See `docs/api/validation.md` for declaration examples and severity override rules.
+/// See `docs/api/validation.md` for declaration examples and the
+/// shipped-vs-deferred split.
 pub struct ValidationRule {
     /// Stable rule identifier in `<pack>/<rule-id>` format.
     pub id: RuleId,
-    /// Default severity; can be overridden in `.khive/kg/rules.toml`.
+    /// Default severity. TOML severity override for pack rules is part of the
+    /// deferred runner wiring (ADR-034); no override mapping exists yet.
     pub severity: Severity,
     /// Human-readable description (surfaced once the CLI runner wiring lands; ADR-034).
     pub description: &'static str,

--- a/crates/khive-runtime/src/validation.rs
+++ b/crates/khive-runtime/src/validation.rs
@@ -16,9 +16,11 @@ pub type RuleId = &'static str;
 
 /// Severity of a validation finding.
 ///
-/// - `Error`: causes `kkernel kg validate` to exit with code 1.
-/// - `Warning`: reported but does not affect exit code (unless `--strict`).
-/// - `Info`: informational; no exit-code effect.
+/// Intended exit-code semantics (`Error` = exit 1, `Warning` = report-only
+/// unless `--strict`, `Info` = informational) apply to the shipped TOML
+/// RulePass; pack-declared rules are not yet executed by `kkernel kg
+/// validate` (ADR-034 defers CLI runner wiring). See
+/// `crates/khive-runtime/docs/api/validation.md` for the shipped-vs-deferred split.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
 pub enum Severity {
     Info,
@@ -65,7 +67,7 @@ pub struct Violation {
     pub severity: Severity,
     /// Human-readable explanation of the violation.
     pub message: String,
-    /// Whether the violation can be fixed by `kkernel kg validate --fix`.
+    /// Whether the violation is auto-fixable (the `--fix` write path is deferred; ADR-034).
     pub fixable: bool,
     /// Optional entity UUID (short-form) that the violation targets.
     pub entity_id: Option<String>,
@@ -130,7 +132,7 @@ pub struct ValidationRule {
     pub id: RuleId,
     /// Default severity; can be overridden in `.khive/kg/rules.toml`.
     pub severity: Severity,
-    /// Human-readable description shown in `kkernel kg validate` output.
+    /// Human-readable description (surfaced once the CLI runner wiring lands; ADR-034).
     pub description: &'static str,
     /// Whole-corpus check function.
     pub check: RuleFn,

--- a/crates/khive-vcs/docs/api/sync.md
+++ b/crates/khive-vcs/docs/api/sync.md
@@ -105,9 +105,13 @@ the canonical helper was updated but the inline copy wasn't.
 
 ## WAL checkpoint under the write queue
 
-`run_sync`'s WAL truncate-checkpoint must go through the write queue's
-`BEGIN IMMEDIATE` wrapping, not a plain `execute_script` call — the latter
-was the old, broken call shape. The regression test
+`run_sync`'s WAL truncate-checkpoint must bypass the write queue's
+per-request `BEGIN IMMEDIATE` wrapping via `execute_script_top_level` — a
+checkpoint cannot complete while a transaction is open on the same
+connection. Ordinary `execute_script` is the old, broken call shape: under
+`KHIVE_WRITE_QUEUE=1` it wraps the statement in `BEGIN IMMEDIATE`, which
+silently no-ops the checkpoint and can lose WAL-resident writes at the
+subsequent rename. The regression test
 `wal_checkpoint_truncate_via_plain_execute_script_fails_with_write_queue_enabled`
 is a revert-and-confirm-fails companion: it asserts the OLD call shape
 *fails* under the write queue, which proves the paired "succeeds" test is

--- a/crates/khive-vcs/src/sync.rs
+++ b/crates/khive-vcs/src/sync.rs
@@ -1202,7 +1202,7 @@ mod tests {
     }
 
     /// Chunk-boundary round-trip across `SYNC_CHUNK_SIZE`. See
-    /// `docs/test-rationale.md#sync_chunk_boundary_round_trip`.
+    /// `docs/api/sync.md#local-sync--run_sync`.
     #[tokio::test]
     async fn sync_chunk_boundary_round_trip() {
         const N: usize = 11; // > SYNC_CHUNK_SIZE (5 in test mode)
@@ -1805,7 +1805,7 @@ mod tests {
     }
 
     /// Issue #474: path-traversal remote names must be unconstructable. See
-    /// `docs/test-rationale.md#run_sync_remote_cannot_be_constructed_with_invalid_name`.
+    /// `docs/api/sync.md#remotename--construction-time-path-traversal-safety`.
     #[tokio::test]
     async fn run_sync_remote_cannot_be_constructed_with_invalid_name() {
         let repo_dir = TempDir::new().unwrap();
@@ -2349,7 +2349,7 @@ mod tests {
     // the caller actually sees in `err.to_string()`.
 
     /// Credential-bearing HTTPS URLs must not leak into the public error
-    /// string. See `docs/test-rationale.md#public_error_redacts_https_credential_url`.
+    /// string. See `docs/api/sync.md#credential-redaction-in-git-error-output--redact_git_stderr`.
     #[tokio::test]
     async fn public_error_redacts_https_credential_url() {
         let repo_dir = tempfile::TempDir::new().unwrap();
@@ -2388,7 +2388,7 @@ mod tests {
     }
 
     /// scp-style `git@host:org/repo.git` must not leak through the sanitiser.
-    /// See `docs/test-rationale.md#public_error_redacts_scp_style_remote`.
+    /// See `docs/api/sync.md#credential-redaction-in-git-error-output--redact_git_stderr`.
     #[tokio::test]
     async fn public_error_redacts_scp_style_remote() {
         let repo_dir = tempfile::TempDir::new().unwrap();
@@ -2432,7 +2432,7 @@ mod tests {
 
     /// Regression: VCS sync FTS document must be field-identical to
     /// `entity_fts_document`'s output. See
-    /// `docs/test-rationale.md#sync_fts_document_matches_entity_fts_document`.
+    /// `docs/api/sync.md#fts-document-consistency`.
     #[test]
     fn sync_fts_document_matches_entity_fts_document() {
         use khive_runtime::entity_fts_document;
@@ -2569,7 +2569,7 @@ mod checkpoint_wal_write_queue_tests {
     }
 
     /// Revert-and-confirm-fails companion to the test above. See
-    /// `docs/test-rationale.md#wal_checkpoint_truncate_via_plain_execute_script_fails_with_write_queue_enabled`.
+    /// `docs/api/sync.md#wal-checkpoint-under-the-write-queue`.
     #[tokio::test]
     async fn wal_checkpoint_truncate_via_plain_execute_script_fails_with_write_queue_enabled() {
         let dir = tempfile::tempdir().expect("tempdir");


### PR DESCRIPTION
## What

Consolidated review-fix follow-up for the pass-2 rustdoc PRs #1011-#1014, which merged before their review-round fixes landed. Carries every outstanding finding:

- **khive-runtime** (#1011 r1+r2): ADR-034 relative-link depth in `docs/api/validation.md`; atomic-runner docs updated from superseded B2-only prose to the shipped ADR-099 B3 flow; stale `rules.yaml` note dropped; atomic verb-set corrected (`merge`/governance verbs are D3-admissible but rejected as known-unimplemented, not executable); `validation.md` + `validation.rs` now separate the shipped TOML RulePass from the declared-but-deferred Rust pack-validator API (`kkernel kg validate` does not call `PackRuntime::validation_rules`).
- **khive-vcs** (#1012 r1+r2): six test doc-comments redirected from the deleted `docs/test-rationale.md` to `docs/api/sync.md` anchors; WAL checkpoint rule in `sync.md` corrected — the checkpoint must *bypass* the write queue's `BEGIN IMMEDIATE` wrapping via `execute_script_top_level` (the guide previously prescribed the known-broken inverse).
- **khive-hnsw** (#1014 r1): two relocated doc paths in `docs/algorithm.md` updated to `docs/api/`.

## Verification

- `cargo check -p khive-vcs -p khive-runtime` clean
- `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps -p khive-runtime -p khive-vcs -p khive-hnsw` clean
- All content claims verified against source (`ATOMIC_KNOWN_UNIMPLEMENTED_VERBS`, `checkpoint_wal`, ADR-034 deferred-wiring language).

🤖 Generated with [Claude Code](https://claude.com/claude-code)