### PR TITLE
fix(brain): always stamp resolved served_by_profile_id + resolution marker on feedback events

### DIFF
--- a/crates/khive-pack-brain/src/event.rs
+++ b/crates/khive-pack-brain/src/event.rs
@@ -210,6 +210,31 @@ mod tests {
     }
 
     #[test]
+    fn brain_feedback_with_resolution_marker_decodes_served_by() {
+        // #1016: handle_feedback now always stamps the resolved profile plus a
+        // `profile_resolution` marker. The marker is payload-only metadata —
+        // the decoder must surface served_by_profile_id and ignore the marker.
+        let id = Uuid::new_v4();
+        let mut e = make_event("brain.feedback", EventOutcome::Success, Some(id));
+        e.payload = serde_json::json!({
+            "signal": "useful",
+            "served_by_profile_id": "balanced-recall-v1",
+            "profile_resolution": "default"
+        });
+        match interpret(&e) {
+            BrainSignal::Feedback {
+                target_id,
+                served_by_profile_id,
+                ..
+            } => {
+                assert_eq!(target_id, id);
+                assert_eq!(served_by_profile_id.as_deref(), Some("balanced-recall-v1"));
+            }
+            other => panic!("expected Feedback, got {other:?}"),
+        }
+    }
+
+    #[test]
     fn brain_feedback_without_target_is_irrelevant() {
         let e = make_event("brain.feedback", EventOutcome::Success, None);
         assert!(matches!(interpret(&e), BrainSignal::Irrelevant));

--- a/crates/khive-pack-brain/src/handlers.rs
+++ b/crates/khive-pack-brain/src/handlers.rs
@@ -1227,20 +1227,23 @@ impl BrainPack {
     /// which resolves its own tier and passes an explicit profile) always
     /// originates from the recall serve loop, so it must resolve against the
     /// same binding bucket the serve path used.
+    /// Returns the profile id plus a resolution marker (`explicit` |
+    /// `binding` | `default`) so event payloads can record call-site
+    /// discipline separately from attribution (#1016).
     fn resolve_effective_feedback_profile(
         &self,
         token: &NamespaceToken,
         explicit: Option<&str>,
-    ) -> String {
+    ) -> (String, &'static str) {
         if let Some(profile_id) = explicit {
-            return profile_id.to_string();
+            return (profile_id.to_string(), "explicit");
         }
         let actor = token.actor().binding_id();
         let namespace = token.namespace().as_str();
         let state = self.state.lock().unwrap();
         match state.resolve_with_match(actor, Some(namespace), ConsumerKind::Recall.as_str()) {
-            Some((record, _matched_kind, true)) => record.id.clone(),
-            _ => "balanced-recall-v1".to_string(),
+            Some((record, _matched_kind, true)) => (record.id.clone(), "binding"),
+            _ => ("balanced-recall-v1".to_string(), "default"),
         }
     }
 
@@ -1328,7 +1331,7 @@ impl BrainPack {
         // Compute the effective serving profile (explicit, else a matching
         // actor+namespace binding, else the system default — #697), then
         // validate that it exists in the registry and is not Archived.
-        let effective_profile =
+        let (effective_profile, profile_resolution) =
             self.resolve_effective_feedback_profile(token, p.served_by_profile_id.as_deref());
         let effective_profile = effective_profile.as_str();
         {
@@ -1415,10 +1418,15 @@ impl BrainPack {
         // Base feedback payload, shared by every signal kind. The gated
         // (implicit) path below adds a "gate" key inside the atomic unit;
         // the ungated path (explicit/correction) adds nothing further.
-        let mut base_data = json!({"signal": signal});
-        if let Some(ref profile_id) = p.served_by_profile_id {
-            base_data["served_by_profile_id"] = json!(profile_id);
-        }
+        // #1016: always stamp the resolved profile (not just the
+        // caller-explicit value) so event_counts attribution and ADR-032
+        // replay match what the posterior fold actually credited; the
+        // marker records how it was resolved.
+        let mut base_data = json!({
+            "signal": signal,
+            "served_by_profile_id": effective_profile,
+            "profile_resolution": profile_resolution,
+        });
         if let Some(ref ss) = p.section_signals {
             base_data["section_signals"] = ss.clone();
         }

--- a/crates/khive-pack-brain/src/tests.rs
+++ b/crates/khive-pack-brain/src/tests.rs
@@ -2314,6 +2314,141 @@ async fn feedback_697_unattributed_resolves_via_actor_binding() {
     );
 }
 
+/// #1016: every persisted feedback event payload must carry the RESOLVED
+/// `served_by_profile_id` plus the `profile_resolution` marker — across all
+/// three resolution tiers AND the gated implicit append path (which builds
+/// its event inside the fold-gate atomic unit from a cloned `base_data`).
+#[tokio::test]
+async fn feedback_1016_event_payload_stamps_resolved_profile_all_tiers() {
+    use khive_storage::event::EventFilter;
+    use khive_storage::types::PageRequest;
+
+    let (pack, rt) = make_pack_with_actor("leo");
+    let registry = empty_registry();
+    let token = rt.authorize(Namespace::local()).unwrap();
+    let target = create_test_entity(&rt, &token).await;
+
+    // Tier 3 (default): no explicit value, no binding — ordinary append path.
+    pack.dispatch(
+        "brain.feedback",
+        json!({"target_id": target, "signal": "useful"}),
+        &registry,
+        &token,
+    )
+    .await
+    .unwrap();
+
+    // Tier 3, gated implicit: same resolution, fold-gate append closure.
+    pack.dispatch(
+        "brain.feedback",
+        json!({"target_id": target, "signal": "implicit_positive"}),
+        &registry,
+        &token,
+    )
+    .await
+    .unwrap();
+
+    // Tier 2 (binding): bound profile resolves when the caller omits the id.
+    for (verb, params) in [
+        (
+            "brain.create_profile",
+            json!({"name": "leo-bound-v1", "consumer_kind": "recall"}),
+        ),
+        ("brain.activate", json!({"profile_id": "leo-bound-v1"})),
+        (
+            "brain.bind",
+            json!({"actor": "leo", "profile_id": "leo-bound-v1", "consumer_kind": "recall"}),
+        ),
+    ] {
+        pack.dispatch(verb, params, &registry, &token)
+            .await
+            .unwrap();
+    }
+    pack.dispatch(
+        "brain.feedback",
+        json!({"target_id": target, "signal": "useful"}),
+        &registry,
+        &token,
+    )
+    .await
+    .unwrap();
+
+    // Tier 1 (explicit): caller-supplied id wins over the binding.
+    pack.dispatch(
+        "brain.feedback",
+        json!({
+            "target_id": target,
+            "signal": "useful",
+            "served_by_profile_id": "balanced-recall-v1"
+        }),
+        &registry,
+        &token,
+    )
+    .await
+    .unwrap();
+
+    let events = rt
+        .events(&token)
+        .expect("event store")
+        .query_events(
+            EventFilter::default(),
+            PageRequest {
+                offset: 0,
+                limit: 1000,
+            },
+        )
+        .await
+        .expect("query_events");
+    let mut stamps: Vec<(String, String, String)> = events
+        .items
+        .iter()
+        .filter(|e| e.verb == "brain.feedback")
+        .map(|e| {
+            (
+                e.payload["signal"].as_str().unwrap_or("").to_string(),
+                e.payload["served_by_profile_id"]
+                    .as_str()
+                    .unwrap_or("<missing>")
+                    .to_string(),
+                e.payload["profile_resolution"]
+                    .as_str()
+                    .unwrap_or("<missing>")
+                    .to_string(),
+            )
+        })
+        .collect();
+    stamps.sort();
+
+    let mut expected = vec![
+        (
+            "useful".to_string(),
+            "balanced-recall-v1".to_string(),
+            "default".to_string(),
+        ),
+        (
+            "implicit_positive".to_string(),
+            "balanced-recall-v1".to_string(),
+            "default".to_string(),
+        ),
+        (
+            "useful".to_string(),
+            "leo-bound-v1".to_string(),
+            "binding".to_string(),
+        ),
+        (
+            "useful".to_string(),
+            "balanced-recall-v1".to_string(),
+            "explicit".to_string(),
+        ),
+    ];
+    expected.sort();
+
+    assert_eq!(
+        stamps, expected,
+        "#1016: all four feedback events must persist the resolved profile and its resolution marker"
+    );
+}
+
 /// Systemic-fix regression: an ANONYMOUS caller must not match an explicit
 /// `actor="local"` binding. `ActorRef::anonymous()` carries `id: "local"`
 /// (`khive-gate/src/actor.rs`); before the `binding_id()` fix,

--- a/crates/khive-pack-brain/src/tests.rs
+++ b/crates/khive-pack-brain/src/tests.rs
@@ -2323,7 +2323,7 @@ async fn feedback_1016_event_payload_stamps_resolved_profile_all_tiers() {
     use khive_storage::event::EventFilter;
     use khive_storage::types::PageRequest;
 
-    let (pack, rt) = make_pack_with_actor("leo");
+    let (pack, rt) = make_pack_with_actor("test-actor");
     let registry = empty_registry();
     let token = rt.authorize(Namespace::local()).unwrap();
     let target = create_test_entity(&rt, &token).await;
@@ -2352,12 +2352,12 @@ async fn feedback_1016_event_payload_stamps_resolved_profile_all_tiers() {
     for (verb, params) in [
         (
             "brain.create_profile",
-            json!({"name": "leo-bound-v1", "consumer_kind": "recall"}),
+            json!({"name": "test-bound-v1", "consumer_kind": "recall"}),
         ),
-        ("brain.activate", json!({"profile_id": "leo-bound-v1"})),
+        ("brain.activate", json!({"profile_id": "test-bound-v1"})),
         (
             "brain.bind",
-            json!({"actor": "leo", "profile_id": "leo-bound-v1", "consumer_kind": "recall"}),
+            json!({"actor": "test-actor", "profile_id": "test-bound-v1", "consumer_kind": "recall"}),
         ),
     ] {
         pack.dispatch(verb, params, &registry, &token)
@@ -2432,7 +2432,7 @@ async fn feedback_1016_event_payload_stamps_resolved_profile_all_tiers() {
         ),
         (
             "useful".to_string(),
-            "leo-bound-v1".to_string(),
+            "test-bound-v1".to_string(),
             "binding".to_string(),
         ),
         (

--- a/docs/adr/ADR-032-brain-profile-orchestration.md
+++ b/docs/adr/ADR-032-brain-profile-orchestration.md
@@ -182,7 +182,7 @@ field — they were never "served" by a profile, just observed by brain.
 // Minimum payload shape for profile-served events.
 #[derive(Serialize, Deserialize)]
 pub struct ServedEventPayload {
-    pub served_by_profile_id: Option<String>,  // None ⇒ default/no-binding path
+    pub served_by_profile_id: Option<String>,  // None ⇒ legacy event (see Amendment 1)
     #[serde(flatten)]
     pub kind_specific: serde_json::Value,
 }
@@ -1272,6 +1272,28 @@ deployment.
    threshold? Success rate drop over a rolling window? Fixed epoch schedule? Needs empirical
    calibration on real usage data. `BalancedRecallProfile` ships with variance-threshold
    default; operators can override.
+
+---
+
+## Amendment 1 — Always-stamped feedback attribution (2026-07-14, #1016)
+
+The original payload shape above allowed `served_by_profile_id: None` to mean the
+default/no-binding resolution path. That made per-profile event accounting ambiguous: the
+posterior fold credited the resolved profile (explicit value, else the actor+namespace
+binding, else the system default) while the persisted event carried no attribution unless
+the caller passed the id explicitly.
+
+As of #1016, newly emitted `FeedbackExplicit` events always persist the effective profile:
+
+- `served_by_profile_id` is stamped with the RESOLVED profile id on every feedback event,
+  matching what the posterior fold credits — never omitted for the binding or default path.
+- A `profile_resolution` marker records how the id was resolved: `explicit` (caller
+  supplied it), `binding` (actor+namespace resolution table), or `default` (system default
+  profile). This keeps call-site discipline measurable separately from attribution.
+- A missing `served_by_profile_id` on a stored event now means exactly one thing: the event
+  predates this amendment (legacy semantics). Historical events are not retro-stamped —
+  the resolution table may have changed since they were written — and decoders remain
+  tolerant of both missing fields.
 
 ---
 


### PR DESCRIPTION
## What

Closes #1016.

`brain.feedback` / `brain.auto_feedback` resolve the effective serving profile when the caller omits `served_by_profile_id` (explicit -> actor+namespace binding -> system default), and the posterior fold credits that resolved profile — but the emitted feedback event only carried `served_by_profile_id` when the caller passed it explicitly. Per-profile event accounting therefore reported those events as unattributed even though the fold credited the right profile.

- `resolve_effective_feedback_profile` now returns the profile id plus a resolution marker (`explicit` | `binding` | `default`).
- `handle_feedback` always stamps the resolved `served_by_profile_id` and the `profile_resolution` marker into the event payload, so attribution matches what the fold credited while call-site discipline stays measurable separately.
- `brain.auto_feedback` inherits the behavior by delegation.
- New decoder test: a payload carrying the resolved profile plus the marker surfaces `served_by_profile_id` and ignores the marker (replay path unaffected; historical events are not retro-stamped).

## Verification

- `cargo clippy -p khive-pack-brain --all-targets -- -D warnings` clean
- `cargo test -p khive-pack-brain` — 226 + doc/integration suites, all green
- Payload decoders in `khive-types` are tolerant of unknown keys (no `deny_unknown_fields` on event payloads), verified before adding the marker