### PR TITLE
perf: rename mislabeled load-harness dimension 9 and split compose vs search latencies

### DIFF
--- a/scripts/perf/bench_load_harness.py
+++ b/scripts/perf/bench_load_harness.py
@@ -642,9 +642,8 @@ def main() -> int:
             }
 
         recall_latencies = latencies_by_op.get("memory.recall", [])
-        compose_latencies = latencies_by_op.get("knowledge.compose", []) + latencies_by_op.get(
-            "knowledge.search", []
-        )
+        compose_latencies = latencies_by_op.get("knowledge.compose", [])
+        knowledge_search_latencies = latencies_by_op.get("knowledge.search", [])
 
         # fallback scrape (dim 1) — across every worker's own front-end stderr
         fallback_lines: list[str] = []
@@ -727,9 +726,13 @@ def main() -> int:
                 "distinct tenants get distinct attributed identities (no cross-tenant collapse).",
                 "detail": attributions,
             },
-            "9_brain_slot_throughput": {
+            "9_knowledge_latency": {
                 "channel": "client-measured",
-                **_percentiles(compose_latencies),
+                "compose": _percentiles(compose_latencies),
+                "search": _percentiles(knowledge_search_latencies),
+                "note": "renamed from 9_brain_slot_throughput, which mislabeled this block: it "
+                "aggregated knowledge.compose and knowledge.search client latencies into one "
+                "percentile set and measured nothing brain-slot-related",
             },
         }
 


### PR DESCRIPTION
Follow-up rider from the load-harness calibration lane.

The report's `9_brain_slot_throughput` dimension was mislabeled: it aggregated `knowledge.compose` and `knowledge.search` client latencies into one percentile block and measured nothing brain-slot-related. (The earlier ~5s constant readings in this dimension were the ANN warm-wait timeout on an empty corpus, resolved separately by #1026/#1027.)

This renames the key to `9_knowledge_latency` and splits the payload into separate `compose` and `search` percentile blocks (`{n, p50_us, p95_us, p99_us}` each, channel unchanged: client-measured). No other dimension changes. `bench_calibrate.py`'s load-suite extractor walks numeric leaves generically, so it picks up the new paths without changes; its 12 embedded self-checks pass.

Gates: `python -m py_compile` on both scripts, `python -m unittest scripts.perf.bench_calibrate` (12 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
