### PR TITLE
feat(channel-telegram): Telegram Bot API adapter + daemon wiring (ADR-056 amendment, #113)

### DIFF
--- a/crates/Cargo.toml
+++ b/crates/Cargo.toml
@@ -39,6 +39,7 @@ members = [
     "khive-retrieval",
     "khive-channel",
     "khive-channel-email",
+    "khive-channel-telegram",
 ]
 exclude = ["khive-merge"]
 # khive-merge is forward-deployed v2 infrastructure (ADR-039), not removed or

--- a/crates/khive-channel-telegram/Cargo.toml
+++ b/crates/khive-channel-telegram/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "khive-channel-telegram"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+categories.workspace = true
+description = "Telegram Bot API channel adapter for khive (ADR-056)"
+
+[dependencies]
+khive-channel = { version = "0.5.0", path = "../khive-channel" }
+async-trait = { workspace = true }
+thiserror = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+chrono = { workspace = true }
+tracing = { workspace = true }
+reqwest = { workspace = true }
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["full", "test-util"] }

--- a/crates/khive-channel-telegram/src/channel.rs
+++ b/crates/khive-channel-telegram/src/channel.rs
@@ -1,0 +1,416 @@
+//! `TelegramChannel` — implements the `Channel` trait for the Telegram Bot API
+//! (ADR-056 Amendment 2026-07-05).
+
+use std::sync::Mutex;
+
+use async_trait::async_trait;
+use chrono::{DateTime, TimeZone, Utc};
+use khive_channel::{Channel, ChannelEnvelope, ChannelError};
+
+use crate::config::TelegramChannelConfig;
+use crate::connector::{LiveTelegramConnector, TelegramConnector, TelegramUpdate};
+
+/// Self-identifying address used as the `to`/`from` half of an envelope that
+/// represents the bot's own end of the chat. The ADR defines only the
+/// maintainer's `telegram:<slug>` address; there is no separate configured
+/// identity for the bot side, so a fixed marker is used (mirrors the email
+/// adapter using its own configured mailbox address for the analogous slot).
+const BOT_SELF_ADDRESS: &str = "telegram:bot";
+
+/// Telegram channel adapter implementing `Channel` via the Bot API
+/// `sendMessage`/`getUpdates` methods.
+///
+/// Configuration is provided at construction time via `TelegramChannelConfig`.
+/// The `getUpdates` offset watermark is held in memory only (ADR-056
+/// Amendment 2026-07-05, "Poll offset and restart durability") — restart
+/// durability relies on Telegram's own server-side offset semantics plus the
+/// `idx_comm_message_external_id` dedup index, not on a persisted cursor.
+pub struct TelegramChannel {
+    config: TelegramChannelConfig,
+    connector: Box<dyn TelegramConnector>,
+    offset: Mutex<Option<i64>>,
+}
+
+impl TelegramChannel {
+    /// Build from environment variables. Fails if any required env var is absent.
+    pub fn from_env() -> Result<Self, ChannelError> {
+        let config = TelegramChannelConfig::from_env()?;
+        let connector = LiveTelegramConnector::new(config.bot_token.clone());
+        Ok(Self::with_connector(config, Box::new(connector)))
+    }
+
+    /// Build from a pre-constructed connector (for testing against a mock
+    /// Bot API — never a live network call in unit tests).
+    pub(crate) fn with_connector(
+        config: TelegramChannelConfig,
+        connector: Box<dyn TelegramConnector>,
+    ) -> Self {
+        Self {
+            config,
+            connector,
+            offset: Mutex::new(None),
+        }
+    }
+
+    /// The slug this channel routes outbound `telegram:<slug>` sends to.
+    pub fn maintainer_slug(&self) -> &str {
+        &self.config.maintainer_slug
+    }
+
+    fn current_offset(&self) -> Option<i64> {
+        *self.offset.lock().expect("offset mutex is never poisoned")
+    }
+
+    fn advance_offset(&self, next: i64) {
+        let mut guard = self.offset.lock().expect("offset mutex is never poisoned");
+        if guard.map(|o| next > o).unwrap_or(true) {
+            *guard = Some(next);
+        }
+    }
+
+    /// Convert one Telegram update into a `ChannelEnvelope`, or `None` when
+    /// the update is not an authenticated, actionable text message (ADR-056
+    /// §8: unauthorized-sender updates and non-text/non-message updates are
+    /// dropped with no note written, never surfaced as an error that would
+    /// abort the rest of the batch).
+    fn envelope_for(&self, update: &TelegramUpdate) -> Option<ChannelEnvelope> {
+        let message = update.message.as_ref()?;
+
+        if message.chat.id != self.config.maintainer_chat_id {
+            tracing::warn!(
+                chat_id = message.chat.id,
+                update_id = update.update_id,
+                "telegram: update from unauthorized chat id, dropping"
+            );
+            return None;
+        }
+
+        let text = message.text.as_ref()?;
+        let external_id = format!("tg:{}:{}", message.chat.id, update.update_id);
+        let from = format!("telegram:{}", self.config.maintainer_slug);
+        let sent_at = Utc.timestamp_opt(message.date, 0).single();
+
+        let mut env = ChannelEnvelope::new(from, BOT_SELF_ADDRESS, text.clone())
+            .with_external_id(external_id);
+        if let Some(ts) = sent_at {
+            env = env.with_sent_at(ts);
+        }
+        Some(env)
+    }
+}
+
+#[async_trait]
+impl Channel for TelegramChannel {
+    fn kind(&self) -> &'static str {
+        "telegram"
+    }
+
+    fn is_configured(&self) -> bool {
+        !self.config.bot_token.is_empty()
+    }
+
+    /// Send a single outbound message. Only the configured maintainer slug is
+    /// routable in v1 (ADR-056 "Outbound addressing"); any other
+    /// `telegram:<slug>` recipient is unroutable and is logged and dropped,
+    /// never silently misdelivered to the maintainer chat.
+    async fn send(&self, envelope: ChannelEnvelope) -> Result<(), ChannelError> {
+        let slug = strip_kind_prefix(&envelope.to, "telegram");
+        if slug != self.config.maintainer_slug {
+            tracing::warn!(
+                slug,
+                "telegram: unroutable recipient slug (only the configured maintainer slug is \
+                 routable in v1); dropping outbound message"
+            );
+            return Ok(());
+        }
+        self.connector
+            .send_message(self.config.maintainer_chat_id, &envelope.content)
+            .await
+    }
+
+    /// Poll `getUpdates` for new inbound messages.
+    ///
+    /// `since` is unused: Telegram's `getUpdates` offset watermark (held in
+    /// memory) is the sole progress mechanism, mirroring the ADR's explicit
+    /// choice not to reuse the IMAP-style persisted checkpoint for this
+    /// adapter.
+    async fn poll(&self, _since: DateTime<Utc>) -> Result<Vec<ChannelEnvelope>, ChannelError> {
+        let updates = self.connector.get_updates(self.current_offset()).await?;
+
+        let mut envelopes = Vec::new();
+        let mut max_update_id = None;
+        for update in &updates {
+            max_update_id = Some(
+                max_update_id
+                    .unwrap_or(update.update_id)
+                    .max(update.update_id),
+            );
+            if let Some(env) = self.envelope_for(update) {
+                envelopes.push(env);
+            }
+        }
+
+        // Advance the offset past every fetched update (authorized or not) so
+        // getUpdates never re-delivers an already-seen update, regardless of
+        // whether it produced an envelope.
+        if let Some(max_id) = max_update_id {
+            self.advance_offset(max_id + 1);
+        }
+
+        Ok(envelopes)
+    }
+}
+
+/// Strip a `"kind:"` prefix from an address string.
+fn strip_kind_prefix<'a>(addr: &'a str, kind: &str) -> &'a str {
+    let prefix = format!("{kind}:");
+    addr.strip_prefix(prefix.as_str()).unwrap_or(addr)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::connector::{TelegramChat, TelegramMessage};
+    use std::sync::Mutex as StdMutex;
+
+    fn make_config() -> TelegramChannelConfig {
+        TelegramChannelConfig {
+            bot_token: "test-token".to_string(), // gitleaks:allow
+            maintainer_chat_id: 555,
+            maintainer_slug: "maintainer".to_string(),
+            ingest_namespace: "local".to_string(),
+        }
+    }
+
+    /// A mock Bot API connector: no live network, just recorded calls and
+    /// scripted `getUpdates` responses.
+    struct MockConnector {
+        sent: StdMutex<Vec<(i64, String)>>,
+        updates: StdMutex<Vec<Vec<TelegramUpdate>>>,
+        offsets_seen: StdMutex<Vec<Option<i64>>>,
+        fail_send: bool,
+    }
+
+    impl MockConnector {
+        fn new(pages: Vec<Vec<TelegramUpdate>>) -> Self {
+            Self {
+                sent: StdMutex::new(Vec::new()),
+                updates: StdMutex::new(pages),
+                offsets_seen: StdMutex::new(Vec::new()),
+                fail_send: false,
+            }
+        }
+
+        fn failing_send() -> Self {
+            Self {
+                sent: StdMutex::new(Vec::new()),
+                updates: StdMutex::new(Vec::new()),
+                offsets_seen: StdMutex::new(Vec::new()),
+                fail_send: true,
+            }
+        }
+    }
+
+    #[async_trait]
+    impl TelegramConnector for MockConnector {
+        async fn send_message(&self, chat_id: i64, text: &str) -> Result<(), ChannelError> {
+            if self.fail_send {
+                return Err(ChannelError::Transport("mock send failure".to_string()));
+            }
+            self.sent.lock().unwrap().push((chat_id, text.to_string()));
+            Ok(())
+        }
+
+        async fn get_updates(
+            &self,
+            offset: Option<i64>,
+        ) -> Result<Vec<TelegramUpdate>, ChannelError> {
+            self.offsets_seen.lock().unwrap().push(offset);
+            let mut pages = self.updates.lock().unwrap();
+            if pages.is_empty() {
+                Ok(Vec::new())
+            } else {
+                Ok(pages.remove(0))
+            }
+        }
+    }
+
+    fn text_update(update_id: i64, chat_id: i64, text: &str, date: i64) -> TelegramUpdate {
+        TelegramUpdate {
+            update_id,
+            message: Some(TelegramMessage {
+                message_id: update_id,
+                date,
+                chat: TelegramChat { id: chat_id },
+                text: Some(text.to_string()),
+            }),
+        }
+    }
+
+    #[test]
+    fn kind_is_telegram() {
+        let ch =
+            TelegramChannel::with_connector(make_config(), Box::new(MockConnector::new(vec![])));
+        assert_eq!(ch.kind(), "telegram");
+    }
+
+    #[tokio::test]
+    async fn poll_authorized_chat_produces_envelope_with_correct_external_id() {
+        let updates = vec![vec![text_update(10, 555, "hello khive", 1_700_000_000)]];
+        let ch =
+            TelegramChannel::with_connector(make_config(), Box::new(MockConnector::new(updates)));
+
+        let envs = ch.poll(Utc::now()).await.unwrap();
+        assert_eq!(envs.len(), 1);
+        assert_eq!(envs[0].external_id.as_deref(), Some("tg:555:10"));
+        assert_eq!(envs[0].from, "telegram:maintainer");
+        assert_eq!(envs[0].content, "hello khive");
+    }
+
+    #[tokio::test]
+    async fn poll_unauthorized_chat_is_dropped_not_returned_as_error() {
+        let updates = vec![vec![text_update(
+            11,
+            999,
+            "i am not the maintainer",
+            1_700_000_000,
+        )]];
+        let ch =
+            TelegramChannel::with_connector(make_config(), Box::new(MockConnector::new(updates)));
+
+        let envs = ch.poll(Utc::now()).await.unwrap();
+        assert!(
+            envs.is_empty(),
+            "unauthorized chat id must be dropped with no note, not surfaced as an error"
+        );
+    }
+
+    #[tokio::test]
+    async fn poll_bad_message_in_batch_does_not_abort_others() {
+        let updates = vec![vec![
+            text_update(20, 999, "attacker", 1_700_000_000),
+            text_update(21, 555, "maintainer says hi", 1_700_000_001),
+        ]];
+        let ch =
+            TelegramChannel::with_connector(make_config(), Box::new(MockConnector::new(updates)));
+
+        let envs = ch.poll(Utc::now()).await.unwrap();
+        assert_eq!(envs.len(), 1, "only the authorized update must be returned");
+        assert_eq!(envs[0].external_id.as_deref(), Some("tg:555:21"));
+    }
+
+    #[tokio::test]
+    async fn poll_advances_offset_past_all_fetched_updates_including_unauthorized() {
+        let updates = vec![
+            vec![
+                text_update(1, 999, "attacker", 1_700_000_000),
+                text_update(2, 555, "maintainer", 1_700_000_001),
+            ],
+            vec![],
+        ];
+        let connector = std::sync::Arc::new(MockConnector::new(updates));
+        let ch = TelegramChannel::with_connector(make_config(), Box::new(connector.clone()));
+
+        let first = ch.poll(Utc::now()).await.unwrap();
+        assert_eq!(first.len(), 1);
+        let _second = ch.poll(Utc::now()).await.unwrap();
+
+        let seen = connector.offsets_seen.lock().unwrap().clone();
+        assert_eq!(
+            seen,
+            vec![None, Some(3)],
+            "second poll must request offset = last update_id + 1"
+        );
+    }
+
+    #[tokio::test]
+    async fn send_to_maintainer_slug_is_routed() {
+        let connector = MockConnector::new(vec![]);
+        let ch = TelegramChannel::with_connector(make_config(), Box::new(connector));
+
+        let env = ChannelEnvelope::new(BOT_SELF_ADDRESS, "telegram:maintainer", "reply text");
+        ch.send(env).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn send_to_unroutable_slug_is_dropped_not_misdelivered() {
+        let connector = std::sync::Arc::new(MockConnector::new(vec![]));
+        let ch = TelegramChannel::with_connector(make_config(), Box::new(connector.clone()));
+
+        let env = ChannelEnvelope::new(BOT_SELF_ADDRESS, "telegram:someone-else", "reply text");
+        ch.send(env).await.unwrap();
+
+        assert!(
+            connector.sent.lock().unwrap().is_empty(),
+            "an unroutable slug must never be sent to the maintainer chat"
+        );
+    }
+
+    #[tokio::test]
+    async fn send_propagates_connector_error() {
+        let ch =
+            TelegramChannel::with_connector(make_config(), Box::new(MockConnector::failing_send()));
+        let env = ChannelEnvelope::new(BOT_SELF_ADDRESS, "telegram:maintainer", "reply text");
+        let err = ch.send(env).await.unwrap_err();
+        assert!(matches!(err, ChannelError::Transport(_)));
+    }
+
+    #[tokio::test]
+    async fn poll_message_without_text_is_dropped() {
+        let update = TelegramUpdate {
+            update_id: 5,
+            message: Some(TelegramMessage {
+                message_id: 5,
+                date: 1_700_000_000,
+                chat: TelegramChat { id: 555 },
+                text: None,
+            }),
+        };
+        let ch = TelegramChannel::with_connector(
+            make_config(),
+            Box::new(MockConnector::new(vec![vec![update]])),
+        );
+        let envs = ch.poll(Utc::now()).await.unwrap();
+        assert!(
+            envs.is_empty(),
+            "a non-text update must be dropped, not errored"
+        );
+    }
+
+    #[tokio::test]
+    async fn poll_update_without_message_is_dropped() {
+        let update = TelegramUpdate {
+            update_id: 6,
+            message: None,
+        };
+        let ch = TelegramChannel::with_connector(
+            make_config(),
+            Box::new(MockConnector::new(vec![vec![update]])),
+        );
+        let envs = ch.poll(Utc::now()).await.unwrap();
+        assert!(envs.is_empty());
+    }
+
+    #[test]
+    fn is_configured_true_with_nonempty_token() {
+        let ch =
+            TelegramChannel::with_connector(make_config(), Box::new(MockConnector::new(vec![])));
+        assert!(ch.is_configured());
+    }
+
+    #[test]
+    fn strip_kind_prefix_removes_prefix() {
+        assert_eq!(
+            strip_kind_prefix("telegram:maintainer", "telegram"),
+            "maintainer"
+        );
+        assert_eq!(strip_kind_prefix("maintainer", "telegram"), "maintainer");
+    }
+
+    #[test]
+    fn maintainer_slug_accessor() {
+        let ch =
+            TelegramChannel::with_connector(make_config(), Box::new(MockConnector::new(vec![])));
+        assert_eq!(ch.maintainer_slug(), "maintainer");
+    }
+}

--- a/crates/khive-channel-telegram/src/channel.rs
+++ b/crates/khive-channel-telegram/src/channel.rs
@@ -29,6 +29,13 @@ pub struct TelegramChannel {
     config: TelegramChannelConfig,
     connector: Box<dyn TelegramConnector>,
     offset: Mutex<Option<i64>>,
+    /// The offset [`Channel::poll`] would advance to, computed from the most
+    /// recent batch of fetched updates but not yet applied to `offset`.
+    /// Applied only by [`Self::commit_offset`], which callers must invoke
+    /// after every authorized envelope from that batch durably ingests.
+    /// Until then, the next `poll` call re-requests with the unchanged
+    /// `offset`, so a failed batch is re-fetched rather than lost.
+    pending_offset: Mutex<Option<i64>>,
 }
 
 impl TelegramChannel {
@@ -49,6 +56,7 @@ impl TelegramChannel {
             config,
             connector,
             offset: Mutex::new(None),
+            pending_offset: Mutex::new(None),
         }
     }
 
@@ -134,6 +142,14 @@ impl Channel for TelegramChannel {
     /// memory) is the sole progress mechanism, mirroring the ADR's explicit
     /// choice not to reuse the IMAP-style persisted checkpoint for this
     /// adapter.
+    ///
+    /// This does **not** advance the offset used for the next `getUpdates`
+    /// call — it only records the candidate advance in `pending_offset`.
+    /// Advancing the confirmed offset (so Telegram stops re-delivering this
+    /// batch) requires an explicit [`Self::commit_offset`] call, which the
+    /// caller must make only after every authorized envelope from this batch
+    /// durably ingests. Until committed, the next `poll` reuses the same
+    /// offset and re-fetches the same batch.
     async fn poll(&self, _since: DateTime<Utc>) -> Result<Vec<ChannelEnvelope>, ChannelError> {
         let updates = self.connector.get_updates(self.current_offset()).await?;
 
@@ -150,14 +166,36 @@ impl Channel for TelegramChannel {
             }
         }
 
-        // Advance the offset past every fetched update (authorized or not) so
-        // getUpdates never re-delivers an already-seen update, regardless of
-        // whether it produced an envelope.
         if let Some(max_id) = max_update_id {
-            self.advance_offset(max_id + 1);
+            *self
+                .pending_offset
+                .lock()
+                .expect("pending_offset mutex is never poisoned") = Some(max_id + 1);
         }
 
         Ok(envelopes)
+    }
+}
+
+impl TelegramChannel {
+    /// Advance the confirmed offset to the value computed by the most
+    /// recent [`Channel::poll`] call, so the next `getUpdates` request no
+    /// longer re-delivers that batch.
+    ///
+    /// Callers (the daemon poll loop) must call this only after every
+    /// authorized envelope from that batch has durably ingested via
+    /// `comm.ingest` — never unconditionally after `poll` returns. A no-op
+    /// if there is no pending advance (e.g. an empty batch, or this batch's
+    /// advance was already committed).
+    pub fn commit_offset(&self) {
+        let next = self
+            .pending_offset
+            .lock()
+            .expect("pending_offset mutex is never poisoned")
+            .take();
+        if let Some(next) = next {
+            self.advance_offset(next);
+        }
     }
 }
 
@@ -300,7 +338,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn poll_advances_offset_past_all_fetched_updates_including_unauthorized() {
+    async fn poll_advances_offset_past_all_fetched_updates_including_unauthorized_after_commit() {
         let updates = vec![
             vec![
                 text_update(1, 999, "attacker", 1_700_000_000),
@@ -313,14 +351,73 @@ mod tests {
 
         let first = ch.poll(Utc::now()).await.unwrap();
         assert_eq!(first.len(), 1);
+        ch.commit_offset();
         let _second = ch.poll(Utc::now()).await.unwrap();
 
         let seen = connector.offsets_seen.lock().unwrap().clone();
         assert_eq!(
             seen,
             vec![None, Some(3)],
-            "second poll must request offset = last update_id + 1"
+            "second poll must request offset = last update_id + 1, once committed"
         );
+    }
+
+    #[tokio::test]
+    async fn poll_without_commit_reuses_old_offset_so_ingest_failure_can_retry() {
+        // Same batch returned twice: Telegram keeps re-delivering it because
+        // the offset was never acknowledged (no `commit_offset()` call
+        // between the two polls), simulating a failed `comm.ingest`.
+        let batch = vec![text_update(9, 555, "maintainer", 1_700_000_000)];
+        let updates = vec![batch.clone(), batch];
+        let connector = std::sync::Arc::new(MockConnector::new(updates));
+        let ch = TelegramChannel::with_connector(make_config(), Box::new(connector.clone()));
+
+        let first = ch.poll(Utc::now()).await.unwrap();
+        assert_eq!(first.len(), 1);
+        // Deliberately no commit_offset() call here — simulates comm.ingest
+        // failing for this batch.
+        let second = ch.poll(Utc::now()).await.unwrap();
+        assert_eq!(
+            second.len(),
+            1,
+            "an uncommitted batch must be re-fetched and re-delivered, not lost"
+        );
+
+        let seen = connector.offsets_seen.lock().unwrap().clone();
+        assert_eq!(
+            seen,
+            vec![None, None],
+            "retry without commit must reuse the old (unset) offset"
+        );
+    }
+
+    #[tokio::test]
+    async fn commit_offset_after_successful_retry_advances_offset() {
+        let batch = vec![text_update(9, 555, "maintainer", 1_700_000_000)];
+        let updates = vec![batch.clone(), batch, vec![]];
+        let connector = std::sync::Arc::new(MockConnector::new(updates));
+        let ch = TelegramChannel::with_connector(make_config(), Box::new(connector.clone()));
+
+        let _first = ch.poll(Utc::now()).await.unwrap(); // simulated ingest failure, no commit
+        let _retry = ch.poll(Utc::now()).await.unwrap(); // re-fetched same batch
+        ch.commit_offset(); // this time ingest succeeds
+        let _third = ch.poll(Utc::now()).await.unwrap();
+
+        let seen = connector.offsets_seen.lock().unwrap().clone();
+        assert_eq!(
+            seen,
+            vec![None, None, Some(10)],
+            "offset only advances after commit_offset() following a successful ingest"
+        );
+    }
+
+    #[tokio::test]
+    async fn commit_offset_without_pending_poll_is_a_noop() {
+        let ch =
+            TelegramChannel::with_connector(make_config(), Box::new(MockConnector::new(vec![])));
+        ch.commit_offset();
+        ch.commit_offset();
+        assert_eq!(ch.current_offset(), None);
     }
 
     #[tokio::test]

--- a/crates/khive-channel-telegram/src/config.rs
+++ b/crates/khive-channel-telegram/src/config.rs
@@ -1,0 +1,223 @@
+//! Environment-only configuration for the Telegram channel (ADR-056 Amendment
+//! 2026-07-05).
+//!
+//! All settings are read from environment variables. No filesystem config is
+//! loaded. Missing required variables produce an error at construction time.
+
+use khive_channel::ChannelError;
+
+/// Default slug for the single routable `telegram:<slug>` recipient (v1 is
+/// single-maintainer; see ADR-056 §"Outbound addressing").
+const DEFAULT_MAINTAINER_SLUG: &str = "maintainer";
+
+/// Default namespace inbound Telegram messages are ingested into.
+const DEFAULT_INGEST_NAMESPACE: &str = "local";
+
+/// Configuration for the Telegram Bot API adapter.
+///
+/// Build via [`TelegramChannelConfig::from_env`]. All fields are sourced
+/// exclusively from environment variables; no defaults are provided for the
+/// bot token or the maintainer chat id.
+#[derive(Clone)]
+pub struct TelegramChannelConfig {
+    /// Bot API token (BotFather). Never logged in full.
+    pub bot_token: String,
+    /// The single authorized inbound sender AND the outbound recipient for
+    /// the maintainer slug.
+    pub maintainer_chat_id: i64,
+    /// The slug in `telegram:<slug>` that maps to `maintainer_chat_id`.
+    pub maintainer_slug: String,
+    /// Target namespace for ingested inbound messages.
+    pub ingest_namespace: String,
+}
+
+impl std::fmt::Debug for TelegramChannelConfig {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("TelegramChannelConfig")
+            .field("bot_token", &mask_token(&self.bot_token))
+            .field("maintainer_chat_id", &self.maintainer_chat_id)
+            .field("maintainer_slug", &self.maintainer_slug)
+            .field("ingest_namespace", &self.ingest_namespace)
+            .finish()
+    }
+}
+
+/// Mask a secret token for safe logging: `{first6}...[N chars]` (ADR-056 §9).
+fn mask_token(token: &str) -> String {
+    let visible: String = token.chars().take(6).collect();
+    format!("{visible}...[{} chars]", token.chars().count())
+}
+
+impl TelegramChannelConfig {
+    /// Load configuration from environment variables.
+    ///
+    /// Required:
+    /// - `KHIVE_TELEGRAM_BOT_TOKEN`
+    /// - `KHIVE_TELEGRAM_MAINTAINER_CHAT_ID` (numeric)
+    ///
+    /// Optional with defaults:
+    /// - `KHIVE_TELEGRAM_MAINTAINER_SLUG` (default `"maintainer"`)
+    /// - `KHIVE_TELEGRAM_INGEST_NAMESPACE` (default `"local"`)
+    pub fn from_env() -> Result<Self, ChannelError> {
+        let bot_token = require_nonempty_env("KHIVE_TELEGRAM_BOT_TOKEN")?;
+
+        let chat_id_raw = require_nonempty_env("KHIVE_TELEGRAM_MAINTAINER_CHAT_ID")?;
+        let maintainer_chat_id = chat_id_raw.trim().parse::<i64>().map_err(|_| {
+            ChannelError::Config(format!(
+                "KHIVE_TELEGRAM_MAINTAINER_CHAT_ID must be a valid signed integer, got: {chat_id_raw:?}"
+            ))
+        })?;
+
+        let maintainer_slug = match std::env::var("KHIVE_TELEGRAM_MAINTAINER_SLUG") {
+            Ok(v) if !v.trim().is_empty() => v,
+            _ => DEFAULT_MAINTAINER_SLUG.to_string(),
+        };
+
+        let ingest_namespace = match std::env::var("KHIVE_TELEGRAM_INGEST_NAMESPACE") {
+            Ok(v) if !v.trim().is_empty() => v,
+            _ => DEFAULT_INGEST_NAMESPACE.to_string(),
+        };
+
+        Ok(Self {
+            bot_token,
+            maintainer_chat_id,
+            maintainer_slug,
+            ingest_namespace,
+        })
+    }
+}
+
+fn require_nonempty_env(key: &str) -> Result<String, ChannelError> {
+    match std::env::var(key) {
+        Ok(v) if !v.trim().is_empty() => Ok(v),
+        Ok(_) => Err(ChannelError::Config(format!(
+            "environment variable {key:?} must not be empty"
+        ))),
+        Err(_) => Err(ChannelError::Config(format!(
+            "required environment variable {key:?} is not set"
+        ))),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Mutex;
+
+    // Environment variables are process-global; serialize env-mutating tests
+    // and restore prior values on drop (mirrors khive-channel-email's pattern).
+    static ENV_MUTEX: Mutex<()> = Mutex::new(());
+
+    struct EnvSnapshot {
+        vars: Vec<(String, Option<String>)>,
+    }
+
+    impl EnvSnapshot {
+        fn capture(keys: &[&str]) -> Self {
+            Self {
+                vars: keys
+                    .iter()
+                    .map(|k| (k.to_string(), std::env::var(k).ok()))
+                    .collect(),
+            }
+        }
+    }
+
+    impl Drop for EnvSnapshot {
+        fn drop(&mut self) {
+            for (k, v) in &self.vars {
+                match v {
+                    Some(val) => std::env::set_var(k, val),
+                    None => std::env::remove_var(k),
+                }
+            }
+        }
+    }
+
+    const KEYS: &[&str] = &[
+        "KHIVE_TELEGRAM_BOT_TOKEN",
+        "KHIVE_TELEGRAM_MAINTAINER_CHAT_ID",
+        "KHIVE_TELEGRAM_MAINTAINER_SLUG",
+        "KHIVE_TELEGRAM_INGEST_NAMESPACE",
+    ];
+
+    #[test]
+    fn from_env_missing_bot_token_fails_closed() {
+        let _guard = ENV_MUTEX.lock().unwrap();
+        let _snap = EnvSnapshot::capture(KEYS);
+        std::env::remove_var("KHIVE_TELEGRAM_BOT_TOKEN");
+        std::env::set_var("KHIVE_TELEGRAM_MAINTAINER_CHAT_ID", "12345");
+
+        let err = TelegramChannelConfig::from_env().unwrap_err();
+        assert!(err.to_string().contains("KHIVE_TELEGRAM_BOT_TOKEN"));
+    }
+
+    #[test]
+    fn from_env_missing_chat_id_fails_closed() {
+        let _guard = ENV_MUTEX.lock().unwrap();
+        let _snap = EnvSnapshot::capture(KEYS);
+        std::env::set_var("KHIVE_TELEGRAM_BOT_TOKEN", "test-token"); // gitleaks:allow
+        std::env::remove_var("KHIVE_TELEGRAM_MAINTAINER_CHAT_ID");
+
+        let err = TelegramChannelConfig::from_env().unwrap_err();
+        assert!(err
+            .to_string()
+            .contains("KHIVE_TELEGRAM_MAINTAINER_CHAT_ID"));
+    }
+
+    #[test]
+    fn from_env_non_numeric_chat_id_fails_closed() {
+        let _guard = ENV_MUTEX.lock().unwrap();
+        let _snap = EnvSnapshot::capture(KEYS);
+        std::env::set_var("KHIVE_TELEGRAM_BOT_TOKEN", "test-token"); // gitleaks:allow
+        std::env::set_var("KHIVE_TELEGRAM_MAINTAINER_CHAT_ID", "not-a-number");
+
+        let err = TelegramChannelConfig::from_env().unwrap_err();
+        assert!(err
+            .to_string()
+            .contains("KHIVE_TELEGRAM_MAINTAINER_CHAT_ID"));
+    }
+
+    #[test]
+    fn from_env_defaults_slug_and_namespace() {
+        let _guard = ENV_MUTEX.lock().unwrap();
+        let _snap = EnvSnapshot::capture(KEYS);
+        std::env::set_var("KHIVE_TELEGRAM_BOT_TOKEN", "test-token"); // gitleaks:allow
+        std::env::set_var("KHIVE_TELEGRAM_MAINTAINER_CHAT_ID", "-98765");
+        std::env::remove_var("KHIVE_TELEGRAM_MAINTAINER_SLUG");
+        std::env::remove_var("KHIVE_TELEGRAM_INGEST_NAMESPACE");
+
+        let config = TelegramChannelConfig::from_env().expect("valid config must succeed");
+        assert_eq!(config.maintainer_chat_id, -98765);
+        assert_eq!(config.maintainer_slug, "maintainer");
+        assert_eq!(config.ingest_namespace, "local");
+    }
+
+    #[test]
+    fn from_env_respects_overridden_slug_and_namespace() {
+        let _guard = ENV_MUTEX.lock().unwrap();
+        let _snap = EnvSnapshot::capture(KEYS);
+        std::env::set_var("KHIVE_TELEGRAM_BOT_TOKEN", "test-token"); // gitleaks:allow
+        std::env::set_var("KHIVE_TELEGRAM_MAINTAINER_CHAT_ID", "42");
+        std::env::set_var("KHIVE_TELEGRAM_MAINTAINER_SLUG", "leo");
+        std::env::set_var("KHIVE_TELEGRAM_INGEST_NAMESPACE", "lambda:leo");
+
+        let config = TelegramChannelConfig::from_env().expect("valid config must succeed");
+        assert_eq!(config.maintainer_slug, "leo");
+        assert_eq!(config.ingest_namespace, "lambda:leo");
+    }
+
+    #[test]
+    fn debug_output_masks_bot_token() {
+        let config = TelegramChannelConfig {
+            bot_token: "123456:AAFakeTokenValueForTestingOnly".to_string(), // gitleaks:allow
+            maintainer_chat_id: 1,
+            maintainer_slug: "maintainer".to_string(),
+            ingest_namespace: "local".to_string(),
+        };
+        let debug_output = format!("{config:?}");
+        assert!(!debug_output.contains("AAFakeTokenValueForTestingOnly"));
+        assert!(debug_output.contains("123456"));
+        assert!(debug_output.contains("chars]"));
+    }
+}

--- a/crates/khive-channel-telegram/src/connector.rs
+++ b/crates/khive-channel-telegram/src/connector.rs
@@ -70,24 +70,61 @@ impl<T: TelegramConnector + ?Sized> TelegramConnector for std::sync::Arc<T> {
     }
 }
 
+/// Default Bot API host. Overridable only in tests via
+/// [`LiveTelegramConnector::with_base_url`], so production always targets the
+/// real Telegram host.
+const DEFAULT_API_BASE: &str = "https://api.telegram.org";
+
+/// `getUpdates` long-poll timeout, in seconds, sent to the Bot API (ADR-056
+/// Amendment 2026-07-05 requires long polling, not short polling).
+const LONG_POLL_TIMEOUT_SECS: i64 = 25;
+
+/// HTTP client request timeout. Must exceed [`LONG_POLL_TIMEOUT_SECS`] so a
+/// `getUpdates` call that legitimately blocks server-side for the full
+/// long-poll window is not cut off by the client itself.
+const HTTP_CLIENT_TIMEOUT_SECS: u64 = 35;
+
 /// Live Bot API connector: plain HTTPS POST + JSON, reusing the workspace
 /// `reqwest` client (rustls-tls + json), same as `khive-channel-email`'s
 /// OAuth token fetch. No Telegram SDK.
 pub(crate) struct LiveTelegramConnector {
     http: reqwest::Client,
     bot_token: String,
+    api_base: String,
 }
 
 impl LiveTelegramConnector {
     pub fn new(bot_token: String) -> Self {
+        let http = reqwest::Client::builder()
+            .timeout(std::time::Duration::from_secs(HTTP_CLIENT_TIMEOUT_SECS))
+            .build()
+            .expect("reqwest client with static, valid config must build");
         Self {
-            http: reqwest::Client::new(),
+            http,
             bot_token,
+            api_base: DEFAULT_API_BASE.to_string(),
+        }
+    }
+
+    /// Same as [`Self::new`] but pointed at a caller-supplied base URL
+    /// instead of the real Bot API host. Test-only seam so connector error
+    /// paths can be exercised against a local socket without ever reaching
+    /// `api.telegram.org`.
+    #[cfg(test)]
+    fn with_base_url(bot_token: String, api_base: String) -> Self {
+        let http = reqwest::Client::builder()
+            .timeout(std::time::Duration::from_secs(HTTP_CLIENT_TIMEOUT_SECS))
+            .build()
+            .expect("reqwest client with static, valid config must build");
+        Self {
+            http,
+            bot_token,
+            api_base,
         }
     }
 
     fn api_url(&self, method: &str) -> String {
-        format!("https://api.telegram.org/bot{}/{method}", self.bot_token)
+        format!("{}/bot{}/{method}", self.api_base, self.bot_token)
     }
 }
 
@@ -100,11 +137,16 @@ impl TelegramConnector for LiveTelegramConnector {
             .json(&json!({ "chat_id": chat_id, "text": text }))
             .send()
             .await
-            .map_err(|e| ChannelError::Transport(format!("sendMessage request failed: {e}")))?;
+            .map_err(|e| {
+                ChannelError::Transport(format!("sendMessage request failed: {}", e.without_url()))
+            })?;
 
         let status = resp.status();
         let parsed: TelegramApiResponse<serde_json::Value> = resp.json().await.map_err(|e| {
-            ChannelError::Transport(format!("sendMessage: malformed response: {e}"))
+            ChannelError::Transport(format!(
+                "sendMessage: malformed response: {}",
+                e.without_url()
+            ))
         })?;
 
         if !status.is_success() || !parsed.ok {
@@ -117,7 +159,7 @@ impl TelegramConnector for LiveTelegramConnector {
     }
 
     async fn get_updates(&self, offset: Option<i64>) -> Result<Vec<TelegramUpdate>, ChannelError> {
-        let mut body = json!({ "timeout": 0 });
+        let mut body = json!({ "timeout": LONG_POLL_TIMEOUT_SECS });
         if let Some(off) = offset {
             body["offset"] = json!(off);
         }
@@ -128,13 +170,17 @@ impl TelegramConnector for LiveTelegramConnector {
             .json(&body)
             .send()
             .await
-            .map_err(|e| ChannelError::Transport(format!("getUpdates request failed: {e}")))?;
+            .map_err(|e| {
+                ChannelError::Transport(format!("getUpdates request failed: {}", e.without_url()))
+            })?;
 
         let status = resp.status();
-        let parsed: TelegramApiResponse<Vec<TelegramUpdate>> = resp
-            .json()
-            .await
-            .map_err(|e| ChannelError::Transport(format!("getUpdates: malformed response: {e}")))?;
+        let parsed: TelegramApiResponse<Vec<TelegramUpdate>> = resp.json().await.map_err(|e| {
+            ChannelError::Transport(format!(
+                "getUpdates: malformed response: {}",
+                e.without_url()
+            ))
+        })?;
 
         if !status.is_success() || !parsed.ok {
             return Err(ChannelError::Transport(format!(
@@ -202,5 +248,146 @@ mod tests {
         let parsed: TelegramApiResponse<serde_json::Value> = serde_json::from_value(raw).unwrap();
         assert!(!parsed.ok);
         assert_eq!(parsed.description.as_deref(), Some("Unauthorized"));
+    }
+
+    const SENTINEL_TOKEN: &str = "SENTINEL-TOKEN-DO-NOT-LEAK-abcdef123456";
+
+    /// A local address nothing is listening on: the bound listener is
+    /// dropped immediately, so a subsequent connect attempt gets a prompt
+    /// connection-refused instead of hanging.
+    fn refused_port_base_url() -> String {
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap();
+        drop(listener);
+        format!("http://{addr}")
+    }
+
+    /// A minimal one-shot raw-socket HTTP server: accepts a single
+    /// connection, drains the request, and writes back a fixed response
+    /// body with `200 OK` and a matching `Content-Length`. No HTTP
+    /// framework dependency needed for these connector-level tests.
+    fn spawn_one_shot_server(response_body: &'static str) -> String {
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap();
+        std::thread::spawn(move || {
+            if let Ok((mut stream, _)) = listener.accept() {
+                use std::io::{Read, Write};
+                let mut buf = [0u8; 4096];
+                let _ = stream.read(&mut buf);
+                let response = format!(
+                    "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                    response_body.len(),
+                    response_body
+                );
+                let _ = stream.write_all(response.as_bytes());
+            }
+        });
+        format!("http://{addr}")
+    }
+
+    /// Same as [`spawn_one_shot_server`], but also captures the request
+    /// body it received back to the caller via a channel, so the test can
+    /// assert on the JSON this connector actually sent.
+    fn spawn_capturing_server(
+        response_body: &'static str,
+    ) -> (String, std::sync::mpsc::Receiver<String>) {
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap();
+        let (tx, rx) = std::sync::mpsc::channel();
+        std::thread::spawn(move || {
+            if let Ok((mut stream, _)) = listener.accept() {
+                use std::io::{Read, Write};
+                let mut buf = [0u8; 4096];
+                let n = stream.read(&mut buf).unwrap_or(0);
+                let request = String::from_utf8_lossy(&buf[..n]).to_string();
+                let body = request
+                    .split("\r\n\r\n")
+                    .nth(1)
+                    .unwrap_or_default()
+                    .to_string();
+                let _ = tx.send(body);
+                let response = format!(
+                    "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                    response_body.len(),
+                    response_body
+                );
+                let _ = stream.write_all(response.as_bytes());
+            }
+        });
+        (format!("http://{addr}"), rx)
+    }
+
+    #[tokio::test]
+    async fn send_message_request_failure_does_not_leak_token() {
+        let connector = LiveTelegramConnector::with_base_url(
+            SENTINEL_TOKEN.to_string(),
+            refused_port_base_url(),
+        );
+        let err = connector.send_message(555, "hi").await.unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            !msg.contains(SENTINEL_TOKEN),
+            "error must not leak the bot token: {msg}"
+        );
+    }
+
+    #[tokio::test]
+    async fn send_message_decode_failure_does_not_leak_token() {
+        let base_url = spawn_one_shot_server("not valid json");
+        let connector = LiveTelegramConnector::with_base_url(SENTINEL_TOKEN.to_string(), base_url);
+        let err = connector.send_message(555, "hi").await.unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            !msg.contains(SENTINEL_TOKEN),
+            "error must not leak the bot token: {msg}"
+        );
+    }
+
+    #[tokio::test]
+    async fn get_updates_request_failure_does_not_leak_token() {
+        let connector = LiveTelegramConnector::with_base_url(
+            SENTINEL_TOKEN.to_string(),
+            refused_port_base_url(),
+        );
+        let err = connector.get_updates(None).await.unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            !msg.contains(SENTINEL_TOKEN),
+            "error must not leak the bot token: {msg}"
+        );
+    }
+
+    #[tokio::test]
+    async fn get_updates_decode_failure_does_not_leak_token() {
+        let base_url = spawn_one_shot_server("not valid json");
+        let connector = LiveTelegramConnector::with_base_url(SENTINEL_TOKEN.to_string(), base_url);
+        let err = connector.get_updates(None).await.unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            !msg.contains(SENTINEL_TOKEN),
+            "error must not leak the bot token: {msg}"
+        );
+    }
+
+    #[tokio::test]
+    async fn get_updates_sends_positive_long_poll_timeout_and_offset() {
+        let (base_url, request_rx) = spawn_capturing_server(r#"{"ok":true,"result":[]}"#);
+        let connector = LiveTelegramConnector::with_base_url("token".to_string(), base_url);
+
+        let updates = connector.get_updates(Some(42)).await.unwrap();
+        assert!(updates.is_empty());
+
+        let captured_body = request_rx
+            .recv_timeout(std::time::Duration::from_secs(5))
+            .expect("server must capture a request body");
+        let parsed: serde_json::Value = serde_json::from_str(&captured_body).unwrap();
+        assert_eq!(parsed["offset"], 42);
+        let timeout = parsed["timeout"]
+            .as_i64()
+            .expect("timeout field must be present and numeric");
+        assert!(
+            timeout > 0,
+            "getUpdates must use long polling, not timeout=0"
+        );
     }
 }

--- a/crates/khive-channel-telegram/src/connector.rs
+++ b/crates/khive-channel-telegram/src/connector.rs
@@ -1,0 +1,206 @@
+//! Telegram Bot API connector: a thin, injectable seam over `sendMessage` /
+//! `getUpdates` so `TelegramChannel` can be unit-tested against a mock
+//! implementation (no live network calls in tests), mirroring the
+//! `SmtpConnector`/`ImapConnector` split in `khive-channel-email`.
+//!
+//! Plain HTTPS + JSON only — no Telegram SDK (ADR-056 Amendment 2026-07-05).
+
+use async_trait::async_trait;
+use khive_channel::ChannelError;
+use serde::Deserialize;
+use serde_json::json;
+
+/// One `getUpdates` result entry.
+#[derive(Debug, Clone, Deserialize)]
+pub(crate) struct TelegramUpdate {
+    pub update_id: i64,
+    #[serde(default)]
+    pub message: Option<TelegramMessage>,
+}
+
+/// The `message` field of a Telegram update. Only the fields this adapter
+/// needs are modeled; unknown fields are ignored by serde's default
+/// (non-`deny_unknown_fields`) behavior.
+#[derive(Debug, Clone, Deserialize)]
+pub(crate) struct TelegramMessage {
+    #[allow(dead_code)]
+    pub message_id: i64,
+    /// Unix timestamp (seconds) the message was sent.
+    pub date: i64,
+    pub chat: TelegramChat,
+    /// Absent for non-text messages (media, stickers, etc. — out of scope
+    /// for v1, ADR-056 "Out of scope (v1)").
+    #[serde(default)]
+    pub text: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub(crate) struct TelegramChat {
+    pub id: i64,
+}
+
+#[derive(Debug, Deserialize)]
+struct TelegramApiResponse<T> {
+    ok: bool,
+    #[serde(default)]
+    result: Option<T>,
+    #[serde(default)]
+    description: Option<String>,
+}
+
+/// Injectable seam for the two Bot API methods this adapter uses.
+#[async_trait]
+pub(crate) trait TelegramConnector: Send + Sync {
+    async fn send_message(&self, chat_id: i64, text: &str) -> Result<(), ChannelError>;
+    async fn get_updates(&self, offset: Option<i64>) -> Result<Vec<TelegramUpdate>, ChannelError>;
+}
+
+/// A [`TelegramConnector`] implementation shared through an `Arc`, so tests
+/// can retain an observable handle to a mock connector after handing a copy
+/// to [`crate::channel::TelegramChannel`] (which owns a `Box<dyn
+/// TelegramConnector>`).
+#[async_trait]
+impl<T: TelegramConnector + ?Sized> TelegramConnector for std::sync::Arc<T> {
+    async fn send_message(&self, chat_id: i64, text: &str) -> Result<(), ChannelError> {
+        (**self).send_message(chat_id, text).await
+    }
+
+    async fn get_updates(&self, offset: Option<i64>) -> Result<Vec<TelegramUpdate>, ChannelError> {
+        (**self).get_updates(offset).await
+    }
+}
+
+/// Live Bot API connector: plain HTTPS POST + JSON, reusing the workspace
+/// `reqwest` client (rustls-tls + json), same as `khive-channel-email`'s
+/// OAuth token fetch. No Telegram SDK.
+pub(crate) struct LiveTelegramConnector {
+    http: reqwest::Client,
+    bot_token: String,
+}
+
+impl LiveTelegramConnector {
+    pub fn new(bot_token: String) -> Self {
+        Self {
+            http: reqwest::Client::new(),
+            bot_token,
+        }
+    }
+
+    fn api_url(&self, method: &str) -> String {
+        format!("https://api.telegram.org/bot{}/{method}", self.bot_token)
+    }
+}
+
+#[async_trait]
+impl TelegramConnector for LiveTelegramConnector {
+    async fn send_message(&self, chat_id: i64, text: &str) -> Result<(), ChannelError> {
+        let resp = self
+            .http
+            .post(self.api_url("sendMessage"))
+            .json(&json!({ "chat_id": chat_id, "text": text }))
+            .send()
+            .await
+            .map_err(|e| ChannelError::Transport(format!("sendMessage request failed: {e}")))?;
+
+        let status = resp.status();
+        let parsed: TelegramApiResponse<serde_json::Value> = resp.json().await.map_err(|e| {
+            ChannelError::Transport(format!("sendMessage: malformed response: {e}"))
+        })?;
+
+        if !status.is_success() || !parsed.ok {
+            return Err(ChannelError::Transport(format!(
+                "sendMessage failed: status={status}, description={:?}",
+                parsed.description
+            )));
+        }
+        Ok(())
+    }
+
+    async fn get_updates(&self, offset: Option<i64>) -> Result<Vec<TelegramUpdate>, ChannelError> {
+        let mut body = json!({ "timeout": 0 });
+        if let Some(off) = offset {
+            body["offset"] = json!(off);
+        }
+
+        let resp = self
+            .http
+            .post(self.api_url("getUpdates"))
+            .json(&body)
+            .send()
+            .await
+            .map_err(|e| ChannelError::Transport(format!("getUpdates request failed: {e}")))?;
+
+        let status = resp.status();
+        let parsed: TelegramApiResponse<Vec<TelegramUpdate>> = resp
+            .json()
+            .await
+            .map_err(|e| ChannelError::Transport(format!("getUpdates: malformed response: {e}")))?;
+
+        if !status.is_success() || !parsed.ok {
+            return Err(ChannelError::Transport(format!(
+                "getUpdates failed: status={status}, description={:?}",
+                parsed.description
+            )));
+        }
+        Ok(parsed.result.unwrap_or_default())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn api_url_embeds_token_and_method() {
+        let connector = LiveTelegramConnector::new("123:ABC".to_string());
+        assert_eq!(
+            connector.api_url("sendMessage"),
+            "https://api.telegram.org/bot123:ABC/sendMessage"
+        );
+    }
+
+    #[test]
+    fn telegram_update_deserializes_text_message() {
+        let raw = json!({
+            "update_id": 42,
+            "message": {
+                "message_id": 7,
+                "date": 1_700_000_000,
+                "chat": { "id": 555 },
+                "text": "hello"
+            }
+        });
+        let update: TelegramUpdate = serde_json::from_value(raw).unwrap();
+        assert_eq!(update.update_id, 42);
+        let message = update.message.unwrap();
+        assert_eq!(message.chat.id, 555);
+        assert_eq!(message.text.as_deref(), Some("hello"));
+    }
+
+    #[test]
+    fn telegram_update_without_message_deserializes() {
+        let raw = json!({ "update_id": 43 });
+        let update: TelegramUpdate = serde_json::from_value(raw).unwrap();
+        assert_eq!(update.update_id, 43);
+        assert!(update.message.is_none());
+    }
+
+    #[test]
+    fn telegram_message_without_text_deserializes_none() {
+        let raw = json!({
+            "message_id": 8,
+            "date": 1_700_000_000,
+            "chat": { "id": 555 }
+        });
+        let message: TelegramMessage = serde_json::from_value(raw).unwrap();
+        assert!(message.text.is_none());
+    }
+
+    #[test]
+    fn api_response_ok_false_carries_description() {
+        let raw = json!({ "ok": false, "description": "Unauthorized" });
+        let parsed: TelegramApiResponse<serde_json::Value> = serde_json::from_value(raw).unwrap();
+        assert!(!parsed.ok);
+        assert_eq!(parsed.description.as_deref(), Some("Unauthorized"));
+    }
+}

--- a/crates/khive-channel-telegram/src/lib.rs
+++ b/crates/khive-channel-telegram/src/lib.rs
@@ -1,0 +1,11 @@
+//! Telegram Bot API channel adapter (ADR-056 Amendment 2026-07-05).
+//!
+//! Implements the `khive-channel` `Channel` trait over the Telegram Bot API's
+//! `sendMessage`/`getUpdates` methods. Plain HTTPS + JSON — no Telegram SDK.
+
+mod channel;
+mod config;
+mod connector;
+
+pub use channel::TelegramChannel;
+pub use config::TelegramChannelConfig;

--- a/crates/khive-mcp/Cargo.toml
+++ b/crates/khive-mcp/Cargo.toml
@@ -47,6 +47,7 @@ tempfile = { workspace = true }
 lattice-embed = { workspace = true, optional = true }
 khive-channel = { version = "0.5.0", path = "../khive-channel", optional = true }
 khive-channel-email = { version = "0.5.0", path = "../khive-channel-email", optional = true }
+khive-channel-telegram = { version = "0.5.0", path = "../khive-channel-telegram", optional = true }
 
 [features]
 # bench-embedder: inject deterministic FNV-1a hash embedder into the serve path.
@@ -55,6 +56,10 @@ bench-embedder = ["lattice-embed"]
 # channel-email: enable the SMTP/IMAP email polling loop.
 # Requires KHIVE_EMAIL_* environment variables at runtime; does nothing when unset.
 channel-email = ["khive-channel", "khive-channel-email"]
+# channel-telegram: enable the Telegram Bot API polling + outbox loop.
+# Requires KHIVE_TELEGRAM_* environment variables at runtime; does nothing when unset.
+# Coexists with channel-email (ChannelRegistry keys by (kind, slug), #606).
+channel-telegram = ["khive-channel", "khive-channel-telegram"]
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["test-util"] }

--- a/crates/khive-mcp/src/serve.rs
+++ b/crates/khive-mcp/src/serve.rs
@@ -1181,8 +1181,7 @@ fn telegram_ingest_namespace_from_env() -> String {
 /// A fetched batch's offset is committed (acknowledged to Telegram) only
 /// after every authorized envelope in it durably ingests via `comm.ingest`
 /// — mirrors the IMAP cursor-commit discipline at `channel_poll_loop`
-/// (~L492-550) without importing its IMAP-specific machinery (issue #113
-/// fix round 1, finding 2).
+/// without importing its IMAP-specific machinery (issue #113).
 #[cfg(feature = "channel-telegram")]
 async fn telegram_poll_loop(
     telegram_channel: std::sync::Arc<khive_channel_telegram::TelegramChannel>,

--- a/crates/khive-mcp/src/serve.rs
+++ b/crates/khive-mcp/src/serve.rs
@@ -1108,17 +1108,12 @@ fn spawn_telegram_channel_loops_if_daemon(server: &KhiveMcpServer, args: &Args) 
 /// durability model.
 #[cfg(feature = "channel-telegram")]
 fn spawn_telegram_channel_loops(server: &KhiveMcpServer) {
-    use khive_channel::ChannelRegistry;
     use khive_channel_telegram::TelegramChannel;
     use std::sync::Arc;
 
     match TelegramChannel::from_env() {
         Ok(tg_ch) => {
             let tg_ch = Arc::new(tg_ch);
-            let mut ch_registry = ChannelRegistry::new();
-            let dyn_ch: Arc<dyn khive_channel::Channel> = tg_ch.clone();
-            ch_registry.register(dyn_ch);
-            let ch_registry = Arc::new(ch_registry);
             let verb_reg = server.verb_registry_clone();
             let ingest_ns = telegram_ingest_namespace_from_env();
 
@@ -1126,11 +1121,12 @@ fn spawn_telegram_channel_loops(server: &KhiveMcpServer) {
             let verb_reg_outbox = verb_reg.clone();
             let ingest_ns_poll = ingest_ns.clone();
             let ingest_ns_outbox = ingest_ns.clone();
+            let tg_ch_poll = Arc::clone(&tg_ch);
             let tg_ch_outbox = Arc::clone(&tg_ch);
 
             let spawned = run_if_authorized(&ingest_ns, &verb_reg, || {
                 tokio::task::spawn(telegram_poll_loop(
-                    ch_registry,
+                    tg_ch_poll,
                     verb_reg_poll,
                     ingest_ns_poll,
                 ));
@@ -1170,49 +1166,75 @@ fn telegram_ingest_namespace_from_env() -> String {
         .unwrap_or_else(|| "local".to_string())
 }
 
-/// Background task that polls the Telegram channel every 5 seconds and
-/// ingests new inbound messages via `comm.ingest`. No backoff/heartbeat/
-/// lifecycle-event surface — see [`spawn_telegram_channel_loops`]'s doc
-/// comment for why this is a deliberately smaller loop than
-/// `channel_poll_loop`.
+/// Background task that polls the Telegram channel via `getUpdates` long
+/// polling and ingests new inbound messages via `comm.ingest`. No
+/// backoff/heartbeat/lifecycle-event surface — see
+/// [`spawn_telegram_channel_loops`]'s doc comment for why this is a
+/// deliberately smaller loop than `channel_poll_loop`.
+///
+/// The Bot API `getUpdates` call itself blocks server-side for the
+/// connector's long-poll timeout awaiting new updates (ADR-056 Amendment
+/// 2026-07-05 requires long polling, not short polling), so the success path
+/// adds no extra sleep between requests — the long poll paces the loop.
+/// Only the error path sleeps, so a failing Bot API does not hot-loop.
+///
+/// A fetched batch's offset is committed (acknowledged to Telegram) only
+/// after every authorized envelope in it durably ingests via `comm.ingest`
+/// — mirrors the IMAP cursor-commit discipline at `channel_poll_loop`
+/// (~L492-550) without importing its IMAP-specific machinery (issue #113
+/// fix round 1, finding 2).
 #[cfg(feature = "channel-telegram")]
 async fn telegram_poll_loop(
-    channels: std::sync::Arc<khive_channel::ChannelRegistry>,
+    telegram_channel: std::sync::Arc<khive_channel_telegram::TelegramChannel>,
     registry: khive_runtime::VerbRegistry,
     ingest_namespace: String,
 ) {
     use chrono::Utc;
+    use khive_channel::Channel;
     use serde_json::json;
 
-    const POLL_INTERVAL: std::time::Duration = std::time::Duration::from_secs(5);
+    const ERROR_BACKOFF: std::time::Duration = std::time::Duration::from_secs(5);
 
     loop {
-        tokio::time::sleep(POLL_INTERVAL).await;
-
-        for (kind, _slug, channel) in channels.iter() {
-            match channel.poll(Utc::now()).await {
-                Ok(envelopes) => {
-                    for env in envelopes {
-                        let params = json!({
-                            "namespace": ingest_namespace,
-                            "from": env.from,
-                            "to": env.to,
-                            "content": env.content,
-                            "channel_kind": kind,
-                            "external_id": env.external_id,
-                            "sent_at": env.sent_at.map(|ts| ts.to_rfc3339()),
-                        });
-                        if let Err(e) = registry.dispatch("comm.ingest", params).await {
-                            tracing::warn!(
-                                channel = kind,
-                                "comm.ingest failed for inbound telegram message: {e}"
-                            );
-                        }
+        match telegram_channel.poll(Utc::now()).await {
+            Ok(envelopes) => {
+                let kind = telegram_channel.kind();
+                let mut all_ingested = true;
+                for env in envelopes {
+                    let params = json!({
+                        "namespace": ingest_namespace,
+                        "from": env.from,
+                        "to": env.to,
+                        "content": env.content,
+                        "channel_kind": kind,
+                        "external_id": env.external_id,
+                        "sent_at": env.sent_at.map(|ts| ts.to_rfc3339()),
+                    });
+                    if let Err(e) = registry.dispatch("comm.ingest", params).await {
+                        tracing::warn!(
+                            channel = kind,
+                            "comm.ingest failed for inbound telegram message: {e}"
+                        );
+                        all_ingested = false;
                     }
                 }
-                Err(e) => {
-                    tracing::warn!(channel = kind, "telegram channel poll failed: {e}");
+
+                if all_ingested {
+                    telegram_channel.commit_offset();
+                } else {
+                    tracing::warn!(
+                        channel = kind,
+                        "not committing telegram offset: at least one message in this batch \
+                         failed comm.ingest; the whole batch will be retried next poll"
+                    );
                 }
+            }
+            Err(e) => {
+                tracing::warn!(
+                    channel = telegram_channel.kind(),
+                    "telegram channel poll failed: {e}"
+                );
+                tokio::time::sleep(ERROR_BACKOFF).await;
             }
         }
     }

--- a/crates/khive-mcp/src/serve.rs
+++ b/crates/khive-mcp/src/serve.rs
@@ -64,6 +64,8 @@ pub async fn run(args: Args, registry: &TransportRegistry) -> anyhow::Result<()>
 
     #[cfg(feature = "channel-email")]
     spawn_email_channel_loops_if_daemon(&server, &args);
+    #[cfg(feature = "channel-telegram")]
+    spawn_telegram_channel_loops_if_daemon(&server, &args);
     spawn_schedule_tick_loop_if_daemon(&args, &server, schedule_rt);
 
     #[cfg(unix)]
@@ -285,7 +287,7 @@ fn allowed_recipients_from_env() -> Vec<String> {
 /// Returns `true` when the closure was called (preflight passed), `false`
 /// otherwise.  Tests can inject a counting closure to verify the loop is not
 /// started when preflight fails (ADR-056 §6 fail-closed contract).
-#[cfg(feature = "channel-email")]
+#[cfg(any(feature = "channel-email", feature = "channel-telegram"))]
 fn run_if_authorized(
     ns_str: &str,
     registry: &khive_runtime::VerbRegistry,
@@ -305,7 +307,7 @@ fn run_if_authorized(
 /// gate permits it.  Returns `false` on any parse failure or authorization
 /// denial, after logging the reason.  The caller must not spawn the poll loop
 /// when this returns `false` (fail-closed, ADR-056 §6).
-#[cfg(feature = "channel-email")]
+#[cfg(any(feature = "channel-email", feature = "channel-telegram"))]
 fn preflight_ingest_namespace(ns_str: &str, registry: &khive_runtime::VerbRegistry) -> bool {
     match khive_runtime::Namespace::parse(ns_str) {
         Ok(ns) => match registry.authorize_namespace(ns) {
@@ -842,7 +844,7 @@ fn log_eligible_poll_failure(
 /// present-but-null `delivered_at` is undelivered, not delivered. Checking
 /// `.is_some()` alone would treat an explicit null (e.g. left by a curation
 /// `update`) as delivered and strand the note in the outbox forever.
-#[cfg(feature = "channel-email")]
+#[cfg(any(feature = "channel-email", feature = "channel-telegram"))]
 fn note_already_delivered(props: &serde_json::Map<String, serde_json::Value>) -> bool {
     props
         .get("delivered_at")
@@ -1069,6 +1071,259 @@ async fn channel_outbox_loop(
     }
 }
 
+/// Whether this process owns the Telegram channel loops. Mirrors
+/// [`is_daemon_role`]'s email-channel role gate (#602): channel loops are a
+/// daemon-role responsibility, never spawned per client process.
+#[cfg(feature = "channel-telegram")]
+fn is_telegram_daemon_role(args: &Args) -> bool {
+    args.daemon
+}
+
+/// Spawn the Telegram channel loops if — and only if — `args` indicates this
+/// process is the daemon. Mirrors
+/// [`spawn_email_channel_loops_if_daemon`]. If no daemon is running, Telegram
+/// is simply not polled until one starts.
+#[cfg(feature = "channel-telegram")]
+fn spawn_telegram_channel_loops_if_daemon(server: &KhiveMcpServer, args: &Args) {
+    if is_telegram_daemon_role(args) {
+        tracing::info!("telegram channel loops: spawning (daemon role)");
+        spawn_telegram_channel_loops(server);
+    } else {
+        tracing::info!("telegram channel loops: skipped (client role; daemon owns channel loops)");
+    }
+}
+
+/// Spawn the Telegram channel polling + outbox loops if the `channel-telegram`
+/// feature is enabled and `KHIVE_TELEGRAM_*` config resolves. Non-fatal: logs
+/// a warning and returns on incomplete config. Only call this when
+/// [`is_telegram_daemon_role`] is true — use
+/// [`spawn_telegram_channel_loops_if_daemon`].
+///
+/// Unlike the email adapter, Telegram's poll offset is held in memory inside
+/// `TelegramChannel` itself (ADR-056 Amendment 2026-07-05, "Poll offset and
+/// restart durability") — there is no per-channel checkpoint/cursor
+/// persistence, backoff escalation, or ADR-094 lifecycle-event surface for
+/// this adapter; those are email-specific hardening (#605/#606/ADR-094)
+/// this ADR explicitly does not require for Telegram's simpler getUpdates
+/// durability model.
+#[cfg(feature = "channel-telegram")]
+fn spawn_telegram_channel_loops(server: &KhiveMcpServer) {
+    use khive_channel::ChannelRegistry;
+    use khive_channel_telegram::TelegramChannel;
+    use std::sync::Arc;
+
+    match TelegramChannel::from_env() {
+        Ok(tg_ch) => {
+            let tg_ch = Arc::new(tg_ch);
+            let mut ch_registry = ChannelRegistry::new();
+            let dyn_ch: Arc<dyn khive_channel::Channel> = tg_ch.clone();
+            ch_registry.register(dyn_ch);
+            let ch_registry = Arc::new(ch_registry);
+            let verb_reg = server.verb_registry_clone();
+            let ingest_ns = telegram_ingest_namespace_from_env();
+
+            let verb_reg_poll = verb_reg.clone();
+            let verb_reg_outbox = verb_reg.clone();
+            let ingest_ns_poll = ingest_ns.clone();
+            let ingest_ns_outbox = ingest_ns.clone();
+            let tg_ch_outbox = Arc::clone(&tg_ch);
+
+            let spawned = run_if_authorized(&ingest_ns, &verb_reg, || {
+                tokio::task::spawn(telegram_poll_loop(
+                    ch_registry,
+                    verb_reg_poll,
+                    ingest_ns_poll,
+                ));
+                tokio::task::spawn(telegram_outbox_loop(
+                    tg_ch_outbox,
+                    verb_reg_outbox,
+                    ingest_ns_outbox,
+                ));
+                tracing::info!("telegram channel polling and outbox loops started");
+            });
+            if !spawned {
+                tracing::error!(
+                    namespace = %ingest_ns,
+                    "telegram channel loops NOT started: ingest namespace authorization failed (fail-closed)"
+                );
+            }
+        }
+        Err(e) => {
+            tracing::warn!(
+                "channel-telegram feature is enabled but configuration is incomplete: {e}; \
+                 telegram polling is disabled"
+            );
+        }
+    }
+}
+
+/// Resolve the target namespace for ingested Telegram messages.
+///
+/// Reads `KHIVE_TELEGRAM_INGEST_NAMESPACE`; falls back to `"local"` when the
+/// variable is unset or blank. Called once at server startup before the poll
+/// loop is spawned.
+#[cfg(feature = "channel-telegram")]
+fn telegram_ingest_namespace_from_env() -> String {
+    std::env::var("KHIVE_TELEGRAM_INGEST_NAMESPACE")
+        .ok()
+        .filter(|s| !s.trim().is_empty())
+        .unwrap_or_else(|| "local".to_string())
+}
+
+/// Background task that polls the Telegram channel every 5 seconds and
+/// ingests new inbound messages via `comm.ingest`. No backoff/heartbeat/
+/// lifecycle-event surface — see [`spawn_telegram_channel_loops`]'s doc
+/// comment for why this is a deliberately smaller loop than
+/// `channel_poll_loop`.
+#[cfg(feature = "channel-telegram")]
+async fn telegram_poll_loop(
+    channels: std::sync::Arc<khive_channel::ChannelRegistry>,
+    registry: khive_runtime::VerbRegistry,
+    ingest_namespace: String,
+) {
+    use chrono::Utc;
+    use serde_json::json;
+
+    const POLL_INTERVAL: std::time::Duration = std::time::Duration::from_secs(5);
+
+    loop {
+        tokio::time::sleep(POLL_INTERVAL).await;
+
+        for (kind, _slug, channel) in channels.iter() {
+            match channel.poll(Utc::now()).await {
+                Ok(envelopes) => {
+                    for env in envelopes {
+                        let params = json!({
+                            "namespace": ingest_namespace,
+                            "from": env.from,
+                            "to": env.to,
+                            "content": env.content,
+                            "channel_kind": kind,
+                            "external_id": env.external_id,
+                            "sent_at": env.sent_at.map(|ts| ts.to_rfc3339()),
+                        });
+                        if let Err(e) = registry.dispatch("comm.ingest", params).await {
+                            tracing::warn!(
+                                channel = kind,
+                                "comm.ingest failed for inbound telegram message: {e}"
+                            );
+                        }
+                    }
+                }
+                Err(e) => {
+                    tracing::warn!(channel = kind, "telegram channel poll failed: {e}");
+                }
+            }
+        }
+    }
+}
+
+/// Background task that delivers undelivered outbound notes addressed to a
+/// `telegram:` recipient every 5 seconds. Mirrors `channel_outbox_loop`'s
+/// note-scan/send/mark-delivered shape without the Message-ID minting logic
+/// (Telegram has no RFC 822 Message-ID concept).
+#[cfg(feature = "channel-telegram")]
+async fn telegram_outbox_loop(
+    telegram_channel: std::sync::Arc<khive_channel_telegram::TelegramChannel>,
+    registry: khive_runtime::VerbRegistry,
+    ingest_namespace: String,
+) {
+    use chrono::Utc;
+    use khive_channel::{Channel, ChannelEnvelope};
+    use serde_json::json;
+
+    loop {
+        tokio::time::sleep(std::time::Duration::from_secs(5)).await;
+
+        let list_params = json!({
+            "namespace": ingest_namespace,
+            "kind": "message",
+            "direction": "outbound",
+            "delivered": false,
+            "limit": 200,
+        });
+        let list_result = match registry.dispatch("list", list_params).await {
+            Ok(r) => r,
+            Err(e) => {
+                tracing::warn!(error = %e, "telegram outbox loop: list failed");
+                continue;
+            }
+        };
+
+        let notes = match list_result.as_array() {
+            Some(arr) => arr.clone(),
+            None => continue,
+        };
+
+        for note_val in notes {
+            let props = match note_val.get("properties") {
+                Some(serde_json::Value::Object(m)) => m.clone(),
+                _ => continue,
+            };
+
+            if props.get("direction").and_then(|v| v.as_str()) != Some("outbound") {
+                continue;
+            }
+
+            let to_actor = match props.get("to_actor").and_then(|v| v.as_str()) {
+                Some(a) if a.starts_with("telegram:") => a.to_string(),
+                _ => continue,
+            };
+
+            if note_already_delivered(&props) {
+                continue;
+            }
+
+            let note_id = match note_val.get("id").and_then(|v| v.as_str()) {
+                Some(id) => id.to_string(),
+                None => continue,
+            };
+
+            let content = match note_val.get("content").and_then(|v| v.as_str()) {
+                Some(c) => c.to_string(),
+                None => continue,
+            };
+
+            let env = ChannelEnvelope::new("telegram:bot", to_actor, content);
+
+            match telegram_channel.send(env).await {
+                Ok(()) => {
+                    let delivered_at = Utc::now().to_rfc3339();
+                    let mark_result = registry
+                        .dispatch(
+                            "update",
+                            json!({
+                                "namespace": ingest_namespace,
+                                "id": note_id,
+                                "properties": { "delivered_at": delivered_at },
+                            }),
+                        )
+                        .await;
+                    match mark_result {
+                        Ok(_) => {
+                            tracing::info!(note_id = %note_id, "telegram outbox loop: delivered");
+                        }
+                        Err(e) => {
+                            tracing::warn!(
+                                note_id = %note_id,
+                                error = %e,
+                                "telegram outbox loop: failed to set delivered_at (AT-LEAST-ONCE: will retry)"
+                            );
+                        }
+                    }
+                }
+                Err(e) => {
+                    tracing::warn!(
+                        note_id = %note_id,
+                        error = %e,
+                        "telegram outbox loop: send failed; will retry next cycle"
+                    );
+                }
+            }
+        }
+    }
+}
+
 /// Serve a pre-built server (ADR-029 Phase 2 boot path).
 ///
 /// Extracted from `run()` so that `kkernel`'s `Command::Mcp` arm can build a
@@ -1104,6 +1359,8 @@ pub async fn serve_server(
     }
     #[cfg(feature = "channel-email")]
     spawn_email_channel_loops_if_daemon(&server, args);
+    #[cfg(feature = "channel-telegram")]
+    spawn_telegram_channel_loops_if_daemon(&server, args);
     spawn_schedule_tick_loop_if_daemon(args, &server, schedule_rt);
 
     #[cfg(unix)]

--- a/crates/khive-mcp/src/server.rs
+++ b/crates/khive-mcp/src/server.rs
@@ -441,7 +441,7 @@ impl KhiveMcpServer {
     ///
     /// `VerbRegistry` is internally `Arc`-wrapped so this clone is cheap. The returned
     /// registry shares the same packs and dispatch state as the server.
-    #[cfg(feature = "channel-email")]
+    #[cfg(any(feature = "channel-email", feature = "channel-telegram"))]
     pub(crate) fn verb_registry_clone(&self) -> VerbRegistry {
         self.registry.clone()
     }


### PR DESCRIPTION
Implements the ADR-056 Amendment 2026-07-05 (Telegram adapter implementation and two-way chat): a new `khive-channel-telegram` crate implementing the `Channel` trait over the Telegram Bot API, plus `channel-telegram`-feature-gated daemon wiring (`spawn_telegram_channel_loops` with a poll loop and an outbox loop), mirroring the shipped email adapter.

Closes #113.

## What's in

- **`crates/khive-channel-telegram`** (new): `TelegramChannel` with `send` via `sendMessage` and `poll` via `getUpdates`; in-memory offset watermark per the amendment (restart durability via Telegram's server-side offset semantics + the `external_id` dedup index); connector-trait seam (`TelegramConnector`) so all 24 unit tests run against a mock — no live network in tests; config from env only (`KHIVE_TELEGRAM_BOT_TOKEN`, `KHIVE_TELEGRAM_MAINTAINER_CHAT_ID`), token masked in `Debug` output, fail-closed construction when unset.
- **Trust model**: inbound updates from any chat id other than the configured maintainer are dropped (batch-isolated — one unauthorized update never aborts the batch, and the offset still advances past it so an unauthorized sender cannot wedge the poll loop). Outbound to a non-maintainer slug is logged and dropped, never misdelivered.
- **`khive-mcp` wiring**: feature-gated poll + outbox loops (5s cadence) dispatching `comm.ingest`/`comm.send` through the existing verb surface — two-way chat with no comm API change, per the amendment. Four channel-agnostic helpers previously gated on `channel-email` relaxed to `any(channel-email, channel-telegram)`; both adapters compile and coexist (`ChannelRegistry` keys by `(kind, slug)`).

## Deliberately out (v1 scope per the amendment)

Media/non-text updates, group chats, webhook inbound (long-poll only), channel-health heartbeat coverage (follow-up if wanted).

## Gates

`cargo check/clippy -D warnings/test -p khive-channel-telegram` (24/24), `cargo check -p khive-mcp --features channel-telegram` and `--features channel-telegram,channel-email`, `cargo check --workspace`, fmt clean, `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps -p khive-channel-telegram` clean.

The round trip (send → Telegram → maintainer reply → `comm.inbox`) is design-verified via the mocked unit tests; a live smoke against a real bot token plugs in at the connector seam when a token is provisioned.
