### PR TITLE
feat(scripts): canonical workspace-artifact ingest (dry-run gated)

### DIFF
--- a/.khive/scripts/ingest_workspace_artifacts.py
+++ b/.khive/scripts/ingest_workspace_artifacts.py
@@ -540,6 +540,7 @@ class Stats:
     pr_link_misses: int = 0
     pr_link_na: int = 0
     samples: list = field(default_factory=list)
+    blocked_secret_gate: list = field(default_factory=list)
 
 
 def _acquire_live_lock() -> "object":
@@ -689,7 +690,18 @@ def _process_one(
         f"content={dsl_str(content)}, properties={props_json}, "
         f"tags={json.dumps(note_tags)}, annotates={json.dumps(annotate_targets)})"
     )
-    first_op_result(resp)  # raises on failure; note+edges are all-or-nothing
+    try:
+        first_op_result(resp)  # raises on failure; note+edges are all-or-nothing
+    except RuntimeError as e:
+        if "matches secret pattern" in str(e):
+            # Daemon secret-gate false positive on legitimate artifact text
+            # (high-entropy string near a trigger word). Content is never
+            # reworded to dodge the gate — the artifact stays un-cursored
+            # for a later pass once the gate's masking handles it.
+            stats.blocked_secret_gate.append(a.rel_path)
+            print(f"  [secret-gate blocked] {a.rel_path}", file=sys.stderr)
+            return
+        raise
 
     stats.notes_created += 1
     append_cursor(*key)
@@ -778,8 +790,11 @@ def main() -> int:
             f"LIVE run complete. notes_created={stats.notes_created} "
             f"skipped_cursor={stats.notes_skipped_cursor} "
             f"skipped_existing={stats.notes_skipped_existing} "
-            f"edges_backfilled={stats.edges_backfilled}"
+            f"edges_backfilled={stats.edges_backfilled} "
+            f"blocked_secret_gate={len(stats.blocked_secret_gate)}"
         )
+        for rel in stats.blocked_secret_gate:
+            print(f"  blocked: {rel}")
 
     print(json.dumps(stats.by_class, indent=2))
     return 0

--- a/.khive/scripts/ingest_workspace_artifacts.py
+++ b/.khive/scripts/ingest_workspace_artifacts.py
@@ -24,8 +24,15 @@ Design notes:
   records completed (source_path, sha16) pairs so a re-run after interruption
   skips already-ingested files without any server round-trip. As a second,
   server-side safety net (covers a lost/stale cursor file), --live also
-  bulk-loads existing ws-ingest-tagged notes once at startup and skips any
-  file whose key is already present there.
+  bulk-loads existing ws-ingest-tagged notes once at startup, keyed to their
+  note id. A file whose key is already present there is NOT accepted as
+  complete on sight: its note's outgoing `annotates` edges are checked
+  (`neighbors`, direction outgoing, relation annotates) against the targets
+  this artifact requires (workspace lane, and PR for codex verdicts), and
+  whatever is missing is created before the cursor is backfilled. This
+  covers a note left incomplete by a pre-fix run, or by a create-time link
+  failure whose runtime-side compensation was itself best-effort and did not
+  run to completion (crates/khive-runtime/src/operations.rs).
 - Content is truncated at ~48KB (of the FINAL UTF-8-encoded, replacement-
   decoded payload, marker space reserved) with a trailing marker; the sha256
   is always computed over the ORIGINAL (untruncated) bytes so the dedup key
@@ -36,9 +43,10 @@ Design notes:
   the note row) if an edge fails, so a note can never be persisted with a
   missing required edge (crates/khive-runtime/src/operations.rs
   create_note_inner).
-- CONCURRENCY: a same-host POSIX advisory lock (fcntl.flock on
-  `.khive/scripts/.ws_ingest.lock`) excludes concurrent --live invocations on
-  this machine. This is NOT a substitute for a server-side atomic natural-key
+- CONCURRENCY: a machine-wide POSIX advisory lock (fcntl.flock on the fixed
+  path `/tmp/lion-khive-wsingest.lock`, independent of which checkout/
+  worktree the script runs from) excludes concurrent --live invocations on
+  this host. This is NOT a substitute for a server-side atomic natural-key
   dedup: the generic `create` verb does not expose the `external_id` /
   `try_insert_note` atomic-insert path (that path exists only on the
   internal `try_create_note` runtime method, unused by the MCP `create`
@@ -71,7 +79,11 @@ SCRIPT_DIR = Path(__file__).resolve().parent
 REPO_ROOT = SCRIPT_DIR.parent.parent  # .khive/scripts -> .khive -> repo root
 KHIVE_DIR = REPO_ROOT / ".khive"
 CURSOR_PATH = SCRIPT_DIR / ".ws_ingest_cursor"
-LOCK_PATH = SCRIPT_DIR / ".ws_ingest.lock"
+# Fixed, checkout-independent path: multiple worktrees of this repo (or
+# multiple repos, incidentally) share the same khive.db, so the exclusion
+# lock must be machine-wide, not per-checkout. /tmp, lion-prefixed, never
+# inside a cargo target tree (fleet lock-naming convention).
+LOCK_PATH = Path("/tmp/lion-khive-wsingest.lock")
 KKERNEL = os.path.expanduser("~/.cargo/bin/kkernel")
 
 MAX_CONTENT_BYTES = 48 * 1024
@@ -390,9 +402,12 @@ def load_existing_workspaces(kk: KKernel) -> dict[str, str]:
 
 def load_existing_ws_ingest_notes(
     kk: KKernel, note_kinds: list[str], page_limit: int = 200, max_pages: int = 500
-) -> set[tuple[str, str]]:
-    """(source_path, content_sha256_16) pairs already ingested by this script, across kinds."""
-    seen: set[tuple[str, str]] = set()
+) -> dict[tuple[str, str], str]:
+    """(source_path, content_sha256_16) -> note id, for notes already ingested
+    by this script, across kinds. The note id is retained (not just the key)
+    so a match can be reconciled — its `annotates` edges verified/backfilled
+    — rather than accepted as complete on sight; see reconcile_existing_note."""
+    seen: dict[tuple[str, str], str] = {}
     for kind in note_kinds:
         offset = 0
         for _ in range(max_pages):
@@ -408,11 +423,69 @@ def load_existing_ws_ingest_notes(
                 sp = props.get("source_path")
                 sha = props.get("content_sha256_16")
                 if sp and sha:
-                    seen.add((sp, sha))
+                    seen[(sp, sha)] = row["id"]
             if len(rows) < page_limit:
                 break
             offset += page_limit
     return seen
+
+
+def fetch_outgoing_annotate_targets(kk: KKernel, note_id: str) -> set[str]:
+    """Target ids of `note_id`'s outgoing `annotates` edges. Read-only."""
+    resp = kk.read(
+        f'neighbors(node_id={dsl_str(note_id)}, direction="outgoing", '
+        f"relations={json.dumps(['annotates'])})"
+    )
+    hits = first_op_result(resp)
+    return {hit["id"] for hit in hits if "id" in hit}
+
+
+def compute_annotate_targets(
+    a: Artifact, ws_id: str | None, pr_by_number: dict[int, str]
+) -> list[str]:
+    """The full set of `annotates` targets this artifact requires: its
+    workspace lane entity, plus (for codex verdicts with a project-scoped PR
+    match) the pull_request note. Pure — no I/O."""
+    targets: list[str] = []
+    if ws_id:
+        targets.append(ws_id)
+    if a.artifact_class == "codex_verdict" and a.pr_number in pr_by_number:
+        targets.append(pr_by_number[a.pr_number])
+    return targets
+
+
+def missing_annotate_targets(required: list[str], existing: set[str]) -> list[str]:
+    """Required targets not already covered by an existing outgoing edge.
+    Pure — no I/O."""
+    return [t for t in required if t not in existing]
+
+
+def reconcile_existing_note(
+    kk: KKernel,
+    a: Artifact,
+    note_id: str,
+    ws_cache: dict[str, str],
+    pr_by_number: dict[int, str],
+    stats: Stats,
+) -> None:
+    """A note matching this artifact's (source_path, sha16) key was found by
+    the startup server scan. Before accepting it as complete, verify its
+    outgoing `annotates` edges cover every target this artifact requires and
+    create whatever is missing — a note can be present with a missing edge
+    if it was written by a pre-fix run, or if create-time link-failure
+    compensation (best-effort, ignores its own failures — see
+    crates/khive-runtime/src/operations.rs) did not run to completion."""
+    ws_id = ensure_workspace(kk, a.lane, ws_cache, live=True, stats=stats)
+    required = compute_annotate_targets(a, ws_id, pr_by_number)
+    if not required:
+        return
+    existing_targets = fetch_outgoing_annotate_targets(kk, note_id)
+    for target_id in missing_annotate_targets(required, existing_targets):
+        kk.write(
+            f"link(source_id={dsl_str(note_id)}, target_id={dsl_str(target_id)}, "
+            f'relation="annotates")'
+        )
+        stats.edges_backfilled += 1
 
 
 def cap_content(raw: bytes) -> str:
@@ -461,6 +534,7 @@ class Stats:
     workspaces_to_create: int = 0
     edges_workspace_planned: int = 0
     edges_pr_planned: int = 0
+    edges_backfilled: int = 0
     pr_link_hits: int = 0
     pr_link_misses: int = 0
     pr_link_na: int = 0
@@ -468,19 +542,20 @@ class Stats:
 
 
 def _acquire_live_lock() -> "object":
-    """Same-host exclusion for --live runs (fcntl.flock, non-blocking).
-    See module docstring CONCURRENCY note for what this does and does not
-    cover."""
+    """Machine-wide exclusion for --live runs (fcntl.flock, non-blocking, on
+    a fixed path shared by every checkout on this host). See module
+    docstring CONCURRENCY note for what this does and does not cover."""
     fd = LOCK_PATH.open("w")
     try:
         fcntl.flock(fd.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
     except OSError as e:
         fd.close()
         raise RuntimeError(
-            f"another --live ws-ingest run already holds {LOCK_PATH} (same-host "
-            "exclusion lock) — wait for it to finish before retrying. This lock "
-            "does NOT exclude concurrent --live runs on a different host against "
-            "the same khive.db; see module docstring CONCURRENCY note."
+            f"another --live ws-ingest run already holds {LOCK_PATH} (machine-wide "
+            "exclusion lock, shared across checkouts) — wait for it to finish "
+            "before retrying. This lock does NOT exclude concurrent --live runs "
+            "on a different host against the same khive.db; see module docstring "
+            "CONCURRENCY note."
         ) from e
     return fd
 
@@ -502,7 +577,7 @@ def process(dry_run: bool) -> tuple[Stats, list[Artifact]]:
         project_id = resolve_project_id(kk)
         pr_by_number = filter_pr_by_number(fetch_all(kk, "pull_request"), project_id)
         existing_notes = (
-            load_existing_ws_ingest_notes(kk, sorted(set(NOTE_KIND.values()))) if live else set()
+            load_existing_ws_ingest_notes(kk, sorted(set(NOTE_KIND.values()))) if live else {}
         )
 
         lanes_needed = sorted({a.lane for a in artifacts})
@@ -527,7 +602,7 @@ def _process_one(
     ws_cache: dict[str, str],
     pr_by_number: dict[int, str],
     cursor_done: set[tuple[str, str]],
-    existing_notes: set[tuple[str, str]],
+    existing_notes: dict[tuple[str, str], str],
     stats: Stats,
 ) -> None:
     key = (a.rel_path, a.sha16)
@@ -544,6 +619,7 @@ def _process_one(
         stats.notes_skipped_cursor += 1
         return
     if live and key in existing_notes:
+        reconcile_existing_note(kk, a, existing_notes[key], ws_cache, pr_by_number, stats)
         stats.notes_skipped_existing += 1
         append_cursor(*key)
         return
@@ -591,12 +667,12 @@ def _process_one(
     # Note + its annotates edges are created atomically in one call: the
     # runtime validates every target exists before any write and compensates
     # (deletes the note row) if an edge fails — see module docstring.
-    annotate_targets: list[str] = []
-    if ws_id:
-        annotate_targets.append(ws_id)
-    if a.artifact_class == "codex_verdict" and a.pr_number in pr_by_number:
-        annotate_targets.append(pr_by_number[a.pr_number])
-    elif a.artifact_class == "codex_verdict" and a.pr_number is not None:
+    annotate_targets = compute_annotate_targets(a, ws_id, pr_by_number)
+    if (
+        a.artifact_class == "codex_verdict"
+        and a.pr_number is not None
+        and a.pr_number not in pr_by_number
+    ):
         print(
             f"  [pr-link miss] {a.rel_path}: no project-scoped pull_request "
             f"note for #{a.pr_number}",
@@ -689,7 +765,8 @@ def main() -> int:
         print(
             f"LIVE run complete. notes_created={stats.notes_created} "
             f"skipped_cursor={stats.notes_skipped_cursor} "
-            f"skipped_existing={stats.notes_skipped_existing}"
+            f"skipped_existing={stats.notes_skipped_existing} "
+            f"edges_backfilled={stats.edges_backfilled}"
         )
 
     print(json.dumps(stats.by_class, indent=2))

--- a/.khive/scripts/ingest_workspace_artifacts.py
+++ b/.khive/scripts/ingest_workspace_artifacts.py
@@ -26,13 +26,37 @@ Design notes:
   server-side safety net (covers a lost/stale cursor file), --live also
   bulk-loads existing ws-ingest-tagged notes once at startup and skips any
   file whose key is already present there.
-- Content is truncated at ~48KB with a trailing marker; the sha256 is always
-  computed over the ORIGINAL (untruncated) bytes so the dedup key is stable.
+- Content is truncated at ~48KB (of the FINAL UTF-8-encoded, replacement-
+  decoded payload, marker space reserved) with a trailing marker; the sha256
+  is always computed over the ORIGINAL (untruncated) bytes so the dedup key
+  is stable.
+- Note + its `annotates` edges (workspace lane, and PR for codex verdicts)
+  are created in ONE `create(..., annotates=[...])` call. The runtime
+  validates every annotate target before any write and compensates (deletes
+  the note row) if an edge fails, so a note can never be persisted with a
+  missing required edge (crates/khive-runtime/src/operations.rs
+  create_note_inner).
+- CONCURRENCY: a same-host POSIX advisory lock (fcntl.flock on
+  `.khive/scripts/.ws_ingest.lock`) excludes concurrent --live invocations on
+  this machine. This is NOT a substitute for a server-side atomic natural-key
+  dedup: the generic `create` verb does not expose the `external_id` /
+  `try_insert_note` atomic-insert path (that path exists only on the
+  internal `try_create_note` runtime method, unused by the MCP `create`
+  verb). Two --live runs on DIFFERENT hosts against the same khive.db are
+  NOT excluded and can still race to create duplicate notes for the same
+  (source_path, sha16). Product gap, not fixed here — see PR body.
+- PR annotation is scoped to THIS repository's `project` entity (exact-name
+  match against WS_INGEST_PROJECT_NAME, default "khive-oss"). A codex-verdict
+  file naming PR #N only annotates a `pull_request` note whose
+  properties.project_id matches that project; a same-numbered PR in another
+  repository's project is never used (mirrors khive-pack-git ingest.rs
+  find_by_number's project_id scoping).
 """
 
 from __future__ import annotations
 
 import argparse
+import fcntl
 import hashlib
 import json
 import os
@@ -47,12 +71,18 @@ SCRIPT_DIR = Path(__file__).resolve().parent
 REPO_ROOT = SCRIPT_DIR.parent.parent  # .khive/scripts -> .khive -> repo root
 KHIVE_DIR = REPO_ROOT / ".khive"
 CURSOR_PATH = SCRIPT_DIR / ".ws_ingest_cursor"
+LOCK_PATH = SCRIPT_DIR / ".ws_ingest.lock"
 KKERNEL = os.path.expanduser("~/.cargo/bin/kkernel")
 
 MAX_CONTENT_BYTES = 48 * 1024
 TRUNCATION_MARKER = "\n\n...[truncated by ws-ingest, original length {orig} bytes]...\n"
 
 INGEST_TAG = "ws-ingest"
+
+# This checkout's canonical `project` entity name (exact match). PR/issue
+# notes carry `properties.project_id`; PR numbers are only unique within a
+# project, so annotation must be scoped to this one, never number-only.
+WS_INGEST_PROJECT_NAME = os.environ.get("WS_INGEST_PROJECT_NAME", "khive-oss")
 
 # artifact_class -> canonical note kind (closed set: observation/insight/
 # question/decision/reference). Verdicts, workspace docs, and audits are all
@@ -85,8 +115,24 @@ def sha256_16(data: bytes) -> str:
 
 
 def dsl_escape(s: str) -> str:
-    """Escape a string for embedding as a double-quoted DSL literal."""
-    return s.replace("\\", "\\\\").replace('"', '\\"').replace("\n", "\\n").replace("\r", "")
+    """Escape a string for embedding as a double-quoted DSL literal.
+
+    Backslash/quote/newline/CR are JSON-escaped (CR as \\r, never dropped —
+    dropping it would silently alter CRLF content while the sha256 dedup key
+    still reflects the original bytes). A value that is, in full, a `$prev`
+    chain reference (`$prev`, `$prev.<path>`, `$prev[<idx>]...`) would
+    otherwise be promoted by the DSL parser into a chain reference instead of
+    the literal string (khive-request parser_impl.rs string_as_prev_ref); the
+    parser's own documented escape is a single leading backslash
+    (parser_impl.rs: `s.strip_prefix('\\')` then re-checks the $prev
+    prefixes), so such values get one extra literal backslash prepended.
+    """
+    escaped = (
+        s.replace("\\", "\\\\").replace('"', '\\"').replace("\n", "\\n").replace("\r", "\\r")
+    )
+    if s == "$prev" or s.startswith("$prev.") or s.startswith("$prev["):
+        escaped = "\\\\" + escaped
+    return escaped
 
 
 def dsl_str(s: str) -> str:
@@ -256,11 +302,6 @@ class KKernel:
         return self._run(ops)
 
 
-def annotate_op(source_id: str, target_id: str) -> str:
-    src, tgt, rel = dsl_str(source_id), dsl_str(target_id), dsl_str("annotates")
-    return f"link(source_id={src}, target_id={tgt}, relation={rel})"
-
-
 def first_op_result(resp: dict) -> dict:
     results = resp.get("results", [])
     if not results:
@@ -282,46 +323,68 @@ def list_items(result) -> list:
     return result
 
 
-def load_existing_pull_requests(
-    kk: KKernel, page_limit: int = 200, max_pages: int = 50
-) -> dict[int, str]:
-    """number -> note id, for existing pull_request notes. Bounded pagination."""
-    by_number: dict[int, str] = {}
+def fetch_all(kk: KKernel, kind: str, page_limit: int = 200, max_pages: int = 50) -> list[dict]:
+    """Fetch every row of `kind` via bounded pagination. Read-only."""
+    rows_all: list[dict] = []
     offset = 0
     for _ in range(max_pages):
-        resp = kk.read(f"list(kind={dsl_str('pull_request')}, limit={page_limit}, offset={offset})")
+        resp = kk.read(f"list(kind={dsl_str(kind)}, limit={page_limit}, offset={offset})")
         rows = list_items(first_op_result(resp))
         if not rows:
             break
-        for row in rows:
-            props = row.get("properties") or {}
-            num = props.get("number")
-            if isinstance(num, int):
-                by_number[num] = row["id"]
+        rows_all.extend(rows)
         if len(rows) < page_limit:
             break
         offset += page_limit
+    return rows_all
+
+
+def select_exact_project(project_rows: list[dict], expected_name: str) -> str | None:
+    """Exact-name match against `project` entity rows. 0 or >1 matches -> None
+    (an explicit miss the caller must log — never a fallback guess)."""
+    exact = [r for r in project_rows if r.get("name") == expected_name]
+    if len(exact) != 1:
+        return None
+    return exact[0]["id"]
+
+
+def resolve_project_id(kk: KKernel, expected_name: str = WS_INGEST_PROJECT_NAME) -> str | None:
+    project_id = select_exact_project(fetch_all(kk, "project"), expected_name)
+    if project_id is None:
+        print(
+            f"  [project-resolve] could not uniquely resolve this repo's project "
+            f"entity (expected exactly one `project` named {expected_name!r}); "
+            "codex_verdict notes will NOT be annotated to any pull_request note "
+            "this run.",
+            file=sys.stderr,
+        )
+    return project_id
+
+
+def filter_pr_by_number(pr_rows: list[dict], project_id: str | None) -> dict[int, str]:
+    """number -> note id, restricted to pull_request notes whose
+    properties.project_id matches this checkout's project. PR numbers are
+    only unique within a project (mirrors khive-pack-git ingest.rs
+    find_by_number); project_id=None (unresolved project) yields no matches
+    rather than a number-only cross-repository fallback."""
+    by_number: dict[int, str] = {}
+    if project_id is None:
+        return by_number
+    for row in pr_rows:
+        props = row.get("properties") or {}
+        num = props.get("number")
+        if isinstance(num, int) and props.get("project_id") == project_id:
+            by_number[num] = row["id"]
     return by_number
 
 
-def load_existing_workspaces(
-    kk: KKernel, page_limit: int = 200, max_pages: int = 50
-) -> dict[str, str]:
+def load_existing_workspaces(kk: KKernel) -> dict[str, str]:
     """lane name -> workspace entity id."""
     by_name: dict[str, str] = {}
-    offset = 0
-    for _ in range(max_pages):
-        resp = kk.read(f"list(kind={dsl_str('workspace')}, limit={page_limit}, offset={offset})")
-        rows = list_items(first_op_result(resp))
-        if not rows:
-            break
-        for row in rows:
-            name = row.get("name")
-            if name:
-                by_name[name] = row["id"]
-        if len(rows) < page_limit:
-            break
-        offset += page_limit
+    for row in fetch_all(kk, "workspace"):
+        name = row.get("name")
+        if name:
+            by_name[name] = row["id"]
     return by_name
 
 
@@ -352,15 +415,23 @@ def load_existing_ws_ingest_notes(
     return seen
 
 
-def build_note_content(artifact: Artifact) -> str:
-    raw = artifact.path.read_bytes()
+def cap_content(raw: bytes) -> str:
+    """Decode `raw` (replacing invalid UTF-8) and cap the FINAL encoded
+    payload at MAX_CONTENT_BYTES, marker space reserved. Capping on the
+    original raw byte length is not sufficient: `errors="replace"` can
+    expand invalid bytes (each -> U+FFFD, 3 bytes), so the cap must apply
+    after replacement decoding, not before."""
     text = raw.decode("utf-8", errors="replace")
-    if len(raw) > MAX_CONTENT_BYTES:
-        text = text.encode("utf-8", errors="replace")[:MAX_CONTENT_BYTES].decode(
-            "utf-8", errors="ignore"
-        )
-        text += TRUNCATION_MARKER.format(orig=len(raw))
-    return text
+    encoded = text.encode("utf-8")
+    if len(encoded) <= MAX_CONTENT_BYTES:
+        return text
+    marker = TRUNCATION_MARKER.format(orig=len(raw))
+    budget = max(MAX_CONTENT_BYTES - len(marker.encode("utf-8")), 0)
+    return encoded[:budget].decode("utf-8", errors="ignore") + marker
+
+
+def build_note_content(artifact: Artifact) -> str:
+    return cap_content(artifact.path.read_bytes())
 
 
 def ensure_workspace(
@@ -396,110 +467,153 @@ class Stats:
     samples: list = field(default_factory=list)
 
 
+def _acquire_live_lock() -> "object":
+    """Same-host exclusion for --live runs (fcntl.flock, non-blocking).
+    See module docstring CONCURRENCY note for what this does and does not
+    cover."""
+    fd = LOCK_PATH.open("w")
+    try:
+        fcntl.flock(fd.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+    except OSError as e:
+        fd.close()
+        raise RuntimeError(
+            f"another --live ws-ingest run already holds {LOCK_PATH} (same-host "
+            "exclusion lock) — wait for it to finish before retrying. This lock "
+            "does NOT exclude concurrent --live runs on a different host against "
+            "the same khive.db; see module docstring CONCURRENCY note."
+        ) from e
+    return fd
+
+
 def process(dry_run: bool) -> tuple[Stats, list[Artifact]]:
     live = not dry_run
     kk = KKernel(live=live)
     stats = Stats()
+    lock_fd = _acquire_live_lock() if live else None
 
-    artifacts = discover()
-    for a in artifacts:
-        stats.by_class[a.artifact_class] += 1
+    try:
+        artifacts = discover()
+        for a in artifacts:
+            stats.by_class[a.artifact_class] += 1
 
-    cursor_done = load_cursor()
+        cursor_done = load_cursor()
 
-    ws_cache = load_existing_workspaces(kk)
-    pr_by_number = load_existing_pull_requests(kk)
-    existing_notes = (
-        load_existing_ws_ingest_notes(kk, sorted(set(NOTE_KIND.values()))) if live else set()
-    )
-
-    lanes_needed = sorted({a.lane for a in artifacts})
-    for lane in lanes_needed:
-        if lane not in ws_cache:
-            stats.workspaces_to_create += 1
-
-    for a in artifacts:
-        key = (a.rel_path, a.sha16)
-
-        if a.artifact_class == "codex_verdict":
-            if a.pr_number is None:
-                stats.pr_link_na += 1
-            elif a.pr_number in pr_by_number:
-                stats.pr_link_hits += 1
-            else:
-                stats.pr_link_misses += 1
-
-        if key in cursor_done:
-            stats.notes_skipped_cursor += 1
-            continue
-        if live and key in existing_notes:
-            stats.notes_skipped_existing += 1
-            append_cursor(*key)
-            continue
-
-        note_kind = NOTE_KIND[a.artifact_class]
-        note_tags = [INGEST_TAG, a.artifact_class]
-        stats.edges_workspace_planned += 1
-        if a.artifact_class == "codex_verdict" and a.pr_number in pr_by_number:
-            stats.edges_pr_planned += 1
-
-        if len(stats.samples) < 10:
-            stats.samples.append(
-                {
-                    "source_path": a.rel_path,
-                    "artifact_class": a.artifact_class,
-                    "note_kind": note_kind,
-                    "lane": a.lane,
-                    "pr_number": a.pr_number,
-                    "pr_link": (
-                        "hit"
-                        if (a.pr_number is not None and a.pr_number in pr_by_number)
-                        else ("miss" if a.pr_number is not None else "n/a")
-                    ),
-                    "sha16": a.sha16,
-                    "size": a.size,
-                }
-            )
-
-        if not live:
-            stats.notes_created += 1  # "would create"
-            continue
-
-        ws_id = ensure_workspace(kk, a.lane, ws_cache, live, stats)
-
-        content = build_note_content(a)
-        properties = {
-            "source_path": a.rel_path,
-            "content_sha256_16": a.sha16,
-            "artifact_class": a.artifact_class,
-            "ingested_at": datetime.now(UTC).isoformat(),
-        }
-        if a.pr_number is not None:
-            properties["pr_number"] = a.pr_number
-
-        name = a.rel_path.rsplit("/", 1)[-1][:120]
-        props_json = json.dumps(properties)
-        resp = kk.write(
-            f"create(kind={dsl_str(note_kind)}, name={dsl_str(name)}, "
-            f"content={dsl_str(content)}, properties={props_json}, tags={json.dumps(note_tags)})"
+        ws_cache = load_existing_workspaces(kk)
+        project_id = resolve_project_id(kk)
+        pr_by_number = filter_pr_by_number(fetch_all(kk, "pull_request"), project_id)
+        existing_notes = (
+            load_existing_ws_ingest_notes(kk, sorted(set(NOTE_KIND.values()))) if live else set()
         )
-        note_id = first_op_result(resp)["id"]
 
-        if ws_id:
-            kk.write(annotate_op(note_id, ws_id))
+        lanes_needed = sorted({a.lane for a in artifacts})
+        for lane in lanes_needed:
+            if lane not in ws_cache:
+                stats.workspaces_to_create += 1
 
-        if a.artifact_class == "codex_verdict" and a.pr_number in pr_by_number:
-            kk.write(annotate_op(note_id, pr_by_number[a.pr_number]))
-        elif a.artifact_class == "codex_verdict" and a.pr_number is not None:
-            print(
-                f"  [pr-link miss] {a.rel_path}: no pull_request note for #{a.pr_number}",
-                file=sys.stderr,
-            )
-
-        stats.notes_created += 1
-        append_cursor(*key)
+        for a in artifacts:
+            _process_one(kk, a, live, ws_cache, pr_by_number, cursor_done, existing_notes, stats)
+    finally:
+        if lock_fd is not None:
+            fcntl.flock(lock_fd.fileno(), fcntl.LOCK_UN)
+            lock_fd.close()
 
     return stats, artifacts
+
+
+def _process_one(
+    kk: KKernel,
+    a: Artifact,
+    live: bool,
+    ws_cache: dict[str, str],
+    pr_by_number: dict[int, str],
+    cursor_done: set[tuple[str, str]],
+    existing_notes: set[tuple[str, str]],
+    stats: Stats,
+) -> None:
+    key = (a.rel_path, a.sha16)
+
+    if a.artifact_class == "codex_verdict":
+        if a.pr_number is None:
+            stats.pr_link_na += 1
+        elif a.pr_number in pr_by_number:
+            stats.pr_link_hits += 1
+        else:
+            stats.pr_link_misses += 1
+
+    if key in cursor_done:
+        stats.notes_skipped_cursor += 1
+        return
+    if live and key in existing_notes:
+        stats.notes_skipped_existing += 1
+        append_cursor(*key)
+        return
+
+    note_kind = NOTE_KIND[a.artifact_class]
+    note_tags = [INGEST_TAG, a.artifact_class]
+    stats.edges_workspace_planned += 1
+    if a.artifact_class == "codex_verdict" and a.pr_number in pr_by_number:
+        stats.edges_pr_planned += 1
+
+    if len(stats.samples) < 10:
+        stats.samples.append(
+            {
+                "source_path": a.rel_path,
+                "artifact_class": a.artifact_class,
+                "note_kind": note_kind,
+                "lane": a.lane,
+                "pr_number": a.pr_number,
+                "pr_link": (
+                    "hit"
+                    if (a.pr_number is not None and a.pr_number in pr_by_number)
+                    else ("miss" if a.pr_number is not None else "n/a")
+                ),
+                "sha16": a.sha16,
+                "size": a.size,
+            }
+        )
+
+    if not live:
+        stats.notes_created += 1  # "would create"
+        return
+
+    ws_id = ensure_workspace(kk, a.lane, ws_cache, live, stats)
+
+    content = build_note_content(a)
+    properties = {
+        "source_path": a.rel_path,
+        "content_sha256_16": a.sha16,
+        "artifact_class": a.artifact_class,
+        "ingested_at": datetime.now(UTC).isoformat(),
+    }
+    if a.pr_number is not None:
+        properties["pr_number"] = a.pr_number
+
+    # Note + its annotates edges are created atomically in one call: the
+    # runtime validates every target exists before any write and compensates
+    # (deletes the note row) if an edge fails — see module docstring.
+    annotate_targets: list[str] = []
+    if ws_id:
+        annotate_targets.append(ws_id)
+    if a.artifact_class == "codex_verdict" and a.pr_number in pr_by_number:
+        annotate_targets.append(pr_by_number[a.pr_number])
+    elif a.artifact_class == "codex_verdict" and a.pr_number is not None:
+        print(
+            f"  [pr-link miss] {a.rel_path}: no project-scoped pull_request "
+            f"note for #{a.pr_number}",
+            file=sys.stderr,
+        )
+
+    name = a.rel_path.rsplit("/", 1)[-1][:120]
+    props_json = json.dumps(properties)
+    resp = kk.write(
+        f"create(kind={dsl_str(note_kind)}, name={dsl_str(name)}, "
+        f"content={dsl_str(content)}, properties={props_json}, "
+        f"tags={json.dumps(note_tags)}, annotates={json.dumps(annotate_targets)})"
+    )
+    first_op_result(resp)  # raises on failure; note+edges are all-or-nothing
+
+    stats.notes_created += 1
+    append_cursor(*key)
 
 
 def write_dryrun_report(stats: Stats, artifacts: list[Artifact], out_path: Path) -> None:

--- a/.khive/scripts/ingest_workspace_artifacts.py
+++ b/.khive/scripts/ingest_workspace_artifacts.py
@@ -1,0 +1,586 @@
+#!/usr/bin/env python3
+"""Canonical ingest of .khive/ workspace artifacts into khive.db (workspace pack).
+
+Migrates loose, gitignored `.khive/` files (codex verdicts, workspace docs,
+session summaries/handoffs, crate audits) into queryable khive.db records:
+one `workspace` entity per lane (date/topic grouping), one note per file,
+`annotates` edges from each note back to its lane entity, and (for codex
+verdicts that name a PR) an additional `annotates` edge to the matching
+git-pack `pull_request` note.
+
+No new MCP verbs are needed — this uses only the existing generic
+create/link/list/search verbs over the merged workspace-pack substrate
+(Ocean ruling 2026-07-13).
+
+Usage:
+    uv run python .khive/scripts/ingest_workspace_artifacts.py --dry-run
+    uv run python .khive/scripts/ingest_workspace_artifacts.py --live
+
+Design notes:
+- DRY-RUN IS THE DEFAULT. --live is required to perform any khive writes.
+- All writes go through `kkernel exec '<ops-DSL>'` (subprocess). This script
+  never opens khive.db directly; sqlite3 is used nowhere.
+- Idempotency key = (source_path, content_sha256_16). A resume cursor file
+  records completed (source_path, sha16) pairs so a re-run after interruption
+  skips already-ingested files without any server round-trip. As a second,
+  server-side safety net (covers a lost/stale cursor file), --live also
+  bulk-loads existing ws-ingest-tagged notes once at startup and skips any
+  file whose key is already present there.
+- Content is truncated at ~48KB with a trailing marker; the sha256 is always
+  computed over the ORIGINAL (untruncated) bytes so the dedup key is stable.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import re
+import subprocess
+import sys
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from pathlib import Path
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+REPO_ROOT = SCRIPT_DIR.parent.parent  # .khive/scripts -> .khive -> repo root
+KHIVE_DIR = REPO_ROOT / ".khive"
+CURSOR_PATH = SCRIPT_DIR / ".ws_ingest_cursor"
+KKERNEL = os.path.expanduser("~/.cargo/bin/kkernel")
+
+MAX_CONTENT_BYTES = 48 * 1024
+TRUNCATION_MARKER = "\n\n...[truncated by ws-ingest, original length {orig} bytes]...\n"
+
+INGEST_TAG = "ws-ingest"
+
+# artifact_class -> canonical note kind (closed set: observation/insight/
+# question/decision/reference). Verdicts, workspace docs, and audits are all
+# "reference" (ingested-document semantics); summaries/handoffs are
+# "observation" (session-context semantics).
+NOTE_KIND = {
+    "codex_verdict": "reference",
+    "workspace_doc": "reference",
+    "summary": "observation",
+    "handoff": "observation",
+    "audit": "reference",
+}
+
+PR_NUM_RE = re.compile(r"codex_review_pr(\d+)")
+
+
+@dataclass
+class Artifact:
+    artifact_class: str
+    path: Path  # absolute
+    rel_path: str  # posix, relative to REPO_ROOT
+    lane: str
+    pr_number: int | None = None
+    sha16: str = ""
+    size: int = 0
+
+
+def sha256_16(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()[:16]
+
+
+def dsl_escape(s: str) -> str:
+    """Escape a string for embedding as a double-quoted DSL literal."""
+    return s.replace("\\", "\\\\").replace('"', '\\"').replace("\n", "\\n").replace("\r", "")
+
+
+def dsl_str(s: str) -> str:
+    return f'"{dsl_escape(s)}"'
+
+
+def lane_for(artifact_class: str, rel: Path) -> str:
+    parts = rel.parts
+    if artifact_class == "workspace_doc":
+        idx = parts.index("workspaces")
+        if len(parts) > idx + 2:
+            return f"{parts[idx + 1]}/{parts[idx + 2]}"
+        if len(parts) > idx + 1:
+            return parts[idx + 1]
+        return "workspaces/misc"
+    if artifact_class == "audit":
+        idx = parts.index("audits")
+        if len(parts) > idx + 2:
+            return f"audits/{parts[idx + 1]}/{parts[idx + 2]}"
+        if len(parts) > idx + 1:
+            return f"audits/{parts[idx + 1]}"
+        return "audits/misc"
+    if artifact_class == "codex_verdict":
+        return "codex-reviews"
+    if artifact_class == "summary":
+        return "notes/summaries"
+    if artifact_class == "handoff":
+        return "notes/handoffs"
+    raise ValueError(f"unknown artifact_class {artifact_class!r}")
+
+
+def discover() -> list[Artifact]:
+    found: list[Artifact] = []
+
+    codex_dir = KHIVE_DIR / "codex_reviews"
+    if codex_dir.is_dir():
+        for p in sorted(codex_dir.glob("codex_review_pr*.md")):
+            rel = p.relative_to(REPO_ROOT)
+            m = PR_NUM_RE.search(p.name)
+            pr_number = int(m.group(1)) if m else None
+            found.append(
+                Artifact(
+                    artifact_class="codex_verdict",
+                    path=p,
+                    rel_path=rel.as_posix(),
+                    lane=lane_for("codex_verdict", rel),
+                    pr_number=pr_number,
+                )
+            )
+
+    ws_root = KHIVE_DIR / "workspaces"
+    if ws_root.is_dir():
+        for p in sorted(ws_root.rglob("*.md")):
+            if not p.is_file():
+                continue
+            rel = p.relative_to(REPO_ROOT)
+            found.append(
+                Artifact(
+                    artifact_class="workspace_doc",
+                    path=p,
+                    rel_path=rel.as_posix(),
+                    lane=lane_for("workspace_doc", rel),
+                )
+            )
+
+    summaries_dir = KHIVE_DIR / "notes" / "summaries"
+    if summaries_dir.is_dir():
+        for p in sorted(summaries_dir.glob("*.md")):
+            if p.name == "_TEMPLATE.md":
+                continue
+            rel = p.relative_to(REPO_ROOT)
+            found.append(
+                Artifact(
+                    artifact_class="summary",
+                    path=p,
+                    rel_path=rel.as_posix(),
+                    lane=lane_for("summary", rel),
+                )
+            )
+
+    handoffs_dir = KHIVE_DIR / "notes" / "handoffs"
+    if handoffs_dir.is_dir():
+        for p in sorted(handoffs_dir.glob("*.md")):
+            rel = p.relative_to(REPO_ROOT)
+            found.append(
+                Artifact(
+                    artifact_class="handoff",
+                    path=p,
+                    rel_path=rel.as_posix(),
+                    lane=lane_for("handoff", rel),
+                )
+            )
+
+    audits_dir = KHIVE_DIR / "audits"
+    if audits_dir.is_dir():
+        for p in sorted(audits_dir.rglob("*.md")):
+            if not p.is_file():
+                continue
+            rel = p.relative_to(REPO_ROOT)
+            found.append(
+                Artifact(
+                    artifact_class="audit",
+                    path=p,
+                    rel_path=rel.as_posix(),
+                    lane=lane_for("audit", rel),
+                )
+            )
+
+    for a in found:
+        data = a.path.read_bytes()
+        a.size = len(data)
+        a.sha16 = sha256_16(data)
+
+    return found
+
+
+def load_cursor() -> set[tuple[str, str]]:
+    done: set[tuple[str, str]] = set()
+    if CURSOR_PATH.exists():
+        for line in CURSOR_PATH.read_text().splitlines():
+            line = line.strip()
+            if not line or "\t" not in line:
+                continue
+            path, sha = line.split("\t", 1)
+            done.add((path, sha))
+    return done
+
+
+def append_cursor(rel_path: str, sha16: str) -> None:
+    with CURSOR_PATH.open("a") as fh:
+        fh.write(f"{rel_path}\t{sha16}\n")
+
+
+class KKernel:
+    """Thin wrapper around `kkernel exec '<ops>'`."""
+
+    def __init__(self, live: bool):
+        self.live = live
+        self.read_calls = 0
+        self.write_calls = 0
+
+    def _run(self, ops: str) -> dict:
+        proc = subprocess.run(
+            [KKERNEL, "exec", ops],
+            capture_output=True,
+            text=True,
+            cwd=str(REPO_ROOT),
+            timeout=60,
+        )
+        if proc.returncode != 0:
+            raise RuntimeError(
+                f"kkernel exec failed (rc={proc.returncode}): {proc.stderr}\nops={ops}"
+            )
+        try:
+            return json.loads(proc.stdout)
+        except json.JSONDecodeError as e:
+            raise RuntimeError(f"kkernel exec returned non-JSON stdout: {proc.stdout[:500]}") from e
+
+    def read(self, ops: str) -> dict:
+        self.read_calls += 1
+        return self._run(ops)
+
+    def write(self, ops: str) -> dict:
+        """Only ever called when self.live is True — callers must gate on it."""
+        assert self.live, "write() called without --live"
+        self.write_calls += 1
+        return self._run(ops)
+
+
+def annotate_op(source_id: str, target_id: str) -> str:
+    src, tgt, rel = dsl_str(source_id), dsl_str(target_id), dsl_str("annotates")
+    return f"link(source_id={src}, target_id={tgt}, relation={rel})"
+
+
+def first_op_result(resp: dict) -> dict:
+    results = resp.get("results", [])
+    if not results:
+        raise RuntimeError(f"empty results in response: {resp}")
+    op = results[0]
+    if not op.get("ok"):
+        raise RuntimeError(f"op failed: {op}")
+    return op["result"]
+
+
+# The server clamps `list` limit to 200 and, only when the caller's requested
+# limit exceeded that clamp, wraps the array in
+# {items, effective_limit, limit_clamped, requested_limit} instead of
+# returning a bare array. Requesting <=200 always yields a bare array; we
+# still normalize defensively in case that changes.
+def list_items(result) -> list:
+    if isinstance(result, dict) and "items" in result:
+        return result["items"]
+    return result
+
+
+def load_existing_pull_requests(
+    kk: KKernel, page_limit: int = 200, max_pages: int = 50
+) -> dict[int, str]:
+    """number -> note id, for existing pull_request notes. Bounded pagination."""
+    by_number: dict[int, str] = {}
+    offset = 0
+    for _ in range(max_pages):
+        resp = kk.read(f"list(kind={dsl_str('pull_request')}, limit={page_limit}, offset={offset})")
+        rows = list_items(first_op_result(resp))
+        if not rows:
+            break
+        for row in rows:
+            props = row.get("properties") or {}
+            num = props.get("number")
+            if isinstance(num, int):
+                by_number[num] = row["id"]
+        if len(rows) < page_limit:
+            break
+        offset += page_limit
+    return by_number
+
+
+def load_existing_workspaces(
+    kk: KKernel, page_limit: int = 200, max_pages: int = 50
+) -> dict[str, str]:
+    """lane name -> workspace entity id."""
+    by_name: dict[str, str] = {}
+    offset = 0
+    for _ in range(max_pages):
+        resp = kk.read(f"list(kind={dsl_str('workspace')}, limit={page_limit}, offset={offset})")
+        rows = list_items(first_op_result(resp))
+        if not rows:
+            break
+        for row in rows:
+            name = row.get("name")
+            if name:
+                by_name[name] = row["id"]
+        if len(rows) < page_limit:
+            break
+        offset += page_limit
+    return by_name
+
+
+def load_existing_ws_ingest_notes(
+    kk: KKernel, note_kinds: list[str], page_limit: int = 200, max_pages: int = 500
+) -> set[tuple[str, str]]:
+    """(source_path, content_sha256_16) pairs already ingested by this script, across kinds."""
+    seen: set[tuple[str, str]] = set()
+    for kind in note_kinds:
+        offset = 0
+        for _ in range(max_pages):
+            resp = kk.read(f"list(kind={dsl_str(kind)}, limit={page_limit}, offset={offset})")
+            rows = list_items(first_op_result(resp))
+            if not rows:
+                break
+            for row in rows:
+                props = row.get("properties") or {}
+                tags = props.get("tags") or row.get("tags") or []
+                if INGEST_TAG not in tags:
+                    continue
+                sp = props.get("source_path")
+                sha = props.get("content_sha256_16")
+                if sp and sha:
+                    seen.add((sp, sha))
+            if len(rows) < page_limit:
+                break
+            offset += page_limit
+    return seen
+
+
+def build_note_content(artifact: Artifact) -> str:
+    raw = artifact.path.read_bytes()
+    text = raw.decode("utf-8", errors="replace")
+    if len(raw) > MAX_CONTENT_BYTES:
+        text = text.encode("utf-8", errors="replace")[:MAX_CONTENT_BYTES].decode(
+            "utf-8", errors="ignore"
+        )
+        text += TRUNCATION_MARKER.format(orig=len(raw))
+    return text
+
+
+def ensure_workspace(
+    kk: KKernel, lane: str, cache: dict[str, str], live: bool, stats: Stats
+) -> str | None:
+    if lane in cache:
+        return cache[lane]
+    stats.workspaces_to_create += 1
+    if not live:
+        return None
+    ws_props = json.dumps({"schema_version": 1, "lane": lane, "created_by": "ws-ingest"})
+    resp = kk.write(
+        f"create(kind={dsl_str('workspace')}, name={dsl_str(lane)}, "
+        f"properties={ws_props}, tags={json.dumps([INGEST_TAG])})"
+    )
+    ws_id = first_op_result(resp)["id"]
+    cache[lane] = ws_id
+    return ws_id
+
+
+@dataclass
+class Stats:
+    by_class: dict = field(default_factory=lambda: dict.fromkeys(NOTE_KIND, 0))
+    notes_created: int = 0
+    notes_skipped_existing: int = 0
+    notes_skipped_cursor: int = 0
+    workspaces_to_create: int = 0
+    edges_workspace_planned: int = 0
+    edges_pr_planned: int = 0
+    pr_link_hits: int = 0
+    pr_link_misses: int = 0
+    pr_link_na: int = 0
+    samples: list = field(default_factory=list)
+
+
+def process(dry_run: bool) -> tuple[Stats, list[Artifact]]:
+    live = not dry_run
+    kk = KKernel(live=live)
+    stats = Stats()
+
+    artifacts = discover()
+    for a in artifacts:
+        stats.by_class[a.artifact_class] += 1
+
+    cursor_done = load_cursor()
+
+    ws_cache = load_existing_workspaces(kk)
+    pr_by_number = load_existing_pull_requests(kk)
+    existing_notes = (
+        load_existing_ws_ingest_notes(kk, sorted(set(NOTE_KIND.values()))) if live else set()
+    )
+
+    lanes_needed = sorted({a.lane for a in artifacts})
+    for lane in lanes_needed:
+        if lane not in ws_cache:
+            stats.workspaces_to_create += 1
+
+    for a in artifacts:
+        key = (a.rel_path, a.sha16)
+
+        if a.artifact_class == "codex_verdict":
+            if a.pr_number is None:
+                stats.pr_link_na += 1
+            elif a.pr_number in pr_by_number:
+                stats.pr_link_hits += 1
+            else:
+                stats.pr_link_misses += 1
+
+        if key in cursor_done:
+            stats.notes_skipped_cursor += 1
+            continue
+        if live and key in existing_notes:
+            stats.notes_skipped_existing += 1
+            append_cursor(*key)
+            continue
+
+        note_kind = NOTE_KIND[a.artifact_class]
+        note_tags = [INGEST_TAG, a.artifact_class]
+        stats.edges_workspace_planned += 1
+        if a.artifact_class == "codex_verdict" and a.pr_number in pr_by_number:
+            stats.edges_pr_planned += 1
+
+        if len(stats.samples) < 10:
+            stats.samples.append(
+                {
+                    "source_path": a.rel_path,
+                    "artifact_class": a.artifact_class,
+                    "note_kind": note_kind,
+                    "lane": a.lane,
+                    "pr_number": a.pr_number,
+                    "pr_link": (
+                        "hit"
+                        if (a.pr_number is not None and a.pr_number in pr_by_number)
+                        else ("miss" if a.pr_number is not None else "n/a")
+                    ),
+                    "sha16": a.sha16,
+                    "size": a.size,
+                }
+            )
+
+        if not live:
+            stats.notes_created += 1  # "would create"
+            continue
+
+        ws_id = ensure_workspace(kk, a.lane, ws_cache, live, stats)
+
+        content = build_note_content(a)
+        properties = {
+            "source_path": a.rel_path,
+            "content_sha256_16": a.sha16,
+            "artifact_class": a.artifact_class,
+            "ingested_at": datetime.now(UTC).isoformat(),
+        }
+        if a.pr_number is not None:
+            properties["pr_number"] = a.pr_number
+
+        name = a.rel_path.rsplit("/", 1)[-1][:120]
+        props_json = json.dumps(properties)
+        resp = kk.write(
+            f"create(kind={dsl_str(note_kind)}, name={dsl_str(name)}, "
+            f"content={dsl_str(content)}, properties={props_json}, tags={json.dumps(note_tags)})"
+        )
+        note_id = first_op_result(resp)["id"]
+
+        if ws_id:
+            kk.write(annotate_op(note_id, ws_id))
+
+        if a.artifact_class == "codex_verdict" and a.pr_number in pr_by_number:
+            kk.write(annotate_op(note_id, pr_by_number[a.pr_number]))
+        elif a.artifact_class == "codex_verdict" and a.pr_number is not None:
+            print(
+                f"  [pr-link miss] {a.rel_path}: no pull_request note for #{a.pr_number}",
+                file=sys.stderr,
+            )
+
+        stats.notes_created += 1
+        append_cursor(*key)
+
+    return stats, artifacts
+
+
+def write_dryrun_report(stats: Stats, artifacts: list[Artifact], out_path: Path) -> None:
+    lines = []
+    lines.append("# Workspace-artifact ingest — DRY RUN")
+    lines.append("")
+    lines.append(f"Generated: {datetime.now(UTC).isoformat()}")
+    lines.append(f"Total files discovered: {len(artifacts)}")
+    lines.append("")
+    lines.append("## Counts by artifact_class")
+    lines.append("")
+    lines.append("| artifact_class | note_kind | file count |")
+    lines.append("|---|---|---|")
+    for k, v in stats.by_class.items():
+        lines.append(f"| {k} | {NOTE_KIND[k]} | {v} |")
+    lines.append("")
+    lines.append("## Planned writes")
+    lines.append("")
+    lines.append(f"- Workspace entities to create: {stats.workspaces_to_create}")
+    lines.append(f"- Notes to create: {stats.notes_created}")
+    lines.append(f"- Notes skipped (already in cursor): {stats.notes_skipped_cursor}")
+    lines.append(
+        f"- Notes skipped (found on server, cursor backfilled): {stats.notes_skipped_existing}"
+    )
+    lines.append(f"- annotates edges to workspace entity planned: {stats.edges_workspace_planned}")
+    lines.append(f"- annotates edges to pull_request note planned: {stats.edges_pr_planned}")
+    lines.append("")
+    lines.append("## PR-link hit/miss (codex_verdict files only)")
+    lines.append("")
+    lines.append(f"- hit (matching pull_request note found): {stats.pr_link_hits}")
+    lines.append(f"- miss (no pull_request note for that number): {stats.pr_link_misses}")
+    lines.append(f"- n/a (filename carried no parseable PR number): {stats.pr_link_na}")
+    lines.append("")
+    lines.append("## Sample mappings (first 10 planned)")
+    lines.append("")
+    lines.append(
+        "| source_path | artifact_class | note_kind | lane | pr_number | pr_link | sha16 | size |"
+    )
+    lines.append("|---|---|---|---|---|---|---|---|")
+    for s in stats.samples:
+        lines.append(
+            f"| {s['source_path']} | {s['artifact_class']} | {s['note_kind']} | {s['lane']} | "
+            f"{s['pr_number']} | {s['pr_link']} | {s['sha16']} | {s['size']} |"
+        )
+    lines.append("")
+    out_path.write_text("\n".join(lines) + "\n")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--live", action="store_true", help="Perform real khive writes (default: dry-run)"
+    )
+    parser.add_argument(
+        "--report",
+        type=Path,
+        default=None,
+        help="Path to write the dry-run markdown report (dry-run mode only)",
+    )
+    args = parser.parse_args()
+
+    dry_run = not args.live
+    stats, artifacts = process(dry_run=dry_run)
+
+    if dry_run:
+        report_path = args.report or (
+            KHIVE_DIR / "workspaces" / "20260716" / "ws-artifact-ingest" / "DRYRUN.md"
+        )
+        report_path.parent.mkdir(parents=True, exist_ok=True)
+        write_dryrun_report(stats, artifacts, report_path)
+        print(f"DRY RUN complete. Report: {report_path}")
+    else:
+        print(
+            f"LIVE run complete. notes_created={stats.notes_created} "
+            f"skipped_cursor={stats.notes_skipped_cursor} "
+            f"skipped_existing={stats.notes_skipped_existing}"
+        )
+
+    print(json.dumps(stats.by_class, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.khive/scripts/ingest_workspace_artifacts.py
+++ b/.khive/scripts/ingest_workspace_artifacts.py
@@ -33,8 +33,9 @@ Design notes:
   covers a note left incomplete by a pre-fix run, or by a create-time link
   failure whose runtime-side compensation was itself best-effort and did not
   run to completion (crates/khive-runtime/src/operations.rs).
-- Content is truncated at 32,768 characters (of the FINAL replacement-decoded
-  text, marker space reserved — the daemon embedder's char-count limit) with
+- Content is truncated at 32,768 bytes (of the FINAL UTF-8-encoded,
+  replacement-decoded payload, marker space reserved — the daemon embedder's
+  actual limit, which is byte-counted despite its "chars" error wording) with
   a trailing marker; the sha256 is always computed over the ORIGINAL
   (untruncated) bytes so the dedup key is stable.
 - Note + its `annotates` edges (workspace lane, and PR for codex verdicts)
@@ -86,11 +87,14 @@ CURSOR_PATH = SCRIPT_DIR / ".ws_ingest_cursor"
 LOCK_PATH = Path("/tmp/lion-khive-wsingest.lock")
 KKERNEL = os.path.expanduser("~/.cargo/bin/kkernel")
 
-# The daemon's embedder rejects create() content over 32,768 CHARS (observed
-# live 2026-07-16: "embedding: text too long: 36556 chars exceeds maximum
-# 32768 chars"), so the cap counts characters, not bytes — a byte cap lets
-# ASCII-heavy docs through with more chars than the embedder accepts.
-MAX_CONTENT_CHARS = 32_768
+# The daemon's embedder rejects create() content whose UTF-8 BYTE length
+# exceeds 32,768: lattice-embed 0.6.1 (service/cached.rs, native.rs) checks
+# `text.len()` — Rust String BYTES — even though its error message says
+# "chars". Observed live 2026-07-16: a 36,556-byte ASCII doc was rejected,
+# and a char-capped 32,768-char doc still failed at 32,846 (bytes, from
+# multibyte expansion). The cap therefore applies to the final encoded
+# byte length, at the embedder's actual limit.
+MAX_CONTENT_BYTES = 32_768
 TRUNCATION_MARKER = "\n\n...[truncated by ws-ingest, original length {orig} bytes]...\n"
 
 INGEST_TAG = "ws-ingest"
@@ -494,18 +498,18 @@ def reconcile_existing_note(
 
 
 def cap_content(raw: bytes) -> str:
-    """Decode `raw` (replacing invalid UTF-8) and cap the FINAL decoded text
-    at MAX_CONTENT_CHARS, marker space reserved. The cap counts CHARACTERS
-    after replacement decoding (matching the daemon embedder's char-count
-    check), not raw bytes: `errors="replace"` can change the char count
-    (invalid byte -> one U+FFFD), and byte length overstates ASCII char
-    budgets while understating multibyte ones."""
+    """Decode `raw` (replacing invalid UTF-8) and cap the FINAL encoded
+    payload at MAX_CONTENT_BYTES, marker space reserved. Capping on the
+    original raw byte length is not sufficient: `errors="replace"` can
+    expand invalid bytes (each -> U+FFFD, 3 bytes), so the cap must apply
+    after replacement decoding, not before."""
     text = raw.decode("utf-8", errors="replace")
-    if len(text) <= MAX_CONTENT_CHARS:
+    encoded = text.encode("utf-8")
+    if len(encoded) <= MAX_CONTENT_BYTES:
         return text
     marker = TRUNCATION_MARKER.format(orig=len(raw))
-    budget = max(MAX_CONTENT_CHARS - len(marker), 0)
-    return text[:budget] + marker
+    budget = max(MAX_CONTENT_BYTES - len(marker.encode("utf-8")), 0)
+    return encoded[:budget].decode("utf-8", errors="ignore") + marker
 
 
 def build_note_content(artifact: Artifact) -> str:

--- a/.khive/scripts/ingest_workspace_artifacts.py
+++ b/.khive/scripts/ingest_workspace_artifacts.py
@@ -481,10 +481,11 @@ def reconcile_existing_note(
         return
     existing_targets = fetch_outgoing_annotate_targets(kk, note_id)
     for target_id in missing_annotate_targets(required, existing_targets):
-        kk.write(
+        resp = kk.write(
             f"link(source_id={dsl_str(note_id)}, target_id={dsl_str(target_id)}, "
             f'relation="annotates")'
         )
+        first_op_result(resp)
         stats.edges_backfilled += 1
 
 

--- a/.khive/scripts/ingest_workspace_artifacts.py
+++ b/.khive/scripts/ingest_workspace_artifacts.py
@@ -33,10 +33,10 @@ Design notes:
   covers a note left incomplete by a pre-fix run, or by a create-time link
   failure whose runtime-side compensation was itself best-effort and did not
   run to completion (crates/khive-runtime/src/operations.rs).
-- Content is truncated at ~48KB (of the FINAL UTF-8-encoded, replacement-
-  decoded payload, marker space reserved) with a trailing marker; the sha256
-  is always computed over the ORIGINAL (untruncated) bytes so the dedup key
-  is stable.
+- Content is truncated at 32,768 characters (of the FINAL replacement-decoded
+  text, marker space reserved — the daemon embedder's char-count limit) with
+  a trailing marker; the sha256 is always computed over the ORIGINAL
+  (untruncated) bytes so the dedup key is stable.
 - Note + its `annotates` edges (workspace lane, and PR for codex verdicts)
   are created in ONE `create(..., annotates=[...])` call. The runtime
   validates every annotate target before any write and compensates (deletes
@@ -86,7 +86,11 @@ CURSOR_PATH = SCRIPT_DIR / ".ws_ingest_cursor"
 LOCK_PATH = Path("/tmp/lion-khive-wsingest.lock")
 KKERNEL = os.path.expanduser("~/.cargo/bin/kkernel")
 
-MAX_CONTENT_BYTES = 48 * 1024
+# The daemon's embedder rejects create() content over 32,768 CHARS (observed
+# live 2026-07-16: "embedding: text too long: 36556 chars exceeds maximum
+# 32768 chars"), so the cap counts characters, not bytes — a byte cap lets
+# ASCII-heavy docs through with more chars than the embedder accepts.
+MAX_CONTENT_CHARS = 32_768
 TRUNCATION_MARKER = "\n\n...[truncated by ws-ingest, original length {orig} bytes]...\n"
 
 INGEST_TAG = "ws-ingest"
@@ -490,18 +494,18 @@ def reconcile_existing_note(
 
 
 def cap_content(raw: bytes) -> str:
-    """Decode `raw` (replacing invalid UTF-8) and cap the FINAL encoded
-    payload at MAX_CONTENT_BYTES, marker space reserved. Capping on the
-    original raw byte length is not sufficient: `errors="replace"` can
-    expand invalid bytes (each -> U+FFFD, 3 bytes), so the cap must apply
-    after replacement decoding, not before."""
+    """Decode `raw` (replacing invalid UTF-8) and cap the FINAL decoded text
+    at MAX_CONTENT_CHARS, marker space reserved. The cap counts CHARACTERS
+    after replacement decoding (matching the daemon embedder's char-count
+    check), not raw bytes: `errors="replace"` can change the char count
+    (invalid byte -> one U+FFFD), and byte length overstates ASCII char
+    budgets while understating multibyte ones."""
     text = raw.decode("utf-8", errors="replace")
-    encoded = text.encode("utf-8")
-    if len(encoded) <= MAX_CONTENT_BYTES:
+    if len(text) <= MAX_CONTENT_CHARS:
         return text
     marker = TRUNCATION_MARKER.format(orig=len(raw))
-    budget = max(MAX_CONTENT_BYTES - len(marker.encode("utf-8")), 0)
-    return encoded[:budget].decode("utf-8", errors="ignore") + marker
+    budget = max(MAX_CONTENT_CHARS - len(marker), 0)
+    return text[:budget] + marker
 
 
 def build_note_content(artifact: Artifact) -> str:

--- a/.khive/scripts/ingest_workspace_artifacts.py
+++ b/.khive/scripts/ingest_workspace_artifacts.py
@@ -561,7 +561,7 @@ def _acquire_live_lock() -> "object":
     return fd
 
 
-def process(dry_run: bool) -> tuple[Stats, list[Artifact]]:
+def process(dry_run: bool, only_classes: set[str] | None = None) -> tuple[Stats, list[Artifact]]:
     live = not dry_run
     kk = KKernel(live=live)
     stats = Stats()
@@ -569,6 +569,8 @@ def process(dry_run: bool) -> tuple[Stats, list[Artifact]]:
 
     try:
         artifacts = discover()
+        if only_classes:
+            artifacts = [a for a in artifacts if a.artifact_class in only_classes]
         for a in artifacts:
             stats.by_class[a.artifact_class] += 1
 
@@ -750,10 +752,19 @@ def main() -> int:
         default=None,
         help="Path to write the dry-run markdown report (dry-run mode only)",
     )
+    parser.add_argument(
+        "--only-class",
+        action="append",
+        choices=sorted(NOTE_KIND.keys()),
+        default=None,
+        help="Restrict this run to the given artifact class(es) — the tranche knob "
+        "(repeatable). Cursor idempotency makes later full runs skip these.",
+    )
     args = parser.parse_args()
 
     dry_run = not args.live
-    stats, artifacts = process(dry_run=dry_run)
+    only_classes = set(args.only_class) if args.only_class else None
+    stats, artifacts = process(dry_run=dry_run, only_classes=only_classes)
 
     if dry_run:
         report_path = args.report or (

--- a/.khive/scripts/test_ingest_workspace_artifacts.py
+++ b/.khive/scripts/test_ingest_workspace_artifacts.py
@@ -1,0 +1,190 @@
+#!/usr/bin/env python3
+"""Regression tests for ingest_workspace_artifacts.py — pure functions only,
+no DB / kkernel round-trip. Covers PR #1049 fix-round-1 findings:
+
+  M1 - DSL $prev-literal escaping (dsl_escape)
+  M2 - CRLF round-trip (dsl_escape)
+  M3 - 48KiB cap on the FINAL encoded payload, incl. invalid-UTF-8 expansion
+       and a multibyte char split at the boundary (cap_content)
+  H3 - PR annotation scoped to this checkout's project entity, never a
+       number-only cross-repository fallback (select_exact_project,
+       filter_pr_by_number)
+
+Run: python3 .khive/scripts/test_ingest_workspace_artifacts.py
+"""
+
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from ingest_workspace_artifacts import (  # noqa: E402
+    MAX_CONTENT_BYTES,
+    cap_content,
+    dsl_escape,
+    filter_pr_by_number,
+    select_exact_project,
+)
+
+
+class DslEscapePrevRefTests(unittest.TestCase):
+    def test_bare_dollar_prev_escaped(self):
+        self.assertEqual(dsl_escape("$prev"), '\\\\$prev')
+
+    def test_dollar_prev_dot_id_escaped(self):
+        self.assertEqual(dsl_escape("$prev.id"), '\\\\$prev.id')
+
+    def test_dollar_prev_bracket_index_escaped(self):
+        self.assertEqual(dsl_escape("$prev[0].id"), '\\\\$prev[0].id')
+
+    def test_dollar_prev_as_prefix_of_longer_content_still_escaped(self):
+        # string_as_prev_ref matches on a $prev.<path> prefix of the WHOLE
+        # value; over-escaping here is safe (round-trips to the same literal).
+        s = "$prev.anything not a real path but still starts with the prefix"
+        self.assertTrue(dsl_escape(s).startswith('\\\\$prev.'))
+
+    def test_prev_not_at_start_is_not_escaped(self):
+        s = "see $prev.id in the log"
+        self.assertEqual(dsl_escape(s), s)
+
+    def test_dollar_alone_not_escaped(self):
+        self.assertEqual(dsl_escape("$5.00 total"), "$5.00 total")
+
+    def test_round_trip_via_json_decode(self):
+        # Simulates what khive-request actually does: JSON-decode the
+        # dsl_str() literal, then re-check the decoded value against the
+        # parser's own escape rule (strip one leading backslash iff what
+        # follows is a $prev chain prefix).
+        import json
+
+        for original in ("$prev", "$prev.id", "$prev[0].nested", "$prev.a.b.c"):
+            literal = f'"{dsl_escape(original)}"'
+            decoded = json.loads(literal)
+            self.assertTrue(decoded.startswith("\\"))
+            rest = decoded[1:]
+            self.assertTrue(
+                rest == "$prev" or rest.startswith("$prev.") or rest.startswith("$prev[")
+            )
+            self.assertEqual(rest, original)
+
+
+class DslEscapeCrlfTests(unittest.TestCase):
+    def test_crlf_preserved_as_escape(self):
+        self.assertEqual(dsl_escape("a\r\nb"), "a\\r\\nb")
+
+    def test_lone_cr_preserved(self):
+        self.assertEqual(dsl_escape("a\rb"), "a\\rb")
+
+    def test_crlf_round_trip_via_json_decode(self):
+        import json
+
+        original = "line1\r\nline2\rline3\n"
+        literal = f'"{dsl_escape(original)}"'
+        decoded = json.loads(literal)
+        self.assertEqual(decoded, original)
+
+
+class CapContentTests(unittest.TestCase):
+    def test_under_cap_not_truncated(self):
+        raw = ("a" * (MAX_CONTENT_BYTES - 1)).encode("utf-8")
+        text = cap_content(raw)
+        self.assertEqual(len(text.encode("utf-8")), len(raw))
+        self.assertNotIn("truncated", text)
+
+    def test_exactly_at_cap_not_truncated(self):
+        raw = ("a" * MAX_CONTENT_BYTES).encode("utf-8")
+        text = cap_content(raw)
+        self.assertEqual(len(text.encode("utf-8")), MAX_CONTENT_BYTES)
+        self.assertNotIn("truncated", text)
+
+    def test_over_cap_valid_utf8_is_truncated_and_capped(self):
+        raw = ("a" * (MAX_CONTENT_BYTES + 10)).encode("utf-8")
+        text = cap_content(raw)
+        self.assertLessEqual(len(text.encode("utf-8")), MAX_CONTENT_BYTES)
+        self.assertIn("truncated", text)
+
+    def test_invalid_utf8_at_exactly_cap_length_is_still_capped(self):
+        # H3/M3 regression: MAX_CONTENT_BYTES of 0xFF is invalid UTF-8; the
+        # OLD code compared len(raw) > MAX_CONTENT_BYTES BEFORE replacement
+        # decoding, so an exactly-at-cap invalid file skipped truncation
+        # entirely and ballooned to 3x size (each byte -> U+FFFD, 3 bytes).
+        raw = b"\xff" * MAX_CONTENT_BYTES
+        text = cap_content(raw)
+        encoded_len = len(text.encode("utf-8"))
+        self.assertLessEqual(
+            encoded_len,
+            MAX_CONTENT_BYTES,
+            f"final encoded payload {encoded_len} bytes exceeds the {MAX_CONTENT_BYTES} cap",
+        )
+
+    def test_invalid_utf8_well_over_cap_is_capped(self):
+        raw = b"\xff" * (MAX_CONTENT_BYTES + 1024)
+        text = cap_content(raw)
+        self.assertLessEqual(len(text.encode("utf-8")), MAX_CONTENT_BYTES)
+
+    def test_multibyte_char_split_at_boundary_stays_valid_utf8(self):
+        # A 3-byte char (€) straddling the truncation boundary must not
+        # produce a malformed/half UTF-8 sequence in the output.
+        head = "a" * (MAX_CONTENT_BYTES - 1)
+        raw = (head + "€" + "tail-sentinel").encode("utf-8")
+        text = cap_content(raw)
+        encoded = text.encode("utf-8")
+        self.assertLessEqual(len(encoded), MAX_CONTENT_BYTES)
+        # round-trips cleanly (no stray surrogate / partial sequence)
+        encoded.decode("utf-8")
+        self.assertNotIn("tail-sentinel", text)
+
+    def test_sha_key_computed_over_original_bytes_not_capped_text(self):
+        # Sanity: cap_content itself does not touch hashing; verify the
+        # truncation marker records the ORIGINAL raw length.
+        raw = ("a" * (MAX_CONTENT_BYTES + 500)).encode("utf-8")
+        text = cap_content(raw)
+        self.assertIn(str(len(raw)), text)
+
+
+class ProjectScopingTests(unittest.TestCase):
+    def test_select_exact_project_single_match(self):
+        rows = [{"id": "p1", "name": "khive-oss"}, {"id": "p2", "name": "lattice"}]
+        self.assertEqual(select_exact_project(rows, "khive-oss"), "p1")
+
+    def test_select_exact_project_no_match_returns_none(self):
+        rows = [{"id": "p2", "name": "lattice"}]
+        self.assertIsNone(select_exact_project(rows, "khive-oss"))
+
+    def test_select_exact_project_ambiguous_returns_none(self):
+        rows = [{"id": "p1", "name": "khive-oss"}, {"id": "p1b", "name": "khive-oss"}]
+        self.assertIsNone(select_exact_project(rows, "khive-oss"))
+
+    def test_filter_pr_by_number_scopes_to_project(self):
+        rows = [
+            {"id": "n1", "properties": {"number": 1049, "project_id": "khive-oss-id"}},
+            {"id": "n2", "properties": {"number": 1049, "project_id": "lattice-id"}},
+        ]
+        by_number = filter_pr_by_number(rows, "khive-oss-id")
+        self.assertEqual(by_number, {1049: "n1"})
+
+    def test_filter_pr_by_number_cross_repo_collision_not_used(self):
+        # Regression for H3: same PR number in two different repos must
+        # never resolve to the wrong project's note.
+        rows = [
+            {"id": "khive-pr", "properties": {"number": 1041, "project_id": "khive-oss-id"}},
+            {"id": "lionagi-pr", "properties": {"number": 1041, "project_id": "lionagi-id"}},
+            {"id": "lattice-pr", "properties": {"number": 1041, "project_id": "lattice-id"}},
+        ]
+        by_number = filter_pr_by_number(rows, "lattice-id")
+        self.assertEqual(by_number, {1041: "lattice-pr"})
+
+    def test_filter_pr_by_number_unresolved_project_yields_no_matches(self):
+        rows = [{"id": "n1", "properties": {"number": 1049, "project_id": "khive-oss-id"}}]
+        self.assertEqual(filter_pr_by_number(rows, None), {})
+
+    def test_filter_pr_by_number_ignores_rows_missing_project_id(self):
+        rows = [{"id": "n1", "properties": {"number": 1049}}]
+        self.assertEqual(filter_pr_by_number(rows, "khive-oss-id"), {})
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/.khive/scripts/test_ingest_workspace_artifacts.py
+++ b/.khive/scripts/test_ingest_workspace_artifacts.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 """Regression tests for ingest_workspace_artifacts.py — pure functions only,
-no DB / kkernel round-trip. Covers PR #1049 fix-round-1 findings:
+no DB / kkernel round-trip, except the fake-KKernel reconciliation tests at
+the bottom (no subprocess either). Covers PR #1049 fix-round-1 findings:
 
   M1 - DSL $prev-literal escaping (dsl_escape)
   M2 - CRLF round-trip (dsl_escape)
@@ -10,11 +11,19 @@ no DB / kkernel round-trip. Covers PR #1049 fix-round-1 findings:
        number-only cross-repository fallback (select_exact_project,
        filter_pr_by_number)
 
+...and PR #1049 fix-round-2 findings:
+
+  H1 - resume reconciliation: a note matching an artifact's key must have
+       its required `annotates` edges verified/backfilled, not accepted as
+       complete on sight (compute_annotate_targets, missing_annotate_targets,
+       reconcile_existing_note)
+
 Run: python3 .khive/scripts/test_ingest_workspace_artifacts.py
 """
 
 from __future__ import annotations
 
+import re
 import sys
 import unittest
 from pathlib import Path
@@ -23,9 +32,14 @@ sys.path.insert(0, str(Path(__file__).resolve().parent))
 
 from ingest_workspace_artifacts import (  # noqa: E402
     MAX_CONTENT_BYTES,
+    Artifact,
+    Stats,
     cap_content,
+    compute_annotate_targets,
     dsl_escape,
     filter_pr_by_number,
+    missing_annotate_targets,
+    reconcile_existing_note,
     select_exact_project,
 )
 
@@ -184,6 +198,135 @@ class ProjectScopingTests(unittest.TestCase):
     def test_filter_pr_by_number_ignores_rows_missing_project_id(self):
         rows = [{"id": "n1", "properties": {"number": 1049}}]
         self.assertEqual(filter_pr_by_number(rows, "khive-oss-id"), {})
+
+
+class ComputeAnnotateTargetsTests(unittest.TestCase):
+    def test_workspace_doc_requires_only_workspace(self):
+        a = Artifact(artifact_class="workspace_doc", path=Path("/x"), rel_path="x", lane="lane-a")
+        self.assertEqual(compute_annotate_targets(a, "ws-1", {}), ["ws-1"])
+
+    def test_codex_verdict_with_pr_hit_requires_both(self):
+        a = Artifact(
+            artifact_class="codex_verdict",
+            path=Path("/x"),
+            rel_path="x",
+            lane="codex-reviews",
+            pr_number=1049,
+        )
+        self.assertEqual(compute_annotate_targets(a, "ws-1", {1049: "pr-1"}), ["ws-1", "pr-1"])
+
+    def test_codex_verdict_with_pr_miss_requires_only_workspace(self):
+        a = Artifact(
+            artifact_class="codex_verdict",
+            path=Path("/x"),
+            rel_path="x",
+            lane="codex-reviews",
+            pr_number=1049,
+        )
+        self.assertEqual(compute_annotate_targets(a, "ws-1", {}), ["ws-1"])
+
+    def test_no_workspace_id_yields_no_targets(self):
+        a = Artifact(artifact_class="workspace_doc", path=Path("/x"), rel_path="x", lane="lane-a")
+        self.assertEqual(compute_annotate_targets(a, None, {}), [])
+
+
+class MissingAnnotateTargetsTests(unittest.TestCase):
+    def test_missing_workspace_edge(self):
+        self.assertEqual(missing_annotate_targets(["ws-1", "pr-1"], {"pr-1"}), ["ws-1"])
+
+    def test_missing_pr_edge(self):
+        self.assertEqual(missing_annotate_targets(["ws-1", "pr-1"], {"ws-1"}), ["pr-1"])
+
+    def test_nothing_missing(self):
+        self.assertEqual(missing_annotate_targets(["ws-1", "pr-1"], {"ws-1", "pr-1"}), [])
+
+    def test_all_missing(self):
+        self.assertEqual(missing_annotate_targets(["ws-1", "pr-1"], set()), ["ws-1", "pr-1"])
+
+
+class FakeKKernel:
+    """Minimal ops-string-driven stand-in for KKernel — no subprocess. Answers
+    `neighbors` reads from a fixed set of existing target ids and records
+    every `link` write it's asked to perform."""
+
+    def __init__(self, existing_annotate_targets: set[str]):
+        self.live = True
+        self._existing = existing_annotate_targets
+        self.link_calls: list[tuple[str, str]] = []
+
+    def read(self, ops: str) -> dict:
+        assert ops.startswith("neighbors("), f"unexpected read ops: {ops}"
+        hits = [{"id": t} for t in self._existing]
+        return {"results": [{"ok": True, "result": hits}]}
+
+    def write(self, ops: str) -> dict:
+        assert ops.startswith("link("), f"unexpected write ops: {ops}"
+        m = re.search(r'source_id="([^"]*)".*target_id="([^"]*)"', ops)
+        assert m, f"could not parse link() ops: {ops}"
+        self.link_calls.append((m.group(1), m.group(2)))
+        return {"results": [{"ok": True, "result": {"ok": True}}]}
+
+
+class ReconcileExistingNoteTests(unittest.TestCase):
+    """H1 fix-round-2 regressions: a note matching an artifact's key is
+    reconciled — missing required `annotates` edges are backfilled — instead
+    of being accepted as complete on sight."""
+
+    def test_backfills_missing_workspace_edge(self):
+        a = Artifact(artifact_class="workspace_doc", path=Path("/x"), rel_path="x", lane="lane-a")
+        kk = FakeKKernel(existing_annotate_targets=set())
+        ws_cache = {"lane-a": "ws-1"}
+        stats = Stats()
+        reconcile_existing_note(kk, a, "note-1", ws_cache, {}, stats)
+        self.assertEqual(kk.link_calls, [("note-1", "ws-1")])
+        self.assertEqual(stats.edges_backfilled, 1)
+
+    def test_backfills_missing_pr_edge_when_workspace_edge_already_present(self):
+        a = Artifact(
+            artifact_class="codex_verdict",
+            path=Path("/x"),
+            rel_path="x",
+            lane="codex-reviews",
+            pr_number=1049,
+        )
+        kk = FakeKKernel(existing_annotate_targets={"ws-1"})
+        ws_cache = {"codex-reviews": "ws-1"}
+        stats = Stats()
+        reconcile_existing_note(kk, a, "note-1", ws_cache, {1049: "pr-1"}, stats)
+        self.assertEqual(kk.link_calls, [("note-1", "pr-1")])
+        self.assertEqual(stats.edges_backfilled, 1)
+
+    def test_no_backfill_when_all_required_edges_present(self):
+        a = Artifact(
+            artifact_class="codex_verdict",
+            path=Path("/x"),
+            rel_path="x",
+            lane="codex-reviews",
+            pr_number=1049,
+        )
+        kk = FakeKKernel(existing_annotate_targets={"ws-1", "pr-1"})
+        ws_cache = {"codex-reviews": "ws-1"}
+        stats = Stats()
+        reconcile_existing_note(kk, a, "note-1", ws_cache, {1049: "pr-1"}, stats)
+        self.assertEqual(kk.link_calls, [])
+        self.assertEqual(stats.edges_backfilled, 0)
+
+    def test_pr_miss_does_not_require_pr_edge(self):
+        # No project-scoped pull_request match this run -> only the
+        # workspace edge is required, even if it's a codex_verdict.
+        a = Artifact(
+            artifact_class="codex_verdict",
+            path=Path("/x"),
+            rel_path="x",
+            lane="codex-reviews",
+            pr_number=1049,
+        )
+        kk = FakeKKernel(existing_annotate_targets={"ws-1"})
+        ws_cache = {"codex-reviews": "ws-1"}
+        stats = Stats()
+        reconcile_existing_note(kk, a, "note-1", ws_cache, {}, stats)
+        self.assertEqual(kk.link_calls, [])
+        self.assertEqual(stats.edges_backfilled, 0)
 
 
 if __name__ == "__main__":

--- a/.khive/scripts/test_ingest_workspace_artifacts.py
+++ b/.khive/scripts/test_ingest_workspace_artifacts.py
@@ -311,6 +311,22 @@ class ReconcileExistingNoteTests(unittest.TestCase):
         self.assertEqual(kk.link_calls, [])
         self.assertEqual(stats.edges_backfilled, 0)
 
+    def test_failed_backfill_link_raises(self):
+        # Round-3 regression: a rejected link write must raise (so the caller
+        # never appends the cursor), not silently count as backfilled.
+        class RejectingKKernel(FakeKKernel):
+            def write(self, ops: str) -> dict:
+                assert ops.startswith("link("), f"unexpected write ops: {ops}"
+                return {"results": [{"ok": False, "error": "validation failed"}]}
+
+        a = Artifact(artifact_class="workspace_doc", path=Path("/x"), rel_path="x", lane="lane-a")
+        kk = RejectingKKernel(existing_annotate_targets=set())
+        ws_cache = {"lane-a": "ws-1"}
+        stats = Stats()
+        with self.assertRaises(RuntimeError):
+            reconcile_existing_note(kk, a, "note-1", ws_cache, {}, stats)
+        self.assertEqual(stats.edges_backfilled, 0)
+
     def test_pr_miss_does_not_require_pr_edge(self):
         # No project-scoped pull_request match this run -> only the
         # workspace edge is required, even if it's a codex_verdict.

--- a/.khive/scripts/test_ingest_workspace_artifacts.py
+++ b/.khive/scripts/test_ingest_workspace_artifacts.py
@@ -5,9 +5,10 @@ the bottom (no subprocess either). Covers PR #1049 fix-round-1 findings:
 
   M1 - DSL $prev-literal escaping (dsl_escape)
   M2 - CRLF round-trip (dsl_escape)
-  M3 - content cap on the FINAL replacement-decoded text (now 32,768 CHARS,
-       matching the daemon embedder's char-count limit), incl. invalid-UTF-8
-       expansion and multibyte counting (cap_content)
+  M3 - 32,768-byte cap on the FINAL encoded payload (the daemon embedder's
+       actual limit — byte-counted despite its "chars" error wording), incl.
+       invalid-UTF-8 expansion and a multibyte char split at the boundary
+       (cap_content)
   H3 - PR annotation scoped to this checkout's project entity, never a
        number-only cross-repository fallback (select_exact_project,
        filter_pr_by_number)
@@ -32,7 +33,7 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 
 from ingest_workspace_artifacts import (  # noqa: E402
-    MAX_CONTENT_CHARS,
+    MAX_CONTENT_BYTES,
     Artifact,
     Stats,
     cap_content,
@@ -104,68 +105,78 @@ class DslEscapeCrlfTests(unittest.TestCase):
 
 class CapContentTests(unittest.TestCase):
     def test_under_cap_not_truncated(self):
-        raw = ("a" * (MAX_CONTENT_CHARS - 1)).encode("utf-8")
+        raw = ("a" * (MAX_CONTENT_BYTES - 1)).encode("utf-8")
         text = cap_content(raw)
-        self.assertEqual(len(text), MAX_CONTENT_CHARS - 1)
+        self.assertEqual(len(text.encode("utf-8")), len(raw))
         self.assertNotIn("truncated", text)
 
     def test_exactly_at_cap_not_truncated(self):
-        raw = ("a" * MAX_CONTENT_CHARS).encode("utf-8")
+        raw = ("a" * MAX_CONTENT_BYTES).encode("utf-8")
         text = cap_content(raw)
-        self.assertEqual(len(text), MAX_CONTENT_CHARS)
+        self.assertEqual(len(text.encode("utf-8")), MAX_CONTENT_BYTES)
         self.assertNotIn("truncated", text)
 
     def test_over_cap_valid_utf8_is_truncated_and_capped(self):
-        raw = ("a" * (MAX_CONTENT_CHARS + 10)).encode("utf-8")
+        raw = ("a" * (MAX_CONTENT_BYTES + 10)).encode("utf-8")
         text = cap_content(raw)
-        self.assertLessEqual(len(text), MAX_CONTENT_CHARS)
+        self.assertLessEqual(len(text.encode("utf-8")), MAX_CONTENT_BYTES)
         self.assertIn("truncated", text)
 
-    def test_live_repro_ascii_char_count_is_capped(self):
-        # Live tranche-2 abort 2026-07-16: a 36,556-char ASCII doc passed the
-        # OLD 48KiB byte cap untouched, then the daemon embedder rejected the
-        # whole create ("text too long: 36556 chars exceeds maximum 32768
-        # chars"). The cap must count chars, matching the daemon check.
+    def test_live_repro_ascii_doc_over_embed_limit_is_capped(self):
+        # Live tranche-2 abort 2026-07-16: a 36,556-byte ASCII doc passed the
+        # OLD 48KiB cap untouched, then the daemon embedder rejected the whole
+        # create ("text too long: 36556 chars exceeds maximum 32768 chars" —
+        # byte-counted despite the wording). The cap must sit at the
+        # embedder's actual limit.
         raw = ("a" * 36_556).encode("utf-8")
         text = cap_content(raw)
-        self.assertLessEqual(len(text), MAX_CONTENT_CHARS)
+        self.assertLessEqual(len(text.encode("utf-8")), MAX_CONTENT_BYTES)
         self.assertIn("truncated", text)
 
-    def test_invalid_utf8_at_exactly_cap_length_is_still_within_cap(self):
-        # H3/M3 regression lineage: the cap must apply AFTER replacement
-        # decoding. Each invalid byte decodes to one U+FFFD char, so
-        # MAX_CONTENT_CHARS invalid bytes land exactly at the char cap.
-        raw = b"\xff" * MAX_CONTENT_CHARS
+    def test_live_repro_multibyte_expansion_is_capped_in_bytes(self):
+        # Second live abort same day: a 32,768-CHAR cap still failed at
+        # 32,846 (bytes) once multibyte chars expanded. The cap must bound
+        # the ENCODED byte length, not the char count.
+        raw = ("€" * 26 + "a" * 32_742).encode("utf-8")  # 32,768 chars, 32,820 bytes
         text = cap_content(raw)
-        self.assertLessEqual(len(text), MAX_CONTENT_CHARS)
+        self.assertLessEqual(len(text.encode("utf-8")), MAX_CONTENT_BYTES)
+        self.assertIn("truncated", text)
+
+    def test_invalid_utf8_at_exactly_cap_length_is_still_capped(self):
+        # H3/M3 regression: MAX_CONTENT_BYTES of 0xFF is invalid UTF-8; the
+        # OLD code compared len(raw) > MAX_CONTENT_BYTES BEFORE replacement
+        # decoding, so an exactly-at-cap invalid file skipped truncation
+        # entirely and ballooned to 3x size (each byte -> U+FFFD, 3 bytes).
+        raw = b"\xff" * MAX_CONTENT_BYTES
+        text = cap_content(raw)
+        encoded_len = len(text.encode("utf-8"))
+        self.assertLessEqual(
+            encoded_len,
+            MAX_CONTENT_BYTES,
+            f"final encoded payload {encoded_len} bytes exceeds the {MAX_CONTENT_BYTES} cap",
+        )
 
     def test_invalid_utf8_well_over_cap_is_capped(self):
-        raw = b"\xff" * (MAX_CONTENT_CHARS + 1024)
+        raw = b"\xff" * (MAX_CONTENT_BYTES + 1024)
         text = cap_content(raw)
-        self.assertLessEqual(len(text), MAX_CONTENT_CHARS)
+        self.assertLessEqual(len(text.encode("utf-8")), MAX_CONTENT_BYTES)
 
-    def test_multibyte_chars_counted_as_chars_not_bytes(self):
-        # 3-bytes-per-char content: a byte cap would truncate this at a third
-        # of the budget; the char cap must keep all MAX_CONTENT_CHARS chars.
-        raw = ("€" * MAX_CONTENT_CHARS).encode("utf-8")
+    def test_multibyte_char_split_at_boundary_stays_valid_utf8(self):
+        # A 3-byte char (€) straddling the truncation boundary must not
+        # produce a malformed/half UTF-8 sequence in the output.
+        head = "a" * (MAX_CONTENT_BYTES - 1)
+        raw = (head + "€" + "tail-sentinel").encode("utf-8")
         text = cap_content(raw)
-        self.assertEqual(len(text), MAX_CONTENT_CHARS)
-        self.assertNotIn("truncated", text)
-
-    def test_truncation_slices_chars_cleanly(self):
-        # Truncating by char index can never split a UTF-8 sequence; the
-        # output must round-trip and drop the tail sentinel.
-        head = "€" * (MAX_CONTENT_CHARS - 1)
-        raw = (head + "tail-sentinel").encode("utf-8")
-        text = cap_content(raw)
-        self.assertLessEqual(len(text), MAX_CONTENT_CHARS)
-        text.encode("utf-8").decode("utf-8")
+        encoded = text.encode("utf-8")
+        self.assertLessEqual(len(encoded), MAX_CONTENT_BYTES)
+        # round-trips cleanly (no stray surrogate / partial sequence)
+        encoded.decode("utf-8")
         self.assertNotIn("tail-sentinel", text)
 
     def test_sha_key_computed_over_original_bytes_not_capped_text(self):
         # Sanity: cap_content itself does not touch hashing; verify the
         # truncation marker records the ORIGINAL raw length.
-        raw = ("a" * (MAX_CONTENT_CHARS + 500)).encode("utf-8")
+        raw = ("a" * (MAX_CONTENT_BYTES + 500)).encode("utf-8")
         text = cap_content(raw)
         self.assertIn(str(len(raw)), text)
 

--- a/.khive/scripts/test_ingest_workspace_artifacts.py
+++ b/.khive/scripts/test_ingest_workspace_artifacts.py
@@ -5,8 +5,9 @@ the bottom (no subprocess either). Covers PR #1049 fix-round-1 findings:
 
   M1 - DSL $prev-literal escaping (dsl_escape)
   M2 - CRLF round-trip (dsl_escape)
-  M3 - 48KiB cap on the FINAL encoded payload, incl. invalid-UTF-8 expansion
-       and a multibyte char split at the boundary (cap_content)
+  M3 - content cap on the FINAL replacement-decoded text (now 32,768 CHARS,
+       matching the daemon embedder's char-count limit), incl. invalid-UTF-8
+       expansion and multibyte counting (cap_content)
   H3 - PR annotation scoped to this checkout's project entity, never a
        number-only cross-repository fallback (select_exact_project,
        filter_pr_by_number)
@@ -31,7 +32,7 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 
 from ingest_workspace_artifacts import (  # noqa: E402
-    MAX_CONTENT_BYTES,
+    MAX_CONTENT_CHARS,
     Artifact,
     Stats,
     cap_content,
@@ -103,58 +104,68 @@ class DslEscapeCrlfTests(unittest.TestCase):
 
 class CapContentTests(unittest.TestCase):
     def test_under_cap_not_truncated(self):
-        raw = ("a" * (MAX_CONTENT_BYTES - 1)).encode("utf-8")
+        raw = ("a" * (MAX_CONTENT_CHARS - 1)).encode("utf-8")
         text = cap_content(raw)
-        self.assertEqual(len(text.encode("utf-8")), len(raw))
+        self.assertEqual(len(text), MAX_CONTENT_CHARS - 1)
         self.assertNotIn("truncated", text)
 
     def test_exactly_at_cap_not_truncated(self):
-        raw = ("a" * MAX_CONTENT_BYTES).encode("utf-8")
+        raw = ("a" * MAX_CONTENT_CHARS).encode("utf-8")
         text = cap_content(raw)
-        self.assertEqual(len(text.encode("utf-8")), MAX_CONTENT_BYTES)
+        self.assertEqual(len(text), MAX_CONTENT_CHARS)
         self.assertNotIn("truncated", text)
 
     def test_over_cap_valid_utf8_is_truncated_and_capped(self):
-        raw = ("a" * (MAX_CONTENT_BYTES + 10)).encode("utf-8")
+        raw = ("a" * (MAX_CONTENT_CHARS + 10)).encode("utf-8")
         text = cap_content(raw)
-        self.assertLessEqual(len(text.encode("utf-8")), MAX_CONTENT_BYTES)
+        self.assertLessEqual(len(text), MAX_CONTENT_CHARS)
         self.assertIn("truncated", text)
 
-    def test_invalid_utf8_at_exactly_cap_length_is_still_capped(self):
-        # H3/M3 regression: MAX_CONTENT_BYTES of 0xFF is invalid UTF-8; the
-        # OLD code compared len(raw) > MAX_CONTENT_BYTES BEFORE replacement
-        # decoding, so an exactly-at-cap invalid file skipped truncation
-        # entirely and ballooned to 3x size (each byte -> U+FFFD, 3 bytes).
-        raw = b"\xff" * MAX_CONTENT_BYTES
+    def test_live_repro_ascii_char_count_is_capped(self):
+        # Live tranche-2 abort 2026-07-16: a 36,556-char ASCII doc passed the
+        # OLD 48KiB byte cap untouched, then the daemon embedder rejected the
+        # whole create ("text too long: 36556 chars exceeds maximum 32768
+        # chars"). The cap must count chars, matching the daemon check.
+        raw = ("a" * 36_556).encode("utf-8")
         text = cap_content(raw)
-        encoded_len = len(text.encode("utf-8"))
-        self.assertLessEqual(
-            encoded_len,
-            MAX_CONTENT_BYTES,
-            f"final encoded payload {encoded_len} bytes exceeds the {MAX_CONTENT_BYTES} cap",
-        )
+        self.assertLessEqual(len(text), MAX_CONTENT_CHARS)
+        self.assertIn("truncated", text)
+
+    def test_invalid_utf8_at_exactly_cap_length_is_still_within_cap(self):
+        # H3/M3 regression lineage: the cap must apply AFTER replacement
+        # decoding. Each invalid byte decodes to one U+FFFD char, so
+        # MAX_CONTENT_CHARS invalid bytes land exactly at the char cap.
+        raw = b"\xff" * MAX_CONTENT_CHARS
+        text = cap_content(raw)
+        self.assertLessEqual(len(text), MAX_CONTENT_CHARS)
 
     def test_invalid_utf8_well_over_cap_is_capped(self):
-        raw = b"\xff" * (MAX_CONTENT_BYTES + 1024)
+        raw = b"\xff" * (MAX_CONTENT_CHARS + 1024)
         text = cap_content(raw)
-        self.assertLessEqual(len(text.encode("utf-8")), MAX_CONTENT_BYTES)
+        self.assertLessEqual(len(text), MAX_CONTENT_CHARS)
 
-    def test_multibyte_char_split_at_boundary_stays_valid_utf8(self):
-        # A 3-byte char (€) straddling the truncation boundary must not
-        # produce a malformed/half UTF-8 sequence in the output.
-        head = "a" * (MAX_CONTENT_BYTES - 1)
-        raw = (head + "€" + "tail-sentinel").encode("utf-8")
+    def test_multibyte_chars_counted_as_chars_not_bytes(self):
+        # 3-bytes-per-char content: a byte cap would truncate this at a third
+        # of the budget; the char cap must keep all MAX_CONTENT_CHARS chars.
+        raw = ("€" * MAX_CONTENT_CHARS).encode("utf-8")
         text = cap_content(raw)
-        encoded = text.encode("utf-8")
-        self.assertLessEqual(len(encoded), MAX_CONTENT_BYTES)
-        # round-trips cleanly (no stray surrogate / partial sequence)
-        encoded.decode("utf-8")
+        self.assertEqual(len(text), MAX_CONTENT_CHARS)
+        self.assertNotIn("truncated", text)
+
+    def test_truncation_slices_chars_cleanly(self):
+        # Truncating by char index can never split a UTF-8 sequence; the
+        # output must round-trip and drop the tail sentinel.
+        head = "€" * (MAX_CONTENT_CHARS - 1)
+        raw = (head + "tail-sentinel").encode("utf-8")
+        text = cap_content(raw)
+        self.assertLessEqual(len(text), MAX_CONTENT_CHARS)
+        text.encode("utf-8").decode("utf-8")
         self.assertNotIn("tail-sentinel", text)
 
     def test_sha_key_computed_over_original_bytes_not_capped_text(self):
         # Sanity: cap_content itself does not touch hashing; verify the
         # truncation marker records the ORIGINAL raw length.
-        raw = ("a" * (MAX_CONTENT_BYTES + 500)).encode("utf-8")
+        raw = ("a" * (MAX_CONTENT_CHARS + 500)).encode("utf-8")
         text = cap_content(raw)
         self.assertIn(str(len(raw)), text)
 


### PR DESCRIPTION
## Summary

Adds a canonical, idempotent, resumable ingest script that migrates the
project's local (gitignored) artifact directory — codex review verdicts,
workspace docs, session summaries/handoffs, crate audits — into the
workspace-pack substrate as queryable graph records: one workspace entity
per lane, one note per file, `annotates` edges back to the lane entity and
(for codex verdicts) to the matching git-pack pull_request note by number.
No new MCP verbs are needed — it reuses the existing generic create/link
verbs.

- Dedup key: (source path, content sha256 prefix). A resume cursor file
  tracks completed keys so a re-run after interruption skips them with
  zero server round-trips; a server-side bulk-load of previously ingested
  records is a second safety net.
- All writes go through the `kkernel exec` ops DSL, never direct sqlite.
- Dry-run is the default; a `--live` flag is required for any real write.

## Verification

Ran a dry pass against the real local artifact tree: ~9k files discovered
across five artifact classes, the large majority of codex-verdict files
resolved to an existing pull_request record by parsed PR number, and a
sample-mapping + counts report was generated (not part of this PR — the
report itself lives in the same gitignored artifact directory).

## Note on repo convention

The directory this script lives in is currently blanket-gitignored —
sibling scripts there are local-only and have never been committed. This
file is force-added so it's reviewable in a PR. Open question for review:
keep it committed going forward, or move it back to local-only after
review.

## Test plan

- [x] Lint/format clean, compiles clean
- [x] Dry run executed against the real local artifact tree; zero writes
      performed (the write path is only reachable under `--live`)
- [ ] Review of the generated sample-mapping report before any live run
- [ ] Live run gated separately, not part of this PR

Generated with Claude Code

## Fix round 1

Addresses 3 High and 3 Medium findings from a pre-merge design review of this
PR (idempotency and cross-repository-safety concerns in the ingest logic).
Commit c59e9f8e9.

| Finding | Fix | Evidence |
|---|---|---|
| **H1** — partial edge failure becomes permanent on resume (note created, `annotates` edges separate requests, cursor doesn't check edges) | Note + its `annotates` edges (workspace lane, PR) are now created in **one** `create(..., annotates=[...])` call. The runtime (`create_note_inner`, `crates/khive-runtime/src/operations.rs`) validates every annotate target exists before any write and compensates (deletes the note row, FTS doc, vectors) if an edge insert fails — note+edges are structurally all-or-nothing. The separate `link()` calls (and the `annotate_op` helper) are removed. | Read `create_note_inner` end to end (operations.rs:2546-2635, annotates-edge block with compensation ~2872-2940); confirmed the `create` MCP verb's `annotates` param resolves and validates targets pre-write (`crates/khive-pack-kg/src/handlers/create.rs:347-362`). |
| **H2** — non-atomic dedup read-then-write race | The generic `create` verb does **not** expose the server's atomic natural-key path: `try_insert_note`/`external_id` dedup exists only on the internal `try_create_note` runtime method, which the MCP `create` verb never calls (`create_note_inner` always does a plain `upsert_note`). Added a same-host `fcntl.flock` exclusion lock (a lockfile alongside the script) around `--live` runs. **Cross-host concurrent `--live` runs against the same khive.db are NOT excluded** — this is a product gap (generic `create` should surface an atomic natural-key insert path), not fixed in this script. Documented in the module docstring's CONCURRENCY note. | Read `try_insert_note` (`crates/khive-db/src/stores/note.rs:645-719`) vs. `create_note_inner`'s `upsert_note` call (operations.rs:2635) — confirmed the atomic path is unreachable from the `create` verb. |
| **H3** — PR annotations could hit another repository's PR | PR-number lookup is now scoped to this checkout's `project` entity (exact-name match, `WS_INGEST_PROJECT_NAME` env var, default `"khive-oss"`) via `properties.project_id`, mirroring `khive-pack-git ingest.rs find_by_number`'s scoping. A same-numbered PR in a different project is never used as a fallback; 0 or >1 exact project-name matches yields an explicit miss (logged), never a guess. | **Verified live against the production DB**: `pull_request` notes exist under 3 different `project_id`s (khive-oss, lionagi, lattice) with colliding PR numbers (e.g. #1041 in more than one project). Re-ran the dry-run against the full local artifact tree (9078 files, was ~9072 in the original PR): PR-link hit/miss went from **633/7/4** (unscoped) to **624/17/4** (project-scoped) — the 9-hit delta are codex verdicts whose PR number matched a `pull_request` note belonging to a *different* repository, now correctly reported as a miss instead of a false cross-repo hit. |
| **M1** — DSL `$prev` literal breaks parse | `dsl_escape` now prepends the parser's own documented single-backslash escape (`s.strip_prefix('\\')` in `parser_impl.rs::string_as_prev_ref`) whenever content is, in full, a `$prev` chain-reference literal (`$prev`, `$prev.<path>`, `$prev[<idx>]...`). | Verified against the **live server**: `kkernel exec 'get(id="\\$prev.id")'` → `{"error":"not found: not found: $prev.id", ...}` — proves the literal string `$prev.id` round-tripped through the parser instead of being promoted to a chain reference or rejected as `PrevRefOutsideChain`. |
| **M2** — CRLF silently altered while the sha256 dedup key reflects the original bytes | `\r` is now emitted as the DSL `\r` escape instead of being deleted. | Verified against the **live server**: `kkernel exec` with content `"line1\r\nline2"` round-tripped exactly (error message echoed the CRLF-preserved string). |
| **M3** — 48KiB cap bypassed by invalid UTF-8 at/below the raw-byte boundary | The cap now applies to the **final** UTF-8-encoded, replacement-decoded payload (marker space reserved), not the pre-decode raw byte length — `errors="replace"` can expand each invalid byte to a 3-byte U+FFFD, so capping on raw length let a boundary-sized invalid file balloon to 3x. | New unit tests `test_invalid_utf8_at_exactly_cap_length_is_still_capped` / `test_invalid_utf8_well_over_cap_is_capped` / `test_multibyte_char_split_at_boundary_stays_valid_utf8` — all pass. |

### Verification performed

- New `test_ingest_workspace_artifacts.py` (alongside the script): 24 pure-function
  regression tests (no DB round-trip) covering M1/M2/M3 and the H3 project-scoping
  resolver. running it directly → **24/24 pass**.
- M1/M2 additionally verified against the live khive MCP server (see table above).
- Dry run re-run against the full local artifact tree (temporary
  copy, cleaned up after) — see H3 row for the hit/miss delta.
- **No `--live` run performed.** Live stays lambda-gated, out of scope for this round.

Not marking ready — awaiting re-review.


## Fix round 2

Addresses 1 High and 1 Low finding from a re-review of the fix-round-1 commit
(verdict REJECT). Commit `1a66be1e3`.

| Finding | Fix | Evidence |
|---|---|---|
| **[High]** — resume still permanently accepted an incomplete matching note: the server scan matched a note by `(source_path, sha16)` and appended the cursor without checking its `annotates` edges, so a note left incomplete by a pre-fix run (or by best-effort link-failure compensation that didn't run to completion) was never reconciled | The startup server-scan lookup now retains `key -> note_id` instead of a bare key set. When a match is found, a new reconciliation step resolves the artifact's required `annotates` targets (workspace lane, and project-scoped PR for codex verdicts) via the same pure helper the create path uses, reads the note's actual outgoing `annotates` edges (`neighbors(node_id, direction="outgoing", relations=["annotates"])`), and creates whatever is missing (`link(...)`) before the cursor is backfilled. | 12 new pure-function / fake-KKernel tests cover: a matching note with a missing workspace edge, a codex verdict with a missing PR edge, and the already-complete no-op case — all pass. |
| **[Low]** — the advisory lock was per-checkout (derived from the script's own directory), while the module docstring described it as same-host exclusion; separate worktrees on one host used distinct lock inodes | The lock now lives at a fixed, checkout-independent path (`/tmp/lion-khive-wsingest.lock`, lion-prefixed per fleet lock-naming convention). Docstring and error text updated to say machine-wide, shared across checkouts. | Two `--live` invocations from different worktrees of this repo now contend on the same lock file. |

### Verification performed

- Regression suite: **36/36 pass** (24 prior + 12 new).
- Re-ran the default dry-run against this worktree: report still shows the same discovery counts as before this round (0 files — this worktree has none of the gitignored local artifact directories populated; discovery logic itself is untouched by this round).
- **No `--live` run performed.** Live stays lambda-gated, out of scope for this round.

Not marking ready — awaiting re-review.



## Fix round 5 (post-approval delta, live-run findings)

Tranche-2 of the live ingest (workspace_doc class, ~7.5k files) aborted twice on the daemon's embedder length limit; both aborts are fixed and pinned as regression tests.

| Finding | Fix | Evidence |
|---|---|---|
| The 48KiB content cap exceeds the daemon embedder's actual limit: a 36,556-byte ASCII doc passed the cap untouched and the whole `create()` was rejected ("text too long ... exceeds maximum 32768") | Cap lowered to the embedder's limit (commit 30f568fa6 counted chars per the error wording) | `test_live_repro_ascii_doc_over_embed_limit_is_capped` |
| The error message wording is misleading: the embedder counts BYTES (`text.len()` in lattice-embed 0.6.1 service/cached.rs), not chars — a 32,768-char cap still failed at 32,846 bytes on multibyte expansion | Restored the byte-slicing cap algorithm at 32,768 bytes (commit f8a46ed89); comments document the byte-vs-chars discrepancy; upstream wording bug reported to the owning team | `test_live_repro_multibyte_expansion_is_capped_in_bytes`; 39/39 tests pass |
