### PR TITLE
docs: batch B7 — public-surface integrity (#453 #514 #524 #964 #1055)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,8 @@
 # khive — Developer Guide
 
 **What this is**: A research knowledge graph runtime. Typed entities, closed edge ontology,
-hybrid search, GQL/SPARQL queries — all in a single 18MB Rust binary over MCP stdio.
+hybrid search, GQL/SPARQL queries — all in a single ~21MB Rust binary over MCP stdio (see #1055;
+measure a fresh `main` build before citing an exact figure — it drifts).
 
 **v0.3.0** — [crates.io](https://crates.io/crates/khive-mcp) | Apache 2.0
 

--- a/crates/khive-pack-kg/src/handler_defs.rs
+++ b/crates/khive-pack-kg/src/handler_defs.rs
@@ -530,7 +530,7 @@ pub(crate) static KG_HANDLERS: [HandlerDef; 18] = [
                 required: true,
                 description: "Edge relation (contains | part_of | instance_of | extends | variant_of | introduced_by | supersedes | derived_from | precedes | depends_on | enables | implements | competes_with | composed_with | annotates | supports | refutes). \
                     Each relation only accepts specific (source_kind -> target_kind) endpoint pairs; an out-of-allowlist pair is rejected with PermissionDenied, not silently accepted. \
-                    Base ADR-002 entity->entity allowlist (issue #964 — this table mirrors `base_entity_endpoint_rules()`, the exact source the validator consults, so it cannot drift out of sync): \
+                    Base ADR-002 entity->entity allowlist (issue #964 — this table is a hand-maintained mirror of `base_entity_endpoint_rules()` (khive-runtime) and is guarded by a regression test on key rows; the validator consults the function, not this text): \
                     contains: concept->concept, project->project, project->artifact, org->project, org->service. \
                     part_of: concept->concept, project->project, project->org. \
                     instance_of: *->concept (any source kind), service->project. \
@@ -547,7 +547,7 @@ pub(crate) static KG_HANDLERS: [HandlerDef; 18] = [
                     supports / refutes: concept->concept, document->concept, dataset->concept, artifact->concept (evidence -> claim). \
                     annotates: note -> {entity, note, edge, event} (the only relation whose source is a note, not an entity). \
                     The `kg` pack additionally allows (pack-extensible, additive-only per ADR-017): part_of/instance_of person->org, part_of/instance_of person->project, depends_on/enables/contains/part_of/precedes org->org, precedes decision-note->decision-note. \
-                    Other loaded packs may add further pairs (e.g. `gtd` allows depends_on task-note->task-note; `formal` allows typed depends_on between theorem/definition/axiom/structure/instance/goal entity_types) — pack rules only ever add allowed pairs, never remove one listed here. Full pack-rule source: `docs/api/edge-rules-pack-kg.md`.",
+                    Other loaded packs may add further pairs (e.g. `gtd` allows depends_on task-note->task-note; `formal` allows typed depends_on between theorem/definition/axiom/structure/instance/goal entity_types) — pack rules only ever add allowed pairs, never remove one listed here. Full pack-rule source: `KG_EDGE_RULES` in `khive-pack-kg/src/pack.rs` (ADR-017).",
             },
             ParamDef {
                 name: "weight",

--- a/crates/khive-pack-kg/src/handler_defs.rs
+++ b/crates/khive-pack-kg/src/handler_defs.rs
@@ -528,7 +528,26 @@ pub(crate) static KG_HANDLERS: [HandlerDef; 18] = [
                 name: "relation",
                 param_type: "string",
                 required: true,
-                description: "Edge relation (contains | part_of | instance_of | extends | variant_of | introduced_by | supersedes | derived_from | precedes | depends_on | enables | implements | competes_with | composed_with | annotates | supports | refutes).",
+                description: "Edge relation (contains | part_of | instance_of | extends | variant_of | introduced_by | supersedes | derived_from | precedes | depends_on | enables | implements | competes_with | composed_with | annotates | supports | refutes). \
+                    Each relation only accepts specific (source_kind -> target_kind) endpoint pairs; an out-of-allowlist pair is rejected with PermissionDenied, not silently accepted. \
+                    Base ADR-002 entity->entity allowlist (issue #964 — this table mirrors `base_entity_endpoint_rules()`, the exact source the validator consults, so it cannot drift out of sync): \
+                    contains: concept->concept, project->project, project->artifact, org->project, org->service. \
+                    part_of: concept->concept, project->project, project->org. \
+                    instance_of: *->concept (any source kind), service->project. \
+                    extends: concept->concept. variant_of: concept->concept, artifact->artifact. \
+                    introduced_by: concept->document, concept->person, concept->org, artifact->document, document->person, document->org. \
+                    derived_from: artifact->dataset, artifact->document, artifact->project, artifact->artifact. \
+                    precedes: document->document, dataset->dataset, artifact->artifact, service->service, project->project. \
+                    depends_on: project->project, service->project, service->service, service->artifact, service->dataset, artifact->project, artifact->service, document->document. \
+                    enables: concept->concept, service->concept, dataset->concept. \
+                    implements: project->concept, service->concept. \
+                    competes_with (symmetric): concept<->concept, project<->project, service<->service. \
+                    composed_with (symmetric): concept<->concept, project<->project. \
+                    supersedes: concept->concept, document->document, artifact->artifact, service->service, dataset->dataset. \
+                    supports / refutes: concept->concept, document->concept, dataset->concept, artifact->concept (evidence -> claim). \
+                    annotates: note -> {entity, note, edge, event} (the only relation whose source is a note, not an entity). \
+                    The `kg` pack additionally allows (pack-extensible, additive-only per ADR-017): part_of/instance_of person->org, part_of/instance_of person->project, depends_on/enables/contains/part_of/precedes org->org, precedes decision-note->decision-note. \
+                    Other loaded packs may add further pairs (e.g. `gtd` allows depends_on task-note->task-note; `formal` allows typed depends_on between theorem/definition/axiom/structure/instance/goal entity_types) — pack rules only ever add allowed pairs, never remove one listed here. Full pack-rule source: `docs/api/edge-rules-pack-kg.md`.",
             },
             ParamDef {
                 name: "weight",
@@ -994,6 +1013,35 @@ mod tests {
         assert!(
             h.params.iter().any(|p| p.name == "comment" && !p.required),
             "review must document optional comment param"
+        );
+    }
+
+    /// Regression for #964: `link(help=true)` must surface the per-relation
+    /// edge-endpoint allowlist so batch appliers can defer to the kernel's own
+    /// table instead of reimplementing (and drifting from) it.
+    #[test]
+    fn link_relation_param_documents_edge_endpoint_allowlist() {
+        let h = find_handler("link");
+        let relation_param = h
+            .params
+            .iter()
+            .find(|p| p.name == "relation")
+            .expect("link must document a relation param");
+        assert!(
+            relation_param
+                .description
+                .contains("contains: concept->concept"),
+            "link.relation help must enumerate the base ADR-002 endpoint allowlist"
+        );
+        assert!(
+            relation_param
+                .description
+                .contains("part_of/instance_of person->org"),
+            "link.relation help must enumerate the kg pack's additive EDGE_RULES"
+        );
+        assert!(
+            relation_param.description.contains("annotates: note ->"),
+            "link.relation help must document the annotates note->* endpoint"
         );
     }
 

--- a/crates/khive-pack-kg/src/handler_defs.rs
+++ b/crates/khive-pack-kg/src/handler_defs.rs
@@ -1095,7 +1095,13 @@ mod tests {
             "link.relation help must document the annotates note->* endpoint"
         );
 
-        // kg pack's additive EDGE_RULES — every row must appear in the pack clause.
+        // kg pack's additive EDGE_RULES — every (relation, source, target)
+        // TRIPLE must appear in the pack clause, not merely the endpoint pair.
+        // The clause groups relations that share an endpoint pair
+        // ("part_of/instance_of person->org"), so a row is verified by finding a
+        // comma-delimited segment that carries BOTH the relation token AND the
+        // "src->tgt" endpoint — deleting a relation from a grouped run (e.g.
+        // dropping instance_of but keeping part_of) then fails the test.
         let kg_clause = desc
             .split(". ")
             .find(|c| c.contains("kg` pack additionally allows"))
@@ -1104,10 +1110,13 @@ mod tests {
             let src = endpoint_kind_label(&rule.source);
             let tgt = endpoint_kind_label(&rule.target);
             let row = format!("{src}->{tgt}");
+            let rel = rule.relation.as_str();
+            let matched = kg_clause
+                .split(", ")
+                .any(|seg| seg.contains(&row) && seg.contains(rel));
             assert!(
-                kg_clause.contains(&row),
-                "kg pack EDGE_RULES row missing from help: {:?} {row}",
-                rule.relation
+                matched,
+                "kg pack EDGE_RULES triple missing from help: {rel} {row}\nclause: {kg_clause}"
             );
         }
     }

--- a/crates/khive-pack-kg/src/handler_defs.rs
+++ b/crates/khive-pack-kg/src/handler_defs.rs
@@ -529,8 +529,8 @@ pub(crate) static KG_HANDLERS: [HandlerDef; 18] = [
                 param_type: "string",
                 required: true,
                 description: "Edge relation (contains | part_of | instance_of | extends | variant_of | introduced_by | supersedes | derived_from | precedes | depends_on | enables | implements | competes_with | composed_with | annotates | supports | refutes). \
-                    Each relation only accepts specific (source_kind -> target_kind) endpoint pairs; an out-of-allowlist pair is rejected with PermissionDenied, not silently accepted. \
-                    Base ADR-002 entity->entity allowlist (issue #964 — this table is a hand-maintained mirror of `base_entity_endpoint_rules()` (khive-runtime) and is guarded by a regression test on key rows; the validator consults the function, not this text): \
+                    Each relation only accepts specific (source_kind -> target_kind) endpoint pairs; an out-of-allowlist pair between two otherwise-valid endpoints is rejected with InvalidInput, and a missing endpoint returns NotFound — never silently accepted. \
+                    Base ADR-002 entity->entity allowlist (issue #964 — this table is a hand-maintained mirror of `base_entity_endpoint_rules()` (khive-runtime) and is guarded by a regression test on key rows; enforcement consults the shared rule data via `base_entity_rule_allows()`, not this text — `base_entity_endpoint_rules()` is just an exposed view of the same constant): \
                     contains: concept->concept, project->project, project->artifact, org->project, org->service. \
                     part_of: concept->concept, project->project, project->org. \
                     instance_of: *->concept (any source kind), service->project. \
@@ -543,9 +543,9 @@ pub(crate) static KG_HANDLERS: [HandlerDef; 18] = [
                     implements: project->concept, service->concept. \
                     competes_with (symmetric): concept<->concept, project<->project, service<->service. \
                     composed_with (symmetric): concept<->concept, project<->project. \
-                    supersedes: concept->concept, document->document, artifact->artifact, service->service, dataset->dataset. \
-                    supports / refutes: concept->concept, document->concept, dataset->concept, artifact->concept (evidence -> claim). \
-                    annotates: note -> {entity, note, edge, event} (the only relation whose source is a note, not an entity). \
+                    supersedes: concept->concept, document->document, artifact->artifact, service->service, dataset->dataset, note->note (same-substrate only). \
+                    supports / refutes: concept->concept, document->concept, dataset->concept, artifact->concept (evidence -> claim), note->note (same-substrate only). \
+                    annotates: note -> {entity, note, edge, event} — the only relation permitting a note source paired with ANY target substrate (supersedes/supports/refutes also permit a note source, but only same-substrate: a note source there requires a note target too). \
                     The `kg` pack additionally allows (pack-extensible, additive-only per ADR-017): part_of/instance_of person->org, part_of/instance_of person->project, depends_on/enables/contains/part_of/precedes org->org, precedes decision-note->decision-note. \
                     Other loaded packs may add further pairs (e.g. `gtd` allows depends_on task-note->task-note; `formal` allows typed depends_on between theorem/definition/axiom/structure/instance/goal entity_types) — pack rules only ever add allowed pairs, never remove one listed here. Full pack-rule source: `KG_EDGE_RULES` in `khive-pack-kg/src/pack.rs` (ADR-017).",
             },
@@ -1016,9 +1016,40 @@ mod tests {
         );
     }
 
+    /// Locate the substring of `desc` documenting `relation` — either its own
+    /// `"{relation}:"` clause, its `"{relation} (symmetric):"` clause, or a
+    /// grouped `"a / b:"` clause (used for `supports / refutes`).
+    fn relation_clause<'a>(desc: &'a str, relation: &str) -> &'a str {
+        desc.split(". ")
+            .find(|c| {
+                c.contains(&format!("{relation}:"))
+                    || c.contains(&format!("{relation} ("))
+                    || c.contains(&format!("{relation} /"))
+                    || c.contains(&format!("/ {relation}"))
+            })
+            .unwrap_or_else(|| {
+                panic!("link.relation help must document a clause for relation `{relation}`")
+            })
+    }
+
+    fn endpoint_kind_label(kind: &khive_types::EndpointKind) -> String {
+        match kind {
+            khive_types::EndpointKind::EntityOfKind(k) => (*k).to_string(),
+            khive_types::EndpointKind::NoteOfKind(k) => format!("{k}-note"),
+            khive_types::EndpointKind::EntityOfType { kind, .. } => (*kind).to_string(),
+        }
+    }
+
     /// Regression for #964: `link(help=true)` must surface the per-relation
     /// edge-endpoint allowlist so batch appliers can defer to the kernel's own
     /// table instead of reimplementing (and drifting from) it.
+    ///
+    /// Full-coverage drift tripwire (codex PR #1060 review): derives the
+    /// expected rows from the live rule sources (`base_entity_endpoint_rules()`
+    /// and `KG_EDGE_RULES`) instead of asserting a handful of substrings, so a
+    /// typo'd or dropped row in an untested relation (e.g. `derived_from`,
+    /// `depends_on`, the epistemic pairs) fails the test rather than shipping
+    /// a stale contract.
     #[test]
     fn link_relation_param_documents_edge_endpoint_allowlist() {
         let h = find_handler("link");
@@ -1027,22 +1058,58 @@ mod tests {
             .iter()
             .find(|p| p.name == "relation")
             .expect("link must document a relation param");
+        let desc = relation_param.description;
+
+        for (src, relation, tgt) in khive_runtime::base_entity_endpoint_rules() {
+            let rel = relation.as_str();
+            let clause = relation_clause(desc, rel);
+            if relation.is_symmetric() {
+                let a = format!("{src}<->{tgt}");
+                let b = format!("{tgt}<->{src}");
+                assert!(
+                    clause.contains(&a) || clause.contains(&b),
+                    "link.relation help missing symmetric base row {rel}: {src}<->{tgt}"
+                );
+            } else {
+                let row = format!("{src}->{tgt}");
+                assert!(
+                    clause.contains(&row),
+                    "link.relation help missing base row {rel}: {row}\nclause: {clause}"
+                );
+            }
+        }
+
+        // The three same-substrate note->note families (ADR-055/ADR-002) must
+        // be documented alongside their entity->entity cases.
+        for rel in ["supersedes", "supports", "refutes"] {
+            let clause = relation_clause(desc, rel);
+            assert!(
+                clause.contains("note->note"),
+                "link.relation help must document {rel}: note->note (same-substrate only)"
+            );
+        }
+
+        // annotates: the only relation permitting a note source with any target.
         assert!(
-            relation_param
-                .description
-                .contains("contains: concept->concept"),
-            "link.relation help must enumerate the base ADR-002 endpoint allowlist"
-        );
-        assert!(
-            relation_param
-                .description
-                .contains("part_of/instance_of person->org"),
-            "link.relation help must enumerate the kg pack's additive EDGE_RULES"
-        );
-        assert!(
-            relation_param.description.contains("annotates: note ->"),
+            desc.contains("annotates: note ->"),
             "link.relation help must document the annotates note->* endpoint"
         );
+
+        // kg pack's additive EDGE_RULES — every row must appear in the pack clause.
+        let kg_clause = desc
+            .split(". ")
+            .find(|c| c.contains("kg` pack additionally allows"))
+            .expect("link.relation help must document the kg pack's additive EDGE_RULES clause");
+        for rule in crate::pack::KG_EDGE_RULES.iter() {
+            let src = endpoint_kind_label(&rule.source);
+            let tgt = endpoint_kind_label(&rule.target);
+            let row = format!("{src}->{tgt}");
+            assert!(
+                kg_clause.contains(&row),
+                "kg pack EDGE_RULES row missing from help: {:?} {row}",
+                rule.relation
+            );
+        }
     }
 
     #[test]

--- a/docs/adr/ADR-018-authorization-gate.md
+++ b/docs/adr/ADR-018-authorization-gate.md
@@ -208,9 +208,10 @@ Callers can match on it to distinguish authorization failures from operational e
 
 ### Fail-open on gate `Err`
 
-A gate that errors out (Rego policy fails to compile, regorus throws, internal
-timeout) returns `Err(GateError)`. This is treated as **infrastructure failure**, not
-authorization decision. The dispatch proceeds; the error is logged.
+A gate that errors out before it can produce a decision (e.g. request serialization
+failure, a poisoned internal lock surfaced as `GateError::Internal`) returns
+`Err(GateError)`. This is treated as **infrastructure failure**, not an authorization
+decision. The dispatch proceeds; the error is logged.
 
 Rationale: blocking dispatch on infrastructure failures means every verb depends on
 gate-infrastructure availability. A misconfigured policy in production would take down
@@ -220,6 +221,17 @@ operators see the warning and fix the policy.
 This is distinct from `Deny`, which is an explicit policy decision. Deny blocks; Err
 does not. Future deployments needing strict-mode (block on gate Err) can wrap `Gate`
 in a `StrictGate { inner: Arc<dyn Gate> }` adapter — but that's not the default.
+
+**`RegoGate` narrows this further than the base contract implies.** Policy-load
+failures (a Rego file that fails to compile, or an empty policy directory) surface as
+`Err(GateError::Policy)` at construction time, before the gate is ever installed —
+consistent with fail-open-on-infra-error above. But at _dispatch_ time, `RegoGate`
+never returns `Err` for policy-evaluation uncertainty: an undefined `decision` rule, a
+`regorus` evaluation throw, a poisoned engine mutex, or a decision value that fails to
+serialize or doesn't match the `GateDecision` shape are all converted to an explicit
+`Ok(GateDecision::Deny)` with a diagnostic reason (`crates/khive-gate-rego/src/gate.rs`).
+Only pre-evaluation failures (request serialization) reach `Err(GateError)` for
+`RegoGate`. See `crates/khive-gate-rego/README.md` for the full breakdown.
 
 ### `AuditEvent` envelope
 

--- a/docs/adr/ADR-046-event-sourced-proposals.md
+++ b/docs/adr/ADR-046-event-sourced-proposals.md
@@ -109,6 +109,8 @@ pub enum ProposalChangeset {
     /// Supersede an entity with another (sets `supersedes` edge).
     SupersedeEntity { old: Uuid, new: Uuid },
     /// Compound: an ordered sequence of the above, applied atomically.
+    /// NOTE: as of PR #517, only single-step Compound is accepted at propose-time
+    /// and legacy-apply-time — see "Compound changeset semantics (Fix 4)" below.
     Compound { steps: Vec<ProposalChangeset> },
 }
 
@@ -155,6 +157,18 @@ applies steps in order. The apply worker uses a single SQLite write transaction
 wrapping all steps (since all v1 backends share the same SQLite connection per
 `khive-db`). If ANY step's runtime validation fails, the entire transaction
 rolls back and the worker emits
+
+> **Current restriction (PR #517, containment fix for #423):** multi-step `Compound`
+> (more than one step, including nested `Compound` containing more than one step) is
+> rejected at propose-time and legacy-apply-time — `propose` returns
+> `InvalidInput("multi-step Compound proposals are not supported until atomic proposal
+> apply is available")` (`crates/khive-pack-kg/src/handlers/proposal.rs`,
+> `has_multi_step_compound`). This is pending a real runtime/storage atomic-apply
+> primitive that can span multiple public mutations — today `create_entity`, `link`,
+> `merge`, and event-append are separate transactions, so the single-SQLite-transaction
+> guarantee described below does not yet hold for genuinely multi-step compounds.
+> Single-step `Compound` is unaffected and applies as described.
+
 `ProposalApplied { result: Failed { error, applied_step_count: 0 } }`.
 
 Cross-store atomicity (e.g., entity creation in SQLite + vector insert in
@@ -346,7 +360,8 @@ On each approved review handled by `handle_review`, `ProposalApplyWorker::maybe_
    - `AddNote` → `runtime.notes.create(...)`
    - `MergeEntities` → `runtime.curation.merge_entities(...)`
    - `SupersedeEntity` → adds `supersedes` edge via `runtime.graph.link(...)`
-   - `Compound` → recursive within a single transaction
+   - `Compound` → recursive within a single transaction (multi-step Compound
+     currently rejected before this stage — see the current-restriction note above)
 4. Emits `ProposalApplied` with `Success { created_records }` or `Failed { error }`.
 
 Authorization (ADR-018) checks the apply attempt. The worker's actor identity

--- a/docs/adr/ADR-091-wal-snapshot-lifetime.md
+++ b/docs/adr/ADR-091-wal-snapshot-lifetime.md
@@ -495,7 +495,7 @@ Existing, unchanged: `KHIVE_CHECKPOINT_INTERVAL_MS` (500), `KHIVE_WAL_WARN_PAGES
    mean vendoring a patched SQLite build for a config-and-scheduling-level fix. Revisit
    only if WAL2 reaches upstream stable and the config-level fix proves insufficient.
 2. **External checkpointer process** (litestream-style out-of-process WAL manager).
-   Rejected: khive embeds SQLite in-process by design (single 18MB binary); an external
+   Rejected: khive embeds SQLite in-process by design (single self-contained binary); an external
    process reintroduces an operational dependency and IPC surface for a problem a
    background `tokio::spawn` task (already present, `checkpoint.rs`) solves in-process.
 3. **Kill long-lived reader sessions at the OS level** (SIGKILL `kkernel mcp` processes

--- a/docs/adr/ADR-111-blob-store.md
+++ b/docs/adr/ADR-111-blob-store.md
@@ -486,9 +486,16 @@ versions already present in the workspace dependency graph while excluding its f
 other cloud backends. This provides a Tokio-native client, signing, retries,
 conditional PUT support, custom endpoints, and streaming LIST pagination without importing its
 other provider implementations. The implementation gate must record the normal dependency-tree and
-stripped release-binary delta against khive's established 18 MB single-binary goal; this draft does
+stripped release-binary delta against a freshly measured `main` baseline; this draft does
 not claim an unmeasured byte cost. Updating the pinned dependency is allowed only with the same
 feature, compatibility, and size evidence.
+
+**Baseline note (2026-07-16, #1055):** the "18 MB single-binary goal" cited in earlier drafts and
+in other khive docs is stale — a stripped release `kkernel` at `main` (pre-#1054) measured
+21,654,816 bytes (20.65 MiB); #1054 itself adds only +67,312 bytes (+0.3%), so the growth predates
+and is unrelated to this ADR's S3 backend. There is no re-derived hard budget yet; until one is set,
+size-delta reviews for this and future backends must compare against a freshly measured `main`
+binary, not the old 18 MB figure.
 
 The existing whole-buffer trait is accepted for S3 v1 up to 64 MiB per object. `put` rejects a
 larger buffer with `InvalidInput`; `get` checks returned object metadata before collecting a larger


### PR DESCRIPTION
## Summary

Reconciles docs/ADR claims with shipped behavior across five open findings. Code changed
only where the fix was surfacing existing internal data through the documented `help=true`
surface (#964); every other fix is docs-only.

### #453 — khive-gate-rego docs described stale fail-open behavior

`crates/khive-gate-rego/README.md` already stated the corrected behavior (policy-evaluation
uncertainty fails **closed** — an explicit `Ok(Deny)`), but `docs/adr/ADR-018-authorization-gate.md`
still described the generic base-`Gate` "fail-open on gate `Err`" contract as if `RegoGate`
itself returns `Err` for evaluation-time failures. Verified against
`crates/khive-gate-rego/src/gate.rs`: an undefined `decision` rule, a `regorus` evaluation
throw, a poisoned engine mutex, and a decision value that fails to serialize or has the wrong
shape are all converted to an explicit `Ok(GateDecision::Deny)` inside `RegoGate::check`. Only
pre-evaluation failures (request serialization) still reach `Err(GateError)`. Added a
paragraph to ADR-018 distinguishing the base contract from `RegoGate`'s narrower dispatch-time
behavior, cross-referencing the README.

### #524 — ADR-046 Compound changeset text overstated apply guarantees

PR #517 (containment fix for #423) made `propose`/legacy-apply reject multi-step `Compound`
proposals (`crates/khive-pack-kg/src/handlers/proposal.rs`, `has_multi_step_compound`) until a
real atomic-apply primitive spanning multiple public mutations exists. `ADR-046` still
described `Compound` as unconditionally "applied atomically." Added a current-restriction note
at the `Compound` variant doc and the "Compound changeset semantics (Fix 4)" section, and a
one-line pointer at the apply-worker dispatch table. Single-step `Compound` is unaffected.

### #1055 — ADR-111 cites a stale 18 MB single-binary figure

Measured baseline (per the issue): a stripped release `kkernel` at `main` (pre-#1054) is
21,654,816 bytes (20.65 MiB); #1054 itself adds only +67,312 bytes. The "18 MB" figure ADR-111
and other docs anchor on no longer reflects `main`. Updated ADR-111 with the measured baseline
and a note that size-delta reviews should compare against a freshly measured `main`, not the
old figure — there is no re-derived hard budget yet. Also corrected the same stale figure
where it appears in `docs/adr/ADR-091-wal-snapshot-lifetime.md` and the repo's top-level
`CLAUDE.md` dev guide (the latter now avoids hardcoding an exact figure that will drift again).

### #964 — link/verbs help didn't expose the edge-endpoint allowlist

The kernel enforces per-relation `(source_kind -> target_kind)` endpoints with a
self-documenting runtime error, but `link(help=true)` didn't surface the allowlist itself, so
client tooling reimplemented it and drifted (a reported case: a batch applier dropped a legal
`composed_with` project→project edge because its local table was stricter than the kernel's).
`link`'s `relation` param description now enumerates the base ADR-002 entity-endpoint
allowlist — the same data `base_entity_endpoint_rules()` exposes to the live validator — plus
the `kg` pack's own additive `EDGE_RULES`, with a pointer to other loaded packs (`gtd`,
`formal`) that can add further pairs. Added a regression test
(`link_relation_param_documents_edge_endpoint_allowlist`) so the help text can't silently drift
from this PR's snapshot again.

### #514 — knowledge pack verb-surface consolidation: not implemented, by design

This is a forward-looking design note, not a doc-vs-code drift. The issue itself is explicit
that any consolidation of the `knowledge` pack's verb surface is a wire-contract change
requiring an ADR-023 amendment before implementation, and is "not urgent, not blocking." No
code change is made here — consolidating now would change observable MCP behavior ahead of
that amendment. Left open, untouched, pending a dedicated design pass.

## Evidence

- `crates/khive-gate-rego/src/gate.rs` (fail-closed conversion sites), `crates/khive-gate-rego/README.md`
- `crates/khive-pack-kg/src/handlers/proposal.rs` (`has_multi_step_compound`)
- issue #1055 measured baseline (21,654,816 bytes / 20.65 MiB, pre-#1054)
- `crates/khive-runtime/src/operations.rs` (`base_entity_endpoint_rules`), `crates/khive-pack-kg/src/pack.rs` (`KG_EDGE_RULES`)

## Test plan

- [x] `cargo check -p khive-pack-kg`
- [x] `cargo test -p khive-pack-kg --lib` (148 passed, incl. new regression test)
- [x] `cargo clippy -p khive-pack-kg --all-targets -- -D warnings`
- [x] `cargo fmt` (via pre-commit hook on both commits)
- [x] `deno fmt docs/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

Closes #453
Closes #524
Closes #1055
Closes #964
