### PR TITLE
docs(readme): fix CLI-is-planned contradiction with shipped kkernel CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,9 @@ The **khived daemon** (ADR-049) keeps the runtime warm between MCP sessions: the
 stays loaded, SQLite connections stay open, and pack registries stay initialized. It auto-spawns on
 first request and persists in the background, eliminating cold-start overhead on reconnect.
 
-HTTP gateway, CLI, and visual frontend are planned for future releases.
+HTTP gateway and visual frontend are planned for future releases. The `kkernel` admin CLI
+(migrations, reindexing, data import/export, diagnostics) ships today, documented in
+[docs/operations.md](docs/operations.md).
 
 ---
 


### PR DESCRIPTION
## Summary

README.md line 163 said:

> HTTP gateway, CLI, and visual frontend are planned for future releases.

but lines 334-335 of the same file document the `kkernel` admin CLI (migrations, reindexing, data import/export, diagnostics) as already shipping, linking to `docs/operations.md`. The `kkernel` admin CLI has been on crates.io since well before this line was last touched — line 163 predates kkernel becoming the admin-CLI surface and was never updated.

This self-contradiction is not hypothetical: an external technical evaluator read line 163 in isolation and wrote "khive has no CLI (planned)" in an integration doc, a factual error directly caused by the stale line.

## Fix

Line 163 now reads:

> HTTP gateway and visual frontend are planned for future releases. The `kkernel` admin CLI (migrations, reindexing, data import/export, diagnostics) ships today, documented in [docs/operations.md](docs/operations.md).

Swept the rest of the file for the same class of contradiction (`grep -ni "cli" README.md`, read every hit) — no other line claims the CLI is unshipped or planned. Minimal diff: only the one contradictory sentence changed, nothing else touched.

## Test plan

- [x] `grep -ni "cli" README.md` reviewed line by line — no remaining CLI-unshipped claims
- [x] `deno fmt README.md` run, diff is clean (no unrelated reformatting)
- [x] Docs-only change, no code touched, no cargo build needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
