### PR TITLE
ci: auto-merge push guard needs contents:write for its disable mutation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,12 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:
-      contents: read
+      # disablePullRequestAutoMerge needs contents: write in addition to
+      # pull-requests: write — with contents: read the mutation is rejected
+      # ("Resource not accessible by integration") and, because this job
+      # fail-closes into the CI gate, every push to an armed PR turned the
+      # gate red even after re-review (first hit: PR #1054, 2026-07-17).
+      contents: write
       pull-requests: write
     steps:
       - name: Disable stale auto-merge request


### PR DESCRIPTION
## Problem

The automerge-push-guard job in ci.yml disables a stale auto-merge request whenever an armed PR receives a new push, and CI gate depends on it fail-closed. The job's GraphQL disablePullRequestAutoMerge mutation requires contents: write in addition to pull-requests: write. With only contents: read, GitHub rejects the call with "Resource not accessible by integration", the job exits 1, and CI gate goes red on every push to an armed PR, even after the delta has been re-reviewed and auto-merge deliberately re-armed.

First observed on PR #1054 (2026-07-17): both fix-forward pushes turned the gate red via the guard rather than via any real check.

## Fix

Grant the guard job contents: write (2 lines plus a rationale comment). No behavior change otherwise: the deliberate-re-arm escape (auto-merge enabledAt newer than the push updated_at) keeps working; this just lets the disable path actually execute instead of erroring.

## Verification

Static: the mutation's documented required permission set. Behavioral verification happens on the first armed-PR push after merge, where the guard should disable auto-merge and exit 0 instead of erroring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)