### PR TITLE
fix(release): wire khive-channel-telegram into publish ladder + refresh stale semver excludes

### DIFF
--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -62,12 +62,12 @@ CRATES=(
     khive-retrieval
     khive-vcs-adapters
     khive-vcs
-    khive-changeset      # needs khive-types (above); never published, no crates.io baseline yet
+    khive-changeset      # needs khive-types (above)
     # khive-merge — excluded from workspace (ADR-043 forward-deployed, ahead of khive-vcs)
     khive-pack-formal    # needs khive-runtime + khive-types (both above); dev-dep of khive-pack-kg, so publish first
     khive-pack-kg
-    khive-pack-git       # needs khive-runtime/storage + khive-pack-kg (all above); never published, no baseline yet
-    khive-pack-code      # needs khive-runtime/storage + khive-pack-kg (all above); never published, no baseline yet
+    khive-pack-git       # needs khive-runtime/storage + khive-pack-kg (all above)
+    khive-pack-code      # needs khive-runtime/storage + khive-pack-kg (all above)
     khive-pack-gtd
     khive-brain-core
     khive-pack-brain
@@ -76,10 +76,11 @@ CRATES=(
     khive-pack-schedule
     khive-pack-knowledge
     khive-pack-session   # needs khive-pack-kg + khive-runtime/storage/types (all above)
-    khive-pack-workspace # needs khive-pack-kg/gtd/git/session (all above); never published, no baseline yet
+    khive-pack-workspace # needs khive-pack-kg/gtd/git/session (all above)
     khive-pack-template
-    khive-channel        # no khive-* deps; transport abstraction
-    khive-channel-email  # needs khive-channel (above); optional dep of khive-mcp
+    khive-channel          # no khive-* deps; transport abstraction
+    khive-channel-email    # needs khive-channel (above); optional dep of khive-mcp
+    khive-channel-telegram # needs khive-channel (above); optional dep of khive-mcp
     khive-mcp
     kkernel
 )
@@ -94,11 +95,12 @@ DELAY=10  # seconds to wait for crates.io index between publishes
 # (which is why it is NOT a per-PR CI gate). Runs in preflight and live alike so
 # `make publish-dry` validates SemVer before any real publish. Crates with no
 # crates.io baseline yet (never published) have nothing to diff against and are
-# excluded until their first publish. As of the 0.5.0 cycle that is exactly the
-# four crates added since 0.3.0: khive-changeset, khive-pack-code, khive-pack-git,
-# khive-pack-workspace. Every other workspace crate, including khive-quant and the
-# crates first shipped in 0.3.0, has a published 0.3.0 baseline and MUST be
-# checked. Drop an exclusion once that crate has one published version.
+# excluded until their first publish. As of the 0.5.0 cycle that is exactly
+# khive-channel-telegram (added since 0.4.0 via #1048). The four crates first
+# published in 0.4.0 — khive-changeset, khive-pack-code, khive-pack-git,
+# khive-pack-workspace — now have a 0.4.0 baseline and are checked again. Every
+# other workspace crate has a published baseline and MUST be checked. Drop an
+# exclusion once that crate has one published version.
 echo ""
 echo "--- SemVer gate (cargo-semver-checks vs crates.io baseline) ---"
 if ! command -v cargo-semver-checks >/dev/null 2>&1; then
@@ -107,10 +109,7 @@ if ! command -v cargo-semver-checks >/dev/null 2>&1; then
     exit 1
 fi
 cargo semver-checks check-release --workspace \
-    --exclude khive-changeset \
-    --exclude khive-pack-code \
-    --exclude khive-pack-git \
-    --exclude khive-pack-workspace
+    --exclude khive-channel-telegram
 echo "    SemVer gate OK"
 
 for crate in "${CRATES[@]}"; do


### PR DESCRIPTION
## Problem

`make publish-dry` for the 0.5.0 release failed — **not** a semver break — with `khive-channel-telegram not found in registry (crates.io)`.

`khive-channel-telegram` (added in #1048) is version-depended by `khive-mcp` (`version = "0.5.0"`, optional), so it must publish in the 0.5.0 cycle. It was absent from **both** the CRATES publish list and the `cargo semver-checks` exclude set in `scripts/publish.sh`, so the `--workspace` semver gate failed trying to fetch a baseline for a never-published crate. Its sibling `khive-channel-email` was wired correctly; telegram was missed when #1048 landed.

## Fix

- Add `khive-channel-telegram` to CRATES after `khive-channel-email`, before `khive-mcp` — its only khive dependency (`khive-channel`) is already above it, so live-publish order is correct.
- Narrow the semver-checks excludes to `khive-channel-telegram` only (first publish, no crates.io baseline to diff).
- Drop the four now-published 0.4.0 excludes (`khive-changeset`, `khive-pack-code`, `khive-pack-git`, `khive-pack-workspace`) per the script's own drop-once-published rule — they have 0.4.0 baselines and are checked again this cycle.
- Correct the stale "never published" comments on those entries.

## Verification

`make publish-dry` returns rc=0 from this branch (semver gate passes, all crates package + workspace check clean).

## Follow-up

The root cause is that adding a workspace crate has no guard forcing the `publish.sh` wiring. Filing a separate issue for an in-script guard (fail loud if any publishable workspace member is absent from CRATES) rather than scope-creeping this release-gate fix.
