### PR TITLE
fix(kkernel): cover ingested non-crate projects in default code-audit policy (#1067)

### DIFF
--- a/crates/kkernel/policy/code-audit-khive.toml
+++ b/crates/kkernel/policy/code-audit-khive.toml
@@ -13,7 +13,12 @@
 # `[dependencies]` graph (dev-dependencies excluded — several packs carry
 # deliberate cyclic dev-only test deps, e.g. khive-pack-kg/khive-pack-gtd and
 # khive-pack-brain/khive-pack-memory; production dependencies among them do
-# not cycle). Every directory under `crates/` must appear here.
+# not cycle). Every ingested `project` in the code map must appear here — the
+# Rust crates under `crates/` and every other manifest `code.ingest` resolves
+# (the npm distribution packages, the Python contract/workspace projects).
+# Those non-crate projects form a dependency island disconnected from the Rust
+# crate graph (no cross edges), so their ranks are evaluated in isolation and
+# never interact with the crate ranks above.
 policy_version = 1
 coverage_floor = 0.0
 
@@ -66,3 +71,21 @@ khive-pack-knowledge = 6
 khive-pack-memory = 6
 khive-mcp = 7
 kkernel = 8
+
+# Non-crate projects the workspace also ships and `code.ingest` resolves. The
+# npm distribution graph is a real DAG evaluated in isolation: the six
+# platform-native kernel binaries are leaves, the `khive` npm root bundles them
+# as optional platform deps (rank 1), and `@khive-ai/cli` aliases `khive`
+# (rank 2). `khive-contract` (Python contract-test harness) and
+# `khive-workspace` resolve only external PyPI specifiers, so they are leaves
+# in the project graph (rank 0).
+"@khive-ai/kernel-darwin-arm64" = 0
+"@khive-ai/kernel-darwin-x64" = 0
+"@khive-ai/kernel-linux-arm64" = 0
+"@khive-ai/kernel-linux-x64-gnu" = 0
+"@khive-ai/kernel-linux-x64-musl" = 0
+"@khive-ai/kernel-win32-x64" = 0
+khive = 1
+"@khive-ai/cli" = 2
+khive-contract = 0
+khive-workspace = 0

--- a/crates/kkernel/policy/code-audit-khive.toml
+++ b/crates/kkernel/policy/code-audit-khive.toml
@@ -77,8 +77,9 @@ kkernel = 8
 # platform-native kernel binaries are leaves, the `khive` npm root bundles them
 # as optional platform deps (rank 1), and `@khive-ai/cli` aliases `khive`
 # (rank 2). `khive-contract` (Python contract-test harness) and
-# `khive-workspace` resolve only external PyPI specifiers, so they are leaves
-# in the project graph (rank 0).
+# `khive-workspace` have no in-map project dependencies (their specifiers
+# resolve outside the code map), so they are leaves in the project graph
+# (rank 0).
 "@khive-ai/kernel-darwin-arm64" = 0
 "@khive-ai/kernel-darwin-x64" = 0
 "@khive-ai/kernel-linux-arm64" = 0


### PR DESCRIPTION
## Summary

The default `kkernel code-audit` policy's `crate_ranks` table omitted the 10 non-crate projects that `code.ingest` resolves into the map, so a clean run against the repo's own code map flagged **POLICY_INCOMPLETE** and degraded every layering signal for those 10 to `unavailable` (found by running the shipped audit — #1067).

## What was missing

Exactly 10 `project` entities in the map, none under `crates/`:
- 6 npm platform packages `@khive-ai/kernel-{darwin-arm64,darwin-x64,linux-arm64,linux-x64-gnu,linux-x64-musl,win32-x64}`
- the `khive` npm root and `@khive-ai/cli`
- the Python projects `khive-contract` and `khive-workspace`

Confirmed the missing set is exactly these 10 by diffing all 50 `project` entities in the map against the 40 previously-ranked crates (0 stale ranks, 0 other gaps).

## The ranks are honest, not placeholders

I read the actual `depends_on` edges in the map rather than assigning fake ranks:

- The npm distribution graph is a real DAG: the six platform kernel binaries have no outgoing deps (leaves, **rank 0**); `khive` depends on all six (**rank 1**); `@khive-ai/cli` depends on `khive` (**rank 2**).
- `khive-contract` and `khive-workspace` are Python projects whose dependencies are external PyPI specifiers (pytest, pandas, …) that do not resolve to in-map projects, so they are project-graph leaves (**rank 0**).

These 10 form a dependency island with no edges to the Rust crate graph, so their ranks are evaluated in isolation and never interact with the crate ranks. The header comment is updated accordingly (it previously said "every directory under `crates/` must appear here").

## Verification (before/after against the repo's own map)

Ran `kkernel code-audit` against a copy of the repo's code map with the old and new policy:

| policy | `errors[]` | layering signals `unavailable` |
|---|---|---|
| before | HISTORY_ABSENT, **POLICY_INCOMPLETE** | 10 |
| after | HISTORY_ABSENT | **0** |

- POLICY_INCOMPLETE clears; only the unrelated `HISTORY_ABSENT` phase-1 limitation remains (churn / dead-file / orphan-test signals require history facts the phase-1 map schema does not persist).
- No new layering violation is introduced: `khive → kernel` is 1→0 and `cli → khive` is 2→1, both satisfy `rank(target) ≤ rank(source)`.

## Why no new test

Data-only change to the default policy TOML. The `code_audit.rs` tests use synthetic `[crate_ranks]` fixtures, not this file, so nothing loads the real policy in-test. The living regression guard is the weekly code-audit consumer, which self-reports POLICY_INCOMPLETE on any future gap; #1069 tracks the complementary fail-loud publish-ladder guard.

## Test plan
- [x] `check toml` pre-commit hook passes
- [x] before/after `kkernel code-audit` run against the repo map (table above)

Closes #1067
