### PR TITLE
feat(release): guard publish.sh CRATES ladder against missing publishable members (#1069)

### DIFF
--- a/scripts/lib/publish_guard.sh
+++ b/scripts/lib/publish_guard.sh
@@ -32,9 +32,20 @@ check_crates_ladder() {
     shift
     local -a ladder=("$@")
     local -a missing=()
-    local name found c
+    local name found c members
+
+    # Capture the producer's output AND its exit status explicitly. A process
+    # substitution's exit status is not propagated to a `while` loop, so a
+    # failed parser (invalid/corrupt metadata, missing python3) would yield no
+    # names and let the guard pass silently. A publish preflight must fail
+    # CLOSED when it cannot enumerate members (#1071 review).
+    if ! members=$(publishable_members_from_metadata < "$metadata_path"); then
+        echo "ERROR: could not enumerate publishable workspace members from cargo metadata (parser failed) — refusing to proceed" >&2
+        return 2
+    fi
 
     while IFS= read -r name; do
+        [[ -n "$name" ]] || continue
         found=false
         for c in "${ladder[@]}"; do
             if [[ "$c" == "$name" ]]; then
@@ -43,7 +54,7 @@ check_crates_ladder() {
             fi
         done
         $found || missing+=("$name")
-    done < <(publishable_members_from_metadata < "$metadata_path")
+    done <<< "$members"
 
     if [[ ${#missing[@]} -gt 0 ]]; then
         echo "ERROR: publishable workspace member(s) missing from the CRATES ladder in scripts/publish.sh:" >&2

--- a/scripts/lib/publish_guard.sh
+++ b/scripts/lib/publish_guard.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# Preflight guard (#1069): every publishable cargo workspace member must
+# appear in publish.sh's CRATES ladder. A member is publishable unless its
+# Cargo.toml sets `publish = false`, which `cargo metadata` serializes as
+# an empty `publish` array (null, or a non-empty registry list, means the
+# member is publishable).
+#
+# Scoped to CRATES membership only — the separate cargo-semver-checks
+# `--exclude` list (also in publish.sh) is a different concern and is not
+# guarded here (#1069 out-of-scope).
+#
+# Sourced by scripts/publish.sh and by scripts/tests/publish-guard-test.sh
+# so the check can run against a fixture without a live `cargo metadata`.
+
+# Prints publishable workspace member names (one per line) from a
+# `cargo metadata --no-deps --format-version=1` JSON blob on stdin.
+publishable_members_from_metadata() {
+    python3 -c '
+import sys, json
+pkgs = json.load(sys.stdin)["packages"]
+for p in sorted(pkgs, key=lambda p: p["name"]):
+    if p.get("publish") != []:
+        print(p["name"])
+'
+}
+
+# check_crates_ladder <metadata_json_path> <crate>...
+# Prints and fails (non-zero) if any publishable workspace member found in
+# the metadata file is absent from the given CRATES ladder.
+check_crates_ladder() {
+    local metadata_path="$1"
+    shift
+    local -a ladder=("$@")
+    local -a missing=()
+    local name found c
+
+    while IFS= read -r name; do
+        found=false
+        for c in "${ladder[@]}"; do
+            if [[ "$c" == "$name" ]]; then
+                found=true
+                break
+            fi
+        done
+        $found || missing+=("$name")
+    done < <(publishable_members_from_metadata < "$metadata_path")
+
+    if [[ ${#missing[@]} -gt 0 ]]; then
+        echo "ERROR: publishable workspace member(s) missing from the CRATES ladder in scripts/publish.sh:" >&2
+        printf '  - %s\n' "${missing[@]}" >&2
+        return 1
+    fi
+    return 0
+}

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -39,7 +39,11 @@ else
     echo "=== PREFLIGHT (metadata + tarball file list + workspace check; pass --live to publish for real) ==="
 fi
 
-cd "$(dirname "$0")/../crates"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+# shellcheck source=lib/publish_guard.sh
+source "$SCRIPT_DIR/lib/publish_guard.sh"
+
+cd "$SCRIPT_DIR/../crates"
 
 # Dependency order: each crate only depends on crates above it.
 CRATES=(
@@ -86,6 +90,21 @@ CRATES=(
 )
 
 DELAY=10  # seconds to wait for crates.io index between publishes
+
+# Preflight guard (#1069): fail loud if any publishable workspace member is
+# missing from CRATES. Closes the gap #1068 hit — khive-channel-telegram was
+# added to the workspace but never wired into the publish ladder, invisible
+# until `make publish-dry` failed at the SemVer gate. Runs in preflight and
+# live alike, before any real publish work.
+echo ""
+echo "--- Publish ladder guard (CRATES membership vs cargo metadata) ---"
+METADATA_JSON=$(mktemp)
+trap 'rm -f "$METADATA_JSON"' EXIT
+cargo metadata --no-deps --format-version=1 >"$METADATA_JSON"
+if ! check_crates_ladder "$METADATA_JSON" "${CRATES[@]}"; then
+    exit 1
+fi
+echo "    CRATES ladder OK (${#CRATES[@]} publishable workspace members all present)"
 
 # SemVer gate (ADR-066 §3 release-gate component, relocated from per-PR #216).
 # cargo-semver-checks compares each publishable crate's public API against its

--- a/scripts/tests/publish-guard-test.sh
+++ b/scripts/tests/publish-guard-test.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# Standalone fixture test for scripts/lib/publish_guard.sh (#1069).
+# No network, no live cargo publish — run with:
+#   bash scripts/tests/publish-guard-test.sh
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+# shellcheck source=../lib/publish_guard.sh
+source "$SCRIPT_DIR/lib/publish_guard.sh"
+
+FIXTURE=$(mktemp)
+STDERR_CAPTURE=$(mktemp)
+trap 'rm -f "$FIXTURE" "$STDERR_CAPTURE"' EXIT
+
+cat >"$FIXTURE" <<'JSON'
+{
+  "packages": [
+    {"name": "crate-a", "publish": null},
+    {"name": "crate-b", "publish": ["crates-io"]},
+    {"name": "crate-c", "publish": []}
+  ]
+}
+JSON
+
+echo "--- case 1: complete ladder passes (and publish=false crate-c is not required) ---"
+if check_crates_ladder "$FIXTURE" crate-a crate-b; then
+    echo "PASS"
+else
+    echo "FAIL: complete ladder [crate-a, crate-b] was rejected" >&2
+    exit 1
+fi
+
+echo "--- case 2: ladder missing a publishable crate fires and names it ---"
+if check_crates_ladder "$FIXTURE" crate-a 2>"$STDERR_CAPTURE"; then
+    echo "FAIL: guard did not fire when crate-b was omitted" >&2
+    exit 1
+fi
+if grep -q "crate-b" "$STDERR_CAPTURE"; then
+    echo "PASS"
+else
+    echo "FAIL: guard fired but did not name the missing crate (crate-b)" >&2
+    cat "$STDERR_CAPTURE" >&2
+    exit 1
+fi
+
+echo "--- case 3: publish=false crate never appears as missing, even from an empty ladder ---"
+if check_crates_ladder "$FIXTURE" 2>"$STDERR_CAPTURE"; then
+    echo "FAIL: guard passed with an empty ladder (should have flagged crate-a, crate-b)" >&2
+    exit 1
+fi
+if grep -q "crate-c" "$STDERR_CAPTURE"; then
+    echo "FAIL: publish=false crate-c was falsely flagged as missing" >&2
+    cat "$STDERR_CAPTURE" >&2
+    exit 1
+else
+    echo "PASS"
+fi
+
+echo ""
+echo "=== publish-guard-test: all cases passed ==="

--- a/scripts/tests/publish-guard-test.sh
+++ b/scripts/tests/publish-guard-test.sh
@@ -56,5 +56,22 @@ else
     echo "PASS"
 fi
 
+echo "--- case 4: malformed metadata makes the guard fail CLOSED (non-zero), not silently pass ---"
+BAD_FIXTURE=$(mktemp)
+printf 'this is not valid json\n' >"$BAD_FIXTURE"
+if check_crates_ladder "$BAD_FIXTURE" crate-a crate-b 2>"$STDERR_CAPTURE"; then
+    rm -f "$BAD_FIXTURE"
+    echo "FAIL: guard passed on malformed metadata (fail-open)" >&2
+    exit 1
+fi
+rm -f "$BAD_FIXTURE"
+if grep -qiE "parser failed|could not enumerate" "$STDERR_CAPTURE"; then
+    echo "PASS"
+else
+    echo "FAIL: guard failed on malformed metadata but without a clear parser-failure error" >&2
+    cat "$STDERR_CAPTURE" >&2
+    exit 1
+fi
+
 echo ""
 echo "=== publish-guard-test: all cases passed ==="


### PR DESCRIPTION
## Summary

Adds a preflight guard to `scripts/publish.sh` that fails LOUD if any publishable cargo
workspace member is absent from the `CRATES` publish ladder. This closes the recurring gap
#1068 hit at release time: `khive-channel-telegram` (added in #1048, version-depended by
`khive-mcp`) was never wired into `CRATES`, invisible until `make publish-dry` failed at the
SemVer gate. Any future crate added without ladder wiring now fails immediately, at preflight,
with the missing name printed.

## What it does

- **`scripts/lib/publish_guard.sh`** (new, sourced by publish.sh and the test):
  - `publishable_members_from_metadata` — reads `cargo metadata --no-deps --format-version=1`
    and emits each publishable member. A member is publishable unless its `publish` field is
    `[]` (how cargo serializes `publish = false`); `null` or a non-empty registry list means
    publishable.
  - `check_crates_ladder` — diffs the publishable set against the passed CRATES array; on any
    gap, prints `ERROR: publishable workspace member(s) missing ...` naming each and returns 1.
- **`scripts/publish.sh`** — sources the lib, runs the guard right before the SemVer gate (so
  it fires in both `make publish-dry` and `--live`), aborts non-zero on a gap.
- **`scripts/tests/publish-guard-test.sh`** (new) — standalone fixture test, no network / no
  live cargo: (1) a complete ladder passes and a `publish=false` member is not required; (2) an
  omitted publishable member fires the guard and is named; (3) a `publish=false` member is never
  flagged, even against an empty ladder.

## Acceptance criteria (from #1069)

- **khive-merge is not special-cased.** It is intentionally excluded from the workspace
  (ADR-043 forward-deployed), so `cargo metadata --no-deps` does not list it — confirmed by the
  real-workspace run (39 members, all present) rather than a hardcoded exception.
- **`publish = false` members are legitimately out-of-ladder** — the `!= []` filter handles
  this; fixture case 3 proves such a member is never flagged. (No `publish=false` member exists
  in the workspace today, so the fixture, not a live crate, exercises that path.)
- **Not a flaky blocker** — the guard passes cleanly against the current real workspace, and its
  own fixture test proves it both fires on a gap and passes when the ladder is complete.

## Scope

CRATES *membership* only. The separate `cargo-semver-checks --exclude` list (the other half of
the #1068 miss) is a distinct concern and deliberately out of scope here, noted in the lib
comment. Ordering logic is untouched — the guard checks set membership, not order.

## Gate output

```
publish-guard-test.sh:  case 1 PASS, case 2 PASS, case 3 PASS  (all cases passed)
real workspace:         GUARD PASS — ladder complete (39 crates)
publish.sh in-situ:     "CRATES ladder OK (39 publishable workspace members all present)",
                        proceeds into SemVer gate with no false abort
shellcheck -x:          0 findings, exit 0 on all three files
```

No Rust touched (shell + fixture only), so `cargo fmt`/`clippy` are N/A.

## Note

The lib parses `cargo metadata` with an inline `python3 -c`, matching publish.sh's existing
convention for cargo-metadata parsing (jq is on PATH but is not what this script reaches for).

Closes #1069
