### PR TITLE
ci(deps-review): allow-list sqlite-vec license (SPDX parse artifact)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -318,7 +318,15 @@ jobs:
           # GPL-1.0-or-later — a known false positive for this package. Scope the
           # exception to exactly this purl so the allow-list above is unchanged
           # for everything else.
-          allow-dependencies-licenses: pkg:pypi/typing-extensions
+          #
+          # sqlite-vec is dual-licensed MIT OR Apache-2.0 (both already in the
+          # allow-list above), but dependency-review's SPDX parser cannot parse
+          # its combined license string and tags it LicenseRef-bad-mitapache-2.0.
+          # Our own cargo-deny gate (crates/deny.toml) already accepts it. Once
+          # crates/Cargo.lock is committed (#992), the full cargo tree becomes
+          # visible to dependency-review permanently, so this scoped exemption is
+          # durable infrastructure rather than a temporary workaround.
+          allow-dependencies-licenses: pkg:pypi/typing-extensions, pkg:cargo/sqlite-vec
 
   wasm-parity:
     name: wasm-parity (khive-changeset)


### PR DESCRIPTION
## What

Extend the `dependency-review` allow-list in `.github/workflows/ci.yml` with
`pkg:cargo/sqlite-vec`, mirroring the existing `pkg:pypi/typing-extensions`
exemption.

## Why

GitHub's `dependency-review-action` flags `sqlite-vec` with license
`LicenseRef-bad-mitapache-2.0`. This is a GitHub SPDX-parser artifact:
`sqlite-vec` is dual-licensed `MIT OR Apache-2.0`, and the action's SPDX parser
cannot parse the combined license string, so it emits a synthetic
`LicenseRef-bad-*` identifier. Both `MIT` and `Apache-2.0` are already on the
allow-list.

- **0 vulnerabilities** are reported for `sqlite-vec`. This is purely a
  license-string parse failure, not a security or compliance finding.
- Our own `cargo-deny` gate (`crates/deny.toml`) already accepts `sqlite-vec`,
  so the crate is already vetted by the workspace's authoritative license policy.

Committing `crates/Cargo.lock` (#992) exposes the full cargo tree to
dependency-review permanently, so this allow-list entry is durable
infrastructure, not a workaround.

## Scope

One line in one file. The allow-list gains a single scoped purl; nothing else in
the dependency-review policy changes. This lands on `main` first, then #992's
dependency-review is re-run so it picks up the entry.
