### PR TITLE
test(search): regression guards for unknown-kind error and hyphenated FTS ids (#1061, #1064)

### DIFF
--- a/crates/khive-db/src/stores/text_tests.rs
+++ b/crates/khive-db/src/stores/text_tests.rs
@@ -2258,3 +2258,52 @@ async fn upsert_documents_routes_through_writer_task_when_flag_enabled() {
         "the flag-ON path must actually spawn and use the writer task"
     );
 }
+
+/// #1064 regression: a hyphenated identifier token mixed with plain keyword
+/// terms (`"ADR-086 workspace mirror"`) must still surface the document whose
+/// title/body contains that identifier under the production `trigram`
+/// tokenizer, in both `Plain` and `AnyTerm` mode.
+#[tokio::test]
+async fn test_search_hyphenated_id_with_plain_terms_matches_exact_id() {
+    let store = setup_trigram_store("issue_1064_hyphenated_multiword");
+    let target_id = Uuid::new_v4();
+    store
+        .upsert_document(make_document(
+            target_id,
+            "ADR-086",
+            "ADR-086 workspace mirror amendment document",
+        ))
+        .await
+        .unwrap();
+    let unrelated_id = Uuid::new_v4();
+    store
+        .upsert_document(make_document(
+            unrelated_id,
+            "unrelated",
+            "completely unrelated gardening content",
+        ))
+        .await
+        .unwrap();
+
+    for mode in [TextQueryMode::Plain, TextQueryMode::AnyTerm] {
+        let hits = store
+            .search(TextSearchRequest {
+                query: "ADR-086 workspace mirror".to_string(),
+                mode: mode.clone(),
+                filter: Some(ns_filter("test_ns")),
+                top_k: 10,
+                snippet_chars: 64,
+            })
+            .await
+            .unwrap();
+        let hit_ids: std::collections::HashSet<_> = hits.iter().map(|h| h.subject_id).collect();
+        assert!(
+            hit_ids.contains(&target_id),
+            "#1064 {mode:?} query must match {target_id}, got {hit_ids:?}"
+        );
+        assert!(
+            !hit_ids.contains(&unrelated_id),
+            "#1064 {mode:?} query must not match unrelated doc, got {hit_ids:?}"
+        );
+    }
+}

--- a/crates/khive-pack-kg/tests/integration.rs
+++ b/crates/khive-pack-kg/tests/integration.rs
@@ -11764,3 +11764,81 @@ async fn search_note_emits_exactly_one_search_executed_event_with_note_result_ki
     assert_eq!(event.payload["result_count"], json!(hits.len()));
     assert_search_projection(&rt, &store, event, hits, "note").await;
 }
+
+/// #1061 regression: `search` must reject an unregistered kind the same way
+/// `list` does — a loud `{ok: false, error: "unknown kind ..."}`, never a
+/// silent empty result.
+#[tokio::test]
+async fn search_unregistered_kind_matches_list_error_shape() {
+    let pack = pack();
+    let search_err = pack
+        .dispatch(
+            "search",
+            json!({"kind": "workspace_doc", "query": "anything", "limit": 5}),
+        )
+        .await
+        .unwrap_err();
+    let list_err = pack
+        .dispatch("list", json!({"kind": "workspace_doc", "limit": 3}))
+        .await
+        .unwrap_err();
+
+    assert!(
+        is_invalid_input(&search_err),
+        "#1061 search with unregistered kind must be InvalidInput, got {search_err:?}"
+    );
+    assert_eq!(
+        invalid_input_message(&search_err),
+        invalid_input_message(&list_err),
+        "#1061 search and list must report the identical unknown-kind error"
+    );
+}
+
+/// #1064 regression, full dispatch path: an entity named after a hyphenated
+/// ADR id must be found by a `search(kind="entity", ...)` query that mixes
+/// the hyphenated id with plain keyword terms.
+#[tokio::test]
+async fn search_entity_hyphenated_adr_id_with_plain_terms_matches() {
+    let pack = pack();
+    pack.dispatch(
+        "create",
+        json!({
+            "kind": "entity",
+            "name": "ADR-086",
+            "entity_kind": "document",
+            "description": "workspace mirror amendment document"
+        }),
+    )
+    .await
+    .expect("create must succeed");
+
+    pack.dispatch(
+        "create",
+        json!({
+            "kind": "entity",
+            "name": "unrelated gardening note",
+            "entity_kind": "document",
+            "description": "completely unrelated content"
+        }),
+    )
+    .await
+    .expect("create must succeed");
+
+    let result = pack
+        .dispatch(
+            "search",
+            json!({"kind": "entity", "query": "ADR-086 workspace mirror", "limit": 10}),
+        )
+        .await
+        .expect("search must succeed");
+    let titles: Vec<_> = result
+        .as_array()
+        .unwrap()
+        .iter()
+        .filter_map(|h| h.get("title").and_then(Value::as_str))
+        .collect();
+    assert!(
+        titles.iter().any(|t| t.contains("ADR-086")),
+        "#1064 hyphenated query must surface ADR-086 entity; got titles={titles:?}, full={result}"
+    );
+}


### PR DESCRIPTION
Test-only regression coverage for two filed search-robustness issues, both already resolved on main. These tests pin the behavior against regression.

**#1061** — search rejects an unregistered kind with the same loud InvalidInput error as list (asserts the identical unknown-kind message), never a silent empty result.

**#1064** — a hyphenated identifier mixed with plain keyword terms ("ADR-086 workspace mirror") matches the target document literally rather than treating the hyphen as an FTS5 NOT operator. Covered at the khive-db TextSearch layer (Plain and AnyTerm modes, trigram tokenizer) and end-to-end through the pack-kg search dispatch path.

Verified: all three tests pass on current main (khive-db 1, pack-kg 2). No source change — the fixes already exist; this adds the missing regression guards.

Resolves #1061, #1064.
