### PR TITLE
fix(runtime): stats() aggregates over caller-visible namespaces to match list (#711)

### DIFF
--- a/crates/khive-pack-kg/src/handlers/stats.rs
+++ b/crates/khive-pack-kg/src/handlers/stats.rs
@@ -10,6 +10,15 @@ use super::common::{deser, StatsParams};
 use crate::KgPack;
 
 impl KgPack {
+    /// Aggregate KG substrate counts (entities, edges, notes).
+    ///
+    /// Scope contract: every total here is summed across the caller's
+    /// full *visible-namespace* set (`token.visible_namespaces()`), the same
+    /// scope `list(kind=...)` merges pages over — not just `token.namespace()`.
+    /// This keeps `stats()` reconcilable with a full `list` keyset walk under
+    /// the same identity: `edges_by_relation` sums to `edges`, and each
+    /// scalar equals the count of a full multi-namespace `list` walk, for
+    /// entities, edges, and notes alike (#711).
     pub(crate) async fn handle_stats(
         &self,
         token: &NamespaceToken,
@@ -22,12 +31,7 @@ impl KgPack {
             .count_edges(token, EdgeListFilter::default())
             .await?;
         let edges_by_relation = self.runtime.count_edges_by_relation(token).await?;
-        let notes = self
-            .runtime
-            .notes(token)?
-            .count_notes(token.namespace().as_str(), None)
-            .await
-            .map_err(RuntimeError::Storage)?;
+        let notes = self.runtime.count_notes(token, None).await?;
         Ok(serde_json::json!({
             "entities": entities,
             "edges": edges,

--- a/crates/khive-runtime/src/operations.rs
+++ b/crates/khive-runtime/src/operations.rs
@@ -2999,6 +2999,25 @@ impl KhiveRuntime {
         Ok(page.items)
     }
 
+    /// Count notes matching `kind`, summed across the caller's visible
+    /// namespaces. The store-layer `count_notes` is namespace-pinned by
+    /// design (no `NamespaceFilter`-style `IN (...)` support); this sums the
+    /// per-namespace store calls, mirroring [`Self::count_edges_by_relation`]
+    /// and the multi-namespace path in [`Self::list_notes`] so `stats().notes`
+    /// reconciles with a full `list` keyset walk under the same token.
+    pub async fn count_notes(
+        &self,
+        token: &NamespaceToken,
+        kind: Option<&str>,
+    ) -> RuntimeResult<u64> {
+        let mut total = 0u64;
+        for ns in token.visible_namespaces() {
+            let temp = NamespaceToken::for_namespace(ns.clone());
+            total += self.notes(&temp)?.count_notes(ns.as_str(), kind).await?;
+        }
+        Ok(total)
+    }
+
     /// Search notes using a hybrid FTS5 + vector pipeline with salience weighting.
     ///
     /// Pipeline:
@@ -3976,11 +3995,17 @@ impl KhiveRuntime {
         token: &NamespaceToken,
         kind: Option<&str>,
     ) -> RuntimeResult<u64> {
+        let ns_strs: Vec<String> = token
+            .visible_namespaces()
+            .iter()
+            .map(|ns| ns.as_str().to_owned())
+            .collect();
         let filter = EntityFilter {
             kinds: match kind {
                 Some(k) => vec![k.to_string()],
                 None => vec![],
             },
+            namespaces: ns_strs,
             ..Default::default()
         };
         Ok(self
@@ -4596,13 +4621,24 @@ impl KhiveRuntime {
         Ok(deleted)
     }
 
-    /// Count edges matching `filter`.
+    /// Count edges matching `filter`, summed across the caller's visible
+    /// namespaces (mirrors [`Self::count_edges_by_relation`] and
+    /// [`Self::list_edges`] so `stats().edges` reconciles with a full `list`
+    /// keyset walk under the same token).
     pub async fn count_edges(
         &self,
         token: &NamespaceToken,
         filter: crate::curation::EdgeListFilter,
     ) -> RuntimeResult<u64> {
-        Ok(self.graph(token)?.count_edges(filter.into()).await?)
+        let mut total = 0u64;
+        for ns in token.visible_namespaces() {
+            let temp = NamespaceToken::for_namespace(ns.clone());
+            total += self
+                .graph(&temp)?
+                .count_edges(filter.clone().into())
+                .await?;
+        }
+        Ok(total)
     }
 
     /// Validate and construct an edge from a [`LinkSpec`] without writing to storage.

--- a/crates/khive-runtime/tests/integration.rs
+++ b/crates/khive-runtime/tests/integration.rs
@@ -3012,3 +3012,117 @@ async fn delete_edge_cross_namespace_audit_uses_record_namespace_hard() {
         "EdgeDeleted payload.namespace must be the record's namespace (ns-owner-hard)"
     );
 }
+
+// =============================================================================
+// #711: stats() must aggregate over the caller's visible namespaces, matching
+// the scope a full `list` keyset walk computes over — not just token.namespace().
+// =============================================================================
+
+/// `count_entities` / `count_edges` / `count_edges_by_relation` / `count_notes`
+/// must all sum across an identity-bearing caller's visible-namespace set, so
+/// `stats()` totals reconcile with a full multi-namespace `list` walk, for
+/// entities, edges, and notes alike.
+#[tokio::test]
+async fn stats_totals_match_list_walk_across_visible_namespaces() {
+    use khive_runtime::EdgeListFilter;
+
+    // Identity-bearing caller: actor_id configured (not anonymous).
+    let rt = KhiveRuntime::new(RuntimeConfig {
+        db_path: None,
+        packs: vec!["kg".to_string()],
+        brain_profile: None,
+        actor_id: Some("lambda:stats-711-test".to_string()),
+        ..RuntimeConfig::no_embeddings()
+    })
+    .expect("in-memory runtime with actor identity");
+
+    let ns_a = Namespace::parse("stats-711-a").unwrap();
+    let ns_b = Namespace::parse("stats-711-b").unwrap();
+    let tok_a = rt.authorize(ns_a.clone()).unwrap();
+    let tok_b = rt.authorize(ns_b.clone()).unwrap();
+
+    // Entities: 2 in ns_a, 2 in ns_b (b2 created below, alongside the edges).
+    let a1 = rt
+        .create_entity(&tok_a, "concept", None, "StatsA1", None, None, vec![])
+        .await
+        .unwrap();
+    let a2 = rt
+        .create_entity(&tok_a, "concept", None, "StatsA2", None, None, vec![])
+        .await
+        .unwrap();
+    let b1 = rt
+        .create_entity(&tok_b, "concept", None, "StatsB1", None, None, vec![])
+        .await
+        .unwrap();
+
+    // Edges: two `extends` in ns_a, one `enables` in ns_b.
+    rt.link(&tok_a, a1.id, a2.id, EdgeRelation::Extends, 1.0, None)
+        .await
+        .unwrap();
+    rt.link(&tok_a, a2.id, a1.id, EdgeRelation::Extends, 1.0, None)
+        .await
+        .unwrap();
+    let b2 = rt
+        .create_entity(&tok_b, "concept", None, "StatsB2", None, None, vec![])
+        .await
+        .unwrap();
+    rt.link(&tok_b, b1.id, b2.id, EdgeRelation::Enables, 1.0, None)
+        .await
+        .unwrap();
+
+    // Notes: one in each namespace.
+    rt.create_note(&tok_a, "observation", None, "NoteInA", None, None, vec![])
+        .await
+        .unwrap();
+    rt.create_note(&tok_b, "observation", None, "NoteInB", None, None, vec![])
+        .await
+        .unwrap();
+
+    // Identity-bearing frame whose visible set spans both namespaces.
+    let vis_tok = rt
+        .authorize_with_visibility(ns_a.clone(), vec![ns_b.clone()])
+        .unwrap();
+
+    let full_entities = rt
+        .list_entities(&vis_tok, None, None, 500, 0)
+        .await
+        .unwrap();
+    let stats_entities = rt.count_entities(&vis_tok, None).await.unwrap();
+    assert_eq!(
+        stats_entities,
+        full_entities.len() as u64,
+        "stats() entity total must equal a full list keyset walk under the same identity"
+    );
+    assert_eq!(stats_entities, 4);
+
+    let full_edges = rt
+        .list_edges(&vis_tok, EdgeListFilter::default(), 1000, 0)
+        .await
+        .unwrap();
+    let stats_edges = rt
+        .count_edges(&vis_tok, EdgeListFilter::default())
+        .await
+        .unwrap();
+    assert_eq!(
+        stats_edges,
+        full_edges.len() as u64,
+        "stats() edge total must equal a full list keyset walk under the same identity"
+    );
+    assert_eq!(stats_edges, 3);
+
+    let edges_by_relation = rt.count_edges_by_relation(&vis_tok).await.unwrap();
+    let relation_sum: u64 = edges_by_relation.values().sum();
+    assert_eq!(
+        relation_sum, stats_edges,
+        "edges_by_relation must sum to the edges scalar under all identities"
+    );
+
+    let full_notes = rt.list_notes(&vis_tok, None, 200, 0).await.unwrap();
+    let stats_notes = rt.count_notes(&vis_tok, None).await.unwrap();
+    assert_eq!(
+        stats_notes,
+        full_notes.len() as u64,
+        "stats() note total must equal a full list keyset walk under the same identity"
+    );
+    assert_eq!(stats_notes, 2);
+}


### PR DESCRIPTION
Fixes #711.

## Problem

For an identity-bearing caller whose visible-namespace set extends beyond `local`, `stats()` and a full `list` keyset walk could not be reconciled: `list(kind="edge")` merges edges across the caller's frame-visible namespaces, while `stats()` (and `edges_by_relation`) pinned `WHERE namespace = ?1` — a single namespace. The two verbs computed over different scopes.

## Fix (Option 1 in the issue)

`stats()` now aggregates over the caller's visible namespaces, consistent with `list`. The store-layer count functions stay namespace-pinned by design; the aggregation is done at the runtime layer over `token.visible_namespaces()`, mirroring how `list` merges pages:

- `crates/khive-runtime/src/operations.rs`: added a `count_notes` runtime function and reworked `count_entities`/`count_edges` (and `edges_by_relation`) to sum across the visible set.
- `crates/khive-pack-kg/src/handlers/stats.rs`: wired the handler to the visible-namespace-aware counts.

The scalar totals and `edges_by_relation` now share one scope; the fix covers entities, edges, and notes per the acceptance criteria.

## Test

`stats_totals_match_list_walk_across_visible_namespaces` (`crates/khive-runtime/tests/integration.rs`): with two namespaces and an identity-bearing frame, asserts `stats()` totals equal a full `list` keyset-walk count for entities, edges, and notes, and that `edges_by_relation` sums to the `edges` scalar.

## Gates

`cargo test -p khive-runtime`: 70 passed, 0 failed. `cargo clippy -p khive-runtime -p khive-pack-kg --all-targets -- -D warnings`: clean. `cargo fmt --all -- --check`: clean.

Clean-room implementation from the issue spec (no prior partial patch reused).
