### PR TITLE
fix(db): correct legacy-snapshot purge predicate for the retained ADR-062 key

### DIFF
--- a/crates/kkernel/src/reindex.rs
+++ b/crates/kkernel/src/reindex.rs
@@ -843,8 +843,8 @@ async fn invalidate_vamana_snapshots(rt: &KhiveRuntime, namespace: &str) -> anyh
 
 /// Remove per-namespace memory Vamana snapshot rows (legacy `{ns}::memory_vamana::*` format).
 /// After FTS+ANN consolidation the active, retained key is `global::memory_vamana::{model}`
-/// (ADR-062, corrected by ADR-116); old per-ns rows are orphaned. Best-effort — missing table
-/// or SQL failure is logged and ignored.
+/// (ADR-062, corrected by ADR-116 (PR #1080)); old per-ns rows are orphaned. Best-effort —
+/// missing table or SQL failure is logged and ignored.
 async fn purge_stale_memory_vamana_snapshots(rt: &KhiveRuntime) {
     use khive_storage::types::SqlStatement;
     let sql = rt.sql();
@@ -857,12 +857,16 @@ async fn purge_stale_memory_vamana_snapshots(rt: &KhiveRuntime) {
             // `ann::snapshot_key` (`"global::memory_vamana::{model}"`), not a bare
             // namespace — `namespace != 'global'` never matches that literal string and
             // so purged every memory_vamana row unconditionally, including current,
-            // still-valid `global::memory_vamana::*` snapshots (ADR-116 condition 4).
-            // Match the retained key's prefix instead, mirroring
-            // `invalidate_active_memory_vamana_snapshot`'s LIKE pattern below.
+            // still-valid `global::memory_vamana::*` snapshots (ADR-116 (PR #1080)
+            // condition 4). Match the retained key's prefix instead, mirroring
+            // `invalidate_active_memory_vamana_snapshot`'s LIKE pattern below — but with
+            // GLOB, not LIKE: SQLite's LIKE is ASCII case-insensitive, so a legacy
+            // `GLOBAL::memory_vamana::*` row (a valid namespace per namespace validation)
+            // would otherwise be treated as the retained lowercase key and never purged.
+            // GLOB is case-sensitive (uses `*`/`?` globbing, not `%`/`_`).
             sql: "DELETE FROM retrieval_snapshots \
                   WHERE index_type = 'memory_vamana' \
-                    AND namespace NOT LIKE 'global::memory_vamana::%'"
+                    AND namespace NOT GLOB 'global::memory_vamana::*'"
                 .into(),
             params: vec![],
             label: Some("purge_stale_memory_vamana_snapshots".into()),
@@ -1467,7 +1471,7 @@ mod tests {
         );
     }
 
-    /// Regression test (ADR-116 condition 4): `purge_stale_memory_vamana_snapshots` must
+    /// Regression test (ADR-116 (PR #1080) condition 4): `purge_stale_memory_vamana_snapshots` must
     /// keep the current, retained `global::memory_vamana::{model}` key (ADR-062) and purge
     /// only legacy per-namespace `{ns}::memory_vamana::*` rows. The prior predicate
     /// (`namespace != 'global'`) matched every row unconditionally, since the namespace
@@ -1548,6 +1552,80 @@ mod tests {
         assert!(
             remaining.contains(&"local::vamana::model-a".to_string()),
             "unrelated knowledge Vamana rows must survive: {remaining:?}"
+        );
+    }
+
+    /// Regression test (PR #1081 review): SQLite `LIKE` is ASCII case-insensitive, so
+    /// `NOT LIKE 'global::memory_vamana::%'` treated a legacy `GLOBAL::memory_vamana::*`
+    /// row (a valid namespace per namespace validation) as the retained lowercase key and
+    /// never purged it. `GLOB` is case-sensitive and must tell the two apart.
+    #[tokio::test]
+    async fn test_purge_stale_memory_vamana_snapshots_is_case_sensitive() {
+        let rt = KhiveRuntime::memory().expect("in-memory runtime");
+        let sql = rt.sql();
+
+        let mut w = sql.writer().await.expect("writer");
+        w.execute_script(
+            "CREATE TABLE IF NOT EXISTS retrieval_snapshots (\
+             namespace TEXT NOT NULL, \
+             index_type TEXT NOT NULL, \
+             snapshot BLOB NOT NULL, \
+             created_at INTEGER NOT NULL, \
+             PRIMARY KEY (namespace, index_type));"
+                .into(),
+        )
+        .await
+        .expect("create table");
+
+        for (ns, idx_type) in &[
+            ("global::memory_vamana::model-a", "memory_vamana"),
+            ("GLOBAL::memory_vamana::model-a", "memory_vamana"),
+        ] {
+            w.execute(SqlStatement {
+                sql: "INSERT INTO retrieval_snapshots \
+                      (namespace, index_type, snapshot, created_at) \
+                      VALUES (?1, ?2, ?3, 0)"
+                    .into(),
+                params: vec![
+                    SqlValue::Text(ns.to_string()),
+                    SqlValue::Text(idx_type.to_string()),
+                    SqlValue::Blob(b"{}".to_vec()),
+                ],
+                label: None,
+            })
+            .await
+            .expect("insert row");
+        }
+        drop(w);
+
+        purge_stale_memory_vamana_snapshots(&rt).await;
+
+        let mut r = sql.reader().await.expect("reader");
+        let rows = r
+            .query_all(SqlStatement {
+                sql: "SELECT namespace FROM retrieval_snapshots ORDER BY namespace".into(),
+                params: vec![],
+                label: None,
+            })
+            .await
+            .expect("query");
+
+        let remaining: Vec<String> = rows
+            .iter()
+            .filter_map(|row| match row.get("namespace") {
+                Some(SqlValue::Text(s)) => Some(s.clone()),
+                _ => None,
+            })
+            .collect();
+
+        assert!(
+            remaining.contains(&"global::memory_vamana::model-a".to_string()),
+            "current-key lowercase global memory Vamana snapshot must be retained: {remaining:?}"
+        );
+        assert!(
+            !remaining.contains(&"GLOBAL::memory_vamana::model-a".to_string()),
+            "legacy uppercase GLOBAL::memory_vamana snapshot must be purged, not mistaken for \
+             the retained lowercase key: {remaining:?}"
         );
     }
 

--- a/crates/kkernel/src/reindex.rs
+++ b/crates/kkernel/src/reindex.rs
@@ -842,8 +842,9 @@ async fn invalidate_vamana_snapshots(rt: &KhiveRuntime, namespace: &str) -> anyh
 }
 
 /// Remove per-namespace memory Vamana snapshot rows (legacy `{ns}::memory_vamana::*` format).
-/// After FTS+ANN consolidation the active key is `global::memory_vamana::*`; old per-ns rows
-/// are orphaned. Best-effort — missing table or SQL failure is logged and ignored.
+/// After FTS+ANN consolidation the active, retained key is `global::memory_vamana::{model}`
+/// (ADR-062, corrected by ADR-116); old per-ns rows are orphaned. Best-effort — missing table
+/// or SQL failure is logged and ignored.
 async fn purge_stale_memory_vamana_snapshots(rt: &KhiveRuntime) {
     use khive_storage::types::SqlStatement;
     let sql = rt.sql();
@@ -852,8 +853,16 @@ async fn purge_stale_memory_vamana_snapshots(rt: &KhiveRuntime) {
     };
     match writer
         .execute(SqlStatement {
+            // `retrieval_snapshots.namespace` holds the FULL composite key produced by
+            // `ann::snapshot_key` (`"global::memory_vamana::{model}"`), not a bare
+            // namespace — `namespace != 'global'` never matches that literal string and
+            // so purged every memory_vamana row unconditionally, including current,
+            // still-valid `global::memory_vamana::*` snapshots (ADR-116 condition 4).
+            // Match the retained key's prefix instead, mirroring
+            // `invalidate_active_memory_vamana_snapshot`'s LIKE pattern below.
             sql: "DELETE FROM retrieval_snapshots \
-                  WHERE index_type = 'memory_vamana' AND namespace != 'global'"
+                  WHERE index_type = 'memory_vamana' \
+                    AND namespace NOT LIKE 'global::memory_vamana::%'"
                 .into(),
             params: vec![],
             label: Some("purge_stale_memory_vamana_snapshots".into()),
@@ -1455,6 +1464,90 @@ mod tests {
             remaining.contains(&"local::memory_vamana::model-a".to_string()),
             "legacy per-namespace memory Vamana rows are purge_stale_memory_vamana_snapshots's \
              job, not this function's: {remaining:?}"
+        );
+    }
+
+    /// Regression test (ADR-116 condition 4): `purge_stale_memory_vamana_snapshots` must
+    /// keep the current, retained `global::memory_vamana::{model}` key (ADR-062) and purge
+    /// only legacy per-namespace `{ns}::memory_vamana::*` rows. The prior predicate
+    /// (`namespace != 'global'`) matched every row unconditionally, since the namespace
+    /// column stores the full composite key and is never the bare string `'global'`.
+    #[tokio::test]
+    async fn test_purge_stale_memory_vamana_snapshots_keeps_current_key() {
+        let rt = KhiveRuntime::memory().expect("in-memory runtime");
+        let sql = rt.sql();
+
+        let mut w = sql.writer().await.expect("writer");
+        w.execute_script(
+            "CREATE TABLE IF NOT EXISTS retrieval_snapshots (\
+             namespace TEXT NOT NULL, \
+             index_type TEXT NOT NULL, \
+             snapshot BLOB NOT NULL, \
+             created_at INTEGER NOT NULL, \
+             PRIMARY KEY (namespace, index_type));"
+                .into(),
+        )
+        .await
+        .expect("create table");
+
+        for (ns, idx_type) in &[
+            ("global::memory_vamana::model-a", "memory_vamana"),
+            ("local::memory_vamana::model-a", "memory_vamana"),
+            ("tenant-a::memory_vamana::model-b", "memory_vamana"),
+            ("local::vamana::model-a", "vamana"),
+        ] {
+            w.execute(SqlStatement {
+                sql: "INSERT INTO retrieval_snapshots \
+                      (namespace, index_type, snapshot, created_at) \
+                      VALUES (?1, ?2, ?3, 0)"
+                    .into(),
+                params: vec![
+                    SqlValue::Text(ns.to_string()),
+                    SqlValue::Text(idx_type.to_string()),
+                    SqlValue::Blob(b"{}".to_vec()),
+                ],
+                label: None,
+            })
+            .await
+            .expect("insert row");
+        }
+        drop(w);
+
+        purge_stale_memory_vamana_snapshots(&rt).await;
+
+        let mut r = sql.reader().await.expect("reader");
+        let rows = r
+            .query_all(SqlStatement {
+                sql: "SELECT namespace FROM retrieval_snapshots ORDER BY namespace".into(),
+                params: vec![],
+                label: None,
+            })
+            .await
+            .expect("query");
+
+        let remaining: Vec<String> = rows
+            .iter()
+            .filter_map(|row| match row.get("namespace") {
+                Some(SqlValue::Text(s)) => Some(s.clone()),
+                _ => None,
+            })
+            .collect();
+
+        assert!(
+            remaining.contains(&"global::memory_vamana::model-a".to_string()),
+            "current-key global memory Vamana snapshot must be retained: {remaining:?}"
+        );
+        assert!(
+            !remaining.contains(&"local::memory_vamana::model-a".to_string()),
+            "legacy per-namespace memory Vamana snapshot must be purged: {remaining:?}"
+        );
+        assert!(
+            !remaining.contains(&"tenant-a::memory_vamana::model-b".to_string()),
+            "legacy per-namespace memory Vamana snapshot must be purged: {remaining:?}"
+        );
+        assert!(
+            remaining.contains(&"local::vamana::model-a".to_string()),
+            "unrelated knowledge Vamana rows must survive: {remaining:?}"
         );
     }
 


### PR DESCRIPTION
## Summary

`purge_stale_memory_vamana_snapshots` (`crates/kkernel/src/reindex.rs`) is meant to delete legacy
per-namespace memory Vamana snapshot rows (`{ns}::memory_vamana::*`, pre ADR-062 FTS/ANN
consolidation) while keeping the current, retained key (`global::memory_vamana::{model}`).

Its predicate was `WHERE index_type = 'memory_vamana' AND namespace != 'global'`. The
`retrieval_snapshots.namespace` column stores the **full composite key**
(`global::memory_vamana::{model}`), never the bare string `global` — the same gotcha already
documented on the neighboring `invalidate_active_memory_vamana_snapshot` function. So
`namespace != 'global'` was true for every row, including current, still-valid
`global::memory_vamana::*` snapshots, and the function purged all memory_vamana snapshots
unconditionally instead of only legacy ones.

Fixed to match the retained key's prefix (`namespace NOT LIKE 'global::memory_vamana::%'`),
mirroring the LIKE pattern already used by `invalidate_active_memory_vamana_snapshot` in the
same file.

This is the corrected legacy-snapshot purge predicate called out in ADR-116 (docs PR #1080,
binding condition 4) — it ships independently of the rest of that ADR, which is otherwise
docs-only and unmerged.

## Test plan

- [x] `cargo check -p kkernel`
- [x] `cargo test -p kkernel` (262 lib tests + integration suites, 0 failures) — includes a new
      regression test, `test_purge_stale_memory_vamana_snapshots_keeps_current_key`, pinning
      that a current-key row survives and legacy per-namespace rows are purged
- [x] `cargo clippy -p kkernel --all-targets -- -D warnings`
- [x] `cargo fmt --all -- --check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)