### PR TITLE
fix(db): unify note writers onto a true UPSERT (ADR-116 prereq)

### DIFF
--- a/crates/khive-db/src/stores/note.rs
+++ b/crates/khive-db/src/stores/note.rs
@@ -32,18 +32,42 @@ fn map_sqlite_err(e: SqliteError, op: &'static str) -> StorageError {
 // and ADR-099's atomic prepare path (`khive-runtime`) both call these.
 // ---------------------------------------------------------------------------
 
-/// The exact `INSERT OR REPLACE` this store's `upsert_note` issues.
+/// The single true UPSERT every note writer (single, batch, and note-merge)
+/// issues against `notes` (ADR-116 memory-ANN-generation-coherence prereq).
+///
+/// `INSERT OR REPLACE` is a SQLite DELETE-then-INSERT on a conflicting `id`:
+/// it fires DELETE-path triggers (spuriously invalidating ANN generation
+/// state once ADR-116's liveness triggers land) and discards the row's
+/// original `created_at`/rowid identity. This form updates in place on a
+/// primary-key conflict instead. `created_at` is deliberately absent from
+/// the `DO UPDATE SET` list — it is bound for the INSERT branch only and
+/// left untouched by the UPDATE branch, so an existing row keeps its
+/// original `created_at` across any number of upserts.
+pub const NOTE_UPSERT_SQL: &str = "INSERT INTO notes \
+     (id, namespace, kind, status, name, content, salience, decay_factor, expires_at, \
+      properties, created_at, updated_at, deleted_at) \
+     VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13) \
+     ON CONFLICT(id) DO UPDATE SET \
+       namespace = excluded.namespace, \
+       kind = excluded.kind, \
+       status = excluded.status, \
+       name = excluded.name, \
+       content = excluded.content, \
+       salience = excluded.salience, \
+       decay_factor = excluded.decay_factor, \
+       expires_at = excluded.expires_at, \
+       properties = excluded.properties, \
+       updated_at = excluded.updated_at, \
+       deleted_at = excluded.deleted_at";
+
+/// The exact true UPSERT this store's `upsert_note` issues.
 pub fn note_upsert_statement(note: &Note) -> SqlStatement {
     let properties_str = note
         .properties
         .as_ref()
         .map(|v| serde_json::to_string(v).unwrap_or_default());
     SqlStatement {
-        sql: "INSERT OR REPLACE INTO notes \
-              (id, namespace, kind, status, name, content, salience, decay_factor, expires_at, \
-               properties, created_at, updated_at, deleted_at) \
-              VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13)"
-            .to_string(),
+        sql: NOTE_UPSERT_SQL.to_string(),
         params: vec![
             SqlValue::Text(note.id.to_string()),
             SqlValue::Text(note.namespace.clone()),
@@ -374,10 +398,7 @@ fn batch_upsert_notes(
             .map(|v| serde_json::to_string(v).unwrap_or_default());
 
         match conn.execute(
-            "INSERT OR REPLACE INTO notes \
-             (id, namespace, kind, status, name, content, salience, decay_factor, expires_at, \
-              properties, created_at, updated_at, deleted_at) \
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13)",
+            NOTE_UPSERT_SQL,
             rusqlite::params![
                 id_str,
                 &note.namespace,
@@ -417,10 +438,9 @@ fn batch_upsert_notes(
 
 /// Assign a note id its durable, non-reusing sequence number the first time
 /// it is inserted (khive #827 — see `sql/007-notes-seq.sql`). `INSERT OR
-/// IGNORE` makes this idempotent across an `INSERT OR REPLACE`
-/// delete+reinsert of the same note id: the sequence value is fixed at the
-/// note's first insert and never reassigned, unlike `notes`' own implicit
-/// rowid.
+/// IGNORE` makes this idempotent across repeated upserts of the same note
+/// id: the sequence value is fixed at the note's first insert and never
+/// reassigned, unlike `notes`' own implicit rowid.
 fn assign_note_seq(conn: &rusqlite::Connection, note_id: &str) -> Result<(), rusqlite::Error> {
     conn.execute(
         "INSERT OR IGNORE INTO notes_seq (note_id) VALUES (?1)",

--- a/crates/khive-db/src/stores/note.rs
+++ b/crates/khive-db/src/stores/note.rs
@@ -388,6 +388,12 @@ fn batch_upsert_notes(
     let mut failed = 0u64;
     let mut first_error = String::new();
 
+    // Prepare the UPSERT once for the whole batch — `Connection::execute`
+    // re-parses and re-plans the statement on every call, which dominates
+    // wall time at conflict-heavy batch sizes (measured 536ms vs 260ms at
+    // 50k conflicts; see PR #1082 review).
+    let mut stmt = conn.prepare_cached(NOTE_UPSERT_SQL)?;
+
     for note in notes {
         let id_str = note.id.to_string();
         let kind_str = note.kind.to_string();
@@ -397,24 +403,21 @@ fn batch_upsert_notes(
             .as_ref()
             .map(|v| serde_json::to_string(v).unwrap_or_default());
 
-        match conn.execute(
-            NOTE_UPSERT_SQL,
-            rusqlite::params![
-                id_str,
-                &note.namespace,
-                kind_str,
-                status_str,
-                &note.name,
-                note.content,
-                note.salience,
-                note.decay_factor,
-                note.expires_at,
-                properties_str,
-                note.created_at,
-                note.updated_at,
-                note.deleted_at,
-            ],
-        ) {
+        match stmt.execute(rusqlite::params![
+            id_str,
+            &note.namespace,
+            kind_str,
+            status_str,
+            &note.name,
+            note.content,
+            note.salience,
+            note.decay_factor,
+            note.expires_at,
+            properties_str,
+            note.created_at,
+            note.updated_at,
+            note.deleted_at,
+        ]) {
             Ok(_) => {
                 assign_note_seq(conn, &id_str)?;
                 affected += 1;
@@ -638,7 +641,7 @@ impl NoteStore for SqlNoteStore {
         let id_str = note.id.to_string();
         let statement = note_upsert_statement(&note);
         self.with_writer_tx("upsert_note", move |conn| {
-            let mut stmt = conn.prepare(&statement.sql)?;
+            let mut stmt = conn.prepare_cached(&statement.sql)?;
             bind_params(&mut stmt, &statement.params)?;
             stmt.raw_execute()?;
             assign_note_seq(conn, &id_str)?;

--- a/crates/khive-db/src/stores/note_tests.rs
+++ b/crates/khive-db/src/stores/note_tests.rs
@@ -431,6 +431,93 @@ async fn test_upsert_note_insert_and_seq_assignment_are_atomic() {
     );
 }
 
+/// ADR-116 prerequisite: `upsert_note` must be a true UPSERT (`INSERT ...
+/// ON CONFLICT(id) DO UPDATE`), not `INSERT OR REPLACE` — the latter is a
+/// SQLite DELETE-then-INSERT that would spuriously fire ANN-generation
+/// DELETE triggers and discard the row's original `created_at`. This
+/// installs a stand-in DELETE trigger (the shape ADR-116 lands on `notes`)
+/// to prove upserting an existing row never fires it, while a real delete
+/// still does — confirming the probe itself is live.
+#[tokio::test]
+async fn test_upsert_note_is_true_upsert_no_delete_semantics() {
+    let store = setup_memory_store();
+    {
+        let writer = store.pool.try_writer().unwrap();
+        writer
+            .conn()
+            .execute_batch(
+                "CREATE TABLE delete_fires (n INTEGER);
+                 CREATE TRIGGER notes_delete_probe AFTER DELETE ON notes \
+                 BEGIN INSERT INTO delete_fires VALUES (1); END;",
+            )
+            .unwrap();
+    }
+
+    let mut note = make_note("default", "observation", "v1");
+    let id = note.id;
+    let original_created_at = note.created_at;
+
+    store.upsert_note(note.clone()).await.unwrap();
+
+    // Re-upsert the same id with mutated fields and a later created_at, as a
+    // careless caller might pass — the store must still preserve the original.
+    note.content = "v2".to_string();
+    note.salience = Some(0.9);
+    note.updated_at += 1_000;
+    note.created_at += 1_000;
+    store.upsert_note(note).await.unwrap();
+
+    let fetched = store.get_note(id).await.unwrap().unwrap();
+    assert_eq!(
+        fetched.content, "v2",
+        "mutable fields must reflect the second upsert"
+    );
+    assert_eq!(fetched.salience, Some(0.9));
+    assert_eq!(
+        fetched.created_at, original_created_at,
+        "created_at must be preserved across an upsert of an existing row"
+    );
+
+    let (row_count, delete_fires): (i64, i64) = {
+        let writer = store.pool.try_writer().unwrap();
+        let conn = writer.conn();
+        let row_count: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM notes WHERE id = ?1",
+                rusqlite::params![id.to_string()],
+                |row| row.get(0),
+            )
+            .unwrap();
+        let delete_fires: i64 = conn
+            .query_row("SELECT COUNT(*) FROM delete_fires", [], |row| row.get(0))
+            .unwrap();
+        (row_count, delete_fires)
+    };
+    assert_eq!(
+        row_count, 1,
+        "upsert must update in place, never duplicate rows"
+    );
+    assert_eq!(
+        delete_fires, 0,
+        "upserting an existing row must not fire DELETE-path triggers"
+    );
+
+    // Sanity: a real delete does fire the probe, proving it would have
+    // caught the old INSERT OR REPLACE delete+insert behavior.
+    store.delete_note(id, DeleteMode::Hard).await.unwrap();
+    let delete_fires_after: i64 = {
+        let writer = store.pool.try_writer().unwrap();
+        writer
+            .conn()
+            .query_row("SELECT COUNT(*) FROM delete_fires", [], |row| row.get(0))
+            .unwrap()
+    };
+    assert_eq!(
+        delete_fires_after, 1,
+        "the probe trigger must fire on a genuine delete"
+    );
+}
+
 /// Same regression as `test_upsert_note_insert_and_seq_assignment_are_atomic`
 /// for `try_insert_note`'s flag-off path.
 #[tokio::test]

--- a/crates/khive-db/src/stores/note_tests.rs
+++ b/crates/khive-db/src/stores/note_tests.rs
@@ -446,7 +446,13 @@ async fn test_upsert_note_is_true_upsert_no_delete_semantics() {
         writer
             .conn()
             .execute_batch(
-                "CREATE TABLE delete_fires (n INTEGER);
+                // `recursive_triggers` defaults OFF, under which SQLite does
+                // NOT fire AFTER DELETE triggers for the delete half of an
+                // `INSERT OR REPLACE` conflict resolution — so without this
+                // pragma the probe below would read 0 even on the old
+                // INSERT-OR-REPLACE path, and the test would prove nothing.
+                "PRAGMA recursive_triggers = ON;
+                 CREATE TABLE delete_fires (n INTEGER);
                  CREATE TRIGGER notes_delete_probe AFTER DELETE ON notes \
                  BEGIN INSERT INTO delete_fires VALUES (1); END;",
             )

--- a/crates/khive-pack-memory/tests/integration.rs
+++ b/crates/khive-pack-memory/tests/integration.rs
@@ -5,6 +5,7 @@ use khive_pack_memory::MemoryPack;
 use khive_runtime::{
     EmbedderProvider, FusionStrategy, KhiveRuntime, Namespace, RuntimeConfig, VerbRegistryBuilder,
 };
+use khive_storage::{SqlStatement, SqlValue};
 use khive_types::Pack;
 use lattice_embed::{EmbedError, EmbeddingModel, EmbeddingService};
 use serde_json::json;
@@ -140,14 +141,24 @@ async fn test_recall_decay_ranking() {
         .expect("old remember");
     let old_id = old["id"].as_str().unwrap().to_string();
 
-    // Manually backdate the old note to simulate age
+    // Manually backdate the old note to simulate age. `upsert_note` preserves
+    // `created_at` on existing rows, so the backdate must be a direct UPDATE.
     let old_uuid: uuid::Uuid = old_id.parse().unwrap();
-    let note_store = rt
-        .notes(&rt.authorize(Namespace::local()).unwrap())
-        .unwrap();
-    let mut old_note = note_store.get_note(old_uuid).await.unwrap().unwrap();
-    old_note.created_at -= 90 * 86_400_000_000i64; // 90 days in microseconds
-    note_store.upsert_note(old_note).await.unwrap();
+    let sql = rt.sql();
+    let mut writer = sql.writer().await.expect("sql writer");
+    let backdated = writer
+        .execute(SqlStatement {
+            sql: "UPDATE notes SET created_at = created_at - ? WHERE id = ?".into(),
+            params: vec![
+                SqlValue::Integer(90 * 86_400_000_000i64),
+                SqlValue::Text(old_uuid.to_string()),
+            ],
+            label: Some("test-backdate-note".into()),
+        })
+        .await
+        .expect("backdate update");
+    assert_eq!(backdated, 1, "backdate must touch exactly the old note row");
+    drop(writer);
 
     // Disable MMR penalty so identical-content notes are ranked purely by
     // temporal decay. MMR would suppress the second hit (rank 2) by -0.1,

--- a/crates/khive-runtime/src/curation.rs
+++ b/crates/khive-runtime/src/curation.rs
@@ -1705,9 +1705,8 @@ fn merge_note_sql(
             }
         }
 
-        conn.execute(
-            khive_db::stores::note::NOTE_UPSERT_SQL,
-            rusqlite::params![
+        conn.prepare_cached(khive_db::stores::note::NOTE_UPSERT_SQL)?
+            .execute(rusqlite::params![
                 &into_str,
                 &namespace,
                 &into_note.kind,
@@ -1721,8 +1720,7 @@ fn merge_note_sql(
                 into_note.created_at,
                 now,
                 into_note.deleted_at,
-            ],
-        )?;
+            ])?;
 
         conn.execute(
             &format!(

--- a/crates/khive-runtime/src/curation.rs
+++ b/crates/khive-runtime/src/curation.rs
@@ -1706,10 +1706,7 @@ fn merge_note_sql(
         }
 
         conn.execute(
-            "INSERT OR REPLACE INTO notes \
-             (id, namespace, kind, status, name, content, salience, decay_factor, \
-              expires_at, properties, created_at, updated_at, deleted_at) \
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13)",
+            khive_db::stores::note::NOTE_UPSERT_SQL,
             rusqlite::params![
                 &into_str,
                 &namespace,


### PR DESCRIPTION
## Summary

ADR-116 (memory-ANN-generation-coherence) requires the notes table's upcoming liveness triggers to fire only on real deletes and liveness changes, not on ordinary content/salience updates. The blocker: the note-write path currently issues `INSERT OR REPLACE INTO notes` from three independent call sites. SQLite implements that as a delete-then-insert on a conflicting id, which would spuriously fire a future DELETE-path trigger on every routine upsert and discards the row's original `created_at`.

This PR is the prerequisite fix called out in ADR-116: unify all three writers onto one true UPSERT before any generation-tracking trigger is added.

- `crates/khive-db/src/stores/note.rs`: added `NOTE_UPSERT_SQL`, a shared `INSERT ... ON CONFLICT(id) DO UPDATE SET ...` statement. `created_at` is intentionally left out of the `DO UPDATE SET` list, so it is bound only on the INSERT branch and preserved on every subsequent update of the same row. Both `note_upsert_statement` (used by the canonical single-note writer and by `khive-runtime`'s atomic prepare path) and the batch `upsert_notes` loop now use this constant.
- `crates/khive-runtime/src/curation.rs`: the note-merge write path now uses the same shared `NOTE_UPSERT_SQL` instead of its own `INSERT OR REPLACE` literal.
- All three sites now share identical column order and update semantics.

## Test plan

- [x] `cargo check -p khive-db -p khive-runtime`
- [x] `cargo test -p khive-db -p khive-runtime` — 898 passed (khive-db lib), 70 passed (integration), all green
- [x] `cargo clippy -p khive-db -p khive-runtime --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean
- [x] New regression test `test_upsert_note_is_true_upsert_no_delete_semantics`: installs a stand-in `AFTER DELETE` trigger on `notes`, upserts an existing row twice with mutated fields, and asserts: exactly one row remains, mutable fields reflect the latest write, `created_at` is unchanged from the original insert, and the delete trigger never fired — then does a real delete as a sanity check that the probe trigger is live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)