### PR TITLE
build(make): compile channel-telegram into the local kkernel binary

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,8 +54,8 @@ bench-1m-ci:
 	bash scripts/bench_1m.sh --ci
 
 local:
-	@echo "==> Building kkernel (release, channel-email)..."
-	@cd crates && cargo build --release -p kkernel --features channel-email
+	@echo "==> Building kkernel (release, channel-email, channel-telegram)..."
+	@cd crates && cargo build --release -p kkernel --features channel-email,channel-telegram
 	@SRC=crates/target/release/kkernel; \
 	DEST=$$HOME/.cargo/bin/kkernel; \
 	if [ ! -f "$$SRC" ]; then echo "==> ERROR: build artifact $$SRC missing"; exit 1; fi; \

--- a/crates/kkernel/Cargo.toml
+++ b/crates/kkernel/Cargo.toml
@@ -60,6 +60,8 @@ rmcp = { workspace = true, features = ["client", "transport-child-process"] }
 bench-embedder = ["khive-mcp/bench-embedder"]
 # Pass-through: enables the SMTP/IMAP email polling loop. Inert without KHIVE_EMAIL_* env vars.
 channel-email = ["khive-mcp/channel-email"]
+# Pass-through: enables the Telegram Bot API polling + outbox loop. Inert without KHIVE_TELEGRAM_* env vars.
+channel-telegram = ["khive-mcp/channel-telegram"]
 
 [[bin]]
 name = "kkernel"


### PR DESCRIPTION
make local builds with --features channel-email only, so the installed kkernel binary cannot spawn the Telegram channel loops that shipped with the ADR-056 amendment adapter. This enables channel-email,channel-telegram together in the local build target.

Runtime behavior is unchanged until KHIVE_TELEGRAM_BOT_TOKEN and KHIVE_TELEGRAM_MAINTAINER_CHAT_ID resolve at daemon startup; with them unset the spawn path logs a warning and skips, per the existing non-fatal config contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)