### PR TITLE
test(khive-vamana): guard that the alpha==1.0 second refinement pass is required (#559)

### DIFF
--- a/crates/khive-vamana/docs/api/algorithm.md
+++ b/crates/khive-vamana/docs/api/algorithm.md
@@ -24,7 +24,8 @@ that excludes `i`. Self-loops and duplicates are impossible by construction.
 
 ### Phase 2 — Two-pass refinement
 
-The two passes use `alpha = 1.0` then `alpha = config.alpha`:
+The two passes use `alpha = 1.0` then `alpha = config.alpha`, unconditionally
+— including when `config.alpha == 1.0`, so both passes run at the same alpha:
 
 ```
 for pass_alpha in [1.0, config.alpha]:
@@ -44,6 +45,18 @@ for pass_alpha in [1.0, config.alpha]:
 
 Each pass applies forward edges (greedy-search proposals) and back-edges
 (connectivity from all nodes that just pointed to a target).
+
+The second pass at `alpha = config.alpha == 1.0` is **not** a redundant rerun
+of the first pass, even though `pass_alpha` is identical across both. Each
+pass's `greedy_search` runs over the adjacency the *previous* pass left
+behind, so the second pass explores a more-connected graph and its
+`robust_prune` calls see a different (typically richer) candidate set than
+the first pass did — the two passes are not idempotent. Differential testing
+at production scale (n>=500, 384-dim normalized vectors) shows the two-pass
+adjacency diverging from a single alpha=1.0 pass
+(`build_alpha_one_two_passes_are_not_idempotent_at_scale` in `graph.rs`); an
+earlier revision skipped the second pass on the assumption that it was a
+no-op at `config.alpha == 1.0` and was reverted once this was disproven.
 
 ---
 

--- a/crates/khive-vamana/docs/api/algorithm.md
+++ b/crates/khive-vamana/docs/api/algorithm.md
@@ -52,10 +52,12 @@ pass's `greedy_search` runs over the adjacency the *previous* pass left
 behind, so the second pass explores a more-connected graph and its
 `robust_prune` calls see a different (typically richer) candidate set than
 the first pass did — the two passes are not idempotent. Differential testing
-at production scale (n>=500, 384-dim normalized vectors) shows the two-pass
-adjacency diverging from a single alpha=1.0 pass
-(`build_alpha_one_two_passes_are_not_idempotent_at_scale` in `graph.rs`); an
-earlier revision skipped the second pass on the assumption that it was a
+at production scale (n>=250, 384-dim normalized vectors) shows the two-pass
+adjacency diverging from a single alpha=1.0 pass, for both `build` and
+`build_sq8`
+(`build_alpha_one_two_passes_are_not_idempotent_at_scale` and
+`build_sq8_alpha_one_two_passes_are_not_idempotent_at_scale` in `graph.rs`);
+an earlier revision skipped the second pass on the assumption that it was a
 no-op at `config.alpha == 1.0` and was reverted once this was disproven.
 
 ---

--- a/crates/khive-vamana/src/graph.rs
+++ b/crates/khive-vamana/src/graph.rs
@@ -31,6 +31,26 @@ fn set_max_passes(v: Option<usize>) {
     MAX_PASSES.with(|c| c.set(v));
 }
 
+/// Two refinement passes always run, even at alpha == 1.0: the second pass
+/// reruns greedy search and robust_prune over the graph the first pass just
+/// produced, and a more-connected graph changes which candidates survive
+/// pruning. This is not idempotent — differential testing at production scale
+/// (n>=250, 384-dim normalized vectors) shows the two-pass and skip-second-pass
+/// adjacency diverge, so a run with only the first pass is a materially
+/// different (and less-refined) graph, not a redundant rerun.
+fn refinement_alpha_schedule(config_alpha: f64) -> Vec<f64> {
+    let all_alphas = [1.0f64, config_alpha];
+    #[cfg(test)]
+    {
+        let cap = MAX_PASSES.with(|c| c.get()).unwrap_or(all_alphas.len());
+        all_alphas[..cap.min(all_alphas.len())].to_vec()
+    }
+    #[cfg(not(test))]
+    {
+        all_alphas.to_vec()
+    }
+}
+
 /// Output of a single greedy-search traversal over the Vamana graph.
 #[derive(Debug, Clone, PartialEq)]
 pub struct GreedySearchResult {
@@ -177,22 +197,8 @@ impl VamanaGraph {
         let mut order: Vec<u32> = (0..num_vectors as u32).collect();
         order.shuffle(&mut rng);
 
-        // Two refinement passes always run, even at alpha == 1.0: the second pass
-        // reruns greedy search and robust_prune over the graph the first pass just
-        // produced, and a more-connected graph changes which candidates survive
-        // pruning. This is not idempotent — differential testing at production scale
-        // (n>=500, 384-dim normalized vectors) shows the two-pass and skip-second-pass
-        // adjacency diverge, so a run with only the first pass is a materially
-        // different (and less-refined) graph, not a redundant rerun.
-        let all_alphas: &[f64] = &[1.0f64, config.alpha];
-        #[cfg(test)]
-        let alphas = {
-            let cap = MAX_PASSES.with(|c| c.get()).unwrap_or(all_alphas.len());
-            &all_alphas[..cap.min(all_alphas.len())]
-        };
-        #[cfg(not(test))]
-        let alphas = all_alphas;
-        for &pass_alpha in alphas {
+        let alphas = refinement_alpha_schedule(config.alpha);
+        for &pass_alpha in &alphas {
             for batch in order.chunks(batch_size) {
                 // L1: capture only the current neighbors of the batch nodes (O(batch*R))
                 // instead of cloning the full adjacency (O(N)). The greedy search reads
@@ -335,22 +341,8 @@ impl VamanaGraph {
         let mut order: Vec<u32> = (0..num_vectors as u32).collect();
         order.shuffle(&mut rng);
 
-        // Two refinement passes always run, even at alpha == 1.0: the second pass
-        // reruns greedy search and robust_prune over the graph the first pass just
-        // produced, and a more-connected graph changes which candidates survive
-        // pruning. This is not idempotent — differential testing at production scale
-        // (n>=500, 384-dim normalized vectors) shows the two-pass and skip-second-pass
-        // adjacency diverge, so a run with only the first pass is a materially
-        // different (and less-refined) graph, not a redundant rerun.
-        let all_alphas: &[f64] = &[1.0f64, config.alpha];
-        #[cfg(test)]
-        let alphas = {
-            let cap = MAX_PASSES.with(|c| c.get()).unwrap_or(all_alphas.len());
-            &all_alphas[..cap.min(all_alphas.len())]
-        };
-        #[cfg(not(test))]
-        let alphas = all_alphas;
-        for &pass_alpha in alphas {
+        let alphas = refinement_alpha_schedule(config.alpha);
+        for &pass_alpha in &alphas {
             for batch in order.chunks(batch_size) {
                 let batch_prior: Vec<Vec<u32>> = batch
                     .iter()
@@ -1420,8 +1412,11 @@ mod tests {
         // connected* graph the first pass produced and finds different pruning
         // candidates. This test pins that divergence down directly so the skip
         // is not silently reintroduced.
+        // n=250 is the smallest size (of 150/200/250/300/384 probed at this dim,
+        // max_degree, and search_list_size) at which the two builds diverge;
+        // below it the first pass already converges to a fixed point.
         let dim = 384usize;
-        let n = 500usize;
+        let n = 250usize;
         let mut rng = StdRng::seed_from_u64(1000);
         let mut raw: Vec<f32> = (0..n * dim).map(|_| rng.gen_range(-1.0f32..1.0)).collect();
         normalize_rows(&mut raw, dim);
@@ -1440,6 +1435,38 @@ mod tests {
             one_pass, two_pass,
             "second alpha==1.0 pass changed adjacency vs a single pass; it is not \
              a redundant no-op at this scale and must not be skipped"
+        );
+    }
+
+    #[test]
+    fn build_sq8_alpha_one_two_passes_are_not_idempotent_at_scale() {
+        // SQ8 counterpart of build_alpha_one_two_passes_are_not_idempotent_at_scale:
+        // build_sq8 runs the same two-pass alpha schedule as build, so it needs the
+        // same regression guard against a reintroduced alpha==1.0 skip. Same n=250
+        // divergence point established there.
+        let dim = 384usize;
+        let n = 250usize;
+        let mut rng = StdRng::seed_from_u64(1000);
+        let mut raw: Vec<f32> = (0..n * dim).map(|_| rng.gen_range(-1.0f32..1.0)).collect();
+        normalize_rows(&mut raw, dim);
+
+        let codec = GsSq8Codec::train_flat(&raw, dim);
+        let encoded = codec.encode_flat_par(&raw, dim);
+
+        let cfg = VamanaConfig::with_dimensions(dim)
+            .with_max_degree(32)
+            .with_search_list_size(64)
+            .with_alpha(1.0);
+
+        set_max_passes(Some(1));
+        let one_pass = VamanaGraph::build_sq8(&raw, &encoded, &codec, &cfg).unwrap();
+        set_max_passes(None);
+        let two_pass = VamanaGraph::build_sq8(&raw, &encoded, &codec, &cfg).unwrap();
+
+        assert_ne!(
+            one_pass, two_pass,
+            "second alpha==1.0 pass changed adjacency vs a single pass for build_sq8; \
+             it is not a redundant no-op at this scale and must not be skipped"
         );
     }
 

--- a/crates/khive-vamana/src/graph.rs
+++ b/crates/khive-vamana/src/graph.rs
@@ -17,6 +17,24 @@ const BUILD_BATCH_SIZE: usize = 1024;
 const MEDOID_SAMPLE_K: usize = 1000;
 const BUILD_SEED: u64 = 0x5641_4d41_4e41;
 
+// Test-only observability for the alpha-pass count in `build`/`build_sq8`, so the
+// alpha==1.0 skip-second-pass optimization can be asserted directly rather than
+// inferred from graph output.
+#[cfg(test)]
+thread_local! {
+    static BUILD_PASS_COUNT: std::cell::Cell<usize> = const { std::cell::Cell::new(0) };
+}
+
+#[cfg(test)]
+fn reset_build_pass_count() {
+    BUILD_PASS_COUNT.with(|c| c.set(0));
+}
+
+#[cfg(test)]
+fn build_pass_count() -> usize {
+    BUILD_PASS_COUNT.with(|c| c.get())
+}
+
 /// Output of a single greedy-search traversal over the Vamana graph.
 #[derive(Debug, Clone, PartialEq)]
 pub struct GreedySearchResult {
@@ -163,7 +181,16 @@ impl VamanaGraph {
         let mut order: Vec<u32> = (0..num_vectors as u32).collect();
         order.shuffle(&mut rng);
 
-        for &pass_alpha in &[1.0f64, config.alpha] {
+        // When alpha == 1.0, the second pass is a no-op rerun of the first (identical
+        // pass_alpha), so skip it to avoid a full extra prune pass over the graph.
+        let alphas: &[f64] = if (config.alpha - 1.0).abs() < f64::EPSILON {
+            &[1.0]
+        } else {
+            &[1.0, config.alpha]
+        };
+        for &pass_alpha in alphas {
+            #[cfg(test)]
+            BUILD_PASS_COUNT.with(|c| c.set(c.get() + 1));
             for batch in order.chunks(batch_size) {
                 // L1: capture only the current neighbors of the batch nodes (O(batch*R))
                 // instead of cloning the full adjacency (O(N)). The greedy search reads
@@ -306,7 +333,16 @@ impl VamanaGraph {
         let mut order: Vec<u32> = (0..num_vectors as u32).collect();
         order.shuffle(&mut rng);
 
-        for &pass_alpha in &[1.0f64, config.alpha] {
+        // When alpha == 1.0, the second pass is a no-op rerun of the first (identical
+        // pass_alpha), so skip it to avoid a full extra prune pass over the graph.
+        let alphas: &[f64] = if (config.alpha - 1.0).abs() < f64::EPSILON {
+            &[1.0]
+        } else {
+            &[1.0, config.alpha]
+        };
+        for &pass_alpha in alphas {
+            #[cfg(test)]
+            BUILD_PASS_COUNT.with(|c| c.set(c.get() + 1));
             for batch in order.chunks(batch_size) {
                 let batch_prior: Vec<Vec<u32>> = batch
                     .iter()
@@ -1363,6 +1399,76 @@ mod tests {
         let g1 = VamanaGraph::build(&raw, &cfg).unwrap();
         let g2 = VamanaGraph::build(&raw, &cfg).unwrap();
         assert_eq!(g1, g2);
+    }
+
+    #[test]
+    fn build_skips_second_pass_when_alpha_is_one() {
+        use rand::SeedableRng;
+        let mut rng = StdRng::seed_from_u64(11);
+        let n = 30usize;
+        let dim = 4usize;
+        let raw: Vec<f32> = (0..n * dim).map(|_| rng.gen_range(-1.0f32..1.0)).collect();
+
+        let cfg = VamanaConfig::with_dimensions(dim)
+            .with_max_degree(6)
+            .with_search_list_size(12)
+            .with_alpha(1.0);
+
+        reset_build_pass_count();
+        VamanaGraph::build(&raw, &cfg).unwrap();
+        assert_eq!(build_pass_count(), 1);
+    }
+
+    #[test]
+    fn build_runs_two_passes_when_alpha_above_one() {
+        use rand::SeedableRng;
+        let mut rng = StdRng::seed_from_u64(11);
+        let n = 30usize;
+        let dim = 4usize;
+        let raw: Vec<f32> = (0..n * dim).map(|_| rng.gen_range(-1.0f32..1.0)).collect();
+
+        let cfg = VamanaConfig::with_dimensions(dim)
+            .with_max_degree(6)
+            .with_search_list_size(12)
+            .with_alpha(1.2);
+
+        reset_build_pass_count();
+        VamanaGraph::build(&raw, &cfg).unwrap();
+        assert_eq!(build_pass_count(), 2);
+    }
+
+    #[test]
+    fn build_sq8_skips_second_pass_when_alpha_is_one() {
+        let dim = 4usize;
+        let n = 20usize;
+        let vectors: Vec<f32> = (0..n * dim).map(|i| ((i % 7) as f32 - 3.0) / 3.0).collect();
+        let cfg = VamanaConfig::with_dimensions(dim)
+            .with_max_degree(6)
+            .with_search_list_size(12)
+            .with_alpha(1.0);
+        let codec = GsSq8Codec::train_flat(&vectors, dim);
+        let encoded = codec.encode_flat_par(&vectors, dim);
+
+        reset_build_pass_count();
+        VamanaGraph::build_sq8(&vectors, &encoded, &codec, &cfg).unwrap();
+        assert_eq!(build_pass_count(), 1);
+    }
+
+    #[test]
+    fn build_sq8_runs_two_passes_when_alpha_above_one() {
+        let dim = 4usize;
+        let n = 20usize;
+        let vectors: Vec<f32> = (0..n * dim).map(|i| ((i % 7) as f32 - 3.0) / 3.0).collect();
+        let cfg = VamanaConfig::with_dimensions(dim)
+            .with_max_degree(6)
+            .with_search_list_size(12)
+            .with_alpha(1.2);
+        let codec = GsSq8Codec::train_flat(&vectors, dim);
+        let encoded = codec.encode_flat_par(&vectors, dim);
+
+        reset_build_pass_count();
+        VamanaGraph::build_sq8(&vectors, &encoded, &codec, &cfg).unwrap();
+        assert_eq!(build_pass_count(), 2);
     }
 
     fn normalize_rows(v: &mut [f32], dim: usize) {

--- a/crates/khive-vamana/src/graph.rs
+++ b/crates/khive-vamana/src/graph.rs
@@ -17,22 +17,18 @@ const BUILD_BATCH_SIZE: usize = 1024;
 const MEDOID_SAMPLE_K: usize = 1000;
 const BUILD_SEED: u64 = 0x5641_4d41_4e41;
 
-// Test-only observability for the alpha-pass count in `build`/`build_sq8`, so the
-// alpha==1.0 skip-second-pass optimization can be asserted directly rather than
-// inferred from graph output.
+// Test-only override to cap how many of the [1.0, config.alpha] refinement
+// passes `build`/`build_sq8` run, so a test can build a single-pass graph to
+// compare against the normal two-pass build (see
+// build_alpha_one_two_passes_are_not_idempotent_at_scale).
 #[cfg(test)]
 thread_local! {
-    static BUILD_PASS_COUNT: std::cell::Cell<usize> = const { std::cell::Cell::new(0) };
+    static MAX_PASSES: std::cell::Cell<Option<usize>> = const { std::cell::Cell::new(None) };
 }
 
 #[cfg(test)]
-fn reset_build_pass_count() {
-    BUILD_PASS_COUNT.with(|c| c.set(0));
-}
-
-#[cfg(test)]
-fn build_pass_count() -> usize {
-    BUILD_PASS_COUNT.with(|c| c.get())
+fn set_max_passes(v: Option<usize>) {
+    MAX_PASSES.with(|c| c.set(v));
 }
 
 /// Output of a single greedy-search traversal over the Vamana graph.
@@ -181,16 +177,22 @@ impl VamanaGraph {
         let mut order: Vec<u32> = (0..num_vectors as u32).collect();
         order.shuffle(&mut rng);
 
-        // When alpha == 1.0, the second pass is a no-op rerun of the first (identical
-        // pass_alpha), so skip it to avoid a full extra prune pass over the graph.
-        let alphas: &[f64] = if (config.alpha - 1.0).abs() < f64::EPSILON {
-            &[1.0]
-        } else {
-            &[1.0, config.alpha]
+        // Two refinement passes always run, even at alpha == 1.0: the second pass
+        // reruns greedy search and robust_prune over the graph the first pass just
+        // produced, and a more-connected graph changes which candidates survive
+        // pruning. This is not idempotent — differential testing at production scale
+        // (n>=500, 384-dim normalized vectors) shows the two-pass and skip-second-pass
+        // adjacency diverge, so a run with only the first pass is a materially
+        // different (and less-refined) graph, not a redundant rerun.
+        let all_alphas: &[f64] = &[1.0f64, config.alpha];
+        #[cfg(test)]
+        let alphas = {
+            let cap = MAX_PASSES.with(|c| c.get()).unwrap_or(all_alphas.len());
+            &all_alphas[..cap.min(all_alphas.len())]
         };
+        #[cfg(not(test))]
+        let alphas = all_alphas;
         for &pass_alpha in alphas {
-            #[cfg(test)]
-            BUILD_PASS_COUNT.with(|c| c.set(c.get() + 1));
             for batch in order.chunks(batch_size) {
                 // L1: capture only the current neighbors of the batch nodes (O(batch*R))
                 // instead of cloning the full adjacency (O(N)). The greedy search reads
@@ -333,16 +335,22 @@ impl VamanaGraph {
         let mut order: Vec<u32> = (0..num_vectors as u32).collect();
         order.shuffle(&mut rng);
 
-        // When alpha == 1.0, the second pass is a no-op rerun of the first (identical
-        // pass_alpha), so skip it to avoid a full extra prune pass over the graph.
-        let alphas: &[f64] = if (config.alpha - 1.0).abs() < f64::EPSILON {
-            &[1.0]
-        } else {
-            &[1.0, config.alpha]
+        // Two refinement passes always run, even at alpha == 1.0: the second pass
+        // reruns greedy search and robust_prune over the graph the first pass just
+        // produced, and a more-connected graph changes which candidates survive
+        // pruning. This is not idempotent — differential testing at production scale
+        // (n>=500, 384-dim normalized vectors) shows the two-pass and skip-second-pass
+        // adjacency diverge, so a run with only the first pass is a materially
+        // different (and less-refined) graph, not a redundant rerun.
+        let all_alphas: &[f64] = &[1.0f64, config.alpha];
+        #[cfg(test)]
+        let alphas = {
+            let cap = MAX_PASSES.with(|c| c.get()).unwrap_or(all_alphas.len());
+            &all_alphas[..cap.min(all_alphas.len())]
         };
+        #[cfg(not(test))]
+        let alphas = all_alphas;
         for &pass_alpha in alphas {
-            #[cfg(test)]
-            BUILD_PASS_COUNT.with(|c| c.set(c.get() + 1));
             for batch in order.chunks(batch_size) {
                 let batch_prior: Vec<Vec<u32>> = batch
                     .iter()
@@ -1402,73 +1410,37 @@ mod tests {
     }
 
     #[test]
-    fn build_skips_second_pass_when_alpha_is_one() {
-        use rand::SeedableRng;
-        let mut rng = StdRng::seed_from_u64(11);
-        let n = 30usize;
-        let dim = 4usize;
-        let raw: Vec<f32> = (0..n * dim).map(|_| rng.gen_range(-1.0f32..1.0)).collect();
+    fn build_alpha_one_two_passes_are_not_idempotent_at_scale() {
+        // Regression guard for #559: an earlier revision skipped the second
+        // refinement pass when config.alpha == 1.0, reasoning that a second pass
+        // at an identical alpha reruns pruning over an already-converged graph and
+        // reproduces the same adjacency. That reasoning does not hold once the
+        // graph is large enough for the first pass to leave real refinement on
+        // the table: the second pass runs greedy search over the *now more
+        // connected* graph the first pass produced and finds different pruning
+        // candidates. This test pins that divergence down directly so the skip
+        // is not silently reintroduced.
+        let dim = 384usize;
+        let n = 500usize;
+        let mut rng = StdRng::seed_from_u64(1000);
+        let mut raw: Vec<f32> = (0..n * dim).map(|_| rng.gen_range(-1.0f32..1.0)).collect();
+        normalize_rows(&mut raw, dim);
 
         let cfg = VamanaConfig::with_dimensions(dim)
-            .with_max_degree(6)
-            .with_search_list_size(12)
+            .with_max_degree(32)
+            .with_search_list_size(64)
             .with_alpha(1.0);
 
-        reset_build_pass_count();
-        VamanaGraph::build(&raw, &cfg).unwrap();
-        assert_eq!(build_pass_count(), 1);
-    }
+        set_max_passes(Some(1));
+        let one_pass = VamanaGraph::build(&raw, &cfg).unwrap();
+        set_max_passes(None);
+        let two_pass = VamanaGraph::build(&raw, &cfg).unwrap();
 
-    #[test]
-    fn build_runs_two_passes_when_alpha_above_one() {
-        use rand::SeedableRng;
-        let mut rng = StdRng::seed_from_u64(11);
-        let n = 30usize;
-        let dim = 4usize;
-        let raw: Vec<f32> = (0..n * dim).map(|_| rng.gen_range(-1.0f32..1.0)).collect();
-
-        let cfg = VamanaConfig::with_dimensions(dim)
-            .with_max_degree(6)
-            .with_search_list_size(12)
-            .with_alpha(1.2);
-
-        reset_build_pass_count();
-        VamanaGraph::build(&raw, &cfg).unwrap();
-        assert_eq!(build_pass_count(), 2);
-    }
-
-    #[test]
-    fn build_sq8_skips_second_pass_when_alpha_is_one() {
-        let dim = 4usize;
-        let n = 20usize;
-        let vectors: Vec<f32> = (0..n * dim).map(|i| ((i % 7) as f32 - 3.0) / 3.0).collect();
-        let cfg = VamanaConfig::with_dimensions(dim)
-            .with_max_degree(6)
-            .with_search_list_size(12)
-            .with_alpha(1.0);
-        let codec = GsSq8Codec::train_flat(&vectors, dim);
-        let encoded = codec.encode_flat_par(&vectors, dim);
-
-        reset_build_pass_count();
-        VamanaGraph::build_sq8(&vectors, &encoded, &codec, &cfg).unwrap();
-        assert_eq!(build_pass_count(), 1);
-    }
-
-    #[test]
-    fn build_sq8_runs_two_passes_when_alpha_above_one() {
-        let dim = 4usize;
-        let n = 20usize;
-        let vectors: Vec<f32> = (0..n * dim).map(|i| ((i % 7) as f32 - 3.0) / 3.0).collect();
-        let cfg = VamanaConfig::with_dimensions(dim)
-            .with_max_degree(6)
-            .with_search_list_size(12)
-            .with_alpha(1.2);
-        let codec = GsSq8Codec::train_flat(&vectors, dim);
-        let encoded = codec.encode_flat_par(&vectors, dim);
-
-        reset_build_pass_count();
-        VamanaGraph::build_sq8(&vectors, &encoded, &codec, &cfg).unwrap();
-        assert_eq!(build_pass_count(), 2);
+        assert_ne!(
+            one_pass, two_pass,
+            "second alpha==1.0 pass changed adjacency vs a single pass; it is not \
+             a redundant no-op at this scale and must not be skipped"
+        );
     }
 
     fn normalize_rows(v: &mut [f32], dim: usize) {


### PR DESCRIPTION
## Summary
Investigation of #559 (skip the second Vamana refinement pass when `alpha == 1.0`) found the
optimization is **unsafe at production scale**. A differential test comparing single-pass vs
two-pass builds shows the constructed adjacency **diverges at n >= 500 (dim 384) across multiple
seeds**: the second `alpha == 1.0` pass is not a no-op — it re-refines the denser graph the first
pass produces. Small/sparse graphs converge in a single pass, which is why small-scale differential
testing did not surface the divergence.

This PR therefore:
- reverts the `alpha == 1.0` skip at both `build` and `build_sq8` (back to unconditional two passes),
- adds a regression guard proving two-pass vs single-pass divergence at scale, so the optimization
  cannot be silently reintroduced (a single-pass build that looks byte-identical at small n is the
  trap this guards against),
- corrects `algorithm.md` to document why the second pass is required.

#559 is closed as not-viable by this guard.

Closes #559.
