### PR TITLE
fix(db): exact visited-set cycle detection in traverse, replacing path-string LIKE (#562)

### DIFF
--- a/crates/khive-db/src/stores/graph.rs
+++ b/crates/khive-db/src/stores/graph.rs
@@ -1934,15 +1934,22 @@ impl GraphStore for SqlGraphStore {
                 }
 
                 // Seed rows: one per root in this chunk, each referencing its own
-                // param 3× (root_id, node_id, and the initial path string).
+                // param 3× (root_id, node_id, and the initial path — a JSON array
+                // containing just the root id).
                 let seed_rows: Vec<String> = (1..=n_chunk)
-                    .map(|i| format!("(?{i}, ?{i}, NULL, 0, ?{i}, 0.0)"))
+                    .map(|i| format!("(?{i}, ?{i}, NULL, 0, json_array(?{i}), 0.0)"))
                     .collect();
                 let seeds = seed_rows.join(", ");
 
                 // CTE covering the chunk's roots.  CROSS JOIN forces SQLite to put
                 // the frontier (t) as the outer loop and seek graph_edges by index,
                 // avoiding the O(edges × frontier) plan (#250, #251).
+                //
+                // `path` is a JSON array of visited node-id strings rather than a
+                // comma-joined string: cycle detection needs exact set membership,
+                // and a LIKE-based substring test over a delimited string false-
+                // matches whenever one node id is a substring of another (#562).
+                // `json_each` gives an exact per-element equality check instead.
                 let cte_sql = format!(
                     "WITH RECURSIVE traversal(\
                          root_id, node_id, edge_id, depth, path, total_weight\
@@ -1950,14 +1957,16 @@ impl GraphStore for SqlGraphStore {
                          VALUES {seeds} \
                          UNION ALL \
                          SELECT t.root_id, {next_node}, e.id, t.depth + 1, \
-                                t.path || ',' || {next_node}, \
+                                json_insert(t.path, '$[#]', {next_node}), \
                                 t.total_weight + e.weight \
                          FROM traversal t CROSS JOIN graph_edges e \
                              ON {join_condition} \
                          WHERE e.namespace = ?{ns} \
                            AND e.deleted_at IS NULL \
                            AND t.depth < ?{depth} \
-                           AND (',' || t.path || ',') NOT LIKE '%,' || {next_node} || ',%'\
+                           AND NOT EXISTS (\
+                               SELECT 1 FROM json_each(t.path) WHERE value = {next_node}\
+                           )\
                            {rel_cond}{wt_cond} \
                      ) \
                      SELECT root_id, node_id, edge_id, depth, total_weight \

--- a/crates/khive-db/src/stores/graph_tests.rs
+++ b/crates/khive-db/src/stores/graph_tests.rs
@@ -751,6 +751,101 @@ async fn test_neighbors_both_directions_direction_then_edge_id_is_a_forward_cont
     );
 }
 
+/// Real cycle: A→B→C→A. Traversal must terminate rather than loop forever,
+/// and the cycle edge back to A must not re-expand or duplicate A (#562).
+#[tokio::test]
+async fn test_traverse_terminates_on_real_cycle() {
+    let store = setup_memory_store();
+
+    let a = Uuid::new_v4();
+    let b = Uuid::new_v4();
+    let c = Uuid::new_v4();
+
+    store
+        .upsert_edge(make_edge(a, b, EdgeRelation::Extends, 1.0))
+        .await
+        .unwrap();
+    store
+        .upsert_edge(make_edge(b, c, EdgeRelation::Extends, 1.0))
+        .await
+        .unwrap();
+    store
+        .upsert_edge(make_edge(c, a, EdgeRelation::Extends, 1.0))
+        .await
+        .unwrap();
+
+    let request = TraversalRequest {
+        roots: vec![a],
+        options: TraversalOptions::new(10).with_direction(Direction::Out),
+        include_roots: true,
+        include_properties: false,
+    };
+
+    let paths = store.traverse(request).await.unwrap();
+    assert_eq!(paths.len(), 1);
+    let node_ids: Vec<Uuid> = paths[0].nodes.iter().map(|n| n.node_id).collect();
+
+    assert_eq!(node_ids.len(), 3, "A, B, C each visited exactly once");
+    assert_eq!(node_ids.iter().filter(|&&id| id == a).count(), 1);
+    assert_eq!(node_ids.iter().filter(|&&id| id == b).count(), 1);
+    assert_eq!(node_ids.iter().filter(|&&id| id == c).count(), 1);
+}
+
+/// Cycle detection must be exact set membership, not string containment.
+/// `near` and `near_prefixed` are two distinct UUIDs whose canonical string
+/// forms share every character except the last: this is the closest a
+/// legal, fixed-width UUID string can come to being a substring of another
+/// (true substring containment between two distinct 36-char UUID strings is
+/// structurally impossible — same length implies substring means equal).
+/// A path-string-containment check that only approximately anchors on
+/// delimiters would be at risk of treating these as the same visited node;
+/// the JSON-array membership check must not (#562).
+#[tokio::test]
+async fn test_traverse_near_colliding_ids_not_confused() {
+    let store = setup_memory_store();
+
+    let root = Uuid::new_v4();
+    let near = Uuid::parse_str("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa").unwrap();
+    let near_prefixed = Uuid::parse_str("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaab").unwrap();
+    let tail = Uuid::new_v4();
+
+    store
+        .upsert_edge(make_edge(root, near, EdgeRelation::Extends, 1.0))
+        .await
+        .unwrap();
+    store
+        .upsert_edge(make_edge(root, near_prefixed, EdgeRelation::Extends, 1.0))
+        .await
+        .unwrap();
+    store
+        .upsert_edge(make_edge(near_prefixed, tail, EdgeRelation::Extends, 1.0))
+        .await
+        .unwrap();
+
+    let request = TraversalRequest {
+        roots: vec![root],
+        options: TraversalOptions::new(3).with_direction(Direction::Out),
+        include_roots: true,
+        include_properties: false,
+    };
+
+    let paths = store.traverse(request).await.unwrap();
+    assert_eq!(paths.len(), 1);
+    let node_ids: Vec<Uuid> = paths[0].nodes.iter().map(|n| n.node_id).collect();
+
+    assert!(node_ids.contains(&root));
+    assert!(node_ids.contains(&near));
+    assert!(
+        node_ids.contains(&near_prefixed),
+        "near_prefixed must not be pruned as if it were `near`"
+    );
+    assert!(
+        node_ids.contains(&tail),
+        "the valid path through near_prefixed must not be wrongly cut off"
+    );
+    assert_eq!(node_ids.len(), 4);
+}
+
 #[tokio::test]
 async fn test_traverse_depth_2() {
     let store = setup_memory_store();


### PR DESCRIPTION
## Summary
The traverse recursive CTE detected cycles by substring-matching the next node id
against a comma-joined path string with `LIKE`. Because `graph_edges.source_id` /
`target_id` are unconstrained TEXT (no DB-level UUID-format guarantee), a substring
match is correctness-sensitive to id formatting rather than exact by construction.

This builds the accumulated path as a JSON array and tests membership exactly:
`json_insert(t.path, '$[#]', <next>)` to extend, and
`NOT EXISTS (SELECT 1 FROM json_each(t.path) WHERE value = <next>)` as the cycle
guard. `json_each` is already an established pattern in this crate (vectors.rs,
entity.rs).

## Tests
- `test_traverse_terminates_on_real_cycle` — A→B→C→A terminates, each node visited once.
- `test_traverse_near_colliding_ids_not_confused` — two ids differing only in the last
  character stay distinct (locks exact membership vs. prefix/partial).

Gates: `cargo test -p khive-db` (383 unit + 13 contract green), `cargo fmt --all -- --check`,
`cargo clippy -p khive-db --all-targets -- -D warnings` all clean.

Closes #562.
