### PR TITLE
ci: complete the no-stub guard with a placeholder-message scanner (#560)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,19 +148,19 @@ jobs:
           deno-version: v2.x
       - uses: astral-sh/setup-uv@v5
         if: env.CI_SUITE == 'full'
+      # SECURITY ORDERING (#560): the placeholder-stub scan runs before any cargo
+      # phase so no PR-controlled build script or proc-macro executes before the
+      # guard; it reads the pristine checkout. Keep this step ahead of every cargo
+      # step below, and ungated: both suites compile PR-controlled code, so gating
+      # the scan to one suite leaves the other lane unguarded.
+      - name: No-stub placeholder scan (before any cargo)
+        run: ../scripts/ci.sh no-stubs-scan
       - name: macOS PR compile check
         if: env.CI_SUITE == 'macos-pr'
         run: ../scripts/ci.sh macos-pr-check
       - name: macOS PR platform tests
         if: env.CI_SUITE == 'macos-pr'
         run: ../scripts/ci.sh macos-pr-tests
-      # SECURITY ORDERING (#560): the placeholder-stub scan runs before any cargo
-      # phase so no PR-controlled build script or proc-macro executes before the
-      # guard; it reads the pristine checkout. Keep this step ahead of every cargo
-      # step below.
-      - name: No-stub placeholder scan (before any cargo)
-        if: env.CI_SUITE == 'full'
-        run: ../scripts/ci.sh no-stubs-scan
       - name: Lockfile freshness
         if: env.CI_SUITE == 'full'
         run: ../scripts/ci.sh lockfile

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -154,6 +154,13 @@ jobs:
       - name: macOS PR platform tests
         if: env.CI_SUITE == 'macos-pr'
         run: ../scripts/ci.sh macos-pr-tests
+      # SECURITY ORDERING (#560): the placeholder-stub scan runs before any cargo
+      # phase so no PR-controlled build script or proc-macro executes before the
+      # guard; it reads the pristine checkout. Keep this step ahead of every cargo
+      # step below.
+      - name: No-stub placeholder scan (before any cargo)
+        if: env.CI_SUITE == 'full'
+        run: ../scripts/ci.sh no-stubs-scan
       - name: Lockfile freshness
         if: env.CI_SUITE == 'full'
         run: ../scripts/ci.sh lockfile

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -48,6 +48,15 @@ phase_no_stubs() {
     cargo clippy --workspace --lib --bins -- $NOSTUB_LINTS
     # shellcheck disable=SC2086
     cargo clippy --manifest-path "$SCRIPT_DIR/../crates/khive-merge/Cargo.toml" --lib --bins -- $NOSTUB_LINTS
+
+    echo "=== No-Stub Guard (placeholder-string panic!/unreachable! scan) ==="
+    # `todo!()`/`unimplemented!()` are denied unconditionally above regardless of
+    # message, but `panic!`/`unreachable!` are legitimate everywhere (assertion
+    # failures, invariant violations) -- clippy has no lint for "the message looks
+    # like a stub", and denying the macros outright would fail hundreds of correct
+    # call sites. This scans the string literal argument of every panic!/unreachable!
+    # call in shipping source for placeholder language (#560).
+    sh "$SCRIPT_DIR/lint-stub-markers.sh"
 }
 
 phase_clippy() {

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -35,6 +35,36 @@ phase_lint() {
     sh "$SCRIPT_DIR/lint-adr-refs.sh" --self-test
 }
 
+phase_no_stubs_scan() {
+    echo "=== No-Stub Guard (placeholder-string panic!/unreachable! scan) ==="
+    # SECURITY ORDERING (#560 follow-up): this placeholder-string scan and its
+    # self-test run as the FIRST ci phase, before phase_lockfile or any other
+    # cargo invocation. The cargo phases compile PR-controlled code (build
+    # scripts, proc-macros); if this guard ran after them, a build step could
+    # replace a committed stub source, the committed allowlist, or this scanner
+    # script itself with benign content and slip a stub past the guard. Running
+    # before any cargo compilation removes that opportunity: at this point the
+    # working tree is the pristine checkout, so the scanner reads exactly the
+    # committed sources. The scanner self-test asserts this ordering so a future
+    # reorder that moves the scan after a cargo phase fails loud.
+    #
+    # `todo!()`/`unimplemented!()` are denied unconditionally by the clippy pass
+    # in phase_no_stubs, but `panic!`/`unreachable!` are legitimate everywhere
+    # (assertion failures, invariant violations) -- clippy has no lint for "the
+    # message looks like a stub", and denying the macros outright would fail
+    # hundreds of correct call sites. This scans the string literal argument of
+    # every panic!/unreachable! call for placeholder language across every .rs
+    # file under crates/ (source, tests, benches, examples) -- a broader scope
+    # than the --lib --bins clippy pass: a placeholder message reads as a stub
+    # whether or not the code compiling it is test-gated (#560).
+    sh "$SCRIPT_DIR/lint-stub-markers.sh"
+
+    echo "=== No-Stub Guard (placeholder-string scanner self-test) ==="
+    # Locks in the scanner's own fixture coverage so a future parser change
+    # cannot silently regress it without the fixtures ever running in CI.
+    sh "$SCRIPT_DIR/lint-stub-markers.sh" --self-test
+}
+
 phase_no_stubs() {
     echo "=== No-Stub Guard (clippy restriction lints) ==="
     # AST-aware "No stubs. Ever." enforcement. clippy parses the macros, so it is
@@ -42,29 +72,14 @@ phase_no_stubs() {
     # `unimplemented!{}`, macro names inside comments or string literals). Scoped to
     # --lib --bins = shipping source only (excludes tests/benches/examples), matching
     # the prior policy. khive-merge is excluded from the workspace (forward-deployed),
-    # so it gets its own pass to preserve coverage.
+    # so it gets its own pass to preserve coverage. The placeholder-string scan that
+    # used to run here now runs first, in phase_no_stubs_scan, before any cargo
+    # compilation (see that phase's security-ordering note).
     NOSTUB_LINTS="-Dclippy::todo -Dclippy::unimplemented -Dclippy::dbg_macro"
     # shellcheck disable=SC2086
     cargo clippy --workspace --lib --bins -- $NOSTUB_LINTS
     # shellcheck disable=SC2086
     cargo clippy --manifest-path "$SCRIPT_DIR/../crates/khive-merge/Cargo.toml" --lib --bins -- $NOSTUB_LINTS
-
-    echo "=== No-Stub Guard (placeholder-string panic!/unreachable! scan) ==="
-    # `todo!()`/`unimplemented!()` are denied unconditionally above regardless of
-    # message, but `panic!`/`unreachable!` are legitimate everywhere (assertion
-    # failures, invariant violations) -- clippy has no lint for "the message looks
-    # like a stub", and denying the macros outright would fail hundreds of correct
-    # call sites. This scans the string literal argument of every panic!/unreachable!
-    # call for placeholder language across every .rs file under crates/ (source,
-    # tests, benches, examples) -- a broader scope than the clippy pass above, which
-    # is --lib --bins only: a placeholder message reads as a stub whether or not the
-    # code compiling it is test-gated (#560).
-    sh "$SCRIPT_DIR/lint-stub-markers.sh"
-
-    echo "=== No-Stub Guard (placeholder-string scanner self-test) ==="
-    # Locks in the scanner's own fixture coverage so a future parser change
-    # cannot silently regress it without the fixtures ever running in CI.
-    sh "$SCRIPT_DIR/lint-stub-markers.sh" --self-test
 }
 
 phase_clippy() {
@@ -159,6 +174,7 @@ phase_macos_pr_tests() {
 
 run_phase() {
     case "$1" in
+        no-stubs-scan) phase_no_stubs_scan ;;
         lockfile) phase_lockfile ;;
         forward-deployed) phase_forward_deployed ;;
         lint) phase_lint ;;
@@ -178,7 +194,7 @@ run_phase() {
         macos-pr-tests) phase_macos_pr_tests ;;
         *)
             echo "Unknown CI phase: $1" >&2
-            echo "Valid phases: lockfile forward-deployed lint no-stubs clippy docs tests channel-email no-default-features release contract-tests deno-tests smoke-tests vector-smoke contract-suite macos-pr-check macos-pr-tests" >&2
+            echo "Valid phases: no-stubs-scan lockfile forward-deployed lint no-stubs clippy docs tests channel-email no-default-features release contract-tests deno-tests smoke-tests vector-smoke contract-suite macos-pr-check macos-pr-tests" >&2
             exit 2
             ;;
     esac
@@ -186,6 +202,7 @@ run_phase() {
 
 run_all() {
     for phase in \
+        no-stubs-scan \
         lockfile \
         forward-deployed \
         lint \

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -57,6 +57,11 @@ phase_no_stubs() {
     # call sites. This scans the string literal argument of every panic!/unreachable!
     # call in shipping source for placeholder language (#560).
     sh "$SCRIPT_DIR/lint-stub-markers.sh"
+
+    echo "=== No-Stub Guard (placeholder-string scanner self-test) ==="
+    # Locks in the scanner's own fixture coverage so a future parser change
+    # cannot silently regress it without the fixtures ever running in CI.
+    sh "$SCRIPT_DIR/lint-stub-markers.sh" --self-test
 }
 
 phase_clippy() {

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -55,7 +55,10 @@ phase_no_stubs() {
     # failures, invariant violations) -- clippy has no lint for "the message looks
     # like a stub", and denying the macros outright would fail hundreds of correct
     # call sites. This scans the string literal argument of every panic!/unreachable!
-    # call in shipping source for placeholder language (#560).
+    # call for placeholder language across every .rs file under crates/ (source,
+    # tests, benches, examples) -- a broader scope than the clippy pass above, which
+    # is --lib --bins only: a placeholder message reads as a stub whether or not the
+    # code compiling it is test-gated (#560).
     sh "$SCRIPT_DIR/lint-stub-markers.sh"
 
     echo "=== No-Stub Guard (placeholder-string scanner self-test) ==="

--- a/scripts/lint-stub-markers.sh
+++ b/scripts/lint-stub-markers.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-# Detect placeholder-string `panic!`/`unreachable!` calls in shipping source
+# Detect placeholder-string `panic!`/`unreachable!` calls in crate source
 # (#560, closes the gap in the clippy-based No-Stub Guard).
 #
 # `-Dclippy::todo`/`-Dclippy::unimplemented` (scripts/ci.sh phase_no_stubs)
@@ -8,14 +8,17 @@
 # invariant violations) -- denying them outright would fail hundreds of
 # existing, correct call sites. The actual stub signal is the MESSAGE: a
 # `panic!("not implemented yet")` or `unreachable!("stub")` is a placeholder
-# wearing a real macro. This scans the string literal argument of every
+# wearing a real macro. This scans the string literal argument(s) of every
 # panic!/unreachable! call for that language, not the macro itself.
 #
-# Scope mirrors phase_no_stubs (`--lib --bins`): only crates/*/src (workspace +
-# the forward-deployed khive-merge crate), never crates/*/tests, benches, or
-# examples. Within src, a `#[cfg(test)]`-gated item is source clippy never
-# type-checks under `--lib --bins` (no `--cfg test`), so this scanner skips
-# those blocks the same way.
+# Scans every `.rs` file under crates/ -- source, tests, benches, and
+# examples alike (build-artifact `target`/`.cargo-target` dirs excluded,
+# same as .gitignore). There is no reachability/cfg analysis: a placeholder
+# message is a placeholder message whether or not the code compiling it is
+# test-gated. The small number of legitimate matches (a test mock whose
+# type/method name happens to contain a placeholder word) are suppressed via
+# the explicit, in-diff reviewed allowlist at stub-marker-allowlist.txt --
+# see that file's header for the format.
 set -eu
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
@@ -26,6 +29,7 @@ self_test() {
     trap 'rm -rf "$tmp"' EXIT
 
     mkdir -p "$tmp/case-fail/crates/fixture-crate/src"
+    mkdir -p "$tmp/case-fail/crates/fixture-crate/tests"
     mkdir -p "$tmp/case-pass/crates/fixture-crate/src"
 
     cat > "$tmp/case-fail/crates/fixture-crate/src/lib.rs" <<'FIXTURE'
@@ -55,16 +59,6 @@ const NOTE: &str = "warning: #[cfg(test)] { this is not a real attribute }";
 pub fn after_lookalike_string(flag: bool) -> u32 {
     if !flag {
         panic!("not implemented for this flag");
-    }
-    1
-}
-
-#[cfg(test)]
-const GREETING: &str = "x";
-
-pub fn after_nonbraced_cfg_test_item(flag: bool) -> u32 {
-    if !flag {
-        panic!("not implemented after a non-braced cfg(test) item");
     }
     1
 }
@@ -106,45 +100,66 @@ pub fn after_concat_stub(flag: bool) -> u32 {
     1
 }
 
-#[cfg(any(test, feature = "test-support"))]
-pub fn composite_test_gated_stub() -> u32 {
-    panic!("todo: still a stub behind a cfg(any(test, feature)) composite, must never reach shipping scan")
+pub fn unicode_escape_stub(flag: bool) -> u32 {
+    if !flag {
+        panic!("t\u{6f}do: only catches via unicode escape decoding");
+    }
+    1
 }
 
-#[cfg(not(test))]
-pub fn after_not_test_cfg_stub(flag: bool) -> u32 {
+pub fn hex_escape_stub(flag: bool) -> u32 {
     if !flag {
-        panic!("todo: still not implemented behind a cfg(not(test)) attribute, must always be scanned");
+        panic!("s\x74ub: only catches via hex escape decoding");
+    }
+    1
+}
+
+pub fn sql_with_line_continuation() -> &'static str {
+    // Rust's backslash-newline string continuation (used throughout this
+    // codebase for long multi-line SQL literals) strips the newline and
+    // following whitespace from the string value -- it must not desync the
+    // lexer for whatever code follows it.
+    "SELECT * FROM widgets \
+     WHERE active = 1"
+}
+
+pub fn after_line_continuation_string(flag: bool) -> u32 {
+    if !flag {
+        panic!("todo: still not implemented after a backslash-newline string continuation");
     }
     1
 }
 
 #[cfg(test)]
-mod ext_tests;
+fn const_generic_default_guard<const N: usize = { 4 }>() -> usize {
+    if N == 0 {
+        panic!("todo: a placeholder inside a #[cfg(test)] item must now be caught");
+    }
+    N
+}
 FIXTURE
 
     # Appended via printf (not the quoted heredoc above) so the fixture can
     # carry a real ESC byte and a real embedded newline inside the panic
-    # message -- the exact CI-log-forgery shape blocking fix 2 sanitizes.
+    # message -- the exact CI-log-forgery shape this scanner sanitizes.
     printf '\npub fn ci_log_forgery_stub(flag: bool) -> u32 {\n    if !flag {\n        panic!("todo: stub \033[31m::error::forged\nmid-message newline injection");\n    }\n    1\n}\n' \
         >> "$tmp/case-fail/crates/fixture-crate/src/lib.rs"
 
-    # External test module (blocking fix 3): `src/lib.rs` above declares
-    # `#[cfg(test)] mod ext_tests;` -- Rust's external-module-file form.
-    # Nothing inside ext_tests.rs itself carries a #[cfg(test)] attribute; the
-    # gate lives entirely in the parent's mod declaration. clippy --lib --bins
-    # never compiles it, so this placeholder must never be scanned.
-    cat > "$tmp/case-fail/crates/fixture-crate/src/ext_tests.rs" <<'EXTFIXTURE'
-pub fn only_reachable_from_cfg_test_mod_decl() {
-    panic!("todo: external test module content must never be scanned because it is only reachable via a cfg(test)-gated external mod declaration");
+    # A placeholder panic living under tests/ (previously pruned from
+    # discovery entirely) must now be caught -- nothing is excluded by
+    # location anymore, only by the explicit allowlist.
+    cat > "$tmp/case-fail/crates/fixture-crate/tests/integration.rs" <<'TESTFIXTURE'
+#[test]
+fn placeholder_inside_tests_dir() {
+    panic!("todo: a placeholder inside a tests/ directory file must now be caught");
 }
-EXTFIXTURE
+TESTFIXTURE
 
-    # Filename-injection fixture (blocking fix 1): the filename itself -- not
-    # the panic message -- carries a real newline and an unbroken
-    # `::error::forged` sequence. If a rendered finding line ever echoes this
-    # path unsanitized, it forges a GitHub Actions workflow command the same
-    # way an unsanitized message would.
+    # Filename-injection fixture: the filename itself -- not the panic
+    # message -- carries a real newline and an unbroken `::error::forged`
+    # sequence. If a rendered finding line ever echoes this path
+    # unsanitized, it forges a GitHub Actions workflow command the same way
+    # an unsanitized message would.
     newline_filename="exploit$(printf '\n')::error::forged.rs"
     cat > "$tmp/case-fail/crates/fixture-crate/src/$newline_filename" <<'NLFIXTURE'
 pub fn newline_filename_stub() -> u32 {
@@ -193,6 +208,10 @@ pub fn concat_arg_dispatch(kind: &str) -> u32 {
     }
 }
 
+// Mirrors the real crates/kkernel/src/reindex.rs mock pattern (a #[cfg(test)]
+// EmbeddingService mock named StubService whose guard message names the
+// mock's own type/method, not a real placeholder) -- the reason
+// stub-marker-allowlist.txt exists.
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -210,22 +229,14 @@ mod tests {
         assert_eq!(dispatch("a"), 1);
     }
 }
-
-#[cfg(test)]
-fn const_generic_default_guard<const N: usize = { 4 }>() -> usize {
-    if N == 0 {
-        panic!("todo: still a stub guarded by cfg(test), must never reach shipping scan");
-    }
-    N
-}
 FIXTURE
 
     status=0
 
-    # Exactly 12 markers are seeded in case-fail above; asserting the count
+    # Exactly 15 markers are seeded in case-fail above; asserting the count
     # (not just substring presence) catches a parser-overmatch regression
     # that would otherwise slip through as an unnoticed extra finding.
-    expected_marker_count=12
+    expected_marker_count=15
 
     if scan "$tmp/case-fail" > "$tmp/fail.log" 2>&1; then
         echo "self-test FAILED: expected placeholder call sites were not caught"
@@ -243,14 +254,17 @@ FIXTURE
             "not implemented for other kinds yet" \
             "todo: handle the false branch" \
             "not implemented for this flag" \
-            "not implemented after a non-braced cfg(test) item" \
             "todo: still not implemented after a long comment gap" \
             "todo: still not implemented after a byte-raw string literal" \
-            "mid-message newline injection" \
             "todo: not implemented for the format-arg case" \
             "concat-assembled stub message" \
-            "todo: still not implemented behind a cfg(not(test)) attribute" \
-            "carries a newline and a forged CI workflow command sequence"
+            "only catches via unicode escape decoding" \
+            "only catches via hex escape decoding" \
+            "still not implemented after a backslash-newline string continuation" \
+            "a placeholder inside a #[cfg(test)] item must now be caught" \
+            "mid-message newline injection" \
+            "carries a newline and a forged CI workflow command sequence" \
+            "a placeholder inside a tests/ directory file must now be caught"
         do
             if ! grep -qF "$marker" "$tmp/fail.log"; then
                 echo "self-test FAILED: expected finding missing: $marker"
@@ -259,24 +273,9 @@ FIXTURE
             fi
         done
 
-        # blocking fix 3: an external test module (only reachable via a
-        # cfg(test)-gated `mod ext_tests;` in lib.rs) and a same-file
-        # cfg(any(test, ...)) composite must never surface as findings --
-        # clippy --lib --bins never compiles either.
-        if grep -qF 'external test module content' "$tmp/fail.log"; then
-            echo "self-test FAILED: content only reachable via a cfg(test)-gated external mod declaration was scanned"
-            cat "$tmp/fail.log"
-            status=1
-        fi
-        if grep -qF 'cfg(any(test, feature)) composite' "$tmp/fail.log"; then
-            echo "self-test FAILED: an item gated by a cfg(any(test, ...)) composite was scanned"
-            cat "$tmp/fail.log"
-            status=1
-        fi
-
-        # blocking fix 2: the ci_log_forgery_stub message above carries a raw
-        # ANSI escape, a literal "::error::forged" workflow-command shape, and
-        # an embedded newline -- none of the three may survive into CI stdout.
+        # the ci_log_forgery_stub message above carries a raw ANSI escape, a
+        # literal "::error::forged" workflow-command shape, and an embedded
+        # newline -- none of the three may survive into CI stdout.
         esc="$(printf '\033')"
         if grep -qF "$esc" "$tmp/fail.log"; then
             echo "self-test FAILED: a raw ANSI escape byte leaked into CI output"
@@ -299,10 +298,10 @@ FIXTURE
             status=1
         fi
 
-        # blocking fix 1: the fixture filename itself (not its content)
-        # carries a real newline and an unbroken "::error::forged" sequence
-        # -- the rendered path must be sanitized the same way a message is,
-        # and the whole finding must survive as a single, unbroken CI line.
+        # the fixture filename itself (not its content) carries a real
+        # newline and an unbroken "::error::forged" sequence -- the rendered
+        # path must be sanitized the same way a message is, and the whole
+        # finding must survive as a single, unbroken CI line.
         if ! grep -Eq 'exploit.*forged\.rs.*reads as a placeholder stub' "$tmp/fail.log"; then
             echo "self-test FAILED: the embedded newline in the fixture filename split the CI finding line in two, or the sanitized path did not render as expected"
             cat "$tmp/fail.log"
@@ -311,9 +310,41 @@ FIXTURE
     fi
 
     if ! scan "$tmp/case-pass" > "$tmp/pass.log" 2>&1; then
-        echo "self-test FAILED: legitimate panic!/unreachable! messages (raw strings, lookalike text inside strings, a #[cfg(test)] helper named StubService, a #[cfg(test)] item with a signature brace before its body) false-positived:"
+        echo "self-test FAILED: legitimate panic!/unreachable! messages (raw strings, lookalike text inside strings, a #[cfg(test)] helper named StubService) false-positived:"
         cat "$tmp/pass.log"
         status=1
+    fi
+
+    # Allowlist suppression: one fixture finding matches an allowlist entry
+    # (by path substring AND decoded-message substring) and must be
+    # suppressed; a sibling finding that does not match must still surface.
+    mkdir -p "$tmp/case-allowlist/crates/fixture-crate/src"
+    cat > "$tmp/case-allowlist/crates/fixture-crate/src/lib.rs" <<'ALWFIXTURE'
+pub fn allowlisted_stub() -> u32 {
+    panic!("todo: this one is allowlisted and must be suppressed")
+}
+
+pub fn not_allowlisted_stub() -> u32 {
+    panic!("todo: this one is NOT allowlisted and must still be caught")
+}
+ALWFIXTURE
+    printf 'fixture-crate/src/lib.rs\tthis one is allowlisted\n' > "$tmp/self-test-allowlist.txt"
+
+    if STUB_MARKER_ALLOWLIST="$tmp/self-test-allowlist.txt" scan "$tmp/case-allowlist" > "$tmp/allowlist.log" 2>&1; then
+        echo "self-test FAILED: the non-allowlisted sibling finding should have failed the scan"
+        cat "$tmp/allowlist.log"
+        status=1
+    else
+        if grep -qF 'this one is allowlisted' "$tmp/allowlist.log"; then
+            echo "self-test FAILED: an allowlisted finding was not suppressed"
+            cat "$tmp/allowlist.log"
+            status=1
+        fi
+        if ! grep -qF 'this one is NOT allowlisted' "$tmp/allowlist.log"; then
+            echo "self-test FAILED: a sibling non-allowlisted finding was incorrectly suppressed"
+            cat "$tmp/allowlist.log"
+            status=1
+        fi
     fi
 
     if [ "$status" -eq 0 ]; then
@@ -329,31 +360,35 @@ scan() {
     # NUL-delimited discovery and transport end-to-end: a filename may
     # legally contain a newline (or any byte but NUL and `/`), and this
     # scanner's own findings later echo filenames straight into CI stdout.
-    # Word/newline-splitting a file list (the previous `$(find ...)` capture
-    # into a newline-joined string) lets such a filename inject extra,
-    # bogus list entries -- or, once rendered, forge GitHub Actions
-    # workflow-command lines. `-print0` + a NUL-delimited transport file
-    # sidesteps splitting entirely; `sanitize_for_ci` (applied to every
-    # rendered path below, the same function already used on messages)
-    # handles the render side.
+    # `-print0` + a NUL-delimited transport file sidesteps splitting
+    # entirely; `sanitize_for_ci` (applied to every rendered path below, the
+    # same function already used on messages) handles the render side.
+    #
+    # Only `target`/`.cargo-target` (build-artifact dirs, per .gitignore)
+    # are pruned -- everything else under crates/, including tests/,
+    # benches/, and examples/, is in scan scope.
     find "$root/crates" \
-        \( -name 'target' -o -name 'target-wt' -o -name 'tests' -o -name 'benches' -o -name 'examples' \) -type d -prune \
-        -o -path '*/src/*.rs' -type f -print0 \
+        \( -name 'target' -o -name '.cargo-target' \) -type d -prune \
+        -o -name '*.rs' -type f -print0 \
         > "$file_list"
 
     if [ ! -s "$file_list" ]; then
         rm -f "$file_list"
-        echo "no source files matched crates/*/src/**/*.rs under $root/crates (excluding target*/tests/benches/examples) -- the scanner would silently be a no-op; fix the file-layout selection" >&2
+        echo "no .rs files matched under $root/crates (excluding target/.cargo-target build-artifact dirs) -- the scanner would silently be a no-op; fix the file-layout selection" >&2
         return 1
     fi
 
-    python3 - "$file_list" <<'PY'
+    allowlist="${STUB_MARKER_ALLOWLIST:-$SCRIPT_DIR/stub-marker-allowlist.txt}"
+
+    python3 - "$file_list" "$allowlist" <<'PY'
 import os
 import re
 import sys
 
 with open(sys.argv[1], "rb") as fh:
     files = sorted(os.fsdecode(f) for f in fh.read().split(b"\0") if f)
+
+ALLOWLIST_PATH = sys.argv[2]
 
 PLACEHOLDER_RE = re.compile(
     r"\b(stub|todo|fixme|placeholder|unimplemented|not\s*yet\s*implemented|"
@@ -364,15 +399,21 @@ PLACEHOLDER_RE = re.compile(
 # (`panic!(...)`, `panic!{...}`, `panic![...]`) -- all three are legal macro
 # call syntax, not just parens.
 MACRO_CALL_RE = re.compile(r"\b(panic|unreachable)\s*!\s*([(\{\[])")
-STRING_LIT_RE = re.compile(r'"((?:[^"\\]|\\.)*)"')
-CFG_ATTR_START_RE = re.compile(r"#\s*\[\s*cfg\s*\(")
-ATTR_RE = re.compile(r"#\s*!?\s*\[[^\[\]]*\]\s*")
-MOD_DECL_RE = re.compile(r"mod\s+([A-Za-z_][A-Za-z0-9_]*)\s*;")
-NOT_TEST_RE = re.compile(r"not\s*\(\s*test\s*\)")
-TEST_IDENT_RE = re.compile(r"\btest\b")
-WHITESPACE_RE = re.compile(r"\s*")
+# re.DOTALL: Rust's backslash-newline string continuation (`"...\<newline>
+# ..."`, used throughout this codebase for long multi-line SQL literals)
+# puts a literal `\` immediately before a `\n` inside a plain string. Without
+# DOTALL, `\.` in the escaped-char alternative never matches that `\n`, so
+# the literal never finds its closing quote here -- and the next real `"`
+# anywhere later in the file gets mistaken for a fresh opening quote,
+# silently blanking arbitrary code (including real panic!/unreachable!
+# calls) as if it were string content. `[^"\\]` already matches newlines
+# regardless of DOTALL (character classes aren't affected by the flag); this
+# only changes what `\.` matches.
+STRING_LIT_RE = re.compile(r'"((?:[^"\\]|\\.)*)"', re.DOTALL)
 ANSI_ESCAPE_RE = re.compile(r"\x1b\[[0-9;]*[a-zA-Z]|\x1b.")
 CLOSERS = {"(": ")", "{": "}", "[": "]"}
+ESCAPE_RE = re.compile(r"\\(n|r|t|\\|\"|'|0|x[0-9A-Fa-f]{2}|u\{[0-9A-Fa-f]+\})")
+SIMPLE_ESCAPES = {"n": "\n", "r": "\r", "t": "\t", "\\": "\\", '"': '"', "'": "'", "0": "\0"}
 
 
 def sanitize_for_ci(raw):
@@ -505,12 +546,12 @@ def strip_comments_and_char_lits(text):
 def match_string_literal(text, pos):
     """Match a plain or raw string literal beginning at pos in `text` (which
     must have string content intact, i.e. `clean`, never the strings-blanked
-    variant). Returns (end_offset, inner_content) or None."""
+    variant). Returns (end_offset, inner_content, is_raw) or None."""
     if pos >= len(text):
         return None
     if text[pos] == '"':
         m = STRING_LIT_RE.match(text, pos)
-        return None if m is None else (m.end(), m.group(1))
+        return None if m is None else (m.end(), m.group(1), False)
     rs_end = raw_string_end(text, pos)
     if rs_end is None:
         return None
@@ -519,14 +560,14 @@ def match_string_literal(text, pos):
     while text[j] == "#":
         hashes += 1
         j += 1
-    return rs_end, text[j + 1 : rs_end - 1 - hashes]
+    return rs_end, text[j + 1 : rs_end - 1 - hashes], True
 
 
 def blank_strings(clean_text):
     """Given `clean` (comments/char-lits stripped, strings intact), replace
     every plain and raw string literal's content with spaces (newlines kept)
-    so downstream scans (cfg(test) attribute detection, macro-call matching)
-    never mistake text living inside a string literal for real code."""
+    so downstream macro-call matching never mistakes text living inside a
+    string literal for real code."""
     out = list(clean_text)
     i = 0
     n = len(clean_text)
@@ -549,54 +590,6 @@ def blank_strings(clean_text):
     return "".join(out)
 
 
-def find_item_head_end(code_only, start):
-    """Scan an item's head (from just after its `#[cfg(test)]` attribute) for
-    the item's own body-opening `{` or, for a non-braced item, its
-    terminating `;` -- both counted only at signature level, i.e. outside any
-    `()`, `[]`, or `<>` nesting. A brace living inside the signature (a
-    generic const default's block, e.g. `<const N: usize = { 4 }>`, or an
-    array-length const block in a where-clause bound, e.g.
-    `where [(); { 1 }]: Sized`) is not the item body -- it is skipped as a
-    balanced, opaque unit so it can never be mistaken for the body opener.
-    Returns `("brace", offset)` / `("semi", offset)`, or None if the head
-    runs off the end of the file unterminated."""
-    n = len(code_only)
-    i = start
-    paren = bracket = angle = 0
-    while i < n:
-        c = code_only[i]
-        if c == "(":
-            paren += 1
-        elif c == ")":
-            paren = max(0, paren - 1)
-        elif c == "[":
-            bracket += 1
-        elif c == "]":
-            bracket = max(0, bracket - 1)
-        elif c == "<":
-            angle += 1
-        elif c == ">":
-            if angle > 0:
-                angle -= 1
-        elif c == "{":
-            if paren == 0 and bracket == 0 and angle == 0:
-                return ("brace", i)
-            depth = 1
-            i += 1
-            while i < n and depth > 0:
-                if code_only[i] == "{":
-                    depth += 1
-                elif code_only[i] == "}":
-                    depth -= 1
-                i += 1
-            continue
-        elif c == ";":
-            if paren == 0 and bracket == 0 and angle == 0:
-                return ("semi", i)
-        i += 1
-    return None
-
-
 def find_matching_close(code_only, open_pos):
     """code_only[open_pos] is an opening `(`/`{`/`[`; return the offset of its
     same-type-nesting-depth matching close, or len(code_only) if
@@ -617,170 +610,8 @@ def find_matching_close(code_only, open_pos):
     return i - 1 if depth == 0 else n
 
 
-def is_test_gated_predicate(predicate):
-    """True if this #[cfg(...)] predicate can only be satisfied when --cfg
-    test is set -- matching what `cargo clippy --lib --bins` never compiles
-    (it never passes --cfg test). Covers the bare `test` predicate and any
-    any(...)/all(...) composite carrying `test` as a direct operand
-    (`any(test, feature = "x")`, `all(test, feature = "x")`) -- in this
-    codebase both shapes gate test-only helpers behind a feature that is
-    never active in a plain --lib --bins build, so treating either as
-    test-gated matches actual clippy behavior. `not(test)` is stripped
-    before the check: an item gated by `not(test)` (or `all(not(test), ...)`)
-    compiles precisely when test is ABSENT, i.e. always under --lib --bins,
-    so it must stay in scan scope, never be excluded."""
-    stripped = NOT_TEST_RE.sub(" ", predicate)
-    return bool(TEST_IDENT_RE.search(stripped))
-
-
-def find_test_gated_cfg_attrs(code_only):
-    """[(attr_start, attr_end), ...] for every #[cfg(...)] attribute in
-    code_only whose predicate is_test_gated_predicate. attr_end is the
-    offset just past the attribute's closing `]`. Balanced-paren parsing
-    (via find_matching_close) means a composite predicate's own nested
-    parens -- any(test, ...), all(test, ...) -- are captured whole, unlike
-    the old fixed `#[cfg(test)]`-only regex."""
-    results = []
-    n = len(code_only)
-    for m in CFG_ATTR_START_RE.finditer(code_only):
-        paren_start = m.end() - 1
-        close = find_matching_close(code_only, paren_start)
-        if close >= n:
-            continue
-        predicate = code_only[paren_start + 1 : close]
-        j = close + 1
-        while j < n and code_only[j].isspace():
-            j += 1
-        if j >= n or code_only[j] != "]":
-            continue
-        attr_end = j + 1
-        if is_test_gated_predicate(predicate):
-            results.append((m.start(), attr_end))
-    return results
-
-
-def test_gated_spans(code_only):
-    """Byte-offset [start, end) spans of every item gated by a test-shaped
-    #[cfg(...)] attribute (is_test_gated_predicate) -- clippy --lib --bins
-    never compiles these, so the scanner must not flag placeholder messages
-    living only in such code. Runs on the strings-blanked `code_only` text
-    so a cfg-attribute-shaped substring living inside a string literal is
-    never mistaken for a real attribute. For a non-braced item (e.g.
-    `#[cfg(test)] const X: u32 = 1;`) the span ends at the terminating `;`;
-    for a braced item (including `#[cfg(test)] mod tests { ... }`, whose
-    entire body is covered by the balanced brace count) it ends at the
-    body's balanced close, per find_item_head_end above."""
-    spans = []
-    n = len(code_only)
-    for attr_start, attr_end in find_test_gated_cfg_attrs(code_only):
-        head = find_item_head_end(code_only, attr_end)
-        if head is None:
-            continue
-        kind, pos = head
-        if kind == "semi":
-            spans.append((attr_start, pos + 1))
-            continue
-        depth = 1
-        i = pos + 1
-        while i < n and depth > 0:
-            if code_only[i] == "{":
-                depth += 1
-            elif code_only[i] == "}":
-                depth -= 1
-            i += 1
-        spans.append((attr_start, i))
-    return spans
-
-
-def skip_attrs_and_ws(code_only, pos):
-    """Advance past a run of `#[...]`/`#![...]` attributes and whitespace
-    starting at pos, so a cfg-gated `mod name;` declaration is still found
-    even when other attributes (`#[allow(dead_code)]`, doc comments already
-    blanked by strip_comments_and_char_lits, ...) sit between the cfg
-    attribute and the mod keyword."""
-    n = len(code_only)
-    while True:
-        m = ATTR_RE.match(code_only, pos)
-        if m is None:
-            break
-        pos = m.end()
-    ws = WHITESPACE_RE.match(code_only, pos)
-    return ws.end()
-
-
-def find_test_gated_external_mod_decls(parent_code_only):
-    """Module names declared as `#[cfg(test)] mod NAME;` (or an any/all-over-
-    test composite, is_test_gated_predicate) in this already
-    comments/strings-stripped parent-module source. Only the semicolon
-    (external-file) mod form matters here -- a braced `mod NAME { ... }` is
-    an inline module already covered by test_gated_spans' own balanced span
-    for that same file."""
-    names = set()
-    for attr_start, attr_end in find_test_gated_cfg_attrs(parent_code_only):
-        j = skip_attrs_and_ws(parent_code_only, attr_end)
-        m = MOD_DECL_RE.match(parent_code_only, j)
-        if m:
-            names.add(m.group(1))
-    return names
-
-
-def compute_externally_test_gated_files(files):
-    """Path set of every file reachable ONLY via a `#[cfg(test)] mod NAME;`
-    declaration in its parent module file -- Rust's external-module-file
-    form (e.g. `src/foo.rs` declaring `#[cfg(test)] mod tests;` for a
-    sibling `src/foo/tests.rs` or `src/foo/tests/mod.rs`). Nothing INSIDE
-    such a file carries a #[cfg(test)] attribute itself -- the gate lives in
-    the parent -- so test_gated_spans (which only looks within a single
-    file) cannot see it; clippy --lib --bins still never compiles it, since
-    the mod statement pulling it in is itself test-gated. Best-effort:
-    resolves only the single-parent-candidate cases Rust's module system
-    actually allows (`X.rs` or `X/mod.rs` declaring `mod Y;` for `X/Y.rs` or
-    `X/Y/mod.rs`, or `src/lib.rs`/`src/main.rs` for a crate-root `mod Y;`)."""
-    by_norm = {os.path.normpath(f): f for f in files}
-    parent_cache = {}
-    excluded = set()
-    for f in files:
-        norm = os.path.normpath(f)
-        d, base = os.path.split(norm)
-        stem, ext = os.path.splitext(base)
-        if ext != ".rs":
-            continue
-        if base == "mod.rs":
-            mod_name = os.path.basename(d)
-            owning_dir = os.path.dirname(d)
-        else:
-            mod_name = stem
-            owning_dir = d
-        if os.path.basename(owning_dir) == "src":
-            candidates = [
-                os.path.join(owning_dir, "lib.rs"),
-                os.path.join(owning_dir, "main.rs"),
-            ]
-        else:
-            candidates = [
-                os.path.join(os.path.dirname(owning_dir), os.path.basename(owning_dir) + ".rs"),
-                os.path.join(owning_dir, "mod.rs"),
-            ]
-        for cand in candidates:
-            cand_norm = os.path.normpath(cand)
-            if cand_norm == norm or cand_norm not in by_norm:
-                continue
-            if cand_norm not in parent_cache:
-                with open(by_norm[cand_norm], "r", encoding="utf-8") as fh:
-                    parent_text = fh.read()
-                parent_cache[cand_norm] = blank_strings(strip_comments_and_char_lits(parent_text))
-            if mod_name in find_test_gated_external_mod_decls(parent_cache[cand_norm]):
-                excluded.add(f)
-                break
-    return excluded
-
-
-def in_span(offset, spans):
-    return any(start <= offset < end for start, end in spans)
-
-
 def collect_string_literals(clean, start, end):
-    """All string-literal contents (plain or raw) found anywhere in
+    """All (content, is_raw) string-literal pairs found anywhere in
     clean[start:end], in source order. Used to scan a panic!/unreachable!
     macro's full balanced argument list -- not just the token immediately
     after the opening delimiter -- so a placeholder message hiding behind a
@@ -794,14 +625,63 @@ def collect_string_literals(clean, start, end):
     while i < end:
         lit = match_string_literal(clean, i)
         if lit is not None and lit[0] <= end:
-            parts.append(lit[1])
+            parts.append((lit[1], lit[2]))
             i = lit[0]
             continue
         i += 1
     return parts
 
 
-externally_gated_files = compute_externally_test_gated_files(files)
+def decode_rust_escapes(body, is_raw):
+    """Decode the Rust string-literal escapes a PLACEHOLDER_RE match needs
+    to see through (\\n \\r \\t \\\\ \\" \\' \\0, \\xNN, \\u{...}) so an
+    escape-obfuscated placeholder (e.g. `panic!("t\\u{6f}do: ...")`) is
+    still caught. Raw literals (`r"..."`, `r#"..."#`) have no escapes --
+    returned unchanged. Any other backslash sequence is left as-is."""
+    if is_raw:
+        return body
+
+    def repl(m):
+        tok = m.group(1)
+        if tok in SIMPLE_ESCAPES:
+            return SIMPLE_ESCAPES[tok]
+        if tok[0] == "x":
+            return chr(int(tok[1:], 16))
+        return chr(int(tok[2:-1], 16))  # u{...}
+
+    return ESCAPE_RE.sub(repl, body)
+
+
+def load_allowlist(path):
+    """Parse `<path-substring>\\t<message-substring>` entries from the
+    allowlist file at `path`. Blank lines and lines starting with `#` (after
+    stripping leading whitespace) are ignored. A missing file (e.g. a caller
+    override pointing at a path that does not exist) is an empty allowlist,
+    not an error."""
+    entries = []
+    if not os.path.isfile(path):
+        return entries
+    with open(path, "r", encoding="utf-8") as fh:
+        for raw_line in fh:
+            line = raw_line.rstrip("\n")
+            if not line.strip() or line.lstrip().startswith("#"):
+                continue
+            if "\t" not in line:
+                continue
+            path_sub, message_sub = line.split("\t", 1)
+            entries.append((path_sub, message_sub))
+    return entries
+
+
+def is_allowlisted(path, message, entries):
+    """A finding is suppressed iff some entry's path-substring is contained
+    in the file path AND its message-substring is contained in the decoded
+    panic!/unreachable! message. An entry that matches nothing in a given
+    run is not an error."""
+    return any(path_sub in path and message_sub in message for path_sub, message_sub in entries)
+
+
+allowlist = load_allowlist(ALLOWLIST_PATH)
 
 findings = []
 for path in files:
@@ -809,18 +689,8 @@ for path in files:
         text = fh.read()
     clean = strip_comments_and_char_lits(text)
     code_only = blank_strings(clean)
-    if path in externally_gated_files:
-        # The whole file is reachable only via a test-gated external `mod
-        # NAME;` declaration in its parent -- see
-        # compute_externally_test_gated_files. Nothing in it ever compiles
-        # under --lib --bins, so none of its content is in scan scope.
-        test_spans = [(0, len(code_only))]
-    else:
-        test_spans = test_gated_spans(code_only)
 
     for m in MACRO_CALL_RE.finditer(code_only):
-        if in_span(m.start(), test_spans):
-            continue
         call_start = m.end() - 1  # the opening delimiter char (`(`/`{`/`[`)
         # Scan every string literal within the macro's own balanced argument
         # list (in source order), not just the token immediately after the
@@ -831,13 +701,16 @@ for path in files:
         parts = collect_string_literals(clean, call_start + 1, close_pos)
         if not parts:
             continue
-        message = "".join(parts)
-        if PLACEHOLDER_RE.search(message):
-            line_no = clean.count("\n", 0, m.start()) + 1
-            macro_name = m.group(1)
-            safe_path = sanitize_for_ci(path)
-            safe_message = sanitize_for_ci(message)
-            findings.append(f"{safe_path}:{line_no}: {macro_name}!(\"{safe_message}\") reads as a placeholder stub, not a real error path")
+        message = "".join(decode_rust_escapes(content, is_raw) for content, is_raw in parts)
+        if not PLACEHOLDER_RE.search(message):
+            continue
+        if is_allowlisted(path, message, allowlist):
+            continue
+        line_no = clean.count("\n", 0, m.start()) + 1
+        macro_name = m.group(1)
+        safe_path = sanitize_for_ci(path)
+        safe_message = sanitize_for_ci(message)
+        findings.append(f"{safe_path}:{line_no}: {macro_name}!(\"{safe_message}\") reads as a placeholder stub, not a real error path")
 
 if findings:
     for f in findings:

--- a/scripts/lint-stub-markers.sh
+++ b/scripts/lint-stub-markers.sh
@@ -93,6 +93,12 @@ pub fn after_byte_raw_string_literal(flag: bool) -> u32 {
 }
 FIXTURE
 
+    # Appended via printf (not the quoted heredoc above) so the fixture can
+    # carry a real ESC byte and a real embedded newline inside the panic
+    # message -- the exact CI-log-forgery shape blocking fix 2 sanitizes.
+    printf '\npub fn ci_log_forgery_stub(flag: bool) -> u32 {\n    if !flag {\n        panic!("todo: stub \033[31m::error::forged\nmid-message newline injection");\n    }\n    1\n}\n' \
+        >> "$tmp/case-fail/crates/fixture-crate/src/lib.rs"
+
     cat > "$tmp/case-pass/crates/fixture-crate/src/lib.rs" <<'FIXTURE'
 pub fn dispatch(kind: &str) -> u32 {
     match kind {
@@ -137,14 +143,22 @@ mod tests {
         assert_eq!(dispatch("a"), 1);
     }
 }
+
+#[cfg(test)]
+fn const_generic_default_guard<const N: usize = { 4 }>() -> usize {
+    if N == 0 {
+        panic!("todo: still a stub guarded by cfg(test), must never reach shipping scan");
+    }
+    N
+}
 FIXTURE
 
     status=0
 
-    # Exactly 7 markers are seeded in case-fail above; asserting the count
+    # Exactly 8 markers are seeded in case-fail above; asserting the count
     # (not just substring presence) catches a parser-overmatch regression
     # that would otherwise slip through as an unnoticed extra finding.
-    expected_marker_count=7
+    expected_marker_count=8
 
     if scan "$tmp/case-fail" > "$tmp/fail.log" 2>&1; then
         echo "self-test FAILED: expected placeholder call sites were not caught"
@@ -164,7 +178,8 @@ FIXTURE
             "not implemented for this flag" \
             "not implemented after a non-braced cfg(test) item" \
             "todo: still not implemented after a long comment gap" \
-            "todo: still not implemented after a byte-raw string literal"
+            "todo: still not implemented after a byte-raw string literal" \
+            "mid-message newline injection"
         do
             if ! grep -qF "$marker" "$tmp/fail.log"; then
                 echo "self-test FAILED: expected finding missing: $marker"
@@ -172,10 +187,35 @@ FIXTURE
                 status=1
             fi
         done
+
+        # blocking fix 2: the ci_log_forgery_stub message above carries a raw
+        # ANSI escape, a literal "::error::forged" workflow-command shape, and
+        # an embedded newline -- none of the three may survive into CI stdout.
+        esc="$(printf '\033')"
+        if grep -qF "$esc" "$tmp/fail.log"; then
+            echo "self-test FAILED: a raw ANSI escape byte leaked into CI output"
+            cat "$tmp/fail.log"
+            status=1
+        fi
+        if grep -qF '::error::forged' "$tmp/fail.log"; then
+            echo "self-test FAILED: an unbroken '::error::forged' workflow command leaked into CI output"
+            cat "$tmp/fail.log"
+            status=1
+        fi
+        if grep -n '^::' "$tmp/fail.log" | grep -q .; then
+            echo "self-test FAILED: a CI output line starts with '::' (workflow-command syntax)"
+            cat "$tmp/fail.log"
+            status=1
+        fi
+        if ! grep -q 'mid-message newline injection.*reads as a placeholder stub' "$tmp/fail.log"; then
+            echo "self-test FAILED: the embedded newline in the panic message split the CI log line in two"
+            cat "$tmp/fail.log"
+            status=1
+        fi
     fi
 
     if ! scan "$tmp/case-pass" > "$tmp/pass.log" 2>&1; then
-        echo "self-test FAILED: legitimate panic!/unreachable! messages (raw strings, lookalike text inside strings, a #[cfg(test)] helper named StubService) false-positived:"
+        echo "self-test FAILED: legitimate panic!/unreachable! messages (raw strings, lookalike text inside strings, a #[cfg(test)] helper named StubService, a #[cfg(test)] item with a signature brace before its body) false-positived:"
         cat "$tmp/pass.log"
         status=1
     fi
@@ -216,6 +256,24 @@ MACRO_CALL_RE = re.compile(r"\b(panic|unreachable)\s*!\s*([(\{\[])")
 STRING_LIT_RE = re.compile(r'"((?:[^"\\]|\\.)*)"')
 CFG_TEST_RE = re.compile(r"#\s*\[\s*cfg\s*\(\s*test\s*\)\s*\]")
 WHITESPACE_RE = re.compile(r"\s*")
+ANSI_ESCAPE_RE = re.compile(r"\x1b\[[0-9;]*[a-zA-Z]|\x1b.")
+
+
+def sanitize_for_ci(raw):
+    """The panic!/unreachable! message text this scanner echoes into CI
+    stdout comes straight from a PR-controlled string literal. GitHub Actions
+    parses a `::name ...::value`-shaped line as a workflow command
+    (`::error::`, `::add-mask::`, `::set-output::`, ...), so an embedded
+    newline could let attacker text start a fresh line and forge one, and
+    ANSI escapes can rewrite terminal/log-viewer state. Strip ANSI escapes,
+    collapse newlines to a literal `\\n` (never a real line break), and break
+    every `::` so no substring can be parsed as workflow-command syntax --
+    all while keeping the text readable for a human operator."""
+    s = ANSI_ESCAPE_RE.sub("", raw)
+    s = s.replace("\x1b", "")
+    s = s.replace("\r\n", "\\n").replace("\n", "\\n").replace("\r", "\\n")
+    s = s.replace("::", ": :")
+    return s
 
 
 def raw_string_end(text, i):
@@ -375,6 +433,54 @@ def blank_strings(clean_text):
     return "".join(out)
 
 
+def find_item_head_end(code_only, start):
+    """Scan an item's head (from just after its `#[cfg(test)]` attribute) for
+    the item's own body-opening `{` or, for a non-braced item, its
+    terminating `;` -- both counted only at signature level, i.e. outside any
+    `()`, `[]`, or `<>` nesting. A brace living inside the signature (a
+    generic const default's block, e.g. `<const N: usize = { 4 }>`, or an
+    array-length const block in a where-clause bound, e.g.
+    `where [(); { 1 }]: Sized`) is not the item body -- it is skipped as a
+    balanced, opaque unit so it can never be mistaken for the body opener.
+    Returns `("brace", offset)` / `("semi", offset)`, or None if the head
+    runs off the end of the file unterminated."""
+    n = len(code_only)
+    i = start
+    paren = bracket = angle = 0
+    while i < n:
+        c = code_only[i]
+        if c == "(":
+            paren += 1
+        elif c == ")":
+            paren = max(0, paren - 1)
+        elif c == "[":
+            bracket += 1
+        elif c == "]":
+            bracket = max(0, bracket - 1)
+        elif c == "<":
+            angle += 1
+        elif c == ">":
+            if angle > 0:
+                angle -= 1
+        elif c == "{":
+            if paren == 0 and bracket == 0 and angle == 0:
+                return ("brace", i)
+            depth = 1
+            i += 1
+            while i < n and depth > 0:
+                if code_only[i] == "{":
+                    depth += 1
+                elif code_only[i] == "}":
+                    depth -= 1
+                i += 1
+            continue
+        elif c == ";":
+            if paren == 0 and bracket == 0 and angle == 0:
+                return ("semi", i)
+        i += 1
+    return None
+
+
 def test_gated_spans(code_only):
     """Byte-offset [start, end) spans of every #[cfg(test)]-attributed item --
     clippy --lib --bins never compiles these (no --cfg test), so the scanner
@@ -382,21 +488,20 @@ def test_gated_spans(code_only):
     strings-blanked `code_only` text so a `#[cfg(test)]`-shaped substring
     living inside a string literal is never mistaken for a real attribute.
     For a non-braced item (e.g. `#[cfg(test)] const X: u32 = 1;`) the span
-    ends at the terminating `;`, not at some later item's `{` -- braces are
-    only brace-matched when `{` is the item's own opener (i.e. comes before
-    any `;`)."""
+    ends at the terminating `;`; for a braced item it ends at the body's
+    balanced close, per find_item_head_end above."""
     spans = []
     n = len(code_only)
     for m in CFG_TEST_RE.finditer(code_only):
-        semi = code_only.find(";", m.end())
-        brace = code_only.find("{", m.end())
-        if brace == -1 and semi == -1:
+        head = find_item_head_end(code_only, m.end())
+        if head is None:
             continue
-        if semi != -1 and (brace == -1 or semi < brace):
-            spans.append((m.start(), semi + 1))
+        kind, pos = head
+        if kind == "semi":
+            spans.append((m.start(), pos + 1))
             continue
         depth = 1
-        i = brace + 1
+        i = pos + 1
         while i < n and depth > 0:
             if code_only[i] == "{":
                 depth += 1
@@ -443,7 +548,8 @@ for path in files:
         if PLACEHOLDER_RE.search(message):
             line_no = clean.count("\n", 0, m.start()) + 1
             macro_name = m.group(1)
-            findings.append(f"{path}:{line_no}: {macro_name}!(\"{message}\") reads as a placeholder stub, not a real error path")
+            safe_message = sanitize_for_ci(message)
+            findings.append(f"{path}:{line_no}: {macro_name}!(\"{safe_message}\") reads as a placeholder stub, not a real error path")
 
 if findings:
     for f in findings:

--- a/scripts/lint-stub-markers.sh
+++ b/scripts/lint-stub-markers.sh
@@ -137,6 +137,14 @@ fn const_generic_default_guard<const N: usize = { 4 }>() -> usize {
     }
     N
 }
+
+pub fn split_marker_by_continuation_stub(flag: bool) -> u32 {
+    if !flag {
+        panic!("to\
+                do: a marker split across a backslash-newline continuation must still be caught");
+    }
+    1
+}
 FIXTURE
 
     # Appended via printf (not the quoted heredoc above) so the fixture can
@@ -236,7 +244,7 @@ FIXTURE
     # Exactly 15 markers are seeded in case-fail above; asserting the count
     # (not just substring presence) catches a parser-overmatch regression
     # that would otherwise slip through as an unnoticed extra finding.
-    expected_marker_count=15
+    expected_marker_count=16
 
     if scan "$tmp/case-fail" > "$tmp/fail.log" 2>&1; then
         echo "self-test FAILED: expected placeholder call sites were not caught"
@@ -261,6 +269,7 @@ FIXTURE
             "only catches via unicode escape decoding" \
             "only catches via hex escape decoding" \
             "still not implemented after a backslash-newline string continuation" \
+            "a marker split across a backslash-newline continuation must still be caught" \
             "a placeholder inside a #[cfg(test)] item must now be caught" \
             "mid-message newline injection" \
             "carries a newline and a forged CI workflow command sequence" \
@@ -315,9 +324,13 @@ FIXTURE
         status=1
     fi
 
-    # Allowlist suppression: one fixture finding matches an allowlist entry
-    # (by path substring AND decoded-message substring) and must be
-    # suppressed; a sibling finding that does not match must still surface.
+    # Allowlist suppression exercised against the COMMITTED allowlist file
+    # (no temp override): the committed `stub-marker-allowlist.txt` carries a
+    # self-test fixture anchor whose exact (repo-relative path, full message)
+    # pair matches the allowlisted fixture below, so a broken committed file
+    # (bad format, wrong path form) fails this test. Exact-match is checked in
+    # both directions -- the anchor-matching finding is suppressed, and a
+    # sibling with a different message at the same path still surfaces.
     mkdir -p "$tmp/case-allowlist/crates/fixture-crate/src"
     cat > "$tmp/case-allowlist/crates/fixture-crate/src/lib.rs" <<'ALWFIXTURE'
 pub fn allowlisted_stub() -> u32 {
@@ -328,15 +341,14 @@ pub fn not_allowlisted_stub() -> u32 {
     panic!("todo: this one is NOT allowlisted and must still be caught")
 }
 ALWFIXTURE
-    printf 'fixture-crate/src/lib.rs\tthis one is allowlisted\n' > "$tmp/self-test-allowlist.txt"
 
-    if STUB_MARKER_ALLOWLIST="$tmp/self-test-allowlist.txt" scan "$tmp/case-allowlist" > "$tmp/allowlist.log" 2>&1; then
+    if scan "$tmp/case-allowlist" > "$tmp/allowlist.log" 2>&1; then
         echo "self-test FAILED: the non-allowlisted sibling finding should have failed the scan"
         cat "$tmp/allowlist.log"
         status=1
     else
-        if grep -qF 'this one is allowlisted' "$tmp/allowlist.log"; then
-            echo "self-test FAILED: an allowlisted finding was not suppressed"
+        if grep -qF 'this one is allowlisted and must be suppressed' "$tmp/allowlist.log"; then
+            echo "self-test FAILED: an allowlisted finding (exact committed-allowlist match) was not suppressed"
             cat "$tmp/allowlist.log"
             status=1
         fi
@@ -380,7 +392,7 @@ scan() {
 
     allowlist="${STUB_MARKER_ALLOWLIST:-$SCRIPT_DIR/stub-marker-allowlist.txt}"
 
-    python3 - "$file_list" "$allowlist" <<'PY'
+    python3 - "$file_list" "$allowlist" "$root" <<'PY'
 import os
 import re
 import sys
@@ -389,6 +401,7 @@ with open(sys.argv[1], "rb") as fh:
     files = sorted(os.fsdecode(f) for f in fh.read().split(b"\0") if f)
 
 ALLOWLIST_PATH = sys.argv[2]
+SCAN_ROOT = sys.argv[3]
 
 PLACEHOLDER_RE = re.compile(
     r"\b(stub|todo|fixme|placeholder|unimplemented|not\s*yet\s*implemented|"
@@ -413,6 +426,12 @@ STRING_LIT_RE = re.compile(r'"((?:[^"\\]|\\.)*)"', re.DOTALL)
 ANSI_ESCAPE_RE = re.compile(r"\x1b\[[0-9;]*[a-zA-Z]|\x1b.")
 CLOSERS = {"(": ")", "{": "}", "[": "]"}
 ESCAPE_RE = re.compile(r"\\(n|r|t|\\|\"|'|0|x[0-9A-Fa-f]{2}|u\{[0-9A-Fa-f]+\})")
+# Rust string-continuation escape: a `\` immediately followed by a newline
+# removes the `\`, the newline, and the following whitespace (Rust reference,
+# "String continuation escapes"). A placeholder marker split across such a
+# continuation (`"to\<newline>    do"` == "todo") would otherwise evade
+# PLACEHOLDER_RE, so it is stripped before any other escape is decoded.
+STRING_CONTINUATION_RE = re.compile(r"\\\r?\n\s*")
 SIMPLE_ESCAPES = {"n": "\n", "r": "\r", "t": "\t", "\\": "\\", '"': '"', "'": "'", "0": "\0"}
 
 
@@ -636,10 +655,15 @@ def decode_rust_escapes(body, is_raw):
     """Decode the Rust string-literal escapes a PLACEHOLDER_RE match needs
     to see through (\\n \\r \\t \\\\ \\" \\' \\0, \\xNN, \\u{...}) so an
     escape-obfuscated placeholder (e.g. `panic!("t\\u{6f}do: ...")`) is
-    still caught. Raw literals (`r"..."`, `r#"..."#`) have no escapes --
-    returned unchanged. Any other backslash sequence is left as-is."""
+    still caught. A backslash-newline string continuation is collapsed first
+    (STRING_CONTINUATION_RE) so a placeholder split across a line
+    continuation is rejoined before matching. Raw literals (`r"..."`,
+    `r#"..."#`) have no escapes -- returned unchanged. Any other backslash
+    sequence is left as-is."""
     if is_raw:
         return body
+
+    body = STRING_CONTINUATION_RE.sub("", body)
 
     def repl(m):
         tok = m.group(1)
@@ -653,11 +677,13 @@ def decode_rust_escapes(body, is_raw):
 
 
 def load_allowlist(path):
-    """Parse `<path-substring>\\t<message-substring>` entries from the
-    allowlist file at `path`. Blank lines and lines starting with `#` (after
-    stripping leading whitespace) are ignored. A missing file (e.g. a caller
-    override pointing at a path that does not exist) is an empty allowlist,
-    not an error."""
+    """Parse `<repo-relative-path>\\t<exact-decoded-message>` entries from the
+    allowlist file at `path`. Each entry suppresses a finding only when both
+    fields match exactly (see is_allowlisted) -- the repo-relative path (as
+    rendered under `crates/...`) and the fully decoded panic!/unreachable!
+    message. Blank lines and lines starting with `#` (after stripping leading
+    whitespace) are ignored. A missing file (e.g. a caller override pointing
+    at a path that does not exist) is an empty allowlist, not an error."""
     entries = []
     if not os.path.isfile(path):
         return entries
@@ -668,23 +694,26 @@ def load_allowlist(path):
                 continue
             if "\t" not in line:
                 continue
-            path_sub, message_sub = line.split("\t", 1)
-            entries.append((path_sub, message_sub))
+            entry_path, entry_message = line.split("\t", 1)
+            entries.append((entry_path, entry_message))
     return entries
 
 
-def is_allowlisted(path, message, entries):
-    """A finding is suppressed iff some entry's path-substring is contained
-    in the file path AND its message-substring is contained in the decoded
-    panic!/unreachable! message. An entry that matches nothing in a given
-    run is not an error."""
-    return any(path_sub in path and message_sub in message for path_sub, message_sub in entries)
+def is_allowlisted(rel_path, message, entries):
+    """A finding is suppressed iff some entry matches it EXACTLY: the entry's
+    repo-relative path equals the finding's repo-relative path AND the
+    entry's message equals the finding's fully decoded panic!/unreachable!
+    message. Exact (not substring) so an allowlisted entry can never suppress
+    an unrelated NEW marker that merely shares a path prefix or a message
+    fragment. An entry that matches nothing in a given run is not an error."""
+    return any(rel_path == entry_path and message == entry_message for entry_path, entry_message in entries)
 
 
 allowlist = load_allowlist(ALLOWLIST_PATH)
 
 findings = []
 for path in files:
+    rel_path = os.path.relpath(path, SCAN_ROOT).replace(os.sep, "/")
     with open(path, "r", encoding="utf-8") as fh:
         text = fh.read()
     clean = strip_comments_and_char_lits(text)
@@ -704,11 +733,11 @@ for path in files:
         message = "".join(decode_rust_escapes(content, is_raw) for content, is_raw in parts)
         if not PLACEHOLDER_RE.search(message):
             continue
-        if is_allowlisted(path, message, allowlist):
+        if is_allowlisted(rel_path, message, allowlist):
             continue
         line_no = clean.count("\n", 0, m.start()) + 1
         macro_name = m.group(1)
-        safe_path = sanitize_for_ci(path)
+        safe_path = sanitize_for_ci(rel_path)
         safe_message = sanitize_for_ci(message)
         findings.append(f"{safe_path}:{line_no}: {macro_name}!(\"{safe_message}\") reads as a placeholder stub, not a real error path")
 

--- a/scripts/lint-stub-markers.sh
+++ b/scripts/lint-stub-markers.sh
@@ -774,6 +774,22 @@ LSTREEFAILFIXTURE
         fi
     fi
 
+    # Security-ordering regression (#560 follow-up): the placeholder scan phase
+    # must run before any cargo phase in ci.sh, so no PR-controlled build step or
+    # proc-macro runs before the guard reads the tree. A guard running after cargo
+    # could read a committed stub source, the committed allowlist, or this script
+    # itself after a build step replaced it with benign content. Extract run_all's
+    # phase order and assert no-stubs-scan is first; a reorder that moves it after
+    # a cargo phase reopens that mutable-checkout bypass and fails here.
+    ci_sh="$SCRIPT_DIR/ci.sh"
+    if [ -f "$ci_sh" ]; then
+        first_phase="$(awk '/^run_all\(\)/{f=1} f&&/for phase in/{g=1;next} g&&/do$/{exit} g{gsub(/[^a-z-]/,"");if($0!="")print}' "$ci_sh" | head -1)"
+        if [ "$first_phase" != "no-stubs-scan" ]; then
+            echo "self-test FAILED: ci.sh run_all must run 'no-stubs-scan' first (before any cargo phase); found '$first_phase'. Moving the placeholder scan after a cargo phase reopens the mutable-checkout bypass (#560)."
+            status=1
+        fi
+    fi
+
     if [ "$status" -eq 0 ]; then
         echo "lint-stub-markers self-test: OK"
     fi

--- a/scripts/lint-stub-markers.sh
+++ b/scripts/lint-stub-markers.sh
@@ -12,24 +12,36 @@
 # panic!/unreachable! call for that language, not the macro itself.
 #
 # Scans every `.rs` file under crates/ -- source, tests, benches, and
-# examples alike (build-artifact `target`/`.cargo-target` dirs excluded,
-# same as .gitignore). There is no reachability/cfg analysis: a placeholder
-# message is a placeholder message whether or not the code compiling it is
-# test-gated. The small number of legitimate matches (a test mock whose
-# type/method name happens to contain a placeholder word) are suppressed via
-# the explicit, in-diff reviewed allowlist at stub-marker-allowlist.txt --
-# see that file's header for the format.
+# examples alike. Production discovery is git-tracked-file based (`git
+# ls-files -s -z -- crates/`): untracked build-artifact output (target/,
+# .cargo-target/, anything gitignored) is never listed by git, so no
+# name-based directory pruning is needed and, unlike a name-pruning `find`,
+# a TRACKED Rust module nested under a dir literally named `target` (e.g.
+# reachable via #[path]) is not invisible to the scan. There is no
+# reachability/cfg analysis: a placeholder message is a placeholder message
+# whether or not the code compiling it is test-gated. The small number of
+# legitimate matches (a test mock whose type/method name happens to contain
+# a placeholder word) are suppressed via the explicit, in-diff reviewed
+# allowlist at stub-marker-allowlist.txt -- see that file's header for the
+# format.
+#
+# SCOPE (documented non-goal): this is a placeholder-LANGUAGE net over the
+# literal spellings `panic!`/`unreachable!` only. It does not resolve macro
+# aliases, re-exports, or wrapper macros (e.g. a local `crash!` expanding to
+# panic!) -- that would require macro-expansion-aware parsing this scanner
+# does not attempt. Alias coverage is left to clippy and human review; this
+# is a known non-goal, not a silent bypass of a stated promise.
 #
 # Filesystem-indirection (symlink) policy -- every path this script opens or
 # walks, and the symlink handling applied to each:
 #
-#   script self-location     | `cd $(dirname $0) && pwd`       | trusted; resolved once at startup
-#   crates/ regular .rs      | `find -type f -name '*.rs'`     | only real files scanned; symlinks excluded by -type f
-#   crates/ any symlink      | `find -type l`                  | HARD-FAIL, named via sanitize_for_ci, before scanning
-#   discovered .rs reads     | `open(path)` in the scan loop   | guaranteed real by the -type f / -type l split; CI checkout is static (no find->read swap)
-#   allowlist file           | `os.open(O_RDONLY|O_NOFOLLOW)`  | symlink refused atomically; in-repo default must also resolve under the scan root; env override is containment-exempt but still symlink-refused
-#   temp transport files     | `mktemp`                        | mktemp regular files (O_EXCL); not attacker-controlled
-#   self-test fixture trees  | self-authored under `mktemp -d` | test-authored real files
+#   script self-location     | `cd $(dirname $0) && pwd`         | trusted; resolved once at startup
+#   crates/ regular .rs      | `git ls-files -s` mode 100644/100755, self-test fallback `find -type f` | only tracked-regular/self-test-real files scanned
+#   crates/ any symlink      | `git ls-files -s` mode 120000, self-test fallback `find -type l` | HARD-FAIL, named via sanitize_for_ci, before scanning
+#   discovered .rs reads     | `os.open(O_RDONLY|O_NOFOLLOW)` in the scan loop | binds the read to the exact discovered path; a post-discovery swap to a symlink (a build step/proc-macro racing the guard, or a working-tree file diverging from a clean git index entry) raises ELOOP and hard-fails that path by name, rather than silently following or reading a replacement
+#   allowlist file            | `os.open(O_RDONLY|O_NOFOLLOW)`    | symlink refused atomically; in-repo default must also resolve under the scan root; env override is containment-exempt but still symlink-refused
+#   temp transport files      | `mktemp`                          | mktemp regular files (O_EXCL); not attacker-controlled
+#   self-test fixture trees   | self-authored under `mktemp -d`   | test-authored real files (find-mode discovery; not git-tracked)
 set -eu
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
@@ -192,6 +204,17 @@ pub fn c1_csi_forgery_stub(flag: bool) -> u32 {
     }
     1
 }
+
+pub fn after_nested_format_args_stub(flag: bool) -> u32 {
+    if !flag {
+        // Adversarial: a placeholder assembled through a nested format_args!
+        // call whose own arguments are all literals -- fully statically
+        // derivable, so it must be reconstructed and caught, not treated as
+        // an opaque non-literal argument.
+        panic!("{}", format_args!("not {}", "implemented via nested format_args"));
+    }
+    1
+}
 FIXTURE
 
     # Appended via printf (not the quoted heredoc above) so the fixture can
@@ -263,6 +286,25 @@ pub fn concat_arg_dispatch(kind: &str) -> u32 {
     }
 }
 
+pub fn named_variable_slot_dispatch(stage: &str) -> u32 {
+    // Adversarial: a non-literal (runtime variable) argument filling a
+    // format slot must never be silently vacated to an empty string -- that
+    // would let "not {feature} implemented" collapse into a false-positive
+    // "not  implemented". The slot resolves to UNRESOLVED_SLOT_SENTINEL
+    // instead, which breaks the marker regex's `\s*` span.
+    panic!("not {feature} implemented", feature = stage)
+}
+
+pub fn alias_macro_not_matched(flag: bool) -> u32 {
+    if !flag {
+        // Adversarial: macro-alias resolution is a documented non-goal (see
+        // MACRO_CALL_RE's scope comment) -- only literal panic!/unreachable!
+        // spellings are matched, so an alias must not be flagged here.
+        crash!("todo: alias bypass is a documented non-goal, not a silent guard failure");
+    }
+    1
+}
+
 // Mirrors the real crates/kkernel/src/reindex.rs mock pattern (a #[cfg(test)]
 // EmbeddingService mock named StubService whose guard message names the
 // mock's own type/method, not a real placeholder) -- the reason
@@ -291,9 +333,9 @@ FIXTURE
     # Exactly 19 markers are seeded in case-fail above; asserting the count
     # (not just substring presence) catches a parser-overmatch regression
     # that would otherwise slip through as an unnoticed extra finding.
-    expected_marker_count=19
+    expected_marker_count=20
 
-    if STUB_MARKER_ALLOWLIST="$empty_allowlist" scan "$tmp/case-fail" > "$tmp/fail.log" 2>&1; then
+    if STUB_MARKER_ALLOWLIST="$empty_allowlist" scan "$tmp/case-fail" find > "$tmp/fail.log" 2>&1; then
         echo "self-test FAILED: expected placeholder call sites were not caught"
         cat "$tmp/fail.log"
         status=1
@@ -323,7 +365,8 @@ FIXTURE
             "carries a newline and a forged CI workflow command sequence" \
             "a placeholder inside a tests/ directory file must now be caught" \
             "implemented for the mixed positional and named case" \
-            "sanitization probe"
+            "sanitization probe" \
+            "implemented via nested format_args"
         do
             if ! grep -qF "$marker" "$tmp/fail.log"; then
                 echo "self-test FAILED: expected finding missing: $marker"
@@ -378,7 +421,7 @@ PYCTL
         fi
     fi
 
-    if ! STUB_MARKER_ALLOWLIST="$empty_allowlist" scan "$tmp/case-pass" > "$tmp/pass.log" 2>&1; then
+    if ! STUB_MARKER_ALLOWLIST="$empty_allowlist" scan "$tmp/case-pass" find > "$tmp/pass.log" 2>&1; then
         echo "self-test FAILED: legitimate panic!/unreachable! messages (raw strings, lookalike text inside strings, a #[cfg(test)] helper named StubService) false-positived:"
         cat "$tmp/pass.log"
         status=1
@@ -400,7 +443,7 @@ PYCTL
     # This repeats the production scan's full-tree pass; removing that duplication
     # is the self-test/production structure work tracked in #1108.
     committed_allowlist="$SCRIPT_DIR/stub-marker-allowlist.txt"
-    if ! STUB_MARKER_ALLOWLIST="$committed_allowlist" scan "$ROOT" > "$tmp/committed.log" 2>&1; then
+    if ! STUB_MARKER_ALLOWLIST="$committed_allowlist" scan "$ROOT" git > "$tmp/committed.log" 2>&1; then
         echo "self-test FAILED: the committed allowlist did not pass the scanner over the real tree -- a malformed, stale, or pre-planted allowlist entry, or an un-suppressed placeholder stub in the tree (named below):"
         cat "$tmp/committed.log"
         status=1
@@ -426,7 +469,7 @@ ALWFIXTURE
     printf 'crates/fixture-crate/src/lib.rs\ttodo: this one is allowlisted and must be suppressed\n' \
         >> "$temp_allowlist"
 
-    if STUB_MARKER_ALLOWLIST="$temp_allowlist" scan "$tmp/case-allowlist" > "$tmp/allowlist.log" 2>&1; then
+    if STUB_MARKER_ALLOWLIST="$temp_allowlist" scan "$tmp/case-allowlist" find > "$tmp/allowlist.log" 2>&1; then
         echo "self-test FAILED: the non-allowlisted sibling finding should have failed the scan"
         cat "$tmp/allowlist.log"
         status=1
@@ -456,7 +499,7 @@ STALEFIXTURE
     stale_allowlist="$tmp/stale-allowlist.txt"
     printf 'crates/does-not-exist/src/lib.rs\ttodo: entry for a path not in the tree\n' \
         > "$stale_allowlist"
-    if STUB_MARKER_ALLOWLIST="$stale_allowlist" scan "$tmp/case-stale-allowlist" > "$tmp/stale.log" 2>&1; then
+    if STUB_MARKER_ALLOWLIST="$stale_allowlist" scan "$tmp/case-stale-allowlist" find > "$tmp/stale.log" 2>&1; then
         echo "self-test FAILED: a scan with an allowlist entry for a nonexistent path should have failed loud"
         cat "$tmp/stale.log"
         status=1
@@ -480,7 +523,7 @@ UNUSEDFIXTURE
     unused_allowlist_file="$tmp/unused-allowlist.txt"
     printf 'crates/real-crate/src/lib.rs\ttodo: no finding in this file matches this message\n' \
         > "$unused_allowlist_file"
-    if STUB_MARKER_ALLOWLIST="$unused_allowlist_file" scan "$tmp/case-unused-allowlist" > "$tmp/unused.log" 2>&1; then
+    if STUB_MARKER_ALLOWLIST="$unused_allowlist_file" scan "$tmp/case-unused-allowlist" find > "$tmp/unused.log" 2>&1; then
         echo "self-test FAILED: an allowlist entry with a valid path but no matching finding should have failed loud"
         cat "$tmp/unused.log"
         status=1
@@ -504,7 +547,7 @@ MALFIXTURE
     malformed_allowlist_file="$tmp/malformed-allowlist.txt"
     printf 'crates/real-crate/src/lib.rs no tab between path and message\n' \
         > "$malformed_allowlist_file"
-    if STUB_MARKER_ALLOWLIST="$malformed_allowlist_file" scan "$tmp/case-malformed-allowlist" > "$tmp/malformed.log" 2>&1; then
+    if STUB_MARKER_ALLOWLIST="$malformed_allowlist_file" scan "$tmp/case-malformed-allowlist" find > "$tmp/malformed.log" 2>&1; then
         echo "self-test FAILED: a malformed (no-TAB) allowlist line should have failed the scan loud"
         cat "$tmp/malformed.log"
         status=1
@@ -529,7 +572,7 @@ SLFIXTURE
     printf 'SENTINEL_ALLOWLIST_SECRET_MUST_NOT_LEAK\tx\n' > "$tmp/symlink-allowlist-target.txt"
     symlink_allowlist="$tmp/symlink-allowlist.txt"
     ln -s "$tmp/symlink-allowlist-target.txt" "$symlink_allowlist"
-    if STUB_MARKER_ALLOWLIST="$symlink_allowlist" scan "$tmp/case-symlink-allowlist" > "$tmp/symlink-allow.log" 2>&1; then
+    if STUB_MARKER_ALLOWLIST="$symlink_allowlist" scan "$tmp/case-symlink-allowlist" find > "$tmp/symlink-allow.log" 2>&1; then
         echo "self-test FAILED: a symlinked allowlist file should have failed the scan loud"
         cat "$tmp/symlink-allow.log"
         status=1
@@ -562,7 +605,7 @@ pub fn hidden_stub() -> u32 {
 }
 RSHIDDEN
     ln -s "$tmp/case-symlink-rs/elsewhere.rs" "$tmp/case-symlink-rs/crates/real-crate/src/linked.rs"
-    if STUB_MARKER_ALLOWLIST="$empty_allowlist" scan "$tmp/case-symlink-rs" > "$tmp/symlink-rs.log" 2>&1; then
+    if STUB_MARKER_ALLOWLIST="$empty_allowlist" scan "$tmp/case-symlink-rs" find > "$tmp/symlink-rs.log" 2>&1; then
         echo "self-test FAILED: a symlinked .rs under crates/ should have hard-failed the scan"
         cat "$tmp/symlink-rs.log"
         status=1
@@ -570,6 +613,60 @@ RSHIDDEN
         if ! grep -qF 'linked.rs' "$tmp/symlink-rs.log"; then
             echo "self-test FAILED: the symlinked-.rs error did not name the offending link"
             cat "$tmp/symlink-rs.log"
+            status=1
+        fi
+    fi
+
+    # git-mode TOCTOU: a git index entry's mode reflects what was STAGED, not
+    # necessarily the current on-disk file. A build step that swaps a tracked
+    # regular file for a symlink AFTER checkout (without re-staging) has git
+    # ls-files -s still report 100644 -- so it lands in file_list, not
+    # symlink_list, and the O_NOFOLLOW read guard is the ONLY thing that
+    # catches the swap.
+    mkdir -p "$tmp/case-git-toctou/crates/fixture-crate/src"
+    (
+        cd "$tmp/case-git-toctou" && git init -q . \
+            && git config user.email "test@example.com" && git config user.name "test" \
+            && printf 'pub fn ok() -> u32 {\n    1\n}\n' > crates/fixture-crate/src/lib.rs \
+            && git add -A && git commit -q -m seed
+    )
+    rm "$tmp/case-git-toctou/crates/fixture-crate/src/lib.rs"
+    ln -s "/nonexistent-toctou-target" "$tmp/case-git-toctou/crates/fixture-crate/src/lib.rs"
+    if STUB_MARKER_ALLOWLIST="$empty_allowlist" scan "$tmp/case-git-toctou" git > "$tmp/git-toctou.log" 2>&1; then
+        echo "self-test FAILED: a git-tracked file swapped for a symlink after commit (index still 100644) should have hard-failed the scan"
+        cat "$tmp/git-toctou.log"
+        status=1
+    else
+        if ! grep -qF 'crates/fixture-crate/src/lib.rs' "$tmp/git-toctou.log"; then
+            echo "self-test FAILED: the post-commit symlink-swap error did not name the offending path"
+            cat "$tmp/git-toctou.log"
+            status=1
+        fi
+    fi
+
+    # git-mode discovery: a tracked Rust module nested under a directory
+    # literally named `target` (reachable via #[path], compilable) must now
+    # be scanned and flagged -- name-based `find -prune` previously made it
+    # invisible; git-tracked discovery has no such name-based exclusion.
+    mkdir -p "$tmp/case-git-target/crates/fixture-crate/target"
+    cat > "$tmp/case-git-target/crates/fixture-crate/target/tracked_via_path_attr.rs" <<'GITTARGETFIXTURE'
+pub fn tracked_under_target_dir_stub() -> u32 {
+    panic!("todo: a tracked module nested under a target/-named dir must now be caught")
+}
+GITTARGETFIXTURE
+    (
+        cd "$tmp/case-git-target" && git init -q . \
+            && git config user.email "test@example.com" && git config user.name "test" \
+            && git add -A && git commit -q -m seed
+    )
+    if STUB_MARKER_ALLOWLIST="$empty_allowlist" scan "$tmp/case-git-target" git > "$tmp/git-target.log" 2>&1; then
+        echo "self-test FAILED: a tracked Rust module under a target/-named directory should have been scanned and flagged"
+        cat "$tmp/git-target.log"
+        status=1
+    else
+        if ! grep -qF 'tracked module nested under a target' "$tmp/git-target.log"; then
+            echo "self-test FAILED: the tracked-under-target/ finding was not reported"
+            cat "$tmp/git-target.log"
             status=1
         fi
     fi
@@ -582,37 +679,92 @@ RSHIDDEN
 
 scan() {
     root="$1"
+    mode="${2:-find}"
     file_list="$(mktemp)"
-
-    # NUL-delimited discovery and transport end-to-end: a filename may
-    # legally contain a newline (or any byte but NUL and `/`), and this
-    # scanner's own findings later echo filenames straight into CI stdout.
-    # `-print0` + a NUL-delimited transport file sidesteps splitting
-    # entirely; `sanitize_for_ci` (applied to every rendered path below, the
-    # same function already used on messages) handles the render side.
-    #
-    # Only `target`/`.cargo-target` (build-artifact dirs, per .gitignore)
-    # are pruned -- everything else under crates/, including tests/,
-    # benches/, and examples/, is in scan scope.
-    find "$root/crates" \
-        \( -name 'target' -o -name '.cargo-target' \) -type d -prune \
-        -o -name '*.rs' -type f -print0 \
-        > "$file_list"
-
-    # Filesystem-indirection guard: collect EVERY symlink under crates/ (any
-    # name, file or directory), excluding the same pruned build-artifact dirs.
-    # A symlinked .rs is skipped by the -type f pass above but compiled by
-    # Cargo; a symlinked directory is not descended by find (no -L) yet Cargo
-    # builds through it. The python below hard-fails on any of them.
     symlink_list="$(mktemp)"
-    find "$root/crates" \
-        \( -name 'target' -o -name '.cargo-target' \) -type d -prune \
-        -o -type l -print0 \
-        > "$symlink_list"
+
+    if [ "$mode" = "git" ]; then
+        # Tracked-file discovery (production): `git ls-files` lists only
+        # what git actually tracks under crates/, so untracked build-artifact
+        # output (target/, .cargo-target/, anything gitignored) is never
+        # listed -- no name-based pruning needed, and a TRACKED module nested
+        # under a dir literally named `target` is no longer invisible the way
+        # `find -prune` made it. `-s -z` reports each entry's INDEX mode
+        # ("<mode> <object> <stage>\t<path>", NUL-terminated); mode 120000 is
+        # a tracked symlink, the same filesystem-indirection hazard the
+        # find-mode -type l pass catches below. This is index state, not a
+        # live stat of the working tree: an entry staged as 100644 whose
+        # on-disk file was swapped to a symlink AFTER checkout (by a prior
+        # build step/proc-macro, without re-staging) still reports 100644
+        # here -- the O_NOFOLLOW read guard in the python scan loop is what
+        # catches that swap; this check and that one are complementary.
+        if ! git -C "$root" rev-parse --is-inside-work-tree > /dev/null 2>&1; then
+            rm -f "$file_list" "$symlink_list"
+            echo "stub-marker scan: $root is not inside a git working tree -- tracked-file discovery requires git; refusing to fall back to a raw filesystem walk" >&2
+            return 1
+        fi
+        git -C "$root" ls-files -s -z -- crates/ | python3 -c '
+import os
+import sys
+
+root, out_files, out_symlinks = sys.argv[1], sys.argv[2], sys.argv[3]
+raw = sys.stdin.buffer.read()
+files = []
+symlinks = []
+for entry in raw.split(b"\0"):
+    if not entry:
+        continue
+    meta, sep, relpath = entry.partition(b"\t")
+    if not sep:
+        continue
+    file_mode = meta.split(b" ", 1)[0]
+    relpath_s = os.fsdecode(relpath)
+    abspath = os.path.join(root, relpath_s)
+    if file_mode == b"120000":
+        symlinks.append(abspath)
+    elif relpath_s.endswith(".rs"):
+        files.append(abspath)
+with open(out_files, "wb") as fh:
+    fh.write(b"\0".join(os.fsencode(p) for p in files))
+    if files:
+        fh.write(b"\0")
+with open(out_symlinks, "wb") as fh:
+    fh.write(b"\0".join(os.fsencode(p) for p in symlinks))
+    if symlinks:
+        fh.write(b"\0")
+' "$root" "$file_list" "$symlink_list"
+    else
+        # find-mode discovery: self-test fixture trees only (mktemp -d
+        # trees, never git repos) -- production always uses git mode above.
+        # NUL-delimited discovery and transport end-to-end: a filename may
+        # legally contain a newline (or any byte but NUL and `/`), and this
+        # scanner's own findings later echo filenames straight into CI
+        # stdout. `-print0` + a NUL-delimited transport file sidesteps
+        # splitting entirely; `sanitize_for_ci` (applied to every rendered
+        # path below, the same function already used on messages) handles
+        # the render side. Only `target`/`.cargo-target` (build-artifact
+        # dirs, per .gitignore) are pruned here -- fixture trees have no git
+        # index to consult.
+        find "$root/crates" \
+            \( -name 'target' -o -name '.cargo-target' \) -type d -prune \
+            -o -name '*.rs' -type f -print0 \
+            > "$file_list"
+
+        # Filesystem-indirection guard: collect EVERY symlink under crates/
+        # (any name, file or directory), excluding the same pruned
+        # build-artifact dirs. A symlinked .rs is skipped by the -type f pass
+        # above but compiled by Cargo; a symlinked directory is not descended
+        # by find (no -L) yet Cargo builds through it. The python below
+        # hard-fails on any of them.
+        find "$root/crates" \
+            \( -name 'target' -o -name '.cargo-target' \) -type d -prune \
+            -o -type l -print0 \
+            > "$symlink_list"
+    fi
 
     if [ ! -s "$file_list" ] && [ ! -s "$symlink_list" ]; then
         rm -f "$file_list" "$symlink_list"
-        echo "no .rs files matched under $root/crates (excluding target/.cargo-target build-artifact dirs) -- the scanner would silently be a no-op; fix the file-layout selection" >&2
+        echo "no .rs files matched under $root/crates -- the scanner would silently be a no-op; fix the file-layout selection" >&2
         return 1
     fi
 
@@ -654,6 +806,14 @@ PLACEHOLDER_RE = re.compile(
 # Rust accepts whitespace before `!` and any of the three delimiter kinds
 # (`panic!(...)`, `panic!{...}`, `panic![...]`) -- all three are legal macro
 # call syntax, not just parens.
+#
+# SCOPE (documented non-goal, not a silent bypass): this matches the LITERAL
+# spellings `panic!`/`unreachable!` only. A macro alias, re-export, or
+# wrapper (e.g. a local `crash!` that expands to panic!) is not resolved --
+# that requires macro-expansion-aware parsing this scanner does not attempt,
+# and expanding this regex to guess at alias names would be unreliable and
+# unmaintainable. Alias coverage is intentionally left to clippy and human
+# review; see the scanner's file-header SCOPE note.
 MACRO_CALL_RE = re.compile(r"\b(panic|unreachable)\s*!\s*([(\{\[])")
 # re.DOTALL: Rust's backslash-newline string continuation (`"...\<newline>
 # ..."`, used throughout this codebase for long multi-line SQL literals)
@@ -686,6 +846,18 @@ SIMPLE_ESCAPES = {"n": "\n", "r": "\r", "t": "\t", "\\": "\\", '"': '"', "'": "'
 # argument prefix (a single `=`, never `==`).
 FORMAT_SLOT_RE = re.compile(r"\{\{|\}\}|\{([^{}]*)\}")
 IDENT_ARG_RE = re.compile(r"\s*([A-Za-z_][A-Za-z0-9_]*)\s*=(?!=)")
+# A slot backed by a non-literal argument (a variable, a function call, a
+# Rust-2021 inline-captured identifier) must never be silently vacated to an
+# empty string: `panic!("not {feature} implemented")` with `feature` a
+# runtime value would collapse to "not  implemented" and false-positive
+# through PLACEHOLDER_RE's `\s*` alternatives. Substituting a byte no
+# PLACEHOLDER_RE alternative's `\s*`/word content can match through prevents
+# the slot from bridging two unrelated neighboring words into a marker,
+# without itself ever completing one (`\b` never matches NUL, and no
+# alternative contains it). It only ever reaches CI output through
+# sanitize_for_ci (whose CONTROL_CHAR_RE already covers 0x00), so it never
+# leaks raw.
+UNRESOLVED_SLOT_SENTINEL = "\x00"
 
 
 def sanitize_for_ci(raw):
@@ -966,11 +1138,14 @@ def split_macro_args(code_only, clean, open_pos):
 
 def arg_literal_value(clean, code_only, start, end):
     """The decoded string value of the argument clean[start:end] when it is a
-    string literal (plain, raw, or byte-raw) or a concat!(...) of string
-    literals; otherwise None. A non-literal argument -- a variable, a function
-    call, a format! result assembled elsewhere -- is invisible to a static text
-    scan and returns None. Leading whitespace is skipped; a concat! call's own
-    literal arguments are joined."""
+    string literal (plain, raw, or byte-raw), a concat!(...) of string
+    literals, or a format_args!(...) call whose own arguments are ALL
+    themselves literal-derivable (recursively, via resolve_format_message_strict)
+    -- statically reconstructible end to end; otherwise None. A non-literal
+    argument -- a variable, a function call, a format_args!(...) with even one
+    non-literal slot -- is invisible to a static text scan and returns None
+    rather than a partial/fabricated reconstruction. Leading whitespace is
+    skipped; a concat! call's own literal arguments are joined."""
     i = start
     while i < end and clean[i].isspace():
         i += 1
@@ -984,10 +1159,64 @@ def arg_literal_value(clean, code_only, start, end):
         if not parts:
             return None
         return "".join(decode_rust_escapes(content, is_raw) for content, is_raw in parts)
+    m = re.match(r"format_args\s*!\s*[([{]", code_only[i:end])
+    if m is not None:
+        open_pos = i + m.end() - 1
+        inner_spans, _inner_close = split_macro_args(code_only, clean, open_pos)
+        if not inner_spans:
+            return None
+        inner_template = arg_literal_value(clean, code_only, inner_spans[0][0], inner_spans[0][1])
+        if inner_template is None:
+            return None
+        inner_positionals = []
+        inner_named = {}
+        for span_start, span_end in inner_spans[1:]:
+            nm = IDENT_ARG_RE.match(code_only, span_start, span_end)
+            if nm is not None:
+                inner_named[nm.group(1)] = arg_literal_value(clean, code_only, nm.end(), span_end)
+            else:
+                inner_positionals.append(arg_literal_value(clean, code_only, span_start, span_end))
+        return resolve_format_message_strict(inner_template, inner_positionals, inner_named)
     lit = match_string_literal(clean, i)
     if lit is None:
         return None
     return decode_rust_escapes(lit[1], lit[2])
+
+
+def resolve_format_message_strict(template, positionals, named):
+    """Like resolve_format_message, but for fully reconstructing a NESTED
+    format_args!(...) call (see arg_literal_value): returns the substituted
+    text only if EVERY slot the template references resolves to a literal
+    argument, else None. None means "not statically derivable end to end" --
+    the caller (arg_literal_value) then reports the whole format_args! call as
+    non-literal, so its slot falls back to UNRESOLVED_SLOT_SENTINEL at the
+    outer level instead of silently reconstructing a partial message."""
+    auto = [0]
+    unresolved = [False]
+
+    def repl(m):
+        tok = m.group(0)
+        if tok == "{{":
+            return "{"
+        if tok == "}}":
+            return "}"
+        ref = m.group(1).split(":", 1)[0].strip()
+        if ref == "":
+            idx = auto[0]
+            auto[0] += 1
+            value = positionals[idx] if idx < len(positionals) else None
+        elif ref.isdigit():
+            idx = int(ref)
+            value = positionals[idx] if idx < len(positionals) else None
+        else:
+            value = named.get(ref)
+        if value is None:
+            unresolved[0] = True
+            return ""
+        return value
+
+    result = FORMAT_SLOT_RE.sub(repl, template)
+    return None if unresolved[0] else result
 
 
 def resolve_format_message(template, positionals, named):
@@ -997,7 +1226,10 @@ def resolve_format_message(template, positionals, named):
     `{name}` takes a named argument. A slot backed by a literal argument is
     filled with that literal's decoded text; a slot backed by a non-literal or
     unresolved argument -- including a Rust 2021 inline-captured variable, which
-    is not among the macro's explicit args -- is vacated. That is the
+    is not among the macro's explicit args -- is filled with
+    UNRESOLVED_SLOT_SENTINEL, never an empty string (an empty-string vacate
+    would let "not {var} implemented" collapse into a false-positive "not
+    implemented" through PLACEHOLDER_RE's `\\s*` alternatives). That is the
     conservative posture: it never fabricates text a static scan cannot prove,
     while denying a literal argument any way to hide a placeholder by sitting out
     of source order or behind a positional/named split."""
@@ -1019,7 +1251,7 @@ def resolve_format_message(template, positionals, named):
             value = positionals[idx] if idx < len(positionals) else None
         else:
             value = named.get(ref)
-        return value if value is not None else ""
+        return value if value is not None else UNRESOLVED_SLOT_SENTINEL
 
     return FORMAT_SLOT_RE.sub(repl, template)
 
@@ -1142,7 +1374,26 @@ allowlist_used = [False] * len(allowlist)
 findings = []
 for path in files:
     rel_path = os.path.relpath(path, SCAN_ROOT).replace(os.sep, "/")
-    with open(path, "r", encoding="utf-8") as fh:
+    # Bind the read to the exact path discovery found, atomically: O_NOFOLLOW
+    # refuses to open through a symlink, so a path that was a real regular
+    # file at discovery time (a `find -type f` hit, or a git-index 100644/
+    # 100755 entry) but has since been swapped to a symlink -- by a
+    # PR-controlled build script or proc-macro racing this guard, or simply
+    # because a git-tracked working-tree file diverged from its clean index
+    # entry -- raises ELOOP here instead of silently following the
+    # replacement or reading different content than what was discovered.
+    try:
+        fd = os.open(path, os.O_RDONLY | os.O_NOFOLLOW)
+    except OSError as exc:
+        if exc.errno in (errno.ELOOP, errno.EMLINK):
+            sys.stderr.write(
+                "stub-marker scan: discovered path is a symlink at read time "
+                "(swapped after discovery) -- refusing to follow a "
+                f"post-discovery filesystem indirection: {sanitize_for_ci(rel_path)}\n"
+            )
+            sys.exit(1)
+        raise
+    with os.fdopen(fd, "r", encoding="utf-8") as fh:
         text = fh.read()
     clean = strip_comments_and_char_lits(text)
     code_only = blank_strings(clean)
@@ -1228,7 +1479,7 @@ case "${1:-}" in
         self_test
         ;;
     "")
-        scan "$ROOT"
+        scan "$ROOT" git
         ;;
     *)
         echo "usage: $0 [--self-test]" >&2

--- a/scripts/lint-stub-markers.sh
+++ b/scripts/lint-stub-markers.sh
@@ -68,6 +68,29 @@ pub fn after_nonbraced_cfg_test_item(flag: bool) -> u32 {
     }
     1
 }
+
+pub fn after_long_comment_gap(flag: bool) -> u32 {
+    if !flag {
+        panic!(
+            /* this block comment is deliberately long so that the gap of
+               whitespace and comment text between the macro's opening
+               delimiter and its message argument exceeds forty characters,
+               /* nested comments are legal Rust and must not end the outer
+                  comment early */
+               which used to blind a fixed-width lookahead window */
+            "todo: still not implemented after a long comment gap"
+        );
+    }
+    1
+}
+
+pub fn after_byte_raw_string_literal(flag: bool) -> u32 {
+    let _marker: &[u8] = br#"raw byte data, not a panic argument"#;
+    if !flag {
+        panic!("todo: still not implemented after a byte-raw string literal");
+    }
+    1
+}
 FIXTURE
 
     cat > "$tmp/case-pass/crates/fixture-crate/src/lib.rs" <<'FIXTURE'
@@ -118,17 +141,30 @@ FIXTURE
 
     status=0
 
+    # Exactly 7 markers are seeded in case-fail above; asserting the count
+    # (not just substring presence) catches a parser-overmatch regression
+    # that would otherwise slip through as an unnoticed extra finding.
+    expected_marker_count=7
+
     if scan "$tmp/case-fail" > "$tmp/fail.log" 2>&1; then
         echo "self-test FAILED: expected placeholder call sites were not caught"
         cat "$tmp/fail.log"
         status=1
     else
+        found_marker_count=$(grep -c 'reads as a placeholder stub' "$tmp/fail.log")
+        if [ "$found_marker_count" -ne "$expected_marker_count" ]; then
+            echo "self-test FAILED: expected exactly $expected_marker_count findings, got $found_marker_count"
+            cat "$tmp/fail.log"
+            status=1
+        fi
         for marker in \
             "stub: not implemented for other kinds yet" \
             "not implemented for other kinds yet" \
             "todo: handle the false branch" \
             "not implemented for this flag" \
-            "not implemented after a non-braced cfg(test) item"
+            "not implemented after a non-braced cfg(test) item" \
+            "todo: still not implemented after a long comment gap" \
+            "todo: still not implemented after a byte-raw string literal"
         do
             if ! grep -qF "$marker" "$tmp/fail.log"; then
                 echo "self-test FAILED: expected finding missing: $marker"
@@ -158,8 +194,8 @@ scan() {
         | sort)
 
     if [ -z "$files" ]; then
-        echo "no source files found under $root/crates"
-        return 0
+        echo "no source files matched crates/*/src/**/*.rs under $root/crates (excluding target*/tests/benches/examples) -- the scanner would silently be a no-op; fix the file-layout selection" >&2
+        return 1
     fi
 
     python3 - "$files" <<'PY'
@@ -179,19 +215,24 @@ PLACEHOLDER_RE = re.compile(
 MACRO_CALL_RE = re.compile(r"\b(panic|unreachable)\s*!\s*([(\{\[])")
 STRING_LIT_RE = re.compile(r'"((?:[^"\\]|\\.)*)"')
 CFG_TEST_RE = re.compile(r"#\s*\[\s*cfg\s*\(\s*test\s*\)\s*\]")
+WHITESPACE_RE = re.compile(r"\s*")
 
 
 def raw_string_end(text, i):
-    """If text[i] starts a raw string literal `r#*"..."#*` (word-boundary
-    checked so an identifier ending in `r` is never mistaken for one), return
-    the offset just past its closing quote+hashes (len(text) if unterminated).
-    Otherwise None."""
+    """If text[i] starts a raw or byte-raw string literal (`r#*"..."#*` or
+    `br#*"..."#*`, word-boundary checked at the start of the prefix so an
+    identifier ending in `r`/`br` -- e.g. `xr"..."` or `abr"..."` -- is never
+    mistaken for one), return the offset just past its closing quote+hashes
+    (len(text) if unterminated). Otherwise None."""
     n = len(text)
-    if text[i] != "r":
-        return None
     if i > 0 and (text[i - 1].isalnum() or text[i - 1] == "_"):
         return None
-    j = i + 1
+    if text[i] == "b" and i + 1 < n and text[i + 1] == "r":
+        j = i + 2
+    elif text[i] == "r":
+        j = i + 1
+    else:
+        return None
     hashes = 0
     while j < n and text[j] == "#":
         hashes += 1
@@ -204,17 +245,19 @@ def raw_string_end(text, i):
 
 
 def strip_comments_and_char_lits(text):
-    """Blank out //, /* */ comments and char literals so brace-counting and
-    macro-matching never trip on braces/quotes living inside them. Plain and
-    raw string literals are left untouched -- their content is exactly what
-    this script inspects. Raw strings are hand-scanned to their matching
+    """Blank out //, /* */ comments (nesting -- Rust block comments nest, so
+    a depth counter tracks inner `/* */` pairs rather than ending at the
+    first `*/`) and char literals, so brace-counting and macro-matching
+    never trip on braces/quotes living inside them. Plain and raw string
+    literals are left untouched -- their content is exactly what this
+    script inspects. Raw strings are hand-scanned to their matching
     "###-count closer so quotes inside them (e.g. `r#"say "hi""#`) do not
     prematurely end the literal."""
     out = []
     i = 0
     n = len(text)
     in_line_comment = False
-    in_block_comment = False
+    block_depth = 0
     in_string = False
     while i < n:
         c = text[i]
@@ -224,11 +267,16 @@ def strip_comments_and_char_lits(text):
                 in_line_comment = False
             i += 1
             continue
-        if in_block_comment:
-            if c == "*" and i + 1 < n and text[i + 1] == "/":
+        if block_depth > 0:
+            if c == "/" and i + 1 < n and text[i + 1] == "*":
+                block_depth += 1
                 out.append("  ")
                 i += 2
-                in_block_comment = False
+                continue
+            if c == "*" and i + 1 < n and text[i + 1] == "/":
+                block_depth -= 1
+                out.append("  ")
+                i += 2
                 continue
             out.append(" " if c != "\n" else "\n")
             i += 1
@@ -249,7 +297,7 @@ def strip_comments_and_char_lits(text):
             i += 2
             continue
         if c == "/" and i + 1 < n and text[i + 1] == "*":
-            in_block_comment = True
+            block_depth = 1
             out.append("  ")
             i += 2
             continue
@@ -292,7 +340,7 @@ def match_string_literal(text, pos):
     rs_end = raw_string_end(text, pos)
     if rs_end is None:
         return None
-    j = pos + 1
+    j = pos + (2 if text[pos] == "b" else 1)  # skip the `br`/`r` prefix
     hashes = 0
     while text[j] == "#":
         hashes += 1
@@ -375,16 +423,19 @@ for path in files:
         if in_span(m.start(), test_spans):
             continue
         call_start = m.end() - 1  # the opening delimiter char (`(`/`{`/`[`)
-        # Only consider a string literal immediately after the delimiter
-        # (allowing whitespace) -- this is the macro's message argument, not
-        # some unrelated string buried deeper in a multi-arg call. Read the
-        # lookahead from `clean` (strings intact), never `code_only` (which
-        # has blanked exactly the string content being looked for here).
-        lookahead = clean[call_start + 1 : call_start + 1 + 40]
-        stripped = lookahead.lstrip()
-        if not (stripped.startswith('"') or stripped.startswith("r")):
-            continue
-        msg_start = call_start + 1 + (len(lookahead) - len(stripped))
+        # Only consider a string literal immediately after the delimiter --
+        # this is the macro's message argument, not some unrelated string
+        # buried deeper in a multi-arg call. Rust allows arbitrary whitespace
+        # and comments between the delimiter and the argument; `clean` has
+        # already blanked every comment to whitespace (nesting-aware), so
+        # skipping whitespace with no length cap is a full trivia skip, not
+        # just a wider fixed window -- a placeholder message is caught no
+        # matter how much trivia precedes it. Read from `clean` (strings
+        # intact), never `code_only` (which has blanked exactly the string
+        # content being looked for here).
+        after_delim = call_start + 1
+        trivia = WHITESPACE_RE.match(clean, after_delim)
+        msg_start = trivia.end()
         msg_m = match_string_literal(clean, msg_start)
         if msg_m is None:
             continue

--- a/scripts/lint-stub-markers.sh
+++ b/scripts/lint-stub-markers.sh
@@ -805,54 +805,79 @@ LSTREEFAILFIXTURE
     # no condition. Scope is the `ci` job: other jobs compile deliberately narrow
     # slices and are not the lane #560 concerns.
     #
-    # python3 is already required by this script (see the scan loop). PyYAML is the
-    # one added dependency, and its absence HARD-FAILS rather than skipping: a
-    # guard that silently downgrades to "no check" is worse than no guard, because
-    # it reports success.
+    # python3 is already required by this script (see the scan loop); no library
+    # beyond the stdlib is used, because the macOS runner's /usr/bin/python3 has
+    # no PyYAML and installing one before the guard would put a network step
+    # ahead of the thing that must run first.
+    #
+    # The parse is line-structural, so it handles only block-style steps. That is
+    # sufficient because it REFUSES what it cannot analyze: a flow-style step or a
+    # merge key inside the job fails the check rather than passing unexamined.
+    # Every construct below is therefore either understood or rejected, never
+    # silently skipped.
     workflow="$SCRIPT_DIR/../.github/workflows/ci.yml"
     if [ -f "$workflow" ]; then
         workflow_verdict="$(WORKFLOW="$workflow" python3 - <<'PYWF'
 import os, re, sys
 
-try:
-    import yaml
-except ImportError:
-    print("NOPARSER|")
-    sys.exit(0)
+lines = open(os.environ["WORKFLOW"], encoding="utf-8").read().splitlines()
 
-try:
-    with open(os.environ["WORKFLOW"], encoding="utf-8") as fh:
-        doc = yaml.safe_load(fh)
-except Exception as exc:
-    print("UNPARSEABLE|%s" % exc)
-    sys.exit(0)
-
-job = ((doc or {}).get("jobs") or {}).get("ci")
-if not isinstance(job, dict):
+# Locate the `ci` job and the extent of its block.
+job_at = None
+for i, line in enumerate(lines):
+    if re.match(r"^  ci:\s*$", line):
+        job_at = i
+        break
+if job_at is None:
     print("NOJOB|")
     sys.exit(0)
 
-# A step that shells to ci.sh runs cargo transitively; one naming a cargo or make
-# subcommand runs it directly. `rustup which cargo` prints a path and builds
-# nothing, so a bare "cargo" with no following subcommand does not count.
-runs_cargo = re.compile(r"scripts/ci\.sh|cargo[ \t]+[a-z]|make[ \t]+[a-z]")
+job = []
+for line in lines[job_at + 1:]:
+    if line.strip() and not line.startswith("   "):
+        break
+    job.append(line)
+
+# `if:`, `if :`, `"if":` and `'if':` are one key to YAML and four strings to a
+# matcher. All four gate the step, so all four must be recognized.
+IF_KEY = re.compile(r"""^\s*(?:if|"if"|'if')\s*:""")
+# ci.sh runs cargo transitively; a cargo/make subcommand runs it directly.
+# `rustup which cargo` prints a path and builds nothing, so a bare "cargo" with
+# no following subcommand does not count.
+RUNS_CARGO = re.compile(r"scripts/ci\.sh|cargo[ \t]+[a-z]|make[ \t]+[a-z]")
+STEP_START = re.compile(r"^(\s+)-\s")
+
+steps, cur, key_indent = [], None, 0
+for line in job:
+    if re.match(r"^\s*<<\s*:", line):
+        print("UNANALYZABLE|a merge key in the ci job means steps cannot be read from the text")
+        sys.exit(0)
+    m = STEP_START.match(line)
+    if m:
+        if re.match(r"^\s+-\s*[\{\[]", line):
+            print("UNANALYZABLE|a flow-style step in the ci job cannot be read from the text")
+            sys.exit(0)
+        if cur is not None:
+            steps.append((cur, key_indent))
+        cur, key_indent = [line], len(m.group(0))
+    elif cur is not None:
+        cur.append(line)
+if cur is not None:
+    steps.append((cur, key_indent))
 
 verdict = "NOCARGO|"
-for step in job.get("steps") or []:
-    if not isinstance(step, dict):
-        continue
-    run = step.get("run") or ""
+for body_lines, indent in steps:
     # Comment lines never execute, and the ordering rationale written above the
     # scan step names cargo; counting it would fail a correct workflow.
-    body = "\n".join(
-        line for line in run.splitlines() if not line.lstrip().startswith("#")
-    )
-    if not runs_cargo.search(body):
+    live = [l for l in body_lines if not l.lstrip().startswith("#")]
+    body = "\n".join(live)
+    if not RUNS_CARGO.search(body):
         continue
-    name = step.get("name") or step.get("uses") or "(unnamed step)"
+    name = body_lines[0].split(":", 1)[-1].strip() or "(unnamed step)"
+    gated = any(IF_KEY.match(l) and len(l) - len(l.lstrip()) == indent for l in live)
     if "no-stubs-scan" not in body:
         verdict = "NOTSCAN|%s" % name
-    elif "if" in step:
+    elif gated:
         verdict = "GATED|%s" % name
     else:
         verdict = "OK|%s" % name
@@ -865,12 +890,8 @@ PYWF
         workflow_step="${workflow_verdict#*|}"
         case "$workflow_state" in
             OK) ;;
-            NOPARSER)
-                echo "self-test FAILED: PyYAML is not importable, so the workflow ordering check cannot run. Install it (pip install pyyaml) -- this check must not be skipped, because a guard that silently downgrades to no check still reports success (#560)."
-                status=1
-                ;;
-            UNPARSEABLE)
-                echo "self-test FAILED: .github/workflows/ci.yml did not parse as YAML: $workflow_step"
+            UNANALYZABLE)
+                echo "self-test FAILED: the ordering check cannot read .github/workflows/ci.yml: $workflow_step. Use block-style steps in the 'ci' job so the guard can verify the placeholder scan runs first and ungated; this check refuses to pass on a shape it cannot examine (#560)."
                 status=1
                 ;;
             NOJOB)

--- a/scripts/lint-stub-markers.sh
+++ b/scripts/lint-stub-markers.sh
@@ -28,6 +28,13 @@ self_test() {
     tmp="$(mktemp -d)"
     trap 'rm -rf "$tmp"' EXIT
 
+    # case-fail and case-pass assert detection and false-positive avoidance,
+    # not suppression; they scan against an empty allowlist so the committed
+    # file's real-repo paths are never validated against these temp trees (the
+    # path-existence guard would otherwise fail loud on them).
+    empty_allowlist="$tmp/empty-allowlist.txt"
+    : > "$empty_allowlist"
+
     mkdir -p "$tmp/case-fail/crates/fixture-crate/src"
     mkdir -p "$tmp/case-fail/crates/fixture-crate/tests"
     mkdir -p "$tmp/case-pass/crates/fixture-crate/src"
@@ -89,6 +96,13 @@ pub fn after_byte_raw_string_literal(flag: bool) -> u32 {
 pub fn after_format_arg_stub(flag: bool) -> u32 {
     if !flag {
         panic!("{}", "todo: not implemented for the format-arg case");
+    }
+    1
+}
+
+pub fn after_format_split_arg_stub(flag: bool) -> u32 {
+    if !flag {
+        panic!("not {}", "implemented for the format-split case");
     }
     1
 }
@@ -241,12 +255,12 @@ FIXTURE
 
     status=0
 
-    # Exactly 15 markers are seeded in case-fail above; asserting the count
+    # Exactly 17 markers are seeded in case-fail above; asserting the count
     # (not just substring presence) catches a parser-overmatch regression
     # that would otherwise slip through as an unnoticed extra finding.
-    expected_marker_count=16
+    expected_marker_count=17
 
-    if scan "$tmp/case-fail" > "$tmp/fail.log" 2>&1; then
+    if STUB_MARKER_ALLOWLIST="$empty_allowlist" scan "$tmp/case-fail" > "$tmp/fail.log" 2>&1; then
         echo "self-test FAILED: expected placeholder call sites were not caught"
         cat "$tmp/fail.log"
         status=1
@@ -265,6 +279,7 @@ FIXTURE
             "todo: still not implemented after a long comment gap" \
             "todo: still not implemented after a byte-raw string literal" \
             "todo: not implemented for the format-arg case" \
+            "implemented for the format-split case" \
             "concat-assembled stub message" \
             "only catches via unicode escape decoding" \
             "only catches via hex escape decoding" \
@@ -318,20 +333,35 @@ FIXTURE
         fi
     fi
 
-    if ! scan "$tmp/case-pass" > "$tmp/pass.log" 2>&1; then
+    if ! STUB_MARKER_ALLOWLIST="$empty_allowlist" scan "$tmp/case-pass" > "$tmp/pass.log" 2>&1; then
         echo "self-test FAILED: legitimate panic!/unreachable! messages (raw strings, lookalike text inside strings, a #[cfg(test)] helper named StubService) false-positived:"
         cat "$tmp/pass.log"
         status=1
     fi
 
-    # Allowlist suppression exercised against the COMMITTED allowlist file
-    # (no temp override): the committed `stub-marker-allowlist.txt` carries a
-    # self-test fixture anchor whose exact (repo-relative path, full message)
-    # pair matches the allowlisted fixture below, so a broken committed file
-    # (bad format, wrong path form) fails this test. Exact-match is checked in
-    # both directions -- the anchor-matching finding is suppressed, and a
-    # sibling with a different message at the same path still surfaces.
+    # The committed allowlist must stay parseable and keep its one known real
+    # entry; a format drift (missing tab, wrong path form) or an accidental
+    # deletion is caught here. The committed file carries NO self-test anchor:
+    # a committed entry is a real, PR-recreatable suppression, so a fixture
+    # entry there would let a PR add that exact path+message and suppress its
+    # own stub. Suppression is therefore exercised via a temp copy below.
+    committed_allowlist="$SCRIPT_DIR/stub-marker-allowlist.txt"
+    reindex_entry="$(printf 'crates/kkernel/src/reindex.rs\tStubService::embed must not be called in this test')"
+    if ! grep -Fqx "$reindex_entry" "$committed_allowlist"; then
+        echo "self-test FAILED: committed allowlist lost its expected reindex.rs entry or its format drifted"
+        status=1
+    fi
+
+    # Suppression is exercised against a TEMP allowlist: a copy of the committed
+    # file (so a committed parse/format break still surfaces) with a fixture
+    # anchor appended. Every referenced path is created under the temp tree so
+    # the path-existence guard passes -- including a stand-in for the committed
+    # reindex.rs entry. Exact-match is checked both ways: the anchor-matching
+    # finding is suppressed, and a sibling with a different message at the same
+    # path still surfaces.
     mkdir -p "$tmp/case-allowlist/crates/fixture-crate/src"
+    mkdir -p "$tmp/case-allowlist/crates/kkernel/src"
+    : > "$tmp/case-allowlist/crates/kkernel/src/reindex.rs"
     cat > "$tmp/case-allowlist/crates/fixture-crate/src/lib.rs" <<'ALWFIXTURE'
 pub fn allowlisted_stub() -> u32 {
     panic!("todo: this one is allowlisted and must be suppressed")
@@ -341,20 +371,48 @@ pub fn not_allowlisted_stub() -> u32 {
     panic!("todo: this one is NOT allowlisted and must still be caught")
 }
 ALWFIXTURE
+    temp_allowlist="$tmp/case-allowlist-allowlist.txt"
+    cp "$committed_allowlist" "$temp_allowlist"
+    printf 'crates/fixture-crate/src/lib.rs\ttodo: this one is allowlisted and must be suppressed\n' \
+        >> "$temp_allowlist"
 
-    if scan "$tmp/case-allowlist" > "$tmp/allowlist.log" 2>&1; then
+    if STUB_MARKER_ALLOWLIST="$temp_allowlist" scan "$tmp/case-allowlist" > "$tmp/allowlist.log" 2>&1; then
         echo "self-test FAILED: the non-allowlisted sibling finding should have failed the scan"
         cat "$tmp/allowlist.log"
         status=1
     else
         if grep -qF 'this one is allowlisted and must be suppressed' "$tmp/allowlist.log"; then
-            echo "self-test FAILED: an allowlisted finding (exact committed-allowlist match) was not suppressed"
+            echo "self-test FAILED: an allowlisted finding (exact temp-allowlist match) was not suppressed"
             cat "$tmp/allowlist.log"
             status=1
         fi
         if ! grep -qF 'this one is NOT allowlisted' "$tmp/allowlist.log"; then
             echo "self-test FAILED: a sibling non-allowlisted finding was incorrectly suppressed"
             cat "$tmp/allowlist.log"
+            status=1
+        fi
+    fi
+
+    # The scan must FAIL LOUD when an allowlist entry names a path absent from
+    # the scanned tree -- the stale or pre-planted shape that could otherwise
+    # sit ready to suppress a future finding. The offending path must be named.
+    mkdir -p "$tmp/case-stale-allowlist/crates/real-crate/src"
+    cat > "$tmp/case-stale-allowlist/crates/real-crate/src/lib.rs" <<'STALEFIXTURE'
+pub fn ok() -> u32 {
+    1
+}
+STALEFIXTURE
+    stale_allowlist="$tmp/stale-allowlist.txt"
+    printf 'crates/does-not-exist/src/lib.rs\ttodo: entry for a path not in the tree\n' \
+        > "$stale_allowlist"
+    if STUB_MARKER_ALLOWLIST="$stale_allowlist" scan "$tmp/case-stale-allowlist" > "$tmp/stale.log" 2>&1; then
+        echo "self-test FAILED: a scan with an allowlist entry for a nonexistent path should have failed loud"
+        cat "$tmp/stale.log"
+        status=1
+    else
+        if ! grep -qF 'crates/does-not-exist/src/lib.rs' "$tmp/stale.log"; then
+            echo "self-test FAILED: the nonexistent-allowlist-path error did not name the offending entry"
+            cat "$tmp/stale.log"
             status=1
         fi
     fi
@@ -392,7 +450,12 @@ scan() {
 
     allowlist="${STUB_MARKER_ALLOWLIST:-$SCRIPT_DIR/stub-marker-allowlist.txt}"
 
-    python3 - "$file_list" "$allowlist" "$root" <<'PY'
+    # `|| rc=$?` keeps set -e from exiting the script the moment python3 returns
+    # non-zero (findings present, or the allowlist-path guard failing): the temp
+    # file_list below must still be removed on that path, and the caller needs
+    # the real exit code, not a set-e-induced abort.
+    rc=0
+    python3 - "$file_list" "$allowlist" "$root" <<'PY' || rc=$?
 import os
 import re
 import sys
@@ -433,6 +496,13 @@ ESCAPE_RE = re.compile(r"\\(n|r|t|\\|\"|'|0|x[0-9A-Fa-f]{2}|u\{[0-9A-Fa-f]+\})")
 # PLACEHOLDER_RE, so it is stripped before any other escape is decoded.
 STRING_CONTINUATION_RE = re.compile(r"\\\r?\n\s*")
 SIMPLE_ESCAPES = {"n": "\n", "r": "\r", "t": "\t", "\\": "\\", '"': '"', "'": "'", "0": "\0"}
+# A placeholder phrase can be split by a format-string placeholder when a
+# panic!/unreachable! assembles its message from a format literal plus trailing
+# args -- `panic!("not {}", "implemented")` joins to "not {}implemented", and
+# the brace defeats PLACEHOLDER_RE's `not\s*implemented`. A probe copy with
+# `{...}` placeholders removed is matched instead, so the surrounding literal
+# text reads as it does at runtime; the reported message keeps the braces.
+FORMAT_BRACE_RE = re.compile(r"\{[^{}]*\}")
 
 
 def sanitize_for_ci(raw):
@@ -711,6 +781,26 @@ def is_allowlisted(rel_path, message, entries):
 
 allowlist = load_allowlist(ALLOWLIST_PATH)
 
+# Fail loud on any allowlist entry whose path is absent from the scanned tree.
+# A stale entry (the file moved or was deleted) or a pre-planted entry (added
+# ahead of the file it would suppress) must never sit here silently disabling a
+# future finding; rejecting it keeps the committed allowlist honestly in sync
+# with the tree. Paths are checked against SCAN_ROOT, the same anchor the
+# finding's repo-relative path is rendered against.
+missing_allowlist_paths = [
+    entry_path
+    for entry_path, _ in allowlist
+    if not os.path.exists(os.path.join(SCAN_ROOT, entry_path))
+]
+if missing_allowlist_paths:
+    sys.stderr.write(
+        "stub-marker allowlist references path(s) that do not exist under "
+        f"{SCAN_ROOT} -- remove the stale entry or correct the path:\n"
+    )
+    for entry_path in missing_allowlist_paths:
+        sys.stderr.write(f"  {entry_path}\n")
+    sys.exit(1)
+
 findings = []
 for path in files:
     rel_path = os.path.relpath(path, SCAN_ROOT).replace(os.sep, "/")
@@ -731,7 +821,8 @@ for path in files:
         if not parts:
             continue
         message = "".join(decode_rust_escapes(content, is_raw) for content, is_raw in parts)
-        if not PLACEHOLDER_RE.search(message):
+        probe = FORMAT_BRACE_RE.sub("", message)
+        if not PLACEHOLDER_RE.search(probe):
             continue
         if is_allowlisted(rel_path, message, allowlist):
             continue
@@ -749,7 +840,6 @@ if findings:
 
 print(f"stub-marker lint: {len(files)} file(s) OK")
 PY
-    rc=$?
     rm -f "$file_list"
     return "$rc"
 }

--- a/scripts/lint-stub-markers.sh
+++ b/scripts/lint-stub-markers.sh
@@ -790,6 +790,31 @@ LSTREEFAILFIXTURE
         fi
     fi
 
+    # The ci.sh check above constrains only run_all's phase list. GitHub Actions
+    # does not call run_all: it invokes phases as individual workflow steps, so a
+    # step reordered (or suite-gated) in the workflow bypasses the guard while
+    # run_all still looks correct. That is exactly how the macOS PR lane once ran
+    # cargo with no scan at all. Assert against the workflow itself: the first
+    # ci.sh phase any job invokes must be no-stubs-scan, and it must carry no
+    # suite condition -- an `if:` on that step re-splits the lanes and leaves
+    # whichever suite it excludes unguarded.
+    workflow="$SCRIPT_DIR/../.github/workflows/ci.yml"
+    if [ -f "$workflow" ]; then
+        first_ci_phase="$(grep -oE 'scripts/ci\.sh [a-z-]+' "$workflow" | head -1 | awk '{print $2}')"
+        if [ "$first_ci_phase" != "no-stubs-scan" ]; then
+            echo "self-test FAILED: the first scripts/ci.sh phase invoked in .github/workflows/ci.yml must be 'no-stubs-scan'; found '$first_ci_phase'. A cargo-running step ahead of the guard executes PR-controlled build scripts against an unscanned tree (#560)."
+            status=1
+        fi
+        scan_line="$(grep -nE 'scripts/ci\.sh no-stubs-scan' "$workflow" | head -1 | cut -d: -f1)"
+        if [ -n "$scan_line" ]; then
+            guard_start="$((scan_line > 3 ? scan_line - 3 : 1))"
+            if sed -n "${guard_start},${scan_line}p" "$workflow" | grep -qE '^[[:space:]]*if:'; then
+                echo "self-test FAILED: the no-stubs-scan step in .github/workflows/ci.yml carries an 'if:' condition. The scan must run on every suite; gating it leaves the excluded lane compiling PR-controlled code unguarded (#560)."
+                status=1
+            fi
+        fi
+    fi
+
     if [ "$status" -eq 0 ]; then
         echo "lint-stub-markers self-test: OK"
     fi

--- a/scripts/lint-stub-markers.sh
+++ b/scripts/lint-stub-markers.sh
@@ -373,18 +373,25 @@ PYCTL
         status=1
     fi
 
-    # The committed allowlist carries no active entries today (its documented
-    # state): every entry must suppress a CURRENT finding, and none exists in the
-    # tree. Assert there is no non-comment, non-blank line -- an entry sneaked in
-    # without a matching finding would fail the real scan's unused-entry guard,
-    # but catching it here names the regression directly. The committed file also
-    # carries NO self-test anchor: a committed entry is a real, PR-recreatable
-    # suppression, so a fixture there would let a PR add that exact path+message
-    # and suppress its own stub. Suppression is exercised via a temp copy below.
+    # The committed allowlist is validated by running the scanner over the real
+    # tree with it: the unused-entry guard fails loud on any entry that suppresses
+    # no current finding (stale, moved, or pre-planted), and the malformed-line
+    # guard fails loud on a no-TAB entry. That is the scanner's own contract, so a
+    # comment-only file (its state today) passes and a legitimate committed
+    # suppression -- one that matches a current finding -- passes too, where a
+    # blunt "no active line" assertion would wrongly reject it. Any offending
+    # entry is named through the scanner's own sanitize_for_ci output, never
+    # echoed raw from the file. The committed file carries NO self-test fixture
+    # anchor: a committed entry is a real, PR-recreatable suppression, so a fixture
+    # there would let a PR add that exact path+message and suppress its own stub.
+    # Suppression is exercised via a temp copy below.
+    #
+    # This repeats the production scan's full-tree pass; removing that duplication
+    # is the self-test/production structure work tracked in #1108.
     committed_allowlist="$SCRIPT_DIR/stub-marker-allowlist.txt"
-    if grep -qvE '^[[:space:]]*(#|$)' "$committed_allowlist"; then
-        echo "self-test FAILED: committed allowlist has an active entry; it must be comment-only unless it suppresses a current finding:"
-        grep -nvE '^[[:space:]]*(#|$)' "$committed_allowlist"
+    if ! STUB_MARKER_ALLOWLIST="$committed_allowlist" scan "$ROOT" > "$tmp/committed.log" 2>&1; then
+        echo "self-test FAILED: the committed allowlist did not pass the scanner over the real tree -- a malformed, stale, or pre-planted allowlist entry, or an un-suppressed placeholder stub in the tree (named below):"
+        cat "$tmp/committed.log"
         status=1
     fi
 

--- a/scripts/lint-stub-markers.sh
+++ b/scripts/lint-stub-markers.sh
@@ -159,6 +159,28 @@ pub fn split_marker_by_continuation_stub(flag: bool) -> u32 {
     }
     1
 }
+
+pub fn mixed_positional_named_stub(flag: bool) -> u32 {
+    if !flag {
+        // Adversarial: a placeholder split across a positional and a named
+        // argument. Slot substitution fills the named slot from x and the auto
+        // slot from the positional regardless of source order, so the
+        // reconstructed message reads as a stub even though neither literal does
+        // alone.
+        panic!("{x} {}", "implemented for the mixed positional and named case", x = "not");
+    }
+    1
+}
+
+pub fn c1_csi_forgery_stub(flag: bool) -> u32 {
+    if !flag {
+        // Adversarial: a single-byte C1 CSI control decoded from a unicode
+        // escape, which no ESC-prefixed pattern would catch. The sanitizer must
+        // strip every C0 and C1 control byte from CI output.
+        panic!("todo: c1 single-byte CSI \u{9b}31m::error::forged sanitization probe");
+    }
+    1
+}
 FIXTURE
 
     # Appended via printf (not the quoted heredoc above) so the fixture can
@@ -255,10 +277,10 @@ FIXTURE
 
     status=0
 
-    # Exactly 17 markers are seeded in case-fail above; asserting the count
+    # Exactly 19 markers are seeded in case-fail above; asserting the count
     # (not just substring presence) catches a parser-overmatch regression
     # that would otherwise slip through as an unnoticed extra finding.
-    expected_marker_count=17
+    expected_marker_count=19
 
     if STUB_MARKER_ALLOWLIST="$empty_allowlist" scan "$tmp/case-fail" > "$tmp/fail.log" 2>&1; then
         echo "self-test FAILED: expected placeholder call sites were not caught"
@@ -288,7 +310,9 @@ FIXTURE
             "a placeholder inside a #[cfg(test)] item must now be caught" \
             "mid-message newline injection" \
             "carries a newline and a forged CI workflow command sequence" \
-            "a placeholder inside a tests/ directory file must now be caught"
+            "a placeholder inside a tests/ directory file must now be caught" \
+            "implemented for the mixed positional and named case" \
+            "sanitization probe"
         do
             if ! grep -qF "$marker" "$tmp/fail.log"; then
                 echo "self-test FAILED: expected finding missing: $marker"
@@ -297,13 +321,23 @@ FIXTURE
             fi
         done
 
-        # the ci_log_forgery_stub message above carries a raw ANSI escape, a
-        # literal "::error::forged" workflow-command shape, and an embedded
-        # newline -- none of the three may survive into CI stdout.
-        esc="$(printf '\033')"
-        if grep -qF "$esc" "$tmp/fail.log"; then
-            echo "self-test FAILED: a raw ANSI escape byte leaked into CI output"
-            cat "$tmp/fail.log"
+        # the ci_log_forgery_stub and c1_csi_forgery_stub messages carry raw
+        # control bytes (an ANSI ESC, a single-byte C1 CSI decoded from \u{9b}, an
+        # embedded newline) plus a literal "::error::forged" workflow-command
+        # shape. sanitize_for_ci must leave NO C0 or C1 control byte in CI output;
+        # assert the whole log is free of them. A real newline separates finding
+        # lines, so 0x0a alone is excluded from the check.
+        if ! python3 - "$tmp/fail.log" <<'PYCTL'
+import sys
+data = open(sys.argv[1], "rb").read()
+leaked = sorted({b for b in data if b < 0x0a or 0x0a < b < 0x20 or b == 0x7f or 0x80 <= b <= 0x9f})
+if leaked:
+    sys.stderr.write("leaked control bytes: " + " ".join("0x%02x" % b for b in leaked) + "\n")
+    sys.exit(1)
+PYCTL
+        then
+            echo "self-test FAILED: a raw C0/C1 control byte (e.g. the single-byte CSI 0x9b) leaked into CI output"
+            cat -v "$tmp/fail.log"
             status=1
         fi
         if grep -qF '::error::forged' "$tmp/fail.log"; then
@@ -339,29 +373,27 @@ FIXTURE
         status=1
     fi
 
-    # The committed allowlist must stay parseable and keep its one known real
-    # entry; a format drift (missing tab, wrong path form) or an accidental
-    # deletion is caught here. The committed file carries NO self-test anchor:
-    # a committed entry is a real, PR-recreatable suppression, so a fixture
-    # entry there would let a PR add that exact path+message and suppress its
-    # own stub. Suppression is therefore exercised via a temp copy below.
+    # The committed allowlist carries no active entries today (its documented
+    # state): every entry must suppress a CURRENT finding, and none exists in the
+    # tree. Assert there is no non-comment, non-blank line -- an entry sneaked in
+    # without a matching finding would fail the real scan's unused-entry guard,
+    # but catching it here names the regression directly. The committed file also
+    # carries NO self-test anchor: a committed entry is a real, PR-recreatable
+    # suppression, so a fixture there would let a PR add that exact path+message
+    # and suppress its own stub. Suppression is exercised via a temp copy below.
     committed_allowlist="$SCRIPT_DIR/stub-marker-allowlist.txt"
-    reindex_entry="$(printf 'crates/kkernel/src/reindex.rs\tStubService::embed must not be called in this test')"
-    if ! grep -Fqx "$reindex_entry" "$committed_allowlist"; then
-        echo "self-test FAILED: committed allowlist lost its expected reindex.rs entry or its format drifted"
+    if grep -qvE '^[[:space:]]*(#|$)' "$committed_allowlist"; then
+        echo "self-test FAILED: committed allowlist has an active entry; it must be comment-only unless it suppresses a current finding:"
+        grep -nvE '^[[:space:]]*(#|$)' "$committed_allowlist"
         status=1
     fi
 
     # Suppression is exercised against a TEMP allowlist: a copy of the committed
     # file (so a committed parse/format break still surfaces) with a fixture
-    # anchor appended. Every referenced path is created under the temp tree so
-    # the path-existence guard passes -- including a stand-in for the committed
-    # reindex.rs entry. Exact-match is checked both ways: the anchor-matching
-    # finding is suppressed, and a sibling with a different message at the same
-    # path still surfaces.
+    # anchor appended. The anchor entry suppresses the matching finding, so it is
+    # used and the unused-entry guard stays satisfied; a sibling with a different
+    # message at the same path still surfaces, checking exact-match both ways.
     mkdir -p "$tmp/case-allowlist/crates/fixture-crate/src"
-    mkdir -p "$tmp/case-allowlist/crates/kkernel/src"
-    : > "$tmp/case-allowlist/crates/kkernel/src/reindex.rs"
     cat > "$tmp/case-allowlist/crates/fixture-crate/src/lib.rs" <<'ALWFIXTURE'
 pub fn allowlisted_stub() -> u32 {
     panic!("todo: this one is allowlisted and must be suppressed")
@@ -393,9 +425,10 @@ ALWFIXTURE
         fi
     fi
 
-    # The scan must FAIL LOUD when an allowlist entry names a path absent from
-    # the scanned tree -- the stale or pre-planted shape that could otherwise
-    # sit ready to suppress a future finding. The offending path must be named.
+    # The scan must FAIL LOUD on an allowlist entry that suppresses no finding in
+    # the scanned tree -- stale or pre-planted, the shape that could otherwise sit
+    # ready to suppress a future finding. A path absent from the tree is the
+    # simplest such entry (it can match nothing); the offending entry is named.
     mkdir -p "$tmp/case-stale-allowlist/crates/real-crate/src"
     cat > "$tmp/case-stale-allowlist/crates/real-crate/src/lib.rs" <<'STALEFIXTURE'
 pub fn ok() -> u32 {
@@ -413,6 +446,54 @@ STALEFIXTURE
         if ! grep -qF 'crates/does-not-exist/src/lib.rs' "$tmp/stale.log"; then
             echo "self-test FAILED: the nonexistent-allowlist-path error did not name the offending entry"
             cat "$tmp/stale.log"
+            status=1
+        fi
+    fi
+
+    # An allowlist entry whose path DOES exist but whose message matches no
+    # finding is equally stale: the unused-entry guard covers it, not just the
+    # path-absent case above.
+    mkdir -p "$tmp/case-unused-allowlist/crates/real-crate/src"
+    cat > "$tmp/case-unused-allowlist/crates/real-crate/src/lib.rs" <<'UNUSEDFIXTURE'
+pub fn ok() -> u32 {
+    1
+}
+UNUSEDFIXTURE
+    unused_allowlist_file="$tmp/unused-allowlist.txt"
+    printf 'crates/real-crate/src/lib.rs\ttodo: no finding in this file matches this message\n' \
+        > "$unused_allowlist_file"
+    if STUB_MARKER_ALLOWLIST="$unused_allowlist_file" scan "$tmp/case-unused-allowlist" > "$tmp/unused.log" 2>&1; then
+        echo "self-test FAILED: an allowlist entry with a valid path but no matching finding should have failed loud"
+        cat "$tmp/unused.log"
+        status=1
+    else
+        if ! grep -qF 'crates/real-crate/src/lib.rs' "$tmp/unused.log"; then
+            echo "self-test FAILED: the unused-allowlist-entry error did not name the offending entry"
+            cat "$tmp/unused.log"
+            status=1
+        fi
+    fi
+
+    # A non-comment allowlist line with no TAB is malformed and must fail loud,
+    # naming the line -- never silently dropped (a mis-typed suppression that
+    # silently does nothing is worse than a loud rejection).
+    mkdir -p "$tmp/case-malformed-allowlist/crates/real-crate/src"
+    cat > "$tmp/case-malformed-allowlist/crates/real-crate/src/lib.rs" <<'MALFIXTURE'
+pub fn ok() -> u32 {
+    1
+}
+MALFIXTURE
+    malformed_allowlist_file="$tmp/malformed-allowlist.txt"
+    printf 'crates/real-crate/src/lib.rs no tab between path and message\n' \
+        > "$malformed_allowlist_file"
+    if STUB_MARKER_ALLOWLIST="$malformed_allowlist_file" scan "$tmp/case-malformed-allowlist" > "$tmp/malformed.log" 2>&1; then
+        echo "self-test FAILED: a malformed (no-TAB) allowlist line should have failed the scan loud"
+        cat "$tmp/malformed.log"
+        status=1
+    else
+        if ! grep -qF 'malformed' "$tmp/malformed.log"; then
+            echo "self-test FAILED: the malformed-allowlist-line error was not reported as malformed"
+            cat "$tmp/malformed.log"
             status=1
         fi
     fi
@@ -486,7 +567,7 @@ MACRO_CALL_RE = re.compile(r"\b(panic|unreachable)\s*!\s*([(\{\[])")
 # regardless of DOTALL (character classes aren't affected by the flag); this
 # only changes what `\.` matches.
 STRING_LIT_RE = re.compile(r'"((?:[^"\\]|\\.)*)"', re.DOTALL)
-ANSI_ESCAPE_RE = re.compile(r"\x1b\[[0-9;]*[a-zA-Z]|\x1b.")
+CONTROL_CHAR_RE = re.compile(r"[\x00-\x1f\x7f-\x9f]")
 CLOSERS = {"(": ")", "{": "}", "[": "]"}
 ESCAPE_RE = re.compile(r"\\(n|r|t|\\|\"|'|0|x[0-9A-Fa-f]{2}|u\{[0-9A-Fa-f]+\})")
 # Rust string-continuation escape: a `\` immediately followed by a newline
@@ -496,28 +577,34 @@ ESCAPE_RE = re.compile(r"\\(n|r|t|\\|\"|'|0|x[0-9A-Fa-f]{2}|u\{[0-9A-Fa-f]+\})")
 # PLACEHOLDER_RE, so it is stripped before any other escape is decoded.
 STRING_CONTINUATION_RE = re.compile(r"\\\r?\n\s*")
 SIMPLE_ESCAPES = {"n": "\n", "r": "\r", "t": "\t", "\\": "\\", '"': '"', "'": "'", "0": "\0"}
-# A placeholder phrase can be split by a format-string placeholder when a
-# panic!/unreachable! assembles its message from a format literal plus trailing
-# args -- `panic!("not {}", "implemented")` joins to "not {}implemented", and
-# the brace defeats PLACEHOLDER_RE's `not\s*implemented`. A probe copy with
-# `{...}` placeholders removed is matched instead, so the surrounding literal
-# text reads as it does at runtime; the reported message keeps the braces.
-FORMAT_BRACE_RE = re.compile(r"\{[^{}]*\}")
+# A placeholder phrase can be split across a format template and its arguments:
+# `panic!("not {}", "implemented")` renders "not implemented" at runtime, and a
+# naive scan of the template alone ("not {}") misses it. The message is instead
+# reconstructed by substituting each literal argument into its own format slot
+# (resolve_format_message), so out-of-source-order named args and mixed
+# positional/named splits cannot hide a placeholder. FORMAT_SLOT_RE matches one
+# `{...}` slot (or an escaped `{{`/`}}`); IDENT_ARG_RE matches a `name =` named
+# argument prefix (a single `=`, never `==`).
+FORMAT_SLOT_RE = re.compile(r"\{\{|\}\}|\{([^{}]*)\}")
+IDENT_ARG_RE = re.compile(r"\s*([A-Za-z_][A-Za-z0-9_]*)\s*=(?!=)")
 
 
 def sanitize_for_ci(raw):
-    """The panic!/unreachable! message text this scanner echoes into CI
-    stdout comes straight from a PR-controlled string literal. GitHub Actions
-    parses a `::name ...::value`-shaped line as a workflow command
-    (`::error::`, `::add-mask::`, `::set-output::`, ...), so an embedded
-    newline could let attacker text start a fresh line and forge one, and
-    ANSI escapes can rewrite terminal/log-viewer state. Strip ANSI escapes,
-    collapse newlines to a literal `\\n` (never a real line break), and break
-    every `::` so no substring can be parsed as workflow-command syntax --
-    all while keeping the text readable for a human operator."""
-    s = ANSI_ESCAPE_RE.sub("", raw)
-    s = s.replace("\x1b", "")
-    s = s.replace("\r\n", "\\n").replace("\n", "\\n").replace("\r", "\\n")
+    """The single sanitizer every output path routes through. Both the
+    panic!/unreachable! message and the repo path this scanner echoes into CI
+    stdout/stderr come straight from PR-controlled text (a string literal, a
+    filename). GitHub Actions parses a `::name ...::value`-shaped line as a
+    workflow command (`::error::`, `::add-mask::`, `::set-output::`, ...), so
+    an embedded newline could let attacker text start a fresh line and forge
+    one; an ANSI/CSI escape can rewrite terminal and log-viewer state; and a
+    single-byte C1 CSI (U+009B) introduces a control sequence no ESC-prefixed
+    pattern would catch. Collapse every newline to a literal `\\n` (never a
+    real break), escape every remaining C0 control, DEL, and C1 control byte
+    -- ESC, the single-byte CSI, and the rest -- to a visible inert `\\xNN`
+    token, and break every `::` so no substring parses as workflow-command
+    syntax, all while staying readable for a human operator."""
+    s = raw.replace("\r\n", "\\n").replace("\n", "\\n").replace("\r", "\\n")
+    s = CONTROL_CHAR_RE.sub(lambda m: "\\x%02x" % ord(m.group()), s)
     s = s.replace("::", ": :")
     return s
 
@@ -746,60 +833,156 @@ def decode_rust_escapes(body, is_raw):
     return ESCAPE_RE.sub(repl, body)
 
 
+def split_macro_args(code_only, clean, open_pos):
+    """Scan a macro's balanced argument list in a single pass. code_only[open_pos]
+    is the opening delimiter (`(`/`{`/`[`); return (arg_spans, close_pos), where
+    arg_spans are (start, end) offsets into `clean` for each top-level,
+    comma-separated argument (empty spans dropped) and close_pos is the offset of
+    the matching closing delimiter (len(code_only) if unterminated). Folding
+    bracket matching into the split avoids a separate find_matching_close pass
+    over the same region. Commas nested inside (), {}, [] never split; string and
+    comment content is already blanked in code_only, so a comma or bracket living
+    inside a literal never desyncs the depth count."""
+    n = len(code_only)
+    depth = 1
+    i = open_pos + 1
+    arg_start = i
+    spans = []
+    while i < n and depth > 0:
+        c = code_only[i]
+        if c in "([{":
+            depth += 1
+        elif c in ")]}":
+            depth -= 1
+            if depth == 0:
+                break
+        elif c == "," and depth == 1:
+            spans.append((arg_start, i))
+            arg_start = i + 1
+        i += 1
+    spans.append((arg_start, i))
+    close_pos = i if i < n else n
+    return [(s, e) for (s, e) in spans if clean[s:e].strip()], close_pos
+
+
+def arg_literal_value(clean, code_only, start, end):
+    """The decoded string value of the argument clean[start:end] when it is a
+    string literal (plain, raw, or byte-raw) or a concat!(...) of string
+    literals; otherwise None. A non-literal argument -- a variable, a function
+    call, a format! result assembled elsewhere -- is invisible to a static text
+    scan and returns None. Leading whitespace is skipped; a concat! call's own
+    literal arguments are joined."""
+    i = start
+    while i < end and clean[i].isspace():
+        i += 1
+    if i >= end:
+        return None
+    m = re.match(r"concat\s*!\s*[([{]", code_only[i:end])
+    if m is not None:
+        open_pos = i + m.end() - 1
+        close_pos = min(find_matching_close(code_only, open_pos), end)
+        parts = collect_string_literals(clean, open_pos + 1, close_pos)
+        if not parts:
+            return None
+        return "".join(decode_rust_escapes(content, is_raw) for content, is_raw in parts)
+    lit = match_string_literal(clean, i)
+    if lit is None:
+        return None
+    return decode_rust_escapes(lit[1], lit[2])
+
+
+def resolve_format_message(template, positionals, named):
+    """Approximate the runtime message by substituting the macro's literal
+    arguments into the format template's slots. `{{`/`}}` are literal braces; an
+    auto `{}` takes the next positional in order, `{n}` takes positional n, and
+    `{name}` takes a named argument. A slot backed by a literal argument is
+    filled with that literal's decoded text; a slot backed by a non-literal or
+    unresolved argument -- including a Rust 2021 inline-captured variable, which
+    is not among the macro's explicit args -- is vacated. That is the
+    conservative posture: it never fabricates text a static scan cannot prove,
+    while denying a literal argument any way to hide a placeholder by sitting out
+    of source order or behind a positional/named split."""
+    auto = [0]
+
+    def repl(m):
+        tok = m.group(0)
+        if tok == "{{":
+            return "{"
+        if tok == "}}":
+            return "}"
+        ref = m.group(1).split(":", 1)[0].strip()
+        if ref == "":
+            idx = auto[0]
+            auto[0] += 1
+            value = positionals[idx] if idx < len(positionals) else None
+        elif ref.isdigit():
+            idx = int(ref)
+            value = positionals[idx] if idx < len(positionals) else None
+        else:
+            value = named.get(ref)
+        return value if value is not None else ""
+
+    return FORMAT_SLOT_RE.sub(repl, template)
+
+
 def load_allowlist(path):
     """Parse `<repo-relative-path>\\t<exact-decoded-message>` entries from the
-    allowlist file at `path`. Each entry suppresses a finding only when both
-    fields match exactly (see is_allowlisted) -- the repo-relative path (as
-    rendered under `crates/...`) and the fully decoded panic!/unreachable!
-    message. Blank lines and lines starting with `#` (after stripping leading
-    whitespace) are ignored. A missing file (e.g. a caller override pointing
-    at a path that does not exist) is an empty allowlist, not an error."""
+    allowlist file at `path`, returning (entries, malformed). Each entry
+    suppresses a finding only when both fields match exactly (see
+    allowlist_match_index) -- the repo-relative path (as rendered under
+    `crates/...`) and the fully decoded panic!/unreachable! message. Blank lines
+    and lines starting with `#` (after stripping leading whitespace) are
+    ignored. A non-comment line with no TAB is malformed -- collected in
+    `malformed` with its 1-based line number so the caller can fail loud rather
+    than silently drop a mis-typed entry that would suppress nothing. A missing
+    file is an empty allowlist, not an error."""
     entries = []
+    malformed = []
     if not os.path.isfile(path):
-        return entries
+        return entries, malformed
     with open(path, "r", encoding="utf-8") as fh:
-        for raw_line in fh:
+        for lineno, raw_line in enumerate(fh, 1):
             line = raw_line.rstrip("\n")
             if not line.strip() or line.lstrip().startswith("#"):
                 continue
             if "\t" not in line:
+                malformed.append((lineno, line))
                 continue
             entry_path, entry_message = line.split("\t", 1)
             entries.append((entry_path, entry_message))
-    return entries
+    return entries, malformed
 
 
-def is_allowlisted(rel_path, message, entries):
-    """A finding is suppressed iff some entry matches it EXACTLY: the entry's
-    repo-relative path equals the finding's repo-relative path AND the
-    entry's message equals the finding's fully decoded panic!/unreachable!
-    message. Exact (not substring) so an allowlisted entry can never suppress
-    an unrelated NEW marker that merely shares a path prefix or a message
-    fragment. An entry that matches nothing in a given run is not an error."""
-    return any(rel_path == entry_path and message == entry_message for entry_path, entry_message in entries)
+def allowlist_match_index(rel_path, message, entries):
+    """The index of the allowlist entry that matches this finding EXACTLY --
+    the entry's repo-relative path equals the finding's path AND the entry's
+    message equals the finding's fully decoded panic!/unreachable! message -- or
+    None. Exact (not substring) so an entry can never suppress an unrelated NEW
+    marker that merely shares a path prefix or a message fragment. Returning the
+    index (not a bool) lets the caller record which entries actually suppressed
+    a finding, so an entry that matches nothing this run can be rejected as
+    stale."""
+    for idx, (entry_path, entry_message) in enumerate(entries):
+        if rel_path == entry_path and message == entry_message:
+            return idx
+    return None
 
 
-allowlist = load_allowlist(ALLOWLIST_PATH)
+allowlist, malformed_allowlist = load_allowlist(ALLOWLIST_PATH)
 
-# Fail loud on any allowlist entry whose path is absent from the scanned tree.
-# A stale entry (the file moved or was deleted) or a pre-planted entry (added
-# ahead of the file it would suppress) must never sit here silently disabling a
-# future finding; rejecting it keeps the committed allowlist honestly in sync
-# with the tree. Paths are checked against SCAN_ROOT, the same anchor the
-# finding's repo-relative path is rendered against.
-missing_allowlist_paths = [
-    entry_path
-    for entry_path, _ in allowlist
-    if not os.path.exists(os.path.join(SCAN_ROOT, entry_path))
-]
-if missing_allowlist_paths:
+# A non-comment allowlist line with no TAB is a mis-typed entry: it parses as
+# neither a path nor a message and would silently suppress nothing. Fail loud
+# and name it (sanitized) rather than dropping it.
+if malformed_allowlist:
     sys.stderr.write(
-        "stub-marker allowlist references path(s) that do not exist under "
-        f"{SCAN_ROOT} -- remove the stale entry or correct the path:\n"
+        "stub-marker allowlist has malformed line(s) -- a non-comment entry needs "
+        "a TAB between the repo-relative path and the message:\n"
     )
-    for entry_path in missing_allowlist_paths:
-        sys.stderr.write(f"  {entry_path}\n")
+    for lineno, line in malformed_allowlist:
+        sys.stderr.write(f"  line {lineno}: {sanitize_for_ci(line)}\n")
     sys.exit(1)
+
+allowlist_used = [False] * len(allowlist)
 
 findings = []
 for path in files:
@@ -811,31 +994,72 @@ for path in files:
 
     for m in MACRO_CALL_RE.finditer(code_only):
         call_start = m.end() - 1  # the opening delimiter char (`(`/`{`/`[`)
-        # Scan every string literal within the macro's own balanced argument
-        # list (in source order), not just the token immediately after the
-        # opening delimiter -- see collect_string_literals. Read from
-        # `clean` (strings intact), never `code_only` (which has blanked
-        # exactly the string content being looked for here).
-        close_pos = find_matching_close(code_only, call_start)
-        parts = collect_string_literals(clean, call_start + 1, close_pos)
-        if not parts:
+        # The first argument is the format template; every later argument is a
+        # positional value or a `name = value` named value. Each literal
+        # argument is substituted into its own slot (resolve_format_message), so
+        # a placeholder split across the template and its args -- in any order --
+        # is reconstructed rather than missed. Literal content is read from
+        # `clean` (strings intact), never `code_only` (which blanked it).
+        arg_spans, close_pos = split_macro_args(code_only, clean, call_start)
+        if not arg_spans:
             continue
-        message = "".join(decode_rust_escapes(content, is_raw) for content, is_raw in parts)
-        probe = FORMAT_BRACE_RE.sub("", message)
-        if not PLACEHOLDER_RE.search(probe):
+        template = arg_literal_value(clean, code_only, arg_spans[0][0], arg_spans[0][1])
+        if template is None:
+            # No static format template (the first argument is itself a variable
+            # or a runtime expression). Fall back to the bag of any string
+            # literals anywhere in the argument list so a lone literal message
+            # still surfaces.
+            parts = collect_string_literals(clean, call_start + 1, close_pos)
+            if not parts:
+                continue
+            message = "".join(decode_rust_escapes(content, is_raw) for content, is_raw in parts)
+        else:
+            positionals = []
+            named = {}
+            for span_start, span_end in arg_spans[1:]:
+                nm = IDENT_ARG_RE.match(code_only, span_start, span_end)
+                if nm is not None:
+                    named[nm.group(1)] = arg_literal_value(clean, code_only, nm.end(), span_end)
+                else:
+                    positionals.append(arg_literal_value(clean, code_only, span_start, span_end))
+            message = resolve_format_message(template, positionals, named)
+        if not PLACEHOLDER_RE.search(message):
             continue
-        if is_allowlisted(rel_path, message, allowlist):
+        idx = allowlist_match_index(rel_path, message, allowlist)
+        if idx is not None:
+            allowlist_used[idx] = True
             continue
         line_no = clean.count("\n", 0, m.start()) + 1
         macro_name = m.group(1)
-        safe_path = sanitize_for_ci(rel_path)
-        safe_message = sanitize_for_ci(message)
-        findings.append(f"{safe_path}:{line_no}: {macro_name}!(\"{safe_message}\") reads as a placeholder stub, not a real error path")
+        findings.append(
+            f'{sanitize_for_ci(rel_path)}:{line_no}: {macro_name}!("{sanitize_for_ci(message)}") '
+            "reads as a placeholder stub, not a real error path"
+        )
+
+failed = False
+
+# Every allowlist entry must suppress a CURRENT finding. An entry that matched
+# nothing this run -- its path is gone, its file no longer holds that marker, or
+# it was pre-planted ahead of the finding it would suppress -- is stale and must
+# not sit here silently disabling a future finding. This subsumes a bare
+# path-existence check: an entry whose path is absent trivially matches nothing.
+unused_allowlist = [allowlist[i] for i, used in enumerate(allowlist_used) if not used]
+if unused_allowlist:
+    sys.stderr.write(
+        "stub-marker allowlist has entr(y/ies) that suppress no current finding "
+        "-- stale or pre-planted; remove or correct:\n"
+    )
+    for entry_path, entry_message in unused_allowlist:
+        sys.stderr.write(f"  {sanitize_for_ci(entry_path)}\t{sanitize_for_ci(entry_message)}\n")
+    failed = True
 
 if findings:
     for f in findings:
         print(f)
     print(f"\nstub-marker lint: {len(findings)} issue(s)")
+    failed = True
+
+if failed:
     sys.exit(1)
 
 print(f"stub-marker lint: {len(files)} file(s) OK")

--- a/scripts/lint-stub-markers.sh
+++ b/scripts/lint-stub-markers.sh
@@ -12,8 +12,15 @@
 # panic!/unreachable! call for that language, not the macro itself.
 #
 # Scans every `.rs` file under crates/ -- source, tests, benches, and
-# examples alike. Production discovery is git-tracked-file based (`git
-# ls-files -s -z -- crates/`): untracked build-artifact output (target/,
+# examples alike. Production discovery is git-tracked-tree based (`git
+# ls-tree -r -z HEAD -- crates/`): the COMMITTED TREE, not the mutable
+# index. `scripts/ci.sh` runs clippy/build (executing PR-controlled
+# build.rs / proc-macros) before this guard runs; a build step can `git rm
+# --cached` a stub-bearing path to mutate the index while leaving the
+# working-tree file in place, and index-based discovery (`git ls-files`)
+# would then omit it. The HEAD tree object cannot be mutated by anything
+# running after checkout, so this scan always reflects what was actually
+# committed and compiled. Untracked build-artifact output (target/,
 # .cargo-target/, anything gitignored) is never listed by git, so no
 # name-based directory pruning is needed and, unlike a name-pruning `find`,
 # a TRACKED Rust module nested under a dir literally named `target` (e.g.
@@ -36,9 +43,9 @@
 # walks, and the symlink handling applied to each:
 #
 #   script self-location     | `cd $(dirname $0) && pwd`         | trusted; resolved once at startup
-#   crates/ regular .rs      | `git ls-files -s` mode 100644/100755, self-test fallback `find -type f` | only tracked-regular/self-test-real files scanned
-#   crates/ any symlink      | `git ls-files -s` mode 120000, self-test fallback `find -type l` | HARD-FAIL, named via sanitize_for_ci, before scanning
-#   discovered .rs reads     | `os.open(O_RDONLY|O_NOFOLLOW)` in the scan loop | binds the read to the exact discovered path; a post-discovery swap to a symlink (a build step/proc-macro racing the guard, or a working-tree file diverging from a clean git index entry) raises ELOOP and hard-fails that path by name, rather than silently following or reading a replacement
+#   crates/ regular .rs      | `git ls-tree -r HEAD` mode 100644/100755, self-test fallback `find -type f` | only tracked-regular/self-test-real files scanned; committed-tree, not index, state
+#   crates/ any symlink      | `git ls-tree -r HEAD` mode 120000, self-test fallback `find -type l` | HARD-FAIL, named via sanitize_for_ci, before scanning
+#   discovered .rs reads     | per-component `os.open(O_RDONLY|O_NOFOLLOW, dir_fd=...)` walk from a root fd, in the scan loop | proves every path component from the scan root down to the file -- not just the final one -- is not a symlink at read time; a post-discovery swap of the file OR any parent directory (a build step/proc-macro racing the guard, or a working-tree entry diverging from its clean git tree entry) raises ELOOP and hard-fails that path by name, rather than silently following or reading a replacement
 #   allowlist file            | `os.open(O_RDONLY|O_NOFOLLOW)`    | symlink refused atomically; in-repo default must also resolve under the scan root; env override is containment-exempt but still symlink-refused
 #   temp transport files      | `mktemp`                          | mktemp regular files (O_EXCL); not attacker-controlled
 #   self-test fixture trees   | self-authored under `mktemp -d`   | test-authored real files (find-mode discovery; not git-tracked)
@@ -330,7 +337,7 @@ FIXTURE
 
     status=0
 
-    # Exactly 19 markers are seeded in case-fail above; asserting the count
+    # Exactly 20 markers are seeded in case-fail above; asserting the count
     # (not just substring presence) catches a parser-overmatch regression
     # that would otherwise slip through as an unnoticed extra finding.
     expected_marker_count=20
@@ -671,6 +678,102 @@ GITTARGETFIXTURE
         fi
     fi
 
+    # Parent-directory symlink swap: git-tree discovery only reads the
+    # COMMITTED tree, so a file committed under a real `src/` directory is
+    # still discovered as a plain 100644 entry even after the working-tree
+    # `src` directory is swapped to a symlink post-commit -- the same
+    # decoupling the git-TOCTOU fixture above exercises for the file itself.
+    # The per-component openat walk must refuse the symlinked PARENT
+    # directory (ELOOP) before ever reaching the file, naming the full
+    # discovered path.
+    mkdir -p "$tmp/case-parent-symlink/crates/fixture-crate/src"
+    cat > "$tmp/case-parent-symlink/crates/fixture-crate/src/f.rs" <<'PARENTFIXTURE'
+pub fn parent_symlink_stub() -> u32 {
+    panic!("todo: this file rode in behind a parent directory swapped to a symlink after discovery")
+}
+PARENTFIXTURE
+    (
+        cd "$tmp/case-parent-symlink" && git init -q . \
+            && git config user.email "test@example.com" && git config user.name "test" \
+            && git add -A && git commit -q -m seed
+    )
+    rm -rf "$tmp/case-parent-symlink/crates/fixture-crate/src"
+    mkdir -p "$tmp/parent-symlink-target"
+    ln -s "$tmp/parent-symlink-target" "$tmp/case-parent-symlink/crates/fixture-crate/src"
+    if STUB_MARKER_ALLOWLIST="$empty_allowlist" scan "$tmp/case-parent-symlink" git > "$tmp/parent-symlink.log" 2>&1; then
+        echo "self-test FAILED: a parent directory swapped to a symlink after discovery should have hard-failed the scan"
+        cat "$tmp/parent-symlink.log"
+        status=1
+    else
+        if ! grep -qF 'crates/fixture-crate/src/f.rs' "$tmp/parent-symlink.log"; then
+            echo "self-test FAILED: the parent-directory-symlink error did not name the offending path"
+            cat "$tmp/parent-symlink.log"
+            status=1
+        fi
+    fi
+
+    # Index-mutation immunity: `git rm --cached` unstages a committed file
+    # (removing it from the index) while leaving the working-tree copy in
+    # place and HEAD unchanged. `git ls-tree HEAD` reads the commit's tree
+    # object, not the index, so it still lists the file and the stub is
+    # still scanned and flagged -- the exact gap index-based `git ls-files`
+    # discovery had.
+    mkdir -p "$tmp/case-index-mutation/crates/fixture-crate/src"
+    cat > "$tmp/case-index-mutation/crates/fixture-crate/src/lib.rs" <<'IDXFIXTURE'
+pub fn index_mutation_stub() -> u32 {
+    panic!("todo: this stub must still be caught after git rm --cached unstages it")
+}
+IDXFIXTURE
+    (
+        cd "$tmp/case-index-mutation" && git init -q . \
+            && git config user.email "test@example.com" && git config user.name "test" \
+            && git add -A && git commit -q -m seed \
+            && git rm --cached -q crates/fixture-crate/src/lib.rs
+    )
+    if STUB_MARKER_ALLOWLIST="$empty_allowlist" scan "$tmp/case-index-mutation" git > "$tmp/index-mutation.log" 2>&1; then
+        echo "self-test FAILED: a stub still present in the committed HEAD tree (after git rm --cached unstaged it from the index) should have been caught, not skipped"
+        cat "$tmp/index-mutation.log"
+        status=1
+    else
+        if ! grep -qF 'this stub must still be caught after git rm --cached unstages it' "$tmp/index-mutation.log"; then
+            echo "self-test FAILED: the index-mutation-immunity finding was not reported"
+            cat "$tmp/index-mutation.log"
+            status=1
+        fi
+    fi
+
+    # Producer-failure fail-closed: corrupt the committed tree object itself
+    # (delete its loose object file) so `git ls-tree -r HEAD` fails even
+    # though `git rev-parse --verify HEAD` succeeds (the commit object is
+    # still intact). The scan must fail loud and non-zero, never silently
+    # scan an empty or partial listing as if it were a clean pass.
+    mkdir -p "$tmp/case-ls-tree-fail/crates/fixture-crate/src"
+    cat > "$tmp/case-ls-tree-fail/crates/fixture-crate/src/lib.rs" <<'LSTREEFAILFIXTURE'
+pub fn ok() -> u32 {
+    1
+}
+LSTREEFAILFIXTURE
+    (
+        cd "$tmp/case-ls-tree-fail" && git init -q . \
+            && git config user.email "test@example.com" && git config user.name "test" \
+            && git add -A && git commit -q -m seed
+    )
+    tree_sha="$(cd "$tmp/case-ls-tree-fail" && git rev-parse 'HEAD^{tree}')"
+    obj_dir="${tree_sha%"${tree_sha#??}"}"
+    obj_file="${tree_sha#??}"
+    rm -f "$tmp/case-ls-tree-fail/.git/objects/$obj_dir/$obj_file"
+    if STUB_MARKER_ALLOWLIST="$empty_allowlist" scan "$tmp/case-ls-tree-fail" git > "$tmp/ls-tree-fail.log" 2>&1; then
+        echo "self-test FAILED: a git ls-tree HEAD failure (corrupted tree object) should have hard-failed the scan, not passed"
+        cat "$tmp/ls-tree-fail.log"
+        status=1
+    else
+        if ! grep -qF 'ls-tree' "$tmp/ls-tree-fail.log"; then
+            echo "self-test FAILED: the git-producer-failure error did not name the failing command"
+            cat "$tmp/ls-tree-fail.log"
+            status=1
+        fi
+    fi
+
     if [ "$status" -eq 0 ]; then
         echo "lint-stub-markers self-test: OK"
     fi
@@ -684,31 +787,59 @@ scan() {
     symlink_list="$(mktemp)"
 
     if [ "$mode" = "git" ]; then
-        # Tracked-file discovery (production): `git ls-files` lists only
-        # what git actually tracks under crates/, so untracked build-artifact
-        # output (target/, .cargo-target/, anything gitignored) is never
-        # listed -- no name-based pruning needed, and a TRACKED module nested
-        # under a dir literally named `target` is no longer invisible the way
-        # `find -prune` made it. `-s -z` reports each entry's INDEX mode
-        # ("<mode> <object> <stage>\t<path>", NUL-terminated); mode 120000 is
-        # a tracked symlink, the same filesystem-indirection hazard the
-        # find-mode -type l pass catches below. This is index state, not a
-        # live stat of the working tree: an entry staged as 100644 whose
-        # on-disk file was swapped to a symlink AFTER checkout (by a prior
-        # build step/proc-macro, without re-staging) still reports 100644
-        # here -- the O_NOFOLLOW read guard in the python scan loop is what
-        # catches that swap; this check and that one are complementary.
+        # Tracked-tree discovery (production): `git ls-tree -r HEAD` reads
+        # the HEAD COMMIT's tree object, which is immutable once committed --
+        # unlike `git ls-files -s` (index state), nothing running after
+        # checkout (a build step or proc-macro executed earlier in
+        # scripts/ci.sh, which runs clippy/build before this guard) can
+        # mutate it via `git rm --cached` or any other index surgery.
+        # Untracked build-artifact output (target/, .cargo-target/, anything
+        # gitignored) is still never listed -- no name-based pruning needed
+        # -- and a TRACKED module nested under a dir literally named `target`
+        # is still not invisible the way `find -prune` made it. `-r -z`
+        # recurses fully (only blob/commit entries are emitted, never
+        # intermediate tree entries) and NUL-terminates each entry
+        # ("<mode> <type> <object>\t<path>"); mode 120000 is a tracked
+        # symlink, the same filesystem-indirection hazard the find-mode
+        # -type l pass catches below. This is the COMMITTED tree, not a live
+        # stat of the working tree: a working-tree entry that diverges from
+        # its clean HEAD entry (a prior build step/proc-macro swapping the
+        # file, or a parent directory, to a symlink after checkout, without
+        # re-staging) is what the per-component O_NOFOLLOW read guard in the
+        # python scan loop catches; this check and that one are
+        # complementary.
         if ! git -C "$root" rev-parse --is-inside-work-tree > /dev/null 2>&1; then
             rm -f "$file_list" "$symlink_list"
-            echo "stub-marker scan: $root is not inside a git working tree -- tracked-file discovery requires git; refusing to fall back to a raw filesystem walk" >&2
+            echo "stub-marker scan: $root is not inside a git working tree -- tracked-tree discovery requires git; refusing to fall back to a raw filesystem walk" >&2
             return 1
         fi
-        git -C "$root" ls-files -s -z -- crates/ | python3 -c '
+        if ! git -C "$root" rev-parse --verify HEAD > /dev/null 2>&1; then
+            rm -f "$file_list" "$symlink_list"
+            echo "stub-marker scan: $root has no valid HEAD commit -- tracked-tree discovery requires a committed HEAD; refusing to fall back to the mutable index or a raw filesystem walk" >&2
+            return 1
+        fi
+
+        # Capture git's own exit code explicitly (`|| git_rc=$?` keeps set -e
+        # from aborting before the check runs) and write its output to a temp
+        # file rather than piping straight into python3: a pipe lets python's
+        # exit status mask git's, so a partial listing followed by git's own
+        # non-zero exit would otherwise still read as an overall success and
+        # scan only a subset of files. Fail closed on any non-zero rc.
+        tree_list="$(mktemp)"
+        git_rc=0
+        git -C "$root" ls-tree -r -z HEAD -- crates/ > "$tree_list" || git_rc=$?
+        if [ "$git_rc" -ne 0 ]; then
+            rm -f "$file_list" "$symlink_list" "$tree_list"
+            echo "stub-marker scan: git ls-tree -r HEAD -- crates/ failed (exit $git_rc) -- refusing to scan a partial or absent tree listing" >&2
+            return 1
+        fi
+        python3 -c '
 import os
 import sys
 
-root, out_files, out_symlinks = sys.argv[1], sys.argv[2], sys.argv[3]
-raw = sys.stdin.buffer.read()
+root, out_files, out_symlinks, tree_list_path = sys.argv[1], sys.argv[2], sys.argv[3], sys.argv[4]
+with open(tree_list_path, "rb") as fh:
+    raw = fh.read()
 files = []
 symlinks = []
 for entry in raw.split(b"\0"):
@@ -717,6 +848,8 @@ for entry in raw.split(b"\0"):
     meta, sep, relpath = entry.partition(b"\t")
     if not sep:
         continue
+    # ls-tree metadata is "<mode> <type> <object>" (no index stage field,
+    # unlike ls-files -s).
     file_mode = meta.split(b" ", 1)[0]
     relpath_s = os.fsdecode(relpath)
     abspath = os.path.join(root, relpath_s)
@@ -732,7 +865,8 @@ with open(out_symlinks, "wb") as fh:
     fh.write(b"\0".join(os.fsencode(p) for p in symlinks))
     if symlinks:
         fh.write(b"\0")
-' "$root" "$file_list" "$symlink_list"
+' "$root" "$file_list" "$symlink_list" "$tree_list"
+        rm -f "$tree_list"
     else
         # find-mode discovery: self-test fixture trees only (mktemp -d
         # trees, never git repos) -- production always uses git mode above.
@@ -1331,6 +1465,36 @@ def allowlist_match_index(rel_path, message, entries):
     return None
 
 
+def open_no_indirection(scan_root, rel_path):
+    """Open `rel_path` (forward-slash separated, relative to `scan_root`) for
+    reading, refusing a symlink at EVERY path component -- not just the
+    final one. `os.open(path, O_NOFOLLOW)` on a full path string only binds
+    the LAST component: a PARENT directory swapped to a symlink after
+    discovery (e.g. a build step racing this guard) redirects the read to
+    wherever that symlink points, and a final-component-only O_NOFOLLOW
+    never sees it. Walk component-by-component with `dir_fd=` (openat(2)
+    semantics) starting from a root directory fd opened once with
+    O_DIRECTORY|O_NOFOLLOW, refusing a symlink -- ELOOP -- at each step, so
+    every component from the scan root down to the file is proven a
+    non-symlink at read time. Raises OSError (ELOOP/EMLINK on a symlinked
+    component, ENOENT/ENOTDIR on a vanished or non-directory component) --
+    the caller handles these the same way it handled a final-component
+    O_NOFOLLOW failure."""
+    parts = rel_path.split("/")
+    if not parts or any(p in ("", ".", "..") for p in parts):
+        raise OSError(errno.ELOOP, "path has an empty, '.', or '..' component: " + rel_path)
+    dir_fd = os.open(scan_root, os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW)
+    try:
+        for part in parts[:-1]:
+            next_fd = os.open(part, os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW, dir_fd=dir_fd)
+            os.close(dir_fd)
+            dir_fd = next_fd
+        file_fd = os.open(parts[-1], os.O_RDONLY | os.O_NOFOLLOW, dir_fd=dir_fd)
+    finally:
+        os.close(dir_fd)
+    return file_fd
+
+
 # Filesystem-indirection class: the scan() find already collected EVERY symlink
 # under crates/ (any name, file or directory), excluding pruned build-artifact
 # dirs, into SYMLINK_LIST_PATH. A symlinked .rs rides past the -type f discovery
@@ -1374,20 +1538,29 @@ allowlist_used = [False] * len(allowlist)
 findings = []
 for path in files:
     rel_path = os.path.relpath(path, SCAN_ROOT).replace(os.sep, "/")
-    # Bind the read to the exact path discovery found, atomically: O_NOFOLLOW
-    # refuses to open through a symlink, so a path that was a real regular
-    # file at discovery time (a `find -type f` hit, or a git-index 100644/
-    # 100755 entry) but has since been swapped to a symlink -- by a
+    # Bind the read to the exact path discovery found, atomically, at EVERY
+    # path component (not just the final one): a path that was a real
+    # regular file under a real directory tree at discovery time (a
+    # `find -type f` hit, or a git-tree 100644/100755 entry) but has since
+    # had itself OR any parent directory swapped to a symlink -- by a
     # PR-controlled build script or proc-macro racing this guard, or simply
-    # because a git-tracked working-tree file diverged from its clean index
-    # entry -- raises ELOOP here instead of silently following the
+    # because a git-tracked working-tree entry diverged from its clean
+    # HEAD-tree entry -- raises ELOOP here instead of silently following the
     # replacement or reading different content than what was discovered.
     try:
-        fd = os.open(path, os.O_RDONLY | os.O_NOFOLLOW)
+        fd = open_no_indirection(SCAN_ROOT, rel_path)
     except OSError as exc:
-        if exc.errno in (errno.ELOOP, errno.EMLINK):
+        # ENOTDIR joins ELOOP/EMLINK here: opening a symlinked directory
+        # component with O_DIRECTORY|O_NOFOLLOW raises ELOOP on Linux but
+        # ENOTDIR on macOS/BSD (O_NOFOLLOW refuses to dereference it, so the
+        # kernel reports the un-dereferenced node -- a symlink -- as not a
+        # directory rather than as a symlink loop). Both mean the same thing
+        # here: a parent component that should be a directory is not one at
+        # read time.
+        if exc.errno in (errno.ELOOP, errno.EMLINK, errno.ENOTDIR):
             sys.stderr.write(
-                "stub-marker scan: discovered path is a symlink at read time "
+                "stub-marker scan: a path component (the discovered file "
+                "itself, or a PARENT directory) is a symlink at read time "
                 "(swapped after discovery) -- refusing to follow a "
                 f"post-discovery filesystem indirection: {sanitize_for_ci(rel_path)}\n"
             )

--- a/scripts/lint-stub-markers.sh
+++ b/scripts/lint-stub-markers.sh
@@ -1,0 +1,272 @@
+#!/bin/sh
+# Detect placeholder-string `panic!`/`unreachable!` calls in shipping source
+# (#560, closes the gap in the clippy-based No-Stub Guard).
+#
+# `-Dclippy::todo`/`-Dclippy::unimplemented` (scripts/ci.sh phase_no_stubs)
+# unconditionally deny `todo!()`/`unimplemented!()` regardless of message, but
+# `panic!`/`unreachable!` are legitimate everywhere (assertion failures,
+# invariant violations) -- denying them outright would fail hundreds of
+# existing, correct call sites. The actual stub signal is the MESSAGE: a
+# `panic!("not implemented yet")` or `unreachable!("stub")` is a placeholder
+# wearing a real macro. This scans the string literal argument of every
+# panic!/unreachable! call for that language, not the macro itself.
+#
+# Scope mirrors phase_no_stubs (`--lib --bins`): only crates/*/src (workspace +
+# the forward-deployed khive-merge crate), never crates/*/tests, benches, or
+# examples. Within src, a `#[cfg(test)]`-gated item is source clippy never
+# type-checks under `--lib --bins` (no `--cfg test`), so this scanner skips
+# those blocks the same way.
+set -eu
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$SCRIPT_DIR/.."
+
+self_test() {
+    tmp="$(mktemp -d)"
+    trap 'rm -rf "$tmp"' EXIT
+
+    mkdir -p "$tmp/case-fail/crates/fixture-crate/src"
+    mkdir -p "$tmp/case-pass/crates/fixture-crate/src"
+
+    cat > "$tmp/case-fail/crates/fixture-crate/src/lib.rs" <<'FIXTURE'
+pub fn dispatch(kind: &str) -> u32 {
+    match kind {
+        "a" => 1,
+        _ => unreachable!("stub: not implemented for other kinds yet"),
+    }
+}
+FIXTURE
+
+    cat > "$tmp/case-pass/crates/fixture-crate/src/lib.rs" <<'FIXTURE'
+pub fn dispatch(kind: &str) -> u32 {
+    match kind {
+        "a" => 1,
+        "b" => 2,
+        _ => unreachable!("dispatch: unknown kind {kind:?} (validated by caller)"),
+    }
+}
+
+pub fn divide(a: i32, b: i32) -> i32 {
+    if b == 0 {
+        panic!("divide: b must be non-zero, got {b}");
+    }
+    a / b
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    struct StubService;
+
+    impl StubService {
+        fn call(&self) {
+            panic!("StubService::call must not be invoked in this test")
+        }
+    }
+
+    #[test]
+    fn dispatch_a() {
+        assert_eq!(dispatch("a"), 1);
+    }
+}
+FIXTURE
+
+    status=0
+
+    if scan "$tmp/case-fail" > "$tmp/fail.log" 2>&1; then
+        echo "self-test FAILED: placeholder unreachable!(\"stub: ...\") was not caught"
+        cat "$tmp/fail.log"
+        status=1
+    elif ! grep -q "stub" "$tmp/fail.log"; then
+        echo "self-test FAILED: scan failed, but not for the expected reason:"
+        cat "$tmp/fail.log"
+        status=1
+    fi
+
+    if ! scan "$tmp/case-pass" > "$tmp/pass.log" 2>&1; then
+        echo "self-test FAILED: legitimate panic!/unreachable! messages (incl. a #[cfg(test)] helper named StubService) false-positived:"
+        cat "$tmp/pass.log"
+        status=1
+    fi
+
+    if [ "$status" -eq 0 ]; then
+        echo "lint-stub-markers self-test: OK"
+    fi
+    return "$status"
+}
+
+scan() {
+    root="$1"
+    files=$(find "$root/crates" \
+        \( -name 'target' -o -name 'target-wt' -o -name 'tests' -o -name 'benches' -o -name 'examples' \) -type d -prune \
+        -o -path '*/src/*.rs' -type f -print \
+        | sort)
+
+    if [ -z "$files" ]; then
+        echo "no source files found under $root/crates"
+        return 0
+    fi
+
+    python3 - "$files" <<'PY'
+import re
+import sys
+
+files = [f for f in sys.argv[1].split("\n") if f.strip()]
+
+PLACEHOLDER_RE = re.compile(
+    r"\b(stub|todo|fixme|placeholder|unimplemented|not\s*yet\s*implemented|"
+    r"not\s*implemented|coming\s*soon)\b",
+    re.IGNORECASE,
+)
+MACRO_CALL_RE = re.compile(r"\b(panic|unreachable)!\s*\(")
+STRING_LIT_RE = re.compile(r'"((?:[^"\\]|\\.)*)"')
+CFG_TEST_RE = re.compile(r"#\s*\[\s*cfg\s*\(\s*test\s*\)\s*\]")
+
+
+def strip_comments_and_char_lits(text):
+    """Blank out //, /* */ comments and char literals so brace-counting and
+    macro-matching never trip on braces/quotes living inside them. String
+    literals are left untouched -- their content is exactly what this script
+    inspects."""
+    out = []
+    i = 0
+    n = len(text)
+    in_line_comment = False
+    in_block_comment = False
+    in_string = False
+    while i < n:
+        c = text[i]
+        if in_line_comment:
+            out.append(" " if c != "\n" else "\n")
+            if c == "\n":
+                in_line_comment = False
+            i += 1
+            continue
+        if in_block_comment:
+            if c == "*" and i + 1 < n and text[i + 1] == "/":
+                out.append("  ")
+                i += 2
+                in_block_comment = False
+                continue
+            out.append(" " if c != "\n" else "\n")
+            i += 1
+            continue
+        if in_string:
+            out.append(c)
+            if c == "\\" and i + 1 < n:
+                out.append(text[i + 1])
+                i += 2
+                continue
+            if c == '"':
+                in_string = False
+            i += 1
+            continue
+        if c == "/" and i + 1 < n and text[i + 1] == "/":
+            in_line_comment = True
+            out.append("  ")
+            i += 2
+            continue
+        if c == "/" and i + 1 < n and text[i + 1] == "*":
+            in_block_comment = True
+            out.append("  ")
+            i += 2
+            continue
+        if c == '"':
+            in_string = True
+            out.append(c)
+            i += 1
+            continue
+        if c == "'" and i + 1 < n:
+            # char literal e.g. 'a', '\'', or a lifetime 'a -- only blank the
+            # `'x'`/`'\x'` form so lifetimes (no closing quote) pass through.
+            j = i + 1
+            if text[j] == "\\" and j + 1 < n:
+                j += 2
+            else:
+                j += 1
+            if j < n and text[j] == "'":
+                out.append(" " * (j - i + 1))
+                i = j + 1
+                continue
+        out.append(c)
+        i += 1
+    return "".join(out)
+
+
+def test_gated_spans(clean_text):
+    """Byte-offset [start, end) spans of every #[cfg(test)]-attributed item's
+    body -- clippy --lib --bins never compiles these (no --cfg test), so the
+    scanner must not flag placeholder messages living only in test code."""
+    spans = []
+    for m in CFG_TEST_RE.finditer(clean_text):
+        brace_open = clean_text.find("{", m.end())
+        if brace_open == -1:
+            continue
+        depth = 1
+        i = brace_open + 1
+        n = len(clean_text)
+        while i < n and depth > 0:
+            if clean_text[i] == "{":
+                depth += 1
+            elif clean_text[i] == "}":
+                depth -= 1
+            i += 1
+        spans.append((m.start(), i))
+    return spans
+
+
+def in_span(offset, spans):
+    return any(start <= offset < end for start, end in spans)
+
+
+findings = []
+for path in files:
+    with open(path, "r", encoding="utf-8") as fh:
+        text = fh.read()
+    clean = strip_comments_and_char_lits(text)
+    test_spans = test_gated_spans(clean)
+
+    for m in MACRO_CALL_RE.finditer(clean):
+        if in_span(m.start(), test_spans):
+            continue
+        call_start = m.end() - 1  # the '(' of the macro call
+        # Only consider a string literal immediately after the '(' (allowing
+        # whitespace) -- this is the macro's message argument, not some
+        # unrelated string buried deeper in a multi-arg call.
+        lookahead = clean[call_start + 1 : call_start + 1 + 40]
+        stripped = lookahead.lstrip()
+        if not stripped.startswith('"'):
+            continue
+        msg_start = call_start + 1 + (len(lookahead) - len(stripped))
+        msg_m = STRING_LIT_RE.match(clean, msg_start)
+        if msg_m is None:
+            continue
+        message = msg_m.group(1)
+        if PLACEHOLDER_RE.search(message):
+            line_no = clean.count("\n", 0, m.start()) + 1
+            macro_name = m.group(1)
+            findings.append(f"{path}:{line_no}: {macro_name}!(\"{message}\") reads as a placeholder stub, not a real error path")
+
+if findings:
+    for f in findings:
+        print(f)
+    print(f"\nstub-marker lint: {len(findings)} issue(s)")
+    sys.exit(1)
+
+print(f"stub-marker lint: {len(files)} file(s) OK")
+PY
+}
+
+case "${1:-}" in
+    --self-test)
+        self_test
+        ;;
+    "")
+        scan "$ROOT"
+        ;;
+    *)
+        echo "usage: $0 [--self-test]" >&2
+        exit 2
+        ;;
+esac

--- a/scripts/lint-stub-markers.sh
+++ b/scripts/lint-stub-markers.sh
@@ -796,62 +796,87 @@ LSTREEFAILFIXTURE
     # run_all still looks correct. That is exactly how the macOS PR lane once ran
     # cargo with no scan at all.
     #
-    # Decide this on the workflow's step structure, not on its text. Text cannot
-    # answer it: YAML mapping keys are unordered, so a condition may sit after the
-    # `run:` it gates, and a step may invoke cargo directly without ever naming
-    # ci.sh. Segment the compile job into steps and require that the first step
-    # able to execute cargo is the scan, carrying no condition. Scope is the `ci`
-    # job: other jobs compile deliberately narrow slices and are not the lane #560
-    # concerns.
+    # Decide this by PARSING the workflow, not by matching its text. Text cannot
+    # answer the question at all: `if:`, `if :`, `"if":` and `'if':` are the same
+    # key to YAML but four different strings, a step may invoke cargo without ever
+    # naming ci.sh, and mapping keys are unordered so a condition may follow the
+    # `run:` it gates. Each of those defeated a text scan here. Load the document
+    # and require that the first step able to execute cargo is the scan, carrying
+    # no condition. Scope is the `ci` job: other jobs compile deliberately narrow
+    # slices and are not the lane #560 concerns.
+    #
+    # python3 is already required by this script (see the scan loop). PyYAML is the
+    # one added dependency, and its absence HARD-FAILS rather than skipping: a
+    # guard that silently downgrades to "no check" is worse than no guard, because
+    # it reports success.
     workflow="$SCRIPT_DIR/../.github/workflows/ci.yml"
     if [ -f "$workflow" ]; then
-        workflow_verdict="$(awk '
-            function flush(   i, line, has_if, runs_cargo, is_scan) {
-                if (!in_step) { return }
-                for (i = 1; i <= n; i++) {
-                    line = buf[i]
-                    # Comment lines never execute. They must be ignored, not just
-                    # for tidiness: the ordering rationale written above the scan
-                    # step names cargo, and counting it would mark the preceding
-                    # step cargo-capable and fail a correct workflow.
-                    if (line ~ /^[ \t]*#/) { continue }
-                    if (line ~ if_re) { has_if = 1 }
-                    if (line ~ /scripts\/ci\.sh/ ||
-                        line ~ /cargo[ \t]+[a-z]/ ||
-                        line ~ /make[ \t]+[a-z]/) { runs_cargo = 1 }
-                    if (line ~ /no-stubs-scan/) { is_scan = 1 }
-                }
-                if (runs_cargo && verdict == "") {
-                    if (!is_scan)      { verdict = "NOTSCAN|" step_name }
-                    else if (has_if)   { verdict = "GATED|" step_name }
-                    else               { verdict = "OK|" step_name }
-                }
-                in_step = 0
-                n = 0
-            }
-            /^  ci:$/                { in_job = 1; next }
-            /^  [a-z0-9_-]+:$/       { flush(); in_job = 0 }
-            !in_job                  { next }
-            match($0, /^ +- /) {
-                flush()
-                # Build the key indent literally rather than with a {n} interval:
-                # interval support differs between the awk implementations on the
-                # Linux and macOS runners, and a regex that silently fails to
-                # match would turn this guard into a no-op.
-                pad = ""
-                for (i = 0; i < RLENGTH; i++) { pad = pad " " }
-                if_re = "^" pad "if:"
-                step_name = $0
-                sub(/^ +- (name|uses): */, "", step_name)
-                in_step = 1
-            }
-            in_step                  { buf[++n] = $0 }
-            END                      { flush(); print verdict }
-        ' "$workflow")"
+        workflow_verdict="$(WORKFLOW="$workflow" python3 - <<'PYWF'
+import os, re, sys
+
+try:
+    import yaml
+except ImportError:
+    print("NOPARSER|")
+    sys.exit(0)
+
+try:
+    with open(os.environ["WORKFLOW"], encoding="utf-8") as fh:
+        doc = yaml.safe_load(fh)
+except Exception as exc:
+    print("UNPARSEABLE|%s" % exc)
+    sys.exit(0)
+
+job = ((doc or {}).get("jobs") or {}).get("ci")
+if not isinstance(job, dict):
+    print("NOJOB|")
+    sys.exit(0)
+
+# A step that shells to ci.sh runs cargo transitively; one naming a cargo or make
+# subcommand runs it directly. `rustup which cargo` prints a path and builds
+# nothing, so a bare "cargo" with no following subcommand does not count.
+runs_cargo = re.compile(r"scripts/ci\.sh|cargo[ \t]+[a-z]|make[ \t]+[a-z]")
+
+verdict = "NOCARGO|"
+for step in job.get("steps") or []:
+    if not isinstance(step, dict):
+        continue
+    run = step.get("run") or ""
+    # Comment lines never execute, and the ordering rationale written above the
+    # scan step names cargo; counting it would fail a correct workflow.
+    body = "\n".join(
+        line for line in run.splitlines() if not line.lstrip().startswith("#")
+    )
+    if not runs_cargo.search(body):
+        continue
+    name = step.get("name") or step.get("uses") or "(unnamed step)"
+    if "no-stubs-scan" not in body:
+        verdict = "NOTSCAN|%s" % name
+    elif "if" in step:
+        verdict = "GATED|%s" % name
+    else:
+        verdict = "OK|%s" % name
+    break
+
+print(verdict)
+PYWF
+)"
         workflow_state="${workflow_verdict%%|*}"
         workflow_step="${workflow_verdict#*|}"
         case "$workflow_state" in
             OK) ;;
+            NOPARSER)
+                echo "self-test FAILED: PyYAML is not importable, so the workflow ordering check cannot run. Install it (pip install pyyaml) -- this check must not be skipped, because a guard that silently downgrades to no check still reports success (#560)."
+                status=1
+                ;;
+            UNPARSEABLE)
+                echo "self-test FAILED: .github/workflows/ci.yml did not parse as YAML: $workflow_step"
+                status=1
+                ;;
+            NOJOB)
+                echo "self-test FAILED: .github/workflows/ci.yml has no 'ci' job, so the guard's scope no longer matches the workflow. Either the job was renamed or the compile lane moved; this check must not silently pass (#560)."
+                status=1
+                ;;
             NOTSCAN)
                 echo "self-test FAILED: in .github/workflows/ci.yml the first step of job 'ci' that can execute cargo is '$workflow_step', not the placeholder scan. A cargo-running step ahead of the guard executes PR-controlled build scripts and proc-macros against an unscanned tree (#560)."
                 status=1
@@ -861,7 +886,7 @@ LSTREEFAILFIXTURE
                 status=1
                 ;;
             *)
-                echo "self-test FAILED: could not find any cargo-executing step in job 'ci' of .github/workflows/ci.yml. Either the job was renamed or the guard's scope no longer matches the workflow; this check must not silently pass (#560)."
+                echo "self-test FAILED: no step in job 'ci' of .github/workflows/ci.yml executes cargo, so the guard has nothing to order itself against. The compile lane moved or the step shape changed; this check must not silently pass (#560)."
                 status=1
                 ;;
         esac

--- a/scripts/lint-stub-markers.sh
+++ b/scripts/lint-stub-markers.sh
@@ -91,6 +91,36 @@ pub fn after_byte_raw_string_literal(flag: bool) -> u32 {
     }
     1
 }
+
+pub fn after_format_arg_stub(flag: bool) -> u32 {
+    if !flag {
+        panic!("{}", "todo: not implemented for the format-arg case");
+    }
+    1
+}
+
+pub fn after_concat_stub(flag: bool) -> u32 {
+    if !flag {
+        panic!(concat!("todo: ", "concat-assembled stub message"));
+    }
+    1
+}
+
+#[cfg(any(test, feature = "test-support"))]
+pub fn composite_test_gated_stub() -> u32 {
+    panic!("todo: still a stub behind a cfg(any(test, feature)) composite, must never reach shipping scan")
+}
+
+#[cfg(not(test))]
+pub fn after_not_test_cfg_stub(flag: bool) -> u32 {
+    if !flag {
+        panic!("todo: still not implemented behind a cfg(not(test)) attribute, must always be scanned");
+    }
+    1
+}
+
+#[cfg(test)]
+mod ext_tests;
 FIXTURE
 
     # Appended via printf (not the quoted heredoc above) so the fixture can
@@ -98,6 +128,29 @@ FIXTURE
     # message -- the exact CI-log-forgery shape blocking fix 2 sanitizes.
     printf '\npub fn ci_log_forgery_stub(flag: bool) -> u32 {\n    if !flag {\n        panic!("todo: stub \033[31m::error::forged\nmid-message newline injection");\n    }\n    1\n}\n' \
         >> "$tmp/case-fail/crates/fixture-crate/src/lib.rs"
+
+    # External test module (blocking fix 3): `src/lib.rs` above declares
+    # `#[cfg(test)] mod ext_tests;` -- Rust's external-module-file form.
+    # Nothing inside ext_tests.rs itself carries a #[cfg(test)] attribute; the
+    # gate lives entirely in the parent's mod declaration. clippy --lib --bins
+    # never compiles it, so this placeholder must never be scanned.
+    cat > "$tmp/case-fail/crates/fixture-crate/src/ext_tests.rs" <<'EXTFIXTURE'
+pub fn only_reachable_from_cfg_test_mod_decl() {
+    panic!("todo: external test module content must never be scanned because it is only reachable via a cfg(test)-gated external mod declaration");
+}
+EXTFIXTURE
+
+    # Filename-injection fixture (blocking fix 1): the filename itself -- not
+    # the panic message -- carries a real newline and an unbroken
+    # `::error::forged` sequence. If a rendered finding line ever echoes this
+    # path unsanitized, it forges a GitHub Actions workflow command the same
+    # way an unsanitized message would.
+    newline_filename="exploit$(printf '\n')::error::forged.rs"
+    cat > "$tmp/case-fail/crates/fixture-crate/src/$newline_filename" <<'NLFIXTURE'
+pub fn newline_filename_stub() -> u32 {
+    panic!("todo: this file's name itself carries a newline and a forged CI workflow command sequence")
+}
+NLFIXTURE
 
     cat > "$tmp/case-pass/crates/fixture-crate/src/lib.rs" <<'FIXTURE'
 pub fn dispatch(kind: &str) -> u32 {
@@ -124,6 +177,20 @@ pub fn divide(a: i32, b: i32) -> i32 {
 
 pub fn help_text() -> &'static str {
     r#"call panic!("stub") to simulate a crash in the demo harness"#
+}
+
+pub fn format_arg_dispatch(kind: &str) -> u32 {
+    match kind {
+        "a" => 1,
+        _ => panic!("{}", "dispatch: unexpected kind encountered during normal operation"),
+    }
+}
+
+pub fn concat_arg_dispatch(kind: &str) -> u32 {
+    match kind {
+        "a" => 1,
+        _ => panic!(concat!("dispatch failure: ", "unexpected kind encountered")),
+    }
 }
 
 #[cfg(test)]
@@ -155,10 +222,10 @@ FIXTURE
 
     status=0
 
-    # Exactly 8 markers are seeded in case-fail above; asserting the count
+    # Exactly 12 markers are seeded in case-fail above; asserting the count
     # (not just substring presence) catches a parser-overmatch regression
     # that would otherwise slip through as an unnoticed extra finding.
-    expected_marker_count=8
+    expected_marker_count=12
 
     if scan "$tmp/case-fail" > "$tmp/fail.log" 2>&1; then
         echo "self-test FAILED: expected placeholder call sites were not caught"
@@ -179,7 +246,11 @@ FIXTURE
             "not implemented after a non-braced cfg(test) item" \
             "todo: still not implemented after a long comment gap" \
             "todo: still not implemented after a byte-raw string literal" \
-            "mid-message newline injection"
+            "mid-message newline injection" \
+            "todo: not implemented for the format-arg case" \
+            "concat-assembled stub message" \
+            "todo: still not implemented behind a cfg(not(test)) attribute" \
+            "carries a newline and a forged CI workflow command sequence"
         do
             if ! grep -qF "$marker" "$tmp/fail.log"; then
                 echo "self-test FAILED: expected finding missing: $marker"
@@ -187,6 +258,21 @@ FIXTURE
                 status=1
             fi
         done
+
+        # blocking fix 3: an external test module (only reachable via a
+        # cfg(test)-gated `mod ext_tests;` in lib.rs) and a same-file
+        # cfg(any(test, ...)) composite must never surface as findings --
+        # clippy --lib --bins never compiles either.
+        if grep -qF 'external test module content' "$tmp/fail.log"; then
+            echo "self-test FAILED: content only reachable via a cfg(test)-gated external mod declaration was scanned"
+            cat "$tmp/fail.log"
+            status=1
+        fi
+        if grep -qF 'cfg(any(test, feature)) composite' "$tmp/fail.log"; then
+            echo "self-test FAILED: an item gated by a cfg(any(test, ...)) composite was scanned"
+            cat "$tmp/fail.log"
+            status=1
+        fi
 
         # blocking fix 2: the ci_log_forgery_stub message above carries a raw
         # ANSI escape, a literal "::error::forged" workflow-command shape, and
@@ -198,7 +284,7 @@ FIXTURE
             status=1
         fi
         if grep -qF '::error::forged' "$tmp/fail.log"; then
-            echo "self-test FAILED: an unbroken '::error::forged' workflow command leaked into CI output"
+            echo "self-test FAILED: an unbroken '::error::forged' workflow command leaked into CI output (from a message or a filename)"
             cat "$tmp/fail.log"
             status=1
         fi
@@ -209,6 +295,16 @@ FIXTURE
         fi
         if ! grep -q 'mid-message newline injection.*reads as a placeholder stub' "$tmp/fail.log"; then
             echo "self-test FAILED: the embedded newline in the panic message split the CI log line in two"
+            cat "$tmp/fail.log"
+            status=1
+        fi
+
+        # blocking fix 1: the fixture filename itself (not its content)
+        # carries a real newline and an unbroken "::error::forged" sequence
+        # -- the rendered path must be sanitized the same way a message is,
+        # and the whole finding must survive as a single, unbroken CI line.
+        if ! grep -Eq 'exploit.*forged\.rs.*reads as a placeholder stub' "$tmp/fail.log"; then
+            echo "self-test FAILED: the embedded newline in the fixture filename split the CI finding line in two, or the sanitized path did not render as expected"
             cat "$tmp/fail.log"
             status=1
         fi
@@ -228,21 +324,36 @@ FIXTURE
 
 scan() {
     root="$1"
-    files=$(find "$root/crates" \
-        \( -name 'target' -o -name 'target-wt' -o -name 'tests' -o -name 'benches' -o -name 'examples' \) -type d -prune \
-        -o -path '*/src/*.rs' -type f -print \
-        | sort)
+    file_list="$(mktemp)"
 
-    if [ -z "$files" ]; then
+    # NUL-delimited discovery and transport end-to-end: a filename may
+    # legally contain a newline (or any byte but NUL and `/`), and this
+    # scanner's own findings later echo filenames straight into CI stdout.
+    # Word/newline-splitting a file list (the previous `$(find ...)` capture
+    # into a newline-joined string) lets such a filename inject extra,
+    # bogus list entries -- or, once rendered, forge GitHub Actions
+    # workflow-command lines. `-print0` + a NUL-delimited transport file
+    # sidesteps splitting entirely; `sanitize_for_ci` (applied to every
+    # rendered path below, the same function already used on messages)
+    # handles the render side.
+    find "$root/crates" \
+        \( -name 'target' -o -name 'target-wt' -o -name 'tests' -o -name 'benches' -o -name 'examples' \) -type d -prune \
+        -o -path '*/src/*.rs' -type f -print0 \
+        > "$file_list"
+
+    if [ ! -s "$file_list" ]; then
+        rm -f "$file_list"
         echo "no source files matched crates/*/src/**/*.rs under $root/crates (excluding target*/tests/benches/examples) -- the scanner would silently be a no-op; fix the file-layout selection" >&2
         return 1
     fi
 
-    python3 - "$files" <<'PY'
+    python3 - "$file_list" <<'PY'
+import os
 import re
 import sys
 
-files = [f for f in sys.argv[1].split("\n") if f.strip()]
+with open(sys.argv[1], "rb") as fh:
+    files = sorted(os.fsdecode(f) for f in fh.read().split(b"\0") if f)
 
 PLACEHOLDER_RE = re.compile(
     r"\b(stub|todo|fixme|placeholder|unimplemented|not\s*yet\s*implemented|"
@@ -254,9 +365,14 @@ PLACEHOLDER_RE = re.compile(
 # call syntax, not just parens.
 MACRO_CALL_RE = re.compile(r"\b(panic|unreachable)\s*!\s*([(\{\[])")
 STRING_LIT_RE = re.compile(r'"((?:[^"\\]|\\.)*)"')
-CFG_TEST_RE = re.compile(r"#\s*\[\s*cfg\s*\(\s*test\s*\)\s*\]")
+CFG_ATTR_START_RE = re.compile(r"#\s*\[\s*cfg\s*\(")
+ATTR_RE = re.compile(r"#\s*!?\s*\[[^\[\]]*\]\s*")
+MOD_DECL_RE = re.compile(r"mod\s+([A-Za-z_][A-Za-z0-9_]*)\s*;")
+NOT_TEST_RE = re.compile(r"not\s*\(\s*test\s*\)")
+TEST_IDENT_RE = re.compile(r"\btest\b")
 WHITESPACE_RE = re.compile(r"\s*")
 ANSI_ESCAPE_RE = re.compile(r"\x1b\[[0-9;]*[a-zA-Z]|\x1b.")
+CLOSERS = {"(": ")", "{": "}", "[": "]"}
 
 
 def sanitize_for_ci(raw):
@@ -481,24 +597,88 @@ def find_item_head_end(code_only, start):
     return None
 
 
+def find_matching_close(code_only, open_pos):
+    """code_only[open_pos] is an opening `(`/`{`/`[`; return the offset of its
+    same-type-nesting-depth matching close, or len(code_only) if
+    unterminated. Runs on `code_only` (strings already blanked to spaces),
+    so a bracket character living inside string content can never desync
+    the depth count."""
+    open_ch = code_only[open_pos]
+    close_ch = CLOSERS[open_ch]
+    n = len(code_only)
+    depth = 1
+    i = open_pos + 1
+    while i < n and depth > 0:
+        if code_only[i] == open_ch:
+            depth += 1
+        elif code_only[i] == close_ch:
+            depth -= 1
+        i += 1
+    return i - 1 if depth == 0 else n
+
+
+def is_test_gated_predicate(predicate):
+    """True if this #[cfg(...)] predicate can only be satisfied when --cfg
+    test is set -- matching what `cargo clippy --lib --bins` never compiles
+    (it never passes --cfg test). Covers the bare `test` predicate and any
+    any(...)/all(...) composite carrying `test` as a direct operand
+    (`any(test, feature = "x")`, `all(test, feature = "x")`) -- in this
+    codebase both shapes gate test-only helpers behind a feature that is
+    never active in a plain --lib --bins build, so treating either as
+    test-gated matches actual clippy behavior. `not(test)` is stripped
+    before the check: an item gated by `not(test)` (or `all(not(test), ...)`)
+    compiles precisely when test is ABSENT, i.e. always under --lib --bins,
+    so it must stay in scan scope, never be excluded."""
+    stripped = NOT_TEST_RE.sub(" ", predicate)
+    return bool(TEST_IDENT_RE.search(stripped))
+
+
+def find_test_gated_cfg_attrs(code_only):
+    """[(attr_start, attr_end), ...] for every #[cfg(...)] attribute in
+    code_only whose predicate is_test_gated_predicate. attr_end is the
+    offset just past the attribute's closing `]`. Balanced-paren parsing
+    (via find_matching_close) means a composite predicate's own nested
+    parens -- any(test, ...), all(test, ...) -- are captured whole, unlike
+    the old fixed `#[cfg(test)]`-only regex."""
+    results = []
+    n = len(code_only)
+    for m in CFG_ATTR_START_RE.finditer(code_only):
+        paren_start = m.end() - 1
+        close = find_matching_close(code_only, paren_start)
+        if close >= n:
+            continue
+        predicate = code_only[paren_start + 1 : close]
+        j = close + 1
+        while j < n and code_only[j].isspace():
+            j += 1
+        if j >= n or code_only[j] != "]":
+            continue
+        attr_end = j + 1
+        if is_test_gated_predicate(predicate):
+            results.append((m.start(), attr_end))
+    return results
+
+
 def test_gated_spans(code_only):
-    """Byte-offset [start, end) spans of every #[cfg(test)]-attributed item --
-    clippy --lib --bins never compiles these (no --cfg test), so the scanner
-    must not flag placeholder messages living only in test code. Runs on the
-    strings-blanked `code_only` text so a `#[cfg(test)]`-shaped substring
-    living inside a string literal is never mistaken for a real attribute.
-    For a non-braced item (e.g. `#[cfg(test)] const X: u32 = 1;`) the span
-    ends at the terminating `;`; for a braced item it ends at the body's
-    balanced close, per find_item_head_end above."""
+    """Byte-offset [start, end) spans of every item gated by a test-shaped
+    #[cfg(...)] attribute (is_test_gated_predicate) -- clippy --lib --bins
+    never compiles these, so the scanner must not flag placeholder messages
+    living only in such code. Runs on the strings-blanked `code_only` text
+    so a cfg-attribute-shaped substring living inside a string literal is
+    never mistaken for a real attribute. For a non-braced item (e.g.
+    `#[cfg(test)] const X: u32 = 1;`) the span ends at the terminating `;`;
+    for a braced item (including `#[cfg(test)] mod tests { ... }`, whose
+    entire body is covered by the balanced brace count) it ends at the
+    body's balanced close, per find_item_head_end above."""
     spans = []
     n = len(code_only)
-    for m in CFG_TEST_RE.finditer(code_only):
-        head = find_item_head_end(code_only, m.end())
+    for attr_start, attr_end in find_test_gated_cfg_attrs(code_only):
+        head = find_item_head_end(code_only, attr_end)
         if head is None:
             continue
         kind, pos = head
         if kind == "semi":
-            spans.append((m.start(), pos + 1))
+            spans.append((attr_start, pos + 1))
             continue
         depth = 1
         i = pos + 1
@@ -508,13 +688,120 @@ def test_gated_spans(code_only):
             elif code_only[i] == "}":
                 depth -= 1
             i += 1
-        spans.append((m.start(), i))
+        spans.append((attr_start, i))
     return spans
+
+
+def skip_attrs_and_ws(code_only, pos):
+    """Advance past a run of `#[...]`/`#![...]` attributes and whitespace
+    starting at pos, so a cfg-gated `mod name;` declaration is still found
+    even when other attributes (`#[allow(dead_code)]`, doc comments already
+    blanked by strip_comments_and_char_lits, ...) sit between the cfg
+    attribute and the mod keyword."""
+    n = len(code_only)
+    while True:
+        m = ATTR_RE.match(code_only, pos)
+        if m is None:
+            break
+        pos = m.end()
+    ws = WHITESPACE_RE.match(code_only, pos)
+    return ws.end()
+
+
+def find_test_gated_external_mod_decls(parent_code_only):
+    """Module names declared as `#[cfg(test)] mod NAME;` (or an any/all-over-
+    test composite, is_test_gated_predicate) in this already
+    comments/strings-stripped parent-module source. Only the semicolon
+    (external-file) mod form matters here -- a braced `mod NAME { ... }` is
+    an inline module already covered by test_gated_spans' own balanced span
+    for that same file."""
+    names = set()
+    for attr_start, attr_end in find_test_gated_cfg_attrs(parent_code_only):
+        j = skip_attrs_and_ws(parent_code_only, attr_end)
+        m = MOD_DECL_RE.match(parent_code_only, j)
+        if m:
+            names.add(m.group(1))
+    return names
+
+
+def compute_externally_test_gated_files(files):
+    """Path set of every file reachable ONLY via a `#[cfg(test)] mod NAME;`
+    declaration in its parent module file -- Rust's external-module-file
+    form (e.g. `src/foo.rs` declaring `#[cfg(test)] mod tests;` for a
+    sibling `src/foo/tests.rs` or `src/foo/tests/mod.rs`). Nothing INSIDE
+    such a file carries a #[cfg(test)] attribute itself -- the gate lives in
+    the parent -- so test_gated_spans (which only looks within a single
+    file) cannot see it; clippy --lib --bins still never compiles it, since
+    the mod statement pulling it in is itself test-gated. Best-effort:
+    resolves only the single-parent-candidate cases Rust's module system
+    actually allows (`X.rs` or `X/mod.rs` declaring `mod Y;` for `X/Y.rs` or
+    `X/Y/mod.rs`, or `src/lib.rs`/`src/main.rs` for a crate-root `mod Y;`)."""
+    by_norm = {os.path.normpath(f): f for f in files}
+    parent_cache = {}
+    excluded = set()
+    for f in files:
+        norm = os.path.normpath(f)
+        d, base = os.path.split(norm)
+        stem, ext = os.path.splitext(base)
+        if ext != ".rs":
+            continue
+        if base == "mod.rs":
+            mod_name = os.path.basename(d)
+            owning_dir = os.path.dirname(d)
+        else:
+            mod_name = stem
+            owning_dir = d
+        if os.path.basename(owning_dir) == "src":
+            candidates = [
+                os.path.join(owning_dir, "lib.rs"),
+                os.path.join(owning_dir, "main.rs"),
+            ]
+        else:
+            candidates = [
+                os.path.join(os.path.dirname(owning_dir), os.path.basename(owning_dir) + ".rs"),
+                os.path.join(owning_dir, "mod.rs"),
+            ]
+        for cand in candidates:
+            cand_norm = os.path.normpath(cand)
+            if cand_norm == norm or cand_norm not in by_norm:
+                continue
+            if cand_norm not in parent_cache:
+                with open(by_norm[cand_norm], "r", encoding="utf-8") as fh:
+                    parent_text = fh.read()
+                parent_cache[cand_norm] = blank_strings(strip_comments_and_char_lits(parent_text))
+            if mod_name in find_test_gated_external_mod_decls(parent_cache[cand_norm]):
+                excluded.add(f)
+                break
+    return excluded
 
 
 def in_span(offset, spans):
     return any(start <= offset < end for start, end in spans)
 
+
+def collect_string_literals(clean, start, end):
+    """All string-literal contents (plain or raw) found anywhere in
+    clean[start:end], in source order. Used to scan a panic!/unreachable!
+    macro's full balanced argument list -- not just the token immediately
+    after the opening delimiter -- so a placeholder message hiding behind a
+    leading format-string argument (`panic!("{}", "todo: ...")`) or a
+    nested `concat!("not ", "implemented")` call is still found. Does not
+    evaluate non-literal arguments (variables, function calls, `format!`
+    results assembled elsewhere) -- those are invisible to a static text
+    scan and are out of scope."""
+    parts = []
+    i = start
+    while i < end:
+        lit = match_string_literal(clean, i)
+        if lit is not None and lit[0] <= end:
+            parts.append(lit[1])
+            i = lit[0]
+            continue
+        i += 1
+    return parts
+
+
+externally_gated_files = compute_externally_test_gated_files(files)
 
 findings = []
 for path in files:
@@ -522,34 +809,35 @@ for path in files:
         text = fh.read()
     clean = strip_comments_and_char_lits(text)
     code_only = blank_strings(clean)
-    test_spans = test_gated_spans(code_only)
+    if path in externally_gated_files:
+        # The whole file is reachable only via a test-gated external `mod
+        # NAME;` declaration in its parent -- see
+        # compute_externally_test_gated_files. Nothing in it ever compiles
+        # under --lib --bins, so none of its content is in scan scope.
+        test_spans = [(0, len(code_only))]
+    else:
+        test_spans = test_gated_spans(code_only)
 
     for m in MACRO_CALL_RE.finditer(code_only):
         if in_span(m.start(), test_spans):
             continue
         call_start = m.end() - 1  # the opening delimiter char (`(`/`{`/`[`)
-        # Only consider a string literal immediately after the delimiter --
-        # this is the macro's message argument, not some unrelated string
-        # buried deeper in a multi-arg call. Rust allows arbitrary whitespace
-        # and comments between the delimiter and the argument; `clean` has
-        # already blanked every comment to whitespace (nesting-aware), so
-        # skipping whitespace with no length cap is a full trivia skip, not
-        # just a wider fixed window -- a placeholder message is caught no
-        # matter how much trivia precedes it. Read from `clean` (strings
-        # intact), never `code_only` (which has blanked exactly the string
-        # content being looked for here).
-        after_delim = call_start + 1
-        trivia = WHITESPACE_RE.match(clean, after_delim)
-        msg_start = trivia.end()
-        msg_m = match_string_literal(clean, msg_start)
-        if msg_m is None:
+        # Scan every string literal within the macro's own balanced argument
+        # list (in source order), not just the token immediately after the
+        # opening delimiter -- see collect_string_literals. Read from
+        # `clean` (strings intact), never `code_only` (which has blanked
+        # exactly the string content being looked for here).
+        close_pos = find_matching_close(code_only, call_start)
+        parts = collect_string_literals(clean, call_start + 1, close_pos)
+        if not parts:
             continue
-        _, message = msg_m
+        message = "".join(parts)
         if PLACEHOLDER_RE.search(message):
             line_no = clean.count("\n", 0, m.start()) + 1
             macro_name = m.group(1)
+            safe_path = sanitize_for_ci(path)
             safe_message = sanitize_for_ci(message)
-            findings.append(f"{path}:{line_no}: {macro_name}!(\"{safe_message}\") reads as a placeholder stub, not a real error path")
+            findings.append(f"{safe_path}:{line_no}: {macro_name}!(\"{safe_message}\") reads as a placeholder stub, not a real error path")
 
 if findings:
     for f in findings:
@@ -559,6 +847,9 @@ if findings:
 
 print(f"stub-marker lint: {len(files)} file(s) OK")
 PY
+    rc=$?
+    rm -f "$file_list"
+    return "$rc"
 }
 
 case "${1:-}" in

--- a/scripts/lint-stub-markers.sh
+++ b/scripts/lint-stub-markers.sh
@@ -794,25 +794,77 @@ LSTREEFAILFIXTURE
     # does not call run_all: it invokes phases as individual workflow steps, so a
     # step reordered (or suite-gated) in the workflow bypasses the guard while
     # run_all still looks correct. That is exactly how the macOS PR lane once ran
-    # cargo with no scan at all. Assert against the workflow itself: the first
-    # ci.sh phase any job invokes must be no-stubs-scan, and it must carry no
-    # suite condition -- an `if:` on that step re-splits the lanes and leaves
-    # whichever suite it excludes unguarded.
+    # cargo with no scan at all.
+    #
+    # Decide this on the workflow's step structure, not on its text. Text cannot
+    # answer it: YAML mapping keys are unordered, so a condition may sit after the
+    # `run:` it gates, and a step may invoke cargo directly without ever naming
+    # ci.sh. Segment the compile job into steps and require that the first step
+    # able to execute cargo is the scan, carrying no condition. Scope is the `ci`
+    # job: other jobs compile deliberately narrow slices and are not the lane #560
+    # concerns.
     workflow="$SCRIPT_DIR/../.github/workflows/ci.yml"
     if [ -f "$workflow" ]; then
-        first_ci_phase="$(grep -oE 'scripts/ci\.sh [a-z-]+' "$workflow" | head -1 | awk '{print $2}')"
-        if [ "$first_ci_phase" != "no-stubs-scan" ]; then
-            echo "self-test FAILED: the first scripts/ci.sh phase invoked in .github/workflows/ci.yml must be 'no-stubs-scan'; found '$first_ci_phase'. A cargo-running step ahead of the guard executes PR-controlled build scripts against an unscanned tree (#560)."
-            status=1
-        fi
-        scan_line="$(grep -nE 'scripts/ci\.sh no-stubs-scan' "$workflow" | head -1 | cut -d: -f1)"
-        if [ -n "$scan_line" ]; then
-            guard_start="$((scan_line > 3 ? scan_line - 3 : 1))"
-            if sed -n "${guard_start},${scan_line}p" "$workflow" | grep -qE '^[[:space:]]*if:'; then
-                echo "self-test FAILED: the no-stubs-scan step in .github/workflows/ci.yml carries an 'if:' condition. The scan must run on every suite; gating it leaves the excluded lane compiling PR-controlled code unguarded (#560)."
+        workflow_verdict="$(awk '
+            function flush(   i, line, has_if, runs_cargo, is_scan) {
+                if (!in_step) { return }
+                for (i = 1; i <= n; i++) {
+                    line = buf[i]
+                    # Comment lines never execute. They must be ignored, not just
+                    # for tidiness: the ordering rationale written above the scan
+                    # step names cargo, and counting it would mark the preceding
+                    # step cargo-capable and fail a correct workflow.
+                    if (line ~ /^[ \t]*#/) { continue }
+                    if (line ~ if_re) { has_if = 1 }
+                    if (line ~ /scripts\/ci\.sh/ ||
+                        line ~ /cargo[ \t]+[a-z]/ ||
+                        line ~ /make[ \t]+[a-z]/) { runs_cargo = 1 }
+                    if (line ~ /no-stubs-scan/) { is_scan = 1 }
+                }
+                if (runs_cargo && verdict == "") {
+                    if (!is_scan)      { verdict = "NOTSCAN|" step_name }
+                    else if (has_if)   { verdict = "GATED|" step_name }
+                    else               { verdict = "OK|" step_name }
+                }
+                in_step = 0
+                n = 0
+            }
+            /^  ci:$/                { in_job = 1; next }
+            /^  [a-z0-9_-]+:$/       { flush(); in_job = 0 }
+            !in_job                  { next }
+            match($0, /^ +- /) {
+                flush()
+                # Build the key indent literally rather than with a {n} interval:
+                # interval support differs between the awk implementations on the
+                # Linux and macOS runners, and a regex that silently fails to
+                # match would turn this guard into a no-op.
+                pad = ""
+                for (i = 0; i < RLENGTH; i++) { pad = pad " " }
+                if_re = "^" pad "if:"
+                step_name = $0
+                sub(/^ +- (name|uses): */, "", step_name)
+                in_step = 1
+            }
+            in_step                  { buf[++n] = $0 }
+            END                      { flush(); print verdict }
+        ' "$workflow")"
+        workflow_state="${workflow_verdict%%|*}"
+        workflow_step="${workflow_verdict#*|}"
+        case "$workflow_state" in
+            OK) ;;
+            NOTSCAN)
+                echo "self-test FAILED: in .github/workflows/ci.yml the first step of job 'ci' that can execute cargo is '$workflow_step', not the placeholder scan. A cargo-running step ahead of the guard executes PR-controlled build scripts and proc-macros against an unscanned tree (#560)."
                 status=1
-            fi
-        fi
+                ;;
+            GATED)
+                echo "self-test FAILED: in .github/workflows/ci.yml the placeholder scan step carries an 'if:' condition. The scan must run on every suite; gating it leaves the excluded lane compiling PR-controlled code unguarded (#560)."
+                status=1
+                ;;
+            *)
+                echo "self-test FAILED: could not find any cargo-executing step in job 'ci' of .github/workflows/ci.yml. Either the job was renamed or the guard's scope no longer matches the workflow; this check must not silently pass (#560)."
+                status=1
+                ;;
+        esac
     fi
 
     if [ "$status" -eq 0 ]; then

--- a/scripts/lint-stub-markers.sh
+++ b/scripts/lint-stub-markers.sh
@@ -35,6 +35,39 @@ pub fn dispatch(kind: &str) -> u32 {
         _ => unreachable!("stub: not implemented for other kinds yet"),
     }
 }
+
+pub fn raw_stub(kind: &str) -> u32 {
+    match kind {
+        "a" => 1,
+        _ => panic!(r#"not implemented for other kinds yet"#),
+    }
+}
+
+pub fn braced_stub(flag: bool) -> u32 {
+    if !flag {
+        panic! { "todo: handle the false branch" }
+    }
+    1
+}
+
+const NOTE: &str = "warning: #[cfg(test)] { this is not a real attribute }";
+
+pub fn after_lookalike_string(flag: bool) -> u32 {
+    if !flag {
+        panic!("not implemented for this flag");
+    }
+    1
+}
+
+#[cfg(test)]
+const GREETING: &str = "x";
+
+pub fn after_nonbraced_cfg_test_item(flag: bool) -> u32 {
+    if !flag {
+        panic!("not implemented after a non-braced cfg(test) item");
+    }
+    1
+}
 FIXTURE
 
     cat > "$tmp/case-pass/crates/fixture-crate/src/lib.rs" <<'FIXTURE'
@@ -46,11 +79,22 @@ pub fn dispatch(kind: &str) -> u32 {
     }
 }
 
+pub fn raw_dispatch(kind: &str) -> u32 {
+    match kind {
+        "a" => 1,
+        _ => panic!(r#"dispatch: unknown kind {kind:?}"#),
+    }
+}
+
 pub fn divide(a: i32, b: i32) -> i32 {
     if b == 0 {
         panic!("divide: b must be non-zero, got {b}");
     }
     a / b
+}
+
+pub fn help_text() -> &'static str {
+    r#"call panic!("stub") to simulate a crash in the demo harness"#
 }
 
 #[cfg(test)]
@@ -75,17 +119,27 @@ FIXTURE
     status=0
 
     if scan "$tmp/case-fail" > "$tmp/fail.log" 2>&1; then
-        echo "self-test FAILED: placeholder unreachable!(\"stub: ...\") was not caught"
+        echo "self-test FAILED: expected placeholder call sites were not caught"
         cat "$tmp/fail.log"
         status=1
-    elif ! grep -q "stub" "$tmp/fail.log"; then
-        echo "self-test FAILED: scan failed, but not for the expected reason:"
-        cat "$tmp/fail.log"
-        status=1
+    else
+        for marker in \
+            "stub: not implemented for other kinds yet" \
+            "not implemented for other kinds yet" \
+            "todo: handle the false branch" \
+            "not implemented for this flag" \
+            "not implemented after a non-braced cfg(test) item"
+        do
+            if ! grep -qF "$marker" "$tmp/fail.log"; then
+                echo "self-test FAILED: expected finding missing: $marker"
+                cat "$tmp/fail.log"
+                status=1
+            fi
+        done
     fi
 
     if ! scan "$tmp/case-pass" > "$tmp/pass.log" 2>&1; then
-        echo "self-test FAILED: legitimate panic!/unreachable! messages (incl. a #[cfg(test)] helper named StubService) false-positived:"
+        echo "self-test FAILED: legitimate panic!/unreachable! messages (raw strings, lookalike text inside strings, a #[cfg(test)] helper named StubService) false-positived:"
         cat "$tmp/pass.log"
         status=1
     fi
@@ -119,16 +173,43 @@ PLACEHOLDER_RE = re.compile(
     r"not\s*implemented|coming\s*soon)\b",
     re.IGNORECASE,
 )
-MACRO_CALL_RE = re.compile(r"\b(panic|unreachable)!\s*\(")
+# Rust accepts whitespace before `!` and any of the three delimiter kinds
+# (`panic!(...)`, `panic!{...}`, `panic![...]`) -- all three are legal macro
+# call syntax, not just parens.
+MACRO_CALL_RE = re.compile(r"\b(panic|unreachable)\s*!\s*([(\{\[])")
 STRING_LIT_RE = re.compile(r'"((?:[^"\\]|\\.)*)"')
 CFG_TEST_RE = re.compile(r"#\s*\[\s*cfg\s*\(\s*test\s*\)\s*\]")
 
 
+def raw_string_end(text, i):
+    """If text[i] starts a raw string literal `r#*"..."#*` (word-boundary
+    checked so an identifier ending in `r` is never mistaken for one), return
+    the offset just past its closing quote+hashes (len(text) if unterminated).
+    Otherwise None."""
+    n = len(text)
+    if text[i] != "r":
+        return None
+    if i > 0 and (text[i - 1].isalnum() or text[i - 1] == "_"):
+        return None
+    j = i + 1
+    hashes = 0
+    while j < n and text[j] == "#":
+        hashes += 1
+        j += 1
+    if j >= n or text[j] != '"':
+        return None
+    closer = '"' + "#" * hashes
+    end = text.find(closer, j + 1)
+    return n if end == -1 else end + len(closer)
+
+
 def strip_comments_and_char_lits(text):
     """Blank out //, /* */ comments and char literals so brace-counting and
-    macro-matching never trip on braces/quotes living inside them. String
-    literals are left untouched -- their content is exactly what this script
-    inspects."""
+    macro-matching never trip on braces/quotes living inside them. Plain and
+    raw string literals are left untouched -- their content is exactly what
+    this script inspects. Raw strings are hand-scanned to their matching
+    "###-count closer so quotes inside them (e.g. `r#"say "hi""#`) do not
+    prematurely end the literal."""
     out = []
     i = 0
     n = len(text)
@@ -172,6 +253,11 @@ def strip_comments_and_char_lits(text):
             out.append("  ")
             i += 2
             continue
+        rs_end = raw_string_end(text, i)
+        if rs_end is not None:
+            out.append(text[i:rs_end])
+            i = rs_end
+            continue
         if c == '"':
             in_string = True
             out.append(c)
@@ -194,22 +280,79 @@ def strip_comments_and_char_lits(text):
     return "".join(out)
 
 
-def test_gated_spans(clean_text):
-    """Byte-offset [start, end) spans of every #[cfg(test)]-attributed item's
-    body -- clippy --lib --bins never compiles these (no --cfg test), so the
-    scanner must not flag placeholder messages living only in test code."""
+def match_string_literal(text, pos):
+    """Match a plain or raw string literal beginning at pos in `text` (which
+    must have string content intact, i.e. `clean`, never the strings-blanked
+    variant). Returns (end_offset, inner_content) or None."""
+    if pos >= len(text):
+        return None
+    if text[pos] == '"':
+        m = STRING_LIT_RE.match(text, pos)
+        return None if m is None else (m.end(), m.group(1))
+    rs_end = raw_string_end(text, pos)
+    if rs_end is None:
+        return None
+    j = pos + 1
+    hashes = 0
+    while text[j] == "#":
+        hashes += 1
+        j += 1
+    return rs_end, text[j + 1 : rs_end - 1 - hashes]
+
+
+def blank_strings(clean_text):
+    """Given `clean` (comments/char-lits stripped, strings intact), replace
+    every plain and raw string literal's content with spaces (newlines kept)
+    so downstream scans (cfg(test) attribute detection, macro-call matching)
+    never mistake text living inside a string literal for real code."""
+    out = list(clean_text)
+    i = 0
+    n = len(clean_text)
+    while i < n:
+        c = clean_text[i]
+        end = None
+        if c == '"':
+            m = STRING_LIT_RE.match(clean_text, i)
+            if m is not None:
+                end = m.end()
+        else:
+            end = raw_string_end(clean_text, i)
+        if end is not None:
+            for k in range(i, end):
+                if out[k] != "\n":
+                    out[k] = " "
+            i = end
+            continue
+        i += 1
+    return "".join(out)
+
+
+def test_gated_spans(code_only):
+    """Byte-offset [start, end) spans of every #[cfg(test)]-attributed item --
+    clippy --lib --bins never compiles these (no --cfg test), so the scanner
+    must not flag placeholder messages living only in test code. Runs on the
+    strings-blanked `code_only` text so a `#[cfg(test)]`-shaped substring
+    living inside a string literal is never mistaken for a real attribute.
+    For a non-braced item (e.g. `#[cfg(test)] const X: u32 = 1;`) the span
+    ends at the terminating `;`, not at some later item's `{` -- braces are
+    only brace-matched when `{` is the item's own opener (i.e. comes before
+    any `;`)."""
     spans = []
-    for m in CFG_TEST_RE.finditer(clean_text):
-        brace_open = clean_text.find("{", m.end())
-        if brace_open == -1:
+    n = len(code_only)
+    for m in CFG_TEST_RE.finditer(code_only):
+        semi = code_only.find(";", m.end())
+        brace = code_only.find("{", m.end())
+        if brace == -1 and semi == -1:
+            continue
+        if semi != -1 and (brace == -1 or semi < brace):
+            spans.append((m.start(), semi + 1))
             continue
         depth = 1
-        i = brace_open + 1
-        n = len(clean_text)
+        i = brace + 1
         while i < n and depth > 0:
-            if clean_text[i] == "{":
+            if code_only[i] == "{":
                 depth += 1
-            elif clean_text[i] == "}":
+            elif code_only[i] == "}":
                 depth -= 1
             i += 1
         spans.append((m.start(), i))
@@ -225,24 +368,27 @@ for path in files:
     with open(path, "r", encoding="utf-8") as fh:
         text = fh.read()
     clean = strip_comments_and_char_lits(text)
-    test_spans = test_gated_spans(clean)
+    code_only = blank_strings(clean)
+    test_spans = test_gated_spans(code_only)
 
-    for m in MACRO_CALL_RE.finditer(clean):
+    for m in MACRO_CALL_RE.finditer(code_only):
         if in_span(m.start(), test_spans):
             continue
-        call_start = m.end() - 1  # the '(' of the macro call
-        # Only consider a string literal immediately after the '(' (allowing
-        # whitespace) -- this is the macro's message argument, not some
-        # unrelated string buried deeper in a multi-arg call.
+        call_start = m.end() - 1  # the opening delimiter char (`(`/`{`/`[`)
+        # Only consider a string literal immediately after the delimiter
+        # (allowing whitespace) -- this is the macro's message argument, not
+        # some unrelated string buried deeper in a multi-arg call. Read the
+        # lookahead from `clean` (strings intact), never `code_only` (which
+        # has blanked exactly the string content being looked for here).
         lookahead = clean[call_start + 1 : call_start + 1 + 40]
         stripped = lookahead.lstrip()
-        if not stripped.startswith('"'):
+        if not (stripped.startswith('"') or stripped.startswith("r")):
             continue
         msg_start = call_start + 1 + (len(lookahead) - len(stripped))
-        msg_m = STRING_LIT_RE.match(clean, msg_start)
+        msg_m = match_string_literal(clean, msg_start)
         if msg_m is None:
             continue
-        message = msg_m.group(1)
+        _, message = msg_m
         if PLACEHOLDER_RE.search(message):
             line_no = clean.count("\n", 0, m.start()) + 1
             macro_name = m.group(1)

--- a/scripts/lint-stub-markers.sh
+++ b/scripts/lint-stub-markers.sh
@@ -19,6 +19,17 @@
 # type/method name happens to contain a placeholder word) are suppressed via
 # the explicit, in-diff reviewed allowlist at stub-marker-allowlist.txt --
 # see that file's header for the format.
+#
+# Filesystem-indirection (symlink) policy -- every path this script opens or
+# walks, and the symlink handling applied to each:
+#
+#   script self-location     | `cd $(dirname $0) && pwd`       | trusted; resolved once at startup
+#   crates/ regular .rs      | `find -type f -name '*.rs'`     | only real files scanned; symlinks excluded by -type f
+#   crates/ any symlink      | `find -type l`                  | HARD-FAIL, named via sanitize_for_ci, before scanning
+#   discovered .rs reads     | `open(path)` in the scan loop   | guaranteed real by the -type f / -type l split; CI checkout is static (no find->read swap)
+#   allowlist file           | `os.open(O_RDONLY|O_NOFOLLOW)`  | symlink refused atomically; in-repo default must also resolve under the scan root; env override is containment-exempt but still symlink-refused
+#   temp transport files     | `mktemp`                        | mktemp regular files (O_EXCL); not attacker-controlled
+#   self-test fixture trees  | self-authored under `mktemp -d` | test-authored real files
 set -eu
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
@@ -505,6 +516,64 @@ MALFIXTURE
         fi
     fi
 
+    # Filesystem-indirection: a symlinked allowlist must be refused (never
+    # followed), and the target's content must NOT be echoed into output. The
+    # target holds a sentinel that would only appear if the scanner followed the
+    # link and read it.
+    mkdir -p "$tmp/case-symlink-allowlist/crates/real-crate/src"
+    cat > "$tmp/case-symlink-allowlist/crates/real-crate/src/lib.rs" <<'SLFIXTURE'
+pub fn ok() -> u32 {
+    1
+}
+SLFIXTURE
+    printf 'SENTINEL_ALLOWLIST_SECRET_MUST_NOT_LEAK\tx\n' > "$tmp/symlink-allowlist-target.txt"
+    symlink_allowlist="$tmp/symlink-allowlist.txt"
+    ln -s "$tmp/symlink-allowlist-target.txt" "$symlink_allowlist"
+    if STUB_MARKER_ALLOWLIST="$symlink_allowlist" scan "$tmp/case-symlink-allowlist" > "$tmp/symlink-allow.log" 2>&1; then
+        echo "self-test FAILED: a symlinked allowlist file should have failed the scan loud"
+        cat "$tmp/symlink-allow.log"
+        status=1
+    else
+        if ! grep -qF 'symlink' "$tmp/symlink-allow.log"; then
+            echo "self-test FAILED: the symlinked-allowlist error did not report a symlink"
+            cat "$tmp/symlink-allow.log"
+            status=1
+        fi
+        if grep -qF 'SENTINEL_ALLOWLIST_SECRET_MUST_NOT_LEAK' "$tmp/symlink-allow.log"; then
+            echo "self-test FAILED: the symlinked allowlist's TARGET content leaked into CI output"
+            cat "$tmp/symlink-allow.log"
+            status=1
+        fi
+    fi
+
+    # Filesystem-indirection: a symlinked .rs under crates/ must hard-fail the
+    # scan (Cargo compiles it; -type f discovery would skip it). A real sibling
+    # .rs keeps the discovery list non-empty so the failure is the symlink, not
+    # an empty tree.
+    mkdir -p "$tmp/case-symlink-rs/crates/real-crate/src"
+    cat > "$tmp/case-symlink-rs/crates/real-crate/src/real.rs" <<'RSREAL'
+pub fn ok() -> u32 {
+    1
+}
+RSREAL
+    cat > "$tmp/case-symlink-rs/elsewhere.rs" <<'RSHIDDEN'
+pub fn hidden_stub() -> u32 {
+    panic!("todo: this stub rode in behind a symlinked .rs")
+}
+RSHIDDEN
+    ln -s "$tmp/case-symlink-rs/elsewhere.rs" "$tmp/case-symlink-rs/crates/real-crate/src/linked.rs"
+    if STUB_MARKER_ALLOWLIST="$empty_allowlist" scan "$tmp/case-symlink-rs" > "$tmp/symlink-rs.log" 2>&1; then
+        echo "self-test FAILED: a symlinked .rs under crates/ should have hard-failed the scan"
+        cat "$tmp/symlink-rs.log"
+        status=1
+    else
+        if ! grep -qF 'linked.rs' "$tmp/symlink-rs.log"; then
+            echo "self-test FAILED: the symlinked-.rs error did not name the offending link"
+            cat "$tmp/symlink-rs.log"
+            status=1
+        fi
+    fi
+
     if [ "$status" -eq 0 ]; then
         echo "lint-stub-markers self-test: OK"
     fi
@@ -530,22 +599,43 @@ scan() {
         -o -name '*.rs' -type f -print0 \
         > "$file_list"
 
-    if [ ! -s "$file_list" ]; then
-        rm -f "$file_list"
+    # Filesystem-indirection guard: collect EVERY symlink under crates/ (any
+    # name, file or directory), excluding the same pruned build-artifact dirs.
+    # A symlinked .rs is skipped by the -type f pass above but compiled by
+    # Cargo; a symlinked directory is not descended by find (no -L) yet Cargo
+    # builds through it. The python below hard-fails on any of them.
+    symlink_list="$(mktemp)"
+    find "$root/crates" \
+        \( -name 'target' -o -name '.cargo-target' \) -type d -prune \
+        -o -type l -print0 \
+        > "$symlink_list"
+
+    if [ ! -s "$file_list" ] && [ ! -s "$symlink_list" ]; then
+        rm -f "$file_list" "$symlink_list"
         echo "no .rs files matched under $root/crates (excluding target/.cargo-target build-artifact dirs) -- the scanner would silently be a no-op; fix the file-layout selection" >&2
         return 1
     fi
 
     allowlist="${STUB_MARKER_ALLOWLIST:-$SCRIPT_DIR/stub-marker-allowlist.txt}"
+    # Whether the allowlist path came from the env override (a deliberate
+    # operator choice, containment-exempt) or the in-repo default (must resolve
+    # under the scan root). Symlink refusal applies to BOTH; see load_allowlist.
+    if [ -n "${STUB_MARKER_ALLOWLIST:-}" ]; then
+        allowlist_is_override=1
+    else
+        allowlist_is_override=0
+    fi
 
     # `|| rc=$?` keeps set -e from exiting the script the moment python3 returns
     # non-zero (findings present, or the allowlist-path guard failing): the temp
     # file_list below must still be removed on that path, and the caller needs
     # the real exit code, not a set-e-induced abort.
     rc=0
-    python3 - "$file_list" "$allowlist" "$root" <<'PY' || rc=$?
+    python3 - "$file_list" "$allowlist" "$root" "$symlink_list" "$allowlist_is_override" <<'PY' || rc=$?
+import errno
 import os
 import re
+import stat
 import sys
 
 with open(sys.argv[1], "rb") as fh:
@@ -553,6 +643,8 @@ with open(sys.argv[1], "rb") as fh:
 
 ALLOWLIST_PATH = sys.argv[2]
 SCAN_ROOT = sys.argv[3]
+SYMLINK_LIST_PATH = sys.argv[4]
+ALLOWLIST_IS_OVERRIDE = sys.argv[5] == "1"
 
 PLACEHOLDER_RE = re.compile(
     r"\b(stub|todo|fixme|placeholder|unimplemented|not\s*yet\s*implemented|"
@@ -932,7 +1024,7 @@ def resolve_format_message(template, positionals, named):
     return FORMAT_SLOT_RE.sub(repl, template)
 
 
-def load_allowlist(path):
+def load_allowlist(path, scan_root, is_override):
     """Parse `<repo-relative-path>\\t<exact-decoded-message>` entries from the
     allowlist file at `path`, returning (entries, malformed). Each entry
     suppresses a finding only when both fields match exactly (see
@@ -942,12 +1034,44 @@ def load_allowlist(path):
     ignored. A non-comment line with no TAB is malformed -- collected in
     `malformed` with its 1-based line number so the caller can fail loud rather
     than silently drop a mis-typed entry that would suppress nothing. A missing
-    file is an empty allowlist, not an error."""
+    file is an empty allowlist, not an error.
+
+    Filesystem-indirection policy: the allowlist is opened with O_NOFOLLOW, so a
+    symlinked allowlist file is refused atomically (no check-then-open gap) --
+    a symlink could point at a sensitive out-of-tree file whose content the
+    malformed-line reporter would otherwise echo into CI. For the in-repo
+    DEFAULT allowlist (no env override) the resolved path must additionally
+    stay under the scan root; an env override is a deliberate operator choice
+    and is containment-exempt, but is still symlink-refused."""
     entries = []
     malformed = []
-    if not os.path.isfile(path):
+    try:
+        fd = os.open(path, os.O_RDONLY | os.O_NOFOLLOW)
+    except OSError as exc:
+        if exc.errno == errno.ENOENT:
+            return entries, malformed
+        if exc.errno in (errno.ELOOP, errno.EMLINK):
+            sys.stderr.write(
+                "stub-marker allowlist path is a symlink; refusing to follow it "
+                "(a symlinked allowlist could disclose an out-of-tree file's "
+                f"content into CI): {sanitize_for_ci(path)}\n"
+            )
+            sys.exit(1)
+        raise
+    if not stat.S_ISREG(os.fstat(fd).st_mode):
+        os.close(fd)
         return entries, malformed
-    with open(path, "r", encoding="utf-8") as fh:
+    if not is_override:
+        real = os.path.realpath(path)
+        root_real = os.path.realpath(scan_root)
+        if real != root_real and not real.startswith(root_real + os.sep):
+            os.close(fd)
+            sys.stderr.write(
+                "stub-marker default allowlist resolves outside the scan root; "
+                f"refusing: {sanitize_for_ci(path)}\n"
+            )
+            sys.exit(1)
+    with os.fdopen(fd, "r", encoding="utf-8") as fh:
         for lineno, raw_line in enumerate(fh, 1):
             line = raw_line.rstrip("\n")
             if not line.strip() or line.lstrip().startswith("#"):
@@ -975,7 +1099,31 @@ def allowlist_match_index(rel_path, message, entries):
     return None
 
 
-allowlist, malformed_allowlist = load_allowlist(ALLOWLIST_PATH)
+# Filesystem-indirection class: the scan() find already collected EVERY symlink
+# under crates/ (any name, file or directory), excluding pruned build-artifact
+# dirs, into SYMLINK_LIST_PATH. A symlinked .rs rides past the -type f discovery
+# while Cargo compiles it; a symlinked directory is not descended by find (no -L)
+# yet Cargo builds through it. Either way a placeholder stub could ride past this
+# guard, so refuse to scan through any of them -- named via sanitize_for_ci --
+# before doing anything else.
+with open(SYMLINK_LIST_PATH, "rb") as fh:
+    symlinked = sorted(os.fsdecode(f) for f in fh.read().split(b"\0") if f)
+if symlinked:
+    sys.stderr.write(
+        "stub-marker scan found symlink(s) under crates/ -- a symlinked source "
+        "file is compiled by Cargo but skipped by -type f discovery, and a "
+        "symlinked directory hides its source from the scan while Cargo still "
+        "builds it; either way a placeholder stub could ride past this guard. "
+        "Refusing to scan through them; replace each with a real file or dir:\n"
+    )
+    for entry in symlinked:
+        rel = os.path.relpath(entry, SCAN_ROOT).replace(os.sep, "/")
+        sys.stderr.write(f"  {sanitize_for_ci(rel)}\n")
+    sys.exit(1)
+
+allowlist, malformed_allowlist = load_allowlist(
+    ALLOWLIST_PATH, SCAN_ROOT, ALLOWLIST_IS_OVERRIDE
+)
 
 # A non-comment allowlist line with no TAB is a mis-typed entry: it parses as
 # neither a path nor a message and would silently suppress nothing. Fail loud
@@ -1071,7 +1219,7 @@ if failed:
 
 print(f"stub-marker lint: {len(files)} file(s) OK")
 PY
-    rm -f "$file_list"
+    rm -f "$file_list" "$symlink_list"
     return "$rc"
 }
 

--- a/scripts/stub-marker-allowlist.txt
+++ b/scripts/stub-marker-allowlist.txt
@@ -1,0 +1,25 @@
+# Explicit allowlist for scripts/lint-stub-markers.sh (#560).
+#
+# The scanner has no reachability/cfg analysis -- it scans every .rs file
+# under crates/ (source, tests, benches, examples) and flags any
+# panic!/unreachable! call whose decoded string-literal message reads as a
+# placeholder. A small number of matches are legitimate (a test mock whose
+# type or method name happens to contain a placeholder word); those are
+# suppressed here, one line per exception, never by loosening the scanner
+# itself.
+#
+# Format: one entry per line, a path-substring and a decoded-message-
+# substring separated by a single TAB. A finding is suppressed iff its file
+# path contains the path-substring AND its decoded message contains the
+# message-substring. Keep both substrings as specific as the real match to
+# avoid over-suppressing unrelated findings. An entry that matches nothing
+# in a given run is not an error. Blank lines and lines starting with `#`
+# are ignored. Adding a line here is a reviewed code change, not a blanket
+# exemption -- justify it in the PR.
+
+# crates/kkernel/src/reindex.rs: a #[cfg(test)] EmbeddingService mock named
+# StubService whose guard message names the mock's own type/method, not a
+# real placeholder. Currently inert under the scanner's word-boundary
+# PLACEHOLDER_RE ("StubService" has no isolated "stub" word), seeded here
+# for the case the mock's naming or the regex broadens later.
+crates/kkernel/src/reindex.rs	StubService::embed must not be called in this test

--- a/scripts/stub-marker-allowlist.txt
+++ b/scripts/stub-marker-allowlist.txt
@@ -8,14 +8,16 @@
 # suppressed here, one line per exception, never by loosening the scanner
 # itself.
 #
-# Format: one entry per line, a path-substring and a decoded-message-
-# substring separated by a single TAB. A finding is suppressed iff its file
-# path contains the path-substring AND its decoded message contains the
-# message-substring. Keep both substrings as specific as the real match to
-# avoid over-suppressing unrelated findings. An entry that matches nothing
-# in a given run is not an error. Blank lines and lines starting with `#`
-# are ignored. Adding a line here is a reviewed code change, not a blanket
-# exemption -- justify it in the PR.
+# Format: one entry per line, a repo-relative path and a fully decoded
+# message separated by a single TAB. A finding is suppressed iff BOTH match
+# EXACTLY: the path equals the finding's repo-relative path (as rendered
+# under `crates/...`) AND the message equals the finding's fully decoded
+# panic!/unreachable! message. Matching is exact, not substring, so an entry
+# can never suppress an unrelated finding that merely shares a path prefix or
+# a message fragment. An entry that matches nothing in a given run is not an
+# error. Blank lines and lines starting with `#` are ignored. Adding a line
+# here is a reviewed code change, not a blanket exemption -- justify it in
+# the PR.
 
 # crates/kkernel/src/reindex.rs: a #[cfg(test)] EmbeddingService mock named
 # StubService whose guard message names the mock's own type/method, not a
@@ -23,3 +25,9 @@
 # PLACEHOLDER_RE ("StubService" has no isolated "stub" word), seeded here
 # for the case the mock's naming or the regex broadens later.
 crates/kkernel/src/reindex.rs	StubService::embed must not be called in this test
+
+# Self-test fixture anchor, exercised by `lint-stub-markers.sh --self-test`
+# to prove the committed allowlist loads and suppresses by exact (path,
+# message) match. Inert in a real scan: no `fixture-crate` exists under
+# crates/ in the repo.
+crates/fixture-crate/src/lib.rs	todo: this one is allowlisted and must be suppressed

--- a/scripts/stub-marker-allowlist.txt
+++ b/scripts/stub-marker-allowlist.txt
@@ -14,10 +14,13 @@
 # under `crates/...`) AND the message equals the finding's fully decoded
 # panic!/unreachable! message. Matching is exact, not substring, so an entry
 # can never suppress an unrelated finding that merely shares a path prefix or
-# a message fragment. An entry that matches nothing in a given run is not an
-# error. Blank lines and lines starting with `#` are ignored. Adding a line
-# here is a reviewed code change, not a blanket exemption -- justify it in
-# the PR.
+# a message fragment. Blank lines and lines starting with `#` are ignored.
+#
+# Every entry's path MUST exist in the repo. The scanner fails loud on any
+# entry whose path is absent, so a stale entry (the file moved or was
+# deleted) or a pre-planted entry (added ahead of the file it would suppress)
+# cannot sit here silently disabling a future finding. Adding a line here is a
+# reviewed code change, not a blanket exemption -- justify it in the PR.
 
 # crates/kkernel/src/reindex.rs: a #[cfg(test)] EmbeddingService mock named
 # StubService whose guard message names the mock's own type/method, not a
@@ -25,9 +28,3 @@
 # PLACEHOLDER_RE ("StubService" has no isolated "stub" word), seeded here
 # for the case the mock's naming or the regex broadens later.
 crates/kkernel/src/reindex.rs	StubService::embed must not be called in this test
-
-# Self-test fixture anchor, exercised by `lint-stub-markers.sh --self-test`
-# to prove the committed allowlist loads and suppresses by exact (path,
-# message) match. Inert in a real scan: no `fixture-crate` exists under
-# crates/ in the repo.
-crates/fixture-crate/src/lib.rs	todo: this one is allowlisted and must be suppressed

--- a/scripts/stub-marker-allowlist.txt
+++ b/scripts/stub-marker-allowlist.txt
@@ -14,17 +14,19 @@
 # under `crates/...`) AND the message equals the finding's fully decoded
 # panic!/unreachable! message. Matching is exact, not substring, so an entry
 # can never suppress an unrelated finding that merely shares a path prefix or
-# a message fragment. Blank lines and lines starting with `#` are ignored.
+# a message fragment. Blank lines and lines starting with `#` are ignored; a
+# non-comment line without a TAB is a malformed entry and fails the scan loud.
 #
-# Every entry's path MUST exist in the repo. The scanner fails loud on any
-# entry whose path is absent, so a stale entry (the file moved or was
-# deleted) or a pre-planted entry (added ahead of the file it would suppress)
-# cannot sit here silently disabling a future finding. Adding a line here is a
-# reviewed code change, not a blanket exemption -- justify it in the PR.
-
-# crates/kkernel/src/reindex.rs: a #[cfg(test)] EmbeddingService mock named
-# StubService whose guard message names the mock's own type/method, not a
-# real placeholder. Currently inert under the scanner's word-boundary
-# PLACEHOLDER_RE ("StubService" has no isolated "stub" word), seeded here
-# for the case the mock's naming or the regex broadens later.
-crates/kkernel/src/reindex.rs	StubService::embed must not be called in this test
+# Every entry must suppress a CURRENT finding. The scanner fails loud on any
+# entry that matches no finding in the scanned tree -- a stale entry (the file
+# moved, or its message changed) or a pre-planted entry (added ahead of the
+# file it would suppress) cannot sit here silently disabling a future finding.
+# An allowlist entry is therefore only ever added in the same change as the
+# finding it suppresses, and justified in the PR.
+#
+# There are no active entries today. The crates/kkernel/src/reindex.rs
+# #[cfg(test)] EmbeddingService mock named StubService (whose guard message
+# names the mock's own type/method, not a real placeholder) is inert under the
+# scanner's word-boundary PLACEHOLDER_RE -- "StubService" has no isolated
+# "stub" word -- so it produces no finding and needs no entry. An entry would
+# be added here only if a real match ever appears.


### PR DESCRIPTION
## Summary

Closes the gap #560 identified: `phase_no_stubs` in `scripts/ci.sh` denies `clippy::todo`, `clippy::unimplemented`, and `clippy::dbg_macro` unconditionally, but had no detection for `panic!`/`unreachable!` calls carrying a placeholder message (e.g. `unreachable!("stub: not implemented yet")`).

`panic!`/`unreachable!` can't be denied outright the way `todo!`/`unimplemented!` are — a repo-wide scan turned up 359 legitimate call sites (assertion failures, invariant violations) across shipping source; denying the macros themselves would fail hundreds of correct sites, which is explicitly out of scope for this fix.

Instead, `scripts/lint-stub-markers.sh` inspects only the string-literal message argument of `panic!`/`unreachable!` calls for placeholder language (`stub`, `todo`, `fixme`, `placeholder`, `unimplemented`, `not yet implemented`, `coming soon`). Scope mirrors the existing clippy pass: `crates/*/src` only (workspace + the forward-deployed `khive-merge` crate), excluding `tests/`, `benches/`, `examples/` directories and any `#[cfg(test)]`-gated block — the same code clippy never type-checks under `--lib --bins` without `--cfg test`.

Wired into `phase_no_stubs` in `scripts/ci.sh` as an additional step alongside the existing clippy invocations.

## What was verified

- `sh scripts/lint-stub-markers.sh --self-test` — a fixture crate with a planted `unreachable!("stub: ...")` is caught; a fixture crate with legitimate `panic!`/`unreachable!` messages (including a `#[cfg(test)]` helper struct literally named `StubService`, to guard against a naive substring match on "stub") passes clean.
- `sh scripts/lint-stub-markers.sh` against the actual repo: 484 source files, 0 findings — confirms the scanner does not cascade against existing shipping code.
- `sh scripts/ci.sh no-stubs` (full phase, clippy + new scan): passes end to end.
- Manually planted `unreachable!("stub: not implemented for this path yet")` in `crates/khive-types/src/lib.rs`, re-ran the scanner: caught with a `file:line` pointer. Removed the plant, re-ran: clean again.

## Out of scope (left for a follow-up)

The issue also flagged a secondary naming drift: ADR-066 calls this a "No-stub guard" required status *context*, but the actual required contexts are the CI matrix jobs (`scripts/apply-autonomous-merge.sh`), not a standalone context. That's a doc/ADR-alignment fix, independent of this scanner, and is not addressed here to keep this PR scoped to the actual coverage gap.

## Test plan

- [x] `sh scripts/lint-stub-markers.sh --self-test`
- [x] `sh scripts/lint-stub-markers.sh` clean on current `main`
- [x] `sh scripts/ci.sh no-stubs` passes
- [x] Planted-stub regression: guard fails on a planted `unreachable!("stub: ...")`, passes once removed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
