### PR TITLE
fix(pack-memory): fuse recall across every configured embedding engine (#1115)

### DIFF
--- a/crates/khive-mcp/src/serve.rs
+++ b/crates/khive-mcp/src/serve.rs
@@ -2514,17 +2514,20 @@ mod tests {
     #[test]
     #[serial]
     fn resolver_uses_config_file_engines_over_defaults() {
-        // Ensure env vars cannot leak into either branch.
+        // Ensure a stale ambient value cannot leak into either branch.
         std::env::remove_var("KHIVE_EMBEDDING_MODEL");
-        std::env::remove_var("KHIVE_ADDITIONAL_EMBEDDING_MODELS");
+        // The shipped default is single-engine, so leaving the additional list
+        // unset would make "the config file overrode the default" and "there
+        // was nothing to override" produce the same empty result, and the
+        // final assertion below would stop discriminating. Declare one
+        // deliberately so the override remains observable.
+        std::env::set_var("KHIVE_ADDITIONAL_EMBEDDING_MODELS", "paraphrase");
 
         let default_cfg = RuntimeConfig::default();
         let default_primary = format!("{:?}", default_cfg.embedding_model);
-        // Default ships a non-empty additional-engine list (the multilingual
-        // model). The single-engine config file below must override it.
         assert!(
             !default_cfg.additional_embedding_models.is_empty(),
-            "precondition: default config has additional engines"
+            "precondition: default config must carry an additional engine for this test to discriminate"
         );
 
         let dir = tempfile::tempdir().expect("temp dir");
@@ -2565,6 +2568,8 @@ default = true
             "config file declares one engine; additional list must be empty (not the default's)"
         );
         assert_eq!(resolved.db_path, None, ":memory: must map to in-memory db");
+
+        std::env::remove_var("KHIVE_ADDITIONAL_EMBEDDING_MODELS");
     }
 
     /// Regression for #379: when the loaded config file has NO `[[engines]]`

--- a/crates/khive-pack-knowledge/src/knowledge/index_handler.rs
+++ b/crates/khive-pack-knowledge/src/knowledge/index_handler.rs
@@ -1,9 +1,11 @@
 //! Index handler: embed atoms and build/persist the Vamana ANN index.
 
+use std::sync::Arc;
+
 use serde_json::{json, Value};
 
 use khive_runtime::{KhiveRuntime, NamespaceToken, RuntimeError};
-use khive_storage::types::{SqlStatement, SqlValue};
+use khive_storage::types::{SqlStatement, SqlValue, VectorRecord};
 use khive_types::SubstrateKind;
 
 use super::schema::{Atom, IndexParams};
@@ -134,129 +136,62 @@ impl KnowledgeHandlers {
                 })
                 .collect();
 
-            let embeddings = match runtime
-                .embed_document_batch_with_model(default_model_name, &texts)
-                .await
-            {
-                Ok(e) => e,
-                Err(e) => {
-                    tracing::warn!(
-                        batch_size = staged.len(),
-                        error = %e,
-                        "embed_batch failed; atoms cannot be recalled until reindexed"
-                    );
-                    failed += staged.len();
-                    continue;
-                }
-            };
-            if embeddings.len() != staged.len() {
-                tracing::warn!(
-                    expected = staged.len(),
-                    got = embeddings.len(),
-                    "embed_batch returned wrong number of vectors; atoms cannot be recalled until reindexed"
-                );
-                failed += staged.len();
-                continue;
-            }
+            // Every configured engine embeds and writes its own batch independently
+            // (issue #1115): a secondary-engine failure does not affect `indexed`/
+            // `failed`, which stay keyed on the default model, as before this fix.
+            // Fan the models out concurrently — each is an independent embed call
+            // plus vector write, so serializing them only adds up their latencies.
+            let staged = Arc::new(staged);
+            let texts = Arc::new(texts);
+
+            let default_handle = tokio::spawn(embed_and_insert_model(
+                runtime.clone(),
+                token.clone(),
+                default_model_name.to_string(),
+                true,
+                Arc::clone(&staged),
+                Arc::clone(&texts),
+            ));
+            let secondary_handles: Vec<_> = secondary_model_names
+                .iter()
+                .map(|model_name| {
+                    tokio::spawn(embed_and_insert_model(
+                        runtime.clone(),
+                        token.clone(),
+                        model_name.clone(),
+                        false,
+                        Arc::clone(&staged),
+                        Arc::clone(&texts),
+                    ))
+                })
+                .collect();
 
             // Track which atoms in this chunk had their vector persisted, so a
             // failed insert is reported as `failed` rather than silently counted
             // as `indexed`. A failed vector write means recall cannot retrieve
             // that atom — that is a failure, not a success.
             //
-            // No pre-delete loop: SqliteVecStore::insert wraps its own DELETE+INSERT
-            // in a single transaction, so a failed INSERT rolls back the DELETE and
-            // the prior vector survives (no-worse-than-stale). A separate pre-delete
-            // committed before insert would re-introduce the stranding window.
-            let mut chunk_ok: Vec<bool> = vec![true; staged.len()];
-            match runtime.vectors_for_model(token, default_model_name) {
-                Ok(vectors) => {
-                    let ns_str = token.namespace().as_str();
-                    for (i, ((id, _), emb)) in staged.iter().zip(embeddings.iter()).enumerate() {
-                        if let Err(e) = vectors
-                            .insert(
-                                *id,
-                                SubstrateKind::Entity,
-                                ns_str,
-                                "knowledge.atom",
-                                vec![emb.clone()],
-                            )
-                            .await
-                        {
-                            tracing::warn!(id = %id, error = %e, "knowledge vector insert failed");
-                            chunk_ok[i] = false;
-                            failed += 1;
-                        }
-                    }
+            // No pre-delete loop: SqliteVecStore::insert_batch wraps each record's
+            // own DELETE+INSERT in a savepoint, so a failed INSERT rolls back only
+            // that record's DELETE and the prior vector survives (no-worse-than-
+            // stale). A separate pre-delete committed before insert would
+            // re-introduce the stranding window.
+            match default_handle.await {
+                Ok(outcome) => {
+                    indexed += outcome.affected as usize;
+                    failed += outcome.failed as usize;
                 }
                 Err(e) => {
-                    tracing::warn!(error = %e, "knowledge vector store unavailable");
-                    for ok in chunk_ok.iter_mut() {
-                        *ok = false;
-                    }
+                    tracing::warn!(error = %e, "knowledge index default-model task panicked");
                     failed += staged.len();
                 }
             }
-
-            indexed += chunk_ok.iter().filter(|ok| **ok).count();
-
-            for model_name in &secondary_model_names {
-                let secondary_embeddings = match runtime
-                    .embed_document_batch_with_model(model_name, &texts)
-                    .await
-                {
-                    Ok(e) => e,
-                    Err(e) => {
-                        tracing::warn!(
-                            model = %model_name,
-                            batch_size = staged.len(),
-                            error = %e,
-                            "knowledge secondary-engine embed_batch failed; \
-                             atoms miss a vector for this engine until backfill"
-                        );
-                        continue;
-                    }
-                };
-                if secondary_embeddings.len() != staged.len() {
-                    tracing::warn!(
-                        model = %model_name,
-                        expected = staged.len(),
-                        got = secondary_embeddings.len(),
-                        "knowledge secondary-engine embed_batch returned wrong \
-                         vector count; skipping this engine for the batch"
-                    );
-                    continue;
-                }
-                match runtime.vectors_for_model(token, model_name) {
-                    Ok(vectors) => {
-                        let ns_str = token.namespace().as_str();
-                        for ((id, _), emb) in staged.iter().zip(secondary_embeddings.iter()) {
-                            if let Err(e) = vectors
-                                .insert(
-                                    *id,
-                                    SubstrateKind::Entity,
-                                    ns_str,
-                                    "knowledge.atom",
-                                    vec![emb.clone()],
-                                )
-                                .await
-                            {
-                                tracing::warn!(
-                                    id = %id,
-                                    model = %model_name,
-                                    error = %e,
-                                    "knowledge secondary-engine vector insert failed"
-                                );
-                            }
-                        }
-                    }
-                    Err(e) => {
-                        tracing::warn!(
-                            model = %model_name,
-                            error = %e,
-                            "knowledge secondary-engine vector store unavailable"
-                        );
-                    }
+            for handle in secondary_handles {
+                // Secondary-engine failures are best-effort (logged inside the
+                // task) and never affect `indexed`/`failed`; only a task panic
+                // needs handling here.
+                if let Err(e) = handle.await {
+                    tracing::warn!(error = %e, "knowledge index secondary-model task panicked");
                 }
             }
 
@@ -318,5 +253,149 @@ impl KnowledgeHandlers {
             "ann_vectors": ann_count,
             "ann_failed": ann_failed,
         }))
+    }
+}
+
+/// One embedding model's outcome from [`embed_and_insert_model`], counted in vectors.
+struct ModelIndexOutcome {
+    affected: u64,
+    failed: u64,
+}
+
+/// Embed one chunk's staged atoms with `model_name` and batch-insert the resulting
+/// vectors. Split out of `index` so the default model and every secondary model
+/// (issue #1115) can run as independent `tokio::spawn` tasks instead of embedding
+/// and writing serially, one model at a time. `is_default` only selects tracing
+/// wording — the default model's outcome is applied to the caller's `indexed`/
+/// `failed` counters; secondary-model outcomes are best-effort and only logged.
+async fn embed_and_insert_model(
+    runtime: KhiveRuntime,
+    token: NamespaceToken,
+    model_name: String,
+    is_default: bool,
+    staged: Arc<Vec<(uuid::Uuid, String)>>,
+    texts: Arc<Vec<String>>,
+) -> ModelIndexOutcome {
+    let embeddings = match runtime
+        .embed_document_batch_with_model(&model_name, &texts)
+        .await
+    {
+        Ok(e) => e,
+        Err(e) => {
+            if is_default {
+                tracing::warn!(
+                    batch_size = staged.len(),
+                    error = %e,
+                    "embed_batch failed; atoms cannot be recalled until reindexed"
+                );
+            } else {
+                tracing::warn!(
+                    model = %model_name,
+                    batch_size = staged.len(),
+                    error = %e,
+                    "knowledge secondary-engine embed_batch failed; \
+                     atoms miss a vector for this engine until backfill"
+                );
+            }
+            return ModelIndexOutcome {
+                affected: 0,
+                failed: if is_default { staged.len() as u64 } else { 0 },
+            };
+        }
+    };
+    if embeddings.len() != staged.len() {
+        if is_default {
+            tracing::warn!(
+                expected = staged.len(),
+                got = embeddings.len(),
+                "embed_batch returned wrong number of vectors; atoms cannot be recalled until reindexed"
+            );
+        } else {
+            tracing::warn!(
+                model = %model_name,
+                expected = staged.len(),
+                got = embeddings.len(),
+                "knowledge secondary-engine embed_batch returned wrong \
+                 vector count; skipping this engine for the batch"
+            );
+        }
+        return ModelIndexOutcome {
+            affected: 0,
+            failed: if is_default { staged.len() as u64 } else { 0 },
+        };
+    }
+
+    let vectors = match runtime.vectors_for_model(&token, &model_name) {
+        Ok(v) => v,
+        Err(e) => {
+            if is_default {
+                tracing::warn!(error = %e, "knowledge vector store unavailable");
+            } else {
+                tracing::warn!(
+                    model = %model_name,
+                    error = %e,
+                    "knowledge secondary-engine vector store unavailable"
+                );
+            }
+            return ModelIndexOutcome {
+                affected: 0,
+                failed: if is_default { staged.len() as u64 } else { 0 },
+            };
+        }
+    };
+
+    let ns_str = token.namespace().as_str().to_string();
+    let records: Vec<VectorRecord> = staged
+        .iter()
+        .zip(embeddings.iter())
+        .map(|((id, _), emb)| VectorRecord {
+            subject_id: *id,
+            kind: SubstrateKind::Entity,
+            namespace: ns_str.clone(),
+            field: "knowledge.atom".to_string(),
+            embedding_model: Some(model_name.clone()),
+            vectors: vec![emb.clone()],
+            updated_at: chrono::Utc::now(),
+        })
+        .collect();
+
+    match vectors.insert_batch(records).await {
+        Ok(summary) => {
+            if summary.failed > 0 {
+                if is_default {
+                    tracing::warn!(
+                        failed = summary.failed,
+                        error = %summary.first_error,
+                        "knowledge vector batch insert had failures"
+                    );
+                } else {
+                    tracing::warn!(
+                        model = %model_name,
+                        failed = summary.failed,
+                        error = %summary.first_error,
+                        "knowledge secondary-engine vector batch insert had failures"
+                    );
+                }
+            }
+            ModelIndexOutcome {
+                affected: summary.affected,
+                failed: summary.failed,
+            }
+        }
+        Err(e) => {
+            if is_default {
+                tracing::warn!(error = %e, "knowledge vector store unavailable");
+            } else {
+                tracing::warn!(
+                    model = %model_name,
+                    error = %e,
+                    "knowledge secondary-engine vector store unavailable"
+                );
+            }
+            ModelIndexOutcome {
+                affected: 0,
+                failed: if is_default { staged.len() as u64 } else { 0 },
+            }
+        }
     }
 }

--- a/crates/khive-pack-knowledge/src/knowledge/index_handler.rs
+++ b/crates/khive-pack-knowledge/src/knowledge/index_handler.rs
@@ -25,11 +25,20 @@ impl KnowledgeHandlers {
         let rebuild_ann = p.rebuild_ann.unwrap_or(false);
         let ns = token.namespace().as_str().to_owned();
 
-        if runtime.default_embedder_name().is_empty() {
+        let default_model_name = runtime.default_embedder_name();
+        if default_model_name.is_empty() {
             return Ok(
                 json!({ "indexed": 0, "skipped": 0, "failed": 0, "total": 0, "reason": "no embedding model configured" }),
             );
         }
+        // Every other registered engine gets the same batch, best-effort (issue
+        // #1115): a secondary-engine failure does not affect indexed/failed/
+        // skipped, which stay keyed on the default model as before this fix.
+        let secondary_model_names: Vec<String> = runtime
+            .registered_embedding_model_names()
+            .into_iter()
+            .filter(|m| m != default_model_name)
+            .collect();
 
         let sql = runtime.sql();
         let batch_size = p.batch_size.unwrap_or(DEFAULT_EMBED_BATCH).clamp(1, 1000);
@@ -125,7 +134,10 @@ impl KnowledgeHandlers {
                 })
                 .collect();
 
-            let embeddings = match runtime.embed_document_batch(&texts).await {
+            let embeddings = match runtime
+                .embed_document_batch_with_model(default_model_name, &texts)
+                .await
+            {
                 Ok(e) => e,
                 Err(e) => {
                     tracing::warn!(
@@ -157,7 +169,7 @@ impl KnowledgeHandlers {
             // the prior vector survives (no-worse-than-stale). A separate pre-delete
             // committed before insert would re-introduce the stranding window.
             let mut chunk_ok: Vec<bool> = vec![true; staged.len()];
-            match runtime.vectors(token) {
+            match runtime.vectors_for_model(token, default_model_name) {
                 Ok(vectors) => {
                     let ns_str = token.namespace().as_str();
                     for (i, ((id, _), emb)) in staged.iter().zip(embeddings.iter()).enumerate() {
@@ -187,6 +199,66 @@ impl KnowledgeHandlers {
             }
 
             indexed += chunk_ok.iter().filter(|ok| **ok).count();
+
+            for model_name in &secondary_model_names {
+                let secondary_embeddings = match runtime
+                    .embed_document_batch_with_model(model_name, &texts)
+                    .await
+                {
+                    Ok(e) => e,
+                    Err(e) => {
+                        tracing::warn!(
+                            model = %model_name,
+                            batch_size = staged.len(),
+                            error = %e,
+                            "knowledge secondary-engine embed_batch failed; \
+                             atoms miss a vector for this engine until backfill"
+                        );
+                        continue;
+                    }
+                };
+                if secondary_embeddings.len() != staged.len() {
+                    tracing::warn!(
+                        model = %model_name,
+                        expected = staged.len(),
+                        got = secondary_embeddings.len(),
+                        "knowledge secondary-engine embed_batch returned wrong \
+                         vector count; skipping this engine for the batch"
+                    );
+                    continue;
+                }
+                match runtime.vectors_for_model(token, model_name) {
+                    Ok(vectors) => {
+                        let ns_str = token.namespace().as_str();
+                        for ((id, _), emb) in staged.iter().zip(secondary_embeddings.iter()) {
+                            if let Err(e) = vectors
+                                .insert(
+                                    *id,
+                                    SubstrateKind::Entity,
+                                    ns_str,
+                                    "knowledge.atom",
+                                    vec![emb.clone()],
+                                )
+                                .await
+                            {
+                                tracing::warn!(
+                                    id = %id,
+                                    model = %model_name,
+                                    error = %e,
+                                    "knowledge secondary-engine vector insert failed"
+                                );
+                            }
+                        }
+                    }
+                    Err(e) => {
+                        tracing::warn!(
+                            model = %model_name,
+                            error = %e,
+                            "knowledge secondary-engine vector store unavailable"
+                        );
+                    }
+                }
+            }
 
             if let Some(cb) = on_progress {
                 cb(indexed as u64, total as u64);

--- a/crates/khive-pack-knowledge/tests/fixes.rs
+++ b/crates/khive-pack-knowledge/tests/fixes.rs
@@ -2158,6 +2158,117 @@ mod embed_failure_tests {
         );
     }
 
+    /// Issue #1115: `knowledge.index` must write a vector for every configured
+    /// engine, not just the default. Fake providers stand in for both engines
+    /// so the test doesn't load real lattice weights.
+    #[tokio::test]
+    async fn index_writes_vector_for_every_configured_engine() {
+        const SECONDARY_KEY: &str = "paraphrase-multilingual-minilm-l12-v2";
+
+        struct FixedVecService {
+            seed: f32,
+        }
+
+        #[async_trait]
+        impl EmbeddingService for FixedVecService {
+            async fn embed(
+                &self,
+                texts: &[String],
+                _model: EmbeddingModel,
+            ) -> std::result::Result<Vec<Vec<f32>>, EmbedError> {
+                Ok(texts.iter().map(|_| vec![self.seed; 384]).collect())
+            }
+
+            fn supports_model(&self, _model: EmbeddingModel) -> bool {
+                true
+            }
+
+            fn name(&self) -> &'static str {
+                "fixed-vec"
+            }
+        }
+
+        struct FixedVecProvider {
+            key: &'static str,
+            seed: f32,
+        }
+
+        #[async_trait]
+        impl EmbedderProvider for FixedVecProvider {
+            fn name(&self) -> &str {
+                self.key
+            }
+
+            fn dimensions(&self) -> usize {
+                384
+            }
+
+            async fn build(
+                &self,
+            ) -> std::result::Result<Arc<dyn EmbeddingService>, khive_runtime::RuntimeError>
+            {
+                Ok(Arc::new(FixedVecService { seed: self.seed }))
+            }
+        }
+
+        let rt = KhiveRuntime::new(RuntimeConfig {
+            git_write: Default::default(),
+            db_path: None,
+            default_namespace: Namespace::local(),
+            embedding_model: Some(EmbeddingModel::AllMiniLmL6V2),
+            additional_embedding_models: vec![EmbeddingModel::ParaphraseMultilingualMiniLmL12V2],
+            gate: Arc::new(AllowAllGate),
+            packs: vec!["kg".to_string(), "knowledge".to_string()],
+            backend_id: BackendId::main(),
+            brain_profile: None,
+            visible_namespaces: vec![],
+            allowed_outbound_namespaces: vec![],
+            actor_id: None,
+        })
+        .expect("runtime");
+        rt.register_embedder(FixedVecProvider {
+            key: MODEL_KEY,
+            seed: 0.5,
+        });
+        rt.register_embedder(FixedVecProvider {
+            key: SECONDARY_KEY,
+            seed: 0.6,
+        });
+
+        let f = fixture_with_two_atoms(rt).await;
+        let result = f
+            .dispatch("knowledge.index", json!({}))
+            .await
+            .expect("index ok");
+        assert_eq!(
+            result["indexed"].as_u64().unwrap_or(0),
+            2,
+            "both atoms must index via the default engine: {result:?}"
+        );
+
+        let row_primary = f
+            .sql_query_one(
+                "SELECT subject_id FROM vec_all_minilm_l6_v2 LIMIT 1",
+                vec![],
+            )
+            .await;
+        assert!(
+            row_primary.is_some(),
+            "primary engine table must have a row"
+        );
+
+        let row_secondary = f
+            .sql_query_one(
+                "SELECT subject_id FROM vec_paraphrase_multilingual_minilm_l12_v2 LIMIT 1",
+                vec![],
+            )
+            .await;
+        assert!(
+            row_secondary.is_some(),
+            "secondary engine table must have a row — issue #1115 write-path coverage"
+        );
+    }
+
     // ── Section embed failure regression ────────────────
     //
     // Mirrors the atom failure tests above but exercises the SECTION path via

--- a/crates/khive-pack-memory/docs/api/recall-pipeline.md
+++ b/crates/khive-pack-memory/docs/api/recall-pipeline.md
@@ -22,7 +22,7 @@ This deadline differs from `ann_ready_timeout_ms`: the former returns a typed `D
 
 Noise-only queries are rejected before expensive embedding work. `is_meaningful_query` requires alphabetic or CJK content, rejects empty/symbol-only input, rejects a lone non-CJK meaningful character, and filters repeated-character gibberish.
 
-FTS CJK bypass uses `contains_cjk`, while dense multilingual routing uses the broader `needs_multilingual` signal. If multilingual routing is requested but no multilingual model is registered, recall falls back to the registered model set rather than returning no results.
+FTS CJK bypass uses `contains_cjk` to route the text leg through the CJK-bypass tokenizer. The dense/vector leg has no separate query-language routing: it always searches every configured embedding engine and fuses the results (issue #1115), whether or not the query contains CJK.
 
 `embed_query_model` checks the pack-local LRU by `(model, query)` and embeds on the blocking pool when absent. It uses the runtime's query-side instruction prefix, which preserves the trained retrieval space for instruction-tuned models such as multilingual-e5. Cache hits clone the stored vector result.
 

--- a/crates/khive-pack-memory/docs/api/scoring.md
+++ b/crates/khive-pack-memory/docs/api/scoring.md
@@ -46,9 +46,7 @@ Explicit caller `entity_names` take precedence over derived candidates.
 
 ## Query language routing
 
-`is_cjk_char` recognizes Unified CJK, Extensions A and B, compatibility ideographs, Hiragana, Katakana, and Hangul syllables. `contains_cjk` returns true when CJK exceeds 15% of all characters.
-
-`needs_multilingual` uses a different denominator: it routes when more than 15% of alphabetic characters are non-ASCII. Punctuation, digits, and whitespace do not dilute the ratio, so `Müller`, `Müller?`, and `Müller!!!` route identically. It covers CJK, Cyrillic, Arabic, Devanagari, Hebrew, Thai, accented Latin, and other Unicode alphabetic scripts. ASCII-only non-English text is a known limitation and continues to the primary model unless a separate language detector is introduced.
+`is_cjk_char` recognizes Unified CJK, Extensions A and B, compatibility ideographs, Hiragana, Katakana, and Hangul syllables. `contains_cjk` returns true when CJK exceeds 15% of all characters; it gates only the FTS CJK-bypass tokenizer path (see recall-pipeline.md), not vector engine selection.
 
 ## `normalize_min_score`
 
@@ -82,4 +80,4 @@ The score is `sum(weight * feature) / sum(positive weights)`. Unknown names are 
 
 `ScoringConfig::apply_dos_caps` clamps candidates to 500, token budget to 16,000, and result limit to 200. Defaults are 200 candidates, 4,000 tokens, and 10 results. MMR applies a default `0.1` penalty when the first 100 characters duplicate an earlier result.
 
-Supersedes suppression and multilingual routing are enabled by default. A configured multilingual model is preferred; otherwise registered model names containing `multilingual` or `paraphrase` are candidates.
+Supersedes suppression is enabled by default. Recall always fans out across every registered embedding engine and fuses the results (issue #1115) — there is no per-query engine selection to configure.

--- a/crates/khive-pack-memory/src/handlers/common.rs
+++ b/crates/khive-pack-memory/src/handlers/common.rs
@@ -370,8 +370,6 @@ pub(super) struct RecallCandidateSet {
     /// One entry per embedding model: (model_name, hits). These have already been
     /// filtered to the caller's visible namespace set via over-fetch + post-filter.
     pub(super) vector_hits_per_model: Vec<(String, Vec<VectorSearchHit>)>,
-    /// True when multilingual dense routing was requested AND a multilingual model was found.
-    pub(super) multilingual_routed: bool,
     /// The caller's full visible namespace set (primary + any explicit extras).
     pub(super) visible_namespaces: Vec<String>,
     /// #836: true when at least one model's vector leg degraded to FTS-only
@@ -433,9 +431,6 @@ pub(super) struct RecallCandidateParams<'a> {
     pub(super) embedding_model: Option<&'a str>,
     /// Route the FTS path through the CJK-bypass tokenizer. Keyed on `contains_cjk`.
     pub(super) cjk_fts_bypass: bool,
-    /// Route the dense/vector path to the multilingual model. Keyed on `needs_multilingual`.
-    pub(super) use_multilingual: bool,
-    pub(super) scoring_cfg: &'a crate::scoring::ScoringConfig,
     pub(super) snippet_policy: TextSnippetPolicy,
     pub(super) fts_gather: &'a crate::config::RecallFtsGatherConfig,
     /// Bounded ANN widening rounds, resolved before collection.
@@ -447,9 +442,6 @@ pub(super) struct RecallCandidateParams<'a> {
 pub(super) struct RecallVectorCandidateParams<'a> {
     pub(super) candidate_limit: u32,
     pub(super) embedding_model: Option<&'a str>,
-    /// Route the dense/vector path to the multilingual model. Keyed on `needs_multilingual`.
-    pub(super) use_multilingual: bool,
-    pub(super) scoring_cfg: &'a crate::scoring::ScoringConfig,
     /// Namespace set the caller is allowed to read. ANN returns global candidates;
     /// post-filter trims to this set before returning hits.
     pub(super) visible_namespaces: Vec<String>,
@@ -461,7 +453,6 @@ pub(super) struct RecallVectorCandidateParams<'a> {
 
 pub(super) struct RecallVectorCandidateResult {
     pub(super) vector_hits_per_model: Vec<(String, Vec<VectorSearchHit>)>,
-    pub(super) multilingual_routed: bool,
     /// Whether any model timed out to FTS-only while its tracked build continued.
     pub(super) ann_degraded: bool,
 }
@@ -736,8 +727,6 @@ impl MemoryPack {
             candidate_limit,
             embedding_model,
             cjk_fts_bypass,
-            use_multilingual,
-            scoring_cfg,
             snippet_policy,
             fts_gather,
             ann_overfetch_max_rounds,
@@ -769,8 +758,6 @@ impl MemoryPack {
             RecallVectorCandidateParams {
                 candidate_limit,
                 embedding_model,
-                use_multilingual,
-                scoring_cfg,
                 visible_namespaces: visible.clone(),
                 ann_overfetch_max_rounds,
                 ann_ready_timeout_ms,
@@ -781,7 +768,6 @@ impl MemoryPack {
             namespace: primary_ns,
             text_hits,
             vector_hits_per_model: vector_result.vector_hits_per_model,
-            multilingual_routed: vector_result.multilingual_routed,
             visible_namespaces: visible,
             ann_degraded: vector_result.ann_degraded,
         })
@@ -801,8 +787,6 @@ impl MemoryPack {
         let RecallVectorCandidateParams {
             candidate_limit,
             embedding_model,
-            use_multilingual,
-            scoring_cfg,
             visible_namespaces,
             ann_overfetch_max_rounds,
             ann_ready_timeout_ms,
@@ -818,35 +802,11 @@ impl MemoryPack {
         let prof = recall_profile_enabled();
         let call_id = PROF_CID.with(|c| c.get());
 
-        let mut multilingual_routed = false;
         let mut ann_degraded = false;
         let model_names: Vec<String> = if let Some(m) = embedding_model {
             vec![m.to_string()]
         } else {
-            let names = self.runtime.registered_embedding_model_names();
-            if names.is_empty() {
-                vec![]
-            } else if use_multilingual {
-                let multilingual_model = scoring_cfg
-                    .multilingual_model
-                    .as_deref()
-                    .and_then(|m| names.iter().find(|n| n.as_str() == m).cloned())
-                    .or_else(|| {
-                        names
-                            .iter()
-                            .find(|n| n.contains("multilingual") || n.contains("paraphrase"))
-                            .cloned()
-                    });
-                match multilingual_model {
-                    Some(model) => {
-                        multilingual_routed = true;
-                        vec![model]
-                    }
-                    None => names,
-                }
-            } else {
-                names
-            }
+            self.runtime.registered_embedding_model_names()
         };
 
         let vector_hits_per_model: Vec<(String, Vec<VectorSearchHit>)> = if model_names.is_empty() {
@@ -1145,7 +1105,6 @@ impl MemoryPack {
 
         Ok(RecallVectorCandidateResult {
             vector_hits_per_model,
-            multilingual_routed,
             ann_degraded,
         })
     }

--- a/crates/khive-pack-memory/src/handlers/common.rs
+++ b/crates/khive-pack-memory/src/handlers/common.rs
@@ -28,6 +28,48 @@ use crate::config::{RecallConfig, ScoreBreakdown, WeightedContributions};
 use crate::query_cache::QueryEmbeddingCache;
 use crate::MemoryPack;
 
+/// Test-only per-model retrieval failpoints for exercising `collect_model_ann_hits`'
+/// engine-failure isolation (ADR-031) without a real ANN or sqlite-vec outage.
+#[cfg(test)]
+pub(super) mod retrieval_failpoints {
+    use std::collections::HashSet;
+    use std::sync::{Mutex, OnceLock};
+
+    fn ann() -> &'static Mutex<HashSet<String>> {
+        static S: OnceLock<Mutex<HashSet<String>>> = OnceLock::new();
+        S.get_or_init(Default::default)
+    }
+
+    fn vec() -> &'static Mutex<HashSet<String>> {
+        static S: OnceLock<Mutex<HashSet<String>>> = OnceLock::new();
+        S.get_or_init(Default::default)
+    }
+
+    pub fn fail_ann(model: &str) {
+        ann().lock().unwrap().insert(model.to_owned());
+    }
+
+    pub fn clear_ann(model: &str) {
+        ann().lock().unwrap().remove(model);
+    }
+
+    pub fn fail_vec(model: &str) {
+        vec().lock().unwrap().insert(model.to_owned());
+    }
+
+    pub fn clear_vec(model: &str) {
+        vec().lock().unwrap().remove(model);
+    }
+
+    pub(super) fn ann_flagged(model: &str) -> bool {
+        ann().lock().unwrap().contains(model)
+    }
+
+    pub(super) fn vec_flagged(model: &str) -> bool {
+        vec().lock().unwrap().contains(model)
+    }
+}
+
 // KHIVE_RECALL_PROFILE emits per-call stage JSON to stderr.
 pub(super) static RECALL_CALL_ID: AtomicU64 = AtomicU64::new(0);
 
@@ -918,218 +960,114 @@ impl MemoryPack {
 
             let t_ann_total = if prof { Some(Instant::now()) } else { None };
             let mut ann_route = "ann";
-            let mut results = Vec::with_capacity(query_vecs.len());
-            for (model_name, vec) in query_vecs {
-                let key = AnnKey::new(ns, &model_name);
 
-                // Global ANN search widens only when namespace post-filtering leaves too few hits.
-                // A stale installed graph remains the immediate fallback and triggers background
-                // replacement; only a genuine miss waits for ensure. Durable epoch checking adds
-                // cross-process reindex visibility beyond in-process generations.
-                ann::maybe_check_durable_epoch(&self.runtime, &self.ann, &key).await;
-                let cache_fresh = ann::is_current(&self.ann, &key).await;
-                let search_result =
-                    ann::search_loaded(&self.ann, &key, &vec, ann_fetch_limit).await;
-                if !cache_fresh && matches!(search_result, Ok(Some(_))) {
-                    ann::ensure_ann_background(&self.runtime, token, &self.ann, &model_name).await;
+            // Per-model ANN/sqlite-vec resolution is independent I/O (durable-epoch
+            // check, warm-cache search, possible detached ensure-wait, possible
+            // exact-scan fallback) — fan the models out concurrently instead of
+            // paying their latency serially. Mirrors the embed step's 1/2/N
+            // dispatch immediately above.
+            let per_model_results: Vec<PerModelAnnHits> = match query_vecs.len() {
+                0 => Vec::new(),
+                1 => {
+                    let (model_name, vec) = query_vecs.into_iter().next().unwrap();
+                    let r = collect_model_ann_hits(
+                        &self.runtime,
+                        &self.ann,
+                        token,
+                        ns,
+                        &visible_namespaces,
+                        model_name,
+                        vec,
+                        candidate_limit,
+                        ann_fetch_limit,
+                        ann_overfetch_max_rounds,
+                        ann_ready_timeout_ms,
+                    )
+                    .await?;
+                    vec![r]
                 }
-                // Bound genuine-miss readiness, but never drop the build itself: a tracked task
-                // owns ensure and its phase span while this request races only the result channel.
-                // Per-model single flight prevents duplicate detached builds.
-                let mut model_ann_timed_out = false;
-                let initial_raw_hits: Option<Vec<(Uuid, f32)>> = match search_result {
-                    Ok(Some(hits)) => Some(hits),
-                    Ok(None) => {
-                        let (done_tx, done_rx) = tokio::sync::oneshot::channel();
-                        let rt_detached = self.runtime.clone();
-                        let token_detached = token.clone();
-                        let ann_detached = self.ann.clone();
-                        let model_detached = model_name.clone();
-                        khive_runtime::track_background_task(async move {
-                            let result = ann::ensure_ann_for_model(
-                                &rt_detached,
-                                &token_detached,
-                                &ann_detached,
-                                &model_detached,
-                            )
-                            .await;
-                            let _ = done_tx.send(result);
-                        });
-                        match tokio::time::timeout(
-                            std::time::Duration::from_millis(ann_ready_timeout_ms),
-                            done_rx,
-                        )
-                        .await
-                        {
-                            Ok(Ok(Ok(status))) => {
-                                tracing::debug!(
-                                    ?status,
-                                    model = %model_name,
-                                    namespace = %ns,
-                                    "memory ANN ensured on recall miss"
-                                );
-                                ann::search_loaded(&self.ann, &key, &vec, ann_fetch_limit).await?
-                            }
-                            Ok(Ok(Err(e))) => return Err(e),
-                            Ok(Err(_sender_dropped)) => {
-                                // A detached-task panic degrades this model instead of failing recall.
-                                tracing::warn!(
-                                    model = %model_name,
-                                    namespace = %ns,
-                                    "memory ANN detached build task ended \
-                                     without a result; degrading recall to \
-                                     FTS-only for this model (#836)"
-                                );
-                                model_ann_timed_out = true;
-                                ann_degraded = true;
-                                None
-                            }
-                            Err(_elapsed) => {
-                                tracing::warn!(
-                                    model = %model_name,
-                                    namespace = %ns,
-                                    timeout_ms = ann_ready_timeout_ms,
-                                    "memory ANN not ready within bounded wait; \
-                                     degrading recall to FTS-only for this \
-                                     model and detaching the build to finish \
-                                     in the background (#836)"
-                                );
-                                model_ann_timed_out = true;
-                                ann_degraded = true;
-                                None
-                            }
-                        }
-                    }
-                    Err(e) => {
-                        tracing::warn!(
-                            error = %e,
-                            namespace = %ns,
-                            model = %model_name,
-                            "memory ANN search failed; falling back to exact sqlite-vec"
-                        );
-                        ann::clear_key(&self.ann, &key).await;
-                        None
-                    }
-                };
-
-                if model_ann_timed_out {
-                    // Do not replace a bounded timeout with an O(corpus) exact scan.
-                    results.push((model_name, Vec::new()));
-                    continue;
-                }
-
-                if let Some(first_raw) = initial_raw_hits {
-                    // Widen until enough visible hits survive or ANN reports corpus exhaustion.
-                    let note_store = self.runtime.notes(token)?;
-                    let visible_set: std::collections::HashSet<&str> =
-                        visible_namespaces.iter().map(String::as_str).collect();
-
-                    // Empty namespace metadata is conservative; a visible-only set skips retry.
-                    let index_has_non_visible =
-                        match ann::index_namespace_set(&self.ann, &key).await {
-                            Some(index_ns) if !index_ns.is_empty() => {
-                                !index_ns.iter().all(|ns| visible_set.contains(ns.as_str()))
-                            }
-                            // Empty set (snapshot-restored without population yet) or cache miss:
-                            // be conservative — assume non-visible namespaces may be present.
-                            _ => true,
-                        };
-
-                    let mut best_raw = first_raw;
-                    let mut current_fetch_limit = ann_fetch_limit;
-
-                    // Visible-only indexes incur no hydration or extra ANN searches here.
-                    if index_has_non_visible {
-                        for _round in 1..ann_overfetch_max_rounds {
-                            let corpus_exhausted = best_raw.len() < current_fetch_limit;
-                            if corpus_exhausted {
-                                break;
-                            }
-                            // Count visible-namespace survivors via a lightweight note batch fetch.
-                            let candidate_ids: Vec<Uuid> =
-                                best_raw.iter().map(|(id, _)| *id).collect();
-                            let notes = note_store.get_notes_batch(&candidate_ids).await?;
-                            let visible_count = notes
-                                .iter()
-                                .filter(|n| {
-                                    n.deleted_at.is_none()
-                                        && n.kind == "memory"
-                                        && visible_set.contains(n.namespace.as_str())
-                                })
-                                .count();
-                            if visible_count >= candidate_limit as usize {
-                                break;
-                            }
-                            // Widen and retry.
-                            current_fetch_limit *= 2;
-                            tracing::debug!(
-                                model = %model_name,
-                                namespace = %ns,
-                                visible_count,
-                                candidate_limit,
-                                new_fetch_limit = current_fetch_limit,
-                                "memory ANN: widening over-fetch (visible survivors short)"
-                            );
-                            if let Ok(Some(wider)) =
-                                ann::search_loaded(&self.ann, &key, &vec, current_fetch_limit).await
-                            {
-                                best_raw = wider;
-                            } else {
-                                break;
-                            }
-                        }
-                    }
-
-                    tracing::debug!(
-                        model = %model_name,
-                        namespace = %ns,
-                        hits = best_raw.len(),
-                        "memory recall via warm ANN"
+                2 => {
+                    let mut it = query_vecs.into_iter();
+                    let (m0, v0) = it.next().unwrap();
+                    let (m1, v1) = it.next().unwrap();
+                    let f0 = collect_model_ann_hits(
+                        &self.runtime,
+                        &self.ann,
+                        token,
+                        ns,
+                        &visible_namespaces,
+                        m0,
+                        v0,
+                        candidate_limit,
+                        ann_fetch_limit,
+                        ann_overfetch_max_rounds,
+                        ann_ready_timeout_ms,
                     );
-                    let hits: Vec<VectorSearchHit> = best_raw
-                        .into_iter()
-                        .enumerate()
-                        .map(|(idx, (uuid, score))| VectorSearchHit {
-                            subject_id: uuid,
-                            score: khive_score::DeterministicScore::from_f64(score as f64),
-                            rank: (idx + 1) as u32,
-                        })
-                        .collect();
-                    results.push((model_name, hits));
-                    continue;
+                    let f1 = collect_model_ann_hits(
+                        &self.runtime,
+                        &self.ann,
+                        token,
+                        ns,
+                        &visible_namespaces,
+                        m1,
+                        v1,
+                        candidate_limit,
+                        ann_fetch_limit,
+                        ann_overfetch_max_rounds,
+                        ann_ready_timeout_ms,
+                    );
+                    let (r0, r1) = tokio::join!(f0, f1);
+                    vec![r0?, r1?]
                 }
+                _ => {
+                    let mut handles = Vec::with_capacity(query_vecs.len());
+                    for (model_name, vec) in query_vecs {
+                        let rt = self.runtime.clone();
+                        let ann_shared = self.ann.clone();
+                        let token_owned = token.clone();
+                        let ns_owned = ns.to_string();
+                        let visible_owned = visible_namespaces.clone();
+                        handles.push(tokio::spawn(async move {
+                            collect_model_ann_hits(
+                                &rt,
+                                &ann_shared,
+                                &token_owned,
+                                &ns_owned,
+                                &visible_owned,
+                                model_name,
+                                vec,
+                                candidate_limit,
+                                ann_fetch_limit,
+                                ann_overfetch_max_rounds,
+                                ann_ready_timeout_ms,
+                            )
+                            .await
+                        }));
+                    }
+                    let mut out = Vec::with_capacity(handles.len());
+                    for h in handles {
+                        let r = h.await.map_err(|e| {
+                            RuntimeError::Internal(format!("recall ann task panicked: {e}"))
+                        })??;
+                        out.push(r);
+                    }
+                    out
+                }
+            };
 
-                // sqlite-vec fallback: the query includes namespace IN (...) so it
-                // respects the caller's visible set directly without over-fetch.
-                // When visible_namespaces has multiple entries we fan out one search
-                // per namespace and union the results, since VectorSearchRequest
-                // accepts a single namespace string.
-                tracing::debug!(model = %model_name, namespace = %ns, "memory recall via exact sqlite-vec");
-                ann_route = "sqlite_vec";
-                let store = self.runtime.vectors_for_model(token, &model_name)?;
-                let mut all_hits: Vec<VectorSearchHit> = Vec::new();
-                for search_ns in &visible_namespaces {
-                    let ns_hits = store
-                        .search(VectorSearchRequest {
-                            query_vectors: vec![vec.clone()],
-                            top_k: candidate_limit,
-                            namespace: Some(search_ns.clone()),
-                            kind: Some(SubstrateKind::Note),
-                            embedding_model: Some(model_name.clone()),
-                            filter: None,
-                            backend_hints: None,
-                        })
-                        .await?;
-                    all_hits.extend(ns_hits);
+            for r in &per_model_results {
+                if r.degraded {
+                    ann_degraded = true;
                 }
-                // Merge + re-rank by score descending.
-                all_hits.sort_by_key(|hit| std::cmp::Reverse(hit.score));
-                all_hits.truncate(candidate_limit as usize);
-                for (idx, hit) in all_hits.iter_mut().enumerate() {
-                    hit.rank = (idx + 1) as u32;
+                if r.used_sqlite_vec_fallback {
+                    ann_route = "sqlite_vec";
                 }
-                results.push((model_name, all_hits));
             }
+            let results: Vec<(String, Vec<VectorSearchHit>)> = per_model_results
+                .into_iter()
+                .map(|r| (r.model_name, r.hits))
+                .collect();
+
             if prof {
                 if let Some(t) = t_ann_total {
                     let total_hits: usize = results.iter().map(|(_, h)| h.len()).sum();
@@ -1200,4 +1138,325 @@ impl MemoryPack {
 
         Ok((memory_ids, notes_by_id))
     }
+}
+
+/// One embedding model's outcome from [`collect_model_ann_hits`].
+pub(super) struct PerModelAnnHits {
+    model_name: String,
+    hits: Vec<VectorSearchHit>,
+    /// This model's warm ANN wait was bounded out (#836); recall degraded to FTS-only for it.
+    degraded: bool,
+    /// This model fell through to the exact sqlite-vec scan instead of warm ANN.
+    used_sqlite_vec_fallback: bool,
+}
+
+/// Resolve one embedding model's vector candidates via warm ANN or the exact sqlite-vec
+/// fallback, degrading this model to FTS-only on any retrieval error instead of aborting
+/// recall across every engine (ADR-031 engine-failure isolation). Takes owned/cloned
+/// inputs (rather than `&self`) so the multi-model case can dispatch it via `tokio::spawn`.
+#[allow(clippy::too_many_arguments)]
+pub(super) async fn collect_model_ann_hits(
+    runtime: &khive_runtime::KhiveRuntime,
+    ann: &ann::SharedAnn,
+    token: &NamespaceToken,
+    ns: &str,
+    visible_namespaces: &[String],
+    model_name: String,
+    vec: Vec<f32>,
+    candidate_limit: u32,
+    ann_fetch_limit: usize,
+    ann_overfetch_max_rounds: usize,
+    ann_ready_timeout_ms: u64,
+) -> Result<PerModelAnnHits, RuntimeError> {
+    let degrade_name = model_name.clone();
+    match collect_model_ann_hits_inner(
+        runtime,
+        ann,
+        token,
+        ns,
+        visible_namespaces,
+        model_name,
+        vec,
+        candidate_limit,
+        ann_fetch_limit,
+        ann_overfetch_max_rounds,
+        ann_ready_timeout_ms,
+    )
+    .await
+    {
+        Ok(hits) => Ok(hits),
+        Err(e) => {
+            tracing::warn!(
+                model = %degrade_name,
+                namespace = %ns,
+                error = %e,
+                "per-model recall retrieval failed; degrading this engine to \
+                 FTS-only (empty vector hits) so healthy engines still serve (ADR-031)"
+            );
+            Ok(PerModelAnnHits {
+                model_name: degrade_name,
+                hits: Vec::new(),
+                degraded: true,
+                used_sqlite_vec_fallback: false,
+            })
+        }
+    }
+}
+
+/// Split out of `collect_recall_vector_hits` so per-model units — each with independent
+/// durable-epoch checks, warm-cache search, possible detached ensure-wait, and possible
+/// exact-scan fallback — can run concurrently instead of serially. All error paths
+/// propagate via `?`; the [`collect_model_ann_hits`] wrapper converts them into a
+/// degraded outcome for this model rather than aborting every engine's recall.
+#[allow(clippy::too_many_arguments)]
+async fn collect_model_ann_hits_inner(
+    runtime: &khive_runtime::KhiveRuntime,
+    ann: &ann::SharedAnn,
+    token: &NamespaceToken,
+    ns: &str,
+    visible_namespaces: &[String],
+    model_name: String,
+    vec: Vec<f32>,
+    candidate_limit: u32,
+    ann_fetch_limit: usize,
+    ann_overfetch_max_rounds: usize,
+    ann_ready_timeout_ms: u64,
+) -> Result<PerModelAnnHits, RuntimeError> {
+    let key = AnnKey::new(ns, &model_name);
+
+    // Global ANN search widens only when namespace post-filtering leaves too few hits.
+    // A stale installed graph remains the immediate fallback and triggers background
+    // replacement; only a genuine miss waits for ensure. Durable epoch checking adds
+    // cross-process reindex visibility beyond in-process generations.
+    ann::maybe_check_durable_epoch(runtime, ann, &key).await;
+    let cache_fresh = ann::is_current(ann, &key).await;
+    let search_result = ann::search_loaded(ann, &key, &vec, ann_fetch_limit).await;
+    if !cache_fresh && matches!(search_result, Ok(Some(_))) {
+        ann::ensure_ann_background(runtime, token, ann, &model_name).await;
+    }
+    // Bound genuine-miss readiness, but never drop the build itself: a tracked task
+    // owns ensure and its phase span while this request races only the result channel.
+    // Per-model single flight prevents duplicate detached builds.
+    let mut model_ann_timed_out = false;
+    let initial_raw_hits: Option<Vec<(Uuid, f32)>> = match search_result {
+        Ok(Some(hits)) => Some(hits),
+        Ok(None) => {
+            let (done_tx, done_rx) = tokio::sync::oneshot::channel();
+            let rt_detached = runtime.clone();
+            let token_detached = token.clone();
+            let ann_detached = ann.clone();
+            let model_detached = model_name.clone();
+            khive_runtime::track_background_task(async move {
+                let result = ann::ensure_ann_for_model(
+                    &rt_detached,
+                    &token_detached,
+                    &ann_detached,
+                    &model_detached,
+                )
+                .await;
+                let _ = done_tx.send(result);
+            });
+            match tokio::time::timeout(
+                std::time::Duration::from_millis(ann_ready_timeout_ms),
+                done_rx,
+            )
+            .await
+            {
+                Ok(Ok(Ok(status))) => {
+                    tracing::debug!(
+                        ?status,
+                        model = %model_name,
+                        namespace = %ns,
+                        "memory ANN ensured on recall miss"
+                    );
+                    ann::search_loaded(ann, &key, &vec, ann_fetch_limit).await?
+                }
+                Ok(Ok(Err(e))) => return Err(e),
+                Ok(Err(_sender_dropped)) => {
+                    // A detached-task panic degrades this model instead of failing recall.
+                    tracing::warn!(
+                        model = %model_name,
+                        namespace = %ns,
+                        "memory ANN detached build task ended \
+                         without a result; degrading recall to \
+                         FTS-only for this model (#836)"
+                    );
+                    model_ann_timed_out = true;
+                    None
+                }
+                Err(_elapsed) => {
+                    tracing::warn!(
+                        model = %model_name,
+                        namespace = %ns,
+                        timeout_ms = ann_ready_timeout_ms,
+                        "memory ANN not ready within bounded wait; \
+                         degrading recall to FTS-only for this \
+                         model and detaching the build to finish \
+                         in the background (#836)"
+                    );
+                    model_ann_timed_out = true;
+                    None
+                }
+            }
+        }
+        Err(e) => {
+            tracing::warn!(
+                error = %e,
+                namespace = %ns,
+                model = %model_name,
+                "memory ANN search failed; falling back to exact sqlite-vec"
+            );
+            ann::clear_key(ann, &key).await;
+            None
+        }
+    };
+
+    if model_ann_timed_out {
+        // Do not replace a bounded timeout with an O(corpus) exact scan.
+        return Ok(PerModelAnnHits {
+            model_name,
+            hits: Vec::new(),
+            degraded: true,
+            used_sqlite_vec_fallback: false,
+        });
+    }
+
+    #[cfg(test)]
+    let initial_raw_hits = if retrieval_failpoints::vec_flagged(&model_name) {
+        None
+    } else {
+        initial_raw_hits
+    };
+
+    if let Some(first_raw) = initial_raw_hits {
+        #[cfg(test)]
+        if retrieval_failpoints::ann_flagged(&model_name) {
+            return Err(RuntimeError::Internal(format!(
+                "test-injected ANN retrieval failure for {model_name}"
+            )));
+        }
+
+        // Widen until enough visible hits survive or ANN reports corpus exhaustion.
+        let note_store = runtime.notes(token)?;
+        let visible_set: HashSet<&str> = visible_namespaces.iter().map(String::as_str).collect();
+
+        // Empty namespace metadata is conservative; a visible-only set skips retry.
+        let index_has_non_visible = match ann::index_namespace_set(ann, &key).await {
+            Some(index_ns) if !index_ns.is_empty() => {
+                !index_ns.iter().all(|ns| visible_set.contains(ns.as_str()))
+            }
+            // Empty set (snapshot-restored without population yet) or cache miss:
+            // be conservative — assume non-visible namespaces may be present.
+            _ => true,
+        };
+
+        let mut best_raw = first_raw;
+        let mut current_fetch_limit = ann_fetch_limit;
+
+        // Visible-only indexes incur no hydration or extra ANN searches here.
+        if index_has_non_visible {
+            for _round in 1..ann_overfetch_max_rounds {
+                let corpus_exhausted = best_raw.len() < current_fetch_limit;
+                if corpus_exhausted {
+                    break;
+                }
+                // Count visible-namespace survivors via a lightweight note batch fetch.
+                let candidate_ids: Vec<Uuid> = best_raw.iter().map(|(id, _)| *id).collect();
+                let notes = note_store.get_notes_batch(&candidate_ids).await?;
+                let visible_count = notes
+                    .iter()
+                    .filter(|n| {
+                        n.deleted_at.is_none()
+                            && n.kind == "memory"
+                            && visible_set.contains(n.namespace.as_str())
+                    })
+                    .count();
+                if visible_count >= candidate_limit as usize {
+                    break;
+                }
+                // Widen and retry.
+                current_fetch_limit *= 2;
+                tracing::debug!(
+                    model = %model_name,
+                    namespace = %ns,
+                    visible_count,
+                    candidate_limit,
+                    new_fetch_limit = current_fetch_limit,
+                    "memory ANN: widening over-fetch (visible survivors short)"
+                );
+                if let Ok(Some(wider)) =
+                    ann::search_loaded(ann, &key, &vec, current_fetch_limit).await
+                {
+                    best_raw = wider;
+                } else {
+                    break;
+                }
+            }
+        }
+
+        tracing::debug!(
+            model = %model_name,
+            namespace = %ns,
+            hits = best_raw.len(),
+            "memory recall via warm ANN"
+        );
+        let hits: Vec<VectorSearchHit> = best_raw
+            .into_iter()
+            .enumerate()
+            .map(|(idx, (uuid, score))| VectorSearchHit {
+                subject_id: uuid,
+                score: khive_score::DeterministicScore::from_f64(score as f64),
+                rank: (idx + 1) as u32,
+            })
+            .collect();
+        return Ok(PerModelAnnHits {
+            model_name,
+            hits,
+            degraded: false,
+            used_sqlite_vec_fallback: false,
+        });
+    }
+
+    // sqlite-vec fallback: the query includes namespace IN (...) so it
+    // respects the caller's visible set directly without over-fetch.
+    // When visible_namespaces has multiple entries we fan out one search
+    // per namespace and union the results, since VectorSearchRequest
+    // accepts a single namespace string.
+    tracing::debug!(model = %model_name, namespace = %ns, "memory recall via exact sqlite-vec");
+
+    #[cfg(test)]
+    if retrieval_failpoints::vec_flagged(&model_name) {
+        return Err(RuntimeError::Internal(format!(
+            "test-injected sqlite-vec retrieval failure for {model_name}"
+        )));
+    }
+
+    let store = runtime.vectors_for_model(token, &model_name)?;
+    let mut all_hits: Vec<VectorSearchHit> = Vec::new();
+    for search_ns in visible_namespaces {
+        let ns_hits = store
+            .search(VectorSearchRequest {
+                query_vectors: vec![vec.clone()],
+                top_k: candidate_limit,
+                namespace: Some(search_ns.clone()),
+                kind: Some(SubstrateKind::Note),
+                embedding_model: Some(model_name.clone()),
+                filter: None,
+                backend_hints: None,
+            })
+            .await?;
+        all_hits.extend(ns_hits);
+    }
+    // Merge + re-rank by score descending.
+    all_hits.sort_by_key(|hit| std::cmp::Reverse(hit.score));
+    all_hits.truncate(candidate_limit as usize);
+    for (idx, hit) in all_hits.iter_mut().enumerate() {
+        hit.rank = (idx + 1) as u32;
+    }
+    Ok(PerModelAnnHits {
+        model_name,
+        hits: all_hits,
+        degraded: false,
+        used_sqlite_vec_fallback: true,
+    })
 }

--- a/crates/khive-pack-memory/src/handlers/common.rs
+++ b/crates/khive-pack-memory/src/handlers/common.rs
@@ -549,7 +549,7 @@ pub(super) fn fuse_candidates(
     let is_weighted = matches!(&cfg.fuse_strategy, FusionStrategy::Weighted { .. });
 
     let sources: Vec<Vec<_>> = if vector_only {
-        vector_sources
+        vec![combine_vector_sources_union(vector_sources)]
     } else if keyword_only {
         vec![text_source]
     } else if is_weighted && vector_sources.len() > 1 {

--- a/crates/khive-pack-memory/src/handlers/common.rs
+++ b/crates/khive-pack-memory/src/handlers/common.rs
@@ -115,6 +115,38 @@ pub(super) async fn embed_query_model(
     Ok((model_name, v))
 }
 
+type NamedEmbedResult = (String, Result<(String, Vec<f32>), RuntimeError>);
+
+/// Partition per-engine embed results into successes, warning on each failure so one
+/// unhealthy embedding engine degrades recall instead of aborting it. Errors only if
+/// every engine failed.
+pub(super) fn collect_embed_results(
+    named_results: Vec<NamedEmbedResult>,
+) -> Result<Vec<(String, Vec<f32>)>, RuntimeError> {
+    let mut oks = Vec::with_capacity(named_results.len());
+    let mut failures = Vec::new();
+    for (model_name, result) in named_results {
+        match result {
+            Ok(pair) => oks.push(pair),
+            Err(e) => {
+                tracing::warn!(
+                    model = %model_name,
+                    error = %e,
+                    "recall: embedding failed for engine, degrading to remaining engines"
+                );
+                failures.push(format!("{model_name}: {e}"));
+            }
+        }
+    }
+    if oks.is_empty() {
+        return Err(RuntimeError::Internal(format!(
+            "recall: all embedding engines failed: {}",
+            failures.join("; ")
+        )));
+    }
+    Ok(oks)
+}
+
 pub(super) fn to_json<T: serde::Serialize>(v: &T) -> Result<Value, RuntimeError> {
     serde_json::to_value(v).map_err(|e| RuntimeError::InvalidInput(e.to_string()))
 }
@@ -816,15 +848,21 @@ impl MemoryPack {
             let query_vecs: Vec<(String, Vec<f32>)> = match model_names.len() {
                 1 => {
                     let m = model_names.into_iter().next().unwrap();
-                    vec![
-                        embed_query_model(
-                            self.runtime.clone(),
-                            self.query_cache.clone(),
-                            m,
-                            query.to_string(),
-                        )
-                        .await?,
-                    ]
+                    let result = embed_query_model(
+                        self.runtime.clone(),
+                        self.query_cache.clone(),
+                        m.clone(),
+                        query.to_string(),
+                    )
+                    .await;
+                    match result {
+                        Ok(pair) => vec![pair],
+                        Err(e) => {
+                            return Err(RuntimeError::Internal(format!(
+                                "recall: all embedding engines failed: {m}: {e}"
+                            )));
+                        }
+                    }
                 }
                 2 => {
                     let mut it = model_names.into_iter();
@@ -833,17 +871,17 @@ impl MemoryPack {
                     let f0 = embed_query_model(
                         self.runtime.clone(),
                         self.query_cache.clone(),
-                        m0,
+                        m0.clone(),
                         query.to_string(),
                     );
                     let f1 = embed_query_model(
                         self.runtime.clone(),
                         self.query_cache.clone(),
-                        m1,
+                        m1.clone(),
                         query.to_string(),
                     );
                     let (r0, r1) = tokio::join!(f0, f1);
-                    vec![r0?, r1?]
+                    collect_embed_results(vec![(m0, r0), (m1, r1)])?
                 }
                 _ => {
                     let mut handles = Vec::with_capacity(model_names.len());
@@ -851,18 +889,22 @@ impl MemoryPack {
                         let rt = self.runtime.clone();
                         let cache = self.query_cache.clone();
                         let q = query.to_string();
+                        let name_for_result = model_name.clone();
                         handles.push(tokio::spawn(async move {
-                            embed_query_model(rt, cache, model_name, q).await
+                            (
+                                name_for_result,
+                                embed_query_model(rt, cache, model_name, q).await,
+                            )
                         }));
                     }
-                    let mut vecs = Vec::with_capacity(handles.len());
+                    let mut named_results = Vec::with_capacity(handles.len());
                     for h in handles {
                         let pair = h.await.map_err(|e| {
                             RuntimeError::Internal(format!("recall embed task panicked: {e}"))
-                        })??;
-                        vecs.push(pair);
+                        })?;
+                        named_results.push(pair);
                     }
-                    vecs
+                    collect_embed_results(named_results)?
                 }
             };
 

--- a/crates/khive-pack-memory/src/handlers/recall.rs
+++ b/crates/khive-pack-memory/src/handlers/recall.rs
@@ -5187,4 +5187,134 @@ mod tests {
              return empty results: {result:?}"
         );
     }
+
+    // ── #1116: one engine's ANN/sqlite-vec retrieval failing must degrade that
+    // engine to FTS-only, not abort recall across every engine ──────────────
+
+    use super::super::common::retrieval_failpoints;
+
+    /// One engine's ANN retrieval failing must degrade recall to the healthy engine.
+    #[tokio::test]
+    #[serial(background_tasks)]
+    async fn recall_1116_one_engine_ann_retrieval_failure_still_serves_healthy() {
+        const HEALTHY_MODEL: &str = "recall-1116-ann-healthy-model";
+        const FAILING_MODEL: &str = "recall-1116-ann-failing-model";
+        const NOTE_TEXT: &str = "issue 1116 ann retrieval failure recall note";
+
+        let rt = KhiveRuntime::memory().expect("in-memory runtime");
+        rt.register_embedder(HashVecProvider {
+            model_name: HEALTHY_MODEL.to_owned(),
+            dims: 16,
+        });
+        rt.register_embedder(HashVecProvider {
+            model_name: FAILING_MODEL.to_owned(),
+            dims: 16,
+        });
+
+        let mut builder = VerbRegistryBuilder::new();
+        builder.register(KgPack::new(rt.clone()));
+        builder.register(MemoryPack::new(rt.clone()));
+        let registry = builder.build().expect("registry");
+
+        registry
+            .dispatch(
+                "memory.remember",
+                serde_json::json!({
+                    "content": NOTE_TEXT,
+                    "memory_type": "semantic",
+                }),
+            )
+            .await
+            .expect("remember note under both models");
+
+        retrieval_failpoints::fail_ann(FAILING_MODEL);
+        let result = registry
+            .dispatch(
+                "memory.recall",
+                serde_json::json!({
+                    "query": NOTE_TEXT,
+                    "fusion_strategy": "vector_only",
+                    "limit": 10,
+                }),
+            )
+            .await;
+        retrieval_failpoints::clear_ann(FAILING_MODEL);
+
+        let result = result.unwrap_or_else(|e| {
+            panic!(
+                "recall must still serve the healthy engine when one engine's \
+                 ANN retrieval fails, got error: {e:?}"
+            )
+        });
+        let hits = result.as_array().expect("recall result must be an array");
+        assert!(
+            !hits.is_empty(),
+            "recall must surface the healthy engine's hits despite the other \
+             engine's ANN retrieval failing; got {result:?}"
+        );
+    }
+
+    /// One engine's sqlite-vec retrieval failing must degrade recall to the healthy engine.
+    #[tokio::test]
+    #[serial(background_tasks)]
+    async fn recall_1116_one_engine_sqlite_vec_retrieval_failure_still_serves_healthy() {
+        const HEALTHY_MODEL: &str = "recall-1116-vec-healthy-model";
+        const FAILING_MODEL: &str = "recall-1116-vec-failing-model";
+        const NOTE_TEXT: &str = "issue 1116 sqlite-vec retrieval failure recall note";
+
+        let rt = KhiveRuntime::memory().expect("in-memory runtime");
+        // Register the failing-retrieval model before the remember so a real
+        // index exists to search — the failpoint forces the sqlite-vec
+        // fallback route and fails it, not an empty/never-built index.
+        rt.register_embedder(HashVecProvider {
+            model_name: FAILING_MODEL.to_owned(),
+            dims: 16,
+        });
+        rt.register_embedder(HashVecProvider {
+            model_name: HEALTHY_MODEL.to_owned(),
+            dims: 16,
+        });
+
+        let mut builder = VerbRegistryBuilder::new();
+        builder.register(KgPack::new(rt.clone()));
+        builder.register(MemoryPack::new(rt.clone()));
+        let registry = builder.build().expect("registry");
+
+        registry
+            .dispatch(
+                "memory.remember",
+                serde_json::json!({
+                    "content": NOTE_TEXT,
+                    "memory_type": "semantic",
+                }),
+            )
+            .await
+            .expect("remember note under both models");
+
+        retrieval_failpoints::fail_vec(FAILING_MODEL);
+        let result = registry
+            .dispatch(
+                "memory.recall",
+                serde_json::json!({
+                    "query": NOTE_TEXT,
+                    "fusion_strategy": "vector_only",
+                    "limit": 10,
+                }),
+            )
+            .await;
+        retrieval_failpoints::clear_vec(FAILING_MODEL);
+
+        let result = result.unwrap_or_else(|e| {
+            panic!(
+                "recall must still serve the healthy engine when one engine's \
+                 sqlite-vec retrieval fails, got error: {e:?}"
+            )
+        });
+        let hits = result.as_array().expect("recall result must be an array");
+        assert!(
+            !hits.is_empty(),
+            "recall must surface the healthy engine's hits despite the other \
+             engine's sqlite-vec retrieval failing; got {result:?}"
+        );
+    }
 }

--- a/crates/khive-pack-memory/src/handlers/recall.rs
+++ b/crates/khive-pack-memory/src/handlers/recall.rs
@@ -21,8 +21,8 @@ use khive_storage::EdgeRelation;
 use crate::config::{RecallConfig, ScoreBreakdown};
 use crate::rerank::{weighted_rerank, RerankFeatures};
 use crate::scoring::{
-    calculate_score, contains_cjk, extract_entity_candidates, needs_multilingual,
-    normalize_min_score, normalize_rank_fusion_scores, normalize_rrf_scores, ScoreInput,
+    calculate_score, contains_cjk, extract_entity_candidates, normalize_min_score,
+    normalize_rank_fusion_scores, normalize_rrf_scores, ScoreInput,
 };
 use crate::MemoryPack;
 
@@ -129,9 +129,7 @@ impl MemoryPack {
         let mut scoring_cfg = cfg.scoring.clone().unwrap_or_default();
         scoring_cfg.apply_dos_caps();
 
-        let cjk_fts_bypass = scoring_cfg.enable_multilingual_routing && contains_cjk(query_trimmed);
-        let use_multilingual =
-            scoring_cfg.enable_multilingual_routing && needs_multilingual(query_trimmed);
+        let cjk_fts_bypass = contains_cjk(query_trimmed);
 
         let candidate_limit =
             recall_candidate_count(&cfg, limit_u32).min(scoring_cfg.max_recall_candidates as u32);
@@ -224,8 +222,6 @@ impl MemoryPack {
                     candidate_limit: current_candidate_limit,
                     embedding_model: p.embedding_model.as_deref(),
                     cjk_fts_bypass,
-                    use_multilingual,
-                    scoring_cfg: &scoring_cfg,
                     snippet_policy: TextSnippetPolicy::Omit,
                     fts_gather: &effective_fts_gather,
                     ann_overfetch_max_rounds,
@@ -263,8 +259,6 @@ impl MemoryPack {
                         candidate_limit: current_candidate_limit,
                         embedding_model: p.embedding_model.as_deref(),
                         cjk_fts_bypass,
-                        use_multilingual,
-                        scoring_cfg: &scoring_cfg,
                         snippet_policy: TextSnippetPolicy::Omit,
                         fts_gather: &effective_fts_gather,
                         ann_overfetch_max_rounds,
@@ -294,7 +288,6 @@ impl MemoryPack {
             t_stage = Some(Instant::now());
         }
 
-        let actual_multilingual_routed = candidates.multilingual_routed;
         // #836: at least one embedding model's vector leg hit the bounded
         // ANN readiness wait and was served FTS-only for this recall.
         let ann_degraded = candidates.ann_degraded;
@@ -702,9 +695,6 @@ impl MemoryPack {
                 });
                 if is_verbose {
                     result["breakdown"] = json!(sn.breakdown);
-                }
-                if actual_multilingual_routed {
-                    result["multilingual_routed"] = json!(true);
                 }
                 if ann_degraded {
                     // Per-result stamp keeps degradation visible without verbose output.

--- a/crates/khive-pack-memory/src/handlers/recall.rs
+++ b/crates/khive-pack-memory/src/handlers/recall.rs
@@ -5041,4 +5041,150 @@ mod tests {
             "normal recall must surface the seeded note under a generous override"
         );
     }
+
+    // ── #1116: one engine failing must degrade recall, not abort it ──────────
+
+    struct FailingEmbedService;
+
+    #[async_trait]
+    impl EmbeddingService for FailingEmbedService {
+        async fn embed(
+            &self,
+            _texts: &[String],
+            _model: EmbeddingModel,
+        ) -> Result<Vec<Vec<f32>>, EmbedError> {
+            Err(EmbedError::ModelNotLoaded(
+                "simulated embedding engine outage".to_string(),
+            ))
+        }
+
+        fn supports_model(&self, _model: EmbeddingModel) -> bool {
+            true
+        }
+
+        fn name(&self) -> &'static str {
+            "failing-embed"
+        }
+    }
+
+    struct FailingEmbedProvider {
+        model_name: String,
+    }
+
+    #[async_trait]
+    impl EmbedderProvider for FailingEmbedProvider {
+        fn name(&self) -> &str {
+            &self.model_name
+        }
+
+        fn dimensions(&self) -> usize {
+            8
+        }
+
+        async fn build(&self) -> Result<Arc<dyn EmbeddingService>, khive_runtime::RuntimeError> {
+            Ok(Arc::new(FailingEmbedService))
+        }
+    }
+
+    /// One embedding engine failing must degrade recall to the healthy engine, not abort it.
+    #[tokio::test]
+    #[serial(background_tasks)]
+    async fn recall_1116_one_failed_engine_still_serves_the_healthy_engines_hits() {
+        const HEALTHY_MODEL: &str = "recall-1116-healthy-model";
+        const FAILING_MODEL: &str = "recall-1116-failing-model";
+        const NOTE_TEXT: &str = "issue 1116 partial engine outage recall note";
+
+        let rt = KhiveRuntime::memory().expect("in-memory runtime");
+        rt.register_embedder(HashVecProvider {
+            model_name: HEALTHY_MODEL.to_owned(),
+            dims: 16,
+        });
+
+        let mut builder = VerbRegistryBuilder::new();
+        builder.register(KgPack::new(rt.clone()));
+        builder.register(MemoryPack::new(rt.clone()));
+        let registry = builder.build().expect("registry");
+
+        // Seed while only the healthy engine is registered — write-time
+        // indexing embeds under every registered model, so the failing
+        // engine is added only after setup, isolating #1116's assertion to
+        // the read-time recall path (embed-on-write is a separate,
+        // already-best-effort path).
+        registry
+            .dispatch(
+                "memory.remember",
+                serde_json::json!({
+                    "content": NOTE_TEXT,
+                    "memory_type": "semantic",
+                }),
+            )
+            .await
+            .expect("remember note under the healthy model");
+
+        rt.register_embedder(FailingEmbedProvider {
+            model_name: FAILING_MODEL.to_owned(),
+        });
+
+        let result = registry
+            .dispatch(
+                "memory.recall",
+                serde_json::json!({
+                    "query": NOTE_TEXT,
+                    "fusion_strategy": "vector_only",
+                    "limit": 10,
+                }),
+            )
+            .await
+            .unwrap_or_else(|e| {
+                panic!(
+                    "recall must still serve the healthy engine when one engine's \
+                     embedder fails, got error: {e:?}"
+                )
+            });
+
+        let hits = result.as_array().expect("recall result must be an array");
+        assert!(
+            !hits.is_empty(),
+            "recall must surface the healthy engine's hits despite the other \
+             engine's embedder failing; got {result:?}"
+        );
+    }
+
+    /// If every engine's embedder fails, recall must error rather than silently return empty.
+    #[tokio::test]
+    #[serial(background_tasks)]
+    async fn recall_1116_all_engines_failed_returns_error_not_empty() {
+        const FAILING_MODEL_A: &str = "recall-1116-all-failed-model-a";
+        const FAILING_MODEL_B: &str = "recall-1116-all-failed-model-b";
+
+        let rt = KhiveRuntime::memory().expect("in-memory runtime");
+        rt.register_embedder(FailingEmbedProvider {
+            model_name: FAILING_MODEL_A.to_owned(),
+        });
+        rt.register_embedder(FailingEmbedProvider {
+            model_name: FAILING_MODEL_B.to_owned(),
+        });
+
+        let mut builder = VerbRegistryBuilder::new();
+        builder.register(KgPack::new(rt.clone()));
+        builder.register(MemoryPack::new(rt.clone()));
+        let registry = builder.build().expect("registry");
+
+        let result = registry
+            .dispatch(
+                "memory.recall",
+                serde_json::json!({
+                    "query": "issue 1116 total engine outage recall query",
+                    "fusion_strategy": "vector_only",
+                    "limit": 10,
+                }),
+            )
+            .await;
+
+        assert!(
+            result.is_err(),
+            "recall must error when every embedding engine failed, not silently \
+             return empty results: {result:?}"
+        );
+    }
 }

--- a/crates/khive-pack-memory/src/handlers/recall.rs
+++ b/crates/khive-pack-memory/src/handlers/recall.rs
@@ -129,7 +129,7 @@ impl MemoryPack {
         let mut scoring_cfg = cfg.scoring.clone().unwrap_or_default();
         scoring_cfg.apply_dos_caps();
 
-        let cjk_fts_bypass = contains_cjk(query_trimmed);
+        let cjk_fts_bypass = scoring_cfg.enable_cjk_fts_bypass && contains_cjk(query_trimmed);
 
         let candidate_limit =
             recall_candidate_count(&cfg, limit_u32).min(scoring_cfg.max_recall_candidates as u32);

--- a/crates/khive-pack-memory/src/handlers/sub_handlers.rs
+++ b/crates/khive-pack-memory/src/handlers/sub_handlers.rs
@@ -119,8 +119,6 @@ impl MemoryPack {
                     candidate_limit,
                     embedding_model: p.embedding_model.as_deref(),
                     cjk_fts_bypass: false,
-                    use_multilingual: false,
-                    scoring_cfg: &scoring_cfg,
                     snippet_policy: TextSnippetPolicy::Include {
                         chars: RECALL_DIAGNOSTIC_SNIPPET_CHARS,
                     },
@@ -237,8 +235,6 @@ impl MemoryPack {
                     candidate_limit,
                     embedding_model: p.embedding_model.as_deref(),
                     cjk_fts_bypass: false,
-                    use_multilingual: false,
-                    scoring_cfg: &scoring_cfg_fuse,
                     snippet_policy: TextSnippetPolicy::Include {
                         chars: RECALL_DIAGNOSTIC_SNIPPET_CHARS,
                     },

--- a/crates/khive-pack-memory/src/handlers/tests.rs
+++ b/crates/khive-pack-memory/src/handlers/tests.rs
@@ -289,7 +289,6 @@ fn fusion_strategy_change_produces_observable_ordering_difference() {
         namespace: "local".to_string(),
         text_hits: text_hits.clone(),
         vector_hits_per_model: vec![("mock".to_string(), vector_hits.clone())],
-        multilingual_routed: false,
         visible_namespaces: vec!["local".to_string()],
         ann_degraded: false,
     };
@@ -304,7 +303,6 @@ fn fusion_strategy_change_produces_observable_ordering_difference() {
         namespace: "local".to_string(),
         text_hits,
         vector_hits_per_model: vec![("mock".to_string(), vector_hits)],
-        multilingual_routed: false,
         visible_namespaces: vec!["local".to_string()],
         ann_degraded: false,
     };
@@ -646,7 +644,6 @@ fn vector_candidates_per_model_shape_is_array_of_model_objects() {
             ("model-a".to_string(), hits_a),
             ("model-b".to_string(), hits_b),
         ],
-        multilingual_routed: false,
         visible_namespaces: vec!["test".to_string()],
         ann_degraded: false,
     };

--- a/crates/khive-pack-memory/src/handlers/tests.rs
+++ b/crates/khive-pack-memory/src/handlers/tests.rs
@@ -332,6 +332,57 @@ fn fusion_strategy_change_produces_observable_ordering_difference() {
 }
 
 #[test]
+fn vector_only_fusion_unions_hits_across_every_engine() {
+    use khive_storage::types::VectorSearchHit;
+    use std::collections::HashSet;
+    use uuid::Uuid;
+
+    let id_first_engine_only = Uuid::from_u128(0x1111);
+    let id_second_engine_only = Uuid::from_u128(0x2222);
+
+    let hits_engine_a = vec![VectorSearchHit {
+        subject_id: id_first_engine_only,
+        score: 0.9_f64.into(),
+        rank: 1,
+    }];
+    let hits_engine_b = vec![VectorSearchHit {
+        subject_id: id_second_engine_only,
+        score: 0.8_f64.into(),
+        rank: 1,
+    }];
+    let memory_ids: HashSet<Uuid> = [id_first_engine_only, id_second_engine_only]
+        .into_iter()
+        .collect();
+
+    let candidates = RecallCandidateSet {
+        namespace: "local".to_string(),
+        text_hits: vec![],
+        vector_hits_per_model: vec![
+            ("engine-a".to_string(), hits_engine_a),
+            ("engine-b".to_string(), hits_engine_b),
+        ],
+        visible_namespaces: vec!["local".to_string()],
+        ann_degraded: false,
+    };
+    let cfg = RecallConfig {
+        fuse_strategy: FusionStrategy::VectorOnly,
+        ..RecallConfig::default()
+    };
+
+    let results = fuse_candidates(&candidates, &memory_ids, &cfg, 10);
+    let ids: Vec<Uuid> = results.iter().map(|h| h.entity_id).collect();
+
+    assert!(
+        ids.contains(&id_second_engine_only),
+        "vector-only fusion must keep hits from every configured engine, not just the first; got {ids:?}"
+    );
+    assert!(
+        ids.contains(&id_first_engine_only),
+        "vector-only fusion must still keep the first engine's hits too; got {ids:?}"
+    );
+}
+
+#[test]
 fn compute_score_weighted_strategy_formula() {
     let cfg = RecallConfig {
         fuse_strategy: FusionStrategy::Weighted {

--- a/crates/khive-pack-memory/src/scoring.rs
+++ b/crates/khive-pack-memory/src/scoring.rs
@@ -514,6 +514,11 @@ pub struct ScoringConfig {
     /// When true, suppress memories whose `properties.supersedes` value matches
     /// the ID of another memory in the result set. Default: true.
     pub enable_supersedes_suppression: bool,
+    /// When true, a CJK-majority query bypasses the FTS5 leg (whose trigram
+    /// tokenizer does not segment CJK well) and relies on the vector leg
+    /// instead. Default: true.
+    #[serde(alias = "enable_multilingual_routing")]
+    pub enable_cjk_fts_bypass: bool,
 
     // ── Conditional adjustments ────────────────────────────────────────────
     /// Score adjustments applied after the base formula. Default: episodic bonus,
@@ -541,6 +546,7 @@ impl Default for ScoringConfig {
             mmr_prefix_len: 100,
 
             enable_supersedes_suppression: true,
+            enable_cjk_fts_bypass: true,
 
             adjustments: default_adjustments(),
         }
@@ -890,6 +896,23 @@ mod tests {
     fn contains_cjk_ignores_latin() {
         assert!(!contains_cjk("hello world"));
         assert!(!contains_cjk(""));
+    }
+
+    #[test]
+    fn scoring_config_old_multilingual_routing_key_still_disables_cjk_bypass() {
+        let cfg: ScoringConfig =
+            serde_json::from_value(serde_json::json!({ "enable_multilingual_routing": false }))
+                .expect("old key must still deserialize via the alias");
+        assert!(
+            !cfg.enable_cjk_fts_bypass,
+            "a config that disabled the old enable_multilingual_routing key must still \
+             disable the CJK FTS bypass under its new name"
+        );
+    }
+
+    #[test]
+    fn scoring_config_default_enables_cjk_bypass() {
+        assert!(ScoringConfig::default().enable_cjk_fts_bypass);
     }
 
     #[test]

--- a/crates/khive-pack-memory/src/scoring.rs
+++ b/crates/khive-pack-memory/src/scoring.rs
@@ -514,14 +514,6 @@ pub struct ScoringConfig {
     /// When true, suppress memories whose `properties.supersedes` value matches
     /// the ID of another memory in the result set. Default: true.
     pub enable_supersedes_suppression: bool,
-    /// When true and a multilingual embedding model is registered, route
-    /// non-ASCII-script queries (CJK, Cyrillic, Arabic, accented-Latin, …) to
-    /// it as the primary dense model. Default: true.
-    pub enable_multilingual_routing: bool,
-    /// Name of the multilingual embedding model to prefer for dense routing.
-    /// When None, the handler checks registered model names for substrings
-    /// "multilingual" or "paraphrase". Default: None.
-    pub multilingual_model: Option<String>,
 
     // ── Conditional adjustments ────────────────────────────────────────────
     /// Score adjustments applied after the base formula. Default: episodic bonus,
@@ -549,8 +541,6 @@ impl Default for ScoringConfig {
             mmr_prefix_len: 100,
 
             enable_supersedes_suppression: true,
-            enable_multilingual_routing: true,
-            multilingual_model: None,
 
             adjustments: default_adjustments(),
         }
@@ -600,22 +590,6 @@ pub fn contains_cjk(text: &str) -> bool {
     }
     let cjk = chars.iter().filter(|&&c| is_cjk_char(c)).count();
     (cjk as f32) / (chars.len() as f32) > 0.15
-}
-
-/// Return whether more than 15% of alphabetic characters are non-ASCII.
-///
-/// Punctuation and digits do not dilute the ratio. ASCII-only non-English Latin remains
-/// undetected and uses the primary model. See `crates/khive-pack-memory/docs/api/scoring.md`.
-pub fn needs_multilingual(text: &str) -> bool {
-    let alpha_chars: Vec<char> = text.chars().filter(|c| c.is_alphabetic()).collect();
-    if alpha_chars.is_empty() {
-        return false;
-    }
-    let non_ascii_alpha = alpha_chars
-        .iter()
-        .filter(|&&c| !c.is_ascii_alphabetic())
-        .count();
-    (non_ascii_alpha as f32) / (alpha_chars.len() as f32) > 0.15
 }
 
 /// Normalize `min_score`: 0–1 passes through, 1–100 divides by 100, others return Err.
@@ -1087,91 +1061,6 @@ mod tests {
         let s2 = output[&ids[2]];
         assert!(s0 > s1 && s1 > s2, "ordering must be preserved");
         assert!(s0 <= 1.0 && s2 >= 0.0, "scores must be in [0,1]");
-    }
-
-    // ── needs_multilingual ────────────────────────────────────────────────────
-
-    #[test]
-    fn needs_multilingual_ascii_english_routes_primary() {
-        assert!(!needs_multilingual("hello world"));
-        assert!(!needs_multilingual("rust programming language"));
-        assert!(!needs_multilingual(""));
-        assert!(!needs_multilingual("42 items in the list"));
-    }
-
-    #[test]
-    fn needs_multilingual_cjk_routes_multilingual() {
-        // Pure CJK: 4/4 = 100% non-ASCII alpha → well above 15%.
-        assert!(needs_multilingual("你好世界"));
-        // Mixed: 2 CJK out of 5 chars = 40%.
-        assert!(needs_multilingual("abc你好"));
-    }
-
-    #[test]
-    fn needs_multilingual_cyrillic_routes_multilingual() {
-        // "Привет мир" (Hello world in Russian): all Cyrillic alphabetic.
-        assert!(needs_multilingual("Привет мир"));
-        // Single Cyrillic word mixed with Latin — Г alone is 1/7 ≈ 14% (below threshold).
-        // Verify with a word that has enough Cyrillic chars to cross 15%.
-        assert!(needs_multilingual("Привет hello")); // Привет = 6 non-ASCII alpha, total chars including space = 12 → 6/12 = 50%
-    }
-
-    #[test]
-    fn needs_multilingual_arabic_routes_multilingual() {
-        // "مرحبا" (Hello in Arabic): all Arabic alphabetic.
-        assert!(needs_multilingual("مرحبا بالعالم"));
-    }
-
-    #[test]
-    fn needs_multilingual_devanagari_routes_multilingual() {
-        // "नमस्ते" (Namaste in Hindi/Devanagari).
-        assert!(needs_multilingual("नमस्ते दुनिया"));
-    }
-
-    #[test]
-    fn needs_multilingual_accented_latin_routes_multilingual() {
-        // French: "café résumé" — é is alphabetic and non-ASCII.
-        // Alphabetic chars: c,a,f,é,r,é,s,u,m,é = 10; non-ASCII alpha: 3; 3/10 = 30% > 15%.
-        assert!(needs_multilingual("café résumé"));
-        // German: "Müller" — ü is 1/6 alpha = 16.7% > 15%.
-        assert!(needs_multilingual("Müller"));
-        // Spanish: "niño" — ñ is 1/4 alpha = 25% > 15%.
-        assert!(needs_multilingual("niño"));
-    }
-
-    #[test]
-    fn needs_multilingual_alphabetic_denominator_is_stable_under_punctuation() {
-        // INVARIANT 2: punctuation/digits must not change routing decision.
-        // "Müller" alpha: M,ü,l,l,e,r = 6; non-ASCII alpha: ü = 1; 1/6 = 16.7% > 15%.
-        assert!(needs_multilingual("Müller"));
-        // "Müller?" — same 6 alpha chars; ? is not alphabetic; 1/6 = 16.7% → still routes.
-        assert!(needs_multilingual("Müller?"));
-        // "Müller!!!" — same 6 alpha chars; 1/6 = 16.7% → still routes.
-        assert!(needs_multilingual("Müller!!!"));
-        // Digit-heavy short accented query: "42 Ü" — alpha: Ü = 1; non-ASCII: 1; 1/1 = 100%.
-        assert!(needs_multilingual("42 Ü"));
-        // Empty / no-alpha: must return false without divide-by-zero.
-        assert!(!needs_multilingual(""));
-        assert!(!needs_multilingual("42 100 ???"));
-    }
-
-    #[test]
-    fn needs_multilingual_pure_ascii_accented_below_threshold_routes_primary() {
-        // "hello naïve" — ï is 1 non-ASCII alpha out of 10 alpha = 10% < 15% → primary.
-        // (Deliberate design decision: a single diacritic in an otherwise English
-        // sentence does not warrant multilingual routing.)
-        assert!(!needs_multilingual("hello naive")); // no diacritics, definitely primary
-                                                     // "über" — ü is 1/4 alpha = 25% → routes multilingual (German word).
-        assert!(needs_multilingual("über"));
-    }
-
-    #[test]
-    fn needs_multilingual_ascii_only_non_english_latin_routes_primary_known_limitation() {
-        // INVARIANT 4: ASCII-only non-English Latin is NOT detected here.
-        // Real language detection is tracked as a follow-up to issue #101.
-        assert!(!needs_multilingual("bonjour le monde"));
-        assert!(!needs_multilingual("como estas"));
-        assert!(!needs_multilingual("ich suche einen buchhalter"));
     }
 
     // ── extract_entity_candidates ─────────────────────────────────────────────

--- a/crates/khive-pack-memory/tests/integration.rs
+++ b/crates/khive-pack-memory/tests/integration.rs
@@ -2182,6 +2182,63 @@ async fn test_weighted_fusion_multi_model_text_not_zeroed() {
     );
 }
 
+/// Issue #1115 regression: a CJK query must fuse across every configured
+/// embedding engine rather than narrowing to a single model. A note embedded
+/// only through the primary engine must still be found by a CJK query, even
+/// though FTS5 has no CJK tokenizer and cannot rescue it via the text leg.
+#[tokio::test]
+async fn test_cjk_query_finds_note_embedded_by_primary_engine() {
+    const PRIMARY: &str = "enc-primary";
+    const SECONDARY: &str = "enc-multilingual-b";
+    const DIMS: usize = 4;
+
+    let rt = KhiveRuntime::new(RuntimeConfig {
+        db_path: None,
+        embedding_model: None,
+        additional_embedding_models: vec![],
+        ..RuntimeConfig::default()
+    })
+    .expect("runtime");
+    // Only the primary engine is registered when the note is written — this
+    // mirrors a secondary engine being added to config after existing notes
+    // were already embedded, before any backfill runs.
+    rt.register_embedder(ConstVecProvider::new(PRIMARY, DIMS, 0.5));
+
+    let registry = make_registry(rt.clone());
+
+    let result = registry
+        .dispatch(
+            "memory.remember",
+            json!({
+                "content": "cjk fusion regression note embedded via primary engine only",
+                "salience": 0.7,
+            }),
+        )
+        .await
+        .expect("remember with only the primary engine registered");
+    let note_id = result["id"].as_str().expect("note_id");
+
+    // The secondary engine becomes available only now — this note has no
+    // vector row in its table.
+    rt.register_embedder(ConstVecProvider::new(SECONDARY, DIMS, 0.6));
+
+    let recall = registry
+        .dispatch(
+            "memory.recall",
+            json!({ "query": "你好世界的中文查询", "limit": 10 }),
+        )
+        .await
+        .expect("recall with cjk query");
+
+    let hits = recall.as_array().expect("array");
+    let ids: Vec<&str> = hits.iter().map(|h| h["id"].as_str().unwrap()).collect();
+    assert!(
+        ids.contains(&note_id),
+        "cjk query must fuse across every configured engine and find a note \
+         embedded only via the primary engine; got: {ids:?}"
+    );
+}
+
 // ── Wave-2 regression tests (M-C1..M-C4) ──────────────────────────────────────
 
 /// M-C1: memory_type="procedural" must be rejected with a clear error listing

--- a/crates/khive-runtime/src/config.rs
+++ b/crates/khive-runtime/src/config.rs
@@ -496,13 +496,15 @@ pub(crate) fn build_embedder_registry(
 }
 
 fn configured_embedding_models(config: &RuntimeConfig) -> Vec<EmbeddingModel> {
-    let mut models = Vec::new();
+    let mut models: Vec<EmbeddingModel> = Vec::new();
     if let Some(model) = config.embedding_model {
         models.push(model);
     }
-    models.extend(config.additional_embedding_models.iter().copied());
-    models.sort_by_key(|model| model.to_string());
-    models.dedup();
+    for model in config.additional_embedding_models.iter().copied() {
+        if !models.contains(&model) {
+            models.push(model);
+        }
+    }
     models
 }
 
@@ -903,6 +905,58 @@ mod no_embeddings_tests {
             !buggy_form.additional_embedding_models.is_empty(),
             "Default's independent-field seeding must remain unchanged; \
              no_embeddings() is the fix, not a change to Default"
+        );
+    }
+}
+
+#[cfg(test)]
+mod configured_embedding_models_order_tests {
+    use super::*;
+
+    /// Issue #1115: the configured engine list must preserve declaration
+    /// order (primary first, then `additional_embedding_models` in order)
+    /// instead of alphabetizing — any consumer that treats the list as
+    /// ordered (e.g. recall fan-out) otherwise gets the wrong primary.
+    #[test]
+    fn preserves_primary_first_then_additional_in_declared_order() {
+        let config = RuntimeConfig {
+            embedding_model: Some(EmbeddingModel::AllMiniLmL6V2),
+            additional_embedding_models: vec![
+                EmbeddingModel::Qwen3Embedding4B,
+                EmbeddingModel::BgeSmallEnV15,
+            ],
+            ..RuntimeConfig::default()
+        };
+
+        assert_eq!(
+            configured_embedding_models(&config),
+            vec![
+                EmbeddingModel::AllMiniLmL6V2,
+                EmbeddingModel::Qwen3Embedding4B,
+                EmbeddingModel::BgeSmallEnV15,
+            ],
+            "order must be primary-first, then additional models as declared, \
+             not alphabetized"
+        );
+    }
+
+    /// A model repeated in both `embedding_model` and `additional_embedding_models`
+    /// must be deduped to a single entry, keeping its first (primary) position.
+    #[test]
+    fn dedupes_model_shared_between_primary_and_additional() {
+        let config = RuntimeConfig {
+            embedding_model: Some(EmbeddingModel::AllMiniLmL6V2),
+            additional_embedding_models: vec![
+                EmbeddingModel::AllMiniLmL6V2,
+                EmbeddingModel::BgeSmallEnV15,
+            ],
+            ..RuntimeConfig::default()
+        };
+
+        assert_eq!(
+            configured_embedding_models(&config),
+            vec![EmbeddingModel::AllMiniLmL6V2, EmbeddingModel::BgeSmallEnV15],
+            "the shared model must appear once, in its primary position"
         );
     }
 }

--- a/crates/khive-runtime/src/config.rs
+++ b/crates/khive-runtime/src/config.rs
@@ -289,10 +289,13 @@ impl Default for RuntimeConfig {
             .ok()
             .and_then(|s| s.parse().ok())
             .or(Some(EmbeddingModel::AllMiniLmL6V2));
+        // Ships single-engine. A second engine is embedded on every write and
+        // searched on every read, which is cost a deployment should opt into
+        // rather than inherit: set KHIVE_ADDITIONAL_EMBEDDING_MODELS to add one.
         let additional_embedding_models = std::env::var("KHIVE_ADDITIONAL_EMBEDDING_MODELS")
             .ok()
             .map(|s| parse_embedding_model_list(&s))
-            .unwrap_or_else(|| vec![EmbeddingModel::ParaphraseMultilingualMiniLmL12V2]);
+            .unwrap_or_default();
         let packs = std::env::var("KHIVE_PACKS")
             .ok()
             .map(|s| parse_pack_list(&s))
@@ -883,12 +886,21 @@ mod no_embeddings_tests {
 
     #[test]
     #[serial]
-    fn default_still_seeds_additional_models_when_env_unset() {
+    fn default_computes_additional_models_independently_of_no_embeddings() {
         // `Default` must keep computing `embedding_model` and
         // `additional_embedding_models` independently; `no_embeddings()` is a
         // separate opt-out constructor, not a change to `Default`'s seeding.
-        std::env::remove_var("KHIVE_ADDITIONAL_EMBEDDING_MODELS");
+        // The env var is SET here rather than cleared: since Default now ships
+        // no secondary engine, an unset env would make Default and
+        // no_embeddings() indistinguishable and the test would stop
+        // discriminating the thing it exists to discriminate.
+        std::env::set_var("KHIVE_ADDITIONAL_EMBEDDING_MODELS", "paraphrase");
         let config = RuntimeConfig::default();
+        let buggy_form = RuntimeConfig {
+            embedding_model: None,
+            ..RuntimeConfig::default()
+        };
+        std::env::remove_var("KHIVE_ADDITIONAL_EMBEDDING_MODELS");
 
         assert_eq!(
             config.additional_embedding_models,
@@ -897,14 +909,29 @@ mod no_embeddings_tests {
 
         // Overriding only `embedding_model` via struct-update syntax does not
         // clear `additional_embedding_models`.
-        let buggy_form = RuntimeConfig {
-            embedding_model: None,
-            ..RuntimeConfig::default()
-        };
         assert!(
             !buggy_form.additional_embedding_models.is_empty(),
             "Default's independent-field seeding must remain unchanged; \
              no_embeddings() is the fix, not a change to Default"
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn default_ships_a_single_engine_when_env_unset() {
+        // A secondary engine is embedded on every write and searched on every
+        // read. That cost is opted into, not inherited.
+        std::env::remove_var("KHIVE_ADDITIONAL_EMBEDDING_MODELS");
+        let config = RuntimeConfig::default();
+
+        assert!(
+            config.additional_embedding_models.is_empty(),
+            "shipped default must register one engine; a second is opt-in via \
+             KHIVE_ADDITIONAL_EMBEDDING_MODELS"
+        );
+        assert_eq!(
+            configured_embedding_models(&config),
+            vec![EmbeddingModel::AllMiniLmL6V2]
         );
     }
 }


### PR DESCRIPTION
Closes #1115.

Recall fanned out across every configured embedding engine in the general case, but when a query contained CJK the model list was *replaced* by a single multilingual engine rather than extended with it:

```rust
match multilingual_model {
    Some(model) => { multilingual_routed = true; vec![model] }
    None => names,
}
```

So a Chinese query searched the multilingual engine alone and never saw the primary engine's vectors, while an English query searched everything. A record embedded before a second engine was configured was therefore invisible to exactly the queries that engine exists to serve.

The whole block collapses to `registered_embedding_model_names()`. An explicit `embedding_model` argument still pins to that one engine.

## Changes

- **Recall fuses across all configured engines.** Removes `use_multilingual`, `multilingual_routed` (including the response JSON key), and the `enable_multilingual_routing` / `multilingual_model` scoring knobs. `needs_multilingual` had no remaining callers and is gone. `contains_cjk` is kept: it independently gates the FTS bypass path, which is #1113's territory, and that path's behaviour is unchanged.
- **Configured engine order is preserved.** `configured_embedding_models` alphabetized via `sort_by_key`, so the declared primary was not necessarily first. It now dedupes while preserving declaration order.
- **Knowledge atom indexing writes a vector per configured engine.** `knowledge.index` embedded with the default engine only. Secondary engines are now written best-effort through the existing per-model `vec_<model>` store, mirroring `backfill_missing_embeddings`; a secondary failure is logged and does not change the `indexed`/`failed`/`skipped` counters, which stay keyed on the default engine as before.

No schema migration: vectors are already keyed per engine by `embedding_model`, so N embeddings per subject is an existing shape.

## Verification

`test_cjk_query_finds_note_embedded_by_primary_engine` is the regression guard. It registers a primary engine, writes a note through it, *then* registers a second engine whose name would win the old substring heuristic, and recalls with a CJK query.

Confirmed meaningful rather than vacuous: against the pre-change code it fails with `got: []` (exit 101); after the change it passes. Also added order-preservation and dedupe tests for the config change, and a test asserting `knowledge.index` populates both engines' vector tables.

Gates: `cargo check` / `clippy -D warnings` / `test -p khive-pack-memory` / `test -p khive-pack-knowledge` / `fmt --check` all clean.

## Known gap, deliberately not addressed here

`knowledge_sections` embedding remains single-engine. That table stores one inline `embedding BLOB` column rather than the per-engine `vec_<model>` tables everything else uses, so making it multi-engine needs either a schema change or migrating section vectors onto the `VectorStore` abstraction, plus a matching read-path change. That is a design decision rather than a mechanical fix, so it is left for follow-up instead of half-built here.
