### PR TITLE
docs(adr): ADR-117 session continuity — cross-session search and remote ingestion

### DIFF
--- a/docs/adr/ADR-117-session-continuity-search.md
+++ b/docs/adr/ADR-117-session-continuity-search.md
@@ -13,15 +13,42 @@
 - [ADR-014](ADR-014-curation-operations.md) — Curation Operations (deletion is a curation-layer
   operation that removes data, not a view-layer filter)
 - [ADR-018](ADR-018-authorization-gate.md) — Authorization Gate (the pre-dispatch `Gate::check`
-  contract this ADR's enforcement composes with, and whose fail-open default this ADR carves a
-  fail-closed verb class out of)
+  contract the isolation requirement must compose with, and whose fail-open default a follow-on ADR
+  carves a fail-closed verb class out of)
 - [ADR-021](ADR-021-memory-pack.md) — Memory Pack (the hybrid FTS + vector recall with RRF fusion
-  this ADR reuses rather than re-implements)
+  the search capability reuses rather than re-implements)
 - [ADR-025](ADR-025-verb-speech-acts.md) — Verb Speech Acts (the Assertive category `session.search`
   joins)
 - [ADR-083](ADR-083-session-pack-t1-verbs.md) — Session Pack T1 Verb Surface (the existing
   `store`/`list`/`resume`/`export` verbs over the `notes` table, and the separate mirror aux tables
   this ADR searches)
+
+---
+
+## This is a direction ADR
+
+This document establishes the **direction** for session continuity: the capability, the properties it
+must have, and the requirements those properties impose. It deliberately does **not** define the
+schema, verb APIs, or enforcement mechanisms that satisfy those requirements. Each of those carries a
+proof obligation — a schema migration, an isolation test, a deletion lifecycle — that belongs to a
+focused implementation ADR with its own spec-gate pass, not to a direction document.
+
+The mechanism-and-proof work is split into named follow-ons (see **Follow-on ADRs** below):
+
+- **ADR-117a** — session identity and tenant isolation
+- **ADR-117b** — deletion and retention
+- **ADR-117c** — continuity bridge (a search hit resumes and exports)
+- **ADR-117d** — remote cross-machine ingestion
+
+The properties named in D2, D4, D5, and D6 are stated here as **requirements**, never as delivered
+behavior. They become delivered only when the follow-on that carries each one lands, with its proof.
+
+**Capability-consumption rule.** Nothing markets, documents as available, or takes a runtime
+dependency on session continuity until the follow-ons a given slice needs are **live**. The v1
+single-machine search slice needs ADR-117a (identity + isolation) and ADR-117b (deletion) live, and
+ADR-117c (continuity bridge) for hits to be useful; cross-machine search additionally needs
+ADR-117d. Until then, session continuity is a direction with in-flight mechanisms, not a shipped
+feature.
 
 ---
 
@@ -39,20 +66,27 @@ split that [ADR-083](ADR-083-session-pack-t1-verbs.md) makes deliberately:
    these separate from the notes precisely because one is caller-authored and one is passive
    ingestion.
 
-Each mirrored event already carries a **scoped identity**: `ParsedEvent.uuid` is the primary key for
-idempotency — the Claude Code top-level `uuid`, or the synthesized `"{session_id}:{byte_offset}"` for
-Codex, or the ChatGPT `message.id` (`crates/khive-pack-session/src/mirror/parse.rs`).
+Two facts about the mirror as it exists today shape every requirement below, and both were verified
+against source rather than assumed:
 
-The one capability neither store has is **search over message content**. `session.resume` fetches a
-single session by id; `session.list` is a recency browse. The transcript text sits in
-`session_messages` and is not indexed for retrieval.
+- **The persistence identity is a bare global primary key.** `session_messages.id` and `sessions.id`
+  are each `TEXT PRIMARY KEY` with no account or tenant component
+  (`crates/khive-pack-session/src/vocab.rs`). `session_messages.id` is populated from
+  `ParsedEvent.uuid` — the Claude Code top-level `uuid`, the ChatGPT `message.id`, or the synthesized
+  `"{session_id}:{byte_offset}"` for Codex (`crates/khive-pack-session/src/mirror/parse.rs`). Those
+  are **provider event ids**, unique enough for the single-writer mirror's idempotency, but not
+  tenant-scoped: two accounts that produced the same provider event id would collide on one primary
+  key. The `namespace` column is nullable and is not part of any key. **The mirror is single-tenant
+  by construction.**
+- **There is no search over message content.** `session.resume` fetches a single session by id;
+  `session.list` is a recency browse. The transcript text sits in `session_messages` and is not
+  indexed for retrieval.
 
-This ADR specifies that search capability and the four contracts it cannot ship without: the identity
-model for mirrored messages, the ingestion model that lets one account span multiple machines, the
-tenant-isolation enforcement that keeps one account's transcripts unreachable by another, and the
-deletion and retention model for the most sensitive data the substrate holds.
-
-This ADR specifies the capability and its contracts. It does not schedule the implementation.
+The capability this ADR sets direction for — search across an account's own session history, reaching
+back over retained history and (later) across machines — cannot be layered onto that mirror without
+first making the identity tenant-scoped, defining how isolation is enforced where rows exist, defining
+how the most sensitive data the substrate holds is deleted, and defining how a search hit reconnects
+to `resume`/`export`. Those are the requirements below; the mechanisms are the follow-ons.
 
 ---
 
@@ -60,195 +94,216 @@ This ADR specifies the capability and its contracts. It does not schedule the im
 
 ### D1 — A `session.search` verb, FTS5 first
 
-Add one Assertive verb:
+The capability is one Assertive verb:
 
 ```
 session.search(query, limit?, since?, source?, cwd?)
   -> [{ session, score, snippets }]
 ```
 
-It runs keyword retrieval over `session_messages.text`, **scoped to the caller's authenticated
-tenant** (D4), and returns matching sessions ranked by score with the matching snippets. The optional
-filters narrow by recency (`since`), originating tool (`source`), and working directory (`cwd`).
+It runs keyword retrieval over `session_messages.text`, scoped to the caller's authenticated tenant
+(the isolation requirement, D4), and returns matching sessions ranked by score with the matching
+snippets. The optional filters narrow by recency (`since`), originating tool (`source`), and working
+directory (`cwd`).
 
-The search corpus is the mirror's `session_messages` — that is where transcript text lives.
-Caller-authored session notes (D-context store 1) are metadata records, not transcript text, and are
-out of the search corpus in v1; a returned hit's identity is nonetheless guaranteed to resume and
-export (D6).
+The search corpus is the mirror's `session_messages`, where transcript text lives. Caller-authored
+session notes (Context store 1) are metadata records, not transcript text, and are out of the search
+corpus in v1; a returned hit's identity is nonetheless required to resume and export (D6).
 
 Version 1 is **FTS5-only**. Session-search queries are keyword-rich by nature — a user searching their
-own history remembers the terms they typed — and full-text retrieval covers that query class
-directly. FTS5 over `session_messages.text` needs an index and a triggered content table, the same
-pattern the note substrate already uses. Ranking and fusion primitives are shared with the memory
-pack (ADR-021), not re-implemented; when vector retrieval is added (D2), `session.search` gains a
-second RRF-fused signal without a signature change.
+own history remembers the terms they typed — and full-text retrieval covers that query class directly.
+FTS5 over `session_messages.text` needs an index and a triggered content table, the same pattern the
+note substrate already uses. Ranking and fusion primitives are shared with the memory pack (ADR-021),
+not re-implemented; a later vector signal (D2) fuses in without a signature change.
 
-### D2 — Message identity is scoped; the content hash is an integrity adjunct
+The verb **shape** is decided here. The verb **does not ship until ADR-117a lands**, because a search
+verb that returns transcript rows is unsafe to expose before the tenant-isolation enforcement it
+depends on exists and is proven (D4). This gating is a hard condition, carried from the direction to
+the follow-on.
 
-Message identity is the existing **scoped `ParsedEvent.uuid`** (provider / session / event scope),
-not a hash of content. This is a hard correctness requirement, not a preference:
+### D2 — Message identity must be tenant-scoped (requirement → ADR-117a)
+
+**Requirement.** Before search can be exposed, the mirror's persistence identity must be **tenant-
+scoped**, so that no two accounts can collide on one row and no query can reach another account's rows
+by construction. The mirror is single-tenant today (Context); making it scoped is the first thing
+ADR-117a must do — for example a uniqueness contract over `(account, provider_session_id, event)` or
+an equivalent scoping, decided with the migration in ADR-117a.
+
+**Ruling: identity is not a content hash.** Whatever the scoped identity is, it is not a hash of
+message content. This is a decided design position, not a deferred mechanism:
 
 - A content-only identity **collides across tenants** — identical message text in two accounts would
   map to one row, leaking or losing data across the isolation boundary.
 - A content-only identity **collapses legitimate repeated events** — the same text occurring twice in
   one session (a command retyped, a repeated tool result) is two events, and hashing them to one
   identity silently loses the second.
-- It would contradict the mirror's shipped design, where `ParsedEvent.uuid` is already the idempotency
-  key (`parse.rs`).
 
-A content hash is still carried, but as a **dedup / integrity adjunct** on the scoped id, never the
-id: it detects whether a re-streamed event bearing the same scoped `uuid` carries the same content
-(integrity on idempotent re-stream), and it gates the future embedding-backfill so an unchanged event
-is not re-embedded. Idempotent backfill (D3) is provided by the scoped id — re-streaming the same
-provider/session/event is idempotent by that id — with the hash guarding content integrity.
+A content hash is still useful, but as a **dedup / integrity adjunct** on the scoped id, never the id:
+it detects whether a re-streamed event bearing the same scoped identity carries the same content
+(integrity on idempotent re-stream), and it gates a future embedding backfill so an unchanged event is
+not re-embedded.
 
-The vector signal remains a gated later addition: the schema is embedding-ready (a stable per-event id
-plus the content hash make a later embed backfill idempotent and re-runnable), and the vector add is
-**gated on the per-engine retrieval parallelization work** (khive#1121) for the same reason the
-multi-engine default change (khive#1116) is — embedding every message is a cost that scales with
-history size, and vector recall rides the same serialized retrieval path #1121 addresses. Until vector
-search ships, every surface describes the capability as **full-text search across sessions**, never
-semantic search.
+A vector signal is a gated later addition, not part of v1. The scoped-identity schema must be
+embedding-ready (a stable per-event id plus the content hash make a later embed backfill idempotent
+and re-runnable), but embedding every message is a cost that scales with history size and rides the
+same serialized retrieval path that khive#1121 addresses, so the vector add is gated on that work the
+same way the multi-engine default change (khive#1116) is. Until vector search ships, every surface
+describes the capability as **full-text search across sessions**, never semantic search.
 
-### D3 — Ingestion: a principal-scoped backend with an authenticated contract
+### D3 — Cross-machine ingestion is a principal-scoped backend (requirement → ADR-117d)
 
-Spanning multiple originating machines under one account is a **principal-scoped backend** in the
-sense of [ADR-007](ADR-007-namespace.md) Rule 8: the pack's own ADR (this one) defines the mechanism,
-authentication model, migration path, and failure modes, and the backend's **server-side per-principal
-scope is the Gate for that backend** (ADR-007 Rule 8 §3) — it composes with the single-seam
-authorization model, it does not sit outside it.
+**Requirement.** Spanning multiple originating machines under one account is a **principal-scoped
+backend** in the sense of [ADR-007](ADR-007-namespace.md) Rule 8: a follow-on ADR (ADR-117d) must
+define the mechanism, authentication model, migration path, and failure modes, and the backend's
+**server-side per-principal scope is the Gate for that backend** (ADR-007 Rule 8 §3) — it composes
+with the single-seam authorization model, it does not sit outside it.
 
-The existing mirror is extended with a **remote sink**: instead of writing a local table, it streams
-parsed events to a per-account ingestion endpoint. That endpoint carries a real contract, none of it
-optional:
+The direction is that the existing mirror gains a **remote sink**: instead of writing only a local
+table, it can stream parsed events to a per-account ingestion endpoint. ADR-117d must give that
+endpoint a real, non-optional contract: authentication that binds a credential to an account (the
+authenticated principal, never a client-supplied account string, decides which account events land
+under); an encrypted transport; origin verification and replay protection; and enumerated failure
+modes that reject and surface rather than silently accept or drop. The byte-offset cursor already
+collapses cold backfill and live tailing into one loop (a fresh machine starts at cursor zero), so no
+separate uploader tool is needed; re-streaming stays idempotent by the scoped identity (D2).
 
-- **Authentication and credential-to-account binding.** Every ingestion connection authenticates a
-  principal, and the authenticated principal — not any client-supplied namespace or account string —
-  determines which account the events land under. A client cannot assert another account's identity.
-- **Transport security.** The endpoint is reachable only over an encrypted transport.
-- **Origin verification and replay protection.** Requests are integrity-protected and carry
-  anti-replay material so a captured stream cannot be re-injected.
-- **Failure modes.** Authentication failure, integrity failure, and backend-unavailable are
-  enumerated with defined behavior (reject and surface, never silently accept or silently drop).
+Cross-machine ingestion is **off the v1 single-machine critical path**. v1 search reads the local
+mirror; ADR-117d extends the corpus to every machine that streams to the account. The direction ADR
+names it so the identity (D2) and isolation (D4) requirements are designed to hold across machines
+from the start, not retrofitted.
 
-The endpoint is admin/bulk-shaped — a streaming ingestion path, not a per-message interactive verb
-round-trip — consistent with keeping long-running bulk work off the interactive verb surface.
-
-The byte-offset cursor collapses what would otherwise be two code paths: a fresh machine's cursor
-starts at zero, so the same tail loop performs a cold bulk backfill of that machine's existing
-transcripts and then continues into live tailing, with no separate uploader tool. Re-streaming is
-idempotent by the **scoped event id** (D2) — a machine re-syncing, or the same transcript arriving
-from a backup, never doubles an event — with the content hash guarding integrity.
-
-### D4 — Tenant isolation is fail-closed and enforced at a specified seam (hard requirement)
+### D4 — Tenant isolation must be fail-closed, enforced where rows exist (requirement → ADR-117a)
 
 Session transcripts contain everything a user typed and was shown. In a multi-tenant deployment one
-account's sessions must be unreachable by another account's query. Getting the enforcement mechanism
-right matters more than asserting the property, so this decision specifies the mechanism against the
-actual Gate contract.
+account's sessions must be unreachable by another account's query. This is a hard requirement on the
+search capability; ADR-117a carries the enforcement mechanism and its proof. The direction ADR fixes
+the **constraints** that mechanism must satisfy, because those constraints are what make a naive
+design wrong:
 
-The [ADR-018](ADR-018-authorization-gate.md) Gate is a **pre-dispatch check over request metadata**
-(`actor`, `namespace`, `verb`, `args`, `context`) that returns Allow/Deny. It runs **before** the
-handler and therefore never sees matched rows; and by ADR-018's fifth principle it **fails open on
-infrastructure errors** (a Gate-infra failure logs a warning and proceeds; only an explicit `Deny`
-blocks). A search verb returns rows, so row-level isolation cannot be a property of the Gate's
-pre-dispatch decision, and it cannot rest on the Gate failing safely — it does not.
+- **The [ADR-018](ADR-018-authorization-gate.md) Gate cannot be the row-isolation mechanism.** The
+  Gate is a pre-dispatch check over request metadata (`actor`, `namespace`, `verb`, `args`,
+  `context`) that returns Allow/Deny. It runs **before** the handler and therefore never sees matched
+  rows; and by ADR-018's fifth principle it **fails open on infrastructure errors**. Row-level
+  isolation can therefore be neither a property of the Gate's pre-dispatch decision nor a consequence
+  of the Gate failing safely.
+- **The scope must be the authenticated tenant, never a caller argument.** A caller-supplied
+  `namespace` is forgeable; resolving scope from it is the prior v1 anti-pattern ADR-007 removed.
 
-Enforcement is therefore specified as follows:
+ADR-117a must therefore enforce isolation **where the rows exist** — a non-widenable predicate at the
+handler seam, keyed to the authenticated tenant — and make the verb **fail-closed by construction**:
+`session.search` requires a positive authenticated tenant scope to execute, so that ADR-018's fail-open
+default cannot leak session data (fail-open yields no authenticated scope, and no scope yields no
+results). ADR-117a codifies this at the contract level by amending ADR-018 to designate a **fail-closed
+verb class**, with `session.search` as its first member — and the enforcement structure is
+construction-primary: the safety property holds in the shipped seam without depending on the amendment
+landing first, and the amendment is contract-level codification of a property the seam already
+guarantees. ADR-117a lands this enforcement, a cross-account isolation test, and a no-scope-refusal
+test **in the same change as `session.search`** (the D1 gate). Isolation is a property proven by test,
+not asserted in prose.
 
-1. **The authenticated tenant is the scope.** The scope applied to a `session.search` query is the
-   caller's **authenticated** tenant (resolved from the authenticated principal / installed
-   `TenantGate`), never a caller-supplied `namespace` argument, which a caller could forge.
-2. **A mandatory query predicate at the handler seam.** The handler applies that authenticated tenant
-   as a non-widenable predicate on the search query, so rows outside the tenant are unreachable. This
-   is the enforcement seam — it is where rows exist, downstream of the Gate's authorization.
-3. **Fail-closed by construction.** `session.search` **requires a positive authenticated tenant
-   scope** to execute. Absent one — from any cause, including an authentication or Gate-infrastructure
-   error — the handler refuses and returns nothing. This means ADR-018's fail-open default cannot leak
-   session data: fail-open yields no authenticated scope, and no scope yields no results. To codify the
-   property at the contract level rather than rely only on the handler, ADR-018 is amended to designate
-   a **fail-closed verb class** (a Gate-infrastructure error is a `Deny` for these verbs);
-   `session.search` is the first member.
-4. **Proven by test, in the same change.** `session.search` lands **only together with** this
-   enforcement, plus an isolation test that issues a crafted cross-account query and asserts it returns
-   nothing, and a test that asserts the verb refuses when no authenticated scope is present. The
-   isolation is a property proven by test, not documented in prose.
+### D5 — Deletion and retention must be executable across every derived surface (requirement → ADR-117b)
 
-This is consistent with ADR-007: namespace is a policy input to the Gate and the authenticated tenant
-predicate, never a storage partition; the only difference between a permissive and an isolating
-deployment is which Gate/`TenantGate` is installed.
+**Requirement.** Deletion and retention over session transcripts must **remove data, not hide it**
+([ADR-014](ADR-014-curation-operations.md)), and must be complete across every surface the mirror data
+is derived onto. ADR-117b carries the verb APIs, the tombstone lifecycle, and the surface-by-surface
+semantics; the direction ADR fixes the scope those verbs must cover and the retention model.
 
-### D5 — Deletion and retention are executable across every derived surface
+- **Retention is bounded by a configurable storage cap, not a time window.** Within the cap, history
+  is kept indefinitely, so search reaches back across the full retained span; at the cap the account
+  ages out its oldest sessions first, and that aging is an executable, surfaced operation, never a
+  silent background deletion.
+- **User-initiated deletion is available from day one**, at two granularities — a single session and a
+  full account wipe.
+- **Deletion is not complete until every derived surface is handled.** ADR-117b's contract must
+  enumerate, with verb-level semantics: the `session_messages` rows and the `sessions` row; the FTS5
+  index (the triggered content table), so deleted content is not still matchable; future vector rows
+  (when D2's vector signal ships), on the same path; `session_mirror_cursor`, where a deleted session
+  is tombstoned by scoped id so a subsequent re-stream of the same source file does not resurrect it;
+  remote copies at the ingestion sink (D3) and any in-flight / retry state for that account; and any
+  cached or hydrated search results. Retention aging is the same oldest-first operation over the same
+  surfaces.
 
-Retention is bounded by a configurable **storage cap**, not a time window. Within the cap, history is
-kept indefinitely, so search reaches back across the full retained span; at the cap the account ages
-out its oldest sessions first, and that aging is an **executable, surfaced** operation — never a silent
-background deletion.
+### D6 — A search hit's identity must resume and export (requirement → ADR-117c)
 
-Independent of the cap, **user-initiated deletion is available from day one** at two granularities — a
-single session and a full account wipe — and both are **curation-layer** operations
-([ADR-014](ADR-014-curation-operations.md)) that remove data, not view-layer filters that hide it.
-Because the mirror data is spread across derived surfaces, the deletion contract enumerates each with
-verb-level semantics; deletion is not complete until every one is handled:
+**Requirement.** `session.search` reads the mirror's `sessions` / `session_messages`, while
+`session.resume` and `session.export` operate on the T1 note store and today accept only UUID/hex ids
+that resolve to session notes (ADR-083). A search result therefore returns a mirror session identity
+(`provider_session_id` and its `sessions` row key), and that identity must be **resolvable by `resume`
+and `export`** — a hit is useless if it cannot be reopened or exported.
 
-- `session_messages` rows and the `sessions` row.
-- The FTS5 index (the triggered content table) — removed with the rows, so deleted content is not still
-  matchable.
-- Future vector rows (when D2's vector signal ships) — removed on the same path.
-- `session_mirror_cursor` — a deleted session is **tombstoned** by scoped id so a subsequent re-stream
-  of the same source file does not resurrect it.
-- Remote copies at the ingestion sink, and any in-flight / retry state for that account.
-- Any cached or hydrated search results.
+ADR-117c must pick **one** bridge and resolve it against ADR-083's UUID-only resolution — not leave it
+as an open alternative. The two candidate shapes are (a) `resume`/`export` accept the mirror session
+identity directly, or (b) a defined resolution maps the mirror identity to the T1 store. ADR-117c
+chooses one and specifies it; the direction ADR only requires that the chosen bridge exist so every
+`session.search` result carries an identity guaranteed to resume and export. The caller-authored note
+store and the mirror store stay distinct per ADR-083; the bridge connects their identities for
+continuity, it does not merge the schemas.
 
-Retention aging is itself an executable oldest-first operation over the same surfaces.
+---
 
-### D6 — A search hit's identity resumes and exports
+## Follow-on ADRs (the mechanism carriers)
 
-`session.search` reads the mirror's `sessions` / `session_messages`, while `session.resume` and
-`session.export` operate on the T1 note store. A search result therefore returns a session identity —
-the mirror's `provider_session_id` (and its `sessions` row key) — and this ADR requires that identity
-to be **resolvable by `resume` and `export`**: a hit is not useful if it cannot be reopened or
-exported. The bridge is specified as part of this change (either `resume`/`export` accept the mirror
-session identity directly, or a defined resolution maps it), so every `session.search` result carries
-an identity guaranteed to resume and export. The caller-authored note store and the mirror store stay
-distinct per ADR-083; D6 bridges their identities for continuity, it does not merge the schemas.
+Each follow-on gets its own spec-gate pass. This direction ADR is signed off on the **coherence of its
+requirements**; each follow-on is signed off on **proof of its mechanism**.
+
+| Follow-on                                          | Carries                                                                                                                                                                                            | Hard conditions                                                                                                                                                                                                   |
+| -------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **ADR-117a** — session identity + tenant isolation | The scoped-identity migration (D2); the fail-closed handler-seam predicate keyed to the authenticated tenant (D4); the ADR-018 fail-closed-verb-class amendment; and `session.search` itself (D1). | The scoped-identity migration, the enforcement predicate, a cross-account isolation test, and a no-scope-refusal test all land **in the same PR** as the enforcement. `session.search` does not ship before this. |
+| **ADR-117b** — deletion + retention                | The deletion verb APIs and tombstone lifecycle, executable across every surface D5 enumerates; the storage-cap retention model and its oldest-first aging operation.                               | Deletion is proven complete across all enumerated surfaces, including the FTS index and (when present) vector rows and remote copies.                                                                             |
+| **ADR-117c** — continuity bridge                   | The single resume/export bridge for a search hit's identity (D6), resolved against ADR-083's UUID-only resolution.                                                                                 | Exactly one bridge shape, specified; no unresolved alternative.                                                                                                                                                   |
+| **ADR-117d** — remote cross-machine ingestion      | The principal-scoped ingestion backend (D3): authentication and credential-to-account binding, encrypted transport, origin verification and replay protection, enumerated failure modes.           | Off the v1 single-machine critical path; the identity (D2) and isolation (D4) requirements must hold across machines by design, not retrofit.                                                                     |
 
 ---
 
 ## Consequences
 
-**Enables.** Content search across an account's entire retained session history, spanning every
-machine that streams to it, resolvable back to resume/export. None of D1–D3 is useful alone: search
-without cross-machine ingestion sees one machine; ingestion without search is storage; either without
-D4 is unsafe to operate multi-tenant; search without D6 returns hits that cannot be reopened.
+**What this ADR delivers.** A coherent direction and a fixed set of requirements: the capability
+(`session.search`, FTS5-first), the identity property it needs, the ingestion model that later spans
+machines, the isolation property that makes it safe to operate multi-tenant, the deletion and retention
+model, and the continuity bridge back to resume/export. It delivers the **decomposition** into
+follow-ons that can each be proven at their own gate, and the sequencing and gating that binds them (D1
+gated on ADR-117a; the capability-consumption rule gating any dependence on the whole).
 
-**Cost.** The dominant cost is D2's future vector mode: embedding every message is compute and storage
+**What it does not deliver.** No schema, no verb implementation, no enforcement code, no test. Those
+are the follow-ons. Nothing in this ADR is a delivered property; the properties become real only as
+ADR-117a/b/c/d land with their proofs.
+
+**Cost.** The dominant future cost is D2's vector mode: embedding every message is compute and storage
 that scales with history size, which is why v1 is FTS5-only and the vector add is gated on khive#1121.
 Retrieval latency is the same shape measured for `memory.recall`, so khive#1116 and khive#1121 are
 direct cost levers on this capability.
 
-**Sensitivity.** Holding full transcript history is a data-sensitivity obligation. D3's authenticated
-ingestion, D4's fail-closed proven isolation, and D5's executable deletion are load-bearing for that
-reason, not optional polish.
+**Sensitivity.** Holding full transcript history is a data-sensitivity obligation. That is exactly why
+identity scoping (ADR-117a), fail-closed proven isolation (ADR-117a), authenticated ingestion
+(ADR-117d), and executable deletion (ADR-117b) are load-bearing requirements with their own gates, not
+optional polish folded into a direction.
 
-**Surface delta.** One new verb (`session.search`); one internal principal-scoped ingestion endpoint;
-deletion and retention verbs (D5); one ADR-018 amendment (the fail-closed verb class, D4); and the D6
-identity bridge for resume/export. The existing four T1 verbs are unchanged. The local single-source
-mirror remains for the single-machine case; the remote sink is an added ingestion mode, not a
-replacement.
+**Surface delta, once the follow-ons land.** One new verb (`session.search`); one internal
+principal-scoped ingestion endpoint; deletion and retention verbs; one ADR-018 amendment (the
+fail-closed verb class); and the continuity bridge for resume/export. The existing four T1 verbs are
+unchanged by this direction; if ADR-117c's chosen bridge extends `resume`/`export`, that change is
+specified and proven in ADR-117c, not assumed here. The local single-source mirror remains for the
+single-machine case; the remote sink is an added ingestion mode, not a replacement.
 
 ---
 
 ## Alternatives considered
 
+**One mega-ADR that specifies all mechanisms inline.** Rejected. Isolation, deletion, and continuity
+each carry a proof obligation — a schema migration, a deletion lifecycle, a resolved identity bridge —
+that a reviewer can and should check at source. Bundling all three into one document made each promise
+a claim the review could disprove against the actual schema and Gate contract, which is a structural
+reject loop, not a drafting problem. Splitting each mechanism to a focused follow-on with its own gate
+lets the direction land on requirement-coherence while each mechanism is proven where its proof lives.
+
 **Content-hash message identity.** Rejected as incorrect (D2): it collides identical messages across
-tenants and collapses legitimate repeated events, and it contradicts the mirror's shipped scoped-uuid
-idempotency key. The hash is retained as an integrity/dedup adjunct instead.
+tenants and collapses legitimate repeated events. The hash is retained as an integrity/dedup adjunct on
+the scoped id instead.
 
 **Gate-decision row isolation / relying on Gate fail-safety.** Rejected as unenforceable (D4): the
 ADR-018 Gate is pre-dispatch, sees no rows, and fails open, so row isolation cannot be a property of
-its decision. Enforcement is a mandatory authenticated-tenant predicate at the handler seam, fail-closed
-by requiring a positive scope, with an ADR-018 amendment codifying the fail-closed verb class.
+its decision. The isolation requirement is a mandatory authenticated-tenant predicate at the handler
+seam, fail-closed by requiring a positive scope — carried by ADR-117a.
 
 **A handler-level namespace filter on a caller-supplied namespace.** Rejected as forgeable and as the
 prior v1 anti-pattern (ADR-007): the scope must be the authenticated tenant, not a caller argument.
@@ -262,5 +317,5 @@ declared limit and makes aging an explicit, surfaced event.
 
 **Searching the caller-authored note store and the mirror as one corpus in v1.** Deferred, not
 adopted: ADR-083 keeps the two stores distinct by design. v1 searches the transcript text where the
-searchable content is, and D6 bridges the identity so hits resume and export; unifying the corpora is a
-later option, not a v1 requirement.
+searchable content is, and the continuity bridge (D6) reconnects hits to resume/export; unifying the
+corpora is a later option, not a v1 requirement.

--- a/docs/adr/ADR-117-session-continuity-search.md
+++ b/docs/adr/ADR-117-session-continuity-search.md
@@ -5,48 +5,54 @@
 **Authors**: khive maintainers
 **Depends on**:
 
-- [ADR-007](ADR-007-namespace.md) — Namespace as Attribution-Only Open String (the Gate is the
-  single authorization seam this ADR's tenant scoping is enforced at)
-- [ADR-013](ADR-013-note-kind-taxonomy.md) — Note Kind Taxonomy (the `session` note kind the
-  session pack registers)
+- [ADR-007](ADR-007-namespace.md) — Namespace as Attribution-Only Open String (Rule 8: a pack with
+  a principal-scoped backend carries its own isolation contract; the broker's server-side principal
+  scope is the Gate for that backend)
+- [ADR-013](ADR-013-note-kind-taxonomy.md) — Note Kind Taxonomy (the `session` note kind the T1 verbs
+  read and write)
+- [ADR-014](ADR-014-curation-operations.md) — Curation Operations (deletion is a curation-layer
+  operation that removes data, not a view-layer filter)
+- [ADR-018](ADR-018-authorization-gate.md) — Authorization Gate (the pre-dispatch `Gate::check`
+  contract this ADR's enforcement composes with, and whose fail-open default this ADR carves a
+  fail-closed verb class out of)
 - [ADR-021](ADR-021-memory-pack.md) — Memory Pack (the hybrid FTS + vector recall with RRF fusion
   this ADR reuses rather than re-implements)
-- [ADR-025](ADR-025-verb-speech-acts.md) — Verb Speech Acts (the Assertive category
-  `session.search` joins)
+- [ADR-025](ADR-025-verb-speech-acts.md) — Verb Speech Acts (the Assertive category `session.search`
+  joins)
 - [ADR-083](ADR-083-session-pack-t1-verbs.md) — Session Pack T1 Verb Surface (the existing
-  `store`/`list`/`resume`/`export` verbs and mirror this ADR extends)
+  `store`/`list`/`resume`/`export` verbs over the `notes` table, and the separate mirror aux tables
+  this ADR searches)
 
 ---
 
 ## Context
 
-The session pack (`khive-pack-session`) already persists agent-session transcripts. A background
-mirror service tails Claude Code, Codex CLI, and ChatGPT export files, parses each line into
-structured messages, and writes three tables: `sessions` (one row per transcript, carrying
-`provider_session_id`, source, cwd, git_branch, and timestamps), `session_messages` (the full
-message text plus the raw line), and `session_mirror_cursor` (a byte-offset cursor that makes the
-tail resumable and idempotent). Four verbs read and write this data: `session.store`,
-`session.list`, `session.resume`, `session.export`.
+The session pack (`khive-pack-session`) persists agent-session data in **two distinct stores**, a
+split that [ADR-083](ADR-083-session-pack-t1-verbs.md) makes deliberately:
 
-There is one capability the pack does not have: **search over message content**. `session.resume`
-fetches a single session by id; `session.list` is a recency-ordered browse. Neither can answer
-"which session was I working on the retrieval-fusion bug" or "find the session where I first
-sketched the blob cache." The message text is stored — it is simply not indexed for retrieval.
+1. **Caller-authored session notes.** The four T1 verbs (`session.store` / `list` / `resume` /
+   `export`) read and write the shared `notes` table. These are records a caller explicitly stores.
+2. **Passively-mirrored transcript tables.** A background mirror tails Claude Code, Codex CLI, and
+   ChatGPT exports and writes three auxiliary tables — `sessions` (one row per transcript, carrying
+   `provider_session_id`, source, cwd, git_branch, timestamps), `session_messages` (the parsed
+   message text plus raw line), and `session_mirror_cursor` (a byte-offset cursor). ADR-083 keeps
+   these separate from the notes precisely because one is caller-authored and one is passive
+   ingestion.
 
-Two properties of the existing design make this a build-out rather than a new subsystem:
+Each mirrored event already carries a **scoped identity**: `ParsedEvent.uuid` is the primary key for
+idempotency — the Claude Code top-level `uuid`, or the synthesized `"{session_id}:{byte_offset}"` for
+Codex, or the ChatGPT `message.id` (`crates/khive-pack-session/src/mirror/parse.rs`).
 
-1. The mirror already ingests from **multiple sources** and is cursor-resumable, so extending
-   ingestion to span multiple originating machines is a change of sink and source, not a rewrite.
-2. The memory pack already implements exactly the retrieval shape session search needs — hybrid
-   FTS5 + vector with reciprocal-rank fusion — over a different table. Session search is that same
-   shape over `session_messages`.
+The one capability neither store has is **search over message content**. `session.resume` fetches a
+single session by id; `session.list` is a recency browse. The transcript text sits in
+`session_messages` and is not indexed for retrieval.
 
-This ADR specifies the search capability, the ingestion model that lets a single logical account
-span multiple machines, the isolation contract that keeps one account's transcripts private in a
-multi-tenant deployment, and the retention and deletion model for what is the most sensitive data
-the substrate holds.
+This ADR specifies that search capability and the four contracts it cannot ship without: the identity
+model for mirrored messages, the ingestion model that lets one account span multiple machines, the
+tenant-isolation enforcement that keeps one account's transcripts unreachable by another, and the
+deletion and retention model for the most sensitive data the substrate holds.
 
-This ADR specifies the capability and its contract. It does not schedule the implementation.
+This ADR specifies the capability and its contracts. It does not schedule the implementation.
 
 ---
 
@@ -54,129 +60,207 @@ This ADR specifies the capability and its contract. It does not schedule the imp
 
 ### D1 — A `session.search` verb, FTS5 first
 
-Add one Assertive verb to the session pack:
+Add one Assertive verb:
 
 ```
 session.search(query, limit?, since?, source?, cwd?)
   -> [{ session, score, snippets }]
 ```
 
-It runs keyword retrieval over `session_messages.text`, scoped to the caller's namespace, and
-returns matching sessions ranked by score with the matching message snippets. The optional
+It runs keyword retrieval over `session_messages.text`, **scoped to the caller's authenticated
+tenant** (D4), and returns matching sessions ranked by score with the matching snippets. The optional
 filters narrow by recency (`since`), originating tool (`source`), and working directory (`cwd`).
 
-Version 1 is **FTS5-only**. Session-search queries are keyword-rich by nature — a user searching
-their own history remembers the terms they typed — and full-text retrieval covers that query
-class directly. FTS5 over `session_messages.text` needs an index and a triggered content table,
-following the same pattern the note substrate already uses.
+The search corpus is the mirror's `session_messages` — that is where transcript text lives.
+Caller-authored session notes (D-context store 1) are metadata records, not transcript text, and are
+out of the search corpus in v1; a returned hit's identity is nonetheless guaranteed to resume and
+export (D6).
 
-The verb's ranking and fusion primitives are shared with the memory pack (ADR-021), not
-re-implemented. When vector retrieval is added (D2), `session.search` gains a second signal fused
-by RRF exactly as `memory.recall` does; the verb signature does not change.
+Version 1 is **FTS5-only**. Session-search queries are keyword-rich by nature — a user searching their
+own history remembers the terms they typed — and full-text retrieval covers that query class
+directly. FTS5 over `session_messages.text` needs an index and a triggered content table, the same
+pattern the note substrate already uses. Ranking and fusion primitives are shared with the memory
+pack (ADR-021), not re-implemented; when vector retrieval is added (D2), `session.search` gains a
+second RRF-fused signal without a signature change.
 
-### D2 — Schema is embedding-ready; vector search is a gated later addition
+### D2 — Message identity is scoped; the content hash is an integrity adjunct
 
-Version 1 does not embed messages, but the schema is authored so that adding a vector signal later
-is a backfill, not a migration of live data:
+Message identity is the existing **scoped `ParsedEvent.uuid`** (provider / session / event scope),
+not a hash of content. This is a hard correctness requirement, not a preference:
 
-- `session_messages` rows are **content-addressed** (a stable hash of the message content), so a
-  later embedding-backfill job is idempotent and re-runnable without duplicating vectors or
-  re-embedding unchanged rows.
-- The vector addition is **gated on the per-engine retrieval parallelization work**
-  (khive#1121). Embedding every message means an embedding cost that scales with the size of a
-  user's history rather than their current activity, and vector recall rides the same serialized
-  per-engine retrieval path #1121 addresses. Adding a second retrieval signal before that path is
-  parallel would compound a known latency cost. This is the same sequencing constraint the
-  multi-engine default change applies (khive#1116): the more expensive retrieval mode does not
-  ship until the path that makes it affordable does.
+- A content-only identity **collides across tenants** — identical message text in two accounts would
+  map to one row, leaking or losing data across the isolation boundary.
+- A content-only identity **collapses legitimate repeated events** — the same text occurring twice in
+  one session (a command retyped, a repeated tool result) is two events, and hashing them to one
+  identity silently loses the second.
+- It would contradict the mirror's shipped design, where `ParsedEvent.uuid` is already the idempotency
+  key (`parse.rs`).
 
-Until vector search ships, the capability is described in every surface as **full-text search
-across sessions**, never semantic search — the contract must not advertise a signal that is not
-yet in the retrieval path.
+A content hash is still carried, but as a **dedup / integrity adjunct** on the scoped id, never the
+id: it detects whether a re-streamed event bearing the same scoped `uuid` carries the same content
+(integrity on idempotent re-stream), and it gates the future embedding-backfill so an unchanged event
+is not re-embedded. Idempotent backfill (D3) is provided by the scoped id — re-streaming the same
+provider/session/event is idempotent by that id — with the hash guarding content integrity.
 
-### D3 — Ingestion: the existing mirror with a remote sink
+The vector signal remains a gated later addition: the schema is embedding-ready (a stable per-event id
+plus the content hash make a later embed backfill idempotent and re-runnable), and the vector add is
+**gated on the per-engine retrieval parallelization work** (khive#1121) for the same reason the
+multi-engine default change (khive#1116) is — embedding every message is a cost that scales with
+history size, and vector recall rides the same serialized retrieval path #1121 addresses. Until vector
+search ships, every surface describes the capability as **full-text search across sessions**, never
+semantic search.
 
-Spanning multiple originating machines under one logical account does not require a new client
-tool. The existing mirror is extended with a **remote sink**: instead of writing to a local
-table, it streams parsed messages to a per-account ingestion endpoint. The endpoint is
-admin/bulk-shaped — a streaming ingestion path, not a per-message interactive verb round-trip —
-consistent with keeping long-running bulk work off the interactive verb surface.
+### D3 — Ingestion: a principal-scoped backend with an authenticated contract
 
-The byte-offset cursor already resolves what would otherwise be two separate code paths. A fresh
-machine's cursor starts at zero, so the same tail loop performs a cold bulk backfill of that
-machine's existing transcripts and then continues into live tailing, with no separate uploader.
-A one-shot upload of an archived transcript directory fast-follows against the same endpoint.
+Spanning multiple originating machines under one account is a **principal-scoped backend** in the
+sense of [ADR-007](ADR-007-namespace.md) Rule 8: the pack's own ADR (this one) defines the mechanism,
+authentication model, migration path, and failure modes, and the backend's **server-side per-principal
+scope is the Gate for that backend** (ADR-007 Rule 8 §3) — it composes with the single-seam
+authorization model, it does not sit outside it.
 
-Re-streaming is idempotent by construction: `provider_session_id` identifies the logical session
-and the content-addressed message rows (D2) dedup individual messages, so a machine re-syncing, or
-the same transcript arriving from a backup, never doubles a session.
+The existing mirror is extended with a **remote sink**: instead of writing a local table, it streams
+parsed events to a per-account ingestion endpoint. That endpoint carries a real contract, none of it
+optional:
 
-### D4 — Tenant scoping is Gate-enforced and proven, in the same change (hard requirement)
+- **Authentication and credential-to-account binding.** Every ingestion connection authenticates a
+  principal, and the authenticated principal — not any client-supplied namespace or account string —
+  determines which account the events land under. A client cannot assert another account's identity.
+- **Transport security.** The endpoint is reachable only over an encrypted transport.
+- **Origin verification and replay protection.** Requests are integrity-protected and carry
+  anti-replay material so a captured stream cannot be re-injected.
+- **Failure modes.** Authentication failure, integrity failure, and backend-unavailable are
+  enumerated with defined behavior (reject and surface, never silently accept or silently drop).
 
-Session transcripts contain everything a user typed and everything they were shown. In a
-multi-tenant deployment, one account's sessions must never be reachable by another account's
-query, and per ADR-007 that boundary is enforced at the Gate, not by a convenience filter in the
-handler.
+The endpoint is admin/bulk-shaped — a streaming ingestion path, not a per-message interactive verb
+round-trip — consistent with keeping long-running bulk work off the interactive verb surface.
 
-Therefore `session.search` lands **only together with** its Gate-enforced tenant scoping, in the
-same change, plus an isolation test that constructs a crafted cross-account query and asserts it
-returns nothing. The scoping is a property proven by test, not an aspiration documented in prose.
-A `session.search` that is not tenant-scoped by construction does not ship, even partially.
+The byte-offset cursor collapses what would otherwise be two code paths: a fresh machine's cursor
+starts at zero, so the same tail loop performs a cold bulk backfill of that machine's existing
+transcripts and then continues into live tailing, with no separate uploader tool. Re-streaming is
+idempotent by the **scoped event id** (D2) — a machine re-syncing, or the same transcript arriving
+from a backup, never doubles an event — with the content hash guarding integrity.
 
-This extends the same discipline the substrate already applies to multi-record reads: the default
-is the caller's own namespace, and the only widening is an explicit, authorized parameter the Gate
-evaluates.
+### D4 — Tenant isolation is fail-closed and enforced at a specified seam (hard requirement)
 
-### D5 — Retention bounded by a storage cap, with visible aging and user deletion
+Session transcripts contain everything a user typed and was shown. In a multi-tenant deployment one
+account's sessions must be unreachable by another account's query. Getting the enforcement mechanism
+right matters more than asserting the property, so this decision specifies the mechanism against the
+actual Gate contract.
 
-Retention is bounded by a configurable **storage cap**, not by a time window. Within the cap,
-history is kept indefinitely, so a search can reach back across the full retained span. When the
-cap is reached, the account ages out its oldest sessions first, and that aging is **always
-explicit and surfaced to the user** — never a silent background deletion.
+The [ADR-018](ADR-018-authorization-gate.md) Gate is a **pre-dispatch check over request metadata**
+(`actor`, `namespace`, `verb`, `args`, `context`) that returns Allow/Deny. It runs **before** the
+handler and therefore never sees matched rows; and by ADR-018's fifth principle it **fails open on
+infrastructure errors** (a Gate-infra failure logs a warning and proceeds; only an explicit `Deny`
+blocks). A search verb returns rows, so row-level isolation cannot be a property of the Gate's
+pre-dispatch decision, and it cannot rest on the Gate failing safely — it does not.
 
-Independent of the cap, **user-initiated deletion is available from day one**, at two
-granularities: a single session, and a full wipe of all session data for the account. Deletion is
-a curation-layer operation (ADR-014), not a view-layer filter: the data is removed, not hidden.
+Enforcement is therefore specified as follows:
+
+1. **The authenticated tenant is the scope.** The scope applied to a `session.search` query is the
+   caller's **authenticated** tenant (resolved from the authenticated principal / installed
+   `TenantGate`), never a caller-supplied `namespace` argument, which a caller could forge.
+2. **A mandatory query predicate at the handler seam.** The handler applies that authenticated tenant
+   as a non-widenable predicate on the search query, so rows outside the tenant are unreachable. This
+   is the enforcement seam — it is where rows exist, downstream of the Gate's authorization.
+3. **Fail-closed by construction.** `session.search` **requires a positive authenticated tenant
+   scope** to execute. Absent one — from any cause, including an authentication or Gate-infrastructure
+   error — the handler refuses and returns nothing. This means ADR-018's fail-open default cannot leak
+   session data: fail-open yields no authenticated scope, and no scope yields no results. To codify the
+   property at the contract level rather than rely only on the handler, ADR-018 is amended to designate
+   a **fail-closed verb class** (a Gate-infrastructure error is a `Deny` for these verbs);
+   `session.search` is the first member.
+4. **Proven by test, in the same change.** `session.search` lands **only together with** this
+   enforcement, plus an isolation test that issues a crafted cross-account query and asserts it returns
+   nothing, and a test that asserts the verb refuses when no authenticated scope is present. The
+   isolation is a property proven by test, not documented in prose.
+
+This is consistent with ADR-007: namespace is a policy input to the Gate and the authenticated tenant
+predicate, never a storage partition; the only difference between a permissive and an isolating
+deployment is which Gate/`TenantGate` is installed.
+
+### D5 — Deletion and retention are executable across every derived surface
+
+Retention is bounded by a configurable **storage cap**, not a time window. Within the cap, history is
+kept indefinitely, so search reaches back across the full retained span; at the cap the account ages
+out its oldest sessions first, and that aging is an **executable, surfaced** operation — never a silent
+background deletion.
+
+Independent of the cap, **user-initiated deletion is available from day one** at two granularities — a
+single session and a full account wipe — and both are **curation-layer** operations
+([ADR-014](ADR-014-curation-operations.md)) that remove data, not view-layer filters that hide it.
+Because the mirror data is spread across derived surfaces, the deletion contract enumerates each with
+verb-level semantics; deletion is not complete until every one is handled:
+
+- `session_messages` rows and the `sessions` row.
+- The FTS5 index (the triggered content table) — removed with the rows, so deleted content is not still
+  matchable.
+- Future vector rows (when D2's vector signal ships) — removed on the same path.
+- `session_mirror_cursor` — a deleted session is **tombstoned** by scoped id so a subsequent re-stream
+  of the same source file does not resurrect it.
+- Remote copies at the ingestion sink, and any in-flight / retry state for that account.
+- Any cached or hydrated search results.
+
+Retention aging is itself an executable oldest-first operation over the same surfaces.
+
+### D6 — A search hit's identity resumes and exports
+
+`session.search` reads the mirror's `sessions` / `session_messages`, while `session.resume` and
+`session.export` operate on the T1 note store. A search result therefore returns a session identity —
+the mirror's `provider_session_id` (and its `sessions` row key) — and this ADR requires that identity
+to be **resolvable by `resume` and `export`**: a hit is not useful if it cannot be reopened or
+exported. The bridge is specified as part of this change (either `resume`/`export` accept the mirror
+session identity directly, or a defined resolution maps it), so every `session.search` result carries
+an identity guaranteed to resume and export. The caller-authored note store and the mirror store stay
+distinct per ADR-083; D6 bridges their identities for continuity, it does not merge the schemas.
 
 ---
 
 ## Consequences
 
 **Enables.** Content search across an account's entire retained session history, spanning every
-machine that streams to it, is the capability D1 through D3 deliver together. None of the three is
-useful alone: search without cross-machine ingestion sees one machine; ingestion without search is
-storage; either without D4 is unsafe to operate multi-tenant.
+machine that streams to it, resolvable back to resume/export. None of D1–D3 is useful alone: search
+without cross-machine ingestion sees one machine; ingestion without search is storage; either without
+D4 is unsafe to operate multi-tenant; search without D6 returns hits that cannot be reopened.
 
-**Cost.** The dominant cost is D2's vector mode: embedding every message is compute and storage
-that scales with history size. FTS5-only v1 is comparatively cheap and is the reason v1 is the
-floor. Retrieval latency for session search is the same shape measured for `memory.recall`, so the
-retrieval-path work in khive#1116 and khive#1121 is a direct cost lever on this capability, not an
-unrelated lane.
+**Cost.** The dominant cost is D2's future vector mode: embedding every message is compute and storage
+that scales with history size, which is why v1 is FTS5-only and the vector add is gated on khive#1121.
+Retrieval latency is the same shape measured for `memory.recall`, so khive#1116 and khive#1121 are
+direct cost levers on this capability.
 
-**Sensitivity.** Holding full transcript history is a data-sensitivity obligation as much as a
-storage bill. D4's proven isolation and D5's user-initiated deletion are load-bearing for that
+**Sensitivity.** Holding full transcript history is a data-sensitivity obligation. D3's authenticated
+ingestion, D4's fail-closed proven isolation, and D5's executable deletion are load-bearing for that
 reason, not optional polish.
 
-**Surface delta.** One new verb (`session.search`) and one internal ingestion endpoint. The
-existing four session verbs are unchanged. The local single-source mirror remains for the
-single-machine case; the remote sink is an added ingestion mode, not a replacement.
+**Surface delta.** One new verb (`session.search`); one internal principal-scoped ingestion endpoint;
+deletion and retention verbs (D5); one ADR-018 amendment (the fail-closed verb class, D4); and the D6
+identity bridge for resume/export. The existing four T1 verbs are unchanged. The local single-source
+mirror remains for the single-machine case; the remote sink is an added ingestion mode, not a
+replacement.
 
 ---
 
 ## Alternatives considered
 
-**Vector search in v1.** Rejected for sequencing, not merit: it rides the un-parallelized
-per-engine retrieval path and embeds cost that scales with history. Deferred behind khive#1121 and
-made a schema-ready backfill (D2) rather than dropped.
+**Content-hash message identity.** Rejected as incorrect (D2): it collides identical messages across
+tenants and collapses legitimate repeated events, and it contradicts the mirror's shipped scoped-uuid
+idempotency key. The hash is retained as an integrity/dedup adjunct instead.
 
-**A separate uploader tool for cross-machine ingestion.** Rejected as redundant. The mirror's
-zero-cursor cold start already performs bulk backfill through the same loop as live tailing (D3),
-so a second tool would duplicate the ingestion and dedup logic.
+**Gate-decision row isolation / relying on Gate fail-safety.** Rejected as unenforceable (D4): the
+ADR-018 Gate is pre-dispatch, sees no rows, and fails open, so row isolation cannot be a property of
+its decision. Enforcement is a mandatory authenticated-tenant predicate at the handler seam, fail-closed
+by requiring a positive scope, with an ADR-018 amendment codifying the fail-closed verb class.
 
-**A time-window retention bound.** Rejected in favor of a storage cap (D5). A fixed time window
-either discards history a search should still reach or grows without bound; a storage cap keeps
-history reachable up to a declared limit and makes aging an explicit, surfaced event.
+**A handler-level namespace filter on a caller-supplied namespace.** Rejected as forgeable and as the
+prior v1 anti-pattern (ADR-007): the scope must be the authenticated tenant, not a caller argument.
 
-**Namespace-filter tenant scoping in the handler.** Rejected as unsafe. Per ADR-007 the
-authorization boundary is the Gate; a handler-level `WHERE namespace=` is a convenience, not a
-boundary, and for data this sensitive the isolation must be Gate-enforced and test-proven (D4).
+**A separate uploader tool for cross-machine ingestion.** Rejected as redundant (D3): the mirror's
+zero-cursor cold start already performs bulk backfill through the same loop as live tailing.
+
+**A time-window retention bound.** Rejected in favor of a storage cap (D5): a fixed window either
+discards history search should still reach or grows unbounded; a cap keeps history reachable up to a
+declared limit and makes aging an explicit, surfaced event.
+
+**Searching the caller-authored note store and the mirror as one corpus in v1.** Deferred, not
+adopted: ADR-083 keeps the two stores distinct by design. v1 searches the transcript text where the
+searchable content is, and D6 bridges the identity so hits resume and export; unifying the corpora is a
+later option, not a v1 requirement.

--- a/docs/adr/ADR-117-session-continuity-search.md
+++ b/docs/adr/ADR-117-session-continuity-search.md
@@ -1,0 +1,182 @@
+# ADR-117: Session Continuity — Cross-Session Search and Remote Ingestion
+
+**Status**: proposed
+**Date**: 2026-07-19
+**Authors**: khive maintainers
+**Depends on**:
+
+- [ADR-007](ADR-007-namespace.md) — Namespace as Attribution-Only Open String (the Gate is the
+  single authorization seam this ADR's tenant scoping is enforced at)
+- [ADR-013](ADR-013-note-kind-taxonomy.md) — Note Kind Taxonomy (the `session` note kind the
+  session pack registers)
+- [ADR-021](ADR-021-memory-pack.md) — Memory Pack (the hybrid FTS + vector recall with RRF fusion
+  this ADR reuses rather than re-implements)
+- [ADR-025](ADR-025-verb-speech-acts.md) — Verb Speech Acts (the Assertive category
+  `session.search` joins)
+- [ADR-083](ADR-083-session-pack-t1-verbs.md) — Session Pack T1 Verb Surface (the existing
+  `store`/`list`/`resume`/`export` verbs and mirror this ADR extends)
+
+---
+
+## Context
+
+The session pack (`khive-pack-session`) already persists agent-session transcripts. A background
+mirror service tails Claude Code, Codex CLI, and ChatGPT export files, parses each line into
+structured messages, and writes three tables: `sessions` (one row per transcript, carrying
+`provider_session_id`, source, cwd, git_branch, and timestamps), `session_messages` (the full
+message text plus the raw line), and `session_mirror_cursor` (a byte-offset cursor that makes the
+tail resumable and idempotent). Four verbs read and write this data: `session.store`,
+`session.list`, `session.resume`, `session.export`.
+
+There is one capability the pack does not have: **search over message content**. `session.resume`
+fetches a single session by id; `session.list` is a recency-ordered browse. Neither can answer
+"which session was I working on the retrieval-fusion bug" or "find the session where I first
+sketched the blob cache." The message text is stored — it is simply not indexed for retrieval.
+
+Two properties of the existing design make this a build-out rather than a new subsystem:
+
+1. The mirror already ingests from **multiple sources** and is cursor-resumable, so extending
+   ingestion to span multiple originating machines is a change of sink and source, not a rewrite.
+2. The memory pack already implements exactly the retrieval shape session search needs — hybrid
+   FTS5 + vector with reciprocal-rank fusion — over a different table. Session search is that same
+   shape over `session_messages`.
+
+This ADR specifies the search capability, the ingestion model that lets a single logical account
+span multiple machines, the isolation contract that keeps one account's transcripts private in a
+multi-tenant deployment, and the retention and deletion model for what is the most sensitive data
+the substrate holds.
+
+This ADR specifies the capability and its contract. It does not schedule the implementation.
+
+---
+
+## Decision
+
+### D1 — A `session.search` verb, FTS5 first
+
+Add one Assertive verb to the session pack:
+
+```
+session.search(query, limit?, since?, source?, cwd?)
+  -> [{ session, score, snippets }]
+```
+
+It runs keyword retrieval over `session_messages.text`, scoped to the caller's namespace, and
+returns matching sessions ranked by score with the matching message snippets. The optional
+filters narrow by recency (`since`), originating tool (`source`), and working directory (`cwd`).
+
+Version 1 is **FTS5-only**. Session-search queries are keyword-rich by nature — a user searching
+their own history remembers the terms they typed — and full-text retrieval covers that query
+class directly. FTS5 over `session_messages.text` needs an index and a triggered content table,
+following the same pattern the note substrate already uses.
+
+The verb's ranking and fusion primitives are shared with the memory pack (ADR-021), not
+re-implemented. When vector retrieval is added (D2), `session.search` gains a second signal fused
+by RRF exactly as `memory.recall` does; the verb signature does not change.
+
+### D2 — Schema is embedding-ready; vector search is a gated later addition
+
+Version 1 does not embed messages, but the schema is authored so that adding a vector signal later
+is a backfill, not a migration of live data:
+
+- `session_messages` rows are **content-addressed** (a stable hash of the message content), so a
+  later embedding-backfill job is idempotent and re-runnable without duplicating vectors or
+  re-embedding unchanged rows.
+- The vector addition is **gated on the per-engine retrieval parallelization work**
+  (khive#1121). Embedding every message means an embedding cost that scales with the size of a
+  user's history rather than their current activity, and vector recall rides the same serialized
+  per-engine retrieval path #1121 addresses. Adding a second retrieval signal before that path is
+  parallel would compound a known latency cost. This is the same sequencing constraint the
+  multi-engine default change applies (khive#1116): the more expensive retrieval mode does not
+  ship until the path that makes it affordable does.
+
+Until vector search ships, the capability is described in every surface as **full-text search
+across sessions**, never semantic search — the contract must not advertise a signal that is not
+yet in the retrieval path.
+
+### D3 — Ingestion: the existing mirror with a remote sink
+
+Spanning multiple originating machines under one logical account does not require a new client
+tool. The existing mirror is extended with a **remote sink**: instead of writing to a local
+table, it streams parsed messages to a per-account ingestion endpoint. The endpoint is
+admin/bulk-shaped — a streaming ingestion path, not a per-message interactive verb round-trip —
+consistent with keeping long-running bulk work off the interactive verb surface.
+
+The byte-offset cursor already resolves what would otherwise be two separate code paths. A fresh
+machine's cursor starts at zero, so the same tail loop performs a cold bulk backfill of that
+machine's existing transcripts and then continues into live tailing, with no separate uploader.
+A one-shot upload of an archived transcript directory fast-follows against the same endpoint.
+
+Re-streaming is idempotent by construction: `provider_session_id` identifies the logical session
+and the content-addressed message rows (D2) dedup individual messages, so a machine re-syncing, or
+the same transcript arriving from a backup, never doubles a session.
+
+### D4 — Tenant scoping is Gate-enforced and proven, in the same change (hard requirement)
+
+Session transcripts contain everything a user typed and everything they were shown. In a
+multi-tenant deployment, one account's sessions must never be reachable by another account's
+query, and per ADR-007 that boundary is enforced at the Gate, not by a convenience filter in the
+handler.
+
+Therefore `session.search` lands **only together with** its Gate-enforced tenant scoping, in the
+same change, plus an isolation test that constructs a crafted cross-account query and asserts it
+returns nothing. The scoping is a property proven by test, not an aspiration documented in prose.
+A `session.search` that is not tenant-scoped by construction does not ship, even partially.
+
+This extends the same discipline the substrate already applies to multi-record reads: the default
+is the caller's own namespace, and the only widening is an explicit, authorized parameter the Gate
+evaluates.
+
+### D5 — Retention bounded by a storage cap, with visible aging and user deletion
+
+Retention is bounded by a configurable **storage cap**, not by a time window. Within the cap,
+history is kept indefinitely, so a search can reach back across the full retained span. When the
+cap is reached, the account ages out its oldest sessions first, and that aging is **always
+explicit and surfaced to the user** — never a silent background deletion.
+
+Independent of the cap, **user-initiated deletion is available from day one**, at two
+granularities: a single session, and a full wipe of all session data for the account. Deletion is
+a curation-layer operation (ADR-014), not a view-layer filter: the data is removed, not hidden.
+
+---
+
+## Consequences
+
+**Enables.** Content search across an account's entire retained session history, spanning every
+machine that streams to it, is the capability D1 through D3 deliver together. None of the three is
+useful alone: search without cross-machine ingestion sees one machine; ingestion without search is
+storage; either without D4 is unsafe to operate multi-tenant.
+
+**Cost.** The dominant cost is D2's vector mode: embedding every message is compute and storage
+that scales with history size. FTS5-only v1 is comparatively cheap and is the reason v1 is the
+floor. Retrieval latency for session search is the same shape measured for `memory.recall`, so the
+retrieval-path work in khive#1116 and khive#1121 is a direct cost lever on this capability, not an
+unrelated lane.
+
+**Sensitivity.** Holding full transcript history is a data-sensitivity obligation as much as a
+storage bill. D4's proven isolation and D5's user-initiated deletion are load-bearing for that
+reason, not optional polish.
+
+**Surface delta.** One new verb (`session.search`) and one internal ingestion endpoint. The
+existing four session verbs are unchanged. The local single-source mirror remains for the
+single-machine case; the remote sink is an added ingestion mode, not a replacement.
+
+---
+
+## Alternatives considered
+
+**Vector search in v1.** Rejected for sequencing, not merit: it rides the un-parallelized
+per-engine retrieval path and embeds cost that scales with history. Deferred behind khive#1121 and
+made a schema-ready backfill (D2) rather than dropped.
+
+**A separate uploader tool for cross-machine ingestion.** Rejected as redundant. The mirror's
+zero-cursor cold start already performs bulk backfill through the same loop as live tailing (D3),
+so a second tool would duplicate the ingestion and dedup logic.
+
+**A time-window retention bound.** Rejected in favor of a storage cap (D5). A fixed time window
+either discards history a search should still reach or grows without bound; a storage cap keeps
+history reachable up to a declared limit and makes aging an explicit, surfaced event.
+
+**Namespace-filter tenant scoping in the handler.** Rejected as unsafe. Per ADR-007 the
+authorization boundary is the Gate; a handler-level `WHERE namespace=` is a convenience, not a
+boundary, and for data this sensitive the isolation must be Gate-enforced and test-proven (D4).

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -136,6 +136,7 @@ For historical context, see [v0 archive](../_archive/adr_v0/README.md). v0 ADRs 
 | [ADR-113](ADR-113-identifier-continuity.md)                  | Identifier Continuity — Merged-Entity Redirect Resolution and Split Endpoint-Move                     |
 | [ADR-114](ADR-114-code-audit-derived-report.md)              | Code-Audit Derived Report, Not Agent Findings                                                         |
 | [ADR-115](ADR-115-secret-gate-content-manifest-exemption.md) | Exact-Content Manifest Exemption for the Write Secret Gate                                            |
+| [ADR-117](ADR-117-session-continuity-search.md)              | Session Continuity — Cross-Session Search and Remote Ingestion                                        |
 
 ## Closed Taxonomies — Quick Reference
 


### PR DESCRIPTION
## ADR-117: Session Continuity — Cross-Session Search and Remote Ingestion

Docs-only. Adds `docs/adr/ADR-117-session-continuity-search.md` and its README index row.

### What it specifies

The session pack (`khive-pack-session`) already persists agent-session transcripts — a
background mirror tails Claude Code, Codex, and ChatGPT exports into `sessions` /
`session_messages` / `session_mirror_cursor`. The one capability it lacks is **search over
message content**: `session.resume` is fetch-by-id and `session.list` is a recency browse. The
text is stored; it is simply not indexed for retrieval.

ADR-117 specifies that capability and its contract:

- **D1** — a `session.search` verb, FTS5-first over `session_messages.text`, reusing the memory
  pack's fusion rather than re-implementing it.
- **D2** — the schema stays embedding-ready (content-addressed message rows so a later embed
  backfill is idempotent); a vector signal is a gated later addition, sequenced behind the
  per-engine retrieval parallelization work (#1121) for the same reason the multi-engine default
  change (#1116) is.
- **D3** — cross-machine ingestion is the existing mirror with a remote sink, not a new tool: a
  fresh machine's zero-offset cursor makes cold backfill and live tail one code path, and
  `provider_session_id` + content addressing make re-streaming idempotent.
- **D4** — tenant scoping is Gate-enforced (ADR-007) and lands **in the same change** as the
  verb, with an isolation test proving a cross-tenant query returns nothing. Blocking, not
  aspirational.
- **D5** — retention is bounded by a storage cap with visible oldest-first aging, plus day-one
  user-initiated deletion (single session and full wipe) as a curation-layer operation.

### Scope

Proposed. This ADR specifies the capability and its contract; it does not schedule the
implementation. Depends on ADR-007, ADR-013, ADR-021, ADR-025, ADR-083.
