### PR TITLE
chore(merge): bump crossbeam-epoch and memmap2 in the pinned lockfile

### DIFF
--- a/crates/khive-merge/Cargo.lock
+++ b/crates/khive-merge/Cargo.lock
@@ -442,9 +442,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -1479,9 +1479,9 @@ checksum = "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
 
 [[package]]
 name = "memmap2"
-version = "0.9.10"
+version = "0.9.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "714098028fe011992e1c3962653c96b2d578c4b4bce9036e15ff220319b1e0e3"
+checksum = "d1219ed1b7f229ee7104d281dd01d6802fe28bb6e95d292942c4daacdeb798c0"
 dependencies = [
  "libc",
 ]


### PR DESCRIPTION
Resolves the two locked dependency advisories in `crates/khive-merge/Cargo.lock` (committed and pinned via #1119):

- crossbeam-epoch 0.9.18 → 0.9.20 (RUSTSEC-2026-0204)
- memmap2 0.9.10 → 0.9.11 (RUSTSEC-2026-0186)

Verification: `cargo audit --file crates/khive-merge/Cargo.lock` now exits with only the pre-existing allowlisted warning (RUSTSEC-2026-0002), and `cargo check --locked` passes in the crate.

Lockfile-only change; no source edits.