### PR TITLE
docs(adr): ADR-079 Amendment 1 addendum — global-scope consumers and join-filtered corpora

### DIFF
--- a/docs/adr/ADR-079-ann-persistence-warm-path-integration.md
+++ b/docs/adr/ADR-079-ann-persistence-warm-path-integration.md
@@ -496,11 +496,15 @@ CREATE TABLE ann_consumer_watermark (
      `S`, the consumer raises its row monotonically
      (`UPDATE ... SET watermark = MAX(watermark, S)`); a crash in between leaves the smaller
      registered watermark, which under-compacts — safe.
-  3. **Compact through the registry minimum only.** Compaction deletes rows with
-     `seq <= (SELECT MIN(watermark) FROM ann_consumer_watermark WHERE namespace=? AND
-     embedding_model=?)` for the pair — never a checkpoint-local `seq <= S`. An empty row set
-     yields no deletion (consistent with rule 2's compaction ban). Never above any registered
-     watermark.
+  3. **Compact through the registry minimum only.** Compaction for a pair
+     `(namespace, embedding_model)` deletes rows with
+     `seq <= (SELECT MIN(watermark) FROM ann_consumer_watermark WHERE (namespace = ?ns OR
+     namespace = '*') AND embedding_model = ?model)` — never a checkpoint-local `seq <= S`. This
+     wildcard-inclusive form is the universal pair-compaction query: wildcard rows are global-scope
+     consumers' registrations (see "Global-scope consumers" below), and a database with none
+     reduces the query to the per-namespace minimum. An empty row set yields NULL, `seq <= NULL`
+     matches nothing, so an unregistered pair never compacts (consistent with rule 2's compaction
+     ban). Never above any registered watermark.
 
   Operational note: a decommissioned consumer's registry row pins the pair's `MIN` at its last
   watermark, so the log for that `(namespace, embedding_model)` grows unbounded until an operator
@@ -517,12 +521,11 @@ CREATE TABLE ann_consumer_watermark (
      `(consumer, '*', embedding_model, watermark)`. `'*'` is not a valid namespace value, so
      wildcard rows cannot collide with per-namespace rows. The register-at-0-before-persist and
      monotonic post-commit raise rules apply unchanged.
-  2. **Compaction minimum includes wildcard rows.** Step 3's minimum for a pair
-     `(namespace, embedding_model)` is computed over rows matching
-     `(namespace = ?ns OR namespace = '*') AND embedding_model = ?model`. A global consumer
-     thereby bounds compaction in every namespace its scope contains — including a namespace
-     whose first row appears after registration, because the wildcard row is durable before the
-     global consumer's first persist and therefore before any compaction its tail must survive.
+  2. **Compaction minimum includes wildcard rows.** Step 3's universal query already includes
+     wildcard rows in the pair's minimum. A global consumer thereby bounds compaction in every
+     namespace its scope contains — including a namespace whose first row appears after
+     registration, because the wildcard row is durable before the global consumer's first persist
+     and therefore before any compaction its tail must survive.
   3. **Classification is otherwise unchanged.** A global consumer classifies and tail-reads under
      its own corpus predicate (no namespace restriction); `seq` is a single database-wide
      monotone sequence, so watermark comparisons are well-defined across namespaces, and decision
@@ -600,8 +603,8 @@ never to serving a stale-but-adopted index.
 2. **Crash between `save_atomic` and log compaction**: the segment commits (staged files, fsync,
    rename, commit magic — existing v2 semantics) carrying `last_applied_seq = S` atomically
    inside its commit record. The registry raise and compaction
-   (`DELETE ... WHERE seq <= MIN(watermark)` over the pair's registered consumers, §A step 3)
-   run only after the commit, in that order. A crash before the raise leaves the smaller
+   (`DELETE ... WHERE seq <= MIN(watermark)` over the pair's registered rows, wildcard rows
+   included, §A step 3) run only after the commit, in that order. A crash before the raise leaves the smaller
    registered watermark (under-compacts); a crash before compaction leaves log rows with
    `seq <= S`, which the classifier's strict `seq > last_applied_seq` filter ignores; the next
    checkpoint re-raises and re-compacts. Idempotent, harmless.

--- a/docs/adr/ADR-079-ann-persistence-warm-path-integration.md
+++ b/docs/adr/ADR-079-ann-persistence-warm-path-integration.md
@@ -376,8 +376,11 @@ testable. Step 0 is the precondition; steps 1–2 land the #322 root-cause fix a
 
 ## Amendment 1 — Delta-log restart classifier and mmap re-adoption (2026-07-19)
 
-**Status**: Accepted (design; the implementation is tracked separately, and prior mechanisms
-remain operative until it lands)
+**Status**: Accepted
+
+This acceptance covers the design. Prior mechanisms remain operative in shipped code until the
+implementation lands; the ADR-107 supersession note carries the same boundary for the memory
+consumer.
 
 ### Context
 
@@ -456,6 +459,14 @@ CREATE TABLE ann_consumer_watermark (
   | 6 | `NOT EXISTS (SELECT 1 FROM ann_write_log WHERE <scope> AND seq > S)`                                       | **Hot**: mmap load, zero corpus IO. This is the post-compaction steady state — an empty scope (`MAX(seq)` NULL) with a valid watermark `S` is Hot, because every post-migration write logs a row and compaction only ever removes rows `<= S`                                                                                         |
   | 7 | tail rows exist, tail count ≤ `ceil(ann_rebuild_threshold × live vector_count)`                            | **Stale-tail**: mmap load, then final-state tail replay (below). §2 serve-stale applies while the tail applies. Rules 7-8 are reachable only with live vector count > 0 (rule 5 matched first otherwise)                                                                                                                              |
   | 8 | tail count above threshold                                                                                 | **Stale-rebuild** (amends the §2 state table): the checksum-valid segment loads and serves under the existing `ann_serve_stale` gate while a full rebuild runs in the background. The threshold is a cost decision, not evidence of unreadability — it never demotes a loadable segment to Cold/FTS-only                              |
+
+- **Evaluation order of rules 5 and 6.** An implementation may test rule 6's tail predicate (a
+  log-table-only query) before rule 5's live count, and adopt Hot without ever running the live
+  count. The outcomes coincide: with an empty tail, the committed segment already reflects every
+  logged op at or below `S`, so a zero-live scope implies the segment itself holds zero live
+  vectors and adoption serves exactly what Empty serves. This ordering is what makes the Hot
+  path's zero-corpus-IO property literal — the live corpus count is executed only when a tail
+  exists (rules 5, 7, and 8), where corpus-scale work is already inherent.
 
 - **Tail replay is a final-state delta, not an event replay.** Coalesce the tail to the highest
   `seq` per `subject_id`; only the final op is applied. A final `upsert` resolves the subject's

--- a/docs/adr/ADR-079-ann-persistence-warm-path-integration.md
+++ b/docs/adr/ADR-079-ann-persistence-warm-path-integration.md
@@ -507,6 +507,39 @@ CREATE TABLE ann_consumer_watermark (
   removes the row. Removal is an administrative action and is safe precisely because of decision
   rule 4: a returning consumer finds its row absent, re-registers at 0, and rebuilds Cold instead
   of trusting a segment whose tail may have been compacted away.
+
+- **Global-scope consumers.** Some consumers index one corpus across ALL namespaces for a model —
+  the memory pack's note index is the canonical case (a single graph over every namespace's
+  `kind = 'note' AND field = 'note.content'` rows). Per-namespace registry rows cannot represent
+  that scope: registering under any single namespace leaves the consumer's tail in every other
+  namespace unprotected, and namespaces can appear after registration. Instead:
+  1. **Wildcard registration.** A global-scope consumer registers exactly one row per model:
+     `(consumer, '*', embedding_model, watermark)`. `'*'` is not a valid namespace value, so
+     wildcard rows cannot collide with per-namespace rows. The register-at-0-before-persist and
+     monotonic post-commit raise rules apply unchanged.
+  2. **Compaction minimum includes wildcard rows.** Step 3's minimum for a pair
+     `(namespace, embedding_model)` is computed over rows matching
+     `(namespace = ?ns OR namespace = '*') AND embedding_model = ?model`. A global consumer
+     thereby bounds compaction in every namespace its scope contains — including a namespace
+     whose first row appears after registration, because the wildcard row is durable before the
+     global consumer's first persist and therefore before any compaction its tail must survive.
+  3. **Classification is otherwise unchanged.** A global consumer classifies and tail-reads under
+     its own corpus predicate (no namespace restriction); `seq` is a single database-wide
+     monotone sequence, so watermark comparisons are well-defined across namespaces, and decision
+     rule 4 applies to the wildcard row exactly as to a per-namespace row.
+
+  **Soft-delete visibility (join-filtered corpora).** The memory corpus excludes soft-deleted
+  notes via a join on `notes.deleted_at IS NULL`, but a note soft-delete mutates the notes row,
+  not the vector row — no log row is appended. A Hot-classified segment may therefore retain
+  soft-deleted subjects as candidates until the next vector mutation or checkpoint. This is a
+  candidate-hygiene lag, not a correctness gap: the memory recall path post-filters every ANN
+  candidate on `deleted_at IS NULL` (plus namespace visibility and expiry) before serving, so
+  deleted content is never returned. A consumer whose serve path lacks such a filter MUST NOT
+  adopt this amendment for a join-filtered corpus. For such corpora, tail replay measures "source
+  row missing" under the full corpus predicate (join included): a final `upsert` whose subject no
+  longer satisfies the predicate replays as a delete — the subject's final corpus state is
+  absence — rather than escalating to Cold, which is reserved for id-map/log state that
+  contradicts a subject the predicate still admits.
 - **Configuration (§5 amendment)**: `ann_rebuild_threshold` joins the `[retrieval]` table —
   fraction of the index's live vector count, `f64` in `(0, 1]`, default `0.20`, env
   `KHIVE_ANN_REBUILD_THRESHOLD`, CLI `--ann-rebuild-threshold`, precedence per ADR-035. The tail

--- a/docs/adr/ADR-079-ann-persistence-warm-path-integration.md
+++ b/docs/adr/ADR-079-ann-persistence-warm-path-integration.md
@@ -146,9 +146,10 @@ snapshot store (`khive-retrieval/src/persist/core.rs`), the admin reindex invali
 knowledge pack's own rows** (`index_type='vamana'` under the `{ns}::vamana::{model}` key): the bridge
 stops _writing_ them and, on first warm after upgrade, ignores any present-but-orphaned knowledge row
 (a rebuild produces v2 segments instead). The table itself and every other consumer's rows are
-untouched. **No table-drop migration is in scope.** Migrating the memory pack and the
-retrieval-persist layer onto v2 segments — if ever desired — is a separate ADR coordinating all
-consumers and all create sites.
+untouched. **No table-drop migration is in scope.** The memory pack's migration onto v2 segments
+is now specified by Amendment 1's global-scope-consumer addendum below (coordinated through the
+ADR-107 supersession note); the retrieval-persist layer remains out of scope and would need its
+own coordination across consumers and create sites.
 
 This is consistent with khive's data-vs-view principle: the authoritative vectors remain in the
 vector store; the ANN segment directory is a rebuildable index over them, not a second source of
@@ -375,7 +376,8 @@ testable. Step 0 is the precondition; steps 1–2 land the #322 root-cause fix a
 
 ## Amendment 1 — Delta-log restart classifier and mmap re-adoption (2026-07-19)
 
-**Status**: Proposed
+**Status**: Accepted (design; the implementation is tracked separately, and prior mechanisms
+remain operative until it lands)
 
 ### Context
 
@@ -497,8 +499,10 @@ CREATE TABLE ann_consumer_watermark (
      (`UPDATE ... SET watermark = MAX(watermark, S)`); a crash in between leaves the smaller
      registered watermark, which under-compacts — safe.
   3. **Compact through the registry minimum only.** Compaction for a pair
-     `(namespace, embedding_model)` deletes rows with
-     `seq <= (SELECT MIN(watermark) FROM ann_consumer_watermark WHERE (namespace = ?ns OR
+     `(namespace, embedding_model)` constrains the delete to that pair explicitly — `seq` values
+     are database-global, so an unconstrained delete would erase other pairs' tails:
+     `DELETE FROM ann_write_log WHERE namespace = ?ns AND embedding_model = ?model AND
+     seq <= (SELECT MIN(watermark) FROM ann_consumer_watermark WHERE (namespace = ?ns OR
      namespace = '*') AND embedding_model = ?model)` — never a checkpoint-local `seq <= S`. This
      wildcard-inclusive form is the universal pair-compaction query: wildcard rows are global-scope
      consumers' registrations (see "Global-scope consumers" below), and a database with none
@@ -603,8 +607,9 @@ never to serving a stale-but-adopted index.
 2. **Crash between `save_atomic` and log compaction**: the segment commits (staged files, fsync,
    rename, commit magic — existing v2 semantics) carrying `last_applied_seq = S` atomically
    inside its commit record. The registry raise and compaction
-   (`DELETE ... WHERE seq <= MIN(watermark)` over the pair's registered rows, wildcard rows
-   included, §A step 3) run only after the commit, in that order. A crash before the raise leaves the smaller
+   (the pair-constrained delete of §A step 3 — outer `WHERE namespace = ?ns AND
+   embedding_model = ?model`, subquery over the pair's registered rows, wildcard rows
+   included) run only after the commit, in that order. A crash before the raise leaves the smaller
    registered watermark (under-compacts); a crash before compaction leaves log rows with
    `seq <= S`, which the classifier's strict `seq > last_applied_seq` filter ignores; the next
    checkpoint re-raises and re-compacts. Idempotent, harmless.
@@ -640,7 +645,7 @@ The expected case is orders of magnitude smaller: a typical restart tail is one 
 
 ### Lever inventory (full residency budget, with projections)
 
-Levers named per review request, including rejected ones, at current corpus (~553K entity/note +
+Levers considered, including rejected ones, at current corpus (~553K entity/note +
 ~358K knowledge-section vectors, 384-d f32):
 
 | Lever                                                            | Projected saving                                                                                                              | Cost / risk                                                                                      | Disposition                                                                                                                                                                               |

--- a/docs/adr/ADR-107-memory-ann-lifecycle.md
+++ b/docs/adr/ADR-107-memory-ann-lifecycle.md
@@ -266,9 +266,9 @@ leaking through.
   documented) are not served by this contract and must poll `memory.recall` or wait
   for the rebuild to observably complete via `memory.feedback`/index inspection; this
   ADR does not add a synchronous variant.
-- Future work extending ADR-079's v2 segment format to the memory pack would supersede
-  §4's memory-pack-specific hash with ADR-079's own content-hash mechanism; that
-  migration is out of scope for this ADR.
+- ADR-079 Amendment 1's global-scope addendum has since extended its delta-log/watermark
+  classifier to the memory index, superseding §4's memory-pack-specific hash — see the
+  Supersession note at the top of this ADR.
 - A write that lands after the self-driving re-enqueue loop (§2) has already fully
   exited — whether by converging or by hitting its 3-attempt cap — does not need a
   normal write-path call to `ensure_ann_background` to be picked up: if the

--- a/docs/adr/ADR-107-memory-ann-lifecycle.md
+++ b/docs/adr/ADR-107-memory-ann-lifecycle.md
@@ -10,7 +10,9 @@
 
 [ADR-079](ADR-079-ann-persistence-warm-path-integration.md) Amendment 1's global-scope-consumer
 addendum extends the delta-log/watermark restart classifier to the memory pack's note index. Two
-provisions of this ADR are superseded by it:
+provisions of this ADR are superseded by it. The supersession takes effect when the Amendment 1
+implementation for this consumer lands; until then the hash-based restart validation specified
+here remains the operative mechanism in shipped code:
 
 - **The scope exclusion.** The Context statement that ADR-079 "explicitly excludes memory-pack
   migration" and that this ADR "does not extend ADR-079's scope to the memory pack" no longer

--- a/docs/adr/ADR-107-memory-ann-lifecycle.md
+++ b/docs/adr/ADR-107-memory-ann-lifecycle.md
@@ -1,7 +1,8 @@
 # ADR-107: Memory ANN Lifecycle — Eventual Consistency Contract
 
-**Status**: Accepted; partially superseded by the ADR-079 Amendment 1 addendum
+**Status**: Accepted
 **Date**: 2026-07-10
+**Superseded in part**: restart validation and scope provisions, by the [ADR-079](ADR-079-ann-persistence-warm-path-integration.md) Amendment 1 addendum (details in the Supersession note below)
 **Depends on**: [ADR-021](ADR-021-memory-pack.md) (Memory Pack), [ADR-079](ADR-079-ann-persistence-warm-path-integration.md) (ANN persistence warm-path integration, knowledge pack scope)
 **References**: issue #791, PR #812
 

--- a/docs/adr/ADR-107-memory-ann-lifecycle.md
+++ b/docs/adr/ADR-107-memory-ann-lifecycle.md
@@ -2,7 +2,6 @@
 
 **Status**: Accepted
 **Date**: 2026-07-10
-**Superseded in part**: restart validation and scope provisions, by the [ADR-079](ADR-079-ann-persistence-warm-path-integration.md) Amendment 1 addendum (details in the Supersession note below)
 **Depends on**: [ADR-021](ADR-021-memory-pack.md) (Memory Pack), [ADR-079](ADR-079-ann-persistence-warm-path-integration.md) (ANN persistence warm-path integration, knowledge pack scope)
 **References**: issue #791, PR #812
 

--- a/docs/adr/ADR-107-memory-ann-lifecycle.md
+++ b/docs/adr/ADR-107-memory-ann-lifecycle.md
@@ -1,9 +1,41 @@
 # ADR-107: Memory ANN Lifecycle — Eventual Consistency Contract
 
-**Status**: Accepted
+**Status**: Accepted (restart-validation and scope provisions superseded — see Supersession note)
 **Date**: 2026-07-10
 **Depends on**: [ADR-021](ADR-021-memory-pack.md) (Memory Pack), [ADR-079](ADR-079-ann-persistence-warm-path-integration.md) (ANN persistence warm-path integration, knowledge pack scope)
 **References**: issue #791, PR #812
+
+## Supersession note (2026-07-19)
+
+[ADR-079](ADR-079-ann-persistence-warm-path-integration.md) Amendment 1's global-scope-consumer
+addendum extends the delta-log/watermark restart classifier to the memory pack's note index. Two
+provisions of this ADR are superseded by it:
+
+- **The scope exclusion.** The Context statement that ADR-079 "explicitly excludes memory-pack
+  migration" and that this ADR "does not extend ADR-079's scope to the memory pack" no longer
+  holds: the memory note index is Amendment 1's canonical global-scope consumer, registering one
+  wildcard `(consumer, '*', embedding_model, watermark)` row.
+- **§4 Restart validation.** The persisted `CorpusContentHash` and its full restart re-scan are
+  replaced by Amendment 1's decision table: restart freshness is established by comparing the
+  segment's committed `last_applied_seq` watermark against the `ann_write_log` tail under the
+  consumer's own corpus predicate, with final-state tail replay for small tails. The two gaps §4's
+  hash closed remain closed by construction — same-cardinality replacement appends log rows (tail
+  non-empty → Stale, never Hot), and the watermark is captured in the same SQLite read snapshot as
+  the build's corpus scan, so no separately-sampled-signal race exists. §4's requirement is
+  retired, not weakened: a restart never trusts a segment on count/dimension agreement alone.
+
+One consequence of the replacement is a new obligation on §4's reindex discussion: Amendment 1's
+write-path rule (every vector mutation appends a log row in the same transaction) now binds every
+write path, including `kkernel reindex`'s direct embedding overwrites. A re-embed that bypassed the
+log would classify Hot on stale bytes at the next restart; the reindex path must therefore append
+`upsert` log rows for every row it overwrites (its snapshot-row deletion becomes moot once the
+JSON snapshot path is retired).
+
+Everything else in this ADR remains normative and unchanged: the stale bound (§1), the
+write-generation bump / high-water re-enqueue rebuild trigger and non-eviction contract (§2), Cold
+behavior (§3), the durable-epoch cross-process invalidation for warm daemons (§4's epoch
+paragraphs), and deletion filtering (§5). The classifier replaces only what a restart validates
+against — not the in-process eventual-consistency contract.
 
 ## Context
 

--- a/docs/adr/ADR-107-memory-ann-lifecycle.md
+++ b/docs/adr/ADR-107-memory-ann-lifecycle.md
@@ -1,6 +1,6 @@
 # ADR-107: Memory ANN Lifecycle — Eventual Consistency Contract
 
-**Status**: Accepted (restart-validation and scope provisions superseded — see Supersession note)
+**Status**: Accepted; partially superseded by the ADR-079 Amendment 1 addendum
 **Date**: 2026-07-10
 **Depends on**: [ADR-021](ADR-021-memory-pack.md) (Memory Pack), [ADR-079](ADR-079-ann-persistence-warm-path-integration.md) (ANN persistence warm-path integration, knowledge pack scope)
 **References**: issue #791, PR #812

--- a/docs/adr/ADR-117-session-continuity-search.md
+++ b/docs/adr/ADR-117-session-continuity-search.md
@@ -291,10 +291,10 @@ single-machine case; the remote sink is an added ingestion mode, not a replaceme
 
 **One mega-ADR that specifies all mechanisms inline.** Rejected. Isolation, deletion, and continuity
 each carry a proof obligation — a schema migration, a deletion lifecycle, a resolved identity bridge —
-that a reviewer can and should check at source. Bundling all three into one document made each promise
-a claim the review could disprove against the actual schema and Gate contract, which is a structural
-reject loop, not a drafting problem. Splitting each mechanism to a focused follow-on with its own gate
-lets the direction land on requirement-coherence while each mechanism is proven where its proof lives.
+that must be checked against the actual schema and Gate contract. Bundling all three into one document
+couples every mechanism's acceptance to the slowest-to-prove one. Splitting each mechanism into a
+focused follow-on lets the direction land on requirement-coherence while each mechanism is proven
+where its proof lives.
 
 **Content-hash message identity.** Rejected as incorrect (D2): it collides identical messages across
 tenants and collapses legitimate repeated events. The hash is retained as an integrity/dedup adjunct on


### PR DESCRIPTION
Extends the just-merged Amendment 1 (#1128) with the contract needed for the memory pack's namespace-global note index before its implementation lands:

- **Wildcard registration**: a consumer whose corpus spans all namespaces for a model registers one `(consumer, '*', embedding_model, watermark)` row; register-at-0-before-persist and monotonic raise apply unchanged.
- **Compaction minimum includes wildcard rows**: pair compaction computes its MIN over `namespace = ?ns OR namespace = '*'`, so a global consumer's tail survives in namespaces that first appear after registration.
- **Classification unchanged**: global consumers classify and tail-read under their own corpus predicate; `seq` is database-wide monotone; decision rule 4 applies to the wildcard row as to any row.
- **Soft-delete visibility for join-filtered corpora**: note soft-deletes append no log row, so a Hot segment may retain soft-deleted candidates until the next checkpoint; the recall path's `deleted_at IS NULL` post-filter hides them at serve time, and consumers without such a filter must not adopt the amendment for a join-filtered corpus. Tail replay measures source-row absence under the full corpus predicate: a final upsert whose subject fails the predicate replays as a delete, not a Cold escalation.

Docs-only. Blocks the memory-pack implementation PR; the knowledge-pack implementation is independent of this addendum.