### PR TITLE
feat(ann): write-log restart classifier, codes.bin mmap segment, and consumer watermark registry (ADR-079 Amendment 1)

### DIFF
--- a/crates/khive-db/sql/011-ann-write-log.sql
+++ b/crates/khive-db/sql/011-ann-write-log.sql
@@ -1,14 +1,32 @@
 -- ANN write log: per-vector-write delta records consumed by the restart
 -- classifier (ADR-079 Amendment 1). AUTOINCREMENT is load-bearing: seq must be
 -- strictly monotone and never reused so a persisted watermark stays comparable
--- across log compactions.
+-- across log compactions. kind/field carry the vector row's own scope so a
+-- consumer whose corpus is a subset of a shared vec table can filter its tail
+-- with the same predicate as its corpus scan.
 CREATE TABLE IF NOT EXISTS ann_write_log (
     seq             INTEGER PRIMARY KEY AUTOINCREMENT,
     namespace       TEXT NOT NULL,
     embedding_model TEXT NOT NULL,
+    kind            TEXT NOT NULL,
+    field           TEXT NOT NULL,
     subject_id      TEXT NOT NULL,
     op              TEXT NOT NULL CHECK (op IN ('upsert', 'delete'))
 );
 
 CREATE INDEX IF NOT EXISTS idx_ann_write_log_ns_model_seq
     ON ann_write_log (namespace, embedding_model, seq);
+
+-- Durable per-consumer watermark registry gating log compaction. A consumer
+-- registers its row at watermark 0 (INSERT OR IGNORE) before persisting or
+-- serving any extended-format segment, then raises it monotonically after each
+-- segment commit. Compaction deletes only seq <= MIN(watermark) over the
+-- (namespace, embedding_model) pair's registered rows, so a stale or
+-- crash-frozen row under-compacts (safe) and never hides a consumer's tail.
+CREATE TABLE IF NOT EXISTS ann_consumer_watermark (
+    consumer        TEXT NOT NULL,
+    namespace       TEXT NOT NULL,
+    embedding_model TEXT NOT NULL,
+    watermark       INTEGER NOT NULL,
+    PRIMARY KEY (consumer, namespace, embedding_model)
+);

--- a/crates/khive-db/sql/011-ann-write-log.sql
+++ b/crates/khive-db/sql/011-ann-write-log.sql
@@ -1,0 +1,14 @@
+-- ANN write log: per-vector-write delta records consumed by the restart
+-- classifier (ADR-079 Amendment 1). AUTOINCREMENT is load-bearing: seq must be
+-- strictly monotone and never reused so a persisted watermark stays comparable
+-- across log compactions.
+CREATE TABLE IF NOT EXISTS ann_write_log (
+    seq             INTEGER PRIMARY KEY AUTOINCREMENT,
+    namespace       TEXT NOT NULL,
+    embedding_model TEXT NOT NULL,
+    subject_id      TEXT NOT NULL,
+    op              TEXT NOT NULL CHECK (op IN ('upsert', 'delete'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_ann_write_log_ns_model_seq
+    ON ann_write_log (namespace, embedding_model, seq);

--- a/crates/khive-db/src/backend.rs
+++ b/crates/khive-db/src/backend.rs
@@ -608,6 +608,16 @@ impl StorageBackend {
         self.path.as_ref()?.parent().map(|p| p.to_path_buf())
     }
 
+    /// Root directory for this database's ANN segment tree, or `None` for an
+    /// in-memory backend. Derived from the database file name itself
+    /// (`<db-file>.ann/` beside the file), so two databases sharing a parent
+    /// directory can never adopt each other's segments or UUID maps.
+    pub fn ann_root(&self) -> Option<std::path::PathBuf> {
+        let path = self.path.as_ref()?;
+        let file = path.file_name()?.to_string_lossy();
+        path.parent().map(|p| p.join(format!("{file}.ann")))
+    }
+
     /// Access the underlying pool (escape hatch).
     pub fn pool(&self) -> &ConnectionPool {
         &self.pool

--- a/crates/khive-db/src/backend.rs
+++ b/crates/khive-db/src/backend.rs
@@ -392,6 +392,13 @@ impl StorageBackend {
             .conn()
             .execute_batch(crate::migrations::EMBEDDING_MODELS_DDL)?;
 
+        // Same guarantee for the ANN write log: vector write paths append to it
+        // in the same transaction as the vec0 mutation, so it must exist in any
+        // database that hosts vec_* tables.
+        writer
+            .conn()
+            .execute_batch(crate::migrations::ANN_WRITE_LOG_DDL)?;
+
         // Create the vec0 virtual table. Idempotent on fresh databases and after the
         // old-schema rebuild above.
         let ddl = format!(

--- a/crates/khive-db/src/backend.rs
+++ b/crates/khive-db/src/backend.rs
@@ -611,11 +611,12 @@ impl StorageBackend {
     /// Root directory for this database's ANN segment tree, or `None` for an
     /// in-memory backend. Derived from the database file name itself
     /// (`<db-file>.ann/` beside the file), so two databases sharing a parent
-    /// directory can never adopt each other's segments or UUID maps.
+    /// directory can never adopt each other's segments or UUID maps. The
+    /// suffix is appended at the `OsString` byte level — a lossy UTF-8
+    /// conversion would collapse distinct non-UTF-8 filenames into one
+    /// replacement-character root, breaking exactly that isolation.
     pub fn ann_root(&self) -> Option<std::path::PathBuf> {
-        let path = self.path.as_ref()?;
-        let file = path.file_name()?.to_string_lossy();
-        path.parent().map(|p| p.join(format!("{file}.ann")))
+        ann_root_for(self.path.as_ref()?)
     }
 
     /// Access the underlying pool (escape hatch).
@@ -627,6 +628,16 @@ impl StorageBackend {
     pub fn pool_arc(&self) -> Arc<ConnectionPool> {
         Arc::clone(&self.pool)
     }
+}
+
+/// `<db-file>.ann` sibling of a database file, appended at the `OsString`
+/// byte level: a lossy UTF-8 conversion would collapse distinct non-UTF-8
+/// filenames into one replacement-character root, breaking the per-database
+/// segment isolation that `ann_root` exists to guarantee.
+fn ann_root_for(path: &std::path::Path) -> Option<std::path::PathBuf> {
+    let mut file = path.file_name()?.to_os_string();
+    file.push(".ann");
+    path.parent().map(|p| p.join(file))
 }
 
 #[cfg(test)]
@@ -662,6 +673,35 @@ mod tests {
         let backend = StorageBackend::sqlite(&path).expect("file backend");
         let got = backend.data_dir().expect("file backend must return Some");
         assert_eq!(got, dir.path());
+    }
+
+    #[test]
+    fn ann_root_is_database_scoped_sibling_dir() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("data.db");
+        let backend = StorageBackend::sqlite(&path).expect("file backend");
+        let got = backend.ann_root().expect("file backend must return Some");
+        assert_eq!(got, dir.path().join("data.db.ann"));
+        assert!(StorageBackend::memory().unwrap().ann_root().is_none());
+    }
+
+    /// Two distinct non-UTF-8 database filenames must never share an ANN
+    /// root: a lossy UTF-8 conversion collapses both to the replacement
+    /// character, letting one database adopt the other's segments. Exercised
+    /// on the path derivation directly — APFS (macOS CI) refuses to create
+    /// files with non-UTF-8 names, so a real backend cannot be opened there.
+    #[cfg(unix)]
+    #[test]
+    fn ann_root_distinct_for_non_utf8_filenames() {
+        use std::os::unix::ffi::OsStrExt;
+        let path_a = std::path::Path::new("/data").join(std::ffi::OsStr::from_bytes(b"\xff.db"));
+        let path_b = std::path::Path::new("/data").join(std::ffi::OsStr::from_bytes(b"\xfe.db"));
+        let root_a = ann_root_for(&path_a).expect("Some for a file path");
+        let root_b = ann_root_for(&path_b).expect("Some for a file path");
+        assert_ne!(
+            root_a, root_b,
+            "distinct database files must map to distinct ANN roots"
+        );
     }
 
     #[tokio::test]

--- a/crates/khive-db/src/migrations.rs
+++ b/crates/khive-db/src/migrations.rs
@@ -120,6 +120,17 @@ const V9_UP: &str = include_str!("../sql/009-entities-name-ci-index.sql");
 
 const V10_UP: &str = include_str!("../sql/010-entities-content-ref.sql");
 
+const V11_UP: &str = include_str!("../sql/011-ann-write-log.sql");
+
+/// DDL for the `ann_write_log` delta table.
+///
+/// Shared between migration V11 and the belt-and-suspenders creation in
+/// `StorageBackend::vectors_for_namespace` (same pattern as
+/// [`EMBEDDING_MODELS_DDL`]): every database that hosts `vec_*` tables must
+/// also have the write log, or vector writes would fail on databases opened
+/// without `run_migrations()`. The `.sql` file is `IF NOT EXISTS`-idempotent.
+pub const ANN_WRITE_LOG_DDL: &str = V11_UP;
+
 /// DDL for the `_embedding_models` registry table.
 ///
 /// Shared between the V1 schema and the belt-and-suspenders creation in
@@ -178,6 +189,11 @@ pub const MIGRATIONS: &[VersionedMigration] = &[
         version: 10,
         name: "entities_content_ref",
         up: V10_UP,
+    },
+    VersionedMigration {
+        version: 11,
+        name: "ann_write_log",
+        up: V11_UP,
     },
 ];
 

--- a/crates/khive-db/src/stores/vectors.rs
+++ b/crates/khive-db/src/stores/vectors.rs
@@ -379,11 +379,13 @@ fn replace_vector_row_dml(
     // Delta record for the ANN restart classifier; rides the caller's
     // savepoint/transaction so a rolled-back upsert leaves no log row.
     conn.execute(
-        "INSERT INTO ann_write_log (namespace, embedding_model, subject_id, op) \
-         VALUES (?1, ?2, ?3, 'upsert')",
+        "INSERT INTO ann_write_log (namespace, embedding_model, kind, field, subject_id, op) \
+         VALUES (?1, ?2, ?3, ?4, ?5, 'upsert')",
         rusqlite::params![
             row.namespace,
             row.embedding_model,
+            row.kind,
+            row.field,
             row.subject_id.to_string()
         ],
     )?;
@@ -402,8 +404,8 @@ fn log_vector_deletes(
     params: &[&dyn rusqlite::ToSql],
 ) -> Result<(), rusqlite::Error> {
     let sql = format!(
-        "INSERT INTO ann_write_log (namespace, embedding_model, subject_id, op) \
-         SELECT namespace, embedding_model, subject_id, 'delete' \
+        "INSERT INTO ann_write_log (namespace, embedding_model, kind, field, subject_id, op) \
+         SELECT namespace, embedding_model, kind, field, subject_id, 'delete' \
          FROM {table} WHERE {where_clause}"
     );
     conn.execute(&sql, params)?;
@@ -1537,6 +1539,10 @@ mod batch_exists_tests {
             model_key, dims
         );
         writer.conn().execute_batch(&ddl).expect("create vec table");
+        writer
+            .conn()
+            .execute_batch(crate::migrations::ANN_WRITE_LOG_DDL)
+            .expect("create ann_write_log");
     }
 
     /// Valid (underscored) model key: batch_exists returns the exact set of IDs
@@ -1953,6 +1959,10 @@ mod atomic_replace_tests {
             model_key, dims
         );
         writer.conn().execute_batch(&ddl).expect("create vec table");
+        writer
+            .conn()
+            .execute_batch(crate::migrations::ANN_WRITE_LOG_DDL)
+            .expect("create ann_write_log");
     }
 
     /// insert_batch: a record with wrong dimensions fails its INSERT but must not
@@ -2734,11 +2744,12 @@ mod orphan_sweep_tests {
              embedding float[{}] distance_metric=cosine)",
             model_key, dims
         );
-        pool.try_writer()
-            .expect("writer")
+        let writer = pool.try_writer().expect("writer");
+        writer.conn().execute_batch(&ddl).expect("create vec table");
+        writer
             .conn()
-            .execute_batch(&ddl)
-            .expect("create vec table");
+            .execute_batch(crate::migrations::ANN_WRITE_LOG_DDL)
+            .expect("create ann_write_log");
     }
 
     fn make_store(
@@ -3339,11 +3350,12 @@ mod write_queue_tests {
              embedding float[{}] distance_metric=cosine)",
             model_key, dims
         );
-        pool.writer()
-            .expect("writer")
+        let writer = pool.writer().expect("writer");
+        writer.conn().execute_batch(&ddl).expect("create vec table");
+        writer
             .conn()
-            .execute_batch(&ddl)
-            .expect("create vec table");
+            .execute_batch(crate::migrations::ANN_WRITE_LOG_DDL)
+            .expect("create ann_write_log");
     }
 
     /// Constructed via a `PoolConfig` literal (`write_queue_enabled: true`),

--- a/crates/khive-db/src/stores/vectors.rs
+++ b/crates/khive-db/src/stores/vectors.rs
@@ -376,6 +376,37 @@ fn replace_vector_row_dml(
         ],
     )?;
 
+    // Delta record for the ANN restart classifier; rides the caller's
+    // savepoint/transaction so a rolled-back upsert leaves no log row.
+    conn.execute(
+        "INSERT INTO ann_write_log (namespace, embedding_model, subject_id, op) \
+         VALUES (?1, ?2, ?3, 'upsert')",
+        rusqlite::params![
+            row.namespace,
+            row.embedding_model,
+            row.subject_id.to_string()
+        ],
+    )?;
+
+    Ok(())
+}
+
+/// Log `'delete'` rows into `ann_write_log` for every vector row in `table`
+/// matching `where_clause` (a predicate over the vec0 table's own columns).
+/// Must run in the same transaction as — and before — the corresponding
+/// `DELETE`, so the logged set is exactly the deleted set.
+fn log_vector_deletes(
+    conn: &rusqlite::Connection,
+    table: &str,
+    where_clause: &str,
+    params: &[&dyn rusqlite::ToSql],
+) -> Result<(), rusqlite::Error> {
+    let sql = format!(
+        "INSERT INTO ann_write_log (namespace, embedding_model, subject_id, op) \
+         SELECT namespace, embedding_model, subject_id, 'delete' \
+         FROM {table} WHERE {where_clause}"
+    );
+    conn.execute(&sql, params)?;
     Ok(())
 }
 
@@ -393,6 +424,12 @@ pub fn delete_subject_from_vector_tables(
     namespace: &str,
 ) -> Result<(), rusqlite::Error> {
     for table in tables {
+        log_vector_deletes(
+            conn,
+            table,
+            "subject_id = ?1 AND namespace = ?2",
+            &[&subject_id.to_string(), &namespace],
+        )?;
         let sql = format!("DELETE FROM {table} WHERE subject_id = ?1 AND namespace = ?2");
         conn.execute(&sql, rusqlite::params![subject_id.to_string(), namespace])?;
     }
@@ -619,20 +656,44 @@ fn orphan_sweep_dml(
     // delete subject_ids returned by a capped SELECT subquery.  SQLite
     // materialises the inner SELECT before running the outer DELETE, so there
     // is no self-referential conflict.
+    // Materialize the capped victim set first: the same `LIMIT` subquery
+    // evaluated twice (once to log deletes, once to delete) has no ordering
+    // guarantee, so logging and deleting must share one explicit id list.
     let deleted: i64 = if dry_run {
         0
     } else {
-        let del_sql = format!(
-            "DELETE FROM {t} WHERE subject_id IN (\
-             SELECT subject_id FROM {t} WHERE {p} LIMIT ?4\
-             )",
+        let select_sql = format!(
+            "SELECT subject_id FROM {t} WHERE {p} LIMIT ?4",
             t = table,
             p = orphan_pred,
         );
-        conn.execute(
-            &del_sql,
-            rusqlite::params![ns_json, kind_json, allow_json, max_delete],
-        )? as i64
+        let mut stmt = conn.prepare(&select_sql)?;
+        let victim_ids: Vec<String> = stmt
+            .query_map(
+                rusqlite::params![ns_json, kind_json, allow_json, max_delete],
+                |row| row.get::<_, String>(0),
+            )?
+            .collect::<Result<_, _>>()?;
+        drop(stmt);
+
+        let mut total: i64 = 0;
+        for chunk in victim_ids.chunks(400) {
+            let placeholders: String = (1..=chunk.len())
+                .map(|i| format!("?{i}"))
+                .collect::<Vec<_>>()
+                .join(", ");
+            let in_clause = format!("subject_id IN ({placeholders})");
+            let params: Vec<&dyn rusqlite::ToSql> =
+                chunk.iter().map(|s| s as &dyn rusqlite::ToSql).collect();
+            log_vector_deletes(conn, table, &in_clause, &params)?;
+            let del_sql = format!("DELETE FROM {t} WHERE {in_clause}", t = table);
+            let mut del_stmt = conn.prepare(&del_sql)?;
+            for (i, id_str) in chunk.iter().enumerate() {
+                del_stmt.raw_bind_parameter(i + 1, id_str.as_str())?;
+            }
+            total += del_stmt.raw_execute()? as i64;
+        }
+        total
     };
 
     Ok(OrphanSweepResult {
@@ -908,11 +969,33 @@ impl VectorStore for SqliteVecStore {
 
     async fn delete(&self, subject_id: Uuid) -> Result<bool, StorageError> {
         let statement = delete_vector_statement(&self.table_name, subject_id, &self.namespace);
+        let table = self.table_name.clone();
+        let namespace = self.namespace.clone();
 
         self.with_writer("vec_delete", move |conn| {
-            let mut stmt = conn.prepare(&statement.sql)?;
-            bind_params(&mut stmt, &statement.params)?;
-            Ok(stmt.raw_execute()? > 0)
+            conn.execute_batch("SAVEPOINT vec_delete_log")?;
+            let result = (|| {
+                log_vector_deletes(
+                    conn,
+                    &table,
+                    "subject_id = ?1 AND namespace = ?2",
+                    &[&subject_id.to_string(), &namespace],
+                )?;
+                let mut stmt = conn.prepare(&statement.sql)?;
+                bind_params(&mut stmt, &statement.params)?;
+                Ok(stmt.raw_execute()? > 0)
+            })();
+            match result {
+                Ok(v) => {
+                    conn.execute_batch("RELEASE SAVEPOINT vec_delete_log")?;
+                    Ok(v)
+                }
+                Err(e) => {
+                    let _ = conn.execute_batch("ROLLBACK TO SAVEPOINT vec_delete_log");
+                    let _ = conn.execute_batch("RELEASE SAVEPOINT vec_delete_log");
+                    Err(e)
+                }
+            }
         })
         .await
     }
@@ -1097,15 +1180,37 @@ impl VectorStore for SqliteVecStore {
                 .collect::<Vec<_>>()
                 .join(", ");
             let sql = format!("DELETE FROM {table} WHERE subject_id IN ({placeholders})");
+            let in_clause = format!("subject_id IN ({placeholders})");
             let chunk_owned = chunk.to_vec();
             let table_cl = table.clone();
+            let table_sp = table.clone();
             let deleted = self
                 .with_writer("vec_delete_subjects", move |conn| {
-                    let mut stmt = conn.prepare(&sql)?;
-                    for (i, id_str) in chunk_owned.iter().enumerate() {
-                        stmt.raw_bind_parameter(i + 1, id_str.as_str())?;
+                    conn.execute_batch("SAVEPOINT vec_delete_subjects_log")?;
+                    let result = (|| {
+                        let params: Vec<&dyn rusqlite::ToSql> = chunk_owned
+                            .iter()
+                            .map(|s| s as &dyn rusqlite::ToSql)
+                            .collect();
+                        log_vector_deletes(conn, &table_sp, &in_clause, &params)?;
+                        let mut stmt = conn.prepare(&sql)?;
+                        for (i, id_str) in chunk_owned.iter().enumerate() {
+                            stmt.raw_bind_parameter(i + 1, id_str.as_str())?;
+                        }
+                        stmt.raw_execute().map(|n| n as u64)
+                    })();
+                    match result {
+                        Ok(n) => {
+                            conn.execute_batch("RELEASE SAVEPOINT vec_delete_subjects_log")?;
+                            Ok(n)
+                        }
+                        Err(e) => {
+                            let _ =
+                                conn.execute_batch("ROLLBACK TO SAVEPOINT vec_delete_subjects_log");
+                            let _ = conn.execute_batch("RELEASE SAVEPOINT vec_delete_subjects_log");
+                            Err(e)
+                        }
                     }
-                    stmt.raw_execute().map(|n| n as u64)
                 })
                 .await
                 .map_err(|e| {

--- a/crates/khive-pack-knowledge/src/knowledge/index_handler.rs
+++ b/crates/khive-pack-knowledge/src/knowledge/index_handler.rs
@@ -225,15 +225,19 @@ impl KnowledgeHandlers {
             // atom-iteration order persists a hash the warm path always reads as stale.
             match vamana::load_and_build_from_vector_store(runtime, token, model_name).await {
                 Ok(Some(bridge)) => {
-                    let bridge = bridge.with_generation(build_generation);
                     let n = bridge.num_vectors();
                     ann_count = Some(n);
-                    if let Err(e) = vamana::persist_ann_v2(runtime, &ns, model_name, &bridge) {
-                        tracing::error!(error = %e, "failed to persist v2 Vamana segments");
-                        ann_failed = true;
-                    }
                     let key = vamana::AnnKey::new(&ns, model_name);
-                    vamana::install_if_fresher(ann, &key, bridge).await;
+                    vamana::checkpoint_raise_compact_readopt(
+                        runtime,
+                        ann,
+                        &key,
+                        &ns,
+                        model_name,
+                        bridge,
+                        build_generation,
+                    )
+                    .await;
                     eprintln!("  Vamana ANN built ({n} vectors)");
                 }
                 Ok(None) => {}

--- a/crates/khive-pack-knowledge/src/knowledge/vamana.rs
+++ b/crates/khive-pack-knowledge/src/knowledge/vamana.rs
@@ -711,10 +711,10 @@ pub(crate) fn snapshot_key(namespace: &str, model: &str) -> String {
 /// the bytes of `snapshot_key(ns, model)`. Hex encoding is injective, filesystem-safe,
 /// and reversible via `decode_ann_dir_name`. Returns `None` for in-memory backends.
 fn ann_segment_dir(rt: &KhiveRuntime, ns: &str, model: &str) -> Option<std::path::PathBuf> {
-    let data_dir = rt.backend_data_dir()?;
+    let ann_root = rt.backend_ann_root()?;
     let key = snapshot_key(ns, model);
     let hex: String = key.bytes().map(|b| format!("{b:02x}")).collect();
-    Some(data_dir.join("ann").join(hex))
+    Some(ann_root.join(hex))
 }
 
 /// Decode a hex-encoded ann directory name back to `(namespace, model)`.
@@ -887,6 +887,34 @@ async fn compact_log(rt: &KhiveRuntime, ns: &str, model: &str) -> Result<(), Str
     .await
     .map_err(|e| e.to_string())?;
     Ok(())
+}
+
+/// Whether any tail row exists above `s` for this consumer's scope. A pure
+/// `ann_write_log` index probe (`idx_ann_write_log_ns_model_seq`) — never
+/// touches the vec0 corpus, which is what keeps Hot classification free of
+/// corpus IO (the amendment's rule 5/6 evaluation-order note).
+async fn tail_exists(rt: &KhiveRuntime, ns: &str, model: &str, s: u64) -> Result<bool, String> {
+    let sql = rt.sql();
+    let mut reader = sql.reader().await.map_err(|e| e.to_string())?;
+    let rows = reader
+        .query_all(SqlStatement {
+            sql: "SELECT EXISTS(SELECT 1 FROM ann_write_log \
+                  WHERE namespace = ?1 AND embedding_model = ?2 \
+                    AND field = 'knowledge.atom' AND seq > ?3) AS has_tail"
+                .into(),
+            params: vec![
+                SqlValue::Text(ns.to_owned()),
+                SqlValue::Text(model.to_owned()),
+                SqlValue::Integer(s as i64),
+            ],
+            label: Some("ann_tail_probe".into()),
+        })
+        .await
+        .map_err(|e| e.to_string())?;
+    match rows.first().and_then(|r| r.get("has_tail")) {
+        Some(SqlValue::Integer(n)) => Ok(*n != 0),
+        other => Err(format!("tail probe: unexpected value {other:?}")),
+    }
 }
 
 /// Live corpus count and tail count for this consumer's scope, captured in ONE
@@ -1394,10 +1422,10 @@ pub(crate) async fn warm_known_snapshots(rt: &KhiveRuntime, ann: &SharedAnn) {
         }
     }
 
-    // Enumerate v2 segment directories in `data_dir/ann/` and warm any keys not
-    // already loaded by the v1 DB pass above.
-    let ann_root = match rt.backend_data_dir() {
-        Some(d) => d.join("ann"),
+    // Enumerate v2 segment directories under this database's own ANN root and
+    // warm any keys not already loaded by the v1 DB pass above.
+    let ann_root = match rt.backend_ann_root() {
+        Some(d) => d,
         None => return,
     };
     let read_dir = match std::fs::read_dir(&ann_root) {
@@ -1543,7 +1571,35 @@ async fn classify_and_adopt_segment(
         }
     }
 
-    // Rules 5-8 read (live, tail) from one snapshot.
+    // Rule 6, tested first per the amendment's evaluation-order note: the
+    // tail predicate is a log-table-only index probe, so the Hot path never
+    // touches the vec0 corpus at all. With an empty tail the committed
+    // segment already reflects every logged op at or below S, so a zero-live
+    // scope implies an empty segment and adoption serves exactly what Empty
+    // serves.
+    match tail_exists(rt, ns, model, s).await {
+        Ok(false) => {
+            return match AnnBridge::load(seg_dir) {
+                Ok(bridge) => {
+                    install_if_fresher(ann, key, bridge.with_generation(target_generation)).await;
+                    SegmentOutcome::Installed
+                }
+                Err(e) => {
+                    tracing::warn!(error = %e, dir = %seg_dir.display(),
+                        "Hot segment load failed; Cold rebuild");
+                    SegmentOutcome::Cold
+                }
+            };
+        }
+        Ok(true) => {}
+        Err(e) => {
+            tracing::warn!(error = %e, "ann tail probe failed; Cold");
+            return SegmentOutcome::Cold;
+        }
+    }
+
+    // A tail exists — corpus-scale work is inherent from here. Rules 5, 7,
+    // and 8 read (live, tail) from one snapshot.
     let (live, tail) = match scope_counts(rt, ns, model, s).await {
         Ok(counts) => counts,
         Err(e) => {
@@ -1557,23 +1613,6 @@ async fn classify_and_adopt_segment(
         tracing::info!(namespace = %ns, model = %model,
             "zero live corpus for scope; Empty (FTS/degraded path)");
         return SegmentOutcome::Empty;
-    }
-
-    // Rule 6: no tail above S → Hot: mmap load. The only corpus access on
-    // this path is the single `scope_counts` statement above — no embedding
-    // bytes are read.
-    if tail == 0 {
-        return match AnnBridge::load(seg_dir) {
-            Ok(bridge) => {
-                install_if_fresher(ann, key, bridge.with_generation(target_generation)).await;
-                SegmentOutcome::Installed
-            }
-            Err(e) => {
-                tracing::warn!(error = %e, dir = %seg_dir.display(),
-                    "Hot segment load failed; Cold rebuild");
-                SegmentOutcome::Cold
-            }
-        };
     }
 
     // Rule 7: tail within threshold → Stale-tail: mmap load + final-state
@@ -2749,12 +2788,13 @@ mod tests {
         assert_eq!(decoded_ns, "local");
         assert_eq!(decoded_model, WARM_TEST_MODEL);
 
-        // Parent directory is `data_dir/ann/`.
+        // Parent directory is the database's own ANN root (`<db-file>.ann/`
+        // beside the file), so co-located databases never share segments.
         let parent = seg_dir.parent().expect("seg_dir must have a parent");
         assert_eq!(
             parent.file_name().unwrap().to_string_lossy(),
-            "ann",
-            "seg_dir parent must be named 'ann'"
+            "test.db.ann",
+            "seg_dir parent must be the database-scoped ANN root"
         );
     }
 

--- a/crates/khive-pack-knowledge/src/knowledge/vamana.rs
+++ b/crates/khive-pack-knowledge/src/knowledge/vamana.rs
@@ -2655,6 +2655,13 @@ mod tests {
     /// Calls `rt.vectors_for_model` first so the virtual table is created, then
     /// inserts raw f32 LE blobs directly via SQL.
     async fn seed_warm_corpus(rt: &KhiveRuntime, token: &NamespaceToken, n: usize) {
+        seed_warm_corpus_opts(rt, token, n, true).await;
+    }
+
+    /// `log = false` seeds vec rows WITHOUT write-log rows — constructs the
+    /// empty-log zero-watermark baseline state (a corpus that predates the
+    /// migration's first logged write).
+    async fn seed_warm_corpus_opts(rt: &KhiveRuntime, token: &NamespaceToken, n: usize, log: bool) {
         let _store = rt
             .vectors_for_model(token, WARM_TEST_MODEL)
             .expect("vec store");
@@ -2686,6 +2693,9 @@ mod tests {
             })
             .await
             .expect("insert corpus row");
+            if !log {
+                continue;
+            }
             // Mirror the production write path: every vector mutation appends
             // a write-log row in the same funnel (ADR-079 Amendment 1).
             w.execute(SqlStatement {
@@ -2883,6 +2893,221 @@ mod tests {
         assert_eq!(
             tail_after, 0,
             "replayed tail must be covered by the new watermark"
+        );
+    }
+
+    /// Review-mandated case: a checkpoint taken over an EMPTY log persists the
+    /// zero watermark (the defined empty-log baseline), and the first logged
+    /// write afterwards classifies Stale-tail — never Hot.
+    #[tokio::test]
+    async fn ensure_ann_zero_watermark_then_first_write_is_stale_tail() {
+        let dir = TempDir::new().expect("tempdir");
+        let rt = file_rt_with_embedder(dir.path().join("test.db"));
+        let token = rt.authorize(Namespace::local()).expect("authorize");
+        // Corpus WITHOUT log rows: the log is empty at checkpoint time.
+        seed_warm_corpus_opts(&rt, &token, 4, false).await;
+
+        let ann = new_shared();
+        ensure_ann_for_model(&rt, &token, &ann, WARM_TEST_MODEL).await;
+        let seg_dir = ann_segment_dir(&rt, "local", WARM_TEST_MODEL).expect("seg_dir");
+        let info = read_commit_info(&seg_dir)
+            .expect("read_commit_info")
+            .expect("v2 commit record");
+        assert_eq!(
+            info.last_applied_seq,
+            Some(0),
+            "empty-log checkpoint must persist the numeric zero baseline, not a missing watermark"
+        );
+
+        // First logged write after the zero-watermark checkpoint.
+        seed_warm_corpus_opts(&rt, &token, 1, true).await;
+        let ann2 = new_shared();
+        ensure_ann_for_model(&rt, &token, &ann2, WARM_TEST_MODEL).await;
+        let key = AnnKey::new("local", WARM_TEST_MODEL);
+        let n = ann2
+            .indexes
+            .read()
+            .await
+            .get(&key)
+            .map(AnnBridge::num_vectors)
+            .expect("index must be served after the first logged write");
+        assert_eq!(
+            n, 5,
+            "Stale-tail must replay the logged write (Hot would serve 4)"
+        );
+        let info2 = read_commit_info(&seg_dir)
+            .expect("read_commit_info")
+            .expect("v2 commit record after replay");
+        assert!(
+            info2.last_applied_seq.unwrap_or(0) > 0,
+            "replay checkpoint must advance past the zero baseline"
+        );
+    }
+
+    /// Review-mandated case: deleting every live vector classifies Empty — no
+    /// ANN is served or replayed, and the terminal unavailable marker is set.
+    #[tokio::test]
+    async fn ensure_ann_delete_all_is_empty() {
+        let dir = TempDir::new().expect("tempdir");
+        let rt = file_rt_with_embedder(dir.path().join("test.db"));
+        let token = rt.authorize(Namespace::local()).expect("authorize");
+        seed_warm_corpus(&rt, &token, 3).await;
+
+        let ann = new_shared();
+        ensure_ann_for_model(&rt, &token, &ann, WARM_TEST_MODEL).await;
+        let key = AnnKey::new("local", WARM_TEST_MODEL);
+        assert!(ann.indexes.read().await.contains_key(&key), "initial build");
+
+        // Delete every corpus row, logging each delete (production funnel shape).
+        let table = format!("vec_{}", sanitize_model_key(WARM_TEST_MODEL));
+        let sql = rt.sql();
+        let mut w = sql.writer().await.expect("writer");
+        w.execute(SqlStatement {
+            sql: format!(
+                "INSERT INTO ann_write_log \
+                 (namespace, embedding_model, kind, field, subject_id, op) \
+                 SELECT namespace, embedding_model, kind, field, subject_id, 'delete' \
+                 FROM {table} WHERE namespace = ?1 AND embedding_model = ?2"
+            ),
+            params: vec![
+                SqlValue::Text("local".into()),
+                SqlValue::Text(WARM_TEST_MODEL.into()),
+            ],
+            label: None,
+        })
+        .await
+        .expect("log deletes");
+        w.execute(SqlStatement {
+            sql: format!("DELETE FROM {table} WHERE namespace = ?1 AND embedding_model = ?2"),
+            params: vec![
+                SqlValue::Text("local".into()),
+                SqlValue::Text(WARM_TEST_MODEL.into()),
+            ],
+            label: None,
+        })
+        .await
+        .expect("delete corpus");
+        drop(w);
+
+        let ann2 = new_shared();
+        ensure_ann_for_model(&rt, &token, &ann2, WARM_TEST_MODEL).await;
+        assert!(
+            !ann2.indexes.read().await.contains_key(&key),
+            "zero live corpus must classify Empty — no ANN served (rule 5 precedes Hot)"
+        );
+        assert!(
+            is_terminally_unavailable(&ann2, &key),
+            "Empty must set the terminal unavailable marker for wait_for_ann"
+        );
+    }
+
+    /// Review-mandated interleaving: consumer A registers at 0, checkpoints at
+    /// S, and crashes before its raise — the pair MIN stays 0 and another
+    /// consumer's compaction cannot delete A's tail. After A's row is raised
+    /// (or an overlapping row removed), compaction advances to the pair MIN.
+    #[tokio::test]
+    async fn compact_log_bounded_by_pair_minimum() {
+        let dir = TempDir::new().expect("tempdir");
+        let rt = file_rt_with_embedder(dir.path().join("test.db"));
+        let token = rt.authorize(Namespace::local()).expect("authorize");
+        seed_warm_corpus(&rt, &token, 4).await; // seqs 1..=4 in the log
+
+        register_consumer(&rt, "local", WARM_TEST_MODEL)
+            .await
+            .expect("register at 0");
+        // Overlapping consumer B durably checkpointed past every row.
+        {
+            let sql = rt.sql();
+            let mut w = sql.writer().await.expect("writer");
+            w.execute(SqlStatement {
+                sql: "INSERT INTO ann_consumer_watermark \
+                      (consumer, namespace, embedding_model, watermark) VALUES (?1, ?2, ?3, 99)"
+                    .into(),
+                params: vec![
+                    SqlValue::Text("other:test".into()),
+                    SqlValue::Text("local".into()),
+                    SqlValue::Text(WARM_TEST_MODEL.into()),
+                ],
+                label: None,
+            })
+            .await
+            .expect("insert B row");
+        }
+
+        // A crashed before its raise: row is 0 → MIN(0, 99) = 0 → nothing deletes.
+        compact_log(&rt, "local", WARM_TEST_MODEL)
+            .await
+            .expect("compact");
+        let (_, tail_at_zero) = scope_counts(&rt, "local", WARM_TEST_MODEL, 0)
+            .await
+            .expect("scope_counts");
+        assert_eq!(
+            tail_at_zero, 4,
+            "a zero-watermark row must block pair compaction"
+        );
+
+        // A raises to 2 → MIN(2, 99) = 2 → rows 1-2 compact, 3-4 remain.
+        raise_watermark(&rt, "local", WARM_TEST_MODEL, 2)
+            .await
+            .expect("raise");
+        compact_log(&rt, "local", WARM_TEST_MODEL)
+            .await
+            .expect("compact");
+        let (_, tail_after) = scope_counts(&rt, "local", WARM_TEST_MODEL, 0)
+            .await
+            .expect("scope_counts");
+        assert_eq!(
+            tail_after, 2,
+            "compaction must advance exactly to the pair MIN"
+        );
+    }
+
+    /// Review-mandated case: a pre-amendment commit record (base length, no
+    /// watermark trailer) classifies Cold and rebuilds — never serves Hot.
+    #[tokio::test]
+    async fn ensure_ann_pre_amendment_record_is_cold() {
+        let dir = TempDir::new().expect("tempdir");
+        let rt = file_rt_with_embedder(dir.path().join("test.db"));
+        let token = rt.authorize(Namespace::local()).expect("authorize");
+        seed_warm_corpus(&rt, &token, 4).await;
+
+        let ann = new_shared();
+        ensure_ann_for_model(&rt, &token, &ann, WARM_TEST_MODEL).await;
+        let seg_dir = ann_segment_dir(&rt, "local", WARM_TEST_MODEL).expect("seg_dir");
+
+        // Truncate the 41-byte extended trailer: the record parses at the base
+        // length — a legitimate pre-amendment commit with no watermark.
+        let meta_path = seg_dir.join("metadata.bin");
+        let bytes = std::fs::read(&meta_path).expect("read metadata.bin");
+        std::fs::write(&meta_path, &bytes[..bytes.len() - 41]).expect("truncate trailer");
+        let info = read_commit_info(&seg_dir)
+            .expect("read_commit_info")
+            .expect("base-length record must still parse");
+        assert_eq!(
+            info.last_applied_seq, None,
+            "trailer removed → no watermark"
+        );
+
+        use std::os::unix::fs::MetadataExt;
+        let ino_before = std::fs::metadata(&meta_path).expect("meta").ino();
+        let ann2 = new_shared();
+        ensure_ann_for_model(&rt, &token, &ann2, WARM_TEST_MODEL).await;
+        let key = AnnKey::new("local", WARM_TEST_MODEL);
+        assert!(
+            ann2.indexes.read().await.contains_key(&key),
+            "Cold rebuild must still produce a served index"
+        );
+        let ino_after = std::fs::metadata(&meta_path).expect("meta").ino();
+        assert_ne!(
+            ino_before, ino_after,
+            "pre-amendment record must force a rebuild (metadata.bin rewritten), not a Hot load"
+        );
+        let info2 = read_commit_info(&seg_dir)
+            .expect("read_commit_info")
+            .expect("rebuilt record");
+        assert!(
+            info2.last_applied_seq.is_some(),
+            "rebuild must restore the extended watermark record"
         );
     }
 

--- a/crates/khive-pack-knowledge/src/knowledge/vamana.rs
+++ b/crates/khive-pack-knowledge/src/knowledge/vamana.rs
@@ -405,61 +405,64 @@ impl AnnBridge {
         self.index.set_last_applied_seq(Some(seq));
     }
 
-    /// Apply a coalesced final-state tail (ADR-079 Amendment 1) to this
-    /// bridge: for each subject, `Some(embedding)` replays a final upsert
-    /// (tombstone the mapped old ordinal, then exactly one insert) and `None`
-    /// replays a final delete (tombstone if mapped, no-op otherwise). `new_s`
-    /// is the highest tail seq, stamped as the new applied watermark. Any
-    /// id-map contradiction returns `Err` — the caller escalates to Cold.
-    pub(crate) fn apply_final_ops(
-        &mut self,
-        ops: Vec<(Uuid, Option<Vec<f32>>)>,
-        new_s: u64,
-    ) -> Result<(), String> {
-        // Highest ordinal wins for a repeated uuid: inserts append, so the
-        // latest slot is the live one; earlier slots are tombstoned.
+    /// Ordinal lookup for streamed tail replay. Built once per replay so
+    /// batches can apply incrementally without rescanning the id-map.
+    /// Highest ordinal wins for a repeated uuid: inserts append, so the
+    /// latest slot is the live one; earlier slots are tombstoned.
+    pub(crate) fn reverse_map(&self) -> HashMap<Uuid, u32> {
         let mut reverse: HashMap<Uuid, u32> = HashMap::with_capacity(self.id_map.len());
         for (ordinal, uuid) in self.id_map.iter().enumerate() {
             reverse.insert(*uuid, ordinal as u32);
         }
+        reverse
+    }
 
-        for (uuid, op) in ops {
-            match op {
-                None => {
-                    if let Some(&ordinal) = reverse.get(&uuid) {
-                        self.index
-                            .tombstone(ordinal)
-                            .map_err(|e| format!("replay tombstone({ordinal}): {e}"))?;
-                        reverse.remove(&uuid);
-                    }
-                }
-                Some(mut embedding) => {
-                    l2_normalize(&mut embedding);
-                    if let Some(&old) = reverse.get(&uuid) {
-                        self.index
-                            .tombstone(old)
-                            .map_err(|e| format!("replay tombstone({old}): {e}"))?;
-                    }
-                    let ordinal = self
-                        .index
-                        .insert(&embedding)
-                        .map_err(|e| format!("replay insert: {e}"))?;
-                    let slot = ordinal as usize;
-                    match slot.cmp(&self.id_map.len()) {
-                        std::cmp::Ordering::Less => self.id_map[slot] = uuid,
-                        std::cmp::Ordering::Equal => self.id_map.push(uuid),
-                        std::cmp::Ordering::Greater => {
-                            return Err(format!(
-                                "replay insert returned ordinal {ordinal} beyond id_map len {}",
-                                self.id_map.len()
-                            ));
-                        }
-                    }
-                    reverse.insert(uuid, ordinal);
+    /// Apply one subject's coalesced final state (ADR-079 Amendment 1):
+    /// `Some(embedding)` replays a final upsert (tombstone the mapped old
+    /// ordinal, then exactly one insert); `None` replays a final delete
+    /// (tombstone if mapped, no-op otherwise). `reverse` is the map from
+    /// [`reverse_map`](Self::reverse_map), kept current across calls. Any
+    /// id-map contradiction returns `Err` — the caller escalates to Cold.
+    pub(crate) fn apply_final_op(
+        &mut self,
+        reverse: &mut HashMap<Uuid, u32>,
+        uuid: Uuid,
+        op: Option<Vec<f32>>,
+    ) -> Result<(), String> {
+        match op {
+            None => {
+                if let Some(&ordinal) = reverse.get(&uuid) {
+                    self.index
+                        .tombstone(ordinal)
+                        .map_err(|e| format!("replay tombstone({ordinal}): {e}"))?;
+                    reverse.remove(&uuid);
                 }
             }
+            Some(mut embedding) => {
+                l2_normalize(&mut embedding);
+                if let Some(&old) = reverse.get(&uuid) {
+                    self.index
+                        .tombstone(old)
+                        .map_err(|e| format!("replay tombstone({old}): {e}"))?;
+                }
+                let ordinal = self
+                    .index
+                    .insert(&embedding)
+                    .map_err(|e| format!("replay insert: {e}"))?;
+                let slot = ordinal as usize;
+                match slot.cmp(&self.id_map.len()) {
+                    std::cmp::Ordering::Less => self.id_map[slot] = uuid,
+                    std::cmp::Ordering::Equal => self.id_map.push(uuid),
+                    std::cmp::Ordering::Greater => {
+                        return Err(format!(
+                            "replay insert returned ordinal {ordinal} beyond id_map len {}",
+                            self.id_map.len()
+                        ));
+                    }
+                }
+                reverse.insert(uuid, ordinal);
+            }
         }
-        self.index.set_last_applied_seq(Some(new_s));
         Ok(())
     }
 
@@ -929,40 +932,39 @@ async fn scope_counts(
     Ok((get("live")?, get("tail")?))
 }
 
-/// Fetch the scope's tail (rows above `s`, ordered) and coalesce it to the
-/// final op per subject with the embeddings needed for final upserts, ready
-/// for [`AnnBridge::apply_final_ops`]. Returns the ops and the new watermark.
-/// A final upsert whose source row is missing is a contradiction → `Err`
-/// (caller escalates to Cold).
-async fn fetch_final_tail(
+/// Coalesce the scope's tail (rows above `s`) to the final op per subject in
+/// ONE aggregate query — SQLite's bare-column-with-MAX guarantee makes `op`
+/// the value from each subject's max-seq row. Returns `(subject, is_delete)`
+/// pairs plus the new watermark; memory is O(distinct tail subjects), never
+/// O(tail rows). Embeddings are read separately, per batch, by
+/// [`replay_final_states`].
+async fn fetch_final_states(
     rt: &KhiveRuntime,
     ns: &str,
     model: &str,
     s: u64,
-) -> Result<(Vec<(Uuid, Option<Vec<f32>>)>, u64), String> {
+) -> Result<(Vec<(Uuid, bool)>, u64), String> {
     let sql = rt.sql();
     let mut reader = sql.reader().await.map_err(|e| e.to_string())?;
     let rows = reader
         .query_all(SqlStatement {
-            sql: "SELECT seq, subject_id, op FROM ann_write_log \
+            sql: "SELECT subject_id, op, MAX(seq) AS seq FROM ann_write_log \
                   WHERE namespace = ?1 AND embedding_model = ?2 \
                     AND field = 'knowledge.atom' AND seq > ?3 \
-                  ORDER BY seq"
+                  GROUP BY subject_id"
                 .into(),
             params: vec![
                 SqlValue::Text(ns.to_owned()),
                 SqlValue::Text(model.to_owned()),
                 SqlValue::Integer(s as i64),
             ],
-            label: Some("ann_fetch_tail".into()),
+            label: Some("ann_fetch_final_states".into()),
         })
         .await
         .map_err(|e| e.to_string())?;
 
     let mut new_s = s;
-    // Ordered iteration + insert-overwrite = final op per subject wins.
-    let mut finals: Vec<(Uuid, bool)> = Vec::new();
-    let mut index_of: HashMap<Uuid, usize> = HashMap::new();
+    let mut finals: Vec<(Uuid, bool)> = Vec::with_capacity(rows.len());
     for row in &rows {
         let seq = match row.get("seq") {
             Some(SqlValue::Integer(n)) => *n,
@@ -979,74 +981,89 @@ async fn fetch_final_tail(
             Some(SqlValue::Text(t)) => t == "delete",
             _ => return Err("ann_write_log.op: unexpected value".into()),
         };
-        match index_of.get(&uuid) {
-            Some(&i) => finals[i].1 = is_delete,
-            None => {
-                index_of.insert(uuid, finals.len());
-                finals.push((uuid, is_delete));
-            }
-        }
+        finals.push((uuid, is_delete));
     }
+    Ok((finals, new_s))
+}
 
-    // Point-read the embeddings for final upserts, chunked under the SQLite
-    // parameter limit, always under the consumer's own scope predicate.
-    let upsert_ids: Vec<Uuid> = finals
-        .iter()
-        .filter(|(_, is_delete)| !is_delete)
-        .map(|(u, _)| *u)
-        .collect();
-    let mut embeddings: HashMap<Uuid, Vec<f32>> = HashMap::with_capacity(upsert_ids.len());
+/// Subjects per streamed replay batch: bounds transient replay memory at
+/// O(batch × dimensions) regardless of tail size.
+const REPLAY_BATCH: usize = 500;
+
+/// Stream the coalesced final states onto `bridge`. Each final upsert's
+/// embedding is point-read by single-key equality — the only constraint
+/// shape sqlite-vec plans as a primary-key point lookup rather than a full
+/// table scan — and the consumer scope predicate is checked in process on
+/// the returned row. Batches apply as they are read, so peak memory is one
+/// batch of embeddings, never the whole tail. A final upsert whose source
+/// row is missing or out of scope is a contradiction → `Err` (caller
+/// escalates to Cold).
+async fn replay_final_states(
+    rt: &KhiveRuntime,
+    bridge: &mut AnnBridge,
+    ns: &str,
+    model: &str,
+    finals: &[(Uuid, bool)],
+) -> Result<(), String> {
     let table_name = format!("vec_{}", sanitize_model_key(model));
-    for chunk in upsert_ids.chunks(500) {
-        let placeholders: Vec<String> = (0..chunk.len()).map(|i| format!("?{}", i + 3)).collect();
-        let mut params = vec![
-            SqlValue::Text(ns.to_owned()),
-            SqlValue::Text(model.to_owned()),
-        ];
-        params.extend(chunk.iter().map(|u| SqlValue::Text(u.to_string())));
-        let rows = reader
-            .query_all(SqlStatement {
-                sql: format!(
-                    "SELECT subject_id, embedding FROM {table_name} \
-                     WHERE namespace = ?1 AND embedding_model = ?2 \
-                       AND field = 'knowledge.atom' \
-                       AND subject_id IN ({})",
-                    placeholders.join(", ")
-                ),
-                params,
-                label: Some("ann_tail_point_read".into()),
-            })
-            .await
-            .map_err(|e| e.to_string())?;
-        for row in &rows {
-            let (Some(SqlValue::Text(id_str)), Some(SqlValue::Blob(bytes))) =
-                (row.get("subject_id"), row.get("embedding"))
-            else {
+    let point_read_sql = format!(
+        "SELECT namespace, embedding_model, field, embedding \
+         FROM {table_name} WHERE subject_id = ?1"
+    );
+    let sql = rt.sql();
+    let mut reader = sql.reader().await.map_err(|e| e.to_string())?;
+    let mut reverse = bridge.reverse_map();
+
+    for batch in finals.chunks(REPLAY_BATCH) {
+        let mut embeddings: HashMap<Uuid, Vec<f32>> = HashMap::new();
+        for (uuid, is_delete) in batch {
+            if *is_delete {
                 continue;
+            }
+            let rows = reader
+                .query_all(SqlStatement {
+                    sql: point_read_sql.clone(),
+                    params: vec![SqlValue::Text(uuid.to_string())],
+                    label: Some("ann_replay_point_read".into()),
+                })
+                .await
+                .map_err(|e| e.to_string())?;
+            let Some(row) = rows.first() else {
+                return Err(format!(
+                    "final upsert for {uuid} has no source row (contradiction → Cold)"
+                ));
             };
-            let Ok(uuid) = Uuid::parse_str(id_str) else {
-                continue;
+            let in_scope = matches!(row.get("namespace"), Some(SqlValue::Text(t)) if t == ns)
+                && matches!(row.get("embedding_model"), Some(SqlValue::Text(t)) if t == model)
+                && matches!(row.get("field"), Some(SqlValue::Text(t)) if t == "knowledge.atom");
+            if !in_scope {
+                return Err(format!(
+                    "final upsert for {uuid}: source row left the consumer scope \
+                     (contradiction → Cold)"
+                ));
+            }
+            let Some(SqlValue::Blob(bytes)) = row.get("embedding") else {
+                return Err(format!("final upsert for {uuid}: embedding missing on row"));
             };
             let vec: Vec<f32> = bytes
                 .chunks_exact(4)
                 .map(|c| f32::from_le_bytes([c[0], c[1], c[2], c[3]]))
                 .collect();
-            embeddings.insert(uuid, vec);
+            embeddings.insert(*uuid, vec);
+        }
+        for (uuid, is_delete) in batch {
+            let op =
+                if *is_delete {
+                    None
+                } else {
+                    Some(embeddings.remove(uuid).ok_or_else(|| {
+                        format!("final upsert for {uuid}: embedding lost in batch")
+                    })?)
+                };
+            bridge.apply_final_op(&mut reverse, *uuid, op)?;
         }
     }
-
-    let mut ops: Vec<(Uuid, Option<Vec<f32>>)> = Vec::with_capacity(finals.len());
-    for (uuid, is_delete) in finals {
-        if is_delete {
-            ops.push((uuid, None));
-        } else {
-            let embedding = embeddings.remove(&uuid).ok_or_else(|| {
-                format!("final upsert for {uuid} has no source row (contradiction → Cold)")
-            })?;
-            ops.push((uuid, Some(embedding)));
-        }
-    }
-    Ok((ops, new_s))
+    Ok(())
 }
 
 /// Persist `bridge` at its applied watermark, raise this consumer's registry
@@ -1464,7 +1481,6 @@ enum SegmentOutcome {
 #[allow(clippy::too_many_arguments)]
 async fn classify_and_adopt_segment(
     rt: &KhiveRuntime,
-    token: &NamespaceToken,
     ann: &SharedAnn,
     key: &AnnKey,
     ns: &str,
@@ -1493,11 +1509,14 @@ async fn classify_and_adopt_segment(
     };
 
     // Rule 3: configured embedder dimensions ≠ segment dimensions → Cold.
-    match compute_fingerprint(rt, token, model).await {
-        Some(fp) if fp.dimensions as u64 == info.dimensions => {}
-        Some(fp) => {
+    // Resolved from the embedder registry — no storage access. The corpus
+    // itself is touched by exactly one statement in the whole decision path:
+    // `scope_counts` below.
+    match rt.embedder_dimensions(model) {
+        Some(dims) if dims as u64 == info.dimensions => {}
+        Some(dims) => {
             tracing::info!(namespace = %ns, model = %model,
-                segment_dims = info.dimensions, live_dims = fp.dimensions,
+                segment_dims = info.dimensions, live_dims = dims,
                 "v2 segment dimension mismatch; Cold rebuild");
             return SegmentOutcome::Cold;
         }
@@ -1540,7 +1559,9 @@ async fn classify_and_adopt_segment(
         return SegmentOutcome::Empty;
     }
 
-    // Rule 6: no tail above S → Hot: mmap load, zero corpus IO.
+    // Rule 6: no tail above S → Hot: mmap load. The only corpus access on
+    // this path is the single `scope_counts` statement above — no embedding
+    // bytes are read.
     if tail == 0 {
         return match AnnBridge::load(seg_dir) {
             Ok(bridge) => {
@@ -1568,17 +1589,18 @@ async fn classify_and_adopt_segment(
                 return SegmentOutcome::Cold;
             }
         };
-        let (ops, new_s) = match fetch_final_tail(rt, ns, model, s).await {
+        let (finals, new_s) = match fetch_final_states(rt, ns, model, s).await {
             Ok(t) => t,
             Err(e) => {
                 tracing::warn!(error = %e, "tail replay contradiction; Cold rebuild");
                 return SegmentOutcome::Cold;
             }
         };
-        if let Err(e) = bridge.apply_final_ops(ops, new_s) {
+        if let Err(e) = replay_final_states(rt, &mut bridge, ns, model, &finals).await {
             tracing::warn!(error = %e, "tail replay failed; Cold rebuild");
             return SegmentOutcome::Cold;
         }
+        bridge.set_applied_seq(new_s);
         checkpoint_raise_compact_readopt(rt, ann, key, ns, model, bridge, target_generation).await;
         return SegmentOutcome::Installed;
     }
@@ -1653,17 +1675,8 @@ pub(crate) async fn ensure_ann_for_model(
     // first-match decision table over the persisted commit record, this
     // consumer's registry row, and one same-snapshot (live, tail) read.
     if let Some(seg_dir) = ann_segment_dir(rt, &ns, model) {
-        match classify_and_adopt_segment(
-            rt,
-            token,
-            ann,
-            &key,
-            &ns,
-            model,
-            &seg_dir,
-            target_generation,
-        )
-        .await
+        match classify_and_adopt_segment(rt, ann, &key, &ns, model, &seg_dir, target_generation)
+            .await
         {
             SegmentOutcome::Installed => return,
             SegmentOutcome::Empty => {

--- a/crates/khive-pack-knowledge/src/knowledge/vamana.rs
+++ b/crates/khive-pack-knowledge/src/knowledge/vamana.rs
@@ -21,7 +21,7 @@ use std::sync::Arc;
 use khive_runtime::{KhiveRuntime, Namespace, NamespaceToken, RuntimeError};
 use khive_storage::types::{SqlStatement, SqlValue};
 use khive_vamana::{
-    corpus_content_hash, read_commit_fingerprint, CorpusFingerprint, VamanaConfig, VamanaIndex,
+    read_commit_fingerprint, read_commit_info, CorpusFingerprint, VamanaConfig, VamanaIndex,
     VamanaSnapshot,
 };
 use tokio::sync::RwLock;
@@ -157,6 +157,32 @@ pub(crate) async fn install_if_fresher(ann: &SharedAnn, key: &AnnKey, candidate:
             unavailable_guard(&ann.unavailable).remove(key);
         }
     }
+}
+
+/// Install `candidate`, replacing an equal-generation incumbent.
+///
+/// Same namespace-generation fence as `install_if_fresher` (a candidate that
+/// predates the namespace's current generation is rejected), but ties REPLACE
+/// instead of keeping the incumbent. Only two ordered-within-one-warm-task
+/// paths use it: swapping a just-persisted segment's mmap reopen in for the
+/// Owned build product (identical content), and replacing a served stale
+/// segment with its completed rebuild (rule 8 → rebuild completion). The
+/// A/B-race protection that motivates tie-keeps-incumbent in
+/// `install_if_fresher` does not apply inside a single single-flight task.
+pub(crate) async fn install_replacing(ann: &SharedAnn, key: &AnnKey, candidate: AnnBridge) {
+    let mut idxs = ann.indexes.write().await;
+    let ns_generation = current_generation(ann, &key.namespace);
+    if candidate.generation < ns_generation {
+        tracing::debug!(
+            key = ?key,
+            candidate_generation = candidate.generation,
+            namespace_generation = ns_generation,
+            "knowledge ANN replace skipped: candidate predates namespace's current generation"
+        );
+        return;
+    }
+    idxs.insert(key.clone(), candidate);
+    unavailable_guard(&ann.unavailable).remove(key);
 }
 
 // Recover a poisoned warming Mutex rather than aborting: the guarded HashSet<AnnKey>
@@ -370,6 +396,71 @@ impl AnnBridge {
     pub(crate) fn with_generation(mut self, generation: u64) -> Self {
         self.generation = generation;
         self
+    }
+
+    /// Stamp the ann_write_log watermark this bridge's corpus state reflects
+    /// (ADR-079 Amendment 1). Persisted by `save_atomic` into the extended
+    /// commit record.
+    pub(crate) fn set_applied_seq(&mut self, seq: u64) {
+        self.index.set_last_applied_seq(Some(seq));
+    }
+
+    /// Apply a coalesced final-state tail (ADR-079 Amendment 1) to this
+    /// bridge: for each subject, `Some(embedding)` replays a final upsert
+    /// (tombstone the mapped old ordinal, then exactly one insert) and `None`
+    /// replays a final delete (tombstone if mapped, no-op otherwise). `new_s`
+    /// is the highest tail seq, stamped as the new applied watermark. Any
+    /// id-map contradiction returns `Err` — the caller escalates to Cold.
+    pub(crate) fn apply_final_ops(
+        &mut self,
+        ops: Vec<(Uuid, Option<Vec<f32>>)>,
+        new_s: u64,
+    ) -> Result<(), String> {
+        // Highest ordinal wins for a repeated uuid: inserts append, so the
+        // latest slot is the live one; earlier slots are tombstoned.
+        let mut reverse: HashMap<Uuid, u32> = HashMap::with_capacity(self.id_map.len());
+        for (ordinal, uuid) in self.id_map.iter().enumerate() {
+            reverse.insert(*uuid, ordinal as u32);
+        }
+
+        for (uuid, op) in ops {
+            match op {
+                None => {
+                    if let Some(&ordinal) = reverse.get(&uuid) {
+                        self.index
+                            .tombstone(ordinal)
+                            .map_err(|e| format!("replay tombstone({ordinal}): {e}"))?;
+                        reverse.remove(&uuid);
+                    }
+                }
+                Some(mut embedding) => {
+                    l2_normalize(&mut embedding);
+                    if let Some(&old) = reverse.get(&uuid) {
+                        self.index
+                            .tombstone(old)
+                            .map_err(|e| format!("replay tombstone({old}): {e}"))?;
+                    }
+                    let ordinal = self
+                        .index
+                        .insert(&embedding)
+                        .map_err(|e| format!("replay insert: {e}"))?;
+                    let slot = ordinal as usize;
+                    match slot.cmp(&self.id_map.len()) {
+                        std::cmp::Ordering::Less => self.id_map[slot] = uuid,
+                        std::cmp::Ordering::Equal => self.id_map.push(uuid),
+                        std::cmp::Ordering::Greater => {
+                            return Err(format!(
+                                "replay insert returned ordinal {ordinal} beyond id_map len {}",
+                                self.id_map.len()
+                            ));
+                        }
+                    }
+                    reverse.insert(uuid, ordinal);
+                }
+            }
+        }
+        self.index.set_last_applied_seq(Some(new_s));
+        Ok(())
     }
 
     pub fn search(&self, query: &[f32], k: usize) -> Vec<(Uuid, f32)> {
@@ -672,6 +763,340 @@ pub(crate) fn persist_ann_v2(
     }
 }
 
+/// Stable, scope-bearing consumer identity for the knowledge atom index
+/// (ADR-079 Amendment 1): pack name plus the corpus predicate's field value,
+/// so the same predicate always maps to the same `ann_consumer_watermark`
+/// row across restarts.
+const ANN_CONSUMER: &str = "knowledge:knowledge.atom";
+
+const ANN_REBUILD_THRESHOLD_DEFAULT: f64 = 0.20;
+
+/// `ann_rebuild_threshold` (ADR-079 Amendment 1 §5): the tail fraction of the
+/// live vector count above which replay costs more than a full rebuild.
+/// Values outside `(0, 1]` fall back to the default.
+fn ann_rebuild_threshold() -> f64 {
+    std::env::var("KHIVE_ANN_REBUILD_THRESHOLD")
+        .ok()
+        .and_then(|v| v.parse::<f64>().ok())
+        .filter(|v| *v > 0.0 && *v <= 1.0)
+        .unwrap_or(ANN_REBUILD_THRESHOLD_DEFAULT)
+}
+
+/// Durably register this consumer's watermark row at 0 (`INSERT OR IGNORE`).
+///
+/// MUST run before the consumer persists or serves any extended-format
+/// segment for the scope: a row at 0 blocks pair-wide compaction instead of
+/// hiding this consumer from the registry `MIN` (ADR-079 Amendment 1 §A
+/// step 1).
+async fn register_consumer(rt: &KhiveRuntime, ns: &str, model: &str) -> Result<(), String> {
+    let sql = rt.sql();
+    let mut w = sql.writer().await.map_err(|e| e.to_string())?;
+    w.execute(SqlStatement {
+        sql: "INSERT OR IGNORE INTO ann_consumer_watermark \
+              (consumer, namespace, embedding_model, watermark) VALUES (?1, ?2, ?3, 0)"
+            .into(),
+        params: vec![
+            SqlValue::Text(ANN_CONSUMER.into()),
+            SqlValue::Text(ns.to_owned()),
+            SqlValue::Text(model.to_owned()),
+        ],
+        label: Some("ann_register_consumer".into()),
+    })
+    .await
+    .map_err(|e| e.to_string())?;
+    Ok(())
+}
+
+/// Read this consumer's own registry watermark. `None` = no row (decision
+/// rule 4: Cold after re-registering at 0).
+async fn read_own_watermark(
+    rt: &KhiveRuntime,
+    ns: &str,
+    model: &str,
+) -> Result<Option<i64>, String> {
+    let sql = rt.sql();
+    let mut reader = sql.reader().await.map_err(|e| e.to_string())?;
+    let rows = reader
+        .query_all(SqlStatement {
+            sql: "SELECT watermark FROM ann_consumer_watermark \
+                  WHERE consumer = ?1 AND namespace = ?2 AND embedding_model = ?3"
+                .into(),
+            params: vec![
+                SqlValue::Text(ANN_CONSUMER.into()),
+                SqlValue::Text(ns.to_owned()),
+                SqlValue::Text(model.to_owned()),
+            ],
+            label: Some("ann_read_own_watermark".into()),
+        })
+        .await
+        .map_err(|e| e.to_string())?;
+    Ok(rows
+        .into_iter()
+        .next()
+        .and_then(|row| match row.get("watermark") {
+            Some(SqlValue::Integer(n)) => Some(*n),
+            _ => None,
+        }))
+}
+
+/// Raise this consumer's registered watermark monotonically after a durable
+/// segment commit at `s` (ADR-079 Amendment 1 §A step 2). A crash before this
+/// leaves the smaller watermark — under-compacts, never over-compacts.
+async fn raise_watermark(rt: &KhiveRuntime, ns: &str, model: &str, s: u64) -> Result<(), String> {
+    let sql = rt.sql();
+    let mut w = sql.writer().await.map_err(|e| e.to_string())?;
+    w.execute(SqlStatement {
+        sql: "UPDATE ann_consumer_watermark SET watermark = MAX(watermark, ?4) \
+              WHERE consumer = ?1 AND namespace = ?2 AND embedding_model = ?3"
+            .into(),
+        params: vec![
+            SqlValue::Text(ANN_CONSUMER.into()),
+            SqlValue::Text(ns.to_owned()),
+            SqlValue::Text(model.to_owned()),
+            SqlValue::Integer(s as i64),
+        ],
+        label: Some("ann_raise_watermark".into()),
+    })
+    .await
+    .map_err(|e| e.to_string())?;
+    Ok(())
+}
+
+/// Compact the write log through the pair-wide registry minimum ONLY (ADR-079
+/// Amendment 1 §A step 3). The scalar subquery yields NULL when no consumer
+/// has registered, and `seq <= NULL` matches nothing — an unregistered pair
+/// never compacts.
+async fn compact_log(rt: &KhiveRuntime, ns: &str, model: &str) -> Result<(), String> {
+    let sql = rt.sql();
+    let mut w = sql.writer().await.map_err(|e| e.to_string())?;
+    w.execute(SqlStatement {
+        sql: "DELETE FROM ann_write_log \
+              WHERE namespace = ?1 AND embedding_model = ?2 \
+                AND seq <= (SELECT MIN(watermark) FROM ann_consumer_watermark \
+                             WHERE namespace = ?1 AND embedding_model = ?2)"
+            .into(),
+        params: vec![
+            SqlValue::Text(ns.to_owned()),
+            SqlValue::Text(model.to_owned()),
+        ],
+        label: Some("ann_compact_log".into()),
+    })
+    .await
+    .map_err(|e| e.to_string())?;
+    Ok(())
+}
+
+/// Live corpus count and tail count for this consumer's scope, captured in ONE
+/// statement so both come from the same SQLite read snapshot (the decision
+/// table requires the live count and the tail to describe one state).
+async fn scope_counts(
+    rt: &KhiveRuntime,
+    ns: &str,
+    model: &str,
+    s: u64,
+) -> Result<(u64, u64), String> {
+    let table_name = format!("vec_{}", sanitize_model_key(model));
+    let sql = rt.sql();
+    let mut reader = sql.reader().await.map_err(|e| e.to_string())?;
+    let rows = reader
+        .query_all(SqlStatement {
+            sql: format!(
+                "SELECT \
+                   (SELECT COUNT(*) FROM {table_name} \
+                     WHERE namespace = ?1 AND embedding_model = ?2 \
+                       AND field = 'knowledge.atom') AS live, \
+                   (SELECT COUNT(*) FROM ann_write_log \
+                     WHERE namespace = ?1 AND embedding_model = ?2 \
+                       AND field = 'knowledge.atom' AND seq > ?3) AS tail"
+            ),
+            params: vec![
+                SqlValue::Text(ns.to_owned()),
+                SqlValue::Text(model.to_owned()),
+                SqlValue::Integer(s as i64),
+            ],
+            label: Some("ann_scope_counts".into()),
+        })
+        .await
+        .map_err(|e| e.to_string())?;
+    let row = rows
+        .into_iter()
+        .next()
+        .ok_or("scope_counts returned no row")?;
+    let get = |col: &str| match row.get(col) {
+        Some(SqlValue::Integer(n)) => u64::try_from(*n).map_err(|_| format!("negative {col}")),
+        other => Err(format!("scope_counts {col}: unexpected value {other:?}")),
+    };
+    Ok((get("live")?, get("tail")?))
+}
+
+/// Fetch the scope's tail (rows above `s`, ordered) and coalesce it to the
+/// final op per subject with the embeddings needed for final upserts, ready
+/// for [`AnnBridge::apply_final_ops`]. Returns the ops and the new watermark.
+/// A final upsert whose source row is missing is a contradiction → `Err`
+/// (caller escalates to Cold).
+async fn fetch_final_tail(
+    rt: &KhiveRuntime,
+    ns: &str,
+    model: &str,
+    s: u64,
+) -> Result<(Vec<(Uuid, Option<Vec<f32>>)>, u64), String> {
+    let sql = rt.sql();
+    let mut reader = sql.reader().await.map_err(|e| e.to_string())?;
+    let rows = reader
+        .query_all(SqlStatement {
+            sql: "SELECT seq, subject_id, op FROM ann_write_log \
+                  WHERE namespace = ?1 AND embedding_model = ?2 \
+                    AND field = 'knowledge.atom' AND seq > ?3 \
+                  ORDER BY seq"
+                .into(),
+            params: vec![
+                SqlValue::Text(ns.to_owned()),
+                SqlValue::Text(model.to_owned()),
+                SqlValue::Integer(s as i64),
+            ],
+            label: Some("ann_fetch_tail".into()),
+        })
+        .await
+        .map_err(|e| e.to_string())?;
+
+    let mut new_s = s;
+    // Ordered iteration + insert-overwrite = final op per subject wins.
+    let mut finals: Vec<(Uuid, bool)> = Vec::new();
+    let mut index_of: HashMap<Uuid, usize> = HashMap::new();
+    for row in &rows {
+        let seq = match row.get("seq") {
+            Some(SqlValue::Integer(n)) => *n,
+            _ => return Err("ann_write_log.seq: unexpected value".into()),
+        };
+        new_s = new_s.max(u64::try_from(seq).map_err(|_| "negative seq")?);
+        let uuid = match row.get("subject_id") {
+            Some(SqlValue::Text(t)) => {
+                Uuid::parse_str(t).map_err(|e| format!("tail subject_id {t}: {e}"))?
+            }
+            _ => return Err("ann_write_log.subject_id: unexpected value".into()),
+        };
+        let is_delete = match row.get("op") {
+            Some(SqlValue::Text(t)) => t == "delete",
+            _ => return Err("ann_write_log.op: unexpected value".into()),
+        };
+        match index_of.get(&uuid) {
+            Some(&i) => finals[i].1 = is_delete,
+            None => {
+                index_of.insert(uuid, finals.len());
+                finals.push((uuid, is_delete));
+            }
+        }
+    }
+
+    // Point-read the embeddings for final upserts, chunked under the SQLite
+    // parameter limit, always under the consumer's own scope predicate.
+    let upsert_ids: Vec<Uuid> = finals
+        .iter()
+        .filter(|(_, is_delete)| !is_delete)
+        .map(|(u, _)| *u)
+        .collect();
+    let mut embeddings: HashMap<Uuid, Vec<f32>> = HashMap::with_capacity(upsert_ids.len());
+    let table_name = format!("vec_{}", sanitize_model_key(model));
+    for chunk in upsert_ids.chunks(500) {
+        let placeholders: Vec<String> = (0..chunk.len()).map(|i| format!("?{}", i + 3)).collect();
+        let mut params = vec![
+            SqlValue::Text(ns.to_owned()),
+            SqlValue::Text(model.to_owned()),
+        ];
+        params.extend(chunk.iter().map(|u| SqlValue::Text(u.to_string())));
+        let rows = reader
+            .query_all(SqlStatement {
+                sql: format!(
+                    "SELECT subject_id, embedding FROM {table_name} \
+                     WHERE namespace = ?1 AND embedding_model = ?2 \
+                       AND field = 'knowledge.atom' \
+                       AND subject_id IN ({})",
+                    placeholders.join(", ")
+                ),
+                params,
+                label: Some("ann_tail_point_read".into()),
+            })
+            .await
+            .map_err(|e| e.to_string())?;
+        for row in &rows {
+            let (Some(SqlValue::Text(id_str)), Some(SqlValue::Blob(bytes))) =
+                (row.get("subject_id"), row.get("embedding"))
+            else {
+                continue;
+            };
+            let Ok(uuid) = Uuid::parse_str(id_str) else {
+                continue;
+            };
+            let vec: Vec<f32> = bytes
+                .chunks_exact(4)
+                .map(|c| f32::from_le_bytes([c[0], c[1], c[2], c[3]]))
+                .collect();
+            embeddings.insert(uuid, vec);
+        }
+    }
+
+    let mut ops: Vec<(Uuid, Option<Vec<f32>>)> = Vec::with_capacity(finals.len());
+    for (uuid, is_delete) in finals {
+        if is_delete {
+            ops.push((uuid, None));
+        } else {
+            let embedding = embeddings.remove(&uuid).ok_or_else(|| {
+                format!("final upsert for {uuid} has no source row (contradiction → Cold)")
+            })?;
+            ops.push((uuid, Some(embedding)));
+        }
+    }
+    Ok((ops, new_s))
+}
+
+/// Persist `bridge` at its applied watermark, raise this consumer's registry
+/// row, compact the pair's log through the registry MIN, then reopen the
+/// just-written segment via the mmap load path and swap it in for the Owned
+/// build product (ADR-079 Amendment 1 §B). Registration precedes the persist
+/// (§A step 1). On any persist/reopen failure the Owned bridge is installed
+/// instead — correctness first, memory second.
+pub(crate) async fn checkpoint_raise_compact_readopt(
+    rt: &KhiveRuntime,
+    ann: &SharedAnn,
+    key: &AnnKey,
+    ns: &str,
+    model: &str,
+    bridge: AnnBridge,
+    generation: u64,
+) {
+    let applied = bridge.index.last_applied_seq().unwrap_or(0);
+    if let Err(e) = register_consumer(rt, ns, model).await {
+        tracing::warn!(error = %e, "ann consumer registration failed; serving Owned, no persist");
+        install_replacing(ann, key, bridge.with_generation(generation)).await;
+        return;
+    }
+    if let Err(e) = persist_ann_v2(rt, ns, model, &bridge) {
+        tracing::error!(error = %e, "failed to persist v2 Vamana segment");
+        install_replacing(ann, key, bridge.with_generation(generation)).await;
+        return;
+    }
+    if let Err(e) = raise_watermark(rt, ns, model, applied).await {
+        tracing::warn!(error = %e, "ann watermark raise failed (under-compacts; safe)");
+    } else if let Err(e) = compact_log(rt, ns, model).await {
+        tracing::warn!(error = %e, "ann log compaction failed (retries next checkpoint)");
+    }
+    match ann_segment_dir(rt, ns, model) {
+        Some(dir) => match AnnBridge::load(&dir) {
+            Ok(mmap_bridge) => {
+                install_replacing(ann, key, mmap_bridge.with_generation(generation)).await;
+            }
+            Err(e) => {
+                tracing::warn!(error = %e, "mmap re-adoption failed; serving Owned build");
+                install_replacing(ann, key, bridge.with_generation(generation)).await;
+            }
+        },
+        None => {
+            // In-memory backend: nothing was persisted; serve the Owned build.
+            install_replacing(ann, key, bridge.with_generation(generation)).await;
+        }
+    }
+}
+
 /// Try to load a Vamana snapshot for `namespace`+`model` from `retrieval_snapshots`.
 ///
 /// Returns `Ok(None)` when the table is absent, the row is missing, or
@@ -731,7 +1156,7 @@ async fn scan_corpus_raw(
     rt: &KhiveRuntime,
     token: &NamespaceToken,
     model: &str,
-) -> Result<Option<(Vec<f32>, Vec<Uuid>)>, RuntimeError> {
+) -> Result<Option<(Vec<f32>, Vec<Uuid>, u64)>, RuntimeError> {
     let store = rt
         .vectors_for_model(token, model)
         .map_err(|e| RuntimeError::Internal(e.to_string()))?;
@@ -758,10 +1183,18 @@ async fn scan_corpus_raw(
         .await
         .map_err(|e| RuntimeError::Internal(e.to_string()))?;
 
+    // The uncorrelated scalar subquery evaluates inside the SAME statement —
+    // and therefore the same SQLite read snapshot — as the corpus rows, so
+    // the captured watermark S describes exactly this scan's state (ADR-079
+    // Amendment 1: watermark capture and corpus read are linearized).
     let rows = reader
         .query_all(SqlStatement {
             sql: format!(
-                "SELECT subject_id, embedding FROM {table_name} \
+                "SELECT subject_id, embedding, \
+                        (SELECT COALESCE(MAX(seq), 0) FROM ann_write_log \
+                          WHERE namespace = ?1 AND embedding_model = ?2 \
+                            AND field = 'knowledge.atom') AS log_s \
+                 FROM {table_name} \
                  WHERE namespace = ?1 AND embedding_model = ?2 \
                    AND field = 'knowledge.atom' \
                  ORDER BY subject_id"
@@ -778,6 +1211,13 @@ async fn scan_corpus_raw(
 
     let mut id_map: Vec<Uuid> = Vec::with_capacity(rows.len());
     let mut flat: Vec<f32> = Vec::with_capacity(rows.len() * dims);
+    let scan_watermark = rows
+        .first()
+        .and_then(|row| match row.get("log_s") {
+            Some(SqlValue::Integer(n)) => u64::try_from(*n).ok(),
+            _ => None,
+        })
+        .unwrap_or(0);
 
     for row in &rows {
         let id_str = match row.get("subject_id") {
@@ -807,7 +1247,7 @@ async fn scan_corpus_raw(
         return Ok(None);
     }
 
-    Ok(Some((flat, id_map)))
+    Ok(Some((flat, id_map, scan_watermark)))
 }
 
 /// Scan the sqlite-vec table and build a fresh `AnnBridge`.
@@ -818,36 +1258,16 @@ pub(crate) async fn load_and_build_from_vector_store(
     token: &NamespaceToken,
     model: &str,
 ) -> Result<Option<AnnBridge>, RuntimeError> {
-    let Some((flat, id_map)) = scan_corpus_raw(rt, token, model).await? else {
+    let Some((flat, id_map, scan_watermark)) = scan_corpus_raw(rt, token, model).await? else {
         return Ok(None);
     };
     let dims = flat.len() / id_map.len();
     AnnBridge::build(flat, dims, id_map)
-        .map(Some)
+        .map(|mut bridge| {
+            bridge.set_applied_seq(scan_watermark);
+            Some(bridge)
+        })
         .map_err(RuntimeError::Internal)
-}
-
-/// Hash the live corpus as it would appear inside a freshly built `AnnBridge`.
-///
-/// Scans the sqlite-vec corpus, L2-normalizes each vector in place (matching
-/// `AnnBridge::build` which calls `l2_normalize` exactly once per row), then
-/// passes the normalized flat buffer through `corpus_content_hash`.  Returns
-/// `None` when the corpus is empty or the model is not configured.
-///
-/// INVARIANT: normalize ONCE here, never re-normalize an already-normalized
-/// buffer.  Calling this on a buffer that has already been normalized produces a
-/// non-idempotent hash and causes always-stale comparisons.
-async fn live_content_hash(
-    rt: &KhiveRuntime,
-    token: &NamespaceToken,
-    model: &str,
-) -> Option<[u8; 32]> {
-    let (mut flat, id_map) = scan_corpus_raw(rt, token, model).await.ok()??;
-    let dims = flat.len() / id_map.len();
-    for row in flat.chunks_exact_mut(dims) {
-        l2_normalize(row);
-    }
-    Some(corpus_content_hash(&flat))
 }
 
 /// Delete all Vamana snapshots for `namespace` from `retrieval_snapshots`.
@@ -1025,6 +1445,161 @@ pub(crate) fn ensure_ann_background(rt: &KhiveRuntime, token: &NamespaceToken, a
     });
 }
 
+/// Outcome of the v2-segment decision table for one `(namespace, model)` scope.
+enum SegmentOutcome {
+    /// An index was installed (Hot, Stale-tail, or a served Stale-rebuild
+    /// segment whose replacement rebuild the caller must still run — those
+    /// return Cold instead so the rebuild path fires).
+    Installed,
+    /// Live corpus is zero: no ANN candidate may be served or replayed
+    /// (decision rule 5). Caller records the terminal unavailable marker.
+    Empty,
+    /// No trustworthy segment: fall through to the v1 / rebuild paths.
+    Cold,
+}
+
+/// ADR-079 Amendment 1 restart classifier (the 8-rule first-match decision
+/// table), evaluated for one consumer scope, followed by the matching
+/// adoption action. Replaces the retired full-corpus content-hash gate.
+#[allow(clippy::too_many_arguments)]
+async fn classify_and_adopt_segment(
+    rt: &KhiveRuntime,
+    token: &NamespaceToken,
+    ann: &SharedAnn,
+    key: &AnnKey,
+    ns: &str,
+    model: &str,
+    seg_dir: &std::path::Path,
+    target_generation: u64,
+) -> SegmentOutcome {
+    // Rule 1: commit record absent, corrupt, or invalid length → Cold.
+    let info = match read_commit_info(seg_dir) {
+        Ok(Some(info)) => info,
+        Ok(None) => return SegmentOutcome::Cold,
+        Err(e) => {
+            tracing::warn!(error = %e, dir = %seg_dir.display(),
+                "error reading v2 commit record; Cold");
+            return SegmentOutcome::Cold;
+        }
+    };
+
+    // Rule 2: readable but pre-amendment (no watermark) → Cold. Compaction
+    // stays blocked naturally: this consumer's registry row (0 until its
+    // first extended checkpoint) holds the pair MIN at 0.
+    let Some(s) = info.last_applied_seq else {
+        tracing::info!(namespace = %ns, model = %model,
+            "pre-amendment v2 segment (no watermark); Cold rebuild");
+        return SegmentOutcome::Cold;
+    };
+
+    // Rule 3: configured embedder dimensions ≠ segment dimensions → Cold.
+    match compute_fingerprint(rt, token, model).await {
+        Some(fp) if fp.dimensions as u64 == info.dimensions => {}
+        Some(fp) => {
+            tracing::info!(namespace = %ns, model = %model,
+                segment_dims = info.dimensions, live_dims = fp.dimensions,
+                "v2 segment dimension mismatch; Cold rebuild");
+            return SegmentOutcome::Cold;
+        }
+        None => return SegmentOutcome::Cold,
+    }
+
+    // Rule 4: own registry row absent for an extended-format state → Cold
+    // after re-registering at 0. Registration precedes every persist, so an
+    // absent row means administrative removal or registry loss — compaction
+    // may already have deleted this consumer's tail.
+    match read_own_watermark(rt, ns, model).await {
+        Ok(Some(_)) => {}
+        Ok(None) => {
+            tracing::info!(namespace = %ns, model = %model,
+                "ann consumer registry row absent; re-registering at 0, Cold rebuild");
+            if let Err(e) = register_consumer(rt, ns, model).await {
+                tracing::warn!(error = %e, "ann consumer re-registration failed");
+            }
+            return SegmentOutcome::Cold;
+        }
+        Err(e) => {
+            tracing::warn!(error = %e, "ann registry read failed; Cold");
+            return SegmentOutcome::Cold;
+        }
+    }
+
+    // Rules 5-8 read (live, tail) from one snapshot.
+    let (live, tail) = match scope_counts(rt, ns, model, s).await {
+        Ok(counts) => counts,
+        Err(e) => {
+            tracing::warn!(error = %e, "ann scope-count read failed; Cold");
+            return SegmentOutcome::Cold;
+        }
+    };
+
+    // Rule 5: zero live corpus → Empty, regardless of tail contents.
+    if live == 0 {
+        tracing::info!(namespace = %ns, model = %model,
+            "zero live corpus for scope; Empty (FTS/degraded path)");
+        return SegmentOutcome::Empty;
+    }
+
+    // Rule 6: no tail above S → Hot: mmap load, zero corpus IO.
+    if tail == 0 {
+        return match AnnBridge::load(seg_dir) {
+            Ok(bridge) => {
+                install_if_fresher(ann, key, bridge.with_generation(target_generation)).await;
+                SegmentOutcome::Installed
+            }
+            Err(e) => {
+                tracing::warn!(error = %e, dir = %seg_dir.display(),
+                    "Hot segment load failed; Cold rebuild");
+                SegmentOutcome::Cold
+            }
+        };
+    }
+
+    // Rule 7: tail within threshold → Stale-tail: mmap load + final-state
+    // replay, then checkpoint so the next restart's tail starts empty and the
+    // served bridge returns to mmap backing.
+    let threshold = (ann_rebuild_threshold() * live as f64).ceil() as u64;
+    if tail <= threshold {
+        let mut bridge = match AnnBridge::load(seg_dir) {
+            Ok(b) => b,
+            Err(e) => {
+                tracing::warn!(error = %e, dir = %seg_dir.display(),
+                    "Stale-tail segment load failed; Cold rebuild");
+                return SegmentOutcome::Cold;
+            }
+        };
+        let (ops, new_s) = match fetch_final_tail(rt, ns, model, s).await {
+            Ok(t) => t,
+            Err(e) => {
+                tracing::warn!(error = %e, "tail replay contradiction; Cold rebuild");
+                return SegmentOutcome::Cold;
+            }
+        };
+        if let Err(e) = bridge.apply_final_ops(ops, new_s) {
+            tracing::warn!(error = %e, "tail replay failed; Cold rebuild");
+            return SegmentOutcome::Cold;
+        }
+        checkpoint_raise_compact_readopt(rt, ann, key, ns, model, bridge, target_generation).await;
+        return SegmentOutcome::Installed;
+    }
+
+    // Rule 8: tail above threshold → Stale-rebuild: serve the checksum-valid
+    // segment while the caller's rebuild path replaces it (`install_replacing`
+    // on completion). Cost decision, never a demotion to Cold/FTS-only.
+    match AnnBridge::load(seg_dir) {
+        Ok(bridge) => {
+            tracing::info!(namespace = %ns, model = %model, tail, live,
+                "tail above rebuild threshold; serving stale segment during rebuild");
+            install_if_fresher(ann, key, bridge.with_generation(target_generation)).await;
+        }
+        Err(e) => {
+            tracing::warn!(error = %e, dir = %seg_dir.display(),
+                "Stale-rebuild segment load failed; rebuilding without serve-stale");
+        }
+    }
+    SegmentOutcome::Cold
+}
+
 /// Lazy warm-load for a specific `model`. Load order (first hit wins): (1)
 /// in-memory cache fast path, (2) v2 segment directory (content-hash gated),
 /// (3) legacy v1 JSON snapshot, (4) full corpus rebuild, atomically persisted
@@ -1074,64 +1649,28 @@ pub(crate) async fn ensure_ann_for_model(
         );
     }
 
-    // 2. v2 segment path.
+    // 2. v2 segment path — ADR-079 Amendment 1 watermark classifier. Total,
+    // first-match decision table over the persisted commit record, this
+    // consumer's registry row, and one same-snapshot (live, tail) read.
     if let Some(seg_dir) = ann_segment_dir(rt, &ns, model) {
-        match read_commit_fingerprint(&seg_dir) {
-            Ok(Some(persisted)) => {
-                // Cheap count+dims gate before hashing the full corpus.
-                let current_fp = compute_fingerprint(rt, token, model).await;
-                let count_dims_ok = current_fp.is_some_and(|fp| {
-                    fp.vector_count == persisted.vector_count
-                        && fp.dimensions as u64 == persisted.dimensions
-                });
-                if count_dims_ok {
-                    // Full content-hash check (normalizes corpus once).
-                    if let Some(live_hash) = live_content_hash(rt, token, model).await {
-                        if live_hash == persisted.content_hash {
-                            match AnnBridge::load(&seg_dir) {
-                                Ok(bridge) => {
-                                    install_if_fresher(
-                                        ann,
-                                        &key,
-                                        bridge.with_generation(target_generation),
-                                    )
-                                    .await;
-                                    return;
-                                }
-                                Err(e) => {
-                                    tracing::warn!(
-                                        error = %e,
-                                        dir = %seg_dir.display(),
-                                        "v2 segment load failed; falling through to rebuild"
-                                    );
-                                }
-                            }
-                        } else {
-                            tracing::info!(
-                                namespace = %ns,
-                                model = %model,
-                                "stale v2 segment (content-hash mismatch); rebuilding"
-                            );
-                        }
-                    }
-                } else {
-                    tracing::info!(
-                        namespace = %ns,
-                        model = %model,
-                        "stale v2 segment (count/dims mismatch); rebuilding"
-                    );
-                }
+        match classify_and_adopt_segment(
+            rt,
+            token,
+            ann,
+            &key,
+            &ns,
+            model,
+            &seg_dir,
+            target_generation,
+        )
+        .await
+        {
+            SegmentOutcome::Installed => return,
+            SegmentOutcome::Empty => {
+                mark_unavailable(ann, &key, target_generation);
+                return;
             }
-            Ok(None) => {
-                // No v2 segments yet (or torn write) — fall through to v1 / rebuild.
-            }
-            Err(e) => {
-                tracing::warn!(
-                    error = %e,
-                    dir = %seg_dir.display(),
-                    "error reading v2 segment fingerprint; falling through"
-                );
-            }
+            SegmentOutcome::Cold => {} // fall through to v1 / rebuild
         }
     }
 
@@ -1160,13 +1699,12 @@ pub(crate) async fn ensure_ann_for_model(
         }
     }
 
-    // 4. Rebuild fallthrough — build from vector store and persist v2 segments.
+    // 4. Rebuild fallthrough — build from vector store, persist v2 segments,
+    // raise the registry watermark, compact the log, and re-adopt as mmap.
     match load_and_build_from_vector_store(rt, token, model).await {
         Ok(Some(bridge)) => {
-            if let Err(e) = persist_ann_v2(rt, &ns, model, &bridge) {
-                tracing::error!(error = %e, "failed to persist v2 Vamana segment after rebuild");
-            }
-            install_if_fresher(ann, &key, bridge.with_generation(target_generation)).await;
+            checkpoint_raise_compact_readopt(rt, ann, &key, &ns, model, bridge, target_generation)
+                .await;
         }
         Ok(None) => {
             // Empty corpus: this scan (at target_generation) proves nothing is
@@ -2148,6 +2686,24 @@ mod tests {
             })
             .await
             .expect("insert corpus row");
+            // Mirror the production write path: every vector mutation appends
+            // a write-log row in the same funnel (ADR-079 Amendment 1).
+            w.execute(SqlStatement {
+                sql: "INSERT INTO ann_write_log \
+                      (namespace, embedding_model, kind, field, subject_id, op) \
+                      VALUES (?1, ?2, ?3, ?4, ?5, 'upsert')"
+                    .into(),
+                params: vec![
+                    SqlValue::Text(ns.clone()),
+                    SqlValue::Text(WARM_TEST_MODEL.to_string()),
+                    SqlValue::Text("concept".to_string()),
+                    SqlValue::Text("knowledge.atom".to_string()),
+                    SqlValue::Text(id.to_string()),
+                ],
+                label: None,
+            })
+            .await
+            .expect("append write-log row");
         }
     }
 
@@ -2196,8 +2752,9 @@ mod tests {
 
     /// Cold-start build persists v2 segments; a second call restores from disk.
     ///
-    /// Also gates the normalize-once invariant: `live_content_hash` must equal the
-    /// persisted commit hash, proving the Hot branch can fire without double-normalization.
+    /// Also gates the watermark contract: the persisted commit record must carry
+    /// `last_applied_seq` covering the seeded writes, so the second call's
+    /// classifier sees an empty tail and takes the Hot branch.
     #[tokio::test]
     async fn ensure_ann_round_trip_hot() {
         let dir = TempDir::new().expect("tempdir");
@@ -2214,23 +2771,28 @@ mod tests {
             "first call must build the ANN index"
         );
 
-        // Normalize-once invariant: the live corpus hash must equal the persisted
-        // commit hash.  A double-normalize bug produces always-stale hashes here.
+        // Watermark contract: the extended commit record must carry a numeric
+        // watermark covering every seeded write, so the tail above it is empty
+        // and the Hot branch can fire.
         let seg_dir = ann_segment_dir(&rt, "local", WARM_TEST_MODEL)
             .expect("file backend must have a seg_dir");
         assert!(
             seg_dir.join("metadata.bin").exists(),
             "first call must persist v2 segments (metadata.bin missing)"
         );
-        let persisted = read_commit_fingerprint(&seg_dir)
-            .expect("read_commit_fingerprint must not err")
-            .expect("metadata.bin must carry a v2 fingerprint");
-        let live = live_content_hash(&rt, &token, WARM_TEST_MODEL)
+        let info = read_commit_info(&seg_dir)
+            .expect("read_commit_info must not err")
+            .expect("metadata.bin must carry a v2 commit record");
+        let s = info
+            .last_applied_seq
+            .expect("checkpoint must persist an extended record with a watermark");
+        let (live, tail) = scope_counts(&rt, "local", WARM_TEST_MODEL, s)
             .await
-            .expect("live_content_hash must return Some for a seeded corpus");
+            .expect("scope_counts must succeed");
+        assert!(live > 0, "seeded corpus must be live");
         assert_eq!(
-            live, persisted.content_hash,
-            "live_content_hash must equal persisted content_hash (normalize-once invariant)"
+            tail, 0,
+            "watermark must cover every seeded write (empty tail)"
         );
 
         // Hot path: load from persisted v2 segments without rebuilding. A rebuild
@@ -2257,10 +2819,9 @@ mod tests {
         );
     }
 
-    /// After a corpus mutation the persisted v2 segment is stale and triggers a rebuild.
-    ///
-    /// Proves the stale branch is actually exercised (not silently falling through to rebuild),
-    /// and that the rebuild re-persists v2 segments matching the mutated corpus.
+    /// After a corpus mutation the persisted segment has a non-empty tail and the
+    /// classifier replays it (Stale-tail), re-persisting a checkpoint that
+    /// reflects the mutated corpus.
     #[tokio::test]
     async fn ensure_ann_stale_rebuild() {
         let dir = TempDir::new().expect("tempdir");
@@ -2277,43 +2838,51 @@ mod tests {
         // Mutate corpus: add one more row.
         seed_warm_corpus(&rt, &token, 1).await;
 
-        // Gate: after mutation, live hash must DIFFER from persisted — proves the stale
-        // branch will fire (not silently succeed with the same hash).
+        // Gate: the mutation's logged write must sit above the persisted
+        // watermark — the Stale-tail pre-condition.
         let seg_dir = ann_segment_dir(&rt, "local", WARM_TEST_MODEL)
             .expect("file backend must have a seg_dir");
-        let persisted_before = read_commit_fingerprint(&seg_dir)
-            .expect("read_commit_fingerprint must not err")
-            .expect("v2 fingerprint must be present after initial build");
-        let live_after_mutation = live_content_hash(&rt, &token, WARM_TEST_MODEL)
+        let info_before = read_commit_info(&seg_dir)
+            .expect("read_commit_info must not err")
+            .expect("v2 commit record must be present after initial build");
+        let s_before = info_before
+            .last_applied_seq
+            .expect("initial checkpoint must carry a watermark");
+        let (_, tail) = scope_counts(&rt, "local", WARM_TEST_MODEL, s_before)
             .await
-            .expect("live_content_hash must return Some");
-        assert_ne!(
-            live_after_mutation, persisted_before.content_hash,
-            "mutation must make live hash differ from persisted (stale-branch pre-condition)"
+            .expect("scope_counts must succeed");
+        assert!(
+            tail > 0,
+            "mutation must appear as a tail row above the watermark"
         );
 
-        // Fresh SharedAnn: stale v2 detected → rebuild from corpus.
+        // Fresh SharedAnn: non-empty tail detected → replay + checkpoint.
         let ann2 = new_shared();
         ensure_ann_for_model(&rt, &token, &ann2, WARM_TEST_MODEL).await;
         assert!(
             ann2.indexes.read().await.contains_key(&key),
-            "must rebuild the index after corpus mutation (stale v2 segment rejected)"
+            "must serve an index after corpus mutation (tail replayed)"
         );
 
-        // Rebuild must re-persist v2 segments matching the mutated (5-row) corpus.
-        let persisted_after = read_commit_fingerprint(&seg_dir)
-            .expect("read_commit_fingerprint after rebuild must not err")
-            .expect("v2 fingerprint must be present after rebuild");
-        let live_final = live_content_hash(&rt, &token, WARM_TEST_MODEL)
-            .await
-            .expect("live_content_hash must return Some after rebuild");
+        // The post-replay checkpoint must reflect the mutated (5-row) corpus
+        // and advance the watermark past the mutation's log row.
+        let info_after = read_commit_info(&seg_dir)
+            .expect("read_commit_info after replay must not err")
+            .expect("v2 commit record must be present after replay checkpoint");
         assert_eq!(
-            live_final, persisted_after.content_hash,
-            "rebuild must re-persist v2 matching the mutated corpus"
+            info_after.vector_count, 5,
+            "checkpoint must reflect the 5-row corpus (4 initial + 1 replayed)"
         );
+        let s_after = info_after
+            .last_applied_seq
+            .expect("replay checkpoint must carry a watermark");
+        assert!(s_after > s_before, "checkpoint must advance the watermark");
+        let (_, tail_after) = scope_counts(&rt, "local", WARM_TEST_MODEL, s_after)
+            .await
+            .expect("scope_counts must succeed");
         assert_eq!(
-            persisted_after.vector_count, 5,
-            "re-persisted segment must reflect the 5-row corpus (4 initial + 1 mutation)"
+            tail_after, 0,
+            "replayed tail must be covered by the new watermark"
         );
     }
 

--- a/crates/khive-quant/src/lib.rs
+++ b/crates/khive-quant/src/lib.rs
@@ -785,6 +785,13 @@ impl GsSq8Codec {
         self.gs_sq * u8_l2sq_u32(&a.codes, &b.codes) as f32
     }
 
+    /// [`Self::l2_sq`] over raw code slices, for callers that store codes in a
+    /// flat (possibly memory-mapped) buffer rather than per-vector allocations.
+    #[inline]
+    pub fn l2_sq_codes(&self, a: &[u8], b: &[u8]) -> f32 {
+        self.gs_sq * u8_l2sq_u32(a, b) as f32
+    }
+
     /// Number of dimensions.
     pub fn dims(&self) -> usize {
         self.min.len()

--- a/crates/khive-runtime/src/runtime.rs
+++ b/crates/khive-runtime/src/runtime.rs
@@ -317,6 +317,14 @@ impl KhiveRuntime {
         self.backend.data_dir()
     }
 
+    /// Root directory for this database's ANN segment tree (`<db-file>.ann/`
+    /// beside the file), or `None` for an in-memory backend. Scoped to the
+    /// database file itself so two databases sharing a parent directory can
+    /// never adopt each other's segments.
+    pub fn backend_ann_root(&self) -> Option<std::path::PathBuf> {
+        self.backend.ann_root()
+    }
+
     // ---- Store accessors (token-scoped) ----
 
     /// Get an EntityStore scoped to the token's namespace.

--- a/crates/khive-runtime/src/runtime.rs
+++ b/crates/khive-runtime/src/runtime.rs
@@ -406,6 +406,31 @@ impl KhiveRuntime {
         )?)
     }
 
+    /// Output dimensions for a named embedding model, resolved from the
+    /// embedder registry alone — no storage access. Mirrors
+    /// [`vectors_for_model`](Self::vectors_for_model)'s resolution order:
+    /// lattice aliases route through the enum when registered, otherwise the
+    /// custom provider's declared `dimensions()`. `None` when no such model
+    /// is registered.
+    pub fn embedder_dimensions(&self, model_name: &str) -> Option<usize> {
+        if let Some(model) = parse_embedding_model_alias(model_name) {
+            let key = model.to_string();
+            let in_registry = self
+                .embedder_registry
+                .read()
+                .map(|reg| reg.contains(&key))
+                .unwrap_or(false);
+            if in_registry {
+                return Some(model.dimensions());
+            }
+        }
+        self.embedder_registry
+            .read()
+            .ok()?
+            .get_provider(model_name)
+            .map(|p| p.dimensions())
+    }
+
     fn vectors_for_embedding_model(
         &self,
         token: &NamespaceToken,

--- a/crates/khive-vamana/src/graph.rs
+++ b/crates/khive-vamana/src/graph.rs
@@ -4,6 +4,49 @@ use std::collections::{BTreeMap, HashSet};
 
 use khive_quant::{GsEncodedVector, GsSq8Codec};
 use rand::prelude::*;
+
+/// Read-only view over per-node SQ8 codes, decoupling graph algorithms from
+/// how the codes are stored: per-vector heap allocations (build/mutation
+/// paths) or one flat, possibly memory-mapped buffer (segment load paths).
+#[derive(Clone, Copy)]
+pub enum CodesView<'a> {
+    /// One `GsEncodedVector` per node.
+    Owned(&'a [GsEncodedVector]),
+    /// Flat row-major code bytes, `dims` bytes per node.
+    Flat { bytes: &'a [u8], dims: usize },
+}
+
+impl<'a> CodesView<'a> {
+    /// Code bytes for node `i`.
+    #[inline]
+    pub fn code(&self, i: usize) -> &'a [u8] {
+        match self {
+            CodesView::Owned(v) => &v[i].codes,
+            CodesView::Flat { bytes, dims } => &bytes[i * dims..(i + 1) * dims],
+        }
+    }
+
+    /// Number of encoded nodes.
+    #[inline]
+    pub fn len(&self) -> usize {
+        match self {
+            CodesView::Owned(v) => v.len(),
+            CodesView::Flat { bytes, dims } => {
+                if *dims == 0 {
+                    0
+                } else {
+                    bytes.len() / dims
+                }
+            }
+        }
+    }
+
+    /// True when no nodes are encoded.
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+}
 #[cfg(feature = "parallel")]
 use rayon::prelude::*;
 
@@ -311,7 +354,7 @@ impl VamanaGraph {
     /// `vectors` into `encoded` first (see crates/khive-vamana/docs/api/algorithm.md#sq8-acquisition-tier).
     pub fn build_sq8(
         vectors: &[f32],
-        encoded: &[GsEncodedVector],
+        encoded: CodesView<'_>,
         codec: &GsSq8Codec,
         config: &VamanaConfig,
     ) -> Result<Self> {
@@ -352,7 +395,7 @@ impl VamanaGraph {
                 let propose = |(&node, prior_neighbors): (&u32, &Vec<u32>)| {
                     let mut visited = VisitedSet::new(num_vectors);
                     let query = row(vectors, config.dimensions, node);
-                    let query_enc = &encoded[node as usize];
+                    let query_enc = encoded.code(node as usize);
                     let search = greedy_search_inner_sq8(
                         vectors,
                         config.dimensions,
@@ -837,11 +880,11 @@ pub(crate) fn robust_prune_inner(
 pub(crate) fn greedy_search_inner_sq8(
     vectors: &[f32],
     dimensions: usize,
-    encoded: &[GsEncodedVector],
+    encoded: CodesView<'_>,
     codec: &GsSq8Codec,
     adjacency: &[Vec<u32>],
     query: &[f32],
-    query_enc: &GsEncodedVector,
+    query_enc: &[u8],
     start: u32,
     k: usize,
     search_list_size: usize,
@@ -860,7 +903,7 @@ pub(crate) fn greedy_search_inner_sq8(
         }
     }
 
-    let start_dist = codec.l2_sq(query_enc, &encoded[start as usize]);
+    let start_dist = codec.l2_sq_codes(query_enc, encoded.code(start as usize));
     visited.mark_if_new(start as usize);
 
     let mut frontier = vec![Candidate {
@@ -898,7 +941,7 @@ pub(crate) fn greedy_search_inner_sq8(
             if !visited.mark_if_new(neighbor as usize) {
                 continue;
             }
-            let d = codec.l2_sq(query_enc, &encoded[neighbor as usize]);
+            let d = codec.l2_sq_codes(query_enc, encoded.code(neighbor as usize));
             frontier.push(Candidate {
                 id: neighbor,
                 distance: d,
@@ -958,14 +1001,14 @@ pub(crate) fn greedy_search_inner_sq8(
 pub(crate) fn robust_prune_inner_sq8(
     vectors: &[f32],
     dimensions: usize,
-    encoded: &[GsEncodedVector],
+    encoded: CodesView<'_>,
     codec: &GsSq8Codec,
     node: u32,
     candidates: Vec<u32>,
     alpha: f64,
     max_degree: usize,
 ) -> Vec<u32> {
-    let node_enc = &encoded[node as usize];
+    let node_enc = encoded.code(node as usize);
     let mut seen = HashSet::new();
     let mut pool: Vec<(u32, f32)> = Vec::new();
 
@@ -976,7 +1019,7 @@ pub(crate) fn robust_prune_inner_sq8(
         if !seen.insert(candidate) {
             continue;
         }
-        let d2 = codec.l2_sq(node_enc, &encoded[candidate as usize]);
+        let d2 = codec.l2_sq_codes(node_enc, encoded.code(candidate as usize));
         pool.push((candidate, d2));
     }
 
@@ -1459,9 +1502,11 @@ mod tests {
             .with_alpha(1.0);
 
         set_max_passes(Some(1));
-        let one_pass = VamanaGraph::build_sq8(&raw, &encoded, &codec, &cfg).unwrap();
+        let one_pass =
+            VamanaGraph::build_sq8(&raw, CodesView::Owned(&encoded), &codec, &cfg).unwrap();
         set_max_passes(None);
-        let two_pass = VamanaGraph::build_sq8(&raw, &encoded, &codec, &cfg).unwrap();
+        let two_pass =
+            VamanaGraph::build_sq8(&raw, CodesView::Owned(&encoded), &codec, &cfg).unwrap();
 
         assert_ne!(
             one_pass, two_pass,
@@ -1791,8 +1836,9 @@ mod tests {
         let mut encoded = codec.encode_flat_par(&vectors, dim);
         encoded.truncate(0); // malformed: expected 2 encoded rows, actual 0
 
-        let result =
-            std::panic::catch_unwind(|| VamanaGraph::build_sq8(&vectors, &encoded, &codec, &cfg));
+        let result = std::panic::catch_unwind(|| {
+            VamanaGraph::build_sq8(&vectors, CodesView::Owned(&encoded), &codec, &cfg)
+        });
         assert!(matches!(
             result,
             Ok(Err(VamanaError::DimensionMismatch {

--- a/crates/khive-vamana/src/index.rs
+++ b/crates/khive-vamana/src/index.rs
@@ -316,7 +316,9 @@ impl VectorStorage {
     }
 }
 
+#[cfg(feature = "mmap")]
 const CODES_MAGIC: &[u8; 8] = b"KHVCODE1";
+#[cfg(feature = "mmap")]
 const CODES_HEADER_LEN: usize = 8 + 8 + 8 + 4 + 4;
 
 /// Storage for the per-node SQ8 code table: owned per-vector allocations
@@ -382,6 +384,7 @@ impl CodeStore {
 /// Serialize the SQ8 codec parameters and per-node codes into the `codes.bin`
 /// segment layout: magic, dims, count, gs, anisotropy_ratio, per-dimension
 /// minima, then `count * dims` code bytes in ordinal order.
+#[cfg(feature = "mmap")]
 fn encode_codes_bin(codec: &GsSq8Codec, codes: CodesView<'_>) -> Vec<u8> {
     let dims = codec.dims();
     let count = codes.len();
@@ -403,6 +406,7 @@ fn encode_codes_bin(codec: &GsSq8Codec, codes: CodesView<'_>) -> Vec<u8> {
 /// Parse and validate a `codes.bin` header, returning the reconstructed codec.
 /// The code bytes themselves stay in the caller's buffer/mapping at offset
 /// `CODES_HEADER_LEN + dims * 4`.
+#[cfg(feature = "mmap")]
 fn parse_codes_bin(data: &[u8], expected_dims: usize, expected_count: usize) -> Result<GsSq8Codec> {
     if data.len() < CODES_HEADER_LEN || &data[..8] != CODES_MAGIC {
         return Err(VamanaError::invalid_format(
@@ -2731,7 +2735,10 @@ struct V2Commit {
     /// so a legitimate watermark of 0 (empty log at save time) round-trips.
     last_applied_seq: Option<u64>,
     /// blake3 checksum of the `codes.bin` segment; `None` on pre-trailer
-    /// records and on containers that omit the codes segment.
+    /// records and on containers that omit the codes segment. Read only by
+    /// the mmap load path; parsed unconditionally so record validation stays
+    /// identical across feature sets.
+    #[cfg_attr(not(feature = "mmap"), allow(dead_code))]
     codes_hash: Option<[u8; 32]>,
 }
 
@@ -3475,25 +3482,10 @@ fn mmap_vectors(path: &Path, expected_len_f32: usize) -> Result<VectorStorage> {
     })
 }
 
-/// Read the v2 commit fingerprint from a persisted segment directory without
-/// loading the graph or vectors.
-///
-/// `path` is the segment directory; this function joins `metadata.bin`
-/// internally, matching the convention used by [`VamanaIndex::load`] and
-/// [`VamanaIndex::load_or_build`].
-///
-/// Returns `Ok(None)` when:
-/// - `path/metadata.bin` is absent (clean first run)
-/// - the record does not begin with the KHVVAMG2 magic (v1 format or
-///   unrelated file)
-/// - the record is too short or otherwise cannot be parsed (torn write)
-///
-/// In the `None` cases the caller should treat the segment as Cold and proceed
-/// to build. Returns `Err` only for unexpected IO failures (not `NotFound`).
-#[cfg(feature = "mmap")]
 /// Extended commit metadata: the corpus fingerprint plus the write-log
 /// watermark trailer. `last_applied_seq` is `None` for pre-amendment (short
 /// layout) records — the ADR-079 Amendment 1 classifier treats that as Cold.
+#[cfg(feature = "mmap")]
 pub struct PersistedCommitInfo {
     pub vector_count: u64,
     pub dimensions: u64,
@@ -3505,6 +3497,7 @@ pub struct PersistedCommitInfo {
 ///
 /// Same absence/corruption semantics as [`read_commit_fingerprint`]:
 /// `Ok(None)` for a missing file, v1 magic, or an unparseable record.
+#[cfg(feature = "mmap")]
 pub fn read_commit_info(path: &Path) -> Result<Option<PersistedCommitInfo>> {
     let metadata_path = path.join("metadata.bin");
     let bytes = match fs::read(&metadata_path) {
@@ -3526,6 +3519,22 @@ pub fn read_commit_info(path: &Path) -> Result<Option<PersistedCommitInfo>> {
     }
 }
 
+/// Read the v2 commit fingerprint from a persisted segment directory without
+/// loading the graph or vectors.
+///
+/// `path` is the segment directory; this function joins `metadata.bin`
+/// internally, matching the convention used by [`VamanaIndex::load`] and
+/// [`VamanaIndex::load_or_build`].
+///
+/// Returns `Ok(None)` when:
+/// - `path/metadata.bin` is absent (clean first run)
+/// - the record does not begin with the KHVVAMG2 magic (v1 format or
+///   unrelated file)
+/// - the record is too short or otherwise cannot be parsed (torn write)
+///
+/// In the `None` cases the caller should treat the segment as Cold and proceed
+/// to build. Returns `Err` only for unexpected IO failures (not `NotFound`).
+#[cfg(feature = "mmap")]
 pub fn read_commit_fingerprint(path: &Path) -> Result<Option<PersistedFingerprint>> {
     let metadata_path = path.join("metadata.bin");
     let bytes = match fs::read(&metadata_path) {

--- a/crates/khive-vamana/src/index.rs
+++ b/crates/khive-vamana/src/index.rs
@@ -1081,6 +1081,26 @@ impl VamanaIndex {
                 return Ok(index);
             }
 
+            // codes.bin is checksum-gated exactly like the other segments whenever the
+            // commit record carries a codes_hash: a missing or altered codes segment
+            // must never reach load_v2_fast's mmap parse, which trusts its header.
+            if let Some(expected) = commit.codes_hash {
+                let codes_ok = fs::read(path.join("codes.bin"))
+                    .map(|d| *blake3::hash(&d).as_bytes() == expected)
+                    .unwrap_or(false);
+                if !codes_ok {
+                    let config = VamanaConfig {
+                        dimensions: commit.index_meta.dimensions,
+                        max_degree: commit.index_meta.max_degree,
+                        search_list_size: commit.index_meta.search_list_size,
+                        alpha: commit.index_meta.alpha,
+                    };
+                    let index = Self::rebuild_from_corpus(corpus_vectors, config)?;
+                    index.save_atomic(path)?;
+                    return Ok(index);
+                }
+            }
+
             // Verify corpus fingerprint: dimensions, count, and content hash.
             let dim = commit.index_meta.dimensions;
             if dim == 0 || !corpus_vectors.len().is_multiple_of(dim) {

--- a/crates/khive-vamana/src/index.rs
+++ b/crates/khive-vamana/src/index.rs
@@ -3471,6 +3471,41 @@ fn mmap_vectors(path: &Path, expected_len_f32: usize) -> Result<VectorStorage> {
 /// In the `None` cases the caller should treat the segment as Cold and proceed
 /// to build. Returns `Err` only for unexpected IO failures (not `NotFound`).
 #[cfg(feature = "mmap")]
+/// Extended commit metadata: the corpus fingerprint plus the write-log
+/// watermark trailer. `last_applied_seq` is `None` for pre-amendment (short
+/// layout) records — the ADR-079 Amendment 1 classifier treats that as Cold.
+pub struct PersistedCommitInfo {
+    pub vector_count: u64,
+    pub dimensions: u64,
+    pub content_hash: [u8; 32],
+    pub last_applied_seq: Option<u64>,
+}
+
+/// Read the full v2 commit record from `path/metadata.bin`.
+///
+/// Same absence/corruption semantics as [`read_commit_fingerprint`]:
+/// `Ok(None)` for a missing file, v1 magic, or an unparseable record.
+pub fn read_commit_info(path: &Path) -> Result<Option<PersistedCommitInfo>> {
+    let metadata_path = path.join("metadata.bin");
+    let bytes = match fs::read(&metadata_path) {
+        Ok(b) => b,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(e) => return Err(e.into()),
+    };
+    if bytes.len() < 8 || &bytes[..8] != V2_COMMIT_MAGIC {
+        return Ok(None);
+    }
+    match parse_v2_commit(&bytes) {
+        Ok(commit) => Ok(Some(PersistedCommitInfo {
+            vector_count: commit.fingerprint.vector_count,
+            dimensions: commit.fingerprint.dimensions,
+            content_hash: commit.fingerprint.content_hash,
+            last_applied_seq: commit.last_applied_seq,
+        })),
+        Err(_) => Ok(None),
+    }
+}
+
 pub fn read_commit_fingerprint(path: &Path) -> Result<Option<PersistedFingerprint>> {
     let metadata_path = path.join("metadata.bin");
     let bytes = match fs::read(&metadata_path) {

--- a/crates/khive-vamana/src/index.rs
+++ b/crates/khive-vamana/src/index.rs
@@ -24,7 +24,7 @@ use crate::{
     error::{Result, VamanaError},
     graph::{
         greedy_search_inner, greedy_search_inner_sq8, is_tombstoned_bit, robust_prune_inner,
-        sort_dedup_u32, VamanaGraph, VisitedSet,
+        sort_dedup_u32, CodesView, VamanaGraph, VisitedSet,
     },
 };
 
@@ -316,6 +316,141 @@ impl VectorStorage {
     }
 }
 
+const CODES_MAGIC: &[u8; 8] = b"KHVCODE1";
+const CODES_HEADER_LEN: usize = 8 + 8 + 8 + 4 + 4;
+
+/// Storage for the per-node SQ8 code table: owned per-vector allocations
+/// (build and mutation paths) or the flat, memory-mapped `codes.bin` segment
+/// (v2 load path). Mirrors `VectorStorage`'s Owned/Mmap split.
+enum CodeStore {
+    Owned(Vec<GsEncodedVector>),
+    #[cfg(feature = "mmap")]
+    Mmap {
+        mmap: memmap2::Mmap,
+        dims: usize,
+        len: usize,
+    },
+}
+
+impl std::fmt::Debug for CodeStore {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Owned(v) => write!(f, "Owned(len={})", v.len()),
+            #[cfg(feature = "mmap")]
+            Self::Mmap { len, .. } => write!(f, "Mmap(len={len})"),
+        }
+    }
+}
+
+impl CodeStore {
+    fn view(&self) -> CodesView<'_> {
+        match self {
+            Self::Owned(v) => CodesView::Owned(v),
+            #[cfg(feature = "mmap")]
+            Self::Mmap { mmap, dims, len } => CodesView::Flat {
+                bytes: &mmap.as_ref()[CODES_HEADER_LEN + dims * 4..][..len * dims],
+                dims: *dims,
+            },
+        }
+    }
+
+    fn owned_mut(&mut self) -> Result<&mut Vec<GsEncodedVector>> {
+        match self {
+            Self::Owned(v) => Ok(v),
+            #[cfg(feature = "mmap")]
+            Self::Mmap { .. } => Err(VamanaError::invalid_format(
+                "codes: unexpected Mmap after ensure_owned".into(),
+            )),
+        }
+    }
+
+    fn ensure_owned(&mut self) {
+        #[cfg(feature = "mmap")]
+        if let Self::Mmap { len, .. } = self {
+            let len = *len;
+            let view = self.view();
+            let owned: Vec<GsEncodedVector> = (0..len)
+                .map(|i| GsEncodedVector {
+                    codes: view.code(i).to_vec(),
+                })
+                .collect();
+            *self = Self::Owned(owned);
+        }
+    }
+}
+
+/// Serialize the SQ8 codec parameters and per-node codes into the `codes.bin`
+/// segment layout: magic, dims, count, gs, anisotropy_ratio, per-dimension
+/// minima, then `count * dims` code bytes in ordinal order.
+fn encode_codes_bin(codec: &GsSq8Codec, codes: CodesView<'_>) -> Vec<u8> {
+    let dims = codec.dims();
+    let count = codes.len();
+    let mut buf = Vec::with_capacity(CODES_HEADER_LEN + dims * 4 + count * dims);
+    buf.extend_from_slice(CODES_MAGIC);
+    buf.extend_from_slice(&(dims as u64).to_le_bytes());
+    buf.extend_from_slice(&(count as u64).to_le_bytes());
+    buf.extend_from_slice(&codec.gs.to_le_bytes());
+    buf.extend_from_slice(&codec.anisotropy_ratio.to_le_bytes());
+    for m in &codec.min {
+        buf.extend_from_slice(&m.to_le_bytes());
+    }
+    for i in 0..count {
+        buf.extend_from_slice(codes.code(i));
+    }
+    buf
+}
+
+/// Parse and validate a `codes.bin` header, returning the reconstructed codec.
+/// The code bytes themselves stay in the caller's buffer/mapping at offset
+/// `CODES_HEADER_LEN + dims * 4`.
+fn parse_codes_bin(data: &[u8], expected_dims: usize, expected_count: usize) -> Result<GsSq8Codec> {
+    if data.len() < CODES_HEADER_LEN || &data[..8] != CODES_MAGIC {
+        return Err(VamanaError::invalid_format(
+            "codes.bin missing or bad magic".into(),
+        ));
+    }
+    let dims = usize::try_from(u64::from_le_bytes(data[8..16].try_into().unwrap()))
+        .map_err(|_| VamanaError::invalid_format("codes.bin dims overflow".into()))?;
+    let count = usize::try_from(u64::from_le_bytes(data[16..24].try_into().unwrap()))
+        .map_err(|_| VamanaError::invalid_format("codes.bin count overflow".into()))?;
+    let gs = f32::from_le_bytes(data[24..28].try_into().unwrap());
+    let anisotropy_ratio = f32::from_le_bytes(data[28..32].try_into().unwrap());
+    if dims != expected_dims || count != expected_count {
+        return Err(VamanaError::invalid_format(format!(
+            "codes.bin shape {count}x{dims} != expected {expected_count}x{expected_dims}"
+        )));
+    }
+    let expected_len = CODES_HEADER_LEN + dims * 4 + count * dims;
+    if data.len() != expected_len {
+        return Err(VamanaError::invalid_format(format!(
+            "codes.bin length {} != expected {expected_len}",
+            data.len()
+        )));
+    }
+    if !gs.is_finite() || gs <= 0.0 {
+        return Err(VamanaError::invalid_format(
+            "codes.bin non-positive gs".into(),
+        ));
+    }
+    let mut min = Vec::with_capacity(dims);
+    for d in 0..dims {
+        let off = CODES_HEADER_LEN + d * 4;
+        let v = f32::from_le_bytes(data[off..off + 4].try_into().unwrap());
+        if !v.is_finite() {
+            return Err(VamanaError::invalid_format(
+                "codes.bin non-finite min".into(),
+            ));
+        }
+        min.push(v);
+    }
+    Ok(GsSq8Codec {
+        min,
+        gs,
+        gs_sq: gs * gs,
+        anisotropy_ratio,
+    })
+}
+
 /// An in-memory Vamana ANN index over pre-normalized vectors.
 #[derive(Debug)]
 pub struct VamanaIndex {
@@ -338,8 +473,8 @@ pub struct VamanaIndex {
     // ---- SQ8 acquisition tier (ADR-052 §1, Step 2) ----
     /// Global-scale SQ8 codec trained over the build corpus; used for acquisition-tier distances.
     gs_codec: GsSq8Codec,
-    /// Pre-encoded corpus vectors (one `GsEncodedVector` per node, ordinal-stable).
-    gs_codes: Vec<GsEncodedVector>,
+    /// Pre-encoded corpus vectors, ordinal-stable (owned or mmap `codes.bin`).
+    gs_codes: CodeStore,
     /// External write-log watermark carried in the v2 commit record. `None` on
     /// indexes built or loaded from segments that predate the field; the
     /// storage layer that owns the log sets it before `save_atomic` and reads
@@ -396,7 +531,8 @@ impl VamanaIndex {
 
         let (gs_codec, gs_codes) = train_codec_and_encode(vectors, config.dimensions);
 
-        let graph = VamanaGraph::build_sq8(vectors, &gs_codes, &gs_codec, &config)?;
+        let graph =
+            VamanaGraph::build_sq8(vectors, CodesView::Owned(&gs_codes), &gs_codec, &config)?;
         let dimensions = config.dimensions;
 
         Ok(Self {
@@ -411,7 +547,7 @@ impl VamanaIndex {
             free_slots: Vec::new(),
             consolidation_tau: DEFAULT_CONSOLIDATION_TAU,
             gs_codec,
-            gs_codes,
+            gs_codes: CodeStore::Owned(gs_codes),
             last_applied_seq: None,
         })
     }
@@ -448,11 +584,11 @@ impl VamanaIndex {
             greedy_search_inner_sq8(
                 self.vectors()?,
                 self.dimensions,
-                &self.gs_codes,
+                self.gs_codes.view(),
                 &self.gs_codec,
                 self.graph.adjacency(),
                 query,
-                &query_enc,
+                &query_enc.codes,
                 self.graph.medoid(),
                 k,
                 self.config.search_list_size,
@@ -510,6 +646,7 @@ impl VamanaIndex {
             self.config.search_list_size,
             self.config.alpha,
             self.last_applied_seq,
+            None,
         );
 
         let mut segments = vec![
@@ -633,7 +770,7 @@ impl VamanaIndex {
             free_slots: parsed.free_slots,
             consolidation_tau: DEFAULT_CONSOLIDATION_TAU,
             gs_codec,
-            gs_codes,
+            gs_codes: CodeStore::Owned(gs_codes),
             last_applied_seq: commit.last_applied_seq,
         })
     }
@@ -711,7 +848,7 @@ impl VamanaIndex {
             free_slots: Vec::new(),
             consolidation_tau: DEFAULT_CONSOLIDATION_TAU,
             gs_codec,
-            gs_codes,
+            gs_codes: CodeStore::Owned(gs_codes),
             last_applied_seq: None,
         })
     }
@@ -731,9 +868,11 @@ impl VamanaIndex {
         let vectors_new = path.join("vectors.bin.v2new");
         let graph_new = path.join("graph.bin.v2new");
         let lifecycle_new = path.join("lifecycle.bin.v2new");
+        let codes_new = path.join("codes.bin.v2new");
         let vectors_path = path.join("vectors.bin");
         let graph_path = path.join("graph.bin");
         let lifecycle_path = path.join("lifecycle.bin");
+        let codes_path = path.join("codes.bin");
         let metadata_path = path.join("metadata.bin");
         let metadata_tmp = path.join("metadata.bin.tmp");
 
@@ -758,14 +897,27 @@ impl VamanaIndex {
             self.ops_since_consolidation,
         )?;
 
-        // 5. Compute blake3 checksums of the three staged segments.
+        // 4b. Write codes.bin.v2new (SQ8 codec + per-node codes, ADR-052
+        // acquisition tier) so the load path never retrains over the corpus.
+        {
+            let buf = encode_codes_bin(&self.gs_codec, self.gs_codes.view());
+            let file = File::create(&codes_new)?;
+            let mut w = std::io::BufWriter::new(file);
+            w.write_all(&buf)?;
+            let file = w.into_inner().map_err(|e| e.into_error())?;
+            file.sync_all()?;
+        }
+
+        // 5. Compute blake3 checksums of the four staged segments.
         let vectors_data = fs::read(&vectors_new)?;
         let graph_data = fs::read(&graph_new)?;
         let lifecycle_data = fs::read(&lifecycle_new)?;
+        let codes_data = fs::read(&codes_new)?;
 
         let vectors_hash = blake3::hash(&vectors_data);
         let graph_hash = blake3::hash(&graph_data);
         let lifecycle_hash = blake3::hash(&lifecycle_data);
+        let codes_hash = blake3::hash(&codes_data);
 
         // 6. Build the corpus fingerprint (content_hash = blake3 over raw vector bytes).
         let content_hash = *vectors_hash.as_bytes();
@@ -788,6 +940,7 @@ impl VamanaIndex {
             self.config.search_list_size,
             self.config.alpha,
             self.last_applied_seq,
+            Some(codes_hash.as_bytes()),
         )?;
         fs::rename(&metadata_tmp, &metadata_path)?;
 
@@ -805,6 +958,7 @@ impl VamanaIndex {
         fs::rename(&vectors_new, &vectors_path)?;
         fs::rename(&graph_new, &graph_path)?;
         fs::rename(&lifecycle_new, &lifecycle_path)?;
+        fs::rename(&codes_new, &codes_path)?;
 
         // 9. Sync the directory entry so all renames are durable.
         let dir_file = File::open(path)?;
@@ -1029,6 +1183,14 @@ impl VamanaIndex {
                 "v2 segment checksum mismatch".into(),
             ));
         }
+        if let Some(expected) = commit.codes_hash {
+            let codes_data = fs::read(path.join("codes.bin"))?;
+            if *blake3::hash(&codes_data).as_bytes() != expected {
+                return Err(VamanaError::invalid_format(
+                    "v2 codes segment checksum mismatch".into(),
+                ));
+            }
+        }
 
         Self::load_v2_fast(path, &lifecycle_data)
     }
@@ -1115,7 +1277,37 @@ impl VamanaIndex {
             )));
         }
 
-        let (gs_codec, gs_codes) = train_codec_and_encode(storage.as_slice()?, dimensions);
+        // Codes segment: mmap `codes.bin` when the commit record carries its
+        // checksum (extended format); otherwise retrain from the corpus — the
+        // compatibility path for segments written before the codes segment
+        // existed. Retraining touches every vector page; the extended format
+        // exists precisely to avoid that on the steady-state load.
+        let (gs_codec, gs_codes) = match commit.codes_hash {
+            Some(_) => {
+                let codes_path = path.join("codes.bin");
+                let file = File::open(&codes_path)?;
+                let byte_len = usize::try_from(file.metadata()?.len()).map_err(|_| {
+                    VamanaError::invalid_format("codes.bin file size exceeds usize".into())
+                })?;
+                // SAFETY: read-only mapping; callers must not mutate or
+                // truncate codes.bin while this index is alive (same contract
+                // as the vectors.bin mapping).
+                let mmap = unsafe { MmapOptions::new().len(byte_len).map(&file)? };
+                let codec = parse_codes_bin(mmap.as_ref(), dimensions, num_vectors)?;
+                (
+                    codec,
+                    CodeStore::Mmap {
+                        mmap,
+                        dims: dimensions,
+                        len: num_vectors,
+                    },
+                )
+            }
+            None => {
+                let (codec, codes) = train_codec_and_encode(storage.as_slice()?, dimensions);
+                (codec, CodeStore::Owned(codes))
+            }
+        };
 
         Ok(Self {
             vectors: storage,
@@ -1355,7 +1547,7 @@ impl VamanaIndex {
             free_slots: Vec::new(),
             consolidation_tau: DEFAULT_CONSOLIDATION_TAU,
             gs_codec,
-            gs_codes,
+            gs_codes: CodeStore::Owned(gs_codes),
             last_applied_seq: None,
         })
     }
@@ -1435,6 +1627,7 @@ impl VamanaIndex {
             let owned: Vec<f32> = self.vectors.as_slice()?.to_vec();
             self.vectors = VectorStorage::Owned(owned);
         }
+        self.gs_codes.ensure_owned();
         Ok(())
     }
 
@@ -1503,7 +1696,8 @@ impl VamanaIndex {
                 }
             }
             // Update SQ8 code for the recycled slot.
-            self.gs_codes[ordinal as usize] = self.gs_codec.encode(vector);
+            let code = self.gs_codec.encode(vector);
+            self.gs_codes.owned_mut()?[ordinal as usize] = code;
         } else {
             // Append path: assign next ordinal and extend storage.
             ordinal = self.num_vectors as u32;
@@ -1529,7 +1723,8 @@ impl VamanaIndex {
                 }
             }
             // Append SQ8 code for the new slot.
-            self.gs_codes.push(self.gs_codec.encode(vector));
+            let code = self.gs_codec.encode(vector);
+            self.gs_codes.owned_mut()?.push(code);
         }
 
         // Graph wiring.
@@ -1746,9 +1941,12 @@ impl VamanaIndex {
         new_graph.rebuild_reverse_adj_from_adjacency();
 
         // Compact the SQ8 code table to match the new ordinal space.
+        let codes_view = self.gs_codes.view();
         let new_gs_codes: Vec<GsEncodedVector> = new_to_old
             .iter()
-            .map(|&old| self.gs_codes[old as usize].clone())
+            .map(|&old| GsEncodedVector {
+                codes: codes_view.code(old as usize).to_vec(),
+            })
             .collect();
 
         self.graph = new_graph;
@@ -1758,7 +1956,7 @@ impl VamanaIndex {
         self.tombstone_count = 0;
         self.free_slots.clear();
         self.ops_since_consolidation = 0;
-        self.gs_codes = new_gs_codes;
+        self.gs_codes = CodeStore::Owned(new_gs_codes);
 
         Ok(new_to_old)
     }
@@ -2512,6 +2710,9 @@ struct V2Commit {
     /// (short layout) — the record length, not a sentinel value, discriminates,
     /// so a legitimate watermark of 0 (empty log at save time) round-trips.
     last_applied_seq: Option<u64>,
+    /// blake3 checksum of the `codes.bin` segment; `None` on pre-trailer
+    /// records and on containers that omit the codes segment.
+    codes_hash: Option<[u8; 32]>,
 }
 
 /// Parsed lifecycle.bin content.
@@ -2537,6 +2738,7 @@ fn write_v2_commit_full(
     search_list_size: usize,
     alpha: f64,
     last_applied_seq: Option<u64>,
+    codes_hash: Option<&[u8; 32]>,
 ) -> Result<()> {
     let buf = encode_v2_commit_full(
         vectors_hash,
@@ -2549,6 +2751,7 @@ fn write_v2_commit_full(
         search_list_size,
         alpha,
         last_applied_seq,
+        codes_hash,
     );
     let file = File::create(path)?;
     let mut w = std::io::BufWriter::new(file);
@@ -2570,6 +2773,7 @@ fn encode_v2_commit_full(
     search_list_size: usize,
     alpha: f64,
     last_applied_seq: Option<u64>,
+    codes_hash: Option<&[u8; 32]>,
 ) -> Vec<u8> {
     let mut buf = Vec::with_capacity(220);
     buf.extend_from_slice(V2_COMMIT_MAGIC);
@@ -2584,19 +2788,20 @@ fn encode_v2_commit_full(
     buf.extend_from_slice(&(max_degree as u64).to_le_bytes());
     buf.extend_from_slice(&(search_list_size as u64).to_le_bytes());
     buf.extend_from_slice(&alpha.to_le_bytes());
-    // Watermark trailer: presence byte + value. Written unconditionally so all
-    // new records share one length; readers of the short (pre-trailer) layout
-    // reject on length and rebuild, readers of this layout parse both.
-    match last_applied_seq {
-        Some(seq) => {
-            buf.push(1);
-            buf.extend_from_slice(&seq.to_le_bytes());
-        }
-        None => {
-            buf.push(0);
-            buf.extend_from_slice(&0u64.to_le_bytes());
-        }
+    // Fixed-size trailer: flags byte (bit0 = watermark present, bit1 =
+    // codes hash present) + watermark + codes hash. Written unconditionally so
+    // all new records share one length; the short pre-trailer layout parses as
+    // a pre-amendment record.
+    let mut flags = 0u8;
+    if last_applied_seq.is_some() {
+        flags |= 1;
     }
+    if codes_hash.is_some() {
+        flags |= 2;
+    }
+    buf.push(flags);
+    buf.extend_from_slice(&last_applied_seq.unwrap_or(0).to_le_bytes());
+    buf.extend_from_slice(codes_hash.unwrap_or(&[0u8; 32]));
     buf
 }
 
@@ -2604,9 +2809,9 @@ fn encode_v2_commit_full(
 fn parse_v2_commit(data: &[u8]) -> Result<V2Commit> {
     // magic(8) + 3 hashes(96) + fp.vector_count(8) + fp.dimensions(8) + fp.content_hash(32)
     // + num_vectors(8) + dimensions(8) + max_degree(8) + search_list_size(8) + alpha(8)
-    // + optional watermark trailer: presence(1) + last_applied_seq(8)
+    // + optional trailer: flags(1) + last_applied_seq(8) + codes_hash(32)
     let base_len = 8 + 32 + 32 + 32 + 8 + 8 + 32 + 8 + 8 + 8 + 8 + 8;
-    let trailer_len = base_len + 9;
+    let trailer_len = base_len + 41;
     if data.len() != base_len && data.len() != trailer_len {
         return Err(VamanaError::invalid_format(format!(
             "v2 commit record length {} != {base_len} or {trailer_len}",
@@ -2665,13 +2870,19 @@ fn parse_v2_commit(data: &[u8]) -> Result<V2Commit> {
     let alpha = f64::from_le_bytes(data[offset..offset + 8].try_into().unwrap());
     offset += 8;
 
-    let last_applied_seq = if data.len() == trailer_len {
-        let present = data[offset] == 1;
+    let (last_applied_seq, codes_hash) = if data.len() == trailer_len {
+        let flags = data[offset];
         offset += 1;
-        let value = u64::from_le_bytes(data[offset..offset + 8].try_into().unwrap());
-        present.then_some(value)
+        let seq = u64::from_le_bytes(data[offset..offset + 8].try_into().unwrap());
+        offset += 8;
+        let mut hash = [0u8; 32];
+        hash.copy_from_slice(&data[offset..offset + 32]);
+        (
+            (flags & 1 != 0).then_some(seq),
+            (flags & 2 != 0).then_some(hash),
+        )
     } else {
-        None
+        (None, None)
     };
 
     if num_vectors == 0 {
@@ -2716,6 +2927,7 @@ fn parse_v2_commit(data: &[u8]) -> Result<V2Commit> {
             alpha,
         },
         last_applied_seq,
+        codes_hash,
     })
 }
 
@@ -4488,11 +4700,11 @@ mod tests {
         let sq8_only = greedy_search_inner_sq8(
             vecs,
             DIM,
-            &index.gs_codes,
+            index.gs_codes.view(),
             &index.gs_codec,
             index.graph.adjacency(),
             &query,
-            &query_enc,
+            &query_enc.codes,
             index.graph.medoid(),
             1,
             index.config.search_list_size,
@@ -4577,11 +4789,11 @@ mod tests {
         let sq8_result = greedy_search_inner_sq8(
             &vectors,
             DIM,
-            &encoded,
+            CodesView::Owned(&encoded),
             &codec,
             &adjacency,
             &query,
-            &query_enc,
+            &query_enc.codes,
             0, // start at node 0
             2,
             4,
@@ -4617,7 +4829,7 @@ mod tests {
         let sq8_prune = robust_prune_inner_sq8(
             &vectors,
             DIM,
-            &encoded,
+            CodesView::Owned(&encoded),
             &codec,
             2, // node
             vec![0, 1],
@@ -4686,8 +4898,16 @@ mod tests {
         let f32_result = robust_prune_inner(&vectors, DIM, 0, vec![1, 2], 1.2, 4);
 
         // SQ8 RobustPrune — after the predicate fix, must match f32.
-        let sq8_result =
-            robust_prune_inner_sq8(&vectors, DIM, &encoded, &codec, 0, vec![1, 2], 1.2, 4);
+        let sq8_result = robust_prune_inner_sq8(
+            &vectors,
+            DIM,
+            CodesView::Owned(&encoded),
+            &codec,
+            0,
+            vec![1, 2],
+            1.2,
+            4,
+        );
 
         println!(
             "sq8_prune_predicate | f32={f32_result:?}  sq8={sq8_result:?}  \

--- a/crates/khive-vamana/src/index.rs
+++ b/crates/khive-vamana/src/index.rs
@@ -340,6 +340,11 @@ pub struct VamanaIndex {
     gs_codec: GsSq8Codec,
     /// Pre-encoded corpus vectors (one `GsEncodedVector` per node, ordinal-stable).
     gs_codes: Vec<GsEncodedVector>,
+    /// External write-log watermark carried in the v2 commit record. `None` on
+    /// indexes built or loaded from segments that predate the field; the
+    /// storage layer that owns the log sets it before `save_atomic` and reads
+    /// it back after load to classify restart state.
+    last_applied_seq: Option<u64>,
 }
 
 struct IndexMetadata {
@@ -407,6 +412,7 @@ impl VamanaIndex {
             consolidation_tau: DEFAULT_CONSOLIDATION_TAU,
             gs_codec,
             gs_codes,
+            last_applied_seq: None,
         })
     }
 
@@ -503,6 +509,7 @@ impl VamanaIndex {
             self.config.max_degree,
             self.config.search_list_size,
             self.config.alpha,
+            self.last_applied_seq,
         );
 
         let mut segments = vec![
@@ -627,6 +634,7 @@ impl VamanaIndex {
             consolidation_tau: DEFAULT_CONSOLIDATION_TAU,
             gs_codec,
             gs_codes,
+            last_applied_seq: commit.last_applied_seq,
         })
     }
 
@@ -704,6 +712,7 @@ impl VamanaIndex {
             consolidation_tau: DEFAULT_CONSOLIDATION_TAU,
             gs_codec,
             gs_codes,
+            last_applied_seq: None,
         })
     }
 
@@ -778,6 +787,7 @@ impl VamanaIndex {
             self.config.max_degree,
             self.config.search_list_size,
             self.config.alpha,
+            self.last_applied_seq,
         )?;
         fs::rename(&metadata_tmp, &metadata_path)?;
 
@@ -1120,6 +1130,7 @@ impl VamanaIndex {
             consolidation_tau: DEFAULT_CONSOLIDATION_TAU,
             gs_codec,
             gs_codes,
+            last_applied_seq: commit.last_applied_seq,
         })
     }
 
@@ -1345,6 +1356,7 @@ impl VamanaIndex {
             consolidation_tau: DEFAULT_CONSOLIDATION_TAU,
             gs_codec,
             gs_codes,
+            last_applied_seq: None,
         })
     }
 
@@ -1371,6 +1383,19 @@ impl VamanaIndex {
     /// Return the flat row-major vector data as a slice.
     pub fn vectors(&self) -> Result<&[f32]> {
         self.vectors.as_slice()
+    }
+
+    /// Write-log watermark carried by the v2 commit record. `None` on indexes
+    /// built in-memory or loaded from segments predating the field.
+    pub fn last_applied_seq(&self) -> Option<u64> {
+        self.last_applied_seq
+    }
+
+    /// Set the write-log watermark to persist with the next [`Self::save_atomic`].
+    /// The caller owns the log and must pass the highest sequence whose write is
+    /// reflected in this index's current state.
+    pub fn set_last_applied_seq(&mut self, seq: Option<u64>) {
+        self.last_applied_seq = seq;
     }
 
     // ---- PR2: lifecycle API (ADR-052 §2) ----
@@ -2483,6 +2508,10 @@ struct V2Commit {
     lifecycle_hash: [u8; 32],
     fingerprint: V2CorpusFingerprint,
     index_meta: IndexMetadata,
+    /// Write-log watermark trailer. `None` when the record predates the field
+    /// (short layout) — the record length, not a sentinel value, discriminates,
+    /// so a legitimate watermark of 0 (empty log at save time) round-trips.
+    last_applied_seq: Option<u64>,
 }
 
 /// Parsed lifecycle.bin content.
@@ -2507,6 +2536,7 @@ fn write_v2_commit_full(
     max_degree: usize,
     search_list_size: usize,
     alpha: f64,
+    last_applied_seq: Option<u64>,
 ) -> Result<()> {
     let buf = encode_v2_commit_full(
         vectors_hash,
@@ -2518,6 +2548,7 @@ fn write_v2_commit_full(
         max_degree,
         search_list_size,
         alpha,
+        last_applied_seq,
     );
     let file = File::create(path)?;
     let mut w = std::io::BufWriter::new(file);
@@ -2538,8 +2569,9 @@ fn encode_v2_commit_full(
     max_degree: usize,
     search_list_size: usize,
     alpha: f64,
+    last_applied_seq: Option<u64>,
 ) -> Vec<u8> {
-    let mut buf = Vec::with_capacity(200);
+    let mut buf = Vec::with_capacity(220);
     buf.extend_from_slice(V2_COMMIT_MAGIC);
     buf.extend_from_slice(vectors_hash);
     buf.extend_from_slice(graph_hash);
@@ -2552,6 +2584,19 @@ fn encode_v2_commit_full(
     buf.extend_from_slice(&(max_degree as u64).to_le_bytes());
     buf.extend_from_slice(&(search_list_size as u64).to_le_bytes());
     buf.extend_from_slice(&alpha.to_le_bytes());
+    // Watermark trailer: presence byte + value. Written unconditionally so all
+    // new records share one length; readers of the short (pre-trailer) layout
+    // reject on length and rebuild, readers of this layout parse both.
+    match last_applied_seq {
+        Some(seq) => {
+            buf.push(1);
+            buf.extend_from_slice(&seq.to_le_bytes());
+        }
+        None => {
+            buf.push(0);
+            buf.extend_from_slice(&0u64.to_le_bytes());
+        }
+    }
     buf
 }
 
@@ -2559,10 +2604,12 @@ fn encode_v2_commit_full(
 fn parse_v2_commit(data: &[u8]) -> Result<V2Commit> {
     // magic(8) + 3 hashes(96) + fp.vector_count(8) + fp.dimensions(8) + fp.content_hash(32)
     // + num_vectors(8) + dimensions(8) + max_degree(8) + search_list_size(8) + alpha(8)
-    let expected_len = 8 + 32 + 32 + 32 + 8 + 8 + 32 + 8 + 8 + 8 + 8 + 8;
-    if data.len() != expected_len {
+    // + optional watermark trailer: presence(1) + last_applied_seq(8)
+    let base_len = 8 + 32 + 32 + 32 + 8 + 8 + 32 + 8 + 8 + 8 + 8 + 8;
+    let trailer_len = base_len + 9;
+    if data.len() != base_len && data.len() != trailer_len {
         return Err(VamanaError::invalid_format(format!(
-            "v2 commit record length {} != {expected_len}",
+            "v2 commit record length {} != {base_len} or {trailer_len}",
             data.len()
         )));
     }
@@ -2616,6 +2663,16 @@ fn parse_v2_commit(data: &[u8]) -> Result<V2Commit> {
     .map_err(|_| VamanaError::invalid_format("v2 commit search_list_size overflow".into()))?;
     offset += 8;
     let alpha = f64::from_le_bytes(data[offset..offset + 8].try_into().unwrap());
+    offset += 8;
+
+    let last_applied_seq = if data.len() == trailer_len {
+        let present = data[offset] == 1;
+        offset += 1;
+        let value = u64::from_le_bytes(data[offset..offset + 8].try_into().unwrap());
+        present.then_some(value)
+    } else {
+        None
+    };
 
     if num_vectors == 0 {
         return Err(VamanaError::invalid_format(
@@ -2658,6 +2715,7 @@ fn parse_v2_commit(data: &[u8]) -> Result<V2Commit> {
             search_list_size,
             alpha,
         },
+        last_applied_seq,
     })
 }
 

--- a/crates/khive-vamana/src/lib.rs
+++ b/crates/khive-vamana/src/lib.rs
@@ -15,6 +15,7 @@ pub use index::{
     corpus_content_hash, CorpusFingerprint, PersistedFingerprint, VamanaIndex, VamanaIndexSnapshot,
     VamanaSnapshot, VAMANA_SNAPSHOT_FORMAT, VAMANA_SNAPSHOT_VERSION,
 };
+pub use index::{read_commit_info, PersistedCommitInfo};
 
 /// Build a Vamana index from a flat row-major vector slice.
 pub fn build(vectors: &[f32], config: VamanaConfig) -> Result<VamanaIndex> {

--- a/crates/khive-vamana/src/lib.rs
+++ b/crates/khive-vamana/src/lib.rs
@@ -15,6 +15,7 @@ pub use index::{
     corpus_content_hash, CorpusFingerprint, PersistedFingerprint, VamanaIndex, VamanaIndexSnapshot,
     VamanaSnapshot, VAMANA_SNAPSHOT_FORMAT, VAMANA_SNAPSHOT_VERSION,
 };
+#[cfg(feature = "mmap")]
 pub use index::{read_commit_info, PersistedCommitInfo};
 
 /// Build a Vamana index from a flat row-major vector slice.

--- a/crates/khive-vamana/tests/persistence.rs
+++ b/crates/khive-vamana/tests/persistence.rs
@@ -346,6 +346,80 @@ fn v2_crash_corrupted_metadata_falls_back_to_rebuild() {
     assert!(!rebuilt.search(&query, 3).unwrap().is_empty());
 }
 
+/// A checksum-invalid codes.bin with a still-valid header must never reach the
+/// fast mmap parse: load_or_build rebuilds and rewrites the segment.
+#[cfg(feature = "mmap")]
+#[test]
+fn v2_corrupt_codes_segment_triggers_rebuild_in_load_or_build() {
+    let dim = 4usize;
+    let vectors = rand_unit_vectors(20, dim, 0xC0_DE);
+    let cfg = VamanaConfig::with_dimensions(dim)
+        .with_max_degree(4)
+        .with_search_list_size(8);
+    let idx = VamanaIndex::build(&vectors, cfg).unwrap();
+
+    let dir = tempfile::tempdir().unwrap();
+    idx.save_atomic(dir.path()).unwrap();
+
+    // Flip the last byte (a quantized code, well past the header) so the header
+    // still parses but the blake3 gate must reject the segment.
+    let codes_path = dir.path().join("codes.bin");
+    let mut codes = fs::read(&codes_path).unwrap();
+    let last = codes.len() - 1;
+    codes[last] ^= 0xff;
+    fs::write(&codes_path, &codes).unwrap();
+    let corrupted = codes;
+
+    let fallback = VamanaConfig::with_dimensions(dim)
+        .with_max_degree(4)
+        .with_search_list_size(8);
+    let loaded = VamanaIndex::load_or_build(dir.path(), &vectors, fallback).unwrap();
+    assert_eq!(loaded.num_vectors(), idx.num_vectors());
+
+    // The rebuild path re-runs save_atomic, replacing the corrupted bytes. A
+    // fast-path load would have left the corrupt file in place untouched.
+    let after = fs::read(&codes_path).unwrap();
+    assert_ne!(
+        after, corrupted,
+        "load_or_build accepted a checksum-invalid codes.bin via the fast path"
+    );
+    let query = rand_unit_vectors(1, dim, 0xdef);
+    assert!(!loaded.search(&query, 3).unwrap().is_empty());
+}
+
+/// A partially truncated extended trailer (base + 40 bytes) is an invalid
+/// commit-record length — rule 1 (corrupt) rather than rule 2 (pre-amendment).
+#[cfg(feature = "mmap")]
+#[test]
+fn v2_truncated_extended_trailer_is_invalid() {
+    let dim = 4usize;
+    let vectors = rand_unit_vectors(12, dim, 0x7A_11);
+    let cfg = VamanaConfig::with_dimensions(dim)
+        .with_max_degree(4)
+        .with_search_list_size(8);
+    let idx = VamanaIndex::build(&vectors, cfg).unwrap();
+
+    let dir = tempfile::tempdir().unwrap();
+    idx.save_atomic(dir.path()).unwrap();
+
+    let meta_path = dir.path().join("metadata.bin");
+    let meta = fs::read(&meta_path).unwrap();
+    fs::write(&meta_path, &meta[..meta.len() - 1]).unwrap();
+
+    // The commit-record reader must reject the malformed length outright.
+    assert!(
+        khive_vamana::read_commit_info(dir.path()).is_err(),
+        "a base+40-byte record must not parse as either base or extended"
+    );
+
+    // load_or_build recovers by rebuilding, mirroring the corrupt-metadata case.
+    let fallback = VamanaConfig::with_dimensions(dim)
+        .with_max_degree(4)
+        .with_search_list_size(8);
+    let rebuilt = VamanaIndex::load_or_build(dir.path(), &vectors, fallback).unwrap();
+    assert_eq!(rebuilt.num_vectors(), idx.num_vectors());
+}
+
 /// Fingerprint mismatch: modify corpus → load_or_build triggers rebuild.
 #[cfg(feature = "mmap")]
 #[test]

--- a/crates/khive-vamana/tests/persistence.rs
+++ b/crates/khive-vamana/tests/persistence.rs
@@ -406,9 +406,13 @@ fn v2_truncated_extended_trailer_is_invalid() {
     let meta = fs::read(&meta_path).unwrap();
     fs::write(&meta_path, &meta[..meta.len() - 1]).unwrap();
 
-    // The commit-record reader must reject the malformed length outright.
+    // The commit-record reader must reject the malformed length: it reports
+    // an unparseable record as None (torn write), never as a valid base or
+    // extended record.
     assert!(
-        khive_vamana::read_commit_info(dir.path()).is_err(),
+        khive_vamana::read_commit_info(dir.path())
+            .expect("reading a present but malformed record is not an IO error")
+            .is_none(),
         "a base+40-byte record must not parse as either base or extended"
     );
 

--- a/crates/khive-vamana/tests/portable.rs
+++ b/crates/khive-vamana/tests/portable.rs
@@ -164,6 +164,6 @@ fn fixed_seed_build_has_feature_independent_graph_and_search_digest() {
     }
     assert_eq!(
         blake3::hash(&bytes).to_hex().as_str(),
-        "19d4c2097fbd58d54920724d5a2749370166e345406e06b80fc71e745b52feee"
+        "86afcf6147c2de6da5f7d03e1df9f171e400c1ea4e73134debbc09d42129e91d"
     );
 }


### PR DESCRIPTION
Implements ADR-079 Amendment 1 (#1128) for the knowledge pack — the daemon memory lane.

## What changes

**khive-db**
- Migration 011: `ann_write_log` (AUTOINCREMENT seq) + `ann_consumer_watermark` registry table.
- Write path appends one log row per vector upsert/delete in the same transaction as the mutation.

**khive-vamana**
- `codes.bin` becomes the fifth checksummed v2 segment (SQ8 codec params + codes persisted); `load_v2_fast` mmaps codes instead of retraining, killing the retrain-on-load anonymous allocation and the full-corpus page touch.
- Extended v2 commit record: unconditional 41-byte trailer (flags, `last_applied_seq`, `codes_hash`); parser accepts base and extended lengths, so pre-amendment segments still load (and classify Cold per rule 2).
- New `read_commit_info` — reads the commit record without loading the segment.

**khive-pack-knowledge**
- The O(corpus) content-hash restart classifier is replaced by the 8-rule first-match decision table over the write log: Hot restarts are mmap-only (zero corpus IO), small tails replay final-state per subject (Stale-tail), large tails serve the checksum-valid stale segment while rebuilding in the background (Stale-rebuild).
- Three-step registry protocol: register-at-0-before-persist, monotonic raise-after-commit, compaction bounded by the per-pair registry MIN (never a checkpoint-local watermark).
- Every checkpoint/rebuild re-adopts its own segment as mmap, so steady-state memory is file-backed page cache rather than anonymous heap.

## Notes for review
- `ann_rebuild_threshold` is env-only for now (`KHIVE_ANN_REBUILD_THRESHOLD`, default 0.20, clamped to (0,1]); TOML/CLI binding follows in a config PR.
- `compact_log` uses the per-pair predicate; the wildcard-inclusive form specified for global-scope consumers rides the memory-pack PR alongside its addendum (#1131).
- Portability digest pin updated (the unconditional trailer changes `to_bytes` output); verified identical across default and `--all-features` builds.

## Validation
- `cargo test --workspace --all-features` green on this tree (4200+ tests), including 4 new interleaving tests from design review: zero-watermark first-write, delete-all→Empty, compaction bounded by pair minimum, pre-amendment record→Cold.