### PR TITLE
docs(ann): qualify zero-live rule and document segment-root migration

### DIFF
--- a/crates/khive-pack-knowledge/docs/api/vamana.md
+++ b/crates/khive-pack-knowledge/docs/api/vamana.md
@@ -8,12 +8,16 @@ Source: `crates/khive-pack-knowledge/src/knowledge/vamana.rs` (entire module is
 Wraps `khive_vamana::VamanaIndex` with an ID map (u32 → UUID) so search results can be
 fused with FTS5 candidates via RRF.
 
-Persistence (ADR-079): v2 binary segments are written to `data_dir/ann/<hex>/` on every
-cold-start rebuild or explicit reindex. `ensure_ann_for_model` checks the v2 segment
-directory first (content-hash gated), falling back to legacy v1 JSON rows in
-`retrieval_snapshots` for in-place upgrades, then rebuilds from the full sqlite-vec corpus
-on cache-miss. `kkernel reindex` re-persists v2 segments and calls `invalidate_snapshot` to
-clean up stale v1 rows.
+Persistence (ADR-079, Amendment 1): v2 binary segments are written to
+`<db-file>.ann/<hex>/` — a database-scoped root beside the backing database file, so
+co-located databases can never adopt each other's segments — on every cold-start rebuild
+or explicit reindex. `ensure_ann_for_model` checks the v2 segment directory first, gated
+by the write-log restart classifier (`classify_and_adopt_segment`: commit-record and
+watermark checks, then a log-table tail probe, ahead of any corpus read — see the
+ADR-079 Amendment 1 decision table for the full rule order), falling back to legacy v1
+JSON rows in `retrieval_snapshots` for in-place upgrades, then rebuilds from the full
+sqlite-vec corpus on cache-miss. `kkernel reindex` re-persists v2 segments and calls
+`invalidate_snapshot` to clean up stale v1 rows.
 
 This module exceeds the 700-line soft target because it owns the complete Vamana ANN
 lifecycle for knowledge search: `SharedAnn` type, `AnnKey`, snapshot persistence
@@ -48,10 +52,14 @@ corpus `content_hash` taken from the v2 commit record.
 First hit wins:
 
 1. **Fast path** — already in the in-memory cache; return immediately.
-2. **v2 segment path** — if a `data_dir/ann/<hex>/` directory exists with a valid
-   `metadata.bin`, compare its `content_hash` against a freshly computed
-   `live_content_hash`. On match, load the Vamana binary segments directly via
-   `AnnBridge::load` (O(load), no rebuild). On mismatch, fall through.
+2. **v2 segment path** — if a `<db-file>.ann/<hex>/` directory exists with a valid
+   `metadata.bin`, run the ADR-079 Amendment 1 restart classifier
+   (`classify_and_adopt_segment`): a per-write delta log (`ann_write_log`) plus each
+   consumer's durable watermark replace the old full-corpus content-hash check, so a
+   Hot classification loads the Vamana binary segments directly via `AnnBridge::load`
+   (O(load), zero corpus I/O) instead of hashing the live corpus on every restart. A
+   short tail replays incrementally (Stale-tail); a long tail serves the existing
+   segment while rebuilding in the background (Stale-rebuild). On Cold, fall through.
 3. **v1 JSON snapshot path** — try `retrieval_snapshots`; on hit, validate the
    `CorpusFingerprint` (count + dims) and restore from JSON. On miss / stale / corrupt,
    fall through.

--- a/crates/khive-pack-knowledge/src/knowledge/vamana.rs
+++ b/crates/khive-pack-knowledge/src/knowledge/vamana.rs
@@ -9,8 +9,9 @@
 //! Vamana ANN bridge — parallel semantic signal for `knowledge.search`.
 //!
 //! Wraps `khive_vamana::VamanaIndex` with an ID map (u32 → UUID) so search
-//! results can be fused with FTS5 candidates via RRF. Persistence (ADR-079):
-//! v2 binary segments under `data_dir/ann/<hex>/`, falling back to legacy v1
+//! results can be fused with FTS5 candidates via RRF. Persistence (ADR-079,
+//! Amendment 1): v2 binary segments under `<db-file>.ann/<hex>/`, restored
+//! through the write-log restart classifier, falling back to legacy v1
 //! JSON snapshot rows, then a full corpus rebuild on cache-miss. See
 //! crates/khive-pack-knowledge/docs/api/vamana.md for the persistence
 //! fallback chain and the file-size/module-coupling rationale.
@@ -615,9 +616,11 @@ pub(crate) fn snapshot_key(namespace: &str, model: &str) -> String {
 
 /// Filesystem directory for v2 Vamana segment files for a given `(ns, model)` pair.
 ///
-/// Returns `Some(data_dir/ann/<hex>)` where `<hex>` is the lowercase hex encoding of
-/// the bytes of `snapshot_key(ns, model)`. Hex encoding is injective, filesystem-safe,
-/// and reversible via `decode_ann_dir_name`. Returns `None` for in-memory backends.
+/// Returns `Some(<db-file>.ann/<hex>)` where `<hex>` is the lowercase hex encoding of
+/// the bytes of `snapshot_key(ns, model)`, rooted beside the backing database file
+/// (`backend_ann_root`) so co-located databases can never adopt each other's segments.
+/// Hex encoding is injective, filesystem-safe, and reversible via
+/// `decode_ann_dir_name`. Returns `None` for in-memory backends.
 fn ann_segment_dir(rt: &KhiveRuntime, ns: &str, model: &str) -> Option<std::path::PathBuf> {
     let ann_root = rt.backend_ann_root()?;
     let key = snapshot_key(ns, model);
@@ -656,10 +659,10 @@ pub(crate) fn sanitize_model_key(s: &str) -> String {
         .collect()
 }
 
-/// Persist `bridge` as v2 Vamana segments under `data_dir/ann/<hex>/`.
+/// Persist `bridge` as v2 Vamana segments under `<db-file>.ann/<hex>/`.
 ///
 /// Resolves the segment directory via `ann_segment_dir`. Returns `Ok(())` when the
-/// backend is in-memory (no `data_dir`) — skipping persistence is not an error.
+/// backend is in-memory (no database file) — skipping persistence is not an error.
 /// `save_atomic` binds the id-map sidecar to the commit-record digest internally;
 /// callers do not need to supply a `CorpusFingerprint`.
 pub(crate) fn persist_ann_v2(
@@ -1573,8 +1576,9 @@ async fn classify_and_adopt_segment(
 }
 
 /// Lazy warm-load for a specific `model`. Load order (first hit wins): (1)
-/// in-memory cache fast path, (2) v2 segment directory (content-hash gated),
-/// (3) legacy v1 JSON snapshot, (4) full corpus rebuild, atomically persisted
+/// in-memory cache fast path, (2) v2 segment directory (ADR-079 Amendment 1
+/// write-log restart classifier — see `classify_and_adopt_segment`), (3)
+/// legacy v1 JSON snapshot, (4) full corpus rebuild, atomically persisted
 /// as v2 for next restart. See
 /// crates/khive-pack-knowledge/docs/api/vamana.md#ensure_ann_for_model-load-order
 /// for the per-step detail.

--- a/crates/khive-pack-memory/docs/api/ann-lifecycle.md
+++ b/crates/khive-pack-memory/docs/api/ann-lifecycle.md
@@ -92,6 +92,29 @@ Graph construction trains SQ8 quantization and builds Vamana synchronously, so i
 
 `warm_existing_memory_indexes` schedules indexes for registered embedding models at pack warm time. ANN search remains global, then recall post-filters hydrated hits to the token's visible namespaces. The namespace-aware over-fetch algorithm is documented in `crates/khive-pack-memory/docs/api/recall-pipeline.md`.
 
+## Segment-root migration (legacy `data_dir/ann` cleanup)
+
+ADR-079 Amendment 1 moved the ANN segment root from a directory shared by every database in a
+data directory to a database-scoped root: `<db-file>.ann/<hex>` beside the database file itself
+(`ann_root_for` in `crates/khive-db/src/backend.rs`), rather than `<data_dir>/ann/<hex>`. This
+applies to both consumers that persist through `backend_ann_root()` — the memory pack's own
+global-scope index (`crates/khive-pack-memory/src/ann.rs`) and the knowledge pack's
+per-namespace index (`crates/khive-pack-knowledge/src/knowledge/vamana.rs`).
+
+The move is not an in-place migration. A segment persisted under the old shared root is not
+copied or relinked to the new database-scoped root:
+
+- On the first warm after upgrading past this change, the restart classifier looks for a commit
+  record at the new `<db-file>.ann/<hex>` path, finds nothing, and classifies Cold (decision
+  rule 1) — the index rebuilds from the corpus and persists under the new root. This is a
+  one-time cost per `(namespace/global, model)` scope; every subsequent restart is Hot again
+  once the new segment exists.
+- The old `<data_dir>/ann/` tree is not read by any code path after the upgrade. It is safe to
+  remove once the new-root rebuild has completed (confirm the corresponding
+  `<db-file>.ann/<hex>` directory exists with a valid `metadata.bin`); nothing sweeps it
+  automatically today, so cleanup is a manual `rm -rf <data_dir>/ann` once you've verified the
+  new root is populated.
+
 ## Ordering and atomicity guarantees
 
 - Generation is captured before a build or fast-path decision.

--- a/docs/adr/ADR-079-ann-persistence-warm-path-integration.md
+++ b/docs/adr/ADR-079-ann-persistence-warm-path-integration.md
@@ -109,15 +109,15 @@ the lowercase-hex encoding of the snapshot key `"{namespace}::vamana::{model}"` 
 pair, decoded by the warm-path filesystem enumeration:
 
 ```
-<backend_data_dir>/ann/<hex(namespace::vamana::model)>/
+<db-file>.ann/<hex(namespace::vamana::model)>/
     {metadata.bin, graph.bin, vectors.bin, lifecycle.bin, external_ids.bin}
 ```
 
-**Segment root superseded (shipped with Amendment 1).** The root shown above changed from a
-directory shared by every database in `<backend_data_dir>` to a database-scoped
-`<db-file>.ann/<hex(...)>` root beside the database file itself (`ann_root_for` in
-`khive-db/src/backend.rs`), so two databases sharing a parent directory can never adopt each
-other's segments or UUID maps. Pre-existing segments under the old shared root are not migrated
+**Segment root superseded (shipped with Amendment 1).** As originally accepted, this ADR rooted
+segments at `<backend_data_dir>/ann/<hex(...)>` — a directory shared by every database in
+`<backend_data_dir>`. Amendment 1 changed the root to the database-scoped `<db-file>.ann/<hex(...)>`
+shown above, beside the database file itself (`ann_root_for` in `khive-db/src/backend.rs`), so two
+databases sharing a parent directory can never adopt each other's segments or UUID maps. Pre-existing segments under the old shared root are not migrated
 in place: the classifier finds no commit record at the new root, Colds, and rebuilds — a one-time
 cost after upgrade. The old `<backend_data_dir>/ann/` tree is then inert and safe to remove; see
 [ann-lifecycle.md](../../crates/khive-pack-memory/docs/api/ann-lifecycle.md#segment-root-migration-legacy-data_dirann-cleanup)
@@ -472,11 +472,13 @@ CREATE TABLE ann_consumer_watermark (
 
 - **Evaluation order of rules 5 and 6.** An implementation may test rule 6's tail predicate (a
   log-table-only query) before rule 5's live count, and adopt Hot without ever running the live
-  count. The outcomes coincide: with an empty tail, the committed segment already reflects every
-  logged op at or below `S`, so a zero-live scope implies the segment itself holds zero live
-  vectors and adoption serves exactly what Empty serves. This ordering is what makes the Hot
-  path's zero-corpus-IO property literal — the live corpus count is executed only when a tail
-  exists (rules 5, 7, and 8), where corpus-scale work is already inherent.
+  count. For vector-scoped corpora the outcomes coincide: with an empty tail, the committed
+  segment already reflects every logged op at or below `S`, so a zero-live scope implies the
+  segment itself holds zero live vectors and adoption serves exactly what Empty serves. For
+  join-filtered corpora the equivalence is behavioral rather than structural — see the
+  qualification below. This ordering is what makes the Hot path's zero-corpus-IO property
+  literal — the live corpus count is executed only when a tail exists (rules 5, 7, and 8),
+  where corpus-scale work is already inherent.
 
 - **Rule 5 qualification for join-filtered corpora.** "Live corpus row count for the scope" is
   read under the consumer's own scope predicate (§"Scope rule" above), which for a join-filtered
@@ -485,11 +487,15 @@ CREATE TABLE ann_consumer_watermark (
   from the predicate without emitting an `ann_write_log` row or removing its vector row. A live
   count of zero under that predicate therefore means _no row currently satisfies the join
   predicate_, not that the persisted segment file is byte-empty — the segment's vectors.bin may
-  still contain filtered-out candidates from before the soft delete. Rule 5 still classifies this
-  case Empty and drops the index rather than serving it: adoption is decided by the predicate-scoped
-  live count, never by a raw segment/tail inspection. This is why the case is safe even though the
-  segment is not content-empty — recall never sees it, and if it were ever served, recall
-  post-filters hydrated hits against the same join predicate before returning them.
+  still contain filtered-out candidates from before the soft delete. Two consequences follow.
+  When rule 5 is evaluated (a tail exists), a zero live count classifies Empty on the
+  predicate-scoped count alone, never on a raw segment or tail inspection. When rule 6 fires
+  first (no tail), the segment may be adopted Hot even though every remaining candidate is
+  join-filtered — and this adoption is safe, not a defect: recall post-filters hydrated hits
+  against the same join predicate before returning them, so filtered candidates are never
+  surfaced. The cost of serving such a segment is bounded over-fetch waste, not correctness;
+  it self-corrects at the next logged write, whose tail routes the following restart through
+  rules 5, 7, or 8.
 
 - **Tail replay is a final-state delta, not an event replay.** Coalesce the tail to the highest
   `seq` per `subject_id`; only the final op is applied. A final `upsert` resolves the subject's

--- a/docs/adr/ADR-079-ann-persistence-warm-path-integration.md
+++ b/docs/adr/ADR-079-ann-persistence-warm-path-integration.md
@@ -113,6 +113,16 @@ pair, decoded by the warm-path filesystem enumeration:
     {metadata.bin, graph.bin, vectors.bin, lifecycle.bin, external_ids.bin}
 ```
 
+**Segment root superseded (shipped with Amendment 1).** The root shown above changed from a
+directory shared by every database in `<backend_data_dir>` to a database-scoped
+`<db-file>.ann/<hex(...)>` root beside the database file itself (`ann_root_for` in
+`khive-db/src/backend.rs`), so two databases sharing a parent directory can never adopt each
+other's segments or UUID maps. Pre-existing segments under the old shared root are not migrated
+in place: the classifier finds no commit record at the new root, Colds, and rebuilds — a one-time
+cost after upgrade. The old `<backend_data_dir>/ann/` tree is then inert and safe to remove; see
+[ann-lifecycle.md](../../crates/khive-pack-memory/docs/api/ann-lifecycle.md#segment-root-migration-legacy-data_dirann-cleanup)
+for the migration/cleanup note.
+
 The four Vamana segment files are ADR-052's crash-safe commit set, inherited unchanged: `metadata.bin`
 is the commit record (written last, via tmp-then-rename), alongside `graph.bin`, `vectors.bin`, and
 `lifecycle.bin` (tombstones, free slots, reverse adjacency, and the consolidation counter).
@@ -467,6 +477,19 @@ CREATE TABLE ann_consumer_watermark (
   vectors and adoption serves exactly what Empty serves. This ordering is what makes the Hot
   path's zero-corpus-IO property literal — the live corpus count is executed only when a tail
   exists (rules 5, 7, and 8), where corpus-scale work is already inherent.
+
+- **Rule 5 qualification for join-filtered corpora.** "Live corpus row count for the scope" is
+  read under the consumer's own scope predicate (§"Scope rule" above), which for a join-filtered
+  corpus (for example the memory index's note-scope) can exclude rows that a plain vec0 row-count
+  would still include: a soft delete on the joined table (not a vector delete) removes a subject
+  from the predicate without emitting an `ann_write_log` row or removing its vector row. A live
+  count of zero under that predicate therefore means _no row currently satisfies the join
+  predicate_, not that the persisted segment file is byte-empty — the segment's vectors.bin may
+  still contain filtered-out candidates from before the soft delete. Rule 5 still classifies this
+  case Empty and drops the index rather than serving it: adoption is decided by the predicate-scoped
+  live count, never by a raw segment/tail inspection. This is why the case is safe even though the
+  segment is not content-empty — recall never sees it, and if it were ever served, recall
+  post-filters hydrated hits against the same join predicate before returning them.
 
 - **Tail replay is a final-state delta, not an event replay.** Coalesce the tail to the highest
   `seq` per `subject_id`; only the final op is applied. A final `upsert` resolves the subject's


### PR DESCRIPTION
## Summary

Review follow-up.

- ADR-079 Amendment 1's rule 5 (zero live corpus → Empty) is qualified for
  join-filtered corpora: a zero live count under a consumer's scope predicate
  means the predicate currently selects nothing, not that the persisted
  segment file is byte-empty. Adoption stays safe either way — rule 5 drops
  the index rather than serving it, and recall post-filters any served hit
  against the same predicate.
- Documents that the ANN segment root moved from a shared
  `<data_dir>/ann/<hex>` tree to a database-scoped `<db-file>.ann/<hex>` root,
  and that pre-existing segments under the old root are not migrated in
  place — first restart after upgrade Colds and rebuilds under the new root;
  the old tree is then inert and safe to remove.
- Sweeps stale `data_dir/ann` path and content-hash-classifier comments in
  `vamana.rs`/`vamana.md` left over from the segment-root and
  restart-classifier changes.

Docs-only change, no behavior change.

Closes #1135, Closes #1136

## Test plan

- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps -p khive-pack-memory -p khive-pack-knowledge` — clean
- [x] pre-commit hooks (fmt, clippy, ADR-reference lint, deno fmt) — passed