### PR TITLE
refactor(pack-memory): drop the ignored namespace argument from AnnKey constructors

### DIFF
--- a/crates/khive-pack-memory/src/ann.rs
+++ b/crates/khive-pack-memory/src/ann.rs
@@ -28,13 +28,13 @@ pub(crate) struct AnnKey {
 }
 
 impl AnnKey {
-    pub(crate) fn new(_namespace: impl Into<String>, model: impl Into<String>) -> Self {
+    pub(crate) fn new(model: impl Into<String>) -> Self {
         Self {
             model: model.into(),
         }
     }
 
-    pub(crate) fn from_token(_token: &NamespaceToken, model: &str) -> Self {
+    pub(crate) fn from_token(model: &str) -> Self {
         Self {
             model: model.to_owned(),
         }
@@ -584,14 +584,14 @@ pub(crate) async fn wait_until_warm_idle(ann: &SharedAnn, key: &AnnKey) {
 /// Fire-once per-model background warm. Returns `true` if a new task was started.
 pub(crate) async fn ensure_ann_background(
     rt: &KhiveRuntime,
-    token: &NamespaceToken,
+    _token: &NamespaceToken,
     ann: &SharedAnn,
     model: &str,
 ) -> bool {
     if model.is_empty() {
         return false;
     }
-    let key = AnnKey::from_token(token, model);
+    let key = AnnKey::from_token(model);
 
     // Capture the generation before the fast path so the caller observes prior writes.
     let target_generation = current_generation(ann, &key).await;
@@ -740,7 +740,7 @@ pub(crate) async fn ensure_ann_for_model(
     if model.is_empty() {
         return Ok(AnnEnsureStatus::EmptyCorpus);
     }
-    let key = AnnKey::from_token(token, model);
+    let key = AnnKey::from_token(model);
 
     // Read generation BEFORE any fast path or corpus snapshot to close the write race.
     let target_generation = current_generation(ann, &key).await;
@@ -870,7 +870,7 @@ async fn ensure_ann_for_model_inner(
     target_generation: u64,
 ) -> Result<AnnEnsureStatus, RuntimeError> {
     let ns = "global";
-    let key = AnnKey::new(ns, model);
+    let key = AnnKey::new(model);
 
     if installed_is_fresh(ann, &key, target_generation).await {
         return Ok(AnnEnsureStatus::AlreadyLoaded);
@@ -1727,9 +1727,9 @@ mod tests {
     #[test]
     fn ann_key_is_model_only() {
         // After FTS+ANN consolidation AnnKey is model-only; namespace is ignored.
-        let k1 = AnnKey::new("ns:a", "model-x");
-        let k2 = AnnKey::new("ns:b", "model-x"); // same model, different ns → same key
-        let k3 = AnnKey::new("ns:a", "model-y"); // different model → different key
+        let k1 = AnnKey::new("model-x");
+        let k2 = AnnKey::new("model-x"); // same model, different ns → same key
+        let k3 = AnnKey::new("model-y"); // different model → different key
         assert_eq!(
             k1, k2,
             "same model, different namespace must produce the same key"
@@ -1788,7 +1788,7 @@ mod tests {
     #[tokio::test]
     async fn bump_generation_does_not_evict_installed_index_or_segment() {
         let ann = new_shared();
-        let key = AnnKey::new("global", "model-x");
+        let key = AnnKey::new("model-x");
         let id = Uuid::new_v4();
 
         install_replacing(&ann, &key, tiny_bridge(id, 1)).await;
@@ -1820,7 +1820,7 @@ mod tests {
     #[tokio::test]
     async fn search_loaded_serves_stale_installed_entry_without_rebuild() {
         let ann = new_shared();
-        let key = AnnKey::new("global", "model-x");
+        let key = AnnKey::new("model-x");
         let id = Uuid::new_v4();
 
         install_replacing(&ann, &key, tiny_bridge(id, 1)).await;
@@ -1857,7 +1857,7 @@ mod tests {
     #[tokio::test]
     async fn install_replacing_rejects_older_generation_candidate() {
         let ann = new_shared();
-        let key = AnnKey::new("any-ns", "model-x");
+        let key = AnnKey::new("model-x");
         let newer_id = Uuid::new_v4();
         let older_id = Uuid::new_v4();
 
@@ -1878,7 +1878,7 @@ mod tests {
     #[tokio::test]
     async fn install_replacing_replaces_older_installed_entry() {
         let ann = new_shared();
-        let key = AnnKey::new("any-ns", "model-x");
+        let key = AnnKey::new("model-x");
         let older_id = Uuid::new_v4();
         let newer_id = Uuid::new_v4();
 
@@ -1897,7 +1897,7 @@ mod tests {
     #[tokio::test]
     async fn install_replacing_replaces_on_equal_generation() {
         let ann = new_shared();
-        let key = AnnKey::new("any-ns", "model-x");
+        let key = AnnKey::new("model-x");
         let first_id = Uuid::new_v4();
         let second_id = Uuid::new_v4();
 
@@ -1917,7 +1917,7 @@ mod tests {
     #[tokio::test]
     async fn is_current_false_when_installed_generation_behind_counter() {
         let ann = new_shared();
-        let key = AnnKey::new("any-ns", "model-x");
+        let key = AnnKey::new("model-x");
 
         // Install a bridge stamped with generation 1 (as if built before any
         // write bumped the counter further).
@@ -1949,7 +1949,7 @@ mod tests {
     #[tokio::test]
     async fn is_current_false_when_absent() {
         let ann = new_shared();
-        let key = AnnKey::new("any-ns", "model-x");
+        let key = AnnKey::new("model-x");
         assert!(!is_current(&ann, &key).await);
     }
 
@@ -2122,7 +2122,7 @@ mod tests {
             ann.indexes
                 .read()
                 .await
-                .contains_key(&AnnKey::from_token(&token, MODEL)),
+                .contains_key(&AnnKey::from_token(MODEL)),
             "the model must end up warm regardless of which caller built it"
         );
 
@@ -2376,7 +2376,7 @@ mod tests {
         }
 
         let ann = new_shared();
-        let key = AnnKey::from_token(&token, MODEL);
+        let key = AnnKey::from_token(MODEL);
 
         assert!(
             ensure_ann_background(&rt, &token, &ann, MODEL).await,
@@ -2510,7 +2510,7 @@ mod tests {
         // The replacement note's write left a tail row, so a Hot adoption of
         // the pre-change segment (which would report LoadedSnapshot WITHOUT
         // containing the replacement) is ruled out by searching for it.
-        let key = AnnKey::from_token(&token, MODEL);
+        let key = AnnKey::from_token(MODEL);
         let query = fnv_to_vec("restart signal note REPLACEMENT", DIMS);
         let hits = search_loaded(&ann2, &key, &query, 5)
             .await
@@ -2618,7 +2618,7 @@ mod tests {
         );
         // The replayed index must serve the NEW embedding for the re-embedded
         // note — a Hot adoption of the stale segment would miss it.
-        let key = AnnKey::from_token(&token, MODEL);
+        let key = AnnKey::from_token(MODEL);
         let replacement: Vec<f32> = (0..DIMS).map(|i| (i as f32 + 100.0) / 7.0).collect();
         let hits = search_loaded(&ann2, &key, &replacement, 1)
             .await
@@ -2713,7 +2713,7 @@ mod tests {
             "a predicate-failing final upsert must replay as a delete within \
              Stale-tail adoption, not force a Cold rebuild, got: {status:?}"
         );
-        let key = AnnKey::from_token(&token, MODEL);
+        let key = AnnKey::from_token(MODEL);
         let query = fnv_to_vec("join predicate note 0", DIMS);
         let hits = search_loaded(&ann2, &key, &query, 4)
             .await
@@ -2848,7 +2848,7 @@ mod tests {
         }
 
         let ann1 = new_shared();
-        let key = AnnKey::from_token(&token1, MODEL);
+        let key = AnnKey::from_token(MODEL);
         let status = ensure_ann_for_model(&rt1, &token1, &ann1, MODEL)
             .await
             .expect("first warm");
@@ -2974,7 +2974,7 @@ mod tests {
         }
 
         let ann = new_shared();
-        let key = AnnKey::from_token(&token, MODEL);
+        let key = AnnKey::from_token(MODEL);
 
         // The two-way barrier orders the write after the task captures its first floor.
         ann.attempt_floor_barrier

--- a/crates/khive-pack-memory/src/handlers/common.rs
+++ b/crates/khive-pack-memory/src/handlers/common.rs
@@ -1222,7 +1222,7 @@ async fn collect_model_ann_hits_inner(
     ann_overfetch_max_rounds: usize,
     ann_ready_timeout_ms: u64,
 ) -> Result<PerModelAnnHits, RuntimeError> {
-    let key = AnnKey::new(ns, &model_name);
+    let key = AnnKey::new(&model_name);
 
     // Global ANN search widens only when namespace post-filtering leaves too few hits.
     // A stale installed graph remains the immediate fallback and triggers background

--- a/crates/khive-pack-memory/src/handlers/prune.rs
+++ b/crates/khive-pack-memory/src/handlers/prune.rs
@@ -140,7 +140,7 @@ impl MemoryPack {
         // Keep the stale graph intact while a live-row scan builds its replacement.
         if pruned > 0 {
             for model in self.runtime.registered_embedding_model_names() {
-                let key = ann::AnnKey::new(namespace.as_str(), model.as_str());
+                let key = ann::AnnKey::new(model.as_str());
                 ann::bump_generation(&self.ann, &key).await;
                 ann::ensure_ann_background(&self.runtime, token, &self.ann, &model).await;
             }
@@ -315,7 +315,7 @@ mod prune_recall_visibility_tests {
         // Evict the warm graph now, so the recalls below rebuild against the
         // now-pruned corpus and fall through to the exact sqlite-vec search
         // instead of the warm ANN route.
-        let key = crate::ann::AnnKey::new("local", MODEL);
+        let key = crate::ann::AnnKey::new(MODEL);
         crate::ann::clear_key(&ann, &key).await;
         ann.reset_warm_route_count();
 

--- a/crates/khive-pack-memory/src/handlers/recall.rs
+++ b/crates/khive-pack-memory/src/handlers/recall.rs
@@ -1105,7 +1105,7 @@ mod tests {
         // Simulate the daemon's boot-time background warm holding the
         // per-model single-flight lock mid-build (ann.rs `model_warm_lock`),
         // exactly the contention #836 diagnosed.
-        let key = crate::ann::AnnKey::new("local", MODEL);
+        let key = crate::ann::AnnKey::new(MODEL);
         let _held = crate::ann::hold_model_warm_lock_for_test(&ann_handle, &key).await;
 
         let start = std::time::Instant::now();
@@ -1214,7 +1214,7 @@ mod tests {
         builder.register(pack);
         let registry = builder.build().expect("registry");
 
-        let key = crate::ann::AnnKey::new("local", MODEL);
+        let key = crate::ann::AnnKey::new(MODEL);
         let _held = crate::ann::hold_model_warm_lock_for_test(&ann_handle, &key).await;
 
         let result = registry
@@ -1298,7 +1298,7 @@ mod tests {
         // The detached build must keep running after the timed-out recall
         // returns — poll the ANN cache directly (mirrors ann.rs's own
         // #812/#844 convergence tests) rather than sleeping a fixed amount.
-        let key = crate::ann::AnnKey::new("local", MODEL);
+        let key = crate::ann::AnnKey::new(MODEL);
         let mut warmed = false;
         for _ in 0..300 {
             if crate::ann::is_current(&ann_handle, &key).await {

--- a/crates/khive-pack-memory/src/handlers/remember.rs
+++ b/crates/khive-pack-memory/src/handlers/remember.rs
@@ -136,7 +136,7 @@ impl MemoryPack {
             };
             for model in affected_models {
                 // Bump BEFORE warming so this write is included in the required generation floor.
-                let key = ann::AnnKey::from_token(write_token, &model);
+                let key = ann::AnnKey::from_token(&model);
                 ann::bump_generation(&self.ann, &key).await;
                 ann::ensure_ann_background(&self.runtime, write_token, &self.ann, &model).await;
             }

--- a/crates/khive-pack-memory/src/pack.rs
+++ b/crates/khive-pack-memory/src/pack.rs
@@ -421,7 +421,7 @@ impl PackRuntime for MemoryPack {
                     return;
                 };
                 for model in runtime.registered_embedding_model_names() {
-                    let key = crate::ann::AnnKey::new("local", model.as_str());
+                    let key = crate::ann::AnnKey::new(model.as_str());
                     crate::ann::bump_generation(&ann, &key).await;
                     crate::ann::ensure_ann_background(&runtime, &token, &ann, &model).await;
                 }
@@ -747,7 +747,7 @@ mod note_mutation_hook_tests {
     }
 
     fn mutation_hook_ann_key() -> ann::AnnKey {
-        ann::AnnKey::new("local", FR1_MODEL)
+        ann::AnnKey::new(FR1_MODEL)
     }
 
     /// Seeds one note, warms ANN through recall, and verifies the pre-mutation state.


### PR DESCRIPTION
## Summary

Review follow-up.

`AnnKey` has been model-only since the FTS+ANN consolidation (one index per
model, spanning every namespace), but its constructors still accepted and
discarded a namespace/token argument for compatibility with the
pre-consolidation call shape. `AnnKey::new` / `AnnKey::from_token` now take
only `model`; the ~29 call sites across the pack are updated to match.

`ensure_ann_background`'s `token` parameter, previously passed straight into
the discarded `AnnKey::from_token` argument, is genuinely unused now — it is
underscore-prefixed rather than removed from the signature, since
`ensure_ann_for_model`'s sibling warm entry point keeps the same
`(rt, token, ann, model)` shape and both are called from the same call sites.

Purely mechanical; no behavior change.

Closes #1137

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test -p khive-pack-knowledge -p khive-pack-memory -p khive-vamana` — 16 suites, all passing