### PR TITLE
docs(adr): ADR-091 Amendment 2 — cross-process WAL pin attribution and per-session sweep

### DIFF
--- a/docs/adr/ADR-091-wal-snapshot-lifetime.md
+++ b/docs/adr/ADR-091-wal-snapshot-lifetime.md
@@ -738,12 +738,32 @@ question (Inventory item 4) remains unverified precisely there.
   only entries it can attribute to a dead or stale process AND that pass
   ownership validation. The daemon logs every live report alongside its
   existing no-progress WARN. The
-  next recurrence therefore names the pinning process directly — or, if the WAL
-  is pinned while no sidecar reports an old span, yields the sharper conclusion
-  that the pin is an unregistered/native mechanism (`vec0` cursor, or a span the
-  registry does not cover) in one of the live PIDs, which is exactly the
-  fork needed to justify or reject the deferred route-reads-through-the-daemon
-  alternative with evidence.
+  next recurrence therefore names the pinning process directly when a report
+  exists. When none does, absence of evidence is attributed only through the
+  per-PID sidecar-health distinction below — silence alone never licenses a
+  conclusion.
+
+  _Sidecar-health attribution (gate ruling, 2026-07-19)._ A missing heartbeat
+  has two very different causes: the process genuinely has no old span, or its
+  sidecar never functioned (older binary without the feature, sidecar disabled,
+  heartbeat write failed, or the trust-boundary check below refused the
+  directory — note that a daemon-side refusal is itself a sidecar-health
+  failure and must not masquerade as evidence). To keep the
+  zero-steady-state-traffic property while making the two distinguishable,
+  each process writes a **one-time registration beacon** at sidecar
+  initialization (a per-PID marker written once, under the same trust-boundary
+  and liveness rules as heartbeats — not per-tick). Enumeration then classifies
+  every live database-holding PID three ways: **reporting** (heartbeat present
+  and live), **registered-silent** (beacon present, no heartbeat — the process
+  affirmatively has no over-threshold span), and **unknown** (no beacon — the
+  sidecar's health is unestablished; states: disabled, pre-feature binary,
+  write-failed, or refused). Only a pin observed while every live PID is
+  reporting or registered-silent licenses the sharper conclusion that the pin
+  is an unregistered/native mechanism (`vec0` cursor, or a span the registry
+  does not cover) — the fork needed to justify or reject the deferred
+  route-reads-through-the-daemon alternative with evidence. Any `unknown` PID
+  makes the attribution inconclusive, and the daemon's WARN names the unknown
+  PIDs as the reason.
 
   _Sidecar filesystem trust boundary (gate ruling, 2026-07-19)._ The sidecar
   path is predictable, so in a shared or attacker-writable database directory a

--- a/docs/adr/ADR-091-wal-snapshot-lifetime.md
+++ b/docs/adr/ADR-091-wal-snapshot-lifetime.md
@@ -724,22 +724,30 @@ question (Inventory item 4) remains unverified precisely there.
   `KHIVE_TX_WARN_SECS` (plus one removal on clean shutdown and on the first tick
   after the condition clears) — quiet processes write nothing, so steady-state
   filesystem traffic is zero. On a TRUNCATE no-progress event, the daemon
-  enumerates the sidecar directory, discards entries whose PID is no longer
-  alive, and logs every live report alongside its existing no-progress WARN. The
+  enumerates the sidecar directory and applies a two-test liveness gate (gate
+  ruling, 2026-07-19): an entry is live only if its PID is alive **and** its
+  `updated_at` falls within roughly 3 session sweep intervals (the sidecar
+  refreshes `updated_at` on every sweep tick while the warn condition persists,
+  so a stale timestamp means a crashed process's orphan file or a reused PID —
+  `started_at` remains the identity cross-check). Entries failing either test
+  are **deleted** during enumeration, not merely skipped, so orphan files cannot
+  accumulate or false-attribute. The daemon logs every live report alongside its
+  existing no-progress WARN. The
   next recurrence therefore names the pinning process directly — or, if the WAL
   is pinned while no sidecar reports an old span, yields the sharper conclusion
   that the pin is an unregistered/native mechanism (`vec0` cursor, or a span the
   registry does not cover) in one of the live PIDs, which is exactly the
   fork needed to justify or reject the deferred route-reads-through-the-daemon
   alternative with evidence.
-- **Plank C (optional, gate may strike): WAL-index read-mark depth probe.** On a
-  TRUNCATE no-progress event, additionally report how far behind the oldest
-  reader mark sits (frames pinned behind the boundary), derived from the shm
-  WAL-index. This quantifies pin depth even when no process self-reports.
-  Flagged optional because the WAL-index layout is an SQLite implementation
-  detail; if a stable probe (e.g. an additional `PRAGMA wal_checkpoint(PASSIVE)`
-  return-column analysis, which already yields `log` vs `checkpointed` counts)
-  provides equivalent signal, prefer that and drop shm parsing entirely.
+- **Plank C: pin-depth probe via `PRAGMA wal_checkpoint(PASSIVE)` return
+  columns.** On a TRUNCATE no-progress event, additionally run
+  `PRAGMA wal_checkpoint(PASSIVE)` and report pin depth as `log` minus
+  `checkpointed` from its 3-column return row — the number of frames pinned
+  behind the backfill boundary. Equivalent signal to reader-mark introspection
+  with zero dependence on SQLite's shm WAL-index layout, and PASSIVE never
+  blocks readers or writers. The draft's alternative of parsing the shm
+  WAL-index directly was struck at the spec gate (2026-07-19) as
+  implementation-detail-fragile; do not ship shm parsing.
 
 **Deployment-shape note.** The hosted khive-cloud topology is single-process:
 the in-process registry already sees every span there, and this amendment adds

--- a/docs/adr/ADR-091-wal-snapshot-lifetime.md
+++ b/docs/adr/ADR-091-wal-snapshot-lifetime.md
@@ -677,3 +677,84 @@ possibility this ADR's own Alternatives section already named — the pin is out
 entirely (a separate `kkernel mcp` stdio session's own connection; `tx_registry` is
 process-local and cannot see it) — remains unruled-out and is exactly the "route reads through
 the daemon" alternative this ADR already deferred.
+
+### 2026-07-19 amendment (Amendment 2): the pin is cross-process — per-session observability and attribution
+
+**Telemetry conclusion (Plank 0 delivered its purpose).** A third recurrence
+(2026-07-19) provided the discriminating evidence Plank 0 was built to capture.
+`wal_pages` sat at 84,000-85,000 (14x `high_water_pages`, 4x
+`truncate_high_water_pages`) for at least ten hours. Three TRUNCATE attempts
+(22:15, 02:00, 05:58) each made zero progress (`wal_pages_before ==
+wal_pages_after`). Across every checkpoint-tick observation in that window, the
+in-process registry's oldest open span was **milliseconds to sub-second old**
+(`writer_task_tx`, `text_upsert_document` — ordinary bounded writes). The
+in-process inventory this ADR audited is therefore exonerated for this
+recurrence: no registered span in the daemon held the pin. The pin lives in
+another process. Corroborating: a full process-set cycle later that morning (a
+binary reinstall killed the daemon; stdio sessions re-exec'd) dropped the WAL
+from ~85,000 pages to under 1,000 — the same "killing processes frees the WAL"
+signature as #580's original incident.
+
+**Topology fact the original ADR under-weighted.** At observation time, 13
+processes held `khive.db` open directly: the daemon plus 12 `kkernel mcp` stdio
+sessions (ages minutes to 10+ hours). Session reads do not route through the
+daemon; every session runs its own connection pool against the shared file. The
+checkpoint task — and with it the entire Plank 0/Plank 1 sweep — runs **only in
+the daemon** (`khive-runtime/src/daemon.rs`, daemon boot path). The processes
+most likely to hold the pin are exactly the processes with zero WAL
+observability. Channel poll loops are already daemon-gated (#602), so sessions
+are pure request-servers; their read/write spans use the same bounded patterns
+inventoried above, but nothing observes them, and the `vec0` native cursor
+question (Inventory item 4) remains unverified precisely there.
+
+**Decision (additive, observability-first — same posture as Plank 0).**
+
+- **Plank A: per-session registry sweep.** Every `kkernel mcp` process (stdio
+  session or daemon) runs the lightweight tx-registry age sweep, not only the
+  daemon. For sessions this is observe-only (no PASSIVE/TRUNCATE checkpointing —
+  checkpointing stays daemon-owned to avoid N processes competing for the writer
+  mutex): a coarse tick (default 5s; sessions do not need the daemon's 500ms
+  cadence) checks `tx_registry::oldest()` against the existing
+  `KHIVE_TX_WARN_SECS`/`KHIVE_TX_MAX_AGE_SECS` thresholds with the same
+  edge-triggered logging.
+- **Plank B: cross-process attribution sidecar.** Each process maintains a
+  per-PID heartbeat file under `<db-file>.walpin/<pid>.json` containing
+  `{pid, process_role, started_at, oldest_tx_age_secs, oldest_tx_label,
+  updated_at}`. Written on the sweep tick only when an open span exceeds
+  `KHIVE_TX_WARN_SECS` (plus one removal on clean shutdown and on the first tick
+  after the condition clears) — quiet processes write nothing, so steady-state
+  filesystem traffic is zero. On a TRUNCATE no-progress event, the daemon
+  enumerates the sidecar directory, discards entries whose PID is no longer
+  alive, and logs every live report alongside its existing no-progress WARN. The
+  next recurrence therefore names the pinning process directly — or, if the WAL
+  is pinned while no sidecar reports an old span, yields the sharper conclusion
+  that the pin is an unregistered/native mechanism (`vec0` cursor, or a span the
+  registry does not cover) in one of the live PIDs, which is exactly the
+  fork needed to justify or reject the deferred route-reads-through-the-daemon
+  alternative with evidence.
+- **Plank C (optional, gate may strike): WAL-index read-mark depth probe.** On a
+  TRUNCATE no-progress event, additionally report how far behind the oldest
+  reader mark sits (frames pinned behind the boundary), derived from the shm
+  WAL-index. This quantifies pin depth even when no process self-reports.
+  Flagged optional because the WAL-index layout is an SQLite implementation
+  detail; if a stable probe (e.g. an additional `PRAGMA wal_checkpoint(PASSIVE)`
+  return-column analysis, which already yields `log` vs `checkpointed` counts)
+  provides equivalent signal, prefer that and drop shm parsing entirely.
+
+**Deployment-shape note.** The hosted khive-cloud topology is single-process:
+the in-process registry already sees every span there, and this amendment adds
+nothing to that path (the sidecar is a no-op with one process, and its
+enumeration output is trivially self-attributing). The multi-process shape this
+amendment instruments is local multi-seat operation — which is also the
+many-agents-one-substrate deployment khivedb ships as, so the gap is a product
+defect class, not a dev-environment quirk.
+
+**Non-goals.** No enforcement changes: thresholds, TRUNCATE policy, and the
+visibility-not-reclamation posture are unchanged. No read-routing migration
+(Alternative 4) is designed here; Plank B exists to produce the attribution that
+decision needs. `vec0` internals remain unverified; Plank B is designed to
+implicate or exonerate them without reading native code.
+
+**Config.** `KHIVE_SESSION_SWEEP_INTERVAL_MS` (default 5000, sessions only);
+`KHIVE_WALPIN_SIDECAR` (default on for file-backed backends, off for in-memory).
+Existing threshold keys are reused unchanged.

--- a/docs/adr/ADR-091-wal-snapshot-lifetime.md
+++ b/docs/adr/ADR-091-wal-snapshot-lifetime.md
@@ -695,7 +695,7 @@ binary reinstall killed the daemon; stdio sessions re-exec'd) dropped the WAL
 from ~85,000 pages to under 1,000 — the same "killing processes frees the WAL"
 signature as #580's original incident.
 
-**Topology fact the original ADR under-weighted.** At observation time, 13
+**Cross-process topology.** At observation time, 13
 processes held `khive.db` open directly: the daemon plus 12 `kkernel mcp` stdio
 sessions (ages minutes to 10+ hours). Session reads do not route through the
 daemon; every session runs its own connection pool against the shared file. The

--- a/docs/adr/ADR-091-wal-snapshot-lifetime.md
+++ b/docs/adr/ADR-091-wal-snapshot-lifetime.md
@@ -680,7 +680,7 @@ the daemon" alternative this ADR already deferred.
 
 ### 2026-07-19 amendment (Amendment 2): the pin is cross-process — per-session observability and attribution
 
-**Telemetry conclusion (Plank 0 delivered its purpose).** A third recurrence
+**Plank 0 telemetry summary.** A third recurrence
 (2026-07-19) provided the discriminating evidence Plank 0 was built to capture.
 `wal_pages` sat at 84,000-85,000 (14x `high_water_pages`, 4x
 `truncate_high_water_pages`) for at least ten hours. Three TRUNCATE attempts

--- a/docs/adr/ADR-091-wal-snapshot-lifetime.md
+++ b/docs/adr/ADR-091-wal-snapshot-lifetime.md
@@ -750,20 +750,44 @@ question (Inventory item 4) remains unverified precisely there.
   directory — note that a daemon-side refusal is itself a sidecar-health
   failure and must not masquerade as evidence). To keep the
   zero-steady-state-traffic property while making the two distinguishable,
-  each process writes a **one-time registration beacon** at sidecar
-  initialization (a per-PID marker written once, under the same trust-boundary
-  and liveness rules as heartbeats — not per-tick). Enumeration then classifies
-  every live database-holding PID three ways: **reporting** (heartbeat present
-  and live), **registered-silent** (beacon present, no heartbeat — the process
-  affirmatively has no over-threshold span), and **unknown** (no beacon — the
-  sidecar's health is unestablished; states: disabled, pre-feature binary,
-  write-failed, or refused). Only a pin observed while every live PID is
+  each process writes a **registration beacon** at sidecar initialization (a
+  per-PID marker whose content is written once and thereafter only
+  timestamp-refreshed per the beacon refresh rule below, under the same
+  trust-boundary and liveness rules as heartbeats). The census universe is authoritative and
+  OS-derived, never sidecar-derived: the set of live database-holding PIDs is
+  established by enumerating the processes that hold the database file open at
+  the OS level (the same observation that produced the topology count above),
+  and sidecar states are then mapped onto that universe. The sidecar directory
+  alone cannot define the universe — a database holder that never wrote a
+  beacon would be invisible to a sidecar-only census, and the any-unknown rule
+  below could never fire for exactly the PIDs it exists to catch. Enumeration
+  classifies every PID in the OS-derived census three ways: **reporting**
+  (heartbeat present and live), **registered-silent** (live beacon per the
+  refresh rule below, no heartbeat — the process affirmatively has no
+  over-threshold span), and **unknown** (no beacon, a stale beacon, or a
+  database holder absent from all sidecar data — the sidecar's health is
+  unestablished; states: disabled, pre-feature binary, write-failed, refused,
+  or wedged after initialization). Only a pin observed while every live PID is
   reporting or registered-silent licenses the sharper conclusion that the pin
   is an unregistered/native mechanism (`vec0` cursor, or a span the registry
   does not cover) — the fork needed to justify or reject the deferred
   route-reads-through-the-daemon alternative with evidence. Any `unknown` PID
   makes the attribution inconclusive, and the daemon's WARN names the unknown
   PIDs as the reason.
+
+  _Beacon refresh rule._ Registration at initialization alone never licenses
+  `registered-silent`: the beacon proves the sidecar initialized once, not that
+  it still functions, and a wedged process whose sweep task has died would
+  otherwise hold the pin with exactly the beacon-present/heartbeat-absent
+  signature that the sharper conclusion trusts. `registered-silent` therefore
+  requires ongoing sidecar liveness: each sweep tick performs a metadata-only
+  refresh of the beacon (a timestamp touch of the existing per-PID marker — no
+  data write, preserving the zero-steady-state-data-traffic property), and
+  classification accepts a beacon only when its refresh timestamp falls within
+  the same roughly-3-sweep-interval freshness window and the owning PID passes
+  the same identity gate as heartbeats. A stale beacon — and likewise any PID
+  whose heartbeat was deleted as stale during enumeration — classifies as
+  `unknown`, never `registered-silent`.
 
   _Sidecar filesystem trust boundary (gate ruling, 2026-07-19)._ The sidecar
   path is predictable, so in a shared or attacker-writable database directory a
@@ -776,6 +800,16 @@ question (Inventory item 4) remains unverified precisely there.
   temporary file followed by atomic rename over the target, never an in-place
   open of a possibly-attacker-placed path; enumeration validates per-entry
   ownership and refuses symlinks before reading or deleting anything.
+  Validation binds to an opened handle, not a path: in the attacker-writable
+  directory this contract assumes, a path component swapped between a
+  path-based validation and the subsequent operation would redirect renames or
+  deletions outside the sidecar. The sidecar root is therefore opened once
+  with `O_DIRECTORY | O_NOFOLLOW`, its ownership and mode validated on that
+  file descriptor, and every subsequent create, rename, unlink, and
+  enumeration read performed relative to that descriptor (`openat` /
+  `renameat` / `unlinkat` semantics) — the path is never re-resolved per
+  operation, and parent components must resolve without traversing a symlink
+  at open time.
 - **Plank C: pin-depth probe via `PRAGMA wal_checkpoint(PASSIVE)` return
   columns.** On a TRUNCATE no-progress event, additionally run
   `PRAGMA wal_checkpoint(PASSIVE)` and report pin depth as `log` minus

--- a/docs/adr/ADR-091-wal-snapshot-lifetime.md
+++ b/docs/adr/ADR-091-wal-snapshot-lifetime.md
@@ -724,14 +724,19 @@ question (Inventory item 4) remains unverified precisely there.
   `KHIVE_TX_WARN_SECS` (plus one removal on clean shutdown and on the first tick
   after the condition clears) — quiet processes write nothing, so steady-state
   filesystem traffic is zero. On a TRUNCATE no-progress event, the daemon
-  enumerates the sidecar directory and applies a two-test liveness gate (gate
-  ruling, 2026-07-19): an entry is live only if its PID is alive **and** its
-  `updated_at` falls within roughly 3 session sweep intervals (the sidecar
-  refreshes `updated_at` on every sweep tick while the warn condition persists,
-  so a stale timestamp means a crashed process's orphan file or a reused PID —
-  `started_at` remains the identity cross-check). Entries failing either test
-  are **deleted** during enumeration, not merely skipped, so orphan files cannot
-  accumulate or false-attribute. The daemon logs every live report alongside its
+  enumerates the sidecar directory and applies a three-test liveness gate (gate
+  ruling, 2026-07-19): an entry is live only if (1) its PID is alive, (2) its
+  `started_at` matches the OS-reported start time of that PID within a small
+  epsilon — a required identity validation, not an advisory cross-check, so a
+  reused PID is rejected deterministically rather than probabilistically — and
+  (3) its `updated_at` falls within roughly 3 session sweep intervals (the
+  sidecar refreshes `updated_at` on every sweep tick while the warn condition
+  persists, so a stale timestamp means a crashed process's orphan file).
+  Entries failing any test are **deleted** during enumeration, not merely
+  skipped, so orphan files cannot accumulate or false-attribute; deletion is
+  additionally conditioned on the ownership check below — the daemon removes
+  only entries it can attribute to a dead or stale process AND that pass
+  ownership validation. The daemon logs every live report alongside its
   existing no-progress WARN. The
   next recurrence therefore names the pinning process directly — or, if the WAL
   is pinned while no sidecar reports an old span, yields the sharper conclusion
@@ -739,6 +744,18 @@ question (Inventory item 4) remains unverified precisely there.
   registry does not cover) in one of the live PIDs, which is exactly the
   fork needed to justify or reject the deferred route-reads-through-the-daemon
   alternative with evidence.
+
+  _Sidecar filesystem trust boundary (gate ruling, 2026-07-19)._ The sidecar
+  path is predictable, so in a shared or attacker-writable database directory a
+  symlinked heartbeat path could otherwise redirect a khive process into
+  overwriting an arbitrary file. The write and enumeration contract is
+  therefore binding: the `<db-file>.walpin/` directory is created with mode
+  `0700` and validated as owned by the current user before any use (refuse the
+  directory otherwise — never chmod/chown an existing one into compliance);
+  heartbeat writes go through exclusive create with `O_NOFOLLOW` semantics to a
+  temporary file followed by atomic rename over the target, never an in-place
+  open of a possibly-attacker-placed path; enumeration validates per-entry
+  ownership and refuses symlinks before reading or deleting anything.
 - **Plank C: pin-depth probe via `PRAGMA wal_checkpoint(PASSIVE)` return
   columns.** On a TRUNCATE no-progress event, additionally run
   `PRAGMA wal_checkpoint(PASSIVE)` and report pin depth as `log` minus


### PR DESCRIPTION
Amendment to ADR-091 recording the 2026-07-19 telemetry conclusion: during a sustained 84k-page WAL pressure window with three zero-progress TRUNCATE attempts, the in-process transaction registry's oldest span was milliseconds old at every observation — exonerating the in-process inventory and locating the pin in another process. 13 processes hold the database open directly; the checkpoint/sweep telemetry runs daemon-only, so the likely pinning processes have zero observability today.

Adds three additive, observability-first planks: (A) the registry age sweep runs in every process (observe-only in sessions, checkpointing stays daemon-owned), (B) a per-PID attribution sidecar the daemon enumerates on TRUNCATE no-progress so the next recurrence names the pinning process, (C, optional) a pin-depth probe. No enforcement or policy changes. Single-process deployments are unaffected.

Review follow-up lane: #580, ADR-091.

---

**Review scope note (final round).** The latest review round confirms all three specification
findings against this document are resolved (OS-derived census, beacon refresh rule,
handle-bound sidecar operations). The two remaining findings it raises are in code this
documentation-only diff does not modify and are tracked on their own lanes: blob access
semantics in #1145, ANN checkpoint compare-and-publish in #1138. Neither is addressable
within this diff's scope.
