### PR TITLE
feat(pack-memory): fresh-tail exact leg for vector recall (ADR-118)

### DIFF
--- a/crates/khive-db/sql/012-ann-write-log-model-seq-index.sql
+++ b/crates/khive-db/sql/012-ann-write-log-model-seq-index.sql
@@ -1,0 +1,10 @@
+-- ADR-118: the fresh-tail exact leg's per-model tail scans (global-scope
+-- consumers, e.g. the memory pack) filter by embedding_model/kind/field and
+-- range over seq WITHOUT a namespace predicate. The existing
+-- idx_ann_write_log_ns_model_seq index is namespace-leading, so it cannot
+-- serve these scans as an index range seek — the query degrades to a full
+-- table scan. This index leads with embedding_model so an
+-- (embedding_model, kind, field) equality prefix plus a seq range seek stays
+-- an index-only operation regardless of namespace.
+CREATE INDEX IF NOT EXISTS idx_ann_write_log_model_kind_field_seq
+    ON ann_write_log (embedding_model, kind, field, seq);

--- a/crates/khive-db/src/backend.rs
+++ b/crates/khive-db/src/backend.rs
@@ -398,6 +398,9 @@ impl StorageBackend {
         writer
             .conn()
             .execute_batch(crate::migrations::ANN_WRITE_LOG_DDL)?;
+        writer
+            .conn()
+            .execute_batch(crate::migrations::ANN_WRITE_LOG_MODEL_SEQ_INDEX_DDL)?;
 
         // Create the vec0 virtual table. Idempotent on fresh databases and after the
         // old-schema rebuild above.

--- a/crates/khive-db/src/migrations.rs
+++ b/crates/khive-db/src/migrations.rs
@@ -122,6 +122,8 @@ const V10_UP: &str = include_str!("../sql/010-entities-content-ref.sql");
 
 const V11_UP: &str = include_str!("../sql/011-ann-write-log.sql");
 
+const V12_UP: &str = include_str!("../sql/012-ann-write-log-model-seq-index.sql");
+
 /// DDL for the `ann_write_log` delta table.
 ///
 /// Shared between migration V11 and the belt-and-suspenders creation in
@@ -130,6 +132,12 @@ const V11_UP: &str = include_str!("../sql/011-ann-write-log.sql");
 /// also have the write log, or vector writes would fail on databases opened
 /// without `run_migrations()`. The `.sql` file is `IF NOT EXISTS`-idempotent.
 pub const ANN_WRITE_LOG_DDL: &str = V11_UP;
+
+/// DDL for the `ann_write_log` model/kind/field-leading index (ADR-118 §"Cost
+/// bound"), shared between migration V12 and the belt-and-suspenders creation
+/// in `StorageBackend::vectors_for_namespace` for the same reason as
+/// [`ANN_WRITE_LOG_DDL`].
+pub const ANN_WRITE_LOG_MODEL_SEQ_INDEX_DDL: &str = V12_UP;
 
 /// DDL for the `_embedding_models` registry table.
 ///
@@ -194,6 +202,11 @@ pub const MIGRATIONS: &[VersionedMigration] = &[
         version: 11,
         name: "ann_write_log",
         up: V11_UP,
+    },
+    VersionedMigration {
+        version: 12,
+        name: "ann_write_log_model_seq_index",
+        up: V12_UP,
     },
 ];
 

--- a/crates/khive-pack-memory/src/ann.rs
+++ b/crates/khive-pack-memory/src/ann.rs
@@ -549,8 +549,7 @@ pub(crate) async fn search_loaded(
 /// fresh-tail watermark (ADR-118), captured from the SAME read-lock guard as
 /// the search itself — one lock acquisition, so a concurrent bridge swap
 /// (a checkpoint installing a replacement) cannot pair these candidates with
-/// a different bridge's watermark (review finding: the two were previously
-/// read via separate lock acquisitions).
+/// a different bridge's watermark.
 pub(crate) async fn search_loaded_with_seq(
     ann: &SharedAnn,
     key: &AnnKey,
@@ -2005,7 +2004,7 @@ async fn fresh_tail_reresolve(
 /// Fixed ceiling for the Cold/Empty-tier capped scan (ADR-118 §3). Deriving
 /// a corpus-proportional cap (`ann_rebuild_threshold() * live`) needs an
 /// O(corpus) live-count join — appropriate for the background restart
-/// classifier, not for this per-query path (review finding). The ceiling is
+/// classifier, not for this per-query path. The ceiling is
 /// a fixed, conservative match to the ADR's own worked example (a 0.20
 /// threshold on a 68k-row corpus is ~13.6k comparisons).
 const FRESH_TAIL_CAPPED_MAX_ROWS: u64 = 20_000;

--- a/crates/khive-pack-memory/src/ann.rs
+++ b/crates/khive-pack-memory/src/ann.rs
@@ -1839,6 +1839,16 @@ async fn fresh_tail_serving(
     }
 }
 
+/// Bound on the re-resolution convergence loop below. Compaction through a
+/// registry minimum implies every registered watermark — including this
+/// consumer's own — is at or above it, so the currently published segment
+/// is always re-available at (or past) a newly observed minimum: reloading
+/// it converges. Three peers landing a checkpoint back-to-back inside a
+/// single query's read window would be pathological; the bound exists so a
+/// pathological run degrades to the ADR's floored fallback instead of
+/// looping unboundedly.
+const FRESH_TAIL_RERESOLVE_MAX_ROUNDS: u32 = 3;
+
 /// Real mismatch re-resolution (ADR-118 §1 "mismatch re-resolution"): load
 /// the currently published segment, search IT for candidates, and merge in
 /// ITS own tail above ITS own watermark — a self-consistent pair that never
@@ -1846,6 +1856,22 @@ async fn fresh_tail_serving(
 /// This load is local to the query (not installed into `ann`'s served map);
 /// `bump_generation` still forces the existing background machinery to
 /// adopt this segment for future queries.
+///
+/// A peer checkpoint can advance the registry minimum past the just-loaded
+/// segment's own watermark in the window between the load and the
+/// re-validation read below — the same compaction race the primary path
+/// (`fresh_tail_serving`) already guards against for its own tail fetch.
+/// Unlike that primary-path guard, this one can *reload*: the segment this
+/// function loads is always the currently published one, and compaction
+/// through a minimum M implies the published segment already covers M (see
+/// [`FRESH_TAIL_RERESOLVE_MAX_ROUNDS`]). So a mismatch here re-loops instead
+/// of immediately falling back to a floored scan — flooring on the first
+/// mismatch would leave the (old watermark, new minimum] window in neither
+/// the (stale) candidate set nor the (floored) tail, silently dropping
+/// committed writes. Only [`FRESH_TAIL_RERESOLVE_MAX_ROUNDS`] consecutive
+/// mismatches — peers advancing the minimum faster than this leg can load a
+/// segment for it, which should not happen at normal checkpoint cadence —
+/// fall back to that floor.
 async fn fresh_tail_reresolve(
     rt: &KhiveRuntime,
     ann: &SharedAnn,
@@ -1855,85 +1881,125 @@ async fn fresh_tail_reresolve(
     k: usize,
     new_s: u64,
 ) -> FreshTailOutcome {
-    let Some(dir) = ann_segment_dir(rt, model) else {
+    let mut expected_s = new_s;
+    for round in 1..=FRESH_TAIL_RERESOLVE_MAX_ROUNDS {
+        let Some(dir) = ann_segment_dir(rt, model) else {
+            bump_generation(ann, key).await;
+            return FreshTailOutcome::Skipped;
+        };
+        let bridge = match AnnBridge::load(&dir) {
+            Ok(b) => b,
+            Err(e) => {
+                tracing::warn!(error = %e, model, "fresh-tail: re-resolved segment load failed; skipping exact leg");
+                bump_generation(ann, key).await;
+                return FreshTailOutcome::Skipped;
+            }
+        };
+        let s_loaded = bridge.index.last_applied_seq().unwrap_or(expected_s);
+        let candidates = match bridge.search(query, k) {
+            Ok(hits) => hits,
+            Err(e) => {
+                tracing::warn!(error = %e, model, "fresh-tail: re-resolved segment search failed; skipping exact leg");
+                bump_generation(ann, key).await;
+                return FreshTailOutcome::Skipped;
+            }
+        };
+        // Force re-adoption so the background warm path installs this segment
+        // for future queries too — this load served only the current query.
         bump_generation(ann, key).await;
-        return FreshTailOutcome::Skipped;
-    };
-    let bridge = match AnnBridge::load(&dir) {
-        Ok(b) => b,
-        Err(e) => {
-            tracing::warn!(error = %e, model, "fresh-tail: re-resolved segment load failed; skipping exact leg");
-            bump_generation(ann, key).await;
-            return FreshTailOutcome::Skipped;
-        }
-    };
-    let candidates = match bridge.search(query, k) {
-        Ok(hits) => hits,
-        Err(e) => {
-            tracing::warn!(error = %e, model, "fresh-tail: re-resolved segment search failed; skipping exact leg");
-            bump_generation(ann, key).await;
-            return FreshTailOutcome::Skipped;
-        }
-    };
-    // Force re-adoption so the background warm path installs this segment
-    // for future queries too — this load served only the current query.
-    bump_generation(ann, key).await;
 
-    #[cfg(test)]
-    {
-        if ann
-            .reresolve_race_barrier
-            .load(std::sync::atomic::Ordering::SeqCst)
+        #[cfg(test)]
         {
-            ann.reresolve_race_notify.notify_one();
-            ann.reresolve_race_release.notified().await;
+            if ann
+                .reresolve_race_barrier
+                .load(std::sync::atomic::Ordering::SeqCst)
+            {
+                ann.reresolve_race_notify.notify_one();
+                ann.reresolve_race_release.notified().await;
+            }
         }
-    }
 
-    // The filesystem commit-info read that produced `new_s` and this tail
-    // scan are not otherwise ordered against a concurrent checkpoint: a
-    // peer can raise the registry watermark past `new_s` and compact the
-    // now-covered log rows in between, silently dropping a committed write
-    // from a `> new_s` scan — the same compaction race the primary path
-    // (`fresh_tail_serving`) already guards against for its own tail fetch.
-    // Re-validate the registry minimum and run the tail scan inside one
-    // snapshot so no compaction can strike between the guard and the fetch.
-    let mut reader = match rt.sql().reader().await {
-        Ok(r) => r,
-        Err(e) => {
-            tracing::warn!(error = %e, model, "fresh-tail: re-resolved reader open failed; serving re-resolved candidates without further tail");
+        // The filesystem commit-info read that produced this segment and
+        // the tail scan below are not otherwise ordered against a
+        // concurrent checkpoint: a peer can raise the registry watermark
+        // past `s_loaded` and compact the now-covered log rows in between,
+        // silently dropping a committed write from a `> s_loaded` scan.
+        // Re-validate the registry minimum and run the tail scan inside one
+        // snapshot so no compaction can strike between the guard and the
+        // fetch.
+        let mut reader = match rt.sql().reader().await {
+            Ok(r) => r,
+            Err(e) => {
+                tracing::warn!(error = %e, model, "fresh-tail: re-resolved reader open failed; serving re-resolved candidates without further tail");
+                return FreshTailOutcome::Replace(candidates);
+            }
+        };
+        if let Err(e) = begin_read_snapshot(reader.as_mut()).await {
+            tracing::warn!(error = %e, model, "fresh-tail: re-resolved snapshot begin failed; serving re-resolved candidates without further tail");
             return FreshTailOutcome::Replace(candidates);
         }
-    };
-    if let Err(e) = begin_read_snapshot(reader.as_mut()).await {
-        tracing::warn!(error = %e, model, "fresh-tail: re-resolved snapshot begin failed; serving re-resolved candidates without further tail");
-        return FreshTailOutcome::Replace(candidates);
-    }
 
-    let floor = match registry_min_watermark_on(reader.as_mut(), model).await {
-        Ok(Some(m)) if m as u64 > new_s => m as u64,
-        Ok(_) => new_s,
-        Err(e) => {
+        let registry_min = match registry_min_watermark_on(reader.as_mut(), model).await {
+            Ok(v) => v.map(|m| m as u64),
+            Err(e) => {
+                end_read_snapshot(reader.as_mut()).await;
+                tracing::warn!(error = %e, model, "fresh-tail: re-resolved registry-min read failed; serving re-resolved candidates without further tail");
+                return FreshTailOutcome::Replace(candidates);
+            }
+        };
+
+        let coherent = match registry_min {
+            Some(m) => m <= s_loaded,
+            None => true,
+        };
+        if coherent {
+            // Coherent (these candidates, this watermark) pair: the log
+            // still retains every row above `s_loaded`, so the tail scan
+            // needs no floor beyond it.
+            let outcome = fetch_final_tail_on(reader.as_mut(), model, s_loaded, None).await;
             end_read_snapshot(reader.as_mut()).await;
-            tracing::warn!(error = %e, model, "fresh-tail: re-resolved registry-min read failed; serving re-resolved candidates without further tail");
-            return FreshTailOutcome::Replace(candidates);
+            return match outcome {
+                Ok((ops, _)) => FreshTailOutcome::Replace(merge_fresh_tail(candidates, query, ops)),
+                Err(e) => {
+                    tracing::warn!(error = %e, model, "fresh-tail: re-resolved tail fetch failed; serving re-resolved candidates without further tail");
+                    FreshTailOutcome::Replace(candidates)
+                }
+            };
         }
-    };
-    // `floor > new_s` is the ADR's floored fallback (mirrors
-    // `fresh_tail_serving`'s own mismatch floor): the registry minimum
-    // advanced again after this segment was loaded, so its (new_s, floor]
-    // window is not provably retained in the log. Scan from `floor` instead
-    // — a coherent (these candidates, this floor) pair — rather than
-    // re-resolving again; one re-validation is the terminal branch.
-    let outcome = fetch_final_tail_on(reader.as_mut(), model, floor, None).await;
-    end_read_snapshot(reader.as_mut()).await;
-    match outcome {
-        Ok((ops, _)) => FreshTailOutcome::Replace(merge_fresh_tail(candidates, query, ops)),
-        Err(e) => {
-            tracing::warn!(error = %e, model, "fresh-tail: re-resolved tail fetch failed; serving re-resolved candidates without further tail");
-            FreshTailOutcome::Replace(candidates)
+        let m = registry_min.expect("coherent=false implies registry_min is Some");
+
+        if round == FRESH_TAIL_RERESOLVE_MAX_ROUNDS {
+            // ADR-118 §1 terminal mismatch-window branch: peers advanced
+            // the registry minimum faster than this leg could converge on
+            // a published segment for it. Serve the last loaded candidates
+            // with the scan floored at the last observed minimum — a
+            // coherent (these candidates, this floor) pair, at the cost of
+            // the (s_loaded, m] window not being provably retained in the
+            // log — and force re-adoption so a future query closes it.
+            tracing::warn!(
+                model,
+                rounds = round,
+                floor = m,
+                "fresh-tail: re-resolution did not converge within {round} rounds; \
+                 serving the ADR-118 floored fallback"
+            );
+            let outcome = fetch_final_tail_on(reader.as_mut(), model, m, None).await;
+            end_read_snapshot(reader.as_mut()).await;
+            return match outcome {
+                Ok((ops, _)) => FreshTailOutcome::Replace(merge_fresh_tail(candidates, query, ops)),
+                Err(e) => {
+                    tracing::warn!(error = %e, model, "fresh-tail: floored-fallback tail fetch failed; serving re-resolved candidates without further tail");
+                    FreshTailOutcome::Replace(candidates)
+                }
+            };
         }
+
+        end_read_snapshot(reader.as_mut()).await;
+        // Reload the currently published segment next round — by the
+        // compaction invariant above it is now at or past `m`.
+        expected_s = m;
     }
+    unreachable!("the loop always returns on or before its terminal round")
 }
 
 /// Fixed ceiling for the Cold/Empty-tier capped scan (ADR-118 §3). Deriving
@@ -3898,12 +3964,16 @@ mod tests {
     /// a peer checkpoint can advance the registry minimum PAST the segment
     /// `fresh_tail_reresolve` just loaded, in the window between that load
     /// and its tail scan. The fix re-validates the registry minimum inside a
-    /// fresh snapshot before scanning and floors the scan at the new minimum
-    /// when it has moved — the same terminal floor `fresh_tail_serving`
-    /// already takes on its own mismatch. A write committed above that new
-    /// floor must still surface through the floored scan, not be silently
-    /// dropped the way it would be by a plain, unvalidated `> new_s` scan
-    /// racing against the interleaved compaction.
+    /// fresh snapshot before scanning and, on a mismatch, RELOADS the
+    /// currently published segment instead of immediately flooring the scan
+    /// — flooring on the first mismatch would leave the (old watermark, new
+    /// minimum] window in neither the stale candidate set nor the floored
+    /// tail, silently dropping a committed write in exactly that range. The
+    /// reload converges because compaction through the new minimum implies
+    /// the published segment already covers it. A write compacted into the
+    /// interleaved window must surface via the reloaded segment's own
+    /// search, and a write committed above the (now coherent) watermark
+    /// must still surface through its tail scan.
     #[tokio::test]
     #[serial(adr118_fresh_tail)]
     async fn fresh_tail_reresolve_revalidates_registry_minimum_against_interleaved_compaction() {
@@ -4006,19 +4076,20 @@ mod tests {
         // removes the (s2, s3] log window — including the write below — from
         // `ann_write_log`, and is exactly the interleaving the fix must
         // detect via its re-validated registry-minimum read.
-        rt.create_note_with_decay_for_embedding_model(
-            &token,
-            "memory",
-            None,
-            "interleave second-checkpoint write",
-            Some(0.7),
-            0.01,
-            None,
-            vec![],
-            None,
-        )
-        .await
-        .expect("create second-checkpoint note");
+        let second_checkpoint_write = rt
+            .create_note_with_decay_for_embedding_model(
+                &token,
+                "memory",
+                None,
+                "interleave second-checkpoint write",
+                Some(0.7),
+                0.01,
+                None,
+                vec![],
+                None,
+            )
+            .await
+            .expect("create second-checkpoint note");
         let (_live, tail2) = scope_counts(&rt, MODEL, s2)
             .await
             .expect("scope counts before second peer checkpoint");
@@ -4042,8 +4113,9 @@ mod tests {
             .await
             .expect("compact log through s3");
 
-        // A write above the new floor — still present in the log, not
-        // compacted away — must survive the floored scan.
+        // A write above s3 — still present in the log, not compacted away —
+        // must survive the coherent tail scan once the loop converges on
+        // the s3 segment.
         let post = rt
             .create_note_with_decay_for_embedding_model(
                 &token,
@@ -4073,19 +4145,285 @@ mod tests {
                  just return ops to merge into the stale bridge's candidates"
             ),
             FreshTailOutcome::Skipped => {
-                panic!("expected the interleaved-compaction floor fallback, not a skip")
+                panic!("expected the interleaved-compaction re-resolution to converge, not a skip")
             }
         };
         assert!(
+            candidates
+                .iter()
+                .any(|(id, _)| *id == second_checkpoint_write.id),
+            "a write compacted into the interleaved (s2, s3] window must be \
+             recovered by reloading the >= s3 segment on the second round, \
+             not silently dropped by a scan floored at s3 with candidates \
+             still pinned to the stale s2 segment: {candidates:?}"
+        );
+        assert!(
             candidates.iter().any(|(id, _)| *id == post.id),
-            "a write committed above the re-validated registry minimum must \
-             survive the floored tail scan, not be silently dropped by a \
-             scan still anchored at the stale re-resolved watermark: {candidates:?}"
+            "a write committed above the converged s3 watermark must \
+             survive the coherent tail scan: {candidates:?}"
         );
         assert!(
             current_generation(&ann, &key).await > generation_before,
-            "the interleaved-compaction floor must still force re-adoption \
-             so a future query gets a fresh bridge"
+            "re-resolution must still force re-adoption so a future query \
+             gets a fresh bridge"
+        );
+    }
+
+    /// [`FRESH_TAIL_RERESOLVE_MAX_ROUNDS`]'s terminal branch: three peer
+    /// checkpoints land back-to-back, one inside each round's pause, so the
+    /// registry minimum keeps outrunning the reload before it can converge.
+    /// The first two mismatches must still recover via reload (their gap
+    /// writes are compacted INTO the next reloaded segment); only the third
+    /// — exhausting the bound — falls back to the floored scan, which
+    /// cannot see its own round's gap write but must still surface a write
+    /// that lands above the final floor.
+    #[tokio::test]
+    #[serial(adr118_fresh_tail)]
+    async fn fresh_tail_reresolve_falls_back_to_floor_after_max_rounds() {
+        const MODEL: &str = "adr118-reresolve-exhaustion-test-model";
+        const DIMS: usize = 8;
+        let rt = test_runtime_with_hash_embedder(MODEL, DIMS);
+        let token = rt.authorize(Namespace::local()).expect("authorize local");
+
+        for i in 0..3u32 {
+            rt.create_note_with_decay_for_embedding_model(
+                &token,
+                "memory",
+                None,
+                &format!("exhaustion seed note {i}"),
+                Some(0.7),
+                0.01,
+                None,
+                vec![],
+                None,
+            )
+            .await
+            .expect("create seed note");
+        }
+
+        let ann = new_shared();
+        let key = AnnKey::from_token(MODEL);
+        ensure_ann_for_model(&rt, &token, &ann, MODEL)
+            .await
+            .expect("warm");
+        let s1 = bridge_applied_seq(&ann, &key)
+            .await
+            .expect("bridge watermark after initial warm");
+
+        // First checkpoint (pre-spawn, mirrors the two-round interleave
+        // test): this is what `fresh_tail_serving` resolves `new_s` to
+        // before ever calling `fresh_tail_reresolve`.
+        let write_a = rt
+            .create_note_with_decay_for_embedding_model(
+                &token,
+                "memory",
+                None,
+                "exhaustion round-1 write",
+                Some(0.7),
+                0.01,
+                None,
+                vec![],
+                None,
+            )
+            .await
+            .expect("create round-1 write");
+        let dir = ann_segment_dir(&rt, MODEL).expect("segment dir (file-backed test runtime)");
+        let (_live, tail1) = scope_counts(&rt, MODEL, s1)
+            .await
+            .expect("scope counts before first checkpoint");
+        assert!(tail1 > 0, "sanity: a tail must exist above s1");
+        let s2 = s1 + tail1;
+        {
+            let mut peer_bridge = AnnBridge::load(&dir).expect("load persisted segment");
+            let (ops, applied) = fetch_final_tail(&rt, MODEL, s1, None)
+                .await
+                .expect("fetch tail for first checkpoint");
+            peer_bridge
+                .apply_final_ops(ops, applied)
+                .expect("apply first checkpoint");
+            peer_bridge
+                .save_atomic(&dir)
+                .expect("persist first checkpoint");
+        }
+        raise_watermark(&rt, MODEL, s2)
+            .await
+            .expect("raise registry watermark to s2");
+        compact_log(&rt, MODEL)
+            .await
+            .expect("compact log through s2");
+
+        ann.reresolve_race_barrier
+            .store(true, std::sync::atomic::Ordering::SeqCst);
+        let mut paused = ann.reresolve_race_notify.notified();
+
+        let generation_before = current_generation(&ann, &key).await;
+        let query = fnv_to_vec("exhaustion beyond-floor write", DIMS);
+        let handle = tokio::spawn({
+            let rt = rt.clone();
+            let ann = ann.clone();
+            let key = key.clone();
+            async move { fresh_tail_leg(&rt, &ann, &key, MODEL, &query, 10, Some(s1)).await }
+        });
+
+        // Two more checkpoints, one per round's pause, each removing that
+        // round's gap write from `ann_write_log` — but each gap write is
+        // carried forward because the peer checkpoint that compacts it away
+        // also folds it into the segment this loop reloads next round.
+        let mut prev_s = s2;
+        let mut gap_writes = Vec::new();
+        for round_idx in 1..=2u32 {
+            paused.await;
+            let gap_write = rt
+                .create_note_with_decay_for_embedding_model(
+                    &token,
+                    "memory",
+                    None,
+                    &format!("exhaustion round-{} gap write", round_idx + 1),
+                    Some(0.7),
+                    0.01,
+                    None,
+                    vec![],
+                    None,
+                )
+                .await
+                .expect("create gap write");
+            let (_live, tail) = scope_counts(&rt, MODEL, prev_s)
+                .await
+                .expect("scope counts before interleaved checkpoint");
+            assert!(
+                tail > 0,
+                "sanity: a tail must exist above the prior watermark"
+            );
+            let next_s = prev_s + tail;
+            {
+                let mut peer_bridge = AnnBridge::load(&dir).expect("load segment for checkpoint");
+                let (ops, applied) = fetch_final_tail(&rt, MODEL, prev_s, None)
+                    .await
+                    .expect("fetch tail for interleaved checkpoint");
+                peer_bridge
+                    .apply_final_ops(ops, applied)
+                    .expect("apply interleaved checkpoint");
+                peer_bridge
+                    .save_atomic(&dir)
+                    .expect("persist interleaved checkpoint");
+            }
+            raise_watermark(&rt, MODEL, next_s)
+                .await
+                .expect("raise registry watermark");
+            compact_log(&rt, MODEL).await.expect("compact log");
+
+            let next_paused = ann.reresolve_race_notify.notified();
+            ann.reresolve_race_release.notify_one();
+            paused = next_paused;
+            gap_writes.push(gap_write);
+            prev_s = next_s;
+        }
+
+        // Third (terminal-round) checkpoint: its gap write lands in the
+        // window the floored fallback cannot see (round == MAX exhausts the
+        // loop before it can reload past this checkpoint).
+        paused.await;
+        let lost_write = rt
+            .create_note_with_decay_for_embedding_model(
+                &token,
+                "memory",
+                None,
+                "exhaustion round-4 lost write",
+                Some(0.7),
+                0.01,
+                None,
+                vec![],
+                None,
+            )
+            .await
+            .expect("create terminal-round gap write");
+        let (_live, tail) = scope_counts(&rt, MODEL, prev_s)
+            .await
+            .expect("scope counts before terminal checkpoint");
+        assert!(
+            tail > 0,
+            "sanity: a tail must exist above the prior watermark"
+        );
+        let s_final = prev_s + tail;
+        {
+            let mut peer_bridge = AnnBridge::load(&dir).expect("load segment for checkpoint");
+            let (ops, applied) = fetch_final_tail(&rt, MODEL, prev_s, None)
+                .await
+                .expect("fetch tail for terminal checkpoint");
+            peer_bridge
+                .apply_final_ops(ops, applied)
+                .expect("apply terminal checkpoint");
+            peer_bridge
+                .save_atomic(&dir)
+                .expect("persist terminal checkpoint");
+        }
+        raise_watermark(&rt, MODEL, s_final)
+            .await
+            .expect("raise registry watermark to s_final");
+        compact_log(&rt, MODEL)
+            .await
+            .expect("compact log through s_final");
+
+        // A write above the terminal floor must still surface through the
+        // floored fallback's own (still-real) tail scan.
+        let beyond_floor = rt
+            .create_note_with_decay_for_embedding_model(
+                &token,
+                "memory",
+                None,
+                "exhaustion beyond-floor write",
+                Some(0.7),
+                0.01,
+                None,
+                vec![],
+                None,
+            )
+            .await
+            .expect("create beyond-floor write");
+
+        ann.reresolve_race_barrier
+            .store(false, std::sync::atomic::Ordering::SeqCst);
+        ann.reresolve_race_release.notify_one();
+
+        let outcome = handle.await.expect("fresh_tail_leg task");
+        let candidates = match outcome {
+            FreshTailOutcome::Replace(candidates) => candidates,
+            FreshTailOutcome::Ops(_) => panic!(
+                "expected the terminal round to replace candidates outright, \
+                 not just return ops to merge into the stale bridge's candidates"
+            ),
+            FreshTailOutcome::Skipped => {
+                panic!("expected the bound-exhaustion floored fallback, not a skip")
+            }
+        };
+        assert!(
+            candidates.iter().any(|(id, _)| *id == write_a.id),
+            "the pre-spawn checkpoint's write must survive every reload: {candidates:?}"
+        );
+        for gap_write in &gap_writes {
+            assert!(
+                candidates.iter().any(|(id, _)| *id == gap_write.id),
+                "a gap write compacted into a NON-terminal round's reloaded \
+                 segment must be recovered, not dropped: {candidates:?}"
+            );
+        }
+        assert!(
+            !candidates.iter().any(|(id, _)| *id == lost_write.id),
+            "the terminal round's own gap write is the documented \
+             ADR-118 mismatch-window loss (its segment is never reloaded \
+             once the bound is exhausted) — it must NOT silently reappear \
+             here, or this assertion is guarding a fix that changed \
+             behavior without updating this test: {candidates:?}"
+        );
+        assert!(
+            candidates.iter().any(|(id, _)| *id == beyond_floor.id),
+            "a write committed above the terminal floor must survive the \
+             floored fallback's own tail scan: {candidates:?}"
+        );
+        assert!(
+            current_generation(&ann, &key).await > generation_before,
+            "the bound-exhaustion floored fallback must still force \
+             re-adoption so a future query gets a fresh bridge"
         );
     }
 

--- a/crates/khive-pack-memory/src/ann.rs
+++ b/crates/khive-pack-memory/src/ann.rs
@@ -1336,20 +1336,31 @@ async fn tail_exists(rt: &KhiveRuntime, model: &str, s: u64) -> Result<bool, Str
 /// a row that is present but whose note fails the join predicate
 /// (soft-deleted, or gone) replays as a delete — its final corpus state is
 /// absence. Returns the ops and the new watermark.
-async fn fetch_final_tail(
+pub(crate) async fn fetch_final_tail(
     rt: &KhiveRuntime,
     model: &str,
     s: u64,
+    limit: Option<u64>,
 ) -> Result<(Vec<(Uuid, Option<Vec<f32>>)>, u64), String> {
     let sql = rt.sql();
     let mut reader = sql.reader().await.map_err(|e| e.to_string())?;
+    // `limit` (ADR-118 §3, Cold/Empty tier): cap the scan to the newest
+    // `limit` log rows instead of the entire scope, taking the highest-seq
+    // suffix so the freshest writes stay visible. The DESC+LIMIT rows are
+    // reversed back to ascending order below so final-op-per-subject
+    // coalescing (insert-overwrite = last write wins) is unaffected.
+    let order_limit = match limit {
+        Some(n) => format!("ORDER BY seq DESC LIMIT {n}"),
+        None => "ORDER BY seq".to_string(),
+    };
     let rows = reader
         .query_all(SqlStatement {
-            sql: "SELECT seq, subject_id, op FROM ann_write_log \
+            sql: format!(
+                "SELECT seq, subject_id, op FROM ann_write_log \
                   WHERE embedding_model = ?1 \
                     AND kind = 'note' AND field = 'note.content' AND seq > ?2 \
-                  ORDER BY seq"
-                .into(),
+                  {order_limit}"
+            ),
             params: vec![
                 SqlValue::Text(model.to_owned()),
                 SqlValue::Integer(s as i64),
@@ -1358,6 +1369,10 @@ async fn fetch_final_tail(
         })
         .await
         .map_err(|e| e.to_string())?;
+    let mut rows = rows;
+    if limit.is_some() {
+        rows.reverse();
+    }
 
     let mut new_s = s;
     // Ordered iteration + insert-overwrite = final op per subject wins.
@@ -1483,6 +1498,236 @@ async fn fetch_final_tail(
         }
     }
     Ok((ops, new_s))
+}
+
+// ── ADR-118: fresh-tail exact leg (read-your-writes recall visibility) ─────────
+
+/// `KHIVE_ANN_FRESH_TAIL=0` disables the exact leg (default enabled). Any
+/// other value, including unset, leaves it enabled.
+fn fresh_tail_enabled() -> bool {
+    std::env::var("KHIVE_ANN_FRESH_TAIL")
+        .map(|v| v != "0")
+        .unwrap_or(true)
+}
+
+/// Read the currently-installed bridge's fresh-tail watermark for `key`: the
+/// `ann_write_log` seq its corpus state reflects, or `None` if no bridge is
+/// installed. Call this immediately adjacent to a `search_loaded` call that
+/// returned `Some` to minimize the window for a concurrent bridge swap.
+pub(crate) async fn bridge_applied_seq(ann: &SharedAnn, key: &AnnKey) -> Option<u64> {
+    let guard = ann.indexes.read().await;
+    guard
+        .get(key)
+        .map(|b| b.index.last_applied_seq().unwrap_or(0))
+}
+
+/// The pair's wildcard-inclusive registry minimum (ADR-118 §1 "Compaction
+/// linearization"): the same subselect `compact_log` uses to bound deletion,
+/// evaluated at this consumer's own registered namespace (`'*'`). If this
+/// exceeds a bridge's watermark, the log may no longer retain every row
+/// above that watermark — completeness above it is unprovable.
+async fn registry_min_watermark(rt: &KhiveRuntime, model: &str) -> Result<Option<i64>, String> {
+    let sql = rt.sql();
+    let mut reader = sql.reader().await.map_err(|e| e.to_string())?;
+    let rows = reader
+        .query_all(SqlStatement {
+            sql: "SELECT MIN(watermark) AS m FROM ann_consumer_watermark \
+                  WHERE (namespace = ?1 OR namespace = '*') AND embedding_model = ?2"
+                .into(),
+            params: vec![
+                SqlValue::Text(ANN_WILDCARD_NS.into()),
+                SqlValue::Text(model.to_owned()),
+            ],
+            label: Some("memory_ann_registry_min".into()),
+        })
+        .await
+        .map_err(|e| e.to_string())?;
+    Ok(rows.into_iter().next().and_then(|row| match row.get("m") {
+        Some(SqlValue::Integer(n)) => Some(*n),
+        _ => None,
+    }))
+}
+
+/// Exact cosine similarity between a raw query vector and a raw stored
+/// embedding, using the same L2-normalization convention as
+/// [`AnnBridge::search`]: both vectors normalized, dot product, clamped to a
+/// non-negative floor.
+pub(crate) fn exact_cosine(query: &[f32], embedding: &[f32]) -> f32 {
+    let mut q = query.to_vec();
+    l2_normalize(&mut q);
+    let mut e = embedding.to_vec();
+    l2_normalize(&mut e);
+    q.iter()
+        .zip(e.iter())
+        .map(|(a, b)| a * b)
+        .sum::<f32>()
+        .max(0.0)
+}
+
+/// Merge a fresh-tail's coalesced final ops into an existing ANN candidate
+/// list (ADR-118 §2): deduplicated by `subject_id` with the tail winning
+/// (its embedding is at least as fresh as the segment's), then re-sorted by
+/// score. A `None` op (final delete) drops the subject from the merged list
+/// even if it was present in `best_raw` — the tail is authoritative for
+/// every subject it names. An empty `ops` returns `best_raw` unchanged, so
+/// fusion is byte-identical whenever there is nothing to merge.
+pub(crate) fn merge_fresh_tail(
+    best_raw: Vec<(Uuid, f32)>,
+    query: &[f32],
+    ops: Vec<(Uuid, Option<Vec<f32>>)>,
+) -> Vec<(Uuid, f32)> {
+    if ops.is_empty() {
+        return best_raw;
+    }
+    let mut deletes: HashSet<Uuid> = HashSet::new();
+    let mut upserts: HashMap<Uuid, f32> = HashMap::new();
+    for (uuid, op) in ops {
+        match op {
+            None => {
+                deletes.insert(uuid);
+            }
+            Some(embedding) => {
+                upserts.insert(uuid, exact_cosine(query, &embedding));
+            }
+        }
+    }
+    let mut merged: Vec<(Uuid, f32)> = best_raw
+        .into_iter()
+        .filter(|(u, _)| !deletes.contains(u) && !upserts.contains_key(u))
+        .collect();
+    merged.extend(upserts);
+    merged.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
+    merged
+}
+
+/// Outcome of [`fresh_tail_leg`]: either coalesced final ops ready to merge
+/// via [`merge_fresh_tail`], or a signal that the leg sat out this query.
+pub(crate) enum FreshTailOutcome {
+    Merged(Vec<(Uuid, Option<Vec<f32>>)>),
+    Skipped,
+}
+
+/// The ADR-118 fresh-tail exact leg. `s = Some(watermark)` is the first
+/// (and primary) tier: a serving bridge exists, and every committed write
+/// above its watermark is merged in, giving read-your-writes visibility.
+/// `s = None` is the second tier (§3): no serving index is available at all,
+/// so the leg caps its scan at the rebuild-threshold-sized newest suffix of
+/// the log instead of the entire scope, guaranteeing visibility of only the
+/// caller's most recent writes until a serving index exists again.
+pub(crate) async fn fresh_tail_leg(
+    rt: &KhiveRuntime,
+    ann: &SharedAnn,
+    key: &AnnKey,
+    model: &str,
+    s: Option<u64>,
+) -> FreshTailOutcome {
+    if !fresh_tail_enabled() {
+        return FreshTailOutcome::Skipped;
+    }
+
+    // Registration precondition (ADR-118 §1): S = 0 (or "no bridge") proves
+    // an entire-scope tail only if no compaction has ever run for this
+    // consumer's registration. Absent row: register at 0 and sit out this
+    // query — the existing Cold classification already serves correctly.
+    match read_own_watermark(rt, model).await {
+        Ok(Some(_)) => {}
+        Ok(None) => {
+            if let Err(e) = register_consumer(rt, model).await {
+                tracing::warn!(error = %e, model, "fresh-tail: consumer re-registration failed");
+            }
+            return FreshTailOutcome::Skipped;
+        }
+        Err(e) => {
+            tracing::warn!(error = %e, model, "fresh-tail: registry read failed; skipping exact leg");
+            return FreshTailOutcome::Skipped;
+        }
+    }
+
+    match s {
+        Some(s) => fresh_tail_serving(rt, ann, key, model, s).await,
+        None => fresh_tail_capped(rt, model).await,
+    }
+}
+
+/// Tier 1: a serving bridge exists at watermark `s`.
+async fn fresh_tail_serving(
+    rt: &KhiveRuntime,
+    ann: &SharedAnn,
+    key: &AnnKey,
+    model: &str,
+    s: u64,
+) -> FreshTailOutcome {
+    // Compaction linearization (ADR-118 §1): the registry minimum can
+    // advance past a stale in-memory bridge's watermark the instant another
+    // process's checkpoint raises it and compacts. A scan above `s` proves
+    // completeness only if the log still retains every row above `s`.
+    let registry_min = match registry_min_watermark(rt, model).await {
+        Ok(v) => v,
+        Err(e) => {
+            tracing::warn!(error = %e, model, "fresh-tail: registry-min read failed; skipping exact leg");
+            return FreshTailOutcome::Skipped;
+        }
+    };
+    let effective_s = match registry_min {
+        Some(m) if m as u64 > s => {
+            // Re-resolve the currently published segment (its watermark is
+            // at least the registry minimum) and use its watermark instead.
+            let resolved = ann_segment_dir(rt, model)
+                .and_then(|dir| read_commit_info(&dir).ok().flatten())
+                .and_then(|info| info.last_applied_seq);
+            match resolved {
+                Some(new_s) if new_s >= m as u64 => {
+                    // Force re-adoption so the next warm check picks up the
+                    // segment this query just resolved to.
+                    bump_generation(ann, key).await;
+                    new_s
+                }
+                _ => {
+                    // Re-resolution failed: degrade to ADR-107 (ANN-only)
+                    // for this query rather than serve an unprovable tail.
+                    bump_generation(ann, key).await;
+                    return FreshTailOutcome::Skipped;
+                }
+            }
+        }
+        _ => s,
+    };
+    match fetch_final_tail(rt, model, effective_s, None).await {
+        Ok((ops, _new_s)) => FreshTailOutcome::Merged(ops),
+        Err(e) => {
+            tracing::warn!(error = %e, model, "fresh-tail: tail fetch failed; skipping exact leg");
+            FreshTailOutcome::Skipped
+        }
+    }
+}
+
+/// Tier 2 (§3): no serving index at all. Caps the scan at the
+/// rebuild-threshold-sized newest suffix so the caller's most recent writes
+/// stay visible without absorbing the full Cold/Empty scope.
+async fn fresh_tail_capped(rt: &KhiveRuntime, model: &str) -> FreshTailOutcome {
+    let (live, tail) = match scope_counts(rt, model, 0).await {
+        Ok(counts) => counts,
+        Err(e) => {
+            tracing::warn!(error = %e, model, "fresh-tail: scope-count read failed; skipping capped exact leg");
+            return FreshTailOutcome::Skipped;
+        }
+    };
+    if live == 0 || tail == 0 {
+        return FreshTailOutcome::Merged(Vec::new());
+    }
+    let threshold = (ann_rebuild_threshold() * live as f64).ceil() as u64;
+    let cap = if tail > threshold {
+        Some(threshold)
+    } else {
+        None
+    };
+    match fetch_final_tail(rt, model, 0, cap).await {
+        Ok((ops, _new_s)) => FreshTailOutcome::Merged(ops),
+        Err(e) => {
+            tracing::warn!(error = %e, model, "fresh-tail: capped tail fetch failed; skipping exact leg");
+            FreshTailOutcome::Skipped
+        }
+    }
 }
 
 /// Persist `bridge` at its applied watermark, raise the wildcard registry row,
@@ -1672,7 +1917,7 @@ async fn classify_and_adopt_segment(
                 return SegmentOutcome::Cold;
             }
         };
-        let (ops, new_s) = match fetch_final_tail(rt, model, s).await {
+        let (ops, new_s) = match fetch_final_tail(rt, model, s, None).await {
             Ok(t) => t,
             Err(e) => {
                 tracing::warn!(error = %e, "memory tail replay read failed; Cold rebuild");
@@ -3013,6 +3258,349 @@ mod tests {
             "a write racing in during an in-flight warm must eventually be \
              picked up and converge on its own, with zero further recalls or \
              writes to retrigger it (#812)"
+        );
+    }
+
+    // ── ADR-118: fresh-tail exact leg ───────────────────────────────────────
+
+    /// A subject present in the stale warm ANN index whose final tail op is
+    /// `delete` must be dropped from the merged candidate list — the tail is
+    /// authoritative for every subject it names.
+    #[tokio::test]
+    #[serial(adr118_fresh_tail)]
+    async fn fresh_tail_leg_drops_subject_whose_final_tail_op_is_delete() {
+        const MODEL: &str = "adr118-tail-delete-test-model";
+        const DIMS: usize = 8;
+        let rt = test_runtime_with_hash_embedder(MODEL, DIMS);
+        let token = rt.authorize(Namespace::local()).expect("authorize local");
+
+        let target = rt
+            .create_note_with_decay_for_embedding_model(
+                &token,
+                "memory",
+                None,
+                "tail delete target note",
+                Some(0.7),
+                0.01,
+                None,
+                vec![],
+                None,
+            )
+            .await
+            .expect("create target note");
+        for i in 0..3u32 {
+            rt.create_note_with_decay_for_embedding_model(
+                &token,
+                "memory",
+                None,
+                &format!("tail delete filler note {i}"),
+                Some(0.7),
+                0.01,
+                None,
+                vec![],
+                None,
+            )
+            .await
+            .expect("create filler note");
+        }
+
+        let ann = new_shared();
+        let key = AnnKey::from_token(MODEL);
+        let status = ensure_ann_for_model(&rt, &token, &ann, MODEL)
+            .await
+            .expect("warm");
+        assert!(
+            matches!(status, AnnEnsureStatus::Built { vectors: 4 }),
+            "expected initial build of 4 vectors, got: {status:?}"
+        );
+
+        // Delete AFTER the bridge is warm — a write only bumps generation, it
+        // never evicts the served bridge, so its cached graph still nominates
+        // the now-deleted subject.
+        rt.delete_note(&token, target.id, false)
+            .await
+            .expect("soft delete target");
+
+        let query = fnv_to_vec("tail delete target note", DIMS);
+        let raw = search_loaded(&ann, &key, &query, 10)
+            .await
+            .expect("search")
+            .expect("bridge still warm");
+        assert!(
+            raw.iter().any(|(id, _)| *id == target.id),
+            "sanity: the stale warm bridge must still nominate the deleted \
+             subject from its cached graph before the fresh-tail leg runs"
+        );
+
+        let s = bridge_applied_seq(&ann, &key)
+            .await
+            .expect("bridge watermark");
+        let ops = match fresh_tail_leg(&rt, &ann, &key, MODEL, Some(s)).await {
+            FreshTailOutcome::Merged(ops) => ops,
+            FreshTailOutcome::Skipped => panic!("fresh-tail leg unexpectedly skipped"),
+        };
+        let merged = merge_fresh_tail(raw, &query, ops);
+        assert!(
+            !merged.iter().any(|(id, _)| *id == target.id),
+            "a subject whose final tail op is delete must be dropped from the \
+             merged candidate list even though the stale ANN index still \
+             nominates it, got: {merged:?}"
+        );
+    }
+
+    /// A subject present in both the stale ANN candidates and the tail
+    /// appears exactly once in the merged list, carrying the tail's exact
+    /// (fresher) score rather than the segment's quantized one.
+    #[tokio::test]
+    #[serial(adr118_fresh_tail)]
+    async fn fresh_tail_leg_dedups_with_tail_winning() {
+        const MODEL: &str = "adr118-tail-dedup-test-model";
+        const DIMS: usize = 8;
+        let rt = test_runtime_with_hash_embedder(MODEL, DIMS);
+        let token = rt.authorize(Namespace::local()).expect("authorize local");
+
+        let target = rt
+            .create_note_with_decay_for_embedding_model(
+                &token,
+                "memory",
+                None,
+                "tail dedup original content",
+                Some(0.7),
+                0.01,
+                None,
+                vec![],
+                None,
+            )
+            .await
+            .expect("create target note");
+        for i in 0..3u32 {
+            rt.create_note_with_decay_for_embedding_model(
+                &token,
+                "memory",
+                None,
+                &format!("tail dedup filler note {i}"),
+                Some(0.7),
+                0.01,
+                None,
+                vec![],
+                None,
+            )
+            .await
+            .expect("create filler note");
+        }
+
+        let ann = new_shared();
+        let key = AnnKey::from_token(MODEL);
+        let status = ensure_ann_for_model(&rt, &token, &ann, MODEL)
+            .await
+            .expect("warm");
+        assert!(
+            matches!(status, AnnEnsureStatus::Built { vectors: 4 }),
+            "expected initial build of 4 vectors, got: {status:?}"
+        );
+
+        const UPDATED_TEXT: &str = "tail dedup UPDATED content, unrelated to the original";
+        rt.update_note(
+            &token,
+            target.id,
+            khive_runtime::NotePatch::new(None, Some(UPDATED_TEXT.to_string()), None, None, None),
+        )
+        .await
+        .expect("update target note");
+
+        // Query the segment's stale embedding of the ORIGINAL content: the
+        // stale ANN index nominates the subject at its old (now-superseded)
+        // score, while the tail carries the exact score against the updated
+        // embedding — they must collapse to one entry, tail winning.
+        let query = fnv_to_vec("tail dedup original content", DIMS);
+        let raw = search_loaded(&ann, &key, &query, 10)
+            .await
+            .expect("search")
+            .expect("bridge still warm");
+        let stale_score = raw
+            .iter()
+            .find(|(id, _)| *id == target.id)
+            .map(|(_, score)| *score)
+            .expect("sanity: stale ANN index must still nominate the pre-update subject");
+
+        let s = bridge_applied_seq(&ann, &key)
+            .await
+            .expect("bridge watermark");
+        let ops = match fresh_tail_leg(&rt, &ann, &key, MODEL, Some(s)).await {
+            FreshTailOutcome::Merged(ops) => ops,
+            FreshTailOutcome::Skipped => panic!("fresh-tail leg unexpectedly skipped"),
+        };
+        let merged = merge_fresh_tail(raw, &query, ops);
+
+        let matches: Vec<&(Uuid, f32)> = merged.iter().filter(|(id, _)| *id == target.id).collect();
+        assert_eq!(
+            matches.len(),
+            1,
+            "the subject must appear exactly once in the merged list, got: {merged:?}"
+        );
+        let exact_score = exact_cosine(&query, &fnv_to_vec(UPDATED_TEXT, DIMS));
+        assert!(
+            (matches[0].1 - exact_score).abs() < 1e-6,
+            "the merged entry must carry the tail's exact score ({exact_score}) \
+             rather than the stale segment's score ({stale_score}), got {}",
+            matches[0].1
+        );
+    }
+
+    /// The compaction-linearization guard: if the registry minimum has
+    /// advanced past the serving bridge's watermark, the log may no longer
+    /// retain every row above it. The leg must detect the mismatch in the
+    /// same snapshot and refuse to serve an unprovable (silently incomplete)
+    /// tail — it re-resolves the published segment or skips outright.
+    #[tokio::test]
+    #[serial(adr118_fresh_tail)]
+    async fn fresh_tail_leg_skips_when_registry_minimum_outpaces_bridge_watermark() {
+        const MODEL: &str = "adr118-compaction-guard-test-model";
+        const DIMS: usize = 8;
+        let rt = test_runtime_with_hash_embedder(MODEL, DIMS);
+        let token = rt.authorize(Namespace::local()).expect("authorize local");
+
+        for i in 0..3u32 {
+            rt.create_note_with_decay_for_embedding_model(
+                &token,
+                "memory",
+                None,
+                &format!("compaction guard seed note {i}"),
+                Some(0.7),
+                0.01,
+                None,
+                vec![],
+                None,
+            )
+            .await
+            .expect("create seed note");
+        }
+
+        let ann = new_shared();
+        let key = AnnKey::from_token(MODEL);
+        ensure_ann_for_model(&rt, &token, &ann, MODEL)
+            .await
+            .expect("warm");
+        let s1 = bridge_applied_seq(&ann, &key)
+            .await
+            .expect("bridge watermark after initial warm");
+
+        // A write lands after the checkpoint: the log advances, but the
+        // served bridge is never re-persisted (only `ensure_ann_for_model`
+        // does that), so its own watermark stays pinned at `s1`.
+        rt.create_note_with_decay_for_embedding_model(
+            &token,
+            "memory",
+            None,
+            "compaction guard post-checkpoint write",
+            Some(0.7),
+            0.01,
+            None,
+            vec![],
+            None,
+        )
+        .await
+        .expect("create post-checkpoint note");
+
+        // Simulate a peer process's checkpoint: raise the shared durable
+        // registry watermark past `s1` and compact the log through it —
+        // exactly `checkpoint_raise_compact_readopt`'s raise+compact steps,
+        // without the persist/re-adopt this bridge never observes.
+        let (_live, tail_before) = scope_counts(&rt, MODEL, s1)
+            .await
+            .expect("scope counts before compaction");
+        assert!(tail_before > 0, "sanity: a tail must exist above s1");
+        let s2 = s1 + tail_before;
+        raise_watermark(&rt, MODEL, s2)
+            .await
+            .expect("raise registry watermark past bridge watermark");
+        compact_log(&rt, MODEL).await.expect("compact log");
+
+        let outcome = fresh_tail_leg(&rt, &ann, &key, MODEL, Some(s1)).await;
+        assert!(
+            matches!(outcome, FreshTailOutcome::Skipped),
+            "a bridge watermark behind the registry minimum, with the log \
+             compacted past it and no re-persisted segment to re-resolve to, \
+             must refuse to serve an unprovable tail instead of silently \
+             returning an incomplete merge"
+        );
+    }
+
+    /// Registration precondition: absent a durable registry row for this
+    /// consumer, the leg must not trust `S = 0` as an entire-scope tail (a
+    /// registered peer consumer may have already compacted rows this one
+    /// never saw) — it registers at 0 and sits out the query.
+    #[tokio::test]
+    #[serial(adr118_fresh_tail)]
+    async fn fresh_tail_leg_skips_and_reregisters_when_consumer_row_absent() {
+        const MODEL: &str = "adr118-registration-precondition-test-model";
+        const DIMS: usize = 8;
+        let rt = test_runtime_with_hash_embedder(MODEL, DIMS);
+        let token = rt.authorize(Namespace::local()).expect("authorize local");
+
+        rt.create_note_with_decay_for_embedding_model(
+            &token,
+            "memory",
+            None,
+            "registration precondition seed note",
+            Some(0.7),
+            0.01,
+            None,
+            vec![],
+            None,
+        )
+        .await
+        .expect("create seed note");
+
+        let ann = new_shared();
+        let key = AnnKey::from_token(MODEL);
+        ensure_ann_for_model(&rt, &token, &ann, MODEL)
+            .await
+            .expect("warm");
+        let s = bridge_applied_seq(&ann, &key)
+            .await
+            .expect("bridge watermark");
+
+        // Delete this consumer's durable registry row directly, simulating a
+        // process that has never registered (or whose row was reset).
+        {
+            let sql = rt.sql();
+            let mut w = sql.writer().await.expect("writer");
+            w.execute(SqlStatement {
+                sql: "DELETE FROM ann_consumer_watermark \
+                      WHERE consumer = ?1 AND namespace = ?2 AND embedding_model = ?3"
+                    .into(),
+                params: vec![
+                    SqlValue::Text(ANN_CONSUMER.into()),
+                    SqlValue::Text(ANN_WILDCARD_NS.into()),
+                    SqlValue::Text(MODEL.into()),
+                ],
+                label: Some("test_delete_consumer_watermark_row".into()),
+            })
+            .await
+            .expect("delete registry row");
+        }
+        assert!(
+            read_own_watermark(&rt, MODEL)
+                .await
+                .expect("read watermark")
+                .is_none(),
+            "sanity: the registry row must be gone before the leg runs"
+        );
+
+        let outcome = fresh_tail_leg(&rt, &ann, &key, MODEL, Some(s)).await;
+        assert!(
+            matches!(outcome, FreshTailOutcome::Skipped),
+            "the exact leg must sit out a query when this consumer's durable \
+             registration row is absent"
+        );
+        assert_eq!(
+            read_own_watermark(&rt, MODEL)
+                .await
+                .expect("read watermark"),
+            Some(0),
+            "the leg must re-register this consumer at watermark 0 before \
+             sitting out the query"
         );
     }
 }

--- a/crates/khive-pack-memory/src/ann.rs
+++ b/crates/khive-pack-memory/src/ann.rs
@@ -79,6 +79,16 @@ pub(crate) struct AnnState {
     /// Test notification emitted when the background warming guard becomes idle.
     #[cfg(test)]
     pub(crate) warming_idle: tokio::sync::Notify,
+    /// Arms the test-only pause in `fresh_tail_reresolve` between its
+    /// segment load and its registry-minimum re-check.
+    #[cfg(test)]
+    pub(crate) reresolve_race_barrier: std::sync::atomic::AtomicBool,
+    /// Notified once `fresh_tail_reresolve` reaches the armed pause point.
+    #[cfg(test)]
+    pub(crate) reresolve_race_notify: tokio::sync::Notify,
+    /// `fresh_tail_reresolve` waits on this to resume past the armed pause.
+    #[cfg(test)]
+    pub(crate) reresolve_race_release: tokio::sync::Notify,
 }
 
 pub(crate) type SharedAnn = Arc<AnnState>;
@@ -100,6 +110,12 @@ pub(crate) fn new_shared() -> SharedAnn {
         attempt_floor_barrier: std::sync::atomic::AtomicBool::new(false),
         #[cfg(test)]
         warming_idle: tokio::sync::Notify::new(),
+        #[cfg(test)]
+        reresolve_race_barrier: std::sync::atomic::AtomicBool::new(false),
+        #[cfg(test)]
+        reresolve_race_notify: tokio::sync::Notify::new(),
+        #[cfg(test)]
+        reresolve_race_release: tokio::sync::Notify::new(),
     })
 }
 
@@ -1862,7 +1878,56 @@ async fn fresh_tail_reresolve(
     // Force re-adoption so the background warm path installs this segment
     // for future queries too — this load served only the current query.
     bump_generation(ann, key).await;
-    match fetch_final_tail(rt, model, new_s, None).await {
+
+    #[cfg(test)]
+    {
+        if ann
+            .reresolve_race_barrier
+            .load(std::sync::atomic::Ordering::SeqCst)
+        {
+            ann.reresolve_race_notify.notify_one();
+            ann.reresolve_race_release.notified().await;
+        }
+    }
+
+    // The filesystem commit-info read that produced `new_s` and this tail
+    // scan are not otherwise ordered against a concurrent checkpoint: a
+    // peer can raise the registry watermark past `new_s` and compact the
+    // now-covered log rows in between, silently dropping a committed write
+    // from a `> new_s` scan — the same compaction race the primary path
+    // (`fresh_tail_serving`) already guards against for its own tail fetch.
+    // Re-validate the registry minimum and run the tail scan inside one
+    // snapshot so no compaction can strike between the guard and the fetch.
+    let mut reader = match rt.sql().reader().await {
+        Ok(r) => r,
+        Err(e) => {
+            tracing::warn!(error = %e, model, "fresh-tail: re-resolved reader open failed; serving re-resolved candidates without further tail");
+            return FreshTailOutcome::Replace(candidates);
+        }
+    };
+    if let Err(e) = begin_read_snapshot(reader.as_mut()).await {
+        tracing::warn!(error = %e, model, "fresh-tail: re-resolved snapshot begin failed; serving re-resolved candidates without further tail");
+        return FreshTailOutcome::Replace(candidates);
+    }
+
+    let floor = match registry_min_watermark_on(reader.as_mut(), model).await {
+        Ok(Some(m)) if m as u64 > new_s => m as u64,
+        Ok(_) => new_s,
+        Err(e) => {
+            end_read_snapshot(reader.as_mut()).await;
+            tracing::warn!(error = %e, model, "fresh-tail: re-resolved registry-min read failed; serving re-resolved candidates without further tail");
+            return FreshTailOutcome::Replace(candidates);
+        }
+    };
+    // `floor > new_s` is the ADR's floored fallback (mirrors
+    // `fresh_tail_serving`'s own mismatch floor): the registry minimum
+    // advanced again after this segment was loaded, so its (new_s, floor]
+    // window is not provably retained in the log. Scan from `floor` instead
+    // — a coherent (these candidates, this floor) pair — rather than
+    // re-resolving again; one re-validation is the terminal branch.
+    let outcome = fetch_final_tail_on(reader.as_mut(), model, floor, None).await;
+    end_read_snapshot(reader.as_mut()).await;
+    match outcome {
         Ok((ops, _)) => FreshTailOutcome::Replace(merge_fresh_tail(candidates, query, ops)),
         Err(e) => {
             tracing::warn!(error = %e, model, "fresh-tail: re-resolved tail fetch failed; serving re-resolved candidates without further tail");
@@ -3826,6 +3891,201 @@ mod tests {
             current_generation(&ann, &key).await > generation_before,
             "re-resolution must still force re-adoption so a future query \
              installs this segment as the served bridge"
+        );
+    }
+
+    /// ADR-118 §1 "Compaction linearization" applied to re-resolution itself:
+    /// a peer checkpoint can advance the registry minimum PAST the segment
+    /// `fresh_tail_reresolve` just loaded, in the window between that load
+    /// and its tail scan. The fix re-validates the registry minimum inside a
+    /// fresh snapshot before scanning and floors the scan at the new minimum
+    /// when it has moved — the same terminal floor `fresh_tail_serving`
+    /// already takes on its own mismatch. A write committed above that new
+    /// floor must still surface through the floored scan, not be silently
+    /// dropped the way it would be by a plain, unvalidated `> new_s` scan
+    /// racing against the interleaved compaction.
+    #[tokio::test]
+    #[serial(adr118_fresh_tail)]
+    async fn fresh_tail_reresolve_revalidates_registry_minimum_against_interleaved_compaction() {
+        const MODEL: &str = "adr118-reresolve-interleave-test-model";
+        const DIMS: usize = 8;
+        let rt = test_runtime_with_hash_embedder(MODEL, DIMS);
+        let token = rt.authorize(Namespace::local()).expect("authorize local");
+
+        for i in 0..3u32 {
+            rt.create_note_with_decay_for_embedding_model(
+                &token,
+                "memory",
+                None,
+                &format!("interleave seed note {i}"),
+                Some(0.7),
+                0.01,
+                None,
+                vec![],
+                None,
+            )
+            .await
+            .expect("create seed note");
+        }
+
+        let ann = new_shared();
+        let key = AnnKey::from_token(MODEL);
+        ensure_ann_for_model(&rt, &token, &ann, MODEL)
+            .await
+            .expect("warm");
+        let s1 = bridge_applied_seq(&ann, &key)
+            .await
+            .expect("bridge watermark after initial warm");
+
+        // A write lands after the checkpoint — this is what the first peer
+        // checkpoint (below) will persist into its segment.
+        rt.create_note_with_decay_for_embedding_model(
+            &token,
+            "memory",
+            None,
+            "interleave first-checkpoint write",
+            Some(0.7),
+            0.01,
+            None,
+            vec![],
+            None,
+        )
+        .await
+        .expect("create first-checkpoint note");
+
+        let (_live, tail1) = scope_counts(&rt, MODEL, s1)
+            .await
+            .expect("scope counts before first peer checkpoint");
+        assert!(tail1 > 0, "sanity: a tail must exist above s1");
+        let s2 = s1 + tail1;
+
+        // Peer checkpoint #1: persist a segment at s2, raise+compact through
+        // it. This is the mismatch `fresh_tail_leg` will detect against the
+        // stale in-memory bridge still pinned at s1, and `new_s` it will
+        // re-resolve to.
+        let dir = ann_segment_dir(&rt, MODEL).expect("segment dir (file-backed test runtime)");
+        let mut peer_bridge = AnnBridge::load(&dir).expect("load persisted segment");
+        let (ops1, applied_s2) = fetch_final_tail(&rt, MODEL, s1, None)
+            .await
+            .expect("fetch tail for first peer checkpoint");
+        peer_bridge
+            .apply_final_ops(ops1, applied_s2)
+            .expect("apply first peer checkpoint");
+        peer_bridge
+            .save_atomic(&dir)
+            .expect("persist first peer checkpoint");
+        raise_watermark(&rt, MODEL, s2)
+            .await
+            .expect("raise registry watermark to s2");
+        compact_log(&rt, MODEL)
+            .await
+            .expect("compact log through s2");
+
+        // Arm the race: `fresh_tail_reresolve` will pause right after it
+        // loads and searches the s2 segment, before it re-validates the
+        // registry minimum.
+        ann.reresolve_race_barrier
+            .store(true, std::sync::atomic::Ordering::SeqCst);
+        let paused = ann.reresolve_race_notify.notified();
+
+        let generation_before = current_generation(&ann, &key).await;
+        let query = fnv_to_vec("interleave post-compaction write", DIMS);
+        let handle = tokio::spawn({
+            let rt = rt.clone();
+            let ann = ann.clone();
+            let key = key.clone();
+            async move { fresh_tail_leg(&rt, &ann, &key, MODEL, &query, 10, Some(s1)).await }
+        });
+
+        // Wait for the leg to reach the armed pause (after its segment load,
+        // before its registry re-check) before racing a second checkpoint in.
+        paused.await;
+
+        // A further write lands, THEN a peer's second checkpoint covers it:
+        // persist a segment at s3, raise+compact through it. This physically
+        // removes the (s2, s3] log window — including the write below — from
+        // `ann_write_log`, and is exactly the interleaving the fix must
+        // detect via its re-validated registry-minimum read.
+        rt.create_note_with_decay_for_embedding_model(
+            &token,
+            "memory",
+            None,
+            "interleave second-checkpoint write",
+            Some(0.7),
+            0.01,
+            None,
+            vec![],
+            None,
+        )
+        .await
+        .expect("create second-checkpoint note");
+        let (_live, tail2) = scope_counts(&rt, MODEL, s2)
+            .await
+            .expect("scope counts before second peer checkpoint");
+        assert!(tail2 > 0, "sanity: a tail must exist above s2");
+        let s3 = s2 + tail2;
+        let mut peer_bridge2 =
+            AnnBridge::load(&dir).expect("load s2 segment for second checkpoint");
+        let (ops2, applied_s3) = fetch_final_tail(&rt, MODEL, s2, None)
+            .await
+            .expect("fetch tail for second peer checkpoint");
+        peer_bridge2
+            .apply_final_ops(ops2, applied_s3)
+            .expect("apply second peer checkpoint");
+        peer_bridge2
+            .save_atomic(&dir)
+            .expect("persist second peer checkpoint");
+        raise_watermark(&rt, MODEL, s3)
+            .await
+            .expect("raise registry watermark to s3");
+        compact_log(&rt, MODEL)
+            .await
+            .expect("compact log through s3");
+
+        // A write above the new floor — still present in the log, not
+        // compacted away — must survive the floored scan.
+        let post = rt
+            .create_note_with_decay_for_embedding_model(
+                &token,
+                "memory",
+                None,
+                "interleave post-compaction write",
+                Some(0.7),
+                0.01,
+                None,
+                vec![],
+                None,
+            )
+            .await
+            .expect("create post-compaction note");
+
+        // Release the paused leg into its (now re-validated) registry-minimum
+        // check and tail scan.
+        ann.reresolve_race_barrier
+            .store(false, std::sync::atomic::Ordering::SeqCst);
+        ann.reresolve_race_release.notify_one();
+
+        let outcome = handle.await.expect("fresh_tail_leg task");
+        let candidates = match outcome {
+            FreshTailOutcome::Replace(candidates) => candidates,
+            FreshTailOutcome::Ops(_) => panic!(
+                "expected re-resolution to replace candidates outright, not \
+                 just return ops to merge into the stale bridge's candidates"
+            ),
+            FreshTailOutcome::Skipped => {
+                panic!("expected the interleaved-compaction floor fallback, not a skip")
+            }
+        };
+        assert!(
+            candidates.iter().any(|(id, _)| *id == post.id),
+            "a write committed above the re-validated registry minimum must \
+             survive the floored tail scan, not be silently dropped by a \
+             scan still anchored at the stale re-resolved watermark: {candidates:?}"
+        );
+        assert!(
+            current_generation(&ann, &key).await > generation_before,
+            "the interleaved-compaction floor must still force re-adoption \
+             so a future query gets a fresh bridge"
         );
     }
 

--- a/crates/khive-pack-memory/src/ann.rs
+++ b/crates/khive-pack-memory/src/ann.rs
@@ -515,19 +515,41 @@ pub(crate) enum AnnEnsureStatus {
 
 /// Search the already-loaded index for `key`. Returns `Ok(None)` on cache miss,
 /// `Ok(Some(hits))` on success, `Err` on ANN search failure (caller falls back).
+/// Test-only: production call sites need the watermark paired atomically with
+/// the search (ADR-118) and use [`search_loaded_with_seq`] directly.
+#[cfg(test)]
 pub(crate) async fn search_loaded(
     ann: &SharedAnn,
     key: &AnnKey,
     query: &[f32],
     k: usize,
 ) -> Result<Option<Vec<(Uuid, f32)>>, RuntimeError> {
+    search_loaded_with_seq(ann, key, query, k)
+        .await
+        .map(|opt| opt.map(|(hits, _seq)| hits))
+}
+
+/// Same as [`search_loaded`], but also returns the searched bridge's
+/// fresh-tail watermark (ADR-118), captured from the SAME read-lock guard as
+/// the search itself — one lock acquisition, so a concurrent bridge swap
+/// (a checkpoint installing a replacement) cannot pair these candidates with
+/// a different bridge's watermark (review finding: the two were previously
+/// read via separate lock acquisitions).
+pub(crate) async fn search_loaded_with_seq(
+    ann: &SharedAnn,
+    key: &AnnKey,
+    query: &[f32],
+    k: usize,
+) -> Result<Option<(Vec<(Uuid, f32)>, u64)>, RuntimeError> {
     let guard = ann.indexes.read().await;
     match guard.get(key) {
         None => Ok(None),
         Some(bridge) => {
             #[cfg(test)]
             ann.warm_route_count.fetch_add(1, Ordering::SeqCst);
-            bridge.search(query, k).map(Some)
+            let hits = bridge.search(query, k)?;
+            let seq = bridge.index.last_applied_seq().unwrap_or(0);
+            Ok(Some((hits, seq)))
         }
     }
 }
@@ -1344,6 +1366,19 @@ pub(crate) async fn fetch_final_tail(
 ) -> Result<(Vec<(Uuid, Option<Vec<f32>>)>, u64), String> {
     let sql = rt.sql();
     let mut reader = sql.reader().await.map_err(|e| e.to_string())?;
+    fetch_final_tail_on(reader.as_mut(), model, s, limit).await
+}
+
+/// Same as [`fetch_final_tail`] but runs every read through a caller-supplied
+/// reader instead of acquiring its own connection — used by the ADR-118 §1
+/// "Compaction linearization" fix to keep the registry-minimum guard and this
+/// scan inside one read snapshot (see [`fresh_tail_serving`]).
+async fn fetch_final_tail_on(
+    reader: &mut dyn khive_storage::SqlReader,
+    model: &str,
+    s: u64,
+    limit: Option<u64>,
+) -> Result<(Vec<(Uuid, Option<Vec<f32>>)>, u64), String> {
     // `limit` (ADR-118 §3, Cold/Empty tier): cap the scan to the newest
     // `limit` log rows instead of the entire scope, taking the highest-seq
     // suffix so the freshest writes stay visible. The DESC+LIMIT rows are
@@ -1512,8 +1547,10 @@ fn fresh_tail_enabled() -> bool {
 
 /// Read the currently-installed bridge's fresh-tail watermark for `key`: the
 /// `ann_write_log` seq its corpus state reflects, or `None` if no bridge is
-/// installed. Call this immediately adjacent to a `search_loaded` call that
-/// returned `Some` to minimize the window for a concurrent bridge swap.
+/// installed. Test-only: production call sites need this paired atomically
+/// with the search that produced their candidates (ADR-118) and get it from
+/// [`search_loaded_with_seq`] directly instead of a second lock acquisition.
+#[cfg(test)]
 pub(crate) async fn bridge_applied_seq(ann: &SharedAnn, key: &AnnKey) -> Option<u64> {
     let guard = ann.indexes.read().await;
     guard
@@ -1526,9 +1563,10 @@ pub(crate) async fn bridge_applied_seq(ann: &SharedAnn, key: &AnnKey) -> Option<
 /// evaluated at this consumer's own registered namespace (`'*'`). If this
 /// exceeds a bridge's watermark, the log may no longer retain every row
 /// above that watermark — completeness above it is unprovable.
-async fn registry_min_watermark(rt: &KhiveRuntime, model: &str) -> Result<Option<i64>, String> {
-    let sql = rt.sql();
-    let mut reader = sql.reader().await.map_err(|e| e.to_string())?;
+async fn registry_min_watermark_on(
+    reader: &mut dyn khive_storage::SqlReader,
+    model: &str,
+) -> Result<Option<i64>, String> {
     let rows = reader
         .query_all(SqlStatement {
             sql: "SELECT MIN(watermark) AS m FROM ann_consumer_watermark \
@@ -1546,6 +1584,40 @@ async fn registry_min_watermark(rt: &KhiveRuntime, model: &str) -> Result<Option
         Some(SqlValue::Integer(n)) => Some(*n),
         _ => None,
     }))
+}
+
+/// Open an explicit read transaction so every subsequent query through
+/// `reader` observes one consistent snapshot (ADR-118 §1 "Compaction
+/// linearization") instead of each `query_all` call taking its own implicit
+/// per-statement snapshot (the default for a connection with no open
+/// transaction). `BEGIN DEFERRED` is valid on a read-only connection: it
+/// starts a read transaction, not a write.
+async fn begin_read_snapshot(reader: &mut dyn khive_storage::SqlReader) -> Result<(), String> {
+    reader
+        .query_all(SqlStatement {
+            sql: "BEGIN DEFERRED".into(),
+            params: vec![],
+            label: Some("memory_ann_fresh_tail_snapshot_begin".into()),
+        })
+        .await
+        .map(|_| ())
+        .map_err(|e| e.to_string())
+}
+
+/// Close the snapshot opened by [`begin_read_snapshot`]. The transaction is
+/// read-only (no DML issued inside it), so `COMMIT` and `ROLLBACK` are
+/// equivalent — `COMMIT` is used for symmetry with a normal transaction end.
+async fn end_read_snapshot(reader: &mut dyn khive_storage::SqlReader) {
+    if let Err(e) = reader
+        .query_all(SqlStatement {
+            sql: "COMMIT".into(),
+            params: vec![],
+            label: Some("memory_ann_fresh_tail_snapshot_end".into()),
+        })
+        .await
+    {
+        tracing::warn!(error = %e, "fresh-tail: snapshot COMMIT failed (read-only transaction; the connection is dropped regardless, so no lock is leaked)");
+    }
 }
 
 /// Exact cosine similarity between a raw query vector and a raw stored
@@ -1600,10 +1672,21 @@ pub(crate) fn merge_fresh_tail(
     merged
 }
 
-/// Outcome of [`fresh_tail_leg`]: either coalesced final ops ready to merge
-/// via [`merge_fresh_tail`], or a signal that the leg sat out this query.
+/// Outcome of [`fresh_tail_leg`].
 pub(crate) enum FreshTailOutcome {
-    Merged(Vec<(Uuid, Option<Vec<f32>>)>),
+    /// Coalesced final tail ops (ADR-118 §1/§2), valid against the
+    /// candidate list the caller already has (`best_raw` unchanged) — merge
+    /// via [`merge_fresh_tail`]. The common case.
+    Ops(Vec<(Uuid, Option<Vec<f32>>)>),
+    /// A compaction mismatch forced re-resolution to the currently published
+    /// segment (ADR-118 §1 "mismatch re-resolution"): these candidates
+    /// REPLACE the caller's `best_raw` outright — they are already a
+    /// self-consistent (new candidates, new watermark) pair, exact-scored
+    /// against that segment's own tail. Never merge them with the stale set.
+    Replace(Vec<(Uuid, f32)>),
+    /// The leg sat out this query entirely (disabled, unregistered
+    /// consumer, or an unrecoverable read failure); the caller's candidates
+    /// are unaffected.
     Skipped,
 }
 
@@ -1611,14 +1694,19 @@ pub(crate) enum FreshTailOutcome {
 /// (and primary) tier: a serving bridge exists, and every committed write
 /// above its watermark is merged in, giving read-your-writes visibility.
 /// `s = None` is the second tier (§3): no serving index is available at all,
-/// so the leg caps its scan at the rebuild-threshold-sized newest suffix of
-/// the log instead of the entire scope, guaranteeing visibility of only the
+/// so the leg caps its scan at a fixed-ceiling newest suffix of the log
+/// instead of the entire scope, guaranteeing visibility of only the
 /// caller's most recent writes until a serving index exists again.
+/// `query`/`k` are the recall vector and fetch limit — needed only by the
+/// serving tier's mismatch re-resolution path, which must run a fresh ANN
+/// search against a newly loaded segment.
 pub(crate) async fn fresh_tail_leg(
     rt: &KhiveRuntime,
     ann: &SharedAnn,
     key: &AnnKey,
     model: &str,
+    query: &[f32],
+    k: usize,
     s: Option<u64>,
 ) -> FreshTailOutcome {
     if !fresh_tail_enabled() {
@@ -1644,56 +1732,90 @@ pub(crate) async fn fresh_tail_leg(
     }
 
     match s {
-        Some(s) => fresh_tail_serving(rt, ann, key, model, s).await,
+        Some(s) => fresh_tail_serving(rt, ann, key, model, query, k, s).await,
         None => fresh_tail_capped(rt, model).await,
     }
 }
 
-/// Tier 1: a serving bridge exists at watermark `s`.
+/// Tier 1: a serving bridge exists at watermark `s`. The registry-minimum
+/// guard, the tail scan, and the tail's embedding point-reads run inside ONE
+/// read transaction (ADR-118 §1 "Compaction linearization") so compaction
+/// cannot strike between the guard and the fetch it is meant to justify.
 async fn fresh_tail_serving(
     rt: &KhiveRuntime,
     ann: &SharedAnn,
     key: &AnnKey,
     model: &str,
+    query: &[f32],
+    k: usize,
     s: u64,
 ) -> FreshTailOutcome {
-    // Compaction linearization (ADR-118 §1): the registry minimum can
-    // advance past a stale in-memory bridge's watermark the instant another
-    // process's checkpoint raises it and compacts. A scan above `s` proves
-    // completeness only if the log still retains every row above `s`.
-    let registry_min = match registry_min_watermark(rt, model).await {
+    let mut reader = match rt.sql().reader().await {
+        Ok(r) => r,
+        Err(e) => {
+            tracing::warn!(error = %e, model, "fresh-tail: reader open failed; skipping exact leg");
+            return FreshTailOutcome::Skipped;
+        }
+    };
+    if let Err(e) = begin_read_snapshot(reader.as_mut()).await {
+        tracing::warn!(error = %e, model, "fresh-tail: snapshot begin failed; skipping exact leg");
+        return FreshTailOutcome::Skipped;
+    }
+
+    let registry_min = match registry_min_watermark_on(reader.as_mut(), model).await {
         Ok(v) => v,
         Err(e) => {
+            end_read_snapshot(reader.as_mut()).await;
             tracing::warn!(error = %e, model, "fresh-tail: registry-min read failed; skipping exact leg");
             return FreshTailOutcome::Skipped;
         }
     };
-    let effective_s = match registry_min {
-        Some(m) if m as u64 > s => {
-            // Re-resolve the currently published segment (its watermark is
-            // at least the registry minimum) and use its watermark instead.
-            let resolved = ann_segment_dir(rt, model)
+
+    if let Some(m) = registry_min {
+        let m = m as u64;
+        if m > s {
+            // Mismatch (ADR-118 §1): the log may no longer retain every row
+            // above `s`. Real re-resolution needs no DB read (a filesystem
+            // commit-record read), so it can be checked before deciding
+            // whether the floor fallback needs this same snapshot.
+            let resolved_new_s = ann_segment_dir(rt, model)
                 .and_then(|dir| read_commit_info(&dir).ok().flatten())
-                .and_then(|info| info.last_applied_seq);
-            match resolved {
-                Some(new_s) if new_s >= m as u64 => {
-                    // Force re-adoption so the next warm check picks up the
-                    // segment this query just resolved to.
-                    bump_generation(ann, key).await;
-                    new_s
+                .and_then(|info| info.last_applied_seq)
+                .filter(|new_s| *new_s >= m);
+            return match resolved_new_s {
+                Some(new_s) => {
+                    // Re-resolution is possible: this snapshot's floor fetch
+                    // is not needed. Close it and read fresh, self-consistent
+                    // state anchored at the re-resolved segment instead.
+                    end_read_snapshot(reader.as_mut()).await;
+                    drop(reader);
+                    fresh_tail_reresolve(rt, ann, key, model, query, k, new_s).await
                 }
-                _ => {
-                    // Re-resolution failed: degrade to ADR-107 (ANN-only)
-                    // for this query rather than serve an unprovable tail.
+                None => {
+                    // Re-resolution genuinely not possible within this
+                    // query: floor at the same-snapshot registry minimum
+                    // rather than dropping the leg (ADR-118 §1) — a
+                    // coherent (old candidates, registry minimum) pair.
+                    let outcome = fetch_final_tail_on(reader.as_mut(), model, m, None).await;
+                    end_read_snapshot(reader.as_mut()).await;
+                    // Force re-adoption so a future query gets a fresh bridge.
                     bump_generation(ann, key).await;
-                    return FreshTailOutcome::Skipped;
+                    match outcome {
+                        Ok((ops, _)) => FreshTailOutcome::Ops(ops),
+                        Err(e) => {
+                            tracing::warn!(error = %e, model, "fresh-tail: floored tail fetch failed; skipping exact leg");
+                            FreshTailOutcome::Skipped
+                        }
+                    }
                 }
-            }
+            };
         }
-        _ => s,
-    };
-    match fetch_final_tail(rt, model, effective_s, None).await {
-        Ok((ops, _new_s)) => FreshTailOutcome::Merged(ops),
+    }
+
+    let outcome = fetch_final_tail_on(reader.as_mut(), model, s, None).await;
+    end_read_snapshot(reader.as_mut()).await;
+    match outcome {
+        Ok((ops, _new_s)) => FreshTailOutcome::Ops(ops),
         Err(e) => {
             tracing::warn!(error = %e, model, "fresh-tail: tail fetch failed; skipping exact leg");
             FreshTailOutcome::Skipped
@@ -1701,28 +1823,77 @@ async fn fresh_tail_serving(
     }
 }
 
-/// Tier 2 (§3): no serving index at all. Caps the scan at the
-/// rebuild-threshold-sized newest suffix so the caller's most recent writes
-/// stay visible without absorbing the full Cold/Empty scope.
-async fn fresh_tail_capped(rt: &KhiveRuntime, model: &str) -> FreshTailOutcome {
-    let (live, tail) = match scope_counts(rt, model, 0).await {
-        Ok(counts) => counts,
+/// Real mismatch re-resolution (ADR-118 §1 "mismatch re-resolution"): load
+/// the currently published segment, search IT for candidates, and merge in
+/// ITS own tail above ITS own watermark — a self-consistent pair that never
+/// borrows a newer watermark while serving older (stale-bridge) candidates.
+/// This load is local to the query (not installed into `ann`'s served map);
+/// `bump_generation` still forces the existing background machinery to
+/// adopt this segment for future queries.
+async fn fresh_tail_reresolve(
+    rt: &KhiveRuntime,
+    ann: &SharedAnn,
+    key: &AnnKey,
+    model: &str,
+    query: &[f32],
+    k: usize,
+    new_s: u64,
+) -> FreshTailOutcome {
+    let Some(dir) = ann_segment_dir(rt, model) else {
+        bump_generation(ann, key).await;
+        return FreshTailOutcome::Skipped;
+    };
+    let bridge = match AnnBridge::load(&dir) {
+        Ok(b) => b,
         Err(e) => {
-            tracing::warn!(error = %e, model, "fresh-tail: scope-count read failed; skipping capped exact leg");
+            tracing::warn!(error = %e, model, "fresh-tail: re-resolved segment load failed; skipping exact leg");
+            bump_generation(ann, key).await;
             return FreshTailOutcome::Skipped;
         }
     };
-    if live == 0 || tail == 0 {
-        return FreshTailOutcome::Merged(Vec::new());
-    }
-    let threshold = (ann_rebuild_threshold() * live as f64).ceil() as u64;
-    let cap = if tail > threshold {
-        Some(threshold)
-    } else {
-        None
+    let candidates = match bridge.search(query, k) {
+        Ok(hits) => hits,
+        Err(e) => {
+            tracing::warn!(error = %e, model, "fresh-tail: re-resolved segment search failed; skipping exact leg");
+            bump_generation(ann, key).await;
+            return FreshTailOutcome::Skipped;
+        }
     };
-    match fetch_final_tail(rt, model, 0, cap).await {
-        Ok((ops, _new_s)) => FreshTailOutcome::Merged(ops),
+    // Force re-adoption so the background warm path installs this segment
+    // for future queries too — this load served only the current query.
+    bump_generation(ann, key).await;
+    match fetch_final_tail(rt, model, new_s, None).await {
+        Ok((ops, _)) => FreshTailOutcome::Replace(merge_fresh_tail(candidates, query, ops)),
+        Err(e) => {
+            tracing::warn!(error = %e, model, "fresh-tail: re-resolved tail fetch failed; serving re-resolved candidates without further tail");
+            FreshTailOutcome::Replace(candidates)
+        }
+    }
+}
+
+/// Fixed ceiling for the Cold/Empty-tier capped scan (ADR-118 §3). Deriving
+/// a corpus-proportional cap (`ann_rebuild_threshold() * live`) needs an
+/// O(corpus) live-count join — appropriate for the background restart
+/// classifier, not for this per-query path (review finding). The ceiling is
+/// a fixed, conservative match to the ADR's own worked example (a 0.20
+/// threshold on a 68k-row corpus is ~13.6k comparisons).
+const FRESH_TAIL_CAPPED_MAX_ROWS: u64 = 20_000;
+
+/// Tier 2 (§3): no serving index at all. A cheap, log-only existence probe
+/// (no corpus join) fast-paths the common empty-tail case; a non-empty tail
+/// is capped at a fixed ceiling rather than a live-corpus-proportional one,
+/// so this bounded fallback never itself pays an O(corpus) cost.
+async fn fresh_tail_capped(rt: &KhiveRuntime, model: &str) -> FreshTailOutcome {
+    match tail_exists(rt, model, 0).await {
+        Ok(false) => return FreshTailOutcome::Ops(Vec::new()),
+        Ok(true) => {}
+        Err(e) => {
+            tracing::warn!(error = %e, model, "fresh-tail: tail-existence read failed; skipping capped exact leg");
+            return FreshTailOutcome::Skipped;
+        }
+    }
+    match fetch_final_tail(rt, model, 0, Some(FRESH_TAIL_CAPPED_MAX_ROWS)).await {
+        Ok((ops, _new_s)) => FreshTailOutcome::Ops(ops),
         Err(e) => {
             tracing::warn!(error = %e, model, "fresh-tail: capped tail fetch failed; skipping exact leg");
             FreshTailOutcome::Skipped
@@ -3335,8 +3506,9 @@ mod tests {
         let s = bridge_applied_seq(&ann, &key)
             .await
             .expect("bridge watermark");
-        let ops = match fresh_tail_leg(&rt, &ann, &key, MODEL, Some(s)).await {
-            FreshTailOutcome::Merged(ops) => ops,
+        let ops = match fresh_tail_leg(&rt, &ann, &key, MODEL, &query, 10, Some(s)).await {
+            FreshTailOutcome::Ops(ops) => ops,
+            FreshTailOutcome::Replace(_) => panic!("fresh-tail leg unexpectedly re-resolved"),
             FreshTailOutcome::Skipped => panic!("fresh-tail leg unexpectedly skipped"),
         };
         let merged = merge_fresh_tail(raw, &query, ops);
@@ -3426,8 +3598,9 @@ mod tests {
         let s = bridge_applied_seq(&ann, &key)
             .await
             .expect("bridge watermark");
-        let ops = match fresh_tail_leg(&rt, &ann, &key, MODEL, Some(s)).await {
-            FreshTailOutcome::Merged(ops) => ops,
+        let ops = match fresh_tail_leg(&rt, &ann, &key, MODEL, &query, 10, Some(s)).await {
+            FreshTailOutcome::Ops(ops) => ops,
+            FreshTailOutcome::Replace(_) => panic!("fresh-tail leg unexpectedly re-resolved"),
             FreshTailOutcome::Skipped => panic!("fresh-tail leg unexpectedly skipped"),
         };
         let merged = merge_fresh_tail(raw, &query, ops);
@@ -3450,11 +3623,14 @@ mod tests {
     /// The compaction-linearization guard: if the registry minimum has
     /// advanced past the serving bridge's watermark, the log may no longer
     /// retain every row above it. The leg must detect the mismatch in the
-    /// same snapshot and refuse to serve an unprovable (silently incomplete)
-    /// tail — it re-resolves the published segment or skips outright.
+    /// same snapshot and never silently drop it — it re-resolves the
+    /// published segment (not possible here: the only persisted segment is
+    /// exactly as stale as the in-memory bridge) or floors the scan at the
+    /// same-snapshot registry minimum, which here finds nothing above it
+    /// (compacted away) but still runs — never `Skipped`.
     #[tokio::test]
     #[serial(adr118_fresh_tail)]
-    async fn fresh_tail_leg_skips_when_registry_minimum_outpaces_bridge_watermark() {
+    async fn fresh_tail_leg_floors_when_registry_minimum_outpaces_bridge_watermark() {
         const MODEL: &str = "adr118-compaction-guard-test-model";
         const DIMS: usize = 8;
         let rt = test_runtime_with_hash_embedder(MODEL, DIMS);
@@ -3516,13 +3692,140 @@ mod tests {
             .expect("raise registry watermark past bridge watermark");
         compact_log(&rt, MODEL).await.expect("compact log");
 
-        let outcome = fresh_tail_leg(&rt, &ann, &key, MODEL, Some(s1)).await;
+        let generation_before = current_generation(&ann, &key).await;
+        let query = fnv_to_vec("compaction guard seed note 0", DIMS);
+        let outcome = fresh_tail_leg(&rt, &ann, &key, MODEL, &query, 10, Some(s1)).await;
+        let ops = match outcome {
+            FreshTailOutcome::Ops(ops) => ops,
+            FreshTailOutcome::Replace(_) => panic!(
+                "re-resolution must not succeed here: the only persisted \
+                 segment is exactly as stale as the in-memory bridge"
+            ),
+            FreshTailOutcome::Skipped => panic!(
+                "a mismatch must never silently drop the leg — it floors at \
+                 the same-snapshot registry minimum instead of skipping"
+            ),
+        };
         assert!(
-            matches!(outcome, FreshTailOutcome::Skipped),
-            "a bridge watermark behind the registry minimum, with the log \
-             compacted past it and no re-persisted segment to re-resolve to, \
-             must refuse to serve an unprovable tail instead of silently \
-             returning an incomplete merge"
+            ops.is_empty(),
+            "the floored scan starts at the registry minimum, above which \
+             every row was already compacted away, so it must legitimately \
+             find nothing, got: {ops:?}"
+        );
+        assert!(
+            current_generation(&ann, &key).await > generation_before,
+            "the mismatch must force re-adoption (bump_generation) so a \
+             future query gets a fresh bridge instead of repeating the \
+             floor fallback forever"
+        );
+    }
+
+    /// Real mismatch re-resolution (ADR-118 §1 "mismatch re-resolution"): a
+    /// peer process's checkpoint re-persists a NEWER segment (watermark at
+    /// least the registry minimum) that this process's in-memory bridge
+    /// never observed. The leg must load that segment, search IT directly,
+    /// and return a `Replace` outcome carrying a coherent (new candidates,
+    /// new watermark) pair — never merging the re-resolved tail into the
+    /// stale bridge's candidates.
+    #[tokio::test]
+    #[serial(adr118_fresh_tail)]
+    async fn fresh_tail_leg_reresolves_to_a_newer_persisted_segment_on_mismatch() {
+        const MODEL: &str = "adr118-reresolve-test-model";
+        const DIMS: usize = 8;
+        let rt = test_runtime_with_hash_embedder(MODEL, DIMS);
+        let token = rt.authorize(Namespace::local()).expect("authorize local");
+
+        for i in 0..3u32 {
+            rt.create_note_with_decay_for_embedding_model(
+                &token,
+                "memory",
+                None,
+                &format!("reresolve seed note {i}"),
+                Some(0.7),
+                0.01,
+                None,
+                vec![],
+                None,
+            )
+            .await
+            .expect("create seed note");
+        }
+
+        let ann = new_shared();
+        let key = AnnKey::from_token(MODEL);
+        ensure_ann_for_model(&rt, &token, &ann, MODEL)
+            .await
+            .expect("warm");
+        let s1 = bridge_applied_seq(&ann, &key)
+            .await
+            .expect("bridge watermark after initial warm");
+
+        // A new note lands after the checkpoint.
+        let fresh = rt
+            .create_note_with_decay_for_embedding_model(
+                &token,
+                "memory",
+                None,
+                "reresolve distinctive fresh note",
+                Some(0.7),
+                0.01,
+                None,
+                vec![],
+                None,
+            )
+            .await
+            .expect("create fresh note");
+
+        let (_live, tail_before) = scope_counts(&rt, MODEL, s1)
+            .await
+            .expect("scope counts before peer checkpoint");
+        assert!(tail_before > 0, "sanity: a tail must exist above s1");
+        let s2 = s1 + tail_before;
+
+        // Simulate a PEER PROCESS's real checkpoint: replay the tail into a
+        // fresh load of the persisted segment, persist it back to disk at
+        // s2, and raise+compact the registry — all WITHOUT touching this
+        // process's in-memory `ann` map, which stays pinned at the stale s1
+        // bridge (the mismatch this leg must detect and recover from).
+        let dir = ann_segment_dir(&rt, MODEL).expect("segment dir (file-backed test runtime)");
+        let mut peer_bridge = AnnBridge::load(&dir).expect("load persisted segment");
+        let (ops, new_s) = fetch_final_tail(&rt, MODEL, s1, None)
+            .await
+            .expect("fetch tail for peer replay");
+        peer_bridge
+            .apply_final_ops(ops, new_s)
+            .expect("apply peer replay");
+        peer_bridge
+            .save_atomic(&dir)
+            .expect("persist peer checkpoint");
+        raise_watermark(&rt, MODEL, s2)
+            .await
+            .expect("raise registry watermark");
+        compact_log(&rt, MODEL).await.expect("compact log");
+
+        let generation_before = current_generation(&ann, &key).await;
+        let query = fnv_to_vec("reresolve distinctive fresh note", DIMS);
+        let outcome = fresh_tail_leg(&rt, &ann, &key, MODEL, &query, 10, Some(s1)).await;
+        let candidates = match outcome {
+            FreshTailOutcome::Replace(candidates) => candidates,
+            FreshTailOutcome::Ops(_) => panic!(
+                "expected re-resolution to replace candidates outright, not \
+                 just return ops to merge into the stale bridge's candidates"
+            ),
+            FreshTailOutcome::Skipped => {
+                panic!("expected successful re-resolution, not a skip")
+            }
+        };
+        assert!(
+            candidates.iter().any(|(id, _)| *id == fresh.id),
+            "the re-resolved segment's own search must surface the note \
+             that only the peer's checkpoint (not this process's stale \
+             bridge) reflects, got: {candidates:?}"
+        );
+        assert!(
+            current_generation(&ann, &key).await > generation_before,
+            "re-resolution must still force re-adoption so a future query \
+             installs this segment as the served bridge"
         );
     }
 
@@ -3588,7 +3891,8 @@ mod tests {
             "sanity: the registry row must be gone before the leg runs"
         );
 
-        let outcome = fresh_tail_leg(&rt, &ann, &key, MODEL, Some(s)).await;
+        let query = fnv_to_vec("registration precondition seed note", DIMS);
+        let outcome = fresh_tail_leg(&rt, &ann, &key, MODEL, &query, 10, Some(s)).await;
         assert!(
             matches!(outcome, FreshTailOutcome::Skipped),
             "the exact leg must sit out a query when this consumer's durable \

--- a/crates/khive-pack-memory/src/handlers/common.rs
+++ b/crates/khive-pack-memory/src/handlers/common.rs
@@ -1312,10 +1312,27 @@ async fn collect_model_ann_hits_inner(
     };
 
     if model_ann_timed_out {
-        // Do not replace a bounded timeout with an O(corpus) exact scan.
+        // No serving index is available for this model within the bounded
+        // wait. Rather than replace it with an O(corpus) exact scan, ADR-118
+        // §3's second tier guarantees visibility of the newest
+        // rebuild-threshold-sized suffix of writes while FTS covers the rest.
+        let tail_ops = match ann::fresh_tail_leg(runtime, ann, &key, &model_name, None).await {
+            ann::FreshTailOutcome::Merged(ops) => ops,
+            ann::FreshTailOutcome::Skipped => Vec::new(),
+        };
+        let merged = ann::merge_fresh_tail(Vec::new(), &vec, tail_ops);
+        let hits: Vec<VectorSearchHit> = merged
+            .into_iter()
+            .enumerate()
+            .map(|(idx, (uuid, score))| VectorSearchHit {
+                subject_id: uuid,
+                score: khive_score::DeterministicScore::from_f64(score as f64),
+                rank: (idx + 1) as u32,
+            })
+            .collect();
         return Ok(PerModelAnnHits {
             model_name,
-            hits: Vec::new(),
+            hits,
             degraded: true,
             used_sqlite_vec_fallback: false,
         });
@@ -1393,6 +1410,21 @@ async fn collect_model_ann_hits_inner(
                 }
             }
         }
+
+        // ADR-118: merge the fresh-tail exact leg into this model's warm-ANN
+        // candidates before fusion. The watermark is read adjacent to the
+        // search that produced `best_raw` to minimize the window for a
+        // concurrent bridge swap; a swap widening the window only makes the
+        // tail scan more conservative (wider), never less complete.
+        let applied_seq = ann::bridge_applied_seq(ann, &key).await;
+        let tail_ops = match applied_seq {
+            Some(s) => match ann::fresh_tail_leg(runtime, ann, &key, &model_name, Some(s)).await {
+                ann::FreshTailOutcome::Merged(ops) => ops,
+                ann::FreshTailOutcome::Skipped => Vec::new(),
+            },
+            None => Vec::new(),
+        };
+        let best_raw = ann::merge_fresh_tail(best_raw, &vec, tail_ops);
 
         tracing::debug!(
             model = %model_name,

--- a/crates/khive-pack-memory/src/handlers/common.rs
+++ b/crates/khive-pack-memory/src/handlers/common.rs
@@ -1230,7 +1230,10 @@ async fn collect_model_ann_hits_inner(
     // cross-process reindex visibility beyond in-process generations.
     ann::maybe_check_durable_epoch(runtime, ann, &key).await;
     let cache_fresh = ann::is_current(ann, &key).await;
-    let search_result = ann::search_loaded(ann, &key, &vec, ann_fetch_limit).await;
+    // ADR-118: candidates and the bridge's fresh-tail watermark are captured
+    // together from `search_loaded_with_seq`'s single lock acquisition (never
+    // paired via a separate later read — see the merge below).
+    let search_result = ann::search_loaded_with_seq(ann, &key, &vec, ann_fetch_limit).await;
     if !cache_fresh && matches!(search_result, Ok(Some(_))) {
         ann::ensure_ann_background(runtime, token, ann, &model_name).await;
     }
@@ -1238,8 +1241,8 @@ async fn collect_model_ann_hits_inner(
     // owns ensure and its phase span while this request races only the result channel.
     // Per-model single flight prevents duplicate detached builds.
     let mut model_ann_timed_out = false;
-    let initial_raw_hits: Option<Vec<(Uuid, f32)>> = match search_result {
-        Ok(Some(hits)) => Some(hits),
+    let initial_raw_hits: Option<(Vec<(Uuid, f32)>, u64)> = match search_result {
+        Ok(Some(hits_and_seq)) => Some(hits_and_seq),
         Ok(None) => {
             let (done_tx, done_rx) = tokio::sync::oneshot::channel();
             let rt_detached = runtime.clone();
@@ -1269,7 +1272,7 @@ async fn collect_model_ann_hits_inner(
                         namespace = %ns,
                         "memory ANN ensured on recall miss"
                     );
-                    ann::search_loaded(ann, &key, &vec, ann_fetch_limit).await?
+                    ann::search_loaded_with_seq(ann, &key, &vec, ann_fetch_limit).await?
                 }
                 Ok(Ok(Err(e))) => return Err(e),
                 Ok(Err(_sender_dropped)) => {
@@ -1316,10 +1319,13 @@ async fn collect_model_ann_hits_inner(
         // wait. Rather than replace it with an O(corpus) exact scan, ADR-118
         // §3's second tier guarantees visibility of the newest
         // rebuild-threshold-sized suffix of writes while FTS covers the rest.
-        let tail_ops = match ann::fresh_tail_leg(runtime, ann, &key, &model_name, None).await {
-            ann::FreshTailOutcome::Merged(ops) => ops,
-            ann::FreshTailOutcome::Skipped => Vec::new(),
-        };
+        let tail_ops =
+            match ann::fresh_tail_leg(runtime, ann, &key, &model_name, &vec, ann_fetch_limit, None)
+                .await
+            {
+                ann::FreshTailOutcome::Ops(ops) => ops,
+                ann::FreshTailOutcome::Replace(_) | ann::FreshTailOutcome::Skipped => Vec::new(),
+            };
         let merged = ann::merge_fresh_tail(Vec::new(), &vec, tail_ops);
         let hits: Vec<VectorSearchHit> = merged
             .into_iter()
@@ -1345,7 +1351,7 @@ async fn collect_model_ann_hits_inner(
         initial_raw_hits
     };
 
-    if let Some(first_raw) = initial_raw_hits {
+    if let Some((first_raw, first_seq)) = initial_raw_hits {
         #[cfg(test)]
         if retrieval_failpoints::ann_flagged(&model_name) {
             return Err(RuntimeError::Internal(format!(
@@ -1368,6 +1374,7 @@ async fn collect_model_ann_hits_inner(
         };
 
         let mut best_raw = first_raw;
+        let mut best_seq = first_seq;
         let mut current_fetch_limit = ann_fetch_limit;
 
         // Visible-only indexes incur no hydration or extra ANN searches here.
@@ -1401,10 +1408,14 @@ async fn collect_model_ann_hits_inner(
                     new_fetch_limit = current_fetch_limit,
                     "memory ANN: widening over-fetch (visible survivors short)"
                 );
-                if let Ok(Some(wider)) =
-                    ann::search_loaded(ann, &key, &vec, current_fetch_limit).await
+                // ADR-118: re-pair candidates and watermark from this same
+                // wider search (never keep the earlier round's watermark
+                // against these new candidates).
+                if let Ok(Some((wider, wider_seq))) =
+                    ann::search_loaded_with_seq(ann, &key, &vec, current_fetch_limit).await
                 {
                     best_raw = wider;
+                    best_seq = wider_seq;
                 } else {
                     break;
                 }
@@ -1412,19 +1423,25 @@ async fn collect_model_ann_hits_inner(
         }
 
         // ADR-118: merge the fresh-tail exact leg into this model's warm-ANN
-        // candidates before fusion. The watermark is read adjacent to the
-        // search that produced `best_raw` to minimize the window for a
-        // concurrent bridge swap; a swap widening the window only makes the
-        // tail scan more conservative (wider), never less complete.
-        let applied_seq = ann::bridge_applied_seq(ann, &key).await;
-        let tail_ops = match applied_seq {
-            Some(s) => match ann::fresh_tail_leg(runtime, ann, &key, &model_name, Some(s)).await {
-                ann::FreshTailOutcome::Merged(ops) => ops,
-                ann::FreshTailOutcome::Skipped => Vec::new(),
-            },
-            None => Vec::new(),
+        // candidates before fusion. `best_seq` was captured atomically with
+        // `best_raw` (from the same bridge instance, same lock acquisition)
+        // by whichever search produced it, so the pair is always coherent —
+        // never a newer watermark paired with an older search's candidates.
+        let outcome = ann::fresh_tail_leg(
+            runtime,
+            ann,
+            &key,
+            &model_name,
+            &vec,
+            current_fetch_limit,
+            Some(best_seq),
+        )
+        .await;
+        let best_raw = match outcome {
+            ann::FreshTailOutcome::Ops(ops) => ann::merge_fresh_tail(best_raw, &vec, ops),
+            ann::FreshTailOutcome::Replace(candidates) => candidates,
+            ann::FreshTailOutcome::Skipped => best_raw,
         };
-        let best_raw = ann::merge_fresh_tail(best_raw, &vec, tail_ops);
 
         tracing::debug!(
             model = %model_name,

--- a/crates/khive-pack-memory/src/handlers/fresh_tail_tests.rs
+++ b/crates/khive-pack-memory/src/handlers/fresh_tail_tests.rs
@@ -1,0 +1,344 @@
+//! ADR-118 end-to-end regression tests: fresh-tail exact leg visibility
+//! through the real `memory.recall` / `memory.recall_candidates` verbs.
+//!
+//! Function-level coverage of the merge/registration/compaction-linearization
+//! mechanics lives in `crate::ann`'s own test module, which has direct access
+//! to its private helpers. This file exercises the same code paths end to
+//! end, through the dispatch surface a real agent actually calls.
+
+use khive_pack_kg::KgPack;
+use khive_runtime::{KhiveRuntime, Namespace, RuntimeConfig, VerbRegistry, VerbRegistryBuilder};
+use serde_json::json;
+use serial_test::serial;
+
+use crate::test_support::HashVecProvider;
+use crate::MemoryPack;
+
+const MODEL: &str = "adr118-e2e-test-model";
+const DIMS: usize = 16;
+
+/// Guards a mutated `KHIVE_ANN_FRESH_TAIL` value, restoring the prior state
+/// (unset, by default) on drop even if the test panics.
+struct EnvGuard;
+
+impl EnvGuard {
+    fn disable_fresh_tail() -> Self {
+        std::env::set_var("KHIVE_ANN_FRESH_TAIL", "0");
+        Self
+    }
+}
+
+impl Drop for EnvGuard {
+    fn drop(&mut self) {
+        std::env::remove_var("KHIVE_ANN_FRESH_TAIL");
+    }
+}
+
+async fn build_registry(rt: &KhiveRuntime) -> VerbRegistry {
+    let mut builder = VerbRegistryBuilder::new();
+    builder.register(KgPack::new(rt.clone()));
+    builder.register(MemoryPack::new(rt.clone()));
+    builder.build().expect("registry")
+}
+
+fn new_runtime(tmp: &std::path::Path) -> KhiveRuntime {
+    let db_path = tmp.join("khive-graph.db");
+    let rt = KhiveRuntime::new(RuntimeConfig {
+        db_path: Some(db_path),
+        embedding_model: None,
+        additional_embedding_models: vec![],
+        ..RuntimeConfig::default()
+    })
+    .expect("runtime");
+    rt.register_embedder(HashVecProvider {
+        model_name: MODEL.to_owned(),
+        dims: DIMS,
+    });
+    rt
+}
+
+fn contains_id(hits: &[serde_json::Value], id: uuid::Uuid) -> bool {
+    let target = id.to_string();
+    hits.iter()
+        .any(|h| h["id"].as_str() == Some(target.as_str()))
+}
+
+/// Same-process write-then-recall: a note written after the ANN cache is
+/// warm must surface on the very next `memory.recall`, without waiting for
+/// any background rebuild.
+#[tokio::test]
+#[serial(adr118_fresh_tail)]
+async fn same_process_write_then_recall_surfaces_without_rebuild() {
+    let tmp = tempfile::Builder::new()
+        .prefix("khive-adr118-e2e-1-")
+        .tempdir_in(std::env::temp_dir())
+        .expect("tempdir");
+    let rt = new_runtime(tmp.path());
+    let ns = Namespace::parse("local").expect("local namespace");
+    let token = rt.authorize(ns).expect("authorize local");
+
+    for i in 0..5u32 {
+        rt.create_note(
+            &token,
+            "memory",
+            None,
+            &format!("adr118 e2e seed note {i}"),
+            Some(0.7),
+            None,
+            vec![],
+        )
+        .await
+        .expect("create seed note");
+    }
+
+    let registry = build_registry(&rt).await;
+
+    // First recall is a cache miss: it blocks on a synchronous warm build,
+    // installing a bridge whose watermark covers exactly the 5 seed notes.
+    registry
+        .dispatch(
+            "memory.recall",
+            json!({"query": "adr118 e2e seed note", "limit": 10}),
+        )
+        .await
+        .expect("warm recall");
+
+    const MARKER: &str = "adr118 e2e distinctive fresh tail marker zzyx quux";
+    let fresh = rt
+        .create_note(&token, "memory", None, MARKER, Some(0.7), None, vec![])
+        .await
+        .expect("create fresh note");
+
+    // Second call reuses the now-warm (and now one-write-stale) bridge —
+    // exactly the regression path (#1143). Assert on `recall_candidates`'s
+    // `vector_candidates`, sourced only from the vector leg: the FTS leg
+    // would find a fresh note regardless of this fix (its own index updates
+    // in the write transaction, per the ADR's own root-cause analysis), so a
+    // plain end-to-end `memory.recall` check would pass even without the fix
+    // and would not actually be testing the fresh-tail leg.
+    let candidates = registry
+        .dispatch(
+            "memory.recall_candidates",
+            json!({"query": MARKER, "limit": 10}),
+        )
+        .await
+        .expect("recall_candidates after fresh write");
+    let vector_candidates = candidates["vector_candidates"]
+        .as_array()
+        .expect("vector_candidates must be an array");
+    assert!(
+        contains_id(vector_candidates, fresh.id),
+        "a note written after the ANN cache warmed must surface in the \
+         vector leg's own candidates on the very next recall, without \
+         waiting for a rebuild, got: {vector_candidates:?}"
+    );
+
+    // End-to-end sanity: the note is also visible through the full,
+    // fusion-facing `memory.recall` verb (both legs now agree on it).
+    let result = registry
+        .dispatch("memory.recall", json!({"query": MARKER, "limit": 10}))
+        .await
+        .expect("recall after fresh write");
+    let hits = result.as_array().expect("recall result must be an array");
+    assert!(
+        contains_id(hits, fresh.id),
+        "the fresh note must also surface through full memory.recall, got: {hits:?}"
+    );
+}
+
+/// Cross-process visibility: an external writer (a second runtime handle
+/// against the same database file) commits a note; the first runtime's warm
+/// daemon must surface it on its next recall, even though its in-process
+/// generation counters were never touched by the external write.
+#[tokio::test]
+#[serial(adr118_fresh_tail)]
+async fn cross_process_external_writer_surfaces_on_next_recall() {
+    let tmp = tempfile::Builder::new()
+        .prefix("khive-adr118-e2e-2-")
+        .tempdir_in(std::env::temp_dir())
+        .expect("tempdir");
+    let rt1 = new_runtime(tmp.path());
+    let ns = Namespace::parse("local").expect("local namespace");
+    let token1 = rt1.authorize(ns.clone()).expect("authorize local rt1");
+
+    for i in 0..5u32 {
+        rt1.create_note(
+            &token1,
+            "memory",
+            None,
+            &format!("adr118 e2e cross-process seed note {i}"),
+            Some(0.7),
+            None,
+            vec![],
+        )
+        .await
+        .expect("create seed note");
+    }
+
+    let registry1 = build_registry(&rt1).await;
+    registry1
+        .dispatch(
+            "memory.recall_candidates",
+            json!({"query": "adr118 e2e cross-process seed note", "limit": 10}),
+        )
+        .await
+        .expect("warm recall_candidates on rt1");
+
+    // A second runtime handle against the SAME database file — simulates an
+    // external writer (`kkernel --atomic`, another daemon process) whose
+    // write rt1's in-process generation counter never observes.
+    let rt2 = new_runtime(tmp.path());
+    let token2 = rt2.authorize(ns).expect("authorize local rt2");
+    const MARKER: &str = "adr118 e2e cross-process distinctive marker plugh";
+    let fresh = rt2
+        .create_note(&token2, "memory", None, MARKER, Some(0.7), None, vec![])
+        .await
+        .expect("external writer creates fresh note");
+
+    // Assert on the vector leg specifically (see the same-process test's
+    // comment): FTS would find this note regardless of the fix.
+    let candidates = registry1
+        .dispatch(
+            "memory.recall_candidates",
+            json!({"query": MARKER, "limit": 10}),
+        )
+        .await
+        .expect("recall_candidates on rt1 after external write");
+    let vector_candidates = candidates["vector_candidates"]
+        .as_array()
+        .expect("vector_candidates must be an array");
+    assert!(
+        contains_id(vector_candidates, fresh.id),
+        "the warm daemon (rt1) must surface, in its vector leg's own \
+         candidates, a note committed by an external writer (rt2) against \
+         the same database file on its very next recall, got: {vector_candidates:?}"
+    );
+
+    let result = registry1
+        .dispatch("memory.recall", json!({"query": MARKER, "limit": 10}))
+        .await
+        .expect("recall on rt1 after external write");
+    let hits = result.as_array().expect("recall result must be an array");
+    assert!(
+        contains_id(hits, fresh.id),
+        "the fresh note must also surface through full memory.recall, got: {hits:?}"
+    );
+}
+
+/// Empty tail: with nothing written since the bridge warmed, the merged
+/// vector candidates are unchanged — fusion is byte-identical whenever there
+/// is nothing to merge.
+#[tokio::test]
+#[serial(adr118_fresh_tail)]
+async fn empty_tail_leaves_vector_candidates_unchanged() {
+    let tmp = tempfile::Builder::new()
+        .prefix("khive-adr118-e2e-5-")
+        .tempdir_in(std::env::temp_dir())
+        .expect("tempdir");
+    let rt = new_runtime(tmp.path());
+    let ns = Namespace::parse("local").expect("local namespace");
+    let token = rt.authorize(ns).expect("authorize local");
+
+    for i in 0..5u32 {
+        rt.create_note(
+            &token,
+            "memory",
+            None,
+            &format!("adr118 e2e empty-tail seed note {i}"),
+            Some(0.7),
+            None,
+            vec![],
+        )
+        .await
+        .expect("create seed note");
+    }
+
+    let registry = build_registry(&rt).await;
+    let query = "adr118 e2e empty-tail seed note";
+
+    let first = registry
+        .dispatch(
+            "memory.recall_candidates",
+            json!({"query": query, "limit": 10}),
+        )
+        .await
+        .expect("first recall_candidates (warms the cache)");
+    let second = registry
+        .dispatch(
+            "memory.recall_candidates",
+            json!({"query": query, "limit": 10}),
+        )
+        .await
+        .expect("second recall_candidates (empty tail)");
+
+    assert_eq!(
+        first["vector_candidates"], second["vector_candidates"],
+        "with no writes between two recalls, the fresh-tail leg's empty tail \
+         must leave the merged vector candidates byte-identical to the \
+         ANN-only list"
+    );
+}
+
+/// `KHIVE_ANN_FRESH_TAIL=0` disables the exact leg: a note written after the
+/// ANN cache is warm must NOT appear in the vector leg's own candidates
+/// (`memory.recall_candidates`'s `vector_candidates`, sourced only from the
+/// vector leg — unlike full `memory.recall`, unaffected by FTS finding it).
+#[tokio::test]
+#[serial(adr118_fresh_tail)]
+async fn env_var_disables_fresh_tail_restoring_pre_adr_behavior() {
+    let tmp = tempfile::Builder::new()
+        .prefix("khive-adr118-e2e-6-")
+        .tempdir_in(std::env::temp_dir())
+        .expect("tempdir");
+    let rt = new_runtime(tmp.path());
+    let ns = Namespace::parse("local").expect("local namespace");
+    let token = rt.authorize(ns).expect("authorize local");
+
+    for i in 0..5u32 {
+        rt.create_note(
+            &token,
+            "memory",
+            None,
+            &format!("adr118 e2e env-disable seed note {i}"),
+            Some(0.7),
+            None,
+            vec![],
+        )
+        .await
+        .expect("create seed note");
+    }
+
+    let registry = build_registry(&rt).await;
+    registry
+        .dispatch(
+            "memory.recall_candidates",
+            json!({"query": "adr118 e2e env-disable seed note", "limit": 10}),
+        )
+        .await
+        .expect("warm recall_candidates");
+
+    let _guard = EnvGuard::disable_fresh_tail();
+
+    const MARKER: &str = "adr118 e2e env-disable distinctive marker xyzzy";
+    let fresh = rt
+        .create_note(&token, "memory", None, MARKER, Some(0.7), None, vec![])
+        .await
+        .expect("create fresh note");
+
+    let result = registry
+        .dispatch(
+            "memory.recall_candidates",
+            json!({"query": MARKER, "limit": 10}),
+        )
+        .await
+        .expect("recall_candidates with fresh-tail disabled");
+    let vector_candidates = result["vector_candidates"]
+        .as_array()
+        .expect("vector_candidates must be an array");
+    assert!(
+        !contains_id(vector_candidates, fresh.id),
+        "KHIVE_ANN_FRESH_TAIL=0 must restore pre-ADR-118 behavior: a note \
+         written after the cache warmed must stay invisible to the vector \
+         leg until a rebuild, got: {vector_candidates:?}"
+    );
+}

--- a/crates/khive-pack-memory/src/handlers/fresh_tail_tests.rs
+++ b/crates/khive-pack-memory/src/handlers/fresh_tail_tests.rs
@@ -17,20 +17,27 @@ use crate::MemoryPack;
 const MODEL: &str = "adr118-e2e-test-model";
 const DIMS: usize = 16;
 
-/// Guards a mutated `KHIVE_ANN_FRESH_TAIL` value, restoring the prior state
-/// (unset, by default) on drop even if the test panics.
-struct EnvGuard;
+/// Guards a mutated `KHIVE_ANN_FRESH_TAIL` value, restoring whatever value
+/// (present or absent) it held before the guard was created, even if the
+/// test panics.
+struct EnvGuard {
+    prior: Option<String>,
+}
 
 impl EnvGuard {
     fn disable_fresh_tail() -> Self {
+        let prior = std::env::var("KHIVE_ANN_FRESH_TAIL").ok();
         std::env::set_var("KHIVE_ANN_FRESH_TAIL", "0");
-        Self
+        Self { prior }
     }
 }
 
 impl Drop for EnvGuard {
     fn drop(&mut self) {
-        std::env::remove_var("KHIVE_ANN_FRESH_TAIL");
+        match self.prior.take() {
+            Some(v) => std::env::set_var("KHIVE_ANN_FRESH_TAIL", v),
+            None => std::env::remove_var("KHIVE_ANN_FRESH_TAIL"),
+        }
     }
 }
 

--- a/crates/khive-pack-memory/src/handlers/mod.rs
+++ b/crates/khive-pack-memory/src/handlers/mod.rs
@@ -2,6 +2,8 @@
 
 mod common;
 mod feedback;
+#[cfg(test)]
+mod fresh_tail_tests;
 mod prune;
 mod recall;
 mod remember;


### PR DESCRIPTION
## Summary

Implements ADR-118 (fresh-tail exact leg) for the memory pack's vector recall path.

Each per-model vector leg of `memory.recall` now merges a fresh-tail exact leg into candidates before fusion, giving read-your-writes visibility on top of the existing warm-ANN serving path:

- Writes committed after a serving bridge's watermark are read from `ann_write_log`, coalesced to the final op per subject (reusing the existing `fetch_final_tail` coalescing logic), scored exactly, and merged into the vector leg's own candidates — not added as a separate fusion source, so results are never buried by RRF's fixed per-source rank weighting.
- A final delete drops the subject from candidates too.
- Dedup is by `subject_id` with the tail winning; the merged set is re-sorted before fusion.
- Cold/Empty bridges (no serving index at all) get a second, capped tier: the scan is bounded to `ann_rebuild_threshold() * live` rows, highest-seq suffix, rather than a general exact-search fallback.

Two checks are binding, not advisory:

- **Registration precondition**: no durable watermark row for this consumer means completeness above watermark 0 is unprovable, so the leg registers at 0 and sits out that one query rather than assuming full coverage.
- **Compaction linearization**: if the registry-wide watermark minimum has advanced past the in-memory bridge's watermark, the write-log may no longer retain every row above it; the leg re-resolves the current segment's watermark (forcing re-adoption) or skips, rather than scanning a window the log can no longer prove complete.

`KHIVE_ANN_FRESH_TAIL=0` restores the pre-ADR-118 behavior (default: enabled).

Scope: the memory pack only. The knowledge pack's own vector legs are unaffected, pending a follow-up PR.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy -p khive-pack-memory -p khive-runtime --all-targets -- -D warnings`
- [x] `cargo test -p khive-pack-memory -p khive-runtime` (all green, including 8 new tests covering: same-process write-then-recall visibility, cross-process external-writer visibility, final-delete dropping a subject, dedup with the tail winning, the registration precondition, the compaction-linearization mismatch, empty-tail byte-identical output, and the `KHIVE_ANN_FRESH_TAIL=0` escape hatch)
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps -p khive-pack-memory -p khive-runtime`
- [x] `cargo check --workspace` (full workspace, including the knowledge pack, compiles unaffected)