### PR TITLE
fix(pack-memory): align replay contracts and size reverse maps by live count

### DIFF
--- a/crates/khive-pack-knowledge/src/knowledge/vamana.rs
+++ b/crates/khive-pack-knowledge/src/knowledge/vamana.rs
@@ -417,7 +417,7 @@ impl AnnBridge {
     /// reused slot's new owner can be tombstoned by a replay op for the
     /// old, already-deleted subject (#1150).
     pub(crate) fn reverse_map(&self) -> HashMap<Uuid, u32> {
-        let mut reverse: HashMap<Uuid, u32> = HashMap::with_capacity(self.id_map.len());
+        let mut reverse: HashMap<Uuid, u32> = HashMap::with_capacity(self.index.live_count());
         for (ordinal, uuid) in self.id_map.iter().enumerate() {
             if self.index.is_tombstoned(ordinal as u32) {
                 continue;
@@ -431,8 +431,13 @@ impl AnnBridge {
     /// `Some(embedding)` replays a final upsert (tombstone the mapped old
     /// ordinal, then exactly one insert); `None` replays a final delete
     /// (tombstone if mapped, no-op otherwise). `reverse` is the map from
-    /// [`reverse_map`](Self::reverse_map), kept current across calls. Any
-    /// id-map contradiction returns `Err` — the caller escalates to Cold.
+    /// [`reverse_map`](Self::reverse_map), kept current across calls.
+    ///
+    /// A delete whose mapped ordinal has been reassigned by an earlier
+    /// upsert in this replay is skipped with a warning, not an error: the
+    /// old subject's vector was already tombstoned when the slot was
+    /// reused, so there is nothing left to delete. Any other id-map
+    /// contradiction returns `Err` — the caller escalates to Cold.
     pub(crate) fn apply_final_op(
         &mut self,
         reverse: &mut HashMap<Uuid, u32>,

--- a/crates/khive-pack-memory/src/ann.rs
+++ b/crates/khive-pack-memory/src/ann.rs
@@ -371,8 +371,13 @@ impl AnnBridge {
     /// bridge: `Some(embedding)` replays a final upsert (tombstone the mapped
     /// old ordinal, then exactly one insert); `None` replays a final delete
     /// (tombstone if mapped, no-op otherwise). `new_s` is the highest tail
-    /// seq, stamped as the new applied watermark. Any id-map contradiction
-    /// returns `Err` — the caller escalates to Cold.
+    /// seq, stamped as the new applied watermark.
+    ///
+    /// A delete whose mapped ordinal has been reassigned by an earlier
+    /// upsert in the same batch is skipped with a warning, not an error:
+    /// the old subject's vector was already tombstoned when the slot was
+    /// reused, so there is nothing left to delete. Any other id-map
+    /// contradiction returns `Err` — the caller escalates to Cold.
     pub(crate) fn apply_final_ops(
         &mut self,
         ops: Vec<(Uuid, Option<Vec<f32>>)>,
@@ -383,7 +388,7 @@ impl AnnBridge {
         // are stale (tombstoning never clears them) and must be excluded
         // here, or a reused slot's new owner can be tombstoned by a replay
         // op for the old, already-deleted subject (#1150).
-        let mut reverse: HashMap<Uuid, u32> = HashMap::with_capacity(self.id_map.len());
+        let mut reverse: HashMap<Uuid, u32> = HashMap::with_capacity(self.index.live_count());
         for (ordinal, uuid) in self.id_map.iter().enumerate() {
             if self.index.is_tombstoned(ordinal as u32) {
                 continue;


### PR DESCRIPTION
Follow-ups from #1152, closing #1153. Both ANN tail-replay consumers (`khive-pack-memory::ann`, `khive-pack-knowledge::knowledge::vamana`):

1. **Contract alignment.** The replay method docs claimed any id-map contradiction returns `Err` and escalates to Cold, but the ownership-mismatch branch added in #1152 intentionally skips the tombstone with a warning when a same-batch upsert has already reused the slot — the old subject's vector was tombstoned at reuse, so there is nothing left to delete. The contracts now state both behaviors explicitly; genuine contradictions still escalate to Cold.

2. **Reverse-map capacity.** Both reverse maps reserved `HashMap` capacity for every `id_map` slot, including tombstoned history the build filter excludes, so churn-heavy indexes over-allocated transiently. Capacity now comes from `VamanaIndex::live_count()` (`num_vectors - tombstone_count`), matching the number of entries actually inserted.

Doc + allocation-size only; no behavior change on the replay paths. Gates run locally: `cargo test -p khive-pack-memory -p khive-pack-knowledge` (84+ tests), clippy `-D warnings`, fmt, `RUSTDOCFLAGS="-D warnings" cargo doc` on both packs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)