### PR TITLE
docs(design): backend-scoped WAL-pin attribution (issue #1160)

### DIFF
--- a/docs/design/walpin-backend-scoped-attribution.md
+++ b/docs/design/walpin-backend-scoped-attribution.md
@@ -1,0 +1,113 @@
+# WAL-Pin Attribution — Backend-Scoped Transaction Registry
+
+**Status**: draft\
+**Date**: 2026-07-19\
+**Authors**: khive maintainers\
+**Tracking**: issue #1160\
+**Related**: ADR-091 (WAL snapshot lifetime) and its Amendment 2 (attribution sidecar)
+
+---
+
+## Problem
+
+The open-transaction registry (`khive_storage::tx_registry`, ADR-091 Plank 0) is
+process-global: `register(label)` records only an opened-at instant and an optional
+diagnostic label, and `oldest()` returns the oldest span across the whole process.
+Both attribution consumers observe this global view but act on exactly one database:
+
+- The per-session sweep (`run_session_sweep_task`) writes heartbeats only into the
+  sidecar directory of the database path it was spawned with — the main backend.
+- The daemon checkpoint task (`run_checkpoint_task`) observes the same global
+  `oldest()` while checkpointing one specific pool.
+
+On a multi-backend process (for example a dedicated map database alongside the main
+store) this produces two failures:
+
+1. **Wrong-database attribution.** A long transaction on a secondary backend is
+   reported under the main database's sidecar, pointing a checkpoint stall at a
+   database that is not pinned.
+2. **Invisible backends.** Secondary databases get no sweep coverage and no sidecar
+   entries at all; their WAL pins cannot be attributed by any enumerator.
+
+## Requirement
+
+Attribution must be keyed to the database whose WAL is actually pinned. The sidecar
+contract is already scoped that way — each database file owns a `<db-file>.walpin/`
+directory — so the gap is entirely on the producer side: registry entries do not say
+which database they belong to.
+
+## Design forks
+
+### Fork A — origin identity on registry entries (recommended)
+
+Registry entries gain an optional origin: the canonical path of the database the
+transaction runs against.
+
+```rust
+// khive-storage (additive; existing register() delegates with origin = None)
+pub fn register_scoped(label: Option<String>, origin: Option<Arc<str>>) -> TxHandle;
+pub fn oldest_for(origin: Option<&str>) -> Option<(TxId, Duration, Option<String>)>;
+// oldest() retained unchanged: the process-wide aggregate view.
+```
+
+- **Registration sites** (all in `khive-db`: `WriterGuard::transaction`,
+  `atomic_unit`'s span, the raw batch-writer spans) thread the pool's canonical
+  database path as the origin. The pool already knows its path; no new state.
+- **The session sweep** keeps its single task but fans out per backend: one
+  `WalpinSidecarState` per file-backed backend, each observing
+  `oldest_for(<that backend's canonical path>)` and writing into that backend's own
+  sidecar directory.
+- **The daemon checkpoint task** switches its observation to
+  `oldest_for(<its pool's canonical path>)`, so a stall on pool X is never blamed
+  on a transaction pinning pool Y.
+- **Enumeration side needs zero change**: readers already enumerate per sidecar
+  directory.
+
+### Fork B — per-backend registry instances
+
+Replace the global static with a registry owned by each pool, threaded through every
+registration site.
+
+Rejected: every caller of `register` (guards, atomic units, batch writers) would need
+a registry handle plumbed through, inverting the current zero-argument seam for no
+attribution gain over Fork A. The global-static registry with origin filtering
+provides the same partitioning with an additive API.
+
+## Decisions folded into Fork A
+
+- **Origin identity is the canonical database path**, not the configured backend
+  name. The path is the same key the sidecar contract uses (`<db-file>.walpin/`),
+  is stable across processes that open the same database, and requires no config
+  plumbing. Backend names are per-process configuration and can differ between a
+  session and the daemon observing the same file.
+- **Memory backends are out of scope.** No database file means no WAL, no pins, and
+  no sidecar directory; their transactions register with `origin = None`.
+- **Unscoped entries keep today's behavior.** An entry with no origin (external
+  callers, tests, not-yet-threaded sites) is observed by the main backend's sidecar
+  state, exactly as every entry is today. Scoping narrows attribution; it never
+  silently drops a span from observation. All in-tree registration sites are
+  threaded in the same change, so unscoped entries should not occur from khive's own
+  write paths.
+- **`oldest()` survives as the aggregate view** for consumers that genuinely want
+  the process-wide oldest span (logging, diagnostics). Attribution consumers move to
+  `oldest_for`.
+
+## Test plan
+
+- Registry unit tests: `oldest_for` partitions by origin; unscoped entries appear
+  under `oldest_for(None)` and in `oldest()`; scoped entries never leak into a
+  different origin's view.
+- Sweep integration test: two file-backed pools in one process; a long-running
+  transaction on the secondary backend produces a heartbeat in the **secondary**
+  database's sidecar directory and none in the main database's sidecar.
+- Daemon-side test: checkpoint attribution for pool X ignores a span registered
+  against pool Y.
+
+## Rollout
+
+Single implementation PR after this note is accepted: additive `khive-storage` API,
+origin threading at the `khive-db` registration sites, session-sweep fan-out, and
+the daemon checkpoint task's scoped observation, with the tests above. No schema,
+wire, or sidecar-format change; ADR-091 Amendment 2's sidecar contract is unchanged
+— this note only closes the producer-side scoping gap against the contract's
+existing per-database key.

--- a/docs/design/walpin-backend-scoped-attribution.md
+++ b/docs/design/walpin-backend-scoped-attribution.md
@@ -40,28 +40,70 @@ which database they belong to.
 
 ### Fork A — origin identity on registry entries (recommended)
 
-Registry entries gain an optional origin: the canonical path of the database the
-transaction runs against.
+Registry entries gain an explicit origin describing which database, if any, the
+transaction runs against. Origin is a three-state contract, not an option type —
+"no database file" and "not yet threaded" are different facts and must never
+share a representation:
 
 ```rust
-// khive-storage (additive; existing register() delegates with origin = None)
-pub fn register_scoped(label: Option<String>, origin: Option<Arc<str>>) -> TxHandle;
-pub fn oldest_for(origin: Option<&str>) -> Option<(TxId, Duration, Option<String>)>;
+// khive-storage (additive; existing register() delegates with TxOrigin::Unscoped)
+pub enum TxOrigin {
+    /// A file-backed database, identified by the shared lossless identity below.
+    Database(DbIdentity),
+    /// An in-memory backend: no database file, no WAL, no sidecar — excluded
+    /// from WAL-pin attribution entirely.
+    Memory,
+    /// A registration site that has not been threaded (external callers,
+    /// tests). Observed by the main backend's attribution view, exactly as
+    /// every entry is today, so scoping can never silently drop a span.
+    Unscoped,
+}
+pub fn register_scoped(label: Option<String>, origin: TxOrigin) -> TxHandle;
+pub fn oldest_for(filter: &TxOriginFilter) -> Option<(TxId, Duration, Option<String>)>;
 // oldest() retained unchanged: the process-wide aggregate view.
 ```
 
-- **Registration sites** (all in `khive-db`: `WriterGuard::transaction`,
-  `atomic_unit`'s span, the raw batch-writer spans) thread the pool's canonical
-  database path as the origin. The pool already knows its path; no new state.
+The main backend's attribution view uses a filter matching
+`Database(main) | Unscoped`; a secondary backend's view matches only
+`Database(that backend)`; `Memory` matches no attribution view.
+
+- **Database identity** (`DbIdentity`) is a shared, lossless key produced at
+  exactly one canonicalization point — the pool, from the backend's resolved
+  path — and reused everywhere origin is compared. It preserves the platform
+  path encoding (`OsString`-based, never lossy UTF-8 conversion: the backend
+  layer deliberately preserves non-UTF-8 path identity to avoid database
+  collisions, and origin must not be weaker than that) and is the same input
+  the sidecar-directory key (`<db-file>.walpin/`) derives from, so a sidecar
+  directory and the spans attributed to it can never disagree about which
+  database they mean.
+- **Registration sites**: every `khive_storage::tx_registry::register` call
+  site is threaded in the same change — the current inventory spans
+  `pool.rs` (`WriterGuard::transaction`), `writer_task.rs` (the batch-writer
+  span), `stores/graph.rs` (`graph_upsert_edges`, `graph_upsert_edge_guarded`,
+  the guarded-edge span, and `graph_traverse_read` — the long-lived deferred
+  read snapshot held across traversal chunks, which is precisely the span
+  class attribution exists for), and the daemon's own registration sites in
+  `khive-runtime`. The implementation PR gates completeness with a grep over
+  `tx_registry::register` — the list above is the audit baseline, not the
+  contract; any site added later must register scoped or is a review defect.
 - **The session sweep** keeps its single task but fans out per backend: one
-  `WalpinSidecarState` per file-backed backend, each observing
-  `oldest_for(<that backend's canonical path>)` and writing into that backend's own
-  sidecar directory.
-- **The daemon checkpoint task** switches its observation to
-  `oldest_for(<its pool's canonical path>)`, so a stall on pool X is never blamed
-  on a transaction pinning pool Y.
-- **Enumeration side needs zero change**: readers already enumerate per sidecar
-  directory.
+  `WalpinSidecarState` per file-backed backend, each observing its backend's
+  filtered view and writing into that backend's own sidecar directory.
+- **The daemon checkpoint task** switches its observation to its own pool's
+  filtered view, so a stall on pool X is never blamed on a transaction pinning
+  pool Y.
+- **Enumeration ownership must extend, not stay put.** The per-directory
+  enumeration _mechanism_ is unchanged, but today the daemon wires a
+  checkpoint pool — and therefore stall detection and TRUNCATE-time
+  attribution enumeration — for the **main** backend only
+  (`build_server_from_multi_backend_registry` calls `checkpoint_pool_for` on
+  `main_backend` alone). Writing secondary sidecars without extending
+  ownership would produce heartbeats nothing ever reads. The implementation
+  PR therefore extends daemon checkpoint/enumeration ownership to every
+  file-backed backend (one checkpoint task per file-backed pool, each owning
+  its own sidecar enumeration), and the sweep fan-out lands in the same PR so
+  producers and consumers of secondary sidecars ship together — never one
+  without the other.
 
 ### Fork B — per-backend registry instances
 
@@ -75,39 +117,54 @@ provides the same partitioning with an additive API.
 
 ## Decisions folded into Fork A
 
-- **Origin identity is the canonical database path**, not the configured backend
-  name. The path is the same key the sidecar contract uses (`<db-file>.walpin/`),
-  is stable across processes that open the same database, and requires no config
-  plumbing. Backend names are per-process configuration and can differ between a
-  session and the daemon observing the same file.
-- **Memory backends are out of scope.** No database file means no WAL, no pins, and
-  no sidecar directory; their transactions register with `origin = None`.
-- **Unscoped entries keep today's behavior.** An entry with no origin (external
-  callers, tests, not-yet-threaded sites) is observed by the main backend's sidecar
-  state, exactly as every entry is today. Scoping narrows attribution; it never
-  silently drops a span from observation. All in-tree registration sites are
-  threaded in the same change, so unscoped entries should not occur from khive's own
-  write paths.
+- **Origin identity is a lossless database identity, not the configured backend
+  name.** The resolved path is the same key the sidecar contract uses
+  (`<db-file>.walpin/`), is stable across processes that open the same database,
+  and requires no config plumbing. Backend names are per-process configuration
+  and can differ between a session and the daemon observing the same file.
+  `DbIdentity` preserves platform path encoding and is minted at one
+  canonicalization point (the pool); no other layer constructs or normalizes it.
+- **Memory backends register `TxOrigin::Memory`, never `Unscoped`.** No database
+  file means no WAL, no pins, and no sidecar directory. Conflating "memory" with
+  "unscoped" would either drop unscoped spans from observation (exact filtering)
+  or falsely attribute memory spans to the main database (fallback filtering) —
+  the three-state contract exists precisely to keep these apart.
+- **`Unscoped` entries keep today's behavior.** They are observed by the main
+  backend's attribution view, exactly as every entry is today. Scoping narrows
+  attribution; it never silently drops a span from observation. All in-tree
+  registration sites are threaded in the same change, so `Unscoped` should not
+  occur from khive's own write paths; the grep gate makes any later regression a
+  review defect rather than a silent hole.
 - **`oldest()` survives as the aggregate view** for consumers that genuinely want
-  the process-wide oldest span (logging, diagnostics). Attribution consumers move to
-  `oldest_for`.
+  the process-wide oldest span (logging, diagnostics). Attribution consumers move
+  to `oldest_for`.
 
 ## Test plan
 
-- Registry unit tests: `oldest_for` partitions by origin; unscoped entries appear
-  under `oldest_for(None)` and in `oldest()`; scoped entries never leak into a
-  different origin's view.
+- Registry unit tests: `oldest_for` partitions by origin; `Unscoped` entries
+  appear in the main backend's filtered view and in `oldest()`; `Memory` entries
+  appear in no attribution view but still in `oldest()`; `Database` entries never
+  leak into a different backend's view.
 - Sweep integration test: two file-backed pools in one process; a long-running
   transaction on the secondary backend produces a heartbeat in the **secondary**
   database's sidecar directory and none in the main database's sidecar.
-- Daemon-side test: checkpoint attribution for pool X ignores a span registered
-  against pool Y.
+- Daemon-side tests: checkpoint attribution for pool X ignores a span registered
+  against pool Y; with two file-backed backends, a WAL stall on the secondary is
+  detected and its sidecar enumerated (per-backend ownership, not main-only).
+- Traversal coverage test: a `graph_traverse_read` deferred span on a secondary
+  backend appears in that backend's filtered view — the long-lived read snapshot
+  is the span class this design exists for and must not remain unscoped.
+- Identity test: a non-UTF-8 database path (Unix) round-trips through
+  `DbIdentity` without loss and matches its own sidecar directory key.
 
 ## Rollout
 
-Single implementation PR after this note is accepted: additive `khive-storage` API,
-origin threading at the `khive-db` registration sites, session-sweep fan-out, and
-the daemon checkpoint task's scoped observation, with the tests above. No schema,
-wire, or sidecar-format change; ADR-091 Amendment 2's sidecar contract is unchanged
-— this note only closes the producer-side scoping gap against the contract's
-existing per-database key.
+Single implementation PR after this note is accepted: additive `khive-storage`
+API (`TxOrigin`, `DbIdentity`, `register_scoped`, `oldest_for`), origin threading
+at every registry call site (the grep-gated inventory above, including
+`graph_traverse_read` and the daemon's own spans), session-sweep fan-out,
+per-file-backed-backend daemon checkpoint/enumeration ownership, and the tests
+above — producers and consumers of secondary sidecars land in the same PR. No
+schema, wire, or sidecar-format change; ADR-091 Amendment 2's sidecar contract is
+unchanged — this note closes the producer-side scoping gap and the main-only
+consumer-ownership gap against the contract's existing per-database key.


### PR DESCRIPTION
Design note requested by #1160 before implementation: session attribution is not scoped to the backend that owns the transaction.

The note grounds the gap in the current code (process-global `tx_registry` with no origin identity; both attribution consumers observe the global oldest while acting on one database), lays out the two forks — origin identity on registry entries vs per-backend registry instances — and recommends the first: canonical database path as an optional origin, additive `register_scoped`/`oldest_for` API, single session sweep fanning out one sidecar state per file-backed backend, and the daemon checkpoint task observing only its own pool's spans. Unscoped entries keep today's behavior so scoping can never silently drop a span from observation. Includes the test plan and a single-PR rollout; no schema, wire, or sidecar-format change.

Implementation follows in a separate PR once this note is accepted.