### PR TITLE
docs: ADR-091 Amendment 3 and the backend-scoped attribution note amendment (issue #1160)

### DIFF
--- a/docs/adr/ADR-091-wal-snapshot-lifetime.md
+++ b/docs/adr/ADR-091-wal-snapshot-lifetime.md
@@ -837,3 +837,82 @@ implicate or exonerate them without reading native code.
 **Config.** `KHIVE_SESSION_SWEEP_INTERVAL_MS` (default 5000, sessions only);
 `KHIVE_WALPIN_SIDECAR` (default on for file-backed backends, off for in-memory).
 Existing threshold keys are reused unchanged.
+
+### 2026-07-20 amendment (Amendment 3): heartbeat freshness basis and the attribution-basis field
+
+**Motivation.** Two contract refinements, both surfaced by review follow-ups to
+Amendment 2's implementation (#1155 item 1; the backend-scoped attribution
+design in `docs/design/walpin-backend-scoped-attribution.md`):
+
+1. While a transaction is over-threshold, the session sweep rewrites and fsyncs
+   the full heartbeat record on every tick (exclusive-create temp file plus
+   atomic rename, per the trust-boundary contract). Freshness only needs a
+   timestamp to advance, and beacons already refresh with a metadata-only
+   mtime touch. The asymmetry is pure write churn: N ticks of one long-running
+   span produce N full record writes whose only material delta is the embedded
+   age.
+2. The backend-scoped attribution design introduces heartbeats written under a
+   fallback attribution (an unscoped-origin span observed by the main
+   backend's view). The record format needs a field that distinguishes
+   evidence-based attribution from fallback so diagnostics never read fallback
+   attribution as ground truth. This amendment is the sole source of truth for
+   that field's format; the design note consumes the definition and does not
+   restate it.
+
+**Plank F1: file mtime is the freshness basis for both record kinds.**
+
+Heartbeat liveness moves to the same basis the beacon refresh rule already
+uses: the record's freshness timestamp is the sidecar file's mtime, evaluated
+against the unchanged roughly-3-sweep-interval window. While the warn
+condition persists, each sweep tick performs a metadata-only mtime touch of
+the existing heartbeat file — the same mechanism and the same
+opened-directory-descriptor discipline as beacon refresh, preserving the
+trust-boundary contract. The full body is rewritten (exclusive-create temp
+file plus atomic rename, unchanged) only when record content changes: the
+first over-threshold observation, a change of the oldest span's identity or
+label, a change of `attribution_basis` (Plank F2), and the removal cases
+Amendment 2 already defines (clean shutdown, first tick after the condition
+clears). The body's `updated_at` field is retained and now means exactly "the
+instant of the last body write"; it no longer participates in liveness
+classification.
+
+_Age is computed at read time._ A body that is not rewritten cannot carry a
+current age. The heartbeat record gains `oldest_tx_started_at` (epoch
+timestamp of the oldest span's registration instant); enumeration computes
+the current age as now minus `oldest_tx_started_at`. The existing
+`oldest_tx_age_secs` field is retained with its documentation narrowed: the
+age as of the last body write. Readers prefer `oldest_tx_started_at` when
+present; records written by pre-amendment binaries lack it and are read
+exactly as before. The alternative — keeping age current by rewriting the
+body every tick — is the status quo this plank exists to remove.
+
+_Crash conservatism._ An mtime touch is not durability-critical: a touch lost
+to a crash makes the record look stale, and Amendment 2's liveness gate
+already deletes stale entries and classifies their PIDs as `unknown` — the
+failure direction is inconclusive attribution, never false attribution. This
+is the same conservatism the beacon refresh rule accepted.
+
+**Plank F2: the `attribution_basis` field.**
+
+The heartbeat record gains exactly one additive field:
+
+- `attribution_basis`: string with exactly two values.
+  - `"origin"` — the oldest span carried this database's own origin
+    identity.
+  - `"fallback"` — the oldest span was unscoped and is observed by the main
+    backend's view as the designed never-silently-drop fallback.
+- Absence: records written by binaries predating this field carry no
+  `attribution_basis`; readers treat absence as unspecified — neither origin
+  nor fallback may be inferred from a missing field.
+
+The origin semantics (which spans are scoped to which database, and why
+unscoped spans fall back to the main view) are specified by the
+backend-scoped attribution design note; this amendment owns only the field's
+name, type, and values. A change of `attribution_basis` is a content change
+and forces a body rewrite under Plank F1. Beacons carry no attribution and
+are unchanged.
+
+**Non-goals.** Thresholds, the enumeration liveness gate structure, census
+rules, the filesystem trust boundary, and the beacon contract are unchanged.
+This amendment adds no fields beyond the two named here
+(`oldest_tx_started_at`, `attribution_basis`).

--- a/docs/adr/ADR-091-wal-snapshot-lifetime.md
+++ b/docs/adr/ADR-091-wal-snapshot-lifetime.md
@@ -888,18 +888,26 @@ beacon content each gain a `sweep_interval_ms` field, written at record
 creation (a mid-process configuration change is a content change and forces a
 rewrite). Classification is then exact:
 
-- **live** iff `enumeration_time - mtime <= 3 x declared sweep_interval_ms`
-  (boundary inclusive);
+- **live** iff `enumeration_time - mtime <= 3 x max(declared
+  sweep_interval_ms, 1000 ms)` (boundary inclusive);
 - otherwise **stale**, with Amendment 2's consequences unchanged (stale
   entries are deleted and their PIDs classify `unknown`).
+
+The `max(..., 1000 ms)` clamp is the mtime-resolution floor: filesystem
+mtime granularity is as coarse as one second, so a sub-second declared
+cadence must never narrow the classification window below what the basis
+can resolve — without the floor, a 100 ms cadence would yield a 300 ms
+window and healthy records would classify stale on any coarse filesystem.
+Sub-second cadences remain supported on the write side; the clamp affects
+classification only, flooring the effective window at three seconds.
 
 Records written by pre-amendment binaries carry no declaration; the
 enumerator evaluates them against the default interval (5000 ms), which is
 exactly today's behavior. Both timestamps come from the same host — the
 sidecar is same-machine by construction, since every writer holds the same
 database file — so no cross-host clock skew enters the comparison; filesystem
-mtime granularity (worst case one second on coarse filesystems) is absorbed
-by the multiplier. The multiplier's operational meaning is the measurable
+mtime granularity (worst case one second on coarse filesystems) is covered
+by the mtime-resolution floor above. The multiplier's operational meaning is the measurable
 spec: a touch is a synchronous same-kernel metadata write, visible to
 enumeration the moment the tick completes, so a healthy process's record
 never exceeds one declared interval of age plus scheduling jitter, and the

--- a/docs/adr/ADR-091-wal-snapshot-lifetime.md
+++ b/docs/adr/ADR-091-wal-snapshot-lifetime.md
@@ -840,9 +840,9 @@ Existing threshold keys are reused unchanged.
 
 ### 2026-07-20 amendment (Amendment 3): heartbeat freshness basis and the attribution-basis field
 
-**Motivation.** Two contract refinements, both surfaced by review follow-ups to
-Amendment 2's implementation (#1155 item 1; the backend-scoped attribution
-design in `docs/design/walpin-backend-scoped-attribution.md`):
+**Motivation.** Two contract refinements to Amendment 2 (#1155 item 1; the
+backend-scoped attribution design in
+`docs/design/walpin-backend-scoped-attribution.md`):
 
 1. While a transaction is over-threshold, the session sweep rewrites and fsyncs
    the full heartbeat record on every tick (exclusive-create temp file plus
@@ -919,6 +919,33 @@ present; records written by pre-amendment binaries lack it and are read
 exactly as before. The alternative — keeping age current by rewriting the
 body every tick — is the status quo this plank exists to remove.
 
+_Recovery rule._ The touch path must never assume the file still exists:
+enumeration deletes stale entries, and a slow writer's heartbeat can be
+deleted while its span is still live. On every sweep tick where the warn
+condition holds, a missing heartbeat (or a touch failing with not-found) is
+recreated by a full body write through the unchanged create path — so a
+deletion costs at most one tick of attribution gap, never permanent
+invisibility. Beacons recover the same way, fail-closed: a missing beacon is
+rewritten on the next tick, and a beacon that cannot be recreated is a
+sidecar-health failure — the process classifies `unknown`, per Amendment 2's
+rule that a daemon-side or write-side failure must never masquerade as
+affirmative evidence.
+
+_Mixed-version rule._ An enumerator predating this amendment classifies by
+body `updated_at` and would delete a live heartbeat whose new-style writer
+touches only mtime. The contract does not pretend this window away; it bounds
+it and fixes the failure direction. Deployment on a host is effectively
+single-binary (every khive process runs the installed `kkernel`; the daemon
+restarts on reinstall and sessions re-exec), so a mixed window exists only
+between binary upgrade and process restart. Inside that window, an old-reader
+deletion of a new-writer record is repaired by the recovery rule on the
+writer's next tick, and the interim classification is `unknown` —
+inconclusive, never false attribution. Readers upgraded to this amendment
+accept both generations: records carrying the new fields classify on mtime;
+records without them classify on `updated_at` exactly as before. The window
+closes when the enumerating daemon process is running the amended binary; no
+flag-day coordination is required.
+
 _Crash conservatism._ An mtime touch is not durability-critical: a touch lost
 to a crash makes the record look stale, and Amendment 2's liveness gate
 already deletes stale entries and classifies their PIDs as `unknown` — the
@@ -938,12 +965,24 @@ The heartbeat record gains exactly one additive field:
   `attribution_basis`; readers treat absence as unspecified — neither origin
   nor fallback may be inferred from a missing field.
 
+_Fail-closed reading rule (binding on every consumer)._ Classification of a
+record's attribution confidence fails closed: a missing `attribution_basis`,
+an unrecognized value, or any parse failure of the field classifies the
+record as unspecified/fallback-confidence — **never** as evidence-backed.
+Only the exact string `"origin"` licenses the evidence-backed reading. This
+rule is versioned with the field itself: mixed-version readers encountering
+records from newer writers with values this amendment does not define must
+degrade to fallback-confidence rather than guess. Without this rule a
+fallback attribution could be read as ground truth — the exact confusion the
+field exists to prevent.
+
 The origin semantics (which spans are scoped to which database, and why
 unscoped spans fall back to the main view) are specified by the
 backend-scoped attribution design note; this amendment owns only the field's
-name, type, and values. A change of `attribution_basis` is a content change
-and forces a body rewrite under Plank F1. Beacons carry no attribution and
-are unchanged.
+name, type, values, and the reading rule above. A change of
+`attribution_basis` is a content change and forces a body rewrite under
+Plank F1. Beacons carry no attribution and are unchanged beyond the cadence
+declaration.
 
 **Non-goals.** Thresholds, the enumeration liveness gate structure, census
 rules, the filesystem trust boundary, and the beacon refresh mechanism are

--- a/docs/adr/ADR-091-wal-snapshot-lifetime.md
+++ b/docs/adr/ADR-091-wal-snapshot-lifetime.md
@@ -929,22 +929,33 @@ invisibility. Beacons recover the same way, fail-closed: a missing beacon is
 rewritten on the next tick, and a beacon that cannot be recreated is a
 sidecar-health failure — the process classifies `unknown`, per Amendment 2's
 rule that a daemon-side or write-side failure must never masquerade as
-affirmative evidence.
+affirmative evidence. The full record lifecycle is therefore closed, with
+every transition defined: **create** (first over-threshold observation, full
+body write) → **touch** (each subsequent tick while the condition persists,
+metadata-only) → **rewrite** (content change, full body write) → **stale**
+(mtime falls outside the declared window) → **delete** (by enumeration, or
+by the writer on clean shutdown / first tick after the condition clears) →
+**recreate** (next over-threshold tick, identical to create). No state is
+terminal while the underlying span is live.
 
 _Mixed-version rule._ An enumerator predating this amendment classifies by
 body `updated_at` and would delete a live heartbeat whose new-style writer
-touches only mtime. The contract does not pretend this window away; it bounds
-it and fixes the failure direction. Deployment on a host is effectively
-single-binary (every khive process runs the installed `kkernel`; the daemon
-restarts on reinstall and sessions re-exec), so a mixed window exists only
-between binary upgrade and process restart. Inside that window, an old-reader
-deletion of a new-writer record is repaired by the recovery rule on the
-writer's next tick, and the interim classification is `unknown` —
-inconclusive, never false attribution. Readers upgraded to this amendment
-accept both generations: records carrying the new fields classify on mtime;
-records without them classify on `updated_at` exactly as before. The window
-closes when the enumerating daemon process is running the amended binary; no
-flag-day coordination is required.
+touches only mtime — the old reader actively destroys live records, which is
+the dangerous direction. The normative rule is therefore
+**readers-before-writers**: after a binary upgrade, the enumerating daemon
+process is restarted onto the amended binary before new-style writers
+matter. This is the deployment's natural order — the daemon is restarted at
+reinstall while stdio sessions re-exec afterward — so the ordering is the
+default behavior, not an operational burden; readers upgraded to this
+amendment accept both generations (records carrying the new fields classify
+on mtime; records without them classify on `updated_at` exactly as before),
+so upgraded readers never misjudge old writers. Should the ordering ever be
+violated (an old daemon process still running against new-style writers),
+the contract bounds the damage rather than pretending the window away: the
+window exists only between binary upgrade and daemon restart, an old-reader
+deletion is repaired by the recovery rule on the writer's next tick, and the
+interim classification is `unknown` — inconclusive, never false attribution.
+No flag-day coordination is required.
 
 _Crash conservatism._ An mtime touch is not durability-critical: a touch lost
 to a crash makes the record look stale, and Amendment 2's liveness gate

--- a/docs/adr/ADR-091-wal-snapshot-lifetime.md
+++ b/docs/adr/ADR-091-wal-snapshot-lifetime.md
@@ -876,6 +876,39 @@ clears). The body's `updated_at` field is retained and now means exactly "the
 instant of the last body write"; it no longer participates in liveness
 classification.
 
+_Liveness boundary (determinate form)._ Amendment 2 phrased the freshness
+window as "roughly 3 session sweep intervals"; on the mtime basis this
+amendment replaces that phrasing with an exact, observable contract, because
+the window has a hidden indeterminacy: the sweep interval is per-process
+configuration (`KHIVE_SESSION_SWEEP_INTERVAL_MS`), and the enumerating daemon
+cannot know a remote process's configured value — judging a 60-second-interval
+writer by three times the 5-second default would deterministically
+misclassify it. Records therefore declare their own cadence: heartbeat and
+beacon content each gain a `sweep_interval_ms` field, written at record
+creation (a mid-process configuration change is a content change and forces a
+rewrite). Classification is then exact:
+
+- **live** iff `enumeration_time - mtime <= 3 x declared sweep_interval_ms`
+  (boundary inclusive);
+- otherwise **stale**, with Amendment 2's consequences unchanged (stale
+  entries are deleted and their PIDs classify `unknown`).
+
+Records written by pre-amendment binaries carry no declaration; the
+enumerator evaluates them against the default interval (5000 ms), which is
+exactly today's behavior. Both timestamps come from the same host — the
+sidecar is same-machine by construction, since every writer holds the same
+database file — so no cross-host clock skew enters the comparison; filesystem
+mtime granularity (worst case one second on coarse filesystems) is absorbed
+by the multiplier. The multiplier's operational meaning is the measurable
+spec: a touch is a synchronous same-kernel metadata write, visible to
+enumeration the moment the tick completes, so a healthy process's record
+never exceeds one declared interval of age plus scheduling jitter, and the
+3x window tolerates up to two consecutive missed ticks before classifying
+stale. A process that misses more than two ticks is delayed by more than
+twice its own declared cadence — which is precisely the wedged-sweep
+signature Amendment 2's `unknown` classification exists to surface, so the
+false-stale case and the wanted-detection case coincide at the boundary.
+
 _Age is computed at read time._ A body that is not rewritten cannot carry a
 current age. The heartbeat record gains `oldest_tx_started_at` (epoch
 timestamp of the oldest span's registration instant); enumeration computes
@@ -913,6 +946,7 @@ and forces a body rewrite under Plank F1. Beacons carry no attribution and
 are unchanged.
 
 **Non-goals.** Thresholds, the enumeration liveness gate structure, census
-rules, the filesystem trust boundary, and the beacon contract are unchanged.
-This amendment adds no fields beyond the two named here
-(`oldest_tx_started_at`, `attribution_basis`).
+rules, the filesystem trust boundary, and the beacon refresh mechanism are
+unchanged; beacon content changes only by gaining the same `sweep_interval_ms`
+declaration heartbeats gain. This amendment adds no fields beyond the three
+named here (`oldest_tx_started_at`, `attribution_basis`, `sweep_interval_ms`).

--- a/docs/design/walpin-backend-scoped-attribution.md
+++ b/docs/design/walpin-backend-scoped-attribution.md
@@ -59,7 +59,17 @@ pub enum TxOrigin {
     Unscoped,
 }
 pub fn register_scoped(label: Option<String>, origin: TxOrigin) -> TxHandle;
-pub fn oldest_for(filter: &TxOriginFilter) -> Option<(TxId, Duration, Option<String>)>;
+pub struct OldestSpan {
+    pub id: TxId,
+    pub age: Duration,
+    pub label: Option<String>,
+    /// The winning span's origin, so the consumer can distinguish an
+    /// evidence-backed Database(_) winner from an Unscoped fallback winner
+    /// when writing the attribution-basis field. Without this the marker
+    /// could not be set at all.
+    pub origin: TxOrigin,
+}
+pub fn oldest_for(filter: &TxOriginFilter) -> Option<OldestSpan>;
 // oldest() retained unchanged: the process-wide aggregate view.
 ```
 
@@ -67,15 +77,39 @@ The main backend's attribution view uses a filter matching
 `Database(main) | Unscoped`; a secondary backend's view matches only
 `Database(that backend)`; `Memory` matches no attribution view.
 
-- **Database identity** (`DbIdentity`) is a shared, lossless key produced at
-  exactly one canonicalization point — the pool, from the backend's resolved
-  path — and reused everywhere origin is compared. It preserves the platform
-  path encoding (`OsString`-based, never lossy UTF-8 conversion: the backend
-  layer deliberately preserves non-UTF-8 path identity to avoid database
-  collisions, and origin must not be weaker than that) and is the same input
-  the sidecar-directory key (`<db-file>.walpin/`) derives from, so a sidecar
-  directory and the spans attributed to it can never disagree about which
-  database they mean.
+- **Database identity** (`DbIdentity`) is a shared key produced at exactly
+  one minting point — the pool — and reused everywhere origin is compared.
+  Minting is defined operationally, in three steps. First, a relative
+  configured path is resolved against the process current directory before
+  any canonicalization — a bare file name like `khive.db` has an empty
+  parent, and canonicalizing an empty path fails, so resolution must precede
+  the filesystem steps. Second, when the database file **exists**,
+  canonicalize the full path: this resolves symlinks at every level,
+  including a symlink at the database-file level itself (a `link.sqlite`
+  pointing at the real file must mint the target's identity, which
+  parent-only canonicalization would miss). Third, when the file does **not
+  yet exist** (first open), canonicalize the parent directory and append the
+  file name unchanged — the same pattern `FsBlobStore` uses for its
+  root-keyed write locks, and for the same reason (`Path::canonicalize`
+  requires an existing path). Canonicalization is what collapses aliased
+  spellings — symlink vs. target, relative vs. absolute, file-level
+  symlinks — into one identity, so a daemon and a session opening the same
+  database through different spellings mint the same `DbIdentity`.
+- **Canonical and lossless are reconciled explicitly**, because they pull in
+  opposite directions: _canonical_ collapses aliases; _lossless_ governs the
+  representation of the canonical path once minted (`OsString`-based, never
+  lossy UTF-8 conversion — the backend layer deliberately preserves
+  non-UTF-8 path identity to avoid database collisions, and origin must not
+  be weaker than that). Lossless does **not** mean preserving pre-canonical
+  alias spellings; those are collapsed by design.
+- **Sidecar derivation consumes the minted `DbIdentity`**, never the raw
+  configured path. Today's `sidecar_dir_for` is a purely lexical sibling
+  derivation, so two aliased openers would land on two different sidecar
+  directories; the implementation routes it through the minted identity so
+  a sidecar directory and the spans attributed to it can never disagree
+  about which database they mean. Sidecar contents are ephemeral
+  observability records (heartbeats, beacons), so re-keying the derivation
+  requires no migration.
 - **Registration sites**: every `khive_storage::tx_registry::register` call
   site is threaded in the same change — the current inventory spans
   `pool.rs` (`WriterGuard::transaction`), `writer_task.rs` (the batch-writer
@@ -117,21 +151,33 @@ provides the same partitioning with an additive API.
 
 ## Decisions folded into Fork A
 
-- **Origin identity is a lossless database identity, not the configured backend
-  name.** The resolved path is the same key the sidecar contract uses
-  (`<db-file>.walpin/`), is stable across processes that open the same database,
-  and requires no config plumbing. Backend names are per-process configuration
-  and can differ between a session and the daemon observing the same file.
-  `DbIdentity` preserves platform path encoding and is minted at one
-  canonicalization point (the pool); no other layer constructs or normalizes it.
+- **Origin identity is the minted `DbIdentity`, not the configured backend
+  name.** The canonical identity is the same key the sidecar contract uses
+  (`<db-file>.walpin/`), is stable across processes that open the same database
+  — including through aliased spellings, which minting collapses — and requires
+  no config plumbing. Backend names are per-process configuration and can
+  differ between a session and the daemon observing the same file. `DbIdentity`
+  is minted at one point (the pool, per the operational definition above); no
+  other layer constructs, normalizes, or re-canonicalizes it.
 - **Memory backends register `TxOrigin::Memory`, never `Unscoped`.** No database
   file means no WAL, no pins, and no sidecar directory. Conflating "memory" with
   "unscoped" would either drop unscoped spans from observation (exact filtering)
   or falsely attribute memory spans to the main database (fallback filtering) —
   the three-state contract exists precisely to keep these apart.
-- **`Unscoped` entries keep today's behavior.** They are observed by the main
-  backend's attribution view, exactly as every entry is today. Scoping narrows
-  attribution; it never silently drops a span from observation. All in-tree
+- **`Unscoped` entries keep today's behavior — and are labeled as such.** They
+  are observed by the main backend's attribution view, exactly as every entry
+  is today. Scoping narrows attribution; it never silently drops a span from
+  observation. A heartbeat whose oldest span carries `Unscoped` origin is
+  written with an explicit fallback-attribution marker, so diagnostics can
+  distinguish "attributed to main by evidence" from "attributed to main as the
+  fallback for unknown origin" and never read fallback attribution as ground
+  truth. The marker is the `attribution_basis` heartbeat field whose name,
+  type, values, and fail-closed reading rule are defined solely by ADR-091
+  Amendment 3 (which also defines the freshness-contract fields the sweep
+  writes) — this note consumes that definition and deliberately does not
+  restate it, so the record format has exactly one source of truth. The
+  sweep sets it from the winning span's origin, which `oldest_for` returns
+  for exactly this purpose. All in-tree
   registration sites are threaded in the same change, so `Unscoped` should not
   occur from khive's own write paths; the grep gate makes any later regression a
   review defect rather than a silent hole.
@@ -145,6 +191,14 @@ provides the same partitioning with an additive API.
   appear in the main backend's filtered view and in `oldest()`; `Memory` entries
   appear in no attribution view but still in `oldest()`; `Database` entries never
   leak into a different backend's view.
+- Alias-convergence test: the same database opened via its real path, a
+  directory symlink, a **file-level symlink** (a link whose final component
+  points at the database file), a relative spelling, and a **bare file name**
+  (empty parent, resolved against the current directory) mints identical
+  `DbIdentity` values and derives the identical sidecar directory.
+- Fallback-marker test: a heartbeat produced from an `Unscoped` oldest span
+  carries the fallback-attribution marker; one produced from a
+  `Database(main)` span does not.
 - Sweep integration test: two file-backed pools in one process; a long-running
   transaction on the secondary backend produces a heartbeat in the **secondary**
   database's sidecar directory and none in the main database's sidecar.
@@ -162,9 +216,14 @@ provides the same partitioning with an additive API.
 Single implementation PR after this note is accepted: additive `khive-storage`
 API (`TxOrigin`, `DbIdentity`, `register_scoped`, `oldest_for`), origin threading
 at every registry call site (the grep-gated inventory above, including
-`graph_traverse_read` and the daemon's own spans), session-sweep fan-out,
-per-file-backed-backend daemon checkpoint/enumeration ownership, and the tests
-above — producers and consumers of secondary sidecars land in the same PR. No
-schema, wire, or sidecar-format change; ADR-091 Amendment 2's sidecar contract is
-unchanged — this note closes the producer-side scoping gap and the main-only
-consumer-ownership gap against the contract's existing per-database key.
+`graph_traverse_read` and the daemon's own spans), the sidecar-derivation change
+routing `sidecar_dir_for` consumers through the minted `DbIdentity`,
+session-sweep fan-out, per-file-backed-backend daemon checkpoint/enumeration
+ownership, and the tests above — producers and consumers of secondary sidecars
+land in the same PR. No schema or wire change. Every sidecar record-format
+delta — the `attribution_basis` marker this note motivates and the
+freshness-contract fields — is defined in ADR-091 Amendment 3, the sole source
+of truth for the record format, which must be accepted before or together with
+the implementation; everything else in the sidecar contract is unchanged — this
+note closes the producer-side scoping gap and the main-only consumer-ownership
+gap against the contract's existing per-database key.

--- a/docs/design/walpin-backend-scoped-attribution.md
+++ b/docs/design/walpin-backend-scoped-attribution.md
@@ -88,10 +88,19 @@ The main backend's attribution view uses a filter matching
   including a symlink at the database-file level itself (a `link.sqlite`
   pointing at the real file must mint the target's identity, which
   parent-only canonicalization would miss). Third, when the file does **not
-  yet exist** (first open), canonicalize the parent directory and append the
-  file name unchanged — the same pattern `FsBlobStore` uses for its
-  root-keyed write locks, and for the same reason (`Path::canonicalize`
-  requires an existing path). Canonicalization is what collapses aliased
+  yet exist** (first open), resolve any symlink at the final component
+  first: a **dangling** file-level symlink is a valid first-open state —
+  SQLite creates the target through the link on first write — and minting
+  the link's own name would diverge from a later opener using the target
+  path, splitting one database across two sidecars. The link chain is
+  followed to its final non-symlink path (bounded, exactly as the OS's own
+  loop limit bounds the subsequent open), and then that path's parent
+  directory is canonicalized and its file name appended unchanged — the
+  same pattern `FsBlobStore` uses for its root-keyed write locks, and for
+  the same reason (`Path::canonicalize` requires an existing path). A
+  resolved target whose parent directory does not exist fails minting
+  exactly as the subsequent open itself would fail — the identity layer
+  never succeeds where the open cannot. Canonicalization is what collapses aliased
   spellings — symlink vs. target, relative vs. absolute, file-level
   symlinks — into one identity, so a daemon and a session opening the same
   database through different spellings mint the same `DbIdentity`.
@@ -196,6 +205,11 @@ provides the same partitioning with an additive API.
   points at the database file), a relative spelling, and a **bare file name**
   (empty parent, resolved against the current directory) mints identical
   `DbIdentity` values and derives the identical sidecar directory.
+- Dangling-symlink first-open test: opening via a file-level symlink whose
+  target does not yet exist, then (after the target is created through the
+  link) via the target path directly, mints identical `DbIdentity` values —
+  the first-open fallback resolves the final component before
+  canonicalizing the parent.
 - Fallback-marker test: a heartbeat produced from an `Unscoped` oldest span
   carries the fallback-attribution marker; one produced from a
   `Database(main)` span does not.


### PR DESCRIPTION
One self-consistent artifact carrying both halves of the WAL-pin attribution contract revision — the ADR record contract and the design note that consumes it. Earlier rounds reviewed these as two PRs (#1170 held the note); each reviewer then saw the other document's absence and flagged a structural contradiction, so the pair is now one diff. Read the ADR section first, the note second.

**ADR-091 Amendment 3 (record contract + freshness basis):**
- Plank F1: heartbeat liveness moves to the file-mtime basis beacons already use. Per-tick refresh is a metadata-only touch; full body rewrites happen only on content change. The liveness predicate is exact and floored: live iff `enumeration_time - mtime <= 3 x max(declared sweep_interval_ms, 1000 ms)`, records self-declare cadence via `sweep_interval_ms`, undeclared records evaluate against the 5000 ms default (today's behavior), and the 1000 ms clamp keeps sub-second cadences from narrowing the window below filesystem mtime resolution. Age re-bases on `oldest_tx_started_at`, computed at read time.
- Full record lifecycle defined (create → touch → rewrite → stale → delete → recreate; no terminal state while the span is live), with fail-closed beacon recovery.
- Mixed-version rule: normative readers-before-writers (the deployment's natural order), with the bounded-window self-heal as the net for ordering violations.
- Plank F2: `attribution_basis` ("origin" | "fallback", absence unspecified) with a binding fail-closed reading rule — only the exact string "origin" licenses evidence-backed reading.

**Design note amendment (consumes the ADR contract):**
- DbIdentity minting as a three-step rule (resolve bare relatives against the current directory, canonicalize the full path when the file exists — catching file-level symlinks, parent-join fallback for not-yet-existing files); canonical vs lossless reconciled; sidecar derivation consumes the minted identity.
- `oldest_for` returns an `OldestSpan` carrying the winning span's origin so the sweep can set the attribution marker.
- Record-format authority: ADR-091 Amendment 3 (in this same diff) is the sole source of truth; the note references it without restating.
- Test plan: alias convergence (real path, directory symlink, file-level symlink, relative, bare name), fallback marker, two-pool sweep and daemon ownership, traversal coverage, non-UTF-8 identity.

Supersedes #1170, which is closed in favor of this combined artifact. The implementation PR for issue #1160 builds against this contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)