### PR TITLE
chore(policy): rank khive-pack-blob in code-audit crate_ranks

### DIFF
--- a/crates/kkernel/policy/code-audit-khive.toml
+++ b/crates/kkernel/policy/code-audit-khive.toml
@@ -55,6 +55,7 @@ khive-retrieval = 4
 khive-runtime = 4
 khive-brain-core = 5
 khive-merge = 5
+khive-pack-blob = 5
 khive-pack-code = 5
 khive-pack-comm = 5
 khive-pack-formal = 5


### PR DESCRIPTION
Adds the missing `khive-pack-blob = 5` row to the code-audit layering policy. The crate was the sole remaining POLICY_INCOMPLETE in the weekly audit: absent crates degrade their layering signal to unavailable rather than defaulting to rank 0. Rank 5 matches the other verb packs; all of its dependencies (khive-types 0, khive-storage 2, khive-db 3, khive-runtime 4) are lower-ranked, so the same-or-lower dependency rule holds. One-line data change, TOML parse verified.