### PR TITLE
feat(db): backend-scoped WAL-pin attribution (ADR-091 Amendment 3)

### DIFF
--- a/crates/khive-db/src/checkpoint.rs
+++ b/crates/khive-db/src/checkpoint.rs
@@ -643,7 +643,7 @@ struct WalpinSidecarState {
     /// heartbeat so the enumerating daemon judges freshness against the
     /// PRODUCER's interval — a session on an independently slower configured
     /// cadence must not be misread as stale.
-    interval_ms: u64,
+    sweep_interval_ms: u64,
     wrote: bool,
     /// Whether this process's registration beacon is believed present on
     /// disk. Cleared when a failed heartbeat write escalates to beacon
@@ -651,6 +651,46 @@ struct WalpinSidecarState {
     /// next healthy tick then re-registers with a full write instead of a
     /// metadata touch.
     beacon_registered: bool,
+    /// The content actually on disk in the last successful heartbeat body
+    /// write, if any (ADR-091 Amendment 3 Plank F1). `None` whenever the
+    /// next tick must go through a full write — no heartbeat written yet,
+    /// the last write failed, or the threshold cleared. Compared against
+    /// each new observation to decide touch (content unchanged) vs.
+    /// rewrite (content changed).
+    last_heartbeat: Option<LastHeartbeatState>,
+}
+
+/// ADR-091 Amendment 3 Plank F1: the content signature of the heartbeat
+/// body currently on disk, plus the `oldest_tx_started_at` value that body
+/// carries — kept separate from the signature proper because it is derived
+/// (fixed for as long as the same span stays oldest), not an independent
+/// change signal.
+struct LastHeartbeatState {
+    span_id: khive_storage::tx_registry::TxId,
+    label: Option<String>,
+    attribution_basis: &'static str,
+    sweep_interval_ms: u64,
+    oldest_tx_started_at: i64,
+}
+
+impl LastHeartbeatState {
+    /// Whether a fresh observation carries exactly the content already on
+    /// disk — the licensing condition for a metadata-only touch instead of
+    /// a full body rewrite (the first over-threshold observation, a change
+    /// of the oldest span's identity or label, a change of
+    /// `attribution_basis`, or a change of the declared sweep cadence).
+    fn content_matches(
+        &self,
+        span_id: khive_storage::tx_registry::TxId,
+        label: &Option<String>,
+        attribution_basis: &str,
+        sweep_interval_ms: u64,
+    ) -> bool {
+        self.span_id == span_id
+            && self.label == *label
+            && self.attribution_basis == attribution_basis
+            && self.sweep_interval_ms == sweep_interval_ms
+    }
 }
 
 impl WalpinSidecarState {
@@ -672,8 +712,9 @@ impl WalpinSidecarState {
             pid,
             role,
             started_at: crate::walpin::process_start_time_secs(pid).unwrap_or(0),
-            interval_ms: interval.as_millis().min(u64::MAX as u128) as u64,
+            sweep_interval_ms: interval.as_millis().min(u64::MAX as u128) as u64,
             wrote: false,
+            last_heartbeat: None,
             beacon_registered: false,
         })
     }
@@ -692,7 +733,7 @@ impl WalpinSidecarState {
             pid: self.pid,
             process_role: self.role.to_string(),
             started_at: self.started_at,
-            interval_ms: self.interval_ms,
+            sweep_interval_ms: self.sweep_interval_ms,
         };
         let result =
             tokio::task::spawn_blocking(move || crate::walpin::write_beacon(&dir, &beacon)).await;
@@ -809,14 +850,77 @@ impl WalpinSidecarState {
                     khive_storage::tx_registry::TxOrigin::Unscoped
                     | khive_storage::tx_registry::TxOrigin::Memory => "fallback",
                 };
+
+                // ADR-091 Amendment 3 Plank F1: a metadata-only mtime touch
+                // advances freshness whenever nothing content-relevant has
+                // changed since the last body write; a full rewrite happens
+                // only on the first over-threshold observation or a genuine
+                // content change.
+                let content_unchanged = self.wrote
+                    && self.last_heartbeat.as_ref().is_some_and(|last| {
+                        last.content_matches(
+                            span.id,
+                            &span.label,
+                            attribution_basis,
+                            self.sweep_interval_ms,
+                        )
+                    });
+
+                if content_unchanged {
+                    let dir = self.dir.clone();
+                    let pid = self.pid;
+                    let touch_result = tokio::task::spawn_blocking(move || {
+                        crate::walpin::touch_heartbeat(&dir, pid)
+                    })
+                    .await;
+                    match touch_result {
+                        Ok(Ok(())) => {
+                            self.refresh_beacon().await;
+                            return;
+                        }
+                        Ok(Err(e)) => {
+                            tracing::warn!(
+                                error = %e,
+                                "ADR-091 Amendment 3 Plank F1: walpin heartbeat touch failed; \
+                                 recreating with a full body write"
+                            );
+                        }
+                        Err(join_err) => {
+                            tracing::warn!(
+                                error = %join_err,
+                                "ADR-091 Amendment 3 Plank F1: walpin heartbeat touch task \
+                                 panicked; recreating with a full body write"
+                            );
+                        }
+                    }
+                    // Recovery rule: the touch path must never assume the
+                    // target still exists — enumeration can delete a slow
+                    // writer's heartbeat while its span is still live. Fall
+                    // through to the full write below unconditionally.
+                }
+
+                // The oldest span's registration instant is fixed for as
+                // long as it stays the SAME span: reuse the previously
+                // recorded value rather than re-deriving it from `now -
+                // age`, which would drift by measurement noise across ticks
+                // for no reason. A genuinely new oldest span (or the first
+                // observation) derives it fresh.
+                let oldest_tx_started_at = self
+                    .last_heartbeat
+                    .as_ref()
+                    .filter(|last| last.span_id == span.id)
+                    .map(|last| last.oldest_tx_started_at)
+                    .unwrap_or_else(|| now_epoch_secs().saturating_sub(span.age.as_secs() as i64));
+
                 let heartbeat = crate::walpin::WalpinHeartbeat {
                     pid: self.pid,
                     process_role: self.role.to_string(),
                     started_at: self.started_at,
                     oldest_tx_age_secs: span.age.as_secs_f64(),
-                    oldest_tx_label: span.label,
+                    oldest_tx_label: span.label.clone(),
+                    oldest_tx_started_at: Some(oldest_tx_started_at),
                     updated_at: now_epoch_secs(),
-                    interval_ms: self.interval_ms,
+                    sweep_interval_ms: self.sweep_interval_ms,
                     attribution_basis: Some(attribution_basis.to_string()),
                 };
                 let dir = self.dir.clone();
@@ -836,6 +940,13 @@ impl WalpinSidecarState {
                 match result {
                     Ok(Ok(())) => {
                         self.wrote = true;
+                        self.last_heartbeat = Some(LastHeartbeatState {
+                            span_id: span.id,
+                            label: span.label,
+                            attribution_basis,
+                            sweep_interval_ms: self.sweep_interval_ms,
+                            oldest_tx_started_at,
+                        });
                         self.refresh_beacon().await;
                     }
                     Ok(Err(e)) => {
@@ -845,6 +956,10 @@ impl WalpinSidecarState {
                              removing beacon so this process cannot read as \
                              registered-silent while over threshold"
                         );
+                        // Unknown what (if anything) is on disk now — the
+                        // next tick must go through a full write, never a
+                        // touch, until a write actually lands.
+                        self.last_heartbeat = None;
                         self.drop_beacon_fail_closed().await;
                     }
                     Err(join_err) => {
@@ -852,6 +967,7 @@ impl WalpinSidecarState {
                             error = %join_err,
                             "ADR-091 Amendment 2 Plank B: walpin heartbeat write task panicked"
                         );
+                        self.last_heartbeat = None;
                         self.drop_beacon_fail_closed().await;
                     }
                 }
@@ -877,6 +993,7 @@ impl WalpinSidecarState {
                         ),
                     }
                     self.wrote = false;
+                    self.last_heartbeat = None;
                 }
             }
         }
@@ -1563,9 +1680,10 @@ fn log_walpin_sidecar_report(pool: &ConnectionPool) {
         return;
     }
     let dir = crate::walpin::sidecar_dir_for(path);
-    // Each record carries its producer's own sweep cadence (`interval_ms`),
-    // which is what freshness is judged against; the interval passed here is
-    // only the fallback for records written before that field existed.
+    // Each record carries its producer's own sweep cadence
+    // (`sweep_interval_ms`), which is what freshness is judged against; the
+    // interval passed here is only the fallback for records written before
+    // that field existed.
     let sweep_interval = SessionSweepConfig::from_env().interval;
     let report = match crate::walpin::enumerate_live(&dir, sweep_interval) {
         Ok(report) => report,
@@ -4001,6 +4119,116 @@ mod tests {
             beacon_path.exists(),
             "beacon must re-register on the first healthy tick after removal"
         );
+    }
+
+    #[tokio::test]
+    #[serial(khive_walpin_sidecar_env)]
+    async fn walpin_observe_touches_mtime_without_rewriting_body_when_content_unchanged() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("observe_touch.db");
+        let sidecar_dir = crate::walpin::sidecar_dir_for(&db_path);
+        let _env_guard = crate::walpin::EnvVarGuard::capture("KHIVE_WALPIN_SIDECAR");
+        std::env::set_var("KHIVE_WALPIN_SIDECAR", "1");
+
+        let mut state = WalpinSidecarState::new(
+            Some(db_path.as_path()),
+            true,
+            "session",
+            Duration::from_millis(500),
+        )
+        .expect("sidecar enabled for a file-backed path");
+        let pid = std::process::id();
+        let heartbeat_path = sidecar_dir.join(format!("{pid}.json"));
+        let span = khive_storage::tx_registry::OldestSpan {
+            id: khive_storage::tx_registry::TxId(1),
+            age: Duration::from_secs(60),
+            label: None,
+            origin: khive_storage::tx_registry::TxOrigin::Unscoped,
+        };
+
+        state
+            .observe(Some(span.clone()), Duration::from_secs(30))
+            .await;
+        let body_after_create = std::fs::read(&heartbeat_path).expect("heartbeat written");
+
+        // Backdate the mtime so the touch is unambiguous: if `observe`
+        // rewrote the body instead of touching it, the write would also
+        // reset the mtime, making this assertion pass for the wrong reason —
+        // the body-byte comparison below is what actually distinguishes
+        // touch from rewrite.
+        let backdated = std::time::SystemTime::now() - Duration::from_secs(120);
+        std::fs::File::open(&heartbeat_path)
+            .unwrap()
+            .set_modified(backdated)
+            .unwrap();
+
+        state.observe(Some(span), Duration::from_secs(30)).await;
+
+        let body_after_second_observe =
+            std::fs::read(&heartbeat_path).expect("heartbeat still present");
+        assert_eq!(
+            body_after_create, body_after_second_observe,
+            "unchanged oldest-span identity/label/attribution/cadence must touch mtime, \
+             not rewrite the body"
+        );
+        let mtime_after = std::fs::metadata(&heartbeat_path)
+            .unwrap()
+            .modified()
+            .unwrap();
+        assert!(
+            mtime_after > backdated,
+            "the touch must advance mtime past the backdated value"
+        );
+    }
+
+    #[tokio::test]
+    #[serial(khive_walpin_sidecar_env)]
+    async fn walpin_observe_recreates_heartbeat_after_it_is_deleted_while_span_still_live() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("observe_recreate.db");
+        let sidecar_dir = crate::walpin::sidecar_dir_for(&db_path);
+        let _env_guard = crate::walpin::EnvVarGuard::capture("KHIVE_WALPIN_SIDECAR");
+        std::env::set_var("KHIVE_WALPIN_SIDECAR", "1");
+
+        let mut state = WalpinSidecarState::new(
+            Some(db_path.as_path()),
+            true,
+            "session",
+            Duration::from_millis(500),
+        )
+        .expect("sidecar enabled for a file-backed path");
+        let pid = std::process::id();
+        let heartbeat_path = sidecar_dir.join(format!("{pid}.json"));
+        let span = khive_storage::tx_registry::OldestSpan {
+            id: khive_storage::tx_registry::TxId(1),
+            age: Duration::from_secs(60),
+            label: None,
+            origin: khive_storage::tx_registry::TxOrigin::Unscoped,
+        };
+
+        state
+            .observe(Some(span.clone()), Duration::from_secs(30))
+            .await;
+        assert!(heartbeat_path.exists(), "heartbeat written on first tick");
+
+        // Simulate enumeration deleting a slow writer's heartbeat while its
+        // span is still live: the next tick still sees unchanged content
+        // (same span, same label, same attribution, same cadence) so it
+        // takes the touch path — which must detect the missing target and
+        // fall through to a full recreate rather than silently no-op.
+        std::fs::remove_file(&heartbeat_path).unwrap();
+        assert!(!heartbeat_path.exists());
+
+        state.observe(Some(span), Duration::from_secs(30)).await;
+
+        assert!(
+            heartbeat_path.exists(),
+            "a touch failure against a deleted heartbeat must recreate it via a full write"
+        );
+        let recreated: crate::walpin::WalpinHeartbeat =
+            serde_json::from_slice(&std::fs::read(&heartbeat_path).unwrap()).unwrap();
+        assert_eq!(recreated.pid, pid);
+        assert_eq!(recreated.oldest_tx_age_secs, 60.0);
     }
 
     #[tokio::test]

--- a/crates/khive-db/src/checkpoint.rs
+++ b/crates/khive-db/src/checkpoint.rs
@@ -793,19 +793,31 @@ impl WalpinSidecarState {
     /// executor thread on synchronous filesystem I/O.
     async fn observe(
         &mut self,
-        oldest: Option<(khive_storage::tx_registry::TxId, Duration, Option<String>)>,
+        oldest: Option<khive_storage::tx_registry::OldestSpan>,
         tx_warn_secs: Duration,
     ) {
         match oldest {
-            Some((_, age, label)) if age >= tx_warn_secs => {
+            Some(span) if span.age >= tx_warn_secs => {
+                // ADR-091 Amendment 3 Plank F2: the caller's `TxOriginFilter`
+                // guarantees a `Main` view's winner is either `Database` (this
+                // backend's own identity) or `Unscoped` (the fallback), and a
+                // `Secondary` view's winner is always `Database` — `Memory`
+                // can never win a filtered query, so it degrades to
+                // fallback-confidence rather than a reachability panic.
+                let attribution_basis = match span.origin {
+                    khive_storage::tx_registry::TxOrigin::Database(_) => "origin",
+                    khive_storage::tx_registry::TxOrigin::Unscoped
+                    | khive_storage::tx_registry::TxOrigin::Memory => "fallback",
+                };
                 let heartbeat = crate::walpin::WalpinHeartbeat {
                     pid: self.pid,
                     process_role: self.role.to_string(),
                     started_at: self.started_at,
-                    oldest_tx_age_secs: age.as_secs_f64(),
-                    oldest_tx_label: label,
+                    oldest_tx_age_secs: span.age.as_secs_f64(),
+                    oldest_tx_label: span.label,
                     updated_at: now_epoch_secs(),
                     interval_ms: self.interval_ms,
+                    attribution_basis: Some(attribution_basis.to_string()),
                 };
                 let dir = self.dir.clone();
                 let result = tokio::task::spawn_blocking(move || {
@@ -940,26 +952,82 @@ impl SessionSweepConfig {
     }
 }
 
-/// ADR-091 Amendment 2 Plank A: run the observe-only per-session sweep.
+/// One file-backed backend the session sweep observes (ADR-091 Amendment 3
+/// fan-out). `is_main` selects which [`khive_storage::tx_registry::TxOriginFilter`]
+/// variant scopes this backend's view of the registry: the main backend's
+/// `Main` filter additionally observes `Unscoped` spans (the
+/// never-silently-drop fallback for call sites not yet threaded to an
+/// origin); a secondary backend's `Secondary` filter is scoped to exactly
+/// its own identity. A pool whose origin is `Memory` contributes no entry —
+/// in-memory backends have no sidecar and nothing to attribute
+/// cross-process.
+pub struct SweepBackend {
+    pub pool: Arc<ConnectionPool>,
+    pub is_main: bool,
+}
+
+/// Per-backend state the session sweep carries across ticks: this backend's
+/// registry view, its own edge-triggered age-sweep state machine (so a
+/// sustained stale span on one backend logs independently of the others),
+/// and its own walpin sidecar (`None` if the sidecar is disabled or this
+/// backend's origin is `Memory`).
+struct BackendSweep {
+    filter: khive_storage::tx_registry::TxOriginFilter,
+    tx_age_state: TxAgeSweepState,
+    sidecar: Option<WalpinSidecarState>,
+}
+
+/// ADR-091 Amendment 2 Plank A (Amendment 3: per-backend fan-out): run the
+/// observe-only per-session sweep.
 ///
 /// Every non-daemon `kkernel mcp` process runs this instead of the daemon's
 /// `run_checkpoint_task`: same `tx_registry` age check and Plank B heartbeat
 /// refresh, but no PASSIVE/TRUNCATE checkpointing — checkpointing stays
-/// daemon-owned. Loops until `shutdown_rx` observes a change (or its sender
-/// is dropped), removing this process's walpin heartbeat (if written) on the
-/// way out.
+/// daemon-owned. Stays ONE task for the whole process, but fans out
+/// internally: each file-backed backend in `backends` gets its own
+/// registry view, age-sweep state, and sidecar directory, so a long span on
+/// a secondary backend is attributed (and heartbeats) only in that
+/// backend's own sidecar — never the main backend's. Loops until
+/// `shutdown_rx` observes a change (or its sender is dropped), removing
+/// every written heartbeat on the way out.
 pub async fn run_session_sweep_task(
-    db_path: Option<PathBuf>,
+    backends: Vec<SweepBackend>,
     config: SessionSweepConfig,
     mut shutdown_rx: tokio::sync::watch::Receiver<()>,
 ) {
     let mut interval = tokio::time::interval(config.interval);
     interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
-    let mut tx_age_state = TxAgeSweepState::default();
-    let mut sidecar = db_path
-        .and_then(|p| WalpinSidecarState::new(Some(p.as_path()), true, "session", config.interval));
-    if let Some(sidecar) = sidecar.as_mut() {
-        sidecar.register_beacon().await;
+
+    let mut sweeps: Vec<BackendSweep> = Vec::with_capacity(backends.len());
+    for backend in backends {
+        let identity = match backend.pool.origin() {
+            khive_storage::tx_registry::TxOrigin::Database(id) => id,
+            // No on-disk file, so no sidecar and no cross-process
+            // attribution surface — nothing for this sweep to fan out to.
+            khive_storage::tx_registry::TxOrigin::Memory
+            | khive_storage::tx_registry::TxOrigin::Unscoped => continue,
+        };
+        let filter = if backend.is_main {
+            khive_storage::tx_registry::TxOriginFilter::Main(identity)
+        } else {
+            khive_storage::tx_registry::TxOriginFilter::Secondary(identity)
+        };
+        let sidecar = WalpinSidecarState::new(
+            backend.pool.canonical_path(),
+            true,
+            "session",
+            config.interval,
+        );
+        sweeps.push(BackendSweep {
+            filter,
+            tx_age_state: TxAgeSweepState::default(),
+            sidecar,
+        });
+    }
+    for sweep in sweeps.iter_mut() {
+        if let Some(sidecar) = sweep.sidecar.as_mut() {
+            sidecar.register_beacon().await;
+        }
     }
 
     loop {
@@ -968,19 +1036,25 @@ pub async fn run_session_sweep_task(
             _ = shutdown_rx.changed() => break,
         }
 
-        let oldest = khive_storage::tx_registry::oldest();
-        for emission in
-            tx_age_state.observe(oldest.clone(), config.tx_warn_secs, config.tx_max_age_secs)
-        {
-            log_tx_age_emission(&emission);
-        }
-        if let Some(sidecar) = sidecar.as_mut() {
-            sidecar.observe(oldest, config.tx_warn_secs).await;
+        for sweep in sweeps.iter_mut() {
+            let oldest = khive_storage::tx_registry::oldest_for(&sweep.filter);
+            for emission in sweep.tx_age_state.observe(
+                oldest.as_ref().map(|s| (s.id, s.age, s.label.clone())),
+                config.tx_warn_secs,
+                config.tx_max_age_secs,
+            ) {
+                log_tx_age_emission(&emission);
+            }
+            if let Some(sidecar) = sweep.sidecar.as_mut() {
+                sidecar.observe(oldest, config.tx_warn_secs).await;
+            }
         }
     }
 
-    if let Some(sidecar) = sidecar.as_mut() {
-        sidecar.shutdown().await;
+    for sweep in sweeps.iter_mut() {
+        if let Some(sidecar) = sweep.sidecar.as_mut() {
+            sidecar.shutdown().await;
+        }
     }
 }
 
@@ -1021,6 +1095,22 @@ pub async fn run_checkpoint_task(
     // elevated" edge the ADR-094 event emission needs, so the event path
     // never has to reach into the severity state machine's private fields.
     let mut event_was_elevated = false;
+    // ADR-091 Amendment 3: this daemon's own backend-scoped view of the
+    // registry. `Main` because the checkpoint pool is (today) always the
+    // deployment's one wired backend (`checkpoint_pool_for` requires
+    // file-backed), so it must still observe legacy `Unscoped` spans from
+    // any call site not yet threaded to an origin as the designed
+    // never-silently-drop fallback. `None` only if that invariant is ever
+    // violated (an in-memory checkpoint pool) — degrades to "no open span
+    // observed" for the tick rather than panicking a long-running daemon
+    // loop on an assumed-impossible state.
+    let tx_filter = match pool.origin() {
+        khive_storage::tx_registry::TxOrigin::Database(id) => {
+            Some(khive_storage::tx_registry::TxOriginFilter::Main(id))
+        }
+        khive_storage::tx_registry::TxOrigin::Memory
+        | khive_storage::tx_registry::TxOrigin::Unscoped => None,
+    };
     // ADR-091 Amendment 2 Plank B: the checkpoint pool is only ever wired for
     // file-backed backends (`checkpoint_pool_for`), so `is_file_backed: true`
     // is always correct here. `canonical_path()` (not `pool.config().path`)
@@ -1061,9 +1151,11 @@ pub async fn run_checkpoint_task(
         // tick. Edge-triggered per rung, same debounce idiom as the severity
         // ladder below, so a sustained stale span logs once per rung rather
         // than once per tick.
-        let oldest_tx = khive_storage::tx_registry::oldest();
+        let oldest_tx = tx_filter
+            .as_ref()
+            .and_then(khive_storage::tx_registry::oldest_for);
         for emission in tx_age_state.observe(
-            oldest_tx.clone(),
+            oldest_tx.as_ref().map(|s| (s.id, s.age, s.label.clone())),
             config.tx_warn_secs,
             config.tx_max_age_secs,
         ) {
@@ -1074,7 +1166,9 @@ pub async fn run_checkpoint_task(
         // pin — if any — is attributable the same way a session's is.
         #[cfg(unix)]
         if let Some(sidecar) = walpin_state.as_mut() {
-            sidecar.observe(oldest_tx, config.tx_warn_secs).await;
+            sidecar
+                .observe(oldest_tx.clone(), config.tx_warn_secs)
+                .await;
         }
 
         // Skipped ticks leave crossing state unchanged — a busy tick must not
@@ -1088,11 +1182,12 @@ pub async fn run_checkpoint_task(
         let above_high_water = wal_pages >= config.high_water_pages;
         let above_truncate_high_water = wal_pages >= config.truncate_high_water_pages;
 
-        // Per-tick debug for the oldest open entry always fires (cheap, single
-        // `oldest()` lookup); the two `warn!`-level registry logs below are
-        // gated on the SAME crossing state as the WAL-threshold WARNs above,
-        // so sustained pressure logs once per crossing, not once per tick.
-        log_tx_registry_oldest_debug(wal_pages);
+        // Per-tick debug for the oldest open entry always fires (cheap —
+        // reuses this tick's already-computed `oldest_tx`); the two
+        // `warn!`-level registry logs below are gated on the SAME crossing
+        // state as the WAL-threshold WARNs above, so sustained pressure
+        // logs once per crossing, not once per tick.
+        log_tx_registry_oldest_debug(wal_pages, oldest_tx.as_ref());
 
         // ADR-091 severity ladder: INFO on the first below→above crossing,
         // WARN once `warn_sustained_cycles` consecutive ticks stay elevated.
@@ -1101,7 +1196,7 @@ pub async fn run_checkpoint_task(
         for emission in severity_state.observe_wal_pages(wal_pages, &config) {
             match emission.rung {
                 CheckpointSeverityRung::Info => {
-                    log_tx_registry_oldest_warn(wal_pages);
+                    log_tx_registry_oldest_warn(wal_pages, oldest_tx.as_ref());
                     tracing::info!(
                         wal_pages = emission.wal_pages,
                         warn_threshold = emission.threshold_pages,
@@ -1215,18 +1310,23 @@ async fn append_checkpoint_lifecycle_event<P: serde::Serialize>(
     }
 }
 
-/// ADR-091 Plank 0: log the oldest open transaction registry entry alongside
-/// the WAL frame count at `debug!`, on EVERY tick regardless of threshold
+/// ADR-091 Plank 0 (Amendment 3: takes the tick's already-computed,
+/// backend-scoped oldest span instead of re-querying the process-wide
+/// aggregate): log the oldest open transaction registry entry alongside the
+/// WAL frame count at `debug!`, on EVERY tick regardless of threshold
 /// state. This is the low-volume per-tick trace; the WARN-level escalations
 /// live in [`log_tx_registry_oldest_warn`] and
 /// debug-level, unconditional per-tick trace. See
 /// crates/khive-db/docs/api/checkpoint.md#private-tx-registry-logging-helpers-plank-0
-fn log_tx_registry_oldest_debug(wal_pages: u64) {
-    if let Some((_id, age, label)) = khive_storage::tx_registry::oldest() {
+fn log_tx_registry_oldest_debug(
+    wal_pages: u64,
+    oldest: Option<&khive_storage::tx_registry::OldestSpan>,
+) {
+    if let Some(span) = oldest {
         tracing::debug!(
             wal_pages,
-            oldest_tx_age_secs = age.as_secs_f64(),
-            oldest_tx_label = label.as_deref().unwrap_or("<unlabeled>"),
+            oldest_tx_age_secs = span.age.as_secs_f64(),
+            oldest_tx_label = span.label.as_deref().unwrap_or("<unlabeled>"),
             "WAL checkpoint tick: oldest open transaction registry entry"
         );
     }
@@ -1235,12 +1335,15 @@ fn log_tx_registry_oldest_debug(wal_pages: u64) {
 /// Escalates the oldest open registry entry to `warn!`. NOT internally
 /// rate-limited — caller MUST gate on a below→above `warn_pages` crossing
 /// (`crossing_warn`) or every tick reproduces the log-spam bug this fixes.
-fn log_tx_registry_oldest_warn(wal_pages: u64) {
-    if let Some((_id, age, label)) = khive_storage::tx_registry::oldest() {
+fn log_tx_registry_oldest_warn(
+    wal_pages: u64,
+    oldest: Option<&khive_storage::tx_registry::OldestSpan>,
+) {
+    if let Some(span) = oldest {
         tracing::warn!(
             wal_pages,
-            oldest_tx_age_secs = age.as_secs_f64(),
-            oldest_tx_label = label.as_deref().unwrap_or("<unlabeled>"),
+            oldest_tx_age_secs = span.age.as_secs_f64(),
+            oldest_tx_label = span.label.as_deref().unwrap_or("<unlabeled>"),
             "WAL checkpoint tick: oldest open transaction registry entry"
         );
     }
@@ -1721,12 +1824,21 @@ mod tests {
         let _handle =
             khive_storage::tx_registry::register(Some("checkpoint_tick_test".to_string()));
 
-        let expected_label = khive_storage::tx_registry::oldest()
-            .and_then(|(_, _, label)| label)
+        let oldest = khive_storage::tx_registry::oldest().map(|(id, age, label)| {
+            khive_storage::tx_registry::OldestSpan {
+                id,
+                age,
+                label,
+                origin: khive_storage::tx_registry::TxOrigin::Unscoped,
+            }
+        });
+        let expected_label = oldest
+            .as_ref()
+            .and_then(|s| s.label.clone())
             .unwrap_or_else(|| "<unlabeled>".to_string());
 
         tracing::subscriber::with_default(subscriber, || {
-            log_tx_registry_oldest_debug(100);
+            log_tx_registry_oldest_debug(100, oldest.as_ref());
         });
 
         let events = buffer.lock().unwrap();
@@ -1755,6 +1867,14 @@ mod tests {
 
         let _handle =
             khive_storage::tx_registry::register(Some("registry_warn_crossing_test".to_string()));
+        let oldest = khive_storage::tx_registry::oldest().map(|(id, age, label)| {
+            khive_storage::tx_registry::OldestSpan {
+                id,
+                age,
+                label,
+                origin: khive_storage::tx_registry::TxOrigin::Unscoped,
+            }
+        });
 
         let mut was_above_warn = false;
         let mut was_above_high_water = false;
@@ -1762,7 +1882,7 @@ mod tests {
         tracing::subscriber::with_default(subscriber, || {
             // Tick 1: below→above crossing for both bands — both WARNs fire.
             if crossing_warn(true, &mut was_above_warn) {
-                log_tx_registry_oldest_warn(6000);
+                log_tx_registry_oldest_warn(6000, oldest.as_ref());
             }
             if crossing_warn(true, &mut was_above_high_water) {
                 log_tx_registry_snapshot_warn(6000);
@@ -1770,7 +1890,7 @@ mod tests {
 
             // Tick 2: still above both thresholds — neither must repeat.
             if crossing_warn(true, &mut was_above_warn) {
-                log_tx_registry_oldest_warn(6000);
+                log_tx_registry_oldest_warn(6000, oldest.as_ref());
             }
             if crossing_warn(true, &mut was_above_high_water) {
                 log_tx_registry_snapshot_warn(6000);
@@ -3769,7 +3889,7 @@ mod tests {
             ..SessionSweepConfig::default()
         };
         let (shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(());
-        let handle = tokio::spawn(run_session_sweep_task(None, cfg, shutdown_rx));
+        let handle = tokio::spawn(run_session_sweep_task(Vec::new(), cfg, shutdown_rx));
 
         shutdown_tx.send(()).expect("send shutdown signal");
 
@@ -3825,11 +3945,12 @@ mod tests {
         std::fs::create_dir(&obstruction).unwrap();
 
         tokio::time::sleep(Duration::from_millis(20)).await;
-        let over_threshold = Some((
-            khive_storage::tx_registry::TxId(1),
-            Duration::from_secs(60),
-            None,
-        ));
+        let over_threshold = Some(khive_storage::tx_registry::OldestSpan {
+            id: khive_storage::tx_registry::TxId(1),
+            age: Duration::from_secs(60),
+            label: None,
+            origin: khive_storage::tx_registry::TxOrigin::Unscoped,
+        });
         state
             .observe(over_threshold.clone(), Duration::from_secs(30))
             .await;
@@ -3866,7 +3987,9 @@ mod tests {
     async fn session_sweep_task_writes_and_clears_walpin_heartbeat() {
         let dir = tempfile::tempdir().unwrap();
         let db_path = dir.path().join("session_sweep.db");
-        let sidecar_dir = crate::walpin::sidecar_dir_for(&db_path);
+        let pool = file_pool(&db_path);
+        let sidecar_dir =
+            crate::walpin::sidecar_dir_for(pool.canonical_path().expect("file-backed pool"));
         let _env_guard = crate::walpin::EnvVarGuard::capture("KHIVE_WALPIN_SIDECAR");
         std::env::set_var("KHIVE_WALPIN_SIDECAR", "1");
 
@@ -3877,7 +4000,10 @@ mod tests {
         };
         let (shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(());
         let handle = tokio::spawn(run_session_sweep_task(
-            Some(db_path.clone()),
+            vec![SweepBackend {
+                pool: Arc::clone(&pool),
+                is_main: true,
+            }],
             cfg,
             shutdown_rx,
         ));
@@ -3914,11 +4040,106 @@ mod tests {
             hb.oldest_tx_label.as_deref(),
             Some("session_sweep_walpin_test")
         );
+        assert_eq!(
+            hb.attribution_basis.as_deref(),
+            Some("fallback"),
+            "an Unscoped span observed only through the main view's fallback \
+             must carry attribution_basis=\"fallback\", never \"origin\""
+        );
 
         drop(tx_handle);
         assert!(
             wait_for(Duration::from_secs(2), || !heartbeat_path.exists()).await,
             "heartbeat must be removed once the stale span clears"
+        );
+
+        shutdown_tx.send(()).expect("send shutdown signal");
+        tokio::time::timeout(Duration::from_secs(1), handle)
+            .await
+            .expect("session sweep task should exit within 1s")
+            .expect("session sweep task panicked");
+    }
+
+    /// ADR-091 Amendment 3 fan-out: two file-backed pools in one process,
+    /// each its own `SweepBackend`. A span scoped to the SECONDARY pool's
+    /// own origin must produce a heartbeat only in the secondary's sidecar
+    /// — never the main backend's — and, because a `Secondary` filter never
+    /// falls back to `Unscoped`, its heartbeat carries the evidence-backed
+    /// `attribution_basis="origin"`. Uses the `graph_traverse_read` label
+    /// (`stores/graph.rs`'s `traverse`) — the design note's own example of
+    /// "the most WAL-pin-relevant span in the store" — as the registered
+    /// span's label, so this doubles as coverage that a traversal read span
+    /// surfaces correctly in a secondary backend's filtered view.
+    #[tokio::test]
+    #[serial(tx_registry, khive_walpin_sidecar_env)]
+    async fn session_sweep_fan_out_scopes_secondary_span_to_secondary_sidecar_only() {
+        let main_dir = tempfile::tempdir().unwrap();
+        let secondary_dir = tempfile::tempdir().unwrap();
+        let main_pool = file_pool(&main_dir.path().join("main.db"));
+        let secondary_pool = file_pool(&secondary_dir.path().join("secondary.db"));
+        let main_sidecar =
+            crate::walpin::sidecar_dir_for(main_pool.canonical_path().expect("file-backed"));
+        let secondary_sidecar =
+            crate::walpin::sidecar_dir_for(secondary_pool.canonical_path().expect("file-backed"));
+        let _env_guard = crate::walpin::EnvVarGuard::capture("KHIVE_WALPIN_SIDECAR");
+        std::env::set_var("KHIVE_WALPIN_SIDECAR", "1");
+
+        let cfg = SessionSweepConfig {
+            interval: Duration::from_millis(10),
+            tx_warn_secs: Duration::from_millis(20),
+            tx_max_age_secs: Duration::from_millis(500),
+        };
+        let (shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(());
+        let handle = tokio::spawn(run_session_sweep_task(
+            vec![
+                SweepBackend {
+                    pool: Arc::clone(&main_pool),
+                    is_main: true,
+                },
+                SweepBackend {
+                    pool: Arc::clone(&secondary_pool),
+                    is_main: false,
+                },
+            ],
+            cfg,
+            shutdown_rx,
+        ));
+
+        let pid = std::process::id();
+        let secondary_heartbeat = secondary_sidecar.join(format!("{pid}.json"));
+        let main_heartbeat = main_sidecar.join(format!("{pid}.json"));
+
+        let tx_handle = khive_storage::tx_registry::register_scoped(
+            Some("graph_traverse_read".to_string()),
+            secondary_pool.origin(),
+        );
+        assert!(
+            wait_for(Duration::from_secs(2), || secondary_heartbeat.exists()).await,
+            "expected a walpin heartbeat in the secondary backend's own sidecar"
+        );
+        assert!(
+            !main_heartbeat.exists(),
+            "a span scoped to the secondary backend's origin must never produce \
+             a heartbeat in the main backend's sidecar"
+        );
+
+        let body = std::fs::read_to_string(&secondary_heartbeat).unwrap();
+        let hb: crate::walpin::WalpinHeartbeat = serde_json::from_str(&body).unwrap();
+        assert_eq!(hb.oldest_tx_label.as_deref(), Some("graph_traverse_read"));
+        assert_eq!(
+            hb.attribution_basis.as_deref(),
+            Some("origin"),
+            "a Secondary-view winner is always Database-origin-backed — never fallback"
+        );
+
+        drop(tx_handle);
+        assert!(
+            wait_for(Duration::from_secs(2), || !secondary_heartbeat.exists()).await,
+            "secondary heartbeat must be removed once its span clears"
+        );
+        assert!(
+            !main_heartbeat.exists(),
+            "the main sidecar must have stayed untouched for the whole tick sequence"
         );
 
         shutdown_tx.send(()).expect("send shutdown signal");

--- a/crates/khive-db/src/checkpoint.rs
+++ b/crates/khive-db/src/checkpoint.rs
@@ -1696,12 +1696,20 @@ fn log_walpin_sidecar_report(pool: &ConnectionPool) {
             return;
         }
     };
+    let now = now_epoch_secs();
     for hb in report.reporting() {
+        // ADR-091 Amendment 3 Plank F2 fail-closed reading rule: the
+        // logger must never let a fallback-confidence entry read as live
+        // cross-process ground truth, so the confidence distinction is
+        // always emitted alongside the raw field — never inferred by the
+        // reader of this log line.
         tracing::warn!(
             walpin_pid = hb.pid,
             walpin_role = %hb.process_role,
-            walpin_oldest_tx_age_secs = hb.oldest_tx_age_secs,
+            walpin_oldest_tx_age_secs = hb.current_oldest_tx_age_secs(now),
             walpin_oldest_tx_label = hb.oldest_tx_label.as_deref().unwrap_or("<unlabeled>"),
+            walpin_attribution_basis = hb.attribution_basis.as_deref().unwrap_or("<unspecified>"),
+            walpin_attribution_evidence_backed = hb.attribution_is_evidence_backed(),
             walpin_health = "reporting",
             "ADR-091 Amendment 2 Plank B: live cross-process WAL-pin attribution report"
         );

--- a/crates/khive-db/src/checkpoint.rs
+++ b/crates/khive-db/src/checkpoint.rs
@@ -1023,14 +1023,12 @@ pub async fn run_checkpoint_task(
     let mut event_was_elevated = false;
     // ADR-091 Amendment 2 Plank B: the checkpoint pool is only ever wired for
     // file-backed backends (`checkpoint_pool_for`), so `is_file_backed: true`
-    // is always correct here.
+    // is always correct here. `canonical_path()` (not `pool.config().path`)
+    // so the sidecar directory is keyed off the same minted identity every
+    // alias of this backend's configured path converges to.
     #[cfg(unix)]
-    let mut walpin_state = WalpinSidecarState::new(
-        pool.config().path.as_deref(),
-        true,
-        "daemon",
-        config.interval,
-    );
+    let mut walpin_state =
+        WalpinSidecarState::new(pool.canonical_path(), true, "daemon", config.interval);
     #[cfg(unix)]
     if let Some(sidecar) = walpin_state.as_mut() {
         sidecar.register_beacon().await;
@@ -1442,7 +1440,7 @@ fn note_truncate_outcome(
 /// instead of silently exonerating them.
 #[cfg(unix)]
 fn log_walpin_sidecar_report(pool: &ConnectionPool) {
-    let Some(path) = pool.config().path.as_deref() else {
+    let Some(path) = pool.canonical_path() else {
         return;
     };
     if !crate::walpin::sidecar_enabled(true) {

--- a/crates/khive-db/src/checkpoint.rs
+++ b/crates/khive-db/src/checkpoint.rs
@@ -4170,6 +4170,172 @@ mod tests {
             .expect("session sweep task panicked");
     }
 
+    /// ADR-091 Amendment 3: a `run_checkpoint_task` instance for backend A
+    /// (`is_main: false`, a `Secondary` filter scoped to A's own identity)
+    /// must never observe a span registered against a DIFFERENT backend's
+    /// `Database` origin, nor an `Unscoped` span — a `Secondary` filter never
+    /// falls back to `Unscoped` (that fallback is the main view's alone).
+    /// Drives the real task for several ticks and asserts neither the
+    /// captured `tracing` emissions nor backend A's own sidecar ever name
+    /// either span.
+    #[tokio::test]
+    #[serial(tx_registry, checkpoint_skip_metrics, khive_walpin_sidecar_env)]
+    async fn checkpoint_task_ignores_span_registered_against_other_backend_origin_and_unscoped() {
+        let dir_a = tempfile::tempdir().unwrap();
+        let dir_b = tempfile::tempdir().unwrap();
+        let pool_a = file_pool(&dir_a.path().join("backend_a.db"));
+        // Only used to mint a real, distinct `DbIdentity` for backend B — no
+        // checkpoint task is spawned for it.
+        let pool_b = file_pool(&dir_b.path().join("backend_b.db"));
+        let sidecar_a =
+            crate::walpin::sidecar_dir_for(pool_a.canonical_path().expect("file-backed"));
+        let _env_guard = crate::walpin::EnvVarGuard::capture("KHIVE_WALPIN_SIDECAR");
+        std::env::set_var("KHIVE_WALPIN_SIDECAR", "1");
+
+        let buffer = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+        let subscriber = CaptureSubscriber {
+            events: std::sync::Arc::clone(&buffer),
+        };
+        let _tracing_guard = tracing::subscriber::set_default(subscriber);
+
+        let _b_origin_handle = khive_storage::tx_registry::register_scoped(
+            Some("b_origin_span_ignored_by_a".to_string()),
+            pool_b.origin(),
+        );
+        let _unscoped_handle = khive_storage::tx_registry::register(Some(
+            "unscoped_span_ignored_by_secondary".to_string(),
+        ));
+
+        let cfg = CheckpointConfig {
+            interval: Duration::from_millis(10),
+            tx_warn_secs: Duration::from_millis(1),
+            tx_max_age_secs: Duration::from_millis(1),
+            ..CheckpointConfig::default()
+        };
+        let (shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(());
+        let handle = tokio::spawn(run_checkpoint_task(
+            pool_a,
+            cfg,
+            None,
+            "local".to_string(),
+            shutdown_rx,
+            false, // is_main: backend A is a secondary backend here
+        ));
+
+        // No positive condition to poll for — this asserts an absence over a
+        // bounded run of several ticks, mirroring
+        // `checkpoint_task_emits_no_age_alert_for_an_empty_registry`'s same
+        // fixed-window shape (there is nothing to wait-until for a negative).
+        tokio::time::sleep(Duration::from_millis(60)).await;
+        shutdown_tx.send(()).expect("send shutdown signal");
+        tokio::time::timeout(Duration::from_secs(1), handle)
+            .await
+            .expect("checkpoint task should exit within 1s")
+            .expect("checkpoint task panicked");
+
+        let events = buffer.lock().unwrap();
+        assert!(
+            events.iter().all(|e| {
+                e.tx_label.as_deref() != Some("b_origin_span_ignored_by_a")
+                    && e.tx_label.as_deref() != Some("unscoped_span_ignored_by_secondary")
+            }),
+            "backend A's Secondary filter must never emit an age alert naming a span \
+             registered against a different backend's origin or an Unscoped span, got: \
+             {events:?}"
+        );
+        assert!(
+            !sidecar_a
+                .join(format!("{}.json", std::process::id()))
+                .exists(),
+            "backend A's own sidecar must never gain a heartbeat from a span it does not own"
+        );
+    }
+
+    /// ADR-091 Amendment 3: a secondary backend's own `run_checkpoint_task`
+    /// must detect a stall on its OWN backend (never main-only ownership) —
+    /// both the Plank 1 age-sweep emission and the sidecar heartbeat, with
+    /// `attribution_basis="origin"` (a `Secondary` filter winner is always
+    /// `Database`-origin-backed, never the `Unscoped` fallback) and a
+    /// nonzero reflected age.
+    #[tokio::test]
+    #[serial(tx_registry, checkpoint_skip_metrics, khive_walpin_sidecar_env)]
+    async fn checkpoint_task_detects_and_enumerates_secondary_backend_stall() {
+        let dir = tempfile::tempdir().unwrap();
+        let pool = file_pool(&dir.path().join("secondary_stall.db"));
+        let sidecar_dir =
+            crate::walpin::sidecar_dir_for(pool.canonical_path().expect("file-backed"));
+        let _env_guard = crate::walpin::EnvVarGuard::capture("KHIVE_WALPIN_SIDECAR");
+        std::env::set_var("KHIVE_WALPIN_SIDECAR", "1");
+
+        let buffer = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+        let subscriber = CaptureSubscriber {
+            events: std::sync::Arc::clone(&buffer),
+        };
+        let _tracing_guard = tracing::subscriber::set_default(subscriber);
+
+        let tx_handle = khive_storage::tx_registry::register_scoped(
+            Some("secondary_stall_test".to_string()),
+            pool.origin(),
+        );
+
+        let cfg = CheckpointConfig {
+            interval: Duration::from_millis(10),
+            tx_warn_secs: Duration::from_millis(5),
+            tx_max_age_secs: Duration::from_millis(500),
+            ..CheckpointConfig::default()
+        };
+        let (shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(());
+        let pid = std::process::id();
+        let heartbeat_path = sidecar_dir.join(format!("{pid}.json"));
+        let handle = tokio::spawn(run_checkpoint_task(
+            pool,
+            cfg,
+            None,
+            "local".to_string(),
+            shutdown_rx,
+            false, // is_main: this is a secondary backend's own checkpoint task
+        ));
+
+        assert!(
+            wait_for(Duration::from_secs(2), || heartbeat_path.exists()).await,
+            "expected a walpin heartbeat once the secondary backend's own span crossed \
+             tx_warn_secs"
+        );
+        let body = std::fs::read_to_string(&heartbeat_path).unwrap();
+        let hb: crate::walpin::WalpinHeartbeat = serde_json::from_str(&body).unwrap();
+        assert_eq!(hb.oldest_tx_label.as_deref(), Some("secondary_stall_test"));
+        assert_eq!(
+            hb.attribution_basis.as_deref(),
+            Some("origin"),
+            "a Secondary-view winner is always Database-origin-backed — never fallback"
+        );
+        assert!(
+            hb.oldest_tx_age_secs > 0.0,
+            "the heartbeat must reflect a nonzero stale age for the secondary backend's own \
+             span, got {hb:?}"
+        );
+
+        shutdown_tx.send(()).expect("send shutdown signal");
+        tokio::time::timeout(Duration::from_secs(1), handle)
+            .await
+            .expect("checkpoint task should exit within 1s")
+            .expect("checkpoint task panicked");
+
+        drop(tx_handle);
+
+        let events = buffer.lock().unwrap();
+        assert!(
+            events.iter().any(|e| {
+                e.tx_label.as_deref() == Some("secondary_stall_test")
+                    && e.message
+                        .as_deref()
+                        .is_some_and(|m| m.contains("ADR-091 Plank 1"))
+            }),
+            "expected the secondary backend's own checkpoint task to emit a Plank 1 age alert \
+             for its own stalled span, got: {events:?}"
+        );
+    }
+
     #[test]
     fn wal_pin_depth_arithmetic_against_real_connection() {
         let dir = tempfile::tempdir().unwrap();

--- a/crates/khive-db/src/checkpoint.rs
+++ b/crates/khive-db/src/checkpoint.rs
@@ -1077,12 +1077,20 @@ pub async fn run_session_sweep_task(
 /// plus one drain row when pressure falls back below `warn_pages`. `None` is
 /// a no-op. See `crates/khive-db/docs/api/checkpoint.md` for the full
 /// shutdown-mechanism and event-emission design history.
+///
+/// `is_main` (ADR-091 Amendment 3): whether `pool` is the deployment's main
+/// backend. A daemon owning several file-backed backends spawns one task per
+/// backend, each with its own pool and shutdown-channel clone (the sender
+/// broadcasts to every receiver clone alike); exactly one of those calls
+/// passes `true`. See the `tx_filter` construction below for what this
+/// selects.
 pub async fn run_checkpoint_task(
     pool: Arc<ConnectionPool>,
     config: CheckpointConfig,
     event_store: Option<Arc<dyn khive_storage::EventStore>>,
     namespace: String,
     mut shutdown_rx: tokio::sync::watch::Receiver<()>,
+    is_main: bool,
 ) {
     let mut interval = tokio::time::interval(config.interval);
     interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
@@ -1095,19 +1103,24 @@ pub async fn run_checkpoint_task(
     // elevated" edge the ADR-094 event emission needs, so the event path
     // never has to reach into the severity state machine's private fields.
     let mut event_was_elevated = false;
-    // ADR-091 Amendment 3: this daemon's own backend-scoped view of the
-    // registry. `Main` because the checkpoint pool is (today) always the
-    // deployment's one wired backend (`checkpoint_pool_for` requires
-    // file-backed), so it must still observe legacy `Unscoped` spans from
-    // any call site not yet threaded to an origin as the designed
-    // never-silently-drop fallback. `None` only if that invariant is ever
-    // violated (an in-memory checkpoint pool) — degrades to "no open span
-    // observed" for the tick rather than panicking a long-running daemon
-    // loop on an assumed-impossible state.
+    // ADR-091 Amendment 3: this task's own backend-scoped view of the
+    // registry. `is_main` selects which `TxOriginFilter` variant applies —
+    // the caller passes `true` for exactly the one checkpoint task covering
+    // the deployment's main backend, so only that task also observes legacy
+    // `Unscoped` spans from any call site not yet threaded to an origin, the
+    // designed never-silently-drop fallback. A secondary backend's task
+    // never falls back to `Unscoped`: those spans belong to the main view or
+    // to no view, never to a database they were never registered against.
+    // `None` only when this pool's own origin isn't `Database` (an in-memory
+    // checkpoint pool) — degrades to "no open span observed" for the tick
+    // rather than panicking a long-running daemon loop on an
+    // assumed-impossible state.
     let tx_filter = match pool.origin() {
-        khive_storage::tx_registry::TxOrigin::Database(id) => {
-            Some(khive_storage::tx_registry::TxOriginFilter::Main(id))
-        }
+        khive_storage::tx_registry::TxOrigin::Database(id) => Some(if is_main {
+            khive_storage::tx_registry::TxOriginFilter::Main(id)
+        } else {
+            khive_storage::tx_registry::TxOriginFilter::Secondary(id)
+        }),
         khive_storage::tx_registry::TxOrigin::Memory
         | khive_storage::tx_registry::TxOrigin::Unscoped => None,
     };
@@ -2054,6 +2067,7 @@ mod tests {
             None,
             "local".to_string(),
             shutdown_rx,
+            true,
         ));
 
         shutdown_tx.send(()).expect("send shutdown signal");
@@ -2098,6 +2112,7 @@ mod tests {
             Some(event_store),
             "local".to_string(),
             shutdown_rx,
+            true,
         ));
 
         // Confirm strong_count is well above 1 — the old check would spin
@@ -3576,6 +3591,7 @@ mod tests {
             Some(store_dyn),
             "local".to_string(),
             shutdown_rx,
+            true,
         ));
 
         tokio::time::sleep(Duration::from_millis(60)).await;
@@ -3626,6 +3642,7 @@ mod tests {
             Some(store_dyn),
             "local".to_string(),
             shutdown_rx,
+            true,
         ));
 
         tokio::time::sleep(Duration::from_millis(60)).await;
@@ -3661,6 +3678,7 @@ mod tests {
             None,
             "local".to_string(),
             shutdown_rx,
+            true,
         ));
 
         tokio::time::sleep(Duration::from_millis(40)).await;
@@ -3721,6 +3739,7 @@ mod tests {
             None,
             "local".to_string(),
             shutdown_rx,
+            true,
         ));
 
         tokio::time::sleep(Duration::from_millis(60)).await;
@@ -3775,6 +3794,7 @@ mod tests {
             None,
             "local".to_string(),
             shutdown_rx,
+            true,
         ));
 
         tokio::time::sleep(Duration::from_millis(40)).await;
@@ -3846,6 +3866,7 @@ mod tests {
             None,
             "local".to_string(),
             shutdown_rx,
+            true,
         ));
 
         // Several 10ms intervals, every one of them writer-busy.

--- a/crates/khive-db/src/lib.rs
+++ b/crates/khive-db/src/lib.rs
@@ -30,7 +30,7 @@ pub mod writer_task;
 
 pub use backend::StorageBackend;
 pub use checkpoint::{checkpoint_once, run_checkpoint_task, CheckpointConfig, CheckpointTick};
-pub use checkpoint::{run_session_sweep_task, SessionSweepConfig};
+pub use checkpoint::{run_session_sweep_task, SessionSweepConfig, SweepBackend};
 pub use error::SqliteError;
 pub use migrations::{
     inspect_schema_version, query_embedding_models, read_schema_version, run_migrations,

--- a/crates/khive-db/src/pool.rs
+++ b/crates/khive-db/src/pool.rs
@@ -1184,6 +1184,87 @@ mod tests {
         assert_eq!(via_real, via_bare_name);
     }
 
+    /// ADR-091 backend-scoped attribution: `DbIdentity`/canonical-path
+    /// equality across alias spellings (proven above by
+    /// `mint_db_identity_alias_convergence`) does not by itself prove the
+    /// walpin sidecar re-key — `sidecar_dir_for` is a separate, purely
+    /// lexical derivation (`walpin::sidecar_dir_for`) that must be fed the
+    /// *minted* canonical path, never the raw configured one. This test
+    /// opens a real `ConnectionPool` (not the private `mint_db_identity` free
+    /// function) through each alias spelling and asserts
+    /// `sidecar_dir_for(pool.canonical_path())` converges to one directory —
+    /// exercising the actual `ConnectionPool::new` → `canonical_path()` wiring
+    /// every sidecar consumer (`checkpoint.rs`) reads from.
+    #[test]
+    #[serial(pool_cwd)]
+    fn sidecar_dir_for_alias_convergence() {
+        let dir = tempfile::tempdir().unwrap();
+        let real_dir = dir.path().join("real");
+        fs::create_dir(&real_dir).unwrap();
+        let db_path = real_dir.join("khive.db");
+        fs::write(&db_path, b"").unwrap();
+
+        let dir_symlink = dir.path().join("dir_link");
+        let file_symlink = dir.path().join("file_link.db");
+        #[cfg(unix)]
+        {
+            std::os::unix::fs::symlink(&real_dir, &dir_symlink).unwrap();
+            std::os::unix::fs::symlink(&db_path, &file_symlink).unwrap();
+        }
+
+        let pool_for = |path: &Path| -> Arc<ConnectionPool> {
+            let cfg = PoolConfig {
+                path: Some(path.to_path_buf()),
+                ..PoolConfig::default()
+            };
+            Arc::new(ConnectionPool::new(cfg).expect("file-backed pool should open"))
+        };
+        let sidecar_of = |pool: &ConnectionPool| -> PathBuf {
+            crate::walpin::sidecar_dir_for(pool.canonical_path().expect("file-backed pool"))
+        };
+
+        let via_real = pool_for(&db_path);
+        let sidecar_real = sidecar_of(&via_real);
+
+        let orig_cwd = std::env::current_dir().unwrap();
+        std::env::set_current_dir(&real_dir).unwrap();
+        let via_relative = pool_for(Path::new("khive.db"));
+        std::env::set_current_dir(&orig_cwd).unwrap();
+        assert_eq!(
+            sidecar_real,
+            sidecar_of(&via_relative),
+            "a relative spelling of the same database must derive the same sidecar directory"
+        );
+
+        #[cfg(unix)]
+        {
+            let via_dir_symlink = pool_for(&dir_symlink.join("khive.db"));
+            assert_eq!(
+                sidecar_real,
+                sidecar_of(&via_dir_symlink),
+                "opening through a directory symlink must derive the same sidecar directory"
+            );
+
+            let via_file_symlink = pool_for(&file_symlink);
+            assert_eq!(
+                sidecar_real,
+                sidecar_of(&via_file_symlink),
+                "opening through a file-level symlink must derive the same sidecar directory"
+            );
+        }
+
+        let orig_cwd = std::env::current_dir().unwrap();
+        std::env::set_current_dir(&real_dir).unwrap();
+        let via_bare_name = pool_for(Path::new("khive.db"));
+        std::env::set_current_dir(orig_cwd).unwrap();
+        assert_eq!(
+            sidecar_real,
+            sidecar_of(&via_bare_name),
+            "a bare file name resolved against the current directory must derive the same \
+             sidecar directory"
+        );
+    }
+
     /// ADR-091 backend-scoped attribution: opening via a file-level symlink
     /// whose target does not exist yet (a valid first-open state), then
     /// after the target is created, opening via the target path directly,

--- a/crates/khive-db/src/pool.rs
+++ b/crates/khive-db/src/pool.rs
@@ -213,6 +213,10 @@ impl<'pool> Drop for ReaderGuard<'pool> {
 /// The Mutex ensures only one writer at a time.
 pub struct WriterGuard<'pool> {
     guard: parking_lot::MutexGuard<'pool, Connection>,
+    /// The origin (ADR-091 backend-scoped attribution) of the pool this
+    /// guard was checked out from, carried so `transaction` can register its
+    /// span with the correct origin without holding a `&ConnectionPool`.
+    origin: TxOrigin,
 }
 
 impl<'pool> WriterGuard<'pool> {
@@ -233,7 +237,10 @@ impl<'pool> WriterGuard<'pool> {
         F: FnOnce(&Connection) -> Result<R, SqliteError>,
     {
         self.guard.execute_batch("BEGIN IMMEDIATE")?;
-        let _tx_handle = khive_storage::tx_registry::register(Some("writer_guard_tx".to_string()));
+        let _tx_handle = khive_storage::tx_registry::register_scoped(
+            Some("writer_guard_tx".to_string()),
+            self.origin.clone(),
+        );
 
         match f(&self.guard) {
             Ok(result) => {
@@ -383,7 +390,10 @@ impl ConnectionPool {
                     self.config.checkout_timeout
                 ))
             })?;
-        Ok(WriterGuard { guard })
+        Ok(WriterGuard {
+            guard,
+            origin: self.origin(),
+        })
     }
 
     /// Non-panicking writer checkout.
@@ -408,7 +418,10 @@ impl ConnectionPool {
                 "writer connection busy (checkpoint skipped this tick)".to_string(),
             )
         })?;
-        Ok(WriterGuard { guard })
+        Ok(WriterGuard {
+            guard,
+            origin: self.origin(),
+        })
     }
 
     /// Get the current number of available reader connections.

--- a/crates/khive-db/src/pool.rs
+++ b/crates/khive-db/src/pool.rs
@@ -910,6 +910,28 @@ mod tests {
     use super::*;
     use serial_test::serial;
 
+    /// Restores the process CWD on drop — including on panic — so a mid-test
+    /// assertion failure (or an unexpected panic from the code under test)
+    /// can never leave the process chdir'd into a `tempfile::tempdir()` that
+    /// unwinds out from under every later test sharing this process.
+    struct CwdGuard {
+        original: PathBuf,
+    }
+
+    impl CwdGuard {
+        fn enter(dir: &Path) -> Self {
+            let original = std::env::current_dir().unwrap();
+            std::env::set_current_dir(dir).unwrap();
+            Self { original }
+        }
+    }
+
+    impl Drop for CwdGuard {
+        fn drop(&mut self) {
+            let _ = std::env::set_current_dir(&self.original);
+        }
+    }
+
     #[test]
     #[serial]
     fn pool_config_default_values_match_constants() {
@@ -1150,10 +1172,10 @@ mod tests {
         let (via_real, canonical_real) = mint_db_identity(&db_path).unwrap();
 
         // Relative spelling: resolved against the process CWD (step 1).
-        let orig_cwd = std::env::current_dir().unwrap();
-        std::env::set_current_dir(&real_dir).unwrap();
-        let relative_result = mint_db_identity(&PathBuf::from("khive.db"));
-        std::env::set_current_dir(&orig_cwd).unwrap();
+        let relative_result = {
+            let _cwd = CwdGuard::enter(&real_dir);
+            mint_db_identity(&PathBuf::from("khive.db"))
+        };
         let (via_relative, canonical_relative) = relative_result.unwrap();
         assert_eq!(canonical_real, canonical_relative);
         assert_eq!(via_real, via_relative);
@@ -1172,14 +1194,11 @@ mod tests {
         }
 
         // Bare file name: resolved against the current directory (step 1).
-        let orig_cwd = std::env::current_dir().unwrap();
-        std::env::set_current_dir(&real_dir).unwrap();
-        let (via_bare_name, canonical_bare_name) = mint_db_identity(&PathBuf::from("khive.db"))
-            .inspect_err(|_| {
-                std::env::set_current_dir(&orig_cwd).unwrap();
-            })
-            .unwrap();
-        std::env::set_current_dir(orig_cwd).unwrap();
+        let bare_name_result = {
+            let _cwd = CwdGuard::enter(&real_dir);
+            mint_db_identity(&PathBuf::from("khive.db"))
+        };
+        let (via_bare_name, canonical_bare_name) = bare_name_result.unwrap();
         assert_eq!(canonical_real, canonical_bare_name);
         assert_eq!(via_real, via_bare_name);
     }
@@ -1226,10 +1245,10 @@ mod tests {
         let via_real = pool_for(&db_path);
         let sidecar_real = sidecar_of(&via_real);
 
-        let orig_cwd = std::env::current_dir().unwrap();
-        std::env::set_current_dir(&real_dir).unwrap();
-        let via_relative = pool_for(Path::new("khive.db"));
-        std::env::set_current_dir(&orig_cwd).unwrap();
+        let via_relative = {
+            let _cwd = CwdGuard::enter(&real_dir);
+            pool_for(Path::new("khive.db"))
+        };
         assert_eq!(
             sidecar_real,
             sidecar_of(&via_relative),
@@ -1253,10 +1272,10 @@ mod tests {
             );
         }
 
-        let orig_cwd = std::env::current_dir().unwrap();
-        std::env::set_current_dir(&real_dir).unwrap();
-        let via_bare_name = pool_for(Path::new("khive.db"));
-        std::env::set_current_dir(orig_cwd).unwrap();
+        let via_bare_name = {
+            let _cwd = CwdGuard::enter(&real_dir);
+            pool_for(Path::new("khive.db"))
+        };
         assert_eq!(
             sidecar_real,
             sidecar_of(&via_bare_name),

--- a/crates/khive-db/src/pool.rs
+++ b/crates/khive-db/src/pool.rs
@@ -2,6 +2,7 @@
 use crossbeam_queue::ArrayQueue;
 use parking_lot::Mutex;
 use rusqlite::{Connection, OpenFlags};
+use std::fs;
 use std::ops::{Deref, DerefMut};
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, OnceLock};
@@ -11,6 +12,7 @@ use std::time::{Duration, Instant};
 use crate::error::SqliteError;
 use crate::writer_task::WriterTaskHandle;
 use khive_storage::error::StorageError;
+use khive_storage::tx_registry::{DbIdentity, TxOrigin};
 
 const CACHE_SIZE_KIB: &str = "-65536";
 const MMAP_SIZE_BYTES: &str = "1073741824";
@@ -139,6 +141,18 @@ pub struct ConnectionPool {
     /// see that method's doc comment for why this lives here rather than on
     /// each store.
     writer_task: OnceLock<Option<WriterTaskHandle>>,
+    /// This pool's ADR-091 backend-scoped attribution origin, minted exactly
+    /// once at construction (see [`mint_db_identity`]): `Database(_)` for a
+    /// file-backed pool, `Memory` for an in-memory pool. Every
+    /// `tx_registry::register_scoped` call site in this crate reaches its
+    /// origin through [`Self::origin`] rather than re-deriving it.
+    origin: TxOrigin,
+    /// The canonical path `origin`'s `DbIdentity` was minted from, `None` for
+    /// an in-memory pool. `DbIdentity` is deliberately opaque (no path
+    /// accessor) — filesystem consumers that need the actual path (sidecar
+    /// derivation) use this, the same canonical value the identity was
+    /// minted from, via [`Self::canonical_path`].
+    identity_path: Option<PathBuf>,
     /// Test-only instrumentation: counts how many times the writer-task
     /// init closure actually ran. Must never exceed 1 per pool no matter how
     /// many stores are constructed over it — that is the invariant
@@ -266,12 +280,22 @@ impl ConnectionPool {
 
         let readers = ArrayQueue::new(max_readers.max(1));
 
+        let (origin, identity_path) = match config.path.as_ref() {
+            Some(path) => {
+                let (identity, canonical) = mint_db_identity(path)?;
+                (TxOrigin::Database(identity), Some(canonical))
+            }
+            None => (TxOrigin::Memory, None),
+        };
+
         let pool = Self {
             writer: Arc::new(Mutex::new(writer)),
             readers,
             max_readers,
             config,
             writer_task: OnceLock::new(),
+            origin,
+            identity_path,
             #[cfg(test)]
             writer_task_spawn_count: std::sync::atomic::AtomicUsize::new(0),
         };
@@ -400,6 +424,24 @@ impl ConnectionPool {
     /// Return the pool configuration.
     pub fn config(&self) -> &PoolConfig {
         &self.config
+    }
+
+    /// This pool's ADR-091 backend-scoped attribution origin (ADR-091,
+    /// backend-scoped WAL-pin attribution design note): `Database(_)` for a
+    /// file-backed pool, `Memory` for an in-memory pool. Every
+    /// `tx_registry::register_scoped` call site threaded in this crate
+    /// passes this value as the span's origin.
+    pub fn origin(&self) -> TxOrigin {
+        self.origin.clone()
+    }
+
+    /// The canonical path this pool's `origin()` identity was minted from,
+    /// `None` for an in-memory pool. `DbIdentity` has no path accessor by
+    /// design; sidecar derivation and other filesystem consumers use this —
+    /// the same canonical value the identity was minted from — instead of
+    /// re-deriving a path from the raw configured one.
+    pub fn canonical_path(&self) -> Option<&Path> {
+        self.identity_path.as_deref()
     }
 
     /// Return the pool-wide ADR-067 Component A writer task, spawning it
@@ -567,6 +609,129 @@ impl ConnectionPool {
             }
         }
     }
+}
+
+/// Bound on the final-component symlink chain [`resolve_symlink_chain`]
+/// follows before failing loud, mirroring the OS's own loop limit (e.g.
+/// Linux/macOS `ELOOP`, commonly 40 hops) rather than looping forever on a
+/// cycle.
+const MAX_SYMLINK_DEPTH: u32 = 40;
+
+/// Mint the canonical [`DbIdentity`] for a configured database path.
+///
+/// The sole minting point (ADR-091 backend-scoped attribution design note):
+/// `tx_registry` origin threading and `sidecar_dir_for` re-keying both
+/// consume this function's output rather than re-deriving it. Operationally
+/// three steps:
+///
+/// 1. A relative configured path is resolved against the process's current
+///    directory BEFORE any canonicalization — a bare file name has an empty
+///    parent, and canonicalizing an empty path fails.
+/// 2. If the resolved path exists, canonicalize the full path: this
+///    resolves symlinks at every level, including a symlink at the
+///    database-file level itself (a `link.sqlite` pointing at the real file
+///    mints the target's identity).
+/// 3. If the resolved path does not yet exist (first open), a dangling
+///    file-level symlink is a valid first-open state — SQLite creates the
+///    target through the link on first write, and minting the link's own
+///    name would diverge from a later opener using the target path
+///    directly. The final-component symlink chain is followed to its
+///    ultimate target first (bounded, see [`MAX_SYMLINK_DEPTH`]), then that
+///    target's PARENT directory is canonicalized and the file name is
+///    appended unchanged — the same pattern `FsBlobStore` uses for its
+///    root-keyed write locks (`stores/blob.rs::write_lock_for_root`), and
+///    for the same reason: `Path::canonicalize` requires an existing path.
+///
+/// A resolved target whose parent directory does not exist fails minting
+/// exactly as the subsequent database open itself would fail.
+///
+/// Returns the minted [`DbIdentity`] alongside the canonical [`PathBuf`] it
+/// was built from — `DbIdentity` has no path accessor by design, so callers
+/// that need the filesystem path (sidecar derivation) keep this pairing
+/// rather than re-deriving it from the raw configured path.
+fn mint_db_identity(configured_path: &Path) -> Result<(DbIdentity, PathBuf), SqliteError> {
+    let absolute = if configured_path.is_absolute() {
+        configured_path.to_path_buf()
+    } else {
+        let cwd = std::env::current_dir().map_err(|e| {
+            SqliteError::InvalidData(format!(
+                "cannot mint database identity for {configured_path:?}: failed to resolve the \
+                 process current directory: {e}"
+            ))
+        })?;
+        cwd.join(configured_path)
+    };
+
+    if absolute.exists() {
+        let canonical = absolute.canonicalize().map_err(|e| {
+            SqliteError::InvalidData(format!(
+                "cannot mint database identity: failed to canonicalize existing path \
+                 {absolute:?}: {e}"
+            ))
+        })?;
+        return Ok((
+            DbIdentity::new(canonical.clone().into_os_string()),
+            canonical,
+        ));
+    }
+
+    let resolved_target = resolve_symlink_chain(&absolute)?;
+    let parent = resolved_target.parent().ok_or_else(|| {
+        SqliteError::InvalidData(format!(
+            "cannot mint database identity for {resolved_target:?}: path has no parent \
+             directory"
+        ))
+    })?;
+    let file_name = resolved_target.file_name().ok_or_else(|| {
+        SqliteError::InvalidData(format!(
+            "cannot mint database identity for {resolved_target:?}: path has no file name"
+        ))
+    })?;
+    let canonical_parent = parent.canonicalize().map_err(|e| {
+        SqliteError::InvalidData(format!(
+            "cannot mint database identity: parent directory {parent:?} of first-open path \
+             {resolved_target:?} does not exist or is inaccessible: {e}"
+        ))
+    })?;
+    let mut identity_path = canonical_parent;
+    identity_path.push(file_name);
+    Ok((
+        DbIdentity::new(identity_path.clone().into_os_string()),
+        identity_path,
+    ))
+}
+
+/// Follow a (possibly dangling) final-component symlink chain to its
+/// ultimate target, bounded at [`MAX_SYMLINK_DEPTH`] hops. A path that is
+/// not itself a symlink — including one that does not exist at all —
+/// returns unchanged on the first iteration; this is the common case, a
+/// first-open path with no symlink involved.
+fn resolve_symlink_chain(path: &Path) -> Result<PathBuf, SqliteError> {
+    let mut current = path.to_path_buf();
+    for _ in 0..MAX_SYMLINK_DEPTH {
+        match fs::symlink_metadata(&current) {
+            Ok(meta) if meta.file_type().is_symlink() => {
+                let target = fs::read_link(&current).map_err(|e| {
+                    SqliteError::InvalidData(format!(
+                        "cannot mint database identity: failed to read symlink {current:?}: {e}"
+                    ))
+                })?;
+                current = if target.is_absolute() {
+                    target
+                } else {
+                    match current.parent() {
+                        Some(parent) => parent.join(&target),
+                        None => target,
+                    }
+                };
+            }
+            _ => return Ok(current),
+        }
+    }
+    Err(SqliteError::InvalidData(format!(
+        "cannot mint database identity for {path:?}: symlink chain exceeds \
+         {MAX_SYMLINK_DEPTH} levels"
+    )))
 }
 
 fn effective_reader_count(config: &PoolConfig, wal_enabled: bool) -> usize {
@@ -946,5 +1111,134 @@ mod tests {
             0,
             "the guard must reject before ever attempting tokio::spawn"
         );
+    }
+
+    /// ADR-091 backend-scoped attribution: the real path, a directory
+    /// symlink, a file-level symlink, a relative spelling, and a bare file
+    /// name (resolved against the current directory) must all mint an
+    /// identical `DbIdentity` and canonical path for the same database.
+    #[test]
+    #[serial(pool_cwd)]
+    fn mint_db_identity_alias_convergence() {
+        let dir = tempfile::tempdir().unwrap();
+        let real_dir = dir.path().join("real");
+        fs::create_dir(&real_dir).unwrap();
+        let db_path = real_dir.join("khive.db");
+        fs::write(&db_path, b"").unwrap();
+
+        let dir_symlink = dir.path().join("dir_link");
+        let file_symlink = dir.path().join("file_link.db");
+        #[cfg(unix)]
+        {
+            std::os::unix::fs::symlink(&real_dir, &dir_symlink).unwrap();
+            std::os::unix::fs::symlink(&db_path, &file_symlink).unwrap();
+        }
+
+        let (via_real, canonical_real) = mint_db_identity(&db_path).unwrap();
+
+        // Relative spelling: resolved against the process CWD (step 1).
+        let orig_cwd = std::env::current_dir().unwrap();
+        std::env::set_current_dir(&real_dir).unwrap();
+        let relative_result = mint_db_identity(&PathBuf::from("khive.db"));
+        std::env::set_current_dir(&orig_cwd).unwrap();
+        let (via_relative, canonical_relative) = relative_result.unwrap();
+        assert_eq!(canonical_real, canonical_relative);
+        assert_eq!(via_real, via_relative);
+
+        #[cfg(unix)]
+        {
+            let (via_dir_symlink, canonical_dir_symlink) =
+                mint_db_identity(&dir_symlink.join("khive.db")).unwrap();
+            assert_eq!(canonical_real, canonical_dir_symlink);
+            assert_eq!(via_real, via_dir_symlink);
+
+            let (via_file_symlink, canonical_file_symlink) =
+                mint_db_identity(&file_symlink).unwrap();
+            assert_eq!(canonical_real, canonical_file_symlink);
+            assert_eq!(via_real, via_file_symlink);
+        }
+
+        // Bare file name: resolved against the current directory (step 1).
+        let orig_cwd = std::env::current_dir().unwrap();
+        std::env::set_current_dir(&real_dir).unwrap();
+        let (via_bare_name, canonical_bare_name) = mint_db_identity(&PathBuf::from("khive.db"))
+            .inspect_err(|_| {
+                std::env::set_current_dir(&orig_cwd).unwrap();
+            })
+            .unwrap();
+        std::env::set_current_dir(orig_cwd).unwrap();
+        assert_eq!(canonical_real, canonical_bare_name);
+        assert_eq!(via_real, via_bare_name);
+    }
+
+    /// ADR-091 backend-scoped attribution: opening via a file-level symlink
+    /// whose target does not exist yet (a valid first-open state), then
+    /// after the target is created, opening via the target path directly,
+    /// must mint identical `DbIdentity` values — the first-open path
+    /// resolves the final component before canonicalizing the parent.
+    #[cfg(unix)]
+    #[test]
+    fn mint_db_identity_dangling_symlink_first_open_convergence() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("target.db");
+        let link = dir.path().join("link.db");
+        std::os::unix::fs::symlink(&target, &link).unwrap();
+        assert!(!target.exists(), "target must not exist yet (dangling)");
+
+        let (via_dangling_link, canonical_via_link) = mint_db_identity(&link).unwrap();
+
+        // Now create the target (as SQLite would on first write) and mint
+        // again directly against the target path.
+        fs::write(&target, b"").unwrap();
+        let (via_target, canonical_via_target) = mint_db_identity(&target).unwrap();
+
+        assert_eq!(canonical_via_link, canonical_via_target);
+        assert_eq!(via_dangling_link, via_target);
+    }
+
+    /// A resolved target whose parent directory does not exist must fail
+    /// minting exactly as the subsequent database open itself would fail.
+    #[test]
+    fn mint_db_identity_missing_parent_fails() {
+        let dir = tempfile::tempdir().unwrap();
+        let missing = dir.path().join("nonexistent_subdir").join("khive.db");
+        let result = mint_db_identity(&missing);
+        assert!(
+            result.is_err(),
+            "minting must fail when the parent directory does not exist"
+        );
+    }
+
+    /// Non-UTF-8 database paths (Unix) must round-trip through
+    /// `DbIdentity`/canonicalization without loss.
+    #[cfg(unix)]
+    #[test]
+    fn mint_db_identity_non_utf8_path_round_trips() {
+        use std::ffi::OsStr;
+        use std::os::unix::ffi::OsStrExt;
+
+        let dir = tempfile::tempdir().unwrap();
+        // 0xFF is not valid UTF-8 as a standalone byte.
+        let raw_name = OsStr::from_bytes(b"khive-\xffdb.sqlite");
+        let db_path = dir.path().join(raw_name);
+        // Some Unix filesystems (notably macOS's APFS) reject non-UTF-8
+        // names outright at the syscall level — that is a filesystem
+        // limitation, not a `mint_db_identity` bug, so skip rather than
+        // fail where the underlying `write` itself cannot succeed.
+        if let Err(e) = fs::write(&db_path, b"") {
+            eprintln!(
+                "skipping mint_db_identity_non_utf8_path_round_trips: filesystem rejected a \
+                 non-UTF-8 file name ({e}); this platform's filesystem does not support the \
+                 case under test"
+            );
+            return;
+        }
+
+        let (identity, canonical) = mint_db_identity(&db_path).unwrap();
+        assert_eq!(canonical.file_name().unwrap(), raw_name);
+
+        let (identity_again, canonical_again) = mint_db_identity(&db_path).unwrap();
+        assert_eq!(identity, identity_again);
+        assert_eq!(canonical, canonical_again);
     }
 }

--- a/crates/khive-db/src/sql_bridge.rs
+++ b/crates/khive-db/src/sql_bridge.rs
@@ -236,6 +236,9 @@ struct SqliteWriter {
     /// `conn`. `None` when the flag is off or no writer task is available
     /// (best-effort — degrades to the standalone-connection path below).
     writer_task: Option<crate::writer_task::WriterTaskHandle>,
+    /// The origin (ADR-091 backend-scoped attribution) of the pool this
+    /// standalone connection was opened against.
+    origin: khive_storage::tx_registry::TxOrigin,
 }
 
 #[async_trait]
@@ -380,6 +383,7 @@ impl khive_storage::SqlWriter for SqliteWriter {
             operation: "execute_batch".into(),
             message: "connection already consumed".into(),
         })?;
+        let origin = self.origin.clone();
         let (conn, result) = tokio::task::spawn_blocking(move || {
             if let Err(e) = conn.execute_batch("BEGIN IMMEDIATE") {
                 return (conn, Err(e));
@@ -389,8 +393,10 @@ impl khive_storage::SqlWriter for SqliteWriter {
             // statement-execution closure below AND the ROLLBACK path — so it
             // stays registered until the transaction is actually finished
             // (COMMIT or ROLLBACK), not just until the inner closure returns.
-            let _tx_handle =
-                khive_storage::tx_registry::register(Some("execute_batch".to_string()));
+            let _tx_handle = khive_storage::tx_registry::register_scoped(
+                Some("execute_batch".to_string()),
+                origin,
+            );
             let result = (|| -> Result<u64, rusqlite::Error> {
                 let mut total: u64 = 0;
                 for statement in &statements {
@@ -645,8 +651,10 @@ impl khive_storage::SqlWriter for PoolBackedWriter {
             guard
                 .execute_batch("BEGIN IMMEDIATE")
                 .map_err(|e| map_rusqlite_err(e, "pool_writer.execute_batch"))?;
-            let _tx_handle =
-                khive_storage::tx_registry::register(Some("pool_writer.execute_batch".to_string()));
+            let _tx_handle = khive_storage::tx_registry::register_scoped(
+                Some("pool_writer.execute_batch".to_string()),
+                pool.origin(),
+            );
             let result = (|| -> Result<u64, StorageError> {
                 let mut total = 0u64;
                 for statement in &statements {
@@ -888,6 +896,7 @@ fn block_on_sync<F: std::future::Future>(fut: F) -> Result<F::Output, StorageErr
 async fn run_manual_atomic_unit(
     writer: &mut dyn khive_storage::SqlWriter,
     op: AtomicUnitOp,
+    origin: khive_storage::tx_registry::TxOrigin,
 ) -> khive_storage::types::StorageResult<Box<dyn Any + Send>> {
     fn tx_stmt(sql: &str, label: &str) -> SqlStatement {
         SqlStatement {
@@ -897,7 +906,8 @@ async fn run_manual_atomic_unit(
         }
     }
     khive_storage::SqlWriter::execute(writer, tx_stmt("BEGIN IMMEDIATE", "begin")).await?;
-    let _tx_handle = khive_storage::tx_registry::register(Some("atomic_unit".to_string()));
+    let _tx_handle =
+        khive_storage::tx_registry::register_scoped(Some("atomic_unit".to_string()), origin);
 
     let result = op(writer).await;
 
@@ -980,6 +990,7 @@ impl khive_storage::SqlAccess for SqlBridge {
             Ok(Box::new(SqliteWriter {
                 conn: Some(conn),
                 writer_task,
+                origin: self.pool.origin(),
             }))
         } else {
             Ok(Box::new(PoolBackedWriter {
@@ -1046,8 +1057,9 @@ impl khive_storage::SqlAccess for SqlBridge {
             let mut writer = SqliteWriter {
                 conn: Some(conn),
                 writer_task: None,
+                origin: self.pool.origin(),
             };
-            run_manual_atomic_unit(&mut writer, op).await
+            run_manual_atomic_unit(&mut writer, op, self.pool.origin()).await
         } else {
             // In-memory pools are exempt (not accept-loop reachable, per the
             // rework spec's "Out of scope") — preserve the existing
@@ -1055,7 +1067,7 @@ impl khive_storage::SqlAccess for SqlBridge {
             let mut writer = PoolBackedWriter {
                 pool: Arc::clone(&self.pool),
             };
-            run_manual_atomic_unit(&mut writer, op).await
+            run_manual_atomic_unit(&mut writer, op, self.pool.origin()).await
         }
     }
 }

--- a/crates/khive-db/src/stores/entity.rs
+++ b/crates/khive-db/src/stores/entity.rs
@@ -588,10 +588,13 @@ impl EntityStore for SqlEntityStore {
         // Flag-off (default) path: byte-for-byte unchanged from pre-ADR-067
         // behavior — the closure owns its own BEGIN IMMEDIATE/COMMIT/ROLLBACK
         // via the pool-mutex writer.
+        let origin = self.pool.origin();
         self.with_writer("upsert_entities", move |conn| {
             conn.execute_batch("BEGIN IMMEDIATE")?;
-            let _tx_handle =
-                khive_storage::tx_registry::register(Some("entity_upsert_batch".to_string()));
+            let _tx_handle = khive_storage::tx_registry::register_scoped(
+                Some("entity_upsert_batch".to_string()),
+                origin,
+            );
 
             let summary = batch_upsert_entities(conn, &entities, attempted)?;
 

--- a/crates/khive-db/src/stores/event.rs
+++ b/crates/khive-db/src/stores/event.rs
@@ -925,9 +925,13 @@ impl EventStore for SqlEventStore {
 
         // Flag-off (default) path: byte-for-byte unchanged from pre-ADR-067
         // behavior — the closure owns its own BEGIN IMMEDIATE/COMMIT/ROLLBACK.
+        let origin = self.pool.origin();
         self.with_writer("append_event", move |conn| {
             conn.execute_batch("BEGIN IMMEDIATE")?;
-            let _tx_handle = khive_storage::tx_registry::register(Some("event_append".to_string()));
+            let _tx_handle = khive_storage::tx_registry::register_scoped(
+                Some("event_append".to_string()),
+                origin,
+            );
             if let Err(e) = insert_event_with_observations(conn, &event) {
                 let _ = conn.execute_batch("ROLLBACK");
                 return Err(e);
@@ -957,10 +961,13 @@ impl EventStore for SqlEventStore {
 
         // Flag-off (default) path: byte-for-byte unchanged from pre-ADR-067
         // behavior — the closure owns its own BEGIN IMMEDIATE/COMMIT/ROLLBACK.
+        let origin = self.pool.origin();
         self.with_writer("append_events", move |conn| {
             conn.execute_batch("BEGIN IMMEDIATE")?;
-            let _tx_handle =
-                khive_storage::tx_registry::register(Some("event_append_batch".to_string()));
+            let _tx_handle = khive_storage::tx_registry::register_scoped(
+                Some("event_append_batch".to_string()),
+                origin,
+            );
 
             let summary = match batch_append_events_dml(conn, &events, attempted) {
                 Ok(summary) => summary,

--- a/crates/khive-db/src/stores/graph.rs
+++ b/crates/khive-db/src/stores/graph.rs
@@ -1028,10 +1028,13 @@ impl GraphStore for SqlGraphStore {
         // Flag-off (default) path: byte-for-byte unchanged from pre-ADR-067
         // behavior — the closure owns its own BEGIN IMMEDIATE/COMMIT/ROLLBACK
         // via the pool-mutex/standalone writer.
+        let origin = self.pool.origin();
         self.with_writer("upsert_edges", move |conn| {
             conn.execute_batch("BEGIN IMMEDIATE")?;
-            let _tx_handle =
-                khive_storage::tx_registry::register(Some("graph_upsert_edges".to_string()));
+            let _tx_handle = khive_storage::tx_registry::register_scoped(
+                Some("graph_upsert_edges".to_string()),
+                origin,
+            );
 
             let summary = match batch_upsert_edges(conn, &edges, attempted) {
                 Ok(summary) => summary,
@@ -1087,10 +1090,13 @@ impl GraphStore for SqlGraphStore {
         // between them (this fallback previously
         // ran the two as separate autocommit statements on the standalone
         // writer connection).
+        let origin = self.pool.origin();
         self.with_writer("upsert_edge_guarded", move |conn| {
             conn.execute_batch("BEGIN IMMEDIATE")?;
-            let _tx_handle =
-                khive_storage::tx_registry::register(Some("graph_upsert_edge_guarded".to_string()));
+            let _tx_handle = khive_storage::tx_registry::register_scoped(
+                Some("graph_upsert_edge_guarded".to_string()),
+                origin,
+            );
 
             let outcome = match edge_insert_guarded(conn, &statement, source_id, target_id) {
                 Ok(outcome) => outcome,
@@ -1127,11 +1133,13 @@ impl GraphStore for SqlGraphStore {
                 .await;
         }
 
+        let origin = self.pool.origin();
         self.with_writer("upsert_edges_guarded", move |conn| {
             conn.execute_batch("BEGIN IMMEDIATE")?;
-            let _tx_handle = khive_storage::tx_registry::register(Some(
-                "graph_upsert_edges_guarded".to_string(),
-            ));
+            let _tx_handle = khive_storage::tx_registry::register_scoped(
+                Some("graph_upsert_edges_guarded".to_string()),
+                origin,
+            );
 
             let summary = match batch_upsert_edges_guarded(conn, &edges, attempted) {
                 Ok(summary) => summary,
@@ -1831,6 +1839,7 @@ impl GraphStore for SqlGraphStore {
                 ),
             })?;
 
+        let origin = self.pool.origin();
         self.with_reader("traverse", move |conn| {
             // Two SQLite limits apply to the seed VALUES clause:
             //
@@ -1866,8 +1875,10 @@ impl GraphStore for SqlGraphStore {
             // Registered before the transaction is opened so the handle (declared
             // first) drops after `tx`'s own Drop runs (locals drop in reverse
             // declaration order within the same scope).
-            let _tx_handle =
-                khive_storage::tx_registry::register(Some("graph_traverse_read".to_string()));
+            let _tx_handle = khive_storage::tx_registry::register_scoped(
+                Some("graph_traverse_read".to_string()),
+                origin,
+            );
             let tx = conn.unchecked_transaction()?;
 
             // Accumulate per-root state across all chunks: (nodes_with_path_weight, seen_set).

--- a/crates/khive-db/src/stores/graph_tests.rs
+++ b/crates/khive-db/src/stores/graph_tests.rs
@@ -1047,6 +1047,89 @@ async fn test_traverse_binary_tree_result_count() {
     }
 }
 
+/// ADR-091 Amendment 3 / design-note test plan "Traversal coverage test":
+/// the `graph_traverse_read` registration inside `traverse` (the long-lived
+/// deferred-read snapshot the whole design exists for) must carry the
+/// store's own pool origin, so it is visible through a `Secondary` filter
+/// scoped to THIS backend's identity and invisible through a `Main` filter
+/// scoped to a DIFFERENT backend's identity. Exercises the real
+/// `SqlGraphStore::traverse` call site rather than a hand-registered span —
+/// a wide root set (with real matching edges) forces the chunked traversal
+/// past `CHUNK_ROOTS` (400) more than once inside the single registered
+/// closure, giving the polling loop below a real window in which the span
+/// is observably open (registered before, dropped after, the whole chunked
+/// loop — see `traverse`'s doc comment).
+#[tokio::test]
+#[serial(tx_registry)]
+async fn graph_traverse_read_span_scoped_to_secondary_backend_visible_only_in_its_own_view() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("traverse_secondary_origin.db");
+    let pool_cfg = PoolConfig {
+        path: Some(path.clone()),
+        ..PoolConfig::default()
+    };
+    let pool = Arc::new(ConnectionPool::new(pool_cfg).unwrap());
+    {
+        let writer = pool.writer().unwrap();
+        writer.conn().execute_batch(GRAPH_DDL).unwrap();
+    }
+    let secondary_identity = match pool.origin() {
+        khive_storage::tx_registry::TxOrigin::Database(id) => id,
+        other => panic!("expected a file-backed pool to mint a Database origin, got {other:?}"),
+    };
+    let other_identity = khive_storage::tx_registry::DbIdentity::new(
+        pool.canonical_path()
+            .unwrap()
+            .with_file_name("unrelated-backend.db"),
+    );
+
+    let store = SqlGraphStore::new_scoped(Arc::clone(&pool), false, "default");
+    let roots: Vec<Uuid> = (0..900).map(|_| Uuid::new_v4()).collect();
+    let edges: Vec<Edge> = roots
+        .iter()
+        .map(|&root| make_edge(root, Uuid::new_v4(), EdgeRelation::Extends, 1.0))
+        .collect();
+    store.upsert_edges(edges).await.unwrap();
+
+    let request = TraversalRequest {
+        roots,
+        options: TraversalOptions::new(10).with_direction(Direction::Out),
+        include_roots: false,
+        include_properties: false,
+    };
+
+    let traverse_handle = tokio::spawn(async move { store.traverse(request).await });
+
+    let secondary_view =
+        khive_storage::tx_registry::TxOriginFilter::Secondary(secondary_identity.clone());
+    let main_view = khive_storage::tx_registry::TxOriginFilter::Main(other_identity);
+
+    let mut seen_via_secondary = false;
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(2);
+    while std::time::Instant::now() < deadline && !traverse_handle.is_finished() {
+        if let Some(span) = khive_storage::tx_registry::oldest_for(&secondary_view) {
+            if span.label.as_deref() == Some("graph_traverse_read") {
+                seen_via_secondary = true;
+                assert!(
+                    khive_storage::tx_registry::oldest_for(&main_view).is_none(),
+                    "a secondary-origin graph_traverse_read span must never be visible \
+                     through a different backend's Main view"
+                );
+                break;
+            }
+        }
+        tokio::task::yield_now().await;
+    }
+
+    let result = traverse_handle.await.unwrap();
+    assert!(result.is_ok(), "traverse should succeed: {result:?}");
+    assert!(
+        seen_via_secondary,
+        "expected to observe a graph_traverse_read span through the secondary backend's own \
+         filtered view while the traversal's read transaction was open"
+    );
+}
+
 #[tokio::test]
 async fn test_metadata_roundtrip() {
     let store = setup_memory_store();

--- a/crates/khive-db/src/stores/note.rs
+++ b/crates/khive-db/src/stores/note.rs
@@ -759,9 +759,12 @@ impl NoteStore for SqlNoteStore {
         // connection. `with_writer_tx` rolls back on ANY error from `f`, on
         // both the flag-on (WriterTask, which wraps its own transaction) and
         // flag-off (pool-mutex) paths.
+        let origin = self.pool.origin();
         self.with_writer_tx("upsert_notes", move |conn| {
-            let _tx_handle =
-                khive_storage::tx_registry::register(Some("note_upsert_batch".to_string()));
+            let _tx_handle = khive_storage::tx_registry::register_scoped(
+                Some("note_upsert_batch".to_string()),
+                origin,
+            );
             batch_upsert_notes(conn, &notes, attempted)
         })
         .await

--- a/crates/khive-db/src/stores/sparse.rs
+++ b/crates/khive-db/src/stores/sparse.rs
@@ -364,10 +364,13 @@ impl SqliteSparseStore {
 
         // Flag-off (default) path: byte-for-byte unchanged from pre-ADR-067
         // behavior — the closure owns its own BEGIN IMMEDIATE/COMMIT.
+        let origin = self.pool.origin();
         self.with_writer("sparse_insert_batch", move |conn| {
             conn.execute_batch("BEGIN IMMEDIATE")?;
-            let _tx_handle =
-                khive_storage::tx_registry::register(Some("sparse_insert_batch".to_string()));
+            let _tx_handle = khive_storage::tx_registry::register_scoped(
+                Some("sparse_insert_batch".to_string()),
+                origin,
+            );
 
             let summary = batch_insert_sparse_dml(conn, &table, &records, attempted)?;
 

--- a/crates/khive-db/src/stores/text.rs
+++ b/crates/khive-db/src/stores/text.rs
@@ -741,10 +741,13 @@ impl TextSearch for Fts5TextSearch {
 
         // Flag-off (default) path: byte-for-byte unchanged from pre-ADR-067
         // behavior — the closure owns its own BEGIN IMMEDIATE/COMMIT/ROLLBACK.
+        let origin = self.pool.origin();
         self.with_writer("fts_upsert", move |conn| {
             conn.execute_batch("BEGIN IMMEDIATE")?;
-            let _tx_handle =
-                khive_storage::tx_registry::register(Some("text_upsert_document".to_string()));
+            let _tx_handle = khive_storage::tx_registry::register_scoped(
+                Some("text_upsert_document".to_string()),
+                origin,
+            );
 
             if let Err(e) = upsert_document_dml(conn, &table, &document) {
                 let _ = conn.execute_batch("ROLLBACK");
@@ -781,10 +784,13 @@ impl TextSearch for Fts5TextSearch {
 
         // Flag-off (default) path: byte-for-byte unchanged from pre-ADR-067
         // behavior — the closure owns its own BEGIN IMMEDIATE/COMMIT.
+        let origin = self.pool.origin();
         self.with_writer("fts_upsert_batch", move |conn| {
             conn.execute_batch("BEGIN IMMEDIATE")?;
-            let _tx_handle =
-                khive_storage::tx_registry::register(Some("text_upsert_batch".to_string()));
+            let _tx_handle = khive_storage::tx_registry::register_scoped(
+                Some("text_upsert_batch".to_string()),
+                origin,
+            );
 
             let summary = batch_upsert_documents_dml(conn, &table, &documents, attempted)?;
 
@@ -1381,6 +1387,7 @@ impl Fts5TextSearch {
         let old_ns = old_namespace.to_string();
         let new_ns = new_namespace.to_string();
 
+        let origin = self.pool.origin();
         self.with_writer_unmanaged("fts_rename_namespace", move |conn| {
             let sel_sql = format!(
                 "SELECT subject_id, kind, title, body, tags, metadata, updated_at \
@@ -1417,8 +1424,10 @@ impl Fts5TextSearch {
             }
 
             conn.execute_batch("BEGIN IMMEDIATE")?;
-            let _tx_handle =
-                khive_storage::tx_registry::register(Some("text_rename_namespace".to_string()));
+            let _tx_handle = khive_storage::tx_registry::register_scoped(
+                Some("text_rename_namespace".to_string()),
+                origin,
+            );
 
             let del_sql = format!("DELETE FROM {} WHERE namespace = ?1", table);
             if let Err(e) = conn.execute(&del_sql, rusqlite::params![&old_ns]) {

--- a/crates/khive-db/src/stores/vectors.rs
+++ b/crates/khive-db/src/stores/vectors.rs
@@ -779,14 +779,17 @@ impl VectorStore for SqliteVecStore {
         // `conn.unchecked_transaction()`; the DELETE+INSERT body is the same
         // shared helper the WriterTask/batch paths use (#546), so this path
         // now also exercises the post-delete failpoint in tests.
+        let origin = self.pool.origin();
         self.with_writer("vec_insert", move |conn| {
             // ADR-091 Plank 0: register the span before opening the transaction so
             // the handle (declared first) drops AFTER `tx` (declared second) —
             // locals drop in reverse declaration order, so `tx`'s own Drop (which
             // rolls back if uncommitted) runs while the registry entry is still
             // present.
-            let _tx_handle =
-                khive_storage::tx_registry::register(Some("vec_insert_tx".to_string()));
+            let _tx_handle = khive_storage::tx_registry::register_scoped(
+                Some("vec_insert_tx".to_string()),
+                origin,
+            );
             let tx = conn.unchecked_transaction()?;
 
             replace_vector_row_dml(
@@ -850,10 +853,13 @@ impl VectorStore for SqliteVecStore {
 
         // Flag-off (default) path: byte-for-byte unchanged from pre-ADR-067
         // behavior — the closure owns its own BEGIN IMMEDIATE/COMMIT.
+        let origin = self.pool.origin();
         self.with_writer("vec_insert_batch", move |conn| {
             conn.execute_batch("BEGIN IMMEDIATE")?;
-            let _tx_handle =
-                khive_storage::tx_registry::register(Some("vector_insert_batch".to_string()));
+            let _tx_handle = khive_storage::tx_registry::register_scoped(
+                Some("vector_insert_batch".to_string()),
+                origin,
+            );
 
             let summary = batch_insert_vectors_dml(
                 conn,
@@ -942,11 +948,14 @@ impl VectorStore for SqliteVecStore {
         // Flag-off (default) path: the closure owns its own transaction via
         // `conn.unchecked_transaction()`; the DELETE+INSERT body is the same
         // shared helper the WriterTask/batch paths use (#546).
+        let origin = self.pool.origin();
         self.with_writer("vec_update", move |conn| {
             // ADR-091 Plank 0: registered before the transaction is opened — see
             // the matching note in `insert()` above for the drop-order rationale.
-            let _tx_handle =
-                khive_storage::tx_registry::register(Some("vec_update_tx".to_string()));
+            let _tx_handle = khive_storage::tx_registry::register_scoped(
+                Some("vec_update_tx".to_string()),
+                origin,
+            );
             let tx = conn.unchecked_transaction()?;
 
             replace_vector_row_dml(
@@ -1339,6 +1348,7 @@ impl VectorStore for SqliteVecStore {
         // Flag-off (default) path: byte-for-byte unchanged from pre-ADR-067
         // behavior — the closure owns its own transaction via
         // `Transaction::new_unchecked`.
+        let origin = self.pool.origin();
         self.with_writer_unmanaged("orphan_sweep", move |conn| {
             // `Transaction::new_unchecked` issues `BEGIN IMMEDIATE` and RAII-manages
             // rollback via its Drop impl: it checks `conn.is_autocommit()` and issues
@@ -1356,8 +1366,10 @@ impl VectorStore for SqliteVecStore {
             // ADR-091 Plank 0: registered before the transaction is opened — see the
             // matching note in `insert()` for the drop-order rationale (the handle,
             // declared first, drops after `tx`'s own Drop/rollback runs).
-            let _tx_handle =
-                khive_storage::tx_registry::register(Some("vec_orphan_sweep".to_string()));
+            let _tx_handle = khive_storage::tx_registry::register_scoped(
+                Some("vec_orphan_sweep".to_string()),
+                origin,
+            );
             let tx = rusqlite::Transaction::new_unchecked(
                 conn,
                 rusqlite::TransactionBehavior::Immediate,

--- a/crates/khive-db/src/walpin.rs
+++ b/crates/khive-db/src/walpin.rs
@@ -270,7 +270,7 @@ mod unix_impl {
     use std::io::{self, Read, Write};
     use std::os::unix::ffi::OsStrExt;
     use std::os::unix::io::{AsRawFd, FromRawFd, RawFd};
-    use std::path::Path;
+    use std::path::{Path, PathBuf};
     use std::time::{Duration, SystemTime};
 
     /// Hard cap on one sidecar entry's byte size. Real heartbeat/beacon
@@ -278,6 +278,13 @@ mod unix_impl {
     /// this module wrote, and reading it unboundedly would let a same-uid
     /// process balloon checkpoint-time enumeration.
     pub(super) const MAX_SIDECAR_ENTRY_BYTES: u64 = 64 * 1024;
+
+    /// Bound on the number of ancestor symlink hops
+    /// [`SidecarDirHandle::open_dir_component_walk`] will resolve (each
+    /// independently root-owned-checked) before refusing outright — caps a
+    /// pathological or looping symlink chain to bounded work instead of
+    /// unbounded recursion.
+    const MAX_ANCESTOR_SYMLINK_DEPTH: u32 = 8;
 
     /// Every raw directory entry — hidden or not — counts toward a scan
     /// bound of `RAW_SCAN_FACTOR * max` in `list_names`, so a flood of
@@ -405,24 +412,34 @@ mod unix_impl {
         /// `openat` call's "final component" the immediate next segment, so
         /// `O_NOFOLLOW` refuses a symlink at every level, not just the last.
         ///
-        /// The walk runs over `path` resolved through `fs::canonicalize`
-        /// first, not the caller's literal path: legitimate OS-level
-        /// ancestor symlinks (macOS's `/tmp -> private/tmp`, `/var ->
-        /// private/var`) are a normal part of the filesystem layout, not an
-        /// attacker's TOCTOU target, and refusing them outright would
-        /// refuse every sidecar under the platform's own temp/var trees.
-        /// `canonicalize` resolves those once, up front; the descriptor
-        /// walk that follows is what closes the actual race ADR-091 cares
-        /// about — an ancestor swapped for a symlink AFTER `canonicalize`
-        /// returns but before (or during) this walk is refused component by
-        /// component via `O_NOFOLLOW`, rather than silently re-resolved the
-        /// way a second path-based open would.
+        /// The walk runs over `path` LITERALLY — never through a
+        /// `fs::canonicalize` pre-pass. A pre-resolve pass would itself
+        /// follow every ancestor symlink through ordinary kernel path
+        /// resolution before the descriptor walk ever starts, silently
+        /// validating whatever a hostile symlink planted before this call
+        /// pointed at; the walk would then only ever see the
+        /// already-attacker-chosen path. Legitimate OS-level ancestor
+        /// symlinks (macOS's `/tmp -> private/tmp`, `/var -> private/var`)
+        /// still have to work, so a component `openat` refuses with
+        /// `ELOOP`/`ENOTDIR` gets exactly one second look, via
+        /// [`Self::open_component`]: `fstatat` it (without following) to
+        /// confirm it really is a symlink AND is owned by root (uid 0,
+        /// mirroring the trust `open_component` extends to firmlinks the OS
+        /// itself planted in stock platform layout — never an arbitrary
+        /// user), then `readlinkat` + recurse into its target through this
+        /// same component-at-a-time discipline. A non-root-owned symlink
+        /// ancestor is refused outright; total symlink hops across the
+        /// whole walk are capped by `MAX_ANCESTOR_SYMLINK_DEPTH`.
         fn open_dir_component_walk(path: &Path) -> io::Result<fs::File> {
-            use std::path::Component;
+            let start = Self::open_anchor(path.is_absolute())?;
+            let mut budget = MAX_ANCESTOR_SYMLINK_DEPTH;
+            Self::walk_components(start, path, &mut budget)
+        }
 
-            let path = fs::canonicalize(path)?;
-            let path = path.as_path();
-            let anchor = if path.is_absolute() { "/" } else { "." };
+        /// Open `/` (absolute) or `.` (relative) as the starting descriptor
+        /// for a component walk.
+        fn open_anchor(absolute: bool) -> io::Result<fs::File> {
+            let anchor = if absolute { "/" } else { "." };
             let c_anchor = path_cstring(Path::new(anchor))?;
             // SAFETY: `c_anchor` is NUL-terminated for the call; the
             // returned fd is uniquely owned by this call and wrapped
@@ -437,32 +454,130 @@ mod unix_impl {
                 return Err(io::Error::last_os_error());
             }
             // SAFETY: `fd` was just returned by the successful `open` above.
-            let mut current = unsafe { fs::File::from_raw_fd(fd) };
+            Ok(unsafe { fs::File::from_raw_fd(fd) })
+        }
 
+        /// Walk every component of `path` starting from the already-open
+        /// `start` descriptor, one `openat(O_NOFOLLOW)` hop at a time.
+        fn walk_components(start: fs::File, path: &Path, budget: &mut u32) -> io::Result<fs::File> {
+            use std::path::Component;
+
+            let mut current = start;
             for component in path.components() {
                 let name = match component {
                     Component::RootDir | Component::CurDir | Component::Prefix(_) => continue,
                     Component::ParentDir => std::ffi::OsStr::new(".."),
                     Component::Normal(c) => c,
                 };
-                let c_name = name_cstring_os(name)?;
-                // SAFETY: `c_name` is NUL-terminated for the call; `current`
-                // is a live, open directory descriptor for the call's
-                // duration; the returned fd is uniquely owned by this call
-                // and wrapped immediately.
-                let next_fd = unsafe {
-                    libc::openat(
-                        current.as_raw_fd(),
-                        c_name.as_ptr(),
-                        libc::O_DIRECTORY | libc::O_NOFOLLOW | libc::O_CLOEXEC,
-                    )
-                };
-                if next_fd < 0 {
-                    return Err(io::Error::last_os_error());
-                }
-                current = unsafe { fs::File::from_raw_fd(next_fd) };
+                current = Self::open_component(current, name, budget)?;
             }
             Ok(current)
+        }
+
+        /// Open a single path component relative to `dir` via
+        /// `openat(O_DIRECTORY | O_NOFOLLOW)`. If the component is refused
+        /// because it is a symlink, the refusal is allowed exactly one
+        /// second look: the component must independently `fstatat` as a
+        /// root-owned (uid 0) symlink — the only party that plants firmlinks
+        /// in stock platform layout — before its target is read via
+        /// `readlinkat` and resolved through this same discipline. Anything
+        /// else (a non-root-owned symlink, or an `ELOOP`/`ENOTDIR` that
+        /// `fstatat` shows isn't actually a symlink) fails closed with the
+        /// original `openat` error.
+        fn open_component(
+            dir: fs::File,
+            name: &std::ffi::OsStr,
+            budget: &mut u32,
+        ) -> io::Result<fs::File> {
+            let c_name = name_cstring_os(name)?;
+            // SAFETY: `c_name` is NUL-terminated for the call; `dir` is a
+            // live, open directory descriptor for the call's duration; the
+            // returned fd is uniquely owned by this call and wrapped
+            // immediately.
+            let next_fd = unsafe {
+                libc::openat(
+                    dir.as_raw_fd(),
+                    c_name.as_ptr(),
+                    libc::O_DIRECTORY | libc::O_NOFOLLOW | libc::O_CLOEXEC,
+                )
+            };
+            if next_fd >= 0 {
+                // SAFETY: `next_fd` was just returned by the successful
+                // `openat` above.
+                return Ok(unsafe { fs::File::from_raw_fd(next_fd) });
+            }
+            let open_err = io::Error::last_os_error();
+            let raw = open_err.raw_os_error();
+            if raw != Some(libc::ELOOP) && raw != Some(libc::ENOTDIR) {
+                return Err(open_err);
+            }
+
+            // The refusal above already made the security decision for
+            // every case except "this component is a root-owned platform
+            // firmlink" — this `fstatat` is diagnostic classification, not
+            // a second trust decision: it runs against the same live `dir`
+            // descriptor and the same `c_name`, so there is no re-resolution
+            // between the refused `openat` and this call.
+            let mut st: libc::stat = unsafe { std::mem::zeroed() };
+            // SAFETY: `c_name` is NUL-terminated for the call; `dir` is a
+            // live, open directory descriptor for the call's duration; `st`
+            // is a valid, appropriately-sized output buffer.
+            let rc = unsafe {
+                libc::fstatat(
+                    dir.as_raw_fd(),
+                    c_name.as_ptr(),
+                    &mut st,
+                    libc::AT_SYMLINK_NOFOLLOW,
+                )
+            };
+            if rc != 0 || !is_symlink_mode(st.st_mode) {
+                return Err(open_err);
+            }
+            if st.st_uid != 0 {
+                return Err(io_other(format!(
+                    "walpin sidecar ancestor {name:?} is a non-root-owned symlink; refusing"
+                )));
+            }
+            if *budget == 0 {
+                return Err(io_other(format!(
+                    "walpin sidecar ancestor {name:?} exceeded the symlink resolution depth budget"
+                )));
+            }
+            *budget -= 1;
+
+            let target = Self::read_link_component(&dir, &c_name)?;
+            let target_path = PathBuf::from(target);
+            let next_start = if target_path.is_absolute() {
+                Self::open_anchor(true)?
+            } else {
+                dir
+            };
+            Self::walk_components(next_start, &target_path, budget)
+        }
+
+        /// `readlinkat` a single component relative to `dir`, byte-exact
+        /// (never a lossy UTF-8 conversion — same rationale as
+        /// [`name_cstring_os`]).
+        fn read_link_component(dir: &fs::File, c_name: &CString) -> io::Result<std::ffi::OsString> {
+            use std::os::unix::ffi::OsStringExt;
+
+            let mut buf = vec![0u8; libc::PATH_MAX as usize];
+            // SAFETY: `c_name` is NUL-terminated for the call; `dir` is a
+            // live, open directory descriptor for the call's duration;
+            // `buf` is a valid output buffer of its declared capacity.
+            let rc = unsafe {
+                libc::readlinkat(
+                    dir.as_raw_fd(),
+                    c_name.as_ptr(),
+                    buf.as_mut_ptr() as *mut libc::c_char,
+                    buf.len(),
+                )
+            };
+            if rc < 0 {
+                return Err(io::Error::last_os_error());
+            }
+            buf.truncate(rc as usize);
+            Ok(std::ffi::OsString::from_vec(buf))
         }
 
         fn open_validated_at(
@@ -969,11 +1084,53 @@ mod windows_impl {
         Ok(())
     }
 
-    /// Open the sidecar directory as a validated handle: a real directory,
-    /// never a reparse point, checked on the OPENED handle via
-    /// `GetFileInformationByHandle` — never a separate path-based query
-    /// that a later operation could re-resolve against a different object.
+    /// Case-insensitive comparison of two `GetFinalPathNameByHandleW`-
+    /// resolved paths (NTFS default collation). Both sides of every call
+    /// site here are handle-resolved paths from the same API, so a lossy
+    /// `to_string_lossy` is a conservative (fail-closed, never
+    /// fail-open) simplification: at worst a non-ASCII-identical byte
+    /// sequence that is genuinely equal reads as a mismatch and the open
+    /// is refused, never the reverse.
+    fn resolved_paths_match(a: &Path, b: &Path) -> bool {
+        a.as_os_str().to_string_lossy().to_ascii_lowercase()
+            == b.as_os_str().to_string_lossy().to_ascii_lowercase()
+    }
+
+    /// Open the sidecar directory as a validated handle, bound to the
+    /// database directory that is its one legitimate anchor (the threat
+    /// model: the sidecar is always a sibling of the live database file,
+    /// so binding to the parent directory's own resolved identity is the
+    /// strongest anchor available — anything above that the OS itself
+    /// owns is trusted platform layout). `dir`'s parent is opened first
+    /// and its `GetFinalPathNameByHandleW`-resolved path establishes the
+    /// EXPECTED final path (`<parent's resolved path>\<dir's own file
+    /// name>`); `dir` is then opened the same reparse-aware way as
+    /// before — a real directory, never a reparse point, checked on the
+    /// OPENED handle via `GetFileInformationByHandle` — and its OWN
+    /// resolved path must equal that expectation. A pre-existing ancestor
+    /// junction, or a create-then-swap race between the two opens, moves
+    /// `dir`'s resolved path away from `<parent>\<name>` and is refused
+    /// here as a mismatch — the racy window collapses to detect-and-
+    /// refuse (fail closed), which is what the contract asks for; nothing
+    /// upstream of the parent open pins that race away.
     fn open_dir_handle(dir: &Path) -> io::Result<fs::File> {
+        let parent = dir.parent().unwrap_or_else(|| Path::new("."));
+        let name = dir.file_name().ok_or_else(|| {
+            io_other(format!(
+                "walpin sidecar path {dir:?} has no final path component"
+            ))
+        })?;
+
+        let parent_handle =
+            open_reparse_aware(parent, 0, OPEN_EXISTING, FILE_FLAG_BACKUP_SEMANTICS)?;
+        let parent_info = file_info(&parent_handle)?;
+        if parent_info.dw_file_attributes & FILE_ATTRIBUTE_DIRECTORY == 0 {
+            return Err(io_other(format!(
+                "walpin sidecar parent {parent:?} is not a directory"
+            )));
+        }
+        let expected = resolved_path(&parent_handle)?.join(name);
+
         let file = open_reparse_aware(dir, 0, OPEN_EXISTING, FILE_FLAG_BACKUP_SEMANTICS)?;
         let info = file_info(&file)?;
         if info.dw_file_attributes & FILE_ATTRIBUTE_REPARSE_POINT != 0 {
@@ -984,6 +1141,13 @@ mod windows_impl {
         if info.dw_file_attributes & FILE_ATTRIBUTE_DIRECTORY == 0 {
             return Err(io_other(format!(
                 "walpin sidecar path {dir:?} exists and is not a directory"
+            )));
+        }
+        let resolved = resolved_path(&file)?;
+        if !resolved_paths_match(&resolved, &expected) {
+            return Err(io_other(format!(
+                "walpin sidecar path {dir:?} resolved to {resolved:?}, outside its \
+                 validated database-directory anchor {expected:?}; refusing"
             )));
         }
         Ok(file)
@@ -1152,6 +1316,8 @@ mod windows_impl {
     /// as its inherited ACL — a residual, documented gap, not an
     /// oversight.
     pub(super) fn touch_mtime(dir: &Path, name: &str) -> io::Result<()> {
+        let dir_handle = open_dir_handle(dir)?;
+        let dir_resolved = resolved_path(&dir_handle)?;
         let target = dir.join(name);
         let file = open_reparse_aware(&target, GENERIC_WRITE, OPEN_EXISTING, 0).map_err(|_| {
             io_other(format!(
@@ -1164,6 +1330,7 @@ mod windows_impl {
                 "walpin sidecar entry {target:?} is a reparse point; refusing to touch it"
             )));
         }
+        verify_under(&resolved_path(&file)?, &dir_resolved, &target)?;
         let now = SystemTime::now()
             .duration_since(SystemTime::UNIX_EPOCH)
             .map_err(|e| io_other(e.to_string()))?;
@@ -2623,6 +2790,28 @@ mod tests {
         std::os::unix::fs::symlink(&real, &link).unwrap();
         let err = ensure_sidecar_dir(&link).expect_err("symlink must be refused");
         assert!(err.to_string().contains("symlink"));
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn ensure_sidecar_dir_refuses_non_root_owned_ancestor_symlink() {
+        // The sidecar dir's own final component is real; a symlink sits at
+        // an ANCESTOR of it instead. This must be refused just as hard as a
+        // symlinked final component — only a root-owned ancestor symlink
+        // (the OS's own firmlinks, e.g. macOS's /tmp -> private/tmp) gets a
+        // pass, and the test process does not own this symlink as root.
+        let root = tempfile::tempdir().unwrap();
+        let real = root.path().join("real_ancestor");
+        fs::create_dir(&real).unwrap();
+        let link = root.path().join("linked_ancestor");
+        std::os::unix::fs::symlink(&real, &link).unwrap();
+        let dir = link.join("khive.db.walpin");
+        let err =
+            ensure_sidecar_dir(&dir).expect_err("non-root-owned ancestor symlink must be refused");
+        assert!(
+            err.to_string().contains("symlink"),
+            "unexpected error: {err}"
+        );
     }
 
     #[test]

--- a/crates/khive-db/src/walpin.rs
+++ b/crates/khive-db/src/walpin.rs
@@ -72,6 +72,16 @@ pub struct WalpinHeartbeat {
     /// enumerator's own interval.
     #[serde(default)]
     pub interval_ms: u64,
+    /// ADR-091 Amendment 3 Plank F2: `"origin"` when the oldest span above
+    /// carried this backend's own origin identity, `"fallback"` when it was
+    /// an `Unscoped` span observed only through the main view's
+    /// never-silently-drop fallback. `None` for records written before this
+    /// field existed. Exactly these two values when present — a consumer
+    /// MUST fail closed (treat as fallback-confidence) on any other value,
+    /// per the amendment's reading rule; this crate does not yet have a
+    /// reader that classifies on it.
+    #[serde(default)]
+    pub attribution_basis: Option<String>,
 }
 
 /// A heartbeat that survived the three-test liveness gate at enumeration time.
@@ -1992,6 +2002,7 @@ mod tests {
             oldest_tx_label: Some("test_span".to_string()),
             updated_at: now_epoch_secs(),
             interval_ms: 5_000,
+            attribution_basis: Some("origin".to_string()),
         }
     }
 

--- a/crates/khive-db/src/walpin.rs
+++ b/crates/khive-db/src/walpin.rs
@@ -61,6 +61,11 @@ pub struct WalpinHeartbeat {
     /// check at enumeration time — a reused PID is rejected deterministically
     /// rather than probabilistically.
     pub started_at: i64,
+    /// Age of the oldest span as of the last body write. Not current once a
+    /// tick advances freshness via a metadata-only mtime touch (ADR-091
+    /// Amendment 3 Plank F1) — readers that want the current age prefer
+    /// [`WalpinHeartbeat::current_oldest_tx_age_secs`], which uses
+    /// `oldest_tx_started_at` when present.
     pub oldest_tx_age_secs: f64,
     pub oldest_tx_label: Option<String>,
     /// Epoch timestamp of the oldest span's registration instant, fixed for
@@ -87,12 +92,36 @@ pub struct WalpinHeartbeat {
     /// carried this backend's own origin identity, `"fallback"` when it was
     /// an `Unscoped` span observed only through the main view's
     /// never-silently-drop fallback. `None` for records written before this
-    /// field existed. Exactly these two values when present — a consumer
-    /// MUST fail closed (treat as fallback-confidence) on any other value,
-    /// per the amendment's reading rule; this crate does not yet have a
-    /// reader that classifies on it.
+    /// field existed. Exactly these two values when present — every
+    /// consumer MUST fail closed (treat as fallback-confidence) on any
+    /// other value, per the amendment's reading rule; see
+    /// [`WalpinHeartbeat::attribution_is_evidence_backed`].
     #[serde(default)]
     pub attribution_basis: Option<String>,
+}
+
+impl WalpinHeartbeat {
+    /// ADR-091 Amendment 3 Plank F2 fail-closed reading rule, binding on
+    /// every consumer: only the exact string `"origin"` licenses an
+    /// evidence-backed reading. A missing field, or any value this
+    /// amendment does not define, classifies as fallback-confidence —
+    /// never evidence-backed.
+    pub fn attribution_is_evidence_backed(&self) -> bool {
+        self.attribution_basis.as_deref() == Some("origin")
+    }
+
+    /// ADR-091 Amendment 3 Plank F1: age computed at read time. Prefers
+    /// `oldest_tx_started_at` — fixed for as long as the span stays the
+    /// oldest one, so it stays correct across metadata-only touches — over
+    /// the possibly-stale `oldest_tx_age_secs` body field. Records written
+    /// before this amendment lack the field and fall back to the body
+    /// value exactly as before.
+    pub fn current_oldest_tx_age_secs(&self, now_epoch_secs: i64) -> f64 {
+        match self.oldest_tx_started_at {
+            Some(started_at) => (now_epoch_secs - started_at).max(0) as f64,
+            None => self.oldest_tx_age_secs,
+        }
+    }
 }
 
 /// A heartbeat that survived the three-test liveness gate at enumeration time.
@@ -2795,6 +2824,34 @@ mod tests {
             1,
             "a 100ms declared cadence must floor its window at 3s, not 1s: 2s old must \
              still classify live: {report:?}"
+        );
+    }
+
+    /// ADR-091 Amendment 3 Plank F2 fail-closed reading rule, exercised at
+    /// the canonical consumer-facing accessor: only the exact string
+    /// `"origin"` licenses an evidence-backed reading. A missing field or
+    /// any unrecognized value — including a value a future amendment might
+    /// define — must classify as fallback-confidence, never evidence-backed.
+    #[test]
+    fn attribution_is_evidence_backed_fails_closed_on_missing_or_unrecognized_value() {
+        let mut hb = heartbeat(std::process::id());
+
+        hb.attribution_basis = Some("origin".to_string());
+        assert!(hb.attribution_is_evidence_backed());
+
+        hb.attribution_basis = Some("fallback".to_string());
+        assert!(!hb.attribution_is_evidence_backed());
+
+        hb.attribution_basis = None;
+        assert!(
+            !hb.attribution_is_evidence_backed(),
+            "a missing attribution_basis must never be read as evidence-backed"
+        );
+
+        hb.attribution_basis = Some("some-future-value".to_string());
+        assert!(
+            !hb.attribution_is_evidence_backed(),
+            "an unrecognized value must degrade to fallback-confidence, never guess origin"
         );
     }
 

--- a/crates/khive-db/src/walpin.rs
+++ b/crates/khive-db/src/walpin.rs
@@ -63,6 +63,17 @@ pub struct WalpinHeartbeat {
     pub started_at: i64,
     pub oldest_tx_age_secs: f64,
     pub oldest_tx_label: Option<String>,
+    /// Epoch timestamp of the oldest span's registration instant, fixed for
+    /// as long as that span stays the oldest one (ADR-091 Amendment 3 Plank
+    /// F1). `None` for records written before this field existed. Present
+    /// specifically to let readers compute a current age from a body that a
+    /// touch-only tick left otherwise unchanged.
+    #[serde(default)]
+    pub oldest_tx_started_at: Option<i64>,
+    /// The instant of the last body write. No longer part of liveness
+    /// classification for a record carrying `oldest_tx_started_at` (Plank
+    /// F1 moves that basis to the entry's mtime); records without it are
+    /// still classified on this field exactly as before Amendment 3.
     pub updated_at: i64,
     /// The producer's own sweep cadence in milliseconds. Freshness at
     /// enumeration is judged against THIS cadence, not the enumerating
@@ -71,7 +82,7 @@ pub struct WalpinHeartbeat {
     /// record written before this field existed) falls back to the
     /// enumerator's own interval.
     #[serde(default)]
-    pub interval_ms: u64,
+    pub sweep_interval_ms: u64,
     /// ADR-091 Amendment 3 Plank F2: `"origin"` when the oldest span above
     /// carried this backend's own origin identity, `"fallback"` when it was
     /// an `Unscoped` span observed only through the main view's
@@ -106,7 +117,7 @@ pub struct WalpinBeacon {
     /// refresh mtime is judged against this cadence at enumeration, not the
     /// enumerating daemon's. `0` falls back to the enumerator's interval.
     #[serde(default)]
-    pub interval_ms: u64,
+    pub sweep_interval_ms: u64,
 }
 
 /// Three-state sidecar-health classification for one PID observed in the
@@ -1464,6 +1475,28 @@ pub fn write_heartbeat(dir: &Path, heartbeat: &WalpinHeartbeat) -> io::Result<()
     }
 }
 
+/// ADR-091 Amendment 3 Plank F1: a metadata-only mtime touch of this
+/// process's already-written heartbeat — no data write, mirroring
+/// [`touch_beacon`]'s mechanism and opened-directory-descriptor discipline
+/// exactly. Must run on every sweep tick where the warn condition persists
+/// and the heartbeat's content has not changed; a content change still
+/// goes through [`write_heartbeat`]. Callers must not assume the target
+/// exists — enumeration can delete a slow writer's heartbeat while its
+/// span is still live — and must recreate via [`write_heartbeat`] on any
+/// touch failure, never treat the record as gone for good.
+pub fn touch_heartbeat(dir: &Path, pid: u32) -> io::Result<()> {
+    let name = format!("{pid}.json");
+    #[cfg(unix)]
+    {
+        let handle = unix_impl::SidecarDirHandle::open_or_create(dir)?;
+        handle.touch_mtime(&name)
+    }
+    #[cfg(windows)]
+    {
+        windows_impl::touch_mtime(dir, &name)
+    }
+}
+
 /// Remove this process's registration beacon, if present (fail-closed
 /// escalation for a failing heartbeat write path — see the sidecar
 /// `observe` logic in `khive-db`'s checkpoint module). Never follows a
@@ -1684,20 +1717,27 @@ fn now_epoch_secs() -> i64 {
 }
 
 /// Staleness window for a producer sweeping at `interval`: three missed
-/// ticks, floored at one second — subsecond intervals must not collapse the
-/// window to zero, which would make any timestamp other than the current
-/// wall-clock second appear stale.
+/// ticks of a cadence floored at one second (ADR-091 Amendment 3 Plank F1's
+/// `3 x max(interval, 1000ms)`) — a sub-second interval must not collapse
+/// the window below what mtime resolution can distinguish, which would make
+/// any timestamp other than the current wall-clock second appear stale.
 #[cfg(unix)]
 fn stale_window_from(interval: Duration) -> i64 {
+    // ADR-091 Amendment 3 Plank F1's determinate form is `3 x
+    // max(declared cadence, 1000ms)` — clamp the interval to the
+    // mtime-resolution floor FIRST, then multiply by three, so a
+    // sub-second cadence floors the effective window at three seconds
+    // rather than merely at one. `max(3*interval, 1s)` (multiplying
+    // first) would under-floor any cadence below ~333ms.
     interval
-        .saturating_mul(3)
         .max(Duration::from_secs(1))
+        .saturating_mul(3)
         .as_secs() as i64
 }
 
 /// Per-record staleness window: the producer's own recorded cadence wins;
-/// `0` (a record written before `interval_ms` existed) falls back to the
-/// enumerator's window.
+/// `0` (a record written before `sweep_interval_ms` existed) falls back to
+/// the enumerator's window.
 #[cfg(unix)]
 fn stale_window_secs(producer_interval_ms: u64, fallback_secs: i64) -> i64 {
     if producer_interval_ms == 0 {
@@ -1793,11 +1833,11 @@ fn enumerate_live_bounded(
     };
 
     let now = now_epoch_secs();
-    // Fallback window for records that predate the `interval_ms` field —
-    // records carrying their producer's own cadence are judged against it
-    // instead (see `stale_window_secs`), so a session sweeping on an
-    // independently slower configured interval is not misread as stale by
-    // a faster-ticking daemon.
+    // Fallback window for records that predate the `sweep_interval_ms`
+    // field — records carrying their producer's own cadence are judged
+    // against it instead (see `stale_window_secs`), so a session sweeping
+    // on an independently slower configured interval is not misread as
+    // stale by a faster-ticking daemon.
     let fallback_window_secs = stale_window_from(sweep_interval);
 
     let mut heartbeats: std::collections::HashMap<u32, WalpinHeartbeat> = Default::default();
@@ -1882,13 +1922,22 @@ fn enumerate_live_bounded(
                 let _ = handle.unlink_tolerant(&name);
                 continue;
             }
-            // `updated_at` is the heartbeat's own field (refreshed every
-            // tick the warn condition persists); the entry's mtime tracks
-            // it closely, but the JSON field is the authoritative source
-            // the ADR specifies for heartbeat freshness. The window is the
-            // PRODUCER's recorded cadence, not the enumerator's.
-            let window = stale_window_secs(heartbeat.interval_ms, fallback_window_secs);
-            let hb_fresh = epoch_abs_diff(now, heartbeat.updated_at) <= window as u64;
+            // ADR-091 Amendment 3 Plank F1: a record carrying
+            // `oldest_tx_started_at` is new-style — its body is only
+            // rewritten on content change, so freshness is judged against
+            // the entry's mtime (advanced by a metadata-only touch every
+            // tick), never the possibly-stale `updated_at` body field. A
+            // record without it predates this amendment and is read
+            // exactly as before: `updated_at` is its own freshness field.
+            // Either way the window is the PRODUCER's recorded cadence,
+            // not the enumerator's — the mixed-version rule (readers accept
+            // both generations; see the amendment) depends on this branch.
+            let window = stale_window_secs(heartbeat.sweep_interval_ms, fallback_window_secs);
+            let hb_fresh = if heartbeat.oldest_tx_started_at.is_some() {
+                epoch_abs_diff(now, mtime_secs) <= window as u64
+            } else {
+                epoch_abs_diff(now, heartbeat.updated_at) <= window as u64
+            };
             if !hb_fresh {
                 let _ = handle.unlink_tolerant(&name);
                 wedged.insert(pid);
@@ -1922,7 +1971,7 @@ fn enumerate_live_bounded(
             // metadata-only touch), not any JSON field — the beacon's body
             // is written once and never refreshed. The window is the
             // producer's recorded cadence, not the enumerator's.
-            let window = stale_window_secs(beacon.interval_ms, fallback_window_secs);
+            let window = stale_window_secs(beacon.sweep_interval_ms, fallback_window_secs);
             let fresh = epoch_abs_diff(now, mtime_secs) <= window as u64;
             if !fresh {
                 let _ = handle.unlink_tolerant(&name);
@@ -1994,14 +2043,16 @@ mod tests {
     }
 
     fn heartbeat(pid: u32) -> WalpinHeartbeat {
+        let now = now_epoch_secs();
         WalpinHeartbeat {
             pid,
             process_role: "session".to_string(),
             started_at: process_start_time_secs(std::process::id()).unwrap_or(0),
             oldest_tx_age_secs: 45.0,
             oldest_tx_label: Some("test_span".to_string()),
-            updated_at: now_epoch_secs(),
-            interval_ms: 5_000,
+            oldest_tx_started_at: Some(now - 45),
+            updated_at: now,
+            sweep_interval_ms: 5_000,
             attribution_basis: Some("origin".to_string()),
         }
     }
@@ -2134,7 +2185,7 @@ mod tests {
             pid,
             process_role: "session".to_string(),
             started_at: process_start_time_secs(std::process::id()).unwrap_or(0),
-            interval_ms: 5_000,
+            sweep_interval_ms: 5_000,
         }
     }
 
@@ -2171,6 +2222,9 @@ mod tests {
         let root = tempfile::tempdir().unwrap();
         let dir = root.path().join("khive.db.walpin");
         let mut hb = heartbeat(std::process::id());
+        // Pre-amendment (`updated_at`-basis) record: this test exercises
+        // `epoch_abs_diff`'s overflow protection on that field specifically.
+        hb.oldest_tx_started_at = None;
         hb.updated_at = i64::MIN;
         write_heartbeat(&dir, &hb).unwrap();
 
@@ -2316,6 +2370,8 @@ mod tests {
         let root = tempfile::tempdir().unwrap();
         let dir = root.path().join("khive.db.walpin");
         let mut hb = heartbeat(std::process::id());
+        // Pre-amendment record: freshness classifies on `updated_at` alone.
+        hb.oldest_tx_started_at = None;
         hb.updated_at = now_epoch_secs() - 3600; // far outside 3 sweep intervals
         write_heartbeat(&dir, &hb).unwrap();
 
@@ -2518,6 +2574,8 @@ mod tests {
         let pid = std::process::id();
         write_beacon(&dir, &beacon(pid)).unwrap();
         let mut hb = heartbeat(pid);
+        // Pre-amendment record: freshness classifies on `updated_at` alone.
+        hb.oldest_tx_started_at = None;
         hb.updated_at = now_epoch_secs() - 3600;
         write_heartbeat(&dir, &hb).unwrap();
 
@@ -2560,7 +2618,12 @@ mod tests {
     /// Producer-cadence regression: freshness is judged against the cadence
     /// RECORDED in the entry, not the enumerating daemon's interval — a
     /// session sweeping on an independently slower configured interval must
-    /// not be misread as stale by a faster-ticking daemon.
+    /// not be misread as stale by a faster-ticking daemon. Pre-amendment
+    /// records (`oldest_tx_started_at: None`) still classify on `updated_at`
+    /// (ADR-091 Amendment 3 Plank F1 mixed-version rule) — a new-style
+    /// record's `updated_at` would go stale under a touch-only tick even
+    /// while its mtime stays fresh, so this test pins the basis this
+    /// exercises to the old-style body field deliberately.
     #[test]
     #[cfg(unix)]
     fn heartbeat_freshness_uses_producer_cadence_not_enumerator_interval() {
@@ -2569,7 +2632,8 @@ mod tests {
         let pid = std::process::id();
 
         let mut slow = heartbeat(pid);
-        slow.interval_ms = 60_000;
+        slow.oldest_tx_started_at = None;
+        slow.sweep_interval_ms = 60_000;
         slow.updated_at = now_epoch_secs() - 30;
         write_heartbeat(&dir, &slow).unwrap();
 
@@ -2586,12 +2650,152 @@ mod tests {
         // Control: the same 30s-old timestamp under a recorded 1s cadence
         // IS stale — the recorded cadence cuts both ways.
         let mut fast = heartbeat(pid);
-        fast.interval_ms = 1_000;
+        fast.oldest_tx_started_at = None;
+        fast.sweep_interval_ms = 1_000;
         fast.updated_at = now_epoch_secs() - 30;
         write_heartbeat(&dir, &fast).unwrap();
         let report = enumerate_live(&dir, Duration::from_secs(60)).unwrap();
         assert_eq!(report.reporting().count(), 0);
         assert_eq!(report.unknown_pids().collect::<Vec<_>>(), vec![pid]);
+    }
+
+    /// ADR-091 Amendment 3 Plank F1 mixed-version rule: a record carrying
+    /// `oldest_tx_started_at` is new-style and classifies on the entry's
+    /// mtime, never the body's `updated_at` field — a stale `updated_at`
+    /// (as a touch-only tick would leave it) must not make a genuinely
+    /// fresh entry classify stale.
+    #[test]
+    #[cfg(unix)]
+    fn enumerate_live_new_style_heartbeat_uses_mtime_not_stale_updated_at() {
+        let root = tempfile::tempdir().unwrap();
+        let dir = root.path().join("khive.db.walpin");
+        let mut hb = heartbeat(std::process::id());
+        hb.updated_at = now_epoch_secs() - 3600;
+        write_heartbeat(&dir, &hb).unwrap(); // mtime is fresh (just written)
+
+        let report = enumerate_live(&dir, Duration::from_secs(5)).unwrap();
+        assert_eq!(
+            report.reporting().count(),
+            1,
+            "a new-style record with a fresh mtime must classify live regardless \
+             of a stale `updated_at` body field: {report:?}"
+        );
+    }
+
+    /// Complement of the above: a new-style record whose mtime has fallen
+    /// outside the declared window classifies stale even though its body's
+    /// `updated_at` field looks fresh — proving the classification basis is
+    /// genuinely the mtime, not merely "whichever of the two is fresher."
+    #[test]
+    #[cfg(unix)]
+    fn enumerate_live_new_style_heartbeat_stale_via_mtime_despite_fresh_updated_at() {
+        let root = tempfile::tempdir().unwrap();
+        let dir = root.path().join("khive.db.walpin");
+        let pid = std::process::id();
+        let hb = heartbeat(pid); // updated_at freshly set by the helper
+        write_heartbeat(&dir, &hb).unwrap();
+
+        let heartbeat_path = dir.join(format!("{pid}.json"));
+        let file = fs::OpenOptions::new()
+            .write(true)
+            .open(&heartbeat_path)
+            .unwrap();
+        file.set_modified(SystemTime::now() - Duration::from_secs(3600))
+            .unwrap();
+
+        let report = enumerate_live(&dir, Duration::from_secs(5)).unwrap();
+        assert_eq!(report.reporting().count(), 0);
+        assert_eq!(report.unknown_pids().collect::<Vec<_>>(), vec![pid]);
+        assert!(
+            !heartbeat_path.exists(),
+            "a new-style entry stale by mtime must be deleted, not merely unreported"
+        );
+    }
+
+    /// ADR-091 Amendment 3 Plank F1: `3 x max(interval, 1000ms)` is exact
+    /// and inclusive — not "roughly 3 intervals" — and a sub-second
+    /// declared cadence floors the effective window at three seconds
+    /// (flooring the interval at 1s BEFORE multiplying by 3), never at one.
+    #[test]
+    #[cfg(unix)]
+    fn stale_window_from_boundary_inclusive_and_floors_subsecond_cadence_at_three_seconds() {
+        assert_eq!(stale_window_from(Duration::from_secs(2)), 6);
+        assert_eq!(stale_window_from(Duration::from_millis(100)), 3);
+        assert_eq!(stale_window_from(Duration::from_millis(999)), 3);
+        assert_eq!(stale_window_from(Duration::from_secs(1)), 3);
+    }
+
+    /// Boundary inclusivity exercised end-to-end through `enumerate_live`:
+    /// an entry exactly `3 x max(interval, 1000ms)` old is still live
+    /// (`<=`, not `<`); one second older is stale.
+    #[test]
+    #[cfg(unix)]
+    fn enumerate_live_new_style_heartbeat_boundary_is_inclusive() {
+        let root = tempfile::tempdir().unwrap();
+        let dir = root.path().join("khive.db.walpin");
+        let pid = std::process::id();
+        let mut hb = heartbeat(pid);
+        hb.sweep_interval_ms = 2_000; // window = 3 * 2s = 6s
+
+        write_heartbeat(&dir, &hb).unwrap();
+        let heartbeat_path = dir.join(format!("{pid}.json"));
+        let touch = |age_secs: u64| {
+            let file = fs::OpenOptions::new()
+                .write(true)
+                .open(&heartbeat_path)
+                .unwrap();
+            file.set_modified(SystemTime::now() - Duration::from_secs(age_secs))
+                .unwrap();
+        };
+
+        touch(6);
+        let report = enumerate_live(&dir, Duration::from_secs(5)).unwrap();
+        assert_eq!(
+            report.reporting().count(),
+            1,
+            "exactly 3x the declared interval old must still classify live: {report:?}"
+        );
+
+        // Re-write (enumeration deletes stale/live entries it processes,
+        // but a live entry is retained — reuse the same file) and push one
+        // second past the boundary.
+        touch(7);
+        let report = enumerate_live(&dir, Duration::from_secs(5)).unwrap();
+        assert_eq!(
+            report.reporting().count(),
+            0,
+            "one second past 3x the declared interval must classify stale: {report:?}"
+        );
+    }
+
+    /// Sub-second declared cadence floors the effective window at three
+    /// seconds (not one) — exercised end-to-end, not just at the pure
+    /// `stale_window_from` function.
+    #[test]
+    #[cfg(unix)]
+    fn enumerate_live_new_style_heartbeat_subsecond_cadence_floors_at_three_seconds() {
+        let root = tempfile::tempdir().unwrap();
+        let dir = root.path().join("khive.db.walpin");
+        let pid = std::process::id();
+        let mut hb = heartbeat(pid);
+        hb.sweep_interval_ms = 100; // floors to a 3s window, not 300ms/1s
+
+        write_heartbeat(&dir, &hb).unwrap();
+        let heartbeat_path = dir.join(format!("{pid}.json"));
+        let file = fs::OpenOptions::new()
+            .write(true)
+            .open(&heartbeat_path)
+            .unwrap();
+        file.set_modified(SystemTime::now() - Duration::from_secs(2))
+            .unwrap();
+
+        let report = enumerate_live(&dir, Duration::from_secs(5)).unwrap();
+        assert_eq!(
+            report.reporting().count(),
+            1,
+            "a 100ms declared cadence must floor its window at 3s, not 1s: 2s old must \
+             still classify live: {report:?}"
+        );
     }
 
     /// A FIFO planted at a sidecar entry name must be refused as `Unknown`

--- a/crates/khive-db/src/walpin.rs
+++ b/crates/khive-db/src/walpin.rs
@@ -26,17 +26,32 @@
 //! anchors to) is Unix-only: its sole caller is the daemon's checkpoint task,
 //! and daemon mode itself requires Unix (`khive-mcp/src/serve.rs` refuses
 //! `--daemon` on non-Unix). The Unix write path is additionally
-//! **handle-bound**: the sidecar directory is opened once with
-//! `O_DIRECTORY | O_NOFOLLOW`, validated on that file descriptor, and every
-//! create/rename/unlink/enumeration read is performed `*at()`-relative to it
-//! — the path is never re-resolved per operation, closing the window where a
-//! path component swapped between a path-based validation and the subsequent
-//! operation could redirect a rename or deletion outside the sidecar. Windows
-//! has no equivalent of `openat`/`fstat`-bound ownership validation in `std`;
-//! it uses plain `std::fs` path-based primitives with symlink refusal via
-//! `symlink_metadata` and no uid/mode check (documented residual gap: a
-//! Windows sidecar directory is only as protected as its inherited ACL, not
-//! actively narrowed by this code).
+//! **handle-bound at every path component**: reaching the sidecar directory
+//! walks each component of its parent path with
+//! `openat(.., O_DIRECTORY | O_NOFOLLOW)` relative to the previous
+//! descriptor (never a single `open()` on the parent's full path, which
+//! only refuses a symlink at the parent's own final component and silently
+//! follows every component before it), the directory itself is then
+//! validated on the resulting file descriptor, and every
+//! create/rename/unlink/enumeration read is performed `*at()`-relative to
+//! it — no path is ever re-resolved per operation. The final path
+//! component (the sidecar directory's own name, derived from the database
+//! file name) is converted to its `openat` argument byte-exact, never via a
+//! lossy UTF-8 conversion, since this project supports non-UTF-8 database
+//! paths and a lossy conversion could collide two distinct database names
+//! onto one sidecar directory. Windows has no `openat`/`fstat`-bound
+//! ownership-validation equivalent in `std`, so this module talks to the
+//! Win32 API directly: every write/rename/delete opens its target with
+//! `FILE_FLAG_OPEN_REPARSE_POINT` (never following a symlink/junction at
+//! the target), validates on the resulting handle via
+//! `GetFileInformationByHandle`, confirms the handle's OS-resolved path
+//! (`GetFinalPathNameByHandle`) sits inside the validated directory
+//! handle's own resolved path, and performs the rename/delete itself
+//! through `SetFileInformationByHandle` on that same handle — never a
+//! re-resolved path in between. There is no uid/mode-equivalent narrowing
+//! on Windows (documented residual gap: a Windows sidecar directory is
+//! only as protected as its inherited ACL, not actively narrowed by this
+//! code — ADR-091 specifies handle-bound validation, not ACL hardening).
 
 use std::fs;
 use std::io;
@@ -285,6 +300,20 @@ mod unix_impl {
             .map_err(|_| io_other(format!("sidecar entry name {name:?} contains a NUL byte")))
     }
 
+    /// Byte-exact `CString` construction for a path component that may come
+    /// from an arbitrary database file name (never lossy `to_string_lossy`
+    /// conversion): the sidecar directory's own final component is derived
+    /// from the caller's database path (see `sidecar_dir_for`), and this
+    /// project explicitly supports non-UTF-8 database paths (`pool.rs`'s
+    /// `mint_db_identity_non_utf8_path_round_trips`). A lossy conversion
+    /// here would map distinct non-UTF-8 names to the same replacement-
+    /// character byte sequence, colliding two different databases onto one
+    /// sidecar directory.
+    fn name_cstring_os(name: &std::ffi::OsStr) -> io::Result<CString> {
+        CString::new(name.as_bytes())
+            .map_err(|_| io_other(format!("sidecar entry name {name:?} contains a NUL byte")))
+    }
+
     fn is_symlink_mode(mode: libc::mode_t) -> bool {
         (mode & libc::S_IFMT) == libc::S_IFLNK
     }
@@ -335,17 +364,21 @@ mod unix_impl {
             }
         }
 
-        /// Open `dir`'s parent directory (`O_DIRECTORY | O_NOFOLLOW`) and
-        /// return it alongside `dir`'s final path component, so the caller
-        /// can `openat()` `dir` itself relative to an already-live
-        /// descriptor instead of re-resolving `dir`'s full path. A bare
-        /// `open(dir, O_NOFOLLOW)` only refuses a symlink at `dir`'s own,
-        /// final component — an attacker who can replace `dir`'s *parent*
-        /// between path construction and this open would still redirect the
-        /// lookup, since intermediate path components are always followed
-        /// regardless of `O_NOFOLLOW`. Anchoring on the parent's descriptor
-        /// closes that gap for `dir` the same way `SidecarDirHandle` already
-        /// closes it for every entry `dir` contains.
+        /// Open `dir`'s parent directory and return it alongside `dir`'s
+        /// final path component (as an exact, non-lossy `CString` — see
+        /// [`name_cstring_os`]), so the caller can `openat()` `dir` itself
+        /// relative to an already-live descriptor instead of re-resolving
+        /// `dir`'s full path. The parent is reached via
+        /// [`open_dir_component_walk`], which refuses a symlink at EVERY
+        /// path component, not just `dir`'s own final one — a bare
+        /// `open(parent, O_NOFOLLOW)` only refuses a symlink at `parent`'s
+        /// own final component; every component before that is followed by
+        /// ordinary kernel path resolution, so an attacker who can replace
+        /// any ancestor of `dir` between path construction and this open
+        /// would still redirect the lookup. Anchoring on a descriptor at
+        /// every level closes that gap for `dir` the same way
+        /// `SidecarDirHandle` already closes it for every entry `dir`
+        /// contains.
         fn open_parent_and_name(dir: &Path) -> io::Result<(fs::File, CString)> {
             let parent = match dir.parent() {
                 Some(p) if !p.as_os_str().is_empty() => p,
@@ -356,13 +389,47 @@ mod unix_impl {
                     "walpin sidecar path {dir:?} has no final path component"
                 ))
             })?;
-            let c_parent = path_cstring(parent)?;
-            // SAFETY: `c_parent` is NUL-terminated for the call; the
+            let parent_file = Self::open_dir_component_walk(parent)?;
+            let c_name = name_cstring_os(name)?;
+            Ok((parent_file, c_name))
+        }
+
+        /// Open `path` (a directory) as an owned descriptor by walking
+        /// every path component with `openat(.., O_DIRECTORY | O_NOFOLLOW)`
+        /// relative to the previous descriptor — anchored at `/` for an
+        /// absolute path, or the current directory for a relative one. A
+        /// single `open(path, O_NOFOLLOW)` only refuses a symlink at
+        /// `path`'s own, final component; every intermediate component is
+        /// followed by ordinary kernel path resolution regardless of that
+        /// flag. Walking component-by-component makes each individual
+        /// `openat` call's "final component" the immediate next segment, so
+        /// `O_NOFOLLOW` refuses a symlink at every level, not just the last.
+        ///
+        /// The walk runs over `path` resolved through `fs::canonicalize`
+        /// first, not the caller's literal path: legitimate OS-level
+        /// ancestor symlinks (macOS's `/tmp -> private/tmp`, `/var ->
+        /// private/var`) are a normal part of the filesystem layout, not an
+        /// attacker's TOCTOU target, and refusing them outright would
+        /// refuse every sidecar under the platform's own temp/var trees.
+        /// `canonicalize` resolves those once, up front; the descriptor
+        /// walk that follows is what closes the actual race ADR-091 cares
+        /// about — an ancestor swapped for a symlink AFTER `canonicalize`
+        /// returns but before (or during) this walk is refused component by
+        /// component via `O_NOFOLLOW`, rather than silently re-resolved the
+        /// way a second path-based open would.
+        fn open_dir_component_walk(path: &Path) -> io::Result<fs::File> {
+            use std::path::Component;
+
+            let path = fs::canonicalize(path)?;
+            let path = path.as_path();
+            let anchor = if path.is_absolute() { "/" } else { "." };
+            let c_anchor = path_cstring(Path::new(anchor))?;
+            // SAFETY: `c_anchor` is NUL-terminated for the call; the
             // returned fd is uniquely owned by this call and wrapped
             // immediately.
             let fd = unsafe {
                 libc::open(
-                    c_parent.as_ptr(),
+                    c_anchor.as_ptr(),
                     libc::O_DIRECTORY | libc::O_NOFOLLOW | libc::O_CLOEXEC,
                 )
             };
@@ -370,9 +437,32 @@ mod unix_impl {
                 return Err(io::Error::last_os_error());
             }
             // SAFETY: `fd` was just returned by the successful `open` above.
-            let parent_file = unsafe { fs::File::from_raw_fd(fd) };
-            let c_name = name_cstring(&name.to_string_lossy())?;
-            Ok((parent_file, c_name))
+            let mut current = unsafe { fs::File::from_raw_fd(fd) };
+
+            for component in path.components() {
+                let name = match component {
+                    Component::RootDir | Component::CurDir | Component::Prefix(_) => continue,
+                    Component::ParentDir => std::ffi::OsStr::new(".."),
+                    Component::Normal(c) => c,
+                };
+                let c_name = name_cstring_os(name)?;
+                // SAFETY: `c_name` is NUL-terminated for the call; `current`
+                // is a live, open directory descriptor for the call's
+                // duration; the returned fd is uniquely owned by this call
+                // and wrapped immediately.
+                let next_fd = unsafe {
+                    libc::openat(
+                        current.as_raw_fd(),
+                        c_name.as_ptr(),
+                        libc::O_DIRECTORY | libc::O_NOFOLLOW | libc::O_CLOEXEC,
+                    )
+                };
+                if next_fd < 0 {
+                    return Err(io::Error::last_os_error());
+                }
+                current = unsafe { fs::File::from_raw_fd(next_fd) };
+            }
+            Ok(current)
         }
 
         fn open_validated_at(
@@ -777,37 +867,207 @@ mod unix_impl {
 #[cfg(windows)]
 mod windows_impl {
     use super::io_other;
+    use std::ffi::OsStr;
     use std::fs;
     use std::io::{self, Write};
     use std::os::raw::c_void;
-    use std::os::windows::ffi::OsStrExt;
-    use std::path::Path;
+    use std::os::windows::ffi::{OsStrExt, OsStringExt};
+    use std::os::windows::io::{AsRawHandle, FromRawHandle, RawHandle};
+    use std::path::{Path, PathBuf};
     use std::time::SystemTime;
 
+    fn to_wide_nul(path: &Path) -> Vec<u16> {
+        let mut wide: Vec<u16> = path.as_os_str().encode_wide().collect();
+        wide.push(0);
+        wide
+    }
+
+    /// Open `path` with `FILE_FLAG_OPEN_REPARSE_POINT`, so a symlink or
+    /// junction planted at `path`'s own final component is opened AS that
+    /// reparse-point object itself, never followed. The returned `File`
+    /// owns the handle and closes it exactly once, on drop.
+    fn open_reparse_aware(
+        path: &Path,
+        access: u32,
+        disposition: u32,
+        extra_flags: u32,
+    ) -> io::Result<fs::File> {
+        let wide = to_wide_nul(path);
+        // SAFETY: `wide` is a valid, NUL-terminated UTF-16 string for the
+        // call's duration; the returned handle, on success, is uniquely
+        // owned by this call and wrapped immediately below.
+        let handle = unsafe {
+            CreateFileW(
+                wide.as_ptr(),
+                access,
+                FILE_SHARE_READ | FILE_SHARE_WRITE,
+                std::ptr::null_mut(),
+                disposition,
+                FILE_FLAG_OPEN_REPARSE_POINT | extra_flags,
+                std::ptr::null_mut(),
+            )
+        };
+        if handle == invalid_handle_value() {
+            return Err(io::Error::last_os_error());
+        }
+        // SAFETY: `handle` was just returned by the successful `CreateFileW`
+        // above; wrapping it in `File` binds its lifetime to this value so
+        // it is closed exactly once, on drop.
+        Ok(unsafe { fs::File::from_raw_handle(handle as RawHandle) })
+    }
+
+    fn file_info(file: &fs::File) -> io::Result<ByHandleFileInformation> {
+        let mut info: ByHandleFileInformation = unsafe { std::mem::zeroed() };
+        // SAFETY: `file`'s handle is live; `info` is a valid,
+        // appropriately-sized output buffer for the call.
+        if unsafe { GetFileInformationByHandle(file.as_raw_handle() as Handle, &mut info) } == 0 {
+            return Err(io::Error::last_os_error());
+        }
+        Ok(info)
+    }
+
+    /// The handle's own OS-resolved canonical path, queried from the live
+    /// object rather than re-derived from a path string — the binding half
+    /// of the handle-bound contract: a path can be swapped by a concurrent
+    /// rename/symlink between a path-based validation and a path-based
+    /// use, but a resolved handle always names the exact object it was
+    /// opened against.
+    fn resolved_path(file: &fs::File) -> io::Result<PathBuf> {
+        let mut buf: Vec<u16> = vec![0u16; 260];
+        loop {
+            // SAFETY: `file`'s handle is live; `buf` is a valid output
+            // buffer of its declared capacity.
+            let len = unsafe {
+                GetFinalPathNameByHandleW(
+                    file.as_raw_handle() as Handle,
+                    buf.as_mut_ptr(),
+                    buf.len() as u32,
+                    0,
+                )
+            };
+            if len == 0 {
+                return Err(io::Error::last_os_error());
+            }
+            if (len as usize) < buf.len() {
+                buf.truncate(len as usize);
+                return Ok(PathBuf::from(std::ffi::OsString::from_wide(&buf)));
+            }
+            buf.resize(len as usize + 1, 0);
+        }
+    }
+
+    /// `resolved` must sit directly inside `dir_resolved` — the binding
+    /// check that catches `dir` (or an ancestor of it) having been swapped
+    /// for a symlink between the directory handle's own validation and
+    /// this entry's open.
+    fn verify_under(resolved: &Path, dir_resolved: &Path, target: &Path) -> io::Result<()> {
+        if resolved.parent() != Some(dir_resolved) {
+            return Err(io_other(format!(
+                "walpin sidecar path {target:?} resolved outside its validated directory"
+            )));
+        }
+        Ok(())
+    }
+
+    /// Open the sidecar directory as a validated handle: a real directory,
+    /// never a reparse point, checked on the OPENED handle via
+    /// `GetFileInformationByHandle` — never a separate path-based query
+    /// that a later operation could re-resolve against a different object.
+    fn open_dir_handle(dir: &Path) -> io::Result<fs::File> {
+        let file = open_reparse_aware(dir, 0, OPEN_EXISTING, FILE_FLAG_BACKUP_SEMANTICS)?;
+        let info = file_info(&file)?;
+        if info.dw_file_attributes & FILE_ATTRIBUTE_REPARSE_POINT != 0 {
+            return Err(io_other(format!(
+                "walpin sidecar path {dir:?} is a symlink; refusing"
+            )));
+        }
+        if info.dw_file_attributes & FILE_ATTRIBUTE_DIRECTORY == 0 {
+            return Err(io_other(format!(
+                "walpin sidecar path {dir:?} exists and is not a directory"
+            )));
+        }
+        Ok(file)
+    }
+
     pub(super) fn ensure_sidecar_dir(dir: &Path) -> io::Result<()> {
-        match fs::symlink_metadata(dir) {
-            Ok(meta) => validate(dir, &meta),
+        match open_dir_handle(dir) {
+            Ok(_) => Ok(()),
             Err(e) if e.kind() == io::ErrorKind::NotFound => {
                 fs::create_dir(dir)?;
                 // Re-validate post-creation the same way the Unix path
                 // does: a concurrent process could have raced this create.
-                let meta = fs::symlink_metadata(dir)?;
-                validate(dir, &meta)
+                open_dir_handle(dir).map(|_| ())
             }
             Err(e) => Err(e),
         }
     }
 
-    fn validate(dir: &Path, meta: &fs::Metadata) -> io::Result<()> {
-        if meta.file_type().is_symlink() {
-            return Err(io_other(format!(
-                "walpin sidecar path {dir:?} is a symlink; refusing"
-            )));
+    fn delete_via_handle(file: &fs::File) -> io::Result<()> {
+        let info = FileDispositionInfo { delete_pending: 1 };
+        // SAFETY: `file`'s handle is live and was opened with `DELETE`
+        // access; `info` is a valid, correctly sized input buffer for the
+        // `FileDispositionInfo` class.
+        let ok = unsafe {
+            SetFileInformationByHandle(
+                file.as_raw_handle() as Handle,
+                FILE_DISPOSITION_INFO_CLASS,
+                &info as *const FileDispositionInfo as *mut c_void,
+                std::mem::size_of::<FileDispositionInfo>() as u32,
+            )
+        };
+        if ok == 0 {
+            return Err(io::Error::last_os_error());
         }
-        if !meta.is_dir() {
-            return Err(io_other(format!(
-                "walpin sidecar path {dir:?} exists and is not a directory"
-            )));
+        Ok(())
+    }
+
+    /// Handle-bound rename: `RootDirectory` is the validated directory's
+    /// own handle, so the new name resolves relative to the directory the
+    /// caller already proved is real and non-reparse — the closest Win32
+    /// equivalent to Unix `renameat`, since `CreateFileW` itself has no
+    /// directory-relative open primitive.
+    fn rename_via_handle(
+        file: &fs::File,
+        dir_handle: &fs::File,
+        target_name: &str,
+    ) -> io::Result<()> {
+        let wide: Vec<u16> = OsStr::new(target_name).encode_wide().collect();
+        let name_bytes = wide.len() * 2;
+        // `size_of::<FileRenameInfo>() - 2` over-counts the true header
+        // offset by however much trailing struct padding rounds the whole
+        // type up to its 8-byte alignment — always >= the real `file_name`
+        // field offset, so the buffer this sizes is never too small, only
+        // (harmlessly) a few bytes larger than strictly required.
+        let header_size = std::mem::size_of::<FileRenameInfo>() - 2;
+        let total_size = header_size + name_bytes;
+        let words = total_size.div_ceil(8).max(1);
+        let mut buf: Vec<u64> = vec![0u64; words];
+        // SAFETY: `buf` is 8-byte aligned (backed by `Vec<u64>`) and sized
+        // to hold at least the header plus `name_bytes` of `file_name`; the
+        // pointer arithmetic below stays within that allocation.
+        unsafe {
+            let header = buf.as_mut_ptr() as *mut FileRenameInfo;
+            (*header).replace_if_exists = 1;
+            (*header).root_directory = dir_handle.as_raw_handle() as Handle;
+            (*header).file_name_length = name_bytes as u32;
+            let name_ptr = (*header).file_name.as_mut_ptr();
+            std::ptr::copy_nonoverlapping(wide.as_ptr(), name_ptr, wide.len());
+        }
+        let byte_ptr = buf.as_mut_ptr() as *mut c_void;
+        // SAFETY: `file`'s handle is live and was opened with `DELETE`
+        // access (required by the `FileRenameInfo` class); `byte_ptr`
+        // addresses the well-formed buffer built above, sized exactly
+        // `total_size`.
+        let ok = unsafe {
+            SetFileInformationByHandle(
+                file.as_raw_handle() as Handle,
+                FILE_RENAME_INFO_CLASS,
+                byte_ptr,
+                total_size as u32,
+            )
+        };
+        if ok == 0 {
+            return Err(io::Error::last_os_error());
         }
         Ok(())
     }
@@ -818,110 +1078,118 @@ mod windows_impl {
         tmp_name: &str,
         body: &[u8],
     ) -> io::Result<()> {
+        let dir_handle = open_dir_handle(dir)?;
+        let dir_resolved = resolved_path(&dir_handle)?;
+
+        // Refuse a pre-existing symlink at the target — checked on an
+        // opened handle (never followed, via `FILE_FLAG_OPEN_REPARSE_POINT`)
+        // rather than a path query a later step could re-resolve
+        // differently.
         let target = dir.join(target_name);
-        if let Ok(meta) = fs::symlink_metadata(&target) {
-            if meta.file_type().is_symlink() {
-                return Err(io_other(format!(
-                    "walpin sidecar path {target:?} is a symlink; refusing to write through it"
-                )));
+        match open_reparse_aware(&target, 0, OPEN_EXISTING, 0) {
+            Ok(existing) => {
+                let info = file_info(&existing)?;
+                if info.dw_file_attributes & FILE_ATTRIBUTE_REPARSE_POINT != 0 {
+                    return Err(io_other(format!(
+                        "walpin sidecar path {target:?} is a symlink; refusing to write through it"
+                    )));
+                }
             }
+            Err(e) if e.kind() == io::ErrorKind::NotFound => {}
+            Err(e) => return Err(e),
         }
+
+        // Best-effort stale-tmp cleanup: delete-on-close via a
+        // reparse-aware handle removes whatever object sits at `tmp_name`
+        // (including a symlink itself, never its target) without a
+        // separate path-based `remove_file` re-resolving it.
         let tmp = dir.join(tmp_name);
-        let _ = fs::remove_file(&tmp);
-        {
-            let mut file = fs::OpenOptions::new()
-                .write(true)
-                .create_new(true)
-                .open(&tmp)?;
-            file.write_all(body)?;
-            file.sync_all()?;
+        if let Ok(stale) = open_reparse_aware(&tmp, DELETE, OPEN_EXISTING, 0) {
+            let _ = delete_via_handle(&stale);
         }
-        fs::rename(&tmp, &target)
+
+        let mut tmp_file = open_reparse_aware(&tmp, GENERIC_WRITE | DELETE, CREATE_NEW, 0)?;
+        verify_under(&resolved_path(&tmp_file)?, &dir_resolved, &tmp)?;
+        tmp_file.write_all(body)?;
+        tmp_file.sync_all()?;
+        rename_via_handle(&tmp_file, &dir_handle, target_name)
     }
 
     pub(super) fn remove_checked(dir: &Path, name: &str) -> io::Result<()> {
+        let dir_handle = open_dir_handle(dir)?;
+        let dir_resolved = resolved_path(&dir_handle)?;
         let target = dir.join(name);
-        match fs::symlink_metadata(&target) {
-            Ok(meta) if meta.file_type().is_symlink() => Err(io_other(format!(
-                "refusing to remove symlinked walpin sidecar entry {target:?}"
-            ))),
-            Ok(_) => fs::remove_file(&target),
-            Err(e) if e.kind() == io::ErrorKind::NotFound => Ok(()),
-            Err(e) => Err(e),
-        }
-    }
-
-    /// Validation-then-operation on a plain path (the `write_atomic`/
-    /// `remove_checked` pattern above) is a TOCTOU race: nothing pins the
-    /// object between `symlink_metadata` and the follow-up open. The touch
-    /// path is hardened against it — `CreateFileW` with
-    /// `FILE_FLAG_OPEN_REPARSE_POINT` opens `target` AS a reparse point
-    /// rather than following it, the reparse-point check runs against the
-    /// SAME opened handle via `GetFileInformationByHandle`, and the mtime
-    /// update (`SetFileTime`) runs on that same handle — never a
-    /// re-resolved path. Pre-existing races on the write/remove paths above
-    /// are a wider class left for a follow-up; this closes it for the
-    /// per-tick touch/recreate path only.
-    pub(super) fn touch_mtime(dir: &Path, name: &str) -> io::Result<()> {
-        let target = dir.join(name);
-        let mut wide: Vec<u16> = target.as_os_str().encode_wide().collect();
-        wide.push(0);
-
-        // SAFETY: `wide` is a valid, NUL-terminated UTF-16 string for the
-        // call's duration; `FILE_FLAG_OPEN_REPARSE_POINT` means a
-        // symlink/junction at `target` is opened as itself, never followed.
-        let handle = unsafe {
-            CreateFileW(
-                wide.as_ptr(),
-                GENERIC_WRITE,
-                FILE_SHARE_READ | FILE_SHARE_WRITE,
-                std::ptr::null_mut(),
-                OPEN_EXISTING,
-                FILE_FLAG_OPEN_REPARSE_POINT,
-                std::ptr::null_mut(),
-            )
+        let file = match open_reparse_aware(&target, DELETE, OPEN_EXISTING, 0) {
+            Ok(f) => f,
+            Err(e) if e.kind() == io::ErrorKind::NotFound => return Ok(()),
+            Err(e) => return Err(e),
         };
-        if handle == invalid_handle_value() {
+        let info = file_info(&file)?;
+        if info.dw_file_attributes & FILE_ATTRIBUTE_REPARSE_POINT != 0 {
             return Err(io_other(format!(
-                "walpin sidecar entry {target:?} does not exist or could not be opened"
+                "refusing to remove symlinked walpin sidecar entry {target:?}"
             )));
         }
-        let result = (|| {
-            let mut info: ByHandleFileInformation = unsafe { std::mem::zeroed() };
-            // SAFETY: `handle` is the live handle opened above; `info` is a
-            // valid, appropriately-sized output buffer for the call.
-            if unsafe { GetFileInformationByHandle(handle, &mut info) } == 0 {
-                return Err(io::Error::last_os_error());
-            }
-            if info.dw_file_attributes & FILE_ATTRIBUTE_REPARSE_POINT != 0 {
-                return Err(io_other(format!(
-                    "walpin sidecar entry {target:?} is a reparse point; refusing to touch it"
-                )));
-            }
-            let now = SystemTime::now()
-                .duration_since(SystemTime::UNIX_EPOCH)
-                .map_err(|e| io_other(e.to_string()))?;
-            const EPOCH_DIFF_100NS: u64 = 116_444_736_000_000_000;
-            let ticks =
-                now.as_secs() * 10_000_000 + u64::from(now.subsec_nanos()) / 100 + EPOCH_DIFF_100NS;
-            let last_write = FileTime {
-                dw_low_date_time: (ticks & 0xFFFF_FFFF) as u32,
-                dw_high_date_time: (ticks >> 32) as u32,
-            };
-            // SAFETY: `handle` is live; null creation/access-time pointers
-            // leave those fields untouched (metadata-only mtime refresh,
-            // mirroring the Unix `UTIME_OMIT` behavior); `last_write` is a
-            // valid `FILETIME`-shaped value for the call's duration.
-            if unsafe { SetFileTime(handle, std::ptr::null(), std::ptr::null(), &last_write) } == 0
-            {
-                return Err(io::Error::last_os_error());
-            }
-            Ok(())
-        })();
-        // SAFETY: `handle` was opened above and is closed exactly once
-        // here, regardless of the touch outcome.
-        unsafe { CloseHandle(handle) };
-        result
+        verify_under(&resolved_path(&file)?, &dir_resolved, &target)?;
+        delete_via_handle(&file)
+    }
+
+    /// Validation-then-operation on a plain path (the historical
+    /// `write_atomic`/`remove_checked` pattern) is a TOCTOU race: nothing
+    /// pins the object between a path-based validation and a follow-up
+    /// path-based open. Every write/rename/delete path above, and the
+    /// touch path below, are hardened against it the same way:
+    /// `CreateFileW` with `FILE_FLAG_OPEN_REPARSE_POINT` opens the target
+    /// AS a reparse point rather than following it, the reparse-point
+    /// check runs against the SAME opened handle via
+    /// `GetFileInformationByHandle`, the created/opened object's identity
+    /// is confirmed via `GetFinalPathNameByHandle` against the validated
+    /// directory handle's own resolved path, and the rename/delete
+    /// themselves run through `SetFileInformationByHandle` on that same
+    /// handle — never a re-resolved path. ACL hardening is explicitly NOT
+    /// part of this: ADR-091 specifies handle-bound validation, not ACL
+    /// narrowing, so a Windows sidecar directory remains only as protected
+    /// as its inherited ACL — a residual, documented gap, not an
+    /// oversight.
+    pub(super) fn touch_mtime(dir: &Path, name: &str) -> io::Result<()> {
+        let target = dir.join(name);
+        let file = open_reparse_aware(&target, GENERIC_WRITE, OPEN_EXISTING, 0).map_err(|_| {
+            io_other(format!(
+                "walpin sidecar entry {target:?} does not exist or could not be opened"
+            ))
+        })?;
+        let info = file_info(&file)?;
+        if info.dw_file_attributes & FILE_ATTRIBUTE_REPARSE_POINT != 0 {
+            return Err(io_other(format!(
+                "walpin sidecar entry {target:?} is a reparse point; refusing to touch it"
+            )));
+        }
+        let now = SystemTime::now()
+            .duration_since(SystemTime::UNIX_EPOCH)
+            .map_err(|e| io_other(e.to_string()))?;
+        const EPOCH_DIFF_100NS: u64 = 116_444_736_000_000_000;
+        let ticks =
+            now.as_secs() * 10_000_000 + u64::from(now.subsec_nanos()) / 100 + EPOCH_DIFF_100NS;
+        let last_write = FileTime {
+            dw_low_date_time: (ticks & 0xFFFF_FFFF) as u32,
+            dw_high_date_time: (ticks >> 32) as u32,
+        };
+        // SAFETY: `file`'s handle is live; null creation/access-time
+        // pointers leave those fields untouched (metadata-only mtime
+        // refresh, mirroring the Unix `UTIME_OMIT` behavior); `last_write`
+        // is a valid `FILETIME`-shaped value for the call's duration.
+        if unsafe {
+            SetFileTime(
+                file.as_raw_handle() as Handle,
+                std::ptr::null(),
+                std::ptr::null(),
+                &last_write,
+            )
+        } == 0
+        {
+            return Err(io::Error::last_os_error());
+        }
+        Ok(())
     }
 
     type Handle = *mut c_void;
@@ -933,9 +1201,9 @@ mod windows_impl {
     }
 
     /// Mirrors Win32's `BY_HANDLE_FILE_INFORMATION` layout exactly — every
-    /// field must stay present and in order even though [`touch_mtime`]
-    /// only reads `dw_file_attributes`, since `GetFileInformationByHandle`
-    /// writes the full struct.
+    /// field must stay present and in order even though callers here only
+    /// read `dw_file_attributes`, since `GetFileInformationByHandle` writes
+    /// the full struct.
     #[repr(C)]
     struct ByHandleFileInformation {
         dw_file_attributes: u32,
@@ -950,14 +1218,42 @@ mod windows_impl {
         n_file_index_low: u32,
     }
 
+    /// Mirrors Win32's `FILE_RENAME_INFO` (the pre-Windows-10-1607 layout,
+    /// the one `SetFileInformationByHandle`'s `FileRenameInfo` class
+    /// expects): a `BOOLEAN`, then a `HANDLE` (natural alignment inserts
+    /// padding between them, matched here by `repr(C)`), a `DWORD` length,
+    /// and a flexible `WCHAR` array sized by `file_name_length` bytes — the
+    /// trailing `[u16; 1]` is a placeholder; real instances are built in a
+    /// manually sized buffer in [`rename_via_handle`].
+    #[repr(C)]
+    struct FileRenameInfo {
+        replace_if_exists: u8,
+        root_directory: Handle,
+        file_name_length: u32,
+        file_name: [u16; 1],
+    }
+
+    /// Mirrors Win32's `FILE_DISPOSITION_INFO`: a single `BOOLEAN` marking
+    /// the handle's object for delete-on-close.
+    #[repr(C)]
+    struct FileDispositionInfo {
+        delete_pending: u8,
+    }
+
     const PROCESS_QUERY_LIMITED_INFORMATION: u32 = 0x1000;
     const STILL_ACTIVE: u32 = 259;
     const GENERIC_WRITE: u32 = 0x4000_0000;
+    const DELETE: u32 = 0x0001_0000;
     const FILE_SHARE_READ: u32 = 0x0000_0001;
     const FILE_SHARE_WRITE: u32 = 0x0000_0002;
     const OPEN_EXISTING: u32 = 3;
+    const CREATE_NEW: u32 = 1;
+    const FILE_FLAG_BACKUP_SEMANTICS: u32 = 0x0200_0000;
     const FILE_FLAG_OPEN_REPARSE_POINT: u32 = 0x0020_0000;
     const FILE_ATTRIBUTE_REPARSE_POINT: u32 = 0x0000_0400;
+    const FILE_ATTRIBUTE_DIRECTORY: u32 = 0x0000_0010;
+    const FILE_RENAME_INFO_CLASS: i32 = 3;
+    const FILE_DISPOSITION_INFO_CLASS: i32 = 4;
 
     fn invalid_handle_value() -> Handle {
         usize::MAX as Handle
@@ -996,6 +1292,18 @@ mod windows_impl {
             lp_creation_time: *const FileTime,
             lp_last_access_time: *const FileTime,
             lp_last_write_time: *const FileTime,
+        ) -> i32;
+        fn GetFinalPathNameByHandleW(
+            h_file: Handle,
+            lp_sz_file_path: *mut u16,
+            cch_file_path: u32,
+            dw_flags: u32,
+        ) -> u32;
+        fn SetFileInformationByHandle(
+            h_file: Handle,
+            file_information_class: i32,
+            lp_file_information: *mut c_void,
+            dw_buffer_size: u32,
         ) -> i32;
     }
 
@@ -2374,6 +2682,61 @@ mod tests {
         assert!(err.to_string().contains("symlink"));
         // The real file behind the symlink must be untouched.
         assert_eq!(fs::read_to_string(&real).unwrap(), "nope");
+    }
+
+    /// Regression for the review-round-2 finding: the resolver used to
+    /// convert the sidecar directory's final `OsStr` component via
+    /// `to_string_lossy()` before `openat`, so two distinct non-UTF-8
+    /// database names (which differ only in their invalid byte) both
+    /// lossy-collapsed to the same `U+FFFD`-bearing name and cross-
+    /// contaminated attribution onto one physical sidecar directory. This
+    /// project explicitly supports non-UTF-8 database paths (see
+    /// `pool.rs`'s `mint_db_identity_non_utf8_path_round_trips`), so the
+    /// sidecar resolver must preserve that same byte-exact distinctness.
+    #[cfg(unix)]
+    #[test]
+    fn sidecar_dir_distinguishes_non_utf8_db_names_on_disk() {
+        use std::os::unix::ffi::OsStrExt;
+
+        let root = tempfile::tempdir().unwrap();
+        // 0xFF and 0xFE are each invalid standalone UTF-8 bytes; both
+        // lossy-convert to the same U+FFFD replacement character.
+        let name_a = std::ffi::OsStr::from_bytes(b"khive-\xffdb.sqlite");
+        let name_b = std::ffi::OsStr::from_bytes(b"khive-\xfedb.sqlite");
+        let dir_a = sidecar_dir_for(&root.path().join(name_a));
+        let dir_b = sidecar_dir_for(&root.path().join(name_b));
+        assert_ne!(
+            dir_a, dir_b,
+            "distinct db names must produce distinct sidecar paths"
+        );
+
+        let hb = heartbeat(std::process::id());
+        // Some Unix filesystems (notably macOS's APFS) reject non-UTF-8
+        // names outright at the syscall level — a filesystem limitation,
+        // not a bug under test here, so skip rather than fail in that case
+        // (mirrors pool.rs's non-UTF-8 round-trip test).
+        if let Err(e) = write_heartbeat(&dir_a, &hb) {
+            eprintln!(
+                "skipping sidecar_dir_distinguishes_non_utf8_db_names_on_disk: filesystem \
+                 rejected a non-UTF-8 sidecar directory name ({e}); this platform's filesystem \
+                 does not support the case under test"
+            );
+            return;
+        }
+        write_heartbeat(&dir_b, &hb).expect("write to second non-UTF-8 sidecar");
+
+        let mut entries: Vec<_> = fs::read_dir(root.path())
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .map(|e| e.file_name())
+            .collect();
+        entries.sort();
+        assert_eq!(
+            entries.len(),
+            2,
+            "distinct non-UTF-8 database names must produce two distinct sidecar directories \
+             on disk, not collide onto one: got {entries:?}"
+        );
     }
 
     #[test]

--- a/crates/khive-db/src/walpin.rs
+++ b/crates/khive-db/src/walpin.rs
@@ -85,8 +85,11 @@ pub struct WalpinHeartbeat {
     /// daemon's — two processes with independently configured sweep
     /// intervals must not misread each other as stale. `0` (absent in a
     /// record written before this field existed) falls back to the
-    /// enumerator's own interval.
-    #[serde(default)]
+    /// enumerator's own interval. `interval_ms` is accepted as an alias for
+    /// records written before the ADR-091 Amendment 2 review-follow-up
+    /// rename — a live writer still on the old field name must not have its
+    /// real cadence silently dropped to the enumerator's fallback.
+    #[serde(default, alias = "interval_ms")]
     pub sweep_interval_ms: u64,
     /// ADR-091 Amendment 3 Plank F2: `"origin"` when the oldest span above
     /// carried this backend's own origin identity, `"fallback"` when it was
@@ -145,7 +148,10 @@ pub struct WalpinBeacon {
     /// The producer's own sweep cadence in milliseconds — the beacon's
     /// refresh mtime is judged against this cadence at enumeration, not the
     /// enumerating daemon's. `0` falls back to the enumerator's interval.
-    #[serde(default)]
+    /// `interval_ms` is accepted as an alias — see
+    /// [`WalpinHeartbeat::sweep_interval_ms`] for why the old field name
+    /// must still deserialize correctly.
+    #[serde(default, alias = "interval_ms")]
     pub sweep_interval_ms: u64,
 }
 
@@ -295,19 +301,22 @@ mod unix_impl {
         /// the OPENED descriptor, never trusted from the `mkdir` call alone
         /// — a concurrent process could have raced the creation.
         pub(super) fn open_or_create(dir: &Path) -> io::Result<Self> {
-            match Self::open_validated(dir) {
+            let (parent_fd, c_name) = Self::open_parent_and_name(dir)?;
+            match Self::open_validated_at(&parent_fd, &c_name, dir) {
                 Ok(handle) => Ok(handle),
                 Err(e) if e.kind() == io::ErrorKind::NotFound => {
-                    let c_path = path_cstring(dir)?;
-                    // SAFETY: `c_path` is NUL-terminated for the call.
-                    let rc = unsafe { libc::mkdir(c_path.as_ptr(), 0o700) };
+                    // SAFETY: `c_name` is NUL-terminated for the call;
+                    // `parent_fd` is a live, open directory descriptor for
+                    // the call's duration.
+                    let rc =
+                        unsafe { libc::mkdirat(parent_fd.as_raw_fd(), c_name.as_ptr(), 0o700) };
                     if rc != 0 {
                         let err = io::Error::last_os_error();
                         if err.kind() != io::ErrorKind::AlreadyExists {
                             return Err(err);
                         }
                     }
-                    Self::open_validated(dir)
+                    Self::open_validated_at(&parent_fd, &c_name, dir)
                 }
                 Err(e) => Err(e),
             }
@@ -318,26 +327,73 @@ mod unix_impl {
         /// not an error, and must not have the side effect of creating one
         /// — e.g. a stray `remove_heartbeat`/`touch_beacon` call).
         pub(super) fn open_if_exists(dir: &Path) -> io::Result<Option<Self>> {
-            match Self::open_validated(dir) {
+            let (parent_fd, c_name) = Self::open_parent_and_name(dir)?;
+            match Self::open_validated_at(&parent_fd, &c_name, dir) {
                 Ok(handle) => Ok(Some(handle)),
                 Err(e) if e.kind() == io::ErrorKind::NotFound => Ok(None),
                 Err(e) => Err(e),
             }
         }
 
-        fn open_validated(dir: &Path) -> io::Result<Self> {
-            let c_path = path_cstring(dir)?;
-            // SAFETY: `c_path` is NUL-terminated for the call; the returned
-            // fd is uniquely owned by this call and wrapped immediately.
+        /// Open `dir`'s parent directory (`O_DIRECTORY | O_NOFOLLOW`) and
+        /// return it alongside `dir`'s final path component, so the caller
+        /// can `openat()` `dir` itself relative to an already-live
+        /// descriptor instead of re-resolving `dir`'s full path. A bare
+        /// `open(dir, O_NOFOLLOW)` only refuses a symlink at `dir`'s own,
+        /// final component — an attacker who can replace `dir`'s *parent*
+        /// between path construction and this open would still redirect the
+        /// lookup, since intermediate path components are always followed
+        /// regardless of `O_NOFOLLOW`. Anchoring on the parent's descriptor
+        /// closes that gap for `dir` the same way `SidecarDirHandle` already
+        /// closes it for every entry `dir` contains.
+        fn open_parent_and_name(dir: &Path) -> io::Result<(fs::File, CString)> {
+            let parent = match dir.parent() {
+                Some(p) if !p.as_os_str().is_empty() => p,
+                _ => Path::new("."),
+            };
+            let name = dir.file_name().ok_or_else(|| {
+                io_other(format!(
+                    "walpin sidecar path {dir:?} has no final path component"
+                ))
+            })?;
+            let c_parent = path_cstring(parent)?;
+            // SAFETY: `c_parent` is NUL-terminated for the call; the
+            // returned fd is uniquely owned by this call and wrapped
+            // immediately.
             let fd = unsafe {
                 libc::open(
-                    c_path.as_ptr(),
+                    c_parent.as_ptr(),
+                    libc::O_DIRECTORY | libc::O_NOFOLLOW | libc::O_CLOEXEC,
+                )
+            };
+            if fd < 0 {
+                return Err(io::Error::last_os_error());
+            }
+            // SAFETY: `fd` was just returned by the successful `open` above.
+            let parent_file = unsafe { fs::File::from_raw_fd(fd) };
+            let c_name = name_cstring(&name.to_string_lossy())?;
+            Ok((parent_file, c_name))
+        }
+
+        fn open_validated_at(
+            parent_fd: &fs::File,
+            c_name: &CString,
+            dir: &Path,
+        ) -> io::Result<Self> {
+            // SAFETY: `c_name` is NUL-terminated for the call; `parent_fd`
+            // is a live, open directory descriptor for the call's duration;
+            // the returned fd is uniquely owned by this call and wrapped
+            // immediately.
+            let fd = unsafe {
+                libc::openat(
+                    parent_fd.as_raw_fd(),
+                    c_name.as_ptr(),
                     libc::O_DIRECTORY | libc::O_NOFOLLOW | libc::O_CLOEXEC,
                 )
             };
             if fd < 0 {
                 let err = io::Error::last_os_error();
-                // The `O_NOFOLLOW` open above already made the refusal
+                // The `O_NOFOLLOW` openat above already made the refusal
                 // decision (a symlink at `dir` cannot have produced a live
                 // fd) — this is diagnostic-only, not a second
                 // security check, so it carries no TOCTOU risk. It exists
@@ -355,7 +411,7 @@ mod unix_impl {
                 }
                 return Err(err);
             }
-            // SAFETY: `fd` was just returned by the successful `open` above.
+            // SAFETY: `fd` was just returned by the successful `openat` above.
             let handle = Self(unsafe { fs::File::from_raw_fd(fd) });
             handle.validate(dir)?;
             Ok(handle)
@@ -724,6 +780,7 @@ mod windows_impl {
     use std::fs;
     use std::io::{self, Write};
     use std::os::raw::c_void;
+    use std::os::windows::ffi::OsStrExt;
     use std::path::Path;
     use std::time::SystemTime;
 
@@ -794,17 +851,77 @@ mod windows_impl {
         }
     }
 
+    /// Validation-then-operation on a plain path (the `write_atomic`/
+    /// `remove_checked` pattern above) is a TOCTOU race: nothing pins the
+    /// object between `symlink_metadata` and the follow-up open. The touch
+    /// path is hardened against it — `CreateFileW` with
+    /// `FILE_FLAG_OPEN_REPARSE_POINT` opens `target` AS a reparse point
+    /// rather than following it, the reparse-point check runs against the
+    /// SAME opened handle via `GetFileInformationByHandle`, and the mtime
+    /// update (`SetFileTime`) runs on that same handle — never a
+    /// re-resolved path. Pre-existing races on the write/remove paths above
+    /// are a wider class left for a follow-up; this closes it for the
+    /// per-tick touch/recreate path only.
     pub(super) fn touch_mtime(dir: &Path, name: &str) -> io::Result<()> {
         let target = dir.join(name);
-        let meta = fs::symlink_metadata(&target)
-            .map_err(|_| io_other(format!("walpin sidecar entry {target:?} does not exist")))?;
-        if meta.file_type().is_symlink() {
+        let mut wide: Vec<u16> = target.as_os_str().encode_wide().collect();
+        wide.push(0);
+
+        // SAFETY: `wide` is a valid, NUL-terminated UTF-16 string for the
+        // call's duration; `FILE_FLAG_OPEN_REPARSE_POINT` means a
+        // symlink/junction at `target` is opened as itself, never followed.
+        let handle = unsafe {
+            CreateFileW(
+                wide.as_ptr(),
+                GENERIC_WRITE,
+                FILE_SHARE_READ | FILE_SHARE_WRITE,
+                std::ptr::null_mut(),
+                OPEN_EXISTING,
+                FILE_FLAG_OPEN_REPARSE_POINT,
+                std::ptr::null_mut(),
+            )
+        };
+        if handle == invalid_handle_value() {
             return Err(io_other(format!(
-                "walpin sidecar entry {target:?} is a symlink; refusing to touch it"
+                "walpin sidecar entry {target:?} does not exist or could not be opened"
             )));
         }
-        let file = fs::OpenOptions::new().write(true).open(&target)?;
-        file.set_modified(SystemTime::now())
+        let result = (|| {
+            let mut info: ByHandleFileInformation = unsafe { std::mem::zeroed() };
+            // SAFETY: `handle` is the live handle opened above; `info` is a
+            // valid, appropriately-sized output buffer for the call.
+            if unsafe { GetFileInformationByHandle(handle, &mut info) } == 0 {
+                return Err(io::Error::last_os_error());
+            }
+            if info.dw_file_attributes & FILE_ATTRIBUTE_REPARSE_POINT != 0 {
+                return Err(io_other(format!(
+                    "walpin sidecar entry {target:?} is a reparse point; refusing to touch it"
+                )));
+            }
+            let now = SystemTime::now()
+                .duration_since(SystemTime::UNIX_EPOCH)
+                .map_err(|e| io_other(e.to_string()))?;
+            const EPOCH_DIFF_100NS: u64 = 116_444_736_000_000_000;
+            let ticks =
+                now.as_secs() * 10_000_000 + u64::from(now.subsec_nanos()) / 100 + EPOCH_DIFF_100NS;
+            let last_write = FileTime {
+                dw_low_date_time: (ticks & 0xFFFF_FFFF) as u32,
+                dw_high_date_time: (ticks >> 32) as u32,
+            };
+            // SAFETY: `handle` is live; null creation/access-time pointers
+            // leave those fields untouched (metadata-only mtime refresh,
+            // mirroring the Unix `UTIME_OMIT` behavior); `last_write` is a
+            // valid `FILETIME`-shaped value for the call's duration.
+            if unsafe { SetFileTime(handle, std::ptr::null(), std::ptr::null(), &last_write) } == 0
+            {
+                return Err(io::Error::last_os_error());
+            }
+            Ok(())
+        })();
+        // SAFETY: `handle` was opened above and is closed exactly once
+        // here, regardless of the touch outcome.
+        unsafe { CloseHandle(handle) };
+        result
     }
 
     type Handle = *mut c_void;
@@ -815,8 +932,36 @@ mod windows_impl {
         dw_high_date_time: u32,
     }
 
+    /// Mirrors Win32's `BY_HANDLE_FILE_INFORMATION` layout exactly — every
+    /// field must stay present and in order even though [`touch_mtime`]
+    /// only reads `dw_file_attributes`, since `GetFileInformationByHandle`
+    /// writes the full struct.
+    #[repr(C)]
+    struct ByHandleFileInformation {
+        dw_file_attributes: u32,
+        ft_creation_time: FileTime,
+        ft_last_access_time: FileTime,
+        ft_last_write_time: FileTime,
+        dw_volume_serial_number: u32,
+        n_file_size_high: u32,
+        n_file_size_low: u32,
+        n_number_of_links: u32,
+        n_file_index_high: u32,
+        n_file_index_low: u32,
+    }
+
     const PROCESS_QUERY_LIMITED_INFORMATION: u32 = 0x1000;
     const STILL_ACTIVE: u32 = 259;
+    const GENERIC_WRITE: u32 = 0x4000_0000;
+    const FILE_SHARE_READ: u32 = 0x0000_0001;
+    const FILE_SHARE_WRITE: u32 = 0x0000_0002;
+    const OPEN_EXISTING: u32 = 3;
+    const FILE_FLAG_OPEN_REPARSE_POINT: u32 = 0x0020_0000;
+    const FILE_ATTRIBUTE_REPARSE_POINT: u32 = 0x0000_0400;
+
+    fn invalid_handle_value() -> Handle {
+        usize::MAX as Handle
+    }
 
     // `kernel32` is implicitly linked on every Windows target (same as
     // `std` itself relies on); no explicit `#[link(...)]` is needed, mirroring
@@ -832,6 +977,25 @@ mod windows_impl {
             lp_exit_time: *mut FileTime,
             lp_kernel_time: *mut FileTime,
             lp_user_time: *mut FileTime,
+        ) -> i32;
+        fn CreateFileW(
+            lp_file_name: *const u16,
+            dw_desired_access: u32,
+            dw_share_mode: u32,
+            lp_security_attributes: *mut c_void,
+            dw_creation_disposition: u32,
+            dw_flags_and_attributes: u32,
+            h_template_file: Handle,
+        ) -> Handle;
+        fn GetFileInformationByHandle(
+            h_file: Handle,
+            lp_file_information: *mut ByHandleFileInformation,
+        ) -> i32;
+        fn SetFileTime(
+            h_file: Handle,
+            lp_creation_time: *const FileTime,
+            lp_last_access_time: *const FileTime,
+            lp_last_write_time: *const FileTime,
         ) -> i32;
     }
 
@@ -2162,6 +2326,38 @@ mod tests {
         let content = fs::read_to_string(dir.join(format!("{}.json", hb.pid))).unwrap();
         let read_back: WalpinHeartbeat = serde_json::from_str(&content).unwrap();
         assert_eq!(read_back, hb);
+    }
+
+    #[test]
+    fn heartbeat_deserializes_pre_rename_interval_ms_field() {
+        // Old-format sidecar body from a writer that predates the
+        // `interval_ms` -> `sweep_interval_ms` rename. A live writer still
+        // on the old field name must keep its real cadence, not silently
+        // fall back to the enumerator's default (which can misjudge a slow
+        // writer's heartbeat as stale mid-upgrade).
+        let json = r#"{
+            "pid": 4242,
+            "process_role": "session",
+            "started_at": 1000,
+            "oldest_tx_age_secs": 45.0,
+            "oldest_tx_label": "test_span",
+            "updated_at": 1045,
+            "interval_ms": 60000
+        }"#;
+        let hb: WalpinHeartbeat = serde_json::from_str(json).unwrap();
+        assert_eq!(hb.sweep_interval_ms, 60_000);
+    }
+
+    #[test]
+    fn beacon_deserializes_pre_rename_interval_ms_field() {
+        let json = r#"{
+            "pid": 4242,
+            "process_role": "session",
+            "started_at": 1000,
+            "interval_ms": 60000
+        }"#;
+        let b: WalpinBeacon = serde_json::from_str(json).unwrap();
+        assert_eq!(b.sweep_interval_ms, 60_000);
     }
 
     #[test]

--- a/crates/khive-db/src/writer_task.rs
+++ b/crates/khive-db/src/writer_task.rs
@@ -327,8 +327,9 @@ impl WriterTaskHandle {
 /// migration-slice scope this commits per `BEGIN IMMEDIATE`.
 pub fn spawn(pool: &ConnectionPool, capacity: usize) -> Result<WriterTaskHandle, SqliteError> {
     let conn = pool.open_standalone_writer()?;
+    let origin = pool.origin();
     let (tx, rx) = mpsc::channel(capacity.max(1));
-    tokio::spawn(run_writer_task(conn, rx));
+    tokio::spawn(run_writer_task(conn, rx, origin));
     Ok(WriterTaskHandle { tx })
 }
 
@@ -344,8 +345,10 @@ pub fn spawn(pool: &ConnectionPool, capacity: usize) -> Result<WriterTaskHandle,
 async fn run_writer_task(
     mut conn: Connection,
     mut rx: mpsc::Receiver<Box<dyn AnyWriteRequest + Send>>,
+    origin: khive_storage::tx_registry::TxOrigin,
 ) {
     while let Some(request) = rx.recv().await {
+        let origin = origin.clone();
         let outcome = tokio::task::spawn_blocking(move || {
             if request.is_top_level() {
                 // ADR-067 Component A:
@@ -358,8 +361,10 @@ async fn run_writer_task(
                 request.execute_and_reply_top_level(&conn);
                 return conn;
             }
-            let _tx_handle =
-                khive_storage::tx_registry::register(Some("writer_task_tx".to_string()));
+            let _tx_handle = khive_storage::tx_registry::register_scoped(
+                Some("writer_task_tx".to_string()),
+                origin,
+            );
             match conn.execute_batch("BEGIN IMMEDIATE") {
                 Ok(()) => request.execute_and_reply(&conn),
                 Err(e) => {

--- a/crates/khive-mcp/src/daemon.rs
+++ b/crates/khive-mcp/src/daemon.rs
@@ -397,6 +397,10 @@ impl daemon::DaemonDispatch for crate::server::KhiveMcpServer {
         self.pool()
     }
 
+    fn secondary_pools_for_checkpoint(&self) -> Vec<std::sync::Arc<khive_db::ConnectionPool>> {
+        self.secondary_pools()
+    }
+
     fn event_store_for_checkpoint(&self) -> Option<std::sync::Arc<dyn khive_storage::EventStore>> {
         self.event_store()
     }

--- a/crates/khive-mcp/src/serve.rs
+++ b/crates/khive-mcp/src/serve.rs
@@ -3,7 +3,7 @@
 //! This is the bootstrap that the `kkernel mcp` subcommand drives. Logging is
 //! initialized by the binary, not here.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
 use std::sync::Arc;
 
@@ -133,9 +133,11 @@ impl SessionSweepHandle {
     }
 }
 
-/// Spawn the ADR-091 Amendment 2 Plank A observe-only session sweep task for
-/// this process's checkpoint pool, if it has one (a checkpoint pool is only
-/// wired for file-backed backends — see `checkpoint_pool_for`). Returns a
+/// Spawn the ADR-091 Amendment 2 Plank A observe-only session sweep task,
+/// fanned out over every file-backed backend this server carries: `pool` as
+/// the main backend, plus one entry per pool in `secondary_pools` (ADR-091
+/// Amendment 3). Returns `None` only when the server has no file-backed
+/// backend at all (a purely in-memory or registry-only server). Returns a
 /// [`SessionSweepHandle`] the caller MUST hold for the session's run scope
 /// and shut down explicitly (see [`SessionSweepHandle::shutdown`]) — mirrors
 /// `run_checkpoint_task`'s shutdown-channel contract on the daemon side.
@@ -155,20 +157,26 @@ impl SessionSweepHandle {
 /// classifies as `reporting`/`registered-silent` (not a permanent `unknown`)
 /// whenever a Unix daemon does enumerate the shared sidecar directory.
 fn spawn_session_walpin_sweep(server: &KhiveMcpServer) -> Option<SessionSweepHandle> {
-    let pool = server.pool()?;
-    // ADR-091 Amendment 3: this server exposes exactly one backend pool
-    // today, so it is always the sweep's main backend — the sidecar
-    // directory and registry view are keyed off the pool's own minted
-    // identity internally, not a raw configured path passed in here.
-    // Multi-backend discovery (a secondary pool per additional wired
-    // backend) is a separate wiring concern from this single-pool server.
+    let mut backends = Vec::new();
+    if let Some(pool) = server.pool() {
+        backends.push(khive_db::SweepBackend {
+            pool,
+            is_main: true,
+        });
+    }
+    for pool in server.secondary_pools() {
+        backends.push(khive_db::SweepBackend {
+            pool,
+            is_main: false,
+        });
+    }
+    if backends.is_empty() {
+        return None;
+    }
     let config = khive_db::SessionSweepConfig::from_env();
     let (shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(());
     let join = tokio::spawn(khive_db::run_session_sweep_task(
-        vec![khive_db::SweepBackend {
-            pool,
-            is_main: true,
-        }],
+        backends,
         config,
         shutdown_rx,
     ));
@@ -2086,6 +2094,11 @@ pub fn build_server_from_multi_backend_registry(
     // only present for file-backed databases; in-memory backends return None here
     // so that checkpoint_once never runs on a non-WAL connection.
     let pool = checkpoint_pool_for(multi.main_backend.as_ref());
+    // ADR-091 Amendment 3: every OTHER file-backed backend this registry
+    // wired, so the session sweep (`spawn_session_walpin_sweep`) and the
+    // daemon's checkpoint task can attribute and checkpoint them instead of
+    // leaving them permanently invisible to cross-process WAL-pin attribution.
+    let secondary_pools = secondary_file_backed_pools(&multi);
     let fmt = apply_env_output_format(khive_cfg.runtime.default_output_format);
 
     let server = KhiveMcpServer::from_registry_with_meta(
@@ -2093,7 +2106,8 @@ pub fn build_server_from_multi_backend_registry(
         &multi.default_namespace,
         &multi.config_id,
     )
-    .with_default_output_format(fmt);
+    .with_default_output_format(fmt)
+    .with_secondary_pools(secondary_pools);
 
     let server = match coordinator {
         Some(c) => server.with_coordinator(c),
@@ -2104,6 +2118,31 @@ pub fn build_server_from_multi_backend_registry(
         Some(p) => server.with_pool(p),
         None => server,
     }
+}
+
+/// Distinct file-backed backend pools among `multi`'s per-pack runtimes,
+/// excluding the main backend's own pool (wired separately via
+/// [`checkpoint_pool_for`]) — ADR-091 Amendment 3 fan-out needs exactly one
+/// entry per additional file-backed backend the registry wired, not one per
+/// pack, since several packs can share a backend. Dedup is pool-identity
+/// (`Arc::as_ptr`), the same pointer-identity discipline
+/// `apply_schema_plans_with_map` (khive-runtime) already uses to tell
+/// backends apart.
+fn secondary_file_backed_pools(multi: &MultiBackendRegistry) -> Vec<Arc<ConnectionPool>> {
+    let main_ptr = Arc::as_ptr(&multi.main_backend.pool_arc());
+    let mut seen: HashSet<*const ConnectionPool> = HashSet::from([main_ptr]);
+    let mut pools = Vec::new();
+    for rt in multi.per_pack_runtimes.values() {
+        let backend = rt.backend();
+        if !backend.is_file_backed() {
+            continue;
+        }
+        let pool = backend.pool_arc();
+        if seen.insert(Arc::as_ptr(&pool)) {
+            pools.push(pool);
+        }
+    }
+    pools
 }
 
 /// Construction-time facts that every multi-backend boot path must agree on

--- a/crates/khive-mcp/src/serve.rs
+++ b/crates/khive-mcp/src/serve.rs
@@ -156,7 +156,10 @@ impl SessionSweepHandle {
 /// whenever a Unix daemon does enumerate the shared sidecar directory.
 fn spawn_session_walpin_sweep(server: &KhiveMcpServer) -> Option<SessionSweepHandle> {
     let pool = server.pool()?;
-    let db_path = pool.config().path.clone();
+    // ADR-091 backend-scoped attribution: the sidecar directory is keyed off
+    // the pool's minted canonical identity, not the raw configured path — the
+    // same convergence every other consumer of that identity relies on.
+    let db_path = pool.canonical_path().map(std::path::PathBuf::from);
     let config = khive_db::SessionSweepConfig::from_env();
     let (shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(());
     let join = tokio::spawn(khive_db::run_session_sweep_task(

--- a/crates/khive-mcp/src/serve.rs
+++ b/crates/khive-mcp/src/serve.rs
@@ -156,14 +156,19 @@ impl SessionSweepHandle {
 /// whenever a Unix daemon does enumerate the shared sidecar directory.
 fn spawn_session_walpin_sweep(server: &KhiveMcpServer) -> Option<SessionSweepHandle> {
     let pool = server.pool()?;
-    // ADR-091 backend-scoped attribution: the sidecar directory is keyed off
-    // the pool's minted canonical identity, not the raw configured path — the
-    // same convergence every other consumer of that identity relies on.
-    let db_path = pool.canonical_path().map(std::path::PathBuf::from);
+    // ADR-091 Amendment 3: this server exposes exactly one backend pool
+    // today, so it is always the sweep's main backend — the sidecar
+    // directory and registry view are keyed off the pool's own minted
+    // identity internally, not a raw configured path passed in here.
+    // Multi-backend discovery (a secondary pool per additional wired
+    // backend) is a separate wiring concern from this single-pool server.
     let config = khive_db::SessionSweepConfig::from_env();
     let (shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(());
     let join = tokio::spawn(khive_db::run_session_sweep_task(
-        db_path,
+        vec![khive_db::SweepBackend {
+            pool,
+            is_main: true,
+        }],
         config,
         shutdown_rx,
     ));

--- a/crates/khive-mcp/src/serve.rs
+++ b/crates/khive-mcp/src/serve.rs
@@ -2124,13 +2124,21 @@ pub fn build_server_from_multi_backend_registry(
 /// excluding the main backend's own pool (wired separately via
 /// [`checkpoint_pool_for`]) — ADR-091 Amendment 3 fan-out needs exactly one
 /// entry per additional file-backed backend the registry wired, not one per
-/// pack, since several packs can share a backend. Dedup is pool-identity
-/// (`Arc::as_ptr`), the same pointer-identity discipline
-/// `apply_schema_plans_with_map` (khive-runtime) already uses to tell
-/// backends apart.
+/// pack, since several packs can share a backend.
+///
+/// Dedup is by canonical database identity (each pool's [`TxOrigin::Database`]
+/// origin, minted from its canonical path — see `ConnectionPool::origin`),
+/// never by pool pointer: two backends configured with alias spellings of
+/// the SAME file (a direct path and a symlinked path, say) mint two distinct
+/// `Arc<ConnectionPool>` but converge on one canonical sidecar, and admitting
+/// both would race two `SweepBackend`s on the same heartbeat file.
 fn secondary_file_backed_pools(multi: &MultiBackendRegistry) -> Vec<Arc<ConnectionPool>> {
-    let main_ptr = Arc::as_ptr(&multi.main_backend.pool_arc());
-    let mut seen: HashSet<*const ConnectionPool> = HashSet::from([main_ptr]);
+    use khive_storage::tx_registry::TxOrigin;
+
+    let mut seen: HashSet<khive_storage::tx_registry::DbIdentity> = HashSet::new();
+    if let TxOrigin::Database(id) = multi.main_backend.pool_arc().origin() {
+        seen.insert(id);
+    }
     let mut pools = Vec::new();
     for rt in multi.per_pack_runtimes.values() {
         let backend = rt.backend();
@@ -2138,7 +2146,14 @@ fn secondary_file_backed_pools(multi: &MultiBackendRegistry) -> Vec<Arc<Connecti
             continue;
         }
         let pool = backend.pool_arc();
-        if seen.insert(Arc::as_ptr(&pool)) {
+        let TxOrigin::Database(id) = pool.origin() else {
+            // A file-backed backend always mints a `Database` origin
+            // (`ConnectionPool::origin`'s own contract); anything else here
+            // has no canonical identity to dedup on, so it cannot be
+            // admitted as a secondary fan-out target.
+            continue;
+        };
+        if seen.insert(id) {
             pools.push(pool);
         }
     }
@@ -4275,6 +4290,106 @@ region = "us-east-1"
             "secondary-backend pack must have core_backend wired to main (ADR-073); \
              core().backend_id() returned {:?} — build_pack_runtime wiring missing",
             comm_rt.core().backend_id().as_str()
+        );
+    }
+
+    /// ADR-091 Amendment 3 fan-out regression: two backends declared at
+    /// alias spellings of the SAME database file (a direct path and a
+    /// symlinked path) must mint the same canonical `DbIdentity` and
+    /// therefore dedup to exactly one secondary pool. The pointer-identity
+    /// dedup this replaced would have kept both `Arc<ConnectionPool>`
+    /// instances distinct, letting two `SweepBackend`s race on one
+    /// heartbeat file.
+    #[test]
+    #[serial]
+    #[cfg(unix)]
+    fn secondary_pools_dedup_by_canonical_identity_across_alias_spellings() {
+        use khive_runtime::PackConfig;
+
+        let dir = tempfile::tempdir().unwrap();
+        let real_path = dir.path().join("khive.db");
+        std::fs::write(&real_path, b"").unwrap();
+        let alias_path = dir.path().join("khive_alias.db");
+        std::os::unix::fs::symlink(&real_path, &alias_path).unwrap();
+
+        let khive_cfg = KhiveConfig {
+            backends: vec![
+                BackendConfig {
+                    name: "main".to_string(),
+                    kind: BackendKind::Memory,
+                    path: None,
+                    cache_mb: None,
+                    journal_mode: None,
+                    read_only: false,
+                },
+                BackendConfig {
+                    name: "direct".to_string(),
+                    kind: BackendKind::Sqlite,
+                    path: Some(real_path.clone()),
+                    cache_mb: None,
+                    journal_mode: None,
+                    read_only: false,
+                },
+                BackendConfig {
+                    name: "alias".to_string(),
+                    kind: BackendKind::Sqlite,
+                    path: Some(alias_path.clone()),
+                    cache_mb: None,
+                    journal_mode: None,
+                    read_only: false,
+                },
+            ],
+            packs: {
+                let mut m = std::collections::HashMap::new();
+                m.insert(
+                    "kg".to_string(),
+                    PackConfig {
+                        backend: "direct".to_string(),
+                    },
+                );
+                m.insert(
+                    "comm".to_string(),
+                    PackConfig {
+                        backend: "alias".to_string(),
+                    },
+                );
+                m
+            },
+            ..KhiveConfig::default()
+        };
+
+        let base_cfg = base_runtime_config_for_multi_backend();
+        let multi = build_registry_for_multi_backend(base_cfg, &khive_cfg, None)
+            .expect("multi-backend registry with alias-spelled backends must boot");
+
+        let secondary = secondary_file_backed_pools(&multi);
+        assert_eq!(
+            secondary.len(),
+            1,
+            "two backends aliasing the same database file must dedup to exactly one \
+             secondary pool by canonical identity, got {} pools",
+            secondary.len()
+        );
+
+        let server = build_server_from_multi_backend_registry(multi, &khive_cfg, None);
+        let mut backends = Vec::new();
+        if let Some(pool) = server.pool() {
+            backends.push(khive_db::SweepBackend {
+                pool,
+                is_main: true,
+            });
+        }
+        for pool in server.secondary_pools() {
+            backends.push(khive_db::SweepBackend {
+                pool,
+                is_main: false,
+            });
+        }
+        assert_eq!(
+            backends.len(),
+            1,
+            "exactly one SweepBackend must survive dedup for the alias pair — the \
+             in-memory main backend contributes no pool of its own"
         );
     }
 

--- a/crates/khive-mcp/src/server.rs
+++ b/crates/khive-mcp/src/server.rs
@@ -210,6 +210,12 @@ pub struct KhiveMcpServer {
     /// Pool arc for the WAL checkpoint background task. `None` for in-memory
     /// or registry-only servers that have no persistent database.
     pool: Option<Arc<ConnectionPool>>,
+    /// File-backed backend pools beyond `pool` (ADR-091 Amendment 3
+    /// fan-out): every additional backend a multi-backend boot wired, so the
+    /// session sweep and the daemon's checkpoint ownership can cover them
+    /// too. Always empty for a single-backend server — `pool` alone is that
+    /// server's one backend.
+    secondary_pools: Vec<Arc<ConnectionPool>>,
     /// Server-level default output format (ADR-078). Resolved from TOML →
     /// `KHIVE_OUTPUT_FORMAT` → builtin `json`. Per-request `format` fields
     /// override this at dispatch time.
@@ -380,6 +386,7 @@ impl KhiveMcpServer {
             config_id,
             coordinator: None,
             pool,
+            secondary_pools: Vec::new(),
             default_output_format: OutputFormat::Json,
         })
     }
@@ -400,6 +407,7 @@ impl KhiveMcpServer {
             config_id: "registry-only".to_string(),
             coordinator: None,
             pool: None,
+            secondary_pools: Vec::new(),
             default_output_format: OutputFormat::Json,
         }
     }
@@ -419,6 +427,7 @@ impl KhiveMcpServer {
             config_id: config_id.to_string(),
             coordinator: None,
             pool: None,
+            secondary_pools: Vec::new(),
             default_output_format: OutputFormat::Json,
         }
     }
@@ -450,6 +459,15 @@ impl KhiveMcpServer {
     /// because registry-only construction has no access to the backend layer).
     pub fn with_pool(mut self, pool: Arc<ConnectionPool>) -> Self {
         self.pool = Some(pool);
+        self
+    }
+
+    /// Attach every file-backed backend pool beyond the main one (ADR-091
+    /// Amendment 3 fan-out), so the session sweep and the daemon's
+    /// checkpoint task can cover the full multi-backend deployment instead
+    /// of only `pool`.
+    pub fn with_secondary_pools(mut self, pools: Vec<Arc<ConnectionPool>>) -> Self {
+        self.secondary_pools = pools;
         self
     }
 
@@ -528,6 +546,12 @@ impl KhiveMcpServer {
     /// Returns `None` for in-memory or registry-only servers.
     pub fn pool(&self) -> Option<Arc<ConnectionPool>> {
         self.pool.clone()
+    }
+
+    /// File-backed backend pools beyond [`Self::pool`] (ADR-091 Amendment 3
+    /// fan-out). Empty for a single-backend server.
+    pub fn secondary_pools(&self) -> Vec<Arc<ConnectionPool>> {
+        self.secondary_pools.clone()
     }
 
     /// This server's configured audit `EventStore`, if any (ADR-094).

--- a/crates/khive-runtime/src/daemon.rs
+++ b/crates/khive-runtime/src/daemon.rs
@@ -560,6 +560,19 @@ pub trait DaemonDispatch: Clone + Send + Sync + 'static {
         None
     }
 
+    /// File-backed backend pools beyond [`Self::pool_for_checkpoint`]'s pool
+    /// (ADR-091 Amendment 3): one checkpoint task is spawned per entry here,
+    /// in addition to the one spawned for the primary pool, so a
+    /// multi-backend deployment gets PASSIVE/TRUNCATE checkpointing and
+    /// sidecar enumeration on every file-backed backend it wired, not only
+    /// the main one.
+    ///
+    /// The default implementation returns an empty `Vec` — an implementor
+    /// with only one backend (or none) needs no override.
+    fn secondary_pools_for_checkpoint(&self) -> Vec<Arc<ConnectionPool>> {
+        Vec::new()
+    }
+
     /// Return the audit `EventStore` the checkpoint task should append
     /// ADR-094 lifecycle events (`CheckpointOutcomeRecorded`) to, if any.
     ///
@@ -1051,18 +1064,34 @@ pub async fn run_daemon_with_boot_guard<D: DaemonDispatch>(
     // scope and signalled as the first action once shutdown is observed,
     // below.
     let (checkpoint_shutdown_tx, checkpoint_shutdown_rx) = tokio::sync::watch::channel(());
+    // ADR-091 Amendment 3: one checkpoint task per file-backed backend the
+    // dispatcher wired — the primary pool plus every entry
+    // `secondary_pools_for_checkpoint` returns — sharing this one shutdown
+    // channel (the sender broadcasts to every receiver clone), so the single
+    // send below stops every spawned task before `drain()`.
+    let mut checkpoint_pools: Vec<(Arc<ConnectionPool>, bool)> = Vec::new();
     if let Some(pool) = dispatcher.pool_for_checkpoint() {
+        checkpoint_pools.push((pool, true));
+    }
+    for pool in dispatcher.secondary_pools_for_checkpoint() {
+        checkpoint_pools.push((pool, false));
+    }
+    if !checkpoint_pools.is_empty() {
         let cfg = CheckpointConfig::from_env();
         let event_store = dispatcher.event_store_for_checkpoint();
         let namespace = dispatcher.namespace().to_string();
-        track_background_task(run_checkpoint_task(
-            pool,
-            cfg,
-            event_store,
-            namespace,
-            checkpoint_shutdown_rx,
-        ));
-        tracing::info!("WAL checkpoint task started");
+        let checkpoint_task_count = checkpoint_pools.len();
+        for (pool, is_main) in checkpoint_pools {
+            track_background_task(run_checkpoint_task(
+                pool,
+                cfg.clone(),
+                event_store.clone(),
+                namespace.clone(),
+                checkpoint_shutdown_rx.clone(),
+                is_main,
+            ));
+        }
+        tracing::info!(checkpoint_task_count, "WAL checkpoint task(s) started");
     }
 
     let active = Arc::new(std::sync::atomic::AtomicUsize::new(0));

--- a/crates/khive-runtime/src/daemon.rs
+++ b/crates/khive-runtime/src/daemon.rs
@@ -723,6 +723,12 @@ pub fn active_phase_names() -> Vec<String> {
 #[cfg(unix)]
 fn build_metrics_snapshot<D: DaemonDispatch>(dispatcher: &D) -> MetricsSnapshot {
     let open_tx_count = khive_storage::tx_registry::snapshot().len();
+    // ADR-091 Amendment 3: deliberately the process-wide aggregate, not a
+    // backend-attributed view — this gauge reports "oldest pinned tx in this
+    // process" across every wired backend, not an attribution claim about
+    // which database it belongs to. Attribution consumers (the session sweep,
+    // the per-backend checkpoint tasks) use the scoped `oldest_for` views in
+    // khive-db instead.
     let (oldest_pinned_tx_micros, oldest_pinned_tx_label) =
         match khive_storage::tx_registry::oldest() {
             Some((_id, age, label)) => (Some(age.as_micros() as u64), label),

--- a/crates/khive-storage/src/tx_registry.rs
+++ b/crates/khive-storage/src/tx_registry.rs
@@ -8,6 +8,7 @@
 //! holding a WAL snapshot open.
 
 use std::collections::HashMap;
+use std::ffi::OsString;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{LazyLock, Mutex};
 use std::time::{Duration, Instant};
@@ -22,10 +23,76 @@ use std::time::{Duration, Instant};
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub struct TxId(pub u64);
 
+/// Opaque identity for a file-backed database, keyed on its already-minted
+/// canonical path. Minting (resolving aliases to one canonical path) happens
+/// at exactly one point — the pool in `khive-db` — every other layer treats
+/// this constructor as accepting that output only.
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub struct DbIdentity(OsString);
+
+impl DbIdentity {
+    pub fn new(canonical_path: impl Into<OsString>) -> Self {
+        Self(canonical_path.into())
+    }
+}
+
+/// Which database, if any, a registered span runs against. Three states,
+/// never an option: "no database file" ([`TxOrigin::Memory`]) and "not yet
+/// threaded to an origin" ([`TxOrigin::Unscoped`]) are different facts and
+/// must never share a representation.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum TxOrigin {
+    /// A file-backed database, identified by its minted [`DbIdentity`].
+    Database(DbIdentity),
+    /// An in-memory backend: no database file, no WAL, no sidecar —
+    /// excluded from WAL-pin attribution entirely.
+    Memory,
+    /// A registration site not yet threaded to an origin. Observed by the
+    /// main backend's attribution view, exactly as every entry was before
+    /// origins existed, so scoping can never silently drop a span.
+    Unscoped,
+}
+
+/// An attribution view over the registry: which origins it observes.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum TxOriginFilter {
+    /// The main backend's view: spans scoped to `main`, plus every
+    /// [`TxOrigin::Unscoped`] span (the never-silently-drop fallback).
+    Main(DbIdentity),
+    /// A secondary backend's view: spans scoped to exactly this database.
+    /// Never falls back to unscoped spans — only the main view does.
+    Secondary(DbIdentity),
+}
+
+impl TxOriginFilter {
+    fn matches(&self, origin: &TxOrigin) -> bool {
+        match (self, origin) {
+            (TxOriginFilter::Main(id), TxOrigin::Database(origin_id)) => origin_id == id,
+            (TxOriginFilter::Main(_), TxOrigin::Unscoped) => true,
+            (TxOriginFilter::Main(_), TxOrigin::Memory) => false,
+            (TxOriginFilter::Secondary(id), TxOrigin::Database(origin_id)) => origin_id == id,
+            (TxOriginFilter::Secondary(_), TxOrigin::Unscoped | TxOrigin::Memory) => false,
+        }
+    }
+}
+
+/// Identity, age, label, and origin of the oldest span an attribution view
+/// observes. Origin lets the consumer distinguish an evidence-backed
+/// `Database(_)` winner from an `Unscoped` fallback winner when writing the
+/// attribution-basis field.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct OldestSpan {
+    pub id: TxId,
+    pub age: Duration,
+    pub label: Option<String>,
+    pub origin: TxOrigin,
+}
+
 #[derive(Clone, Debug)]
 struct TxMeta {
     opened_at: Instant,
     label: Option<String>,
+    origin: TxOrigin,
 }
 
 static NEXT_ID: AtomicU64 = AtomicU64::new(1);
@@ -48,16 +115,16 @@ impl Drop for TxHandle {
     }
 }
 
-/// Register a new open transaction span with an optional diagnostic label.
-///
-/// Recovers a poisoned lock via `into_inner()` rather than dropping the
-/// write — a poisoned registry must keep tracking spans, not go silently
-/// blind. See `crates/khive-storage/docs/api/tx-registry.md`.
-pub fn register(label: Option<String>) -> TxHandle {
+/// Register a new open transaction span with an optional diagnostic label
+/// and an explicit origin. Recovers a poisoned lock via `into_inner()`
+/// rather than dropping the write — a poisoned registry must keep tracking
+/// spans, not go silently blind. See `crates/khive-storage/docs/api/tx-registry.md`.
+pub fn register_scoped(label: Option<String>, origin: TxOrigin) -> TxHandle {
     let id = TxId(NEXT_ID.fetch_add(1, Ordering::Relaxed));
     let meta = TxMeta {
         opened_at: Instant::now(),
         label,
+        origin,
     };
     let mut registry = REGISTRY
         .lock()
@@ -65,6 +132,12 @@ pub fn register(label: Option<String>) -> TxHandle {
     registry.insert(id, meta);
     drop(registry);
     TxHandle { id }
+}
+
+/// Register a new open transaction span with an optional diagnostic label.
+/// Delegates to [`register_scoped`] with [`TxOrigin::Unscoped`].
+pub fn register(label: Option<String>) -> TxHandle {
+    register_scoped(label, TxOrigin::Unscoped)
 }
 
 /// Identity, age, and label of the oldest currently-open registry entry, if
@@ -81,6 +154,26 @@ pub fn oldest() -> Option<(TxId, Duration, Option<String>)> {
         .iter()
         .min_by_key(|(_, meta)| meta.opened_at)
         .map(|(id, meta)| (*id, meta.opened_at.elapsed(), meta.label.clone()))
+}
+
+/// Identity, age, label, and origin of the oldest entry an attribution view
+/// observes, if any. See [`TxOriginFilter`] for the main/secondary view
+/// semantics and [`oldest`] for the process-wide aggregate this narrows.
+/// Recovers a poisoned lock via `into_inner()` (see [`register_scoped`]).
+pub fn oldest_for(filter: &TxOriginFilter) -> Option<OldestSpan> {
+    let registry = REGISTRY
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    registry
+        .iter()
+        .filter(|(_, meta)| filter.matches(&meta.origin))
+        .min_by_key(|(_, meta)| meta.opened_at)
+        .map(|(id, meta)| OldestSpan {
+            id: *id,
+            age: meta.opened_at.elapsed(),
+            label: meta.label.clone(),
+            origin: meta.origin.clone(),
+        })
 }
 
 /// Age and label of every currently-open registry entry. Recovers a poisoned
@@ -159,6 +252,103 @@ mod tests {
         assert!(labels.contains(&Some("snap_b".to_string())));
         drop(a);
         drop(b);
+    }
+
+    #[test]
+    fn oldest_for_partitions_by_origin() {
+        let _guard = TEST_LOCK.lock().unwrap();
+        let main_id = DbIdentity::new("main.db");
+        let secondary_id = DbIdentity::new("secondary.db");
+        let main_view = TxOriginFilter::Main(main_id.clone());
+        let secondary_view = TxOriginFilter::Secondary(secondary_id.clone());
+
+        let main_handle = register_scoped(
+            Some("main_span".to_string()),
+            TxOrigin::Database(main_id.clone()),
+        );
+        let secondary_handle = register_scoped(
+            Some("secondary_span".to_string()),
+            TxOrigin::Database(secondary_id.clone()),
+        );
+
+        let main_oldest = oldest_for(&main_view).expect("main span visible in main view");
+        assert_eq!(main_oldest.label.as_deref(), Some("main_span"));
+        assert_eq!(main_oldest.origin, TxOrigin::Database(main_id));
+
+        let secondary_oldest =
+            oldest_for(&secondary_view).expect("secondary span visible in secondary view");
+        assert_eq!(secondary_oldest.label.as_deref(), Some("secondary_span"));
+
+        drop(main_handle);
+        drop(secondary_handle);
+    }
+
+    #[test]
+    fn register_delegates_to_unscoped_origin() {
+        let _guard = TEST_LOCK.lock().unwrap();
+        let main_id = DbIdentity::new("main.db");
+        let main_view = TxOriginFilter::Main(main_id);
+        let handle = register(Some("legacy_span".to_string()));
+
+        let oldest = oldest_for(&main_view).expect("register() delegates to Unscoped");
+        assert_eq!(oldest.origin, TxOrigin::Unscoped);
+
+        drop(handle);
+    }
+
+    #[test]
+    fn unscoped_visible_in_main_view_and_oldest() {
+        let _guard = TEST_LOCK.lock().unwrap();
+        let main_id = DbIdentity::new("main.db");
+        let main_view = TxOriginFilter::Main(main_id);
+        let handle = register_scoped(Some("unscoped_span".to_string()), TxOrigin::Unscoped);
+
+        let via_filter = oldest_for(&main_view).expect("unscoped span falls back to main view");
+        assert_eq!(via_filter.label.as_deref(), Some("unscoped_span"));
+        assert_eq!(via_filter.origin, TxOrigin::Unscoped);
+
+        let via_aggregate = oldest().expect("unscoped span visible in aggregate oldest()");
+        assert_eq!(via_aggregate.2.as_deref(), Some("unscoped_span"));
+
+        drop(handle);
+    }
+
+    #[test]
+    fn memory_absent_from_attribution_views_but_present_in_oldest() {
+        let _guard = TEST_LOCK.lock().unwrap();
+        let main_id = DbIdentity::new("main.db");
+        let secondary_id = DbIdentity::new("secondary.db");
+        let main_view = TxOriginFilter::Main(main_id);
+        let secondary_view = TxOriginFilter::Secondary(secondary_id);
+        let handle = register_scoped(Some("memory_span".to_string()), TxOrigin::Memory);
+
+        assert!(oldest_for(&main_view).is_none());
+        assert!(oldest_for(&secondary_view).is_none());
+
+        let via_aggregate = oldest().expect("memory span visible in aggregate oldest()");
+        assert_eq!(via_aggregate.2.as_deref(), Some("memory_span"));
+
+        drop(handle);
+    }
+
+    #[test]
+    fn database_entries_never_leak_across_views() {
+        let _guard = TEST_LOCK.lock().unwrap();
+        let main_id = DbIdentity::new("main.db");
+        let secondary_id = DbIdentity::new("secondary.db");
+        let main_view = TxOriginFilter::Main(main_id);
+        let secondary_view = TxOriginFilter::Secondary(secondary_id.clone());
+        let handle = register_scoped(
+            Some("secondary_span".to_string()),
+            TxOrigin::Database(secondary_id),
+        );
+
+        assert!(oldest_for(&main_view).is_none());
+        let via_secondary =
+            oldest_for(&secondary_view).expect("secondary span visible in its own view");
+        assert_eq!(via_secondary.label.as_deref(), Some("secondary_span"));
+
+        drop(handle);
     }
 
     #[test]


### PR DESCRIPTION
Closes #1160.

Implements the backend-scoped WAL-pin attribution design (docs/design/walpin-backend-scoped-attribution.md, ADR-091 Amendment 3): long-running transaction spans are attributed to the database backend that owns them, so a multi-backend deployment enumerates each backend's pins in that backend's own sidecar instead of collapsing everything into the main view.

## What changed

- **`TxOrigin` / `TxOriginFilter`** (khive-storage tx_registry): spans register with a `Database(DbIdentity)` / `Memory` / `Unscoped` origin; the `Main(id)` filter matches its own database plus the `Unscoped` fallback, `Secondary(id)` matches exactly and never falls back.
- **`DbIdentity` minting** (khive-db pool): minted once at pool construction from the configured path — relative paths resolve against CWD, existing paths canonicalize, missing files resolve a bounded final-component symlink chain (depth 40) then canonicalize the parent. Alias spellings (relative / symlinked dir / symlinked file / bare name) converge to one identity, proven by tests including non-UTF-8 and dangling-symlink cases.
- **Sweep fan-out** (khive-db checkpoint): `run_session_sweep_task` takes `Vec<SweepBackend>` and fans one sweep per file-backed backend internally; each backend's sidecar heartbeat carries only that backend's spans.
- **Checkpoint ownership** (khive-runtime daemon): `run_checkpoint_task` takes an explicit `is_main` flag selecting the filter; the daemon spawns one checkpoint task per file-backed backend sharing a single shutdown channel.
- **Server wiring** (khive-mcp): the multi-backend registry path collects secondary file-backed pools (deduped by pool identity, main excluded) and carries them through `KhiveMcpServer` into both the session sweep and the daemon checkpoint fan-out.
- **`attribution_basis` heartbeat field**: `"origin"` for database-attributed spans, `"fallback"` for spans observed only through the main view's `Unscoped` fallback; serde-defaulted so older sidecar readers are unaffected, and consumers treat unknown values as untrusted.
- **Metrics**: `build_metrics_snapshot` deliberately keeps the process-wide `oldest()` aggregate (documented at the call site) — per-backend attribution is a sidecar concern, the gauge stays deployment-wide.

## Test coverage

Beyond per-unit coverage added with each stage: alias-convergence riders for the sidecar directory re-key, fallback/origin marker assertions, a two-pool sweep integration test proving a secondary-scoped span lands only in the secondary sidecar, task-level cross-pool ignore for secondary checkpoint tasks, secondary stall detection + enumeration, and secondary-view visibility for the traverse read-path span.

Full workspace gates green at head: test, clippy `-D warnings`, fmt, doc build with `-D warnings`.

## Known follow-up (out of scope here)

ADR-094 checkpoint lifecycle events do not yet discriminate backend; a follow-up will thread backend identity through those events.