### PR TITLE
fix(pack-git): canonical repo-slug anchor identity for git.digest

### DIFF
--- a/crates/khive-pack-git/src/handlers.rs
+++ b/crates/khive-pack-git/src/handlers.rs
@@ -19,7 +19,7 @@ use crate::ingest::{
     resolve_project_id, run_ingest, run_ingest_with_commit_recovery, CacheRepairStrategy,
     GitLogError, IngestInclude, IngestOptions, RecoveredRepo,
 };
-use crate::source::{parse_source, repo_basename, DigestSource};
+use crate::source::{parse_source, repo_basename, repo_identity, DigestSource, REPO_SLUG_PROPERTY};
 use crate::GitPack;
 
 /// Issue #765 bounded repair policy: at most one refetch, then at most one
@@ -152,7 +152,7 @@ impl GitPack {
         };
 
         // Resolve or auto-create the repo-anchor `project` entity.
-        let (project_id, project_created) = match params.get("project").and_then(Value::as_str) {
+        let resolution = match params.get("project").and_then(Value::as_str) {
             Some(raw) => {
                 let id = resolve_project_id(self.runtime(), raw)
                     .await
@@ -162,10 +162,16 @@ impl GitPack {
                             "project {raw:?} did not resolve to an entity"
                         ))
                     })?;
-                (id, false)
+                ProjectResolution {
+                    id,
+                    created: false,
+                    orphan: None,
+                }
             }
             None => resolve_or_create_project(self.runtime(), registry, token, &source).await?,
         };
+        let project_id = resolution.id;
+        let project_created = resolution.created;
 
         let effective_include = IngestInclude {
             commits: include.commits,
@@ -198,6 +204,11 @@ impl GitPack {
         report.warnings.extend(warnings);
         report.project_id = Some(project_id.to_string());
         report.project_created = project_created;
+        if let Some(orphan) = resolution.orphan {
+            report.orphaned_corpus_detected = true;
+            report.orphaned_project_id = Some(orphan.dead_project_id.to_string());
+            report.orphaned_note_count = orphan.annotated_note_count;
+        }
 
         serde_json::to_value(&report)
             .map_err(|e| RuntimeError::InvalidInput(format!("serializing report: {e}")))
@@ -231,28 +242,79 @@ fn parse_include(v: &Value) -> Result<IngestInclude, RuntimeError> {
     Ok(include)
 }
 
-/// Find an existing `project` entity whose `properties.repo_url` matches the
-/// source's canonical URL/path, or whose `name` matches the repo basename;
-/// create the anchor when none is found (ADR-088 Amendment 1 — auto-creation
-/// is reported via `IngestReport.project_created`, never silent).
+/// Outcome of `resolve_or_create_project`'s match/create decision.
+pub(crate) struct ProjectResolution {
+    pub(crate) id: Uuid,
+    pub(crate) created: bool,
+    /// `Some` when `created` is `true` AND a soft-deleted anchor for this
+    /// repo identity was found with a live corpus still annotating it
+    /// (issue #1173) — surfaced via `IngestReport`, never silent.
+    pub(crate) orphan: Option<OrphanSignal>,
+}
+
+pub(crate) struct OrphanSignal {
+    pub(crate) dead_project_id: Uuid,
+    pub(crate) annotated_note_count: u64,
+}
+
+/// Find an existing `project` entity whose `properties.repo_slug` matches
+/// the source's canonical repo identity (issue #1173), falling back to a
+/// legacy `properties.repo_url` match for pre-existing anchors that predate
+/// the slug property (backfilling it on match so future calls converge on
+/// the slug lookup without a migration); create the anchor when neither
+/// matches (ADR-088 Amendment 1 — auto-creation is reported via
+/// `IngestReport.project_created`, never silent). The basename `name`
+/// fallback from the original v1 match is intentionally gone: it is both
+/// too weak (a differently-named legacy anchor is missed) and too broad (an
+/// unrelated `project` entity sharing the basename would capture the
+/// ingest) — see issue #1173.
 async fn resolve_or_create_project(
     runtime: &KhiveRuntime,
     registry: &VerbRegistry,
     token: &NamespaceToken,
     source: &DigestSource,
-) -> Result<(Uuid, bool), RuntimeError> {
+) -> Result<ProjectResolution, RuntimeError> {
     let repo_url = match source {
         DigestSource::Local(p) => p.to_string_lossy().to_string(),
         DigestSource::Remote { canonical, .. } => canonical.clone(),
     };
+    let identity = repo_identity(source);
     let name = repo_basename(source);
 
-    if let Some(id) = find_project_by_repo(runtime, token, &repo_url, &name)
+    if let Some(id) = find_project_by_slug(runtime, token, &identity)
         .await
         .map_err(|e| RuntimeError::InvalidInput(e.to_string()))?
     {
-        return Ok((id, false));
+        return Ok(ProjectResolution {
+            id,
+            created: false,
+            orphan: None,
+        });
     }
+
+    if let Some(id) = find_project_by_legacy_repo_url(runtime, token, &repo_url)
+        .await
+        .map_err(|e| RuntimeError::InvalidInput(e.to_string()))?
+    {
+        registry
+            .dispatch(
+                "update",
+                json!({
+                    "id": id.to_string(),
+                    "properties": { REPO_SLUG_PROPERTY: identity },
+                }),
+            )
+            .await?;
+        return Ok(ProjectResolution {
+            id,
+            created: false,
+            orphan: None,
+        });
+    }
+
+    let orphan = find_orphaned_anchor(runtime, token, &identity, &repo_url)
+        .await
+        .map_err(|e| RuntimeError::InvalidInput(e.to_string()))?;
 
     let resp = registry
         .dispatch(
@@ -260,7 +322,7 @@ async fn resolve_or_create_project(
             json!({
                 "kind": "project",
                 "name": name,
-                "properties": { "repo_url": repo_url },
+                "properties": { "repo_url": repo_url, REPO_SLUG_PROPERTY: identity },
             }),
         )
         .await?;
@@ -271,14 +333,17 @@ async fn resolve_or_create_project(
         .ok_or_else(|| {
             RuntimeError::InvalidInput("create(kind=project) did not return an id".into())
         })?;
-    Ok((id, true))
+    Ok(ProjectResolution {
+        id,
+        created: true,
+        orphan,
+    })
 }
 
-async fn find_project_by_repo(
+async fn find_project_by_slug(
     runtime: &KhiveRuntime,
     token: &NamespaceToken,
-    repo_url: &str,
-    name: &str,
+    identity: &str,
 ) -> anyhow::Result<Option<Uuid>> {
     let sql = runtime.sql();
     let mut r = sql.reader().await.map_err(|e| anyhow!("{e}"))?;
@@ -286,15 +351,14 @@ async fn find_project_by_repo(
         .query_row(SqlStatement {
             sql: "SELECT id FROM entities WHERE kind='project' AND namespace=?1 \
                   AND deleted_at IS NULL \
-                  AND (json_extract(properties,'$.repo_url')=?2 OR name=?3) \
+                  AND json_extract(properties,'$.repo_slug')=?2 \
                   LIMIT 1"
                 .into(),
             params: vec![
                 SqlValue::Text(token.namespace().as_str().to_string()),
-                SqlValue::Text(repo_url.to_string()),
-                SqlValue::Text(name.to_string()),
+                SqlValue::Text(identity.to_string()),
             ],
-            label: Some("git_digest_find_project_by_repo".into()),
+            label: Some("git_digest_find_project_by_slug".into()),
         })
         .await
         .map_err(|e| anyhow!("{e}"))?;
@@ -302,5 +366,100 @@ async fn find_project_by_repo(
         Some(SqlValue::Uuid(u)) => Some(*u),
         Some(SqlValue::Text(s)) => Uuid::parse_str(s).ok(),
         _ => None,
+    }))
+}
+
+async fn find_project_by_legacy_repo_url(
+    runtime: &KhiveRuntime,
+    token: &NamespaceToken,
+    repo_url: &str,
+) -> anyhow::Result<Option<Uuid>> {
+    let sql = runtime.sql();
+    let mut r = sql.reader().await.map_err(|e| anyhow!("{e}"))?;
+    let row = r
+        .query_row(SqlStatement {
+            sql: "SELECT id FROM entities WHERE kind='project' AND namespace=?1 \
+                  AND deleted_at IS NULL \
+                  AND json_extract(properties,'$.repo_url')=?2 \
+                  LIMIT 1"
+                .into(),
+            params: vec![
+                SqlValue::Text(token.namespace().as_str().to_string()),
+                SqlValue::Text(repo_url.to_string()),
+            ],
+            label: Some("git_digest_find_project_by_legacy_repo_url".into()),
+        })
+        .await
+        .map_err(|e| anyhow!("{e}"))?;
+    Ok(row.and_then(|r| match r.get("id") {
+        Some(SqlValue::Uuid(u)) => Some(*u),
+        Some(SqlValue::Text(s)) => Uuid::parse_str(s).ok(),
+        _ => None,
+    }))
+}
+
+/// Look for a soft-deleted `project` anchor matching the resolved repo
+/// identity (or its legacy `repo_url` spelling) that still has a live
+/// `commit`/`issue`/`pull_request` corpus `annotates`-linked to it (issue
+/// #1173 items 2/3). A hard-deleted anchor cannot be detected this way — its
+/// row, including `properties.repo_slug`, is gone — this covers the soft
+/// delete (the default; see ADR-014) case, where the identity survives.
+async fn find_orphaned_anchor(
+    runtime: &KhiveRuntime,
+    token: &NamespaceToken,
+    identity: &str,
+    repo_url: &str,
+) -> anyhow::Result<Option<OrphanSignal>> {
+    let sql = runtime.sql();
+    let mut r = sql.reader().await.map_err(|e| anyhow!("{e}"))?;
+    let row = r
+        .query_row(SqlStatement {
+            sql: "SELECT id FROM entities WHERE kind='project' AND namespace=?1 \
+                  AND deleted_at IS NOT NULL \
+                  AND (json_extract(properties,'$.repo_slug')=?2 \
+                       OR json_extract(properties,'$.repo_url')=?3) \
+                  ORDER BY deleted_at DESC LIMIT 1"
+                .into(),
+            params: vec![
+                SqlValue::Text(token.namespace().as_str().to_string()),
+                SqlValue::Text(identity.to_string()),
+                SqlValue::Text(repo_url.to_string()),
+            ],
+            label: Some("git_digest_find_orphaned_anchor".into()),
+        })
+        .await
+        .map_err(|e| anyhow!("{e}"))?;
+    let Some(dead_project_id) = row.and_then(|r| match r.get("id") {
+        Some(SqlValue::Uuid(u)) => Some(*u),
+        Some(SqlValue::Text(s)) => Uuid::parse_str(s).ok(),
+        _ => None,
+    }) else {
+        return Ok(None);
+    };
+
+    let count = r
+        .query_scalar(SqlStatement {
+            sql: "SELECT COUNT(*) FROM notes n \
+                  JOIN graph_edges e ON e.source_id = n.id AND e.namespace = n.namespace \
+                  WHERE n.namespace = ?1 AND n.deleted_at IS NULL \
+                  AND n.kind IN ('commit', 'issue', 'pull_request') \
+                  AND e.relation = 'annotates' AND e.target_id = ?2 AND e.deleted_at IS NULL"
+                .into(),
+            params: vec![
+                SqlValue::Text(token.namespace().as_str().to_string()),
+                SqlValue::Text(dead_project_id.to_string()),
+            ],
+            label: Some("git_digest_count_orphaned_notes".into()),
+        })
+        .await
+        .map_err(|e| anyhow!("{e}"))?;
+    let annotated_note_count = match count {
+        Some(SqlValue::Integer(n)) => n as u64,
+        _ => 0,
+    };
+
+    Ok(Some(OrphanSignal {
+        dead_project_id,
+        annotated_note_count,
     }))
 }

--- a/crates/khive-pack-git/src/handlers.rs
+++ b/crates/khive-pack-git/src/handlers.rs
@@ -19,7 +19,10 @@ use crate::ingest::{
     resolve_project_id, run_ingest, run_ingest_with_commit_recovery, CacheRepairStrategy,
     GitLogError, IngestInclude, IngestOptions, RecoveredRepo,
 };
-use crate::source::{parse_source, repo_basename, repo_identity, DigestSource, REPO_SLUG_PROPERTY};
+use crate::source::{
+    parse_source, redact_repo_url, remote_url_to_slug, repo_basename, repo_identity, DigestSource,
+    REPO_SLUG_PROPERTY,
+};
 use crate::GitPack;
 
 /// Issue #765 bounded repair policy: at most one refetch, then at most one
@@ -295,7 +298,7 @@ async fn resolve_or_create_project(
         DigestSource::Local(p) => p.to_string_lossy().to_string(),
         DigestSource::Remote { canonical, .. } => canonical.clone(),
     };
-    let identity = repo_identity(source);
+    let identity = repo_identity(source).await;
     let name = repo_basename(source);
 
     let slug_matches = find_projects_by_slug(runtime, token, &identity)
@@ -331,6 +334,44 @@ async fn resolve_or_create_project(
         });
     }
 
+    // ADR-088 Amendment 2 step 2: a legacy anchor that predates `repo_slug`
+    // entirely (so its stored `repo_url` is some other spelling of the same
+    // repository -- e.g. a bare local clone path from before this identity
+    // model existed) is reconciled by re-deriving each such anchor's own
+    // identity from its stored `repo_url` and comparing it to this source's
+    // resolved `identity`, not by a second exact-string match.
+    let legacy_candidates = find_legacy_projects_without_slug(runtime, token)
+        .await
+        .map_err(|e| RuntimeError::InvalidInput(e.to_string()))?;
+    let mut normalized_matches: Vec<Uuid> = Vec::new();
+    for (id, candidate_repo_url) in legacy_candidates {
+        if normalize_legacy_repo_url(&candidate_repo_url)
+            .await
+            .as_deref()
+            == Some(identity.as_str())
+        {
+            normalized_matches.push(id);
+        }
+    }
+    if let Some((selected, duplicates)) = normalized_matches.split_first() {
+        let selected = *selected;
+        registry
+            .dispatch(
+                "update",
+                json!({
+                    "id": selected.to_string(),
+                    "properties": { REPO_SLUG_PROPERTY: identity },
+                }),
+            )
+            .await?;
+        return Ok(ProjectResolution {
+            id: selected,
+            created: false,
+            orphan: None,
+            slug_duplicates: duplicates.to_vec(),
+        });
+    }
+
     let orphan = find_orphaned_anchor(runtime, token, &identity, &repo_url)
         .await
         .map_err(|e| RuntimeError::InvalidInput(e.to_string()))?;
@@ -341,7 +382,10 @@ async fn resolve_or_create_project(
             json!({
                 "kind": "project",
                 "name": name,
-                "properties": { "repo_url": repo_url, REPO_SLUG_PROPERTY: identity },
+                "properties": {
+                    "repo_url": redact_repo_url(&repo_url),
+                    REPO_SLUG_PROPERTY: identity,
+                },
             }),
         )
         .await?;
@@ -424,6 +468,73 @@ async fn find_project_by_legacy_repo_url(
         Some(SqlValue::Text(s)) => Uuid::parse_str(s).ok(),
         _ => None,
     }))
+}
+
+/// Fetch every live `project` anchor in this namespace that has no
+/// `repo_slug` yet -- candidates for step-2 normalization reconciliation
+/// (ADR-088 Amendment 2). An anchor that already carries `repo_slug` was
+/// either created post-#1173 or already backfilled by the exact-match path
+/// above; it is found (if at all) via `find_projects_by_slug` instead.
+async fn find_legacy_projects_without_slug(
+    runtime: &KhiveRuntime,
+    token: &NamespaceToken,
+) -> anyhow::Result<Vec<(Uuid, String)>> {
+    let sql = runtime.sql();
+    let mut r = sql.reader().await.map_err(|e| anyhow!("{e}"))?;
+    let rows = r
+        .query_all(SqlStatement {
+            sql: "SELECT id, json_extract(properties,'$.repo_url') AS repo_url \
+                  FROM entities WHERE kind='project' AND namespace=?1 \
+                  AND deleted_at IS NULL \
+                  AND json_extract(properties,'$.repo_slug') IS NULL \
+                  AND json_extract(properties,'$.repo_url') IS NOT NULL \
+                  ORDER BY created_at ASC, id ASC"
+                .into(),
+            params: vec![SqlValue::Text(token.namespace().as_str().to_string())],
+            label: Some("git_digest_find_legacy_projects_without_slug".into()),
+        })
+        .await
+        .map_err(|e| anyhow!("{e}"))?;
+    Ok(rows
+        .iter()
+        .filter_map(|r| {
+            let id = match r.get("id") {
+                Some(SqlValue::Uuid(u)) => Some(*u),
+                Some(SqlValue::Text(s)) => Uuid::parse_str(s).ok(),
+                _ => None,
+            }?;
+            let url = match r.get("repo_url") {
+                Some(SqlValue::Text(s)) => Some(s.clone()),
+                _ => None,
+            }?;
+            Some((id, url))
+        })
+        .collect())
+}
+
+/// Re-derive the repo-identity slug a legacy anchor's stored `repo_url`
+/// would resolve to today (ADR-088 Amendment 2 step 2). A URL-shaped value
+/// normalizes directly via `remote_url_to_slug`. A path-shaped value (an
+/// absolute local path, stored verbatim by the pre-#1173 local-source
+/// resolution path) is treated as a local clone and resolved the same way
+/// `repo_identity` resolves a `DigestSource::Local` -- via its current
+/// `origin` remote -- so a legacy local-path anchor reconciles with a
+/// later remote-URL digest of the same repository. Returns `None` when
+/// neither path yields a URL-shaped identity (e.g. the path no longer
+/// exists, or has no matching origin -- there is nothing to reconcile
+/// against).
+async fn normalize_legacy_repo_url(repo_url: &str) -> Option<String> {
+    if let Some(slug) = remote_url_to_slug(repo_url) {
+        return Some(slug);
+    }
+    if repo_url.starts_with('/') {
+        let candidate = DigestSource::Local(std::path::PathBuf::from(repo_url));
+        let slug = repo_identity(&candidate).await;
+        if !slug.starts_with("local:") {
+            return Some(slug);
+        }
+    }
+    None
 }
 
 /// Look for a soft-deleted `project` anchor matching the resolved repo
@@ -908,5 +1019,227 @@ mod tests {
             "signal must point at the tombstone with the live corpus, not merely the most recent one"
         );
         assert_eq!(orphan.annotated_note_count, 1);
+    }
+
+    /// Persisted `repo_url` must never carry userinfo or a query-string
+    /// token (ADR-088 Amendment 2) -- the in-memory canonical (used only
+    /// for the identity slug and any clone/gh operation) is unaffected.
+    #[tokio::test]
+    async fn persisted_repo_url_is_credential_and_query_redacted() {
+        let (rt, token, registry) = fixture().await;
+
+        let source = DigestSource::Remote {
+            canonical: "https://user:tok3n@github.com/org/redact-repo?token=SECRETQUERY#frag"
+                .to_string(),
+            gh_slug: Some(("org".to_string(), "redact-repo".to_string())),
+        };
+
+        let resolution = resolve_or_create_project(&rt, &registry, &token, &source)
+            .await
+            .expect("resolve");
+        assert!(resolution.created);
+
+        let entity = rt
+            .get_entity(&token, resolution.id)
+            .await
+            .expect("fetch entity");
+        let stored_url = entity
+            .properties
+            .as_ref()
+            .and_then(|p| p.get("repo_url"))
+            .and_then(Value::as_str)
+            .expect("repo_url present");
+        assert!(!stored_url.contains("tok3n"), "{stored_url}");
+        assert!(!stored_url.contains("SECRETQUERY"), "{stored_url}");
+        assert!(!stored_url.contains('#'), "{stored_url}");
+        assert_eq!(stored_url, "https://github.com/org/redact-repo");
+
+        assert_eq!(
+            entity
+                .properties
+                .as_ref()
+                .and_then(|p| p.get("repo_slug"))
+                .and_then(Value::as_str),
+            Some("github.com/org/redact-repo")
+        );
+    }
+
+    fn init_bare_repo_with_origin(dir: &Path, origin: &str) {
+        for args in [vec!["init", "-q"], vec!["remote", "add", "origin", origin]] {
+            let status = std::process::Command::new("git")
+                .arg("-C")
+                .arg(dir)
+                .args(&args)
+                .status()
+                .expect("spawn git");
+            assert!(status.success(), "git {args:?} failed");
+        }
+    }
+
+    /// Same as [`init_bare_repo_with_origin`] but with `user.*` configured
+    /// and one commit -- `git log` (and thus `git.digest`) needs a real
+    /// commit to walk; a freshly-inited repo with zero commits fails at
+    /// the `git log` step before anchor resolution is even exercised.
+    fn init_repo_with_origin_and_one_commit(dir: &Path, origin: &str) {
+        init_bare_repo_with_origin(dir, origin);
+        for args in [
+            vec!["config", "user.email", "test@example.com"],
+            vec!["config", "user.name", "Test User"],
+        ] {
+            let status = std::process::Command::new("git")
+                .arg("-C")
+                .arg(dir)
+                .args(&args)
+                .status()
+                .expect("spawn git");
+            assert!(status.success(), "git {args:?} failed");
+        }
+        std::fs::write(dir.join("README.md"), "hello\n").expect("write file");
+        for args in [
+            vec!["add", "README.md"],
+            vec!["commit", "-q", "-m", "Initial commit"],
+        ] {
+            let status = std::process::Command::new("git")
+                .arg("-C")
+                .arg(dir)
+                .args(&args)
+                .status()
+                .expect("spawn git");
+            assert!(status.success(), "git {args:?} failed");
+        }
+    }
+
+    /// A legacy anchor created before `repo_slug` existed at all, from a
+    /// LOCAL path source (so its `repo_url` is a bare filesystem path with
+    /// no `repo_slug`), is reconciled by a later remote-URL digest of the
+    /// same repository via step-2 normalization (ADR-088 Amendment 2).
+    #[tokio::test]
+    async fn legacy_local_path_anchor_reconciled_by_later_remote_digest() {
+        let (rt, token, registry) = fixture().await;
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        init_bare_repo_with_origin(dir.path(), "https://github.com/org/legacy-local-repo");
+
+        let path_str = dir.path().to_string_lossy().to_string();
+        let legacy_id = registry
+            .dispatch(
+                "create",
+                json!({
+                    "kind": "project",
+                    "name": "legacy-local-repo",
+                    "properties": { "repo_url": path_str },
+                }),
+            )
+            .await
+            .expect("create legacy local anchor");
+        let legacy_id = Uuid::parse_str(legacy_id["id"].as_str().unwrap()).expect("uuid");
+
+        let remote_source = DigestSource::Remote {
+            canonical: "https://github.com/org/legacy-local-repo".to_string(),
+            gh_slug: Some(("org".to_string(), "legacy-local-repo".to_string())),
+        };
+        let resolution = resolve_or_create_project(&rt, &registry, &token, &remote_source)
+            .await
+            .expect("resolve");
+        assert!(
+            !resolution.created,
+            "legacy local-path anchor must be reconciled, not re-created"
+        );
+        assert_eq!(resolution.id, legacy_id);
+
+        let entity = rt
+            .get_entity(&token, legacy_id)
+            .await
+            .expect("fetch entity");
+        assert_eq!(
+            entity
+                .properties
+                .as_ref()
+                .and_then(|p| p.get("repo_slug"))
+                .and_then(Value::as_str),
+            Some("github.com/org/legacy-local-repo"),
+            "repo_slug must be backfilled via step-2 normalization"
+        );
+    }
+
+    /// Public-surface regression (ADR-088 Amendment 2 round-2 finding): the
+    /// duplicate-anchor warning and selected id, and all three orphan
+    /// report fields (including the no-orphan defaults), must be observable
+    /// on the real `git.digest` verb's serialized `IngestReport` -- not
+    /// merely on the private `resolve_or_create_project` helper's return
+    /// value. Driven through `registry.dispatch("git.digest", ...)` over a
+    /// LOCAL (no-network) source so it needs no real remote clone.
+    #[tokio::test]
+    async fn git_digest_public_surface_reports_duplicate_and_selects_oldest_no_third_anchor() {
+        let (rt, token, registry) = fixture().await;
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        init_repo_with_origin_and_one_commit(dir.path(), "https://github.com/org/pub-dup-repo");
+
+        let slug = "github.com/org/pub-dup-repo";
+        let mut ids = Vec::new();
+        for repo_url in [
+            "https://github.com/org/pub-dup-repo",
+            "git@github.com:org/pub-dup-repo.git",
+        ] {
+            let resp = registry
+                .dispatch(
+                    "create",
+                    json!({
+                        "kind": "project",
+                        "name": "pub-dup-repo",
+                        "properties": { "repo_url": repo_url, "repo_slug": slug },
+                    }),
+                )
+                .await
+                .expect("create anchor");
+            ids.push(Uuid::parse_str(resp["id"].as_str().unwrap()).expect("uuid"));
+        }
+
+        let source_path = dir.path().to_string_lossy().to_string();
+        let resp = registry
+            .dispatch(
+                "git.digest",
+                json!({
+                    "source": source_path,
+                    "include": ["commits"],
+                    "max_items": 1,
+                }),
+            )
+            .await
+            .expect("git.digest dispatch");
+
+        assert_eq!(resp["project_created"], json!(false), "{resp}");
+        let selected_id = resp["project_id"]
+            .as_str()
+            .expect("project_id present")
+            .to_string();
+        assert!(
+            ids.iter().any(|id| id.to_string() == selected_id),
+            "selected id must be one of the pre-seeded pair: {resp}"
+        );
+        assert_eq!(selected_id, ids[0].to_string(), "must select the oldest");
+
+        let warnings = resp["warnings"].as_array().expect("warnings array");
+        assert!(
+            warnings.iter().any(|w| {
+                let w = w.as_str().unwrap_or("");
+                w.contains("duplicate")
+                    && w.contains(&selected_id)
+                    && w.contains(&ids[1].to_string())
+            }),
+            "duplicate warning must name the selected and duplicate ids: {warnings:?}"
+        );
+
+        // No-orphan defaults must be present on the wire shape.
+        assert_eq!(resp["orphaned_corpus_detected"], json!(false), "{resp}");
+        assert_eq!(resp["orphaned_project_id"], json!(null), "{resp}");
+        assert_eq!(resp["orphaned_note_count"], json!(0), "{resp}");
+
+        // No third anchor was minted.
+        let live = find_projects_by_slug(&rt, &token, slug)
+            .await
+            .expect("find_projects_by_slug");
+        assert_eq!(live.len(), 2, "no third anchor should be minted: {live:?}");
     }
 }

--- a/crates/khive-pack-git/src/handlers.rs
+++ b/crates/khive-pack-git/src/handlers.rs
@@ -463,3 +463,236 @@ async fn find_orphaned_anchor(
         annotated_note_count,
     }))
 }
+
+#[cfg(test)]
+mod tests {
+    use khive_runtime::{Namespace, VerbRegistryBuilder};
+
+    use super::*;
+
+    async fn fixture() -> (KhiveRuntime, NamespaceToken, VerbRegistry) {
+        let rt = KhiveRuntime::memory().expect("memory runtime");
+        let mut builder = VerbRegistryBuilder::new();
+        builder.register(khive_pack_kg::KgPack::new(rt.clone()));
+        builder.register(GitPack::new(rt.clone()));
+        let registry = builder.build().expect("registry builds");
+        rt.install_edge_rules(registry.all_edge_rules());
+        registry.apply_schema_plans(rt.backend());
+        let token = rt.authorize(Namespace::local()).expect("authorize local");
+        (rt, token, registry)
+    }
+
+    async fn create_note_annotating(
+        registry: &VerbRegistry,
+        kind: &str,
+        name: &str,
+        project_id: Uuid,
+    ) -> Uuid {
+        let properties = match kind {
+            "commit" => json!({ "sha": "deadbeef".repeat(5) }),
+            "issue" | "pull_request" => {
+                json!({ "number": 1, "project_id": project_id.to_string() })
+            }
+            other => panic!("unsupported note kind in test helper: {other}"),
+        };
+        let resp = registry
+            .dispatch(
+                "create",
+                json!({
+                    "kind": kind,
+                    "name": name,
+                    "content": format!("{name} body"),
+                    "properties": properties,
+                    "annotates": [project_id.to_string()],
+                }),
+            )
+            .await
+            .expect("create note ok");
+        Uuid::parse_str(resp["id"].as_str().expect("id present")).expect("id is uuid")
+    }
+
+    /// Regression for the 505-dup incident shape (issue #1173): a repo
+    /// digested once via a local clone path and once via its remote https
+    /// URL must converge on ONE anchor, not mint a second one that then
+    /// re-ingests the whole corpus from an empty start.
+    #[tokio::test]
+    async fn same_repo_via_local_and_remote_spelling_resolves_to_one_anchor() {
+        let (rt, token, registry) = fixture().await;
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        let status = std::process::Command::new("git")
+            .arg("-C")
+            .arg(dir.path())
+            .args(["init", "-q"])
+            .status()
+            .expect("git init");
+        assert!(status.success());
+        let status = std::process::Command::new("git")
+            .arg("-C")
+            .arg(dir.path())
+            .args([
+                "remote",
+                "add",
+                "origin",
+                "https://github.com/org/dupe-repo",
+            ])
+            .status()
+            .expect("git remote add");
+        assert!(status.success());
+
+        let local_source = DigestSource::Local(dir.path().to_path_buf());
+        let remote_source = DigestSource::Remote {
+            canonical: "https://github.com/org/dupe-repo".to_string(),
+            gh_slug: Some(("org".to_string(), "dupe-repo".to_string())),
+        };
+
+        let first = resolve_or_create_project(&rt, &registry, &token, &local_source)
+            .await
+            .expect("first resolve");
+        assert!(first.created);
+
+        let second = resolve_or_create_project(&rt, &registry, &token, &remote_source)
+            .await
+            .expect("second resolve");
+        assert!(!second.created, "second spelling must match, not re-create");
+        assert_eq!(first.id, second.id);
+    }
+
+    /// An unrelated `project` entity that happens to share the repo's
+    /// basename must NOT capture the ingest (issue #1173 item 1 -- the
+    /// basename fallback is dropped entirely).
+    #[tokio::test]
+    async fn basename_collision_with_unrelated_project_is_not_captured() {
+        let (rt, token, registry) = fixture().await;
+
+        let unrelated_id = registry
+            .dispatch(
+                "create",
+                json!({
+                    "kind": "project",
+                    "name": "collide-repo",
+                    "properties": { "repo_url": "https://example.com/totally/unrelated" },
+                }),
+            )
+            .await
+            .expect("create unrelated project");
+        let unrelated_id = Uuid::parse_str(unrelated_id["id"].as_str().unwrap()).expect("uuid");
+
+        let source = DigestSource::Remote {
+            canonical: "https://github.com/org/collide-repo".to_string(),
+            gh_slug: Some(("org".to_string(), "collide-repo".to_string())),
+        };
+        let resolution = resolve_or_create_project(&rt, &registry, &token, &source)
+            .await
+            .expect("resolve");
+        assert!(
+            resolution.created,
+            "basename collision must not capture an unrelated anchor"
+        );
+        assert_ne!(resolution.id, unrelated_id);
+    }
+
+    /// A pre-existing anchor created before this fix (only `properties.repo_url`,
+    /// no `repo_slug`) is matched by legacy `repo_url` lookup and backfilled
+    /// with `repo_slug`, so subsequent calls converge on the slug match
+    /// without a migration (issue #1173 item 1).
+    #[tokio::test]
+    async fn legacy_anchor_without_slug_is_matched_and_backfilled() {
+        let (rt, token, registry) = fixture().await;
+
+        let source = DigestSource::Remote {
+            canonical: "https://github.com/org/legacy-repo".to_string(),
+            gh_slug: Some(("org".to_string(), "legacy-repo".to_string())),
+        };
+        let repo_url = "https://github.com/org/legacy-repo";
+
+        let legacy_id = registry
+            .dispatch(
+                "create",
+                json!({
+                    "kind": "project",
+                    "name": "legacy-repo",
+                    "properties": { "repo_url": repo_url },
+                }),
+            )
+            .await
+            .expect("create legacy project");
+        let legacy_id = Uuid::parse_str(legacy_id["id"].as_str().unwrap()).expect("uuid");
+
+        let resolution = resolve_or_create_project(&rt, &registry, &token, &source)
+            .await
+            .expect("resolve");
+        assert!(
+            !resolution.created,
+            "legacy repo_url match must not re-create"
+        );
+        assert_eq!(resolution.id, legacy_id);
+
+        let entity = rt
+            .get_entity(&token, legacy_id)
+            .await
+            .expect("fetch legacy entity");
+        assert_eq!(
+            entity
+                .properties
+                .as_ref()
+                .and_then(|p| p.get("repo_slug"))
+                .and_then(Value::as_str),
+            Some("github.com/org/legacy-repo"),
+            "repo_slug must be backfilled on the legacy anchor"
+        );
+    }
+
+    /// A hard-deleted-vs-soft-deleted anchor whose corpus is still
+    /// `annotates`-linked surfaces a distinct, non-silent signal instead of
+    /// quietly minting a fresh anchor over an orphaned corpus (issue #1173
+    /// items 2/3).
+    #[tokio::test]
+    async fn orphaned_anchor_is_flagged_not_silently_reminted() {
+        let (rt, token, registry) = fixture().await;
+
+        let source = DigestSource::Remote {
+            canonical: "https://github.com/org/orphan-repo".to_string(),
+            gh_slug: Some(("org".to_string(), "orphan-repo".to_string())),
+        };
+
+        let dead = registry
+            .dispatch(
+                "create",
+                json!({
+                    "kind": "project",
+                    "name": "orphan-repo",
+                    "properties": {
+                        "repo_url": "https://github.com/org/orphan-repo",
+                        "repo_slug": "github.com/org/orphan-repo",
+                    },
+                }),
+            )
+            .await
+            .expect("create dead anchor");
+        let dead_id = Uuid::parse_str(dead["id"].as_str().unwrap()).expect("uuid");
+
+        create_note_annotating(&registry, "commit", "c1", dead_id).await;
+        create_note_annotating(&registry, "issue", "#1 bug", dead_id).await;
+
+        let deleted = rt
+            .delete_entity(&token, dead_id, false)
+            .await
+            .expect("soft delete");
+        assert!(deleted);
+
+        let resolution = resolve_or_create_project(&rt, &registry, &token, &source)
+            .await
+            .expect("resolve");
+        assert!(
+            resolution.created,
+            "no live anchor for this slug -- a fresh one is minted"
+        );
+        assert_ne!(resolution.id, dead_id);
+        let orphan = resolution
+            .orphan
+            .expect("orphaned corpus must be flagged, not silent");
+        assert_eq!(orphan.dead_project_id, dead_id);
+        assert_eq!(orphan.annotated_note_count, 2);
+    }
+}

--- a/crates/khive-pack-git/src/handlers.rs
+++ b/crates/khive-pack-git/src/handlers.rs
@@ -208,7 +208,7 @@ impl GitPack {
         report.warnings.extend(warnings);
         if !resolution.slug_duplicates.is_empty() {
             report.warnings.push(format!(
-                "multiple live project anchors share repo_slug; selected oldest {}; duplicates: {}",
+                "multiple live project anchors match the same repo identity; selected oldest {}; duplicates: {}",
                 project_id,
                 resolution
                     .slug_duplicates
@@ -313,10 +313,11 @@ async fn resolve_or_create_project(
         });
     }
 
-    if let Some(id) = find_project_by_legacy_repo_url(runtime, token, &repo_url)
+    let exact_matches = find_projects_by_legacy_repo_url(runtime, token, &repo_url)
         .await
-        .map_err(|e| RuntimeError::InvalidInput(e.to_string()))?
-    {
+        .map_err(|e| RuntimeError::InvalidInput(e.to_string()))?;
+    if let Some((id, duplicates)) = exact_matches.split_first() {
+        let id = *id;
         registry
             .dispatch(
                 "update",
@@ -337,7 +338,7 @@ async fn resolve_or_create_project(
             id,
             created: false,
             orphan: None,
-            slug_duplicates: Vec::new(),
+            slug_duplicates: duplicates.to_vec(),
         });
     }
 
@@ -453,33 +454,45 @@ async fn find_projects_by_slug(
         .collect())
 }
 
-async fn find_project_by_legacy_repo_url(
+/// Exact step-2 legacy match (ADR-088 Amendment 2): every live pre-slug
+/// anchor whose stored `repo_url` equals the source spelling verbatim,
+/// ordered `created_at ASC, id ASC` so multi-match cases select the oldest
+/// deterministically and surface the remainder as a report warning -- the
+/// same contract as the step-1 slug lookup and the normalized step-2 route.
+/// Anchors that already carry `repo_slug` are excluded: they are found (if
+/// at all) via `find_projects_by_slug`, and an exact `repo_url` hit must
+/// never overwrite an already-derived identity.
+async fn find_projects_by_legacy_repo_url(
     runtime: &KhiveRuntime,
     token: &NamespaceToken,
     repo_url: &str,
-) -> anyhow::Result<Option<Uuid>> {
+) -> anyhow::Result<Vec<Uuid>> {
     let sql = runtime.sql();
     let mut r = sql.reader().await.map_err(|e| anyhow!("{e}"))?;
-    let row = r
-        .query_row(SqlStatement {
+    let rows = r
+        .query_all(SqlStatement {
             sql: "SELECT id FROM entities WHERE kind='project' AND namespace=?1 \
                   AND deleted_at IS NULL \
+                  AND json_extract(properties,'$.repo_slug') IS NULL \
                   AND json_extract(properties,'$.repo_url')=?2 \
-                  LIMIT 1"
+                  ORDER BY created_at ASC, id ASC"
                 .into(),
             params: vec![
                 SqlValue::Text(token.namespace().as_str().to_string()),
                 SqlValue::Text(repo_url.to_string()),
             ],
-            label: Some("git_digest_find_project_by_legacy_repo_url".into()),
+            label: Some("git_digest_find_projects_by_legacy_repo_url".into()),
         })
         .await
         .map_err(|e| anyhow!("{e}"))?;
-    Ok(row.and_then(|r| match r.get("id") {
-        Some(SqlValue::Uuid(u)) => Some(*u),
-        Some(SqlValue::Text(s)) => Uuid::parse_str(s).ok(),
-        _ => None,
-    }))
+    Ok(rows
+        .iter()
+        .filter_map(|r| match r.get("id") {
+            Some(SqlValue::Uuid(u)) => Some(*u),
+            Some(SqlValue::Text(s)) => Uuid::parse_str(s).ok(),
+            _ => None,
+        })
+        .collect())
 }
 
 /// Fetch every live `project` anchor in this namespace that has no
@@ -1253,5 +1266,86 @@ mod tests {
             .await
             .expect("find_projects_by_slug");
         assert_eq!(live.len(), 2, "no third anchor should be minted: {live:?}");
+    }
+
+    /// Exact step-2 multi-match (ADR-088 Amendment 2 round-3 finding): two
+    /// live pre-slug anchors sharing the source's exact `repo_url` spelling
+    /// must resolve to the oldest deterministically, surface the remainder
+    /// in the report warning, and mint no third anchor -- observed on the
+    /// public `git.digest` wire shape, not the private helper.
+    #[tokio::test]
+    async fn git_digest_exact_legacy_multi_match_selects_oldest_and_warns() {
+        let (rt, token, registry) = fixture().await;
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        init_repo_with_origin_and_one_commit(dir.path(), "https://github.com/org/exact-dup-repo");
+        let source_path = dir.path().to_string_lossy().to_string();
+
+        let mut ids = Vec::new();
+        for _ in 0..2 {
+            let resp = registry
+                .dispatch(
+                    "create",
+                    json!({
+                        "kind": "project",
+                        "name": "exact-dup-repo",
+                        // Pre-slug anchors: repo_url only, exactly the local
+                        // source spelling the handler will match on.
+                        "properties": { "repo_url": source_path.clone() },
+                    }),
+                )
+                .await
+                .expect("create anchor");
+            ids.push(Uuid::parse_str(resp["id"].as_str().unwrap()).expect("uuid"));
+        }
+
+        let resp = registry
+            .dispatch(
+                "git.digest",
+                json!({
+                    "source": source_path,
+                    "include": ["commits"],
+                    "max_items": 1,
+                }),
+            )
+            .await
+            .expect("git.digest dispatch");
+
+        assert_eq!(resp["project_created"], json!(false), "{resp}");
+        let selected_id = resp["project_id"]
+            .as_str()
+            .expect("project_id present")
+            .to_string();
+        assert_eq!(selected_id, ids[0].to_string(), "must select the oldest");
+
+        let warnings = resp["warnings"].as_array().expect("warnings array");
+        assert!(
+            warnings.iter().any(|w| {
+                let w = w.as_str().unwrap_or("");
+                w.contains("duplicate")
+                    && w.contains(&selected_id)
+                    && w.contains(&ids[1].to_string())
+            }),
+            "duplicate warning must name the selected and duplicate ids: {warnings:?}"
+        );
+
+        // The selected anchor was backfilled with the origin-derived slug;
+        // the duplicate remains pre-slug and untouched; no third anchor.
+        let slugged = find_projects_by_slug(&rt, &token, "github.com/org/exact-dup-repo")
+            .await
+            .expect("find_projects_by_slug");
+        assert_eq!(
+            slugged,
+            vec![ids[0]],
+            "only the selected anchor gains the slug"
+        );
+        let still_legacy = find_projects_by_legacy_repo_url(&rt, &token, &source_path)
+            .await
+            .expect("find_projects_by_legacy_repo_url");
+        assert_eq!(
+            still_legacy,
+            vec![ids[1]],
+            "duplicate stays pre-slug; no third anchor minted"
+        );
     }
 }

--- a/crates/khive-pack-git/src/handlers.rs
+++ b/crates/khive-pack-git/src/handlers.rs
@@ -404,6 +404,17 @@ async fn find_project_by_legacy_repo_url(
 /// #1173 items 2/3). A hard-deleted anchor cannot be detected this way — its
 /// row, including `properties.repo_slug`, is gone — this covers the soft
 /// delete (the default; see ADR-014) case, where the identity survives.
+///
+/// Multiple soft-deleted tombstones can share the same identity (repeated
+/// delete/re-ingest cycles). The most-recently-deleted one is not
+/// necessarily the one still holding the live corpus — e.g. a later
+/// tombstone created by an empty re-ingest-then-delete has zero annotating
+/// notes while an older one still has the original corpus. Every matching
+/// tombstone (newest first) is checked in turn; the signal fires only for
+/// the first one found with at least one live annotating note. A tombstone
+/// with zero live notes is not an orphan — it is a routine delete of an
+/// already-empty anchor — so `None` is returned instead of `Some` with a
+/// zero count.
 async fn find_orphaned_anchor(
     runtime: &KhiveRuntime,
     token: &NamespaceToken,
@@ -412,13 +423,13 @@ async fn find_orphaned_anchor(
 ) -> anyhow::Result<Option<OrphanSignal>> {
     let sql = runtime.sql();
     let mut r = sql.reader().await.map_err(|e| anyhow!("{e}"))?;
-    let row = r
-        .query_row(SqlStatement {
+    let rows = r
+        .query_all(SqlStatement {
             sql: "SELECT id FROM entities WHERE kind='project' AND namespace=?1 \
                   AND deleted_at IS NOT NULL \
                   AND (json_extract(properties,'$.repo_slug')=?2 \
                        OR json_extract(properties,'$.repo_url')=?3) \
-                  ORDER BY deleted_at DESC LIMIT 1"
+                  ORDER BY deleted_at DESC"
                 .into(),
             params: vec![
                 SqlValue::Text(token.namespace().as_str().to_string()),
@@ -429,39 +440,42 @@ async fn find_orphaned_anchor(
         })
         .await
         .map_err(|e| anyhow!("{e}"))?;
-    let Some(dead_project_id) = row.and_then(|r| match r.get("id") {
+    let dead_project_ids = rows.into_iter().filter_map(|r| match r.get("id") {
         Some(SqlValue::Uuid(u)) => Some(*u),
         Some(SqlValue::Text(s)) => Uuid::parse_str(s).ok(),
         _ => None,
-    }) else {
-        return Ok(None);
-    };
+    });
 
-    let count = r
-        .query_scalar(SqlStatement {
-            sql: "SELECT COUNT(*) FROM notes n \
-                  JOIN graph_edges e ON e.source_id = n.id AND e.namespace = n.namespace \
-                  WHERE n.namespace = ?1 AND n.deleted_at IS NULL \
-                  AND n.kind IN ('commit', 'issue', 'pull_request') \
-                  AND e.relation = 'annotates' AND e.target_id = ?2 AND e.deleted_at IS NULL"
-                .into(),
-            params: vec![
-                SqlValue::Text(token.namespace().as_str().to_string()),
-                SqlValue::Text(dead_project_id.to_string()),
-            ],
-            label: Some("git_digest_count_orphaned_notes".into()),
-        })
-        .await
-        .map_err(|e| anyhow!("{e}"))?;
-    let annotated_note_count = match count {
-        Some(SqlValue::Integer(n)) => n as u64,
-        _ => 0,
-    };
+    for dead_project_id in dead_project_ids {
+        let count = r
+            .query_scalar(SqlStatement {
+                sql: "SELECT COUNT(*) FROM notes n \
+                      JOIN graph_edges e ON e.source_id = n.id AND e.namespace = n.namespace \
+                      WHERE n.namespace = ?1 AND n.deleted_at IS NULL \
+                      AND n.kind IN ('commit', 'issue', 'pull_request') \
+                      AND e.relation = 'annotates' AND e.target_id = ?2 AND e.deleted_at IS NULL"
+                    .into(),
+                params: vec![
+                    SqlValue::Text(token.namespace().as_str().to_string()),
+                    SqlValue::Text(dead_project_id.to_string()),
+                ],
+                label: Some("git_digest_count_orphaned_notes".into()),
+            })
+            .await
+            .map_err(|e| anyhow!("{e}"))?;
+        let annotated_note_count = match count {
+            Some(SqlValue::Integer(n)) => n as u64,
+            _ => 0,
+        };
+        if annotated_note_count > 0 {
+            return Ok(Some(OrphanSignal {
+                dead_project_id,
+                annotated_note_count,
+            }));
+        }
+    }
 
-    Ok(Some(OrphanSignal {
-        dead_project_id,
-        annotated_note_count,
-    }))
+    Ok(None)
 }
 
 #[cfg(test)]
@@ -694,5 +708,119 @@ mod tests {
             .expect("orphaned corpus must be flagged, not silent");
         assert_eq!(orphan.dead_project_id, dead_id);
         assert_eq!(orphan.annotated_note_count, 2);
+    }
+
+    /// A soft-deleted anchor with zero live annotating notes is a routine
+    /// delete of an already-empty anchor, not an orphaned corpus -- it must
+    /// not raise the signal (issue #1185 finding 3).
+    #[tokio::test]
+    async fn tombstone_with_zero_live_notes_is_not_flagged_as_orphan() {
+        let (rt, token, registry) = fixture().await;
+
+        let source = DigestSource::Remote {
+            canonical: "https://github.com/org/empty-tombstone-repo".to_string(),
+            gh_slug: Some(("org".to_string(), "empty-tombstone-repo".to_string())),
+        };
+
+        let dead = registry
+            .dispatch(
+                "create",
+                json!({
+                    "kind": "project",
+                    "name": "empty-tombstone-repo",
+                    "properties": {
+                        "repo_url": "https://github.com/org/empty-tombstone-repo",
+                        "repo_slug": "github.com/org/empty-tombstone-repo",
+                    },
+                }),
+            )
+            .await
+            .expect("create dead anchor");
+        let dead_id = Uuid::parse_str(dead["id"].as_str().unwrap()).expect("uuid");
+
+        // No annotating notes created -- this tombstone never had a corpus.
+        let deleted = rt
+            .delete_entity(&token, dead_id, false)
+            .await
+            .expect("soft delete");
+        assert!(deleted);
+
+        let resolution = resolve_or_create_project(&rt, &registry, &token, &source)
+            .await
+            .expect("resolve");
+        assert!(resolution.created);
+        assert!(
+            resolution.orphan.is_none(),
+            "zero live notes must not raise the orphan signal"
+        );
+    }
+
+    /// When several soft-deleted tombstones share the same repo identity,
+    /// the signal must select the one that actually still has a live
+    /// annotating corpus -- not merely the most-recently-deleted one (issue
+    /// #1185 finding 3).
+    #[tokio::test]
+    async fn orphan_signal_selects_tombstone_with_live_corpus_among_several() {
+        let (rt, token, registry) = fixture().await;
+
+        let source = DigestSource::Remote {
+            canonical: "https://github.com/org/multi-tombstone-repo".to_string(),
+            gh_slug: Some(("org".to_string(), "multi-tombstone-repo".to_string())),
+        };
+        let properties = json!({
+            "repo_url": "https://github.com/org/multi-tombstone-repo",
+            "repo_slug": "github.com/org/multi-tombstone-repo",
+        });
+
+        // Older tombstone: still has a live annotating corpus.
+        let old_dead = registry
+            .dispatch(
+                "create",
+                json!({
+                    "kind": "project",
+                    "name": "multi-tombstone-repo",
+                    "properties": properties.clone(),
+                }),
+            )
+            .await
+            .expect("create old dead anchor");
+        let old_dead_id = Uuid::parse_str(old_dead["id"].as_str().unwrap()).expect("uuid");
+        create_note_annotating(&registry, "commit", "c-old", old_dead_id).await;
+        rt.delete_entity(&token, old_dead_id, false)
+            .await
+            .expect("soft delete old");
+
+        // deleted_at ordering must be distinct for the two tombstones.
+        tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+
+        // Newer tombstone: an empty re-ingest-then-delete cycle, zero live notes.
+        let new_dead = registry
+            .dispatch(
+                "create",
+                json!({
+                    "kind": "project",
+                    "name": "multi-tombstone-repo",
+                    "properties": properties,
+                }),
+            )
+            .await
+            .expect("create new dead anchor");
+        let new_dead_id = Uuid::parse_str(new_dead["id"].as_str().unwrap()).expect("uuid");
+        rt.delete_entity(&token, new_dead_id, false)
+            .await
+            .expect("soft delete new");
+
+        let resolution = resolve_or_create_project(&rt, &registry, &token, &source)
+            .await
+            .expect("resolve");
+        assert!(resolution.created);
+        let orphan = resolution
+            .orphan
+            .expect("orphaned corpus must be flagged, not silent");
+        assert_eq!(
+            orphan.dead_project_id, old_dead_id,
+            "signal must point at the tombstone with the live corpus, not merely the most recent one"
+        );
+        assert_eq!(orphan.annotated_note_count, 1);
     }
 }

--- a/crates/khive-pack-git/src/handlers.rs
+++ b/crates/khive-pack-git/src/handlers.rs
@@ -322,7 +322,14 @@ async fn resolve_or_create_project(
                 "update",
                 json!({
                     "id": id.to_string(),
-                    "properties": { REPO_SLUG_PROPERTY: identity },
+                    // Backfill hits also redact the stored repo_url in the
+                    // same patch (ADR-088 Amendment 2 step 2) -- the
+                    // lazy-upgrade path closes out any credential-bearing
+                    // legacy URL it touches.
+                    "properties": {
+                        REPO_SLUG_PROPERTY: identity,
+                        "repo_url": redact_repo_url(&repo_url),
+                    },
                 }),
             )
             .await?;
@@ -343,24 +350,29 @@ async fn resolve_or_create_project(
     let legacy_candidates = find_legacy_projects_without_slug(runtime, token)
         .await
         .map_err(|e| RuntimeError::InvalidInput(e.to_string()))?;
-    let mut normalized_matches: Vec<Uuid> = Vec::new();
+    let mut normalized_matches: Vec<(Uuid, String)> = Vec::new();
     for (id, candidate_repo_url) in legacy_candidates {
         if normalize_legacy_repo_url(&candidate_repo_url)
             .await
             .as_deref()
             == Some(identity.as_str())
         {
-            normalized_matches.push(id);
+            normalized_matches.push((id, candidate_repo_url));
         }
     }
-    if let Some((selected, duplicates)) = normalized_matches.split_first() {
+    if let Some(((selected, selected_repo_url), duplicates)) = normalized_matches.split_first() {
         let selected = *selected;
         registry
             .dispatch(
                 "update",
                 json!({
                     "id": selected.to_string(),
-                    "properties": { REPO_SLUG_PROPERTY: identity },
+                    // Same-patch redaction of the matched anchor's own stored
+                    // repo_url (ADR-088 Amendment 2 step 2).
+                    "properties": {
+                        REPO_SLUG_PROPERTY: identity,
+                        "repo_url": redact_repo_url(selected_repo_url),
+                    },
                 }),
             )
             .await?;
@@ -368,7 +380,7 @@ async fn resolve_or_create_project(
             id: selected,
             created: false,
             orphan: None,
-            slug_duplicates: duplicates.to_vec(),
+            slug_duplicates: duplicates.iter().map(|(id, _)| *id).collect(),
         });
     }
 

--- a/crates/khive-pack-git/src/handlers.rs
+++ b/crates/khive-pack-git/src/handlers.rs
@@ -166,6 +166,7 @@ impl GitPack {
                     id,
                     created: false,
                     orphan: None,
+                    slug_duplicates: Vec::new(),
                 }
             }
             None => resolve_or_create_project(self.runtime(), registry, token, &source).await?,
@@ -202,6 +203,18 @@ impl GitPack {
         .map_err(|e| RuntimeError::InvalidInput(e.to_string()))?;
 
         report.warnings.extend(warnings);
+        if !resolution.slug_duplicates.is_empty() {
+            report.warnings.push(format!(
+                "multiple live project anchors share repo_slug; selected oldest {}; duplicates: {}",
+                project_id,
+                resolution
+                    .slug_duplicates
+                    .iter()
+                    .map(Uuid::to_string)
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            ));
+        }
         report.project_id = Some(project_id.to_string());
         report.project_created = project_created;
         if let Some(orphan) = resolution.orphan {
@@ -250,6 +263,10 @@ pub(crate) struct ProjectResolution {
     /// repo identity was found with a live corpus still annotating it
     /// (issue #1173) — surfaced via `IngestReport`, never silent.
     pub(crate) orphan: Option<OrphanSignal>,
+    /// Additional live anchors carrying the same `repo_slug` beyond the
+    /// deterministically selected one (ADR-088 Amendment 2 step-1
+    /// multi-match) — surfaced as a report warning, never silent.
+    pub(crate) slug_duplicates: Vec<Uuid>,
 }
 
 pub(crate) struct OrphanSignal {
@@ -281,14 +298,15 @@ async fn resolve_or_create_project(
     let identity = repo_identity(source);
     let name = repo_basename(source);
 
-    if let Some(id) = find_project_by_slug(runtime, token, &identity)
+    let slug_matches = find_projects_by_slug(runtime, token, &identity)
         .await
-        .map_err(|e| RuntimeError::InvalidInput(e.to_string()))?
-    {
+        .map_err(|e| RuntimeError::InvalidInput(e.to_string()))?;
+    if let Some((id, duplicates)) = slug_matches.split_first() {
         return Ok(ProjectResolution {
-            id,
+            id: *id,
             created: false,
             orphan: None,
+            slug_duplicates: duplicates.to_vec(),
         });
     }
 
@@ -309,6 +327,7 @@ async fn resolve_or_create_project(
             id,
             created: false,
             orphan: None,
+            slug_duplicates: Vec::new(),
         });
     }
 
@@ -337,36 +356,45 @@ async fn resolve_or_create_project(
         id,
         created: true,
         orphan,
+        slug_duplicates: Vec::new(),
     })
 }
 
-async fn find_project_by_slug(
+// Multiple live anchors can carry one slug when two legacy anchors holding
+// different URL spellings of the same repository were each exact-matched and
+// backfilled on separate ingests. Selection must be deterministic (oldest
+// `created_at`, id tie-break) and the condition surfaced as a report warning,
+// never an arbitrary or silent pick (ADR-088 Amendment 2).
+async fn find_projects_by_slug(
     runtime: &KhiveRuntime,
     token: &NamespaceToken,
     identity: &str,
-) -> anyhow::Result<Option<Uuid>> {
+) -> anyhow::Result<Vec<Uuid>> {
     let sql = runtime.sql();
     let mut r = sql.reader().await.map_err(|e| anyhow!("{e}"))?;
-    let row = r
-        .query_row(SqlStatement {
+    let rows = r
+        .query_all(SqlStatement {
             sql: "SELECT id FROM entities WHERE kind='project' AND namespace=?1 \
                   AND deleted_at IS NULL \
                   AND json_extract(properties,'$.repo_slug')=?2 \
-                  LIMIT 1"
+                  ORDER BY created_at ASC, id ASC"
                 .into(),
             params: vec![
                 SqlValue::Text(token.namespace().as_str().to_string()),
                 SqlValue::Text(identity.to_string()),
             ],
-            label: Some("git_digest_find_project_by_slug".into()),
+            label: Some("git_digest_find_projects_by_slug".into()),
         })
         .await
         .map_err(|e| anyhow!("{e}"))?;
-    Ok(row.and_then(|r| match r.get("id") {
-        Some(SqlValue::Uuid(u)) => Some(*u),
-        Some(SqlValue::Text(s)) => Uuid::parse_str(s).ok(),
-        _ => None,
-    }))
+    Ok(rows
+        .iter()
+        .filter_map(|r| match r.get("id") {
+            Some(SqlValue::Uuid(u)) => Some(*u),
+            Some(SqlValue::Text(s)) => Uuid::parse_str(s).ok(),
+            _ => None,
+        })
+        .collect())
 }
 
 async fn find_project_by_legacy_repo_url(
@@ -654,6 +682,64 @@ mod tests {
                 .and_then(Value::as_str),
             Some("github.com/org/legacy-repo"),
             "repo_slug must be backfilled on the legacy anchor"
+        );
+    }
+
+    /// Two live anchors sharing one `repo_slug` (each backfilled from a
+    /// different legacy `repo_url` spelling) must resolve deterministically
+    /// to one of them with the rest surfaced as duplicates, never an
+    /// arbitrary or silent pick (ADR-088 Amendment 2 step-1 multi-match).
+    #[tokio::test]
+    async fn duplicate_slug_anchors_resolve_deterministically_with_signal() {
+        let (rt, token, registry) = fixture().await;
+
+        let slug = "github.com/org/dup-repo";
+        let mut ids = Vec::new();
+        for repo_url in [
+            "https://github.com/org/dup-repo",
+            "git@github.com:org/dup-repo.git",
+        ] {
+            let resp = registry
+                .dispatch(
+                    "create",
+                    json!({
+                        "kind": "project",
+                        "name": "dup-repo",
+                        "properties": { "repo_url": repo_url, "repo_slug": slug },
+                    }),
+                )
+                .await
+                .expect("create anchor");
+            ids.push(Uuid::parse_str(resp["id"].as_str().unwrap()).expect("uuid"));
+        }
+
+        let source = DigestSource::Remote {
+            canonical: "https://github.com/org/dup-repo".to_string(),
+            gh_slug: Some(("org".to_string(), "dup-repo".to_string())),
+        };
+        let first = resolve_or_create_project(&rt, &registry, &token, &source)
+            .await
+            .expect("resolve");
+        assert!(!first.created, "multi-match must not create a third anchor");
+        assert!(
+            ids.contains(&first.id),
+            "selected anchor must be one of the existing pair"
+        );
+        assert_eq!(
+            first.slug_duplicates,
+            ids.iter()
+                .copied()
+                .filter(|id| *id != first.id)
+                .collect::<Vec<_>>(),
+            "the unselected anchor must be surfaced as a duplicate"
+        );
+
+        let second = resolve_or_create_project(&rt, &registry, &token, &source)
+            .await
+            .expect("resolve again");
+        assert_eq!(
+            second.id, first.id,
+            "selection must be deterministic across calls"
         );
     }
 

--- a/crates/khive-pack-git/src/ingest.rs
+++ b/crates/khive-pack-git/src/ingest.rs
@@ -124,6 +124,21 @@ pub struct IngestReport {
     /// because none was found (ADR-088 Amendment 1) — never set by
     /// `run_ingest` itself, only by the verb handler after it returns.
     pub project_created: bool,
+    /// `true` when `project_created` fired over a soft-deleted anchor that
+    /// still had a live corpus annotating it (issue #1173) — the resolved
+    /// repo identity matched no LIVE `project` entity, but did match a
+    /// soft-deleted one with `annotates` edges still pointing at it. This
+    /// distinguishes "first ingest of a new repo" from "anchor lost,
+    /// corpus about to duplicate under a fresh anchor" — never set by
+    /// `run_ingest` itself, only by the verb handler after it returns.
+    pub orphaned_corpus_detected: bool,
+    /// The dangling anchor id `orphaned_corpus_detected` was found under.
+    /// `None` unless `orphaned_corpus_detected` is `true`.
+    pub orphaned_project_id: Option<String>,
+    /// Count of `commit`/`issue`/`pull_request` notes still `annotates`-
+    /// linked to `orphaned_project_id`. `0` unless `orphaned_corpus_detected`
+    /// is `true`.
+    pub orphaned_note_count: u64,
     /// `annotates` edges created from a `Closes/Fixes/Resolves #N` or bare
     /// `#N` reference in a commit message or issue/PR body to the referenced
     /// issue/PR note (ADR-088 Amendment 1 ingest enrichment).

--- a/crates/khive-pack-git/src/source.rs
+++ b/crates/khive-pack-git/src/source.rs
@@ -95,32 +95,54 @@ fn is_scp_shorthand(s: &str) -> bool {
 }
 
 /// Split `[user@]host:path` shorthand into `(host, path)`, or `None` when
-/// `s` doesn't have that shape. The host segment (whatever precedes the
-/// first `:`, minus any `user@` prefix) must contain no `/` -- this is what
-/// keeps a local path with an embedded colon, e.g. `local/path:with-colon`,
-/// from being misparsed as SCP shorthand: `local/path` fails the host check
-/// because of the `/`, so `scp_parts` returns `None` and the caller falls
-/// through to local-path handling.
-fn scp_parts(s: &str) -> Option<(&str, &str)> {
+/// `s` doesn't have that shape. A bracketed IPv6 host (`git@[::1]:path` or
+/// the bare `[::1]:path`) is handled by locating the `[...]` span and
+/// requiring the very next character to be `:` -- naively taking the first
+/// `:` in the string (as the plain-host branch below does) would land on a
+/// colon INSIDE the address instead of the host/path separator, which is
+/// what let a bracketed-IPv6 SCP origin fall through to `local:<path>`
+/// instead of converging with its remote slug (ADR-088 Amendment 2
+/// round-2 finding). For a plain (non-bracketed) host, the segment
+/// (whatever precedes the first `:`, minus any `user@` prefix) must
+/// contain no `/` -- this is what keeps a local path with an embedded
+/// colon, e.g. `local/path:with-colon`, from being misparsed as SCP
+/// shorthand: `local/path` fails the host check because of the `/`, so
+/// `scp_parts` returns `None` and the caller falls through to local-path
+/// handling.
+fn scp_parts(s: &str) -> Option<(String, &str)> {
     if s.starts_with('/') {
         return None;
     }
-    let colon = s.find(':')?;
-    let before_colon = &s[..colon];
-    let host = match before_colon.rfind('@') {
-        Some(at) => {
-            let user = &before_colon[..at];
-            if user.is_empty()
-                || !user
-                    .chars()
-                    .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_' || c == '.')
-            {
-                return None;
-            }
-            &before_colon[at + 1..]
-        }
-        None => before_colon,
+
+    let (user, rest) = match s.find('@') {
+        Some(at) => (Some(&s[..at]), &s[at + 1..]),
+        None => (None, s),
     };
+    if let Some(user) = user {
+        if user.is_empty()
+            || !user
+                .chars()
+                .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_' || c == '.')
+        {
+            return None;
+        }
+    }
+
+    if let Some(inner) = rest.strip_prefix('[') {
+        let end = inner.find(']')?;
+        let host_inner = &inner[..end];
+        if host_inner.is_empty() {
+            return None;
+        }
+        let path = inner[end + 1..].strip_prefix(':')?;
+        if path.is_empty() {
+            return None;
+        }
+        return Some((format!("[{host_inner}]"), path));
+    }
+
+    let colon = rest.find(':')?;
+    let host = &rest[..colon];
     if host.is_empty()
         || host.contains('/')
         || !host
@@ -129,11 +151,11 @@ fn scp_parts(s: &str) -> Option<(&str, &str)> {
     {
         return None;
     }
-    let path = &s[colon + 1..];
+    let path = &rest[colon + 1..];
     if path.is_empty() {
         return None;
     }
-    Some((host, path))
+    Some((host.to_string(), path))
 }
 
 fn canonicalize_https_url(url: &str) -> String {
@@ -224,7 +246,9 @@ fn strip_port(host: &str) -> String {
 /// are preserved verbatim -- case-folding those risks collapsing two
 /// genuinely distinct repos on a case-sensitive host.
 pub fn remote_url_to_slug(url: &str) -> Option<String> {
-    let trimmed = url.trim().trim_end_matches('/');
+    let trimmed = url.trim();
+    let trimmed = strip_query_and_fragment(trimmed);
+    let trimmed = trimmed.trim_end_matches('/');
     let trimmed = trimmed.strip_suffix(".git").unwrap_or(trimmed);
     if trimmed.is_empty() {
         return None;
@@ -239,7 +263,7 @@ pub fn remote_url_to_slug(url: &str) -> Option<String> {
     } else if let Some(rest) = trimmed.strip_prefix("ssh://") {
         split_host_path(rest)?
     } else if let Some((host, path)) = scp_parts(trimmed) {
-        (host.to_string(), path.to_string())
+        (host, path.to_string())
     } else {
         return None;
     };
@@ -252,30 +276,80 @@ pub fn remote_url_to_slug(url: &str) -> Option<String> {
     if segs.len() < 2 || segs.iter().any(|s| s.is_empty()) {
         return None;
     }
-    Some(format!("{}/{}", host.to_ascii_lowercase(), segs.join("/")))
+    let host = host.to_ascii_lowercase();
+    let host = host.strip_prefix("www.").unwrap_or(&host);
+    Some(format!("{host}/{}", segs.join("/")))
+}
+
+/// Strip a URL's query (`?...`) and fragment (`#...`) components, in that
+/// lexical order, before any path-segment splitting or `.git`-suffix
+/// stripping (ADR-088 Amendment 2) -- a caller-supplied source URL can
+/// carry an access token in its query string, and that token must never
+/// reach the derived slug (or, via `redact_repo_url`, storage).
+fn strip_query_and_fragment(s: &str) -> &str {
+    let s = match s.find('#') {
+        Some(i) => &s[..i],
+        None => s,
+    };
+    match s.find('?') {
+        Some(i) => &s[..i],
+        None => s,
+    }
+}
+
+/// Redact credential and tracking material from a URL before it is
+/// persisted as `properties.repo_url` display metadata (ADR-088 Amendment
+/// 2): userinfo (`user[:pass]@`), the query string, and the fragment are
+/// stripped. This is for the STORED value only -- the in-memory canonical
+/// URL used for cloning/gh operations is never passed through this.
+pub(crate) fn redact_repo_url(url: &str) -> String {
+    let stripped = strip_query_and_fragment(url);
+    for scheme in ["https://", "http://", "git://", "ssh://"] {
+        if let Some(rest) = stripped.strip_prefix(scheme) {
+            let authority_end = rest.find('/').unwrap_or(rest.len());
+            let (authority, path) = rest.split_at(authority_end);
+            let authority = match authority.rfind('@') {
+                Some(pos) => &authority[pos + 1..],
+                None => authority,
+            };
+            return format!("{scheme}{authority}{path}");
+        }
+    }
+    stripped.to_string()
 }
 
 /// Read the local repo's configured `origin` remote URL via `git -C <path>
 /// remote get-url origin`. Returns `None` for any failure (no `origin`
 /// remote, `git` not on PATH, not a git repo) -- a local repo with no
 /// remote is a valid, expected state (see `repo_identity`), not an error.
-fn local_origin_remote_url(canonical_repo_path: &Path) -> Option<String> {
-    let out = Command::new("git")
-        .arg("-C")
-        .arg(canonical_repo_path)
-        .args(["remote", "get-url", "origin"])
-        .env("GIT_TERMINAL_PROMPT", "0")
-        .output()
-        .ok()?;
-    if !out.status.success() {
-        return None;
-    }
-    let url = String::from_utf8_lossy(&out.stdout).trim().to_string();
-    if url.is_empty() {
-        None
-    } else {
-        Some(url)
-    }
+///
+/// Runs the blocking `Command::output()` call on a `spawn_blocking` thread:
+/// every caller of `repo_identity` is an async handler path, and a
+/// synchronous subprocess spawn there would block the async runtime worker
+/// thread it runs on.
+async fn local_origin_remote_url(canonical_repo_path: &Path) -> Option<String> {
+    let path = canonical_repo_path.to_path_buf();
+    tokio::task::spawn_blocking(move || {
+        let out = Command::new("git")
+            .arg("-C")
+            .arg(&path)
+            .args(["remote", "get-url", "origin"])
+            .env("GIT_TERMINAL_PROMPT", "0")
+            .output()
+            .ok()?;
+        if !out.status.success() {
+            return None;
+        }
+        let url = String::from_utf8_lossy(&out.stdout).trim().to_string();
+        if url.is_empty() {
+            None
+        } else {
+            Some(url)
+        }
+    })
+    .await
+    .ok()
+    .flatten()
 }
 
 /// Resolve the canonical repo-anchor identity (issue #1173) for a digest
@@ -293,14 +367,14 @@ fn local_origin_remote_url(canonical_repo_path: &Path) -> Option<String> {
 ///   that exact path: two clones of the same remote-less repo at different
 ///   paths do NOT converge (there is no remote to prove they're the same
 ///   repository).
-pub fn repo_identity(source: &DigestSource) -> String {
+pub async fn repo_identity(source: &DigestSource) -> String {
     match source {
         DigestSource::Remote { canonical, .. } => {
             remote_url_to_slug(canonical).unwrap_or_else(|| canonical.clone())
         }
         DigestSource::Local(path) => {
             let canon = std::fs::canonicalize(path).unwrap_or_else(|_| path.clone());
-            if let Some(origin) = local_origin_remote_url(&canon) {
+            if let Some(origin) = local_origin_remote_url(&canon).await {
                 if let Some(slug) = remote_url_to_slug(&origin) {
                     return slug;
                 }
@@ -390,6 +464,18 @@ mod tests {
     }
 
     #[test]
+    fn scp_shorthand_bracketed_ipv6_host_rejected_as_source() {
+        let err = parse_source("git@[::1]:group/repo.git").unwrap_err();
+        assert!(err.contains("SSH"), "{err}");
+    }
+
+    #[test]
+    fn bare_scp_shorthand_bracketed_ipv6_host_rejected_as_source() {
+        let err = parse_source("[::1]:group/repo.git").unwrap_err();
+        assert!(err.contains("SSH"), "{err}");
+    }
+
+    #[test]
     fn git_protocol_rejected() {
         let err = parse_source("git://github.com/org/repo.git").unwrap_err();
         assert!(err.contains("git://"), "{err}");
@@ -471,8 +557,22 @@ mod tests {
             // ssh:// with a port -- the port is not part of the identity.
             "ssh://git@github.com:2222/org/repo.git",
             "ssh://github.com:2222/org/repo",
+            // https/http/git:// with an authority port -- likewise not part
+            // of the identity (round-2 finding: only ssh:// was covered).
+            "https://github.com:8443/org/repo",
+            "https://github.com:8443/org/repo.git",
+            "http://github.com:8080/org/repo",
+            "git://github.com:9418/org/repo",
             // Host case is folded; owner/repo case is preserved separately below.
             "https://GitHub.com/org/repo",
+            // A leading www. host label is folded (ADR-088 Amendment 2).
+            "https://www.github.com/org/repo",
+            // A query string and/or fragment must not affect normalization
+            // and must never leak a token into the slug.
+            "https://github.com/org/repo?ref=nightly",
+            "https://github.com/org/repo.git?ref=nightly",
+            "https://github.com/org/repo#readme",
+            "https://github.com/org/repo.git?token=SECRET#section",
         ];
         for s in spellings {
             assert_eq!(
@@ -481,6 +581,46 @@ mod tests {
                 "spelling {s:?} should normalize to {expected:?}"
             );
         }
+    }
+
+    #[test]
+    fn remote_url_to_slug_strips_query_and_fragment_before_splitting() {
+        let slug = remote_url_to_slug("https://github.com/org/repo?token=SECRETTOKEN").unwrap();
+        assert_eq!(slug, "github.com/org/repo");
+        assert!(!slug.contains("SECRETTOKEN"), "{slug}");
+    }
+
+    #[test]
+    fn remote_url_to_slug_folds_leading_www_host_label() {
+        assert_eq!(
+            remote_url_to_slug("https://www.gitlab.com/org/repo").as_deref(),
+            Some("gitlab.com/org/repo")
+        );
+    }
+
+    #[test]
+    fn scp_shorthand_bracketed_ipv6_host_normalizes_directly() {
+        assert_eq!(
+            remote_url_to_slug("git@[::1]:group/repo.git").as_deref(),
+            Some("[::1]/group/repo")
+        );
+        assert_eq!(
+            remote_url_to_slug("[::1]:group/repo.git").as_deref(),
+            Some("[::1]/group/repo"),
+            "the no-user bracketed SCP variant must also normalize"
+        );
+    }
+
+    #[test]
+    fn redact_repo_url_strips_userinfo_query_and_fragment() {
+        assert_eq!(
+            redact_repo_url("https://user:tok3n@github.com/org/repo?token=SECRET#frag"),
+            "https://github.com/org/repo"
+        );
+        assert_eq!(
+            redact_repo_url("https://github.com/org/repo"),
+            "https://github.com/org/repo"
+        );
     }
 
     #[test]
@@ -557,17 +697,17 @@ mod tests {
         }
     }
 
-    #[test]
-    fn repo_identity_https_and_ssh_spellings_of_same_remote_converge() {
+    #[tokio::test]
+    async fn repo_identity_https_and_ssh_spellings_of_same_remote_converge() {
         let https = DigestSource::Remote {
             canonical: "https://github.com/org/repo".to_string(),
             gh_slug: Some(("org".to_string(), "repo".to_string())),
         };
-        assert_eq!(repo_identity(&https), "github.com/org/repo");
+        assert_eq!(repo_identity(&https).await, "github.com/org/repo");
     }
 
-    #[test]
-    fn repo_identity_local_path_with_origin_matches_remote_identity() {
+    #[tokio::test]
+    async fn repo_identity_local_path_with_origin_matches_remote_identity() {
         let dir = tempfile::tempdir().expect("tempdir");
         init_repo_with_origin(dir.path(), "git@github.com:org/repo.git");
 
@@ -576,12 +716,29 @@ mod tests {
             canonical: "https://github.com/org/repo".to_string(),
             gh_slug: Some(("org".to_string(), "repo".to_string())),
         };
-        assert_eq!(repo_identity(&local), repo_identity(&remote));
-        assert_eq!(repo_identity(&local), "github.com/org/repo");
+        assert_eq!(repo_identity(&local).await, repo_identity(&remote).await);
+        assert_eq!(repo_identity(&local).await, "github.com/org/repo");
     }
 
-    #[test]
-    fn repo_identity_local_path_without_remote_falls_back_to_path_form() {
+    /// Round-2 finding: a local clone whose `origin` is bracketed-IPv6 SCP
+    /// shorthand must converge with the equivalent `ssh://` spelling's
+    /// slug, not fall back to `local:<path>`.
+    #[tokio::test]
+    async fn repo_identity_local_path_with_bracketed_ipv6_scp_origin_converges() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        init_repo_with_origin(dir.path(), "git@[::1]:group/repo.git");
+
+        let local = DigestSource::Local(dir.path().to_path_buf());
+        let remote = DigestSource::Remote {
+            canonical: "https://[::1]/group/repo".to_string(),
+            gh_slug: None,
+        };
+        assert_eq!(repo_identity(&local).await, "[::1]/group/repo");
+        assert_eq!(repo_identity(&local).await, repo_identity(&remote).await);
+    }
+
+    #[tokio::test]
+    async fn repo_identity_local_path_without_remote_falls_back_to_path_form() {
         let dir = tempfile::tempdir().expect("tempdir");
         let status = Command::new("git")
             .arg("-C")
@@ -592,7 +749,7 @@ mod tests {
         assert!(status.success());
 
         let local = DigestSource::Local(dir.path().to_path_buf());
-        let identity = repo_identity(&local);
+        let identity = repo_identity(&local).await;
         assert!(identity.starts_with("local:"), "{identity}");
         let canon = std::fs::canonicalize(dir.path()).unwrap();
         assert_eq!(identity, format!("local:{}", canon.to_string_lossy()));

--- a/crates/khive-pack-git/src/source.rs
+++ b/crates/khive-pack-git/src/source.rs
@@ -398,12 +398,16 @@ pub fn repo_basename(source: &DigestSource) -> String {
             .and_then(|f| f.to_str())
             .unwrap_or("repo")
             .to_string(),
-        DigestSource::Remote { canonical, .. } => strip_query_and_fragment(canonical)
+        // Derived from the fully redacted URL: a root-path remote like
+        // `https://user:token@example.com` has no path segment to split off,
+        // so without redaction the authority -- userinfo included -- would
+        // become the persisted project name.
+        DigestSource::Remote { canonical, .. } => redact_repo_url(canonical)
             .rsplit('/')
             .next()
             .filter(|s| !s.is_empty())
-            .unwrap_or("repo")
-            .to_string(),
+            .map(str::to_string)
+            .unwrap_or_else(|| "repo".to_string()),
     }
 }
 
@@ -738,6 +742,17 @@ mod tests {
             gh_slug: None,
         };
         assert_eq!(repo_basename(&src), "repo");
+    }
+
+    #[test]
+    fn repo_basename_never_carries_userinfo_for_root_path_remotes() {
+        let src = DigestSource::Remote {
+            canonical: "https://user:tok3n@example.com".to_string(),
+            gh_slug: None,
+        };
+        let name = repo_basename(&src);
+        assert_eq!(name, "example.com");
+        assert!(!name.contains("tok3n"));
     }
 
     #[tokio::test]

--- a/crates/khive-pack-git/src/source.rs
+++ b/crates/khive-pack-git/src/source.rs
@@ -390,4 +390,101 @@ mod tests {
         assert_eq!(a.len(), 16);
         assert!(a.chars().all(|ch| ch.is_ascii_hexdigit()));
     }
+
+    // -- repo identity slug (issue #1173) --------------------------------
+
+    #[test]
+    fn remote_url_to_slug_normalization_table() {
+        let expected = "github.com/org/repo";
+        let spellings = [
+            "https://github.com/org/repo",
+            "https://github.com/org/repo.git",
+            "https://github.com/org/repo/",
+            "https://github.com/org/repo.git/",
+            "http://github.com/org/repo",
+            "https://token@github.com/org/repo.git",
+            "https://user:token@github.com/org/repo.git",
+            "ssh://git@github.com/org/repo.git",
+            "git@github.com:org/repo.git",
+            "git@github.com:org/repo",
+            "git://github.com/org/repo.git",
+            // Host case is folded; owner/repo case is preserved separately below.
+            "https://GitHub.com/org/repo",
+        ];
+        for s in spellings {
+            assert_eq!(
+                remote_url_to_slug(s).as_deref(),
+                Some(expected),
+                "spelling {s:?} should normalize to {expected:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn remote_url_to_slug_preserves_owner_repo_case() {
+        assert_eq!(
+            remote_url_to_slug("https://github.com/Org/Repo").as_deref(),
+            Some("github.com/Org/Repo")
+        );
+    }
+
+    #[test]
+    fn remote_url_to_slug_rejects_unparseable_input() {
+        assert_eq!(remote_url_to_slug(""), None);
+        assert_eq!(remote_url_to_slug("not-a-url"), None);
+        assert_eq!(remote_url_to_slug("https://github.com/onlyowner"), None);
+    }
+
+    fn init_repo_with_origin(dir: &Path, origin: &str) {
+        for args in [vec!["init", "-q"], vec!["remote", "add", "origin", origin]] {
+            let status = Command::new("git")
+                .arg("-C")
+                .arg(dir)
+                .args(&args)
+                .status()
+                .expect("spawn git");
+            assert!(status.success(), "git {args:?} failed");
+        }
+    }
+
+    #[test]
+    fn repo_identity_https_and_ssh_spellings_of_same_remote_converge() {
+        let https = DigestSource::Remote {
+            canonical: "https://github.com/org/repo".to_string(),
+            gh_slug: Some(("org".to_string(), "repo".to_string())),
+        };
+        assert_eq!(repo_identity(&https), "github.com/org/repo");
+    }
+
+    #[test]
+    fn repo_identity_local_path_with_origin_matches_remote_identity() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        init_repo_with_origin(dir.path(), "git@github.com:org/repo.git");
+
+        let local = DigestSource::Local(dir.path().to_path_buf());
+        let remote = DigestSource::Remote {
+            canonical: "https://github.com/org/repo".to_string(),
+            gh_slug: Some(("org".to_string(), "repo".to_string())),
+        };
+        assert_eq!(repo_identity(&local), repo_identity(&remote));
+        assert_eq!(repo_identity(&local), "github.com/org/repo");
+    }
+
+    #[test]
+    fn repo_identity_local_path_without_remote_falls_back_to_path_form() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let status = Command::new("git")
+            .arg("-C")
+            .arg(dir.path())
+            .args(["init", "-q"])
+            .status()
+            .expect("spawn git init");
+        assert!(status.success());
+
+        let local = DigestSource::Local(dir.path().to_path_buf());
+        let identity = repo_identity(&local);
+        assert!(identity.starts_with("local:"), "{identity}");
+        let canon = std::fs::canonicalize(dir.path()).unwrap();
+        assert_eq!(identity, format!("local:{}", canon.to_string_lossy()));
+    }
 }

--- a/crates/khive-pack-git/src/source.rs
+++ b/crates/khive-pack-git/src/source.rs
@@ -370,7 +370,12 @@ async fn local_origin_remote_url(canonical_repo_path: &Path) -> Option<String> {
 pub async fn repo_identity(source: &DigestSource) -> String {
     match source {
         DigestSource::Remote { canonical, .. } => {
-            remote_url_to_slug(canonical).unwrap_or_else(|| canonical.clone())
+            // An accepted URL that does not normalize (e.g. a single path
+            // segment) falls back to the URL itself as identity -- but
+            // credential-redacted and stripped of query/fragment, so a
+            // token embedded in the source can never persist in `repo_slug`
+            // and query-only spelling variants converge on one identity.
+            remote_url_to_slug(canonical).unwrap_or_else(|| redact_repo_url(canonical))
         }
         DigestSource::Local(path) => {
             let canon = std::fs::canonicalize(path).unwrap_or_else(|_| path.clone());
@@ -393,7 +398,7 @@ pub fn repo_basename(source: &DigestSource) -> String {
             .and_then(|f| f.to_str())
             .unwrap_or("repo")
             .to_string(),
-        DigestSource::Remote { canonical, .. } => canonical
+        DigestSource::Remote { canonical, .. } => strip_query_and_fragment(canonical)
             .rsplit('/')
             .next()
             .filter(|s| !s.is_empty())
@@ -704,6 +709,35 @@ mod tests {
             gh_slug: Some(("org".to_string(), "repo".to_string())),
         };
         assert_eq!(repo_identity(&https).await, "github.com/org/repo");
+    }
+
+    #[tokio::test]
+    async fn repo_identity_unsluggable_remote_fallback_is_redacted_and_converges() {
+        // A single-path-segment URL does not normalize to a slug; the raw-URL
+        // identity fallback must never carry userinfo/query/fragment, and
+        // query-only spelling variants must converge on one identity.
+        let with_secret = DigestSource::Remote {
+            canonical: "https://user:tok3n@example.com/repo?token=SECRET#frag".to_string(),
+            gh_slug: None,
+        };
+        let identity = repo_identity(&with_secret).await;
+        assert_eq!(identity, "https://example.com/repo");
+        assert!(!identity.contains("tok3n") && !identity.contains("SECRET"));
+
+        let bare = DigestSource::Remote {
+            canonical: "https://example.com/repo".to_string(),
+            gh_slug: None,
+        };
+        assert_eq!(repo_identity(&bare).await, identity);
+    }
+
+    #[test]
+    fn repo_basename_strips_query_and_fragment() {
+        let src = DigestSource::Remote {
+            canonical: "https://example.com/org/repo?x=1#frag".to_string(),
+            gh_slug: None,
+        };
+        assert_eq!(repo_basename(&src), "repo");
     }
 
     #[tokio::test]

--- a/crates/khive-pack-git/src/source.rs
+++ b/crates/khive-pack-git/src/source.rs
@@ -244,13 +244,15 @@ pub fn remote_url_to_slug(url: &str) -> Option<String> {
         return None;
     };
 
-    let mut segs = path.split('/');
-    let owner = segs.next()?;
-    let repo = segs.next()?;
-    if owner.is_empty() || repo.is_empty() {
+    // ALL path segments are preserved (ADR-088 Amendment 2): a nested-group
+    // remote like host/group/subgroup/repo keeps every segment, so two
+    // repositories under one subgroup never collapse onto one slug. Fewer
+    // than two segments, or any empty segment, does not normalize.
+    let segs: Vec<&str> = path.split('/').collect();
+    if segs.len() < 2 || segs.iter().any(|s| s.is_empty()) {
         return None;
     }
-    Some(format!("{}/{owner}/{repo}", host.to_ascii_lowercase()))
+    Some(format!("{}/{}", host.to_ascii_lowercase(), segs.join("/")))
 }
 
 /// Read the local repo's configured `origin` remote URL via `git -C <path>
@@ -479,6 +481,24 @@ mod tests {
                 "spelling {s:?} should normalize to {expected:?}"
             );
         }
+    }
+
+    #[test]
+    fn remote_url_to_slug_preserves_all_nested_path_segments() {
+        assert_eq!(
+            remote_url_to_slug("https://gitlab.com/group/subgroup/repo.git").as_deref(),
+            Some("gitlab.com/group/subgroup/repo")
+        );
+        assert_eq!(
+            remote_url_to_slug("git@gitlab.com:group/subgroup/repo.git").as_deref(),
+            Some("gitlab.com/group/subgroup/repo"),
+            "scp spelling of a nested-group remote must converge with https"
+        );
+        assert_ne!(
+            remote_url_to_slug("https://gitlab.com/group/subgroup/repo"),
+            remote_url_to_slug("https://gitlab.com/group/subgroup/other"),
+            "two repos under one subgroup must not collapse onto one slug"
+        );
     }
 
     #[test]

--- a/crates/khive-pack-git/src/source.rs
+++ b/crates/khive-pack-git/src/source.rs
@@ -87,27 +87,53 @@ pub fn parse_source(raw: &str) -> Result<DigestSource, String> {
     Ok(DigestSource::Local(path))
 }
 
-/// `true` for scp-like SSH shorthand (`user@host:path`, e.g.
-/// `git@github.com:org/repo.git`) — recognized by an `@` before the first
-/// `:` and no leading `/`.
+/// `true` for scp-like SSH shorthand (`[user@]host:path`, e.g.
+/// `git@github.com:org/repo.git` or the bare `github.com:org/repo.git` —
+/// the SCP user is optional in git's own remote grammar).
 fn is_scp_shorthand(s: &str) -> bool {
+    scp_parts(s).is_some()
+}
+
+/// Split `[user@]host:path` shorthand into `(host, path)`, or `None` when
+/// `s` doesn't have that shape. The host segment (whatever precedes the
+/// first `:`, minus any `user@` prefix) must contain no `/` -- this is what
+/// keeps a local path with an embedded colon, e.g. `local/path:with-colon`,
+/// from being misparsed as SCP shorthand: `local/path` fails the host check
+/// because of the `/`, so `scp_parts` returns `None` and the caller falls
+/// through to local-path handling.
+fn scp_parts(s: &str) -> Option<(&str, &str)> {
     if s.starts_with('/') {
-        return false;
+        return None;
     }
-    let Some(at) = s.find('@') else {
-        return false;
+    let colon = s.find(':')?;
+    let before_colon = &s[..colon];
+    let host = match before_colon.rfind('@') {
+        Some(at) => {
+            let user = &before_colon[..at];
+            if user.is_empty()
+                || !user
+                    .chars()
+                    .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_' || c == '.')
+            {
+                return None;
+            }
+            &before_colon[at + 1..]
+        }
+        None => before_colon,
     };
-    let Some(colon) = s.find(':') else {
-        return false;
-    };
-    if colon <= at {
-        return false;
-    }
-    let user = &s[..at];
-    !user.is_empty()
-        && user
+    if host.is_empty()
+        || host.contains('/')
+        || !host
             .chars()
-            .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_' || c == '.')
+            .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '.')
+    {
+        return None;
+    }
+    let path = &s[colon + 1..];
+    if path.is_empty() {
+        return None;
+    }
+    Some((host, path))
 }
 
 fn canonicalize_https_url(url: &str) -> String {
@@ -145,7 +171,10 @@ pub const REPO_SLUG_PROPERTY: &str = "repo_slug";
 /// `github.com/owner/repo` from `https://github.com/owner/repo`, or
 /// `github.com/owner/repo` from the `host/owner/repo` remainder of an
 /// `ssh://user@host/owner/repo` URL. `rfind('@')` (not the first `@`) drops
-/// userinfo because a password component can itself contain `@`.
+/// userinfo because a password component can itself contain `@`. Any port
+/// on the authority is stripped via `strip_port` -- the slug identity is
+/// host+path only, so `github.com:2222/org/repo` and `github.com/org/repo`
+/// must converge.
 fn split_host_path(rest: &str) -> Option<(String, String)> {
     let after_userinfo = match rest.rfind('@') {
         Some(pos) => &rest[pos + 1..],
@@ -155,7 +184,29 @@ fn split_host_path(rest: &str) -> Option<(String, String)> {
     if host.is_empty() || path.is_empty() {
         return None;
     }
-    Some((host.to_string(), path.to_string()))
+    let host = strip_port(host);
+    if host.is_empty() {
+        return None;
+    }
+    Some((host, path.to_string()))
+}
+
+/// Strip a trailing `:port` from a URL authority's host segment. Handles a
+/// bracketed IPv6 host (`[::1]:2222` -> `[::1]`, brackets kept -- brackets
+/// are what make an IPv6 literal unambiguous in a slug, since the address
+/// itself contains colons) as well as a plain hostname (`github.com:2222`
+/// -> `github.com`). A host with no port passes through unchanged.
+fn strip_port(host: &str) -> String {
+    if let Some(rest) = host.strip_prefix('[') {
+        if let Some(end) = rest.find(']') {
+            return format!("[{}]", &rest[..end]);
+        }
+        return host.to_string();
+    }
+    match host.split_once(':') {
+        Some((h, _port)) => h.to_string(),
+        None => host.to_string(),
+    }
 }
 
 /// Normalize ANY git remote URL spelling -- `https://`, `ssh://`, the
@@ -187,20 +238,18 @@ pub fn remote_url_to_slug(url: &str) -> Option<String> {
         split_host_path(rest)?
     } else if let Some(rest) = trimmed.strip_prefix("ssh://") {
         split_host_path(rest)?
-    } else if is_scp_shorthand(trimmed) {
-        let at = trimmed.find('@')?;
-        let (host, path) = trimmed[at + 1..].split_once(':')?;
-        if host.is_empty() || path.is_empty() {
-            return None;
-        }
+    } else if let Some((host, path)) = scp_parts(trimmed) {
         (host.to_string(), path.to_string())
     } else {
         return None;
     };
 
-    let mut segs = path.split('/').filter(|s| !s.is_empty());
+    let mut segs = path.split('/');
     let owner = segs.next()?;
     let repo = segs.next()?;
+    if owner.is_empty() || repo.is_empty() {
+        return None;
+    }
     Some(format!("{}/{owner}/{repo}", host.to_ascii_lowercase()))
 }
 
@@ -333,6 +382,12 @@ mod tests {
     }
 
     #[test]
+    fn bare_scp_shorthand_without_userinfo_rejected() {
+        let err = parse_source("github.com:org/repo.git").unwrap_err();
+        assert!(err.contains("SSH"), "{err}");
+    }
+
+    #[test]
     fn git_protocol_rejected() {
         let err = parse_source("git://github.com/org/repo.git").unwrap_err();
         assert!(err.contains("git://"), "{err}");
@@ -408,6 +463,12 @@ mod tests {
             "git@github.com:org/repo.git",
             "git@github.com:org/repo",
             "git://github.com/org/repo.git",
+            // Bare SCP shorthand -- the SCP user is optional.
+            "github.com:org/repo.git",
+            "github.com:org/repo",
+            // ssh:// with a port -- the port is not part of the identity.
+            "ssh://git@github.com:2222/org/repo.git",
+            "ssh://github.com:2222/org/repo",
             // Host case is folded; owner/repo case is preserved separately below.
             "https://GitHub.com/org/repo",
         ];
@@ -426,6 +487,35 @@ mod tests {
             remote_url_to_slug("https://github.com/Org/Repo").as_deref(),
             Some("github.com/Org/Repo")
         );
+    }
+
+    #[test]
+    fn remote_url_to_slug_bracketed_ipv6_host_with_port() {
+        assert_eq!(
+            remote_url_to_slug("ssh://git@[::1]:2222/org/repo").as_deref(),
+            Some("[::1]/org/repo")
+        );
+    }
+
+    #[test]
+    fn remote_url_to_slug_bracketed_ipv6_host_without_port() {
+        assert_eq!(
+            remote_url_to_slug("ssh://git@[::1]/org/repo").as_deref(),
+            Some("[::1]/org/repo")
+        );
+    }
+
+    #[test]
+    fn remote_url_to_slug_rejects_empty_owner_or_repo_segment() {
+        assert_eq!(remote_url_to_slug("https://github.com/org//repo"), None);
+        assert_eq!(remote_url_to_slug("https://github.com//repo"), None);
+        assert_eq!(remote_url_to_slug("git@github.com:/repo"), None);
+        assert_eq!(remote_url_to_slug("git@github.com:org/"), None);
+    }
+
+    #[test]
+    fn remote_url_to_slug_does_not_misparse_local_path_with_colon() {
+        assert_eq!(remote_url_to_slug("local/path:with-colon"), None);
     }
 
     #[test]

--- a/crates/khive-pack-git/src/source.rs
+++ b/crates/khive-pack-git/src/source.rs
@@ -1,8 +1,15 @@
 //! `git.digest` source resolution (ADR-088 Amendment 1): local paths vs.
 //! `https://` remote URLs, canonicalization, and `github.com` owner/repo
 //! slug derivation for `gh`-based issue/PR ingestion.
+//!
+//! Also owns repo-anchor identity derivation (issue #1173): a canonical
+//! `host/owner/repo` slug (or a path-derived fallback for a remote-less
+//! local repo) that the same repository resolves to regardless of which
+//! spelling — https URL, ssh/scp remote, local clone path — a given
+//! `git.digest` call used.
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
+use std::process::Command;
 
 /// A digest source, resolved from the `git.digest` verb's `source` argument.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -126,6 +133,130 @@ fn github_slug(canonical: &str) -> Option<(String, String)> {
     let owner = segs.next()?;
     let repo = segs.next()?;
     Some((owner.to_string(), repo.to_string()))
+}
+
+/// The repo-anchor identity property key (issue #1173) — the durable
+/// matching key for `resolve_or_create_project`. `repo_url` remains display
+/// metadata only; this is the one property that is matched on.
+pub const REPO_SLUG_PROPERTY: &str = "repo_slug";
+
+/// Split `host` from `path` out of a URL/remote body that has already had
+/// its scheme and any `user[:pass]@` userinfo prefix stripped -- e.g.
+/// `github.com/owner/repo` from `https://github.com/owner/repo`, or
+/// `github.com/owner/repo` from the `host/owner/repo` remainder of an
+/// `ssh://user@host/owner/repo` URL. `rfind('@')` (not the first `@`) drops
+/// userinfo because a password component can itself contain `@`.
+fn split_host_path(rest: &str) -> Option<(String, String)> {
+    let after_userinfo = match rest.rfind('@') {
+        Some(pos) => &rest[pos + 1..],
+        None => rest,
+    };
+    let (host, path) = after_userinfo.split_once('/')?;
+    if host.is_empty() || path.is_empty() {
+        return None;
+    }
+    Some((host.to_string(), path.to_string()))
+}
+
+/// Normalize ANY git remote URL spelling -- `https://`, `ssh://`, the
+/// `git://` protocol, or scp-like shorthand (`git@host:owner/repo.git`) --
+/// into a lowercase-host `host/owner/repo` slug (issue #1173). This is
+/// broader than `github_slug` (which only recognizes `github.com` and
+/// requires the caller to have already canonicalized an `https://` URL):
+/// this function accepts every spelling `git remote get-url origin` can
+/// hand back, because a local clone's configured origin is not restricted
+/// to the schemes `parse_source` accepts for the top-level `source`
+/// argument. Returns `None` when the remainder doesn't parse into a host
+/// plus at least two path segments (owner + repo).
+///
+/// The host is lowercased (DNS is case-insensitive); owner/repo segments
+/// are preserved verbatim -- case-folding those risks collapsing two
+/// genuinely distinct repos on a case-sensitive host.
+pub fn remote_url_to_slug(url: &str) -> Option<String> {
+    let trimmed = url.trim().trim_end_matches('/');
+    let trimmed = trimmed.strip_suffix(".git").unwrap_or(trimmed);
+    if trimmed.is_empty() {
+        return None;
+    }
+
+    let (host, path) = if let Some(rest) = trimmed
+        .strip_prefix("https://")
+        .or_else(|| trimmed.strip_prefix("http://"))
+        .or_else(|| trimmed.strip_prefix("git://"))
+    {
+        split_host_path(rest)?
+    } else if let Some(rest) = trimmed.strip_prefix("ssh://") {
+        split_host_path(rest)?
+    } else if is_scp_shorthand(trimmed) {
+        let at = trimmed.find('@')?;
+        let (host, path) = trimmed[at + 1..].split_once(':')?;
+        if host.is_empty() || path.is_empty() {
+            return None;
+        }
+        (host.to_string(), path.to_string())
+    } else {
+        return None;
+    };
+
+    let mut segs = path.split('/').filter(|s| !s.is_empty());
+    let owner = segs.next()?;
+    let repo = segs.next()?;
+    Some(format!("{}/{owner}/{repo}", host.to_ascii_lowercase()))
+}
+
+/// Read the local repo's configured `origin` remote URL via `git -C <path>
+/// remote get-url origin`. Returns `None` for any failure (no `origin`
+/// remote, `git` not on PATH, not a git repo) -- a local repo with no
+/// remote is a valid, expected state (see `repo_identity`), not an error.
+fn local_origin_remote_url(canonical_repo_path: &Path) -> Option<String> {
+    let out = Command::new("git")
+        .arg("-C")
+        .arg(canonical_repo_path)
+        .args(["remote", "get-url", "origin"])
+        .env("GIT_TERMINAL_PROMPT", "0")
+        .output()
+        .ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    let url = String::from_utf8_lossy(&out.stdout).trim().to_string();
+    if url.is_empty() {
+        None
+    } else {
+        Some(url)
+    }
+}
+
+/// Resolve the canonical repo-anchor identity (issue #1173) for a digest
+/// source -- the value stored in `properties.repo_slug` and matched on by
+/// `resolve_or_create_project`.
+///
+/// - `Remote`: the `host/owner/repo` slug of the canonical URL.
+/// - `Local`: the canonicalized path's configured `origin` remote, sluggified
+///   the same way -- so a repo digested once via `https://host/owner/repo`
+///   and once via a local clone of that same remote converge on one anchor.
+///   When the local repo has no `origin` remote (or `remote_url_to_slug`
+///   can't parse it), the identity falls back to a `local:<canonical path>`
+///   form -- clearly distinct from a `host/owner/repo` slug (no host name
+///   contains a `:`) so it can never collide with one, but scoped only to
+///   that exact path: two clones of the same remote-less repo at different
+///   paths do NOT converge (there is no remote to prove they're the same
+///   repository).
+pub fn repo_identity(source: &DigestSource) -> String {
+    match source {
+        DigestSource::Remote { canonical, .. } => {
+            remote_url_to_slug(canonical).unwrap_or_else(|| canonical.clone())
+        }
+        DigestSource::Local(path) => {
+            let canon = std::fs::canonicalize(path).unwrap_or_else(|_| path.clone());
+            if let Some(origin) = local_origin_remote_url(&canon) {
+                if let Some(slug) = remote_url_to_slug(&origin) {
+                    return slug;
+                }
+            }
+            format!("local:{}", canon.to_string_lossy())
+        }
+    }
 }
 
 /// Basename used as the default `project` entity name and as a fallback


### PR DESCRIPTION
Closes #1173.

Every spelling of the same repository — https URL, ssh/scp remote, git protocol, or a local clone path — now resolves to one canonical `host/owner/repo` anchor identity, stored in `properties.repo_slug` and matched on by `resolve_or_create_project`. Local paths derive the slug from their `origin` remote; a remote-less local repo falls back to a `local:<canonicalized-path>` identity. The old basename `name` fallback (which caused distinct repos with the same directory name to collapse onto one anchor) is removed.

Existing anchors need no migration: a legacy `repo_url` match still resolves and is backfilled with `repo_slug` on first contact.

When no live anchor matches but a soft-deleted anchor at the same identity still has a live annotates-linked corpus, ingestion no longer silently mints a fresh anchor next to the orphaned corpus — the condition is surfaced in the `IngestReport` (`orphaned_corpus_detected`, `orphaned_project_id`, `orphaned_note_count`). A hard-deleted anchor's identity is unrecoverable (the row is gone); documented as a known limitation.

Tests: slug-normalization table across all remote spellings, local/remote convergence regression, basename-collision non-capture, legacy match+backfill, orphan-not-silently-reminted — all through the real handler surface.

Gates: `cargo test -p khive-pack-git` (185+54), workspace clippy `-D warnings`, fmt check, doc build `-D warnings` — all clean.