### PR TITLE
docs(adr): ADR-088 Amendment 2 — canonical repo-anchor identity

### DIFF
--- a/docs/adr/ADR-088-amendment-1-git-digest.md
+++ b/docs/adr/ADR-088-amendment-1-git-digest.md
@@ -39,6 +39,10 @@ git.digest(source, project?, max_items?, include?)
   found it CREATES the anchor entity (`kind=project`, `name=<repo basename>`,
   `properties.repo_url=<canonical url>`), returning its id in the report. Auto-creation is
   reported, never silent.
+  > **Amended by [Amendment 2](ADR-088-amendment-2-anchor-identity.md)** (issue #1173):
+  > anchor resolution is now slug-first on `properties.repo_slug` with exact legacy
+  > `repo_url` fallback and backfill; the basename fallback is removed, and an
+  > orphaned-corpus signal is added to the report.
 - `max_items` (optional, int, default 500, clamp 1..2000) — bounded work per call, counted
   across commits + issues + PRs. The existing per-repo cursors (ADR-088 §5) make the verb
   resumable: each call ingests up to `max_items` and returns `done: false` with cursor

--- a/docs/adr/ADR-088-amendment-1-git-digest.md
+++ b/docs/adr/ADR-088-amendment-1-git-digest.md
@@ -40,9 +40,9 @@ git.digest(source, project?, max_items?, include?)
   `properties.repo_url=<canonical url>`), returning its id in the report. Auto-creation is
   reported, never silent.
   > **Amended by [Amendment 2](ADR-088-amendment-2-anchor-identity.md)** (issue #1173):
-  > anchor resolution is now slug-first on `properties.repo_slug` with exact legacy
-  > `repo_url` fallback and backfill; the basename fallback is removed, and an
-  > orphaned-corpus signal is added to the report.
+  > anchor resolution is now slug-first on `properties.repo_slug` with a legacy
+  > `repo_url` fallback (exact, then normalized) and backfill; the basename
+  > fallback is removed, and an orphaned-corpus signal is added to the report.
 - `max_items` (optional, int, default 500, clamp 1..2000) — bounded work per call, counted
   across commits + issues + PRs. The existing per-repo cursors (ADR-088 §5) make the verb
   resumable: each call ingests up to `max_items` and returns `done: false` with cursor

--- a/docs/adr/ADR-088-amendment-2-anchor-identity.md
+++ b/docs/adr/ADR-088-amendment-2-anchor-identity.md
@@ -1,0 +1,75 @@
+# ADR-088 Amendment 2: Canonical Repo-Anchor Identity for `git.digest`
+
+**Status**: Proposed
+**Date**: 2026-07-20
+**Amends**: ADR-088 Amendment 1 (anchor-resolution clause of the `project`
+parameter)
+**Tracking**: issue #1173
+
+## Context
+
+Amendment 1 specified that when `project` is absent, the handler matches an
+existing `project` entity by `properties.repo_url` **or by the name derived
+from the URL/path basename**. In practice this produced duplicate anchors:
+the same repository ingested once via its `https://` URL and once via a local
+clone path has two distinct `repo_url` spellings, so neither matches the
+other, and each spelling minted its own anchor with its own annotated corpus.
+Conversely, the basename fallback over-matched: two genuinely distinct
+repositories that happen to share a directory name collapsed onto one anchor.
+
+## Decision
+
+### Canonical identity
+
+Every digest source resolves to one canonical **repo slug** stored in
+`properties.repo_slug` on the anchor entity:
+
+- A remote URL in any spelling git accepts — `https://`, `http://`, `git://`,
+  `ssh://`, or scp-style shorthand — normalizes to `host/owner/repo`:
+  scheme, userinfo credentials, a port in the authority, a `.git` suffix, and
+  trailing slashes are stripped; the host is lowercased (DNS is
+  case-insensitive); owner and repo segments are preserved verbatim. Inputs
+  that do not yield a host plus at least owner and repo segments, or that
+  contain empty segments, do not normalize (they are not silently coerced).
+- A local path derives the same slug from its configured `origin` remote.
+- A local repository with no `origin` remote (or an origin that does not
+  normalize) uses the fallback identity `local:<canonicalized-path>`.
+
+`properties.repo_url` remains display metadata; it is never the matching key
+for new anchors.
+
+### Resolution order (replaces the Amendment 1 clause)
+
+1. Match a live `project` entity on `properties.repo_slug`.
+2. Otherwise match on legacy exact `properties.repo_url`; on a hit, backfill
+   `properties.repo_slug` onto the matched entity. Existing anchors therefore
+   need no migration.
+3. Otherwise create the anchor with both `repo_slug` and `repo_url` set.
+
+The basename `name` fallback is **removed**. No resolution path matches an
+anchor by name alone.
+
+### Orphaned-corpus signal
+
+When no live anchor matches but a soft-deleted anchor with the same identity
+still has at least one live `annotates`-linked git note, the handler does not
+silently mint a fresh anchor beside the orphaned corpus. It proceeds with
+creation but reports the condition in the `IngestReport` via three added
+fields:
+
+- `orphaned_corpus_detected: bool`
+- `orphaned_project_id` — the soft-deleted anchor holding the live corpus
+- `orphaned_note_count` — the count of its live annotating notes
+
+A soft-deleted anchor with zero live annotating notes is not an orphaned
+corpus and raises no signal. A hard-deleted anchor's identity is
+unrecoverable (the entity row, including `repo_slug`, is removed); this is a
+documented limitation, consistent with hard-delete cascade semantics.
+
+## Consequences
+
+- All spellings of one repository converge on one anchor and one corpus;
+  same-basename distinct repositories no longer collapse.
+- Legacy anchors upgrade lazily on first contact, with no migration step.
+- Deleting an anchor while its corpus remains live is surfaced to the caller
+  instead of silently duplicated around.

--- a/docs/adr/ADR-088-amendment-2-anchor-identity.md
+++ b/docs/adr/ADR-088-amendment-2-anchor-identity.md
@@ -68,8 +68,14 @@ entity properties.
    whose stored `repo_url` normalizes to the same slug also matches (this
    reconciles an anchor created from one spelling with a later ingest under
    another, e.g. a local-path anchor with a subsequent remote-URL digest).
-   On either hit, backfill `properties.repo_slug` onto the matched entity.
-   Existing anchors therefore need no migration.
+   Step-2 matches, exact or normalized, resolve multi-candidate cases by
+   the same rule as step 1: oldest `created_at` (id tie-break) selected
+   deterministically, with the remainder surfaced in the same report
+   warning — never an arbitrary or silent pick. On a hit, backfill
+   `properties.repo_slug` onto the matched entity, and redact its stored
+   `properties.repo_url` (userinfo, query, fragment) in the same patch —
+   the lazy-upgrade path also closes out any credential-bearing legacy URL
+   it touches. Existing anchors therefore need no migration.
 3. Otherwise create the anchor with both `repo_slug` and `repo_url` set.
 
 Anchor creation carries no uniqueness constraint, so two concurrent digests

--- a/docs/adr/ADR-088-amendment-2-anchor-identity.md
+++ b/docs/adr/ADR-088-amendment-2-anchor-identity.md
@@ -26,22 +26,34 @@ Every digest source resolves to one canonical **repo slug** stored in
 
 - A remote URL in any spelling git accepts — `https://`, `http://`, `git://`,
   `ssh://`, or scp-style shorthand — normalizes to `host/<path>`: scheme,
-  userinfo credentials, a port in the authority, a `.git` suffix, and
-  trailing slashes are stripped; the host is lowercased (DNS is
-  case-insensitive). **All** path segments are preserved in the slug — a
-  nested-group URL such as `host/group/subgroup/repo` keeps every segment,
-  so two repositories under one subgroup never collapse. Path segments are
-  preserved verbatim: case-folding them could merge genuinely distinct
-  repositories on a case-sensitive host, so casing variants of the same
-  path remain distinct slugs by design. Inputs that do not yield a host
-  plus at least two path segments, or that contain empty segments, do not
+  userinfo credentials, a port in the authority, query and fragment
+  components, a `.git` suffix, and trailing slashes are stripped; the host
+  is lowercased (DNS is case-insensitive) and a leading `www.` label is
+  folded (matching the existing github.com owner/repo derivation). This
+  broad grammar governs **origin-remote normalization only** — the identity
+  derived for a local path from its configured `origin`. The `git.digest`
+  `source` argument itself remains restricted to `https://` URLs and local
+  paths exactly as Amendment 1 specifies; no new transport is accepted.
+  **All** path segments are preserved in the slug — a nested-group URL such
+  as `host/group/subgroup/repo` keeps every segment, so two repositories
+  under one subgroup never collapse. Path segments are preserved verbatim:
+  case-folding them could merge genuinely distinct repositories on a
+  case-sensitive host, so casing variants of the same path remain distinct
+  slugs by design. Port stripping is likewise a deliberate trade: an
+  alternate-port ssh remote converges with its https spelling, at the cost
+  of aliasing genuinely distinct git servers on different ports of one
+  host — an accepted residual. Inputs that do not yield a host plus at
+  least two path segments, or that contain empty segments, do not
   normalize (they are not silently coerced).
 - A local path derives the same slug from its configured `origin` remote.
 - A local repository with no `origin` remote (or an origin that does not
   normalize) uses the fallback identity `local:<canonicalized-path>`.
 
 `properties.repo_url` remains display metadata; it is never the matching key
-for new anchors.
+for new anchors. The persisted `repo_url` is credential-redacted: userinfo,
+query, and fragment components of the caller-supplied URL are stripped before
+storage, so an access token embedded in a source URL is never written into
+entity properties.
 
 ### Resolution order (replaces the Amendment 1 clause)
 
@@ -51,10 +63,20 @@ for new anchors.
    separate ingests), the handler deterministically selects the oldest by
    `created_at` and surfaces the condition as a report warning naming the
    duplicate anchor ids; it never picks arbitrarily or silently.
-2. Otherwise match on legacy exact `properties.repo_url`; on a hit, backfill
-   `properties.repo_slug` onto the matched entity. Existing anchors therefore
-   need no migration.
+2. Otherwise match on legacy `properties.repo_url` — first by exact string
+   equality, then by normalization: a legacy anchor without `repo_slug`
+   whose stored `repo_url` normalizes to the same slug also matches (this
+   reconciles an anchor created from one spelling with a later ingest under
+   another, e.g. a local-path anchor with a subsequent remote-URL digest).
+   On either hit, backfill `properties.repo_slug` onto the matched entity.
+   Existing anchors therefore need no migration.
 3. Otherwise create the anchor with both `repo_slug` and `repo_url` set.
+
+Anchor creation carries no uniqueness constraint, so two concurrent digests
+of a previously unseen repository can race and each create an anchor. This
+is an accepted residual: the step-1 multi-match rule is the deterministic
+recovery path — every subsequent ingest selects the oldest anchor and
+surfaces the duplicates as a report warning for curation (`merge`).
 
 The basename `name` fallback is **removed**. No resolution path matches an
 anchor by name alone.
@@ -67,9 +89,17 @@ silently mint a fresh anchor beside the orphaned corpus. It proceeds with
 creation but reports the condition in the `IngestReport` via three added
 fields:
 
-- `orphaned_corpus_detected: bool`
-- `orphaned_project_id` — the soft-deleted anchor holding the live corpus
-- `orphaned_note_count` — the count of its live annotating notes
+- `orphaned_corpus_detected: bool` (`false` when no orphan exists)
+- `orphaned_project_id: string | null` — UUID of the soft-deleted anchor
+  holding the live corpus; `null` when no orphan exists
+- `orphaned_note_count: u64` — the count of its live annotating notes; `0`
+  when no orphan exists
+
+These fields disclose the id of a soft-deleted record to the caller. That is
+consistent with the substrate's authorization model: namespace is
+attribution, not isolation (ADR-007 Rev 6), read authorization is the Gate's
+concern (ADR-018), and soft-deleted state is a view-layer distinction — the
+report surfaces it precisely so the caller can act on it deliberately.
 
 A soft-deleted anchor with zero live annotating notes is not an orphaned
 corpus and raises no signal. A hard-deleted anchor's identity is

--- a/docs/adr/ADR-088-amendment-2-anchor-identity.md
+++ b/docs/adr/ADR-088-amendment-2-anchor-identity.md
@@ -25,12 +25,17 @@ Every digest source resolves to one canonical **repo slug** stored in
 `properties.repo_slug` on the anchor entity:
 
 - A remote URL in any spelling git accepts — `https://`, `http://`, `git://`,
-  `ssh://`, or scp-style shorthand — normalizes to `host/owner/repo`:
-  scheme, userinfo credentials, a port in the authority, a `.git` suffix, and
+  `ssh://`, or scp-style shorthand — normalizes to `host/<path>`: scheme,
+  userinfo credentials, a port in the authority, a `.git` suffix, and
   trailing slashes are stripped; the host is lowercased (DNS is
-  case-insensitive); owner and repo segments are preserved verbatim. Inputs
-  that do not yield a host plus at least owner and repo segments, or that
-  contain empty segments, do not normalize (they are not silently coerced).
+  case-insensitive). **All** path segments are preserved in the slug — a
+  nested-group URL such as `host/group/subgroup/repo` keeps every segment,
+  so two repositories under one subgroup never collapse. Path segments are
+  preserved verbatim: case-folding them could merge genuinely distinct
+  repositories on a case-sensitive host, so casing variants of the same
+  path remain distinct slugs by design. Inputs that do not yield a host
+  plus at least two path segments, or that contain empty segments, do not
+  normalize (they are not silently coerced).
 - A local path derives the same slug from its configured `origin` remote.
 - A local repository with no `origin` remote (or an origin that does not
   normalize) uses the fallback identity `local:<canonicalized-path>`.
@@ -40,7 +45,12 @@ for new anchors.
 
 ### Resolution order (replaces the Amendment 1 clause)
 
-1. Match a live `project` entity on `properties.repo_slug`.
+1. Match a live `project` entity on `properties.repo_slug`. If more than one
+   live entity carries the slug (possible when two legacy anchors holding
+   different URL spellings of the same repository were each backfilled on
+   separate ingests), the handler deterministically selects the oldest by
+   `created_at` and surfaces the condition as a report warning naming the
+   duplicate anchor ids; it never picks arbitrarily or silently.
 2. Otherwise match on legacy exact `properties.repo_url`; on a hit, backfill
    `properties.repo_slug` onto the matched entity. Existing anchors therefore
    need no migration.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -70,75 +70,76 @@ For historical context, see [v0 archive](../_archive/adr_v0/README.md). v0 ADRs 
 
 ## New v1 Surfaces
 
-| #                                                            | Title                                                                                                 |
-| ------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------- |
-| [ADR-040](ADR-040-communication-and-schedule-packs.md)       | Communication and Schedule Packs                                                                      |
-| [ADR-041](ADR-041-event-provenance-projection.md)            | Event Provenance Projection — Hybrid Log + Graph Edges                                                |
-| [ADR-042](ADR-042-local-rerank-via-lattice-inference.md)     | Composable Rerank Pipeline (local cross-encoder + salience + graph-proximity)                         |
-| [ADR-043](ADR-043-embedding-model-migration.md)              | Embedding Model Migration                                                                             |
-| [ADR-044](ADR-044-vector-store-extensions.md)                | Vector Store Extensions — Capabilities, Metadata Filter, Batched Search, Update, Orphan Sweep         |
-| [ADR-045](ADR-045-verb-response-presentation.md)             | Verb Response Presentation Modes                                                                      |
-| [ADR-046](ADR-046-event-sourced-proposals.md)                | Event-Sourced Agent KG Proposals                                                                      |
-| [ADR-047](ADR-047-knowledge-pack.md)                         | Knowledge Pack                                                                                        |
-| [ADR-048](ADR-048-knowledge-section-profiles.md)             | Knowledge Section Profiles                                                                            |
-| [ADR-049](ADR-049-khived-daemon.md)                          | khived daemon — persistent warm runtime over a Unix socket                                            |
-| [ADR-050](ADR-050-kg-token-namespace-contract.md)            | KG Token Namespace Contract                                                                           |
-| [ADR-051](ADR-051-section-embeddings-hybrid-compose.md)      | Section-level embeddings and hybrid compose scoring                                                   |
-| [ADR-052](ADR-052-ann-production-lifecycle.md)               | ANN Production Lifecycle -- SQ8 Quantization, Tombstone Delete, Consolidation, Crash-Safe Persistence |
-| [ADR-053](ADR-053-authorization-gate.md)                     | Authorization Gate -- ActorStore, SessionStore, and Caller Propagation                                |
-| [ADR-054](ADR-054-ann-build-strategy-scaling-limits.md)      | ANN Build Strategy and Scaling Limits                                                                 |
-| [ADR-055](ADR-055-epistemic-edge-relations.md)               | Epistemic Edge Relations — `supports` and `refutes`                                                   |
-| [ADR-056](ADR-056-channel-transport-layer.md)                | Channel Transport Layer -- `khive-channel` and External Messaging Adapters                            |
-| [ADR-057](ADR-057-comm-actor-addressed-delivery.md)          | Comm Actor-Addressed Delivery                                                                         |
-| [ADR-058](ADR-058-brain-posterior-read-path.md)              | Brain Posterior Read Path — Wiring Profile Posteriors into Recall Ranking                             |
-| [ADR-059](ADR-059-namespace-write-tiers.md)                  | Namespace Write Tiers and Cross-Namespace Link Access Control                                         |
-| [ADR-061](ADR-061-pack-extensible-by-id-resolution.md)       | Pack-Extensible by-ID Resolution                                                                      |
-| [ADR-062](ADR-062-fts-ann-consolidation.md)                  | FTS and ANN Consolidation -- Unified Search Tables (Schema V4)                                        |
-| [ADR-066](ADR-066-autonomous-merge-pipeline.md)              | Autonomous Merge Pipeline — Gate Wall as Reviewer                                                     |
-| [ADR-067](ADR-067-write-owner-daemon.md)                     | Write-Owner Daemon — Single-Writer Task and Write Queue                                               |
-| [ADR-068](ADR-068-process-isolation-topology.md)             | Per-Process Isolation Topology                                                                        |
-| [ADR-069](ADR-069-subject-model.md)                          | The Subject Model -- Domain-Ontology Ingestion and Map Pipeline                                       |
-| [ADR-071](ADR-071-backend-pluggable-runtime.md)              | Backend-Pluggable Runtime — Polystore Restoration                                                     |
-| [ADR-072](ADR-072-subject-ontologyspec-as-data.md)           | Subject OntologySpec as Runtime Data -- Verbless Verticals and Pack Retirement                        |
-| [ADR-073](ADR-073-pack-core-backend-accessor.md)             | Pack Core-Backend Accessor                                                                            |
-| [ADR-074](ADR-074-graph-aware-recall.md)                     | Graph-Aware Recall — Graph-Proximity Signal in Memory Retrieval                                       |
-| [ADR-075](ADR-075-owl-rdf-interoperability.md)               | OWL/RDF Interoperability -- Publishing the khive Vocabulary and Aligning with External Ontologies     |
-| [ADR-076](ADR-076-relation-calculability-and-system-role.md) | Relation-Set Calculability — System Role and the Non-Redundancy Certificate                           |
-| [ADR-078](ADR-078-output-format-shape-aware-rendering.md)    | Output Format and Shape-Aware Rendering                                                               |
-| [ADR-079](ADR-079-ann-persistence-warm-path-integration.md)  | ANN Persistence Warm-Path Integration — Wiring v2 Persistence into the Daemon                         |
-| [ADR-080](ADR-080-session-pack-oss-storage-mechanism.md)     | Session Pack — OSS Storage Mechanism                                                                  |
-| [ADR-082](ADR-082-retrieval-quality-measurement-loop.md)     | Retrieval Quality Measurement Loop                                                                    |
-| [ADR-083](ADR-083-session-pack-t1-verbs.md)                  | Session Pack T1 Verb Surface                                                                          |
-| [ADR-084](ADR-084-verb-surface-consistency.md)               | Verb-Surface Consistency Contract and Live Ontology Introspection                                     |
-| [ADR-085](ADR-085-code-pack.md)                              | Code Pack — Source-Code Ontology and Audit-Finding Vocabulary                                         |
-| [ADR-086](ADR-086-doc-file-pack.md)                          | Document/File Modeling — Content on the Existing `document` Entity Kind                               |
-| [ADR-087](ADR-087-workspace-mirror.md)                       | Workspace Mirror — Folding `.khive/` Into the Graph Substrate                                         |
-| [ADR-088](ADR-088-git-lifecycle-pack.md)                     | Git-Lifecycle Pack — Commit and Issue Note Kinds                                                      |
-| [ADR-088 Amendment 1](ADR-088-amendment-1-git-digest.md)     | `git.digest` — Agent-Facing Digest Verb with Remote-URL Support (Accepted)                            |
-| [ADR-089](ADR-089-context-verb.md)                           | `context` verb — entity-anchored graph context in one call                                            |
-| [ADR-090](ADR-090-docs-site-standard.md)                     | Docs site standard — navigation, agent md/txt surfaces, visual style                                  |
-| [ADR-091](ADR-091-wal-snapshot-lifetime.md)                  | Bounded read-transaction lifetime and WAL checkpoint escalation                                       |
-| [ADR-092](ADR-092-context-composer.md)                       | Cross-substrate context composer — ContextContributor trait + `context.assemble`                      |
-| [ADR-093](ADR-093-sessions-raw-zstd-compression.md)          | zstd Compression for Session-Mirror Raw Storage                                                       |
-| [ADR-094](ADR-094-lifecycle-telemetry-events.md)             | Sequencing-Assertable Lifecycle Telemetry Events                                                      |
-| [ADR-095](ADR-095-verb-surface-consolidation.md)             | Verb-Surface Consolidation and Field-Validation Governance                                            |
-| [ADR-096](ADR-096-warm-daemon-per-request-identity.md)       | warm daemon per-request identity — serving many attribution identities over one shared backend        |
-| [ADR-099](ADR-099-bulk-apply-atomic-units.md)                | Cross-Op Atomicity for Bulk Apply — Prepared Write Plans over the Single-Writer Seam                  |
-| [ADR-100](ADR-100-store-backup-replication.md)               | Store backup and replication                                                                          |
-| [ADR-101](ADR-101-kg-changeset-model.md)                     | KG Change-Set Model — Producer-Agnostic Op-List with Stage-Time Stable IDs                            |
-| [ADR-102](ADR-102-tiered-validate-and-merge.md)              | Tiered Validate-and-Merge — Rule-Gated Fast Path and Reviewed Change-Set Path                         |
-| [ADR-106](ADR-106-schedule-pack-executor.md)                 | Schedule Pack Executor — Daemon-Resident Tick for the Pending-Event Drain                             |
-| [ADR-108](ADR-108-git-write-surface.md)                      | Git Write Surface Through khive (Phase B)                                                             |
-| [ADR-109](ADR-109-sandboxed-kkernel-gateway.md)              | Sandboxed kkernel Gateway for Untrusted Execution (Phase C)                                           |
-| [ADR-110](ADR-110-vamana-wasm.md)                            | WebAssembly Support for khive-vamana                                                                  |
-| [ADR-111](ADR-111-blob-store.md)                             | BlobStore — Content-Addressed Binary Object Storage                                                   |
-| [ADR-112](ADR-112-git-outbound-publish-verbs.md)             | Outbound GitHub Publish Verbs with a Publication-Hygiene Scan                                         |
-| [ADR-113](ADR-113-identifier-continuity.md)                  | Identifier Continuity — Merged-Entity Redirect Resolution and Split Endpoint-Move                     |
-| [ADR-114](ADR-114-code-audit-derived-report.md)              | Code-Audit Derived Report, Not Agent Findings                                                         |
-| [ADR-115](ADR-115-secret-gate-content-manifest-exemption.md) | Exact-Content Manifest Exemption for the Write Secret Gate                                            |
-| [ADR-117](ADR-117-session-continuity-search.md)              | Session Continuity — Cross-Session Search and Remote Ingestion                                        |
-| [ADR-118](ADR-118-fresh-tail-recall-visibility.md)           | Fresh-Tail Exact Leg — Read-Your-Writes Visibility for Vector Recall                                  |
-| [ADR-119](ADR-119-daemon-component-supervision.md)           | Host-Supervised Daemon Components Beside the Verb Plane                                               |
+| #                                                             | Title                                                                                                 |
+| ------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------- |
+| [ADR-040](ADR-040-communication-and-schedule-packs.md)        | Communication and Schedule Packs                                                                      |
+| [ADR-041](ADR-041-event-provenance-projection.md)             | Event Provenance Projection — Hybrid Log + Graph Edges                                                |
+| [ADR-042](ADR-042-local-rerank-via-lattice-inference.md)      | Composable Rerank Pipeline (local cross-encoder + salience + graph-proximity)                         |
+| [ADR-043](ADR-043-embedding-model-migration.md)               | Embedding Model Migration                                                                             |
+| [ADR-044](ADR-044-vector-store-extensions.md)                 | Vector Store Extensions — Capabilities, Metadata Filter, Batched Search, Update, Orphan Sweep         |
+| [ADR-045](ADR-045-verb-response-presentation.md)              | Verb Response Presentation Modes                                                                      |
+| [ADR-046](ADR-046-event-sourced-proposals.md)                 | Event-Sourced Agent KG Proposals                                                                      |
+| [ADR-047](ADR-047-knowledge-pack.md)                          | Knowledge Pack                                                                                        |
+| [ADR-048](ADR-048-knowledge-section-profiles.md)              | Knowledge Section Profiles                                                                            |
+| [ADR-049](ADR-049-khived-daemon.md)                           | khived daemon — persistent warm runtime over a Unix socket                                            |
+| [ADR-050](ADR-050-kg-token-namespace-contract.md)             | KG Token Namespace Contract                                                                           |
+| [ADR-051](ADR-051-section-embeddings-hybrid-compose.md)       | Section-level embeddings and hybrid compose scoring                                                   |
+| [ADR-052](ADR-052-ann-production-lifecycle.md)                | ANN Production Lifecycle -- SQ8 Quantization, Tombstone Delete, Consolidation, Crash-Safe Persistence |
+| [ADR-053](ADR-053-authorization-gate.md)                      | Authorization Gate -- ActorStore, SessionStore, and Caller Propagation                                |
+| [ADR-054](ADR-054-ann-build-strategy-scaling-limits.md)       | ANN Build Strategy and Scaling Limits                                                                 |
+| [ADR-055](ADR-055-epistemic-edge-relations.md)                | Epistemic Edge Relations — `supports` and `refutes`                                                   |
+| [ADR-056](ADR-056-channel-transport-layer.md)                 | Channel Transport Layer -- `khive-channel` and External Messaging Adapters                            |
+| [ADR-057](ADR-057-comm-actor-addressed-delivery.md)           | Comm Actor-Addressed Delivery                                                                         |
+| [ADR-058](ADR-058-brain-posterior-read-path.md)               | Brain Posterior Read Path — Wiring Profile Posteriors into Recall Ranking                             |
+| [ADR-059](ADR-059-namespace-write-tiers.md)                   | Namespace Write Tiers and Cross-Namespace Link Access Control                                         |
+| [ADR-061](ADR-061-pack-extensible-by-id-resolution.md)        | Pack-Extensible by-ID Resolution                                                                      |
+| [ADR-062](ADR-062-fts-ann-consolidation.md)                   | FTS and ANN Consolidation -- Unified Search Tables (Schema V4)                                        |
+| [ADR-066](ADR-066-autonomous-merge-pipeline.md)               | Autonomous Merge Pipeline — Gate Wall as Reviewer                                                     |
+| [ADR-067](ADR-067-write-owner-daemon.md)                      | Write-Owner Daemon — Single-Writer Task and Write Queue                                               |
+| [ADR-068](ADR-068-process-isolation-topology.md)              | Per-Process Isolation Topology                                                                        |
+| [ADR-069](ADR-069-subject-model.md)                           | The Subject Model -- Domain-Ontology Ingestion and Map Pipeline                                       |
+| [ADR-071](ADR-071-backend-pluggable-runtime.md)               | Backend-Pluggable Runtime — Polystore Restoration                                                     |
+| [ADR-072](ADR-072-subject-ontologyspec-as-data.md)            | Subject OntologySpec as Runtime Data -- Verbless Verticals and Pack Retirement                        |
+| [ADR-073](ADR-073-pack-core-backend-accessor.md)              | Pack Core-Backend Accessor                                                                            |
+| [ADR-074](ADR-074-graph-aware-recall.md)                      | Graph-Aware Recall — Graph-Proximity Signal in Memory Retrieval                                       |
+| [ADR-075](ADR-075-owl-rdf-interoperability.md)                | OWL/RDF Interoperability -- Publishing the khive Vocabulary and Aligning with External Ontologies     |
+| [ADR-076](ADR-076-relation-calculability-and-system-role.md)  | Relation-Set Calculability — System Role and the Non-Redundancy Certificate                           |
+| [ADR-078](ADR-078-output-format-shape-aware-rendering.md)     | Output Format and Shape-Aware Rendering                                                               |
+| [ADR-079](ADR-079-ann-persistence-warm-path-integration.md)   | ANN Persistence Warm-Path Integration — Wiring v2 Persistence into the Daemon                         |
+| [ADR-080](ADR-080-session-pack-oss-storage-mechanism.md)      | Session Pack — OSS Storage Mechanism                                                                  |
+| [ADR-082](ADR-082-retrieval-quality-measurement-loop.md)      | Retrieval Quality Measurement Loop                                                                    |
+| [ADR-083](ADR-083-session-pack-t1-verbs.md)                   | Session Pack T1 Verb Surface                                                                          |
+| [ADR-084](ADR-084-verb-surface-consistency.md)                | Verb-Surface Consistency Contract and Live Ontology Introspection                                     |
+| [ADR-085](ADR-085-code-pack.md)                               | Code Pack — Source-Code Ontology and Audit-Finding Vocabulary                                         |
+| [ADR-086](ADR-086-doc-file-pack.md)                           | Document/File Modeling — Content on the Existing `document` Entity Kind                               |
+| [ADR-087](ADR-087-workspace-mirror.md)                        | Workspace Mirror — Folding `.khive/` Into the Graph Substrate                                         |
+| [ADR-088](ADR-088-git-lifecycle-pack.md)                      | Git-Lifecycle Pack — Commit and Issue Note Kinds                                                      |
+| [ADR-088 Amendment 1](ADR-088-amendment-1-git-digest.md)      | `git.digest` — Agent-Facing Digest Verb with Remote-URL Support (Accepted)                            |
+| [ADR-088 Amendment 2](ADR-088-amendment-2-anchor-identity.md) | `git.digest` — Canonical Repo-Anchor Identity, Slug-First Resolution, Orphan Signal (Proposed)        |
+| [ADR-089](ADR-089-context-verb.md)                            | `context` verb — entity-anchored graph context in one call                                            |
+| [ADR-090](ADR-090-docs-site-standard.md)                      | Docs site standard — navigation, agent md/txt surfaces, visual style                                  |
+| [ADR-091](ADR-091-wal-snapshot-lifetime.md)                   | Bounded read-transaction lifetime and WAL checkpoint escalation                                       |
+| [ADR-092](ADR-092-context-composer.md)                        | Cross-substrate context composer — ContextContributor trait + `context.assemble`                      |
+| [ADR-093](ADR-093-sessions-raw-zstd-compression.md)           | zstd Compression for Session-Mirror Raw Storage                                                       |
+| [ADR-094](ADR-094-lifecycle-telemetry-events.md)              | Sequencing-Assertable Lifecycle Telemetry Events                                                      |
+| [ADR-095](ADR-095-verb-surface-consolidation.md)              | Verb-Surface Consolidation and Field-Validation Governance                                            |
+| [ADR-096](ADR-096-warm-daemon-per-request-identity.md)        | warm daemon per-request identity — serving many attribution identities over one shared backend        |
+| [ADR-099](ADR-099-bulk-apply-atomic-units.md)                 | Cross-Op Atomicity for Bulk Apply — Prepared Write Plans over the Single-Writer Seam                  |
+| [ADR-100](ADR-100-store-backup-replication.md)                | Store backup and replication                                                                          |
+| [ADR-101](ADR-101-kg-changeset-model.md)                      | KG Change-Set Model — Producer-Agnostic Op-List with Stage-Time Stable IDs                            |
+| [ADR-102](ADR-102-tiered-validate-and-merge.md)               | Tiered Validate-and-Merge — Rule-Gated Fast Path and Reviewed Change-Set Path                         |
+| [ADR-106](ADR-106-schedule-pack-executor.md)                  | Schedule Pack Executor — Daemon-Resident Tick for the Pending-Event Drain                             |
+| [ADR-108](ADR-108-git-write-surface.md)                       | Git Write Surface Through khive (Phase B)                                                             |
+| [ADR-109](ADR-109-sandboxed-kkernel-gateway.md)               | Sandboxed kkernel Gateway for Untrusted Execution (Phase C)                                           |
+| [ADR-110](ADR-110-vamana-wasm.md)                             | WebAssembly Support for khive-vamana                                                                  |
+| [ADR-111](ADR-111-blob-store.md)                              | BlobStore — Content-Addressed Binary Object Storage                                                   |
+| [ADR-112](ADR-112-git-outbound-publish-verbs.md)              | Outbound GitHub Publish Verbs with a Publication-Hygiene Scan                                         |
+| [ADR-113](ADR-113-identifier-continuity.md)                   | Identifier Continuity — Merged-Entity Redirect Resolution and Split Endpoint-Move                     |
+| [ADR-114](ADR-114-code-audit-derived-report.md)               | Code-Audit Derived Report, Not Agent Findings                                                         |
+| [ADR-115](ADR-115-secret-gate-content-manifest-exemption.md)  | Exact-Content Manifest Exemption for the Write Secret Gate                                            |
+| [ADR-117](ADR-117-session-continuity-search.md)               | Session Continuity — Cross-Session Search and Remote Ingestion                                        |
+| [ADR-118](ADR-118-fresh-tail-recall-visibility.md)            | Fresh-Tail Exact Leg — Read-Your-Writes Visibility for Vector Recall                                  |
+| [ADR-119](ADR-119-daemon-component-supervision.md)            | Host-Supervised Daemon Components Beside the Verb Plane                                               |
 
 ## Closed Taxonomies — Quick Reference
 


### PR DESCRIPTION
Specifies the anchor-resolution contract that #1185 (issue #1173) implements: canonical `host/owner/repo` slug identity in `properties.repo_slug`, slug-first resolution with exact legacy `repo_url` fallback and backfill, removal of the basename name fallback, the `local:<canonicalized-path>` identity for remote-less local repos, and the orphaned-corpus report fields. Adds a pointer note to the amended clause in Amendment 1 and an index row.

Merge order: this amendment merges before #1185 so the implementation lands against an accepted contract.