### PR TITLE
docs(adr): ADR-091 ancestry trust-boundary clarification

### DIFF
--- a/docs/adr/ADR-091-wal-snapshot-lifetime.md
+++ b/docs/adr/ADR-091-wal-snapshot-lifetime.md
@@ -810,6 +810,13 @@ question (Inventory item 4) remains unverified precisely there.
   `renameat` / `unlinkat` semantics) — the path is never re-resolved per
   operation, and parent components must resolve without traversing a symlink
   at open time.
+
+  _Amendment (clarification of existing intent, 2026-07-20)._ Ancestor path
+  components above the database file's containing directory are trusted
+  platform layout: an adversary able to substitute or redirect that ancestry
+  already controls the database path itself, so sidecar hardening binds
+  identity from the database's containing directory downward and makes no
+  guarantee against hostile mutation of higher components.
 - **Plank C: pin-depth probe via `PRAGMA wal_checkpoint(PASSIVE)` return
   columns.** On a TRUNCATE no-progress event, additionally run
   `PRAGMA wal_checkpoint(PASSIVE)` and report pin depth as `log` minus


### PR DESCRIPTION
One-sentence stamped amendment to the ADR-091 sidecar filesystem
trust-boundary ruling, marked as a clarification of existing intent:
ancestor path components above the database file's containing directory are
trusted platform layout — an adversary able to substitute or redirect that
ancestry already controls the database path itself, so sidecar hardening
binds identity from the database's containing directory downward and makes
no guarantee against hostile mutation of higher components.

Docs-only. Anchors the residual-risk disposition for the #1180 walpin
ancestor-binding work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)