### PR TITLE
docs(adr): amend ADR-023 for the reduced open-source pack surface

### DIFF
--- a/docs/adr/ADR-023-declarative-pack-format.md
+++ b/docs/adr/ADR-023-declarative-pack-format.md
@@ -672,8 +672,14 @@ at link time; there is no plugin-loading step at runtime. A distribution that
 wishes to compose additional packs — including the ones described above — does
 so by adding their crates as build dependencies and force-linking them the same
 way every pack in this repository is force-linked today (§9); the open-source
-repository itself carries no feature flags, optional dependencies, or
-configuration referencing packs it does not ship.
+repository itself carries no feature flags or optional dependencies referencing
+packs it does not ship. Runtime configuration sections that an extension pack
+consumes are the one deliberate exception: the `[git_write]` allowlist plumbing
+is retained (ADR-108 amendment of the same date) so a deployment that loads the
+extension gets the documented fail-closed behavior without further changes, and
+the section is inert — parsed but consumed by nothing — in a build where the
+pack is not loaded. Retained inert configuration of this shape is permitted;
+feature flags and optional crate dependencies on unshipped packs are not.
 
 ### Scope of this amendment
 

--- a/docs/adr/ADR-023-declarative-pack-format.md
+++ b/docs/adr/ADR-023-declarative-pack-format.md
@@ -584,7 +584,9 @@ refactor that unifies `gtd.assign` onto the shared create-plus-`TaskHook` path.
 
 ## Amendment: reduced open-source pack surface (2026-07-20)
 
-As of 2026-07-20, the open-source distribution's default pack set is reduced. The
+Effective with the accompanying crate-extraction changes (which land as
+separate pull requests; this amendment describes the surface they produce
+together), the open-source distribution's default pack set is reduced. The
 brain, knowledge, and code packs move to commercially licensed extensions
 maintained outside this repository; they are not part of the open-source
 distribution. The formal pack, which was never part of the open-source default
@@ -592,6 +594,13 @@ pack set (see below), moves alongside the code pack as part of the same
 crate departure. A small set of channel-transport crates supporting alternate
 message delivery also move out of this repository; they contribute no MCP
 verbs and are unrelated to the pack-verb surface this ADR governs.
+
+Interface crates remain. `khive-brain-core` — and, in general, any interface
+crate that a shipped pack depends on — stays in this repository:
+`khive-pack-memory` has a hard dependency on `khive-brain-core` for the
+ranking types and the degradation behavior described below. Removing a pack
+crate never removes the interface crates the remaining open-source packs
+consume.
 
 ### Default pack set, before and after
 
@@ -619,13 +628,20 @@ Following this change, the open-source build no longer registers `brain.*` or
 `knowledge.*` verbs, nor the `code.ingest` verb. The kg substrate verbs (§4)
 and the `memory.*` verbs are unaffected and continue to operate as documented.
 
-Serving-profile resolution inside `memory.recall` (and `memory.feedback`)
-degrades gracefully in the absence of a registered brain pack: profile
-resolution dispatches an internal `brain.resolve` call and treats a failed
-dispatch (no such verb registered) the same as a resolvable-but-unmatched
-profile, returning no serving profile. Recall and feedback continue to operate
-on their plain-scoring path; the profile-weighted ranking terms described
-elsewhere in this document simply do not apply when no brain pack is loaded.
+Serving-profile resolution inside `memory.recall` degrades gracefully in the
+absence of a registered brain pack: profile resolution dispatches an internal
+`brain.resolve` call and treats a failed dispatch (no such verb registered)
+the same as a resolvable-but-unmatched profile, returning no serving profile.
+Recall operates on its plain-scoring path; the profile-weighted ranking terms
+described elsewhere in this document simply do not apply when no brain pack
+is loaded.
+
+`memory.feedback` is not fully symmetric: when its configuration routes
+feedback through a brain profile, the handler dispatches `brain.feedback`,
+and with no brain pack registered that dispatch fails and the error
+propagates to the caller. Deployments of the open-source build should not
+configure brain-profile feedback routing; the plain feedback path operates
+unchanged.
 
 ### Composition after the carve
 

--- a/docs/adr/ADR-023-declarative-pack-format.md
+++ b/docs/adr/ADR-023-declarative-pack-format.md
@@ -591,7 +591,13 @@ brain, knowledge, code, and git packs move to commercially licensed
 extensions maintained outside this repository; they are not part of the
 open-source distribution. The git pack's departure takes its note kinds
 (`commit`, `issue`, `pull_request`), its ingestion surface, and its verbs
-with it. The formal pack, which was never part of the open-source default
+with it. The workspace pack's declared pack dependency is accordingly
+relaxed from `kg, git, gtd, session` to `kg, gtd, session`: its membership
+rules targeting the git note kinds stay declared but are inert when no pack
+registers those kinds (edge endpoint rules are installed without
+kind-existence validation and can only ever match kinds a loaded pack
+provides), so the reduced default boots and workspace containment continues
+to serve task and session records. The formal pack, which was never part of the open-source default
 pack set (see below), moves alongside the code pack as part of the same
 crate departure. A small set of channel-transport crates supporting alternate
 message delivery also move out of this repository; they contribute no MCP

--- a/docs/adr/ADR-023-declarative-pack-format.md
+++ b/docs/adr/ADR-023-declarative-pack-format.md
@@ -587,9 +587,11 @@ refactor that unifies `gtd.assign` onto the shared create-plus-`TaskHook` path.
 Effective with the accompanying crate-extraction changes (which land as
 separate pull requests; this amendment describes the surface they produce
 together), the open-source distribution's default pack set is reduced. The
-brain, knowledge, and code packs move to commercially licensed extensions
-maintained outside this repository; they are not part of the open-source
-distribution. The formal pack, which was never part of the open-source default
+brain, knowledge, code, and git packs move to commercially licensed
+extensions maintained outside this repository; they are not part of the
+open-source distribution. The git pack's departure takes its note kinds
+(`commit`, `issue`, `pull_request`), its ingestion surface, and its verbs
+with it. The formal pack, which was never part of the open-source default
 pack set (see below), moves alongside the code pack as part of the same
 crate departure. A small set of channel-transport crates supporting alternate
 message delivery also move out of this repository; they contribute no MCP
@@ -614,7 +616,7 @@ kg, gtd, memory, brain, comm, schedule, knowledge, session, git, code, workspace
 and is, after this change:
 
 ```
-kg, gtd, memory, comm, schedule, session, git, workspace, blob
+kg, gtd, memory, comm, schedule, session, workspace, blob
 ```
 
 The formal pack was never included in this default set. It was compiled into
@@ -624,17 +626,30 @@ crates ship in this repository, not the default verb surface.
 
 ### Consequence for the agent-facing verb surface
 
-Following this change, the open-source build no longer registers `brain.*` or
-`knowledge.*` verbs, nor the `code.ingest` verb. The kg substrate verbs (§4)
-and the `memory.*` verbs are unaffected and continue to operate as documented.
+Following this change, the open-source build no longer registers `brain.*`,
+`knowledge.*`, or `git.*` verbs, nor the `code.ingest` verb. The kg substrate
+verbs (§4) and the `memory.*` verbs are unaffected and continue to operate as
+documented.
 
 Serving-profile resolution inside `memory.recall` degrades gracefully in the
-absence of a registered brain pack: profile resolution dispatches an internal
-`brain.resolve` call and treats a failed dispatch (no such verb registered)
-the same as a resolvable-but-unmatched profile, returning no serving profile.
-Recall operates on its plain-scoring path; the profile-weighted ranking terms
+absence of a registered brain pack **only when no profile is configured**:
+profile resolution dispatches an internal `brain.resolve` call and treats a
+failed dispatch (no such verb registered) the same as a
+resolvable-but-unmatched profile, returning no serving profile. Recall
+operates on its plain-scoring path; the profile-weighted ranking terms
 described elsewhere in this document simply do not apply when no brain pack
 is loaded.
+
+That graceful path does not extend to configured or requested profiles. A
+memory-pack configuration that names a brain profile bypasses `brain.resolve`
+entirely: the configured profile id survives a failed `brain.profile` state
+read (the handler logs a warning and scores with configured defaults) and is
+still stamped as `served_by_profile_id` on recall results — the stamp then
+reflects static configuration, not live profile state. A per-request
+`profile_id` parameter is stricter still: its `brain.profile` dispatch failure
+is a hard error, so the request fails outright with no brain pack registered.
+Deployments of the open-source build should therefore leave the memory pack's
+brain-profile configuration unset and omit per-request profile ids.
 
 `memory.feedback` is not fully symmetric: when its configuration routes
 feedback through a brain profile, the handler dispatches `brain.feedback`,

--- a/docs/adr/ADR-023-declarative-pack-format.md
+++ b/docs/adr/ADR-023-declarative-pack-format.md
@@ -582,6 +582,70 @@ argument, the rejected alternatives (wire-facing verb retirement, a composed
 field-validation registry analogous to `EDGE_RULES`), and the accompanying internal
 refactor that unifies `gtd.assign` onto the shared create-plus-`TaskHook` path.
 
+## Amendment: reduced open-source pack surface (2026-07-20)
+
+As of 2026-07-20, the open-source distribution's default pack set is reduced. The
+brain, knowledge, and code packs move to commercially licensed extensions
+maintained outside this repository; they are not part of the open-source
+distribution. The formal pack, which was never part of the open-source default
+pack set (see below), moves alongside the code pack as part of the same
+crate departure. A small set of channel-transport crates supporting alternate
+message delivery also move out of this repository; they contribute no MCP
+verbs and are unrelated to the pack-verb surface this ADR governs.
+
+### Default pack set, before and after
+
+The open-source default pack set (`RuntimeConfig::default()`, selectable via
+`KHIVE_PACKS` / `--pack`) was, before this change:
+
+```
+kg, gtd, memory, brain, comm, schedule, knowledge, session, git, code, workspace, blob
+```
+
+and is, after this change:
+
+```
+kg, gtd, memory, comm, schedule, session, git, workspace, blob
+```
+
+The formal pack was never included in this default set. It was compiled into
+the admin (`kkernel`) binary for operator/CLI-only use and never registered as
+part of the agent-facing MCP pack selection; its removal here changes which
+crates ship in this repository, not the default verb surface.
+
+### Consequence for the agent-facing verb surface
+
+Following this change, the open-source build no longer registers `brain.*` or
+`knowledge.*` verbs, nor the `code.ingest` verb. The kg substrate verbs (§4)
+and the `memory.*` verbs are unaffected and continue to operate as documented.
+
+Serving-profile resolution inside `memory.recall` (and `memory.feedback`)
+degrades gracefully in the absence of a registered brain pack: profile
+resolution dispatches an internal `brain.resolve` call and treats a failed
+dispatch (no such verb registered) the same as a resolvable-but-unmatched
+profile, returning no serving profile. Recall and feedback continue to operate
+on their plain-scoring path; the profile-weighted ranking terms described
+elsewhere in this document simply do not apply when no brain pack is loaded.
+
+### Composition after the carve
+
+This amendment does not change how packs compose. Per [ADR-027](ADR-027-dynamic-pack-loading.md),
+each pack registers itself into the shared handler table via `inventory::submit!`
+at link time; there is no plugin-loading step at runtime. A distribution that
+wishes to compose additional packs — including the ones described above — does
+so by adding their crates as build dependencies and force-linking them the same
+way every pack in this repository is force-linked today (§9); the open-source
+repository itself carries no feature flags, optional dependencies, or
+configuration referencing packs it does not ship.
+
+### Scope of this amendment
+
+This amendment records the pack-surface consequence of moving pack crates out
+of this repository. It does not introduce, retire, or rename any verb, and it
+does not change the visibility, naming, or composition rules established
+elsewhere in this ADR. Corresponding extraction changes are expected to land as
+separate pull requests against this repository.
+
 ## References
 
 - [ADR-001](ADR-001-entity-kind-taxonomy.md) — closed `EntityKind` taxonomy that packs

--- a/docs/adr/ADR-032-brain-profile-orchestration.md
+++ b/docs/adr/ADR-032-brain-profile-orchestration.md
@@ -1323,3 +1323,18 @@ As of #1016, newly emitted `FeedbackExplicit` events always persist the effectiv
 - Rao, R. & Ballard, D., "Predictive coding in the visual cortex" (1999)
 - Anderson, J.R., "How Can the Human Mind Occur in the Physical Universe?" (2007) — ACT-R
   base-level activation as a structural analogue to Beta-posterior accumulation
+
+## Amendment (2026-07-20): distribution boundary — commercially licensed extension
+
+Effective with the accompanying crate-extraction change (which lands as a separate
+pull request; this amendment records the boundary that change produces),
+`khive-pack-brain` ceases to be part of the open-source distribution. The crate ships
+as a commercially licensed extension; the default pack set no longer includes
+`brain`, and the open-source build registers no `brain.*` verbs (see the ADR-023
+amendment of the same date, which also specifies `memory.recall`'s degradation
+behavior when no brain pack is registered). `khive-brain-core` — the interface crate
+`khive-pack-memory` consumes for ranking types — remains in the open-source tree.
+Until the extraction change lands, the in-tree crate remains present, force-linked,
+and part of the default pack set, and this ADR's pre-amendment text describes it
+as-is. Nothing normative here is superseded: this ADR continues to govern the pack
+wherever the extension is deployed.

--- a/docs/adr/ADR-047-knowledge-pack.md
+++ b/docs/adr/ADR-047-knowledge-pack.md
@@ -1,8 +1,25 @@
 # ADR-047: Knowledge Pack
 
-**Status**: accepted (amended 2026-06-07, 2026-06-10, 2026-06-10b)
+**Status**: accepted (amended 2026-06-07, 2026-06-10, 2026-06-10b, 2026-07-20)
 **Date**: 2026-05-25
 **Authors**: khive maintainers
+
+## Amendment (2026-07-20): distribution boundary — commercially licensed extension
+
+Effective with the accompanying crate-extraction change (which lands as a separate
+pull request; this amendment records the boundary that change produces),
+`khive-pack-knowledge` ceases to be part of the open-source distribution. The crate
+ships as a commercially licensed extension; the default pack set no longer includes
+`knowledge`, and the open-source build registers no `knowledge.*` verbs (see the
+ADR-023 amendment of the same date). Until that extraction change lands, the in-tree
+crate remains present, force-linked, and part of the default pack set, and this ADR's
+pre-amendment text describes it as-is.
+
+Nothing normative here is superseded: this ADR and its amendments continue to govern
+the pack wherever the extension is deployed. The atom/section stores, the Vamana ANN
+index over the knowledge corpus, and the warm-path behavior described in ADR-049
+travel with the pack; `khive-vamana` and the other retrieval crates remain in the
+open-source tree, consumed by the memory pack's recall path.
 
 ## Amendment (2026-06-10b): exclude_status precedence fix; auto-compose member filter; atom status taxonomy clarification
 

--- a/docs/adr/ADR-049-khived-daemon.md
+++ b/docs/adr/ADR-049-khived-daemon.md
@@ -243,3 +243,17 @@ The daemon remains an optimization for warm-state reuse; the thin-client archite
 socket protocol, and background warm behavior of this ADR are unaffected. Quiet local
 dispatch remains the contract for genuinely daemonless environments (`no_socket` without a
 confirmed failed recovery attempt, and the `KHIVE_NO_DAEMON=1` opt-out).
+
+## Amendment 3 (2026-07-20): knowledge warm path moves with the knowledge pack
+
+Effective with the crate-extraction change that moves `khive-pack-knowledge` to a
+commercially licensed extension (ADR-047 amendment of the same date; the change lands
+as a separate pull request), the knowledge-ANN portions of this ADR — the
+knowledge-corpus snapshot restore, the `ensure_ann_background` warm path behind
+`knowledge.search`, and the knowledge warm-state sizing in the Context — describe the
+extension's deployment rather than the open-source daemon. The daemon architecture
+itself is unchanged and remains open source: the single-binary kkernel topology
+(first amendment), the socket protocol and thin-client dispatch, and the graduated
+fail-loud fallback policy (Amendment 2) all continue to apply, as does the memory
+pack's ANN warm path. Until the extraction change lands, the in-tree pack and this
+ADR's pre-amendment text describe the tree as-is.

--- a/docs/adr/ADR-056-channel-transport-layer.md
+++ b/docs/adr/ADR-056-channel-transport-layer.md
@@ -2720,6 +2720,20 @@ properties and is corrected here.
 - The address form (`imessage:<slug>`, normative) and the poll-interval and sender-validation
   rules are settled by this amendment text; no open items remain for design sign-off.
 
+## Amendment 2026-07-20 -- Distribution boundary: commercially licensed extensions
+
+Effective with the accompanying crate-extraction change (which lands as a separate
+pull request; this amendment records the boundary that change produces), the
+channel-transport crates -- `khive-channel`, `khive-channel-email`, and
+`khive-channel-telegram` -- cease to be part of the open-source distribution and ship
+as commercially licensed extensions. They contribute no MCP verbs, so the comm pack's
+verb surface (ADR-063) is unaffected; the optional cargo features that wired these
+crates into the server binary leave with them. Until the extraction change lands, the
+in-tree crates and this ADR's pre-amendment text describe the tree as-is. This ADR
+remains the normative contract for the `Channel` trait and the adapters wherever the
+extensions are deployed; dependent designs (for example ADR-105's node channel) build
+against the extension's trait crate.
+
 ## Context
 
 The autonomous build loop blocks regularly on the maintainer. Merge approvals and ADR

--- a/docs/adr/ADR-085-code-pack.md
+++ b/docs/adr/ADR-085-code-pack.md
@@ -1422,3 +1422,27 @@ existing one (`code.ingest`), against the count current as of Amendment 2's
 acceptance (79 verbs on the default pack set) — the implementation PR
 should cite the then-current count at merge time, since intervening PRs may
 have changed it.
+
+## Amendment 5 (2026-07-20) — Distribution boundary: commercially licensed extension
+
+Effective with the accompanying crate-extraction change (which lands as a separate
+pull request; this amendment records the boundary that change produces),
+`khive-pack-code` ceases to be part of the open-source distribution. The crate ships
+as a commercially licensed extension, the default pack set no longer includes `code`,
+and the open-source admin binary no longer carries the `code-ingest` subcommand
+(Amendment 3's admin ingest path) or registers `code.ingest` (see the ADR-023
+amendment of the same date for the resulting default set). Until that extraction
+change lands, the in-tree crate remains present, force-linked, and part of the
+default pack set, and this ADR's pre-amendment text describes it as-is.
+
+Nothing in this ADR's Decision or prior amendments is superseded: the ontology,
+ingest contracts, and the Amendment 4 analysis-verb specification remain normative
+for the pack wherever it is deployed. What changes is ownership and distribution
+only. Once the extraction change lands:
+
+- The open-source tree no longer contains `crates/khive-pack-code`; references to
+  that path in this ADR describe the extension's crate, not an in-tree one.
+- The map-database contract (Amendment 2's dedicated ingest target) travels with the
+  pack; no open-source component reads or writes it.
+- A deployment that loads the extension observes exactly the surface this ADR and
+  its amendments specify, including any analysis verbs landed under Amendment 4.

--- a/docs/adr/ADR-088-git-lifecycle-pack.md
+++ b/docs/adr/ADR-088-git-lifecycle-pack.md
@@ -262,3 +262,24 @@ Decision text.
    unmasked secret patterns. The ingester calls the same masking helper the gate uses
    before submitting commit-message and issue/PR-body content, so ingested provenance text
    is redacted rather than rejected outright.
+
+## Amendment 2 (2026-07-20) — Distribution boundary: commercially licensed extension
+
+`khive-pack-git` — the `commit` / `issue` / `pull_request` note kinds, the batch
+ingester, `git.digest` (Amendment 1), and the ADR-108 write verbs — is no longer part
+of the open-source distribution. The crate ships as a commercially licensed extension,
+and the default pack set no longer includes `git` (see the ADR-023 amendment of the
+same date for the resulting default set).
+
+Nothing in this ADR's Decision, Rationale, or Amendment 1 is superseded: the contracts
+here remain normative for the pack wherever it is deployed. What changes is ownership
+and distribution only:
+
+- The open-source tree no longer contains `crates/khive-pack-git`; references to that
+  path in this ADR describe the extension's crate, not an in-tree one.
+- Pack-declared endpoint rules elsewhere in the tree that name git note kinds (for
+  example the workspace pack's `contains` rules) remain declared and are simply inert
+  when the git pack is not loaded — rule installation does not require the named kinds
+  to exist (ADR-017; ADR-023 amendment).
+- A deployment that loads the extension observes exactly the surface this ADR and its
+  Amendment 1 specify.

--- a/docs/adr/ADR-088-git-lifecycle-pack.md
+++ b/docs/adr/ADR-088-git-lifecycle-pack.md
@@ -263,7 +263,7 @@ Decision text.
    before submitting commit-message and issue/PR-body content, so ingested provenance text
    is redacted rather than rejected outright.
 
-## Amendment 2 (2026-07-20) — Distribution boundary: commercially licensed extension
+## Amendment 3 (2026-07-20) — Distribution boundary: commercially licensed extension
 
 Effective with the accompanying crate-extraction change (which lands as a separate
 pull request; this amendment records the boundary that change produces),
@@ -275,7 +275,7 @@ same date for the resulting default set). Until that extraction change lands, th
 in-tree crate remains present, force-linked, and part of the default pack set, and
 this ADR's pre-amendment text describes it as-is.
 
-Nothing in this ADR's Decision, Rationale, or Amendment 1 is superseded: the contracts
+Nothing in this ADR's Decision, Rationale, or prior amendments is superseded: the contracts
 here remain normative for the pack wherever it is deployed. What changes is ownership
 and distribution only. Once the extraction change lands:
 
@@ -286,4 +286,4 @@ and distribution only. Once the extraction change lands:
   when the git pack is not loaded — rule installation does not require the named kinds
   to exist (ADR-017; ADR-023 amendment).
 - A deployment that loads the extension observes exactly the surface this ADR and its
-  Amendment 1 specify.
+  prior amendments specify.

--- a/docs/adr/ADR-088-git-lifecycle-pack.md
+++ b/docs/adr/ADR-088-git-lifecycle-pack.md
@@ -265,15 +265,19 @@ Decision text.
 
 ## Amendment 2 (2026-07-20) — Distribution boundary: commercially licensed extension
 
+Effective with the accompanying crate-extraction change (which lands as a separate
+pull request; this amendment records the boundary that change produces),
 `khive-pack-git` — the `commit` / `issue` / `pull_request` note kinds, the batch
-ingester, `git.digest` (Amendment 1), and the ADR-108 write verbs — is no longer part
+ingester, `git.digest` (Amendment 1), and the ADR-108 write verbs — ceases to be part
 of the open-source distribution. The crate ships as a commercially licensed extension,
 and the default pack set no longer includes `git` (see the ADR-023 amendment of the
-same date for the resulting default set).
+same date for the resulting default set). Until that extraction change lands, the
+in-tree crate remains present, force-linked, and part of the default pack set, and
+this ADR's pre-amendment text describes it as-is.
 
 Nothing in this ADR's Decision, Rationale, or Amendment 1 is superseded: the contracts
 here remain normative for the pack wherever it is deployed. What changes is ownership
-and distribution only:
+and distribution only. Once the extraction change lands:
 
 - The open-source tree no longer contains `crates/khive-pack-git`; references to that
   path in this ADR describe the extension's crate, not an in-tree one.

--- a/docs/adr/ADR-105-cross-node-comm-transport.md
+++ b/docs/adr/ADR-105-cross-node-comm-transport.md
@@ -206,3 +206,12 @@ three-node star, verified by the end-to-end flow above.
    one specified here; this ADR is that shape written down.
 4. **KG-versioning snapshot push/pull as the comm transport.** Rejected: built for
    version-controlled graph state, wrong latency and granularity shape for messaging.
+
+## Amendment (2026-07-20): transport layer ships as a commercially licensed extension
+
+The ADR-056 channel-transport layer this design builds on moves out of the
+open-source repository as a commercially licensed extension (ADR-056 amendment of the
+same date; the extraction lands as a separate pull request). This ADR's design is
+unchanged; its MAY-add implementation surface (`khive-channel-node`, the hub ingress
+module) lands alongside the extension's trait crate rather than in the open-source
+tree.

--- a/docs/adr/ADR-108-git-write-surface.md
+++ b/docs/adr/ADR-108-git-write-surface.md
@@ -465,15 +465,21 @@ would execute as a side effect of an otherwise-successful, policy-permitted writ
 
 ## Amendment 2 (2026-07-20) — Distribution boundary: commercially licensed extension
 
-The pack this ADR's write surface lives in (`khive-pack-git`, per ADR-088 Amendment 2)
-is no longer part of the open-source distribution; it ships as a commercially licensed
-extension, and the default pack set no longer registers `git.commit` / `git.branch` /
-`git.push` (see the ADR-023 amendment of the same date).
+Effective with the crate-extraction change recorded in ADR-088 Amendment 2 (which
+lands as a separate pull request; this amendment records the boundary that change
+produces), the pack this ADR's write surface lives in (`khive-pack-git`) ceases to be
+part of the open-source distribution; it ships as a commercially licensed extension,
+and the default pack set no longer registers `git.commit` / `git.branch` / `git.push`
+(see the ADR-023 amendment of the same date). Until that extraction change lands, the
+in-tree pack — including its `[git_write]`-gated write verbs — remains present in the
+default pack set and operational under this ADR's pre-amendment contract; an
+allowlisted `[git_write]` configuration continues to expose the write verbs exactly
+as Amendment 1 specifies.
 
 This ADR's normative content — the hardened argv construction, unconditional
 force-push denial, the Amendment 1 fail-closed `[git_write]` allowlist, and the
 hooks-disabled execution contract — is unchanged and continues to govern the verbs
-wherever the extension is deployed. The runtime keeps the `[git_write]` configuration
-plumbing so a deployment that loads the extension gets Amendment 1's fail-closed
-behavior without further changes; with no git pack loaded, that configuration is
-inert.
+wherever the extension is deployed. After the extraction, the runtime keeps the
+`[git_write]` configuration plumbing so a deployment that loads the extension gets
+Amendment 1's fail-closed behavior without further changes; in a build with no git
+pack loaded, that configuration is inert.

--- a/docs/adr/ADR-108-git-write-surface.md
+++ b/docs/adr/ADR-108-git-write-surface.md
@@ -465,7 +465,7 @@ would execute as a side effect of an otherwise-successful, policy-permitted writ
 
 ## Amendment 2 (2026-07-20) — Distribution boundary: commercially licensed extension
 
-Effective with the crate-extraction change recorded in ADR-088 Amendment 2 (which
+Effective with the crate-extraction change recorded in ADR-088 Amendment 3 (which
 lands as a separate pull request; this amendment records the boundary that change
 produces), the pack this ADR's write surface lives in (`khive-pack-git`) ceases to be
 part of the open-source distribution; it ships as a commercially licensed extension,

--- a/docs/adr/ADR-108-git-write-surface.md
+++ b/docs/adr/ADR-108-git-write-surface.md
@@ -462,3 +462,18 @@ would execute as a side effect of an otherwise-successful, policy-permitted writ
 - Operators who want the write verbs to work at all must maintain the `[git_write]` section
   as repos and branch conventions change; this is an explicit operational cost of the
   fail-closed default, accepted in exchange for closing the reachable-by-default gap.
+
+## Amendment 2 (2026-07-20) — Distribution boundary: commercially licensed extension
+
+The pack this ADR's write surface lives in (`khive-pack-git`, per ADR-088 Amendment 2)
+is no longer part of the open-source distribution; it ships as a commercially licensed
+extension, and the default pack set no longer registers `git.commit` / `git.branch` /
+`git.push` (see the ADR-023 amendment of the same date).
+
+This ADR's normative content — the hardened argv construction, unconditional
+force-push denial, the Amendment 1 fail-closed `[git_write]` allowlist, and the
+hooks-disabled execution contract — is unchanged and continues to govern the verbs
+wherever the extension is deployed. The runtime keeps the `[git_write]` configuration
+plumbing so a deployment that loads the extension gets Amendment 1's fail-closed
+behavior without further changes; with no git pack loaded, that configuration is
+inert.


### PR DESCRIPTION
## Summary

Amends ADR-023 to record that the open-source distribution's default pack
set is reduced: the brain, knowledge, code, and formal packs, along with a
small set of channel-transport crates, move to commercially licensed
extensions maintained outside this repository. Documents the resulting
default pack list (before/after), the agent-facing verb-surface consequence,
and confirms (against the pack-memory source) that profile-scoped recall
degrades gracefully when no brain pack is registered.

Docs-only change to `docs/adr/ADR-023-declarative-pack-format.md`. Accompanies
the pack-extraction changes and is intended to merge after them.

## Test plan

- [ ] Pre-commit hooks pass (fmt, ADR-reference lint) — confirmed locally
- [ ] Reviewed against the shipped `RuntimeConfig::default()` pack list at time of merge