### PR TITLE
docs(adr): mark ADR-118 accepted

### DIFF
--- a/docs/adr/ADR-118-fresh-tail-recall-visibility.md
+++ b/docs/adr/ADR-118-fresh-tail-recall-visibility.md
@@ -1,6 +1,6 @@
 # ADR-118: Fresh-Tail Exact Leg — Read-Your-Writes Visibility for Vector Recall
 
-**Status**: Proposed
+**Status**: Accepted
 **Date**: 2026-07-19
 **Depends on**: [ADR-021](ADR-021-memory-pack.md) (Memory Pack),
 [ADR-079](ADR-079-ann-persistence-warm-path-integration.md) (ANN persistence, Amendment 1


### PR DESCRIPTION
One-line record fix: ADR-118 (fresh-tail recall visibility) still carried **Status: Proposed** although the mechanism shipped in #1147 and runs on every vector recall leg. Header updated to Accepted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)