### PR TITLE
fix(db): harden migration boot path for concurrent processes

### DIFF
--- a/crates/khive-db/src/migrations.rs
+++ b/crates/khive-db/src/migrations.rs
@@ -249,13 +249,18 @@ pub fn inspect_schema_version(path: &std::path::Path) -> Result<u32, SqliteError
 
 pub fn run_migrations(conn: &mut Connection) -> Result<u32, SqliteError> {
     // Concurrent boots (multiple processes migrating the same file) contend on
-    // the write lock below; the pool default busy_timeout is tuned for hot-path
-    // queries and is too short to wait out a sibling's migration. Raise it for
-    // the migration run and restore the caller's value after.
+    // the write lock below; a short hot-path busy_timeout cannot wait out a
+    // sibling's migration. Raise-only to a 5s floor — never reduce a caller
+    // whose configured timeout is already longer — and restore after.
     let prior_busy_ms: i64 = conn.query_row("PRAGMA busy_timeout", [], |row| row.get(0))?;
-    conn.busy_timeout(std::time::Duration::from_secs(5))?;
+    let raised = prior_busy_ms < 5_000;
+    if raised {
+        conn.busy_timeout(std::time::Duration::from_secs(5))?;
+    }
     let result = run_migrations_locked(conn);
-    let _ = conn.busy_timeout(std::time::Duration::from_millis(prior_busy_ms.max(0) as u64));
+    if raised {
+        let _ = conn.busy_timeout(std::time::Duration::from_millis(prior_busy_ms.max(0) as u64));
+    }
     result
 }
 
@@ -280,9 +285,14 @@ fn run_migrations_locked(conn: &mut Connection) -> Result<u32, SqliteError> {
     }
 
     let mut applied_version = current_version;
+    // Floor advanced when a sibling's work is observed under the write lock,
+    // so a losing process skips the remaining already-applied migrations
+    // without opening a transaction for each.
+    let mut skip_through = current_version;
 
     for migration in MIGRATIONS {
-        if migration.version <= current_version {
+        if migration.version <= skip_through {
+            applied_version = applied_version.max(migration.version);
             continue;
         }
 
@@ -297,19 +307,21 @@ fn run_migrations_locked(conn: &mut Connection) -> Result<u32, SqliteError> {
             })?;
 
         // Re-check under the write lock: a sibling process may have applied
-        // this migration while we waited. Running its DDL again would fail.
-        let already_applied: bool = tx
+        // this migration (and possibly later ones) while we waited. Running
+        // its DDL again would fail; fast-forward past everything it applied.
+        let sibling_version: u32 = tx
             .query_row(
-                "SELECT EXISTS(SELECT 1 FROM _schema_migrations WHERE version = ?1)",
-                rusqlite::params![migration.version],
+                "SELECT COALESCE(MAX(version), 0) FROM _schema_migrations",
+                [],
                 |row| row.get(0),
             )
             .map_err(|e| SqliteError::Migration {
                 version: migration.version,
                 error: e.to_string(),
             })?;
-        if already_applied {
-            applied_version = migration.version;
+        if sibling_version >= migration.version {
+            skip_through = sibling_version.min(latest_version);
+            applied_version = applied_version.max(migration.version);
             continue;
         }
 

--- a/crates/khive-db/src/migrations.rs
+++ b/crates/khive-db/src/migrations.rs
@@ -216,14 +216,23 @@ const MIGRATION_TRACKING_TABLE: &str = include_str!("../sql/schema-migrations-ta
 /// Errors on non-contiguous version array or failed migration.
 /// Read the applied schema version from an open connection **without** running
 /// migrations. Returns 0 when the `_schema_migrations` ledger is absent (an
-/// un-migrated or empty database). Never writes.
-pub fn read_schema_version(conn: &Connection) -> u32 {
-    conn.query_row(
+/// un-migrated or empty database); any other failure (BUSY, IO) propagates —
+/// collapsing it to 0 would misreport a live database as un-migrated. Never
+/// writes.
+pub fn read_schema_version(conn: &Connection) -> Result<u32, SqliteError> {
+    match conn.query_row(
         "SELECT COALESCE(MAX(version), 0) FROM _schema_migrations",
         [],
         |row| row.get(0),
-    )
-    .unwrap_or(0)
+    ) {
+        Ok(version) => Ok(version),
+        Err(rusqlite::Error::SqliteFailure(_, Some(ref msg)))
+            if msg.contains("no such table: _schema_migrations") =>
+        {
+            Ok(0)
+        }
+        Err(e) => Err(e.into()),
+    }
 }
 
 /// Open `path` read-only and report its applied schema version without creating
@@ -235,19 +244,25 @@ pub fn inspect_schema_version(path: &std::path::Path) -> Result<u32, SqliteError
         path,
         rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY | rusqlite::OpenFlags::SQLITE_OPEN_NO_MUTEX,
     )?;
-    Ok(read_schema_version(&conn))
+    read_schema_version(&conn)
 }
 
 pub fn run_migrations(conn: &mut Connection) -> Result<u32, SqliteError> {
+    // Concurrent boots (multiple processes migrating the same file) contend on
+    // the write lock below; the pool default busy_timeout is tuned for hot-path
+    // queries and is too short to wait out a sibling's migration. Raise it for
+    // the migration run and restore the caller's value after.
+    let prior_busy_ms: i64 = conn.query_row("PRAGMA busy_timeout", [], |row| row.get(0))?;
+    conn.busy_timeout(std::time::Duration::from_secs(5))?;
+    let result = run_migrations_locked(conn);
+    let _ = conn.busy_timeout(std::time::Duration::from_millis(prior_busy_ms.max(0) as u64));
+    result
+}
+
+fn run_migrations_locked(conn: &mut Connection) -> Result<u32, SqliteError> {
     conn.execute_batch(MIGRATION_TRACKING_TABLE)?;
 
-    let current_version: u32 = conn
-        .query_row(
-            "SELECT COALESCE(MAX(version), 0) FROM _schema_migrations",
-            [],
-            |row| row.get(0),
-        )
-        .unwrap_or(0);
+    let current_version: u32 = read_schema_version(conn)?;
 
     // A database whose recorded version is ahead of the latest known migration
     // predates the consolidated V1 baseline (ADR-015) — e.g. it still carries the
@@ -271,10 +286,32 @@ pub fn run_migrations(conn: &mut Connection) -> Result<u32, SqliteError> {
             continue;
         }
 
-        let tx = conn.transaction().map_err(|e| SqliteError::Migration {
-            version: migration.version,
-            error: e.to_string(),
-        })?;
+        // IMMEDIATE: take the write lock up front so concurrent boots serialize
+        // here instead of failing mid-migration when a DEFERRED transaction
+        // upgrades to a write.
+        let tx = conn
+            .transaction_with_behavior(rusqlite::TransactionBehavior::Immediate)
+            .map_err(|e| SqliteError::Migration {
+                version: migration.version,
+                error: e.to_string(),
+            })?;
+
+        // Re-check under the write lock: a sibling process may have applied
+        // this migration while we waited. Running its DDL again would fail.
+        let already_applied: bool = tx
+            .query_row(
+                "SELECT EXISTS(SELECT 1 FROM _schema_migrations WHERE version = ?1)",
+                rusqlite::params![migration.version],
+                |row| row.get(0),
+            )
+            .map_err(|e| SqliteError::Migration {
+                version: migration.version,
+                error: e.to_string(),
+            })?;
+        if already_applied {
+            applied_version = migration.version;
+            continue;
+        }
 
         tx.execute_batch(migration.up)
             .map_err(|e| SqliteError::Migration {
@@ -284,7 +321,8 @@ pub fn run_migrations(conn: &mut Connection) -> Result<u32, SqliteError> {
 
         let now = chrono::Utc::now().timestamp_micros();
         tx.execute(
-            "INSERT INTO _schema_migrations (version, name, applied_at) VALUES (?1, ?2, ?3)",
+            "INSERT INTO _schema_migrations (version, name, applied_at) VALUES (?1, ?2, ?3) \
+             ON CONFLICT(version) DO NOTHING",
             rusqlite::params![migration.version, migration.name, now],
         )
         .map_err(|e| SqliteError::Migration {

--- a/crates/khive-db/src/migrations.rs
+++ b/crates/khive-db/src/migrations.rs
@@ -247,6 +247,26 @@ pub fn inspect_schema_version(path: &std::path::Path) -> Result<u32, SqliteError
     read_schema_version(&conn)
 }
 
+#[cfg(test)]
+pub(crate) mod test_sync {
+    use std::sync::atomic::AtomicU32;
+    use std::sync::{Arc, Barrier, Mutex};
+
+    /// When set, `run_migrations_locked` parks after its initial (stale)
+    /// ledger read until every racing thread has arrived — forcing the
+    /// contended interleaving the concurrent-boot test asserts on.
+    pub(crate) static STALE_READ_BARRIER: Mutex<Option<Arc<Barrier>>> = Mutex::new(None);
+    /// Counts entries into the under-lock sibling fast-forward branch.
+    pub(crate) static LOCKED_FAST_FORWARDS: AtomicU32 = AtomicU32::new(0);
+
+    std::thread_local! {
+        /// Opt-in flag: only threads that set this participate in the barrier,
+        /// so unrelated tests migrating in parallel are never parked.
+        pub(crate) static PARTICIPATE: std::cell::Cell<bool> =
+            const { std::cell::Cell::new(false) };
+    }
+}
+
 pub fn run_migrations(conn: &mut Connection) -> Result<u32, SqliteError> {
     // Concurrent boots (multiple processes migrating the same file) contend on
     // the write lock below; a short hot-path busy_timeout cannot wait out a
@@ -268,6 +288,17 @@ fn run_migrations_locked(conn: &mut Connection) -> Result<u32, SqliteError> {
     conn.execute_batch(MIGRATION_TRACKING_TABLE)?;
 
     let current_version: u32 = read_schema_version(conn)?;
+
+    // Deterministic-contention hook: parks every caller after the stale ledger
+    // read (no lock held) until all racing test threads have observed it, so
+    // they are then released to compete for the IMMEDIATE write lock below.
+    #[cfg(test)]
+    if test_sync::PARTICIPATE.with(|p| p.get()) {
+        let barrier = test_sync::STALE_READ_BARRIER.lock().unwrap().clone();
+        if let Some(barrier) = barrier {
+            barrier.wait();
+        }
+    }
 
     // A database whose recorded version is ahead of the latest known migration
     // predates the consolidated V1 baseline (ADR-015) — e.g. it still carries the
@@ -320,6 +351,8 @@ fn run_migrations_locked(conn: &mut Connection) -> Result<u32, SqliteError> {
                 error: e.to_string(),
             })?;
         if sibling_version >= migration.version {
+            #[cfg(test)]
+            test_sync::LOCKED_FAST_FORWARDS.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
             skip_through = sibling_version.min(latest_version);
             applied_version = applied_version.max(migration.version);
             continue;

--- a/crates/khive-db/src/migrations.rs
+++ b/crates/khive-db/src/migrations.rs
@@ -410,6 +410,19 @@ fn run_migrations_locked(conn: &mut Connection) -> Result<u32, SqliteError> {
             }
         }
 
+        // The ahead-of-latest guard above ran on a pre-lock read; a newer
+        // build may have committed a version past ours while we waited for
+        // the write lock. Accepting it (clamped) would return Ok on a schema
+        // this binary does not understand — reject it the same way.
+        if sibling_version > latest_version {
+            return Err(SqliteError::InvalidData(format!(
+                "database schema version {sibling_version} is ahead of the latest known \
+                 migration {latest_version} (committed by a concurrent process while this \
+                 one waited for the migration write lock). This build cannot run against \
+                 the newer schema; upgrade the binary or recreate the database."
+            )));
+        }
+
         if sibling_version >= migration.version {
             #[cfg(test)]
             test_sync::LOCKED_FAST_FORWARDS.fetch_add(1, std::sync::atomic::Ordering::Relaxed);

--- a/crates/khive-db/src/migrations.rs
+++ b/crates/khive-db/src/migrations.rs
@@ -258,11 +258,27 @@ pub(crate) mod test_sync {
     pub(crate) static STALE_READ_BARRIER: Mutex<Option<Arc<Barrier>>> = Mutex::new(None);
     /// Counts entries into the under-lock sibling fast-forward branch.
     pub(crate) static LOCKED_FAST_FORWARDS: AtomicU32 = AtomicU32::new(0);
+    /// Number of participating threads that have registered their first
+    /// `BEGIN IMMEDIATE` attempt.
+    pub(crate) static BEGIN_ATTEMPTS: AtomicU32 = AtomicU32::new(0);
+    /// Set by the winner immediately before committing its first migration
+    /// transaction — i.e. before the write lock is first released.
+    pub(crate) static WINNER_COMMITTED: std::sync::atomic::AtomicBool =
+        std::sync::atomic::AtomicBool::new(false);
+    /// Recorded by the loser when its first `BEGIN IMMEDIATE` returns: whether
+    /// the winner had already committed at that moment. `true` is direct
+    /// evidence the loser's lock acquisition blocked across the winner's held
+    /// write lock rather than the two calls serializing by scheduler accident.
+    pub(crate) static LOSER_SAW_WINNER_COMMIT: std::sync::atomic::AtomicBool =
+        std::sync::atomic::AtomicBool::new(false);
 
     std::thread_local! {
         /// Opt-in flag: only threads that set this participate in the barrier,
         /// so unrelated tests migrating in parallel are never parked.
         pub(crate) static PARTICIPATE: std::cell::Cell<bool> =
+            const { std::cell::Cell::new(false) };
+        /// Whether this thread has already instrumented its first BEGIN.
+        pub(crate) static FIRST_BEGIN_DONE: std::cell::Cell<bool> =
             const { std::cell::Cell::new(false) };
     }
 }
@@ -330,6 +346,14 @@ fn run_migrations_locked(conn: &mut Connection) -> Result<u32, SqliteError> {
         // IMMEDIATE: take the write lock up front so concurrent boots serialize
         // here instead of failing mid-migration when a DEFERRED transaction
         // upgrades to a write.
+        #[cfg(test)]
+        let instrumented_first_begin = test_sync::PARTICIPATE.with(|p| p.get())
+            && !test_sync::FIRST_BEGIN_DONE.with(|f| f.get());
+        #[cfg(test)]
+        if instrumented_first_begin {
+            test_sync::FIRST_BEGIN_DONE.with(|f| f.set(true));
+            test_sync::BEGIN_ATTEMPTS.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+        }
         let tx = conn
             .transaction_with_behavior(rusqlite::TransactionBehavior::Immediate)
             .map_err(|e| SqliteError::Migration {
@@ -350,6 +374,31 @@ fn run_migrations_locked(conn: &mut Connection) -> Result<u32, SqliteError> {
                 version: migration.version,
                 error: e.to_string(),
             })?;
+        #[cfg(test)]
+        if instrumented_first_begin {
+            use std::sync::atomic::Ordering::SeqCst;
+            if sibling_version == 0 {
+                // Winner: hold the write lock until every participating thread
+                // has registered its first BEGIN attempt (bounded), plus a
+                // grace interval for the last registrant to reach the blocking
+                // call — guaranteeing the loser's acquisition overlaps this
+                // held lock instead of serializing by scheduler accident.
+                let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+                while test_sync::BEGIN_ATTEMPTS.load(SeqCst) < 2
+                    && std::time::Instant::now() < deadline
+                {
+                    std::thread::yield_now();
+                }
+                std::thread::sleep(std::time::Duration::from_millis(100));
+            } else {
+                // Loser: our first BEGIN just returned. Record whether the
+                // winner had already committed — true means we blocked across
+                // its held lock.
+                test_sync::LOSER_SAW_WINNER_COMMIT
+                    .store(test_sync::WINNER_COMMITTED.load(SeqCst), SeqCst);
+            }
+        }
+
         if sibling_version >= migration.version {
             #[cfg(test)]
             test_sync::LOCKED_FAST_FORWARDS.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
@@ -374,6 +423,11 @@ fn run_migrations_locked(conn: &mut Connection) -> Result<u32, SqliteError> {
             version: migration.version,
             error: e.to_string(),
         })?;
+
+        #[cfg(test)]
+        if instrumented_first_begin {
+            test_sync::WINNER_COMMITTED.store(true, std::sync::atomic::Ordering::SeqCst);
+        }
 
         tx.commit().map_err(|e| SqliteError::Migration {
             version: migration.version,

--- a/crates/khive-db/src/migrations.rs
+++ b/crates/khive-db/src/migrations.rs
@@ -258,9 +258,20 @@ pub(crate) mod test_sync {
     pub(crate) static STALE_READ_BARRIER: Mutex<Option<Arc<Barrier>>> = Mutex::new(None);
     /// Counts entries into the under-lock sibling fast-forward branch.
     pub(crate) static LOCKED_FAST_FORWARDS: AtomicU32 = AtomicU32::new(0);
-    /// Number of participating threads that have registered their first
-    /// `BEGIN IMMEDIATE` attempt.
-    pub(crate) static BEGIN_ATTEMPTS: AtomicU32 = AtomicU32::new(0);
+    /// Set by the SQLite busy handler installed on participating connections:
+    /// `true` means SQLite itself reported a blocked lock acquisition to the
+    /// loser — actual contention, not merely an intended attempt.
+    pub(crate) static BUSY_OBSERVED: std::sync::atomic::AtomicBool =
+        std::sync::atomic::AtomicBool::new(false);
+
+    /// Busy handler for participating test connections: records that SQLite
+    /// observed a busy acquisition, then keeps retrying.
+    pub(crate) fn record_busy(_count: i32) -> bool {
+        BUSY_OBSERVED.store(true, std::sync::atomic::Ordering::SeqCst);
+        std::thread::sleep(std::time::Duration::from_millis(1));
+        true
+    }
+
     /// Set by the winner immediately before committing its first migration
     /// transaction — i.e. before the write lock is first released.
     pub(crate) static WINNER_COMMITTED: std::sync::atomic::AtomicBool =
@@ -310,6 +321,9 @@ fn run_migrations_locked(conn: &mut Connection) -> Result<u32, SqliteError> {
     // they are then released to compete for the IMMEDIATE write lock below.
     #[cfg(test)]
     if test_sync::PARTICIPATE.with(|p| p.get()) {
+        // Replaces the busy_timeout raised by `run_migrations` on this test
+        // connection: records SQLite-observed contention, then keeps retrying.
+        conn.busy_handler(Some(test_sync::record_busy))?;
         let barrier = test_sync::STALE_READ_BARRIER.lock().unwrap().clone();
         if let Some(barrier) = barrier {
             barrier.wait();
@@ -352,7 +366,6 @@ fn run_migrations_locked(conn: &mut Connection) -> Result<u32, SqliteError> {
         #[cfg(test)]
         if instrumented_first_begin {
             test_sync::FIRST_BEGIN_DONE.with(|f| f.set(true));
-            test_sync::BEGIN_ATTEMPTS.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
         }
         let tx = conn
             .transaction_with_behavior(rusqlite::TransactionBehavior::Immediate)
@@ -378,18 +391,16 @@ fn run_migrations_locked(conn: &mut Connection) -> Result<u32, SqliteError> {
         if instrumented_first_begin {
             use std::sync::atomic::Ordering::SeqCst;
             if sibling_version == 0 {
-                // Winner: hold the write lock until every participating thread
-                // has registered its first BEGIN attempt (bounded), plus a
-                // grace interval for the last registrant to reach the blocking
-                // call — guaranteeing the loser's acquisition overlaps this
-                // held lock instead of serializing by scheduler accident.
+                // Winner: hold the write lock until SQLite has reported a
+                // busy acquisition to the loser (its busy handler fired) —
+                // proof the loser's BEGIN is actually blocked on this held
+                // lock, not merely intended. Bounded so a regression fails
+                // the assertion instead of hanging the test.
                 let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
-                while test_sync::BEGIN_ATTEMPTS.load(SeqCst) < 2
-                    && std::time::Instant::now() < deadline
+                while !test_sync::BUSY_OBSERVED.load(SeqCst) && std::time::Instant::now() < deadline
                 {
                     std::thread::yield_now();
                 }
-                std::thread::sleep(std::time::Duration::from_millis(100));
             } else {
                 // Loser: our first BEGIN just returned. Record whether the
                 // winner had already committed — true means we blocked across

--- a/crates/khive-db/src/migrations_tests.rs
+++ b/crates/khive-db/src/migrations_tests.rs
@@ -679,17 +679,21 @@ fn concurrent_boots_converge() {
     let dir = tempfile::tempdir().expect("tempdir");
     let path = dir.path().join("concurrent-boot.db");
 
-    // Both threads open their connection first, then release through a barrier
-    // so the two run_migrations calls genuinely race for the write lock
-    // instead of serializing on thread spawn latency.
+    // Deterministic interleaving via the in-crate stale-read barrier: both
+    // threads must observe the empty ledger (version 0, no lock held) before
+    // either is released to compete for the IMMEDIATE write lock. The loser
+    // is thereby guaranteed to reach the under-lock re-check with a stale
+    // view, which the fast-forward counter asserts below.
     let barrier = std::sync::Arc::new(std::sync::Barrier::new(2));
+    *test_sync::STALE_READ_BARRIER.lock().unwrap() = Some(barrier);
+    test_sync::LOCKED_FAST_FORWARDS.store(0, std::sync::atomic::Ordering::Relaxed);
+
     let handles: Vec<_> = (0..2)
         .map(|_| {
             let path = path.clone();
-            let barrier = std::sync::Arc::clone(&barrier);
             std::thread::spawn(move || {
+                test_sync::PARTICIPATE.with(|p| p.set(true));
                 let mut conn = Connection::open(&path).expect("open");
-                barrier.wait();
                 run_migrations(&mut conn)
             })
         })
@@ -703,6 +707,16 @@ fn concurrent_boots_converge() {
             .expect("both concurrent boots must succeed");
         assert_eq!(version, latest);
     }
+    *test_sync::STALE_READ_BARRIER.lock().unwrap() = None;
+
+    // Both threads observed version 0 before either took the write lock, so
+    // the loser necessarily re-checked under the lock and fast-forwarded past
+    // the winner's applied migrations. This fails if either the IMMEDIATE
+    // behavior or the under-lock MAX(version) re-check regresses.
+    assert!(
+        test_sync::LOCKED_FAST_FORWARDS.load(std::sync::atomic::Ordering::Relaxed) >= 1,
+        "loser thread must observe the sibling's ledger under the write lock"
+    );
 
     let conn = Connection::open(&path).expect("reopen");
     let rows: u32 = conn

--- a/crates/khive-db/src/migrations_tests.rs
+++ b/crates/khive-db/src/migrations_tests.rs
@@ -679,11 +679,17 @@ fn concurrent_boots_converge() {
     let dir = tempfile::tempdir().expect("tempdir");
     let path = dir.path().join("concurrent-boot.db");
 
+    // Both threads open their connection first, then release through a barrier
+    // so the two run_migrations calls genuinely race for the write lock
+    // instead of serializing on thread spawn latency.
+    let barrier = std::sync::Arc::new(std::sync::Barrier::new(2));
     let handles: Vec<_> = (0..2)
         .map(|_| {
             let path = path.clone();
+            let barrier = std::sync::Arc::clone(&barrier);
             std::thread::spawn(move || {
                 let mut conn = Connection::open(&path).expect("open");
+                barrier.wait();
                 run_migrations(&mut conn)
             })
         })

--- a/crates/khive-db/src/migrations_tests.rs
+++ b/crates/khive-db/src/migrations_tests.rs
@@ -671,13 +671,27 @@ fn read_schema_version_missing_ledger_is_zero() {
     );
 }
 
+/// Clears the shared `test_sync` barrier on drop so a panicking test cannot
+/// strand it and hang every later test that opts into the contention hook.
+struct BarrierGuard;
+
+impl Drop for BarrierGuard {
+    fn drop(&mut self) {
+        *test_sync::STALE_READ_BARRIER
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner()) = None;
+    }
+}
+
 // khive#1212: two processes booting the same database file must both complete
 // migrations — the IMMEDIATE transaction serializes them and the under-lock
 // re-check makes the loser converge instead of failing on already-applied DDL.
 #[test]
+#[serial_test::serial(migration_contention)]
 fn concurrent_boots_converge() {
     let dir = tempfile::tempdir().expect("tempdir");
     let path = dir.path().join("concurrent-boot.db");
+    let _guard = BarrierGuard;
 
     // Deterministic interleaving via the in-crate stale-read barrier: both
     // threads must observe the empty ledger (version 0, no lock held) before
@@ -746,5 +760,75 @@ fn concurrent_boots_converge() {
         rows as usize,
         MIGRATIONS.len(),
         "exactly one ledger row per migration"
+    );
+}
+
+// khive#1217 review blocking finding: the pre-lock ahead-of-latest guard runs
+// on a stale read. If a NEWER build commits a schema version above this
+// binary's latest while this process waits for the migration write lock, the
+// under-lock re-read must reject that version — not clamp it into a false Ok.
+#[test]
+#[serial_test::serial(migration_contention)]
+fn mixed_version_boot_rejects_newer_schema_under_lock() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = dir.path().join("mixed-version-boot.db");
+    let _guard = BarrierGuard;
+
+    // The "newer build": create the ledger, then hold an uncommitted
+    // IMMEDIATE transaction carrying a version above latest. Uncommitted, it
+    // is invisible to the booting thread's stale read regardless of thread
+    // scheduling; committed only after the barrier, it is ordered before the
+    // booting thread's under-lock re-read by the write lock itself. That
+    // makes the under-lock guard — not the pre-lock guard — the one that
+    // must fire.
+    let newer = Connection::open(&path).expect("open newer-build connection");
+    newer
+        .execute_batch(MIGRATION_TRACKING_TABLE)
+        .expect("create ledger");
+    let latest = MIGRATIONS.last().expect("at least one migration").version;
+    newer
+        .execute_batch(&format!(
+            "BEGIN IMMEDIATE; INSERT INTO _schema_migrations (version, name, applied_at) \
+             VALUES ({}, 'future-build', 0);",
+            latest + 1
+        ))
+        .expect("stage future version uncommitted");
+
+    let barrier = std::sync::Arc::new(std::sync::Barrier::new(2));
+    *test_sync::STALE_READ_BARRIER.lock().unwrap() = Some(barrier.clone());
+    test_sync::BUSY_OBSERVED.store(false, std::sync::atomic::Ordering::SeqCst);
+    test_sync::WINNER_COMMITTED.store(false, std::sync::atomic::Ordering::SeqCst);
+    test_sync::LOSER_SAW_WINNER_COMMIT.store(false, std::sync::atomic::Ordering::SeqCst);
+
+    let boot = {
+        let path = path.clone();
+        std::thread::spawn(move || {
+            test_sync::PARTICIPATE.with(|p| p.set(true));
+            let mut conn = Connection::open(&path).expect("open booting connection");
+            run_migrations(&mut conn)
+        })
+    };
+
+    // Rendezvous: the booting thread has read the (stale, version-0) ledger
+    // and is released toward its BEGIN IMMEDIATE, which blocks on the lock
+    // still held here. Committing now publishes the future version strictly
+    // before the boot's under-lock re-read.
+    barrier.wait();
+    newer
+        .execute_batch("COMMIT")
+        .expect("commit future version");
+
+    let err = boot
+        .join()
+        .expect("thread join")
+        .expect_err("a schema version above latest must be rejected, not clamped");
+    let msg = err.to_string();
+    assert!(
+        msg.contains("ahead of the latest known migration"),
+        "unexpected error: {msg}"
+    );
+    assert!(
+        msg.contains("migration write lock"),
+        "the under-lock guard, not the pre-lock guard, must fire: {msg}"
     );
 }

--- a/crates/khive-db/src/migrations_tests.rs
+++ b/crates/khive-db/src/migrations_tests.rs
@@ -687,7 +687,7 @@ fn concurrent_boots_converge() {
     let barrier = std::sync::Arc::new(std::sync::Barrier::new(2));
     *test_sync::STALE_READ_BARRIER.lock().unwrap() = Some(barrier);
     test_sync::LOCKED_FAST_FORWARDS.store(0, std::sync::atomic::Ordering::Relaxed);
-    test_sync::BEGIN_ATTEMPTS.store(0, std::sync::atomic::Ordering::SeqCst);
+    test_sync::BUSY_OBSERVED.store(false, std::sync::atomic::Ordering::SeqCst);
     test_sync::WINNER_COMMITTED.store(false, std::sync::atomic::Ordering::SeqCst);
     test_sync::LOSER_SAW_WINNER_COMMIT.store(false, std::sync::atomic::Ordering::SeqCst);
 
@@ -721,16 +721,19 @@ fn concurrent_boots_converge() {
         "loser thread must observe the sibling's ledger under the write lock"
     );
 
-    // The loser's first BEGIN IMMEDIATE returned only after the winner had
-    // committed: the winner held the write lock (parked inside its first
-    // transaction until both threads registered a BEGIN attempt) while the
-    // loser's acquisition was pending, so the loser demonstrably blocked on
-    // the lock. If IMMEDIATE regressed to deferred behavior, the loser's
-    // BEGIN would return before any commit and this flag would stay false
-    // (that interleaving also fails outright on duplicate DDL).
+    // SQLite itself reported a busy acquisition to the loser while the winner
+    // held the write lock: the winner does not commit until the loser's busy
+    // handler has fired, so this is observed contention, not an intended
+    // attempt. If IMMEDIATE regressed to deferred behavior, no busy signal
+    // occurs on BEGIN and this fails (that interleaving also fails outright
+    // on duplicate DDL).
+    assert!(
+        test_sync::BUSY_OBSERVED.load(std::sync::atomic::Ordering::SeqCst),
+        "SQLite must observe the loser's blocked BEGIN IMMEDIATE while the winner holds the lock"
+    );
     assert!(
         test_sync::LOSER_SAW_WINNER_COMMIT.load(std::sync::atomic::Ordering::SeqCst),
-        "loser's BEGIN IMMEDIATE must block across the winner's held write lock"
+        "loser's BEGIN IMMEDIATE must return only after the winner committed"
     );
 
     let conn = Connection::open(&path).expect("reopen");

--- a/crates/khive-db/src/migrations_tests.rs
+++ b/crates/khive-db/src/migrations_tests.rs
@@ -687,6 +687,9 @@ fn concurrent_boots_converge() {
     let barrier = std::sync::Arc::new(std::sync::Barrier::new(2));
     *test_sync::STALE_READ_BARRIER.lock().unwrap() = Some(barrier);
     test_sync::LOCKED_FAST_FORWARDS.store(0, std::sync::atomic::Ordering::Relaxed);
+    test_sync::BEGIN_ATTEMPTS.store(0, std::sync::atomic::Ordering::SeqCst);
+    test_sync::WINNER_COMMITTED.store(false, std::sync::atomic::Ordering::SeqCst);
+    test_sync::LOSER_SAW_WINNER_COMMIT.store(false, std::sync::atomic::Ordering::SeqCst);
 
     let handles: Vec<_> = (0..2)
         .map(|_| {
@@ -716,6 +719,18 @@ fn concurrent_boots_converge() {
     assert!(
         test_sync::LOCKED_FAST_FORWARDS.load(std::sync::atomic::Ordering::Relaxed) >= 1,
         "loser thread must observe the sibling's ledger under the write lock"
+    );
+
+    // The loser's first BEGIN IMMEDIATE returned only after the winner had
+    // committed: the winner held the write lock (parked inside its first
+    // transaction until both threads registered a BEGIN attempt) while the
+    // loser's acquisition was pending, so the loser demonstrably blocked on
+    // the lock. If IMMEDIATE regressed to deferred behavior, the loser's
+    // BEGIN would return before any commit and this flag would stay false
+    // (that interleaving also fails outright on duplicate DDL).
+    assert!(
+        test_sync::LOSER_SAW_WINNER_COMMIT.load(std::sync::atomic::Ordering::SeqCst),
+        "loser's BEGIN IMMEDIATE must block across the winner's held write lock"
     );
 
     let conn = Connection::open(&path).expect("reopen");

--- a/crates/khive-db/src/migrations_tests.rs
+++ b/crates/khive-db/src/migrations_tests.rs
@@ -661,3 +661,52 @@ fn v10_content_ref_defaults_null_and_accepts_a_value() {
         .expect("read content_ref");
     assert_eq!(stored_ref, Some(digest));
 }
+
+#[test]
+fn read_schema_version_missing_ledger_is_zero() {
+    let conn = open_memory();
+    assert_eq!(
+        read_schema_version(&conn).expect("absent ledger is not an error"),
+        0
+    );
+}
+
+// khive#1212: two processes booting the same database file must both complete
+// migrations — the IMMEDIATE transaction serializes them and the under-lock
+// re-check makes the loser converge instead of failing on already-applied DDL.
+#[test]
+fn concurrent_boots_converge() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = dir.path().join("concurrent-boot.db");
+
+    let handles: Vec<_> = (0..2)
+        .map(|_| {
+            let path = path.clone();
+            std::thread::spawn(move || {
+                let mut conn = Connection::open(&path).expect("open");
+                run_migrations(&mut conn)
+            })
+        })
+        .collect();
+
+    let latest = MIGRATIONS.last().expect("at least one migration").version;
+    for handle in handles {
+        let version = handle
+            .join()
+            .expect("thread join")
+            .expect("both concurrent boots must succeed");
+        assert_eq!(version, latest);
+    }
+
+    let conn = Connection::open(&path).expect("reopen");
+    let rows: u32 = conn
+        .query_row("SELECT COUNT(*) FROM _schema_migrations", [], |row| {
+            row.get(0)
+        })
+        .expect("count ledger rows");
+    assert_eq!(
+        rows as usize,
+        MIGRATIONS.len(),
+        "exactly one ledger row per migration"
+    );
+}


### PR DESCRIPTION
Closes #1212.

Three defects in the migration boot path, all confirmed at source and all in the path a multi-instance deployment hits on first boot:

1. **DEFERRED migration transactions** — the only write path in the crate not using BEGIN IMMEDIATE. Two processes booting the same database file could both pass the version pre-check and then race the lock upgrade mid-migration. Now `transaction_with_behavior(Immediate)` with an under-lock re-check (`SELECT EXISTS ... WHERE version = ?`) so the process that loses the race converges — it never re-runs already-applied DDL — plus `ON CONFLICT(version) DO NOTHING` on the ledger insert as a backstop (the version column is the primary key).

2. **`read_schema_version` swallowed errors** — `unwrap_or(0)` collapsed BUSY/IO failures into "version 0", misreporting a live, fully-migrated database as un-migrated. It now returns `Result<u32, SqliteError>` and treats only the missing-ledger case (`no such table: _schema_migrations`) as version 0. Sole caller (`inspect_schema_version`) updated; the exported signature change is source-compatible with all in-workspace consumers (verified by workspace check).

3. **No busy_timeout for the migration run** — the pool default (200ms) is tuned for hot-path queries and cannot wait out a sibling process's migration. `run_migrations` now raises it to 5s for the run and restores the caller's prior value after, success or failure.

## Tests

New: `concurrent_boots_converge` (two threads, one database file, both `run_migrations` calls must succeed, exactly one ledger row per migration) and `read_schema_version_missing_ledger_is_zero`. Full `khive-db` suite (478), `khive-runtime` suite, workspace check, clippy `-D warnings`, and fmt all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)