### PR TITLE
docs(adr): ADR-027 Amendment 3 — config-file pack selection + licensed-pack manifest constraint

### DIFF
--- a/docs/adr/ADR-027-dynamic-pack-loading.md
+++ b/docs/adr/ADR-027-dynamic-pack-loading.md
@@ -466,13 +466,18 @@ set, and lower layers are ignored. An empty value at any layer (`--pack` with no
 names, an empty `KHIVE_PACKS`, `runtime.packs = []`) is treated as absent and falls
 through to the next layer — matching the existing environment-variable behavior.
 
+The built-in default is `["kg"]`, matching the single-pack open-source surface
+(ADR-023 amendment) and the runtime's default configuration. Amendment 2's
+eleven-pack default described the pre-split distribution and is superseded on this
+point by the ADR-023 amendment and this amendment.
+
 For this option the environment outranks discovered configuration, deviating from the
 general ADR-035 rule (config over env). Pack selection is deployment topology: a
 single host legitimately runs processes with different surfaces, and a per-process
 override must not require editing a shared file. ADR-035's option table is updated by
 this amendment to reflect the deviation.
 
-**3. The manifest is a constraint, not a precedence layer.** An optional key:
+**3. The manifest is a constraint, not a precedence layer.** A configuration key:
 
 ```toml
 [runtime]
@@ -488,22 +493,61 @@ configuration-only — there is no CLI flag or environment variable for it; lice
 deployments have configuration files, and a constraint that could be repointed
 per-process would not be one.
 
-**4. Fail-closed, loudly.** Each of the following is a hard boot error, never a
-silent narrowing of the loaded set:
+The manifest is not optional for the deployments it exists to bound. Pack metadata
+(the `Pack` trait's static declaration, ADR-017) carries a licensing classification:
+`open` or `licensed`. Every pack in the open-source distribution is `open`;
+commercially licensed extensions declare `licensed`. Whenever the resolved requested
+set contains a `licensed` pack, a verified manifest covering it is required — a
+missing `pack_manifest` key in that case is itself a hard boot error, identical in
+consequence to a manifest that fails verification. Deployments whose resolved set is
+entirely `open` packs load without any manifest processing.
+
+**4. The verification contract.** The open-source runtime defines an opaque verifier
+interface and consumes only its result; it embeds no entitlement logic, key
+material, or signature scheme. The contract:
+
+- **Input**: the manifest bytes read from the configured `pack_manifest` path.
+- **Output**: either a normalized allow list — a set of canonical pack names plus an
+  expiry instant — or a typed verification error.
+- **Expiry**: boot compares the returned expiry instant against the system UTC clock
+  once, at boot; an expired manifest is a verification failure. In-flight behavior
+  after boot is out of scope for this ADR.
+- **Registration**: verifier implementations are supplied by the commercially
+  licensed distribution and register through the same self-registration mechanism as
+  packs (Amendment 1). If a `licensed` pack is requested and no verifier is
+  registered, boot fails — an unverifiable manifest and an absent verifier are the
+  same condition.
+
+Manifest issuance, the signature scheme, trust-root and key lifecycle, renewal, and
+entitlement semantics are the licensing system's contract: the commercially licensed
+distribution's documentation is the authoritative source for them, and its verifier
+implementation is the trust-root handoff. This ADR fixes only the interface above
+and the subset rule.
+
+**5. Fail-closed, loudly.** Each of the following is a hard boot error, never a
+silent narrowing of the loaded set. The error names the failing condition (which
+pack, which rule) without reproducing manifest contents:
 
 - a requested pack the binary does not carry (existing behavior, unchanged);
 - a requested pack outside the manifest's allow list;
-- a manifest that is named but missing, unreadable, expired, or fails verification.
+- a `licensed` pack requested with no `pack_manifest` configured;
+- a manifest that is named but missing, unreadable, expired, or fails verification;
+- a `licensed` pack requested with no verifier registered.
 
-**5. Introspection names the source.** `kkernel pack list --loaded` and the `verbs()`
+**6. Introspection names the source.** `kkernel pack list --loaded` and the `verbs()`
 verb report which layer supplied the resolved set (CLI, environment, configuration,
 or default) alongside the set itself, so a mis-threaded deployment is diagnosable
 from the surface it exposes.
 
-Manifest issuance, signature scheme, renewal, and entitlement semantics are the
-licensing system's contract and live with the commercial distribution's
-documentation, not in this ADR; the open-source runtime defines only the
-verification hook and the subset rule.
+**Scope of the manifest constraint.** The manifest bounds deployments where the
+operator runs their own binary: desktop application installs and self-hosted or
+single-tenant deployments. A shared hosted multi-tenant service is not a manifest
+consumer — it loads its full pack surface at boot and enforces per-caller
+entitlement at its own request-authorization gate, which checks each dispatched
+verb's owning pack against the caller's entitlements and rejects unauthorized calls
+with an error. Boot-time selection and request-time authorization are complementary
+enforcement points, not alternatives: each applies to the deployment shape where the
+trust boundary actually sits.
 
 ### Alternatives considered
 
@@ -522,7 +566,8 @@ verification hook and the subset rule.
   environment variable becomes an override, not a load-bearing requirement.
 - The commercial licensing boundary gains a runtime enforcement point with
   fail-closed semantics, without the open-source runtime embedding any entitlement
-  logic.
+  logic. Pack metadata gains a licensing classification (`open`/`licensed`), an
+  ADR-017 surface addition.
 - One more selection layer to document and test; the resolution order is centralized
   in the runtime configuration loader and reported by introspection.
 

--- a/docs/adr/ADR-027-dynamic-pack-loading.md
+++ b/docs/adr/ADR-027-dynamic-pack-loading.md
@@ -494,13 +494,27 @@ deployments have configuration files, and a constraint that could be repointed
 per-process would not be one.
 
 The manifest is not optional for the deployments it exists to bound. Pack metadata
-(the `Pack` trait's static declaration, ADR-017) carries a licensing classification:
-`open` or `licensed`. Every pack in the open-source distribution is `open`;
-commercially licensed extensions declare `licensed`. Whenever the resolved requested
-set contains a `licensed` pack, a verified manifest covering it is required — a
-missing `pack_manifest` key in that case is itself a hard boot error, identical in
-consequence to a manifest that fails verification. Deployments whose resolved set is
-entirely `open` packs load without any manifest processing.
+carries a licensing classification, `open` or `licensed`, declared in the pack's
+static registration record (the same self-registration inventory entry that carries
+the pack's name, Amendment 1) — it is therefore readable before any pack is
+constructed, and the boot sequence evaluates the manifest rules against the resolved
+requested set strictly before pack construction begins. Every pack in the
+open-source distribution is `open`; commercially licensed extensions declare
+`licensed`. Whenever the resolved requested set contains a `licensed` pack, a
+verified manifest covering it is required — a missing `pack_manifest` key in that
+case is itself a hard boot error, identical in consequence to a manifest that fails
+verification.
+
+The rules compose as follows, in order:
+
+1. If `pack_manifest` is configured, the named manifest is always read and verified
+   — regardless of the resolved set's composition. A named manifest that is missing,
+   unreadable, expired, or fails verification is a hard boot error even when every
+   requested pack is `open`.
+2. If `pack_manifest` is not configured and the resolved set contains a `licensed`
+   pack, boot fails.
+3. If `pack_manifest` is not configured and the resolved set is entirely `open`
+   packs, no manifest processing occurs.
 
 **4. The verification contract.** The open-source runtime defines an opaque verifier
 interface and consumes only its result; it embeds no entitlement logic, key
@@ -514,9 +528,12 @@ material, or signature scheme. The contract:
   after boot is out of scope for this ADR.
 - **Registration**: verifier implementations are supplied by the commercially
   licensed distribution and register through the same self-registration mechanism as
-  packs (Amendment 1). If a `licensed` pack is requested and no verifier is
-  registered, boot fails — an unverifiable manifest and an absent verifier are the
-  same condition.
+  packs (Amendment 1). Exactly one verifier may be registered: zero registered
+  verifiers with a `licensed` pack requested is a hard boot error (an unverifiable
+  manifest and an absent verifier are the same condition), and more than one
+  registered verifier is likewise a hard boot error — verification must not depend
+  on registration order or an ambiguous selection among verifiers. Introspection
+  reports the registered verifier's identity alongside the loaded-pack source.
 
 Manifest issuance, the signature scheme, trust-root and key lifecycle, renewal, and
 entitlement semantics are the licensing system's contract: the commercially licensed
@@ -545,7 +562,9 @@ single-tenant deployments. A shared hosted multi-tenant service is not a manifes
 consumer — it loads its full pack surface at boot and enforces per-caller
 entitlement at its own request-authorization gate, which checks each dispatched
 verb's owning pack against the caller's entitlements and rejects unauthorized calls
-with an error. Boot-time selection and request-time authorization are complementary
+with an error. Such a gate must itself be fail-closed for entitlement decisions: a
+verb whose owning pack cannot be determined, or an entitlement lookup that fails for
+infrastructure reasons, is a denial, never a pass-through. Boot-time selection and request-time authorization are complementary
 enforcement points, not alternatives: each applies to the deployment shape where the
 trust boundary actually sits.
 

--- a/docs/adr/ADR-027-dynamic-pack-loading.md
+++ b/docs/adr/ADR-027-dynamic-pack-loading.md
@@ -461,6 +461,11 @@ and plays no role in selection.
 --pack (CLI) > KHIVE_PACKS (env) > runtime.packs (config) > built-in default
 ```
 
+Layers override, never merge: the first present layer supplies the entire resolved
+set, and lower layers are ignored. An empty value at any layer (`--pack` with no
+names, an empty `KHIVE_PACKS`, `runtime.packs = []`) is treated as absent and falls
+through to the next layer — matching the existing environment-variable behavior.
+
 For this option the environment outranks discovered configuration, deviating from the
 general ADR-035 rule (config over env). Pack selection is deployment topology: a
 single host legitimately runs processes with different surfaces, and a per-process
@@ -478,7 +483,10 @@ names an externally-issued, verifiable artifact carrying the set of packs the
 deployment is entitled to load. When present, the _resolved_ requested set — from
 whichever precedence layer supplied it — must be a subset of the manifest's allow
 list. Because the manifest bounds the result rather than participating in precedence,
-no higher-precedence layer can escape it.
+no higher-precedence layer can escape it. `pack_manifest` is deliberately
+configuration-only — there is no CLI flag or environment variable for it; licensed
+deployments have configuration files, and a constraint that could be repointed
+per-process would not be one.
 
 **4. Fail-closed, loudly.** Each of the following is a hard boot error, never a
 silent narrowing of the loaded set:

--- a/docs/adr/ADR-027-dynamic-pack-loading.md
+++ b/docs/adr/ADR-027-dynamic-pack-loading.md
@@ -415,6 +415,109 @@ only the pack count moves from ten to eleven. Every surface that enumerates the 
 list. The force-link discipline of Amendment 1 applies: `workspace` carries a `Cargo.toml`
 dependency and an anchor line in `crates/khive-mcp/src/pack.rs`.
 
+## Amendment 3 (2026-07-21): configuration-file pack selection and the licensed-pack manifest constraint
+
+**Status**: proposed
+
+### Context
+
+Pack selection is specified by this ADR as `--pack` CLI > `KHIVE_PACKS` env > built-in
+default. [ADR-035](ADR-035-cli-config-and-auto-embed.md) additionally lists a
+`runtime.packs` configuration key in its option table, but that key was never
+implemented: the configuration loader parses only `[packs.<name>]` backend assignments
+(ADR-028), and the runtime resolves the loaded set from the environment alone.
+
+Environment-only selection makes the loaded pack set a property of each spawning
+process's environment. Every spawn path — interactive shells, service managers,
+supervisor-launched helpers, a daemon auto-spawned by its first client — must
+independently carry the same variable, and a path that misses it silently boots a
+different surface. Operating the current distribution surfaced this as a recurring
+failure class: service managers do not read shell profiles, and long-lived processes
+re-spawned after a host restart inherit whatever environment their launcher happened
+to have. A declaration in discovered configuration removes the per-spawn-path
+threading entirely.
+
+Separately, commercially licensed pack extensions (see the ADR-023 amendment on the
+single-pack open-source surface) need a way for a deployment to be bounded to the
+packs it is licensed to load, issued and verified outside the binary's own
+configuration.
+
+### Decision
+
+**1. `runtime.packs` in discovered configuration.** The discovered `khive.toml` gains
+the selection key ADR-035 already lists:
+
+```toml
+[runtime]
+packs = ["kg", "gtd", "memory"]
+```
+
+This is distinct from `[packs.<name>]`, which remains backend assignment (ADR-028)
+and plays no role in selection.
+
+**2. Precedence of the requested set.**
+
+```text
+--pack (CLI) > KHIVE_PACKS (env) > runtime.packs (config) > built-in default
+```
+
+For this option the environment outranks discovered configuration, deviating from the
+general ADR-035 rule (config over env). Pack selection is deployment topology: a
+single host legitimately runs processes with different surfaces, and a per-process
+override must not require editing a shared file. ADR-035's option table is updated by
+this amendment to reflect the deviation.
+
+**3. The manifest is a constraint, not a precedence layer.** An optional key:
+
+```toml
+[runtime]
+pack_manifest = "/path/to/manifest"
+```
+
+names an externally-issued, verifiable artifact carrying the set of packs the
+deployment is entitled to load. When present, the _resolved_ requested set — from
+whichever precedence layer supplied it — must be a subset of the manifest's allow
+list. Because the manifest bounds the result rather than participating in precedence,
+no higher-precedence layer can escape it.
+
+**4. Fail-closed, loudly.** Each of the following is a hard boot error, never a
+silent narrowing of the loaded set:
+
+- a requested pack the binary does not carry (existing behavior, unchanged);
+- a requested pack outside the manifest's allow list;
+- a manifest that is named but missing, unreadable, expired, or fails verification.
+
+**5. Introspection names the source.** `kkernel pack list --loaded` and the `verbs()`
+verb report which layer supplied the resolved set (CLI, environment, configuration,
+or default) alongside the set itself, so a mis-threaded deployment is diagnosable
+from the surface it exposes.
+
+Manifest issuance, signature scheme, renewal, and entitlement semantics are the
+licensing system's contract and live with the commercial distribution's
+documentation, not in this ADR; the open-source runtime defines only the
+verification hook and the subset rule.
+
+### Alternatives considered
+
+- **Keep environment-only selection.** Rejected: the per-spawn-path threading failure
+  class is structural, not a matter of operator discipline.
+- **Configuration over environment (strict ADR-035 ordering).** Rejected: breaks
+  per-process override on multi-surface hosts, and the manifest constraint already
+  removes any security rationale for ordering — no layer ordering can widen the
+  loaded set past the manifest.
+- **Per-deployment binaries with only licensed packs compiled in.** Rejected: a
+  build-matrix explosion, and contradicts this ADR's single-binary, linked-set model.
+
+### Consequences
+
+- Fleet and service-manager deployments declare packs once in configuration; the
+  environment variable becomes an override, not a load-bearing requirement.
+- The commercial licensing boundary gains a runtime enforcement point with
+  fail-closed semantics, without the open-source runtime embedding any entitlement
+  logic.
+- One more selection layer to document and test; the resolution order is centralized
+  in the runtime configuration loader and reported by introspection.
+
 ## References
 
 - [ADR-003](ADR-003-system-architecture.md) — `kkernel` binary; `pack list` introspection

--- a/docs/adr/ADR-035-cli-config-and-auto-embed.md
+++ b/docs/adr/ADR-035-cli-config-and-auto-embed.md
@@ -146,6 +146,11 @@ A `KHIVE_*` env var is only a fallback default — when a TOML key resolves at e
 wins over the env var. This matches the runtime config loader (`engine_config.rs`) and the
 config docs (`docs/khive-config-example.toml`).
 
+Exception: **Loaded packs** resolves as `--pack` > `KHIVE_PACKS` > `runtime.packs` >
+default — the environment outranks configuration for this option. Rationale and the
+licensed-pack manifest constraint that bounds the resolved set:
+[ADR-027 Amendment 3](ADR-027-dynamic-pack-loading.md).
+
 | Option             | CLI flag          | Env var                  | Config key                | Default           |
 | ------------------ | ----------------- | ------------------------ | ------------------------- | ----------------- |
 | Namespace          | `--namespace`     | `KHIVE_NAMESPACE`        | `runtime.namespace`       | `default`         |


### PR DESCRIPTION
Spec half of #1211. Docs-only.

Three decisions:

1. **`runtime.packs` in discovered configuration** — the selection key ADR-035's option table already listed but which was never implemented (the loader parses only `[packs.<name>]` backend assignment per ADR-028). Selection today is env-only, which makes the loaded surface a property of each spawn path's environment; service managers don't read shell profiles and post-restart respawns inherit stale environments, a recurring operational failure class.

2. **Precedence** — `--pack` > `KHIVE_PACKS` > `runtime.packs` > built-in default. Documented deviation from ADR-035's general config-over-env rule (pack selection is deployment topology; per-process override must not require editing a shared file); ADR-035's table gains the exception note in this PR.

3. **Manifest as constraint, not precedence layer** — optional `runtime.pack_manifest` names an externally-issued verifiable artifact bounding what the deployment may load. The resolved set from any precedence layer must be a subset; violations, unknown packs, and missing/expired/unverifiable manifests are hard boot errors (fail-closed, never silent narrowing). Issuance/signature/renewal semantics live with the commercial distribution's licensing documentation, not this ADR.

Plus: introspection (`pack list --loaded`, `verbs()`) reports which layer supplied the resolved set.

Implementation lands separately after acceptance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)