### PR TITLE
fix(runtime): additional embedding models add to the built-in primary on the env-only path

### DIFF
--- a/crates/khive-runtime/src/engine_config.rs
+++ b/crates/khive-runtime/src/engine_config.rs
@@ -781,7 +781,11 @@ impl KhiveConfig {
 /// operators to migrate to `~/.khive/config.toml`.
 ///
 /// The primary model (`KHIVE_EMBEDDING_MODEL`) becomes the `default = true`
-/// engine; additional models become non-default secondary engines.
+/// engine; additional models become non-default secondary engines. When only
+/// `KHIVE_ADDITIONAL_EMBEDDING_MODELS` is set, the built-in default model is
+/// synthesized as the primary — the additional list is additive, never a
+/// replacement for the primary (khive#1221; matches `RuntimeConfig::default()`,
+/// which resolves an unset `KHIVE_EMBEDDING_MODEL` to the built-in default).
 pub fn config_from_env() -> KhiveConfig {
     let primary_model = std::env::var("KHIVE_EMBEDDING_MODEL")
         .ok()
@@ -802,19 +806,29 @@ pub fn config_from_env() -> KhiveConfig {
         "using env-var embedding config; consider migrating to .khive/config.toml in your project root"
     );
 
+    config_from_env_parts(primary_model, additional)
+}
+
+/// Pure core of [`config_from_env`], separated so the engine-list derivation
+/// is testable without mutating process-global environment variables.
+fn config_from_env_parts(primary_model: Option<String>, additional: Vec<String>) -> KhiveConfig {
     let mut engines = Vec::new();
 
-    if let Some(model) = primary_model {
-        engines.push(EngineConfig {
-            name: "default".to_string(),
-            model,
-            default: true,
-            fusion_weight: None,
-            dims: None,
-        });
-    }
+    let primary =
+        primary_model.unwrap_or_else(|| lattice_embed::EmbeddingModel::AllMiniLmL6V2.to_string());
+    engines.push(EngineConfig {
+        name: "default".to_string(),
+        model: primary.clone(),
+        default: true,
+        fusion_weight: None,
+        dims: None,
+    });
 
     for (i, model) in additional.into_iter().enumerate() {
+        // The additional list restating the primary is a no-op, not a second engine.
+        if model.eq_ignore_ascii_case(&primary) {
+            continue;
+        }
         engines.push(EngineConfig {
             name: format!("engine-{}", i + 1),
             model,
@@ -822,12 +836,6 @@ pub fn config_from_env() -> KhiveConfig {
             fusion_weight: None,
             dims: None,
         });
-    }
-
-    // If no primary was specified but there are additional models, promote the
-    // first additional model as the default so the list stays valid.
-    if !engines.is_empty() && !engines.iter().any(|e| e.default) {
-        engines[0].default = true;
     }
 
     KhiveConfig {
@@ -848,6 +856,45 @@ mod tests {
         let path = dir.path().join("config.toml");
         std::fs::write(&path, content).unwrap();
         path
+    }
+
+    // khive#1221: with no primary set, the additional list must ADD to the
+    // built-in default primary, never replace it.
+    #[test]
+    fn env_additional_only_keeps_builtin_primary() {
+        let cfg = super::config_from_env_parts(
+            None,
+            vec!["paraphrase-multilingual-minilm-l12-v2".to_string()],
+        );
+        assert_eq!(cfg.engines.len(), 2);
+        let default_engine = cfg.default_engine().expect("a default engine");
+        assert_eq!(default_engine.model, "all-minilm-l6-v2");
+        assert!(
+            cfg.engines
+                .iter()
+                .any(|e| !e.default && e.model == "paraphrase-multilingual-minilm-l12-v2"),
+            "additional model must be a non-default secondary engine"
+        );
+    }
+
+    #[test]
+    fn env_explicit_primary_stays_primary() {
+        let cfg = super::config_from_env_parts(
+            Some("paraphrase-multilingual-minilm-l12-v2".to_string()),
+            vec![],
+        );
+        assert_eq!(cfg.engines.len(), 1);
+        assert_eq!(
+            cfg.default_engine().expect("default").model,
+            "paraphrase-multilingual-minilm-l12-v2"
+        );
+    }
+
+    #[test]
+    fn env_additional_restating_primary_is_deduped() {
+        let cfg = super::config_from_env_parts(None, vec!["all-minilm-l6-v2".to_string()]);
+        assert_eq!(cfg.engines.len(), 1);
+        assert!(cfg.engines[0].default);
     }
 
     #[test]


### PR DESCRIPTION
Closes #1221.

On the env-only path (no discovered config), `config_from_env` synthesized an engine list from `KHIVE_ADDITIONAL_EMBEDDING_MODELS` alone and promoted the first additional model to `default = true`, silently REPLACING the built-in primary `all-MiniLM-L6-v2` — contradicting the field's documented additive contract and `RuntimeConfig::default()`, which resolves an unset `KHIVE_EMBEDDING_MODEL` to the built-in default. Field evidence in #1221: a fresh DB with only the additional var set registered exactly one model (`_embedding_models` = 1 row, only `vec_paraphrase_*` tables, no `vec_all_minilm_*`).

The env path now always synthesizes the default-primary engine (explicit env value, or the built-in default when unset) and appends additional models as non-default secondaries, deduping a restated primary. The engine-list derivation moves into a pure `config_from_env_parts` helper so regression tests avoid process-global env mutation.

Tests: three new regression tests (`env_additional_only_keeps_builtin_primary`, `env_explicit_primary_stays_primary`, `env_additional_restating_primary_is_deduped`); `cargo test -p khive-runtime` (917 tests) and `-p khive-mcp` serve/resolution suites green; clippy clean.

Config-file deployments (`[[engines]]`) are unaffected — config overrides env with an explicit WARN.

🤖 Generated with [Claude Code](https://claude.com/claude-code)