### PR TITLE
docs: remove dead security-record citations from the gate surface

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -553,8 +553,8 @@ default. It is attribution, not isolation: queryable and filterable as a data co
 storage boundary.
 
 By-ID operations (`get`, `update`, `delete`, `merge`) are namespace-agnostic. They resolve the
-globally-unique UUID with no namespace check at any layer. Authorization is enforced at the Gate
-(ADR-018), not in storage or by-ID post-fetch checks.
+globally-unique UUID with no namespace check at any layer. Authorization is enforced at the Gate,
+not in storage or by-ID post-fetch checks.
 
 Multi-record operations (`list`, `search`, `recall`, `neighbors`, `traverse`, `query`) default to
 `WHERE namespace='local'`. The only way to target a different namespace is an explicit `namespace=`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -263,7 +263,7 @@ NOT abort the batch — each entry has its own ok/error. The aggregate response 
   caller_namespace` check exists at the store, runtime, or handler layer. This was the
   prior v1 behavior; it was removed by PR-A1 (commit 2607e263) and is no longer correct.
   Do not add such checks.
-- **Authorization lives at one seam: the Gate** (ADR-018). Storage stores are ID-only. The
+- **Authorization lives at one seam: the Gate.** Storage stores are ID-only. The
   Gate is the trust boundary.
 - **Multi-record ops default to `WHERE namespace='local'`**; the only escape is an explicit
   `namespace=` parameter from the caller.

--- a/cli/kg/init.ts
+++ b/cli/kg/init.ts
@@ -33,7 +33,6 @@ import {
 const DEFAULT_CONFIG_TOML = `\
 # .khive/config.toml — project KG configuration
 # Committed to git. All collaborators use these settings.
-# See: https://github.com/ohdearquant/khive/blob/main/docs/adr/ADR-035-cli-config-and-auto-embed.md
 
 [embed]
 model = "mE5-small"

--- a/crates/khive-gate-rego/README.md
+++ b/crates/khive-gate-rego/README.md
@@ -5,7 +5,7 @@ Agent) backend for [`khive-gate`](https://crates.io/crates/khive-gate)'s `Gate` 
 powered by [`regorus`](https://crates.io/crates/regorus).
 
 This is the **reference policy backend** for khive's authorization gate
-(ADR-018).
+(the authorization-gate design record).
 It is opt-in: a deployment that wants Rego-based authorization adds this crate as a
 dependency and installs a `RegoGate` as the runtime gate. Consumers that do not need
 Rego (e.g. the personal-local OSS binary, which runs the permissive `AllowAllGate`
@@ -94,7 +94,7 @@ Load every `*.rego` file under a directory (non-recursive, deterministic order) 
 
 ## Semantics
 
-Per ADR-018:
+Per the authorization-gate design record:
 
 - **`Deny` is authoritative.** A `Deny` decision aborts dispatch with
   `RuntimeError::PermissionDenied`.
@@ -107,7 +107,7 @@ Per ADR-018:
   fails to serialize, or the result is not a `GateDecision` shape — the gate converts
   it to an explicit `Ok(GateDecision::Deny)` with a diagnostic reason. Only failures
   before evaluation (e.g. request serialization, `GateError::Internal`) surface as
-  `Err(GateError)`, which the runtime treats as an infrastructure failure per ADR-018.
+  `Err(GateError)`, which the runtime treats as an infrastructure failure by contract.
   Declaring a `default decision := {deny ...}` is still good practice so unmatched
   requests deny with a policy-authored reason instead of the generic fail-closed one.
 

--- a/crates/khive-gate-rego/docs/api/policy-contract.md
+++ b/crates/khive-gate-rego/docs/api/policy-contract.md
@@ -74,7 +74,7 @@ assert!(gate.check(&req).unwrap().is_allow());
 
 ## Evaluation failures and fail-closed behavior
 
-Per ADR-018, a `GateError` returned from `Gate::check` is treated as a fail-open infrastructure
+By the authorization-gate contract, a `GateError` returned from `Gate::check` is treated as a fail-open infrastructure
 failure by the dispatcher. `RegoGate` therefore converts policy evaluation uncertainty into an
 explicit `Ok(GateDecision::Deny)`:
 

--- a/crates/khive-gate-rego/docs/design.md
+++ b/crates/khive-gate-rego/docs/design.md
@@ -2,14 +2,14 @@
 
 ## ADR Compliance
 
-### ADR-018: Authorization Gate
+### Authorization gate
 
-This crate is the reference Rego backend for the khive authorization gate defined in ADR-018.
+This crate is the reference Rego backend for the khive authorization gate design record.
 
 Key design decisions and constraints:
 
 - **Fail-open on dispatch errors.** When `Gate::check` returns `Err(GateError)`, the runtime
-  treats it as an infrastructure failure, logs a warning, and proceeds. This is the ADR-018
+  treats it as an infrastructure failure, logs a warning, and proceeds. This is the gate contract's
   "fail-open on gate Err" behavior. To prevent unintended access, always declare a
   `default decision := {"decision": "deny", ...}` so unmatched requests deny explicitly
   rather than relying on the fail-open path.
@@ -32,9 +32,6 @@ Key design decisions and constraints:
 
 ## Consistency Notes
 
-- The `README.md` and `docs/api/policy-contract.md` retain ADR-018 cross-references for external readers
-  navigating from documentation to the authoritative design record. Only the `.rs` source files
-  have had ADR citations removed.
 - The fail-open behavior described here matches the production runtime behavior in
   `khive-runtime`. Any change to the gate error handling policy must be coordinated with
   the runtime gate dispatch path.

--- a/crates/khive-gate/README.md
+++ b/crates/khive-gate/README.md
@@ -43,7 +43,7 @@ are both non-zero.
 - `AuditEvent::from_check` builds the structured audit record (`actor`, `namespace`,
   `verb`, `decision`, `obligations`, `gate_impl`, `session_id`) emitted once per gate
   consultation. Its JSON projection is a stable public contract — field names don't
-  change without a new ADR.
+  change without a design-record amendment.
 - All wire types (`ActorRef`, `GateRequest`, `GateDecision`, `Obligation`) validate
   their invariants both at construction (`try_new` / `try_*` constructors) and at
   deserialization (custom `Deserialize` via a private `TryFrom<Raw*>` shape), so a
@@ -60,8 +60,6 @@ dependency on any other khive crate beyond `khive-types`.
 - [`khive-gate-rego`](https://crates.io/crates/khive-gate-rego) (BUSL-1.1) — the OSS
   reference [Rego](https://www.openpolicyagent.org/) backend (`RegoGate`), installed in
   place of `AllowAllGate` when a deployment needs real policy enforcement.
-
-Governed by ADR-018.
 
 ## License
 

--- a/crates/khive-gate/docs/design.md
+++ b/crates/khive-gate/docs/design.md
@@ -1,17 +1,15 @@
 # khive-gate Design
 
-## ADR Compliance
+## Design contract
 
-### ADR-018: Authorization Gate
+### Authorization gate
 
-Full spec: `ADR-018-authorization-gate` (repo root).
-
-This crate implements the public types and default gate defined by ADR-018:
+This crate implements the public types and default gate defined by the authorization-gate design record:
 
 - **`Gate` trait** — the authorization hook consulted before each verb dispatch.
   The `check` method returns `Ok(GateDecision)` or `Err(GateError)`. A `Deny`
-  decision blocks dispatch; an `Err` (infrastructure failure) is fail-open per
-  the ADR — dispatch proceeds with a tracing warning, no audit event emitted.
+  decision blocks dispatch; an `Err` (infrastructure failure) is fail-open by
+  design — dispatch proceeds with a tracing warning, no audit event emitted.
 
 - **`impl_name()`** — stable string identifier per `Gate` implementation.
   Default returns `std::any::type_name::<Self>()`. Concrete impls override for
@@ -27,7 +25,7 @@ This crate implements the public types and default gate defined by ADR-018:
   The JSON field names (`actor`, `namespace`, `verb`, `decision`, `deny_reason`,
   `obligations`, `gate_impl`, `session_id`, `timestamp`) are a **stable public
   contract**. Adding fields is non-breaking; removing or renaming requires an
-  ADR amendment.
+  design-record amendment.
 
 - **`Obligation::Custom { value }`** — the struct-like variant (with named field
   `value`) is mandatory. A newtype variant cannot merge serde's internally-tagged
@@ -38,7 +36,7 @@ This crate implements the public types and default gate defined by ADR-018:
   `input.verb`, `input.args`) are the policy input contract (e.g., for Rego). Any
   field rename is a breaking change.
 
-### Namespace (ADR-007)
+### Namespace (attribution-only)
 
 `GateRequest.namespace` must reflect exactly what the runtime sees, with no coercion
 at the gate layer. Coercing an empty namespace to a default inside the gate would
@@ -49,7 +47,7 @@ the same logic.
 
 - **`Obligation::RateLimit` and `Custom` are declared but not enforced in v0.**
   Policy authors can return these obligations; the runtime records them in the audit
-  event but does not enforce rate limits or custom semantics. A future ADR adds
+  event but does not enforce rate limits or custom semantics. A future design record adds
   per-actor rate-limit enforcement.
 
 - **`AuditEvent` obligations field always serializes** (even as `[]` on Deny) so

--- a/crates/khive-gate/docs/gate.md
+++ b/crates/khive-gate/docs/gate.md
@@ -1,7 +1,5 @@
 # khive-gate
 
-**ADR:** ADR-018 Authorization Gate
-
 Pluggable authorization gate for verb dispatch in the khive runtime.
 
 ## Purpose
@@ -30,11 +28,11 @@ Tagged by `"decision"` field: `"allow"` or `"deny"`.
 - `Allow` carries an optional `obligations` array.
 - `Deny` carries a `reason` string.
 
-### `AuditEvent` (ADR-018 audit record)
+### `AuditEvent` (audit record)
 
 Emitted once per gate consultation. Fields include `actor`, `namespace`, `verb`,
 `decision`, `deny_reason`, `obligations`, `gate_impl`, `session_id`, and `timestamp`.
-Field names are a **stable public contract** — renaming requires a new ADR.
+Field names are a **stable public contract** — renaming requires a design-record amendment.
 
 ## Quick start
 
@@ -87,10 +85,10 @@ An `Allow` decision may carry obligations the dispatch layer should honour:
 
 ## Known gate implementations
 
-| Crate             | License    | Description                               |
-| ----------------- | ---------- | ----------------------------------------- |
+| Crate             | License  | Description                               |
+| ----------------- | -------- | ----------------------------------------- |
 | `khive-gate`      | BUSL-1.1 | `AllowAllGate` — permissive local default |
-| `khive-gate-rego` | BUSL-1.1 | Rego-backed via `regorus` (ADR-018)       |
+| `khive-gate-rego` | BUSL-1.1 | Rego-backed via `regorus`                 |
 
 Deployments with multi-actor isolation requirements may supply a custom `Gate` implementation
 behind the `Gate` trait without modifying this crate.

--- a/crates/khive-mcp/docs/design.md
+++ b/crates/khive-mcp/docs/design.md
@@ -51,7 +51,7 @@ decisions and rationale.
 - `call_register_embedders` is invoked after registry construction, before any
   verb dispatch, to wire custom embedding providers from each pack.
 
-### Authorization Gate and Audit Persistence (ADR-018)
+### Authorization Gate and Audit Persistence
 
 - The authorization gate from `runtime.config().gate` is threaded into the
   registry. Gate decisions are hard-enforcing — a `Deny` result blocks pack

--- a/crates/khive-mcp/src/serve.rs
+++ b/crates/khive-mcp/src/serve.rs
@@ -1554,7 +1554,7 @@ brain_profile = "unrelated"
     /// Regression for PR #52: project-toml brain_profile
     /// MUST win over KHIVE_BRAIN_PROFILE env var.
     ///
-    /// Merged ADR-035 §Precedence: CLI > project toml > global toml > env > default.
+    /// Merged config precedence: CLI > project toml > global toml > env > default.
     /// Before the fix, the env var was bound into the clap `brain_profile` arg and
     /// placed at tier-1 via RuntimeConfig::default() in the base_config spread,
     /// causing env to override TOML.

--- a/crates/khive-runtime/README.md
+++ b/crates/khive-runtime/README.md
@@ -110,8 +110,7 @@ dynamic pack loading via self-registration
 (ADR-027),
 pack-scoped backends and per-pack schema
 (ADR-028),
-and the authorization gate
-(ADR-018).
+and the authorization gate.
 
 ## License
 

--- a/crates/khive-runtime/docs/design.md
+++ b/crates/khive-runtime/docs/design.md
@@ -77,7 +77,7 @@
 - Boot-time collision: two packs declaring the same public verb name produce `RuntimeError::VerbCollision`
 - Pack-auxiliary schema plans are collected from all registered packs and applied at startup
 
-### ADR-018: Authorization Gate
+### Authorization gate
 
 - Gate is consulted before every verb dispatch; gate infrastructure failures are fail-open
 - `GateDecision::Deny` is hard enforcement: the pack is never invoked on denial

--- a/crates/khive-runtime/docs/protocol.md
+++ b/crates/khive-runtime/docs/protocol.md
@@ -63,7 +63,7 @@ For subhandlers, the envelope additionally carries `"visibility": "internal"` an
 ## Invariants
 
 - One pack per verb at boot: duplicate verb names across packs produce `RuntimeError::VerbCollision`.
-- Gate is consulted before every dispatch. Gate infrastructure errors are fail-open (ADR-018).
+- Gate is consulted before every dispatch. Gate infrastructure errors are fail-open by design.
 - Namespace is attribution and gate-policy input (ADR-007 Rev 6, ADR-050): it is minted into
   the dispatch `NamespaceToken`'s read/write scope, not re-checked per record. By-ID
   operations (get, delete, update) resolve globally unique UUIDs without a namespace
@@ -71,16 +71,16 @@ For subhandlers, the envelope additionally carries `"visibility": "internal"` an
   namespace match.
 - A present but non-string `namespace` request param (`null`, number, boolean, array,
   object) is rejected with `RuntimeError::InvalidInput` before the gate is consulted —
-  it is never coerced to the default namespace (RUNTIME-AUD-002 / #433, ADR-018 fail-closed).
+  it is never coerced to the default namespace (RUNTIME-AUD-002 / #433 fail-closed contract).
 
 ## Failure Modes
 
-| Condition                        | Error                                              |
-| --------------------------------- | --------------------------------------------------- |
-| Unknown verb                      | `RuntimeError::InvalidInput("unknown verb ...")`   |
-| Gate deny                         | `RuntimeError::PermissionDenied { verb, reason }`  |
-| Pack not loaded                   | `RuntimeError::InvalidInput` (unknown verb path)   |
-| Malformed explicit namespace      | `RuntimeError::InvalidInput` (non-string `namespace`, rejected before gate) |
+| Condition                    | Error                                                                       |
+| ---------------------------- | --------------------------------------------------------------------------- |
+| Unknown verb                 | `RuntimeError::InvalidInput("unknown verb ...")`                            |
+| Gate deny                    | `RuntimeError::PermissionDenied { verb, reason }`                           |
+| Pack not loaded              | `RuntimeError::InvalidInput` (unknown verb path)                            |
+| Malformed explicit namespace | `RuntimeError::InvalidInput` (non-string `namespace`, rejected before gate) |
 
 `RuntimeError::NamespaceMismatch` is a historical/rejected variant from a pre-Rev-6
 design where by-ID lookups compared `record.namespace == caller_namespace`; it is not

--- a/crates/khive-runtime/src/config.rs
+++ b/crates/khive-runtime/src/config.rs
@@ -226,9 +226,9 @@ pub struct RuntimeConfig {
     /// Single-backend deployments use the default `BackendId::MAIN`.
     pub backend_id: BackendId,
     /// Brain profile to use for `memory.feedback` / `knowledge.feedback` and
-    /// recall-time score boosting (ADR-035 §Brain profile configuration).
+    /// recall-time score boosting (brain profile configuration).
     ///
-    /// Resolution order (highest to lowest, ADR-035): CLI flag, then
+    /// Resolution order (highest to lowest): CLI flag, then
     /// `runtime.brain_profile` in project/global `khive.toml`, then the
     /// `KHIVE_BRAIN_PROFILE` env var as fallback default. Callers must keep
     /// env OUT of the base config they pass in (see `khive-mcp` serve.rs).

--- a/crates/khive-runtime/src/engine_config.rs
+++ b/crates/khive-runtime/src/engine_config.rs
@@ -409,7 +409,7 @@ pub struct KhiveConfig {
 #[derive(Debug, Clone, Deserialize, Default)]
 pub struct RuntimeSectionConfig {
     /// Brain profile ID to use for `memory.feedback` / `knowledge.feedback`
-    /// and recall-time score boosting (ADR-035 §Brain profile configuration).
+    /// and recall-time score boosting (brain profile configuration).
     ///
     /// Mirrors `--brain-profile` / `KHIVE_BRAIN_PROFILE`. When absent, the
     /// namespace-bound profile (via `brain.resolve`) is tried, then the

--- a/docs/_templates/crate-README.md
+++ b/docs/_templates/crate-README.md
@@ -46,8 +46,7 @@
 
        types -> score -> storage -> db -> query -> runtime -> pack-* -> mcp
 
-     Name the crates it builds on and the ones that consume it, and link the
-     governing ADR(s) by full GitHub URL. -->
+     Name the crates it builds on and the ones that consume it. -->
 
 ## License
 

--- a/docs/guide/communication.md
+++ b/docs/guide/communication.md
@@ -283,7 +283,7 @@ boundary (ADR-063). Any process
 with access to the underlying SQLite store can read every message row
 regardless of `to_actor`, and there is no per-principal storage partition on
 the local backend. Where authorization is enforced, it lives at a single
-seam, the Gate (ADR-018), not at the
+seam, the Gate, not at the
 comm pack's inbox filter.
 
 ## See also


### PR DESCRIPTION
## What

Follow-up to #1222. The design-record corpus left the public repo, but several surfaces still cited records that no longer resolve here.

Commit 1 (docs, 14 files):
- `khive-gate` / `khive-gate-rego` / `khive-runtime` / `khive-mcp` docs: reword numbered-record citations to self-contained contract language; drop the dead "full spec (repo root)" pointer
- crate-README template: drop the instruction to link governing records by full GitHub URL
- `CLAUDE.md` / `AGENTS.md` / the communication guide: same treatment for the Gate-seam citations

Commit 2 (user-facing dead link + doc comments, 4 files):
- `cli/kg/init.ts`: the init template stamped every generated project config with a URL to a removed record (now a 404) — line dropped
- `crates/khive-mcp/src/serve.rs`, `crates/khive-runtime/src/config.rs`, `crates/khive-runtime/src/engine_config.rs`: reword the four remaining doc-comment citations to the same removed record

No behavior changes; `cargo check -p khive-runtime -p khive-mcp` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)