### PR TITLE
perf(db): index-seekable both-direction recursive traverse (closes #1229)

### DIFF
--- a/crates/khive-db/src/stores/graph.rs
+++ b/crates/khive-db/src/stores/graph.rs
@@ -995,6 +995,87 @@ fn batch_upsert_edges_guarded(
     })
 }
 
+/// Builds the recursive-member SQL for one chunk of `GraphStore::traverse`'s
+/// recursive CTE. `ns_param`/`depth_param` are the 1-based positional bind
+/// indices for this chunk's `?N` placeholders; `relation_cond`/`weight_cond`
+/// are the (already-indexed) optional filter fragments built by the caller.
+///
+/// `Out`/`In` each emit a single indexed-seek arm. `Both` emits two arms —
+/// one keyed on `e.source_id = t.node_id` (seekable via
+/// `idx_graph_edges_ns_src_rel`), one on `e.target_id = t.node_id` (seekable
+/// via `idx_graph_edges_ns_tgt_rel`) — UNION ALL'd inside the recursive
+/// member, mirroring the pattern already proven correct and fast for
+/// `batch_neighbors` (`build_inner_sql` above). A single
+/// `e.source_id = t.node_id OR e.target_id = t.node_id` predicate cannot be
+/// satisfied by one index seek: SQLite falls back to a full namespace scan
+/// per frontier row, degrading `Direction::Both` traversal from
+/// `O(frontier × avg_degree)` to `O(frontier × total_edges)` (#1229).
+fn traverse_recursive_member_sql(
+    direction: Direction,
+    ns_param: usize,
+    depth_param: usize,
+    relation_cond: &str,
+    weight_cond: &str,
+) -> String {
+    match direction {
+        Direction::Out => format!(
+            "SELECT t.root_id, e.target_id, e.id, t.depth + 1, \
+                 t.path || ',' || e.target_id, t.total_weight + e.weight \
+             FROM traversal t CROSS JOIN graph_edges e \
+                 ON e.source_id = t.node_id \
+             WHERE e.namespace = ?{ns} \
+               AND e.deleted_at IS NULL \
+               AND t.depth < ?{depth} \
+               AND (',' || t.path || ',') NOT LIKE '%,' || e.target_id || ',%'\
+               {rel_cond}{wt_cond}",
+            ns = ns_param,
+            depth = depth_param,
+            rel_cond = relation_cond,
+            wt_cond = weight_cond,
+        ),
+        Direction::In => format!(
+            "SELECT t.root_id, e.source_id, e.id, t.depth + 1, \
+                 t.path || ',' || e.source_id, t.total_weight + e.weight \
+             FROM traversal t CROSS JOIN graph_edges e \
+                 ON e.target_id = t.node_id \
+             WHERE e.namespace = ?{ns} \
+               AND e.deleted_at IS NULL \
+               AND t.depth < ?{depth} \
+               AND (',' || t.path || ',') NOT LIKE '%,' || e.source_id || ',%'\
+               {rel_cond}{wt_cond}",
+            ns = ns_param,
+            depth = depth_param,
+            rel_cond = relation_cond,
+            wt_cond = weight_cond,
+        ),
+        Direction::Both => format!(
+            "SELECT t.root_id, e.target_id, e.id, t.depth + 1, \
+                 t.path || ',' || e.target_id, t.total_weight + e.weight \
+             FROM traversal t CROSS JOIN graph_edges e \
+                 ON e.source_id = t.node_id \
+             WHERE e.namespace = ?{ns} \
+               AND e.deleted_at IS NULL \
+               AND t.depth < ?{depth} \
+               AND (',' || t.path || ',') NOT LIKE '%,' || e.target_id || ',%'\
+               {rel_cond}{wt_cond} \
+             UNION ALL \
+             SELECT t.root_id, e.source_id, e.id, t.depth + 1, \
+                 t.path || ',' || e.source_id, t.total_weight + e.weight \
+             FROM traversal t CROSS JOIN graph_edges e \
+                 ON e.target_id = t.node_id \
+             WHERE e.namespace = ?{ns} \
+               AND e.deleted_at IS NULL \
+               AND t.depth < ?{depth} \
+               AND (',' || t.path || ',') NOT LIKE '%,' || e.source_id || ',%'\
+               {rel_cond}{wt_cond}",
+            ns = ns_param,
+            depth = depth_param,
+            rel_cond = relation_cond,
+            wt_cond = weight_cond,
+        ),
+    }
+}
+
 #[async_trait]
 impl GraphStore for SqlGraphStore {
     async fn upsert_edge(&self, edge: Edge) -> Result<(), StorageError> {
@@ -1819,8 +1900,6 @@ impl GraphStore for SqlGraphStore {
     async fn traverse(&self, request: TraversalRequest) -> Result<Vec<GraphPath>, StorageError> {
         use std::collections::{HashMap, HashSet};
 
-        use khive_storage::types::Direction;
-
         if request.roots.is_empty() {
             return Ok(Vec::new());
         }
@@ -1854,16 +1933,6 @@ impl GraphStore for SqlGraphStore {
             // 400 rows stays safely below both: 400 < 500 (compound) and
             // 400 + fixed << 999 (variables).
             const CHUNK_ROOTS: usize = 400;
-
-            // Determine join direction (invariant across chunks).
-            let (join_condition, next_node) = match opts.direction {
-                Direction::Out => ("e.source_id = t.node_id", "e.target_id"),
-                Direction::In => ("e.target_id = t.node_id", "e.source_id"),
-                Direction::Both => (
-                    "(e.source_id = t.node_id OR e.target_id = t.node_id)",
-                    "CASE WHEN e.source_id = t.node_id THEN e.target_id ELSE e.source_id END",
-                ),
-            };
 
             // Open a deferred read transaction so ALL chunk queries observe the same
             // graph snapshot.  Without this, a writer committing between chunks could
@@ -1951,36 +2020,33 @@ impl GraphStore for SqlGraphStore {
                     .collect();
                 let seeds = seed_rows.join(", ");
 
-                // CTE covering the chunk's roots.  CROSS JOIN forces SQLite to put
-                // the frontier (t) as the outer loop and seek graph_edges by index,
-                // avoiding the O(edges × frontier) plan (#250, #251).
+                // Recursive-member SQL for this chunk.  CROSS JOIN forces SQLite to
+                // put the frontier (t) as the outer loop and seek graph_edges by
+                // index, avoiding the O(edges × frontier) plan (#250, #251).
+                // See `traverse_recursive_member_sql` for why `Both` is split
+                // into two UNION ALL'd arms instead of one OR-predicate arm
+                // (#1229).
+                let recursive_member = traverse_recursive_member_sql(
+                    opts.direction.clone(),
+                    ns_param,
+                    depth_param,
+                    &relation_cond,
+                    &weight_cond,
+                );
+
                 let cte_sql = format!(
                     "WITH RECURSIVE traversal(\
                          root_id, node_id, edge_id, depth, path, total_weight\
                      ) AS (\
                          VALUES {seeds} \
                          UNION ALL \
-                         SELECT t.root_id, {next_node}, e.id, t.depth + 1, \
-                                t.path || ',' || {next_node}, \
-                                t.total_weight + e.weight \
-                         FROM traversal t CROSS JOIN graph_edges e \
-                             ON {join_condition} \
-                         WHERE e.namespace = ?{ns} \
-                           AND e.deleted_at IS NULL \
-                           AND t.depth < ?{depth} \
-                           AND (',' || t.path || ',') NOT LIKE '%,' || {next_node} || ',%'\
-                           {rel_cond}{wt_cond} \
+                         {recursive_member} \
                      ) \
                      SELECT root_id, node_id, edge_id, depth, total_weight \
                      FROM traversal WHERE depth > 0 \
                      ORDER BY root_id, depth",
                     seeds = seeds,
-                    next_node = next_node,
-                    join_condition = join_condition,
-                    ns = ns_param,
-                    depth = depth_param,
-                    rel_cond = relation_cond,
-                    wt_cond = weight_cond,
+                    recursive_member = recursive_member,
                 );
 
                 let mut all_params: Vec<Box<dyn rusqlite::types::ToSql>> = Vec::new();

--- a/crates/khive-db/src/stores/graph_tests.rs
+++ b/crates/khive-db/src/stores/graph_tests.rs
@@ -3228,3 +3228,146 @@ async fn upsert_edge_guarded_probe_is_atomic_with_insert_on_file_backed_singleto
         "no dangling edge may be persisted"
     );
 }
+
+/// khive#1229: `Direction::Both`'s recursive-CTE join predicate used to be a
+/// single `(e.source_id = t.node_id OR e.target_id = t.node_id)` arm, which
+/// SQLite cannot satisfy with one index seek — it falls back to a full
+/// namespace scan of `graph_edges` per frontier row. This asserts the fixed
+/// `traverse_recursive_member_sql` shape plans as two separately-indexed
+/// `SEARCH` operations (one on `idx_graph_edges_ns_src_rel` binding
+/// `source_id=?`, one on `idx_graph_edges_ns_tgt_rel` binding `target_id=?`),
+/// not a scan qualified by `namespace=?` alone.
+#[tokio::test]
+async fn traverse_both_direction_recursive_member_seeks_by_source_and_target_id() {
+    let store = setup_memory_store();
+    // Same schema `traverse()` runs against; EXPLAIN QUERY PLAN doesn't
+    // execute the statement, so no rows need to exist.
+    let seeds = "(?1, ?1, NULL, 0, ?1, 0.0)";
+    let recursive_member = traverse_recursive_member_sql(Direction::Both, 2, 3, "", "");
+    let cte_sql = format!(
+        "WITH RECURSIVE traversal(\
+             root_id, node_id, edge_id, depth, path, total_weight\
+         ) AS (\
+             VALUES {seeds} \
+             UNION ALL \
+             {recursive_member} \
+         ) \
+         SELECT root_id, node_id, edge_id, depth, total_weight \
+         FROM traversal WHERE depth > 0 \
+         ORDER BY root_id, depth",
+        seeds = seeds,
+        recursive_member = recursive_member,
+    );
+
+    let reader = store.pool.reader().unwrap();
+    let plan_sql = format!("EXPLAIN QUERY PLAN {cte_sql}");
+    let mut stmt = reader.conn().prepare(&plan_sql).unwrap();
+    let params: [&str; 3] = ["root", "default", "2"];
+    let details: Vec<String> = stmt
+        .query_map(rusqlite::params_from_iter(params.iter()), |row| row.get(3))
+        .unwrap()
+        .collect::<Result<_, _>>()
+        .unwrap();
+
+    assert!(
+        details
+            .iter()
+            .any(|d| d.contains("idx_graph_edges_ns_src_rel") && d.contains("source_id=?")),
+        "expected an out-arm SEARCH binding source_id=? via idx_graph_edges_ns_src_rel, got: {details:?}"
+    );
+    assert!(
+        details
+            .iter()
+            .any(|d| d.contains("idx_graph_edges_ns_tgt_rel") && d.contains("target_id=?")),
+        "expected an in-arm SEARCH binding target_id=? via idx_graph_edges_ns_tgt_rel, got: {details:?}"
+    );
+    assert!(
+        !details.iter().any(|d| d.contains("SCAN e")),
+        "no arm may fall back to a full graph_edges scan, got: {details:?}"
+    );
+}
+
+/// khive#1229 correctness: a hub node with mixed out- and in-edges to its
+/// spokes, each spoke extending one hop further to its own tail node.
+/// `Direction::Both` at `max_depth=2` from the hub must return every spoke
+/// (reached via whichever direction connects it to the hub) AND every tail
+/// (reached via the spoke's outgoing edge), regardless of which arm of the
+/// recursive member found the spoke. This is the exact shape the OR-predicate
+/// bug silently returned correct results for at small scale but 380x slower
+/// at hub scale — this test locks the result set the perf fix must preserve.
+#[tokio::test]
+async fn traverse_both_direction_hub_depth_two_returns_full_node_set() {
+    let store = setup_memory_store();
+
+    let hub = Uuid::new_v4();
+    let mut expected_depth1 = HashSet::new();
+    let mut expected_depth2 = HashSet::new();
+
+    const SPOKES: usize = 40;
+    for i in 0..SPOKES {
+        let spoke = Uuid::new_v4();
+        let tail = Uuid::new_v4();
+        expected_depth1.insert(spoke);
+        expected_depth2.insert(tail);
+
+        if i % 2 == 0 {
+            // hub --out--> spoke
+            store
+                .upsert_edge(make_edge(hub, spoke, EdgeRelation::Extends, 1.0))
+                .await
+                .unwrap();
+        } else {
+            // spoke --out--> hub (hub reaches it via the in-arm)
+            store
+                .upsert_edge(make_edge(spoke, hub, EdgeRelation::Extends, 1.0))
+                .await
+                .unwrap();
+        }
+        // spoke --out--> tail, reachable regardless of which arm found spoke
+        store
+            .upsert_edge(make_edge(spoke, tail, EdgeRelation::VariantOf, 1.0))
+            .await
+            .unwrap();
+    }
+
+    let paths = store
+        .traverse(TraversalRequest {
+            roots: vec![hub],
+            options: TraversalOptions::new(2).with_direction(Direction::Both),
+            include_roots: false,
+            include_properties: false,
+        })
+        .await
+        .unwrap();
+
+    assert_eq!(paths.len(), 1);
+    let path = &paths[0];
+    assert_eq!(path.root_id, hub);
+
+    let got_depth1: HashSet<Uuid> = path
+        .nodes
+        .iter()
+        .filter(|n| n.depth == 1)
+        .map(|n| n.node_id)
+        .collect();
+    let got_depth2: HashSet<Uuid> = path
+        .nodes
+        .iter()
+        .filter(|n| n.depth == 2)
+        .map(|n| n.node_id)
+        .collect();
+
+    assert_eq!(
+        got_depth1, expected_depth1,
+        "every spoke must be reached at depth 1 regardless of edge direction"
+    );
+    assert_eq!(
+        got_depth2, expected_depth2,
+        "every tail must be reached at depth 2 through its spoke's out-edge"
+    );
+    assert_eq!(
+        path.nodes.len(),
+        expected_depth1.len() + expected_depth2.len(),
+        "no duplicate or spurious nodes"
+    );
+}


### PR DESCRIPTION
## Summary

`GraphStore::traverse`'s recursive CTE builds its per-step join predicate
differently depending on direction. For `Direction::Out`/`Direction::In` this
is a single-column equality (`e.source_id = t.node_id` / `e.target_id =
t.node_id`), which SQLite can satisfy with an index seek. For
`Direction::Both` — the default traversal direction — the predicate was a
single OR-across-columns arm: `(e.source_id = t.node_id OR e.target_id =
t.node_id)`.

SQLite cannot satisfy an OR-across-columns predicate with one index seek.
`EXPLAIN QUERY PLAN` shows the `Both` arm only binding `namespace=?` as an
equality constraint, degrading to a full scan of every edge row in the
namespace, repeated once per node in the recursive frontier —
`O(frontier_size × total_edges)` instead of the intended
`O(frontier_size × avg_degree)`. Measured on a synthetic 8,000-node /
46,000-edge graph with a 1,500-out-edge root (comparable to the reported
issue): `Direction::Out` at depth 2 ran in 0.17s (10,688 rows); the
equivalent `Direction::Both` query ran in 63.1s (19,127 rows) — roughly
380x slower for a comparable row count, purely from the predicate shape.

This is the same bug class #280 already fixed for `Out`/`In` (forcing the
recursive frontier to be the outer loop via `CROSS JOIN` to restore
index-seek behavior), but that fix only helps when the join condition is a
single-column equality — it does nothing for `Both`'s OR predicate, which
was never covered by a perf-scale regression test.

## Fix

Split the `Both` recursive member into two separately-indexable arms —
one keyed on `e.source_id = t.node_id` (seekable via
`idx_graph_edges_ns_src_rel`), one on `e.target_id = t.node_id` (seekable
via `idx_graph_edges_ns_tgt_rel`) — `UNION ALL`'d together inside the
recursive member, instead of one OR-predicate arm. This mirrors the pattern
`batch_neighbors` in the same file already uses correctly for
`Direction::Both`. `Out`/`In` are unchanged. The recursive-member SQL
construction is extracted into a standalone `traverse_recursive_member_sql`
function so its shape is independently testable via `EXPLAIN QUERY PLAN`.
Cycle-guard and per-root dedup logic are unaffected.

## Test plan

- [x] New `EXPLAIN QUERY PLAN` regression test asserting the `Both` recursive
      member plans as two indexed `SEARCH` operations binding
      `source_id=?`/`target_id=?` respectively, not a namespace-only scan.
- [x] New correctness test: a hub node with mixed outgoing/incoming edges to
      40 spokes, each extending one hop further to its own tail node —
      `Direction::Both` at `max_depth=2` returns the full expected node set
      regardless of which arm found each spoke.
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy -p khive-db --all-targets -- -D warnings`
- [x] `cargo test -p khive-db` (468 + 3 + 10 tests, all passing)

Closes #1229