### PR TITLE
feat(kg): warn when a query pattern is impossible under the edge contract

### DIFF
--- a/crates/khive-runtime/src/operations.rs
+++ b/crates/khive-runtime/src/operations.rs
@@ -391,6 +391,13 @@ pub fn accepted_pack_relations_for_entities(
 /// (the exact functions the live validator consults) over the closed kind set,
 /// rather than re-deriving a parallel table — issue #543 precedent, applied to
 /// GQL query-pattern hint derivation (issue #593).
+///
+/// Pack rules are skipped for `crate::pack::SPECIAL_RELATIONS` (supersedes /
+/// supports / refutes): the live validator's special-relation branch
+/// (`validate_edge_relation_endpoints`, this file) resolves those relations
+/// before `pack_rule_allows` is ever reached, so a pack `EDGE_RULES` entry for
+/// one of them is never actually enforced (see `pack.rs`'s
+/// `edge_endpoint_table` doc comment for the authoritative statement of this).
 fn accepted_entity_kind_pairs_for_relation(
     pack_rules: &[EdgeEndpointRule],
     relation: EdgeRelation,
@@ -399,14 +406,15 @@ fn accepted_entity_kind_pairs_for_relation(
     for src in khive_types::EntityKind::ALL {
         for tgt in khive_types::EntityKind::ALL {
             let allowed = base_entity_rule_allows(src.name(), relation, tgt.name())
-                || accepted_pack_relations_for_entities(
-                    pack_rules,
-                    src.name(),
-                    None,
-                    tgt.name(),
-                    None,
-                )
-                .contains(&relation);
+                || (!crate::pack::SPECIAL_RELATIONS.contains(&relation)
+                    && accepted_pack_relations_for_entities(
+                        pack_rules,
+                        src.name(),
+                        None,
+                        tgt.name(),
+                        None,
+                    )
+                    .contains(&relation));
             if allowed {
                 pairs.push((src.name(), tgt.name()));
             }
@@ -425,6 +433,10 @@ fn accepted_entity_kind_pairs_for_relation(
 /// undirected edges, variable-length hops, and note-kind endpoints are left
 /// unchecked, since none of those name a single static triple to test against
 /// the validator (issue #593).
+///
+/// Mirrors the validator's special-relation precedence for `supersedes` /
+/// `supports` / `refutes` (see [`accepted_entity_kind_pairs_for_relation`]):
+/// pack rules never make those triples possible, only the base allowlist does.
 fn static_impossible_edge_pattern_warnings(
     pattern: &khive_query::ast::MatchPattern,
     pack_rules: &[EdgeEndpointRule],
@@ -465,14 +477,15 @@ fn static_impossible_edge_pattern_warnings(
         };
 
         let possible = base_entity_rule_allows(src_kind.name(), relation, tgt_kind.name())
-            || accepted_pack_relations_for_entities(
-                pack_rules,
-                src_kind.name(),
-                src_node.entity_type.as_deref(),
-                tgt_kind.name(),
-                tgt_node.entity_type.as_deref(),
-            )
-            .contains(&relation);
+            || (!crate::pack::SPECIAL_RELATIONS.contains(&relation)
+                && accepted_pack_relations_for_entities(
+                    pack_rules,
+                    src_kind.name(),
+                    src_node.entity_type.as_deref(),
+                    tgt_kind.name(),
+                    tgt_node.entity_type.as_deref(),
+                )
+                .contains(&relation));
         if possible {
             continue;
         }

--- a/crates/khive-runtime/src/operations.rs
+++ b/crates/khive-runtime/src/operations.rs
@@ -383,6 +383,121 @@ pub fn accepted_pack_relations_for_entities(
     relations
 }
 
+/// All `(source_kind, target_kind)` entity-kind pairs — restricted to the closed
+/// 8-kind base [`khive_types::EntityKind`] taxonomy — that accept `relation`
+/// under the composed base allowlist plus pack `EDGE_RULES`.
+///
+/// Reuses [`base_entity_rule_allows`] and [`accepted_pack_relations_for_entities`]
+/// (the exact functions the live validator consults) over the closed kind set,
+/// rather than re-deriving a parallel table — issue #543 precedent, applied to
+/// GQL query-pattern hint derivation (issue #593).
+fn accepted_entity_kind_pairs_for_relation(
+    pack_rules: &[EdgeEndpointRule],
+    relation: EdgeRelation,
+) -> Vec<(&'static str, &'static str)> {
+    let mut pairs = Vec::new();
+    for src in khive_types::EntityKind::ALL {
+        for tgt in khive_types::EntityKind::ALL {
+            let allowed = base_entity_rule_allows(src.name(), relation, tgt.name())
+                || accepted_pack_relations_for_entities(
+                    pack_rules,
+                    src.name(),
+                    None,
+                    tgt.name(),
+                    None,
+                )
+                .contains(&relation);
+            if allowed {
+                pairs.push((src.name(), tgt.name()));
+            }
+        }
+    }
+    pairs
+}
+
+/// Scans a GQL `MATCH` pattern for edges that name an explicit relation and
+/// explicit entity kinds on both endpoints — a single mandatory hop, a fixed
+/// direction — where the `(source_kind, relation, target_kind)` triple can
+/// never match under the composed edge endpoint contract. Returns one warning
+/// per statically-impossible edge.
+///
+/// Deliberately conservative: unlabeled nodes, unlabeled/multi-relation edges,
+/// undirected edges, variable-length hops, and note-kind endpoints are left
+/// unchecked, since none of those name a single static triple to test against
+/// the validator (issue #593).
+fn static_impossible_edge_pattern_warnings(
+    pattern: &khive_query::ast::MatchPattern,
+    pack_rules: &[EdgeEndpointRule],
+) -> Vec<String> {
+    use khive_query::ast::{EdgeDirection, PatternElement};
+
+    let elements = &pattern.elements;
+    let mut warnings = Vec::new();
+
+    for (i, el) in elements.iter().enumerate() {
+        let PatternElement::Edge(edge) = el else {
+            continue;
+        };
+        if edge.relations.len() != 1 || edge.min_hops != 1 || edge.max_hops != 1 {
+            continue;
+        }
+        let (left, right) = match (elements.get(i.wrapping_sub(1)), elements.get(i + 1)) {
+            (Some(PatternElement::Node(l)), Some(PatternElement::Node(r))) => (l, r),
+            _ => continue,
+        };
+        let (src_node, tgt_node) = match edge.direction {
+            EdgeDirection::Out => (left, right),
+            EdgeDirection::In => (right, left),
+            EdgeDirection::Both => continue,
+        };
+        let (Some(src_raw), Some(tgt_raw)) = (src_node.kind.as_deref(), tgt_node.kind.as_deref())
+        else {
+            continue;
+        };
+        let (Ok(src_kind), Ok(tgt_kind)) = (
+            src_raw.parse::<khive_types::EntityKind>(),
+            tgt_raw.parse::<khive_types::EntityKind>(),
+        ) else {
+            continue;
+        };
+        let Ok(relation) = edge.relations[0].parse::<EdgeRelation>() else {
+            continue;
+        };
+
+        let possible = base_entity_rule_allows(src_kind.name(), relation, tgt_kind.name())
+            || accepted_pack_relations_for_entities(
+                pack_rules,
+                src_kind.name(),
+                src_node.entity_type.as_deref(),
+                tgt_kind.name(),
+                tgt_node.entity_type.as_deref(),
+            )
+            .contains(&relation);
+        if possible {
+            continue;
+        }
+
+        let accepted = accepted_entity_kind_pairs_for_relation(pack_rules, relation);
+        let accepted_str = if accepted.is_empty() {
+            "none".to_string()
+        } else {
+            accepted
+                .iter()
+                .map(|(s, t)| format!("{s}->{t}"))
+                .collect::<Vec<_>>()
+                .join(", ")
+        };
+        warnings.push(format!(
+            "pattern ({src})-[:{relation}]->({tgt}) can never match: '{relation}' does not accept \
+             {src}->{tgt} endpoints; accepted source->target kinds for '{relation}': {accepted_str}",
+            src = src_kind.name(),
+            tgt = tgt_kind.name(),
+        ));
+    }
+
+    warnings
+}
+
 /// `true` if any pack-declared edge endpoint rule allows the
 /// `(source, relation, target)` triple. Pack rules are additive only.
 fn pack_rule_allows(
@@ -3864,6 +3979,24 @@ impl KhiveRuntime {
         let compiled = khive_query::compile(&ast, &opts)?;
         let mut warnings = compiled.warnings;
         let truncation_check = compiled.truncation_check;
+
+        // Static schema-mismatch hint (issue #593): GQL-only by design — the
+        // hint is worded around GQL's `(kind)-[:relation]->(kind)` syntax, so
+        // it is scoped out of SPARQL even though SPARQL compiles to the same
+        // `MatchPattern` shape. Dialect is detected the same way `parse_auto`
+        // selects it, since neither the AST nor `CompiledQuery` retains it.
+        let is_sparql = query
+            .trim()
+            .as_bytes()
+            .get(..6)
+            .is_some_and(|p| p.eq_ignore_ascii_case(b"SELECT"));
+        if !is_sparql {
+            let pack_rules = self.pack_edge_rules();
+            warnings.extend(static_impossible_edge_pattern_warnings(
+                &ast.pattern,
+                &pack_rules,
+            ));
+        }
 
         // Convert QueryValue params (query-layer type) to SqlValue (storage-layer type)
         // at the query–storage boundary.

--- a/crates/khive-runtime/src/pack.rs
+++ b/crates/khive-runtime/src/pack.rs
@@ -920,7 +920,7 @@ fn endpoint_kind_label(kind: &EndpointKind) -> String {
 /// any `note -> note` pair unconditionally, regardless of note kind
 /// (ADR-002 §"Versioning" and §"Epistemic"), and never consults pack
 /// `EDGE_RULES` at all, on either substrate.
-const SPECIAL_RELATIONS: &[khive_types::EdgeRelation] = &[
+pub(crate) const SPECIAL_RELATIONS: &[khive_types::EdgeRelation] = &[
     khive_types::EdgeRelation::Supersedes,
     khive_types::EdgeRelation::Supports,
     khive_types::EdgeRelation::Refutes,

--- a/crates/khive-runtime/tests/integration.rs
+++ b/crates/khive-runtime/tests/integration.rs
@@ -865,6 +865,282 @@ async fn query_static_impossible_check_honors_pack_extended_endpoint_rules() {
 }
 
 #[tokio::test]
+async fn link_and_hint_agree_special_relation_pack_rules_never_enforced() {
+    let rt = rt();
+    let tok = rt.authorize(Namespace::local()).unwrap();
+
+    // supersedes is a SPECIAL_RELATIONS entry (pack.rs): the live validator
+    // resolves it in a dedicated branch (operations.rs) that only consults
+    // base_entity_rule_allows, never pack_rule_allows. A pack rule for it must
+    // therefore be inert on both paths: `link` must still reject the pair, and
+    // the GQL static hint must still warn, even with the rule installed.
+    rt.install_edge_rules(vec![khive_types::EdgeEndpointRule {
+        relation: EdgeRelation::Supersedes,
+        source: khive_types::EndpointKind::EntityOfKind("person"),
+        target: khive_types::EndpointKind::EntityOfKind("person"),
+    }]);
+
+    let p1 = rt
+        .create_entity(&tok, "person", None, "Old Ada", None, None, vec![])
+        .await
+        .unwrap();
+    let p2 = rt
+        .create_entity(&tok, "person", None, "New Ada", None, None, vec![])
+        .await
+        .unwrap();
+
+    let link_result = rt
+        .link(&tok, p1.id, p2.id, EdgeRelation::Supersedes, 1.0, None)
+        .await;
+    assert!(
+        link_result.is_err(),
+        "person->person supersedes must be rejected: the special-relation branch \
+         never consults the installed pack rule; got {link_result:?}"
+    );
+
+    let query_result = rt
+        .query_with_metadata(
+            &tok,
+            "MATCH (a:person)-[:supersedes]->(b:person) RETURN a, b LIMIT 10",
+            khive_query::CompileOptions::default(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(
+        query_result.warnings.len(),
+        1,
+        "the hint must agree with the validator and warn even though a pack rule \
+         is installed for this special relation: {:?}",
+        query_result.warnings
+    );
+}
+
+#[tokio::test]
+async fn query_static_possible_pattern_inbound_introduced_by_no_warning() {
+    let rt = rt();
+    let tok = rt.authorize(Namespace::local()).unwrap();
+
+    let doc = rt
+        .create_entity(&tok, "document", None, "Paper", None, None, vec![])
+        .await
+        .unwrap();
+    let author = rt
+        .create_entity(&tok, "person", None, "Author", None, None, vec![])
+        .await
+        .unwrap();
+    rt.link(
+        &tok,
+        doc.id,
+        author.id,
+        EdgeRelation::IntroducedBy,
+        1.0,
+        None,
+    )
+    .await
+    .unwrap();
+
+    // Same (document, introduced_by, person) triple as the base allowlist, but
+    // expressed with an inbound (`<-`) arrow instead of the outbound (`->`)
+    // form used elsewhere: source is the right-hand node (document), target is
+    // the left-hand node (person).
+    let result = rt
+        .query_with_metadata(
+            &tok,
+            "MATCH (p:person)<-[:introduced_by]-(d:document) RETURN d, p LIMIT 10",
+            khive_query::CompileOptions::default(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(result.rows.len(), 1);
+    assert!(
+        result.warnings.is_empty(),
+        "an inbound-arrow pattern naming a valid base-contract triple must not warn: {:?}",
+        result.warnings
+    );
+}
+
+#[tokio::test]
+async fn query_static_possible_pattern_entity_of_type_pack_rule_no_false_warning() {
+    let rt = rt();
+    let tok = rt.authorize(Namespace::local()).unwrap();
+
+    // theorem depends_on definition has no base-contract row (concept->concept
+    // depends_on is not in BASE_ENTITY_ENDPOINT_RULES) — only the installed
+    // EntityOfType pack rule makes it possible.
+    rt.install_edge_rules(vec![khive_types::EdgeEndpointRule {
+        relation: EdgeRelation::DependsOn,
+        source: khive_types::EndpointKind::EntityOfType {
+            kind: "concept",
+            entity_type: "theorem",
+        },
+        target: khive_types::EndpointKind::EntityOfType {
+            kind: "concept",
+            entity_type: "definition",
+        },
+    }]);
+
+    let thm = rt
+        .create_entity(&tok, "concept", Some("theorem"), "T1", None, None, vec![])
+        .await
+        .unwrap();
+    let def = rt
+        .create_entity(
+            &tok,
+            "concept",
+            Some("definition"),
+            "D1",
+            None,
+            None,
+            vec![],
+        )
+        .await
+        .unwrap();
+    rt.link(&tok, thm.id, def.id, EdgeRelation::DependsOn, 1.0, None)
+        .await
+        .unwrap();
+
+    let result = rt
+        .query_with_metadata(
+            &tok,
+            "MATCH (a:concept {entity_type: 'theorem'})-[:depends_on]->\
+             (b:concept {entity_type: 'definition'}) RETURN a, b LIMIT 10",
+            khive_query::CompileOptions::default(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(result.rows.len(), 1);
+    assert!(
+        result.warnings.is_empty(),
+        "the hint must consult the pack's EntityOfType rule (matched against \
+         each node's entity_type, not just its base kind) so this must not be \
+         falsely flagged: {:?}",
+        result.warnings
+    );
+}
+
+#[tokio::test]
+async fn query_static_impossible_chained_pattern_warns_once_per_edge() {
+    let rt = rt();
+    let tok = rt.authorize(Namespace::local()).unwrap();
+
+    // Two chained edges sharing node `b`, both statically impossible
+    // (concept->concept precedes is never in the composed contract). Each
+    // edge is scanned independently, so both must warn.
+    let result = rt
+        .query_with_metadata(
+            &tok,
+            "MATCH (a:concept)-[:precedes]->(b:concept)-[:precedes]->(c:concept) RETURN a, b, c LIMIT 10",
+            khive_query::CompileOptions::default(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(
+        result.warnings.len(),
+        2,
+        "a chained pattern with two statically-impossible edges sharing a node \
+         must warn once per edge: {:?}",
+        result.warnings
+    );
+}
+
+#[tokio::test]
+async fn query_static_impossible_check_skips_multi_relation_edge() {
+    let rt = rt();
+    let tok = rt.authorize(Namespace::local()).unwrap();
+
+    // Two relations named on one edge — no single static triple to test, so
+    // this must never warn even though neither relation accepts concept->concept.
+    let result = rt
+        .query_with_metadata(
+            &tok,
+            "MATCH (a:concept)-[:precedes|contains]->(b:concept) RETURN a, b LIMIT 10",
+            khive_query::CompileOptions::default(),
+        )
+        .await
+        .unwrap();
+
+    assert!(
+        result.warnings.is_empty(),
+        "a multi-relation edge names no single static triple to test: {:?}",
+        result.warnings
+    );
+}
+
+#[tokio::test]
+async fn query_static_impossible_check_skips_variable_length_edge() {
+    let rt = rt();
+    let tok = rt.authorize(Namespace::local()).unwrap();
+
+    let result = rt
+        .query_with_metadata(
+            &tok,
+            "MATCH (a:concept)-[:precedes*1..2]->(b:concept) RETURN a, b LIMIT 10",
+            khive_query::CompileOptions::default(),
+        )
+        .await
+        .unwrap();
+
+    assert!(
+        result.warnings.is_empty(),
+        "a variable-length hop is not a single mandatory hop and must not warn: {:?}",
+        result.warnings
+    );
+}
+
+#[tokio::test]
+async fn query_static_impossible_check_skips_undirected_edge() {
+    let rt = rt();
+    let tok = rt.authorize(Namespace::local()).unwrap();
+
+    let result = rt
+        .query_with_metadata(
+            &tok,
+            "MATCH (a:concept)-[:precedes]-(b:concept) RETURN a, b LIMIT 10",
+            khive_query::CompileOptions::default(),
+        )
+        .await
+        .unwrap();
+
+    assert!(
+        result.warnings.is_empty(),
+        "an undirected edge names no fixed (source, target) triple and must not warn: {:?}",
+        result.warnings
+    );
+}
+
+#[tokio::test]
+async fn query_static_impossible_pattern_warning_exact_message() {
+    let rt = rt();
+    let tok = rt.authorize(Namespace::local()).unwrap();
+
+    let result = rt
+        .query_with_metadata(
+            &tok,
+            "MATCH (n:concept)-[:precedes]->(m:concept) RETURN n, m LIMIT 10",
+            khive_query::CompileOptions::default(),
+        )
+        .await
+        .unwrap();
+
+    // Exact-message pin (issue #593's public contract): this is a load-bearing
+    // string once callers script against it, so pin the full text, not just a
+    // substring, catching any accidental wording/ordering drift.
+    assert_eq!(
+        result.warnings,
+        vec![
+            "pattern (concept)-[:precedes]->(concept) can never match: 'precedes' does not \
+             accept concept->concept endpoints; accepted source->target kinds for 'precedes': \
+             document->document, dataset->dataset, project->project, artifact->artifact, \
+             service->service"
+                .to_string()
+        ]
+    );
+}
+
+#[tokio::test]
 async fn query_static_impossible_check_skips_sparql() {
     let rt = rt();
     let tok = rt.authorize(Namespace::local()).unwrap();

--- a/crates/khive-runtime/tests/integration.rs
+++ b/crates/khive-runtime/tests/integration.rs
@@ -706,6 +706,200 @@ async fn explicit_limit_over_cap_with_few_real_matches_emits_no_warning() {
 }
 
 // =============================================================================
+// GQL static edge-pattern schema-mismatch hint (issue #593)
+//
+// A MATCH pattern that names an explicit relation and explicit entity kinds
+// on both endpoints can be *statically* impossible under the composed edge
+// endpoint contract (base allowlist + pack EDGE_RULES) — e.g. `precedes`
+// never accepts concept->concept endpoints. Executed unchanged, this always
+// returns zero rows, indistinguishable from "no data yet". These tests cover
+// the warning that distinguishes the two cases, scoped to the exact cases
+// where the emptiness is statically knowable.
+// =============================================================================
+
+#[tokio::test]
+async fn query_static_impossible_pattern_precedes_concept_concept_warns_and_returns_empty() {
+    let rt = rt();
+    let tok = rt.authorize(Namespace::local()).unwrap();
+
+    // Real `precedes` edges exist — just never between two concepts (issue
+    // #593's repro: 3445 `precedes` edges in the wild, all document/project/etc).
+    let d1 = rt
+        .create_entity(&tok, "document", None, "Doc1", None, None, vec![])
+        .await
+        .unwrap();
+    let d2 = rt
+        .create_entity(&tok, "document", None, "Doc2", None, None, vec![])
+        .await
+        .unwrap();
+    rt.link(&tok, d1.id, d2.id, EdgeRelation::Precedes, 1.0, None)
+        .await
+        .unwrap();
+
+    let result = rt
+        .query_with_metadata(
+            &tok,
+            "MATCH (n:concept)-[:precedes]->(m:concept) RETURN n.name, m.name LIMIT 10",
+            khive_query::CompileOptions::default(),
+        )
+        .await
+        .unwrap();
+
+    assert!(
+        result.rows.is_empty(),
+        "no concept->concept precedes edges exist: {:?}",
+        result.rows
+    );
+    assert_eq!(result.warnings.len(), 1, "warnings: {:?}", result.warnings);
+    let w = &result.warnings[0];
+    assert!(w.contains("precedes"), "{w}");
+    assert!(w.contains("concept"), "{w}");
+    assert!(
+        w.contains("document->document"),
+        "must name an accepted pair for the relation: {w}"
+    );
+}
+
+#[tokio::test]
+async fn query_static_possible_pattern_extends_concept_concept_no_warning() {
+    let rt = rt();
+    let tok = rt.authorize(Namespace::local()).unwrap();
+
+    let a = rt
+        .create_entity(&tok, "concept", None, "LoRA2", None, None, vec![])
+        .await
+        .unwrap();
+    let b = rt
+        .create_entity(&tok, "concept", None, "QLoRA2", None, None, vec![])
+        .await
+        .unwrap();
+    rt.link(&tok, b.id, a.id, EdgeRelation::Extends, 1.0, None)
+        .await
+        .unwrap();
+
+    let result = rt
+        .query_with_metadata(
+            &tok,
+            "MATCH (n:concept)-[:extends]->(m:concept) RETURN n, m LIMIT 10",
+            khive_query::CompileOptions::default(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(
+        result.rows.len(),
+        1,
+        "concept->concept is a valid base-contract pair for extends"
+    );
+    assert!(
+        result.warnings.is_empty(),
+        "a statically-valid pattern must not warn: {:?}",
+        result.warnings
+    );
+}
+
+#[tokio::test]
+async fn query_static_impossible_check_skips_unlabeled_source_node() {
+    let rt = rt();
+    let tok = rt.authorize(Namespace::local()).unwrap();
+
+    // The source node is unlabeled — no static (kind, relation, kind) triple
+    // is named, so this must never warn regardless of what `precedes` accepts.
+    let result = rt
+        .query_with_metadata(
+            &tok,
+            "MATCH (n)-[:precedes]->(m:document) RETURN n, m LIMIT 10",
+            khive_query::CompileOptions::default(),
+        )
+        .await
+        .unwrap();
+
+    assert!(
+        result.warnings.is_empty(),
+        "an unlabeled endpoint names no static triple to test: {:?}",
+        result.warnings
+    );
+}
+
+#[tokio::test]
+async fn query_static_impossible_check_honors_pack_extended_endpoint_rules() {
+    let rt = rt();
+    let tok = rt.authorize(Namespace::local()).unwrap();
+
+    // Mirrors khive-pack-kg's KG_EDGE_RULES: `person part_of org` is valid
+    // only via a pack-declared rule, never the base allowlist alone. The hint
+    // must consult the exact same composed rule set the link validator does.
+    rt.install_edge_rules(vec![khive_types::EdgeEndpointRule {
+        relation: EdgeRelation::PartOf,
+        source: khive_types::EndpointKind::EntityOfKind("person"),
+        target: khive_types::EndpointKind::EntityOfKind("org"),
+    }]);
+
+    let p = rt
+        .create_entity(&tok, "person", None, "Ada", None, None, vec![])
+        .await
+        .unwrap();
+    let o = rt
+        .create_entity(&tok, "org", None, "Acme", None, None, vec![])
+        .await
+        .unwrap();
+    rt.link(&tok, p.id, o.id, EdgeRelation::PartOf, 1.0, None)
+        .await
+        .unwrap();
+
+    let result = rt
+        .query_with_metadata(
+            &tok,
+            "MATCH (n:person)-[:part_of]->(m:org) RETURN n, m LIMIT 10",
+            khive_query::CompileOptions::default(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(result.rows.len(), 1);
+    assert!(
+        result.warnings.is_empty(),
+        "a pack-declared endpoint rule must not be falsely flagged as impossible: {:?}",
+        result.warnings
+    );
+}
+
+#[tokio::test]
+async fn query_static_impossible_check_skips_sparql() {
+    let rt = rt();
+    let tok = rt.authorize(Namespace::local()).unwrap();
+
+    let d1 = rt
+        .create_entity(&tok, "document", None, "Doc1", None, None, vec![])
+        .await
+        .unwrap();
+    let d2 = rt
+        .create_entity(&tok, "document", None, "Doc2", None, None, vec![])
+        .await
+        .unwrap();
+    rt.link(&tok, d1.id, d2.id, EdgeRelation::Precedes, 1.0, None)
+        .await
+        .unwrap();
+
+    // Same statically-impossible shape as the GQL case above (precedes
+    // concept->concept), expressed in SPARQL — must never receive the hint.
+    let result = rt
+        .query_with_metadata(
+            &tok,
+            "SELECT ?a ?b WHERE { ?a :precedes ?b . ?a a :concept . ?b a :concept . }",
+            khive_query::CompileOptions::default(),
+        )
+        .await
+        .unwrap();
+
+    assert!(
+        result.warnings.is_empty(),
+        "SPARQL must never receive the static GQL-pattern hint: {:?}",
+        result.warnings
+    );
+}
+
+// =============================================================================
 // Namespace isolation
 // =============================================================================
 


### PR DESCRIPTION
## Problem

`query(query="MATCH (n:concept)-[:precedes]->(m:concept) RETURN n.name, m.name LIMIT 10")`
returns `{"rows":[]}` with no signal, even though `precedes` carries no
`concept->concept` endpoints under the closed edge contract (base allowlist +
pack `EDGE_RULES`). A schema mismatch is indistinguishable from "no data yet".

## Change

When a GQL `MATCH` edge pattern names both an explicit relation and explicit
entity kinds on both endpoints, and that `(source_kind, relation, target_kind)`
triple is impossible under the composed edge endpoint contract, the query still
executes unchanged (rows are never affected), but a warning is appended to the
existing `QueryResult.warnings` channel, e.g.:

```
pattern (concept)-[:precedes]->(concept) can never match: 'precedes' does not
accept concept->concept endpoints; accepted source->target kinds for
'precedes': document->document, dataset->dataset, artifact->artifact,
service->service, project->project
```

The check reuses the exact `base_entity_rule_allows` /
`accepted_pack_relations_for_entities` validator functions (issue #543
precedent) rather than a parallel matcher table, and consults the same
composed pack-rule set (`KhiveRuntime::pack_edge_rules()`) that edge-link
validation uses.

Scope, deliberately conservative:
- Only fires for a single-hop, fixed-direction edge naming exactly one
  relation, where both endpoints name an entity kind under the closed 8-kind
  base taxonomy.
- Unlabeled nodes, unlabeled/multi-relation edges, undirected edges,
  variable-length hops, note-kind endpoints, and SPARQL queries are all left
  unchecked — none of those name a single static triple to test against the
  validator.
- Rows are never affected; this only ever adds a warning alongside existing
  ones (e.g. row-cap truncation warnings), never an error.

## Tests

Added to `crates/khive-runtime/tests/integration.rs`:
- `query_static_impossible_pattern_precedes_concept_concept_warns_and_returns_empty`
- `query_static_possible_pattern_extends_concept_concept_no_warning`
- `query_static_impossible_check_skips_unlabeled_source_node`
- `query_static_impossible_check_honors_pack_extended_endpoint_rules`
- `query_static_impossible_check_skips_sparql`

All existing truncation-warning tests continue to pass unchanged.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test -p khive-pack-kg -p khive-runtime -p khive-query` (all green, including the 5 new tests)
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps -p khive-pack-kg -p khive-runtime`

🤖 Generated with [Claude Code](https://claude.com/claude-code)