### PR TITLE
fix(runtime): disclose merged_into target when a by-id lookup misses a merged entity

### DIFF
--- a/crates/khive-pack-kg/src/handlers/get.rs
+++ b/crates/khive-pack-kg/src/handlers/get.rs
@@ -46,6 +46,14 @@ impl KgPack {
 
         let include_deleted = p.include_deleted.unwrap_or(false);
 
+        // Interim merged_into disclosure (data-integrity, precedes the full
+        // ADR-113 redirect chase): `get_entity` names the kept id in its
+        // NotFound message when `id` was consumed by `merge`. Captured here
+        // so it can stand in for the generic not-found built below once
+        // every other substrate (note/edge/event/pack-resolver) also misses
+        // — the marker string is one we control on the write side above.
+        let mut merge_redirect_hint: Option<String> = None;
+
         match self.runtime.get_entity(graph_token, id).await {
             Ok(entity) => {
                 return flatten_get_result(
@@ -53,7 +61,24 @@ impl KgPack {
                     normalize_entity_timestamps(to_json(&entity)?),
                 );
             }
-            Err(RuntimeError::NotFound(_) | RuntimeError::NamespaceMismatch { .. }) => {
+            Err(RuntimeError::NotFound(msg)) => {
+                if msg.contains("was merged into") {
+                    merge_redirect_hint = Some(msg);
+                }
+                if include_deleted {
+                    if let Some(deleted) = self
+                        .runtime
+                        .get_entity_including_deleted(graph_token, id)
+                        .await?
+                    {
+                        return flatten_get_result(
+                            "entity",
+                            normalize_entity_timestamps(to_json(&deleted)?),
+                        );
+                    }
+                }
+            }
+            Err(RuntimeError::NamespaceMismatch { .. }) => {
                 if include_deleted {
                     if let Some(deleted) = self
                         .runtime
@@ -110,6 +135,10 @@ impl KgPack {
 
         if let Some(payload_val) = self.try_get_proposal_payload(token, &p.id).await? {
             return Ok(payload_val);
+        }
+
+        if let Some(hint) = merge_redirect_hint {
+            return Err(RuntimeError::NotFound(hint));
         }
 
         Err(RuntimeError::NotFound(format!("not found: {}", p.id)))

--- a/crates/khive-pack-kg/src/handlers/tests.rs
+++ b/crates/khive-pack-kg/src/handlers/tests.rs
@@ -1562,3 +1562,140 @@ async fn merge_note_reason_forwarded_through_registry_dispatch() {
         events.items[0].payload
     );
 }
+
+// ── interim merged_into miss-hint (data-integrity, precedes the full
+// ADR-113 transitive redirect chase) ───────────────────────────────────────
+//
+// `get(absorbed_id)` after a merge names the kept id in its NotFound error
+// instead of a bare "not found" — single-level pointer disclosure, message
+// only, never a transparent redirect to the kept entity's data.
+
+#[tokio::test]
+async fn get_dispatch_after_merge_discloses_kept_id() {
+    use khive_runtime::RuntimeError;
+
+    let (rt, token, _pack) = configured_kg_pack().await;
+    let mut builder = khive_runtime::VerbRegistryBuilder::new();
+    builder.register(crate::KgPack::new(rt.clone()));
+    let registry = builder.build().expect("registry build");
+
+    let into = rt
+        .create_entity(&token, "concept", None, "Kept", None, None, vec![])
+        .await
+        .expect("create into entity");
+    let from = rt
+        .create_entity(&token, "concept", None, "Absorbed", None, None, vec![])
+        .await
+        .expect("create from entity");
+
+    registry
+        .dispatch(
+            "merge",
+            json!({
+                "kind": "entity",
+                "into_id": into.id.to_string(),
+                "from_id": from.id.to_string(),
+            }),
+        )
+        .await
+        .expect("merge dispatch must succeed");
+
+    let err = registry
+        .dispatch("get", json!({ "id": from.id.to_string() }))
+        .await
+        .expect_err("get on an absorbed id must still miss");
+    let RuntimeError::NotFound(msg) = err else {
+        panic!("expected NotFound, got {err:?}");
+    };
+    assert!(
+        msg.contains("was merged into") && msg.contains(&into.id.to_string()),
+        "expected a merged_into disclosure naming {}, got {msg:?}",
+        into.id
+    );
+}
+
+#[tokio::test]
+async fn get_dispatch_on_plain_deleted_and_absent_ids_unchanged() {
+    use khive_runtime::RuntimeError;
+
+    let (rt, token, _pack) = configured_kg_pack().await;
+    let mut builder = khive_runtime::VerbRegistryBuilder::new();
+    builder.register(crate::KgPack::new(rt.clone()));
+    let registry = builder.build().expect("registry build");
+
+    let entity = rt
+        .create_entity(&token, "concept", None, "Deleted", None, None, vec![])
+        .await
+        .expect("create entity");
+    assert!(rt.delete_entity(&token, entity.id, false).await.unwrap());
+
+    let deleted_err = registry
+        .dispatch("get", json!({ "id": entity.id.to_string() }))
+        .await
+        .expect_err("get on a plain soft-deleted id must still miss");
+    let RuntimeError::NotFound(msg) = deleted_err else {
+        panic!("expected NotFound, got {deleted_err:?}");
+    };
+    assert!(
+        !msg.contains("merged into"),
+        "plain soft-delete must not gain a merge hint, got {msg:?}"
+    );
+
+    let absent = uuid::Uuid::new_v4();
+    let absent_err = registry
+        .dispatch("get", json!({ "id": absent.to_string() }))
+        .await
+        .expect_err("get on a never-existed id must miss");
+    let RuntimeError::NotFound(msg) = absent_err else {
+        panic!("expected NotFound, got {absent_err:?}");
+    };
+    assert!(
+        !msg.contains("merged into"),
+        "a never-existed id must not gain a merge hint, got {msg:?}"
+    );
+}
+
+// `resolve`'s `NotFound` outcome (`ReferenceResolution::NotFound`) is a unit
+// variant with no message slot to carry a hint in — scope is `get` only for
+// this interim change (see PR description). This test pins that boundary:
+// resolving an absorbed uuid still reports a bare `not_found` status.
+#[tokio::test]
+async fn resolve_dispatch_on_merged_uuid_stays_bare_not_found() {
+    let (rt, token, _pack) = configured_kg_pack().await;
+    let mut builder = khive_runtime::VerbRegistryBuilder::new();
+    builder.register(crate::KgPack::new(rt.clone()));
+    let registry = builder.build().expect("registry build");
+    let _ = token;
+
+    let into = rt
+        .create_entity(&token, "concept", None, "Kept", None, None, vec![])
+        .await
+        .expect("create into entity");
+    let from = rt
+        .create_entity(&token, "concept", None, "Absorbed", None, None, vec![])
+        .await
+        .expect("create from entity");
+
+    registry
+        .dispatch(
+            "merge",
+            json!({
+                "kind": "entity",
+                "into_id": into.id.to_string(),
+                "from_id": from.id.to_string(),
+            }),
+        )
+        .await
+        .expect("merge dispatch must succeed");
+
+    let result = registry
+        .dispatch("resolve", json!({ "refs": [from.id.to_string()] }))
+        .await
+        .expect("resolve dispatch must succeed (NotFound is a status, not an error)");
+
+    let status = result["results"][0]["status"].as_str().unwrap();
+    assert_eq!(
+        status, "not_found",
+        "resolve has no message slot for a merge hint in this interim change; got {result:?}"
+    );
+}

--- a/crates/khive-runtime/src/curation.rs
+++ b/crates/khive-runtime/src/curation.rs
@@ -3340,6 +3340,75 @@ mod tests {
         .unwrap();
     }
 
+    // ---- interim merged_into miss-hint (data-integrity, precedes ADR-113 chase) ----
+
+    #[tokio::test]
+    async fn get_entity_after_merge_discloses_kept_id() {
+        let rt = rt();
+        let tok = NamespaceToken::local();
+        let into = rt
+            .create_entity(&tok, "concept", None, "Kept", None, None, vec![])
+            .await
+            .unwrap();
+        let from = rt
+            .create_entity(&tok, "concept", None, "Absorbed", None, None, vec![])
+            .await
+            .unwrap();
+
+        rt.merge_entity(
+            &tok,
+            into.id,
+            from.id,
+            EntityDedupMergePolicy::PreferInto,
+            ContentMergeStrategy::Append,
+            false,
+        )
+        .await
+        .unwrap();
+
+        let err = rt.get_entity(&tok, from.id).await.unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("was merged into") && msg.contains(&into.id.to_string()),
+            "expected a merged_into disclosure naming {}, got {msg:?}",
+            into.id
+        );
+    }
+
+    #[tokio::test]
+    async fn get_entity_on_plain_soft_delete_stays_bare_not_found() {
+        let rt = rt();
+        let tok = NamespaceToken::local();
+        let entity = rt
+            .create_entity(&tok, "concept", None, "Deleted", None, None, vec![])
+            .await
+            .unwrap();
+        assert!(rt.delete_entity(&tok, entity.id, false).await.unwrap());
+
+        let err = rt.get_entity(&tok, entity.id).await.unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            !msg.contains("merged into"),
+            "plain soft-delete must not gain a merge hint, got {msg:?}"
+        );
+        assert_eq!(msg, format!("not found: entity {}", entity.id));
+    }
+
+    #[tokio::test]
+    async fn get_entity_on_absent_id_stays_bare_not_found() {
+        let rt = rt();
+        let tok = NamespaceToken::local();
+        let absent = Uuid::new_v4();
+
+        let err = rt.get_entity(&tok, absent).await.unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            !msg.contains("merged into"),
+            "a never-existed id must not gain a merge hint, got {msg:?}"
+        );
+        assert_eq!(msg, format!("not found: entity {absent}"));
+    }
+
     // ---- merge helper unit tests ----
 
     #[test]

--- a/crates/khive-runtime/src/operations.rs
+++ b/crates/khive-runtime/src/operations.rs
@@ -963,11 +963,28 @@ impl KhiveRuntime {
     /// Retrieve an entity by ID.
     ///
     /// UUID v4 is globally unique: no namespace filter on by-ID ops.
+    ///
+    /// Interim identifier-continuity disclosure (precedes the full transitive
+    /// redirect chase): a miss is probed once against the tombstone row. If
+    /// the id was consumed by `merge(into_id, from_id)` — `merged_into` set —
+    /// the `NotFound` message names the kept id so the caller can requery it
+    /// directly. Single-level only: it does not chase a chain of merges and
+    /// does not return the kept entity in place of the miss. The probe only
+    /// runs after the live-row lookup misses, so the happy path pays no
+    /// extra query.
     pub async fn get_entity(&self, token: &NamespaceToken, id: Uuid) -> RuntimeResult<Entity> {
-        self.entities(token)?
-            .get_entity(id)
-            .await?
-            .ok_or_else(|| RuntimeError::NotFound(format!("entity {id}")))
+        let store = self.entities(token)?;
+        if let Some(entity) = store.get_entity(id).await? {
+            return Ok(entity);
+        }
+        if let Some(tombstone) = store.get_entity_including_deleted(id).await? {
+            if let Some(kept_id) = tombstone.merged_into {
+                return Err(RuntimeError::NotFound(format!(
+                    "{id} was merged into {kept_id}; query the kept id"
+                )));
+            }
+        }
+        Err(RuntimeError::NotFound(format!("entity {id}")))
     }
 
     /// Retrieve an entity by ID including soft-deleted rows.


### PR DESCRIPTION
## Summary

After `merge(into_id, from_id)`, a stored reference to the absorbed id (`from_id`) becomes indistinguishable from a reference to an id that never existed: `get(from_id)` and `resolve(refs=[from_id])` both report a bare not-found, even though the tombstone row durably records `merged_into`. This is an interim, deliberately narrow fix that discloses the redirect target in the error message — it does not implement the full transitive redirect chase (tracked separately).

- `KhiveRuntime::get_entity` (`crates/khive-runtime/src/operations.rs`): on a miss against a live row, probes the tombstone once via `get_entity_including_deleted`. If `merged_into` is set, the `NotFound` error becomes `"not found: <id> was merged into <kept-id>; query the kept id"` instead of the bare `"not found: entity <id>"`. The probe only runs after the live-row lookup misses, so the happy path pays no extra query. Single-level disclosure only — it does not chase a chain of merges, and it never returns the kept entity in place of the miss.
- `KgPack::handle_get` (`crates/khive-pack-kg/src/handlers/get.rs`): captures that hint when `get_entity` misses, and surfaces it as the final error only if no other substrate (note/edge/event/pack-resolver/proposal) claims the id — preserving the existing fallthrough behavior for ids of other kinds.
- `resolve` (`crates/khive-pack-kg/src/handlers/resolve.rs`) is **unchanged**: `ReferenceResolution::NotFound` is a unit variant with no message slot to carry a hint in, so there is nowhere to attach the disclosure without a response-shape change, which is out of scope here. A resolve on an absorbed uuid still reports a bare `not_found` status (pinned by a regression test).
- Note merge (`merge_note`) is out of scope: `Note` has no `merged_into` field in storage at all, so there is no tombstone pointer to disclose for notes.

## Test plan

- [x] `get(absorbed-full-uuid)` after a merge: error message contains `"merged into"` and the kept id (`curation::tests::get_entity_after_merge_discloses_kept_id`, `handlers::tests::get_dispatch_after_merge_discloses_kept_id`)
- [x] `get` on a plain soft-deleted (non-merged) entity: unchanged bare not-found (`curation::tests::get_entity_on_plain_soft_delete_stays_bare_not_found`, part of `handlers::tests::get_dispatch_on_plain_deleted_and_absent_ids_unchanged`)
- [x] `get` on a random absent uuid: unchanged bare not-found, no merge hint (`curation::tests::get_entity_on_absent_id_stays_bare_not_found`, part of `handlers::tests::get_dispatch_on_plain_deleted_and_absent_ids_unchanged`)
- [x] `resolve` on an absorbed uuid: still a bare `not_found` status, documented boundary (`handlers::tests::resolve_dispatch_on_merged_uuid_stays_bare_not_found`)
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test -p khive-runtime -p khive-pack-kg -p khive-db` (all green)
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps -p khive-runtime`

🤖 Generated with [Claude Code](https://claude.com/claude-code)