### PR TITLE
docs(pack-kg): state entity/note corpus scope in the search verb description

### DIFF
--- a/crates/khive-pack-kg/src/handler_defs.rs
+++ b/crates/khive-pack-kg/src/handler_defs.rs
@@ -469,7 +469,7 @@ pub(crate) static KG_HANDLERS: [HandlerDef; 18] = [
     // Assertive: retrieves and presents search results
     HandlerDef {
         name: "search",
-        description: "Hybrid FTS + vector search",
+        description: "Hybrid FTS + vector search over knowledge-graph entities and notes. Corpora owned by other packs (for example teaching or document corpora with their own search verbs) are disjoint and are not searched here.",
         visibility: Visibility::Verb,
         category: VerbCategory::Assertive,
         params: &[


### PR DESCRIPTION
Doc-only change: the `search` verb description now states it searches knowledge-graph entities and notes, and that corpora owned by other packs (which carry their own search verbs) are disjoint and not searched here. Callers reaching for a similarly named search verb otherwise silently conclude records do not exist when they searched the wrong corpus.

Gates: fmt clean, `cargo test -p khive-pack-kg` 150+6+3+244+11 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)