### PR TITLE
fix(pack-kg): let short-prefix get reach soft-deleted rows and the merged_into disclosure

### DIFF
--- a/crates/khive-pack-kg/src/handler_defs.rs
+++ b/crates/khive-pack-kg/src/handler_defs.rs
@@ -141,8 +141,8 @@ pub(crate) static KG_HANDLERS: [HandlerDef; 18] = [
                 required: false,
                 description:
                     "If true, return soft-deleted entities (with deleted_at populated). Default false. \
-                     Requires a full UUID — short prefix resolution filters deleted records; \
-                     the delete response always returns the full UUID for this purpose.",
+                     Accepts a full UUID or a unique short hex prefix — prefix resolution falls back \
+                     to soft-deleted entities when no live record matches.",
             },
         ],
     },

--- a/crates/khive-pack-kg/src/handlers/get.rs
+++ b/crates/khive-pack-kg/src/handlers/get.rs
@@ -17,7 +17,7 @@ use khive_types::EventKind;
 use super::common::{
     deser, flatten_get_result, normalize_entity_timestamps, normalize_event_timestamps,
     parse_event_kind, parse_event_outcome, parse_event_substrate, remap_note_status,
-    resolve_uuid_unfiltered, to_json, GetParams,
+    resolve_uuid_unfiltered, resolve_uuid_unfiltered_including_deleted, to_json, GetParams,
 };
 use crate::KgPack;
 
@@ -33,9 +33,18 @@ impl KgPack {
 
         // By-ID resolution (including the hex-prefix form) is namespace-agnostic
         // (ADR-007 Rev 6 / #391 §3) — the Gate is the authz seam, not this lookup.
+        // Live rows resolve first so ambiguity semantics are unchanged; the
+        // including-deleted fallback lets a short prefix reach soft-deleted
+        // rows — required both for `include_deleted=true` and for the
+        // merged_into disclosure below (absorbed entities are soft-deleted, so
+        // a live-only prefix scan would miss them before the hint could fire).
         let id = if let Ok(id) = resolve_uuid_unfiltered(&p.id, &self.runtime, graph_token).await {
             id
         } else if let Ok(id) = resolve_uuid_unfiltered(&p.id, &self.runtime, token).await {
+            id
+        } else if let Ok(id) =
+            resolve_uuid_unfiltered_including_deleted(&p.id, &self.runtime, graph_token).await
+        {
             id
         } else {
             if let Some(payload_val) = self.try_get_proposal_payload(token, &p.id).await? {

--- a/crates/khive-pack-kg/src/handlers/tests.rs
+++ b/crates/khive-pack-kg/src/handlers/tests.rs
@@ -1632,6 +1632,34 @@ async fn get_dispatch_after_merge_discloses_kept_id() {
 }
 
 #[tokio::test]
+async fn get_dispatch_short_prefix_with_include_deleted_returns_deleted_entity() {
+    let (rt, token, _pack) = configured_kg_pack().await;
+    let mut builder = khive_runtime::VerbRegistryBuilder::new();
+    builder.register(crate::KgPack::new(rt.clone()));
+    let registry = builder.build().expect("registry build");
+
+    let entity = rt
+        .create_entity(&token, "concept", None, "SoftDeleted", None, None, vec![])
+        .await
+        .expect("create entity");
+    assert!(rt.delete_entity(&token, entity.id, false).await.unwrap());
+
+    let short = entity.id.to_string().replace('-', "")[..8].to_string();
+    let got = registry
+        .dispatch("get", json!({ "id": short, "include_deleted": true }))
+        .await
+        .expect("short prefix + include_deleted must return the soft-deleted entity");
+    assert_eq!(
+        got.get("id").and_then(|v| v.as_str()),
+        Some(entity.id.to_string().as_str())
+    );
+    assert!(
+        got.get("deleted_at").and_then(|v| v.as_str()).is_some(),
+        "deleted_at must be populated on the returned soft-deleted entity, got {got:?}"
+    );
+}
+
+#[tokio::test]
 async fn get_dispatch_on_plain_deleted_and_absent_ids_unchanged() {
     use khive_runtime::RuntimeError;
 

--- a/crates/khive-pack-kg/src/handlers/tests.rs
+++ b/crates/khive-pack-kg/src/handlers/tests.rs
@@ -1612,6 +1612,23 @@ async fn get_dispatch_after_merge_discloses_kept_id() {
         "expected a merged_into disclosure naming {}, got {msg:?}",
         into.id
     );
+
+    // The documented short-prefix form must reach the same disclosure:
+    // absorbed entities are soft-deleted, so this exercises the
+    // including-deleted prefix-resolution fallback in handle_get.
+    let short = from.id.to_string().replace('-', "")[..8].to_string();
+    let err = registry
+        .dispatch("get", json!({ "id": short }))
+        .await
+        .expect_err("get on an absorbed short id must still miss");
+    let RuntimeError::NotFound(msg) = err else {
+        panic!("expected NotFound, got {err:?}");
+    };
+    assert!(
+        msg.contains("was merged into") && msg.contains(&into.id.to_string()),
+        "expected a merged_into disclosure for the short-prefix form naming {}, got {msg:?}",
+        into.id
+    );
 }
 
 #[tokio::test]

--- a/docs/guide/api-reference.md
+++ b/docs/guide/api-reference.md
@@ -164,10 +164,10 @@ request(ops="create(kind=\"concept\", name=\"RoPE\", description=\"Rotary positi
 
 Fetch any record by UUID (auto-detects entity/note/edge/event/proposal).
 
-| Param             | Type | Required | Notes                                                                  |
-| ----------------- | ---- | -------- | ---------------------------------------------------------------------- |
-| `id`              | uuid | yes      | Full UUID or short hex prefix (min 8 chars).                           |
-| `include_deleted` | bool | no       | Return soft-deleted records too (default false); requires a full UUID. |
+| Param             | Type | Required | Notes                                                                 |
+| ----------------- | ---- | -------- | --------------------------------------------------------------------- |
+| `id`              | uuid | yes      | Full UUID or short hex prefix (min 8 chars).                          |
+| `include_deleted` | bool | no       | Return soft-deleted records too (default false); full UUID or prefix. |
 
 ```
 request(ops="get(id=\"3f2a9c1e\")")


### PR DESCRIPTION
Follow-up to #1237. A post-merge review found the merged_into disclosure unreachable for the documented short-prefix identifier form: `handle_get` resolves prefixes via a live-rows-only scan, and absorbed entities are soft-deleted, so `get(id=<absorbed-short-id>)` failed at prefix resolution (`no record matches prefix`) before the disclosure logic could run. Verified at source (`resolve_uuid_unfiltered` -> `resolve_prefix_unfiltered`, include_deleted=false).

## Fix

Add an including-deleted prefix-resolution fallback in `handle_get` only, after both live-scan attempts miss. Live rows resolve first, so ambiguity semantics for live prefixes are unchanged.

## Behavior changes (both consistency-restoring)

- Short prefix of an absorbed entity now reaches the merged_into disclosure, matching the full-UUID form.
- Short prefix of a plain soft-deleted row now reports `not found: <uuid>` instead of `no record matches prefix`, matching the full-UUID form.
- Short prefix + `include_deleted=true` can now actually return the soft-deleted row — previously unreachable, contradicting the documented parameter.

## Out of scope (fold into the ADR-113 chase design)

The double tombstone read on miss paths and the message-marker coupling flagged by the same review are deferred to the full chase spec, which replaces the string protocol with a typed redirect.

## Tests

Extended `get_dispatch_after_merge_discloses_kept_id` with the short-prefix form (exercises the fallback end to end).

Gates: fmt clean, clippy `-D warnings` clean, `cargo test -p khive-pack-kg` 153+6+3+244+11 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)