### PR TITLE
fix(runtime): treat untyped GQL hint endpoints as unconstrained over entity_type

### DIFF
--- a/crates/khive-runtime/src/operations.rs
+++ b/crates/khive-runtime/src/operations.rs
@@ -350,6 +350,34 @@ pub fn endpoint_matches(
     }
 }
 
+/// `true` if `spec` matches the given substrate + kind + entity_type triple,
+/// treating an *absent* `entity_type` on the query side as unconstrained
+/// rather than an exact match against "no subtype".
+///
+/// Used only by the static GQL impossibility hint (`static_impossible_edge_pattern_warnings`,
+/// `accepted_entity_kind_pairs_for_relation`), which reasons over a *pattern*
+/// endpoint, not a resolved entity. A pattern endpoint that names a kind but
+/// no `entity_type` (`(a:concept)-[:depends_on]->(b:concept)`) has not ruled
+/// out any subtype, so an `EntityOfType` rule for that kind still makes the
+/// triple possible — unlike `endpoint_matches`, which the live link
+/// validator applies to *resolved* entities, where a `None` `entity_type`
+/// means the entity genuinely has no subtype and must be an exact miss
+/// against a typed rule. Do not use this for validation.
+fn pattern_endpoint_matches(
+    spec: &EndpointKind,
+    substrate: &str,
+    kind: &str,
+    entity_type: Option<&str>,
+) -> bool {
+    match spec {
+        EndpointKind::EntityOfType {
+            kind: k,
+            entity_type: t,
+        } => substrate == "entity" && *k == kind && entity_type.is_none_or(|et| et == *t),
+        _ => endpoint_matches(spec, substrate, kind, entity_type),
+    }
+}
+
 /// Relations that a composed pack `EDGE_RULES` set accepts for a given
 /// `(entity_kind, entity_type)` endpoint pair, using the EXACT SAME
 /// `endpoint_matches` semantics `pack_rule_allows` applies internally
@@ -383,14 +411,40 @@ pub fn accepted_pack_relations_for_entities(
     relations
 }
 
+/// Hint-only counterpart to [`accepted_pack_relations_for_entities`] that
+/// matches via [`pattern_endpoint_matches`] instead of [`endpoint_matches`],
+/// so an absent `entity_type` is treated as unconstrained rather than an
+/// exact-match miss against `EntityOfType` rules. Used exclusively by the
+/// static GQL impossibility hint — never by validation.
+fn accepted_pack_relations_for_pattern_entities(
+    rules: &[EdgeEndpointRule],
+    src_kind: &str,
+    src_entity_type: Option<&str>,
+    tgt_kind: &str,
+    tgt_entity_type: Option<&str>,
+) -> Vec<EdgeRelation> {
+    let mut relations: Vec<EdgeRelation> = rules
+        .iter()
+        .filter(|r| {
+            pattern_endpoint_matches(&r.source, "entity", src_kind, src_entity_type)
+                && pattern_endpoint_matches(&r.target, "entity", tgt_kind, tgt_entity_type)
+        })
+        .map(|r| r.relation)
+        .collect();
+    relations.sort_by_key(|r| r.as_str());
+    relations.dedup();
+    relations
+}
+
 /// All `(source_kind, target_kind)` entity-kind pairs — restricted to the closed
 /// 8-kind base [`khive_types::EntityKind`] taxonomy — that accept `relation`
 /// under the composed base allowlist plus pack `EDGE_RULES`.
 ///
-/// Reuses [`base_entity_rule_allows`] and [`accepted_pack_relations_for_entities`]
-/// (the exact functions the live validator consults) over the closed kind set,
-/// rather than re-deriving a parallel table — issue #543 precedent, applied to
-/// GQL query-pattern hint derivation (issue #593).
+/// Reuses [`base_entity_rule_allows`] and [`accepted_pack_relations_for_pattern_entities`]
+/// (the pattern-side, unconstrained-`None` counterpart of the functions the live
+/// validator consults) over the closed kind set, rather than re-deriving a
+/// parallel table — issue #543 precedent, applied to GQL query-pattern hint
+/// derivation (issue #593).
 ///
 /// Pack rules are skipped for `crate::pack::SPECIAL_RELATIONS` (supersedes /
 /// supports / refutes): the live validator's special-relation branch
@@ -407,7 +461,7 @@ fn accepted_entity_kind_pairs_for_relation(
         for tgt in khive_types::EntityKind::ALL {
             let allowed = base_entity_rule_allows(src.name(), relation, tgt.name())
                 || (!crate::pack::SPECIAL_RELATIONS.contains(&relation)
-                    && accepted_pack_relations_for_entities(
+                    && accepted_pack_relations_for_pattern_entities(
                         pack_rules,
                         src.name(),
                         None,
@@ -478,7 +532,7 @@ fn static_impossible_edge_pattern_warnings(
 
         let possible = base_entity_rule_allows(src_kind.name(), relation, tgt_kind.name())
             || (!crate::pack::SPECIAL_RELATIONS.contains(&relation)
-                && accepted_pack_relations_for_entities(
+                && accepted_pack_relations_for_pattern_entities(
                     pack_rules,
                     src_kind.name(),
                     src_node.entity_type.as_deref(),

--- a/crates/khive-runtime/tests/integration.rs
+++ b/crates/khive-runtime/tests/integration.rs
@@ -1021,6 +1021,152 @@ async fn query_static_possible_pattern_entity_of_type_pack_rule_no_false_warning
 }
 
 #[tokio::test]
+async fn query_static_possible_pattern_untyped_endpoints_with_entity_of_type_rule_no_false_warning()
+{
+    let rt = rt();
+    let tok = rt.authorize(Namespace::local()).unwrap();
+
+    // Same EntityOfType rule as the typed-pattern test above, but the pattern
+    // here names no `entity_type` on either endpoint — just the base kind.
+    // An untyped pattern endpoint has not ruled out any subtype, so the
+    // installed theorem->definition rule still makes concept->concept
+    // depends_on possible and this must not warn.
+    rt.install_edge_rules(vec![khive_types::EdgeEndpointRule {
+        relation: EdgeRelation::DependsOn,
+        source: khive_types::EndpointKind::EntityOfType {
+            kind: "concept",
+            entity_type: "theorem",
+        },
+        target: khive_types::EndpointKind::EntityOfType {
+            kind: "concept",
+            entity_type: "definition",
+        },
+    }]);
+
+    let thm = rt
+        .create_entity(&tok, "concept", Some("theorem"), "T1", None, None, vec![])
+        .await
+        .unwrap();
+    let def = rt
+        .create_entity(
+            &tok,
+            "concept",
+            Some("definition"),
+            "D1",
+            None,
+            None,
+            vec![],
+        )
+        .await
+        .unwrap();
+    rt.link(&tok, thm.id, def.id, EdgeRelation::DependsOn, 1.0, None)
+        .await
+        .unwrap();
+
+    let result = rt
+        .query_with_metadata(
+            &tok,
+            "MATCH (a:concept)-[:depends_on]->(b:concept) RETURN a, b LIMIT 10",
+            khive_query::CompileOptions::default(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(
+        result.rows.len(),
+        1,
+        "the stored theorem->definition edge must be returned: {:?}",
+        result.rows
+    );
+    assert!(
+        result.warnings.is_empty(),
+        "an untyped pattern endpoint has not ruled out any entity_type, so it must not \
+         be falsely flagged as impossible just because it names no entity_type filter: {:?}",
+        result.warnings
+    );
+}
+
+#[tokio::test]
+async fn query_static_impossible_pattern_mismatching_entity_type_still_warns() {
+    let rt = rt();
+    let tok = rt.authorize(Namespace::local()).unwrap();
+
+    // Same EntityOfType rule, but the pattern names an entity_type that does
+    // NOT match the rule's source subtype ("lemma" vs the rule's "theorem")
+    // — exact-match semantics must still apply and this must warn.
+    rt.install_edge_rules(vec![khive_types::EdgeEndpointRule {
+        relation: EdgeRelation::DependsOn,
+        source: khive_types::EndpointKind::EntityOfType {
+            kind: "concept",
+            entity_type: "theorem",
+        },
+        target: khive_types::EndpointKind::EntityOfType {
+            kind: "concept",
+            entity_type: "definition",
+        },
+    }]);
+
+    let result = rt
+        .query_with_metadata(
+            &tok,
+            "MATCH (a:concept {entity_type: 'lemma'})-[:depends_on]->\
+             (b:concept {entity_type: 'definition'}) RETURN a, b LIMIT 10",
+            khive_query::CompileOptions::default(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(
+        result.warnings.len(),
+        1,
+        "a pattern entity_type that mismatches the installed rule's subtype must still \
+         be flagged as impossible: {:?}",
+        result.warnings
+    );
+}
+
+#[tokio::test]
+async fn query_static_impossible_warning_accepted_pairs_include_entity_of_type_only_relation() {
+    let rt = rt();
+    let tok = rt.authorize(Namespace::local()).unwrap();
+
+    // depends_on has no base-contract person->person row (the base allowlist
+    // only grants project/service/artifact/document pairs); the only way
+    // concept->concept becomes accepted is the installed EntityOfType rule.
+    // person->person stays impossible and must still warn, and the
+    // accepted-pairs list in the warning text must surface the
+    // EntityOfType-derived concept->concept pair rather than omitting it.
+    rt.install_edge_rules(vec![khive_types::EdgeEndpointRule {
+        relation: EdgeRelation::DependsOn,
+        source: khive_types::EndpointKind::EntityOfType {
+            kind: "concept",
+            entity_type: "theorem",
+        },
+        target: khive_types::EndpointKind::EntityOfType {
+            kind: "concept",
+            entity_type: "definition",
+        },
+    }]);
+
+    let result = rt
+        .query_with_metadata(
+            &tok,
+            "MATCH (a:person)-[:depends_on]->(b:person) RETURN a, b LIMIT 10",
+            khive_query::CompileOptions::default(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(result.warnings.len(), 1, "warnings: {:?}", result.warnings);
+    assert!(
+        result.warnings[0].contains("concept->concept"),
+        "the accepted-pairs list must include the EntityOfType-derived concept->concept \
+         pair for depends_on, not just base-allowlist pairs: {}",
+        result.warnings[0]
+    );
+}
+
+#[tokio::test]
 async fn query_static_impossible_chained_pattern_warns_once_per_edge() {
     let rt = rt();
     let tok = rt.authorize(Namespace::local()).unwrap();


### PR DESCRIPTION
## Summary

The static GQL impossibility hint (`static_impossible_edge_pattern_warnings` in `crates/khive-runtime/src/operations.rs`) checks whether a `MATCH` pattern's `(source_kind, relation, target_kind)` triple can ever be satisfied under the composed edge endpoint contract (base allowlist + pack `EDGE_RULES`). It reused `endpoint_matches`, whose `EntityOfType` arm requires `entity_type == Some(t)`.

A pattern endpoint that names only a base kind, with no `entity_type` filter (e.g. `(a:concept)-[:depends_on]->(b:concept)`), has `entity_type = None`. Under `endpoint_matches`'s exact-match semantics, `None` never satisfies an `EntityOfType` rule such as `concept(theorem)-depends_on->concept(definition)`. This produced two defects:

1. The pattern was flagged with a false "can never match" warning even when a pack installs an `EntityOfType` rule that makes the triple possible, and stored typed entities exist that would in fact match — because the compiled SQL for an untyped pattern emits no `entity_type` predicate.
2. The warning's accepted-pairs listing omitted `EntityOfType`-derived kind pairs, since it also passed `None`/`None` through the same exact-match check.

## Fix

In the hint analysis only, an absent `entity_type` on a pattern endpoint now means *unconstrained* rather than "no subtype": an installed `EntityOfType` rule whose kind matches makes the triple possible, regardless of the rule's specific `entity_type`. A pattern endpoint that does name an `entity_type` still requires an exact match.

This is implemented as a new hint-only predicate, `pattern_endpoint_matches`, and a matching `accepted_pack_relations_for_pattern_entities` helper, used by both the possible-triple check and the accepted-pairs derivation inside `static_impossible_edge_pattern_warnings`. The live link validator (`endpoint_matches`, used elsewhere over already-resolved entities, where `None` correctly means "this entity has no subtype") is unchanged — a resolved entity with no subtype must still fail an exact-match `EntityOfType` rule.

## Test plan

Four new regression tests added to `crates/khive-runtime/tests/integration.rs`, alongside the existing GQL static-hint test suite:

- [x] `query_static_possible_pattern_untyped_endpoints_with_entity_of_type_rule_no_false_warning` — untyped kind-only pattern over a relation with only an `EntityOfType` pack rule installed → no warning (previously failed)
- [x] `query_static_impossible_pattern_mismatching_entity_type_still_warns` — same rule, pattern typed with a mismatching `entity_type` → warning still fires (exact-match preserved)
- [x] `query_static_impossible_warning_accepted_pairs_include_entity_of_type_only_relation` — the accepted-pairs text in a warning for a relation whose only accepted pair comes from an `EntityOfType` rule includes that pair
- [x] Existing `query_static_possible_pattern_entity_of_type_pack_rule_no_false_warning` (typed pattern matching the rule) kept as a guard, still passing

Gates, run from `crates/`:
- `cargo fmt --all -- --check` — exit 0
- `cargo clippy -p khive-runtime --all-targets -- -D warnings` — exit 0
- `cargo test -p khive-runtime` — exit 0 (919 lib unit tests, 2 cold-boot tests, 86 integration tests, all passing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)