### PR TITLE
fix(pack-kg): stop budget assembly from starving later context anchors

### DIFF
--- a/crates/khive-pack-kg/src/handlers/context.rs
+++ b/crates/khive-pack-kg/src/handlers/context.rs
@@ -499,36 +499,61 @@ impl KgPack {
         Ok(json!({
             "anchors": out_anchors,
             "truncated": truncated,
-            "dropped": { "anchors": dropped_anchors, "neighbors": dropped_neighbors },
+            // `stage` is additive: every drop this handler produces originates in the
+            // Stage-4 budget walk — `fanout`/`hops` bound the neighbor candidate pool
+            // upstream, before assembly, so they never show up as a "drop" here today.
+            "dropped": {
+                "anchors": dropped_anchors,
+                "neighbors": dropped_neighbors,
+                "stage": "budget",
+            },
         }))
     }
 }
 
-/// Deterministic-order budget walk over anchors + neighbors. See `docs/api/context-verb.md`.
+/// Two-pass deterministic budget walk over anchors + neighbors. See
+/// `docs/api/context-verb.md`.
+///
+/// Pass 1 reserves budget for every anchor's own entity record, in rank
+/// order, ignoring neighbors entirely. Pass 2 then fills neighbors for the
+/// anchors that made it through pass 1, again in rank order, spending
+/// whatever budget remains.
+///
+/// A single-pass walk (entity+neighbors per anchor before moving to the
+/// next) lets one anchor's neighbor fan-out (driven by `fanout`/`hops`,
+/// unrelated to how relevant that anchor is) exhaust the entire budget and
+/// starve every anchor ranked after it — including anchors that are more
+/// relevant to the query and would otherwise have made it into the result.
+/// Reserving entity space first guarantees every anchor that fits gets
+/// *some* representation before any anchor's neighbor list is allowed to
+/// consume shared budget.
 fn assemble_within_budget(
     blocks: &[AnchorBlock],
     budget: usize,
 ) -> (Vec<Value>, bool, usize, usize) {
-    let mut committed_anchor_entities = 0usize;
-    let mut committed_neighbors: Vec<usize> = vec![0; blocks.len()];
     let mut running = 0usize;
     let mut truncated = false;
-    let mut out_anchors: Vec<Value> = Vec::with_capacity(blocks.len());
+    let mut included: Vec<bool> = vec![false; blocks.len()];
 
-    'outer: for (i, block) in blocks.iter().enumerate() {
+    for (i, block) in blocks.iter().enumerate() {
         if running + block.entity_size > budget {
             truncated = true;
-            break 'outer;
+            break;
         }
         running += block.entity_size;
-        committed_anchor_entities += 1;
+        included[i] = true;
+    }
 
+    let mut out_anchors: Vec<Value> = Vec::with_capacity(blocks.len());
+    let mut committed_neighbors: Vec<usize> = vec![0; blocks.len()];
+    for (i, block) in blocks.iter().enumerate() {
+        if !included[i] {
+            continue;
+        }
         let mut neighbor_out: Vec<Value> = Vec::new();
-        let mut hit_budget_mid_anchor = false;
         for (nj, size) in &block.neighbor_jsons {
             if running + size > budget {
                 truncated = true;
-                hit_budget_mid_anchor = true;
                 break;
             }
             running += size;
@@ -539,11 +564,9 @@ fn assemble_within_budget(
             "entity": block.entity_json.clone(),
             "neighbors": neighbor_out,
         }));
-        if hit_budget_mid_anchor {
-            break 'outer;
-        }
     }
 
+    let committed_anchor_entities = out_anchors.len();
     let dropped_anchors = blocks.len() - committed_anchor_entities;
     let dropped_neighbors: usize = blocks
         .iter()
@@ -665,14 +688,39 @@ mod tests {
     }
 
     #[test]
-    fn assemble_within_budget_second_anchor_fully_dropped_when_budget_exhausted_by_first() {
-        let blocks = vec![anchor_block("a1", 4, &[4]), anchor_block("a2", 4, &[4, 4])];
-        let budget = blocks[0].entity_size + blocks[0].neighbor_jsons[0].1;
+    fn assemble_within_budget_first_anchor_bloated_neighbor_no_longer_starves_second_anchor() {
+        // Regression test for the context-verb anchor-starvation defect: a bloated
+        // neighbor list on a higher-ranked anchor must never push a lower-ranked
+        // (but still selected) anchor's own entity record out of the result. Only
+        // that first anchor's oversized neighbor should be dropped.
+        let blocks = vec![anchor_block("a1", 4, &[2000]), anchor_block("a2", 4, &[4])];
+        let budget = blocks[0].entity_size + blocks[1].entity_size + blocks[1].neighbor_jsons[0].1;
         let (out, truncated, d_anchors, d_neighbors) = assemble_within_budget(&blocks, budget);
         assert!(truncated);
-        assert_eq!(out.len(), 1, "only the first anchor was assembled");
-        assert_eq!(d_anchors, 1, "second anchor dropped entirely");
-        assert_eq!(d_neighbors, 2, "second anchor's two neighbors both dropped");
+        assert_eq!(
+            out.len(),
+            2,
+            "both anchors' entity records must survive a bloated sibling neighbor list"
+        );
+        assert_eq!(
+            out[1]["entity"]["id"], "a2",
+            "second anchor's entity must be present"
+        );
+        assert_eq!(d_anchors, 0, "no anchor entity is dropped");
+        assert_eq!(
+            d_neighbors, 1,
+            "only the oversized first-anchor neighbor is dropped"
+        );
+        assert_eq!(
+            out[0]["neighbors"].as_array().unwrap().len(),
+            0,
+            "first anchor's oversized neighbor did not fit"
+        );
+        assert_eq!(
+            out[1]["neighbors"].as_array().unwrap().len(),
+            1,
+            "second anchor's small neighbor still fits"
+        );
     }
 
     #[test]

--- a/crates/khive-pack-kg/tests/integration.rs
+++ b/crates/khive-pack-kg/tests/integration.rs
@@ -10233,6 +10233,102 @@ async fn context_budget_truncation_sets_flag_and_dropped_counts() {
 }
 
 #[tokio::test]
+async fn context_bloated_anchor_neighbors_do_not_starve_a_later_relevant_anchor() {
+    // Regression test: a higher-ranked anchor with a large neighbor fan-out must
+    // not consume the entire budget and push a lower-ranked (but still
+    // query-relevant) anchor's own entity record out of the response. Before the
+    // fix, `assemble_within_budget` walked each anchor's entity *and* neighbors
+    // before moving to the next anchor, so one anchor's neighbor sprawl could
+    // exhaust the budget and drop every anchor ranked after it — including
+    // anchors a plain entity search on the same query would have surfaced.
+    let pack = pack();
+
+    let bloat = pack
+        .dispatch(
+            "create",
+            json!({"kind": "entity", "name": "CtxStarveBloatAnchor", "entity_kind": "concept", "description": "ctxstarve shared regression phrase alpha"}),
+        )
+        .await
+        .expect("create bloat anchor");
+    let bloat_id = bloat["id"].as_str().unwrap().to_string();
+
+    for i in 0..15 {
+        let n = pack
+            .dispatch(
+                "create",
+                json!({"kind": "entity", "name": format!("CtxStarveBloatNeighbor{i}"), "entity_kind": "concept", "description": "a verbose neighbor description with enough text to consume budget quickly"}),
+            )
+            .await
+            .expect("create bloat neighbor");
+        let n_id = n["id"].as_str().unwrap().to_string();
+        pack.dispatch(
+            "link",
+            json!({"source_id": bloat_id, "target_id": n_id, "relation": "extends"}),
+        )
+        .await
+        .expect("link bloat anchor -> neighbor");
+    }
+
+    let on_topic = pack
+        .dispatch(
+            "create",
+            json!({"kind": "entity", "name": "CtxStarveOnTopicAnchor", "entity_kind": "concept", "description": "ctxstarve shared regression phrase beta"}),
+        )
+        .await
+        .expect("create on-topic anchor");
+    let on_topic_id = on_topic["id"].as_str().unwrap().to_string();
+
+    let query = "ctxstarve shared regression phrase";
+
+    // A plain entity search on the same query surfaces the on-topic anchor.
+    let search_resp = pack
+        .dispatch(
+            "search",
+            json!({"kind": "entity", "query": query, "limit": 5}),
+        )
+        .await
+        .expect("search must succeed");
+    let search_hits = search_resp.as_array().unwrap();
+    assert!(
+        search_hits.iter().any(|h| h["id"] == on_topic_id),
+        "plain entity search must surface the on-topic anchor; got: {search_hits:?}"
+    );
+
+    // A budget that comfortably fits both anchor entity records, but not the
+    // bloated anchor's 15 verbose neighbors.
+    let resp = pack
+        .dispatch(
+            "context",
+            json!({"query": query, "hops": 1, "fanout": 20, "limit": 5, "budget": 900}),
+        )
+        .await
+        .expect("context must succeed");
+
+    let anchors = resp["anchors"].as_array().unwrap();
+    assert!(
+        anchors.iter().any(|a| a["entity"]["id"] == on_topic_id),
+        "the on-topic anchor's entity record must survive a sibling's bloated \
+         neighbor list; got anchors: {anchors:?}"
+    );
+    assert_eq!(
+        resp["dropped"]["anchors"], 0,
+        "no anchor entity should be dropped"
+    );
+    assert!(
+        resp["truncated"] == true,
+        "the bloated neighbor list must still trigger truncation"
+    );
+    assert!(
+        resp["dropped"]["neighbors"].as_i64().unwrap() > 0,
+        "the bloated anchor's neighbors must be the thing that gets dropped"
+    );
+    assert_eq!(
+        resp["dropped"]["stage"], "budget",
+        "drop accounting must name the stage responsible for the drop"
+    );
+}
+
+#[tokio::test]
 async fn context_ample_budget_reports_no_truncation() {
     let pack = pack();
     let a = pack


### PR DESCRIPTION
## Summary

The `context` verb's anchor selection (query → hybrid entity search) is unaffected by this bug — it already reuses the same `hybrid_search` fusion the `search` verb uses, so ranking parity between the two was never the issue.

The bug is in the response-assembly stage. `assemble_within_budget` walked each anchor's entity record *and* its full neighbor list before moving on to the next anchor. A single anchor with a large neighbor fan-out (driven by `fanout`/`hops`, unrelated to how relevant that anchor is to the query) could exhaust the entire byte budget on its own neighbors, dropping every anchor ranked after it in the response — including anchors that a plain entity search on the same query would have surfaced as directly relevant. Increasing `budget`, `hops`, `limit`, or `fanout` doesn't help, since a larger fan-out cap just makes the starving anchor's neighbor list bigger too.

## Fix

Assemble in two passes:

1. **Entity pass** — walk anchors in rank order and reserve budget for each one's own entity record only, ignoring neighbors entirely.
2. **Neighbor pass** — for the anchors that survived pass 1, walk them again in the same rank order and fill neighbors with whatever budget remains.

An anchor's neighbor sprawl can now only crowd out its own or later anchors' *neighbors* — never a sibling anchor's entity record. Anchors that the query legitimately ranked as relevant are no longer collateral damage of an unrelated anchor's graph degree.

Also names the stage responsible for a drop (additive `dropped.stage` field) instead of reporting bare integers, since in this handler every drop originates in the budget-assembly walk — `fanout`/`hops` bound the neighbor candidate pool upstream, before assembly, and never produce a drop themselves. The existing `dropped.anchors` / `dropped.neighbors` counts are unchanged.

## Tests

- Unit test on `assemble_within_budget` reproducing the starvation pattern directly with a bloated first anchor and a small second anchor.
- Integration regression test: a plain `search(kind="entity", ...)` surfaces an on-topic entity for a query; `context(query=...)` with a budget that comfortably fits both anchors' entity records but not one anchor's 15-neighbor fan-out still returns the on-topic anchor's entity record, with `truncated: true` and `dropped.neighbors > 0` accounting for the actual drop.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy -p khive-pack-kg -p khive-runtime --all-targets -- -D warnings`
- [x] `cargo test -p khive-pack-kg -p khive-runtime`