### PR TITLE
fix(khive-request): DSL parse errors explain the fix, not just the position

### DIFF
--- a/crates/khive-request/docs/api/limits-and-errors.md
+++ b/crates/khive-request/docs/api/limits-and-errors.md
@@ -30,7 +30,7 @@ This public helper checks a runtime `serde_json::Value`, including handler resul
 | `UnexpectedEof`          | input ends before a required token                                   |
 | `InvalidIdentifier`      | identifier violates the ASCII identifier grammar                     |
 | `DuplicateArg`           | one operation repeats an argument name                               |
-| `InvalidValue`           | function-form value cannot be decoded or reference syntax is invalid |
+| `InvalidValue`           | function-form value cannot be decoded or reference syntax is invalid; an unquoted bareword names the quoting fix (and the corrected call, when the argument or key is known) |
 | `InvalidJson`            | JSON form is malformed or has the wrong shape                        |
 | `UnclosedString`         | quoted string has no terminator                                      |
 | `UnclosedBracket`        | array, object, or parenthesis has no matching close                  |
@@ -41,5 +41,6 @@ This public helper checks a runtime `serde_json::Value`, including handler resul
 | `UnsupportedVerbNesting` | a tool name has more than one dot                                    |
 | `WriteKeyConflict`       | two parallel operations claim the same derived write key             |
 | `ReservedEnvelopeArg`    | an operation contains an envelope-only field                         |
+| `TrailingComma`          | a batch element list ends `,` immediately before its closing `]`     |
 
 Display messages are actionable and retain values such as byte position, count, duplicated argument, conflicting tools, or reserved field. The enum implements `std::error::Error` and is surfaced as invalid request parameters rather than an operation-level execution failure.

--- a/crates/khive-request/src/parser/dispatch.rs
+++ b/crates/khive-request/src/parser/dispatch.rs
@@ -70,6 +70,14 @@ pub fn parse_request(input: &str) -> Result<ParsedRequest, DslError> {
         return parse_chain_tail(p, first_op);
     }
 
+    // A top-level `,` here means the caller wrote `a(), b()` without the
+    // `[...]` a parallel batch requires — the same top-level-separator
+    // mistake `parse_fn_batch` and `parse_chain_tail` already name via
+    // `MixedSeparators`, just hit before either of them ran.
+    if p.peek() == Some(',') {
+        return Err(DslError::MixedSeparators);
+    }
+
     Err(DslError::UnexpectedChar {
         pos: p.pos,
         found: p.peek().unwrap(),
@@ -199,8 +207,12 @@ fn parse_fn_batch(input: &str) -> Result<ParsedRequest, DslError> {
         p.skip_ws();
         match p.peek() {
             Some(',') => {
+                let comma_pos = p.pos;
                 p.advance(1);
                 p.skip_ws();
+                if p.peek() == Some(']') {
+                    return Err(DslError::TrailingComma { pos: comma_pos });
+                }
             }
             Some(']') => {
                 p.advance(1);

--- a/crates/khive-request/src/parser/parser_impl.rs
+++ b/crates/khive-request/src/parser/parser_impl.rs
@@ -126,7 +126,7 @@ impl<'a> Parser<'a> {
             let name = self.parse_identifier()?;
             self.expect_char('=')?;
             self.skip_ws();
-            let arg_val = self.parse_arg_value()?;
+            let arg_val = self.parse_arg_value_with_hint(Some(&name))?;
             if args.contains_key(&name) {
                 return Err(DslError::DuplicateArg { name });
             }
@@ -154,6 +154,14 @@ impl<'a> Parser<'a> {
     }
 
     fn parse_arg_value(&mut self) -> Result<ArgValue, DslError> {
+        self.parse_arg_value_with_hint(None)
+    }
+
+    /// Same as [`Self::parse_arg_value`], but `hint` names the argument or
+    /// object key this value is being assigned to (when known), so a
+    /// bareword-value failure can show the exact corrected call instead of
+    /// just the corrected literal.
+    fn parse_arg_value_with_hint(&mut self, hint: Option<&str>) -> Result<ArgValue, DslError> {
         self.skip_ws();
         if self.peek() == Some('$') {
             return self.parse_prev_ref();
@@ -164,7 +172,7 @@ impl<'a> Parser<'a> {
         if self.peek() == Some('{') {
             return self.parse_object_arg();
         }
-        let v = self.parse_value()?;
+        let v = self.parse_value(hint)?;
         if let Value::String(s) = &v {
             if let Some(prev_ref) = Self::string_as_prev_ref(s) {
                 return Ok(prev_ref);
@@ -268,7 +276,7 @@ impl<'a> Parser<'a> {
             self.skip_ws();
             self.expect_char(':')?;
             self.skip_ws();
-            let val = self.parse_arg_value()?;
+            let val = self.parse_arg_value_with_hint(Some(&key))?;
             pairs.push((key, val));
             self.skip_ws();
             match self.peek() {
@@ -376,7 +384,10 @@ impl<'a> Parser<'a> {
         Ok(ArgValue::PrevRef { path })
     }
 
-    fn parse_value(&mut self) -> Result<Value, DslError> {
+    /// `hint` names the argument or object key this value is assigned to
+    /// (when the caller knows it), used only to show a fully corrected call
+    /// when the failure is a bareword value (see [`bareword_hint_message`]).
+    fn parse_value(&mut self, hint: Option<&str>) -> Result<Value, DslError> {
         self.skip_ws();
         let start = self.pos;
         let end = self.scan_value_end()?;
@@ -392,9 +403,21 @@ impl<'a> Parser<'a> {
         let value = if trimmed.starts_with('"') {
             Value::String(decode_quoted_json_string(trimmed, start)?)
         } else {
-            serde_json::from_str(trimmed).map_err(|e| DslError::InvalidValue {
-                pos: start,
-                error: e.to_string(),
+            serde_json::from_str(trimmed).map_err(|e| {
+                let error = if is_bareword_identifier(trimmed) {
+                    bareword_hint_message(trimmed, hint)
+                } else {
+                    // `e.to_string()` carries its own "at line L column C",
+                    // always relative to `trimmed` (this one value's own
+                    // slice, always line 1) rather than the DSL input as a
+                    // whole — pairing it verbatim with the `at position
+                    // {start}` this crate reports for the same failure would
+                    // state two different, disagreeing locations for one
+                    // problem. Keep the descriptive prefix, drop the
+                    // contradicting position clause.
+                    strip_serde_position(&e.to_string())
+                };
+                DslError::InvalidValue { pos: start, error }
             })?
         };
         self.pos = end;
@@ -558,7 +581,7 @@ fn describe_quoted_string_parse_error(
     e: &serde_json::Error,
     normalized: &NormalizedQuotedString<'_>,
 ) -> String {
-    let base = e.to_string();
+    let base = strip_serde_position(&e.to_string());
     let Some(offset) = serde_error_byte_offset(e, normalized.text.as_ref()) else {
         return base;
     };
@@ -611,8 +634,52 @@ fn decode_quoted_json_string(raw: &str, pos: usize) -> Result<String, DslError> 
 fn decode_quoted_json_key(raw: &str, pos: usize) -> Result<String, DslError> {
     serde_json::from_str(raw).map_err(|e| DslError::InvalidValue {
         pos,
-        error: e.to_string(),
+        error: strip_serde_position(&e.to_string()),
     })
+}
+
+/// Returns whether `s` is a bare identifier (`[A-Za-z_][A-Za-z0-9_]*`) —
+/// the shape of the most common invalid-value mistake: a string value typed
+/// without its surrounding `"..."`. Only called after `serde_json` has
+/// already rejected `s` as a value, so this never misclassifies a valid
+/// JSON literal (`true`, `false`, `null`, a number) as a bareword.
+fn is_bareword_identifier(s: &str) -> bool {
+    let mut chars = s.chars();
+    match chars.next() {
+        Some(c) if c.is_ascii_alphabetic() || c == '_' => {}
+        _ => return false,
+    }
+    chars.all(|c| c.is_ascii_alphanumeric() || c == '_')
+}
+
+/// Builds the message for a bareword-shaped invalid value. `hint`, when the
+/// caller knows the argument name or object key this value belongs to,
+/// lets the message show the exact corrected call rather than just the
+/// corrected literal — a caller who wrote `id=abc` sees `id="abc"` and can
+/// copy it directly.
+fn bareword_hint_message(bareword: &str, hint: Option<&str>) -> String {
+    match hint {
+        Some(name) => format!(
+            "{bareword:?} is a bareword, not a valid value; string values must be \
+             double-quoted — did you mean {name}={bareword:?}?"
+        ),
+        None => format!(
+            "{bareword:?} is a bareword, not a valid value; string values must be \
+             double-quoted — did you mean {bareword:?}?"
+        ),
+    }
+}
+
+/// Strips a `serde_json` `Display` message's trailing `at line L column C`
+/// clause. That clause is always relative to the isolated substring
+/// `serde_json` parsed (one value's slice, or a quoted string's decoded
+/// body) rather than the overall DSL input, so it disagrees with the
+/// `at position {pos}` this crate reports for the same failure whenever the
+/// value does not start at byte 0. The descriptive prefix (`expected
+/// value`, `trailing characters`, `control character ... found while
+/// parsing a string`, ...) stays meaningful on its own and is kept.
+fn strip_serde_position(msg: &str) -> String {
+    msg.split(" at line ").next().unwrap_or(msg).to_owned()
 }
 
 /// Validates quoted-reference brackets before promoting a string to `PrevRef`.

--- a/crates/khive-request/src/types.rs
+++ b/crates/khive-request/src/types.rs
@@ -222,6 +222,12 @@ pub enum DslError {
         arg_name: String,
         verb: String,
     },
+    /// A batch element list has a `,` immediately before its closing `]`,
+    /// e.g. `[a(),]` — the slot between the comma and the bracket looks
+    /// like a missing element, not a second `,` mistake.
+    TrailingComma {
+        pos: usize,
+    },
 }
 
 impl fmt::Display for DslError {
@@ -312,6 +318,13 @@ impl fmt::Display for DslError {
                     f,
                     "argument {arg_name:?} in verb {verb:?} is reserved for the request \
                      envelope; pass it at the envelope level, not inside verb args"
+                )
+            }
+            DslError::TrailingComma { pos } => {
+                write!(
+                    f,
+                    "at position {pos}: trailing comma before ']' — a batch cannot end with \
+                     an empty element; remove the comma or add another op after it"
                 )
             }
         }

--- a/crates/khive-request/tests/parser.rs
+++ b/crates/khive-request/tests/parser.rs
@@ -298,6 +298,92 @@ fn raw_control_byte_in_object_key_rejected() {
 }
 
 #[test]
+fn bareword_value_names_the_quoting_fix() {
+    // `id=abc` is the most common invalid-value mistake: a string typed
+    // without its surrounding quotes. The message must say it is a
+    // bareword, that string values need double quotes, and — since the
+    // argument name is known here — show the exact corrected call.
+    let err = parse_request("get(id=abc)").unwrap_err();
+    assert!(matches!(err, DslError::InvalidValue { .. }));
+    let msg = err.to_string();
+    assert!(
+        msg.contains("bareword") && msg.contains("double-quoted"),
+        "must name the bareword and the quoting fix, got: {msg}"
+    );
+    assert!(
+        msg.contains(r#"id="abc""#),
+        "must show the corrected call, got: {msg}"
+    );
+}
+
+#[test]
+fn bareword_value_in_object_literal_uses_the_key_as_hint() {
+    // Same mistake, inside a JSON-object-shaped argument value: the key is
+    // known there too, so the reconstructed call still names it.
+    let err = parse_request(r#"update(patch={"name": abc})"#).unwrap_err();
+    assert!(matches!(err, DslError::InvalidValue { .. }));
+    let msg = err.to_string();
+    assert!(
+        msg.contains(r#"name="abc""#),
+        "must show the corrected key:value, got: {msg}"
+    );
+}
+
+#[test]
+fn bareword_value_in_array_element_has_no_reconstruction_to_guess() {
+    // Same mistake, as a bare array element: there is no argument name to
+    // anchor a reconstruction to, so the message must describe the fix
+    // without inventing a call it cannot verify.
+    let err = parse_request("get(id=[abc])").unwrap_err();
+    assert!(matches!(err, DslError::InvalidValue { .. }));
+    let msg = err.to_string();
+    assert!(
+        msg.contains("bareword") && msg.contains("double-quoted"),
+        "must still name the bareword mistake, got: {msg}"
+    );
+}
+
+#[test]
+fn invalid_value_position_and_message_no_longer_disagree() {
+    // Before this fix, a non-bareword invalid value (e.g. `1.2.3`) leaked
+    // serde_json's own "at line 1 column N" — always relative to that
+    // single value's isolated slice, so it disagreed with the DSL-absolute
+    // "at position N" this crate reports for the same failure. The
+    // descriptive part of the message stays; the contradicting position
+    // clause must be gone.
+    let err = parse_request("get(id=1.2.3)").unwrap_err();
+    assert!(matches!(err, DslError::InvalidValue { .. }));
+    let msg = err.to_string();
+    assert!(
+        msg.starts_with("at position 7:"),
+        "expected the DSL-absolute position, got: {msg}"
+    );
+    assert!(
+        !msg.contains("line 1 column"),
+        "must not leak serde's own, disagreeing position, got: {msg}"
+    );
+    assert!(
+        msg.contains("trailing characters"),
+        "must keep serde's descriptive text, got: {msg}"
+    );
+}
+
+#[test]
+fn json_request_form_keeps_its_own_serde_position() {
+    // The JSON request form (an object/array of objects sent as `ops`) is
+    // genuinely JSON end to end — its serde `line`/`column` IS the real
+    // location of the problem, so it must NOT be stripped the way the
+    // function-call form's per-value serde fragment is.
+    let err = parse_request(r#"{"tool": "get", "args": {"id": }}"#).unwrap_err();
+    assert!(matches!(err, DslError::InvalidJson { .. }));
+    let msg = err.to_string();
+    assert!(
+        msg.contains("line 1 column"),
+        "JSON form's own serde position is meaningful and must be kept, got: {msg}"
+    );
+}
+
+#[test]
 fn invalid_backslash_escape_in_quoted_string_rejected() {
     // A negative invalid-escape case: `\q` is not a JSON escape sequence.
     // This must fail regardless of the literal-newline carve-out.
@@ -1069,6 +1155,41 @@ fn comma_only_parallel_accepted() {
     let r = parse_request("[a(), b(), c()]").unwrap();
     assert_eq!(r.mode, ExecutionMode::Parallel);
     assert_eq!(r.ops.len(), 3);
+}
+
+#[test]
+fn mixed_separator_before_any_chain_pipe_reaches_the_same_message() {
+    // `a(), b() | c()` hits the mixed-separator mistake on the very first
+    // op, before a chain `|` has ever been seen — a third code path from
+    // the other two `MixedSeparators` tests above (`[a() | b(), c()]` and
+    // `a() | b(), c()`). All three must reach the same actionable message,
+    // not fall through to a generic "expected '|' or end of input" report.
+    let err = parse_request("a(), b() | c()").unwrap_err();
+    assert!(
+        matches!(err, DslError::MixedSeparators),
+        "expected MixedSeparators, got {err:?}"
+    );
+    let msg = err.to_string();
+    assert!(
+        msg.contains("cannot mix ',' (parallel) and '|' (chain) separators"),
+        "message must name the mix mistake, got: {msg}"
+    );
+}
+
+#[test]
+fn trailing_comma_before_batch_close_bracket_named() {
+    // `[gtd.next(),]` used to fail with a confusing "invalid identifier"
+    // report pointing at the `]` — the real mistake is the trailing `,`.
+    let err = parse_request("[gtd.next(),]").unwrap_err();
+    assert!(
+        matches!(err, DslError::TrailingComma { .. }),
+        "expected TrailingComma, got {err:?}"
+    );
+    let msg = err.to_string();
+    assert!(
+        msg.contains("trailing comma"),
+        "message must name the trailing comma, got: {msg}"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary

The DSL parse layer reported *where* a syntax problem was but never *what*
would fix it — unlike the semantic/param layer, where unknown-field errors
enumerate the accepted set and the short-query error both corrects the
input and routes the caller to the right verb. This brings the parse layer
up to that standard for three specific messages, plus a related fix to a
message that stated two disagreeing locations for one problem.

### Before / after

**Unquoted string value** (`get(id=abc)`):
- Before: `at position 7: invalid value: expected value at line 1 column 1`
- After: `at position 7: invalid value: "abc" is a bareword, not a valid value; string values must be double-quoted — did you mean id="abc"?`

**Trailing comma in a batch** (`[gtd.next(),]`):
- Before: `at position 11: invalid identifier (expected [A-Za-z_][A-Za-z0-9_]*)`
- After: `at position 11: trailing comma before ']' — a batch cannot end with an empty element; remove the comma or add another op after it`

**Mixing `,` and `|` separators** (`a(), b() | c()`):
- Before: `expected '|' or end of input, found ','`
- After: `cannot mix ',' (parallel) and '|' (chain) separators at the top level` — the message already existed and was reachable from two of three code paths that hit this mistake; it is now reachable from all three.

**A scalar value's own decode failure** (e.g. `get(id=1.2.3)`) no longer
leaks `serde_json`'s `at line 1 column N`, which is always relative to that
one value's isolated slice and so disagreed with the DSL-absolute `at
position N` this crate reports for the same failure. The descriptive text
(`trailing characters`, `expected value`, ...) is kept; only the
contradicting position clause is dropped. The JSON request form's own
`serde_json` position is untouched — there it parses the whole input, so
its line/column is genuinely correct.

## Behavior

No grammar change. Every input that parsed successfully before this PR
still parses to the identical AST — this is an error-message change only.
The `DslError` enum gains one variant (`TrailingComma`) to name the new
diagnostic distinctly rather than reusing an unrelated one.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy -p khive-request --all-targets -- -D warnings`
- [x] `cargo test -p khive-request` (139 passed, including 7 new tests asserting on message content)
- [x] `cargo test --workspace` (pre-existing, unrelated failures in `khive-mcp`'s `pending_events` tests — reproduced identically on `main` before this change; a missing commercial `gtd` pack in this build, not touched by this PR)