### PR TITLE
kg: add whoami verb for caller identity introspection

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,7 @@ khive gives your agent:
 2. **Notes** — observations, insights, questions, decisions, references that persist across sessions
 3. **Pattern matching queries** — GQL/SPARQL traverse over the graph
 
-The `kg` pack loads by default, giving the `request` tool an 18-verb catalog. Task
+The `kg` pack loads by default, giving the `request` tool a 19-verb catalog. Task
 management (GTD lifecycle), memory (salience- and decay-weighted recall), communication
 (namespaced message passing between agents), scheduling (time-triggered reminders and
 future verb dispatch), session continuity (persist and resume agent-session records),
@@ -29,7 +29,7 @@ or JSON form (ADR-016,
 ADR-027). Verb semantics and namespace contract are
 defined in ADR-023.
 
-### KG pack — 18 verbs (bare names, no prefix)
+### KG pack — 19 verbs (bare names, no prefix)
 
 | Verb        | What it does                                                                                     | When to use                                                             |
 | ----------- | ------------------------------------------------------------------------------------------------ | ----------------------------------------------------------------------- |
@@ -51,6 +51,7 @@ defined in ADR-023.
 | `resolve`   | Resolve natural-language references to ids (id passthrough, recent-ring, hybrid search fallback) | Turning a fuzzy reference ("the old record") into an id before acting   |
 | `verbs`     | List all registered verbs on this server                                                         | Discovery — see what's available                                        |
 | `context`   | Entity-anchored graph context in one call (anchors + 1-2 hop expansion, budget-packed)           | Feeding an agent "everything relevant near X" in one call — see ADR-089 |
+| `whoami`    | Report the caller's actor reference, write namespace, and read-visible namespace set             | Checking whether writes are attributed before relying on it             |
 
 `get`, `update`, `delete` are by-ID — they auto-detect whether the record is an entity, note, or
 edge. The `id` parameter is resolved in three steps: (1) a full UUID (36-char dashed or 32-char

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `whoami` verb (kg pack, bare name): reports the caller's actor reference,
+  write namespace, and read-visible namespace set already resolved by the
+  runtime for the current request. The default pack set now exposes 19 verbs.
+
 ### Changed
 
 - Reduced the open-source distribution to a single production pack: `kg`. The

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,7 +56,7 @@ behavior isn't written there, it is an unspecified design decision → escalate,
 └──────────────────────────────────────────────────────────────┘
                             ↕ VerbRegistry dispatch
 ┌──────────────────────────────────────────────────────────────┐
-│  khive-pack-kg     — KG vocabulary + 18 verb handlers (ADR-017)     │
+│  khive-pack-kg     — KG vocabulary + 19 verb handlers (ADR-017)     │
 │  khive-vcs         — KG versioning: snapshots/branches (ADR-010)    │
 │  khive-merge       — KG merge algorithm (ADR-039)                   │
 └──────────────────────────────────────────────────────────────┘
@@ -98,7 +98,7 @@ not shipped.
 | `crates/khive-query`     | GQL + SPARQL parsers, AST validation, SQL compiler                                                       |
 | `crates/khive-runtime`   | Service API + VerbRegistry + PackRuntime trait                                                           |
 | `crates/khive-request`   | Request DSL parser (function-call + JSON; pipe/LNDL planned)                                             |
-| `crates/khive-pack-kg`   | KG pack: vocabulary, 18 verb handlers, kind validation                                                   |
+| `crates/khive-pack-kg`   | KG pack: vocabulary, 19 verb handlers, kind validation                                                   |
 | `crates/khive-vcs`       | KG versioning: content-addressed snapshots, branch pointers, push/pull (ADR-010)                         |
 | `crates/khive-merge`     | KG merge: three-way merge with LCA walk, conflict enum, strategy shortcuts (ADR-039)                     |
 | `crates/khive-mcp`       | Stdio MCP binary — single `request` tool over VerbRegistry; auto-spawns daemon                           |
@@ -169,7 +169,7 @@ linking, blob storage, and the profile-oriented feedback/learning-loop pack (`br
 provided by commercially licensed extensions and are not part of this distribution; when
 installed, they load the same way, via `KHIVE_PACKS`/`--pack`.
 
-### KG pack verbs (18 — ADR-017, ADR-046, ADR-089)
+### KG pack verbs (19 — ADR-017, ADR-046, ADR-089)
 
 `create`, `list`, and `search` take a `kind` discriminant. It accepts either the substrate-level
 name (`entity`, `note`, `edge`) **or** a pack-registered granular kind (`concept`, `document`,
@@ -196,6 +196,7 @@ Mixing a granular `kind` with a contradicting `entity_kind`/`note_kind` sub-filt
 | `resolve`   | `refs`, `kind?`, `limit?`                                                                    | Resolve natural-language references to ids (id passthrough, recent-ring, hybrid-search fallback) |
 | `verbs`     | `category?`, `pack?`                                                                         | List all MCP-callable verbs registered on this server                                            |
 | `context`   | `query?`, `entity_ids?`, `hops?`, `budget?`, `relations?`, `direction?`, `limit?`, `fanout?` | Entity-anchored graph context in one call (ADR-089)                                              |
+| `whoami`    | —                                                                                            | Report the caller's actor reference, write namespace, and read-visible namespace set             |
 
 Task-management (`gtd.*`) and memory-recall (`memory.*`) verbs are provided by commercially
 licensed extensions and are not part of the open-source distribution.

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ stdio, and `cargo test` finishes in 4 seconds.
 
 | Capability                  | How                                                                                                                                                      |
 | --------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **18 verbs, 1 pack**        | KG: entities, edges, notes, graph queries, reference resolution — loads by default                                                                       |
+| **19 verbs, 1 pack**        | KG: entities, edges, notes, graph queries, reference resolution, caller identity — loads by default                                                      |
 | **Typed entities**          | 9 closed kinds: concept, document, dataset, project, person, org, artifact, service, resource                                                            |
 | **Typed edges**             | 17 closed relations in 9 categories (structure, derivation, provenance, temporal, dependency, impl, lateral, annotation, epistemic)                      |
 | **Typed notes**             | 5 closed kinds: observation, insight, question, decision, reference                                                                                      |
@@ -63,12 +63,12 @@ request(ops="[v1(...), v2(...), v3(...)]")             # parallel batch (max 100
 request(ops="[{\"tool\":\"v1\",\"args\":{...}}, ...]") # equivalent JSON form
 ```
 
-The `kg` pack loads by default, giving **18 verbs** out of the box (regenerate with
+The `kg` pack loads by default, giving **19 verbs** out of the box (regenerate with
 `request(ops="verbs()")` before editing this table):
 
-| Pack   | Prefix   | Verbs | What it does                                                |
-| ------ | -------- | ----- | ----------------------------------------------------------- |
-| **kg** | _(bare)_ | 18    | Entities, edges, notes, graph queries, reference resolution |
+| Pack   | Prefix   | Verbs | What it does                                                                 |
+| ------ | -------- | ----- | ---------------------------------------------------------------------------- |
+| **kg** | _(bare)_ | 19    | Entities, edges, notes, graph queries, reference resolution, caller identity |
 
 Task management, memory recall, inter-agent messaging, scheduling, session continuity,
 workspace linking, and blob storage are provided by commercially licensed extensions and
@@ -129,7 +129,7 @@ records what's connected, in which direction, and why.
 └──────────────────────────────────────────────────────────────┘
                             ↕ VerbRegistry dispatch
 ┌──────────────────────────────────────────────────────────────┐
-│  khive-pack-kg:        KG vocabulary + 18 verb handlers       │
+│  khive-pack-kg:        KG vocabulary + 19 verb handlers       │
 └──────────────────────────────────────────────────────────────┘
                             ↕ in-process
 ┌──────────────────────────────────────────────────────────────┐
@@ -230,7 +230,7 @@ kkernel --version   # confirms the binary and version you just installed
 ```
 
 The `kg` pack loads by default, a background daemon auto-spawns to keep the runtime warm, and any
-MCP client discovers the `request` tool with the full 18-verb catalog.
+MCP client discovers the `request` tool with the full 19-verb catalog.
 
 ### Alternative: npm
 
@@ -359,7 +359,7 @@ transparency and for building on top of khive under its license terms.
 
 ## Status
 
-**v0.5.0 (publication pending; crates.io currently serves 0.4.0).** 18 verbs in the
+**v0.5.0 (publication pending; crates.io currently serves 0.4.0).** 19 verbs in the
 `kg` pack, 9 entity kinds, 17 edge relations, daemon warm startup (ADR-049).
 Ready for use with Claude Code and any MCP-compatible agent.
 

--- a/crates/khive-pack-kg/README.md
+++ b/crates/khive-pack-kg/README.md
@@ -7,7 +7,7 @@ workspace declares it as a dependency.
 
 ## Verbs
 
-17 handlers, registered under ADR-017:
+19 handlers, registered under ADR-017:
 
 | Verb        | What it does                                                                    |
 | ----------- | ------------------------------------------------------------------------------- |
@@ -28,6 +28,8 @@ workspace declares it as a dependency.
 | `verbs`     | List all MCP-callable verbs registered on the server                            |
 | `stats`     | Aggregate KG substrate counts (entities, edges, notes)                          |
 | `context`   | Entity-anchored graph context in one call (ADR-089)                             |
+| `resolve`   | Resolve natural-language references to record ids                               |
+| `whoami`    | Report the caller identity this request resolved to                             |
 
 `propose`/`review`/`withdraw` implement the event-sourced proposal lifecycle from
 ADR-046.

--- a/crates/khive-pack-kg/docs/design.md
+++ b/crates/khive-pack-kg/docs/design.md
@@ -4,26 +4,27 @@
 
 ## Scope
 
-The KG pack provides 18 verb handlers for the knowledge graph substrate: entity
+The KG pack provides 19 verb handlers for the knowledge graph substrate: entity
 CRUD, note CRUD, edge creation/traversal, hybrid search, graph queries (GQL),
-entity-anchored graph context (ADR-089), and event-sourced proposals (ADR-046).
+entity-anchored graph context (ADR-089), event-sourced proposals (ADR-046), and
+caller identity introspection (`whoami`).
 It is the first-party pack shipped with the khive binary.
 
 ## ADR Compliance
 
-| ADR                                                                | What it governs                                   | Status      |
-| ------------------------------------------------------------------ | ------------------------------------------------- | ----------- |
-| ADR-001       | 9 entity kinds (8 base + resource per ADR-048)    | Implemented |
-| ADR-002              | 17 edge relations, closed set (15 base + 2 epistemic via ADR-055) | Implemented |
-| ADR-007                  | KG uses shared `local` namespace                  | Implemented |
-| ADR-013         | 5 base note kinds                                 | Implemented |
-| ADR-014        | UUID-only get/update/delete                       | Implemented |
-| ADR-017              | Pack trait, vocabulary, edge rules                | Implemented |
-| ADR-001       | Alias normalization (paper→document, write-time)  | Implemented |
-| ADR-045 | ISO-8601 timestamps at handler boundary           | Implemented |
-| ADR-046    | Event-sourced proposals (propose/review/withdraw) | Implemented |
-| ADR-048 | `resource` entity kind (9th kind)                 | Implemented |
-| ADR-089               | `context` verb — entity-anchored graph context    | Implemented |
+| ADR     | What it governs                                                   | Status      |
+| ------- | ----------------------------------------------------------------- | ----------- |
+| ADR-001 | 9 entity kinds (8 base + resource per ADR-048)                    | Implemented |
+| ADR-002 | 17 edge relations, closed set (15 base + 2 epistemic via ADR-055) | Implemented |
+| ADR-007 | KG uses shared `local` namespace                                  | Implemented |
+| ADR-013 | 5 base note kinds                                                 | Implemented |
+| ADR-014 | UUID-only get/update/delete                                       | Implemented |
+| ADR-017 | Pack trait, vocabulary, edge rules                                | Implemented |
+| ADR-001 | Alias normalization (paper→document, write-time)                  | Implemented |
+| ADR-045 | ISO-8601 timestamps at handler boundary                           | Implemented |
+| ADR-046 | Event-sourced proposals (propose/review/withdraw)                 | Implemented |
+| ADR-048 | `resource` entity kind (9th kind)                                 | Implemented |
+| ADR-089 | `context` verb — entity-anchored graph context                    | Implemented |
 
 ## Primary Modules
 
@@ -32,8 +33,8 @@ It is the first-party pack shipped with the khive binary.
 | [`src/lib.rs`](../src/lib.rs)                                     | Pack re-exports and crate documentation                  |
 | [`src/pack.rs`](../src/pack.rs)                                   | KgPack struct, Pack trait impl, edge endpoint rules      |
 | [`src/dispatch.rs`](../src/dispatch.rs)                           | PackRuntime impl, inventory self-registration            |
-| [`src/handler_defs.rs`](../src/handler_defs.rs)                   | KG_HANDLERS static table (18 HandlerDef entries)         |
-| [`src/handlers/mod.rs`](../src/handlers/mod.rs)                   | 18 verb handler implementations                          |
+| [`src/handler_defs.rs`](../src/handler_defs.rs)                   | KG_HANDLERS static table (19 HandlerDef entries)         |
+| [`src/handlers/mod.rs`](../src/handlers/mod.rs)                   | 19 verb handler implementations                          |
 | [`src/vocab.rs`](../src/vocab.rs)                                 | EntityKind (9) and NoteKind (5) enums with alias parsing |
 | [`src/entity_type_registry.rs`](../src/entity_type_registry.rs)   | Validates entity_type against per-kind subtypes          |
 | [`src/apply_worker/mod.rs`](../src/apply_worker/mod.rs)           | Applies approved proposal changesets to KG               |

--- a/crates/khive-pack-kg/src/dispatch.rs
+++ b/crates/khive-pack-kg/src/dispatch.rs
@@ -218,6 +218,7 @@ impl PackRuntime for KgPack {
             "review" => self.handle_review(graph_token, params, registry).await,
             "withdraw" => self.handle_withdraw(graph_token, params).await,
             "stats" => self.handle_stats(graph_token, params).await,
+            "whoami" => self.handle_whoami(graph_token, params).await,
             "resolve" => self.handle_resolve(graph_token, params, registry).await,
             "merge" => self.handle_merge(graph_token, params, registry).await,
             // UUID-based: entities/edges use graph token, notes/events use caller token.

--- a/crates/khive-pack-kg/src/dispatch.rs
+++ b/crates/khive-pack-kg/src/dispatch.rs
@@ -234,7 +234,7 @@ impl PackRuntime for KgPack {
 
 #[cfg(test)]
 mod tests {
-    use khive_runtime::{KhiveRuntime, Namespace, VerbRegistryBuilder};
+    use khive_runtime::{KhiveRuntime, Namespace, RuntimeConfig, VerbRegistryBuilder};
     use serde_json::json;
 
     use super::*;
@@ -331,6 +331,46 @@ mod tests {
                 .iter()
                 .all(|e| e.get("namespace").and_then(|v| v.as_str()) != Some("tenant-a")),
             "list from tenant-b must not include tenant-a entities; got {items:?}"
+        );
+    }
+
+    /// A configured actor whose id happens to be `"local"` is not the anonymous
+    /// kind — `ActorRef::is_anonymous()` is false — but the runtime's own
+    /// authorization/token-minting policy (`actor_is_unattributed`) still
+    /// treats any `"local"`-id actor as the unattributed fallback. `whoami`
+    /// must report the same verdict its caller will actually get from the
+    /// rest of the runtime.
+    #[tokio::test]
+    async fn kg_whoami_flags_configured_local_actor_as_unattributed() {
+        let rt = KhiveRuntime::new(RuntimeConfig {
+            db_path: None,
+            packs: vec!["kg".to_string()],
+            brain_profile: None,
+            actor_id: Some("local".to_string()),
+            ..RuntimeConfig::no_embeddings()
+        })
+        .expect("in-memory runtime with configured local actor");
+
+        let token = rt.authorize(Namespace::local()).expect("authorize local");
+        assert!(
+            !token.actor().is_anonymous(),
+            "a configured actor_id must not resolve to the anonymous kind"
+        );
+
+        let mut builder = VerbRegistryBuilder::new();
+        builder.register(KgPack::new(rt.clone()));
+        let registry = builder.build().expect("registry build");
+
+        let pack = KgPack::new(rt.clone());
+        let result = pack
+            .dispatch("whoami", json!({}), &registry, &token)
+            .await
+            .expect("whoami must succeed");
+
+        assert_eq!(
+            result.get("unattributed").and_then(|v| v.as_bool()),
+            Some(true),
+            "a configured 'local' actor must report unattributed: true, got {result:?}"
         );
     }
 

--- a/crates/khive-pack-kg/src/handler_defs.rs
+++ b/crates/khive-pack-kg/src/handler_defs.rs
@@ -1,4 +1,4 @@
-//! Static `KG_HANDLERS` table (18 `HandlerDef` entries) and the `verbs` introspection handler.
+//! Static `KG_HANDLERS` table (19 `HandlerDef` entries) and the `verbs` introspection handler.
 
 // Illocutionary classification (Searle 1976):
 //   Assertive  -- retrieves/presents state of affairs

--- a/crates/khive-pack-kg/src/handler_defs.rs
+++ b/crates/khive-pack-kg/src/handler_defs.rs
@@ -14,7 +14,7 @@ use serde_json::Value;
 use khive_runtime::{RuntimeError, VerbRegistry};
 use khive_types::{HandlerDef, ParamDef, VerbCategory, Visibility};
 
-pub(crate) static KG_HANDLERS: [HandlerDef; 18] = [
+pub(crate) static KG_HANDLERS: [HandlerDef; 19] = [
     // Commissive: commits an entity or note to the namespace
     HandlerDef {
         name: "create",
@@ -897,6 +897,18 @@ pub(crate) static KG_HANDLERS: [HandlerDef; 18] = [
                               bound. Default 5, max 20.",
             },
         ],
+    },
+    // Assertive: reports the caller's own resolved identity
+    HandlerDef {
+        name: "whoami",
+        description: "Report the caller's identity as the runtime already resolved it for \
+                      this request: actor_id, actor_kind, whether the actor is the \
+                      unattributed/anonymous fallback, the write namespace, and the \
+                      read-visible namespace set. Never returns tokens or credentials — \
+                      only labels the runtime already computed before dispatch.",
+        visibility: Visibility::Verb,
+        category: VerbCategory::Assertive,
+        params: &[],
     },
     // Assertive: verb discovery (ue-help-introspection H5)
     HandlerDef {

--- a/crates/khive-pack-kg/src/handlers/common.rs
+++ b/crates/khive-pack-kg/src/handlers/common.rs
@@ -23,7 +23,8 @@ use crate::vocab::NoteKind;
 pub(crate) use super::params::{
     ContextParams, CreateParams, DeleteParams, GetParams, LinkParams, ListParams,
     ListProposalsParams, MergeParams, NeighborsParams, ProposeParams, QueryParams, ReviewParams,
-    SearchParams, StatsParams, TraverseParams, UpdateParams, WithdrawParams, HARD_CAP,
+    SearchParams, StatsParams, TraverseParams, UpdateParams, WhoamiParams, WithdrawParams,
+    HARD_CAP,
 };
 
 // ---- Kind canonicalization ----

--- a/crates/khive-pack-kg/src/handlers/mod.rs
+++ b/crates/khive-pack-kg/src/handlers/mod.rs
@@ -14,6 +14,7 @@ mod resolve;
 mod search;
 mod stats;
 mod update;
+mod whoami;
 
 pub(crate) use common::{canonical_entity_kind, canonical_note_kind, parse_relation};
 

--- a/crates/khive-pack-kg/src/handlers/params.rs
+++ b/crates/khive-pack-kg/src/handlers/params.rs
@@ -95,6 +95,10 @@ pub(crate) struct ListParams {
 #[serde(deny_unknown_fields)]
 pub(crate) struct StatsParams {}
 
+#[derive(Deserialize, Default)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct WhoamiParams {}
+
 /// ADR-099 B3: `pub` so kkernel's `--atomic` seam can deserialize through this same
 /// canonical struct, reproducing `deny_unknown_fields` rejection. Fields stay
 /// `pub(crate)` — the atomic seam only needs the `Result<_, _>` outcome.

--- a/crates/khive-pack-kg/src/handlers/tests.rs
+++ b/crates/khive-pack-kg/src/handlers/tests.rs
@@ -173,16 +173,16 @@ fn propose_params_no_actor_field() {
     assert_eq!(p.title, "Fix RoPE");
 }
 
-// KG pack must expose exactly 18 handlers including propose/review/withdraw/verbs/stats/context/resolve
+// KG pack must expose exactly 19 handlers including propose/review/withdraw/verbs/stats/context/resolve/whoami
 #[test]
-fn kg_pack_exposes_18_handlers() {
+fn kg_pack_exposes_19_handlers() {
     use crate::KgPack;
     use khive_types::Pack;
     let handlers = KgPack::HANDLERS;
     assert_eq!(
         handlers.len(),
-        18,
-        "kg pack must expose 18 handlers (was 17, +1 for resolve — unified-verb draft ADR Slice 1)"
+        19,
+        "kg pack must expose 19 handlers (was 18, +1 for whoami)"
     );
     let names: Vec<&str> = handlers.iter().map(|h| h.name).collect();
     assert!(names.contains(&"propose"), "propose must be in KG_HANDLERS");

--- a/crates/khive-pack-kg/src/handlers/whoami.rs
+++ b/crates/khive-pack-kg/src/handlers/whoami.rs
@@ -2,7 +2,7 @@
 
 use serde_json::{json, Value};
 
-use khive_runtime::{NamespaceToken, RuntimeError};
+use khive_runtime::{actor_is_unattributed, NamespaceToken, RuntimeError};
 
 use super::common::{deser, WhoamiParams};
 use crate::KgPack;
@@ -12,6 +12,12 @@ impl KgPack {
     /// caller's actor reference, write namespace, and read-visible namespace
     /// set. A projection of existing `NamespaceToken` state, not new state —
     /// every field here is already computed before dispatch reaches a handler.
+    ///
+    /// `unattributed` uses the same id-based fallback predicate as gate
+    /// checks, token minting, and comm attribution (`actor_is_unattributed`),
+    /// not `ActorRef::is_anonymous()` — a configured actor whose id happens
+    /// to be `"local"` is still treated as the unattributed fallback
+    /// elsewhere in the runtime, and this verb must agree with that.
     pub(crate) async fn handle_whoami(
         &self,
         token: &NamespaceToken,
@@ -22,7 +28,7 @@ impl KgPack {
         Ok(json!({
             "actor_id": actor.id,
             "actor_kind": actor.kind,
-            "unattributed": actor.is_anonymous(),
+            "unattributed": actor_is_unattributed(actor),
             "namespace": token.namespace().as_str(),
             "visible_namespaces": token.visible_namespace_strs(),
         }))

--- a/crates/khive-pack-kg/src/handlers/whoami.rs
+++ b/crates/khive-pack-kg/src/handlers/whoami.rs
@@ -1,0 +1,30 @@
+//! `whoami` verb handler.
+
+use serde_json::{json, Value};
+
+use khive_runtime::{NamespaceToken, RuntimeError};
+
+use super::common::{deser, WhoamiParams};
+use crate::KgPack;
+
+impl KgPack {
+    /// Report the identity the runtime already resolved for this request: the
+    /// caller's actor reference, write namespace, and read-visible namespace
+    /// set. A projection of existing `NamespaceToken` state, not new state —
+    /// every field here is already computed before dispatch reaches a handler.
+    pub(crate) async fn handle_whoami(
+        &self,
+        token: &NamespaceToken,
+        params: Value,
+    ) -> Result<Value, RuntimeError> {
+        let _p: WhoamiParams = deser(params)?;
+        let actor = token.actor();
+        Ok(json!({
+            "actor_id": actor.id,
+            "actor_kind": actor.kind,
+            "unattributed": actor.is_anonymous(),
+            "namespace": token.namespace().as_str(),
+            "visible_namespaces": token.visible_namespace_strs(),
+        }))
+    }
+}

--- a/crates/khive-pack-kg/src/lib.rs
+++ b/crates/khive-pack-kg/src/lib.rs
@@ -1,4 +1,4 @@
-//! pack-kg — Knowledge Graph verb pack for khive. 18 verbs: entities, notes, edges, queries, proposals, context, resolve.
+//! pack-kg — Knowledge Graph verb pack for khive. 19 verbs: entities, notes, edges, queries, proposals, context, resolve, whoami.
 
 pub mod apply_worker;
 mod dispatch;

--- a/crates/khive-pack-kg/tests/integration.rs
+++ b/crates/khive-pack-kg/tests/integration.rs
@@ -81,14 +81,14 @@ fn invalid_input_message(err: &RuntimeError) -> &str {
 // ADR-046 (cluster-22) added propose, review, and withdraw — bringing the
 // handler count from 11 to 14, then 15 with verbs introspection, then 16
 // with stats, then 17 with context (ADR-089), then 18 with resolve
-// (unified-verb draft ADR Slice 1).
+// (unified-verb draft ADR Slice 1), then 19 with whoami.
 #[test]
-fn pack_verbs_returns_eighteen() {
+fn pack_verbs_returns_nineteen() {
     let pack = pack();
     assert_eq!(
         pack.verbs().len(),
-        18,
-        "KgPack must expose exactly 18 verbs (17 previous + resolve)"
+        19,
+        "KgPack must expose exactly 19 verbs (18 previous + whoami)"
     );
 }
 
@@ -115,6 +115,7 @@ fn pack_verbs_names_are_correct() {
         "verbs",
         "context",
         "resolve",
+        "whoami",
     ] {
         assert!(names.contains(expected), "verbs() missing {expected:?}");
     }
@@ -11723,5 +11724,131 @@ async fn search_entity_hyphenated_adr_id_with_plain_terms_matches() {
     assert!(
         titles.iter().any(|t| t.contains("ADR-086")),
         "#1064 hyphenated query must surface ADR-086 entity; got titles={titles:?}, full={result}"
+    );
+}
+
+// ---- whoami verb ----
+
+#[tokio::test]
+async fn whoami_reports_configured_actor_and_namespace() {
+    let rt = KhiveRuntime::memory().expect("in-memory runtime must succeed");
+    let mut builder = VerbRegistryBuilder::new();
+    builder.with_actor_id(Some("lambda:khive".to_string()));
+    builder.register(KgPack::new(rt));
+    let registry = builder.build().expect("registry builds");
+
+    let result = registry
+        .dispatch("whoami", json!({}))
+        .await
+        .expect("whoami must succeed");
+
+    assert_eq!(
+        result.get("actor_id").and_then(Value::as_str),
+        Some("lambda:khive"),
+        "whoami must report the configured actor id; got: {result}"
+    );
+    assert_eq!(
+        result.get("actor_kind").and_then(Value::as_str),
+        Some("actor"),
+        "a configured actor id resolves to kind=\"actor\"; got: {result}"
+    );
+    assert_eq!(
+        result.get("unattributed").and_then(Value::as_bool),
+        Some(false),
+        "a configured actor must not be reported unattributed; got: {result}"
+    );
+    assert_eq!(
+        result.get("namespace").and_then(Value::as_str),
+        Some("local"),
+        "default namespace with no explicit override is 'local'; got: {result}"
+    );
+    let visible = result
+        .get("visible_namespaces")
+        .and_then(Value::as_array)
+        .expect("visible_namespaces must be an array");
+    assert!(
+        visible.iter().any(|v| v.as_str() == Some("local")),
+        "visible_namespaces must include the write namespace; got: {result}"
+    );
+}
+
+// A cold caller in a single-actor deployment (no configured actor_id) is
+// exactly who most needs whoami — it must answer honestly, not error.
+#[tokio::test]
+async fn whoami_reports_unattributed_when_no_actor_configured() {
+    let pack = pack();
+    let result = pack
+        .dispatch("whoami", json!({}))
+        .await
+        .expect("whoami must succeed");
+
+    assert_eq!(
+        result.get("unattributed").and_then(Value::as_bool),
+        Some(true),
+        "no configured actor_id must report unattributed=true; got: {result}"
+    );
+    assert_eq!(
+        result.get("actor_id").and_then(Value::as_str),
+        Some("local"),
+        "unattributed caller's actor_id is the anonymous fallback 'local'; got: {result}"
+    );
+    assert!(
+        result.get("namespace").and_then(Value::as_str).is_some(),
+        "whoami must always report a namespace, even for the unattributed caller; got: {result}"
+    );
+}
+
+#[tokio::test]
+async fn whoami_rejects_unknown_params() {
+    let pack = pack();
+    let err = pack
+        .dispatch("whoami", json!({"bogus": true}))
+        .await
+        .unwrap_err();
+    assert!(
+        is_invalid_input(&err),
+        "unknown whoami param must be InvalidInput; got {err:?}"
+    );
+}
+
+// Never expose anything that could authenticate — only labels.
+#[tokio::test]
+async fn whoami_never_exposes_secret_shaped_fields() {
+    let pack = pack();
+    let result = pack
+        .dispatch("whoami", json!({}))
+        .await
+        .expect("whoami must succeed");
+    let obj = result.as_object().expect("whoami must return an object");
+    for forbidden in [
+        "token",
+        "secret",
+        "credential",
+        "api_key",
+        "password",
+        "key",
+    ] {
+        assert!(
+            !obj.contains_key(forbidden),
+            "whoami must never expose a {forbidden:?} field; got: {result}"
+        );
+    }
+}
+
+#[tokio::test]
+async fn whoami_appears_in_verbs_introspection() {
+    let pack = pack();
+    let result = pack
+        .dispatch("verbs", json!({}))
+        .await
+        .expect("verbs must succeed");
+    let verbs = result.get("verbs").and_then(|v| v.as_array()).unwrap();
+    let names: Vec<&str> = verbs
+        .iter()
+        .filter_map(|v| v.get("verb").and_then(|n| n.as_str()))
+        .collect();
+    assert!(
+        names.contains(&"whoami"),
+        "whoami must be registered as a public verb; got {names:?}"
     );
 }

--- a/crates/kkernel/docs/design.md
+++ b/crates/kkernel/docs/design.md
@@ -43,10 +43,10 @@
 
 ### Verb namespace contract (ADR-023)
 
-- The kg substrate pack owns 18 bare verb names (no dot prefix): `create`, `get`,
+- The kg substrate pack owns 19 bare verb names (no dot prefix): `create`, `get`,
   `list`, `stats`, `update`, `delete`, `search`, `link`, `neighbors`, `traverse`,
   `query`, `merge`, `propose`, `review`, `withdraw`, `resolve`, `verbs`, `context`
-  (ADR-089).
+  (ADR-089), `whoami`.
 - A commercially licensed extension pack, when installed, must prefix its verbs with
   `<pack>.` (e.g. `<pack>.verb`); sub-variants use underscore, not nested dots
   (`<pack>.verb_variant`, not `<pack>.verb.variant`).
@@ -98,7 +98,7 @@
 ### Proposal lifecycle (ADR-046)
 
 - The kg pack exposes `propose`, `review`, and `withdraw` verbs as part of the
-  18 kg-substrate bare verbs. These are validated by the contract test.
+  19 kg-substrate bare verbs. These are validated by the contract test.
 
 ### Atomic `exec --ops-file --atomic` execution path (ADR-099 Slice B3)
 

--- a/crates/kkernel/src/pack_introspect.rs
+++ b/crates/kkernel/src/pack_introspect.rs
@@ -219,12 +219,12 @@ mod tests {
             "kg pack must expose verbs; got {:?}",
             info.verbs
         );
-        // kg pack ships 18 verbs: 11 base + propose/review/withdraw (3) + verbs
-        // + stats (2) + context (1, ADR-089) + resolve (1)
+        // kg pack ships 19 verbs: 11 base + propose/review/withdraw (3) + verbs
+        // + stats (2) + context (1, ADR-089) + resolve (1) + whoami (1)
         assert_eq!(
             info.verbs.len(),
-            18,
-            "kg pack must expose 18 verbs; got {}: {:?}",
+            19,
+            "kg pack must expose 19 verbs; got {}: {:?}",
             info.verbs.len(),
             info.verbs.iter().map(|v| &v.name).collect::<Vec<_>>()
         );

--- a/crates/kkernel/tests/verb_namespace_contract.rs
+++ b/crates/kkernel/tests/verb_namespace_contract.rs
@@ -29,10 +29,11 @@ use khive_pack_kg::KgPack as _;
 /// Bare verb names owned by the kg substrate pack. These are the only names
 /// permitted to omit the `<pack>.` prefix.
 ///
-/// The 18 entries cover CRUD + graph + curation + proposal primitives, plus
+/// The 19 entries cover CRUD + graph + curation + proposal primitives, plus
 /// `stats` for aggregate namespace metrics, `verbs` for verb-registry
 /// introspection (J-help PR #464), `context` for entity-anchored graph
-/// context in one call (ADR-089), and `resolve` for reference resolution (S1).
+/// context in one call (ADR-089), `resolve` for reference resolution (S1),
+/// and `whoami` for caller identity introspection.
 const KG_SUBSTRATE_VERBS: &[&str] = &[
     "create",
     "get",
@@ -52,6 +53,7 @@ const KG_SUBSTRATE_VERBS: &[&str] = &[
     "verbs",
     "context",
     "resolve",
+    "whoami",
 ];
 
 fn build_full_registry() -> Vec<(String, String)> {

--- a/docs/guide/api-reference.md
+++ b/docs/guide/api-reference.md
@@ -1,13 +1,13 @@
 # API Reference
 
-khive exposes exactly one MCP tool, `request`. Everything else, 18 verbs in the `kg`
+khive exposes exactly one MCP tool, `request`. Everything else, 19 verbs in the `kg`
 pack, is dispatched through that single tool via a small request DSL. This page
 documents the DSL grammar, the response envelope, and every verb's full parameter
 contract, so an agent can call khive correctly without reading Rust source.
 
 This page is verified against the live registry (`request(ops="verbs()")`) and the pack
 source (`crates/khive-pack-kg/src/*.rs` `HandlerDef`/`ParamDef` struct literals). Verb
-count: **18**, matching the live registry `total` field for the default `kg`-only pack
+count: **19**, matching the live registry `total` field for the default `kg`-only pack
 set. If your server reports a different total, your `KHIVE_PACKS` configuration loads
 additional (commercially licensed) packs beyond the open-source default — run
 `request(ops="verbs()")` against your own server to get the authoritative list.
@@ -21,7 +21,7 @@ An always-machine-readable copy of this page is at
 
 | Pack | Verbs | Load with                  | Optional?           |
 | ---- | ----- | -------------------------- | ------------------- |
-| `kg` | 18    | `KHIVE_PACKS=kg` (default) | No — base substrate |
+| `kg` | 19    | `KHIVE_PACKS=kg` (default) | No — base substrate |
 
 This distribution ships one production pack, `kg`, loaded by default. Task management,
 memory, inter-agent communication, scheduling, session continuity, workspace linking,
@@ -32,7 +32,7 @@ installed, they load the same way, via `KHIVE_PACKS`/`--pack`. Git provenance in
 `git.branch` / `git.push` write verbs (ADR-108) are likewise a commercially licensed
 extension.
 
-The default binary (no `KHIVE_PACKS`/`--pack` override) loads the `kg` pack: **18 verbs**.
+The default binary (no `KHIVE_PACKS`/`--pack` override) loads the `kg` pack: **19 verbs**.
 
 Verb names in the `kg` pack are bare (`create`, `search`, `link`, …). Extension packs
 namespace their verbs with a `pack.` prefix (`gtd.assign`, `memory.recall`,
@@ -130,7 +130,7 @@ parallel batches, since parallel failures do not cascade.
 
 ---
 
-## `kg` pack — 18 verbs
+## `kg` pack — 19 verbs
 
 Base substrate verbs, bare names (no `kg.` prefix). Category is the illocutionary act
 (Searle 1976): Assertive = retrieves state, Commissive = commits a persistent change,
@@ -605,6 +605,28 @@ silent pick among close candidates. Read-only: performs no mutation.
 
 ```
 request(ops="resolve(refs=[\"the old record\", \"<uuid>\"])")
+```
+
+### `whoami` — Assertive
+
+Report the caller's identity as the runtime already resolved it for this request:
+`actor_id`, `actor_kind`, whether the actor is the unattributed/anonymous fallback,
+the write namespace, and the read-visible namespace set. A projection of existing
+per-request state, not new state; never returns tokens or credentials. Takes no
+parameters.
+
+```
+request(ops="whoami()")
+```
+
+```json
+{
+  "actor_id": "local",
+  "actor_kind": "anonymous",
+  "unattributed": true,
+  "namespace": "local",
+  "visible_namespaces": ["local"]
+}
 ```
 
 ### `verbs` — Assertive

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -9,7 +9,7 @@ graph, and link concepts together.
 khive is a research knowledge graph runtime. When you read papers, form
 concepts, link ideas, and record decisions, khive gives that work a
 typed, queryable graph that persists across sessions. Everything is accessible
-through the 18 verbs of the `kg` pack, dispatched through a single MCP tool.
+through the 19 verbs of the `kg` pack, dispatched through a single MCP tool.
 
 ## Install
 

--- a/marketplace/khive/README.md
+++ b/marketplace/khive/README.md
@@ -1,7 +1,7 @@
 # khive — Claude Code plugin
 
 One plugin for the khive knowledge graph surface, served by a single MCP server
-(`kkernel mcp`) exposing one tool — `request` — that dispatches the 18 verbs of the
+(`kkernel mcp`) exposing one tool — `request` — that dispatches the 19 verbs of the
 `kg` pack.
 
 This plugin is **guidance, not a second runtime**. It ships the pattern skill that teaches an
@@ -21,9 +21,9 @@ The skill teaches the _reusable pattern_ for the `kg` pack, not a how-to for eve
 Per-verb parameter detail is always one call away at runtime:
 `request(ops="<verb>(help=true)")`.
 
-| Skill | Pack | The pattern it teaches                                                       |
-| ----- | ---- | ------------------------------------------------------------------------------ |
-| `kg`  | kg   | Search before you create; model as typed entities + edges; explore; propose  |
+| Skill | Pack | The pattern it teaches                                                      |
+| ----- | ---- | --------------------------------------------------------------------------- |
+| `kg`  | kg   | Search before you create; model as typed entities + edges; explore; propose |
 
 ## kg stewardship agents
 

--- a/marketplace/khive/skills/kg/SKILL.md
+++ b/marketplace/khive/skills/kg/SKILL.md
@@ -5,9 +5,10 @@ description: Work the knowledge graph as typed entities and edges — search bef
 # Work the knowledge graph
 
 The kg pack is the shared, cross-project knowledge graph: typed entities (9 kinds), a closed set
-of edge relations (17), and notes. Sixteen verbs — `create`, `get`, `list`, `search`, `update`,
-`delete`, `merge`, `link`, `neighbors`, `traverse`, `query`, `stats`, `propose`, `review`,
-`withdraw`, `verbs` — but the thing worth learning is the _graph discipline_, not the verb list.
+of edge relations (17), and notes. Nineteen verbs — `create`, `get`, `list`, `search`, `update`,
+`delete`, `merge`, `link`, `neighbors`, `traverse`, `query`, `context`, `resolve`, `whoami`,
+`stats`, `propose`, `review`, `withdraw`, `verbs` — but the thing worth learning is the
+_graph discipline_, not the verb list.
 Per-verb param detail is one call away: `request(ops="create(help=true)")`.
 
 **Namespace (ADR-007).** kg ops always use the shared `local` namespace, even when the server

--- a/npm/README.md
+++ b/npm/README.md
@@ -1,6 +1,6 @@
 # khive
 
-A research knowledge graph runtime — 18 verbs, 1 pack, one MCP tool.
+A research knowledge graph runtime — 19 verbs, 1 pack, one MCP tool.
 
 [![GitHub](https://img.shields.io/github/stars/ohdearquant/khive?style=flat)](https://github.com/ohdearquant/khive)
 [![crates.io](https://img.shields.io/crates/v/khive-mcp.svg)](https://crates.io/crates/khive-mcp)
@@ -19,17 +19,18 @@ Add to `.mcp.json` (project-level or `~/.claude/mcp.json` for global):
 { "mcpServers": { "khive": { "command": "khive", "args": ["mcp"] } } }
 ```
 
-The `kg` pack loads by default. A background daemon auto-spawns to keep the runtime warm.
+The `kg` pack loads by default. A background daemon auto-spawns to keep the
+runtime warm.
 
 ## What you get
 
-| Pack   | Verbs | What it does                                       |
-| ------ | ----- | --------------------------------------------------- |
-| **kg** | 18    | Entities, edges, notes, graph queries, proposals    |
+| Pack   | Verbs | What it does                                     |
+| ------ | ----- | ------------------------------------------------ |
+| **kg** | 19    | Entities, edges, notes, graph queries, proposals |
 
-Task management, memory recall, inter-agent messaging, scheduling, session continuity,
-workspace linking, and blob storage are provided by commercially licensed extensions and
-are not part of the open-source distribution.
+Task management, memory recall, inter-agent messaging, scheduling, session
+continuity, workspace linking, and blob storage are provided by commercially
+licensed extensions and are not part of the open-source distribution.
 
 ## Usage
 
@@ -42,6 +43,7 @@ khive kg validate           # Check NDJSON files against schema
 ## Documentation
 
 - [GitHub](https://github.com/ohdearquant/khive)
-- [AGENTS.md](https://github.com/ohdearquant/khive/blob/main/AGENTS.md) — full verb reference
-- [Marketplace plugins](https://github.com/ohdearquant/khive/tree/main/marketplace) — Claude Code
-  skills
+- [AGENTS.md](https://github.com/ohdearquant/khive/blob/main/AGENTS.md) — full
+  verb reference
+- [Marketplace plugins](https://github.com/ohdearquant/khive/tree/main/marketplace)
+  — Claude Code skills

--- a/tests/khive-contract/README.md
+++ b/tests/khive-contract/README.md
@@ -66,12 +66,12 @@ Tests are in `tests/` and organized by ADR. The `khive_contract/` package provid
 Some test filenames use numbers from the play specification that diverged from the final ADR
 numbering in this worktree:
 
-| File | Spec filename | Actual ADR covered |
-|------|--------------|-------------------|
-| `test_adr_020_request_dsl.py` | as-requested | ADR-016 request DSL |
-| `test_adr_027_single_tool_mcp.py` | as-requested | ADR-027 dynamic pack loading |
-| `test_adr_021_recall_pipeline.py` | as-requested | ADR-021 memory pack |
-| `test_adr_033_recall_configurability.py` | as-requested | ADR-033 recall configurability |
+| File                                     | Spec filename | Actual ADR covered             |
+| ---------------------------------------- | ------------- | ------------------------------ |
+| `test_adr_020_request_dsl.py`            | as-requested  | ADR-016 request DSL            |
+| `test_adr_027_single_tool_mcp.py`        | as-requested  | ADR-027 dynamic pack loading   |
+| `test_adr_021_recall_pipeline.py`        | as-requested  | ADR-021 memory pack            |
+| `test_adr_033_recall_configurability.py` | as-requested  | ADR-033 recall configurability |
 
 Each test docstring cites the actual ADR section.
 

--- a/tests/khive-contract/khive_contract/fixtures.py
+++ b/tests/khive-contract/khive_contract/fixtures.py
@@ -83,7 +83,7 @@ ANNOTATES_SOURCE_MUST_BE_NOTE = True
 
 # ---------------------------------------------------------------------------
 # Product verb manifest (ADR-023 / ADR-025 / ADR-027)
-# KG pack ships 18 verbs; bare names (no pack prefix).
+# KG pack ships 19 verbs; bare names (no pack prefix).
 # Source of truth: crates/khive-pack-kg/src/handler_defs.rs KG_HANDLERS
 # ---------------------------------------------------------------------------
 
@@ -107,6 +107,7 @@ KG_VERBS: frozenset[str] = frozenset(
         "verbs",
         "context",
         "resolve",
+        "whoami",
     }
 )
 
@@ -116,15 +117,15 @@ KG_VERBS: frozenset[str] = frozenset(
 # this one. Their dotted pack.verb forms are therefore absent here.
 DISCOVERABLE_PRODUCT_VERBS: frozenset[str] = KG_VERBS
 
-# DISCOVERABLE_PRODUCT_VERBS (18) already meets this floor.
+# DISCOVERABLE_PRODUCT_VERBS (19) already meets this floor.
 PLAY_SPEC_MINIMUM_VERB_COUNT = 11
 
 # ADR-023 coverage-gate manifest: the curated set of product verbs every
 # contract test module's VERBS_UNDER_TEST must jointly cover. Narrower than
 # DISCOVERABLE_PRODUCT_VERBS above (which also counts admin/meta KG verbs
-# like stats/propose/review/withdraw/verbs/context/resolve that the coverage
-# gate does not track), so the two are intentionally not unioned or aliased
-# to each other.
+# like stats/propose/review/withdraw/verbs/context/resolve/whoami that the
+# coverage gate does not track), so the two are intentionally not unioned or
+# aliased to each other.
 PRODUCT_VERB_MANIFEST: frozenset[str] = frozenset({
     # KG substrate (11) — bare names; no pack prefix
     "create", "get", "list", "update", "delete", "merge",

--- a/tests/khive-contract/tests/test_adr_023_verb_taxonomy.py
+++ b/tests/khive-contract/tests/test_adr_023_verb_taxonomy.py
@@ -10,10 +10,10 @@ import pytest
 
 from khive_contract.client import KhiveMcpSession
 
-# All 16 baseline KG substrate verbs exercised below. Written as a set literal
-# so the manifest AST-introspector can parse it (stats/propose/review/withdraw/
-# verbs/context/resolve are the remaining KG verbs not exercised by this
-# module's reachability walk; kg is the sole pack in the OSS distribution).
+# The 16 KG verbs exercised below, of the pack's 19. Written as a set literal
+# so the manifest AST-introspector can parse it (context/resolve/whoami are
+# the remaining KG verbs not exercised by this module's reachability walk;
+# kg is the sole pack in the OSS distribution).
 VERBS_UNDER_TEST = {
     # KG substrate (16) — bare names; no pack prefix
     "create", "get", "list", "update", "delete", "merge",
@@ -35,7 +35,8 @@ def test_kg_bare_product_verbs_are_reachable(
     ADR: ADR-023
     section: kg bare substrate verbs
 
-    Ports smoke KG surface coverage; verifies all 11 KG verbs are registered
+    Ports smoke KG surface coverage; verifies the KG verbs named in
+    VERBS_UNDER_TEST are registered
     and return non-error results in the base kg session.
     """
     ns = temp_namespace

--- a/tests/khive-contract/tests/test_adr_027_single_tool_mcp.py
+++ b/tests/khive-contract/tests/test_adr_027_single_tool_mcp.py
@@ -13,7 +13,7 @@ from khive_contract.fixtures import KG_VERBS as _KG_VERBS
 
 VERBS_UNDER_TEST = {"create"}
 
-# KG verbs imported from fixtures.py — single source of truth (18 verbs).
+# KG verbs imported from fixtures.py — single source of truth (19 verbs).
 KG_VERBS = tuple(sorted(_KG_VERBS))
 # gtd/memory are commercially licensed extensions, not part of this OSS
 # distribution — their absence from the kg-only surface is asserted below.

--- a/tests/khive-contract/tests/test_manifest.py
+++ b/tests/khive-contract/tests/test_manifest.py
@@ -143,7 +143,7 @@ def test_all_test_modules_have_adr_docstring() -> None:
 
 
 def test_combined_verb_coverage_is_complete() -> None:
-    """The union of all VERBS_UNDER_TEST across modules covers all 18 product verbs.
+    """The union of all VERBS_UNDER_TEST across modules covers all product verbs in PRODUCT_VERB_MANIFEST.
 
     ADR: ADR-023
     section: Coverage gates; Verb naming
@@ -193,7 +193,7 @@ def test_no_hardcoded_local_namespace() -> None:
 
 
 def test_verb_coverage_count_reported() -> None:
-    """Report the actual covered verb count vs 18-verb baseline (informational).
+    """Report the actual covered verb count vs the PRODUCT_VERB_MANIFEST baseline (informational).
 
     ADR: ADR-023
     section: Coverage gates

--- a/tests/smoke_test.py
+++ b/tests/smoke_test.py
@@ -196,16 +196,18 @@ def main():
         assert isinstance(verbs_result["verbs"], list), f"verbs must be a list: {verbs_result}"
         # Surface-contract tripwire: the default config (no --pack, KHIVE_PACKS
         # unset) loads the single production pack (kg), so verbs() returns
-        # exactly 18 user-facing MCP-callable verbs (count what verbs()
+        # exactly 19 user-facing MCP-callable verbs (count what verbs()
         # returns, not internal dispatch arms). context (ADR-089, the 17th
-        # kg-substrate bare verb) and resolve (unified-verb draft ADR Slice 1,
-        # the 18th) are included in the count.
+        # kg-substrate bare verb), resolve (unified-verb draft ADR Slice 1,
+        # the 18th), and whoami (caller identity introspection, the 19th) are
+        # included in the count.
         # Update this number when the pack set or verb surface changes; a
         # silent drift here is the bug this assertion exists to catch.
-        assert verbs_result["total"] == 18, (
-            f"expected 18 user-facing verbs from the default kg pack "
+        assert verbs_result["total"] == 19, (
+            f"expected 19 user-facing verbs from the default kg pack "
             f"(context is the 17th kg-substrate bare verb per ADR-089; "
-            f"resolve is the 18th per the unified-verb draft ADR Slice 1), "
+            f"resolve is the 18th per the unified-verb draft ADR Slice 1; "
+            f"whoami is the 19th), "
             f"got {verbs_result['total']}: {verbs_result}"
         )
         verb_names = [v["verb"] for v in verbs_result["verbs"]]


### PR DESCRIPTION
## Summary

Adds a `whoami` verb to the `kg` pack so a caller can learn its own resolved
identity: actor id, actor kind, whether it is the unattributed/anonymous
fallback, the write namespace, and the read-visible namespace set.

Without this, a caller has no way to determine the assignee it should
supply on writes, cannot self-scope a queue-listing query to its own rows,
and ends up learning its actor id by accident from an unrelated echoed
response field.

`whoami` is a pure projection of state the runtime already resolves for
every request — no new state is introduced, and no secrets, tokens, or
connection strings are exposed, only labels. Registered following the same
convention as every other verb: a `HandlerDef` entry with a `description`
(the `help=` text), routed through pack dispatch, and visible through the
`verbs()` introspection call.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test -p khive-pack-kg -p khive-runtime -p khive-mcp` — full pass
      on the two touched crates; pre-existing unrelated failures in
      `khive-mcp::pending_events` (missing `gtd` pack in this distribution)
      reproduce identically on unmodified `main`.
- [x] New tests: configured-actor identity, unattributed/single-actor-deployment
      identity, unknown-param rejection, `verbs()` registration, and a guard
      against any secret-shaped field ever appearing in the response.

🤖 Generated with [Claude Code](https://claude.com/claude-code)