### PR TITLE
fix(request): explain why a $prev chain reference failed to resolve

### DIFF
--- a/crates/khive-mcp/src/server.rs
+++ b/crates/khive-mcp/src/server.rs
@@ -22,7 +22,7 @@ use serde_json::{json, Value};
 use sha2::{Digest, Sha256};
 
 use khive_db::ConnectionPool;
-use khive_request::{parse_request, ArgValue, DslError, ExecutionMode, ParsedOp};
+use khive_request::{parse_request, ArgValue, DslError, ExecutionMode, ParsedOp, PrevFailure};
 use khive_runtime::{
     present, render_format, resolve_explicit_namespace, KhiveRuntime, OutputFormat, PackLoadError,
     PackRegistry, PresentationMode, RuntimeConfig, RuntimeError, VerbPresentationPolicy,
@@ -656,39 +656,31 @@ impl KhiveMcpServer {
         for (name, arg_val) in args {
             let needs_prev = !matches!(&arg_val, ArgValue::Value(_));
             let value = if needs_prev {
+                // `dispatch_op` only ever runs inside a chain (see `run_parsed`'s
+                // `ExecutionMode::Chain` arm); `prev_result` is `None` here
+                // exactly when this is the chain's first op, so there is no
+                // preceding result to substitute from at all.
                 let prev = prev_result.ok_or_else(|| {
                     (
                         tool.clone(),
                         json!({
                             "kind": "substitution_error",
+                            "reason": "no_preceding_op",
                             "message": format!(
-                                "argument {name:?}: $prev reference in non-chain context"
+                                "argument {name:?}: $prev has no preceding op to resolve \
+                                 against — this is the first operation in the chain. $prev \
+                                 always resolves against the immediately preceding op's result \
+                                 only; it cannot reach further back or forward. Move this op \
+                                 after the one that produces the value, or pass a literal value \
+                                 here instead of $prev."
                             )
                         }),
                     )
                 })?;
                 let resolved_val = arg_val.resolve_all(prev).ok_or_else(|| {
-                    // Include available top-level fields in the error message,
-                    // matching the UX of the bare-$prev guard.
-                    let fields_hint = if let Value::Object(map) = prev {
-                        let mut fields: Vec<&str> =
-                            map.keys().map(String::as_str).collect();
-                        fields.sort_unstable();
-                        format!(
-                            " Available top-level fields: [{}]",
-                            fields.join(", ")
-                        )
-                    } else {
-                        String::new()
-                    };
                     (
                         tool.clone(),
-                        json!({
-                            "kind": "substitution_error",
-                            "message": format!(
-                                "argument {name:?}: one or more $prev paths not found in prior result.{fields_hint}"
-                            ),
-                        }),
+                        substitution_error_payload(&name, &arg_val, prev),
                     )
                 })?;
                 // UE4-H1: bare `$prev` (no path) resolving to a map or array
@@ -702,6 +694,7 @@ impl KhiveMcpServer {
                                 tool.clone(),
                                 json!({
                                     "kind": "substitution_error",
+                                    "reason": "bare_ref_ambiguous",
                                     "message": format!(
                                         "argument {name:?}: $prev requires a dotted path \
                                          (e.g. $prev.id) when the prior result is a map. \
@@ -716,6 +709,7 @@ impl KhiveMcpServer {
                                 tool.clone(),
                                 json!({
                                     "kind": "substitution_error",
+                                    "reason": "bare_ref_ambiguous",
                                     "message": format!(
                                         "argument {name:?}: $prev requires a dotted path \
                                          (e.g. $prev.0) when the prior result is an array. \
@@ -1010,9 +1004,28 @@ impl KhiveMcpServer {
                 let mut aborted_from: Option<usize> = None;
 
                 for (i, op) in ops.into_iter().enumerate() {
-                    if aborted_from.is_some() {
-                        // A prior op failed — mark remaining as aborted.
-                        results.push(json!({ "ok": false, "tool": op.tool, "aborted": true }));
+                    if let Some(failed_at) = aborted_from {
+                        // A prior op failed — mark remaining as aborted, and say so
+                        // plainly: this op was never dispatched (its own $prev, if any,
+                        // was never attempted), so the failure to debug lives at the
+                        // earlier op, not here.
+                        let failed_index = failed_at - 1;
+                        let failed_tool = results
+                            .get(failed_index)
+                            .and_then(|r| r.get("tool"))
+                            .and_then(Value::as_str)
+                            .unwrap_or("<unknown>");
+                        results.push(json!({
+                            "ok": false,
+                            "tool": op.tool,
+                            "aborted": true,
+                            "message": format!(
+                                "not executed: op #{failed_index} ({failed_tool:?}) failed \
+                                 earlier in this chain, so the chain aborted before reaching \
+                                 this op. Fix op #{failed_index} — this op's own arguments, \
+                                 including any $prev reference, were never evaluated."
+                            ),
+                        }));
                         continue;
                     }
                     let op_mode = mode_for_op(i);
@@ -1361,6 +1374,47 @@ fn drop_value_iteratively(value: Value) {
             _ => {}
         }
     }
+}
+
+/// Builds a `substitution_error` payload for a `$prev` argument that failed
+/// to resolve (`resolve_all` returned `None`). Uses [`ArgValue::find_prev_failure`]
+/// to identify exactly which lookup failed and why — a missing field/index, a
+/// path segment applied to the wrong JSON type, or unsupported bracket syntax
+/// — each worded differently so the caller isn't left with one generic
+/// "not found" for three different mistakes. Falls back to a generic message
+/// only if `find_prev_failure` cannot explain a miss `resolve_all` reported
+/// (defensive; the two are expected to always agree).
+fn substitution_error_payload(name: &str, arg_val: &ArgValue, prev: &Value) -> Value {
+    let Some(failure) = arg_val.find_prev_failure(prev) else {
+        let fields_hint = if let Value::Object(map) = prev {
+            let mut fields: Vec<&str> = map.keys().map(String::as_str).collect();
+            fields.sort_unstable();
+            format!(" Available top-level fields: [{}]", fields.join(", "))
+        } else {
+            String::new()
+        };
+        return json!({
+            "kind": "substitution_error",
+            "reason": "path_not_found",
+            "message": format!(
+                "argument {name:?}: one or more $prev paths not found in prior result.{fields_hint}"
+            ),
+        });
+    };
+    let reason = match &failure {
+        PrevFailure::NotFound { .. } => "path_not_found",
+        PrevFailure::WrongType { .. } => "path_wrong_type",
+        PrevFailure::Unsupported { .. } => "path_unsupported",
+    };
+    json!({
+        "kind": "substitution_error",
+        "reason": reason,
+        "message": format!(
+            "argument {name:?}: {failure}. $prev resolves only against the immediately \
+             preceding op's result — a non-adjacent dependency cannot be expressed inside \
+             one chain; split into separate calls and carry the value across yourself."
+        ),
+    })
 }
 
 /// Chain-mode (`dispatch_op`) success path: check the raw handler `result`

--- a/crates/khive-mcp/tests/integration.rs
+++ b/crates/khive-mcp/tests/integration.rs
@@ -1473,6 +1473,222 @@ async fn test_h3_prev_nonexistent_field_error_lists_available_fields() -> anyhow
     Ok(())
 }
 
+/// A `$prev` reference in the FIRST op of a chain has no preceding op to
+/// resolve against. This must not reuse the "$prev reference in non-chain
+/// context" wording (misleading — this IS a chain) and must teach the
+/// one-op-back rule instead of failing silently confusing.
+#[tokio::test]
+async fn test_prev_in_first_op_of_chain_names_no_preceding_op() -> anyhow::Result<()> {
+    let client = connect().await?;
+
+    let ops =
+        r#"get(id=$prev.id) | create(kind="entity", entity_kind="concept", name="NeverReached")"#;
+    let result = call(
+        &client,
+        "request",
+        json!({"ops": ops, "presentation": "verbose"}),
+    )
+    .await?;
+    let body: Value = serde_json::from_str(&first_text(&result))?;
+    let results = body["results"].as_array().expect("results array");
+
+    assert_eq!(results.len(), 2, "expected 2 ops");
+    assert_eq!(
+        results[0]["ok"],
+        json!(false),
+        "first op referencing $prev must fail: {}",
+        results[0]
+    );
+    let err = &results[0]["error"];
+    let err_msg = err["message"]
+        .as_str()
+        .unwrap_or_else(|| err.as_str().unwrap_or(""));
+    assert!(
+        err_msg.contains("no preceding op") || err_msg.contains("first operation"),
+        "must name the missing-preceding-op condition, not a generic non-chain message; got: {err_msg}"
+    );
+    assert!(
+        !err_msg.contains("non-chain context"),
+        "stale wording ('non-chain context') must not survive — this op IS in a chain, \
+         it just has nothing before it; got: {err_msg}"
+    );
+    assert!(
+        err_msg.contains("immediately preceding op"),
+        "must teach the one-op-back rule; got: {err_msg}"
+    );
+
+    // Op 1 never runs — chain aborted at op 0 — and its aborted marker must
+    // say plainly that op 0 is the one to fix, not itself.
+    assert_eq!(results[1]["aborted"], json!(true));
+    let aborted_msg = results[1]["message"].as_str().unwrap_or("");
+    assert!(
+        aborted_msg.contains("op #0"),
+        "aborted marker must point at the failed op, not itself; got: {aborted_msg}"
+    );
+
+    Ok(())
+}
+
+/// A path segment that names a field which does exist, but on a value that
+/// is not an object (or an index into something that is not an array), is a
+/// different mistake than "field not found" and must say so — the caller
+/// went looking for a sub-field on a scalar, not a missing name.
+#[tokio::test]
+async fn test_prev_path_wrong_type_names_the_type_mismatch() -> anyhow::Result<()> {
+    let client = connect().await?;
+
+    // `name` resolves to a string; `.foo` on a string is a type mismatch,
+    // not a missing-field lookup.
+    let ops = r#"create(kind="entity", entity_kind="concept", name="WrongTypeSource") | get(id=$prev.name.foo)"#;
+    let result = call(
+        &client,
+        "request",
+        json!({"ops": ops, "presentation": "verbose"}),
+    )
+    .await?;
+    let body: Value = serde_json::from_str(&first_text(&result))?;
+    let results = body["results"].as_array().expect("results array");
+
+    assert_eq!(results[0]["ok"], json!(true), "create must succeed");
+    assert_eq!(
+        results[1]["ok"],
+        json!(false),
+        "get with a field-on-a-scalar path must fail: {}",
+        results[1]
+    );
+    let err = &results[1]["error"];
+    let err_msg = err["message"]
+        .as_str()
+        .unwrap_or_else(|| err.as_str().unwrap_or(""));
+    assert!(
+        err_msg.contains("is a string, not an"),
+        "must name the actual JSON type found and what was expected; got: {err_msg}"
+    );
+    assert!(
+        err_msg.contains("\"foo\""),
+        "must name the segment that could not be applied; got: {err_msg}"
+    );
+    assert_eq!(err["kind"], json!("substitution_error"));
+    assert_eq!(err["reason"], json!("path_wrong_type"));
+
+    Ok(())
+}
+
+/// Bracket syntax that isn't a valid non-negative-integer index (e.g.
+/// `[bad]`) never reaches the substitution layer at all: `khive-request`'s
+/// own DSL parser rejects it up front, both for the unquoted form (here) and
+/// for a quoted `"$prev[bad]"` string (which simply fails promotion to a
+/// `$prev` reference and is treated as a literal string — see
+/// `previous-result.md`). The substituter's own defense against this form
+/// (`PrevFailure::Unsupported`, exercised directly in
+/// `khive-request`'s test suite since it is otherwise unreachable through
+/// this public surface) never fires here; what the caller actually sees is
+/// this parse-time rejection.
+#[tokio::test]
+async fn test_prev_malformed_index_rejected_at_parse_time() -> anyhow::Result<()> {
+    let client = connect().await?;
+
+    let ops = r#"create(kind="entity", entity_kind="concept", name="MalformedIndexSource") | get(id=$prev[bad])"#;
+    let err = call(
+        &client,
+        "request",
+        json!({"ops": ops, "presentation": "verbose"}),
+    )
+    .await
+    .expect_err("malformed bracket syntax must be rejected before any op runs");
+    let err_msg = err.to_string();
+    assert!(
+        err_msg.contains("non-negative integer"),
+        "parse-time rejection must explain what index syntax IS supported; got: {err_msg}"
+    );
+
+    Ok(())
+}
+
+/// A nested `$prev` reference inside an object-literal argument must resolve
+/// (and fail) exactly as clearly as a bare `$prev.field` argument — the
+/// error must still name the missing field, not just the outer arg name.
+#[tokio::test]
+async fn test_prev_nested_in_object_literal_errors_as_clearly_as_bare() -> anyhow::Result<()> {
+    let client = connect().await?;
+
+    let ops = r#"create(kind="entity", entity_kind="concept", name="NestedPrevSource") | create(kind="entity", entity_kind="concept", name="NestedPrevSink", properties={"linked": $prev.bogus_nested_field})"#;
+    let result = call(
+        &client,
+        "request",
+        json!({"ops": ops, "presentation": "verbose"}),
+    )
+    .await?;
+    let body: Value = serde_json::from_str(&first_text(&result))?;
+    let results = body["results"].as_array().expect("results array");
+
+    assert_eq!(results[0]["ok"], json!(true), "first create must succeed");
+    assert_eq!(
+        results[1]["ok"],
+        json!(false),
+        "create with an unresolvable nested $prev inside properties must fail: {}",
+        results[1]
+    );
+    let err = &results[1]["error"];
+    let err_msg = err["message"]
+        .as_str()
+        .unwrap_or_else(|| err.as_str().unwrap_or(""));
+    assert!(
+        err_msg.contains("bogus_nested_field"),
+        "nested $prev failure must name the unresolvable field just as a bare \
+         reference would; got: {err_msg}"
+    );
+
+    Ok(())
+}
+
+/// When op N fails for a reason unrelated to substitution, downstream ops
+/// referencing `$prev` are never dispatched at all (the chain aborts first).
+/// The aborted marker must say plainly that an earlier op is the actual
+/// problem, so the caller doesn't go looking at the wrong line.
+#[tokio::test]
+async fn test_prev_after_unrelated_failure_points_at_the_failed_op() -> anyhow::Result<()> {
+    let client = connect().await?;
+
+    // `get` on a well-formed but nonexistent id fails for reasons that have
+    // nothing to do with $prev; op 1's own $prev.id reference must never be
+    // attempted.
+    let ops = r#"get(id="00000000-0000-0000-0000-000000000000") | create(kind="entity", entity_kind="concept", name=$prev.id)"#;
+    let result = call(
+        &client,
+        "request",
+        json!({"ops": ops, "presentation": "verbose"}),
+    )
+    .await?;
+    let body: Value = serde_json::from_str(&first_text(&result))?;
+    let results = body["results"].as_array().expect("results array");
+
+    assert_eq!(results.len(), 2, "expected 2 ops");
+    assert_eq!(
+        results[0]["ok"],
+        json!(false),
+        "get on a nonexistent id must fail: {}",
+        results[0]
+    );
+    assert_ne!(
+        results[0]["aborted"],
+        json!(true),
+        "the actually-failing op must not itself be marked aborted: {}",
+        results[0]
+    );
+
+    assert_eq!(results[1]["ok"], json!(false));
+    assert_eq!(results[1]["aborted"], json!(true));
+    let aborted_msg = results[1]["message"].as_str().unwrap_or("");
+    assert!(
+        aborted_msg.contains("op #0") && aborted_msg.contains("\"get\""),
+        "aborted marker must name the earlier failed op, not describe op 1's own \
+         (never-attempted) $prev reference; got: {aborted_msg}"
+    );
+
+    Ok(())
+}
+
 // ── help=true schema envelope integration tests ─────────────────────────────
 //
 // These tests confirm that help=true calls through the MCP surface return

--- a/crates/khive-request/docs/api/previous-result.md
+++ b/crates/khive-request/docs/api/previous-result.md
@@ -39,3 +39,13 @@ JSON decoding produces `\$prev.id`; the parser removes that one escape and store
 `resolve_all` recursively materializes an argument into owned JSON. Concrete values are cloned, references are resolved and cloned, and dynamic arrays/objects preserve order while resolving every descendant. If any reference path misses, the entire call returns `None`; partial materialization is never returned.
 
 Runtime results used as future `$prev` context should first pass `value_nesting_within_limit`. That function walks an explicit heap worklist, avoiding recursive clone/serialization of attacker-controlled deep JSON before the depth bound is checked.
+
+## `ArgValue::find_prev_failure`
+
+`resolve_all` returning `None` only says *that* a reference missed, not *why*. `find_prev_failure` walks the same argument (including nested `$prev` refs inside array/object literals) and returns a [`PrevFailure`] explaining the first miss it finds:
+
+- `NotFound` — the field or index simply isn't there; carries the sibling field names (or array length) available at that point.
+- `WrongType` — a path segment expects an object (for a field) or an array (for an index) to continue into, but the value at that point is a different JSON type.
+- `Unsupported` — the path contains bracket syntax that isn't a valid non-negative-integer index. The public DSL parser rejects this shape before it ever reaches `ArgValue::PrevRef`, so this variant only fires against an `ArgValue` built some other way.
+
+Callers building an error message for a `resolve_all` miss should call `find_prev_failure` for the specific reason, rather than emitting one generic "not found" for all three mistakes.

--- a/crates/khive-request/src/lib.rs
+++ b/crates/khive-request/src/lib.rs
@@ -10,5 +10,5 @@ pub use conflict::write_keys_for_op_pub;
 pub use parser::parse_request;
 pub use types::{
     value_nesting_within_limit, ArgValue, DslError, ExecutionMode, ParsedOp, ParsedRequest,
-    MAX_OPS, MAX_OPS_INPUT_LEN, NESTING_DEPTH_LIMIT, RESERVED_ENVELOPE_ARGS,
+    PrevFailure, MAX_OPS, MAX_OPS_INPUT_LEN, NESTING_DEPTH_LIMIT, RESERVED_ENVELOPE_ARGS,
 };

--- a/crates/khive-request/src/parser/mod.rs
+++ b/crates/khive-request/src/parser/mod.rs
@@ -7,4 +7,4 @@ mod scan;
 
 pub use dispatch::parse_request;
 
-pub(crate) use path::{apply_path_segment, split_path};
+pub(crate) use path::{apply_path_segment, split_path, PathSegment};

--- a/crates/khive-request/src/parser/path.rs
+++ b/crates/khive-request/src/parser/path.rs
@@ -7,6 +7,11 @@ use serde_json::Value;
 pub(crate) enum PathSegment<'a> {
     Field(&'a str),
     Index(usize),
+    /// Bracket syntax that is not a valid non-negative-integer index, e.g.
+    /// `[abc]` or `[-1]`. Always a lookup miss (see `apply_path_segment`);
+    /// kept distinct from `Field` so callers building error messages can
+    /// tell "no such field" apart from "this isn't a supported path form".
+    Malformed(&'a str),
 }
 
 /// Splits a `$prev` path into field and index segments.
@@ -25,7 +30,7 @@ pub(crate) fn split_path(path: &str) -> Vec<PathSegment<'_>> {
                 }
             }
             // Preserve malformed quoted paths as a lookup miss, never a partial match.
-            segments.push(PathSegment::Field(remaining));
+            segments.push(PathSegment::Malformed(remaining));
             break;
         }
         let end = remaining.find(['.', '[']).unwrap_or(remaining.len());
@@ -44,5 +49,6 @@ pub(crate) fn apply_path_segment<'a>(cur: &'a Value, seg: PathSegment<'_>) -> Op
     match seg {
         PathSegment::Field(key) => cur.get(key),
         PathSegment::Index(idx) => cur.as_array()?.get(idx),
+        PathSegment::Malformed(_) => None,
     }
 }

--- a/crates/khive-request/src/types.rs
+++ b/crates/khive-request/src/types.rs
@@ -168,7 +168,7 @@ impl ArgValue {
                                     available.sort_unstable();
                                     return Some(PrevFailure::NotFound {
                                         arg_path: arg_path.to_string(),
-                                        prev_path: format!("$prev.{path}"),
+                                        prev_path: render_prev_path(path),
                                         resolved_prefix: prev_path_prefix(&resolved_prefix),
                                         missing: key.to_string(),
                                         available,
@@ -178,7 +178,7 @@ impl ArgValue {
                             other => {
                                 return Some(PrevFailure::WrongType {
                                     arg_path: arg_path.to_string(),
-                                    prev_path: format!("$prev.{path}"),
+                                    prev_path: render_prev_path(path),
                                     resolved_prefix: prev_path_prefix(&resolved_prefix),
                                     segment: key.to_string(),
                                     expected: "object",
@@ -195,7 +195,7 @@ impl ArgValue {
                                 None => {
                                     return Some(PrevFailure::NotFound {
                                         arg_path: arg_path.to_string(),
-                                        prev_path: format!("$prev.{path}"),
+                                        prev_path: render_prev_path(path),
                                         resolved_prefix: prev_path_prefix(&resolved_prefix),
                                         missing: format!("[{idx}]"),
                                         available: vec![format!(
@@ -208,7 +208,7 @@ impl ArgValue {
                             other => {
                                 return Some(PrevFailure::WrongType {
                                     arg_path: arg_path.to_string(),
-                                    prev_path: format!("$prev.{path}"),
+                                    prev_path: render_prev_path(path),
                                     resolved_prefix: prev_path_prefix(&resolved_prefix),
                                     segment: format!("[{idx}]"),
                                     expected: "array",
@@ -219,7 +219,7 @@ impl ArgValue {
                         crate::parser::PathSegment::Malformed(raw) => {
                             return Some(PrevFailure::Unsupported {
                                 arg_path: arg_path.to_string(),
-                                prev_path: format!("$prev.{path}"),
+                                prev_path: render_prev_path(path),
                                 segment: raw.to_string(),
                             });
                         }
@@ -240,6 +240,10 @@ impl ArgValue {
             }),
         }
     }
+}
+
+fn render_prev_path(path: &str) -> String {
+    format!("$prev.{path}").replace(".[", "[")
 }
 
 /// Renders the `$prev`-relative path successfully traversed before a failure,

--- a/crates/khive-request/src/types.rs
+++ b/crates/khive-request/src/types.rs
@@ -127,6 +127,245 @@ impl ArgValue {
             }
         }
     }
+
+    /// Finds the first `$prev` reference within this argument that fails to
+    /// resolve against `prev_result`, and explains why. `None` means every
+    /// reference resolves (consistent with `resolve_all(prev_result).is_some()`)
+    /// or this argument holds no `$prev` reference at all.
+    ///
+    /// Walks the same segments as `resolve_prev`/`resolve_all` but never
+    /// changes what resolves — it exists purely to build an actionable error
+    /// message for a `resolve_all` miss.
+    pub fn find_prev_failure(&self, prev_result: &Value) -> Option<PrevFailure> {
+        self.find_prev_failure_at("", prev_result)
+    }
+
+    fn find_prev_failure_at(&self, arg_path: &str, prev_result: &Value) -> Option<PrevFailure> {
+        match self {
+            ArgValue::Value(_) => None,
+            ArgValue::PrevRef { path } => {
+                // Empty path = whole-value reference; always resolves. Its
+                // downstream shape (bare $prev onto a map/array) is a
+                // separate, already-handled concern (UE4-H1), not a lookup miss.
+                if path.is_empty() {
+                    return None;
+                }
+                let mut cur = prev_result;
+                let mut resolved_prefix = String::new();
+                for seg in crate::parser::split_path(path) {
+                    match seg {
+                        crate::parser::PathSegment::Field(key) => match cur {
+                            Value::Object(map) => match map.get(key) {
+                                Some(v) => {
+                                    cur = v;
+                                    if !resolved_prefix.is_empty() {
+                                        resolved_prefix.push('.');
+                                    }
+                                    resolved_prefix.push_str(key);
+                                }
+                                None => {
+                                    let mut available: Vec<String> = map.keys().cloned().collect();
+                                    available.sort_unstable();
+                                    return Some(PrevFailure::NotFound {
+                                        arg_path: arg_path.to_string(),
+                                        prev_path: format!("$prev.{path}"),
+                                        resolved_prefix: prev_path_prefix(&resolved_prefix),
+                                        missing: key.to_string(),
+                                        available,
+                                    });
+                                }
+                            },
+                            other => {
+                                return Some(PrevFailure::WrongType {
+                                    arg_path: arg_path.to_string(),
+                                    prev_path: format!("$prev.{path}"),
+                                    resolved_prefix: prev_path_prefix(&resolved_prefix),
+                                    segment: key.to_string(),
+                                    expected: "object",
+                                    found: json_type_name(other),
+                                });
+                            }
+                        },
+                        crate::parser::PathSegment::Index(idx) => match cur {
+                            Value::Array(arr) => match arr.get(idx) {
+                                Some(v) => {
+                                    cur = v;
+                                    resolved_prefix.push_str(&format!("[{idx}]"));
+                                }
+                                None => {
+                                    return Some(PrevFailure::NotFound {
+                                        arg_path: arg_path.to_string(),
+                                        prev_path: format!("$prev.{path}"),
+                                        resolved_prefix: prev_path_prefix(&resolved_prefix),
+                                        missing: format!("[{idx}]"),
+                                        available: vec![format!(
+                                            "array has {} element(s)",
+                                            arr.len()
+                                        )],
+                                    });
+                                }
+                            },
+                            other => {
+                                return Some(PrevFailure::WrongType {
+                                    arg_path: arg_path.to_string(),
+                                    prev_path: format!("$prev.{path}"),
+                                    resolved_prefix: prev_path_prefix(&resolved_prefix),
+                                    segment: format!("[{idx}]"),
+                                    expected: "array",
+                                    found: json_type_name(other),
+                                });
+                            }
+                        },
+                        crate::parser::PathSegment::Malformed(raw) => {
+                            return Some(PrevFailure::Unsupported {
+                                arg_path: arg_path.to_string(),
+                                prev_path: format!("$prev.{path}"),
+                                segment: raw.to_string(),
+                            });
+                        }
+                    }
+                }
+                None
+            }
+            ArgValue::Array(elements) => elements.iter().enumerate().find_map(|(i, el)| {
+                el.find_prev_failure_at(&format!("{arg_path}[{i}]"), prev_result)
+            }),
+            ArgValue::Object(pairs) => pairs.iter().find_map(|(k, v)| {
+                let sub = if arg_path.is_empty() {
+                    k.clone()
+                } else {
+                    format!("{arg_path}.{k}")
+                };
+                v.find_prev_failure_at(&sub, prev_result)
+            }),
+        }
+    }
+}
+
+/// Renders the `$prev`-relative path successfully traversed before a failure,
+/// for messages like "`$prev.user` is a string, not an object".
+fn prev_path_prefix(resolved_prefix: &str) -> String {
+    if resolved_prefix.is_empty() {
+        "$prev".to_string()
+    } else {
+        format!("$prev.{resolved_prefix}")
+    }
+}
+
+fn json_type_name(v: &Value) -> &'static str {
+    match v {
+        Value::Null => "null",
+        Value::Bool(_) => "boolean",
+        Value::Number(_) => "number",
+        Value::String(_) => "string",
+        Value::Array(_) => "array",
+        Value::Object(_) => "object",
+    }
+}
+
+/// Explains why a `$prev` path failed to resolve, for error-message
+/// construction. Distinguishes three mistakes that a single generic
+/// "not found" message conflates:
+///
+/// - the field/index simply isn't there (`NotFound`);
+/// - a segment expects an object or array to index into, but the prior
+///   result holds a scalar at that point (`WrongType`);
+/// - the bracket syntax itself isn't a supported index form (`Unsupported`).
+#[derive(Debug, Clone, PartialEq)]
+pub enum PrevFailure {
+    /// A path segment names a field or index that does not exist on an
+    /// otherwise correctly-typed container.
+    NotFound {
+        /// Path to the offending `$prev` reference within the verb argument
+        /// it appears in (empty when the argument itself is the reference).
+        arg_path: String,
+        /// The full `$prev` path that was attempted, e.g. `$prev.user.id`.
+        prev_path: String,
+        /// The `$prev`-relative path successfully traversed before the miss.
+        resolved_prefix: String,
+        /// The field name or `[index]` that could not be found.
+        missing: String,
+        /// Sibling field names (object) or a length note (array) at the
+        /// point of failure.
+        available: Vec<String>,
+    },
+    /// A path segment expects an object (for a field) or an array (for an
+    /// index) to continue into, but the prior result holds a different JSON
+    /// type at that point.
+    WrongType {
+        arg_path: String,
+        prev_path: String,
+        /// The `$prev`-relative path successfully traversed before the type
+        /// mismatch — this is what actually holds `found`.
+        resolved_prefix: String,
+        /// The field name or `[index]` that could not be applied.
+        segment: String,
+        expected: &'static str,
+        found: &'static str,
+    },
+    /// Bracket syntax that is not a valid non-negative-integer index.
+    Unsupported {
+        arg_path: String,
+        prev_path: String,
+        /// The unsupported segment as written, e.g. `[bad]`.
+        segment: String,
+    },
+}
+
+impl fmt::Display for PrevFailure {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fn arg_ref(arg_path: &str) -> String {
+            if arg_path.is_empty() {
+                String::new()
+            } else {
+                format!(" (at {arg_path})")
+            }
+        }
+        match self {
+            PrevFailure::NotFound {
+                arg_path,
+                prev_path,
+                resolved_prefix,
+                missing,
+                available,
+            } => {
+                write!(
+                    f,
+                    "{prev_path}{arg}: {resolved_prefix} has no {missing:?}. \
+                     Available top-level fields: [{}]",
+                    available.join(", "),
+                    arg = arg_ref(arg_path),
+                )
+            }
+            PrevFailure::WrongType {
+                arg_path,
+                prev_path,
+                resolved_prefix,
+                segment,
+                expected,
+                found,
+            } => {
+                write!(
+                    f,
+                    "{prev_path}{arg}: {resolved_prefix} is a {found}, not an {expected}, so \
+                     {segment:?} cannot be applied to it",
+                    arg = arg_ref(arg_path),
+                )
+            }
+            PrevFailure::Unsupported {
+                arg_path,
+                prev_path,
+                segment,
+            } => {
+                write!(
+                    f,
+                    "{prev_path}{arg}: {segment:?} is not a supported $prev path segment; \
+                     array indices must be a plain non-negative integer, e.g. $prev.items[0]",
+                    arg = arg_ref(arg_path),
+                )
+            }
+        }
+    }
 }
 
 /// One parsed tool name and its deterministically ordered named arguments.

--- a/crates/khive-request/tests/parser.rs
+++ b/crates/khive-request/tests/parser.rs
@@ -1868,6 +1868,32 @@ fn find_prev_failure_reports_not_found_for_missing_field() {
 }
 
 #[test]
+fn find_prev_failure_renders_root_index_as_valid_dsl_path() {
+    let parsed = req(r#"list(kind="concept") | get(id=$prev[2])"#);
+    let failure = parsed.ops[1].args["id"]
+        .find_prev_failure(&json!([]))
+        .expect("out-of-range index must report a substitution failure");
+    let rendered = failure.to_string();
+    assert_eq!(
+        rendered.split_once(':').map(|(path, _)| path),
+        Some("$prev[2]")
+    );
+}
+
+#[test]
+fn find_prev_failure_renders_nested_index_as_valid_dsl_path() {
+    let parsed = req(r#"list(kind="concept") | get(id=$prev.items[0].id)"#);
+    let failure = parsed.ops[1].args["id"]
+        .find_prev_failure(&json!({"items": []}))
+        .expect("out-of-range index must report a substitution failure");
+    let rendered = failure.to_string();
+    assert_eq!(
+        rendered.split_once(':').map(|(path, _)| path),
+        Some("$prev.items[0].id")
+    );
+}
+
+#[test]
 fn find_prev_failure_reports_wrong_type_for_field_on_scalar() {
     let prev: JsonValue = json!({"name": "concept-1"});
     let failure = prev_ref("name.sub").find_prev_failure(&prev);

--- a/crates/khive-request/tests/parser.rs
+++ b/crates/khive-request/tests/parser.rs
@@ -1711,3 +1711,93 @@ fn realistic_nested_payload_well_under_limit_still_parses() {
     );
     assert_eq!(r.mode, ExecutionMode::Single);
 }
+
+// ── ArgValue::find_prev_failure — $prev substitution error diagnosis ───────
+//
+// These exercise `find_prev_failure` directly against hand-built `ArgValue`s
+// rather than through `parse_request`, because the DSL parser (both the
+// unquoted `$prev[..]` grammar above and `quoted_prev_path_is_valid` for the
+// quoted-string form) already rejects malformed bracket syntax before an
+// `ArgValue::PrevRef` is ever constructed — that parser-level rejection is
+// covered in `khive-mcp`'s integration suite
+// (`test_prev_malformed_index_rejected_at_parse_time`). The substituter's own
+// `PrevFailure::Unsupported` defense is otherwise unreachable through the
+// public DSL surface today, so it is verified here, directly, as
+// defense-in-depth against a future caller that builds an `ArgValue` some
+// other way (e.g. a second parser front-end).
+
+use khive_request::PrevFailure;
+use serde_json::Value as JsonValue;
+
+fn prev_ref(path: &str) -> ArgValue {
+    ArgValue::PrevRef {
+        path: path.to_string(),
+    }
+}
+
+#[test]
+fn find_prev_failure_reports_not_found_for_missing_field() {
+    let prev: JsonValue = json!({"id": "abc", "kind": "concept"});
+    let failure = prev_ref("bogus").find_prev_failure(&prev);
+    match failure {
+        Some(PrevFailure::NotFound {
+            missing, available, ..
+        }) => {
+            assert_eq!(missing, "bogus");
+            assert!(available.contains(&"id".to_string()));
+        }
+        other => panic!("expected NotFound, got {other:?}"),
+    }
+}
+
+#[test]
+fn find_prev_failure_reports_wrong_type_for_field_on_scalar() {
+    let prev: JsonValue = json!({"name": "concept-1"});
+    let failure = prev_ref("name.sub").find_prev_failure(&prev);
+    match failure {
+        Some(PrevFailure::WrongType {
+            expected, found, ..
+        }) => {
+            assert_eq!(expected, "object");
+            assert_eq!(found, "string");
+        }
+        other => panic!("expected WrongType, got {other:?}"),
+    }
+}
+
+#[test]
+fn find_prev_failure_reports_wrong_type_for_index_on_object() {
+    let prev: JsonValue = json!({"items": {"not": "an array"}});
+    let failure = prev_ref("items[0]").find_prev_failure(&prev);
+    match failure {
+        Some(PrevFailure::WrongType {
+            expected, found, ..
+        }) => {
+            assert_eq!(expected, "array");
+            assert_eq!(found, "object");
+        }
+        other => panic!("expected WrongType, got {other:?}"),
+    }
+}
+
+#[test]
+fn find_prev_failure_reports_unsupported_for_malformed_bracket() {
+    // `ArgValue::PrevRef` built directly (bypassing the parser, which never
+    // produces this shape) to exercise the substituter's own defense.
+    let prev: JsonValue = json!({"id": "abc"});
+    let failure = prev_ref("[bad]").find_prev_failure(&prev);
+    match failure {
+        Some(PrevFailure::Unsupported { segment, .. }) => {
+            assert_eq!(segment, "[bad]");
+        }
+        other => panic!("expected Unsupported, got {other:?}"),
+    }
+}
+
+#[test]
+fn find_prev_failure_none_when_resolve_all_succeeds() {
+    let prev: JsonValue = json!({"id": "abc", "nested": {"x": 1}});
+    let arg = prev_ref("nested.x");
+    assert!(arg.resolve_all(&prev).is_some());
+    assert!(arg.find_prev_failure(&prev).is_none());
+}


### PR DESCRIPTION
## Summary

`$prev` in a chained request always resolves against the immediately preceding
op's result only — that design is unchanged by this PR. What changed is the
error you get when a `$prev` reference can't be resolved: previously every
failure collapsed into one generic `substitution_error`, and the case where
the very first op in a chain used `$prev` (no preceding op exists yet) was
mislabeled as `$prev reference in non-chain context`, which is misleading
inside an actual chain.

This distinguishes the ways a `$prev` path can fail:

- **no preceding op** — `$prev` used in the chain's first operation
- **path not found** — the named field or array index isn't present; the
  message lists the sibling fields (or array length) that are
- **wrong type** — a path segment expects an object (for a field) or an array
  (for an index) to continue into, but the value at that point is a
  different JSON type
- **unsupported path form** — bracket syntax that isn't a valid
  non-negative-integer index (guarded at parse time on the public DSL surface;
  the substitution layer carries its own defense-in-depth check for this too)

Each message names the exact field/segment involved, what was found instead,
and the fix: split a non-adjacent dependency into separate calls and carry the
value across yourself, since `$prev` cannot reach more than one op back. A
chain aborted by an earlier op's failure now also says plainly which op
failed, so downstream ops that never ran don't read like the problem is local
to them.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy -p khive-request --all-targets -- -D warnings`
- [x] `cargo test -p khive-request` (137 passed, incl. 5 new tests against the
      substitution-failure classifier)
- [x] `cargo test -p khive-mcp` (194 passed / 21 pre-existing failures in
      `pending_events`, unrelated to this change and present on `main`;
      integration suite: 86 passed incl. 5 new chain-substitution tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)