### PR TITLE
fix(pack-kg): surface verb signatures in verbs(), enumerate valid kinds on a missing search kind

### DIFF
--- a/crates/khive-pack-kg/src/handler_defs.rs
+++ b/crates/khive-pack-kg/src/handler_defs.rs
@@ -925,6 +925,29 @@ pub(crate) static KG_HANDLERS: [HandlerDef; 18] = [
     },
 ];
 
+/// Render a `HandlerDef`'s params as a one-line call shape a caller can copy
+/// and fill in, e.g. `search(kind, query, limit?, entity_kind?, ...)`.
+///
+/// Required params are listed bare; optional params carry a trailing `?`.
+/// This is deliberately compact (names only, no types/descriptions) — the
+/// full schema is still available per-verb via `help=true`; `verbs()` is a
+/// catalog, not a `help=true` dump for every row.
+fn compact_signature(handler: &HandlerDef) -> String {
+    let params = handler
+        .params
+        .iter()
+        .map(|p| {
+            if p.required {
+                p.name.to_string()
+            } else {
+                format!("{}?", p.name)
+            }
+        })
+        .collect::<Vec<_>>()
+        .join(", ");
+    format!("{}({params})", handler.name)
+}
+
 /// Handle the `verbs` introspection verb — returns all public verbs, with optional category/pack filters.
 pub(crate) fn handle_verbs(params: Value, registry: &VerbRegistry) -> Result<Value, RuntimeError> {
     #[derive(serde::Deserialize, Default)]
@@ -955,6 +978,7 @@ pub(crate) fn handle_verbs(params: Value, registry: &VerbRegistry) -> Result<Val
                 "pack": pack_name,
                 "description": handler.description,
                 "category": format!("{:?}", handler.category),
+                "signature": compact_signature(handler),
             })
         })
         .collect();

--- a/crates/khive-pack-kg/src/handlers/common.rs
+++ b/crates/khive-pack-kg/src/handlers/common.rs
@@ -115,6 +115,35 @@ impl KindSpec {
     }
 }
 
+/// Every wire-level `kind` value accepted anywhere in the KG pack: the five
+/// fixed substrate names plus every granular entity/note kind `registry` has
+/// merged in from the loaded pack set. Sourced entirely from the registry so
+/// a pack that registers a new kind is reflected here without a code change.
+fn all_valid_kind_names(registry: &VerbRegistry) -> Vec<String> {
+    let mut all: Vec<String> = vec![
+        "entity".into(),
+        "note".into(),
+        "edge".into(),
+        "event".into(),
+        "proposal".into(),
+    ];
+    all.extend(registry.all_entity_kinds().iter().map(|s| (*s).to_string()));
+    all.extend(registry.all_note_kinds().iter().map(|s| (*s).to_string()));
+    all.sort();
+    all.dedup();
+    all
+}
+
+/// Build the error for a required `kind`-shaped param that the caller omitted
+/// entirely, enumerating every value the registry currently accepts (same
+/// list [`resolve_kind_spec`] uses for an unrecognized value).
+pub fn missing_kind_error(param_name: &str, registry: &VerbRegistry) -> RuntimeError {
+    RuntimeError::InvalidInput(format!(
+        "missing required param {param_name:?}; valid kinds: {}",
+        all_valid_kind_names(registry).join(" | ")
+    ))
+}
+
 /// Resolve a wire-level `kind` value into a [`KindSpec`]. Accepts a bare substrate
 /// name (`entity`, `note`, `edge`, `event`, `proposal`) or a granular entity/note kind
 /// registered on `registry`.
@@ -162,20 +191,9 @@ pub fn resolve_kind_spec(raw: &str, registry: &VerbRegistry) -> Result<KindSpec,
         });
     }
 
-    let mut all: Vec<String> = vec![
-        "entity".into(),
-        "note".into(),
-        "edge".into(),
-        "event".into(),
-        "proposal".into(),
-    ];
-    all.extend(registry.all_entity_kinds().iter().map(|s| (*s).to_string()));
-    all.extend(registry.all_note_kinds().iter().map(|s| (*s).to_string()));
-    all.sort();
-    all.dedup();
     Err(RuntimeError::InvalidInput(format!(
         "unknown kind {raw:?}; valid: {}",
-        all.join(" | ")
+        all_valid_kind_names(registry).join(" | ")
     )))
 }
 

--- a/crates/khive-pack-kg/src/handlers/params.rs
+++ b/crates/khive-pack-kg/src/handlers/params.rs
@@ -146,7 +146,10 @@ pub(crate) struct MergeParams {
 #[derive(Deserialize)]
 #[serde(deny_unknown_fields)]
 pub(crate) struct SearchParams {
-    pub(crate) kind: String,
+    /// Required, but kept `Option` at the wire boundary so a caller who omits
+    /// it entirely gets the enumerated-valid-kinds error from
+    /// `missing_kind_error` instead of a raw serde "missing field" message.
+    pub(crate) kind: Option<String>,
     pub(crate) query: String,
     pub(crate) limit: Option<u32>,
     pub(crate) entity_kind: Option<String>,

--- a/crates/khive-pack-kg/src/handlers/search.rs
+++ b/crates/khive-pack-kg/src/handlers/search.rs
@@ -16,8 +16,9 @@ use khive_storage::types::PageRequest;
 use khive_storage::EntityFilter;
 
 use super::common::{
-    canonical_entity_kind, canonical_note_kind, deser, props_match, reconcile_specific,
-    resolve_kind_spec, tags_match_any, to_json, validate_entity_type, KindSpec, SearchParams,
+    canonical_entity_kind, canonical_note_kind, deser, missing_kind_error, props_match,
+    reconcile_specific, resolve_kind_spec, tags_match_any, to_json, validate_entity_type, KindSpec,
+    SearchParams,
 };
 use crate::KgPack;
 
@@ -31,7 +32,11 @@ impl KgPack {
         let search_start = Instant::now();
         let p: SearchParams = deser(params)?;
         let limit = p.limit.unwrap_or(10).min(100);
-        let spec = resolve_kind_spec(&p.kind, registry)?;
+        let kind_raw = p
+            .kind
+            .as_deref()
+            .ok_or_else(|| missing_kind_error("kind", registry))?;
+        let spec = resolve_kind_spec(kind_raw, registry)?;
         match spec {
             KindSpec::Entity { specific } => {
                 let kind_filter = reconcile_specific(

--- a/crates/khive-pack-kg/tests/integration.rs
+++ b/crates/khive-pack-kg/tests/integration.rs
@@ -4831,6 +4831,83 @@ async fn verbs_dispatch_pack_filter_fake_excludes_subhandler() {
     );
 }
 
+/// `verbs()` output must carry enough of each verb's param schema that a
+/// caller can build a request that parses without first calling it wrong.
+/// Regression: `verbs()` used to list only name/pack/description/category,
+/// so learning a verb's required params meant reading source or eating a
+/// failed call.
+#[tokio::test]
+async fn verbs_dispatch_signature_is_enough_to_construct_a_parsing_call() {
+    let pack = pack();
+    let result = pack
+        .dispatch("verbs", json!({}))
+        .await
+        .expect("verbs() must succeed");
+
+    let verbs_arr = result["verbs"].as_array().expect("verbs must be an array");
+    let search_row = verbs_arr
+        .iter()
+        .find(|v| v["verb"].as_str() == Some("search"))
+        .expect("search must appear in verbs()");
+    let signature = search_row["signature"]
+        .as_str()
+        .expect("verbs() row must carry a 'signature' field");
+    let inner = signature
+        .trim_start_matches("search(")
+        .trim_end_matches(')');
+    let param_tokens: Vec<&str> = inner.split(", ").collect();
+    assert!(
+        param_tokens.contains(&"kind") && param_tokens.contains(&"query"),
+        "search's signature must name its required params kind and query, \
+         unmarked (not optional); got: {signature:?}"
+    );
+
+    // Build a call using exactly the required param names the signature
+    // named, with real values, and confirm it parses and executes rather
+    // than failing on a missing/unknown required field.
+    let call_result = pack
+        .dispatch("search", json!({"kind": "entity", "query": "anything"}))
+        .await;
+    assert!(
+        call_result.is_ok(),
+        "a call built from the signature's required params must parse; got: {call_result:?}"
+    );
+}
+
+/// `search` omitted entirely without `kind` must return the same
+/// enumerated-valid-kinds error as an unrecognized `kind` value, and the
+/// enumeration must be sourced from the registry (a kind contributed by
+/// another loaded pack must appear), not a hardcoded list or a raw serde
+/// "missing field" message.
+#[tokio::test]
+async fn search_missing_kind_lists_registry_kinds_including_other_packs() {
+    let fixture = pack_with_memory();
+
+    let err = fixture
+        .dispatch("search", json!({"query": "anything"}))
+        .await
+        .unwrap_err();
+
+    assert!(
+        is_invalid_input(&err),
+        "missing kind must be InvalidInput; got: {err:?}"
+    );
+    let msg = invalid_input_message(&err);
+    assert!(
+        msg.contains("entity") && msg.contains("note"),
+        "error must enumerate substrate kinds: {msg}"
+    );
+    assert!(
+        msg.contains("memory"),
+        "error must list 'memory' contributed by the extra pack, proving the \
+         enumeration is registry-sourced, not hardcoded: {msg}"
+    );
+    assert!(
+        !msg.to_ascii_lowercase().contains("missing field"),
+        "error must not be a raw serde deserialization message; got: {msg}"
+    );
+}
+
 // Concurrency regression: three parallel singleton link() calls for the same
 // (source, target, relation) triple must all return the same edge ID and the
 // database must contain exactly one edge row for that triple.


### PR DESCRIPTION
## Summary

Two related discoverability gaps in the KG pack's introspection and search surfaces:

1. `verbs()` listed only `verb` / `pack` / `description` / `category` for each row — nothing about parameters. The only way to learn what a verb required was to call it and read the resulting error. Each row now also carries a compact `signature` field (e.g. `search(kind, query, limit?, entity_kind?, ...)`), built from the same per-verb param schema `help=true` already renders, with required params listed bare and optional ones marked with a trailing `?`.

2. `search`'s `kind` parameter is required, and that requirement is now visible via (1) — but `search(query="...")` with `kind` omitted entirely used to fail with a raw serde `missing field` message. An unrecognized `kind` value (e.g. `kind="bogus"`) already produced a helpful error enumerating every valid kind sourced from the registry; the missing-parameter case now produces the same enumeration instead of a generic parser error, via a small shared helper so both paths always stay in sync with whatever kinds the loaded packs have registered.

Both are additive: no existing response field changes shape, and the kind enumeration is still built entirely from the registry's own kind lists (entity/note substrate + every pack-registered granular kind) — never a hardcoded list.

## Test plan

- [x] `cargo fmt -p khive-pack-kg -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test -p khive-pack-kg -p khive-runtime -p khive-mcp` (khive-pack-kg: 100% pass, including two new tests; the khive-mcp `pending_events` failures are pre-existing on unmodified `main` — reproduced separately — caused by a commercially-licensed pack absent from this distribution, unrelated to this change)
- [x] New test: a `verbs()` row for a required-param verb carries enough of its signature to build a call that actually parses and executes
- [x] New test: `search` with `kind` omitted lists the accepted kinds, including one contributed by a pack registered only for the test, proving the list is registry-sourced rather than hardcoded