### PR TITLE
feat(runtime): refuse daemon connections from a foreign uid

### DIFF
--- a/crates/khive-runtime/src/daemon.rs
+++ b/crates/khive-runtime/src/daemon.rs
@@ -1101,19 +1101,27 @@ pub async fn run_daemon<D: DaemonDispatch>(dispatcher: D) -> anyhow::Result<()> 
     run_daemon_with_boot_guard(dispatcher, boot_guard).await
 }
 
-/// Require the socket's parent directory to be owner-only, and re-permission it
-/// only when it is the directory khive owns by convention.
+/// Vet the socket's parent directory, re-permissioning it only when it is the
+/// directory khive owns by convention.
 ///
-/// ADR-096 condition 2 rests the same-uid safety on an owner-only socket inside
-/// an owner-only directory, so a daemon that cannot establish that mode must not
-/// serve. That justifies refusing; it does not justify *rewriting* a directory
-/// the operator handed us. `KHIVE_SOCKET` takes an arbitrary path, so chmodding
-/// its parent unconditionally is wrong in both directions: pointed at a shared
-/// parent like `/tmp` it either fails outright for an ordinary user, or — worse
-/// — succeeds when privileged and strips access for every other process on the
-/// machine. A directory we did not create is checked, never modified.
+/// `KHIVE_SOCKET` takes an arbitrary path, and the previous unconditional
+/// chmod-0700 of its parent was wrong in both directions: pointed at a shared
+/// parent like `/tmp` it either failed outright for an ordinary user, or —
+/// worse — succeeded when privileged and stripped access for every other
+/// process on the machine. A directory we did not create is never modified.
+///
+/// What the directory mode must actually prevent is narrower than "any access":
+/// the connection gate is the 0600 socket plus the accept-time peer-uid check,
+/// both of which fail closed on their own. The attack only the directory can
+/// enable is a *swap* — another writer unlinking the bound socket and binding
+/// its own at the same path, silently diverting clients. That requires the
+/// directory to be writable by others without the sticky bit (the sticky bit
+/// is exactly the guard that lets `/tmp` host per-user files safely). So:
+/// group/other-writable and non-sticky is refused; merely readable or
+/// traversable (0755, or 1777 with sticky) is served, since the socket's own
+/// mode and the peer check carry the guarantee there.
 #[cfg(unix)]
-fn ensure_socket_dir_is_owner_only(parent: &std::path::Path) -> anyhow::Result<()> {
+fn ensure_socket_dir_is_swap_safe(parent: &std::path::Path) -> anyhow::Result<()> {
     if parent == khive_dir() {
         std::fs::set_permissions(parent, std::fs::Permissions::from_mode(0o700)).map_err(|e| {
             anyhow::anyhow!(
@@ -1122,28 +1130,33 @@ fn ensure_socket_dir_is_owner_only(parent: &std::path::Path) -> anyhow::Result<(
                 parent.display()
             )
         })?;
+        return Ok(());
     }
 
+    // Fail closed on the stat itself: not being able to read the mode is not
+    // the same as the mode passing.
     let mode = std::fs::metadata(parent)
         .map_err(|e| {
             anyhow::anyhow!(
-                "refusing to start: cannot stat {}: {e}. The socket directory's mode is half \
-                 of the same-uid guarantee this daemon enforces, and an unreadable mode is \
-                 not a passing one.",
+                "refusing to start: cannot stat {}: {e}. The socket directory's mode gates \
+                 socket-swap safety, and an unreadable mode is not a passing one.",
                 parent.display()
             )
         })?
         .permissions()
-        .mode()
-        & 0o777;
+        .mode();
 
-    if mode & 0o077 != 0 {
+    let writable_by_others = mode & 0o022 != 0;
+    let sticky = mode & 0o1000 != 0;
+    if writable_by_others && !sticky {
         anyhow::bail!(
-            "refusing to start: socket directory {} is mode {mode:04o}, which grants access \
-             beyond its owner. Point KHIVE_SOCKET at a directory only you can reach, or unset \
-             it to use the default. This daemon is not changing the permissions of a directory \
-             it does not own.",
-            parent.display()
+            "refusing to start: socket directory {} is mode {:04o} — writable by group or \
+             other without the sticky bit, so another local user could replace the socket \
+             after this daemon binds it. Use a directory only you can write, a sticky \
+             world-writable directory, or unset KHIVE_SOCKET for the default. This daemon \
+             is not changing the permissions of a directory it does not own.",
+            parent.display(),
+            mode & 0o7777
         );
     }
 
@@ -1172,7 +1185,7 @@ pub async fn run_daemon_with_boot_guard<D: DaemonDispatch>(
 
     if let Some(parent) = sock.parent() {
         std::fs::create_dir_all(parent)?;
-        ensure_socket_dir_is_owner_only(parent)?;
+        ensure_socket_dir_is_swap_safe(parent)?;
     }
 
     // Hold the startup lock across cleanup → bind → pid-write so a concurrent
@@ -2033,22 +2046,23 @@ mod tests {
 
     /// Test 2: `wal_pages` reflects a real
     /// checkpoint observation after writes, deterministically forced via a
-    /// A shared socket directory is refused, and — the part that matters — is
-    /// left exactly as it was found.
+    /// A non-sticky directory writable by others is refused, and — the part
+    /// that matters — is left exactly as it was found.
     ///
-    /// `KHIVE_SOCKET` accepts any path, so this stands in for pointing it at
-    /// `/tmp`. Refusing is correct. Re-permissioning someone else's directory
-    /// on the way past is what this pins against: run as a user who *can*
-    /// chmod it, the old unconditional call succeeded and revoked access for
-    /// every other process using that directory.
+    /// This is the one shape the directory mode alone must gate: another
+    /// writer can unlink the bound socket and bind its own at the same path.
+    /// Re-permissioning someone else's directory on the way past is what the
+    /// second assertion pins against: run as a user who *can* chmod it, the
+    /// old unconditional call succeeded and revoked access for every other
+    /// process using that directory.
     #[test]
-    fn shared_socket_dir_is_refused_without_being_modified() {
+    fn swappable_socket_dir_is_refused_without_being_modified() {
         let dir = tempfile::tempdir().expect("tempdir");
         let shared = dir.path().join("shared");
         std::fs::create_dir(&shared).expect("create");
         std::fs::set_permissions(&shared, std::fs::Permissions::from_mode(0o777)).expect("chmod");
 
-        let err = ensure_socket_dir_is_owner_only(&shared).expect_err("must refuse 0777");
+        let err = ensure_socket_dir_is_swap_safe(&shared).expect_err("must refuse non-sticky 0777");
         assert!(
             err.to_string().contains("0777"),
             "the refusal should name the mode it saw, got: {err}"
@@ -2065,16 +2079,31 @@ mod tests {
         );
     }
 
-    /// An operator-chosen directory that is already owner-only is accepted as
-    /// found, so the check gates on the mode rather than on the location.
+    /// Directory modes that cannot host a socket swap are served as found:
+    /// owner-only, the umask-default 0755 every `tempfile::tempdir` and test
+    /// runner produces, and sticky world-writable (the `/tmp` shape, where the
+    /// sticky bit is exactly what stops another user unlinking the socket).
     #[test]
-    fn owner_only_socket_dir_outside_khive_home_is_accepted() {
+    fn swap_safe_socket_dirs_are_accepted_unmodified() {
         let dir = tempfile::tempdir().expect("tempdir");
-        let private = dir.path().join("private");
-        std::fs::create_dir(&private).expect("create");
-        std::fs::set_permissions(&private, std::fs::Permissions::from_mode(0o700)).expect("chmod");
+        for (name, mode) in [
+            ("private", 0o700),
+            ("listable", 0o755),
+            ("sticky-tmp", 0o1777),
+        ] {
+            let d = dir.path().join(name);
+            std::fs::create_dir(&d).expect("create");
+            std::fs::set_permissions(&d, std::fs::Permissions::from_mode(mode)).expect("chmod");
 
-        ensure_socket_dir_is_owner_only(&private).expect("0700 dir must be accepted");
+            ensure_socket_dir_is_swap_safe(&d)
+                .unwrap_or_else(|e| panic!("mode {mode:04o} must be accepted, got: {e}"));
+
+            let after = std::fs::metadata(&d).expect("stat").permissions().mode() & 0o7777;
+            assert_eq!(
+                after, mode,
+                "acceptance must not re-permission the directory either"
+            );
+        }
     }
 
     /// direct `checkpoint_once` call rather than waiting on the async

--- a/crates/khive-runtime/src/daemon.rs
+++ b/crates/khive-runtime/src/daemon.rs
@@ -1125,6 +1125,9 @@ pub async fn run_daemon<D: DaemonDispatch>(dispatcher: D) -> anyhow::Result<()> 
 /// `/tmp` do not.
 #[cfg(unix)]
 fn ensure_socket_dir_is_trusted(parent: &std::path::Path) -> anyhow::Result<()> {
+    // SAFETY: `geteuid` is always successful and takes no arguments.
+    let daemon_euid = unsafe { libc::geteuid() } as u32;
+
     if parent == khive_dir() {
         std::fs::set_permissions(parent, std::fs::Permissions::from_mode(0o700)).map_err(|e| {
             anyhow::anyhow!(
@@ -1133,7 +1136,7 @@ fn ensure_socket_dir_is_trusted(parent: &std::path::Path) -> anyhow::Result<()> 
                 parent.display()
             )
         })?;
-        return Ok(());
+        return ensure_socket_dir_ancestors_are_swap_resistant(parent, daemon_euid);
     }
 
     // Fail closed on the stat itself: not being able to read the metadata is
@@ -1148,8 +1151,6 @@ fn ensure_socket_dir_is_trusted(parent: &std::path::Path) -> anyhow::Result<()> 
 
     use std::os::unix::fs::MetadataExt;
     let owner = meta.uid();
-    // SAFETY: `geteuid` is always successful and takes no arguments.
-    let daemon_euid = unsafe { libc::geteuid() } as u32;
     if owner != daemon_euid && owner != 0 {
         anyhow::bail!(
             "refusing to start: socket directory {} is owned by uid {owner}, not this \
@@ -1172,6 +1173,78 @@ fn ensure_socket_dir_is_trusted(parent: &std::path::Path) -> anyhow::Result<()> 
             parent.display(),
             mode & 0o7777
         );
+    }
+
+    ensure_socket_dir_ancestors_are_swap_resistant(parent, daemon_euid)
+}
+
+/// Walk every ancestor of the (already-vetted) socket directory and refuse
+/// any that would let another local user *replace a path component*: rename
+/// the trusted final directory away and recreate it, re-rooting the socket
+/// path under attacker control without ever touching the vetted directory
+/// itself.
+///
+/// The ancestor rule is deliberately weaker than the immediate parent's.
+/// The parent hosts the socket file, where the threat is *creation* of the
+/// predictable path — the sticky bit does not restrict creating, so no
+/// sticky exception is sound there. An ancestor only threatens via
+/// *rename/unlink of an existing entry we own*, which the sticky bit does
+/// restrict: in a sticky directory, only the entry's owner, the directory's
+/// owner, or root may rename it. So a root-owned `/tmp` (1777) is an
+/// acceptable ancestor of a user-owned 0700 socket directory, while a
+/// non-sticky group/other-writable ancestor, or one owned by a third uid
+/// (who could rename the entry, or chmod the directory first), is refused.
+///
+/// The path is canonicalized first so a symlink component cannot smuggle in
+/// an unvetted real location; canonicalization failure fails closed.
+#[cfg(unix)]
+fn ensure_socket_dir_ancestors_are_swap_resistant(
+    parent: &std::path::Path,
+    daemon_euid: u32,
+) -> anyhow::Result<()> {
+    use std::os::unix::fs::MetadataExt;
+
+    let canonical = std::fs::canonicalize(parent).map_err(|e| {
+        anyhow::anyhow!(
+            "refusing to start: cannot canonicalize socket directory {}: {e}. Ancestor \
+             trust cannot be checked through an unresolvable path.",
+            parent.display()
+        )
+    })?;
+
+    for ancestor in canonical.ancestors().skip(1) {
+        if ancestor.as_os_str().is_empty() {
+            break;
+        }
+        let meta = std::fs::metadata(ancestor).map_err(|e| {
+            anyhow::anyhow!(
+                "refusing to start: cannot stat socket-path ancestor {}: {e}. An \
+                 unreadable ancestor is not a passing one.",
+                ancestor.display()
+            )
+        })?;
+        let owner = meta.uid();
+        let mode = meta.permissions().mode();
+        let sticky = mode & 0o1000 != 0;
+        if owner != daemon_euid && owner != 0 {
+            anyhow::bail!(
+                "refusing to start: socket-path ancestor {} is owned by uid {owner}, not \
+                 this daemon's uid ({daemon_euid}) or root — its owner could rename the \
+                 next path component and re-root the socket path. Point KHIVE_SOCKET \
+                 somewhere trusted end to end, or unset it for the default.",
+                ancestor.display()
+            );
+        }
+        if mode & 0o022 != 0 && !sticky {
+            anyhow::bail!(
+                "refusing to start: socket-path ancestor {} is mode {:04o} — writable by \
+                 group or other without the sticky bit, so another local user could rename \
+                 the next path component and re-root the socket path. Point KHIVE_SOCKET \
+                 somewhere trusted end to end, or unset it for the default.",
+                ancestor.display(),
+                mode & 0o7777
+            );
+        }
     }
 
     Ok(())
@@ -2095,6 +2168,36 @@ mod tests {
                 "refusing must not re-permission a directory khive does not own"
             );
         }
+    }
+
+    /// A vetted final directory is still refused when an ANCESTOR would let
+    /// another local user rename it away and recreate it: a non-sticky
+    /// group/other-writable ancestor re-roots the whole socket path without
+    /// the final directory's own metadata ever changing. The sticky-ancestor
+    /// arm (a root-owned 1777 `/tmp` above a user-owned 0700 directory is
+    /// acceptable) is exercised implicitly by every accepting test below,
+    /// whose tempdirs live under the platform temp root.
+    #[test]
+    fn writable_non_sticky_ancestor_is_refused() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let open_mid = dir.path().join("open-mid");
+        std::fs::create_dir(&open_mid).expect("create mid");
+        let inner = open_mid.join("private");
+        std::fs::create_dir(&inner).expect("create inner");
+        std::fs::set_permissions(&inner, std::fs::Permissions::from_mode(0o700)).expect("chmod");
+        std::fs::set_permissions(&open_mid, std::fs::Permissions::from_mode(0o777))
+            .expect("chmod mid");
+
+        let err = ensure_socket_dir_is_trusted(&inner)
+            .expect_err("a 0777 non-sticky ancestor must be refused");
+        assert!(
+            err.to_string().contains("ancestor"),
+            "the refusal should say it was an ancestor that failed, got: {err}"
+        );
+        assert!(
+            err.to_string().contains("open-mid"),
+            "the refusal should name the failing ancestor, got: {err}"
+        );
     }
 
     /// Directories this daemon can trust end to end are served as found:

--- a/crates/khive-runtime/src/daemon.rs
+++ b/crates/khive-runtime/src/daemon.rs
@@ -304,6 +304,103 @@ fn socket_identity(path: &std::path::Path) -> Option<SocketIdentity> {
     })
 }
 
+// ── connection principal ──────────────────────────────────────────────────────
+
+/// The uid on the other end of an accepted connection, read from the kernel.
+///
+/// This is the only identity on this socket the caller cannot choose. Every
+/// identity field on the request frame — `namespace`, `actor_id`,
+/// `visible_namespaces`, `config_id` — is supplied by the connecting process,
+/// so none of them can answer "who is this". A check reading self-asserted
+/// fields is not a weak gate, it is not a gate: anyone who wants to pass it
+/// asserts the passing values.
+///
+/// `getpeereid(2)` on macOS/BSD, `SO_PEERCRED` on Linux. Both report the peer's
+/// credentials as recorded by the kernel at connect time.
+#[cfg(unix)]
+fn peer_uid(stream: &UnixStream) -> std::io::Result<u32> {
+    use std::os::fd::AsRawFd;
+    let fd = stream.as_raw_fd();
+
+    #[cfg(any(target_os = "macos", target_os = "ios", target_vendor = "apple"))]
+    {
+        let mut uid: libc::uid_t = 0;
+        let mut gid: libc::gid_t = 0;
+        // SAFETY: `fd` is a live connected socket owned by `stream` for the
+        // duration of this call; both out-params are valid initialized locals.
+        let rc = unsafe { libc::getpeereid(fd, &mut uid, &mut gid) };
+        if rc != 0 {
+            return Err(std::io::Error::last_os_error());
+        }
+        Ok(uid as u32)
+    }
+
+    #[cfg(target_os = "linux")]
+    {
+        let mut cred = libc::ucred {
+            pid: 0,
+            uid: 0,
+            gid: 0,
+        };
+        let mut len = std::mem::size_of::<libc::ucred>() as libc::socklen_t;
+        // SAFETY: `fd` is a live connected socket owned by `stream`; `cred` is
+        // an initialized local of exactly `len` bytes, which is what
+        // SO_PEERCRED writes.
+        let rc = unsafe {
+            libc::getsockopt(
+                fd,
+                libc::SOL_SOCKET,
+                libc::SO_PEERCRED,
+                (&mut cred as *mut libc::ucred).cast::<libc::c_void>(),
+                &mut len,
+            )
+        };
+        if rc != 0 {
+            return Err(std::io::Error::last_os_error());
+        }
+        Ok(cred.uid as u32)
+    }
+
+    #[cfg(not(any(
+        target_os = "linux",
+        target_os = "macos",
+        target_os = "ios",
+        target_vendor = "apple"
+    )))]
+    {
+        let _ = fd;
+        Err(std::io::Error::new(
+            std::io::ErrorKind::Unsupported,
+            "peer-credential capture is not implemented for this platform",
+        ))
+    }
+}
+
+/// Whether a connection from `uid` may be served by this daemon.
+///
+/// ADR-096 accepted per-request identity threading **for the single-principal
+/// owner-only socket only**, and rested that on three things: the `0600`
+/// socket, all connections being the same uid, and the database being already
+/// same-uid-accessible. The socket mode is asserted at bind. This asserts the
+/// second, which previously had no representation in the code at all — nothing
+/// read peer identity, so nothing could notice when it stopped being true.
+///
+/// **Principal is not attribution.** Many `actor_id`s over one socket is
+/// exactly what ADR-096 shipped and what every seat on a normal host does;
+/// refusing a second distinct actor would break the accepted design. The
+/// principal is the uid, and this refuses only a genuinely foreign one.
+///
+/// **There is deliberately no configuration escape hatch.** A flag permitting
+/// other uids would not weaken this assertion, it would delete it, in the way
+/// hardest to notice later: the check still exists, its tests still pass, and
+/// the deployment that matters has it off. A deployment that genuinely needs
+/// multiple uids needs a code change and a gated ADR — which is precisely the
+/// decision that should be impossible to make by accident.
+#[cfg(unix)]
+fn uid_is_permitted(peer: u32, daemon_euid: u32) -> bool {
+    peer == daemon_euid
+}
+
 // ── wire types ────────────────────────────────────────────────────────────────
 
 /// Request frame sent from a client to the daemon.
@@ -1026,9 +1123,18 @@ pub async fn run_daemon_with_boot_guard<D: DaemonDispatch>(
 
     if let Some(parent) = sock.parent() {
         std::fs::create_dir_all(parent)?;
-        if let Err(e) = std::fs::set_permissions(parent, std::fs::Permissions::from_mode(0o700)) {
-            tracing::warn!(error = %e, path = ?parent, "failed to chmod 0700 khive dir");
-        }
+        // Fail closed. ADR-096 condition 2 rests the single-principal safety on
+        // the owner-only socket and its owner-only directory; a daemon that
+        // cannot prove that mode must not serve. Warn-and-continue here would
+        // leave the process running on whatever mode the umask happened to
+        // give, with the warning the only trace.
+        std::fs::set_permissions(parent, std::fs::Permissions::from_mode(0o700)).map_err(|e| {
+            anyhow::anyhow!(
+                "refusing to start: cannot chmod 0700 {}: {e}. The khive directory must be \
+                 owner-only — it is half of the single-principal guarantee this daemon enforces.",
+                parent.display()
+            )
+        })?;
     }
 
     // Hold the startup lock across cleanup → bind → pid-write so a concurrent
@@ -1052,8 +1158,17 @@ pub async fn run_daemon_with_boot_guard<D: DaemonDispatch>(
     }
 
     let listener = UnixListener::bind(&sock)?;
+    // Fail closed, same reason as the directory above. If this chmod fails the
+    // socket is world-reachable in a way the accepted design never covered, so
+    // the bound listener is dropped and the entry removed rather than served.
     if let Err(e) = std::fs::set_permissions(&sock, std::fs::Permissions::from_mode(0o600)) {
-        tracing::warn!(error = %e, path = ?sock, "failed to chmod 0600 socket");
+        drop(listener);
+        let _ = std::fs::remove_file(&sock);
+        return Err(anyhow::anyhow!(
+            "refusing to start: cannot chmod 0600 {}: {e}. The daemon socket must be owner-only \
+             — it is half of the single-principal guarantee this daemon enforces.",
+            sock.display()
+        ));
     }
     // Captured while still holding the startup lock, immediately after
     // bind, so shutdown cleanup can later prove "this is still the same socket
@@ -1153,11 +1268,41 @@ pub async fn run_daemon_with_boot_guard<D: DaemonDispatch>(
         }
     };
 
+    // SAFETY: `geteuid` is always successful and takes no arguments.
+    let daemon_euid = unsafe { libc::geteuid() } as u32;
+
     tokio::select! {
         _ = async {
             loop {
                 match listener.accept().await {
                     Ok((stream, _)) => {
+                        // Refuse a foreign principal before any frame is read.
+                        // Fails CLOSED: an error reading peer credentials is
+                        // "cannot prove same-uid", which is the same answer as
+                        // "is not same-uid" — never a pass.
+                        match peer_uid(&stream) {
+                            Ok(peer) if uid_is_permitted(peer, daemon_euid) => {}
+                            Ok(peer) => {
+                                tracing::error!(
+                                    peer_uid = peer,
+                                    daemon_euid,
+                                    "refusing connection from a foreign uid: this daemon serves a \
+                                     single principal (ADR-096 condition 2); multi-principal \
+                                     serving requires a gated ADR, not a configuration change"
+                                );
+                                drop(stream);
+                                continue;
+                            }
+                            Err(e) => {
+                                tracing::error!(
+                                    error = %e,
+                                    "refusing connection: cannot read peer credentials, so \
+                                     same-uid cannot be proven"
+                                );
+                                drop(stream);
+                                continue;
+                            }
+                        }
                         let d = dispatcher.clone();
                         let active = Arc::clone(&active);
                         tokio::spawn(async move {
@@ -2414,6 +2559,74 @@ mod tests {
             "the surviving pid file must contain the winner's pid — both threads \
              share this process's pid, so an unexpected value would also prove a \
              lost/garbled write raced through"
+        );
+    }
+
+    // ── connection principal (ADR-096 condition 2) ────────────────────────────
+
+    /// The peer-credential syscall must actually work on this platform and
+    /// report the real uid, not error or return a placeholder.
+    ///
+    /// This matters more than it looks because the accept path fails CLOSED: if
+    /// `peer_uid` errored unconditionally — wrong syscall, wrong socket option,
+    /// an unimplemented platform arm — every connection would be refused and
+    /// the daemon would be silently unreachable. A test that only exercised the
+    /// decision function would not catch that.
+    #[tokio::test]
+    async fn peer_uid_reports_the_connecting_process_uid() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let sock = dir.path().join("peer.sock");
+        let listener = UnixListener::bind(&sock).expect("bind");
+
+        let connect_path = sock.clone();
+        let client = tokio::spawn(async move { UnixStream::connect(&connect_path).await });
+
+        let (server_side, _) = listener.accept().await.expect("accept");
+        let client_side = client.await.expect("join").expect("connect");
+
+        // SAFETY: `geteuid` is always successful and takes no arguments.
+        let expected = unsafe { libc::geteuid() } as u32;
+
+        assert_eq!(
+            peer_uid(&server_side).expect("peer_uid must succeed on a live connection"),
+            expected,
+            "the uid read from the kernel for a same-process connection must be \
+             this process's euid"
+        );
+        // Symmetric: both ends report the same peer on a same-uid connection.
+        assert_eq!(
+            peer_uid(&client_side).expect("peer_uid must succeed on the client end"),
+            expected
+        );
+    }
+
+    /// The refusal rule itself: the principal is the uid, and only a foreign
+    /// uid is refused.
+    ///
+    /// The second assertion is the load-bearing one and it is a regression
+    /// guard, not a formality. ADR-096 shipped many `actor_id`s over one
+    /// socket; every seat on a normal host is a distinct attribution at the
+    /// same uid. A check that conflated attribution with principal would refuse
+    /// them all, so "same uid is permitted" must stay true no matter how the
+    /// rule is later tightened.
+    #[test]
+    fn only_a_foreign_uid_is_refused() {
+        // SAFETY: `geteuid` is always successful and takes no arguments.
+        let euid = unsafe { libc::geteuid() } as u32;
+
+        assert!(
+            uid_is_permitted(euid, euid),
+            "a connection from the daemon's own uid must be served — this is \
+             every seat on the host, and ADR-096 accepted exactly this shape"
+        );
+        assert!(
+            !uid_is_permitted(euid.wrapping_add(1), euid),
+            "a connection from any other uid must be refused"
+        );
+        assert!(
+            !uid_is_permitted(0, euid.wrapping_add(1)),
+            "root is not special-cased: the rule is equality with the daemon's \
+             euid, not a privilege comparison"
         );
     }
 }

--- a/crates/khive-runtime/src/daemon.rs
+++ b/crates/khive-runtime/src/daemon.rs
@@ -358,7 +358,7 @@ fn peer_uid(stream: &UnixStream) -> std::io::Result<u32> {
         if rc != 0 {
             return Err(std::io::Error::last_os_error());
         }
-        Ok(cred.uid as u32)
+        Ok(cred.uid)
     }
 
     #[cfg(not(any(

--- a/crates/khive-runtime/src/daemon.rs
+++ b/crates/khive-runtime/src/daemon.rs
@@ -1101,6 +1101,55 @@ pub async fn run_daemon<D: DaemonDispatch>(dispatcher: D) -> anyhow::Result<()> 
     run_daemon_with_boot_guard(dispatcher, boot_guard).await
 }
 
+/// Require the socket's parent directory to be owner-only, and re-permission it
+/// only when it is the directory khive owns by convention.
+///
+/// ADR-096 condition 2 rests the same-uid safety on an owner-only socket inside
+/// an owner-only directory, so a daemon that cannot establish that mode must not
+/// serve. That justifies refusing; it does not justify *rewriting* a directory
+/// the operator handed us. `KHIVE_SOCKET` takes an arbitrary path, so chmodding
+/// its parent unconditionally is wrong in both directions: pointed at a shared
+/// parent like `/tmp` it either fails outright for an ordinary user, or — worse
+/// — succeeds when privileged and strips access for every other process on the
+/// machine. A directory we did not create is checked, never modified.
+#[cfg(unix)]
+fn ensure_socket_dir_is_owner_only(parent: &std::path::Path) -> anyhow::Result<()> {
+    if parent == khive_dir() {
+        std::fs::set_permissions(parent, std::fs::Permissions::from_mode(0o700)).map_err(|e| {
+            anyhow::anyhow!(
+                "refusing to start: cannot chmod 0700 {}: {e}. The khive directory must be \
+                 owner-only — it is half of the same-uid guarantee this daemon enforces.",
+                parent.display()
+            )
+        })?;
+    }
+
+    let mode = std::fs::metadata(parent)
+        .map_err(|e| {
+            anyhow::anyhow!(
+                "refusing to start: cannot stat {}: {e}. The socket directory's mode is half \
+                 of the same-uid guarantee this daemon enforces, and an unreadable mode is \
+                 not a passing one.",
+                parent.display()
+            )
+        })?
+        .permissions()
+        .mode()
+        & 0o777;
+
+    if mode & 0o077 != 0 {
+        anyhow::bail!(
+            "refusing to start: socket directory {} is mode {mode:04o}, which grants access \
+             beyond its owner. Point KHIVE_SOCKET at a directory only you can reach, or unset \
+             it to use the default. This daemon is not changing the permissions of a directory \
+             it does not own.",
+            parent.display()
+        );
+    }
+
+    Ok(())
+}
+
 /// Run the daemon using a startup lock acquired by the caller *before*
 /// building `dispatcher`, so a second process racing to boot (e.g. two
 /// `kkernel mcp --daemon` spawns before either has bound its socket) cannot
@@ -1123,18 +1172,7 @@ pub async fn run_daemon_with_boot_guard<D: DaemonDispatch>(
 
     if let Some(parent) = sock.parent() {
         std::fs::create_dir_all(parent)?;
-        // Fail closed. ADR-096 condition 2 rests the single-principal safety on
-        // the owner-only socket and its owner-only directory; a daemon that
-        // cannot prove that mode must not serve. Warn-and-continue here would
-        // leave the process running on whatever mode the umask happened to
-        // give, with the warning the only trace.
-        std::fs::set_permissions(parent, std::fs::Permissions::from_mode(0o700)).map_err(|e| {
-            anyhow::anyhow!(
-                "refusing to start: cannot chmod 0700 {}: {e}. The khive directory must be \
-                 owner-only — it is half of the single-principal guarantee this daemon enforces.",
-                parent.display()
-            )
-        })?;
+        ensure_socket_dir_is_owner_only(parent)?;
     }
 
     // Hold the startup lock across cleanup → bind → pid-write so a concurrent
@@ -1995,6 +2033,50 @@ mod tests {
 
     /// Test 2: `wal_pages` reflects a real
     /// checkpoint observation after writes, deterministically forced via a
+    /// A shared socket directory is refused, and — the part that matters — is
+    /// left exactly as it was found.
+    ///
+    /// `KHIVE_SOCKET` accepts any path, so this stands in for pointing it at
+    /// `/tmp`. Refusing is correct. Re-permissioning someone else's directory
+    /// on the way past is what this pins against: run as a user who *can*
+    /// chmod it, the old unconditional call succeeded and revoked access for
+    /// every other process using that directory.
+    #[test]
+    fn shared_socket_dir_is_refused_without_being_modified() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let shared = dir.path().join("shared");
+        std::fs::create_dir(&shared).expect("create");
+        std::fs::set_permissions(&shared, std::fs::Permissions::from_mode(0o777)).expect("chmod");
+
+        let err = ensure_socket_dir_is_owner_only(&shared).expect_err("must refuse 0777");
+        assert!(
+            err.to_string().contains("0777"),
+            "the refusal should name the mode it saw, got: {err}"
+        );
+
+        let after = std::fs::metadata(&shared)
+            .expect("stat")
+            .permissions()
+            .mode()
+            & 0o777;
+        assert_eq!(
+            after, 0o777,
+            "refusing must not re-permission a directory khive does not own"
+        );
+    }
+
+    /// An operator-chosen directory that is already owner-only is accepted as
+    /// found, so the check gates on the mode rather than on the location.
+    #[test]
+    fn owner_only_socket_dir_outside_khive_home_is_accepted() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let private = dir.path().join("private");
+        std::fs::create_dir(&private).expect("create");
+        std::fs::set_permissions(&private, std::fs::Permissions::from_mode(0o700)).expect("chmod");
+
+        ensure_socket_dir_is_owner_only(&private).expect("0700 dir must be accepted");
+    }
+
     /// direct `checkpoint_once` call rather than waiting on the async
     /// periodic task.
     #[tokio::test]

--- a/crates/khive-runtime/src/daemon.rs
+++ b/crates/khive-runtime/src/daemon.rs
@@ -1276,19 +1276,27 @@ pub async fn run_daemon_with_boot_guard<D: DaemonDispatch>(
             loop {
                 match listener.accept().await {
                     Ok((stream, _)) => {
-                        // Refuse a foreign principal before any frame is read.
+                        // Refuse a foreign uid before any frame is read.
                         // Fails CLOSED: an error reading peer credentials is
                         // "cannot prove same-uid", which is the same answer as
                         // "is not same-uid" — never a pass.
+                        //
+                        // Scope: this is a same-UID check, which is strictly
+                        // weaker than same-PRINCIPAL. Several distinct actors
+                        // running under one uid all pass here, so this does not
+                        // by itself establish that the daemon serves a single
+                        // principal, and nothing downstream refuses or degrades
+                        // on observing more than one. Do not describe it as a
+                        // multi-principal guard — it bounds the process boundary,
+                        // not the identity one.
                         match peer_uid(&stream) {
                             Ok(peer) if uid_is_permitted(peer, daemon_euid) => {}
                             Ok(peer) => {
                                 tracing::error!(
                                     peer_uid = peer,
                                     daemon_euid,
-                                    "refusing connection from a foreign uid: this daemon serves a \
-                                     single principal (ADR-096 condition 2); multi-principal \
-                                     serving requires a gated ADR, not a configuration change"
+                                    "refusing connection from a foreign uid: this daemon accepts \
+                                     only peers running as its own uid"
                                 );
                                 drop(stream);
                                 continue;

--- a/crates/khive-runtime/src/daemon.rs
+++ b/crates/khive-runtime/src/daemon.rs
@@ -1110,18 +1110,21 @@ pub async fn run_daemon<D: DaemonDispatch>(dispatcher: D) -> anyhow::Result<()> 
 /// worse — succeeded when privileged and stripped access for every other
 /// process on the machine. A directory we did not create is never modified.
 ///
-/// What the directory mode must actually prevent is narrower than "any access":
-/// the connection gate is the 0600 socket plus the accept-time peer-uid check,
-/// both of which fail closed on their own. The attack only the directory can
-/// enable is a *swap* — another writer unlinking the bound socket and binding
-/// its own at the same path, silently diverting clients. That requires the
-/// directory to be writable by others without the sticky bit (the sticky bit
-/// is exactly the guard that lets `/tmp` host per-user files safely). So:
-/// group/other-writable and non-sticky is refused; merely readable or
-/// traversable (0755, or 1777 with sticky) is served, since the socket's own
-/// mode and the peer check carry the guarantee there.
+/// What the directory must actually prevent is a *takeover of the socket
+/// path*: the connection gate is the 0600 socket plus the accept-time
+/// peer-uid check, but both defend the daemon's own socket — neither helps
+/// once another local user can put *their* listener at the path clients
+/// resolve. There are two ways a shared directory allows that, and the
+/// sticky bit closes neither: a writer can *pre-bind* the predictable path
+/// before this daemon starts (the sticky bit restricts unlinking, not
+/// creating), and the directory's *owner* can unlink and rebind even in a
+/// 1777 directory (sticky exempts the directory owner). So a caller-chosen
+/// directory is served only when it is trusted end to end: owned by this
+/// daemon's euid or root, and not writable by group or other at all. The
+/// umask-default 0755 stays acceptable; shared sticky directories like
+/// `/tmp` do not.
 #[cfg(unix)]
-fn ensure_socket_dir_is_swap_safe(parent: &std::path::Path) -> anyhow::Result<()> {
+fn ensure_socket_dir_is_trusted(parent: &std::path::Path) -> anyhow::Result<()> {
     if parent == khive_dir() {
         std::fs::set_permissions(parent, std::fs::Permissions::from_mode(0o700)).map_err(|e| {
             anyhow::anyhow!(
@@ -1133,28 +1136,39 @@ fn ensure_socket_dir_is_swap_safe(parent: &std::path::Path) -> anyhow::Result<()
         return Ok(());
     }
 
-    // Fail closed on the stat itself: not being able to read the mode is not
-    // the same as the mode passing.
-    let mode = std::fs::metadata(parent)
-        .map_err(|e| {
-            anyhow::anyhow!(
-                "refusing to start: cannot stat {}: {e}. The socket directory's mode gates \
-                 socket-swap safety, and an unreadable mode is not a passing one.",
-                parent.display()
-            )
-        })?
-        .permissions()
-        .mode();
+    // Fail closed on the stat itself: not being able to read the metadata is
+    // not the same as the directory passing.
+    let meta = std::fs::metadata(parent).map_err(|e| {
+        anyhow::anyhow!(
+            "refusing to start: cannot stat {}: {e}. The socket directory gates \
+             socket-takeover safety, and unreadable metadata is not a passing state.",
+            parent.display()
+        )
+    })?;
 
-    let writable_by_others = mode & 0o022 != 0;
-    let sticky = mode & 0o1000 != 0;
-    if writable_by_others && !sticky {
+    use std::os::unix::fs::MetadataExt;
+    let owner = meta.uid();
+    // SAFETY: `geteuid` is always successful and takes no arguments.
+    let daemon_euid = unsafe { libc::geteuid() } as u32;
+    if owner != daemon_euid && owner != 0 {
+        anyhow::bail!(
+            "refusing to start: socket directory {} is owned by uid {owner}, not this \
+             daemon's uid ({daemon_euid}) or root. A directory owner can replace the \
+             socket regardless of mode bits. Point KHIVE_SOCKET at a directory you own, \
+             or unset it for the default.",
+            parent.display()
+        );
+    }
+
+    let mode = meta.permissions().mode();
+    if mode & 0o022 != 0 {
         anyhow::bail!(
             "refusing to start: socket directory {} is mode {:04o} — writable by group or \
-             other without the sticky bit, so another local user could replace the socket \
-             after this daemon binds it. Use a directory only you can write, a sticky \
-             world-writable directory, or unset KHIVE_SOCKET for the default. This daemon \
-             is not changing the permissions of a directory it does not own.",
+             other, so another local user could bind their own listener at the socket path \
+             (before this daemon starts, the sticky bit does not prevent creating the \
+             path). Use a directory only you can write, or unset KHIVE_SOCKET for the \
+             default. This daemon is not changing the permissions of a directory it does \
+             not own.",
             parent.display(),
             mode & 0o7777
         );
@@ -1185,7 +1199,7 @@ pub async fn run_daemon_with_boot_guard<D: DaemonDispatch>(
 
     if let Some(parent) = sock.parent() {
         std::fs::create_dir_all(parent)?;
-        ensure_socket_dir_is_swap_safe(parent)?;
+        ensure_socket_dir_is_trusted(parent)?;
     }
 
     // Hold the startup lock across cleanup → bind → pid-write so a concurrent
@@ -2044,58 +2058,61 @@ mod tests {
         assert_eq!(dispatch_calls.load(std::sync::atomic::Ordering::SeqCst), 1);
     }
 
-    /// Test 2: `wal_pages` reflects a real
-    /// checkpoint observation after writes, deterministically forced via a
-    /// A non-sticky directory writable by others is refused, and — the part
-    /// that matters — is left exactly as it was found.
+    /// Group/other-writable socket directories are refused whether or not the
+    /// sticky bit is set, and — the part that matters — are left exactly as
+    /// they were found.
     ///
-    /// This is the one shape the directory mode alone must gate: another
-    /// writer can unlink the bound socket and bind its own at the same path.
-    /// Re-permissioning someone else's directory on the way past is what the
-    /// second assertion pins against: run as a user who *can* chmod it, the
-    /// old unconditional call succeeded and revoked access for every other
-    /// process using that directory.
+    /// The sticky `/tmp` shape (1777) is in the refusal set deliberately: the
+    /// sticky bit restricts unlinking, not creating, so a shared directory
+    /// lets another user pre-bind the predictable socket path before this
+    /// daemon starts; and a sticky directory's owner may unlink and rebind
+    /// regardless. Re-permissioning someone else's directory on the way past
+    /// is what the second assertion pins against: run as a user who *can*
+    /// chmod it, the old unconditional call succeeded and revoked access for
+    /// every other process using that directory.
     #[test]
-    fn swappable_socket_dir_is_refused_without_being_modified() {
+    fn shared_writable_socket_dirs_are_refused_without_being_modified() {
         let dir = tempfile::tempdir().expect("tempdir");
-        let shared = dir.path().join("shared");
-        std::fs::create_dir(&shared).expect("create");
-        std::fs::set_permissions(&shared, std::fs::Permissions::from_mode(0o777)).expect("chmod");
+        for (name, mode) in [("open", 0o777u32), ("sticky-tmp", 0o1777u32)] {
+            let shared = dir.path().join(name);
+            std::fs::create_dir(&shared).expect("create");
+            std::fs::set_permissions(&shared, std::fs::Permissions::from_mode(mode))
+                .expect("chmod");
 
-        let err = ensure_socket_dir_is_swap_safe(&shared).expect_err("must refuse non-sticky 0777");
-        assert!(
-            err.to_string().contains("0777"),
-            "the refusal should name the mode it saw, got: {err}"
-        );
-
-        let after = std::fs::metadata(&shared)
-            .expect("stat")
-            .permissions()
-            .mode()
-            & 0o777;
-        assert_eq!(
-            after, 0o777,
-            "refusing must not re-permission a directory khive does not own"
-        );
+            let err = ensure_socket_dir_is_trusted(&shared)
+                .expect_err("group/other-writable must be refused, sticky or not");
+            assert!(
+                err.to_string().contains(&format!("{:04o}", mode & 0o7777)),
+                "the refusal should name the mode it saw, got: {err}"
+            );
+            let after = std::fs::metadata(&shared)
+                .expect("stat")
+                .permissions()
+                .mode()
+                & 0o7777;
+            assert_eq!(
+                after, mode,
+                "refusing must not re-permission a directory khive does not own"
+            );
+        }
     }
 
-    /// Directory modes that cannot host a socket swap are served as found:
-    /// owner-only, the umask-default 0755 every `tempfile::tempdir` and test
-    /// runner produces, and sticky world-writable (the `/tmp` shape, where the
-    /// sticky bit is exactly what stops another user unlinking the socket).
+    /// Directories this daemon can trust end to end are served as found:
+    /// owner-only, and the umask-default 0755 every `tempfile::tempdir` and
+    /// test runner produces (readable/traversable but writable only by the
+    /// owner). Foreign ownership is also refused by the same helper, but a
+    /// non-root test cannot chown a directory away from itself, so that arm
+    /// is exercised by the mode checks' shared fail-closed path rather than
+    /// a dedicated fixture.
     #[test]
-    fn swap_safe_socket_dirs_are_accepted_unmodified() {
+    fn trusted_socket_dirs_are_accepted_unmodified() {
         let dir = tempfile::tempdir().expect("tempdir");
-        for (name, mode) in [
-            ("private", 0o700),
-            ("listable", 0o755),
-            ("sticky-tmp", 0o1777),
-        ] {
+        for (name, mode) in [("private", 0o700), ("listable", 0o755)] {
             let d = dir.path().join(name);
             std::fs::create_dir(&d).expect("create");
             std::fs::set_permissions(&d, std::fs::Permissions::from_mode(mode)).expect("chmod");
 
-            ensure_socket_dir_is_swap_safe(&d)
+            ensure_socket_dir_is_trusted(&d)
                 .unwrap_or_else(|e| panic!("mode {mode:04o} must be accepted, got: {e}"));
 
             let after = std::fs::metadata(&d).expect("stat").permissions().mode() & 0o7777;
@@ -2106,6 +2123,8 @@ mod tests {
         }
     }
 
+    /// Test 2: `wal_pages` reflects a real
+    /// checkpoint observation after writes, deterministically forced via a
     /// direct `checkpoint_once` call rather than waiting on the async
     /// periodic task.
     #[tokio::test]

--- a/crates/khive-runtime/src/daemon.rs
+++ b/crates/khive-runtime/src/daemon.rs
@@ -1136,7 +1136,7 @@ fn ensure_socket_dir_is_trusted(parent: &std::path::Path) -> anyhow::Result<()> 
                 parent.display()
             )
         })?;
-        return ensure_socket_dir_ancestors_are_swap_resistant(parent, daemon_euid);
+        return ensure_socket_path_is_swap_resistant(parent, daemon_euid);
     }
 
     // Fail closed on the stat itself: not being able to read the metadata is
@@ -1175,16 +1175,23 @@ fn ensure_socket_dir_is_trusted(parent: &std::path::Path) -> anyhow::Result<()> 
         );
     }
 
-    ensure_socket_dir_ancestors_are_swap_resistant(parent, daemon_euid)
+    ensure_socket_path_is_swap_resistant(parent, daemon_euid)
 }
 
-/// Walk every ancestor of the (already-vetted) socket directory and refuse
-/// any that would let another local user *replace a path component*: rename
-/// the trusted final directory away and recreate it, re-rooting the socket
-/// path under attacker control without ever touching the vetted directory
-/// itself.
+/// Walk the socket directory path exactly as the kernel will traverse it at
+/// bind time — component by component, following symlinks — and refuse any
+/// node another local user could swap after this validation.
 ///
-/// The ancestor rule is deliberately weaker than the immediate parent's.
+/// Checking only the canonicalized result is not enough: bind and every
+/// client traverse the *original* path, so a symlink component owned by
+/// another user can resolve somewhere trusted while it is being validated
+/// and be retargeted before the socket is bound. Validating the nodes the
+/// traversal actually visits closes that gap: a symlink component is
+/// acceptable only when its owner — the only party besides root who can
+/// retarget it — is this daemon's euid or root, and every directory
+/// component is held to the ancestor rule below.
+///
+/// The directory rule is deliberately weaker than the immediate parent's.
 /// The parent hosts the socket file, where the threat is *creation* of the
 /// predictable path — the sticky bit does not restrict creating, so no
 /// sticky exception is sound there. An ancestor only threatens via
@@ -1194,57 +1201,123 @@ fn ensure_socket_dir_is_trusted(parent: &std::path::Path) -> anyhow::Result<()> 
 /// acceptable ancestor of a user-owned 0700 socket directory, while a
 /// non-sticky group/other-writable ancestor, or one owned by a third uid
 /// (who could rename the entry, or chmod the directory first), is refused.
-///
-/// The path is canonicalized first so a symlink component cannot smuggle in
-/// an unvetted real location; canonicalization failure fails closed.
+/// Every stat failure fails closed.
 #[cfg(unix)]
-fn ensure_socket_dir_ancestors_are_swap_resistant(
+fn ensure_socket_path_is_swap_resistant(
     parent: &std::path::Path,
     daemon_euid: u32,
 ) -> anyhow::Result<()> {
     use std::os::unix::fs::MetadataExt;
 
-    let canonical = std::fs::canonicalize(parent).map_err(|e| {
-        anyhow::anyhow!(
-            "refusing to start: cannot canonicalize socket directory {}: {e}. Ancestor \
-             trust cannot be checked through an unresolvable path.",
-            parent.display()
-        )
-    })?;
+    let absolute = if parent.is_absolute() {
+        parent.to_path_buf()
+    } else {
+        std::env::current_dir()
+            .map_err(|e| {
+                anyhow::anyhow!(
+                    "refusing to start: cannot resolve the working directory to absolutize \
+                     socket directory {}: {e}.",
+                    parent.display()
+                )
+            })?
+            .join(parent)
+    };
 
-    for ancestor in canonical.ancestors().skip(1) {
-        if ancestor.as_os_str().is_empty() {
-            break;
+    fn push_components(stack: &mut Vec<std::ffi::OsString>, path: &std::path::Path) {
+        let components: Vec<_> = path
+            .components()
+            .map(|c| c.as_os_str().to_os_string())
+            .collect();
+        stack.extend(components.into_iter().rev());
+    }
+
+    let mut stack: Vec<std::ffi::OsString> = Vec::new();
+    push_components(&mut stack, &absolute);
+    let mut resolved = std::path::PathBuf::new();
+    let mut symlinks_followed = 0u32;
+
+    while let Some(component) = stack.pop() {
+        if component == "/" {
+            resolved = std::path::PathBuf::from("/");
+            continue;
         }
-        let meta = std::fs::metadata(ancestor).map_err(|e| {
+        if component == "." {
+            continue;
+        }
+        if component == ".." {
+            resolved.pop();
+            continue;
+        }
+        let candidate = resolved.join(&component);
+        let meta = std::fs::symlink_metadata(&candidate).map_err(|e| {
             anyhow::anyhow!(
-                "refusing to start: cannot stat socket-path ancestor {}: {e}. An \
-                 unreadable ancestor is not a passing one.",
-                ancestor.display()
+                "refusing to start: cannot stat socket-path component {}: {e}. An \
+                 unreadable component is not a passing one.",
+                candidate.display()
             )
         })?;
         let owner = meta.uid();
-        let mode = meta.permissions().mode();
-        let sticky = mode & 0o1000 != 0;
-        if owner != daemon_euid && owner != 0 {
-            anyhow::bail!(
-                "refusing to start: socket-path ancestor {} is owned by uid {owner}, not \
-                 this daemon's uid ({daemon_euid}) or root — its owner could rename the \
-                 next path component and re-root the socket path. Point KHIVE_SOCKET \
-                 somewhere trusted end to end, or unset it for the default.",
-                ancestor.display()
-            );
+
+        if meta.file_type().is_symlink() {
+            symlinks_followed += 1;
+            if symlinks_followed > 40 {
+                anyhow::bail!(
+                    "refusing to start: socket path resolves through more than 40 symlinks \
+                     at {} — treating this as a loop.",
+                    candidate.display()
+                );
+            }
+            if owner != daemon_euid && owner != 0 {
+                anyhow::bail!(
+                    "refusing to start: socket-path symlink component {} is owned by uid \
+                     {owner}, not this daemon's uid ({daemon_euid}) or root — its owner \
+                     could retarget it after this check and re-root the socket path. Point \
+                     KHIVE_SOCKET somewhere trusted end to end, or unset it for the \
+                     default.",
+                    candidate.display()
+                );
+            }
+            let target = std::fs::read_link(&candidate).map_err(|e| {
+                anyhow::anyhow!(
+                    "refusing to start: cannot read socket-path symlink component {}: {e}.",
+                    candidate.display()
+                )
+            })?;
+            push_components(&mut stack, &target);
+            continue;
         }
-        if mode & 0o022 != 0 && !sticky {
-            anyhow::bail!(
-                "refusing to start: socket-path ancestor {} is mode {:04o} — writable by \
-                 group or other without the sticky bit, so another local user could rename \
-                 the next path component and re-root the socket path. Point KHIVE_SOCKET \
-                 somewhere trusted end to end, or unset it for the default.",
-                ancestor.display(),
-                mode & 0o7777
-            );
+
+        if meta.is_dir() {
+            let mode = meta.permissions().mode();
+            let sticky = mode & 0o1000 != 0;
+            if owner != daemon_euid && owner != 0 {
+                anyhow::bail!(
+                    "refusing to start: socket-path ancestor {} is owned by uid {owner}, not \
+                     this daemon's uid ({daemon_euid}) or root — its owner could rename the \
+                     next path component and re-root the socket path. Point KHIVE_SOCKET \
+                     somewhere trusted end to end, or unset it for the default.",
+                    candidate.display()
+                );
+            }
+            if mode & 0o022 != 0 && !sticky {
+                anyhow::bail!(
+                    "refusing to start: socket-path ancestor {} is mode {:04o} — writable by \
+                     group or other without the sticky bit, so another local user could rename \
+                     the next path component and re-root the socket path. Point KHIVE_SOCKET \
+                     somewhere trusted end to end, or unset it for the default.",
+                    candidate.display(),
+                    mode & 0o7777
+                );
+            }
+            resolved = candidate;
+            continue;
         }
+
+        anyhow::bail!(
+            "refusing to start: socket-path component {} is neither a directory nor a \
+             symlink — the socket path cannot traverse it.",
+            candidate.display()
+        );
     }
 
     Ok(())
@@ -2200,13 +2273,71 @@ mod tests {
         );
     }
 
+    /// The path walk validates what a symlink component points AT, not just
+    /// the symlink node: a trusted (self-owned) link into a group/other-
+    /// writable non-sticky directory is refused on the target directory's
+    /// metadata, proving the walk keeps traversing — and keeps applying the
+    /// directory rules — past the link, exactly as the kernel will at bind
+    /// time.
+    #[test]
+    fn symlink_component_to_untrusted_directory_is_refused() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let open = dir.path().join("open-target");
+        std::fs::create_dir(&open).expect("create target");
+        std::fs::set_permissions(&open, std::fs::Permissions::from_mode(0o777)).expect("chmod");
+        let link = dir.path().join("link");
+        std::os::unix::fs::symlink(&open, &link).expect("symlink");
+
+        // SAFETY: `geteuid` is always successful and takes no arguments.
+        let euid = unsafe { libc::geteuid() } as u32;
+        let err = ensure_socket_path_is_swap_resistant(&link, euid)
+            .expect_err("a link into a 0777 non-sticky directory must be refused");
+        assert!(
+            err.to_string().contains("open-target"),
+            "the refusal should name the untrusted target directory, got: {err}"
+        );
+    }
+
+    /// A symlink component owned by neither the daemon euid nor root is
+    /// refused on the symlink itself: its owner can retarget it after
+    /// validation, so where it currently points is irrelevant. A non-root
+    /// test cannot create a foreign-owned symlink, so this injects a
+    /// mismatched euid instead — and the fixture must live under an
+    /// all-root-owned chain (the platform `/tmp`), because under the test's
+    /// own tempdir the self-owned ancestor directories would already fail
+    /// the injected euid before the walk ever reached the link.
+    #[test]
+    fn foreign_owned_symlink_component_is_refused() {
+        let link =
+            std::path::PathBuf::from(format!("/tmp/khive-swaptest-link-{}", std::process::id()));
+        let _ = std::fs::remove_file(&link);
+        std::os::unix::fs::symlink("/tmp", &link).expect("symlink");
+
+        // SAFETY: `geteuid` is always successful and takes no arguments.
+        let not_my_euid = (unsafe { libc::geteuid() } as u32).wrapping_add(1);
+        let result = ensure_socket_path_is_swap_resistant(&link, not_my_euid);
+        std::fs::remove_file(&link).expect("cleanup");
+
+        let err = result.expect_err("a symlink owned by another uid must be refused");
+        assert!(
+            err.to_string().contains("symlink component"),
+            "the refusal should strike the symlink itself, got: {err}"
+        );
+        assert!(
+            err.to_string().contains("khive-swaptest-link"),
+            "the refusal should name the offending link, got: {err}"
+        );
+    }
+
     /// Directories this daemon can trust end to end are served as found:
     /// owner-only, and the umask-default 0755 every `tempfile::tempdir` and
     /// test runner produces (readable/traversable but writable only by the
-    /// owner). Foreign ownership is also refused by the same helper, but a
-    /// non-root test cannot chown a directory away from itself, so that arm
-    /// is exercised by the mode checks' shared fail-closed path rather than
-    /// a dedicated fixture.
+    /// owner). On macOS these fixtures also implicitly exercise the
+    /// symlink-accept arm, since the platform temp root itself resolves
+    /// through root-owned symlinks. Foreign ownership of a directory is
+    /// refused by the same helper, but a non-root test cannot chown a
+    /// directory away from itself, so that arm is exercised by the mode
+    /// checks' shared fail-closed path rather than a dedicated fixture.
     #[test]
     fn trusted_socket_dirs_are_accepted_unmodified() {
         let dir = tempfile::tempdir().expect("tempdir");

--- a/crates/khive-runtime/src/secret_gate.rs
+++ b/crates/khive-runtime/src/secret_gate.rs
@@ -831,7 +831,13 @@ fn check_entropy_heuristic(text: &str, from: usize) -> Option<(&str, &'static st
             // gate is accidental-persistence hygiene on a single-principal
             // same-uid host, not defense against a same-uid adversary
             // hand-splitting a credential to evade it — that adversary can
-            // write the DB directly. See
+            // write the DB directly. This module does not itself establish
+            // that the host is same-uid; it inherits that from the daemon's
+            // accept-site refusal of any peer uid other than its own
+            // (`khive-runtime/src/daemon.rs`, peer-credential check before the
+            // first frame is read). If that refusal is ever removed or
+            // weakened, the residual limitation documented here stops being
+            // residual. See
             // `allows_seven_way_hex_split_beyond_fragment_cap_documented_limitation`
             // and `allows_six_way_sub_floor_hex_split_documented_limitation`.
             //


### PR DESCRIPTION
The daemon serves a single principal over an owner-only socket. That was an ambient property of the deployment rather than something the code asserted: nothing read peer identity, so nothing could notice when it stopped holding.

Every identity field on the request frame (`namespace`, `actor_id`, `visible_namespaces`, `config_id`) is supplied by the connecting process. A check reading those is not a weak check, it is not a check, because anyone who wants to pass it asserts the passing values. The peer uid is the only identity on this socket the caller cannot choose.

## What changed

- Capture the peer uid at `accept` — `getpeereid(2)` on macOS/BSD, `SO_PEERCRED` on Linux — and refuse any connection whose uid differs from the daemon's own euid, before a frame is read.
- **Fails closed.** An error reading peer credentials means "cannot prove same-uid", which is the same answer as "is not same-uid".
- The two chmods guarding the socket (`0600`) and its directory (`0700`) now fail closed as well. They warned and continued, so a daemon that could not prove its owner-only mode kept serving with the warning as the only trace.

## Principal is not attribution

Many `actor_id`s over one socket is the accepted design, and every seat on a normal host is a distinct attribution at the same uid. A check that refused a second distinct actor would break that on day one. Only a genuinely foreign uid is refused, and `only_a_foreign_uid_is_refused` pins that as a regression guard.

## No configuration escape hatch, deliberately

A flag permitting other uids would not weaken the assertion, it would delete it in the way hardest to notice later: the check still exists, its tests still pass, and the deployment that matters has it off. Multiple uids should require a code change and a design record, because that is the decision that should be impossible to make by accident.

## Scope

This makes the currently accepted single-principal envelope self-enforcing. It is **not** a connection-identity mechanism, it does not bind a principal to allowed namespaces, and it does not enable hosted or multi-tenant serving, which remains gated on its own design record.

## Tests

- `peer_uid_reports_the_connecting_process_uid` — the syscall path actually works on this platform and reports the real uid over a live `UnixStream`, from both ends. This matters because the accept path fails closed: if `peer_uid` errored unconditionally (wrong syscall, wrong socket option, an unimplemented platform arm) every connection would be refused and the daemon would be silently unreachable. A test covering only the decision function would not catch that.
- `only_a_foreign_uid_is_refused` — same uid served, any other refused, root not special-cased.

## Gates (real exit codes)

```
cargo clippy -p khive-runtime --all-targets -- -D warnings   rc=0
cargo test -p khive-runtime --lib                            rc=0   (921 passed)
cargo test -p khive-mcp                                      rc=0   (215 passed)
cargo fmt --all -- --check                                   rc=0
```

`libc` was already a direct dependency of `khive-runtime`, so this adds none.

Related: #1269 (the `khive-mcp` suite must be run with `KHIVE_PACKS` unset, or it fails on packs this distribution does not build).