### PR TITLE
fix(kg): search/list/query response-shape consistency

### DIFF
--- a/crates/khive-mcp/src/save_sink.rs
+++ b/crates/khive-mcp/src/save_sink.rs
@@ -202,12 +202,30 @@ pub fn write_and_manifest(
     let abs_path = std::fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf());
     let null_counts_val: Value = serde_json::to_value(&null_counts).unwrap_or_else(|_| json!({}));
 
+    // Carry the envelope's op-outcome summary through: the manifest is the
+    // only output the caller sees on the save path, and without the counts a
+    // strict caller (`kkernel exec --strict --save-file`) cannot distinguish
+    // an all-green batch from one whose failures are sitting in the file.
+    let summary = results_envelope.get("summary").cloned().unwrap_or_else(|| {
+        let succeeded = results_arr
+            .iter()
+            .filter(|r| r.get("ok").and_then(Value::as_bool) == Some(true))
+            .count();
+        json!({
+            "total": rows,
+            "succeeded": succeeded,
+            "failed": rows - succeeded,
+            "aborted": 0,
+        })
+    });
+
     Ok(json!({
         "path": abs_path.to_string_lossy(),
         "rows": rows,
         "per_column_null_counts": null_counts_val,
         "schema_fingerprint": schema_fingerprint,
         "checksum": checksum,
+        "summary": summary,
     }))
 }
 
@@ -274,6 +292,22 @@ mod tests {
             "results": results,
             "summary": { "total": total, "succeeded": succeeded, "failed": failed, "aborted": 0 }
         })
+    }
+
+    #[test]
+    fn manifest_carries_the_envelope_summary() {
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("out.jsonl");
+
+        let envelope = make_envelope(vec![
+            json!({ "ok": true, "tool": "stats", "result": {} }),
+            json!({ "ok": false, "tool": "get", "error": "not found" }),
+        ]);
+
+        let manifest = write_and_manifest(&envelope, &path, false).unwrap();
+        assert_eq!(manifest["summary"]["total"], json!(2));
+        assert_eq!(manifest["summary"]["succeeded"], json!(1));
+        assert_eq!(manifest["summary"]["failed"], json!(1));
     }
 
     #[test]

--- a/crates/khive-mcp/src/server.rs
+++ b/crates/khive-mcp/src/server.rs
@@ -798,9 +798,17 @@ impl KhiveMcpServer {
     /// ```json
     /// {
     ///   "results": [...],
-    ///   "summary": { "total": N, "succeeded": K, "failed": M, "aborted": A }
+    ///   "summary": { "total": N, "succeeded": K, "failed": M, "aborted": A },
+    ///   "status": "success" | "partial"
     /// }
     /// ```
+    ///
+    /// `status` is a structural signal for a partially-failed batch (#1220):
+    /// per-op `results` entries and `summary.failed`/`summary.aborted` counts
+    /// already carry this information, but a caller that checks only for the
+    /// absence of a top-level RPC error has nothing to branch on. `"partial"`
+    /// means at least one op in this response failed or was aborted;
+    /// `"success"` means every op in `results` reports `ok: true`.
     async fn run_parsed(
         &self,
         ops: Vec<ParsedOp>,
@@ -997,6 +1005,7 @@ impl KhiveMcpServer {
                 json!({
                     "results": results,
                     "summary": { "total": total, "succeeded": succeeded, "failed": failed, "aborted": 0 },
+                    "status": batch_status(failed, 0),
                 })
             }
             ExecutionMode::Chain => {
@@ -1077,6 +1086,7 @@ impl KhiveMcpServer {
                 json!({
                     "results": results,
                     "summary": { "total": total, "succeeded": succeeded, "failed": failed, "aborted": aborted },
+                    "status": batch_status(failed, aborted),
                 })
             }
         }
@@ -1495,11 +1505,14 @@ Response shape:
 
   {
     "results": [ {"ok": true, "tool": "verb", "result": {...}}, ... ],
-    "summary": { "total": N, "succeeded": N, "failed": N, "aborted": N }
+    "summary": { "total": N, "succeeded": N, "failed": N, "aborted": N },
+    "status": "success" | "partial"
   }
 
 Parallel: a failed op does NOT abort siblings. Chain: failure aborts remaining
 ops (reported as {"ok": false, "aborted": true}). Committed ops are not rolled back.
+`status` is "partial" whenever summary.failed or summary.aborted is non-zero — check
+it (or summary) rather than relying on the absence of a top-level error.
 
 Verb discovery: install the `kg` / `gtd` plugins for usage skills. The verbs
 currently registered on this server (pack-derived) are listed below. Argument
@@ -1544,6 +1557,19 @@ result (e.g. create then link with the new entity's id)."#)]
             }
         }
         self.dispatch_request_wire(p).await
+    }
+}
+
+/// Response-envelope `status` for a batch of `failed`/`aborted` counts
+/// (#1220): `"partial"` when either is non-zero, `"success"` otherwise. A
+/// caller that only checks for the absence of a top-level RPC error has
+/// nothing else to branch on for a batch where some ops failed or were
+/// skipped after a chain abort.
+fn batch_status(failed: usize, aborted: usize) -> &'static str {
+    if failed == 0 && aborted == 0 {
+        "success"
+    } else {
+        "partial"
     }
 }
 
@@ -1613,6 +1639,7 @@ fn strict_fallback_envelope_response(
     Ok(serde_json::to_string(&json!({
         "results": results,
         "summary": { "total": total, "succeeded": 0, "failed": failed, "aborted": aborted },
+        "status": batch_status(failed, aborted),
     }))
     .expect("envelope of string/bool JSON values always serializes"))
 }
@@ -2877,5 +2904,103 @@ mod tests {
 
         crate::daemon::reset_fallback_counters();
         clear_daemon_env();
+    }
+
+    // ── #1220: top-level `status` distinguishes a partially-failed batch ──────
+
+    fn in_memory_kg_server() -> KhiveMcpServer {
+        let config = RuntimeConfig {
+            db_path: None,
+            default_namespace: Namespace::local(),
+            embedding_model: None,
+            additional_embedding_models: vec![],
+            packs: vec!["kg".to_string()],
+            ..RuntimeConfig::default()
+        };
+        let runtime = KhiveRuntime::new(config).expect("in-memory runtime");
+        KhiveMcpServer::new(runtime).expect("server builds with kg")
+    }
+
+    #[tokio::test]
+    async fn request_status_is_success_when_every_op_in_batch_succeeds() {
+        let server = in_memory_kg_server();
+        let resp = server
+            .dispatch_request_local(RequestParams {
+                ops: "[create(kind=\"entity\", entity_kind=\"concept\", name=\"status-ok-1\"), \
+                       create(kind=\"entity\", entity_kind=\"concept\", name=\"status-ok-2\")]"
+                    .to_string(),
+                presentation: None,
+                presentation_per_op: None,
+                save_to: None,
+                format: None,
+                format_per_op: None,
+                request_id: None,
+            })
+            .await
+            .expect("batch dispatch must succeed");
+        let parsed: Value = serde_json::from_str(&resp).expect("envelope must be JSON");
+        assert_eq!(parsed["summary"]["failed"], 0);
+        assert_eq!(
+            parsed["status"], "success",
+            "an all-succeeding batch must report status=success; got {parsed}"
+        );
+    }
+
+    #[tokio::test]
+    async fn request_status_is_partial_when_a_batch_op_fails() {
+        let server = in_memory_kg_server();
+        // The second op targets an unknown kind and fails; the first succeeds.
+        let resp = server
+            .dispatch_request_local(RequestParams {
+                ops:
+                    "[create(kind=\"entity\", entity_kind=\"concept\", name=\"status-partial-1\"), \
+                       search(kind=\"not_a_real_kind\", query=\"x\")]"
+                        .to_string(),
+                presentation: None,
+                presentation_per_op: None,
+                save_to: None,
+                format: None,
+                format_per_op: None,
+                request_id: None,
+            })
+            .await
+            .expect("batch dispatch must succeed at the RPC level even with a failed op");
+        let parsed: Value = serde_json::from_str(&resp).expect("envelope must be JSON");
+        assert!(
+            parsed["summary"]["failed"].as_u64().unwrap_or(0) > 0,
+            "expected at least one failed op; got {parsed}"
+        );
+        assert_eq!(
+            parsed["status"], "partial",
+            "a batch with a failed op must report status=partial; got {parsed}"
+        );
+    }
+
+    #[tokio::test]
+    async fn request_status_is_partial_when_a_chain_op_is_aborted() {
+        let server = in_memory_kg_server();
+        let resp = server
+            .dispatch_request_local(RequestParams {
+                ops: "search(kind=\"not_a_real_kind\", query=\"x\") | \
+                      create(kind=\"entity\", entity_kind=\"concept\", name=\"status-chain-aborted\")"
+                    .to_string(),
+                presentation: None,
+                presentation_per_op: None,
+                save_to: None,
+                format: None,
+                format_per_op: None,
+                request_id: None,
+            })
+            .await
+            .expect("chain dispatch must succeed at the RPC level even with an aborted op");
+        let parsed: Value = serde_json::from_str(&resp).expect("envelope must be JSON");
+        assert!(
+            parsed["summary"]["aborted"].as_u64().unwrap_or(0) > 0,
+            "expected the second chain op to be aborted; got {parsed}"
+        );
+        assert_eq!(
+            parsed["status"], "partial",
+            "a chain with an aborted op must report status=partial; got {parsed}"
+        );
     }
 }

--- a/crates/khive-pack-kg/src/handlers/common.rs
+++ b/crates/khive-pack-kg/src/handlers/common.rs
@@ -888,5 +888,9 @@ pub(crate) fn render_query_result(result: QueryResult) -> Value {
     if !result.warnings.is_empty() {
         out.insert("warnings".to_string(), json!(result.warnings));
     }
+    // Always present (not gated on the cap having fired) so a caller can
+    // check it unconditionally rather than inferring "not truncated" from
+    // the field's absence (#1168, #1247).
+    out.insert("truncated".to_string(), json!(result.truncated));
     Value::Object(out)
 }

--- a/crates/khive-pack-kg/src/handlers/search.rs
+++ b/crates/khive-pack-kg/src/handlers/search.rs
@@ -257,9 +257,7 @@ impl KgPack {
                     .map(|h| {
                         let meta = note_meta.get(&h.note_id);
                         let note_kind = meta.map(|(k, _, _, _)| k.as_str());
-                        let name = meta
-                            .and_then(|(_, _, name, _)| name.clone())
-                            .or_else(|| h.title.clone());
+                        let name = meta.and_then(|(_, _, name, _)| name.clone());
                         let created_at = meta.map(|(_, _, _, c)| micros_to_iso(*c));
                         serde_json::json!({
                             "id": h.note_id.to_string(),

--- a/crates/khive-pack-kg/src/handlers/search.rs
+++ b/crates/khive-pack-kg/src/handlers/search.rs
@@ -11,7 +11,7 @@ use std::time::Instant;
 use serde_json::{json, Value};
 use uuid::Uuid;
 
-use khive_runtime::{KhiveRuntime, NamespaceToken, RuntimeError, VerbRegistry};
+use khive_runtime::{micros_to_iso, KhiveRuntime, NamespaceToken, RuntimeError, VerbRegistry};
 use khive_storage::types::PageRequest;
 use khive_storage::EntityFilter;
 
@@ -84,7 +84,7 @@ impl KgPack {
                     .await?;
 
                 let candidate_ids: Vec<Uuid> = hits.iter().map(|h| h.entity_id).collect();
-                let entity_meta: HashMap<Uuid, (String, Option<Value>, Vec<String>)> =
+                let entity_meta: HashMap<Uuid, (String, Option<Value>, Vec<String>, i64)> =
                     if candidate_ids.is_empty() {
                         HashMap::new()
                     } else {
@@ -112,14 +112,14 @@ impl KgPack {
                         entities_page
                             .items
                             .into_iter()
-                            .map(|e| (e.id, (e.kind, e.properties, e.tags)))
+                            .map(|e| (e.id, (e.kind, e.properties, e.tags, e.created_at)))
                             .collect()
                     };
 
                 let filtered_hits = if props_filter.is_some() || tag_filter.is_some() {
                     hits.into_iter()
                         .filter(|h| {
-                            let Some((_, props, tags)) = entity_meta.get(&h.entity_id) else {
+                            let Some((_, props, tags, _)) = entity_meta.get(&h.entity_id) else {
                                 return false;
                             };
                             props_filter
@@ -139,13 +139,21 @@ impl KgPack {
                     .filter(|h| h.score.to_f64() >= score_floor)
                     .map(|h| {
                         let entity_kind =
-                            entity_meta.get(&h.entity_id).map(|(k, _, _)| k.as_str());
+                            entity_meta.get(&h.entity_id).map(|(k, _, _, _)| k.as_str());
+                        let created_at = entity_meta
+                            .get(&h.entity_id)
+                            .map(|(_, _, _, c)| micros_to_iso(*c));
                         serde_json::json!({
                             "id": h.entity_id.to_string(),
+                            // `kind`/`name` match the list()/get() row shape (#1174);
+                            // `entity_kind`/`title` are kept for compatibility.
+                            "kind": entity_kind,
                             "entity_kind": entity_kind,
+                            "name": h.title,
                             "score": h.score.to_f64(),
                             "title": h.title,
                             "snippet": h.snippet,
+                            "created_at": created_at,
                         })
                     })
                     .collect();
@@ -197,24 +205,25 @@ impl KgPack {
                 // N individual gets. Notes absent from the batch result (deleted
                 // between the search and the fetch) are simply absent from the map
                 // and filtered out by the `note_meta.get` guard below.
-                let note_meta: HashMap<Uuid, (String, Option<Value>)> = if hits.is_empty() {
-                    HashMap::new()
-                } else {
-                    let candidate_ids: Vec<Uuid> = hits.iter().map(|h| h.note_id).collect();
-                    let note_store = self.runtime.notes(token)?;
-                    note_store
-                        .get_notes_batch(&candidate_ids)
-                        .await
-                        .map_err(RuntimeError::Storage)?
-                        .into_iter()
-                        .map(|n| (n.id, (n.kind, n.properties)))
-                        .collect()
-                };
+                let note_meta: HashMap<Uuid, (String, Option<Value>, Option<String>, i64)> =
+                    if hits.is_empty() {
+                        HashMap::new()
+                    } else {
+                        let candidate_ids: Vec<Uuid> = hits.iter().map(|h| h.note_id).collect();
+                        let note_store = self.runtime.notes(token)?;
+                        note_store
+                            .get_notes_batch(&candidate_ids)
+                            .await
+                            .map_err(RuntimeError::Storage)?
+                            .into_iter()
+                            .map(|n| (n.id, (n.kind, n.properties, n.name, n.created_at)))
+                            .collect()
+                    };
 
                 let filtered_hits: Vec<_> = if props_filter.is_some() || tag_filter.is_some() {
                     hits.into_iter()
                         .filter(|h| {
-                            let Some((_, props)) = note_meta.get(&h.note_id) else {
+                            let Some((_, props, _, _)) = note_meta.get(&h.note_id) else {
                                 return false;
                             };
                             let props_ok = props_filter
@@ -246,14 +255,23 @@ impl KgPack {
                     .iter()
                     .filter(|h| h.score.to_f64() >= score_floor)
                     .map(|h| {
-                        let note_kind =
-                            note_meta.get(&h.note_id).map(|(k, _)| k.as_str());
+                        let meta = note_meta.get(&h.note_id);
+                        let note_kind = meta.map(|(k, _, _, _)| k.as_str());
+                        let name = meta
+                            .and_then(|(_, _, name, _)| name.clone())
+                            .or_else(|| h.title.clone());
+                        let created_at = meta.map(|(_, _, _, c)| micros_to_iso(*c));
                         serde_json::json!({
                             "id": h.note_id.to_string(),
+                            // `kind`/`name` match the list()/get() row shape (#1174);
+                            // `note_kind`/`title` are kept for compatibility.
+                            "kind": note_kind,
                             "note_kind": note_kind,
+                            "name": name,
                             "score": h.score.to_f64(),
                             "title": h.title,
                             "snippet": h.snippet,
+                            "created_at": created_at,
                         })
                     })
                     .collect();

--- a/crates/khive-pack-kg/tests/integration.rs
+++ b/crates/khive-pack-kg/tests/integration.rs
@@ -12025,3 +12025,40 @@ async fn whoami_appears_in_verbs_introspection() {
         "whoami must be registered as a public verb; got {names:?}"
     );
 }
+
+/// Regression for #1168/#1247: the `query()` wire response always carries a
+/// structural `truncated` boolean, present whether or not the cap fired, so
+/// a caller can check it directly instead of inferring "not truncated" from
+/// the absence of a `warnings` entry (whose text also used to recommend an
+/// unimplemented OFFSET/SKIP paging path).
+#[tokio::test]
+async fn query_response_always_carries_truncated_field() {
+    let pack = pack();
+    pack.dispatch(
+        "create",
+        json!({"kind": "entity", "name": "QueryTruncFieldProbe", "entity_kind": "concept"}),
+    )
+    .await
+    .expect("create must succeed");
+
+    let result = pack
+        .dispatch("query", json!({"query": "MATCH (a:concept) RETURN a"}))
+        .await
+        .expect("query must succeed");
+
+    assert_eq!(
+        result.get("truncated").and_then(Value::as_bool),
+        Some(false),
+        "#1247: an under-the-cap query result must still carry truncated:false, not omit the \
+         field; got {result}"
+    );
+    if let Some(warnings) = result.get("warnings").and_then(Value::as_array) {
+        for w in warnings {
+            let text = w.as_str().unwrap_or_default();
+            assert!(
+                !text.contains("LIMIT/OFFSET"),
+                "#1168: no warning may recommend the unimplemented OFFSET/SKIP path: {text}"
+            );
+        }
+    }
+}

--- a/crates/khive-pack-kg/tests/integration.rs
+++ b/crates/khive-pack-kg/tests/integration.rs
@@ -854,6 +854,58 @@ async fn search_entity_response_includes_entity_kind() {
     );
 }
 
+/// Regression for #1174: entity search rows carry `name`/`kind`/`created_at`
+/// matching the list()/get() projection, alongside the legacy `title`/
+/// `entity_kind` spellings — a consumer that filters on `row["name"]` after
+/// working with list/get must not read a real hit as an empty result.
+#[tokio::test]
+async fn search_entity_response_includes_list_shape_fields() {
+    let pack = pack();
+    pack.dispatch(
+        "create",
+        json!({"kind": "entity", "name": "GammaSearchShape", "entity_kind": "concept"}),
+    )
+    .await
+    .unwrap();
+
+    let resp = pack
+        .dispatch(
+            "search",
+            json!({"kind": "entity", "query": "GammaSearchShape"}),
+        )
+        .await
+        .expect("search must succeed");
+    let arr = resp.as_array().expect("array");
+    assert!(
+        !arr.is_empty(),
+        "search must return the entity we just created"
+    );
+    let hit = &arr[0];
+    assert_eq!(
+        hit.get("name").and_then(Value::as_str),
+        Some("GammaSearchShape"),
+        "#1174: search response must carry name matching list()/get(); got hit {hit}"
+    );
+    assert_eq!(
+        hit.get("kind").and_then(Value::as_str),
+        Some("concept"),
+        "#1174: search response must carry kind matching list()/get(); got hit {hit}"
+    );
+    assert!(
+        hit.get("created_at").and_then(Value::as_str).is_some(),
+        "#1174: search response must carry created_at; got hit {hit}"
+    );
+    // Legacy spellings stay present for the deprecation window.
+    assert_eq!(
+        hit.get("entity_kind").and_then(Value::as_str),
+        Some("concept")
+    );
+    assert_eq!(
+        hit.get("title").and_then(Value::as_str),
+        Some("GammaSearchShape")
+    );
+}
+
 /// Regression for #160 (note half): note search response includes `note_kind`.
 #[tokio::test]
 async fn search_note_response_includes_note_kind() {
@@ -886,6 +938,50 @@ async fn search_note_response_includes_note_kind() {
         hit.get("note_kind").and_then(Value::as_str),
         Some("insight"),
         "#160 (note half): search response must carry note_kind; got hit {hit}"
+    );
+}
+
+/// Regression for #1174 (note half): note search rows carry `kind`/`created_at`
+/// matching the list()/get() projection, alongside the legacy `note_kind` spelling.
+#[tokio::test]
+async fn search_note_response_includes_list_shape_fields() {
+    let pack = pack();
+    pack.dispatch(
+        "create",
+        json!({
+            "kind": "note",
+            "content": "DeltaInsight unique_marker_9182",
+            "note_kind": "insight"
+        }),
+    )
+    .await
+    .unwrap();
+
+    let resp = pack
+        .dispatch(
+            "search",
+            json!({"kind": "note", "query": "unique_marker_9182"}),
+        )
+        .await
+        .expect("note search must succeed");
+    let arr = resp.as_array().expect("array");
+    assert!(
+        !arr.is_empty(),
+        "note search must return the note we just created"
+    );
+    let hit = &arr[0];
+    assert_eq!(
+        hit.get("kind").and_then(Value::as_str),
+        Some("insight"),
+        "#1174: note search response must carry kind matching list()/get(); got hit {hit}"
+    );
+    assert!(
+        hit.get("created_at").and_then(Value::as_str).is_some(),
+        "#1174: note search response must carry created_at; got hit {hit}"
+    );
+    assert!(
+        hit.get("name").is_some(),
+        "#1174: note search response must carry a name field (may be null); got hit {hit}"
     );
 }
 

--- a/crates/khive-pack-kg/tests/integration.rs
+++ b/crates/khive-pack-kg/tests/integration.rs
@@ -985,6 +985,45 @@ async fn search_note_response_includes_list_shape_fields() {
     );
 }
 
+/// A nameless note's search row must carry `name: null` exactly as list()/get()
+/// do — `title` remains the display value, but `name` never inherits it.
+#[tokio::test]
+async fn search_nameless_note_name_is_null() {
+    let pack = pack();
+    pack.dispatch(
+        "create",
+        json!({
+            "kind": "note",
+            "content": "NamelessNote unique_marker_5527",
+            "note_kind": "observation"
+        }),
+    )
+    .await
+    .unwrap();
+
+    let resp = pack
+        .dispatch(
+            "search",
+            json!({"kind": "note", "query": "unique_marker_5527"}),
+        )
+        .await
+        .expect("note search must succeed");
+    let arr = resp.as_array().expect("array");
+    assert!(
+        !arr.is_empty(),
+        "note search must return the note we just created"
+    );
+    let hit = &arr[0];
+    assert!(
+        hit.get("name").is_some_and(Value::is_null),
+        "nameless note search row must carry name: null matching list()/get(); got hit {hit}"
+    );
+    assert!(
+        hit.get("title").and_then(Value::as_str).is_some(),
+        "title must remain populated as the display value; got hit {hit}"
+    );
+}
+
 /// Regression for #163: `search` accepts a `properties` filter that restricts
 /// results to entities whose properties contain the given key=value pairs.
 #[tokio::test]

--- a/crates/khive-runtime/src/operations.rs
+++ b/crates/khive-runtime/src/operations.rs
@@ -4134,6 +4134,11 @@ pub struct QueryResult {
     pub rows: Vec<SqlRow>,
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub warnings: Vec<String>,
+    /// `true` when the server-side row cap bound this result — `rows` is a
+    /// prefix of the true match set, not the whole thing (#1168, #1247). A
+    /// structural flag so a caller can detect an incomplete result without
+    /// parsing the human-oriented `warnings` text.
+    pub truncated: bool,
 }
 
 impl KhiveRuntime {
@@ -4216,25 +4221,39 @@ impl KhiveRuntime {
         // result set — not the requested LIMIT — is the truncation signal
         // (a `LIMIT 1000` that only matches 20 rows must not warn, and a
         // query with no `LIMIT` that matches 501+ rows must).
+        let mut truncated = false;
         if let Some(check) = truncation_check {
             if rows.len() > check.max_limit {
                 rows.truncate(check.max_limit);
+                truncated = true;
+                // GQL has no SKIP/OFFSET/ORDER BY today (#1168) — the prior
+                // wording here recommended a paging path that does not exist.
+                // `truncated` is the structural signal (#1247); this message
+                // stays prose-only context for a human reader.
                 warnings.push(match check.requested_limit {
                     Some(requested) => format!(
                         "result set capped at {} rows; requested limit {requested} exceeds the \
-                         cap — use LIMIT/OFFSET to page through the remaining results",
+                         cap. This query language does not support SKIP/OFFSET paging yet — \
+                         check the `truncated` field, not this message, to detect an incomplete \
+                         result programmatically.",
                         check.max_limit
                     ),
                     None => format!(
                         "result set capped at {} rows; more than {} rows matched with no LIMIT \
-                         clause — use LIMIT/OFFSET to page through the remaining results",
+                         clause. This query language does not support SKIP/OFFSET paging yet — \
+                         check the `truncated` field, not this message, to detect an incomplete \
+                         result programmatically.",
                         check.max_limit, check.max_limit
                     ),
                 });
             }
         }
 
-        Ok(QueryResult { rows, warnings })
+        Ok(QueryResult {
+            rows,
+            warnings,
+            truncated,
+        })
     }
 
     /// Soft-delete or hard-delete an entity by ID (soft delete by default).

--- a/crates/khive-runtime/tests/integration.rs
+++ b/crates/khive-runtime/tests/integration.rs
@@ -623,6 +623,10 @@ async fn no_explicit_limit_under_and_at_cap_emits_no_warning() {
         "499 matches under the cap must not warn: {:?}",
         result_499.warnings
     );
+    assert!(
+        !result_499.truncated,
+        "#1247: under the cap is not truncated"
+    );
 
     // Exactly 500 matches, no explicit LIMIT: right at the cap, no truncation, no warning.
     let tok_500 = seed_concepts(&rt, "trunc-500", 500).await;
@@ -639,6 +643,10 @@ async fn no_explicit_limit_under_and_at_cap_emits_no_warning() {
         result_500.warnings.is_empty(),
         "exactly 500 matches must not warn (nothing was dropped): {:?}",
         result_500.warnings
+    );
+    assert!(
+        !result_500.truncated,
+        "#1247: exactly at the cap is not truncated (nothing was dropped)"
     );
 }
 
@@ -666,6 +674,15 @@ async fn no_explicit_limit_over_cap_warns_and_strips_sentinel() {
     );
     assert_eq!(result.warnings.len(), 1, "warnings: {:?}", result.warnings);
     assert!(result.warnings[0].contains("500"), "{}", result.warnings[0]);
+    assert!(
+        !result.warnings[0].contains("LIMIT/OFFSET"),
+        "#1168: the warning must not recommend an unimplemented OFFSET path: {}",
+        result.warnings[0]
+    );
+    assert!(
+        result.truncated,
+        "#1247: truncated must be the structural signal, independent of warnings text"
+    );
 
     // The sentinel row must not leak into the returned set: every row must be
     // a distinct seeded entity.
@@ -703,6 +720,10 @@ async fn explicit_limit_variants_against_501_matches() {
     );
     assert!(above_cap.warnings[0].contains("600"));
     assert!(above_cap.warnings[0].contains("500"));
+    assert!(
+        above_cap.truncated,
+        "#1247: LIMIT above cap must set truncated"
+    );
 
     // LIMIT exactly at the cap: the cap never binds (requested <= max_limit),
     // so no sentinel is fetched and no warning fires, even though 501 rows
@@ -720,6 +741,10 @@ async fn explicit_limit_variants_against_501_matches() {
         at_cap.warnings.is_empty(),
         "LIMIT == cap must not warn: {:?}",
         at_cap.warnings
+    );
+    assert!(
+        !at_cap.truncated,
+        "#1247: an explicit LIMIT the caller chose is not server-side truncation"
     );
 
     // LIMIT below the cap: this is the false-positive regression
@@ -740,6 +765,10 @@ async fn explicit_limit_variants_against_501_matches() {
         below_cap.warnings.is_empty(),
         "LIMIT below cap must not warn: {:?}",
         below_cap.warnings
+    );
+    assert!(
+        !below_cap.truncated,
+        "#1247: LIMIT below cap is not truncated"
     );
 }
 
@@ -767,6 +796,10 @@ async fn explicit_limit_over_cap_with_few_real_matches_emits_no_warning() {
         result.warnings.is_empty(),
         "LIMIT above cap with fewer real matches than the cap must not warn: {:?}",
         result.warnings
+    );
+    assert!(
+        !result.truncated,
+        "#1247: fewer real matches than the cap is not truncation"
     );
 }
 

--- a/crates/kkernel/src/exec.rs
+++ b/crates/kkernel/src/exec.rs
@@ -278,6 +278,16 @@ pub struct ExecArgs {
     /// meaningful with `--atomic`.
     #[arg(long, requires = "atomic")]
     pub atomic_max_ops: Option<usize>,
+
+    /// Exit non-zero when any op in the batch fails (or, for `--ops-file`,
+    /// when any applied op fails). Without this flag the process exits 0
+    /// whenever the request itself was dispatched, even if every op inside
+    /// it failed — the per-op `results` entries and the `summary`/`status`
+    /// fields in the printed output are the only signal (#1220). Not
+    /// meaningful with `--atomic`, which already fails the whole file on
+    /// any rejected op.
+    #[arg(long)]
+    pub strict: bool,
 }
 
 /// A single parsed op entry from an ops-file line.
@@ -385,6 +395,7 @@ async fn apply_ops_file(
     server: &KhiveMcpServer,
     ops: Vec<OpsFileEntry>,
     presentation: Option<String>,
+    strict: bool,
 ) -> Result<()> {
     let total = ops.len();
     let mut total_succeeded: usize = 0;
@@ -459,6 +470,11 @@ async fn apply_ops_file(
         "{}",
         serde_json::to_string_pretty(&summary).expect("serialize summary")
     );
+    if strict && total_failed > 0 {
+        anyhow::bail!(
+            "--strict: {total_failed} op(s) failed out of {total} (see printed summary above)"
+        );
+    }
     Ok(())
 }
 
@@ -566,6 +582,7 @@ pub async fn run_exec(args: ExecArgs) -> Result<()> {
                 args.output_format,
                 args.save_file,
                 db_context,
+                args.strict,
             )
             .await
         }
@@ -578,10 +595,35 @@ pub async fn run_exec(args: ExecArgs) -> Result<()> {
                 db_context,
                 args.atomic,
                 args.atomic_max_ops,
+                args.strict,
             )
             .await
         }
     }
+}
+
+/// Returns `Err` describing the failed/aborted op counts when `strict` is set
+/// and the parsed response envelope's `summary` reports either as non-zero
+/// (#1220). `raw` must be the exact envelope string already printed to
+/// stdout — the caller prints first, unconditionally, then this decides the
+/// exit code; a caller piping the output still sees the full result either way.
+fn enforce_strict_batch_result(raw: &str, strict: bool) -> Result<()> {
+    if !strict {
+        return Ok(());
+    }
+    let Ok(parsed) = serde_json::from_str::<serde_json::Value>(raw) else {
+        // Non-JSON output (e.g. --output-format table/auto): nothing to
+        // inspect here. `--strict` only applies to the default JSON shape.
+        return Ok(());
+    };
+    let failed = parsed["summary"]["failed"].as_u64().unwrap_or(0);
+    let aborted = parsed["summary"]["aborted"].as_u64().unwrap_or(0);
+    if failed > 0 || aborted > 0 {
+        anyhow::bail!(
+            "--strict: {failed} op(s) failed, {aborted} op(s) aborted (see printed output above)"
+        );
+    }
+    Ok(())
 }
 
 enum ExecMode {
@@ -602,6 +644,7 @@ async fn run_exec_inline(
     output_format: Option<String>,
     save_file: Option<String>,
     db_context: ExecDbContext,
+    strict: bool,
 ) -> Result<()> {
     #[cfg(unix)]
     return run_exec_inline_with_forward(
@@ -611,6 +654,7 @@ async fn run_exec_inline(
         output_format,
         save_file,
         db_context,
+        strict,
         forward_or_spawn_boxed,
     )
     .await;
@@ -622,6 +666,7 @@ async fn run_exec_inline(
         output_format,
         save_file,
         db_context,
+        strict,
     )
     .await;
 }
@@ -639,6 +684,7 @@ async fn run_exec_inline(
 /// enables the latter: tests pass a spy `forward_fn` and assert it is never
 /// called when the gate should have rejected.
 #[cfg_attr(not(unix), allow(unused_variables))]
+#[allow(clippy::too_many_arguments)]
 async fn run_exec_inline_with_forward(
     ops: String,
     cfg: RuntimeConfig,
@@ -646,6 +692,7 @@ async fn run_exec_inline_with_forward(
     output_format: Option<String>,
     save_file: Option<String>,
     db_context: ExecDbContext,
+    strict: bool,
     #[cfg(unix)] forward_fn: ForwardFnPtr,
 ) -> Result<()> {
     // ── strict-actor gate (before any forwarding) ─────────────────────────────
@@ -719,6 +766,7 @@ async fn run_exec_inline_with_forward(
         if let Some(res) = forward_fn(&frame).await {
             let output = res.map_err(|e| anyhow::anyhow!("{}", e.message))?;
             println!("{output}");
+            enforce_strict_batch_result(&output, strict)?;
             return Ok(());
         }
     }
@@ -754,6 +802,7 @@ async fn run_exec_inline_with_forward(
         .await
         .map_err(|e| anyhow::anyhow!("{e}"))?;
     println!("{output}");
+    enforce_strict_batch_result(&output, strict)?;
     Ok(())
 }
 
@@ -783,6 +832,7 @@ fn build_local_fallback_server(
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 async fn run_exec_ops_file(
     path: PathBuf,
     cfg: RuntimeConfig,
@@ -791,6 +841,7 @@ async fn run_exec_ops_file(
     db_context: ExecDbContext,
     atomic: bool,
     atomic_max_ops: Option<usize>,
+    strict: bool,
 ) -> Result<()> {
     // Parse the whole file first — fail before any writes if any line is bad.
     let ops = parse_ops_file(&path)?;
@@ -847,7 +898,7 @@ async fn run_exec_ops_file(
         db_context.anchor.as_deref(),
     )?;
 
-    apply_ops_file(&server, ops, presentation).await
+    apply_ops_file(&server, ops, presentation, strict).await
 }
 
 #[cfg(test)]
@@ -1917,7 +1968,7 @@ default = true
 
         let ops = parse_ops_file(&f.path().to_path_buf()).unwrap();
         assert_eq!(ops.len(), 3);
-        apply_ops_file(&server, ops, None).await.unwrap();
+        apply_ops_file(&server, ops, None, false).await.unwrap();
 
         // Verify all 3 entities are present.
         let params = RequestParams {
@@ -1941,6 +1992,83 @@ default = true
             count, 3,
             "all 3 entities should be present after apply\nraw: {resp}"
         );
+    }
+
+    // ── #1220: --strict exit-code signal for partially-failed batches ─────────
+
+    #[test]
+    fn enforce_strict_batch_result_ok_when_strict_off_regardless_of_failures() {
+        let raw = serde_json::json!({
+            "results": [],
+            "summary": {"total": 1, "succeeded": 0, "failed": 1, "aborted": 0},
+        })
+        .to_string();
+        assert!(enforce_strict_batch_result(&raw, false).is_ok());
+    }
+
+    #[test]
+    fn enforce_strict_batch_result_ok_when_strict_on_and_nothing_failed() {
+        let raw = serde_json::json!({
+            "results": [],
+            "summary": {"total": 2, "succeeded": 2, "failed": 0, "aborted": 0},
+        })
+        .to_string();
+        assert!(enforce_strict_batch_result(&raw, true).is_ok());
+    }
+
+    #[test]
+    fn enforce_strict_batch_result_errs_when_strict_on_and_a_failure_present() {
+        let raw = serde_json::json!({
+            "results": [],
+            "summary": {"total": 2, "succeeded": 1, "failed": 1, "aborted": 0},
+        })
+        .to_string();
+        let err = enforce_strict_batch_result(&raw, true).unwrap_err();
+        assert!(format!("{err}").contains("1 op(s) failed"));
+    }
+
+    #[test]
+    fn enforce_strict_batch_result_errs_when_strict_on_and_chain_aborted() {
+        let raw = serde_json::json!({
+            "results": [],
+            "summary": {"total": 2, "succeeded": 0, "failed": 1, "aborted": 1},
+        })
+        .to_string();
+        assert!(enforce_strict_batch_result(&raw, true).is_err());
+    }
+
+    #[test]
+    fn enforce_strict_batch_result_ok_on_non_json_output() {
+        // --output-format table/auto renders a non-JSON string; --strict has
+        // nothing to inspect and must not itself error out on that shape.
+        assert!(enforce_strict_batch_result("| a | b |\n", true).is_ok());
+    }
+
+    #[tokio::test]
+    async fn apply_ops_file_strict_errs_when_an_op_fails() {
+        let db_file = NamedTempFile::new().expect("temp db");
+        let db_path = db_file.path().to_str().expect("utf8").to_string();
+        let server = isolated_server(&db_path);
+
+        // First op succeeds; second targets an unknown kind and fails.
+        let mut f = NamedTempFile::new().unwrap();
+        use std::io::Write as _;
+        f.write_all(
+            b"{\"tool\":\"create\",\"args\":{\"kind\":\"concept\",\"name\":\"StrictOne\"}}\n",
+        )
+        .unwrap();
+        f.write_all(
+            b"{\"tool\":\"search\",\"args\":{\"kind\":\"not_a_real_kind\",\"query\":\"x\"}}\n",
+        )
+        .unwrap();
+
+        let ops = parse_ops_file(&f.path().to_path_buf()).unwrap();
+        assert_eq!(ops.len(), 2);
+
+        let err = apply_ops_file(&server, ops, None, true)
+            .await
+            .expect_err("strict mode must surface the per-op failure as a process error");
+        assert!(format!("{err}").contains("1 op(s) failed"));
     }
 
     // ── ADR-099 B1 inertness (golden shape) ────────────────────────────────────
@@ -2038,8 +2166,8 @@ default = true
             .collect();
         assert_eq!(
             top_level_keys,
-            std::collections::BTreeSet::from(["results", "summary"]),
-            "non-atomic envelope must carry exactly results+summary, no `atomic` block: {resp}"
+            std::collections::BTreeSet::from(["results", "summary", "status"]),
+            "non-atomic envelope must carry exactly results+summary+status, no `atomic` block (#1220 added `status`): {resp}"
         );
 
         let summary_keys: std::collections::BTreeSet<&str> = resp["summary"]
@@ -2094,6 +2222,7 @@ default = true
             ExecDbContext::default(),
             false,
             None,
+            false,
         )
         .await
         .unwrap();
@@ -2147,6 +2276,7 @@ default = true
             None,
             None,
             ExecDbContext::default(),
+            false,
         )
         .await;
 
@@ -2192,6 +2322,7 @@ default = true
             None,
             None,
             ExecDbContext::default(),
+            false,
         )
         .await;
 
@@ -2302,6 +2433,7 @@ backend = "sessions"
             None,
             None,
             ExecDbContext::default(),
+            false,
             spy_capture_config_id,
         )
         .await;

--- a/crates/kkernel/src/exec.rs
+++ b/crates/kkernel/src/exec.rs
@@ -2038,6 +2038,17 @@ default = true
     }
 
     #[test]
+    fn enforce_strict_batch_result_errs_on_save_manifest_with_failures() {
+        // The save-file path prints a manifest, not the raw envelope; the
+        // manifest carries the envelope's summary through (khive-mcp
+        // save_sink) precisely so --strict works on this path too.
+        let raw = r#"{"path":"/tmp/out.jsonl","rows":2,"checksum":"ab","summary":{"total":2,"succeeded":1,"failed":1,"aborted":0}}"#;
+        assert!(enforce_strict_batch_result(raw, true).is_err());
+        let clean = r#"{"path":"/tmp/out.jsonl","rows":2,"checksum":"ab","summary":{"total":2,"succeeded":2,"failed":0,"aborted":0}}"#;
+        assert!(enforce_strict_batch_result(clean, true).is_ok());
+    }
+
+    #[test]
     fn enforce_strict_batch_result_ok_on_non_json_output() {
         // --output-format table/auto renders a non-JSON string; --strict has
         // nothing to inspect and must not itself error out on that shape.

--- a/crates/kkernel/tests/config_discovery_reload_anchor.rs
+++ b/crates/kkernel/tests/config_discovery_reload_anchor.rs
@@ -119,6 +119,7 @@ path = "{}"
         dry_run: false,
         atomic: false,
         atomic_max_ops: None,
+        strict: false,
     };
 
     let result = run_exec(args).await;


### PR DESCRIPTION
## Summary

Three response-shape fixes for the `kg` pack and the MCP `request` envelope:

- `search` rows for both entities and notes now carry the same `name`,
  `kind`/`entity_kind`/`note_kind`, and `created_at` fields that `list()` and
  `get()` already return, instead of a narrower ad hoc shape (#1174).
- The `request` tool's batch/chain response envelope now carries a
  `status: "success" | "partial"` field, so a caller can detect a partial
  failure without diffing `summary.failed`/`summary.aborted` by hand. The
  `kkernel exec` CLI gains a `--strict` flag that turns a partial result into
  a non-zero exit code for scripting (#1220).
- GQL query results now carry a `truncated: bool` field whenever the result
  set was capped, and the accompanying warning text no longer suggests
  `LIMIT`/`OFFSET` paging syntax the query language doesn't support (#1168,
  #1247).

## Also investigated

#1233 (unknown `kind` silently falling through in `search`) did not
reproduce against current `main` — `search` and `list` share the same kind
resolution path and already return matching errors for unrecognized kinds,
and existing regression tests cover this. No code change included for it;
flagging for maintainer triage rather than closing it directly.

## Test plan

- [x] `cargo test -p khive-pack-kg -p khive-runtime -p khive-mcp -p kkernel`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo fmt --all -- --check`