### PR TITLE
fix(kg): close two edge-validation bypass paths

### DIFF
--- a/crates/khive-runtime/src/portability.rs
+++ b/crates/khive-runtime/src/portability.rs
@@ -270,6 +270,20 @@ impl KhiveRuntime {
                 edges_skipped += 1;
                 continue;
             }
+            if let Err(e) = self
+                .validate_edge_relation_endpoints(token, ee.source, ee.target, ee.relation)
+                .await
+            {
+                tracing::warn!(
+                    source = %ee.source,
+                    target = %ee.target,
+                    relation = ?ee.relation,
+                    error = %e,
+                    "import_kg: skipping edge — endpoint contract violation in namespace {ns:?}"
+                );
+                edges_skipped += 1;
+                continue;
+            }
             let now = Utc::now();
             let edge = khive_storage::types::Edge {
                 id: LinkId::from(ee.edge_id),
@@ -701,7 +715,11 @@ mod tests {
                     edge_id: Uuid::new_v4(),
                     source: b.id,
                     target: c.id,
-                    relation: EdgeRelation::DependsOn,
+                    // #1235: concept->concept is not in depends_on's endpoint
+                    // contract; use variant_of (concept->concept is valid) so
+                    // this fixture exercises "one dangling edge skipped" only,
+                    // not an endpoint-contract violation this test isn't about.
+                    relation: EdgeRelation::VariantOf,
                     weight: 0.9,
                 },
                 ExportedEdge {
@@ -751,6 +769,88 @@ mod tests {
         assert_eq!(
             summary.edges_skipped, 0,
             "no edges should be skipped when all endpoints exist"
+        );
+    }
+
+    /// #1235: an edge whose (source kind, relation, target kind) triple violates the
+    /// endpoint contract (here: `precedes` between two `concept` entities — `precedes`
+    /// is restricted to document/dataset/artifact/service/project pairs) must be
+    /// skipped by import the same way a dangling endpoint is, not written straight
+    /// through with `graph.upsert_edge`.
+    #[tokio::test]
+    async fn import_edge_violating_endpoint_contract_is_skipped() {
+        let src = make_rt().await;
+        let tok = NamespaceToken::local();
+        let e1 = src
+            .create_entity(&tok, "concept", None, "E1", None, None, vec![])
+            .await
+            .unwrap();
+        let e2 = src
+            .create_entity(&tok, "concept", None, "E2", None, None, vec![])
+            .await
+            .unwrap();
+
+        let archive = KgArchive {
+            format: "khive-kg".to_string(),
+            version: "0.1".to_string(),
+            namespace: "local".to_string(),
+            exported_at: Utc::now(),
+            entities: vec![
+                ExportedEntity {
+                    id: e1.id,
+                    kind: "concept".to_string(),
+                    entity_type: None,
+                    name: "E1".to_string(),
+                    description: None,
+                    properties: None,
+                    tags: vec![],
+                    created_at: Utc::now(),
+                    updated_at: Utc::now(),
+                },
+                ExportedEntity {
+                    id: e2.id,
+                    kind: "concept".to_string(),
+                    entity_type: None,
+                    name: "E2".to_string(),
+                    description: None,
+                    properties: None,
+                    tags: vec![],
+                    created_at: Utc::now(),
+                    updated_at: Utc::now(),
+                },
+            ],
+            edges: vec![ExportedEdge {
+                edge_id: Uuid::new_v4(),
+                source: e1.id,
+                target: e2.id,
+                relation: EdgeRelation::Precedes,
+                weight: 1.0,
+            }],
+        };
+
+        let dst = make_rt().await;
+        let summary = dst.import_kg(&archive, &tok).await.unwrap();
+        assert_eq!(summary.entities_imported, 2);
+        assert_eq!(
+            summary.edges_imported, 0,
+            "an endpoint-contract-violating edge must not be imported"
+        );
+        assert_eq!(
+            summary.edges_skipped, 1,
+            "an endpoint-contract-violating edge must be counted as skipped"
+        );
+        assert!(
+            dst.neighbors(
+                &tok,
+                e1.id,
+                khive_storage::types::Direction::Out,
+                None,
+                None
+            )
+            .await
+            .unwrap()
+            .is_empty(),
+            "the contract-violating edge must not exist in the destination graph"
         );
     }
 

--- a/crates/khive-runtime/src/portability.rs
+++ b/crates/khive-runtime/src/portability.rs
@@ -270,19 +270,27 @@ impl KhiveRuntime {
                 edges_skipped += 1;
                 continue;
             }
-            if let Err(e) = self
+            // Only a contract verdict (InvalidInput) or an endpoint-resolution
+            // miss (NotFound) is a property of the edge being imported; any
+            // other error is an operational failure of the check itself and
+            // must abort the import rather than silently discard a valid edge.
+            match self
                 .validate_edge_relation_endpoints(token, ee.source, ee.target, ee.relation)
                 .await
             {
-                tracing::warn!(
-                    source = %ee.source,
-                    target = %ee.target,
-                    relation = ?ee.relation,
-                    error = %e,
-                    "import_kg: skipping edge — endpoint contract violation in namespace {ns:?}"
-                );
-                edges_skipped += 1;
-                continue;
+                Ok(()) => {}
+                Err(e @ (RuntimeError::InvalidInput(_) | RuntimeError::NotFound(_))) => {
+                    tracing::warn!(
+                        source = %ee.source,
+                        target = %ee.target,
+                        relation = ?ee.relation,
+                        error = %e,
+                        "import_kg: skipping edge — endpoint contract violation in namespace {ns:?}"
+                    );
+                    edges_skipped += 1;
+                    continue;
+                }
+                Err(e) => return Err(e),
             }
             let now = Utc::now();
             let edge = khive_storage::types::Edge {

--- a/crates/kkernel/src/kg/validate.rs
+++ b/crates/kkernel/src/kg/validate.rs
@@ -15,6 +15,26 @@ use super::types::{
     OutputFormat, RuleResult, ValidateArgs, ValidationReport, ValidationSummary, Violation,
 };
 
+/// Read an edge record's source endpoint id, accepting either canonical
+/// serialization spelling: `source` (khive-vcs sync, kkernel archive, and
+/// the runtime portability export all write this) or `source_id` (accepted
+/// for forward compatibility with any other producer). See #1225 — every
+/// canonical NDJSON writer emits `source`/`target`, not `source_id`/
+/// `target_id`, and a validator that only recognized the latter silently
+/// skipped the endpoint checks on every record those writers produce.
+fn edge_source_id(v: &serde_json::Value) -> Option<&str> {
+    v.get("source")
+        .or_else(|| v.get("source_id"))
+        .and_then(|x| x.as_str())
+}
+
+/// Target-endpoint counterpart of [`edge_source_id`].
+fn edge_target_id(v: &serde_json::Value) -> Option<&str> {
+    v.get("target")
+        .or_else(|| v.get("target_id"))
+        .and_then(|x| x.as_str())
+}
+
 /// Taxonomy sets derived from the loaded pack registry; `pub(super)` so
 /// `kg::commit` (ADR-102) can reuse them. See
 /// `crates/kkernel/docs/kg-rules.md#build_taxonomy--strict-actor-mode-exemption`.
@@ -261,10 +281,16 @@ fn check_schema_compliance(
             let line_no = idx + 1;
             match serde_json::from_str::<serde_json::Value>(line) {
                 Ok(v) => {
-                    let missing: Vec<&str> = ["source_id", "target_id", "relation"]
-                        .into_iter()
-                        .filter(|f| v.get(f).and_then(|x| x.as_str()).is_none())
-                        .collect();
+                    let mut missing: Vec<&str> = Vec::new();
+                    if edge_source_id(&v).is_none() {
+                        missing.push("source (or source_id)");
+                    }
+                    if edge_target_id(&v).is_none() {
+                        missing.push("target (or target_id)");
+                    }
+                    if v.get("relation").and_then(|x| x.as_str()).is_none() {
+                        missing.push("relation");
+                    }
                     if !missing.is_empty() {
                         violations.push(schema_violation(
                             "edges.ndjson",
@@ -469,16 +495,8 @@ fn check_valid_edge_relations(edges_path: &Path) -> RuleResult {
                             .or_else(|| v.get("id").and_then(|i| i.as_str()))
                             .unwrap_or("")
                             .to_string();
-                        let src = v
-                            .get("source_id")
-                            .and_then(|i| i.as_str())
-                            .unwrap_or("")
-                            .to_string();
-                        let tgt = v
-                            .get("target_id")
-                            .and_then(|i| i.as_str())
-                            .unwrap_or("")
-                            .to_string();
+                        let src = edge_source_id(&v).unwrap_or("").to_string();
+                        let tgt = edge_target_id(&v).unwrap_or("").to_string();
                         let id_display = if !edge_id.is_empty() {
                             edge_id.clone()
                         } else if !src.is_empty() && !tgt.is_empty() {
@@ -588,8 +606,8 @@ fn check_sort_order(entities_path: &Path, edges_path: &Path) -> RuleResult {
             .filter(|l| !l.trim().is_empty())
             .filter_map(|l| {
                 let v: serde_json::Value = serde_json::from_str(l).ok()?;
-                let s = v.get("source_id")?.as_str()?.to_string();
-                let t = v.get("target_id")?.as_str()?.to_string();
+                let s = edge_source_id(&v)?.to_string();
+                let t = edge_target_id(&v)?.to_string();
                 let r = v.get("relation")?.as_str()?.to_string();
                 Some((s, t, r))
             })
@@ -687,8 +705,11 @@ fn check_referential_integrity(
     if let Ok(content) = std::fs::read_to_string(edges_path) {
         for line in content.lines().filter(|l| !l.trim().is_empty()) {
             if let Ok(v) = serde_json::from_str::<serde_json::Value>(line) {
-                for field in &["source_id", "target_id"] {
-                    if let Some(id) = v.get(field).and_then(|i| i.as_str()) {
+                for (label, id) in [
+                    ("source", edge_source_id(&v)),
+                    ("target", edge_target_id(&v)),
+                ] {
+                    if let Some(id) = id {
                         if !known_ids.contains(id) {
                             violations.push(Violation {
                                 entity_id: Some(id.to_string()),
@@ -696,14 +717,7 @@ fn check_referential_integrity(
                                 entity_kind: None,
                                 rule_id: "referential-integrity".into(),
                                 severity: "error",
-                                message: format!(
-                                    "Edge {} references unknown record: {id}",
-                                    if *field == "source_id" {
-                                        "source"
-                                    } else {
-                                        "target"
-                                    }
-                                ),
+                                message: format!("Edge {label} references unknown record: {id}"),
                                 fixable: false,
                             });
                         }
@@ -1175,8 +1189,8 @@ fn evaluate_rule(rule: &RuleConfig, path: &Path) -> Vec<Violation> {
 
         if let Some((field, expected)) = condition {
             if field == "source_id" && expected == "target_id" {
-                let src = v.get("source_id").and_then(|s| s.as_str()).unwrap_or("");
-                let tgt = v.get("target_id").and_then(|s| s.as_str()).unwrap_or("");
+                let src = edge_source_id(&v).unwrap_or("");
+                let tgt = edge_target_id(&v).unwrap_or("");
                 if src == tgt {
                     violations.push(Violation {
                         entity_id: Some(src.to_owned()),
@@ -1381,10 +1395,10 @@ fn check_edge_endpoint_types(
             let Ok(v) = serde_json::from_str::<serde_json::Value>(line) else {
                 continue;
             };
-            let Some(src_id) = v.get("source_id").and_then(|s| s.as_str()) else {
+            let Some(src_id) = edge_source_id(&v) else {
                 continue;
             };
-            let Some(tgt_id) = v.get("target_id").and_then(|s| s.as_str()) else {
+            let Some(tgt_id) = edge_target_id(&v) else {
                 continue;
             };
             let Some(rel_str) = v.get("relation").and_then(|r| r.as_str()) else {
@@ -1485,10 +1499,10 @@ fn check_edge_direction_conventions(
             let Ok(v) = serde_json::from_str::<serde_json::Value>(line) else {
                 continue;
             };
-            let Some(src_id) = v.get("source_id").and_then(|s| s.as_str()) else {
+            let Some(src_id) = edge_source_id(&v) else {
                 continue;
             };
-            let Some(tgt_id) = v.get("target_id").and_then(|s| s.as_str()) else {
+            let Some(tgt_id) = edge_target_id(&v) else {
                 continue;
             };
             let Some(rel_str) = v.get("relation").and_then(|r| r.as_str()) else {
@@ -1570,8 +1584,11 @@ fn check_dangling_refs(
     if let Ok(content) = std::fs::read_to_string(edges_path) {
         for line in content.lines().filter(|l| !l.trim().is_empty()) {
             if let Ok(v) = serde_json::from_str::<serde_json::Value>(line) {
-                for field in &["source_id", "target_id"] {
-                    if let Some(id) = v.get(*field).and_then(|i| i.as_str()) {
+                for (field, id) in [
+                    ("source", edge_source_id(&v)),
+                    ("target", edge_target_id(&v)),
+                ] {
+                    if let Some(id) = id {
                         if !known_ids.contains(id) {
                             violations.push(Violation {
                                 entity_id: Some(id.to_string()),
@@ -1874,13 +1891,13 @@ fn fix_sort_order_edges(path: &Path) -> Result<()> {
     }
     lines.sort_by(|a, b| {
         let ak = (
-            a.get("source_id").and_then(|v| v.as_str()).unwrap_or(""),
-            a.get("target_id").and_then(|v| v.as_str()).unwrap_or(""),
+            edge_source_id(a).unwrap_or(""),
+            edge_target_id(a).unwrap_or(""),
             a.get("relation").and_then(|v| v.as_str()).unwrap_or(""),
         );
         let bk = (
-            b.get("source_id").and_then(|v| v.as_str()).unwrap_or(""),
-            b.get("target_id").and_then(|v| v.as_str()).unwrap_or(""),
+            edge_source_id(b).unwrap_or(""),
+            edge_target_id(b).unwrap_or(""),
             b.get("relation").and_then(|v| v.as_str()).unwrap_or(""),
         );
         ak.cmp(&bk)
@@ -2010,6 +2027,23 @@ mod tests {
             .iter()
             .map(|(src, tgt, rel)| {
                 format!(r#"{{"source_id":"{src}","target_id":"{tgt}","relation":"{rel}"}}"#)
+            })
+            .collect::<Vec<_>>()
+            .join("\n");
+        std::fs::write(kg_dir.join("edges.ndjson"), content + "\n").unwrap();
+    }
+
+    /// #1225: the canonical wire spelling every real NDJSON writer emits
+    /// (`khive-vcs::sync::NdjsonEdge`, `kkernel::kg::archive::NdjsonEdge`, and
+    /// the runtime portability `ExportedEdge`) is `source`/`target`, not the
+    /// `source_id`/`target_id` [`write_edges`] uses. This helper writes the
+    /// spelling real producers actually emit, so round-trip tests exercise
+    /// what `kg validate` is actually validating in production.
+    fn write_edges_canonical(kg_dir: &std::path::Path, edges: &[(&str, &str, &str)]) {
+        let content: String = edges
+            .iter()
+            .map(|(src, tgt, rel)| {
+                format!(r#"{{"source":"{src}","target":"{tgt}","relation":"{rel}"}}"#)
             })
             .collect::<Vec<_>>()
             .join("\n");
@@ -2153,6 +2187,87 @@ mod tests {
         );
         assert!(!result.passed);
         assert_eq!(result.violations.len(), 1);
+    }
+
+    /// #1225: edges.ndjson written in the CANONICAL `source`/`target` spelling
+    /// (what `khive-vcs::sync`, `kkernel::kg::archive`, and the runtime
+    /// portability exporter all actually emit) must be evaluated by
+    /// referential-integrity, not silently skipped. Same fixture as
+    /// `referential_integrity_catches_missing_target` above, just in the
+    /// spelling real writers use.
+    #[test]
+    fn referential_integrity_catches_missing_target_in_canonical_spelling() {
+        let tmp = TempDir::new().unwrap();
+        let kg_dir = make_kg_dir(&tmp);
+        write_entities(
+            &kg_dir,
+            &[("aaaaaaaa-0000-0000-0000-000000000001", "concept", "A")],
+        );
+        write_edges_canonical(
+            &kg_dir,
+            &[(
+                "aaaaaaaa-0000-0000-0000-000000000001",
+                "bbbbbbbb-0000-0000-0000-000000000002",
+                "extends",
+            )],
+        );
+        let result = check_referential_integrity(
+            &kg_dir.join("entities.ndjson"),
+            &kg_dir.join("notes.ndjson"),
+            &kg_dir.join("edges.ndjson"),
+        );
+        assert!(
+            !result.passed,
+            "a dangling target in canonical source/target spelling must not be silently skipped"
+        );
+        assert_eq!(result.violations.len(), 1);
+    }
+
+    /// #1225: a well-formed edge in canonical `source`/`target` spelling must
+    /// round-trip cleanly through referential-integrity AND schema-compliance
+    /// — the two checks that previously either flagged it as missing required
+    /// fields or silently excluded it from endpoint evaluation.
+    #[test]
+    fn canonical_spelling_edge_round_trips_clean() {
+        let tmp = TempDir::new().unwrap();
+        let kg_dir = make_kg_dir(&tmp);
+        write_entities(
+            &kg_dir,
+            &[
+                ("aaaaaaaa-0000-0000-0000-000000000001", "concept", "A"),
+                ("bbbbbbbb-0000-0000-0000-000000000002", "concept", "B"),
+            ],
+        );
+        write_edges_canonical(
+            &kg_dir,
+            &[(
+                "aaaaaaaa-0000-0000-0000-000000000001",
+                "bbbbbbbb-0000-0000-0000-000000000002",
+                "extends",
+            )],
+        );
+        let ref_result = check_referential_integrity(
+            &kg_dir.join("entities.ndjson"),
+            &kg_dir.join("notes.ndjson"),
+            &kg_dir.join("edges.ndjson"),
+        );
+        assert!(
+            ref_result.passed,
+            "canonical-spelling edge with valid endpoints must pass; violations: {:?}",
+            ref_result.violations
+        );
+
+        let schema_result = check_schema_compliance(
+            &kg_dir.join("entities.ndjson"),
+            &kg_dir.join("edges.ndjson"),
+            &kg_dir.join("notes.ndjson"),
+        );
+        assert!(
+            schema_result.passed,
+            "canonical-spelling edge must not be reported as missing source_id/target_id; \
+             violations: {:?}",
+            schema_result.violations
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- `import_kg` checked that both edge endpoints existed in the target
  namespace but never validated the (source kind, relation, target kind)
  triple against the same endpoint contract `link()` enforces. An imported
  archive could introduce edges the interactive path would reject outright.
  Contract-violating edges are now skipped and counted, consistent with the
  existing dangling-endpoint skip behavior (#1235).
- `kg validate`'s edge checks read `source_id`/`target_id`, but every NDJSON
  writer (sync, archive, portability export) serializes edges as
  `source`/`target`. A validate run against normally-produced NDJSON either
  reported a missing-field error or silently excluded those records from
  endpoint evaluation, so a clean run didn't mean the endpoint rules had
  actually been checked. Endpoint field reads now accept both spellings
  (#1225).

## Test plan

- [x] `cargo test -p khive-runtime -p kkernel`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo fmt --all -- --check`