### PR TITLE
fix(kkernel): reject db-override/backend conflicts before daemon forward

### DIFF
--- a/crates/khive-mcp/src/serve.rs
+++ b/crates/khive-mcp/src/serve.rs
@@ -351,20 +351,34 @@ pub fn build_registry_for_multi_backend_with_db_anchor(
     build_registry_for_multi_backend_inner(base_config, khive_cfg, cli_db_override)
 }
 
-fn build_registry_for_multi_backend_inner(
-    base_config: RuntimeConfig,
-    khive_cfg: &KhiveConfig,
+/// Validate a `--db`/`KHIVE_DB` override against a non-empty `[[backends]]`
+/// declaration WITHOUT opening any backend — the same rule
+/// `build_registry_for_multi_backend_inner` enforces, factored out so a
+/// caller that hasn't yet decided whether it will construct backends in this
+/// process can apply the check up front.
+///
+/// This closes #1226: `kkernel exec`'s daemon-forward fast path (inline ops,
+/// used whenever a warm daemon answers) never called into this guard at all
+/// — only the in-process fallback did — so an inline invocation with a
+/// conflicting override silently forwarded to the daemon's own already-open
+/// backends instead of being rejected, while the same override on
+/// `--ops-file` (always in-process by design) correctly bailed. The two call
+/// forms disagreed about whether the override was legal because only one of
+/// them ever ran this check. Returns `Ok(true)` when the override forces
+/// every backend to in-memory (`:memory:`), `Ok(false)` when there is no
+/// override to apply.
+pub fn validate_db_override_against_backends(
     cli_db_override: Option<&str>,
-) -> anyhow::Result<MultiBackendRegistry> {
-    let backend_count = khive_cfg.backends.len();
-    let force_memory = match cli_db_override {
+    backend_count: usize,
+) -> anyhow::Result<bool> {
+    match cli_db_override {
         Some(":memory:") => {
             tracing::warn!(
                 "--db :memory: (or KHIVE_DB=:memory:) is overriding {backend_count} \
                  configured [[backends]] entries to in-memory storage for this invocation; \
                  khive.toml's declared backend paths will not be used this run"
             );
-            true
+            Ok(true)
         }
         Some(other) => {
             anyhow::bail!(
@@ -376,8 +390,17 @@ fn build_registry_for_multi_backend_inner(
                  this invocation."
             );
         }
-        None => false,
-    };
+        None => Ok(false),
+    }
+}
+
+fn build_registry_for_multi_backend_inner(
+    base_config: RuntimeConfig,
+    khive_cfg: &KhiveConfig,
+    cli_db_override: Option<&str>,
+) -> anyhow::Result<MultiBackendRegistry> {
+    let backend_count = khive_cfg.backends.len();
+    let force_memory = validate_db_override_against_backends(cli_db_override, backend_count)?;
 
     // Open and migrate each declared backend, deduplicating SQLite backends by
     // canonical path (ADR-028 §8).

--- a/crates/kkernel/src/exec.rs
+++ b/crates/kkernel/src/exec.rs
@@ -683,6 +683,18 @@ async fn run_exec_inline_with_forward(
         .map_err(|e| anyhow::anyhow!("config error: {e}"))?
         .unwrap_or_default();
 
+    // #1226: apply the same --db/[[backends]] conflict guard the in-process
+    // fallback below applies, BEFORE the daemon fast-path — otherwise a warm
+    // daemon answers this request without the override ever being checked at
+    // all, while the identical override on `--ops-file` (always in-process)
+    // correctly rejects it. See `validate_db_override_against_backends`.
+    if !khive_cfg.backends.is_empty() {
+        khive_mcp::serve::validate_db_override_against_backends(
+            db_context.raw.as_deref(),
+            khive_cfg.backends.len(),
+        )?;
+    }
+
     // ── daemon fast-path (Unix only) ─────────────────────────────────────────
     // The daemon path does not support --save-file (the daemon returns a string;
     // we would need to parse it back to apply the sink).  Skip daemon forwarding
@@ -2345,6 +2357,86 @@ backend = "sessions"
              daemon must be byte-identical to what the daemon computes for the same \
              multi-backend config.toml (D1 acceptance gate, exercised end-to-end through \
              the real call site rather than a standalone compute_config_id comparison)"
+        );
+    }
+
+    // ── #1226: inline --db/[[backends]] guard must fire before daemon-forward ──
+
+    #[cfg(unix)]
+    #[tokio::test]
+    #[serial]
+    async fn inline_db_override_conflicting_with_backends_is_rejected_before_daemon_forward() {
+        std::env::remove_var("KHIVE_EMBEDDING_MODEL");
+        std::env::remove_var("KHIVE_ADDITIONAL_EMBEDDING_MODELS");
+        std::env::remove_var("KHIVE_ACTOR");
+        std::env::remove_var("KHIVE_REQUIRE_ATTRIBUTED_ACTOR");
+        let (prev_home, home_dir) = isolate_home_for_test();
+        SPY_CAPTURED_CONFIG_ID.with(|c| *c.borrow_mut() = None);
+
+        let khive_dir = home_dir.path().join(".khive");
+        std::fs::create_dir_all(&khive_dir).expect("mkdir .khive");
+        let main_backend_path = khive_dir.join("main-backend.db");
+        let sessions_backend_path = khive_dir.join("sessions-backend.db");
+        std::fs::write(
+            khive_dir.join("config.toml"),
+            format!(
+                r#"
+[[backends]]
+name = "main"
+kind = "sqlite"
+path = "{}"
+
+[[backends]]
+name = "sessions"
+kind = "sqlite"
+path = "{}"
+
+[packs.session]
+backend = "sessions"
+"#,
+                main_backend_path.display(),
+                sessions_backend_path.display(),
+            ),
+        )
+        .expect("write multi-backend config.toml");
+
+        let cfg = resolve_runtime_config(RuntimeConfigInputs {
+            db: None,
+            config: None,
+            namespace: Namespace::parse("local").expect("ns"),
+            namespace_explicit: true,
+            actor_explicit: false,
+            no_embed: true,
+            packs: None,
+            brain_profile: None,
+        })
+        .expect("resolve exec-shaped config");
+
+        let conflicting_override = khive_dir.join("override.db");
+        let result = run_exec_inline_with_forward(
+            "stats()".to_string(),
+            cfg,
+            None,
+            None,
+            None,
+            ExecDbContext {
+                raw: Some(conflicting_override.display().to_string()),
+                anchor: None,
+            },
+            spy_capture_config_id,
+        )
+        .await;
+        restore_home(prev_home);
+
+        assert!(
+            result.is_err(),
+            "a --db/KHIVE_DB override that conflicts with a declared [[backends]] topology \
+             must be rejected on the inline path too, not only on --ops-file; got: {result:?}"
+        );
+        assert!(
+            SPY_CAPTURED_CONFIG_ID.with(|c| c.borrow().is_none()),
+            "the conflict must be caught BEFORE any daemon-forward attempt — the spy must \
+             never have been called"
         );
     }
 


### PR DESCRIPTION
## Summary

- `run_exec_inline_with_forward` now validates an explicit `--db` override against the
  project's configured backends *before* forwarding the request to the daemon, using the
  same check `khive-mcp`'s registry-build path already applies. Previously the conflict
  only surfaced after a round trip to the daemon.
- Extracted the check into `khive_mcp::serve::validate_db_override_against_backends` so
  both call sites share one implementation.

## Test plan

- [x] `cargo test -p khive-mcp -p kkernel --lib` (green, includes a new regression test
      asserting the guard fires before the daemon forward is attempted)
- [x] `cargo clippy -p khive-mcp -p kkernel --all-targets -- -D warnings`
- [x] `cargo fmt --all -- --check`

Closes #1226