### PR TITLE
test(kkernel): pin exec test helpers' pack list instead of inheriting KHIVE_PACKS

### DIFF
--- a/crates/kkernel/src/exec.rs
+++ b/crates/kkernel/src/exec.rs
@@ -1128,10 +1128,42 @@ mod tests {
             db_path: Some(PathBuf::from(db_path)),
             embedding_model: None,
             additional_embedding_models: vec![],
+            // Pin the pack list explicitly rather than inheriting `KHIVE_PACKS`
+            // from the ambient environment (#1276) — every caller of this
+            // helper only dispatches `kg` verbs, so the behavior under test
+            // shouldn't depend on a wider pack set a developer's shell exports.
+            packs: vec!["kg".to_string()],
             ..Default::default()
         };
         let rt = KhiveRuntime::new(cfg).expect("runtime on temp db");
         KhiveMcpServer::new(rt).expect("server on temp db")
+    }
+
+    // ── isolated_server ignores ambient KHIVE_PACKS (#1276) ───────────────────
+    //
+    // `cargo test -p kkernel` failed ~20 exec tests whenever a developer's
+    // shell exported `KHIVE_PACKS` naming a pack not compiled into this
+    // workspace (e.g. `kg,gtd`): every `RuntimeConfig` built by this test
+    // module's shared helpers fell through to `RuntimeConfig::default()`'s
+    // `packs` field, which reads that env var, so construction panicked with
+    // `PackRegError { unknown: "gtd", .. }`. A unit test's outcome must not
+    // depend on ambient shell configuration.
+    #[test]
+    #[serial(khive_packs_env)]
+    fn isolated_server_ignores_ambient_khive_packs_naming_unavailable_pack() {
+        let prev = std::env::var("KHIVE_PACKS").ok();
+        std::env::set_var("KHIVE_PACKS", "kg,gtd");
+
+        let db_file = NamedTempFile::new().expect("temp db");
+        let db_path = db_file.path().to_str().expect("utf8").to_string();
+        // Before the fix, this panicked inside `KhiveMcpServer::new` — the
+        // helper inherited the ambient list above instead of pinning its own.
+        let _server = isolated_server(&db_path);
+
+        match prev {
+            Some(v) => std::env::set_var("KHIVE_PACKS", v),
+            None => std::env::remove_var("KHIVE_PACKS"),
+        }
     }
 
     // ── exec-path / serve-path config_id parity (#581) ────────────────────────
@@ -1670,6 +1702,10 @@ default = true
                 db_path: Some(db_path),
                 embedding_model: None,
                 additional_embedding_models: vec![],
+                // Pin the pack list explicitly rather than inheriting
+                // `KHIVE_PACKS` from the ambient environment (#1276) — this
+                // race only exercises `kg` writes.
+                packs: vec!["kg".to_string()],
                 ..RuntimeConfig::default()
             };
             let khive_cfg = KhiveConfig::default();
@@ -1748,6 +1784,9 @@ default = true
                 db_path: Some(db_path),
                 embedding_model: None,
                 additional_embedding_models: vec![],
+                // Pin the pack list explicitly rather than inheriting
+                // `KHIVE_PACKS` from the ambient environment (#1276).
+                packs: vec!["kg".to_string()],
                 ..RuntimeConfig::default()
             };
             let khive_cfg = KhiveConfig::default();
@@ -2290,7 +2329,10 @@ backend = "sessions"
             namespace_explicit: true,
             actor_explicit: false,
             no_embed: true,
-            packs: None,
+            // Pin the pack list explicitly rather than inheriting `KHIVE_PACKS`
+            // from the ambient environment (#1276) — this test's assertion is
+            // about config_id parity, not about pack resolution.
+            packs: Some(vec!["kg".to_string()]),
             brain_profile: None,
         })
         .expect("resolve exec-shaped config");
@@ -2324,7 +2366,10 @@ backend = "sessions"
             namespace_explicit: false,
             actor_explicit: false,
             no_embed: true,
-            packs: None,
+            // Same pin as `cfg` above (#1276) — both sides of the parity
+            // comparison must resolve identically regardless of ambient
+            // `KHIVE_PACKS`.
+            packs: Some(vec!["kg".to_string()]),
             brain_profile: None,
         })
         .expect("resolve serve-shaped config");
@@ -2429,6 +2474,10 @@ backend = "sessions"
             db_path: Some(PathBuf::from(db_path)),
             embedding_model: None,
             additional_embedding_models: vec![],
+            // Pin the pack list explicitly rather than inheriting `KHIVE_PACKS`
+            // from the ambient environment (#1276) — every atomic-apply test
+            // using this helper only dispatches `kg` verbs.
+            packs: vec!["kg".to_string()],
             ..Default::default()
         }
     }


### PR DESCRIPTION
## Summary

`cargo test -p kkernel` failed a large slice of the exec-dispatch test suite
whenever the shell running it exported `KHIVE_PACKS` naming a pack not
compiled into this workspace (e.g. `KHIVE_PACKS=kg,gtd`). Several shared test
helpers built their `RuntimeConfig` via a struct-update spread from
`RuntimeConfig::default()`, which falls back to that environment variable
when the caller doesn't set its own `packs` field — so construction panicked
with an "unknown pack" registration error, even though none of the affected
tests exercise anything beyond the built-in `kg` pack.

## Changes

- Pinned `packs: vec!["kg".to_string()]` (or the `RuntimeConfigInputs`
  equivalent) on every affected helper/test: `isolated_server`, `atomic_cfg`,
  and three individually-constructed configs in tests exercising
  `build_local_fallback_server` directly.
- New regression test: sets `KHIVE_PACKS` to a value naming an unavailable
  pack and asserts `isolated_server` still succeeds (confirmed to fail
  without the fix).

## Test plan

- [x] `cargo test -p kkernel --lib` — 259 passed, rc=0
- [x] `cargo clippy -p kkernel --all-targets -- -D warnings` — clean, rc=0
- [x] `cargo fmt --all -- --check` — clean, rc=0
- [x] confirmed the affected tests fail under `KHIVE_PACKS=kg,gtd` before this
      fix (19 failures) and pass after (0 failures), both runs in an isolated
      throwaway `CARGO_TARGET_DIR` to rule out stale-binary reuse from a
      shared target directory
- [x] confirmed the new regression test itself fails without the fix
      (temporarily reverted the `isolated_server` pin, re-ran, restored it)

Closes #1276
