### PR TITLE
fix(kkernel): pass strict flag in db-override conflict test call

### DIFF
--- a/crates/kkernel/src/exec.rs
+++ b/crates/kkernel/src/exec.rs
@@ -2653,6 +2653,7 @@ backend = "sessions"
                 raw: Some(conflicting_override.display().to_string()),
                 anchor: None,
             },
+            false,
             spy_capture_config_id,
         )
         .await;


### PR DESCRIPTION
Restores compilation of the kkernel test target on main.

Two independently green changes merged into a call-arity mismatch: `run_exec_inline_with_forward` gained a `strict` parameter while a new test call site landed with the prior seven-argument shape. Main CI is red at the current head with E0061 in `kkernel/src/exec.rs`.

One-line fix: the `inline_db_override_conflicting_with_backends_is_rejected_before_daemon_forward` test now passes `strict=false`, matching the sibling call site in the same module.

Gates: `cargo clippy -p kkernel --all-targets -- -D warnings` clean (was failing on exactly this), the fixed test passes, fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
