### PR TITLE
fix(mcp): pin test runtime fixtures to the kg pack

### DIFF
--- a/crates/khive-mcp/src/pending_events.rs
+++ b/crates/khive-mcp/src/pending_events.rs
@@ -1330,6 +1330,7 @@ mod tests {
             default_namespace: Namespace::parse("local").unwrap(),
             embedding_model: None,
             additional_embedding_models: vec![],
+            packs: vec!["kg".to_string()],
             actor_id: actor_id.map(str::to_string),
             ..Default::default()
         };

--- a/crates/khive-mcp/src/serve.rs
+++ b/crates/khive-mcp/src/serve.rs
@@ -1471,6 +1471,10 @@ mod tests {
         path
     }
 
+    fn kg_test_packs() -> Vec<String> {
+        vec!["kg".to_string()]
+    }
+
     // The resolver MUST honor config-file `[[engines]]` over RuntimeConfig
     // defaults — otherwise `kkernel reindex` embeds for the wrong model set
     // versus what `kkernel mcp` serves recall from. Regression for PR #8
@@ -1513,7 +1517,7 @@ default = true
             namespace_explicit: false,
             actor_explicit: false,
             no_embed: false,
-            packs: None,
+            packs: Some(kg_test_packs()),
             brain_profile: None,
         })
         .expect("resolve config");
@@ -1564,7 +1568,7 @@ brain_profile = "unrelated"
             namespace_explicit: false,
             actor_explicit: false,
             no_embed: false,
-            packs: None,
+            packs: Some(kg_test_packs()),
             brain_profile: None,
         })
         .expect("resolve config");
@@ -1607,7 +1611,7 @@ brain_profile = "project-profile"
             namespace_explicit: false,
             actor_explicit: false,
             no_embed: false,
-            packs: None,
+            packs: Some(kg_test_packs()),
             brain_profile: None, // no explicit CLI flag
         })
         .expect("resolve config");
@@ -1646,7 +1650,7 @@ default = true
             namespace_explicit: false,
             actor_explicit: false,
             no_embed: false,
-            packs: None,
+            packs: Some(kg_test_packs()),
             brain_profile: None,
         })
         .expect("resolve config");
@@ -1682,7 +1686,7 @@ brain_profile = "project-profile"
             namespace_explicit: false,
             actor_explicit: false,
             no_embed: false,
-            packs: None,
+            packs: Some(kg_test_packs()),
             brain_profile: Some("cli-profile".to_string()), // explicit CLI
         })
         .expect("resolve config");
@@ -1720,7 +1724,7 @@ brain_profile = "project-profile"
             namespace_explicit: true,
             actor_explicit: true,
             no_embed: true,
-            packs: None,
+            packs: Some(kg_test_packs()),
             brain_profile: None,
         })
         .expect("resolve config");
@@ -1759,7 +1763,7 @@ brain_profile = "project-profile"
             namespace_explicit: true,
             actor_explicit: true,
             no_embed: true,
-            packs: None,
+            packs: Some(kg_test_packs()),
             brain_profile: None,
         })
         .expect("resolve no-embed config");
@@ -1792,7 +1796,7 @@ brain_profile = "project-profile"
             namespace_explicit: true,
             actor_explicit: true,
             no_embed: true,
-            packs: None,
+            packs: Some(kg_test_packs()),
             brain_profile: None,
         })
         .expect("resolve config");
@@ -1919,7 +1923,7 @@ brain_profile = "project-profile"
             namespace_explicit: false,
             actor_explicit: false,
             no_embed: true,
-            packs: None,
+            packs: Some(kg_test_packs()),
             brain_profile: None,
         })
         .expect("resolve seat-shaped config");
@@ -1983,7 +1987,7 @@ brain_profile = "project-profile"
             namespace_explicit: false,
             actor_explicit: false,
             no_embed: true,
-            packs: None,
+            packs: Some(kg_test_packs()),
             brain_profile: None,
         })
         .expect("resolve unset-db config");
@@ -2022,7 +2026,7 @@ brain_profile = "project-profile"
             namespace_explicit: true,
             actor_explicit: true,
             no_embed: true,
-            packs: None,
+            packs: Some(kg_test_packs()),
             brain_profile: None,
         })
         .expect("resolve config");
@@ -2060,7 +2064,7 @@ id = "lambda:project-actor"
             namespace_explicit: false,
             actor_explicit: false,
             no_embed: true,
-            packs: None,
+            packs: Some(kg_test_packs()),
             brain_profile: None,
         })
         .expect("resolve config with project actor");
@@ -2074,7 +2078,7 @@ id = "lambda:project-actor"
             namespace_explicit: false,
             actor_explicit: false,
             no_embed: true,
-            packs: None,
+            packs: Some(kg_test_packs()),
             brain_profile: None,
         })
         .expect("resolve config without project actor");
@@ -2130,7 +2134,7 @@ id = "lambda:project-actor"
             namespace_explicit,
             actor_explicit: namespace_explicit,
             no_embed: true,
-            packs: None,
+            packs: Some(kg_test_packs()),
             brain_profile: None,
         });
 
@@ -2182,7 +2186,7 @@ id = "lambda:project-actor"
             namespace_explicit,
             actor_explicit: namespace_explicit,
             no_embed: true,
-            packs: None,
+            packs: Some(kg_test_packs()),
             brain_profile: None,
         });
 
@@ -2251,7 +2255,7 @@ id = "lambda:project-actor"
             namespace_explicit: true,
             actor_explicit: true,
             no_embed: false,
-            packs: None,
+            packs: Some(kg_test_packs()),
             brain_profile: None,
         })
         .expect("resolve config");
@@ -2330,7 +2334,7 @@ id = "lambda:project-actor"
                 namespace_explicit: false,
                 actor_explicit: false,
                 no_embed: true,
-                packs: None,
+                packs: Some(kg_test_packs()),
                 brain_profile: None,
             })
             .expect("resolve config a")
@@ -2345,7 +2349,7 @@ id = "lambda:project-actor"
                 namespace_explicit: false,
                 actor_explicit: false,
                 no_embed: true,
-                packs: None,
+                packs: Some(kg_test_packs()),
                 brain_profile: None,
             })
             .expect("resolve config b")

--- a/crates/khive-mcp/tests/integration.rs
+++ b/crates/khive-mcp/tests/integration.rs
@@ -1248,6 +1248,7 @@ model = "bge-small-en-v1.5"
         db_path: None,
         embedding_model: None,
         additional_embedding_models: vec![],
+        packs: vec!["kg".to_string()],
         ..RuntimeConfig::default()
     };
     let config = runtime_config_from_khive_config(&khive_cfg, base);


### PR DESCRIPTION
Test-only runtime construction in khive-mcp passed `packs: None` and so inherited `KHIVE_PACKS` from the ambient environment; a value naming packs this distribution does not build failed the suite on pack-load errors unrelated to the code under test.

Test fixtures now pin the `kg` pack explicitly through a shared helper (`kg_test_packs`) in serve.rs, the pending-events fixture, and the engine-configuration integration fixture. Production pack resolution is unchanged; no test mutates process environment.

Verified red-to-green: with `KHIVE_PACKS=kg,gtd,bogus` exported, `pending_events::tests::dispatch_action_rejects_non_literal_prev_reference` failed with a pack-load error before the change and passes after; the suite passes with the variable unset and set.

Closes #1269

🤖 Generated with [Claude Code](https://claude.com/claude-code)
