### PR TITLE
feat(perf): guard flagship manifest against unavailable operations; add benchmark evidence protocol

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,9 @@ The `kg` pack loads by default, giving **19 verbs** out of the box (regenerate w
 
 Task management, memory recall, inter-agent messaging, scheduling, session continuity,
 workspace linking, and blob storage are provided by commercially licensed extensions and
-are not part of the open-source distribution.
+are not part of the open-source distribution. Git provenance ingestion and write verbs,
+along with the code-quality and formal-methods ontology packs, are likewise distributed as
+commercially licensed extensions.
 
 `create`, `list`, `search` take `kind=entity|note` (or `kind=edge` for `list`).
 `get`, `update`, `delete`, `merge` are UUID-only: they auto-detect the record type.
@@ -173,7 +175,8 @@ The speedups over exhaustive search implied by these latencies (89x at 100K, 153
 at 1M) are computed against a back-derived brute-force baseline rather than a directly measured
 one (see [#167](https://github.com/ohdearquant/khive/issues/167)); treat them as indicative, not
 as a measured headline figure. The benchmark harness lives in `perf/`; raw data is in
-[`perf/ledger.csv`](perf/ledger.csv).
+[`perf/ledger.csv`](perf/ledger.csv). New latency and throughput claims used as decision evidence
+must follow the [cache-state and warm-up protocol](scripts/perf/README.md#benchmark-evidence-protocol).
 
 ---
 

--- a/docs/guide/api-reference.md
+++ b/docs/guide/api-reference.md
@@ -30,7 +30,8 @@ provided by commercially licensed extensions and are not part of this distributi
 installed, they load the same way, via `KHIVE_PACKS`/`--pack`. Git provenance ingestion
 (`git.digest`, the `commit`/`issue`/`pull_request` note kinds) and the `git.commit` /
 `git.branch` / `git.push` write verbs (ADR-108) are likewise a commercially licensed
-extension.
+extension. The code-quality and formal-methods ontology packs are also distributed as
+commercially licensed extensions rather than as part of this repository.
 
 The default binary (no `KHIVE_PACKS`/`--pack` override) loads the `kg` pack: **19 verbs**.
 

--- a/marketplace/khive/README.md
+++ b/marketplace/khive/README.md
@@ -49,7 +49,8 @@ workspace linking, blob storage, and brain profiles (`brain.*` verbs — Bayesia
 recall-tuning) are provided by commercially licensed extensions and are not part of this
 distribution; this plugin ships a pattern skill only for `kg`. Git provenance ingestion and
 write verbs (`git.digest`, `git.commit`, `git.branch`, `git.push`) are likewise a
-commercially licensed extension.
+commercially licensed extension. Code-quality and formal-methods ontology packs are also
+commercially licensed extensions and are not included in this plugin.
 See [INSTALL.md](../INSTALL.md) for setup, the actor config, and the smoke test.
 
 ## Links

--- a/perf/README.md
+++ b/perf/README.md
@@ -3,6 +3,12 @@
 This directory holds the machine-generated performance record for khive-vamana's
 approximate nearest-neighbour (ANN) engine.
 
+Ledger rows become decision evidence only when their run follows the
+[benchmark evidence protocol](../scripts/perf/README.md#benchmark-evidence-protocol),
+including pre-registered cache-state labels and a warm-up boundary. Older rows
+without that provenance remain historical observations and must not be pooled
+with protocol-compliant samples.
+
 ## Directory contents
 
 | File | Purpose |

--- a/scripts/perf/README.md
+++ b/scripts/perf/README.md
@@ -4,6 +4,53 @@ See `perf/README.md` for the Vamana scale-proof ledger (`perf/ledger.csv`).
 This file documents the trend-tracking tooling: `bench_track.py`,
 `publish_ledger.sh`, and the `bench-track.yml` CI workflow.
 
+## Benchmark evidence protocol
+
+Any latency or throughput result used as decision evidence in an issue, pull
+request, or design record must link to a measurement plan written before the
+run. The plan and result must use the same cache-state labels and warm-up
+boundary.
+
+### Cache states and warm-up
+
+Pre-register every state that will be measured and the procedure that
+establishes it. Treat cache state as a vector rather than a single `cold` or
+`warm` flag:
+
+- **Cold start:** state whether the process is new, which application caches
+  begin empty, and whether model or index initialization is included in the
+  timed interval.
+- **Warm process:** state the initialization or request sequence that makes
+  the process resident before measurement.
+- **SQLite cache:** state whether each sample uses a new connection or a warm
+  connection and how the SQLite page-cache condition is established.
+- **OS page cache:** state how the filesystem-cache condition is established.
+  If the runner cannot reliably establish a cold OS cache, report that state
+  as uncontrolled rather than calling it cold.
+
+Declare the warm-up boundary before measuring: the exact number of discarded
+requests, elapsed-time rule, or observable readiness condition. Only samples
+collected after that boundary are measurement samples. Preserve the cache-state
+label on every sample or on an unambiguous enclosing run record.
+
+### Analysis and isolation
+
+Report each cache-state vector independently. Never pool samples across cache
+states, and compute confidence intervals only from post-warm-up samples with
+the same state label. If a required state has too few samples, report it as
+insufficient rather than merging it with another state.
+
+The exclusive benchmark window and an isolated build directory remain
+required for decision evidence. They control resource contention and build
+interference; they do not establish application, SQLite, or OS cache state.
+
+### Write workloads
+
+In addition to the cache protocol, pre-register and report the offered and
+achieved write rate, overflow or backpressure policy, residency mode, vector
+dimensionality, and every tail-cap parameter. A write-workload result missing
+any of these fields is exploratory, not decision evidence.
+
 ## Trend ledger (`bench_track.py`)
 
 `bench_track.py` is a stdlib-only companion to `bench_calibrate.py`. Where

--- a/scripts/perf/coverage_validator.py
+++ b/scripts/perf/coverage_validator.py
@@ -220,16 +220,23 @@ def load_manifest(path: pathlib.Path) -> tuple[dict, list[str]]:
                 f"{label}: invalid feature {sc['feature']!r} (expected one of {flagship_schema.MANIFEST_FEATURES})"
             )
 
-        if sc["surface"] not in flagship_schema.SURFACES:
-            errors.append(f"{label}: invalid surface {sc['surface']!r} (expected one of {flagship_schema.SURFACES})")
+        surface = sc["surface"]
+        operation = sc["operation"]
+        if not isinstance(surface, str):
+            errors.append(f"{label}: surface must be a string, got {type(surface).__name__}: {surface!r}")
+        elif surface not in flagship_schema.SURFACES:
+            errors.append(f"{label}: invalid surface {surface!r} (expected one of {flagship_schema.SURFACES})")
 
-        available_operations = AVAILABLE_OPERATIONS_BY_SURFACE.get(sc["surface"])
-        if available_operations is not None and sc["operation"] not in available_operations:
-            available = ", ".join(sorted(available_operations)) or "none"
-            errors.append(
-                f"{label}: operation is not available on {sc['surface']}: {sc['operation']!r} "
-                f"(available: {available})"
-            )
+        if not isinstance(operation, str):
+            errors.append(f"{label}: operation must be a string, got {type(operation).__name__}: {operation!r}")
+        elif isinstance(surface, str):
+            available_operations = AVAILABLE_OPERATIONS_BY_SURFACE.get(surface)
+            if available_operations is not None and operation not in available_operations:
+                available = ", ".join(sorted(available_operations)) or "none"
+                errors.append(
+                    f"{label}: operation is not available on {surface}: {operation!r} "
+                    f"(available: {available})"
+                )
 
         if sc["embedder"] not in flagship_schema.EMBEDDERS:
             errors.append(f"{label}: invalid embedder {sc['embedder']!r} (expected one of {flagship_schema.EMBEDDERS})")

--- a/scripts/perf/coverage_validator.py
+++ b/scripts/perf/coverage_validator.py
@@ -117,6 +117,34 @@ FRESHNESS_DAYS_HOSTED = 7
 FRESHNESS_DAYS_SELF_HOSTED = 14
 HOSTED_RUNNER_CLASSES = {"hosted_hash"}
 
+AVAILABLE_OPERATIONS_BY_SURFACE = {
+    "mcp_daemon": frozenset(
+        {
+            "context",
+            "create",
+            "delete",
+            "get",
+            "link",
+            "list",
+            "merge",
+            "neighbors",
+            "propose",
+            "query",
+            "resolve",
+            "review",
+            "search",
+            "stats",
+            "traverse",
+            "update",
+            "verbs",
+            "whoami",
+            "withdraw",
+        }
+    ),
+    "admin_cli": frozenset(),
+    "raw_daemon_control": frozenset({"probe_only"}),
+}
+
 # The manifest declares no `manifest_version`/`manifest_hash` field of its
 # own (checked: `flagship_workloads.toml` has no such key), so the current
 # manifest's identity is derived here rather than read - MANIFEST_VERSION is
@@ -153,9 +181,10 @@ class ManifestError(Exception):
 def load_manifest(path: pathlib.Path) -> tuple[dict, list[str]]:
     """Parse and structurally validate the manifest. Returns (data, errors).
     `errors` is non-empty for duplicate scenario_ids, invalid `surface`
-    values, malformed `fixture_hash` values, or missing required fields -
-    the manifest is still returned (best-effort) so callers can inspect
-    what did parse even when validation flags a problem.
+    values, operations unavailable on their declared surface, malformed
+    `fixture_hash` values, or missing required fields - the manifest is still
+    returned (best-effort) so callers can inspect what did parse even when
+    validation flags a problem.
     """
     with path.open("rb") as fh:
         data = tomllib.load(fh)
@@ -193,6 +222,14 @@ def load_manifest(path: pathlib.Path) -> tuple[dict, list[str]]:
 
         if sc["surface"] not in flagship_schema.SURFACES:
             errors.append(f"{label}: invalid surface {sc['surface']!r} (expected one of {flagship_schema.SURFACES})")
+
+        available_operations = AVAILABLE_OPERATIONS_BY_SURFACE.get(sc["surface"])
+        if available_operations is not None and sc["operation"] not in available_operations:
+            available = ", ".join(sorted(available_operations)) or "none"
+            errors.append(
+                f"{label}: operation is not available on {sc['surface']}: {sc['operation']!r} "
+                f"(available: {available})"
+            )
 
         if sc["embedder"] not in flagship_schema.EMBEDDERS:
             errors.append(f"{label}: invalid embedder {sc['embedder']!r} (expected one of {flagship_schema.EMBEDDERS})")
@@ -573,7 +610,7 @@ def main(argv: list[str] | None = None) -> int:
         "--strict",
         action="store_true",
         help="exit nonzero if the manifest itself fails structural validation "
-        "(duplicate ids, invalid enums, malformed fixture hashes, missing fields)",
+        "(duplicate ids, invalid enums, unavailable operations, malformed fixture hashes, missing fields)",
     )
     args = ap.parse_args(argv)
 

--- a/scripts/perf/test_flagship_coverage.py
+++ b/scripts/perf/test_flagship_coverage.py
@@ -12,6 +12,7 @@ import datetime
 import hashlib
 import json
 import pathlib
+import re
 import tempfile
 import unittest
 
@@ -19,6 +20,7 @@ import coverage_validator
 import flagship_schema
 
 MANIFEST_PATH = pathlib.Path(__file__).parent / "flagship_workloads.toml"
+KG_HANDLER_DEFS_PATH = pathlib.Path(__file__).parents[2] / "crates" / "khive-pack-kg" / "src" / "handler_defs.rs"
 
 
 def _base_scenario(**overrides) -> dict:
@@ -106,6 +108,18 @@ class ManifestTests(unittest.TestCase):
         data, errors = coverage_validator.load_manifest(MANIFEST_PATH)
         self.assertEqual(errors, [])
         self.assertGreater(len(data["scenario"]), 0)
+
+    def test_mcp_operation_allowlist_matches_shipped_kg_handlers(self):
+        handler_names = set(
+            re.findall(
+                r'HandlerDef\s*\{\s*name:\s*"([^"]+)"',
+                KG_HANDLER_DEFS_PATH.read_text(),
+            )
+        )
+        self.assertEqual(
+            coverage_validator.AVAILABLE_OPERATIONS_BY_SURFACE["mcp_daemon"],
+            handler_names,
+        )
 
     def test_every_feature_has_at_least_one_scenario(self):
         data, _ = coverage_validator.load_manifest(MANIFEST_PATH)
@@ -248,6 +262,37 @@ class ManifestTests(unittest.TestCase):
             path = self._write_manifest(pathlib.Path(tmp), [_base_scenario(surface="local_dispatch")])
             _, errors = coverage_validator.load_manifest(path)
             self.assertTrue(any("invalid surface" in e for e in errors), errors)
+
+    def test_unknown_mcp_operation_is_flagged(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = self._write_manifest(
+                pathlib.Path(tmp),
+                [
+                    _base_scenario(
+                        scenario_id="f2.removed.command.warm",
+                        feature="F2",
+                        operation="removed.command",
+                    )
+                ],
+            )
+            _, errors = coverage_validator.load_manifest(path)
+            self.assertTrue(any("operation is not available on mcp_daemon" in e for e in errors), errors)
+
+    def test_removed_code_ingest_cli_is_flagged(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = self._write_manifest(
+                pathlib.Path(tmp),
+                [
+                    _base_scenario(
+                        scenario_id="f6.code_ingest.cli.production",
+                        feature="F6",
+                        surface="admin_cli",
+                        operation="kkernel code-ingest",
+                    )
+                ],
+            )
+            _, errors = coverage_validator.load_manifest(path)
+            self.assertTrue(any("operation is not available on admin_cli" in e for e in errors), errors)
 
     def test_malformed_fixture_hash_is_flagged(self):
         with tempfile.TemporaryDirectory() as tmp:

--- a/scripts/perf/test_flagship_coverage.py
+++ b/scripts/perf/test_flagship_coverage.py
@@ -8,8 +8,10 @@ Run: python3 -m unittest scripts.perf.test_flagship_coverage -v
 
 from __future__ import annotations
 
+import contextlib
 import datetime
 import hashlib
+import io
 import json
 import pathlib
 import re
@@ -262,6 +264,42 @@ class ManifestTests(unittest.TestCase):
             path = self._write_manifest(pathlib.Path(tmp), [_base_scenario(surface="local_dispatch")])
             _, errors = coverage_validator.load_manifest(path)
             self.assertTrue(any("invalid surface" in e for e in errors), errors)
+
+    def test_non_string_surface_and_operation_are_flagged(self):
+        for field, bad_value, value_type in (
+            ("surface", ["mcp_daemon"], "list"),
+            ("surface", {"name": "mcp_daemon"}, "dict"),
+            ("operation", ["list"], "list"),
+            ("operation", {"name": "list"}, "dict"),
+        ):
+            with self.subTest(field=field, value_type=value_type), tempfile.TemporaryDirectory() as tmp:
+                scenario = _base_scenario(scenario_id="f2.list.warm.real", feature="F2", operation="list")
+                scenario[field] = bad_value
+                path = self._write_manifest(pathlib.Path(tmp), [scenario])
+                _, errors = coverage_validator.load_manifest(path)
+                self.assertEqual(len(errors), 1, errors)
+                self.assertTrue(
+                    any(field in error and value_type in error for error in errors),
+                    errors,
+                )
+
+    def test_strict_reports_non_string_surface_and_operation(self):
+        for field, bad_value, value_type in (
+            ("surface", ["mcp_daemon"], "list"),
+            ("surface", {"name": "mcp_daemon"}, "dict"),
+            ("operation", ["list"], "list"),
+            ("operation", {"name": "list"}, "dict"),
+        ):
+            with self.subTest(field=field, value_type=value_type), tempfile.TemporaryDirectory() as tmp:
+                scenario = _base_scenario(scenario_id="f2.list.warm.real", feature="F2", operation="list")
+                scenario[field] = bad_value
+                path = self._write_manifest(pathlib.Path(tmp), [scenario])
+                stderr = io.StringIO()
+                with contextlib.redirect_stderr(stderr):
+                    exit_code = coverage_validator.main(["--manifest", str(path), "--strict"])
+                self.assertEqual(exit_code, 1)
+                self.assertIn(field, stderr.getvalue())
+                self.assertIn(value_type, stderr.getvalue())
 
     def test_unknown_mcp_operation_is_flagged(self):
         with tempfile.TemporaryDirectory() as tmp:


### PR DESCRIPTION
Two related evidence-quality improvements around the perf surface.

**Manifest guard (#1206).** The flagship manifest validator accepted scenarios naming operations no shipped surface provides, so a manifest could reference removed functionality and still validate. Structural validation now checks each scenario's operation against per-surface allowlists (the 19 MCP verbs of the default distribution, the admin CLI, raw daemon control) and rejects unavailable operations with an explicit error; the removed code-ingest operation is rejected by name. Boundary text in the README, API reference, and plugin README now names the ontology packs distributed as commercial extensions, matching the pack list the binary actually ships.

**Benchmark evidence protocol (#1175).** Latency and throughput claims used as decision evidence must now follow a documented protocol: pre-registered cache-state vectors (process, application caches, SQLite page cache, index residency), an explicit warm-up boundary, per-state reporting with confidence intervals, isolation evidence, and write-workload parameters. The perf ledger README marks pre-protocol rows as historical observations not to be pooled with compliant samples.

Tests: validator suite extended to 97 tests covering the new unavailable-operation errors and strict-mode diagnostics; all pass.

Closes #1206
Closes #1175

🤖 Generated with [Claude Code](https://claude.com/claude-code)
