### PR TITLE
feat(kkernel): embeds-only reindex repair mode and newer-store diagnostic

### DIFF
--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -1968,6 +1968,7 @@ dependencies = [
  "khive-vcs-adapters",
  "lattice-embed",
  "rmcp",
+ "rusqlite",
  "serde",
  "serde_json",
  "serial_test",

--- a/crates/khive-db/src/error.rs
+++ b/crates/khive-db/src/error.rs
@@ -25,4 +25,17 @@ pub enum SqliteError {
         /// Human-readable description of the failure.
         error: String,
     },
+
+    /// The store was migrated by a newer binary and cannot be downgraded in place.
+    #[error(
+        "this binary knows migrations up to {max_known_migration} but the store is at version \
+         {store_version} — the binary is older than the store; upgrade the binary (in-place \
+         downgrade is not supported)"
+    )]
+    SchemaTooNew {
+        /// Highest migration version this binary can apply.
+        max_known_migration: u32,
+        /// Migration version recorded by the store.
+        store_version: u32,
+    },
 }

--- a/crates/khive-db/src/lib.rs
+++ b/crates/khive-db/src/lib.rs
@@ -33,8 +33,9 @@ pub use checkpoint::{checkpoint_once, run_checkpoint_task, CheckpointConfig, Che
 pub use checkpoint::{run_session_sweep_task, SessionSweepConfig, SweepBackend};
 pub use error::SqliteError;
 pub use migrations::{
-    inspect_schema_version, query_embedding_models, read_schema_version, run_migrations,
-    EmbeddingModelRegistryRecord, Migration, ServiceSchemaPlan, VersionedMigration, MIGRATIONS,
+    inspect_schema, inspect_schema_version, query_embedding_models, read_schema_version,
+    run_migrations, EmbeddingModelRegistryRecord, Migration, SchemaInspection, ServiceSchemaPlan,
+    VersionedMigration, MIGRATIONS,
 };
 pub use pool::{ConnectionPool, PoolConfig, ReaderGuard, WriterGuard};
 pub use sql_bridge::SqlBridge;

--- a/crates/khive-db/src/migrations.rs
+++ b/crates/khive-db/src/migrations.rs
@@ -331,18 +331,14 @@ fn run_migrations_locked(conn: &mut Connection) -> Result<u32, SqliteError> {
     }
 
     // A database whose recorded version is ahead of the latest known migration
-    // predates the consolidated V1 baseline (ADR-015) — e.g. it still carries the
-    // pre-consolidation V2..V22 ledger — or was written by a newer build. Either
-    // way the baseline schema would be silently skipped, leaving the process on a
-    // stale schema. Fail loudly instead of corrupting silently.
+    // was written by a newer build. Running this binary would silently skip
+    // unknown schema changes, so fail with the upgrade action instead.
     let latest_version = MIGRATIONS.last().map(|m| m.version).unwrap_or(0);
     if current_version > latest_version {
-        return Err(SqliteError::InvalidData(format!(
-            "database schema version {current_version} is ahead of the latest known migration \
-             {latest_version}. This database predates the consolidated baseline (ADR-015) or was \
-             written by a newer build. Recreate it from the current schema; in-place downgrade is \
-             not supported."
-        )));
+        return Err(SqliteError::SchemaTooNew {
+            max_known_migration: latest_version,
+            store_version: current_version,
+        });
     }
 
     let mut applied_version = current_version;
@@ -415,12 +411,10 @@ fn run_migrations_locked(conn: &mut Connection) -> Result<u32, SqliteError> {
         // the write lock. Accepting it (clamped) would return Ok on a schema
         // this binary does not understand — reject it the same way.
         if sibling_version > latest_version {
-            return Err(SqliteError::InvalidData(format!(
-                "database schema version {sibling_version} is ahead of the latest known \
-                 migration {latest_version} (committed by a concurrent process while this \
-                 one waited for the migration write lock). This build cannot run against \
-                 the newer schema; upgrade the binary or recreate the database."
-            )));
+            return Err(SqliteError::SchemaTooNew {
+                max_known_migration: latest_version,
+                store_version: sibling_version,
+            });
         }
 
         if sibling_version >= migration.version {

--- a/crates/khive-db/src/migrations.rs
+++ b/crates/khive-db/src/migrations.rs
@@ -212,6 +212,34 @@ pub const MIGRATIONS: &[VersionedMigration] = &[
 
 const MIGRATION_TRACKING_TABLE: &str = include_str!("../sql/schema-migrations-table.sql");
 
+fn validate_schema_compatibility(
+    conn: &Connection,
+    store_version: u32,
+    max_known_migration: u32,
+) -> Result<(), SqliteError> {
+    // V1 used the same name in both lineages; the historical V2 and V22 names
+    // are unambiguous signals that this ledger predates consolidation.
+    let pre_consolidation: bool = conn.query_row(
+        "SELECT EXISTS(SELECT 1 FROM _schema_migrations \
+         WHERE (version = 2 AND name = ?1) OR (version = 22 AND name = ?2))",
+        ["add_name_to_notes", "knowledge_lifecycle_status"],
+        |row| row.get(0),
+    )?;
+    if pre_consolidation {
+        return Err(SqliteError::InvalidData(format!(
+            "database schema version {store_version} predates the consolidated baseline; \
+             recreate it from the current schema because in-place upgrade is not supported."
+        )));
+    }
+    if store_version > max_known_migration {
+        return Err(SqliteError::SchemaTooNew {
+            max_known_migration,
+            store_version,
+        });
+    }
+    Ok(())
+}
+
 /// Apply all unapplied migrations in order. Idempotent; each migration runs in its own transaction.
 /// Errors on non-contiguous version array or failed migration.
 /// Read the applied schema version from an open connection **without** running
@@ -330,16 +358,8 @@ fn run_migrations_locked(conn: &mut Connection) -> Result<u32, SqliteError> {
         }
     }
 
-    // A database whose recorded version is ahead of the latest known migration
-    // was written by a newer build. Running this binary would silently skip
-    // unknown schema changes, so fail with the upgrade action instead.
     let latest_version = MIGRATIONS.last().map(|m| m.version).unwrap_or(0);
-    if current_version > latest_version {
-        return Err(SqliteError::SchemaTooNew {
-            max_known_migration: latest_version,
-            store_version: current_version,
-        });
-    }
+    validate_schema_compatibility(conn, current_version, latest_version)?;
 
     let mut applied_version = current_version;
     // Floor advanced when a sibling's work is observed under the write lock,
@@ -406,16 +426,9 @@ fn run_migrations_locked(conn: &mut Connection) -> Result<u32, SqliteError> {
             }
         }
 
-        // The ahead-of-latest guard above ran on a pre-lock read; a newer
-        // build may have committed a version past ours while we waited for
-        // the write lock. Accepting it (clamped) would return Ok on a schema
-        // this binary does not understand — reject it the same way.
-        if sibling_version > latest_version {
-            return Err(SqliteError::SchemaTooNew {
-                max_known_migration: latest_version,
-                store_version: sibling_version,
-            });
-        }
+        // The first guard ran before the write lock; re-check both lineage and
+        // version in case another process advanced the ledger while we waited.
+        validate_schema_compatibility(&tx, sibling_version, latest_version)?;
 
         if sibling_version >= migration.version {
             #[cfg(test)]

--- a/crates/khive-db/src/migrations.rs
+++ b/crates/khive-db/src/migrations.rs
@@ -212,20 +212,33 @@ pub const MIGRATIONS: &[VersionedMigration] = &[
 
 const MIGRATION_TRACKING_TABLE: &str = include_str!("../sql/schema-migrations-table.sql");
 
+/// Read-only schema metadata used by administrative diagnostics.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SchemaInspection {
+    /// Highest version recorded in the migration ledger.
+    pub version: u32,
+    /// Whether the ledger belongs to the pre-consolidation migration lineage.
+    pub pre_consolidation: bool,
+}
+
+fn is_pre_consolidation_ledger(conn: &Connection) -> Result<bool, SqliteError> {
+    // V1 used the same name in both lineages; the historical V2 and V22 names
+    // are unambiguous signals that this ledger predates consolidation.
+    conn.query_row(
+        "SELECT EXISTS(SELECT 1 FROM _schema_migrations \
+         WHERE (version = 2 AND name = ?1) OR (version = 22 AND name = ?2))",
+        ["add_name_to_notes", "knowledge_lifecycle_status"],
+        |row| row.get(0),
+    )
+    .map_err(Into::into)
+}
+
 fn validate_schema_compatibility(
     conn: &Connection,
     store_version: u32,
     max_known_migration: u32,
 ) -> Result<(), SqliteError> {
-    // V1 used the same name in both lineages; the historical V2 and V22 names
-    // are unambiguous signals that this ledger predates consolidation.
-    let pre_consolidation: bool = conn.query_row(
-        "SELECT EXISTS(SELECT 1 FROM _schema_migrations \
-         WHERE (version = 2 AND name = ?1) OR (version = 22 AND name = ?2))",
-        ["add_name_to_notes", "knowledge_lifecycle_status"],
-        |row| row.get(0),
-    )?;
-    if pre_consolidation {
+    if is_pre_consolidation_ledger(conn)? {
         return Err(SqliteError::InvalidData(format!(
             "database schema version {store_version} predates the consolidated baseline; \
              recreate it from the current schema because in-place upgrade is not supported."
@@ -273,6 +286,21 @@ pub fn inspect_schema_version(path: &std::path::Path) -> Result<u32, SqliteError
         rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY | rusqlite::OpenFlags::SQLITE_OPEN_NO_MUTEX,
     )?;
     read_schema_version(&conn)
+}
+
+/// Open `path` read-only and inspect both its applied version and migration lineage.
+/// An absent migration ledger is reported as version 0 in the consolidated lineage.
+pub fn inspect_schema(path: &std::path::Path) -> Result<SchemaInspection, SqliteError> {
+    let conn = Connection::open_with_flags(
+        path,
+        rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY | rusqlite::OpenFlags::SQLITE_OPEN_NO_MUTEX,
+    )?;
+    let version = read_schema_version(&conn)?;
+    let pre_consolidation = version > 0 && is_pre_consolidation_ledger(&conn)?;
+    Ok(SchemaInspection {
+        version,
+        pre_consolidation,
+    })
 }
 
 #[cfg(test)]

--- a/crates/khive-db/src/migrations.rs
+++ b/crates/khive-db/src/migrations.rs
@@ -224,13 +224,33 @@ pub struct SchemaInspection {
 fn is_pre_consolidation_ledger(conn: &Connection) -> Result<bool, SqliteError> {
     // V1 used the same name in both lineages; the historical V2 and V22 names
     // are unambiguous signals that this ledger predates consolidation.
-    conn.query_row(
+    let has_legacy_name: bool = conn.query_row(
         "SELECT EXISTS(SELECT 1 FROM _schema_migrations \
          WHERE (version = 2 AND name = ?1) OR (version = 22 AND name = ?2))",
         ["add_name_to_notes", "knowledge_lifecycle_status"],
         |row| row.get(0),
-    )
-    .map_err(Into::into)
+    )?;
+    if has_legacy_name {
+        return Ok(true);
+    }
+
+    let highest_version: u32 = conn.query_row(
+        "SELECT COALESCE(MAX(version), 0) FROM _schema_migrations",
+        [],
+        |row| row.get(0),
+    )?;
+    if highest_version != 1 {
+        return Ok(false);
+    }
+
+    // Consolidated V1 includes the event-kind discriminator; historical V1
+    // did not gain it until a later migration in the retired lineage.
+    let has_consolidated_v1_shape: bool = conn.query_row(
+        "SELECT EXISTS(SELECT 1 FROM pragma_table_info('events') WHERE name = 'kind')",
+        [],
+        |row| row.get(0),
+    )?;
+    Ok(!has_consolidated_v1_shape)
 }
 
 fn validate_schema_compatibility(

--- a/crates/khive-db/src/migrations_tests.rs
+++ b/crates/khive-db/src/migrations_tests.rs
@@ -114,6 +114,68 @@ fn pre_consolidation_store_reports_recreation_action() {
 }
 
 #[test]
+fn legacy_v1_only_store_reports_recreation_before_current_v2() {
+    let mut conn = open_memory();
+    conn.execute_batch(
+        "CREATE TABLE events (\
+             id TEXT PRIMARY KEY,\
+             namespace TEXT NOT NULL,\
+             verb TEXT NOT NULL,\
+             substrate TEXT NOT NULL,\
+             actor TEXT NOT NULL,\
+             outcome TEXT NOT NULL,\
+             data TEXT,\
+             duration_us INTEGER NOT NULL DEFAULT 0,\
+             target_id TEXT,\
+             created_at INTEGER NOT NULL\
+         );",
+    )
+    .expect("create legacy V1 schema marker");
+    conn.execute_batch(MIGRATION_TRACKING_TABLE).unwrap();
+    conn.execute(
+        "INSERT INTO _schema_migrations (version, name, applied_at) \
+         VALUES (1, 'initial_schema', 0)",
+        [],
+    )
+    .unwrap();
+
+    let err = run_migrations(&mut conn).expect_err("legacy V1 must require recreation");
+    let SqliteError::InvalidData(message) = err else {
+        panic!("expected legacy-schema InvalidData diagnostic, got {err:?}");
+    };
+    assert!(
+        message.contains("predates the consolidated baseline"),
+        "{message}"
+    );
+    assert!(message.contains("recreate"), "{message}");
+    assert_eq!(
+        read_schema_version(&conn).expect("read unchanged ledger"),
+        1,
+        "the current V2 migration must not run"
+    );
+}
+
+#[test]
+fn consolidated_v1_only_store_migrates_normally() {
+    let mut conn = open_memory();
+    conn.execute_batch(MIGRATION_TRACKING_TABLE).unwrap();
+    conn.execute_batch(MIGRATIONS[0].up)
+        .expect("apply consolidated V1 schema");
+    conn.execute(
+        "INSERT INTO _schema_migrations (version, name, applied_at) \
+         VALUES (1, 'initial_schema', 0)",
+        [],
+    )
+    .unwrap();
+
+    let version = run_migrations(&mut conn).expect("consolidated V1 must migrate");
+    assert_eq!(
+        version,
+        MIGRATIONS.last().expect("latest migration").version
+    );
+}
+
+#[test]
 fn core_tables_exist() {
     let mut conn = open_memory();
     run_migrations(&mut conn).expect("migrations");

--- a/crates/khive-db/src/migrations_tests.rs
+++ b/crates/khive-db/src/migrations_tests.rs
@@ -86,6 +86,34 @@ fn newer_store_reports_binary_upgrade_action() {
 }
 
 #[test]
+fn pre_consolidation_store_reports_recreation_action() {
+    let mut conn = open_memory();
+    conn.execute_batch(MIGRATION_TRACKING_TABLE).unwrap();
+    for (version, name) in [
+        (1, "initial_schema"),
+        (2, "add_name_to_notes"),
+        (22, "knowledge_lifecycle_status"),
+    ] {
+        conn.execute(
+            "INSERT INTO _schema_migrations (version, name, applied_at) VALUES (?1, ?2, 0)",
+            rusqlite::params![version, name],
+        )
+        .unwrap();
+    }
+
+    let err = run_migrations(&mut conn).expect_err("must reject a pre-consolidation ledger");
+    let SqliteError::InvalidData(message) = err else {
+        panic!("expected legacy-schema InvalidData diagnostic, got {err:?}");
+    };
+    assert!(
+        message.contains("predates the consolidated baseline"),
+        "{message}"
+    );
+    assert!(message.contains("recreate"), "{message}");
+    assert!(!message.contains("upgrade the binary"), "{message}");
+}
+
+#[test]
 fn core_tables_exist() {
     let mut conn = open_memory();
     run_migrations(&mut conn).expect("migrations");

--- a/crates/khive-db/src/migrations_tests.rs
+++ b/crates/khive-db/src/migrations_tests.rs
@@ -57,24 +57,32 @@ fn v4_creates_consolidated_fts_tables() {
 }
 
 #[test]
-fn rejects_pre_consolidation_ledger() {
+fn newer_store_reports_binary_upgrade_action() {
     let mut conn = open_memory();
-    // Simulate a database carrying the old, pre-consolidation V1..V22 ledger.
+    let latest = MIGRATIONS.last().expect("at least one migration").version;
+    let store_version = latest + 1;
     conn.execute_batch(MIGRATION_TRACKING_TABLE).unwrap();
     conn.execute(
-        "INSERT INTO _schema_migrations (version, name, applied_at) VALUES (22, 'legacy', 0)",
-        [],
+        "INSERT INTO _schema_migrations (version, name, applied_at) VALUES (?1, 'future', 0)",
+        [store_version],
     )
     .unwrap();
 
     let err = run_migrations(&mut conn).expect_err("must reject a version ahead of latest");
-    match err {
-        SqliteError::InvalidData(msg) => assert!(
-            msg.contains("ahead of the latest known migration"),
-            "unexpected message: {msg}"
-        ),
-        other => panic!("expected InvalidData, got {other:?}"),
-    }
+    assert!(matches!(
+        &err,
+        SqliteError::SchemaTooNew {
+            store_version: found,
+            max_known_migration,
+        } if *found == store_version && *max_known_migration == latest
+    ));
+    let message = err.to_string();
+    assert!(
+        message.contains("the binary is older than the store"),
+        "{message}"
+    );
+    assert!(message.contains("upgrade the binary"), "{message}");
+    assert!(!message.contains("recreate"), "{message}");
 }
 
 #[test]
@@ -822,13 +830,11 @@ fn mixed_version_boot_rejects_newer_schema_under_lock() {
         .join()
         .expect("thread join")
         .expect_err("a schema version above latest must be rejected, not clamped");
-    let msg = err.to_string();
-    assert!(
-        msg.contains("ahead of the latest known migration"),
-        "unexpected error: {msg}"
-    );
-    assert!(
-        msg.contains("migration write lock"),
-        "the under-lock guard, not the pre-lock guard, must fire: {msg}"
-    );
+    assert!(matches!(
+        err,
+        SqliteError::SchemaTooNew {
+            store_version,
+            max_known_migration,
+        } if store_version == latest + 1 && max_known_migration == latest
+    ));
 }

--- a/crates/kkernel/Cargo.toml
+++ b/crates/kkernel/Cargo.toml
@@ -46,6 +46,7 @@ tokio = { workspace = true, features = ["test-util"] }
 serial_test = { workspace = true }
 rmcp = { workspace = true, features = ["client", "transport-child-process"] }
 khive-pack-template = { version = "0.6.0", path = "../khive-pack-template" }
+rusqlite = { workspace = true }
 
 [features]
 # Pass-through: enables the deterministic hash embedder in the serve path (bench use only).

--- a/crates/kkernel/src/cli.rs
+++ b/crates/kkernel/src/cli.rs
@@ -553,14 +553,13 @@ async fn cmd_db_check(args: DbCheckArgs) -> Result<()> {
     };
 
     let is_current = current_version == latest;
-    // A version beyond the latest known migration is a stale ledger: the database
-    // predates the consolidated V1 baseline (ADR-015) or was written by a newer
-    // build. Report it rather than treating it as current.
+    // A version beyond the latest known migration was written by a newer build.
+    // Report it rather than treating it as current.
     let ahead = current_version > latest;
 
     if args.human {
         let state = if ahead {
-            "ahead — predates the consolidated baseline (ADR-015) or written by a newer build; recreate it"
+            "ahead — the binary is older than the store; upgrade the binary"
         } else if is_current {
             "current"
         } else {
@@ -581,9 +580,9 @@ async fn cmd_db_check(args: DbCheckArgs) -> Result<()> {
     if args.strict && !is_current {
         if ahead {
             anyhow::bail!(
-                "schema version {current_version} is ahead of the latest known migration {latest} — \
-                 this database predates the consolidated baseline (ADR-015) or was written by a newer \
-                 build; recreate it from the current schema"
+                "this binary knows migrations up to {latest} but the store is at version \
+                 {current_version} — the binary is older than the store; upgrade the binary \
+                 (in-place downgrade is not supported)"
             );
         }
         anyhow::bail!(

--- a/crates/kkernel/src/cli.rs
+++ b/crates/kkernel/src/cli.rs
@@ -531,6 +531,9 @@ async fn cmd_db_migrate(args: DbMigrateArgs) -> Result<()> {
 }
 
 async fn cmd_db_check(args: DbCheckArgs) -> Result<()> {
+    const RECREATION_GUIDANCE: &str =
+        "predates the consolidated baseline; recreate it from the current schema because \
+         in-place upgrade is not supported";
     let latest = khive_db::MIGRATIONS.len() as u32;
 
     // A schema check must never mutate the database. Resolve the effective path
@@ -545,20 +548,23 @@ async fn cmd_db_check(args: DbCheckArgs) -> Result<()> {
     };
 
     // An absent file is an un-migrated database (version 0); do not create it.
-    let current_version: u32 = match resolved {
+    let (current_version, pre_consolidation) = match resolved {
         Some(ref p) if p.exists() => {
-            khive_db::inspect_schema_version(p).map_err(|e| anyhow::anyhow!("{e}"))?
+            let inspection = khive_db::inspect_schema(p).map_err(|e| anyhow::anyhow!("{e}"))?;
+            (inspection.version, inspection.pre_consolidation)
         }
-        _ => 0,
+        _ => (0, false),
     };
 
-    let is_current = current_version == latest;
+    let is_current = current_version == latest && !pre_consolidation;
     // A version beyond the latest known migration was written by a newer build.
     // Report it rather than treating it as current.
-    let ahead = current_version > latest;
+    let ahead = current_version > latest && !pre_consolidation;
 
     if args.human {
-        let state = if ahead {
+        let state = if pre_consolidation {
+            RECREATION_GUIDANCE
+        } else if ahead {
             "ahead — the binary is older than the store; upgrade the binary"
         } else if is_current {
             "current"
@@ -573,11 +579,16 @@ async fn cmd_db_check(args: DbCheckArgs) -> Result<()> {
             "current": is_current,
             "ahead": ahead,
             "pending": latest.saturating_sub(current_version),
+            "recreation_required": pre_consolidation,
+            "guidance": pre_consolidation.then_some(RECREATION_GUIDANCE),
         });
         println!("{}", serde_json::to_string(&json).expect("serialize"));
     }
 
     if args.strict && !is_current {
+        if pre_consolidation {
+            anyhow::bail!("database schema version {current_version} {RECREATION_GUIDANCE}");
+        }
         if ahead {
             anyhow::bail!(
                 "this binary knows migrations up to {latest} but the store is at version \

--- a/crates/kkernel/src/reindex.rs
+++ b/crates/kkernel/src/reindex.rs
@@ -426,6 +426,7 @@ async fn missing_embedding_batch(
     rt: &KhiveRuntime,
     namespace: &str,
     vector_table: &str,
+    embedding_model: &str,
     kind: SubstrateKind,
     after: &str,
     limit: u32,
@@ -446,8 +447,9 @@ async fn missing_embedding_batch(
          WHERE base.namespace = ?1 AND base.deleted_at IS NULL AND base.id > ?2 \
          AND {text_predicate} \
          AND NOT EXISTS (SELECT 1 FROM {vector_table} AS vectors \
-             WHERE vectors.subject_id = base.id AND vectors.namespace = ?1) \
-         ORDER BY base.id LIMIT ?3"
+             WHERE vectors.subject_id = base.id AND vectors.namespace = ?1 \
+             AND vectors.embedding_model = ?3) \
+         ORDER BY base.id LIMIT ?4"
     );
     let rows = {
         let mut reader = rt
@@ -461,6 +463,7 @@ async fn missing_embedding_batch(
                 params: vec![
                     SqlValue::Text(namespace.to_string()),
                     SqlValue::Text(after.to_string()),
+                    SqlValue::Text(embedding_model.to_string()),
                     SqlValue::Integer(i64::from(limit)),
                 ],
                 label: Some("reindex_missing_embeddings".into()),
@@ -517,6 +520,10 @@ async fn repair_missing_embeddings(
             .await
             .with_context(|| format!("inspect vector store for model {model_name}"))?;
         let vector_table = vector_table_name(&info.model_name)?;
+        let embedding_model = rt
+            .resolve_embedding_model(Some(model_name))
+            .map(|model| model.to_string())
+            .unwrap_or_else(|_| model_name.clone());
 
         for (kind, field) in [
             (SubstrateKind::Entity, "entity.body"),
@@ -524,9 +531,16 @@ async fn repair_missing_embeddings(
         ] {
             let mut after = String::new();
             loop {
-                let batch =
-                    missing_embedding_batch(rt, namespace, &vector_table, kind, &after, batch_size)
-                        .await?;
+                let batch = missing_embedding_batch(
+                    rt,
+                    namespace,
+                    &vector_table,
+                    &embedding_model,
+                    kind,
+                    &after,
+                    batch_size,
+                )
+                .await?;
                 let Some((last_id, _)) = batch.last() else {
                     break;
                 };
@@ -1159,12 +1173,14 @@ mod tests {
         }
     }
 
-    struct RepairEmbedderProvider;
+    struct RepairEmbedderProvider {
+        model_name: &'static str,
+    }
 
     #[async_trait::async_trait]
     impl khive_runtime::EmbedderProvider for RepairEmbedderProvider {
         fn name(&self) -> &str {
-            REPAIR_MODEL
+            self.model_name
         }
 
         fn dimensions(&self) -> usize {
@@ -1487,9 +1503,10 @@ mod tests {
             .await
             .expect("seed vector");
 
-        let selected = missing_embedding_batch(&rt, "local", TABLE, SubstrateKind::Note, "", 100)
-            .await
-            .expect("select missing notes");
+        let selected =
+            missing_embedding_batch(&rt, "local", TABLE, MODEL, SubstrateKind::Note, "", 100)
+                .await
+                .expect("select missing notes");
 
         assert_eq!(selected, vec![(missing.id, missing.content)]);
     }
@@ -1506,7 +1523,9 @@ mod tests {
             ..RuntimeConfig::default()
         })
         .expect("runtime");
-        rt.register_embedder(RepairEmbedderProvider);
+        rt.register_embedder(RepairEmbedderProvider {
+            model_name: REPAIR_MODEL,
+        });
         let token = rt
             .authorize(Namespace::parse("local").expect("namespace"))
             .expect("authorize");
@@ -1552,6 +1571,78 @@ mod tests {
         assert!(
             matches!(rows[0].get("namespace"), Some(SqlValue::Text(value)) if value == "local"),
             "repair must replace the stale row with the base row namespace"
+        );
+    }
+
+    #[tokio::test]
+    async fn embeds_only_repair_does_not_treat_colliding_model_as_target_embedding() {
+        use khive_runtime::RuntimeConfig;
+        use khive_storage::types::VectorRecord;
+
+        const MODEL_A: &str = "collision-model";
+        const MODEL_B: &str = "collision_model";
+        const TABLE: &str = "vec_collision_model";
+
+        let rt = KhiveRuntime::new(RuntimeConfig {
+            db_path: None,
+            embedding_model: None,
+            additional_embedding_models: vec![],
+            ..RuntimeConfig::default()
+        })
+        .expect("runtime");
+        rt.register_embedder(RepairEmbedderProvider {
+            model_name: MODEL_A,
+        });
+        rt.register_embedder(RepairEmbedderProvider {
+            model_name: MODEL_B,
+        });
+        let token = rt
+            .authorize(Namespace::parse("local").expect("namespace"))
+            .expect("authorize");
+        let note = Note::new("local", "observation", "repair colliding model");
+        rt.notes(&token)
+            .expect("notes")
+            .upsert_note(note.clone())
+            .await
+            .expect("seed note");
+
+        rt.vectors_for_model(&token, MODEL_A)
+            .expect("model A vectors")
+            .insert_batch(vec![VectorRecord {
+                subject_id: note.id,
+                kind: SubstrateKind::Note,
+                namespace: "local".to_string(),
+                field: "note.content".to_string(),
+                embedding_model: Some(MODEL_A.to_string()),
+                vectors: vec![vec![0.1; REPAIR_DIMS]],
+                updated_at: chrono::Utc::now(),
+            }])
+            .await
+            .expect("seed model A vector");
+
+        let result = repair_missing_embeddings(&rt, &token, &[MODEL_B.to_string()], "local", 100)
+            .await
+            .expect("repair model B embeddings");
+        assert_eq!(result, (0, 1, 0));
+
+        let mut reader = rt.sql().reader().await.expect("reader");
+        let rows = reader
+            .query_all(SqlStatement {
+                sql: format!(
+                    "SELECT embedding_model FROM {TABLE} WHERE subject_id = ?1 AND namespace = ?2"
+                ),
+                params: vec![
+                    SqlValue::Text(note.id.to_string()),
+                    SqlValue::Text("local".to_string()),
+                ],
+                label: None,
+            })
+            .await
+            .expect("read repaired vector");
+        assert_eq!(rows.len(), 1, "repair must leave one vector row");
+        assert!(
+            matches!(rows[0].get("embedding_model"), Some(SqlValue::Text(value)) if value == MODEL_B),
+            "repair must replace the colliding model A row with model B"
         );
     }
 

--- a/crates/kkernel/src/reindex.rs
+++ b/crates/kkernel/src/reindex.rs
@@ -5,7 +5,7 @@
 //! FTS index. It is NOT a pack verb — it operates on the raw runtime stores
 //! regardless of which packs are loaded.
 
-use std::collections::HashSet;
+use std::collections::{BTreeMap, BTreeSet, HashSet};
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::Instant;
@@ -500,16 +500,19 @@ async fn missing_embedding_batch(
         .collect()
 }
 
-async fn repair_missing_embeddings(
+struct RepairModelTarget {
+    model_name: String,
+    embedding_model: String,
+    vector_table: String,
+}
+
+async fn prepare_repair_models(
     rt: &KhiveRuntime,
     token: &khive_runtime::NamespaceToken,
     model_names: &[String],
-    namespace: &str,
-    batch_size: u32,
-) -> Result<(u64, u64, u64)> {
-    let mut entities_processed = 0u64;
-    let mut notes_processed = 0u64;
-    let mut errors = 0u64;
+) -> Result<Vec<RepairModelTarget>> {
+    let mut targets = Vec::with_capacity(model_names.len());
+    let mut identities_by_table = BTreeMap::<String, BTreeSet<String>>::new();
 
     for model_name in model_names {
         let vectors = rt
@@ -525,6 +528,43 @@ async fn repair_missing_embeddings(
             .map(|model| model.to_string())
             .unwrap_or_else(|_| model_name.clone());
 
+        identities_by_table
+            .entry(vector_table.clone())
+            .or_default()
+            .insert(embedding_model.clone());
+        targets.push(RepairModelTarget {
+            model_name: model_name.clone(),
+            embedding_model,
+            vector_table,
+        });
+    }
+
+    if let Some((table, identities)) = identities_by_table
+        .into_iter()
+        .find(|(_, identities)| identities.len() > 1)
+    {
+        let identities: Vec<_> = identities.into_iter().collect();
+        anyhow::bail!(
+            "embeds-only repair models {identities:?} share vector table {table:?}; colliding registered model names cannot be repaired or served from one table"
+        );
+    }
+
+    Ok(targets)
+}
+
+async fn repair_missing_embeddings(
+    rt: &KhiveRuntime,
+    token: &khive_runtime::NamespaceToken,
+    model_names: &[String],
+    namespace: &str,
+    batch_size: u32,
+) -> Result<(u64, u64, u64)> {
+    let targets = prepare_repair_models(rt, token, model_names).await?;
+    let mut entities_processed = 0u64;
+    let mut notes_processed = 0u64;
+    let mut errors = 0u64;
+
+    for target in targets {
         for (kind, field) in [
             (SubstrateKind::Entity, "entity.body"),
             (SubstrateKind::Note, "note.content"),
@@ -534,8 +574,8 @@ async fn repair_missing_embeddings(
                 let batch = missing_embedding_batch(
                     rt,
                     namespace,
-                    &vector_table,
-                    &embedding_model,
+                    &target.vector_table,
+                    &target.embedding_model,
                     kind,
                     &after,
                     batch_size,
@@ -549,7 +589,7 @@ async fn repair_missing_embeddings(
                 errors += embed_and_store_batch(
                     rt,
                     token,
-                    std::slice::from_ref(model_name),
+                    std::slice::from_ref(&target.model_name),
                     namespace,
                     &batch,
                     kind,
@@ -1643,6 +1683,66 @@ mod tests {
         assert!(
             matches!(rows[0].get("embedding_model"), Some(SqlValue::Text(value)) if value == MODEL_B),
             "repair must replace the colliding model A row with model B"
+        );
+    }
+
+    #[tokio::test]
+    async fn embeds_only_repair_refuses_colliding_models_before_vector_writes() {
+        use khive_runtime::RuntimeConfig;
+
+        const MODEL_A: &str = "collision-model";
+        const MODEL_B: &str = "collision_model";
+        const TABLE: &str = "vec_collision_model";
+
+        let rt = KhiveRuntime::new(RuntimeConfig {
+            db_path: None,
+            embedding_model: None,
+            additional_embedding_models: vec![],
+            ..RuntimeConfig::default()
+        })
+        .expect("runtime");
+        rt.register_embedder(RepairEmbedderProvider {
+            model_name: MODEL_A,
+        });
+        rt.register_embedder(RepairEmbedderProvider {
+            model_name: MODEL_B,
+        });
+        let token = rt
+            .authorize(Namespace::parse("local").expect("namespace"))
+            .expect("authorize");
+        let note = Note::new("local", "observation", "do not repair colliding models");
+        rt.notes(&token)
+            .expect("notes")
+            .upsert_note(note)
+            .await
+            .expect("seed note");
+        let vectors = rt.vectors_for_model(&token, MODEL_A).expect("vectors");
+        assert_eq!(vectors.count().await.expect("count before repair"), 0);
+
+        let error = repair_missing_embeddings(
+            &rt,
+            &token,
+            &[MODEL_A.to_string(), MODEL_B.to_string()],
+            "local",
+            100,
+        )
+        .await
+        .expect_err("colliding repair models must be refused");
+
+        let message = error.to_string();
+        assert!(message.contains(MODEL_A), "missing first model: {message}");
+        assert!(message.contains(MODEL_B), "missing second model: {message}");
+        assert!(message.contains(TABLE), "missing shared table: {message}");
+        assert!(
+            message.contains(
+                "colliding registered model names cannot be repaired or served from one table"
+            ),
+            "missing refusal rationale: {message}"
+        );
+        assert_eq!(
+            vectors.count().await.expect("count after refusal"),
+            0,
+            "collision refusal must happen before vector writes"
         );
     }
 

--- a/crates/kkernel/src/reindex.rs
+++ b/crates/kkernel/src/reindex.rs
@@ -158,6 +158,11 @@ pub struct ReindexArgs {
     #[arg(long)]
     pub keep_existing: bool,
 
+    /// Repair only missing embeddings. Skips FTS backfill and reads only base
+    /// rows without a vector for each target model.
+    #[arg(long)]
+    pub embeds_only: bool,
+
     /// Namespace to operate on. When omitted, the config file `[actor] id` (if
     /// any) is honored — matching the same precedence as `kkernel mcp`. An
     /// explicit `--namespace` / `KHIVE_NAMESPACE` overrides the config tier.
@@ -406,6 +411,149 @@ async fn filter_unembedded(
     }
 }
 
+fn vector_table_name(model_key: &str) -> Result<String> {
+    if model_key.is_empty()
+        || !model_key
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == '_')
+    {
+        anyhow::bail!("invalid vector model key {model_key:?}");
+    }
+    Ok(format!("vec_{model_key}"))
+}
+
+async fn missing_embedding_batch(
+    rt: &KhiveRuntime,
+    namespace: &str,
+    vector_table: &str,
+    kind: SubstrateKind,
+    after: &str,
+    limit: u32,
+) -> Result<Vec<(Uuid, String)>> {
+    use khive_storage::types::{SqlStatement, SqlValue};
+
+    let (select, table, text_predicate) = match kind {
+        SubstrateKind::Entity => (
+            "base.id, base.name, base.description",
+            "entities",
+            "TRIM(base.name) <> ''",
+        ),
+        SubstrateKind::Note => ("base.id, base.content", "notes", "TRIM(base.content) <> ''"),
+        _ => anyhow::bail!("embeds-only reindex does not support {kind}"),
+    };
+    let sql = format!(
+        "SELECT {select} FROM {table} AS base \
+         WHERE base.namespace = ?1 AND base.deleted_at IS NULL AND base.id > ?2 \
+         AND {text_predicate} \
+         AND NOT EXISTS (SELECT 1 FROM {vector_table} AS vectors \
+             WHERE vectors.subject_id = base.id AND vectors.namespace = ?1) \
+         ORDER BY base.id LIMIT ?3"
+    );
+    let rows = {
+        let mut reader = rt
+            .sql()
+            .reader()
+            .await
+            .context("open SQL reader for embeds-only reindex")?;
+        reader
+            .query_all(SqlStatement {
+                sql,
+                params: vec![
+                    SqlValue::Text(namespace.to_string()),
+                    SqlValue::Text(after.to_string()),
+                    SqlValue::Integer(i64::from(limit)),
+                ],
+                label: Some("reindex_missing_embeddings".into()),
+            })
+            .await
+            .context("select rows missing embeddings")?
+    };
+
+    rows.into_iter()
+        .map(|row| {
+            let text = |name: &str| match row.get(name) {
+                Some(SqlValue::Text(value)) => Ok(value.clone()),
+                Some(SqlValue::Null) => Ok(String::new()),
+                _ => anyhow::bail!("missing or invalid {name} in embeds-only row"),
+            };
+            let id = text("id")?
+                .parse::<Uuid>()
+                .context("invalid subject id in embeds-only row")?;
+            let content = match kind {
+                SubstrateKind::Entity => {
+                    let name = text("name")?;
+                    let description = text("description")?;
+                    if description.is_empty() {
+                        name
+                    } else {
+                        format!("{name} {description}")
+                    }
+                }
+                SubstrateKind::Note => text("content")?,
+                _ => unreachable!("kind checked above"),
+            };
+            Ok((id, content))
+        })
+        .collect()
+}
+
+async fn repair_missing_embeddings(
+    rt: &KhiveRuntime,
+    token: &khive_runtime::NamespaceToken,
+    model_names: &[String],
+    namespace: &str,
+    batch_size: u32,
+) -> Result<(u64, u64, u64)> {
+    let mut entities_processed = 0u64;
+    let mut notes_processed = 0u64;
+    let mut errors = 0u64;
+
+    for model_name in model_names {
+        let vectors = rt
+            .vectors_for_model(token, model_name)
+            .with_context(|| format!("resolve vector store for model {model_name}"))?;
+        let info = vectors
+            .info()
+            .await
+            .with_context(|| format!("inspect vector store for model {model_name}"))?;
+        let vector_table = vector_table_name(&info.model_name)?;
+
+        for (kind, field) in [
+            (SubstrateKind::Entity, "entity.body"),
+            (SubstrateKind::Note, "note.content"),
+        ] {
+            let mut after = String::new();
+            loop {
+                let batch =
+                    missing_embedding_batch(rt, namespace, &vector_table, kind, &after, batch_size)
+                        .await?;
+                let Some((last_id, _)) = batch.last() else {
+                    break;
+                };
+                after = last_id.to_string();
+                errors += embed_and_store_batch(
+                    rt,
+                    token,
+                    std::slice::from_ref(model_name),
+                    namespace,
+                    &batch,
+                    kind,
+                    field,
+                    false,
+                )
+                .await;
+                match kind {
+                    SubstrateKind::Entity => entities_processed += batch.len() as u64,
+                    SubstrateKind::Note => notes_processed += batch.len() as u64,
+                    _ => unreachable!("repair kinds are fixed above"),
+                }
+            }
+        }
+    }
+
+    Ok((entities_processed, notes_processed, errors))
+}
+
 /// Re-embed entities and notes, fanning out across every configured embedding
 /// engine. Engines, db path, and config are resolved with the same precedence
 /// as `kkernel mcp` so reindex writes the SAME vectors the MCP server serves
@@ -451,12 +599,16 @@ pub async fn run_reindex(args: ReindexArgs) -> Result<()> {
         Some(name) => vec![name.to_string()],
         None => {
             let names = rt.registered_embedding_model_names();
-            if names.is_empty() {
+            if names.is_empty() && !args.embeds_only {
                 eprintln!("warning: no embedding model configured — skipping vector embedding; FTS backfill will still run");
             }
             names
         }
     };
+
+    if args.embeds_only && model_names.is_empty() {
+        anyhow::bail!("--embeds-only requires at least one configured embedding model");
+    }
 
     let batch_size = args.batch_size.clamp(1, 500);
     let drop_existing = !args.keep_existing;
@@ -468,6 +620,27 @@ pub async fn run_reindex(args: ReindexArgs) -> Result<()> {
     let mut errors_skipped: u64 = 0;
     let mut entities_fts_failed: u64 = 0;
     let mut notes_fts_failed: u64 = 0;
+
+    if args.embeds_only {
+        (entities_processed, notes_processed, errors_skipped) =
+            repair_missing_embeddings(&rt, &token, &model_names, &ns_str, batch_size).await?;
+        if entities_processed + notes_processed > 0 {
+            if let Err(e) = invalidate_vamana_snapshots(&rt, &ns_str).await {
+                tracing::warn!(error = %e, "failed to invalidate Vamana snapshots after reindex");
+            }
+        }
+        let report = ReindexReport {
+            entities_processed,
+            notes_processed,
+            models_used: model_names,
+            elapsed_ms: start.elapsed().as_millis() as u64,
+            errors_skipped,
+            entities_fts_failed,
+            notes_fts_failed,
+        };
+        print_report(&report, args.human);
+        return finish(&report, args.best_effort);
+    }
 
     // ── entities + notes (graph substrate) ────────────────────────────────────
     {
@@ -1214,6 +1387,67 @@ mod tests {
         assert!(decide_result(false, true).is_ok());
     }
 
+    #[test]
+    fn embeds_only_arg_is_opt_in() {
+        let default_args = ReindexArgs::parse_from(["reindex"]);
+        assert!(!default_args.embeds_only);
+
+        let repair_args = ReindexArgs::parse_from(["reindex", "--embeds-only"]);
+        assert!(repair_args.embeds_only);
+    }
+
+    #[tokio::test]
+    async fn embeds_only_selection_returns_only_notes_missing_target_model() {
+        use khive_runtime::RuntimeConfig;
+        use khive_storage::types::VectorRecord;
+        use lattice_embed::EmbeddingModel;
+
+        const MODEL: &str = "paraphrase-multilingual-minilm-l12-v2";
+        const TABLE: &str = "vec_paraphrase_multilingual_minilm_l12_v2";
+
+        let rt = KhiveRuntime::new(RuntimeConfig {
+            db_path: None,
+            embedding_model: None,
+            additional_embedding_models: vec![EmbeddingModel::ParaphraseMultilingualMiniLmL12V2],
+            ..RuntimeConfig::default()
+        })
+        .expect("runtime");
+        let token = rt
+            .authorize(Namespace::parse("local").expect("namespace"))
+            .expect("authorize");
+        let notes = rt.notes(&token).expect("notes");
+        let existing = Note::new("local", "observation", "already embedded");
+        let missing = Note::new("local", "observation", "needs repair");
+        notes
+            .upsert_note(existing.clone())
+            .await
+            .expect("seed existing note");
+        notes
+            .upsert_note(missing.clone())
+            .await
+            .expect("seed missing note");
+
+        rt.vectors_for_model(&token, MODEL)
+            .expect("vectors")
+            .insert_batch(vec![VectorRecord {
+                subject_id: existing.id,
+                kind: SubstrateKind::Note,
+                namespace: "local".to_string(),
+                field: "note.content".to_string(),
+                embedding_model: Some(MODEL.to_string()),
+                vectors: vec![vec![0.1; 384]],
+                updated_at: chrono::Utc::now(),
+            }])
+            .await
+            .expect("seed vector");
+
+        let selected = missing_embedding_batch(&rt, "local", TABLE, SubstrateKind::Note, "", 100)
+            .await
+            .expect("select missing notes");
+
+        assert_eq!(selected, vec![(missing.id, missing.content)]);
+    }
+
     // DB resolution parity with `kkernel exec` / `kkernel mcp`. The shared
     // helper is unit-tested in `dbpath`; here we assert reindex consumes it
     // through clap (`--db` / `KHIVE_DB` / `:memory:`) the same way.
@@ -1757,6 +1991,7 @@ mod tests {
             model: None,
             batch_size: 100,
             keep_existing: false,
+            embeds_only: false,
             namespace: Some("local".to_string()),
             best_effort: true,
             human: false,
@@ -2023,6 +2258,7 @@ mod tests {
             model: None,
             batch_size: 100,
             keep_existing: false,
+            embeds_only: false,
             namespace: Some("local".to_string()),
             best_effort: true,
             human: false,

--- a/crates/kkernel/src/reindex.rs
+++ b/crates/kkernel/src/reindex.rs
@@ -531,6 +531,7 @@ async fn repair_missing_embeddings(
                     break;
                 };
                 after = last_id.to_string();
+                // A selected subject may still have a stale row in another namespace.
                 errors += embed_and_store_batch(
                     rt,
                     token,
@@ -539,7 +540,7 @@ async fn repair_missing_embeddings(
                     &batch,
                     kind,
                     field,
-                    false,
+                    true,
                 )
                 .await;
                 match kind {
@@ -1133,6 +1134,51 @@ mod tests {
     use khive_storage::types::{SqlStatement, SqlValue};
     use serial_test::serial;
 
+    const REPAIR_MODEL: &str = "repair-test-model";
+    const REPAIR_TABLE: &str = "vec_repair_test_model";
+    const REPAIR_DIMS: usize = 4;
+
+    struct RepairEmbeddingService;
+
+    #[async_trait::async_trait]
+    impl lattice_embed::EmbeddingService for RepairEmbeddingService {
+        async fn embed(
+            &self,
+            texts: &[String],
+            _model: lattice_embed::EmbeddingModel,
+        ) -> Result<Vec<Vec<f32>>, lattice_embed::EmbedError> {
+            Ok(vec![vec![0.75; REPAIR_DIMS]; texts.len()])
+        }
+
+        fn supports_model(&self, _model: lattice_embed::EmbeddingModel) -> bool {
+            true
+        }
+
+        fn name(&self) -> &'static str {
+            "repair-test"
+        }
+    }
+
+    struct RepairEmbedderProvider;
+
+    #[async_trait::async_trait]
+    impl khive_runtime::EmbedderProvider for RepairEmbedderProvider {
+        fn name(&self) -> &str {
+            REPAIR_MODEL
+        }
+
+        fn dimensions(&self) -> usize {
+            REPAIR_DIMS
+        }
+
+        async fn build(
+            &self,
+        ) -> Result<std::sync::Arc<dyn lattice_embed::EmbeddingService>, khive_runtime::RuntimeError>
+        {
+            Ok(std::sync::Arc::new(RepairEmbeddingService))
+        }
+    }
+
     #[tokio::test]
     async fn test_reindex_invalidates_vamana_snapshots() {
         let rt = KhiveRuntime::memory().expect("in-memory runtime");
@@ -1446,6 +1492,67 @@ mod tests {
             .expect("select missing notes");
 
         assert_eq!(selected, vec![(missing.id, missing.content)]);
+    }
+
+    #[tokio::test]
+    async fn embeds_only_repair_replaces_stale_cross_namespace_vector() {
+        use khive_runtime::RuntimeConfig;
+        use khive_storage::types::VectorRecord;
+
+        let rt = KhiveRuntime::new(RuntimeConfig {
+            db_path: None,
+            embedding_model: None,
+            additional_embedding_models: vec![],
+            ..RuntimeConfig::default()
+        })
+        .expect("runtime");
+        rt.register_embedder(RepairEmbedderProvider);
+        let token = rt
+            .authorize(Namespace::parse("local").expect("namespace"))
+            .expect("authorize");
+        let note = Note::new("local", "observation", "repair this embedding");
+        rt.notes(&token)
+            .expect("notes")
+            .upsert_note(note.clone())
+            .await
+            .expect("seed note");
+
+        let vectors = rt.vectors_for_model(&token, REPAIR_MODEL).expect("vectors");
+        vectors
+            .insert_batch(vec![VectorRecord {
+                subject_id: note.id,
+                kind: SubstrateKind::Note,
+                namespace: "stale-namespace".to_string(),
+                field: "note.content".to_string(),
+                embedding_model: Some(REPAIR_MODEL.to_string()),
+                vectors: vec![vec![0.1; REPAIR_DIMS]],
+                updated_at: chrono::Utc::now(),
+            }])
+            .await
+            .expect("seed stale vector");
+
+        let result =
+            repair_missing_embeddings(&rt, &token, &[REPAIR_MODEL.to_string()], "local", 100)
+                .await
+                .expect("repair embeddings");
+        assert_eq!(result, (0, 1, 0));
+
+        let mut reader = rt.sql().reader().await.expect("reader");
+        let rows = reader
+            .query_all(SqlStatement {
+                sql: format!(
+                    "SELECT namespace FROM {REPAIR_TABLE} WHERE subject_id = ?1 ORDER BY namespace"
+                ),
+                params: vec![SqlValue::Text(note.id.to_string())],
+                label: None,
+            })
+            .await
+            .expect("read repaired vector");
+        assert_eq!(rows.len(), 1, "repair must leave one vector row");
+        assert!(
+            matches!(rows[0].get("namespace"), Some(SqlValue::Text(value)) if value == "local"),
+            "repair must replace the stale row with the base row namespace"
+        );
     }
 
     // DB resolution parity with `kkernel exec` / `kkernel mcp`. The shared

--- a/crates/kkernel/src/reindex.rs
+++ b/crates/kkernel/src/reindex.rs
@@ -529,7 +529,7 @@ async fn prepare_repair_models(
             .unwrap_or_else(|_| model_name.clone());
 
         identities_by_table
-            .entry(vector_table.clone())
+            .entry(vector_table.to_ascii_lowercase())
             .or_default()
             .insert(embedding_model.clone());
         targets.push(RepairModelTarget {
@@ -1743,6 +1743,66 @@ mod tests {
             vectors.count().await.expect("count after refusal"),
             0,
             "collision refusal must happen before vector writes"
+        );
+    }
+
+    #[tokio::test]
+    async fn embeds_only_repair_refuses_case_distinct_models_before_vector_writes() {
+        use khive_runtime::RuntimeConfig;
+
+        const MODEL_A: &str = "collision";
+        const MODEL_B: &str = "Collision";
+        const TABLE: &str = "vec_collision";
+
+        let rt = KhiveRuntime::new(RuntimeConfig {
+            db_path: None,
+            embedding_model: None,
+            additional_embedding_models: vec![],
+            ..RuntimeConfig::default()
+        })
+        .expect("runtime");
+        rt.register_embedder(RepairEmbedderProvider {
+            model_name: MODEL_A,
+        });
+        rt.register_embedder(RepairEmbedderProvider {
+            model_name: MODEL_B,
+        });
+        let token = rt
+            .authorize(Namespace::parse("local").expect("namespace"))
+            .expect("authorize");
+        let note = Note::new("local", "observation", "do not repair case-distinct models");
+        rt.notes(&token)
+            .expect("notes")
+            .upsert_note(note)
+            .await
+            .expect("seed note");
+        let vectors = rt.vectors_for_model(&token, MODEL_A).expect("vectors");
+        assert_eq!(vectors.count().await.expect("count before repair"), 0);
+
+        let error = repair_missing_embeddings(
+            &rt,
+            &token,
+            &[MODEL_A.to_string(), MODEL_B.to_string()],
+            "local",
+            100,
+        )
+        .await
+        .expect_err("case-distinct repair models must be refused");
+
+        let message = error.to_string();
+        assert!(message.contains(MODEL_A), "missing first model: {message}");
+        assert!(message.contains(MODEL_B), "missing second model: {message}");
+        assert!(message.contains(TABLE), "missing shared table: {message}");
+        assert!(
+            message.contains(
+                "colliding registered model names cannot be repaired or served from one table"
+            ),
+            "missing refusal rationale: {message}"
+        );
+        assert_eq!(
+            vectors.count().await.expect("count after refusal"),
+            0,
+            "case-distinct collision refusal must happen before vector writes"
         );
     }
 

--- a/crates/kkernel/tests/db_check.rs
+++ b/crates/kkernel/tests/db_check.rs
@@ -1,0 +1,70 @@
+use std::process::Command;
+
+use rusqlite::Connection;
+use tempfile::TempDir;
+
+fn kkernel_bin() -> &'static str {
+    env!("CARGO_BIN_EXE_kkernel")
+}
+
+#[test]
+fn legacy_ledger_check_recommends_recreation() {
+    let tmp = TempDir::new().expect("temp dir");
+    let path = tmp.path().join("legacy.db");
+    let conn = Connection::open(&path).expect("open legacy db");
+    conn.execute_batch(
+        "CREATE TABLE _schema_migrations (
+            version INTEGER PRIMARY KEY,
+            name TEXT NOT NULL,
+            applied_at INTEGER NOT NULL
+        );
+        INSERT INTO _schema_migrations (version, name, applied_at) VALUES
+            (1, 'initial_schema', 0),
+            (2, 'add_name_to_notes', 0),
+            (22, 'knowledge_lifecycle_status', 0);",
+    )
+    .expect("create legacy migration ledger");
+    drop(conn);
+
+    let output = Command::new(kkernel_bin())
+        .args(["db", "check", "--db"])
+        .arg(&path)
+        .arg("--human")
+        .output()
+        .expect("run db check");
+
+    assert!(
+        output.status.success(),
+        "db check failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8(output.stdout).expect("utf8 stdout");
+    assert!(
+        stdout.contains("predates the consolidated baseline"),
+        "{stdout}"
+    );
+    assert!(stdout.contains("recreate"), "{stdout}");
+    assert!(!stdout.contains("upgrade the binary"), "{stdout}");
+
+    let output = Command::new(kkernel_bin())
+        .args(["db", "check", "--db"])
+        .arg(&path)
+        .output()
+        .expect("run JSON db check");
+    assert!(
+        output.status.success(),
+        "JSON db check failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8(output.stdout).expect("utf8 JSON stdout");
+    let report: serde_json::Value = serde_json::from_str(&stdout).expect("db check JSON");
+    assert_eq!(report["current_version"], 22);
+    assert_eq!(report["ahead"], false);
+    assert_eq!(report["recreation_required"], true);
+    assert!(
+        report["guidance"]
+            .as_str()
+            .is_some_and(|guidance| guidance.contains("recreate")),
+        "{report}"
+    );
+}


### PR DESCRIPTION
Two operator-facing improvements to store maintenance and diagnostics.

**Embeds-only repair (#1243).** `kkernel reindex --embeds-only` fills embedding gaps without paying the full FTS backfill and full enumeration the combined rebuild costs. For each substrate it runs an indexed NOT EXISTS anti-join against the target model's vector table selecting only live rows lacking a vector, staged for batch embedding with ID-cursor pagination so a failing row cannot repeat a page. FTS backfill and the stale-partition sweep are unreachable from this mode; the default combined rebuild is byte-for-byte unchanged.

**Newer-store diagnostic (#1203).** Direct-opening a store written by a newer binary now yields a dedicated `SchemaTooNew` error carrying both versions and rendering one actionable line directing a binary upgrade — at both the initial migration check and the under-lock recheck, and in `kkernel db check` — replacing generic version guidance that suggested recreation.

Tests: reindex suite extended (34 pass) covering missing-vector selection, pagination, and mode isolation; migrations tests cover the variant and message at both guards.

Closes #1243
Closes #1203

🤖 Generated with [Claude Code](https://claude.com/claude-code)
