### PR TITLE
refactor(query): single-pass dialect selection and shared special-relation predicate

### DIFF
--- a/crates/khive-query/src/language.rs
+++ b/crates/khive-query/src/language.rs
@@ -34,24 +34,27 @@ pub fn parse(language: QueryLanguage, input: &str) -> Result<GqlQuery, QueryErro
 /// Returns [`QueryError`] when syntax is invalid, write-shaped, or unsupported.
 /// See `crates/khive-query/docs/api/parsing.md` for detection and guard behavior.
 pub fn parse_auto(input: &str) -> Result<GqlQuery, QueryError> {
+    parse_auto_with_language(input).map(|(_, query)| query)
+}
+
+/// Auto-detects and parses `input`, retaining the selected query language.
+///
+/// # Errors
+///
+/// Returns [`QueryError`] when syntax is invalid, write-shaped, or unsupported.
+pub fn parse_auto_with_language(input: &str) -> Result<(QueryLanguage, GqlQuery), QueryError> {
     let trimmed = input.trim();
     reject_write(trimmed)?;
-    if trimmed
+    let language = if trimmed
         .as_bytes()
         .get(..6)
         .is_some_and(|p| p.eq_ignore_ascii_case(b"SELECT"))
     {
-        parsers::sparql::parse(trimmed)
-    } else if trimmed
-        .as_bytes()
-        .get(..5)
-        .is_some_and(|p| p.eq_ignore_ascii_case(b"MATCH"))
-    {
-        parsers::gql::parse(trimmed)
+        QueryLanguage::Sparql
     } else {
-        // Preserve compatibility for inputs without a recognized leading keyword.
-        parsers::gql::parse(trimmed)
-    }
+        QueryLanguage::Gql
+    };
+    parse(language, trimmed).map(|query| (language, query))
 }
 
 /// Rejects GQL/Cypher mutations and SPARQL Update before dialect dispatch.
@@ -138,6 +141,16 @@ mod tests {
             !q.pattern.elements.is_empty(),
             "valid SPARQL SELECT must parse"
         );
+    }
+
+    #[test]
+    fn parse_auto_with_language_reports_selected_parser() {
+        let (gql_language, _) = parse_auto_with_language("MATCH (a:concept) RETURN a").unwrap();
+        assert_eq!(gql_language, QueryLanguage::Gql);
+
+        let (sparql_language, _) =
+            parse_auto_with_language("SELECT ?a WHERE { ?a :extends ?b . }").unwrap();
+        assert_eq!(sparql_language, QueryLanguage::Sparql);
     }
 
     #[test]

--- a/crates/khive-runtime/src/curation.rs
+++ b/crates/khive-runtime/src/curation.rs
@@ -267,13 +267,7 @@ fn merge_rewire_endpoint_contract_allows(
     }
     // Same-substrate relations permit any note→note pair unconditionally,
     // matching `validate_edge_relation_endpoints`'s `(Note, Note) => {}` arm.
-    if src_sub == "note"
-        && tgt_sub == "note"
-        && matches!(
-            relation,
-            EdgeRelation::Supersedes | EdgeRelation::Supports | EdgeRelation::Refutes
-        )
-    {
+    if src_sub == "note" && tgt_sub == "note" && crate::pack::is_special_relation(relation) {
         return true;
     }
     if src_sub == "entity"

--- a/crates/khive-runtime/src/operations.rs
+++ b/crates/khive-runtime/src/operations.rs
@@ -446,8 +446,8 @@ fn accepted_pack_relations_for_pattern_entities(
 /// parallel table — issue #543 precedent, applied to GQL query-pattern hint
 /// derivation (issue #593).
 ///
-/// Pack rules are skipped for `crate::pack::SPECIAL_RELATIONS` (supersedes /
-/// supports / refutes): the live validator's special-relation branch
+/// Pack rules are skipped when `crate::pack::is_special_relation` is true
+/// (supersedes / supports / refutes): the live validator's special-relation branch
 /// (`validate_edge_relation_endpoints`, this file) resolves those relations
 /// before `pack_rule_allows` is ever reached, so a pack `EDGE_RULES` entry for
 /// one of them is never actually enforced (see `pack.rs`'s
@@ -460,7 +460,7 @@ fn accepted_entity_kind_pairs_for_relation(
     for src in khive_types::EntityKind::ALL {
         for tgt in khive_types::EntityKind::ALL {
             let allowed = base_entity_rule_allows(src.name(), relation, tgt.name())
-                || (!crate::pack::SPECIAL_RELATIONS.contains(&relation)
+                || (!crate::pack::is_special_relation(relation)
                     && accepted_pack_relations_for_pattern_entities(
                         pack_rules,
                         src.name(),
@@ -492,10 +492,15 @@ fn accepted_entity_kind_pairs_for_relation(
 /// `supports` / `refutes` (see [`accepted_entity_kind_pairs_for_relation`]):
 /// pack rules never make those triples possible, only the base allowlist does.
 fn static_impossible_edge_pattern_warnings(
+    language: khive_query::QueryLanguage,
     pattern: &khive_query::ast::MatchPattern,
     pack_rules: &[EdgeEndpointRule],
 ) -> Vec<String> {
     use khive_query::ast::{EdgeDirection, PatternElement};
+
+    if language != khive_query::QueryLanguage::Gql {
+        return Vec::new();
+    }
 
     let elements = &pattern.elements;
     let mut warnings = Vec::new();
@@ -531,7 +536,7 @@ fn static_impossible_edge_pattern_warnings(
         };
 
         let possible = base_entity_rule_allows(src_kind.name(), relation, tgt_kind.name())
-            || (!crate::pack::SPECIAL_RELATIONS.contains(&relation)
+            || (!crate::pack::is_special_relation(relation)
                 && accepted_pack_relations_for_pattern_entities(
                     pack_rules,
                     src_kind.name(),
@@ -1601,10 +1606,7 @@ impl KhiveRuntime {
                     "link target {target_id} not found"
                 )));
             }
-        } else if matches!(
-            relation,
-            EdgeRelation::Supersedes | EdgeRelation::Supports | EdgeRelation::Refutes
-        ) {
+        } else if crate::pack::is_special_relation(relation) {
             // supersedes / supports / refutes: same-substrate only (note→note or entity→entity).
             // Event and edge endpoints are invalid regardless of the other endpoint.
             // Endpoint resolution is by-ID and namespace-agnostic.
@@ -1813,10 +1815,7 @@ impl KhiveRuntime {
             return Ok(());
         }
 
-        if matches!(
-            relation,
-            EdgeRelation::Supersedes | EdgeRelation::Supports | EdgeRelation::Refutes
-        ) {
+        if crate::pack::is_special_relation(relation) {
             let rel_name = relation.as_str();
             let src = src.ok_or_else(|| {
                 RuntimeError::NotFound(format!("link source {source_id} not found"))
@@ -4201,7 +4200,7 @@ impl KhiveRuntime {
         use khive_query::QueryValue;
         use khive_storage::types::SqlValue;
 
-        let ast = khive_query::parse_auto(query)?;
+        let (language, ast) = khive_query::language::parse_auto_with_language(query)?;
         opts.scopes = token
             .visible_namespaces()
             .iter()
@@ -4211,23 +4210,9 @@ impl KhiveRuntime {
         let mut warnings = compiled.warnings;
         let truncation_check = compiled.truncation_check;
 
-        // Static schema-mismatch hint (issue #593): GQL-only by design — the
-        // hint is worded around GQL's `(kind)-[:relation]->(kind)` syntax, so
-        // it is scoped out of SPARQL even though SPARQL compiles to the same
-        // `MatchPattern` shape. Dialect is detected the same way `parse_auto`
-        // selects it, since neither the AST nor `CompiledQuery` retains it.
-        let is_sparql = query
-            .trim()
-            .as_bytes()
-            .get(..6)
-            .is_some_and(|p| p.eq_ignore_ascii_case(b"SELECT"));
-        if !is_sparql {
-            let pack_rules = self.pack_edge_rules();
-            warnings.extend(static_impossible_edge_pattern_warnings(
-                &ast.pattern,
-                &pack_rules,
-            ));
-        }
+        warnings.extend(self.with_pack_edge_rules(|pack_rules| {
+            static_impossible_edge_pattern_warnings(language, &ast.pattern, pack_rules)
+        }));
 
         // Convert QueryValue params (query-layer type) to SqlValue (storage-layer type)
         // at the query–storage boundary.

--- a/crates/khive-runtime/src/pack.rs
+++ b/crates/khive-runtime/src/pack.rs
@@ -926,6 +926,10 @@ pub(crate) const SPECIAL_RELATIONS: &[khive_types::EdgeRelation] = &[
     khive_types::EdgeRelation::Refutes,
 ];
 
+pub(crate) fn is_special_relation(relation: khive_types::EdgeRelation) -> bool {
+    SPECIAL_RELATIONS.contains(&relation)
+}
+
 /// Compose the full per-relation endpoint allowlist surfaced by
 /// `link(help=true)` (issue #964).
 ///
@@ -965,7 +969,7 @@ fn edge_endpoint_table(packs: &[Box<dyn PackRuntime>]) -> Vec<Value> {
 
     for pack in packs.iter() {
         for rule in pack.edge_rules().iter() {
-            if SPECIAL_RELATIONS.contains(&rule.relation) {
+            if is_special_relation(rule.relation) {
                 continue;
             }
             rows.push(serde_json::json!({
@@ -6522,6 +6526,22 @@ mod help_tests {
                     && r["target"] == "entity:concept"),
                 "endpoint_rules must include the base entity:{kind}->entity:concept row \
                  for '{relation}'; got {rules:#?}"
+            );
+        }
+    }
+
+    #[test]
+    fn special_relation_predicate_matches_the_dedicated_validator_set() {
+        for relation in khive_types::EdgeRelation::ALL {
+            assert_eq!(
+                is_special_relation(relation),
+                matches!(
+                    relation,
+                    khive_types::EdgeRelation::Supersedes
+                        | khive_types::EdgeRelation::Supports
+                        | khive_types::EdgeRelation::Refutes
+                ),
+                "unexpected special-relation classification for {relation}"
             );
         }
     }

--- a/crates/khive-runtime/src/runtime.rs
+++ b/crates/khive-runtime/src/runtime.rs
@@ -749,6 +749,14 @@ impl KhiveRuntime {
             .unwrap_or_default()
     }
 
+    /// Borrow the installed pack edge rules for a synchronous calculation.
+    pub(crate) fn with_pack_edge_rules<T>(&self, f: impl FnOnce(&[EdgeEndpointRule]) -> T) -> T {
+        match self.edge_rules.read() {
+            Ok(rules) => f(&rules),
+            Err(_) => f(&[]),
+        }
+    }
+
     /// Return the name of the default embedding model (empty string if none configured).
     pub fn default_embedder_name(&self) -> &str {
         self.default_embedder_name.as_ref()


### PR DESCRIPTION
Structural cleanup of the GQL impossibility-hint path (#1245 follow-ups to #1240).

- Parser selection is computed once: `parse_auto_with_language` returns the chosen dialect alongside the parse, and the runtime consumes it instead of re-detecting the dialect at the hint site. The hint entry point owns the single GQL-only guard.
- Hint evaluation borrows the runtime's cached pack endpoint rules through a synchronous callback instead of cloning the rule vector per call.
- One shared `is_special_relation` predicate now backs live edge validation, merge rewiring, both hint paths, and endpoint help-table generation, replacing three hand-maintained copies of the relation list; coverage is exhaustive over the relation set.

Behavior is unchanged; this removes per-call allocation and the risk of the three relation lists drifting apart.

Verified on this base: query truncation already reports the structural `truncated` field with corrected warning text, covering the guidance concerns raised alongside these follow-ups.

Closes #1245

🤖 Generated with [Claude Code](https://claude.com/claude-code)
