### PR TITLE
fix(db): apply migration body and ledger row in one transaction

### DIFF
--- a/crates/khive-db/src/migrations.rs
+++ b/crates/khive-db/src/migrations.rs
@@ -62,11 +62,11 @@ pub fn apply_schema_plan(conn: &Connection, plan: &ServiceSchemaPlan) -> Result<
             continue;
         }
 
-        // Apply
-        conn.execute_batch(migration.up_sql)?;
+        let tx =
+            rusqlite::Transaction::new_unchecked(conn, rusqlite::TransactionBehavior::Immediate)?;
+        tx.execute_batch(migration.up_sql)?;
 
-        // Record
-        conn.execute(
+        tx.execute(
             "INSERT INTO _schema_versions (service, migration_id, applied_at) VALUES (?1, ?2, ?3)",
             rusqlite::params![
                 plan.service,
@@ -74,6 +74,7 @@ pub fn apply_schema_plan(conn: &Connection, plan: &ServiceSchemaPlan) -> Result<
                 chrono::Utc::now().timestamp_micros(),
             ],
         )?;
+        tx.commit()?;
     }
 
     Ok(())

--- a/crates/khive-db/src/migrations_tests.rs
+++ b/crates/khive-db/src/migrations_tests.rs
@@ -24,6 +24,46 @@ fn column_exists(conn: &Connection, table: &str, column: &str) -> bool {
 }
 
 #[test]
+fn apply_schema_plan_rolls_back_migration_when_ledger_insert_fails() {
+    static MIGRATIONS: &[Migration] = &[Migration {
+        id: "001_atomic",
+        up_sql: "CREATE TABLE migration_effect (id INTEGER PRIMARY KEY);",
+        down_sql: None,
+        is_already_applied: None,
+    }];
+    let plan = ServiceSchemaPlan {
+        service: "atomicity_test",
+        sqlite: MIGRATIONS,
+        postgres: &[],
+    };
+    let conn = open_memory();
+    conn.execute_batch(SCHEMA_VERSION_TABLE).unwrap();
+    conn.execute_batch(
+        "CREATE TRIGGER reject_schema_version
+         BEFORE INSERT ON _schema_versions
+         BEGIN
+             SELECT RAISE(ABORT, 'injected ledger failure');
+         END;",
+    )
+    .unwrap();
+
+    apply_schema_plan(&conn, &plan).expect_err("ledger failure must abort the migration");
+
+    assert!(
+        !table_exists(&conn, "migration_effect"),
+        "migration body must roll back when its ledger insert fails"
+    );
+    let ledger_rows: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM _schema_versions WHERE service = 'atomicity_test'",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(ledger_rows, 0);
+}
+
+#[test]
 fn fresh_db_migrates_to_latest() {
     let mut conn = open_memory();
     let version = run_migrations(&mut conn).expect("migrations should succeed");


### PR DESCRIPTION
## Summary
`apply_schema_plan` now executes each migration body and its `_schema_versions` ledger insert inside one `BEGIN IMMEDIATE` transaction; a failure in either rolls both back, so applied DDL can no longer exist without its ledger row. The versioned migration path already followed this convention; the service-schema path now matches it while keeping its `&Connection` API (`Transaction::new_unchecked`, which still rejects nesting at runtime).

Closes #1103.

## Testing
- `apply_schema_plan_rolls_back_migration_when_ledger_insert_fails` — deterministic ledger-failure injection via an abort trigger; red before the change (migration table survived), green after.
- `cargo test -p khive-db` full suite green; clippy `-D warnings` clean; workspace check clean.
