### PR TITLE
test(mcp): pin the batch status contract and document strict exit behavior

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -206,7 +206,9 @@ the substrate from the UUID. `create`/`list`/`search` require `kind`.
 
 Each op returns `{ok: true, tool, result}` or `{ok: false, tool, error}`. A failed op does
 NOT abort the batch — each entry has its own ok/error. The aggregate response also carries
-`summary: {total, succeeded, failed}`.
+`summary: {total, succeeded, failed, aborted}` and a top-level `status`: `"success"` when
+every op succeeded, or `"partial"` when any op failed or was aborted. Callers should inspect
+`status` or `summary` instead of treating the absence of an RPC-level error as full success.
 
 ---
 

--- a/crates/khive-mcp/docs/design.md
+++ b/crates/khive-mcp/docs/design.md
@@ -17,7 +17,9 @@ decisions and rationale.
   over the three execution modes. Splitting the branches would scatter the
   contract invariants (summary shape, aborted semantics, `$prev` substitution
   ordering) across files, making them harder to review as a unit.
-- Response envelope shape: `{"results": [...], "summary": {"total": N, "succeeded": K, "failed": M, "aborted": A}}`.
+- Response envelope shape: `{"results": [...], "summary": {"total": N, "succeeded": K, "failed": M, "aborted": A}, "status": "success" | "partial"}`.
+- `status` is `"partial"` when `summary.failed` or `summary.aborted` is non-zero;
+  callers must not infer full success solely from the absence of an RPC-level error.
 - Per-op failures do not abort siblings in Parallel mode; they do abort remaining
   ops in Chain mode (reported as `{"ok": false, "aborted": true}`).
 - Invalid DSL (parse/lex failure) returns an RPC-level `invalid_params` error.

--- a/crates/kkernel/docs/usage.md
+++ b/crates/kkernel/docs/usage.md
@@ -76,12 +76,16 @@ ideal for admin verb calls without standing up an MCP client. Defaults to namesp
 kkernel exec 'stats()'
 kkernel exec 'stats()' --db ~/.khive/khive.db
 kkernel exec '[list(kind="entity", limit=5), stats()]'            # parallel batch
+kkernel exec '[create(kind="concept", name="X"), stats()]' --strict  # nonzero exit if any op fails
 kkernel exec 'create(kind="entity", entity_kind="concept", name="X") | link(source_id=$prev.id, target_id="<id>", relation="extends")'   # chain ($prev)
 kkernel exec 'memory.recall(help=true)'                           # param schema for any verb
 kkernel exec 'memory.recall(query="...")' --presentation verbose
 ```
 
-Flags: `--db`, `--namespace`, `--presentation <agent|verbose|human>`.
+Flags: `--db`, `--namespace`, `--presentation <agent|verbose|human>`, `--strict`.
+Without `--strict`, a dispatched request retains its compatibility behavior and exits zero even
+when its response has `status: "partial"`; `--strict` converts failed or aborted ops into a
+nonzero process exit after printing the full response.
 
 ---
 

--- a/tests/contract_test.py
+++ b/tests/contract_test.py
@@ -28,6 +28,9 @@ Concretely, these tests cover:
   9. Epistemic edge endpoint enforcement — supports/refutes legal pairs are
      accepted; illegal pairs (wrong target kind, cross-substrate) are rejected
      with clear error messages (ADR-055 + ADR-002 §"Epistemic relations").
+ 10. Batch outcome status — full success reports ``status=success`` while a
+     mixed success/failure batch preserves per-op results and reports
+     ``status=partial`` with the corresponding summary counts.
 
 How to run
 ----------
@@ -994,6 +997,48 @@ def test_epistemic_edge_endpoints(proc: subprocess.Popen) -> None:
 
 
 # ---------------------------------------------------------------------------
+# Contract 10 — Batch outcome status
+# ---------------------------------------------------------------------------
+
+def test_batch_outcome_status(proc: subprocess.Popen) -> None:
+    """Batch status distinguishes full success from a mixed outcome."""
+    successful = _request_raw(
+        proc,
+        json.dumps([
+            {"tool": "stats", "args": {}},
+            {"tool": "list", "args": {"kind": "entity", "limit": 1}},
+        ]),
+    )
+    assert successful.get("status") == "success", successful
+    assert successful.get("summary") == {
+        "total": 2,
+        "succeeded": 2,
+        "failed": 0,
+        "aborted": 0,
+    }, successful
+
+    partial = _request_raw(
+        proc,
+        json.dumps([
+            {"tool": "stats", "args": {}},
+            {"tool": "search", "args": {"kind": "not_a_real_kind", "query": "x"}},
+        ]),
+    )
+    assert partial.get("status") == "partial", partial
+    assert partial.get("summary") == {
+        "total": 2,
+        "succeeded": 1,
+        "failed": 1,
+        "aborted": 0,
+    }, partial
+
+    results = partial.get("results") or []
+    assert len(results) == 2, partial
+    assert results[0].get("ok") is True and "result" in results[0], results[0]
+    assert results[1].get("ok") is False and "error" in results[1], results[1]
+
+
+# ---------------------------------------------------------------------------
 # Main
 # ---------------------------------------------------------------------------
 
@@ -1015,6 +1060,7 @@ def main() -> int:
         ("merge_semantics", test_merge_semantics),
         ("annotates_source_must_be_note", test_annotates_source_must_be_note),
         ("epistemic_edge_endpoints", test_epistemic_edge_endpoints),
+        ("batch_outcome_status", test_batch_outcome_status),
     ]
 
     for name, fn in tests:

--- a/tests/smoke_test.py
+++ b/tests/smoke_test.py
@@ -143,6 +143,9 @@ def main():
             assert verb in request_desc, (
                 f"request description missing verb {verb!r}; got:\n{request_desc}"
             )
+        assert '"status": "success" | "partial"' in request_desc, (
+            f"request description missing batch status contract; got:\n{request_desc}"
+        )
         print(f"  [ok] tools/list — single `request` tool; description lists 11 verbs")
 
         # 3. Create entities
@@ -426,6 +429,7 @@ def main():
         assert summary.get("total") == 3 and summary.get("failed") == 0, (
             f"expected 3/0 summary, got {summary}"
         )
+        assert bulk.get("status") == "success", f"expected success status, got {bulk}"
         print(f"  [ok] parallel batch — 3 independent creates in one request call")
 
         # 24. Malformed DSL must surface as RPC-level invalid_params, not silent success.


### PR DESCRIPTION
## Summary
The top-level batch `status` field (`success`/`partial`) and `kkernel exec --strict` nonzero-exit behavior already ship in the runtime. This closes the remaining contract drift around them:

- `crates/khive-mcp/docs/design.md`, `crates/kkernel/docs/usage.md`, and the developer guide now document the additive `status` field, `summary.aborted`, and the `--strict` exit contract (default mode keeps exit-zero compatibility).
- `tests/contract_test.py` adds `test_batch_outcome_status`: all-success batch reports `status: "success"` with the four-field summary; a mixed batch reports `status: "partial"` with per-op `{ok, result}` / `{ok, error}` shapes intact.
- `tests/smoke_test.py` asserts the request tool advertises the status contract and a successful parallel batch reports `status: "success"`.

Closes #1220.

## Testing
Contract suite 10/10 with isolated temp databases; full smoke suite green; direct CLI probe: the same partial batch exits 1 with `--strict` and 0 without, both printing `status: "partial"`.
