### PR TITLE
chore: linear line attribution in stub-marker scan; single-pass quoted-key normalization

### DIFF
--- a/crates/khive-request/src/parser/parser_impl.rs
+++ b/crates/khive-request/src/parser/parser_impl.rs
@@ -553,7 +553,7 @@ fn serde_error_byte_offset(e: &serde_json::Error, text: &str) -> Option<usize> {
 }
 
 /// Enriches a `serde_json` string-decode failure with the ADR-016 escape
-/// grammar and the MCP double-escape gotcha (ADR-084 §3c). Enrichment is
+/// grammar. Enrichment is
 /// gated on the failure being AT the recorded [`ControlByteHit`]: the serde
 /// error's `(line, column)` is mapped to a byte offset in `normalized.text`
 /// via [`serde_error_byte_offset`], then compared against
@@ -602,9 +602,7 @@ fn describe_quoted_string_parse_error(
     format!(
         "{base} — byte {idx} of the value is {c:?} (U+{:04X}). DSL string escapes follow JSON: \
          \\n, \\t, \\\", \\\\ (raw newline/CR/tab are also accepted literally; other control \
-         bytes must be escaped). If `ops` is sent through a JSON transport, the transport \
-         decodes one escape level before the DSL parser runs, so a literal \
-         backslash-escape must be doubled on the wire — e.g. send \\\\n to produce \\n here.",
+         bytes must be escaped).",
         c as u32
     )
 }

--- a/crates/khive-request/src/parser/scan.rs
+++ b/crates/khive-request/src/parser/scan.rs
@@ -108,15 +108,9 @@ pub(crate) struct NormalizedQuotedString<'a> {
 /// does not follow. The control byte it lands on there belongs to that
 /// surrogate failure, not to a fresh broken `\<ctrl>` pair, so it is likewise
 /// not recorded as a [`ControlByteHit`]: recording it would attach the
-/// double-escape teaching to a malformed-surrogate error it does not explain.
+/// control-character guidance to a malformed-surrogate error it does not explain.
 pub(crate) fn normalize_quoted_string(raw: &str) -> NormalizedQuotedString<'_> {
-    if !raw.bytes().any(|b| b < 0x20) {
-        return NormalizedQuotedString {
-            text: Cow::Borrowed(raw),
-            first_control_byte: None,
-        };
-    }
-    let mut out = String::with_capacity(raw.len() + 8);
+    let mut out = None;
     let mut first_control_byte = None;
     let mut chars = raw.char_indices().peekable();
     let mut hex_slots_remaining = 0u32;
@@ -130,7 +124,14 @@ pub(crate) fn normalize_quoted_string(raw: &str) -> NormalizedQuotedString<'_> {
                 Some(d) => hex_acc = (hex_acc << 4) | d,
                 None => hex_valid = false,
             }
-            out.push(c);
+            if (c as u32) < 0x20 && out.is_none() {
+                let mut owned = String::with_capacity(raw.len() + 8);
+                owned.push_str(&raw[..pos]);
+                out = Some(owned);
+            }
+            if let Some(out) = out.as_mut() {
+                out.push(c);
+            }
             if hex_slots_remaining == 0 {
                 after_high_surrogate = hex_valid && (0xD800..=0xDBFF).contains(&hex_acc);
             }
@@ -142,11 +143,15 @@ pub(crate) fn normalize_quoted_string(raw: &str) -> NormalizedQuotedString<'_> {
         let prev_was_high_surrogate = after_high_surrogate;
         after_high_surrogate = false;
         if c == '\\' {
-            out.push(c);
+            if let Some(out) = out.as_mut() {
+                out.push(c);
+            }
             if let Some(&(next_pos, next_c)) = chars.peek() {
                 chars.next();
                 if next_c == 'u' {
-                    out.push(next_c);
+                    if let Some(out) = out.as_mut() {
+                        out.push(next_c);
+                    }
                     hex_slots_remaining = 4;
                     hex_acc = 0;
                     hex_valid = true;
@@ -156,6 +161,11 @@ pub(crate) fn normalize_quoted_string(raw: &str) -> NormalizedQuotedString<'_> {
                     && !prev_was_high_surrogate
                     && first_control_byte.is_none()
                 {
+                    let out = out.get_or_insert_with(|| {
+                        let mut owned = String::with_capacity(raw.len() + 8);
+                        owned.push_str(&raw[..next_pos]);
+                        owned
+                    });
                     first_control_byte = Some(ControlByteHit {
                         normalized_pos: out.len(),
                         raw_pos: next_pos,
@@ -163,15 +173,37 @@ pub(crate) fn normalize_quoted_string(raw: &str) -> NormalizedQuotedString<'_> {
                         preceded_by_backslash: true,
                     });
                 }
-                out.push(next_c);
+                if (next_c as u32) < 0x20 && out.is_none() {
+                    let mut owned = String::with_capacity(raw.len() + 8);
+                    owned.push_str(&raw[..next_pos]);
+                    out = Some(owned);
+                }
+                if let Some(out) = out.as_mut() {
+                    out.push(next_c);
+                }
             }
             continue;
         }
         match c {
-            '\n' => out.push_str("\\n"),
-            '\r' => out.push_str("\\r"),
-            '\t' => out.push_str("\\t"),
+            '\n' | '\r' | '\t' => {
+                let out = out.get_or_insert_with(|| {
+                    let mut owned = String::with_capacity(raw.len() + 8);
+                    owned.push_str(&raw[..pos]);
+                    owned
+                });
+                match c {
+                    '\n' => out.push_str("\\n"),
+                    '\r' => out.push_str("\\r"),
+                    '\t' => out.push_str("\\t"),
+                    _ => unreachable!(),
+                }
+            }
             c if (c as u32) < 0x20 => {
+                let out = out.get_or_insert_with(|| {
+                    let mut owned = String::with_capacity(raw.len() + 8);
+                    owned.push_str(&raw[..pos]);
+                    owned
+                });
                 if first_control_byte.is_none() {
                     first_control_byte = Some(ControlByteHit {
                         normalized_pos: out.len(),
@@ -182,11 +214,15 @@ pub(crate) fn normalize_quoted_string(raw: &str) -> NormalizedQuotedString<'_> {
                 }
                 out.push(c);
             }
-            c => out.push(c),
+            c => {
+                if let Some(out) = out.as_mut() {
+                    out.push(c);
+                }
+            }
         }
     }
     NormalizedQuotedString {
-        text: Cow::Owned(out),
+        text: out.map_or(Cow::Borrowed(raw), Cow::Owned),
         first_control_byte,
     }
 }
@@ -297,5 +333,13 @@ mod tests {
             "must record the earliest hit, not a later one"
         );
         assert_eq!(hit.byte, 0);
+    }
+
+    #[test]
+    fn control_free_string_stays_borrowed_after_single_scan() {
+        let raw = r#""quoted key""#;
+        let normalized = normalize_quoted_string(raw);
+        assert!(matches!(normalized.text, Cow::Borrowed(_)));
+        assert!(normalized.first_control_byte.is_none());
     }
 }

--- a/crates/khive-request/tests/parser.rs
+++ b/crates/khive-request/tests/parser.rs
@@ -221,12 +221,11 @@ fn other_raw_control_chars_in_quoted_string_still_rejected() {
 }
 
 #[test]
-fn control_char_error_teaches_escape_syntax_and_mcp_double_escape() {
+fn control_char_error_teaches_escape_syntax_without_transport_guidance() {
     // #491: the bare serde message ("control character ... found while
     // parsing a string") teaches nothing. The wrapped error must name the
-    // JSON escape grammar and the MCP-transport double-escape gotcha, so a
-    // caller can actually fix the `ops` string instead of landing on the
-    // wrong "switch to JSON op form" workaround.
+    // JSON escape grammar while remaining transport-neutral; wire encoding
+    // guidance belongs to the transport boundary, not this parser.
     let src = format!("gtd.assign(title=\"a{}b\")", '\u{c}');
     let err = parse_request(&src).unwrap_err();
     let msg = err.to_string();
@@ -239,8 +238,8 @@ fn control_char_error_teaches_escape_syntax_and_mcp_double_escape() {
         "error should name the JSON escape grammar, got: {msg}"
     );
     assert!(
-        msg.to_lowercase().contains("double"),
-        "error should call out the MCP double-escape requirement, got: {msg}"
+        !msg.contains("MCP") && !msg.to_lowercase().contains("transport"),
+        "generic parser error should stay transport-neutral, got: {msg}"
     );
 }
 
@@ -275,8 +274,8 @@ fn control_char_in_object_key_rejected_with_plain_serde_message() {
         "expected InvalidValue, got {err:?}"
     );
     assert!(
-        !msg.to_lowercase().contains("double"),
-        "key-path error should not carry the value-path MCP double-escape teaching, got: {msg}"
+        !msg.contains("DSL string escapes follow JSON"),
+        "key-path error should not carry the value-path escape teaching, got: {msg}"
     );
 }
 
@@ -404,7 +403,7 @@ fn invalid_escape_with_unrelated_control_byte_not_misattributed() {
     let msg = err.to_string();
     assert!(matches!(err, DslError::InvalidValue { .. }));
     assert!(
-        !msg.to_lowercase().contains("double"),
+        !msg.contains("DSL string escapes follow JSON"),
         "an invalid \\q escape must not be enriched with the control-char diagnostic, got: {msg}"
     );
 }
@@ -417,7 +416,7 @@ fn malformed_unicode_escape_adjacent_to_control_byte_not_misattributed() {
     // with the recorded control-byte hit (the 4th hex-digit slot serde reads
     // is the control byte itself). Offset alone is not enough to gate the
     // enrichment; the error's kind must also be checked, or this lands the
-    // control-char/double-escape guidance on an invalid-escape failure.
+    // control-character escape guidance on an invalid-escape failure.
     let src = format!("gtd.assign(title=\"bad \\u123{}tail\")", '\u{c}');
     let err = parse_request(&src).unwrap_err();
     let msg = err.to_string();
@@ -427,7 +426,7 @@ fn malformed_unicode_escape_adjacent_to_control_byte_not_misattributed() {
         "expected the plain serde invalid-escape message, got: {msg}"
     );
     assert!(
-        !msg.to_lowercase().contains("double"),
+        !msg.contains("DSL string escapes follow JSON"),
         "a malformed \\u escape must not be enriched with the control-char diagnostic, got: {msg}"
     );
 }
@@ -440,7 +439,7 @@ fn short_unicode_escape_backslash_adjacent_control_byte_not_misattributed() {
     // 3-hex-digit case above. That adjacency is spurious: both bytes are
     // consumed as `\u`'s own hex-digit slots, never reinterpreted as a fresh
     // `\<ctrl>` escape pair. The failure must stay the plain malformed
-    // unicode-escape message with no double-escape guidance.
+    // unicode-escape message with no control-character escape guidance.
     let src = format!("gtd.assign(title=\"bad \\u12\\{}tail\")", '\u{c}');
     let err = parse_request(&src).unwrap_err();
     let msg = err.to_string();
@@ -450,7 +449,7 @@ fn short_unicode_escape_backslash_adjacent_control_byte_not_misattributed() {
         "expected the plain serde invalid-escape message, got: {msg}"
     );
     assert!(
-        !msg.to_lowercase().contains("double"),
+        !msg.contains("DSL string escapes follow JSON"),
         "a short \\u escape landing on a backslash+control-byte pair must not be \
          enriched with the control-char diagnostic, got: {msg}"
     );
@@ -463,8 +462,8 @@ fn short_unicode_escape_backslash_adjacent_control_byte_not_misattributed() {
     let genuine_msg = genuine_err.to_string();
     assert!(matches!(genuine_err, DslError::InvalidValue { .. }));
     assert!(
-        genuine_msg.to_lowercase().contains("double"),
-        "a genuine broken \\<ctrl> pair must still get the double-escape guidance, got: {genuine_msg}"
+        genuine_msg.contains("DSL string escapes follow JSON"),
+        "a genuine broken \\<ctrl> pair must still get the escape guidance, got: {genuine_msg}"
     );
 }
 
@@ -477,7 +476,7 @@ fn leading_surrogate_escape_followed_by_control_byte_not_misattributed() {
     // escape. Scan's general backslash-pair walk resets after the high
     // surrogate's 4 hex slots, so without the surrogate-continuation guard it
     // would record that `\<ctrl>` as a genuine broken pair
-    // (`preceded_by_backslash: true`) and land the double-escape teaching on a
+    // (`preceded_by_backslash: true`) and land the escape teaching on a
     // failure it does not explain. The continuation control byte must not be
     // recorded, so the error stays serde's own surrogate message.
     let src = format!("gtd.assign(title=\"bad \\uD800\\{}tail\")", '\u{c}');
@@ -485,9 +484,9 @@ fn leading_surrogate_escape_followed_by_control_byte_not_misattributed() {
     let msg = err.to_string();
     assert!(matches!(err, DslError::InvalidValue { .. }));
     assert!(
-        !msg.to_lowercase().contains("double"),
+        !msg.contains("DSL string escapes follow JSON"),
         "a control byte on a surrogate-continuation path must not be enriched \
-         with the control-char double-escape diagnostic, got: {msg}"
+         with the control-char escape diagnostic, got: {msg}"
     );
 
     // A broken `\<ctrl>` pair AFTER a complete surrogate pair (high + low) is a
@@ -498,9 +497,9 @@ fn leading_surrogate_escape_followed_by_control_byte_not_misattributed() {
     let after_pair_msg = after_pair_err.to_string();
     assert!(matches!(after_pair_err, DslError::InvalidValue { .. }));
     assert!(
-        after_pair_msg.to_lowercase().contains("double"),
+        after_pair_msg.contains("DSL string escapes follow JSON"),
         "a broken \\<ctrl> pair after a complete surrogate pair must still get \
-         the double-escape guidance, got: {after_pair_msg}"
+         the escape guidance, got: {after_pair_msg}"
     );
 }
 
@@ -520,10 +519,7 @@ fn raw_newline_immediately_after_backslash_caught_as_control_char_cause() {
         msg.contains(r#"\n"#) && msg.contains(r#"\t"#) && msg.contains(r#"\""#),
         "error should name the JSON escape grammar, got: {msg}"
     );
-    assert!(
-        msg.to_lowercase().contains("double"),
-        "error should call out the MCP double-escape requirement, got: {msg}"
-    );
+    assert!(msg.contains("DSL string escapes follow JSON"));
 }
 
 #[test]
@@ -539,8 +535,8 @@ fn raw_carriage_return_and_tab_after_backslash_also_caught() {
         );
         let msg = err.to_string();
         assert!(
-            msg.to_lowercase().contains("double"),
-            "error should call out the MCP double-escape requirement for {:#04x}, got: {msg}",
+            msg.contains("DSL string escapes follow JSON"),
+            "error should explain DSL escape syntax for {:#04x}, got: {msg}",
             raw as u32
         );
     }
@@ -563,8 +559,8 @@ fn backslash_followed_by_other_raw_control_bytes_also_caught() {
         );
         let msg = err.to_string();
         assert!(
-            msg.to_lowercase().contains("double"),
-            "error should call out the MCP double-escape requirement for {:#04x}, got: {msg}",
+            msg.contains("DSL string escapes follow JSON"),
+            "error should explain DSL escape syntax for {:#04x}, got: {msg}",
             raw as u32
         );
     }

--- a/scripts/lint-stub-markers.sh
+++ b/scripts/lint-stub-markers.sh
@@ -382,6 +382,20 @@ FIXTURE
             fi
         done
 
+        # Line attribution advances with the forward macro scan. Check more
+        # than one location so a future cursor change cannot silently report
+        # every finding relative to the previous macro or to byte zero.
+        for location in \
+            "crates/fixture-crate/src/lib.rs:4: unreachable!" \
+            "crates/fixture-crate/src/lib.rs:11: panic!"
+        do
+            if ! grep -qF "$location" "$tmp/fail.log"; then
+                echo "self-test FAILED: expected finding location missing: $location"
+                cat "$tmp/fail.log"
+                status=1
+            fi
+        done
+
         # the ci_log_forgery_stub and c1_csi_forgery_stub messages carry raw
         # control bytes (an ANSI ESC, a single-byte C1 CSI decoded from \u{9b}, an
         # embedded newline) plus a literal "::error::forged" workflow-command
@@ -434,33 +448,12 @@ PYCTL
         status=1
     fi
 
-    # The committed allowlist is validated by running the scanner over the real
-    # tree with it: the unused-entry guard fails loud on any entry that suppresses
-    # no current finding (stale, moved, or pre-planted), and the malformed-line
-    # guard fails loud on a no-TAB entry. That is the scanner's own contract, so a
-    # comment-only file (its state today) passes and a legitimate committed
-    # suppression -- one that matches a current finding -- passes too, where a
-    # blunt "no active line" assertion would wrongly reject it. Any offending
-    # entry is named through the scanner's own sanitize_for_ci output, never
-    # echoed raw from the file. The committed file carries NO self-test fixture
-    # anchor: a committed entry is a real, PR-recreatable suppression, so a fixture
-    # there would let a PR add that exact path+message and suppress its own stub.
-    # Suppression is exercised via a temp copy below.
-    #
-    # This repeats the production scan's full-tree pass; removing that duplication
-    # is the self-test/production structure work tracked in #1108.
-    committed_allowlist="$SCRIPT_DIR/stub-marker-allowlist.txt"
-    if ! STUB_MARKER_ALLOWLIST="$committed_allowlist" scan "$ROOT" git > "$tmp/committed.log" 2>&1; then
-        echo "self-test FAILED: the committed allowlist did not pass the scanner over the real tree -- a malformed, stale, or pre-planted allowlist entry, or an un-suppressed placeholder stub in the tree (named below):"
-        cat "$tmp/committed.log"
-        status=1
-    fi
-
-    # Suppression is exercised against a TEMP allowlist: a copy of the committed
-    # file (so a committed parse/format break still surfaces) with a fixture
-    # anchor appended. The anchor entry suppresses the matching finding, so it is
-    # used and the unused-entry guard stays satisfied; a sibling with a different
-    # message at the same path still surfaces, checking exact-match both ways.
+    # Suppression is exercised against an isolated fixture allowlist. Production
+    # validates the committed allowlist during the normal full-tree scan; keeping
+    # that state out of the self-test avoids scanning the real tree twice and lets
+    # legitimate production entries coexist with fixture-only paths. The anchor
+    # suppresses its exact finding while a sibling message at the same path still
+    # surfaces, checking exact-match both ways.
     mkdir -p "$tmp/case-allowlist/crates/fixture-crate/src"
     cat > "$tmp/case-allowlist/crates/fixture-crate/src/lib.rs" <<'ALWFIXTURE'
 pub fn allowlisted_stub() -> u32 {
@@ -469,12 +462,11 @@ pub fn allowlisted_stub() -> u32 {
 
 pub fn not_allowlisted_stub() -> u32 {
     panic!("todo: this one is NOT allowlisted and must still be caught")
-}
+    }
 ALWFIXTURE
     temp_allowlist="$tmp/case-allowlist-allowlist.txt"
-    cp "$committed_allowlist" "$temp_allowlist"
     printf 'crates/fixture-crate/src/lib.rs\ttodo: this one is allowlisted and must be suppressed\n' \
-        >> "$temp_allowlist"
+        > "$temp_allowlist"
 
     if STUB_MARKER_ALLOWLIST="$temp_allowlist" scan "$tmp/case-allowlist" find > "$tmp/allowlist.log" 2>&1; then
         echo "self-test FAILED: the non-allowlisted sibling finding should have failed the scan"
@@ -1051,12 +1043,11 @@ with open(out_symlinks, "wb") as fh:
         allowlist_is_override=0
     fi
 
-    # `|| rc=$?` keeps set -e from exiting the script the moment python3 returns
-    # non-zero (findings present, or the allowlist-path guard failing): the temp
-    # file_list below must still be removed on that path, and the caller needs
-    # the real exit code, not a set-e-induced abort.
+    # Keep the heredoc command in an explicit conditional so set -e cannot exit
+    # before the temp lists are removed. Handling the status after the heredoc
+    # terminator also keeps the Python/shell boundary unambiguous.
     rc=0
-    python3 - "$file_list" "$allowlist" "$root" "$symlink_list" "$allowlist_is_override" <<'PY' || rc=$?
+    if python3 - "$file_list" "$allowlist" "$root" "$symlink_list" "$allowlist_is_override" <<'PY'
 import errno
 import os
 import re
@@ -1710,7 +1701,11 @@ for path in files:
     clean = strip_comments_and_char_lits(text)
     code_only = blank_strings(clean)
 
+    line_no = 1
+    line_cursor = 0
     for m in MACRO_CALL_RE.finditer(code_only):
+        line_no += clean.count("\n", line_cursor, m.start())
+        line_cursor = m.start()
         call_start = m.end() - 1  # the opening delimiter char (`(`/`{`/`[`)
         # The first argument is the format template; every later argument is a
         # positional value or a `name = value` named value. Each literal
@@ -1747,7 +1742,6 @@ for path in files:
         if idx is not None:
             allowlist_used[idx] = True
             continue
-        line_no = clean.count("\n", 0, m.start()) + 1
         macro_name = m.group(1)
         findings.append(
             f'{sanitize_for_ci(rel_path)}:{line_no}: {macro_name}!("{sanitize_for_ci(message)}") '
@@ -1782,6 +1776,11 @@ if failed:
 
 print(f"stub-marker lint: {len(files)} file(s) OK")
 PY
+    then
+        rc=0
+    else
+        rc=$?
+    fi
     rm -f "$file_list" "$symlink_list"
     return "$rc"
 }


### PR DESCRIPTION
## Summary
Two small follow-ups, one branch:

- **#1108** `scripts/lint-stub-markers.sh`: line attribution now uses a monotonically advancing cursor instead of re-counting the whole file prefix per finding (linear in file length); the embedded heredoc is an explicit condition with exit-code capture; `--self-test` drops its duplicate production-tree scan and asserts exact finding locations.
- **#1106** `crates/khive-request`: `normalize_quoted_string` is one forward state-machine pass that keeps borrowed storage for control-free strings and allocates only when the first control byte requires owned output; the generic parser diagnostic states only the transport-neutral escape contract.

Closes #1108. Closes #1106.

## Testing
- `control_free_string_stays_borrowed_after_single_scan` (new)
- `control_char_error_teaches_escape_syntax_without_transport_guidance` (red before fix: message still carried JSON-transport advice)
- `lint-stub-markers.sh --self-test` extended with exact line-attribution assertions; full scan of 420 files passes.
- `cargo test -p khive-request` 23 unit + 139 integration green; clippy `-D warnings` clean; workspace check clean.
