### PR TITLE
fix(kkernel): honor the selected config through exec, local fallback, and replay

### DIFF
--- a/crates/khive-mcp/src/daemon.rs
+++ b/crates/khive-mcp/src/daemon.rs
@@ -628,20 +628,40 @@ fn prepare_daemon_log_file(log_path: &std::path::Path) -> Option<std::fs::File> 
     prepare_daemon_log_file_with_cap(log_path, DAEMON_LOG_MAX_BYTES)
 }
 
-fn spawn_daemon() -> std::io::Result<std::process::Child> {
-    let exe = std::env::current_exe()?;
-    spawn_daemon_with_exe(&exe)
+fn daemon_args(config: Option<&std::path::Path>) -> Vec<std::ffi::OsString> {
+    let mut args = vec![
+        std::ffi::OsString::from("mcp"),
+        std::ffi::OsString::from("--daemon"),
+    ];
+    if let Some(path) = config {
+        args.push(std::ffi::OsString::from("--config"));
+        args.push(path.as_os_str().to_os_string());
+    }
+    args
 }
 
-fn spawn_daemon_with_exe(exe: &std::path::Path) -> std::io::Result<std::process::Child> {
+fn spawn_daemon() -> std::io::Result<std::process::Child> {
+    spawn_daemon_with_config(None)
+}
+
+fn spawn_daemon_with_config(
+    config: Option<&std::path::Path>,
+) -> std::io::Result<std::process::Child> {
+    let exe = std::env::current_exe()?;
+    spawn_daemon_with_exe_and_config(&exe, config)
+}
+
+fn spawn_daemon_with_exe_and_config(
+    exe: &std::path::Path,
+    config: Option<&std::path::Path>,
+) -> std::io::Result<std::process::Child> {
     #[cfg(test)]
     SPAWN_COUNT.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
 
     // The binary is `kkernel`; the MCP server (and its daemon mode) live under
     // the `mcp` subcommand.
     let mut cmd = std::process::Command::new(exe);
-    cmd.arg("mcp")
-        .arg("--daemon")
+    cmd.args(daemon_args(config))
         .stdin(Stdio::null())
         .stdout(Stdio::null());
     // The daemon's tracing (including WAL/checkpoint telemetry) goes to
@@ -1710,12 +1730,31 @@ pub async fn forward_or_spawn(frame: &DaemonRequestFrame) -> Option<Result<Strin
     forward_or_spawn_with(frame, &spawn_daemon).await
 }
 
+/// Forward a request and propagate an explicitly selected config to any
+/// daemon process this call auto-spawns.
+pub async fn forward_or_spawn_with_config(
+    frame: &DaemonRequestFrame,
+    config: Option<&std::path::Path>,
+) -> Option<Result<String, McpError>> {
+    let spawn = || spawn_daemon_with_config(config);
+    forward_or_spawn_with(frame, &spawn).await
+}
+
 #[cfg(test)]
 async fn forward_or_spawn_with_exe(
     frame: &DaemonRequestFrame,
     exe: &std::path::Path,
 ) -> Option<Result<String, McpError>> {
-    let spawn = || spawn_daemon_with_exe(exe);
+    forward_or_spawn_with_exe_and_config(frame, exe, None).await
+}
+
+#[cfg(test)]
+async fn forward_or_spawn_with_exe_and_config(
+    frame: &DaemonRequestFrame,
+    exe: &std::path::Path,
+    config: Option<&std::path::Path>,
+) -> Option<Result<String, McpError>> {
+    let spawn = || spawn_daemon_with_exe_and_config(exe, config);
     forward_or_spawn_with(frame, &spawn).await
 }
 
@@ -2938,6 +2977,60 @@ mod tests {
         std::env::remove_var("KHIVE_LOCK");
     }
 
+    #[cfg(unix)]
+    #[tokio::test]
+    #[serial]
+    async fn strict_auto_spawn_passes_selected_config() {
+        clear_daemon_env();
+        reset_fallback_counters();
+        let dir = tempfile::tempdir().expect("tempdir");
+        let captured_args = dir.path().join("daemon-args");
+        let config = dir.path().join("selected-khive.toml");
+        std::env::set_var("KHIVE_SOCKET", dir.path().join("khived.sock"));
+        std::env::set_var("KHIVE_PID", dir.path().join("khived.pid"));
+        std::env::set_var("KHIVE_LOCK", dir.path().join("khived.recovery.lock"));
+        std::env::set_var("KHIVE_DAEMON_STRICT", "1");
+        std::env::set_var("KHIVE_TEST_DAEMON_ARGS", &captured_args);
+        std::env::remove_var("KHIVE_NO_DAEMON");
+        let exe = daemon_script_fixture(
+            &dir,
+            "capture-args",
+            "#!/bin/sh\nprintf '%s\\n' \"$@\" > \"$KHIVE_TEST_DAEMON_ARGS\"\nsleep 10\n",
+        );
+
+        let out = forward_or_spawn_with_exe_and_config(
+            &unreachable_daemon_frame(CFG),
+            &exe,
+            Some(&config),
+        )
+        .await;
+
+        let error = match out {
+            Some(Err(error)) => error,
+            other => panic!(
+                "strict mode must reject the no-socket fallback after the spawn probe: {other:?}"
+            ),
+        };
+        let data = error.data.expect("strict fallback error data");
+        assert_eq!(data[STRICT_FALLBACK_MARKER], true);
+        assert_eq!(data["reason"], "no_socket");
+        let args = std::fs::read_to_string(&captured_args).expect("read captured daemon args");
+        assert_eq!(
+            args.lines().collect::<Vec<_>>(),
+            [
+                "mcp",
+                "--daemon",
+                "--config",
+                config.to_str().expect("UTF-8 config path")
+            ]
+        );
+
+        clear_daemon_env();
+        std::env::remove_var("KHIVE_LOCK");
+        std::env::remove_var("KHIVE_DAEMON_STRICT");
+        std::env::remove_var("KHIVE_TEST_DAEMON_ARGS");
+    }
+
     #[tokio::test]
     #[serial]
     async fn daemon_round_trip_dispatches_and_enforces_config_id() {
@@ -3584,6 +3677,22 @@ mod tests {
     fn argv_daemon_true_bare() {
         // Exact daemon argv as spawned by spawn_daemon().
         assert!(argv_is_khive_daemon("kkernel mcp --daemon"));
+    }
+
+    #[test]
+    fn daemon_args_include_selected_config() {
+        let config = std::path::Path::new("/tmp/selected-khive.toml");
+        let args = daemon_args(Some(config));
+
+        assert_eq!(
+            args,
+            [
+                std::ffi::OsString::from("mcp"),
+                std::ffi::OsString::from("--daemon"),
+                std::ffi::OsString::from("--config"),
+                config.as_os_str().to_os_string(),
+            ]
+        );
     }
 
     #[test]

--- a/crates/khive-mcp/src/pending_events.rs
+++ b/crates/khive-mcp/src/pending_events.rs
@@ -141,6 +141,19 @@ pub async fn run_pending_events(
     namespace: &str,
     verbose: bool,
 ) -> Result<DrainSummary> {
+    run_pending_events_with_config(db, None, namespace, verbose).await
+}
+
+/// One-shot drain using an explicit config selection.
+///
+/// This is the config-aware counterpart used by `kkernel exec` when
+/// `--config` or `KHIVE_CONFIG` selected a non-default instance.
+pub async fn run_pending_events_with_config(
+    db: Option<&str>,
+    config: Option<&std::path::Path>,
+    namespace: &str,
+    verbose: bool,
+) -> Result<DrainSummary> {
     // Resolve through the SAME multi-backend-aware construction the daemon
     // boot path uses (`khive-mcp::serve::build_server_with_explicit_namespace`),
     // rather than a throwaway `RuntimeConfig::default()` (PR #782):
@@ -155,11 +168,10 @@ pub async fn run_pending_events(
     // (single- or multi-backend), so replayed actions route through the
     // correct per-pack backend exactly like the daemon tick now does — not a
     // single runtime standing in for every pack (the same issue this fix
-    // closes for the daemon-resident tick). `kkernel exec` has no
-    // `--config` flag today (see `kkernel::exec::run_exec`'s own
-    // `resolve_runtime_config` call), so this mirrors that: `config: None`
-    // still triggers `khive.toml`'s standard cwd/home search order inside
-    // `resolve_runtime_config`.
+    // closes for the daemon-resident tick). `config` carries the same explicit
+    // `--config`/`KHIVE_CONFIG` selection as ordinary `kkernel exec`
+    // operations. `None` still triggers the standard cwd/database/home search
+    // order inside `resolve_runtime_config`.
     //
     // This does NOT call `crate::serve::build_server` directly (PR #782):
     // `build_server` derives BOTH
@@ -194,7 +206,7 @@ pub async fn run_pending_events(
         namespace: None,
         no_embed: false,
         pack: Vec::new(),
-        config: None,
+        config: config.map(std::path::Path::to_path_buf),
         daemon: false,
         transport: None,
         bind: None,

--- a/crates/kkernel/src/exec.rs
+++ b/crates/kkernel/src/exec.rs
@@ -198,6 +198,13 @@ pub struct ExecArgs {
     #[arg(long, env = "KHIVE_DB")]
     pub db: Option<String>,
 
+    /// Path to a khive TOML config file.
+    ///
+    /// Overrides the standard cwd/database/home config discovery order and
+    /// matches `kkernel mcp` and `kkernel reindex` (`KHIVE_CONFIG`).
+    #[arg(long, env = "KHIVE_CONFIG")]
+    pub config: Option<PathBuf>,
+
     /// Namespace to operate in.
     #[arg(long, default_value = "local")]
     pub namespace: String,
@@ -498,9 +505,13 @@ async fn apply_ops_file(
 pub async fn run_exec(args: ExecArgs) -> Result<()> {
     // ── pending-events drain ─────────────────────────────────────────────────
     if args.pending_events {
-        let summary =
-            pending_events::run_pending_events(args.db.as_deref(), &args.namespace, args.verbose)
-                .await?;
+        let summary = pending_events::run_pending_events_with_config(
+            args.db.as_deref(),
+            args.config.as_deref(),
+            &args.namespace,
+            args.verbose,
+        )
+        .await?;
         pending_events::print_summary(&summary);
         return Ok(());
     }
@@ -536,7 +547,7 @@ pub async fn run_exec(args: ExecArgs) -> Result<()> {
     let (cfg, db_anchor) =
         khive_mcp::serve::resolve_runtime_config_with_db_anchor(RuntimeConfigInputs {
             db: args.db.as_deref(),
-            config: None, // `kkernel exec` has no `--config` flag today
+            config: args.config.as_deref(),
             namespace,
             // `--namespace` has a clap `default_value = "local"`, so it is always
             // present — there is no way to distinguish "operator typed --namespace
@@ -571,6 +582,7 @@ pub async fn run_exec(args: ExecArgs) -> Result<()> {
     let db_context = ExecDbContext {
         raw: args.db,
         anchor: db_anchor,
+        config: args.config,
     };
 
     match mode {
@@ -635,6 +647,7 @@ enum ExecMode {
 struct ExecDbContext {
     raw: Option<String>,
     anchor: Option<PathBuf>,
+    config: Option<PathBuf>,
 }
 
 async fn run_exec_inline(
@@ -710,8 +723,8 @@ async fn run_exec_inline_with_forward(
     // daemon's own boot path loads (`serve.rs`'s `build_server`:
     // `KhiveConfig::load_with_home_fallback(args.config.as_deref(),
     // config_discovery_db_anchor(args.db.as_deref()).as_deref())` —
-    // `kkernel exec` has no `--config` flag, so the first argument here is
-    // always `None`, exactly like there. The second argument is the raw
+    // The first argument is the same explicit `--config`/`KHIVE_CONFIG`
+    // selection used during initial resolution. The second argument is the raw
     // `--db`/`KHIVE_DB` discovery anchor (`None` unless `--db` was set) rather
     // than `cfg.db_path` — `cfg.db_path` materializes the `$HOME/.khive`
     // default when `--db` is unset (#689), which would incorrectly re-anchor
@@ -726,9 +739,12 @@ async fn run_exec_inline_with_forward(
     // `ConfigMismatch` and silently fell back to the cold in-process path on
     // every call.
     let db_path_for_config = config_discovery_db_anchor(db_context.raw.as_deref());
-    let khive_cfg = KhiveConfig::load_with_home_fallback(None, db_path_for_config.as_deref())
-        .map_err(|e| anyhow::anyhow!("config error: {e}"))?
-        .unwrap_or_default();
+    let khive_cfg = KhiveConfig::load_with_home_fallback(
+        db_context.config.as_deref(),
+        db_path_for_config.as_deref(),
+    )
+    .map_err(|e| anyhow::anyhow!("config error: {e}"))?
+    .unwrap_or_default();
 
     // #1226: apply the same --db/[[backends]] conflict guard the in-process
     // fallback below applies, BEFORE the daemon fast-path — otherwise a warm
@@ -893,9 +909,12 @@ async fn run_exec_ops_file(
     // path — see `build_local_fallback_server`.
     enforce_strict_actor_mode(cfg.actor_id.as_deref(), &cfg.packs)?;
     let db_path_for_config = config_discovery_db_anchor(db_context.raw.as_deref());
-    let khive_cfg = KhiveConfig::load_with_home_fallback(None, db_path_for_config.as_deref())
-        .map_err(|e| anyhow::anyhow!("config error: {e}"))?
-        .unwrap_or_default();
+    let khive_cfg = KhiveConfig::load_with_home_fallback(
+        db_context.config.as_deref(),
+        db_path_for_config.as_deref(),
+    )
+    .map_err(|e| anyhow::anyhow!("config error: {e}"))?
+    .unwrap_or_default();
 
     if atomic {
         let max_ops = atomic_max_ops.unwrap_or(khive_types::pack::ATOMIC_MAX_OPS_DEFAULT);
@@ -2652,6 +2671,7 @@ backend = "sessions"
             ExecDbContext {
                 raw: Some(conflicting_override.display().to_string()),
                 anchor: None,
+                config: None,
             },
             false,
             spy_capture_config_id,

--- a/crates/kkernel/src/exec.rs
+++ b/crates/kkernel/src/exec.rs
@@ -26,7 +26,7 @@
 
 use std::collections::BTreeMap;
 use std::io::BufRead as _;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result};
 use clap::Parser;
@@ -62,12 +62,17 @@ type ForwardFuture<'a> = std::pin::Pin<
 
 /// Function pointer type for the daemon-forwarding seam.
 #[cfg(unix)]
-type ForwardFnPtr = for<'a> fn(&'a DaemonRequestFrame) -> ForwardFuture<'a>;
+type ForwardFnPtr = for<'a> fn(&'a DaemonRequestFrame, Option<&'a Path>) -> ForwardFuture<'a>;
 
-/// Adapts the real `forward_or_spawn` to the `ForwardFnPtr` signature.
+/// Adapts the real daemon forwarding path to the `ForwardFnPtr` signature.
 #[cfg(unix)]
-fn forward_or_spawn_boxed(frame: &DaemonRequestFrame) -> ForwardFuture<'_> {
-    Box::pin(khive_mcp::daemon::forward_or_spawn(frame))
+fn forward_or_spawn_boxed<'a>(
+    frame: &'a DaemonRequestFrame,
+    config: Option<&'a Path>,
+) -> ForwardFuture<'a> {
+    Box::pin(khive_mcp::daemon::forward_or_spawn_with_config(
+        frame, config,
+    ))
 }
 
 // The scheduled-event drain now lives in `khive-mcp` (ADR-106: the
@@ -791,7 +796,7 @@ async fn run_exec_inline_with_forward(
             from_wire: false,
             request_id: None,
         };
-        if let Some(res) = forward_fn(&frame).await {
+        if let Some(res) = forward_fn(&frame, db_context.config.as_deref()).await {
             let output = res.map_err(|e| anyhow::anyhow!("{}", e.message))?;
             println!("{output}");
             enforce_strict_batch_result(&output, strict)?;
@@ -2482,37 +2487,48 @@ default = true
     std::thread_local! {
         static SPY_CAPTURED_CONFIG_ID: std::cell::RefCell<Option<String>> =
             const { std::cell::RefCell::new(None) };
+        static SPY_CAPTURED_CONFIG_PATH: std::cell::RefCell<Option<PathBuf>> =
+            const { std::cell::RefCell::new(None) };
     }
 
     #[cfg(unix)]
-    fn spy_capture_config_id(frame: &DaemonRequestFrame) -> super::ForwardFuture<'_> {
+    fn spy_capture_config_id<'a>(
+        frame: &'a DaemonRequestFrame,
+        config: Option<&'a Path>,
+    ) -> super::ForwardFuture<'a> {
         SPY_CAPTURED_CONFIG_ID.with(|c| *c.borrow_mut() = Some(frame.config_id.clone()));
-        Box::pin(async { None })
+        SPY_CAPTURED_CONFIG_PATH.with(|c| *c.borrow_mut() = config.map(Path::to_path_buf));
+        Box::pin(async {
+            Some(Ok(
+                r#"{"results":[],"summary":{"total":0,"succeeded":0,"failed":0,"aborted":0}}"#
+                    .to_string(),
+            ))
+        })
     }
 
     #[cfg(unix)]
     #[tokio::test]
     #[serial]
-    async fn exec_frame_config_id_matches_daemon_config_id_for_multi_backend_project_toml() {
+    async fn cli_only_config_reaches_strict_daemon_spawn_with_matching_config_id() {
         std::env::remove_var("KHIVE_EMBEDDING_MODEL");
         std::env::remove_var("KHIVE_ADDITIONAL_EMBEDDING_MODELS");
         std::env::remove_var("KHIVE_ACTOR");
         std::env::remove_var("KHIVE_REQUIRE_ATTRIBUTED_ACTOR");
+        let previous_config = std::env::var_os("KHIVE_CONFIG");
+        let previous_strict = std::env::var_os("KHIVE_DAEMON_STRICT");
+        std::env::remove_var("KHIVE_CONFIG");
+        std::env::set_var("KHIVE_DAEMON_STRICT", "1");
         let (prev_home, home_dir) = isolate_home_for_test();
         SPY_CAPTURED_CONFIG_ID.with(|c| *c.borrow_mut() = None);
+        SPY_CAPTURED_CONFIG_PATH.with(|c| *c.borrow_mut() = None);
 
-        // No explicit `--db` anywhere below — this mirrors the real multi-tenant
-        // deployment shape the bug affects: `~/.khive/config.toml` declares
-        // `[[backends]]` and `kkernel exec` relies on default discovery. An
-        // explicit `--db` would itself be rejected as ambiguous once backends
-        // are declared (ADR-028 §8, `build_registry_for_multi_backend`), so it
-        // is not a legitimate way to reach this scenario — default discovery is.
         let khive_dir = home_dir.path().join(".khive");
         std::fs::create_dir_all(&khive_dir).expect("mkdir .khive");
         let main_backend_path = khive_dir.join("main-backend.db");
         let sessions_backend_path = khive_dir.join("sessions-backend.db");
+        let config_path = home_dir.path().join("selected-khive.toml");
         std::fs::write(
-            khive_dir.join("config.toml"),
+            &config_path,
             format!(
                 r#"
 [[backends]]
@@ -2532,14 +2548,22 @@ backend = "sessions"
                 sessions_backend_path.display(),
             ),
         )
-        .expect("write multi-backend config.toml");
+        .expect("write selected config");
 
-        // `no_embed: true` keeps this test fast and network-independent — it is
-        // scoped to the backends-topology fold, not embedding-model resolution
-        // (a separate, already-covered concern in the sibling project-toml test).
+        let args = ExecArgs::parse_from([
+            "exec",
+            "stats()",
+            "--config",
+            config_path.to_str().expect("UTF-8 config path"),
+        ]);
+        assert!(
+            std::env::var_os("KHIVE_CONFIG").is_none(),
+            "the selected config must come only from the CLI"
+        );
+
         let cfg = resolve_runtime_config(RuntimeConfigInputs {
             db: None,
-            config: None,
+            config: args.config.as_deref(),
             namespace: Namespace::parse("local").expect("ns"),
             namespace_explicit: true,
             actor_explicit: false,
@@ -2558,7 +2582,10 @@ backend = "sessions"
             None,
             None,
             None,
-            ExecDbContext::default(),
+            ExecDbContext {
+                config: args.config.clone(),
+                ..ExecDbContext::default()
+            },
             false,
             spy_capture_config_id,
         )
@@ -2568,6 +2595,10 @@ backend = "sessions"
         let captured = SPY_CAPTURED_CONFIG_ID
             .with(|c| c.borrow_mut().take())
             .expect("spy must have captured a forwarded frame");
+        let captured_config_path = SPY_CAPTURED_CONFIG_PATH
+            .with(|c| c.borrow_mut().take())
+            .expect("spy must have captured the daemon spawn config");
+        assert_eq!(captured_config_path, config_path);
 
         // Independently compute what the DAEMON would compute for the exact
         // same on-disk config.toml + database, mirroring serve.rs's own boot
@@ -2577,7 +2608,7 @@ backend = "sessions"
         // serve.rs:916 does.
         let serve_cfg = resolve_runtime_config(RuntimeConfigInputs {
             db: None,
-            config: None,
+            config: Some(&config_path),
             namespace: Namespace::parse("local").expect("ns"),
             namespace_explicit: false,
             actor_explicit: false,
@@ -2589,9 +2620,10 @@ backend = "sessions"
             brain_profile: None,
         })
         .expect("resolve serve-shaped config");
-        let khive_cfg = KhiveConfig::load_with_home_fallback(None, serve_cfg.db_path.as_deref())
-            .expect("load multi-backend config.toml")
-            .expect("config.toml must be found at tier 3");
+        let khive_cfg =
+            KhiveConfig::load_with_home_fallback(Some(&config_path), serve_cfg.db_path.as_deref())
+                .expect("load selected config")
+                .expect("selected config must be found");
         assert!(
             !khive_cfg.backends.is_empty(),
             "sanity: the written config.toml must actually resolve with a non-empty \
@@ -2599,6 +2631,14 @@ backend = "sessions"
         );
         let daemon_config_id = compute_config_id(&serve_cfg, Some(&khive_cfg));
         restore_home(prev_home);
+        match previous_config {
+            Some(value) => std::env::set_var("KHIVE_CONFIG", value),
+            None => std::env::remove_var("KHIVE_CONFIG"),
+        }
+        match previous_strict {
+            Some(value) => std::env::set_var("KHIVE_DAEMON_STRICT", value),
+            None => std::env::remove_var("KHIVE_DAEMON_STRICT"),
+        }
 
         assert_eq!(
             captured, daemon_config_id,

--- a/crates/kkernel/tests/config_discovery_reload_anchor.rs
+++ b/crates/kkernel/tests/config_discovery_reload_anchor.rs
@@ -110,6 +110,7 @@ path = "{}"
         ops: Some("stats()".to_string()),
         pending_events: false,
         db: None, // the repro shape: --db left unset
+        config: None,
         namespace: "local".to_string(),
         presentation: Some("agent".to_string()),
         output_format: None,

--- a/crates/kkernel/tests/config_env_db_isolation.rs
+++ b/crates/kkernel/tests/config_env_db_isolation.rs
@@ -1,0 +1,101 @@
+use std::path::Path;
+
+use clap::Parser;
+use khive_runtime::{KhiveRuntime, RuntimeConfig};
+use khive_storage::types::{SqlStatement, SqlValue};
+use kkernel::exec::{run_exec, ExecArgs};
+
+fn initialize_store(path: &Path) {
+    let runtime = KhiveRuntime::new(RuntimeConfig {
+        db_path: Some(path.to_path_buf()),
+        packs: vec!["kg".to_string()],
+        ..RuntimeConfig::no_embeddings()
+    })
+    .expect("initialize isolated store");
+    drop(runtime);
+}
+
+async fn count_named_entities(path: &Path, name: &str) -> i64 {
+    let runtime = KhiveRuntime::new(RuntimeConfig {
+        db_path: Some(path.to_path_buf()),
+        packs: vec!["kg".to_string()],
+        ..RuntimeConfig::no_embeddings()
+    })
+    .expect("open isolated store");
+    let sql = runtime.sql();
+    let mut reader = sql.reader().await.expect("open isolated store reader");
+    let row = reader
+        .query_row(SqlStatement {
+            sql: "SELECT COUNT(*) AS count FROM entities WHERE name = ?1".to_string(),
+            params: vec![SqlValue::Text(name.to_string())],
+            label: Some("config_env_db_isolation_count".to_string()),
+        })
+        .await
+        .expect("count named entities")
+        .expect("count query returns one row");
+    match row.get("count") {
+        Some(SqlValue::Integer(count)) => *count,
+        other => panic!("unexpected count value: {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn khive_config_override_keeps_create_out_of_default_store() {
+    let root = tempfile::tempdir().expect("isolated test root");
+    let default_home = root.path().join("default-home");
+    let sandbox_dir = root.path().join("sandbox");
+    std::fs::create_dir_all(default_home.join(".khive")).expect("create default store dir");
+    std::fs::create_dir_all(&sandbox_dir).expect("create sandbox store dir");
+
+    let default_db = default_home.join(".khive/khive.db");
+    let overridden_db = sandbox_dir.join("khive.db");
+    initialize_store(&default_db);
+    initialize_store(&overridden_db);
+
+    let config_path = sandbox_dir.join("config.toml");
+    std::fs::write(
+        &config_path,
+        format!(
+            r#"
+[[backends]]
+name = "main"
+kind = "sqlite"
+path = "{}"
+"#,
+            overridden_db.display()
+        ),
+    )
+    .expect("write sandbox config");
+
+    std::env::set_var("HOME", &default_home);
+    std::env::set_var("KHIVE_CONFIG", &config_path);
+    std::env::set_var("KHIVE_NO_DAEMON", "1");
+    std::env::set_var("KHIVE_LOCK", sandbox_dir.join("khived.lock"));
+    std::env::set_var(
+        "KHIVE_RECOVERER_LOCK",
+        sandbox_dir.join("khived.recoverer.lock"),
+    );
+    std::env::set_var("KHIVE_PACKS", "kg");
+    for key in "KHIVE_DB KHIVE_EMBEDDING_MODEL KHIVE_ADDITIONAL_EMBEDDING_MODELS \
+                KHIVE_ACTOR KHIVE_REQUIRE_ATTRIBUTED_ACTOR KHIVE_BLOB_ROOT"
+        .split_whitespace()
+    {
+        std::env::remove_var(key);
+    }
+
+    let entity_name = "config-selected-store-only";
+    let args = ExecArgs::parse_from([
+        "exec",
+        &format!(r#"create(items=[{{"kind":"concept","name":"{entity_name}"}}])"#),
+    ]);
+    assert_eq!(args.config.as_deref(), Some(config_path.as_path()));
+    run_exec(args).await.expect("create through kkernel exec");
+
+    let overridden_count = count_named_entities(&overridden_db, entity_name).await;
+    let default_count = count_named_entities(&default_db, entity_name).await;
+    assert_eq!(
+        (overridden_count, default_count),
+        (1, 0),
+        "create must land only in the KHIVE_CONFIG-selected store, never the HOME-derived default"
+    );
+}


### PR DESCRIPTION
## Summary

`kkernel exec` now honors `--config`/`KHIVE_CONFIG` through every layer: initial runtime resolution, inline and ops-file local-fallback topology reloads, and pending-event replay. Previously a secondary instance whose config selected an isolated backend could fall back to the HOME-derived default database for creates.

Closes #1246

## Changes

- `crates/kkernel/src/exec.rs`: bind the config selector on `ExecArgs`; carry it through initial resolution, `ExecDbContext` reloads, and pending-event replay.
- `crates/khive-mcp/src/pending_events.rs`: config-aware pending-event entry point; selected config flows into programmatic MCP server construction.
- New regression `config_env_db_isolation.rs`: two independent temp stores; create via `kkernel exec` with `KHIVE_CONFIG` set must land in the override store only (`(1, 0)`).

## Verification

- Regression red-to-green: exit 101 before (create landed in default store), exit 0 after.
- `kkernel` exec tests (54), `khive-mcp` pending_events tests (30), fmt, clippy `-D warnings`, `cargo check --workspace` all green.
