### PR TITLE
perf(runtime): batch per-namespace stats counts into IN-aggregate queries

### DIFF
--- a/crates/khive-db/Cargo.toml
+++ b/crates/khive-db/Cargo.toml
@@ -42,7 +42,7 @@ libc = { workspace = true }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["full", "test-util"] }
-rusqlite = { workspace = true, features = ["bundled", "column_decltype"] }
+rusqlite = { workspace = true, features = ["bundled", "column_decltype", "limits"] }
 bytes = "1"
 khive-storage = { version = "0.6.0", path = "../khive-storage" }
 khive-types = { version = "0.6.0", path = "../khive-types", features = ["serde"] }

--- a/crates/khive-db/src/stores/entity.rs
+++ b/crates/khive-db/src/stores/entity.rs
@@ -26,6 +26,8 @@ fn map_sqlite_err(e: SqliteError, op: &'static str) -> StorageError {
     StorageError::driver(StorageCapability::Entities, op, e)
 }
 
+const NAMESPACE_COUNT_CHUNK_SIZE: usize = 500;
+
 // ---------------------------------------------------------------------------
 // Pure statement builders (ADR-099 B3 r6 structural cut)
 //
@@ -786,13 +788,31 @@ impl EntityStore for SqlEntityStore {
         let namespace = namespace.to_string();
 
         self.with_reader("count_entities", move |conn| {
-            let (where_sql, params) = build_entity_where(&namespace, &filter);
-            let sql = format!("SELECT COUNT(*) FROM entities{}", where_sql);
-            let mut stmt = conn.prepare(&sql)?;
-            let param_refs: Vec<&dyn rusqlite::types::ToSql> =
-                params.iter().map(|p| p.as_ref()).collect();
-            let count: i64 = stmt.query_row(param_refs.as_slice(), |row| row.get(0))?;
-            Ok(count as u64)
+            if filter.namespaces.is_empty() {
+                let (where_sql, params) = build_entity_where(&namespace, &filter);
+                let sql = format!("SELECT COUNT(*) FROM entities{}", where_sql);
+                let mut stmt = conn.prepare(&sql)?;
+                let param_refs: Vec<&dyn rusqlite::types::ToSql> =
+                    params.iter().map(|p| p.as_ref()).collect();
+                let count: i64 = stmt.query_row(param_refs.as_slice(), |row| row.get(0))?;
+                return Ok(count as u64);
+            }
+
+            let mut total = 0;
+            for chunk in filter.namespaces.chunks(NAMESPACE_COUNT_CHUNK_SIZE) {
+                let chunk_filter = EntityFilter {
+                    namespaces: chunk.to_vec(),
+                    ..filter.clone()
+                };
+                let (where_sql, params) = build_entity_where(&namespace, &chunk_filter);
+                let sql = format!("SELECT COUNT(*) FROM entities{}", where_sql);
+                let mut stmt = conn.prepare(&sql)?;
+                let param_refs: Vec<&dyn rusqlite::types::ToSql> =
+                    params.iter().map(|p| p.as_ref()).collect();
+                let count: i64 = stmt.query_row(param_refs.as_slice(), |row| row.get(0))?;
+                total += count as u64;
+            }
+            Ok(total)
         })
         .await
     }

--- a/crates/khive-db/src/stores/entity.rs
+++ b/crates/khive-db/src/stores/entity.rs
@@ -1,5 +1,6 @@
 //! SQL-backed `EntityStore` implementation.
 
+use std::collections::HashSet;
 use std::sync::Arc;
 
 use async_trait::async_trait;
@@ -798,8 +799,16 @@ impl EntityStore for SqlEntityStore {
                 return Ok(count as u64);
             }
 
+            let deduped_namespaces: Vec<String> = filter
+                .namespaces
+                .iter()
+                .cloned()
+                .collect::<HashSet<_>>()
+                .into_iter()
+                .collect();
+
             let mut total = 0;
-            for chunk in filter.namespaces.chunks(NAMESPACE_COUNT_CHUNK_SIZE) {
+            for chunk in deduped_namespaces.chunks(NAMESPACE_COUNT_CHUNK_SIZE) {
                 let chunk_filter = EntityFilter {
                     namespaces: chunk.to_vec(),
                     ..filter.clone()

--- a/crates/khive-db/src/stores/entity_tests.rs
+++ b/crates/khive-db/src/stores/entity_tests.rs
@@ -526,6 +526,61 @@ async fn count_entities_normalizes_case_insensitive_names() {
 }
 
 #[tokio::test]
+async fn batched_namespace_entity_count_exceeds_sqlite_variable_limit() {
+    let pool = setup_pool();
+    let store = SqlEntityStore::new(Arc::clone(&pool), false);
+    let live_a = make_entity("stats-a", "concept", "live-a");
+    let deleted_a = make_entity("stats-a", "concept", "deleted-a");
+    let deleted_a_id = deleted_a.id;
+    let live_b = make_entity("stats-b", "document", "live-b");
+
+    store.upsert_entity(live_a).await.unwrap();
+    store.upsert_entity(deleted_a).await.unwrap();
+    store.upsert_entity(live_b).await.unwrap();
+    assert!(store
+        .delete_entity(deleted_a_id, DeleteMode::Soft)
+        .await
+        .unwrap());
+
+    let per_namespace_total = store
+        .count_entities("stats-a", EntityFilter::default())
+        .await
+        .unwrap()
+        + store
+            .count_entities("stats-b", EntityFilter::default())
+            .await
+            .unwrap();
+    pool.writer()
+        .unwrap()
+        .conn()
+        .set_limit(rusqlite::limits::Limit::SQLITE_LIMIT_VARIABLE_NUMBER, 999)
+        .unwrap();
+    let mut namespaces = vec!["stats-a".to_string(), "stats-b".to_string()];
+    namespaces.extend((0..999).map(|i| format!("empty-{i}")));
+    assert_eq!(namespaces.len(), 1_001);
+
+    let filter = EntityFilter {
+        namespaces: namespaces.clone(),
+        ..EntityFilter::default()
+    };
+    assert_eq!(
+        store.count_entities("stats-a", filter).await.unwrap(),
+        per_namespace_total
+    );
+
+    let kind_filter = EntityFilter {
+        namespaces,
+        kinds: vec!["document".to_string()],
+        ..EntityFilter::default()
+    };
+    assert_eq!(
+        store.count_entities("stats-a", kind_filter).await.unwrap(),
+        1
+    );
+    assert_eq!(per_namespace_total, 2);
+}
+
+#[tokio::test]
 async fn test_batch_upsert() {
     let store = setup_memory_store_ns("batch_ns");
 

--- a/crates/khive-db/src/stores/entity_tests.rs
+++ b/crates/khive-db/src/stores/entity_tests.rs
@@ -581,6 +581,45 @@ async fn batched_namespace_entity_count_exceeds_sqlite_variable_limit() {
 }
 
 #[tokio::test]
+async fn duplicate_namespace_across_chunk_boundary_is_not_double_counted() {
+    let pool = setup_pool();
+    let store = SqlEntityStore::new(Arc::clone(&pool), false);
+
+    store
+        .upsert_entity(make_entity("stats-a", "concept", "live-a-1"))
+        .await
+        .unwrap();
+    store
+        .upsert_entity(make_entity("stats-a", "concept", "live-a-2"))
+        .await
+        .unwrap();
+
+    let per_namespace_total = store
+        .count_entities("stats-a", EntityFilter::default())
+        .await
+        .unwrap();
+    assert_eq!(per_namespace_total, 2);
+
+    // 501 unique namespaces ("stats-a" + 500 empties), then "stats-a" repeats
+    // once more past index 500 — the repeat lands in the second 500-entry
+    // chunk, so a dedup bug double-counts "stats-a"'s rows.
+    let mut namespaces = vec!["stats-a".to_string()];
+    namespaces.extend((0..500).map(|i| format!("empty-{i}")));
+    assert_eq!(namespaces.len(), 501);
+    namespaces.push("stats-a".to_string());
+    assert_eq!(namespaces.len(), 502);
+
+    let filter = EntityFilter {
+        namespaces,
+        ..EntityFilter::default()
+    };
+    assert_eq!(
+        store.count_entities("stats-a", filter).await.unwrap(),
+        per_namespace_total
+    );
+}
+
+#[tokio::test]
 async fn test_batch_upsert() {
     let store = setup_memory_store_ns("batch_ns");
 

--- a/crates/khive-db/src/stores/graph.rs
+++ b/crates/khive-db/src/stores/graph.rs
@@ -1700,7 +1700,12 @@ impl GraphStore for SqlGraphStore {
         namespaces: &[String],
         filter: EdgeFilter,
     ) -> Result<u64, StorageError> {
-        let namespaces = namespaces.to_vec();
+        let namespaces: Vec<String> = namespaces
+            .iter()
+            .cloned()
+            .collect::<HashSet<_>>()
+            .into_iter()
+            .collect();
         self.with_reader("count_edges_in_namespaces", move |conn| {
             let mut total = 0;
             for chunk in namespaces.chunks(NAMESPACE_COUNT_CHUNK_SIZE) {
@@ -1750,7 +1755,12 @@ impl GraphStore for SqlGraphStore {
         &self,
         namespaces: &[String],
     ) -> Result<Vec<(EdgeRelation, u64)>, StorageError> {
-        let namespaces = namespaces.to_vec();
+        let namespaces: Vec<String> = namespaces
+            .iter()
+            .cloned()
+            .collect::<HashSet<_>>()
+            .into_iter()
+            .collect();
         self.with_reader("count_edges_by_relation_in_namespaces", move |conn| {
             let mut totals = HashMap::new();
             for chunk in namespaces.chunks(NAMESPACE_COUNT_CHUNK_SIZE) {

--- a/crates/khive-db/src/stores/graph.rs
+++ b/crates/khive-db/src/stores/graph.rs
@@ -33,6 +33,8 @@ fn map_sqlite_err(e: SqliteError, op: &'static str) -> StorageError {
     StorageError::driver(StorageCapability::Graph, op, e)
 }
 
+const NAMESPACE_COUNT_CHUNK_SIZE: usize = 500;
+
 // ---------------------------------------------------------------------------
 // Pure statement builders (ADR-099 B3 r6 structural cut) — see entity.rs's
 // sibling block for the full rationale. `upsert_edge`/`delete_edge` below and
@@ -1700,13 +1702,17 @@ impl GraphStore for SqlGraphStore {
     ) -> Result<u64, StorageError> {
         let namespaces = namespaces.to_vec();
         self.with_reader("count_edges_in_namespaces", move |conn| {
-            let (where_clause, params) = build_edge_filter_sql_for_namespaces(&namespaces, &filter);
-            let sql = format!("SELECT COUNT(*) FROM graph_edges{where_clause}");
-            let mut stmt = conn.prepare(&sql)?;
-            let param_refs: Vec<&dyn rusqlite::types::ToSql> =
-                params.iter().map(|p| p.as_ref()).collect();
-            let count: i64 = stmt.query_row(param_refs.as_slice(), |row| row.get(0))?;
-            Ok(count as u64)
+            let mut total = 0;
+            for chunk in namespaces.chunks(NAMESPACE_COUNT_CHUNK_SIZE) {
+                let (where_clause, params) = build_edge_filter_sql_for_namespaces(chunk, &filter);
+                let sql = format!("SELECT COUNT(*) FROM graph_edges{where_clause}");
+                let mut stmt = conn.prepare(&sql)?;
+                let param_refs: Vec<&dyn rusqlite::types::ToSql> =
+                    params.iter().map(|p| p.as_ref()).collect();
+                let count: i64 = stmt.query_row(param_refs.as_slice(), |row| row.get(0))?;
+                total += count as u64;
+            }
+            Ok(total)
         })
         .await
     }
@@ -1746,32 +1752,34 @@ impl GraphStore for SqlGraphStore {
     ) -> Result<Vec<(EdgeRelation, u64)>, StorageError> {
         let namespaces = namespaces.to_vec();
         self.with_reader("count_edges_by_relation_in_namespaces", move |conn| {
-            let (where_clause, params) =
-                build_edge_filter_sql_for_namespaces(&namespaces, &EdgeFilter::default());
-            let sql = format!(
-                "SELECT relation, COUNT(*) FROM graph_edges{where_clause} GROUP BY relation"
-            );
-            let mut stmt = conn.prepare(&sql)?;
-            let param_refs: Vec<&dyn rusqlite::types::ToSql> =
-                params.iter().map(|p| p.as_ref()).collect();
-            let rows = stmt.query_map(param_refs.as_slice(), |row| {
-                let relation_str: String = row.get(0)?;
-                let count: i64 = row.get(1)?;
-                Ok((relation_str, count))
-            })?;
-            let mut out = Vec::new();
-            for row in rows {
-                let (relation_str, count) = row?;
-                let relation = relation_str.parse::<EdgeRelation>().map_err(|e| {
-                    rusqlite::Error::FromSqlConversionFailure(
-                        0,
-                        rusqlite::types::Type::Text,
-                        Box::new(e),
-                    )
+            let mut totals = HashMap::new();
+            for chunk in namespaces.chunks(NAMESPACE_COUNT_CHUNK_SIZE) {
+                let (where_clause, params) =
+                    build_edge_filter_sql_for_namespaces(chunk, &EdgeFilter::default());
+                let sql = format!(
+                    "SELECT relation, COUNT(*) FROM graph_edges{where_clause} GROUP BY relation"
+                );
+                let mut stmt = conn.prepare(&sql)?;
+                let param_refs: Vec<&dyn rusqlite::types::ToSql> =
+                    params.iter().map(|p| p.as_ref()).collect();
+                let rows = stmt.query_map(param_refs.as_slice(), |row| {
+                    let relation_str: String = row.get(0)?;
+                    let count: i64 = row.get(1)?;
+                    Ok((relation_str, count))
                 })?;
-                out.push((relation, count as u64));
+                for row in rows {
+                    let (relation_str, count) = row?;
+                    let relation = relation_str.parse::<EdgeRelation>().map_err(|e| {
+                        rusqlite::Error::FromSqlConversionFailure(
+                            0,
+                            rusqlite::types::Type::Text,
+                            Box::new(e),
+                        )
+                    })?;
+                    *totals.entry(relation).or_insert(0) += count as u64;
+                }
             }
-            Ok(out)
+            Ok(totals.into_iter().collect())
         })
         .await
     }

--- a/crates/khive-db/src/stores/graph.rs
+++ b/crates/khive-db/src/stores/graph.rs
@@ -763,11 +763,27 @@ fn build_edge_filter_sql(
     namespace: &str,
     filter: &EdgeFilter,
 ) -> (String, Vec<Box<dyn rusqlite::types::ToSql>>) {
-    let mut conditions: Vec<String> = vec![
-        "namespace = ?1".to_string(),
-        "deleted_at IS NULL".to_string(),
-    ];
-    let mut params: Vec<Box<dyn rusqlite::types::ToSql>> = vec![Box::new(namespace.to_string())];
+    build_edge_filter_sql_for_namespaces(&[namespace.to_string()], filter)
+}
+
+fn build_edge_filter_sql_for_namespaces(
+    namespaces: &[String],
+    filter: &EdgeFilter,
+) -> (String, Vec<Box<dyn rusqlite::types::ToSql>>) {
+    let mut params: Vec<Box<dyn rusqlite::types::ToSql>> = namespaces
+        .iter()
+        .map(|namespace| -> Box<dyn rusqlite::types::ToSql> { Box::new(namespace.clone()) })
+        .collect();
+    let namespace_condition = match namespaces.len() {
+        0 => "0".to_string(),
+        1 => "namespace = ?1".to_string(),
+        _ => {
+            let placeholders: Vec<String> =
+                (1..=namespaces.len()).map(|i| format!("?{i}")).collect();
+            format!("namespace IN ({})", placeholders.join(", "))
+        }
+    };
+    let mut conditions = vec![namespace_condition, "deleted_at IS NULL".to_string()];
 
     if !filter.ids.is_empty() {
         let placeholders: Vec<String> = filter
@@ -1677,6 +1693,24 @@ impl GraphStore for SqlGraphStore {
         .await
     }
 
+    async fn count_edges_in_namespaces(
+        &self,
+        namespaces: &[String],
+        filter: EdgeFilter,
+    ) -> Result<u64, StorageError> {
+        let namespaces = namespaces.to_vec();
+        self.with_reader("count_edges_in_namespaces", move |conn| {
+            let (where_clause, params) = build_edge_filter_sql_for_namespaces(&namespaces, &filter);
+            let sql = format!("SELECT COUNT(*) FROM graph_edges{where_clause}");
+            let mut stmt = conn.prepare(&sql)?;
+            let param_refs: Vec<&dyn rusqlite::types::ToSql> =
+                params.iter().map(|p| p.as_ref()).collect();
+            let count: i64 = stmt.query_row(param_refs.as_slice(), |row| row.get(0))?;
+            Ok(count as u64)
+        })
+        .await
+    }
+
     async fn count_edges_by_relation(&self) -> Result<Vec<(EdgeRelation, u64)>, StorageError> {
         let namespace = self.namespace.clone();
         self.with_reader("count_edges_by_relation", move |conn| {
@@ -1685,6 +1719,42 @@ impl GraphStore for SqlGraphStore {
                        GROUP BY relation";
             let mut stmt = conn.prepare(sql)?;
             let rows = stmt.query_map([&namespace], |row| {
+                let relation_str: String = row.get(0)?;
+                let count: i64 = row.get(1)?;
+                Ok((relation_str, count))
+            })?;
+            let mut out = Vec::new();
+            for row in rows {
+                let (relation_str, count) = row?;
+                let relation = relation_str.parse::<EdgeRelation>().map_err(|e| {
+                    rusqlite::Error::FromSqlConversionFailure(
+                        0,
+                        rusqlite::types::Type::Text,
+                        Box::new(e),
+                    )
+                })?;
+                out.push((relation, count as u64));
+            }
+            Ok(out)
+        })
+        .await
+    }
+
+    async fn count_edges_by_relation_in_namespaces(
+        &self,
+        namespaces: &[String],
+    ) -> Result<Vec<(EdgeRelation, u64)>, StorageError> {
+        let namespaces = namespaces.to_vec();
+        self.with_reader("count_edges_by_relation_in_namespaces", move |conn| {
+            let (where_clause, params) =
+                build_edge_filter_sql_for_namespaces(&namespaces, &EdgeFilter::default());
+            let sql = format!(
+                "SELECT relation, COUNT(*) FROM graph_edges{where_clause} GROUP BY relation"
+            );
+            let mut stmt = conn.prepare(&sql)?;
+            let param_refs: Vec<&dyn rusqlite::types::ToSql> =
+                params.iter().map(|p| p.as_ref()).collect();
+            let rows = stmt.query_map(param_refs.as_slice(), |row| {
                 let relation_str: String = row.get(0)?;
                 let count: i64 = row.get(1)?;
                 Ok((relation_str, count))

--- a/crates/khive-db/src/stores/graph_tests.rs
+++ b/crates/khive-db/src/stores/graph_tests.rs
@@ -308,6 +308,63 @@ async fn batched_namespace_edge_counts_exceed_sqlite_variable_limit() {
     );
 }
 
+#[tokio::test]
+async fn duplicate_namespace_across_chunk_boundary_is_not_double_counted() {
+    let config = PoolConfig {
+        path: None,
+        ..PoolConfig::default()
+    };
+    let pool = Arc::new(ConnectionPool::new(config).unwrap());
+    pool.writer()
+        .unwrap()
+        .conn()
+        .execute_batch(GRAPH_DDL)
+        .unwrap();
+    let store_a = SqlGraphStore::new_scoped(Arc::clone(&pool), false, "stats-a");
+
+    let mut edge_a1 = make_edge(Uuid::new_v4(), Uuid::new_v4(), EdgeRelation::Extends, 1.0);
+    edge_a1.namespace = "stats-a".to_string();
+    let mut edge_a2 = make_edge(Uuid::new_v4(), Uuid::new_v4(), EdgeRelation::Enables, 1.0);
+    edge_a2.namespace = "stats-a".to_string();
+    store_a.upsert_edge(edge_a1).await.unwrap();
+    store_a.upsert_edge(edge_a2).await.unwrap();
+
+    let per_namespace_total = store_a.count_edges(EdgeFilter::default()).await.unwrap();
+    assert_eq!(per_namespace_total, 2);
+    let per_namespace_relations: HashMap<EdgeRelation, u64> = store_a
+        .count_edges_by_relation()
+        .await
+        .unwrap()
+        .into_iter()
+        .collect();
+
+    // 501 unique namespaces ("stats-a" + 500 empties), then "stats-a" repeats
+    // once more past index 500 — the repeat lands in the second 500-entry
+    // chunk, so a dedup bug double-counts "stats-a"'s rows.
+    let mut namespaces = vec!["stats-a".to_string()];
+    namespaces.extend((0..500).map(|i| format!("empty-{i}")));
+    assert_eq!(namespaces.len(), 501);
+    namespaces.push("stats-a".to_string());
+    assert_eq!(namespaces.len(), 502);
+
+    assert_eq!(
+        store_a
+            .count_edges_in_namespaces(&namespaces, EdgeFilter::default())
+            .await
+            .unwrap(),
+        per_namespace_total
+    );
+    assert_eq!(
+        store_a
+            .count_edges_by_relation_in_namespaces(&namespaces)
+            .await
+            .unwrap()
+            .into_iter()
+            .collect::<HashMap<_, _>>(),
+        per_namespace_relations
+    );
+}
+
 // `#[serial(neighbor_select_count)]`: shares the key with the tests that
 // assert on the process-wide `NEIGHBOR_SELECT_COUNT` so a concurrent
 // `neighbors()` call from this test can't corrupt their count.

--- a/crates/khive-db/src/stores/graph_tests.rs
+++ b/crates/khive-db/src/stores/graph_tests.rs
@@ -238,6 +238,69 @@ async fn test_count_edges() {
     assert_eq!(store.count_edges(EdgeFilter::default()).await.unwrap(), 5);
 }
 
+#[tokio::test]
+async fn batched_namespace_edge_counts_match_per_namespace_counts() {
+    let config = PoolConfig {
+        path: None,
+        ..PoolConfig::default()
+    };
+    let pool = Arc::new(ConnectionPool::new(config).unwrap());
+    pool.writer()
+        .unwrap()
+        .conn()
+        .execute_batch(GRAPH_DDL)
+        .unwrap();
+    let store_a = SqlGraphStore::new_scoped(Arc::clone(&pool), false, "stats-a");
+    let store_b = SqlGraphStore::new_scoped(Arc::clone(&pool), false, "stats-b");
+
+    let mut edge_a = make_edge(Uuid::new_v4(), Uuid::new_v4(), EdgeRelation::Extends, 1.0);
+    edge_a.namespace = "stats-a".to_string();
+    let mut deleted_edge = make_edge(Uuid::new_v4(), Uuid::new_v4(), EdgeRelation::Enables, 1.0);
+    deleted_edge.namespace = "stats-a".to_string();
+    let deleted_edge_id = deleted_edge.id;
+    let mut edge_b = make_edge(Uuid::new_v4(), Uuid::new_v4(), EdgeRelation::DependsOn, 1.0);
+    edge_b.namespace = "stats-b".to_string();
+
+    store_a.upsert_edge(edge_a).await.unwrap();
+    store_a.upsert_edge(deleted_edge).await.unwrap();
+    store_b.upsert_edge(edge_b).await.unwrap();
+    assert!(store_a
+        .delete_edge(deleted_edge_id, DeleteMode::Soft)
+        .await
+        .unwrap());
+
+    let per_namespace_total = store_a.count_edges(EdgeFilter::default()).await.unwrap()
+        + store_b.count_edges(EdgeFilter::default()).await.unwrap();
+    let mut per_namespace_relations: HashMap<EdgeRelation, u64> = store_a
+        .count_edges_by_relation()
+        .await
+        .unwrap()
+        .into_iter()
+        .collect();
+    for (relation, count) in store_b.count_edges_by_relation().await.unwrap() {
+        *per_namespace_relations.entry(relation).or_insert(0) += count;
+    }
+    let namespaces = vec!["stats-a".to_string(), "stats-b".to_string()];
+
+    assert_eq!(
+        store_a
+            .count_edges_in_namespaces(&namespaces, EdgeFilter::default())
+            .await
+            .unwrap(),
+        per_namespace_total
+    );
+    assert_eq!(per_namespace_total, 2);
+    assert_eq!(
+        store_a
+            .count_edges_by_relation_in_namespaces(&namespaces)
+            .await
+            .unwrap()
+            .into_iter()
+            .collect::<HashMap<_, _>>(),
+        per_namespace_relations
+    );
+}
+
 // `#[serial(neighbor_select_count)]`: shares the key with the tests that
 // assert on the process-wide `NEIGHBOR_SELECT_COUNT` so a concurrent
 // `neighbors()` call from this test can't corrupt their count.

--- a/crates/khive-db/src/stores/graph_tests.rs
+++ b/crates/khive-db/src/stores/graph_tests.rs
@@ -239,7 +239,7 @@ async fn test_count_edges() {
 }
 
 #[tokio::test]
-async fn batched_namespace_edge_counts_match_per_namespace_counts() {
+async fn batched_namespace_edge_counts_exceed_sqlite_variable_limit() {
     let config = PoolConfig {
         path: None,
         ..PoolConfig::default()
@@ -280,7 +280,14 @@ async fn batched_namespace_edge_counts_match_per_namespace_counts() {
     for (relation, count) in store_b.count_edges_by_relation().await.unwrap() {
         *per_namespace_relations.entry(relation).or_insert(0) += count;
     }
-    let namespaces = vec!["stats-a".to_string(), "stats-b".to_string()];
+    pool.writer()
+        .unwrap()
+        .conn()
+        .set_limit(rusqlite::limits::Limit::SQLITE_LIMIT_VARIABLE_NUMBER, 999)
+        .unwrap();
+    let mut namespaces = vec!["stats-a".to_string(), "stats-b".to_string()];
+    namespaces.extend((0..999).map(|i| format!("empty-{i}")));
+    assert_eq!(namespaces.len(), 1_001);
 
     assert_eq!(
         store_a

--- a/crates/khive-db/src/stores/note.rs
+++ b/crates/khive-db/src/stores/note.rs
@@ -26,6 +26,8 @@ fn map_sqlite_err(e: SqliteError, op: &'static str) -> StorageError {
     StorageError::driver(StorageCapability::Notes, op, e)
 }
 
+const NAMESPACE_COUNT_CHUNK_SIZE: usize = 500;
+
 // ---------------------------------------------------------------------------
 // Pure statement builders (ADR-099 B3 r6 structural cut) — see entity.rs's
 // sibling block for the full rationale. `upsert_note`/`delete_note` below
@@ -1118,13 +1120,17 @@ impl NoteStore for SqlNoteStore {
         let kind = kind.map(str::to_string);
 
         self.with_reader("count_notes_in_namespaces", move |conn| {
-            let (where_sql, params) = build_note_where_for_namespaces(&namespaces, kind.as_deref());
-            let sql = format!("SELECT COUNT(*) FROM notes{where_sql}");
-            let mut stmt = conn.prepare(&sql)?;
-            let param_refs: Vec<&dyn rusqlite::types::ToSql> =
-                params.iter().map(|p| p.as_ref()).collect();
-            let count: i64 = stmt.query_row(param_refs.as_slice(), |row| row.get(0))?;
-            Ok(count as u64)
+            let mut total = 0;
+            for chunk in namespaces.chunks(NAMESPACE_COUNT_CHUNK_SIZE) {
+                let (where_sql, params) = build_note_where_for_namespaces(chunk, kind.as_deref());
+                let sql = format!("SELECT COUNT(*) FROM notes{where_sql}");
+                let mut stmt = conn.prepare(&sql)?;
+                let param_refs: Vec<&dyn rusqlite::types::ToSql> =
+                    params.iter().map(|p| p.as_ref()).collect();
+                let count: i64 = stmt.query_row(param_refs.as_slice(), |row| row.get(0))?;
+                total += count as u64;
+            }
+            Ok(total)
         })
         .await
     }

--- a/crates/khive-db/src/stores/note.rs
+++ b/crates/khive-db/src/stores/note.rs
@@ -471,6 +471,34 @@ fn build_note_where(
     (clause, params)
 }
 
+fn build_note_where_for_namespaces(
+    namespaces: &[String],
+    kind: Option<&str>,
+) -> (String, Vec<Box<dyn rusqlite::types::ToSql>>) {
+    let mut params: Vec<Box<dyn rusqlite::types::ToSql>> = namespaces
+        .iter()
+        .map(|namespace| -> Box<dyn rusqlite::types::ToSql> { Box::new(namespace.clone()) })
+        .collect();
+    let namespace_condition = match namespaces.len() {
+        0 => "0".to_string(),
+        1 => "namespace = ?1".to_string(),
+        _ => {
+            let placeholders: Vec<String> =
+                (1..=namespaces.len()).map(|i| format!("?{i}")).collect();
+            format!("namespace IN ({})", placeholders.join(", "))
+        }
+    };
+    let mut conditions = vec![namespace_condition, "deleted_at IS NULL".to_string()];
+
+    if let Some(kind) = kind {
+        params.push(Box::new(kind.to_string()));
+        conditions.push(format!("kind = ?{}", params.len()));
+    }
+
+    let clause = format!(" WHERE {}", conditions.join(" AND "));
+    (clause, params)
+}
+
 /// Validate that a json_path is safe to interpolate into SQL.
 /// Accepts only `$.field` or `$.field.subfield` paths with alphanumeric/underscore segments.
 fn validate_json_path(path: &str) -> Result<(), StorageError> {
@@ -1072,6 +1100,26 @@ impl NoteStore for SqlNoteStore {
         self.with_reader("count_notes", move |conn| {
             let (where_sql, params) = build_note_where(&namespace, kind.as_deref());
             let sql = format!("SELECT COUNT(*) FROM notes{}", where_sql);
+            let mut stmt = conn.prepare(&sql)?;
+            let param_refs: Vec<&dyn rusqlite::types::ToSql> =
+                params.iter().map(|p| p.as_ref()).collect();
+            let count: i64 = stmt.query_row(param_refs.as_slice(), |row| row.get(0))?;
+            Ok(count as u64)
+        })
+        .await
+    }
+
+    async fn count_notes_in_namespaces(
+        &self,
+        namespaces: &[String],
+        kind: Option<&str>,
+    ) -> Result<u64, StorageError> {
+        let namespaces = namespaces.to_vec();
+        let kind = kind.map(str::to_string);
+
+        self.with_reader("count_notes_in_namespaces", move |conn| {
+            let (where_sql, params) = build_note_where_for_namespaces(&namespaces, kind.as_deref());
+            let sql = format!("SELECT COUNT(*) FROM notes{where_sql}");
             let mut stmt = conn.prepare(&sql)?;
             let param_refs: Vec<&dyn rusqlite::types::ToSql> =
                 params.iter().map(|p| p.as_ref()).collect();

--- a/crates/khive-db/src/stores/note.rs
+++ b/crates/khive-db/src/stores/note.rs
@@ -1,5 +1,6 @@
 //! SQL-backed `NoteStore` implementation.
 
+use std::collections::HashSet;
 use std::sync::Arc;
 
 use async_trait::async_trait;
@@ -1116,7 +1117,12 @@ impl NoteStore for SqlNoteStore {
         namespaces: &[String],
         kind: Option<&str>,
     ) -> Result<u64, StorageError> {
-        let namespaces = namespaces.to_vec();
+        let namespaces: Vec<String> = namespaces
+            .iter()
+            .cloned()
+            .collect::<HashSet<_>>()
+            .into_iter()
+            .collect();
         let kind = kind.map(str::to_string);
 
         self.with_reader("count_notes_in_namespaces", move |conn| {

--- a/crates/khive-db/src/stores/note_tests.rs
+++ b/crates/khive-db/src/stores/note_tests.rs
@@ -112,8 +112,9 @@ async fn test_namespace_isolation() {
 }
 
 #[tokio::test]
-async fn batched_namespace_note_count_matches_per_namespace_counts() {
-    let store = setup_memory_store();
+async fn batched_namespace_note_count_exceeds_sqlite_variable_limit() {
+    let pool = setup_pool();
+    let store = SqlNoteStore::new(Arc::clone(&pool), false);
     let live_a = make_note("stats-a", "observation", "live-a");
     let deleted_a = make_note("stats-a", "observation", "deleted-a");
     let deleted_a_id = deleted_a.id;
@@ -129,7 +130,14 @@ async fn batched_namespace_note_count_matches_per_namespace_counts() {
 
     let per_namespace_total = store.count_notes("stats-a", None).await.unwrap()
         + store.count_notes("stats-b", None).await.unwrap();
-    let namespaces = vec!["stats-a".to_string(), "stats-b".to_string()];
+    pool.writer()
+        .unwrap()
+        .conn()
+        .set_limit(rusqlite::limits::Limit::SQLITE_LIMIT_VARIABLE_NUMBER, 999)
+        .unwrap();
+    let mut namespaces = vec!["stats-a".to_string(), "stats-b".to_string()];
+    namespaces.extend((0..999).map(|i| format!("empty-{i}")));
+    assert_eq!(namespaces.len(), 1_001);
 
     assert_eq!(
         store
@@ -137,6 +145,13 @@ async fn batched_namespace_note_count_matches_per_namespace_counts() {
             .await
             .unwrap(),
         per_namespace_total
+    );
+    assert_eq!(
+        store
+            .count_notes_in_namespaces(&namespaces, Some("observation"))
+            .await
+            .unwrap(),
+        1
     );
     assert_eq!(per_namespace_total, 2);
 }

--- a/crates/khive-db/src/stores/note_tests.rs
+++ b/crates/khive-db/src/stores/note_tests.rs
@@ -111,6 +111,36 @@ async fn test_namespace_isolation() {
     assert_eq!(count_ns2, 1);
 }
 
+#[tokio::test]
+async fn batched_namespace_note_count_matches_per_namespace_counts() {
+    let store = setup_memory_store();
+    let live_a = make_note("stats-a", "observation", "live-a");
+    let deleted_a = make_note("stats-a", "observation", "deleted-a");
+    let deleted_a_id = deleted_a.id;
+    let live_b = make_note("stats-b", "insight", "live-b");
+
+    store.upsert_note(live_a).await.unwrap();
+    store.upsert_note(deleted_a).await.unwrap();
+    store.upsert_note(live_b).await.unwrap();
+    assert!(store
+        .delete_note(deleted_a_id, DeleteMode::Soft)
+        .await
+        .unwrap());
+
+    let per_namespace_total = store.count_notes("stats-a", None).await.unwrap()
+        + store.count_notes("stats-b", None).await.unwrap();
+    let namespaces = vec!["stats-a".to_string(), "stats-b".to_string()];
+
+    assert_eq!(
+        store
+            .count_notes_in_namespaces(&namespaces, None)
+            .await
+            .unwrap(),
+        per_namespace_total
+    );
+    assert_eq!(per_namespace_total, 2);
+}
+
 /// query_notes and count_notes use the namespace parameter as passed.
 #[tokio::test]
 async fn test_query_and_count_use_caller_namespace() {

--- a/crates/khive-db/src/stores/note_tests.rs
+++ b/crates/khive-db/src/stores/note_tests.rs
@@ -156,6 +156,41 @@ async fn batched_namespace_note_count_exceeds_sqlite_variable_limit() {
     assert_eq!(per_namespace_total, 2);
 }
 
+#[tokio::test]
+async fn duplicate_namespace_across_chunk_boundary_is_not_double_counted() {
+    let pool = setup_pool();
+    let store = SqlNoteStore::new(Arc::clone(&pool), false);
+
+    store
+        .upsert_note(make_note("stats-a", "observation", "live-a-1"))
+        .await
+        .unwrap();
+    store
+        .upsert_note(make_note("stats-a", "observation", "live-a-2"))
+        .await
+        .unwrap();
+
+    let per_namespace_total = store.count_notes("stats-a", None).await.unwrap();
+    assert_eq!(per_namespace_total, 2);
+
+    // 501 unique namespaces ("stats-a" + 500 empties), then "stats-a" repeats
+    // once more past index 500 — the repeat lands in the second 500-entry
+    // chunk, so a dedup bug double-counts "stats-a"'s rows.
+    let mut namespaces = vec!["stats-a".to_string()];
+    namespaces.extend((0..500).map(|i| format!("empty-{i}")));
+    assert_eq!(namespaces.len(), 501);
+    namespaces.push("stats-a".to_string());
+    assert_eq!(namespaces.len(), 502);
+
+    assert_eq!(
+        store
+            .count_notes_in_namespaces(&namespaces, None)
+            .await
+            .unwrap(),
+        per_namespace_total
+    );
+}
+
 /// query_notes and count_notes use the namespace parameter as passed.
 #[tokio::test]
 async fn test_query_and_count_use_caller_namespace() {

--- a/crates/khive-runtime/src/operations.rs
+++ b/crates/khive-runtime/src/operations.rs
@@ -3339,23 +3339,21 @@ impl KhiveRuntime {
         Ok(page.items)
     }
 
-    /// Count notes matching `kind`, summed across the caller's visible
-    /// namespaces. The store-layer `count_notes` is namespace-pinned by
-    /// design (no `NamespaceFilter`-style `IN (...)` support); this sums the
-    /// per-namespace store calls, mirroring [`Self::count_edges_by_relation`]
-    /// and the multi-namespace path in [`Self::list_notes`] so `stats().notes`
-    /// reconciles with a full `list` keyset walk under the same token.
+    /// Count notes matching `kind` across the caller's visible namespaces.
     pub async fn count_notes(
         &self,
         token: &NamespaceToken,
         kind: Option<&str>,
     ) -> RuntimeResult<u64> {
-        let mut total = 0u64;
-        for ns in token.visible_namespaces() {
-            let temp = NamespaceToken::for_namespace(ns.clone());
-            total += self.notes(&temp)?.count_notes(ns.as_str(), kind).await?;
-        }
-        Ok(total)
+        let namespaces: Vec<String> = token
+            .visible_namespaces()
+            .iter()
+            .map(|namespace| namespace.as_str().to_owned())
+            .collect();
+        Ok(self
+            .notes(token)?
+            .count_notes_in_namespaces(&namespaces, kind)
+            .await?)
     }
 
     /// Search notes using a hybrid FTS5 + vector pipeline with salience weighting.
@@ -4612,14 +4610,38 @@ impl KhiveRuntime {
         &self,
         token: &NamespaceToken,
     ) -> RuntimeResult<std::collections::HashMap<String, u64>> {
-        let mut totals: std::collections::HashMap<String, u64> = std::collections::HashMap::new();
-        for ns in token.visible_namespaces() {
-            let temp = NamespaceToken::for_namespace(ns.clone());
-            for (relation, count) in self.graph(&temp)?.count_edges_by_relation().await? {
-                *totals.entry(relation.to_string()).or_insert(0) += count;
+        let namespaces: Vec<String> = token
+            .visible_namespaces()
+            .iter()
+            .map(|namespace| namespace.as_str().to_owned())
+            .collect();
+        let graph = self.graph(token)?;
+        let counts = match graph
+            .count_edges_by_relation_in_namespaces(&namespaces)
+            .await
+        {
+            Ok(counts) => counts,
+            Err(khive_storage::StorageError::Unsupported { operation, .. })
+                if operation == "count_edges_by_relation_in_namespaces" =>
+            {
+                let mut totals = HashMap::new();
+                for namespace in token.visible_namespaces() {
+                    let scoped = NamespaceToken::for_namespace(namespace.clone());
+                    for (relation, count) in self.graph(&scoped)?.count_edges_by_relation().await? {
+                        *totals.entry(relation).or_insert(0) += count;
+                    }
+                }
+                return Ok(totals
+                    .into_iter()
+                    .map(|(relation, count)| (relation.to_string(), count))
+                    .collect());
             }
-        }
-        Ok(totals)
+            Err(error) => return Err(error.into()),
+        };
+        Ok(counts
+            .into_iter()
+            .map(|(relation, count)| (relation.to_string(), count))
+            .collect())
     }
 
     /// DML-only body of the symmetric-relation conflict-resolution path in
@@ -4999,24 +5021,38 @@ impl KhiveRuntime {
         Ok(deleted)
     }
 
-    /// Count edges matching `filter`, summed across the caller's visible
-    /// namespaces (mirrors [`Self::count_edges_by_relation`] and
-    /// [`Self::list_edges`] so `stats().edges` reconciles with a full `list`
-    /// keyset walk under the same token).
+    /// Count edges matching `filter` across the caller's visible namespaces.
     pub async fn count_edges(
         &self,
         token: &NamespaceToken,
         filter: crate::curation::EdgeListFilter,
     ) -> RuntimeResult<u64> {
-        let mut total = 0u64;
-        for ns in token.visible_namespaces() {
-            let temp = NamespaceToken::for_namespace(ns.clone());
-            total += self
-                .graph(&temp)?
-                .count_edges(filter.clone().into())
-                .await?;
+        let namespaces: Vec<String> = token
+            .visible_namespaces()
+            .iter()
+            .map(|namespace| namespace.as_str().to_owned())
+            .collect();
+        let graph = self.graph(token)?;
+        match graph
+            .count_edges_in_namespaces(&namespaces, filter.clone().into())
+            .await
+        {
+            Ok(count) => Ok(count),
+            Err(khive_storage::StorageError::Unsupported { operation, .. })
+                if operation == "count_edges_in_namespaces" =>
+            {
+                let mut total = 0;
+                for namespace in token.visible_namespaces() {
+                    let scoped = NamespaceToken::for_namespace(namespace.clone());
+                    total += self
+                        .graph(&scoped)?
+                        .count_edges(filter.clone().into())
+                        .await?;
+                }
+                Ok(total)
+            }
+            Err(error) => Err(error.into()),
         }
-        Ok(total)
     }
 
     /// Validate and construct an edge from a [`LinkSpec`] without writing to storage.

--- a/crates/khive-runtime/tests/integration.rs
+++ b/crates/khive-runtime/tests/integration.rs
@@ -3732,10 +3732,9 @@ async fn delete_edge_cross_namespace_audit_uses_record_namespace_hard() {
 // the scope a full `list` keyset walk computes over — not just token.namespace().
 // =============================================================================
 
-/// `count_entities` / `count_edges` / `count_edges_by_relation` / `count_notes`
-/// must all sum across an identity-bearing caller's visible-namespace set, so
-/// `stats()` totals reconcile with a full multi-namespace `list` walk, for
-/// entities, edges, and notes alike.
+/// Batched stats counts must match both a full multi-namespace `list` walk and
+/// the sum of the corresponding per-namespace counts, excluding soft-deleted
+/// rows from every path.
 #[tokio::test]
 async fn stats_totals_match_list_walk_across_visible_namespaces() {
     use khive_runtime::EdgeListFilter;
@@ -3783,6 +3782,14 @@ async fn stats_totals_match_list_walk_across_visible_namespaces() {
     rt.link(&tok_b, b1.id, b2.id, EdgeRelation::Enables, 1.0, None)
         .await
         .unwrap();
+    let deleted_edge = rt
+        .link(&tok_b, b2.id, b1.id, EdgeRelation::Extends, 1.0, None)
+        .await
+        .unwrap();
+    assert!(rt
+        .delete_edge(&tok_b, deleted_edge.id.into(), false)
+        .await
+        .unwrap());
 
     // Notes: one in each namespace.
     rt.create_note(&tok_a, "observation", None, "NoteInA", None, None, vec![])
@@ -3791,6 +3798,36 @@ async fn stats_totals_match_list_walk_across_visible_namespaces() {
     rt.create_note(&tok_b, "observation", None, "NoteInB", None, None, vec![])
         .await
         .unwrap();
+    let deleted_note = rt
+        .create_note(
+            &tok_a,
+            "observation",
+            None,
+            "DeletedNoteInA",
+            None,
+            None,
+            vec![],
+        )
+        .await
+        .unwrap();
+    assert!(rt
+        .delete_note(&tok_a, deleted_note.id, false)
+        .await
+        .unwrap());
+
+    let per_namespace_edges = rt
+        .count_edges(&tok_a, EdgeListFilter::default())
+        .await
+        .unwrap()
+        + rt.count_edges(&tok_b, EdgeListFilter::default())
+            .await
+            .unwrap();
+    let mut per_namespace_relations = rt.count_edges_by_relation(&tok_a).await.unwrap();
+    for (relation, count) in rt.count_edges_by_relation(&tok_b).await.unwrap() {
+        *per_namespace_relations.entry(relation).or_insert(0) += count;
+    }
+    let per_namespace_notes =
+        rt.count_notes(&tok_a, None).await.unwrap() + rt.count_notes(&tok_b, None).await.unwrap();
 
     // Identity-bearing frame whose visible set spans both namespaces.
     let vis_tok = rt
@@ -3822,9 +3859,11 @@ async fn stats_totals_match_list_walk_across_visible_namespaces() {
         full_edges.len() as u64,
         "stats() edge total must equal a full list keyset walk under the same identity"
     );
+    assert_eq!(stats_edges, per_namespace_edges);
     assert_eq!(stats_edges, 3);
 
     let edges_by_relation = rt.count_edges_by_relation(&vis_tok).await.unwrap();
+    assert_eq!(edges_by_relation, per_namespace_relations);
     let relation_sum: u64 = edges_by_relation.values().sum();
     assert_eq!(
         relation_sum, stats_edges,
@@ -3838,5 +3877,6 @@ async fn stats_totals_match_list_walk_across_visible_namespaces() {
         full_notes.len() as u64,
         "stats() note total must equal a full list keyset walk under the same identity"
     );
+    assert_eq!(stats_notes, per_namespace_notes);
     assert_eq!(stats_notes, 2);
 }

--- a/crates/khive-storage/src/graph.rs
+++ b/crates/khive-storage/src/graph.rs
@@ -76,10 +76,44 @@ pub trait GraphStore: Send + Sync + 'static {
     ) -> StorageResult<Page<Edge>>;
     /// Count edges matching the given filter.
     async fn count_edges(&self, filter: EdgeFilter) -> StorageResult<u64>;
+    /// Count edges across the given namespaces in one aggregate query.
+    /// Backends without batched namespace support retain the single-namespace
+    /// path and reject multi-namespace requests explicitly.
+    async fn count_edges_in_namespaces(
+        &self,
+        namespaces: &[String],
+        filter: EdgeFilter,
+    ) -> StorageResult<u64> {
+        match namespaces.len() {
+            0 => Ok(0),
+            1 => self.count_edges(filter).await,
+            _ => Err(StorageError::Unsupported {
+                capability: StorageCapability::Graph,
+                operation: "count_edges_in_namespaces".into(),
+                message: "this backend does not implement batched namespace edge counts".into(),
+            }),
+        }
+    }
     /// Count edges grouped by relation, ignoring soft-deleted rows. Cheap
     /// aggregate (`GROUP BY relation`) used to report the true per-relation
     /// population for full-graph audits (#702.3).
     async fn count_edges_by_relation(&self) -> StorageResult<Vec<(EdgeRelation, u64)>>;
+    /// Count edges grouped by relation across the given namespaces in one
+    /// aggregate query.
+    async fn count_edges_by_relation_in_namespaces(
+        &self,
+        namespaces: &[String],
+    ) -> StorageResult<Vec<(EdgeRelation, u64)>> {
+        match namespaces.len() {
+            0 => Ok(Vec::new()),
+            1 => self.count_edges_by_relation().await,
+            _ => Err(StorageError::Unsupported {
+                capability: StorageCapability::Graph,
+                operation: "count_edges_by_relation_in_namespaces".into(),
+                message: "this backend does not implement batched namespace relation counts".into(),
+            }),
+        }
+    }
     /// Seek-pagination page of edges ordered by `id` ascending, using an
     /// indexed range scan (`id > after`) against the `(namespace, id)`
     /// primary key instead of `OFFSET`. `after` is exclusive; `None` starts

--- a/crates/khive-storage/src/note.rs
+++ b/crates/khive-storage/src/note.rs
@@ -359,6 +359,21 @@ pub trait NoteStore: Send + Sync + 'static {
     ) -> StorageResult<Vec<Note>>;
     /// Count notes in a namespace, optionally filtered by kind.
     async fn count_notes(&self, namespace: &str, kind: Option<&str>) -> StorageResult<u64>;
+    /// Count notes across the given namespaces, optionally filtered by kind.
+    /// The default preserves compatibility by summing the existing
+    /// single-namespace operation; SQL backends should override this with one
+    /// `IN` aggregate.
+    async fn count_notes_in_namespaces(
+        &self,
+        namespaces: &[String],
+        kind: Option<&str>,
+    ) -> StorageResult<u64> {
+        let mut total = 0;
+        for namespace in namespaces {
+            total += self.count_notes(namespace, kind).await?;
+        }
+        Ok(total)
+    }
 
     /// Attempt to insert a note without overwriting an existing row.
     ///


### PR DESCRIPTION
## Summary

Batches the per-namespace stats counts into IN-aggregate queries instead of issuing one COUNT query per namespace per substrate. Reduces `stats()` query volume from O(namespaces × substrates) to a fixed handful of grouped queries.

Closes #1078

## Changes

- `crates/khive-storage`: batch count methods on the graph and note store traits.
- `crates/khive-db`: grouped-count implementations with tests.
- `crates/khive-runtime/src/operations.rs`: stats path consumes the batched counts.

## Verification

- Store-level and integration tests green; fmt, clippy `-D warnings`, `cargo check --workspace` green. Details in the branch test suite.
