### PR TITLE
fix(runtime): resolve drops low-relevance semantic-only fallback candidates

### DIFF
--- a/crates/khive-pack-kg/docs/api/resolve-verb.md
+++ b/crates/khive-pack-kg/docs/api/resolve-verb.md
@@ -48,7 +48,8 @@ filter every real match out (#849) — `entities.kind` only ever holds a granula
 4. **Hybrid search fallback** — a ref with no exact-name match falls through to hybrid search
    at a confidence below the exact-name stage's 0.98. The fallback searches deeper than the
    caller's `limit` so a match ranked just outside a small `limit` is still ranked against the
-   alternatives. Semantic-only hits below the server-side `0.3` relevance floor are discarded;
+   alternatives. Vector hits below the server-side `0.3` raw cosine-similarity floor are discarded
+   before RRF fusion;
    this rejects low-confidence ANN neighbors while preserving lexical partial-name matches whose
    RRF score encodes rank rather than textual relevance. When the result stays ambiguous, the
    returned `candidates` are a bounded sample capped at `limit`. That bound is intentional.

--- a/crates/khive-pack-kg/docs/api/resolve-verb.md
+++ b/crates/khive-pack-kg/docs/api/resolve-verb.md
@@ -23,7 +23,9 @@ filter every real match out (#849) — `entities.kind` only ever holds a granula
 
 1. **Id-string passthrough** — a UUID ref resolves at confidence `1.0` regardless of whether
    the entity was ever touched through this registry's ring. Entity-only: a note's id-string
-   is `NotFound` through `resolve`, even though `get` on the same id would succeed.
+   is `NotFound` through `resolve`, even though `get` on the same id would succeed. The same
+   boundary applies to edge and event UUIDs and hex prefixes under every `kind`: `resolve`
+   never resolves them, while `get` auto-detects their substrate.
 2. **Recently-referenced ring** — the dispatch boundary (`VerbRegistry::dispatch_with_identity`
    in `pack.rs`, not `KgPack::dispatch`) admits ids under their name whenever `create`/`get`/
    `update`/`delete`/`merge`/`link` runs through the registry. A later `resolve(refs=[name])`
@@ -46,11 +48,14 @@ filter every real match out (#849) — `entities.kind` only ever holds a granula
 4. **Hybrid search fallback** — a ref with no exact-name match falls through to hybrid search
    at a confidence below the exact-name stage's 0.98. The fallback searches deeper than the
    caller's `limit` so a match ranked just outside a small `limit` is still ranked against the
-   alternatives. When the result stays ambiguous, the returned `candidates` are a bounded sample
-   capped at `limit`. That bound is intentional. Outside exact matches there is no oracle for a
-   single "canonical" candidate (an exact identity would have resolved at stage 3), so `resolve`
-   returns a bounded ambiguous sample instead of silently picking one, and raising `limit`
-   surfaces deeper-ranked matches. A ref matching nothing at any stage is `NotFound`.
+   alternatives. Semantic-only hits below the server-side `0.3` relevance floor are discarded;
+   this rejects low-confidence ANN neighbors while preserving lexical partial-name matches whose
+   RRF score encodes rank rather than textual relevance. When the result stays ambiguous, the
+   returned `candidates` are a bounded sample capped at `limit`. That bound is intentional.
+   Outside exact matches there is no oracle for a single "canonical" candidate (an exact identity
+   would have resolved at stage 3), so `resolve` returns a bounded ambiguous sample instead of
+   silently picking one, and raising `limit` surfaces deeper-ranked matches. A ref matching nothing
+   at any stage is `NotFound`.
 
 `resolve`'s `kind` param is entity-only: a note kind is rejected with a clear error rather
 than silently over-filtering to zero matches. `resolve` is registered as a public verb and

--- a/crates/khive-pack-kg/src/dispatch.rs
+++ b/crates/khive-pack-kg/src/dispatch.rs
@@ -1324,6 +1324,36 @@ mod tests {
         );
     }
 
+    #[tokio::test]
+    async fn resolve_short_case_variant_survives_relevance_floor() {
+        let rt = KhiveRuntime::memory().expect("in-memory runtime");
+        let direct_tok = rt.authorize(Namespace::local()).unwrap();
+        let entity = rt
+            .create_entity(&direct_tok, "concept", None, "RoPE", None, None, vec![])
+            .await
+            .expect("direct entity create must succeed");
+
+        let mut builder = VerbRegistryBuilder::new();
+        builder.with_default_namespace("local");
+        builder.register(KgPack::new(rt));
+        let registry = builder.build().expect("registry build");
+
+        let result = registry
+            .dispatch("resolve", json!({"refs": ["rope"]}))
+            .await
+            .expect("resolve must succeed");
+        let results = result.get("results").and_then(Value::as_array).unwrap();
+        assert_eq!(
+            results[0].get("status").and_then(Value::as_str),
+            Some("resolved"),
+            "a short case-only name variant must remain resolvable: {results:?}"
+        );
+        assert_eq!(
+            results[0].get("id").and_then(Value::as_str),
+            Some(entity.id.to_string().as_str())
+        );
+    }
+
     /// `search` result-sets never admit to the ring (gate condition, 2026-07-09). See `docs/api/resolve-verb.md`.
     #[tokio::test]
     async fn resolve_search_result_sets_never_populate_the_ring() {

--- a/crates/khive-pack-kg/src/handler_defs.rs
+++ b/crates/khive-pack-kg/src/handler_defs.rs
@@ -856,12 +856,15 @@ pub(crate) static KG_HANDLERS: [HandlerDef; 19] = [
         description: "Resolve natural-language references to ids. Each ref in \
                        `refs` is resolved through, in order: (1) id-string \
                        passthrough (UUID / 8+ hex prefix) via the by-ID path; \
-                       (2) this actor's recently-referenced ring; (3) an exact, \
+                       Entity ids only: note, edge, and event ids return \
+                       NotFound here; use `get` for auto-detection. (2) this \
+                       actor's recently-referenced ring; (3) an exact, \
                        case-sensitive entity-name match, which resolves \
                        deterministically regardless of search rank (one match \
                        -> Resolved; several identically-named entities -> \
                        Ambiguous over exactly that set); (4) hybrid search over \
-                       the namespace. Returns one of Resolved{id,confidence} | \
+                       the namespace, discarding semantic-only hits scored \
+                       below 0.3. Returns one of Resolved{id,confidence} | \
                        Ambiguous{candidates} | NotFound per ref — never a silent \
                        pick among close candidates. For a non-exact ref that \
                        stays ambiguous, `candidates` is a bounded sample capped \

--- a/crates/khive-pack-kg/src/handler_defs.rs
+++ b/crates/khive-pack-kg/src/handler_defs.rs
@@ -863,8 +863,8 @@ pub(crate) static KG_HANDLERS: [HandlerDef; 19] = [
                        deterministically regardless of search rank (one match \
                        -> Resolved; several identically-named entities -> \
                        Ambiguous over exactly that set); (4) hybrid search over \
-                       the namespace, discarding semantic-only hits scored \
-                       below 0.3. Returns one of Resolved{id,confidence} | \
+                       the namespace, discarding vector hits with raw cosine similarity \
+                       below 0.3 before RRF fusion. Returns one of Resolved{id,confidence} | \
                        Ambiguous{candidates} | NotFound per ref — never a silent \
                        pick among close candidates. For a non-exact ref that \
                        stays ambiguous, `candidates` is a bounded sample capped \

--- a/crates/khive-runtime/src/reference_resolution.rs
+++ b/crates/khive-runtime/src/reference_resolution.rs
@@ -36,7 +36,6 @@ use khive_storage::EntityFilter;
 use crate::error::{RuntimeError, RuntimeResult};
 use crate::operations::Resolved;
 use crate::reference_ring::ReferenceRing;
-use crate::retrieval::SearchSource;
 use crate::runtime::{KhiveRuntime, NamespaceToken};
 
 /// A candidate id surfaced when a reference did not resolve outright.
@@ -80,10 +79,10 @@ const EXACT_NAME_CONFIDENCE: f64 = 0.98;
 /// best" the way it can for the ring. Below the margin, every hit above the
 /// score floor is surfaced as a candidate instead.
 const SEARCH_MARGIN_RATIO: f64 = 2.0;
-/// Semantic-only hybrid-search hits below this score never enter the candidate
-/// set. Lexical hits remain admissible because RRF magnitude encodes rank, not
-/// textual relevance, and genuine partial-name matches score below this floor.
-const SEARCH_SCORE_FLOOR: f64 = 0.3;
+/// Vector hits below this raw cosine-similarity score are removed before RRF
+/// fusion. Lexical hits remain admissible because RRF magnitude encodes rank,
+/// not textual relevance, and genuine partial-name matches score below this floor.
+const SEARCH_VECTOR_SIMILARITY_FLOOR: f64 = 0.3;
 /// Confidence reported on a search-stage `Resolved` outcome: not the raw
 /// RRF score, which lives on a much smaller scale (`sum 1/(k + rank)`, e.g.
 /// ~0.016-0.033) and would never clear a 0..1 confidence bar. Fixed below
@@ -252,7 +251,7 @@ pub async fn resolve_reference(
     let candidate_limit = limit.max(1);
     let search_limit = candidate_limit.max(STAGE4_MIN_SEARCH_LIMIT);
     let hits = runtime
-        .hybrid_search(
+        .hybrid_search_with_vector_similarity_floor(
             token,
             trimmed,
             None,
@@ -261,13 +260,11 @@ pub async fn resolve_reference(
             None,
             &[],
             None,
+            SEARCH_VECTOR_SIMILARITY_FLOOR,
         )
         .await?;
     let candidates: Vec<ReferenceCandidate> = hits
         .into_iter()
-        .filter(|h| {
-            !matches!(h.source, SearchSource::Vector) || h.score.to_f64() >= SEARCH_SCORE_FLOOR
-        })
         .map(|h| ReferenceCandidate {
             id: h.entity_id,
             name: h.title,
@@ -412,8 +409,9 @@ mod tests {
     use super::*;
     use crate::config::{NamespaceToken as TokenCtor, RuntimeConfig};
     use crate::embedder_registry::EmbedderProvider;
+    use crate::retrieval::SearchSource;
     use khive_gate::ActorRef;
-    use khive_types::namespace::Namespace;
+    use khive_types::{namespace::Namespace, SubstrateKind};
     use lattice_embed::{EmbeddingModel, EmbeddingService};
     use std::sync::Arc;
 
@@ -883,34 +881,97 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn fallback_stage_drops_low_score_semantic_only_candidates() {
+    async fn fallback_stage_resolves_high_similarity_semantic_only_candidate() {
         let rt = runtime_with_constant_embeddings();
         let token = actor_token("resolver-test");
         let ring = ReferenceRing::new();
 
-        for name in ["Unrelated Alpha", "Unrelated Beta"] {
-            rt.create_entity(&token, "concept", None, name, None, None, vec![])
-                .await
-                .expect("create unrelated entity");
-        }
+        let entity = rt
+            .create_entity(&token, "concept", None, "Canine", None, None, vec![])
+            .await
+            .expect("create semantic match");
 
-        let hits = rt
-            .hybrid_search(
+        let raw_hits = rt
+            .vector_search(
                 &token,
-                "totally-nonexistent-zzz",
                 None,
+                Some("domestic dog"),
                 5,
-                None,
-                None,
-                &[],
-                None,
+                Some(SubstrateKind::Entity),
             )
             .await
+            .expect("vector search");
+        assert_eq!(raw_hits.len(), 1);
+        assert_eq!(raw_hits[0].subject_id, entity.id);
+        assert!(raw_hits[0].score.to_f64() >= SEARCH_VECTOR_SIMILARITY_FLOOR);
+
+        let hits = rt
+            .hybrid_search(&token, "domestic dog", None, 5, None, None, &[], None)
+            .await
             .expect("hybrid search");
-        assert_eq!(hits.len(), 2);
-        assert!(hits.iter().all(|hit| {
-            hit.source == SearchSource::Vector && hit.score.to_f64() < SEARCH_SCORE_FLOOR
-        }));
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].source, SearchSource::Vector);
+
+        let resolution = resolve_reference(&rt, &ring, &token, "domestic dog", 5, None)
+            .await
+            .expect("resolve_reference");
+
+        assert_eq!(
+            resolution,
+            ReferenceResolution::Resolved {
+                id: entity.id,
+                confidence: SEARCH_RESOLVED_CONFIDENCE,
+            }
+        );
+    }
+
+    #[tokio::test]
+    async fn fallback_stage_drops_low_similarity_semantic_only_candidates() {
+        let rt = runtime_with_constant_embeddings();
+        let token = actor_token("resolver-test");
+        let ring = ReferenceRing::new();
+        let dimensions = EmbeddingModel::AllMiniLmL6V2.dimensions();
+
+        let entity = rt
+            .create_entity(
+                &token,
+                "concept",
+                None,
+                "Unrelated Alpha",
+                None,
+                None,
+                vec![],
+            )
+            .await
+            .expect("create unrelated entity");
+        let vectors = rt.vectors(&token).expect("vector store");
+        vectors
+            .delete(entity.id)
+            .await
+            .expect("delete generated vector");
+        vectors
+            .insert(
+                entity.id,
+                SubstrateKind::Entity,
+                token.namespace().as_str(),
+                "entity.body",
+                vec![vec![-1.0; dimensions]],
+            )
+            .await
+            .expect("insert opposite vector");
+
+        let raw_hits = rt
+            .vector_search(
+                &token,
+                None,
+                Some("totally-nonexistent-zzz"),
+                5,
+                Some(SubstrateKind::Entity),
+            )
+            .await
+            .expect("vector search");
+        assert_eq!(raw_hits.len(), 1);
+        assert!(raw_hits[0].score.to_f64() < SEARCH_VECTOR_SIMILARITY_FLOOR);
 
         let resolution = resolve_reference(&rt, &ring, &token, "totally-nonexistent-zzz", 5, None)
             .await

--- a/crates/khive-runtime/src/reference_resolution.rs
+++ b/crates/khive-runtime/src/reference_resolution.rs
@@ -36,6 +36,7 @@ use khive_storage::EntityFilter;
 use crate::error::{RuntimeError, RuntimeResult};
 use crate::operations::Resolved;
 use crate::reference_ring::ReferenceRing;
+use crate::retrieval::SearchSource;
 use crate::runtime::{KhiveRuntime, NamespaceToken};
 
 /// A candidate id surfaced when a reference did not resolve outright.
@@ -79,8 +80,10 @@ const EXACT_NAME_CONFIDENCE: f64 = 0.98;
 /// best" the way it can for the ring. Below the margin, every hit above the
 /// score floor is surfaced as a candidate instead.
 const SEARCH_MARGIN_RATIO: f64 = 2.0;
-/// Hybrid-search hits below this score never enter the candidate set at all.
-const SEARCH_SCORE_FLOOR: f64 = 0.0;
+/// Semantic-only hybrid-search hits below this score never enter the candidate
+/// set. Lexical hits remain admissible because RRF magnitude encodes rank, not
+/// textual relevance, and genuine partial-name matches score below this floor.
+const SEARCH_SCORE_FLOOR: f64 = 0.3;
 /// Confidence reported on a search-stage `Resolved` outcome: not the raw
 /// RRF score, which lives on a much smaller scale (`sum 1/(k + rank)`, e.g.
 /// ~0.016-0.033) and would never clear a 0..1 confidence bar. Fixed below
@@ -262,7 +265,9 @@ pub async fn resolve_reference(
         .await?;
     let candidates: Vec<ReferenceCandidate> = hits
         .into_iter()
-        .filter(|h| h.score.to_f64() > SEARCH_SCORE_FLOOR)
+        .filter(|h| {
+            !matches!(h.source, SearchSource::Vector) || h.score.to_f64() >= SEARCH_SCORE_FLOOR
+        })
         .map(|h| ReferenceCandidate {
             id: h.entity_id,
             name: h.title,
@@ -405,9 +410,73 @@ fn is_hex_prefix(s: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::config::NamespaceToken as TokenCtor;
+    use crate::config::{NamespaceToken as TokenCtor, RuntimeConfig};
+    use crate::embedder_registry::EmbedderProvider;
     use khive_gate::ActorRef;
     use khive_types::namespace::Namespace;
+    use lattice_embed::{EmbeddingModel, EmbeddingService};
+    use std::sync::Arc;
+
+    struct ConstantEmbeddingService {
+        dimensions: usize,
+    }
+
+    #[async_trait::async_trait]
+    impl EmbeddingService for ConstantEmbeddingService {
+        async fn embed(
+            &self,
+            texts: &[String],
+            _model: EmbeddingModel,
+        ) -> Result<Vec<Vec<f32>>, lattice_embed::EmbedError> {
+            Ok(texts.iter().map(|_| vec![1.0; self.dimensions]).collect())
+        }
+
+        fn supports_model(&self, _model: EmbeddingModel) -> bool {
+            true
+        }
+
+        fn name(&self) -> &'static str {
+            "resolve-test-constant-embedding"
+        }
+    }
+
+    struct ConstantEmbedderProvider {
+        name: String,
+        dimensions: usize,
+    }
+
+    #[async_trait::async_trait]
+    impl EmbedderProvider for ConstantEmbedderProvider {
+        fn name(&self) -> &str {
+            &self.name
+        }
+
+        fn dimensions(&self) -> usize {
+            self.dimensions
+        }
+
+        async fn build(&self) -> RuntimeResult<Arc<dyn EmbeddingService>> {
+            Ok(Arc::new(ConstantEmbeddingService {
+                dimensions: self.dimensions,
+            }))
+        }
+    }
+
+    fn runtime_with_constant_embeddings() -> KhiveRuntime {
+        let model = EmbeddingModel::AllMiniLmL6V2;
+        let runtime = KhiveRuntime::new(RuntimeConfig {
+            db_path: None,
+            embedding_model: Some(model),
+            packs: vec!["kg".to_string()],
+            ..RuntimeConfig::no_embeddings()
+        })
+        .expect("in-memory runtime");
+        runtime.register_embedder(ConstantEmbedderProvider {
+            name: model.to_string(),
+            dimensions: model.dimensions(),
+        });
+        runtime
+    }
 
     fn actor_token(actor_id: &str) -> NamespaceToken {
         TokenCtor::mint_authorized(Namespace::local(), ActorRef::new("agent", actor_id))
@@ -811,6 +880,43 @@ mod tests {
             }
             other => panic!("expected Ambiguous on a genuine name tie, got {other:?}"),
         }
+    }
+
+    #[tokio::test]
+    async fn fallback_stage_drops_low_score_semantic_only_candidates() {
+        let rt = runtime_with_constant_embeddings();
+        let token = actor_token("resolver-test");
+        let ring = ReferenceRing::new();
+
+        for name in ["Unrelated Alpha", "Unrelated Beta"] {
+            rt.create_entity(&token, "concept", None, name, None, None, vec![])
+                .await
+                .expect("create unrelated entity");
+        }
+
+        let hits = rt
+            .hybrid_search(
+                &token,
+                "totally-nonexistent-zzz",
+                None,
+                5,
+                None,
+                None,
+                &[],
+                None,
+            )
+            .await
+            .expect("hybrid search");
+        assert_eq!(hits.len(), 2);
+        assert!(hits.iter().all(|hit| {
+            hit.source == SearchSource::Vector && hit.score.to_f64() < SEARCH_SCORE_FLOOR
+        }));
+
+        let resolution = resolve_reference(&rt, &ring, &token, "totally-nonexistent-zzz", 5, None)
+            .await
+            .expect("resolve_reference");
+
+        assert_eq!(resolution, ReferenceResolution::NotFound);
     }
 
     // Regression for #908: garbage input that matches nothing must still be

--- a/crates/khive-runtime/src/retrieval.rs
+++ b/crates/khive-runtime/src/retrieval.rs
@@ -403,6 +403,60 @@ impl KhiveRuntime {
         tags_any: &[String],
         properties_filter: Option<&serde_json::Value>,
     ) -> RuntimeResult<Vec<SearchHit>> {
+        self.hybrid_search_inner(
+            token,
+            query_text,
+            query_vector,
+            limit,
+            entity_kind,
+            entity_type,
+            tags_any,
+            properties_filter,
+            None,
+        )
+        .await
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) async fn hybrid_search_with_vector_similarity_floor(
+        &self,
+        token: &NamespaceToken,
+        query_text: &str,
+        query_vector: Option<Vec<f32>>,
+        limit: u32,
+        entity_kind: Option<&str>,
+        entity_type: Option<&str>,
+        tags_any: &[String],
+        properties_filter: Option<&serde_json::Value>,
+        vector_similarity_floor: f64,
+    ) -> RuntimeResult<Vec<SearchHit>> {
+        self.hybrid_search_inner(
+            token,
+            query_text,
+            query_vector,
+            limit,
+            entity_kind,
+            entity_type,
+            tags_any,
+            properties_filter,
+            Some(DeterministicScore::from_f64(vector_similarity_floor)),
+        )
+        .await
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    async fn hybrid_search_inner(
+        &self,
+        token: &NamespaceToken,
+        query_text: &str,
+        query_vector: Option<Vec<f32>>,
+        limit: u32,
+        entity_kind: Option<&str>,
+        entity_type: Option<&str>,
+        tags_any: &[String],
+        properties_filter: Option<&serde_json::Value>,
+        vector_similarity_floor: Option<DeterministicScore>,
+    ) -> RuntimeResult<Vec<SearchHit>> {
         let candidates = limit.saturating_mul(CANDIDATE_MULTIPLIER).max(limit);
 
         let visible_ns: Vec<String> = token
@@ -433,7 +487,7 @@ impl KhiveRuntime {
             query_text,
         )?;
 
-        let vector_hits = if query_vector.is_some() || self.config().embedding_model.is_some() {
+        let mut vector_hits = if query_vector.is_some() || self.config().embedding_model.is_some() {
             self.vector_search(
                 token,
                 query_vector,
@@ -445,6 +499,9 @@ impl KhiveRuntime {
         } else {
             Vec::new()
         };
+        if let Some(floor) = vector_similarity_floor {
+            vector_hits.retain(|hit| hit.score >= floor);
+        }
 
         // Keep the full candidate pool (untruncated) through the alive/kind/tag/property
         // filter below, so matching hits ranked below `limit` in the raw fusion aren't

--- a/docs/guide/api-reference.md
+++ b/docs/guide/api-reference.md
@@ -593,14 +593,14 @@ request(ops="withdraw(id=\"<proposal-id>\")")
 Resolve natural-language references to ids. Each ref in `refs` is resolved through:
 (1) id-string passthrough (UUID or 8+ hex prefix) via the existing by-ID path; (2) this
 actor's recently-referenced ring; (3) a case-sensitive exact match on `entities.name`;
-(4) hybrid search over the namespace, with semantic-only hits below the server-side `0.3`
-relevance floor discarded. Returns one of
+(4) hybrid search over the namespace, with vector hits below the server-side `0.3` raw
+cosine-similarity floor discarded before RRF fusion. Returns one of
 `Resolved{id,confidence}` | `Ambiguous{candidates}` | `NotFound` per ref — never a
 silent pick among close candidates. Read-only: performs no mutation.
 
 The id-string stage resolves entities only. Note, edge, and event UUIDs or hex prefixes
 return `NotFound` through `resolve` under every `kind`; use `get` when the substrate should
-be auto-detected. The relevance floor removes low-confidence ANN neighbors while preserving
+be auto-detected. The similarity floor removes low-confidence ANN neighbors while preserving
 lexical partial-name matches, whose RRF score encodes rank rather than textual relevance.
 
 | Param   | Type            | Required | Notes                                                                                                           |

--- a/docs/guide/api-reference.md
+++ b/docs/guide/api-reference.md
@@ -593,9 +593,15 @@ request(ops="withdraw(id=\"<proposal-id>\")")
 Resolve natural-language references to ids. Each ref in `refs` is resolved through:
 (1) id-string passthrough (UUID or 8+ hex prefix) via the existing by-ID path; (2) this
 actor's recently-referenced ring; (3) a case-sensitive exact match on `entities.name`;
-(4) hybrid search over the namespace. Returns one of
+(4) hybrid search over the namespace, with semantic-only hits below the server-side `0.3`
+relevance floor discarded. Returns one of
 `Resolved{id,confidence}` | `Ambiguous{candidates}` | `NotFound` per ref — never a
 silent pick among close candidates. Read-only: performs no mutation.
+
+The id-string stage resolves entities only. Note, edge, and event UUIDs or hex prefixes
+return `NotFound` through `resolve` under every `kind`; use `get` when the substrate should
+be auto-detected. The relevance floor removes low-confidence ANN neighbors while preserving
+lexical partial-name matches, whose RRF score encodes rank rather than textual relevance.
 
 | Param   | Type            | Required | Notes                                                                                                           |
 | ------- | --------------- | -------- | --------------------------------------------------------------------------------------------------------------- |


### PR DESCRIPTION
## Summary

`resolve` now discards semantic-only hybrid-search fallback candidates below a server-side relevance floor of `0.3`. If the floor removes every candidate, the existing empty-candidate path returns `not_found` instead of surfacing unrelated ambiguous hits.

The floor applies only to vector-only hits. Lexical hits stay eligible because their RRF score measures rank, not textual relevance — a blanket cutoff was tested and rejected (it broke shortened-name and lexical-ambiguity contracts; short case-only lookups like `rope` → `RoPE` still resolve).

Docs now state that note, edge, and event UUIDs/hex prefixes are not resolved under any `kind`; callers needing substrate auto-detection use `get`.

Closes #1088

## Verification

- New regression `fallback_stage_drops_low_score_semantic_only_candidates`: red (ambiguous with 0.08-0.09 scored unrelated hits) → green (`not_found`).
- Control `resolve_short_case_variant_survives_relevance_floor` green; pack resolve suite 20 passed; fmt, deno fmt, clippy `-D warnings`, `cargo check --workspace` green.
