### PR TITLE
fix(runtime): create_many writes entity and FTS rows in one transaction

### DIFF
--- a/crates/khive-db/src/sql_bridge.rs
+++ b/crates/khive-db/src/sql_bridge.rs
@@ -316,7 +316,7 @@ impl khive_storage::SqlWriter for SqliteWriter {
             return writer_task
                 .send(move |conn| {
                     let mut stmt = conn
-                        .prepare(&statement.sql)
+                        .prepare_cached(&statement.sql)
                         .map_err(|e| map_rusqlite_err(e, "execute"))?;
                     bind_params(&mut stmt, &statement.params)
                         .map_err(|e| map_rusqlite_err(e, "execute"))?;
@@ -334,7 +334,7 @@ impl khive_storage::SqlWriter for SqliteWriter {
         })?;
         let (conn, result) = tokio::task::spawn_blocking(move || {
             let res = (|| -> Result<usize, rusqlite::Error> {
-                let mut stmt = conn.prepare(&statement.sql)?;
+                let mut stmt = conn.prepare_cached(&statement.sql)?;
                 bind_params(&mut stmt, &statement.params)?;
                 stmt.raw_execute()
             })();
@@ -626,7 +626,7 @@ impl khive_storage::SqlWriter for PoolBackedWriter {
                 StorageError::driver(StorageCapability::Sql, "pool_writer.execute", e)
             })?;
             let mut stmt = guard
-                .prepare(&statement.sql)
+                .prepare_cached(&statement.sql)
                 .map_err(|e| map_rusqlite_err(e, "pool_writer.execute"))?;
             bind_params(&mut stmt, &statement.params)
                 .map_err(|e| map_rusqlite_err(e, "pool_writer.execute"))?;
@@ -799,7 +799,7 @@ impl khive_storage::SqlWriter for InlineWriter {
     ) -> khive_storage::types::StorageResult<u64> {
         let mut stmt = self
             .conn()
-            .prepare(&statement.sql)
+            .prepare_cached(&statement.sql)
             .map_err(|e| map_rusqlite_err(e, "inline.execute"))?;
         bind_params(&mut stmt, &statement.params)
             .map_err(|e| map_rusqlite_err(e, "inline.execute"))?;

--- a/crates/khive-runtime/src/operations.rs
+++ b/crates/khive-runtime/src/operations.rs
@@ -17,20 +17,23 @@ use uuid::Uuid;
 use khive_score::DeterministicScore;
 use khive_storage::note::Note;
 use khive_storage::types::{
-    BatchWriteSummary, DeleteMode, DirectedNeighborHit, Direction, EdgeSortField, GraphPath,
-    LinkId, NeighborHit, NeighborQuery, Page, PageRequest, SortOrder, SqlRow, SqlStatement,
-    SqlValue, TextFilter, TextQueryMode, TextSearchRequest, TraversalRequest,
+    DeleteMode, DirectedNeighborHit, Direction, EdgeSortField, GraphPath, LinkId, NeighborHit,
+    NeighborQuery, Page, PageRequest, SortOrder, SqlRow, SqlStatement, SqlValue, TextFilter,
+    TextQueryMode, TextSearchRequest, TraversalRequest,
 };
 use khive_storage::{Edge, EdgeRelation, Entity, EntityFilter, Event, EventFilter};
 use khive_types::{EdgeEndpointRule, EndpointKind, EventKind, SubstrateKind};
 
-use khive_db::stores::entity::entity_hard_delete_statement;
+use khive_db::stores::entity::{entity_hard_delete_statement, entity_upsert_statement};
 use khive_db::stores::graph::{edge_hard_delete_statement, purge_incident_edges_statement};
 use khive_db::stores::note::note_hard_delete_statement;
+use khive_db::stores::text::insert_document_statement;
 use khive_db::SqliteError;
 use rusqlite::OptionalExtension;
 
-use crate::atomic_plan::{AffectedRowGuard, DeletePlan, PlanStatement, PostCommitEffect};
+use crate::atomic_plan::{
+    AddEntityPlan, AffectedRowGuard, DeletePlan, PlanStatement, PostCommitEffect,
+};
 use crate::atomic_runner::{run_atomic_unit, AtomicOpFailure, AtomicOpPlan, AtomicRunOutcome};
 use crate::curation::{entity_fts_document, note_fts_document};
 use crate::error::{GuardedWriteFailure, RuntimeError, RuntimeResult};
@@ -90,14 +93,11 @@ static FTS_FAIL_NS: std::sync::LazyLock<std::sync::Mutex<std::collections::HashS
 #[cfg(any(test, feature = "fault-injection"))]
 static VECTOR_FAIL_NS: std::sync::LazyLock<std::sync::Mutex<std::collections::HashSet<String>>> =
     std::sync::LazyLock::new(|| std::sync::Mutex::new(std::collections::HashSet::new()));
-/// FTS failure injection for `create_many` — separate from `FTS_FAIL_NS` so that
-/// create_note_inner and create_many tests cannot disarm each other.
+/// Fail the first FTS statement inside `create_many`'s atomic write.
 #[cfg(any(test, feature = "fault-injection"))]
 static FTS_FAIL_MANY_NS: std::sync::LazyLock<std::sync::Mutex<std::collections::HashSet<String>>> =
     std::sync::LazyLock::new(|| std::sync::Mutex::new(std::collections::HashSet::new()));
-/// FTS partial-failure injection for `create_many` — returns `Ok(BatchWriteSummary)`
-/// with `failed > 0` so that the `summary.failed > 0` rollback branch is exercised.
-/// Distinct from `FTS_FAIL_MANY_NS` which injects a hard `Err`.
+/// Fail an FTS statement after one complete entity/FTS pair when the batch permits it.
 #[cfg(any(test, feature = "fault-injection"))]
 static FTS_FAIL_MANY_PARTIAL_NS: std::sync::LazyLock<
     std::sync::Mutex<std::collections::HashSet<String>>,
@@ -129,7 +129,7 @@ pub fn arm_fts_fail(ns: &str) {
 /// Arm the FTS failure injection for `create_many` targeting namespace `ns`.
 ///
 /// The next `create_many` call whose namespace equals `ns` returns an injected
-/// error at the FTS upsert step (after entity rows are committed), then disarms.
+/// error at the first FTS statement inside the atomic batch, then disarms.
 /// Calls on other namespaces are unaffected, and concurrent arms of distinct
 /// namespaces do not overwrite each other.
 /// Available when compiled with `cfg(test)` or `feature = "fault-injection"`.
@@ -138,13 +138,11 @@ pub fn arm_fts_fail_many(ns: &str) {
     FTS_FAIL_MANY_NS.lock().unwrap().insert(ns.to_string());
 }
 
-/// Arm the FTS *partial*-failure injection for `create_many` targeting namespace `ns`.
+/// Arm a mid-batch FTS failure for `create_many` targeting namespace `ns`.
 ///
-/// The next `create_many` call whose namespace equals `ns` returns
-/// `Ok(BatchWriteSummary { attempted: 2, affected: 1, failed: 1, ... })` from the
-/// FTS upsert step, exercising the `summary.failed > 0` rollback branch (as opposed
-/// to the hard-`Err` branch exercised by `arm_fts_fail_many`). Then disarms only
-/// that namespace's entry.
+/// The next matching call fails the second FTS statement when the batch contains at
+/// least two entities, after one entity/FTS pair has executed in the transaction.
+/// A one-entity batch fails its first FTS statement. Then disarms only that namespace.
 /// Available when compiled with `cfg(test)` or `feature = "fault-injection"`.
 #[cfg(any(test, feature = "fault-injection"))]
 pub fn arm_fts_fail_many_partial(ns: &str) {
@@ -5159,15 +5157,10 @@ impl KhiveRuntime {
     /// (unknown kind, empty name, secret-gate violation), the method returns
     /// that error and no entities are written.
     ///
-    /// Storage writes are issued as ONE `upsert_entities` call followed by ONE
-    /// `upsert_documents` call — the same primitives that the single-entity path
-    /// uses, but batched. Embedding is intentionally skipped: bulk structural
-    /// ingest is the expected use-case, and dense vectors are backfilled later
-    /// via a `reindex` call. Callers that need immediate vector search
-    /// immediately after creation should use per-entity `create_entity` instead.
-    ///
-    /// On FTS failure, every newly written entity row is hard-deleted to maintain
-    /// consistency (mirrors the single-entity rollback in `create_entity`).
+    /// Entity rows and their FTS documents are written in one SQLite transaction.
+    /// Any statement failure rolls back the entire batch across both surfaces.
+    /// Embedding is intentionally skipped: bulk structural ingest is the expected
+    /// use-case, and dense vectors are backfilled later via a `reindex` call.
     pub async fn create_many(
         &self,
         token: &NamespaceToken,
@@ -5216,124 +5209,72 @@ impl KhiveRuntime {
             entities.push(entity);
         }
 
-        // Phase 2: single bulk entity write.
-        // Capture the BatchWriteSummary to detect partial failures.
-        // The store commits the transaction even when some rows fail (per-row error
-        // isolation). If any row failed, compensate by hard-deleting the rows that DID
-        // land, then return Err so the caller sees zero net writes.
-        //
-        // NOTE: this compensation path (delete-on-partial-failure) is a stopgap until
-        // a true single-transaction bulk primitive is available in the entity store.
-        // That primitive (writing entity rows and FTS rows in one SQL transaction) is
-        // tracked as a follow-up issue.
-        let entity_summary = self
-            .entities(token)?
-            .upsert_entities(entities.clone())
-            .await?;
-
-        if entity_summary.failed > 0 {
-            // Compensate: hard-delete any entity rows that did land.
-            if let Ok(store) = self.entities(token) {
-                for entity in &entities {
-                    if let Err(ce) = store.delete_entity(entity.id, DeleteMode::Hard).await {
-                        tracing::error!(
-                            error = %ce,
-                            id = %entity.id,
-                            "create_many: failed to roll back entity row after partial entity write"
-                        );
-                    }
-                }
-            }
-            return Err(RuntimeError::Internal(format!(
-                "create_many: {}/{} entity rows failed to write (first error: {}); \
-                 all rows rolled back",
-                entity_summary.failed, entity_summary.attempted, entity_summary.first_error
-            )));
-        }
-
-        // Phase 3: single bulk FTS write.
-        //
-        // The FTS store commits partial batches and signals per-document failures
-        // via BatchWriteSummary.failed (same as the entity store in Phase 2).
-        // We must capture the summary and treat failed > 0 as an error.
-        //
-        // Compensation is symmetric: on any FTS failure (Err or failed > 0),
-        // we first delete any FTS documents that may have landed, then
-        // hard-delete the entity rows.  This order matters: the entity delete
-        // is the authoritative write; FTS is a derived index.  Cleaning FTS
-        // first avoids a window where entity rows are gone but stale FTS rows
-        // survive.
-        let docs: Vec<_> = entities.iter().map(entity_fts_document).collect();
-
         #[cfg(any(test, feature = "fault-injection"))]
         let fts_many_inject = FTS_FAIL_MANY_NS.lock().unwrap().remove(ns);
         #[cfg(not(any(test, feature = "fault-injection")))]
         let fts_many_inject = false;
 
-        // Partial-failure seam: returns Ok(summary) with failed > 0 so the
-        // `summary.failed > 0` rollback branch is exercised in tests.
         #[cfg(any(test, feature = "fault-injection"))]
         let fts_many_inject_partial = FTS_FAIL_MANY_PARTIAL_NS.lock().unwrap().remove(ns);
         #[cfg(not(any(test, feature = "fault-injection")))]
         let fts_many_inject_partial = false;
 
-        let fts_summary_result: RuntimeResult<BatchWriteSummary> = if fts_many_inject {
-            Err(RuntimeError::Internal(
-                "injected FTS failure for create_many".to_string(),
-            ))
+        let injected_failure_index = if fts_many_inject {
+            Some(0)
         } else if fts_many_inject_partial {
-            Ok(BatchWriteSummary {
-                attempted: docs.len() as u64,
-                affected: docs.len().saturating_sub(1) as u64,
-                failed: 1,
-                first_error: "injected partial FTS failure for create_many".to_string(),
-            })
+            Some(usize::from(entities.len() > 1))
         } else {
-            match self.text(token) {
-                Ok(fts) => fts.upsert_documents(docs).await.map_err(RuntimeError::from),
-                Err(e) => Err(e),
-            }
+            None
         };
 
-        let fts_err: Option<RuntimeError> = match fts_summary_result {
-            Err(e) => Some(e),
-            Ok(summary) if summary.failed > 0 => Some(RuntimeError::Internal(format!(
-                "create_many: {}/{} FTS rows failed to index (first error: {}); \
-                 all rows rolled back",
-                summary.failed, summary.attempted, summary.first_error
+        let _ = self.entities(token)?;
+        let _ = self.text(token)?;
+
+        let plans = entities
+            .iter()
+            .enumerate()
+            .map(|(index, entity)| {
+                let mut fts_statement =
+                    insert_document_statement("fts_entities", &entity_fts_document(entity));
+                if injected_failure_index == Some(index) {
+                    fts_statement = SqlStatement {
+                        sql: "INSERT INTO __khive_create_many_injected_failure__ DEFAULT VALUES"
+                            .to_string(),
+                        params: vec![],
+                        label: Some("fts-insert-injected-failure".to_string()),
+                    };
+                }
+                AtomicOpPlan::AddEntity(AddEntityPlan {
+                    entity_id: entity.id,
+                    statements: vec![
+                        PlanStatement {
+                            statement: entity_upsert_statement(entity),
+                            guard: Some(AffectedRowGuard::exactly(1)),
+                        },
+                        PlanStatement {
+                            statement: fts_statement,
+                            guard: None,
+                        },
+                    ],
+                    post_commit: PostCommitEffect::None,
+                })
+            })
+            .collect();
+
+        match run_atomic_unit(self.sql().as_ref(), plans).await {
+            Ok(AtomicRunOutcome::Committed { .. }) => Ok(entities),
+            Ok(AtomicRunOutcome::RolledBack {
+                failed_op_index,
+                failure,
+            }) => Err(RuntimeError::Internal(format!(
+                "create_many: atomic batch rolled back at entity index {failed_op_index}: \
+                 {failure:?}"
             ))),
-            Ok(_) => None,
-        };
-
-        if let Some(e) = fts_err {
-            // Clean up any FTS docs that landed before deleting entity rows.
-            if let Ok(fts) = self.text(token) {
-                for entity in &entities {
-                    if let Err(ce) = fts.delete_document(ns, entity.id).await {
-                        tracing::error!(
-                            error = %ce,
-                            id = %entity.id,
-                            "create_many: failed to remove FTS doc during rollback"
-                        );
-                    }
-                }
-            }
-            if let Ok(store) = self.entities(token) {
-                for entity in &entities {
-                    if let Err(ce) = store.delete_entity(entity.id, DeleteMode::Hard).await {
-                        tracing::error!(
-                            error = %ce,
-                            id = %entity.id,
-                            "create_many: failed to roll back entity row after FTS failure"
-                        );
-                    }
-                }
-            }
-            return Err(e);
+            Err(e) => Err(RuntimeError::Internal(format!(
+                "create_many: atomic batch failed: {}",
+                e.0
+            ))),
         }
-
-        // Embedding is skipped intentionally — see doc comment above.
-        Ok(entities)
     }
 }
 
@@ -10981,16 +10922,10 @@ mod tests {
         );
     }
 
-    // FTS partial-failure (Ok(summary) with summary.failed > 0) rolls back
-    // both substrates.
-    //
-    // The production code has a distinct arm:
-    //   Ok(summary) if summary.failed > 0 => return Err(...)
-    // This test exercises that arm by arming `arm_fts_fail_many_partial`, which
-    // returns Ok(BatchWriteSummary { failed: 1, ... }) instead of a hard Err.
-    // Both entity rows and FTS rows must be empty after rollback.
+    // A failure after the first entity and FTS document have been written rolls
+    // back both substrates for the entire batch.
     #[tokio::test]
-    async fn create_many_fts_partial_failure_rolls_back_both_substrates() {
+    async fn create_many_mid_batch_storage_failure_rolls_back_both_substrates() {
         let ns = format!("fts-fail-partial-{}", uuid::Uuid::new_v4().as_simple());
         let rt = rt();
         let tok = NamespaceToken::for_namespace(Namespace::parse(&ns).unwrap());
@@ -11019,7 +10954,12 @@ mod tests {
 
         assert!(
             result.is_err(),
-            "create_many must return Err when FTS summary.failed > 0"
+            "create_many must return Err when an FTS write fails mid-batch"
+        );
+        let error = result.unwrap_err().to_string();
+        assert!(
+            error.contains("atomic batch rolled back at entity index 1"),
+            "the failure must occur inside the atomic batch after one complete row; got: {error}"
         );
 
         // Entity substrate must be empty — entity rows must have been rolled back.
@@ -11027,7 +10967,7 @@ mod tests {
         assert_eq!(
             entity_rows.len(),
             0,
-            "entity rows must be rolled back when FTS summary.failed > 0; found {entity_rows:?}"
+            "entity rows must be empty after a mid-batch FTS failure; found {entity_rows:?}"
         );
 
         // FTS substrate must be empty — no stale fts_entities rows.
@@ -11042,7 +10982,7 @@ mod tests {
             .unwrap();
         assert_eq!(
             fts_count, 0,
-            "fts_entities must be empty after partial-FTS-failure rollback; found {fts_count}"
+            "fts_entities must be empty after a mid-batch FTS failure; found {fts_count}"
         );
     }
 


### PR DESCRIPTION
## Summary

`create_many` previously wrote entity and FTS batches through separate upserts and attempted compensating hard deletes after a partial failure. The path now assembles paired entity/FTS write plans and submits them through one atomic unit; any statement failure rolls back the outer SQLite transaction. The compensating-delete path is removed. Repeated entity and FTS SQL uses rusqlite's connection-level prepared-statement cache.

Dense-vector rows remain intentionally outside `create_many` (populated by later reindexing), so there is no vector row to include or roll back.

Closes #233

## Verification

- New regression `create_many_mid_batch_storage_failure_rolls_back_both_substrates`: the fault seam injects a real SQL failure into the second FTS statement after one complete pair; asserts the error surfaces at entity index 1 and both `entities` and `fts_entities` contain zero rows. Red under the old compensating-delete path, green now.
- Focused `create_many` suite 8 passed; fmt, clippy `-D warnings`, `cargo check --workspace` green; 518 khive-db tests passed.
