### PR TITLE
fix(mcp): apply the verb-specific gate on coordinator-routed operations

### DIFF
--- a/crates/khive-mcp/src/coordinator.rs
+++ b/crates/khive-mcp/src/coordinator.rs
@@ -273,19 +273,28 @@ pub(crate) mod tests {
 
     use crate::server::KhiveMcpServer;
     use crate::tools::request::RequestParams;
-    use khive_runtime::{KhiveRuntime, Namespace as RuntimeNamespace, RuntimeConfig};
+    use khive_runtime::{
+        AllowAllGate, Gate, GateDecision, GateError, GateRef, GateRequest, KhiveRuntime,
+        Namespace as RuntimeNamespace, RuntimeConfig,
+    };
 
     fn make_registry() -> (khive_runtime::VerbRegistry, khive_runtime::KhiveRuntime) {
+        make_registry_with_gate(Arc::new(AllowAllGate))
+    }
+
+    fn make_registry_with_gate(
+        gate: GateRef,
+    ) -> (khive_runtime::VerbRegistry, khive_runtime::KhiveRuntime) {
         let config = RuntimeConfig {
             db_path: None,
             default_namespace: RuntimeNamespace::parse("local").unwrap(),
             embedding_model: None,
             additional_embedding_models: vec![],
             packs: vec!["kg".to_string()],
+            gate: Arc::clone(&gate),
             ..RuntimeConfig::default()
         };
         let runtime = KhiveRuntime::new(config).expect("in-memory runtime");
-        let gate = runtime.config().gate.clone();
         let default_ns = runtime.config().default_namespace.clone();
         let actor_id = runtime.config().actor_id.clone();
         let mut builder = khive_runtime::VerbRegistryBuilder::new();
@@ -301,6 +310,18 @@ pub(crate) mod tests {
         let registry = builder.build().expect("build registry");
         runtime.install_edge_rules(registry.all_edge_rules());
         (registry, runtime)
+    }
+
+    #[derive(Debug, Default)]
+    struct CapturingGate {
+        requests: std::sync::Mutex<Vec<GateRequest>>,
+    }
+
+    impl Gate for CapturingGate {
+        fn check(&self, req: &GateRequest) -> Result<GateDecision, GateError> {
+            self.requests.lock().unwrap().push(req.clone());
+            Ok(GateDecision::allow())
+        }
     }
 
     /// T6a: a multi-backend server MUST route `link` through the coordinator.
@@ -363,6 +384,60 @@ pub(crate) mod tests {
                 .load(std::sync::atomic::Ordering::SeqCst),
             "T6b: coordinator.fan_out_search must be called when a search op is dispatched through a multi-backend server"
         );
+    }
+
+    #[tokio::test]
+    async fn coordinator_and_registry_routes_submit_equivalent_link_and_search_gate_requests() {
+        let direct_gate = Arc::new(CapturingGate::default());
+        let coordinator_gate = Arc::new(CapturingGate::default());
+        let (direct_registry, _direct_runtime) =
+            make_registry_with_gate(Arc::clone(&direct_gate) as GateRef);
+        let (coordinator_registry, _coordinator_runtime) =
+            make_registry_with_gate(Arc::clone(&coordinator_gate) as GateRef);
+        let direct_server =
+            KhiveMcpServer::from_registry_with_meta(direct_registry, "local", "test-cfg");
+        let coord = MockCoordinator::multi_backend();
+        let coordinator_server =
+            KhiveMcpServer::from_registry_with_meta(coordinator_registry, "local", "test-cfg")
+                .with_coordinator(Arc::clone(&coord) as Arc<dyn CoordinatorService>);
+
+        let source_id = Uuid::new_v4();
+        let target_id = Uuid::new_v4();
+        let operations = [
+            format!(
+                r#"link(source_id="{source_id}", target_id="{target_id}", relation="implements", namespace="tenant-a")"#
+            ),
+            r#"search(kind="entity", query="gate parity", limit=7, namespace="tenant-a")"#
+                .to_string(),
+        ];
+
+        for ops in operations {
+            for server in [&direct_server, &coordinator_server] {
+                server
+                    .dispatch_request_local(RequestParams {
+                        ops: ops.clone(),
+                        presentation: None,
+                        presentation_per_op: None,
+                        save_to: None,
+                        format: None,
+                        format_per_op: None,
+                        request_id: None,
+                    })
+                    .await
+                    .expect("dispatch returns a per-operation result");
+            }
+        }
+
+        let direct_requests = direct_gate.requests.lock().unwrap().clone();
+        let coordinator_requests = coordinator_gate.requests.lock().unwrap().clone();
+        assert_eq!(direct_requests.len(), 2);
+        assert_eq!(coordinator_requests.len(), 2);
+        for (direct, coordinated) in direct_requests.iter().zip(&coordinator_requests) {
+            assert_eq!(
+                serde_json::to_value(direct).unwrap(),
+                serde_json::to_value(coordinated).unwrap()
+            );
+        }
     }
 
     #[tokio::test]

--- a/crates/khive-mcp/src/coordinator.rs
+++ b/crates/khive-mcp/src/coordinator.rs
@@ -277,6 +277,8 @@ pub(crate) mod tests {
         AllowAllGate, Gate, GateDecision, GateError, GateRef, GateRequest, KhiveRuntime,
         Namespace as RuntimeNamespace, RuntimeConfig,
     };
+    use khive_storage::{Event, EventFilter, PageRequest};
+    use khive_types::{EventKind, EventOutcome};
 
     fn make_registry() -> (khive_runtime::VerbRegistry, khive_runtime::KhiveRuntime) {
         make_registry_with_gate(Arc::new(AllowAllGate))
@@ -301,6 +303,11 @@ pub(crate) mod tests {
         builder.with_gate(gate);
         builder.with_default_namespace(default_ns.as_str());
         builder.with_actor_id(actor_id);
+        let token = runtime
+            .authorize(RuntimeNamespace::local())
+            .expect("authorize event store");
+        let event_store = runtime.events(&token).expect("in-memory event store");
+        builder.with_event_store(event_store);
         khive_runtime::PackRegistry::register_packs(
             &["kg".to_string()],
             runtime.clone(),
@@ -315,13 +322,49 @@ pub(crate) mod tests {
     #[derive(Debug, Default)]
     struct CapturingGate {
         requests: std::sync::Mutex<Vec<GateRequest>>,
+        deny: bool,
+    }
+
+    impl CapturingGate {
+        fn denying() -> Self {
+            Self {
+                requests: std::sync::Mutex::new(Vec::new()),
+                deny: true,
+            }
+        }
     }
 
     impl Gate for CapturingGate {
         fn check(&self, req: &GateRequest) -> Result<GateDecision, GateError> {
             self.requests.lock().unwrap().push(req.clone());
-            Ok(GateDecision::allow())
+            if self.deny && req.verb != "authorize" {
+                Ok(GateDecision::deny("denied by coordinator parity test"))
+            } else {
+                Ok(GateDecision::allow())
+            }
         }
+    }
+
+    async fn audit_events(runtime: &KhiveRuntime, namespace: &str) -> Vec<Event> {
+        let token = runtime
+            .authorize(RuntimeNamespace::parse(namespace).expect("audit namespace"))
+            .expect("authorize audit query");
+        runtime
+            .events(&token)
+            .expect("runtime event store")
+            .query_events(
+                EventFilter {
+                    kinds: vec![EventKind::Audit],
+                    ..EventFilter::default()
+                },
+                PageRequest {
+                    limit: 10,
+                    offset: 0,
+                },
+            )
+            .await
+            .expect("query audit events")
+            .items
     }
 
     /// T6a: a multi-backend server MUST route `link` through the coordinator.
@@ -392,7 +435,7 @@ pub(crate) mod tests {
         let coordinator_gate = Arc::new(CapturingGate::default());
         let (direct_registry, _direct_runtime) =
             make_registry_with_gate(Arc::clone(&direct_gate) as GateRef);
-        let (coordinator_registry, _coordinator_runtime) =
+        let (coordinator_registry, coordinator_runtime) =
             make_registry_with_gate(Arc::clone(&coordinator_gate) as GateRef);
         let direct_server =
             KhiveMcpServer::from_registry_with_meta(direct_registry, "local", "test-cfg");
@@ -428,8 +471,22 @@ pub(crate) mod tests {
             }
         }
 
-        let direct_requests = direct_gate.requests.lock().unwrap().clone();
-        let coordinator_requests = coordinator_gate.requests.lock().unwrap().clone();
+        let direct_requests: Vec<_> = direct_gate
+            .requests
+            .lock()
+            .unwrap()
+            .iter()
+            .filter(|request| matches!(request.verb.as_str(), "link" | "search"))
+            .cloned()
+            .collect();
+        let coordinator_requests: Vec<_> = coordinator_gate
+            .requests
+            .lock()
+            .unwrap()
+            .iter()
+            .filter(|request| matches!(request.verb.as_str(), "link" | "search"))
+            .cloned()
+            .collect();
         assert_eq!(direct_requests.len(), 2);
         assert_eq!(coordinator_requests.len(), 2);
         for (direct, coordinated) in direct_requests.iter().zip(&coordinator_requests) {
@@ -438,6 +495,59 @@ pub(crate) mod tests {
                 serde_json::to_value(coordinated).unwrap()
             );
         }
+
+        let coordinator_audits = audit_events(&coordinator_runtime, "tenant-a").await;
+        assert_eq!(coordinator_audits.len(), 2);
+        assert!(coordinator_audits
+            .iter()
+            .all(|event| event.payload["decision"] == "allow"));
+        assert!(coordinator_audits
+            .iter()
+            .any(|event| event.verb == "link" && event.outcome == EventOutcome::Error));
+        assert!(coordinator_audits
+            .iter()
+            .any(|event| event.verb == "search" && event.outcome == EventOutcome::Success));
+    }
+
+    #[tokio::test]
+    async fn coordinator_route_persists_denied_gate_audit() {
+        let gate = Arc::new(CapturingGate::denying());
+        let (registry, runtime) = make_registry_with_gate(Arc::clone(&gate) as GateRef);
+        let coord = MockCoordinator::multi_backend();
+        let server = KhiveMcpServer::from_registry_with_meta(registry, "local", "test-cfg")
+            .with_coordinator(Arc::clone(&coord) as Arc<dyn CoordinatorService>);
+
+        server
+            .dispatch_request_local(RequestParams {
+                ops: r#"search(kind="entity", query="gate parity", namespace="tenant-a")"#
+                    .to_string(),
+                presentation: None,
+                presentation_per_op: None,
+                save_to: None,
+                format: None,
+                format_per_op: None,
+                request_id: None,
+            })
+            .await
+            .expect("dispatch returns a denied per-operation result");
+
+        assert_eq!(
+            gate.requests
+                .lock()
+                .unwrap()
+                .iter()
+                .filter(|request| request.verb == "search")
+                .count(),
+            1
+        );
+        assert!(!coord
+            .search_called
+            .load(std::sync::atomic::Ordering::SeqCst));
+        let audits = audit_events(&runtime, "tenant-a").await;
+        assert_eq!(audits.len(), 1);
+        assert_eq!(audits[0].verb, "search");
+        assert_eq!(audits[0].outcome, EventOutcome::Denied);
+        assert_eq!(audits[0].payload["decision"], "deny");
     }
 
     #[tokio::test]

--- a/crates/khive-mcp/src/server.rs
+++ b/crates/khive-mcp/src/server.rs
@@ -1138,189 +1138,174 @@ async fn dispatch_via_coordinator_inner(
             let source_id: uuid::Uuid = source_str.parse().ok()?;
             let target_id: uuid::Uuid = target_str.parse().ok()?;
             let relation: EdgeRelation = relation_str.parse().ok()?;
-            let namespace =
-                match registry.authorize_intercepted_dispatch(tool, args_value, identity) {
-                    Ok(namespace) => namespace,
-                    Err(error) => return Some(Err(runtime_error_payload(tool, error))),
-                };
-
             let weight = args_value
                 .get("weight")
                 .and_then(Value::as_f64)
                 .unwrap_or(1.0);
             let metadata = args_value.get("metadata").cloned();
 
-            let result = coord
-                .link(&namespace, source_id, target_id, relation, weight, metadata)
+            let result = registry
+                .dispatch_intercepted_with_identity(
+                    tool,
+                    args_value,
+                    identity,
+                    |namespace| async move {
+                        let coord_result = coord
+                            .link(&namespace, source_id, target_id, relation, weight, metadata)
+                            .await
+                            .map_err(RuntimeError::from)?;
+                        let mut raw = serde_json::to_value(&coord_result.edge)
+                            .unwrap_or_else(|e| json!({"error": format!("serialize edge: {e}")}));
+                        if relation.is_symmetric() {
+                            if let Some(obj) = raw.as_object_mut() {
+                                obj.insert("source_id".to_string(), json!(source_id.to_string()));
+                                obj.insert("target_id".to_string(), json!(target_id.to_string()));
+                            }
+                        }
+                        Ok(raw)
+                    },
+                )
                 .await;
-
-            let tool_name = tool.to_string();
-            Some(match result {
-                Ok(coord_result) => {
-                    // Serialize the edge using serde_json — matches `to_json(&edge)` in the kg
-                    // handler, which is what `format_edge_output` receives (identity fn).
-                    let edge_val = serde_json::to_value(&coord_result.edge)
-                        .unwrap_or_else(|e| json!({"error": format!("serialize edge: {e}")}));
-                    // Preserve symmetric-relation source/target override that the kg handler
-                    // applies: if the edge was written with swapped endpoints, inject the
-                    // canonical source/target so callers get what they requested.
-                    let mut raw = edge_val;
-                    if relation.is_symmetric() {
-                        if let Some(obj) = raw.as_object_mut() {
-                            obj.insert("source_id".to_string(), json!(source_id.to_string()));
-                            obj.insert("target_id".to_string(), json!(target_id.to_string()));
-                        }
-                    }
-                    Ok(raw)
-                }
-                Err(e) => {
-                    let re: RuntimeError = e.into();
-                    match re {
-                        RuntimeError::Khive(k) => {
-                            let error_payload = serde_json::to_value(&k).unwrap_or_else(
-                                |_| json!({"kind": "internal", "message": k.to_string()}),
-                            );
-                            Err((tool_name, error_payload))
-                        }
-                        other => Err((tool_name, json!(other.to_string()))),
-                    }
-                }
-            })
+            Some(result.map_err(|error| runtime_error_payload(tool, error)))
         }
         "search" => {
             let kind = args_value.get("kind")?.as_str()?;
             let query = args_value.get("query")?.as_str()?;
-            let namespace =
-                match registry.authorize_intercepted_dispatch(tool, args_value, identity) {
-                    Ok(namespace) => namespace,
-                    Err(error) => return Some(Err(runtime_error_payload(tool, error))),
-                };
-            // Parse strictly as u32 (matching the single-backend `SearchParams { limit:
-            // Option<u32> }` contract) instead of parsing as u64 and casting — `as u32`
-            // wraps values above `u32::MAX` (e.g. 4294967297 as u32 == 1) before the
-            // `.min(100)` cap ever runs, silently truncating a huge limit to a near-empty
-            // result set rather than rejecting it (MCP-AUD-003).
-            let limit = match args_value.get("limit") {
-                None | Some(Value::Null) => 10,
-                Some(v) => match serde_json::from_value::<u32>(v.clone()) {
-                    Ok(limit) => limit.min(100),
-                    Err(_) => {
-                        return Some(Err((
-                            "search".to_string(),
-                            json!("limit must be an unsigned 32-bit integer"),
-                        )));
-                    }
-                },
-            };
-            let score_floor = args_value
-                .get("min_score")
-                .and_then(Value::as_f64)
-                .unwrap_or(0.0)
-                .max(0.0);
+            let result = registry
+                .dispatch_intercepted_with_identity(
+                    tool,
+                    args_value,
+                    identity,
+                    |namespace| async move {
+                        // Parse strictly as u32 (matching the single-backend `SearchParams { limit:
+                        // Option<u32> }` contract) instead of parsing as u64 and casting — `as u32`
+                        // wraps values above `u32::MAX` (e.g. 4294967297 as u32 == 1) before the
+                        // `.min(100)` cap ever runs, silently truncating a huge limit to a near-empty
+                        // result set rather than rejecting it (MCP-AUD-003).
+                        let limit = match args_value.get("limit") {
+                            None | Some(Value::Null) => 10,
+                            Some(v) => match serde_json::from_value::<u32>(v.clone()) {
+                                Ok(limit) => limit.min(100),
+                                Err(_) => {
+                                    return Err(RuntimeError::InvalidInput(
+                                        "limit must be an unsigned 32-bit integer".to_string(),
+                                    ));
+                                }
+                            },
+                        };
+                        let score_floor = args_value
+                            .get("min_score")
+                            .and_then(Value::as_f64)
+                            .unwrap_or(0.0)
+                            .max(0.0);
 
-            // For substrate-level kinds ("entity" / "note"), pass None so the search
-            // is unrestricted. For granular kinds ("concept", "observation", etc.) pass
-            // the kind string so each backend filters at the storage layer — matching
-            // the behaviour of the single-backend handler (search.rs).
-            let kind_filter: Option<&str> = match kind {
-                "entity" | "note" => None,
-                other => Some(other),
-            };
+                        // For substrate-level kinds ("entity" / "note"), pass None so the search
+                        // is unrestricted. For granular kinds ("concept", "observation", etc.) pass
+                        // the kind string so each backend filters at the storage layer — matching
+                        // the behaviour of the single-backend handler (search.rs).
+                        let kind_filter: Option<&str> = match kind {
+                            "entity" | "note" => None,
+                            other => Some(other),
+                        };
 
-            // Extract entity-substrate filters and forward them to each backend.
-            // When either is active the coordinator widens the per-backend candidate
-            // window so that sparse matches ranked below the bare limit are not cut
-            // off before filtering (before-truncation parity with the single-backend
-            // handler in search.rs).
-            let props_filter: Option<&serde_json::Value> =
-                args_value.get("properties").and_then(|v| {
-                    if v.as_object().is_some_and(|m| !m.is_empty()) {
-                        Some(v)
-                    } else {
-                        None
-                    }
-                });
-            // Parse tags strictly: absent/null → no filter (empty Vec); present and
-            // valid Vec<String> → use as-is (including empty array → no filter);
-            // present but not a Vec<String> → reject with a per-op error so the
-            // multi-backend path matches single-backend behaviour, which rejects
-            // malformed tags via SearchParams deserialisation (RuntimeError::InvalidInput).
-            // filter_map(as_str) would silently drop non-string entries and produce
-            // an empty Vec, bypassing the filter and returning unfiltered results.
-            let tags_owned: Vec<String> = match args_value.get("tags") {
-                None | Some(Value::Null) => vec![],
-                Some(v) => match serde_json::from_value::<Vec<String>>(v.clone()) {
-                    Ok(t) => t,
-                    Err(_) => {
-                        return Some(Err((
-                            "search".to_string(),
-                            json!("tags must be an array of strings"),
-                        )));
-                    }
-                },
-            };
+                        // Extract entity-substrate filters and forward them to each backend.
+                        // When either is active the coordinator widens the per-backend candidate
+                        // window so that sparse matches ranked below the bare limit are not cut
+                        // off before filtering (before-truncation parity with the single-backend
+                        // handler in search.rs).
+                        let props_filter: Option<&serde_json::Value> =
+                            args_value.get("properties").and_then(|v| {
+                                if v.as_object().is_some_and(|m| !m.is_empty()) {
+                                    Some(v)
+                                } else {
+                                    None
+                                }
+                            });
+                        // Parse tags strictly: absent/null → no filter (empty Vec); present and
+                        // valid Vec<String> → use as-is (including empty array → no filter);
+                        // present but not a Vec<String> → reject with a per-op error so the
+                        // multi-backend path matches single-backend behaviour, which rejects
+                        // malformed tags via SearchParams deserialisation (RuntimeError::InvalidInput).
+                        // filter_map(as_str) would silently drop non-string entries and produce
+                        // an empty Vec, bypassing the filter and returning unfiltered results.
+                        let tags_owned: Vec<String> = match args_value.get("tags") {
+                            None | Some(Value::Null) => vec![],
+                            Some(v) => match serde_json::from_value::<Vec<String>>(v.clone()) {
+                                Ok(t) => t,
+                                Err(_) => {
+                                    return Err(RuntimeError::InvalidInput(
+                                        "tags must be an array of strings".to_string(),
+                                    ));
+                                }
+                            },
+                        };
 
-            let coord_result = coord
-                .fan_out_search(
-                    kind,
-                    query,
-                    &namespace,
-                    limit,
-                    kind_filter,
-                    props_filter,
-                    &tags_owned,
+                        let coord_result = coord
+                            .fan_out_search(
+                                kind,
+                                query,
+                                &namespace,
+                                limit,
+                                kind_filter,
+                                props_filter,
+                                &tags_owned,
+                            )
+                            .await;
+
+                        // Shape result to match the kg search handler's output fields exactly.
+                        // Entity hits: [{id, entity_kind, score, title, snippet}]
+                        //   - entity_kind: real kind string fetched from the owning backend
+                        //   - score: RRF-merged, subject to min_score floor
+                        // Note hits:   [{id, note_kind, score, title, snippet}]
+                        //   - note_kind: real kind string fetched from the owning backend
+                        let result_val = if !coord_result.note_hits.is_empty()
+                            || (coord_result.entity_hits.is_empty()
+                                && coord_result.note_hits.is_empty())
+                        {
+                            // Note substrate or empty — return note-shaped result.
+                            let items: Vec<Value> = coord_result
+                                .note_hits
+                                .iter()
+                                .filter(|h| h.score.to_f64() >= score_floor)
+                                .map(|h| {
+                                    let note_kind = coord_result.note_kinds.get(&h.note_id);
+                                    json!({
+                                        "id": h.note_id.to_string(),
+                                        "note_kind": note_kind,
+                                        "score": h.score.to_f64(),
+                                        "source": h.source.as_str(),
+                                        "title": h.title,
+                                        "snippet": h.snippet,
+                                    })
+                                })
+                                .collect();
+                            serde_json::to_value(items).unwrap_or_else(|_| json!([]))
+                        } else {
+                            // Entity substrate — return entity-shaped result.
+                            let items: Vec<Value> = coord_result
+                                .entity_hits
+                                .iter()
+                                .filter(|h| h.score.to_f64() >= score_floor)
+                                .map(|h| {
+                                    let entity_kind = coord_result.entity_kinds.get(&h.entity_id);
+                                    json!({
+                                        "id": h.entity_id.to_string(),
+                                        "entity_kind": entity_kind,
+                                        "score": h.score.to_f64(),
+                                        "source": h.source.as_str(),
+                                        "title": h.title,
+                                        "snippet": h.snippet,
+                                    })
+                                })
+                                .collect();
+                            serde_json::to_value(items).unwrap_or_else(|_| json!([]))
+                        };
+
+                        Ok(result_val)
+                    },
                 )
                 .await;
-
-            // Shape result to match the kg search handler's output fields exactly.
-            // Entity hits: [{id, entity_kind, score, title, snippet}]
-            //   - entity_kind: real kind string fetched from the owning backend
-            //   - score: RRF-merged, subject to min_score floor
-            // Note hits:   [{id, note_kind, score, title, snippet}]
-            //   - note_kind: real kind string fetched from the owning backend
-            let result_val = if !coord_result.note_hits.is_empty()
-                || (coord_result.entity_hits.is_empty() && coord_result.note_hits.is_empty())
-            {
-                // Note substrate or empty — return note-shaped result.
-                let items: Vec<Value> = coord_result
-                    .note_hits
-                    .iter()
-                    .filter(|h| h.score.to_f64() >= score_floor)
-                    .map(|h| {
-                        let note_kind = coord_result.note_kinds.get(&h.note_id);
-                        json!({
-                            "id": h.note_id.to_string(),
-                            "note_kind": note_kind,
-                            "score": h.score.to_f64(),
-                            "source": h.source.as_str(),
-                            "title": h.title,
-                            "snippet": h.snippet,
-                        })
-                    })
-                    .collect();
-                serde_json::to_value(items).unwrap_or_else(|_| json!([]))
-            } else {
-                // Entity substrate — return entity-shaped result.
-                let items: Vec<Value> = coord_result
-                    .entity_hits
-                    .iter()
-                    .filter(|h| h.score.to_f64() >= score_floor)
-                    .map(|h| {
-                        let entity_kind = coord_result.entity_kinds.get(&h.entity_id);
-                        json!({
-                            "id": h.entity_id.to_string(),
-                            "entity_kind": entity_kind,
-                            "score": h.score.to_f64(),
-                            "source": h.source.as_str(),
-                            "title": h.title,
-                            "snippet": h.snippet,
-                        })
-                    })
-                    .collect();
-                serde_json::to_value(items).unwrap_or_else(|_| json!([]))
-            };
-
-            Some(Ok(result_val))
+            Some(result.map_err(|error| runtime_error_payload(tool, error)))
         }
         _ => None,
     }

--- a/crates/khive-mcp/src/server.rs
+++ b/crates/khive-mcp/src/server.rs
@@ -24,9 +24,9 @@ use sha2::{Digest, Sha256};
 use khive_db::ConnectionPool;
 use khive_request::{parse_request, ArgValue, DslError, ExecutionMode, ParsedOp};
 use khive_runtime::{
-    present, render_format, resolve_explicit_namespace, KhiveRuntime, OutputFormat, PackLoadError,
-    PackRegistry, PresentationMode, RuntimeConfig, RuntimeError, VerbPresentationPolicy,
-    VerbRegistry, VerbRegistryBuilder,
+    present, render_format, KhiveRuntime, OutputFormat, PackLoadError, PackRegistry,
+    PresentationMode, RuntimeConfig, RuntimeError, VerbPresentationPolicy, VerbRegistry,
+    VerbRegistryBuilder,
 };
 
 use khive_storage::EdgeRelation;
@@ -499,10 +499,8 @@ impl KhiveMcpServer {
         if coord.is_single_backend() {
             return None;
         }
-        let default_namespace = identity
-            .map(|id| id.namespace.as_str())
-            .unwrap_or(self.default_namespace.as_str());
-        dispatch_via_coordinator_inner(coord.as_ref(), tool, args_value, default_namespace).await
+        dispatch_via_coordinator_inner(coord.as_ref(), &self.registry, tool, args_value, identity)
+            .await
     }
 
     /// Namespace this server's registry was built for.
@@ -860,7 +858,6 @@ impl KhiveMcpServer {
 
                 // Clone coordinator and namespace for use in the per-op closures (ADR-029 D3/D4).
                 let coordinator: Option<Arc<dyn CoordinatorService>> = self.coordinator.clone();
-                let default_namespace = self.default_namespace.clone();
                 // ADR-096 Fork 1: a per-request identity overrides the default
                 // namespace for both the coordinator intercept and the registry
                 // dispatch below, so the two can't drift out of sync per op.
@@ -879,10 +876,6 @@ impl KhiveMcpServer {
 
                     let registry = self.registry.clone();
                     let coord = coordinator.clone();
-                    let ns_str = identity_owned
-                        .as_ref()
-                        .map(|id| id.namespace.clone())
-                        .unwrap_or_else(|| default_namespace.clone());
                     let op_identity = identity_owned.clone();
                     let op_mode = mode_for_op(i);
                     async move {
@@ -959,9 +952,10 @@ impl KhiveMcpServer {
                             if !active_coord.is_single_backend() {
                                 if let Some(coord_result) = dispatch_via_coordinator_inner(
                                     active_coord.as_ref(),
+                                    &registry,
                                     &tool,
                                     &args_value,
-                                    &ns_str,
+                                    op_identity.as_ref(),
                                 )
                                 .await
                                 {
@@ -1118,30 +1112,15 @@ impl KhiveMcpServer {
 /// `crates/khive-mcp/docs/api/coordinator.md`.
 async fn dispatch_via_coordinator_inner(
     coord: &dyn CoordinatorService,
+    registry: &VerbRegistry,
     tool: &str,
     args_value: &Value,
-    default_namespace_str: &str,
+    identity: Option<&khive_runtime::RequestIdentity>,
 ) -> Option<Result<Value, (String, Value)>> {
-    // Only link/search are ever intercepted here — resolve/validate the
-    // namespace only for those verbs so unrelated verbs (which always
-    // fall through to `None` below) don't pay for a parse they don't need.
+    // Only link/search are ever intercepted here.
     if !matches!(tool, "link" | "search") {
         return None;
     }
-
-    let namespace = match resolve_explicit_namespace(args_value, default_namespace_str) {
-        Ok(ns) => ns,
-        Err(e) => {
-            return Some(Err(match e {
-                RuntimeError::Khive(k) => {
-                    let error_payload = serde_json::to_value(&k)
-                        .unwrap_or_else(|_| json!({"kind": "internal", "message": k.to_string()}));
-                    (tool.to_string(), error_payload)
-                }
-                other => (tool.to_string(), json!(other.to_string())),
-            }));
-        }
-    };
 
     match tool {
         "link" => {
@@ -1159,6 +1138,11 @@ async fn dispatch_via_coordinator_inner(
             let source_id: uuid::Uuid = source_str.parse().ok()?;
             let target_id: uuid::Uuid = target_str.parse().ok()?;
             let relation: EdgeRelation = relation_str.parse().ok()?;
+            let namespace =
+                match registry.authorize_intercepted_dispatch(tool, args_value, identity) {
+                    Ok(namespace) => namespace,
+                    Err(error) => return Some(Err(runtime_error_payload(tool, error))),
+                };
 
             let weight = args_value
                 .get("weight")
@@ -1206,6 +1190,11 @@ async fn dispatch_via_coordinator_inner(
         "search" => {
             let kind = args_value.get("kind")?.as_str()?;
             let query = args_value.get("query")?.as_str()?;
+            let namespace =
+                match registry.authorize_intercepted_dispatch(tool, args_value, identity) {
+                    Ok(namespace) => namespace,
+                    Err(error) => return Some(Err(runtime_error_payload(tool, error))),
+                };
             // Parse strictly as u32 (matching the single-backend `SearchParams { limit:
             // Option<u32> }` contract) instead of parsing as u64 and casting — `as u32`
             // wraps values above `u32::MAX` (e.g. 4294967297 as u32 == 1) before the
@@ -1334,6 +1323,17 @@ async fn dispatch_via_coordinator_inner(
             Some(Ok(result_val))
         }
         _ => None,
+    }
+}
+
+fn runtime_error_payload(tool: &str, error: RuntimeError) -> (String, Value) {
+    match error {
+        RuntimeError::Khive(k) => {
+            let error_payload = serde_json::to_value(&k)
+                .unwrap_or_else(|_| json!({"kind": "internal", "message": k.to_string()}));
+            (tool.to_string(), error_payload)
+        }
+        other => (tool.to_string(), json!(other.to_string())),
     }
 }
 

--- a/crates/khive-runtime/src/pack.rs
+++ b/crates/khive-runtime/src/pack.rs
@@ -1129,6 +1129,59 @@ impl VerbRegistry {
         }
     }
 
+    /// Apply the registry's verb gate to an operation handled outside pack dispatch.
+    ///
+    /// Multi-backend transports use this before routing an operation through a
+    /// coordinator. The request construction and decision semantics match
+    /// [`Self::dispatch_with_identity`]: deny is authoritative and gate errors
+    /// fail open.
+    pub fn authorize_intercepted_dispatch(
+        &self,
+        verb: &str,
+        params: &Value,
+        identity: Option<&RequestIdentity>,
+    ) -> Result<Namespace, RuntimeError> {
+        let gate_req = self.gate_request_with_identity(verb, params, identity)?;
+        match self.gate.check(&gate_req) {
+            Ok(decision) => {
+                let audit = AuditEvent::from_check(&gate_req, &decision, self.gate.impl_name());
+                tracing::info!(
+                    audit_event = %serde_json::to_string(&audit)
+                        .unwrap_or_else(|_| "{\"error\":\"serialize\"}".into()),
+                    "gate.check"
+                );
+                match decision {
+                    GateDecision::Deny { reason } => Err(RuntimeError::PermissionDenied {
+                        verb: verb.to_string(),
+                        reason,
+                    }),
+                    _ => Ok(gate_req.namespace),
+                }
+            }
+            Err(err) => {
+                tracing::warn!(verb, error = %err, "gate check failed (fail-open)");
+                Ok(gate_req.namespace)
+            }
+        }
+    }
+
+    fn gate_request_with_identity(
+        &self,
+        verb: &str,
+        params: &Value,
+        identity: Option<&RequestIdentity>,
+    ) -> Result<GateRequest, RuntimeError> {
+        let default_namespace = identity
+            .map(|id| id.namespace.as_str())
+            .unwrap_or(self.default_namespace.as_str());
+        let namespace = resolve_explicit_namespace(params, default_namespace)?;
+        let actor_id = identity
+            .map(|id| id.actor_id.as_deref())
+            .unwrap_or(self.actor_id.as_deref());
+        let actor = crate::actor_identity::resolve_actor(actor_id);
+        Ok(GateRequest::new(actor, namespace, verb, params.clone()))
+    }
+
     /// Dispatch a verb to the first pack that handles it.
     ///
     /// Routes through the gate, then invokes the matching pack handler. When
@@ -1178,24 +1231,14 @@ impl VerbRegistry {
         // here so it is in scope for every audit-append site below,
         // including the ones that run before pack dispatch is attempted.
         let request_id: Option<u64> = identity.as_ref().and_then(|id| id.request_id);
-        // A supplied per-request identity overrides the baked
-        // default_namespace/actor_id/visible_namespaces for this call only.
-        let default_namespace_str: &str = identity
-            .as_ref()
-            .map(|id| id.namespace.as_str())
-            .unwrap_or(self.default_namespace.as_str());
-        let ns = resolve_explicit_namespace(&params, default_namespace_str)?;
-        let actor_id_str: Option<&str> = match identity.as_ref() {
-            Some(id) => id.actor_id.as_deref(),
-            None => self.actor_id.as_deref(),
-        };
         // Thread the configured actor identity into the gate request so the
         // gate can distinguish human vs agent callers at the dispatch seam.
         // Resolved once via the shared actor-identity policy and reused for
         // token minting below, so the gate's notion of "who is the caller"
         // and the storage token's notion can never drift apart.
-        let resolved_actor = crate::actor_identity::resolve_actor(actor_id_str);
-        let gate_req = GateRequest::new(resolved_actor.clone(), ns.clone(), verb, params.clone());
+        let gate_req = self.gate_request_with_identity(verb, &params, identity.as_ref())?;
+        let ns = gate_req.namespace.clone();
+        let resolved_actor = gate_req.actor.clone();
 
         // Consult the gate.
         //

--- a/crates/khive-runtime/src/pack.rs
+++ b/crates/khive-runtime/src/pack.rs
@@ -1129,20 +1129,27 @@ impl VerbRegistry {
         }
     }
 
-    /// Apply the registry's verb gate to an operation handled outside pack dispatch.
+    /// Gate and execute an operation handled outside normal pack dispatch.
     ///
-    /// Multi-backend transports use this before routing an operation through a
-    /// coordinator. The request construction and decision semantics match
-    /// [`Self::dispatch_with_identity`]: deny is authoritative and gate errors
-    /// fail open.
-    pub fn authorize_intercepted_dispatch(
+    /// Multi-backend transports use this to route an operation through a
+    /// coordinator while retaining [`Self::dispatch_with_identity`]'s gate and
+    /// audit lifecycle. Deny is authoritative, gate errors fail open, and an
+    /// allowed audit is persisted after the intercepted operation resolves so
+    /// its outcome and duration reflect the operation result.
+    pub async fn dispatch_intercepted_with_identity<F, Fut>(
         &self,
         verb: &str,
         params: &Value,
         identity: Option<&RequestIdentity>,
-    ) -> Result<Namespace, RuntimeError> {
+        dispatch: F,
+    ) -> Result<Value, RuntimeError>
+    where
+        F: FnOnce(Namespace) -> Fut,
+        Fut: std::future::Future<Output = Result<Value, RuntimeError>>,
+    {
+        let request_id = identity.and_then(|id| id.request_id);
         let gate_req = self.gate_request_with_identity(verb, params, identity)?;
-        match self.gate.check(&gate_req) {
+        let deferred_audit = match self.gate.check(&gate_req) {
             Ok(decision) => {
                 let audit = AuditEvent::from_check(&gate_req, &decision, self.gate.impl_name());
                 tracing::info!(
@@ -1150,19 +1157,116 @@ impl VerbRegistry {
                         .unwrap_or_else(|_| "{\"error\":\"serialize\"}".into()),
                     "gate.check"
                 );
-                match decision {
-                    GateDecision::Deny { reason } => Err(RuntimeError::PermissionDenied {
+                if let GateDecision::Deny { reason } = decision {
+                    if let Some(store) = &self.event_store {
+                        let event = build_audit_storage_event(
+                            &gate_req,
+                            &audit,
+                            EventOutcome::Denied,
+                            Some(crate::cost_unit::base_resource_payload(request_id)),
+                        );
+                        append_audit_event_best_effort(store, event, verb).await;
+                    }
+                    return Err(RuntimeError::PermissionDenied {
                         verb: verb.to_string(),
                         reason,
-                    }),
-                    _ => Ok(gate_req.namespace),
+                    });
                 }
+                Some(audit)
             }
             Err(err) => {
                 tracing::warn!(verb, error = %err, "gate check failed (fail-open)");
-                Ok(gate_req.namespace)
+                None
             }
+        };
+
+        let started = Instant::now();
+        let result = dispatch(gate_req.namespace.clone()).await;
+        let duration_us = started.elapsed().as_micros() as i64;
+        if let Some(audit) = deferred_audit {
+            self.persist_intercepted_audit(
+                verb,
+                &gate_req,
+                audit,
+                &result,
+                duration_us,
+                request_id,
+            )
+            .await;
         }
+        result
+    }
+
+    async fn persist_intercepted_audit(
+        &self,
+        verb: &str,
+        gate_req: &GateRequest,
+        audit: AuditEvent,
+        result: &Result<Value, RuntimeError>,
+        duration_us: i64,
+        request_id: Option<u64>,
+    ) {
+        let Some(store) = &self.event_store else {
+            return;
+        };
+        let event = match result {
+            Ok(value) if verb == "link" && gate_req.args.get("links").is_none() => {
+                let resource = crate::cost_unit::resource_payload(
+                    verb,
+                    &gate_req.args,
+                    value,
+                    || 0,
+                    request_id,
+                );
+                match link_audit_success_from_result(audit.clone(), value) {
+                    Some((edge_id, mut payload)) => {
+                        if let Value::Object(ref mut map) = payload {
+                            map.insert("resource".to_string(), resource);
+                        }
+                        Event::new(
+                            gate_req.namespace.as_str(),
+                            gate_req.verb.as_str(),
+                            EventKind::Audit,
+                            SubstrateKind::Event,
+                            format!("{}:{}", gate_req.actor.kind, gate_req.actor.id),
+                        )
+                        .with_outcome(EventOutcome::Success)
+                        .with_target(edge_id)
+                        .with_payload(payload)
+                        .with_payload_schema_version(2)
+                        .with_duration_us(duration_us)
+                    }
+                    None => build_audit_storage_event(
+                        gate_req,
+                        &audit,
+                        EventOutcome::Success,
+                        Some(resource),
+                    )
+                    .with_duration_us(duration_us),
+                }
+            }
+            Ok(value) => build_audit_storage_event(
+                gate_req,
+                &audit,
+                EventOutcome::Success,
+                Some(crate::cost_unit::resource_payload(
+                    verb,
+                    &gate_req.args,
+                    value,
+                    || 0,
+                    request_id,
+                )),
+            )
+            .with_duration_us(duration_us),
+            Err(_) => build_audit_storage_event(
+                gate_req,
+                &audit,
+                EventOutcome::Error,
+                Some(crate::cost_unit::base_resource_payload(request_id)),
+            )
+            .with_duration_us(duration_us),
+        };
+        append_audit_event_best_effort(store, event, verb).await;
     }
 
     fn gate_request_with_identity(


### PR DESCRIPTION
## Summary

Direct dispatch constructs a `GateRequest` from the resolved actor, effective namespace, verb, and unchanged arguments — but multi-backend interception bypassed that gate, reaching only lower-level authorize checks inside coordinator runtime operations. The coordinator path now applies the registry gate before invoking `link` or `fan_out_search`, via a shared request-construction helper, so both routes submit identical `GateRequest` values. A deny returns the same `PermissionDenied` operation envelope and prevents the coordinator call; gate infrastructure errors retain the direct route's fail-open behavior; allowed checks emit the same `gate.check` audit event shape.

Closes #573

## Verification

- `coordinator_and_registry_routes_submit_equivalent_link_and_search_gate_requests`: red before (direct route captured 2 verb-specific gate requests, coordinator route 0), green after; serialized `GateRequest` equality covers actor, namespace, verb, arguments, context.
- Coordinator suite 9 passed; runtime gate suite 198 passed; fmt, clippy `-D warnings`, `cargo check --workspace` green.
