### PR TITLE
refactor(bm25): adopt khive-text as the shared text-analysis layer

### DIFF
--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -1577,6 +1577,7 @@ version = "0.6.0"
 dependencies = [
  "criterion",
  "khive-score",
+ "khive-text",
  "parking_lot",
  "rand 0.8.7",
  "serde",
@@ -1880,7 +1881,6 @@ name = "khive-text"
 version = "0.6.0"
 dependencies = [
  "criterion",
- "khive-bm25",
  "rust-stemmers",
  "unicode-segmentation",
 ]

--- a/crates/khive-bm25/Cargo.toml
+++ b/crates/khive-bm25/Cargo.toml
@@ -16,6 +16,7 @@ bench = false
 
 [dependencies]
 khive-score = { version = "0.6.0", path = "../khive-score" }
+khive-text = { version = "0.6.0", path = "../khive-text" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/khive-bm25/docs/api/tokenizer.md
+++ b/crates/khive-bm25/docs/api/tokenizer.md
@@ -10,13 +10,13 @@ an `Arc<dyn Tokenizer>`, allowing an index and its clones to share tokenizer sta
 ## `SimpleTokenizer`
 
 `SimpleTokenizer` splits on whitespace, strips leading and trailing ASCII punctuation (non-ASCII
-punctuation is retained), optionally lowercases, filters by minimum UTF-8 byte length, and
+punctuation is retained), optionally lowercases, filters by minimum Unicode character count, and
 optionally removes the built-in English stop-word set. Defaults enable lowercasing and stop-word
 removal with a minimum length of one.
 
-ASCII tokens use an ASCII-only lowercase fast path; non-ASCII input falls back to Unicode-aware
-lowercasing. Capacity is estimated from typical English word length to reduce reallocations without
-affecting output.
+The tokenizer composes `khive-text`'s shared whitespace, lowercase, length, and BM25 stop-word
+primitives. `Tokenizer` and `BoxedTokenizer` are re-exported from `khive-text`, so custom tokenizer
+implementations keep the same public interface.
 
 ## `tokenize`
 

--- a/crates/khive-bm25/src/tokenizer.rs
+++ b/crates/khive-bm25/src/tokenizer.rs
@@ -1,32 +1,10 @@
 //! Pluggable tokenizer trait with a simple English whitespace default.
 
-use std::collections::HashSet;
-use std::sync::{Arc, LazyLock};
+use khive_text::filter::{Bm25StopWordFilter, LowercaseFilter, MinLengthFilter};
+use khive_text::tokenizer::WhitespaceTokenizer;
+use khive_text::TokenFilter;
 
-/// Deterministic, thread-safe term extraction for BM25 indexing.
-///
-/// See `crates/khive-bm25/docs/api/tokenizer.md`.
-pub trait Tokenizer: Send + Sync {
-    /// Tokenize text into terms. Returns empty vec for empty input.
-    fn tokenize(&self, text: &str) -> Vec<String>;
-}
-
-/// Box type for tokenizers (enables dynamic dispatch).
-pub type BoxedTokenizer = Arc<dyn Tokenizer>;
-
-/// English stop words filtered from BM25 postings to reduce index size.
-static STOP_WORDS: LazyLock<HashSet<&'static str>> = LazyLock::new(|| {
-    HashSet::from([
-        "a", "an", "and", "are", "as", "at", "be", "been", "being", "but", "by", "can", "did",
-        "do", "does", "doing", "done", "for", "from", "had", "has", "have", "having", "he", "her",
-        "here", "hers", "him", "his", "how", "i", "if", "in", "into", "is", "it", "its", "just",
-        "may", "me", "might", "my", "no", "nor", "not", "of", "on", "or", "our", "out", "own",
-        "say", "she", "should", "so", "some", "such", "than", "that", "the", "their", "them",
-        "then", "there", "these", "they", "this", "those", "through", "to", "too", "up", "us",
-        "very", "was", "we", "were", "what", "when", "where", "which", "while", "who", "whom",
-        "why", "will", "with", "would", "you", "your",
-    ])
-});
+pub use khive_text::{BoxedTokenizer, Tokenizer};
 
 /// Configurable whitespace tokenizer with punctuation, case, length, and stop-word processing.
 ///
@@ -64,40 +42,25 @@ impl SimpleTokenizer {
 
 impl Tokenizer for SimpleTokenizer {
     fn tokenize(&self, text: &str) -> Vec<String> {
-        // Average English word length gives a useful allocation estimate.
-        let estimated_tokens = text.len() / 6 + 1;
-        let mut result = Vec::with_capacity(estimated_tokens.min(32));
-
-        for word in text.split_whitespace() {
-            let trimmed = word.trim_matches(|c: char| c.is_ascii_punctuation());
-
-            if trimmed.len() < self.min_length {
-                continue;
-            }
-
-            // Avoid Unicode lowercase allocation for the common ASCII path.
-            let token = if self.lowercase {
-                if trimmed.is_ascii() {
-                    let mut s = String::with_capacity(trimmed.len());
-                    for &byte in trimmed.as_bytes() {
-                        s.push(byte.to_ascii_lowercase() as char);
-                    }
-                    s
+        WhitespaceTokenizer
+            .tokenize(text)
+            .into_iter()
+            .filter_map(|token| MinLengthFilter(self.min_length).apply(token))
+            .filter_map(|token| {
+                if self.lowercase {
+                    LowercaseFilter.apply(token)
                 } else {
-                    trimmed.to_lowercase()
+                    Some(token)
                 }
-            } else {
-                trimmed.to_string()
-            };
-
-            if self.filter_stop_words && STOP_WORDS.contains(token.as_str()) {
-                continue;
-            }
-
-            result.push(token);
-        }
-
-        result
+            })
+            .filter_map(|token| {
+                if self.filter_stop_words {
+                    Bm25StopWordFilter.apply(token)
+                } else {
+                    Some(token)
+                }
+            })
+            .collect()
     }
 }
 
@@ -108,6 +71,8 @@ pub fn tokenize(text: &str) -> Vec<String> {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+
     use super::*;
 
     #[test]
@@ -165,6 +130,34 @@ mod tests {
         let tokens = tokenizer.tokenize("I am a cat");
         // "I", "am", "a" filtered by min_length; also stop words
         assert_eq!(tokens, vec!["cat"]);
+    }
+
+    #[test]
+    fn test_simple_tokenizer_min_length_counts_unicode_characters() {
+        let tokenizer = SimpleTokenizer::new(true, 2);
+        assert_eq!(tokenizer.tokenize("你 rust"), vec!["rust"]);
+    }
+
+    #[test]
+    fn test_default_tokenizer_matches_shared_standard_analyzer() {
+        use khive_text::{preset, Analyzer};
+
+        let tokenizer = SimpleTokenizer::default();
+        let analyzer = preset::standard();
+        let cases = [
+            "may x",
+            "done say might",
+            "against",
+            &"a".repeat(41),
+            "The quick brown fox jumps over the lazy dog",
+        ];
+        for input in cases {
+            assert_eq!(
+                tokenizer.tokenize(input),
+                analyzer.analyze(input),
+                "mismatch for input: {input:?}"
+            );
+        }
     }
 
     #[test]

--- a/crates/khive-bm25/tests/integration.rs
+++ b/crates/khive-bm25/tests/integration.rs
@@ -285,6 +285,21 @@ fn custom_tokenizer_min_length_filters_short_tokens() {
     assert_eq!(index.search("quick", 10).len(), 1);
 }
 
+#[test]
+fn unicode_min_length_changes_length_normalized_ranking() {
+    let tokenizer: BoxedTokenizer = Arc::new(SimpleTokenizer::new(true, 2));
+    let mut index =
+        Bm25Index::try_with_tokenizer(Bm25Config::default(), tokenizer).expect("valid config");
+
+    index.index_document("short", "target 你").unwrap();
+    index.index_document("long", "target extra").unwrap();
+
+    let results = index.search("target", 10);
+    assert_eq!(results.len(), 2);
+    assert_eq!(&*results[0].0, "short");
+    assert!(results[0].1 > results[1].1);
+}
+
 // ---------------------------------------------------------------------------
 // Tokenizer Tokenizer trait: verify tokenize() contract via SimpleTokenizer
 // ---------------------------------------------------------------------------

--- a/crates/khive-text/Cargo.toml
+++ b/crates/khive-text/Cargo.toml
@@ -20,7 +20,6 @@ rust-stemmers = { workspace = true, optional = true }
 
 [dev-dependencies]
 criterion = { workspace = true }
-khive-bm25 = { version = "0.6.0", path = "../khive-bm25" }
 
 [features]
 default = []

--- a/crates/khive-text/README.md
+++ b/crates/khive-text/README.md
@@ -50,10 +50,9 @@ choosing an analyzer.
 
 ## Where this sits
 
-`khive-text` has no required khive-* dependencies and no current in-workspace
-consumers — it is a standalone tokenization library extracted for reuse by any
-future retrieval crate that needs a pluggable analyzer independent of
-`khive-bm25`'s built-in `SimpleTokenizer`.
+`khive-text` has no required khive-* dependencies. `khive-bm25` consumes its
+tokenizer trait and normalization filters while retaining `SimpleTokenizer` as
+its compatibility-oriented configuration wrapper.
 
 ## License
 

--- a/crates/khive-text/src/preset.rs
+++ b/crates/khive-text/src/preset.rs
@@ -153,21 +153,4 @@ mod tests {
         let tokens = standard().analyze(&input);
         assert_eq!(tokens, vec!["hello".to_string(), long, "world".to_string()]);
     }
-
-    #[test]
-    fn standard_matches_bm25_default_token_stream() {
-        let bm25 = khive_bm25::SimpleTokenizer::default();
-        let cases = [
-            "may x",
-            "done say might",
-            "against",
-            &"a".repeat(41),
-            "The quick brown fox jumps over the lazy dog",
-        ];
-        for input in cases {
-            let ours = standard().analyze(input);
-            let theirs = khive_bm25::Tokenizer::tokenize(&bm25, input);
-            assert_eq!(ours, theirs, "mismatch for input: {input:?}");
-        }
-    }
 }


### PR DESCRIPTION
## Summary

Keeps `khive-text` and establishes it as the shared text-analysis layer by wiring it into `khive-bm25`. BM25's duplicate tokenizer trait, boxed alias, stop-word table, whitespace splitting, lowercasing, and length filtering are replaced by the shared primitives; public BM25 names and configuration surface are preserved (`SimpleTokenizer` remains as a source-compatible wrapper, and `SimpleTokenizer::default()` produces the same token stream as `khive_text::preset::standard()`, verified by a relocated parity test). The old reverse dev-dependency from `khive-text` to `khive-bm25` is removed, keeping the graph acyclic: `khive-text ← khive-bm25 ← khive-retrieval`.

One intentional behavior change: custom `SimpleTokenizer` configurations with `min_length > 1` now count Unicode scalar values rather than UTF-8 bytes (`你` no longer survives `min_length = 2`). This can change document lengths and length-normalized scores for non-ASCII tokens; persisted indexes built with a non-default minimum length and non-ASCII tokens should be rebuilt for corrected statistics. Documented in the tokenizer API doc with a ranking regression.

The shared `is_meaningful_query` gate has no other in-workspace consumer to reconcile in this distribution.

Closes #377

## Verification

- Red-to-green on the Unicode token-stream test (`["你","rust"]` → `["rust"]`) and the length-normalized ranking regression.
- 136 BM25 + 112 text tests passed; fmt, clippy `-D warnings`, `cargo check --workspace` green; BM25 coverage 92.71% lines, tokenizer.rs 100%.
