### PR TITLE
ci: weekly unlocked-resolution run, guard permission contract, bench-target quick runs

### DIFF
--- a/.github/workflows/bench-component.yml
+++ b/.github/workflows/bench-component.yml
@@ -66,7 +66,7 @@ jobs:
           set -euo pipefail
           pkg_args=()
           for crate in $COMPONENT_CRATES; do pkg_args+=(-p "$crate"); done
-          timeout 600 cargo bench "${pkg_args[@]}" -- --quick || true
+          timeout 600 cargo bench "${pkg_args[@]}" --benches -- --quick || true
 
       - name: Record component trend ledger entry
         id: record

--- a/.github/workflows/unlocked-dependencies.yml
+++ b/.github/workflows/unlocked-dependencies.yml
@@ -1,0 +1,86 @@
+name: Unlocked dependency resolution
+
+on:
+  schedule:
+    - cron: "23 7 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: unlocked-dependency-resolution
+  cancel-in-progress: false
+
+jobs:
+  unlocked-resolution:
+    name: Check latest compatible dependencies
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - uses: dtolnay/rust-toolchain@1.94.1
+
+      - name: Create throwaway workspace
+        run: git worktree add --detach "$RUNNER_TEMP/khive-unlocked" "$GITHUB_SHA"
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: ${{ runner.temp }}/khive-unlocked/crates
+          shared-key: unlocked-dependencies
+          cache-on-failure: true
+
+      - name: Resolve latest compatible dependencies
+        id: update
+        continue-on-error: true
+        working-directory: ${{ runner.temp }}/khive-unlocked/crates
+        run: cargo update
+
+      - name: Check workspace
+        id: check
+        if: steps.update.outcome == 'success'
+        continue-on-error: true
+        working-directory: ${{ runner.temp }}/khive-unlocked/crates
+        run: cargo check --workspace --all-targets --all-features
+
+      - name: Test workspace
+        id: test
+        if: steps.update.outcome == 'success'
+        continue-on-error: true
+        working-directory: ${{ runner.temp }}/khive-unlocked/crates
+        run: cargo test --workspace --all-features
+
+      - name: Write workflow summary
+        if: always()
+        env:
+          UPDATE_OUTCOME: ${{ steps.update.outcome }}
+          CHECK_OUTCOME: ${{ steps.check.outcome }}
+          TEST_OUTCOME: ${{ steps.test.outcome }}
+        run: |
+          {
+            echo "# Unlocked dependency resolution"
+            echo
+            echo "This scheduled check resolves the latest versions allowed by the workspace manifests in a throwaway lockfile."
+            echo
+            echo "| Phase | Outcome |"
+            echo "|---|---|"
+            echo "| cargo update | ${UPDATE_OUTCOME} |"
+            echo "| cargo check --workspace | ${CHECK_OUTCOME} |"
+            echo "| cargo test --workspace | ${TEST_OUTCOME} |"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Report advisory failure
+        if: always()
+        env:
+          UPDATE_OUTCOME: ${{ steps.update.outcome }}
+          CHECK_OUTCOME: ${{ steps.check.outcome }}
+          TEST_OUTCOME: ${{ steps.test.outcome }}
+        run: |
+          if [ "$UPDATE_OUTCOME" != success ] || [ "$CHECK_OUTCOME" != success ] || [ "$TEST_OUTCOME" != success ]; then
+            echo "::error::Latest compatible dependency resolution did not pass; see the workflow summary."
+            exit 1
+          fi

--- a/.github/workflows/unlocked-dependencies.yml
+++ b/.github/workflows/unlocked-dependencies.yml
@@ -21,7 +21,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
         with:
-          fetch-depth: 0
+          persist-credentials: false
 
       - uses: dtolnay/rust-toolchain@1.94.1
 

--- a/scripts/tests/test_ci_workflows.py
+++ b/scripts/tests/test_ci_workflows.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+"""Contract tests for CI workflow triggers, permissions, and command wiring."""
+
+from __future__ import annotations
+
+import pathlib
+import unittest
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
+WORKFLOWS = REPO_ROOT / ".github" / "workflows"
+
+
+def workflow_text(name: str) -> str:
+    return (WORKFLOWS / name).read_text()
+
+
+def indented_block(text: str, key: str, indent: int) -> str:
+    lines = text.splitlines()
+    marker = f"{' ' * indent}{key}:"
+    start = lines.index(marker) + 1
+    end = len(lines)
+    for index in range(start, len(lines)):
+        line = lines[index]
+        if line.strip() and len(line) - len(line.lstrip()) <= indent:
+            end = index
+            break
+    return "\n".join(lines[start:end])
+
+
+def mapping_entries(block: str) -> set[str]:
+    return {
+        line.strip()
+        for line in block.splitlines()
+        if line.strip() and not line.lstrip().startswith("#")
+    }
+
+
+class UnlockedDependencyWorkflowTests(unittest.TestCase):
+    def test_weekly_workflow_uses_throwaway_lockfile_and_reports_all_outcomes(self):
+        workflow = workflow_text("unlocked-dependencies.yml")
+        triggers = indented_block(workflow, "on", 0)
+        self.assertIn("schedule:", triggers)
+        self.assertIn("workflow_dispatch:", triggers)
+        self.assertNotIn("pull_request:", triggers)
+        self.assertNotIn("push:", triggers)
+        self.assertEqual(
+            mapping_entries(indented_block(workflow, "permissions", 0)),
+            {"contents: read"},
+        )
+
+        self.assertIn("$RUNNER_TEMP", workflow)
+        self.assertIn("cargo update", workflow)
+        self.assertIn("cargo check --workspace", workflow)
+        self.assertIn("cargo test --workspace", workflow)
+        self.assertIn("GITHUB_STEP_SUMMARY", workflow)
+
+
+class AutoMergeGuardWorkflowTests(unittest.TestCase):
+    def test_push_guard_has_only_required_write_permissions(self):
+        workflow = workflow_text("ci.yml")
+        guard = indented_block(workflow, "automerge-push-guard", 2)
+        permissions = mapping_entries(indented_block(guard, "permissions", 4))
+        self.assertEqual(permissions, {"contents: write", "pull-requests: write"})
+
+
+class BenchTrackWorkflowTests(unittest.TestCase):
+    def test_component_runner_limits_quick_flag_to_bench_targets(self):
+        workflow = workflow_text("bench-component.yml")
+        bench_commands = [
+            line.strip() for line in workflow.splitlines() if "cargo bench" in line
+        ]
+        quick_commands = [line for line in bench_commands if "--quick" in line]
+        self.assertEqual(len(quick_commands), 1)
+        self.assertIn("--benches", quick_commands[0])
+        self.assertIn("--criterion-dir crates/target/criterion", workflow)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #1072, closes #1057, closes #863.

- Adds `.github/workflows/unlocked-dependencies.yml`: a weekly (and manually dispatchable) advisory run that copies the workspace to a detached worktree, runs `cargo update` on a throwaway lockfile, then runs workspace check/test against the updated resolution. Read-only permissions, no PR trigger; a summary step fails the run when any phase fails so upstream breakage is visible.
- Pins the auto-merge push guard's job-local permission map (`contents: write`, `pull-requests: write`, nothing else) in a workflow contract test so the scopes can neither be silently reduced (recreating the integration-access failure) nor widened.
- Passes `--benches` to the quick Criterion invocation in `bench-component.yml` so libtest targets no longer receive Criterion's `--quick` flag; estimates now land in the recording path consumed by the bench trend ledger.

Tests: `scripts/tests/test_ci_workflows.py` (3 contracts), existing perf suites (34 pass), actionlint + PyYAML parse clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)