### PR TITLE
feat(kg): merge safety floor with structured refusal and force override

### DIFF
--- a/crates/khive-pack-kg/src/handler_defs.rs
+++ b/crates/khive-pack-kg/src/handler_defs.rs
@@ -417,7 +417,7 @@ pub(crate) static KG_HANDLERS: [HandlerDef; 19] = [
     // Declaration: declares two records identical
     HandlerDef {
         name: "merge",
-        description: "Deduplicate two entities or notes. Successful non-dry-run merges emit an entity_merged or note_merged audit event. Returns {kept_id, removed_id, edges_rewired, properties_merged, tags_unioned, content_appended, dry_run}; \
+        description: "Deduplicate two entities or notes. Entity merges that fail the cheap entity_kind, name_similarity, or project_compatibility guard return a structured conflict error naming the guard in details.guard. force=true bypasses those guards and means the caller accepts responsibility. Successful non-dry-run merges emit an entity_merged or note_merged audit event. Returns {kept_id, removed_id, edges_rewired, properties_merged, tags_unioned, content_appended, dry_run}; \
                        chain with $prev.kept_id (not $prev.id — merge does not return a top-level id field).",
         visibility: Visibility::Verb,
         category: VerbCategory::Declaration,
@@ -457,6 +457,12 @@ pub(crate) static KG_HANDLERS: [HandlerDef; 19] = [
                 param_type: "bool",
                 required: false,
                 description: "If true, return the planned summary without mutating records or emitting an event.",
+            },
+            ParamDef {
+                name: "force",
+                param_type: "bool",
+                required: false,
+                description: "If true, bypass entity merge safety guards; the caller accepts responsibility for the merge.",
             },
             ParamDef {
                 name: "reason",
@@ -1412,11 +1418,22 @@ mod tests {
                 "merge must document required {required}"
             );
         }
-        for optional in ["kind", "strategy", "content_strategy", "dry_run", "reason"] {
+        for optional in [
+            "kind",
+            "strategy",
+            "content_strategy",
+            "dry_run",
+            "force",
+            "reason",
+        ] {
             assert!(
                 h.params.iter().any(|p| p.name == optional && !p.required),
                 "merge must document optional {optional}"
             );
         }
+        assert!(
+            h.description.contains("details.guard") && h.description.contains("force=true"),
+            "merge must document structured guard refusal and the responsibility override"
+        );
     }
 }

--- a/crates/khive-pack-kg/src/handlers/merge.rs
+++ b/crates/khive-pack-kg/src/handlers/merge.rs
@@ -83,10 +83,20 @@ fn names_are_similar(left: &str, right: &str) -> bool {
 }
 
 fn normalize_name(name: &str) -> String {
-    name.chars()
-        .flat_map(char::to_lowercase)
-        .filter(|ch| ch.is_alphanumeric())
-        .collect()
+    let mut normalized = String::with_capacity(name.len());
+    let mut pending_space = false;
+    for ch in name.chars().flat_map(char::to_lowercase) {
+        if ch.is_whitespace() {
+            pending_space = !normalized.is_empty();
+        } else {
+            if pending_space {
+                normalized.push(' ');
+                pending_space = false;
+            }
+            normalized.push(ch);
+        }
+    }
+    normalized
 }
 
 fn trigrams(value: &str) -> HashSet<[char; 3]> {
@@ -114,20 +124,37 @@ fn projects_are_disjoint(into: &Entity, from: &Entity) -> bool {
     else {
         return false;
     };
-    !into_projects.is_empty()
-        && !from_projects.is_empty()
-        && !into_projects.iter().any(|left| {
-            from_projects
-                .iter()
-                .any(|right| project_values_match(left, right))
-        })
+    if into_projects.is_empty() || from_projects.is_empty() {
+        return false;
+    }
+
+    // Project arrays are caller-controlled: index the smaller side to bound
+    // memory, scan each side once, and stop at the first match.
+    let (indexed, candidates) = if into_projects.len() <= from_projects.len() {
+        (into_projects, from_projects)
+    } else {
+        (from_projects, into_projects)
+    };
+    let mut indexed_strings = HashSet::new();
+    let mut indexed_values = HashSet::new();
+    for value in indexed {
+        if let Some(value) = value.as_str() {
+            indexed_strings.insert(normalize_project_string(value));
+        } else {
+            indexed_values.insert(value.clone());
+        }
+    }
+    !candidates.iter().any(|candidate| {
+        if let Some(candidate) = candidate.as_str() {
+            indexed_strings.contains(&normalize_project_string(candidate))
+        } else {
+            indexed_values.contains(candidate)
+        }
+    })
 }
 
-fn project_values_match(left: &Value, right: &Value) -> bool {
-    match (left.as_str(), right.as_str()) {
-        (Some(left), Some(right)) => left.trim().eq_ignore_ascii_case(right.trim()),
-        _ => left == right,
-    }
+fn normalize_project_string(value: &str) -> String {
+    value.trim().to_ascii_lowercase()
 }
 
 impl KgPack {

--- a/crates/khive-pack-kg/src/handlers/merge.rs
+++ b/crates/khive-pack-kg/src/handlers/merge.rs
@@ -1,12 +1,11 @@
 //! `merge` verb handler.
 
-use std::collections::HashSet;
-
 use serde_json::Value;
 
-use khive_runtime::{NamespaceToken, RuntimeError, VerbRegistry};
-use khive_storage::Entity;
-use khive_types::{Details, KhiveError};
+use khive_runtime::{
+    entity_merge_guard_error, validate_entity_merge_floor, NamespaceToken, RuntimeError,
+    VerbRegistry,
+};
 
 use super::common::{
     deser, ensure_entity_kind, ensure_note_kind, immutable_event_error, parse_content_strategy,
@@ -14,148 +13,6 @@ use super::common::{
     MergeParams,
 };
 use crate::KgPack;
-
-#[derive(Clone, Copy)]
-enum EntityMergeGuard {
-    EntityKind,
-    NameSimilarity,
-    ProjectCompatibility,
-}
-
-impl EntityMergeGuard {
-    fn as_str(self) -> &'static str {
-        match self {
-            Self::EntityKind => "entity_kind",
-            Self::NameSimilarity => "name_similarity",
-            Self::ProjectCompatibility => "project_compatibility",
-        }
-    }
-}
-
-fn merge_guard_error(guard: EntityMergeGuard) -> RuntimeError {
-    RuntimeError::Khive(
-        KhiveError::conflict(format!(
-            "entity merge refused by {} guard; use force=true only when the caller accepts responsibility",
-            guard.as_str()
-        ))
-        .with_details(Details::new([
-            ("guard", guard.as_str()),
-            ("override", "force=true"),
-        ])),
-    )
-}
-
-fn validate_entity_merge_floor(into: &Entity, from: &Entity) -> Result<(), RuntimeError> {
-    if into.kind != from.kind {
-        return Err(merge_guard_error(EntityMergeGuard::EntityKind));
-    }
-    if !names_are_similar(&into.name, &from.name) {
-        return Err(merge_guard_error(EntityMergeGuard::NameSimilarity));
-    }
-    if projects_are_disjoint(into, from) {
-        return Err(merge_guard_error(EntityMergeGuard::ProjectCompatibility));
-    }
-    Ok(())
-}
-
-fn names_are_similar(left: &str, right: &str) -> bool {
-    let left = normalize_name(left);
-    let right = normalize_name(right);
-    if left.is_empty() || right.is_empty() {
-        return false;
-    }
-    if left == right {
-        return true;
-    }
-
-    let shorter_len = left.chars().count().min(right.chars().count());
-    if shorter_len >= 3 && (left.starts_with(&right) || right.starts_with(&left)) {
-        return true;
-    }
-
-    let left_trigrams = trigrams(&left);
-    let right_trigrams = trigrams(&right);
-    if left_trigrams.is_empty() || right_trigrams.is_empty() {
-        return false;
-    }
-    let overlap = left_trigrams.intersection(&right_trigrams).count();
-    overlap.saturating_mul(4) >= left_trigrams.len().saturating_add(right_trigrams.len())
-}
-
-fn normalize_name(name: &str) -> String {
-    let mut normalized = String::with_capacity(name.len());
-    let mut pending_space = false;
-    for ch in name.chars().flat_map(char::to_lowercase) {
-        if ch.is_whitespace() {
-            pending_space = !normalized.is_empty();
-        } else {
-            if pending_space {
-                normalized.push(' ');
-                pending_space = false;
-            }
-            normalized.push(ch);
-        }
-    }
-    normalized
-}
-
-fn trigrams(value: &str) -> HashSet<[char; 3]> {
-    let chars: Vec<char> = value.chars().collect();
-    chars
-        .windows(3)
-        .map(|window| [window[0], window[1], window[2]])
-        .collect()
-}
-
-fn projects_are_disjoint(into: &Entity, from: &Entity) -> bool {
-    let Some(into_projects) = into
-        .properties
-        .as_ref()
-        .and_then(|properties| properties.get("projects"))
-        .and_then(Value::as_array)
-    else {
-        return false;
-    };
-    let Some(from_projects) = from
-        .properties
-        .as_ref()
-        .and_then(|properties| properties.get("projects"))
-        .and_then(Value::as_array)
-    else {
-        return false;
-    };
-    if into_projects.is_empty() || from_projects.is_empty() {
-        return false;
-    }
-
-    // Project arrays are caller-controlled: index the smaller side to bound
-    // memory, scan each side once, and stop at the first match.
-    let (indexed, candidates) = if into_projects.len() <= from_projects.len() {
-        (into_projects, from_projects)
-    } else {
-        (from_projects, into_projects)
-    };
-    let mut indexed_strings = HashSet::new();
-    let mut indexed_values = HashSet::new();
-    for value in indexed {
-        if let Some(value) = value.as_str() {
-            indexed_strings.insert(normalize_project_string(value));
-        } else {
-            indexed_values.insert(value.clone());
-        }
-    }
-    !candidates.iter().any(|candidate| {
-        if let Some(candidate) = candidate.as_str() {
-            indexed_strings.contains(&normalize_project_string(candidate))
-        } else {
-            indexed_values.contains(candidate)
-        }
-    })
-}
-
-fn normalize_project_string(value: &str) -> String {
-    value.trim().to_ascii_lowercase()
-}
 
 impl KgPack {
     pub(crate) async fn handle_merge(
@@ -185,7 +42,8 @@ impl KgPack {
                 let into_entity = self.runtime.get_entity(token, into_id).await?;
                 let from_entity = self.runtime.get_entity(token, from_id).await?;
                 if !force {
-                    validate_entity_merge_floor(&into_entity, &from_entity)?;
+                    validate_entity_merge_floor(&into_entity, &from_entity)
+                        .map_err(entity_merge_guard_error)?;
                 }
                 self.runtime
                     .merge_entity_with_reason_and_force(

--- a/crates/khive-pack-kg/src/handlers/merge.rs
+++ b/crates/khive-pack-kg/src/handlers/merge.rs
@@ -1,8 +1,12 @@
 //! `merge` verb handler.
 
+use std::collections::HashSet;
+
 use serde_json::Value;
 
 use khive_runtime::{NamespaceToken, RuntimeError, VerbRegistry};
+use khive_storage::Entity;
+use khive_types::{Details, KhiveError};
 
 use super::common::{
     deser, ensure_entity_kind, ensure_note_kind, immutable_event_error, parse_content_strategy,
@@ -10,6 +14,121 @@ use super::common::{
     MergeParams,
 };
 use crate::KgPack;
+
+#[derive(Clone, Copy)]
+enum EntityMergeGuard {
+    EntityKind,
+    NameSimilarity,
+    ProjectCompatibility,
+}
+
+impl EntityMergeGuard {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::EntityKind => "entity_kind",
+            Self::NameSimilarity => "name_similarity",
+            Self::ProjectCompatibility => "project_compatibility",
+        }
+    }
+}
+
+fn merge_guard_error(guard: EntityMergeGuard) -> RuntimeError {
+    RuntimeError::Khive(
+        KhiveError::conflict(format!(
+            "entity merge refused by {} guard; use force=true only when the caller accepts responsibility",
+            guard.as_str()
+        ))
+        .with_details(Details::new([
+            ("guard", guard.as_str()),
+            ("override", "force=true"),
+        ])),
+    )
+}
+
+fn validate_entity_merge_floor(into: &Entity, from: &Entity) -> Result<(), RuntimeError> {
+    if into.kind != from.kind {
+        return Err(merge_guard_error(EntityMergeGuard::EntityKind));
+    }
+    if !names_are_similar(&into.name, &from.name) {
+        return Err(merge_guard_error(EntityMergeGuard::NameSimilarity));
+    }
+    if projects_are_disjoint(into, from) {
+        return Err(merge_guard_error(EntityMergeGuard::ProjectCompatibility));
+    }
+    Ok(())
+}
+
+fn names_are_similar(left: &str, right: &str) -> bool {
+    let left = normalize_name(left);
+    let right = normalize_name(right);
+    if left.is_empty() || right.is_empty() {
+        return false;
+    }
+    if left == right {
+        return true;
+    }
+
+    let shorter_len = left.chars().count().min(right.chars().count());
+    if shorter_len >= 3 && (left.starts_with(&right) || right.starts_with(&left)) {
+        return true;
+    }
+
+    let left_trigrams = trigrams(&left);
+    let right_trigrams = trigrams(&right);
+    if left_trigrams.is_empty() || right_trigrams.is_empty() {
+        return false;
+    }
+    let overlap = left_trigrams.intersection(&right_trigrams).count();
+    overlap.saturating_mul(4) >= left_trigrams.len().saturating_add(right_trigrams.len())
+}
+
+fn normalize_name(name: &str) -> String {
+    name.chars()
+        .flat_map(char::to_lowercase)
+        .filter(|ch| ch.is_alphanumeric())
+        .collect()
+}
+
+fn trigrams(value: &str) -> HashSet<[char; 3]> {
+    let chars: Vec<char> = value.chars().collect();
+    chars
+        .windows(3)
+        .map(|window| [window[0], window[1], window[2]])
+        .collect()
+}
+
+fn projects_are_disjoint(into: &Entity, from: &Entity) -> bool {
+    let Some(into_projects) = into
+        .properties
+        .as_ref()
+        .and_then(|properties| properties.get("projects"))
+        .and_then(Value::as_array)
+    else {
+        return false;
+    };
+    let Some(from_projects) = from
+        .properties
+        .as_ref()
+        .and_then(|properties| properties.get("projects"))
+        .and_then(Value::as_array)
+    else {
+        return false;
+    };
+    !into_projects.is_empty()
+        && !from_projects.is_empty()
+        && !into_projects.iter().any(|left| {
+            from_projects
+                .iter()
+                .any(|right| project_values_match(left, right))
+        })
+}
+
+fn project_values_match(left: &Value, right: &Value) -> bool {
+    match (left.as_str(), right.as_str()) {
+        (Some(left), Some(right)) => left.trim().eq_ignore_ascii_case(right.trim()),
+        _ => left == right,
+    }
+}
 
 impl KgPack {
     pub(crate) async fn handle_merge(
@@ -29,6 +148,7 @@ impl KgPack {
         let content_strategy =
             parse_content_strategy(p.content_strategy.as_deref().unwrap_or("append"))?;
         let dry_run = p.dry_run.unwrap_or(false);
+        let force = p.force.unwrap_or(false);
         let reason = p.reason.clone();
 
         let summary = match spec {
@@ -37,14 +157,11 @@ impl KgPack {
                 ensure_entity_kind(&self.runtime, token, from_id, specific.as_deref()).await?;
                 let into_entity = self.runtime.get_entity(token, into_id).await?;
                 let from_entity = self.runtime.get_entity(token, from_id).await?;
-                if into_entity.kind != from_entity.kind {
-                    return Err(RuntimeError::InvalidInput(format!(
-                        "cannot merge entities of different kinds: into={} ({}), from={} ({})",
-                        into_id, into_entity.kind, from_id, from_entity.kind
-                    )));
+                if !force {
+                    validate_entity_merge_floor(&into_entity, &from_entity)?;
                 }
                 self.runtime
-                    .merge_entity_with_reason(
+                    .merge_entity_with_reason_and_force(
                         token,
                         into_id,
                         from_id,
@@ -52,6 +169,7 @@ impl KgPack {
                         content_strategy,
                         dry_run,
                         reason,
+                        force,
                     )
                     .await?
             }

--- a/crates/khive-pack-kg/src/handlers/params.rs
+++ b/crates/khive-pack-kg/src/handlers/params.rs
@@ -142,6 +142,7 @@ pub(crate) struct MergeParams {
     pub(crate) strategy: Option<String>,
     pub(crate) content_strategy: Option<String>,
     pub(crate) dry_run: Option<bool>,
+    pub(crate) force: Option<bool>,
     #[allow(dead_code)]
     pub(crate) verbose: Option<bool>,
     pub(crate) reason: Option<String>,

--- a/crates/khive-pack-kg/src/handlers/tests.rs
+++ b/crates/khive-pack-kg/src/handlers/tests.rs
@@ -1468,6 +1468,7 @@ async fn merge_entity_reason_forwarded_through_registry_dispatch() {
                 "into_id": into.id.to_string(),
                 "from_id": from.id.to_string(),
                 "reason": "duplicate via dispatch",
+                "force": true,
             }),
         )
         .await
@@ -1595,6 +1596,7 @@ async fn get_dispatch_after_merge_discloses_kept_id() {
                 "kind": "entity",
                 "into_id": into.id.to_string(),
                 "from_id": from.id.to_string(),
+                "force": true,
             }),
         )
         .await
@@ -1728,6 +1730,7 @@ async fn resolve_dispatch_on_merged_uuid_stays_bare_not_found() {
                 "kind": "entity",
                 "into_id": into.id.to_string(),
                 "from_id": from.id.to_string(),
+                "force": true,
             }),
         )
         .await

--- a/crates/khive-pack-kg/src/handlers/tests.rs
+++ b/crates/khive-pack-kg/src/handlers/tests.rs
@@ -1500,6 +1500,15 @@ async fn merge_entity_reason_forwarded_through_registry_dispatch() {
         "reason supplied through the registry dispatch route must land in the EntityMerged payload; got: {:?}",
         events.items[0].payload
     );
+    assert_eq!(
+        events.items[0]
+            .payload
+            .get("force")
+            .and_then(|v| v.as_bool()),
+        Some(true),
+        "force=true must be durable in the EntityMerged payload; got: {:?}",
+        events.items[0].payload
+    );
 }
 
 #[tokio::test]

--- a/crates/khive-pack-kg/tests/integration.rs
+++ b/crates/khive-pack-kg/tests/integration.rs
@@ -3348,7 +3348,12 @@ async fn merge_handler_wires_explicit_prefer_from_content_strategy() {
     // onto the entity policy, the into-description ("desc A") survives instead.
     p.dispatch(
         "merge",
-        json!({"into_id": &into_id, "from_id": &from_id, "content_strategy": "prefer_from"}),
+        json!({
+            "into_id": &into_id,
+            "from_id": &from_id,
+            "content_strategy": "prefer_from",
+            "force": true,
+        }),
     )
     .await
     .expect("merge must succeed");
@@ -5232,6 +5237,199 @@ async fn singleton_link_updates_weight_and_metadata_on_existing_triple() {
 }
 
 // ---- Merge symmetric-relation canonicalization regression (ADR-002 §134) ----
+
+#[tokio::test]
+async fn merge_dissimilar_cross_kind_is_refused_by_entity_kind_guard() {
+    let pack = pack();
+    let into_id = pack
+        .dispatch(
+            "create",
+            json!({"kind": "concept", "name": "Quantum Annealing"}),
+        )
+        .await
+        .expect("create into entity")["id"]
+        .as_str()
+        .unwrap()
+        .to_string();
+    let from_id = pack
+        .dispatch(
+            "create",
+            json!({"kind": "project", "name": "Renaissance Painting"}),
+        )
+        .await
+        .expect("create from entity")["id"]
+        .as_str()
+        .unwrap()
+        .to_string();
+
+    let err = pack
+        .dispatch("merge", json!({"into_id": into_id, "from_id": from_id}))
+        .await
+        .expect_err("cross-kind merge must be refused");
+    let RuntimeError::Khive(err) = err else {
+        panic!("expected structured merge-guard error, got {err:?}");
+    };
+    assert_eq!(err.kind(), khive_types::ErrorKind::Conflict);
+    assert_eq!(
+        err.details().and_then(|details| details.get("guard")),
+        Some("entity_kind")
+    );
+}
+
+#[tokio::test]
+async fn merge_dissimilar_cross_kind_force_overrides_guards() {
+    let pack = pack();
+    let into_id = pack
+        .dispatch(
+            "create",
+            json!({"kind": "concept", "name": "Quantum Annealing"}),
+        )
+        .await
+        .expect("create into entity")["id"]
+        .as_str()
+        .unwrap()
+        .to_string();
+    let from_id = pack
+        .dispatch(
+            "create",
+            json!({"kind": "project", "name": "Renaissance Painting"}),
+        )
+        .await
+        .expect("create from entity")["id"]
+        .as_str()
+        .unwrap()
+        .to_string();
+
+    let result = pack
+        .dispatch(
+            "merge",
+            json!({"into_id": into_id, "from_id": from_id, "force": true}),
+        )
+        .await
+        .expect("force=true must override all entity merge guards");
+    assert_eq!(result["removed_id"], from_id);
+}
+
+#[tokio::test]
+async fn merge_legitimate_near_duplicate_passes_safety_floor() {
+    let pack = pack();
+    let into_id = pack
+        .dispatch(
+            "create",
+            json!({
+                "kind": "concept",
+                "name": "Attention Flash",
+                "properties": {"projects": ["transformers", "inference"]},
+            }),
+        )
+        .await
+        .expect("create into entity")["id"]
+        .as_str()
+        .unwrap()
+        .to_string();
+    let from_id = pack
+        .dispatch(
+            "create",
+            json!({
+                "kind": "concept",
+                "name": "Flash Attention",
+                "properties": {"projects": ["inference", "kernels"]},
+            }),
+        )
+        .await
+        .expect("create from entity")["id"]
+        .as_str()
+        .unwrap()
+        .to_string();
+
+    let result = pack
+        .dispatch("merge", json!({"into_id": into_id, "from_id": from_id}))
+        .await
+        .expect("near-duplicate names with compatible projects must merge");
+    assert_eq!(result["removed_id"], from_id);
+}
+
+#[tokio::test]
+async fn merge_same_kind_dissimilar_names_is_refused_by_name_guard() {
+    let pack = pack();
+    let into_id = pack
+        .dispatch(
+            "create",
+            json!({"kind": "concept", "name": "Quantum Annealing"}),
+        )
+        .await
+        .expect("create into entity")["id"]
+        .as_str()
+        .unwrap()
+        .to_string();
+    let from_id = pack
+        .dispatch(
+            "create",
+            json!({"kind": "concept", "name": "Renaissance Painting"}),
+        )
+        .await
+        .expect("create from entity")["id"]
+        .as_str()
+        .unwrap()
+        .to_string();
+
+    let err = pack
+        .dispatch("merge", json!({"into_id": into_id, "from_id": from_id}))
+        .await
+        .expect_err("dissimilar entity names must be refused");
+    let RuntimeError::Khive(err) = err else {
+        panic!("expected structured merge-guard error, got {err:?}");
+    };
+    assert_eq!(
+        err.details().and_then(|details| details.get("guard")),
+        Some("name_similarity")
+    );
+}
+
+#[tokio::test]
+async fn merge_disjoint_projects_is_refused_by_properties_guard() {
+    let pack = pack();
+    let into_id = pack
+        .dispatch(
+            "create",
+            json!({
+                "kind": "concept",
+                "name": "Vector Search",
+                "properties": {"projects": ["search-service"]},
+            }),
+        )
+        .await
+        .expect("create into entity")["id"]
+        .as_str()
+        .unwrap()
+        .to_string();
+    let from_id = pack
+        .dispatch(
+            "create",
+            json!({
+                "kind": "concept",
+                "name": "vector-search",
+                "properties": {"projects": ["recommendation-service"]},
+            }),
+        )
+        .await
+        .expect("create from entity")["id"]
+        .as_str()
+        .unwrap()
+        .to_string();
+
+    let err = pack
+        .dispatch("merge", json!({"into_id": into_id, "from_id": from_id}))
+        .await
+        .expect_err("disjoint project ownership must be refused");
+    let RuntimeError::Khive(err) = err else {
+        panic!("expected structured merge-guard error, got {err:?}");
+    };
+    assert_eq!(
+        err.details().and_then(|details| details.get("guard")),
+        Some("project_compatibility")
+    );
+}
 
 /// After merging B into A, B's `competes_with` edge to C is rewired to A→C.
 /// If A already has a `competes_with` edge to C, the rewire is a conflict:

--- a/crates/khive-pack-kg/tests/integration.rs
+++ b/crates/khive-pack-kg/tests/integration.rs
@@ -3307,6 +3307,10 @@ async fn curation_merge_entity_event_payload_has_adr014_fields() {
         payload.get("content_strategy").is_some(),
         "entity_merged payload must contain 'content_strategy' (PR #814); got {payload}"
     );
+    assert!(
+        payload.get("force").is_none(),
+        "ordinary entity merges must not carry a force marker; got {payload}"
+    );
 }
 
 /// Handler-wiring test for PR #814: `content_strategy`
@@ -5384,6 +5388,77 @@ async fn merge_same_kind_dissimilar_names_is_refused_by_name_guard() {
         err.details().and_then(|details| details.get("guard")),
         Some("name_similarity")
     );
+}
+
+#[tokio::test]
+async fn merge_punctuation_collision_is_refused_unless_forced() {
+    let pack = pack();
+    let into_id = pack
+        .dispatch("create", json!({"kind": "concept", "name": "C++"}))
+        .await
+        .expect("create C++ entity")["id"]
+        .as_str()
+        .unwrap()
+        .to_string();
+    let from_id = pack
+        .dispatch("create", json!({"kind": "concept", "name": "C#"}))
+        .await
+        .expect("create C# entity")["id"]
+        .as_str()
+        .unwrap()
+        .to_string();
+
+    let err = pack
+        .dispatch("merge", json!({"into_id": &into_id, "from_id": &from_id}))
+        .await
+        .expect_err("punctuation-distinct entity names must be refused");
+    let RuntimeError::Khive(err) = err else {
+        panic!("expected structured merge-guard error, got {err:?}");
+    };
+    assert_eq!(err.kind(), khive_types::ErrorKind::Conflict);
+    assert_eq!(
+        err.details().and_then(|details| details.get("guard")),
+        Some("name_similarity")
+    );
+
+    let result = pack
+        .dispatch(
+            "merge",
+            json!({"into_id": &into_id, "from_id": &from_id, "force": true}),
+        )
+        .await
+        .expect("force=true must override the name-similarity guard");
+    assert_eq!(result["removed_id"], from_id);
+}
+
+#[tokio::test]
+async fn merge_name_equality_ignores_case_and_collapsed_whitespace() {
+    for (into_name, from_name) in [
+        ("Case Fold", "cASE fOLD"),
+        ("Graph Neural Network", "  graph  neural\t network  "),
+    ] {
+        let pack = pack();
+        let into_id = pack
+            .dispatch("create", json!({"kind": "concept", "name": into_name}))
+            .await
+            .expect("create into entity")["id"]
+            .as_str()
+            .unwrap()
+            .to_string();
+        let from_id = pack
+            .dispatch("create", json!({"kind": "concept", "name": from_name}))
+            .await
+            .expect("create from entity")["id"]
+            .as_str()
+            .unwrap()
+            .to_string();
+
+        let result = pack
+            .dispatch("merge", json!({"into_id": into_id, "from_id": from_id}))
+            .await
+            .expect("case and whitespace differences must remain merge-compatible");
+        assert_eq!(result["removed_id"], from_id);
+    }
 }
 
 #[tokio::test]

--- a/crates/khive-runtime/src/curation.rs
+++ b/crates/khive-runtime/src/curation.rs
@@ -437,6 +437,34 @@ impl KhiveRuntime {
         dry_run: bool,
         reason: Option<String>,
     ) -> RuntimeResult<MergeSummary> {
+        self.merge_entity_with_reason_and_force(
+            token,
+            into_id,
+            from_id,
+            strategy,
+            content_strategy,
+            dry_run,
+            reason,
+            false,
+        )
+        .await
+    }
+
+    /// Merge two entities with an explicit override for the entity-kind guard.
+    // REASON: these arguments mirror the merge verb's policy, content strategy,
+    // dry-run, audit-reason, and force fields; a builder would only move that surface.
+    #[allow(clippy::too_many_arguments)]
+    pub async fn merge_entity_with_reason_and_force(
+        &self,
+        token: &NamespaceToken,
+        into_id: Uuid,
+        from_id: Uuid,
+        strategy: EntityDedupMergePolicy,
+        content_strategy: ContentMergeStrategy,
+        dry_run: bool,
+        reason: Option<String>,
+        force: bool,
+    ) -> RuntimeResult<MergeSummary> {
         if let Some(reason) = reason.as_deref() {
             crate::secret_gate::check(reason)?;
         }
@@ -447,7 +475,7 @@ impl KhiveRuntime {
         }
         // Enforce the same-kind constraint here too: any direct runtime caller
         // (CLI, tests, future SDK) would bypass the handler-level guard otherwise.
-        {
+        if !force {
             let into_entity = self.get_entity(token, into_id).await?;
             let from_entity = self.get_entity(token, from_id).await?;
             if into_entity.kind != from_entity.kind {

--- a/crates/khive-runtime/src/curation.rs
+++ b/crates/khive-runtime/src/curation.rs
@@ -451,6 +451,7 @@ impl KhiveRuntime {
     }
 
     /// Merge two entities with an explicit override for the entity-kind guard.
+    /// A non-dry-run override is recorded as `force: true` in the merge event.
     // REASON: these arguments mirror the merge verb's policy, content strategy,
     // dry-run, audit-reason, and force fields; a builder would only move that surface.
     #[allow(clippy::too_many_arguments)]
@@ -586,6 +587,9 @@ impl KhiveRuntime {
             });
             if let Some(reason) = reason {
                 payload["reason"] = serde_json::Value::String(reason);
+            }
+            if force {
+                payload["force"] = serde_json::Value::Bool(true);
             }
             let event = khive_storage::event::Event::new(
                 updated_entity.namespace.clone(),

--- a/crates/khive-runtime/src/curation.rs
+++ b/crates/khive-runtime/src/curation.rs
@@ -16,7 +16,7 @@ use khive_db::SqliteError;
 use khive_storage::note::Note;
 use khive_storage::types::{EdgeFilter, TextDocument};
 use khive_storage::{EdgeRelation, Entity, SubstrateKind};
-use khive_types::{EdgeEndpointRule, EventKind};
+use khive_types::{Details, EdgeEndpointRule, EventKind, KhiveError};
 use rusqlite::OptionalExtension;
 
 use crate::error::{RuntimeError, RuntimeResult};
@@ -64,6 +64,149 @@ pub enum EntityDedupMergePolicy {
     PreferFrom,
     /// Deep-merge: object properties merge recursively. Scalar conflicts go to `into`.
     Union,
+}
+
+/// Safety-floor guard that refused an explicit entity merge.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum EntityMergeGuard {
+    EntityKind,
+    NameSimilarity,
+    ProjectCompatibility,
+}
+
+impl EntityMergeGuard {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::EntityKind => "entity_kind",
+            Self::NameSimilarity => "name_similarity",
+            Self::ProjectCompatibility => "project_compatibility",
+        }
+    }
+}
+
+/// Validate the non-forced entity-merge safety floor.
+pub fn validate_entity_merge_floor(into: &Entity, from: &Entity) -> Result<(), EntityMergeGuard> {
+    if into.kind != from.kind {
+        return Err(EntityMergeGuard::EntityKind);
+    }
+    if !names_are_similar(&into.name, &from.name) {
+        return Err(EntityMergeGuard::NameSimilarity);
+    }
+    if projects_are_disjoint(into, from) {
+        return Err(EntityMergeGuard::ProjectCompatibility);
+    }
+    Ok(())
+}
+
+/// Convert a safety-floor refusal into the merge verb's structured conflict contract.
+pub fn entity_merge_guard_error(guard: EntityMergeGuard) -> RuntimeError {
+    RuntimeError::Khive(
+        KhiveError::conflict(format!(
+            "entity merge refused by {} guard; use force=true only when the caller accepts responsibility",
+            guard.as_str()
+        ))
+        .with_details(Details::new([
+            ("guard", guard.as_str()),
+            ("override", "force=true"),
+        ])),
+    )
+}
+
+fn names_are_similar(left: &str, right: &str) -> bool {
+    let left = normalize_name(left);
+    let right = normalize_name(right);
+    if left.is_empty() || right.is_empty() {
+        return false;
+    }
+    if left == right {
+        return true;
+    }
+
+    let shorter_len = left.chars().count().min(right.chars().count());
+    if shorter_len >= 3 && (left.starts_with(&right) || right.starts_with(&left)) {
+        return true;
+    }
+
+    let left_trigrams = trigrams(&left);
+    let right_trigrams = trigrams(&right);
+    if left_trigrams.is_empty() || right_trigrams.is_empty() {
+        return false;
+    }
+    let overlap = left_trigrams.intersection(&right_trigrams).count();
+    overlap.saturating_mul(4) >= left_trigrams.len().saturating_add(right_trigrams.len())
+}
+
+fn normalize_name(name: &str) -> String {
+    let mut normalized = String::with_capacity(name.len());
+    let mut pending_space = false;
+    for ch in name.chars().flat_map(char::to_lowercase) {
+        if ch.is_whitespace() {
+            pending_space = !normalized.is_empty();
+        } else {
+            if pending_space {
+                normalized.push(' ');
+                pending_space = false;
+            }
+            normalized.push(ch);
+        }
+    }
+    normalized
+}
+
+fn trigrams(value: &str) -> HashSet<[char; 3]> {
+    let chars: Vec<char> = value.chars().collect();
+    chars
+        .windows(3)
+        .map(|window| [window[0], window[1], window[2]])
+        .collect()
+}
+
+fn projects_are_disjoint(into: &Entity, from: &Entity) -> bool {
+    let Some(into_projects) = into
+        .properties
+        .as_ref()
+        .and_then(|properties| properties.get("projects"))
+        .and_then(Value::as_array)
+    else {
+        return false;
+    };
+    let Some(from_projects) = from
+        .properties
+        .as_ref()
+        .and_then(|properties| properties.get("projects"))
+        .and_then(Value::as_array)
+    else {
+        return false;
+    };
+    if into_projects.is_empty() || from_projects.is_empty() {
+        return false;
+    }
+
+    let (indexed, candidates) = if into_projects.len() <= from_projects.len() {
+        (into_projects, from_projects)
+    } else {
+        (from_projects, into_projects)
+    };
+    let mut indexed_strings = HashSet::new();
+    let mut indexed_values = HashSet::new();
+    for value in indexed {
+        if let Some(value) = value.as_str() {
+            indexed_strings.insert(normalize_project_string(value));
+        } else {
+            indexed_values.insert(value.clone());
+        }
+    }
+    !candidates.iter().any(|candidate| {
+        if let Some(candidate) = candidate.as_str() {
+            indexed_strings.contains(&normalize_project_string(candidate))
+        } else {
+            indexed_values.contains(candidate)
+        }
+    })
+}
+
+fn normalize_project_string(value: &str) -> String {
+    value.trim().to_ascii_lowercase()
 }
 
 /// Strategy for merging note content when two notes are combined.
@@ -170,6 +313,91 @@ impl From<EdgeListFilter> for EdgeFilter {
 // ---------------------------------------------------------------------------
 // Private types
 // ---------------------------------------------------------------------------
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum EntityMergeValidation {
+    LegacyKind,
+    SafetyFloor,
+    Forced,
+}
+
+#[derive(Debug)]
+enum EntityMergeRefusal {
+    LegacyKind {
+        into_id: Uuid,
+        into_kind: String,
+        from_id: Uuid,
+        from_kind: String,
+    },
+    SafetyFloor(EntityMergeGuard),
+}
+
+impl EntityMergeRefusal {
+    fn into_runtime_error(self) -> RuntimeError {
+        match self {
+            Self::LegacyKind {
+                into_id,
+                into_kind,
+                from_id,
+                from_kind,
+            } => RuntimeError::InvalidInput(format!(
+                "cannot merge entities of different kinds: into={into_id} ({into_kind}), \
+                 from={from_id} ({from_kind}); merge requires both entities to share the same kind"
+            )),
+            Self::SafetyFloor(guard) => entity_merge_guard_error(guard),
+        }
+    }
+}
+
+#[derive(Debug)]
+enum MergeEntitySqlError {
+    Sqlite(SqliteError),
+    Refusal(EntityMergeRefusal),
+}
+
+impl std::fmt::Display for MergeEntitySqlError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Sqlite(error) => std::fmt::Display::fmt(error, f),
+            Self::Refusal(_) => f.write_str("entity merge refused by transactional policy"),
+        }
+    }
+}
+
+impl std::error::Error for MergeEntitySqlError {}
+
+impl From<SqliteError> for MergeEntitySqlError {
+    fn from(error: SqliteError) -> Self {
+        Self::Sqlite(error)
+    }
+}
+
+impl From<rusqlite::Error> for MergeEntitySqlError {
+    fn from(error: rusqlite::Error) -> Self {
+        Self::Sqlite(SqliteError::Rusqlite(error))
+    }
+}
+
+fn map_merge_entity_storage_error(error: khive_storage::StorageError) -> RuntimeError {
+    match error {
+        khive_storage::StorageError::Driver {
+            capability,
+            operation,
+            source,
+        } => match source.downcast::<MergeEntitySqlError>() {
+            Ok(error) => match *error {
+                MergeEntitySqlError::Sqlite(error) => RuntimeError::Sqlite(error),
+                MergeEntitySqlError::Refusal(error) => error.into_runtime_error(),
+            },
+            Err(source) => RuntimeError::Storage(khive_storage::StorageError::Driver {
+                capability,
+                operation,
+                source,
+            }),
+        },
+        error => RuntimeError::Storage(error),
+    }
+}
 
 // REASON: EdgeRow fields are populated via rusqlite row mapping. The struct is fully
 // constructed even when not all fields are read back after construction. The complete
@@ -437,7 +665,7 @@ impl KhiveRuntime {
         dry_run: bool,
         reason: Option<String>,
     ) -> RuntimeResult<MergeSummary> {
-        self.merge_entity_with_reason_and_force(
+        self.merge_entity_with_validation(
             token,
             into_id,
             from_id,
@@ -445,12 +673,16 @@ impl KhiveRuntime {
             content_strategy,
             dry_run,
             reason,
-            false,
+            EntityMergeValidation::LegacyKind,
         )
         .await
     }
 
-    /// Merge two entities with an explicit override for the entity-kind guard.
+    /// Merge two entities with an explicit override for the entity safety floor.
+    ///
+    /// Non-forced calls enforce entity kind, name similarity, and project compatibility
+    /// against the rows reread inside the merge transaction. Legacy merge methods retain
+    /// their historical same-kind-only policy.
     /// A non-dry-run override is recorded as `force: true` in the merge event.
     // REASON: these arguments mirror the merge verb's policy, content strategy,
     // dry-run, audit-reason, and force fields; a builder would only move that surface.
@@ -466,6 +698,36 @@ impl KhiveRuntime {
         reason: Option<String>,
         force: bool,
     ) -> RuntimeResult<MergeSummary> {
+        let validation = if force {
+            EntityMergeValidation::Forced
+        } else {
+            EntityMergeValidation::SafetyFloor
+        };
+        self.merge_entity_with_validation(
+            token,
+            into_id,
+            from_id,
+            strategy,
+            content_strategy,
+            dry_run,
+            reason,
+            validation,
+        )
+        .await
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    async fn merge_entity_with_validation(
+        &self,
+        token: &NamespaceToken,
+        into_id: Uuid,
+        from_id: Uuid,
+        strategy: EntityDedupMergePolicy,
+        content_strategy: ContentMergeStrategy,
+        dry_run: bool,
+        reason: Option<String>,
+        validation: EntityMergeValidation,
+    ) -> RuntimeResult<MergeSummary> {
         if let Some(reason) = reason.as_deref() {
             crate::secret_gate::check(reason)?;
         }
@@ -473,19 +735,6 @@ impl KhiveRuntime {
             return Err(RuntimeError::InvalidInput(
                 "cannot merge an entity into itself".into(),
             ));
-        }
-        // Enforce the same-kind constraint here too: any direct runtime caller
-        // (CLI, tests, future SDK) would bypass the handler-level guard otherwise.
-        if !force {
-            let into_entity = self.get_entity(token, into_id).await?;
-            let from_entity = self.get_entity(token, from_id).await?;
-            if into_entity.kind != from_entity.kind {
-                return Err(RuntimeError::InvalidInput(format!(
-                    "cannot merge entities of different kinds: into={} ({}), from={} ({}); \
-                     merge requires both entities to share the same kind",
-                    into_id, into_entity.kind, from_id, from_entity.kind
-                )));
-            }
         }
         let ns = token.namespace().as_str().to_owned();
         let fts_table = "fts_entities".to_string();
@@ -528,6 +777,7 @@ impl KhiveRuntime {
                         content_strategy,
                         dry_run,
                         pack_rules,
+                        validation,
                     )
                     .map_err(|e| {
                         khive_storage::StorageError::driver(
@@ -538,11 +788,12 @@ impl KhiveRuntime {
                     })
                 })
                 .await
-                .map_err(RuntimeError::Storage)?
+                .map_err(map_merge_entity_storage_error)?
         } else {
             tokio::task::spawn_blocking(move || {
                 let guard = pool.writer()?;
-                guard.transaction(|conn| {
+                let mut refusal = None;
+                let result = guard.transaction(|conn| {
                     merge_entity_sql(
                         conn,
                         ns,
@@ -554,8 +805,22 @@ impl KhiveRuntime {
                         content_strategy,
                         dry_run,
                         pack_rules,
+                        validation,
                     )
-                })
+                    .map_err(|error| match error {
+                        MergeEntitySqlError::Sqlite(error) => error,
+                        MergeEntitySqlError::Refusal(error) => {
+                            refusal = Some(error);
+                            SqliteError::InvalidData(
+                                "entity merge refused by transactional policy".to_string(),
+                            )
+                        }
+                    })
+                });
+                match refusal {
+                    Some(error) => Err(error.into_runtime_error()),
+                    None => result.map_err(RuntimeError::from),
+                }
             })
             .await
             .map_err(|e| RuntimeError::Internal(e.to_string()))??
@@ -588,7 +853,7 @@ impl KhiveRuntime {
             if let Some(reason) = reason {
                 payload["reason"] = serde_json::Value::String(reason);
             }
-            if force {
+            if validation == EntityMergeValidation::Forced {
                 payload["force"] = serde_json::Value::Bool(true);
             }
             let event = khive_storage::event::Event::new(
@@ -1228,9 +1493,29 @@ fn merge_entity_sql(
     content_strategy: ContentMergeStrategy,
     dry_run: bool,
     pack_rules: Vec<EdgeEndpointRule>,
-) -> Result<(MergeSummary, Entity), SqliteError> {
+    validation: EntityMergeValidation,
+) -> Result<(MergeSummary, Entity), MergeEntitySqlError> {
     let into_entity = read_merge_entity(conn, into_id, &namespace)?;
     let from_entity = read_merge_entity(conn, from_id, &namespace)?;
+
+    match validation {
+        EntityMergeValidation::LegacyKind if into_entity.kind != from_entity.kind => {
+            return Err(MergeEntitySqlError::Refusal(
+                EntityMergeRefusal::LegacyKind {
+                    into_id,
+                    into_kind: into_entity.kind,
+                    from_id,
+                    from_kind: from_entity.kind,
+                },
+            ));
+        }
+        EntityMergeValidation::SafetyFloor => {
+            validate_entity_merge_floor(&into_entity, &from_entity).map_err(|guard| {
+                MergeEntitySqlError::Refusal(EntityMergeRefusal::SafetyFloor(guard))
+            })?;
+        }
+        EntityMergeValidation::LegacyKind | EntityMergeValidation::Forced => {}
+    }
 
     // --- Collect edges incident to from_id ---
     let parse_id =
@@ -5003,6 +5288,81 @@ mod tests {
 
         let c2_after = rt.entities(&tok).unwrap().get_entity(c2.id).await.unwrap();
         assert!(c2_after.is_none(), "from_entity must be tombstoned");
+    }
+
+    #[tokio::test]
+    async fn merge_entity_explicit_policy_rereads_names_before_commit() {
+        let rt = rt();
+        let tok = NamespaceToken::local();
+
+        let into = rt
+            .create_entity(
+                &tok,
+                "concept",
+                None,
+                "Transactional Guard",
+                None,
+                None,
+                vec![],
+            )
+            .await
+            .unwrap();
+        let from = rt
+            .create_entity(
+                &tok,
+                "concept",
+                None,
+                "Transactional Guard",
+                None,
+                None,
+                vec![],
+            )
+            .await
+            .unwrap();
+
+        validate_entity_merge_floor(&into, &from)
+            .expect("the handler's fast-path validation would initially pass");
+        let renamed_into = rt
+            .update_entity(
+                &tok,
+                into.id,
+                EntityPatch {
+                    name: Some("Unrelated Renamed Target".to_string()),
+                    ..Default::default()
+                },
+            )
+            .await
+            .unwrap();
+        let expected = validate_entity_merge_floor(&renamed_into, &from)
+            .expect_err("the renamed transactional state must violate the name guard");
+        let RuntimeError::Khive(expected) = entity_merge_guard_error(expected) else {
+            unreachable!("merge guard errors are structured Khive errors")
+        };
+
+        let err = rt
+            .merge_entity_with_reason_and_force(
+                &tok,
+                into.id,
+                from.id,
+                EntityDedupMergePolicy::PreferInto,
+                ContentMergeStrategy::Append,
+                false,
+                None,
+                false,
+            )
+            .await
+            .expect_err("the explicit non-forced path must validate its transactional reread");
+        let RuntimeError::Khive(err) = err else {
+            panic!("expected a structured merge-guard conflict, got {err:?}");
+        };
+        assert_eq!(err.kind(), expected.kind());
+        assert_eq!(err.message(), expected.message());
+        assert_eq!(err.code(), expected.code());
+        assert_eq!(err.details(), expected.details());
+        assert!(
+            rt.get_entity(&tok, from.id).await.is_ok(),
+            "a refused merge must leave the source entity live"
+        );
     }
 
     // Cross-namespace merge_note must be denied on either ID.

--- a/crates/khive-runtime/src/lib.rs
+++ b/crates/khive-runtime/src/lib.rs
@@ -45,8 +45,9 @@ pub use atomic_runner::{
 pub use blob::resolve_blob_store;
 pub use cost_unit::{base_resource_payload, cost_unit_for_dispatch, resource_payload};
 pub use curation::{
-    entity_fts_document, note_fts_document, ContentMergeStrategy, EdgeListFilter, EdgePatch,
-    EntityDedupMergePolicy, EntityPatch, MergeSummary, NotePatch,
+    entity_fts_document, entity_merge_guard_error, note_fts_document, validate_entity_merge_floor,
+    ContentMergeStrategy, EdgeListFilter, EdgePatch, EntityDedupMergePolicy, EntityMergeGuard,
+    EntityPatch, MergeSummary, NotePatch,
 };
 #[cfg(unix)]
 pub use daemon::{acquire_recovery_lock, pid_path, run_daemon, socket_path, DaemonDispatch};


### PR DESCRIPTION
Closes #893.

Entity `merge` now evaluates three cheap local guards before curation:

- `entity_kind`: both entities must share a kind (previously the only check).
- `name_similarity`: names pass on normalized equality, a >=3-char normalized prefix relationship, or a character-trigram Dice coefficient >= 0.5.
- `project_compatibility`: when both entities carry non-empty `properties.projects` arrays, the arrays must intersect (string values compared trimmed, ASCII-case-insensitively).

A refusal is a structured conflict error naming the failed guard in `details.guard` with `details.override = "force=true"`. `force=true` bypasses the guards, documented as the caller accepting responsibility. No embedding or search call is added to the merge path.