### PR TITLE
fix(db): refuse home-directory stores under the test harness

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,7 +1,7 @@
 [env]
 # Cargo propagates this marker to unit tests, integration tests, and test-spawned
 # binaries. The store-open guard checks it at runtime in every build profile.
-# Deliberate `cargo run` sessions may set KHIVE_ALLOW_HOME_STORE to the exact
-# absolute database path being opened. Boolean or different-path values do not
-# bypass the guard.
+# There is no environment override: deliberate sessions against a real store
+# run the built binary directly (outside the Cargo environment), which never
+# receives this marker.
 KHIVE_TEST_HARNESS = { value = "1", force = true }

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,4 @@
+[env]
+# Cargo propagates this marker to unit tests, integration tests, and test-spawned
+# binaries. The store-open guard compiles it out of release builds.
+KHIVE_TEST_HARNESS = { value = "1", force = true }

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,4 +1,6 @@
 [env]
 # Cargo propagates this marker to unit tests, integration tests, and test-spawned
-# binaries. The store-open guard compiles it out of release builds.
+# binaries. The store-open guard checks it at runtime in every build profile.
+# Deliberate `cargo run` sessions may set KHIVE_ALLOW_HOME_STORE=1; automated
+# tests must never set that operator-only override.
 KHIVE_TEST_HARNESS = { value = "1", force = true }

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,6 +1,7 @@
 [env]
 # Cargo propagates this marker to unit tests, integration tests, and test-spawned
 # binaries. The store-open guard checks it at runtime in every build profile.
-# Deliberate `cargo run` sessions may set KHIVE_ALLOW_HOME_STORE=1; automated
-# tests must never set that operator-only override.
+# Deliberate `cargo run` sessions may set KHIVE_ALLOW_HOME_STORE to the exact
+# absolute database path being opened. Boolean or different-path values do not
+# bypass the guard.
 KHIVE_TEST_HARNESS = { value = "1", force = true }

--- a/crates/khive-db/src/pool.rs
+++ b/crates/khive-db/src/pool.rs
@@ -23,7 +23,6 @@ const DEFAULT_JOURNAL_SIZE_LIMIT_BYTES: i64 = 67_108_864; // 64 MiB
 const DEFAULT_WRITE_QUEUE_CAPACITY: usize = 256;
 
 const TEST_HARNESS_ENV: &str = "KHIVE_TEST_HARNESS";
-const ALLOW_HOME_STORE_ENV: &str = "KHIVE_ALLOW_HOME_STORE";
 
 /// Configuration for the connection pool.
 #[derive(Clone, Debug)]
@@ -129,9 +128,12 @@ impl Default for PoolConfig {
 /// the runtime `KHIVE_TEST_HARNESS=1` marker; production/installed binaries do
 /// not receive that workspace Cargo environment.
 ///
-/// `KHIVE_ALLOW_HOME_STORE=<absolute database path>` is an operator-only escape
-/// hatch for a deliberate in-repository `cargo run`. It bypasses the guard only
-/// when the canonicalized override identifies the configured database path.
+/// There is deliberately no environment override: any inheritable escape
+/// hatch set for one Cargo invocation leaks into the next `cargo test` in the
+/// same shell and re-opens the store the guard exists to protect. A deliberate
+/// session against the real store runs the built binary directly (for example
+/// `target/release/...` or an installed binary), which never receives the
+/// workspace Cargo environment and therefore never trips this guard.
 /// Existing path ancestors are canonicalized before comparison, resolving
 /// traversal, symlinks, and filesystem-provided case (including APFS case
 /// folding). Missing trailing components remain lexical because they have no
@@ -153,8 +155,8 @@ fn refuse_home_data_store_in_tests(config: &PoolConfig) -> Result<(), SqliteErro
     {
         return Err(SqliteError::InvalidData(format!(
             "test harness refused SQLite URI database path {}; use a filesystem path outside \
-             HOME/.khive (a deliberate operator override must name the exact absolute database \
-             path)",
+             HOME/.khive (deliberate sessions against a real store run the built binary \
+             directly, outside the Cargo test environment)",
             path.display()
         )));
     }
@@ -166,21 +168,10 @@ fn refuse_home_data_store_in_tests(config: &PoolConfig) -> Result<(), SqliteErro
     let canonical_home_data_dir =
         canonicalize_deepest_existing(&PathBuf::from(home).join(".khive"))?;
     if canonical_path.starts_with(&canonical_home_data_dir) {
-        let override_matches = std::env::var_os(ALLOW_HOME_STORE_ENV).is_some_and(|value| {
-            let override_path = PathBuf::from(value);
-            override_path.is_absolute()
-                && canonicalize_deepest_existing(&override_path)
-                    .is_ok_and(|canonical_override| canonical_override == canonical_path)
-        });
-        if override_matches {
-            return Ok(());
-        }
-
         return Err(SqliteError::InvalidData(format!(
             "test harness refused to open SQLite database under HOME/.khive: {} \
-             (set KHIVE_ALLOW_HOME_STORE to the exact absolute database path to allow this store: \
-             {})",
-            canonical_path.display(),
+             (deliberate sessions against a real store run the built binary directly, \
+             outside the Cargo test environment)",
             canonical_path.display()
         )));
     }

--- a/crates/khive-db/src/pool.rs
+++ b/crates/khive-db/src/pool.rs
@@ -129,8 +129,9 @@ impl Default for PoolConfig {
 /// the runtime `KHIVE_TEST_HARNESS=1` marker; production/installed binaries do
 /// not receive that workspace Cargo environment.
 ///
-/// `KHIVE_ALLOW_HOME_STORE=1` is an operator-only escape hatch for a deliberate
-/// in-repository `cargo run`. Automated tests must never set or inherit it.
+/// `KHIVE_ALLOW_HOME_STORE=<absolute database path>` is an operator-only escape
+/// hatch for a deliberate in-repository `cargo run`. It bypasses the guard only
+/// when the canonicalized override identifies the configured database path.
 /// Existing path ancestors are canonicalized before comparison, resolving
 /// traversal, symlinks, and filesystem-provided case (including APFS case
 /// folding). Missing trailing components remain lexical because they have no
@@ -138,9 +139,6 @@ impl Default for PoolConfig {
 /// to reproduce SQLite's URI normalization rules.
 fn refuse_home_data_store_in_tests(config: &PoolConfig) -> Result<(), SqliteError> {
     if std::env::var(TEST_HARNESS_ENV).as_deref() != Ok("1") {
-        return Ok(());
-    }
-    if std::env::var(ALLOW_HOME_STORE_ENV).as_deref() == Ok("1") {
         return Ok(());
     }
 
@@ -155,7 +153,8 @@ fn refuse_home_data_store_in_tests(config: &PoolConfig) -> Result<(), SqliteErro
     {
         return Err(SqliteError::InvalidData(format!(
             "test harness refused SQLite URI database path {}; use a filesystem path outside \
-             HOME/.khive (KHIVE_ALLOW_HOME_STORE=1 is for deliberate operator use only)",
+             HOME/.khive (a deliberate operator override must name the exact absolute database \
+             path)",
             path.display()
         )));
     }
@@ -167,9 +166,21 @@ fn refuse_home_data_store_in_tests(config: &PoolConfig) -> Result<(), SqliteErro
     let canonical_home_data_dir =
         canonicalize_deepest_existing(&PathBuf::from(home).join(".khive"))?;
     if canonical_path.starts_with(&canonical_home_data_dir) {
+        let override_matches = std::env::var_os(ALLOW_HOME_STORE_ENV).is_some_and(|value| {
+            let override_path = PathBuf::from(value);
+            override_path.is_absolute()
+                && canonicalize_deepest_existing(&override_path)
+                    .is_ok_and(|canonical_override| canonical_override == canonical_path)
+        });
+        if override_matches {
+            return Ok(());
+        }
+
         return Err(SqliteError::InvalidData(format!(
             "test harness refused to open SQLite database under HOME/.khive: {} \
-             (KHIVE_ALLOW_HOME_STORE=1 is for deliberate operator use only)",
+             (set KHIVE_ALLOW_HOME_STORE to the exact absolute database path to allow this store: \
+             {})",
+            canonical_path.display(),
             canonical_path.display()
         )));
     }

--- a/crates/khive-db/src/pool.rs
+++ b/crates/khive-db/src/pool.rs
@@ -22,6 +22,9 @@ const DEFAULT_WAL_AUTOCHECKPOINT_PAGES: u32 = 4000;
 const DEFAULT_JOURNAL_SIZE_LIMIT_BYTES: i64 = 67_108_864; // 64 MiB
 const DEFAULT_WRITE_QUEUE_CAPACITY: usize = 256;
 
+#[cfg(any(test, debug_assertions))]
+const TEST_HARNESS_ENV: &str = "KHIVE_TEST_HARNESS";
+
 /// Configuration for the connection pool.
 #[derive(Clone, Debug)]
 pub struct PoolConfig {
@@ -119,6 +122,26 @@ impl Default for PoolConfig {
                 .unwrap_or(DEFAULT_WRITE_QUEUE_CAPACITY),
         }
     }
+}
+
+#[cfg(any(test, debug_assertions))]
+fn refuse_home_data_store_in_tests(config: &PoolConfig) -> Result<(), SqliteError> {
+    let under_test = cfg!(test) || std::env::var(TEST_HARNESS_ENV).is_ok_and(|value| value == "1");
+    if !under_test {
+        return Ok(());
+    }
+
+    let (Some(path), Some(home)) = (config.path.as_deref(), std::env::var_os("HOME")) else {
+        return Ok(());
+    };
+    let home_data_dir = PathBuf::from(home).join(".khive");
+    if path.starts_with(&home_data_dir) {
+        return Err(SqliteError::InvalidData(format!(
+            "test harness refused to open SQLite database under the HOME data directory: {}",
+            path.display()
+        )));
+    }
+    Ok(())
 }
 
 /// A read-write connection pool for SQLite.
@@ -281,6 +304,9 @@ impl ConnectionPool {
     /// WAL is disabled or unavailable, the pool falls back to single-connection
     /// mode.
     pub fn new(config: PoolConfig) -> Result<Self, SqliteError> {
+        #[cfg(any(test, debug_assertions))]
+        refuse_home_data_store_in_tests(&config)?;
+
         let writer = open_writer_connection(&config)?;
         let wal_enabled = configure_writer_connection(&writer, &config)?;
         let max_readers = effective_reader_count(&config, wal_enabled);

--- a/crates/khive-db/src/pool.rs
+++ b/crates/khive-db/src/pool.rs
@@ -22,8 +22,8 @@ const DEFAULT_WAL_AUTOCHECKPOINT_PAGES: u32 = 4000;
 const DEFAULT_JOURNAL_SIZE_LIMIT_BYTES: i64 = 67_108_864; // 64 MiB
 const DEFAULT_WRITE_QUEUE_CAPACITY: usize = 256;
 
-#[cfg(any(test, debug_assertions))]
 const TEST_HARNESS_ENV: &str = "KHIVE_TEST_HARNESS";
+const ALLOW_HOME_STORE_ENV: &str = "KHIVE_ALLOW_HOME_STORE";
 
 /// Configuration for the connection pool.
 #[derive(Clone, Debug)]
@@ -124,24 +124,91 @@ impl Default for PoolConfig {
     }
 }
 
-#[cfg(any(test, debug_assertions))]
+/// Prevent Cargo-launched tests and test subprocesses from opening the
+/// operator's default data tree in every build profile. Activation is solely
+/// the runtime `KHIVE_TEST_HARNESS=1` marker; production/installed binaries do
+/// not receive that workspace Cargo environment.
+///
+/// `KHIVE_ALLOW_HOME_STORE=1` is an operator-only escape hatch for a deliberate
+/// in-repository `cargo run`. Automated tests must never set or inherit it.
+/// Existing path ancestors are canonicalized before comparison, resolving
+/// traversal, symlinks, and filesystem-provided case (including APFS case
+/// folding). Missing trailing components remain lexical because they have no
+/// filesystem identity yet. SQLite URI paths are rejected rather than trying
+/// to reproduce SQLite's URI normalization rules.
 fn refuse_home_data_store_in_tests(config: &PoolConfig) -> Result<(), SqliteError> {
-    let under_test = cfg!(test) || std::env::var(TEST_HARNESS_ENV).is_ok_and(|value| value == "1");
-    if !under_test {
+    if std::env::var(TEST_HARNESS_ENV).as_deref() != Ok("1") {
+        return Ok(());
+    }
+    if std::env::var(ALLOW_HOME_STORE_ENV).as_deref() == Ok("1") {
         return Ok(());
     }
 
-    let (Some(path), Some(home)) = (config.path.as_deref(), std::env::var_os("HOME")) else {
+    let Some(path) = config.path.as_deref() else {
         return Ok(());
     };
-    let home_data_dir = PathBuf::from(home).join(".khive");
-    if path.starts_with(&home_data_dir) {
+    if path
+        .as_os_str()
+        .as_encoded_bytes()
+        .get(..5)
+        .is_some_and(|prefix| prefix.eq_ignore_ascii_case(b"file:"))
+    {
         return Err(SqliteError::InvalidData(format!(
-            "test harness refused to open SQLite database under the HOME data directory: {}",
+            "test harness refused SQLite URI database path {}; use a filesystem path outside \
+             HOME/.khive (KHIVE_ALLOW_HOME_STORE=1 is for deliberate operator use only)",
             path.display()
         )));
     }
+
+    let Some(home) = std::env::var_os("HOME") else {
+        return Ok(());
+    };
+    let canonical_path = canonicalize_deepest_existing(path)?;
+    let canonical_home_data_dir =
+        canonicalize_deepest_existing(&PathBuf::from(home).join(".khive"))?;
+    if canonical_path.starts_with(&canonical_home_data_dir) {
+        return Err(SqliteError::InvalidData(format!(
+            "test harness refused to open SQLite database under HOME/.khive: {} \
+             (KHIVE_ALLOW_HOME_STORE=1 is for deliberate operator use only)",
+            canonical_path.display()
+        )));
+    }
     Ok(())
+}
+
+fn canonicalize_deepest_existing(path: &Path) -> Result<PathBuf, SqliteError> {
+    let absolute = if path.is_absolute() {
+        path.to_path_buf()
+    } else {
+        std::env::current_dir().map_err(SqliteError::Io)?.join(path)
+    };
+
+    for ancestor in absolute.ancestors() {
+        match fs::canonicalize(ancestor) {
+            Ok(mut canonical) => {
+                let missing = absolute.strip_prefix(ancestor).map_err(|error| {
+                    SqliteError::InvalidData(format!(
+                        "failed to preserve missing path components for {}: {error}",
+                        absolute.display()
+                    ))
+                })?;
+                canonical.push(missing);
+                return Ok(canonical);
+            }
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+            Err(error) => {
+                return Err(SqliteError::InvalidData(format!(
+                    "failed to canonicalize database path ancestor {}: {error}",
+                    ancestor.display()
+                )));
+            }
+        }
+    }
+
+    Err(SqliteError::InvalidData(format!(
+        "database path has no canonicalizable ancestor: {}",
+        absolute.display()
+    )))
 }
 
 /// A read-write connection pool for SQLite.
@@ -304,7 +371,6 @@ impl ConnectionPool {
     /// WAL is disabled or unavailable, the pool falls back to single-connection
     /// mode.
     pub fn new(config: PoolConfig) -> Result<Self, SqliteError> {
-        #[cfg(any(test, debug_assertions))]
         refuse_home_data_store_in_tests(&config)?;
 
         let writer = open_writer_connection(&config)?;

--- a/crates/khive-db/tests/home_store_guard.rs
+++ b/crates/khive-db/tests/home_store_guard.rs
@@ -36,6 +36,24 @@ fn restore_env(key: &str, value: Option<OsString>) {
 }
 
 fn assert_harness_refuses(path: PathBuf) {
+    let message = harness_refusal(path);
+    assert!(
+        message.contains("test harness refused"),
+        "unexpected guard error: {message}"
+    );
+}
+
+fn assert_harness_refuses_with_path_instruction(path: PathBuf) {
+    let expected_path = path.display().to_string();
+    let message = harness_refusal(path);
+    assert!(
+        message.contains("set KHIVE_ALLOW_HOME_STORE to the exact absolute database path")
+            && message.contains(&expected_path),
+        "refusal did not explain the path-valued override: {message}"
+    );
+}
+
+fn harness_refusal(path: PathBuf) -> String {
     let error = match ConnectionPool::new(PoolConfig {
         path: Some(path),
         ..PoolConfig::default()
@@ -43,10 +61,7 @@ fn assert_harness_refuses(path: PathBuf) {
         Ok(_) => panic!("test harness opened a database under HOME/.khive"),
         Err(error) => error,
     };
-    assert!(
-        error.to_string().contains("test harness refused"),
-        "unexpected guard error: {error}"
-    );
+    error.to_string()
 }
 
 fn fake_home() -> (tempfile::TempDir, PathBuf) {
@@ -68,7 +83,51 @@ fn release_dependency_refuses_home_store() {
     let _home = HomeGuard::install(home.path());
     let database = home_data_dir.join("release.db");
 
-    assert_harness_refuses(database.clone());
+    assert_harness_refuses_with_path_instruction(database.clone());
+
+    assert!(!database.exists(), "guard must run before SQLite opens");
+}
+
+#[test]
+#[serial_test::serial(home_store_guard)]
+fn legacy_boolean_override_does_not_allow_home_store() {
+    let (home, home_data_dir) = fake_home();
+    let _home = HomeGuard::install(home.path());
+    let database = home_data_dir.join("legacy-override.db");
+    std::env::set_var(ALLOW_HOME_STORE_ENV, "1");
+
+    assert_harness_refuses_with_path_instruction(database.clone());
+
+    assert!(!database.exists(), "guard must run before SQLite opens");
+}
+
+#[test]
+#[serial_test::serial(home_store_guard)]
+fn exact_path_override_allows_home_store() {
+    let (home, home_data_dir) = fake_home();
+    let _home = HomeGuard::install(home.path());
+    let database = home_data_dir.join("exact-override.db");
+    std::env::set_var(ALLOW_HOME_STORE_ENV, &database);
+
+    let pool = ConnectionPool::new(PoolConfig {
+        path: Some(database.clone()),
+        ..PoolConfig::default()
+    })
+    .expect("exact database path override should allow the store");
+    drop(pool);
+
+    assert!(database.exists(), "SQLite should open the allowed database");
+}
+
+#[test]
+#[serial_test::serial(home_store_guard)]
+fn different_path_override_does_not_allow_home_store() {
+    let (home, home_data_dir) = fake_home();
+    let _home = HomeGuard::install(home.path());
+    let database = home_data_dir.join("requested.db");
+    std::env::set_var(ALLOW_HOME_STORE_ENV, home_data_dir.join("allowed.db"));
+
+    assert_harness_refuses_with_path_instruction(database.clone());
 
     assert!(!database.exists(), "guard must run before SQLite opens");
 }

--- a/crates/khive-db/tests/home_store_guard.rs
+++ b/crates/khive-db/tests/home_store_guard.rs
@@ -1,0 +1,117 @@
+use khive_db::{ConnectionPool, PoolConfig};
+use std::ffi::OsString;
+use std::path::{Path, PathBuf};
+
+const ALLOW_HOME_STORE_ENV: &str = "KHIVE_ALLOW_HOME_STORE";
+
+struct HomeGuard {
+    home: Option<OsString>,
+    allow_home_store: Option<OsString>,
+}
+
+impl HomeGuard {
+    fn install(home: &Path) -> Self {
+        let guard = Self {
+            home: std::env::var_os("HOME"),
+            allow_home_store: std::env::var_os(ALLOW_HOME_STORE_ENV),
+        };
+        std::env::set_var("HOME", home);
+        std::env::remove_var(ALLOW_HOME_STORE_ENV);
+        guard
+    }
+}
+
+impl Drop for HomeGuard {
+    fn drop(&mut self) {
+        restore_env("HOME", self.home.take());
+        restore_env(ALLOW_HOME_STORE_ENV, self.allow_home_store.take());
+    }
+}
+
+fn restore_env(key: &str, value: Option<OsString>) {
+    match value {
+        Some(value) => std::env::set_var(key, value),
+        None => std::env::remove_var(key),
+    }
+}
+
+fn assert_harness_refuses(path: PathBuf) {
+    let error = match ConnectionPool::new(PoolConfig {
+        path: Some(path),
+        ..PoolConfig::default()
+    }) {
+        Ok(_) => panic!("test harness opened a database under HOME/.khive"),
+        Err(error) => error,
+    };
+    assert!(
+        error.to_string().contains("test harness refused"),
+        "unexpected guard error: {error}"
+    );
+}
+
+fn fake_home() -> (tempfile::TempDir, PathBuf) {
+    assert_eq!(
+        std::env::var("KHIVE_TEST_HARNESS").as_deref(),
+        Ok("1"),
+        "Cargo must mark the test process"
+    );
+    let home = tempfile::tempdir().expect("temporary HOME");
+    let home_data_dir = home.path().join(".khive");
+    std::fs::create_dir(&home_data_dir).expect("create fake home data directory");
+    (home, home_data_dir)
+}
+
+#[test]
+#[serial_test::serial(home_store_guard)]
+fn release_dependency_refuses_home_store() {
+    let (home, home_data_dir) = fake_home();
+    let _home = HomeGuard::install(home.path());
+    let database = home_data_dir.join("release.db");
+
+    assert_harness_refuses(database.clone());
+
+    assert!(!database.exists(), "guard must run before SQLite opens");
+}
+
+#[test]
+#[serial_test::serial(home_store_guard)]
+fn refuses_parent_traversal_into_home_store() {
+    let (home, home_data_dir) = fake_home();
+    let _home = HomeGuard::install(home.path());
+    let outside = home.path().join("outside");
+    std::fs::create_dir(&outside).expect("create traversal anchor");
+    let database = home_data_dir.join("traversal.db");
+    let traversal = outside.join("..").join(".khive").join("traversal.db");
+
+    assert_harness_refuses(traversal);
+
+    assert!(!database.exists(), "guard must run before SQLite opens");
+}
+
+#[cfg(unix)]
+#[test]
+#[serial_test::serial(home_store_guard)]
+fn refuses_symlink_alias_into_home_store() {
+    let (home, home_data_dir) = fake_home();
+    let _home = HomeGuard::install(home.path());
+    let alias = home.path().join("store-alias");
+    std::os::unix::fs::symlink(&home_data_dir, &alias).expect("create store alias");
+    let database = home_data_dir.join("symlink.db");
+
+    assert_harness_refuses(alias.join("symlink.db"));
+
+    assert!(!database.exists(), "guard must run before SQLite opens");
+}
+
+#[test]
+#[serial_test::serial(home_store_guard)]
+fn refuses_sqlite_uri_paths() {
+    let (home, home_data_dir) = fake_home();
+    let _home = HomeGuard::install(home.path());
+    let database = home_data_dir.join("uri.db");
+    let uri = PathBuf::from(format!("file:{}", database.display()));
+
+    assert_harness_refuses(uri);
+
+    assert!(!database.exists(), "guard must run before SQLite opens");
+}

--- a/crates/khive-db/tests/home_store_guard.rs
+++ b/crates/khive-db/tests/home_store_guard.rs
@@ -43,13 +43,12 @@ fn assert_harness_refuses(path: PathBuf) {
     );
 }
 
-fn assert_harness_refuses_with_path_instruction(path: PathBuf) {
+fn assert_harness_refuses_with_direct_binary_instruction(path: PathBuf) {
     let expected_path = path.display().to_string();
     let message = harness_refusal(path);
     assert!(
-        message.contains("set KHIVE_ALLOW_HOME_STORE to the exact absolute database path")
-            && message.contains(&expected_path),
-        "refusal did not explain the path-valued override: {message}"
+        message.contains("run the built binary directly") && message.contains(&expected_path),
+        "refusal did not point at the direct-binary workflow: {message}"
     );
 }
 
@@ -83,7 +82,7 @@ fn release_dependency_refuses_home_store() {
     let _home = HomeGuard::install(home.path());
     let database = home_data_dir.join("release.db");
 
-    assert_harness_refuses_with_path_instruction(database.clone());
+    assert_harness_refuses_with_direct_binary_instruction(database.clone());
 
     assert!(!database.exists(), "guard must run before SQLite opens");
 }
@@ -96,27 +95,22 @@ fn legacy_boolean_override_does_not_allow_home_store() {
     let database = home_data_dir.join("legacy-override.db");
     std::env::set_var(ALLOW_HOME_STORE_ENV, "1");
 
-    assert_harness_refuses_with_path_instruction(database.clone());
+    assert_harness_refuses_with_direct_binary_instruction(database.clone());
 
     assert!(!database.exists(), "guard must run before SQLite opens");
 }
 
 #[test]
 #[serial_test::serial(home_store_guard)]
-fn exact_path_override_allows_home_store() {
+fn exact_path_override_does_not_allow_home_store() {
     let (home, home_data_dir) = fake_home();
     let _home = HomeGuard::install(home.path());
     let database = home_data_dir.join("exact-override.db");
     std::env::set_var(ALLOW_HOME_STORE_ENV, &database);
 
-    let pool = ConnectionPool::new(PoolConfig {
-        path: Some(database.clone()),
-        ..PoolConfig::default()
-    })
-    .expect("exact database path override should allow the store");
-    drop(pool);
+    assert_harness_refuses_with_direct_binary_instruction(database.clone());
 
-    assert!(database.exists(), "SQLite should open the allowed database");
+    assert!(!database.exists(), "guard must run before SQLite opens");
 }
 
 #[test]
@@ -127,7 +121,7 @@ fn different_path_override_does_not_allow_home_store() {
     let database = home_data_dir.join("requested.db");
     std::env::set_var(ALLOW_HOME_STORE_ENV, home_data_dir.join("allowed.db"));
 
-    assert_harness_refuses_with_path_instruction(database.clone());
+    assert_harness_refuses_with_direct_binary_instruction(database.clone());
 
     assert!(!database.exists(), "guard must run before SQLite opens");
 }

--- a/crates/khive-runtime/tests/integration.rs
+++ b/crates/khive-runtime/tests/integration.rs
@@ -3840,3 +3840,43 @@ async fn stats_totals_match_list_walk_across_visible_namespaces() {
     );
     assert_eq!(stats_notes, 2);
 }
+
+#[test]
+#[serial_test::serial]
+fn test_harness_refuses_runtime_default_store() {
+    struct HomeGuard(Option<std::ffi::OsString>);
+
+    impl Drop for HomeGuard {
+        fn drop(&mut self) {
+            match self.0.take() {
+                Some(home) => std::env::set_var("HOME", home),
+                None => std::env::remove_var("HOME"),
+            }
+        }
+    }
+
+    assert_eq!(
+        std::env::var("KHIVE_TEST_HARNESS").as_deref(),
+        Ok("1"),
+        "the workspace Cargo harness must mark integration-test processes"
+    );
+    let fake_home = tempfile::tempdir().expect("temporary HOME");
+    let _home_guard = HomeGuard(std::env::var_os("HOME"));
+    std::env::set_var("HOME", fake_home.path());
+    let expected_path = fake_home.path().join(".khive/khive.db");
+    let config = RuntimeConfig::no_embeddings();
+    assert_eq!(config.db_path.as_deref(), Some(expected_path.as_path()));
+
+    let error = match KhiveRuntime::new(config) {
+        Ok(_) => panic!("test harness opened the default home-directory store"),
+        Err(error) => error,
+    };
+    assert!(
+        error.to_string().contains("test harness refused"),
+        "unexpected guard error: {error}"
+    );
+    assert!(
+        !expected_path.exists(),
+        "the guarded runtime must refuse the path before SQLite creates it"
+    );
+}

--- a/crates/kkernel/src/exec.rs
+++ b/crates/kkernel/src/exec.rs
@@ -2499,8 +2499,12 @@ default = true
         // is not a legitimate way to reach this scenario — default discovery is.
         let khive_dir = home_dir.path().join(".khive");
         std::fs::create_dir_all(&khive_dir).expect("mkdir .khive");
-        let main_backend_path = khive_dir.join("main-backend.db");
-        let sessions_backend_path = khive_dir.join("sessions-backend.db");
+        // Keep the configuration home-shaped while placing the stores in a
+        // separate tempdir. Test-harness builds reject every store under
+        // `$HOME/.khive`, including isolated fixtures, at the open boundary.
+        let backend_dir = tempfile::tempdir().expect("backend tempdir");
+        let main_backend_path = backend_dir.path().join("main-backend.db");
+        let sessions_backend_path = backend_dir.path().join("sessions-backend.db");
         std::fs::write(
             khive_dir.join("config.toml"),
             format!(


### PR DESCRIPTION
A workspace test that inherits the default `db_path` can open and forward-migrate the operator's real store (#1204: a feature-branch test run migrated a live store to a schema version the installed binary did not know).

## Change

- `ConnectionPool::new` refuses any SQLite database under `$HOME/.khive` when running under the workspace test harness, before the file is opened or migrations run.
- Harness detection is a pure runtime check in every build profile: `.cargo/config.toml` sets a `KHIVE_TEST_HARNESS` marker for every cargo-invoked process, and the guard fires whenever that marker is present — including `cargo test --release`. The marker plumbing is itself asserted by the guard tests, so a build configuration that stopped setting it fails the suite rather than silently disabling the guard.
- There is deliberately no environment override. A deliberate session against a real store runs the built binary directly, which never receives the workspace cargo environment. Legacy boolean, exact-path, and different-path override values are all proven inert by tests.
- The guard resolves symlink aliases, parent traversal, and SQLite URI forms before comparing against `$HOME/.khive`, and refuses before SQLite opens the file.
- Audit of every test-reachable runtime/pool construction in the workspace found no currently-offending test; one fixture that parked isolated backend files under a fake `$HOME/.khive` moves them to a plain tempdir.
- Regression: with a fake `HOME` and the unmodified default `db_path`, pool construction fails with the guard error, the refusal message names the direct-binary workflow, and the database file is never created.

Closes #1204

🤖 Generated with [Claude Code](https://claude.com/claude-code)
