### PR TITLE
fix(runtime): bound embedding input instead of failing over-length writes

### DIFF
--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -1739,6 +1739,7 @@ dependencies = [
  "khive-runtime",
  "khive-storage",
  "khive-types",
+ "lattice-embed",
  "serde",
  "serde_json",
  "tokio",

--- a/crates/khive-pack-kg/Cargo.toml
+++ b/crates/khive-pack-kg/Cargo.toml
@@ -31,6 +31,7 @@ tracing = { workspace = true }
 tokio = { workspace = true, features = ["test-util"] }
 criterion = { workspace = true }
 serde_json = { workspace = true }
+lattice-embed = { workspace = true }
 
 
 [[test]]

--- a/crates/khive-pack-kg/src/handlers/create.rs
+++ b/crates/khive-pack-kg/src/handlers/create.rs
@@ -12,6 +12,18 @@ use super::common::{
 };
 use crate::KgPack;
 
+pub(super) fn add_embedding_truncation_warning(response: &mut Value, truncated: bool) {
+    if !truncated {
+        return;
+    }
+    if let Some(obj) = response.as_object_mut() {
+        obj.insert(
+            "warnings".to_string(),
+            json!([khive_runtime::retrieval::EMBEDDING_INPUT_TRUNCATED_WARNING]),
+        );
+    }
+}
+
 impl KgPack {
     pub(crate) async fn handle_create(
         &self,
@@ -305,7 +317,7 @@ impl KgPack {
             None
         };
 
-        let (mut response, new_id) = match p.kind.as_str() {
+        let (mut response, new_id, embedding_input_truncated) = match p.kind.as_str() {
             "entity" => {
                 if p.embedding_content.is_some() {
                     return Err(RuntimeError::InvalidInput(
@@ -335,7 +347,15 @@ impl KgPack {
                     )
                     .await?;
                 let id = entity.id;
-                (normalize_entity_timestamps(to_json(&entity)?), id)
+                let embed_body = khive_runtime::entity_fts_document(&entity).body;
+                let truncated = self
+                    .runtime
+                    .document_embedding_input_will_be_truncated(&embed_body);
+                (
+                    normalize_entity_timestamps(to_json(&entity)?),
+                    id,
+                    truncated,
+                )
             }
             "note" => {
                 let canonical = sub_kind
@@ -349,6 +369,10 @@ impl KgPack {
                     annotates.push(resolve_uuid_unfiltered(&s, &self.runtime, token).await?);
                 }
                 let properties = super::common::merge_note_tags(p.properties, p.tags)?;
+                let embed_text = p.embedding_content.as_deref().unwrap_or(&content);
+                let truncated = self
+                    .runtime
+                    .document_embedding_input_will_be_truncated(embed_text);
                 let note = self
                     .runtime
                     .create_note_with_embedding_content(
@@ -366,6 +390,7 @@ impl KgPack {
                 (
                     remap_note_status(normalize_entity_timestamps(to_json(&note)?)),
                     id,
+                    truncated,
                 )
             }
             other => {
@@ -374,6 +399,8 @@ impl KgPack {
                 )))
             }
         };
+
+        add_embedding_truncation_warning(&mut response, embedding_input_truncated);
 
         if let Some(ref h) = hook {
             if let Err(e) = h.after_create(&self.runtime, new_id, &params).await {

--- a/crates/khive-pack-kg/src/handlers/create.rs
+++ b/crates/khive-pack-kg/src/handlers/create.rs
@@ -334,6 +334,18 @@ impl KgPack {
                 let tags = p.tags.unwrap_or_default();
                 let validated_type =
                     validate_entity_type(&canonical, p.entity_type.as_deref(), registry)?;
+                let embed_body_len = p
+                    .description
+                    .as_deref()
+                    .filter(|description| !description.is_empty())
+                    .map_or(name.len(), |description| {
+                        name.len()
+                            .saturating_add(1)
+                            .saturating_add(description.len())
+                    });
+                let truncated = self
+                    .runtime
+                    .document_embedding_input_len_will_be_truncated(embed_body_len);
                 let entity = self
                     .runtime
                     .create_entity(
@@ -347,10 +359,6 @@ impl KgPack {
                     )
                     .await?;
                 let id = entity.id;
-                let embed_body = khive_runtime::entity_fts_document(&entity).body;
-                let truncated = self
-                    .runtime
-                    .document_embedding_input_will_be_truncated(&embed_body);
                 (
                     normalize_entity_timestamps(to_json(&entity)?),
                     id,

--- a/crates/khive-pack-kg/src/handlers/tests.rs
+++ b/crates/khive-pack-kg/src/handlers/tests.rs
@@ -1170,16 +1170,85 @@ async fn update_entity_with_note_field_salience_returns_error() {
 
 // ── #764: create's embedding_content wiring ─────────────────────────────────
 
-#[test]
-fn create_embedding_truncation_advisory_matches_warnings_shape() {
-    let mut truncated = json!({"id": "created"});
-    super::create::add_embedding_truncation_warning(&mut truncated, true);
+struct WarningEmbeddingService;
+
+#[async_trait::async_trait]
+impl lattice_embed::EmbeddingService for WarningEmbeddingService {
+    async fn embed(
+        &self,
+        texts: &[String],
+        _model: lattice_embed::EmbeddingModel,
+    ) -> Result<Vec<Vec<f32>>, lattice_embed::EmbedError> {
+        Ok(vec![vec![1.0]; texts.len()])
+    }
+
+    fn supports_model(&self, _model: lattice_embed::EmbeddingModel) -> bool {
+        true
+    }
+
+    fn name(&self) -> &'static str {
+        "warning-test"
+    }
+}
+
+struct WarningEmbedderProvider;
+
+#[async_trait::async_trait]
+impl khive_runtime::EmbedderProvider for WarningEmbedderProvider {
+    fn name(&self) -> &str {
+        "warning-test"
+    }
+
+    fn dimensions(&self) -> usize {
+        1
+    }
+
+    async fn build(
+        &self,
+    ) -> Result<std::sync::Arc<dyn lattice_embed::EmbeddingService>, khive_runtime::RuntimeError>
+    {
+        Ok(std::sync::Arc::new(WarningEmbeddingService))
+    }
+}
+
+#[tokio::test]
+async fn create_dispatch_emits_embedding_truncation_advisory() {
+    use crate::KgPack;
+    use khive_runtime::{KhiveRuntime, VerbRegistryBuilder};
+
+    let rt = KhiveRuntime::memory().expect("in-memory runtime");
+    rt.register_embedder(WarningEmbedderProvider);
+    let mut builder = VerbRegistryBuilder::new();
+    builder.register(KgPack::new(rt));
+    let registry = builder.build().expect("registry build");
+
+    let truncated = registry
+        .dispatch(
+            "create",
+            json!({
+                "kind": "concept",
+                "name": "warning target",
+                "description": "x".repeat(lattice_embed::MAX_TEXT_CHARS),
+                "skip_dedup_check": true,
+            }),
+        )
+        .await
+        .expect("over-limit create");
     let warnings = truncated["warnings"].as_array().expect("warnings array");
     assert_eq!(warnings.len(), 1);
     assert!(warnings[0].as_str().unwrap().contains("truncated"));
 
-    let mut normal = json!({"id": "created"});
-    super::create::add_embedding_truncation_warning(&mut normal, false);
+    let normal = registry
+        .dispatch(
+            "create",
+            json!({
+                "kind": "concept",
+                "name": "normal target",
+                "skip_dedup_check": true,
+            }),
+        )
+        .await
+        .expect("normal create");
     assert!(
         normal.get("warnings").is_none(),
         "normal input must not emit an advisory"

--- a/crates/khive-pack-kg/src/handlers/tests.rs
+++ b/crates/khive-pack-kg/src/handlers/tests.rs
@@ -1170,6 +1170,22 @@ async fn update_entity_with_note_field_salience_returns_error() {
 
 // ── #764: create's embedding_content wiring ─────────────────────────────────
 
+#[test]
+fn create_embedding_truncation_advisory_matches_warnings_shape() {
+    let mut truncated = json!({"id": "created"});
+    super::create::add_embedding_truncation_warning(&mut truncated, true);
+    let warnings = truncated["warnings"].as_array().expect("warnings array");
+    assert_eq!(warnings.len(), 1);
+    assert!(warnings[0].as_str().unwrap().contains("truncated"));
+
+    let mut normal = json!({"id": "created"});
+    super::create::add_embedding_truncation_warning(&mut normal, false);
+    assert!(
+        normal.get("warnings").is_none(),
+        "normal input must not emit an advisory"
+    );
+}
+
 /// A note create with a proper-prefix `embedding_content` must succeed and
 /// store the full `content`; the override is a runtime-layer concern
 /// (covered by `khive-runtime`'s own unit tests) — this proves the handler

--- a/crates/khive-runtime/src/operations.rs
+++ b/crates/khive-runtime/src/operations.rs
@@ -5327,7 +5327,7 @@ mod tests {
     use crate::{ActorRef, Namespace};
     use async_trait::async_trait;
     use khive_storage::types::PathNode;
-    use lattice_embed::{EmbedError, EmbeddingModel, EmbeddingService};
+    use lattice_embed::{EmbedError, EmbeddingModel, EmbeddingService, MAX_TEXT_CHARS};
     use std::sync::atomic::{AtomicUsize, Ordering};
     use std::sync::Arc;
 
@@ -13605,6 +13605,14 @@ mod tests {
             texts: &[String],
             _model: EmbeddingModel,
         ) -> std::result::Result<Vec<Vec<f32>>, EmbedError> {
+            for text in texts {
+                if text.len() > MAX_TEXT_CHARS {
+                    return Err(EmbedError::TextTooLong {
+                        length: text.len(),
+                        max: MAX_TEXT_CHARS,
+                    });
+                }
+            }
             self.captured.lock().unwrap().extend(texts.iter().cloned());
             Ok(texts.iter().map(|_| vec![1.0_f32; self.dims]).collect())
         }
@@ -13640,6 +13648,80 @@ mod tests {
                 captured: Arc::clone(&self.captured),
             }))
         }
+    }
+
+    #[tokio::test]
+    async fn create_bounds_embedding_input_without_truncating_stored_content() {
+        let rt = rt();
+        let tok = NamespaceToken::local();
+        let captured = Arc::new(std::sync::Mutex::new(Vec::new()));
+        rt.register_embedder(CapturingVecProvider {
+            provider_name: "strict-length-test".into(),
+            dims: 4,
+            captured: Arc::clone(&captured),
+        });
+
+        let content = format!("{}\u{1f980}tail", "a".repeat(MAX_TEXT_CHARS - 1));
+        let note = rt
+            .create_note(&tok, "observation", None, &content, None, None, vec![])
+            .await
+            .expect("over-length note create must succeed");
+        let fetched = rt
+            .notes(&tok)
+            .unwrap()
+            .get_note(note.id)
+            .await
+            .unwrap()
+            .expect("created note must be retrievable");
+        assert_eq!(fetched.content, content, "stored content must remain full");
+
+        let embedded = captured.lock().unwrap().clone();
+        assert_eq!(embedded.len(), 1);
+        assert_eq!(embedded[0].len(), MAX_TEXT_CHARS - 1);
+        assert!(embedded[0].is_char_boundary(embedded[0].len()));
+        assert!(!embedded[0].contains('\u{1f980}'));
+        assert!(rt.document_embedding_input_will_be_truncated(&content));
+
+        let vector_info = rt
+            .vectors_for_model(&tok, "strict-length-test")
+            .expect("vector store")
+            .info()
+            .await
+            .expect("vector info");
+        assert_eq!(vector_info.dimensions, 4);
+        assert_eq!(vector_info.entry_count, 1);
+
+        captured.lock().unwrap().clear();
+        rt.reindex_note(&tok, &fetched)
+            .await
+            .expect("reindex must bound the same stored content");
+        assert_eq!(captured.lock().unwrap()[0].len(), MAX_TEXT_CHARS - 1);
+
+        captured.lock().unwrap().clear();
+        rt.embed_document_batch_with_model("strict-length-test", std::slice::from_ref(&content))
+            .await
+            .expect("batch reindex seam must bound stored content");
+        assert_eq!(captured.lock().unwrap()[0].len(), MAX_TEXT_CHARS - 1);
+
+        let normal = "normal byte-identical embedding input";
+        rt.create_note(&tok, "observation", None, normal, None, None, vec![])
+            .await
+            .expect("normal note create must succeed");
+        assert_eq!(captured.lock().unwrap().last().unwrap(), normal);
+        assert!(!rt.document_embedding_input_will_be_truncated(normal));
+
+        let long_description = format!("{}\u{1f980}tail", "b".repeat(MAX_TEXT_CHARS));
+        rt.create_entity(
+            &tok,
+            "concept",
+            None,
+            "entity",
+            Some(&long_description),
+            None,
+            vec![],
+        )
+        .await
+        .expect("over-length entity create must succeed");
     }
 
     #[tokio::test]

--- a/crates/khive-runtime/src/retrieval.rs
+++ b/crates/khive-runtime/src/retrieval.rs
@@ -88,7 +88,8 @@ const CANDIDATE_MULTIPLIER: u32 = 4;
 pub const EMBEDDING_INPUT_TRUNCATED_WARNING: &str =
     "embedding input was truncated to the embedder maximum; full content was stored unchanged";
 
-fn document_embedding_budget(model_name: &str) -> usize {
+/// Maximum document bytes accepted before the embedding service adds its model prefix.
+pub fn document_embedding_budget(model_name: &str) -> usize {
     parse_embedding_model_alias(model_name)
         .and_then(|model| model.document_instruction())
         .map_or(MAX_TEXT_CHARS, |prefix| {
@@ -96,7 +97,8 @@ fn document_embedding_budget(model_name: &str) -> usize {
         })
 }
 
-fn bounded_embedding_input(text: &str, max_bytes: usize) -> (&str, bool) {
+/// Return the longest UTF-8-safe prefix of `text` within `max_bytes` and whether it was shortened.
+pub fn bounded_embedding_input(text: &str, max_bytes: usize) -> (&str, bool) {
     if text.len() <= max_bytes {
         return (text, false);
     }
@@ -287,6 +289,7 @@ impl KhiveRuntime {
     ///
     /// Applies `EmbeddingService::embed_passage`. Use for all bulk
     /// index/backfill/reindex operations to apply the passage-side prefix.
+    /// Normal spans remain borrowed when a mixed batch also contains bounded items.
     ///
     /// **Reindex caveat**: see [`Self::embed_document_with_model`] — the same
     /// incomparability applies to batch-indexed vectors when switching models.
@@ -304,25 +307,46 @@ impl KhiveRuntime {
         let service = self.embedder(model_name).await?;
         let emb_model = model.unwrap_or_default();
         let budget = document_embedding_budget(model_name);
-        let bounded = texts.iter().any(|text| text.len() > budget).then(|| {
-            texts
-                .iter()
-                .map(|text| bounded_embedding_input(text, budget).0.to_string())
-                .collect::<Vec<_>>()
-        });
-        let embed_texts = bounded.as_deref().unwrap_or(texts);
-        let out = service.embed_passage(embed_texts, emb_model).await;
+        let out = if texts.iter().all(|text| text.len() <= budget) {
+            service.embed_passage(texts, emb_model).await
+        } else {
+            async {
+                let mut embeddings = Vec::with_capacity(texts.len());
+                let mut start = 0;
+                while start < texts.len() {
+                    if texts[start].len() > budget {
+                        let bounded =
+                            vec![bounded_embedding_input(&texts[start], budget).0.to_owned()];
+                        embeddings.extend(service.embed_passage(&bounded, emb_model).await?);
+                        start += 1;
+                        continue;
+                    }
+
+                    let end = texts[start..]
+                        .iter()
+                        .position(|text| text.len() > budget)
+                        .map_or(texts.len(), |offset| start + offset);
+                    embeddings.extend(service.embed_passage(&texts[start..end], emb_model).await?);
+                    start = end;
+                }
+                Ok(embeddings)
+            }
+            .await
+        };
         crate::usage::count(crate::usage::UsageUnit::EmbedCalls, texts.len() as u64);
         Ok(out?)
     }
 
     /// Whether any registered write embedder would receive a bounded form of `text`.
     pub fn document_embedding_input_will_be_truncated(&self, text: &str) -> bool {
+        self.document_embedding_input_len_will_be_truncated(text.len())
+    }
+
+    /// Whether any registered write embedder would truncate a document of `input_len` bytes.
+    pub fn document_embedding_input_len_will_be_truncated(&self, input_len: usize) -> bool {
         self.registered_embedding_model_names()
             .iter()
-            .any(|model_name| {
-                bounded_embedding_input(text, document_embedding_budget(model_name)).1
-            })
+            .any(|model_name| input_len > document_embedding_budget(model_name))
     }
 
     /// Embed a batch of documents for indexing using the configured default model.
@@ -1848,6 +1872,31 @@ mod tests {
                 ],
             ],
             "E5 must receive its query prefix through single and batch paths"
+        );
+    }
+
+    #[tokio::test]
+    async fn mixed_document_batch_only_rebuilds_over_limit_items() {
+        let model = EmbeddingModel::AllMiniLmL6V2;
+        let (runtime, captured) = runtime_with_capturing_embedder(model);
+        let texts = vec![
+            "first normal document".to_string(),
+            "x".repeat(MAX_TEXT_CHARS + 1),
+            "second normal document".to_string(),
+        ];
+
+        let embeddings = runtime
+            .embed_document_batch_with_model(&model.to_string(), &texts)
+            .await
+            .expect("mixed batch must embed");
+        assert_eq!(embeddings.len(), texts.len());
+        assert_eq!(
+            captured.lock().unwrap().as_slice(),
+            [
+                vec![texts[0].clone()],
+                vec!["x".repeat(MAX_TEXT_CHARS)],
+                vec![texts[2].clone()],
+            ]
         );
     }
 

--- a/crates/khive-runtime/src/retrieval.rs
+++ b/crates/khive-runtime/src/retrieval.rs
@@ -2,7 +2,7 @@
 
 use std::collections::{HashMap, HashSet};
 
-use lattice_embed::EmbeddingModel;
+use lattice_embed::{EmbeddingModel, MAX_TEXT_CHARS};
 use uuid::Uuid;
 
 use crate::config::{parse_embedding_model_alias, sanitize_key};
@@ -84,6 +84,32 @@ const RRF_K: usize = 10;
 /// Candidates pulled per path before fusion. Higher = better recall, more work.
 const CANDIDATE_MULTIPLIER: u32 = 4;
 
+/// Advisory emitted by write verbs when only the embedding input was bounded.
+pub const EMBEDDING_INPUT_TRUNCATED_WARNING: &str =
+    "embedding input was truncated to the embedder maximum; full content was stored unchanged";
+
+fn document_embedding_budget(model_name: &str) -> usize {
+    parse_embedding_model_alias(model_name)
+        .and_then(|model| model.document_instruction())
+        .map_or(MAX_TEXT_CHARS, |prefix| {
+            MAX_TEXT_CHARS.saturating_sub(prefix.len())
+        })
+}
+
+fn bounded_embedding_input(text: &str, max_bytes: usize) -> (&str, bool) {
+    if text.len() <= max_bytes {
+        return (text, false);
+    }
+
+    let end = text
+        .char_indices()
+        .map(|(index, _)| index)
+        .take_while(|index| *index <= max_bytes)
+        .last()
+        .unwrap_or(0);
+    (&text[..end], true)
+}
+
 impl KhiveRuntime {
     /// Generate an embedding vector for `text` using the configured default model.
     ///
@@ -147,6 +173,7 @@ impl KhiveRuntime {
         let model = parse_embedding_model_alias(model_name);
         let service = self.embedder(model_name).await?;
         let emb_model = model.unwrap_or_default();
+        let (text, _) = bounded_embedding_input(text, document_embedding_budget(model_name));
         let embeddings = service.embed_passage(&[text.to_string()], emb_model).await;
         crate::usage::count(crate::usage::UsageUnit::EmbedCalls, 1);
         let out = embeddings?
@@ -276,9 +303,26 @@ impl KhiveRuntime {
         let model = parse_embedding_model_alias(model_name);
         let service = self.embedder(model_name).await?;
         let emb_model = model.unwrap_or_default();
-        let out = service.embed_passage(texts, emb_model).await;
+        let budget = document_embedding_budget(model_name);
+        let bounded = texts.iter().any(|text| text.len() > budget).then(|| {
+            texts
+                .iter()
+                .map(|text| bounded_embedding_input(text, budget).0.to_string())
+                .collect::<Vec<_>>()
+        });
+        let embed_texts = bounded.as_deref().unwrap_or(texts);
+        let out = service.embed_passage(embed_texts, emb_model).await;
         crate::usage::count(crate::usage::UsageUnit::EmbedCalls, texts.len() as u64);
         Ok(out?)
+    }
+
+    /// Whether any registered write embedder would receive a bounded form of `text`.
+    pub fn document_embedding_input_will_be_truncated(&self, text: &str) -> bool {
+        self.registered_embedding_model_names()
+            .iter()
+            .any(|model_name| {
+                bounded_embedding_input(text, document_embedding_budget(model_name)).1
+            })
     }
 
     /// Embed a batch of documents for indexing using the configured default model.
@@ -1093,6 +1137,30 @@ mod tests {
     use khive_storage::types::{TextSearchHit, VectorSearchHit};
     use khive_types::namespace::Namespace;
     use lattice_embed::EmbeddingModel;
+
+    #[test]
+    fn bounded_embedding_input_reserves_prefix_and_preserves_utf8() {
+        assert_eq!(
+            document_embedding_budget("multilingual-e5-base"),
+            MAX_TEXT_CHARS - "passage: ".len()
+        );
+
+        let input = format!("{}\u{1f980}tail", "a".repeat(MAX_TEXT_CHARS - 1));
+        let (bounded, truncated) = bounded_embedding_input(&input, MAX_TEXT_CHARS);
+        assert!(truncated);
+        assert_eq!(bounded.len(), MAX_TEXT_CHARS - 1);
+        assert!(bounded.is_char_boundary(bounded.len()));
+        assert!(!bounded.contains('\u{1f980}'));
+    }
+
+    #[test]
+    fn bounded_embedding_input_leaves_normal_text_unchanged() {
+        let input = "normal byte-identical embedding input";
+        let (bounded, truncated) = bounded_embedding_input(input, MAX_TEXT_CHARS);
+        assert!(!truncated);
+        assert_eq!(bounded, input);
+        assert_eq!(bounded.as_ptr(), input.as_ptr());
+    }
 
     fn text_hit(id: Uuid, rank: u32, title: &str) -> TextSearchHit {
         TextSearchHit {

--- a/crates/kkernel/src/reindex.rs
+++ b/crates/kkernel/src/reindex.rs
@@ -23,8 +23,6 @@ use khive_storage::note::Note;
 use khive_storage::VectorStore;
 use khive_types::SubstrateKind;
 
-const MAX_EMBED_BYTES: usize = 32_768;
-
 // ─── progress bar ─────────────────────────────────────────────────────────────
 
 struct ProgressBar {
@@ -306,11 +304,7 @@ async fn embed_and_store_batch(
             continue;
         }
 
-        let budget = embed_budget(model_name);
-        let texts: Vec<String> = subset
-            .iter()
-            .map(|(_, t)| truncate_text(t, budget))
-            .collect();
+        let texts: Vec<String> = subset.iter().map(|(_, text)| text.clone()).collect();
         match rt.embed_document_batch_with_model(model_name, &texts).await {
             Ok(embeddings) if embeddings.len() == subset.len() => {
                 // No pre-delete: SqliteVecStore::insert wraps DELETE+INSERT in
@@ -1094,32 +1088,6 @@ async fn count_notes(rt: &KhiveRuntime, ns: &str) -> u64 {
     }
 }
 
-// The embed service prepends the model's document instruction (e.g. "passage: "
-// for multilingual-e5) AFTER this truncation, and its input guard rejects the
-// combined length. Reserve the prefix bytes here or a text truncated exactly to
-// the cap fails the whole batch post-prefix.
-fn embed_budget(model_name: &str) -> usize {
-    let normalized = model_name.trim().to_ascii_lowercase().replace('_', "-");
-    let prefix_len = normalized
-        .parse::<lattice_embed::EmbeddingModel>()
-        .ok()
-        .and_then(|m| m.document_instruction())
-        .map_or(0, str::len);
-    MAX_EMBED_BYTES - prefix_len
-}
-
-fn truncate_text(t: &str, max_bytes: usize) -> String {
-    if t.len() <= max_bytes {
-        t.to_string()
-    } else {
-        let mut end = max_bytes;
-        while !t.is_char_boundary(end) {
-            end -= 1;
-        }
-        t[..end].to_string()
-    }
-}
-
 fn print_report(report: &ReindexReport, human: bool) {
     if human {
         let status = if report.has_failures() {
@@ -1160,29 +1128,6 @@ fn print_report(report: &ReindexReport, human: bool) {
 #[cfg(test)]
 mod tests {
     use super::*;
-    #[test]
-    fn embed_budget_reserves_document_prefix_bytes() {
-        // multilingual-e5 prepends "passage: " (9 bytes) after truncation; the
-        // budget must reserve it or exactly-at-cap texts fail the whole batch.
-        assert_eq!(embed_budget("multilingual-e5-base"), MAX_EMBED_BYTES - 9);
-        assert_eq!(embed_budget("multilingual_e5_small"), MAX_EMBED_BYTES - 9);
-        assert_eq!(embed_budget("all-minilm-l6-v2"), MAX_EMBED_BYTES);
-        assert_eq!(embed_budget("unknown-model"), MAX_EMBED_BYTES);
-    }
-
-    #[test]
-    fn truncate_text_respects_budget_and_char_boundaries() {
-        let long = "a".repeat(MAX_EMBED_BYTES + 100);
-        assert_eq!(
-            truncate_text(&long, MAX_EMBED_BYTES - 9).len(),
-            MAX_EMBED_BYTES - 9
-        );
-        let cjk = "\u{4e2d}".repeat(20_000); // 3 bytes each
-        let out = truncate_text(&cjk, 32_759);
-        assert!(out.len() <= 32_759);
-        assert!(out.chars().all(|c| c == '\u{4e2d}'));
-    }
-
     use crate::dbpath::resolve_db_override;
     use clap::Parser;
     use khive_storage::types::{SqlStatement, SqlValue};

--- a/crates/kkernel/src/reindex.rs
+++ b/crates/kkernel/src/reindex.rs
@@ -16,6 +16,7 @@ use serde::Serialize;
 use uuid::Uuid;
 
 use khive_mcp::serve::{resolve_runtime_config, RuntimeConfigInputs};
+use khive_runtime::retrieval::{bounded_embedding_input, document_embedding_budget};
 use khive_runtime::{entity_fts_document, note_fts_document, KhiveRuntime, Namespace};
 use khive_storage::entity::Entity;
 use khive_storage::error::StorageError;
@@ -233,9 +234,8 @@ async fn drop_vectors_for_subjects(
     }
 }
 
-/// Embed `staged` with every model in `model_names` and store one vector record
-/// per model — mirroring the multi-model write path in the runtime. Returns the
-/// number of vector inserts that failed.
+/// Embed one model's bounded `staged` inputs and store its vector records.
+/// Returns the number of vector inserts that failed.
 ///
 /// With `drop_existing`, all staged ids are (re)embedded. Before inserting, a
 /// subject-scoped delete removes ANY existing row for each `subject_id` in the
@@ -244,21 +244,22 @@ async fn drop_vectors_for_subjects(
 /// prior namespace survive. The subsequent INSERT writes the current base-row
 /// namespace. With `--keep-existing`, existing vectors are preserved and ids
 /// already embedded are skipped.
-// REASON: each argument is a distinct embed dimension (runtime, token, models,
+// REASON: each argument is a distinct embed dimension (runtime, token, model,
 // namespace, batch, substrate kind, field, drop flag); a struct would add
 // indirection without grouping anything cohesive.
 #[allow(clippy::too_many_arguments)]
 async fn embed_and_store_batch(
     rt: &KhiveRuntime,
     token: &khive_runtime::NamespaceToken,
-    model_names: &[String],
+    model_name: &str,
     namespace: &str,
-    staged: &[(Uuid, String)],
+    staged: Vec<(Uuid, String)>,
     kind: SubstrateKind,
     field: &str,
     drop_existing: bool,
 ) -> u64 {
     let mut errors: u64 = 0;
+    let staged_len = staged.len();
 
     // Subject-scoped drop: remove ANY existing vec rows for these subject_ids
     // in each model table, regardless of stored namespace. This ensures the
@@ -268,70 +269,115 @@ async fn embed_and_store_batch(
     // stored under a different namespace.
     if drop_existing && !staged.is_empty() {
         let subject_ids: Vec<Uuid> = staged.iter().map(|(id, _)| *id).collect();
-        for model_name in model_names {
-            drop_vectors_for_subjects(rt, token, model_name, &subject_ids).await;
-        }
+        drop_vectors_for_subjects(rt, token, model_name, &subject_ids).await;
     }
 
-    for model_name in model_names {
-        let vectors = match rt.vectors_for_model(token, model_name) {
-            Ok(v) => v,
-            Err(e) => {
-                tracing::warn!(model = %model_name, error = %e, "vector store unavailable");
-                errors += staged.len() as u64;
-                continue;
-            }
-        };
-
-        // Narrow to the records this model still needs when keeping existing vectors.
-        let subset: Vec<&(Uuid, String)> = if drop_existing {
-            staged.iter().collect()
-        } else {
-            let ids: Vec<Uuid> = staged.iter().map(|(id, _)| *id).collect();
-            match filter_unembedded(vectors.as_ref(), &ids, namespace).await {
-                Ok(unembedded) => {
-                    let keep: HashSet<Uuid> = unembedded.into_iter().collect();
-                    staged.iter().filter(|(id, _)| keep.contains(id)).collect()
-                }
-                Err(e) => {
-                    tracing::error!(model = %model_name, error = %e, "filter_unembedded failed; skipping batch for this model");
-                    errors += staged.len() as u64;
-                    continue;
-                }
-            }
-        };
-        if subset.is_empty() {
-            continue;
+    let vectors = match rt.vectors_for_model(token, model_name) {
+        Ok(v) => v,
+        Err(e) => {
+            tracing::warn!(model = %model_name, error = %e, "vector store unavailable");
+            return staged_len as u64;
         }
+    };
 
-        let texts: Vec<String> = subset.iter().map(|(_, text)| text.clone()).collect();
-        match rt.embed_document_batch_with_model(model_name, &texts).await {
-            Ok(embeddings) if embeddings.len() == subset.len() => {
-                // No pre-delete: SqliteVecStore::insert wraps DELETE+INSERT in
-                // a single transaction so a failed INSERT rolls back the DELETE
-                // and the prior vector survives (no-worse-than-stale). A separate
-                // committed delete before insert re-introduces the stranding window.
-                for ((id, _), emb) in subset.iter().zip(embeddings.iter()) {
-                    if let Err(e) = vectors
-                        .insert(*id, kind, namespace, field, vec![emb.clone()])
-                        .await
-                    {
-                        tracing::warn!(id = %id, model = %model_name, error = %e, "vector insert failed");
-                        errors += 1;
-                    }
-                }
-            }
-            Ok(_) => {
-                tracing::warn!(model = %model_name, "embedding count mismatch for batch");
-                errors += subset.len() as u64;
+    // Narrow to the records this model still needs when keeping existing vectors.
+    let subset = if drop_existing {
+        staged
+    } else {
+        let ids: Vec<Uuid> = staged.iter().map(|(id, _)| *id).collect();
+        match filter_unembedded(vectors.as_ref(), &ids, namespace).await {
+            Ok(unembedded) => {
+                let keep: HashSet<Uuid> = unembedded.into_iter().collect();
+                staged
+                    .into_iter()
+                    .filter(|(id, _)| keep.contains(id))
+                    .collect()
             }
             Err(e) => {
-                tracing::warn!(model = %model_name, error = %e, "embed_batch failed");
-                errors += subset.len() as u64;
+                tracing::error!(model = %model_name, error = %e, "filter_unembedded failed; skipping batch for this model");
+                return staged_len as u64;
             }
+        }
+    };
+    if subset.is_empty() {
+        return errors;
+    }
+
+    let (ids, texts): (Vec<Uuid>, Vec<String>) = subset.into_iter().unzip();
+    let expected = ids.len();
+    match rt.embed_document_batch_with_model(model_name, &texts).await {
+        Ok(embeddings) if embeddings.len() == expected => {
+            // No pre-delete: SqliteVecStore::insert wraps DELETE+INSERT in
+            // a single transaction so a failed INSERT rolls back the DELETE
+            // and the prior vector survives (no-worse-than-stale). A separate
+            // committed delete before insert re-introduces the stranding window.
+            for (id, emb) in ids.into_iter().zip(embeddings.iter()) {
+                if let Err(e) = vectors
+                    .insert(id, kind, namespace, field, vec![emb.clone()])
+                    .await
+                {
+                    tracing::warn!(id = %id, model = %model_name, error = %e, "vector insert failed");
+                    errors += 1;
+                }
+            }
+        }
+        Ok(_) => {
+            tracing::warn!(model = %model_name, "embedding count mismatch for batch");
+            errors += expected as u64;
+        }
+        Err(e) => {
+            tracing::warn!(model = %model_name, error = %e, "embed_batch failed");
+            errors += expected as u64;
         }
     }
     errors
+}
+
+fn bounded_joined_embedding_input(first: &str, second: Option<&str>, budget: usize) -> String {
+    let (first, first_truncated) = bounded_embedding_input(first, budget);
+    let mut staged = String::with_capacity(budget.min(first.len().saturating_add(1)));
+    staged.push_str(first);
+    if first_truncated || staged.len() >= budget {
+        return staged;
+    }
+    if let Some(second) = second.filter(|value| !value.is_empty()) {
+        staged.push(' ');
+        let (second, _) = bounded_embedding_input(second, budget.saturating_sub(staged.len()));
+        staged.push_str(second);
+    }
+    staged
+}
+
+fn stage_entity_embedding_batch(batch: &[Entity], model_name: &str) -> Vec<(Uuid, String)> {
+    let budget = document_embedding_budget(model_name);
+    batch
+        .iter()
+        .filter(|entity| {
+            !entity.name.trim().is_empty()
+                || entity
+                    .description
+                    .as_deref()
+                    .is_some_and(|description| !description.trim().is_empty())
+        })
+        .map(|entity| {
+            (
+                entity.id,
+                bounded_joined_embedding_input(&entity.name, entity.description.as_deref(), budget),
+            )
+        })
+        .collect()
+}
+
+fn stage_note_embedding_batch(batch: &[Note], model_name: &str) -> Vec<(Uuid, String)> {
+    let budget = document_embedding_budget(model_name);
+    batch
+        .iter()
+        .filter(|note| !note.content.trim().is_empty())
+        .map(|note| {
+            let (text, _) = bounded_embedding_input(&note.content, budget);
+            (note.id, text.to_owned())
+        })
+        .collect()
 }
 
 /// Upsert FTS documents for a batch of notes into the namespace text index. Returns the
@@ -419,8 +465,7 @@ fn vector_table_name(model_key: &str) -> Result<String> {
 async fn missing_embedding_batch(
     rt: &KhiveRuntime,
     namespace: &str,
-    vector_table: &str,
-    embedding_model: &str,
+    target: &RepairModelTarget,
     kind: SubstrateKind,
     after: &str,
     limit: u32,
@@ -440,10 +485,11 @@ async fn missing_embedding_batch(
         "SELECT {select} FROM {table} AS base \
          WHERE base.namespace = ?1 AND base.deleted_at IS NULL AND base.id > ?2 \
          AND {text_predicate} \
-         AND NOT EXISTS (SELECT 1 FROM {vector_table} AS vectors \
+         AND NOT EXISTS (SELECT 1 FROM {} AS vectors \
              WHERE vectors.subject_id = base.id AND vectors.namespace = ?1 \
              AND vectors.embedding_model = ?3) \
-         ORDER BY base.id LIMIT ?4"
+         ORDER BY base.id LIMIT ?4",
+        target.vector_table
     );
     let rows = {
         let mut reader = rt
@@ -457,7 +503,7 @@ async fn missing_embedding_batch(
                 params: vec![
                     SqlValue::Text(namespace.to_string()),
                     SqlValue::Text(after.to_string()),
-                    SqlValue::Text(embedding_model.to_string()),
+                    SqlValue::Text(target.embedding_model.clone()),
                     SqlValue::Integer(i64::from(limit)),
                 ],
                 label: Some("reindex_missing_embeddings".into()),
@@ -466,11 +512,12 @@ async fn missing_embedding_batch(
             .context("select rows missing embeddings")?
     };
 
+    let budget = document_embedding_budget(&target.model_name);
     rows.into_iter()
         .map(|row| {
             let text = |name: &str| match row.get(name) {
-                Some(SqlValue::Text(value)) => Ok(value.clone()),
-                Some(SqlValue::Null) => Ok(String::new()),
+                Some(SqlValue::Text(value)) => Ok(value.as_str()),
+                Some(SqlValue::Null) => Ok(""),
                 _ => anyhow::bail!("missing or invalid {name} in embeds-only row"),
             };
             let id = text("id")?
@@ -480,13 +527,11 @@ async fn missing_embedding_batch(
                 SubstrateKind::Entity => {
                     let name = text("name")?;
                     let description = text("description")?;
-                    if description.is_empty() {
-                        name
-                    } else {
-                        format!("{name} {description}")
-                    }
+                    bounded_joined_embedding_input(name, Some(description), budget)
                 }
-                SubstrateKind::Note => text("content")?,
+                SubstrateKind::Note => bounded_embedding_input(text("content")?, budget)
+                    .0
+                    .to_owned(),
                 _ => unreachable!("kind checked above"),
             };
             Ok((id, content))
@@ -565,35 +610,29 @@ async fn repair_missing_embeddings(
         ] {
             let mut after = String::new();
             loop {
-                let batch = missing_embedding_batch(
-                    rt,
-                    namespace,
-                    &target.vector_table,
-                    &target.embedding_model,
-                    kind,
-                    &after,
-                    batch_size,
-                )
-                .await?;
+                let batch =
+                    missing_embedding_batch(rt, namespace, &target, kind, &after, batch_size)
+                        .await?;
                 let Some((last_id, _)) = batch.last() else {
                     break;
                 };
                 after = last_id.to_string();
+                let batch_len = batch.len() as u64;
                 // A selected subject may still have a stale row in another namespace.
                 errors += embed_and_store_batch(
                     rt,
                     token,
-                    std::slice::from_ref(&target.model_name),
+                    &target.model_name,
                     namespace,
-                    &batch,
+                    batch,
                     kind,
                     field,
                     true,
                 )
                 .await;
                 match kind {
-                    SubstrateKind::Entity => entities_processed += batch.len() as u64,
-                    SubstrateKind::Note => notes_processed += batch.len() as u64,
+                    SubstrateKind::Entity => entities_processed += batch_len,
+                    SubstrateKind::Note => notes_processed += batch_len,
                     _ => unreachable!("repair kinds are fixed above"),
                 }
             }
@@ -708,31 +747,31 @@ pub async fn run_reindex(args: ReindexArgs) -> Result<()> {
                 break;
             }
 
-            let mut staged: Vec<(Uuid, String)> = Vec::with_capacity(n);
-            for entity in &batch {
-                let text = match &entity.description {
-                    Some(d) if !d.is_empty() => format!("{} {}", entity.name, d),
-                    _ => entity.name.clone(),
-                };
-                if !text.trim().is_empty() {
-                    staged.push((entity.id, text));
-                }
-            }
-
-            if !staged.is_empty() {
+            let staged_count = batch
+                .iter()
+                .filter(|entity| {
+                    !entity.name.trim().is_empty()
+                        || entity
+                            .description
+                            .as_deref()
+                            .is_some_and(|description| !description.trim().is_empty())
+                })
+                .count();
+            for model_name in &model_names {
+                let staged = stage_entity_embedding_batch(&batch, model_name);
                 errors_skipped += embed_and_store_batch(
                     &rt,
                     &token,
-                    &model_names,
+                    model_name,
                     &ns_str,
-                    &staged,
+                    staged,
                     SubstrateKind::Entity,
                     "entity.body",
                     drop_existing,
                 )
                 .await;
-                entities_processed += staged.len() as u64;
             }
+            entities_processed += staged_count as u64;
 
             // FTS backfill: index every entity in this batch regardless of whether
             // it had content to embed. Mirrors the upsert_document call in
@@ -764,28 +803,25 @@ pub async fn run_reindex(args: ReindexArgs) -> Result<()> {
                 break;
             }
 
-            let mut staged: Vec<(Uuid, String)> = Vec::with_capacity(n);
-            for note in &batch {
-                let text = note.content.clone();
-                if !text.trim().is_empty() {
-                    staged.push((note.id, text));
-                }
-            }
-
-            if !staged.is_empty() {
+            let staged_count = batch
+                .iter()
+                .filter(|note| !note.content.trim().is_empty())
+                .count();
+            for model_name in &model_names {
+                let staged = stage_note_embedding_batch(&batch, model_name);
                 errors_skipped += embed_and_store_batch(
                     &rt,
                     &token,
-                    &model_names,
+                    model_name,
                     &ns_str,
-                    &staged,
+                    staged,
                     SubstrateKind::Note,
                     "note.content",
                     drop_existing,
                 )
                 .await;
-                notes_processed += staged.len() as u64;
             }
+            notes_processed += staged_count as u64;
 
             // FTS backfill: index every note in this batch regardless of whether
             // it had content to embed. Mirrors the upsert_document call in
@@ -1488,10 +1524,14 @@ mod tests {
             .await
             .expect("seed vector");
 
-        let selected =
-            missing_embedding_batch(&rt, "local", TABLE, MODEL, SubstrateKind::Note, "", 100)
-                .await
-                .expect("select missing notes");
+        let target = RepairModelTarget {
+            model_name: MODEL.to_string(),
+            embedding_model: MODEL.to_string(),
+            vector_table: TABLE.to_string(),
+        };
+        let selected = missing_embedding_batch(&rt, "local", &target, SubstrateKind::Note, "", 100)
+            .await
+            .expect("select missing notes");
 
         assert_eq!(selected, vec![(missing.id, missing.content)]);
     }
@@ -2116,6 +2156,48 @@ mod tests {
         let doc = note_fts_document(&note);
         assert!(doc.title.is_none());
         assert_eq!(doc.body, "body only content");
+    }
+
+    #[tokio::test]
+    async fn note_embedding_staging_is_bounded_while_fts_receives_full_content() {
+        const TAIL_SENTINEL: &str = "full-content-tail-sentinel";
+
+        // The same full record page feeds both bounded embedding staging and FTS.
+        let rt = KhiveRuntime::memory().expect("in-memory runtime");
+        let token = rt
+            .authorize(Namespace::parse("local").expect("namespace"))
+            .expect("authorize");
+        let content = format!(
+            "{}{TAIL_SENTINEL}",
+            "a".repeat(lattice_embed::MAX_TEXT_CHARS)
+        );
+        let notes = vec![Note::new("local", "observation", content.clone())];
+
+        let staged = stage_note_embedding_batch(&notes, REPAIR_MODEL);
+        assert_eq!(staged.len(), 1);
+        assert_eq!(
+            staged[0].1.len(),
+            khive_runtime::retrieval::document_embedding_budget(REPAIR_MODEL)
+        );
+        assert!(!staged[0].1.contains(TAIL_SENTINEL));
+        assert_eq!(notes[0].content, content, "source batch must remain full");
+
+        let errors = fts_backfill_notes_batch(&rt, &token, &notes).await;
+        assert_eq!(errors, 0);
+        let hits = rt
+            .text_for_notes(&token)
+            .expect("note FTS")
+            .search(khive_storage::types::TextSearchRequest {
+                query: TAIL_SENTINEL.to_string(),
+                mode: khive_storage::types::TextQueryMode::Plain,
+                filter: None,
+                top_k: 10,
+                snippet_chars: 0,
+            })
+            .await
+            .expect("search full FTS content");
+        assert_eq!(hits.len(), 1, "FTS must receive the unbounded note body");
+        assert_eq!(hits[0].subject_id, notes[0].id);
     }
 
     // Regression: insert N notes via NoteStore (bypassing FTS), run


### PR DESCRIPTION
A note/entity create whose embedding text exceeded the embedder maximum (32768 chars) hard-failed the whole write — long-form bodies could not be persisted at all (#1043).

## Change

- `embed_document_with_model` / `embed_document_batch_with_model` (the seam every write, update, reindex, backfill, and repair path reaches) now bound the transient embedder input via a shared helper: UTF-8 char-boundary truncation, limit reused from `lattice_embed::MAX_TEXT_CHARS` (no local copy), budget reduced by any model document-instruction prefix so the service's own prefixing cannot push it back over.
- Stored records and FTS documents keep the complete original body; only the embedder input is bounded. Chunk-and-pool embedding is explicitly out of scope.
- Create responses carry the advisory in the existing optional `warnings` array only when a registered write embedder actually receives bounded text.
- The reindex CLI previously applied its own truncation helper with a duplicated numeric limit; that helper is removed and staged text flows through the shared bounded seam.

## Regressions

Over-length note create persists with full retrievable content, a valid vector row, and the advisory; a multi-byte char straddling the cut is never split; normal-length input reaches the embedder byte-identically (pointer-equal) with no advisory; over-length entity create succeeds; reindex of the same stored body passes through both single and batch seams.

Closes #1043

🤖 Generated with [Claude Code](https://claude.com/claude-code)