### PR TITLE
fix(build): honor CARGO_TARGET_DIR in make local install source

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,7 @@ bench-1m-ci:
 
 local:
 	@echo "==> Building kkernel (release)..."
-	@cd crates && cargo build --release -p kkernel
+	@cargo build --release -p kkernel --manifest-path crates/Cargo.toml
 	@SRC=$${CARGO_TARGET_DIR:-crates/target}/release/kkernel; \
 	DEST=$$HOME/.cargo/bin/kkernel; \
 	if [ ! -f "$$SRC" ]; then echo "==> ERROR: build artifact $$SRC missing"; exit 1; fi; \

--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,7 @@ bench-1m-ci:
 local:
 	@echo "==> Building kkernel (release)..."
 	@cd crates && cargo build --release -p kkernel
-	@SRC=crates/target/release/kkernel; \
+	@SRC=$${CARGO_TARGET_DIR:-crates/target}/release/kkernel; \
 	DEST=$$HOME/.cargo/bin/kkernel; \
 	if [ ! -f "$$SRC" ]; then echo "==> ERROR: build artifact $$SRC missing"; exit 1; fi; \
 	SRC_HASH=$$(md5 -q "$$SRC"); \


### PR DESCRIPTION
Closes #1346.

make local builds via cargo (which honors CARGO_TARGET_DIR) but installed from a hardcoded crates/target/release path. With CARGO_TARGET_DIR set, the freshly built binary lands in the configured directory while the install step ships a stale artifact from the default path — exit code 0, no warning. The install source now resolves ${CARGO_TARGET_DIR:-crates/target}/release/kkernel; if the artifact is missing there, the existing check fails loudly instead of installing something stale.

🤖 Generated with [Claude Code](https://claude.com/claude-code)