### PR TITLE
fix(db): honor ADR-039 DO NOTHING on update_edge's symmetric-conflict path

### DIFF
--- a/crates/khive-db/src/stores/graph.rs
+++ b/crates/khive-db/src/stores/graph.rs
@@ -340,7 +340,7 @@ pub fn edge_symmetric_update_inplace_statement(
 // 1. [`edge_symmetric_delete_if_conflict_statement`]: deletes the requested
 //    (non-canonical) row IF AND ONLY IF a differently-id'd canonical row
 //    exists at the target natural key at THIS moment (guard: 0 or 1 rows).
-// 2. [`edge_symmetric_refresh_or_update_inplace_statement`]: a single
+// 2. [`edge_symmetric_absorb_or_update_inplace_statement`]: a single
 //    `UPDATE` that no longer trusts an `id = ?2 OR natural-key` predicate
 //    (ADR-099 §B3 — that predicate could
 //    match the WRONG row: if a different op earlier in the SAME atomic unit
@@ -356,7 +356,8 @@ pub fn edge_symmetric_update_inplace_statement(
 //      requested row is still live under its own id — update it in place.
 //    - `source_id = ?3 AND target_id = ?4 AND relation = ?5 AND id != ?2
 //      AND changes() = 1`: statement 1 just deleted the requested row
-//      BECAUSE a conflict existed — refresh that surviving canonical row.
+//      BECAUSE a conflict existed — match the surviving canonical row and
+//      leave its attributes unchanged (ADR-039 DO NOTHING; see below).
 //    These two arms are mutually exclusive and, together with statement 1's
 //    own guard, jointly exhaustive: if the requested row no longer existed
 //    when statement 1 ran (the same-unit race above), statement 1 affects 0
@@ -384,9 +385,10 @@ pub fn edge_symmetric_update_inplace_statement(
 //
 // No probe, no branch, no read at all is needed to APPLY this pair. Which
 // row this plan actually touched is derived post-commit by the caller via a
-// fresh natural-key lookup (`khive-runtime::KhiveRuntime::list_edges`,
-// filtered on the canonicalized endpoints/relation — the same mechanism the
-// atomic `link` op's own result rendering already uses) — ADR-099 §B3
+// fresh natural-key lookup (`khive-runtime::KhiveRuntime::get_edge_by_natural_key_including_deleted`,
+// filtered on the canonicalized endpoints/relation and including soft-deleted rows — unlike
+// `list_edges`, which unconditionally filters `deleted_at IS NULL` and would report "not
+// found" for a surviving row this absorption arm left tombstoned) — ADR-099 §B3
 // removed the prior prepare-time advisory `target_id` probe entirely:
 // a value computed before the
 // SAME atomic unit's other ops have run is not a fact this plan can stand
@@ -419,7 +421,7 @@ pub fn edge_symmetric_delete_if_conflict_statement(
 }
 
 #[allow(clippy::too_many_arguments)]
-pub fn edge_symmetric_refresh_or_update_inplace_statement(
+pub fn edge_symmetric_absorb_or_update_inplace_statement(
     namespace: &str,
     id: Uuid,
     canon_src: Uuid,
@@ -464,7 +466,7 @@ pub fn edge_symmetric_refresh_or_update_inplace_statement(
                 None => SqlValue::Null,
             },
         ],
-        label: Some("edge-symmetric-refresh-or-update-inplace".to_string()),
+        label: Some("edge-symmetric-absorb-or-update-inplace".to_string()),
     }
 }
 
@@ -1277,11 +1279,12 @@ impl GraphStore for SqlGraphStore {
 
     async fn get_edge_by_natural_key_including_deleted(
         &self,
+        namespace: &str,
         source_id: Uuid,
         target_id: Uuid,
         relation: EdgeRelation,
     ) -> Result<Option<Edge>, StorageError> {
-        let namespace = self.namespace.clone();
+        let namespace = namespace.to_string();
         let source_str = source_id.to_string();
         let target_str = target_id.to_string();
         let relation_str = relation.to_string();

--- a/crates/khive-db/src/stores/graph.rs
+++ b/crates/khive-db/src/stores/graph.rs
@@ -1275,6 +1275,38 @@ impl GraphStore for SqlGraphStore {
         .await
     }
 
+    async fn get_edge_by_natural_key_including_deleted(
+        &self,
+        source_id: Uuid,
+        target_id: Uuid,
+        relation: EdgeRelation,
+    ) -> Result<Option<Edge>, StorageError> {
+        let namespace = self.namespace.clone();
+        let source_str = source_id.to_string();
+        let target_str = target_id.to_string();
+        let relation_str = relation.to_string();
+
+        self.with_reader("get_edge_by_natural_key_including_deleted", move |conn| {
+            let mut stmt = conn.prepare(
+                "SELECT namespace, id, source_id, target_id, relation, weight, \
+                        created_at, updated_at, deleted_at, metadata, target_backend \
+                 FROM graph_edges \
+                 WHERE namespace = ?1 AND source_id = ?2 AND target_id = ?3 AND relation = ?4",
+            )?;
+            let mut rows = stmt.query(rusqlite::params![
+                namespace,
+                source_str,
+                target_str,
+                relation_str
+            ])?;
+            match rows.next()? {
+                Some(row) => Ok(Some(read_edge(row)?)),
+                None => Ok(None),
+            }
+        })
+        .await
+    }
+
     async fn get_edges(&self, ids: &[LinkId]) -> Result<Vec<Edge>, StorageError> {
         if ids.is_empty() {
             return Ok(Vec::new());

--- a/crates/khive-db/src/stores/graph.rs
+++ b/crates/khive-db/src/stores/graph.rs
@@ -238,11 +238,6 @@ pub const EDGE_SYMMETRIC_CONFLICT_PROBE_SQL: &str = "SELECT id FROM graph_edges 
 pub const EDGE_SYMMETRIC_DELETE_NONCANONICAL_SQL: &str =
     "DELETE FROM graph_edges WHERE namespace = ?1 AND id = ?2";
 
-pub const EDGE_SYMMETRIC_REFRESH_CANONICAL_SQL: &str = "UPDATE graph_edges SET \
-     weight = ?1, updated_at = ?2, deleted_at = NULL, \
-     target_backend = ?3, metadata = ?4 \
-     WHERE namespace = ?5 AND id = ?6";
-
 pub const EDGE_SYMMETRIC_UPDATE_INPLACE_SQL: &str = "UPDATE graph_edges SET \
      source_id = ?1, target_id = ?2, relation = ?3, \
      weight = ?4, updated_at = ?5, metadata = ?6 \
@@ -280,37 +275,6 @@ pub fn edge_symmetric_delete_noncanonical_statement(namespace: &str, id: Uuid) -
             SqlValue::Text(id.to_string()),
         ],
         label: Some("edge-symmetric-delete-noncanonical".to_string()),
-    }
-}
-
-/// Plan-shape builder for [`EDGE_SYMMETRIC_REFRESH_CANONICAL_SQL`] —
-/// case (b) continued: refresh the surviving canonical row.
-#[allow(clippy::too_many_arguments)]
-pub fn edge_symmetric_refresh_canonical_statement(
-    namespace: &str,
-    existing_id: Uuid,
-    weight: f64,
-    updated_at_micros: i64,
-    target_backend: Option<&str>,
-    metadata: Option<&str>,
-) -> SqlStatement {
-    SqlStatement {
-        sql: EDGE_SYMMETRIC_REFRESH_CANONICAL_SQL.to_string(),
-        params: vec![
-            SqlValue::Float(weight),
-            SqlValue::Integer(updated_at_micros),
-            match target_backend {
-                Some(b) => SqlValue::Text(b.to_string()),
-                None => SqlValue::Null,
-            },
-            match metadata {
-                Some(m) => SqlValue::Text(m.to_string()),
-                None => SqlValue::Null,
-            },
-            SqlValue::Text(namespace.to_string()),
-            SqlValue::Text(existing_id.to_string()),
-        ],
-        label: Some("edge-symmetric-refresh-canonical".to_string()),
     }
 }
 
@@ -401,13 +365,22 @@ pub fn edge_symmetric_update_inplace_statement(
 //    `changes() = 1` guard is false — so this statement affects ZERO rows
 //    and the plan's `AffectedRowGuard::exactly(1)` on it fails the op,
 //    aborting the whole atomic unit rather than silently mutating an
-//    unrelated row. `target_backend` is updated only in the natural-key
-//    (absorbed-conflict) arm — the same `changes() = 1` condition, via a
-//    `CASE`, replicating [`EDGE_SYMMETRIC_UPDATE_INPLACE_SQL`]'s "leave
-//    `target_backend` untouched" behavior for the in-place case with the
-//    SAME statement that also replicates
-//    [`EDGE_SYMMETRIC_REFRESH_CANONICAL_SQL`]'s explicit `target_backend`
-//    set for the absorbed case.
+//    unrelated row.
+//
+//    ADR-039's edge-conflict contract is ON CONFLICT DO NOTHING: the
+//    natural-key (absorbed-conflict) arm must leave the surviving canonical
+//    row's attributes exactly as they were — refreshing them from the
+//    discarded edge (and forcing `deleted_at = NULL`, resurrecting a
+//    tombstone) is the same defect already fixed on the merge-rewire path
+//    (khive#1213). Every SET expression is therefore keyed on `id = ?2`:
+//    that condition is true only for the WHERE clause's first (in-place)
+//    arm — the second (absorbed) arm only ever matches a row whose id is
+//    NOT ?2 — so each column either takes its new value (in-place arm) or
+//    self-assigns its current value (absorbed arm, a true no-op). This
+//    still affects exactly one row either way (SQLite's `changes()` counts
+//    matched rows, not changed bytes), so `AffectedRowGuard::exactly(1)`
+//    and the race-abort behavior above are unaffected by this being a
+//    no-op write in the absorbed case.
 //
 // No probe, no branch, no read at all is needed to APPLY this pair. Which
 // row this plan actually touched is derived post-commit by the caller via a
@@ -459,9 +432,14 @@ pub fn edge_symmetric_refresh_or_update_inplace_statement(
 ) -> SqlStatement {
     SqlStatement {
         sql: "UPDATE graph_edges SET \
-              source_id = ?3, target_id = ?4, relation = ?5, \
-              weight = ?6, updated_at = ?7, deleted_at = NULL, metadata = ?8, \
-              target_backend = CASE WHEN changes() = 1 THEN ?9 ELSE target_backend END \
+              source_id = CASE WHEN id = ?2 THEN ?3 ELSE source_id END, \
+              target_id = CASE WHEN id = ?2 THEN ?4 ELSE target_id END, \
+              relation = CASE WHEN id = ?2 THEN ?5 ELSE relation END, \
+              weight = CASE WHEN id = ?2 THEN ?6 ELSE weight END, \
+              updated_at = CASE WHEN id = ?2 THEN ?7 ELSE updated_at END, \
+              deleted_at = CASE WHEN id = ?2 THEN NULL ELSE deleted_at END, \
+              metadata = CASE WHEN id = ?2 THEN ?8 ELSE metadata END, \
+              target_backend = CASE WHEN id = ?2 THEN ?9 ELSE target_backend END \
               WHERE namespace = ?1 \
                 AND ( \
                   (id = ?2 AND changes() = 0) \

--- a/crates/khive-pack-kg/src/handlers/tests.rs
+++ b/crates/khive-pack-kg/src/handlers/tests.rs
@@ -1041,6 +1041,76 @@ async fn update_edge_with_non_edge_field_returns_error() {
     );
 }
 
+// khive#1213: `update(id=<edge>, relation="competes_with", ...)` that collides with an
+// already soft-deleted canonical survivor must return that survivor as-is — including its
+// non-null `deleted_at` — rather than resurrecting the tombstone (ADR-039 DO NOTHING).
+#[tokio::test]
+async fn update_edge_symmetric_conflict_returns_tombstoned_survivor_with_deleted_at() {
+    use crate::KgPack;
+    use khive_runtime::{KhiveRuntime, VerbRegistryBuilder};
+    use khive_types::EdgeRelation;
+
+    let rt = KhiveRuntime::memory().expect("in-memory runtime");
+    let token = rt.authorize(khive_runtime::Namespace::local()).unwrap();
+
+    let a = rt
+        .create_entity(&token, "concept", None, "A", None, None, vec![])
+        .await
+        .expect("create a");
+    let b = rt
+        .create_entity(&token, "concept", None, "B", None, None, vec![])
+        .await
+        .expect("create b");
+
+    let requested = rt
+        .link(&token, a.id, b.id, EdgeRelation::Extends, 0.2, None)
+        .await
+        .expect("create requested edge");
+
+    let canonical = rt
+        .link(&token, a.id, b.id, EdgeRelation::CompetesWith, 0.6, None)
+        .await
+        .expect("create canonical edge");
+    rt.delete_edge(&token, canonical.id.into(), false)
+        .await
+        .expect("soft-delete canonical edge");
+
+    let pack = KgPack::new(rt.clone());
+    let mut builder = VerbRegistryBuilder::new();
+    builder.register(KgPack::new(rt.clone()));
+    let registry = builder.build().expect("registry build");
+
+    let result = pack
+        .handle_update(
+            &token,
+            json!({
+                "id": requested.id.to_string(),
+                "relation": "competes_with",
+                "weight": 0.9,
+            }),
+            &registry,
+        )
+        .await
+        .expect("update must succeed by absorbing into the tombstoned survivor");
+
+    let returned_id = result["id"].as_str().expect("returned id");
+    assert_eq!(
+        returned_id,
+        canonical.id.to_string(),
+        "the returned edge must be the surviving canonical row, not the discarded request: {result}"
+    );
+    assert!(
+        !result["deleted_at"].is_null(),
+        "the returned edge must retain the survivor's non-null deleted_at — absorbing a \
+         conflicting update must not resurrect a tombstone: {result}"
+    );
+    assert_eq!(
+        result["weight"], 0.6,
+        "the survivor's own weight must be preserved, not overwritten by the discarded \
+         request's patch: {result}"
+    );
+}
+
 // HIGH regression: update(note_id, tags=[...]) must return an explicit error.
 // Notes have no top-level tags column; tags live in properties["tags"].
 // Before the fix, tags was silently dropped on the note path (the error string

--- a/crates/khive-runtime/src/atomic_plan.rs
+++ b/crates/khive-runtime/src/atomic_plan.rs
@@ -147,14 +147,16 @@ pub enum PostCommitEffect {
 
 /// The natural key a committed symmetric edge update's surviving row must
 /// be looked up by (ADR-099 B3, second
-/// half). `khive-db`'s `edge_symmetric_refresh_or_update_inplace_statement`
+/// half). `khive-db`'s `edge_symmetric_absorb_or_update_inplace_statement`
 /// pair never trusts a prepare-time-computed target id (see that builder's
 /// doc comment); a caller rendering this op's result derives the actual
 /// surviving id by querying `graph_edges`'s own
-/// `UNIQUE(namespace, source_id, target_id, relation)` constraint (e.g. via
-/// `KhiveRuntime::list_edges` filtered on these fields — the same mechanism
-/// the atomic `link` op's own result rendering already uses), strictly
-/// after commit.
+/// `UNIQUE(namespace, source_id, target_id, relation)` constraint via
+/// `KhiveRuntime::get_edge_by_natural_key_including_deleted`, which — unlike
+/// `list_edges` — includes soft-deleted rows: the ADR-039 DO NOTHING absorption
+/// arm can commit leaving the surviving canonical row tombstoned
+/// (khive#1213/#1214), and `list_edges` would report "not found" for exactly
+/// that row. Looked up strictly after commit.
 #[derive(Debug, Clone)]
 pub struct EdgeNaturalKey {
     pub(crate) namespace: String,

--- a/crates/khive-runtime/src/atomic_prepare.rs
+++ b/crates/khive-runtime/src/atomic_prepare.rs
@@ -43,8 +43,8 @@ use khive_db::stores::entity::{
 use khive_db::stores::event::event_insert_statements;
 use khive_db::stores::graph::{
     edge_hard_delete_statement, edge_insert_guarded_by_endpoints_statement,
-    edge_soft_delete_statement, edge_symmetric_delete_if_conflict_statement,
-    edge_symmetric_refresh_or_update_inplace_statement, edge_upsert_statement,
+    edge_soft_delete_statement, edge_symmetric_absorb_or_update_inplace_statement,
+    edge_symmetric_delete_if_conflict_statement, edge_upsert_statement,
     purge_incident_edges_statement,
 };
 use khive_db::stores::note::{
@@ -842,7 +842,7 @@ pub async fn prepare_update_entity_plan(
 /// op in the same atomic unit could change the conflict landscape between
 /// probe and commit, making any such branch stale by construction. It always
 /// emits BOTH statements from [`edge_symmetric_delete_if_conflict_statement`]
-/// and [`edge_symmetric_refresh_or_update_inplace_statement`], each carrying
+/// and [`edge_symmetric_absorb_or_update_inplace_statement`], each carrying
 /// its own commit-time `WHERE`/`CASE WHEN` predicate that re-evaluates the
 /// conflict condition fresh inside the transaction. This function reads no
 /// state to guess a surviving id; the plan instead carries `edge_natural_key`
@@ -930,7 +930,7 @@ async fn prepare_update_edge(
             }),
         });
         statements.push(PlanStatement {
-            statement: edge_symmetric_refresh_or_update_inplace_statement(
+            statement: edge_symmetric_absorb_or_update_inplace_statement(
                 &namespace,
                 id,
                 canon_src,

--- a/crates/khive-runtime/src/atomic_prepare.rs
+++ b/crates/khive-runtime/src/atomic_prepare.rs
@@ -2903,8 +2903,10 @@ mod tests {
     /// (b): changing a non-symmetric edge's `relation` to a symmetric one
     /// whose canonical natural key collides with an ALREADY-EXISTING
     /// symmetric edge between the same two entities must delete the
-    /// requested (non-canonical) row and refresh the surviving canonical
-    /// row in place, rather than raising a uniqueness error.
+    /// requested (non-canonical) row and leave the surviving canonical row
+    /// untouched (ADR-039 ON CONFLICT DO NOTHING), rather than raising a
+    /// uniqueness error OR overwriting the survivor with the discarded
+    /// edge's attributes (khive#1213).
     #[tokio::test]
     async fn atomic_update_edge_symmetric_conflict_absorbs_into_surviving_row() {
         let runtime = scratch_runtime();
@@ -2985,13 +2987,18 @@ mod tests {
             "the non-canonical requested row must be deleted, not just tombstoned"
         );
 
-        // The surviving canonical row must carry the patch.
+        // ADR-039 DO NOTHING: the surviving canonical row keeps its OWN
+        // pre-existing attributes — the discarded edge's patched weight
+        // (0.9) must never overwrite it.
         let surviving = runtime
             .get_edge(&token, canonical_id)
             .await
             .expect("get_edge")
             .expect("surviving canonical row must remain");
-        assert_eq!(surviving.weight, 0.9);
+        assert_eq!(
+            surviving.weight, 0.6,
+            "survivor weight must not be overwritten by the discarded edge's patch"
+        );
         assert_eq!(surviving.relation, EdgeRelation::CompetesWith);
 
         // Event target is the CALLER-supplied id, not the surviving id —
@@ -3000,6 +3007,78 @@ mod tests {
         let events =
             events_for_target(&runtime, &token, requested_id, EventKind::EdgeUpdated).await;
         assert_eq!(events.len(), 1);
+    }
+
+    /// A soft-deleted surviving canonical row must not be resurrected by a
+    /// conflicting symmetric-relation update (ADR-039 DO NOTHING; khive#1213):
+    /// the requested edge is still deleted (conflict absorbed), but the
+    /// tombstoned survivor must stay tombstoned.
+    #[tokio::test]
+    async fn atomic_update_edge_symmetric_conflict_does_not_resurrect_tombstoned_survivor() {
+        let runtime = scratch_runtime();
+        let token = runtime
+            .authorize(Namespace::parse("local").expect("ns"))
+            .expect("authorize");
+        let entities = runtime.entities(&token).expect("entities store");
+        let a = khive_storage::Entity::new("local", "concept", "GapEdgeSymTombA");
+        let b = khive_storage::Entity::new("local", "concept", "GapEdgeSymTombB");
+        let (a_id, b_id) = (a.id, b.id);
+        entities.upsert_entity(a).await.expect("seed a");
+        entities.upsert_entity(b).await.expect("seed b");
+
+        let requested_edge = runtime
+            .link(&token, a_id, b_id, EdgeRelation::Extends, 0.2, None)
+            .await
+            .expect("seed requested edge");
+        let requested_id = Uuid::from(requested_edge.id);
+
+        let canonical_edge = runtime
+            .link(&token, a_id, b_id, EdgeRelation::CompetesWith, 0.6, None)
+            .await
+            .expect("seed canonical edge");
+        let canonical_id = Uuid::from(canonical_edge.id);
+        runtime
+            .delete_edge(&token, canonical_id, false)
+            .await
+            .expect("soft-delete canonical edge");
+
+        let plan = prepare_update(
+            &runtime,
+            &token,
+            &json!({"id": requested_id.to_string(), "relation": "competes_with", "weight": 0.9}),
+            None,
+        )
+        .await
+        .expect("prepare update edge (symmetric conflict over tombstone)");
+
+        let outcome = crate::atomic_runner::run_atomic_unit(runtime.sql().as_ref(), vec![plan])
+            .await
+            .expect("seam call ok");
+        assert!(
+            matches!(
+                outcome,
+                crate::atomic_runner::AtomicRunOutcome::Committed { .. }
+            ),
+            "expected a clean symmetric-conflict-absorption commit: {outcome:?}"
+        );
+
+        let requested_after = runtime
+            .get_edge_including_deleted(&token, requested_id)
+            .await
+            .expect("get_edge_including_deleted");
+        assert!(
+            requested_after.is_none(),
+            "the non-canonical requested row must be deleted, not just tombstoned"
+        );
+
+        let canonical_after = runtime
+            .get_edge(&token, canonical_id)
+            .await
+            .expect("get_edge");
+        assert!(
+            canonical_after.is_none(),
+            "a tombstoned survivor must not be resurrected by a conflicting update"
+        );
     }
 
     /// The same-unit race: `[delete(X), update(X -> competes_with)]` where

--- a/crates/khive-runtime/src/operations.rs
+++ b/crates/khive-runtime/src/operations.rs
@@ -4452,16 +4452,24 @@ impl KhiveRuntime {
     /// survivor (ADR-039 DO NOTHING conflict absorption) — used by the atomic-apply
     /// post-commit result renderer, which otherwise reports "not found" for a committed
     /// update whose surviving row happens to be soft-deleted.
+    ///
+    /// `token` selects the store instance; `namespace` is the natural key's own
+    /// namespace and is bound into the query explicitly. These can legitimately differ:
+    /// the record namespace is fixed at prepare time (`EdgeNaturalKey::namespace`) and by-ID
+    /// edge updates are namespace-agnostic (ADR-007 Rev 6), so the caller's ambient `token`
+    /// namespace is never a safe substitute for the record's own — the prior implicit
+    /// `self.namespace` scoping is exactly the bug this parameter closes (khive#1213/#1214).
     pub async fn get_edge_by_natural_key_including_deleted(
         &self,
         token: &NamespaceToken,
+        namespace: &str,
         source_id: Uuid,
         target_id: Uuid,
         relation: EdgeRelation,
     ) -> RuntimeResult<Option<Edge>> {
         Ok(self
             .graph(token)?
-            .get_edge_by_natural_key_including_deleted(source_id, target_id, relation)
+            .get_edge_by_natural_key_including_deleted(namespace, source_id, target_id, relation)
             .await?)
     }
 
@@ -8536,6 +8544,74 @@ mod tests {
         let target_ids: Vec<Uuid> = neighbors.iter().map(|n| n.node_id).collect();
         assert!(target_ids.contains(&t1.id));
         assert!(target_ids.contains(&t2.id));
+    }
+
+    /// khive#1213/#1214 fix round: the atomic-apply post-commit renderer for a
+    /// symmetric-edge update resolves the surviving row's store by the CALLER's
+    /// token but must filter by the record's OWN namespace, passed explicitly —
+    /// never by re-deriving it from whichever token happened to select the store
+    /// (`self.graph(token)` scopes by `token.namespace()`, and by-ID edge updates
+    /// are namespace-agnostic, so a caller in one namespace can legitimately
+    /// commit an update against an edge recorded in another). This proves the
+    /// `namespace` parameter — not the `token` argument — decides which row the
+    /// natural-key lookup finds, at the level the review flagged as an
+    /// acceptable substitute for a full cross-namespace atomic-apply test.
+    #[tokio::test]
+    async fn get_edge_by_natural_key_including_deleted_honors_explicit_namespace_not_token() {
+        let rt = rt();
+        let ns_a = NamespaceToken::for_namespace(Namespace::parse("ns-a").unwrap());
+        let ns_b = NamespaceToken::for_namespace(Namespace::parse("ns-b").unwrap());
+
+        let a = rt
+            .create_entity(&ns_b, "concept", None, "A", None, None, vec![])
+            .await
+            .unwrap();
+        let b = rt
+            .create_entity(&ns_b, "concept", None, "B", None, None, vec![])
+            .await
+            .unwrap();
+        let edge = rt
+            .link(&ns_b, a.id, b.id, EdgeRelation::CompetesWith, 1.0, None)
+            .await
+            .unwrap();
+        let (canon_src, canon_tgt) =
+            canonical_edge_endpoints(EdgeRelation::CompetesWith, a.id, b.id);
+
+        // Caller token is ns-a (an unrelated namespace); passing "ns-b" explicitly
+        // must still find the edge recorded there.
+        let found = rt
+            .get_edge_by_natural_key_including_deleted(
+                &ns_a,
+                "ns-b",
+                canon_src,
+                canon_tgt,
+                EdgeRelation::CompetesWith,
+            )
+            .await
+            .unwrap();
+        assert_eq!(
+            found.map(|e| Uuid::from(e.id)),
+            Some(Uuid::from(edge.id)),
+            "must find the edge by its own namespace regardless of the caller's token"
+        );
+
+        // Passing the caller token's OWN namespace ("ns-a") as the explicit filter
+        // must NOT find it — proves the lookup is keyed on the `namespace` argument,
+        // not silently re-scoped to whatever namespace the token carries.
+        let not_found = rt
+            .get_edge_by_natural_key_including_deleted(
+                &ns_a,
+                "ns-a",
+                canon_src,
+                canon_tgt,
+                EdgeRelation::CompetesWith,
+            )
+            .await
+            .unwrap();
+        assert!(
+            not_found.is_none(),
+            "must not find an edge recorded in a different namespace than the one queried"
+        );
     }
 
     /// `link` endpoint existence is a by-ID check and therefore namespace-agnostic:

--- a/crates/khive-runtime/src/operations.rs
+++ b/crates/khive-runtime/src/operations.rs
@@ -4446,6 +4446,25 @@ impl KhiveRuntime {
             .await?)
     }
 
+    /// Fetch an edge by natural key (namespace, canonical source/target, relation)
+    /// including soft-deleted rows. Unlike [`Self::list_edges`]/[`Self::list_edges_after`],
+    /// which always filter `deleted_at IS NULL`, this can render a tombstoned symmetric-edge
+    /// survivor (ADR-039 DO NOTHING conflict absorption) — used by the atomic-apply
+    /// post-commit result renderer, which otherwise reports "not found" for a committed
+    /// update whose surviving row happens to be soft-deleted.
+    pub async fn get_edge_by_natural_key_including_deleted(
+        &self,
+        token: &NamespaceToken,
+        source_id: Uuid,
+        target_id: Uuid,
+        relation: EdgeRelation,
+    ) -> RuntimeResult<Option<Edge>> {
+        Ok(self
+            .graph(token)?
+            .get_edge_by_natural_key_including_deleted(source_id, target_id, relation)
+            .await?)
+    }
+
     /// Maximum rows returned by a single [`Self::list_edges`] /
     /// [`Self::list_edges_after`] page. A lower bound the docs promise callers
     /// can rely on; kept as a named constant so tests can exercise pagination
@@ -4709,8 +4728,9 @@ impl KhiveRuntime {
     /// For symmetric relations (`competes_with`, `composed_with`), endpoint order is
     /// canonicalised to `source_uuid < target_uuid` after validation. If a canonical
     /// row already exists at the target triple, the non-canonical edge is deleted and
-    /// the existing canonical row is refreshed (DELETE + UPDATE pattern, mirroring
-    /// `merge_entity_sql`).
+    /// the existing canonical row is preserved unchanged (ADR-039 ON CONFLICT DO
+    /// NOTHING, mirroring `merge_entity_sql`) — its attributes, including a soft-deleted
+    /// `deleted_at`, are never overwritten by the discarded edge's patch.
     pub async fn update_edge(
         &self,
         token: &NamespaceToken,

--- a/crates/khive-runtime/src/operations.rs
+++ b/crates/khive-runtime/src/operations.rs
@@ -4601,14 +4601,14 @@ impl KhiveRuntime {
     /// boundary — this function issues DML only, no `BEGIN`/`COMMIT`/`ROLLBACK`.
     ///
     /// Returns `Ok(Some(existing_id))` when a canonical conflict was absorbed (the
-    /// requested edge was deleted, the existing canonical row refreshed), or
-    /// `Ok(None)` when the requested edge was updated in place.
+    /// requested edge was deleted, the existing canonical row left untouched per
+    /// ADR-039 DO NOTHING), or `Ok(None)` when the requested edge was updated in
+    /// place.
     ///
     /// DML text is the single source of truth shared with the atomic
     /// `prepare_update_edge` symmetric branch:
     /// [`khive_db::stores::graph::EDGE_SYMMETRIC_CONFLICT_PROBE_SQL`] /
     /// `EDGE_SYMMETRIC_DELETE_NONCANONICAL_SQL` /
-    /// `EDGE_SYMMETRIC_REFRESH_CANONICAL_SQL` /
     /// `EDGE_SYMMETRIC_UPDATE_INPLACE_SQL` — this function binds them against
     /// `rusqlite::params!` (it runs inside an existing transaction on a
     /// borrowed `&rusqlite::Connection`), the atomic path binds the same text
@@ -4624,7 +4624,6 @@ impl KhiveRuntime {
         relation_str: &str,
         weight: f64,
         metadata: Option<String>,
-        target_backend: Option<String>,
     ) -> Result<Option<String>, SqliteError> {
         // `updated_at` is stored in MICROSECONDS on `graph_edges` (every other
         // write path — `edge_upsert_statement`, `edge_soft_delete_statement` —
@@ -4653,25 +4652,22 @@ impl KhiveRuntime {
             .map_err(SqliteError::Rusqlite)?;
 
         if let Some(existing_id) = conflict_id {
-            // Case (b): canonical row already exists — delete the non-canonical
-            // edge and refresh the existing canonical row. Return the surviving
-            // id so the caller can re-fetch it (never the deleted edge's id).
+            // Case (b): canonical row already exists — ADR-039's edge-conflict
+            // contract is ON CONFLICT DO NOTHING: drop the non-canonical edge
+            // and leave the existing canonical row untouched (live or
+            // tombstoned). Refreshing it from the discarded edge's
+            // weight/target_backend/metadata and forcing deleted_at = NULL
+            // would silently overwrite the survivor and resurrect a
+            // tombstone — the same defect already fixed on the merge-rewire
+            // path (`merge_entity_sql`/`merge_note_sql`); this path binds the
+            // same shared `EDGE_SYMMETRIC_*_SQL` text and must honor the same
+            // contract. Return the surviving id unchanged so the caller
+            // re-fetches its real (unmodified) attributes.
             conn.execute(
                 khive_db::stores::graph::EDGE_SYMMETRIC_DELETE_NONCANONICAL_SQL,
                 rusqlite::params![&ns, &edge_id_str],
             )
             .map_err(SqliteError::Rusqlite)?;
-            let affected = conn
-                .execute(
-                    khive_db::stores::graph::EDGE_SYMMETRIC_REFRESH_CANONICAL_SQL,
-                    rusqlite::params![weight, now_ts, target_backend, metadata, &ns, &existing_id],
-                )
-                .map_err(SqliteError::Rusqlite)?;
-            if affected == 0 {
-                return Err(SqliteError::InvalidData(format!(
-                    "update_edge: surviving canonical row {existing_id} vanished during update"
-                )));
-            }
             Ok(Some(existing_id))
         } else {
             // Case (a): no conflict — update source_id/target_id in-place,
@@ -4790,7 +4786,6 @@ impl KhiveRuntime {
                 .metadata
                 .as_ref()
                 .map(|v| serde_json::to_string(v).unwrap_or_default());
-            let target_backend = edge.target_backend.clone();
 
             let pool = self.backend().pool_arc();
             // Route through the single-writer task when the write queue is
@@ -4799,8 +4794,8 @@ impl KhiveRuntime {
             let writer_task = pool.writer_task_handle().ok().flatten();
 
             // Some(surviving_id) when a canonical conflict was absorbed (the requested
-            // edge was deleted, existing canonical row refreshed), or None when the
-            // requested edge was updated in-place.
+            // edge was deleted, existing canonical row left untouched per ADR-039 DO
+            // NOTHING), or None when the requested edge was updated in-place.
             let surviving_id: Option<String> = if let Some(writer_task) = writer_task {
                 writer_task
                     .send(move |conn| {
@@ -4813,7 +4808,6 @@ impl KhiveRuntime {
                             &relation_str,
                             weight,
                             metadata,
-                            target_backend,
                         )
                         .map_err(|e| {
                             khive_storage::StorageError::driver(
@@ -4838,7 +4832,6 @@ impl KhiveRuntime {
                             &relation_str,
                             weight,
                             metadata,
-                            target_backend,
                         )
                     })
                 })
@@ -4850,14 +4843,17 @@ impl KhiveRuntime {
             };
 
             if let Some(sid) = surviving_id {
-                // A conflict was absorbed: re-fetch the surviving canonical row so the
-                // caller receives its real id.
-                // Use record_tok — the surviving row lives in the same namespace as the original.
+                // A conflict was absorbed (ADR-039 DO NOTHING): re-fetch the surviving
+                // canonical row so the caller receives its real, UNMODIFIED attributes —
+                // including soft-deleted rows, since the survivor's tombstone state (if
+                // any) must not be resurrected by the absorbed update either. Use
+                // record_tok — the surviving row lives in the same namespace as the
+                // original.
                 let surviving_uuid = Uuid::parse_str(&sid).map_err(|e| {
                     RuntimeError::Internal(format!("update_edge: surviving id parse failed: {e}"))
                 })?;
                 edge = self
-                    .get_edge(&record_tok, surviving_uuid)
+                    .get_edge_including_deleted(&record_tok, surviving_uuid)
                     .await?
                     .ok_or_else(|| {
                         RuntimeError::Internal(format!(
@@ -5942,6 +5938,122 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(updated.relation, EdgeRelation::VariantOf);
+    }
+
+    /// A symmetric-relation update whose canonical natural key collides
+    /// with an existing edge must delete the requested (non-canonical)
+    /// row and leave the surviving canonical row's attributes untouched
+    /// (ADR-039 ON CONFLICT DO NOTHING) — the discarded edge's patched
+    /// weight must never overwrite the survivor (khive#1213).
+    #[tokio::test]
+    async fn update_edge_symmetric_conflict_keeps_survivor_attributes() {
+        let rt = rt();
+        let tok = NamespaceToken::local();
+        let a = rt
+            .create_entity(&tok, "concept", None, "A", None, None, vec![])
+            .await
+            .unwrap();
+        let b = rt
+            .create_entity(&tok, "concept", None, "B", None, None, vec![])
+            .await
+            .unwrap();
+
+        let requested = rt
+            .link(&tok, a.id, b.id, EdgeRelation::Extends, 0.2, None)
+            .await
+            .unwrap();
+        let requested_id: Uuid = requested.id.into();
+
+        let canonical = rt
+            .link(&tok, a.id, b.id, EdgeRelation::CompetesWith, 0.6, None)
+            .await
+            .unwrap();
+        let canonical_id: Uuid = canonical.id.into();
+
+        let updated = rt
+            .update_edge(
+                &tok,
+                requested_id,
+                crate::curation::EdgePatch {
+                    relation: Some(EdgeRelation::CompetesWith),
+                    weight: Some(0.9),
+                    ..Default::default()
+                },
+            )
+            .await
+            .unwrap();
+
+        // The requested (non-canonical) row was absorbed into the survivor.
+        assert_eq!(Uuid::from(updated.id), canonical_id);
+        assert_eq!(
+            updated.weight, 0.6,
+            "survivor weight must not be overwritten by the discarded edge's patch"
+        );
+
+        let requested_after = rt
+            .get_edge_including_deleted(&tok, requested_id)
+            .await
+            .unwrap();
+        assert!(
+            requested_after.is_none(),
+            "the non-canonical requested row must be deleted, not just tombstoned"
+        );
+    }
+
+    /// A soft-deleted surviving canonical row must not be resurrected by a
+    /// conflicting symmetric-relation update (khive#1213).
+    #[tokio::test]
+    async fn update_edge_symmetric_conflict_does_not_resurrect_tombstoned_survivor() {
+        let rt = rt();
+        let tok = NamespaceToken::local();
+        let a = rt
+            .create_entity(&tok, "concept", None, "A", None, None, vec![])
+            .await
+            .unwrap();
+        let b = rt
+            .create_entity(&tok, "concept", None, "B", None, None, vec![])
+            .await
+            .unwrap();
+
+        let requested = rt
+            .link(&tok, a.id, b.id, EdgeRelation::Extends, 0.2, None)
+            .await
+            .unwrap();
+        let requested_id: Uuid = requested.id.into();
+
+        let canonical = rt
+            .link(&tok, a.id, b.id, EdgeRelation::CompetesWith, 0.6, None)
+            .await
+            .unwrap();
+        let canonical_id: Uuid = canonical.id.into();
+        rt.delete_edge(&tok, canonical_id, false).await.unwrap();
+
+        rt.update_edge(
+            &tok,
+            requested_id,
+            crate::curation::EdgePatch {
+                relation: Some(EdgeRelation::CompetesWith),
+                weight: Some(0.9),
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+
+        let requested_after = rt
+            .get_edge_including_deleted(&tok, requested_id)
+            .await
+            .unwrap();
+        assert!(
+            requested_after.is_none(),
+            "the non-canonical requested row must be deleted, not just tombstoned"
+        );
+
+        let canonical_after = rt.get_edge(&tok, canonical_id).await.unwrap();
+        assert!(
+            canonical_after.is_none(),
+            "a tombstoned survivor must not be resurrected by a conflicting update"
+        );
     }
 
     // ---- update_edge endpoint validation ----

--- a/crates/khive-runtime/tests/integration.rs
+++ b/crates/khive-runtime/tests/integration.rs
@@ -1789,8 +1789,9 @@ async fn synthetic_edge_observed_as_selected_returns_memory_note() {
 // =============================================================================
 
 /// Regression for Bug 1: when update_edge absorbs a conflict (the requested edge
-/// is deleted and the existing canonical row is refreshed), the returned edge must
-/// carry the SURVIVING canonical row's id — not the id of the deleted edge.
+/// is deleted and the existing canonical row is preserved unchanged, ADR-039 DO
+/// NOTHING), the returned edge must carry the SURVIVING canonical row's id — not
+/// the id of the deleted edge.
 ///
 /// Setup: pre-create canonical A→B competes_with (E1), create A→B extends (E2).
 /// Update E2's relation to competes_with. The returned id must be E1, not E2.

--- a/crates/khive-storage/src/graph.rs
+++ b/crates/khive-storage/src/graph.rs
@@ -70,8 +70,17 @@ pub trait GraphStore: Send + Sync + 'static {
     /// update whose surviving canonical row may be tombstoned (ADR-039 DO NOTHING) — the
     /// normal `query_edges`/`list_edges` path filters `deleted_at IS NULL` and would report
     /// "not found" for exactly that row.
+    ///
+    /// `namespace` is the natural key's own `namespace` column value (part of the
+    /// `UNIQUE(namespace, source_id, target_id, relation)` constraint this method queries by)
+    /// — it is passed explicitly rather than implied by whichever store instance `self` is,
+    /// so a caller who resolved the record's namespace independently of its own ambient token
+    /// (the atomic-apply renderer, which knows the committed edge's namespace from its prepare-
+    /// time `EdgeNaturalKey`, not from the caller's token) cannot accidentally query the wrong
+    /// namespace by relying on implicit store scoping (khive#1213/#1214 fix round).
     async fn get_edge_by_natural_key_including_deleted(
         &self,
+        namespace: &str,
         source_id: Uuid,
         target_id: Uuid,
         relation: EdgeRelation,

--- a/crates/khive-storage/src/graph.rs
+++ b/crates/khive-storage/src/graph.rs
@@ -65,6 +65,17 @@ pub trait GraphStore: Send + Sync + 'static {
     /// Fetch an edge by link ID including soft-deleted rows. Used by the runtime hard-delete path
     /// to locate and namespace-check an already-soft-deleted edge before purging it.
     async fn get_edge_including_deleted(&self, id: LinkId) -> StorageResult<Option<Edge>>;
+    /// Fetch an edge by natural key (namespace, source, target, relation) including
+    /// soft-deleted rows. Used by the atomic-apply result renderer for a symmetric-relation
+    /// update whose surviving canonical row may be tombstoned (ADR-039 DO NOTHING) — the
+    /// normal `query_edges`/`list_edges` path filters `deleted_at IS NULL` and would report
+    /// "not found" for exactly that row.
+    async fn get_edge_by_natural_key_including_deleted(
+        &self,
+        source_id: Uuid,
+        target_id: Uuid,
+        relation: EdgeRelation,
+    ) -> StorageResult<Option<Edge>>;
     /// Delete an edge by link ID using the specified delete mode.
     async fn delete_edge(&self, id: LinkId, mode: DeleteMode) -> StorageResult<bool>;
     /// Query edges with filter, sort, and pagination.

--- a/crates/kkernel/src/atomic_apply.rs
+++ b/crates/kkernel/src/atomic_apply.rs
@@ -484,6 +484,7 @@ async fn build_op_result(
             let edge = runtime
                 .get_edge_by_natural_key_including_deleted(
                     token,
+                    key.namespace(),
                     key.canon_source_id(),
                     key.canon_target_id(),
                     key.relation(),

--- a/crates/kkernel/src/atomic_apply.rs
+++ b/crates/kkernel/src/atomic_apply.rs
@@ -471,32 +471,33 @@ async fn build_op_result(
         // `p.target_id` — that field is prepare-time-only (the caller's
         // requested id), and the SAME staleness that made the write path
         // unsafe to branch on at prepare time makes it unsafe to render
-        // from too. This mirrors the `link` arm below exactly (same
-        // reasoning, same `list_edges` mechanism).
+        // from too. This mirrors the `link` arm below (same reasoning), but
+        // uses the deleted-inclusive natural-key lookup, not `list_edges`:
+        // ADR-039's DO NOTHING conflict-absorption arm can commit leaving the
+        // surviving canonical row tombstoned (khive#1213/#1214 fix round),
+        // and `list_edges` unconditionally filters `deleted_at IS NULL` — it
+        // would report "not found" for exactly the row that was just
+        // committed, turning a successful, correct commit into a spurious
+        // post-commit error.
         ("update", AtomicOpPlan::Update(p)) if p.edge_natural_key().is_some() => {
             let key = p.edge_natural_key().expect("checked by guard above");
-            let edges = runtime
-                .list_edges(
+            let edge = runtime
+                .get_edge_by_natural_key_including_deleted(
                     token,
-                    EdgeListFilter {
-                        source_id: Some(key.canon_source_id()),
-                        target_id: Some(key.canon_target_id()),
-                        relations: vec![key.relation()],
-                        ..Default::default()
-                    },
-                    1,
-                    0,
-                )
-                .await?;
-            let edge = edges.into_iter().next().ok_or_else(|| {
-                anyhow::anyhow!(
-                    "atomic update result: committed symmetric edge not found by natural key \
-                     ({}, {}, {})",
                     key.canon_source_id(),
                     key.canon_target_id(),
-                    key.relation()
+                    key.relation(),
                 )
-            })?;
+                .await?
+                .ok_or_else(|| {
+                    anyhow::anyhow!(
+                        "atomic update result: committed symmetric edge not found by natural key \
+                         ({}, {}, {})",
+                        key.canon_source_id(),
+                        key.canon_target_id(),
+                        key.relation()
+                    )
+                })?;
             Ok(serde_json::to_value(&edge)?)
         }
         ("update", AtomicOpPlan::Update(p)) => match runtime

--- a/crates/kkernel/src/exec.rs
+++ b/crates/kkernel/src/exec.rs
@@ -3080,6 +3080,112 @@ backend = "sessions"
         );
     }
 
+    /// khive#1213/#1214 fix round, Medium finding: the canonical survivor a
+    /// symmetric-update op absorbs into can ALREADY be soft-deleted before the
+    /// atomic unit even runs (not just tombstoned as a side effect of the same
+    /// unit's own writes, as the sibling test above covers). This exercises
+    /// `build_op_result`'s `get_edge_by_natural_key_including_deleted` call
+    /// through the real atomic path with a genuinely pre-existing tombstone: the
+    /// pre-fix renderer (`KhiveRuntime::list_edges`, which unconditionally
+    /// filters `deleted_at IS NULL`) would report the committed update as "not
+    /// found" for exactly this row, turning a successful DO NOTHING absorption
+    /// into a spurious post-commit error.
+    #[tokio::test]
+    async fn atomic_symmetric_update_absorbs_into_pre_existing_tombstoned_survivor_and_renders_it()
+    {
+        let db_file = NamedTempFile::new().expect("temp db");
+        let db_path = db_file.path().to_str().expect("utf8").to_string();
+
+        let (canonical_id, x_id) = {
+            let server = isolated_server(&db_path);
+            let resp = dispatch_json(
+                &server,
+                r#"[create(kind="concept", name="TombA"), create(kind="concept", name="TombB")]"#,
+            )
+            .await;
+            let a_id = resp["results"][0]["result"]["id"]
+                .as_str()
+                .expect("a id")
+                .to_string();
+            let b_id = resp["results"][1]["result"]["id"]
+                .as_str()
+                .expect("b id")
+                .to_string();
+
+            // The canonical survivor: created, then soft-deleted, BEFORE the atomic
+            // unit ever runs.
+            let link_resp = dispatch_json(
+                &server,
+                &format!(
+                    r#"link(source_id="{a_id}", target_id="{b_id}", relation="competes_with", weight=0.6)"#
+                ),
+            )
+            .await;
+            let canonical_id = link_resp["results"][0]["result"]["id"]
+                .as_str()
+                .expect("canonical id")
+                .to_string();
+            dispatch_json(&server, &format!(r#"delete(id="{canonical_id}")"#)).await;
+
+            // A distinct pre-existing edge under a different relation, later
+            // converted (by the atomic update below) into the same
+            // (a, b, competes_with) natural key — it must absorb into the
+            // already-tombstoned canonical row, not resurrect or overwrite it.
+            let x_resp = dispatch_json(
+                &server,
+                &format!(
+                    r#"link(source_id="{a_id}", target_id="{b_id}", relation="extends", weight=0.2)"#
+                ),
+            )
+            .await;
+            let x_id = x_resp["results"][0]["result"]["id"]
+                .as_str()
+                .expect("x id")
+                .to_string();
+            (canonical_id, x_id)
+        };
+
+        let ops = vec![atomic_op(
+            "update",
+            serde_json::json!({"id": x_id, "relation": "competes_with", "weight": 0.9}),
+        )];
+
+        let khive_cfg = KhiveConfig::default();
+        let envelope = crate::atomic_apply::execute_atomic_ops_file(
+            ops,
+            atomic_cfg(&db_path),
+            &khive_cfg,
+            khive_types::pack::ATOMIC_MAX_OPS_DEFAULT,
+        )
+        .await
+        .expect("atomic run must succeed by absorbing into the tombstoned survivor");
+
+        assert_eq!(
+            envelope["atomic"]["committed"], true,
+            "envelope: {envelope}"
+        );
+
+        let rendered_id = envelope["results"][0]["result"]["id"]
+            .as_str()
+            .expect("update result id")
+            .to_string();
+        assert_eq!(
+            rendered_id, canonical_id,
+            "must render the pre-existing tombstoned canonical survivor, not X's stale \
+             requested id: {envelope}"
+        );
+        assert!(
+            !envelope["results"][0]["result"]["deleted_at"].is_null(),
+            "the rendered survivor must show its OWN tombstoned state (non-null deleted_at) \
+             — absorbing a conflicting update must not resurrect it: {envelope}"
+        );
+        assert_eq!(
+            envelope["results"][0]["result"]["weight"], 0.6,
+            "ADR-039 DO NOTHING: the survivor keeps its own pre-existing weight, not X's \
+             discarded patched weight (0.9): {envelope}"
+        );
+    }
+
     /// Acceptance test 2: every CLI-boundary rejection fires BEFORE any
     /// write — each sub-case asserts both the error and that the db stays
     /// empty (zero entities created).

--- a/crates/kkernel/src/exec.rs
+++ b/crates/kkernel/src/exec.rs
@@ -2978,7 +2978,8 @@ backend = "sessions"
     /// conflict-absorbs into is created by an EARLIER op in the SAME
     /// atomic unit (so it does not exist at either op's prepare time). The
     /// commit must both write correctly (X deleted, the just-linked row
-    /// carries X's patch) and RENDER the correct surviving id — not X's
+    /// preserved unchanged per ADR-039 DO NOTHING — X's patch is discarded,
+    /// not applied) and RENDER the correct surviving id — not X's
     /// prepare-time-advisory id, which this fix removed reliance on
     /// entirely (`build_op_result` now derives it from a post-commit
     /// natural-key lookup).
@@ -3065,15 +3066,17 @@ backend = "sessions"
             "the update's rendered result must be the surviving (just-linked) row: {envelope}"
         );
         assert_eq!(
-            envelope["results"][1]["result"]["weight"], 0.9,
-            "the surviving row must carry the update's patch: {envelope}"
+            envelope["results"][1]["result"]["weight"], 0.6,
+            "ADR-039 DO NOTHING: the surviving row keeps its OWN pre-existing weight (0.6, \
+             set by the link above), not the discarded update's patched weight (0.9): {envelope}"
         );
 
         let server = isolated_server(&db_path);
         let surviving_resp = dispatch_json(&server, &format!(r#"get(id="{linked_id}")"#)).await;
         assert_eq!(
-            surviving_resp["results"][0]["result"]["weight"], 0.9,
-            "the committed row itself must carry the patch: {surviving_resp}"
+            surviving_resp["results"][0]["result"]["weight"], 0.6,
+            "the committed row itself must keep its pre-existing weight, not the discarded \
+             update's patch: {surviving_resp}"
         );
     }
 

--- a/docs/guide/api-reference.md
+++ b/docs/guide/api-reference.md
@@ -296,6 +296,14 @@ Patch entity, note, or edge fields. Field set depends on substrate: entities acc
 request(ops="update(id=\"<uuid>\", salience=0.7)")
 ```
 
+For a symmetric-relation edge (`competes_with`, `composed_with`), setting `relation` or
+`weight` can collide with an already-existing edge at the same canonical `(source, target,
+relation)` triple. When that happens, the requested edge is dropped and the returned record
+is the pre-existing survivor, left exactly as it was (ADR-039's edge-conflict contract is
+`ON CONFLICT DO NOTHING` — the survivor's own attributes are never overwritten by the
+discarded edge's patch). If that survivor was previously soft-deleted, the returned edge may
+carry a non-null `deleted_at`: absorbing a conflicting update never resurrects a tombstone.
+
 ### `delete` — Declaration
 
 Soft or hard delete a record.


### PR DESCRIPTION
## Defect

`update_edge()`'s symmetric-relation natural-key conflict arm (both the canonical raw-SQL path
in `crates/khive-runtime/src/operations.rs` and its `--atomic` mirror in
`crates/khive-runtime/src/atomic_prepare.rs` / `crates/khive-db/src/stores/graph.rs`) deleted the
non-canonical requested edge but then unconditionally refreshed the surviving canonical row from
the discarded edge's `weight`/`target_backend`/`metadata` and forced `deleted_at = NULL` —
silently overwriting the survivor and resurrecting a tombstone. ADR-039 documents the edge-conflict
contract as `ON CONFLICT DO NOTHING`.

This is the same class of bug already fixed on the entity/note merge-rewire path (`merge_entity_sql`
/ `merge_note_sql` in `curation.rs`). It was still live here because `update_edge()` is a separate
call site binding the same shared `EDGE_SYMMETRIC_*_SQL` text — fixing the merge path alone left
this one unfixed.

## Root cause

Two call sites shared `EDGE_SYMMETRIC_CONFLICT_PROBE_SQL` / `EDGE_SYMMETRIC_REFRESH_CANONICAL_SQL`
(the raw-SQL synchronous path in `operations.rs`, and the atomic-plan builders in `graph.rs`). Both
independently implemented "delete the loser, then UPDATE the survivor with the loser's values",
which contradicts the documented DO NOTHING contract and resurrects soft-deleted rows.

## Fix

- `update_edge_symmetric_dml` (canonical path): on conflict, only deletes the non-canonical row.
  The `EDGE_SYMMETRIC_REFRESH_CANONICAL_SQL` call is removed entirely — the surviving row is never
  touched.
- `edge_symmetric_refresh_or_update_inplace_statement` (atomic path): every `SET` expression is now
  keyed on `id = ?2`, which is true only for the in-place arm. The absorbed-conflict arm therefore
  self-assigns each column's current value — a genuine no-op UPDATE that still counts as one
  affected row (SQLite's `changes()` counts matched rows, not changed bytes), so the existing
  `AffectedRowGuard::exactly(1)` commit-time race-detection invariant is unaffected.
- `update_edge()`'s post-absorption re-fetch now uses `get_edge_including_deleted` instead of
  `get_edge`, so a tombstoned survivor is reported as-is rather than surfacing an internal
  "vanished after update" error (a second-order consequence of no longer forcing
  `deleted_at = NULL`).
- The now-dead `EDGE_SYMMETRIC_REFRESH_CANONICAL_SQL` constant and its plan-shape builder are
  removed rather than left as unused API surface.

## Tests

New regression tests reproducing both defects before the fix, on both call paths:
- `operations::tests::update_edge_symmetric_conflict_keeps_survivor_attributes`
- `operations::tests::update_edge_symmetric_conflict_does_not_resurrect_tombstoned_survivor`
- `atomic_prepare::tests::atomic_update_edge_symmetric_conflict_does_not_resurrect_tombstoned_survivor`

Also corrected the pre-existing `atomic_update_edge_symmetric_conflict_absorbs_into_surviving_row`
test, which asserted the buggy overwrite behavior (`assert_eq!(surviving.weight, 0.9)` — the
discarded edge's patched weight) instead of the survivor's own pre-existing weight (`0.6`).

```
cargo test -p khive-runtime -p khive-db      # 999 + 92 passed, 0 failed (plus integration/doctest binaries, all green)
cargo clippy -p khive-runtime -p khive-db --all-targets -- -D warnings   # clean
cargo fmt -p khive-runtime -p khive-db -- --check   # clean
```

## Deferred

`#1214`'s entity-merge column-loss (`INSERT OR REPLACE` dropping `entity_type`/`content_ref`) and
its pack-endpoint-validation-on-rewire gap are already fixed on `main` (merged PRs #1215 and
#1277) and required no further changes in this branch.

Closes #1213