### PR TITLE
test: deflake two CI-flaky tests (config_id env race, checkpoint sweep timing)

### DIFF
--- a/crates/khive-db/src/checkpoint.rs
+++ b/crates/khive-db/src/checkpoint.rs
@@ -3980,7 +3980,12 @@ mod tests {
             true,
         ));
 
-        tokio::time::sleep(Duration::from_millis(60)).await;
+        // Poll for the first emitted event instead of a fixed sleep (same
+        // slowdown-flake class as the stale-sweep test above).
+        let emitted = wait_for(Duration::from_secs(10), || {
+            !store.events.lock().unwrap().is_empty()
+        })
+        .await;
         shutdown_tx.send(()).expect("send shutdown signal");
         tokio::time::timeout(Duration::from_secs(1), handle)
             .await
@@ -3989,8 +3994,9 @@ mod tests {
 
         let events = store.events.lock().unwrap();
         assert!(
-            !events.is_empty(),
-            "an always-elevated config must append at least one CheckpointOutcomeRecorded event"
+            emitted,
+            "an always-elevated config must append at least one CheckpointOutcomeRecorded event \
+             within the poll deadline"
         );
         assert!(
             events
@@ -4027,7 +4033,12 @@ mod tests {
             false,
         ));
 
-        tokio::time::sleep(Duration::from_millis(40)).await;
+        // Poll for the first emitted event instead of a fixed sleep (same
+        // slowdown-flake class as the stale-sweep test above).
+        let emitted = wait_for(Duration::from_secs(10), || {
+            !store.events.lock().unwrap().is_empty()
+        })
+        .await;
         shutdown_tx.send(()).expect("send shutdown signal");
         tokio::time::timeout(Duration::from_secs(1), handle)
             .await
@@ -4035,8 +4046,9 @@ mod tests {
             .expect("checkpoint task panicked");
 
         assert!(
-            !store.events.lock().unwrap().is_empty(),
-            "a designated secondary lifecycle owner must append outcome events"
+            emitted,
+            "a designated secondary lifecycle owner must append outcome events within the poll \
+             deadline"
         );
     }
 

--- a/crates/khive-db/src/checkpoint.rs
+++ b/crates/khive-db/src/checkpoint.rs
@@ -4149,7 +4149,22 @@ mod tests {
         let (shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(());
         let handle = tokio::spawn(run_checkpoint_task(pool, cfg, None, shutdown_rx, true));
 
-        tokio::time::sleep(Duration::from_millis(60)).await;
+        // Poll for the sweep instead of a fixed sleep: a fixed wall-clock
+        // budget assumes the spawned task completes its tick (registry scan
+        // + walpin sidecar heartbeat) within that window, which widens and
+        // flakes under slowdown (coverage instrumentation, contended CI
+        // runners) — see `wait_for`'s doc comment for the same reasoning
+        // applied to the sibling walpin tests.
+        let swept = wait_for(Duration::from_secs(10), || {
+            buffer.lock().unwrap().iter().any(|e| {
+                e.tx_label.as_deref() == Some("checkpoint_task_healthy_wal_sweep_test")
+                    && e.message
+                        .as_deref()
+                        .is_some_and(|m| m.contains("stale-op cap"))
+            })
+        })
+        .await;
+
         shutdown_tx.send(()).expect("send shutdown signal");
         tokio::time::timeout(Duration::from_secs(1), handle)
             .await
@@ -4160,14 +4175,9 @@ mod tests {
 
         let events = buffer.lock().unwrap();
         assert!(
-            events.iter().any(|e| {
-                e.tx_label.as_deref() == Some("checkpoint_task_healthy_wal_sweep_test")
-                    && e.message
-                        .as_deref()
-                        .is_some_and(|m| m.contains("stale-op cap"))
-            }),
+            swept,
             "expected the spawned task to sweep and escalate the stale registry entry \
-             to Stale on its own, got: {events:?}"
+             to Stale on its own within the poll deadline, got: {events:?}"
         );
     }
 

--- a/crates/kkernel/src/exec.rs
+++ b/crates/kkernel/src/exec.rs
@@ -1308,6 +1308,15 @@ default = true
         // exec-shaped inputs: `config: None` (kkernel exec has no `--config`
         // flag today), `namespace_explicit: true` (the choice made in `run_exec`
         // above).
+        // Pin the pack list explicitly rather than inheriting `KHIVE_PACKS`
+        // from the ambient environment (same rationale as `isolated_server`
+        // above, #1276): `RuntimeConfig::default()` reads `KHIVE_PACKS` fresh
+        // on every call, so leaving this `None` makes the assertion below
+        // depend on two independent env reads observing the same ambient
+        // value — a real flake source when a concurrently-running test
+        // mutates process env between them (#1356).
+        let pinned_packs = Some(vec!["kg".to_string()]);
+
         let exec_cfg = resolve_runtime_config(RuntimeConfigInputs {
             db: Some(&db_str),
             config: None,
@@ -1315,7 +1324,7 @@ default = true
             namespace_explicit: true,
             actor_explicit: false,
             no_embed: false,
-            packs: None,
+            packs: pinned_packs.clone(),
             brain_profile: None,
         })
         .expect("resolve exec-shaped config");
@@ -1331,7 +1340,7 @@ default = true
             namespace_explicit: false,
             actor_explicit: false,
             no_embed: false,
-            packs: None,
+            packs: pinned_packs,
             brain_profile: None,
         })
         .expect("resolve serve-shaped config");
@@ -1384,6 +1393,9 @@ default = true
         let missing_config =
             std::path::PathBuf::from("/nonexistent/khive-exec-parity-test/config.toml");
         let ns = Namespace::parse("lambda:custom-ns").expect("ns");
+        // Pin packs so the `compute_config_id` comparison below never depends
+        // on two independent `KHIVE_PACKS` env reads agreeing (#1356).
+        let pinned_packs = Some(vec!["kg".to_string()]);
 
         let with_explicit_true = resolve_runtime_config(RuntimeConfigInputs {
             db: Some(":memory:"),
@@ -1392,7 +1404,7 @@ default = true
             namespace_explicit: true,
             actor_explicit: false,
             no_embed: false,
-            packs: None,
+            packs: pinned_packs.clone(),
             brain_profile: None,
         })
         .expect("resolve with namespace_explicit=true");
@@ -1404,7 +1416,7 @@ default = true
             namespace_explicit: false,
             actor_explicit: false,
             no_embed: false,
-            packs: None,
+            packs: pinned_packs,
             brain_profile: None,
         })
         .expect("resolve with namespace_explicit=false");
@@ -1491,6 +1503,10 @@ default = true
             ..KhiveConfig::default()
         };
 
+        // Pin packs so the config_id comparisons below never depend on two
+        // independent `KHIVE_PACKS` env reads agreeing (#1356).
+        let pinned_packs = Some(vec!["kg".to_string()]);
+
         // exec-shaped inputs (namespace_explicit: true — the choice `run_exec` makes).
         let exec_cfg = resolve_runtime_config(RuntimeConfigInputs {
             db: Some(":memory:"),
@@ -1499,7 +1515,7 @@ default = true
             namespace_explicit: true,
             actor_explicit: false,
             no_embed: false,
-            packs: None,
+            packs: pinned_packs.clone(),
             brain_profile: None,
         })
         .expect("resolve exec-shaped config");
@@ -1512,7 +1528,7 @@ default = true
             namespace_explicit: false,
             actor_explicit: false,
             no_embed: false,
-            packs: None,
+            packs: pinned_packs,
             brain_profile: None,
         })
         .expect("resolve serve-shaped config");


### PR DESCRIPTION
## Summary

Fixes two intermittently-failing tests identified in #1356 (5 of 7 CI reruns this week traced to these two tests).

- **`exec::tests::exec_config_id_matches_serve_config_id_for_project_toml_actor`** (and two sibling config_id-parity tests in the same file): compared `compute_config_id()` across two separately-constructed configs both built with `packs: None`, which falls back to a fresh `RuntimeConfig::default().packs` read of ambient `KHIVE_PACKS` on each call. Two independent env reads compared for byte-identity only agree when nothing else touches process env in between — a real flake source once the window widens under slower/instrumented test runs. Fix: pin `packs` explicitly in all three tests, matching the pattern this file already uses for `isolated_server` (#1276). Removes the ambient-env dependency instead of widening a timing assumption.

- **`checkpoint::tests::checkpoint_task_sweeps_stale_registry_entry_while_wal_is_healthy`**: spawned the checkpoint task, slept a fixed 60ms, then asserted a captured sweep event. The fixed budget assumes the task completes a full tick (registry scan + walpin sidecar heartbeat write) within that window, which narrows under slower/instrumented runs. Fix: poll for the actual condition using the file's existing `wait_for(deadline, cond)` helper (already used by sibling walpin tests for the same reason) instead of a fixed sleep.

Both fixes remove a timing/env assumption rather than widening one — no added sleeps, retries, or `#[ignore]`.

## Test plan
- [x] `cargo test -p kkernel -p khive-db` (full crates): all green
- [x] 30x loop on the config_id-parity tests with ambient `KHIVE_PACKS` deliberately set (the condition that reproduced the original race 8-9/9 times pre-fix): 0/30 failures post-fix
- [x] 30x loop on the checkpoint sweep test: 0/30 failures
- [x] `cargo clippy -p kkernel -p khive-db --all-targets -- -D warnings`: clean
- [x] `cargo fmt --all -- --check`: clean

Refs #1356

🤖 Generated with [Claude Code](https://claude.com/claude-code)