### PR TITLE
fix(runtime): compare vector-search floor on the storage score scale

### DIFF
--- a/crates/khive-runtime/src/reference_resolution.rs
+++ b/crates/khive-runtime/src/reference_resolution.rs
@@ -82,6 +82,11 @@ const SEARCH_MARGIN_RATIO: f64 = 2.0;
 /// Vector hits below this raw cosine-similarity score are removed before RRF
 /// fusion. Lexical hits remain admissible because RRF magnitude encodes rank,
 /// not textual relevance, and genuine partial-name matches score below this floor.
+///
+/// This is a raw cosine value in `[-1.0, 1.0]`, not the `(1 + cos) / 2`
+/// storage scale vector hits are scored on
+/// (`khive-db` `stores/vectors.rs`) — `hybrid_search_with_vector_similarity_floor`
+/// converts between the two scales at the comparison site.
 const SEARCH_VECTOR_SIMILARITY_FLOOR: f64 = 0.3;
 /// Confidence reported on a search-stage `Resolved` outcome: not the raw
 /// RRF score, which lives on a much smaller scale (`sum 1/(k + rank)`, e.g.
@@ -903,7 +908,10 @@ mod tests {
             .expect("vector search");
         assert_eq!(raw_hits.len(), 1);
         assert_eq!(raw_hits[0].subject_id, entity.id);
-        assert!(raw_hits[0].score.to_f64() >= SEARCH_VECTOR_SIMILARITY_FLOOR);
+        // Identical constant embeddings: raw cosine 1.0, storage score
+        // (1 + 1.0) / 2 == 1.0 — well above 0.65, the storage-scale floor a
+        // raw-cosine bar of 0.3 converts to.
+        assert!((raw_hits[0].score.to_f64() - 1.0).abs() < 1e-6);
 
         let hits = rt
             .hybrid_search(&token, "domestic dog", None, 5, None, None, &[], None)
@@ -923,6 +931,76 @@ mod tests {
                 confidence: SEARCH_RESOLVED_CONFIDENCE,
             }
         );
+    }
+
+    #[tokio::test]
+    async fn fallback_stage_drops_orthogonal_semantic_only_candidate() {
+        // Regression for #1366: an orthogonal vector (raw cosine 0.0) scores
+        // 0.5 on the `(1 + cos) / 2` storage scale, which clears a floor
+        // compared directly against the raw-cosine constant (0.3) even
+        // though the documented contract says it should not. A sole
+        // semantic candidate at this similarity must be dropped, not
+        // resolved.
+        let rt = runtime_with_constant_embeddings();
+        let token = actor_token("resolver-test");
+        let ring = ReferenceRing::new();
+        let dimensions = EmbeddingModel::AllMiniLmL6V2.dimensions();
+
+        let entity = rt
+            .create_entity(
+                &token,
+                "concept",
+                None,
+                "Unrelated Orthogonal",
+                None,
+                None,
+                vec![],
+            )
+            .await
+            .expect("create unrelated entity");
+        let vectors = rt.vectors(&token).expect("vector store");
+        vectors
+            .delete(entity.id)
+            .await
+            .expect("delete generated vector");
+        let mut orthogonal_vector = vec![1.0f32; dimensions / 2];
+        orthogonal_vector.extend(vec![-1.0f32; dimensions - dimensions / 2]);
+        vectors
+            .insert(
+                entity.id,
+                SubstrateKind::Entity,
+                token.namespace().as_str(),
+                "entity.body",
+                vec![orthogonal_vector],
+            )
+            .await
+            .expect("insert orthogonal vector");
+
+        let raw_hits = rt
+            .vector_search(
+                &token,
+                None,
+                Some("totally-nonexistent-orthogonal-zzz"),
+                5,
+                Some(SubstrateKind::Entity),
+            )
+            .await
+            .expect("vector search");
+        assert_eq!(raw_hits.len(), 1);
+        assert!((raw_hits[0].score.to_f64() - 0.5).abs() < 1e-6);
+
+        let resolution = resolve_reference(
+            &rt,
+            &ring,
+            &token,
+            "totally-nonexistent-orthogonal-zzz",
+            5,
+            None,
+        )
+        .await
+        .expect("resolve_reference");
+
+        assert_eq!(resolution, ReferenceResolution::NotFound);
     }
 
     #[tokio::test]
@@ -949,16 +1027,24 @@ mod tests {
             .delete(entity.id)
             .await
             .expect("delete generated vector");
+        // A quarter of dimensions aligned, three-quarters opposed against the
+        // constant all-ones query embedding: raw cosine 2*0.25 - 1 == -0.5,
+        // storage score (1 + -0.5) / 2 == 0.25 — below floor without being
+        // the maximally-opposite case, so this exercises a genuine
+        // below-floor mismatch rather than the degenerate cosine -1 extreme.
+        let quarter = dimensions / 4;
+        let mut mismatched_vector = vec![1.0f32; quarter];
+        mismatched_vector.extend(vec![-1.0f32; dimensions - quarter]);
         vectors
             .insert(
                 entity.id,
                 SubstrateKind::Entity,
                 token.namespace().as_str(),
                 "entity.body",
-                vec![vec![-1.0; dimensions]],
+                vec![mismatched_vector],
             )
             .await
-            .expect("insert opposite vector");
+            .expect("insert mismatched vector");
 
         let raw_hits = rt
             .vector_search(
@@ -971,7 +1057,7 @@ mod tests {
             .await
             .expect("vector search");
         assert_eq!(raw_hits.len(), 1);
-        assert!(raw_hits[0].score.to_f64() < SEARCH_VECTOR_SIMILARITY_FLOOR);
+        assert!((raw_hits[0].score.to_f64() - 0.25).abs() < 1e-6);
 
         let resolution = resolve_reference(&rt, &ring, &token, "totally-nonexistent-zzz", 5, None)
             .await

--- a/crates/khive-runtime/src/retrieval.rs
+++ b/crates/khive-runtime/src/retrieval.rs
@@ -512,6 +512,12 @@ impl KhiveRuntime {
         .await
     }
 
+    /// `vector_similarity_floor` is a raw cosine-similarity value in `[-1.0,
+    /// 1.0]`, matching the scale documented on the `resolve` verb and on
+    /// `SEARCH_VECTOR_SIMILARITY_FLOOR`. Vector store hits are scored on the
+    /// `(1 + cos) / 2` storage scale (`khive-db` `stores/vectors.rs`), so the
+    /// comparison converts the floor to that scale rather than comparing the
+    /// raw cosine value against a storage-scale score directly.
     #[allow(clippy::too_many_arguments)]
     pub(crate) async fn hybrid_search_with_vector_similarity_floor(
         &self,
@@ -534,7 +540,7 @@ impl KhiveRuntime {
             entity_type,
             tags_any,
             properties_filter,
-            Some(DeterministicScore::from_f64(vector_similarity_floor)),
+            Some(vector_similarity_floor),
         )
         .await
     }
@@ -550,7 +556,7 @@ impl KhiveRuntime {
         entity_type: Option<&str>,
         tags_any: &[String],
         properties_filter: Option<&serde_json::Value>,
-        vector_similarity_floor: Option<DeterministicScore>,
+        vector_similarity_floor: Option<f64>,
     ) -> RuntimeResult<Vec<SearchHit>> {
         let candidates = limit.saturating_mul(CANDIDATE_MULTIPLIER).max(limit);
 
@@ -597,8 +603,15 @@ impl KhiveRuntime {
         } else {
             Vec::new()
         };
-        if let Some(floor) = vector_similarity_floor {
-            vector_hits.retain(|hit| hit.score >= floor);
+        if let Some(raw_cosine_floor) = vector_similarity_floor {
+            // Vector store scores are `(1 + cos) / 2` (khive-db stores/vectors.rs),
+            // so a raw-cosine floor must be converted to that scale before it is
+            // compared against `hit.score` — comparing the raw floor directly
+            // against a storage-scale score only rejects hits below raw cosine
+            // -0.4, letting an orthogonal (cosine 0, storage score 0.5) or
+            // opposite-direction candidate clear a floor meant to reject them.
+            let storage_floor = DeterministicScore::from_f64((1.0 + raw_cosine_floor) / 2.0);
+            vector_hits.retain(|hit| hit.score >= storage_floor);
         }
 
         // Keep the full candidate pool (untruncated) through the alive/kind/tag/property


### PR DESCRIPTION
## Summary

The semantic-fallback relevance floor added in #1302 documents a raw cosine-similarity floor of 0.3, but `hybrid_search_inner` compared it directly against `VectorSearchHit.score`, which the SQLite vector store reports on the `(1 + cos) / 2` storage scale (`score = 1 - distance / 2`). An orthogonal candidate (raw cosine 0.0) scores 0.5 on that scale and cleared the 0.3 floor, so an unrelated sole semantic candidate could still resolve. The documented floor only actually rejected candidates below raw cosine -0.4.

This converts the floor to the storage scale at the comparison site (`hybrid_search_inner` in `crates/khive-runtime/src/retrieval.rs`) instead of comparing values on different scales. The floor constant (`SEARCH_VECTOR_SIMILARITY_FLOOR`) and its call site continue to express the floor as a raw cosine value, matching the documented `resolve` verb contract.

## Test plan

- [x] New regression `fallback_stage_drops_orthogonal_semantic_only_candidate`: a sole semantic candidate at raw cosine ~0 (storage score 0.5) is now dropped by the floor.
- [x] `fallback_stage_resolves_high_similarity_semantic_only_candidate`: a clearly-related candidate (raw cosine 1.0, storage score 1.0) still resolves.
- [x] `fallback_stage_drops_low_similarity_semantic_only_candidates`: recast from the extreme opposite-vector fixture (raw cosine -1.0) to a genuine below-floor mismatch (raw cosine -0.5, storage score 0.25) so it still exercises real floor rejection on the corrected scale.
- [x] `cargo test -p khive-runtime`
- [x] `cargo fmt --all -- --check`

Closes #1366