### PR TITLE
chore: use neutral actor identifiers and paths across the tree

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -2,7 +2,7 @@
   "name": "khive",
   "description": "Knowledge graph runtime, structured memory, and agent coordination tools.",
   "owner": {
-    "name": "Ocean (HaiyangLi)",
+    "name": "HaiyangLi",
     "url": "https://github.com/ohdearquant"
   },
   "plugins": [

--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -48,7 +48,7 @@ jobs:
     timeout-minutes: 5
 
     # Guard: only bot-authored, non-draft PRs when the variable is set.
-    # Ocean flips LEO_AUTOMERGE_ENABLED to activate; flip back to deactivate.
+    # A repository admin flips LEO_AUTOMERGE_ENABLED to activate; flip back to deactivate.
     # LEO_AUTOMERGE_ENABLED is a repository variable settable only by an admin,
     # so no PR author can satisfy this guard on their own.
     if: >-

--- a/.github/workflows/bench-track.yml
+++ b/.github/workflows/bench-track.yml
@@ -1,9 +1,8 @@
 name: Bench Trend Tracking
 
 # Informational trend tracking for BOTH component (Criterion) and e2e
-# (bench-1m synthetic) benchmarks. Per the bench-program spec
-# (.khive/workspaces/20260710/bench-program/SPEC-draft.md, "Blocking-promotion
-# ladder"): every metric here is Advisory - measured, appended to
+# (bench-1m synthetic) benchmarks. Per the bench-program blocking-promotion
+# ladder: every metric here is Advisory - measured, appended to
 # bench-data/<suite>.jsonl on the `perf-data` branch, and rendered as a trend
 # summary. Nothing in this workflow asserts pass/fail or sets a threshold;
 # that requires K>=10 same-SHA calibration (scripts/perf/bench_calibrate.py)

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -103,7 +103,7 @@ jobs:
           EOF
 
           # basename -> "nav_order|Title|one-line description used in llms.txt"
-          # Order matches Ocean's requested sidebar: Getting Started, Knowledge
+          # Sidebar order: Getting Started, Knowledge
           # Graph Modeling, Memory, Search, Tasks, Prompt Cookbook, API Reference.
           declare -A NAV_ORDER=(
             [getting-started]="2|Getting Started|Install, connect an MCP client, and run your first khive session."

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -190,7 +190,7 @@ jobs:
     runs-on: ubuntu-latest
     # ADR-066 release gate: in the autonomous-merge model the human approval
     # moves from per-PR to per-release. This job publishes to npm; the
-    # 'publish' environment carries a required reviewer (Ocean), so even an
+    # 'publish' environment carries a required reviewer, so even an
     # automated or accidental tag pauses here until a human authorizes the
     # deployment. The environment is created by scripts/apply-autonomous-merge.sh
     # (STEP=release-gate). Until that runs, the gate is dormant (the environment

--- a/.khive/scripts/ingest_workspace_artifacts.py
+++ b/.khive/scripts/ingest_workspace_artifacts.py
@@ -81,8 +81,8 @@ KHIVE_DIR = REPO_ROOT / ".khive"
 CURSOR_PATH = SCRIPT_DIR / ".ws_ingest_cursor"
 # Fixed, checkout-independent path: multiple worktrees of this repo (or
 # multiple repos, incidentally) share the same khive.db, so the exclusion
-# lock must be machine-wide, not per-checkout. /tmp, lion-prefixed, never
-# inside a cargo target tree (fleet lock-naming convention).
+# lock must be machine-wide, not per-checkout. A fixed /tmp path, never
+# inside a cargo target tree.
 LOCK_PATH = Path("/tmp/khive-wsingest.lock")
 KKERNEL = os.path.expanduser("~/.cargo/bin/kkernel")
 

--- a/.khive/scripts/ingest_workspace_artifacts.py
+++ b/.khive/scripts/ingest_workspace_artifacts.py
@@ -44,7 +44,7 @@ Design notes:
   missing required edge (crates/khive-runtime/src/operations.rs
   create_note_inner).
 - CONCURRENCY: a machine-wide POSIX advisory lock (fcntl.flock on the fixed
-  path `/tmp/lion-khive-wsingest.lock`, independent of which checkout/
+  path `/tmp/khive-wsingest.lock`, independent of which checkout/
   worktree the script runs from) excludes concurrent --live invocations on
   this host. This is NOT a substitute for a server-side atomic natural-key
   dedup: the generic `create` verb does not expose the `external_id` /
@@ -83,7 +83,7 @@ CURSOR_PATH = SCRIPT_DIR / ".ws_ingest_cursor"
 # multiple repos, incidentally) share the same khive.db, so the exclusion
 # lock must be machine-wide, not per-checkout. /tmp, lion-prefixed, never
 # inside a cargo target tree (fleet lock-naming convention).
-LOCK_PATH = Path("/tmp/lion-khive-wsingest.lock")
+LOCK_PATH = Path("/tmp/khive-wsingest.lock")
 KKERNEL = os.path.expanduser("~/.cargo/bin/kkernel")
 
 # The daemon's embedder rejects create() content whose UTF-8 BYTE length

--- a/.khive/scripts/ingest_workspace_artifacts.py
+++ b/.khive/scripts/ingest_workspace_artifacts.py
@@ -9,8 +9,7 @@ verdicts that name a PR) an additional `annotates` edge to the matching
 git-pack `pull_request` note.
 
 No new MCP verbs are needed — this uses only the existing generic
-create/link/list/search verbs over the merged workspace-pack substrate
-(Ocean ruling 2026-07-13).
+create/link/list/search verbs over the merged workspace-pack substrate.
 
 Usage:
     uv run python .khive/scripts/ingest_workspace_artifacts.py --dry-run

--- a/crates/khive-db/src/migrations_tests.rs
+++ b/crates/khive-db/src/migrations_tests.rs
@@ -901,7 +901,7 @@ fn concurrent_boots_converge() {
     );
 }
 
-// khive#1217 review blocking finding: the pre-lock ahead-of-latest guard runs
+// Regression: the pre-lock ahead-of-latest guard runs
 // on a stale read. If a NEWER build commits a schema version above this
 // binary's latest while this process waits for the migration write lock, the
 // under-lock re-read must reject that version — not clamp it into a false Ok.

--- a/crates/khive-db/src/stores/graph_tests.rs
+++ b/crates/khive-db/src/stores/graph_tests.rs
@@ -1515,10 +1515,10 @@ async fn upsert_edge_cross_namespace_accepted() {
     let tgt = Uuid::new_v4();
     let now = Utc::now();
 
-    // Edge carries "lambda:leo" — different from store's "default".
+    // Edge carries "agent:alpha" — different from store's "default".
     let edge = Edge {
         id: Uuid::new_v4().into(),
-        namespace: "lambda:leo".to_string(),
+        namespace: "agent:alpha".to_string(),
         source_id: src,
         target_id: tgt,
         relation: EdgeRelation::Extends,
@@ -1542,7 +1542,7 @@ async fn upsert_edge_cross_namespace_accepted() {
     );
     let stored = stored.unwrap();
     assert_eq!(
-        stored.namespace, "lambda:leo",
+        stored.namespace, "agent:alpha",
         "namespace column must be preserved as stored"
     );
 }

--- a/crates/khive-gate/src/tests.rs
+++ b/crates/khive-gate/src/tests.rs
@@ -52,9 +52,9 @@ fn anonymous_actor_binding_id_is_none() {
 
 #[test]
 fn configured_actor_binding_id_is_its_id() {
-    let a = ActorRef::new("lambda", "leo");
+    let a = ActorRef::new("lambda", "alpha");
     assert!(!a.is_anonymous());
-    assert_eq!(a.binding_id(), Some("leo"));
+    assert_eq!(a.binding_id(), Some("alpha"));
 }
 
 #[test]

--- a/crates/khive-mcp/src/daemon.rs
+++ b/crates/khive-mcp/src/daemon.rs
@@ -3382,8 +3382,8 @@ mod tests {
         std::env::set_var("KHIVE_PID", &pid);
         std::env::remove_var("KHIVE_NO_DAEMON");
 
-        let actor_a = "lambda:actor-a";
-        let actor_b = "lambda:actor-b";
+        let actor_a = "agent:actor-a";
+        let actor_b = "agent:actor-b";
         let cfg_a = folded_actor_memory_config(actor_a);
         let cfg_b = folded_actor_memory_config(actor_b);
         let ns_a = Namespace::parse(actor_a).expect("actor a namespace");
@@ -3446,7 +3446,7 @@ mod tests {
         let seed_a = exchange(
             &sock,
             &frame(
-                r#"create(kind="concept", name="ActorAVisibleOnly", namespace="lambda:actor-a")"#,
+                r#"create(kind="concept", name="ActorAVisibleOnly", namespace="agent:actor-a")"#,
                 actor_a,
                 &cfg_a.visible_namespaces,
             ),
@@ -3456,7 +3456,7 @@ mod tests {
         let seed_b = exchange(
             &sock,
             &frame(
-                r#"create(kind="concept", name="ActorBVisibleOnly", namespace="lambda:actor-b")"#,
+                r#"create(kind="concept", name="ActorBVisibleOnly", namespace="agent:actor-b")"#,
                 actor_b,
                 &cfg_b.visible_namespaces,
             ),

--- a/crates/khive-mcp/src/daemon.rs
+++ b/crates/khive-mcp/src/daemon.rs
@@ -687,7 +687,7 @@ fn spawn_daemon_with_exe(exe: &std::path::Path) -> std::io::Result<std::process:
 ///
 /// Both conditions must hold:
 /// (a) the first whitespace-delimited token's file-name basename is exactly
-///     `kkernel` (an absolute path like `/Users/x/.cargo/bin/kkernel` is
+///     `kkernel` (an absolute path like `/usr/local/bin/kkernel` is
 ///     accepted; a basename of `not-kkernel` or a wrapper whose argv[0] merely
 ///     mentions kkernel elsewhere is rejected), AND
 /// (b) the remaining tokens contain both `mcp` and `--daemon` as distinct
@@ -3758,7 +3758,7 @@ mod tests {
     fn argv_daemon_true_absolute_path() {
         // Absolute path to kkernel binary — basename must match.
         assert!(argv_is_khive_daemon(
-            "/Users/x/.cargo/bin/kkernel mcp --daemon"
+            "/usr/local/bin/kkernel mcp --daemon"
         ));
     }
 
@@ -3772,7 +3772,7 @@ mod tests {
     fn argv_daemon_false_less_with_kkernel_path() {
         // less paging a kkernel source file — argv[0] is "less", not "kkernel".
         assert!(!argv_is_khive_daemon(
-            "less /Users/x/projects/kkernel/daemon.rs"
+            "less /usr/local/src/kkernel/daemon.rs"
         ));
     }
 
@@ -3797,7 +3797,7 @@ mod tests {
     #[test]
     fn argv_daemon_true_with_surrounding_and_inner_whitespace() {
         assert!(argv_is_khive_daemon(
-            "  /Users/x/.cargo/bin/kkernel   mcp    --daemon  "
+            "  /usr/local/bin/kkernel   mcp    --daemon  "
         ));
     }
 
@@ -3807,7 +3807,7 @@ mod tests {
         // as a valid daemon so stale bench daemons are SIGTERM'd on respawn.
         assert!(argv_is_khive_daemon("kkernel-bench mcp --daemon"));
         assert!(argv_is_khive_daemon(
-            "/Users/x/.cargo/bin/kkernel-bench mcp --daemon"
+            "/usr/local/bin/kkernel-bench mcp --daemon"
         ));
     }
 

--- a/crates/khive-mcp/src/serve.rs
+++ b/crates/khive-mcp/src/serve.rs
@@ -581,7 +581,7 @@ fn build_registry_for_multi_backend_inner(
         tracing::warn!(
             "actor identity resolved to \"local\": comm sends will be stamped from \
              \"local\" (unattributed) and comm.inbox will be unscoped (party-line). \
-             Set KHIVE_ACTOR or --actor to this lambda's id."
+             Set KHIVE_ACTOR or --actor to this agent's id."
         );
     }
 
@@ -714,7 +714,7 @@ pub fn enforce_strict_actor_mode(
     if is_strict_actor_mode() && should_warn_unattributed(actor_id, loaded_packs) {
         anyhow::bail!(
             "KHIVE_REQUIRE_ATTRIBUTED_ACTOR=1 is set but no actor identity is \
-             configured. Set KHIVE_ACTOR or --actor to this lambda's id before \
+             configured. Set KHIVE_ACTOR or --actor to this agent's id before \
              starting in strict mode (comm pack requires an attributed actor to \
              prevent party-line inbox exposure)."
         );
@@ -827,7 +827,7 @@ pub fn build_server_with_explicit_namespace(
             tracing::warn!(
                 "actor identity resolved to \"local\": comm sends will be stamped from \
                  \"local\" (unattributed) and comm.inbox will be unscoped (party-line). \
-                 Set KHIVE_ACTOR or --actor to this lambda's id."
+                 Set KHIVE_ACTOR or --actor to this agent's id."
             );
         }
         let schedule_rt = runtime
@@ -1867,7 +1867,7 @@ brain_profile = "project-profile"
 
     /// Regression for #203: the `--actor` / `--namespace`
     /// CLI flag must set `actor_id`, not just `default_namespace`. Before the fix,
-    /// `--actor lambda:x` with no `KHIVE_ACTOR` env and no config-file `[actor] id`
+    /// `--actor agent:x` with no `KHIVE_ACTOR` env and no config-file `[actor] id`
     /// left actor_id None → anonymous token → degraded ADR-057 comm + false warning.
     #[test]
     #[serial]
@@ -1885,7 +1885,7 @@ brain_profile = "project-profile"
         let resolved = resolve_runtime_config(RuntimeConfigInputs {
             db: Some(":memory:"),
             config: Some(&missing_config),
-            namespace: Namespace::parse("lambda:agent-x").expect("ns"),
+            namespace: Namespace::parse("agent:agent-x").expect("ns"),
             namespace_explicit: true,
             actor_explicit: true,
             no_embed: true,
@@ -1896,12 +1896,12 @@ brain_profile = "project-profile"
 
         assert_eq!(
             resolved.actor_id.as_deref(),
-            Some("lambda:agent-x"),
+            Some("agent:agent-x"),
             "--actor flag must populate actor_id (flag==env parity), not just default_namespace"
         );
         assert_eq!(
             resolved.default_namespace.as_str(),
-            "lambda:agent-x",
+            "agent:agent-x",
             "the flag still sets the write namespace"
         );
     }
@@ -1924,7 +1924,7 @@ brain_profile = "project-profile"
         let resolved = resolve_runtime_config(RuntimeConfigInputs {
             db: Some(":memory:"),
             config: Some(&path),
-            namespace: Namespace::parse("lambda:cli-actor").expect("ns"),
+            namespace: Namespace::parse("agent:cli-actor").expect("ns"),
             namespace_explicit: true,
             actor_explicit: true,
             no_embed: true,
@@ -1933,8 +1933,8 @@ brain_profile = "project-profile"
         })
         .expect("resolve no-embed config");
 
-        assert_eq!(resolved.default_namespace.as_str(), "lambda:cli-actor");
-        assert_eq!(resolved.actor_id.as_deref(), Some("lambda:cli-actor"));
+        assert_eq!(resolved.default_namespace.as_str(), "agent:cli-actor");
+        assert_eq!(resolved.actor_id.as_deref(), Some("agent:cli-actor"));
         assert_eq!(resolved.git_write.allowed.len(), 1);
         assert_eq!(
             resolved.git_write.allowed[0].repo,
@@ -2031,7 +2031,7 @@ brain_profile = "project-profile"
         std::fs::create_dir_all(seat_dir.path().join(".khive")).expect("mkdir seat .khive");
         std::fs::write(
             seat_dir.path().join(".khive/config.toml"),
-            "[actor]\nid = \"lambda:seat-actor\"\n",
+            "[actor]\nid = \"agent:seat-actor\"\n",
         )
         .expect("write seat config");
 
@@ -2039,7 +2039,7 @@ brain_profile = "project-profile"
 
         assert_eq!(
             khive_runtime::resolve_project_actor_id(None).expect("no config error"),
-            Some("lambda:seat-actor".to_string()),
+            Some("agent:seat-actor".to_string()),
             "resolve_project_actor_id must read the cwd-anchored .khive/config.toml \
              regardless of any database directory"
         );
@@ -2066,7 +2066,7 @@ brain_profile = "project-profile"
         std::fs::create_dir_all(seat_dir.path().join(".khive")).expect("mkdir seat .khive");
         std::fs::write(
             seat_dir.path().join(".khive/config.toml"),
-            "[actor]\nid = \"lambda:seat-actor\"\n",
+            "[actor]\nid = \"agent:seat-actor\"\n",
         )
         .expect("write seat config");
 
@@ -2095,7 +2095,7 @@ brain_profile = "project-profile"
 
         assert_eq!(
             resolved.actor_id.as_deref(),
-            Some("lambda:seat-actor"),
+            Some("agent:seat-actor"),
             "a seat-shaped cwd with its own [actor] must resolve that actor through \
              the full discovery path even when the shared db-anchored config \
              location carries none — got {:?}",
@@ -2178,7 +2178,7 @@ brain_profile = "project-profile"
         std::fs::create_dir_all(seat_dir.path().join(".khive")).expect("mkdir seat .khive");
         std::fs::write(
             seat_dir.path().join(".khive/config.toml"),
-            "[actor]\nid = \"lambda:project-actor\"\n",
+            "[actor]\nid = \"agent:project-actor\"\n",
         )
         .expect("write seat config");
 
@@ -2187,7 +2187,7 @@ brain_profile = "project-profile"
         let resolved = resolve_runtime_config(RuntimeConfigInputs {
             db: Some(":memory:"),
             config: None,
-            namespace: Namespace::parse("lambda:cli-actor").expect("ns"),
+            namespace: Namespace::parse("agent:cli-actor").expect("ns"),
             namespace_explicit: true,
             actor_explicit: true,
             no_embed: true,
@@ -2198,7 +2198,7 @@ brain_profile = "project-profile"
 
         assert_eq!(
             resolved.actor_id.as_deref(),
-            Some("lambda:cli-actor"),
+            Some("agent:cli-actor"),
             "an explicit --actor flag must win over a discovered project-config actor"
         );
     }
@@ -2216,11 +2216,11 @@ brain_profile = "project-profile"
             dir.path(),
             r#"
 [actor]
-id = "lambda:project-actor"
+id = "agent:project-actor"
 "#,
         );
 
-        std::env::set_var("KHIVE_ACTOR", "lambda:env-actor");
+        std::env::set_var("KHIVE_ACTOR", "agent:env-actor");
 
         let with_project_config = resolve_runtime_config(RuntimeConfigInputs {
             db: Some(":memory:"),
@@ -2252,12 +2252,12 @@ id = "lambda:project-actor"
 
         assert_eq!(
             with_project_config.actor_id.as_deref(),
-            Some("lambda:project-actor"),
+            Some("agent:project-actor"),
             "a project-config [actor] id must win over KHIVE_ACTOR env"
         );
         assert_eq!(
             without_project_config.actor_id.as_deref(),
-            Some("lambda:env-actor"),
+            Some("agent:env-actor"),
             "KHIVE_ACTOR env must still be used when no project config actor exists"
         );
     }
@@ -2279,12 +2279,12 @@ id = "lambda:project-actor"
         std::fs::create_dir_all(seat_dir.path().join(".khive")).expect("mkdir seat .khive");
         std::fs::write(
             seat_dir.path().join(".khive/config.toml"),
-            "[actor]\nid = \"lambda:project-actor\"\n",
+            "[actor]\nid = \"agent:project-actor\"\n",
         )
         .expect("write seat config");
 
         let _seat_env = SeatEnv::enter(seat_dir.path());
-        std::env::set_var("KHIVE_ACTOR", "lambda:env-actor");
+        std::env::set_var("KHIVE_ACTOR", "agent:env-actor");
 
         // The real arg vector `kkernel mcp` parses — no `--actor` flag, so a
         // pre-fix `env = "KHIVE_ACTOR"` binding would populate `args.actor`.
@@ -2312,7 +2312,7 @@ id = "lambda:project-actor"
         );
         assert_eq!(
             resolved.actor_id.as_deref(),
-            Some("lambda:project-actor"),
+            Some("agent:project-actor"),
             "project-config [actor] id must win over KHIVE_ACTOR env on the real clap path"
         );
         assert_eq!(
@@ -2338,7 +2338,7 @@ id = "lambda:project-actor"
         // (~/.khive/config.toml) both come up empty.
         let seat_dir = tempfile::tempdir().expect("seat tempdir");
         let _seat_env = SeatEnv::enter(seat_dir.path());
-        std::env::set_var("KHIVE_ACTOR", "lambda:env-only-actor");
+        std::env::set_var("KHIVE_ACTOR", "agent:env-only-actor");
 
         let args = Args::try_parse_from(["mcp"]).expect("parse real mcp args");
         let (namespace_explicit, namespace) =
@@ -2364,7 +2364,7 @@ id = "lambda:project-actor"
         );
         assert_eq!(
             resolved.actor_id.as_deref(),
-            Some("lambda:env-only-actor"),
+            Some("agent:env-only-actor"),
             "KHIVE_ACTOR env must still land as the tier-3 actor_id fallback \
              when no project config exists"
         );
@@ -2392,7 +2392,7 @@ id = "lambda:project-actor"
         std::fs::create_dir_all(seat_dir.path().join(".khive")).expect("mkdir seat .khive");
         std::fs::write(
             seat_dir.path().join(".khive/config.toml"),
-            "[actor]\nid = \"lambda:seat-actor\"\n",
+            "[actor]\nid = \"agent:seat-actor\"\n",
         )
         .expect("write seat config");
 
@@ -2404,7 +2404,7 @@ id = "lambda:project-actor"
         std::fs::create_dir_all(&khive_dir).expect("mkdir db .khive");
         std::fs::write(
             khive_dir.join("config.toml"),
-            "[actor]\nid = \"lambda:db-actor\"\n",
+            "[actor]\nid = \"agent:db-actor\"\n",
         )
         .expect("write db-anchored config");
         let db_path = khive_dir.join("khive.db");
@@ -2478,7 +2478,7 @@ id = "lambda:project-actor"
         std::fs::create_dir_all(seat_a.path().join(".khive")).expect("mkdir seat a .khive");
         std::fs::write(
             seat_a.path().join(".khive/config.toml"),
-            "[actor]\nid = \"lambda:actor-a\"\n",
+            "[actor]\nid = \"agent:actor-a\"\n",
         )
         .expect("write seat a config");
 
@@ -2486,7 +2486,7 @@ id = "lambda:project-actor"
         std::fs::create_dir_all(seat_b.path().join(".khive")).expect("mkdir seat b .khive");
         std::fs::write(
             seat_b.path().join(".khive/config.toml"),
-            "[actor]\nid = \"lambda:actor-b\"\n",
+            "[actor]\nid = \"agent:actor-b\"\n",
         )
         .expect("write seat b config");
 
@@ -2520,8 +2520,8 @@ id = "lambda:project-actor"
             .expect("resolve config b")
         };
 
-        assert_eq!(cfg_a.actor_id.as_deref(), Some("lambda:actor-a"));
-        assert_eq!(cfg_b.actor_id.as_deref(), Some("lambda:actor-b"));
+        assert_eq!(cfg_a.actor_id.as_deref(), Some("agent:actor-a"));
+        assert_eq!(cfg_b.actor_id.as_deref(), Some("agent:actor-b"));
         assert_ne!(
             cfg_a.actor_id, cfg_b.actor_id,
             "precondition: the two connections must actually declare different actors"
@@ -4224,7 +4224,7 @@ region = "us-east-1"
     #[test]
     fn no_warn_when_actor_is_configured() {
         assert!(!should_warn_unattributed(
-            Some("lambda:khive"),
+            Some("agent:khive"),
             &packs(&["kg", "comm"])
         ));
     }
@@ -4323,7 +4323,7 @@ region = "us-east-1"
         // Strict mode ON + proper actor = Ok (comm pack present is irrelevant).
         let prev = std::env::var("KHIVE_REQUIRE_ATTRIBUTED_ACTOR").ok();
         std::env::set_var("KHIVE_REQUIRE_ATTRIBUTED_ACTOR", "1");
-        let result = enforce_strict_actor_mode(Some("lambda:tenant-x"), &packs(&["kg", "comm"]));
+        let result = enforce_strict_actor_mode(Some("agent:tenant-x"), &packs(&["kg", "comm"]));
         match prev {
             Some(v) => std::env::set_var("KHIVE_REQUIRE_ATTRIBUTED_ACTOR", v),
             None => std::env::remove_var("KHIVE_REQUIRE_ATTRIBUTED_ACTOR"),

--- a/crates/khive-mcp/tests/integration.rs
+++ b/crates/khive-mcp/tests/integration.rs
@@ -2521,14 +2521,14 @@ fn actor_precedence_config_actor_id_does_not_route_namespace() {
     let path = dir.path().join("config.toml");
     writeln!(
         std::fs::File::create(&path).unwrap(),
-        "[actor]\nid = \"lambda:from-config\"\n"
+        "[actor]\nid = \"agent:from-config\"\n"
     )
     .unwrap();
 
     let khive_cfg = KhiveConfig::load(Some(&path))
         .expect("load should succeed")
         .expect("file found");
-    assert_eq!(khive_cfg.actor.id.as_deref(), Some("lambda:from-config"));
+    assert_eq!(khive_cfg.actor.id.as_deref(), Some("agent:from-config"));
 
     // No CLI actor → base stays at "local" default; config actor.id must not move it.
     let base = RuntimeConfig::default();
@@ -2558,7 +2558,7 @@ fn actor_precedence_explicit_namespace_local_wins_over_config() {
     let path = dir.path().join("config.toml");
     writeln!(
         std::fs::File::create(&path).unwrap(),
-        "[actor]\nid = \"lambda:from-config\"\n"
+        "[actor]\nid = \"agent:from-config\"\n"
     )
     .unwrap();
 
@@ -2594,7 +2594,7 @@ fn actor_precedence_cli_actor_wins_over_config() {
     let path = dir.path().join("config.toml");
     writeln!(
         std::fs::File::create(&path).unwrap(),
-        "[actor]\nid = \"lambda:from-config\"\n"
+        "[actor]\nid = \"agent:from-config\"\n"
     )
     .unwrap();
 
@@ -2602,20 +2602,20 @@ fn actor_precedence_cli_actor_wins_over_config() {
         .expect("load should succeed")
         .expect("file found");
 
-    // Simulate: --actor lambda:cli-actor supplied → cli_namespace_explicit = true.
+    // Simulate: --actor agent:cli-actor supplied → cli_namespace_explicit = true.
     let mut effective_cfg = khive_cfg;
     effective_cfg.actor.id = None; // CLI wins — suppress config actor.
 
     let base = RuntimeConfig {
-        default_namespace: Namespace::parse("lambda:cli-actor").unwrap(),
+        default_namespace: Namespace::parse("agent:cli-actor").unwrap(),
         additional_embedding_models: vec![],
         ..RuntimeConfig::default()
     };
     let resolved = runtime_config_from_khive_config(&effective_cfg, base);
     assert_eq!(
         resolved.default_namespace,
-        Namespace::parse("lambda:cli-actor").unwrap(),
-        "--actor lambda:cli-actor must win over config actor.id"
+        Namespace::parse("agent:cli-actor").unwrap(),
+        "--actor agent:cli-actor must win over config actor.id"
     );
 }
 
@@ -2707,10 +2707,10 @@ fn cli_args_actor_flag_is_explicit() {
     use khive_runtime::Namespace;
 
     let _guard = ClearEnvGuard::new(&["KHIVE_ACTOR", "KHIVE_NAMESPACE"]);
-    let args = Args::try_parse_from(["khive-mcp", "--actor", "lambda:cli-actor"]).unwrap();
+    let args = Args::try_parse_from(["khive-mcp", "--actor", "agent:cli-actor"]).unwrap();
     let (explicit, ns) = resolve_cli_namespace(&args).unwrap();
     assert!(explicit, "--actor must mark namespace as explicit");
-    assert_eq!(ns, Namespace::parse("lambda:cli-actor").unwrap());
+    assert_eq!(ns, Namespace::parse("agent:cli-actor").unwrap());
 }
 
 /// Tier 1b: --actor local → explicit=true (regression guard: must NOT be treated as absent).
@@ -2740,10 +2740,10 @@ fn cli_args_namespace_flag_is_explicit() {
     use khive_runtime::Namespace;
 
     let _guard = ClearEnvGuard::new(&["KHIVE_ACTOR", "KHIVE_NAMESPACE"]);
-    let args = Args::try_parse_from(["khive-mcp", "--namespace", "lambda:ns-flag"]).unwrap();
+    let args = Args::try_parse_from(["khive-mcp", "--namespace", "agent:ns-flag"]).unwrap();
     let (explicit, ns) = resolve_cli_namespace(&args).unwrap();
     assert!(explicit, "--namespace must mark namespace as explicit");
-    assert_eq!(ns, Namespace::parse("lambda:ns-flag").unwrap());
+    assert_eq!(ns, Namespace::parse("agent:ns-flag").unwrap());
 }
 
 /// Tier 2b: --namespace local → explicit=true (the original regression case).
@@ -2776,16 +2776,16 @@ fn cli_args_actor_wins_over_namespace_when_both_supplied() {
     let args = Args::try_parse_from([
         "khive-mcp",
         "--actor",
-        "lambda:actor-wins",
+        "agent:actor-wins",
         "--namespace",
-        "lambda:ns-loses",
+        "agent:ns-loses",
     ])
     .unwrap();
     let (explicit, ns) = resolve_cli_namespace(&args).unwrap();
     assert!(explicit);
     assert_eq!(
         ns,
-        Namespace::parse("lambda:actor-wins").unwrap(),
+        Namespace::parse("agent:actor-wins").unwrap(),
         "--actor must win over --namespace when both are supplied"
     );
 }
@@ -2824,7 +2824,7 @@ fn cli_args_khive_namespace_env_is_explicit() {
 
     let _guard = ClearEnvGuard::new(&["KHIVE_NAMESPACE", "KHIVE_ACTOR"]);
 
-    std::env::set_var("KHIVE_NAMESPACE", "lambda:from-env");
+    std::env::set_var("KHIVE_NAMESPACE", "agent:from-env");
     let args = Args::try_parse_from(["khive-mcp"]).unwrap();
     std::env::remove_var("KHIVE_NAMESPACE");
 
@@ -2833,7 +2833,7 @@ fn cli_args_khive_namespace_env_is_explicit() {
         explicit,
         "KHIVE_NAMESPACE env must mark namespace as explicit"
     );
-    assert_eq!(ns, Namespace::parse("lambda:from-env").unwrap());
+    assert_eq!(ns, Namespace::parse("agent:from-env").unwrap());
 }
 
 /// ADR-096 Fork 2 (PR #657): `KHIVE_ACTOR` env var must NOT
@@ -2856,8 +2856,8 @@ fn cli_args_khive_actor_env_no_longer_occupies_cli_tier() {
 
     let _guard = ClearEnvGuard::new(&["KHIVE_NAMESPACE", "KHIVE_ACTOR"]);
 
-    std::env::set_var("KHIVE_ACTOR", "lambda:actor-env");
-    std::env::set_var("KHIVE_NAMESPACE", "lambda:ns-env");
+    std::env::set_var("KHIVE_ACTOR", "agent:actor-env");
+    std::env::set_var("KHIVE_NAMESPACE", "agent:ns-env");
     let args = Args::try_parse_from(["khive-mcp"]).unwrap();
     std::env::remove_var("KHIVE_ACTOR");
     std::env::remove_var("KHIVE_NAMESPACE");
@@ -2875,7 +2875,7 @@ fn cli_args_khive_actor_env_no_longer_occupies_cli_tier() {
     );
     assert_eq!(
         ns,
-        Namespace::parse("lambda:ns-env").unwrap(),
+        Namespace::parse("agent:ns-env").unwrap(),
         "with KHIVE_ACTOR no longer in the CLI tier, KHIVE_NAMESPACE decides \
          the resolved namespace instead of KHIVE_ACTOR"
     );
@@ -3477,7 +3477,7 @@ fn compute_config_id_is_identical_when_only_visible_namespaces_differ() {
 /// fingerprints.
 ///
 /// Without this, a daemon started with `allowed_outbound_namespaces =
-/// ["lambda:khive"]` could be reused for a client whose local config has an
+/// ["agent:khive"]` could be reused for a client whose local config has an
 /// empty allowlist — granting cross-namespace writes that the client should
 /// fail closed on.
 #[test]
@@ -3491,7 +3491,7 @@ fn compute_config_id_differs_when_allowed_outbound_namespaces_differ() {
     base.default_namespace = Namespace::parse("out-a").unwrap();
     base.allowed_outbound_namespaces = vec![];
     let with_outbound = RuntimeConfig {
-        allowed_outbound_namespaces: vec![Namespace::parse("lambda:khive").unwrap()],
+        allowed_outbound_namespaces: vec![Namespace::parse("agent:khive").unwrap()],
         ..base.clone()
     };
 
@@ -3504,8 +3504,8 @@ fn compute_config_id_differs_when_allowed_outbound_namespaces_differ() {
          same id would allow wrong-allowlist daemon reuse"
     );
     assert!(
-        id_with_outbound.contains("lambda:khive"),
-        "allowed outbound namespace 'lambda:khive' must appear in config_id string; got: {id_with_outbound}"
+        id_with_outbound.contains("agent:khive"),
+        "allowed outbound namespace 'agent:khive' must appear in config_id string; got: {id_with_outbound}"
     );
 }
 
@@ -3521,21 +3521,21 @@ fn compute_config_id_is_stable_under_allowed_outbound_namespace_reorder() {
         .clone();
     cfg_ab.default_namespace = Namespace::parse("out-a").unwrap();
     cfg_ab.allowed_outbound_namespaces = vec![
-        Namespace::parse("lambda:khive").unwrap(),
-        Namespace::parse("lambda:leo").unwrap(),
+        Namespace::parse("agent:khive").unwrap(),
+        Namespace::parse("agent:alpha").unwrap(),
     ];
     let cfg_ba = RuntimeConfig {
         allowed_outbound_namespaces: vec![
-            Namespace::parse("lambda:leo").unwrap(),
-            Namespace::parse("lambda:khive").unwrap(),
+            Namespace::parse("agent:alpha").unwrap(),
+            Namespace::parse("agent:khive").unwrap(),
         ],
         ..cfg_ab.clone()
     };
     let cfg_dup = RuntimeConfig {
         allowed_outbound_namespaces: vec![
-            Namespace::parse("lambda:khive").unwrap(),
-            Namespace::parse("lambda:leo").unwrap(),
-            Namespace::parse("lambda:khive").unwrap(), // duplicate
+            Namespace::parse("agent:khive").unwrap(),
+            Namespace::parse("agent:alpha").unwrap(),
+            Namespace::parse("agent:khive").unwrap(), // duplicate
         ],
         ..cfg_ab.clone()
     };
@@ -3663,13 +3663,13 @@ fn compute_config_id_normalizes_absent_and_present_but_empty_git_write_to_same_f
 ///
 ///   (a) with `default_namespace = local`, a plain `create` lands in `"local"`.
 ///
-///   (b) an explicit `create(namespace="lambda:leo")` lands in `"lambda:leo"` —
+///   (b) an explicit `create(namespace="agent:alpha")` lands in `"agent:alpha"` —
 ///       the caller deliberately targeting a namespace (Rule 1).  This is exactly
 ///       what #159's unconditional `Namespace::local()` hard-pin wrongly collapsed
 ///       to `"local"`.
 ///
-///   (c) a default `list` (local) sees the local entity but NOT the lambda:leo one,
-///       and `list(namespace="lambda:leo")` sees the lambda:leo entity but NOT the
+///   (c) a default `list` (local) sees the local entity but NOT the agent:alpha one,
+///       and `list(namespace="agent:alpha")` sees the agent:alpha entity but NOT the
 ///       local one — multi-record reads filter by the supplied namespace.
 ///
 /// Regression sensitivity: if dispatch reverts to pinning `Namespace::local()`,
@@ -3749,10 +3749,10 @@ async fn dispatch_honors_explicit_namespace_else_local_adr007() {
         .expect("create result must carry 'id'")
         .to_string();
 
-    // ── (b) EXPLICIT CREATE: namespace="lambda:leo" is honored ───────────────
+    // ── (b) EXPLICIT CREATE: namespace="agent:alpha" is honored ───────────────
     let named_res = dispatch_op(
         &server,
-        r#"create(kind="concept", name="NamedProbe", namespace="lambda:leo")"#,
+        r#"create(kind="concept", name="NamedProbe", namespace="agent:alpha")"#,
     )
     .await;
     assert_eq!(
@@ -3762,8 +3762,8 @@ async fn dispatch_honors_explicit_namespace_else_local_adr007() {
     );
     assert_eq!(
         named_res["result"]["namespace"].as_str().unwrap_or(""),
-        "lambda:leo",
-        "create(namespace=\"lambda:leo\") must land in 'lambda:leo', not be collapsed to \
+        "agent:alpha",
+        "create(namespace=\"agent:alpha\") must land in 'agent:alpha', not be collapsed to \
          'local' (ADR-007 Rev 2 Rule 1 — explicit namespace is honored); got: {named_res}"
     );
     let named_id = named_res["result"]["id"]
@@ -3771,7 +3771,7 @@ async fn dispatch_honors_explicit_namespace_else_local_adr007() {
         .expect("create result must carry 'id'")
         .to_string();
 
-    // ── (c) LIST scoping: default(local) vs explicit(lambda:leo) ─────────────
+    // ── (c) LIST scoping: default(local) vs explicit(agent:alpha) ─────────────
     let local_ids = list_ids(&dispatch_op(&server, r#"list(kind="entity")"#).await);
     assert!(
         local_ids.contains(&default_id),
@@ -3779,18 +3779,18 @@ async fn dispatch_honors_explicit_namespace_else_local_adr007() {
     );
     assert!(
         !local_ids.contains(&named_id),
-        "default(local) list must NOT see the lambda:leo entity; got: {local_ids:?}"
+        "default(local) list must NOT see the agent:alpha entity; got: {local_ids:?}"
     );
 
-    let leo_ids =
-        list_ids(&dispatch_op(&server, r#"list(kind="entity", namespace="lambda:leo")"#).await);
+    let peer_ids =
+        list_ids(&dispatch_op(&server, r#"list(kind="entity", namespace="agent:alpha")"#).await);
     assert!(
-        leo_ids.contains(&named_id),
-        "list(namespace=lambda:leo) must see the lambda:leo entity; got: {leo_ids:?}"
+        peer_ids.contains(&named_id),
+        "list(namespace=agent:alpha) must see the agent:alpha entity; got: {peer_ids:?}"
     );
     assert!(
-        !leo_ids.contains(&default_id),
-        "list(namespace=lambda:leo) must NOT see the local entity; got: {leo_ids:?}"
+        !peer_ids.contains(&default_id),
+        "list(namespace=agent:alpha) must NOT see the local entity; got: {peer_ids:?}"
     );
 }
 
@@ -3957,7 +3957,7 @@ async fn presentation_per_op_verbose_preserves_full_id_namespace_and_props() {
     // top-level `name`/`description` fields — the same shape the redundancy-
     // drop pre-pass targets (ADR-078 §7.2).
     let create_params = RequestParams {
-        ops: r#"create(kind="entity", entity_kind="concept", name="verbose-pin-entity", description="verbose-pin-description", properties={"name":"verbose-pin-entity","description":"verbose-pin-description","team":"lambda:test"})"#
+        ops: r#"create(kind="entity", entity_kind="concept", name="verbose-pin-entity", description="verbose-pin-description", properties={"name":"verbose-pin-entity","description":"verbose-pin-description","team":"agent:test"})"#
             .to_string(),
         presentation: Some("verbose".to_string()),
         presentation_per_op: None,
@@ -4082,7 +4082,7 @@ async fn format_auto_always_verbose_verb_skips_redundancy_drop_without_override(
     // Create a kg entity whose `properties` deliberately duplicate the
     // top-level `name`/`description` fields, and which carries namespace="local".
     let create_params = RequestParams {
-        ops: r#"create(kind="entity", entity_kind="concept", name="always-verbose-pin", description="always-verbose-pin-description", properties={"name":"always-verbose-pin","description":"always-verbose-pin-description","team":"lambda:test"})"#
+        ops: r#"create(kind="entity", entity_kind="concept", name="always-verbose-pin", description="always-verbose-pin-description", properties={"name":"always-verbose-pin","description":"always-verbose-pin-description","team":"agent:test"})"#
             .to_string(),
         presentation: Some("verbose".to_string()),
         presentation_per_op: None,

--- a/crates/khive-pack-kg/src/dispatch.rs
+++ b/crates/khive-pack-kg/src/dispatch.rs
@@ -712,9 +712,9 @@ mod tests {
     async fn non_local_actor_config_does_not_route_storage_adr007_rule0() {
         let rt = KhiveRuntime::memory().expect("in-memory runtime");
 
-        // Registry whose default namespace mirrors what `[actor] id = "lambda:leo"` sets.
+        // Registry whose default namespace mirrors what `[actor] id = "agent:alpha"` sets.
         let mut builder = VerbRegistryBuilder::new();
-        builder.with_default_namespace("lambda:leo");
+        builder.with_default_namespace("agent:alpha");
         builder.register(KgPack::new(rt.clone()));
         let registry = builder.build().expect("registry builds");
 
@@ -739,7 +739,7 @@ mod tests {
                 .and_then(|v| v.as_str())
                 .unwrap_or(""),
             "local",
-            "entity must land in 'local' even when default_namespace='lambda:leo'; \
+            "entity must land in 'local' even when default_namespace='agent:alpha'; \
              actor identity must not silently become the storage namespace (ADR-007 Rule 0)"
         );
 
@@ -765,8 +765,8 @@ mod tests {
         // written there, confirming storage was not routed through the actor namespace.
         let pack = KgPack::new(rt.clone());
         let actor_ns_token = rt
-            .authorize(Namespace::parse("lambda:leo").expect("valid namespace"))
-            .expect("authorize lambda:leo token");
+            .authorize(Namespace::parse("agent:alpha").expect("valid namespace"))
+            .expect("authorize agent:alpha token");
         let actor_list_result = pack
             .dispatch(
                 "list",
@@ -785,7 +785,7 @@ mod tests {
         };
         assert!(
             !ids_in_actor_ns.contains(&entity_id),
-            "storage must not have been routed to 'lambda:leo'; \
+            "storage must not have been routed to 'agent:alpha'; \
              entity must NOT appear when listing directly under that namespace; \
              got ids: {ids_in_actor_ns:?}"
         );
@@ -1415,7 +1415,7 @@ mod tests {
     async fn resolve_via_ring_survives_non_local_default_namespace() {
         let rt = KhiveRuntime::memory().expect("in-memory runtime");
         let mut builder = VerbRegistryBuilder::new();
-        builder.with_default_namespace("lambda:leo");
+        builder.with_default_namespace("agent:alpha");
         builder.register(KgPack::new(rt.clone()));
         let registry = builder.build().expect("registry build");
 

--- a/crates/khive-pack-kg/tests/integration.rs
+++ b/crates/khive-pack-kg/tests/integration.rs
@@ -12415,7 +12415,7 @@ async fn envelope_usage_equals_audit_row_resource_units() {
 async fn whoami_reports_configured_actor_and_namespace() {
     let rt = KhiveRuntime::memory().expect("in-memory runtime must succeed");
     let mut builder = VerbRegistryBuilder::new();
-    builder.with_actor_id(Some("lambda:khive".to_string()));
+    builder.with_actor_id(Some("agent:khive".to_string()));
     builder.register(KgPack::new(rt));
     let registry = builder.build().expect("registry builds");
 
@@ -12426,7 +12426,7 @@ async fn whoami_reports_configured_actor_and_namespace() {
 
     assert_eq!(
         result.get("actor_id").and_then(Value::as_str),
-        Some("lambda:khive"),
+        Some("agent:khive"),
         "whoami must report the configured actor id; got: {result}"
     );
     assert_eq!(

--- a/crates/khive-retrieval/src/replay/engine_replay.rs
+++ b/crates/khive-retrieval/src/replay/engine_replay.rs
@@ -94,7 +94,7 @@ pub struct RegressionReport {
 // weights_as_of
 // ---------------------------------------------------------------------------
 
-/// Reconstruct the weight state for a lambda at a given point in time.
+/// Reconstruct the weight state for a actor at a given point in time.
 ///
 /// For each (lambda_id, atom_id) pair, selects the latest `weight_events` row
 /// with `ts ≤ at_time` and returns `weight_after`.  Atoms with no history
@@ -180,7 +180,7 @@ pub async fn weights_as_of(
 /// The in-memory HNSW snapshot is global (it indexes all atoms regardless of
 /// namespace).  Without this post-filter, `replay()` would return atoms from
 /// any namespace that happen to be semantically close to the query, leaking
-/// cross-tenant atom UUIDs to the requesting lambda.
+/// cross-tenant atom UUIDs to the requesting actor.
 // REASON: called only from the `#[cfg(feature = "engine")]` replay() function; without the
 // feature gate the caller is compiled out, making this function appear dead to rustc.
 #[allow(dead_code)]
@@ -256,13 +256,13 @@ pub async fn replay(
         .await
         .map_err(|e| EngineError::Retrieval(format!("replay search: {e}")))?;
 
-    // Step 2b (B1 fix): filter to atoms owned by this lambda's namespace.
+    // Step 2b (B1 fix): filter to atoms owned by this actor's namespace.
     //
     // The HNSW snapshot is global — it contains atoms from every namespace
     // stored in this engine instance.  Without this filter, `replay()` would
     // leak cross-tenant atom UUIDs into the ranked result (they default to
     // weight 1.0 when absent from the weight map, potentially outranking the
-    // requesting lambda's own down-weighted atoms).
+    // requesting actor's own down-weighted atoms).
     //
     // A single engine instance may serve multiple lambdas whose atoms co-exist
     // in SQLite but whose HNSW vectors are interleaved.
@@ -868,21 +868,21 @@ mod tests {
     #[tokio::test]
     async fn test_weights_as_of_returns_snapshot_at_time() {
         let conn = make_conn();
-        let lambda = "lambda:test";
+        let actor = "agent:test";
         let atom = Uuid::new_v4();
         let atom_str = atom.to_string();
 
         // t0: weight 1.5
         let t0_us: i64 = 1_000_000_000;
-        insert_weight_event(&conn, lambda, &atom_str, 1.5, t0_us);
+        insert_weight_event(&conn, actor, &atom_str, 1.5, t0_us);
 
         // t1: weight 2.5 (later)
         let t1_us: i64 = 2_000_000_000;
-        insert_weight_event(&conn, lambda, &atom_str, 2.5, t1_us);
+        insert_weight_event(&conn, actor, &atom_str, 2.5, t1_us);
 
         // Query at t0 + 1: should see 1.5.
         let at_t0 = DateTime::from_timestamp_micros(t0_us + 1).unwrap();
-        let snapshot = weights_as_of(&conn, lambda, at_t0)
+        let snapshot = weights_as_of(&conn, actor, at_t0)
             .await
             .expect("weights_as_of");
         let w = *snapshot.get(&atom).expect("atom must be in snapshot");
@@ -890,7 +890,7 @@ mod tests {
 
         // Query at t1 + 1: should see 2.5.
         let at_t1 = DateTime::from_timestamp_micros(t1_us + 1).unwrap();
-        let snapshot2 = weights_as_of(&conn, lambda, at_t1)
+        let snapshot2 = weights_as_of(&conn, actor, at_t1)
             .await
             .expect("weights_as_of at t1");
         let w2 = *snapshot2
@@ -902,16 +902,16 @@ mod tests {
     #[tokio::test]
     async fn test_weights_as_of_before_any_event_is_empty() {
         let conn = make_conn();
-        let lambda = "lambda:test";
+        let actor = "agent:test";
         let atom = Uuid::new_v4();
         let atom_str = atom.to_string();
 
         let t1_us: i64 = 2_000_000_000;
-        insert_weight_event(&conn, lambda, &atom_str, 2.0, t1_us);
+        insert_weight_event(&conn, actor, &atom_str, 2.0, t1_us);
 
         // Query before t1: no rows.
         let before = DateTime::from_timestamp_micros(t1_us - 1).unwrap();
-        let snapshot = weights_as_of(&conn, lambda, before)
+        let snapshot = weights_as_of(&conn, actor, before)
             .await
             .expect("weights_as_of");
         assert!(
@@ -923,15 +923,15 @@ mod tests {
     #[tokio::test]
     async fn test_rank_history_returns_ordered_events() {
         let conn = make_conn();
-        let lambda = "lambda:rank_hist";
+        let actor = "agent:rank_hist";
         let atom = Uuid::new_v4();
         let atom_str = atom.to_string();
 
-        insert_weight_event(&conn, lambda, &atom_str, 1.2, 1_000);
-        insert_weight_event(&conn, lambda, &atom_str, 1.4, 2_000);
-        insert_weight_event(&conn, lambda, &atom_str, 1.1, 3_000);
+        insert_weight_event(&conn, actor, &atom_str, 1.2, 1_000);
+        insert_weight_event(&conn, actor, &atom_str, 1.4, 2_000);
+        insert_weight_event(&conn, actor, &atom_str, 1.1, 3_000);
 
-        let history = rank_history(&conn, lambda, atom)
+        let history = rank_history(&conn, actor, atom)
             .await
             .expect("rank_history");
 
@@ -996,7 +996,7 @@ mod tests {
     #[tokio::test]
     async fn test_adjustment_rate_per_day() {
         let conn = make_conn();
-        let lambda = "lambda:rate_test";
+        let actor = "agent:rate_test";
         let atom = Uuid::new_v4();
         let atom_str = atom.to_string();
 
@@ -1004,11 +1004,11 @@ mod tests {
         let now_us = Utc::now().timestamp_micros();
         let yesterday_us = now_us - 86_400_000_001_i64; // slightly over 24h ago
 
-        insert_weight_event(&conn, lambda, &atom_str, 1.1, now_us - 100);
-        insert_weight_event(&conn, lambda, &atom_str, 1.2, now_us - 50);
-        insert_weight_event(&conn, lambda, &atom_str, 1.3, yesterday_us);
+        insert_weight_event(&conn, actor, &atom_str, 1.1, now_us - 100);
+        insert_weight_event(&conn, actor, &atom_str, 1.2, now_us - 50);
+        insert_weight_event(&conn, actor, &atom_str, 1.3, yesterday_us);
 
-        let rates = metrics::adjustment_rate_per_day(&conn, lambda, 7)
+        let rates = metrics::adjustment_rate_per_day(&conn, actor, 7)
             .await
             .expect("adjustment_rate_per_day");
 

--- a/crates/khive-retrieval/src/weights/engine_weights.rs
+++ b/crates/khive-retrieval/src/weights/engine_weights.rs
@@ -190,7 +190,7 @@ pub async fn apply_weight_delta_with_eta(
 // batch_load_weights
 // ---------------------------------------------------------------------------
 
-/// Batch-load current weights for a slice of atom IDs under one lambda.
+/// Batch-load current weights for a slice of atom IDs under one actor.
 ///
 /// Only rows that exist in `atom_weights` are returned.  Missing atoms are
 /// **not** inserted; callers should treat absent entries as implicit 1.0.
@@ -305,7 +305,7 @@ mod tests {
     #[tokio::test]
     async fn test_apply_weight_delta_ambient_channel() {
         let conn = make_conn();
-        let lambda = "lambda:test";
+        let actor = "agent:test";
         let atom = Uuid::new_v4();
         let delta = 0.01_f32; // positive ambient nudge
 
@@ -313,7 +313,7 @@ mod tests {
         for _ in 0..5 {
             let (w, _row_id) = apply_weight_delta(
                 &conn,
-                lambda,
+                actor,
                 atom,
                 delta,
                 WeightChannel::Ambient,
@@ -335,7 +335,7 @@ mod tests {
         );
 
         // Verify 5 audit rows were written.
-        let map = batch_load_weights(&conn, lambda, &[atom])
+        let map = batch_load_weights(&conn, actor, &[atom])
             .await
             .expect("batch_load_weights");
         assert!(map.contains_key(&atom), "weight row should exist");
@@ -345,7 +345,7 @@ mod tests {
             let c = conn.lock();
             c.query_row(
                 "SELECT COUNT(*) FROM weight_events WHERE namespace = ?1 AND atom_id = ?2 AND channel = 'ambient'",
-                params![lambda, atom.to_string()],
+                params![actor, atom.to_string()],
                 |r| r.get(0),
             )
             .unwrap()
@@ -359,14 +359,14 @@ mod tests {
     #[tokio::test]
     async fn test_apply_weight_delta_clamps_at_ceiling() {
         let conn = make_conn();
-        let lambda = "lambda:test";
+        let actor = "agent:test";
         let atom = Uuid::new_v4();
 
         // Repeatedly push large positive deltas.
         for _ in 0..100 {
             apply_weight_delta(
                 &conn,
-                lambda,
+                actor,
                 atom,
                 5.0, // huge delta
                 WeightChannel::GroundTruth,
@@ -377,7 +377,7 @@ mod tests {
             .expect("apply_weight_delta should succeed");
         }
 
-        let map = batch_load_weights(&conn, lambda, &[atom])
+        let map = batch_load_weights(&conn, actor, &[atom])
             .await
             .expect("batch_load_weights");
         let w = *map.get(&atom).expect("atom weight must exist");
@@ -393,13 +393,13 @@ mod tests {
     #[tokio::test]
     async fn test_apply_weight_delta_namespace_isolation() {
         let conn = make_conn();
-        let lambda_a = "lambda:a";
-        let lambda_b = "lambda:b";
+        let actor_a = "agent:a";
+        let actor_b = "agent:b";
         let atom = Uuid::new_v4();
 
         apply_weight_delta(
             &conn,
-            lambda_a,
+            actor_a,
             atom,
             0.5,
             WeightChannel::Explicit,
@@ -407,24 +407,24 @@ mod tests {
             None,
         )
         .await
-        .expect("apply for lambda:a");
+        .expect("apply for agent:a");
 
-        // lambda:b should see nothing.
-        let map_b = batch_load_weights(&conn, lambda_b, &[atom])
+        // agent:b should see nothing.
+        let map_b = batch_load_weights(&conn, actor_b, &[atom])
             .await
-            .expect("batch_load for lambda:b");
+            .expect("batch_load for agent:b");
         assert!(
             !map_b.contains_key(&atom),
-            "lambda:b should not see lambda:a's weight"
+            "agent:b should not see agent:a's weight"
         );
 
-        // lambda:a should see the written weight.
-        let map_a = batch_load_weights(&conn, lambda_a, &[atom])
+        // agent:a should see the written weight.
+        let map_a = batch_load_weights(&conn, actor_a, &[atom])
             .await
-            .expect("batch_load for lambda:a");
+            .expect("batch_load for agent:a");
         assert!(
             map_a.contains_key(&atom),
-            "lambda:a should see its own weight"
+            "agent:a should see its own weight"
         );
     }
 
@@ -434,7 +434,7 @@ mod tests {
     #[tokio::test]
     async fn test_batch_load_weights_missing_atoms_default() {
         let conn = make_conn();
-        let lambda = "lambda:test";
+        let actor = "agent:test";
         let atom_a = Uuid::new_v4();
         let atom_b = Uuid::new_v4();
         let atom_c = Uuid::new_v4();
@@ -442,7 +442,7 @@ mod tests {
         // Write only atom_a.
         apply_weight_delta(
             &conn,
-            lambda,
+            actor,
             atom_a,
             0.3,
             WeightChannel::Explicit,
@@ -452,7 +452,7 @@ mod tests {
         .await
         .expect("apply for atom_a");
 
-        let map = batch_load_weights(&conn, lambda, &[atom_a, atom_b, atom_c])
+        let map = batch_load_weights(&conn, actor, &[atom_a, atom_b, atom_c])
             .await
             .expect("batch_load");
 
@@ -479,13 +479,13 @@ mod tests {
     #[tokio::test]
     async fn test_channel_a_applies_on_negative_delta() {
         let conn = make_conn();
-        let lambda = "lambda:test";
+        let actor = "agent:test";
         let atom = Uuid::new_v4();
 
         // First boost the atom so it is above floor.
         apply_weight_delta(
             &conn,
-            lambda,
+            actor,
             atom,
             0.5,
             WeightChannel::GroundTruth,
@@ -498,7 +498,7 @@ mod tests {
         // Now apply a negative ambient delta (simulates decay).
         let (w_after, _) = apply_weight_delta(
             &conn,
-            lambda,
+            actor,
             atom,
             -0.1,
             WeightChannel::Ambient,
@@ -524,7 +524,7 @@ mod tests {
             c.query_row(
                 "SELECT COUNT(*) FROM weight_events \
                  WHERE namespace = ?1 AND atom_id = ?2 AND delta < 0",
-                params![lambda, atom.to_string()],
+                params![actor, atom.to_string()],
                 |r| r.get(0),
             )
             .unwrap()
@@ -556,12 +556,12 @@ mod tests {
     #[tokio::test]
     async fn test_apply_weight_delta_rejects_nan_delta() {
         let conn = make_conn();
-        let lambda = "lambda:test";
+        let actor = "agent:test";
         let atom = Uuid::new_v4();
 
         let result = apply_weight_delta(
             &conn,
-            lambda,
+            actor,
             atom,
             f32::NAN,
             WeightChannel::Ambient,
@@ -581,12 +581,12 @@ mod tests {
     #[tokio::test]
     async fn test_apply_weight_delta_rejects_inf_delta() {
         let conn = make_conn();
-        let lambda = "lambda:test";
+        let actor = "agent:test";
         let atom = Uuid::new_v4();
 
         let result = apply_weight_delta(
             &conn,
-            lambda,
+            actor,
             atom,
             f32::INFINITY,
             WeightChannel::Ambient,

--- a/crates/khive-runtime/src/actor_identity.rs
+++ b/crates/khive-runtime/src/actor_identity.rs
@@ -56,17 +56,17 @@ mod tests {
 
     #[test]
     fn resolve_actor_configured_id_is_attributed() {
-        let actor = resolve_actor(Some("lambda:khive"));
+        let actor = resolve_actor(Some("agent:khive"));
         assert_eq!(actor.kind, "actor");
-        assert_eq!(actor.id, "lambda:khive");
+        assert_eq!(actor.id, "agent:khive");
         assert!(!actor_is_unattributed(&actor));
     }
 
     #[test]
     fn resolve_actor_preserves_untrimmed_id() {
         // Trim only decides emptiness; the id itself is stored verbatim.
-        let actor = resolve_actor(Some(" lambda:khive "));
-        assert_eq!(actor.id, " lambda:khive ");
+        let actor = resolve_actor(Some(" agent:khive "));
+        assert_eq!(actor.id, " agent:khive ");
     }
 
     #[test]
@@ -86,9 +86,6 @@ mod tests {
     #[test]
     fn should_warn_unattributed_actor_silent_when_attributed() {
         let packs = vec!["kg".to_string(), "comm".to_string()];
-        assert!(!should_warn_unattributed_actor(
-            Some("lambda:khive"),
-            &packs
-        ));
+        assert!(!should_warn_unattributed_actor(Some("agent:khive"), &packs));
     }
 }

--- a/crates/khive-runtime/src/config.rs
+++ b/crates/khive-runtime/src/config.rs
@@ -808,11 +808,11 @@ mod resolve_project_actor_id_tests {
     #[test]
     fn extracts_non_empty_actor_id_from_explicit_path() {
         let dir = tempfile::tempdir().expect("tempdir");
-        let path = write_toml(&dir, "[actor]\nid = \"lambda:explicit-actor\"\n");
+        let path = write_toml(&dir, "[actor]\nid = \"agent:explicit-actor\"\n");
 
         assert_eq!(
             resolve_project_actor_id(Some(&path)).expect("no error"),
-            Some("lambda:explicit-actor".to_string())
+            Some("agent:explicit-actor".to_string())
         );
     }
 

--- a/crates/khive-runtime/src/engine_config.rs
+++ b/crates/khive-runtime/src/engine_config.rs
@@ -122,9 +122,9 @@ pub struct EngineConfig {
 ///
 /// ```toml
 /// [actor]
-/// id = "lambda:leo"                          # attribution identity (required)
+/// id = "agent:alpha"                          # attribution identity (required)
 /// display_name = "example actor"   # human label (optional)
-/// visible_namespaces = ["lambda:khive", "local"]  # widens default read scope (ADR-007 Rev 4 Rule 3b)
+/// visible_namespaces = ["agent:khive", "local"]  # widens default read scope (ADR-007 Rev 4 Rule 3b)
 /// ```
 ///
 /// `visible_namespaces` is consumed by OSS dispatch to widen the DEFAULT
@@ -136,7 +136,7 @@ pub struct EngineConfig {
 pub struct ActorConfig {
     /// Namespace identifier used as the default actor for all operations.
     ///
-    /// Must be a valid `Namespace` string (e.g. `"local"`, `"lambda:khive"`).
+    /// Must be a valid `Namespace` string (e.g. `"local"`, `"agent:khive"`).
     /// Defaults to `"local"` when absent — backward-compatible with pre-actor
     /// deployments.
     #[serde(default)]
@@ -1125,14 +1125,14 @@ fusion_weight = 0.3
             &dir,
             r#"
 [actor]
-id = "lambda:khive"
+id = "agent:khive"
 display_name = "example actor"
 "#,
         );
         let cfg = KhiveConfig::load(Some(&path))
             .expect("load should succeed")
             .expect("file should be found");
-        assert_eq!(cfg.actor.id.as_deref(), Some("lambda:khive"));
+        assert_eq!(cfg.actor.id.as_deref(), Some("agent:khive"));
         assert_eq!(cfg.actor.display_name.as_deref(), Some("example actor"));
         assert!(cfg.engines.is_empty());
     }
@@ -1144,7 +1144,7 @@ display_name = "example actor"
             &dir,
             r#"
 [actor]
-id = "lambda:test"
+id = "agent:test"
 
 [[engines]]
 name = "default"
@@ -1155,7 +1155,7 @@ default = true
         let cfg = KhiveConfig::load(Some(&path))
             .expect("load should succeed")
             .expect("file should be found");
-        assert_eq!(cfg.actor.id.as_deref(), Some("lambda:test"));
+        assert_eq!(cfg.actor.id.as_deref(), Some("agent:test"));
         assert_eq!(cfg.engines.len(), 1);
     }
 
@@ -1198,13 +1198,13 @@ default = true
             &dir,
             r#"
 [actor]
-id = "lambda:explicit"
+id = "agent:explicit"
 "#,
         );
         let cfg = KhiveConfig::load_with_home_fallback(Some(&path), None)
             .expect("no error expected")
             .expect("file found");
-        assert_eq!(cfg.actor.id.as_deref(), Some("lambda:explicit"));
+        assert_eq!(cfg.actor.id.as_deref(), Some("agent:explicit"));
     }
 
     #[test]
@@ -1248,14 +1248,14 @@ id = ""
             &dir,
             r#"
 [actor]
-id = "lambda:"
+id = "agent:"
 "#,
         );
         let err =
-            KhiveConfig::load(Some(&path)).expect_err("lambda: with no slug should be rejected");
+            KhiveConfig::load(Some(&path)).expect_err("agent: with no slug should be rejected");
         assert!(
             matches!(err, ConfigError::InvalidActorId { .. }),
-            "expected InvalidActorId for 'lambda:', got {err:?}"
+            "expected InvalidActorId for 'agent:', got {err:?}"
         );
     }
 
@@ -1270,7 +1270,7 @@ id = "lambda:"
         let cfg = KhiveConfig {
             engines: vec![],
             actor: ActorConfig {
-                id: Some("lambda:test-actor".to_string()),
+                id: Some("agent:test-actor".to_string()),
                 display_name: None,
                 ..Default::default()
             },
@@ -1291,7 +1291,7 @@ id = "lambda:"
         assert!(
             result
                 .visible_namespaces
-                .contains(&Namespace::parse("lambda:test-actor").unwrap()),
+                .contains(&Namespace::parse("agent:test-actor").unwrap()),
             "actor.id must be folded into visible_namespaces (ADR-007 Rev 4 Rule 3b fold-in); \
              got: {:?}",
             result.visible_namespaces
@@ -1315,7 +1315,7 @@ id = "lambda:"
         };
         cfg.validate().expect("valid config");
 
-        let base_ns = Namespace::parse("lambda:base").unwrap();
+        let base_ns = Namespace::parse("agent:base").unwrap();
         let base = RuntimeConfig {
             default_namespace: base_ns.clone(),
             ..RuntimeConfig::default()
@@ -1335,14 +1335,14 @@ id = "lambda:"
         std::fs::create_dir_all(dir.path().join(".khive")).unwrap();
         std::fs::write(
             dir.path().join(".khive/config.toml"),
-            "[actor]\nid = \"lambda:hidden\"\n",
+            "[actor]\nid = \"agent:hidden\"\n",
         )
         .unwrap();
 
         // Write khive.toml (tier 2) — should win.
         std::fs::write(
             dir.path().join("khive.toml"),
-            "[actor]\nid = \"lambda:project-root\"\n",
+            "[actor]\nid = \"agent:project-root\"\n",
         )
         .unwrap();
 
@@ -1351,7 +1351,7 @@ id = "lambda:"
             .expect("file should be found");
         assert_eq!(
             cfg.actor.id.as_deref(),
-            Some("lambda:project-root"),
+            Some("agent:project-root"),
             "khive.toml (tier 2) must win over .khive/config.toml (tier 3)"
         );
     }
@@ -1363,7 +1363,7 @@ id = "lambda:"
         std::fs::create_dir_all(dir.path().join(".khive")).unwrap();
         std::fs::write(
             dir.path().join(".khive/config.toml"),
-            "[actor]\nid = \"lambda:hidden-config\"\n",
+            "[actor]\nid = \"agent:hidden-config\"\n",
         )
         .unwrap();
         // No khive.toml.
@@ -1373,7 +1373,7 @@ id = "lambda:"
             .expect("file should be found");
         assert_eq!(
             cfg.actor.id.as_deref(),
-            Some("lambda:hidden-config"),
+            Some("agent:hidden-config"),
             ".khive/config.toml (tier 3) must be found when khive.toml is absent"
         );
     }
@@ -1386,7 +1386,7 @@ id = "lambda:"
         std::fs::create_dir_all(home_dir.path().join(".khive")).unwrap();
         std::fs::write(
             home_dir.path().join(".khive/config.toml"),
-            "[actor]\nid = \"lambda:user-global\"\n",
+            "[actor]\nid = \"agent:user-global\"\n",
         )
         .unwrap();
         // No project-level files.
@@ -1396,7 +1396,7 @@ id = "lambda:"
             .expect("file should be found");
         assert_eq!(
             cfg.actor.id.as_deref(),
-            Some("lambda:user-global"),
+            Some("agent:user-global"),
             "~/.khive/config.toml (tier 4) must be found when project files absent"
         );
     }
@@ -1410,7 +1410,7 @@ id = "lambda:"
         std::fs::create_dir_all(home_dir.path().join(".khive")).unwrap();
         std::fs::write(
             home_dir.path().join(".khive/config.toml"),
-            "[actor]\nid = \"lambda:user-global\"\n",
+            "[actor]\nid = \"agent:user-global\"\n",
         )
         .unwrap();
 
@@ -1418,7 +1418,7 @@ id = "lambda:"
         std::fs::create_dir_all(project_dir.path().join(".khive")).unwrap();
         std::fs::write(
             project_dir.path().join(".khive/config.toml"),
-            "[actor]\nid = \"lambda:project-wins\"\n",
+            "[actor]\nid = \"agent:project-wins\"\n",
         )
         .unwrap();
 
@@ -1427,7 +1427,7 @@ id = "lambda:"
             .expect("file should be found");
         assert_eq!(
             cfg.actor.id.as_deref(),
-            Some("lambda:project-wins"),
+            Some("agent:project-wins"),
             "project .khive/config.toml (tier 3) must win over ~/.khive/config.toml (tier 4)"
         );
     }
@@ -1449,13 +1449,13 @@ id = "lambda:"
         std::fs::create_dir_all(cwd_a.path().join(".khive")).unwrap();
         std::fs::write(
             cwd_a.path().join(".khive/config.toml"),
-            "[actor]\nid = \"lambda:wrong-cwd-a\"\n",
+            "[actor]\nid = \"agent:wrong-cwd-a\"\n",
         )
         .unwrap();
         std::fs::create_dir_all(cwd_b.path().join(".khive")).unwrap();
         std::fs::write(
             cwd_b.path().join(".khive/config.toml"),
-            "[actor]\nid = \"lambda:wrong-cwd-b\"\n",
+            "[actor]\nid = \"agent:wrong-cwd-b\"\n",
         )
         .unwrap();
 
@@ -1468,7 +1468,7 @@ id = "lambda:"
         std::fs::write(&db_path, b"").unwrap(); // must exist for canonicalize to succeed
         std::fs::write(
             khive_dir.join("config.toml"),
-            "[actor]\nid = \"lambda:db-anchored\"\n",
+            "[actor]\nid = \"agent:db-anchored\"\n",
         )
         .unwrap();
 
@@ -1481,12 +1481,12 @@ id = "lambda:"
 
         assert_eq!(
             cfg_a.actor.id.as_deref(),
-            Some("lambda:db-anchored"),
+            Some("agent:db-anchored"),
             "cwd A must resolve the db-anchored config, not its own decoy"
         );
         assert_eq!(
             cfg_b.actor.id.as_deref(),
-            Some("lambda:db-anchored"),
+            Some("agent:db-anchored"),
             "cwd B must resolve the db-anchored config, not its own decoy"
         );
         assert_eq!(
@@ -1502,7 +1502,7 @@ id = "lambda:"
     #[test]
     fn test_load_with_home_fallback_explicit_config_wins_over_db_anchor() {
         let explicit_dir = tempfile::tempdir().unwrap();
-        let explicit_path = write_toml(&explicit_dir, "[actor]\nid = \"lambda:explicit-wins\"\n");
+        let explicit_path = write_toml(&explicit_dir, "[actor]\nid = \"agent:explicit-wins\"\n");
 
         let db_root = tempfile::tempdir().unwrap();
         let khive_dir = db_root.path().join(".khive");
@@ -1511,7 +1511,7 @@ id = "lambda:"
         std::fs::write(&db_path, b"").unwrap();
         std::fs::write(
             khive_dir.join("config.toml"),
-            "[actor]\nid = \"lambda:db-anchor-loses\"\n",
+            "[actor]\nid = \"agent:db-anchor-loses\"\n",
         )
         .unwrap();
 
@@ -1520,7 +1520,7 @@ id = "lambda:"
             .expect("explicit path must be found");
         assert_eq!(
             cfg.actor.id.as_deref(),
-            Some("lambda:explicit-wins"),
+            Some("agent:explicit-wins"),
             "explicit --config/KHIVE_CONFIG must win over the db-dir anchor"
         );
     }
@@ -1534,7 +1534,7 @@ id = "lambda:"
         std::fs::create_dir_all(home_dir.path().join(".khive")).unwrap();
         std::fs::write(
             home_dir.path().join(".khive/config.toml"),
-            "[actor]\nid = \"lambda:home-fallback\"\n",
+            "[actor]\nid = \"agent:home-fallback\"\n",
         )
         .unwrap();
 
@@ -1550,7 +1550,7 @@ id = "lambda:"
             .expect("home-tier config must be found");
         assert_eq!(
             cfg.actor.id.as_deref(),
-            Some("lambda:home-fallback"),
+            Some("agent:home-fallback"),
             "tier 4 (~/.khive/config.toml) must still be reached when the db-anchored \
              tier-3 directory has no config.toml"
         );
@@ -1565,7 +1565,7 @@ id = "lambda:"
         std::fs::create_dir_all(home_dir.path().join(".khive")).unwrap();
         std::fs::write(
             home_dir.path().join(".khive/config.toml"),
-            "[actor]\nid = \"lambda:home-cold-start\"\n",
+            "[actor]\nid = \"agent:home-cold-start\"\n",
         )
         .unwrap();
 
@@ -1578,7 +1578,7 @@ id = "lambda:"
                 .expect("home-tier config must still be found");
         assert_eq!(
             cfg.actor.id.as_deref(),
-            Some("lambda:home-cold-start"),
+            Some("agent:home-cold-start"),
             "a nonexistent db path (cold start) must fall through to tier 4, not panic"
         );
     }

--- a/crates/khive-runtime/src/operations.rs
+++ b/crates/khive-runtime/src/operations.rs
@@ -13191,20 +13191,28 @@ mod tests {
     #[tokio::test]
     async fn get_entity_cross_namespace_succeeds() {
         let rt = rt();
-        // Create under "lambda:leo".
-        let leo_tok = NamespaceToken::for_namespace(Namespace::parse("lambda:leo").unwrap());
+        // Create under "agent:alpha".
+        let peer_tok = NamespaceToken::for_namespace(Namespace::parse("agent:alpha").unwrap());
         let entity = rt
-            .create_entity(&leo_tok, "concept", None, "Peer-Entity", None, None, vec![])
+            .create_entity(
+                &peer_tok,
+                "concept",
+                None,
+                "Peer-Entity",
+                None,
+                None,
+                vec![],
+            )
             .await
             .unwrap();
-        assert_eq!(entity.namespace, "lambda:leo");
+        assert_eq!(entity.namespace, "agent:alpha");
 
         // Read from "local" — must succeed (no namespace gate on by-ID get).
         let local_tok = NamespaceToken::local();
         let fetched = rt.get_entity(&local_tok, entity.id).await;
         assert!(
             fetched.is_ok(),
-            "get_entity from local token must find lambda:leo entity; got {:?}",
+            "get_entity from local token must find agent:alpha entity; got {:?}",
             fetched
         );
         assert_eq!(fetched.unwrap().id, entity.id);
@@ -13213,10 +13221,10 @@ mod tests {
     #[tokio::test]
     async fn update_entity_cross_namespace_succeeds() {
         let rt = rt();
-        let leo_tok = NamespaceToken::for_namespace(Namespace::parse("lambda:leo").unwrap());
+        let peer_tok = NamespaceToken::for_namespace(Namespace::parse("agent:alpha").unwrap());
         let entity = rt
             .create_entity(
-                &leo_tok,
+                &peer_tok,
                 "concept",
                 None,
                 "Peer-Entity-Update",
@@ -13236,7 +13244,7 @@ mod tests {
         let result = rt.update_entity(&local_tok, entity.id, patch).await;
         assert!(
             result.is_ok(),
-            "update_entity from local token must succeed on lambda:leo entity; got {:?}",
+            "update_entity from local token must succeed on agent:alpha entity; got {:?}",
             result
         );
         assert_eq!(result.unwrap().name, "Peer-Entity-Updated");
@@ -13245,10 +13253,10 @@ mod tests {
     #[tokio::test]
     async fn delete_entity_cross_namespace_succeeds() {
         let rt = rt();
-        let leo_tok = NamespaceToken::for_namespace(Namespace::parse("lambda:leo").unwrap());
+        let peer_tok = NamespaceToken::for_namespace(Namespace::parse("agent:alpha").unwrap());
         let entity = rt
             .create_entity(
-                &leo_tok,
+                &peer_tok,
                 "concept",
                 None,
                 "Peer-Entity-Delete",
@@ -13264,7 +13272,7 @@ mod tests {
         let deleted = rt.delete_entity(&local_tok, entity.id, false).await;
         assert!(
             deleted.is_ok(),
-            "delete_entity from local token must succeed on lambda:leo entity; got {:?}",
+            "delete_entity from local token must succeed on agent:alpha entity; got {:?}",
             deleted
         );
         assert!(
@@ -13276,10 +13284,10 @@ mod tests {
     #[tokio::test]
     async fn namespace_preserved_on_entity_after_cross_namespace_get() {
         let rt = rt();
-        let leo_tok = NamespaceToken::for_namespace(Namespace::parse("lambda:leo").unwrap());
+        let peer_tok = NamespaceToken::for_namespace(Namespace::parse("agent:alpha").unwrap());
         let entity = rt
             .create_entity(
-                &leo_tok,
+                &peer_tok,
                 "concept",
                 None,
                 "NS-Preserved",
@@ -13290,11 +13298,11 @@ mod tests {
             .await
             .unwrap();
 
-        // The namespace column on the fetched record must still say "lambda:leo".
+        // The namespace column on the fetched record must still say "agent:alpha".
         let local_tok = NamespaceToken::local();
         let fetched = rt.get_entity(&local_tok, entity.id).await.unwrap();
         assert_eq!(
-            fetched.namespace, "lambda:leo",
+            fetched.namespace, "agent:alpha",
             "namespace column must be preserved; not overwritten with caller's namespace"
         );
     }

--- a/crates/khive-runtime/src/runtime.rs
+++ b/crates/khive-runtime/src/runtime.rs
@@ -527,11 +527,11 @@ impl KhiveRuntime {
     /// the token may read. The primary is always included in the visible set
     /// regardless of `extra_visible`.
     ///
-    /// Usage (lambda:leo reading both leo and khive namespaces):
+    /// Usage (an actor reading both its own and a peer namespace):
     /// ```rust,ignore
     /// let tok = rt.authorize_with_visibility(
-    ///     Namespace::parse("lambda:leo").unwrap(),
-    ///     vec![Namespace::parse("lambda:khive").unwrap()],
+    ///     Namespace::parse("agent:alpha").unwrap(),
+    ///     vec![Namespace::parse("agent:khive").unwrap()],
     /// )?;
     /// ```
     pub fn authorize_with_visibility(
@@ -1355,7 +1355,7 @@ mod tests {
             allowed_outbound_namespaces: vec![],
             actor_id: None,
         };
-        let cfg = khive_cfg_with_actor("lambda:khive");
+        let cfg = khive_cfg_with_actor("agent:khive");
         let result = runtime_config_from_khive_config(&cfg, base);
         assert_eq!(
             result.default_namespace.as_str(),
@@ -1369,7 +1369,7 @@ mod tests {
         let base = RuntimeConfig {
             git_write: Default::default(),
             db_path: None,
-            default_namespace: Namespace::parse("lambda:base").unwrap(),
+            default_namespace: Namespace::parse("agent:base").unwrap(),
             embedding_model: None,
             additional_embedding_models: vec![],
             gate: Arc::new(AllowAllGate),
@@ -1392,7 +1392,7 @@ mod tests {
         let result = runtime_config_from_khive_config(&cfg, base);
         assert_eq!(
             result.default_namespace.as_str(),
-            "lambda:base",
+            "agent:base",
             "empty actor.id must not override base namespace"
         );
     }
@@ -1402,7 +1402,7 @@ mod tests {
         let base = RuntimeConfig {
             git_write: Default::default(),
             db_path: None,
-            default_namespace: Namespace::parse("lambda:base").unwrap(),
+            default_namespace: Namespace::parse("agent:base").unwrap(),
             embedding_model: None,
             additional_embedding_models: vec![],
             gate: Arc::new(AllowAllGate),
@@ -1417,7 +1417,7 @@ mod tests {
         let result = runtime_config_from_khive_config(&cfg, base);
         assert_eq!(
             result.default_namespace.as_str(),
-            "lambda:base",
+            "agent:base",
             "absent actor.id must not override base namespace"
         );
     }
@@ -1447,7 +1447,7 @@ mod tests {
                 dims: None,
             }],
             actor: ActorConfig {
-                id: Some("lambda:test".to_string()),
+                id: Some("agent:test".to_string()),
                 display_name: None,
                 ..Default::default()
             },
@@ -1477,10 +1477,10 @@ mod tests {
         let prior = std::env::var("KHIVE_ACTOR").ok();
         // SAFETY: test is #[serial]; no other test in this crate reads/writes KHIVE_ACTOR.
         unsafe {
-            std::env::set_var("KHIVE_ACTOR", "lambda:test-env-actor");
+            std::env::set_var("KHIVE_ACTOR", "agent:test-env-actor");
         }
         let base = RuntimeConfig::default();
-        assert_eq!(base.actor_id.as_deref(), Some("lambda:test-env-actor"));
+        assert_eq!(base.actor_id.as_deref(), Some("agent:test-env-actor"));
 
         let cfg = KhiveConfig {
             engines: vec![crate::engine_config::EngineConfig {
@@ -1496,7 +1496,7 @@ mod tests {
         let result = runtime_config_from_khive_config(&cfg, base);
         assert_eq!(
             result.actor_id.as_deref(),
-            Some("lambda:test-env-actor"),
+            Some("agent:test-env-actor"),
             "engines-present arm must preserve base.actor_id (env actor) when TOML has no [actor] id"
         );
 
@@ -1515,10 +1515,10 @@ mod tests {
         let prior = std::env::var("KHIVE_ACTOR").ok();
         // SAFETY: test is #[serial]; no other test in this crate reads/writes KHIVE_ACTOR.
         unsafe {
-            std::env::set_var("KHIVE_ACTOR", "lambda:test-env-actor");
+            std::env::set_var("KHIVE_ACTOR", "agent:test-env-actor");
         }
         let base = RuntimeConfig::default();
-        assert_eq!(base.actor_id.as_deref(), Some("lambda:test-env-actor"));
+        assert_eq!(base.actor_id.as_deref(), Some("agent:test-env-actor"));
 
         let cfg = KhiveConfig {
             engines: vec![],
@@ -1528,7 +1528,7 @@ mod tests {
         let result = runtime_config_from_khive_config(&cfg, base);
         assert_eq!(
             result.actor_id.as_deref(),
-            Some("lambda:test-env-actor"),
+            Some("agent:test-env-actor"),
             "engines-empty early-return arm must preserve base.actor_id (env actor) when TOML has no [actor] id"
         );
 
@@ -1547,16 +1547,16 @@ mod tests {
         let prior = std::env::var("KHIVE_ACTOR").ok();
         // SAFETY: test is #[serial]; no other test in this crate reads/writes KHIVE_ACTOR.
         unsafe {
-            std::env::set_var("KHIVE_ACTOR", "lambda:test-env-actor");
+            std::env::set_var("KHIVE_ACTOR", "agent:test-env-actor");
         }
         let base = RuntimeConfig::default();
-        assert_eq!(base.actor_id.as_deref(), Some("lambda:test-env-actor"));
+        assert_eq!(base.actor_id.as_deref(), Some("agent:test-env-actor"));
 
-        let cfg = khive_cfg_with_actor("lambda:toml-actor");
+        let cfg = khive_cfg_with_actor("agent:toml-actor");
         let result = runtime_config_from_khive_config(&cfg, base);
         assert_eq!(
             result.actor_id.as_deref(),
-            Some("lambda:toml-actor"),
+            Some("agent:toml-actor"),
             "TOML [actor] id must win over the env-resolved base.actor_id"
         );
 

--- a/crates/khive-runtime/src/secret_gate.rs
+++ b/crates/khive-runtime/src/secret_gate.rs
@@ -4330,7 +4330,7 @@ mod tests {
         // `contains_bounded_word`), so `auth` does not match inside
         // `authorized`; this UUID has no trigger in its window and passes via
         // the ordinary out-of-context UUID allowlist.
-        let content = "area_id: cfcea31d-6f50-4fd1-ad6d-5f160de1694c\n\n## Problem\nReduce Lion microkernel axioms. Converted authorized_write_requires_dominance from axiom to theorem.";
+        let content = "area_id: cfcea31d-6f50-4fd1-ad6d-5f160de1694c\n\n## Problem\nReduce microkernel axioms. Converted authorized_write_requires_dominance from axiom to theorem.";
         assert!(
             check(content).is_ok(),
             "internal area_id UUID near the 'authorized' substring \

--- a/crates/khive-runtime/tests/integration.rs
+++ b/crates/khive-runtime/tests/integration.rs
@@ -3954,7 +3954,7 @@ async fn stats_totals_match_list_walk_across_visible_namespaces() {
         db_path: None,
         packs: vec!["kg".to_string()],
         brain_profile: None,
-        actor_id: Some("lambda:stats-711-test".to_string()),
+        actor_id: Some("agent:stats-711-test".to_string()),
         ..RuntimeConfig::no_embeddings()
     })
     .expect("in-memory runtime with actor identity");

--- a/crates/kkernel/src/exec.rs
+++ b/crates/kkernel/src/exec.rs
@@ -1290,7 +1290,7 @@ mod tests {
             khive_dir.join("config.toml"),
             r#"
 [actor]
-id = "lambda:test-actor"
+id = "agent:test-actor"
 
 [[engines]]
 name = "primary"
@@ -1350,12 +1350,12 @@ default = true
 
         // The TOML must actually have reached both constructions — the direct
         // regression proxy for #581, verified without a live daemon socket.
-        assert_eq!(exec_cfg.actor_id.as_deref(), Some("lambda:test-actor"));
-        assert_eq!(serve_cfg.actor_id.as_deref(), Some("lambda:test-actor"));
+        assert_eq!(exec_cfg.actor_id.as_deref(), Some("agent:test-actor"));
+        assert_eq!(serve_cfg.actor_id.as_deref(), Some("agent:test-actor"));
         assert!(
             exec_cfg
                 .visible_namespaces
-                .contains(&Namespace::parse("lambda:test-actor").expect("ns")),
+                .contains(&Namespace::parse("agent:test-actor").expect("ns")),
             "actor.id must fold into visible_namespaces (ADR-007 Rev 4 Rule 3b)"
         );
         assert!(
@@ -1395,7 +1395,7 @@ default = true
 
         let missing_config =
             std::path::PathBuf::from("/nonexistent/khive-exec-parity-test/config.toml");
-        let ns = Namespace::parse("lambda:custom-ns").expect("ns");
+        let ns = Namespace::parse("agent:custom-ns").expect("ns");
         // Pin packs so the `compute_config_id` comparison below never depends
         // on two independent `KHIVE_PACKS` env reads agreeing (#1356).
         let pinned_packs = Some(vec!["kg".to_string()]);
@@ -1427,7 +1427,7 @@ default = true
         // The fill-when-None guard DOES fire differently between the two arms...
         assert_eq!(
             with_explicit_true.actor_id.as_deref(),
-            Some("lambda:custom-ns"),
+            Some("agent:custom-ns"),
             "namespace_explicit=true + non-local namespace + no config actor.id \
              must fill actor_id from the namespace (ADR-057)"
         );
@@ -2465,7 +2465,7 @@ default = true
         let cfg = RuntimeConfig {
             db_path: None,
             packs: vec!["kg".to_string()],
-            actor_id: Some("lambda:tenant-x".to_string()), // actor configured → no gate
+            actor_id: Some("agent:tenant-x".to_string()), // actor configured → no gate
             ..RuntimeConfig::default()
         };
 
@@ -3639,8 +3639,7 @@ backend = "sessions"
 
     /// `link`: a typo'd key (`relatoin` for `relation`) must be rejected
     /// before any write; a well-formed link still succeeds. (Distinct from
-    /// the Leo-accepted `target_backend` conflict-arm deferral — out of
-    /// scope here.)
+    /// the `target_backend` conflict-arm deferral — out of scope here.)
     #[tokio::test]
     async fn atomic_link_unknown_field_rejected_well_formed_succeeds() {
         let db_file = NamedTempFile::new().expect("temp db");

--- a/crates/kkernel/src/reindex.rs
+++ b/crates/kkernel/src/reindex.rs
@@ -2095,11 +2095,11 @@ mod tests {
         let dir = tempfile::tempdir().expect("temp dir");
         let config_path = dir.path().join("khive.toml");
         let mut f = std::fs::File::create(&config_path).expect("create config");
-        f.write_all(b"[actor]\nid = \"lambda:prod\"\n")
+        f.write_all(b"[actor]\nid = \"agent:prod\"\n")
             .expect("write config");
 
         // No --namespace: config [actor] id is attribution only (Rule 0), so the
-        // effective namespace stays `local` — it must NOT become lambda:prod.
+        // effective namespace stays `local` — it must NOT become agent:prod.
         let resolved = resolve_runtime_config(RuntimeConfigInputs {
             db: Some(":memory:"),
             config: Some(&config_path),

--- a/docs/guide/communication.md
+++ b/docs/guide/communication.md
@@ -232,8 +232,9 @@ Optional, with defaults:
   quarantine record instead of dropping it)
 - `KHIVE_EMAIL_INGEST_NAMESPACE` (default `local`; target namespace for
   ingested messages)
-- `KHIVE_EMAIL_DEFAULT_ACTOR` (inbound actor assigned to
-  fresh, uncorrelated email messages)
+- `KHIVE_EMAIL_DEFAULT_ACTOR` (inbound actor assigned to fresh, uncorrelated
+  email messages; the default is supplied by the installed communication
+  backend — set it explicitly to pin attribution)
 - `KHIVE_EMAIL_SEND_ALLOWED_RECIPIENTS` (comma-separated outbound allowlist;
   falls back to the maintainer address when unset)
 

--- a/docs/guide/communication.md
+++ b/docs/guide/communication.md
@@ -14,12 +14,12 @@ send always produces two notes and no cross-namespace write occurs even when
 
 ## Actor addressing
 
-Actors are labeled strings such as `lambda:leo` or `lambda:khive`. `comm.send`
+Actors are labeled strings such as `agent:alpha` or `agent:khive`. `comm.send`
 stores the caller's actor label as `from_actor` and the `to` argument as
 `to_actor` on both the outbound and inbound copies.
 
 ```
-request(ops="comm.send(to=\"lambda:leo\", content=\"PR #610 merged\")")
+request(ops="comm.send(to=\"agent:alpha\", content=\"PR #610 merged\")")
 ```
 
 `comm.inbox` filters by `to_actor` for the calling actor. Legacy messages
@@ -31,7 +31,7 @@ hidden by the newer filter.
 
 | Param       | Type   | Required | Notes                                                                                                                                                                                           |
 | ----------- | ------ | -------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `to`        | string | yes      | Actor label, e.g. `"lambda:leo"`.                                                                                                                                                               |
+| `to`        | string | yes      | Actor label, e.g. `"agent:alpha"`.                                                                                                                                                               |
 | `content`   | string | yes      | Message body. Must not be empty.                                                                                                                                                                |
 | `subject`   | string | no       | Optional subject line.                                                                                                                                                                          |
 | `thread_id` | uuid   | no       | Groups the message into an existing thread.                                                                                                                                                     |
@@ -232,7 +232,7 @@ Optional, with defaults:
   quarantine record instead of dropping it)
 - `KHIVE_EMAIL_INGEST_NAMESPACE` (default `local`; target namespace for
   ingested messages)
-- `KHIVE_EMAIL_DEFAULT_ACTOR` (default `lambda:leo`; inbound actor assigned to
+- `KHIVE_EMAIL_DEFAULT_ACTOR` (inbound actor assigned to
   fresh, uncorrelated email messages)
 - `KHIVE_EMAIL_SEND_ALLOWED_RECIPIENTS` (comma-separated outbound allowlist;
   falls back to the maintainer address when unset)

--- a/docs/khive-config-example.toml
+++ b/docs/khive-config-example.toml
@@ -37,11 +37,11 @@
 # optional — the defaults apply when the section is absent.
 
 [actor]
-# Attribution identity. Must be a valid namespace string ("local", "lambda:khive",
+# Attribution identity. Must be a valid namespace string ("local", "agent:khive",
 # …). Validated at load — an invalid value is a startup error, not a silent
 # fallback. Absent → `local`. Overridden by --actor / KHIVE_ACTOR. A non-`local` id
 # does NOT route writes; it only widens the default read scope (see below).
-# id = "lambda:khive"
+# id = "agent:khive"
 
 # Human-readable label. Surfaced in introspection and logs only; never used for
 # routing.
@@ -50,11 +50,11 @@
 # Widen the DEFAULT multi-record READ scope to {local} ∪ these namespaces
 # (ADR-007 Rev 4 Rule 3b). Writes stay pinned to `local`. An explicit `namespace=`
 # request parameter is a precise escape and is not widened by this list.
-# visible_namespaces = ["lambda:khive", "local"]
+# visible_namespaces = ["agent:khive", "local"]
 
 # Namespaces this actor's comm.send / comm.reply may deliver INTO. Empty (default)
 # denies all cross-namespace delivery. Each entry must be a valid namespace.
-# allowed_outbound_namespaces = ["lambda:leo"]
+# allowed_outbound_namespaces = ["agent:alpha"]
 
 # ── [runtime] — runtime knobs ────────────────────────────────────────────────────
 

--- a/docs/multi-backend.md
+++ b/docs/multi-backend.md
@@ -96,7 +96,7 @@ or `~/.khive/config.toml`; see [Config resolution](#config-resolution) below).
 ```toml
 # ── Actor identity ─────────────────────────────────────────────────────────────
 [actor]
-id = "lambda:app"                   # attribution label (optional)
+id = "agent:app"                   # attribution label (optional)
 display_name = "khive app node"     # advisory; not used by the runtime
 
 # ── Embedding engines ──────────────────────────────────────────────────────────

--- a/marketplace/INSTALL.md
+++ b/marketplace/INSTALL.md
@@ -57,7 +57,7 @@ Create or update `.mcp.json` in your project root:
         "kg"
       ],
       "env": {
-        "KHIVE_ACTOR": "lambda:your-id"
+        "KHIVE_ACTOR": "agent:your-id"
       }
     }
   }
@@ -79,10 +79,10 @@ silently defaults to `"local"`, which leaves your messages unattributed and your
 unscoped (it returns every `"local"` message, not just yours). Set it once, per agent.
 
 The `env` block in Option A is the simplest place — set `KHIVE_ACTOR` to this agent's id (e.g.
-`lambda:khive`, `lambda:lattice`). For per-session CLI registration, pass the flag instead:
+`agent:alpha`, `agent:beta`). For per-session CLI registration, pass the flag instead:
 
 ```bash
-claude mcp add --transport stdio khive -- kkernel mcp --actor lambda:your-id --pack kg
+claude mcp add --transport stdio khive -- kkernel mcp --actor agent:your-id --pack kg
 ```
 
 Resolution order (highest to lowest):
@@ -97,7 +97,7 @@ The config-file form (searched in order `./khive.toml`, `./.khive/config.toml`,
 
 ```toml
 [actor]
-id = "lambda:your-id"
+id = "agent:your-id"
 ```
 
 When a messaging extension pack (e.g. `comm`, a commercially licensed extension not part of

--- a/marketplace/khive/README.md
+++ b/marketplace/khive/README.md
@@ -12,7 +12,7 @@ the MCP server; install and configure that per [INSTALL.md](../INSTALL.md).
 
 Every record you write is stamped with **who you are** (`from_actor`), resolved from the MCP
 server's actor config. If it is unset it silently defaults to `"local"`. Set
-`KHIVE_ACTOR=lambda:<your-id>` in the server env (or pass `--actor`) before you start. See
+`KHIVE_ACTOR=agent:<your-id>` in the server env (or pass `--actor`) before you start. See
 [INSTALL.md → Set your actor identity](../INSTALL.md#set-your-actor-identity-attribution).
 
 ## Pattern skill

--- a/marketplace/khive/skills/digest/SKILL.md
+++ b/marketplace/khive/skills/digest/SKILL.md
@@ -17,7 +17,7 @@ request(ops="[create(kind=\"entity\", entity_kind=\"concept\", name=\"LoRA\"), c
 The verb examples in this skill show the inner call. Wrap each one as `request(ops="…")`.
 
 **Namespace rule (ADR-007)**: KG operations always use the shared namespace (`local`), even when the
-MCP server runs with `--actor lambda:myproject`. Do NOT override the namespace for entity/edge/note
+MCP server runs with `--actor agent:myproject`. Do NOT override the namespace for entity/edge/note
 operations. The knowledge graph is cross-project by design.
 
 ## Workflow

--- a/marketplace/khive/skills/expand/SKILL.md
+++ b/marketplace/khive/skills/expand/SKILL.md
@@ -26,7 +26,7 @@ request(ops="[create(kind=\"entity\", entity_kind=\"project\", name=\"lora-tools
 The verb examples below show the inner call. Wrap each one as `request(ops="…")`.
 
 **Namespace rule (ADR-007)**: KG operations always use the shared namespace (`local`), even when the
-MCP server runs with `--actor lambda:myproject`. Do NOT override the namespace for entity/edge/note
+MCP server runs with `--actor agent:myproject`. Do NOT override the namespace for entity/edge/note
 operations. The knowledge graph is cross-project by design.
 
 ## Input

--- a/marketplace/khive/skills/gap/SKILL.md
+++ b/marketplace/khive/skills/gap/SKILL.md
@@ -23,7 +23,7 @@ request(ops="[neighbors(node_id=\"<u>\", direction=\"in\", relations=[\"depends_
 The verb examples below show the inner call. Wrap each one as `request(ops="…")`.
 
 **Namespace rule (ADR-007)**: KG operations always use the shared namespace (`local`), even when the
-MCP server runs with `--actor lambda:myproject`. Do NOT override the namespace for entity/edge/note
+MCP server runs with `--actor agent:myproject`. Do NOT override the namespace for entity/edge/note
 operations. The knowledge graph is cross-project by design.
 
 ## Workflow

--- a/marketplace/khive/skills/kg/SKILL.md
+++ b/marketplace/khive/skills/kg/SKILL.md
@@ -12,7 +12,7 @@ _graph discipline_, not the verb list.
 Per-verb param detail is one call away: `request(ops="create(help=true)")`.
 
 **Namespace (ADR-007).** kg ops always use the shared `local` namespace, even when the server
-runs as `--actor lambda:<you>`. Do not override the namespace for entity/edge/note ops — the
+runs as `--actor agent:<you>`. Do not override the namespace for entity/edge/note ops — the
 graph is cross-project by design.
 
 ## The pattern
@@ -99,5 +99,5 @@ reach for them instead of hand-rolling:
 - **Reversed edge direction.** `introduced_by` is concept → paper, never paper → concept. Check the table.
 - **Forcing a fact into an edge.** "published 2021", "written in Rust" are properties, not relations.
 - **`neighbors` without `direction="both"`.** It defaults to outgoing-only and you miss half the graph.
-- **Overriding the namespace with `lambda:*`.** kg is shared `local`; attribution lives elsewhere.
+- **Overriding the namespace with `agent:*`.** kg is shared `local`; attribution lives elsewhere.
 - **Hand-rolling a bulk ingest or a polish sweep.** That is what the digester / polisher agents are for.

--- a/marketplace/khive/skills/polish/SKILL.md
+++ b/marketplace/khive/skills/polish/SKILL.md
@@ -16,7 +16,7 @@ request(ops="[list(kind=\"edge\", source_id=\"<u>\"), list(kind=\"edge\", target
 The verb examples in this skill show the inner call. Wrap each one as `request(ops="…")`.
 
 **Namespace rule (ADR-007)**: KG operations always use the shared namespace (`local`), even when the
-MCP server runs with `--actor lambda:myproject`. Do NOT override the namespace for entity/edge/note
+MCP server runs with `--actor agent:myproject`. Do NOT override the namespace for entity/edge/note
 operations. The knowledge graph is cross-project by design.
 
 ## Workflow

--- a/perf/targets.toml
+++ b/perf/targets.toml
@@ -1,5 +1,5 @@
 # perf/targets.toml — scale-proof assertion thresholds
-# Changes that loosen any threshold require a PR comment from lambda:khive citing the cause.
+# Changes that loosen any threshold require a PR comment from a maintainer citing the cause.
 #
 # Threshold format: hard limit with optional relative tolerance (fractional).
 # A tolerance of 0.10 means:

--- a/scripts/perf/bench_track.py
+++ b/scripts/perf/bench_track.py
@@ -4,8 +4,8 @@
 Appends one JSONL record per (suite, commit) to bench-data/<suite>.jsonl and
 renders a compact markdown trend summary (last N runs, per-metric direction
 arrows). This is purely observational per the bench-program spec's
-blocking-promotion ladder (docs `.khive/workspaces/20260710/bench-program/
-SPEC-draft.md`) - it never asserts pass/fail and never places a threshold.
+blocking-promotion ladder - it never asserts pass/fail and never places a
+threshold.
 That is `bench_calibrate.py`'s job for calibration and, eventually, a real
 CI gate's job for enforcement.
 

--- a/scripts/perf/coverage_validator.py
+++ b/scripts/perf/coverage_validator.py
@@ -55,10 +55,9 @@ never `"unverified"` - and downgrades the scenario straight to confounded
 No manifest scenario is ever reported "measured" when the records
 directory is absent or empty - the coverage percentage is 0% in that case,
 by construction (every scenario starts in the "missing" bucket and nothing
-promotes it without a matching record). This is the PR 1 gate from
-`.khive/workspaces/20260711/bench-overhaul/DESIGN.md`: "coverage validator
-reports the expected scenario set and intentionally reports 0% measured
-until records exist."
+promotes it without a matching record). The coverage validator reports the
+expected scenario set and intentionally reports 0% measured until records
+exist.
 
 This script performs no benchmark execution and adds no CI wiring - it
 only reads the manifest and an existing records directory.

--- a/scripts/perf/flagship_schema.py
+++ b/scripts/perf/flagship_schema.py
@@ -1,9 +1,8 @@
 #!/usr/bin/env python3
 """Flagship E2E result schema v3 (stdlib-only).
 
-Implements the Distribution contract and the Ledger record contract from
-`.khive/workspaces/20260711/bench-overhaul/DESIGN.md` ("Typed interfaces")
-as plain-dict validators, mirroring `schemas/flagship-result-v3.json` (the
+Implements the Distribution contract and the Ledger record contract as
+plain-dict validators, mirroring `schemas/flagship-result-v3.json` (the
 checked JSON Schema copy of the same contract, kept for external tooling
 and IDE validation). This module is the one `scripts/perf/coverage_validator.py`
 actually imports - no `jsonschema` dependency, matching the stdlib-only
@@ -61,7 +60,7 @@ ESTIMATOR = "nearest_rank_v1"
 DISTRIBUTION_UNIT = "us"
 # Global floor for status="ok" records: nearest-rank p99 needs n>=100 to
 # land on a real observation rather than interpolate/repeat a low-n sample
-# (khive#945 amendment, Leo signed §2.1). A scenario may declare a HIGHER
+# A scenario may declare a HIGHER
 # minimum (raise-only, enforced in coverage_validator.py against the
 # manifest); a declared minimum below this floor never lowers it.
 TIMED_MIN_SUCCESSES = 100

--- a/scripts/perf/schemas/flagship-result-v3.json
+++ b/scripts/perf/schemas/flagship-result-v3.json
@@ -2,7 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://khive.dev/schemas/flagship-result-v3.json",
   "title": "FlagshipRecord",
-  "description": "Checked result contract for the flagship E2E benchmark manifest (bench-overhaul PR 1). Implements the Distribution contract and the Ledger record contract from .khive/workspaces/20260711/bench-overhaul/DESIGN.md ('Typed interfaces'), which fixes FlagshipRecord.schema_version at 3 - the same schema_version track scripts/perf/bench_track.py's ledger will carry for flagship-e2e records once PR 2 wires this runner's output into that ledger. bench_track.py itself remains at its own SCHEMA_VERSION = 2 for its existing (non-flagship) suites until then. No runner emits documents against this schema yet - PR 2+ implement the scenario runner.",
+  "description": "Checked result contract for the flagship E2E benchmark manifest. Implements the Distribution contract and the Ledger record contract, which fixes FlagshipRecord.schema_version at 3 - the same schema_version track scripts/perf/bench_track.py's ledger will carry for flagship-e2e records once this runner's output is wired into that ledger. bench_track.py itself remains at its own SCHEMA_VERSION = 2 for its existing (non-flagship) suites until then.",
   "type": "object",
   "required": [
     "schema_version",

--- a/scripts/perf/testdata/bench1m_result_fixture.json
+++ b/scripts/perf/testdata/bench1m_result_fixture.json
@@ -35,7 +35,7 @@
     "exit_code": 0,
     "overall": "PASS",
     "target_key": "khive-vamana/ci-synthetic/clustered-128",
-    "targets_file": "/Users/lion/khive-work/worktrees/fix830-r2/perf/targets.toml"
+    "targets_file": "perf/targets.toml"
   },
   "caveats": [
     "2-point fit",


### PR DESCRIPTION
Replaces machine-specific paths and internal identifiers with neutral equivalents throughout the tree. Actor and namespace strings in tests, doc comments, and configuration examples now use a generic `agent:` prefix; a benchmark fixture references a repository-relative targets path instead of an absolute workspace path; workflow and script comments use role-neutral wording.

No behavior change — every substituted value is test data or a documentation example, and the diff is a line-for-line substitution. The Gate's `lambda` actor kind is a declared part of the policy contract and is left unchanged, as are the BM25 benchmark corpus and search-test fixture text that happen to contain the same word.

Gates run from the worktree: `cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace`, and `cargo check --workspace`.