### PR TITLE
fix(runtime): appease rust 1.95 collapsible_match in atomic_prepare

### DIFF
--- a/crates/khive-runtime/src/atomic_prepare.rs
+++ b/crates/khive-runtime/src/atomic_prepare.rs
@@ -638,12 +638,10 @@ pub async fn prepare_update(
                 None => {}
                 Some(AtomicUpdateKind::Entity {
                     specific: Some(expected),
-                }) => {
-                    if &entity.kind != expected {
-                        return Err(RuntimeError::NotFound(format!("entity {id}")));
-                    }
+                }) if &entity.kind != expected => {
+                    return Err(RuntimeError::NotFound(format!("entity {id}")));
                 }
-                Some(AtomicUpdateKind::Entity { specific: None }) => {}
+                Some(AtomicUpdateKind::Entity { .. }) => {}
                 Some(AtomicUpdateKind::Note { .. }) => {
                     return Err(RuntimeError::NotFound(format!("note {id}")));
                 }
@@ -680,12 +678,10 @@ pub async fn prepare_update(
                 None => {}
                 Some(AtomicUpdateKind::Note {
                     specific: Some(expected),
-                }) => {
-                    if &note.kind != expected {
-                        return Err(RuntimeError::NotFound(format!("note {id}")));
-                    }
+                }) if &note.kind != expected => {
+                    return Err(RuntimeError::NotFound(format!("note {id}")));
                 }
-                Some(AtomicUpdateKind::Note { specific: None }) => {}
+                Some(AtomicUpdateKind::Note { .. }) => {}
                 Some(AtomicUpdateKind::Entity { .. }) => {
                     return Err(RuntimeError::NotFound(format!("entity {id}")));
                 }


### PR DESCRIPTION
The 1.95.0 toolchain raise (#1375) surfaced two new `clippy::collapsible_match` errors in `atomic_prepare.rs`, breaking the CI clippy step on main.

## Summary
- Rewrites the two nested kind-mismatch checks as guarded match arms with a catch-all for the matching case. Behavior identical; `cargo clippy -p khive-runtime --all-targets -- -D warnings` passes on 1.95.0.

Note: clippy's suggested collapse alone does not compile — guards do not count toward match exhaustiveness, so the catch-all arm absorbs the guard-false case.

## Test plan
- Local clippy on 1.95.0 with the CI lint flags: clean.
- No behavior change; existing khive-runtime tests cover both kind-check paths.