### PR TITLE
port: restore maintained development history, batch 3

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,7 @@
+[env]
+# Cargo propagates this marker to unit tests, integration tests, and test-spawned
+# binaries. The store-open guard checks it at runtime in every build profile.
+# There is no environment override: deliberate sessions against a real store
+# run the built binary directly (outside the Cargo environment), which never
+# receives this marker.
+KHIVE_TEST_HARNESS = { value = "1", force = true }

--- a/.github/workflows/bench-component.yml
+++ b/.github/workflows/bench-component.yml
@@ -66,7 +66,7 @@ jobs:
           set -euo pipefail
           pkg_args=()
           for crate in $COMPONENT_CRATES; do pkg_args+=(-p "$crate"); done
-          timeout 600 cargo bench "${pkg_args[@]}" -- --quick || true
+          timeout 600 cargo bench "${pkg_args[@]}" --benches -- --quick || true
 
       - name: Record component trend ledger entry
         id: record

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -564,6 +564,14 @@ jobs:
           tool: cargo-llvm-cov
       - name: Compute coverage
         working-directory: crates
+        # #705: this job runs every workspace test binary alongside instrumented
+        # (and therefore slower) execution, which widens the writer-checkout
+        # contention window some tests are hardened against at a plain-run
+        # timeout. Raise the floor for this job specifically instead of paying
+        # the cost on every CI run — the contention-sensitive test takes the
+        # max of this and its own floor, so this only ever widens the margin.
+        env:
+          KHIVE_CHECKOUT_TIMEOUT_SECS: "300"
         run: |
           # Extract TOTAL *line* coverage from the structured JSON export, not by
           # column position. In `--summary-only` text the TOTAL row has Regions%

--- a/.github/workflows/unlocked-dependencies.yml
+++ b/.github/workflows/unlocked-dependencies.yml
@@ -1,0 +1,86 @@
+name: Unlocked dependency resolution
+
+on:
+  schedule:
+    - cron: "23 7 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: unlocked-dependency-resolution
+  cancel-in-progress: false
+
+jobs:
+  unlocked-resolution:
+    name: Check latest compatible dependencies
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - uses: dtolnay/rust-toolchain@1.94.1
+
+      - name: Create throwaway workspace
+        run: git worktree add --detach "$RUNNER_TEMP/khive-unlocked" "$GITHUB_SHA"
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: ${{ runner.temp }}/khive-unlocked/crates
+          shared-key: unlocked-dependencies
+          cache-on-failure: true
+
+      - name: Resolve latest compatible dependencies
+        id: update
+        continue-on-error: true
+        working-directory: ${{ runner.temp }}/khive-unlocked/crates
+        run: cargo update
+
+      - name: Check workspace
+        id: check
+        if: steps.update.outcome == 'success'
+        continue-on-error: true
+        working-directory: ${{ runner.temp }}/khive-unlocked/crates
+        run: cargo check --workspace --all-targets --all-features
+
+      - name: Test workspace
+        id: test
+        if: steps.update.outcome == 'success'
+        continue-on-error: true
+        working-directory: ${{ runner.temp }}/khive-unlocked/crates
+        run: cargo test --workspace --all-features
+
+      - name: Write workflow summary
+        if: always()
+        env:
+          UPDATE_OUTCOME: ${{ steps.update.outcome }}
+          CHECK_OUTCOME: ${{ steps.check.outcome }}
+          TEST_OUTCOME: ${{ steps.test.outcome }}
+        run: |
+          {
+            echo "# Unlocked dependency resolution"
+            echo
+            echo "This scheduled check resolves the latest versions allowed by the workspace manifests in a throwaway lockfile."
+            echo
+            echo "| Phase | Outcome |"
+            echo "|---|---|"
+            echo "| cargo update | ${UPDATE_OUTCOME} |"
+            echo "| cargo check --workspace | ${CHECK_OUTCOME} |"
+            echo "| cargo test --workspace | ${TEST_OUTCOME} |"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Report advisory failure
+        if: always()
+        env:
+          UPDATE_OUTCOME: ${{ steps.update.outcome }}
+          CHECK_OUTCOME: ${{ steps.check.outcome }}
+          TEST_OUTCOME: ${{ steps.test.outcome }}
+        run: |
+          if [ "$UPDATE_OUTCOME" != success ] || [ "$CHECK_OUTCOME" != success ] || [ "$TEST_OUTCOME" != success ]; then
+            echo "::error::Latest compatible dependency resolution did not pass; see the workflow summary."
+            exit 1
+          fi

--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -1841,6 +1841,7 @@ version = "0.5.0"
 dependencies = [
  "criterion",
  "khive-score",
+ "khive-text",
  "parking_lot",
  "rand 0.8.7",
  "serde",
@@ -2490,7 +2491,6 @@ name = "khive-text"
 version = "0.5.0"
 dependencies = [
  "criterion",
- "khive-bm25",
  "rust-stemmers",
  "unicode-segmentation",
 ]

--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -2512,6 +2512,7 @@ dependencies = [
  "bytemuck",
  "criterion",
  "khive-quant",
+ "libc",
  "memmap2",
  "rand 0.8.7",
  "rayon",
@@ -2521,6 +2522,7 @@ dependencies = [
  "thiserror 2.0.18",
  "toml",
  "uuid",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/crates/khive-bm25/Cargo.toml
+++ b/crates/khive-bm25/Cargo.toml
@@ -16,6 +16,7 @@ bench = false
 
 [dependencies]
 khive-score = { version = "0.5.0", path = "../khive-score" }
+khive-text = { version = "0.5.0", path = "../khive-text" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/khive-bm25/docs/api/tokenizer.md
+++ b/crates/khive-bm25/docs/api/tokenizer.md
@@ -10,13 +10,13 @@ an `Arc<dyn Tokenizer>`, allowing an index and its clones to share tokenizer sta
 ## `SimpleTokenizer`
 
 `SimpleTokenizer` splits on whitespace, strips leading and trailing ASCII punctuation (non-ASCII
-punctuation is retained), optionally lowercases, filters by minimum UTF-8 byte length, and
+punctuation is retained), optionally lowercases, filters by minimum Unicode character count, and
 optionally removes the built-in English stop-word set. Defaults enable lowercasing and stop-word
 removal with a minimum length of one.
 
-ASCII tokens use an ASCII-only lowercase fast path; non-ASCII input falls back to Unicode-aware
-lowercasing. Capacity is estimated from typical English word length to reduce reallocations without
-affecting output.
+The tokenizer composes `khive-text`'s shared whitespace, lowercase, length, and BM25 stop-word
+primitives. `Tokenizer` and `BoxedTokenizer` are re-exported from `khive-text`, so custom tokenizer
+implementations keep the same public interface.
 
 ## `tokenize`
 

--- a/crates/khive-bm25/src/tokenizer.rs
+++ b/crates/khive-bm25/src/tokenizer.rs
@@ -1,32 +1,10 @@
 //! Pluggable tokenizer trait with a simple English whitespace default.
 
-use std::collections::HashSet;
-use std::sync::{Arc, LazyLock};
+use khive_text::filter::{Bm25StopWordFilter, LowercaseFilter, MinLengthFilter};
+use khive_text::tokenizer::WhitespaceTokenizer;
+use khive_text::TokenFilter;
 
-/// Deterministic, thread-safe term extraction for BM25 indexing.
-///
-/// See `crates/khive-bm25/docs/api/tokenizer.md`.
-pub trait Tokenizer: Send + Sync {
-    /// Tokenize text into terms. Returns empty vec for empty input.
-    fn tokenize(&self, text: &str) -> Vec<String>;
-}
-
-/// Box type for tokenizers (enables dynamic dispatch).
-pub type BoxedTokenizer = Arc<dyn Tokenizer>;
-
-/// English stop words filtered from BM25 postings to reduce index size.
-static STOP_WORDS: LazyLock<HashSet<&'static str>> = LazyLock::new(|| {
-    HashSet::from([
-        "a", "an", "and", "are", "as", "at", "be", "been", "being", "but", "by", "can", "did",
-        "do", "does", "doing", "done", "for", "from", "had", "has", "have", "having", "he", "her",
-        "here", "hers", "him", "his", "how", "i", "if", "in", "into", "is", "it", "its", "just",
-        "may", "me", "might", "my", "no", "nor", "not", "of", "on", "or", "our", "out", "own",
-        "say", "she", "should", "so", "some", "such", "than", "that", "the", "their", "them",
-        "then", "there", "these", "they", "this", "those", "through", "to", "too", "up", "us",
-        "very", "was", "we", "were", "what", "when", "where", "which", "while", "who", "whom",
-        "why", "will", "with", "would", "you", "your",
-    ])
-});
+pub use khive_text::{BoxedTokenizer, Tokenizer};
 
 /// Configurable whitespace tokenizer with punctuation, case, length, and stop-word processing.
 ///
@@ -64,40 +42,25 @@ impl SimpleTokenizer {
 
 impl Tokenizer for SimpleTokenizer {
     fn tokenize(&self, text: &str) -> Vec<String> {
-        // Average English word length gives a useful allocation estimate.
-        let estimated_tokens = text.len() / 6 + 1;
-        let mut result = Vec::with_capacity(estimated_tokens.min(32));
-
-        for word in text.split_whitespace() {
-            let trimmed = word.trim_matches(|c: char| c.is_ascii_punctuation());
-
-            if trimmed.len() < self.min_length {
-                continue;
-            }
-
-            // Avoid Unicode lowercase allocation for the common ASCII path.
-            let token = if self.lowercase {
-                if trimmed.is_ascii() {
-                    let mut s = String::with_capacity(trimmed.len());
-                    for &byte in trimmed.as_bytes() {
-                        s.push(byte.to_ascii_lowercase() as char);
-                    }
-                    s
+        WhitespaceTokenizer
+            .tokenize(text)
+            .into_iter()
+            .filter_map(|token| MinLengthFilter(self.min_length).apply(token))
+            .filter_map(|token| {
+                if self.lowercase {
+                    LowercaseFilter.apply(token)
                 } else {
-                    trimmed.to_lowercase()
+                    Some(token)
                 }
-            } else {
-                trimmed.to_string()
-            };
-
-            if self.filter_stop_words && STOP_WORDS.contains(token.as_str()) {
-                continue;
-            }
-
-            result.push(token);
-        }
-
-        result
+            })
+            .filter_map(|token| {
+                if self.filter_stop_words {
+                    Bm25StopWordFilter.apply(token)
+                } else {
+                    Some(token)
+                }
+            })
+            .collect()
     }
 }
 
@@ -108,6 +71,8 @@ pub fn tokenize(text: &str) -> Vec<String> {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+
     use super::*;
 
     #[test]
@@ -165,6 +130,34 @@ mod tests {
         let tokens = tokenizer.tokenize("I am a cat");
         // "I", "am", "a" filtered by min_length; also stop words
         assert_eq!(tokens, vec!["cat"]);
+    }
+
+    #[test]
+    fn test_simple_tokenizer_min_length_counts_unicode_characters() {
+        let tokenizer = SimpleTokenizer::new(true, 2);
+        assert_eq!(tokenizer.tokenize("你 rust"), vec!["rust"]);
+    }
+
+    #[test]
+    fn test_default_tokenizer_matches_shared_standard_analyzer() {
+        use khive_text::{preset, Analyzer};
+
+        let tokenizer = SimpleTokenizer::default();
+        let analyzer = preset::standard();
+        let cases = [
+            "may x",
+            "done say might",
+            "against",
+            &"a".repeat(41),
+            "The quick brown fox jumps over the lazy dog",
+        ];
+        for input in cases {
+            assert_eq!(
+                tokenizer.tokenize(input),
+                analyzer.analyze(input),
+                "mismatch for input: {input:?}"
+            );
+        }
     }
 
     #[test]

--- a/crates/khive-bm25/tests/integration.rs
+++ b/crates/khive-bm25/tests/integration.rs
@@ -285,6 +285,21 @@ fn custom_tokenizer_min_length_filters_short_tokens() {
     assert_eq!(index.search("quick", 10).len(), 1);
 }
 
+#[test]
+fn unicode_min_length_changes_length_normalized_ranking() {
+    let tokenizer: BoxedTokenizer = Arc::new(SimpleTokenizer::new(true, 2));
+    let mut index =
+        Bm25Index::try_with_tokenizer(Bm25Config::default(), tokenizer).expect("valid config");
+
+    index.index_document("short", "target 你").unwrap();
+    index.index_document("long", "target extra").unwrap();
+
+    let results = index.search("target", 10);
+    assert_eq!(results.len(), 2);
+    assert_eq!(&*results[0].0, "short");
+    assert!(results[0].1 > results[1].1);
+}
+
 // ---------------------------------------------------------------------------
 // Tokenizer Tokenizer trait: verify tokenize() contract via SimpleTokenizer
 // ---------------------------------------------------------------------------

--- a/crates/khive-brain-core/src/lib.rs
+++ b/crates/khive-brain-core/src/lib.rs
@@ -23,8 +23,8 @@ pub use profile::{
 pub use query_class::compute_query_class;
 pub use section_state::{
     derive_deterministic_weights, derive_weights, SectionPosteriorSnapshot, SectionPosteriorState,
-    DEFAULT_ESS_CAP, DEFAULT_EXPLORATION_EPOCH, DEFAULT_SECTION_WEIGHT_FLOOR, DEFAULT_TAU_0,
-    DEFAULT_TAU_EXPLOIT,
+    DEFAULT_ESS_CAP, DEFAULT_EXPLORATION_EPOCH, DEFAULT_LCB_Z, DEFAULT_SECTION_WEIGHT_FLOOR,
+    DEFAULT_TAU_0, DEFAULT_TAU_EXPLOIT,
 };
 pub use section_type::SectionType;
 pub use signal::{FeedbackEventKind, FeedbackSignal};

--- a/crates/khive-brain-core/src/section_state.rs
+++ b/crates/khive-brain-core/src/section_state.rs
@@ -15,6 +15,12 @@ pub const DEFAULT_EXPLORATION_EPOCH: u64 = 50;
 pub const DEFAULT_TAU_0: f64 = 1.0;
 pub const DEFAULT_TAU_EXPLOIT: f64 = 0.1;
 pub const DEFAULT_SECTION_WEIGHT_FLOOR: f64 = 0.05;
+/// Standard-deviation multiplier for `lower_confidence_bound`'s pessimistic
+/// estimate. `exploration_epoch` decays to 0 permanently (it only ever counts
+/// down), after which `deterministic_weights` is the sole scoring path
+/// forever — it must not rank a section on posterior mean alone, since mean
+/// is well-defined for a 1-observation posterior with no evidence behind it.
+pub const DEFAULT_LCB_Z: f64 = 1.0;
 
 /// Per-profile section posterior state.
 pub struct SectionPosteriorState {
@@ -125,7 +131,7 @@ impl SectionPosteriorState {
         let logits: HashMap<SectionType, f64> = self
             .posteriors
             .iter()
-            .map(|(&st, p)| (st, p.mean() / tau))
+            .map(|(&st, p)| (st, lower_confidence_bound(p) / tau))
             .collect();
         let max_val = logits.values().cloned().fold(f64::NEG_INFINITY, f64::max);
         let mut raw: HashMap<SectionType, f64> = HashMap::new();
@@ -203,6 +209,21 @@ pub struct SectionPosteriorSnapshot {
     pub priors: HashMap<SectionType, BetaPosterior>,
     pub total_events: u64,
     pub exploration_epoch: u64,
+}
+
+/// Count-aware pessimistic estimate of a section's posterior: the mean minus
+/// `DEFAULT_LCB_Z` standard deviations, floored at 0.
+///
+/// The raw posterior mean alone cannot distinguish a section with one lucky
+/// observation (small `alpha + beta`, high mean, high variance) from one with
+/// hundreds of observations at the same or lower mean (large `alpha + beta`,
+/// low variance) — `deterministic_weights` would rank the former higher on
+/// mean despite having no evidence behind it. Subtracting a variance-scaled
+/// penalty shrinks under-evidenced means toward the floor while barely
+/// touching well-evidenced ones, without discarding `BetaPosterior`'s existing
+/// deterministic `mean()`/`variance()` accessors or introducing randomness.
+fn lower_confidence_bound(p: &BetaPosterior) -> f64 {
+    (p.mean() - DEFAULT_LCB_Z * p.variance().sqrt()).max(0.0)
 }
 
 // ── Sampling helpers ────────────────────────────────────────────────────────
@@ -348,5 +369,63 @@ mod tests {
         let og = weights[&SectionType::OperationalGuidance];
         let form = weights[&SectionType::Formalism];
         assert!(og > form, "og={og:.4} form={form:.4}");
+    }
+
+    /// BRAIN-0483: hand-computed `lower_confidence_bound` values.
+    ///
+    /// alpha=11, beta=1 (10-for-10 lucky streak): mean = 11/12 = 0.916667,
+    /// variance = alpha*beta / (n^2*(n+1)) = 11 / (144*13) = 0.00587607,
+    /// sqrt(variance) = 0.0766595, lcb = 0.916667 - 0.0766595 = 0.840007.
+    ///
+    /// alpha=901, beta=101 (900-for-1000): mean = 901/1002 = 0.899202,
+    /// variance = 91001 / (1002^2*1003) = 91001 / 1007016012 = 0.0000903668,
+    /// sqrt(variance) = 0.00950614, lcb = 0.899202 - 0.00950614 = 0.889696.
+    #[test]
+    fn lower_confidence_bound_hand_computed() {
+        let lucky = BetaPosterior::new(11.0, 1.0);
+        let seasoned = BetaPosterior::new(901.0, 101.0);
+        assert!(
+            (lower_confidence_bound(&lucky) - 0.840_007).abs() < 1e-5,
+            "lucky lcb = {}",
+            lower_confidence_bound(&lucky)
+        );
+        assert!(
+            (lower_confidence_bound(&seasoned) - 0.889_696).abs() < 1e-5,
+            "seasoned lcb = {}",
+            lower_confidence_bound(&seasoned)
+        );
+    }
+
+    /// BRAIN-0483: a section with one lucky streak (high mean, tiny evidence)
+    /// must not outrank a section with hundreds of observations at a lower raw
+    /// mean once `deterministic_weights` is the permanent scoring path
+    /// (`exploration_epoch == 0`). Raw mean alone gets this backwards
+    /// (0.916667 > 0.899202); the lower-confidence-bound correction flips it
+    /// (0.840007 < 0.889696), matching the evidence.
+    #[test]
+    fn deterministic_weights_does_not_let_a_lucky_streak_beat_seasoned_evidence() {
+        let mut priors = SectionPosteriorState::default_priors();
+        priors.insert(SectionType::Examples, BetaPosterior::new(11.0, 1.0));
+        priors.insert(
+            SectionType::OperationalGuidance,
+            BetaPosterior::new(901.0, 101.0),
+        );
+        let mut state = SectionPosteriorState::from_priors(priors);
+        state.exploration_epoch = 0;
+
+        let raw_mean_examples = state.posteriors[&SectionType::Examples].mean();
+        let raw_mean_og = state.posteriors[&SectionType::OperationalGuidance].mean();
+        assert!(
+            raw_mean_examples > raw_mean_og,
+            "fixture must reproduce the raw-mean inversion: examples={raw_mean_examples:.6} og={raw_mean_og:.6}"
+        );
+
+        let weights = derive_deterministic_weights(&state);
+        let examples = weights[&SectionType::Examples];
+        let og = weights[&SectionType::OperationalGuidance];
+        assert!(
+            og > examples,
+            "seasoned evidence must outrank a lucky streak once corrected: og={og:.6} examples={examples:.6}"
+        );
     }
 }

--- a/crates/khive-db/docs/api/checkpoint.md
+++ b/crates/khive-db/docs/api/checkpoint.md
@@ -123,11 +123,17 @@ See `crates/khive-db/src/checkpoint.rs` — `run_checkpoint_task`.
 An earlier version of this task used `Arc::strong_count(&pool) <= 1` as its
 exit condition instead of an explicit signal. That check is unreachable
 whenever a sibling owner holds its own clone of `pool` for the task's
-lifetime — which the production boot path does: `event_store`
-(`Option<Arc<dyn EventStore>>`), when `Some`, is a `SqlEventStore` that
-retains its own `Arc::clone` of the same pool, so the task always observed
-`strong_count == 2` and never exited via that mechanism (issue #774). The
-explicit `watch` channel does not depend on how many other owners exist.
+lifetime — which the production boot path does: `CheckpointLifecycleOwner`
+contains a `SqlEventStore` that retains its own `Arc::clone` of the same pool,
+so the task always observed `strong_count == 2` and never exited via that
+mechanism (issue #774). The explicit `watch` channel does not depend on how
+many other owners exist.
+
+Lifecycle ownership is independent of backend role. Spawn-time fan-out gives
+the lifecycle owner to the main checkpoint task when one exists; if the main
+backend is in-memory and only secondary file-backed tasks are spawned, the
+first secondary task owns emission. Other tasks receive no owner, so the API
+cannot silently discard a caller-supplied event store based on `is_main`.
 
 ## Private tx-registry logging helpers (Plank 0)
 
@@ -160,7 +166,11 @@ snapshot is logged (reusing Plank 0's `tx_registry`) before the attempt.
 `busy_timeout` is temporarily lowered to `truncate_busy_timeout` for the
 PRAGMA call and restored immediately after, regardless of outcome. No
 transaction is ever killed here — enforcement is Plank 1's job, not this
-one's.
+one's. The OS holder census is captured immediately before the TRUNCATE
+attempt, then consumed only if that attempt makes no progress. The reported
+identities therefore include a transient holder that releases during the
+bounded TRUNCATE wait, before the no-progress diagnostic is emitted. Sidecar
+enumeration remains deferred to the no-progress path.
 
 ## `TxAgeSweepState` — identity tracking rationale
 

--- a/crates/khive-db/src/checkpoint.rs
+++ b/crates/khive-db/src/checkpoint.rs
@@ -630,10 +630,11 @@ fn log_tx_age_emission(emission: &TxAgeEmission) {
 
 /// ADR-091 Amendment 2 Plank B: per-process walpin sidecar state, carried
 /// across ticks by whichever sweep owns it (the daemon's `run_checkpoint_task`
-/// or a session's `run_session_sweep_task`). Writes this process's heartbeat
-/// on every tick the registry's oldest span exceeds `tx_warn_secs`, and
-/// removes it once on the tick the condition clears (and on shutdown) — a
-/// process that never crosses the threshold writes nothing.
+/// or a session's `run_session_sweep_task`). Once the registry's oldest span
+/// exceeds `tx_warn_secs`, the first observation and each content change
+/// rewrite the heartbeat body; unchanged ticks refresh only its mtime. The
+/// heartbeat is removed once when the condition clears (and on shutdown), so
+/// a process that never crosses the threshold writes no heartbeat body.
 struct WalpinSidecarState {
     dir: PathBuf,
     pid: u32,
@@ -1175,6 +1176,29 @@ pub async fn run_session_sweep_task(
     }
 }
 
+/// The event sink and namespace owned by one checkpoint task in a fan-out.
+///
+/// Backend role and lifecycle ownership are separate: a secondary task may
+/// own lifecycle emission when the deployment's main backend is in-memory.
+#[derive(Clone)]
+pub struct CheckpointLifecycleOwner {
+    event_store: Arc<dyn khive_storage::EventStore>,
+    namespace: String,
+}
+
+impl CheckpointLifecycleOwner {
+    /// Designate `event_store` as the lifecycle sink for one checkpoint task.
+    pub fn new(
+        event_store: Arc<dyn khive_storage::EventStore>,
+        namespace: impl Into<String>,
+    ) -> Self {
+        Self {
+            event_store,
+            namespace: namespace.into(),
+        }
+    }
+}
+
 /// Run the WAL checkpoint background task.
 ///
 /// Long-running async task — spawn with `tokio::spawn`. Loops until
@@ -1189,23 +1213,23 @@ pub async fn run_session_sweep_task(
 /// write traffic. A WARNING fires once per below→above threshold crossing,
 /// not every tick.
 ///
-/// `event_store` (ADR-094): when `Some`, appends a best-effort
+/// `lifecycle_owner` (ADR-094): exactly one task in a multi-backend fan-out
+/// should receive `Some`. That task appends a best-effort
 /// `CheckpointOutcomeRecorded` event on every at/above-`warn_pages` tick,
-/// plus one drain row when pressure falls back below `warn_pages`. `None` is
-/// a no-op. See `crates/khive-db/docs/api/checkpoint.md` for the full
-/// shutdown-mechanism and event-emission design history.
+/// plus one drain row when pressure falls back below `warn_pages`. `None`
+/// explicitly marks a non-owner. See `crates/khive-db/docs/api/checkpoint.md`
+/// for the full shutdown-mechanism and event-emission design history.
 ///
 /// `is_main` (ADR-091 Amendment 3): whether `pool` is the deployment's main
 /// backend. A daemon owning several file-backed backends spawns one task per
 /// backend, each with its own pool and shutdown-channel clone (the sender
-/// broadcasts to every receiver clone alike); exactly one of those calls
-/// passes `true`. See the `tx_filter` construction below for what this
-/// selects.
+/// broadcasts to every receiver clone alike). Lifecycle ownership is selected
+/// independently through `lifecycle_owner`; `is_main` only controls registry
+/// filtering. See the `tx_filter` construction below.
 pub async fn run_checkpoint_task(
     pool: Arc<ConnectionPool>,
     config: CheckpointConfig,
-    event_store: Option<Arc<dyn khive_storage::EventStore>>,
-    namespace: String,
+    lifecycle_owner: Option<CheckpointLifecycleOwner>,
     mut shutdown_rx: tokio::sync::watch::Receiver<()>,
     is_main: bool,
 ) {
@@ -1372,8 +1396,7 @@ pub async fn run_checkpoint_task(
                 above_truncate_high_water,
             };
             append_checkpoint_lifecycle_event(
-                event_store.as_ref(),
-                &namespace,
+                lifecycle_owner.as_ref(),
                 khive_types::EventKind::CheckpointOutcomeRecorded,
                 payload,
             )
@@ -1399,17 +1422,16 @@ fn checkpoint_outcome_should_emit(above_warn: bool, was_elevated: bool) -> bool 
 
 /// Append one ADR-094 lifecycle event on behalf of the checkpoint task.
 ///
-/// Best-effort: `event_store == None` is a no-op, and an append failure is
+/// Best-effort: `lifecycle_owner == None` is a no-op, and an append failure is
 /// logged and swallowed. No lifecycle-append error may ever interrupt or
 /// slow down checkpoint/TRUNCATE work — the checkpoint task's correctness
 /// does not depend on this succeeding.
 async fn append_checkpoint_lifecycle_event<P: serde::Serialize>(
-    store: Option<&Arc<dyn khive_storage::EventStore>>,
-    namespace: &str,
+    lifecycle_owner: Option<&CheckpointLifecycleOwner>,
     kind: khive_types::EventKind,
     payload: P,
 ) {
-    let Some(store) = store else {
+    let Some(owner) = lifecycle_owner else {
         return;
     };
     let payload_value = match serde_json::to_value(&payload) {
@@ -1424,14 +1446,14 @@ async fn append_checkpoint_lifecycle_event<P: serde::Serialize>(
         }
     };
     let event = khive_storage::Event::new(
-        namespace,
+        &owner.namespace,
         "checkpoint.lifecycle",
         kind,
         khive_types::SubstrateKind::Event,
         "daemon:checkpoint_task",
     )
     .with_payload(payload_value);
-    if let Err(err) = store.append_event(event).await {
+    if let Err(err) = owner.event_store.append_event(event).await {
         tracing::warn!(
             error = %err,
             event_kind = %kind.name(),
@@ -1576,6 +1598,9 @@ fn maybe_truncate(
         return;
     }
 
+    #[cfg(unix)]
+    let holder_census = capture_wal_holder_census(pool);
+
     // Only now is this a genuine attempt: the writer is held, the threshold
     // and interval gates passed, and the busy_timeout override is in effect
     // immediately before the TRUNCATE pragma itself.
@@ -1610,8 +1635,12 @@ fn maybe_truncate(
                      a long-lived reader may still be pinning the WAL snapshot"
                 );
                 log_tx_registry_snapshot_warn(wal_pages_after);
+                #[cfg(test)]
+                if let Some(path) = pool.canonical_path() {
+                    truncate_report_test_sync::after_no_progress_before_report(path);
+                }
                 #[cfg(unix)]
-                log_walpin_sidecar_report(pool);
+                log_walpin_sidecar_report(pool, holder_census);
                 log_wal_pin_depth(conn);
             }
 
@@ -1622,6 +1651,55 @@ fn maybe_truncate(
             log_tx_registry_snapshot_warn(wal_pages_before);
             note_truncate_outcome(config, wal_pages_before, truncate_state);
         }
+    }
+}
+
+#[cfg(test)]
+mod truncate_report_test_sync {
+    use std::path::{Path, PathBuf};
+    use std::sync::mpsc::{sync_channel, Receiver, SyncSender};
+    use std::sync::Mutex;
+
+    struct Hook {
+        db_path: PathBuf,
+        reached_tx: SyncSender<()>,
+        proceed_rx: Receiver<()>,
+    }
+
+    static HOOK: Mutex<Option<Hook>> = Mutex::new(None);
+
+    pub(crate) fn install(db_path: PathBuf) -> (Receiver<()>, SyncSender<()>) {
+        let (reached_tx, reached_rx) = sync_channel(0);
+        let (proceed_tx, proceed_rx) = sync_channel(0);
+        let replaced = HOOK
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .replace(Hook {
+                db_path,
+                reached_tx,
+                proceed_rx,
+            });
+        assert!(replaced.is_none(), "truncate report hook already installed");
+        (reached_rx, proceed_tx)
+    }
+
+    pub(crate) fn uninstall() {
+        *HOOK.lock().unwrap_or_else(|poisoned| poisoned.into_inner()) = None;
+    }
+
+    pub(crate) fn after_no_progress_before_report(db_path: &Path) {
+        let hook = {
+            let mut guard = HOOK.lock().unwrap_or_else(|poisoned| poisoned.into_inner());
+            match guard.as_ref() {
+                Some(hook) if hook.db_path == db_path => guard.take(),
+                _ => None,
+            }
+        };
+        let Some(hook) = hook else {
+            return;
+        };
+        let _ = hook.reached_tx.send(());
+        let _ = hook.proceed_rx.recv();
     }
 }
 
@@ -1657,12 +1735,26 @@ fn note_truncate_outcome(
     TRUNCATE_CONSECUTIVE_FAILURES.store(state.consecutive_failures as u64, Ordering::Relaxed);
 }
 
-/// ADR-091 Amendment 2 Plank B: on a TRUNCATE no-progress event, enumerate
-/// the walpin sidecar directory and log every entry's sidecar-health
-/// classification (reporting / registered-silent / unknown), attributing the
-/// pin to a specific cross-process PID rather than only this process's own
-/// registry. A no-op if the sidecar is disabled or this backend has no
-/// on-disk path.
+/// ADR-091 Amendment 2 Plank B: capture the OS holder census immediately
+/// before a TRUNCATE attempt so a holder that releases during the bounded wait
+/// remains attributable if the attempt reports no progress. A no-op if the
+/// sidecar is disabled or this backend has no on-disk path.
+#[cfg(unix)]
+fn capture_wal_holder_census(
+    pool: &ConnectionPool,
+) -> Option<Result<crate::walpin::CensusResult, String>> {
+    let path = pool.canonical_path()?;
+    if !crate::walpin::sidecar_enabled(true) {
+        return None;
+    }
+    Some(crate::walpin::census_holders(path).map_err(|e| e.to_string()))
+}
+
+/// When a TRUNCATE attempt makes no progress, enumerate the walpin sidecar and
+/// combine it with the holder census captured immediately before that attempt.
+/// Sidecar enumeration remains deferred until this consumed diagnostic path;
+/// holder identity cannot be deferred because a transient blocker may have
+/// released by then.
 ///
 /// Sidecar-health attribution (ADR-091 Amendment 2):
 /// the sharper "unregistered/native mechanism" conclusion is licensed only
@@ -1672,13 +1764,16 @@ fn note_truncate_outcome(
 /// inconclusive, and the WARN below names exactly which PIDs are unresolved
 /// instead of silently exonerating them.
 #[cfg(unix)]
-fn log_walpin_sidecar_report(pool: &ConnectionPool) {
+fn log_walpin_sidecar_report(
+    pool: &ConnectionPool,
+    census: Option<Result<crate::walpin::CensusResult, String>>,
+) {
+    let Some(census) = census else {
+        return;
+    };
     let Some(path) = pool.canonical_path() else {
         return;
     };
-    if !crate::walpin::sidecar_enabled(true) {
-        return;
-    }
     let dir = crate::walpin::sidecar_dir_for(path);
     // Each record carries its producer's own sweep cadence
     // (`sweep_interval_ms`), which is what freshness is judged against; the
@@ -1723,15 +1818,11 @@ fn log_walpin_sidecar_report(pool: &ConnectionPool) {
     }
     let mut unknown_pids: Vec<u32> = report.unknown_pids().collect();
 
-    // ADR-091 Amendment 2 (OS-derived census): the sidecar
-    // directory alone can only speak for PIDs that wrote SOMETHING there —
-    // a database holder that never registered a beacon at all (pre-feature
-    // binary, sidecar disabled, wedged before its first write) would
-    // otherwise be invisible. Widen the universe to every PID the OS
-    // reports as currently holding the database file open; any such PID
-    // absent from `report` entirely is `unknown` for the same reason a
-    // stale/unowned sidecar entry is.
-    match crate::walpin::census_holders(path) {
+    // The sidecar directory alone can only speak for PIDs that wrote
+    // something there. Widen the universe to every PID the OS reports as
+    // holding the database immediately before the TRUNCATE attempt; any holder
+    // absent from `report` is unknown.
+    match census {
         Ok(census) => {
             let sidecar_known: std::collections::HashSet<u32> = report
                 .reporting()
@@ -1894,6 +1985,7 @@ mod tests {
         message: Option<String>,
         oldest_tx_label: Option<String>,
         tx_label: Option<String>,
+        census_only: Option<String>,
     }
 
     #[derive(Default)]
@@ -1919,6 +2011,7 @@ mod tests {
                 "message" => self.0.message = Some(cleaned),
                 "oldest_tx_label" => self.0.oldest_tx_label = Some(cleaned),
                 "tx_label" => self.0.tx_label = Some(cleaned),
+                "census_only" => self.0.census_only = Some(cleaned),
                 _ => {}
             }
         }
@@ -2125,6 +2218,182 @@ mod tests {
         Arc::new(ConnectionPool::new(cfg).expect("pool open"))
     }
 
+    struct TruncateReportHookGuard;
+
+    impl Drop for TruncateReportHookGuard {
+        fn drop(&mut self) {
+            truncate_report_test_sync::uninstall();
+        }
+    }
+
+    struct ReaderProcess {
+        child: std::process::Child,
+        _stdout: std::io::BufReader<std::process::ChildStdout>,
+    }
+
+    impl ReaderProcess {
+        fn spawn(db_path: &std::path::Path) -> Self {
+            use std::io::BufRead;
+            use std::process::Stdio;
+
+            let mut child = std::process::Command::new(
+                std::env::current_exe().expect("resolve current test executable"),
+            )
+            .args([
+                "--exact",
+                "checkpoint::tests::walpin_transient_reader_process_helper",
+                "--nocapture",
+            ])
+            .env("KHIVE_CHECKPOINT_READER_HELPER_PATH", db_path)
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .spawn()
+            .expect("spawn transient WAL reader helper");
+
+            let stdout = child.stdout.take().expect("capture helper stdout");
+            let mut reader = std::io::BufReader::new(stdout);
+            let mut line = String::new();
+            loop {
+                line.clear();
+                let bytes = reader
+                    .read_line(&mut line)
+                    .expect("read transient reader readiness signal");
+                assert!(bytes > 0, "reader helper exited before readiness signal");
+                if line.contains("KHIVE_CHECKPOINT_READER_READY") {
+                    break;
+                }
+            }
+            Self {
+                child,
+                _stdout: reader,
+            }
+        }
+
+        fn pid(&self) -> u32 {
+            self.child.id()
+        }
+
+        fn release(&mut self) {
+            use std::io::Write;
+
+            let mut stdin = self.child.stdin.take().expect("helper stdin is available");
+            stdin
+                .write_all(b"release\n")
+                .expect("release transient reader");
+            drop(stdin);
+            let status = self.child.wait().expect("wait for transient reader helper");
+            assert!(status.success(), "transient reader helper failed: {status}");
+        }
+    }
+
+    impl Drop for ReaderProcess {
+        fn drop(&mut self) {
+            if self.child.try_wait().ok().flatten().is_none() {
+                let _ = self.child.kill();
+                let _ = self.child.wait();
+            }
+        }
+    }
+
+    #[test]
+    fn walpin_transient_reader_process_helper() {
+        use std::io::Write;
+
+        let Some(path) = std::env::var_os("KHIVE_CHECKPOINT_READER_HELPER_PATH") else {
+            return;
+        };
+        let conn = rusqlite::Connection::open(path).expect("helper opens database");
+        conn.execute_batch("BEGIN DEFERRED; SELECT * FROM t;")
+            .expect("helper pins a read snapshot");
+        println!("KHIVE_CHECKPOINT_READER_READY");
+        std::io::stdout().flush().expect("flush readiness signal");
+        let mut release = String::new();
+        std::io::stdin()
+            .read_line(&mut release)
+            .expect("wait for release signal");
+        conn.execute_batch("COMMIT")
+            .expect("helper releases read snapshot");
+    }
+
+    #[test]
+    #[cfg(unix)]
+    #[serial(checkpoint_skip_metrics, walpin_report_seam)]
+    fn no_progress_report_keeps_holder_released_after_truncate_timeout() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("transient-reader.db");
+        let pool = file_pool(&path);
+        {
+            let writer = pool.try_writer().expect("writer");
+            writer
+                .conn()
+                .execute_batch("CREATE TABLE t (x INTEGER); INSERT INTO t VALUES (1);")
+                .expect("seed WAL before reader snapshot");
+        }
+
+        let mut reader = ReaderProcess::spawn(&path);
+        let reader_pid = reader.pid();
+        {
+            let writer = pool.try_writer().expect("writer");
+            writer
+                .conn()
+                .execute_batch("INSERT INTO t VALUES (2);")
+                .expect("append WAL behind reader snapshot");
+        }
+
+        let canonical_path = pool
+            .canonical_path()
+            .expect("file-backed pool has canonical path")
+            .to_path_buf();
+        let (reached_rx, proceed_tx) = truncate_report_test_sync::install(canonical_path.clone());
+        let _hook_guard = TruncateReportHookGuard;
+        let buffer = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+        let thread_buffer = std::sync::Arc::clone(&buffer);
+        let checkpoint_pool = Arc::clone(&pool);
+        let checkpoint = std::thread::spawn(move || {
+            let subscriber = CaptureSubscriber {
+                events: thread_buffer,
+            };
+            tracing::subscriber::with_default(subscriber, || {
+                checkpoint_once(
+                    &checkpoint_pool,
+                    &CheckpointConfig {
+                        truncate_high_water_pages: 0,
+                        truncate_min_interval: Duration::ZERO,
+                        truncate_busy_timeout: Duration::from_millis(50),
+                        ..CheckpointConfig::default()
+                    },
+                    &mut TruncateState::default(),
+                )
+            })
+        });
+
+        reached_rx
+            .recv_timeout(Duration::from_secs(5))
+            .expect("TRUNCATE must report no progress while the reader is pinned");
+        reader.release();
+        let post_attempt_census =
+            crate::walpin::census_holders(&canonical_path).expect("post-attempt holder census");
+        assert!(
+            !post_attempt_census.holders.contains(&reader_pid),
+            "released reader PID must be absent from a post-attempt census"
+        );
+        proceed_tx
+            .send(())
+            .expect("allow no-progress reporting to continue");
+        checkpoint.join().expect("checkpoint thread");
+
+        let events = buffer.lock().expect("captured events");
+        assert!(
+            events.iter().any(|event| {
+                event
+                    .census_only
+                    .as_deref()
+                    .is_some_and(|pids| pids.contains(&reader_pid.to_string()))
+            }),
+            "the no-progress report must retain PID {reader_pid} from the pre-attempt census: {events:?}"
+        );
+    }
+
     // `checkpoint_once` -> `query_wal_pages` writes the process-wide
     // `LAST_WAL_PAGES` gauge and resets `CHECKPOINT_CONSECUTIVE_SKIPS`
     // (see the reset-discipline comment on `reset_checkpoint_metrics_for_tests`
@@ -2187,14 +2456,7 @@ mod tests {
         };
 
         let (shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(());
-        let handle = tokio::spawn(run_checkpoint_task(
-            pool,
-            cfg,
-            None,
-            "local".to_string(),
-            shutdown_rx,
-            true,
-        ));
+        let handle = tokio::spawn(run_checkpoint_task(pool, cfg, None, shutdown_rx, true));
 
         shutdown_tx.send(()).expect("send shutdown signal");
 
@@ -2235,8 +2497,7 @@ mod tests {
         let handle = tokio::spawn(run_checkpoint_task(
             pool,
             cfg,
-            Some(event_store),
-            "local".to_string(),
+            Some(CheckpointLifecycleOwner::new(event_store, "local")),
             shutdown_rx,
             true,
         ));
@@ -3714,8 +3975,7 @@ mod tests {
         let handle = tokio::spawn(run_checkpoint_task(
             pool,
             cfg,
-            Some(store_dyn),
-            "local".to_string(),
+            Some(CheckpointLifecycleOwner::new(store_dyn, "local")),
             shutdown_rx,
             true,
         ));
@@ -3746,6 +4006,42 @@ mod tests {
 
     #[tokio::test]
     #[serial(checkpoint_skip_metrics)]
+    async fn secondary_checkpoint_task_with_lifecycle_ownership_emits_outcome_events() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("secondary_outcome.db");
+        let pool = file_pool(&path);
+        let cfg = CheckpointConfig {
+            interval: Duration::from_millis(10),
+            warn_pages: 0,
+            ..CheckpointConfig::default()
+        };
+        let store = Arc::new(FakeEventStore::default());
+        let store_dyn: Arc<dyn khive_storage::EventStore> = store.clone();
+
+        let (shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(());
+        let handle = tokio::spawn(run_checkpoint_task(
+            pool,
+            cfg,
+            Some(CheckpointLifecycleOwner::new(store_dyn, "local")),
+            shutdown_rx,
+            false,
+        ));
+
+        tokio::time::sleep(Duration::from_millis(40)).await;
+        shutdown_tx.send(()).expect("send shutdown signal");
+        tokio::time::timeout(Duration::from_secs(1), handle)
+            .await
+            .expect("checkpoint task should exit within 1s")
+            .expect("checkpoint task panicked");
+
+        assert!(
+            !store.events.lock().unwrap().is_empty(),
+            "a designated secondary lifecycle owner must append outcome events"
+        );
+    }
+
+    #[tokio::test]
+    #[serial(checkpoint_skip_metrics)]
     async fn checkpoint_task_emits_nothing_while_healthy() {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("outcome_no_emit.db");
@@ -3765,8 +4061,7 @@ mod tests {
         let handle = tokio::spawn(run_checkpoint_task(
             pool,
             cfg,
-            Some(store_dyn),
-            "local".to_string(),
+            Some(CheckpointLifecycleOwner::new(store_dyn, "local")),
             shutdown_rx,
             true,
         ));
@@ -3798,14 +4093,7 @@ mod tests {
         };
 
         let (shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(());
-        let handle = tokio::spawn(run_checkpoint_task(
-            pool,
-            cfg,
-            None,
-            "local".to_string(),
-            shutdown_rx,
-            true,
-        ));
+        let handle = tokio::spawn(run_checkpoint_task(pool, cfg, None, shutdown_rx, true));
 
         tokio::time::sleep(Duration::from_millis(40)).await;
         shutdown_tx.send(()).expect("send shutdown signal");
@@ -3859,14 +4147,7 @@ mod tests {
         };
 
         let (shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(());
-        let handle = tokio::spawn(run_checkpoint_task(
-            pool,
-            cfg,
-            None,
-            "local".to_string(),
-            shutdown_rx,
-            true,
-        ));
+        let handle = tokio::spawn(run_checkpoint_task(pool, cfg, None, shutdown_rx, true));
 
         tokio::time::sleep(Duration::from_millis(60)).await;
         shutdown_tx.send(()).expect("send shutdown signal");
@@ -3914,14 +4195,7 @@ mod tests {
         };
 
         let (shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(());
-        let handle = tokio::spawn(run_checkpoint_task(
-            pool,
-            cfg,
-            None,
-            "local".to_string(),
-            shutdown_rx,
-            true,
-        ));
+        let handle = tokio::spawn(run_checkpoint_task(pool, cfg, None, shutdown_rx, true));
 
         tokio::time::sleep(Duration::from_millis(40)).await;
         shutdown_tx.send(()).expect("send shutdown signal");
@@ -3990,7 +4264,6 @@ mod tests {
             Arc::clone(&pool),
             cfg,
             None,
-            "local".to_string(),
             shutdown_rx,
             true,
         ));
@@ -4465,7 +4738,6 @@ mod tests {
             pool_a,
             cfg,
             None,
-            "local".to_string(),
             shutdown_rx,
             false, // is_main: backend A is a secondary backend here
         ));
@@ -4539,7 +4811,6 @@ mod tests {
             pool,
             cfg,
             None,
-            "local".to_string(),
             shutdown_rx,
             false, // is_main: this is a secondary backend's own checkpoint task
         ));

--- a/crates/khive-db/src/lib.rs
+++ b/crates/khive-db/src/lib.rs
@@ -29,7 +29,10 @@ pub mod walpin;
 pub mod writer_task;
 
 pub use backend::StorageBackend;
-pub use checkpoint::{checkpoint_once, run_checkpoint_task, CheckpointConfig, CheckpointTick};
+pub use checkpoint::{
+    checkpoint_once, run_checkpoint_task, CheckpointConfig, CheckpointLifecycleOwner,
+    CheckpointTick,
+};
 pub use checkpoint::{run_session_sweep_task, SessionSweepConfig, SweepBackend};
 pub use error::SqliteError;
 pub use migrations::{

--- a/crates/khive-db/src/pool.rs
+++ b/crates/khive-db/src/pool.rs
@@ -22,6 +22,8 @@ const DEFAULT_WAL_AUTOCHECKPOINT_PAGES: u32 = 4000;
 const DEFAULT_JOURNAL_SIZE_LIMIT_BYTES: i64 = 67_108_864; // 64 MiB
 const DEFAULT_WRITE_QUEUE_CAPACITY: usize = 256;
 
+const TEST_HARNESS_ENV: &str = "KHIVE_TEST_HARNESS";
+
 /// Configuration for the connection pool.
 #[derive(Clone, Debug)]
 pub struct PoolConfig {
@@ -119,6 +121,96 @@ impl Default for PoolConfig {
                 .unwrap_or(DEFAULT_WRITE_QUEUE_CAPACITY),
         }
     }
+}
+
+/// Prevent Cargo-launched tests and test subprocesses from opening the
+/// operator's default data tree in every build profile. Activation is solely
+/// the runtime `KHIVE_TEST_HARNESS=1` marker; production/installed binaries do
+/// not receive that workspace Cargo environment.
+///
+/// There is deliberately no environment override: any inheritable escape
+/// hatch set for one Cargo invocation leaks into the next `cargo test` in the
+/// same shell and re-opens the store the guard exists to protect. A deliberate
+/// session against the real store runs the built binary directly (for example
+/// `target/release/...` or an installed binary), which never receives the
+/// workspace Cargo environment and therefore never trips this guard.
+/// Existing path ancestors are canonicalized before comparison, resolving
+/// traversal, symlinks, and filesystem-provided case (including APFS case
+/// folding). Missing trailing components remain lexical because they have no
+/// filesystem identity yet. SQLite URI paths are rejected rather than trying
+/// to reproduce SQLite's URI normalization rules.
+fn refuse_home_data_store_in_tests(config: &PoolConfig) -> Result<(), SqliteError> {
+    if std::env::var(TEST_HARNESS_ENV).as_deref() != Ok("1") {
+        return Ok(());
+    }
+
+    let Some(path) = config.path.as_deref() else {
+        return Ok(());
+    };
+    if path
+        .as_os_str()
+        .as_encoded_bytes()
+        .get(..5)
+        .is_some_and(|prefix| prefix.eq_ignore_ascii_case(b"file:"))
+    {
+        return Err(SqliteError::InvalidData(format!(
+            "test harness refused SQLite URI database path {}; use a filesystem path outside \
+             HOME/.khive (deliberate sessions against a real store run the built binary \
+             directly, outside the Cargo test environment)",
+            path.display()
+        )));
+    }
+
+    let Some(home) = std::env::var_os("HOME") else {
+        return Ok(());
+    };
+    let canonical_path = canonicalize_deepest_existing(path)?;
+    let canonical_home_data_dir =
+        canonicalize_deepest_existing(&PathBuf::from(home).join(".khive"))?;
+    if canonical_path.starts_with(&canonical_home_data_dir) {
+        return Err(SqliteError::InvalidData(format!(
+            "test harness refused to open SQLite database under HOME/.khive: {} \
+             (deliberate sessions against a real store run the built binary directly, \
+             outside the Cargo test environment)",
+            canonical_path.display()
+        )));
+    }
+    Ok(())
+}
+
+fn canonicalize_deepest_existing(path: &Path) -> Result<PathBuf, SqliteError> {
+    let absolute = if path.is_absolute() {
+        path.to_path_buf()
+    } else {
+        std::env::current_dir().map_err(SqliteError::Io)?.join(path)
+    };
+
+    for ancestor in absolute.ancestors() {
+        match fs::canonicalize(ancestor) {
+            Ok(mut canonical) => {
+                let missing = absolute.strip_prefix(ancestor).map_err(|error| {
+                    SqliteError::InvalidData(format!(
+                        "failed to preserve missing path components for {}: {error}",
+                        absolute.display()
+                    ))
+                })?;
+                canonical.push(missing);
+                return Ok(canonical);
+            }
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+            Err(error) => {
+                return Err(SqliteError::InvalidData(format!(
+                    "failed to canonicalize database path ancestor {}: {error}",
+                    ancestor.display()
+                )));
+            }
+        }
+    }
+
+    Err(SqliteError::InvalidData(format!(
+        "database path has no canonicalizable ancestor: {}",
+        absolute.display()
+    )))
 }
 
 /// A read-write connection pool for SQLite.
@@ -281,6 +373,8 @@ impl ConnectionPool {
     /// WAL is disabled or unavailable, the pool falls back to single-connection
     /// mode.
     pub fn new(config: PoolConfig) -> Result<Self, SqliteError> {
+        refuse_home_data_store_in_tests(&config)?;
+
         let writer = open_writer_connection(&config)?;
         let wal_enabled = configure_writer_connection(&writer, &config)?;
         let max_readers = effective_reader_count(&config, wal_enabled);

--- a/crates/khive-db/src/pool.rs
+++ b/crates/khive-db/src/pool.rs
@@ -932,10 +932,56 @@ mod tests {
         }
     }
 
+    const POOL_ENV_VARS: [&str; 6] = [
+        "KHIVE_BUSY_TIMEOUT_SECS",
+        "KHIVE_CHECKOUT_TIMEOUT_SECS",
+        "KHIVE_WAL_AUTOCHECKPOINT_PAGES",
+        "KHIVE_JOURNAL_SIZE_LIMIT_BYTES",
+        "KHIVE_WRITE_QUEUE",
+        "KHIVE_WRITE_QUEUE_CAPACITY",
+    ];
+
+    struct PoolEnvGuard {
+        saved: Vec<(&'static str, Option<std::ffi::OsString>)>,
+    }
+
+    impl PoolEnvGuard {
+        fn capture() -> Self {
+            Self {
+                saved: POOL_ENV_VARS
+                    .into_iter()
+                    .map(|key| (key, std::env::var_os(key)))
+                    .collect(),
+            }
+        }
+    }
+
+    impl Drop for PoolEnvGuard {
+        fn drop(&mut self) {
+            for (key, value) in &self.saved {
+                match value {
+                    Some(value) => std::env::set_var(key, value),
+                    None => std::env::remove_var(key),
+                }
+            }
+        }
+    }
+
+    fn clear_pool_env() -> PoolEnvGuard {
+        let guard = PoolEnvGuard::capture();
+        for var in POOL_ENV_VARS {
+            std::env::remove_var(var);
+        }
+        guard
+    }
+
     #[test]
     #[serial]
     fn pool_config_default_values_match_constants() {
-        // Ensure defaults are not accidentally changed.
+        // Ensure defaults are not accidentally changed. The process env may
+        // legitimately carry overrides (CI jobs set KHIVE_CHECKOUT_TIMEOUT_SECS),
+        // so clear them first — this test asserts the constants, not the env.
+        let _pool_env = clear_pool_env();
         let cfg = PoolConfig::default();
         assert_eq!(
             cfg.wal_autocheckpoint_pages,
@@ -988,9 +1034,27 @@ mod tests {
     #[test]
     #[serial]
     fn pool_config_write_queue_defaults_off() {
+        let _pool_env = clear_pool_env();
         let cfg = PoolConfig::default();
         assert!(!cfg.write_queue_enabled);
         assert_eq!(cfg.write_queue_capacity, DEFAULT_WRITE_QUEUE_CAPACITY);
+    }
+
+    #[test]
+    #[serial]
+    fn clear_pool_env_restores_overrides_on_drop() {
+        let _ambient_env = PoolEnvGuard::capture();
+        std::env::set_var("KHIVE_BUSY_TIMEOUT_SECS", "73");
+
+        {
+            let _pool_env = clear_pool_env();
+            assert_eq!(std::env::var_os("KHIVE_BUSY_TIMEOUT_SECS"), None);
+        }
+
+        assert_eq!(
+            std::env::var_os("KHIVE_BUSY_TIMEOUT_SECS"),
+            Some(std::ffi::OsString::from("73"))
+        );
     }
 
     #[test]

--- a/crates/khive-db/src/stores/text.rs
+++ b/crates/khive-db/src/stores/text.rs
@@ -13,6 +13,7 @@ use khive_storage::types::{
     TextGatherMode, TextIndexStats, TextQueryMode, TextSearchHit, TextSearchOptions,
     TextSearchRequest, TextTermStats, TextTermStatsRequest,
 };
+use khive_storage::usage::{UsageContext, UsageUnit};
 use khive_storage::StorageCapability;
 use khive_storage::TextSearch;
 use khive_types::SubstrateKind;
@@ -100,6 +101,12 @@ fn map_err(e: rusqlite::Error, op: &'static str) -> StorageError {
 
 fn map_sqlite_err(e: SqliteError, op: &'static str) -> StorageError {
     StorageError::driver(StorageCapability::Text, op, e)
+}
+
+fn count_fts_pass(context: Option<&UsageContext>) {
+    if let Some(context) = context {
+        context.add(UsageUnit::FtsPasses, 1);
+    }
 }
 
 /// A TextSearch backed by SQLite FTS5 virtual tables.
@@ -879,99 +886,104 @@ impl TextSearch for Fts5TextSearch {
 
     async fn search(&self, request: TextSearchRequest) -> Result<Vec<TextSearchHit>, StorageError> {
         let table = self.table_name.clone();
+        let usage = khive_storage::usage::current();
 
-        self.with_reader("fts_search", move |conn| {
-            let match_expr = match build_match_expr(&request.query, request.mode) {
-                Some(expr) => expr,
-                None => return Ok(Vec::new()),
-            };
+        let result = self
+            .with_reader("fts_search", move |conn| {
+                let match_expr = match build_match_expr(&request.query, request.mode) {
+                    Some(expr) => expr,
+                    None => return Ok(Vec::new()),
+                };
 
-            // Snippet column index 3 = body in the FTS5 schema.
-            // snippet_chars == 0 is the sentinel for "no snippet" — skip the
-            // snippet(...) call entirely and return NULL instead.  This avoids
-            // the ~12ms BM25 snippet computation on the hot recall path where
-            // snippets are unused.  Callers that need snippets (diagnostics) pass
-            // snippet_chars > 0 and get the same behaviour as before.
-            let snippet_expr = if request.snippet_chars == 0 {
-                "NULL AS snippet".to_string()
-            } else {
-                let chars = i32::try_from(request.snippet_chars).unwrap_or(i32::MAX);
-                format!("snippet({table}, 3, '', '', '...', {chars})")
-            };
+                // Snippet column index 3 = body in the FTS5 schema.
+                // snippet_chars == 0 is the sentinel for "no snippet" — skip the
+                // snippet(...) call entirely and return NULL instead.  This avoids
+                // the ~12ms BM25 snippet computation on the hot recall path where
+                // snippets are unused.  Callers that need snippets (diagnostics) pass
+                // snippet_chars > 0 and get the same behaviour as before.
+                let snippet_expr = if request.snippet_chars == 0 {
+                    "NULL AS snippet".to_string()
+                } else {
+                    let chars = i32::try_from(request.snippet_chars).unwrap_or(i32::MAX);
+                    format!("snippet({table}, 3, '', '', '...', {chars})")
+                };
 
-            let (filter_clause, filter_params) = if let Some(ref filter) = request.filter {
-                build_filter_clause(filter, &table, 3)
-            } else {
-                (String::new(), Vec::new())
-            };
+                let (filter_clause, filter_params) = if let Some(ref filter) = request.filter {
+                    build_filter_clause(filter, &table, 3)
+                } else {
+                    (String::new(), Vec::new())
+                };
 
-            let sql = format!(
-                "SELECT subject_id, rank, title, {snippet_expr} \
-                 FROM {table} WHERE {table} MATCH ?1{filter_clause} \
-                 ORDER BY rank LIMIT ?2",
-            );
+                let sql = format!(
+                    "SELECT subject_id, rank, title, {snippet_expr} \
+                     FROM {table} WHERE {table} MATCH ?1{filter_clause} \
+                     ORDER BY rank LIMIT ?2",
+                );
 
-            let mut stmt = conn.prepare(&sql)?;
-            stmt.raw_bind_parameter(1, &match_expr)?;
-            stmt.raw_bind_parameter(2, request.top_k as i64)?;
+                let mut stmt = conn.prepare(&sql)?;
+                count_fts_pass(usage.as_ref());
+                stmt.raw_bind_parameter(1, &match_expr)?;
+                stmt.raw_bind_parameter(2, request.top_k as i64)?;
 
-            for (i, param) in filter_params.iter().enumerate() {
-                param
-                    .to_sql()
-                    .map(|val| stmt.raw_bind_parameter(3 + i, val))
-                    .map_err(|e| rusqlite::Error::ToSqlConversionFailure(Box::new(e)))??;
-            }
+                for (i, param) in filter_params.iter().enumerate() {
+                    param
+                        .to_sql()
+                        .map(|val| stmt.raw_bind_parameter(3 + i, val))
+                        .map_err(|e| rusqlite::Error::ToSqlConversionFailure(Box::new(e)))??;
+                }
 
-            let mut hits = Vec::new();
-            let mut rows = stmt.raw_query();
-            let mut rank_idx = 0u32;
+                let mut hits = Vec::new();
+                let mut rows = stmt.raw_query();
+                let mut rank_idx = 0u32;
 
-            while let Some(row) = rows.next()? {
-                let id_str: String = row.get(0)?;
-                let fts_rank: f64 = row.get(1)?;
-                let title: String = row.get(2)?;
-                let snippet: Option<String> = row.get(3)?;
+                while let Some(row) = rows.next()? {
+                    let id_str: String = row.get(0)?;
+                    let fts_rank: f64 = row.get(1)?;
+                    let title: String = row.get(2)?;
+                    let snippet: Option<String> = row.get(3)?;
 
-                let subject_id = Uuid::parse_str(&id_str).map_err(|e| {
-                    rusqlite::Error::FromSqlConversionFailure(
-                        0,
-                        rusqlite::types::Type::Text,
-                        Box::new(e),
-                    )
-                })?;
+                    let subject_id = Uuid::parse_str(&id_str).map_err(|e| {
+                        rusqlite::Error::FromSqlConversionFailure(
+                            0,
+                            rusqlite::types::Type::Text,
+                            Box::new(e),
+                        )
+                    })?;
 
-                rank_idx += 1;
-                hits.push((subject_id, fts_rank, rank_idx, title, snippet));
-            }
+                    rank_idx += 1;
+                    hits.push((subject_id, fts_rank, rank_idx, title, snippet));
+                }
 
-            // Normalize scores within the result set to (0.05, 1.0].
-            // Best rank (most negative) maps to 1.0, worst to 0.05.
-            let min_rank = hits.iter().map(|h| h.1).fold(f64::INFINITY, f64::min);
-            let max_rank = hits.iter().map(|h| h.1).fold(f64::NEG_INFINITY, f64::max);
-            let range = max_rank - min_rank;
+                // Normalize scores within the result set to (0.05, 1.0].
+                // Best rank (most negative) maps to 1.0, worst to 0.05.
+                let min_rank = hits.iter().map(|h| h.1).fold(f64::INFINITY, f64::min);
+                let max_rank = hits.iter().map(|h| h.1).fold(f64::NEG_INFINITY, f64::max);
+                let range = max_rank - min_rank;
 
-            let results = hits
-                .into_iter()
-                .map(|(subject_id, raw_rank, rank, title, snippet)| {
-                    let score = if range.abs() < 1e-12 {
-                        1.0
-                    } else {
-                        let t = (max_rank - raw_rank) / range;
-                        0.05 + 0.95 * t
-                    };
-                    TextSearchHit {
-                        subject_id,
-                        score: DeterministicScore::from_f64(score),
-                        rank,
-                        title: if title.is_empty() { None } else { Some(title) },
-                        snippet: snippet.filter(|s| !s.is_empty()),
-                    }
-                })
-                .collect();
+                let results = hits
+                    .into_iter()
+                    .map(|(subject_id, raw_rank, rank, title, snippet)| {
+                        let score = if range.abs() < 1e-12 {
+                            1.0
+                        } else {
+                            let t = (max_rank - raw_rank) / range;
+                            0.05 + 0.95 * t
+                        };
+                        TextSearchHit {
+                            subject_id,
+                            score: DeterministicScore::from_f64(score),
+                            rank,
+                            title: if title.is_empty() { None } else { Some(title) },
+                            snippet: snippet.filter(|s| !s.is_empty()),
+                        }
+                    })
+                    .collect();
 
-            Ok(results)
-        })
-        .await
+                Ok(results)
+            })
+            .await;
+
+        result
     }
 
     async fn count(&self, filter: TextFilter) -> Result<u64, StorageError> {
@@ -1177,6 +1189,7 @@ impl Fts5TextSearch {
         request: TextSearchRequest,
     ) -> Result<Vec<TextSearchHit>, StorageError> {
         let table = self.table_name.clone();
+        let usage = khive_storage::usage::current();
 
         self.with_reader("fts_search_unranked", move |conn| {
             let match_expr = match build_match_expr(&request.query, request.mode) {
@@ -1198,6 +1211,7 @@ impl Fts5TextSearch {
             );
 
             let mut stmt = conn.prepare(&sql)?;
+            count_fts_pass(usage.as_ref());
             stmt.raw_bind_parameter(1, &match_expr)?;
             stmt.raw_bind_parameter(2, request.top_k as i64)?;
 
@@ -1246,6 +1260,7 @@ impl Fts5TextSearch {
         gather_limit: u32,
     ) -> Result<Vec<TextSearchHit>, StorageError> {
         let table = self.table_name.clone();
+        let usage = khive_storage::usage::current();
 
         self.with_reader("fts_search_rank_within_cap", move |conn| {
             let match_expr = match build_match_expr(&request.query, request.mode) {
@@ -1265,6 +1280,7 @@ impl Fts5TextSearch {
             );
 
             let mut stmt = conn.prepare(&gather_sql)?;
+            count_fts_pass(usage.as_ref());
             stmt.raw_bind_parameter(1, &match_expr)?;
             stmt.raw_bind_parameter(2, gather_limit as i64)?;
             for (i, param) in filter_params.iter().enumerate() {
@@ -1307,6 +1323,7 @@ impl Fts5TextSearch {
             );
 
             let mut stmt2 = conn.prepare(&rank_sql)?;
+            count_fts_pass(usage.as_ref());
             stmt2.raw_bind_parameter(1, &match_expr)?;
             stmt2.raw_bind_parameter(2, request.top_k as i64)?;
             for (i, id_str) in gathered_ids.iter().enumerate() {

--- a/crates/khive-db/src/stores/text_tests.rs
+++ b/crates/khive-db/src/stores/text_tests.rs
@@ -2307,3 +2307,215 @@ async fn test_search_hyphenated_id_with_plain_terms_matches_exact_id() {
         );
     }
 }
+
+// `fts_passes` is an issued counter (khive_storage::usage): it must count
+// one FTS5 statement actually prepared and executed. An empty/fully-sanitized
+// query short-circuits `search()` before any statement exists (`build_match_expr`
+// returns `None`) and must not count; a normal query that does reach
+// `conn.prepare` must count exactly once.
+#[tokio::test]
+async fn test_search_empty_query_does_not_count_fts_pass() {
+    let store = setup_memory_store("empty_query_no_count");
+
+    let ctx = khive_storage::usage::UsageContext::new();
+    let hits = khive_storage::usage::scope(ctx.clone(), async {
+        store
+            .search(TextSearchRequest {
+                query: String::new(),
+                mode: TextQueryMode::Plain,
+                filter: Some(ns_filter("test_ns")),
+                top_k: 10,
+                snippet_chars: 64,
+            })
+            .await
+    })
+    .await
+    .unwrap();
+
+    assert!(hits.is_empty(), "empty query must return no hits");
+    let snap = ctx.snapshot();
+    assert!(
+        snap.get("fts_passes").is_none(),
+        "an empty query must never prepare an FTS5 statement, so fts_passes \
+         must not count; got {snap:?}"
+    );
+}
+
+#[tokio::test]
+async fn test_search_fully_sanitized_query_does_not_count_fts_pass() {
+    let store = setup_memory_store("sanitized_query_no_count");
+
+    // Pure FTS5 metacharacters — `sanitize_fts5_token_group` strips every
+    // token to nothing, so `build_match_expr` still returns `None`.
+    let ctx = khive_storage::usage::UsageContext::new();
+    let hits = khive_storage::usage::scope(ctx.clone(), async {
+        store
+            .search(TextSearchRequest {
+                query: "\"\"^^**".to_string(),
+                mode: TextQueryMode::Plain,
+                filter: Some(ns_filter("test_ns")),
+                top_k: 10,
+                snippet_chars: 64,
+            })
+            .await
+    })
+    .await
+    .unwrap();
+
+    assert!(hits.is_empty(), "fully-sanitized query must return no hits");
+    let snap = ctx.snapshot();
+    assert!(
+        snap.get("fts_passes").is_none(),
+        "a fully-sanitized query must never prepare an FTS5 statement, so \
+         fts_passes must not count; got {snap:?}"
+    );
+}
+
+#[tokio::test]
+async fn test_search_normal_query_counts_exactly_one_fts_pass() {
+    let store = setup_memory_store("normal_query_counts_once");
+
+    let id = Uuid::new_v4();
+    store
+        .upsert_document(make_document(id, "counted", "fts pass accounting body"))
+        .await
+        .unwrap();
+
+    let ctx = khive_storage::usage::UsageContext::new();
+    let hits = khive_storage::usage::scope(ctx.clone(), async {
+        store
+            .search(TextSearchRequest {
+                query: "accounting".to_string(),
+                mode: TextQueryMode::Plain,
+                filter: Some(ns_filter("test_ns")),
+                top_k: 10,
+                snippet_chars: 64,
+            })
+            .await
+    })
+    .await
+    .unwrap();
+
+    assert_eq!(hits.len(), 1, "query must match the upserted document");
+    let snap = ctx.snapshot();
+    assert_eq!(
+        snap["fts_passes"], 1,
+        "a query that reaches conn.prepare must count exactly one fts_pass; got {snap:?}"
+    );
+}
+
+#[tokio::test]
+async fn test_cancelled_search_continuation_counts_issued_fts_pass() {
+    let store = setup_memory_store("cancelled_search_counts");
+    store
+        .upsert_document(make_document(
+            Uuid::new_v4(),
+            "counted",
+            "cancelled continuation accounting",
+        ))
+        .await
+        .unwrap();
+
+    let pool = Arc::clone(&store.pool);
+    let reader_blocker = pool.writer().unwrap();
+    let ctx = khive_storage::usage::UsageContext::new();
+    let task = tokio::spawn(khive_storage::usage::scope(ctx.clone(), async move {
+        store
+            .search(TextSearchRequest {
+                query: "continuation".to_string(),
+                mode: TextQueryMode::Plain,
+                filter: Some(ns_filter("test_ns")),
+                top_k: 10,
+                snippet_chars: 0,
+            })
+            .await
+    }));
+
+    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+    task.abort();
+    let joined = task.await;
+    assert!(joined.unwrap_err().is_cancelled());
+    drop(reader_blocker);
+
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(2);
+    while ctx.snapshot().get("fts_passes").is_none() && std::time::Instant::now() < deadline {
+        tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+    }
+    assert_eq!(
+        ctx.snapshot()["fts_passes"],
+        1,
+        "the blocking query continues after caller cancellation and must count when issued"
+    );
+}
+
+#[tokio::test]
+async fn test_search_unranked_counts_exactly_one_fts_pass() {
+    let store = setup_memory_store("unranked_counts_once");
+    store
+        .upsert_document(make_document(
+            Uuid::new_v4(),
+            "counted",
+            "unranked pass accounting",
+        ))
+        .await
+        .unwrap();
+
+    let ctx = khive_storage::usage::UsageContext::new();
+    khive_storage::usage::scope(ctx.clone(), async {
+        store
+            .search_with_options(
+                TextSearchRequest {
+                    query: "unranked".to_string(),
+                    mode: TextQueryMode::Plain,
+                    filter: Some(ns_filter("test_ns")),
+                    top_k: 10,
+                    snippet_chars: 0,
+                },
+                TextSearchOptions {
+                    gather_mode: TextGatherMode::Unranked,
+                    gather_limit: None,
+                },
+            )
+            .await
+    })
+    .await
+    .unwrap();
+
+    assert_eq!(ctx.snapshot()["fts_passes"], 1);
+}
+
+#[tokio::test]
+async fn test_search_rank_within_cap_counts_two_fts_passes() {
+    let store = setup_memory_store("rank_within_cap_counts_twice");
+    store
+        .upsert_document(make_document(
+            Uuid::new_v4(),
+            "counted",
+            "rank within cap accounting",
+        ))
+        .await
+        .unwrap();
+
+    let ctx = khive_storage::usage::UsageContext::new();
+    khive_storage::usage::scope(ctx.clone(), async {
+        store
+            .search_with_options(
+                TextSearchRequest {
+                    query: "accounting".to_string(),
+                    mode: TextQueryMode::Plain,
+                    filter: Some(ns_filter("test_ns")),
+                    top_k: 10,
+                    snippet_chars: 0,
+                },
+                TextSearchOptions {
+                    gather_mode: TextGatherMode::RankWithinCap,
+                    gather_limit: Some(20),
+                },
+            )
+            .await
+    })
+    .await
+    .unwrap();
+
+    assert_eq!(ctx.snapshot()["fts_passes"], 2);
+}

--- a/crates/khive-db/src/walpin.rs
+++ b/crates/khive-db/src/walpin.rs
@@ -1553,6 +1553,21 @@ pub struct CensusResult {
     pub truncated: bool,
 }
 
+#[cfg(target_os = "linux")]
+fn census_visible_self_pid() -> Option<u32> {
+    fs::read_link("/proc/self")
+        .ok()?
+        .file_name()?
+        .to_str()?
+        .parse()
+        .ok()
+}
+
+#[cfg(not(target_os = "linux"))]
+fn census_visible_self_pid() -> Option<u32> {
+    Some(std::process::id())
+}
+
 impl CensusResult {
     /// Every discovered PID was either confirmed as a holder or positively
     /// ruled out (no PID's inspection failed outright), AND the walk itself
@@ -1562,17 +1577,22 @@ impl CensusResult {
         self.uninspectable_pids.is_empty() && !self.truncated
     }
 
-    /// ADR-091 Amendment 2 self-canary: the sole caller
-    /// (`log_walpin_sidecar_report`) always runs inside the process whose
+    /// ADR-091 Amendment 2 self-canary: the checkpoint census caller always
+    /// runs inside the process whose
     /// own SQLite connection pool holds `db_path` open, so a correct,
-    /// complete census must find `std::process::id()` among the holders it
-    /// discovered. Not finding it is positive proof the walk missed at
-    /// least one live holder. This is necessary but not sufficient — a
-    /// census that is complete apart from a *different* missed PID still
-    /// passes it — so every platform's `census_holders` applies this on top
-    /// of, never instead of, its own per-step incompleteness markers.
+    /// complete census must find the process identity visible through the
+    /// scanner's process source. On Linux that is `/proc/self`, which can
+    /// differ from `std::process::id()` when procfs and the caller occupy
+    /// different PID namespaces. Not finding the scanner-visible identity
+    /// is positive proof the walk missed at least one live holder. This is
+    /// necessary but not sufficient, so every platform applies this on top
+    /// of its own per-step incompleteness markers.
     fn apply_self_canary(&mut self) {
-        if !self.holders.contains(&std::process::id()) {
+        self.apply_self_canary_for(census_visible_self_pid());
+    }
+
+    fn apply_self_canary_for(&mut self, expected_self: Option<u32>) {
+        if expected_self.is_none_or(|pid| !self.holders.contains(&pid)) {
             self.truncated = true;
         }
     }
@@ -3660,6 +3680,10 @@ mod tests {
     #[test]
     #[cfg(any(target_os = "macos", target_os = "linux"))]
     fn census_holders_discovers_holder_through_hard_link_path() {
+        let Some(self_pid) = census_visible_self_pid() else {
+            eprintln!("skipping census test: process identity source is unavailable");
+            return;
+        };
         let root = tempfile::tempdir().unwrap();
         let db_path = root.path().join("test.db");
         fs::File::create(&db_path).unwrap();
@@ -3669,7 +3693,7 @@ mod tests {
         let file = fs::File::open(&link_path).unwrap();
         let census = census_holders(&db_path).expect("census must succeed for a live target");
         assert!(
-            census.holders.contains(&std::process::id()),
+            census.holders.contains(&self_pid),
             "this process holds the db open via hard link {link_path:?} and must appear in the census for {db_path:?}"
         );
         drop(file);
@@ -3779,22 +3803,39 @@ mod tests {
     #[test]
     #[cfg(target_os = "linux")]
     fn census_holders_linux_discovers_self_as_a_holder_of_an_open_db_file() {
+        let procfs_usable = fs::read_dir("/proc").is_ok()
+            && fs::read_dir("/proc/self/fd").is_ok()
+            && census_visible_self_pid().is_some();
+        if !procfs_usable {
+            eprintln!("skipping census test: procfs holder inspection is unavailable");
+            return;
+        }
+        let self_pid = census_visible_self_pid().expect("checked above");
         let root = tempfile::tempdir().unwrap();
         let db_path = root.path().join("test.db");
         let file = fs::File::create(&db_path).unwrap();
         let census = census_holders(&db_path).expect("census must succeed for a live target");
         assert!(
-            census.holders.contains(&std::process::id()),
+            census.holders.contains(&self_pid),
             "this process holds {db_path:?} open and must appear in its own OS-derived census"
         );
         // The self-canary must NOT fire when self genuinely is discovered —
         // it only forces `truncated` on a missing self-PID, never clears an
         // already-set flag from something else.
-        assert!(
-            !census.truncated,
-            "self was found; the self-canary (and the namespace check, when this test runs \
-             in the host's own PID namespace) must not report truncation on its own"
-        );
+        let global_census_supported = fs::metadata("/proc/self/ns/pid")
+            .is_ok_and(|meta| pid_ns_is_init(meta.ino()))
+            && proc_mount_is_visibility_restricted() == Some(false);
+        if global_census_supported {
+            assert!(
+                !census.truncated,
+                "self was found in an unrestricted init-namespace procfs census"
+            );
+        } else {
+            assert!(
+                census.truncated,
+                "a namespace- or mount-restricted procfs census must stay incomplete"
+            );
+        }
         // Not asserting `is_complete()` here: an unprivileged process
         // legitimately cannot inspect every other PID's open fds on a real,
         // busy machine (other users' / root's processes), so
@@ -3934,12 +3975,13 @@ mod tests {
 
     #[test]
     fn self_canary_marks_truncated_when_own_pid_missing() {
+        let scanner_pid = 41;
         let mut census = CensusResult {
-            holders: std::collections::HashSet::from([std::process::id().wrapping_add(1)]),
+            holders: std::collections::HashSet::from([42]),
             uninspectable_pids: Vec::new(),
             truncated: false,
         };
-        census.apply_self_canary();
+        census.apply_self_canary_for(Some(scanner_pid));
         assert!(
             census.truncated,
             "a census that discovered other holders but not the calling process itself is \
@@ -3949,12 +3991,13 @@ mod tests {
 
     #[test]
     fn self_canary_leaves_a_correct_census_untouched() {
+        let scanner_pid = 41;
         let mut census = CensusResult {
-            holders: std::collections::HashSet::from([std::process::id()]),
+            holders: std::collections::HashSet::from([scanner_pid]),
             uninspectable_pids: Vec::new(),
             truncated: false,
         };
-        census.apply_self_canary();
+        census.apply_self_canary_for(Some(scanner_pid));
         assert!(
             !census.truncated,
             "self was found; the canary must not fire"
@@ -3963,16 +4006,26 @@ mod tests {
 
     #[test]
     fn self_canary_does_not_clear_an_existing_truncated_flag() {
+        let scanner_pid = 41;
         let mut census = CensusResult {
-            holders: std::collections::HashSet::from([std::process::id()]),
+            holders: std::collections::HashSet::from([scanner_pid]),
             uninspectable_pids: Vec::new(),
             truncated: true,
         };
-        census.apply_self_canary();
+        census.apply_self_canary_for(Some(scanner_pid));
         assert!(
             census.truncated,
             "the self-canary only ever sets `truncated`; it must never clear a flag another \
              step already raised"
         );
+    }
+
+    #[test]
+    fn self_canary_fails_closed_when_process_identity_is_unavailable() {
+        let mut census = CensusResult::default();
+
+        census.apply_self_canary_for(None);
+
+        assert!(census.truncated);
     }
 }

--- a/crates/khive-db/tests/home_store_guard.rs
+++ b/crates/khive-db/tests/home_store_guard.rs
@@ -1,0 +1,170 @@
+use khive_db::{ConnectionPool, PoolConfig};
+use std::ffi::OsString;
+use std::path::{Path, PathBuf};
+
+const ALLOW_HOME_STORE_ENV: &str = "KHIVE_ALLOW_HOME_STORE";
+
+struct HomeGuard {
+    home: Option<OsString>,
+    allow_home_store: Option<OsString>,
+}
+
+impl HomeGuard {
+    fn install(home: &Path) -> Self {
+        let guard = Self {
+            home: std::env::var_os("HOME"),
+            allow_home_store: std::env::var_os(ALLOW_HOME_STORE_ENV),
+        };
+        std::env::set_var("HOME", home);
+        std::env::remove_var(ALLOW_HOME_STORE_ENV);
+        guard
+    }
+}
+
+impl Drop for HomeGuard {
+    fn drop(&mut self) {
+        restore_env("HOME", self.home.take());
+        restore_env(ALLOW_HOME_STORE_ENV, self.allow_home_store.take());
+    }
+}
+
+fn restore_env(key: &str, value: Option<OsString>) {
+    match value {
+        Some(value) => std::env::set_var(key, value),
+        None => std::env::remove_var(key),
+    }
+}
+
+fn assert_harness_refuses(path: PathBuf) {
+    let message = harness_refusal(path);
+    assert!(
+        message.contains("test harness refused"),
+        "unexpected guard error: {message}"
+    );
+}
+
+fn assert_harness_refuses_with_direct_binary_instruction(path: PathBuf) {
+    let expected_path = path.display().to_string();
+    let message = harness_refusal(path);
+    assert!(
+        message.contains("run the built binary directly") && message.contains(&expected_path),
+        "refusal did not point at the direct-binary workflow: {message}"
+    );
+}
+
+fn harness_refusal(path: PathBuf) -> String {
+    let error = match ConnectionPool::new(PoolConfig {
+        path: Some(path),
+        ..PoolConfig::default()
+    }) {
+        Ok(_) => panic!("test harness opened a database under HOME/.khive"),
+        Err(error) => error,
+    };
+    error.to_string()
+}
+
+fn fake_home() -> (tempfile::TempDir, PathBuf) {
+    assert_eq!(
+        std::env::var("KHIVE_TEST_HARNESS").as_deref(),
+        Ok("1"),
+        "Cargo must mark the test process"
+    );
+    let home = tempfile::tempdir().expect("temporary HOME");
+    let home_data_dir = home.path().join(".khive");
+    std::fs::create_dir(&home_data_dir).expect("create fake home data directory");
+    (home, home_data_dir)
+}
+
+#[test]
+#[serial_test::serial(home_store_guard)]
+fn release_dependency_refuses_home_store() {
+    let (home, home_data_dir) = fake_home();
+    let _home = HomeGuard::install(home.path());
+    let database = home_data_dir.join("release.db");
+
+    assert_harness_refuses_with_direct_binary_instruction(database.clone());
+
+    assert!(!database.exists(), "guard must run before SQLite opens");
+}
+
+#[test]
+#[serial_test::serial(home_store_guard)]
+fn legacy_boolean_override_does_not_allow_home_store() {
+    let (home, home_data_dir) = fake_home();
+    let _home = HomeGuard::install(home.path());
+    let database = home_data_dir.join("legacy-override.db");
+    std::env::set_var(ALLOW_HOME_STORE_ENV, "1");
+
+    assert_harness_refuses_with_direct_binary_instruction(database.clone());
+
+    assert!(!database.exists(), "guard must run before SQLite opens");
+}
+
+#[test]
+#[serial_test::serial(home_store_guard)]
+fn exact_path_override_does_not_allow_home_store() {
+    let (home, home_data_dir) = fake_home();
+    let _home = HomeGuard::install(home.path());
+    let database = home_data_dir.join("exact-override.db");
+    std::env::set_var(ALLOW_HOME_STORE_ENV, &database);
+
+    assert_harness_refuses_with_direct_binary_instruction(database.clone());
+
+    assert!(!database.exists(), "guard must run before SQLite opens");
+}
+
+#[test]
+#[serial_test::serial(home_store_guard)]
+fn different_path_override_does_not_allow_home_store() {
+    let (home, home_data_dir) = fake_home();
+    let _home = HomeGuard::install(home.path());
+    let database = home_data_dir.join("requested.db");
+    std::env::set_var(ALLOW_HOME_STORE_ENV, home_data_dir.join("allowed.db"));
+
+    assert_harness_refuses_with_direct_binary_instruction(database.clone());
+
+    assert!(!database.exists(), "guard must run before SQLite opens");
+}
+
+#[test]
+#[serial_test::serial(home_store_guard)]
+fn refuses_parent_traversal_into_home_store() {
+    let (home, home_data_dir) = fake_home();
+    let _home = HomeGuard::install(home.path());
+    let outside = home.path().join("outside");
+    std::fs::create_dir(&outside).expect("create traversal anchor");
+    let database = home_data_dir.join("traversal.db");
+    let traversal = outside.join("..").join(".khive").join("traversal.db");
+
+    assert_harness_refuses(traversal);
+
+    assert!(!database.exists(), "guard must run before SQLite opens");
+}
+
+#[cfg(unix)]
+#[test]
+#[serial_test::serial(home_store_guard)]
+fn refuses_symlink_alias_into_home_store() {
+    let (home, home_data_dir) = fake_home();
+    let _home = HomeGuard::install(home.path());
+    let alias = home.path().join("store-alias");
+    std::os::unix::fs::symlink(&home_data_dir, &alias).expect("create store alias");
+    let database = home_data_dir.join("symlink.db");
+
+    assert_harness_refuses(alias.join("symlink.db"));
+
+    assert!(!database.exists(), "guard must run before SQLite opens");
+}
+
+#[test]
+#[serial_test::serial(home_store_guard)]
+fn refuses_sqlite_uri_paths() {
+    let (home, home_data_dir) = fake_home();
+    let _home = HomeGuard::install(home.path());
+    let database = home_data_dir.join("uri.db");
+    let uri = PathBuf::from(format!("file:{}", database.display()));
+
+    assert_harness_refuses(uri);
+
+    assert!(!database.exists(), "guard must run before SQLite opens");
+}

--- a/crates/khive-mcp/src/daemon.rs
+++ b/crates/khive-mcp/src/daemon.rs
@@ -381,9 +381,14 @@ impl daemon::DaemonDispatch for crate::server::KhiveMcpServer {
         // context, built by `handle_conn` from the frame — threaded straight
         // through so this call serves under the CALLER's namespace/actor
         // rather than this server's own construction-baked identity.
-        self.dispatch_request_inner(params, from_wire, identity)
-            .await
-            .map_err(|e| e.message.to_string())
+        self.dispatch_request_inner(
+            params,
+            from_wire,
+            identity,
+            crate::server::DispatchOrigin::Daemon,
+        )
+        .await
+        .map_err(|e| e.message.to_string())
     }
 
     async fn warm_all(&self) {

--- a/crates/khive-mcp/src/daemon.rs
+++ b/crates/khive-mcp/src/daemon.rs
@@ -40,13 +40,17 @@ pub(crate) static KILL_COUNT: std::sync::atomic::AtomicUsize =
 pub(crate) static SPAWN_COUNT: std::sync::atomic::AtomicUsize =
     std::sync::atomic::AtomicUsize::new(0);
 
-/// When set to `true` in tests, `pid_is_khive_daemon` returns `true` for any
-/// positive PID.  This makes every PID file entry SIGTERM-eligible so that a
-/// reverted recheck-under-lock would cause `kill_stale_daemon_inner` to attempt
-/// SIGTERM against the real daemon PID — the `KILL_COUNT` assertion catches
-/// both the SIGTERM-eligible and the skip-SIGTERM paths.
+/// When set to `true` in tests, `classify_pid_identity` identifies any positive
+/// live PID as a daemon. This makes every PID file entry SIGTERM-eligible so
+/// that a reverted recheck-under-lock would cause `kill_stale_daemon_inner` to
+/// attempt SIGTERM against the real daemon PID — the `KILL_COUNT` assertion
+/// catches both the SIGTERM-eligible and the skip-SIGTERM paths.
 #[cfg(test)]
 pub(crate) static FORCE_PID_IS_DAEMON: std::sync::atomic::AtomicBool =
+    std::sync::atomic::AtomicBool::new(false);
+
+#[cfg(test)]
+static FORCE_PID_IS_FOREIGN: std::sync::atomic::AtomicBool =
     std::sync::atomic::AtomicBool::new(false);
 
 /// Counts how many times the daemon's dispatcher has been invoked for a
@@ -84,6 +88,7 @@ pub(crate) fn reset_counters() {
     KILL_COUNT.store(0, std::sync::atomic::Ordering::SeqCst);
     SPAWN_COUNT.store(0, std::sync::atomic::Ordering::SeqCst);
     FORCE_PID_IS_DAEMON.store(false, std::sync::atomic::Ordering::SeqCst);
+    FORCE_PID_IS_FOREIGN.store(false, std::sync::atomic::Ordering::SeqCst);
     DAEMON_DISPATCH.store(0, std::sync::atomic::Ordering::SeqCst);
     *RECOVERY_RACE_BARRIER
         .lock()
@@ -701,33 +706,47 @@ fn argv_is_khive_daemon(args: &str) -> bool {
     rest.contains(&"mcp") && rest.contains(&"--daemon")
 }
 
-/// Return `true` if the process with the given PID is identifiable as a khive
-/// daemon. Uses `ps -p <pid> -o args=` (portable across macOS and Linux) and
-/// verifies that (a) the executable basename is exactly `kkernel`, AND (b) the
-/// remaining argv tokens include both `mcp` and `--daemon` (the daemon spawn
-/// shape). A process that merely mentions "kkernel" in some other argument
-/// position is rejected.
-///
-/// If the process is gone or is a foreign process, returns `false` — the caller
-/// must then clean up the stale PID file without sending SIGTERM.
-fn pid_is_khive_daemon(pid: u32) -> bool {
+enum PidIdentity {
+    KhiveDaemon,
+    Foreign,
+    Indeterminate,
+}
+
+/// Classify the process named by the daemon PID file from its command line.
+/// A live process whose identity cannot be read remains indeterminate so the
+/// caller conservatively waits for its exit instead of treating it as stale.
+fn classify_pid_identity(pid: u32) -> PidIdentity {
     let Ok(pid_i32) = i32::try_from(pid) else {
-        return false;
+        return PidIdentity::Foreign;
     };
     if pid_i32 <= 0 {
-        return false;
+        return PidIdentity::Foreign;
+    }
+    #[cfg(test)]
+    if FORCE_PID_IS_FOREIGN.load(std::sync::atomic::Ordering::SeqCst) {
+        return PidIdentity::Foreign;
     }
     // Test seam: when FORCE_PID_IS_DAEMON is set, treat any positive live PID
     // as a daemon so the SIGTERM branch is reachable in tests.
     #[cfg(test)]
     if FORCE_PID_IS_DAEMON.load(std::sync::atomic::Ordering::SeqCst) {
         // SAFETY: signal 0 is an existence/permission probe with no side effects.
-        return unsafe { libc::kill(pid_i32, 0) } == 0;
+        return if unsafe { libc::kill(pid_i32, 0) } == 0 {
+            PidIdentity::KhiveDaemon
+        } else if std::io::Error::last_os_error().raw_os_error() == Some(libc::EPERM) {
+            PidIdentity::Indeterminate
+        } else {
+            PidIdentity::Foreign
+        };
     }
     // Quick liveness check before shelling out.
     // SAFETY: signal 0 is an existence/permission probe with no side effects.
     if unsafe { libc::kill(pid_i32, 0) } != 0 {
-        return false;
+        return match std::io::Error::last_os_error().raw_os_error() {
+            Some(libc::EPERM) => PidIdentity::Indeterminate,
+            Some(libc::ESRCH) => PidIdentity::Foreign,
+            _ => PidIdentity::Indeterminate,
+        };
     }
     match std::process::Command::new("ps")
         .args(["-p", &pid.to_string(), "-o", "args="])
@@ -735,25 +754,74 @@ fn pid_is_khive_daemon(pid: u32) -> bool {
     {
         Ok(out) if out.status.success() => {
             let args = String::from_utf8_lossy(&out.stdout);
-            argv_is_khive_daemon(args.trim())
+            let args = args.trim();
+            if args.is_empty() {
+                PidIdentity::Indeterminate
+            } else if argv_is_khive_daemon(args) {
+                PidIdentity::KhiveDaemon
+            } else {
+                PidIdentity::Foreign
+            }
         }
-        _ => false,
+        _ => PidIdentity::Indeterminate,
     }
 }
 
-/// Kill the daemon named by the PID file and remove its PID + socket files
-/// (caller holds the recovery lock).
-///
-/// #645: the PID observed here (`expected_pid`) is captured once, before
-/// SIGTERM, and re-checked immediately before unlinking in
-/// [`remove_daemon_paths_if_still_stale`]. The recovery lock normally
-/// serializes this whole function against a concurrent daemon boot (which
-/// holds the same lock across its own cleanup → bind → pid-write), but that
-/// guarantee depends on the daemon side successfully acquiring the lock too.
-/// Re-checking ownership right before deleting is the defense that still
-/// holds if a booting daemon ever proceeds without the lock: this call must
-/// not delete a replacement daemon's live socket/PID out from under it.
-fn kill_stale_daemon_inner() {
+const INCUMBENT_EXIT_TIMEOUT_SECS: u64 = 12;
+const INCUMBENT_EXIT_POLL_MS: u64 = 25;
+
+#[derive(Debug)]
+enum RecoveryError {
+    Spawn(std::io::Error),
+    IncumbentStillAlive { pid: u32 },
+}
+
+fn process_is_alive(pid: u32) -> bool {
+    let Ok(pid) = i32::try_from(pid) else {
+        return false;
+    };
+    if pid <= 0 {
+        return false;
+    }
+    // SAFETY: signal 0 is an existence/permission probe with no side effects.
+    let result = unsafe { libc::kill(pid, 0) };
+    let exists = result == 0 || std::io::Error::last_os_error().raw_os_error() == Some(libc::EPERM);
+    if !exists {
+        return false;
+    }
+    match std::process::Command::new("ps")
+        .args(["-p", &pid.to_string(), "-o", "stat="])
+        .output()
+    {
+        Ok(output) if output.status.success() => !String::from_utf8_lossy(&output.stdout)
+            .trim_start()
+            .starts_with('Z'),
+        _ => true,
+    }
+}
+
+async fn wait_for_process_exit(pid: u32, timeout: std::time::Duration) -> bool {
+    let deadline = tokio::time::Instant::now() + timeout;
+    loop {
+        if !process_is_alive(pid) {
+            return true;
+        }
+        let now = tokio::time::Instant::now();
+        if now >= deadline {
+            return false;
+        }
+        tokio::time::sleep(
+            std::time::Duration::from_millis(INCUMBENT_EXIT_POLL_MS).min(deadline - now),
+        )
+        .await;
+    }
+}
+
+/// Signal the daemon named by the PID file and remove its rendezvous files
+/// only after its PID is positively confirmed dead (caller holds the recovery
+/// lock). The PID is captured before SIGTERM and ownership is re-checked by
+/// [`remove_daemon_paths_if_still_stale`] immediately before unlinking.
+async fn kill_stale_daemon_inner(exit_timeout: std::time::Duration) -> Result<(), RecoveryError> {
     #[cfg(test)]
     KILL_COUNT.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
 
@@ -763,25 +831,41 @@ fn kill_stale_daemon_inner() {
         .and_then(|s| s.trim().parse::<u32>().ok());
 
     if let Some(pid) = expected_pid {
-        if pid_is_khive_daemon(pid) {
-            if let Ok(signed) = i32::try_from(pid) {
-                if signed > 0 {
-                    // SAFETY: SIGTERM is a standard termination signal with no
-                    // side effects beyond asking the process to exit.
-                    unsafe {
-                        libc::kill(signed, libc::SIGTERM);
+        let wait_for_exit = match classify_pid_identity(pid) {
+            PidIdentity::KhiveDaemon => {
+                if let Ok(signed) = i32::try_from(pid) {
+                    if signed > 0 {
+                        // SAFETY: SIGTERM is a standard termination signal with no
+                        // side effects beyond asking the process to exit.
+                        unsafe {
+                            libc::kill(signed, libc::SIGTERM);
+                        }
                     }
                 }
+                true
             }
-        } else {
-            tracing::warn!(
-                pid,
-                "PID in daemon file does not belong to a khive daemon — skipping SIGTERM"
-            );
+            PidIdentity::Foreign => {
+                tracing::warn!(
+                    pid,
+                    "PID in daemon file belongs to a foreign process — treating it as stale"
+                );
+                false
+            }
+            PidIdentity::Indeterminate => {
+                tracing::warn!(
+                    pid,
+                    "could not read PID identity — skipping SIGTERM and waiting conservatively"
+                );
+                true
+            }
+        };
+        if wait_for_exit && !wait_for_process_exit(pid, exit_timeout).await {
+            return Err(RecoveryError::IncumbentStillAlive { pid });
         }
     }
 
     remove_daemon_paths_if_still_stale(&pid_file, expected_pid);
+    Ok(())
 }
 
 /// Remove `pid_file`/the daemon socket only if ownership has not changed since
@@ -1056,11 +1140,11 @@ async fn confirm_genuinely_dead(config_id: &str, namespace: &str) -> ProbeOutcom
 }
 
 /// Deadline for acquiring the recoverer-only lock before starting the
-/// dead-confirmation → kill → spawn critical section — generous enough to
-/// cover a peer's full worst-case critical section so a healthy peer's turn
-/// is never mistaken for a wedge. See
+/// dead-confirmation → kill → confirmed-exit → spawn critical section.
+/// This exceeds the incumbent-exit deadline so a peer can finish a full
+/// recovery turn before another recoverer treats the lock as wedged. See
 /// `crates/khive-mcp/docs/api/daemon-lifecycle.md`.
-const RECOVERER_LOCK_TIMEOUT_MS: u64 = 8_000;
+const RECOVERER_LOCK_TIMEOUT_MS: u64 = 16_000;
 
 /// Kill the stale daemon and spawn a fresh one, serialized against concurrent
 /// recoverers by a dedicated recoverer-only lock (#838 double-checked
@@ -1068,14 +1152,34 @@ const RECOVERER_LOCK_TIMEOUT_MS: u64 = 8_000;
 /// (NEVER-KILL-SLOW). `LockContended` (confirm rounds inconclusive, or the
 /// recoverer lock itself timed out) → `Uncertain`, no kill — same safe
 /// behavior as `Skipped` but reported distinctly. `Dead` (confirmed,
-/// recoverer lock held) → kill+spawn → `Spawned`. See
+/// recoverer lock held) → signal + bounded exit confirmation + spawn →
+/// `Spawned`; a PID still alive at the deadline returns
+/// [`RecoveryError::IncumbentStillAlive`] without spawning. See
 /// `crates/khive-mcp/docs/api/daemon-lifecycle.md` for why a second lock
 /// file is required and how this avoids deadlocking a booting daemon.
 async fn kill_and_respawn<F>(
     config_id: &str,
     namespace: &str,
     spawn: &F,
-) -> std::io::Result<RecoveryOutcome>
+) -> Result<RecoveryOutcome, RecoveryError>
+where
+    F: Fn() -> std::io::Result<std::process::Child> + Sync,
+{
+    kill_and_respawn_with_exit_timeout(
+        config_id,
+        namespace,
+        spawn,
+        std::time::Duration::from_secs(INCUMBENT_EXIT_TIMEOUT_SECS),
+    )
+    .await
+}
+
+async fn kill_and_respawn_with_exit_timeout<F>(
+    config_id: &str,
+    namespace: &str,
+    spawn: &F,
+    exit_timeout: std::time::Duration,
+) -> Result<RecoveryOutcome, RecoveryError>
 where
     F: Fn() -> std::io::Result<std::process::Child> + Sync,
 {
@@ -1170,8 +1274,10 @@ where
             // is a distinct lock file from `recoverer_guard` above, acquired
             // and dropped entirely within this arm.
             let _boot_lock = acquire_recovery_lock();
-            kill_stale_daemon_inner();
-            spawn().map(RecoveryOutcome::Spawned)
+            kill_stale_daemon_inner(exit_timeout).await?;
+            spawn()
+                .map(RecoveryOutcome::Spawned)
+                .map_err(RecoveryError::Spawn)
         }
     };
     drop(recoverer_guard);
@@ -1265,6 +1371,25 @@ fn respawn_failed_error(failure: RespawnFailure) -> McpError {
     };
     McpError::internal_error(
         "daemon respawn failed (respawn_failed); rebuild with `make local` and retry",
+        Some(data),
+    )
+}
+
+fn incumbent_still_alive_error(pid: u32) -> McpError {
+    tracing::error!(
+        reason = "incumbent_still_alive",
+        pid,
+        "daemon recovery refused because the incumbent did not exit before the deadline"
+    );
+    let mut data = serde_json::json!({
+        "reason": "incumbent_still_alive",
+        "pid": pid,
+    });
+    if is_daemon_strict_mode() {
+        data[STRICT_FALLBACK_MARKER] = serde_json::Value::Bool(true);
+    }
+    McpError::internal_error(
+        format!("daemon recovery refused: incumbent PID {pid} is still alive after the deadline"),
         Some(data),
     )
 }
@@ -1783,13 +1908,16 @@ where
     // connect-retry window or the #667 boot-quiescence wait short.
     let mut spawned_child: Option<std::process::Child> = None;
     match kill_and_respawn(&frame.config_id, &frame.namespace, spawn).await {
-        Err(e) => {
+        Err(RecoveryError::Spawn(e)) => {
             // #898: `Command::spawn` itself failed to start the child at all —
             // an unambiguous, already-fully-diagnosed respawn failure. Loud in
             // both strict and non-strict mode; never a silent local fallback.
             return Some(Err(respawn_failed_error(RespawnFailure::SpawnError {
                 os_error_code: e.raw_os_error(),
             })));
+        }
+        Err(RecoveryError::IncumbentStillAlive { pid }) => {
+            return Some(Err(incumbent_still_alive_error(pid)));
         }
         Ok(RecoveryOutcome::Skipped) => {
             // A concurrent client already has a live matching daemon ready.
@@ -1967,6 +2095,41 @@ mod tests {
         std::env::remove_var("KHIVE_NO_DAEMON");
         std::env::remove_var("KHIVE_LOCK");
         std::env::remove_var("KHIVE_RECOVERER_LOCK");
+    }
+
+    struct RecoveryTestGuard {
+        child: Option<std::process::Child>,
+    }
+
+    impl RecoveryTestGuard {
+        fn new() -> Self {
+            Self { child: None }
+        }
+
+        fn track_child(&mut self, child: std::process::Child) -> u32 {
+            let pid = child.id();
+            self.child = Some(child);
+            pid
+        }
+
+        fn child_mut(&mut self) -> &mut std::process::Child {
+            self.child.as_mut().expect("test child must be tracked")
+        }
+
+        fn kill_and_reap_child(&mut self) {
+            if let Some(mut child) = self.child.take() {
+                let _ = child.kill();
+                let _ = child.wait();
+            }
+        }
+    }
+
+    impl Drop for RecoveryTestGuard {
+        fn drop(&mut self) {
+            self.kill_and_reap_child();
+            reset_counters();
+            clear_daemon_env();
+        }
     }
 
     async fn connect_when_ready(sock: &std::path::Path) -> UnixStream {
@@ -3695,7 +3858,7 @@ mod tests {
         // Bind the fake old-daemon socket BEFORE starting the client.
         let listener = tokio::net::UnixListener::bind(&sock).expect("bind fake old-daemon socket");
         // Write a placeholder PID file so kill_stale_daemon finds a PID to look at.
-        // We use the current process's PID, which pid_is_khive_daemon() will reject
+        // We use the current process's PID, which classify_pid_identity() will reject
         // because the current exe is the test binary (not "kkernel"), so no SIGTERM
         // will be sent — this is the safe path we want to exercise.
         std::fs::write(&pid_file, std::process::id().to_string()).expect("write pid file");
@@ -3910,6 +4073,186 @@ mod tests {
         ));
     }
 
+    #[tokio::test]
+    #[serial]
+    async fn recovery_requires_incumbent_exit_before_spawning() {
+        let mut cleanup = RecoveryTestGuard::new();
+        clear_daemon_env();
+        reset_counters();
+        let dir = tempfile::tempdir().expect("tempdir");
+        let pid_file = dir.path().join("khived.pid");
+        let ready_file = dir.path().join("incumbent.ready");
+
+        std::env::set_var("KHIVE_SOCKET", dir.path().join("khived.sock"));
+        std::env::set_var("KHIVE_PID", &pid_file);
+        std::env::set_var("KHIVE_LOCK", dir.path().join("khived.recovery.lock"));
+        std::env::set_var(
+            "KHIVE_RECOVERER_LOCK",
+            dir.path().join("khived.recoverer.lock"),
+        );
+        std::env::remove_var("KHIVE_NO_DAEMON");
+
+        let incumbent = std::process::Command::new("/bin/sh")
+            .arg("-c")
+            .arg("trap '' TERM; : > \"$1\"; while :; do sleep 1; done")
+            .arg("stubborn-incumbent")
+            .arg(&ready_file)
+            .spawn()
+            .expect("spawn signal-resistant incumbent");
+        let incumbent_pid = cleanup.track_child(incumbent);
+        let ready_deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(2);
+        while !ready_file.exists() {
+            assert!(
+                tokio::time::Instant::now() < ready_deadline,
+                "incumbent did not install its signal handler"
+            );
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        }
+        std::fs::write(&pid_file, incumbent_pid.to_string()).expect("write incumbent pid file");
+        FORCE_PID_IS_DAEMON.store(true, std::sync::atomic::Ordering::SeqCst);
+
+        let spawn_calls = std::sync::atomic::AtomicUsize::new(0);
+        let spawn = || {
+            spawn_calls.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            std::process::Command::new("/bin/sh")
+                .args(["-c", "exit 0"])
+                .spawn()
+        };
+        let outcome = kill_and_respawn_with_exit_timeout(
+            CFG,
+            NS,
+            &spawn,
+            std::time::Duration::from_millis(100),
+        )
+        .await;
+        let refused_pid = match outcome {
+            Err(RecoveryError::IncumbentStillAlive { pid }) => Some(pid),
+            Ok(RecoveryOutcome::Spawned(mut child)) => {
+                let _ = child.wait();
+                None
+            }
+            Ok(RecoveryOutcome::Skipped | RecoveryOutcome::Uncertain)
+            | Err(RecoveryError::Spawn(_)) => None,
+        };
+        let live_pid_file_preserved = pid_file.exists();
+        cleanup.kill_and_reap_child();
+
+        assert_eq!(refused_pid, Some(incumbent_pid));
+        assert_eq!(
+            spawn_calls.load(std::sync::atomic::Ordering::SeqCst),
+            0,
+            "a replacement must not spawn while the signalled incumbent PID is still alive"
+        );
+        assert!(
+            live_pid_file_preserved,
+            "the live incumbent's PID file must remain in place after refusal"
+        );
+        let refusal = incumbent_still_alive_error(incumbent_pid);
+        assert!(refusal.message.contains(&format!("PID {incumbent_pid}")));
+        let data = refusal.data.expect("live-incumbent refusal data");
+        assert_eq!(data["reason"], "incumbent_still_alive");
+        assert_eq!(data["pid"], incumbent_pid);
+
+        let recovered = kill_and_respawn_with_exit_timeout(
+            CFG,
+            NS,
+            &spawn,
+            std::time::Duration::from_millis(100),
+        )
+        .await;
+        let spawned = match recovered {
+            Ok(RecoveryOutcome::Spawned(mut child)) => {
+                let _ = child.wait();
+                true
+            }
+            _ => false,
+        };
+
+        FORCE_PID_IS_DAEMON.store(false, std::sync::atomic::Ordering::SeqCst);
+        clear_daemon_env();
+        assert!(spawned, "a confirmed-dead incumbent must still be replaced");
+        assert_eq!(
+            spawn_calls.load(std::sync::atomic::Ordering::SeqCst),
+            1,
+            "confirmed-dead recovery must spawn exactly one replacement"
+        );
+        assert!(
+            !pid_file.exists(),
+            "the confirmed-dead incumbent PID file must be removed before spawning"
+        );
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn recovery_replaces_stale_pid_without_waiting_on_live_foreign_process() {
+        let mut cleanup = RecoveryTestGuard::new();
+        clear_daemon_env();
+        reset_counters();
+        let dir = tempfile::tempdir().expect("tempdir");
+        let pid_file = dir.path().join("khived.pid");
+
+        std::env::set_var("KHIVE_SOCKET", dir.path().join("khived.sock"));
+        std::env::set_var("KHIVE_PID", &pid_file);
+        std::env::set_var("KHIVE_LOCK", dir.path().join("khived.recovery.lock"));
+        std::env::set_var(
+            "KHIVE_RECOVERER_LOCK",
+            dir.path().join("khived.recoverer.lock"),
+        );
+        std::env::remove_var("KHIVE_NO_DAEMON");
+
+        let foreign = std::process::Command::new("/bin/sleep")
+            .arg("30")
+            .spawn()
+            .expect("spawn live foreign process");
+        let foreign_pid = cleanup.track_child(foreign);
+        std::fs::write(&pid_file, foreign_pid.to_string()).expect("write foreign pid file");
+        // Process inspection may be restricted in test environments, so force
+        // the classification while retaining a live child to prove it is not killed.
+        FORCE_PID_IS_FOREIGN.store(true, std::sync::atomic::Ordering::SeqCst);
+
+        let spawn_calls = std::sync::atomic::AtomicUsize::new(0);
+        let spawn = || {
+            spawn_calls.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            std::process::Command::new("/bin/sh")
+                .args(["-c", "exit 0"])
+                .spawn()
+        };
+
+        let outcome = tokio::time::timeout(
+            std::time::Duration::from_secs(2),
+            kill_and_respawn(CFG, NS, &spawn),
+        )
+        .await
+        .expect("recovery stalled on a PID positively identified as foreign")
+        .expect("foreign-PID recovery failed");
+        match outcome {
+            RecoveryOutcome::Spawned(mut child) => {
+                child.wait().expect("reap replacement fixture");
+            }
+            RecoveryOutcome::Skipped | RecoveryOutcome::Uncertain => {
+                panic!("foreign-PID recovery did not spawn a replacement")
+            }
+        }
+
+        assert_eq!(
+            spawn_calls.load(std::sync::atomic::Ordering::SeqCst),
+            1,
+            "foreign-PID recovery must spawn exactly one replacement"
+        );
+        assert!(
+            !pid_file.exists(),
+            "the stale foreign PID file must be removed before spawning"
+        );
+        assert!(
+            cleanup
+                .child_mut()
+                .try_wait()
+                .expect("query foreign child state")
+                .is_none(),
+            "recovery must not signal the live foreign process"
+        );
+    }
+
     // ── concurrent recovery — second client skips kill+spawn when daemon alive ──
     //
     // Exercises the recheck-under-lock (double-checked locking) in
@@ -3970,8 +4313,8 @@ mod tests {
             .parse()
             .expect("daemon pid file must contain a u32");
 
-        // Arm the SIGTERM-eligible hook: pid_is_khive_daemon() will now return
-        // true for the live daemon PID.  Without the bounded-probe, a reverted
+        // Arm the SIGTERM-eligible hook: classify_pid_identity() will now identify
+        // the live daemon PID as khive. Without the bounded-probe, a reverted
         // kill_and_respawn would send SIGTERM to that PID and unlink the socket —
         // KILL_COUNT catches both paths.
         FORCE_PID_IS_DAEMON.store(true, std::sync::atomic::Ordering::SeqCst);

--- a/crates/khive-mcp/src/pending_events.rs
+++ b/crates/khive-mcp/src/pending_events.rs
@@ -1346,11 +1346,13 @@ mod tests {
             default_namespace: Namespace::parse("local").unwrap(),
             embedding_model: None,
             additional_embedding_models: vec![],
-            // kg + schedule + comm: this module's tests drive schedule.remind /
-            // schedule.cancel through the drain path and assert delivery lands in
-            // the creator's comm inbox, on top of the kg-verb fixture actions.
-            packs: vec!["kg".to_string(), "schedule".to_string(), "comm".to_string()],
             actor_id: actor_id.map(str::to_string),
+            // Pin the pack list explicitly rather than inheriting `KHIVE_PACKS`
+            // from the ambient environment (#1269). kg + schedule + comm: this
+            // module's tests drive schedule.remind / schedule.cancel through the
+            // drain path and assert delivery lands in the creator's comm inbox,
+            // on top of the kg-verb fixture actions.
+            packs: vec!["kg".to_string(), "schedule".to_string(), "comm".to_string()],
             ..Default::default()
         };
         KhiveRuntime::new(cfg).expect("runtime")
@@ -2187,8 +2189,23 @@ mod tests {
                 }
             }
         }
-        let _restore = RestoreTimeout(std::env::var("KHIVE_CHECKOUT_TIMEOUT_SECS").ok());
-        std::env::set_var("KHIVE_CHECKOUT_TIMEOUT_SECS", "120");
+        let prior_timeout = std::env::var("KHIVE_CHECKOUT_TIMEOUT_SECS").ok();
+        let _restore = RestoreTimeout(prior_timeout.clone());
+        // #705: an instrumented coverage run (cargo llvm-cov --workspace) runs
+        // this test's binary alongside every other workspace test binary, and
+        // instrumentation overhead widens the contention window this test's
+        // 120s floor was sized for on a plain (uninstrumented) run. Rather than
+        // unconditionally clobbering down to "120" — which would silently
+        // discard a larger value the coverage job set specifically for this
+        // path — take the max of the ambient value (if any) and the 120s
+        // floor, so a caller can raise it further without this test undoing
+        // that raise.
+        let effective_timeout = prior_timeout
+            .as_deref()
+            .and_then(|v| v.parse::<u64>().ok())
+            .map(|ambient| ambient.max(120))
+            .unwrap_or(120);
+        std::env::set_var("KHIVE_CHECKOUT_TIMEOUT_SECS", effective_timeout.to_string());
 
         let (_tmp, db_path) = tmp_db();
         let rt = make_rt(&db_path).await;

--- a/crates/khive-mcp/src/server.rs
+++ b/crates/khive-mcp/src/server.rs
@@ -11,8 +11,9 @@
 // as a unit. The module is the authoritative implementation of request
 // dispatch and is intentionally co-located.
 
-use std::sync::Arc;
+use std::{future::Future, sync::Arc};
 
+use futures::{stream::FuturesUnordered, StreamExt};
 use rmcp::{
     handler::server::wrapper::Parameters,
     model::{Implementation, ServerCapabilities, ServerInfo},
@@ -33,6 +34,31 @@ use khive_storage::EdgeRelation;
 
 use crate::coordinator::CoordinatorService;
 use crate::tools::request::RequestParams;
+
+/// Per-request parallelism stays bounded even when the parser accepts 100 ops; must be nonzero.
+const MAX_BATCH_CONCURRENCY: usize = 8;
+
+/// Half the frame remains for the daemon's outer serialization and budget-error entries.
+const BATCH_RESPONSE_BUDGET_BYTES: usize = khive_runtime::daemon::MAX_FRAME_BYTES / 2;
+
+struct BatchTask<F> {
+    index: usize,
+    tool: String,
+    future: F,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub(crate) enum DispatchOrigin {
+    Local,
+    Daemon,
+}
+
+#[derive(Clone, Copy)]
+struct RunParsedContext<'a> {
+    enforce_response_budget: bool,
+    from_wire: bool,
+    identity: Option<&'a khive_runtime::RequestIdentity>,
+}
 
 /// Fingerprint the engine-coherence parts of a resolved [`RuntimeConfig`].
 ///
@@ -786,8 +812,8 @@ impl KhiveMcpServer {
 
     /// Execute a parsed request, dispatching according to its [`ExecutionMode`].
     ///
-    /// - `Single` / `Parallel`: all ops run concurrently; per-op failure does
-    ///   not abort siblings. `aborted` count is always 0.
+    /// - `Single` / `Parallel`: at most [`MAX_BATCH_CONCURRENCY`] ops run at
+    ///   once; per-op failure does not abort siblings. `aborted` count is 0.
     /// - `Chain`: ops run sequentially; `$prev` from each op's result is
     ///   substituted into the next op's args. If any op fails (or a `$prev`
     ///   substitution fails), remaining ops appear as `aborted: true`.
@@ -818,9 +844,18 @@ impl KhiveMcpServer {
         mode: ExecutionMode,
         presentation: PresentationMode,
         presentation_per_op: Option<Vec<Option<PresentationMode>>>,
-        from_wire: bool,
-        identity: Option<&khive_runtime::RequestIdentity>,
+        context: RunParsedContext<'_>,
     ) -> Value {
+        let RunParsedContext {
+            enforce_response_budget,
+            from_wire,
+            identity,
+        } = context;
+        let response_budget = if mode == ExecutionMode::Parallel && enforce_response_budget {
+            BATCH_RESPONSE_BUDGET_BYTES
+        } else {
+            usize::MAX
+        };
         let now_unix = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
             .ok()
@@ -869,7 +904,7 @@ impl KhiveMcpServer {
                 // dispatch below, so the two can't drift out of sync per op.
                 let identity_owned: Option<khive_runtime::RequestIdentity> = identity.cloned();
 
-                // Independent dispatch — run all concurrently, results in input order.
+                // Independent dispatch — bounded concurrency, results restored to input order.
                 let futures = ops.into_iter().enumerate().map(|(i, op)| {
                     let conflict_with: Option<String> = if conflict_indices.contains(&i) {
                         Some(format!(
@@ -888,7 +923,11 @@ impl KhiveMcpServer {
                         .unwrap_or_else(|| default_namespace.clone());
                     let op_identity = identity_owned.clone();
                     let op_mode = mode_for_op(i);
-                    async move {
+                    let task_tool = op.tool.clone();
+                    BatchTask {
+                        index: i,
+                        tool: task_tool,
+                        future: async move {
                         // ADR-103 Amendment 2: one dispatch-accounting context
                         // per op; the entry is stamped with the frozen usage
                         // snapshot after dispatch resolves.
@@ -1005,20 +1044,11 @@ impl KhiveMcpServer {
                         .await;
                         stamp_usage(&mut entry, &usage_ctx);
                         entry
+                        },
                     }
                 });
-                let results: Vec<Value> = futures::future::join_all(futures).await;
-                let total = results.len();
-                let succeeded = results
-                    .iter()
-                    .filter(|r| r.get("ok").and_then(Value::as_bool) == Some(true))
-                    .count();
-                let failed = total - succeeded;
-                json!({
-                    "results": results,
-                    "summary": { "total": total, "succeeded": succeeded, "failed": failed, "aborted": 0 },
-                    "status": batch_status(failed, 0),
-                })
+                let results = execute_bounded_batch(futures, response_budget).await;
+                parallel_batch_envelope(results)
             }
             ExecutionMode::Chain => {
                 // Sequential execution with $prev substitution and abort-on-failure.
@@ -1663,6 +1693,83 @@ fn batch_status(failed: usize, aborted: usize) -> &'static str {
     }
 }
 
+fn batch_budget_error(tool: &str, response_budget: usize) -> Value {
+    json!({
+        "ok": false,
+        "tool": tool,
+        "error": format!(
+            "batch response budget of {response_budget} serialized bytes exceeded"
+        ),
+    })
+}
+
+async fn execute_bounded_batch<I, F>(tasks: I, response_budget: usize) -> Vec<Value>
+where
+    I: IntoIterator<Item = BatchTask<F>>,
+    F: Future<Output = Value>,
+{
+    let mut queued: std::collections::VecDeque<_> = tasks.into_iter().collect();
+    let total = queued.len();
+    let mut in_flight = FuturesUnordered::new();
+    let start = |task: BatchTask<F>| async move {
+        let entry = task.future.await;
+        (task.index, task.tool, entry)
+    };
+    for _ in 0..MAX_BATCH_CONCURRENCY {
+        if let Some(task) = queued.pop_front() {
+            in_flight.push(start(task));
+        }
+    }
+
+    let mut results: Vec<Option<Value>> = (0..total).map(|_| None).collect();
+    let mut accumulated_bytes = 0usize;
+    let mut budget_breached = false;
+
+    while let Some((index, _tool, entry)) = in_flight.next().await {
+        if budget_breached {
+            results[index] = Some(entry);
+            continue;
+        }
+        let serialized_bytes = serde_json::to_vec(&entry)
+            .expect("serde_json::Value is always serializable")
+            .len();
+        if serialized_bytes > response_budget.saturating_sub(accumulated_bytes) {
+            results[index] = Some(entry);
+            budget_breached = true;
+            continue;
+        }
+
+        accumulated_bytes += serialized_bytes;
+        results[index] = Some(entry);
+        if let Some(task) = queued.pop_front() {
+            in_flight.push(start(task));
+        }
+    }
+
+    for task in queued {
+        results[task.index] = Some(batch_budget_error(&task.tool, response_budget));
+    }
+
+    results
+        .into_iter()
+        .map(|entry| entry.expect("every started or queued batch task has a result"))
+        .collect()
+}
+
+fn parallel_batch_envelope(results: Vec<Value>) -> Value {
+    let total = results.len();
+    let succeeded = results
+        .iter()
+        .filter(|result| result.get("ok").and_then(Value::as_bool) == Some(true))
+        .count();
+    let failed = total - succeeded;
+    json!({
+        "results": results,
+        "summary": { "total": total, "succeeded": succeeded, "failed": failed, "aborted": 0 },
+        "status": batch_status(failed, 0),
+    })
+}
+
 /// Extract the fallback-reason string from a strict-mode rejection's
 /// [`McpError`] (#947), or `None` if `e` is not tagged with
 /// [`crate::daemon::STRICT_FALLBACK_MARKER`] — i.e. some other daemon-forward
@@ -1786,14 +1893,16 @@ impl KhiveMcpServer {
     /// may still synthesize an identity carrying those same baked scalars if
     /// `p.request_id` is set, purely so the audit row is correlatable.
     pub async fn dispatch_request_local(&self, p: RequestParams) -> Result<String, McpError> {
-        self.dispatch_request_inner(p, false, None).await
+        self.dispatch_request_inner(p, false, None, DispatchOrigin::Local)
+            .await
     }
 
     /// Wire-surface dispatch: same as [`Self::dispatch_request_local`] but
     /// enforces verb visibility (`Visibility::Subhandler` verbs are rejected).
     /// Used by the stdio `request` tool's local-fallback path.
     pub(crate) async fn dispatch_request_wire(&self, p: RequestParams) -> Result<String, McpError> {
-        self.dispatch_request_inner(p, true, None).await
+        self.dispatch_request_inner(p, true, None, DispatchOrigin::Local)
+            .await
     }
 
     /// Shared body for both dispatch surfaces. `from_wire` decides whether the
@@ -1803,6 +1912,8 @@ impl KhiveMcpServer {
     /// frame (ADR-096 Fork 1, see `crate::daemon`'s `DaemonDispatch` impl).
     /// `None` for every local (non-daemon-served) call — this server's own
     /// baked identity applies, exactly as before this parameter existed.
+    /// `origin` independently controls daemon-frame response fitting; wire
+    /// visibility does not imply that the response travels through the daemon.
     ///
     /// khive#948: when `identity` is `None` (every local-dispatch call —
     /// `KHIVE_NO_DAEMON`/soft daemon-fallback and the `save_to` bypass both
@@ -1819,6 +1930,7 @@ impl KhiveMcpServer {
         p: RequestParams,
         from_wire: bool,
         identity: Option<khive_runtime::RequestIdentity>,
+        origin: DispatchOrigin,
     ) -> Result<String, McpError> {
         let save_to = p.save_to.clone();
         let identity = identity.or_else(|| {
@@ -1890,8 +2002,11 @@ impl KhiveMcpServer {
                 parsed.mode,
                 presentation,
                 presentation_per_op.clone(),
-                from_wire,
-                identity.as_ref(),
+                RunParsedContext {
+                    enforce_response_budget: save_to.is_none(),
+                    from_wire,
+                    identity: identity.as_ref(),
+                },
             )
             .await;
 
@@ -1917,6 +2032,7 @@ impl KhiveMcpServer {
             presentation,
             &presentation_per_op,
             &self.registry,
+            (origin == DispatchOrigin::Daemon).then_some(self.config_id.as_str()),
         ))
     }
 }
@@ -1967,8 +2083,11 @@ fn parse_output_format(s: Option<&str>) -> Result<Option<OutputFormat>, String> 
 ///   pre-pass (ADR-078 §7 + §8.4; mirrors `run_parsed`).
 ///
 /// The outer envelope (`{results:[...], summary:{...}}`) is always compact JSON (§8.4).
-/// When the result value is not a compound batch envelope (single-op fast path),
-/// the whole value is rendered with `batch_format` and `presentation`.
+/// Daemon-served responses are rendered before fitting. If the rendered envelope
+/// exceeds the frame allowance, entries fall back to compact JSON before payload
+/// details are omitted. Local dispatch has no daemon-frame allowance and returns
+/// the requested representation without fitting. Every daemon fit decision
+/// serializes the actual response-frame shape so JSON string escaping is included.
 fn render_result(
     value: serde_json::Value,
     batch_format: OutputFormat,
@@ -1976,83 +2095,240 @@ fn render_result(
     presentation: PresentationMode,
     presentation_per_op: &Option<Vec<Option<PresentationMode>>>,
     registry: &VerbRegistry,
+    daemon_frame_config_id: Option<&str>,
 ) -> String {
-    // Fast path: if format is json and no per-op overrides, compact-serialize and return.
-    if batch_format == OutputFormat::Json && format_per_op.is_none() {
-        return serde_json::to_string(&value).unwrap_or_else(|_| "null".to_string());
-    }
-
     // Try to detect the compound batch envelope shape: { results: [...], summary: {...} }
     if let serde_json::Value::Object(ref map) = value {
         if let Some(serde_json::Value::Array(results)) = map.get("results") {
-            let mut out_results = Vec::with_capacity(results.len());
-            for (i, entry) in results.iter().enumerate() {
-                let per_op_fmt = format_per_op
-                    .as_ref()
-                    .and_then(|v| v.get(i))
-                    .and_then(|x| *x)
-                    .unwrap_or(batch_format);
-
-                // Resolve per-op presentation: per-op entry overrides batch default,
-                // then the AlwaysVerbose verb policy forces Verbose — mirroring the
-                // resolution `run_parsed` applies before presentation. Without this,
-                // a policy-verbose verb (get/link/query/traverse/neighbors/
-                // brain.feedback) dispatched under format=auto/table with the default
-                // Agent presentation would be redundancy-dropped at the format seam,
-                // stripping the namespace/properties it is declared AlwaysVerbose
-                // precisely to preserve.
-                let base_presentation = presentation_per_op
-                    .as_ref()
-                    .and_then(|v| v.get(i))
-                    .and_then(|o| *o)
-                    .unwrap_or(presentation);
-                let effective_presentation =
-                    match entry.get("tool").and_then(serde_json::Value::as_str) {
-                        Some(tool)
-                            if registry.presentation_policy_for(tool)
-                                == VerbPresentationPolicy::AlwaysVerbose =>
-                        {
-                            PresentationMode::Verbose
-                        }
-                        _ => base_presentation,
-                    };
-
-                // Error entries are never reformatted (§8.2).
-                let is_ok = entry
-                    .get("ok")
-                    .and_then(serde_json::Value::as_bool)
-                    .unwrap_or(false);
-                if !is_ok || per_op_fmt == OutputFormat::Json {
-                    out_results.push(entry.clone());
-                    continue;
+            let out_results = results
+                .iter()
+                .enumerate()
+                .map(|(index, entry)| {
+                    render_batch_entry(
+                        index,
+                        entry,
+                        batch_format,
+                        format_per_op,
+                        presentation,
+                        presentation_per_op,
+                        registry,
+                    )
+                })
+                .collect();
+            let out_map = match daemon_frame_config_id {
+                Some(config_id) => {
+                    fit_rendered_batch_envelope(map, results, out_results, config_id)
                 }
-
-                // For successful entries, render the `result` sub-value with the
-                // effective presentation so verbose ops skip the redundancy drop.
-                if let Some(result_val) = entry.get("result") {
-                    let rendered =
-                        render_format(result_val.clone(), per_op_fmt, effective_presentation);
-                    // Replace `result` with the rendered string.
-                    let mut new_entry = entry.clone();
-                    if let serde_json::Value::Object(ref mut emap) = new_entry {
-                        emap.insert("result".to_string(), serde_json::Value::String(rendered));
-                    }
-                    out_results.push(new_entry);
-                } else {
-                    out_results.push(entry.clone());
+                None => {
+                    let mut out_map = map.clone();
+                    out_map.insert("results".to_string(), Value::Array(out_results));
+                    out_map
                 }
-            }
-
-            // Rebuild envelope: results rendered per-op, summary always compact.
-            let mut out_map = map.clone();
-            out_map.insert("results".to_string(), serde_json::Value::Array(out_results));
-            return serde_json::to_string(&serde_json::Value::Object(out_map))
-                .unwrap_or_else(|_| "null".to_string());
+            };
+            return serialize_response_value(&serde_json::Value::Object(out_map));
         }
     }
 
-    // Single-op or unknown shape: render the whole value with batch_format and presentation.
-    render_format(value, batch_format, presentation)
+    let rendered = render_format(value.clone(), batch_format, presentation);
+    let Some(config_id) = daemon_frame_config_id else {
+        return rendered;
+    };
+    if rendered_response_fits_daemon_frame(&rendered, config_id) {
+        return rendered;
+    }
+    let compact = serialize_response_value(&value);
+    if rendered_response_fits_daemon_frame(&compact, config_id) {
+        return compact;
+    }
+    serde_json::to_string(&json!({
+        "ok": false,
+        "error": "response payload omitted because it exceeds the daemon frame budget",
+    }))
+    .expect("static frame-budget error is serializable")
+}
+
+fn render_batch_entry(
+    index: usize,
+    entry: &Value,
+    batch_format: OutputFormat,
+    format_per_op: &Option<Vec<Option<OutputFormat>>>,
+    presentation: PresentationMode,
+    presentation_per_op: &Option<Vec<Option<PresentationMode>>>,
+    registry: &VerbRegistry,
+) -> Value {
+    let per_op_format = format_per_op
+        .as_ref()
+        .and_then(|formats| formats.get(index))
+        .and_then(|format| *format)
+        .unwrap_or(batch_format);
+    let is_ok = entry.get("ok").and_then(Value::as_bool).unwrap_or(false);
+    if !is_ok || per_op_format == OutputFormat::Json {
+        return entry.clone();
+    }
+
+    let base_presentation = presentation_per_op
+        .as_ref()
+        .and_then(|modes| modes.get(index))
+        .and_then(|mode| *mode)
+        .unwrap_or(presentation);
+    let effective_presentation = match entry.get("tool").and_then(Value::as_str) {
+        Some(tool)
+            if registry.presentation_policy_for(tool) == VerbPresentationPolicy::AlwaysVerbose =>
+        {
+            PresentationMode::Verbose
+        }
+        _ => base_presentation,
+    };
+    let Some(result) = entry.get("result") else {
+        return entry.clone();
+    };
+    let mut rendered_entry = entry.clone();
+    if let Value::Object(ref mut fields) = rendered_entry {
+        fields.insert(
+            "result".to_string(),
+            Value::String(render_format(
+                result.clone(),
+                per_op_format,
+                effective_presentation,
+            )),
+        );
+    }
+    rendered_entry
+}
+
+fn fit_rendered_batch_envelope(
+    map: &serde_json::Map<String, Value>,
+    compact_results: &[Value],
+    mut out_results: Vec<Value>,
+    served_config_id: &str,
+) -> serde_json::Map<String, Value> {
+    let mut out_map = map.clone();
+    out_map.insert(
+        "results".to_string(),
+        serde_json::Value::Array(out_results.clone()),
+    );
+    if response_value_fits_daemon_frame(
+        &serde_json::Value::Object(out_map.clone()),
+        served_config_id,
+    ) {
+        return out_map;
+    }
+
+    let rendered_frame_bytes = response_value_daemon_frame_len(
+        &serde_json::Value::Object(out_map.clone()),
+        served_config_id,
+    );
+    let mut compact_fallbacks: Vec<(usize, usize)> = compact_results
+        .iter()
+        .zip(&out_results)
+        .enumerate()
+        .filter_map(|(index, (compact, rendered))| {
+            if compact == rendered {
+                return None;
+            }
+            let mut candidate_results = out_results.clone();
+            candidate_results[index] = compact.clone();
+            let mut candidate_map = out_map.clone();
+            candidate_map.insert("results".to_string(), Value::Array(candidate_results));
+            let compact_frame_bytes =
+                response_value_daemon_frame_len(&Value::Object(candidate_map), served_config_id);
+            (compact_frame_bytes < rendered_frame_bytes)
+                .then_some((index, rendered_frame_bytes - compact_frame_bytes))
+        })
+        .collect();
+    compact_fallbacks.sort_unstable_by_key(|&(_, saved_bytes)| std::cmp::Reverse(saved_bytes));
+    for (index, _) in compact_fallbacks {
+        out_results[index] = compact_results[index].clone();
+        out_map.insert("results".to_string(), Value::Array(out_results.clone()));
+        if response_value_fits_daemon_frame(&Value::Object(out_map.clone()), served_config_id) {
+            return out_map;
+        }
+    }
+
+    let mut by_size: Vec<(usize, usize)> = out_results
+        .iter()
+        .enumerate()
+        .map(|(index, entry)| (index, serialized_response_len(entry)))
+        .collect();
+    by_size.sort_unstable_by_key(|&(_, bytes)| std::cmp::Reverse(bytes));
+    for (index, _) in by_size {
+        out_results[index] = frame_budget_omission(&compact_results[index]);
+        out_map.insert(
+            "results".to_string(),
+            serde_json::Value::Array(out_results.clone()),
+        );
+        if response_value_fits_daemon_frame(
+            &serde_json::Value::Object(out_map.clone()),
+            served_config_id,
+        ) {
+            break;
+        }
+    }
+    out_map
+}
+
+fn frame_budget_omission(entry: &Value) -> Value {
+    let ok = entry.get("ok").and_then(Value::as_bool).unwrap_or(false);
+    let mut omitted = serde_json::Map::new();
+    for key in ["ok", "tool", "usage", "aborted"] {
+        if let Some(value) = entry.get(key) {
+            omitted.insert(key.to_string(), value.clone());
+        }
+    }
+    if ok {
+        omitted.insert(
+            "result_omitted".to_string(),
+            json!("operation succeeded; result omitted because the response frame budget was exceeded"),
+        );
+    } else {
+        omitted.insert(
+            "error".to_string(),
+            json!("operation failed; error details omitted because the response frame budget was exceeded"),
+        );
+    }
+    Value::Object(omitted)
+}
+
+fn serialized_response_len(value: &Value) -> usize {
+    serde_json::to_vec(value)
+        .expect("serde_json::Value is always serializable")
+        .len()
+}
+
+fn serialize_response_value(value: &Value) -> String {
+    serde_json::to_string(value).expect("serde_json::Value is always serializable")
+}
+
+fn response_value_fits_daemon_frame(value: &Value, served_config_id: &str) -> bool {
+    response_value_daemon_frame_len(value, served_config_id)
+        <= khive_runtime::daemon::MAX_FRAME_BYTES
+}
+
+fn response_value_daemon_frame_len(value: &Value, served_config_id: &str) -> usize {
+    rendered_response_daemon_frame_len(&serialize_response_value(value), served_config_id)
+}
+
+fn rendered_response_fits_daemon_frame(rendered: &str, served_config_id: &str) -> bool {
+    rendered_response_daemon_frame_len(rendered, served_config_id)
+        <= khive_runtime::daemon::MAX_FRAME_BYTES
+}
+
+fn rendered_response_daemon_frame_len(rendered: &str, served_config_id: &str) -> usize {
+    let frame = khive_runtime::DaemonResponseFrame {
+        ok: true,
+        result: Some(rendered.to_string()),
+        error: None,
+        namespace_mismatch: false,
+        config_mismatch: false,
+        served_config_id: Some(served_config_id.to_string()),
+        version_mismatch: false,
+        daemon_protocol_version: khive_runtime::PROTOCOL_VERSION,
+        metrics: None,
+        request_id: Some(u64::MAX),
+    };
+    serde_json::to_vec(&frame)
+        .expect("daemon response frame is always serializable")
+        .len()
 }
 
 /// Build the `initialize` instructions string from the verb catalog and the
@@ -2120,6 +2396,448 @@ mod tests {
     use khive_runtime::Namespace;
     use khive_storage::{EventFilter, PageRequest};
     use serial_test::serial;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::time::Duration;
+
+    async fn observed_batch_entry(
+        _index: usize,
+        delay_ms: u64,
+        entry: Value,
+        in_flight: Arc<AtomicUsize>,
+        max_in_flight: Arc<AtomicUsize>,
+    ) -> Value {
+        let current = in_flight.fetch_add(1, Ordering::SeqCst) + 1;
+        max_in_flight.fetch_max(current, Ordering::SeqCst);
+        tokio::time::sleep(Duration::from_millis(delay_ms)).await;
+        in_flight.fetch_sub(1, Ordering::SeqCst);
+        entry
+    }
+
+    fn batch_task<F>(index: usize, future: F) -> BatchTask<F>
+    where
+        F: Future<Output = Value>,
+    {
+        BatchTask {
+            index,
+            tool: "probe".to_string(),
+            future,
+        }
+    }
+
+    struct LargeResultPack;
+
+    impl khive_types::Pack for LargeResultPack {
+        const NAME: &'static str = "large-result-test";
+        const NOTE_KINDS: &'static [&'static str] = &[];
+        const ENTITY_KINDS: &'static [&'static str] = &[];
+        const HANDLERS: &'static [khive_runtime::HandlerDef] = &[khive_runtime::HandlerDef {
+            name: "large_result",
+            description: "returns a caller-sized test result",
+            visibility: khive_runtime::Visibility::Verb,
+            category: khive_runtime::VerbCategory::Assertive,
+            params: &[],
+        }];
+    }
+
+    #[async_trait::async_trait]
+    impl khive_runtime::PackRuntime for LargeResultPack {
+        fn name(&self) -> &str {
+            <Self as khive_types::Pack>::NAME
+        }
+
+        fn note_kinds(&self) -> &'static [&'static str] {
+            <Self as khive_types::Pack>::NOTE_KINDS
+        }
+
+        fn entity_kinds(&self) -> &'static [&'static str] {
+            <Self as khive_types::Pack>::ENTITY_KINDS
+        }
+
+        fn handlers(&self) -> &'static [khive_runtime::HandlerDef] {
+            <Self as khive_types::Pack>::HANDLERS
+        }
+
+        async fn dispatch(
+            &self,
+            _verb: &str,
+            params: Value,
+            _registry: &VerbRegistry,
+            _token: &khive_runtime::NamespaceToken,
+        ) -> Result<Value, RuntimeError> {
+            if let Some(bytes) = params
+                .get("table_bytes")
+                .and_then(Value::as_u64)
+                .and_then(|n| usize::try_from(n).ok())
+            {
+                let payload = "x".repeat(bytes);
+                return Ok(json!([
+                    {"payload": payload},
+                    {"payload": payload},
+                ]));
+            }
+            let bytes = params
+                .get("bytes")
+                .and_then(Value::as_u64)
+                .and_then(|n| usize::try_from(n).ok())
+                .expect("test supplies a valid byte count");
+            Ok(json!("x".repeat(bytes)))
+        }
+    }
+
+    async fn dispatch_large_result_through_daemon(
+        server: &KhiveMcpServer,
+        ops: String,
+        format: Option<String>,
+    ) -> String {
+        khive_runtime::daemon::DaemonDispatch::dispatch(
+            server, ops, None, None, format, None, false, None,
+        )
+        .await
+        .expect("daemon dispatch")
+    }
+
+    fn large_result_test_server() -> KhiveMcpServer {
+        let mut builder = VerbRegistryBuilder::new();
+        builder.register(LargeResultPack);
+        KhiveMcpServer::from_registry(builder.build().expect("test registry"))
+    }
+
+    #[tokio::test]
+    async fn bounded_batch_preserves_input_order() {
+        let count = MAX_BATCH_CONCURRENCY + 3;
+        let in_flight = Arc::new(AtomicUsize::new(0));
+        let max_in_flight = Arc::new(AtomicUsize::new(0));
+        let futures = (0..count).map(|index| {
+            batch_task(
+                index,
+                observed_batch_entry(
+                    index,
+                    (count - index) as u64,
+                    json!({"ok": true, "tool": "probe", "result": {"index": index}}),
+                    in_flight.clone(),
+                    max_in_flight.clone(),
+                ),
+            )
+        });
+
+        let results = execute_bounded_batch(futures, usize::MAX).await;
+
+        let indices: Vec<u64> = results
+            .iter()
+            .map(|entry| entry["result"]["index"].as_u64().expect("result index"))
+            .collect();
+        assert_eq!(indices, (0..count as u64).collect::<Vec<_>>());
+    }
+
+    #[tokio::test]
+    async fn bounded_batch_enforces_aggregate_response_budget() {
+        assert_eq!(
+            BATCH_RESPONSE_BUDGET_BYTES,
+            khive_runtime::daemon::MAX_FRAME_BYTES / 2
+        );
+        let count = MAX_BATCH_CONCURRENCY * 2;
+        let budget = BATCH_RESPONSE_BUDGET_BYTES;
+        let small = json!({
+            "ok": true,
+            "tool": "probe",
+            "result": "x".repeat(budget / 4 - 128),
+        });
+        let in_flight = Arc::new(AtomicUsize::new(0));
+        let max_in_flight = Arc::new(AtomicUsize::new(0));
+        let futures = (0..count).map(|index| {
+            let (delay_ms, entry) = if index < 2 {
+                (index as u64, small.clone())
+            } else if index == 2 {
+                (
+                    30,
+                    json!({"ok": true, "tool": "probe", "result": "x".repeat(budget)}),
+                )
+            } else {
+                (
+                    60,
+                    json!({"ok": true, "tool": "probe", "result": {"index": index}}),
+                )
+            };
+            batch_task(
+                index,
+                observed_batch_entry(
+                    index,
+                    delay_ms,
+                    entry,
+                    in_flight.clone(),
+                    max_in_flight.clone(),
+                ),
+            )
+        });
+
+        let results = tokio::time::timeout(
+            Duration::from_secs(1),
+            execute_bounded_batch(futures, budget),
+        )
+        .await
+        .expect("started operations must settle promptly after a budget breach");
+        let response = parallel_batch_envelope(results);
+
+        assert_eq!(
+            response["summary"],
+            json!({"total": count, "succeeded": 10, "failed": count - 10, "aborted": 0})
+        );
+        assert_eq!(response["results"][0]["ok"], true);
+        assert_eq!(response["results"][1]["ok"], true);
+        assert_eq!(
+            response["results"][2]["result"]
+                .as_str()
+                .expect("breaching result remains truthful")
+                .len(),
+            budget
+        );
+        for index in 3..10 {
+            assert_eq!(response["results"][index]["ok"], true);
+            assert_eq!(response["results"][index]["result"]["index"], index);
+        }
+        for entry in response["results"]
+            .as_array()
+            .expect("results")
+            .iter()
+            .skip(10)
+        {
+            assert_eq!(entry["ok"], false);
+            let error = entry["error"].as_str().expect("budget error string");
+            assert!(error.contains("batch response budget"));
+            assert!(error.contains(&budget.to_string()));
+        }
+        assert_eq!(in_flight.load(Ordering::SeqCst), 0);
+        serde_json::to_vec(&response).expect("budgeted response must serialize");
+    }
+
+    #[tokio::test]
+    async fn save_to_writes_full_results_without_inline_response_budgeting() {
+        let server = large_result_test_server();
+        let dir = tempfile::tempdir().expect("tempdir");
+        let sink_path = dir.path().join("full-results.jsonl");
+        let result_bytes = BATCH_RESPONSE_BUDGET_BYTES * 3 / 4;
+        let response = server
+            .dispatch_request_inner(
+                RequestParams {
+                    ops: format!(
+                        "[large_result(bytes={result_bytes}), large_result(bytes={result_bytes})]"
+                    ),
+                    presentation: None,
+                    presentation_per_op: None,
+                    save_to: Some(sink_path.to_string_lossy().into_owned()),
+                    format: None,
+                    format_per_op: None,
+                    request_id: None,
+                },
+                false,
+                None,
+                DispatchOrigin::Local,
+            )
+            .await
+            .expect("save_to dispatch");
+
+        let manifest: Value = serde_json::from_str(&response).expect("manifest JSON");
+        assert_eq!(manifest["rows"], 2);
+        assert_eq!(manifest["summary"]["succeeded"], 2);
+        let rows: Vec<Value> = std::fs::read_to_string(&sink_path)
+            .expect("read JSONL")
+            .lines()
+            .map(|line| serde_json::from_str(line).expect("valid JSONL row"))
+            .collect();
+        assert_eq!(rows.len(), 2);
+        for row in rows {
+            assert_eq!(row["ok"], true);
+            assert_eq!(
+                row["result"].as_str().expect("full result string").len(),
+                result_bytes
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn local_dispatch_returns_result_larger_than_daemon_frame() {
+        let server = large_result_test_server();
+        let result_bytes = khive_runtime::daemon::MAX_FRAME_BYTES + 1_024;
+        let response = server
+            .dispatch_request_local(RequestParams {
+                ops: format!("large_result(bytes={result_bytes})"),
+                presentation: None,
+                presentation_per_op: None,
+                save_to: None,
+                format: None,
+                format_per_op: None,
+                request_id: None,
+            })
+            .await
+            .expect("local dispatch");
+
+        let envelope: Value = serde_json::from_str(&response).expect("response envelope");
+        assert_eq!(envelope["results"][0]["ok"], true);
+        assert_eq!(
+            envelope["results"][0]["result"]
+                .as_str()
+                .expect("full local result")
+                .len(),
+            result_bytes
+        );
+        assert!(envelope["results"][0].get("result_omitted").is_none());
+    }
+
+    #[tokio::test]
+    async fn daemon_dispatch_degrades_result_larger_than_frame() {
+        let server = large_result_test_server();
+        let result_bytes = khive_runtime::daemon::MAX_FRAME_BYTES + 1_024;
+        let response = dispatch_large_result_through_daemon(
+            &server,
+            format!("large_result(bytes={result_bytes})"),
+            None,
+        )
+        .await;
+
+        let envelope: Value = serde_json::from_str(&response).expect("response envelope");
+        assert_eq!(envelope["results"][0]["ok"], true);
+        assert!(envelope["results"][0].get("result").is_none());
+        assert!(envelope["results"][0].get("result_omitted").is_some());
+        assert!(rendered_response_fits_daemon_frame(
+            &response,
+            &server.config_id
+        ));
+    }
+
+    #[tokio::test]
+    async fn daemon_batch_keeps_rendered_result_when_compact_result_exceeds_frame() {
+        let server = large_result_test_server();
+        let row_bytes = khive_runtime::daemon::MAX_FRAME_BYTES / 2;
+        let response = dispatch_large_result_through_daemon(
+            &server,
+            format!("large_result(table_bytes={row_bytes})"),
+            Some("auto".to_string()),
+        )
+        .await;
+
+        let envelope: Value = serde_json::from_str(&response).expect("response envelope");
+        let entry = &envelope["results"][0];
+        assert_eq!(entry["ok"], true);
+        assert!(entry.get("result_omitted").is_none());
+        let rendered = entry["result"].as_str().expect("rendered table result");
+        assert!(rendered.starts_with("| payload |"));
+        assert!(rendered.len() < row_bytes);
+        assert!(rendered_response_fits_daemon_frame(
+            &response,
+            &server.config_id
+        ));
+    }
+
+    #[test]
+    fn auto_rendered_batch_stays_within_daemon_frame_cap() {
+        let mut leaves = serde_json::Map::new();
+        for index in 0..80_000 {
+            leaves.insert(format!("k{index}"), json!(0));
+        }
+        let result = nest_object(60, Value::Object(leaves));
+        let envelope = parallel_batch_envelope(vec![json!({
+            "ok": true,
+            "tool": "probe",
+            "result": result,
+        })]);
+        let compact_bytes = serde_json::to_vec(&envelope)
+            .expect("compact envelope")
+            .len();
+        assert!(compact_bytes < BATCH_RESPONSE_BUDGET_BYTES);
+
+        let rendered = render_result(
+            envelope,
+            OutputFormat::Auto,
+            &None,
+            PresentationMode::Agent,
+            &None,
+            &large_result_test_server().registry,
+            Some("test"),
+        );
+        let rendered_value: Value = serde_json::from_str(&rendered).expect("response envelope");
+        assert_eq!(rendered_value["status"], "success");
+        assert_eq!(rendered_value["results"][0]["ok"], true);
+        assert!(
+            rendered_value["results"][0]["result"].is_object(),
+            "oversized auto output must fall back to the truthful compact result"
+        );
+        let frame = khive_runtime::DaemonResponseFrame {
+            ok: true,
+            result: Some(rendered),
+            error: None,
+            namespace_mismatch: false,
+            config_mismatch: false,
+            served_config_id: Some("test".to_string()),
+            version_mismatch: false,
+            daemon_protocol_version: khive_runtime::PROTOCOL_VERSION,
+            metrics: None,
+            request_id: None,
+        };
+        let frame_bytes = serde_json::to_vec(&frame).expect("daemon frame").len();
+        assert!(
+            frame_bytes <= khive_runtime::daemon::MAX_FRAME_BYTES,
+            "rendered daemon frame was {frame_bytes} bytes"
+        );
+    }
+
+    #[tokio::test]
+    async fn bounded_batch_op_error_does_not_abort_siblings() {
+        let count = 5;
+        let in_flight = Arc::new(AtomicUsize::new(0));
+        let max_in_flight = Arc::new(AtomicUsize::new(0));
+        let futures = (0..count).map(|index| {
+            let entry = if index == 2 {
+                json!({"ok": false, "tool": "probe", "error": "expected failure"})
+            } else {
+                json!({"ok": true, "tool": "probe", "result": {"index": index}})
+            };
+            batch_task(
+                index,
+                observed_batch_entry(
+                    index,
+                    (count - index) as u64,
+                    entry,
+                    in_flight.clone(),
+                    max_in_flight.clone(),
+                ),
+            )
+        });
+
+        let response = parallel_batch_envelope(execute_bounded_batch(futures, usize::MAX).await);
+
+        assert_eq!(
+            response["summary"],
+            json!({"total": 5, "succeeded": 4, "failed": 1, "aborted": 0})
+        );
+        assert_eq!(response["results"][2]["error"], "expected failure");
+        assert!(response["results"][3]["ok"].as_bool().unwrap_or(false));
+        assert!(response["results"][4]["ok"].as_bool().unwrap_or(false));
+    }
+
+    #[tokio::test]
+    async fn bounded_batch_never_exceeds_concurrency_limit() {
+        let count = MAX_BATCH_CONCURRENCY * 3;
+        let in_flight = Arc::new(AtomicUsize::new(0));
+        let max_in_flight = Arc::new(AtomicUsize::new(0));
+        let futures = (0..count).map(|index| {
+            batch_task(
+                index,
+                observed_batch_entry(
+                    index,
+                    10,
+                    json!({"ok": true, "tool": "probe", "result": index}),
+                    in_flight.clone(),
+                    max_in_flight.clone(),
+                ),
+            )
+        });
+
+        let results = execute_bounded_batch(futures, usize::MAX).await;
+
+        assert_eq!(results.len(), count);
+        assert_eq!(max_in_flight.load(Ordering::SeqCst), MAX_BATCH_CONCURRENCY);
+        assert_eq!(in_flight.load(Ordering::SeqCst), 0);
+    }
 
     fn t(pack: &str, verb: &str, desc: &str) -> (String, String, String) {
         (pack.to_owned(), verb.to_owned(), desc.to_owned())
@@ -2455,8 +3173,11 @@ mod tests {
                 parsed.mode,
                 PresentationMode::Verbose,
                 None,
-                false,
-                None,
+                RunParsedContext {
+                    enforce_response_budget: true,
+                    from_wire: false,
+                    identity: None,
+                },
             )
             .await;
 
@@ -2524,8 +3245,11 @@ mod tests {
                 parsed.mode,
                 PresentationMode::Verbose,
                 None,
-                false,
-                None,
+                RunParsedContext {
+                    enforce_response_budget: true,
+                    from_wire: false,
+                    identity: None,
+                },
             )
             .await;
 

--- a/crates/khive-mcp/src/server.rs
+++ b/crates/khive-mcp/src/server.rs
@@ -22,7 +22,7 @@ use serde_json::{json, Value};
 use sha2::{Digest, Sha256};
 
 use khive_db::ConnectionPool;
-use khive_request::{parse_request, ArgValue, DslError, ExecutionMode, ParsedOp};
+use khive_request::{parse_request, ArgValue, DslError, ExecutionMode, ParsedOp, PrevFailure};
 use khive_runtime::{
     present, render_format, resolve_explicit_namespace, KhiveRuntime, OutputFormat, PackLoadError,
     PackRegistry, PresentationMode, RuntimeConfig, RuntimeError, VerbPresentationPolicy,
@@ -665,39 +665,31 @@ impl KhiveMcpServer {
         for (name, arg_val) in args {
             let needs_prev = !matches!(&arg_val, ArgValue::Value(_));
             let value = if needs_prev {
+                // `dispatch_op` only ever runs inside a chain (see `run_parsed`'s
+                // `ExecutionMode::Chain` arm); `prev_result` is `None` here
+                // exactly when this is the chain's first op, so there is no
+                // preceding result to substitute from at all.
                 let prev = prev_result.ok_or_else(|| {
                     (
                         tool.clone(),
                         json!({
                             "kind": "substitution_error",
+                            "reason": "no_preceding_op",
                             "message": format!(
-                                "argument {name:?}: $prev reference in non-chain context"
+                                "argument {name:?}: $prev has no preceding op to resolve \
+                                 against — this is the first operation in the chain. $prev \
+                                 always resolves against the immediately preceding op's result \
+                                 only; it cannot reach further back or forward. Move this op \
+                                 after the one that produces the value, or pass a literal value \
+                                 here instead of $prev."
                             )
                         }),
                     )
                 })?;
                 let resolved_val = arg_val.resolve_all(prev).ok_or_else(|| {
-                    // Include available top-level fields in the error message,
-                    // matching the UX of the bare-$prev guard.
-                    let fields_hint = if let Value::Object(map) = prev {
-                        let mut fields: Vec<&str> =
-                            map.keys().map(String::as_str).collect();
-                        fields.sort_unstable();
-                        format!(
-                            " Available top-level fields: [{}]",
-                            fields.join(", ")
-                        )
-                    } else {
-                        String::new()
-                    };
                     (
                         tool.clone(),
-                        json!({
-                            "kind": "substitution_error",
-                            "message": format!(
-                                "argument {name:?}: one or more $prev paths not found in prior result.{fields_hint}"
-                            ),
-                        }),
+                        substitution_error_payload(&name, &arg_val, prev),
                     )
                 })?;
                 // UE4-H1: bare `$prev` (no path) resolving to a map or array
@@ -711,6 +703,7 @@ impl KhiveMcpServer {
                                 tool.clone(),
                                 json!({
                                     "kind": "substitution_error",
+                                    "reason": "bare_ref_ambiguous",
                                     "message": format!(
                                         "argument {name:?}: $prev requires a dotted path \
                                          (e.g. $prev.id) when the prior result is a map. \
@@ -725,6 +718,7 @@ impl KhiveMcpServer {
                                 tool.clone(),
                                 json!({
                                     "kind": "substitution_error",
+                                    "reason": "bare_ref_ambiguous",
                                     "message": format!(
                                         "argument {name:?}: $prev requires a dotted path \
                                          (e.g. $prev.0) when the prior result is an array. \
@@ -1037,9 +1031,28 @@ impl KhiveMcpServer {
                 let mut aborted_from: Option<usize> = None;
 
                 for (i, op) in ops.into_iter().enumerate() {
-                    if aborted_from.is_some() {
-                        // A prior op failed — mark remaining as aborted.
-                        results.push(json!({ "ok": false, "tool": op.tool, "aborted": true }));
+                    if let Some(failed_at) = aborted_from {
+                        // A prior op failed — mark remaining as aborted, and say so
+                        // plainly: this op was never dispatched (its own $prev, if any,
+                        // was never attempted), so the failure to debug lives at the
+                        // earlier op, not here.
+                        let failed_index = failed_at - 1;
+                        let failed_tool = results
+                            .get(failed_index)
+                            .and_then(|r| r.get("tool"))
+                            .and_then(Value::as_str)
+                            .unwrap_or("<unknown>");
+                        results.push(json!({
+                            "ok": false,
+                            "tool": op.tool,
+                            "aborted": true,
+                            "message": format!(
+                                "not executed: op #{failed_index} ({failed_tool:?}) failed \
+                                 earlier in this chain, so the chain aborted before reaching \
+                                 this op. Fix op #{failed_index} — this op's own arguments, \
+                                 including any $prev reference, were never evaluated."
+                            ),
+                        }));
                         continue;
                     }
                     let op_mode = mode_for_op(i);
@@ -1397,6 +1410,47 @@ fn drop_value_iteratively(value: Value) {
             _ => {}
         }
     }
+}
+
+/// Builds a `substitution_error` payload for a `$prev` argument that failed
+/// to resolve (`resolve_all` returned `None`). Uses [`ArgValue::find_prev_failure`]
+/// to identify exactly which lookup failed and why — a missing field/index, a
+/// path segment applied to the wrong JSON type, or unsupported bracket syntax
+/// — each worded differently so the caller isn't left with one generic
+/// "not found" for three different mistakes. Falls back to a generic message
+/// only if `find_prev_failure` cannot explain a miss `resolve_all` reported
+/// (defensive; the two are expected to always agree).
+fn substitution_error_payload(name: &str, arg_val: &ArgValue, prev: &Value) -> Value {
+    let Some(failure) = arg_val.find_prev_failure(prev) else {
+        let fields_hint = if let Value::Object(map) = prev {
+            let mut fields: Vec<&str> = map.keys().map(String::as_str).collect();
+            fields.sort_unstable();
+            format!(" Available top-level fields: [{}]", fields.join(", "))
+        } else {
+            String::new()
+        };
+        return json!({
+            "kind": "substitution_error",
+            "reason": "path_not_found",
+            "message": format!(
+                "argument {name:?}: one or more $prev paths not found in prior result.{fields_hint}"
+            ),
+        });
+    };
+    let reason = match &failure {
+        PrevFailure::NotFound { .. } => "path_not_found",
+        PrevFailure::WrongType { .. } => "path_wrong_type",
+        PrevFailure::Unsupported { .. } => "path_unsupported",
+    };
+    json!({
+        "kind": "substitution_error",
+        "reason": reason,
+        "message": format!(
+            "argument {name:?}: {failure}. $prev resolves only against the immediately \
+             preceding op's result — a non-adjacent dependency cannot be expressed inside \
+             one chain; split into separate calls and carry the value across yourself."
+        ),
+    })
 }
 
 /// ADR-103 Amendment 2: stamp the per-op envelope entry with the dispatch's

--- a/crates/khive-mcp/tests/integration.rs
+++ b/crates/khive-mcp/tests/integration.rs
@@ -1850,6 +1850,222 @@ async fn test_h3_prev_nonexistent_field_error_lists_available_fields() -> anyhow
     Ok(())
 }
 
+/// A `$prev` reference in the FIRST op of a chain has no preceding op to
+/// resolve against. This must not reuse the "$prev reference in non-chain
+/// context" wording (misleading — this IS a chain) and must teach the
+/// one-op-back rule instead of failing silently confusing.
+#[tokio::test]
+async fn test_prev_in_first_op_of_chain_names_no_preceding_op() -> anyhow::Result<()> {
+    let client = connect().await?;
+
+    let ops =
+        r#"get(id=$prev.id) | create(kind="entity", entity_kind="concept", name="NeverReached")"#;
+    let result = call(
+        &client,
+        "request",
+        json!({"ops": ops, "presentation": "verbose"}),
+    )
+    .await?;
+    let body: Value = serde_json::from_str(&first_text(&result))?;
+    let results = body["results"].as_array().expect("results array");
+
+    assert_eq!(results.len(), 2, "expected 2 ops");
+    assert_eq!(
+        results[0]["ok"],
+        json!(false),
+        "first op referencing $prev must fail: {}",
+        results[0]
+    );
+    let err = &results[0]["error"];
+    let err_msg = err["message"]
+        .as_str()
+        .unwrap_or_else(|| err.as_str().unwrap_or(""));
+    assert!(
+        err_msg.contains("no preceding op") || err_msg.contains("first operation"),
+        "must name the missing-preceding-op condition, not a generic non-chain message; got: {err_msg}"
+    );
+    assert!(
+        !err_msg.contains("non-chain context"),
+        "stale wording ('non-chain context') must not survive — this op IS in a chain, \
+         it just has nothing before it; got: {err_msg}"
+    );
+    assert!(
+        err_msg.contains("immediately preceding op"),
+        "must teach the one-op-back rule; got: {err_msg}"
+    );
+
+    // Op 1 never runs — chain aborted at op 0 — and its aborted marker must
+    // say plainly that op 0 is the one to fix, not itself.
+    assert_eq!(results[1]["aborted"], json!(true));
+    let aborted_msg = results[1]["message"].as_str().unwrap_or("");
+    assert!(
+        aborted_msg.contains("op #0"),
+        "aborted marker must point at the failed op, not itself; got: {aborted_msg}"
+    );
+
+    Ok(())
+}
+
+/// A path segment that names a field which does exist, but on a value that
+/// is not an object (or an index into something that is not an array), is a
+/// different mistake than "field not found" and must say so — the caller
+/// went looking for a sub-field on a scalar, not a missing name.
+#[tokio::test]
+async fn test_prev_path_wrong_type_names_the_type_mismatch() -> anyhow::Result<()> {
+    let client = connect().await?;
+
+    // `name` resolves to a string; `.foo` on a string is a type mismatch,
+    // not a missing-field lookup.
+    let ops = r#"create(kind="entity", entity_kind="concept", name="WrongTypeSource") | get(id=$prev.name.foo)"#;
+    let result = call(
+        &client,
+        "request",
+        json!({"ops": ops, "presentation": "verbose"}),
+    )
+    .await?;
+    let body: Value = serde_json::from_str(&first_text(&result))?;
+    let results = body["results"].as_array().expect("results array");
+
+    assert_eq!(results[0]["ok"], json!(true), "create must succeed");
+    assert_eq!(
+        results[1]["ok"],
+        json!(false),
+        "get with a field-on-a-scalar path must fail: {}",
+        results[1]
+    );
+    let err = &results[1]["error"];
+    let err_msg = err["message"]
+        .as_str()
+        .unwrap_or_else(|| err.as_str().unwrap_or(""));
+    assert!(
+        err_msg.contains("is a string, not an"),
+        "must name the actual JSON type found and what was expected; got: {err_msg}"
+    );
+    assert!(
+        err_msg.contains("\"foo\""),
+        "must name the segment that could not be applied; got: {err_msg}"
+    );
+    assert_eq!(err["kind"], json!("substitution_error"));
+    assert_eq!(err["reason"], json!("path_wrong_type"));
+
+    Ok(())
+}
+
+/// Bracket syntax that isn't a valid non-negative-integer index (e.g.
+/// `[bad]`) never reaches the substitution layer at all: `khive-request`'s
+/// own DSL parser rejects it up front, both for the unquoted form (here) and
+/// for a quoted `"$prev[bad]"` string (which simply fails promotion to a
+/// `$prev` reference and is treated as a literal string — see
+/// `previous-result.md`). The substituter's own defense against this form
+/// (`PrevFailure::Unsupported`, exercised directly in
+/// `khive-request`'s test suite since it is otherwise unreachable through
+/// this public surface) never fires here; what the caller actually sees is
+/// this parse-time rejection.
+#[tokio::test]
+async fn test_prev_malformed_index_rejected_at_parse_time() -> anyhow::Result<()> {
+    let client = connect().await?;
+
+    let ops = r#"create(kind="entity", entity_kind="concept", name="MalformedIndexSource") | get(id=$prev[bad])"#;
+    let err = call(
+        &client,
+        "request",
+        json!({"ops": ops, "presentation": "verbose"}),
+    )
+    .await
+    .expect_err("malformed bracket syntax must be rejected before any op runs");
+    let err_msg = err.to_string();
+    assert!(
+        err_msg.contains("non-negative integer"),
+        "parse-time rejection must explain what index syntax IS supported; got: {err_msg}"
+    );
+
+    Ok(())
+}
+
+/// A nested `$prev` reference inside an object-literal argument must resolve
+/// (and fail) exactly as clearly as a bare `$prev.field` argument — the
+/// error must still name the missing field, not just the outer arg name.
+#[tokio::test]
+async fn test_prev_nested_in_object_literal_errors_as_clearly_as_bare() -> anyhow::Result<()> {
+    let client = connect().await?;
+
+    let ops = r#"create(kind="entity", entity_kind="concept", name="NestedPrevSource") | create(kind="entity", entity_kind="concept", name="NestedPrevSink", properties={"linked": $prev.bogus_nested_field})"#;
+    let result = call(
+        &client,
+        "request",
+        json!({"ops": ops, "presentation": "verbose"}),
+    )
+    .await?;
+    let body: Value = serde_json::from_str(&first_text(&result))?;
+    let results = body["results"].as_array().expect("results array");
+
+    assert_eq!(results[0]["ok"], json!(true), "first create must succeed");
+    assert_eq!(
+        results[1]["ok"],
+        json!(false),
+        "create with an unresolvable nested $prev inside properties must fail: {}",
+        results[1]
+    );
+    let err = &results[1]["error"];
+    let err_msg = err["message"]
+        .as_str()
+        .unwrap_or_else(|| err.as_str().unwrap_or(""));
+    assert!(
+        err_msg.contains("bogus_nested_field"),
+        "nested $prev failure must name the unresolvable field just as a bare \
+         reference would; got: {err_msg}"
+    );
+
+    Ok(())
+}
+
+/// When op N fails for a reason unrelated to substitution, downstream ops
+/// referencing `$prev` are never dispatched at all (the chain aborts first).
+/// The aborted marker must say plainly that an earlier op is the actual
+/// problem, so the caller doesn't go looking at the wrong line.
+#[tokio::test]
+async fn test_prev_after_unrelated_failure_points_at_the_failed_op() -> anyhow::Result<()> {
+    let client = connect().await?;
+
+    // `get` on a well-formed but nonexistent id fails for reasons that have
+    // nothing to do with $prev; op 1's own $prev.id reference must never be
+    // attempted.
+    let ops = r#"get(id="00000000-0000-0000-0000-000000000000") | create(kind="entity", entity_kind="concept", name=$prev.id)"#;
+    let result = call(
+        &client,
+        "request",
+        json!({"ops": ops, "presentation": "verbose"}),
+    )
+    .await?;
+    let body: Value = serde_json::from_str(&first_text(&result))?;
+    let results = body["results"].as_array().expect("results array");
+
+    assert_eq!(results.len(), 2, "expected 2 ops");
+    assert_eq!(
+        results[0]["ok"],
+        json!(false),
+        "get on a nonexistent id must fail: {}",
+        results[0]
+    );
+    assert_ne!(
+        results[0]["aborted"],
+        json!(true),
+        "the actually-failing op must not itself be marked aborted: {}",
+        results[0]
+    );
+
+    assert_eq!(results[1]["ok"], json!(false));
+    assert_eq!(results[1]["aborted"], json!(true));
+    let aborted_msg = results[1]["message"].as_str().unwrap_or("");
+    assert!(
+        aborted_msg.contains("op #0") && aborted_msg.contains("\"get\""),
+        "aborted marker must name the earlier failed op, not describe op 1's own \
+         (never-attempted) $prev reference; got: {aborted_msg}"
+    );
+
+    Ok(())
+}
+
 // ── help=true schema envelope integration tests ─────────────────────────────
 //
 // These tests confirm that help=true calls through the MCP surface return

--- a/crates/khive-pack-brain/src/handlers.rs
+++ b/crates/khive-pack-brain/src/handlers.rs
@@ -72,7 +72,9 @@ pub(crate) static BRAIN_HANDLERS: &[HandlerDef] = &[
         name: "brain.event_counts",
         description: "Windowed event counts grouped by kind, actor, and verb over the event \
             plane (ADR-103 Stage 1, #724 Ask A); feedback_explicit events additionally split by \
-            served_by_profile_id; events carrying a work_class (today: phase_started / \
+            served_by_profile_id (by_profile), by signal (counts_by_signal), and by profile \
+            crossed with signal (by_profile_and_signal, for per-seat negative-share); events \
+            carrying a work_class (today: phase_started / \
             phase_completed / phase_cancelled payloads, checked before any future \
             payload.resource.work_class) split by counts_by_work_class. Events carrying \
             payload.resource.cost_unit (ADR-103 Amendment 1; stamped on every successful verb \
@@ -84,7 +86,14 @@ pub(crate) static BRAIN_HANDLERS: &[HandlerDef] = &[
             fields — and, to keep a page-scoped number from being read as the real window total, \
             each is renamed to an explicitly incomplete key (total_page_scoped, \
             total_cost_unit_page_scoped) instead of being returned under its normal name \
-            (issue #14). window_event_total always carries the true count regardless.",
+            (issue #14). window_event_total always carries the true count regardless. The \
+            unfiltered default view (no `kind`) segregates the high-volume `audit` kind from \
+            the shared truncation budget so it cannot crowd other kinds out of counts_by_kind. \
+            Pass exhaustive=true for an exact, non-sampled full-window aggregate (paginates \
+            internally; still one call) instead of a single bounded page — higher cost, use \
+            for coverage-panel/audit-style queries. Exhaustive windows matching more than \
+            2,000,000 events are rejected rather than returned as partial aggregates; narrow \
+            since/until or add actor/kind filters.",
         visibility: khive_types::Visibility::Verb,
         category: khive_types::VerbCategory::Assertive,
         params: &[
@@ -114,6 +123,18 @@ pub(crate) static BRAIN_HANDLERS: &[HandlerDef] = &[
                 param_type: "string",
                 required: false,
                 description: "Filter to a single EventKind (e.g. \"recall_executed\", \"feedback_explicit\"). Omit for all kinds.",
+            },
+            khive_types::ParamDef {
+                name: "exhaustive",
+                param_type: "boolean",
+                required: false,
+                description: "When true, paginate through every matching event instead of a \
+                    single bounded page, returning an exact (non-sampled) full-window \
+                    aggregate in one call. Higher cost than the default bounded page \
+                    (internally issues multiple storage queries); intended for coverage-panel \
+                    / audit-style queries over large windows. Windows above the 2,000,000-event \
+                    exhaustive limit are rejected; narrow since/until or add filters. Default \
+                    false.",
             },
         ],
     },
@@ -719,6 +740,8 @@ impl BrainPack {
     /// storage trait with a grouped-count method was intentionally deferred
     /// rather than contorting `EventStore` for a case that is not yet load-bearing.
     const MAX_WINDOW_EVENTS: u32 = 50_000;
+    const EXHAUSTIVE_PAGE_SIZE: u32 = 10_000;
+    const MAX_EXHAUSTIVE_EVENTS: u64 = 40 * Self::MAX_WINDOW_EVENTS as u64;
 
     /// Issue #14: when the window's aggregation ran over a bounded page
     /// rather than the full window (`truncated`), a bare scalar total next
@@ -755,6 +778,12 @@ impl BrainPack {
             // serde's generic "missing field `since`" message.
             since: Option<String>,
             until: Option<String>,
+            // #21: opt into full-window aggregation (paginates through every
+            // matching event instead of a single bounded page) so a coverage
+            // panel gets exact per-verb/kind/actor counts in one call, without
+            // stitching sampled windows client-side. Default false — the
+            // bounded page is cheaper and sufficient for most callers.
+            exhaustive: Option<bool>,
         }
         let p: EventCountsParams = serde_json::from_value(params)
             .map_err(|e| RuntimeError::InvalidInput(e.to_string()))?;
@@ -792,7 +821,7 @@ impl BrainPack {
         };
 
         let store = self.runtime.events(token)?;
-        let filter = EventFilter {
+        let base_filter = EventFilter {
             actors: actor_filters,
             kinds: kind_filter.into_iter().collect(),
             // Half-open window [since, until): `EventFilter.after` is a strict
@@ -804,19 +833,24 @@ impl BrainPack {
             ..EventFilter::default()
         };
 
-        let page = store
-            .query_events(
-                filter,
-                PageRequest {
-                    offset: 0,
-                    limit: Self::MAX_WINDOW_EVENTS,
-                },
+        let exhaustive = p.exhaustive.unwrap_or(false);
+        let (items, window_event_total, truncated) = if exhaustive {
+            fetch_event_counts_window_exhaustive(
+                store.as_ref(),
+                &base_filter,
+                Self::EXHAUSTIVE_PAGE_SIZE,
+                Self::MAX_EXHAUSTIVE_EVENTS,
             )
-            .await
-            .map_err(|e| RuntimeError::InvalidInput(e.to_string()))?;
-
-        let window_event_total = page.total.unwrap_or(page.items.len() as u64);
-        let truncated = window_event_total > page.items.len() as u64;
+            .await?
+        } else {
+            fetch_event_counts_window(
+                store.as_ref(),
+                &base_filter,
+                p.kind.is_none(),
+                Self::MAX_WINDOW_EVENTS,
+            )
+            .await?
+        };
 
         let mut counts_by_kind: std::collections::BTreeMap<String, u64> =
             std::collections::BTreeMap::new();
@@ -826,13 +860,24 @@ impl BrainPack {
             std::collections::BTreeMap::new();
         let mut by_profile: std::collections::BTreeMap<String, u64> =
             std::collections::BTreeMap::new();
+        // #34: signal breakdown for `feedback_explicit`, both flat (negative-signal
+        // saturation as a first-class metric) and crossed with the profile split
+        // above (negative-share per seat/profile) — same source field
+        // (`payload.signal`, stamped by `brain.feedback`/`brain.auto_feedback`) as
+        // `by_profile` reads `payload.served_by_profile_id` from.
+        let mut counts_by_signal: std::collections::BTreeMap<String, u64> =
+            std::collections::BTreeMap::new();
+        let mut by_profile_and_signal: std::collections::BTreeMap<
+            String,
+            std::collections::BTreeMap<String, u64>,
+        > = std::collections::BTreeMap::new();
         let mut counts_by_work_class: std::collections::BTreeMap<String, u64> =
             std::collections::BTreeMap::new();
         let mut total_cost_unit: i64 = 0;
         let mut cost_unit_by_verb: std::collections::BTreeMap<String, i64> =
             std::collections::BTreeMap::new();
 
-        for event in &page.items {
+        for event in &items {
             *counts_by_kind
                 .entry(event.kind.name().to_string())
                 .or_insert(0) += 1;
@@ -845,7 +890,19 @@ impl BrainPack {
                     .and_then(Value::as_str)
                     .unwrap_or("unspecified")
                     .to_string();
-                *by_profile.entry(profile).or_insert(0) += 1;
+                *by_profile.entry(profile.clone()).or_insert(0) += 1;
+                let signal = event
+                    .payload
+                    .get("signal")
+                    .and_then(Value::as_str)
+                    .unwrap_or("unspecified")
+                    .to_string();
+                *counts_by_signal.entry(signal.clone()).or_insert(0) += 1;
+                *by_profile_and_signal
+                    .entry(profile)
+                    .or_default()
+                    .entry(signal)
+                    .or_insert(0) += 1;
             }
             if let Some(work_class) = event_work_class(&event.payload) {
                 *counts_by_work_class
@@ -869,10 +926,17 @@ impl BrainPack {
             "counts_by_verb": counts_by_verb,
             "truncated": truncated,
             "window_event_total": window_event_total,
+            "exhaustive": exhaustive,
         });
-        result[Self::truncatable_total_key("total", truncated)] = json!(page.items.len() as u64);
+        result[Self::truncatable_total_key("total", truncated)] = json!(items.len() as u64);
         if !by_profile.is_empty() {
             result["by_profile"] = json!(by_profile);
+        }
+        if !counts_by_signal.is_empty() {
+            result["counts_by_signal"] = json!(counts_by_signal);
+        }
+        if !by_profile_and_signal.is_empty() {
+            result["by_profile_and_signal"] = json!(by_profile_and_signal);
         }
         if !counts_by_work_class.is_empty() {
             result["counts_by_work_class"] = json!(counts_by_work_class);
@@ -1293,6 +1357,16 @@ impl BrainPack {
             // is rejected rather than silently coerced.
             scorer_run_id: Option<String>,
             serve_ledger_id: Option<String>,
+            // #35 cheap-half: `brain.auto_feedback` receives the serving `query`
+            // and the full `results` list but previously dropped both, keeping
+            // only `results.first()`'s id as `target_id`. Persisting what
+            // already arrives (emission-side only, no new join) unblocks
+            // "what else was on the candidate list this feedback was chosen
+            // from" without requiring the full RecallExecuted-linkage gap
+            // (#807's harder half) to close first. Both optional so a direct
+            // `brain.feedback` caller (no serving context) is unaffected.
+            query: Option<String>,
+            candidate_ids: Option<Vec<String>>,
         }
         let p: FeedbackParams = serde_json::from_value(params)
             .map_err(|e| RuntimeError::InvalidInput(e.to_string()))?;
@@ -1306,8 +1380,7 @@ impl BrainPack {
             ));
         }
 
-        let target: uuid::Uuid =
-            resolve_auto_feedback_target(&self.runtime, token, &p.target_id).await?;
+        let target: uuid::Uuid = resolve_auto_feedback_target(&self.runtime, &p.target_id).await?;
 
         let signal = match p.signal.as_str() {
             "useful" => "useful",
@@ -1460,6 +1533,17 @@ impl BrainPack {
         {
             base_data["scorer_run_id"] = json!(scorer_run_id);
             base_data["serve_ledger_id"] = json!(serve_ledger_id);
+        }
+        // #35 cheap-half: persist what `brain.auto_feedback` already receives
+        // instead of dropping it. `candidate_ids` are the raw (pre-resolution)
+        // ids `auto_feedback` was handed — not necessarily equal to `target_id`
+        // (which is `results.first()`, resolved to a full UUID) — so a reader
+        // can see the full candidate set the choice was made from.
+        if let Some(ref query) = p.query {
+            base_data["query"] = json!(query);
+        }
+        if let Some(ref candidate_ids) = p.candidate_ids {
+            base_data["candidate_ids"] = json!(candidate_ids);
         }
 
         // ADR-081 §2: the bounded-mass fold gate applies only to implicit
@@ -1763,7 +1847,7 @@ impl BrainPack {
             }));
         };
 
-        let target = resolve_auto_feedback_target(&self.runtime, token, &first.id).await?;
+        let target = resolve_auto_feedback_target(&self.runtime, &first.id).await?;
 
         let mut feedback_params = json!({
             "target_id": target.to_string(),
@@ -1778,6 +1862,12 @@ impl BrainPack {
         if let Some(ref serve_ledger_id) = p.serve_ledger_id {
             feedback_params["serve_ledger_id"] = json!(serve_ledger_id);
         }
+        // #35 cheap-half: forward what already arrived instead of dropping it —
+        // the serving `query` and the raw (pre-resolution) candidate ids for
+        // every result, not just the chosen `first`.
+        feedback_params["query"] = json!(p.query);
+        feedback_params["candidate_ids"] =
+            json!(p.results.iter().map(|r| r.id.clone()).collect::<Vec<_>>());
 
         let mut out = self.handle_feedback(token, feedback_params).await?;
         out["verb"] = json!("brain.auto_feedback");
@@ -2339,6 +2429,164 @@ impl BrainPack {
     }
 }
 
+/// Fetch the event window for `brain.event_counts`, each bounded query capped at
+/// `page_limit` (`BrainPack::MAX_WINDOW_EVENTS` in production; a free function
+/// parameterized on the cap so a unit test can shrink it and exercise the
+/// crowd-out fix below deterministically, instead of needing tens of thousands
+/// of seeded rows to trigger it).
+///
+/// #26: the unfiltered default view (`unfiltered = true`, i.e. the caller
+/// passed no `kind`) must not let the high-volume `audit` kind crowd every
+/// other kind out of the shared budget. `query_events` orders by `created_at
+/// DESC`, so a single bounded fetch over "all kinds" returns whichever kind
+/// fired most densely in the tail of the window — measured at ~12x undercount
+/// for `feedback_explicit` when `audit` alone runs 37k-50k/week. Segregate
+/// `audit` into its own bounded query so each half gets the full `page_limit`
+/// independently — a quiet kind is never crowded out by a busy one. Only
+/// applies to the unfiltered default view: a caller who already passed `kind`
+/// has no crowding to fix (the single query is already scoped to one kind).
+///
+/// Returns the concatenated items, the true total matching the filter (exact,
+/// via `Page::total`'s unbounded `COUNT(*)` — see `khive-db`'s `query_events`),
+/// and whether either half was truncated against its own `page_limit`.
+pub(crate) async fn fetch_event_counts_window(
+    store: &dyn khive_storage::event::EventStore,
+    base_filter: &EventFilter,
+    unfiltered: bool,
+    page_limit: u32,
+) -> Result<(Vec<Event>, u64, bool), RuntimeError> {
+    if !unfiltered {
+        let page = store
+            .query_events(
+                base_filter.clone(),
+                PageRequest {
+                    offset: 0,
+                    limit: page_limit,
+                },
+            )
+            .await
+            .map_err(|e| RuntimeError::InvalidInput(e.to_string()))?;
+        let window_event_total = page.total.unwrap_or(page.items.len() as u64);
+        let truncated = window_event_total > page.items.len() as u64;
+        return Ok((page.items, window_event_total, truncated));
+    }
+
+    let non_audit_kinds: Vec<khive_types::EventKind> = khive_types::EventKind::ALL
+        .iter()
+        .copied()
+        .filter(|k| *k != khive_types::EventKind::Audit)
+        .collect();
+    let audit_filter = EventFilter {
+        kinds: vec![khive_types::EventKind::Audit],
+        ..base_filter.clone()
+    };
+    let non_audit_filter = EventFilter {
+        kinds: non_audit_kinds,
+        ..base_filter.clone()
+    };
+
+    let audit_page = store
+        .query_events(
+            audit_filter,
+            PageRequest {
+                offset: 0,
+                limit: page_limit,
+            },
+        )
+        .await
+        .map_err(|e| RuntimeError::InvalidInput(e.to_string()))?;
+    let non_audit_page = store
+        .query_events(
+            non_audit_filter,
+            PageRequest {
+                offset: 0,
+                limit: page_limit,
+            },
+        )
+        .await
+        .map_err(|e| RuntimeError::InvalidInput(e.to_string()))?;
+
+    let audit_total = audit_page.total.unwrap_or(audit_page.items.len() as u64);
+    let non_audit_total = non_audit_page
+        .total
+        .unwrap_or(non_audit_page.items.len() as u64);
+    let truncated = audit_total > audit_page.items.len() as u64
+        || non_audit_total > non_audit_page.items.len() as u64;
+    let window_event_total = audit_total + non_audit_total;
+    let mut items = audit_page.items;
+    items.extend(non_audit_page.items);
+    Ok((items, window_event_total, truncated))
+}
+
+/// #21: full-window aggregation for `brain.event_counts(exhaustive=true)`.
+///
+/// `EventStore` has no SQL-side grouped-count primitive (`count_events` returns
+/// one scalar per filter, not a GROUP BY) — that would live in `khive-storage`/
+/// `khive-db`, outside this crate. Exact per-verb/kind/actor counts over an
+/// arbitrarily large window are achievable without one: paginate `query_events`
+/// with a fixed page size until exhausted, accumulating every page instead of
+/// stopping at a single bounded page. The caller still makes exactly ONE
+/// `brain.event_counts` call — the pagination loop is internal to this
+/// function — so a coverage panel that needed 19 stitched sampled windows
+/// becomes one exhaustive call.
+///
+/// `window_event_total` comes from a single `count_events` call: the SQL
+/// `COUNT(*)` for a given `WHERE` clause is invariant to `LIMIT`/`OFFSET`, so
+/// it is already exact regardless of how many pages the loop below walks —
+/// cheaper than trusting the last page's `Page::total` and doesn't require
+/// the loop to complete.
+///
+/// `max_events` is a safety bound, not a design limit: without one,
+/// a caller could open a pathological (multi-year, unfiltered) window and this
+/// function would loop until the process runs out of memory rather than
+/// returning. Set to 40x the bounded-mode cap (`BrainPack::MAX_WINDOW_EVENTS`)
+/// — comfortably above the multi-million-event/month volumes `exhaustive` is
+/// meant to serve — so it only binds on something pathological. A window above
+/// the bound is rejected before aggregation; exhaustive mode never returns a
+/// partial result.
+pub(crate) async fn fetch_event_counts_window_exhaustive(
+    store: &dyn khive_storage::event::EventStore,
+    base_filter: &EventFilter,
+    page_size: u32,
+    max_events: u64,
+) -> Result<(Vec<Event>, u64, bool), RuntimeError> {
+    let window_event_total = store
+        .count_events(base_filter.clone())
+        .await
+        .map_err(|e| RuntimeError::InvalidInput(e.to_string()))?;
+    if window_event_total > max_events {
+        return Err(RuntimeError::InvalidInput(format!(
+            "brain.event_counts window exceeds the exhaustive limit of {max_events} events \
+             ({window_event_total} matched); narrow `since`/`until` or add filters (`actor` or \
+             `kind`)"
+        )));
+    }
+
+    let mut items: Vec<Event> = Vec::new();
+    let mut offset: u64 = 0;
+    loop {
+        let page = store
+            .query_events(
+                base_filter.clone(),
+                PageRequest {
+                    offset,
+                    limit: page_size,
+                },
+            )
+            .await
+            .map_err(|e| RuntimeError::InvalidInput(e.to_string()))?;
+        let page_len = page.items.len() as u64;
+        items.extend(page.items);
+        if page_len < page_size as u64 {
+            break;
+        }
+        offset += page_size as u64;
+    }
+
+    let truncated = (items.len() as u64) < window_event_total;
+    Ok((items, window_event_total, truncated))
+}
+
 /// Parse an ISO-8601/RFC-3339 datetime string into a microsecond epoch,
 /// naming the offending field/value in the error rather than a bare parse
 /// failure (`brain.event_counts`, ADR-103 Stage 1).
@@ -2518,9 +2766,21 @@ fn route_via_fann(context: &[f32]) -> Vec<f32> {
 /// Accepts a 36-char UUID directly, or an 8-char hex prefix (Agent-mode short
 /// form). Returns `InvalidInput` if neither form matches or the prefix is
 /// ambiguous.
+///
+/// #38: the full-UUID path above is already namespace-agnostic (ADR-007 Rev 6
+/// — by-ID resolution has no namespace check; the Gate, not storage-layer
+/// filtering, is the authz seam). The prefix path used to be scoped to the
+/// caller's own namespace via `resolve_prefix`, which broke the documented
+/// `memory.recall` -> `brain.auto_feedback` chain whenever the recalled
+/// record lived outside that scope: recall itself fans out cross-namespace by
+/// design (root CLAUDE.md "Rule 3b"), so a namespace-scoped prefix resolution
+/// could fail on an id recall had just served, with
+/// `"no record matches id prefix"`. `resolve_prefix_unfiltered` closes that
+/// asymmetry — same by-ID contract as the four CRUD-by-ID verbs
+/// (get/update/delete/merge) already use, no namespace filter, no `token`
+/// needed (there is no namespace to derive from one).
 pub(crate) async fn resolve_auto_feedback_target(
     runtime: &KhiveRuntime,
-    token: &NamespaceToken,
     raw: &str,
 ) -> Result<uuid::Uuid, RuntimeError> {
     if let Ok(uuid) = raw.parse::<uuid::Uuid>() {
@@ -2528,7 +2788,7 @@ pub(crate) async fn resolve_auto_feedback_target(
     }
     if raw.len() >= 8 && raw.chars().all(|c| c.is_ascii_hexdigit()) {
         return runtime
-            .resolve_prefix(token, raw)
+            .resolve_prefix_unfiltered(raw)
             .await
             .map_err(|e| RuntimeError::InvalidInput(e.to_string()))?
             .ok_or_else(|| {

--- a/crates/khive-pack-brain/src/handlers.rs
+++ b/crates/khive-pack-brain/src/handlers.rs
@@ -85,8 +85,14 @@ pub(crate) static BRAIN_HANDLERS: &[HandlerDef] = &[
             total_cost_unit) is over the fetched page only, same as the other counts_by_* \
             fields — and, to keep a page-scoped number from being read as the real window total, \
             each is renamed to an explicitly incomplete key (total_page_scoped, \
-            total_cost_unit_page_scoped) instead of being returned under its normal name \
-            (issue #14). window_event_total always carries the true count regardless. The \
+            total_cost_unit_page_scoped) instead of being returned under its normal name. \
+            window_event_total always carries the true count regardless. \
+            `kind`/`actor` filters are applied in SQL before the internal window cap \
+            — `window_event_total` reflects the exact filtered total even when \
+            truncated=true. For an exact per-actor count of a specific low-frequency kind, pass \
+            `kind=` explicitly rather than reading it out of an unfiltered call's \
+            counts_by_kind/counts_by_actor breakdown, which is capped over the mixed-kind \
+            window and can undercount a low-frequency kind relative to noisier ones. The \
             unfiltered default view (no `kind`) segregates the high-volume `audit` kind from \
             the shared truncation budget so it cannot crowd other kinds out of counts_by_kind. \
             Pass exhaustive=true for an exact, non-sampled full-window aggregate (paginates \
@@ -366,6 +372,27 @@ pub(crate) static BRAIN_HANDLERS: &[HandlerDef] = &[
                 description: "Serve timestamp in epoch microseconds. Defaults to now.",
             },
         ],
+    },
+    HandlerDef {
+        name: "brain.mark_turn",
+        description: "Emit a PhaseStarted event (work_class=\"actor_turn\") carrying the \
+            calling actor and a timestamp. A per-actor per-work-unit marker: \
+            callers invoke this once per bounded unit of work (a wake, a turn) so \
+            brain.event_counts's counts_by_work_class[\"actor_turn\"], grouped by actor, \
+            gives a discipline-ratio denominator (e.g. feedback_explicit / actor_turn) that \
+            is not biased toward whichever actor issues the most raw verb calls. Reuses the \
+            existing ADR-103 Stage 1 PhaseStarted/work_class vocabulary rather than a new \
+            EventKind variant. Best-effort — never fails the caller's turn.",
+        visibility: khive_types::Visibility::Verb,
+        category: khive_types::VerbCategory::Commissive,
+        params: &[khive_types::ParamDef {
+            name: "label",
+            param_type: "string",
+            required: false,
+            description: "Free-form label for this unit of work (e.g. \"wake\", \"turn\"), \
+                recorded in the event payload's `phase` field for debugging. Does not affect \
+                the work_class grouping, which stays fixed at \"actor_turn\".",
+        }],
     },
     // ── Declaration verbs ─────────────────────────────────────────────────
     HandlerDef {
@@ -1952,6 +1979,51 @@ impl BrainPack {
         }))
     }
 
+    // ── brain.mark_turn ───────────────────────────────────────────────────
+
+    /// Best-effort per-actor work-unit marker. Reuses the
+    /// ADR-103 Stage 1 `PhaseStarted`/`work_class` vocabulary (fixed
+    /// `work_class = "actor_turn"`) instead of minting a new `EventKind`
+    /// variant, since `EventKind` is a closed enum owned by the OSS
+    /// `khive-types` crate.
+    pub(crate) async fn handle_mark_turn(
+        &self,
+        token: &NamespaceToken,
+        params: Value,
+    ) -> Result<Value, RuntimeError> {
+        #[derive(Deserialize)]
+        #[serde(deny_unknown_fields)]
+        struct MarkTurnParams {
+            label: Option<String>,
+        }
+        let p: MarkTurnParams = serde_json::from_value(params)
+            .map_err(|e| RuntimeError::InvalidInput(e.to_string()))?;
+        if let Some(label) = p.label.as_deref() {
+            khive_runtime::secret_gate::check(label)?;
+        }
+        let phase = p.label.unwrap_or_else(|| "actor_turn".to_string());
+        let actor = format!("{}:{}", token.actor().kind, token.actor().id);
+
+        khive_runtime::emit_phase_event(
+            &self.runtime,
+            token,
+            "brain.mark_turn",
+            khive_types::EventKind::PhaseStarted,
+            khive_storage::PhaseStartedPayload {
+                work_class: "actor_turn".to_string(),
+                phase,
+                corpus_size: None,
+            },
+        )
+        .await;
+
+        Ok(json!({
+            "ok": true,
+            "work_class": "actor_turn",
+            "actor": actor,
+        }))
+    }
+
     // ── brain.emit (deprecated) ───────────────────────────────────────────
 
     /// Deprecated alias for `brain.feedback`; routes to `handle_feedback`.
@@ -2911,6 +2983,7 @@ impl khive_runtime::pack::PackRuntime for BrainPack {
             "brain.feedback" => self.handle_feedback(token, params).await,
             "brain.auto_feedback" => self.handle_auto_feedback(token, params).await,
             "brain.record_serve" => self.handle_record_serve(token, params).await,
+            "brain.mark_turn" => self.handle_mark_turn(token, params).await,
             // Declaration
             "brain.bind" => self.handle_bind(token, params).await,
             "brain.unbind" => self.handle_unbind(token, params).await,

--- a/crates/khive-pack-brain/src/handlers.rs
+++ b/crates/khive-pack-brain/src/handlers.rs
@@ -78,9 +78,13 @@ pub(crate) static BRAIN_HANDLERS: &[HandlerDef] = &[
             payload.resource.cost_unit (ADR-103 Amendment 1; stamped on every successful verb \
             dispatch since PR #927) sum into total_cost_unit and cost_unit_by_verb; events with \
             no resource.cost_unit (pre-Amendment-1 events, or errored/denied dispatches) simply \
-            do not contribute. Both fields are omitted, not zero-filled, when no event in the \
-            window carries cost_unit. When truncated=true, both sums are over the fetched page \
-            only, same as the other counts_by_* fields.",
+            do not contribute. total_cost_unit is omitted, not zero-filled, when no event in the \
+            window carries cost_unit. When truncated=true, every scalar total (total, \
+            total_cost_unit) is over the fetched page only, same as the other counts_by_* \
+            fields — and, to keep a page-scoped number from being read as the real window total, \
+            each is renamed to an explicitly incomplete key (total_page_scoped, \
+            total_cost_unit_page_scoped) instead of being returned under its normal name \
+            (issue #14). window_event_total always carries the true count regardless.",
         visibility: khive_types::Visibility::Verb,
         category: khive_types::VerbCategory::Assertive,
         params: &[
@@ -716,6 +720,26 @@ impl BrainPack {
     /// rather than contorting `EventStore` for a case that is not yet load-bearing.
     const MAX_WINDOW_EVENTS: u32 = 50_000;
 
+    /// Issue #14: when the window's aggregation ran over a bounded page
+    /// rather than the full window (`truncated`), a bare scalar total next
+    /// to complete-looking `counts_by_*` maps reads as authoritative even
+    /// though it is only a page-scoped estimate. The interim fix (the
+    /// primary fix -- a SQL-side grouped-count primitive on `EventStore` --
+    /// requires widening a trait owned by the upstream OSS `khive-storage`
+    /// crate, out of scope here): when truncated, the misleading key is
+    /// never emitted; the same page-scoped value is returned under an
+    /// explicitly incomplete name instead. A missing `total` gets noticed;
+    /// a `total` that is wrong by an order of magnitude does not.
+    /// `window_event_total` (the true count) and `truncated` (the marker)
+    /// are unaffected -- this only renames the page-scoped scalar's own key.
+    pub(crate) fn truncatable_total_key(base_key: &str, truncated: bool) -> String {
+        if truncated {
+            format!("{base_key}_page_scoped")
+        } else {
+            base_key.to_string()
+        }
+    }
+
     pub(crate) async fn handle_event_counts(
         &self,
         token: &NamespaceToken,
@@ -840,13 +864,13 @@ impl BrainPack {
             "until": micros_to_iso(until_us),
             "actor": p.actor,
             "kind": p.kind,
-            "total": page.items.len() as u64,
             "counts_by_kind": counts_by_kind,
             "counts_by_actor": counts_by_actor,
             "counts_by_verb": counts_by_verb,
             "truncated": truncated,
             "window_event_total": window_event_total,
         });
+        result[Self::truncatable_total_key("total", truncated)] = json!(page.items.len() as u64);
         if !by_profile.is_empty() {
             result["by_profile"] = json!(by_profile);
         }
@@ -854,7 +878,8 @@ impl BrainPack {
             result["counts_by_work_class"] = json!(counts_by_work_class);
         }
         if !cost_unit_by_verb.is_empty() {
-            result["total_cost_unit"] = json!(total_cost_unit);
+            result[Self::truncatable_total_key("total_cost_unit", truncated)] =
+                json!(total_cost_unit);
             result["cost_unit_by_verb"] = json!(cost_unit_by_verb);
         }
         Ok(result)

--- a/crates/khive-pack-brain/src/tests.rs
+++ b/crates/khive-pack-brain/src/tests.rs
@@ -6411,6 +6411,179 @@ mod event_counts_tests {
         assert!(result["counts_by_kind"].get("search_executed").is_none());
     }
 
+    // ── brain.mark_turn work-start marker ────────────────────
+
+    /// `brain.mark_turn` must persist a `PhaseStarted` event carrying the
+    /// calling actor, the fixed `work_class = "actor_turn"`, and the caller's
+    /// free-form `label` in the `phase` field.
+    #[tokio::test]
+    async fn mark_turn_persists_phase_started_actor_turn_event() {
+        let (pack, rt) = make_pack();
+        let registry = empty_registry();
+        let token = rt.authorize(Namespace::local()).unwrap();
+
+        let result = pack
+            .dispatch(
+                "brain.mark_turn",
+                json!({ "label": "wake" }),
+                &registry,
+                &token,
+            )
+            .await
+            .expect("brain.mark_turn must succeed");
+
+        assert_eq!(result["ok"], json!(true));
+        assert_eq!(result["work_class"], json!("actor_turn"));
+
+        let page = rt
+            .events(&token)
+            .expect("event store")
+            .query_events(
+                EventFilter {
+                    kinds: vec![EventKind::PhaseStarted],
+                    ..EventFilter::default()
+                },
+                PageRequest {
+                    offset: 0,
+                    limit: 10,
+                },
+            )
+            .await
+            .expect("query_events");
+
+        assert_eq!(
+            page.items.len(),
+            1,
+            "exactly one PhaseStarted event must be persisted: {page:?}"
+        );
+        let event = &page.items[0];
+        assert_eq!(event.verb, "brain.mark_turn");
+        assert_eq!(
+            event.actor,
+            format!("{}:{}", token.actor().kind, token.actor().id)
+        );
+        assert_eq!(event.payload["work_class"], json!("actor_turn"));
+        assert_eq!(event.payload["phase"], json!("wake"));
+    }
+
+    /// A rejected credential-shaped label must not reach the event plane.
+    #[tokio::test]
+    async fn mark_turn_blocks_secret_label_without_persisting_event() {
+        let (pack, rt) = make_pack();
+        let registry = empty_registry();
+        let token = rt.authorize(Namespace::local()).unwrap();
+        let actor = format!("{}:{}", token.actor().kind, token.actor().id);
+        let window_start = chrono::Utc::now().timestamp_micros();
+
+        let err = pack
+            .dispatch(
+                "brain.mark_turn",
+                json!({
+                    "label": "AKIAFAKEKEY000000000", // gitleaks:allow
+                }),
+                &registry,
+                &token,
+            )
+            .await
+            .expect_err("credential-shaped label must be rejected");
+        let window_end = chrono::Utc::now().timestamp_micros();
+
+        assert!(
+            matches!(err, RuntimeError::SecretDetected(_)),
+            "credential-shaped label must return SecretDetected, got {err:?}"
+        );
+
+        let page = rt
+            .events(&token)
+            .expect("event store")
+            .query_events(
+                EventFilter {
+                    kinds: vec![EventKind::PhaseStarted],
+                    verbs: vec!["brain.mark_turn".to_string()],
+                    actors: vec![actor],
+                    after: Some(window_start.saturating_sub(1)),
+                    before: Some(window_end.saturating_add(1)),
+                    ..EventFilter::default()
+                },
+                PageRequest {
+                    offset: 0,
+                    limit: 10,
+                },
+            )
+            .await
+            .expect("query phase_started events");
+
+        assert!(
+            page.items.is_empty(),
+            "rejected mark_turn must not persist phase_started events: {page:?}"
+        );
+    }
+
+    /// `brain.mark_turn` calls without an explicit `label` default the
+    /// `phase` field to `"actor_turn"`.
+    #[tokio::test]
+    async fn mark_turn_without_label_defaults_phase_to_actor_turn() {
+        let (pack, rt) = make_pack();
+        let registry = empty_registry();
+        let token = rt.authorize(Namespace::local()).unwrap();
+
+        pack.dispatch("brain.mark_turn", json!({}), &registry, &token)
+            .await
+            .expect("brain.mark_turn must succeed with no params");
+
+        let page = rt
+            .events(&token)
+            .expect("event store")
+            .query_events(
+                EventFilter {
+                    kinds: vec![EventKind::PhaseStarted],
+                    ..EventFilter::default()
+                },
+                PageRequest {
+                    offset: 0,
+                    limit: 10,
+                },
+            )
+            .await
+            .expect("query_events");
+
+        assert_eq!(page.items.len(), 1);
+        assert_eq!(page.items[0].payload["phase"], json!("actor_turn"));
+    }
+
+    /// The `actor_turn` work-unit marker must be visible in
+    /// `brain.event_counts`'s `counts_by_work_class` (the flywheel-scorecard
+    /// discipline-ratio denominator) and grouped correctly by actor via the
+    /// existing kind-agnostic `counts_by_actor` machinery.
+    #[tokio::test]
+    async fn mark_turn_counted_by_work_class_and_grouped_by_actor_in_event_counts() {
+        let (pack, rt) = make_pack();
+        let registry = empty_registry();
+        let token = rt.authorize(Namespace::local()).unwrap();
+
+        pack.dispatch("brain.mark_turn", json!({}), &registry, &token)
+            .await
+            .expect("brain.mark_turn 1");
+        pack.dispatch("brain.mark_turn", json!({}), &registry, &token)
+            .await
+            .expect("brain.mark_turn 2");
+
+        let result = pack
+            .dispatch(
+                "brain.event_counts",
+                json!({ "since": micros_to_iso(0) }),
+                &registry,
+                &token,
+            )
+            .await
+            .expect("brain.event_counts must succeed");
+
+        assert_eq!(result["counts_by_work_class"]["actor_turn"], json!(2));
+        let actor = format!("{}:{}", token.actor().kind, token.actor().id);
+        assert_eq!(result["counts_by_actor"][actor.as_str()], json!(2));
+        assert_eq!(result["counts_by_kind"]["phase_started"], json!(2));
+    }
+
     #[tokio::test]
     async fn actor_filter_scopes_counts() {
         let (pack, rt) = make_pack();

--- a/crates/khive-pack-brain/src/tests.rs
+++ b/crates/khive-pack-brain/src/tests.rs
@@ -2977,6 +2977,105 @@ async fn brain_auto_feedback_emits_implicit_positive_for_first_result() {
     );
 }
 
+/// #35 cheap half: `brain.auto_feedback` must persist the `query` it received
+/// and the raw candidate ids for every result (not just the chosen `first`),
+/// instead of dropping both on emission.
+#[tokio::test]
+async fn brain_auto_feedback_persists_query_and_candidate_ids() {
+    let (pack, rt) = make_pack();
+    let registry = empty_registry();
+    let token = rt.authorize(Namespace::local()).unwrap();
+    let first = create_test_entity(&rt, &token).await;
+    let second = create_test_entity(&rt, &token).await;
+
+    let result = pack
+        .dispatch(
+            "brain.auto_feedback",
+            json!({
+                "query": "recall calibration target",
+                "results": [{ "id": first }, { "id": second }]
+            }),
+            &registry,
+            &token,
+        )
+        .await
+        .expect("auto_feedback succeeds");
+
+    assert_eq!(result["emitted"], json!(true), "got: {result}");
+    let event_id = uuid::Uuid::parse_str(
+        result["event_id"]
+            .as_str()
+            .expect("response must carry event_id"),
+    )
+    .expect("event_id must be a uuid");
+    let event = rt
+        .events(&token)
+        .expect("event store")
+        .get_event(event_id)
+        .await
+        .expect("get_event must not error")
+        .expect("emitted event must be readable back");
+
+    assert_eq!(
+        event.payload["query"],
+        json!("recall calibration target"),
+        "emitted event must persist the serving query, not drop it: {:?}",
+        event.payload
+    );
+    assert_eq!(
+        event.payload["candidate_ids"],
+        json!([first, second]),
+        "emitted event must persist every candidate id, not just results.first(): {:?}",
+        event.payload
+    );
+}
+
+/// #38: `memory.recall` fans results out across namespaces by design (root
+/// CLAUDE.md "Rule 3b"), so a caller's `auto_feedback` on a just-recalled
+/// short-prefix id must not fail just because the record lives outside the
+/// caller's OWN namespace. Prefix resolution here must match the by-ID
+/// contract's full-UUID path, which is already namespace-agnostic.
+#[tokio::test]
+async fn brain_auto_feedback_resolves_short_prefix_across_namespaces() {
+    use core::convert::TryFrom;
+    use khive_runtime::Namespace;
+
+    let rt = KhiveRuntime::memory().expect("in-memory runtime");
+    let pack = BrainPack::new(rt.clone());
+    let registry = empty_registry();
+
+    let ns_a = Namespace::try_from("ns-a").expect("namespace a");
+    let ns_b = Namespace::try_from("ns-b").expect("namespace b");
+    let token_a = rt.authorize(ns_a).expect("token a");
+    let token_b = rt.authorize(ns_b).expect("token b");
+
+    // Entity lives in namespace A.
+    let target = create_test_entity(&rt, &token_a).await;
+    let prefix = &target[..8];
+
+    // Feedback dispatched under namespace B's token — the recalled record was
+    // never in B's own namespace, mirroring recall's cross-namespace fan-out.
+    let result = pack
+        .dispatch(
+            "brain.auto_feedback",
+            json!({
+                "query": "cross-namespace prefix resolution",
+                "results": [{ "id": prefix }]
+            }),
+            &registry,
+            &token_b,
+        )
+        .await
+        .expect("auto_feedback must resolve a short prefix across namespaces, not fail with \"no record matches id prefix\"");
+
+    assert_eq!(result["emitted"], json!(true), "got: {result}");
+    assert_eq!(
+        result["target_id"].as_str().unwrap_or(""),
+        target,
+        "resolved target_id must match the entity created in the OTHER namespace"
+    );
+}
+
 #[tokio::test]
 async fn brain_auto_feedback_empty_results_returns_no_emit() {
     let (pack, rt) = make_pack();
@@ -6032,6 +6131,241 @@ mod event_counts_tests {
         );
     }
 
+    /// #26: with a shrunk `page_limit`, a busy `audit` kind must not crowd a
+    /// quiet non-audit kind out of the unfiltered default view's shared budget.
+    /// Direct unit test of `fetch_event_counts_window` (rather than the full
+    /// `brain.event_counts` verb dispatch) because reproducing this at the real
+    /// `MAX_WINDOW_EVENTS = 50_000` cap would require seeding tens of thousands
+    /// of rows; the crowd-out mechanism is identical at any cap size.
+    #[tokio::test]
+    async fn audit_kind_does_not_crowd_out_non_audit_kinds_in_default_view() {
+        use khive_storage::event::EventFilter;
+
+        let (_, rt) = make_pack();
+        let token = rt.authorize(Namespace::local()).unwrap();
+
+        // 5 audit events (the busy kind) vs. 1 non-audit event (the quiet kind),
+        // all in the same window. A shared, unsegregated 3-row budget ordered
+        // `created_at DESC` (audit seeded last, so audit sorts first) would
+        // return only audit rows and silently drop the lone `search_executed`
+        // row — exactly the ~12x undercount pattern reported in #26.
+        for i in 0..5 {
+            seed_event(
+                &rt,
+                &token,
+                "create",
+                EventKind::Audit,
+                "lambda:a",
+                1_000_000 + i,
+                json!({}),
+            )
+            .await;
+        }
+        seed_event(
+            &rt,
+            &token,
+            "search",
+            EventKind::SearchExecuted,
+            "lambda:a",
+            999_999,
+            json!({}),
+        )
+        .await;
+
+        let store = rt.events(&token).expect("event store");
+        let base_filter = EventFilter {
+            after: Some(0),
+            ..EventFilter::default()
+        };
+
+        let (items, window_event_total, truncated) = crate::handlers::fetch_event_counts_window(
+            store.as_ref(),
+            &base_filter,
+            /* unfiltered = */ true,
+            /* page_limit = */ 3,
+        )
+        .await
+        .expect("fetch_event_counts_window must succeed");
+
+        assert_eq!(
+            window_event_total, 6,
+            "the true total across both segregated queries must be exact, not \
+             page-limited: {items:?}"
+        );
+        assert!(
+            truncated,
+            "5 audit rows against a 3-row budget must report truncated=true"
+        );
+        let search_present = items.iter().any(|e| e.kind == EventKind::SearchExecuted);
+        assert!(
+            search_present,
+            "the lone non-audit event must survive a busy-audit-kind window even \
+             under a shared-looking budget: {items:?}"
+        );
+        let audit_count = items.iter().filter(|e| e.kind == EventKind::Audit).count();
+        assert_eq!(
+            audit_count, 3,
+            "the audit-kind half of the budget is independently capped at \
+             page_limit: {items:?}"
+        );
+    }
+
+    /// #21: a small injected page size makes this exercise three storage pages
+    /// while proving every page contributes to the final per-verb counts.
+    #[tokio::test]
+    async fn exhaustive_fetch_accumulates_counts_across_pages() {
+        let (_, rt) = make_pack();
+        let token = rt.authorize(Namespace::local()).unwrap();
+
+        for i in 0..7 {
+            seed_event(
+                &rt,
+                &token,
+                "recall",
+                EventKind::RecallExecuted,
+                "lambda:a",
+                1_000_000 + i,
+                json!({}),
+            )
+            .await;
+        }
+        for i in 0..3 {
+            seed_event(
+                &rt,
+                &token,
+                "search",
+                EventKind::SearchExecuted,
+                "lambda:a",
+                2_000_000 + i,
+                json!({}),
+            )
+            .await;
+        }
+
+        let store = rt.events(&token).expect("event store");
+        let base_filter = EventFilter {
+            after: Some(0),
+            ..EventFilter::default()
+        };
+        let (items, window_event_total, truncated) =
+            crate::handlers::fetch_event_counts_window_exhaustive(
+                store.as_ref(),
+                &base_filter,
+                /* page_size = */ 4,
+                /* max_events = */ 20,
+            )
+            .await
+            .expect("multi-page exhaustive fetch must succeed");
+
+        let mut counts_by_verb = std::collections::BTreeMap::new();
+        for event in &items {
+            *counts_by_verb.entry(event.verb.as_str()).or_insert(0_u64) += 1;
+        }
+        assert_eq!(items.len(), 10);
+        assert_eq!(window_event_total, 10);
+        assert!(!truncated);
+        assert_eq!(counts_by_verb.get("recall"), Some(&7));
+        assert_eq!(counts_by_verb.get("search"), Some(&3));
+    }
+
+    /// The public handler must still identify a successful exhaustive response
+    /// as exact; pagination mechanics are covered separately with injected limits.
+    #[tokio::test]
+    async fn exhaustive_mode_returns_exact_response_shape() {
+        let (pack, rt) = make_pack();
+        let registry = empty_registry();
+        let token = rt.authorize(Namespace::local()).unwrap();
+
+        seed_event(
+            &rt,
+            &token,
+            "recall",
+            EventKind::RecallExecuted,
+            "lambda:a",
+            1_000_000,
+            json!({}),
+        )
+        .await;
+
+        let result = pack
+            .dispatch(
+                "brain.event_counts",
+                json!({"since": micros_to_iso(0), "exhaustive": true}),
+                &registry,
+                &token,
+            )
+            .await
+            .expect("exhaustive brain.event_counts must succeed");
+
+        assert_eq!(result["exhaustive"], json!(true), "got: {result}");
+        assert_eq!(result["truncated"], json!(false), "got: {result}");
+        assert_eq!(result["total"], json!(1), "got: {result}");
+        assert_eq!(result["window_event_total"], json!(1), "got: {result}");
+        assert_eq!(result["counts_by_verb"]["recall"], json!(1));
+    }
+
+    #[tokio::test]
+    async fn exhaustive_fetch_rejects_windows_over_the_cap() {
+        let (_, rt) = make_pack();
+        let token = rt.authorize(Namespace::local()).unwrap();
+
+        for i in 0..6 {
+            seed_event(
+                &rt,
+                &token,
+                "recall",
+                EventKind::RecallExecuted,
+                "lambda:a",
+                1_000_000 + i,
+                json!({}),
+            )
+            .await;
+        }
+
+        let store = rt.events(&token).expect("event store");
+        let base_filter = EventFilter {
+            after: Some(0),
+            ..EventFilter::default()
+        };
+        let err = crate::handlers::fetch_event_counts_window_exhaustive(
+            store.as_ref(),
+            &base_filter,
+            /* page_size = */ 2,
+            /* max_events = */ 5,
+        )
+        .await
+        .expect_err("an exhaustive window above the safety cap must be rejected");
+
+        match err {
+            RuntimeError::InvalidInput(msg) => {
+                assert!(msg.contains("window exceeds the exhaustive limit of 5 events"));
+                assert!(msg.contains("narrow `since`/`until` or add filters"));
+            }
+            other => panic!("expected InvalidInput, got {other:?}"),
+        }
+    }
+
+    /// Default (non-exhaustive) calls must keep reporting `exhaustive: false`
+    /// so callers can distinguish an exact aggregate from a bounded-page one.
+    #[tokio::test]
+    async fn default_mode_reports_exhaustive_false() {
+        let (pack, rt) = make_pack();
+        let registry = empty_registry();
+        let token = rt.authorize(Namespace::local()).unwrap();
+
+        let result = pack
+            .dispatch(
+                "brain.event_counts",
+                json!({"since": micros_to_iso(0)}),
+                &registry,
+                &token,
+            )
+            .await
+            .expect("brain.event_counts must succeed");
+
+        assert_eq!(result["exhaustive"], json!(false), "got: {result}");
+    }
+
     #[tokio::test]
     async fn kind_filter_scopes_counts() {
         let (pack, rt) = make_pack();
@@ -6309,6 +6643,106 @@ mod event_counts_tests {
         );
         assert_eq!(
             result["by_profile"]["unspecified"],
+            json!(1),
+            "got: {result}"
+        );
+    }
+
+    /// #34: `counts_by_signal` (flat) and `by_profile_and_signal` (crossed with
+    /// `served_by_profile_id`) let a caller compute per-seat negative-signal share
+    /// in one call, mirroring the profile-only split above.
+    #[tokio::test]
+    async fn feedback_events_split_by_signal_and_crossed_with_profile() {
+        let (pack, rt) = make_pack();
+        let registry = empty_registry();
+        let token = rt.authorize(Namespace::local()).unwrap();
+
+        seed_event(
+            &rt,
+            &token,
+            "brain.feedback",
+            EventKind::FeedbackExplicit,
+            "lambda:a",
+            1_000_000,
+            json!({"served_by_profile_id": "balanced-recall-v1", "signal": "useful"}),
+        )
+        .await;
+        seed_event(
+            &rt,
+            &token,
+            "brain.feedback",
+            EventKind::FeedbackExplicit,
+            "lambda:a",
+            1_000_000,
+            json!({"served_by_profile_id": "balanced-recall-v1", "signal": "wrong"}),
+        )
+        .await;
+        seed_event(
+            &rt,
+            &token,
+            "brain.feedback",
+            EventKind::FeedbackExplicit,
+            "lambda:a",
+            1_000_000,
+            json!({"served_by_profile_id": "khive-recall-v1", "signal": "wrong"}),
+        )
+        .await;
+        // No `signal` field at all — must fall into "unspecified", same
+        // no-drop convention as the missing-profile case above.
+        seed_event(
+            &rt,
+            &token,
+            "brain.feedback",
+            EventKind::FeedbackExplicit,
+            "lambda:a",
+            1_000_000,
+            json!({"served_by_profile_id": "balanced-recall-v1"}),
+        )
+        .await;
+
+        let result = pack
+            .dispatch(
+                "brain.event_counts",
+                json!({"since": micros_to_iso(0)}),
+                &registry,
+                &token,
+            )
+            .await
+            .expect("brain.event_counts must succeed");
+
+        assert_eq!(result["total"], json!(4));
+        assert_eq!(
+            result["counts_by_signal"]["useful"],
+            json!(1),
+            "got: {result}"
+        );
+        assert_eq!(
+            result["counts_by_signal"]["wrong"],
+            json!(2),
+            "got: {result}"
+        );
+        assert_eq!(
+            result["counts_by_signal"]["unspecified"],
+            json!(1),
+            "got: {result}"
+        );
+        assert_eq!(
+            result["by_profile_and_signal"]["balanced-recall-v1"]["useful"],
+            json!(1),
+            "got: {result}"
+        );
+        assert_eq!(
+            result["by_profile_and_signal"]["balanced-recall-v1"]["wrong"],
+            json!(1),
+            "got: {result}"
+        );
+        assert_eq!(
+            result["by_profile_and_signal"]["balanced-recall-v1"]["unspecified"],
+            json!(1),
+            "got: {result}"
+        );
+        assert_eq!(
+            result["by_profile_and_signal"]["khive-recall-v1"]["wrong"],
             json!(1),
             "got: {result}"
         );

--- a/crates/khive-pack-brain/src/tests.rs
+++ b/crates/khive-pack-brain/src/tests.rs
@@ -7089,6 +7089,36 @@ mod event_counts_tests {
             "until must be documented as optional"
         );
     }
+
+    /// Issue #14: the untruncated case is unaffected -- `total`/
+    /// `total_cost_unit` keep their existing bare names. This is the shape
+    /// every other test in this module already exercises via the real
+    /// handler (window sizes here never approach `MAX_WINDOW_EVENTS`).
+    #[test]
+    fn truncatable_total_key_is_unchanged_when_not_truncated() {
+        assert_eq!(BrainPack::truncatable_total_key("total", false), "total");
+        assert_eq!(
+            BrainPack::truncatable_total_key("total_cost_unit", false),
+            "total_cost_unit"
+        );
+    }
+
+    /// Issue #14: when the window was truncated, the misleading bare key
+    /// must never be emitted -- it is renamed to an explicitly
+    /// page-scoped/incomplete key instead, so a caller reading `total`
+    /// directly gets nothing rather than a number that may be off by an
+    /// order of magnitude.
+    #[test]
+    fn truncatable_total_key_is_renamed_when_truncated() {
+        assert_eq!(
+            BrainPack::truncatable_total_key("total", true),
+            "total_page_scoped"
+        );
+        assert_eq!(
+            BrainPack::truncatable_total_key("total_cost_unit", true),
+            "total_cost_unit_page_scoped"
+        );
+    }
 }
 
 /// #808: `brain.feedback`'s `FeedbackExplicit` event must carry the resolved

--- a/crates/khive-pack-comm/README.md
+++ b/crates/khive-pack-comm/README.md
@@ -13,7 +13,7 @@ dual-write, actor-addressed delivery.
 | `comm.read`   | Mark an inbound message as read                                    |
 | `comm.reply`  | Reply to a message, preserving thread linkage                      |
 | `comm.thread` | Retrieve all messages in a conversation thread, chronologically    |
-| `comm.probe`  | Read-only poll for new inbound message metadata and a stale unread count |
+| `comm.probe`  | Read-only poll for new inbound message metadata and a stale unread count (takes an explicit `actor`; unlike `comm.inbox`, it is not inferred from the caller) |
 
 A sixth handler, `comm.ingest`, is `Visibility::Subhandler` — it lets an
 out-of-band channel adapter (email, Telegram, etc.) write an inbound message

--- a/crates/khive-pack-comm/README.md
+++ b/crates/khive-pack-comm/README.md
@@ -1,7 +1,7 @@
 # khive-pack-comm
 
 The communication pack for khive — inter-agent messaging (`send`, `inbox`,
-`read`, `reply`, `thread`) over a dedicated `message` note kind, with
+`read`, `unread`, `reply`, `thread`) over a dedicated `message` note kind, with
 dual-write, actor-addressed delivery.
 
 ## Verbs
@@ -11,6 +11,7 @@ dual-write, actor-addressed delivery.
 | `comm.send`   | Send a message, optionally threaded                                |
 | `comm.inbox`  | List inbound messages for the caller (filter: unread / read / all) |
 | `comm.read`   | Mark an inbound message as read                                    |
+| `comm.unread` | Count the caller's unread inbound messages without message payloads |
 | `comm.reply`  | Reply to a message, preserving thread linkage                      |
 | `comm.thread` | Retrieve all messages in a conversation thread, chronologically    |
 | `comm.probe`  | Read-only poll for new inbound message metadata and a stale unread count (takes an explicit `actor`; unlike `comm.inbox`, it is not inferred from the caller) |

--- a/crates/khive-pack-comm/docs/design.md
+++ b/crates/khive-pack-comm/docs/design.md
@@ -23,6 +23,7 @@ Key design decisions from ADR-040:
   - `comm.send` — Commissive (the sender commits to delivery)
   - `comm.inbox` — Assertive (queries state)
   - `comm.read` — Declaration (changes the read/unread state)
+  - `comm.unread` — Assertive (queries state; count-only, khive #66)
   - `comm.reply` — Commissive (the sender commits to a reply)
   - `comm.thread` — Assertive (queries state)
 - **Pack-auxiliary indexes**: two partial indexes on the `notes` table (`idx_comm_message_direction`

--- a/crates/khive-pack-comm/src/handlers.rs
+++ b/crates/khive-pack-comm/src/handlers.rs
@@ -4,7 +4,7 @@
 //! `message` notes in the standard notes table. Message-specific metadata lives
 //! in the `properties` JSON column; `content` is the message body.
 
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 
 use chrono::{DateTime, Utc};
 use serde_json::{json, Value};
@@ -626,6 +626,100 @@ pub(crate) async fn handle_thread(
             json: note_to_message_json(&root_note),
         });
     }
+
+    // #94 fix 1/2 — actor visibility: mirror `handle_inbox`'s EqOrMissing model
+    // (ADR-057 Q3) instead of the unfiltered namespace-wide read `thread` had
+    // before. A caller may see a row iff they are a party to it (its sender or
+    // its addressee) or the row predates actor labeling (`to_actor` absent,
+    // back-compat visible-to-all — same rule `inbox` already applies). Before
+    // this filter, any caller who could resolve a thread id saw every actor's
+    // copies in that thread, including another actor's unread inbound state
+    // (issue #94 symptom 1/2: thread crossed the caller boundary that inbox
+    // already enforced).
+    let caller_actor = token.actor().id.clone();
+    rows.retain(|r| {
+        let props = r.json.get("properties");
+        let to_actor = props
+            .and_then(|p| p.get("to_actor"))
+            .and_then(Value::as_str);
+        let from_actor = props
+            .and_then(|p| p.get("from_actor"))
+            .and_then(Value::as_str);
+        from_actor == Some(caller_actor.as_str())
+            || to_actor.is_none()
+            || to_actor == Some(caller_actor.as_str())
+    });
+
+    // #94 fix 2/2 — collapse the ADR-057 dual-write pair (outbound copy +
+    // inbound copy) of one logical message into a single thread entry. The
+    // inbound copy's `properties.outbound_ref` names its outbound twin's
+    // note id (set by `dual_write_message`); a row without that link (a
+    // directly-ingested inbound message, or legacy data) is its own logical
+    // message. Without this, `thread` rendered both dual-write copies as two
+    // entries — a reply appeared twice with no marker distinguishing the
+    // copies (issue #94 symptom 3). The outbound copy (always the physically
+    // earlier row — `dual_write_message` creates it first) is kept as the
+    // canonical entry; the inbound twin's `read` state is folded in, since
+    // that is the only field where the two copies can differ meaningfully.
+    fn logical_id(row: &ThreadRow) -> Uuid {
+        let props = row.json.get("properties");
+        let direction = props
+            .and_then(|p| p.get("direction"))
+            .and_then(Value::as_str);
+        if direction == Some("inbound") {
+            if let Some(oref) = props
+                .and_then(|p| p.get("outbound_ref"))
+                .and_then(Value::as_str)
+            {
+                if let Ok(u) = oref.parse::<Uuid>() {
+                    return u;
+                }
+            }
+        }
+        row.full_id
+    }
+    fn is_outbound(row: &ThreadRow) -> bool {
+        row.json
+            .get("properties")
+            .and_then(|p| p.get("direction"))
+            .and_then(Value::as_str)
+            == Some("outbound")
+    }
+
+    let mut canonical_order: Vec<Uuid> = Vec::new();
+    let mut canonical: HashMap<Uuid, ThreadRow> = HashMap::new();
+    for row in rows {
+        let lid = logical_id(&row);
+        match canonical.get_mut(&lid) {
+            None => {
+                canonical_order.push(lid);
+                canonical.insert(lid, row);
+            }
+            Some(existing) => {
+                // Prefer the outbound copy as the canonical entry (earlier,
+                // and it is what `comm.send`/`comm.reply` return as `id`),
+                // but carry the inbound twin's `read` state across either way.
+                if is_outbound(&row) && !is_outbound(existing) {
+                    let read = existing.json.get("read").cloned();
+                    let mut promoted = row;
+                    if let (Some(read), Some(obj)) = (read, promoted.json.as_object_mut()) {
+                        obj.insert("read".to_string(), read);
+                    }
+                    *existing = promoted;
+                } else if !is_outbound(&row) && is_outbound(existing) {
+                    if let (Some(read), Some(obj)) =
+                        (row.json.get("read").cloned(), existing.json.as_object_mut())
+                    {
+                        obj.insert("read".to_string(), read);
+                    }
+                }
+            }
+        }
+    }
+    let mut rows: Vec<ThreadRow> = canonical_order
+        .into_iter()
+        .filter_map(|lid| canonical.remove(&lid))
+        .collect();
 
     // #494: `after` cursor — message id or RFC 3339 timestamp; a hard error if
     // neither. See crates/khive-pack-comm/docs/api/message-lifecycle.md#handlersrshandle_thread

--- a/crates/khive-pack-comm/src/handlers.rs
+++ b/crates/khive-pack-comm/src/handlers.rs
@@ -311,6 +311,43 @@ pub(crate) async fn handle_read(
         )));
     }
 
+    // #87: `read` mutates delivery state that belongs to the addressee — restrict
+    // it to the message's own `to_actor`, mirroring the strictness of the direction
+    // check above. Without this, any caller actor in the namespace could flip another
+    // actor's inbound message to read, corrupting the unread counts that fleet-wide
+    // wake/sweep logic polls. The error names only the caller's own actor, never the
+    // real addressee, so a non-addressee cannot use this to enumerate who a message
+    // was meant for.
+    //
+    // Pre-ADR-057 messages may carry no `to_actor` at all. That is treated as
+    // fail-open (with a warning), matching the inbox `EqOrMissing` filter's
+    // precedent (#199): those legacy messages are already visible to any caller via
+    // `comm.inbox` (no to_actor to filter on), so fail-closed here would leave them
+    // permanently unreadable and stuck "unread" — defeating the same wake/sweep logic
+    // this fix protects. The anonymous single-tenant default ("local") deployment is
+    // unaffected either way: caller and to_actor are both "local", so the equality
+    // check passes normally.
+    let caller_actor = token.actor().id.as_str();
+    if let Some(to_actor) = note
+        .properties
+        .as_ref()
+        .and_then(|p| p.get("to_actor"))
+        .and_then(Value::as_str)
+    {
+        if to_actor != caller_actor {
+            return Err(RuntimeError::InvalidInput(format!(
+                "read: message {id} is not addressed to caller actor {caller_actor:?}"
+            )));
+        }
+    } else {
+        tracing::warn!(
+            id = %id,
+            caller_actor = %caller_actor,
+            "comm.read: message has no `to_actor` (pre-ADR-057 legacy); allowing read \
+             without addressee verification (issue #87)"
+        );
+    }
+
     // Patch via a real `UPDATE`, not `upsert_note`'s `INSERT OR REPLACE` (#780
     // silently re-inserts the row on conflict). See docs/api/message-lifecycle.md#handlersrshandle_read
     let mut props = note.properties.clone().unwrap_or_else(|| json!({}));

--- a/crates/khive-pack-comm/src/handlers.rs
+++ b/crates/khive-pack-comm/src/handlers.rs
@@ -43,6 +43,16 @@ fn validate_actor_label(verb: &str, label: &str, field: &str) -> Result<(), Runt
 /// `send` — create a message note in the caller's namespace (outbound) AND
 /// deliver an inbound copy addressed to the actor label in `to` (ADR-057).
 /// Both copies land in the caller's namespace; no cross-namespace write occurs.
+///
+/// Known gap (external desk review, 2026-07-21): there is no idempotency
+/// guard here, so a retrying caller that repeats an identical `send` (same
+/// `to`/`content`) produces a fresh duplicate outbound+inbound pair every
+/// call. `comm.ingest`'s `external_id` dedup key is a different mechanism
+/// (transport-level dedup for channel-delivered inbound mail) and does not
+/// apply to caller-composed sends. Fixing this needs a caller-supplied
+/// idempotency key param on `SendParams` (additive) — a content-hash dedup
+/// invented here would risk collapsing legitimate repeated messages, so this
+/// is left as a design decision rather than implemented speculatively.
 /// See crates/khive-pack-comm/docs/api/message-lifecycle.md#handlersrshandle_send
 pub(crate) async fn handle_send(
     runtime: &KhiveRuntime,

--- a/crates/khive-pack-comm/src/handlers.rs
+++ b/crates/khive-pack-comm/src/handlers.rs
@@ -17,7 +17,7 @@ use khive_storage::types::{PageRequest, SqlValue};
 use crate::message::{dual_write_message, note_to_message_json, resolve_id, short_id};
 use crate::params::{
     deser, CursorCommitParams, CursorGetParams, HeartbeatParams, InboxParams, IngestParams,
-    ProbeParams, ReadParams, ReplyParams, SendParams, ThreadParams,
+    ProbeParams, ReadParams, ReplyParams, SendParams, ThreadParams, UnreadParams,
 };
 
 /// Validate an actor label: non-empty, no control characters, ≤255 bytes (ADR-057 Q1 loose).
@@ -150,7 +150,8 @@ pub(crate) async fn handle_inbox(
     let p: InboxParams = deser(params)?;
     let raw_limit = p.limit.unwrap_or(20);
     if raw_limit == 0 {
-        return Ok(json!({ "messages": [], "count": 0 }));
+        let unread_count = count_unread_messages(runtime, token, &token.actor().id).await?;
+        return Ok(json!({ "messages": [], "count": 0, "unread_count": unread_count }));
     }
     let limit = raw_limit.clamp(1, 200) as usize;
 
@@ -265,7 +266,96 @@ pub(crate) async fn handle_inbox(
         page.items.iter().map(note_to_message_json).collect()
     };
     let count = messages.len();
-    Ok(json!({ "messages": messages, "count": count }))
+    // #66: cheap derived stat over the page already fetched above — no extra
+    // DB round-trip. For `status="unread"` every returned message is unread
+    // by definition, so this equals `count`; for `"read"`/`"all"` it counts
+    // however many of the *returned* rows are unread (not a global total —
+    // `comm.unread` is the verb for that).
+    let unread_count = messages
+        .iter()
+        .filter(|m| !m["read"].as_bool().unwrap_or(false))
+        .count();
+    Ok(json!({ "messages": messages, "count": count, "unread_count": unread_count }))
+}
+
+/// `unread` — count-only view of the caller's unread inbound messages (#66):
+/// same filter stack as `inbox(status="unread")`.
+///
+/// `NoteStore` has no filtered `COUNT(*)` projection (only `count_notes`,
+/// which counts a whole namespace/kind with no property filter) — adding one
+/// is an OSS `khive-storage` change, out of scope here. This pages through
+/// `query_notes_filtered` the same way `handle_inbox`'s `#493` from_actor/
+/// from_prefix path already does, summing page lengths instead of fetching a
+/// bounded `limit` of full payloads — heavier than a real `COUNT(*)` but
+/// correct, and consistent with the pagination style already in this file.
+pub(crate) async fn handle_unread(
+    runtime: &KhiveRuntime,
+    token: &NamespaceToken,
+    params: Value,
+) -> Result<Value, RuntimeError> {
+    let _: UnreadParams = deser(params)?;
+    let caller_actor = token.actor().id.clone();
+    let count = count_unread_messages(runtime, token, &caller_actor).await?;
+
+    Ok(json!({ "count": count, "actor": caller_actor }))
+}
+
+async fn count_unread_messages(
+    runtime: &KhiveRuntime,
+    token: &NamespaceToken,
+    caller_actor: &str,
+) -> Result<u64, RuntimeError> {
+    let property_filters = vec![
+        PropertyFilter {
+            json_path: "$.direction".to_string(),
+            op: FilterOp::Eq,
+            value: SqlValue::Text("inbound".to_string()),
+        },
+        PropertyFilter {
+            json_path: "$.read".to_string(),
+            op: FilterOp::JsonTypeNeMissing,
+            value: SqlValue::Text("true".to_string()),
+        },
+        // ADR-057 Q3: EqOrMissing so legacy to_actor-less messages still count
+        // (same visibility rule `inbox` applies).
+        PropertyFilter {
+            json_path: "$.to_actor".to_string(),
+            op: FilterOp::EqOrMissing,
+            value: SqlValue::Text(caller_actor.to_string()),
+        },
+    ];
+
+    let filter = NoteFilter {
+        kind: Some("message".to_string()),
+        property_filters,
+        order_by: None,
+        ..Default::default()
+    };
+    let store = runtime.notes(token)?;
+
+    const PAGE_SIZE: u32 = 200;
+    let mut count: u64 = 0;
+    let mut db_offset: u32 = 0;
+    loop {
+        let page = store
+            .query_notes_filtered(
+                token.namespace().as_str(),
+                &filter,
+                PageRequest {
+                    limit: PAGE_SIZE,
+                    offset: db_offset.into(),
+                },
+            )
+            .await?;
+        let fetched = page.items.len() as u32;
+        count += u64::from(fetched);
+        if fetched < PAGE_SIZE {
+            break;
+        }
+        db_offset += PAGE_SIZE;
+    }
+
+    Ok(count)
 }
 
 /// `read` — mark a message as read.
@@ -431,6 +521,41 @@ pub(crate) async fn handle_reply(
         .get("to_actor")
         .and_then(Value::as_str)
         .map(|s| s.to_string());
+
+    // #113: sibling of #87 — `reply` never checked who the caller is, so a
+    // caller holding a message id could reply to a message addressed to a
+    // different actor entirely (the reply then routes via the "other party"
+    // logic below, which assumes the caller IS one of the two parties). The
+    // rule chosen is thread-participant, not addressee-only: either party to
+    // the exchange (the addressee or the original sender) may reply, mirroring
+    // #94's thread-visibility filter rather than #87's stricter read-only
+    // rule — a reply from either party is a normal continuation of the
+    // exchange, unlike a third party silently flipping delivery state. #85's
+    // read-mark scoping at `d782709` closed the read-state side of this hole;
+    // the reply itself was still open.
+    //
+    // Fail open only when the original carries neither `to_actor` nor
+    // `from_actor` (pre-ADR-057 legacy — no attributed party to restrict
+    // against, matching #87/#94's rule for such rows). An unattributed caller
+    // is still actor `local`, so it may reply to local party-line messages but
+    // not messages attributed to other participants.
+    if original_to_actor.is_some() || original_from_actor.is_some() {
+        let caller_actor = token.actor().id.as_str();
+        let is_participant = original_from_actor.as_deref() == Some(caller_actor)
+            || original_to_actor.as_deref() == Some(caller_actor);
+        if !is_participant {
+            return Err(RuntimeError::InvalidInput(format!(
+                "reply: message {id} is not addressed to or from caller actor {caller_actor:?}"
+            )));
+        }
+    } else {
+        tracing::warn!(
+            id = %id,
+            caller_actor = %token.actor().id,
+            "comm.reply: message has no `to_actor`/`from_actor` (pre-ADR-057 legacy); \
+             allowing reply without participant verification (issue #113)"
+        );
+    }
 
     let original_from = original_from_actor
         .as_deref()

--- a/crates/khive-pack-comm/src/handlers.rs
+++ b/crates/khive-pack-comm/src/handlers.rs
@@ -621,6 +621,54 @@ pub(crate) async fn handle_reply(
     )
     .await?;
 
+    // Replying is the strongest possible read signal, and callers universally
+    // chained `reply | read` to say so — fold it in. Skips only an explicitly
+    // outbound original, matching handle_read's rejection exactly rather than
+    // requiring a literal "inbound" (legacy messages may carry no direction).
+    // Best-effort: the reply is already committed above, so a failed or
+    // no-op patch degrades to `marked_read: false` rather than failing a
+    // delivered reply.
+    //
+    // The mark is also addressee-scoped: "I read it" is only a claim the
+    // addressee can make. Replying does not give a third party the right to
+    // flip someone else's message, which is the same rule handle_read
+    // enforces. A legacy original with no `to_actor` fails open, matching
+    // handle_inbox's EqOrMissing visibility — a message anyone can see in
+    // their inbox must stay markable by someone, or it inflates unread
+    // counts forever.
+    let original_direction = orig_props
+        .get("direction")
+        .and_then(Value::as_str)
+        .unwrap_or("");
+    let caller_is_addressee = original_to_actor
+        .as_deref()
+        .is_none_or(|addressee| addressee == from_actor_label);
+    let marked_read = if original_direction == "outbound" || !caller_is_addressee {
+        None
+    } else {
+        // Re-fetch: `orig_props` predates the dual write above, so writing it
+        // back wholesale would erase any property another writer set in that
+        // window (the store replaces `properties`, it does not merge).
+        let current = store
+            .get_note(id)
+            .await
+            .ok()
+            .flatten()
+            .and_then(|n| n.properties)
+            .unwrap_or_else(|| orig_props.clone());
+        let mut props = current;
+        props["read"] = json!(true);
+        let updated_at = Utc::now().timestamp_micros();
+        // `Ok(false)` means no live row was updated (e.g. the original was
+        // soft-deleted mid-flight) — that is not a successful mark.
+        Some(
+            store
+                .update_note_properties(id, Some(props), updated_at)
+                .await
+                .unwrap_or(false),
+        )
+    };
+
     Ok(json!({
         "id": short_id(reply_note.id),
         "full_id": reply_note.id.as_hyphenated().to_string(),
@@ -629,6 +677,7 @@ pub(crate) async fn handle_reply(
         "to": reply_to,
         "subject": reply_subject,
         "sent_at": sent_at,
+        "marked_read": marked_read,
     }))
 }
 

--- a/crates/khive-pack-comm/src/message.rs
+++ b/crates/khive-pack-comm/src/message.rs
@@ -117,6 +117,18 @@ fn build_preview(content: &str) -> String {
 /// namespace), rolling back the outbound note if the inbound write fails
 /// (atomicity guarantee). Returns the outbound `Note` on success.
 ///
+/// Known gap (external desk review, 2026-07-21): the two `create_note` calls
+/// below are not wrapped in one DB transaction, so a process crash between
+/// them (as opposed to an in-process error, which the rollback above already
+/// handles) can still leave a durable orphan outbound note with no inbound
+/// copy. `khive-runtime` exposes a lower-level atomic primitive
+/// (`run_atomic_unit`/`AtomicOpPlan::AddNote`) that spans one transaction, but
+/// it bypasses `create_note_inner`'s FTS/embedding/decay handling, so using it
+/// here would require re-deriving that logic at the pack layer rather than
+/// wrapping the existing calls. Blocked on `khive-runtime` exposing a
+/// transaction-scoped `create_note` equivalent; not safe to hack around from
+/// this crate.
+///
 /// Invariant: when `thread_id` is `None` (root send), both copies are patched
 /// to share the sender's outbound UUID as their canonical `thread_id`, so
 /// `comm.thread` finds replies regardless of which copy they replied to. When

--- a/crates/khive-pack-comm/src/pack.rs
+++ b/crates/khive-pack-comm/src/pack.rs
@@ -88,6 +88,7 @@ impl PackRuntime for CommPack {
             "comm.send" => handlers::handle_send(self.runtime(), token, params).await,
             "comm.inbox" => handlers::handle_inbox(self.runtime(), token, params).await,
             "comm.read" => handlers::handle_read(self.runtime(), token, params).await,
+            "comm.unread" => handlers::handle_unread(self.runtime(), token, params).await,
             "comm.reply" => handlers::handle_reply(self.runtime(), token, params).await,
             "comm.thread" => handlers::handle_thread(self.runtime(), token, params).await,
             "comm.ingest" => handlers::handle_ingest(self.runtime(), token, params).await,
@@ -245,10 +246,8 @@ mod help_tests {
 
     #[test]
     fn all_comm_handlers_have_non_empty_params() {
-        // comm.health is a legitimate no-args verb (khive #606 design review: "read-only,
-        // NO args") -- same shape as kg's `stats()`. Every other comm verb takes at
-        // least one param, so the invariant still holds for the rest.
-        const NO_ARGS_VERBS: &[&str] = &["comm.health"];
+        // comm.health and caller-scoped comm.unread are legitimate no-args verbs.
+        const NO_ARGS_VERBS: &[&str] = &["comm.health", "comm.unread"];
         for handler in CommPack::HANDLERS {
             if NO_ARGS_VERBS.contains(&handler.name) {
                 assert!(

--- a/crates/khive-pack-comm/src/pack.rs
+++ b/crates/khive-pack-comm/src/pack.rs
@@ -204,6 +204,27 @@ mod help_tests {
         assert!(id.required, "read.id must be required");
     }
 
+    /// #93 instance 3: the top-level description must not contradict `actor`
+    /// being a required, non-inferred param — a caller reading only the
+    /// one-line description (not the full param list) must not be misled
+    /// into calling `comm.probe()` the way it can call `comm.inbox()`.
+    #[test]
+    fn probe_description_documents_required_actor() {
+        let h = find_handler("comm.probe");
+        assert!(
+            h.description.contains("actor") && h.description.contains("required"),
+            "comm.probe's top-level description must state that `actor` is \
+             required and not inferred from the caller (issue #93); got: {:?}",
+            h.description
+        );
+        let actor = h
+            .params
+            .iter()
+            .find(|p| p.name == "actor")
+            .expect("probe must have 'actor'");
+        assert!(actor.required, "probe.actor must be required");
+    }
+
     #[test]
     fn reply_has_required_id_and_content() {
         let h = find_handler("comm.reply");

--- a/crates/khive-pack-comm/src/params.rs
+++ b/crates/khive-pack-comm/src/params.rs
@@ -48,6 +48,10 @@ pub(crate) struct ReadParams {
 
 #[derive(Deserialize)]
 #[serde(deny_unknown_fields)]
+pub(crate) struct UnreadParams {}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
 pub(crate) struct ReplyParams {
     pub id: String,
     pub content: String,

--- a/crates/khive-pack-comm/src/vocab.rs
+++ b/crates/khive-pack-comm/src/vocab.rs
@@ -367,7 +367,9 @@ pub(crate) static COMM_HANDLERS: [HandlerDef; 11] = [
     },
     HandlerDef {
         name: "comm.probe",
-        description: "Read-only poll for new inbound message metadata and stale unread count.",
+        description: "Read-only poll for new inbound message metadata and stale unread count. \
+                      Unlike comm.inbox, the actor is not inferred from the caller — pass it \
+                      explicitly via the required `actor` param (khive #93).",
         visibility: Visibility::Verb,
         category: khive_types::VerbCategory::Assertive,
         params: &[

--- a/crates/khive-pack-comm/src/vocab.rs
+++ b/crates/khive-pack-comm/src/vocab.rs
@@ -38,7 +38,7 @@ pub(crate) const COMM_CHANNEL_CURSOR_SCHEMA_STMT: &str =
     PRIMARY KEY (channel_kind, channel_slug)\
 )";
 
-pub(crate) static COMM_HANDLERS: [HandlerDef; 11] = [
+pub(crate) static COMM_HANDLERS: [HandlerDef; 12] = [
     HandlerDef {
         name: "comm.send",
         description: "Send a message, optionally threaded.",
@@ -126,6 +126,13 @@ pub(crate) static COMM_HANDLERS: [HandlerDef; 11] = [
             required: true,
             description: "Short 8-char prefix or full UUID of the inbound message to mark read. Outbound messages cannot be marked read.",
         }],
+    },
+    HandlerDef {
+        name: "comm.unread",
+        description: "Count-only view of the caller's unread inbound messages (same filter as inbox(status=\"unread\"), no message payloads).",
+        visibility: Visibility::Verb,
+        category: khive_types::VerbCategory::Assertive,
+        params: &[],
     },
     HandlerDef {
         name: "comm.reply",

--- a/crates/khive-pack-comm/tests/integration.rs
+++ b/crates/khive-pack-comm/tests/integration.rs
@@ -1131,6 +1131,184 @@ async fn test_read_rejects_outbound_message() {
     );
 }
 
+// ── #87 regression: read() is restricted to the message's addressee ─────────
+
+/// A caller whose actor label does not match a message's `to_actor` must not be
+/// able to flip it to read — read-state is delivery state owned by the addressee.
+/// The message must stay unread after the rejected attempt.
+#[tokio::test]
+async fn t87_non_addressee_read_rejected_and_stays_unread() {
+    let backend = shared_backend();
+    let (registry_a, _rt_a) = build_actor_registry(backend.clone(), "lambda:a");
+    let (registry_b, rt_b) = build_actor_registry(backend.clone(), "lambda:b");
+
+    registry_a
+        .dispatch(
+            "comm.send",
+            serde_json::json!({ "to": "lambda:b", "content": "for B's eyes only" }),
+        )
+        .await
+        .expect("A sends to B");
+
+    let local_tok = rt_b.authorize(Namespace::parse("local").unwrap()).unwrap();
+    let notes = rt_b
+        .list_notes(&local_tok, Some("message"), 100, 0)
+        .await
+        .unwrap();
+    let inbound_id = notes
+        .iter()
+        .find(|n| {
+            n.deleted_at.is_none()
+                && n.properties
+                    .as_ref()
+                    .and_then(|p| p.get("direction"))
+                    .and_then(|v| v.as_str())
+                    == Some("inbound")
+        })
+        .map(|n| n.id.as_hyphenated().to_string())
+        .expect("inbound copy addressed to lambda:b must exist");
+
+    // A (not the addressee) attempts to mark B's inbound message as read.
+    let result = registry_a
+        .dispatch("comm.read", serde_json::json!({ "id": inbound_id }))
+        .await;
+    assert!(
+        result.is_err(),
+        "#87: non-addressee read must be rejected; got {result:?}"
+    );
+    let err_msg = format!("{}", result.unwrap_err());
+    assert!(
+        err_msg.contains("lambda:a") && !err_msg.contains("lambda:b"),
+        "#87: error must name only the caller's own actor, never the real \
+         addressee; got {err_msg:?}"
+    );
+
+    // The message must remain unread.
+    let refetched = rt_b
+        .list_notes(&local_tok, Some("message"), 100, 0)
+        .await
+        .unwrap();
+    let still_unread = refetched
+        .iter()
+        .find(|n| n.id.as_hyphenated().to_string() == inbound_id)
+        .and_then(|n| n.properties.as_ref())
+        .and_then(|p| p.get("read"))
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false);
+    assert!(
+        !still_unread,
+        "#87: message must stay unread after a rejected non-addressee read attempt"
+    );
+
+    // B (the true addressee) can still mark it read.
+    let ok = registry_b
+        .dispatch("comm.read", serde_json::json!({ "id": inbound_id }))
+        .await
+        .expect("#87: addressee read must still succeed");
+    assert_eq!(
+        ok.get("read").and_then(|v| v.as_bool()),
+        Some(true),
+        "#87: addressee read must return read:true; got {ok}"
+    );
+}
+
+/// The anonymous/"local" single-actor deployment (no actor.id configured) must keep
+/// working: caller and to_actor both resolve to "local", so the equality check passes.
+#[tokio::test]
+async fn t87_anonymous_local_single_actor_read_still_works() {
+    let (registry, rt) = build_registry_for_ns("local");
+
+    registry
+        .dispatch(
+            "comm.send",
+            serde_json::json!({ "to": "local", "content": "single-tenant read" }),
+        )
+        .await
+        .expect("send succeeds");
+
+    let caller_token = rt
+        .authorize(khive_runtime::Namespace::parse("local").unwrap())
+        .unwrap();
+    let notes = rt
+        .list_notes(&caller_token, Some("message"), 100, 0)
+        .await
+        .unwrap();
+    let inbound_full_id = notes
+        .iter()
+        .find(|n| {
+            n.deleted_at.is_none()
+                && n.properties
+                    .as_ref()
+                    .and_then(|p| p.get("direction"))
+                    .and_then(|v| v.as_str())
+                    == Some("inbound")
+        })
+        .expect("inbound copy must exist after self-send")
+        .id
+        .to_string();
+
+    let result = registry
+        .dispatch("comm.read", serde_json::json!({ "id": inbound_full_id }))
+        .await
+        .expect("#87: anonymous single-actor 'local' read must still succeed");
+    assert_eq!(
+        result.get("read").and_then(|v| v.as_bool()),
+        Some(true),
+        "#87: read returns read:true — got {result}"
+    );
+}
+
+/// Pre-ADR-057 legacy messages may carry no `to_actor` at all. Decision: fail-open
+/// (with a tracing warning) — mirrors the inbox `EqOrMissing` filter precedent (#199),
+/// where legacy to_actor-less messages stay visible to any caller. Failing closed here
+/// would leave such messages permanently unreadable and stuck "unread", defeating the
+/// unread-based wake/sweep logic this fix protects.
+#[tokio::test]
+async fn t87_legacy_message_without_to_actor_reads_fail_open() {
+    let (_registry, rt) = build_registry_for_ns("lambda:legacy");
+    let token = rt
+        .authorize(khive_runtime::Namespace::parse("local").unwrap())
+        .unwrap();
+
+    // Simulate a pre-ADR-057 row: kind=message, direction=inbound, no `to_actor` field.
+    let legacy_note = rt
+        .create_note(
+            &token,
+            "message",
+            None,
+            "legacy inbound, no to_actor",
+            None,
+            Some(serde_json::json!({
+                "from": "someone",
+                "to": "lambda:legacy",
+                "direction": "inbound",
+            })),
+            vec![],
+        )
+        .await
+        .expect("legacy note creation succeeds");
+
+    let mut builder = VerbRegistryBuilder::new();
+    builder.register(khive_pack_kg::KgPack::new(rt.clone()));
+    builder.register(CommPack::new(rt.clone()));
+    builder.with_default_namespace("local");
+    builder.with_actor_id(Some("lambda:legacy".to_string()));
+    let registry = builder.build().expect("registry builds");
+
+    let result = registry
+        .dispatch(
+            "comm.read",
+            serde_json::json!({ "id": legacy_note.id.as_hyphenated().to_string() }),
+        )
+        .await
+        .expect("#87: legacy message without to_actor must fail open on read");
+    assert_eq!(
+        result.get("read").and_then(|v| v.as_bool()),
+        Some(true),
+        "#87: legacy to_actor-less read returns read:true — got {result}"
+    );
+}
+
 // ── H3 regression: thread verb is registered and returns thread messages ──────
 
 /// thread(id=X) must return all messages in the thread in chronological order.

--- a/crates/khive-pack-comm/tests/integration.rs
+++ b/crates/khive-pack-comm/tests/integration.rs
@@ -6202,9 +6202,11 @@ async fn t494_thread_default_order_truncates_head_unchanged() {
             .unwrap_or_else(|e| panic!("reply-{i} succeeds: {e:?}"));
     }
 
-    // 5 logical messages (root + 4 replies) = 10 physical notes (outbound+inbound
-    // pairs). limit=2 with no order= must return the OLDEST 2 physical notes —
-    // both copies of "root" — matching pre-#494 truncate-from-head behavior.
+    // 5 logical messages (root + 4 replies), each an ADR-057 dual-write pair
+    // (outbound+inbound) collapsed by #94's dedup fix into ONE thread entry
+    // per logical message. limit=2 with no order= must return the OLDEST 2
+    // logical messages: root, reply-1 — no duplicate "root" entry anymore
+    // (pre-#94-fix behavior returned both physical copies of "root").
     let result = registry
         .dispatch(
             "comm.thread",
@@ -6220,8 +6222,9 @@ async fn t494_thread_default_order_truncates_head_unchanged() {
         .collect();
     assert_eq!(
         contents,
-        vec!["root", "root"],
-        "default order must truncate from the tail (keep the head), unchanged from before #494"
+        vec!["root", "reply-1"],
+        "default order must truncate from the tail (keep the head), one entry per \
+         logical message post-#94 dedup"
     );
 }
 
@@ -6265,9 +6268,10 @@ async fn t494_thread_order_desc_returns_newest_messages() {
         .collect();
     assert_eq!(
         contents,
-        vec!["reply-4", "reply-4"],
-        "order=desc + limit=2 must return the newest 2 physical notes — both copies \
-         of the last reply — not the oldest (#494 fix: the tail is now reachable)"
+        vec!["reply-4", "reply-3"],
+        "order=desc + limit=2 must return the newest 2 logical messages — not the \
+         oldest (#494 fix: the tail is now reachable), one entry per logical message \
+         post-#94 dedup (no duplicate 'reply-4' entry)"
     );
 }
 
@@ -6304,9 +6308,10 @@ async fn t494_thread_invalid_order_rejected() {
 
 /// `after` accepts a message id cursor and returns only messages strictly after it
 /// (enables incremental polling without re-fetching history). The cursor resolves
-/// to the OUTBOUND copy's `full_id` (what `comm.reply` returns); its own inbound
-/// copy — created a moment later in the same dual-write call — is strictly after
-/// it and so is included.
+/// to the OUTBOUND copy's `full_id` (what `comm.reply` returns), which post-#94 is
+/// also the canonical id of the "reply-1" logical message itself — so it is
+/// excluded by the strict `>` comparison, and there is nothing after it (reply-1
+/// was the last message sent).
 #[tokio::test]
 async fn t494_thread_after_id_cursor_returns_strictly_later_messages() {
     let (registry, _rt) = build_registry_for_ns("local");
@@ -6346,9 +6351,9 @@ async fn t494_thread_after_id_cursor_returns_strictly_later_messages() {
         .collect();
     assert_eq!(
         contents,
-        vec!["reply-1"],
-        "after=reply-1's outbound id must return only its own inbound copy \
-         (strictly later), excluding root and reply-1's own outbound copy; got {contents:?}"
+        Vec::<&str>::new(),
+        "after=reply-1's own canonical (outbound) id excludes reply-1 itself post-#94 \
+         dedup, and reply-1 was the last message sent, so nothing remains; got {contents:?}"
     );
 }
 
@@ -6574,11 +6579,11 @@ async fn t494_thread_order_desc_with_after_id_cursor_returns_strictly_older_in_d
 
     // `comm.send(to="local", ...)` is a self-send: ADR-057 dual-write stores
     // both an outbound and an inbound copy of "root", both real-clock (and so
-    // both strictly older than the synthetic 2099 timestamps). Full desc
-    // sequence is therefore [msg-c, msg-b, msg-a, root, root]. `after=msg-b`
-    // must return only what comes strictly after it in THAT sequence —
-    // msg-a and both root copies — never msg-c, even though msg-c is also
-    // `>` msg-b in wall-clock terms.
+    // both strictly older than the synthetic 2099 timestamps) — collapsed by
+    // #94's dedup fix into a single "root" thread entry. Full desc sequence
+    // is therefore [msg-c, msg-b, msg-a, root]. `after=msg-b` must return
+    // only what comes strictly after it in THAT sequence — msg-a and root —
+    // never msg-c, even though msg-c is also `>` msg-b in wall-clock terms.
     let result = registry
         .dispatch(
             "comm.thread",
@@ -6594,15 +6599,16 @@ async fn t494_thread_order_desc_with_after_id_cursor_returns_strictly_older_in_d
         .collect();
     assert_eq!(
         contents,
-        vec!["msg-a", "root", "root"],
+        vec!["msg-a", "root"],
         "order=desc + after=msg-b must return only rows strictly older than msg-b \
-         (further along the desc sequence), in desc order — both self-send root \
-         copies included, msg-c excluded; got {contents:?}"
+         (further along the desc sequence), in desc order — one 'root' entry \
+         post-#94 dedup, msg-c excluded; got {contents:?}"
     );
 }
 
-/// Absent `order`/`after` preserves today's behavior exactly: same messages, same order,
-/// same truncation as before #494 (regression guard alongside the existing #485 test).
+/// Absent `order`/`after` preserves the #494 ordering/truncation behavior; the message
+/// count itself changed under #94's dedup fix (one entry per logical message, not one
+/// per ADR-057 dual-write physical copy) — see the updated assertions below.
 #[tokio::test]
 async fn t494_thread_without_new_params_unchanged() {
     let (registry, _rt) = build_registry_for_ns("local");
@@ -6631,14 +6637,202 @@ async fn t494_thread_without_new_params_unchanged() {
     let msgs = result["messages"].as_array().expect("messages array");
     assert_eq!(
         msgs.len(),
-        4,
-        "root (outbound+inbound) + reply-1 (outbound+inbound) = 4 physical notes"
+        2,
+        "root + reply-1 = 2 logical messages post-#94 dedup (each was an ADR-057 \
+         dual-write outbound+inbound pair, now collapsed to one thread entry)"
     );
     let contents: Vec<&str> = msgs
         .iter()
         .map(|m| m["content"].as_str().unwrap_or(""))
         .collect();
-    assert_eq!(contents, vec!["root", "root", "reply-1", "reply-1"]);
+    assert_eq!(contents, vec!["root", "reply-1"]);
+}
+
+// ── #94: dual-write dedup + actor-scoped thread visibility ───────────────────
+
+/// Full round trip: A sends to B, B replies, A replies again. `comm.thread`
+/// must return exactly 3 logical messages (not 6 ADR-057 dual-write physical
+/// copies), in chronological order, each attributed to the actor that
+/// actually sent it, with no duplicate entries (issue #94 symptom 3).
+#[tokio::test]
+async fn t94_thread_round_trip_returns_deduped_logical_messages() {
+    let backend = shared_backend();
+    let (registry_a, _rt_a) = build_actor_registry(backend.clone(), "lambda:a");
+    let (registry_b, _rt_b) = build_actor_registry(backend.clone(), "lambda:b");
+
+    // 1. A -> B.
+    let sent = registry_a
+        .dispatch(
+            "comm.send",
+            serde_json::json!({ "to": "lambda:b", "content": "hello from A" }),
+        )
+        .await
+        .expect("A sends to B");
+    let root_id = sent["full_id"].as_str().expect("full_id").to_string();
+
+    // 2. B finds it in inbox and replies.
+    let b_inbox = registry_b
+        .dispatch(
+            "comm.inbox",
+            serde_json::json!({ "status": "all", "limit": 10 }),
+        )
+        .await
+        .expect("B inbox");
+    let b_msgs = b_inbox["messages"].as_array().expect("messages");
+    assert_eq!(b_msgs.len(), 1, "B sees exactly 1 inbound message");
+    let b_inbound_id = b_msgs[0]["full_id"].as_str().expect("full_id").to_string();
+    registry_b
+        .dispatch(
+            "comm.reply",
+            serde_json::json!({ "id": b_inbound_id, "content": "reply from B" }),
+        )
+        .await
+        .expect("B replies");
+
+    // 3. A finds B's reply in inbox and replies again.
+    let a_inbox = registry_a
+        .dispatch(
+            "comm.inbox",
+            serde_json::json!({ "status": "all", "limit": 10 }),
+        )
+        .await
+        .expect("A inbox");
+    let a_msgs = a_inbox["messages"].as_array().expect("messages");
+    assert_eq!(a_msgs.len(), 1, "A sees exactly B's reply");
+    let a_inbound_id = a_msgs[0]["full_id"].as_str().expect("full_id").to_string();
+    registry_a
+        .dispatch(
+            "comm.reply",
+            serde_json::json!({ "id": a_inbound_id, "content": "reply from A again" }),
+        )
+        .await
+        .expect("A replies again");
+
+    // 4. thread() must show exactly 3 logical messages, in order, correctly
+    // attributed, with no duplicates — from either party's point of view.
+    let thread = registry_a
+        .dispatch("comm.thread", serde_json::json!({ "id": root_id }))
+        .await
+        .expect("A reads the thread");
+    let count = thread["count"].as_u64().expect("count");
+    assert_eq!(
+        count, 3,
+        "3 logical messages (not 6 dual-write physical copies); got {thread}"
+    );
+    let msgs = thread["messages"].as_array().expect("messages array");
+    let contents: Vec<&str> = msgs
+        .iter()
+        .map(|m| m["content"].as_str().unwrap_or(""))
+        .collect();
+    assert_eq!(
+        contents,
+        vec!["hello from A", "reply from B", "reply from A again"],
+        "messages in chronological order with no duplicates; got {contents:?}"
+    );
+    let from_actors: Vec<&str> = msgs
+        .iter()
+        .map(|m| m["from"].as_str().unwrap_or(""))
+        .collect();
+    assert_eq!(
+        from_actors,
+        vec!["lambda:a", "lambda:b", "lambda:a"],
+        "each entry attributed to the actor that actually sent it; got {from_actors:?}"
+    );
+
+    // B's view must match exactly — the same 3 deduped, correctly attributed entries.
+    let thread_from_b = registry_b
+        .dispatch("comm.thread", serde_json::json!({ "id": root_id }))
+        .await
+        .expect("B reads the thread");
+    assert_eq!(thread_from_b["count"].as_u64().unwrap_or(0), 3);
+}
+
+/// A message addressed to one actor pair must not be visible to an unrelated
+/// third actor who merely knows (or can resolve) the thread's root id — the
+/// caller-boundary gap between `thread` (previously unfiltered by actor) and
+/// `inbox` (already actor-scoped) from issue #94 symptom 1/2.
+#[tokio::test]
+async fn t94_thread_excludes_messages_not_addressed_to_or_from_caller() {
+    let backend = shared_backend();
+    let (registry_a, _rt_a) = build_actor_registry(backend.clone(), "lambda:a");
+    let (registry_c, _rt_c) = build_actor_registry(backend, "lambda:c");
+
+    let sent = registry_a
+        .dispatch(
+            "comm.send",
+            serde_json::json!({ "to": "lambda:b", "content": "private to B" }),
+        )
+        .await
+        .expect("A sends to B");
+    let root_id = sent["full_id"].as_str().expect("full_id").to_string();
+
+    // C is neither the sender nor the addressee of any row in this thread, even
+    // though C shares the same namespace and can resolve the root id.
+    let thread_from_c = registry_c
+        .dispatch("comm.thread", serde_json::json!({ "id": root_id }))
+        .await
+        .expect("C can resolve the root id but must see zero messages");
+    assert_eq!(
+        thread_from_c["count"].as_u64().unwrap_or(99),
+        0,
+        "an actor who is neither sender nor addressee must see zero thread messages \
+         (issue #94: thread previously exposed every actor's copies unfiltered); \
+         got {thread_from_c}"
+    );
+
+    // A, the actual sender, still sees it.
+    let thread_from_a = registry_a
+        .dispatch("comm.thread", serde_json::json!({ "id": root_id }))
+        .await
+        .expect("A reads own thread");
+    assert_eq!(thread_from_a["count"].as_u64().unwrap_or(0), 1);
+}
+
+/// A legacy message note lacking `to_actor` (pre-ADR-057 data, or directly
+/// store-inserted content) must remain visible via `comm.thread`'s actor
+/// scoping — the same EqOrMissing rule `comm.inbox` already applies for
+/// exactly this shape (ADR-057 Q3).
+#[tokio::test]
+async fn t94_thread_legacy_message_without_to_actor_stays_visible() {
+    let (registry, rt) = build_registry_for_ns("local");
+
+    let root = registry
+        .dispatch(
+            "comm.send",
+            serde_json::json!({ "to": "local", "content": "root" }),
+        )
+        .await
+        .expect("root send succeeds");
+    let root_full_id = root["full_id"].as_str().expect("root full_id").to_string();
+    let root_uuid = uuid::Uuid::parse_str(&root_full_id).unwrap();
+
+    // insert_thread_message stores only `from`/`to` (no from_actor/to_actor) —
+    // exactly the legacy shape this test guards.
+    let legacy_id = uuid::Uuid::new_v4();
+    insert_thread_message(
+        &rt,
+        "local",
+        legacy_id,
+        root_uuid,
+        chrono::Utc::now().timestamp_micros(),
+        "legacy no-to_actor",
+    )
+    .await;
+
+    let thread = registry
+        .dispatch("comm.thread", serde_json::json!({ "id": root_full_id }))
+        .await
+        .expect("thread succeeds");
+    let contents: Vec<&str> = thread["messages"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|m| m["content"].as_str().unwrap_or(""))
+        .collect();
+    assert!(
+        contents.contains(&"legacy no-to_actor"),
+        "a message without to_actor must stay visible (EqOrMissing); got {contents:?}"
+    );
 }
 
 // ── #495: comm.send / comm.reply metadata (tags) passthrough ────────────────

--- a/crates/khive-pack-comm/tests/integration.rs
+++ b/crates/khive-pack-comm/tests/integration.rs
@@ -43,14 +43,18 @@ fn comm_pack_declares_message_note_kind() {
 fn comm_pack_declares_nine_handlers() {
     assert_eq!(
         CommPack::HANDLERS.len(),
-        11,
-        "comm pack must declare 11 handlers: send, inbox, read, reply, thread, ingest, \
-         heartbeat, health, probe, cursor_get, cursor_commit (khive #449)"
+        12,
+        "comm pack must declare 12 handlers: send, inbox, read, unread, reply, thread, \
+         ingest, heartbeat, health, probe, cursor_get, cursor_commit (khive #449, #66)"
     );
     let names: Vec<&str> = CommPack::HANDLERS.iter().map(|h| h.name).collect();
     assert!(names.contains(&"comm.send"));
     assert!(names.contains(&"comm.inbox"));
     assert!(names.contains(&"comm.read"));
+    assert!(
+        names.contains(&"comm.unread"),
+        "comm.unread verb must be registered (khive #66)"
+    );
     assert!(names.contains(&"comm.reply"));
     assert!(
         names.contains(&"comm.thread"),
@@ -4567,7 +4571,7 @@ async fn reply_and_get_outbound_props(
 /// The reply must read `wire_message_id` and wrap it for the wire.
 #[tokio::test]
 async fn reply_sets_in_reply_to_for_inbound_originated_parent() {
-    let (registry, rt) = build_registry_for_ns("local");
+    let (registry, rt) = build_actor_registry(shared_backend(), "lambda:khive");
 
     let parent_id = plant_message_note(
         &rt,
@@ -4603,7 +4607,7 @@ async fn reply_sets_in_reply_to_for_inbound_originated_parent() {
 /// reply must reuse it verbatim.
 #[tokio::test]
 async fn reply_sets_in_reply_to_for_outbound_minted_parent() {
-    let (registry, rt) = build_registry_for_ns("local");
+    let (registry, rt) = build_actor_registry(shared_backend(), "lambda:khive");
 
     let parent_id = plant_message_note(
         &rt,
@@ -4636,7 +4640,7 @@ async fn reply_sets_in_reply_to_for_outbound_minted_parent() {
 /// fabricated, and the reply still succeeds exactly as before this feature.
 #[tokio::test]
 async fn reply_omits_in_reply_to_when_parent_has_no_wire_message_id() {
-    let (registry, rt) = build_registry_for_ns("local");
+    let (registry, rt) = build_actor_registry(shared_backend(), "lambda:khive");
 
     let parent_id = plant_message_note(
         &rt,
@@ -4789,7 +4793,7 @@ async fn ingest_omits_wire_references_when_absent() {
 /// Message-ID, and In-Reply-To must remain exactly the parent Message-ID.
 #[tokio::test]
 async fn reply_extends_existing_references_chain_of_two_or_more() {
-    let (registry, rt) = build_registry_for_ns("local");
+    let (registry, rt) = build_actor_registry(shared_backend(), "lambda:khive");
 
     let parent_id = plant_message_note(
         &rt,
@@ -4829,7 +4833,7 @@ async fn reply_extends_existing_references_chain_of_two_or_more() {
 /// alone, identical to pre-chain-preservation behavior.
 #[tokio::test]
 async fn reply_references_falls_back_to_parent_message_id_when_no_chain() {
-    let (registry, rt) = build_registry_for_ns("local");
+    let (registry, rt) = build_actor_registry(shared_backend(), "lambda:khive");
 
     let parent_id = plant_message_note(
         &rt,
@@ -4868,7 +4872,7 @@ async fn reply_references_falls_back_to_parent_message_id_when_no_chain() {
 /// `comm.reply` end-to-end, not just unit-tested on `parent_references_chain`.
 #[tokio::test]
 async fn reply_extends_references_chain_for_outbound_parent() {
-    let (registry, rt) = build_registry_for_ns("local");
+    let (registry, rt) = build_actor_registry(shared_backend(), "lambda:khive");
 
     let parent_id = plant_message_note(
         &rt,
@@ -4913,7 +4917,7 @@ async fn reply_extends_references_chain_for_outbound_parent() {
 /// rather than propagated into the reply's References header.
 #[tokio::test]
 async fn reply_skips_malformed_token_in_parent_references_chain() {
-    let (registry, rt) = build_registry_for_ns("local");
+    let (registry, rt) = build_actor_registry(shared_backend(), "lambda:khive");
 
     let parent_id = plant_message_note(
         &rt,
@@ -4952,7 +4956,7 @@ async fn reply_skips_malformed_token_in_parent_references_chain() {
 /// chain rather than being appended again at the end.
 #[tokio::test]
 async fn reply_dedups_tainted_parent_references_chain_containing_parent_id() {
-    let (registry, rt) = build_registry_for_ns("local");
+    let (registry, rt) = build_actor_registry(shared_backend(), "lambda:khive");
 
     let parent_id = plant_message_note(
         &rt,
@@ -7440,5 +7444,313 @@ async fn i820_anonymous_local_party_line_send_still_succeeds() {
         result.is_ok(),
         "unattributed to=local send must not be rejected by the #820 self-address guard; \
          got {result:?}"
+    );
+}
+
+// ── #113: reply is restricted to a thread participant ─────────────────────────
+
+/// A third party holding a message id (neither the sender nor the addressee)
+/// must not be able to reply to it.
+#[tokio::test]
+async fn i113_non_participant_reply_rejected() {
+    let backend = shared_backend();
+    let (registry_a, _rt_a) = build_actor_registry(backend.clone(), "lambda:a");
+    let (registry_c, _rt_c) = build_actor_registry(backend.clone(), "lambda:c");
+
+    let send_result = registry_a
+        .dispatch(
+            "comm.send",
+            serde_json::json!({ "to": "lambda:b", "content": "hello B from A" }),
+        )
+        .await
+        .expect("send succeeds");
+    let msg_id = send_result["full_id"]
+        .as_str()
+        .expect("full_id")
+        .to_string();
+
+    let err = registry_c
+        .dispatch(
+            "comm.reply",
+            serde_json::json!({ "id": msg_id, "content": "forged reply from C" }),
+        )
+        .await
+        .unwrap_err();
+    assert!(
+        err.to_string()
+            .contains("not addressed to or from caller actor"),
+        "non-participant reply must be rejected; got {err}"
+    );
+}
+
+/// An unattributed caller is still a distinct `local` actor and must not bypass
+/// participant checks for messages carrying explicit actor fields.
+#[tokio::test]
+async fn i113_anonymous_non_participant_reply_rejected() {
+    let backend = shared_backend();
+    let (registry_a, _rt_a) = build_actor_registry(backend.clone(), "lambda:a");
+    let (registry_local, _rt_local) = build_crossns_registry(backend, "local", vec![]);
+
+    let send_result = registry_a
+        .dispatch(
+            "comm.send",
+            serde_json::json!({ "to": "lambda:b", "content": "hello B from A" }),
+        )
+        .await
+        .expect("send succeeds");
+    let msg_id = send_result["full_id"]
+        .as_str()
+        .expect("full_id")
+        .to_string();
+
+    let err = registry_local
+        .dispatch(
+            "comm.reply",
+            serde_json::json!({ "id": msg_id, "content": "forged anonymous reply" }),
+        )
+        .await
+        .unwrap_err();
+    assert!(
+        err.to_string()
+            .contains("not addressed to or from caller actor"),
+        "anonymous non-participant reply must be rejected; got {err}"
+    );
+}
+
+/// The addressee (recipient) may reply — this is the common case.
+#[tokio::test]
+async fn i113_addressee_reply_succeeds() {
+    let backend = shared_backend();
+    let (registry_a, _rt_a) = build_actor_registry(backend.clone(), "lambda:a");
+    let (registry_b, _rt_b) = build_actor_registry(backend.clone(), "lambda:b");
+
+    let send_result = registry_a
+        .dispatch(
+            "comm.send",
+            serde_json::json!({ "to": "lambda:b", "content": "hello B from A" }),
+        )
+        .await
+        .expect("send succeeds");
+    let msg_id = send_result["full_id"]
+        .as_str()
+        .expect("full_id")
+        .to_string();
+
+    let reply = registry_b
+        .dispatch(
+            "comm.reply",
+            serde_json::json!({ "id": msg_id, "content": "reply from B" }),
+        )
+        .await
+        .expect("addressee reply must succeed");
+    assert_eq!(reply["from"], "lambda:b");
+}
+
+/// The original sender may also reply to their own outbound message (e.g. a
+/// follow-up before the recipient has responded) — either party is a
+/// participant, not addressee-only.
+#[tokio::test]
+async fn i113_sender_reply_to_own_message_succeeds() {
+    let backend = shared_backend();
+    let (registry_a, _rt_a) = build_actor_registry(backend.clone(), "lambda:a");
+
+    let send_result = registry_a
+        .dispatch(
+            "comm.send",
+            serde_json::json!({ "to": "lambda:b", "content": "hello B from A" }),
+        )
+        .await
+        .expect("send succeeds");
+    let msg_id = send_result["full_id"]
+        .as_str()
+        .expect("full_id")
+        .to_string();
+
+    let reply = registry_a
+        .dispatch(
+            "comm.reply",
+            serde_json::json!({ "id": msg_id, "content": "follow-up from A" }),
+        )
+        .await
+        .expect("sender reply to own message must succeed");
+    assert_eq!(reply["from"], "lambda:a");
+}
+
+/// A legacy message with neither `to_actor` nor `from_actor` fails open
+/// (no attributed party to restrict against), matching the #87/#94 precedent.
+#[tokio::test]
+async fn i113_legacy_message_without_actors_fails_open() {
+    use khive_storage::note::Note;
+
+    let (registry, rt) = build_registry_for_ns("local");
+    let token = rt
+        .authorize(khive_runtime::Namespace::parse("local").unwrap())
+        .unwrap();
+    let store = rt.notes(&token).expect("notes store");
+
+    let legacy =
+        Note::new("local", "message", "legacy message body").with_properties(serde_json::json!({
+            "direction": "inbound",
+            "sent_at": chrono::Utc::now().to_rfc3339(),
+        }));
+    let legacy_id = legacy.id;
+    store.upsert_note(legacy).await.expect("legacy note insert");
+
+    let reply = registry
+        .dispatch(
+            "comm.reply",
+            serde_json::json!({ "id": legacy_id.to_string(), "content": "reply to legacy" }),
+        )
+        .await;
+    assert!(
+        reply.is_ok(),
+        "reply to a legacy message with no to_actor/from_actor must fail open; got {reply:?}"
+    );
+}
+
+// ── #66: comm.unread — count-only unread view ──────────────────────────────────
+
+#[tokio::test]
+async fn i66_unread_counts_only_matching_inbound_unread() {
+    let backend = shared_backend();
+    let (registry_a, _rt_a) = build_actor_registry(backend.clone(), "lambda:a");
+    let (registry_b, _rt_b) = build_actor_registry(backend.clone(), "lambda:b");
+
+    registry_a
+        .dispatch(
+            "comm.send",
+            serde_json::json!({ "to": "lambda:b", "content": "msg 1" }),
+        )
+        .await
+        .expect("send 1");
+    registry_a
+        .dispatch(
+            "comm.send",
+            serde_json::json!({ "to": "lambda:b", "content": "msg 2" }),
+        )
+        .await
+        .expect("send 2");
+
+    let unread_before = registry_b
+        .dispatch("comm.unread", serde_json::json!({}))
+        .await
+        .expect("unread succeeds");
+    assert_eq!(unread_before["count"], 2);
+    assert_eq!(unread_before["actor"], "lambda:b");
+
+    // Mark B's own inbound copy of msg 2 read (the id `comm.inbox` returns for
+    // B, not the outbound `send` response's id); unread count must drop to 1.
+    let inbox = registry_b
+        .dispatch(
+            "comm.inbox",
+            serde_json::json!({ "status": "unread", "limit": 50 }),
+        )
+        .await
+        .expect("inbox succeeds");
+    let msg2_inbound_id = inbox["messages"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|m| m["preview"].as_str().unwrap_or("").contains("msg 2"))
+        .map(|m| m["full_id"].as_str().unwrap().to_string())
+        .expect("find B's inbound copy of msg 2");
+    registry_b
+        .dispatch("comm.read", serde_json::json!({ "id": msg2_inbound_id }))
+        .await
+        .expect("read succeeds");
+
+    let unread_after = registry_b
+        .dispatch("comm.unread", serde_json::json!({}))
+        .await
+        .expect("unread succeeds");
+    assert_eq!(unread_after["count"], 1);
+}
+
+/// `comm.unread` is caller-scoped and rejects the removed `assignee` override.
+#[tokio::test]
+async fn i66_unread_rejects_assignee_override() {
+    let backend = shared_backend();
+    let (registry_a, _rt_a) = build_actor_registry(backend.clone(), "lambda:a");
+    let (registry_orch, _rt_o) = build_actor_registry(backend.clone(), "lambda:orch");
+
+    registry_a
+        .dispatch(
+            "comm.send",
+            serde_json::json!({ "to": "lambda:b", "content": "msg for b" }),
+        )
+        .await
+        .expect("send succeeds");
+
+    let err = registry_orch
+        .dispatch("comm.unread", serde_json::json!({ "assignee": "lambda:b" }))
+        .await
+        .unwrap_err();
+    assert!(
+        err.to_string().contains("unknown field `assignee`"),
+        "removed assignee override must be rejected as an unknown param; got {err}"
+    );
+
+    // Without the override, the orchestrator's own unread count is 0.
+    let own_unread = registry_orch
+        .dispatch("comm.unread", serde_json::json!({}))
+        .await
+        .expect("unread succeeds");
+    assert_eq!(own_unread["count"], 0);
+}
+
+/// `comm.inbox`'s response carries `unread_count` alongside `messages`/`count`.
+#[tokio::test]
+async fn i66_inbox_response_carries_unread_count() {
+    let backend = shared_backend();
+    let (registry_a, _rt_a) = build_actor_registry(backend.clone(), "lambda:a");
+    let (registry_b, _rt_b) = build_actor_registry(backend.clone(), "lambda:b");
+
+    registry_a
+        .dispatch(
+            "comm.send",
+            serde_json::json!({ "to": "lambda:b", "content": "msg 1" }),
+        )
+        .await
+        .expect("send 1");
+
+    let inbox = registry_b
+        .dispatch(
+            "comm.inbox",
+            serde_json::json!({ "status": "unread", "limit": 50 }),
+        )
+        .await
+        .expect("inbox succeeds");
+    assert_eq!(inbox["count"], 1);
+    assert_eq!(
+        inbox["unread_count"], 1,
+        "unread_count must be present and match count when status=unread"
+    );
+}
+
+/// `limit=0` is the count-only inbox path: it returns no message payloads but
+/// still reports the caller's real unread total.
+#[tokio::test]
+async fn i66_inbox_limit_zero_carries_real_unread_count() {
+    let backend = shared_backend();
+    let (registry_a, _rt_a) = build_actor_registry(backend.clone(), "lambda:a");
+    let (registry_b, _rt_b) = build_actor_registry(backend, "lambda:b");
+
+    registry_a
+        .dispatch(
+            "comm.send",
+            serde_json::json!({ "to": "lambda:b", "content": "count me" }),
+        )
+        .await
+        .expect("send succeeds");
+
+    let inbox = registry_b
+        .dispatch("comm.inbox", serde_json::json!({ "limit": 0 }))
+        .await
+        .expect("limit=0 inbox succeeds");
+    assert_eq!(inbox["messages"], serde_json::json!([]));
+    assert_eq!(inbox["count"], 0);
+    assert_eq!(
+        inbox["unread_count"], 1,
+        "limit=0 must return the caller's real unread count"
     );
 }

--- a/crates/khive-pack-comm/tests/integration.rs
+++ b/crates/khive-pack-comm/tests/integration.rs
@@ -763,6 +763,311 @@ async fn test_reply_from_recipient_routes_to_sender() {
     );
 }
 
+/// reply() to an inbound message marks the original read — callers previously
+/// chained `reply | read`; the read is now folded into reply itself.
+#[tokio::test]
+async fn test_reply_marks_inbound_original_read() {
+    let backend = shared_backend();
+    let (registry, _rt) = build_actor_registry(backend, "lambda:khive");
+
+    registry
+        .dispatch(
+            "comm.send",
+            serde_json::json!({ "to": "lambda:khive", "content": "needs an answer", "self_send": true }),
+        )
+        .await
+        .expect("self-send succeeds");
+
+    let inbox = registry
+        .dispatch("comm.inbox", serde_json::json!({ "status": "unread" }))
+        .await
+        .expect("inbox succeeds");
+    let msgs = inbox
+        .get("messages")
+        .and_then(|v| v.as_array())
+        .expect("messages array");
+    assert_eq!(msgs.len(), 1, "must have 1 unread inbound message");
+    let inbound_full_id = msgs[0]
+        .get("full_id")
+        .and_then(|v| v.as_str())
+        .expect("full_id on inbound message")
+        .to_string();
+
+    let reply = registry
+        .dispatch(
+            "comm.reply",
+            serde_json::json!({ "id": inbound_full_id, "content": "answered" }),
+        )
+        .await
+        .expect("reply succeeds");
+    assert_eq!(
+        reply.get("marked_read").and_then(|v| v.as_bool()),
+        Some(true),
+        "reply to an inbound message must report marked_read=true; got {reply}"
+    );
+
+    let inbox_after = registry
+        .dispatch("comm.inbox", serde_json::json!({ "status": "unread" }))
+        .await
+        .expect("inbox succeeds after reply");
+    let unread_after = inbox_after
+        .get("messages")
+        .and_then(|v| v.as_array())
+        .expect("messages array");
+    assert!(
+        unread_after
+            .iter()
+            .all(|m| m.get("full_id").and_then(|v| v.as_str()) != Some(inbound_full_id.as_str())),
+        "the replied-to inbound message must no longer be unread"
+    );
+}
+
+/// reply() to an outbound original performs no read-marking (read is a
+/// recipient action); `marked_read` is null.
+#[tokio::test]
+async fn test_reply_to_outbound_original_does_not_mark_read() {
+    let (registry, _rt) = build_registry();
+
+    let original = registry
+        .dispatch(
+            "comm.send",
+            serde_json::json!({ "to": "local", "content": "root message" }),
+        )
+        .await
+        .expect("send succeeds");
+    let outbound_id = original
+        .get("full_id")
+        .and_then(|v| v.as_str())
+        .expect("send returns full_id");
+
+    let reply = registry
+        .dispatch(
+            "comm.reply",
+            serde_json::json!({ "id": outbound_id, "content": "follow-up" }),
+        )
+        .await
+        .expect("reply to own outbound succeeds");
+    assert!(
+        reply
+            .get("marked_read")
+            .map(|v| v.is_null())
+            .unwrap_or(false),
+        "reply to an outbound original must report marked_read=null; got {reply}"
+    );
+}
+
+/// A legacy message carrying no `direction` property is still markable —
+/// reply() skips only an explicitly outbound original, exactly as read() does.
+/// Before this, requiring a literal "inbound" made a directionless legacy
+/// record report `marked_read: null`, which is specified to mean "outbound".
+#[tokio::test]
+async fn test_reply_marks_directionless_legacy_original() {
+    use khive_storage::note::Note;
+    use uuid::Uuid;
+    let (registry, rt) = build_registry();
+    let token = rt.authorize(khive_runtime::Namespace::local()).unwrap();
+    let store = rt.notes(&token).expect("notes store");
+    let now = chrono::Utc::now().timestamp_micros();
+    let id = Uuid::parse_str("dd110000-3333-4000-8000-000000000003").unwrap();
+
+    store
+        .upsert_note(Note {
+            id,
+            namespace: token.namespace().as_str().to_string(),
+            kind: "message".into(),
+            status: "active".into(),
+            name: None,
+            content: "legacy message with no direction".into(),
+            salience: None,
+            decay_factor: None,
+            expires_at: None,
+            // No `direction` — the pre-ADR-057 shape.
+            properties: Some(serde_json::json!({ "from": "x", "to": "local" })),
+            created_at: now,
+            updated_at: now,
+            deleted_at: None,
+        })
+        .await
+        .expect("insert legacy message");
+
+    let reply = registry
+        .dispatch(
+            "comm.reply",
+            serde_json::json!({ "id": id.as_hyphenated().to_string(), "content": "answered" }),
+        )
+        .await
+        .expect("reply to legacy message succeeds");
+    assert_eq!(
+        reply.get("marked_read").and_then(|v| v.as_bool()),
+        Some(true),
+        "a directionless legacy original must be marked, not reported null; got {reply}"
+    );
+
+    let stored = store
+        .get_note(id)
+        .await
+        .expect("get_note")
+        .expect("legacy message still present");
+    assert_eq!(
+        stored
+            .properties
+            .as_ref()
+            .and_then(|p| p.get("read"))
+            .and_then(|v| v.as_bool()),
+        Some(true),
+        "the legacy original must actually carry read=true"
+    );
+}
+
+/// The read-patch must not clobber properties written between the original's
+/// fetch and the patch: reply re-reads current properties before setting
+/// `read`, since the store replaces the properties object wholesale.
+#[tokio::test]
+async fn test_reply_read_patch_preserves_concurrent_properties() {
+    use khive_storage::note::Note;
+    use uuid::Uuid;
+    let (registry, rt) = build_registry();
+    let token = rt.authorize(khive_runtime::Namespace::local()).unwrap();
+    let store = rt.notes(&token).expect("notes store");
+    let now = chrono::Utc::now().timestamp_micros();
+    let id = Uuid::parse_str("dd110000-4444-4000-8000-000000000004").unwrap();
+
+    store
+        .upsert_note(Note {
+            id,
+            namespace: token.namespace().as_str().to_string(),
+            kind: "message".into(),
+            status: "active".into(),
+            name: None,
+            content: "message that gains a property mid-flight".into(),
+            salience: None,
+            decay_factor: None,
+            expires_at: None,
+            properties: Some(
+                serde_json::json!({ "direction": "inbound", "from": "x", "to": "local", "read": false }),
+            ),
+            created_at: now,
+            updated_at: now,
+            deleted_at: None,
+        })
+        .await
+        .expect("insert message");
+
+    // Stand in for another writer stamping metadata after the original was
+    // fetched: patch a new property directly, then reply.
+    let mut with_stamp = serde_json::json!({
+        "direction": "inbound", "from": "x", "to": "local", "read": false,
+        "delivery_stamp": "channel-email"
+    });
+    with_stamp["read"] = serde_json::json!(false);
+    store
+        .update_note_properties(id, Some(with_stamp), now + 1)
+        .await
+        .expect("stamp applied");
+
+    registry
+        .dispatch(
+            "comm.reply",
+            serde_json::json!({ "id": id.as_hyphenated().to_string(), "content": "answered" }),
+        )
+        .await
+        .expect("reply succeeds");
+
+    let stored = store
+        .get_note(id)
+        .await
+        .expect("get_note")
+        .expect("message present");
+    let props = stored.properties.expect("properties");
+    assert_eq!(
+        props.get("read").and_then(|v| v.as_bool()),
+        Some(true),
+        "read must be set"
+    );
+    assert_eq!(
+        props.get("delivery_stamp").and_then(|v| v.as_str()),
+        Some("channel-email"),
+        "the concurrently written property must survive the read patch; got {props}"
+    );
+}
+
+/// A non-participant may reach a message id, but replying must be rejected
+/// without flipping someone else's message to read.
+#[tokio::test]
+async fn test_reply_by_non_participant_is_rejected_without_marking_read() {
+    let backend = shared_backend();
+    let (registry_a, rt_a) = build_actor_registry(backend.clone(), "lambda:a");
+    let (registry_b, _rt_b) = build_actor_registry(backend.clone(), "lambda:b");
+    let (registry_c, _rt_c) = build_actor_registry(backend.clone(), "lambda:c");
+
+    registry_a
+        .dispatch(
+            "comm.send",
+            serde_json::json!({ "to": "lambda:b", "content": "for b only" }),
+        )
+        .await
+        .expect("send succeeds");
+
+    let token = rt_a.authorize(khive_runtime::Namespace::local()).unwrap();
+    let notes = rt_a
+        .list_notes(&token, Some("message"), 100, 0)
+        .await
+        .unwrap();
+    let inbound = notes
+        .iter()
+        .find(|n| {
+            n.properties.as_ref().is_some_and(|p| {
+                p.get("direction").and_then(|v| v.as_str()) == Some("inbound")
+                    && p.get("to_actor").and_then(|v| v.as_str()) == Some("lambda:b")
+            })
+        })
+        .expect("b's inbound copy exists");
+    let id = inbound.id.as_hyphenated().to_string();
+
+    let err = registry_c
+        .dispatch(
+            "comm.reply",
+            serde_json::json!({ "id": id.clone(), "content": "not mine to read" }),
+        )
+        .await
+        .unwrap_err();
+    assert!(
+        err.to_string()
+            .contains("not addressed to or from caller actor"),
+        "a non-participant reply must be rejected; got {err}"
+    );
+
+    let store = rt_a.notes(&token).expect("notes store");
+    let after = store
+        .get_note(inbound.id)
+        .await
+        .expect("get_note")
+        .expect("message present");
+    assert_eq!(
+        after
+            .properties
+            .as_ref()
+            .and_then(|p| p.get("read"))
+            .and_then(|v| v.as_bool()),
+        Some(false),
+        "the original must remain unread after a rejected reply"
+    );
+
+    // The real addressee replying still marks it.
+    let by_b = registry_b
+        .dispatch(
+            "comm.reply",
+            serde_json::json!({ "id": id, "content": "mine, and read" }),
+        )
+        .await
+        .expect("addressee reply succeeds");
+    assert_eq!(
+        by_b["marked_read"].as_bool(),
+        Some(true),
+        "the addressee's reply must still mark the original read; got {by_b}"
+    );
+}
+
 // ── UE6-H2: reply thread_id must be full 36-char UUID ───────────────────────
 
 /// reply thread_id must be the full 36-char hyphenated UUID of the root message.

--- a/crates/khive-pack-comm/tests/probe.rs
+++ b/crates/khive-pack-comm/tests/probe.rs
@@ -12,7 +12,7 @@ use std::sync::Arc;
 
 use khive_pack_comm::CommPack;
 use khive_runtime::{
-    AllowAllGate, BackendId, KhiveRuntime, Namespace, RuntimeConfig, VerbRegistry,
+    AllowAllGate, BackendId, KhiveRuntime, Namespace, RequestIdentity, RuntimeConfig, VerbRegistry,
     VerbRegistryBuilder,
 };
 use khive_storage::note::Note;
@@ -652,8 +652,18 @@ async fn probe_read_does_not_resurrect_message_via_rowid_churn() {
         .expect("cursor_us is an integer");
     assert_eq!(first["new_messages"].as_array().unwrap().len(), 1);
 
+    // #87: read() is restricted to the message's addressee — dispatch as `actor`
+    // (the planted message's `to_actor`), not the registry's baked anonymous identity.
     registry
-        .dispatch("comm.read", json!({ "id": id.to_string() }))
+        .dispatch_with_identity(
+            "comm.read",
+            json!({ "id": id.to_string() }),
+            Some(RequestIdentity {
+                namespace: "local".to_string(),
+                actor_id: Some(actor.to_string()),
+                ..Default::default()
+            }),
+        )
         .await
         .expect("comm.read succeeds");
 

--- a/crates/khive-pack-git/src/cache.rs
+++ b/crates/khive-pack-git/src/cache.rs
@@ -20,7 +20,7 @@ use std::time::SystemTime;
 
 use uuid::Uuid;
 
-use crate::source::cache_key;
+use crate::source::{cache_key, redact_repo_url};
 
 pub const DEFAULT_MAX_REPOS: usize = 5;
 pub const DEFAULT_MAX_TOTAL_BYTES: u64 = 2 * 1024 * 1024 * 1024;
@@ -268,7 +268,8 @@ fn refetch_clone_locked(root: &Path, canonical_url: &str) -> Result<PathBuf, Cac
     let repo_dir = root.join(&key);
     if !repo_dir.join(".git").exists() {
         return Err(CacheError::Git(format!(
-            "refetch requested for {canonical_url:?} but no cache slot exists at {}",
+            "refetch requested for {:?} but no cache slot exists at {}",
+            redact_repo_url(canonical_url),
             repo_dir.display()
         )));
     }
@@ -408,7 +409,8 @@ fn clone(url: &str, dest: &Path) -> Result<(), CacheError> {
         .map_err(|e| CacheError::Git(format!("spawning git clone: {e}")))?;
     if !status.success() {
         return Err(CacheError::Git(format!(
-            "git clone {url} failed (exit {status})"
+            "git clone {:?} failed (exit {status})",
+            redact_repo_url(url)
         )));
     }
     Ok(())
@@ -1226,6 +1228,56 @@ mod tests {
         assert!(
             matches!(err, CacheError::Git(_)),
             "expected CacheError::Git, got {err:?}"
+        );
+
+        std::env::remove_var("KHIVE_GIT_DIGEST_SCRATCH_ROOT");
+    }
+
+    /// Issue #7: a "no cache slot exists" error must not leak an embedded
+    /// credential or query-string token from the caller-supplied URL.
+    #[test]
+    fn refetch_clone_no_slot_error_redacts_credential_bearing_url() {
+        let _guard = ENV_MUTEX.blocking_lock();
+        let scratch = tempfile::tempdir().expect("tempdir");
+        std::env::set_var("KHIVE_GIT_DIGEST_SCRATCH_ROOT", scratch.path());
+
+        let err =
+            refetch_clone("https://user:tok3n@example.invalid/never-cloned/repo?token=SECRET")
+                .expect_err("no slot exists yet");
+        let msg = err.to_string();
+        assert!(
+            !msg.contains("tok3n") && !msg.contains("SECRET"),
+            "issue #7: refetch-no-slot error must not leak embedded credentials/token: {msg}"
+        );
+        assert!(
+            msg.contains("example.invalid"),
+            "redaction must preserve the host for diagnosability: {msg}"
+        );
+
+        std::env::remove_var("KHIVE_GIT_DIGEST_SCRATCH_ROOT");
+    }
+
+    /// Issue #7: a `git clone` failure's error message must not leak an
+    /// embedded credential or query-string token from the caller-supplied
+    /// URL. Port 1 is a reserved low port unlikely to have anything
+    /// listening, so the clone fails fast on connection refusal rather than
+    /// waiting on a real network timeout.
+    #[test]
+    fn ensure_clone_failure_message_redacts_credential_bearing_url() {
+        let _guard = ENV_MUTEX.blocking_lock();
+        let dir = tempfile::tempdir().expect("tempdir");
+        std::env::set_var("KHIVE_GIT_DIGEST_SCRATCH_ROOT", dir.path());
+
+        let result = ensure_clone("https://user:tok3n@127.0.0.1:1/org/repo?token=SECRET");
+        let err = result.expect_err("clone against a closed port must fail");
+        let msg = err.to_string();
+        assert!(
+            !msg.contains("tok3n") && !msg.contains("SECRET"),
+            "issue #7: clone failure message must not leak embedded credentials/token: {msg}"
+        );
+        assert!(
+            msg.contains("127.0.0.1"),
+            "redaction must preserve the host for diagnosability: {msg}"
         );
 
         std::env::remove_var("KHIVE_GIT_DIGEST_SCRATCH_ROOT");

--- a/crates/khive-pack-git/src/handlers.rs
+++ b/crates/khive-pack-git/src/handlers.rs
@@ -141,13 +141,15 @@ impl GitPack {
             DigestSource::Remote { canonical, gh_slug } => {
                 let cloned = cache::ensure_clone(canonical).map_err(|e| {
                     RuntimeError::InvalidInput(format!(
-                        "remote clone/fetch of {canonical:?} failed: {e}"
+                        "remote clone/fetch of {:?} failed: {e}",
+                        redact_repo_url(canonical)
                     ))
                 })?;
                 if gh_slug.is_none() {
                     warnings.push(format!(
-                        "host for {canonical:?} is not github.com; issue/pull_request \
-                         ingestion is skipped (commits-only degradation, ADR-088 Amendment 1)"
+                        "host for {:?} is not github.com; issue/pull_request \
+                         ingestion is skipped (commits-only degradation, ADR-088 Amendment 1)",
+                        redact_repo_url(canonical)
                     ));
                 }
                 (cloned, gh_slug.is_some())

--- a/crates/khive-pack-git/src/handlers.rs
+++ b/crates/khive-pack-git/src/handlers.rs
@@ -307,11 +307,23 @@ async fn resolve_or_create_project(
         .await
         .map_err(|e| RuntimeError::InvalidInput(e.to_string()))?;
     if let Some((id, duplicates)) = slug_matches.split_first() {
+        // issue #6 item 2: a step-1 slug match used to return immediately
+        // without consulting legacy pre-slug anchors, so an older
+        // alternate-spelling anchor for the same repository never
+        // surfaced in the duplicate-anchor warning. Selection is
+        // unchanged (the slug-tier match still wins); this only widens
+        // what gets reported alongside it.
+        let mut slug_duplicates = duplicates.to_vec();
+        slug_duplicates.extend(
+            find_normalized_legacy_matches(runtime, token, &identity)
+                .await
+                .map_err(|e| RuntimeError::InvalidInput(e.to_string()))?,
+        );
         return Ok(ProjectResolution {
             id: *id,
             created: false,
             orphan: None,
-            slug_duplicates: duplicates.to_vec(),
+            slug_duplicates,
         });
     }
 
@@ -539,6 +551,74 @@ async fn find_legacy_projects_without_slug(
         .collect())
 }
 
+/// Same shape as `find_legacy_projects_without_slug`, scoped to soft-deleted
+/// rows (`deleted_at IS NOT NULL`) instead of live ones, and carrying each
+/// row's own `deleted_at` so callers can merge-sort tombstones by recency
+/// alongside an exact-match set (issue #6 item 1).
+async fn find_soft_deleted_legacy_projects_without_slug(
+    runtime: &KhiveRuntime,
+    token: &NamespaceToken,
+) -> anyhow::Result<Vec<(Uuid, String, i64)>> {
+    let sql = runtime.sql();
+    let mut r = sql.reader().await.map_err(|e| anyhow!("{e}"))?;
+    let rows = r
+        .query_all(SqlStatement {
+            sql: "SELECT id, deleted_at, json_extract(properties,'$.repo_url') AS repo_url \
+                  FROM entities WHERE kind='project' AND namespace=?1 \
+                  AND deleted_at IS NOT NULL \
+                  AND json_extract(properties,'$.repo_slug') IS NULL \
+                  AND json_extract(properties,'$.repo_url') IS NOT NULL"
+                .into(),
+            params: vec![SqlValue::Text(token.namespace().as_str().to_string())],
+            label: Some("git_digest_find_soft_deleted_legacy_projects_without_slug".into()),
+        })
+        .await
+        .map_err(|e| anyhow!("{e}"))?;
+    Ok(rows
+        .iter()
+        .filter_map(|r| {
+            let id = match r.get("id") {
+                Some(SqlValue::Uuid(u)) => Some(*u),
+                Some(SqlValue::Text(s)) => Uuid::parse_str(s).ok(),
+                _ => None,
+            }?;
+            let deleted_at = match r.get("deleted_at") {
+                Some(SqlValue::Integer(n)) => *n,
+                _ => 0,
+            };
+            let url = match r.get("repo_url") {
+                Some(SqlValue::Text(s)) => Some(s.clone()),
+                _ => None,
+            }?;
+            Some((id, url, deleted_at))
+        })
+        .collect())
+}
+
+/// Scan every live legacy (pre-slug) project anchor and return the ids whose
+/// stored `repo_url` normalizes to the same `identity` as the caller's
+/// resolved source -- the same normalize-and-compare step ADR-088 Amendment
+/// 2 step 2 already applies, reused here to surface a cross-tier duplicate
+/// when a *different* tier's exact match already won (issue #6 item 2).
+async fn find_normalized_legacy_matches(
+    runtime: &KhiveRuntime,
+    token: &NamespaceToken,
+    identity: &str,
+) -> anyhow::Result<Vec<Uuid>> {
+    let legacy_candidates = find_legacy_projects_without_slug(runtime, token).await?;
+    let mut matches = Vec::new();
+    for (id, candidate_repo_url) in legacy_candidates {
+        if normalize_legacy_repo_url(&candidate_repo_url)
+            .await
+            .as_deref()
+            == Some(identity)
+        {
+            matches.push(id);
+        }
+    }
+    Ok(matches)
+}
+
 /// Re-derive the repo-identity slug a legacy anchor's stored `repo_url`
 /// would resolve to today (ADR-088 Amendment 2 step 2). A URL-shaped value
 /// normalizes directly via `remote_url_to_slug`. A path-shaped value (an
@@ -591,11 +671,10 @@ async fn find_orphaned_anchor(
     let mut r = sql.reader().await.map_err(|e| anyhow!("{e}"))?;
     let rows = r
         .query_all(SqlStatement {
-            sql: "SELECT id FROM entities WHERE kind='project' AND namespace=?1 \
+            sql: "SELECT id, deleted_at FROM entities WHERE kind='project' AND namespace=?1 \
                   AND deleted_at IS NOT NULL \
                   AND (json_extract(properties,'$.repo_slug')=?2 \
-                       OR json_extract(properties,'$.repo_url')=?3) \
-                  ORDER BY deleted_at DESC"
+                       OR json_extract(properties,'$.repo_url')=?3)"
                 .into(),
             params: vec![
                 SqlValue::Text(token.namespace().as_str().to_string()),
@@ -606,11 +685,49 @@ async fn find_orphaned_anchor(
         })
         .await
         .map_err(|e| anyhow!("{e}"))?;
-    let dead_project_ids = rows.into_iter().filter_map(|r| match r.get("id") {
-        Some(SqlValue::Uuid(u)) => Some(*u),
-        Some(SqlValue::Text(s)) => Uuid::parse_str(s).ok(),
-        _ => None,
-    });
+    let mut dead_projects: Vec<(Uuid, i64)> = rows
+        .iter()
+        .filter_map(|r| {
+            let id = match r.get("id") {
+                Some(SqlValue::Uuid(u)) => Some(*u),
+                Some(SqlValue::Text(s)) => Uuid::parse_str(s).ok(),
+                _ => None,
+            }?;
+            let deleted_at = match r.get("deleted_at") {
+                Some(SqlValue::Integer(n)) => *n,
+                _ => 0,
+            };
+            Some((id, deleted_at))
+        })
+        .collect();
+
+    // issue #6 item 1: the exact-match scan above misses a soft-deleted
+    // legacy anchor whose stored repo_url is an alternate spelling of the
+    // same repository (one that would normalize to the same identity).
+    // Extend the tombstone scan with the same normalize-and-compare step
+    // the live step-2 path already uses, scoped to soft-deleted rows.
+    let legacy_tombstones = find_soft_deleted_legacy_projects_without_slug(runtime, token)
+        .await
+        .map_err(|e| anyhow!("{e}"))?;
+    let already_matched: std::collections::HashSet<Uuid> =
+        dead_projects.iter().map(|(id, _)| *id).collect();
+    for (id, candidate_repo_url, deleted_at) in legacy_tombstones {
+        if already_matched.contains(&id) {
+            continue;
+        }
+        if normalize_legacy_repo_url(&candidate_repo_url)
+            .await
+            .as_deref()
+            == Some(identity)
+        {
+            dead_projects.push((id, deleted_at));
+        }
+    }
+    // Newest-deleted-first across both sources: the signal below fires for
+    // the first matching tombstone (newest first) that still has a live
+    // annotating corpus, per the doc comment above.
+    dead_projects.sort_by_key(|(_, deleted_at)| std::cmp::Reverse(*deleted_at));
+    let dead_project_ids = dead_projects.into_iter().map(|(id, _)| id);
 
     for dead_project_id in dead_project_ids {
         let count = r
@@ -1348,6 +1465,116 @@ mod tests {
             still_legacy,
             vec![ids[1]],
             "duplicate stays pre-slug; no third anchor minted"
+        );
+    }
+
+    /// Issue #6 item 1: a soft-deleted legacy (pre-slug) anchor whose stored
+    /// `repo_url` is an alternate spelling (here, a `.git` suffix) of the
+    /// same repository must still be detected by the orphan scan -- the
+    /// exact-match tombstone query alone would miss it.
+    #[tokio::test]
+    async fn orphaned_anchor_with_alternate_spelling_repo_url_is_still_flagged() {
+        let (rt, token, registry) = fixture().await;
+
+        let source = DigestSource::Remote {
+            canonical: "https://github.com/org/normalized-orphan-repo".to_string(),
+            gh_slug: Some(("org".to_string(), "normalized-orphan-repo".to_string())),
+        };
+
+        let dead = registry
+            .dispatch(
+                "create",
+                json!({
+                    "kind": "project",
+                    "name": "normalized-orphan-repo",
+                    "properties": {
+                        "repo_url": "https://github.com/org/normalized-orphan-repo.git",
+                    },
+                }),
+            )
+            .await
+            .expect("create dead anchor");
+        let dead_id = Uuid::parse_str(dead["id"].as_str().unwrap()).expect("uuid");
+
+        create_note_annotating(&registry, "commit", "c1", dead_id).await;
+
+        let deleted = rt
+            .delete_entity(&token, dead_id, false)
+            .await
+            .expect("soft delete");
+        assert!(deleted);
+
+        let resolution = resolve_or_create_project(&rt, &registry, &token, &source)
+            .await
+            .expect("resolve");
+        assert!(
+            resolution.created,
+            "no live anchor matches -- a fresh one is minted"
+        );
+        let orphan = resolution.orphan.expect(
+            "issue #6: an alternate-spelling soft-deleted anchor must still be flagged as orphan",
+        );
+        assert_eq!(orphan.dead_project_id, dead_id);
+        assert_eq!(orphan.annotated_note_count, 1);
+    }
+
+    /// Issue #6 item 2: when a step-1 slug match wins resolution, a live
+    /// legacy (pre-slug) anchor for an alternate spelling of the same
+    /// repository must still surface in `slug_duplicates` -- previously,
+    /// resolution returned at step 1 without ever consulting legacy anchors.
+    #[tokio::test]
+    async fn slug_tier_match_surfaces_cross_tier_legacy_duplicate() {
+        let (rt, token, registry) = fixture().await;
+
+        let source = DigestSource::Remote {
+            canonical: "https://github.com/org/cross-tier-repo".to_string(),
+            gh_slug: Some(("org".to_string(), "cross-tier-repo".to_string())),
+        };
+
+        let winner = registry
+            .dispatch(
+                "create",
+                json!({
+                    "kind": "project",
+                    "name": "cross-tier-repo",
+                    "properties": {
+                        "repo_url": "https://github.com/org/cross-tier-repo",
+                        "repo_slug": "github.com/org/cross-tier-repo",
+                    },
+                }),
+            )
+            .await
+            .expect("create winner anchor");
+        let winner_id = Uuid::parse_str(winner["id"].as_str().unwrap()).expect("uuid");
+
+        // A LIVE legacy (pre-slug) anchor, alternate `.git`-suffixed
+        // spelling of the same repo -- a different resolution tier than
+        // the step-1 winner above.
+        let legacy = registry
+            .dispatch(
+                "create",
+                json!({
+                    "kind": "project",
+                    "name": "cross-tier-repo-legacy",
+                    "properties": {
+                        "repo_url": "https://github.com/org/cross-tier-repo.git",
+                    },
+                }),
+            )
+            .await
+            .expect("create legacy anchor");
+        let legacy_id = Uuid::parse_str(legacy["id"].as_str().unwrap()).expect("uuid");
+
+        let resolution = resolve_or_create_project(&rt, &registry, &token, &source)
+            .await
+            .expect("resolve");
+        assert_eq!(resolution.id, winner_id, "slug tier still wins selection");
+        assert!(!resolution.created);
+        assert!(
+            resolution.slug_duplicates.contains(&legacy_id),
+            "issue #6: a live legacy-tier anchor for the same identity must surface \
+             as a cross-tier duplicate; got {:?}",
+            resolution.slug_duplicates
         );
     }
 }

--- a/crates/khive-pack-gtd/src/handlers.rs
+++ b/crates/khive-pack-gtd/src/handlers.rs
@@ -665,6 +665,7 @@ pub async fn prepare_transition(
         )));
     }
 
+    let updated_at = Utc::now().timestamp_micros();
     let mut props = note.properties.clone().unwrap_or_else(|| json!({}));
     if let Some(obj) = props.as_object_mut() {
         obj.insert("status".into(), json!(target.to_string()));
@@ -674,8 +675,32 @@ pub async fn prepare_transition(
         if target == "done" {
             obj.insert("completed_at".into(), json!(Utc::now().to_rfc3339()));
         }
+
+        // #95: `transition_note` above is last-write-wins by design (it's the
+        // "latest note" quick-read field every existing caller already
+        // depends on) — but that means every note before the last one was
+        // gone with no trace anywhere in the record. `gtd_lifecycle_audit`
+        // (see `write_audit_record` below) already persists the full
+        // from/to/note/at history in SQL, so the storage-side history this
+        // issue asks about already exists; it just isn't surfaced back to a
+        // caller reading the task. `transition_history` mirrors that same
+        // per-transition record onto the note's own `properties` blob (a
+        // free-form JSON column — no schema/storage change needed) so a
+        // plain `get`/`tasks` read of the task, not just a raw SQL query
+        // against the audit table, shows the accumulated history.
+        let entry = json!({
+            "from": current,
+            "to": target,
+            "note": note_arg,
+            "at": micros_to_iso(updated_at),
+        });
+        match obj.get_mut("transition_history") {
+            Some(Value::Array(history)) => history.push(entry),
+            _ => {
+                obj.insert("transition_history".into(), json!([entry]));
+            }
+        }
     }
-    let updated_at = Utc::now().timestamp_micros();
 
     Ok(TransitionDecision::Write {
         note,
@@ -1149,8 +1174,8 @@ impl GtdPack {
         };
         let filter = NoteFilter {
             kind: Some("task".to_string()),
-            property_filters,
-            namespaces,
+            property_filters: property_filters.clone(),
+            namespaces: namespaces.clone(),
             ..Default::default()
         };
         let page = self
@@ -1168,6 +1193,52 @@ impl GtdPack {
             .map_err(|e| RuntimeError::Internal(format!("query_notes_filtered: {e}")))?;
 
         let result: Vec<Value> = page.items.iter().map(render_task).collect();
+
+        // #96: a bare `[]` is indistinguishable from "no such task" when the
+        // *default* terminal-status exclusion is what emptied the result —
+        // the common case a caller hits right after `gtd.complete`. Probe for
+        // a terminal task with the same namespace/assignee/priority filters
+        // before changing the response shape; other empty results keep the
+        // established bare array.
+        if result.is_empty() && status_filter.is_none() {
+            property_filters[0] = PropertyFilter {
+                json_path: "$.status".to_string(),
+                op: FilterOp::In(vec![
+                    SqlValue::Text("done".to_string()),
+                    SqlValue::Text("cancelled".to_string()),
+                ]),
+                value: SqlValue::Null,
+            };
+            let terminal_filter = NoteFilter {
+                kind: Some("task".to_string()),
+                property_filters,
+                namespaces,
+                ..Default::default()
+            };
+            let terminal_page = self
+                .runtime()
+                .notes(token)?
+                .query_notes_filtered(
+                    token.namespace().as_str(),
+                    &terminal_filter,
+                    PageRequest {
+                        limit: 1,
+                        offset: 0,
+                    },
+                )
+                .await
+                .map_err(|e| RuntimeError::Internal(format!("query_notes_filtered: {e}")))?;
+
+            if !terminal_page.items.is_empty() {
+                return Ok(json!({
+                    "tasks": result,
+                    "filter_excluded": ["done", "cancelled"],
+                    "hint": "no tasks matched, but the default filter excludes done/cancelled \
+                              tasks — pass status=\"done\" or status=\"cancelled\" to check \
+                              whether a completed task exists before concluding it doesn't",
+                }));
+            }
+        }
         Ok(Value::Array(result))
     }
 

--- a/crates/khive-pack-gtd/src/vocab.rs
+++ b/crates/khive-pack-gtd/src/vocab.rs
@@ -201,7 +201,13 @@ pub(crate) static GTD_HANDLERS: [HandlerDef; 5] = [
     // Assertive: retrieves filtered task listing
     HandlerDef {
         name: "gtd.tasks",
-        description: "List tasks filtered by status, assignee, priority",
+        description: "List tasks filtered by status, assignee, priority. DEFAULT (no `status` \
+                       given): excludes terminal statuses (done, cancelled) so the default \
+                       listing shows only active work. Pass status=\"done\" or \
+                       status=\"cancelled\" explicitly to see completed/cancelled tasks — an \
+                       empty result under the default filter does NOT mean the task doesn't \
+                       exist; the response carries `filter_excluded` when the default filter \
+                       is the reason the result is empty (issue #96).",
         visibility: Visibility::Verb,
         category: VerbCategory::Assertive,
         params: &[
@@ -211,7 +217,8 @@ pub(crate) static GTD_HANDLERS: [HandlerDef; 5] = [
                 required: false,
                 description: "Filter by status: inbox | next | waiting | someday | active | done | cancelled. \
                                Aliases also accepted: todo=inbox, in_progress=active, blocked=waiting, \
-                               later=someday, finished=done.",
+                               later=someday, finished=done. Omitted (default): excludes done \
+                               and cancelled (terminal statuses) from the result.",
             },
             ParamDef {
                 name: "assignee",

--- a/crates/khive-pack-gtd/tests/audit.rs
+++ b/crates/khive-pack-gtd/tests/audit.rs
@@ -268,6 +268,96 @@ async fn transition_upgrades_namespace_less_audit_table_and_writes_row() {
     );
 }
 
+/// #95: successive `gtd.transition` notes must all remain retrievable, not
+/// just the last one. `transition_note` (a top-level `properties` field)
+/// stays last-write-wins on purpose — every existing caller already reads it
+/// as "the current/latest note" — but `transition_history` (new, additive,
+/// same `properties` JSON blob — no schema change) must accumulate every
+/// transition's own from/to/note/at, in order. Walk a task through three
+/// distinct-note transitions and confirm all three survive a plain task read
+/// (via `gtd.tasks`, exercising the same `render_task` path every caller
+/// hits — not just a raw SQL query against `gtd_lifecycle_audit`).
+#[tokio::test]
+async fn transition_history_accumulates_across_multiple_transitions() {
+    let rt = rt();
+    let fixture = pack(rt.clone());
+
+    let resp = assign(
+        &fixture,
+        json!({"title": "history test task", "status": "inbox"}),
+    )
+    .await;
+    let task_id = resp["full_id"].as_str().unwrap().to_string();
+
+    fixture
+        .dispatch(
+            "gtd.transition",
+            json!({"id": task_id, "status": "next", "note": "triage note"}),
+        )
+        .await
+        .expect("inbox -> next");
+    fixture
+        .dispatch(
+            "gtd.transition",
+            json!({"id": task_id, "status": "active", "note": "start note"}),
+        )
+        .await
+        .expect("next -> active");
+    fixture
+        .dispatch(
+            "gtd.transition",
+            json!({"id": task_id, "status": "done", "note": "finish note"}),
+        )
+        .await
+        .expect("active -> done");
+
+    let tasks = fixture
+        .dispatch("gtd.tasks", json!({"status": "done"}))
+        .await
+        .expect("tasks(status=done) ok");
+    let arr = tasks.as_array().expect("tasks(status=..) stays bare array");
+    let task = arr
+        .iter()
+        .find(|t| t["full_id"] == task_id)
+        .expect("the transitioned task must be in the done listing");
+
+    // Latest-note field is unchanged behavior: still last-write-wins.
+    assert_eq!(
+        task["properties"]["transition_note"], "finish note",
+        "transition_note must still read as the LATEST note (unchanged behavior)"
+    );
+
+    let history = task["properties"]["transition_history"]
+        .as_array()
+        .expect("transition_history must be present and be an array");
+    assert_eq!(
+        history.len(),
+        3,
+        "all three transitions must be recorded; got: {history:?}"
+    );
+    let notes: Vec<&str> = history
+        .iter()
+        .map(|h| h["note"].as_str().unwrap_or("?"))
+        .collect();
+    assert_eq!(
+        notes,
+        vec!["triage note", "start note", "finish note"],
+        "every transition note must be individually retrievable in order; got: {notes:?}"
+    );
+    assert_eq!(history[0]["from"], "inbox");
+    assert_eq!(history[0]["to"], "next");
+    assert_eq!(history[1]["from"], "next");
+    assert_eq!(history[1]["to"], "active");
+    assert_eq!(history[2]["from"], "active");
+    assert_eq!(history[2]["to"], "done");
+    for entry in history {
+        assert!(
+            entry["at"].as_str().is_some(),
+            "every history entry must carry a timestamp; got: {entry:?}"
+        );
+    }
+}
+
 #[tokio::test]
 async fn cc1_complete_cancelled_writes_audit_record() {
     let rt = rt();

--- a/crates/khive-pack-gtd/tests/query.rs
+++ b/crates/khive-pack-gtd/tests/query.rs
@@ -183,6 +183,129 @@ async fn tasks_priority_filter_excludes_terminal_by_default() {
     let _ = a["full_id"].as_str();
 }
 
+/// #96: an empty `gtd.tasks()` result must be distinguishable from "no such
+/// task" when the emptiness is caused by the default terminal-status filter.
+/// Complete the ONLY task in this runtime, then query with no `status` —
+/// the previous behavior was a bare `[]`, indistinguishable from the task
+/// never having existed. It must now carry the applied-filter signal.
+#[tokio::test]
+async fn tasks_empty_default_result_signals_terminal_filter_applied() {
+    let pack = pack(rt());
+
+    let t = assign(&pack, json!({"title": "solo task", "status": "inbox"})).await;
+    let t_id = t["full_id"].as_str().unwrap().to_string();
+    pack.dispatch("gtd.transition", json!({"id": t_id, "status": "done"}))
+        .await
+        .expect("inbox -> done");
+
+    let resp = pack.dispatch("gtd.tasks", json!({})).await.unwrap();
+    assert!(
+        resp.is_object(),
+        "empty-because-filtered result must be an object carrying the applied \
+         filter, not a bare array; got: {resp:?}"
+    );
+    let tasks = resp["tasks"]
+        .as_array()
+        .expect("the object must still carry the (empty) tasks array");
+    assert!(
+        tasks.is_empty(),
+        "no non-terminal tasks exist; got: {tasks:?}"
+    );
+    let excluded = resp["filter_excluded"]
+        .as_array()
+        .expect("filter_excluded must list the statuses the default filter excluded");
+    let excluded_strs: Vec<&str> = excluded.iter().filter_map(|v| v.as_str()).collect();
+    assert!(excluded_strs.contains(&"done"));
+    assert!(excluded_strs.contains(&"cancelled"));
+
+    // Confirm the task is NOT actually missing — it still exists, just
+    // filtered by default. Explicit status=done must surface it.
+    let done_resp = pack
+        .dispatch("gtd.tasks", json!({"status": "done"}))
+        .await
+        .unwrap();
+    let done_arr = done_resp
+        .as_array()
+        .expect("explicit status= must keep the bare-array shape");
+    assert_eq!(
+        done_arr.len(),
+        1,
+        "the completed task must still be readable by id/status"
+    );
+    assert_eq!(done_arr[0]["full_id"], t_id);
+}
+
+#[tokio::test]
+async fn tasks_empty_namespace_stays_bare_array() {
+    let pack = pack(rt());
+
+    let resp = pack.dispatch("gtd.tasks", json!({})).await.unwrap();
+    assert_eq!(
+        resp,
+        json!([]),
+        "a namespace with no tasks must keep the established empty-array response"
+    );
+}
+
+#[tokio::test]
+async fn tasks_unmatched_assignee_stays_bare_array() {
+    let pack = pack(rt());
+    let task = assign(
+        &pack,
+        json!({"title": "alice's task", "status": "inbox", "assignee": "alice"}),
+    )
+    .await;
+    pack.dispatch(
+        "gtd.transition",
+        json!({"id": task["full_id"], "status": "done"}),
+    )
+    .await
+    .expect("inbox -> done");
+
+    let resp = pack
+        .dispatch("gtd.tasks", json!({"assignee": "bob"}))
+        .await
+        .unwrap();
+    assert_eq!(
+        resp,
+        json!([]),
+        "a terminal task for another assignee must not trigger the hint"
+    );
+}
+
+#[tokio::test]
+async fn tasks_offset_beyond_last_active_match_stays_bare_array() {
+    let pack = pack(rt());
+    assign(&pack, json!({"title": "only task", "status": "inbox"})).await;
+
+    let resp = pack
+        .dispatch("gtd.tasks", json!({"offset": 1}))
+        .await
+        .unwrap();
+    assert_eq!(
+        resp,
+        json!([]),
+        "pagination past the final active task must keep the established empty-array response"
+    );
+}
+
+/// A non-empty default `gtd.tasks()` result must keep the plain bare-array
+/// shape every existing caller (`kkernel`, `li` surfaces, this crate's own
+/// tests) already depends on via `.as_array()` — the new object wrapper is
+/// strictly additive to the previously-uninformative empty case, never a
+/// change to the common (non-empty) path.
+#[tokio::test]
+async fn tasks_non_empty_default_result_stays_bare_array() {
+    let pack = pack(rt());
+    assign(&pack, json!({"title": "still open", "status": "inbox"})).await;
+
+    let resp = pack.dispatch("gtd.tasks", json!({})).await.unwrap();
+    assert!(
+        resp.is_array(),
+        "a non-empty default result must stay a bare array; got: {resp:?}"
+    );
+}
+
 #[tokio::test]
 async fn next_excludes_terminal_tasks() {
     let pack = pack(rt());

--- a/crates/khive-pack-kg/src/apply_worker/worker.rs
+++ b/crates/khive-pack-kg/src/apply_worker/worker.rs
@@ -293,7 +293,7 @@ impl ProposalApplyWorker {
                     });
                     let plan = prepare_add_entity(&self.runtime, token, &args).await?;
                     let entity_id = match &plan {
-                        AtomicOpPlan::AddEntity(plan) => plan.entity_id,
+                        AtomicOpPlan::AddEntity(plan) => plan.entity_id(),
                         _ => unreachable!("prepare_add_entity returned a different plan variant"),
                     };
                     Ok(PreparedApply::Atomic {
@@ -337,7 +337,7 @@ impl ProposalApplyWorker {
                     });
                     let plan = prepare_op(&self.runtime, token, "link", &args).await?;
                     let (source_id, target_id) = match &plan {
-                        AtomicOpPlan::Link(plan) => (plan.source_id, plan.target_id),
+                        AtomicOpPlan::Link(plan) => (plan.source_id(), plan.target_id()),
                         _ => unreachable!("link prepare returned a different plan variant"),
                     };
                     Ok(PreparedApply::Atomic {
@@ -361,7 +361,7 @@ impl ProposalApplyWorker {
                     });
                     let plan = prepare_add_note(&self.runtime, token, &args).await?;
                     let note_id = match &plan {
-                        AtomicOpPlan::AddNote(plan) => plan.note_id,
+                        AtomicOpPlan::AddNote(plan) => plan.note_id(),
                         _ => unreachable!("prepare_add_note returned a different plan variant"),
                     };
                     Ok(PreparedApply::Atomic {

--- a/crates/khive-pack-kg/src/handler_defs.rs
+++ b/crates/khive-pack-kg/src/handler_defs.rs
@@ -417,7 +417,7 @@ pub(crate) static KG_HANDLERS: [HandlerDef; 19] = [
     // Declaration: declares two records identical
     HandlerDef {
         name: "merge",
-        description: "Deduplicate two entities or notes. Successful non-dry-run merges emit an entity_merged or note_merged audit event. Returns {kept_id, removed_id, edges_rewired, properties_merged, tags_unioned, content_appended, dry_run}; \
+        description: "Deduplicate two entities or notes. Entity merges that fail the cheap entity_kind, name_similarity, or project_compatibility guard return a structured conflict error naming the guard in details.guard. force=true bypasses those guards and means the caller accepts responsibility. Successful non-dry-run merges emit an entity_merged or note_merged audit event. Returns {kept_id, removed_id, edges_rewired, properties_merged, tags_unioned, content_appended, dry_run}; \
                        chain with $prev.kept_id (not $prev.id — merge does not return a top-level id field).",
         visibility: Visibility::Verb,
         category: VerbCategory::Declaration,
@@ -457,6 +457,12 @@ pub(crate) static KG_HANDLERS: [HandlerDef; 19] = [
                 param_type: "bool",
                 required: false,
                 description: "If true, return the planned summary without mutating records or emitting an event.",
+            },
+            ParamDef {
+                name: "force",
+                param_type: "bool",
+                required: false,
+                description: "If true, bypass entity merge safety guards; the caller accepts responsibility for the merge.",
             },
             ParamDef {
                 name: "reason",
@@ -1412,11 +1418,22 @@ mod tests {
                 "merge must document required {required}"
             );
         }
-        for optional in ["kind", "strategy", "content_strategy", "dry_run", "reason"] {
+        for optional in [
+            "kind",
+            "strategy",
+            "content_strategy",
+            "dry_run",
+            "force",
+            "reason",
+        ] {
             assert!(
                 h.params.iter().any(|p| p.name == optional && !p.required),
                 "merge must document optional {optional}"
             );
         }
+        assert!(
+            h.description.contains("details.guard") && h.description.contains("force=true"),
+            "merge must document structured guard refusal and the responsibility override"
+        );
     }
 }

--- a/crates/khive-pack-kg/src/handlers/merge.rs
+++ b/crates/khive-pack-kg/src/handlers/merge.rs
@@ -2,7 +2,10 @@
 
 use serde_json::Value;
 
-use khive_runtime::{NamespaceToken, RuntimeError, VerbRegistry};
+use khive_runtime::{
+    entity_merge_guard_error, validate_entity_merge_floor, NamespaceToken, RuntimeError,
+    VerbRegistry,
+};
 
 use super::common::{
     deser, ensure_entity_kind, ensure_note_kind, immutable_event_error, parse_content_strategy,
@@ -29,6 +32,7 @@ impl KgPack {
         let content_strategy =
             parse_content_strategy(p.content_strategy.as_deref().unwrap_or("append"))?;
         let dry_run = p.dry_run.unwrap_or(false);
+        let force = p.force.unwrap_or(false);
         let reason = p.reason.clone();
 
         let summary = match spec {
@@ -37,14 +41,12 @@ impl KgPack {
                 ensure_entity_kind(&self.runtime, token, from_id, specific.as_deref()).await?;
                 let into_entity = self.runtime.get_entity(token, into_id).await?;
                 let from_entity = self.runtime.get_entity(token, from_id).await?;
-                if into_entity.kind != from_entity.kind {
-                    return Err(RuntimeError::InvalidInput(format!(
-                        "cannot merge entities of different kinds: into={} ({}), from={} ({})",
-                        into_id, into_entity.kind, from_id, from_entity.kind
-                    )));
+                if !force {
+                    validate_entity_merge_floor(&into_entity, &from_entity)
+                        .map_err(entity_merge_guard_error)?;
                 }
                 self.runtime
-                    .merge_entity_with_reason(
+                    .merge_entity_with_reason_and_force(
                         token,
                         into_id,
                         from_id,
@@ -52,6 +54,7 @@ impl KgPack {
                         content_strategy,
                         dry_run,
                         reason,
+                        force,
                     )
                     .await?
             }

--- a/crates/khive-pack-kg/src/handlers/params.rs
+++ b/crates/khive-pack-kg/src/handlers/params.rs
@@ -142,6 +142,7 @@ pub(crate) struct MergeParams {
     pub(crate) strategy: Option<String>,
     pub(crate) content_strategy: Option<String>,
     pub(crate) dry_run: Option<bool>,
+    pub(crate) force: Option<bool>,
     #[allow(dead_code)]
     pub(crate) verbose: Option<bool>,
     pub(crate) reason: Option<String>,

--- a/crates/khive-pack-kg/src/handlers/tests.rs
+++ b/crates/khive-pack-kg/src/handlers/tests.rs
@@ -1671,6 +1671,7 @@ async fn merge_entity_reason_forwarded_through_registry_dispatch() {
                 "into_id": into.id.to_string(),
                 "from_id": from.id.to_string(),
                 "reason": "duplicate via dispatch",
+                "force": true,
             }),
         )
         .await
@@ -1700,6 +1701,15 @@ async fn merge_entity_reason_forwarded_through_registry_dispatch() {
         events.items[0].payload.get("reason").and_then(|v| v.as_str()),
         Some("duplicate via dispatch"),
         "reason supplied through the registry dispatch route must land in the EntityMerged payload; got: {:?}",
+        events.items[0].payload
+    );
+    assert_eq!(
+        events.items[0]
+            .payload
+            .get("force")
+            .and_then(|v| v.as_bool()),
+        Some(true),
+        "force=true must be durable in the EntityMerged payload; got: {:?}",
         events.items[0].payload
     );
 }
@@ -1798,6 +1808,7 @@ async fn get_dispatch_after_merge_discloses_kept_id() {
                 "kind": "entity",
                 "into_id": into.id.to_string(),
                 "from_id": from.id.to_string(),
+                "force": true,
             }),
         )
         .await
@@ -1931,6 +1942,7 @@ async fn resolve_dispatch_on_merged_uuid_stays_bare_not_found() {
                 "kind": "entity",
                 "into_id": into.id.to_string(),
                 "from_id": from.id.to_string(),
+                "force": true,
             }),
         )
         .await

--- a/crates/khive-pack-kg/tests/integration.rs
+++ b/crates/khive-pack-kg/tests/integration.rs
@@ -3307,6 +3307,10 @@ async fn curation_merge_entity_event_payload_has_adr014_fields() {
         payload.get("content_strategy").is_some(),
         "entity_merged payload must contain 'content_strategy' (PR #814); got {payload}"
     );
+    assert!(
+        payload.get("force").is_none(),
+        "ordinary entity merges must not carry a force marker; got {payload}"
+    );
 }
 
 /// Handler-wiring test for PR #814: `content_strategy`
@@ -3348,7 +3352,12 @@ async fn merge_handler_wires_explicit_prefer_from_content_strategy() {
     // onto the entity policy, the into-description ("desc A") survives instead.
     p.dispatch(
         "merge",
-        json!({"into_id": &into_id, "from_id": &from_id, "content_strategy": "prefer_from"}),
+        json!({
+            "into_id": &into_id,
+            "from_id": &from_id,
+            "content_strategy": "prefer_from",
+            "force": true,
+        }),
     )
     .await
     .expect("merge must succeed");
@@ -5232,6 +5241,270 @@ async fn singleton_link_updates_weight_and_metadata_on_existing_triple() {
 }
 
 // ---- Merge symmetric-relation canonicalization regression (ADR-002 §134) ----
+
+#[tokio::test]
+async fn merge_dissimilar_cross_kind_is_refused_by_entity_kind_guard() {
+    let pack = pack();
+    let into_id = pack
+        .dispatch(
+            "create",
+            json!({"kind": "concept", "name": "Quantum Annealing"}),
+        )
+        .await
+        .expect("create into entity")["id"]
+        .as_str()
+        .unwrap()
+        .to_string();
+    let from_id = pack
+        .dispatch(
+            "create",
+            json!({"kind": "project", "name": "Renaissance Painting"}),
+        )
+        .await
+        .expect("create from entity")["id"]
+        .as_str()
+        .unwrap()
+        .to_string();
+
+    let err = pack
+        .dispatch("merge", json!({"into_id": into_id, "from_id": from_id}))
+        .await
+        .expect_err("cross-kind merge must be refused");
+    let RuntimeError::Khive(err) = err else {
+        panic!("expected structured merge-guard error, got {err:?}");
+    };
+    assert_eq!(err.kind(), khive_types::ErrorKind::Conflict);
+    assert_eq!(
+        err.details().and_then(|details| details.get("guard")),
+        Some("entity_kind")
+    );
+}
+
+#[tokio::test]
+async fn merge_dissimilar_cross_kind_force_overrides_guards() {
+    let pack = pack();
+    let into_id = pack
+        .dispatch(
+            "create",
+            json!({"kind": "concept", "name": "Quantum Annealing"}),
+        )
+        .await
+        .expect("create into entity")["id"]
+        .as_str()
+        .unwrap()
+        .to_string();
+    let from_id = pack
+        .dispatch(
+            "create",
+            json!({"kind": "project", "name": "Renaissance Painting"}),
+        )
+        .await
+        .expect("create from entity")["id"]
+        .as_str()
+        .unwrap()
+        .to_string();
+
+    let result = pack
+        .dispatch(
+            "merge",
+            json!({"into_id": into_id, "from_id": from_id, "force": true}),
+        )
+        .await
+        .expect("force=true must override all entity merge guards");
+    assert_eq!(result["removed_id"], from_id);
+}
+
+#[tokio::test]
+async fn merge_legitimate_near_duplicate_passes_safety_floor() {
+    let pack = pack();
+    let into_id = pack
+        .dispatch(
+            "create",
+            json!({
+                "kind": "concept",
+                "name": "Attention Flash",
+                "properties": {"projects": ["transformers", "inference"]},
+            }),
+        )
+        .await
+        .expect("create into entity")["id"]
+        .as_str()
+        .unwrap()
+        .to_string();
+    let from_id = pack
+        .dispatch(
+            "create",
+            json!({
+                "kind": "concept",
+                "name": "Flash Attention",
+                "properties": {"projects": ["inference", "kernels"]},
+            }),
+        )
+        .await
+        .expect("create from entity")["id"]
+        .as_str()
+        .unwrap()
+        .to_string();
+
+    let result = pack
+        .dispatch("merge", json!({"into_id": into_id, "from_id": from_id}))
+        .await
+        .expect("near-duplicate names with compatible projects must merge");
+    assert_eq!(result["removed_id"], from_id);
+}
+
+#[tokio::test]
+async fn merge_same_kind_dissimilar_names_is_refused_by_name_guard() {
+    let pack = pack();
+    let into_id = pack
+        .dispatch(
+            "create",
+            json!({"kind": "concept", "name": "Quantum Annealing"}),
+        )
+        .await
+        .expect("create into entity")["id"]
+        .as_str()
+        .unwrap()
+        .to_string();
+    let from_id = pack
+        .dispatch(
+            "create",
+            json!({"kind": "concept", "name": "Renaissance Painting"}),
+        )
+        .await
+        .expect("create from entity")["id"]
+        .as_str()
+        .unwrap()
+        .to_string();
+
+    let err = pack
+        .dispatch("merge", json!({"into_id": into_id, "from_id": from_id}))
+        .await
+        .expect_err("dissimilar entity names must be refused");
+    let RuntimeError::Khive(err) = err else {
+        panic!("expected structured merge-guard error, got {err:?}");
+    };
+    assert_eq!(
+        err.details().and_then(|details| details.get("guard")),
+        Some("name_similarity")
+    );
+}
+
+#[tokio::test]
+async fn merge_punctuation_collision_is_refused_unless_forced() {
+    let pack = pack();
+    let into_id = pack
+        .dispatch("create", json!({"kind": "concept", "name": "C++"}))
+        .await
+        .expect("create C++ entity")["id"]
+        .as_str()
+        .unwrap()
+        .to_string();
+    let from_id = pack
+        .dispatch("create", json!({"kind": "concept", "name": "C#"}))
+        .await
+        .expect("create C# entity")["id"]
+        .as_str()
+        .unwrap()
+        .to_string();
+
+    let err = pack
+        .dispatch("merge", json!({"into_id": &into_id, "from_id": &from_id}))
+        .await
+        .expect_err("punctuation-distinct entity names must be refused");
+    let RuntimeError::Khive(err) = err else {
+        panic!("expected structured merge-guard error, got {err:?}");
+    };
+    assert_eq!(err.kind(), khive_types::ErrorKind::Conflict);
+    assert_eq!(
+        err.details().and_then(|details| details.get("guard")),
+        Some("name_similarity")
+    );
+
+    let result = pack
+        .dispatch(
+            "merge",
+            json!({"into_id": &into_id, "from_id": &from_id, "force": true}),
+        )
+        .await
+        .expect("force=true must override the name-similarity guard");
+    assert_eq!(result["removed_id"], from_id);
+}
+
+#[tokio::test]
+async fn merge_name_equality_ignores_case_and_collapsed_whitespace() {
+    for (into_name, from_name) in [
+        ("Case Fold", "cASE fOLD"),
+        ("Graph Neural Network", "  graph  neural\t network  "),
+    ] {
+        let pack = pack();
+        let into_id = pack
+            .dispatch("create", json!({"kind": "concept", "name": into_name}))
+            .await
+            .expect("create into entity")["id"]
+            .as_str()
+            .unwrap()
+            .to_string();
+        let from_id = pack
+            .dispatch("create", json!({"kind": "concept", "name": from_name}))
+            .await
+            .expect("create from entity")["id"]
+            .as_str()
+            .unwrap()
+            .to_string();
+
+        let result = pack
+            .dispatch("merge", json!({"into_id": into_id, "from_id": from_id}))
+            .await
+            .expect("case and whitespace differences must remain merge-compatible");
+        assert_eq!(result["removed_id"], from_id);
+    }
+}
+
+#[tokio::test]
+async fn merge_disjoint_projects_is_refused_by_properties_guard() {
+    let pack = pack();
+    let into_id = pack
+        .dispatch(
+            "create",
+            json!({
+                "kind": "concept",
+                "name": "Vector Search",
+                "properties": {"projects": ["search-service"]},
+            }),
+        )
+        .await
+        .expect("create into entity")["id"]
+        .as_str()
+        .unwrap()
+        .to_string();
+    let from_id = pack
+        .dispatch(
+            "create",
+            json!({
+                "kind": "concept",
+                "name": "vector-search",
+                "properties": {"projects": ["recommendation-service"]},
+            }),
+        )
+        .await
+        .expect("create from entity")["id"]
+        .as_str()
+        .unwrap()
+        .to_string();
+
+    let err = pack
+        .dispatch("merge", json!({"into_id": into_id, "from_id": from_id}))
+        .await
+        .expect_err("disjoint project ownership must be refused");
+    let RuntimeError::Khive(err) = err else {
+        panic!("expected structured merge-guard error, got {err:?}");
+    };
+    assert_eq!(
+        err.details().and_then(|details| details.get("guard")),
+        Some("project_compatibility")
+    );
+}
 
 /// After merging B into A, B's `competes_with` edge to C is rewired to A→C.
 /// If A already has a `competes_with` edge to C, the rewire is a conflict:

--- a/crates/khive-pack-knowledge/src/handlers.rs
+++ b/crates/khive-pack-knowledge/src/handlers.rs
@@ -86,6 +86,19 @@ struct TopicParams {
     limit: Option<u32>,
 }
 
+// `feedback`'s two top-level fields (`target_id`, `section_signals`) are a fixed,
+// closed shape — not open content — so deny_unknown_fields applies here too.
+// `section_signals`'s *inner* keys stay a free-form map (section-type names are
+// validated dynamically below against `SectionType::from_str_loose`, which gives
+// a better error than a derive-time enum could).
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct FeedbackParams {
+    #[serde(default)]
+    target_id: Option<String>,
+    section_signals: Value,
+}
+
 // ── handler implementations ───────────────────────────────────────────────────
 
 impl KnowledgePack {
@@ -331,19 +344,14 @@ impl KnowledgePack {
         params: Value,
         registry: &VerbRegistry,
     ) -> Result<Value, RuntimeError> {
-        let target_id_str = params
-            .get("target_id")
-            .and_then(|v| v.as_str())
-            .map(str::to_owned);
+        let p: FeedbackParams = deser(params)?;
+        let target_id_str = p.target_id;
 
-        let raw = params
-            .get("section_signals")
-            .and_then(|v| v.as_object())
-            .ok_or_else(|| {
-                RuntimeError::InvalidInput(
-                    "section_signals is required and must be an object".to_string(),
-                )
-            })?;
+        let raw = p.section_signals.as_object().ok_or_else(|| {
+            RuntimeError::InvalidInput(
+                "section_signals is required and must be an object".to_string(),
+            )
+        })?;
 
         let mut signals: Vec<(SectionType, FeedbackSignal)> = Vec::with_capacity(raw.len());
         for (key, val) in raw {
@@ -370,7 +378,7 @@ impl KnowledgePack {
         }
 
         let ns = token.namespace().as_str().to_string();
-        let section_signals_val = params.get("section_signals").cloned().unwrap_or_default();
+        let section_signals_val = p.section_signals.clone();
 
         // Tier 1: explicit profile from config — route exclusively to brain.feedback.
         if let Some(ref profile_id) = self.brain_profile {

--- a/crates/khive-pack-knowledge/src/knowledge/ann_degrade_tests.rs
+++ b/crates/khive-pack-knowledge/src/knowledge/ann_degrade_tests.rs
@@ -89,6 +89,81 @@ impl EmbedderProvider for FakeDimProvider {
     }
 }
 
+// Controlled two-topic embedder for the degraded-candidate ranking test.  The
+// query and genuinely relevant domain share the first axis; the domain whose
+// title only collides lexically shares the second.  The failing variant still
+// embeds/indexes the corpus and embeds the ANN query, but rejects the later
+// query-plus-candidates batch so the fresh rerank is genuinely unavailable.
+struct ControlledRankingService {
+    fail_fresh_rerank: bool,
+}
+
+#[async_trait]
+impl EmbeddingService for ControlledRankingService {
+    async fn embed(
+        &self,
+        texts: &[String],
+        _model: EmbeddingModel,
+    ) -> Result<Vec<Vec<f32>>, EmbedError> {
+        if self.fail_fresh_rerank
+            && texts.len() > 1
+            && texts[0].contains("speculative decoding inference acceleration")
+        {
+            return Err(EmbedError::InferenceFailed(
+                "controlled fresh-rerank failure".into(),
+            ));
+        }
+        Ok(texts
+            .iter()
+            .map(|text| {
+                let lower = text.to_lowercase();
+                if lower.contains("semantic_target")
+                    || lower.contains("speculative decoding inference acceleration")
+                {
+                    let mut vector = vec![0.0; DIM];
+                    vector[0] = 1.0;
+                    vector
+                } else if lower.contains("lexical_collision") {
+                    let mut vector = vec![0.0; DIM];
+                    vector[1] = 1.0;
+                    vector
+                } else {
+                    vec![1.0 / (DIM as f32).sqrt(); DIM]
+                }
+            })
+            .collect())
+    }
+
+    fn supports_model(&self, _model: EmbeddingModel) -> bool {
+        true
+    }
+
+    fn name(&self) -> &'static str {
+        "controlled-ranking"
+    }
+}
+
+struct ControlledRankingProvider {
+    fail_fresh_rerank: bool,
+}
+
+#[async_trait]
+impl EmbedderProvider for ControlledRankingProvider {
+    fn name(&self) -> &str {
+        MODEL_KEY
+    }
+
+    fn dimensions(&self) -> usize {
+        DIM
+    }
+
+    async fn build(&self) -> Result<Arc<dyn EmbeddingService>, khive_runtime::RuntimeError> {
+        Ok(Arc::new(ControlledRankingService {
+            fail_fresh_rerank: self.fail_fresh_rerank,
+        }))
+    }
+}
+
 // ── helpers ───────────────────────────────────────────────────────────────────
 
 fn rt_with_fake_embedder() -> KhiveRuntime {
@@ -108,6 +183,26 @@ fn rt_with_fake_embedder() -> KhiveRuntime {
     })
     .expect("in-memory runtime");
     rt.register_embedder(FakeDimProvider);
+    rt
+}
+
+fn rt_with_controlled_ranking(fail_fresh_rerank: bool) -> KhiveRuntime {
+    let rt = KhiveRuntime::new(RuntimeConfig {
+        git_write: Default::default(),
+        db_path: None,
+        default_namespace: Namespace::local(),
+        embedding_model: Some(EmbeddingModel::AllMiniLmL6V2),
+        additional_embedding_models: vec![],
+        gate: Arc::new(AllowAllGate),
+        packs: vec!["kg".to_string(), "knowledge".to_string()],
+        backend_id: BackendId::main(),
+        brain_profile: None,
+        visible_namespaces: vec![],
+        allowed_outbound_namespaces: vec![],
+        actor_id: None,
+    })
+    .expect("in-memory runtime");
+    rt.register_embedder(ControlledRankingProvider { fail_fresh_rerank });
     rt
 }
 
@@ -376,5 +471,144 @@ async fn warm_known_snapshots_loads_persisted_snapshot() {
             .is_some(),
         "search_loaded must return Some after warm_known_snapshots loads the snapshot; \
          model={model}, key={key:?}"
+    );
+}
+
+// ── P3: issue #91 — degraded-mode escalation + consequence semantics ──────────
+
+/// When ANN candidate retrieval times out, distinguish a successful fresh
+/// dense rerank from a genuinely lexical-only result.  Both cases use the same
+/// candidates: dense reranking promotes the semantically relevant domain,
+/// while an unavailable rerank leaves the lexical title collision first.
+#[tokio::test]
+async fn suggest_reports_degraded_candidates_or_lexical_only_from_ranking_consequence() {
+    let _serial = TIMEOUT_OVERRIDE_SERIAL.lock().await;
+    vamana::set_warm_wait_timeout_override_ms(50);
+    let _reset = TimeoutOverrideReset;
+
+    for (fail_fresh_rerank, expected_mode, expected_winner) in [
+        (false, "ann_candidates_degraded", "Opaque Systems Domain"),
+        (
+            true,
+            "lexical_only",
+            "Speculative Decoding Methods for Inference",
+        ),
+    ] {
+        let rt = rt_with_controlled_ranking(fail_fresh_rerank);
+        let registry = build_registry(&rt);
+        registry
+            .dispatch(
+                "knowledge.upsert_domains",
+                json!({"domains": [
+                    {
+                        "slug": "degrade-semantic-domain",
+                        "name": "Opaque Systems Domain",
+                        "description": "SEMANTIC_TARGET serving throughput latency batching cache scheduling gpu utilization request queuing parallelism autoscaling deployment topology load balancing production workloads resource management observability reliability"
+                    },
+                    {
+                        "slug": "degrade-lexical-collision",
+                        "name": "Speculative Decoding Methods for Inference",
+                        "description": "LEXICAL_COLLISION techniques for large language models emphasize decoding speculation, inference methods, acceleration strategies, model techniques, language processing, and unrelated terminology repeated for lexical matching"
+                    }
+                ]}),
+            )
+            .await
+            .expect("upsert domains");
+        registry
+            .dispatch("knowledge.index", json!({ "rebuild_ann": false }))
+            .await
+            .expect("index");
+
+        let ann = vamana::new_shared();
+        let key = vamana::AnnKey::new("local", rt.default_embedder_name());
+        vamana::simulate_warming_in_flight(&ann, key);
+        let token = rt.authorize(Namespace::local()).expect("authorize");
+        let result = KnowledgeHandlers::suggest(
+            &rt,
+            &token,
+            json!({
+                "query": "speculative decoding inference acceleration techniques for large language models"
+            }),
+            &ann,
+        )
+        .await
+        .expect("suggest must not Err");
+
+        assert_eq!(result["ann_unavailable"], true, "result: {result}");
+        assert_eq!(
+            result["degraded"]["mode"], expected_mode,
+            "result: {result}"
+        );
+        assert_eq!(
+            result["results"][0]["name"], expected_winner,
+            "result: {result}"
+        );
+    }
+}
+
+/// The zero-hit case (P1a's scenario) must ALSO carry the new `degraded`
+/// object with `mode: "no_match"`, distinguishing "couldn't check" from
+/// "lexical matching ran and found this particular set" (the P3 case above).
+#[tokio::test]
+async fn suggest_flags_degraded_no_match_when_hits_empty() {
+    let _serial = TIMEOUT_OVERRIDE_SERIAL.lock().await;
+    vamana::set_warm_wait_timeout_override_ms(50);
+    let _reset = TimeoutOverrideReset;
+
+    let rt = rt_with_fake_embedder();
+    let registry = build_registry(&rt);
+
+    // Non-domain atom: `suggest`'s type_filter="domain" drops it, so lexical
+    // hits are empty (mirrors P1a).
+    registry
+        .dispatch(
+            "knowledge.upsert_atoms",
+            json!({
+                "atoms": [{
+                    "slug": "degrade-suggest-atom-2",
+                    "name": "Degrade Suggest Atom 2",
+                    "content": "transformer neural network attention mechanism self-attention encoder decoder positional embedding layer normalization residual connection feed forward dense sparse retrieval vector index"
+                }]
+            }),
+        )
+        .await
+        .expect("upsert atom");
+
+    registry
+        .dispatch("knowledge.index", json!({ "rebuild_ann": false }))
+        .await
+        .expect("index");
+
+    let ann = vamana::new_shared();
+    let model = rt.default_embedder_name().to_string();
+    let key = vamana::AnnKey::new("local", &model);
+    vamana::simulate_warming_in_flight(&ann, key);
+
+    let token = rt.authorize(Namespace::local()).expect("authorize");
+    let result = KnowledgeHandlers::suggest(
+        &rt,
+        &token,
+        json!({ "query": "machine learning neural network transformer attention" }),
+        &ann,
+    )
+    .await
+    .expect("suggest must not Err");
+
+    assert_eq!(result.get("total").and_then(|v| v.as_u64()), Some(0));
+    assert_eq!(
+        result.get("ann_unavailable").and_then(|v| v.as_bool()),
+        Some(true)
+    );
+    let degraded = result
+        .get("degraded")
+        .unwrap_or_else(|| panic!("degraded object must be present; got: {result}"));
+    assert_eq!(
+        degraded.get("mode").and_then(|v| v.as_str()),
+        Some("no_match"),
+        "zero-hit degraded suggest must report mode=no_match, distinct from lexical_only; got: {result}"
+    );
+    assert_eq!(
+        degraded.get("cache_safe").and_then(|v| v.as_bool()),
+        Some(false)
     );
 }

--- a/crates/khive-pack-knowledge/src/knowledge/crud.rs
+++ b/crates/khive-pack-knowledge/src/knowledge/crud.rs
@@ -7,7 +7,7 @@ use khive_runtime::{KhiveRuntime, NamespaceToken, RuntimeError};
 use khive_storage::types::{SqlStatement, SqlValue};
 
 use super::schema::{
-    DeleteAtomsParams, GetParams, ListParams, UpsertAtomsParams, UpsertDomainsParams,
+    DeleteAtomsParams, GetParams, ListParams, StatsParams, UpsertAtomsParams, UpsertDomainsParams,
 };
 use super::sections::{section_from_row, section_to_json};
 use super::util::{
@@ -698,8 +698,9 @@ impl KnowledgeHandlers {
     pub(crate) async fn stats(
         runtime: &KhiveRuntime,
         token: &NamespaceToken,
-        _params: Value,
+        params: Value,
     ) -> Result<Value, RuntimeError> {
+        let _: StatsParams = deser(params)?;
         let ns = token.namespace().as_str().to_owned();
         let sql = runtime.sql();
         let mut reader = sql.reader().await.map_err(|e| sql_err("stats reader", e))?;

--- a/crates/khive-pack-knowledge/src/knowledge/fold_handler.rs
+++ b/crates/khive-pack-knowledge/src/knowledge/fold_handler.rs
@@ -105,6 +105,7 @@ impl KnowledgeHandlers {
                     "id": item.id,
                     "score": item.score,
                     "size": item.size,
+                    "name": item.content.name,
                     "content": item.content.content,
                     "category": item.content.category,
                 })

--- a/crates/khive-pack-knowledge/src/knowledge/mod.rs
+++ b/crates/khive-pack-knowledge/src/knowledge/mod.rs
@@ -18,3 +18,5 @@ pub(crate) struct KnowledgeHandlers;
 
 #[cfg(test)]
 mod ann_degrade_tests;
+#[cfg(test)]
+mod suggest_ranking_tests;

--- a/crates/khive-pack-knowledge/src/knowledge/schema.rs
+++ b/crates/khive-pack-knowledge/src/knowledge/schema.rs
@@ -82,6 +82,7 @@ pub(crate) struct Domain {
 // ── upsert_atoms ─────────────────────────────────────────────────────────────
 
 #[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub(crate) struct AtomInput {
     pub slug: String,
     pub name: String,
@@ -101,6 +102,7 @@ pub(crate) struct AtomInput {
 }
 
 #[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub(crate) struct UpsertAtomsParams {
     pub atoms: Vec<AtomInput>,
     #[serde(default)]
@@ -126,6 +128,7 @@ pub(crate) struct DomainInput {
 }
 
 #[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub(crate) struct UpsertDomainsParams {
     pub domains: Vec<DomainInput>,
 }
@@ -133,6 +136,7 @@ pub(crate) struct UpsertDomainsParams {
 // ── get ───────────────────────────────────────────────────────────────────────
 
 #[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub(crate) struct GetParams {
     pub id: String,
     /// When `true`, include the atom's sections in the response under a `sections` key.
@@ -144,6 +148,7 @@ pub(crate) struct GetParams {
 // ── list ─────────────────────────────────────────────────────────────────────
 
 #[derive(Debug, Deserialize, Default)]
+#[serde(deny_unknown_fields)]
 pub(crate) struct ListParams {
     #[serde(rename = "type", alias = "kind", default)]
     pub kind: Option<String>,
@@ -157,9 +162,19 @@ pub(crate) struct ListParams {
     pub exclude_status: Option<String>,
 }
 
+// ── stats ────────────────────────────────────────────────────────────────────
+
+/// `knowledge.stats` takes no filter arguments; the empty struct exists purely
+/// so unknown/typo'd params (e.g. a caller expecting a `domain` filter that
+/// doesn't exist) are rejected instead of silently ignored.
+#[derive(Debug, Deserialize, Default)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct StatsParams {}
+
 // ── delete_atoms ──────────────────────────────────────────────────────────────
 
 #[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub(crate) struct DeleteAtomsParams {
     pub ids: Vec<String>,
     #[serde(default)]
@@ -171,6 +186,7 @@ pub(crate) struct DeleteAtomsParams {
 // ── index ─────────────────────────────────────────────────────────────────────
 
 #[derive(Debug, Deserialize, Default)]
+#[serde(deny_unknown_fields)]
 pub(crate) struct IndexParams {
     #[serde(default)]
     pub ids: Option<Vec<String>>,
@@ -185,6 +201,7 @@ pub(crate) struct IndexParams {
 // ── fold ─────────────────────────────────────────────────────────────────────
 
 #[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub(crate) struct FoldParams {
     pub candidates: Vec<FoldCandidate>,
     pub budget: usize,
@@ -199,10 +216,17 @@ pub(crate) struct FoldParams {
 }
 
 #[derive(Debug, Clone, Deserialize, serde::Serialize)]
+#[serde(deny_unknown_fields)]
 pub(crate) struct FoldCandidate {
     pub id: String,
     pub score: f32,
     pub size: usize,
+    /// Display name, e.g. from `knowledge.suggest`'s `{id, name, score, size}`
+    /// output — accepted (and echoed back on `selected` items) so `suggest`'s
+    /// results feed `fold`'s `candidates` unmodified (issue #105); not used by
+    /// the selection algorithm itself.
+    #[serde(default)]
+    pub name: Option<String>,
     #[serde(default)]
     pub content: Option<Value>,
     #[serde(default)]
@@ -214,6 +238,7 @@ pub(crate) struct FoldCandidate {
 // ── search ────────────────────────────────────────────────────────────────────
 
 #[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub(crate) struct SearchParams {
     pub query: String,
     #[serde(rename = "type", alias = "kind", default)]
@@ -249,6 +274,7 @@ pub(crate) struct SearchParams {
 
 /// Tunable TF-IDF weight parameters.
 #[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub(crate) struct SearchWeights {
     pub w_exact_name: Option<f64>,
     pub w_name: Option<f64>,
@@ -262,6 +288,7 @@ pub(crate) struct SearchWeights {
 // ── suggest ───────────────────────────────────────────────────────────────────
 
 #[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub(crate) struct SuggestParams {
     pub query: String,
     #[serde(default)]
@@ -273,6 +300,7 @@ pub(crate) struct SuggestParams {
 // ── compose ───────────────────────────────────────────────────────────────────
 
 #[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub(crate) struct ComposeParams {
     #[serde(default)]
     pub domain_ids: Option<Vec<String>>,
@@ -297,6 +325,7 @@ pub(crate) struct ComposeParams {
 
 /// One section update within a `knowledge.edit` call.
 #[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub(crate) struct SectionUpdate {
     /// Section type (must be a valid `SectionType` canonical name).
     pub section_type: String,
@@ -311,6 +340,7 @@ pub(crate) struct SectionUpdate {
 }
 
 #[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub(crate) struct EditParams {
     /// Atom UUID or slug to edit sections for.
     pub id: String,
@@ -321,6 +351,7 @@ pub(crate) struct EditParams {
 // ── challenge / adjudicate ────────────────────────────────────────────────────
 
 #[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub(crate) struct ChallengeParams {
     /// Atom UUID or slug.
     pub atom_id: String,
@@ -337,6 +368,7 @@ pub(crate) struct ChallengeParams {
 }
 
 #[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub(crate) struct AdjudicateParams {
     /// Atom UUID or slug.
     pub atom_id: String,
@@ -354,6 +386,7 @@ pub(crate) struct AdjudicateParams {
 // ── import ────────────────────────────────────────────────────────────────────
 
 #[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub(crate) struct ImportParams {
     /// Filesystem path to a markdown file or directory.
     pub path: String,

--- a/crates/khive-pack-knowledge/src/knowledge/search.rs
+++ b/crates/khive-pack-knowledge/src/knowledge/search.rs
@@ -23,7 +23,7 @@ use super::util::{
     atom_embed_text, atom_from_row, compose_item_char_cost, deser, domain_from_row,
     estimate_compose_item_tokens, explicitly_requested_status, is_stop, row_bool, row_str, sql_err,
     status_multiplier, status_sql_clause, status_values, CANDIDATE_POOL, CHARS_PER_TOKEN,
-    MIN_TERM_LEN,
+    D_SUGGEST_RERANK_ALPHA, MIN_TERM_LEN,
 };
 use super::vamana;
 use super::KnowledgeHandlers;
@@ -502,9 +502,9 @@ async fn rerank_with_embeddings(
     query: &str,
     hits: &mut [ScoredHit],
     alpha: f32,
-) -> Result<(), RuntimeError> {
+) -> Result<bool, RuntimeError> {
     if hits.is_empty() {
-        return Ok(());
+        return Ok(false);
     }
     let texts: Vec<String> = hits
         .iter()
@@ -526,8 +526,9 @@ async fn rerank_with_embeddings(
                 .unwrap_or(std::cmp::Ordering::Equal)
                 .then_with(|| a.slug.cmp(&b.slug))
         });
+        return Ok(true);
     }
-    Ok(())
+    Ok(false)
 }
 
 fn cosine_similarity(a: &[f32], b: &[f32]) -> f32 {
@@ -1418,20 +1419,25 @@ impl KnowledgeHandlers {
                 {
                     ann_hits_opt = vamana::search_loaded(ann, &key, &query_emb, ann_k).await;
                 } else {
-                    // Still not ready after the wait.  If FTS already collected
-                    // non-empty hits, return those partial results rather than
-                    // erroring — mirrors the same guard in `search`.  Only set
-                    // ann_unavailable when FTS is also empty and the corpus is
-                    // non-empty (a genuinely misleading silent-zero case) (issue #322).
-                    if hits.is_empty() {
-                        let model = runtime.default_embedder_name();
-                        let corpus_non_empty = vamana::compute_fingerprint(runtime, token, model)
-                            .await
-                            .map(|fp| fp.vector_count > 0)
-                            .unwrap_or(false);
-                        if corpus_non_empty {
-                            ann_unavailable = true;
-                        }
+                    // Still not ready after the wait.  FTS/full-scan lexical hits
+                    // (if any) already sit in `hits` and are returned regardless —
+                    // ANN unavailability degrades candidate recall breadth, not
+                    // necessarily final ranking: the fresh embedding rerank below
+                    // can still apply a dense score to the lexical candidates.
+                    // A caller must not read non-empty `hits` here as evidence of
+                    // healthy candidate retrieval either.
+                    // Flag degraded whenever the corpus is genuinely non-empty,
+                    // in BOTH the empty-hits case (issue #322: total:0 could
+                    // mean "nothing exists" or "couldn't check") and the
+                    // non-empty case (issue #91: partial candidate retrieval looks
+                    // identical to a healthy response unless flagged).
+                    let model = runtime.default_embedder_name();
+                    let corpus_non_empty = vamana::compute_fingerprint(runtime, token, model)
+                        .await
+                        .map(|fp| fp.vector_count > 0)
+                        .unwrap_or(false);
+                    if corpus_non_empty {
+                        ann_unavailable = true;
                     }
                 }
             }
@@ -1449,7 +1455,8 @@ impl KnowledgeHandlers {
             }
         }
 
-        rerank_with_embeddings(runtime, &raw_query, &mut hits, 0.7).await?;
+        let fresh_rerank_applied =
+            rerank_with_embeddings(runtime, &raw_query, &mut hits, D_SUGGEST_RERANK_ALPHA).await?;
 
         // Safety net: retain only domain hits in case any non-domain survived above.
         hits.retain(|h| h.is_domain);
@@ -1477,7 +1484,42 @@ impl KnowledgeHandlers {
 
         let mut out = json!({ "results": results, "total": count });
         if ann_unavailable {
+            // issue #91: escalate degradation to a top-level, self-explaining
+            // signal instead of a bare total:0 or an unflagged partial list.
+            // `ann_unavailable` is kept unchanged for existing callers; `degraded`
+            // states the consequence so a caller does not have to infer it.
             out["ann_unavailable"] = json!(true);
+            let (mode, note): (&str, &str) = match (count, fresh_rerank_applied) {
+                (0, _) => (
+                    "no_match",
+                    "ANN index unavailable and lexical/FTS matching also found no \
+                     domain for this query. This does NOT confirm the corpus has \
+                     nothing relevant — only that this call could not find one. \
+                     Do not cache as an absence; retry once the index is healthy.",
+                ),
+                (_, true) => (
+                    "ann_candidates_degraded",
+                    "ANN index unavailable: candidate retrieval used lexical/FTS \
+                     matching, but fresh embedding cosine reranking was applied to \
+                     those candidates. Final ranking includes a dense signal, while \
+                     topically relevant domains outside the lexical candidate set may \
+                     still be missing. Do not cache; retry once the index is healthy.",
+                ),
+                (_, false) => (
+                    "lexical_only",
+                    "ANN index unavailable and fresh embedding reranking did not run: \
+                     these results were ranked by lexical/FTS matching only. Ranking \
+                     may be less precise than a healthy call, and topically relevant \
+                     domains outside the lexical match may be missing. Do not cache; \
+                     retry once the index is healthy.",
+                ),
+            };
+            out["degraded"] = json!({
+                "reason": "ann_unavailable",
+                "mode": mode,
+                "cache_safe": false,
+                "note": note,
+            });
         }
         Ok(out)
     }

--- a/crates/khive-pack-knowledge/src/knowledge/search.rs
+++ b/crates/khive-pack-knowledge/src/knowledge/search.rs
@@ -20,9 +20,10 @@ use super::scoring::{
     Candidate, Weights,
 };
 use super::util::{
-    atom_embed_text, atom_from_row, deser, domain_from_row, explicitly_requested_status, is_stop,
-    row_bool, row_str, sql_err, status_multiplier, status_sql_clause, status_values,
-    CANDIDATE_POOL, MIN_TERM_LEN,
+    atom_embed_text, atom_from_row, compose_item_char_cost, deser, domain_from_row,
+    estimate_compose_item_tokens, explicitly_requested_status, is_stop, row_bool, row_str, sql_err,
+    status_multiplier, status_sql_clause, status_values, CANDIDATE_POOL, CHARS_PER_TOKEN,
+    MIN_TERM_LEN,
 };
 use super::vamana;
 use super::KnowledgeHandlers;
@@ -809,6 +810,65 @@ fn parse_domain_members(domain: &Domain) -> Result<Vec<String>, RuntimeError> {
     })
 }
 
+async fn load_domain_member_token_sizes(
+    runtime: &KhiveRuntime,
+    ns: &str,
+    domain_ids: &[String],
+) -> Result<HashMap<String, usize>, RuntimeError> {
+    let mut sizes: HashMap<String, usize> = domain_ids.iter().map(|id| (id.clone(), 0)).collect();
+    if domain_ids.is_empty() {
+        return Ok(sizes);
+    }
+
+    let placeholders = domain_ids
+        .iter()
+        .enumerate()
+        .map(|(i, _)| format!("?{}", i + 2))
+        .collect::<Vec<_>>()
+        .join(",");
+    let mut params = vec![SqlValue::Text(ns.to_owned())];
+    params.extend(domain_ids.iter().cloned().map(SqlValue::Text));
+
+    let sql = runtime.sql();
+    let mut reader = sql
+        .reader()
+        .await
+        .map_err(|e| sql_err("suggest member size reader", e))?;
+    let rows = reader
+        .query_all(SqlStatement {
+            sql: format!(
+                "SELECT d.id AS domain_id, a.name, a.content \
+                 FROM knowledge_domains AS d \
+                 JOIN json_each(d.members) AS member ON 1 = 1 \
+                 JOIN knowledge_atoms AS a \
+                   ON a.namespace = d.namespace \
+                  AND a.slug = member.value \
+                  AND a.deleted_at IS NULL \
+                 WHERE d.namespace = ?1 \
+                   AND d.id IN ({placeholders}) \
+                   AND d.deleted_at IS NULL"
+            ),
+            params,
+            label: None,
+        })
+        .await
+        .map_err(|e| sql_err("suggest member size query", e))?;
+
+    for row in rows {
+        let Some(domain_id) = row_str(&row, "domain_id") else {
+            continue;
+        };
+        let Some(content) = row_str(&row, "content") else {
+            continue;
+        };
+        let name = row_str(&row, "name").unwrap_or_default();
+        let size = sizes.entry(domain_id).or_default();
+        *size = size.saturating_add(estimate_compose_item_tokens(&name, &content));
+    }
+
+    Ok(sizes)
+}
+
 async fn rerank_text_items(
     runtime: &KhiveRuntime,
     query: &str,
@@ -974,7 +1034,7 @@ fn trim_kg_entities_to_budget(hits: Vec<KgEntityHit>, remaining_budget: usize) -
     let mut used = 0usize;
     hits.into_iter()
         .take_while(|h| {
-            let cost = h.name.len() + h.description.len() + 40;
+            let cost = compose_item_char_cost(&h.name, &h.description);
             if used + cost > remaining_budget {
                 return false;
             }
@@ -1395,9 +1455,23 @@ impl KnowledgeHandlers {
         hits.retain(|h| h.is_domain);
         hits.truncate(limit);
 
+        let domain_ids: Vec<String> = hits.iter().map(|h| h.id.clone()).collect();
+        let member_token_sizes = load_domain_member_token_sizes(runtime, &ns, &domain_ids).await?;
+
+        // Price the member atom bodies that compose expands, not the much smaller
+        // domain mirror description used for retrieval. The batched join keeps the
+        // suggest -> fold budget in compose's estimated-token unit without an N+1
+        // hydration pass.
         let results: Vec<Value> = hits
             .iter()
-            .map(|h| json!({ "id": h.id, "name": h.name, "score": h.score }))
+            .map(|h| {
+                json!({
+                    "id": h.id,
+                    "name": h.name,
+                    "score": h.score,
+                    "size": member_token_sizes.get(&h.id).copied().unwrap_or_default(),
+                })
+            })
             .collect();
         let count = results.len();
 
@@ -1660,7 +1734,6 @@ impl KnowledgeHandlers {
         timing.begin(Phase::Trim);
 
         let max_tokens = p.max_tokens.unwrap_or(8000).clamp(500, 100_000);
-        const CHARS_PER_TOKEN: usize = 4;
         let char_budget = max_tokens * CHARS_PER_TOKEN;
 
         // Tracks characters consumed by the atom/section body so blended KG
@@ -1670,7 +1743,7 @@ impl KnowledgeHandlers {
 
         if !section_results.is_empty() {
             section_results.retain(|s| {
-                let cost = s.heading.len() + s.content.len() + 40;
+                let cost = compose_item_char_cost(&s.heading, &s.content);
                 if body_used + cost > char_budget {
                     return false;
                 }
@@ -1723,7 +1796,7 @@ impl KnowledgeHandlers {
                         .map(|a| (a, item.score))
                 })
                 .take_while(|(a, _)| {
-                    let cost = a.name.len() + a.content.len() + 40;
+                    let cost = compose_item_char_cost(&a.name, &a.content);
                     if body_used + cost > char_budget {
                         return false;
                     }

--- a/crates/khive-pack-knowledge/src/knowledge/sections.rs
+++ b/crates/khive-pack-knowledge/src/knowledge/sections.rs
@@ -477,6 +477,13 @@ impl KnowledgeHandlers {
                 properties.insert("atlas_id".to_string(), Value::String(id.clone()));
             }
 
+            // finalized=true so imported atoms land at status="reviewed" instead of the
+            // upsert_atoms default "draft" — knowledge.search/suggest exclude "draft" by
+            // default (SearchParams::include_drafts defaults false), so a bulk-imported
+            // corpus was previously present (knowledge.list, no default status filter)
+            // but unretrievable through search/suggest until someone finalized every atom
+            // individually. Imported content is externally-authored source material the
+            // caller already chose to ingest, not an agent-proposed draft pending review.
             let upsert_params = serde_json::json!({
                 "atoms": [{
                     "slug": slug,
@@ -485,6 +492,7 @@ impl KnowledgeHandlers {
                     "properties": Value::Object(properties),
                     "source_uri": source_uri,
                     "source_type": source_type,
+                    "finalized": true,
                 }]
             });
             KnowledgeHandlers::upsert_atoms(runtime, token, upsert_params).await?;

--- a/crates/khive-pack-knowledge/src/knowledge/suggest_ranking_tests.rs
+++ b/crates/khive-pack-knowledge/src/knowledge/suggest_ranking_tests.rs
@@ -1,0 +1,392 @@
+//! Regression fixture for issue #90 — cross-domain word-sense collisions
+//! outranking the on-field domain in `knowledge.suggest`.
+//!
+//! Root cause (verified against source, see search.rs + util.rs comments):
+//! `suggest` blends a lexical/RRF-fused score (dominated by TF-IDF matches on
+//! the domain NAME, weighted `D_W_EXACT_NAME=5.0`/`D_W_NAME=3.0`) with a
+//! fresh embedding cosine, via `score = alpha*norm_tfidf + (1-alpha)*cos`.
+//! The old `alpha=0.7` let a domain whose TITLE happens to contain a rare,
+//! polysemous query token (e.g. "decoding") win on lexical weight alone, even
+//! when a genuinely good semantic signal (cosine) correctly favors the
+//! on-topic domain. The fix lowers the blend weight to `D_SUGGEST_RERANK_ALPHA
+//! = 0.3` so the semantic leg — the only leg capable of sense disambiguation —
+//! dominates the final rank.
+//!
+//! This fixture uses a controlled fake embedder (topic vectors keyed on a
+//! unique marker token per domain, NOT derived from surface tokens) so the
+//! test isolates the blend-weight mechanism from real embedding-model
+//! quality. Five query/domain-set pairs across different fields: the
+//! production repro from #90 plus four constructed pairs, each following the
+//! same shape (collision domain shares a literal rare token with the query in
+//! its title; correct domain is semantically on-topic per the controlled
+//! embedding but shares fewer/no literal title tokens).
+
+use async_trait::async_trait;
+use khive_pack_kg::KgPack;
+use khive_runtime::{
+    AllowAllGate, BackendId, EmbedderProvider, KhiveRuntime, Namespace, NamespaceToken,
+    RuntimeConfig, VerbRegistry, VerbRegistryBuilder,
+};
+use lattice_embed::{EmbedError, EmbeddingModel, EmbeddingService};
+use serde_json::json;
+use std::sync::Arc;
+
+use crate::knowledge::{vamana, KnowledgeHandlers};
+
+const MODEL_KEY: &str = "all-minilm-l6-v2";
+const DIM: usize = 8;
+
+/// Context-keyword bags per topic — a controlled stand-in for a real
+/// embedding model's ability to use SURROUNDING CONTEXT to disambiguate a
+/// shared polysemous token. Deliberately excludes the collision token itself
+/// (e.g. "decoding") from every bucket, since that lone token is exactly what
+/// a bag-of-words TF-IDF leg over-weights; the buckets instead capture the
+/// multi-word context a real query naturally uses, so the query embeds close
+/// to its on-topic domain and far from the lexical-collision domain
+/// independent of the literal shared word.
+const TOPIC_KEYWORDS: &[&[&str]] = &[
+    &[
+        "inference",
+        "language model",
+        "acceleration",
+        "serving",
+        "latency",
+        "throughput",
+    ],
+    &[
+        "channel",
+        "communication theoretic",
+        "error budget",
+        "bandwidth",
+        "signal processing",
+    ],
+    &[
+        "contract formation",
+        "bargained-for",
+        "enforceable",
+        "bilateral",
+        "consideration requirement",
+    ],
+    &[
+        "empathy",
+        "interpersonal",
+        "workplace communication",
+        "thoughtfulness",
+        "regard for others",
+    ],
+    &[
+        "polymerase",
+        "promoter",
+        "gene expression",
+        "chromatin",
+        "molecular biology",
+    ],
+    &[
+        "acoustic model",
+        "audio recording",
+        "speech recognition",
+        "diarization",
+        "transcript",
+    ],
+    &[
+        "diatonic",
+        "voice leading",
+        "cadence",
+        "songwriting",
+        "harmonic function",
+    ],
+    &[
+        "inscribed angle",
+        "perpendicular bisector",
+        "tangent",
+        "euclidean",
+        "compass",
+    ],
+    &[
+        "options",
+        "portfolio risk",
+        "derivatives",
+        "downside protection",
+        "volatility",
+    ],
+    &[
+        "shrub",
+        "garden boundary",
+        "pruning",
+        "irrigation",
+        "landscape design",
+    ],
+];
+
+fn text_to_vector(text: &str) -> Vec<f32> {
+    let lower = text.to_lowercase();
+    TOPIC_KEYWORDS
+        .iter()
+        .map(|keywords| keywords.iter().filter(|kw| lower.contains(*kw)).count() as f32)
+        .collect()
+}
+
+struct FixtureEmbedService;
+
+#[async_trait]
+impl EmbeddingService for FixtureEmbedService {
+    async fn embed(
+        &self,
+        texts: &[String],
+        _model: EmbeddingModel,
+    ) -> Result<Vec<Vec<f32>>, EmbedError> {
+        Ok(texts.iter().map(|t| text_to_vector(t)).collect())
+    }
+
+    fn supports_model(&self, _model: EmbeddingModel) -> bool {
+        true
+    }
+
+    fn name(&self) -> &'static str {
+        "fixture-topic"
+    }
+}
+
+struct FixtureEmbedProvider;
+
+#[async_trait]
+impl EmbedderProvider for FixtureEmbedProvider {
+    fn name(&self) -> &str {
+        MODEL_KEY
+    }
+
+    fn dimensions(&self) -> usize {
+        DIM.max(10)
+    }
+
+    async fn build(&self) -> Result<Arc<dyn EmbeddingService>, khive_runtime::RuntimeError> {
+        Ok(Arc::new(FixtureEmbedService))
+    }
+}
+
+fn rt_with_fixture_embedder() -> KhiveRuntime {
+    let rt = KhiveRuntime::new(RuntimeConfig {
+        git_write: Default::default(),
+        db_path: None,
+        default_namespace: Namespace::local(),
+        embedding_model: Some(EmbeddingModel::AllMiniLmL6V2),
+        additional_embedding_models: vec![],
+        gate: Arc::new(AllowAllGate),
+        packs: vec!["kg".to_string(), "knowledge".to_string()],
+        backend_id: BackendId::main(),
+        brain_profile: None,
+        visible_namespaces: vec![],
+        allowed_outbound_namespaces: vec![],
+        actor_id: None,
+    })
+    .expect("in-memory runtime");
+    rt.register_embedder(FixtureEmbedProvider);
+    rt
+}
+
+fn build_registry(rt: &KhiveRuntime) -> VerbRegistry {
+    let mut builder = VerbRegistryBuilder::new();
+    builder.register(KgPack::new(rt.clone()));
+    builder.register(crate::KnowledgePack::new(rt.clone()));
+    let registry = builder.build().expect("registry builds");
+    rt.install_edge_rules(registry.all_edge_rules());
+    registry
+}
+
+struct Pair {
+    label: &'static str,
+    query: &'static str,
+    correct_name: &'static str,
+    correct_desc: &'static str,
+    collision_name: &'static str,
+    collision_desc: &'static str,
+}
+
+const PAIRS: &[Pair] = &[
+    Pair {
+        label: "llm-inference (issue #90 production repro)",
+        query: "speculative decoding inference acceleration techniques for large language models",
+        correct_name: "Model Serving and Inference Optimization",
+        correct_desc: "LLM_SERVING covering serving throughput latency batching kv cache scheduling gpu utilization request queuing model parallelism autoscaling deployment topology load balancing techniques for production inference workloads",
+        collision_name: "Decoding and Batch-Inference Error Budgets for Communication-Aware ML",
+        collision_desc: "COMM_THEORY covering channel coding error budgets communication theoretic bounds noisy channel capacity redundancy checksums forward error correction signal processing bandwidth allocation reliability engineering topics",
+    },
+    Pair {
+        label: "contract-law vs general regard",
+        query: "consideration requirement for enforceable bilateral contract formation",
+        correct_name: "Contract Formation and Consideration Doctrine",
+        correct_desc: "CONTRACT_LAW covering offer acceptance bargained-for exchange enforceability mutual assent capacity legality promissory estoppel breach remedies damages formation defenses statute of frauds topics",
+        collision_name: "Consideration and Empathy in Workplace Communication",
+        collision_desc: "AFFECT_REGARD covering thoughtfulness regard for others interpersonal communication empathy active listening workplace kindness emotional intelligence rapport building conflict de-escalation soft skills coaching topics",
+    },
+    Pair {
+        label: "molecular transcription vs speech transcription",
+        query: "RNA polymerase transcription initiation promoter binding gene expression",
+        correct_name: "Transcription Factor Binding and Gene Regulation",
+        correct_desc: "MOL_BIO covering polymerase promoter enhancer chromatin gene expression regulation transcription factor binding sites epigenetics histone modification cell signaling molecular biology laboratory technique topics",
+        collision_name: "Automatic Transcription of Spoken Audio Recordings",
+        collision_desc: "SPEECH_TO_TEXT covering audio recording acoustic model language model decoding speech recognition pipelines diarization noise robustness transcript formatting punctuation restoration captioning workflow topics",
+    },
+    Pair {
+        label: "music chord progressions vs geometric chords",
+        query: "diatonic chord progression voice leading harmonic function in songwriting",
+        correct_name: "Chord Progressions and Harmonic Function",
+        correct_desc: "MUSIC_THEORY covering diatonic harmony voice leading cadence songwriting chord substitution modal interchange functional harmony key modulation counterpoint composition arranging practice topics",
+        collision_name: "Chord Length and Circle Geometry Theorems",
+        collision_desc: "GEOMETRY covering circle chord arc theorem perpendicular bisector inscribed angle tangent secant power of a point compass straightedge construction proof classical euclidean topics",
+    },
+    Pair {
+        label: "financial hedging vs garden hedges",
+        query: "options based hedge strategy for portfolio downside risk management",
+        correct_name: "Portfolio Hedging Strategies with Derivatives",
+        correct_desc: "FINANCE_HEDGE covering options futures downside protection portfolio risk management delta hedging volatility exposure tail risk collar strategy derivatives pricing risk management topics",
+        collision_name: "Hedge Planting and Garden Boundary Maintenance",
+        collision_desc: "LANDSCAPING covering hedge shrub planting garden boundary pruning trimming schedule privacy screening soil preparation irrigation seasonal maintenance landscape design boundary fencing topics",
+    },
+];
+
+async fn seed_pair(registry: &VerbRegistry, pair: &Pair, idx: usize) {
+    registry
+        .dispatch(
+            "knowledge.upsert_domains",
+            json!({
+                "domains": [
+                    {
+                        "slug": format!("fixture-{idx}-correct"),
+                        "name": pair.correct_name,
+                        "description": pair.correct_desc,
+                    },
+                    {
+                        "slug": format!("fixture-{idx}-collision"),
+                        "name": pair.collision_name,
+                        "description": pair.collision_desc,
+                    }
+                ]
+            }),
+        )
+        .await
+        .expect("upsert domain pair");
+}
+
+/// Cosine similarity, mirroring `search::cosine_similarity` (module-private,
+/// so duplicated here — this is pure test-fixture math, not shipped code).
+fn cosine(a: &[f32], b: &[f32]) -> f32 {
+    let dot: f32 = a.iter().zip(b).map(|(x, y)| x * y).sum();
+    let na: f32 = a.iter().map(|x| x * x).sum::<f32>().sqrt();
+    let nb: f32 = b.iter().map(|x| x * x).sum::<f32>().sqrt();
+    if na < 1e-8 || nb < 1e-8 {
+        0.0
+    } else {
+        dot / (na * nb)
+    }
+}
+
+/// Full fixture table, run both through the shipped end-to-end `suggest()`
+/// path AND through a manual reproduction of the blend formula at the OLD
+/// alpha=0.7 (proving the pre-fix ordering was indeed wrong) and the NEW
+/// alpha=0.3 (proving the fix, and matching the real `suggest()` outcome).
+#[tokio::test]
+async fn suggest_ranks_on_field_domain_above_lexical_collision() {
+    const OLD_ALPHA: f32 = 0.7;
+    const NEW_ALPHA: f32 = crate::knowledge::util::D_SUGGEST_RERANK_ALPHA;
+
+    let mut regressions: Vec<String> = Vec::new();
+    let mut report_rows: Vec<String> = Vec::new();
+
+    for (idx, pair) in PAIRS.iter().enumerate() {
+        let rt = rt_with_fixture_embedder();
+        let registry = build_registry(&rt);
+        seed_pair(&registry, pair, idx).await;
+
+        // Raw lexical (TF-IDF) score per domain, unblended — `rerank:false`
+        // skips the embedding leg entirely.
+        let lex = registry
+            .dispatch(
+                "knowledge.search",
+                json!({ "query": pair.query, "type": "domain", "rerank": false, "limit": 10 }),
+            )
+            .await
+            .expect("lexical search");
+        let lex_results = lex["results"].as_array().expect("results array");
+        let lex_score = |name: &str| -> f32 {
+            lex_results
+                .iter()
+                .find(|r| r["name"].as_str() == Some(name))
+                .and_then(|r| r["score"].as_f64())
+                .unwrap_or(0.0) as f32
+        };
+        let correct_lex = lex_score(pair.correct_name);
+        let collision_lex = lex_score(pair.collision_name);
+        let max_lex = correct_lex.max(collision_lex).max(1e-6);
+
+        // Cosine leg from the SAME controlled embedder used by suggest().
+        let q_vec = text_to_vector(pair.query);
+        // suggest's embed text is "{name} {content}"; our marker-substring
+        // matcher only needs the marker to appear anywhere in that string.
+        let correct_text = format!("{} {}", pair.correct_name, pair.correct_desc);
+        let collision_text = format!("{} {}", pair.collision_name, pair.collision_desc);
+        let correct_cos = cosine(&q_vec, &text_to_vector(&correct_text)).max(0.0);
+        let collision_cos = cosine(&q_vec, &text_to_vector(&collision_text)).max(0.0);
+
+        let blend = |alpha: f32, lex: f32, cos: f32| alpha * (lex / max_lex) + (1.0 - alpha) * cos;
+        let old_correct = blend(OLD_ALPHA, correct_lex, correct_cos);
+        let old_collision = blend(OLD_ALPHA, collision_lex, collision_cos);
+        let new_correct = blend(NEW_ALPHA, correct_lex, correct_cos);
+        let new_collision = blend(NEW_ALPHA, collision_lex, collision_cos);
+
+        let old_correct_wins = old_correct > old_collision;
+        let new_correct_wins = new_correct > new_collision;
+
+        // End-to-end: the real `suggest()` handler, fresh unwarmed ANN (no
+        // `knowledge.index` run) so the FTS+fresh-cosine blend path is
+        // exercised deterministically without ANN timing variance.
+        let ann = vamana::new_shared();
+        let token: NamespaceToken = rt.authorize(Namespace::local()).expect("authorize");
+        let suggest_result =
+            KnowledgeHandlers::suggest(&rt, &token, json!({ "query": pair.query }), &ann)
+                .await
+                .expect("suggest must not Err");
+        let results = suggest_result["results"].as_array().expect("results array");
+        let e2e_top_is_correct = results
+            .first()
+            .and_then(|r| r["name"].as_str())
+            .is_some_and(|n| n == pair.correct_name);
+
+        report_rows.push(format!(
+            "| {} | {:.3}/{:.3} | {:.3}/{:.3} | old(0.7)={} | new({NEW_ALPHA})={} | e2e_top_correct={} |",
+            pair.label,
+            correct_lex,
+            collision_lex,
+            correct_cos,
+            collision_cos,
+            if old_correct_wins { "CORRECT_WINS" } else { "COLLISION_WINS" },
+            if new_correct_wins { "CORRECT_WINS" } else { "COLLISION_WINS" },
+            e2e_top_is_correct,
+        ));
+
+        if !new_correct_wins {
+            regressions.push(format!(
+                "{}: correct domain does NOT win under the shipped alpha={NEW_ALPHA}",
+                pair.label
+            ));
+        }
+        if !e2e_top_is_correct {
+            regressions.push(format!(
+                "{}: end-to-end suggest() does not rank the correct domain first",
+                pair.label
+            ));
+        }
+    }
+
+    eprintln!("=== suggest ranking fixture (before/after) ===");
+    for row in &report_rows {
+        eprintln!("{row}");
+    }
+
+    assert!(
+        regressions.is_empty(),
+        "suggest ranking fixture regressions:\n{}\n\nfull table:\n{}",
+        regressions.join("\n"),
+        report_rows.join("\n")
+    );
+}

--- a/crates/khive-pack-knowledge/src/knowledge/util.rs
+++ b/crates/khive-pack-knowledge/src/knowledge/util.rs
@@ -20,6 +20,18 @@ pub(super) const D_EXPAND_DISCOUNT: f32 = 0.35;
 pub(super) const D_COVERAGE_ALPHA: f32 = 0.5;
 pub(super) const D_W_BIGRAM: f32 = 2.0;
 
+/// Final-blend weight given to the lexical/RRF-fused score in `suggest`'s
+/// domain ranking (issue #90). `suggest` picks *topics*, not keywords: a
+/// domain title that happens to contain a rare, polysemous query token
+/// (e.g. "decoding" meaning channel-coding vs. LLM token generation) earns
+/// an outsized TF-IDF name bonus (`D_W_EXACT_NAME`/`D_W_NAME`) purely from
+/// bag-of-words token overlap, which the FTS leg cannot sense-disambiguate.
+/// Embeddings carry distributional sense information FTS does not, so the
+/// final blend must let the freshly-computed cosine leg dominate rather
+/// than the lexical leg — the inverse of `knowledge.search`'s keyword-match
+/// use case, which keeps the general-purpose default weighting.
+pub(super) const D_SUGGEST_RERANK_ALPHA: f32 = 0.3;
+
 pub(super) const CANDIDATE_POOL: usize = 2000;
 pub(super) const MIN_TERM_LEN: usize = 3;
 /// Default embed/write batch when the caller does not pass `batch_size`. This is

--- a/crates/khive-pack-knowledge/src/knowledge/util.rs
+++ b/crates/khive-pack-knowledge/src/knowledge/util.rs
@@ -90,6 +90,21 @@ pub(super) fn deser<T: serde::de::DeserializeOwned>(params: Value) -> Result<T, 
         .map_err(|e| RuntimeError::InvalidInput(format!("bad params: {e}")))
 }
 
+// ─── token estimation ────────────────────────────────────────────────────────
+
+/// Same token unit `compose`'s `max_tokens` budgeting uses.
+pub(super) const CHARS_PER_TOKEN: usize = 4;
+
+pub(super) fn compose_item_char_cost(title: &str, content: &str) -> usize {
+    title.len().saturating_add(content.len()).saturating_add(40)
+}
+
+pub(super) fn estimate_compose_item_tokens(title: &str, content: &str) -> usize {
+    compose_item_char_cost(title, content)
+        .div_ceil(CHARS_PER_TOKEN)
+        .max(1)
+}
+
 // ─── SQL helpers ─────────────────────────────────────────────────────────────
 
 pub(super) fn now_us() -> i64 {

--- a/crates/khive-pack-knowledge/src/knowledge/vamana.rs
+++ b/crates/khive-pack-knowledge/src/knowledge/vamana.rs
@@ -568,7 +568,7 @@ impl AnnBridge {
         // Step 3: write the id-map sidecar atomically (tmp rename), bound to the
         // commit-record digest so any segment/sidecar pairing from different
         // saves is self-detecting at load time.
-        write_external_ids_sidecar(dir, &digest, &self.id_map)
+        write_external_ids_sidecar(dir, &digest, &self.id_map).map_err(|e| e.to_string())
     }
 
     /// Load a bridge from a segment directory previously written by

--- a/crates/khive-pack-knowledge/src/vocab.rs
+++ b/crates/khive-pack-knowledge/src/vocab.rs
@@ -291,7 +291,7 @@ pub(crate) static KNOWLEDGE_HANDLERS: [HandlerDef; 19] = [
     },
     HandlerDef {
         name: "knowledge.suggest",
-        description: "Suggest relevant knowledge domains for a query. Draft and deprecated domain atoms are excluded by default (same quality default as knowledge.search). Each result carries {id, name, score, size} — `size` is the aggregate estimated-token cost of the domain's member atom bodies that compose expands, in the same unit as `knowledge.fold`'s `budget`, so results feed `knowledge.fold(candidates=...)` directly with no caller-side field construction.",
+        description: "Suggest relevant knowledge domains for a query. Draft and deprecated domain atoms are excluded by default (same quality default as knowledge.search). Each result carries {id, name, score, size} — `size` is the aggregate estimated-token cost of the domain's member atom bodies that compose expands, in the same unit as `knowledge.fold`'s `budget`, so results feed `knowledge.fold(candidates=...)` directly with no caller-side field construction. When ANN candidate retrieval is unavailable, the response sets `ann_unavailable: true` and reports `degraded.mode`: `no_match` when lexical/FTS retrieval found no candidates, `ann_candidates_degraded` when lexical/FTS candidates still received fresh embedding cosine reranking, or `lexical_only` when that fresh rerank did not run.",
         visibility: Visibility::Verb,
         category: VerbCategory::Assertive,
         params: &[

--- a/crates/khive-pack-knowledge/src/vocab.rs
+++ b/crates/khive-pack-knowledge/src/vocab.rs
@@ -80,6 +80,18 @@ pub(crate) static KNOWLEDGE_HANDLERS: [HandlerDef; 19] = [
                 required: false,
                 description: "Pagination offset",
             },
+            ParamDef {
+                name: "status",
+                param_type: "string | array<string>",
+                required: false,
+                description: "Filter atoms to this status or set of statuses (e.g. \"draft\" or [\"draft\",\"reviewed\"]). Ignored for domains.",
+            },
+            ParamDef {
+                name: "exclude_status",
+                param_type: "string",
+                required: false,
+                description: "Exclude atoms with this exact status. Only used when status= is not set. Ignored for domains.",
+            },
         ],
     },
     HandlerDef {
@@ -87,12 +99,20 @@ pub(crate) static KNOWLEDGE_HANDLERS: [HandlerDef; 19] = [
         description: "Soft-delete atoms by slug or ID",
         visibility: Visibility::Verb,
         category: VerbCategory::Commissive,
-        params: &[ParamDef {
-            name: "ids",
-            param_type: "array<string>",
-            required: true,
-            description: "Atom slugs or UUIDs to delete",
-        }],
+        params: &[
+            ParamDef {
+                name: "ids",
+                param_type: "array<string>",
+                required: true,
+                description: "Atom slugs or UUIDs to delete",
+            },
+            ParamDef {
+                name: "cascade",
+                param_type: "boolean",
+                required: false,
+                description: "Deprecated no-op. Accepted for API compatibility but not yet implemented; sections are not cascade-deleted when atoms are soft-deleted.",
+            },
+        ],
     },
     HandlerDef {
         name: "knowledge.stats",
@@ -143,7 +163,7 @@ pub(crate) static KNOWLEDGE_HANDLERS: [HandlerDef; 19] = [
                 name: "candidates",
                 param_type: "array<object>",
                 required: true,
-                description: "Scored items: {id, score, size, content?, category?}",
+                description: "Scored items: {id, score, size, content?, category?, information_gain?}",
             },
             ParamDef {
                 name: "budget",
@@ -162,6 +182,18 @@ pub(crate) static KNOWLEDGE_HANDLERS: [HandlerDef; 19] = [
                 param_type: "object",
                 required: false,
                 description: "Per-category score multipliers",
+            },
+            ParamDef {
+                name: "diversity_bias",
+                param_type: "number",
+                required: false,
+                description: "Selector diversity bias weight (default 0.0; must be finite)",
+            },
+            ParamDef {
+                name: "epistemic_weight",
+                param_type: "number",
+                required: false,
+                description: "Selector weight applied to each candidate's information_gain (default 0.0; must be finite)",
             },
         ],
     },
@@ -313,6 +345,24 @@ pub(crate) static KNOWLEDGE_HANDLERS: [HandlerDef; 19] = [
                 required: false,
                 description: "Blend relevant KG concept/document entities into the briefing as a supplementary \"Knowledge graph\" section (default true). Has no effect on atom_ids-only calls, which never blend.",
             },
+            ParamDef {
+                name: "auto_limit",
+                param_type: "integer",
+                required: false,
+                description: "Number of domains to auto-suggest from `query` when both domain_ids and atom_ids are empty (default 5, clamped 1-20).",
+            },
+            ParamDef {
+                name: "max_tokens",
+                param_type: "integer",
+                required: false,
+                description: "Output token budget for the composed briefing (default 8000, clamped 500-100000; ~4 chars/token). Sections are trimmed to fit after scoring/selection.",
+            },
+            ParamDef {
+                name: "explain",
+                param_type: "boolean",
+                required: false,
+                description: "Include per-section score breakdowns in the response (default false).",
+            },
         ],
     },
     // ── section tier ─────────────────────────────────────────────────────────
@@ -439,14 +489,14 @@ pub(crate) static KNOWLEDGE_HANDLERS: [HandlerDef; 19] = [
             ParamDef {
                 name: "name",
                 param_type: "string",
-                required: true,
-                description: "Concept name",
+                required: false,
+                description: "Concept name. When omitted, auto-derived from `description`/`content` (truncated to the last word boundary <=60 chars); at least one of name or description/content must be non-empty.",
             },
             ParamDef {
                 name: "description",
                 param_type: "string",
                 required: false,
-                description: "Optional concept description",
+                description: "Optional concept description. Also accepted as `content` (alias) for UX consistency.",
             },
             ParamDef {
                 name: "domain",
@@ -484,7 +534,7 @@ pub(crate) static KNOWLEDGE_HANDLERS: [HandlerDef; 19] = [
                 name: "weight",
                 param_type: "float",
                 required: false,
-                description: "Edge weight; defaults to 1.0",
+                description: "Edge weight; defaults to 1.0, clamped 0.0-1.0",
             },
         ],
     },
@@ -577,5 +627,129 @@ mod tests {
             sections.description.contains("closed enum"),
             "knowledge.edit sections description must state that section_type is a closed enum"
         );
+    }
+
+    /// Parameter-parity guard (cross-model tooling evaluation, "compose budget
+    /// discoverability"): the top-level field names each handler's `#[derive(Deserialize)]`
+    /// params struct actually accepts, hand-kept in sync with
+    /// `src/knowledge/schema.rs` and `src/handlers.rs`. Every verb's entry here must be
+    /// exactly the set of top-level param names advertised in `KNOWLEDGE_HANDLERS` for
+    /// that verb (order-independent) -- so a field added to a params struct without a
+    /// matching `ParamDef` (or a stale `ParamDef` for a removed field) fails this test
+    /// instead of silently drifting from the actual accepted request shape.
+    ///
+    /// Nested/child structs (e.g. `AtomInput` within `upsert_atoms.atoms`,
+    /// `FoldCandidate` within `fold.candidates`) are documented in prose inside the
+    /// parent `ParamDef.description` rather than as separate top-level entries here.
+    fn expected_params() -> &'static [(&'static str, &'static [&'static str])] {
+        &[
+            ("knowledge.upsert_atoms", &["atoms", "chunk_size"]),
+            ("knowledge.upsert_domains", &["domains"]),
+            ("knowledge.get", &["id", "include_sections"]),
+            (
+                "knowledge.list",
+                &["type", "limit", "offset", "status", "exclude_status"],
+            ),
+            ("knowledge.delete_atoms", &["ids", "cascade"]),
+            ("knowledge.stats", &[]),
+            (
+                "knowledge.index",
+                &["ids", "batch_size", "insert_only", "rebuild_ann"],
+            ),
+            (
+                "knowledge.fold",
+                &[
+                    "candidates",
+                    "budget",
+                    "min_score",
+                    "category_weights",
+                    "diversity_bias",
+                    "epistemic_weight",
+                ],
+            ),
+            (
+                "knowledge.search",
+                &[
+                    "query",
+                    "type",
+                    "include_drafts",
+                    "status",
+                    "exclude_status",
+                    "role",
+                    "limit",
+                    "min_score",
+                    "weights",
+                    "decompose",
+                    "decompose_threshold",
+                    "intersection_bonus",
+                    "rerank",
+                    "rerank_alpha",
+                ],
+            ),
+            ("knowledge.suggest", &["query", "role", "limit"]),
+            (
+                "knowledge.compose",
+                &[
+                    "domain_ids",
+                    "atom_ids",
+                    "query",
+                    "blend_kg",
+                    "auto_limit",
+                    "max_tokens",
+                    "explain",
+                ],
+            ),
+            ("knowledge.edit", &["id", "sections"]),
+            ("knowledge.import", &["path", "format", "chunk_strategy"]),
+            (
+                "knowledge.challenge",
+                &["atom_id", "section_type", "content_hash", "reason"],
+            ),
+            (
+                "knowledge.adjudicate",
+                &["atom_id", "section_type", "content_hash", "resolution"],
+            ),
+            (
+                "knowledge.learn",
+                &["name", "description", "domain", "tags"],
+            ),
+            ("knowledge.cite", &["concept_id", "source_id", "weight"]),
+            ("knowledge.topic", &["domain", "query", "limit"]),
+            ("knowledge.feedback", &["section_signals", "target_id"]),
+        ]
+    }
+
+    #[test]
+    fn advertised_params_match_expected_deserialized_fields_for_every_verb() {
+        for (verb, expected) in expected_params() {
+            let h = find_handler(verb);
+            let mut advertised: Vec<&str> = h.params.iter().map(|p| p.name).collect();
+            let mut expected: Vec<&str> = expected.to_vec();
+            advertised.sort_unstable();
+            expected.sort_unstable();
+            assert_eq!(
+                advertised, expected,
+                "{verb}: advertised params {advertised:?} do not match the params \
+                 struct's deserialized fields {expected:?} -- update either the \
+                 `ParamDef`s in KNOWLEDGE_HANDLERS or the `expected_params()` table \
+                 in this test (whichever is stale)"
+            );
+        }
+    }
+
+    /// Every verb declared in `KNOWLEDGE_HANDLERS` must have a parity row above --
+    /// otherwise a newly added verb could silently escape this guard.
+    #[test]
+    fn every_handler_has_a_parity_row() {
+        let covered: std::collections::HashSet<&str> =
+            expected_params().iter().map(|(name, _)| *name).collect();
+        for h in KNOWLEDGE_HANDLERS.iter() {
+            assert!(
+                covered.contains(h.name),
+                "{}: no entry in expected_params() -- add one so parameter drift \
+                 on this verb cannot silently return",
+                h.name
+            );
+        }
     }
 }

--- a/crates/khive-pack-knowledge/src/vocab.rs
+++ b/crates/khive-pack-knowledge/src/vocab.rs
@@ -163,7 +163,7 @@ pub(crate) static KNOWLEDGE_HANDLERS: [HandlerDef; 19] = [
                 name: "candidates",
                 param_type: "array<object>",
                 required: true,
-                description: "Scored items: {id, score, size, content?, category?, information_gain?}",
+                description: "Scored items: {id, score, size, name?, content?, category?, information_gain?}. `knowledge.suggest`'s `results` feed this directly.",
             },
             ParamDef {
                 name: "budget",
@@ -291,7 +291,7 @@ pub(crate) static KNOWLEDGE_HANDLERS: [HandlerDef; 19] = [
     },
     HandlerDef {
         name: "knowledge.suggest",
-        description: "Suggest relevant knowledge domains for a query. Draft and deprecated domain atoms are excluded by default (same quality default as knowledge.search).",
+        description: "Suggest relevant knowledge domains for a query. Draft and deprecated domain atoms are excluded by default (same quality default as knowledge.search). Each result carries {id, name, score, size} — `size` is the aggregate estimated-token cost of the domain's member atom bodies that compose expands, in the same unit as `knowledge.fold`'s `budget`, so results feed `knowledge.fold(candidates=...)` directly with no caller-side field construction.",
         visibility: Visibility::Verb,
         category: VerbCategory::Assertive,
         params: &[

--- a/crates/khive-pack-knowledge/tests/fixes.rs
+++ b/crates/khive-pack-knowledge/tests/fixes.rs
@@ -955,6 +955,59 @@ async fn w10_import_section_only_markdown_synthesizes_atom_content() {
     );
 }
 
+// ── issue #25: import must finalize atoms so search/suggest can retrieve them ──
+
+#[tokio::test]
+async fn issue25_imported_atom_is_finalized_and_retrievable_via_search() {
+    let f = pack(rt());
+    let dir = std::env::temp_dir().join("khive_fixes_test_issue25");
+    std::fs::create_dir_all(&dir).ok();
+    let md_path = dir.join("retrievable-doc.md");
+    std::fs::write(
+        &md_path,
+        "# Retrievable Doc\n\nContent about zephyroquine dosage covering dense sparse vector search ranking fusion embedding reranking latency gradient transformer attention nearest neighbor index corpus benchmark pipeline cosine.\n",
+    )
+    .expect("write md");
+
+    let resp = f
+        .dispatch(
+            "knowledge.import",
+            json!({ "path": md_path.to_str().unwrap() }),
+        )
+        .await
+        .expect("import ok");
+    assert!(
+        resp["imported_atoms"].as_i64().unwrap_or(0) > 0,
+        "expected at least 1 imported atom"
+    );
+
+    let atom = f
+        .dispatch("knowledge.get", json!({ "id": "retrievable-doc" }))
+        .await
+        .expect("get");
+    assert_eq!(
+        atom["status"].as_str(),
+        Some("reviewed"),
+        "imported atoms must be finalized (status=reviewed), not left at the draft default \
+         that knowledge.search/suggest exclude"
+    );
+
+    // The regression this fix closes: default knowledge.search (no include_drafts, no
+    // status=) must actually surface a freshly-imported atom by its unique content term.
+    let search_resp = f
+        .dispatch(
+            "knowledge.search",
+            json!({ "query": "zephyroquine dosage", "rerank": false }),
+        )
+        .await
+        .expect("search ok");
+    let results = search_resp["results"].as_array().expect("results array");
+    assert!(
+        results.iter().any(|r| r["id"] == atom["id"]),
+        "imported atom must be retrievable via default knowledge.search, got: {search_resp}"
+    );
+}
+
 // ── S4: upsert-on-duplicate-slug updates in place (ADR-007 Rev 2: single local ns) ──
 
 #[tokio::test]

--- a/crates/khive-pack-knowledge/tests/param_strictness.rs
+++ b/crates/khive-pack-knowledge/tests/param_strictness.rs
@@ -1,0 +1,537 @@
+// FILE SIZE JUSTIFICATION: covers issue #89 (deny_unknown_fields audit across every verb in
+// the pack) and issue #105 (suggest -> fold -> compose wireability) in one file. Both fixes
+// touch the same params-deserialization surface; splitting them would duplicate the same
+// runtime/fixture boilerplate for no benefit.
+
+//! Regression coverage for:
+//! - #89: every `knowledge.*` verb rejects unknown params instead of silently ignoring them.
+//! - #105: `knowledge.suggest` output feeds `knowledge.fold`'s `candidates` unmodified, and
+//!   `fold`'s `selected` output feeds `knowledge.compose`'s `domain_ids` unmodified.
+
+use khive_pack_kg::KgPack;
+use khive_pack_knowledge::KnowledgePack;
+use khive_runtime::{KhiveRuntime, RuntimeError, VerbRegistry, VerbRegistryBuilder};
+use serde_json::{json, Value};
+
+fn rt() -> KhiveRuntime {
+    KhiveRuntime::memory().expect("memory runtime")
+}
+
+struct Fixture {
+    registry: VerbRegistry,
+}
+
+impl Fixture {
+    async fn dispatch(&self, verb: &str, args: Value) -> Result<Value, RuntimeError> {
+        self.registry.dispatch(verb, args).await
+    }
+}
+
+fn pack(rt: KhiveRuntime) -> Fixture {
+    let mut builder = VerbRegistryBuilder::new();
+    builder.register(KgPack::new(rt.clone()));
+    builder.register(KnowledgePack::new(rt.clone()));
+    let registry = builder.build().expect("registry builds");
+    rt.install_edge_rules(registry.all_edge_rules());
+    Fixture { registry }
+}
+
+/// Assert that dispatching `verb` with `params` (which carries a bogus
+/// `unknown_field_xyz` key alongside otherwise-valid required fields) fails,
+/// and that the error names the bad field or says "unknown field" — i.e. it
+/// enumerates rather than silently swallows.
+async fn assert_rejects_unknown_field(f: &Fixture, verb: &str, mut params: Value) {
+    params
+        .as_object_mut()
+        .expect("params must be an object")
+        .insert("unknown_field_xyz".into(), json!("should cause rejection"));
+    let result = f.dispatch(verb, params).await;
+    let err = match result {
+        Err(e) => e,
+        Ok(v) => panic!("{verb}: expected rejection of unknown field, got Ok({v:?})"),
+    };
+    let msg = err.to_string();
+    assert!(
+        msg.contains("unknown_field_xyz") || msg.contains("unknown field"),
+        "{verb}: unknown field must be rejected; got: {msg}"
+    );
+}
+
+// ── #89: unknown-field rejection, one test per verb ─────────────────────────
+
+#[tokio::test]
+async fn upsert_atoms_rejects_unknown_top_level_field() {
+    let f = pack(rt());
+    assert_rejects_unknown_field(
+        &f,
+        "knowledge.upsert_atoms",
+        json!({ "atoms": [{ "slug": "a", "name": "A", "content": "x".repeat(200) }] }),
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn upsert_atoms_rejects_unknown_atom_input_field() {
+    let f = pack(rt());
+    let err = f
+        .dispatch(
+            "knowledge.upsert_atoms",
+            json!({ "atoms": [{
+                "slug": "a", "name": "A", "content": "x".repeat(200),
+                "unknown_field_xyz": "boom"
+            }] }),
+        )
+        .await
+        .unwrap_err();
+    let msg = err.to_string();
+    assert!(
+        msg.contains("unknown_field_xyz") || msg.contains("unknown field"),
+        "AtomInput: unknown field must be rejected; got: {msg}"
+    );
+}
+
+#[tokio::test]
+async fn upsert_domains_rejects_unknown_top_level_field() {
+    let f = pack(rt());
+    assert_rejects_unknown_field(
+        &f,
+        "knowledge.upsert_domains",
+        json!({ "domains": [{
+            "slug": "d", "name": "D",
+            "description": "A domain with enough words to pass the twenty word minimum content requirement for testing."
+        }] }),
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn get_rejects_unknown_field() {
+    let f = pack(rt());
+    assert_rejects_unknown_field(&f, "knowledge.get", json!({ "id": "nonexistent" })).await;
+}
+
+#[tokio::test]
+async fn list_rejects_unknown_field() {
+    let f = pack(rt());
+    assert_rejects_unknown_field(&f, "knowledge.list", json!({})).await;
+}
+
+#[tokio::test]
+async fn delete_atoms_rejects_unknown_field() {
+    let f = pack(rt());
+    assert_rejects_unknown_field(
+        &f,
+        "knowledge.delete_atoms",
+        json!({ "ids": ["nonexistent"] }),
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn stats_rejects_unknown_field() {
+    let f = pack(rt());
+    assert_rejects_unknown_field(&f, "knowledge.stats", json!({})).await;
+}
+
+#[tokio::test]
+async fn index_rejects_unknown_field() {
+    let f = pack(rt());
+    assert_rejects_unknown_field(&f, "knowledge.index", json!({})).await;
+}
+
+#[tokio::test]
+async fn fold_rejects_unknown_top_level_field() {
+    let f = pack(rt());
+    assert_rejects_unknown_field(
+        &f,
+        "knowledge.fold",
+        json!({ "candidates": [{ "id": "a", "score": 1.0, "size": 10 }], "budget": 100 }),
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn fold_rejects_unknown_candidate_field() {
+    let f = pack(rt());
+    let err = f
+        .dispatch(
+            "knowledge.fold",
+            json!({
+                "candidates": [{
+                    "id": "a", "score": 1.0, "size": 10,
+                    "unknown_field_xyz": "boom"
+                }],
+                "budget": 100
+            }),
+        )
+        .await
+        .unwrap_err();
+    let msg = err.to_string();
+    assert!(
+        msg.contains("unknown_field_xyz") || msg.contains("unknown field"),
+        "FoldCandidate: unknown field must be rejected; got: {msg}"
+    );
+}
+
+#[tokio::test]
+async fn search_rejects_unknown_field() {
+    let f = pack(rt());
+    assert_rejects_unknown_field(
+        &f,
+        "knowledge.search",
+        json!({ "query": "vector database" }),
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn suggest_rejects_unknown_field() {
+    let f = pack(rt());
+    assert_rejects_unknown_field(
+        &f,
+        "knowledge.suggest",
+        json!({ "query": "vector database retrieval systems" }),
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn compose_rejects_unknown_field() {
+    let f = pack(rt());
+    assert_rejects_unknown_field(
+        &f,
+        "knowledge.compose",
+        json!({ "query": "vector database retrieval systems", "atom_ids": ["nonexistent"] }),
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn edit_rejects_unknown_top_level_field() {
+    let f = pack(rt());
+    assert_rejects_unknown_field(
+        &f,
+        "knowledge.edit",
+        json!({ "id": "nonexistent", "sections": [{ "section_type": "overview", "content": "x" }] }),
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn edit_rejects_unknown_section_update_field() {
+    let f = pack(rt());
+    let err = f
+        .dispatch(
+            "knowledge.edit",
+            json!({
+                "id": "nonexistent",
+                "sections": [{
+                    "section_type": "overview", "content": "x",
+                    "unknown_field_xyz": "boom"
+                }]
+            }),
+        )
+        .await
+        .unwrap_err();
+    let msg = err.to_string();
+    assert!(
+        msg.contains("unknown_field_xyz") || msg.contains("unknown field"),
+        "SectionUpdate: unknown field must be rejected; got: {msg}"
+    );
+}
+
+#[tokio::test]
+async fn import_rejects_unknown_field() {
+    let f = pack(rt());
+    assert_rejects_unknown_field(&f, "knowledge.import", json!({ "path": "/nonexistent" })).await;
+}
+
+#[tokio::test]
+async fn challenge_rejects_unknown_field() {
+    let f = pack(rt());
+    assert_rejects_unknown_field(
+        &f,
+        "knowledge.challenge",
+        json!({ "atom_id": "nonexistent", "section_type": "overview" }),
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn adjudicate_rejects_unknown_field() {
+    let f = pack(rt());
+    assert_rejects_unknown_field(
+        &f,
+        "knowledge.adjudicate",
+        json!({ "atom_id": "nonexistent", "section_type": "overview", "resolution": "accept" }),
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn learn_rejects_unknown_field() {
+    let f = pack(rt());
+    assert_rejects_unknown_field(&f, "knowledge.learn", json!({ "name": "Test Concept" })).await;
+}
+
+#[tokio::test]
+async fn cite_rejects_unknown_field() {
+    let f = pack(rt());
+    assert_rejects_unknown_field(
+        &f,
+        "knowledge.cite",
+        json!({ "concept_id": "nonexistent", "source_id": "nonexistent" }),
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn topic_rejects_unknown_field() {
+    let f = pack(rt());
+    assert_rejects_unknown_field(&f, "knowledge.topic", json!({})).await;
+}
+
+#[tokio::test]
+async fn feedback_rejects_unknown_top_level_field() {
+    let f = pack(rt());
+    assert_rejects_unknown_field(
+        &f,
+        "knowledge.feedback",
+        json!({ "section_signals": { "overview": "useful" } }),
+    )
+    .await;
+}
+
+/// `feedback`'s `section_signals` map keys stay free-form (validated dynamically
+/// against `SectionType`, not via `deny_unknown_fields`) — an unrecognized
+/// section-type key must still be rejected, just with the pack's own
+/// domain-specific error, not a generic serde one.
+#[tokio::test]
+async fn feedback_rejects_unknown_section_type_key_with_domain_error() {
+    let f = pack(rt());
+    let err = f
+        .dispatch(
+            "knowledge.feedback",
+            json!({ "section_signals": { "not_a_real_section": "useful" } }),
+        )
+        .await
+        .unwrap_err();
+    let msg = err.to_string();
+    assert!(
+        msg.contains("unknown section_type"),
+        "expected domain-specific section_type error; got: {msg}"
+    );
+}
+
+// ── #89: documented aliases must keep working under deny_unknown_fields ─────
+
+#[tokio::test]
+async fn learn_content_alias_still_works_under_deny_unknown_fields() {
+    let f = pack(rt());
+    let resp = f
+        .dispatch(
+            "knowledge.learn",
+            json!({ "name": "Aliased Concept", "content": "described via the content alias" }),
+        )
+        .await
+        .expect("content alias must still be accepted for LearnParams.description");
+    assert_eq!(resp["name"], "Aliased Concept");
+    assert_eq!(resp["description"], "described via the content alias");
+}
+
+#[tokio::test]
+async fn list_kind_alias_still_works_under_deny_unknown_fields() {
+    let f = pack(rt());
+    let resp = f
+        .dispatch("knowledge.list", json!({ "kind": "domain", "limit": 5 }))
+        .await
+        .expect("kind alias must still be accepted for ListParams.type");
+    assert_eq!(resp["results"].as_array().map(Vec::len), Some(0));
+}
+
+// ── #105: suggest -> fold -> compose wires without caller-side construction ─
+
+#[tokio::test]
+async fn suggest_output_wires_into_fold_which_wires_into_compose() {
+    let f = pack(rt());
+
+    // Seed a member atom per domain (compose renders domain members, not the
+    // domain's own mirror description) plus the two domains that reference them.
+    f.dispatch(
+        "knowledge.upsert_atoms",
+        json!({ "atoms": [
+            {
+                "slug": "retrieval-atom",
+                "name": "Retrieval Atom",
+                "content": "Dense and sparse retrieval systems for vector search, embeddings, ranking, and hybrid fusion pipelines over large corpora of documents, spanning approximate nearest neighbor indexes and reranking stages.",
+                "finalized": true
+            },
+            {
+                "slug": "training-atom",
+                "name": "Training Atom",
+                "content": "Distributed training infrastructure covering gradient accumulation, checkpointing, mixed precision, and cluster scheduling for large model runs across many GPU nodes and regions.",
+                "finalized": true
+            }
+        ]}),
+    )
+    .await
+    .expect("seed atoms");
+
+    f.dispatch(
+        "knowledge.upsert_domains",
+        json!({ "domains": [
+            {
+                "slug": "retrieval-systems",
+                "name": "Retrieval Systems",
+                "description": "Dense and sparse retrieval systems for vector search, embeddings, ranking, and hybrid fusion pipelines over large corpora of documents, spanning approximate nearest neighbor indexes and reranking stages.",
+                "members": ["retrieval-atom"]
+            },
+            {
+                "slug": "training-infra",
+                "name": "Training Infra",
+                "description": "Distributed training infrastructure covering gradient accumulation, checkpointing, mixed precision, and cluster scheduling for large model runs across many GPU nodes and regions.",
+                "members": ["training-atom"]
+            }
+        ]}),
+    )
+    .await
+    .expect("seed domains");
+
+    let suggest_resp = f
+        .dispatch(
+            "knowledge.suggest",
+            json!({ "query": "vector search retrieval embeddings ranking", "limit": 8 }),
+        )
+        .await
+        .expect("suggest");
+    let results = suggest_resp["results"]
+        .as_array()
+        .expect("suggest results must be an array")
+        .clone();
+    assert!(
+        !results.is_empty(),
+        "suggest must return at least one domain"
+    );
+    for r in &results {
+        assert!(r.get("id").is_some(), "suggest result missing id: {r:?}");
+        assert!(
+            r.get("score").is_some(),
+            "suggest result missing score: {r:?}"
+        );
+        assert!(
+            r.get("size").and_then(Value::as_u64).is_some(),
+            "suggest result missing numeric size (issue #105): {r:?}"
+        );
+    }
+
+    // suggest's `results` array feeds fold's `candidates` UNMODIFIED — no
+    // caller-side field renaming, no size synthesis.
+    let fold_resp = f
+        .dispatch(
+            "knowledge.fold",
+            json!({ "candidates": results, "budget": 100_000 }),
+        )
+        .await
+        .expect("fold must accept suggest's output unmodified");
+    let selected = fold_resp["selected"]
+        .as_array()
+        .expect("fold selected must be an array")
+        .clone();
+    assert!(
+        !selected.is_empty(),
+        "fold must select at least one candidate"
+    );
+
+    // fold's `selected` items feed compose's `domain_ids` UNMODIFIED — pull the
+    // `id` field straight off each selected item, no other construction.
+    let domain_ids: Vec<Value> = selected.iter().map(|s| s["id"].clone()).collect();
+    let compose_resp = f
+        .dispatch(
+            "knowledge.compose",
+            json!({ "domain_ids": domain_ids, "query": "vector search retrieval embeddings ranking", "blend_kg": false }),
+        )
+        .await
+        .expect("compose must accept fold's selected ids unmodified");
+    assert_eq!(compose_resp["status"], "ok");
+    assert!(
+        compose_resp["data"]["count"].as_u64().unwrap_or(0) > 0,
+        "compose must render at least one atom from the wired domain_ids: {compose_resp:?}"
+    );
+}
+
+#[tokio::test]
+async fn suggest_size_prices_member_atoms_instead_of_domain_description() {
+    let f = pack(rt());
+    let first_name = "Large Retrieval Member";
+    let second_name = "Large Ranking Member";
+    let first_member_content =
+        "vector search retrieval embeddings ranking first member body ".repeat(120);
+    let second_member_content =
+        "vector search retrieval embeddings ranking second member body ".repeat(80);
+    let description = "Vector search retrieval embeddings ranking systems improve relevant document discovery with hybrid indexes and carefully tuned reranking across production corpora.";
+    let old_description_size = description.chars().count().div_ceil(4);
+    let expected_member_size = (first_name.len() + first_member_content.len() + 40).div_ceil(4)
+        + (second_name.len() + second_member_content.len() + 40).div_ceil(4);
+
+    f.dispatch(
+        "knowledge.upsert_atoms",
+        json!({ "atoms": [
+            {
+                "slug": "large-retrieval-member",
+                "name": first_name,
+                "content": first_member_content,
+                "finalized": true
+            },
+            {
+                "slug": "large-ranking-member",
+                "name": second_name,
+                "content": second_member_content,
+                "finalized": true
+            }
+        ]}),
+    )
+    .await
+    .expect("seed large member atom");
+
+    f.dispatch(
+        "knowledge.upsert_domains",
+        json!({ "domains": [{
+            "slug": "small-description-domain",
+            "name": "Small Description Domain",
+            "description": description,
+            "members": ["large-retrieval-member", "large-ranking-member"]
+        }]}),
+    )
+    .await
+    .expect("seed domain with small description");
+
+    let suggest_resp = f
+        .dispatch(
+            "knowledge.suggest",
+            json!({ "query": "vector search retrieval embeddings ranking", "limit": 1 }),
+        )
+        .await
+        .expect("suggest");
+    let result = &suggest_resp["results"][0];
+    assert_eq!(
+        result["size"].as_u64(),
+        Some(expected_member_size as u64),
+        "suggest size must aggregate the member body cost, not the domain description"
+    );
+    assert!(expected_member_size > old_description_size);
+
+    let fold_resp = f
+        .dispatch(
+            "knowledge.fold",
+            json!({
+                "candidates": [result.clone()],
+                "budget": old_description_size
+            }),
+        )
+        .await
+        .expect("fold under the old description-sized budget");
+    assert_eq!(
+        fold_resp["selected_count"], 0,
+        "the member-heavy domain must not fit the old description-sized budget"
+    );
+}

--- a/crates/khive-pack-memory/docs/api/recall-pipeline.md
+++ b/crates/khive-pack-memory/docs/api/recall-pipeline.md
@@ -84,7 +84,7 @@ Recall resolves legacy missing properties at read time: memory type defaults to 
 
 Results sort deterministically by descending score with stable tie behavior. Optional score breakdowns expose component contributions and profile effects. `full_content = false` truncates returned content to 200 characters; ranking always uses full stored content.
 
-Superseded candidates are suppressed by inbound `supersedes` graph edges, with the archive-compatible property shortcut as a secondary route. MMR reduces near-duplicate prefixes, and the token budget bounds aggregate response text.
+Superseded candidates are suppressed by inbound `supersedes` graph edges, with the archive-compatible property shortcut as a secondary route. MMR reduces near-duplicate prefixes, and the token budget bounds aggregate response text. Default responses are arrays; when the budget removes candidates, surviving results carry `truncated: true`. When the budget removes every ranked candidate, the default response becomes `{ "results": [], "truncated": true }` so the cutoff stays distinguishable from a genuine no-match, which remains an unadorned empty array.
 
 ## Subhandlers
 

--- a/crates/khive-pack-memory/src/ann.rs
+++ b/crates/khive-pack-memory/src/ann.rs
@@ -471,7 +471,7 @@ impl AnnBridge {
             .ok_or_else(|| {
                 "save_atomic succeeded but metadata.bin is absent (torn commit)".to_string()
             })?;
-        write_external_ids_sidecar(dir, &digest, &self.id_map)
+        write_external_ids_sidecar(dir, &digest, &self.id_map).map_err(|e| e.to_string())
     }
 
     /// Load a bridge from a segment directory written by `save_atomic`. Any

--- a/crates/khive-pack-memory/src/handlers/common.rs
+++ b/crates/khive-pack-memory/src/handlers/common.rs
@@ -368,6 +368,16 @@ pub(super) const DEFAULT_DECAY_EPISODIC: f64 = 0.02;
 /// Default decay_factor for semantic memories (~139-day half-life).
 pub(super) const DEFAULT_DECAY_SEMANTIC: f64 = 0.005;
 
+/// `memory.recall` requests whose total handler time reaches this are logged at WARN
+/// with a duration/result-shape breakdown, unconditionally (unlike the opt-in
+/// `KHIVE_RECALL_PROFILE` per-stage eprintln profiler). Matches the threshold and
+/// rationale established for `knowledge.compose` (#887 / PR #915): well above a
+/// healthy recall (sub-second in the common case) but comfortably inside the
+/// end-to-end `recall_deadline_ms` budget (30s default), so a slow-but-completing
+/// recall is visible in the daemon log before it ever risks tripping the deadline
+/// or a client-side timeout (#30 / originally #889).
+pub(super) const RECALL_SLOW_THRESHOLD_MS: u64 = 10_000;
+
 pub(super) fn compute_score(
     cfg: &RecallConfig,
     pipeline: &MemoryRecallPipeline,

--- a/crates/khive-pack-memory/src/handlers/prune.rs
+++ b/crates/khive-pack-memory/src/handlers/prune.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 
 use khive_runtime::{NamespaceToken, RuntimeError};
-use khive_storage::types::{DeleteMode, SqlStatement, SqlValue};
+use khive_storage::types::{SqlStatement, SqlValue};
 
 use crate::ann;
 use crate::MemoryPack;
@@ -127,17 +127,30 @@ impl MemoryPack {
             }));
         }
 
-        // Soft-delete each candidate via NoteStore.
-        let note_store = self.runtime.notes(token)?;
+        // Soft-delete each candidate through the runtime's coherent delete path
+        // (`KhiveRuntime::delete_note`, ADR-014), not the raw `NoteStore::delete_note`
+        // used before #50: `delete_note` marks the row deleted AND cleans that note's
+        // FTS5 document and every registered model's vector row within the same call,
+        // instead of leaving stale FTS/vector entries behind until a full ANN rebuild
+        // (the same coherent path `delete_entity`/`delete_note` already give every
+        // other curation verb). It also fires the note-mutation hook, so a pack that
+        // has installed one (this pack's own ANN generation bump, wired in production
+        // via `call_register_note_mutation_hooks`) observes the corpus change per note.
         let mut pruned = 0usize;
         for id in to_delete {
-            if note_store.delete_note(id, DeleteMode::Soft).await? {
+            if self.runtime.delete_note(token, id, false).await? {
                 pruned += 1;
             }
         }
 
-        // Raw NoteStore deletion bypasses runtime mutation hooks, so prune bumps directly.
-        // Keep the stale graph intact while a live-row scan builds its replacement.
+        // Belt-and-suspenders generation bump: the mutation-hook fire above is a
+        // no-op wherever no pack has installed a hook (registries built without
+        // calling `call_register_note_mutation_hooks`, e.g. some embedded/test
+        // setups), so this pack still bumps its own ANN generation directly and
+        // schedules a background rebuild here too. Redundant-but-idempotent when
+        // the hook already fired (`bump_generation`/`ensure_ann_background` are
+        // both dedup-guarded), and the only path to ANN freshness when it didn't.
+        // Keeps the stale graph intact while a live-row scan builds its replacement.
         if pruned > 0 {
             for model in self.runtime.registered_embedding_model_names() {
                 let key = ann::AnnKey::new(model.as_str());
@@ -464,6 +477,138 @@ mod prune_recall_visibility_tests {
                 "pruned note must not be returned via {label}, got: {hits:?}"
             );
         }
+    }
+}
+
+// ── #50: memory.prune must clean the FTS5 document and every registered
+// model's vector row for each pruned note, not just mark it deleted ────────
+
+#[cfg(test)]
+mod prune_index_cleanup_tests {
+    use khive_pack_kg::KgPack;
+    use khive_runtime::{KhiveRuntime, Namespace, VerbRegistryBuilder};
+    use uuid::Uuid;
+
+    use crate::test_support::HashVecProvider;
+
+    /// `memory.prune` must remove the pruned note's FTS5 document and vector row,
+    /// not merely soft-delete the notes-table row and leave the auxiliary indexes
+    /// stale. Follow-up to #429/#533 (recall-correctness, already covered by
+    /// `prune_recall_visibility_tests`): this test checks storage-level cleanup
+    /// directly against the TextSearch and VectorStore capabilities, independent
+    /// of any recall-path filtering.
+    #[tokio::test]
+    async fn prune_removes_fts_document_and_vector_row_for_pruned_note() {
+        const MODEL: &str = "prune-50-index-cleanup-model";
+        const DIMS: usize = 16;
+
+        let rt = KhiveRuntime::memory().expect("in-memory runtime");
+        rt.register_embedder(HashVecProvider {
+            model_name: MODEL.to_owned(),
+            dims: DIMS,
+        });
+
+        let ns = Namespace::parse("local").expect("local namespace");
+        let token = rt.authorize(ns).expect("authorize local");
+
+        let mut builder = VerbRegistryBuilder::new();
+        builder.register(KgPack::new(rt.clone()));
+        builder.register(crate::MemoryPack::new(rt.clone()));
+        let registry = builder.build().expect("registry");
+
+        // One low-salience note to be pruned, one high-salience note that must survive.
+        let pruned = registry
+            .dispatch(
+                "memory.remember",
+                serde_json::json!({
+                    "content": "issue 50 index cleanup pruned note",
+                    "salience": 0.1,
+                    "memory_type": "semantic",
+                }),
+            )
+            .await
+            .expect("remember (to be pruned)");
+        let pruned_id: Uuid = pruned["id"]
+            .as_str()
+            .expect("id present")
+            .parse()
+            .expect("valid uuid");
+
+        let survivor = registry
+            .dispatch(
+                "memory.remember",
+                serde_json::json!({
+                    "content": "issue 50 index cleanup surviving note",
+                    "salience": 0.9,
+                    "memory_type": "semantic",
+                }),
+            )
+            .await
+            .expect("remember (survivor)");
+        let survivor_id: Uuid = survivor["id"]
+            .as_str()
+            .expect("id present")
+            .parse()
+            .expect("valid uuid");
+
+        // Sanity: both notes are indexed pre-prune -- a store that never indexed
+        // either note would satisfy the post-prune absence assertion vacuously.
+        let text = rt.text_for_notes(&token).expect("text_for_notes");
+        assert!(
+            text.get_document("local", pruned_id)
+                .await
+                .expect("get_document")
+                .is_some(),
+            "pruned note must have an FTS5 document before prune"
+        );
+        assert!(
+            text.get_document("local", survivor_id)
+                .await
+                .expect("get_document")
+                .is_some(),
+            "survivor note must have an FTS5 document before prune"
+        );
+
+        let vectors = rt
+            .vectors_for_model(&token, MODEL)
+            .expect("vectors_for_model");
+        assert_eq!(
+            vectors.count().await.expect("vector count"),
+            2,
+            "both notes must have a vector row before prune"
+        );
+
+        let prune_result = registry
+            .dispatch("memory.prune", serde_json::json!({ "min_salience": 0.5 }))
+            .await
+            .expect("memory.prune");
+        assert_eq!(
+            prune_result["pruned"], 1,
+            "only the low-salience note must be pruned: {prune_result:?}"
+        );
+
+        // The pruned note's FTS5 document and vector row must be gone.
+        assert!(
+            text.get_document("local", pruned_id)
+                .await
+                .expect("get_document")
+                .is_none(),
+            "#50: pruned note must have no FTS5 document after prune"
+        );
+        assert_eq!(
+            vectors.count().await.expect("vector count"),
+            1,
+            "#50: pruned note's vector row must be removed, leaving only the survivor's"
+        );
+
+        // The surviving note's indexes must be untouched.
+        assert!(
+            text.get_document("local", survivor_id)
+                .await
+                .expect("get_document")
+                .is_some(),
+            "survivor note's FTS5 document must remain after prune"
+        );
     }
 }
 

--- a/crates/khive-pack-memory/src/handlers/recall.rs
+++ b/crates/khive-pack-memory/src/handlers/recall.rs
@@ -30,7 +30,7 @@ use super::common::{
     compute_score, deser, fuse_candidates, make_pipeline, note_matches_tags, plog, plog_n,
     recall_candidate_count, to_json, validate_memory_type, RecallCandidateParams, RecallParams,
     TextSnippetPolicy, DEFAULT_DECAY_EPISODIC, DEFAULT_DECAY_SEMANTIC, DEFAULT_SALIENCE_EPISODIC,
-    DEFAULT_SALIENCE_SEMANTIC, PROF_CID, RECALL_CALL_ID,
+    DEFAULT_SALIENCE_SEMANTIC, PROF_CID, RECALL_CALL_ID, RECALL_SLOW_THRESHOLD_MS,
 };
 
 impl MemoryPack {
@@ -705,6 +705,11 @@ impl MemoryPack {
                     // Per-result stamp keeps degradation visible without verbose output.
                     result["degraded"] = json!("ann_unavailable");
                 }
+                if budget_capped {
+                    // Surviving partial results retain the per-item signal so callers
+                    // that inspect hits individually can still detect truncation.
+                    result["truncated"] = json!(true);
+                }
                 result
             })
             .collect();
@@ -758,6 +763,27 @@ impl MemoryPack {
             }
         }
 
+        // #30/#889: unconditional slow-request observability, mirroring the
+        // knowledge.compose WARN added for #887. Fires on every completed recall
+        // whose total handler time crosses the threshold, regardless of whether
+        // KHIVE_RECALL_PROFILE is set, so a slow-but-completing recall leaves
+        // daemon-side evidence even when nobody opted into per-stage profiling.
+        {
+            let total_ms = recall_start.elapsed().as_millis() as u64;
+            if total_ms >= RECALL_SLOW_THRESHOLD_MS {
+                tracing::warn!(
+                    total_ms,
+                    threshold_ms = RECALL_SLOW_THRESHOLD_MS,
+                    result_count = results.len(),
+                    query_bytes = query_trimmed.len(),
+                    ann_degraded,
+                    budget_capped,
+                    is_verbose,
+                    "memory.recall exceeded slow-request threshold"
+                );
+            }
+        }
+
         if is_verbose && candidates.vector_hits_per_model.len() > 1 {
             // Raw global ANN diagnostics MUST use the same hydrated namespace filter as results.
             let per_model: Vec<Value> = candidates
@@ -800,6 +826,18 @@ impl MemoryPack {
             if let Some(ref t) = t_total {
                 plog(call_id, "total", t.elapsed().as_micros());
             }
+        }
+
+        if budget_capped && results.is_empty() {
+            // Only the ambiguous case changes shape: a budget cutoff at the first
+            // ranked candidate leaves no item to carry the per-result stamp, so a
+            // bare [] would be indistinguishable from a genuine no-match. Non-empty
+            // capped responses keep the bare-array shape (load-bearing for callers
+            // that index the top-level array) with per-item truncated stamps.
+            return to_json(&json!({
+                "results": results,
+                "truncated": true,
+            }));
         }
 
         to_json(&results)
@@ -4917,6 +4955,177 @@ mod tests {
             other => {
                 panic!("#889 expected DeadlineExceeded with the embed stage held, got: {other:?}")
             }
+        }
+    }
+
+    // ── #30/#889: tracing-capture harness for the deadline-exceeded WARN ──────
+    //
+    // The reported incident (`memory.recall` hit the 300s client timeout with
+    // zero daemon-side evidence) is exactly the case where `handle_recall`'s
+    // own future is dropped by `tokio::time::timeout`, never reaching
+    // `recall.rs`'s slow-request WARN. The abandoned-request WARN added to
+    // `handle_recall_with_deadline` in `pack.rs` is the one that must fire
+    // instead; a real `tracing::Subscriber` installed only as this test's
+    // thread-local default (`tracing::subscriber::with_default`) observes it
+    // without a multi-second sleep or interfering with any other test.
+
+    #[derive(Clone, Debug, Default)]
+    struct CapturedEvent {
+        message: Option<String>,
+        fields: std::collections::HashMap<String, String>,
+    }
+
+    #[derive(Default)]
+    struct CapturedEventVisitor(CapturedEvent);
+
+    impl tracing::field::Visit for CapturedEventVisitor {
+        fn record_debug(&mut self, field: &tracing::field::Field, value: &dyn std::fmt::Debug) {
+            let formatted = format!("{value:?}");
+            if field.name() == "message" {
+                self.0.message = Some(
+                    formatted
+                        .trim_start_matches('"')
+                        .trim_end_matches('"')
+                        .to_string(),
+                );
+            } else {
+                self.0.fields.insert(field.name().to_string(), formatted);
+            }
+        }
+
+        fn record_u64(&mut self, field: &tracing::field::Field, value: u64) {
+            self.0
+                .fields
+                .insert(field.name().to_string(), value.to_string());
+        }
+    }
+
+    struct CaptureSubscriber {
+        events: Arc<std::sync::Mutex<Vec<CapturedEvent>>>,
+    }
+
+    impl tracing::Subscriber for CaptureSubscriber {
+        fn enabled(&self, _: &tracing::Metadata<'_>) -> bool {
+            true
+        }
+        fn new_span(&self, _: &tracing::span::Attributes<'_>) -> tracing::span::Id {
+            tracing::span::Id::from_u64(1)
+        }
+        fn record(&self, _: &tracing::span::Id, _: &tracing::span::Record<'_>) {}
+        fn record_follows_from(&self, _: &tracing::span::Id, _: &tracing::span::Id) {}
+        fn event(&self, event: &tracing::Event<'_>) {
+            let mut visitor = CapturedEventVisitor::default();
+            event.record(&mut visitor);
+            self.events.lock().unwrap().push(visitor.0);
+        }
+        fn enter(&self, _: &tracing::span::Id) {}
+        fn exit(&self, _: &tracing::span::Id) {}
+    }
+
+    /// A deadline-exceeded recall emits an unconditional daemon-side WARN — the
+    /// exact evidence #30/#889 reported as missing during the incident.
+    #[test]
+    fn recall_30_deadline_exceeded_emits_abandoned_slow_path_warn() {
+        let buffer = Arc::new(std::sync::Mutex::new(Vec::new()));
+        let subscriber = CaptureSubscriber {
+            events: Arc::clone(&buffer),
+        };
+
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("current-thread runtime");
+
+        tracing::subscriber::with_default(subscriber, || {
+            runtime.block_on(async {
+                const MODEL: &str = "recall-30-warn-model";
+                let hold = Arc::new(Notify::new());
+
+                let rt = KhiveRuntime::memory().expect("in-memory runtime");
+                rt.register_embedder(SlowEmbedProvider {
+                    model_name: MODEL.to_owned(),
+                    hold: hold.clone(),
+                });
+
+                let ns = Namespace::parse("local").expect("local namespace");
+                let token = rt.authorize(ns).expect("authorize local");
+
+                hold.notify_one();
+                rt.create_note(
+                    &token,
+                    "memory",
+                    None,
+                    "issue 30 abandoned slow-path warn test note",
+                    Some(0.7),
+                    None,
+                    vec![],
+                )
+                .await
+                .expect("create note");
+
+                let mut builder = VerbRegistryBuilder::new();
+                builder.register(KgPack::new(rt.clone()));
+                builder.register(MemoryPack::new(rt.clone()));
+                let registry = builder.build().expect("registry");
+
+                let result = registry
+                    .dispatch(
+                        "memory.recall",
+                        serde_json::json!({
+                            "query": "30 abandoned slow-path warn test",
+                            "limit": 10,
+                            "config": { "recall_deadline_ms": 50 }
+                        }),
+                    )
+                    .await;
+                hold.notify_one();
+                assert!(
+                    matches!(result, Err(RuntimeError::DeadlineExceeded { .. })),
+                    "expected DeadlineExceeded, got: {result:?}"
+                );
+            });
+        });
+
+        let events = buffer.lock().unwrap();
+        let warn = events
+            .iter()
+            .find(|e| {
+                e.message.as_deref()
+                    == Some("memory.recall exceeded its deadline and was abandoned")
+            })
+            .unwrap_or_else(|| panic!("expected the abandoned-deadline WARN, got: {events:?}"));
+        assert_eq!(
+            warn.fields.get("operation").map(String::as_str),
+            Some("\"memory.recall\"")
+        );
+        assert_eq!(warn.fields.get("budget_ms").map(String::as_str), Some("50"));
+        assert!(
+            warn.fields.contains_key("elapsed_ms"),
+            "abandoned WARN must carry elapsed_ms, got: {warn:?}"
+        );
+    }
+
+    /// `RECALL_SLOW_THRESHOLD_MS` stays sane: high enough that a healthy recall
+    /// never trips it, low enough it fires well before the deadline default.
+    /// Sanity-bounds the const rather than pinning it exactly, so a deliberate
+    /// future retune doesn't require touching the test — but a typo (e.g.
+    /// dropping three zeros) still fails loudly. Both sides are
+    /// compile-time-constant, so `clippy::assertions_on_constants` requires
+    /// the `const { }` wrapper (mirrors `COMPOSE_SLOW_THRESHOLD_MS`'s
+    /// `slow_threshold_is_sane` test, #887).
+    #[test]
+    fn recall_slow_threshold_is_sane() {
+        const {
+            assert!(
+                super::RECALL_SLOW_THRESHOLD_MS >= 1_000,
+                "threshold must not fire on ordinary sub-second recalls"
+            );
+        }
+        const {
+            assert!(
+                super::RECALL_SLOW_THRESHOLD_MS < 30_000,
+                "threshold must fire before the default 30s recall_deadline_ms budget expires"
+            );
         }
     }
 

--- a/crates/khive-pack-memory/src/handlers/recall.rs
+++ b/crates/khive-pack-memory/src/handlers/recall.rs
@@ -814,7 +814,6 @@ impl MemoryPack {
         target_ids: Vec<String>,
         latency_us: i64,
     ) {
-        let result_count = target_ids.len();
         let registry = registry.clone();
         let namespace = token.namespace().as_str().to_string();
         let query_raw = query_raw.to_string();
@@ -833,8 +832,8 @@ impl MemoryPack {
                 let mut ledger_params = json!({
                     "namespace": namespace,
                     "consumer_kind": "recall",
-                    "target_ids": target_ids,
-                    "query_raw": query_raw,
+                    "target_ids": target_ids.clone(),
+                    "query_raw": query_raw.clone(),
                     "served_at": served_at_us,
                 });
                 if let Some(ref profile_id) = served_by_profile_id {
@@ -851,27 +850,53 @@ impl MemoryPack {
             emit_recall_executed_event(
                 &runtime,
                 &token,
-                actor,
-                served_by_profile_id,
-                query_class,
-                result_count,
-                latency_us,
+                RecallExecutedFields {
+                    actor,
+                    served_by_profile_id,
+                    query_raw,
+                    query_class,
+                    target_ids,
+                    latency_us,
+                },
             )
             .await;
         });
     }
 }
 
+/// Fields for the best-effort `RecallExecuted` telemetry event. Grouped into a
+/// struct rather than passed positionally to stay under clippy's
+/// too-many-arguments threshold.
+struct RecallExecutedFields {
+    actor: String,
+    served_by_profile_id: Option<String>,
+    query_raw: String,
+    query_class: String,
+    target_ids: Vec<String>,
+    latency_us: i64,
+}
+
 /// Append best-effort recall telemetry without affecting the recall response.
+///
+/// khive#36: carries the full returned result-ID list (both `candidates` and
+/// `selected` — the recall pipeline does not track a broader pre-selection
+/// candidate pool at this emission boundary, so every served id is reported
+/// as both), the typed result kind (`memory.recall` always serves `note`
+/// substrate records), the full query text, `served_by_profile_id`, the
+/// calling actor, and a timestamp (`Event::new` stamps `created_at`).
 async fn emit_recall_executed_event(
     rt: &KhiveRuntime,
     token: &NamespaceToken,
-    actor: String,
-    served_by_profile_id: Option<String>,
-    query_class: String,
-    result_count: usize,
-    latency_us: i64,
+    fields: RecallExecutedFields,
 ) {
+    let RecallExecutedFields {
+        actor,
+        served_by_profile_id,
+        query_raw,
+        query_class,
+        target_ids,
+        latency_us,
+    } = fields;
     let store = match rt.events(token) {
         Ok(store) => store,
         Err(err) => {
@@ -884,11 +909,16 @@ async fn emit_recall_executed_event(
             return;
         }
     };
+    let result_count = target_ids.len();
     let payload = json!({
         "actor": actor,
         "served_by_profile_id": served_by_profile_id,
+        "query": query_raw,
         "query_class": query_class,
+        "result_kind": "note",
         "result_count": result_count,
+        "candidates": target_ids.clone(),
+        "selected": target_ids,
         "latency_us": latency_us,
     });
     let event = khive_storage::Event::new(
@@ -5325,6 +5355,99 @@ mod tests {
             !hits.is_empty(),
             "recall must surface the healthy engine's hits despite the other \
              engine's sqlite-vec retrieval failing; got {result:?}"
+        );
+    }
+
+    // ── RecallExecuted event plane emission ─────────────────
+
+    /// `memory.recall` must persist a `RecallExecuted` event carrying the full
+    /// served result-id list (`candidates` + `selected`), the typed result
+    /// kind, the full query text, `served_by_profile_id`, the calling actor,
+    /// and a timestamp — not just the transient in-memory brain-posterior
+    /// stamp.
+    #[tokio::test]
+    #[serial(background_tasks)]
+    async fn recall_persists_recall_executed_event_with_full_payload() {
+        const NOTE_TEXT: &str = "khive#36 recall executed event payload coverage note";
+
+        let rt = KhiveRuntime::memory().expect("in-memory runtime");
+        let ns = Namespace::parse("local").expect("local namespace");
+        let token = rt.authorize(ns).expect("authorize local");
+
+        let note = rt
+            .create_note(&token, "memory", None, NOTE_TEXT, Some(0.7), None, vec![])
+            .await
+            .expect("create note");
+
+        let mut builder = VerbRegistryBuilder::new();
+        builder.register(KgPack::new(rt.clone()));
+        builder.register(MemoryPack::new(rt.clone()));
+        let registry = builder.build().expect("registry");
+
+        let before = khive_runtime::background_task_count();
+        let result = registry
+            .dispatch(
+                "memory.recall",
+                serde_json::json!({
+                    "query": NOTE_TEXT,
+                    "limit": 10,
+                }),
+            )
+            .await
+            .expect("memory.recall must succeed");
+        let hits = result.as_array().expect("bare array result");
+        assert!(!hits.is_empty(), "seeded note must be recalled");
+
+        // The RecallExecuted event append happens on a tracked background
+        // task off the response path; wait for it to drain before querying.
+        for _ in 0..200 {
+            if khive_runtime::background_task_count() <= before {
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        }
+
+        let store = rt.events(&token).expect("event store");
+        let page = store
+            .query_events(
+                khive_storage::event::EventFilter {
+                    kinds: vec![khive_types::EventKind::RecallExecuted],
+                    ..Default::default()
+                },
+                khive_storage::types::PageRequest {
+                    offset: 0,
+                    limit: 10,
+                },
+            )
+            .await
+            .expect("query_events");
+
+        assert_eq!(
+            page.items.len(),
+            1,
+            "exactly one RecallExecuted event must be persisted: {page:?}"
+        );
+        let event = &page.items[0];
+        assert_eq!(event.verb, "memory.recall");
+        assert_eq!(
+            event.actor,
+            format!("{}:{}", token.actor().kind, token.actor().id)
+        );
+        assert_eq!(event.payload["query"], serde_json::json!(NOTE_TEXT));
+        assert_eq!(event.payload["result_kind"], serde_json::json!("note"));
+        assert_eq!(event.payload["result_count"], serde_json::json!(1));
+        let selected = event.payload["selected"]
+            .as_array()
+            .expect("selected must be an array")
+            .clone();
+        assert_eq!(selected.len(), 1);
+        assert_eq!(selected[0], serde_json::json!(note.id.to_string()));
+        let candidates = event.payload["candidates"]
+            .as_array()
+            .expect("candidates must be an array");
+        assert_eq!(
+            candidates, &selected,
+            "candidates mirrors selected at this emission boundary"
         );
     }
 }

--- a/crates/khive-pack-memory/src/handlers/remember.rs
+++ b/crates/khive-pack-memory/src/handlers/remember.rs
@@ -3,7 +3,7 @@
 use serde_json::{json, Value};
 use uuid::Uuid;
 
-use khive_runtime::{micros_to_iso, Namespace, NamespaceToken, RuntimeError};
+use khive_runtime::{micros_to_iso, KhiveRuntime, Namespace, NamespaceToken, RuntimeError};
 use khive_storage::types::{Direction, NeighborQuery};
 use khive_storage::EdgeRelation;
 
@@ -162,6 +162,9 @@ impl MemoryPack {
             None
         };
 
+        emit_memory_remembered_event(&self.runtime, write_token, note.id, memory_type, salience)
+            .await;
+
         let mut response = json!({
             "id": note.id.to_string(),
             "kind": note.kind,
@@ -174,5 +177,131 @@ impl MemoryPack {
             response["edge_id"] = json!(eid);
         }
         to_json(&response)
+    }
+}
+
+/// Best-effort `NoteCreated` telemetry for `memory.remember`.
+///
+/// `EventKind` is a closed enum owned by the OSS `khive-types` crate and has
+/// no dedicated `MemoryRemembered` variant, so — same constraint documented
+/// against `brain.mark_turn`'s `PhaseStarted`/`actor_turn` reuse
+/// — this reuses `NoteCreated`: `memory.remember` always
+/// creates a `memory`-kind `Note`, so a `NoteCreated` event carrying the new
+/// note's id as `target_id` (with `substrate = Note`, matching
+/// `decode_target_observation`'s `ReferentKind` selection) is the concrete
+/// "memory_remembered" signal the issue asks for. Awaited inline rather than
+/// backgrounded like `recall.rs`'s `RecallExecuted` emission: `memory.remember`
+/// is a write path, not a latency-sensitive hot read path, and git pack's
+/// `emit_write_audit` establishes the same inline-await, swallow-on-error
+/// shape for write-time telemetry.
+async fn emit_memory_remembered_event(
+    rt: &KhiveRuntime,
+    token: &NamespaceToken,
+    note_id: Uuid,
+    memory_type: &str,
+    salience: f64,
+) {
+    let store = match rt.events(token) {
+        Ok(store) => store,
+        Err(err) => {
+            tracing::warn!(
+                error = %err,
+                namespace = token.namespace().as_str(),
+                event_kind = "note_created",
+                "memory_remembered (note_created) event store acquisition failed; remember result is unaffected"
+            );
+            return;
+        }
+    };
+    let actor = format!("{}:{}", token.actor().kind, token.actor().id);
+    let payload = json!({
+        "actor": actor,
+        "memory_type": memory_type,
+        "salience": salience,
+    });
+    let event = khive_storage::Event::new(
+        token.namespace().as_str(),
+        "memory.remember",
+        khive_types::EventKind::NoteCreated,
+        khive_types::SubstrateKind::Note,
+        actor,
+    )
+    .with_payload(payload)
+    .with_target(note_id);
+    if let Err(err) = store.append_event(event).await {
+        tracing::warn!(
+            error = %err,
+            "memory_remembered (note_created) event append failed; remember result is unaffected"
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use khive_pack_kg::KgPack;
+    use khive_runtime::{KhiveRuntime, Namespace, VerbRegistryBuilder};
+
+    use crate::MemoryPack;
+
+    /// `memory.remember` must persist a `NoteCreated` event (the
+    /// "memory_remembered" signal) carrying the calling actor, the new
+    /// note's id as `target_id`, and `substrate = Note` so
+    /// `decode_target_observation` resolves it as a `Note` referent.
+    #[tokio::test]
+    async fn remember_persists_note_created_event_with_target() {
+        let rt = KhiveRuntime::memory().expect("in-memory runtime");
+        let ns = Namespace::parse("local").expect("local namespace");
+        let token = rt.authorize(ns).expect("authorize local");
+
+        let mut builder = VerbRegistryBuilder::new();
+        builder.register(KgPack::new(rt.clone()));
+        builder.register(MemoryPack::new(rt.clone()));
+        let registry = builder.build().expect("registry");
+
+        let result = registry
+            .dispatch(
+                "memory.remember",
+                serde_json::json!({
+                    "content": "memory_remembered event payload coverage",
+                    "memory_type": "semantic",
+                }),
+            )
+            .await
+            .expect("memory.remember must succeed");
+        let note_id: uuid::Uuid = result["id"]
+            .as_str()
+            .expect("response must carry id")
+            .parse()
+            .expect("id must be a uuid");
+
+        let store = rt.events(&token).expect("event store");
+        let page = store
+            .query_events(
+                khive_storage::event::EventFilter {
+                    kinds: vec![khive_types::EventKind::NoteCreated],
+                    ..Default::default()
+                },
+                khive_storage::types::PageRequest {
+                    offset: 0,
+                    limit: 10,
+                },
+            )
+            .await
+            .expect("query_events");
+
+        assert_eq!(
+            page.items.len(),
+            1,
+            "exactly one NoteCreated event must be persisted: {page:?}"
+        );
+        let event = &page.items[0];
+        assert_eq!(event.verb, "memory.remember");
+        assert_eq!(
+            event.actor,
+            format!("{}:{}", token.actor().kind, token.actor().id)
+        );
+        assert_eq!(event.target_id, Some(note_id));
+        assert_eq!(event.substrate, khive_types::SubstrateKind::Note);
+        assert_eq!(event.payload["memory_type"], serde_json::json!("semantic"));
     }
 }

--- a/crates/khive-pack-memory/src/pack.rs
+++ b/crates/khive-pack-memory/src/pack.rs
@@ -158,7 +158,7 @@ static MEMORY_HANDLERS: [HandlerDef; 10] = [
     // Assertive: retrieves memory notes via decay-aware ranking
     HandlerDef {
         name: "memory.recall",
-        description: "Recall memory notes with decay-aware hybrid ranking. Each hit carries resolved (read-model) values: memory_type defaults to \"episodic\" when not stored, salience and decay_factor reflect the effective defaults used for ranking.",
+        description: "Recall memory notes with decay-aware hybrid ranking. Each hit carries resolved (read-model) values: memory_type defaults to \"episodic\" when not stored, salience and decay_factor reflect the effective defaults used for ranking. Default responses are arrays; budget-capped hits carry truncated: true per result. When the budget removes every ranked candidate, the response is {results: [], truncated: true} so the cutoff stays distinguishable from a genuine no-match.",
         visibility: Visibility::Verb,
         category: VerbCategory::Assertive,
         params: &[
@@ -481,11 +481,25 @@ impl MemoryPack {
         .await
         {
             Ok(result) => result,
-            Err(_) => Err(RuntimeError::DeadlineExceeded {
-                operation: "memory.recall".to_string(),
-                budget_ms,
-                elapsed_ms: start.elapsed().as_millis() as u64,
-            }),
+            Err(_) => {
+                let elapsed_ms = start.elapsed().as_millis() as u64;
+                // #30/#889: the deadline-exceeded case is exactly the incident this
+                // issue reports (a recall that never returns, no daemon-side trace)
+                // -- the request never reaches recall.rs's own slow-request WARN
+                // because `handle_recall`'s future is dropped, not completed. Log
+                // it here, at the one call site every recall passes through.
+                tracing::warn!(
+                    operation = "memory.recall",
+                    budget_ms,
+                    elapsed_ms,
+                    "memory.recall exceeded its deadline and was abandoned"
+                );
+                Err(RuntimeError::DeadlineExceeded {
+                    operation: "memory.recall".to_string(),
+                    budget_ms,
+                    elapsed_ms,
+                })
+            }
         }
     }
 }

--- a/crates/khive-pack-memory/tests/integration.rs
+++ b/crates/khive-pack-memory/tests/integration.rs
@@ -3108,10 +3108,9 @@ async fn test_recall_legacy_note_no_memory_type_returned_as_episodic() {
 /// #94 regression (budget cap): when the token budget caps the returned count below
 /// the requested `limit`, fewer results than `limit` are returned.
 ///
-/// The non-verbose path always returns a bare array; the budget-capped status is
-/// observable as a count < limit.  Budget signal fields (`budget_capped`,
-/// `truncated_for_budget`) are available on the verbose/breakdown path when the
-/// runtime loads two or more embedding models (multi-model production setup).
+/// The default budget-capped path returns an envelope with top-level
+/// `truncated: true`; each surviving result also retains its per-item signal.
+/// Uncapped responses remain bare arrays.
 #[tokio::test]
 async fn test_recall_budget_capped_surfaces_signal() {
     let rt = make_runtime();
@@ -3152,10 +3151,9 @@ async fn test_recall_budget_capped_surfaces_signal() {
         .await
         .expect("recall with tiny budget succeeds");
 
-    // Non-verbose path always returns a bare array regardless of budget state.
     let returned = result
         .as_array()
-        .expect("#94: recall must return a bare array on the non-verbose path");
+        .expect("#94: non-empty budget-capped recall keeps the bare-array shape");
     assert!(
         !returned.is_empty(),
         "#94: at least one result must fit within the budget"
@@ -3165,6 +3163,84 @@ async fn test_recall_budget_capped_surfaces_signal() {
         "#94: returned count ({}) must be < requested limit (5) when budget is exhausted; \
          prefix-cut is not working if all 5 fit in an 80-char budget",
         returned.len()
+    );
+
+    // #49: every item in a budget-capped bare-array response must carry an
+    // explicit `truncated: true` stamp, distinguishing "capped by budget" from
+    // "only N matched" without requiring include_breakdown.
+    for item in returned {
+        assert_eq!(
+            item.get("truncated").and_then(serde_json::Value::as_bool),
+            Some(true),
+            "#49: budget-capped default-path result must carry truncated:true, got: {item}"
+        );
+    }
+}
+
+/// A budget cutoff at the first ranked candidate must remain distinguishable
+/// from a genuine recall miss even though both contain zero returned items.
+#[tokio::test]
+async fn test_recall_oversized_single_candidate_surfaces_top_level_truncation() {
+    let rt = make_runtime();
+    let registry = make_registry(rt.clone());
+
+    let query = "oversized single candidate budget regression";
+    registry
+        .dispatch(
+            "memory.remember",
+            json!({
+                "content": format!("{query} {}", "oversized".repeat(32)),
+                "salience": 0.8
+            }),
+        )
+        .await
+        .expect("remember oversized candidate");
+
+    let truncated = registry
+        .dispatch(
+            "memory.recall",
+            json!({
+                "query": query,
+                "limit": 1,
+                "config": {
+                    "scoring": {
+                        "default_token_budget": 1,
+                        "chars_per_token": 1,
+                        "mmr_penalty": 0.0
+                    }
+                }
+            }),
+        )
+        .await
+        .expect("recall with oversized first candidate succeeds");
+
+    assert_eq!(
+        truncated
+            .get("truncated")
+            .and_then(serde_json::Value::as_bool),
+        Some(true),
+        "a budget cutoff at the first candidate must surface top-level truncated:true: {truncated}"
+    );
+    assert!(
+        truncated
+            .get("results")
+            .and_then(serde_json::Value::as_array)
+            .is_some_and(Vec::is_empty),
+        "the oversized candidate must not be returned: {truncated}"
+    );
+
+    let no_match = registry
+        .dispatch(
+            "memory.recall",
+            json!({ "query": "genuine unmatched recall phrase", "limit": 1 }),
+        )
+        .await
+        .expect("genuine no-match recall succeeds");
+
+    assert!(no_match.as_array().is_some_and(Vec::is_empty));
+    assert!(
+        no_match.get("truncated").is_none(),
+        "a genuine no-match must not carry a truncation signal: {no_match}"
     );
 }
 
@@ -3196,6 +3272,16 @@ async fn test_recall_no_budget_cap_returns_plain_array() {
         result.is_array(),
         "#94 no-cap path: recall must return a plain array; got: {result}"
     );
+
+    // #49: an uncapped result must NOT carry the truncated stamp — the field is
+    // present only when budget_capped is true, matching the pre-existing
+    // `degraded` stamp's absent-when-false convention.
+    for item in result.as_array().expect("array") {
+        assert!(
+            item.get("truncated").is_none(),
+            "#49: uncapped default-path result must not carry a truncated field, got: {item}"
+        );
+    }
 }
 
 /// #94 regression (rank order): when the token budget forces truncation, the
@@ -3272,10 +3358,9 @@ async fn test_recall_budget_truncation_preserves_rank_order() {
         .await
         .expect("recall with rank-order budget test");
 
-    // Non-verbose path returns a bare array.
     let returned = result
         .as_array()
-        .expect("#94 rank-order: recall must return a bare array");
+        .expect("#94 rank-order: non-empty budget-capped recall keeps the bare-array shape");
 
     // Exactly 1 result (rank #1 fits, prefix cut stops at rank #2 overflow).
     // Old retain would return 2 results: [rank#1, rank#3].

--- a/crates/khive-pack-schedule/src/vocab.rs
+++ b/crates/khive-pack-schedule/src/vocab.rs
@@ -45,7 +45,20 @@ pub(crate) static SCHEDULE_HANDLERS: [HandlerDef; 4] = [
     },
     HandlerDef {
         name: "schedule.schedule",
-        description: "Schedule a future verb dispatch.",
+        description: "Schedule a future verb dispatch. NESTED-ACTION EXAMPLE (issue #110): \
+                       schedule.schedule(action=\"schedule.remind(content=\\\"renew the \
+                       domain\\\", at=\\\"2027-06-01T09:00:00Z\\\")\", \
+                       at=\"2027-05-25T09:00:00Z\") — the OUTER `at` (2027-05-25) is when \
+                       THIS schedule fires and the stored `action` gets dispatched (i.e. when \
+                       the reminder gets CREATED); the INNER `at` (2027-06-01) is the nested \
+                       `schedule.remind` call's own required argument and becomes THAT \
+                       reminder's trigger time (i.e. when the newly-created reminder itself \
+                       fires). The two are independent and commonly differ — this schedules \
+                       the creation of a reminder a week ahead of when the reminder should go \
+                       off. If the nested action's own verb requires `at` (or any other \
+                       required param), it must be supplied on the nested call, exactly as if \
+                       that verb were being called directly — replay dispatches the stored \
+                       `action` string verbatim with no injection from the outer `at`.",
         visibility: Visibility::Verb,
         category: khive_types::VerbCategory::Commissive,
         params: &[
@@ -53,13 +66,23 @@ pub(crate) static SCHEDULE_HANDLERS: [HandlerDef; 4] = [
                 name: "action",
                 param_type: "string",
                 required: true,
-                description: "Verb dispatch payload to execute at the trigger time (e.g. \"schedule.remind(content=\\\"hello\\\")\"). Must not be empty.",
+                description: "Verb dispatch payload to execute at the trigger time — a \
+                               complete, self-sufficient verb call including ALL of that \
+                               verb's OWN required params (e.g. \
+                               \"schedule.remind(content=\\\"hello\\\", \
+                               at=\\\"2027-06-01T09:00:00Z\\\")\" — `schedule.remind` requires \
+                               its own `at`, separate from and independent of this verb's `at` \
+                               below; see the handler description for the full worked \
+                               example). Must not be empty.",
             },
             ParamDef {
                 name: "at",
                 param_type: "string",
                 required: true,
-                description: "Trigger time in RFC 3339 format (e.g. \"2026-06-01T09:00:00Z\"). Must not be empty.",
+                description: "Trigger time in RFC 3339 format (e.g. \"2026-06-01T09:00:00Z\") — \
+                               when THIS schedule fires and `action` gets dispatched. This is \
+                               independent of any `at` the nested `action` verb itself \
+                               requires (see the handler description). Must not be empty.",
             },
             ParamDef {
                 name: "repeat",

--- a/crates/khive-pack-schedule/tests/handler_metadata.rs
+++ b/crates/khive-pack-schedule/tests/handler_metadata.rs
@@ -57,6 +57,45 @@ fn schedule_has_required_action_and_at() {
     assert!(at.required, "schedule.at must be required");
 }
 
+/// #110: the outer `at` and a nested action's own `at` are two independent
+/// timestamps (outer = when this schedule fires and dispatches `action`;
+/// inner = whatever that nested verb's own `at` means, e.g. a reminder's own
+/// trigger time). Nothing in the surface previously said so — the handler
+/// description now carries a full worked example naming both roles
+/// explicitly, so a caller hits the explanation before hitting the error.
+#[test]
+fn schedule_description_documents_nested_action_at_example() {
+    let h = find_handler("schedule.schedule");
+    assert!(
+        h.description.contains("schedule.remind"),
+        "schedule.schedule's description must show a worked nested-action example; got: {}",
+        h.description
+    );
+    assert!(
+        h.description.matches("at=").count() >= 1
+            && h.description.contains("OUTER")
+            && h.description.contains("INNER"),
+        "schedule.schedule's description must explain the outer vs. inner `at` roles; got: {}",
+        h.description
+    );
+}
+
+#[test]
+fn schedule_action_param_description_flags_nested_required_params() {
+    let h = find_handler("schedule.schedule");
+    let action = h
+        .params
+        .iter()
+        .find(|p| p.name == "action")
+        .expect("schedule must have 'action'");
+    assert!(
+        action.description.contains("self-sufficient") || action.description.contains("OWN"),
+        "schedule.action's description must warn that the nested verb's own required \
+         params (e.g. its own `at`) must be supplied on the nested call; got: {}",
+        action.description
+    );
+}
+
 #[test]
 fn schedule_has_optional_repeat() {
     let h = find_handler("schedule.schedule");

--- a/crates/khive-pack-schedule/tests/integration.rs
+++ b/crates/khive-pack-schedule/tests/integration.rs
@@ -170,6 +170,65 @@ async fn s_c1_schedule_valid_rfc3339_succeeds() {
     assert_eq!(result["status"], "pending");
 }
 
+/// #110, World 2 (diagnosed, not incidental): the outer `at` and a nested
+/// action's own `at` are genuinely different timestamps that can diverge —
+/// outer = when `schedule.schedule` fires and dispatches the stored `action`;
+/// inner = whatever the nested verb's own `at` means (here, the reminder's
+/// own future trigger time). Round-trip both through `schedule.agenda` and
+/// assert they land in distinct places: the outer `at` becomes this event's
+/// own `trigger_at`, while the inner `at` survives untouched, literally,
+/// inside the stored `action` payload — nothing coerces or overwrites either
+/// with the other.
+#[tokio::test]
+async fn s_c1_schedule_outer_and_nested_at_are_independent_and_both_preserved() {
+    let (registry, _rt) = build_registry();
+
+    let outer_at = "2099-01-01T00:00:00Z";
+    let inner_at = "2099-12-31T00:00:00Z";
+    assert_ne!(outer_at, inner_at, "the two `at`s must genuinely differ");
+
+    registry
+        .dispatch(
+            "schedule.schedule",
+            serde_json::json!({
+                "action": format!("schedule.remind(content=\"renew\", at=\"{inner_at}\")"),
+                "at": outer_at,
+            }),
+        )
+        .await
+        .expect("schedule with distinct outer/inner at must succeed");
+
+    let agenda = registry
+        .dispatch("schedule.agenda", serde_json::json!({}))
+        .await
+        .expect("agenda must succeed");
+    let events = agenda["events"]
+        .as_array()
+        .expect("agenda.events is an array");
+    let event = events
+        .iter()
+        .find(|e| e["properties"]["event_type"] == "schedule")
+        .expect("the scheduled event must be on the agenda");
+
+    assert_eq!(
+        event["properties"]["trigger_at"], outer_at,
+        "the OUTER at must be this event's own trigger_at (when it fires)"
+    );
+    let payload = event["properties"]["payload"]
+        .as_str()
+        .expect("payload must be the stored action string");
+    assert!(
+        payload.contains(inner_at),
+        "the INNER at must survive verbatim inside the stored action payload, \
+         independent of the outer trigger_at; payload was: {payload}"
+    );
+    assert_ne!(
+        event["properties"]["trigger_at"].as_str().unwrap(),
+        inner_at,
+        "the outer trigger_at must NOT have been overwritten by the nested at"
+    );
+}
+
 #[tokio::test]
 async fn s_c1_schedule_invalid_at_not_a_date() {
     let (registry, _rt) = build_registry();

--- a/crates/khive-request/docs/api/previous-result.md
+++ b/crates/khive-request/docs/api/previous-result.md
@@ -39,3 +39,13 @@ JSON decoding produces `\$prev.id`; the parser removes that one escape and store
 `resolve_all` recursively materializes an argument into owned JSON. Concrete values are cloned, references are resolved and cloned, and dynamic arrays/objects preserve order while resolving every descendant. If any reference path misses, the entire call returns `None`; partial materialization is never returned.
 
 Runtime results used as future `$prev` context should first pass `value_nesting_within_limit`. That function walks an explicit heap worklist, avoiding recursive clone/serialization of attacker-controlled deep JSON before the depth bound is checked.
+
+## `ArgValue::find_prev_failure`
+
+`resolve_all` returning `None` only says *that* a reference missed, not *why*. `find_prev_failure` walks the same argument (including nested `$prev` refs inside array/object literals) and returns a [`PrevFailure`] explaining the first miss it finds:
+
+- `NotFound` — the field or index simply isn't there; carries the sibling field names (or array length) available at that point.
+- `WrongType` — a path segment expects an object (for a field) or an array (for an index) to continue into, but the value at that point is a different JSON type.
+- `Unsupported` — the path contains bracket syntax that isn't a valid non-negative-integer index. The public DSL parser rejects this shape before it ever reaches `ArgValue::PrevRef`, so this variant only fires against an `ArgValue` built some other way.
+
+Callers building an error message for a `resolve_all` miss should call `find_prev_failure` for the specific reason, rather than emitting one generic "not found" for all three mistakes.

--- a/crates/khive-request/src/lib.rs
+++ b/crates/khive-request/src/lib.rs
@@ -10,5 +10,5 @@ pub use conflict::write_keys_for_op_pub;
 pub use parser::parse_request;
 pub use types::{
     value_nesting_within_limit, ArgValue, DslError, ExecutionMode, ParsedOp, ParsedRequest,
-    MAX_OPS, MAX_OPS_INPUT_LEN, NESTING_DEPTH_LIMIT, RESERVED_ENVELOPE_ARGS,
+    PrevFailure, MAX_OPS, MAX_OPS_INPUT_LEN, NESTING_DEPTH_LIMIT, RESERVED_ENVELOPE_ARGS,
 };

--- a/crates/khive-request/src/parser/mod.rs
+++ b/crates/khive-request/src/parser/mod.rs
@@ -7,4 +7,4 @@ mod scan;
 
 pub use dispatch::parse_request;
 
-pub(crate) use path::{apply_path_segment, split_path};
+pub(crate) use path::{apply_path_segment, split_path, PathSegment};

--- a/crates/khive-request/src/parser/path.rs
+++ b/crates/khive-request/src/parser/path.rs
@@ -7,6 +7,11 @@ use serde_json::Value;
 pub(crate) enum PathSegment<'a> {
     Field(&'a str),
     Index(usize),
+    /// Bracket syntax that is not a valid non-negative-integer index, e.g.
+    /// `[abc]` or `[-1]`. Always a lookup miss (see `apply_path_segment`);
+    /// kept distinct from `Field` so callers building error messages can
+    /// tell "no such field" apart from "this isn't a supported path form".
+    Malformed(&'a str),
 }
 
 /// Splits a `$prev` path into field and index segments.
@@ -25,7 +30,7 @@ pub(crate) fn split_path(path: &str) -> Vec<PathSegment<'_>> {
                 }
             }
             // Preserve malformed quoted paths as a lookup miss, never a partial match.
-            segments.push(PathSegment::Field(remaining));
+            segments.push(PathSegment::Malformed(remaining));
             break;
         }
         let end = remaining.find(['.', '[']).unwrap_or(remaining.len());
@@ -44,5 +49,6 @@ pub(crate) fn apply_path_segment<'a>(cur: &'a Value, seg: PathSegment<'_>) -> Op
     match seg {
         PathSegment::Field(key) => cur.get(key),
         PathSegment::Index(idx) => cur.as_array()?.get(idx),
+        PathSegment::Malformed(_) => None,
     }
 }

--- a/crates/khive-request/src/types.rs
+++ b/crates/khive-request/src/types.rs
@@ -127,6 +127,249 @@ impl ArgValue {
             }
         }
     }
+
+    /// Finds the first `$prev` reference within this argument that fails to
+    /// resolve against `prev_result`, and explains why. `None` means every
+    /// reference resolves (consistent with `resolve_all(prev_result).is_some()`)
+    /// or this argument holds no `$prev` reference at all.
+    ///
+    /// Walks the same segments as `resolve_prev`/`resolve_all` but never
+    /// changes what resolves — it exists purely to build an actionable error
+    /// message for a `resolve_all` miss.
+    pub fn find_prev_failure(&self, prev_result: &Value) -> Option<PrevFailure> {
+        self.find_prev_failure_at("", prev_result)
+    }
+
+    fn find_prev_failure_at(&self, arg_path: &str, prev_result: &Value) -> Option<PrevFailure> {
+        match self {
+            ArgValue::Value(_) => None,
+            ArgValue::PrevRef { path } => {
+                // Empty path = whole-value reference; always resolves. Its
+                // downstream shape (bare $prev onto a map/array) is a
+                // separate, already-handled concern (UE4-H1), not a lookup miss.
+                if path.is_empty() {
+                    return None;
+                }
+                let mut cur = prev_result;
+                let mut resolved_prefix = String::new();
+                for seg in crate::parser::split_path(path) {
+                    match seg {
+                        crate::parser::PathSegment::Field(key) => match cur {
+                            Value::Object(map) => match map.get(key) {
+                                Some(v) => {
+                                    cur = v;
+                                    if !resolved_prefix.is_empty() {
+                                        resolved_prefix.push('.');
+                                    }
+                                    resolved_prefix.push_str(key);
+                                }
+                                None => {
+                                    let mut available: Vec<String> = map.keys().cloned().collect();
+                                    available.sort_unstable();
+                                    return Some(PrevFailure::NotFound {
+                                        arg_path: arg_path.to_string(),
+                                        prev_path: render_prev_path(path),
+                                        resolved_prefix: prev_path_prefix(&resolved_prefix),
+                                        missing: key.to_string(),
+                                        available,
+                                    });
+                                }
+                            },
+                            other => {
+                                return Some(PrevFailure::WrongType {
+                                    arg_path: arg_path.to_string(),
+                                    prev_path: render_prev_path(path),
+                                    resolved_prefix: prev_path_prefix(&resolved_prefix),
+                                    segment: key.to_string(),
+                                    expected: "object",
+                                    found: json_type_name(other),
+                                });
+                            }
+                        },
+                        crate::parser::PathSegment::Index(idx) => match cur {
+                            Value::Array(arr) => match arr.get(idx) {
+                                Some(v) => {
+                                    cur = v;
+                                    resolved_prefix.push_str(&format!("[{idx}]"));
+                                }
+                                None => {
+                                    return Some(PrevFailure::NotFound {
+                                        arg_path: arg_path.to_string(),
+                                        prev_path: render_prev_path(path),
+                                        resolved_prefix: prev_path_prefix(&resolved_prefix),
+                                        missing: format!("[{idx}]"),
+                                        available: vec![format!(
+                                            "array has {} element(s)",
+                                            arr.len()
+                                        )],
+                                    });
+                                }
+                            },
+                            other => {
+                                return Some(PrevFailure::WrongType {
+                                    arg_path: arg_path.to_string(),
+                                    prev_path: render_prev_path(path),
+                                    resolved_prefix: prev_path_prefix(&resolved_prefix),
+                                    segment: format!("[{idx}]"),
+                                    expected: "array",
+                                    found: json_type_name(other),
+                                });
+                            }
+                        },
+                        crate::parser::PathSegment::Malformed(raw) => {
+                            return Some(PrevFailure::Unsupported {
+                                arg_path: arg_path.to_string(),
+                                prev_path: render_prev_path(path),
+                                segment: raw.to_string(),
+                            });
+                        }
+                    }
+                }
+                None
+            }
+            ArgValue::Array(elements) => elements.iter().enumerate().find_map(|(i, el)| {
+                el.find_prev_failure_at(&format!("{arg_path}[{i}]"), prev_result)
+            }),
+            ArgValue::Object(pairs) => pairs.iter().find_map(|(k, v)| {
+                let sub = if arg_path.is_empty() {
+                    k.clone()
+                } else {
+                    format!("{arg_path}.{k}")
+                };
+                v.find_prev_failure_at(&sub, prev_result)
+            }),
+        }
+    }
+}
+
+fn render_prev_path(path: &str) -> String {
+    format!("$prev.{path}").replace(".[", "[")
+}
+
+/// Renders the `$prev`-relative path successfully traversed before a failure,
+/// for messages like "`$prev.user` is a string, not an object".
+fn prev_path_prefix(resolved_prefix: &str) -> String {
+    if resolved_prefix.is_empty() {
+        "$prev".to_string()
+    } else {
+        format!("$prev.{resolved_prefix}")
+    }
+}
+
+fn json_type_name(v: &Value) -> &'static str {
+    match v {
+        Value::Null => "null",
+        Value::Bool(_) => "boolean",
+        Value::Number(_) => "number",
+        Value::String(_) => "string",
+        Value::Array(_) => "array",
+        Value::Object(_) => "object",
+    }
+}
+
+/// Explains why a `$prev` path failed to resolve, for error-message
+/// construction. Distinguishes three mistakes that a single generic
+/// "not found" message conflates:
+///
+/// - the field/index simply isn't there (`NotFound`);
+/// - a segment expects an object or array to index into, but the prior
+///   result holds a scalar at that point (`WrongType`);
+/// - the bracket syntax itself isn't a supported index form (`Unsupported`).
+#[derive(Debug, Clone, PartialEq)]
+pub enum PrevFailure {
+    /// A path segment names a field or index that does not exist on an
+    /// otherwise correctly-typed container.
+    NotFound {
+        /// Path to the offending `$prev` reference within the verb argument
+        /// it appears in (empty when the argument itself is the reference).
+        arg_path: String,
+        /// The full `$prev` path that was attempted, e.g. `$prev.user.id`.
+        prev_path: String,
+        /// The `$prev`-relative path successfully traversed before the miss.
+        resolved_prefix: String,
+        /// The field name or `[index]` that could not be found.
+        missing: String,
+        /// Sibling field names (object) or a length note (array) at the
+        /// point of failure.
+        available: Vec<String>,
+    },
+    /// A path segment expects an object (for a field) or an array (for an
+    /// index) to continue into, but the prior result holds a different JSON
+    /// type at that point.
+    WrongType {
+        arg_path: String,
+        prev_path: String,
+        /// The `$prev`-relative path successfully traversed before the type
+        /// mismatch — this is what actually holds `found`.
+        resolved_prefix: String,
+        /// The field name or `[index]` that could not be applied.
+        segment: String,
+        expected: &'static str,
+        found: &'static str,
+    },
+    /// Bracket syntax that is not a valid non-negative-integer index.
+    Unsupported {
+        arg_path: String,
+        prev_path: String,
+        /// The unsupported segment as written, e.g. `[bad]`.
+        segment: String,
+    },
+}
+
+impl fmt::Display for PrevFailure {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fn arg_ref(arg_path: &str) -> String {
+            if arg_path.is_empty() {
+                String::new()
+            } else {
+                format!(" (at {arg_path})")
+            }
+        }
+        match self {
+            PrevFailure::NotFound {
+                arg_path,
+                prev_path,
+                resolved_prefix,
+                missing,
+                available,
+            } => {
+                write!(
+                    f,
+                    "{prev_path}{arg}: {resolved_prefix} has no {missing:?}. \
+                     Available top-level fields: [{}]",
+                    available.join(", "),
+                    arg = arg_ref(arg_path),
+                )
+            }
+            PrevFailure::WrongType {
+                arg_path,
+                prev_path,
+                resolved_prefix,
+                segment,
+                expected,
+                found,
+            } => {
+                write!(
+                    f,
+                    "{prev_path}{arg}: {resolved_prefix} is a {found}, not an {expected}, so \
+                     {segment:?} cannot be applied to it",
+                    arg = arg_ref(arg_path),
+                )
+            }
+            PrevFailure::Unsupported {
+                arg_path,
+                prev_path,
+                segment,
+            } => {
+                write!(
+                    f,
+                    "{prev_path}{arg}: {segment:?} is not a supported $prev path segment; \
+                     array indices must be a plain non-negative integer, e.g. $prev.items[0]",
+                    arg = arg_ref(arg_path),
+                )
+            }
+        }
+    }
 }
 
 /// One parsed tool name and its deterministically ordered named arguments.

--- a/crates/khive-request/tests/parser.rs
+++ b/crates/khive-request/tests/parser.rs
@@ -1828,3 +1828,119 @@ fn realistic_nested_payload_well_under_limit_still_parses() {
     );
     assert_eq!(r.mode, ExecutionMode::Single);
 }
+
+// ── ArgValue::find_prev_failure — $prev substitution error diagnosis ───────
+//
+// These exercise `find_prev_failure` directly against hand-built `ArgValue`s
+// rather than through `parse_request`, because the DSL parser (both the
+// unquoted `$prev[..]` grammar above and `quoted_prev_path_is_valid` for the
+// quoted-string form) already rejects malformed bracket syntax before an
+// `ArgValue::PrevRef` is ever constructed — that parser-level rejection is
+// covered in `khive-mcp`'s integration suite
+// (`test_prev_malformed_index_rejected_at_parse_time`). The substituter's own
+// `PrevFailure::Unsupported` defense is otherwise unreachable through the
+// public DSL surface today, so it is verified here, directly, as
+// defense-in-depth against a future caller that builds an `ArgValue` some
+// other way (e.g. a second parser front-end).
+
+use khive_request::PrevFailure;
+use serde_json::Value as JsonValue;
+
+fn prev_ref(path: &str) -> ArgValue {
+    ArgValue::PrevRef {
+        path: path.to_string(),
+    }
+}
+
+#[test]
+fn find_prev_failure_reports_not_found_for_missing_field() {
+    let prev: JsonValue = json!({"id": "abc", "kind": "concept"});
+    let failure = prev_ref("bogus").find_prev_failure(&prev);
+    match failure {
+        Some(PrevFailure::NotFound {
+            missing, available, ..
+        }) => {
+            assert_eq!(missing, "bogus");
+            assert!(available.contains(&"id".to_string()));
+        }
+        other => panic!("expected NotFound, got {other:?}"),
+    }
+}
+
+#[test]
+fn find_prev_failure_renders_root_index_as_valid_dsl_path() {
+    let parsed = req(r#"list(kind="concept") | get(id=$prev[2])"#);
+    let failure = parsed.ops[1].args["id"]
+        .find_prev_failure(&json!([]))
+        .expect("out-of-range index must report a substitution failure");
+    let rendered = failure.to_string();
+    assert_eq!(
+        rendered.split_once(':').map(|(path, _)| path),
+        Some("$prev[2]")
+    );
+}
+
+#[test]
+fn find_prev_failure_renders_nested_index_as_valid_dsl_path() {
+    let parsed = req(r#"list(kind="concept") | get(id=$prev.items[0].id)"#);
+    let failure = parsed.ops[1].args["id"]
+        .find_prev_failure(&json!({"items": []}))
+        .expect("out-of-range index must report a substitution failure");
+    let rendered = failure.to_string();
+    assert_eq!(
+        rendered.split_once(':').map(|(path, _)| path),
+        Some("$prev.items[0].id")
+    );
+}
+
+#[test]
+fn find_prev_failure_reports_wrong_type_for_field_on_scalar() {
+    let prev: JsonValue = json!({"name": "concept-1"});
+    let failure = prev_ref("name.sub").find_prev_failure(&prev);
+    match failure {
+        Some(PrevFailure::WrongType {
+            expected, found, ..
+        }) => {
+            assert_eq!(expected, "object");
+            assert_eq!(found, "string");
+        }
+        other => panic!("expected WrongType, got {other:?}"),
+    }
+}
+
+#[test]
+fn find_prev_failure_reports_wrong_type_for_index_on_object() {
+    let prev: JsonValue = json!({"items": {"not": "an array"}});
+    let failure = prev_ref("items[0]").find_prev_failure(&prev);
+    match failure {
+        Some(PrevFailure::WrongType {
+            expected, found, ..
+        }) => {
+            assert_eq!(expected, "array");
+            assert_eq!(found, "object");
+        }
+        other => panic!("expected WrongType, got {other:?}"),
+    }
+}
+
+#[test]
+fn find_prev_failure_reports_unsupported_for_malformed_bracket() {
+    // `ArgValue::PrevRef` built directly (bypassing the parser, which never
+    // produces this shape) to exercise the substituter's own defense.
+    let prev: JsonValue = json!({"id": "abc"});
+    let failure = prev_ref("[bad]").find_prev_failure(&prev);
+    match failure {
+        Some(PrevFailure::Unsupported { segment, .. }) => {
+            assert_eq!(segment, "[bad]");
+        }
+        other => panic!("expected Unsupported, got {other:?}"),
+    }
+}
+
+#[test]
+fn find_prev_failure_none_when_resolve_all_succeeds() {
+    let prev: JsonValue = json!({"id": "abc", "nested": {"x": 1}});
+    let arg = prev_ref("nested.x");
+    assert!(arg.resolve_all(&prev).is_some());
+    assert!(arg.find_prev_failure(&prev).is_none());
+}

--- a/crates/khive-runtime/docs/api/atomic_runner.md
+++ b/crates/khive-runtime/docs/api/atomic_runner.md
@@ -51,5 +51,7 @@ Only the **commit pass** (phase 2) lives here: given an already-prepared `Vec<At
 (phase 1, the async prepare pass, is out of scope for B2), `run_atomic_unit` opens one
 `atomic_unit`, applies each plan's statements under a
 named `SAVEPOINT`, and returns either every op's collected `PostCommitEffect`s (phase 3, the
-async post-commit pass — the B3 wiring point: nothing in B2 executes these effects, a test
-consumer only drains the returned list) or the first op's failure and its index.
+async post-commit pass) inside an opaque `CommittedPostCommitEffects` token or the first op's
+failure and its index. Nothing in phase 2 executes deferred effects. After a successful commit,
+the caller passes the token by value to `apply_post_commit_effects`; callers may inspect its
+contents but cannot turn prepare-time effects into an executable token.

--- a/crates/khive-runtime/src/atomic_plan.rs
+++ b/crates/khive-runtime/src/atomic_plan.rs
@@ -157,34 +157,96 @@ pub enum PostCommitEffect {
 /// after commit.
 #[derive(Debug, Clone)]
 pub struct EdgeNaturalKey {
-    pub namespace: String,
-    pub canon_source_id: Uuid,
-    pub canon_target_id: Uuid,
-    pub relation: khive_storage::EdgeRelation,
+    pub(crate) namespace: String,
+    pub(crate) canon_source_id: Uuid,
+    pub(crate) canon_target_id: Uuid,
+    pub(crate) relation: khive_storage::EdgeRelation,
+}
+
+impl EdgeNaturalKey {
+    /// The namespace containing the surviving edge.
+    pub fn namespace(&self) -> &str {
+        &self.namespace
+    }
+
+    /// The canonical source endpoint of the surviving edge.
+    pub fn canon_source_id(&self) -> Uuid {
+        self.canon_source_id
+    }
+
+    /// The canonical target endpoint of the surviving edge.
+    pub fn canon_target_id(&self) -> Uuid {
+        self.canon_target_id
+    }
+
+    /// The surviving edge's relation.
+    pub fn relation(&self) -> khive_storage::EdgeRelation {
+        self.relation
+    }
 }
 
 /// Write plan for an `update` op (entity or note shape — ADR-099 D3's
 /// `update` caveat covers both substrates the same way: row/FTS DML in the
 /// plan, any reindex deferred to `post_commit`).
+///
+/// Deferred effects are assigned by this crate's prepare pass and cannot be
+/// supplied by callers constructing a plan directly:
+///
+/// ```compile_fail
+/// use khive_runtime::{PostCommitEffect, UpdatePlan};
+/// use uuid::Uuid;
+///
+/// let id = Uuid::nil();
+/// let plan = UpdatePlan {
+///     target_id: id,
+///     statements: Vec::new(),
+///     post_commit: PostCommitEffect::ReindexEntity { entity_id: id },
+///     edge_natural_key: None,
+/// };
+/// ```
+///
+/// A plan returned by a prepare function cannot have its validated
+/// statements cleared or replaced before it reaches the runner:
+///
+/// ```compile_fail
+/// use khive_runtime::UpdatePlan;
+///
+/// fn clear_prepared_statements(mut prepared: UpdatePlan) {
+///     prepared.statements.clear();
+/// }
+/// ```
 #[derive(Debug, Clone)]
 pub struct UpdatePlan {
     /// The id of the entity or note being updated. For a symmetric edge
     /// update this is the CALLER's requested id — advisory only, never the
     /// basis for post-commit result rendering (see [`EdgeNaturalKey`]).
-    pub target_id: Uuid,
+    pub(crate) target_id: Uuid,
     /// Row + FTS DML statements to apply inside the atomic unit, in order.
     /// The row-update statement carries the existence guard; any FTS-mirror
     /// statement that follows it is unguarded (its target row's existence
     /// was already asserted by the row-update statement's own guard).
-    pub statements: Vec<PlanStatement>,
-    /// Deferred reindex, if the update changed name/description/content.
-    pub post_commit: PostCommitEffect,
+    pub(crate) statements: Vec<PlanStatement>,
+    /// Deferred reindex assigned by the prepare pass when the update changed
+    /// name, description, or content.
+    pub(crate) post_commit: PostCommitEffect,
     /// `Some` only for a symmetric edge update — the natural key a caller
     /// must use to derive the committed surviving row post-commit, rather
     /// than trusting `target_id`. `None` for every other update shape
     /// (entity, note, non-symmetric edge), where `target_id` alone is
     /// already an exact, non-advisory identifier.
-    pub edge_natural_key: Option<EdgeNaturalKey>,
+    pub(crate) edge_natural_key: Option<EdgeNaturalKey>,
+}
+
+impl UpdatePlan {
+    /// The record id supplied to the prepare pass.
+    pub fn target_id(&self) -> Uuid {
+        self.target_id
+    }
+
+    /// The committed lookup key required for a symmetric edge update.
+    pub fn edge_natural_key(&self) -> Option<&EdgeNaturalKey> {
+        self.edge_natural_key.as_ref()
+    }
 }
 
 /// Write plan for an `AddEntity` proposal change: a fresh entity row plus its
@@ -193,14 +255,22 @@ pub struct UpdatePlan {
 #[derive(Debug, Clone)]
 pub struct AddEntityPlan {
     /// The freshly generated id of the entity being created.
-    pub entity_id: Uuid,
+    pub(crate) entity_id: Uuid,
     /// Row + FTS insert statements to apply inside the atomic unit, in
     /// order. The row-insert statement carries the existence guard; the
     /// FTS-insert statement that follows it is unguarded (an ordinary
     /// `INSERT` into a virtual table with no conflicting row).
-    pub statements: Vec<PlanStatement>,
-    /// Reindex the committed entity after the transaction closes.
-    pub post_commit: PostCommitEffect,
+    pub(crate) statements: Vec<PlanStatement>,
+    /// Reindex the committed entity after the transaction closes, as
+    /// assigned by the prepare pass.
+    pub(crate) post_commit: PostCommitEffect,
+}
+
+impl AddEntityPlan {
+    /// The id generated for the prepared entity.
+    pub fn entity_id(&self) -> Uuid {
+        self.entity_id
+    }
 }
 
 /// Write plan for an `AddNote` proposal change: a fresh note row plus its FTS
@@ -208,29 +278,62 @@ pub struct AddEntityPlan {
 #[derive(Debug, Clone)]
 pub struct AddNotePlan {
     /// The freshly generated id of the note being created.
-    pub note_id: Uuid,
+    pub(crate) note_id: Uuid,
     /// Row + FTS insert statements to apply inside the atomic unit, in
     /// order, mirroring [`AddEntityPlan::statements`].
-    pub statements: Vec<PlanStatement>,
-    /// Reindex the committed note after the transaction closes.
-    pub post_commit: PostCommitEffect,
+    pub(crate) statements: Vec<PlanStatement>,
+    /// Reindex the committed note after the transaction closes, as assigned
+    /// by the prepare pass.
+    pub(crate) post_commit: PostCommitEffect,
+}
+
+impl AddNotePlan {
+    /// The id generated for the prepared note.
+    pub fn note_id(&self) -> Uuid {
+        self.note_id
+    }
 }
 
 /// Write plan for a `delete` op (soft or hard).
+///
+/// Deferred effects are assigned by this crate's prepare pass and cannot be
+/// attached to a statement-free plan by external callers:
+///
+/// ```compile_fail
+/// use khive_runtime::{DeletePlan, PostCommitEffect};
+/// use uuid::Uuid;
+///
+/// let id = Uuid::nil();
+/// let plan = DeletePlan {
+///     target_id: id,
+///     statements: Vec::new(),
+///     post_commit: PostCommitEffect::NoteDeleted {
+///         note_id: id,
+///         kind: "observation".to_owned(),
+///     },
+/// };
+/// ```
 #[derive(Debug, Clone)]
 pub struct DeletePlan {
     /// The id of the entity or note being deleted.
-    pub target_id: Uuid,
+    pub(crate) target_id: Uuid,
     /// Row DML (and, for a hard delete, incident-edge cascade DML) to apply
     /// inside the atomic unit, in order. The target-row delete statement
     /// carries the existence guard; a cascade edge-delete statement (hard
     /// delete only) is unguarded — it may legitimately affect zero rows if
     /// the target had no incident edges.
-    pub statements: Vec<PlanStatement>,
-    /// Deferred note-mutation-hook fire, for a note delete (#750
-    /// 2). `PostCommitEffect::None` for entity and edge deletes — the hook
-    /// system is note-only.
-    pub post_commit: PostCommitEffect,
+    pub(crate) statements: Vec<PlanStatement>,
+    /// Deferred note-mutation-hook fire assigned by the prepare pass for a
+    /// note delete (#750 2). `PostCommitEffect::None` for entity and edge
+    /// deletes — the hook system is note-only.
+    pub(crate) post_commit: PostCommitEffect,
+}
+
+impl DeletePlan {
+    /// The record id supplied to the prepare pass.
+    pub fn target_id(&self) -> Uuid {
+        self.target_id
+    }
 }
 
 /// Write plan for a `link` op (create a typed directed edge). Endpoint
@@ -244,11 +347,23 @@ pub struct DeletePlan {
 /// convention).
 #[derive(Debug, Clone)]
 pub struct LinkPlan {
-    pub source_id: Uuid,
-    pub target_id: Uuid,
+    pub(crate) source_id: Uuid,
+    pub(crate) target_id: Uuid,
     /// The guarded `INSERT ... SELECT ... WHERE EXISTS(...)` statement:
     /// its affected-row count is the endpoint-existence probe.
-    pub statement: PlanStatement,
+    pub(crate) statement: PlanStatement,
+}
+
+impl LinkPlan {
+    /// The canonical source endpoint used by the prepared statement.
+    pub fn source_id(&self) -> Uuid {
+        self.source_id
+    }
+
+    /// The canonical target endpoint used by the prepared statement.
+    pub fn target_id(&self) -> Uuid {
+        self.target_id
+    }
 }
 
 /// Write plan for a `merge` op (deduplicate two entities). Rewires and
@@ -259,25 +374,37 @@ pub struct LinkPlan {
 /// lifecycle write assumes both rows exist, so it always is.
 #[derive(Debug, Clone)]
 pub struct MergePlan {
-    pub into_id: Uuid,
-    pub from_id: Uuid,
+    pub(crate) into_id: Uuid,
+    pub(crate) from_id: Uuid,
     /// Predicate-based edge-rewire statement(s)
     /// (`UPDATE graph_edges SET source_id = :into WHERE source_id = :from`-
     /// shaped), evaluated inside the transaction so they structurally see
     /// any earlier op's edge writes in the same file (ADR-099 acceptance
     /// criteria: "merge rewires see earlier in-file writes"). Never
     /// guarded — a rewire touching zero rows is a legitimate outcome.
-    pub rewires: Vec<PlanPredicate>,
+    pub(crate) rewires: Vec<PlanPredicate>,
     /// The `from` entity's soft-delete/tombstone DML (and any other
     /// lifecycle write prepare assumed a target row exists for). Always
     /// guarded — prepare validated `into`/`from` both exist.
-    pub lifecycle: Vec<PlanStatement>,
+    pub(crate) lifecycle: Vec<PlanStatement>,
+}
+
+impl MergePlan {
+    /// The entity retained by the prepared merge.
+    pub fn into_id(&self) -> Uuid {
+        self.into_id
+    }
+
+    /// The entity retired by the prepared merge.
+    pub fn from_id(&self) -> Uuid {
+        self.from_id
+    }
 }
 
 /// Write plan for a `gtd.transition` op (explicit task lifecycle change).
 #[derive(Debug, Clone)]
 pub struct GtdTransitionPlan {
-    pub task_id: Uuid,
+    pub(crate) task_id: Uuid,
     /// Status-column DML to apply inside the atomic unit. Property-only
     /// status mutation — triggers no reindex (ADR-099 D3). The transition
     /// statement carries the guard (prepare validated the current status
@@ -285,26 +412,40 @@ pub struct GtdTransitionPlan {
     /// no-op (`current == target` after `normalize_status`, GAP-5/GAP-6 fix
     /// round) — canonical performs no write in that case either
     /// (`handlers.rs:995-1005`).
-    pub statements: Vec<PlanStatement>,
-    /// Deferred lifecycle audit row (GAP-5): `PostCommitEffect::
-    /// None` for the idempotent no-op case, matching canonical's early
-    /// return before its own `ensure_audit_schema`/`write_audit_record`
-    /// call.
-    pub post_commit: PostCommitEffect,
+    pub(crate) statements: Vec<PlanStatement>,
+    /// Deferred lifecycle audit row assigned by the prepare pass (GAP-5):
+    /// `PostCommitEffect::None` for the idempotent no-op case, matching
+    /// canonical's early return before its own
+    /// `ensure_audit_schema`/`write_audit_record` call.
+    pub(crate) post_commit: PostCommitEffect,
+}
+
+impl GtdTransitionPlan {
+    /// The task targeted by the prepared transition.
+    pub fn task_id(&self) -> Uuid {
+        self.task_id
+    }
 }
 
 /// Write plan for a `gtd.complete` op (task lifecycle terminal transition).
 #[derive(Debug, Clone)]
 pub struct GtdCompletePlan {
-    pub task_id: Uuid,
+    pub(crate) task_id: Uuid,
     /// Status + `completed_at` DML to apply inside the atomic unit, in
     /// order. The status-update statement carries the guard (prepare
     /// validated the task was in a completable state); the `completed_at`
     /// write targets the same already-guarded row and is unguarded.
-    pub statements: Vec<PlanStatement>,
-    /// Deferred lifecycle audit row (GAP-5): mirrors
-    /// `handle_complete`'s best-effort `write_audit_record` call.
-    pub post_commit: PostCommitEffect,
+    pub(crate) statements: Vec<PlanStatement>,
+    /// Deferred lifecycle audit row assigned by the prepare pass (GAP-5):
+    /// mirrors `handle_complete`'s best-effort `write_audit_record` call.
+    pub(crate) post_commit: PostCommitEffect,
+}
+
+impl GtdCompletePlan {
+    /// The task targeted by the prepared completion.
+    pub fn task_id(&self) -> Uuid {
+        self.task_id
+    }
 }
 
 /// Which governance verb (`propose` / `review` / `withdraw`) a
@@ -320,12 +461,24 @@ pub enum GovernanceOp {
 /// event-sourced change-proposal lifecycle, ADR-046).
 #[derive(Debug, Clone)]
 pub struct GovernancePlan {
-    pub op: GovernanceOp,
-    pub proposal_id: Uuid,
+    pub(crate) op: GovernanceOp,
+    pub(crate) proposal_id: Uuid,
     /// Event-log + status DML to apply inside the atomic unit. The
     /// lifecycle-state-check statement carries the guard (prepare validated
     /// the proposal was in a state admitting this transition).
-    pub statements: Vec<PlanStatement>,
+    pub(crate) statements: Vec<PlanStatement>,
+}
+
+impl GovernancePlan {
+    /// The governance operation represented by this plan.
+    pub fn op(&self) -> GovernanceOp {
+        self.op
+    }
+
+    /// The proposal targeted by this plan.
+    pub fn proposal_id(&self) -> Uuid {
+        self.proposal_id
+    }
 }
 
 #[cfg(test)]

--- a/crates/khive-runtime/src/atomic_plan.rs
+++ b/crates/khive-runtime/src/atomic_plan.rs
@@ -425,7 +425,11 @@ impl GtdTransitionPlan {
     /// Callers outside this crate (e.g. the atomic-apply layer wiring
     /// `gtd.transition` into a multi-op unit) cannot construct the struct
     /// literal directly since its fields are crate-private.
-    pub fn new(task_id: Uuid, statements: Vec<PlanStatement>, post_commit: PostCommitEffect) -> Self {
+    pub fn new(
+        task_id: Uuid,
+        statements: Vec<PlanStatement>,
+        post_commit: PostCommitEffect,
+    ) -> Self {
         Self {
             task_id,
             statements,
@@ -469,7 +473,11 @@ impl GtdCompletePlan {
     /// Callers outside this crate (e.g. the atomic-apply layer wiring
     /// `gtd.complete` into a multi-op unit) cannot construct the struct
     /// literal directly since its fields are crate-private.
-    pub fn new(task_id: Uuid, statements: Vec<PlanStatement>, post_commit: PostCommitEffect) -> Self {
+    pub fn new(
+        task_id: Uuid,
+        statements: Vec<PlanStatement>,
+        post_commit: PostCommitEffect,
+    ) -> Self {
         Self {
             task_id,
             statements,

--- a/crates/khive-runtime/src/atomic_plan.rs
+++ b/crates/khive-runtime/src/atomic_plan.rs
@@ -421,9 +421,32 @@ pub struct GtdTransitionPlan {
 }
 
 impl GtdTransitionPlan {
+    /// Build a plan from its already-decided statements and audit effect.
+    /// Callers outside this crate (e.g. the atomic-apply layer wiring
+    /// `gtd.transition` into a multi-op unit) cannot construct the struct
+    /// literal directly since its fields are crate-private.
+    pub fn new(task_id: Uuid, statements: Vec<PlanStatement>, post_commit: PostCommitEffect) -> Self {
+        Self {
+            task_id,
+            statements,
+            post_commit,
+        }
+    }
+
     /// The task targeted by the prepared transition.
     pub fn task_id(&self) -> Uuid {
         self.task_id
+    }
+
+    /// Status-column DML for this transition; empty for the idempotent
+    /// no-op case.
+    pub fn statements(&self) -> &[PlanStatement] {
+        &self.statements
+    }
+
+    /// The deferred lifecycle audit effect assigned by the prepare pass.
+    pub fn post_commit(&self) -> &PostCommitEffect {
+        &self.post_commit
     }
 }
 
@@ -442,9 +465,31 @@ pub struct GtdCompletePlan {
 }
 
 impl GtdCompletePlan {
+    /// Build a plan from its already-decided statements and audit effect.
+    /// Callers outside this crate (e.g. the atomic-apply layer wiring
+    /// `gtd.complete` into a multi-op unit) cannot construct the struct
+    /// literal directly since its fields are crate-private.
+    pub fn new(task_id: Uuid, statements: Vec<PlanStatement>, post_commit: PostCommitEffect) -> Self {
+        Self {
+            task_id,
+            statements,
+            post_commit,
+        }
+    }
+
     /// The task targeted by the prepared completion.
     pub fn task_id(&self) -> Uuid {
         self.task_id
+    }
+
+    /// Status + `completed_at` DML for this completion.
+    pub fn statements(&self) -> &[PlanStatement] {
+        &self.statements
+    }
+
+    /// The deferred lifecycle audit effect assigned by the prepare pass.
+    pub fn post_commit(&self) -> &PostCommitEffect {
+        &self.post_commit
     }
 }
 

--- a/crates/khive-runtime/src/atomic_prepare.rs
+++ b/crates/khive-runtime/src/atomic_prepare.rs
@@ -28,6 +28,7 @@ use crate::atomic_plan::{
     PlanStatement, PostCommitEffect, UpdatePlan,
 };
 use crate::atomic_runner::AtomicOpPlan;
+use crate::atomic_runner::CommittedPostCommitEffects;
 use crate::curation::{entity_fts_document, note_fts_document};
 use crate::error::{RuntimeError, RuntimeResult};
 use crate::operations::{
@@ -1453,9 +1454,9 @@ async fn prepare_merge(
 pub async fn apply_post_commit_effects(
     runtime: &KhiveRuntime,
     token: &NamespaceToken,
-    effects: Vec<PostCommitEffect>,
+    effects: CommittedPostCommitEffects,
 ) -> RuntimeResult<()> {
-    for effect in effects {
+    for effect in effects.into_effects() {
         match effect {
             PostCommitEffect::None => {}
             PostCommitEffect::ReindexEntity { entity_id } => {
@@ -1726,8 +1727,8 @@ mod tests {
             other => panic!("expected Committed, got {other:?}"),
         };
         assert_eq!(
-            post_commit,
-            vec![PostCommitEffect::ReindexNote { note_id }],
+            post_commit.as_slice(),
+            &[PostCommitEffect::ReindexNote { note_id }],
             "content change must schedule exactly one ReindexNote post-commit effect"
         );
 
@@ -1769,7 +1770,7 @@ mod tests {
     /// dependency is needed at this layer, since the hook itself is
     /// generic.
     #[tokio::test]
-    async fn atomic_note_update_and_delete_post_commit_fire_the_note_mutation_hook() {
+    async fn atomic_note_update_and_delete_post_commit_effects_execute_exactly_once() {
         let runtime = scratch_runtime();
         let token = runtime
             .authorize(Namespace::parse("local").expect("ns"))
@@ -1846,8 +1847,8 @@ mod tests {
             other => panic!("expected Committed, got {other:?}"),
         };
         assert_eq!(
-            post_commit,
-            vec![PostCommitEffect::NoteDeleted {
+            post_commit.as_slice(),
+            &[PostCommitEffect::NoteDeleted {
                 note_id: delete_note_id,
                 kind: "observation".to_string(),
             }],
@@ -1857,14 +1858,13 @@ mod tests {
             .await
             .expect("apply post-commit effects (delete)");
 
-        let seen = fired.lock().expect("lock").clone();
-        assert!(
-            seen.contains(&("observation".to_string(), update_note_id)),
-            "the note-mutation hook must fire for the atomic UPDATE path: {seen:?}"
-        );
-        assert!(
-            seen.contains(&("observation".to_string(), delete_note_id)),
-            "the note-mutation hook must fire for the atomic DELETE path: {seen:?}"
+        assert_eq!(
+            *fired.lock().expect("lock"),
+            vec![
+                ("observation".to_string(), update_note_id),
+                ("observation".to_string(), delete_note_id),
+            ],
+            "each committed token must execute its note-mutation effect exactly once"
         );
     }
 
@@ -3368,12 +3368,15 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn atomic_add_entity_link_add_note_plan_commits_entity_edge_note_and_fts_together() {
+    async fn atomic_proposal_vectors_materialize_only_after_successful_commit() {
         let runtime = scratch_runtime();
         runtime.register_embedder(StubProvider);
         let token = runtime
             .authorize(Namespace::parse("local").expect("ns"))
             .expect("authorize");
+        let vec_store = runtime
+            .vectors_for_model(&token, STUB_MODEL)
+            .expect("vec store");
         let entities = runtime.entities(&token).expect("entities store");
         let a = khive_storage::Entity::new("local", "concept", "ProposalPlanLinkA");
         let b = khive_storage::Entity::new("local", "concept", "ProposalPlanLinkB");
@@ -3422,6 +3425,19 @@ mod tests {
             crate::atomic_runner::AtomicRunOutcome::Committed { post_commit } => post_commit,
             other => panic!("expected the whole unit to commit: {other:?}"),
         };
+        assert_eq!(
+            post_commit.as_slice(),
+            &[
+                PostCommitEffect::ReindexEntity { entity_id },
+                PostCommitEffect::ReindexNote { note_id },
+            ],
+            "prepare-derived effects must reach the committed token unchanged"
+        );
+        assert_eq!(
+            vec_store.count().await.expect("count before effects"),
+            0,
+            "commit returns deferred effects without materializing vectors"
+        );
         let entity = runtime
             .entities(&token)
             .expect("entities store")
@@ -3472,9 +3488,6 @@ mod tests {
             .await
             .expect("apply post-commit effects");
 
-        let vec_store = runtime
-            .vectors_for_model(&token, STUB_MODEL)
-            .expect("vec store");
         assert_eq!(
             vec_store.count().await.expect("count after"),
             2,
@@ -3483,11 +3496,15 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn atomic_add_entity_and_add_note_roll_back_on_later_link_failure_leaving_zero_trace() {
+    async fn atomic_proposal_abort_leaves_zero_vector_rows() {
         let runtime = scratch_runtime();
+        runtime.register_embedder(StubProvider);
         let token = runtime
             .authorize(Namespace::parse("local").expect("ns"))
             .expect("authorize");
+        let vec_store = runtime
+            .vectors_for_model(&token, STUB_MODEL)
+            .expect("vec store");
         let entities = runtime.entities(&token).expect("entities store");
         let a = khive_storage::Entity::new("local", "concept", "ProposalPlanRollbackA");
         let x = khive_storage::Entity::new("local", "concept", "ProposalPlanRollbackX");
@@ -3553,6 +3570,15 @@ mod tests {
             }
             other => panic!("expected the whole unit to roll back, got {other:?}"),
         }
+
+        assert_eq!(
+            vec_store
+                .count()
+                .await
+                .expect("vector count after rollback"),
+            0,
+            "a rolled-back atomic apply must not materialize vectors"
+        );
 
         assert!(
             runtime

--- a/crates/khive-runtime/src/atomic_runner.rs
+++ b/crates/khive-runtime/src/atomic_runner.rs
@@ -149,19 +149,62 @@ pub enum AtomicOpFailure {
     },
 }
 
+/// Deferred effects whose owning atomic unit has committed successfully.
+///
+/// Only [`run_atomic_unit`] can construct this token. Consumers may inspect
+/// its effects through [`CommittedPostCommitEffects::as_slice`], while the
+/// phase-3 executor takes the token by value; no public API exposes the owned
+/// effect collection or accepts a prepare-time [`PostCommitEffect`] in its
+/// place.
+///
+/// A committed token is a one-shot capability and cannot be cloned for
+/// replay:
+///
+/// ```compile_fail
+/// use khive_runtime::CommittedPostCommitEffects;
+///
+/// fn duplicate(
+///     committed: &CommittedPostCommitEffects,
+/// ) -> CommittedPostCommitEffects {
+///     committed.clone()
+/// }
+/// ```
+#[derive(Debug, PartialEq, Eq)]
+pub struct CommittedPostCommitEffects {
+    effects: Vec<PostCommitEffect>,
+}
+
+impl CommittedPostCommitEffects {
+    fn new(effects: Vec<PostCommitEffect>) -> Self {
+        Self { effects }
+    }
+
+    /// Inspect the committed effects without discarding their commit
+    /// provenance.
+    pub fn as_slice(&self) -> &[PostCommitEffect] {
+        &self.effects
+    }
+
+    pub(crate) fn into_effects(self) -> Vec<PostCommitEffect> {
+        self.effects
+    }
+}
+
 /// The whole-unit outcome of a completed [`run_atomic_unit`] call — the
 /// commit pass ran to a clean, distinguishable verdict (never returned for
 /// a seam-level failure; see [`AtomicRunnerError`] for that case).
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq)]
 pub enum AtomicRunOutcome {
-    /// Every op's plan applied and the unit committed. Carries every op's
-    /// deferred post-commit effect, in op order. Draining this list
-    /// (running the actual reindex/embedding side effects) is phase 3 of
-    /// ADR-099 D1 and is out of scope for B2 — **the B3 wiring point**: a
-    /// production caller runs these after `run_atomic_unit` returns, outside
-    /// any transaction; a test caller in this file only asserts on the
-    /// list's contents.
-    Committed { post_commit: Vec<PostCommitEffect> },
+    /// Every op's plan applied and the unit committed. Carries an opaque
+    /// [`CommittedPostCommitEffects`] token containing the deferred effects
+    /// in op order. Phase 3 consumes that token through
+    /// [`crate::atomic_prepare::apply_post_commit_effects`] after
+    /// `run_atomic_unit` returns and outside any transaction; callers can
+    /// inspect the effects without converting them back into an executable
+    /// raw collection.
+    Committed {
+        post_commit: CommittedPostCommitEffects,
+    },
     /// The op at `failed_op_index` failed; the whole unit rolled back
     /// (ADR-099 D1: "the whole unit rolls back and the failing op index is
     /// recorded"). No op's writes are present in the database after this
@@ -328,7 +371,9 @@ pub async fn run_atomic_unit(
             let post_commit = *boxed.downcast::<Vec<PostCommitEffect>>().expect(
                 "run_atomic_unit's own closure always returns Box<Vec<PostCommitEffect>> on Ok",
             );
-            Ok(AtomicRunOutcome::Committed { post_commit })
+            Ok(AtomicRunOutcome::Committed {
+                post_commit: CommittedPostCommitEffects::new(post_commit),
+            })
         }
         Err(storage_err) => {
             let recorded = failure_slot
@@ -1068,9 +1113,11 @@ mod tests {
         let outcome = run_atomic_unit(&bridge, plans).await.expect("seam call ok");
         match outcome {
             AtomicRunOutcome::Committed { post_commit } => {
+                fn require_commit_provenance(_: &CommittedPostCommitEffects) {}
+                require_commit_provenance(&post_commit);
                 assert_eq!(
-                    post_commit,
-                    vec![PostCommitEffect::ReindexEntity { entity_id: a }]
+                    post_commit.as_slice(),
+                    &[PostCommitEffect::ReindexEntity { entity_id: a }]
                 );
             }
             other => panic!("expected Committed, got {other:?}"),

--- a/crates/khive-runtime/src/curation.rs
+++ b/crates/khive-runtime/src/curation.rs
@@ -18,7 +18,7 @@ use khive_db::SqliteError;
 use khive_storage::note::Note;
 use khive_storage::types::{EdgeFilter, TextDocument};
 use khive_storage::{EdgeRelation, Entity, SubstrateKind};
-use khive_types::{EdgeEndpointRule, EventKind};
+use khive_types::{Details, EdgeEndpointRule, EventKind, KhiveError};
 use rusqlite::OptionalExtension;
 
 use crate::error::{RuntimeError, RuntimeResult};
@@ -66,6 +66,149 @@ pub enum EntityDedupMergePolicy {
     PreferFrom,
     /// Deep-merge: object properties merge recursively. Scalar conflicts go to `into`.
     Union,
+}
+
+/// Safety-floor guard that refused an explicit entity merge.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum EntityMergeGuard {
+    EntityKind,
+    NameSimilarity,
+    ProjectCompatibility,
+}
+
+impl EntityMergeGuard {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::EntityKind => "entity_kind",
+            Self::NameSimilarity => "name_similarity",
+            Self::ProjectCompatibility => "project_compatibility",
+        }
+    }
+}
+
+/// Validate the non-forced entity-merge safety floor.
+pub fn validate_entity_merge_floor(into: &Entity, from: &Entity) -> Result<(), EntityMergeGuard> {
+    if into.kind != from.kind {
+        return Err(EntityMergeGuard::EntityKind);
+    }
+    if !names_are_similar(&into.name, &from.name) {
+        return Err(EntityMergeGuard::NameSimilarity);
+    }
+    if projects_are_disjoint(into, from) {
+        return Err(EntityMergeGuard::ProjectCompatibility);
+    }
+    Ok(())
+}
+
+/// Convert a safety-floor refusal into the merge verb's structured conflict contract.
+pub fn entity_merge_guard_error(guard: EntityMergeGuard) -> RuntimeError {
+    RuntimeError::Khive(
+        KhiveError::conflict(format!(
+            "entity merge refused by {} guard; use force=true only when the caller accepts responsibility",
+            guard.as_str()
+        ))
+        .with_details(Details::new([
+            ("guard", guard.as_str()),
+            ("override", "force=true"),
+        ])),
+    )
+}
+
+fn names_are_similar(left: &str, right: &str) -> bool {
+    let left = normalize_name(left);
+    let right = normalize_name(right);
+    if left.is_empty() || right.is_empty() {
+        return false;
+    }
+    if left == right {
+        return true;
+    }
+
+    let shorter_len = left.chars().count().min(right.chars().count());
+    if shorter_len >= 3 && (left.starts_with(&right) || right.starts_with(&left)) {
+        return true;
+    }
+
+    let left_trigrams = trigrams(&left);
+    let right_trigrams = trigrams(&right);
+    if left_trigrams.is_empty() || right_trigrams.is_empty() {
+        return false;
+    }
+    let overlap = left_trigrams.intersection(&right_trigrams).count();
+    overlap.saturating_mul(4) >= left_trigrams.len().saturating_add(right_trigrams.len())
+}
+
+fn normalize_name(name: &str) -> String {
+    let mut normalized = String::with_capacity(name.len());
+    let mut pending_space = false;
+    for ch in name.chars().flat_map(char::to_lowercase) {
+        if ch.is_whitespace() {
+            pending_space = !normalized.is_empty();
+        } else {
+            if pending_space {
+                normalized.push(' ');
+                pending_space = false;
+            }
+            normalized.push(ch);
+        }
+    }
+    normalized
+}
+
+fn trigrams(value: &str) -> HashSet<[char; 3]> {
+    let chars: Vec<char> = value.chars().collect();
+    chars
+        .windows(3)
+        .map(|window| [window[0], window[1], window[2]])
+        .collect()
+}
+
+fn projects_are_disjoint(into: &Entity, from: &Entity) -> bool {
+    let Some(into_projects) = into
+        .properties
+        .as_ref()
+        .and_then(|properties| properties.get("projects"))
+        .and_then(Value::as_array)
+    else {
+        return false;
+    };
+    let Some(from_projects) = from
+        .properties
+        .as_ref()
+        .and_then(|properties| properties.get("projects"))
+        .and_then(Value::as_array)
+    else {
+        return false;
+    };
+    if into_projects.is_empty() || from_projects.is_empty() {
+        return false;
+    }
+
+    let (indexed, candidates) = if into_projects.len() <= from_projects.len() {
+        (into_projects, from_projects)
+    } else {
+        (from_projects, into_projects)
+    };
+    let mut indexed_strings = HashSet::new();
+    let mut indexed_values = HashSet::new();
+    for value in indexed {
+        if let Some(value) = value.as_str() {
+            indexed_strings.insert(normalize_project_string(value));
+        } else {
+            indexed_values.insert(value.clone());
+        }
+    }
+    !candidates.iter().any(|candidate| {
+        if let Some(candidate) = candidate.as_str() {
+            indexed_strings.contains(&normalize_project_string(candidate))
+        } else {
+            indexed_values.contains(candidate)
+        }
+    })
+}
+
+fn normalize_project_string(value: &str) -> String {
+    value.trim().to_ascii_lowercase()
 }
 
 /// Strategy for merging note content when two notes are combined.
@@ -172,6 +315,91 @@ impl From<EdgeListFilter> for EdgeFilter {
 // ---------------------------------------------------------------------------
 // Private types
 // ---------------------------------------------------------------------------
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum EntityMergeValidation {
+    LegacyKind,
+    SafetyFloor,
+    Forced,
+}
+
+#[derive(Debug)]
+enum EntityMergeRefusal {
+    LegacyKind {
+        into_id: Uuid,
+        into_kind: String,
+        from_id: Uuid,
+        from_kind: String,
+    },
+    SafetyFloor(EntityMergeGuard),
+}
+
+impl EntityMergeRefusal {
+    fn into_runtime_error(self) -> RuntimeError {
+        match self {
+            Self::LegacyKind {
+                into_id,
+                into_kind,
+                from_id,
+                from_kind,
+            } => RuntimeError::InvalidInput(format!(
+                "cannot merge entities of different kinds: into={into_id} ({into_kind}), \
+                 from={from_id} ({from_kind}); merge requires both entities to share the same kind"
+            )),
+            Self::SafetyFloor(guard) => entity_merge_guard_error(guard),
+        }
+    }
+}
+
+#[derive(Debug)]
+enum MergeEntitySqlError {
+    Sqlite(SqliteError),
+    Refusal(EntityMergeRefusal),
+}
+
+impl std::fmt::Display for MergeEntitySqlError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Sqlite(error) => std::fmt::Display::fmt(error, f),
+            Self::Refusal(_) => f.write_str("entity merge refused by transactional policy"),
+        }
+    }
+}
+
+impl std::error::Error for MergeEntitySqlError {}
+
+impl From<SqliteError> for MergeEntitySqlError {
+    fn from(error: SqliteError) -> Self {
+        Self::Sqlite(error)
+    }
+}
+
+impl From<rusqlite::Error> for MergeEntitySqlError {
+    fn from(error: rusqlite::Error) -> Self {
+        Self::Sqlite(SqliteError::Rusqlite(error))
+    }
+}
+
+fn map_merge_entity_storage_error(error: khive_storage::StorageError) -> RuntimeError {
+    match error {
+        khive_storage::StorageError::Driver {
+            capability,
+            operation,
+            source,
+        } => match source.downcast::<MergeEntitySqlError>() {
+            Ok(error) => match *error {
+                MergeEntitySqlError::Sqlite(error) => RuntimeError::Sqlite(error),
+                MergeEntitySqlError::Refusal(error) => error.into_runtime_error(),
+            },
+            Err(source) => RuntimeError::Storage(khive_storage::StorageError::Driver {
+                capability,
+                operation,
+                source,
+            }),
+        },
+        error => RuntimeError::Storage(error),
+    }
+}
 
 // REASON: EdgeRow fields are populated via rusqlite row mapping. The struct is fully
 // constructed even when not all fields are read back after construction. The complete
@@ -439,6 +667,69 @@ impl KhiveRuntime {
         dry_run: bool,
         reason: Option<String>,
     ) -> RuntimeResult<MergeSummary> {
+        self.merge_entity_with_validation(
+            token,
+            into_id,
+            from_id,
+            strategy,
+            content_strategy,
+            dry_run,
+            reason,
+            EntityMergeValidation::LegacyKind,
+        )
+        .await
+    }
+
+    /// Merge two entities with an explicit override for the entity safety floor.
+    ///
+    /// Non-forced calls enforce entity kind, name similarity, and project compatibility
+    /// against the rows reread inside the merge transaction. Legacy merge methods retain
+    /// their historical same-kind-only policy.
+    /// A non-dry-run override is recorded as `force: true` in the merge event.
+    // REASON: these arguments mirror the merge verb's policy, content strategy,
+    // dry-run, audit-reason, and force fields; a builder would only move that surface.
+    #[allow(clippy::too_many_arguments)]
+    pub async fn merge_entity_with_reason_and_force(
+        &self,
+        token: &NamespaceToken,
+        into_id: Uuid,
+        from_id: Uuid,
+        strategy: EntityDedupMergePolicy,
+        content_strategy: ContentMergeStrategy,
+        dry_run: bool,
+        reason: Option<String>,
+        force: bool,
+    ) -> RuntimeResult<MergeSummary> {
+        let validation = if force {
+            EntityMergeValidation::Forced
+        } else {
+            EntityMergeValidation::SafetyFloor
+        };
+        self.merge_entity_with_validation(
+            token,
+            into_id,
+            from_id,
+            strategy,
+            content_strategy,
+            dry_run,
+            reason,
+            validation,
+        )
+        .await
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    async fn merge_entity_with_validation(
+        &self,
+        token: &NamespaceToken,
+        into_id: Uuid,
+        from_id: Uuid,
+        strategy: EntityDedupMergePolicy,
+        content_strategy: ContentMergeStrategy,
+        dry_run: bool,
+        reason: Option<String>,
+        validation: EntityMergeValidation,
+    ) -> RuntimeResult<MergeSummary> {
         if let Some(reason) = reason.as_deref() {
             crate::secret_gate::check(reason)?;
         }
@@ -446,19 +737,6 @@ impl KhiveRuntime {
             return Err(RuntimeError::InvalidInput(
                 "cannot merge an entity into itself".into(),
             ));
-        }
-        // Enforce the same-kind constraint here too: any direct runtime caller
-        // (CLI, tests, future SDK) would bypass the handler-level guard otherwise.
-        {
-            let into_entity = self.get_entity(token, into_id).await?;
-            let from_entity = self.get_entity(token, from_id).await?;
-            if into_entity.kind != from_entity.kind {
-                return Err(RuntimeError::InvalidInput(format!(
-                    "cannot merge entities of different kinds: into={} ({}), from={} ({}); \
-                     merge requires both entities to share the same kind",
-                    into_id, into_entity.kind, from_id, from_entity.kind
-                )));
-            }
         }
         let ns = token.namespace().as_str().to_owned();
         let fts_table = "fts_entities".to_string();
@@ -501,6 +779,7 @@ impl KhiveRuntime {
                         content_strategy,
                         dry_run,
                         pack_rules,
+                        validation,
                     )
                     .map_err(|e| {
                         khive_storage::StorageError::driver(
@@ -511,11 +790,12 @@ impl KhiveRuntime {
                     })
                 })
                 .await
-                .map_err(RuntimeError::Storage)?
+                .map_err(map_merge_entity_storage_error)?
         } else {
             tokio::task::spawn_blocking(move || {
                 let guard = pool.writer()?;
-                guard.transaction(|conn| {
+                let mut refusal = None;
+                let result = guard.transaction(|conn| {
                     merge_entity_sql(
                         conn,
                         ns,
@@ -527,8 +807,22 @@ impl KhiveRuntime {
                         content_strategy,
                         dry_run,
                         pack_rules,
+                        validation,
                     )
-                })
+                    .map_err(|error| match error {
+                        MergeEntitySqlError::Sqlite(error) => error,
+                        MergeEntitySqlError::Refusal(error) => {
+                            refusal = Some(error);
+                            SqliteError::InvalidData(
+                                "entity merge refused by transactional policy".to_string(),
+                            )
+                        }
+                    })
+                });
+                match refusal {
+                    Some(error) => Err(error.into_runtime_error()),
+                    None => result.map_err(RuntimeError::from),
+                }
             })
             .await
             .map_err(|e| RuntimeError::Internal(e.to_string()))??
@@ -560,6 +854,9 @@ impl KhiveRuntime {
             });
             if let Some(reason) = reason {
                 payload["reason"] = serde_json::Value::String(reason);
+            }
+            if validation == EntityMergeValidation::Forced {
+                payload["force"] = serde_json::Value::Bool(true);
             }
             let event = khive_storage::event::Event::new(
                 updated_entity.namespace.clone(),
@@ -1198,9 +1495,29 @@ fn merge_entity_sql(
     content_strategy: ContentMergeStrategy,
     dry_run: bool,
     pack_rules: Vec<EdgeEndpointRule>,
-) -> Result<(MergeSummary, Entity), SqliteError> {
+    validation: EntityMergeValidation,
+) -> Result<(MergeSummary, Entity), MergeEntitySqlError> {
     let into_entity = read_merge_entity(conn, into_id, &namespace)?;
     let from_entity = read_merge_entity(conn, from_id, &namespace)?;
+
+    match validation {
+        EntityMergeValidation::LegacyKind if into_entity.kind != from_entity.kind => {
+            return Err(MergeEntitySqlError::Refusal(
+                EntityMergeRefusal::LegacyKind {
+                    into_id,
+                    into_kind: into_entity.kind,
+                    from_id,
+                    from_kind: from_entity.kind,
+                },
+            ));
+        }
+        EntityMergeValidation::SafetyFloor => {
+            validate_entity_merge_floor(&into_entity, &from_entity).map_err(|guard| {
+                MergeEntitySqlError::Refusal(EntityMergeRefusal::SafetyFloor(guard))
+            })?;
+        }
+        EntityMergeValidation::LegacyKind | EntityMergeValidation::Forced => {}
+    }
 
     // --- Collect edges incident to from_id ---
     let parse_id =
@@ -4973,6 +5290,81 @@ mod tests {
 
         let c2_after = rt.entities(&tok).unwrap().get_entity(c2.id).await.unwrap();
         assert!(c2_after.is_none(), "from_entity must be tombstoned");
+    }
+
+    #[tokio::test]
+    async fn merge_entity_explicit_policy_rereads_names_before_commit() {
+        let rt = rt();
+        let tok = NamespaceToken::local();
+
+        let into = rt
+            .create_entity(
+                &tok,
+                "concept",
+                None,
+                "Transactional Guard",
+                None,
+                None,
+                vec![],
+            )
+            .await
+            .unwrap();
+        let from = rt
+            .create_entity(
+                &tok,
+                "concept",
+                None,
+                "Transactional Guard",
+                None,
+                None,
+                vec![],
+            )
+            .await
+            .unwrap();
+
+        validate_entity_merge_floor(&into, &from)
+            .expect("the handler's fast-path validation would initially pass");
+        let renamed_into = rt
+            .update_entity(
+                &tok,
+                into.id,
+                EntityPatch {
+                    name: Some("Unrelated Renamed Target".to_string()),
+                    ..Default::default()
+                },
+            )
+            .await
+            .unwrap();
+        let expected = validate_entity_merge_floor(&renamed_into, &from)
+            .expect_err("the renamed transactional state must violate the name guard");
+        let RuntimeError::Khive(expected) = entity_merge_guard_error(expected) else {
+            unreachable!("merge guard errors are structured Khive errors")
+        };
+
+        let err = rt
+            .merge_entity_with_reason_and_force(
+                &tok,
+                into.id,
+                from.id,
+                EntityDedupMergePolicy::PreferInto,
+                ContentMergeStrategy::Append,
+                false,
+                None,
+                false,
+            )
+            .await
+            .expect_err("the explicit non-forced path must validate its transactional reread");
+        let RuntimeError::Khive(err) = err else {
+            panic!("expected a structured merge-guard conflict, got {err:?}");
+        };
+        assert_eq!(err.kind(), expected.kind());
+        assert_eq!(err.message(), expected.message());
+        assert_eq!(err.code(), expected.code());
+        assert_eq!(err.details(), expected.details());
+        assert!(
+            rt.get_entity(&tok, from.id).await.is_ok(),
+            "a refused merge must leave the source entity live"
+        );
     }
 
     // Cross-namespace merge_note must be denied on either ID.

--- a/crates/khive-runtime/src/daemon.rs
+++ b/crates/khive-runtime/src/daemon.rs
@@ -29,7 +29,7 @@ use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::{UnixListener, UnixStream};
 
 #[cfg(unix)]
-use khive_db::{run_checkpoint_task, CheckpointConfig, ConnectionPool};
+use khive_db::{run_checkpoint_task, CheckpointConfig, CheckpointLifecycleOwner, ConnectionPool};
 
 #[cfg(unix)]
 use crate::pack::RequestIdentity;
@@ -719,6 +719,46 @@ pub trait DaemonDispatch: Clone + Send + Sync + 'static {
     fn event_store_for_checkpoint(&self) -> Option<Arc<dyn khive_storage::EventStore>> {
         None
     }
+}
+
+#[cfg(unix)]
+struct CheckpointTaskSpec {
+    pool: Arc<ConnectionPool>,
+    lifecycle_owner: Option<CheckpointLifecycleOwner>,
+    is_main: bool,
+}
+
+/// Build checkpoint-task fan-out and designate one lifecycle owner.
+///
+/// The main checkpoint task owns lifecycle emission when it exists. If the
+/// main backend is in-memory and therefore has no checkpoint task, the first
+/// file-backed secondary owns emission instead. All remaining tasks are
+/// explicit non-owners.
+#[cfg(unix)]
+fn checkpoint_task_specs(
+    main_pool: Option<Arc<ConnectionPool>>,
+    secondary_pools: Vec<Arc<ConnectionPool>>,
+    event_store: Option<Arc<dyn khive_storage::EventStore>>,
+    namespace: String,
+) -> Vec<CheckpointTaskSpec> {
+    let mut tasks = Vec::with_capacity(usize::from(main_pool.is_some()) + secondary_pools.len());
+    if let Some(pool) = main_pool {
+        tasks.push(CheckpointTaskSpec {
+            pool,
+            lifecycle_owner: None,
+            is_main: true,
+        });
+    }
+    tasks.extend(secondary_pools.into_iter().map(|pool| CheckpointTaskSpec {
+        pool,
+        lifecycle_owner: None,
+        is_main: false,
+    }));
+
+    if let (Some(task), Some(event_store)) = (tasks.first_mut(), event_store) {
+        task.lifecycle_owner = Some(CheckpointLifecycleOwner::new(event_store, namespace));
+    }
+    tasks
 }
 
 // ── tracked background tasks ─────────────────────────────────────────────────
@@ -1438,26 +1478,22 @@ pub async fn run_daemon_with_boot_guard<D: DaemonDispatch>(
     // `secondary_pools_for_checkpoint` returns — sharing this one shutdown
     // channel (the sender broadcasts to every receiver clone), so the single
     // send below stops every spawned task before `drain()`.
-    let mut checkpoint_pools: Vec<(Arc<ConnectionPool>, bool)> = Vec::new();
-    if let Some(pool) = dispatcher.pool_for_checkpoint() {
-        checkpoint_pools.push((pool, true));
-    }
-    for pool in dispatcher.secondary_pools_for_checkpoint() {
-        checkpoint_pools.push((pool, false));
-    }
-    if !checkpoint_pools.is_empty() {
+    let checkpoint_tasks = checkpoint_task_specs(
+        dispatcher.pool_for_checkpoint(),
+        dispatcher.secondary_pools_for_checkpoint(),
+        dispatcher.event_store_for_checkpoint(),
+        dispatcher.namespace().to_string(),
+    );
+    if !checkpoint_tasks.is_empty() {
         let cfg = CheckpointConfig::from_env();
-        let event_store = dispatcher.event_store_for_checkpoint();
-        let namespace = dispatcher.namespace().to_string();
-        let checkpoint_task_count = checkpoint_pools.len();
-        for (pool, is_main) in checkpoint_pools {
+        let checkpoint_task_count = checkpoint_tasks.len();
+        for task in checkpoint_tasks {
             track_background_task(run_checkpoint_task(
-                pool,
+                task.pool,
                 cfg.clone(),
-                event_store.clone(),
-                namespace.clone(),
+                task.lifecycle_owner,
                 checkpoint_shutdown_rx.clone(),
-                is_main,
+                task.is_main,
             ));
         }
         tracing::info!(checkpoint_task_count, "WAL checkpoint task(s) started");
@@ -1815,6 +1851,83 @@ mod khive_root_tests {
 mod tests {
     use super::*;
     use serial_test::serial;
+
+    #[tokio::test]
+    #[serial(checkpoint_skip_metrics)]
+    async fn secondary_only_checkpoint_topology_emits_lifecycle_outcome() {
+        let main_backend = khive_db::StorageBackend::memory().expect("in-memory main backend");
+        let event_store = main_backend.events().expect("main event store");
+        let secondary_dir = tempfile::tempdir().expect("secondary tempdir");
+        let secondary_backend =
+            khive_db::StorageBackend::sqlite(secondary_dir.path().join("secondary.db"))
+                .expect("file-backed secondary backend");
+
+        let mut tasks = checkpoint_task_specs(
+            None,
+            vec![secondary_backend.pool_arc()],
+            Some(Arc::clone(&event_store)),
+            "local".to_string(),
+        );
+        assert_eq!(tasks.len(), 1);
+        let task = tasks.pop().expect("one secondary checkpoint task");
+        assert!(!task.is_main, "the only checkpoint task must be secondary");
+        assert!(
+            task.lifecycle_owner.is_some(),
+            "the secondary task must own lifecycle emission when no main task exists"
+        );
+
+        let config = CheckpointConfig {
+            interval: std::time::Duration::from_millis(10),
+            warn_pages: 0,
+            ..CheckpointConfig::default()
+        };
+        let (shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(());
+        let handle = tokio::spawn(run_checkpoint_task(
+            task.pool,
+            config,
+            task.lifecycle_owner,
+            shutdown_rx,
+            task.is_main,
+        ));
+
+        tokio::time::sleep(std::time::Duration::from_millis(60)).await;
+        shutdown_tx.send(()).expect("send checkpoint shutdown");
+        tokio::time::timeout(std::time::Duration::from_secs(1), handle)
+            .await
+            .expect("checkpoint task should exit within 1s")
+            .expect("checkpoint task panicked");
+
+        let events = event_store
+            .query_events(
+                khive_storage::EventFilter::default(),
+                khive_storage::PageRequest {
+                    limit: 100,
+                    offset: 0,
+                },
+            )
+            .await
+            .expect("query lifecycle events");
+        assert!(
+            !events.items.is_empty()
+                && events
+                    .items
+                    .iter()
+                    .all(|event| event.kind == khive_types::EventKind::CheckpointOutcomeRecorded),
+            "the designated secondary owner must emit CheckpointOutcomeRecorded"
+        );
+
+        let file_main_dir = tempfile::tempdir().expect("file-backed main tempdir");
+        let file_main = khive_db::StorageBackend::sqlite(file_main_dir.path().join("main.db"))
+            .expect("file-backed main backend");
+        let tasks = checkpoint_task_specs(
+            Some(file_main.pool_arc()),
+            vec![secondary_backend.pool_arc()],
+            Some(event_store),
+            "local".to_string(),
+        );
+        assert!(tasks[0].is_main && tasks[0].lifecycle_owner.is_some());
+        assert!(!tasks[1].is_main && tasks[1].lifecycle_owner.is_none());
+    }
 
     // Focused regression tests for the unsafe process probe (SAFETY: signal 0
     // is an existence check with no side effects; see is_process_running).

--- a/crates/khive-runtime/src/embedder_registry.rs
+++ b/crates/khive-runtime/src/embedder_registry.rs
@@ -5,15 +5,251 @@
 //! during runtime construction and require no opt-in.
 
 use std::collections::HashMap;
-use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::mpsc::{self, Receiver, SyncSender, TrySendError};
+use std::sync::{Arc, OnceLock};
 
 use async_trait::async_trait;
 use lattice_embed::{
     CachedEmbeddingService, EmbeddingModel, EmbeddingService, NativeEmbeddingService,
+    DEFAULT_MAX_BATCH_SIZE, MAX_TEXT_CHARS,
 };
 use tokio::sync::OnceCell;
 
 use crate::error::{RuntimeError, RuntimeResult};
+
+#[derive(Clone, Copy)]
+enum EmbeddingCall {
+    Generic,
+    Query,
+    Passage,
+}
+
+const EMBEDDING_QUEUE_CAPACITY: usize = 32;
+const EMBEDDING_MAX_JOB_BYTES: usize = DEFAULT_MAX_BATCH_SIZE * MAX_TEXT_CHARS;
+// 32 queue slots × the normal 128-text batch × 32 KiB/text = 128 MiB in flight.
+const EMBEDDING_QUEUE_BYTE_BUDGET: usize = EMBEDDING_QUEUE_CAPACITY * 128 * MAX_TEXT_CHARS;
+
+struct InFlightBytes {
+    counter: Arc<AtomicUsize>,
+    bytes: usize,
+}
+
+impl InFlightBytes {
+    fn reserve(
+        counter: Arc<AtomicUsize>,
+        byte_budget: usize,
+        bytes: usize,
+    ) -> lattice_embed::Result<Self> {
+        let mut current = counter.load(Ordering::Acquire);
+        loop {
+            let Some(next) = current.checked_add(bytes) else {
+                return Err(lattice_embed::EmbedError::Internal(format!(
+                    "embedding worker byte budget exceeded: in-flight byte count overflowed the {byte_budget}-byte budget"
+                )));
+            };
+            if next > byte_budget {
+                return Err(lattice_embed::EmbedError::Internal(format!(
+                    "embedding worker byte budget exceeded: {current} in flight + {bytes} job bytes > {byte_budget}"
+                )));
+            }
+            match counter.compare_exchange_weak(current, next, Ordering::AcqRel, Ordering::Acquire)
+            {
+                Ok(_) => return Ok(Self { counter, bytes }),
+                Err(observed) => current = observed,
+            }
+        }
+    }
+}
+
+impl Drop for InFlightBytes {
+    fn drop(&mut self) {
+        let previous = self.counter.fetch_sub(self.bytes, Ordering::AcqRel);
+        debug_assert!(previous >= self.bytes, "embedding byte counter underflow");
+    }
+}
+
+struct EmbeddingJob {
+    texts: Vec<String>,
+    model: EmbeddingModel,
+    call: EmbeddingCall,
+    reply: tokio::sync::oneshot::Sender<lattice_embed::Result<Vec<Vec<f32>>>>,
+    _in_flight: InFlightBytes,
+}
+
+/// Bounds non-cancellable native inference to one worker and a fixed queue.
+/// Callers can detach safely because closed queued jobs are skipped before inference.
+pub(crate) struct BlockingEmbeddingService<S> {
+    inner: Arc<S>,
+    worker: OnceLock<Result<SyncSender<EmbeddingJob>, String>>,
+    in_flight_bytes: Arc<AtomicUsize>,
+    byte_budget: usize,
+}
+
+impl<S> BlockingEmbeddingService<S> {
+    pub(crate) fn new(inner: Arc<S>) -> Self {
+        Self {
+            inner,
+            worker: OnceLock::new(),
+            in_flight_bytes: Arc::new(AtomicUsize::new(0)),
+            byte_budget: EMBEDDING_QUEUE_BYTE_BUDGET,
+        }
+    }
+
+    #[cfg(test)]
+    fn with_byte_budget(inner: Arc<S>, byte_budget: usize) -> Self {
+        Self {
+            inner,
+            worker: OnceLock::new(),
+            in_flight_bytes: Arc::new(AtomicUsize::new(0)),
+            byte_budget,
+        }
+    }
+}
+
+impl<S: EmbeddingService + 'static> BlockingEmbeddingService<S> {
+    fn input_bytes(texts: &[String]) -> lattice_embed::Result<usize> {
+        if texts.is_empty() {
+            return Err(lattice_embed::EmbedError::InvalidInput(
+                "no texts provided".to_owned(),
+            ));
+        }
+        let input_bytes = texts.iter().try_fold(0usize, |total, text| {
+            total.checked_add(text.len()).ok_or_else(|| {
+                lattice_embed::EmbedError::InvalidInput(format!(
+                    "embedding job input exceeds the {EMBEDDING_MAX_JOB_BYTES}-byte maximum"
+                ))
+            })
+        })?;
+        if input_bytes > EMBEDDING_MAX_JOB_BYTES {
+            return Err(lattice_embed::EmbedError::InvalidInput(format!(
+                "embedding job input is {input_bytes} bytes; maximum is {EMBEDDING_MAX_JOB_BYTES} bytes"
+            )));
+        }
+        if texts.len() > DEFAULT_MAX_BATCH_SIZE {
+            return Err(lattice_embed::EmbedError::InvalidInput(format!(
+                "batch size {} exceeds maximum {DEFAULT_MAX_BATCH_SIZE}",
+                texts.len()
+            )));
+        }
+        if let Some(text) = texts.iter().find(|text| text.len() > MAX_TEXT_CHARS) {
+            return Err(lattice_embed::EmbedError::TextTooLong {
+                length: text.len(),
+                max: MAX_TEXT_CHARS,
+            });
+        }
+        Ok(input_bytes)
+    }
+
+    fn worker(&self) -> lattice_embed::Result<&SyncSender<EmbeddingJob>> {
+        self.worker
+            .get_or_init(|| {
+                let (sender, receiver) = mpsc::sync_channel(EMBEDDING_QUEUE_CAPACITY);
+                let inner = Arc::clone(&self.inner);
+                let runtime = tokio::runtime::Handle::current();
+                std::thread::Builder::new()
+                    .name("khive-embedding".to_owned())
+                    .spawn(move || Self::run_worker(inner, runtime, receiver))
+                    .map(|_| sender)
+                    .map_err(|error| error.to_string())
+            })
+            .as_ref()
+            .map_err(|error| lattice_embed::EmbedError::Internal(error.clone()))
+    }
+
+    fn run_worker(
+        inner: Arc<S>,
+        runtime: tokio::runtime::Handle,
+        receiver: Receiver<EmbeddingJob>,
+    ) {
+        while let Ok(job) = receiver.recv() {
+            if job.reply.is_closed() {
+                continue;
+            }
+            let result = runtime.block_on(async {
+                match job.call {
+                    EmbeddingCall::Generic => inner.embed(&job.texts, job.model).await,
+                    EmbeddingCall::Query => inner.embed_query(&job.texts, job.model).await,
+                    EmbeddingCall::Passage => inner.embed_passage(&job.texts, job.model).await,
+                }
+            });
+            let _ = job.reply.send(result);
+        }
+    }
+
+    async fn run(
+        &self,
+        texts: &[String],
+        model: EmbeddingModel,
+        call: EmbeddingCall,
+    ) -> lattice_embed::Result<Vec<Vec<f32>>> {
+        let input_bytes = Self::input_bytes(texts)?;
+        let sender = self.worker()?;
+        let in_flight = InFlightBytes::reserve(
+            Arc::clone(&self.in_flight_bytes),
+            self.byte_budget,
+            input_bytes,
+        )?;
+        let (reply, receiver) = tokio::sync::oneshot::channel();
+        let job = EmbeddingJob {
+            texts: texts.to_vec(),
+            model,
+            call,
+            reply,
+            _in_flight: in_flight,
+        };
+        sender.try_send(job).map_err(|error| match error {
+            TrySendError::Full(_) => {
+                lattice_embed::EmbedError::Internal("embedding worker queue is full".to_owned())
+            }
+            TrySendError::Disconnected(_) => lattice_embed::EmbedError::Internal(
+                "embedding worker channel is disconnected".to_owned(),
+            ),
+        })?;
+        receiver
+            .await
+            .map_err(|error| lattice_embed::EmbedError::Internal(error.to_string()))?
+    }
+}
+
+#[async_trait]
+impl<S: EmbeddingService + 'static> EmbeddingService for BlockingEmbeddingService<S> {
+    async fn embed(
+        &self,
+        texts: &[String],
+        model: EmbeddingModel,
+    ) -> lattice_embed::Result<Vec<Vec<f32>>> {
+        self.run(texts, model, EmbeddingCall::Generic).await
+    }
+
+    async fn embed_query(
+        &self,
+        texts: &[String],
+        model: EmbeddingModel,
+    ) -> lattice_embed::Result<Vec<Vec<f32>>> {
+        self.run(texts, model, EmbeddingCall::Query).await
+    }
+
+    async fn embed_passage(
+        &self,
+        texts: &[String],
+        model: EmbeddingModel,
+    ) -> lattice_embed::Result<Vec<Vec<f32>>> {
+        self.run(texts, model, EmbeddingCall::Passage).await
+    }
+
+    fn model_config(&self, model: EmbeddingModel) -> lattice_embed::ModelConfig {
+        self.inner.model_config(model)
+    }
+
+    fn supports_model(&self, model: EmbeddingModel) -> bool {
+        self.inner.supports_model(model)
+    }
+
+    fn name(&self) -> &'static str {
+        self.inner.name()
+    }
+}
 
 /// A source that can produce an [`EmbeddingService`] by name.
 ///
@@ -205,8 +441,8 @@ impl EmbedderProvider for LatticeEmbedderProvider {
 
     async fn build(&self) -> RuntimeResult<Arc<dyn EmbeddingService>> {
         let native = Arc::new(NativeEmbeddingService::with_model(self.model));
-        let cached = CachedEmbeddingService::with_default_cache(native);
-        Ok(Arc::new(cached) as Arc<dyn EmbeddingService>)
+        let cached = Arc::new(CachedEmbeddingService::with_default_cache(native));
+        Ok(Arc::new(BlockingEmbeddingService::new(cached)) as Arc<dyn EmbeddingService>)
     }
 }
 
@@ -215,7 +451,10 @@ impl EmbedderProvider for LatticeEmbedderProvider {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::collections::HashSet;
+    use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+    use std::sync::{Condvar, Mutex};
+    use std::time::Duration;
 
     struct ConstVecProvider {
         name: String,
@@ -273,6 +512,400 @@ mod tests {
             self.build_calls.fetch_add(1, Ordering::SeqCst);
             Ok(Arc::new(ConstVecService { dims: self.dims }))
         }
+    }
+
+    struct FirstLoadBlockingService {
+        loaded: AtomicBool,
+    }
+
+    #[async_trait]
+    impl EmbeddingService for FirstLoadBlockingService {
+        async fn embed(
+            &self,
+            texts: &[String],
+            _model: EmbeddingModel,
+        ) -> lattice_embed::Result<Vec<Vec<f32>>> {
+            if !self.loaded.swap(true, Ordering::SeqCst) {
+                tokio::task::spawn_blocking(|| {})
+                    .await
+                    .map_err(|error| lattice_embed::EmbedError::Internal(error.to_string()))?;
+            }
+            Ok(texts.iter().map(|_| vec![1.0]).collect())
+        }
+
+        fn supports_model(&self, _model: EmbeddingModel) -> bool {
+            true
+        }
+
+        fn name(&self) -> &'static str {
+            "first-load-blocking-service"
+        }
+    }
+
+    struct BlockingTestService {
+        calls: Mutex<Vec<String>>,
+        entered: AtomicUsize,
+        release: (Mutex<bool>, Condvar),
+        thread_ids: Mutex<HashSet<std::thread::ThreadId>>,
+    }
+
+    impl BlockingTestService {
+        fn new() -> Self {
+            Self {
+                calls: Mutex::new(Vec::new()),
+                entered: AtomicUsize::new(0),
+                release: (Mutex::new(false), Condvar::new()),
+                thread_ids: Mutex::new(HashSet::new()),
+            }
+        }
+
+        fn release(&self) {
+            *self
+                .release
+                .0
+                .lock()
+                .expect("release lock must not be poisoned") = true;
+            self.release.1.notify_all();
+        }
+    }
+
+    #[async_trait]
+    impl EmbeddingService for BlockingTestService {
+        async fn embed(
+            &self,
+            texts: &[String],
+            _model: EmbeddingModel,
+        ) -> lattice_embed::Result<Vec<Vec<f32>>> {
+            let text = texts.first().cloned().unwrap_or_default();
+            self.thread_ids
+                .lock()
+                .expect("thread id lock must not be poisoned")
+                .insert(std::thread::current().id());
+            self.calls
+                .lock()
+                .expect("call lock must not be poisoned")
+                .push(text.clone());
+            self.entered.fetch_add(1, Ordering::Release);
+
+            if text != "later" {
+                let (released, wake) = &self.release;
+                let guard = released.lock().expect("release lock must not be poisoned");
+                let _guard = wake
+                    .wait_while(guard, |released| !*released)
+                    .expect("release lock must not be poisoned");
+            }
+
+            Ok(texts.iter().map(|_| vec![1.0]).collect())
+        }
+
+        fn supports_model(&self, _model: EmbeddingModel) -> bool {
+            true
+        }
+
+        fn name(&self) -> &'static str {
+            "blocking-test-service"
+        }
+    }
+
+    #[test]
+    fn blocking_adapter_first_use_completes_with_single_blocking_thread() {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_time()
+            .max_blocking_threads(1)
+            .build()
+            .expect("current-thread runtime must build");
+        let service = BlockingEmbeddingService::new(Arc::new(FirstLoadBlockingService {
+            loaded: AtomicBool::new(false),
+        }));
+
+        let result = runtime.block_on(async {
+            tokio::time::timeout(
+                Duration::from_secs(5),
+                service.embed(&["first use".to_owned()], EmbeddingModel::default()),
+            )
+            .await
+        });
+        runtime.shutdown_timeout(Duration::from_secs(1));
+
+        let embeddings = result
+            .expect("first-use embedding must not exhaust the blocking pool")
+            .expect("first-use embedding must succeed");
+        assert_eq!(embeddings, vec![vec![1.0]]);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn blocking_adapter_uses_one_worker_for_concurrent_calls() {
+        const CALL_COUNT: usize = 32;
+        let inner = Arc::new(BlockingTestService::new());
+        let service = Arc::new(BlockingEmbeddingService::new(Arc::clone(&inner)));
+        let mut calls = Vec::with_capacity(CALL_COUNT);
+
+        for index in 0..CALL_COUNT {
+            let service = Arc::clone(&service);
+            calls.push(tokio::spawn(async move {
+                service
+                    .embed(&[format!("request-{index}")], EmbeddingModel::default())
+                    .await
+            }));
+        }
+
+        let _ = tokio::time::timeout(Duration::from_millis(250), async {
+            while inner.entered.load(Ordering::Acquire) < 2 {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await;
+        inner.release();
+
+        for call in calls {
+            call.await
+                .expect("embedding task must not panic")
+                .expect("embedding call must succeed");
+        }
+        assert_eq!(
+            inner
+                .thread_ids
+                .lock()
+                .expect("thread id lock must not be poisoned")
+                .len(),
+            1,
+            "concurrent calls must share one native worker thread"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn blocking_adapter_skips_timed_out_call_and_serves_later_call() {
+        let inner = Arc::new(BlockingTestService::new());
+        let service = Arc::new(BlockingEmbeddingService::new(Arc::clone(&inner)));
+
+        let first_service = Arc::clone(&service);
+        let first = tokio::spawn(async move {
+            first_service
+                .embed(&["first".to_owned()], EmbeddingModel::default())
+                .await
+        });
+        tokio::time::timeout(Duration::from_secs(1), async {
+            while inner.entered.load(Ordering::Acquire) == 0 {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("first embedding call must enter the native service");
+
+        let abandoned = tokio::time::timeout(
+            Duration::from_millis(50),
+            service.embed(&["abandoned".to_owned()], EmbeddingModel::default()),
+        )
+        .await;
+        let later_service = Arc::clone(&service);
+        let later = tokio::spawn(async move {
+            later_service
+                .embed(&["later".to_owned()], EmbeddingModel::default())
+                .await
+        });
+        inner.release();
+
+        first
+            .await
+            .expect("first embedding task must not panic")
+            .expect("first embedding call must succeed");
+        let later_result = tokio::time::timeout(Duration::from_secs(1), later)
+            .await
+            .expect("later embedding call must be served")
+            .expect("later embedding task must not panic")
+            .expect("later embedding call must succeed");
+
+        assert!(abandoned.is_err(), "queued embedding call must time out");
+        assert_eq!(later_result, vec![vec![1.0]]);
+        assert_eq!(
+            *inner.calls.lock().expect("call lock must not be poisoned"),
+            vec!["first".to_owned(), "later".to_owned()],
+            "the worker must skip a queued call whose receiver is closed"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn blocking_adapter_rejects_call_when_queue_is_full() {
+        let inner = Arc::new(BlockingTestService::new());
+        let service = Arc::new(BlockingEmbeddingService::new(Arc::clone(&inner)));
+        let first_service = Arc::clone(&service);
+        let first = tokio::spawn(async move {
+            first_service
+                .embed(&["first".to_owned()], EmbeddingModel::default())
+                .await
+        });
+        tokio::time::timeout(Duration::from_secs(1), async {
+            while inner.entered.load(Ordering::Acquire) == 0 {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("first embedding call must occupy the native worker");
+
+        let sender = service.worker().expect("worker must be running");
+        let mut queued_receivers = Vec::with_capacity(EMBEDDING_QUEUE_CAPACITY);
+        for index in 0..EMBEDDING_QUEUE_CAPACITY {
+            let (reply, receiver) = tokio::sync::oneshot::channel();
+            let queued = sender.try_send(EmbeddingJob {
+                texts: vec![format!("queued-{index}")],
+                model: EmbeddingModel::default(),
+                call: EmbeddingCall::Generic,
+                reply,
+                _in_flight: InFlightBytes::reserve(
+                    Arc::clone(&service.in_flight_bytes),
+                    service.byte_budget,
+                    0,
+                )
+                .expect("zero-byte test job must fit the byte budget"),
+            });
+            assert!(queued.is_ok(), "bounded queue must accept its capacity");
+            queued_receivers.push(receiver);
+        }
+
+        let overflow = tokio::time::timeout(
+            Duration::from_millis(100),
+            service.embed(&["overflow".to_owned()], EmbeddingModel::default()),
+        )
+        .await
+        .expect("a full embedding queue must fail without waiting")
+        .expect_err("a full embedding queue must return an embedding error");
+
+        drop(queued_receivers);
+        inner.release();
+        first
+            .await
+            .expect("first embedding task must not panic")
+            .expect("first embedding call must succeed");
+        assert!(
+            overflow.to_string().contains("queue is full"),
+            "queue saturation must use the embedding failure path: {overflow}"
+        );
+    }
+
+    #[tokio::test]
+    async fn blocking_adapter_rejects_oversized_job_before_enqueue() {
+        let service = BlockingEmbeddingService::new(Arc::new(ConstVecService { dims: 1 }));
+        let oversized =
+            "x".repeat(lattice_embed::DEFAULT_MAX_BATCH_SIZE * lattice_embed::MAX_TEXT_CHARS + 1);
+
+        let error = service
+            .embed(&[oversized], EmbeddingModel::default())
+            .await
+            .expect_err("an oversized embedding job must be rejected");
+
+        assert!(
+            error.to_string().contains("embedding job input"),
+            "oversized admission must use the embedding error path: {error}"
+        );
+        assert!(
+            service.worker.get().is_none(),
+            "oversized work must be rejected before the worker queue is initialized"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn blocking_adapter_byte_budget_rejects_excess_and_queued_jobs_complete() {
+        const ADMITTED_JOBS: usize = 4;
+        let byte_budget = ADMITTED_JOBS * EMBEDDING_MAX_JOB_BYTES;
+        let inner = Arc::new(BlockingTestService::new());
+        let service = Arc::new(BlockingEmbeddingService::with_byte_budget(
+            Arc::clone(&inner),
+            byte_budget,
+        ));
+        let max_texts = Arc::new(vec![
+            "x".repeat(lattice_embed::MAX_TEXT_CHARS);
+            lattice_embed::DEFAULT_MAX_BATCH_SIZE
+        ]);
+        let mut admitted = Vec::with_capacity(ADMITTED_JOBS);
+
+        for _ in 0..ADMITTED_JOBS {
+            let service = Arc::clone(&service);
+            let texts = Arc::clone(&max_texts);
+            admitted.push(tokio::spawn(async move {
+                service.embed(&texts, EmbeddingModel::default()).await
+            }));
+        }
+        tokio::time::timeout(Duration::from_secs(1), async {
+            while service.in_flight_bytes.load(Ordering::Acquire) < byte_budget {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("all jobs within the byte budget must be admitted");
+
+        let overflow = tokio::time::timeout(
+            Duration::from_millis(100),
+            service.embed(&max_texts, EmbeddingModel::default()),
+        )
+        .await
+        .expect("a byte-budget overflow must fail without waiting")
+        .expect_err("a byte-budget overflow must return an embedding error");
+
+        inner.release();
+        for call in admitted {
+            call.await
+                .expect("admitted embedding task must not panic")
+                .expect("admitted embedding job must complete");
+        }
+        assert!(
+            overflow.to_string().contains("byte budget"),
+            "byte saturation must use the embedding failure path: {overflow}"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn blocking_adapter_releases_byte_budget_after_completion_and_skipped_job() {
+        let byte_budget = "first".len() + "abandoned".len();
+        let inner = Arc::new(BlockingTestService::new());
+        let service = Arc::new(BlockingEmbeddingService::with_byte_budget(
+            Arc::clone(&inner),
+            byte_budget,
+        ));
+
+        let first_service = Arc::clone(&service);
+        let first = tokio::spawn(async move {
+            first_service
+                .embed(&["first".to_owned()], EmbeddingModel::default())
+                .await
+        });
+        tokio::time::timeout(Duration::from_secs(1), async {
+            while inner.entered.load(Ordering::Acquire) == 0 {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("first embedding call must occupy the native worker");
+
+        let abandoned = tokio::time::timeout(
+            Duration::from_millis(50),
+            service.embed(&["abandoned".to_owned()], EmbeddingModel::default()),
+        )
+        .await;
+        assert!(abandoned.is_err(), "queued embedding call must time out");
+        assert_eq!(
+            service.in_flight_bytes.load(Ordering::Acquire),
+            byte_budget,
+            "running and queued jobs must both consume the byte budget"
+        );
+
+        inner.release();
+        first
+            .await
+            .expect("first embedding task must not panic")
+            .expect("first embedding call must succeed");
+        tokio::time::timeout(Duration::from_secs(1), async {
+            while service.in_flight_bytes.load(Ordering::Acquire) != 0 {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("completed and skipped jobs must release their byte reservations");
+
+        let later = service
+            .embed(&["later".to_owned()], EmbeddingModel::default())
+            .await
+            .expect("a later call must succeed after the byte budget is released");
+        assert_eq!(later, vec![vec![1.0]]);
     }
 
     #[test]

--- a/crates/khive-runtime/src/lib.rs
+++ b/crates/khive-runtime/src/lib.rs
@@ -45,8 +45,9 @@ pub use atomic_runner::{
 pub use blob::resolve_blob_store;
 pub use cost_unit::{base_resource_payload, cost_unit_for_dispatch, resource_payload};
 pub use curation::{
-    entity_fts_document, note_fts_document, ContentMergeStrategy, EdgeListFilter, EdgePatch,
-    EntityDedupMergePolicy, EntityPatch, MergeSummary, NotePatch,
+    entity_fts_document, entity_merge_guard_error, note_fts_document, validate_entity_merge_floor,
+    ContentMergeStrategy, EdgeListFilter, EdgePatch, EntityDedupMergePolicy, EntityMergeGuard,
+    EntityPatch, MergeSummary, NotePatch,
 };
 #[cfg(unix)]
 pub use daemon::{acquire_recovery_lock, pid_path, run_daemon, socket_path, DaemonDispatch};

--- a/crates/khive-runtime/src/lib.rs
+++ b/crates/khive-runtime/src/lib.rs
@@ -41,6 +41,7 @@ pub use atomic_plan::{
 };
 pub use atomic_runner::{
     run_atomic_unit, AtomicOpFailure, AtomicOpPlan, AtomicRunOutcome, AtomicRunnerError,
+    CommittedPostCommitEffects,
 };
 pub use blob::resolve_blob_store;
 pub use cost_unit::{base_resource_payload, cost_unit_for_dispatch, resource_payload};

--- a/crates/khive-runtime/src/lib.rs
+++ b/crates/khive-runtime/src/lib.rs
@@ -64,8 +64,8 @@ pub use error::{fts_text_leg_or_err, GuardedWriteFailure, RuntimeError, RuntimeR
 pub use fusion::FusionStrategy;
 pub use graph_traversal::PathNode;
 pub use khive_db::{
-    checkpoint_once, run_checkpoint_task, run_migrations, CheckpointConfig, CheckpointTick,
-    ConnectionPool, StorageBackend,
+    checkpoint_once, run_checkpoint_task, run_migrations, CheckpointConfig,
+    CheckpointLifecycleOwner, CheckpointTick, ConnectionPool, StorageBackend,
 };
 pub use khive_gate::{
     ActorRef, AllowAllGate, AuditDecision, AuditEvent, Gate, GateContext, GateDecision, GateError,

--- a/crates/khive-runtime/src/operations.rs
+++ b/crates/khive-runtime/src/operations.rs
@@ -93,11 +93,16 @@ static FTS_FAIL_NS: std::sync::LazyLock<std::sync::Mutex<std::collections::HashS
 #[cfg(any(test, feature = "fault-injection"))]
 static VECTOR_FAIL_NS: std::sync::LazyLock<std::sync::Mutex<std::collections::HashSet<String>>> =
     std::sync::LazyLock::new(|| std::sync::Mutex::new(std::collections::HashSet::new()));
-/// Fail the first FTS statement inside `create_many`'s atomic write.
+/// FTS failure injection for `create_many` — separate from `FTS_FAIL_NS` so that
+/// create_note_inner and create_many tests cannot disarm each other. Namespace-keyed
+/// set (not a single `Option<String>` slot) for the same reason as `VECTOR_FAIL_NS` (#1263).
 #[cfg(any(test, feature = "fault-injection"))]
 static FTS_FAIL_MANY_NS: std::sync::LazyLock<std::sync::Mutex<std::collections::HashSet<String>>> =
     std::sync::LazyLock::new(|| std::sync::Mutex::new(std::collections::HashSet::new()));
-/// Fail an FTS statement after one complete entity/FTS pair when the batch permits it.
+/// FTS partial-failure injection for `create_many` — returns `Ok(BatchWriteSummary)`
+/// with `failed > 0` so that the `summary.failed > 0` rollback branch is exercised.
+/// Distinct from `FTS_FAIL_MANY_NS` which injects a hard `Err`. Namespace-keyed set
+/// for the same reason as `VECTOR_FAIL_NS` (#1263).
 #[cfg(any(test, feature = "fault-injection"))]
 static FTS_FAIL_MANY_PARTIAL_NS: std::sync::LazyLock<
     std::sync::Mutex<std::collections::HashSet<String>>,

--- a/crates/khive-runtime/src/operations.rs
+++ b/crates/khive-runtime/src/operations.rs
@@ -963,6 +963,47 @@ fn recompute_total_weight(path: &mut GraphPath) {
     path.total_weight = path.nodes.iter().map(|n| n.weight).fold(0.0_f64, f64::max);
 }
 
+/// Await every spawned multi-model embed task in `join_set`, returning one
+/// vector per model (in model order) on full success.
+///
+/// `join_set` entries are `(model_index, embed_result)` — the index lets
+/// completion order (which is arrival order, not spawn order) be reassembled
+/// into the caller's model order. On the first failure (an embed error or a
+/// task panic), every remaining handle is aborted and detached so the error
+/// return is not gated on a sibling reaching a cancellation point. A sibling
+/// already inside synchronous native inference may finish that call in the
+/// background. Embed calls are counted when issued, before the provider
+/// await, so detached completion cannot change the operation's usage count.
+/// Each task owns cloned runtime/provider state and only computes an embedding;
+/// storage writes remain in the parent after this drain succeeds.
+async fn drain_embed_join_set(
+    mut join_set: tokio::task::JoinSet<(usize, RuntimeResult<Vec<f32>>)>,
+    model_count: usize,
+) -> RuntimeResult<Vec<Vec<f32>>> {
+    let mut vectors: Vec<Option<Vec<f32>>> = (0..model_count).map(|_| None).collect();
+
+    while let Some(joined) = join_set.join_next().await {
+        match joined {
+            Ok((idx, Ok(vector))) => vectors[idx] = Some(vector),
+            Ok((_idx, Err(e))) => {
+                join_set.abort_all();
+                return Err(e);
+            }
+            Err(join_err) => {
+                join_set.abort_all();
+                return Err(RuntimeError::Internal(format!(
+                    "embed task panicked: {join_err}"
+                )));
+            }
+        }
+    }
+
+    Ok(vectors
+        .into_iter()
+        .map(|v| v.expect("every model index observed exactly once by join_set drain"))
+        .collect())
+}
+
 impl KhiveRuntime {
     // ---- Entity operations ----
 
@@ -1107,84 +1148,48 @@ impl KhiveRuntime {
             let rt_clone = self.clone();
             let body_owned = embed_body.clone();
             let usage_ctx = crate::usage::current();
-            let mut handles = Vec::with_capacity(embed_model_names.len());
-            for model_name in &embed_model_names {
+            let mut join_set = tokio::task::JoinSet::new();
+            for (idx, model_name) in embed_model_names.iter().enumerate() {
                 let rt = rt_clone.clone();
                 let text = body_owned.clone();
                 let name = model_name.clone();
                 let ctx = usage_ctx.clone();
-                handles.push(tokio::spawn(async move {
+                join_set.spawn(async move {
                     let fut = rt.embed_document_with_model(&name, &text);
-                    match ctx {
+                    let result = match ctx {
                         Some(ctx) => crate::usage::scope(ctx, fut).await,
                         None => fut.await,
-                    }
-                }));
+                    };
+                    (idx, result)
+                });
             }
-            // Await every handle before inspecting any result. Each handle holds a
-            // clone of the dispatch's UsageContext (ADR-103 Amendment 2); returning
-            // early on the first error would leave later handles un-awaited, so
-            // their embed tasks keep running (and incrementing embed_calls) after
-            // this function has already returned — the usage snapshot must never
-            // observe a task the dispatch didn't wait for.
-            let mut join_results = Vec::with_capacity(handles.len());
-            for handle in handles {
-                join_results.push(
-                    handle
-                        .await
-                        .map_err(|e| RuntimeError::Internal(format!("embed task panicked: {e}"))),
-                );
-            }
-            let mut vectors: Vec<Vec<f32>> = Vec::with_capacity(embed_model_names.len());
-            for join_result in join_results {
-                match join_result {
-                    Err(e) => {
-                        if let Ok(store) = self.entities(token) {
-                            if let Err(ce) = store.delete_entity(entity.id, DeleteMode::Hard).await
-                            {
-                                tracing::error!(
-                                    error = %ce,
-                                    id = %entity.id,
-                                    "create_entity: failed to roll back entity row after embed task panic"
-                                );
-                            }
+            // The first failed or panicked handle aborts and detaches its
+            // siblings. Embed usage is counted at dispatch, so a synchronous
+            // provider winding down in the background cannot change it.
+            let vectors = match drain_embed_join_set(join_set, embed_model_names.len()).await {
+                Ok(vectors) => vectors,
+                Err(e) => {
+                    if let Ok(store) = self.entities(token) {
+                        if let Err(ce) = store.delete_entity(entity.id, DeleteMode::Hard).await {
+                            tracing::error!(
+                                error = %ce,
+                                id = %entity.id,
+                                "create_entity: failed to roll back entity row after embed failure"
+                            );
                         }
-                        if let Ok(fts) = self.text(token) {
-                            if let Err(ce) = fts.delete_document(ns, entity.id).await {
-                                tracing::error!(
-                                    error = %ce,
-                                    id = %entity.id,
-                                    "create_entity: failed to roll back FTS document after embed task panic"
-                                );
-                            }
-                        }
-                        return Err(e);
                     }
-                    Ok(Err(e)) => {
-                        if let Ok(store) = self.entities(token) {
-                            if let Err(ce) = store.delete_entity(entity.id, DeleteMode::Hard).await
-                            {
-                                tracing::error!(
-                                    error = %ce,
-                                    id = %entity.id,
-                                    "create_entity: failed to roll back entity row after embed failure"
-                                );
-                            }
+                    if let Ok(fts) = self.text(token) {
+                        if let Err(ce) = fts.delete_document(ns, entity.id).await {
+                            tracing::error!(
+                                error = %ce,
+                                id = %entity.id,
+                                "create_entity: failed to roll back FTS document after embed failure"
+                            );
                         }
-                        if let Ok(fts) = self.text(token) {
-                            if let Err(ce) = fts.delete_document(ns, entity.id).await {
-                                tracing::error!(
-                                    error = %ce,
-                                    id = %entity.id,
-                                    "create_entity: failed to roll back FTS document after embed failure"
-                                );
-                            }
-                        }
-                        return Err(e);
                     }
-                    Ok(Ok(vec)) => vectors.push(vec),
+                    return Err(e);
                 }
-            }
+            };
             // TODO(P2): parallelize vector inserts
             let mut inserted_models: Vec<String> = Vec::with_capacity(embed_model_names.len());
             for (model_name, vector) in embed_model_names.iter().zip(vectors) {
@@ -3108,60 +3113,37 @@ impl KhiveRuntime {
             let rt_clone = self.clone();
             let content_owned = embed_text.to_string();
             let usage_ctx = crate::usage::current();
-            let mut handles = Vec::with_capacity(embed_model_names.len());
-            for model_name in &embed_model_names {
+            let mut join_set = tokio::task::JoinSet::new();
+            for (idx, model_name) in embed_model_names.iter().enumerate() {
                 let rt = rt_clone.clone();
                 let text = content_owned.clone();
                 let name = model_name.clone();
                 let ctx = usage_ctx.clone();
-                handles.push(tokio::spawn(async move {
+                join_set.spawn(async move {
                     let fut = rt.embed_document_with_model(&name, &text);
-                    match ctx {
+                    let result = match ctx {
                         Some(ctx) => crate::usage::scope(ctx, fut).await,
                         None => fut.await,
-                    }
-                }));
+                    };
+                    (idx, result)
+                });
             }
-            // Await every handle before inspecting any result. Each handle holds a
-            // clone of the dispatch's UsageContext (ADR-103 Amendment 2); returning
-            // early on the first error would leave later handles un-awaited, so
-            // their embed tasks keep running (and incrementing embed_calls) after
-            // this function has already returned — the usage snapshot must never
-            // observe a task the dispatch didn't wait for.
-            let mut join_results = Vec::with_capacity(handles.len());
-            for handle in handles {
-                join_results.push(
-                    handle
-                        .await
-                        .map_err(|e| RuntimeError::Internal(format!("embed task panicked: {e}"))),
-                );
-            }
-            let mut vectors: Vec<Vec<f32>> = Vec::with_capacity(embed_model_names.len());
-            for join_result in join_results {
-                match join_result {
-                    Err(e) => {
-                        // Compensate note row + FTS (no vectors inserted yet).
-                        if let Ok(store) = self.notes(token) {
-                            let _ = store.delete_note(note.id, DeleteMode::Hard).await;
-                        }
-                        if let Ok(fts) = self.text_for_notes(token) {
-                            let _ = fts.delete_document(ns, note.id).await;
-                        }
-                        return Err(e);
+            // The first failed or panicked handle aborts and detaches its
+            // siblings. Embed usage is counted at dispatch, so a synchronous
+            // provider winding down in the background cannot change it.
+            let vectors = match drain_embed_join_set(join_set, embed_model_names.len()).await {
+                Ok(vectors) => vectors,
+                Err(e) => {
+                    // Compensate note row + FTS (no vectors inserted yet).
+                    if let Ok(store) = self.notes(token) {
+                        let _ = store.delete_note(note.id, DeleteMode::Hard).await;
                     }
-                    Ok(Err(e)) => {
-                        // Embed call failed — compensate note row + FTS.
-                        if let Ok(store) = self.notes(token) {
-                            let _ = store.delete_note(note.id, DeleteMode::Hard).await;
-                        }
-                        if let Ok(fts) = self.text_for_notes(token) {
-                            let _ = fts.delete_document(ns, note.id).await;
-                        }
-                        return Err(e);
+                    if let Ok(fts) = self.text_for_notes(token) {
+                        let _ = fts.delete_document(ns, note.id).await;
                     }
-                    Ok(Ok(vec)) => vectors.push(vec),
+                    return Err(e);
                 }
-            }
+            };
             // TODO(P2): parallelize vector inserts
             let mut inserted_models: Vec<String> = Vec::with_capacity(embed_model_names.len());
             for (model_name, vector) in embed_model_names.iter().zip(vectors) {
@@ -3440,7 +3422,11 @@ impl KhiveRuntime {
                 .await
         };
 
-        crate::usage::count(crate::usage::UsageUnit::FtsPasses, 1);
+        // FtsPasses is counted inside the store's `search()` (khive-db
+        // stores/text.rs), only once a real FTS5 statement is prepared —
+        // an empty/fully-sanitized query short-circuits there before any
+        // statement exists and must not count (nor does the injected-failure
+        // branch above, which never reaches the store at all).
         let text_hits = crate::error::fts_text_leg_or_err(
             text_search_result.map_err(RuntimeError::from),
             "search_notes",
@@ -5321,14 +5307,14 @@ pub struct EntityCreateSpec {
 mod tests {
     use super::*;
     use crate::curation::EdgeListFilter;
-    use crate::embedder_registry::EmbedderProvider;
+    use crate::embedder_registry::{BlockingEmbeddingService, EmbedderProvider};
     use crate::error::RuntimeError;
     use crate::runtime::{KhiveRuntime, NamespaceToken};
     use crate::{ActorRef, Namespace};
     use async_trait::async_trait;
     use khive_storage::types::PathNode;
     use lattice_embed::{EmbedError, EmbeddingModel, EmbeddingService};
-    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
     use std::sync::Arc;
 
     fn rt() -> KhiveRuntime {
@@ -5456,17 +5442,25 @@ mod tests {
         }
     }
 
-    /// Embedder provider whose `build()` always fails immediately — models
-    /// this provider's embed task resolving (with an error) well before a
-    /// slower sibling model's task completes.
+    /// Embedder that fails inference immediately unless configured to wait for
+    /// a sibling's entry signal first.
     struct FailFastProvider {
         provider_name: String,
+        wait_for: Option<Arc<AtomicBool>>,
     }
 
     impl FailFastProvider {
         fn new(name: &str) -> Self {
             Self {
                 provider_name: name.to_owned(),
+                wait_for: None,
+            }
+        }
+
+        fn after_signal(name: &str, wait_for: Arc<AtomicBool>) -> Self {
+            Self {
+                provider_name: name.to_owned(),
+                wait_for: Some(wait_for),
             }
         }
     }
@@ -5482,9 +5476,200 @@ mod tests {
         }
 
         async fn build(&self) -> crate::error::RuntimeResult<Arc<dyn EmbeddingService>> {
-            Err(RuntimeError::Internal(
-                "injected embed build failure".to_string(),
+            Ok(Arc::new(FailFastService {
+                wait_for: self.wait_for.clone(),
+            }))
+        }
+    }
+
+    struct FailFastService {
+        wait_for: Option<Arc<AtomicBool>>,
+    }
+
+    #[async_trait]
+    impl EmbeddingService for FailFastService {
+        async fn embed(
+            &self,
+            _texts: &[String],
+            _model: EmbeddingModel,
+        ) -> std::result::Result<Vec<Vec<f32>>, EmbedError> {
+            if let Some(wait_for) = &self.wait_for {
+                while !wait_for.load(Ordering::Acquire) {
+                    tokio::task::yield_now().await;
+                }
+            }
+            Err(EmbedError::InferenceFailed(
+                "injected embed failure".to_string(),
             ))
+        }
+
+        fn supports_model(&self, _model: EmbeddingModel) -> bool {
+            true
+        }
+
+        fn name(&self) -> &'static str {
+            "fail-fast"
+        }
+    }
+
+    /// Embedder whose synchronous inference section is controlled by a
+    /// condition variable, matching native inference that cannot observe task
+    /// cancellation until the encode call returns.
+    struct BlockingVecProvider {
+        provider_name: String,
+        dims: usize,
+        release: Arc<(std::sync::Mutex<bool>, std::sync::Condvar)>,
+        entered: Arc<AtomicBool>,
+    }
+
+    struct BlockingVecControls {
+        release: Arc<(std::sync::Mutex<bool>, std::sync::Condvar)>,
+        entered: Arc<AtomicBool>,
+    }
+
+    impl BlockingVecProvider {
+        fn new(name: &str, dims: usize) -> (Self, BlockingVecControls) {
+            let release = Arc::new((std::sync::Mutex::new(false), std::sync::Condvar::new()));
+            let entered = Arc::new(AtomicBool::new(false));
+            (
+                Self {
+                    provider_name: name.to_owned(),
+                    dims,
+                    release: Arc::clone(&release),
+                    entered: Arc::clone(&entered),
+                },
+                BlockingVecControls { release, entered },
+            )
+        }
+    }
+
+    #[async_trait]
+    impl EmbedderProvider for BlockingVecProvider {
+        fn name(&self) -> &str {
+            &self.provider_name
+        }
+
+        fn dimensions(&self) -> usize {
+            self.dims
+        }
+
+        async fn build(&self) -> crate::error::RuntimeResult<Arc<dyn EmbeddingService>> {
+            let service = Arc::new(BlockingVecService {
+                dims: self.dims,
+                release: Arc::clone(&self.release),
+                entered: Arc::clone(&self.entered),
+            });
+            Ok(Arc::new(BlockingEmbeddingService::new(service)))
+        }
+    }
+
+    struct BlockingVecService {
+        dims: usize,
+        release: Arc<(std::sync::Mutex<bool>, std::sync::Condvar)>,
+        entered: Arc<AtomicBool>,
+    }
+
+    #[async_trait]
+    impl EmbeddingService for BlockingVecService {
+        async fn embed(
+            &self,
+            texts: &[String],
+            _model: EmbeddingModel,
+        ) -> std::result::Result<Vec<Vec<f32>>, EmbedError> {
+            self.entered.store(true, Ordering::Release);
+            let (released, wake) = &*self.release;
+            let guard = released.lock().expect("release lock must not be poisoned");
+            let _guard = wake
+                .wait_while(guard, |released| !*released)
+                .expect("release lock must not be poisoned");
+            Ok(texts.iter().map(|_| vec![1.0_f32; self.dims]).collect())
+        }
+
+        fn supports_model(&self, _model: EmbeddingModel) -> bool {
+            true
+        }
+
+        fn name(&self) -> &'static str {
+            "blocking-vec"
+        }
+    }
+
+    /// Embedder whose `embed` parks until a release that never comes — models
+    /// a hung provider. Only task abort can end its embed future. `entered`
+    /// receives a permit when `embed` is reached, so a test can wait until the
+    /// parked task is provably past the dispatch point before acting on it.
+    struct ParkedVecProvider {
+        provider_name: String,
+        dims: usize,
+        release: Arc<tokio::sync::Notify>,
+        entered: Arc<tokio::sync::Notify>,
+    }
+
+    impl ParkedVecProvider {
+        fn new(
+            name: &str,
+            dims: usize,
+        ) -> (Self, Arc<tokio::sync::Notify>, Arc<tokio::sync::Notify>) {
+            let release = Arc::new(tokio::sync::Notify::new());
+            let entered = Arc::new(tokio::sync::Notify::new());
+            (
+                Self {
+                    provider_name: name.to_owned(),
+                    dims,
+                    release: Arc::clone(&release),
+                    entered: Arc::clone(&entered),
+                },
+                release,
+                entered,
+            )
+        }
+    }
+
+    #[async_trait]
+    impl EmbedderProvider for ParkedVecProvider {
+        fn name(&self) -> &str {
+            &self.provider_name
+        }
+
+        fn dimensions(&self) -> usize {
+            self.dims
+        }
+
+        async fn build(&self) -> crate::error::RuntimeResult<Arc<dyn EmbeddingService>> {
+            Ok(Arc::new(ParkedVecService {
+                dims: self.dims,
+                release: Arc::clone(&self.release),
+                entered: Arc::clone(&self.entered),
+            }))
+        }
+    }
+
+    struct ParkedVecService {
+        dims: usize,
+        release: Arc<tokio::sync::Notify>,
+        entered: Arc<tokio::sync::Notify>,
+    }
+
+    #[async_trait]
+    impl EmbeddingService for ParkedVecService {
+        async fn embed(
+            &self,
+            texts: &[String],
+            _model: EmbeddingModel,
+        ) -> std::result::Result<Vec<Vec<f32>>, EmbedError> {
+            // notify_one stores a permit when no waiter is registered yet, so
+            // the entered signal cannot be lost to a start-order race.
+            self.entered.notify_one();
+            self.release.notified().await;
+            Ok(texts.iter().map(|_| vec![1.0_f32; self.dims]).collect())
+        }
+
+        fn supports_model(&self, _model: EmbeddingModel) -> bool {
+            true
+        }
+
+        fn name(&self) -> &'static str {
+            "parked-vec"
         }
     }
 
@@ -11962,15 +12147,10 @@ mod tests {
         );
     }
 
-    // ADR-103 Amendment 2 regression: when one of several spawned embed tasks
-    // errors, create_entity must drain (await) every remaining handle before
-    // returning — each handle holds a clone of the dispatch's UsageContext, so
-    // an un-awaited handle keeps running and can increment embed_calls after
-    // the response has already gone out, making the counter nondeterministic.
-    // The fail-fast model resolves (with an error) first; the slow model's
-    // task is still in flight at that point — the drain must wait for it too.
+    // Embed calls are counted when issued, so detached completion after a
+    // sibling failure cannot change the response's usage snapshot.
     #[tokio::test]
-    async fn create_entity_multi_model_error_drains_all_spawned_embeds_before_returning() {
+    async fn create_entity_multi_model_error_keeps_issued_usage_stable() {
         const DIMS: usize = 4;
 
         let rt = KhiveRuntime::memory().unwrap();
@@ -12006,16 +12186,15 @@ mod tests {
 
         assert_eq!(
             snap_immediately_after, snap_after_delay,
-            "no spawned embed task may still be running after create_entity returns \
-             its error — a late increment means a context-holding handle was left \
-             un-awaited; got immediately_after={snap_immediately_after:?} \
+            "embed completion after create_entity returns must not change issued \
+             usage; got immediately_after={snap_immediately_after:?} \
              after_delay={snap_after_delay:?}"
         );
     }
 
     // Same regression for the note create path's multi-model embed fan-out.
     #[tokio::test]
-    async fn create_note_multi_model_error_drains_all_spawned_embeds_before_returning() {
+    async fn create_note_multi_model_error_keeps_issued_usage_stable() {
         const DIMS: usize = 4;
 
         let rt = KhiveRuntime::memory().unwrap();
@@ -12051,10 +12230,145 @@ mod tests {
 
         assert_eq!(
             snap_immediately_after, snap_after_delay,
-            "no spawned embed task may still be running after create_note returns \
-             its error — a late increment means a context-holding handle was left \
-             un-awaited; got immediately_after={snap_immediately_after:?} \
+            "embed completion after create_note returns must not change issued \
+             usage; got immediately_after={snap_immediately_after:?} \
              after_delay={snap_after_delay:?}"
+        );
+    }
+
+    // A fast provider failure must not wait on a slow sibling: the drain
+    // aborts remaining embed tasks on the first error instead of awaiting
+    // them to completion. The sibling here parks until a release that never
+    // fires, so under await-to-completion this call would never return —
+    // a bounded prompt error return is only reachable through the abort path.
+    #[tokio::test]
+    async fn create_entity_fast_embed_failure_does_not_wait_for_hung_sibling() {
+        const DIMS: usize = 4;
+
+        let rt = KhiveRuntime::memory().unwrap();
+        rt.register_embedder(FailFastProvider::new("latency-fail-fast"));
+        let (parked, _release, _entered) = ParkedVecProvider::new("latency-parked", DIMS);
+        rt.register_embedder(parked);
+
+        let ns = Namespace::parse("usage-entity-latency").unwrap();
+        let tok = NamespaceToken::for_namespace(ns.clone());
+
+        let started = std::time::Instant::now();
+        // Outer timeout so a regression to await-to-completion FAILS this test
+        // within the bound instead of hanging the suite on the parked sibling.
+        let result = tokio::time::timeout(
+            std::time::Duration::from_secs(60),
+            rt.create_entity(
+                &tok,
+                "concept",
+                None,
+                "latency entity",
+                Some("description so embed body is non-empty"),
+                None,
+                vec![],
+            ),
+        )
+        .await
+        .expect("create_entity must return within the timeout — a hang means the abort path regressed to await-to-completion");
+        let elapsed = started.elapsed();
+
+        assert!(
+            result.is_err(),
+            "one model failing must fail the whole create_entity call"
+        );
+        assert!(
+            elapsed < std::time::Duration::from_secs(5),
+            "a fast embed failure must return without waiting on the hung \
+             sibling (which parks forever); took {elapsed:?}"
+        );
+    }
+
+    #[test]
+    fn create_entity_embed_failure_returns_under_single_worker_saturation() {
+        let (blocking, controls) = BlockingVecProvider::new("latency-blocking", 4);
+        let fail_after_entry = FailFastProvider::after_signal(
+            "latency-fail-after-entry",
+            Arc::clone(&controls.entered),
+        );
+        let (result_tx, result_rx) = std::sync::mpsc::sync_channel(1);
+
+        let runtime_thread = std::thread::spawn(move || {
+            let runtime = tokio::runtime::Builder::new_multi_thread()
+                .worker_threads(1)
+                .enable_all()
+                .build()
+                .expect("single-worker runtime must build");
+            let rt = KhiveRuntime::memory().unwrap();
+            rt.register_embedder(blocking);
+            rt.register_embedder(fail_after_entry);
+            let tok =
+                NamespaceToken::for_namespace(Namespace::parse("embed-failure-latency").unwrap());
+            let result = runtime.block_on(rt.create_entity(
+                &tok,
+                "concept",
+                None,
+                "blocked sibling entity",
+                None,
+                None,
+                vec![],
+            ));
+            result_tx
+                .send(result.map_err(|error| error.to_string()))
+                .expect("test receiver must remain connected");
+        });
+
+        let result = result_rx.recv_timeout(std::time::Duration::from_secs(3));
+
+        let (released, wake) = &*controls.release;
+        *released.lock().expect("release lock must not be poisoned") = true;
+        wake.notify_all();
+        runtime_thread
+            .join()
+            .expect("single-worker runtime thread must join after release");
+
+        let error = result
+            .expect("embed failure must return while synchronous inference remains blocked")
+            .expect_err("one failed model must fail entity creation");
+        assert!(error.contains("injected embed failure"));
+    }
+
+    // Issued-at-dispatch accounting: an embed call that was handed to the
+    // provider must count toward embed_calls even if the task is aborted
+    // while parked on the provider await — the increment sits before the
+    // await, so cancellation cannot undercount issued work.
+    #[tokio::test]
+    async fn aborted_embed_task_still_counts_issued_embed_call() {
+        const DIMS: usize = 4;
+
+        let rt = std::sync::Arc::new(KhiveRuntime::memory().unwrap());
+        let (parked, _release, entered) = ParkedVecProvider::new("abort-count-parked", DIMS);
+        rt.register_embedder(parked);
+
+        let ctx = crate::usage::UsageContext::new();
+        let task = {
+            let rt = std::sync::Arc::clone(&rt);
+            let ctx = ctx.clone();
+            tokio::spawn(crate::usage::scope(ctx, async move {
+                rt.embed_document_with_model("abort-count-parked", "abort count body")
+                    .await
+            }))
+        };
+
+        // Wait until the parked service's embed was entered — the dispatch
+        // point (and its count) is strictly before that entry.
+        entered.notified().await;
+        task.abort();
+        let joined = task.await;
+        assert!(
+            joined.is_err() && joined.unwrap_err().is_cancelled(),
+            "task must end as cancelled by the abort"
+        );
+
+        assert_eq!(
+            ctx.snapshot()["embed_calls"],
+            1,
+            "an issued embed call must be counted even when the task is \
+             aborted while parked on the provider await"
         );
     }
 

--- a/crates/khive-runtime/src/retrieval.rs
+++ b/crates/khive-runtime/src/retrieval.rs
@@ -116,8 +116,11 @@ impl KhiveRuntime {
         let model = parse_embedding_model_alias(model_name);
         let service = self.embedder(model_name).await?;
         let emb_model = model.unwrap_or_default();
-        let out = service.embed_one(text, emb_model).await;
+        // Issued-at-dispatch: count before the provider await so a call that
+        // was handed to the provider is counted even if this task is aborted
+        // while parked on the await (drain_embed_join_set cancellation path).
         crate::usage::count(crate::usage::UsageUnit::EmbedCalls, 1);
+        let out = service.embed_one(text, emb_model).await;
         Ok(out?)
     }
 
@@ -147,8 +150,9 @@ impl KhiveRuntime {
         let model = parse_embedding_model_alias(model_name);
         let service = self.embedder(model_name).await?;
         let emb_model = model.unwrap_or_default();
-        let embeddings = service.embed_passage(&[text.to_string()], emb_model).await;
+        // Issued-at-dispatch: counted before the await — see embed_with_model.
         crate::usage::count(crate::usage::UsageUnit::EmbedCalls, 1);
+        let embeddings = service.embed_passage(&[text.to_string()], emb_model).await;
         let out = embeddings?
             .into_iter()
             .next()
@@ -176,13 +180,14 @@ impl KhiveRuntime {
         let service = self.embedder(model_name).await?;
         let texts = [text.to_string()];
         let emb_model = model.unwrap_or_default();
+        // Issued-at-dispatch: counted before the await — see embed_with_model.
+        crate::usage::count(crate::usage::UsageUnit::EmbedCalls, 1);
         let embeddings = match emb_model {
             EmbeddingModel::BgeSmallEnV15
             | EmbeddingModel::BgeBaseEnV15
             | EmbeddingModel::BgeLargeEnV15 => service.embed(&texts, emb_model).await,
             _ => service.embed_query(&texts, emb_model).await,
         };
-        crate::usage::count(crate::usage::UsageUnit::EmbedCalls, 1);
         let out = embeddings?
             .into_iter()
             .next()
@@ -448,7 +453,10 @@ impl KhiveRuntime {
                 snippet_chars: 200,
             })
             .await;
-        crate::usage::count(crate::usage::UsageUnit::FtsPasses, 1);
+        // FtsPasses is counted inside the store's `search()` (khive-db
+        // stores/text.rs), only once a real FTS5 statement is prepared —
+        // an empty/fully-sanitized query short-circuits there before any
+        // statement exists and must not count.
         let text_hits = crate::error::fts_text_leg_or_err(
             text_search_result.map_err(RuntimeError::from),
             "hybrid_search",

--- a/crates/khive-runtime/tests/integration.rs
+++ b/crates/khive-runtime/tests/integration.rs
@@ -3840,3 +3840,43 @@ async fn stats_totals_match_list_walk_across_visible_namespaces() {
     );
     assert_eq!(stats_notes, 2);
 }
+
+#[test]
+#[serial_test::serial]
+fn test_harness_refuses_runtime_default_store() {
+    struct HomeGuard(Option<std::ffi::OsString>);
+
+    impl Drop for HomeGuard {
+        fn drop(&mut self) {
+            match self.0.take() {
+                Some(home) => std::env::set_var("HOME", home),
+                None => std::env::remove_var("HOME"),
+            }
+        }
+    }
+
+    assert_eq!(
+        std::env::var("KHIVE_TEST_HARNESS").as_deref(),
+        Ok("1"),
+        "the workspace Cargo harness must mark integration-test processes"
+    );
+    let fake_home = tempfile::tempdir().expect("temporary HOME");
+    let _home_guard = HomeGuard(std::env::var_os("HOME"));
+    std::env::set_var("HOME", fake_home.path());
+    let expected_path = fake_home.path().join(".khive/khive.db");
+    let config = RuntimeConfig::no_embeddings();
+    assert_eq!(config.db_path.as_deref(), Some(expected_path.as_path()));
+
+    let error = match KhiveRuntime::new(config) {
+        Ok(_) => panic!("test harness opened the default home-directory store"),
+        Err(error) => error,
+    };
+    assert!(
+        error.to_string().contains("test harness refused"),
+        "unexpected guard error: {error}"
+    );
+    assert!(
+        !expected_path.exists(),
+        "the guarded runtime must refuse the path before SQLite creates it"
+    );
+}

--- a/crates/khive-text/Cargo.toml
+++ b/crates/khive-text/Cargo.toml
@@ -20,7 +20,6 @@ rust-stemmers = { workspace = true, optional = true }
 
 [dev-dependencies]
 criterion = { workspace = true }
-khive-bm25 = { version = "0.5.0", path = "../khive-bm25" }
 
 [features]
 default = []

--- a/crates/khive-text/README.md
+++ b/crates/khive-text/README.md
@@ -50,10 +50,9 @@ choosing an analyzer.
 
 ## Where this sits
 
-`khive-text` has no required khive-* dependencies and no current in-workspace
-consumers — it is a standalone tokenization library extracted for reuse by any
-future retrieval crate that needs a pluggable analyzer independent of
-`khive-bm25`'s built-in `SimpleTokenizer`.
+`khive-text` has no required khive-* dependencies. `khive-bm25` consumes its
+tokenizer trait and normalization filters while retaining `SimpleTokenizer` as
+its compatibility-oriented configuration wrapper.
 
 ## License
 

--- a/crates/khive-text/src/preset.rs
+++ b/crates/khive-text/src/preset.rs
@@ -153,21 +153,4 @@ mod tests {
         let tokens = standard().analyze(&input);
         assert_eq!(tokens, vec!["hello".to_string(), long, "world".to_string()]);
     }
-
-    #[test]
-    fn standard_matches_bm25_default_token_stream() {
-        let bm25 = khive_bm25::SimpleTokenizer::default();
-        let cases = [
-            "may x",
-            "done say might",
-            "against",
-            &"a".repeat(41),
-            "The quick brown fox jumps over the lazy dog",
-        ];
-        for input in cases {
-            let ours = standard().analyze(input);
-            let theirs = khive_bm25::Tokenizer::tokenize(&bm25, input);
-            assert_eq!(ours, theirs, "mismatch for input: {input:?}");
-        }
-    }
 }

--- a/crates/khive-vamana/Cargo.toml
+++ b/crates/khive-vamana/Cargo.toml
@@ -29,6 +29,20 @@ blake3 = { workspace = true }
 uuid = { workspace = true, optional = true }
 khive-quant = { version = "0.5.0", path = "../khive-quant", default-features = false }
 
+[target.'cfg(unix)'.dependencies]
+libc = { workspace = true }
+
+[target.'cfg(windows)'.dependencies]
+windows-sys = { version = "0.61", features = [
+    "Wdk_Foundation",
+    "Wdk_Storage_FileSystem",
+    "Win32_Foundation",
+    "Win32_Security",
+    "Win32_Storage_FileSystem",
+    "Win32_System_IO",
+    "Win32_System_WindowsProgramming",
+] }
+
 [dev-dependencies]
 blake3 = { workspace = true }
 tempfile = { workspace = true }

--- a/crates/khive-vamana/src/external_ids.rs
+++ b/crates/khive-vamana/src/external_ids.rs
@@ -16,11 +16,65 @@
 //!   ids_hash      32 bytes  blake3 of the raw id bytes that follow
 //!   count         8 bytes   u64 little-endian — number of UUIDs
 //!   ids           16 × count bytes — raw UUID bytes
+//!
+//! Sidecar mutations are pinned to a verified directory handle on Unix and
+//! Windows. Windows rejects reparse-point handles and compares the opened
+//! directory's final path with its expected canonical location before using
+//! handle-relative file operations. Only targets without handle-relative
+//! filesystem facilities use the documented best-effort path fallback.
 
 use uuid::Uuid;
 
+#[cfg(windows)]
+#[path = "external_ids_windows.rs"]
+mod windows;
+
 const SIDECAR_MAGIC: &[u8; 8] = b"KHVANID2";
 const HEADER_LEN: usize = 8 + 32 + 32 + 8;
+
+/// Fail-closed errors from an external-id sidecar write.
+#[derive(Debug, thiserror::Error)]
+pub enum ExternalIdsWriteError {
+    #[error("{context}: {source}")]
+    Io {
+        context: String,
+        #[source]
+        source: std::io::Error,
+    },
+
+    #[error("{context}: {detail}")]
+    InvalidPath {
+        context: &'static str,
+        detail: String,
+    },
+
+    #[error("open segment dir: path identity changed during validation")]
+    DirectoryIdentityChanged,
+
+    #[error(
+        "open segment dir: untrusted ancestor symlink {component:?} (symlink uid {symlink_uid}, parent uid {parent_uid}, parent mode {parent_mode:#o})"
+    )]
+    UntrustedAncestorSymlink {
+        component: std::ffi::OsString,
+        symlink_uid: u32,
+        parent_uid: u32,
+        parent_mode: u32,
+    },
+
+    #[error(
+        "secure external-id sidecar writes are unsupported on {platform}: no no-follow, handle-relative directory operations are available; refusing write"
+    )]
+    UnsupportedPlatform { platform: &'static str },
+}
+
+impl ExternalIdsWriteError {
+    fn io(context: impl Into<String>, source: std::io::Error) -> Self {
+        Self::Io {
+            context: context.into(),
+            source,
+        }
+    }
+}
 
 /// Blake3 digest of `dir/metadata.bin` — the identity of one specific segment
 /// commit. `Ok(None)` when the file is absent (no committed segment).
@@ -33,17 +87,15 @@ pub fn segment_commit_digest(dir: &std::path::Path) -> Result<Option<[u8; 32]>, 
 }
 
 /// Write `ids` to `dir/external_ids.bin` using a tmp-then-rename pattern,
-/// bound to the commit record identified by `commit_digest`.
+/// bound to the commit record identified by `commit_digest`. On Unix every
+/// filesystem step runs relative to a descriptor reached through a validated
+/// component walk. On Windows the directory's post-open attributes and final
+/// path are verified before every mutation runs relative to that handle.
 pub fn write_external_ids_sidecar(
     dir: &std::path::Path,
     commit_digest: &[u8; 32],
     ids: &[Uuid],
-) -> Result<(), String> {
-    use std::io::Write as _;
-
-    let tmp_path = dir.join("external_ids.bin.tmp");
-    let final_path = dir.join("external_ids.bin");
-
+) -> Result<(), ExternalIdsWriteError> {
     let mut id_bytes: Vec<u8> = Vec::with_capacity(ids.len() * 16);
     for id in ids {
         id_bytes.extend_from_slice(id.as_bytes());
@@ -58,15 +110,496 @@ pub fn write_external_ids_sidecar(
     buf.extend_from_slice(&count.to_le_bytes());
     buf.extend_from_slice(&id_bytes);
 
-    let mut f = std::fs::File::create(&tmp_path)
-        .map_err(|e| format!("create external_ids.bin.tmp: {e}"))?;
-    f.write_all(&buf)
-        .map_err(|e| format!("write external_ids.bin.tmp: {e}"))?;
+    write_via_dirfd(dir, &buf)
+}
+
+/// All sidecar filesystem operations run relative to a directory descriptor
+/// pinned BEFORE any byte is written (mirrors `khive-db`'s `walpin` sidecar
+/// write idiom). The caller's original path is walked `O_NOFOLLOW`; trusted
+/// ancestor symlinks are resolved from their pinned parent descriptors. The
+/// original final component is independently opened `O_NOFOLLOW` and
+/// identity-checked before the tmp file exists. The tmp entry is unlinked and
+/// re-created `O_EXCL | O_NOFOLLOW` relative to that descriptor.
+#[cfg(unix)]
+fn write_via_dirfd(dir: &std::path::Path, buf: &[u8]) -> Result<(), ExternalIdsWriteError> {
+    use std::io::Write as _;
+    use std::os::unix::io::{AsRawFd as _, FromRawFd as _};
+
+    let dir_file = open_dir_with_trusted_symlinks(dir)?;
+    verify_original_dir_identity(dir, &dir_file)?;
+    let dir_fd = dir_file.as_raw_fd();
+
+    const TMP_NAME: &std::ffi::CStr = c"external_ids.bin.tmp";
+
+    // SAFETY: both arguments are live for the call; `unlinkat` removes a
+    // planted symlink or stale tmp as a directory entry, never through it.
+    let rc = unsafe { libc::unlinkat(dir_fd, TMP_NAME.as_ptr(), 0) };
+    if rc != 0 {
+        let err = std::io::Error::last_os_error();
+        if err.raw_os_error() != Some(libc::ENOENT) {
+            return Err(ExternalIdsWriteError::io(
+                "remove stale external_ids.bin.tmp",
+                err,
+            ));
+        }
+    }
+
+    // SAFETY: the name and `dir_fd` are live for the call; the fd returned
+    // on success is uniquely owned and wrapped immediately below.
+    let tmp_fd = unsafe {
+        libc::openat(
+            dir_fd,
+            TMP_NAME.as_ptr(),
+            libc::O_WRONLY | libc::O_CREAT | libc::O_EXCL | libc::O_NOFOLLOW | libc::O_CLOEXEC,
+            0o644 as libc::c_uint,
+        )
+    };
+    if tmp_fd < 0 {
+        return Err(ExternalIdsWriteError::io(
+            "create external_ids.bin.tmp",
+            std::io::Error::last_os_error(),
+        ));
+    }
+    // SAFETY: `tmp_fd` was just returned by the successful `openat` above and
+    // is uniquely owned by this `File`, which closes it exactly once on drop.
+    let mut f = unsafe { std::fs::File::from_raw_fd(tmp_fd) };
+    f.write_all(buf)
+        .map_err(|e| ExternalIdsWriteError::io("write external_ids.bin.tmp", e))?;
     f.sync_all()
-        .map_err(|e| format!("sync external_ids.bin.tmp: {e}"))?;
+        .map_err(|e| ExternalIdsWriteError::io("sync external_ids.bin.tmp", e))?;
     drop(f);
-    std::fs::rename(&tmp_path, &final_path)
-        .map_err(|e| format!("rename external_ids.bin.tmp -> external_ids.bin: {e}"))
+
+    // SAFETY: both names are NUL-terminated C strings; `dir_fd` is a live,
+    // open directory descriptor for the call's duration, and the rename is
+    // performed relative to it rather than a re-resolved path.
+    let rc = unsafe {
+        libc::renameat(
+            dir_fd,
+            TMP_NAME.as_ptr(),
+            dir_fd,
+            c"external_ids.bin".as_ptr(),
+        )
+    };
+    if rc != 0 {
+        return Err(ExternalIdsWriteError::io(
+            "rename external_ids.bin.tmp -> external_ids.bin",
+            std::io::Error::last_os_error(),
+        ));
+    }
+
+    dir_file
+        .sync_all()
+        .map_err(|e| ExternalIdsWriteError::io("sync segment dir", e))
+}
+
+#[cfg(unix)]
+fn verify_original_dir_identity(
+    dir: &std::path::Path,
+    canonical_dir: &std::fs::File,
+) -> Result<(), ExternalIdsWriteError> {
+    use std::os::unix::ffi::OsStrExt as _;
+    use std::os::unix::fs::MetadataExt as _;
+    use std::os::unix::io::FromRawFd as _;
+
+    let c_dir = std::ffi::CString::new(dir.as_os_str().as_bytes()).map_err(|e| {
+        ExternalIdsWriteError::InvalidPath {
+            context: "segment dir path",
+            detail: e.to_string(),
+        }
+    })?;
+    // SAFETY: `c_dir` is NUL-terminated for the call; the returned fd is
+    // uniquely owned and wrapped immediately below.
+    let original_fd = unsafe {
+        libc::open(
+            c_dir.as_ptr(),
+            libc::O_RDONLY | libc::O_DIRECTORY | libc::O_NOFOLLOW | libc::O_CLOEXEC,
+        )
+    };
+    if original_fd < 0 {
+        return Err(ExternalIdsWriteError::io(
+            "open original segment dir without following final component",
+            std::io::Error::last_os_error(),
+        ));
+    }
+    // SAFETY: `original_fd` was returned by the successful `open` above and
+    // is uniquely owned by this `File`.
+    let original_dir = unsafe { std::fs::File::from_raw_fd(original_fd) };
+    let original_meta = original_dir
+        .metadata()
+        .map_err(|e| ExternalIdsWriteError::io("stat original segment dir", e))?;
+    let canonical_meta = canonical_dir
+        .metadata()
+        .map_err(|e| ExternalIdsWriteError::io("stat canonical segment dir", e))?;
+    if original_meta.dev() != canonical_meta.dev() || original_meta.ino() != canonical_meta.ino() {
+        return Err(ExternalIdsWriteError::DirectoryIdentityChanged);
+    }
+
+    Ok(())
+}
+
+#[cfg(unix)]
+fn open_dir_with_trusted_symlinks(
+    dir: &std::path::Path,
+) -> Result<std::fs::File, ExternalIdsWriteError> {
+    use std::os::unix::ffi::OsStrExt as _;
+    use std::os::unix::fs::MetadataExt as _;
+    use std::os::unix::io::AsRawFd as _;
+
+    if dir.as_os_str().is_empty() {
+        return Err(ExternalIdsWriteError::InvalidPath {
+            context: "open segment dir",
+            detail: "empty path".into(),
+        });
+    }
+
+    let mut pending = owned_components(dir)?;
+    let mut current = open_start_directory(dir.is_absolute())?;
+    let effective_uid = unsafe { libc::geteuid() } as u32;
+    let mut followed_symlinks = 0usize;
+
+    while let Some(component) = pending.pop_front() {
+        let name = std::ffi::CString::new(component.as_bytes()).map_err(|e| {
+            ExternalIdsWriteError::InvalidPath {
+                context: "segment dir path component",
+                detail: e.to_string(),
+            }
+        })?;
+        match open_directory_at(current.as_raw_fd(), &name) {
+            Ok(next) => current = next,
+            Err(open_error) => {
+                let link_meta = metadata_at_no_follow(current.as_raw_fd(), &name)?;
+                if link_meta.st_mode & libc::S_IFMT != libc::S_IFLNK {
+                    return Err(ExternalIdsWriteError::io(
+                        format!("open segment dir component {component:?}"),
+                        open_error,
+                    ));
+                }
+                if pending.is_empty() {
+                    return Err(ExternalIdsWriteError::InvalidPath {
+                        context: "open segment dir",
+                        detail: "final component is a symlink".into(),
+                    });
+                }
+
+                let parent_meta = current
+                    .metadata()
+                    .map_err(|e| ExternalIdsWriteError::io("stat symlink parent", e))?;
+                let symlink_uid = link_meta.st_uid;
+                let parent_uid = parent_meta.uid();
+                let parent_mode = parent_meta.mode();
+                if !trusted_ancestor_symlink(symlink_uid, parent_uid, parent_mode, effective_uid) {
+                    return Err(ExternalIdsWriteError::UntrustedAncestorSymlink {
+                        component,
+                        symlink_uid,
+                        parent_uid,
+                        parent_mode,
+                    });
+                }
+
+                followed_symlinks += 1;
+                if followed_symlinks > 40 {
+                    return Err(ExternalIdsWriteError::InvalidPath {
+                        context: "open segment dir",
+                        detail: "too many ancestor symlinks".into(),
+                    });
+                }
+                let target = read_link_at(current.as_raw_fd(), &name, link_meta.st_size)?;
+                let target_is_absolute = target.is_absolute();
+                let mut target_components = owned_components(&target)?;
+                target_components.append(&mut pending);
+                pending = target_components;
+                if target_is_absolute {
+                    current = open_start_directory(true)?;
+                }
+            }
+        }
+    }
+
+    Ok(current)
+}
+
+#[cfg(unix)]
+fn owned_components(
+    path: &std::path::Path,
+) -> Result<std::collections::VecDeque<std::ffi::OsString>, ExternalIdsWriteError> {
+    let mut components = std::collections::VecDeque::new();
+    for component in path.components() {
+        match component {
+            std::path::Component::RootDir | std::path::Component::CurDir => {}
+            std::path::Component::ParentDir | std::path::Component::Normal(_) => {
+                components.push_back(component.as_os_str().to_os_string());
+            }
+            std::path::Component::Prefix(_) => {
+                return Err(ExternalIdsWriteError::InvalidPath {
+                    context: "open segment dir",
+                    detail: "unsupported path prefix".into(),
+                });
+            }
+        }
+    }
+    Ok(components)
+}
+
+#[cfg(unix)]
+fn open_start_directory(absolute: bool) -> Result<std::fs::File, ExternalIdsWriteError> {
+    use std::os::unix::io::FromRawFd as _;
+
+    let start = if absolute { c"/" } else { c"." };
+    // SAFETY: `start` is NUL-terminated; a successful fd is uniquely owned.
+    let fd = unsafe {
+        libc::open(
+            start.as_ptr(),
+            libc::O_RDONLY | libc::O_DIRECTORY | libc::O_NOFOLLOW | libc::O_CLOEXEC,
+        )
+    };
+    if fd < 0 {
+        return Err(ExternalIdsWriteError::io(
+            "open segment dir root",
+            std::io::Error::last_os_error(),
+        ));
+    }
+    // SAFETY: `fd` is newly returned and transferred exactly once.
+    Ok(unsafe { std::fs::File::from_raw_fd(fd) })
+}
+
+#[cfg(unix)]
+fn open_directory_at(
+    parent_fd: std::os::unix::io::RawFd,
+    name: &std::ffi::CStr,
+) -> Result<std::fs::File, std::io::Error> {
+    use std::os::unix::io::FromRawFd as _;
+
+    // SAFETY: `name` and `parent_fd` are live; a successful fd is uniquely owned.
+    let fd = unsafe {
+        libc::openat(
+            parent_fd,
+            name.as_ptr(),
+            libc::O_RDONLY | libc::O_DIRECTORY | libc::O_NOFOLLOW | libc::O_CLOEXEC,
+        )
+    };
+    if fd < 0 {
+        return Err(std::io::Error::last_os_error());
+    }
+    // SAFETY: `fd` is newly returned and transferred exactly once.
+    Ok(unsafe { std::fs::File::from_raw_fd(fd) })
+}
+
+#[cfg(unix)]
+fn metadata_at_no_follow(
+    parent_fd: std::os::unix::io::RawFd,
+    name: &std::ffi::CStr,
+) -> Result<libc::stat, ExternalIdsWriteError> {
+    let mut metadata = std::mem::MaybeUninit::<libc::stat>::uninit();
+    // SAFETY: `metadata` is writable and both lookup arguments are live.
+    let rc = unsafe {
+        libc::fstatat(
+            parent_fd,
+            name.as_ptr(),
+            metadata.as_mut_ptr(),
+            libc::AT_SYMLINK_NOFOLLOW,
+        )
+    };
+    if rc != 0 {
+        return Err(ExternalIdsWriteError::io(
+            "inspect segment dir component without following symlink",
+            std::io::Error::last_os_error(),
+        ));
+    }
+    // SAFETY: successful `fstatat` initialized the output structure.
+    Ok(unsafe { metadata.assume_init() })
+}
+
+#[cfg(unix)]
+fn read_link_at(
+    parent_fd: std::os::unix::io::RawFd,
+    name: &std::ffi::CStr,
+    size_hint: libc::off_t,
+) -> Result<std::path::PathBuf, ExternalIdsWriteError> {
+    use std::os::unix::ffi::OsStringExt as _;
+
+    let hinted = usize::try_from(size_hint).unwrap_or(0).saturating_add(1);
+    let mut capacity = hinted.clamp(256, 65_536);
+    loop {
+        let mut bytes = vec![0u8; capacity];
+        // SAFETY: the buffer is writable and the lookup arguments are live.
+        let len = unsafe {
+            libc::readlinkat(
+                parent_fd,
+                name.as_ptr(),
+                bytes.as_mut_ptr().cast(),
+                bytes.len(),
+            )
+        };
+        if len < 0 {
+            return Err(ExternalIdsWriteError::io(
+                "read trusted ancestor symlink",
+                std::io::Error::last_os_error(),
+            ));
+        }
+        let len = len as usize;
+        if len < bytes.len() {
+            bytes.truncate(len);
+            return Ok(std::ffi::OsString::from_vec(bytes).into());
+        }
+        if capacity == 65_536 {
+            return Err(ExternalIdsWriteError::InvalidPath {
+                context: "open segment dir",
+                detail: "ancestor symlink target is too long".into(),
+            });
+        }
+        capacity = (capacity * 2).min(65_536);
+    }
+}
+
+#[cfg(unix)]
+fn trusted_ancestor_symlink(
+    symlink_uid: u32,
+    parent_uid: u32,
+    parent_mode: u32,
+    effective_uid: u32,
+) -> bool {
+    let owner_is_trusted = |uid| uid == 0 || uid == effective_uid;
+    owner_is_trusted(symlink_uid) && owner_is_trusted(parent_uid) && parent_mode & 0o022 == 0
+}
+
+#[cfg(any(windows, test))]
+const WINDOWS_FILE_ATTRIBUTE_DIRECTORY: u32 = 0x10;
+#[cfg(any(windows, test))]
+const WINDOWS_FILE_ATTRIBUTE_REPARSE_POINT: u32 = 0x400;
+
+#[cfg(any(windows, test))]
+fn windows_attribute_tag_is_acceptable(
+    file_attributes: u32,
+    reparse_tag: u32,
+    require_directory: bool,
+) -> bool {
+    let is_directory = file_attributes & WINDOWS_FILE_ATTRIBUTE_DIRECTORY != 0;
+    let is_reparse = file_attributes & WINDOWS_FILE_ATTRIBUTE_REPARSE_POINT != 0;
+    is_directory == require_directory && !is_reparse && reparse_tag == 0
+}
+
+#[cfg(any(windows, test))]
+fn windows_final_path_matches(expected: &[u16], opened: &[u16]) -> bool {
+    expected == opened
+}
+
+#[cfg(any(not(unix), test))]
+fn ensure_not_symlink_or_reparse(
+    path: &std::path::Path,
+    context: &'static str,
+) -> Result<Option<std::fs::Metadata>, ExternalIdsWriteError> {
+    match std::fs::symlink_metadata(path) {
+        Ok(metadata) if metadata_is_symlink_or_reparse(&metadata) => {
+            Err(ExternalIdsWriteError::InvalidPath {
+                context,
+                detail: "path is a symlink or reparse point".into(),
+            })
+        }
+        Ok(metadata) => Ok(Some(metadata)),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(None),
+        Err(error) => Err(ExternalIdsWriteError::io(context, error)),
+    }
+}
+
+#[cfg(any(not(unix), test))]
+fn metadata_is_symlink_or_reparse(metadata: &std::fs::Metadata) -> bool {
+    if metadata.file_type().is_symlink() {
+        return true;
+    }
+    #[cfg(windows)]
+    {
+        use std::os::windows::fs::MetadataExt as _;
+        const FILE_ATTRIBUTE_REPARSE_POINT: u32 = 0x400;
+        metadata.file_attributes() & FILE_ATTRIBUTE_REPARSE_POINT != 0
+    }
+    #[cfg(not(windows))]
+    false
+}
+
+#[cfg(any(not(unix), test))]
+fn ensure_portable_ancestors_not_symlinks(
+    dir: &std::path::Path,
+    context: &'static str,
+) -> Result<(), ExternalIdsWriteError> {
+    const MAX_ANCESTORS: usize = 40;
+
+    let ancestors: Vec<_> = dir
+        .ancestors()
+        .skip(1)
+        .filter(|ancestor| !ancestor.as_os_str().is_empty())
+        .take(MAX_ANCESTORS + 1)
+        .collect();
+    if ancestors.len() > MAX_ANCESTORS {
+        return Err(ExternalIdsWriteError::InvalidPath {
+            context,
+            detail: format!("path has more than {MAX_ANCESTORS} ancestor components"),
+        });
+    }
+    for ancestor in ancestors.into_iter().rev() {
+        ensure_not_symlink_or_reparse(ancestor, context)?;
+    }
+    Ok(())
+}
+
+#[cfg(windows)]
+fn write_via_dirfd(dir: &std::path::Path, buf: &[u8]) -> Result<(), ExternalIdsWriteError> {
+    windows::write_via_dir_handle(dir, buf)
+}
+
+/// Targets without Unix or Windows handle-relative facilities use this
+/// best-effort path fallback. It rejects pre-existing symlink entries, but a
+/// component can still be replaced between validation and path-based mutation.
+#[cfg(all(not(unix), not(windows)))]
+fn write_via_dirfd(dir: &std::path::Path, buf: &[u8]) -> Result<(), ExternalIdsWriteError> {
+    write_via_paths(dir, buf)
+}
+
+#[cfg(any(all(not(unix), not(windows)), test))]
+fn write_via_paths(dir: &std::path::Path, buf: &[u8]) -> Result<(), ExternalIdsWriteError> {
+    use std::io::Write as _;
+
+    ensure_portable_ancestors_not_symlinks(dir, "inspect segment dir ancestor")?;
+    let dir_metadata =
+        ensure_not_symlink_or_reparse(dir, "inspect segment dir")?.ok_or_else(|| {
+            ExternalIdsWriteError::io(
+                "inspect segment dir",
+                std::io::Error::new(std::io::ErrorKind::NotFound, "segment dir does not exist"),
+            )
+        })?;
+    if !dir_metadata.is_dir() {
+        return Err(ExternalIdsWriteError::InvalidPath {
+            context: "inspect segment dir",
+            detail: "path is not a directory".into(),
+        });
+    }
+
+    let tmp_path = dir.join("external_ids.bin.tmp");
+    let final_path = dir.join("external_ids.bin");
+    let stale_tmp = ensure_not_symlink_or_reparse(&tmp_path, "inspect external_ids.bin.tmp")?;
+    ensure_not_symlink_or_reparse(&final_path, "inspect external_ids.bin")?;
+    if stale_tmp.is_some() {
+        std::fs::remove_file(&tmp_path)
+            .map_err(|e| ExternalIdsWriteError::io("remove stale external_ids.bin.tmp", e))?;
+    }
+
+    let mut file = std::fs::OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(&tmp_path)
+        .map_err(|e| ExternalIdsWriteError::io("create external_ids.bin.tmp", e))?;
+    file.write_all(buf)
+        .map_err(|e| ExternalIdsWriteError::io("write external_ids.bin.tmp", e))?;
+    file.sync_all()
+        .map_err(|e| ExternalIdsWriteError::io("sync external_ids.bin.tmp", e))?;
+    drop(file);
+
+    ensure_portable_ancestors_not_symlinks(dir, "reinspect segment dir ancestor")?;
+    ensure_not_symlink_or_reparse(dir, "reinspect segment dir")?;
+    ensure_not_symlink_or_reparse(&tmp_path, "reinspect external_ids.bin.tmp")?;
+    ensure_not_symlink_or_reparse(&final_path, "reinspect external_ids.bin")?;
+    std::fs::rename(&tmp_path, &final_path).map_err(|e| {
+        ExternalIdsWriteError::io("rename external_ids.bin.tmp -> external_ids.bin", e)
+    })
 }
 
 /// Read `dir/external_ids.bin` and return `(commit_digest, ids)`.
@@ -130,9 +663,41 @@ pub fn read_external_ids_sidecar(dir: &std::path::Path) -> Result<([u8; 32], Vec
 mod tests {
     use super::*;
 
+    fn tempdir() -> tempfile::TempDir {
+        let root = std::fs::canonicalize(std::env::temp_dir()).expect("canonical temp root");
+        tempfile::tempdir_in(root).expect("tempdir")
+    }
+
+    #[test]
+    fn windows_attribute_tag_acceptance_requires_expected_kind_without_reparse_data() {
+        const DIRECTORY: u32 = 0x10;
+        const REPARSE_POINT: u32 = 0x400;
+
+        assert!(windows_attribute_tag_is_acceptable(DIRECTORY, 0, true));
+        assert!(windows_attribute_tag_is_acceptable(0, 0, false));
+        assert!(!windows_attribute_tag_is_acceptable(0, 0, true));
+        assert!(!windows_attribute_tag_is_acceptable(DIRECTORY, 0, false));
+        assert!(!windows_attribute_tag_is_acceptable(
+            DIRECTORY | REPARSE_POINT,
+            0,
+            true
+        ));
+        assert!(!windows_attribute_tag_is_acceptable(DIRECTORY, 1, true));
+    }
+
+    #[test]
+    fn windows_final_path_comparison_requires_exact_handle_resolution() {
+        let expected: Vec<u16> = r"\\?\C:\segments\active".encode_utf16().collect();
+        let same: Vec<u16> = r"\\?\C:\segments\active".encode_utf16().collect();
+        let redirected: Vec<u16> = r"\\?\C:\attacker\active".encode_utf16().collect();
+
+        assert!(windows_final_path_matches(&expected, &same));
+        assert!(!windows_final_path_matches(&expected, &redirected));
+    }
+
     #[test]
     fn sidecar_round_trip() {
-        let dir = tempfile::tempdir().expect("tempdir");
+        let dir = tempdir();
         let digest = [7u8; 32];
         let ids: Vec<Uuid> = (0..5).map(|_| Uuid::new_v4()).collect();
         write_external_ids_sidecar(dir.path(), &digest, &ids).expect("write");
@@ -143,7 +708,7 @@ mod tests {
 
     #[test]
     fn sidecar_rejects_truncation() {
-        let dir = tempfile::tempdir().expect("tempdir");
+        let dir = tempdir();
         let ids: Vec<Uuid> = (0..3).map(|_| Uuid::new_v4()).collect();
         write_external_ids_sidecar(dir.path(), &[0u8; 32], &ids).expect("write");
         let path = dir.path().join("external_ids.bin");
@@ -154,7 +719,7 @@ mod tests {
 
     #[test]
     fn sidecar_rejects_overflowing_count() {
-        let dir = tempfile::tempdir().expect("tempdir");
+        let dir = tempdir();
         write_external_ids_sidecar(dir.path(), &[0u8; 32], &[]).expect("write");
         let path = dir.path().join("external_ids.bin");
         let mut bytes = std::fs::read(&path).expect("read back");
@@ -171,7 +736,7 @@ mod tests {
 
     #[test]
     fn sidecar_rejects_flipped_id_byte() {
-        let dir = tempfile::tempdir().expect("tempdir");
+        let dir = tempdir();
         let ids: Vec<Uuid> = (0..4).map(|_| Uuid::new_v4()).collect();
         write_external_ids_sidecar(dir.path(), &[0u8; 32], &ids).expect("write");
         let path = dir.path().join("external_ids.bin");
@@ -184,8 +749,234 @@ mod tests {
     }
 
     #[test]
+    #[cfg(unix)]
+    fn write_external_ids_sidecar_refuses_symlinked_tmp_path() {
+        let segment_dir = tempdir();
+        let victim_dir = tempdir();
+        let victim_path = victim_dir.path().join("victim.bin");
+        std::fs::write(&victim_path, b"precious").expect("write victim");
+
+        let tmp_path = segment_dir.path().join("external_ids.bin.tmp");
+        std::os::unix::fs::symlink(&victim_path, &tmp_path).expect("symlink tmp path");
+
+        let digest = [9u8; 32];
+        let ids: Vec<Uuid> = (0..3).map(|_| Uuid::new_v4()).collect();
+        write_external_ids_sidecar(segment_dir.path(), &digest, &ids)
+            .expect("write must succeed despite the planted symlink");
+
+        assert_eq!(
+            std::fs::read(&victim_path).expect("victim readable"),
+            b"precious",
+            "the symlink target must never be written through"
+        );
+
+        let (read_digest, read_ids) =
+            read_external_ids_sidecar(segment_dir.path()).expect("sidecar must be readable");
+        assert_eq!(read_digest, digest);
+        assert_eq!(read_ids, ids);
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn write_external_ids_sidecar_refuses_symlinked_segment_dir() {
+        let victim_dir = tempdir();
+        let link_parent = tempdir();
+        let dir_link = link_parent.path().join("segment");
+        std::os::unix::fs::symlink(victim_dir.path(), &dir_link).expect("symlink segment dir");
+
+        let digest = [7u8; 32];
+        let ids: Vec<Uuid> = (0..2).map(|_| Uuid::new_v4()).collect();
+        let err = write_external_ids_sidecar(&dir_link, &digest, &ids)
+            .expect_err("a symlinked segment dir must refuse before any byte is written");
+        assert!(err.to_string().contains("segment dir"), "got: {err}");
+
+        assert!(
+            !victim_dir.path().join("external_ids.bin.tmp").exists()
+                && !victim_dir.path().join("external_ids.bin").exists(),
+            "nothing may be written through the segment-dir symlink"
+        );
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn write_external_ids_sidecar_accepts_symlinked_ancestor() {
+        let real_parent = tempdir();
+        let real_segment = real_parent.path().join("segment");
+        std::fs::create_dir(&real_segment).expect("create real segment dir");
+
+        let link_parent = tempdir();
+        let parent_link = link_parent.path().join("parent");
+        std::os::unix::fs::symlink(real_parent.path(), &parent_link).expect("symlink ancestor");
+        let via_ancestor = parent_link.join("segment");
+
+        let digest = [5u8; 32];
+        let ids: Vec<Uuid> = (0..2).map(|_| Uuid::new_v4()).collect();
+        write_external_ids_sidecar(&via_ancestor, &digest, &ids)
+            .expect("a legitimate symlinked ancestor must be canonicalized");
+
+        let (read_digest, read_ids) =
+            read_external_ids_sidecar(&real_segment).expect("sidecar lands in canonical dir");
+        assert_eq!(read_digest, digest);
+        assert_eq!(read_ids, ids);
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn write_external_ids_sidecar_refuses_symlink_in_world_writable_parent() {
+        use std::os::unix::fs::PermissionsExt as _;
+
+        let real_parent = tempdir();
+        let real_segment = real_parent.path().join("segment");
+        std::fs::create_dir(&real_segment).expect("create real segment dir");
+
+        let link_parent = tempdir();
+        std::fs::set_permissions(link_parent.path(), std::fs::Permissions::from_mode(0o777))
+            .expect("make symlink parent world-writable");
+        let parent_link = link_parent.path().join("parent");
+        std::os::unix::fs::symlink(real_parent.path(), &parent_link).expect("symlink ancestor");
+
+        let err = write_external_ids_sidecar(&parent_link.join("segment"), &[3u8; 32], &[])
+            .expect_err("a symlink in a world-writable parent must be refused");
+        assert!(
+            err.to_string().contains("untrusted ancestor symlink"),
+            "got: {err}"
+        );
+        assert!(
+            !real_segment.join("external_ids.bin.tmp").exists()
+                && !real_segment.join("external_ids.bin").exists(),
+            "nothing may be written through the untrusted ancestor symlink"
+        );
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn ancestor_symlink_trust_requires_safe_owners_and_parent_mode() {
+        let effective_uid = unsafe { libc::geteuid() } as u32;
+        let foreign_uid = if effective_uid == 1 { 2 } else { 1 };
+
+        assert!(trusted_ancestor_symlink(
+            effective_uid,
+            effective_uid,
+            0o40700,
+            effective_uid
+        ));
+        assert!(trusted_ancestor_symlink(
+            0,
+            effective_uid,
+            0o40755,
+            effective_uid
+        ));
+        assert!(!trusted_ancestor_symlink(
+            foreign_uid,
+            effective_uid,
+            0o40700,
+            effective_uid
+        ));
+        assert!(!trusted_ancestor_symlink(
+            effective_uid,
+            foreign_uid,
+            0o40700,
+            effective_uid
+        ));
+        assert!(!trusted_ancestor_symlink(
+            effective_uid,
+            effective_uid,
+            0o40722,
+            effective_uid
+        ));
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn portable_path_check_refuses_symlink() {
+        let dir = tempdir();
+        let target = dir.path().join("target");
+        let link = dir.path().join("link");
+        std::fs::write(&target, b"target").expect("write target");
+        std::os::unix::fs::symlink(&target, &link).expect("create symlink");
+
+        ensure_not_symlink_or_reparse(&target, "inspect target").expect("regular path must pass");
+        let err = ensure_not_symlink_or_reparse(&link, "inspect link")
+            .expect_err("portable check must refuse a symlink");
+        assert!(matches!(err, ExternalIdsWriteError::InvalidPath { .. }));
+    }
+
+    #[test]
+    fn portable_writer_round_trips_bytes() {
+        let dir = tempdir();
+        write_via_paths(dir.path(), b"sidecar").expect("portable write");
+        assert_eq!(
+            std::fs::read(dir.path().join("external_ids.bin")).expect("read sidecar"),
+            b"sidecar"
+        );
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn portable_writer_refuses_symlinked_sidecar_paths() {
+        let victim_dir = tempdir();
+        let victim = victim_dir.path().join("victim");
+        std::fs::write(&victim, b"precious").expect("write victim");
+
+        for sidecar_name in ["external_ids.bin.tmp", "external_ids.bin"] {
+            let segment_dir = tempdir();
+            std::os::unix::fs::symlink(&victim, segment_dir.path().join(sidecar_name))
+                .expect("create sidecar symlink");
+            let err = write_via_paths(segment_dir.path(), b"replacement")
+                .expect_err("portable writer must refuse sidecar symlinks");
+            assert!(matches!(err, ExternalIdsWriteError::InvalidPath { .. }));
+            assert_eq!(std::fs::read(&victim).expect("read victim"), b"precious");
+        }
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn portable_writer_refuses_symlinked_segment_dir() {
+        let real_dir = tempdir();
+        let link_parent = tempdir();
+        let segment_link = link_parent.path().join("segment");
+        std::os::unix::fs::symlink(real_dir.path(), &segment_link).expect("create segment symlink");
+
+        let err = write_via_paths(&segment_link, b"sidecar")
+            .expect_err("portable writer must refuse a symlinked segment dir");
+        assert!(matches!(err, ExternalIdsWriteError::InvalidPath { .. }));
+        assert!(!real_dir.path().join("external_ids.bin").exists());
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn portable_writer_refuses_symlinked_ancestor() {
+        let real_parent = tempdir();
+        let real_segment = real_parent.path().join("regular").join("segment");
+        std::fs::create_dir_all(&real_segment).expect("create real segment dir");
+
+        let link_parent = tempdir();
+        let ancestor_link = link_parent.path().join("ancestor");
+        std::os::unix::fs::symlink(real_parent.path(), &ancestor_link)
+            .expect("create ancestor symlink");
+
+        let err = write_via_paths(&ancestor_link.join("regular").join("segment"), b"sidecar")
+            .expect_err("portable writer must refuse a symlinked ancestor");
+        assert!(matches!(err, ExternalIdsWriteError::InvalidPath { .. }));
+        assert!(!real_segment.join("external_ids.bin").exists());
+    }
+
+    #[test]
+    fn portable_writer_accepts_regular_ancestor_chain() {
+        let root = tempdir();
+        let segment_dir = root.path().join("one").join("two").join("segment");
+        std::fs::create_dir_all(&segment_dir).expect("create regular ancestor chain");
+
+        write_via_paths(&segment_dir, b"sidecar").expect("portable write");
+        assert_eq!(
+            std::fs::read(segment_dir.join("external_ids.bin")).expect("read sidecar"),
+            b"sidecar"
+        );
+    }
+
+    #[test]
     fn segment_commit_digest_absent_and_present() {
-        let dir = tempfile::tempdir().expect("tempdir");
+        let dir = tempdir();
         assert_eq!(segment_commit_digest(dir.path()).expect("absent ok"), None);
         std::fs::write(dir.path().join("metadata.bin"), b"commit-bytes").expect("write");
         let digest = segment_commit_digest(dir.path())

--- a/crates/khive-vamana/src/external_ids_windows.rs
+++ b/crates/khive-vamana/src/external_ids_windows.rs
@@ -1,0 +1,332 @@
+use super::{
+    ensure_not_symlink_or_reparse, ensure_portable_ancestors_not_symlinks,
+    windows_attribute_tag_is_acceptable, windows_final_path_matches, ExternalIdsWriteError,
+};
+use std::ffi::{c_void, OsStr};
+use std::io::Write as _;
+use std::os::windows::ffi::OsStrExt as _;
+use std::os::windows::io::{AsRawHandle as _, FromRawHandle as _};
+use std::path::Path;
+use windows_sys::Wdk::Foundation::OBJECT_ATTRIBUTES;
+use windows_sys::Wdk::Storage::FileSystem::{
+    NtCreateFile, FILE_CREATE, FILE_NON_DIRECTORY_FILE, FILE_OPEN, FILE_OPEN_REPARSE_POINT,
+    FILE_SYNCHRONOUS_IO_NONALERT,
+};
+use windows_sys::Win32::Foundation::{
+    RtlNtStatusToDosError, GENERIC_WRITE, HANDLE, INVALID_HANDLE_VALUE, OBJ_CASE_INSENSITIVE,
+    UNICODE_STRING,
+};
+use windows_sys::Win32::Storage::FileSystem::{
+    CreateFileW, FileAttributeTagInfo, FileDispositionInfo, FileRenameInfoEx,
+    GetFileInformationByHandleEx, GetFinalPathNameByHandleW, SetFileInformationByHandle, DELETE,
+    FILE_ATTRIBUTE_NORMAL, FILE_ATTRIBUTE_TAG_INFO, FILE_DISPOSITION_INFO,
+    FILE_FLAG_BACKUP_SEMANTICS, FILE_FLAG_OPEN_REPARSE_POINT, FILE_NAME_NORMALIZED,
+    FILE_READ_ATTRIBUTES, FILE_RENAME_INFO, FILE_RENAME_INFO_0, FILE_SHARE_DELETE, FILE_SHARE_READ,
+    FILE_SHARE_WRITE, OPEN_EXISTING, SYNCHRONIZE, VOLUME_NAME_DOS,
+};
+use windows_sys::Win32::System::WindowsProgramming::{
+    FILE_RENAME_FLAG_POSIX_SEMANTICS, FILE_RENAME_FLAG_REPLACE_IF_EXISTS,
+};
+use windows_sys::Win32::System::IO::IO_STATUS_BLOCK;
+
+const TMP_NAME: &str = "external_ids.bin.tmp";
+const FINAL_NAME: &str = "external_ids.bin";
+
+#[cfg(test)]
+#[path = "external_ids_windows_tests.rs"]
+mod tests;
+
+pub(super) fn write_via_dir_handle(dir: &Path, buf: &[u8]) -> Result<(), ExternalIdsWriteError> {
+    write_via_dir_handle_with(dir, buf, rename_relative)
+}
+
+fn write_via_dir_handle_with(
+    dir: &Path,
+    buf: &[u8],
+    rename: impl FnOnce(&std::fs::File, &std::fs::File, &str) -> std::io::Result<()>,
+) -> Result<(), ExternalIdsWriteError> {
+    lexical_prefilter(dir)?;
+    let expected = std::fs::canonicalize(dir)
+        .map_err(|error| ExternalIdsWriteError::io("canonicalize segment dir", error))?;
+    let expected_wide: Vec<u16> = expected.as_os_str().encode_wide().collect();
+    lexical_prefilter(dir)?;
+
+    let dir_file = open_directory(dir)?;
+    verify_handle_kind(&dir_file, true, "inspect opened segment dir")?;
+    let opened_path = final_path(&dir_file)?;
+    if !windows_final_path_matches(&expected_wide, &opened_path) {
+        return Err(ExternalIdsWriteError::DirectoryIdentityChanged);
+    }
+
+    remove_relative_if_exists(&dir_file, TMP_NAME, "remove stale external_ids.bin.tmp")?;
+    let mut tmp_file = open_relative(
+        &dir_file,
+        TMP_NAME,
+        GENERIC_WRITE | DELETE | FILE_READ_ATTRIBUTES | SYNCHRONIZE,
+        FILE_CREATE,
+    )
+    .map_err(|error| ExternalIdsWriteError::io("create external_ids.bin.tmp", error))?;
+    verify_handle_kind(&tmp_file, false, "inspect created external_ids.bin.tmp")?;
+    tmp_file
+        .write_all(buf)
+        .map_err(|error| ExternalIdsWriteError::io("write external_ids.bin.tmp", error))?;
+    tmp_file
+        .sync_all()
+        .map_err(|error| ExternalIdsWriteError::io("sync external_ids.bin.tmp", error))?;
+
+    rename(&tmp_file, &dir_file, FINAL_NAME).map_err(|error| {
+        ExternalIdsWriteError::io("rename external_ids.bin.tmp -> external_ids.bin", error)
+    })
+}
+
+fn lexical_prefilter(dir: &Path) -> Result<(), ExternalIdsWriteError> {
+    ensure_portable_ancestors_not_symlinks(dir, "inspect segment dir ancestor")?;
+    let metadata = ensure_not_symlink_or_reparse(dir, "inspect segment dir")?.ok_or_else(|| {
+        ExternalIdsWriteError::io(
+            "inspect segment dir",
+            std::io::Error::new(std::io::ErrorKind::NotFound, "segment dir does not exist"),
+        )
+    })?;
+    if !metadata.is_dir() {
+        return Err(ExternalIdsWriteError::InvalidPath {
+            context: "inspect segment dir",
+            detail: "path is not a directory".into(),
+        });
+    }
+    ensure_not_symlink_or_reparse(&dir.join(TMP_NAME), "inspect external_ids.bin.tmp")?;
+    ensure_not_symlink_or_reparse(&dir.join(FINAL_NAME), "inspect external_ids.bin")?;
+    Ok(())
+}
+
+fn open_directory(dir: &Path) -> Result<std::fs::File, ExternalIdsWriteError> {
+    let wide = nul_terminated(dir.as_os_str(), "segment dir path")?;
+    // SAFETY: `wide` is NUL-terminated and live for the call. A successful
+    // handle is uniquely transferred into `File` below.
+    let handle = unsafe {
+        CreateFileW(
+            wide.as_ptr(),
+            FILE_READ_ATTRIBUTES,
+            FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
+            std::ptr::null(),
+            OPEN_EXISTING,
+            FILE_FLAG_BACKUP_SEMANTICS | FILE_FLAG_OPEN_REPARSE_POINT,
+            std::ptr::null_mut(),
+        )
+    };
+    if handle == INVALID_HANDLE_VALUE {
+        return Err(ExternalIdsWriteError::io(
+            "open segment dir without following reparse point",
+            std::io::Error::last_os_error(),
+        ));
+    }
+    // SAFETY: `handle` is newly returned and transferred exactly once.
+    Ok(unsafe { std::fs::File::from_raw_handle(handle) })
+}
+
+fn nul_terminated(value: &OsStr, context: &'static str) -> Result<Vec<u16>, ExternalIdsWriteError> {
+    let mut wide: Vec<u16> = value.encode_wide().collect();
+    if wide.contains(&0) {
+        return Err(ExternalIdsWriteError::InvalidPath {
+            context,
+            detail: "path contains an interior NUL".into(),
+        });
+    }
+    wide.push(0);
+    Ok(wide)
+}
+
+fn verify_handle_kind(
+    file: &std::fs::File,
+    require_directory: bool,
+    context: &'static str,
+) -> Result<(), ExternalIdsWriteError> {
+    let mut info = FILE_ATTRIBUTE_TAG_INFO::default();
+    // SAFETY: the handle is live and `info` is a correctly sized writable
+    // buffer for `FileAttributeTagInfo`.
+    let ok = unsafe {
+        GetFileInformationByHandleEx(
+            file.as_raw_handle(),
+            FileAttributeTagInfo,
+            (&raw mut info).cast(),
+            std::mem::size_of::<FILE_ATTRIBUTE_TAG_INFO>() as u32,
+        )
+    };
+    if ok == 0 {
+        return Err(ExternalIdsWriteError::io(
+            context,
+            std::io::Error::last_os_error(),
+        ));
+    }
+    if !windows_attribute_tag_is_acceptable(info.FileAttributes, info.ReparseTag, require_directory)
+    {
+        return Err(ExternalIdsWriteError::InvalidPath {
+            context,
+            detail: "opened handle has the wrong kind or is a reparse point".into(),
+        });
+    }
+    Ok(())
+}
+
+fn final_path(file: &std::fs::File) -> Result<Vec<u16>, ExternalIdsWriteError> {
+    let mut path = vec![0u16; 260];
+    loop {
+        // SAFETY: the handle is live and `path` exposes a writable buffer of
+        // the supplied length.
+        let length = unsafe {
+            GetFinalPathNameByHandleW(
+                file.as_raw_handle(),
+                path.as_mut_ptr(),
+                path.len() as u32,
+                FILE_NAME_NORMALIZED | VOLUME_NAME_DOS,
+            )
+        };
+        if length == 0 {
+            return Err(ExternalIdsWriteError::io(
+                "resolve opened segment dir",
+                std::io::Error::last_os_error(),
+            ));
+        }
+        let length = length as usize;
+        if length < path.len() {
+            path.truncate(length);
+            return Ok(path);
+        }
+        path.resize(length.saturating_add(1), 0);
+    }
+}
+
+fn open_relative(
+    dir: &std::fs::File,
+    name: &str,
+    desired_access: u32,
+    create_disposition: u32,
+) -> std::io::Result<std::fs::File> {
+    let mut wide: Vec<u16> = OsStr::new(name).encode_wide().collect();
+    let byte_len = wide
+        .len()
+        .checked_mul(std::mem::size_of::<u16>())
+        .and_then(|length| u16::try_from(length).ok())
+        .ok_or_else(|| std::io::Error::from(std::io::ErrorKind::InvalidFilename))?;
+    let unicode_name = UNICODE_STRING {
+        Length: byte_len,
+        MaximumLength: byte_len,
+        Buffer: wide.as_mut_ptr(),
+    };
+    let attributes = OBJECT_ATTRIBUTES {
+        Length: std::mem::size_of::<OBJECT_ATTRIBUTES>() as u32,
+        RootDirectory: dir.as_raw_handle(),
+        ObjectName: &raw const unicode_name,
+        Attributes: OBJ_CASE_INSENSITIVE,
+        SecurityDescriptor: std::ptr::null(),
+        SecurityQualityOfService: std::ptr::null(),
+    };
+    let mut io_status = IO_STATUS_BLOCK::default();
+    let mut handle: HANDLE = std::ptr::null_mut();
+    // SAFETY: every input structure and name buffer is live for the call; the
+    // root handle is live, and a successful child handle is transferred below.
+    let status = unsafe {
+        NtCreateFile(
+            &raw mut handle,
+            desired_access,
+            &raw const attributes,
+            &raw mut io_status,
+            std::ptr::null(),
+            FILE_ATTRIBUTE_NORMAL,
+            FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
+            create_disposition,
+            FILE_NON_DIRECTORY_FILE | FILE_OPEN_REPARSE_POINT | FILE_SYNCHRONOUS_IO_NONALERT,
+            std::ptr::null(),
+            0,
+        )
+    };
+    if status < 0 {
+        // SAFETY: converting the returned failure status has no preconditions.
+        let error = unsafe { RtlNtStatusToDosError(status) };
+        return Err(std::io::Error::from_raw_os_error(error as i32));
+    }
+    // SAFETY: `handle` is newly returned and transferred exactly once.
+    Ok(unsafe { std::fs::File::from_raw_handle(handle) })
+}
+
+fn remove_relative_if_exists(
+    dir: &std::fs::File,
+    name: &str,
+    context: &'static str,
+) -> Result<(), ExternalIdsWriteError> {
+    let file = match open_relative(
+        dir,
+        name,
+        DELETE | FILE_READ_ATTRIBUTES | SYNCHRONIZE,
+        FILE_OPEN,
+    ) {
+        Ok(file) => file,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(error) => return Err(ExternalIdsWriteError::io(context, error)),
+    };
+    verify_handle_kind(&file, false, context)?;
+    let disposition = FILE_DISPOSITION_INFO { DeleteFile: true };
+    // SAFETY: the handle was opened with `DELETE`, and `disposition` is the
+    // correctly sized input for `FileDispositionInfo`.
+    let ok = unsafe {
+        SetFileInformationByHandle(
+            file.as_raw_handle(),
+            FileDispositionInfo,
+            (&raw const disposition).cast(),
+            std::mem::size_of::<FILE_DISPOSITION_INFO>() as u32,
+        )
+    };
+    if ok == 0 {
+        return Err(ExternalIdsWriteError::io(
+            context,
+            std::io::Error::last_os_error(),
+        ));
+    }
+    Ok(())
+}
+
+fn rename_relative(
+    file: &std::fs::File,
+    dir: &std::fs::File,
+    target_name: &str,
+) -> std::io::Result<()> {
+    let wide: Vec<u16> = OsStr::new(target_name).encode_wide().collect();
+    let name_bytes = wide
+        .len()
+        .checked_mul(std::mem::size_of::<u16>())
+        .and_then(|length| u32::try_from(length).ok())
+        .ok_or_else(|| std::io::Error::from(std::io::ErrorKind::InvalidFilename))?;
+    let header_size = std::mem::offset_of!(FILE_RENAME_INFO, FileName);
+    let total_size = header_size
+        .checked_add(name_bytes as usize)
+        .ok_or_else(|| std::io::Error::from(std::io::ErrorKind::FileTooLarge))?;
+    let mut storage = vec![0usize; total_size.div_ceil(std::mem::size_of::<usize>())];
+    let info = storage.as_mut_ptr().cast::<FILE_RENAME_INFO>();
+    // SAFETY: `storage` has the structure's alignment and enough bytes for
+    // the fixed header plus the complete relative target name.
+    unsafe {
+        (*info).Anonymous = FILE_RENAME_INFO_0 {
+            Flags: FILE_RENAME_FLAG_REPLACE_IF_EXISTS | FILE_RENAME_FLAG_POSIX_SEMANTICS,
+        };
+        (*info).RootDirectory = dir.as_raw_handle();
+        (*info).FileNameLength = name_bytes;
+        std::ptr::copy_nonoverlapping(
+            wide.as_ptr(),
+            (&raw mut (*info).FileName).cast::<u16>(),
+            wide.len(),
+        );
+    }
+    // SAFETY: both handles are live, the source was opened with `DELETE`, and
+    // `info` points at the initialized `total_size`-byte replacement input.
+    let ok = unsafe {
+        SetFileInformationByHandle(
+            file.as_raw_handle(),
+            FileRenameInfoEx,
+            info.cast::<c_void>(),
+            total_size as u32,
+        )
+    };
+    if ok == 0 {
+        return Err(std::io::Error::last_os_error());
+    }
+    Ok(())
+}

--- a/crates/khive-vamana/src/external_ids_windows_tests.rs
+++ b/crates/khive-vamana/src/external_ids_windows_tests.rs
@@ -1,0 +1,26 @@
+use super::{write_via_dir_handle_with, FINAL_NAME, TMP_NAME};
+
+#[test]
+fn rename_failure_preserves_original_sidecar() {
+    let segment_dir = tempfile::tempdir().expect("create temporary segment directory");
+    let original = b"last valid sidecar";
+    let replacement = b"replacement sidecar";
+    std::fs::write(segment_dir.path().join(FINAL_NAME), original).expect("write original sidecar");
+
+    let error = write_via_dir_handle_with(segment_dir.path(), replacement, |_, _, _| {
+        Err(std::io::Error::from(std::io::ErrorKind::PermissionDenied))
+    })
+    .expect_err("injected rename failure must be returned");
+
+    assert!(error
+        .to_string()
+        .starts_with("rename external_ids.bin.tmp -> external_ids.bin:"));
+    assert_eq!(
+        std::fs::read(segment_dir.path().join(FINAL_NAME)).expect("read original sidecar"),
+        original
+    );
+    assert_eq!(
+        std::fs::read(segment_dir.path().join(TMP_NAME)).expect("read temporary sidecar"),
+        replacement
+    );
+}

--- a/crates/khive-vamana/src/lib.rs
+++ b/crates/khive-vamana/src/lib.rs
@@ -13,6 +13,7 @@ pub use error::{Result, VamanaError};
 #[cfg(feature = "mmap")]
 pub use external_ids::{
     read_external_ids_sidecar, segment_commit_digest, write_external_ids_sidecar,
+    ExternalIdsWriteError,
 };
 pub use graph::{GreedySearchResult, VamanaGraph, VisitedSet};
 #[cfg(feature = "mmap")]

--- a/crates/kkernel/src/atomic_apply.rs
+++ b/crates/kkernel/src/atomic_apply.rs
@@ -554,15 +554,15 @@ async fn build_op_result(
         // unsafe to branch on at prepare time makes it unsafe to render
         // from too. This mirrors the `link` arm below exactly (same
         // reasoning, same `list_edges` mechanism).
-        ("update", AtomicOpPlan::Update(p)) if p.edge_natural_key.is_some() => {
-            let key = p.edge_natural_key.as_ref().expect("checked by guard above");
+        ("update", AtomicOpPlan::Update(p)) if p.edge_natural_key().is_some() => {
+            let key = p.edge_natural_key().expect("checked by guard above");
             let edges = runtime
                 .list_edges(
                     token,
                     EdgeListFilter {
-                        source_id: Some(key.canon_source_id),
-                        target_id: Some(key.canon_target_id),
-                        relations: vec![key.relation],
+                        source_id: Some(key.canon_source_id()),
+                        target_id: Some(key.canon_target_id()),
+                        relations: vec![key.relation()],
                         ..Default::default()
                     },
                     1,
@@ -573,15 +573,15 @@ async fn build_op_result(
                 anyhow::anyhow!(
                     "atomic update result: committed symmetric edge not found by natural key \
                      ({}, {}, {})",
-                    key.canon_source_id,
-                    key.canon_target_id,
-                    key.relation
+                    key.canon_source_id(),
+                    key.canon_target_id(),
+                    key.relation()
                 )
             })?;
             Ok(serde_json::to_value(&edge)?)
         }
         ("update", AtomicOpPlan::Update(p)) => match runtime
-            .resolve_by_id(token, p.target_id)
+            .resolve_by_id(token, p.target_id())
             .await?
         {
             Some(Resolved::Entity(entity)) => {
@@ -602,17 +602,20 @@ async fn build_op_result(
             // `updated_at` already serialize as RFC3339 via its own
             // `Serialize` impl).
             None => {
-                let edge = runtime.get_edge(token, p.target_id).await?.ok_or_else(|| {
-                    anyhow::anyhow!(
-                        "atomic update result: target {} not found post-commit",
-                        p.target_id
-                    )
-                })?;
+                let edge = runtime
+                    .get_edge(token, p.target_id())
+                    .await?
+                    .ok_or_else(|| {
+                        anyhow::anyhow!(
+                            "atomic update result: target {} not found post-commit",
+                            p.target_id()
+                        )
+                    })?;
                 Ok(serde_json::to_value(&edge)?)
             }
             _ => anyhow::bail!(
                 "atomic update result: target {} not found post-commit",
-                p.target_id
+                p.target_id()
             ),
         },
         // Canonical shape: `{"deleted": deleted, "id": p.id, "kind": p.kind}`
@@ -651,8 +654,8 @@ async fn build_op_result(
                 .list_edges(
                     token,
                     EdgeListFilter {
-                        source_id: Some(p.source_id),
-                        target_id: Some(p.target_id),
+                        source_id: Some(p.source_id()),
+                        target_id: Some(p.target_id()),
                         relations: vec![relation],
                         ..Default::default()
                     },

--- a/crates/kkernel/src/atomic_apply.rs
+++ b/crates/kkernel/src/atomic_apply.rs
@@ -164,7 +164,7 @@ pub(crate) async fn execute_atomic_ops_file(
             // DDL/INSERT. Best-effort: errors are logged inside those
             // functions and never propagated — a missing audit row must
             // never fail an already-committed atomic unit.
-            apply_gtd_audit_post_commit_effects(&runtime, &post_commit).await;
+            apply_gtd_audit_post_commit_effects(&runtime, post_commit.as_slice()).await;
             khive_runtime::atomic_prepare::apply_post_commit_effects(&runtime, &token, post_commit)
                 .await
                 .context("post-commit reindex after atomic unit commit")?;
@@ -692,13 +692,13 @@ async fn build_op_result(
         ("gtd.transition", AtomicOpPlan::GtdTransition(p)) => {
             let note = runtime
                 .notes(token)?
-                .get_note(p.task_id)
+                .get_note(p.task_id())
                 .await?
                 .ok_or_else(|| {
                     anyhow::anyhow!("atomic gtd.transition result: task not found post-commit")
                 })?;
             let task = khive_pack_gtd::handlers::render_task(&note);
-            if p.statements.is_empty() {
+            if p.statements().is_empty() {
                 let raw_status = original_args
                     .as_object()
                     .and_then(|o| o.get("status"))
@@ -717,7 +717,7 @@ async fn build_op_result(
                 }))
             } else {
                 let (from_status, to_status) =
-                    gtd_audit_from_to(&p.post_commit).ok_or_else(|| {
+                    gtd_audit_from_to(p.post_commit()).ok_or_else(|| {
                         anyhow::anyhow!("atomic gtd.transition result: missing audit effect")
                     })?;
                 Ok(json!({
@@ -738,13 +738,13 @@ async fn build_op_result(
         ("gtd.complete", AtomicOpPlan::GtdComplete(p)) => {
             let note = runtime
                 .notes(token)?
-                .get_note(p.task_id)
+                .get_note(p.task_id())
                 .await?
                 .ok_or_else(|| {
                     anyhow::anyhow!("atomic gtd.complete result: task not found post-commit")
                 })?;
             let task = khive_pack_gtd::handlers::render_task(&note);
-            let (from_status, to_status) = gtd_audit_from_to(&p.post_commit).ok_or_else(|| {
+            let (from_status, to_status) = gtd_audit_from_to(p.post_commit()).ok_or_else(|| {
                 anyhow::anyhow!("atomic gtd.complete result: missing audit effect")
             })?;
             let completed_at = note
@@ -813,11 +813,11 @@ async fn prepare_gtd_transition(
 
     match decision {
         khive_pack_gtd::handlers::TransitionDecision::NoOp { note, .. } => {
-            Ok(AtomicOpPlan::GtdTransition(GtdTransitionPlan {
-                task_id: note.id,
-                statements: vec![],
-                post_commit: PostCommitEffect::None,
-            }))
+            Ok(AtomicOpPlan::GtdTransition(GtdTransitionPlan::new(
+                note.id,
+                vec![],
+                PostCommitEffect::None,
+            )))
         }
         khive_pack_gtd::handlers::TransitionDecision::Write {
             note,
@@ -832,20 +832,20 @@ async fn prepare_gtd_transition(
             )
             .map_err(|e| anyhow::anyhow!("{e}"))?;
 
-            Ok(AtomicOpPlan::GtdTransition(GtdTransitionPlan {
-                task_id: note.id,
-                statements: vec![PlanStatement {
+            Ok(AtomicOpPlan::GtdTransition(GtdTransitionPlan::new(
+                note.id,
+                vec![PlanStatement {
                     statement,
                     guard: Some(AffectedRowGuard::exactly(1)),
                 }],
-                post_commit: PostCommitEffect::GtdAudit {
+                PostCommitEffect::GtdAudit {
                     task_id: note.id,
                     from_status: current,
                     to_status: target,
                     note: transition_note,
                     namespace: token.namespace().as_str().to_string(),
                 },
-            }))
+            )))
         }
     }
 }
@@ -883,20 +883,20 @@ async fn prepare_gtd_complete(
     )
     .map_err(|e| anyhow::anyhow!("{e}"))?;
 
-    Ok(AtomicOpPlan::GtdComplete(GtdCompletePlan {
-        task_id: decision.note.id,
-        statements: vec![PlanStatement {
+    Ok(AtomicOpPlan::GtdComplete(GtdCompletePlan::new(
+        decision.note.id,
+        vec![PlanStatement {
             statement,
             guard: Some(AffectedRowGuard::exactly(1)),
         }],
-        post_commit: PostCommitEffect::GtdAudit {
+        PostCommitEffect::GtdAudit {
             task_id: decision.note.id,
             from_status: decision.current,
             to_status: decision.target.to_string(),
             note: None,
             namespace: token.namespace().as_str().to_string(),
         },
-    }))
+    )))
 }
 
 /// ADR-099 B3 fix (deny_unknown_fields parity): `validate_atomic_args`
@@ -1328,7 +1328,7 @@ mod tests {
             AtomicRunOutcome::Committed { post_commit } => post_commit,
             other => panic!("expected Committed, got {other:?}"),
         };
-        apply_gtd_audit_post_commit_effects(&runtime, &post_commit).await;
+        apply_gtd_audit_post_commit_effects(&runtime, post_commit.as_slice()).await;
 
         // (b) complete next -> done.
         let complete_task = seed_task(&runtime, &token, "next").await;
@@ -1347,7 +1347,7 @@ mod tests {
             AtomicRunOutcome::Committed { post_commit } => post_commit,
             other => panic!("expected Committed, got {other:?}"),
         };
-        apply_gtd_audit_post_commit_effects(&runtime, &post_commit).await;
+        apply_gtd_audit_post_commit_effects(&runtime, post_commit.as_slice()).await;
 
         let mut reader = runtime.sql().reader().await.expect("reader");
         let rows = reader

--- a/crates/kkernel/src/atomic_apply.rs
+++ b/crates/kkernel/src/atomic_apply.rs
@@ -1280,7 +1280,7 @@ mod tests {
             other => panic!("idempotent no-op must still succeed as Committed, got {other:?}"),
         };
         assert!(
-            post_commit.is_empty(),
+            post_commit.as_slice().is_empty(),
             "an idempotent no-op transition must produce no post-commit effect (no audit row \
              either — canonical never reaches its own write_audit_record call): {post_commit:?}"
         );

--- a/crates/kkernel/src/exec.rs
+++ b/crates/kkernel/src/exec.rs
@@ -2706,8 +2706,12 @@ default = true
         // is not a legitimate way to reach this scenario — default discovery is.
         let khive_dir = home_dir.path().join(".khive");
         std::fs::create_dir_all(&khive_dir).expect("mkdir .khive");
-        let main_backend_path = khive_dir.join("main-backend.db");
-        let sessions_backend_path = khive_dir.join("sessions-backend.db");
+        // Keep the configuration home-shaped while placing the stores in a
+        // separate tempdir. Test-harness builds reject every store under
+        // `$HOME/.khive`, including isolated fixtures, at the open boundary.
+        let backend_dir = tempfile::tempdir().expect("backend tempdir");
+        let main_backend_path = backend_dir.path().join("main-backend.db");
+        let sessions_backend_path = backend_dir.path().join("sessions-backend.db");
         std::fs::write(
             khive_dir.join("config.toml"),
             format!(

--- a/crates/kkernel/src/exec.rs
+++ b/crates/kkernel/src/exec.rs
@@ -1218,27 +1218,30 @@ mod tests {
     // `PackRegError { unknown: "gtd", .. }`. A unit test's outcome must not
     // depend on ambient shell configuration.
     #[test]
-    // Bare `#[serial]`, not a named group: this test mutates the process-wide
-    // `KHIVE_PACKS` env var, and so does `code_ingest.rs`'s own ambient-env
-    // coverage — a named group here would let the two race across crate test
-    // modules within the same test binary (both bare-`#[serial]`), letting
-    // this test's temporary "kg,gtd" override leak into a concurrently
-    // running `code_ingest` test's `resolve_runtime_config(packs: None)` call.
-    #[serial]
     fn isolated_server_ignores_ambient_khive_packs_naming_unavailable_pack() {
-        let prev = std::env::var("KHIVE_PACKS").ok();
-        std::env::set_var("KHIVE_PACKS", "kg,gtd");
+        const CHILD_MARKER: &str = "KKERNEL_KHIVE_PACKS_TEST_CHILD";
+        const TEST_NAME: &str =
+            "exec::tests::isolated_server_ignores_ambient_khive_packs_naming_unavailable_pack";
+
+        if std::env::var_os(CHILD_MARKER).is_none() {
+            let status = std::process::Command::new(
+                std::env::current_exe().expect("current test executable"),
+            )
+            .arg(TEST_NAME)
+            .arg("--exact")
+            .env("KHIVE_PACKS", "kg,gtd")
+            .env(CHILD_MARKER, "1")
+            .status()
+            .expect("spawn isolated KHIVE_PACKS test process");
+            assert!(status.success(), "isolated child test failed: {status}");
+            return;
+        }
 
         let db_file = NamedTempFile::new().expect("temp db");
         let db_path = db_file.path().to_str().expect("utf8").to_string();
         // Before the fix, this panicked inside `KhiveMcpServer::new` — the
         // helper inherited the ambient list above instead of pinning its own.
         let _server = isolated_server(&db_path);
-
-        match prev {
-            Some(v) => std::env::set_var("KHIVE_PACKS", v),
-            None => std::env::remove_var("KHIVE_PACKS"),
-        }
     }
 
     // ── exec-path / serve-path config_id parity (#581) ────────────────────────

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -100,7 +100,59 @@ phase_docs() {
 
 phase_tests() {
     echo "=== Tests ==="
+    # #1204 tripwire: RuntimeConfig::default() resolves db_path to
+    # $HOME/.khive/khive.db, and migrations apply on open (forward-only,
+    # ADR-015). A test that boots a runtime through a config path inheriting
+    # that default reaches the operator's/runner's real store instead of an
+    # isolated one. Fingerprint the sentinel file set before the suite and
+    # compare after; any change fails the gate loudly instead of leaving the
+    # drift for a later direct-open to discover. Covered paths are khive.db,
+    # khive.db-wal, khive.db-shm, khive.db.walpin/**, and khive.db.ann/**.
+    # A WAL-mode open can leave the main file unchanged until checkpoint, while
+    # WAL-pin attribution and ANN persistence write the adjacent directories.
+    # Size and mtime catch common changes cheaply; the content hash also catches
+    # same-size writes within the filesystem's timestamp granularity.
+    sentinel_file_fingerprint() {
+        f=$1
+        if [ -f "$f" ]; then
+            m=$(stat -f%m "$f" 2>/dev/null || stat -c%Y "$f")
+            s=$(stat -f%z "$f" 2>/dev/null || stat -c%s "$f")
+            h=$({ shasum -a 256 "$f" 2>/dev/null || sha256sum "$f"; } | awk '{print $1}')
+            printf '%s mtime=%s size=%s sha256=%s\n' "$f" "$m" "$s" "$h"
+        else
+            printf '%s absent\n' "$f"
+        fi
+    }
+
+    sentinel_fingerprint() {
+        for f in "$HOME/.khive/khive.db" "$HOME/.khive/khive.db-wal" "$HOME/.khive/khive.db-shm"; do
+            sentinel_file_fingerprint "$f"
+        done
+
+        for d in "$HOME/.khive/khive.db.walpin" "$HOME/.khive/khive.db.ann"; do
+            if [ -d "$d" ]; then
+                printf '%s directory\n' "$d"
+                find "$d" -type f -print | LC_ALL=C sort | while IFS= read -r f; do
+                    sentinel_file_fingerprint "$f"
+                done
+            else
+                printf '%s absent\n' "$d"
+            fi
+        done
+    }
+    sentinel_before=$(sentinel_fingerprint)
+
     cargo test --workspace
+
+    sentinel_after=$(sentinel_fingerprint)
+    if [ "$sentinel_after" != "$sentinel_before" ]; then
+        echo "FAIL: workspace test suite touched the real default store under \$HOME/.khive — a test opened/migrated it instead of an isolated db_path/HOME (#1204)" >&2
+        echo "before:" >&2
+        printf '%s\n' "$sentinel_before" >&2
+        echo "after:" >&2
+        printf '%s\n' "$sentinel_after" >&2
+        exit 1
+    fi
 }
 
 phase_channel_email() {

--- a/scripts/tests/test_ci_workflows.py
+++ b/scripts/tests/test_ci_workflows.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+"""Contract tests for CI workflow triggers, permissions, and command wiring."""
+
+from __future__ import annotations
+
+import pathlib
+import unittest
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
+WORKFLOWS = REPO_ROOT / ".github" / "workflows"
+
+
+def workflow_text(name: str) -> str:
+    return (WORKFLOWS / name).read_text()
+
+
+def indented_block(text: str, key: str, indent: int) -> str:
+    lines = text.splitlines()
+    marker = f"{' ' * indent}{key}:"
+    start = lines.index(marker) + 1
+    end = len(lines)
+    for index in range(start, len(lines)):
+        line = lines[index]
+        if line.strip() and len(line) - len(line.lstrip()) <= indent:
+            end = index
+            break
+    return "\n".join(lines[start:end])
+
+
+def mapping_entries(block: str) -> set[str]:
+    return {
+        line.strip()
+        for line in block.splitlines()
+        if line.strip() and not line.lstrip().startswith("#")
+    }
+
+
+class UnlockedDependencyWorkflowTests(unittest.TestCase):
+    def test_weekly_workflow_uses_throwaway_lockfile_and_reports_all_outcomes(self):
+        workflow = workflow_text("unlocked-dependencies.yml")
+        triggers = indented_block(workflow, "on", 0)
+        self.assertIn("schedule:", triggers)
+        self.assertIn("workflow_dispatch:", triggers)
+        self.assertNotIn("pull_request:", triggers)
+        self.assertNotIn("push:", triggers)
+        self.assertEqual(
+            mapping_entries(indented_block(workflow, "permissions", 0)),
+            {"contents: read"},
+        )
+
+        self.assertIn("$RUNNER_TEMP", workflow)
+        self.assertIn("cargo update", workflow)
+        self.assertIn("cargo check --workspace", workflow)
+        self.assertIn("cargo test --workspace", workflow)
+        self.assertIn("GITHUB_STEP_SUMMARY", workflow)
+
+
+class AutoMergeGuardWorkflowTests(unittest.TestCase):
+    def test_push_guard_has_only_required_write_permissions(self):
+        workflow = workflow_text("ci.yml")
+        guard = indented_block(workflow, "automerge-push-guard", 2)
+        permissions = mapping_entries(indented_block(guard, "permissions", 4))
+        self.assertEqual(permissions, {"contents: write", "pull-requests: write"})
+
+
+class BenchTrackWorkflowTests(unittest.TestCase):
+    def test_component_runner_limits_quick_flag_to_bench_targets(self):
+        workflow = workflow_text("bench-component.yml")
+        bench_commands = [
+            line.strip() for line in workflow.splitlines() if "cargo bench" in line
+        ]
+        quick_commands = [line for line in bench_commands if "--quick" in line]
+        self.assertEqual(len(quick_commands), 1)
+        self.assertIn("--benches", quick_commands[0])
+        self.assertIn("--criterion-dir crates/target/criterion", workflow)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/smoke_test.py
+++ b/tests/smoke_test.py
@@ -201,7 +201,7 @@ def main():
         # Surface-contract tripwire: the default config (no --pack, KHIVE_PACKS
         # unset) loads 12 production packs (kg, gtd, memory, brain, comm, schedule,
         # knowledge, session, git, code, workspace, blob), so verbs() returns exactly
-        # 86 user-facing MCP-callable verbs (count what verbs() returns, not internal
+        # 88 user-facing MCP-callable verbs (count what verbs() returns, not internal
         # dispatch arms). The session pack contributes 4 agent-facing T1 verbs
         # (store/list/resume/export), promoted from internal subhandlers to
         # Visibility::Verb per ADR-083; brain.register_adapter (#354), context
@@ -225,8 +225,8 @@ def main():
         # until a backend is installed via [storage.blob] or KHIVE_BLOB_ROOT.
         # Update this number when the pack set or verb surface changes; a
         # silent drift here is the bug this assertion exists to catch.
-        assert verbs_result["total"] == 86, (
-            f"expected 86 user-facing verbs from the 12 default packs "
+        assert verbs_result["total"] == 88, (
+            f"expected 88 user-facing verbs from the 12 default packs "
             f"(session contributes 4 T1 verbs promoted to Visibility::Verb per "
             f"ADR-083; context is the 17th kg-substrate bare verb per ADR-089; "
             f"resolve is the 18th kg-substrate bare verb per the unified-verb "
@@ -236,7 +236,9 @@ def main():
             f"git.commit/git.branch/git.push (ADR-108); "
             f"code contributes code.ingest per ADR-085 Amendment 2 (PR #1039); "
             f"workspace (#873) contributes zero verbs; "
-            f"blob contributes blob.put/blob.get/blob.stat per ADR-111), "
+            f"blob contributes blob.put/blob.get/blob.stat per ADR-111; "
+            f"brain.mark_turn is the per-actor work-unit marker; "
+            f"comm.unread lists unread inbound messages), "
             f"got {verbs_result['total']}: {verbs_result}"
         )
         verb_names = [v["verb"] for v in verbs_result["verbs"]]


### PR DESCRIPTION
## Summary

Continues the stacked port of maintained development history onto `port/batch-2` (35 more commits, picked in order). Grouped by area:

- **Retrieval / BM25**: adopt a shared text-analysis layer (`khive-text`) under BM25's tokenizer, replacing duplicated tokenization/stop-word/length-filter logic while preserving the public `SimpleTokenizer` surface.
- **Request DSL**: clearer, more specific error messages when a `$prev` chain reference fails to resolve (no preceding op, path not found, wrong type, unsupported path form), naming the exact field/segment involved.
- **Brain pack**: count-aware (lower-confidence-bound) section-weight scoring instead of raw posterior mean; `event_counts` no longer silently truncates totals to bare scalars; cross-namespace id handling and hardening for `auto_feedback`/`event_counts`. New `brain.mark_turn` work-start marker for per-turn flywheel-discipline ratios, plus `memory_remembered` and enriched `recall_executed` events.
- **Git pack**: credential URL redaction in clone/fetch diagnostics; normalization-aware orphan scan with cross-tier duplicate reporting.
- **Comm pack**: `comm.read`/`comm.reply` restricted to the message's actual addressee/thread participant; dual-write dedup and actor-scoped thread reads; `comm.probe` requires an explicit actor; reply now marks the inbound original read; new unread-count view.
- **Knowledge pack**: imported atoms are finalized so `search`/`suggest` can retrieve them; compose budget params documented and vocab drift swept; unknown params rejected on every verb; `suggest` ranking rebalanced with degraded-mode escalation.
- **GTD**: transition audit trail (accumulated history, not last-write-wins-only) and a documented `tasks()` filter-exclusion signal.
- **KG**: merge safety floor with a structured refusal and an explicit force override; vector-store symlink-redirection hardening in the ANN external-id sidecar write path.
- **MCP / runtime hardening**: batch concurrency and aggregate response size are now bounded (a single oversized or slow op can no longer blow the batch response past the daemon frame budget); incumbent daemon exit is confirmed before spawning a replacement; embed-failure latency and issue-count FTS passes are bounded; WAL-pin census namespace identity and lifecycle ownership hardened; home-directory database stores are refused under the test harness.
- **CI / test isolation**: workspace test suites isolated from ambient environment and the operator's default store; a weekly unlocked-dependency-resolution run and permission-contract guard.
- **Docs**: ADR corpus changes from this range were intentionally dropped (see Licensing & docs below) — the public docs surface is reconciled separately.

## What's not in this batch

Two commits from this row range hit non-mechanical cherry-pick conflicts and were skipped rather than resolved by guessing:
- An embeds-only vector-reindex repair mode conflicts with reindex control-flow already on this branch from other commits; reconciling needs a design decision this batch shouldn't make unilaterally.
- A follow-on fix (bounding embedding input length) builds directly on the above and was skipped for the same reason — its general embedding-input-bounding content is real value that didn't make it into this batch; worth a narrow standalone re-port once the base above lands.

Both are named precisely, with the missing symbols, in the audit notes.

## Licensing & docs

Every commit's diff was scanned for BUSL/commercial-license text and pure-prose docs hunks; none of this batch's picks carried license-text changes to drop. One commit was entirely ADR-doc content and was skipped whole (nothing survives once docs hunks are dropped). Licensing posture aligned with the project's Apache-2.0 stance throughout — verified with a repo-wide absence scan plus a positive-control scan proving the scan itself works.

## Gate results (at this PR's head)

- `cargo check --workspace`: **PASS**
- `cargo clippy --workspace --all-targets -- -D warnings`: **PASS**
- `cargo fmt --all -- --check`: **PASS**
- `deno fmt --check`: **PASS**
- Licensing absence gate: **PASS** (negative arm clean, positive control confirms the instrument works)
- `cargo test --workspace` (`--no-fail-fast`): 159 test binaries green; 2 binaries carry a combined 9 pre-existing failures, verified byte-for-byte identical to `port/batch-2`'s own already-pushed head (not a regression introduced by this batch) — full detail and verification method in the audit notes.

A few compile/lint breaks surfaced only once this batch's rows were applied together — caused by the replay plan's linearized ordering putting two commits whose true dependency ran the other way in the private history next to each other. Fixed as small, targeted follow-up commits on top of the picks (never by editing a picked commit's own diff), each verified against the same behavior the original commits intended. Full detail, including exactly which lines and why, is in the audit notes.

Full per-row disposition table, every message rewrite, every dropped hunk, both conflict write-ups, and an adversarial self-review pass are recorded in this repository's local (gitignored) review notes, not part of this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)