### PR TITLE
ci: add 14-day rolling traffic tracker

### DIFF
--- a/.github/workflows/traffic-tracker.yml
+++ b/.github/workflows/traffic-tracker.yml
@@ -5,6 +5,11 @@ name: Traffic Tracker (14-day rolling)
 # window into a per-day ledger via scripts/track-traffic.sh, and records
 # the result on the dedicated `traffic-data` branch.
 #
+# No workflow_dispatch: manual dispatch resolves workflow YAML from the
+# selected ref, which would let the unprotected data branch supply the
+# code this write-capable workflow runs. To capture a spike manually,
+# push a whitespace edit to one of the two watched paths instead.
+#
 # Trust boundary: the data branch is NEVER checked out and nothing from it
 # is ever executed. The ledger file is read with `git show`, the script
 # runs from the trusted main checkout, and the snapshot commit is built
@@ -18,8 +23,6 @@ on:
   schedule:
     # every 13 days, off the :00 mark to spread cron load
     - cron: '23 5 */13 * *'
-  workflow_dispatch:
-    # manual runs, e.g. after a release announcement to capture the spike
   push:
     branches: [main]
     paths:
@@ -48,7 +51,7 @@ jobs:
         run: |
           set -euo pipefail
           if git ls-remote --exit-code origin traffic-data >/dev/null 2>&1; then
-            git fetch --depth 1 origin traffic-data
+            git fetch --depth 1 origin '+refs/heads/traffic-data:refs/remotes/origin/traffic-data'
             if git rev-parse -q --verify origin/traffic-data:data/traffic-ledger.json >/dev/null; then
               git show origin/traffic-data:data/traffic-ledger.json > "$RUNNER_TEMP/traffic-ledger.json"
             fi
@@ -68,6 +71,10 @@ jobs:
           old_blob=$(git rev-parse -q --verify origin/traffic-data:data/traffic-ledger.json || echo none)
           if [ "$new_blob" = "$old_blob" ]; then
             echo "Ledger unchanged; nothing to commit"
+            exit 0
+          fi
+          if [ "$old_blob" = "none" ] && [ "$(jq '.days | length' "$RUNNER_TEMP/traffic-ledger.json")" -eq 0 ]; then
+            echo "First run returned no traffic days; not creating an empty ledger branch"
             exit 0
           fi
           subtree=$(printf '100644 blob %s\ttraffic-ledger.json\n' "$new_blob" | git mktree)

--- a/.github/workflows/traffic-tracker.yml
+++ b/.github/workflows/traffic-tracker.yml
@@ -1,0 +1,72 @@
+name: Traffic Tracker (14-day rolling)
+
+# GitHub's traffic API retains clone/view data for only 14 days. This
+# workflow runs every 13 days (24h safety overlap), merges the current
+# window into data/traffic-ledger.json via scripts/track-traffic.sh, and
+# commits the result to the dedicated `traffic-data` branch — main is
+# protected, so the ledger lives on its own unprotected branch instead of
+# riding release history.
+#
+# The traffic API requires push access, so this runs in-repo with
+# GITHUB_TOKEN rather than granting any third-party tracker a token.
+
+on:
+  schedule:
+    # every 13 days, off the :00 mark to spread cron load
+    - cron: '23 5 */13 * *'
+  workflow_dispatch:
+    # manual runs, e.g. after a release announcement to capture the spike
+  push:
+    branches: [main]
+    paths:
+      - 'scripts/track-traffic.sh'
+      - '.github/workflows/traffic-tracker.yml'
+
+permissions:
+  contents: write
+
+concurrency:
+  group: traffic-tracker
+  cancel-in-progress: false
+
+jobs:
+  track:
+    name: Snapshot repository traffic
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: main
+          fetch-depth: 1
+
+      - name: Check out traffic-data branch (create from main on first run)
+        run: |
+          set -euo pipefail
+          if git ls-remote --exit-code origin traffic-data >/dev/null 2>&1; then
+            git fetch origin traffic-data
+            git checkout -B traffic-data origin/traffic-data
+          else
+            git checkout -B traffic-data
+          fi
+
+      - name: Merge current traffic window into the ledger
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TRAFFIC_REPO: ${{ github.repository }}
+        run: bash scripts/track-traffic.sh
+
+      - name: Commit and push snapshot
+        run: |
+          set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add data/traffic-ledger.json
+          if git diff --cached --quiet; then
+            echo "No ledger change to commit"
+            exit 0
+          fi
+          clones=$(jq -r '.last_snapshot.clones_14d' data/traffic-ledger.json)
+          views=$(jq -r '.last_snapshot.views_14d' data/traffic-ledger.json)
+          git commit -m "chore(data): traffic snapshot — ${clones} clones / ${views} views (14d)"
+          git push origin traffic-data

--- a/.github/workflows/traffic-tracker.yml
+++ b/.github/workflows/traffic-tracker.yml
@@ -2,10 +2,14 @@ name: Traffic Tracker (14-day rolling)
 
 # GitHub's traffic API retains clone/view data for only 14 days. This
 # workflow runs every 13 days (24h safety overlap), merges the current
-# window into data/traffic-ledger.json via scripts/track-traffic.sh, and
-# commits the result to the dedicated `traffic-data` branch — main is
-# protected, so the ledger lives on its own unprotected branch instead of
-# riding release history.
+# window into a per-day ledger via scripts/track-traffic.sh, and records
+# the result on the dedicated `traffic-data` branch.
+#
+# Trust boundary: the data branch is NEVER checked out and nothing from it
+# is ever executed. The ledger file is read with `git show`, the script
+# runs from the trusted main checkout, and the snapshot commit is built
+# with git plumbing (hash-object/mktree/commit-tree), which also keeps
+# `traffic-data` an orphan branch whose tree contains only the ledger.
 #
 # The traffic API requires push access, so this runs in-repo with
 # GITHUB_TOKEN rather than granting any third-party tracker a token.
@@ -40,33 +44,41 @@ jobs:
           ref: main
           fetch-depth: 1
 
-      - name: Check out traffic-data branch (create from main on first run)
+      - name: Fetch existing ledger without checking out the data branch
         run: |
           set -euo pipefail
           if git ls-remote --exit-code origin traffic-data >/dev/null 2>&1; then
-            git fetch origin traffic-data
-            git checkout -B traffic-data origin/traffic-data
-          else
-            git checkout -B traffic-data
+            git fetch --depth 1 origin traffic-data
+            if git rev-parse -q --verify origin/traffic-data:data/traffic-ledger.json >/dev/null; then
+              git show origin/traffic-data:data/traffic-ledger.json > "$RUNNER_TEMP/traffic-ledger.json"
+            fi
           fi
 
       - name: Merge current traffic window into the ledger
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TRAFFIC_REPO: ${{ github.repository }}
+          TRAFFIC_LEDGER: ${{ runner.temp }}/traffic-ledger.json
         run: bash scripts/track-traffic.sh
 
-      - name: Commit and push snapshot
+      - name: Commit snapshot via plumbing (data-only tree, no checkout)
         run: |
           set -euo pipefail
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add data/traffic-ledger.json
-          if git diff --cached --quiet; then
-            echo "No ledger change to commit"
+          new_blob=$(git hash-object -w "$RUNNER_TEMP/traffic-ledger.json")
+          old_blob=$(git rev-parse -q --verify origin/traffic-data:data/traffic-ledger.json || echo none)
+          if [ "$new_blob" = "$old_blob" ]; then
+            echo "Ledger unchanged; nothing to commit"
             exit 0
           fi
-          clones=$(jq -r '.last_snapshot.clones_14d' data/traffic-ledger.json)
-          views=$(jq -r '.last_snapshot.views_14d' data/traffic-ledger.json)
-          git commit -m "chore(data): traffic snapshot — ${clones} clones / ${views} views (14d)"
-          git push origin traffic-data
+          subtree=$(printf '100644 blob %s\ttraffic-ledger.json\n' "$new_blob" | git mktree)
+          tree=$(printf '040000 tree %s\tdata\n' "$subtree" | git mktree)
+          parent=$(git rev-parse -q --verify origin/traffic-data || true)
+          clones=$(jq -r '.last_snapshot.clones_14d // "n/a"' "$RUNNER_TEMP/traffic-ledger.json")
+          views=$(jq -r '.last_snapshot.views_14d // "n/a"' "$RUNNER_TEMP/traffic-ledger.json")
+          export GIT_AUTHOR_NAME="github-actions[bot]"
+          export GIT_AUTHOR_EMAIL="41898282+github-actions[bot]@users.noreply.github.com"
+          export GIT_COMMITTER_NAME="$GIT_AUTHOR_NAME"
+          export GIT_COMMITTER_EMAIL="$GIT_AUTHOR_EMAIL"
+          commit=$(git commit-tree "$tree" ${parent:+-p "$parent"} \
+            -m "chore(data): traffic snapshot — ${clones} clones / ${views} views (14d)")
+          git push origin "$commit:refs/heads/traffic-data"

--- a/.github/workflows/traffic-tracker.yml
+++ b/.github/workflows/traffic-tracker.yml
@@ -50,7 +50,7 @@ jobs:
       - name: Fetch existing ledger without checking out the data branch
         run: |
           set -euo pipefail
-          if git ls-remote --exit-code origin traffic-data >/dev/null 2>&1; then
+          if git ls-remote --exit-code origin refs/heads/traffic-data >/dev/null 2>&1; then
             git fetch --depth 1 origin '+refs/heads/traffic-data:refs/remotes/origin/traffic-data'
             if git rev-parse -q --verify origin/traffic-data:data/traffic-ledger.json >/dev/null; then
               git show origin/traffic-data:data/traffic-ledger.json > "$RUNNER_TEMP/traffic-ledger.json"

--- a/scripts/track-traffic.sh
+++ b/scripts/track-traffic.sh
@@ -32,8 +32,8 @@ echo "$views_json" | jq -e 'has("views")' >/dev/null || {
 
 mkdir -p "$(dirname "$LEDGER")"
 [ -f "$LEDGER" ] || echo '{"days":{}}' > "$LEDGER"
-jq -e 'has("days")' "$LEDGER" >/dev/null || {
-    echo "ERROR: existing ledger $LEDGER is malformed (no .days key); refusing to overwrite" >&2
+jq -e 'type == "object" and (.days | type == "object")' "$LEDGER" >/dev/null || {
+    echo "ERROR: existing ledger $LEDGER is malformed (.days must be an object); refusing to overwrite" >&2
     exit 1
 }
 
@@ -64,6 +64,14 @@ merged=$(jq -n \
             unique_views_14d: $views.uniques
         }
     }')
+
+# Byte-stable when nothing changed: if the merged day series equals the
+# existing one, leave the file untouched (last_snapshot keeps its old
+# taken_at) so downstream blob comparison sees no delta.
+if jq -e --argjson new "$(echo "$merged" | jq .days)" '.days == $new' "$LEDGER" >/dev/null; then
+    echo "ledger: $LEDGER — day series unchanged; snapshot not refreshed"
+    exit 0
+fi
 
 echo "$merged" | jq . > "$LEDGER"
 

--- a/scripts/track-traffic.sh
+++ b/scripts/track-traffic.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# Append a GitHub Traffic API snapshot to the repository's traffic ledger.
+#
+# GitHub retains clone/view traffic for only 14 days. This script merges the
+# current 14-day window into data/traffic-ledger.json so history accumulates
+# instead of expiring. It is invoked by .github/workflows/traffic-tracker.yml
+# every 13 days (one-day safety overlap); windows overlap by design and the
+# merge takes the per-day maximum, since a partial day's count only grows
+# toward its final value.
+#
+# Requires: gh (authenticated via GH_TOKEN), jq. The traffic API needs push
+# access, which is why this runs in-repo with GITHUB_TOKEN rather than
+# through any third-party tracker.
+set -euo pipefail
+
+REPO="${TRAFFIC_REPO:?TRAFFIC_REPO must be set, e.g. owner/name}"
+LEDGER="${TRAFFIC_LEDGER:-data/traffic-ledger.json}"
+
+clones_json=$(gh api "repos/${REPO}/traffic/clones")
+views_json=$(gh api "repos/${REPO}/traffic/views")
+
+# Fail closed: a response missing its payload key is a failed read, not an
+# empty result. (An empty day-array with the key present is valid data.)
+echo "$clones_json" | jq -e 'has("clones")' >/dev/null || {
+    echo "ERROR: clones response lacks .clones key — treating as failed read" >&2
+    exit 1
+}
+echo "$views_json" | jq -e 'has("views")' >/dev/null || {
+    echo "ERROR: views response lacks .views key — treating as failed read" >&2
+    exit 1
+}
+
+mkdir -p "$(dirname "$LEDGER")"
+[ -f "$LEDGER" ] || echo '{"days":{}}' > "$LEDGER"
+jq -e 'has("days")' "$LEDGER" >/dev/null || {
+    echo "ERROR: existing ledger $LEDGER is malformed (no .days key); refusing to overwrite" >&2
+    exit 1
+}
+
+merged=$(jq -n \
+    --slurpfile ledger "$LEDGER" \
+    --argjson clones "$clones_json" \
+    --argjson views "$views_json" \
+    --arg taken_at "$(date -u +%Y-%m-%dT%H:%M:%SZ)" '
+    def day_map(rows; ck; uk):
+        reduce rows[] as $r ({}; .[$r.timestamp[:10]] = {(ck): $r.count, (uk): $r.uniques});
+    ($ledger[0].days // {}) as $old
+    | day_map($clones.clones; "clones"; "unique_clones") as $c
+    | day_map($views.views; "views"; "unique_views") as $v
+    | (($old | keys) + ($c | keys) + ($v | keys) | unique) as $alldays
+    | {
+        days: (reduce $alldays[] as $d ({};
+            .[$d] = {
+                clones:         ([$old[$d].clones         // 0, $c[$d].clones         // 0] | max),
+                unique_clones:  ([$old[$d].unique_clones  // 0, $c[$d].unique_clones  // 0] | max),
+                views:          ([$old[$d].views          // 0, $v[$d].views          // 0] | max),
+                unique_views:   ([$old[$d].unique_views   // 0, $v[$d].unique_views   // 0] | max)
+            })),
+        last_snapshot: {
+            taken_at: $taken_at,
+            clones_14d: $clones.count,
+            unique_clones_14d: $clones.uniques,
+            views_14d: $views.count,
+            unique_views_14d: $views.uniques
+        }
+    }')
+
+echo "$merged" | jq . > "$LEDGER"
+
+day_total=$(jq '.days | length' "$LEDGER")
+echo "ledger: $LEDGER — $day_total day rows; snapshot: $(echo "$merged" | jq -c .last_snapshot)"


### PR DESCRIPTION
GitHub's traffic API retains clone/view data for only 14 days; nothing in the repo records it, so history expires continuously. This adds:

- `scripts/track-traffic.sh` — merges the current 14-day window into a per-day ledger, taking the per-day maximum across overlapping windows (a partial day's count only grows). Fails closed: a response missing its payload key, or a ledger whose `.days` is not an object, is treated as a failed read — never as empty traffic. When the merged day series is unchanged the file is left byte-identical, so retries produce no commit.
- `.github/workflows/traffic-tracker.yml` — cron every 13 days (24h overlap) plus `workflow_dispatch`. The ledger lives on a dedicated orphan `traffic-data` branch containing only the data file. The branch is never checked out and nothing from it is executed: the file is read via `git show`, the script runs from the trusted main checkout, and the snapshot commit is assembled with git plumbing (`hash-object`/`mktree`/`commit-tree`).

Tested against the live API: fresh-run, unchanged-rerun (no write), malformed-ledger refusal (including `{"days":null}`), and the plumbing path producing a data-only tree.