### PR TITLE
fix(fold): enforce selector contract

### DIFF
--- a/crates/khive-fold/README.md
+++ b/crates/khive-fold/README.md
@@ -64,7 +64,8 @@ N scored, sized candidates into a `SelectorOutput<T>` that fits `budget`.
 `category_weights` multipliers, then packs by effective score (score plus an
 optional `epistemic_weight * information_gain` term) with deterministic
 size-then-ID tie-breaking; `diversity_bias > 0` switches to a pick-best-remaining
-loop that penalizes repeated categories.
+loop that penalizes repeated categories. This priority-ordered greedy strategy fits the
+budget deterministically but does not promise a knapsack optimum or approximation ratio.
 
 ## Checkpoint — durable fold snapshots
 

--- a/crates/khive-fold/docs/api/selector.md
+++ b/crates/khive-fold/docs/api/selector.md
@@ -17,9 +17,15 @@ access, so callers with embedding models pre-compute KL-divergence proxies befor
 
 `GreedySelector` implements priority-ordered budget packing with category-weight multipliers
 and deterministic tie-breaking (effective-score desc, size asc, id asc). The `diversity_bias`
-field controls how aggressively the selector prefers different categories at each pick step.
-At `diversity_bias = 0.0` the behavior reduces to a single-pass greedy sort
-(backward-compatible).
+field controls how aggressively the selector prefers different categories at each pick step;
+values outside the inclusive `[0.0, 1.0]` range are rejected. At `diversity_bias = 0.0` the
+behavior reduces to a single-pass greedy sort (backward-compatible).
+
+This is an ordering heuristic, not a knapsack optimizer. It provides no optimality or
+approximation-ratio guarantee against the additive-value optimum. For example, with a budget
+of 10, a size-10 candidate scoring 1.1 ranks before ten size-1 candidates scoring 1.0 each;
+the selector admits the large candidate and returns total score 1.1 even though the ten small
+candidates form a feasible selection with total score 10.0.
 
 ## Rank-score precision (PR #535)
 

--- a/crates/khive-fold/src/selector.rs
+++ b/crates/khive-fold/src/selector.rs
@@ -69,6 +69,7 @@ pub struct SelectorWeights {
     /// Minimum score threshold (inputs below this are excluded even if budget allows).
     pub min_score: f32,
     /// Preference for diversity vs. relevance (0.0 = pure relevance, 1.0 = pure diversity).
+    /// Values outside the inclusive `[0.0, 1.0]` range are rejected.
     pub diversity_bias: f32,
     /// Weight for epistemic (uncertainty-reducing) selection.
     ///
@@ -101,7 +102,8 @@ pub trait Selector<T>: Send + Sync {
 /// to adjust scores, then greedily packs until the budget is exhausted. When
 /// `diversity_bias > 0`, uses a pick-best-remaining loop instead of a single
 /// sort pass. Tie-breaking is deterministic: effective score descending, size
-/// ascending, then id ascending. See
+/// ascending, then id ascending. This is an ordering heuristic, not a knapsack
+/// optimizer, and provides no optimality or approximation-ratio guarantee. See
 /// crates/khive-fold/docs/design.md#adr-024-bayesian-extensions-selector-budget-packing-and-precision-weighted-scoring
 /// for the diversity-penalty formula.
 #[derive(Debug, Clone, Copy, Default)]
@@ -152,6 +154,11 @@ fn validate_selector_weights(weights: &SelectorWeights) -> Result<(), FoldError>
     if !weights.diversity_bias.is_finite() {
         return Err(FoldError::InvalidInput(
             "SelectorWeights.diversity_bias must be finite".to_string(),
+        ));
+    }
+    if !(0.0..=1.0).contains(&weights.diversity_bias) {
+        return Err(FoldError::InvalidInput(
+            "SelectorWeights.diversity_bias must be within [0.0, 1.0]".to_string(),
         ));
     }
     if !weights.epistemic_weight.is_finite() {
@@ -279,7 +286,7 @@ impl<T: Clone> Selector<T> for GreedySelector {
                         a_det
                             .cmp(&b_det)
                             .then_with(|| remaining[j].size.cmp(&remaining[i].size))
-                            .then_with(|| remaining[i].id.cmp(&remaining[j].id))
+                            .then_with(|| remaining[j].id.cmp(&remaining[i].id))
                     })
                     .map(|(i, _)| i);
 
@@ -549,6 +556,20 @@ mod tests {
     }
 
     #[test]
+    fn diversity_path_tie_breaks_id_ascending() {
+        let inputs = vec![input("z", 1, 0.5), input("a", 1, 0.5)];
+        let w = SelectorWeights {
+            diversity_bias: 0.5,
+            ..Default::default()
+        };
+
+        let out = GreedySelector.select(inputs, 1, &w).unwrap();
+
+        assert_eq!(out.selected.len(), 1);
+        assert_eq!(out.selected[0].id, "a");
+    }
+
+    #[test]
     fn no_overflow_near_usize_max() {
         // Items with near-usize::MAX sizes must not overflow when checking budget.
         let large = usize::MAX - 1;
@@ -751,6 +772,24 @@ mod tests {
             };
             let err = GreedySelector.select(inputs, 100, &w).unwrap_err();
             assert!(matches!(err, FoldError::InvalidInput(_)));
+        }
+    }
+
+    #[test]
+    fn greedy_selector_rejects_out_of_range_diversity_bias() {
+        for bad in [-0.1, 1.1] {
+            let inputs = vec![input("a", 100, 0.5)];
+            let w = SelectorWeights {
+                diversity_bias: bad,
+                ..Default::default()
+            };
+
+            let err = GreedySelector.select(inputs, 100, &w).unwrap_err();
+
+            assert_eq!(
+                err.to_string(),
+                "invalid input: SelectorWeights.diversity_bias must be within [0.0, 1.0]"
+            );
         }
     }
 


### PR DESCRIPTION
> AI-assisted contribution: Codex prepared this change and PR description.

## Summary

- choose ascending IDs when diversity-path candidates tie on score and size
- reject finite `diversity_bias` values outside the documented inclusive `[0.0, 1.0]` range
- document that the selector is deterministic greedy priority packing, not a knapsack optimizer with an optimality or approximation guarantee

Closes #1361.
Closes #1363.
Closes #1364.

## Test plan

- [x] `cargo test -p khive-fold --all-features` (183 tests plus doc tests passed)
- [x] `cargo check -p khive-fold --all-targets --all-features`
- [x] `cargo clippy -p khive-fold --all-targets --all-features -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] `deno fmt --check crates/khive-fold/README.md crates/khive-fold/docs/api/selector.md`
- [ ] `cargo test --workspace` (affected-crate coverage is complete; full-workspace build was withheld to honor the 80 GiB free-space floor)

## ADR

n/a — this enforces and accurately documents the existing selector contract.

## AI-assisted contribution checklist

- [x] Every claim in this PR description matches the actual diff
- [x] Any agent-authored comment / PR body starts with an attribution line
- [x] `cargo test` output included for behavior-changing code
- [x] No typed-relation, kind, supersession, annotation, or namespace semantics changed

## Out of scope

- replacing the greedy selector with an exact or approximate knapsack algorithm
- changing score, category, or epistemic-weight formulas
