### PR TITLE
fix(db): stabilize filtered note pagination

### DIFF
--- a/crates/khive-db/src/stores/note.rs
+++ b/crates/khive-db/src/stores/note.rs
@@ -1010,7 +1010,7 @@ impl NoteStore for SqlNoteStore {
                     };
                     format!(" ORDER BY {} {dir_str}", json_extract_expr(path))
                 }
-                None => " ORDER BY created_at DESC".to_string(),
+                None => " ORDER BY created_at DESC, id ASC".to_string(),
             };
 
             let limit_idx = data_params.len() - 1;

--- a/crates/khive-db/src/stores/note_tests.rs
+++ b/crates/khive-db/src/stores/note_tests.rs
@@ -377,6 +377,45 @@ async fn test_filtered_order_by_json_path_asc() {
 }
 
 #[tokio::test]
+async fn filtered_default_order_is_stable_across_equal_timestamp_pages() {
+    let store = setup_memory_store();
+    let created_at = 1_750_000_000_000_000_i64;
+    let mut expected_ids = Vec::new();
+
+    for index in 0..317 {
+        let mut note = make_note("ns1", "observation", &format!("note-{index}"));
+        note.created_at = created_at;
+        expected_ids.push(note.id);
+        store.upsert_note(note).await.unwrap();
+    }
+    expected_ids.sort_unstable();
+
+    let mut actual_ids = Vec::new();
+    let page_size = 29_u32;
+    let mut offset = 0_u64;
+    loop {
+        let page = store
+            .query_notes_filtered(
+                "ns1",
+                &NoteFilter::default(),
+                PageRequest {
+                    offset,
+                    limit: page_size,
+                },
+            )
+            .await
+            .unwrap();
+        if page.items.is_empty() {
+            break;
+        }
+        offset += page.items.len() as u64;
+        actual_ids.extend(page.items.into_iter().map(|note| note.id));
+    }
+
+    assert_eq!(actual_ids, expected_ids);
+}
+
+#[tokio::test]
 async fn test_filtered_soft_deleted_excluded() {
     let store = setup_memory_store();
     use khive_storage::note::PropertyFilter as NotePropFilter;


### PR DESCRIPTION
> AI-assisted contribution: Codex prepared this change and PR description.

## Summary

- make the default filtered-note ordering total by sorting equal timestamps by `id ASC`
- add a 317-row regression that walks uneven OFFSET pages and proves exactly-once deterministic coverage
- align the paginated path with the existing bounded-query ordering contract

Closes #1351.

## Test plan

- [x] `cargo test -p khive-db` (505 unit tests, 20 integration/contract tests, and doc tests passed)
- [x] `cargo clippy -p khive-db --all-targets --all-features -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] `cargo check --workspace`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [ ] `cargo test --workspace` (the full run was intentionally stopped after compilation and multiple passing crate suites when its generated target crossed the requested 80 GiB free-space floor; the complete affected-crate suite above passed)

## ADR

n/a — this restores deterministic pagination within the existing note-store contract.

## AI-assisted contribution checklist

- [x] Every claim in this PR description matches the actual diff
- [x] Any agent-authored comment / PR body starts with an attribution line
- [x] `cargo test` output included for behavior-changing code
- [x] No typed-relation, kind, supersession, annotation, or namespace semantics changed

## Out of scope

- replacing OFFSET pagination with cursors
- changing explicit JSON-property sort behavior
