### PR TITLE
docs(adr): align shipped contract status

### DIFF
--- a/crates/khive-vcs/docs/api/sync.md
+++ b/crates/khive-vcs/docs/api/sync.md
@@ -17,8 +17,8 @@ visible as the "current" state.
    violation leaves the existing target DB completely untouched.
 3. Build the working database in `<db_path>.tmp`.
 4. Upsert entities and populate the FTS5 index. Vector embeddings are
-   skipped — they're local-only derived state computed lazily via
-   `kkernel kg embed` (ADR-035 §6).
+   skipped — they're local-only derived state repaired explicitly via
+   `kkernel reindex` (ADR-035 §5).
 5. Checkpoint the WAL (`PRAGMA wal_checkpoint(TRUNCATE)`).
 6. Atomic rename: `<db_path>.tmp` → `<db_path>`. A crash before this step
    leaves the previous DB intact (all-or-nothing guarantee).
@@ -114,20 +114,20 @@ silently no-ops the checkpoint and can lose WAL-resident writes at the
 subsequent rename. The regression test
 `wal_checkpoint_truncate_via_plain_execute_script_fails_with_write_queue_enabled`
 is a revert-and-confirm-fails companion: it asserts the OLD call shape
-*fails* under the write queue, which proves the paired "succeeds" test is
+_fails_ under the write queue, which proves the paired "succeeds" test is
 actually exercising the fix rather than passing vacuously (i.e. it isn't a
 test that would pass regardless of which call shape were in use).
 
 ## Failure modes
 
-| Scenario                        | Behaviour                                                |
-| -------------------------------- | ---------------------------------------------------------- |
-| Invalid edge relation in NDJSON | Error before any DB/cache write; previous DB intact       |
-| Hash mismatch on remote pin     | `VcsError::HashMismatch`; no cache files written           |
-| Git clone failure               | Error with remote name only (URL redacted from message)   |
-| Non-UTF-8 staging path          | `Path` passed directly to `Command::arg`; no panic         |
-| Non-finite edge weight          | `VcsError::Internal` from `edge_to_canonical_value`         |
-| WAL checkpoint failure          | Error before rename; previous DB intact                    |
+| Scenario                        | Behaviour                                               |
+| ------------------------------- | ------------------------------------------------------- |
+| Invalid edge relation in NDJSON | Error before any DB/cache write; previous DB intact     |
+| Hash mismatch on remote pin     | `VcsError::HashMismatch`; no cache files written        |
+| Git clone failure               | Error with remote name only (URL redacted from message) |
+| Non-UTF-8 staging path          | `Path` passed directly to `Command::arg`; no panic      |
+| Non-finite edge weight          | `VcsError::Internal` from `edge_to_canonical_value`     |
+| WAL checkpoint failure          | Error before rename; previous DB intact                 |
 
 ## Test coverage map
 

--- a/crates/khive-vcs/docs/design.md
+++ b/crates/khive-vcs/docs/design.md
@@ -39,7 +39,8 @@ and `api/snapshot-hash.md` (content-addressed `SnapshotId` hashing).
 ### Vector embeddings are local-only derived state (ADR-035)
 
 - `run_sync` intentionally skips vector embedding during import. Vectors are local-only
-  derived state computed lazily via `kkernel kg embed` when needed.
+  derived state repaired explicitly with `kkernel reindex` when needed; `--keep-existing`
+  provides incremental top-up and `--no-knowledge` narrows the pass to entities and notes.
 - FTS5 text index is populated during sync so that text search works immediately
   after sync without a separate embedding pass.
 

--- a/crates/khive-vcs/src/sync.rs
+++ b/crates/khive-vcs/src/sync.rs
@@ -996,7 +996,7 @@ async fn upsert_entities(
 
         // FTS docs — one BEGIN IMMEDIATE / COMMIT per chunk.
         // Vectors are intentionally skipped: they are local-only derived state
-        // and will be computed by `kkernel kg embed` when needed.
+        // and can be repaired explicitly by `kkernel reindex` when needed.
         let summary = text
             .upsert_documents(docs_chunk)
             .await
@@ -1716,7 +1716,7 @@ mod tests {
     }
 
     /// F195: verify that FTS5 is populated during sync so text search works
-    /// after sync without a separate `kkernel kg embed` pass.
+    /// after sync without a separate `kkernel reindex` pass.
     #[tokio::test]
     async fn sync_populates_fts_for_text_search() {
         use khive_runtime::RuntimeConfig;

--- a/crates/kkernel/docs/usage.md
+++ b/crates/kkernel/docs/usage.md
@@ -84,7 +84,7 @@ kkernel exec 'knowledge.search(query="...", rerank=true)' --presentation verbose
 
 Flags: `--db`, `--namespace`, `--presentation <agent|verbose|human>`, `--strict`.
 A request in which every op failed or aborted always exits nonzero after printing the full
-response. Without `--strict`, a *partially* failed request (`status: "partial"` with at least
+response. Without `--strict`, a _partially_ failed request (`status: "partial"` with at least
 one success) retains its compatibility behavior and exits zero; `--strict` converts any failed
 or aborted op into a nonzero process exit.
 
@@ -111,10 +111,13 @@ kkernel reindex --db ~/.khive/khive.db --sections-only      # backfill only sect
 | `--no-sections`    | within the knowledge pass, embed atoms but skip section embeddings (ADR-051)    |
 | `--sections-only`  | embed only knowledge sections (skip entities/notes and atoms)                   |
 | `--model <name>`   | entities/notes use this single engine instead of fanning out                    |
-| `--keep-existing`  | skip records already embedded (incremental top-up) instead of drop-and-rebuild  |
-| `--batch-size <n>` | records per embedding batch (default 100, max 500)                              |
+| `--keep-existing`  | skip records already embedded (incremental top-up) instead of replacing them    |
+| `--batch-size <n>` | records per embedding batch (default 128, max 500)                              |
 | `--best-effort`    | downgrade partial failures to a warning and still exit 0 (default fails closed) |
 | `--human`          | readable report instead of JSON                                                 |
+
+There is no `--embeds-only`, `--ids`, or `--dry-run` mode. `--keep-existing` narrows
+vector work to missing records, but the selected graph pass still backfills FTS.
 
 **Config resolution.** Engines, db path, and config file are resolved with the
 **same precedence as `kkernel mcp`** — config-file `[[engines]]` (via `--config`

--- a/docs/adr/ADR-035-cli-config-and-auto-embed.md
+++ b/docs/adr/ADR-035-cli-config-and-auto-embed.md
@@ -99,7 +99,7 @@ backend = "main"
 [embed]
 model = "default"          # logical name — must match a [[engines]] entry
 dimensions = 384            # vector dimensions
-auto_embed = true           # embed on commit and sync (default: true)
+auto_embed = true           # design field; not wired by the current Rust CLI
 batch_size = 64             # entities per embed batch
 
 [embed.fields]
@@ -151,17 +151,18 @@ For each runtime option, precedence is:
 default**. Exact option-specific exceptions are listed in the canonical config
 reference (`docs/core/khive-config-example.toml`).
 
-| Option             | CLI flag          | Env var                  | Config key                | Default           |
-| ------------------ | ----------------- | ------------------------ | ------------------------- | ----------------- |
-| Namespace          | `--namespace`     | `KHIVE_NAMESPACE`        | `runtime.namespace`       | `default`         |
-| Loaded packs       | `--pack` (repeat) | `KHIVE_PACKS`            | `runtime.packs`           | `kg`              |
-| DB path            | `--db`            | `KHIVE_DB`               | `runtime.db_path`         | `~/.khive/kg.db`  |
-| Recall min_score   | (n/a, per-call)   | `KHIVE_RECALL_MIN_SCORE` | `memory.recall.min_score` | `None` (no floor) |
-| Auto-embed mode    | `--auto-embed`    | `KHIVE_AUTO_EMBED`       | `embed.auto_embed`        | `true`            |
-| Embedding model    | `--embed-model`   | `KHIVE_EMBED_MODEL`      | `embed.model`             | `mE5-small`       |
-| Log level          | `--log-level`     | `KHIVE_LOG`              | `runtime.log_level`       | `info`            |
-| Authorization gate | `--gate`          | `KHIVE_GATE`             | `runtime.gate`            | `allow-all`       |
-| Brain profile      | `--brain-profile` | `KHIVE_BRAIN_PROFILE`    | `runtime.brain_profile`   | `None`            |
+| Option             | CLI flag                         | Env var                             | Config key                | Default           |
+| ------------------ | -------------------------------- | ----------------------------------- | ------------------------- | ----------------- |
+| Namespace          | `--namespace`                    | `KHIVE_NAMESPACE`                   | `runtime.namespace`       | `default`         |
+| Loaded packs       | `--pack` (repeat)                | `KHIVE_PACKS`                       | `runtime.packs`           | `kg`              |
+| DB path            | `--db`                           | `KHIVE_DB`                          | `runtime.db_path`         | `~/.khive/kg.db`  |
+| Recall min_score   | (n/a, per-call)                  | `KHIVE_RECALL_MIN_SCORE`            | `memory.recall.min_score` | `None` (no floor) |
+| Disable embeddings | `kkernel mcp --no-embed`         | `KHIVE_NO_EMBED`                    | (none)                    | `false`           |
+| Reindex model      | `kkernel reindex --model <name>` | `KHIVE_EMBEDDING_MODEL`             | `[[engines]]`             | built-in engine   |
+| Additional models  | (none)                           | `KHIVE_ADDITIONAL_EMBEDDING_MODELS` | `[[engines]]`             | none              |
+| Log level          | `--log-level`                    | `KHIVE_LOG`                         | `runtime.log_level`       | `info`            |
+| Authorization gate | `--gate`                         | `KHIVE_GATE`                        | `runtime.gate`            | `allow-all`       |
+| Brain profile      | `--brain-profile`                | `KHIVE_BRAIN_PROFILE`               | `runtime.brain_profile`   | `None`            |
 
 Note: `recall(min_score)` has **no floor by default**. Operators serving larger corpora should
 set `KHIVE_RECALL_MIN_SCORE=0.5` (or similar) in production deployments.
@@ -200,8 +201,12 @@ working as before.
 
 ### 3. `[embed]` and `[schema]` sections
 
-The `[embed]` section controls the automatic embedding pipeline (§5). The `[schema]`
-section controls import validation.
+The original decision assigned automatic-pipeline settings to `[embed]` and import validation
+to `[schema]`. The current Rust runtime resolves embedding engines from `[[engines]]`; it does
+not read `embed.auto_embed`, and it exposes no `--auto-embed` or `KHIVE_AUTO_EMBED` control.
+The shipped operational controls are `kkernel mcp --no-embed` / `KHIVE_NO_EMBED` and the
+explicit `kkernel reindex` workflow in §5. The table below records the decision's intended
+defaults, not additional live CLI flags.
 
 **Built-in defaults** (when no selected config file supplies the setting):
 
@@ -264,66 +269,52 @@ Init automatically updates only the byte-exact `.gitignore` emitted by the
 old initializer (`!khive.toml` to `!config.toml`). It never rewrites a
 customized ignore file.
 
-### 5. Automatic embedding pipeline
+### 5. Shipped embedding and repair workflow
 
-Embeddings are generated during the two operations that transition working state: commit
-and sync. Both use the same `embed_missing` subroutine.
+The original decision specified an `embed_missing` pass in `kkernel kg commit` and
+`kkernel kg sync`, plus a `kkernel kg embed` command. That automatic-embedding behavior and
+dedicated command are not present in the current Rust CLI. `kkernel kg commit` validates and
+commits a staged change-set; the current `kkernel kg sync` spelling is a visible alias for remote
+fetch; and top-level `kkernel sync` rebuilds the SQLite database and FTS documents from NDJSON.
+None invokes an embedding pass, and `kkernel kg` has no `embed` subcommand.
 
-#### `embed_missing` subroutine
+The shipped behavior has two parts:
 
-Queries `working.db` for entities that have no vector in the per-(model, dim) virtual table
-for the currently configured model, or whose vector was computed with a different model than
-the current `embed.model`. Constructs the input text by joining the values of
-`embed.fields.include` with a single space separator. Calls lattice-embed (ADR-011) in
-batches of `embed.batch_size` via the EmbedderRegistry (ADR-031). Writes resulting vectors
-to the appropriate per-(model, dim) table in `working.db` via the VectorStore trait
-(ADR-005).
+1. Runtime create and update paths embed inline for every configured engine.
+   `kkernel mcp --no-embed` (or `KHIVE_NO_EMBED=1`) starts the MCP runtime without any
+   built-in embedding engine, so those writes remain text-only.
+2. `kkernel reindex` is the explicit maintenance and repair command. It rebuilds vectors and
+   FTS documents for entities, notes, and, by default, the knowledge corpus. It resolves the
+   same database, config, namespace, and `[[engines]]` set as `kkernel mcp`.
 
-For an entity with `name = "LoRA"` and `description = "Low-rank adaptation technique for
-fine-tuning"`, the concatenated input is:
-`"LoRA Low-rank adaptation technique for fine-tuning"`.
+Examples using only shipped flags:
 
-#### `kkernel kg commit` — embed before export
+```bash
+# Re-embed entities, notes, and knowledge with every configured engine.
+kkernel reindex --db ~/.khive/khive.db --namespace local
 
-The `commit` pipeline from ADR-020 §6 is extended:
+# Repair only the graph substrate and keep vectors that already exist.
+kkernel reindex --db ~/.khive/khive.db --namespace local \
+  --no-knowledge --keep-existing
 
-1. Run `embed_missing` on `working.db` if `embed.auto_embed = true`.
-2. Run `kkernel kg export` (DB → NDJSON). Unchanged from ADR-020.
-3. Run `kkernel kg validate`. Unchanged from ADR-020.
-4. `git add .khive/kg/` and `git commit`. Unchanged from ADR-020.
-
-Embedding runs before export because export reads `working.db`; per-entity validation
-rules (ADR-034) that check vector quality must see vectors already present. Embedding after
-export would make such checks impossible without a second pass.
-
-#### `kkernel kg sync` — embed after rebuild
-
-The `sync` pipeline from ADR-020 §6 is extended:
-
-1. Check for uncommitted DB changes. Unchanged from ADR-020.
-2. Atomic DB rebuild from NDJSON. Unchanged from ADR-020.
-3. Run `embed_missing` on the freshly rebuilt DB if `embed.auto_embed = true`. Embeds
-   entities that arrived from other collaborators and lack local vectors.
-4. Print summary: `Synced: 472 entities, 1,111 edges (38 entities embedded)`.
-
-Embedding runs after rebuild because the rebuild drops and recreates `working.db` from
-NDJSON. Embedding before rebuild would populate vectors into a DB that is immediately
-discarded.
-
-#### `kkernel kg embed` — explicit command
-
-An explicit command for full or selective re-embedding:
-
-```
-kkernel kg embed              # embed all entities missing vectors for current model
-kkernel kg embed --all        # re-embed all entities (force, regardless of existing vectors)
-kkernel kg embed --ids a1b2 c3d4  # embed specific entity IDs
-kkernel kg embed --dry-run    # print which entities would be embedded; no writes
+# Rebuild entity/note vectors with one named engine.
+kkernel reindex --db ~/.khive/khive.db --namespace local \
+  --no-knowledge --model all-minilm-l6-v2
 ```
 
-When `auto_embed = false`, `kkernel kg embed` is the only way embeddings are created.
-Projects that want explicit control (large KGs, separate embed jobs, slow hardware) set
-`auto_embed = false` and call `kkernel kg embed` on their own schedule.
+Without `--keep-existing`, every staged record is re-embedded and each prior vector is
+replaced atomically with its new value; a failed embed or insert leaves the prior vector in
+place rather than deleting it first. With `--keep-existing`, records already embedded for
+the selected model and namespace are skipped. FTS backfill still runs in either mode. The
+default is fail-closed on partial failures; `--best-effort` is the explicit opt-in to a zero
+exit after partial work.
+
+There is no current `--embeds-only`, `--ids`, or `--dry-run` reindex mode. In particular,
+`--keep-existing` means incremental vector top-up, not vector-only execution. When no
+embedding engine is configured, `kkernel reindex` still backfills FTS but warns and skips
+vector work. An operator who normally runs the server with `--no-embed` can therefore run a
+separate `kkernel reindex` invocation without that server flag, using a config that declares
+the desired `[[engines]]`, to populate vectors on an explicit schedule.
 
 ### 6. Embeddings are local-only derived state
 
@@ -336,43 +327,42 @@ Vectors are stored in `working.db` only. They are **not** written to NDJSON file
 - **Size**: 384 floats per entity is 1.5 KB. A 10,000-entity KG would add 15 MB of
   non-human-readable binary content to NDJSON, destroying the git diff and merge
   guarantees that are the entire value of ADR-020.
-- **Consistency**: `kkernel kg sync` re-embeds after every rebuild. Two collaborators
-  using the same model and entity text produce identical vectors. There is no durability
-  requirement.
+- **Consistency**: `kkernel reindex` recomputes vectors from the selected engine set and
+  current entity/note text. There is no durability requirement for the vectors themselves.
 
 `working.db` is gitignored by ADR-020's allowlist. The `.khive/state/` directory is
 ephemeral by design.
 
 ### 7. Model change workflow
 
-When the project's embedding model changes, all vectors in `working.db` are incompatible
-with the new model. The workflow is:
+When the project's embedding engine set changes, the existing vectors no longer describe the
+selected configuration. The shipped workflow is:
 
 ```bash
-# 1. Edit .khive/config.toml:
-#    embed.model = "BGE-large"
-#    embed.dimensions = 1024
+# 1. Edit the selected config's [[engines]] entries.
 
-# 2. Re-embed all entities with the new model
-kkernel kg embed --all
+# 2. Re-embed graph and knowledge state with that config.
+kkernel reindex --config .khive/config.toml --db ~/.khive/khive.db \
+  --namespace local
 
-# 3. Commit the config change (vectors are local-only — only config.toml changes in git)
-kkernel kg commit -m "switch embedding model to BGE-large"
+# 3. Commit only the config change; vectors remain local derived state.
+git add .khive/config.toml
+git commit -m "config: switch embedding engine"
 ```
 
 After the commit, other collaborators run:
 
 ```bash
 git pull
-kkernel kg sync     # rebuilds DB from NDJSON; auto-embeds with new model
+kkernel reindex --config .khive/config.toml --db ~/.khive/khive.db \
+  --namespace local
 ```
-
-`kkernel kg sync` reads the updated `.khive/config.toml` after the DB rebuild step, so the
-`embed_missing` pass uses the new model automatically.
 
 ### 8. Config validation
 
-The CLI validates the one selected config file at startup. Validation checks:
+The original `[embed]` decision called for the following validation. The current Rust config
+parser validates `[[engines]]` but does not deserialize these `[embed]` keys, so it does not
+currently enforce this list:
 
 - `embed.model` is a non-empty string. Model availability is validated by lattice-embed
   at runtime; the config loader does not check against a list.
@@ -400,18 +390,11 @@ ERROR: .khive/config.toml line 5: expected integer for embed.dimensions, got "38
 `[[engines]]` (ADR-028) declares the process-wide registry of loaded embedding models —
 the names and dimensions that `EmbedderRegistry::from_config` uses to instantiate models.
 
-`[embed]` (this ADR) specifies which model is used for the entity-text embedding pipeline
-and what fields it operates on. `embed.model` must reference a name in `[[engines]]`. The
-runtime validates this at startup:
-
-```
-ERROR: embed.model "BGE-large" not found in [[engines]]. Available: mE5-small
-```
-
-This separation keeps the registry declaration (ADR-028) orthogonal to embed pipeline
-configuration (this ADR). A deployment can load multiple engines (for query-time
-multi-engine retrieval, ADR-031) while designating exactly one as the entity embedding
-model for the commit/sync pipeline.
+The current Rust runtime does not consume `[embed]` or validate `embed.model` against that
+registry. `[[engines]]` is the shipped source of truth: `default = true` selects the default
+engine, inline create/update fans out across the registered set, and `kkernel reindex` does the
+same for entities and notes unless `--model` narrows the pass. The `[embed]` shape above is
+retained as the original decision record, not described as a second live selector.
 
 ## Rationale
 
@@ -429,34 +412,22 @@ just cohabitation in one well-sectioned file.
 
 ### Why project config wins over the global fallback
 
-The embedding model is a project invariant. If a global `~/.khive/config.toml` could
-override the project's `embed.model`, a collaborator with a different default would silently
+The embedding engine set is a project invariant. If a global `~/.khive/config.toml` could
+override the project's `[[engines]]`, a collaborator with a different default would silently
 produce incompatible vectors. The project config must win on embedding-related keys.
 
 Machine-local overrides such as device choice belong in an explicit CLI or
 environment tier when a project config is selected. The global file is a
 fallback for projects without a project config, not a merge source.
 
-### Why auto-embed defaults to true
+### Why inline writes plus an explicit repair command
 
-Without automatic embedding, the user-visible symptom of stale vectors is worse search
-results, not an error. There is no "search returned poor results because vectors are
-missing" warning — the user sees a lower-quality result set and does not know why.
-Auto-embedding prevents this failure mode by ensuring vectors are current after every
-commit and sync. The cost is a few seconds of embed time, negligible for typical KG sizes.
-`auto_embed = false` is the explicit opt-out for large KGs or slow hardware.
-
-### Why embed before export in `kkernel kg commit`
-
-Embedding before export allows validation rules (ADR-034) to check vector quality — for
-example, flagging entities whose stored embedding dimension does not match the configured
-model's output. Embedding after export would make such pre-commit checks impossible.
-
-### Why embed after rebuild in `kkernel kg sync`
-
-The rebuild drops and recreates `working.db`. Embedding before rebuild populates vectors
-into a database that is immediately discarded. Embedding after rebuild ensures vectors are
-computed against the final, committed entity set.
+Missing vectors degrade semantic search without producing a query error. The current runtime
+therefore embeds ordinary create/update writes inline when engines are configured, while
+`kkernel reindex` provides a deliberate full or incremental repair after bulk import, NDJSON
+sync, or an engine change. Keeping reindex separate from git commit/sync also gives operators a
+clear fail-closed maintenance command and avoids documenting lifecycle coupling the Rust CLI does
+not implement.
 
 ### Why NDJSON files never carry vectors
 
@@ -468,17 +439,17 @@ as separating source files from build artifacts in a standard software project.
 
 ## Alternatives Considered
 
-| Alternative                                                 | Pros                        | Cons                                                                  | Why rejected                                                  |
-| ----------------------------------------------------------- | --------------------------- | --------------------------------------------------------------------- | ------------------------------------------------------------- |
-| Separate active topology and embedding files in one project | Clear file roles            | Two files to manage; split mental context                             | One selected file is simpler and sufficient                   |
-| Per-key project/global TOML merge                           | Machine-local overlays      | Hidden composite config; client/daemon fingerprint drift risk         | First-file selection is deterministic and auditable           |
-| YAML config format                                          | Familiar                    | Ambiguous parsing; indentation errors in practice                     | TOML is unambiguous; already used in Cargo and this project   |
-| JSON config format                                          | Machine-writable            | No comments; annoying to hand-edit; trailing-comma errors             | TOML is better for human-edited files                         |
-| Vectors stored in NDJSON (committed)                        | Single source of truth      | 15 MB+ non-diffable content per 10K entities; breaks merge guarantees | Recomputable state should not be committed                    |
-| Dedicated committed vector file (separate from NDJSON)      | Separates vectors from text | Same merge problem; grows with entity count                           | Still recomputable; still breaks git diff                     |
-| Manual embed only (`auto_embed = false` as default)         | Explicit control            | Silent quality degradation when users forget                          | Auto-embed prevents the failure mode at negligible cost       |
-| Embed on every verb write (real-time)                       | Vectors always current      | Embed latency per write blocks interactive use                        | Batch on commit/sync matches the git-workflow cadence         |
-| `embed.model` allowed as per-user override                  | User flexibility            | Incompatible vectors across collaborators                             | Model is a project invariant; must be locked at project level |
+| Alternative                                                 | Pros                         | Cons                                                                  | Why rejected                                                  |
+| ----------------------------------------------------------- | ---------------------------- | --------------------------------------------------------------------- | ------------------------------------------------------------- |
+| Separate active topology and embedding files in one project | Clear file roles             | Two files to manage; split mental context                             | One selected file is simpler and sufficient                   |
+| Per-key project/global TOML merge                           | Machine-local overlays       | Hidden composite config; client/daemon fingerprint drift risk         | First-file selection is deterministic and auditable           |
+| YAML config format                                          | Familiar                     | Ambiguous parsing; indentation errors in practice                     | TOML is unambiguous; already used in Cargo and this project   |
+| JSON config format                                          | Machine-writable             | No comments; annoying to hand-edit; trailing-comma errors             | TOML is better for human-edited files                         |
+| Vectors stored in NDJSON (committed)                        | Single source of truth       | 15 MB+ non-diffable content per 10K entities; breaks merge guarantees | Recomputable state should not be committed                    |
+| Dedicated committed vector file (separate from NDJSON)      | Separates vectors from text  | Same merge problem; grows with entity count                           | Still recomputable; still breaks git diff                     |
+| Manual repair only                                          | Explicit control             | Silent quality degradation when users forget                          | Inline create/update plus explicit reindex covers both paths  |
+| Embed on every embedding-bearing write                      | Fresh vectors for new writes | Adds model latency to those writes                                    | Shipped default; `mcp --no-embed` is the explicit opt-out     |
+| `embed.model` allowed as per-user override                  | User flexibility             | Incompatible vectors across collaborators                             | Model is a project invariant; must be locked at project level |
 
 ## Consequences
 
@@ -493,33 +464,26 @@ as separating source files from build artifacts in a standard software project.
 
 ### Positive
 
-- Search quality is reliable: every collaborator who runs `kkernel kg sync` or `kkernel kg
-  commit` has current vectors without manual intervention.
+- `kkernel reindex` gives operators one verified command for full rebuilds and incremental
+  top-up across the configured engine set.
 - The embedding model is recorded in `.khive/config.toml`, committed alongside the KG data.
   Changing the model produces a one-line diff in git that reviewers can see and approve.
 - Device preferences stay local: `device = "metal"` never appears in committed files.
 - `kkernel kg init` writes a valid, well-commented `.khive/config.toml` that makes its defaults
   explicit and reviewable in the initial PR.
-- `kkernel kg embed --dry-run` gives visibility into which entities lack vectors before
-  committing.
+- `--keep-existing` avoids recomputing vectors already present for the selected model and
+  namespace.
 - One selected config file, not a hidden per-key merge, reduces operator friction.
 
 ### Negative
 
-- `kkernel kg commit` and `kkernel kg sync` have an optional embed step that adds latency.
-  For large KGs on slow hardware, this may be noticeable. Mitigation: `auto_embed = false`
-  moves embedding to an explicit `kkernel kg embed` call.
+- Inline create/update embedding adds model latency. On model-less or latency-sensitive servers,
+  `kkernel mcp --no-embed` disables that work and a separate `kkernel reindex` process can run on
+  an explicit schedule.
 - `~/.khive/config.toml` introduces a user-global fallback that must be documented and
-  supported. A misconfigured `embed.device` produces a runtime error from lattice-embed
-  rather than a config validation error. Mitigation: type validation catches `device`
-  value errors at startup; model availability errors from lattice-embed are propagated
-  with their full message.
-- Changing `embed.model` requires re-embedding all entities (potentially slow for large
-  KGs) and a follow-up commit. The workflow is documented in §7 but adds ceremony to
-  model upgrades.
-- `embed.model` must match a name in `[[engines]]`. Operators who add a new model must
-  update both sections consistently. Mitigation: startup validation reports the mismatch
-  with the list of available engine names.
+  supported. Model availability errors from lattice-embed are propagated at runtime.
+- Changing `[[engines]]` requires re-embedding the affected corpus (potentially slow for large
+  KGs). The explicit workflow is documented in §7.
 
 ### Neutral
 
@@ -527,9 +491,8 @@ as separating source files from build artifacts in a standard software project.
   artifacts beyond the selected config sections in `.khive/config.toml`.
 - `working.db` already carries a per-(model, dim) vector table layout (ADR-005, ADR-009).
   This ADR specifies when those tables are populated, not how they are structured.
-- Projects that do not use `kkernel search` can set `auto_embed = false` and ignore the
-  embed subsystem entirely. The pipeline steps are no-ops when `auto_embed = false` and
-  `kkernel kg embed` is never invoked.
+- Projects that do not use semantic retrieval can run `kkernel mcp --no-embed`; text search
+  remains available, and `kkernel reindex` without a configured engine still backfills FTS.
 
 ## Open Questions
 
@@ -553,20 +516,17 @@ as separating source files from build artifacts in a standard software project.
 
 - [ADR-001](ADR-001-entity-kind-taxonomy.md) — `embed.fields.include` cannot include
   `kind`; it is a closed-taxonomy discriminant, not an embeddable text field
-- [ADR-005](ADR-005-storage-capability-traits.md) — `VectorStore` trait; `embed_missing`
+- [ADR-005](ADR-005-storage-capability-traits.md) — `VectorStore` trait; `kkernel reindex`
   writes to per-(model, dim) tables via this trait
 - [ADR-009](ADR-009-backend-architecture.md) — `khive-db` backend works in-memory and
   on-disk; `working.db` is a project-scoped on-disk backend
-- [ADR-011](ADR-011-embedding-and-inference.md) — lattice-embed boundary; `embed_missing`
-  calls lattice-embed for batched inference
-- [ADR-020](ADR-020-git-native-kg-implementation.md) — git-native KG implementation;
-  this ADR extends the `commit` and `sync` pipelines defined in ADR-020 §6; the
-  `.khive/.gitignore` allowlist gains `config.toml`
+- [ADR-011](ADR-011-embedding-and-inference.md) — lattice-embed boundary used for batched
+  reindex inference
+- [ADR-020](ADR-020-git-native-kg-implementation.md) — git-native KG implementation and the
+  NDJSON sync boundary; the `.khive/.gitignore` allowlist gains `config.toml`
 - [ADR-028](ADR-028-pack-scoped-backends.md) — pack-scoped backends; `[[backends]]`,
   `[[engines]]`, and `[packs.*]` sections live in the same selected TOML file this ADR governs
-- [ADR-031](ADR-031-multi-engine-retrieval.md) — `EmbedderRegistry`; `embed_missing`
-  routes inference requests through the registry; `embed.model` must reference a registered
-  engine name
-- [ADR-034](ADR-034-kg-validation-pipelines.md) — validation pipelines; embedding before
-  export in `commit` allows validation rules to check vector presence and dimension
-  correctness
+- [ADR-031](ADR-031-multi-engine-retrieval.md) — `EmbedderRegistry`; `kkernel reindex`
+  fans entity/note work across registered engines unless `--model` narrows it
+- [ADR-034](ADR-034-kg-validation-pipelines.md) — validation pipelines remain separate from
+  the explicit reindex maintenance path

--- a/docs/adr/ADR-103-resource-attribution-model.md
+++ b/docs/adr/ADR-103-resource-attribution-model.md
@@ -463,7 +463,17 @@ of the previous.
 
 ## Amendment 1 (2026-07-13): Batch-Scaled `cost_unit` and Daemon-Startup Warm-Hook Attribution
 
-**Status**: Proposed (amendment to ADR-103's Stage 1 design; not yet implemented)
+**Status**: Accepted and implemented in PR
+[#927](https://github.com/ohdearquant/khive/pull/927), merged on 2026-07-13 as
+`68e9325a039f0975f9caaa64ee5fb834ba874aa2`.
+
+The shipped boundary is precise: successful dispatch audit rows carry deterministic
+`resource.cost_unit`; all dispatch outcomes carry `resource.work_class`; and the kg and knowledge
+embedder warm hooks emit phase spans. `brain.event_counts` later gained `total_cost_unit` and
+`cost_unit_by_verb` aggregation in PR #958. The formula is implemented, but its current weight
+table is still the uncalibrated baseline (`base_weight = 1` for every verb and
+`per_item_weight = 1` for embedding-bearing verbs). Stage 2 scheduling and Stage 3 quota
+enforcement remain outside this amendment and are not implied by its accepted status.
 
 ### Context
 
@@ -614,8 +624,8 @@ skipped, not counted into a default bucket.
 runtime's embedder once at daemon construction (or lazily on first pack install) to warm
 it. Both run through `PackRuntime::warm(&self)` (`crates/khive-runtime/src/pack.rs:232`),
 which takes no `NamespaceToken` argument, so neither call executes inside `dispatch()` or
-under the Gate. There is no actor in scope, no audit row is written (there is no dispatch
-to attach one to), and both embedder-warmup passes are currently invisible on the event
+under the Gate. Before PR #927 there was no actor in scope, no audit row was written (there
+was no dispatch to attach one to), and both embedder-warmup passes were invisible on the event
 plane entirely, the one concrete gap in Decision (c) as written, which already commits
 background phase work of this shape to `PhaseStarted` plus a terminal event.
 
@@ -674,8 +684,8 @@ already-proven mechanism, not new design surface.
 
 ### Consequences
 
-- Positive: `cost_unit` becomes usable for Stage 3 quota accounting without a follow-up
-  correction once the formula ships, since it already accounts for both the batch-size
+- Positive: the shipped `cost_unit` formula is usable as the deterministic input to future
+  Stage 3 quota accounting, since it already accounts for both the batch-size
   and model-fan-out undercounts a naive per-verb weight would have missed at scale. The
   two daemon-startup warmup passes join the rest of the daemon's background work (ANN
   warm, checkpoint, channel poll) on the event plane instead of remaining the one silent
@@ -693,6 +703,27 @@ already-proven mechanism, not new design surface.
   stage boundaries.
 
 ## Amendment 2 (2026-07-21): Itemized Executed-Usage Counters — Response-Envelope `usage` and Audit-Row `resource.units`
+
+**Status**: Accepted; partially implemented in PR
+[#1231](https://github.com/ohdearquant/khive/pull/1231), merged on 2026-07-22 as
+`bb764bf58f06a8c651b93c3d223dd75dcf6f0a74` (ported in the current history as
+`b0d92a67aa2f69d070daca6911384057cc9bdca6`).
+
+The shipped implementation provides the seven-counter `UsageContext`, per-operation MCP envelope
+`usage`, and the identical frozen audit snapshot at `resource.units`. Production increments exist
+for embedding, FTS, vector probes, graph hops, graph-store round trips, and successfully appended
+event rows. Runtime entity/note multi-model create paths explicitly propagate the context into
+their joined child tasks.
+
+The remaining gaps are observable in current code and are not papered over by this status:
+
+- `ann_jobs_consumed` has no production increment site, so it is always absent/zero.
+- spawned per-model work in `memory.recall` and `knowledge.index` does not re-enter the usage
+  scope, so those child tasks can under-report `embed_calls`, `vector_passes`, and related work;
+- `db_round_trips` is instrumented at graph-read seams, not as a universal counter for every SQL
+  or storage call; and
+- Part 5's `[request] max_ops` deployment setting is not parsed or enforced. The shipped parser
+  ceiling remains the constant `khive_request::MAX_OPS = 100`.
 
 ### Context
 
@@ -824,27 +855,26 @@ the hand-set weight table Amendment 1 left open can now be **calibrated from obs
 `units` distributions** instead of guessed, under the same governance Decision (b)
 established. Nothing in quota enforcement (Decision d) changes.
 
-### Part 5: request-cap configurability
+### Part 5: request-cap configurability (not implemented)
 
-The batch cap is today a protocol constant (`MAX_OPS = 100`, defined in
-`khive-request` and re-exported through its crate root). The parser stays pure:
-ADR-016 makes `khive-request` a zero-runtime-dependency parser shared by every
-transport, and a config-dependent parse would let the same stored input (a scheduled
-action, a replayed request) parse under one deployment and fail under another.
-Instead, the deployment cap is enforced **at the runtime boundary before dispatch**:
-`MAX_OPS` remains the protocol ceiling the parser enforces unconditionally, and a
-`[request] max_ops` setting (default 100, valid range 1..=`MAX_OPS`) is checked after
-parse, rejecting the batch with the existing typed op-count error. The authority
-model is single: the process performing the dispatch applies its own configured
-limit. The 1 MiB input length bound stays a parser constant.
+The shipped batch cap is the protocol constant `MAX_OPS = 100`, defined in
+`khive-request` and re-exported through its crate root. The parser stays pure: ADR-016
+makes `khive-request` a zero-runtime-dependency parser shared by every transport, and a
+config-dependent parse would let the same stored input parse under one deployment and fail
+under another.
+
+This amendment also decides that a future `[request] max_ops` setting (default 100, valid
+range 1..=`MAX_OPS`) belongs at the runtime boundary after parse, while the 1 MiB input
+length bound remains a parser constant. Current code has no such config field or post-parse
+deployment check; only the fixed protocol ceiling is enforced. This paragraph records the
+accepted placement for future implementation, not a shipped operator knob.
 
 ### Consequences
 
-- Positive: usage accounting by executed actuals becomes possible for every consumer
-  (quota policy, operators, external usage readers) without estimating from request
-  shape; the F2 read-time maintenance work and graph-expansion costs become visible
-  per-dispatch for the first time; Amendment 1's open weight table gains an empirical
-  calibration source.
+- Positive: usage accounting by executed actuals is available on the instrumented MCP paths
+  without estimating solely from request shape; graph-expansion costs become visible
+  per-dispatch, and Amendment 1's open weight table gains a partial empirical calibration
+  source. The gaps listed in the lifecycle note above bound that claim.
 - Negative: seven increment sites to keep honest as retrieval paths evolve; a
   regression test per counter per representative verb is required at implementation
   time so a refactor cannot silently zero a counter, plus the two propagation-class

--- a/docs/adr/ADR-111-blob-store.md
+++ b/docs/adr/ADR-111-blob-store.md
@@ -1,7 +1,8 @@
 # ADR-111: BlobStore — Content-Addressed Binary Object Storage
 
 **Status**: accepted
-**Date**: 2026-07-12 (amended 2026-07-13, PR #922; Amendment 2 proposed 2026-07-16; Amendment 3
+**Date**: 2026-07-12 (amended 2026-07-13, PR #922; Amendment 2 accepted and implemented
+2026-07-17, PR #1054; Amendment 3
 accepted 2026-07-17; Amendment 4 accepted 2026-07-19)
 **Authors**: khive maintainers
 **Depends on**:
@@ -241,11 +242,11 @@ deletes blob files directly, so a blob referenced from two places is never remov
 concurrent reader by a consumer-side heuristic. `BlobStore` owns the deletion policy; consumers only
 ever add references and let GC reconcile.
 
-**Concurrency guarantee: offline-maintenance-only (amended 2026-07-13).** The paragraph above, as
-originally written, claimed this design "is never removed out from under a concurrent reader".
-That claim was not true of the shipped implementation and has
-been corrected here rather than left standing. Both `delete` and `orphan_sweep` are
-**offline-maintenance-only** APIs, not safe to run against a live entity writer:
+**Concurrency guarantee: choose the API deliberately (amended 2026-07-23, PR #1313).** The
+paragraph above, as originally written, claimed this design "is never removed out from under a
+concurrent reader". That remains false for `delete` and the caller-snapshot
+`orphan_sweep(config)` API. Both are **offline-maintenance-only**, not safe to run against a live
+entity writer:
 
 - `orphan_sweep`'s `live_refs` set is a **snapshot** the caller assembles before the call. Nothing
   in `BlobStore` detects a `content_ref` that becomes newly live — an entity write lands
@@ -257,20 +258,33 @@ been corrected here rather than left standing. Both `delete` and `orphan_sweep` 
   delete a `content_ref` an entity write races into existence a moment later, with no coordination
   from this trait.
 
-The actual guarantee is narrower than the original text implied: **run `orphan_sweep` and `delete`
-only when writes that could create a new `content_ref` reference are quiesced** — a maintenance
-window, a single-writer admin CLI invocation with no live traffic, or equivalent. `BlobStore` has no
-visibility into the entity substrate (ADR-005 constraint 4) and therefore cannot enforce this
-itself; it is a caller obligation, now stated explicitly on `BlobStore::delete` and
-`BlobStore::orphan_sweep`'s doc comments.
+Run those two methods only when writes that could create a new `content_ref` reference are
+quiesced. `BlobStore::transactional_orphan_sweep(sql, dry_run)`, added by PR #1313, is the live-
+traffic alternative for backends that can coordinate both stores. The filesystem implementation:
 
-A transactional, DB-coordinated sweep — selecting and deleting live/orphaned blobs under the entity
-writer's own transactional boundary, so the sweep is safe to run concurrently with normal traffic —
-would close this hazard properly. That is a larger design (does it live in `khive-storage` as a new
-capability, or in `khive-runtime` orchestrating `BlobStore` + `SqlAccess`/`GraphStore` together?)
-left to a follow-up: [khive#924](https://github.com/ohdearquant/khive/issues/924). It is
-**deliberately not built as part of this fix**. The scoped correction makes the existing hazard
-explicit and tested without expanding into a larger coordination design.
+1. acquires the canonical-root in-process and advisory write locks and captures the complete blob
+   candidate set while publishers are excluded;
+2. enters `SqlAccess::atomic_unit` (`BEGIN IMMEDIATE` on SQLite), selects distinct references from
+   non-deleted entities, and retains the entity-writer boundary through physical deletion; and
+3. deletes only candidates absent from that transaction's live-reference set.
+
+This yields two concurrency guarantees pinned by tests. A blob published after candidate capture
+is not in the sweep set and survives. A committed entity reference cannot appear or disappear
+between the liveness query and physical deletion because both occur under the entity writer's
+transaction. Invalid stored `content_ref` values fail closed rather than making the sweep delete
+against an incomplete live set.
+
+The guarantee still has a bounded publish gap. `put(bytes)` and the later entity write that stores
+its returned reference are separate client steps, outside one shared transaction. A candidate with
+no committed reference is therefore protected by file age: `FsBlobStore` defaults to a one-hour
+grace period, treats an unknown age as protected, and refreshes the mtime on a deduplicated `put`.
+A client whose put-to-reference gap exceeds the configured grace remains exposed to deletion.
+Tests cover a fresh unreferenced publish, deduplicated republication, zero-grace behavior, and
+deletion after grace expiry; the warning is not weakened beyond that evidence.
+
+`S3BlobStore` does not override `transactional_orphan_sweep` and returns `Unsupported`; its
+caller-snapshot `orphan_sweep` has no publish-grace accounting and remains offline-maintenance-
+only. Unconditional `delete` remains offline-maintenance-only on both backends.
 
 ---
 
@@ -332,10 +346,9 @@ misses.
   serialized value is rejected at deserialization instead of later panicking in `shard_path`.
   `FsBlobStore::put`'s floor check now accounts for the pending write's own size. `delete` and
   `orphan_sweep` are now explicitly documented (trait doc comments, §8 above) as
-  offline-maintenance-only, requiring quiesced entity writes — a real, undefended concurrency hazard
-  the original §8 text incorrectly described as absent. A DB-coordinated transactional sweep that
-  would close that hazard is tracked as a follow-up, not built here:
-  [khive#924](https://github.com/ohdearquant/khive/issues/924).
+  offline-maintenance-only, requiring quiesced entity writes — a real concurrency hazard the
+  original §8 text incorrectly described as absent. PR #1313 later added the distinct filesystem
+  `transactional_orphan_sweep` path described in §8; it did not make these legacy methods safe.
 - **Further amendment (same date):** the first fix for serializing `put` scoped
   its `tokio::sync::Mutex` to one
   `FsBlobStore` instance and borrowed the guard across the async fn's own frame — insufficient,
@@ -350,8 +363,12 @@ misses.
 
 ## Amendment 2 (2026-07-16): S3-compatible backend
 
-**Status:** proposed amendment. The accepted filesystem decision and the existing `BlobStore`
-trait remain unchanged while this amendment passes the implementation specification gate.
+**Status:** accepted and implemented. PR
+[#1054](https://github.com/ohdearquant/khive/pull/1054) merged on 2026-07-17 as
+`439b7d30561710c5272e76bd5b3e7e836caacca2`, adding `S3BlobStore`, strict
+`[storage.blob]` selection, single- and multi-backend boot wiring, shared conformance tests,
+fake-client failure tests, and the MinIO compatibility job. The filesystem decision and provider-
+neutral `BlobStore` boundary remain in force.
 
 ### Context and decision
 
@@ -451,10 +468,12 @@ concurrent `put` calls.
 
 No object-store mutex replaces the §8 safety requirement because an in-process lock would not solve
 it. The hazardous race is between a database snapshot of live `content_ref`s and a later entity
-write, potentially across processes and storage systems. `delete` and `orphan_sweep` therefore
-remain offline-maintenance-only for S3 and require deployment-wide quiescence of every writer that
-can create a new entity reference for the full snapshot-plus-sweep interval. The transactional,
-DB-coordinated design remains khive#924.
+write, potentially across processes and storage systems. `delete` and the caller-snapshot
+`orphan_sweep` therefore remain offline-maintenance-only for S3 and require deployment-wide
+quiescence of every writer that can create a new entity reference for the full snapshot-plus-sweep
+interval. PR #1313 implemented `transactional_orphan_sweep` only for `FsBlobStore`;
+`S3BlobStore` retains the trait default (`Unsupported`) and does not inherit the filesystem grace-
+period guarantee.
 
 Out-of-band lifecycle policies have the same limitation and must not delete objects from the live
 BlobStore prefix.
@@ -550,9 +569,10 @@ tests.
 - Existing configurations continue to select `FsBlobStore` with the current root and floor
   behavior.
 - S3 deployments gain off-host blob storage but must provide environment credentials, an
-  unversioned bucket, and an offline maintenance window for deletion and sweep.
-- `BlobStore` still does not provide transactional reference GC; this amendment does not close or
-  weaken khive#924.
+  unversioned bucket, and an offline maintenance window for deletion and caller-snapshot sweep.
+- The later provider-neutral `transactional_orphan_sweep` trait method does not imply S3 support:
+  the S3 backend returns `Unsupported`, while the filesystem backend implements the coordinated
+  guarantee and grace-period boundary described in §8.
 
 ---
 
@@ -701,8 +721,12 @@ unauthenticated callers, or telemetry that leaves the deployment boundary.
   `write_lock_for_root`/`root_write_locks` (the canonical-root-keyed shared-lock registry),
   `crosses_floor` (the pure write-size-aware floor comparison).
 - `crates/khive-db/src/backend.rs` — `StorageBackend::blob_store`.
-- Amendment 2 proposes `S3BlobStore` beside `FsBlobStore` plus one config-aware boot-layer selector;
+- `crates/khive-db/src/stores/blob_s3.rs` — shipped `S3BlobStore` implementation from PR #1054.
+- `crates/khive-runtime/src/blob.rs`, `crates/khive-runtime/src/engine_config.rs`, and
+  `crates/khive-mcp/src/serve.rs` — config-aware blob-store selection and boot wiring from PR #1054;
   no provider type enters `khive-storage`.
+- `crates/khive-storage/src/blob.rs` and `crates/khive-db/src/stores/blob.rs` — provider-neutral
+  transactional sweep contract and filesystem implementation from PR #1313.
 - `crates/khive-db/sql/010-entities-content-ref.sql` — migration V10.
 - `crates/khive-db/sql/entities-ddl.sql` — mirrored `content_ref` column + index.
 - `crates/khive-db/src/stores/entity.rs` — `content_ref` threaded through
@@ -720,8 +744,10 @@ unauthenticated callers, or telemetry that leaves the deployment boundary.
 - PR #922 follow-up confirmed the deserialization fix and found the floor-guard fix
   incomplete (not actually per-root, not cancellation-safe) and this ADR's `ContentRef` example
   stale.
-- [khive#924](https://github.com/ohdearquant/khive/issues/924) — follow-up: transactional,
-  DB-coordinated `BlobStore` orphan sweep.
+- [khive#924](https://github.com/ohdearquant/khive/issues/924) — transactional,
+  DB-coordinated `BlobStore` orphan sweep, closed by PR
+  [#1313](https://github.com/ohdearquant/khive/pull/1313) on 2026-07-23
+  (`c716e9821ba60f444d0400b3004893c2f4c175e5`).
 - [khive#1145](https://github.com/ohdearquant/khive/issues/1145) — capability-by-hash
   authorization model and `blob.stat` oracle posture (Amendment 4).
 - [`object_store` 0.13.2 S3 builder](https://docs.rs/object_store/0.13.2/object_store/aws/struct.AmazonS3Builder.html)

--- a/docs/adr/ADR-124-note-write-identity.md
+++ b/docs/adr/ADR-124-note-write-identity.md
@@ -31,6 +31,12 @@ general-purpose column reached by several runtime write paths that are kind-agno
 3. `update`, which merges a caller `properties` patch into the stored object.
 4. `merge`, which folds two already-written notes' properties together per a strategy.
 
+There is also a specialized direct-ingest path: `KhiveRuntime::try_create_note` uses
+`INSERT OR IGNORE` for transport-level deduplication and intentionally does not route through the
+generic create validator. `comm.ingest` constructs the inbound message identity and routing
+properties before calling it. That exception matters: "direct Rust caller" below means a caller of
+the `create_note*` family, not every Rust function capable of inserting a note.
+
 Each of those paths stores what it is given. Identity that is a function of the token on one
 path and a function of caller input on another is not identity; a stored value is only evidence
 of authorship if every path that can write it derives it the same way.
@@ -48,11 +54,12 @@ exist because a rule that lives in one pack's verb handler is not a rule about t
 `KhiveRuntime` gains `note_write_validator`, sibling to `entity_type_validator` and
 `note_mutation_hook`, installed at pack registration through
 `PackRuntime::register_note_write_validator`. It receives `(note_kind, actor_id,
-caller_properties)` and returns the properties to store. It is invoked at every runtime site
-that materialises a `Note` from caller-supplied properties — `create_note_inner` (the `create`
-verb and every direct Rust caller) and `prepare_add_note` (proposal apply). Kinds the
-installing pack does not own are returned unchanged; the slot is single-occupancy, like
-`note_mutation_hook`.
+caller_properties)` and returns the properties to store. It is invoked by the generic
+caller-supplied-property sites: `create_note_inner` (the `create` verb and direct Rust callers of
+the `create_note*` family) and `prepare_add_note` (proposal apply). It is deliberately not invoked
+by `try_create_note`, whose channel-ingest caller constructs transport identity before the
+deduplicating insert. Kinds the installing pack does not own are returned unchanged; the slot is
+single-occupancy, like `note_mutation_hook`.
 
 `khive-pack-comm` installs one that derives a `message` note's `from_actor` from the
 authorization token, using the same `token.actor().id` resolution `comm.send` already performs,
@@ -277,8 +284,10 @@ carried on the changeset itself and is out of scope here.
 
 ## Consequences
 
-- Identity on a `message` row is a function of the authorization token on every runtime write
-  path, including direct Rust callers and proposal apply.
+- On the generic create family and proposal apply, a `message` row's derived identity is a
+  function of the authorization token, including direct Rust callers of `create_note*`.
+  `try_create_note` is the explicit exception: `comm.ingest` supplies transport-derived inbound
+  identity before that deduplicating insert, and the generic validator does not run there.
 - A bare runtime with no packs installs neither the validator nor the kind set, so all four
   rules are inert there and embedded/unit-test callers keep their current behaviour.
 - Packs owning other identity-bearing kinds can install their own derivation without a new

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -464,27 +464,27 @@ let do_sections  = do_knowledge && !args.no_sections;
 So `--sections-only` forces `do_atoms = false` regardless of `--no-sections`'s state; it is the
 narrowest possible scope, not just "skip the graph pass."
 
-**`--keep-existing`**: without it (default), every existing vector row for the staged
-`subject_id`s in a model's table is deleted up front (`drop_vectors_for_subjects`,
-`reindex.rs:305-310`); necessary because the vector table's primary key is `(subject_id)` only,
-not `(subject_id, namespace)`, so a namespace relabel followed by reindex would otherwise collide.
-Every staged record is then re-embedded unconditionally. With `--keep-existing`, no delete runs at
-all, and the batch is narrowed to subjects **not already present for that specific model +
-namespace** (`filter_unembedded`, `reindex.rs:326-338`). Within that narrowing, only the specific
-case of `StorageError::Unsupported` (a backend that doesn't implement existence checks at all)
-falls back to the conservative "assume nothing is embedded, re-embed everything" path
-(`reindex.rs:425-440`); any other `batch_exists` error instead skips that model's batch entirely
-and counts it as a failure (`reindex.rs:327-340`); it does not silently re-embed.
+**`--keep-existing`**: without it (default), every staged record is re-embedded and handed to
+`VectorStore::insert_batch`. Each subject's old vector is replaced with the new vector in one
+per-record savepoint; there is no committed pre-delete, so a failed embed or insert leaves the
+prior vector stale rather than absent. With `--keep-existing`, the batch is narrowed to subjects
+**not already present for that specific model + namespace** (`filter_unembedded`). Within that
+narrowing, only `StorageError::Unsupported` (a backend that does not implement existence checks)
+falls back to the conservative "assume nothing is embedded, re-embed everything" path. Any other
+`batch_exists` error skips that model's batch and counts it as a failure; it does not silently
+re-embed. In both modes the selected graph pass still backfills FTS. There is no
+`--embeds-only` mode.
 
 **`--best-effort` vs. the fail-closed default**: `ReindexReport::has_failures()`
-(`reindex.rs:228-236`) is a single predicate covering seven categories: vector embed/insert
+(`reindex.rs`) is a single predicate covering eight categories: vector embed/insert
 errors, entity FTS failures, note FTS failures, knowledge atom failures, a knowledge pass that
 didn't complete, Vamana ANN build/persist failure, and knowledge section failures. Without
 `--best-effort`, any of these causes `run_reindex` to `bail!`: "reindex completed with failures;
 recall/search state may be stale. Re-run, or pass `--best-effort` to accept a partial rebuild."
 With `--best-effort`, the same conditions only print a stderr warning and the process still exits
-0 (`reindex.rs:741-758`). **All seven categories are treated uniformly**; there is no failure
-class that's exempt from `--best-effort` on one side or immune to it on the other. What
+0 (`reindex.rs:741-758`). **All eight categories are treated uniformly**; there is no failure
+class that's exempt from `--best-effort` on one side or immune to it on the other. A failed
+completion epoch bump is the eighth category. What
 `--best-effort` cannot paper over are structural/setup failures that occur _before_ a report even
 exists: a bad `--namespace` value, a config resolution failure, a failed runtime open, a failed
 `authorize`, or a failed page-list call abort the whole run via `?` regardless of the flag.


### PR DESCRIPTION
> AI-assisted contribution: Codex prepared this change and PR description.

## Summary

- replace stale embedding commands and automatic commit/sync claims with the shipped inline-write and `kkernel reindex` workflow
- record the verified implementation status and remaining gaps for ADR-103 resource attribution and ADR-111 blob-store S3/orphan sweeping
- narrow ADR-124's validator claim around the intentional direct-ingest bypass and align related operational/VCS documentation

Closes #1412.
Closes #1413.
Closes #1414.
Closes #1466.

## Test plan

- [x] `sh scripts/lint-adr-refs.sh --self-test`
- [x] `sh scripts/lint-adr-refs.sh`
- [x] `deno fmt --check` on every changed Markdown file
- [x] `git diff --check`
- [ ] `cargo test --workspace` (documentation/comment-only change; withheld to honor the 80 GiB free-space floor)
- [ ] `cargo clippy --workspace -- -D warnings` (documentation/comment-only change; withheld for the same reason)
- [ ] `cargo fmt --all -- --check` (no Rust syntax changed; the only Rust edit is a documentation comment)

## ADR

This PR corrects ADR-035, ADR-103, ADR-111, and ADR-124 against behavior verified in current code and tests; it introduces no new architectural decision.

## AI-assisted contribution checklist

- [x] Every claim in this PR description matches the actual diff
- [x] Any agent-authored comment / PR body starts with an attribution line
- [x] No behavior-changing code was added
- [x] No typed-relation, kind, supersession, annotation, or namespace semantics changed

## Out of scope

- ADR-035 config-discovery/init-path claims tracked separately from the embedding workflow
- implementing remaining ADR-103 usage counters or deployment-level request limits
- online S3 orphan sweeping
