### PR TITLE
fix(comm): emit collision-safe inbox ids

### DIFF
--- a/crates/khive-pack-comm/src/message.rs
+++ b/crates/khive-pack-comm/src/message.rs
@@ -55,6 +55,7 @@ async fn rollback_outbound(
 
 pub(crate) fn note_to_message_json(note: &Note) -> Value {
     let props = note.properties.as_ref();
+    let full_id = note.id.as_hyphenated().to_string();
 
     let from = props
         .and_then(|p| p.get("from_actor"))
@@ -85,8 +86,12 @@ pub(crate) fn note_to_message_json(note: &Note) -> Value {
     let preview = build_preview(&note.content);
 
     json!({
-        "id": short_id(note.id),
-        "full_id": note.id.as_hyphenated().to_string(),
+        // `id` is the round-trippable identifier. Keep `full_id` as a
+        // compatibility alias and expose the ambiguous prefix only as an
+        // explicitly display-oriented field (#1421).
+        "id": full_id.clone(),
+        "short_id": short_id(note.id),
+        "full_id": full_id,
         "kind": "message",
         "from": from,
         "to": to,
@@ -462,6 +467,17 @@ mod tests {
         assert_eq!(v["read"], json!(false));
         assert!(v["content"].is_string());
         assert!(v["properties"].is_object());
+    }
+
+    #[test]
+    fn message_ids_are_round_trippable_with_separate_compact_display_id() {
+        let note = make_note("local", "hello", None);
+        let full_id = note.id.as_hyphenated().to_string();
+        let v = note_to_message_json(&note);
+
+        assert_eq!(v["id"], json!(full_id));
+        assert_eq!(v["full_id"], v["id"]);
+        assert_eq!(v["short_id"], json!(short_id(note.id)));
     }
 
     #[test]

--- a/crates/khive-pack-comm/tests/integration.rs
+++ b/crates/khive-pack-comm/tests/integration.rs
@@ -436,6 +436,34 @@ async fn test_short_id_collision_errors_clearly() {
     builder.register(khive_pack_comm::CommPack::new(rt.clone()));
     let registry = builder.build().expect("registry");
 
+    // The inbox must never emit the ambiguous prefix as its actionable `id`.
+    // Both colliding rows remain individually round-trippable through read.
+    let inbox = registry
+        .dispatch("comm.inbox", serde_json::json!({ "status": "all" }))
+        .await
+        .expect("inbox succeeds with colliding UUID prefixes");
+    let messages = inbox["messages"].as_array().expect("messages array");
+    assert_eq!(messages.len(), 2);
+    let returned_ids = messages
+        .iter()
+        .map(|message| {
+            assert_eq!(message["short_id"].as_str(), Some(base));
+            let id = message["id"].as_str().expect("round-trippable id");
+            assert_eq!(message["full_id"].as_str(), Some(id));
+            id.to_string()
+        })
+        .collect::<std::collections::HashSet<_>>();
+    assert_eq!(
+        returned_ids,
+        [uuid_a.to_string(), uuid_b.to_string()].into()
+    );
+    for id in &returned_ids {
+        registry
+            .dispatch("comm.read", serde_json::json!({ "id": id }))
+            .await
+            .expect("every inbox id is accepted by comm.read");
+    }
+
     let err = registry
         .dispatch("comm.read", serde_json::json!({ "id": base }))
         .await
@@ -445,6 +473,10 @@ async fn test_short_id_collision_errors_clearly() {
     assert!(
         msg.contains("ambiguous"),
         "ambiguous prefix error must mention 'ambiguous': got {msg:?}"
+    );
+    assert!(
+        msg.contains(&uuid_a.to_string()) && msg.contains(&uuid_b.to_string()),
+        "ambiguity error must name distinguishable full UUIDs: got {msg:?}"
     );
 }
 // ── UE6 Critical F-C3: dual-write delivery tests ─────────────────────────────
@@ -591,6 +623,30 @@ async fn test_inbox_returns_inbound_for_recipient() {
     assert_eq!(
         props.get("direction").and_then(|v| v.as_str()),
         Some("inbound")
+    );
+
+    let id = msgs[0]
+        .get("id")
+        .and_then(|value| value.as_str())
+        .expect("inbox message exposes a round-trippable id");
+    let short_id = msgs[0]
+        .get("short_id")
+        .and_then(|value| value.as_str())
+        .expect("inbox message exposes a compact display id");
+    let full_id = msgs[0]
+        .get("full_id")
+        .and_then(|value| value.as_str())
+        .expect("inbox message exposes a full id");
+    assert_eq!(short_id.len(), 8);
+    assert_eq!(id, full_id);
+
+    let read = registry
+        .dispatch("comm.read", serde_json::json!({ "id": id }))
+        .await
+        .expect("the id returned by inbox round-trips through comm.read");
+    assert_eq!(
+        read.get("full_id").and_then(|value| value.as_str()),
+        Some(full_id)
     );
 }
 

--- a/crates/khive-runtime/src/error.rs
+++ b/crates/khive-runtime/src/error.rs
@@ -317,11 +317,11 @@ pub fn fts_text_leg_or_err<T>(
 }
 
 fn format_uuid_list(uuids: &[uuid::Uuid]) -> String {
-    let shorts: Vec<String> = uuids
+    uuids
         .iter()
-        .map(|u| u.to_string()[..8].to_string())
-        .collect();
-    shorts.join(", ")
+        .map(uuid::Uuid::to_string)
+        .collect::<Vec<_>>()
+        .join(", ")
 }
 
 /// Maps the dependency-light `khive-types` entity-type resolution error onto

--- a/docs/guide/api-reference.md
+++ b/docs/guide/api-reference.md
@@ -1086,6 +1086,11 @@ List inbound messages for the caller.
 request(ops="comm.inbox(limit=10)")
 ```
 
+Every returned message uses the hyphenated full UUID for `id`, so the value is
+always accepted unchanged by `comm.read`, `comm.reply`, or `comm.thread`, even
+when two messages share an eight-character prefix. `full_id` remains an alias
+for compatibility, while `short_id` is the compact display-only prefix.
+
 ### `comm.read` — Declaration
 
 Mark an inbound message as read. Outbound messages cannot be marked read.


### PR DESCRIPTION
> AI-assisted contribution: Codex prepared this change and PR description.

## Summary

- emit full, collision-safe UUIDs as `id` on inbox and thread message rows while retaining `full_id` as a compatibility alias
- expose the eight-character prefix separately as display-only `short_id`
- make ambiguous-prefix errors list distinguishable full UUIDs and cover a real two-message prefix collision end to end

Closes #1421.

## Test plan

- [x] focused collision regression (`test_short_id_collision_errors_clearly`)
- [x] `cargo test -p khive-pack-comm --all-features` (53 unit, 157 integration, and 25 probe tests passed)
- [x] `cargo check -p khive-pack-comm --all-targets --all-features`
- [x] `cargo clippy -p khive-pack-comm --all-targets --all-features -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] `deno fmt --check docs/guide/api-reference.md`
- [ ] `cargo test --workspace` (affected-crate coverage is complete; full-workspace build was withheld to honor the 80 GiB free-space floor)

## ADR

n/a — this changes identifier presentation to satisfy the existing round-trip contract; message routing and namespace semantics are unchanged.

## AI-assisted contribution checklist

- [x] Every claim in this PR description matches the actual diff
- [x] Any agent-authored comment / PR body starts with an attribution line
- [x] `cargo test` output included for behavior-changing code
- [x] No typed-relation, kind, supersession, annotation, or namespace semantics changed

## Out of scope

- removing support for caller-supplied short prefixes
- changing send/reply write responses, delivery, or thread routing
