### PR TITLE
fix(runtime): honor configured salience decay rate

### DIFF
--- a/crates/khive-runtime/README.md
+++ b/crates/khive-runtime/README.md
@@ -18,8 +18,9 @@ verb-dispatch machinery that lets packs (`kg`, `gtd`, `memory`, …) extend the 
   `EntityDedupMergePolicy`) — update/merge semantics per
   [ADR-014](https://github.com/ohdearquant/khive/blob/main/docs/adr/ADR-014-curation-operations.md)
 - **Retrieval objectives** (`RrfFusionObjective`, `VectorSimilarityObjective`,
-  `TextRelevanceObjective`, `TemporalRecencyObjective`, `DecayAwareSalienceObjective`, …)
-  composed into a `MemoryRecallPipeline`
+  `TextRelevanceObjective`, `TemporalRecencyObjective`,
+  `AmplifiedDecayAwareSalienceObjective`, …) composed into a `MemoryRecallPipeline`, plus
+  `DecayAwareSalienceObjective` for standalone fixed-rate scoring
 - **Graph traversal** (`PathNode`) and **validation** (`ValidationRule`,
   `ValidationReport`, `Violation`) for domain-specific graph-shape rules
 - **Daemon** (unix only) — `run_daemon`, socket/pid path helpers, and the

--- a/crates/khive-runtime/docs/design.md
+++ b/crates/khive-runtime/docs/design.md
@@ -96,7 +96,9 @@
 
 - Memory decay formula: `effective_salience = salience * exp(-decay_factor * age_days)`
 - Default decay rate: 0.01 (~69-day half-life)
-- Per-note `decay_factor` is used by `DecayAwareSalienceObjective` rather than the objective's own rate
+- The active memory pipeline applies each note's `decay_factor` before
+  `AmplifiedDecayAwareSalienceObjective`; the standalone `DecayAwareSalienceObjective` applies
+  its constructor-supplied fixed rate instead
 
 ### Declarative Pack Format (ADR-023)
 

--- a/crates/khive-runtime/src/objectives.rs
+++ b/crates/khive-runtime/src/objectives.rs
@@ -145,8 +145,8 @@ impl Objective<NoteCandidate> for RrfFusionObjective {
 
 /// Pre-computed signals for a single memory note candidate.
 ///
-/// Used by the recall pipeline's `ComposePipeline` to score and rank candidates
-/// via `DecayAwareSalienceObjective`, `TemporalRecencyObjective`, and
+/// Used by the recall pipeline to score and rank candidates via
+/// `AmplifiedDecayAwareSalienceObjective`, `TemporalRecencyObjective`, and
 /// `RerankerObjective` without any IO. The runtime layer populates this struct
 /// from stored notes before handing the slice to the pipeline.
 #[derive(Debug, Clone)]
@@ -183,24 +183,28 @@ impl HasId for NoteCandidate {
 
 /// Scores a `NoteCandidate` by salience with configurable temporal decay.
 ///
-/// The decay formula is determined by the configured `DecayModel` (injected at
-/// construction time). The default `DecayModel::Exponential` uses the note's own
-/// `decay_factor`: `salience * exp(-decay_factor * age_days)`.
+/// Uses the fixed exponential rate supplied at construction:
+/// `salience * exp(-decay_rate * age_days)`. It does not read the candidate's
+/// per-note `decay_factor`. The memory recall pipeline applies its configured
+/// `DecayModel` before scoring and uses `AmplifiedDecayAwareSalienceObjective`
+/// over the resulting `effective_salience` instead.
 ///
-/// This objective participates in `WeightedObjective` composition alongside
-/// `RrfFusionObjective` and `TemporalRecencyObjective` to form the full recall
-/// scoring pipeline.
+/// This objective remains useful for callers that want one decay policy across
+/// every candidate in a `WeightedObjective` composition.
 pub struct DecayAwareSalienceObjective {
-    /// Exponential decay rate k (>= 0.0). Score = `salience * exp(-k * age_days)`.
-    /// Corresponds to the per-note `decay_factor` parameter stored on memory notes.
-    pub decay_rate: f64,
+    decay_rate: f64,
 }
 
 impl DecayAwareSalienceObjective {
-    /// Create a new objective with the given exponential decay rate.
+    /// Create a new objective with the given exponential decay rate. Panics if
+    /// `decay_rate` is negative or non-finite.
     ///
     /// `decay_rate = 0.01` gives a ~69-day half-life (default for memory notes).
     pub fn new(decay_rate: f64) -> Self {
+        assert!(
+            decay_rate.is_finite() && decay_rate >= 0.0,
+            "decay_rate must be finite and non-negative, got {decay_rate}"
+        );
         Self { decay_rate }
     }
 
@@ -213,7 +217,7 @@ impl DecayAwareSalienceObjective {
 impl Objective<NoteCandidate> for DecayAwareSalienceObjective {
     #[inline]
     fn score(&self, candidate: &NoteCandidate, _context: &ObjectiveContext) -> f64 {
-        candidate.salience * (-candidate.decay_factor * candidate.age_days).exp()
+        candidate.salience * (-self.decay_rate * candidate.age_days).exp()
     }
 
     fn name(&self) -> &str {
@@ -644,29 +648,49 @@ mod tests {
     }
 
     #[test]
-    fn decay_aware_uses_note_decay_factor_not_field() {
-        // Scoring uses the note's own decay_factor, not the objective's field.
-        let obj = DecayAwareSalienceObjective::new(0.99); // obj.decay_rate ignored
-        let c = note_candidate(None, 1.0, 0.01, 100.0);
-        let score = obj.score(&c, &ctx());
-        let expected = (-0.01_f64 * 100.0).exp();
+    fn decay_aware_configured_rates_produce_expected_distinct_scores() {
+        let slow = DecayAwareSalienceObjective::new(0.01);
+        let fast = DecayAwareSalienceObjective::new(0.1);
+        let c = note_candidate(None, 0.8, 0.99, 10.0);
+
+        let slow_score = slow.score(&c, &ctx());
+        let fast_score = fast.score(&c, &ctx());
+        let expected_slow = 0.8 * (-0.01_f64 * 10.0).exp();
+        let expected_fast = 0.8 * (-0.1_f64 * 10.0).exp();
+
         assert!(
-            (score - expected).abs() < 1e-12,
-            "got {score}, expected {expected}"
+            (slow_score - expected_slow).abs() < 1e-12,
+            "got {slow_score}, expected {expected_slow}"
+        );
+        assert!(
+            (fast_score - expected_fast).abs() < 1e-12,
+            "got {fast_score}, expected {expected_fast}"
+        );
+        assert!(
+            slow_score > fast_score,
+            "slower configured decay should score higher: {slow_score} vs {fast_score}"
         );
     }
 
     #[test]
-    fn decay_aware_high_decay_reduces_score_faster() {
-        let obj = DecayAwareSalienceObjective::new(0.0);
+    fn decay_aware_does_not_read_candidate_decay_factor() {
+        let obj = DecayAwareSalienceObjective::new(0.05);
         let slow = note_candidate(None, 1.0, 0.001, 100.0);
         let fast = note_candidate(None, 1.0, 0.1, 100.0);
         let score_slow = obj.score(&slow, &ctx());
         let score_fast = obj.score(&fast, &ctx());
         assert!(
-            score_slow > score_fast,
-            "slow decay should score higher: {score_slow} vs {score_fast}"
+            (score_slow - score_fast).abs() < 1e-12,
+            "candidate decay_factor changed fixed-rate score: {score_slow} vs {score_fast}"
         );
+    }
+
+    #[test]
+    fn decay_aware_rejects_invalid_configured_rates() {
+        for bad in [-0.1, f64::NAN, f64::INFINITY, f64::NEG_INFINITY] {
+            let result = std::panic::catch_unwind(|| DecayAwareSalienceObjective::new(bad));
+            assert!(result.is_err(), "accepted invalid decay_rate {bad}");
+        }
     }
 
     // ── TemporalRecencyObjective ─────────────────────────────────────────


### PR DESCRIPTION
> AI-assisted contribution: Codex prepared this change and PR description.

## Summary

- make `DecayAwareSalienceObjective` apply its configured finite, non-negative exponential decay rate
- keep the active memory-recall pipeline's per-note `DecayModel` behavior unchanged and document the distinction
- add exact-score, rate-isolation, and invalid-configuration regressions

Closes #1350.

## Test plan

- [x] focused `decay_aware` tests (4 passed)
- [x] `cargo test -p khive-runtime --all-features` (1,004 unit, 98 integration, and 4 doctests passed; 7 tests ignored)
- [x] `cargo check -p khive-runtime --all-targets --all-features`
- [x] `cargo clippy -p khive-runtime --all-targets --all-features -- -D warnings`
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc -p khive-runtime --all-features --no-deps`
- [x] `cargo fmt --all -- --check`
- [x] `deno fmt --check crates/khive-runtime/README.md crates/khive-runtime/docs/design.md`
- [ ] `cargo test --workspace` (affected-crate coverage is complete; full-workspace build was withheld to honor the 80 GiB free-space floor)

## ADR

n/a — this restores the existing public objective contract; it does not change the active recall architecture.

## AI-assisted contribution checklist

- [x] Every claim in this PR description matches the actual diff
- [x] Any agent-authored comment / PR body starts with an attribution line
- [x] `cargo test` output included for behavior-changing code
- [x] No typed-relation, kind, supersession, annotation, or namespace semantics changed

## Out of scope

- changing per-note decay in `MemoryRecallPipeline`
- changing `AmplifiedDecayAwareSalienceObjective`
