### PR TITLE
fix(bm25): define zero-minimum tokenization

### DIFF
--- a/crates/khive-bm25/docs/api/index-lifecycle.md
+++ b/crates/khive-bm25/docs/api/index-lifecycle.md
@@ -15,6 +15,17 @@ configuration should use `try_new`. Defaults are `k1 = 1.2` and
 `Arc<dyn Tokenizer>`. Changing the tokenizer later affects only future indexing: existing postings
 are not re-tokenized.
 
+## Tokenizer changes and rebuilds
+
+When tokenizer semantics change, call `clear()` and repopulate the index from source text, or build
+a fresh index. Re-indexing the same IDs in place is not a complete rebuild: when replacement text
+has no indexable terms, `index_document` deliberately preserves the existing document.
+
+This applies to persisted indexes created before the `khive-text` tokenizer adoption with
+`SimpleTokenizer::new(_, 0)`. That older path could store an empty-string posting for a
+punctuation-only span; the current tokenizer always drops empty normalized terms. Indexes using the
+default minimum of one are unaffected by this specific change.
+
 ## `index_document`
 
 Indexing tokenizes and builds the replacement term-frequency map before mutating the index. Empty

--- a/crates/khive-bm25/docs/api/tokenizer.md
+++ b/crates/khive-bm25/docs/api/tokenizer.md
@@ -14,9 +14,18 @@ punctuation is retained), optionally lowercases, filters by minimum Unicode char
 optionally removes the built-in English stop-word set. Defaults enable lowercasing and stop-word
 removal with a minimum length of one.
 
+Punctuation trimming always drops an empty result before the length filter runs. A `min_length` of
+zero is therefore supported as “no minimum for non-empty normalized terms”; it never causes a
+punctuation-only span such as `!!!` to emit an empty-string term.
+
 The tokenizer composes `khive-text`'s shared whitespace, lowercase, length, and BM25 stop-word
 primitives. `Tokenizer` and `BoxedTokenizer` are re-exported from `khive-text`, so custom tokenizer
 implementations keep the same public interface.
+
+Indexes created before the `khive-text` tokenizer adoption with `SimpleTokenizer::new(_, 0)` may
+contain empty-string postings from punctuation-only spans. Deserialization does not re-tokenize
+stored documents. Rebuild those indexes from source text after upgrading; see
+[Index lifecycle and persisted state](index-lifecycle.md#tokenizer-changes-and-rebuilds).
 
 ## `tokenize`
 

--- a/crates/khive-bm25/src/tokenizer.rs
+++ b/crates/khive-bm25/src/tokenizer.rs
@@ -13,7 +13,10 @@ pub use khive_text::{BoxedTokenizer, Tokenizer};
 pub struct SimpleTokenizer {
     /// Whether to lowercase tokens.
     pub lowercase: bool,
-    /// Minimum token length (tokens shorter than this are filtered out).
+    /// Minimum Unicode-scalar token length after punctuation trimming.
+    ///
+    /// Zero disables the length threshold, but empty normalized tokens are
+    /// always discarded.
     pub min_length: usize,
     /// Whether to filter out English stop words.
     pub filter_stop_words: bool,
@@ -30,7 +33,10 @@ impl Default for SimpleTokenizer {
 }
 
 impl SimpleTokenizer {
-    /// Create a new SimpleTokenizer with specified options.
+    /// Create a new `SimpleTokenizer` with the specified options.
+    ///
+    /// `min_length = 0` is supported and retains every non-empty normalized
+    /// token; punctuation-only input still produces no terms.
     pub fn new(lowercase: bool, min_length: usize) -> Self {
         Self {
             lowercase,
@@ -136,6 +142,14 @@ mod tests {
     fn test_simple_tokenizer_min_length_counts_unicode_characters() {
         let tokenizer = SimpleTokenizer::new(true, 2);
         assert_eq!(tokenizer.tokenize("你 rust"), vec!["rust"]);
+    }
+
+    #[test]
+    fn test_simple_tokenizer_zero_min_length_never_emits_empty_terms() {
+        let tokenizer = SimpleTokenizer::new(true, 0);
+
+        assert!(tokenizer.tokenize("!!!").is_empty());
+        assert_eq!(tokenizer.tokenize("... alpha ???"), vec!["alpha"]);
     }
 
     #[test]


### PR DESCRIPTION
> AI-assisted contribution: Codex prepared this change and PR description.

## Summary

- define `min_length = 0` as disabling the length threshold only for non-empty normalized tokens
- preserve the source-compatible constructor while locking in that punctuation-only spans never emit empty-string terms
- document the targeted rebuild procedure for pre-`khive-text` persisted zero-minimum indexes

Closes #1344.

## Test plan

- [x] focused zero-minimum tokenizer regression
- [x] `cargo test -p khive-bm25 --all-features` (137 tests passed)
- [x] `cargo check -p khive-bm25 --all-targets --all-features`
- [x] `cargo clippy -p khive-bm25 --all-targets --all-features -- -D warnings`
- [x] `cargo fmt -p khive-bm25 -- --check`
- [x] `deno fmt --check` on both changed API documents
- [ ] `cargo test --workspace` (affected-crate coverage is complete; full-workspace build was withheld to honor the 80 GiB free-space floor)

## ADR

n/a — this documents and tests the adopted tokenizer normalization behavior without changing the public constructor.

## AI-assisted contribution checklist

- [x] Every claim in this PR description matches the actual diff
- [x] Any agent-authored comment / PR body starts with an attribution line
- [x] `cargo test` output included for behavior-changing code
- [x] No typed-relation, kind, supersession, annotation, or namespace semantics changed

## Out of scope

- restoring empty-string postings
- changing the default minimum length
- automatically rebuilding persisted indexes without their source text
