### PR TITLE
test(memory): stabilize ANN overfetch namespace regression

### DIFF
--- a/crates/khive-pack-memory/docs/recall-reliability.md
+++ b/crates/khive-pack-memory/docs/recall-reliability.md
@@ -31,7 +31,7 @@ The hardest race lands a write after a background task has chosen its generation
 
 The ANN graph spans all namespaces. Exact namespace overrides therefore require both post-filtering and enough over-fetch to find visible candidates when unrelated namespaces occupy the nearest positions.
 
-Coverage seeds many local filler vectors and a target in another namespace under deterministic fixed embeddings. With widening enabled the target appears; with `ann_overfetch_max_rounds = 1` it does not. A second case ensures widening is skipped when the graph's namespace set proves there are no hidden namespaces to filter. Tests retry only the warm-state precondition when asynchronous build completion is involved; they do not retry the whole assertion until it happens to pass.
+Coverage seeds many local filler vectors and a target in another namespace under deterministic fixed embeddings. With widening enabled the target appears; with `ann_overfetch_max_rounds = 1` it does not. The two arms run against the same test-owned graph: the test synchronously ensures the final seeded generation, drains the background warm guard, and verifies both namespaces are installed before dispatching either recall. It does not infer ANN readiness from a successful result, because the fresh-tail exact leg can surface a new target while the installed graph is still stale. A second case ensures widening is skipped when the graph's namespace set proves there are no hidden namespaces to filter.
 
 The absent-namespace case remains byte-identical to legacy behavior, an explicit namespace returns only that namespace, and invalid namespace text produces a per-operation error naming the bad value.
 

--- a/crates/khive-pack-memory/src/handlers/recall.rs
+++ b/crates/khive-pack-memory/src/handlers/recall.rs
@@ -4004,7 +4004,6 @@ mod tests {
     #[tokio::test]
     #[serial(background_tasks)]
     async fn ns733_recall_ann_overfetch_retry_loop_respects_effective_namespace() {
-        // Poll only through the bounded stale-serve window; never retry corpus setup.
         let rt = KhiveRuntime::memory().expect("in-memory runtime");
         rt.register_embedder(FixedVecProvider {
             model_name: NS733_ANN_MODEL.to_string(),
@@ -4013,7 +4012,9 @@ mod tests {
 
         let mut builder = VerbRegistryBuilder::new();
         builder.register(KgPack::new(rt.clone()));
-        builder.register(MemoryPack::new(rt.clone()));
+        let memory_pack = MemoryPack::new(rt.clone());
+        let ann = memory_pack.ann_for_test();
+        builder.register(memory_pack);
         let registry = builder.build().expect("registry");
 
         // Omitting the model fans out to the sole registered custom provider.
@@ -4046,6 +4047,30 @@ mod tests {
             .parse::<Uuid>()
             .expect("valid uuid");
 
+        // Establish readiness from this test's own ANN state rather than inferring it
+        // from a successful recall. The fresh-tail leg can surface the newest target
+        // while the installed bridge is still stale, which would make the following
+        // one-round assertion observe a different engine state under load. The
+        // single-flight ensure installs the complete seeded generation, and the idle
+        // barrier drains any fire-and-forget warm started by `memory.remember`.
+        let ann_key = crate::ann::AnnKey::from_token(NS733_ANN_MODEL);
+        let local_token = rt
+            .authorize(Namespace::local())
+            .expect("authorize local for deterministic ANN warm");
+        crate::ann::ensure_ann_for_model(&rt, &local_token, &ann, NS733_ANN_MODEL)
+            .await
+            .expect("synchronously warm the complete ns733 corpus");
+        crate::ann::wait_until_warm_idle(&ann, &ann_key).await;
+        assert!(
+            crate::ann::is_current(&ann, &ann_key).await,
+            "test-owned ANN must cover the final seeded generation"
+        );
+        assert_eq!(
+            crate::ann::index_namespace_set(&ann, &ann_key).await,
+            Some(HashSet::from(["local".to_string(), "bench-a".to_string()])),
+            "the installed graph must contain both namespaces before overfetch assertions"
+        );
+
         let base_params = serde_json::json!({
             "query": NS733_QUERY,
             "namespace": "bench-a",
@@ -4055,17 +4080,11 @@ mod tests {
             "limit": 1,
         });
 
-        // Case 1: default widening — the target must be found, and only the
-        // target. Poll (#791) until the background warm settles the target
-        // into the ANN cache.
-        let widened_result = recall_until(&registry, "memory.recall", base_params.clone(), |r| {
-            r.as_array().is_some_and(|hits| {
-                hits.len() == 1
-                    && hits[0]["id"].as_str().and_then(|s| s.parse::<Uuid>().ok())
-                        == Some(target_id)
-            })
-        })
-        .await;
+        // Case 1: default widening — the target must be found, and only the target.
+        let widened_result = registry
+            .dispatch("memory.recall", base_params.clone())
+            .await
+            .expect("memory.recall with default widening");
         let widened_hits = widened_result.as_array().expect("bare array result");
         assert_eq!(
             widened_hits.len(),


### PR DESCRIPTION
> AI-assisted contribution: Codex prepared this change and PR description.

## Summary

- synchronize the ns733 over-fetch regression on its test-owned ANN state and final seeded generation
- verify the installed graph is current and contains both expected namespaces before exercising either widening arm
- remove result polling that could confuse ADR-118 fresh-tail visibility with installed-graph readiness, and document the test contract

Closes #1425.

## Test plan

- [x] focused ns733 regression (1 test passed)
- [x] focused ns733 regression in 20 fresh test processes (20/20 passed)
- [x] `cargo test -p khive-pack-memory --all-features` (290 unit tests passed, 1 ignored; 86 integration tests passed)
- [x] `cargo check -p khive-pack-memory --all-targets --all-features`
- [x] `cargo clippy -p khive-pack-memory --all-targets --all-features -- -D warnings`
- [x] `cargo fmt -p khive-pack-memory -- --check`
- [x] `deno fmt --check crates/khive-pack-memory/docs/recall-reliability.md`
- [x] `git diff --check`
- [ ] `cargo test --workspace` (affected-package coverage and 20 fresh-process repetitions are complete; the full workspace build was withheld to preserve the requested 80 GiB free-space floor)

## ADR

ADR-118 remains unchanged: the test now distinguishes its fresh-tail serve path from the installed ANN generation before asserting over-fetch behavior.

## AI-assisted contribution checklist

- [x] Every claim in this PR description matches the actual diff
- [x] Any agent-authored comment / PR body starts with an attribution line
- [x] `cargo test` output included for behavior-changing code
- [x] No typed-relation, kind, supersession, annotation, or namespace semantics changed

## Out of scope

- changing production ANN warming or fresh-tail behavior
- changing namespace filtering or over-fetch policy
- retrying the assertion until it happens to pass
