### PR TITLE
fix(db): apply pack schema plans atomically

### DIFF
--- a/crates/khive-db/docs/persistence.md
+++ b/crates/khive-db/docs/persistence.md
@@ -32,6 +32,8 @@ The backend also provides:
 - `apply_pack_ddl_statements(stmts)` -- run pack-auxiliary DDL (ADR-017)
 - `sql()` -- raw `SqlAccess` bridge for the query compiler
 
+Each pack DDL plan is applied atomically in one transaction and remains idempotent on repeat application.
+
 ## Connection pooling
 
 `pool.rs` manages a writer lock (exclusive) and reader connections. All store

--- a/crates/khive-db/src/backend.rs
+++ b/crates/khive-db/src/backend.rs
@@ -124,10 +124,10 @@ impl StorageBackend {
 
     /// Apply pack-auxiliary DDL statements.
     ///
-    /// Executes each DDL statement idempotently via `execute_batch`. Each
-    /// statement MUST be self-contained and use `CREATE TABLE IF NOT EXISTS`
-    /// (or equivalent idempotent DDL) so that calling this method more than
-    /// once does not fail.
+    /// Executes the full plan in one transaction, applying each DDL statement
+    /// idempotently via `execute_batch`. Each statement MUST be self-contained
+    /// and use `CREATE TABLE IF NOT EXISTS` (or equivalent idempotent DDL) so
+    /// that calling this method more than once does not fail.
     ///
     /// Pack auxiliary tables are NOT tracked in `_schema_versions` — they are
     /// non-versioned. Use `apply_schema` with a `ServiceSchemaPlan` when version
@@ -143,10 +143,12 @@ impl StorageBackend {
         statements: &[&'static str],
     ) -> Result<(), SqliteError> {
         let writer = self.pool.try_writer()?;
-        for &stmt in statements {
-            writer.conn().execute_batch(stmt)?;
-        }
-        Ok(())
+        writer.transaction(|conn| {
+            for &stmt in statements {
+                conn.execute_batch(stmt)?;
+            }
+            Ok(())
+        })
     }
 
     /// Get an EntityStore. Applies the entities DDL if not already present.
@@ -1165,6 +1167,59 @@ mod tests {
             )
             .unwrap();
         assert_eq!(count, 1);
+    }
+
+    #[test]
+    fn pack_ddl_plan_rolls_back_all_statements_on_failure() {
+        let backend = StorageBackend::memory().unwrap();
+        let error = backend
+            .apply_pack_ddl_statements(&[
+                "CREATE TABLE IF NOT EXISTS pack_schema_first (id INTEGER PRIMARY KEY)",
+                "CREATE INDEX IF NOT EXISTS pack_schema_second ON pack_schema_missing(id)",
+            ])
+            .unwrap_err();
+
+        assert!(
+            error.to_string().contains("pack_schema_missing"),
+            "schema-plan error must retain the failing SQLite diagnostic: {error}"
+        );
+
+        let reader = backend.pool().reader().unwrap();
+        let visible_objects: i64 = reader
+            .conn()
+            .query_row(
+                "SELECT COUNT(*) FROM sqlite_master \
+                 WHERE name IN ('pack_schema_first', 'pack_schema_second')",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(visible_objects, 0);
+    }
+
+    #[test]
+    fn pack_ddl_plan_applies_all_statements_idempotently() {
+        const PLAN: &[&str] = &[
+            "CREATE TABLE IF NOT EXISTS pack_schema_success (id INTEGER PRIMARY KEY, value TEXT)",
+            "CREATE INDEX IF NOT EXISTS pack_schema_success_value_idx \
+             ON pack_schema_success(value)",
+        ];
+
+        let backend = StorageBackend::memory().unwrap();
+        backend.apply_pack_ddl_statements(PLAN).unwrap();
+        backend.apply_pack_ddl_statements(PLAN).unwrap();
+
+        let reader = backend.pool().reader().unwrap();
+        let visible_objects: i64 = reader
+            .conn()
+            .query_row(
+                "SELECT COUNT(*) FROM sqlite_master \
+                 WHERE name IN ('pack_schema_success', 'pack_schema_success_value_idx')",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(visible_objects, 2);
     }
 
     /// khive#1029 repro: a `create_entity`-shaped write sequence (entity


### PR DESCRIPTION
> AI-assisted contribution: Codex prepared this change and PR description.

## Summary

- execute every statement in one pack DDL plan inside the existing writer transaction boundary
- roll the entire plan back when any statement fails while preserving the underlying SQLite diagnostic
- cover rollback, complete success, repeat application, and the documented atomic/idempotent contract

Closes #1430.

## Test plan

- [x] focused `pack_ddl_plan` regressions (2 passed)
- [x] `cargo test -p khive-db --all-features` (559 passed across package targets)
- [x] `cargo check -p khive-db --all-targets --all-features`
- [x] `cargo clippy -p khive-db --all-targets --all-features -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] `deno fmt --check crates/khive-db/docs/persistence.md`
- [x] `git diff --check`
- [ ] `cargo test --workspace` (the complete affected package is green; the full workspace build was withheld to preserve the requested 80 GiB free-space floor)

## ADR

n/a — this enforces the existing ADR-017 pack-schema-plan contract using the database writer's established transaction primitive.

## AI-assisted contribution checklist

- [x] Every claim in this PR description matches the reviewed diff and test evidence
- [x] The PR body starts with the required attribution line
- [x] Behavior-changing code has passing affected-package tests
- [x] No schema version, pack DDL contents, connection-pool policy, or public API shape changed

## Out of scope

- versioning pack-auxiliary schemas in `_schema_versions`
- changing runtime bootstrap's per-plan failure policy
