### PR TITLE
fix(runtime): tighten secret gate exemptions

### DIFF
--- a/crates/khive-runtime/docs/api/secret_gate.md
+++ b/crates/khive-runtime/docs/api/secret_gate.md
@@ -32,9 +32,18 @@ through to explicit detection instead of being silently allowed.
   whitespace. The literal-prefix checks (Layer 1) treat any non-ASCII-alphanumeric char (CJK,
   accented text, emoji) as a token boundary, so a known-prefix secret is caught whether the
   adjacent non-ASCII sits before the prefix (`数据AKIA…`) or after it (`AKIA…数据`).
+- Known provider prefixes (Layer 1) require the configured minimum token length and reject one
+  narrow filename shape: after the prefix, a payload ending in `.py`, `.rs`, `.ts`, `.js`, `.sh`,
+  `.md`, `.toml`, or `.json` is treated as a source filename only when its stem contains lowercase
+  ASCII letters, contains at least one filename separator, and otherwise consists solely of
+  lowercase letters plus `_`, `-`, `/`, and `.`. This admits ordinary names such as
+  `vercel_deployment_monitor.py`. An uppercase letter, digit, or separator-free payload is
+  independent value-shape evidence and preserves the prefix match even when the token ends in a
+  source extension. Markdown/prose punctuation around the filename is ignored. This check only
+  suppresses the matching prefix detector; every other detector layer still evaluates the token.
 - Structured identifiers: a token is only considered for this exemption when it contains at least
   one of `/`, `-`, `_`, or `.` (the gate); it is then decomposed into maximal alphanumeric runs by
-  splitting on *every* non-alphanumeric character (not just the four gating separators — any other
+  splitting on _every_ non-alphanumeric character (not just the four gating separators — any other
   ASCII punctuation glued into the same whitespace token, e.g. a stray `:` or `,`, also acts as a
   run boundary). A token exempts when it decomposes into two or more such runs and every run is
   letters-then-digits or pure digits, at most 24 chars long, with a low case-transition density.
@@ -72,7 +81,7 @@ through to explicit detection instead of being silently allowed.
 - VCS revisions (trigger-context, narrow): a 40-hex value attached to an explicit VCS coordinate
   marker (`commit`, `revision`, `rev`, `sha` — immediately preceding word, or `marker:value` in
   one token) is treated as a public VCS coordinate near a trigger word, again only outside
-  credential-value syntax. The exemption is a *flag over the hex-credential-shape checks only*,
+  credential-value syntax. The exemption is a _flag over the hex-credential-shape checks only_,
   never an early skip of the whole check sequence. For the bare-marker form (`commit <hex>`) the
   exempt hex value is a plain alphanumeric token, so it still participates in fragment
   reconstruction anchored at neighboring tokens: a split credential hiding one fragment behind
@@ -106,34 +115,54 @@ bypass one natural qualifier past the cap. For the same reason, EXHAUSTING the w
 crossing a delimiter fails CLOSED: the clause is assignment-shaped and its head was never
 scanned, so it is treated as credential-labeled — clause length cannot launder a labeled value
 into the exemptions (`api key for the new shared encrypted regional staging deploy: <value>`
-blocks even though the trigger sits past the walk budget). A past-participle content word ends
-the walk:
-verb-phrase prose narrates an action on the value rather than labeling it (`the auth scanner
-flagged this file: <path>`, `one extra token was introduced by sha: <hex>` stay exempt). The
-walk stops at a sentence/paragraph boundary (`;`, `!`, `?`, blank line; `.` only when not
-immediately followed by an alphanumeric character, so a dotted version qualifier does not read
-as a sentence end). The past-participle stop is position-sensitive: it applies only in verb
-position — the participle followed (in reading order) by a glue word or the value itself
-("flagged this file:", "introduced by sha:", "key updated: <v>"). Followed by a content noun it
-is a participial ADJECTIVE inside a label qualifier ("shared deploy:", "encrypted backup:") and
-walks like any other qualifier noun. Coordinating conjunctions (`and`, `or`) are transparent to
-this classification: in "shared and encrypted staging deploy: <value>" the coordination as a
-whole is followed by a content noun, so both participles read as adjectives and walk. A participle BEFORE the trigger word never matters — the
-walk reaches the trigger first ("generated api key: <v>" blocks). A single-identifier lookback
-is deliberately NOT the contract: `api key value is commit <hex>` is a labeled credential
-wearing a marker, and one connector word must not hide the label. A label on the far side of a
-sentence boundary is prose context (the `near_trigger` window models that), not this value's
-label. Known residuals, accepted under the threat model: a non-connector qualifier without any
-delimiter (`api key pour commit <hex>`) and a participle in verb position directly after the
-trigger (`api key updated: commit <hex>` reads as changelog prose; without the VCS marker the
-raw hex still blocks under the near-trigger rule — note the ordering: `updated api
-key: <hex>` blocks, since the walk meets the trigger first). The no-delimiter residual is not
-limited to the VCS family: without a `:`/`=`, the walk ends open at the first content word, so
-a slash-bearing or path-dressed high-entropy value also reaches the file-path exemption behind
-an intervening verb or noun (`api key found <slash-base64>`, `auth scanner found
-<slash-base64>`, `secret note <high-entropy path>` all pass; adding a delimiter to any of them
-blocks). This is the widest documented residual of the no-delimiter tier and the first
-candidate for a future tightening of that tier. Accepted false positives,
+blocks even though the trigger sits past the walk budget).
+
+A regular `-ed` past-participle content word ends the walk: verb-phrase prose narrates an action
+on the value rather than labeling it (`the auth scanner flagged this file: <path>`, `one extra
+token was introduced by sha: <hex>` stay exempt). The walk stops at a sentence/paragraph boundary
+(`;`, `!`, `?`, blank line; `.` only when not immediately followed by an alphanumeric character,
+so a dotted version qualifier does not read as a sentence end). The participle stop is
+position-sensitive: it applies only in verb position — the participle followed (in reading order)
+by a glue word or the value itself (`flagged this file:`, `introduced by sha:`, `key updated:
+<v>`). For a no-delimiter file-path candidate, however, adjacency to the value is not sufficient:
+the reverse walk must already have processed a real value-side identifier and remain in connector
+position. Thus `api key leaked <value>` blocks, while `the auth scanner flagged this file <path>`
+retains the stop after processing `file` and `this`. Delimiter-bearing clauses and VCS coordinates
+retain their existing direct-participle behavior. Followed by a content noun, a participle is an
+ADJECTIVE inside a label qualifier (`shared deploy:`, `encrypted backup:`) and walks like any other
+qualifier noun. Coordinating conjunctions (`and`, `or`) are transparent to this classification: in
+`shared and encrypted staging deploy: <value>` the coordination as a whole is followed by a content
+noun, so both participles read as adjectives and walk. A participle BEFORE the trigger word never
+matters — the walk reaches the trigger first (`generated api key: <v>` blocks). The regular-suffix
+proxy has an explicit lexical exception set: `hundred` is not treated as a participle merely because
+its bytes end in `ed`. Irregular `found` intentionally is not a narrative stop, so it cannot shield
+the direct label in `api key found <value>`.
+
+Without a `:`/`=`, the two exemptions deliberately use different tiers. VCS coordinates retain
+the strict connector-only walk; the first unknown content word ends it, preserving ordinary prose
+such as `the key changes are in commit <hex>`. This leaves the accepted VCS residual `api key pour
+commit <hex>`. File-path candidates may instead cross at most two content words, in addition to
+the closed connector sets, so direct labels remain reachable: `api key found <slash-base64>`,
+`auth scanner found <slash-base64>`, and `secret note <high-entropy path>` all block, as do the
+corresponding path/slash-base64 combinations. The position-sensitive regular-participle stop applies
+to this bounded bridge only after real value-side walk progress, so `the auth scanner flagged this
+file <path>` stays exempt but `api key leaked <value>` blocks. The file-path tier has one narrower
+regular-`-ing` narrative stop: it applies only when the reverse walk has just crossed the literal
+value-side preposition `in`, preserving technical citations such as `api_key handling in <path>`.
+Adjacency is not enough: `api key handling <value>` keeps walking to the direct trigger and blocks.
+`see` has no special stop; `key: see <path>` likewise blocks, while a citation whose path precedes a
+later topical trigger (`see <path> ... key`) stays exempt because the backward clause contains no
+credential label.
+
+A single-identifier lookback is deliberately NOT the contract: `api key value is commit <hex>` is
+a labeled credential wearing a marker, and one connector word must not hide the label. A label on
+the far side of a sentence boundary is prose context (the `near_trigger` window models that), not
+this value's label. The other accepted participle residual remains: `api key updated: commit
+<hex>` reads as changelog prose; without the VCS marker the raw hex still blocks under the
+near-trigger rule. Ordering remains significant: `updated api key: <hex>` blocks because the walk
+meets the trigger first.
+
+Accepted false positives,
 conservative direction: the walk has no grammar — ANY trigger word reachable inside the
 pre-delimiter clause (absent a sentence boundary or verb-position participle) is treated as a
 credential label, whether it is attributive (`see the docs for auth setup: <path>`, `secret
@@ -169,6 +198,19 @@ credential-config compounds keep firing: `SECRET_KEY=...` (Django/Flask-style co
 half. This is implemented by parameterizing the boundary rule (`contains_word`'s
 `underscore_is_word_char` argument) rather than sharing one rule between the two callers.
 
+## find_prefix_token
+
+Known provider-prefix matching remains context-free and requires both a token boundary and the
+detector's configured minimum total length. Before returning a match, `find_prefix_token` applies
+`is_filename_shaped_prefix_match` to the payload after the prefix. The helper recognizes only the
+closed source-extension set and a stem made entirely from lowercase ASCII letters plus filename
+punctuation (`_`, `-`, `/`, `.`), with at least one letter and at least one such separator. Outer
+backticks, quotes, brackets, and sentence punctuation do not become payload evidence. Any digit,
+uppercase byte, or separator-free payload rejects the filename shape, so a value-shaped provider
+token still matches even if `.py` or another known extension is appended. Suppressing this one
+prefix match is not an allow decision: the remaining known-shape and entropy detectors still scan
+the token.
+
 ## value_candidates
 
 Yields every candidate value that an assignment/wrapper-glued whitespace token could contain, so
@@ -188,7 +230,7 @@ so a last-separator split would land on the padding boundary instead. A label ca
 contain `:`/`=` (`{"api:key":"<uuid>"}`) or the assignment can be doubled
 (`key=label=<uuid>`), so neither "first" nor "last" is a sound single choice. Emitting every
 suffix and letting the caller test each one is the only choice that is sound in all these shapes:
-the true value always appears as *some* suffix, and a `=`/`:` that lands inside padding or a label
+the true value always appears as _some_ suffix, and a `=`/`:` that lands inside padding or a label
 simply yields a non-matching suffix that the caller's shape check harmlessly rejects.
 
 Byte-scan via `char_indices` over an already-short token (whitespace-delimited, so bounded by
@@ -198,6 +240,7 @@ realistic line length) — no allocation, since this runs in the hot scan path.
 
 `underscore_is_word_char` selects which of two, deliberately different, boundary rules the caller
 needs:
+
 - `true` (used by `has_standalone_token` / `has_token_assignment` for `token`): underscore is a
   continuation of the same identifier, so `next_token`, `tokenizer`, and `token_count` do NOT
   match — a prior, deliberate decision that must not change.
@@ -205,7 +248,7 @@ needs:
   boundary, so `secret_key=`/`auth_token=`/`signing_key=` still match on the
   `secret`/`auth`/`key` half of the compound — these underscore-joined credential-config
   compounds (Django/Flask `SECRET_KEY`, OAuth `auth_token`, JWT `signing_key`) are exactly the
-  shape a credential trigger must not lose. Only *letter*-joined collisions (`authorized`,
+  shape a credential trigger must not lose. Only _letter_-joined collisions (`authorized`,
   `authentication`, `monkey`, `keyword`) are meant to stop matching.
 
 CJK/accented prose always counts as a boundary in both modes (only ASCII alphanumerics — plus
@@ -241,6 +284,7 @@ used.
 ## is_base64_content_hash
 
 Criteria:
+
 - Token starts with `sha<digits>-` (e.g. `sha256-`, `sha384-`, `sha512-`).
 - The body after the prefix matches a SHA-family length (43, 64, or 86–88 unpadded chars).
 - Every byte in the body is a standard-base64 or URL-safe-base64 character.

--- a/crates/khive-runtime/src/secret_gate.rs
+++ b/crates/khive-runtime/src/secret_gate.rs
@@ -430,13 +430,54 @@ fn find_prefix_token<'a>(text: &'a str, needle: &str, min_len: usize) -> Option<
         };
         if at_boundary {
             let token = extract_token(&text[abs..]);
-            if token.len() >= min_len {
+            if token.len() >= min_len && !is_filename_shaped_prefix_match(token, needle) {
                 return Some(token);
             }
         }
         start = abs + needle.len().max(1);
     }
     None
+}
+
+/// Known source-file extensions that can terminate an ordinary provider-
+/// prefixed filename. This is deliberately a closed set: an unknown suffix
+/// is not evidence strong enough to suppress a context-free prefix detector.
+const SOURCE_FILE_EXTENSIONS: &[&str] =
+    &[".py", ".rs", ".ts", ".js", ".sh", ".md", ".toml", ".json"];
+
+/// Returns `true` for a lowercase source filename after a known provider
+/// prefix, such as `vercel_deployment_monitor.py`.
+///
+/// A source extension alone is not enough. The payload before it must contain
+/// only lowercase ASCII letters and filename/path punctuation; any uppercase
+/// letter or digit is credential-value evidence and keeps the prefix match
+/// fail-closed. Outer Markdown/prose punctuation is ignored, but never any
+/// payload byte inside the filename itself.
+fn is_filename_shaped_prefix_match(token: &str, needle: &str) -> bool {
+    let token = token.trim_end_matches(|c: char| {
+        matches!(
+            c,
+            '`' | '"' | '\'' | ')' | ']' | '}' | '>' | ',' | ';' | ':' | '!' | '?'
+        )
+    });
+    let token = token.strip_suffix('.').unwrap_or(token);
+    let Some(payload) = token.strip_prefix(needle) else {
+        return false;
+    };
+    let Some(stem) = SOURCE_FILE_EXTENSIONS
+        .iter()
+        .find_map(|extension| payload.strip_suffix(extension))
+    else {
+        return false;
+    };
+
+    stem.bytes().any(|byte| byte.is_ascii_lowercase())
+        && stem
+            .bytes()
+            .any(|byte| matches!(byte, b'_' | b'-' | b'/' | b'.'))
+        && stem
+            .bytes()
+            .all(|byte| byte.is_ascii_lowercase() || matches!(byte, b'_' | b'-' | b'/' | b'.'))
 }
 
 /// Scan for a JWT pattern: at least two "eyJ" segments separated by a `.`
@@ -748,13 +789,23 @@ fn check_entropy_heuristic(text: &str, from: usize) -> Option<(&str, &'static st
         // revision. The hex value itself is a separate token and receives
         // the full check sequence on its own iteration.
         if is_vcs_marker_before_hex(text, raw_token)
-            && !has_clause_credential_label(text, token_offset, raw_token)
+            && !has_clause_credential_label(
+                text,
+                token_offset,
+                raw_token,
+                ClauseValueKind::VcsReference,
+            )
         {
             continue;
         }
 
         let vcs_reference_exempt = is_git_revision_reference(text, token_offset, raw_token)
-            && !has_clause_credential_label(text, token_offset, raw_token);
+            && !has_clause_credential_label(
+                text,
+                token_offset,
+                raw_token,
+                ClauseValueKind::VcsReference,
+            );
 
         // Hex API keys (AWS secret access key, Stripe test keys, random hex
         // tokens) are pure hex yet are real credentials.  The entropy heuristic
@@ -922,7 +973,12 @@ fn check_entropy_heuristic(text: &str, from: usize) -> Option<(&str, &'static st
             }
 
             if is_plausible_file_path(token)
-                && !has_clause_credential_label(text, token_offset, raw_token)
+                && !has_clause_credential_label(
+                    text,
+                    token_offset,
+                    raw_token,
+                    ClauseValueKind::FilePath,
+                )
             {
                 continue;
             }
@@ -1081,6 +1137,21 @@ const LABEL_CLAUSE_SKIP_WORDS: &[&str] = &[
 /// stays in range without exhaustion.
 const LABEL_CLAUSE_WALK_LIMIT: usize = 8;
 
+/// File-path candidates may walk across at most this many content identifiers
+/// without a `:`/`=` delimiter. Two reaches the direct-label shapes that need
+/// protection (`auth scanner found <path>`) while keeping the walk local.
+const FILE_PATH_NO_DELIMITER_CONTENT_LIMIT: usize = 2;
+
+/// The two narrow trigger-context exemptions need different no-delimiter
+/// behavior. VCS coordinates preserve the strict prose guard that keeps
+/// `the key changes are in commit <sha>` readable; file paths admit the
+/// bounded bridge above so a short label cannot disguise a credential value.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum ClauseValueKind {
+    VcsReference,
+    FilePath,
+}
+
 /// Sentence/paragraph boundary inside a clause-walk gap. `;`, `!`, `?`, and
 /// blank lines always end the clause. `.` ends it only when it is not
 /// immediately followed by an alphanumeric character: a dot tight between
@@ -1105,7 +1176,10 @@ fn gap_has_sentence_boundary(gap: &str) -> bool {
 /// Treated as connector material so a versioned label ("api key v1.2 value
 /// is …") stays reachable.
 fn is_version_fragment(word: &str) -> bool {
-    let digits = word.strip_prefix('v').unwrap_or(word);
+    let digits = word
+        .strip_prefix('v')
+        .or_else(|| word.strip_prefix('V'))
+        .unwrap_or(word);
     !digits.is_empty() && digits.bytes().all(|b| b.is_ascii_digit())
 }
 
@@ -1116,6 +1190,63 @@ fn is_version_fragment(word: &str) -> bool {
 /// ends the clause.
 fn is_hex_fragment_word(word: &str) -> bool {
     word.len() >= 12 && word.bytes().all(|b| b.is_ascii_hexdigit())
+}
+
+/// Allocation-free case-insensitive substring search for ASCII identifiers.
+fn contains_ascii_case_insensitive(haystack: &str, needle: &str) -> bool {
+    haystack
+        .as_bytes()
+        .windows(needle.len())
+        .any(|window| window.eq_ignore_ascii_case(needle.as_bytes()))
+}
+
+/// A trailing identifier can contain only ASCII alphanumerics and `_`, so
+/// splitting on `_` exactly preserves the bare-trigger boundary rule used by
+/// [`contains_bounded_word`] without allocating a lowercase copy.
+fn clause_label_has_credential_trigger(label: &str) -> bool {
+    label.eq_ignore_ascii_case("token")
+        || COMPOUND_TRIGGER_WORDS
+            .iter()
+            .any(|trigger| contains_ascii_case_insensitive(label, trigger))
+        || label.split('_').any(|part| {
+            TRIGGER_WORDS
+                .iter()
+                .any(|trigger| part.eq_ignore_ascii_case(trigger))
+        })
+}
+
+fn is_label_clause_skip_word(label: &str) -> bool {
+    LABEL_CLAUSE_SKIP_WORDS
+        .iter()
+        .any(|word| label.eq_ignore_ascii_case(word))
+}
+
+/// Words ending in the byte sequence `ed` are only a cheap proxy for a
+/// regular English participle. Keep known lexical false matches explicit so
+/// a noun such as `hundred` cannot become evidence that a credential label is
+/// merely narrative prose. Irregular forms such as `found` deliberately do
+/// not qualify: they must not shield `api key found <value>`.
+fn is_clause_narrative_participle(label: &str) -> bool {
+    const NON_PARTICIPLE_ED_WORDS: &[&str] = &["hundred"];
+
+    label.len() >= 5
+        && label
+            .get(label.len().saturating_sub(2)..)
+            .is_some_and(|suffix| suffix.eq_ignore_ascii_case("ed"))
+        && !NON_PARTICIPLE_ED_WORDS
+            .iter()
+            .any(|word| label.eq_ignore_ascii_case(word))
+}
+
+/// Cheap regular-gerund proxy used only after the no-delimiter file-path walk
+/// has crossed an explicit `in` on the value side (`api_key handling in
+/// <path>`). Adjacency alone is never narrative evidence: `api key handling
+/// <value>` must keep walking to the direct credential label.
+fn is_clause_narrative_gerund(label: &str) -> bool {
+    label.len() >= 6
+        && label
+            .get(label.len().saturating_sub(3)..)
+            .is_some_and(|suffix| suffix.eq_ignore_ascii_case("ing"))
 }
 
 /// `true` when the candidate token sits in credential-value syntax: an inline
@@ -1136,22 +1267,34 @@ fn is_hex_fragment_word(word: &str) -> bool {
 /// qualifier past the cap. For the same reason, exhausting the walk budget
 /// after crossing a delimiter fails CLOSED: the clause is assignment-shaped
 /// and its head was never scanned, so it is treated as credential-labeled.
-/// A past-participle content word ("flagged", "introduced") ends the walk —
+/// A regular past-participle content word ("flagged", "introduced") ends the walk —
 /// verb-phrase prose narrates an action on the value rather than labeling it
 /// ("the auth scanner flagged this file: <path>", "one extra token was
 /// introduced by sha: <hex>"). Coordinating conjunctions are transparent to
 /// that position test — "shared and encrypted deploy" keeps both participles
-/// in adjective position. Without a delimiter, only the closed sets are
-/// stepped over — skipping arbitrary words there would re-block ordinary
-/// prose like "the key changes are in commit <hex>", the false-positive
-/// class these exemptions exist to fix.
-fn has_clause_credential_label(text: &str, token_offset: usize, raw_token: &str) -> bool {
+/// in adjective position. Without a delimiter, VCS references step over only
+/// the closed connector sets, preserving ordinary prose such as "the key
+/// changes are in commit <hex>". File paths additionally step over at most
+/// [`FILE_PATH_NO_DELIMITER_CONTENT_LIMIT`] content words, closing direct
+/// label shapes such as "auth scanner found <path>" without broadening the
+/// VCS tier.
+fn has_clause_credential_label(
+    text: &str,
+    token_offset: usize,
+    raw_token: &str,
+    value_kind: ClauseValueKind,
+) -> bool {
     if has_inline_credential_trigger(raw_token) {
         return true;
     }
 
     let mut rest = &text[..token_offset];
     let mut crossed_value_delimiter = false;
+    let mut no_delimiter_content_words = 0usize;
+    // Whether the previously processed identifier (the one nearer the value)
+    // was the literal preposition `in`. This starts false deliberately:
+    // adjacency to the value must not make a gerund narrative evidence.
+    let mut arrived_through_in_preposition = false;
     // Whether the previously processed identifier (the one nearer the value)
     // was connector material. Starts true: step 0 is adjacent to the value or
     // its delimiter.
@@ -1165,37 +1308,43 @@ fn has_clause_credential_label(text: &str, token_offset: usize, raw_token: &str)
         if step > 0 && gap_has_sentence_boundary(gap) {
             return false;
         }
-        let lower = label.to_ascii_lowercase();
         if gap.contains([':', '=']) {
             crossed_value_delimiter = true;
         }
-        if lower == "token"
-            || COMPOUND_TRIGGER_WORDS
-                .iter()
-                .any(|trigger| lower.contains(trigger))
-            || TRIGGER_WORDS
-                .iter()
-                .any(|trigger| contains_bounded_word(&lower, trigger))
-        {
+        if clause_label_has_credential_trigger(label) {
             return true;
         }
-        let skippable = LABEL_CLAUSE_SKIP_WORDS.contains(&lower.as_str())
-            || is_version_fragment(&lower)
-            || is_hex_fragment_word(&lower);
+        let skippable = is_label_clause_skip_word(label)
+            || is_version_fragment(label)
+            || is_hex_fragment_word(label);
         if !skippable {
-            if !crossed_value_delimiter {
+            // This barrier applies to delimiter-bearing clauses and to the
+            // bounded file-path bridge. It intentionally recognizes regular
+            // `-ed` forms only: `found` is a bridge word, not a narrative
+            // shield for a direct credential label.
+            let no_delimiter_file_path_narrative = !crossed_value_delimiter
+                && value_kind == ClauseValueKind::FilePath
+                && arrived_through_in_preposition
+                && is_clause_narrative_gerund(label);
+            // Delimiter-bearing clauses and VCS coordinates preserve their
+            // existing direct-participle semantics. A no-delimiter file path
+            // must first process real value-side context: the synthetic
+            // initial connector state alone cannot let `api key leaked
+            // <value>` stop before reaching the trigger.
+            let regular_participle_narrative = is_clause_narrative_participle(label)
+                && (crossed_value_delimiter || value_kind != ClauseValueKind::FilePath || step > 0);
+            if arrived_through_connector
+                && (regular_participle_narrative || no_delimiter_file_path_narrative)
+            {
                 return false;
             }
-            // A past-participle word is verb-phrase evidence ONLY in verb
-            // position — followed by a glue word or the value itself
-            // ("flagged THIS file", "introduced BY sha", "updated: <v>").
-            // Followed by a content word it is a participial adjective
-            // inside a noun-compound label qualifier ("SHARED deploy",
-            // "ENCRYPTED backup") and walks like any other qualifier noun.
-            // The walk runs backwards, so "followed by" is the identifier
-            // processed on the previous iteration.
-            if arrived_through_connector && lower.len() >= 5 && lower.ends_with("ed") {
-                return false;
+            if !crossed_value_delimiter {
+                if value_kind != ClauseValueKind::FilePath
+                    || no_delimiter_content_words >= FILE_PATH_NO_DELIMITER_CONTENT_LIMIT
+                {
+                    return false;
+                }
+                no_delimiter_content_words += 1;
             }
         }
         // Coordinating conjunctions are transparent to participle-position
@@ -1203,9 +1352,10 @@ fn has_clause_credential_label(text: &str, token_offset: usize, raw_token: &str)
         // as a whole is followed by a content noun, so "shared" is still an
         // adjective — the conjunction preserves the arrived state instead of
         // marking connector position.
-        if !matches!(lower.as_str(), "and" | "or") {
+        if !label.eq_ignore_ascii_case("and") && !label.eq_ignore_ascii_case("or") {
             arrived_through_connector = skippable;
         }
+        arrived_through_in_preposition = label.eq_ignore_ascii_case("in");
         let start = label.as_ptr() as usize - rest.as_ptr() as usize;
         rest = &rest[..start];
     }
@@ -1982,6 +2132,67 @@ mod tests {
         let fake = "vercel_FAKETOKEN00000000000000000";
         assert!(scan(fake).is_some(), "vercel_ must be caught");
         assert_eq!(scan(fake).unwrap().detector, "vercel-token");
+    }
+
+    #[test]
+    fn prefix_detectors_allow_lowercase_source_filenames() {
+        let filename_body = "provider_integration_monitoring_adapter_configuration.py";
+
+        for &(_, needle, min_len) in PREFIX_DETECTORS {
+            let candidate = format!("{needle}{filename_body}");
+            assert!(
+                candidate.len() >= min_len,
+                "negative control must exercise {needle}'s length tier"
+            );
+            assert!(
+                find_prefix_token(&candidate, needle, min_len).is_none(),
+                "lowercase source filename must not match prefix {needle}: {candidate}"
+            );
+            assert!(
+                check(&candidate).is_ok(),
+                "lowercase source filename must pass the canonical scanner: {candidate}, got {:?}",
+                scan(&candidate)
+            );
+        }
+    }
+
+    #[test]
+    fn prefix_detectors_keep_value_shaped_payloads_with_source_suffixes() {
+        for &(_, needle, min_len) in PREFIX_DETECTORS {
+            let required_payload_len = min_len.saturating_sub(needle.len()).max(2);
+            let value_payload = "A1".repeat(required_payload_len.div_ceil(2));
+            let candidate = format!("{needle}{value_payload}.py");
+            assert!(
+                find_prefix_token(&candidate, needle, min_len).is_some(),
+                "uppercase/digit value evidence must preserve prefix {needle}: {candidate}"
+            );
+        }
+    }
+
+    #[test]
+    fn prefix_detectors_keep_lowercase_single_run_payloads_with_source_suffixes() {
+        for &(_, needle, min_len) in PREFIX_DETECTORS {
+            let required_payload_len = min_len.saturating_sub(needle.len()).max(24);
+            let value_payload = "a".repeat(required_payload_len);
+            let candidate = format!("{needle}{value_payload}.py");
+            assert!(
+                find_prefix_token(&candidate, needle, min_len).is_some(),
+                "an extension alone must not exempt prefix {needle}: {candidate}"
+            );
+        }
+    }
+
+    #[test]
+    fn allows_vercel_prefixed_source_filename_on_every_scanner_surface() {
+        let content = "review `vercel_deployment_monitoring_adapter.py` before release";
+
+        assert!(check(content).is_ok(), "write gate must allow filename");
+        assert!(scan(content).is_none(), "scanner must not report filename");
+        assert_eq!(
+            mask_secrets(content).as_ref(),
+            content,
+            "masking surface must preserve the filename byte-for-byte"
+        );
     }
 
     #[test]
@@ -3140,10 +3351,9 @@ mod tests {
 
     #[test]
     fn allows_unlabeled_unknown_connector_without_delimiter() {
-        // Documented residuals: without a value delimiter, an identifier
-        // outside the connector set still ends the walk. Skipping arbitrary
-        // words there would re-block ordinary prose — the false-positive
-        // class the exemptions exist to fix.
+        // VCS coordinates retain the strict no-delimiter tier: an identifier
+        // outside the connector set ends the walk. The bounded bridge used by
+        // file paths must not re-block this ordinary revision prose.
         let revision = "d362950a3c9b1a4cb47d97f1623e38f1a1e6bcdf";
         for content in [
             format!("the key changes are in commit {revision}"),
@@ -3152,6 +3362,109 @@ mod tests {
             assert!(
                 check(&content).is_ok(),
                 "prose without a value delimiter must keep the VCS exemption: \
+                 {content:?}, got {:?}",
+                scan(&content)
+            );
+        }
+    }
+
+    #[test]
+    fn blocks_direct_no_delimiter_labels_for_both_file_path_value_families() {
+        let values = [
+            "Xk9mZ2vQpLrT8nJwYuA/HfBsDcGiONvMabcdefgh",
+            "internal/workspaces/20260701/cloud-rebuild/R1-repo-audit.md",
+        ];
+
+        for value in values {
+            for label in ["api key found", "auth scanner found", "secret note"] {
+                let content = format!("{label} {value}");
+                assert!(
+                    check(&content).is_err(),
+                    "a direct no-delimiter label must refuse the file-path exemption: \
+                     {content:?}, got {:?}",
+                    scan(&content)
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn blocks_direct_gerund_and_see_labels_for_both_file_path_value_families() {
+        let values = [
+            "Xk9mZ2vQpLrT8nJwYuA/HfBsDcGiONvMabcdefgh",
+            "internal/workspaces/20260701/cloud-rebuild/R1-repo-audit.md",
+        ];
+
+        for value in values {
+            for label in [
+                "api key handling",
+                "auth scanner handling",
+                "api key see",
+                "key: see",
+            ] {
+                let content = format!("{label} {value}");
+                assert!(
+                    check(&content).is_err(),
+                    "narrative-looking adjacency must not shield a direct credential label: \
+                     {content:?}, got {:?}",
+                    scan(&content)
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn blocks_direct_participle_labels_for_both_file_path_value_families() {
+        let values = [
+            "Xk9mZ2vQpLrT8nJwYuA/HfBsDcGiONvMabcdefgh",
+            "internal/workspaces/20260701/cloud-rebuild/R1-repo-audit.md",
+        ];
+
+        for value in values {
+            for label in ["api key leaked", "auth scanner leaked"] {
+                let content = format!("{label} {value}");
+                assert!(
+                    check(&content).is_err(),
+                    "step-zero participle adjacency must not shield a direct credential label: \
+                     {content:?}, got {:?}",
+                    scan(&content)
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn allows_no_delimiter_narrative_file_path_prose() {
+        // The value-side `file`/`this` identifiers provide real walk context
+        // before `flagged`; the step-zero direct-label tightening must not
+        // remove this required narrative exemption.
+        let content = "the auth scanner flagged this file \
+            internal/workspaces/20260701/cloud-rebuild/R1-repo-audit.md";
+
+        assert!(
+            check(content).is_ok(),
+            "a regular participle in narrative position must preserve the path: got {:?}",
+            scan(content)
+        );
+    }
+
+    #[test]
+    fn suffix_word_hundred_is_not_a_narrative_participle() {
+        assert!(is_clause_narrative_participle("flagged"));
+        assert!(is_clause_narrative_participle("INTRODUCED"));
+        assert!(!is_clause_narrative_participle("found"));
+        assert!(!is_clause_narrative_participle("hundred"));
+        assert!(is_clause_narrative_gerund("HANDLING"));
+        assert!(!is_clause_narrative_gerund("found"));
+
+        for value in [
+            "Xk9mZ2vQpLrT8nJwYuA/HfBsDcGiONvMabcdefgh",
+            "internal/workspaces/20260701/cloud-rebuild/R1-repo-audit.md",
+        ] {
+            let content = format!("api key hundred: {value}");
+            assert!(
+                check(&content).is_err(),
+                "a lexical -ed suffix must not shield a credential label: \
                  {content:?}, got {:?}",
                 scan(&content)
             );
@@ -3640,11 +3953,12 @@ mod tests {
     }
 
     #[test]
-    fn allows_high_entropy_workspace_path_near_key_word() {
-        let content = "key: see internal/workspaces/20260701/adr079-slices234/PACKET.md";
+    fn allows_high_entropy_workspace_path_before_later_key_word() {
+        let content =
+            "see internal/workspaces/20260701/adr079-slices234/PACKET.md for the key behavior";
         assert!(
             check(content).is_ok(),
-            "workspace path in technical prose must pass; got {:?}",
+            "a path before a later topical key word must pass; got {:?}",
             scan(content)
         );
     }


### PR DESCRIPTION
## Summary

- tighten the no-delimiter file-path exemption so direct credential labels remain reachable across bounded verb/noun bridges
- distinguish real narrative context from value-adjacent `-ed`, `-ing`, and `see` words while preserving the documented flagged-file and technical-citation cases
- exempt lowercase, separator-punctuated provider-prefixed source filenames without weakening value-shaped prefix detections
- replace per-word lowercase allocations in the clause walk with ASCII case-insensitive comparisons and document the resulting contract

Closes #1349.
Closes #1429.

## Scope

#1056 is intentionally not claimed here. Its accepted ADR-115 exact-content manifest and finalization infrastructure is not present on `main`; that broader write-finalization work needs a dedicated implementation.

## Validation

- `cargo test -p khive-runtime --all-features` — 1,114 passed, 0 failed, 7 ignored
- `cargo check -p khive-runtime --all-targets --all-features`
- `cargo clippy -p khive-runtime --all-targets --all-features -- -D warnings`
- `cargo fmt -p khive-runtime -- --check`
- `deno fmt --check crates/khive-runtime/docs/api/secret_gate.md`
- `git diff --check`

All Cargo gates used a clean, branch-isolated target with incremental compilation and debug info disabled.

> AI-assisted contribution: Codex prepared this change and PR description.
