### PR TITLE
fix(request): prescribe two-call mixed-mode split

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -313,6 +313,17 @@ The two forms cannot be combined in one `request`, and the JSON op form does not
 Mixing `,` and `|` at the top level of one `request` is rejected, as is `$prev` inside the JSON op
 form. Use the function-call form shown above for chaining.
 
+When one workload contains independent ops alongside a dependent chain, split it into exactly two
+calls:
+
+```text
+request(ops="[create(kind=\"concept\", name=\"Independent A\"), create(kind=\"concept\", name=\"Independent B\")]")
+request(ops="create(kind=\"concept\", name=\"Dependent\") | link(source_id=$prev.id, target_id=\"<existing-uuid>\", relation=\"extends\")")
+```
+
+These calls are independent and may run in either order. `$prev` is scoped to the second call's
+chain and never crosses a `request` boundary.
+
 ### Output format
 
 The `request` envelope accepts a `format` parameter that controls how the response is serialized

--- a/crates/khive-request/docs/api/parsing.md
+++ b/crates/khive-request/docs/api/parsing.md
@@ -30,7 +30,16 @@ Pure JSON arrays/objects become one `ArgValue::Value`; a container with any `$pr
 
 ## Function-call batches and chains
 
-`[op(...), op(...)]` is parallel and rejects `$prev`. `op(...) | op(...)` is a sequential chain and may contain `$prev` anywhere in an argument value. Empty batches, mixed top-level `,` and `|` separators, trailing input, and more than `MAX_OPS` operations are errors.
+`[op(...), op(...)]` is parallel and rejects `$prev`. `op(...) | op(...)` is a sequential chain and may contain `$prev` anywhere in an argument value. Empty batches, mixed `,` and `|` separators in one request, trailing input, and more than `MAX_OPS` operations are errors. A chain is not a valid element of a parallel batch.
+
+Split independent operations and a dependent chain into two `request` calls:
+
+```text
+request(ops='[create(kind="concept", name="Independent A"), create(kind="concept", name="Independent B")]')
+request(ops='create(kind="concept", name="Dependent") | link(source_id=$prev.id, target_id="<existing-uuid>", relation="extends")')
+```
+
+The calls are independent and may run in either order. `$prev` is scoped to the second call and never crosses a request boundary.
 
 Chain parsing does not resolve references; it only represents them. The dispatcher resolves each operation against the immediately preceding result and aborts after a failed step.
 

--- a/crates/khive-request/src/types.rs
+++ b/crates/khive-request/src/types.rs
@@ -532,7 +532,10 @@ impl fmt::Display for DslError {
             DslError::MixedSeparators => {
                 write!(
                     f,
-                    "cannot mix ',' (parallel) and '|' (chain) separators at the top level"
+                    "cannot mix ',' (parallel) and '|' (chain) separators in one request; \
+                     a parallel batch cannot contain a chain. Split the work into two `request` \
+                     calls: put independent ops in one `[...]` batch and dependent ops in a \
+                     separate `a() | b(arg=$prev.id)` chain"
                 )
             }
             DslError::EmptyBatch => {

--- a/crates/khive-request/tests/parser.rs
+++ b/crates/khive-request/tests/parser.rs
@@ -1170,6 +1170,12 @@ fn mixed_separator_before_any_chain_pipe_reaches_the_same_message() {
         msg.contains("cannot mix ',' (parallel) and '|' (chain) separators"),
         "message must name the mix mistake, got: {msg}"
     );
+    assert!(
+        msg.contains("two `request` calls")
+            && msg.contains("one `[...]` batch")
+            && msg.contains("a() | b(arg=$prev.id)"),
+        "message must prescribe the documented two-call split, got: {msg}"
+    );
 }
 
 #[test]

--- a/docs/adr/ADR-016-request-dsl.md
+++ b/docs/adr/ADR-016-request-dsl.md
@@ -69,9 +69,27 @@ verb(arg=value, arg=value)
 verb1(...) | verb2(arg=$prev.id) | verb3(arg=$prev.field)
 ```
 
-Mixing `,` and `|` at the top level is rejected as a parse error. A future
-extension may define sub-chain bracketing if a real use case justifies the
-complexity.
+Mixing `,` and `|` in one request is rejected as a parse error. A parallel
+batch cannot contain a chain; sub-chain bracketing is not part of this DSL.
+For example, this combined shape is invalid:
+
+```text
+[create(kind="concept", name="Independent A"),
+ create(kind="concept", name="Independent B"),
+ create(kind="concept", name="Dependent") |
+   link(source_id=$prev.id, target_id="<existing-uuid>", relation="extends")]
+```
+
+Split it into exactly two `request` calls: one parallel call for the
+independent operations, and one sequential call for the dependency:
+
+```text
+request(ops='[create(kind="concept", name="Independent A"), create(kind="concept", name="Independent B")]')
+request(ops='create(kind="concept", name="Dependent") | link(source_id=$prev.id, target_id="<existing-uuid>", relation="extends")')
+```
+
+The two calls above are independent and may be issued in either order. `$prev`
+is scoped to the second call's chain; it never carries across request calls.
 
 **JSON form** is canonical for programmatic input that produces structured objects
 more easily than string templating:


### PR DESCRIPTION
## Summary

- make the mixed `,` / `|` DSL refusal prescribe two explicit `request` calls instead of leaving the caller without an actionable path
- document the exact split between an independent parallel batch and a dependent `$prev` chain in ADR-016, the parser API, and the agent guide
- pin the refusal text so the documented workaround cannot silently regress

Closes #1388.

## Scope

Nested chains remain unsupported. This change does not claim #890: its owner scoping note requires both bulk note creation and nested parallel-chain execution, which needs a separate request-runtime and accounting design.

## Validation

- `cargo test -p khive-request --all-features`
- `cargo check -p khive-request --all-targets --all-features`
- `cargo clippy -p khive-request --all-targets --all-features -- -D warnings`
- `cargo fmt -p khive-request -- --check`
- `deno fmt --check AGENTS.md docs/adr/ADR-016-request-dsl.md crates/khive-request/docs/api/parsing.md`
- `git diff --check`

All Cargo gates use a clean, branch-isolated target with incremental compilation and debug info disabled.

> AI-assisted contribution: Codex prepared this change and PR description.
