### PR TITLE
feat(kkernel): expose build provenance

### DIFF
--- a/crates/khive-runtime/Cargo.toml
+++ b/crates/khive-runtime/Cargo.toml
@@ -47,3 +47,6 @@ tempfile = { workspace = true }
 tracing-subscriber = { workspace = true }
 serial_test = { workspace = true }
 sha2 = { workspace = true }
+
+[build-dependencies]
+chrono = { workspace = true }

--- a/crates/khive-runtime/build.rs
+++ b/crates/khive-runtime/build.rs
@@ -1,0 +1,77 @@
+use std::env;
+use std::path::{Path, PathBuf};
+
+use chrono::{DateTime, SecondsFormat, Utc};
+
+#[path = "src/build_info_support.rs"]
+mod build_info_support;
+
+use build_info_support::{git_output, source_revision};
+
+const UNSTAMPED_REVISION: &str = "unstamped";
+
+fn main() {
+    println!("cargo:rerun-if-changed=build.rs");
+    println!("cargo:rerun-if-changed=src/build_info.rs");
+    println!("cargo:rerun-if-changed=src/build_info_support.rs");
+    println!("cargo:rerun-if-env-changed=SOURCE_DATE_EPOCH");
+
+    let manifest_dir = PathBuf::from(env::var_os("CARGO_MANIFEST_DIR").unwrap_or_default());
+    let repo_root = git_output(&manifest_dir, &["rev-parse", "--show-toplevel"]).map(PathBuf::from);
+
+    if let Some(repo_root) = repo_root.as_deref() {
+        register_git_inputs(repo_root);
+        register_tracked_files(repo_root);
+    }
+
+    let revision = repo_root
+        .as_deref()
+        .and_then(source_revision)
+        .unwrap_or_else(|| UNSTAMPED_REVISION.to_string());
+    let build_time = build_time();
+
+    println!("cargo:rustc-env=KHIVE_SOURCE_REVISION={revision}");
+    println!("cargo:rustc-env=KHIVE_BUILD_TIME={build_time}");
+}
+
+fn build_time() -> String {
+    let timestamp = env::var("SOURCE_DATE_EPOCH")
+        .ok()
+        .and_then(|raw| raw.parse::<i64>().ok())
+        .and_then(|seconds| DateTime::<Utc>::from_timestamp(seconds, 0))
+        .unwrap_or_else(Utc::now);
+    timestamp.to_rfc3339_opts(SecondsFormat::Secs, true)
+}
+
+fn register_git_inputs(repo_root: &Path) {
+    let mut inputs = vec![
+        "HEAD".to_string(),
+        "index".to_string(),
+        "packed-refs".to_string(),
+    ];
+    if let Some(reference) = git_output(repo_root, &["symbolic-ref", "-q", "HEAD"]) {
+        inputs.push(reference);
+    }
+
+    for input in inputs {
+        let Some(path) = git_output(repo_root, &["rev-parse", "--git-path", &input]) else {
+            continue;
+        };
+        let path = PathBuf::from(path);
+        let path = if path.is_absolute() {
+            path
+        } else {
+            repo_root.join(path)
+        };
+        println!("cargo:rerun-if-changed={}", path.display());
+    }
+}
+
+fn register_tracked_files(repo_root: &Path) {
+    let Some(files) = git_output(repo_root, &["ls-files"]) else {
+        return;
+    };
+    for file in files.lines().filter(|line| !line.is_empty()) {
+        println!("cargo:rerun-if-changed={}", repo_root.join(file).display());
+    }
+}

--- a/crates/khive-runtime/src/build_info.rs
+++ b/crates/khive-runtime/src/build_info.rs
@@ -1,0 +1,154 @@
+//! Compile-time identity for the source and build that produced this runtime.
+
+#[cfg(test)]
+#[path = "build_info_support.rs"]
+mod build_info_support;
+
+/// Explicit source identity used when the build cannot inspect a Git checkout.
+pub const UNSTAMPED_REVISION: &str = "unstamped";
+
+/// Explicit build-time fallback used when no compile-time timestamp is available.
+pub const UNKNOWN_BUILD_TIME: &str = "unknown";
+
+/// Immutable provenance stamped into the binary at compile time.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct BuildInfo {
+    pub source_revision: &'static str,
+    pub build_time: &'static str,
+}
+
+impl BuildInfo {
+    /// Construct build information while preserving an explicit unstamped state.
+    pub const fn new(
+        source_revision: Option<&'static str>,
+        build_time: Option<&'static str>,
+    ) -> Self {
+        Self {
+            source_revision: match source_revision {
+                Some(revision) => revision,
+                None => UNSTAMPED_REVISION,
+            },
+            build_time: match build_time {
+                Some(build_time) => build_time,
+                None => UNKNOWN_BUILD_TIME,
+            },
+        }
+    }
+
+    pub fn is_stamped(&self) -> bool {
+        self.source_revision != UNSTAMPED_REVISION
+    }
+}
+
+/// Provenance for the currently compiled runtime.
+pub const BUILD_INFO: BuildInfo = BuildInfo::new(
+    option_env!("KHIVE_SOURCE_REVISION"),
+    option_env!("KHIVE_BUILD_TIME"),
+);
+
+/// Rich version string used by `kkernel --version`.
+pub const BUILD_VERSION: &str = concat!(
+    env!("CARGO_PKG_VERSION"),
+    " (revision ",
+    env!("KHIVE_SOURCE_REVISION"),
+    ", built ",
+    env!("KHIVE_BUILD_TIME"),
+    ")"
+);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::Path;
+    use std::process::Command;
+
+    #[test]
+    fn stamped_build_preserves_full_dirty_revision_and_time() {
+        let info = BuildInfo::new(
+            Some("45131c27b615f641c579046513d7c0ddd15c0bfb-dirty"),
+            Some("2026-07-31T20:00:00Z"),
+        );
+
+        assert_eq!(
+            info.source_revision,
+            "45131c27b615f641c579046513d7c0ddd15c0bfb-dirty"
+        );
+        assert_eq!(info.build_time, "2026-07-31T20:00:00Z");
+        assert!(info.is_stamped());
+    }
+
+    #[test]
+    fn unstamped_build_is_explicit() {
+        let info = BuildInfo::new(None, None);
+
+        assert_eq!(info.source_revision, UNSTAMPED_REVISION);
+        assert_eq!(info.build_time, UNKNOWN_BUILD_TIME);
+        assert!(!info.is_stamped());
+    }
+
+    #[test]
+    fn compiled_version_uses_the_compiled_provenance() {
+        assert!(BUILD_VERSION.contains(BUILD_INFO.source_revision));
+        assert!(BUILD_VERSION.contains(BUILD_INFO.build_time));
+
+        if BUILD_INFO.is_stamped() {
+            let revision = BUILD_INFO
+                .source_revision
+                .strip_suffix("-dirty")
+                .unwrap_or(BUILD_INFO.source_revision);
+            assert_eq!(revision.len(), 40);
+            assert!(revision.bytes().all(|byte| byte.is_ascii_hexdigit()));
+        }
+    }
+
+    #[test]
+    fn revision_derivation_distinguishes_clean_dirty_and_unstamped() {
+        let repo = tempfile::tempdir().unwrap();
+        run_git(repo.path(), &["init", "--quiet"]);
+        run_git(repo.path(), &["config", "user.email", "test@example.com"]);
+        run_git(repo.path(), &["config", "user.name", "khive test"]);
+        run_git(repo.path(), &["config", "commit.gpgsign", "false"]);
+        std::fs::write(repo.path().join("tracked.txt"), "clean\n").unwrap();
+        run_git(repo.path(), &["add", "tracked.txt"]);
+        run_git(repo.path(), &["commit", "--quiet", "-m", "baseline"]);
+
+        let revision = build_info_support::git_output(repo.path(), &["rev-parse", "HEAD"])
+            .expect("temp repository must have a revision");
+        assert_eq!(
+            build_info_support::source_revision(repo.path()).as_deref(),
+            Some(revision.as_str())
+        );
+
+        std::fs::write(repo.path().join("untracked.txt"), "not compiled\n").unwrap();
+        assert_eq!(
+            build_info_support::source_revision(repo.path()).as_deref(),
+            Some(revision.as_str())
+        );
+
+        std::fs::write(repo.path().join("tracked.txt"), "dirty\n").unwrap();
+        assert_eq!(
+            build_info_support::source_revision(repo.path()),
+            Some(format!("{revision}-dirty"))
+        );
+
+        let non_git = tempfile::tempdir().unwrap();
+        assert_eq!(build_info_support::source_revision(non_git.path()), None);
+    }
+
+    fn run_git(repo: &Path, args: &[&str]) {
+        let output = Command::new("git")
+            .env_remove("GIT_DIR")
+            .env_remove("GIT_WORK_TREE")
+            .arg("-C")
+            .arg(repo)
+            .args(args)
+            .output()
+            .expect("git must be available for build-provenance tests");
+        assert!(
+            output.status.success(),
+            "git {:?} failed: {}",
+            args,
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+}

--- a/crates/khive-runtime/src/build_info_support.rs
+++ b/crates/khive-runtime/src/build_info_support.rs
@@ -1,0 +1,40 @@
+use std::path::Path;
+use std::process::Command;
+
+pub(crate) fn source_revision(repo_root: &Path) -> Option<String> {
+    let revision = git_output(repo_root, &["rev-parse", "--verify", "HEAD^{commit}"])?;
+    let status = git_command(repo_root)
+        .args(["status", "--porcelain=v1", "--untracked-files=no"])
+        .output()
+        .ok()?;
+    if !status.status.success() {
+        return None;
+    }
+
+    if status.stdout.is_empty() {
+        Some(revision)
+    } else {
+        Some(format!("{revision}-dirty"))
+    }
+}
+
+pub(crate) fn git_output(cwd: &Path, args: &[&str]) -> Option<String> {
+    let output = git_command(cwd).args(args).output().ok()?;
+    if !output.status.success() {
+        return None;
+    }
+
+    let value = String::from_utf8(output.stdout).ok()?;
+    let value = value.trim();
+    (!value.is_empty()).then(|| value.to_string())
+}
+
+fn git_command(cwd: &Path) -> Command {
+    let mut command = Command::new("git");
+    command
+        .env_remove("GIT_DIR")
+        .env_remove("GIT_WORK_TREE")
+        .arg("-C")
+        .arg(cwd);
+    command
+}

--- a/crates/khive-runtime/src/daemon.rs
+++ b/crates/khive-runtime/src/daemon.rs
@@ -1490,7 +1490,13 @@ pub async fn run_daemon_with_boot_guard<D: DaemonDispatch>(
     // written.  Any concurrent client or daemon startup will observe a live
     // socket+pid and take the non-recovery path.
     drop(_startup_lock);
-    tracing::info!(socket = ?sock, pid = std::process::id(), "khived listening");
+    tracing::info!(
+        socket = ?sock,
+        pid = std::process::id(),
+        source_revision = crate::BUILD_INFO.source_revision,
+        build_time = crate::BUILD_INFO.build_time,
+        "khived listening"
+    );
 
     {
         let warm = dispatcher.clone();

--- a/crates/khive-runtime/src/lib.rs
+++ b/crates/khive-runtime/src/lib.rs
@@ -7,6 +7,7 @@ pub mod atomic_plan;
 pub mod atomic_prepare;
 pub mod atomic_runner;
 pub mod blob;
+pub mod build_info;
 pub mod config;
 pub mod config_ledger;
 pub mod cost_unit;
@@ -44,6 +45,7 @@ pub use atomic_runner::{
     CommittedPostCommitEffects,
 };
 pub use blob::resolve_blob_store;
+pub use build_info::{BuildInfo, BUILD_INFO, BUILD_VERSION};
 pub use cost_unit::{base_resource_payload, cost_unit_for_dispatch, resource_payload};
 pub use curation::{
     entity_embedding_text, entity_fts_document, entity_merge_guard_error, note_embedding_text,

--- a/crates/kkernel/docs/usage.md
+++ b/crates/kkernel/docs/usage.md
@@ -9,6 +9,9 @@ All subcommands emit JSON on stdout by default; pass `--human` where supported f
 readable table. `--log <level>` (env `KHIVE_LOG`, default `warn`) is global and goes
 to stderr — stdout stays clean for JSON / MCP traffic.
 
+`kkernel -V` reports the package version; `kkernel --version` also reports the full source
+revision (including `-dirty` when applicable) and UTC build time.
+
 ```
 kkernel <command> [flags]
 

--- a/crates/kkernel/src/cli.rs
+++ b/crates/kkernel/src/cli.rs
@@ -25,6 +25,7 @@ use khive_runtime::{BackendId, KhiveConfig, KhiveRuntime, RuntimeConfig};
 #[command(
     name = "kkernel",
     version,
+    long_version = khive_runtime::BUILD_VERSION,
     about = "khive kernel — admin/management Rust binary"
 )]
 struct Args {
@@ -760,8 +761,26 @@ fn cmd_backend(cmd: BackendCommand) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use clap::CommandFactory;
     use serial_test::serial;
     use tempfile::TempDir;
+
+    #[test]
+    fn version_surfaces_share_the_compiled_provenance() {
+        let command = Args::command();
+
+        assert_eq!(command.get_version(), Some(env!("CARGO_PKG_VERSION")));
+        assert_eq!(
+            command.get_long_version(),
+            Some(khive_runtime::BUILD_VERSION)
+        );
+        assert!(command
+            .render_long_version()
+            .contains(khive_runtime::BUILD_INFO.source_revision));
+        assert!(command
+            .render_long_version()
+            .contains(khive_runtime::BUILD_INFO.build_time));
+    }
 
     // A schema check must be read-only: it must not create a missing database,
     // and it must not migrate (mutate) an existing one. Regression for the


### PR DESCRIPTION
## Summary

- stamp the full Git revision, tracked-worktree dirty state, and UTC build time into `khive-runtime`
- expose the same provenance in the daemon startup banner and `kkernel --version`, while preserving the terse package-only `kkernel -V`
- report `unstamped` explicitly outside a Git checkout and honor `SOURCE_DATE_EPOCH` for reproducible timestamps
- watch the resolved Git metadata and tracked source inputs so Cargo refreshes provenance when the checkout changes

## Validation

- `cargo test -p khive-runtime --all-features` (1,119 passed, 0 failed, 7 ignored)
- `cargo test -p kkernel --all-features` (325 passed, 0 failed)
- `cargo check -p khive-runtime -p kkernel --all-targets --all-features`
- `cargo clippy -p khive-runtime -p kkernel --all-targets --all-features -- -D warnings`
- `cargo fmt -p khive-runtime -p kkernel -- --check`
- `deno fmt --check crates/kkernel/docs/usage.md`
- `kkernel -V` => `kkernel 0.5.0`
- `kkernel --version` => full revision `c1587ebe18505b0607297f8b1d27d5d6a66d0ffe` and UTC build time

Closes #1378.

> AI-assisted contribution: Codex prepared this change and PR description.
