### PR TITLE
fix(fold): honor pipeline candidate limits

### DIFF
--- a/crates/khive-fold/docs/design.md
+++ b/crates/khive-fold/docs/design.md
@@ -2,7 +2,7 @@
 
 **Scope:** Cognitive primitives — Fold, Anchor, Objective, Selector.
 
-**Last reviewed:** 2026-06-06
+**Last reviewed:** 2026-07-31
 
 ---
 
@@ -26,6 +26,7 @@
   knowing the wall-clock time.
 - Non-finite scores are rejected at every selection boundary (`passes_score`).
 - Non-finite precision falls back to 1.0 (full trust) rather than propagating NaN into ranking.
+- `ObjectiveContext.max_candidates` bounds the input-order prefix scored by `ComposePipeline`.
 - Deterministic tie-breaking: UUID ascending after score descending everywhere.
 
 ## Dependency Boundary

--- a/crates/khive-fold/src/pipeline.rs
+++ b/crates/khive-fold/src/pipeline.rs
@@ -1,14 +1,11 @@
 //! ComposePipeline: score candidates then pack to budget.
 
-use crate::anchor::{Anchor, AnchorGraph};
 use crate::error::FoldError;
 use crate::objective::{Objective, ObjectiveContext};
 use crate::selector::{Selector, SelectorInput, SelectorOutput, SelectorWeights};
 
 /// Pipeline that scores candidates with an objective then packs to budget via a selector.
 pub struct ComposePipeline<T> {
-    /// Graph anchor used for causal provenance traversal before scoring.
-    pub anchor: Box<dyn Anchor>,
     /// Objective that assigns scores to each candidate.
     pub objective: Box<dyn Objective<T>>,
     /// Selector that packs the scored candidates under a budget.
@@ -16,17 +13,20 @@ pub struct ComposePipeline<T> {
 }
 
 impl<T: Clone + Send + Sync + 'static> ComposePipeline<T> {
-    /// Score candidates with the objective, then pack under budget with the selector.
+    /// Score at most `context.max_candidates` inputs in caller order, then pack under budget.
     pub fn execute(
         &self,
-        _graph: &AnchorGraph,
         candidates: Vec<SelectorInput<T>>,
         budget: usize,
         weights: &SelectorWeights,
         context: &ObjectiveContext,
     ) -> Result<SelectorOutput<T>, FoldError> {
-        let mut scored = Vec::with_capacity(candidates.len());
-        for mut candidate in candidates {
+        let considered = context
+            .max_candidates
+            .unwrap_or(candidates.len())
+            .min(candidates.len());
+        let mut scored = Vec::with_capacity(considered);
+        for mut candidate in candidates.into_iter().take(considered) {
             let score = self.objective.score(&candidate.content, context);
             if !self.objective.passes_score(score, context) {
                 continue;
@@ -103,7 +103,6 @@ mod tests {
 
     fn pipeline() -> ComposePipeline<(f64, f64)> {
         ComposePipeline {
-            anchor: Box::new(crate::anchor::BfsAnchor),
             objective: Box::new(TupleObjective),
             selector: Box::new(crate::selector::GreedySelector),
         }
@@ -115,7 +114,6 @@ mod tests {
         let candidates = vec![input("a", 10.0, 0.1), input("b", 2.0, 1.0)];
         let out = pipeline
             .execute(
-                &AnchorGraph::new(),
                 candidates,
                 1,
                 &SelectorWeights::default(),
@@ -132,15 +130,22 @@ mod tests {
         let candidates = vec![input("a", 1.0, 1.0)];
         let context = ObjectiveContext::new().with_min_score(2.0);
         let out = pipeline
-            .execute(
-                &AnchorGraph::new(),
-                candidates,
-                10,
-                &SelectorWeights::default(),
-                &context,
-            )
+            .execute(candidates, 10, &SelectorWeights::default(), &context)
             .unwrap();
         assert!(out.selected.is_empty());
+    }
+
+    #[test]
+    fn compose_pipeline_respects_max_candidates_before_scoring() {
+        let pipeline = pipeline();
+        let candidates = vec![input("first", 1.0, 1.0), input("outside-limit", 10.0, 1.0)];
+        let context = ObjectiveContext::new().with_max_candidates(1);
+        let out = pipeline
+            .execute(candidates, 10, &SelectorWeights::default(), &context)
+            .unwrap();
+
+        assert_eq!(out.selected.len(), 1);
+        assert_eq!(out.selected[0].id, "first");
     }
 
     #[test]
@@ -155,7 +160,6 @@ mod tests {
         let candidates = vec![input("a", 1.0, 1.0), input("b", 1.000_000_04, 1.0)];
         let out = pipeline
             .execute(
-                &AnchorGraph::new(),
                 candidates,
                 1,
                 &SelectorWeights::default(),
@@ -174,7 +178,6 @@ mod tests {
         let candidates = vec![input("z", 0.0, 1.0), input("a", 0.0, 1.0)];
         let out = pipeline
             .execute(
-                &AnchorGraph::new(),
                 candidates,
                 10,
                 &SelectorWeights::default(),
@@ -209,13 +212,7 @@ mod tests {
             ..Default::default()
         };
         let out = pipeline
-            .execute(
-                &AnchorGraph::new(),
-                candidates,
-                1,
-                &weights,
-                &ObjectiveContext::new(),
-            )
+            .execute(candidates, 1, &weights, &ObjectiveContext::new())
             .unwrap();
         assert_eq!(out.selected.len(), 1);
         assert_eq!(
@@ -230,7 +227,6 @@ mod tests {
         let candidates = vec![input("a", f64::MAX, 1.0)];
         let err = pipeline
             .execute(
-                &AnchorGraph::new(),
                 candidates,
                 10,
                 &SelectorWeights::default(),

--- a/docs/adr/ADR-024-fold-cognitive-primitives.md
+++ b/docs/adr/ADR-024-fold-cognitive-primitives.md
@@ -238,20 +238,26 @@ path (styx/) can later promote these to machine-checked properties.
 
 ### ComposePipeline — the canonical fold pass
 
+Amendment 2026-07-31: `ComposePipeline` composes objective scoring with budget selection only.
+`Anchor` remains an independent causal-traversal primitive. A consumer that needs anchoring must
+materialize graph-derived features before scoring and place them in its candidates or
+`ObjectiveContext`; the pipeline cannot perform a meaningful traversal without a start/outcome
+reference and depth. The unused `anchor` field and `graph` argument were therefore removed rather
+than advertising traversal that never occurred. `ObjectiveContext.max_candidates` bounds the
+input-order prefix scored by the pipeline, matching the `Objective` helpers.
+
 ```rust
 pub struct ComposePipeline<T> {
-    pub anchor:    Box<dyn Anchor>,
     pub objective: Box<dyn Objective<T>>,
     pub selector:  Box<dyn Selector<T>>,
 }
 
 impl<T> ComposePipeline<T> {
     /// Execute the full fold pass.
-    /// Precondition: anchor graph is materialized.
+    /// Precondition: any graph-derived features are already materialized.
     /// Postcondition: output is deterministically ranked within budget.
     pub fn execute(
         &self,
-        graph: &AnchorGraph,
         candidates: Vec<SelectorInput<T>>,
         budget: usize,
         weights: &SelectorWeights,
@@ -260,9 +266,9 @@ impl<T> ComposePipeline<T> {
 }
 ```
 
-Memory recall (ADR-033), retrieval pipelines (ADR-031), and brain profiles (ADR-032) all
-instantiate `ComposePipeline` with their own `Anchor`, `Objective`, and `Selector`
-implementations. The pipeline is the bridge between the foundation layer and consumers.
+Consumers instantiate `ComposePipeline` with their own `Objective` and `Selector`
+implementations. When a consumer also uses `Anchor`, it does so as a separate preprocessing step.
+The pipeline is the bridge between the foundation layer and consumers.
 
 ### Excluded from `khive-fold` (lives in consumers)
 

--- a/docs/adr/ADR-033-recall-pipeline.md
+++ b/docs/adr/ADR-033-recall-pipeline.md
@@ -432,13 +432,13 @@ replace `WeightedObjective` without rewriting scoring logic. `PriorityObjective`
 fallback) and `ConsensusObjective` (geometric mean) are both plausible alternatives for
 specific use cases. One formula cannot be swapped without rewriting.
 
-### Why `NoAnchor` rather than graph-proximate anchoring
+### Why recall does not perform graph-proximate anchoring
 
 Recall is unanchored in v1: it searches all memory notes in the namespace without bias toward
 graph-proximate notes. Graph-proximate anchoring (bias results toward memories connected to
-currently active entities) is a valid v2 extension — the `ComposePipeline`'s `anchor` slot
-exists precisely for this. The `NoAnchor` implementation is a deliberate placeholder, not an
-oversight.
+currently active entities) is a valid v2 extension. It must use ADR-024's independent `Anchor`
+primitive to materialize graph-derived candidate features before objective scoring; the
+`ComposePipeline` itself does not perform traversal.
 
 ### Why Brain integration is one-way
 
@@ -521,8 +521,8 @@ Rejected.
    get different recall tuning) or global to the pack? The current design is global; per-
    namespace config is a natural extension once the multi-namespace use case is established.
 3. **Anchored recall.** Should `recall` accept an anchor set (related entities) to bias
-   results toward graph-proximate memories? The `ComposePipeline.anchor` slot exists for
-   exactly this. Deferred to when a concrete use case emerges.
+   results toward graph-proximate memories? ADR-024's independent `Anchor` primitive can
+   materialize those features before scoring. Deferred to when a concrete use case emerges.
 4. **memory.recall_train.** When brain feedback has accumulated sufficient labeled examples,
    should the pack support a `memory.recall_train` handler that runs gradient-free
    optimization over the weight space? The infrastructure is in place; the training signal


### PR DESCRIPTION
## Summary

- enforce `ObjectiveContext.max_candidates` as an input-order prefix before `ComposePipeline` scores candidates
- remove the unused public `anchor` field and graph argument, whose current signature lacked the start/outcome/depth inputs required to perform a traversal
- document `Anchor` as an explicit preprocessing primitive and align ADR-024, ADR-033, and the fold design notes with the executable contract
- add a regression proving candidates outside the configured limit are not scored or selected

## Validation

- `cargo test -p khive-fold --all-features` (184 passed, 0 failed)
- `cargo check -p khive-fold --all-targets --all-features`
- `cargo clippy -p khive-fold --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS='-D warnings' cargo doc -p khive-fold --no-deps --all-features`
- `cargo fmt -p khive-fold -- --check`
- `deno fmt --check crates/khive-fold/docs/design.md docs/adr/ADR-024-fold-cognitive-primitives.md docs/adr/ADR-033-recall-pipeline.md`

Closes #1362.

> AI-assisted contribution: Codex prepared this change and PR description.
