### PR TITLE
docs(adr): explain edge taxonomy audit

### DIFF
--- a/docs/adr/ADR-002-edge-ontology.md
+++ b/docs/adr/ADR-002-edge-ontology.md
@@ -498,6 +498,45 @@ The second expansion (→ 17, [ADR-055](ADR-055-epistemic-edge-relations.md)) ad
   does not connect two entities. The relation choice carries polarity; the weight carries
   strength. This is the signal a confidence model consumes.
 
+### How is the closed set calculable and auditable?
+
+[ADR-076](ADR-076-relation-calculability-and-system-role.md) records why there is no
+first-principles relation algebra whose closure uniquely derives these 17 relations: khive's
+query classes are design inputs, not deductions. The calculable result is instead a repeatable
+falsification audit. Each relation names a system role, and a proposed relation is tested against
+seven cheaper encodings: converse (Cv), endpoint restriction (Er), attribute (At), polarity
+(Po), fixed property chain (Ch), materialized reachability view (Mv), and typed sub-relation
+(Sr).
+
+The audit disposition for the current set is:
+
+- Exactly the 15 base relations in this ADR are registered as the grandfathered
+  `SurvivesAll` set. No base relation is treated as a converse, fixed composition, or
+  materialized reachability view of another. In particular, `contains`/`part_of` do not collapse:
+  housing or scope and constitution or membership can diverge. `depends_on`/`enables` also do not
+  collapse: a hard requirement is not the converse of making an outcome possible.
+- `supports`/`refutes` are the one algebraically collapsible pair. They fail Po because a single
+  `assesses` relation plus a polarity value can answer the same queries. ADR-055 nevertheless
+  keeps both as top-level relations under an explicit system-role exception so polarity remains
+  visible to planners, indexes, federation, and the public API rather than residing in open
+  metadata.
+- The live base-plus-KG-pack endpoint-signature audit finds only the ratified
+  `supports`/`refutes` collision. An identical signature is a signal to run Er analysis, not by
+  itself proof of redundancy; relations with the same legal endpoint kinds can still answer
+  different questions.
+
+Accordingly, the audit does not replace the stored vocabulary with a smaller inferred generating
+set. The only demonstrated algebraic collapse is retained by a declared system role, and khive
+does not create converse, chained, or materialized derived edges automatically.
+
+The decision is executable, not prose-only. The seven-eliminator harness and closed-set coverage
+gate live in `crates/khive-types/tests/certificate/`; the live endpoint-signature tripwire lives
+in `crates/khive-pack-kg/tests/certificate/endpoint_signatures.rs`. A new Tier-1 relation must
+provide non-vacuous fixtures that defeat all seven eliminators, or record the eliminator it fails
+and the explicit system role that justifies keeping it. A proposed Tier-2 native label (#293)
+must clear the same irreducibility and system-role analysis before its separate storage mechanism
+is designed; an honest mapping to an existing core relation does not qualify as a new label.
+
 ### Why the 2026-07-08 endpoint amendment?
 
 The base contract did not distinguish "who first described this concept" from "who authored


### PR DESCRIPTION
## Summary

- fold the ADR-076 seven-eliminator certificate result into ADR-002
- record why the 17-relation vocabulary is auditable but not uniquely derivable from first principles
- document the live endpoint-signature result, retained polarity exception, and admission rule for future Tier-1/Tier-2 labels

Fixes #297.

## Why

The executable certificate and live endpoint-signature audit already satisfy the issue's
mechanical deliverable. The remaining maintainer-requested work was to make that result part
of ADR-002's authoritative rationale. This documents the 15 grandfathered `SurvivesAll`
relations, the explicit `supports`/`refutes` system-role exception, and why khive does not
replace stored relations with a smaller automatically-derived generating set.

## Validation

- `deno fmt --check docs/` — 152 files checked
- `sh scripts/lint-adr-refs.sh` — 346 files / 180 titled references checked
- ADR reference-lint positive and negative self-tests
- `git diff --check HEAD^ HEAD`

The branch was validated at exact commit `eed807759878d8ecb52d138060070b8ab709ee8b`.

> AI-assisted contribution: Codex prepared this change and PR description.
