### PR TITLE
fix(vectors): canonicalize scores and ranks

### DIFF
--- a/crates/khive-db/src/stores/vectors.rs
+++ b/crates/khive-db/src/stores/vectors.rs
@@ -6,7 +6,7 @@ use std::sync::{Arc, OnceLock};
 use async_trait::async_trait;
 use uuid::Uuid;
 
-use khive_score::DeterministicScore;
+use khive_score::{cmp_desc_then_id, try_score_from_distance, DeterministicScore, ScoreError};
 use khive_storage::error::StorageError;
 use khive_storage::types::{
     BatchWriteSummary, IndexRebuildScope, OrphanSweepConfig, OrphanSweepResult, SqlStatement,
@@ -16,7 +16,7 @@ use khive_storage::types::{
 use khive_storage::StorageCapability;
 use khive_storage::StorageResult;
 use khive_storage::VectorStore;
-use khive_types::SubstrateKind;
+use khive_types::{DistanceMetric, SubstrateKind};
 
 use crate::error::SqliteError;
 use crate::pool::ConnectionPool;
@@ -164,6 +164,74 @@ fn non_finite_vector_error(op: &'static str, idx: usize, value: f32) -> StorageE
             "non-finite value at index {idx}: {value} \
              (NaN/Inf values corrupt distance computations)"
         ),
+    }
+}
+
+/// Convert sqlite-vec's cosine distance through the canonical score contract.
+///
+/// sqlite-vec exposes the value as SQLite `REAL`. Its arithmetic can drift a
+/// mathematically exact endpoint by a few f64 ULPs (for example, a vector's
+/// distance from itself can be `-f64::EPSILON`). Normalize only that boundary
+/// roundoff, then route through the strict canonical f32 score contract.
+fn sqlite_cosine_score(distance: f64) -> Result<DeterministicScore, rusqlite::Error> {
+    const BOUNDARY_EPSILON: f64 = 4.0 * f64::EPSILON;
+
+    let conversion_error = |error| {
+        rusqlite::Error::FromSqlConversionFailure(1, rusqlite::types::Type::Real, Box::new(error))
+    };
+    if !distance.is_finite() {
+        return Err(conversion_error(ScoreError::NonFiniteDistance));
+    }
+    if !(-BOUNDARY_EPSILON..=2.0 + BOUNDARY_EPSILON).contains(&distance) {
+        return Err(conversion_error(ScoreError::InvalidDistanceRange {
+            metric_name: "Cosine",
+            dist_bits: (distance as f32).to_bits(),
+        }));
+    }
+
+    try_score_from_distance(distance.clamp(0.0, 2.0) as f32, DistanceMetric::Cosine)
+        .map_err(conversion_error)
+}
+
+#[cfg(test)]
+mod sqlite_cosine_score_tests {
+    use super::*;
+
+    #[test]
+    fn canonical_conversion_keeps_opposite_vectors_negative() {
+        assert_eq!(
+            sqlite_cosine_score(2.0).unwrap(),
+            DeterministicScore::from_f64(-1.0)
+        );
+    }
+
+    #[test]
+    fn canonical_conversion_normalizes_only_endpoint_roundoff() {
+        assert_eq!(
+            sqlite_cosine_score(-f64::EPSILON).unwrap(),
+            DeterministicScore::from_f64(1.0)
+        );
+        assert_eq!(
+            sqlite_cosine_score(2.0 + f64::EPSILON).unwrap(),
+            DeterministicScore::from_f64(-1.0)
+        );
+    }
+
+    #[test]
+    fn canonical_conversion_rejects_invalid_driver_distances() {
+        for distance in [
+            f64::NAN,
+            f64::INFINITY,
+            -8.0 * f64::EPSILON,
+            2.0 + 8.0 * f64::EPSILON,
+            -0.1,
+            2.1,
+        ] {
+            assert!(
+                sqlite_cosine_score(distance).is_err(),
+                "distance {distance:?} must fail strict canonical validation"
+            );
+        }
     }
 }
 
@@ -1192,13 +1260,9 @@ impl VectorStore for SqliteVecStore {
                     )
                 })?;
 
-                // sqlite-vec cosine distance: 0.0 = identical, 2.0 = opposite.
-                // Convert to similarity in [0, 1]: score = 1.0 - (distance / 2.0)
-                let similarity = 1.0 - (distance / 2.0);
-
                 hits.push(VectorSearchHit {
                     subject_id,
-                    score: DeterministicScore::from_f64(similarity),
+                    score: sqlite_cosine_score(distance)?,
                     rank: (rank_idx + 1) as u32,
                 });
             }
@@ -1469,10 +1533,6 @@ impl SqliteVecStore {
         query_embedding: &[f32],
         candidate_ids: &[Uuid],
     ) -> Result<Vec<VectorSearchHit>, StorageError> {
-        if candidate_ids.is_empty() || query_embedding.is_empty() {
-            return Ok(Vec::new());
-        }
-
         let dims = self.dimensions;
         if query_embedding.len() != dims {
             return Err(StorageError::InvalidInput {
@@ -1484,6 +1544,10 @@ impl SqliteVecStore {
                     dims
                 ),
             });
+        }
+
+        if candidate_ids.is_empty() {
+            return Ok(Vec::new());
         }
 
         if let Some(idx) = non_finite_index(query_embedding) {
@@ -1541,16 +1605,16 @@ impl SqliteVecStore {
                         )
                     })?;
 
-                    let similarity = 1.0 - (distance / 2.0);
                     all_hits.push(VectorSearchHit {
                         subject_id,
-                        score: DeterministicScore::from_f64(similarity),
+                        score: sqlite_cosine_score(distance)?,
                         rank: 0,
                     });
                 }
             }
 
-            all_hits.sort_by_key(|hit| std::cmp::Reverse(hit.score));
+            all_hits
+                .sort_by(|a, b| cmp_desc_then_id(a.score, &a.subject_id, b.score, &b.subject_id));
             for (i, hit) in all_hits.iter_mut().enumerate() {
                 hit.rank = (i + 1) as u32;
             }
@@ -1598,6 +1662,128 @@ mod batch_exists_tests {
             .conn()
             .execute_batch(crate::migrations::ANN_WRITE_LOG_DDL)
             .expect("create ann_write_log");
+    }
+
+    #[tokio::test]
+    async fn sqlite_vector_paths_use_canonical_opposite_cosine_score() {
+        let pool = make_vec_pool();
+        let model_key = "canonical_cosine_score";
+        let namespace = "ns:canonical-score";
+        create_vec_table(&pool, model_key, 2);
+        let store = SqliteVecStore::new(
+            pool,
+            false,
+            model_key.to_string(),
+            model_key.to_string(),
+            2,
+            namespace.to_string(),
+        )
+        .unwrap();
+        let opposite_id = Uuid::from_u128(1);
+        store
+            .insert(
+                opposite_id,
+                SubstrateKind::Entity,
+                namespace,
+                "body",
+                vec![vec![-1.0, 0.0]],
+            )
+            .await
+            .unwrap();
+
+        let candidate_hits = store
+            .score_candidates(&[1.0, 0.0], &[opposite_id])
+            .await
+            .unwrap();
+        assert_eq!(candidate_hits.len(), 1);
+        assert_eq!(candidate_hits[0].score, DeterministicScore::from_f64(-1.0));
+
+        let search_hits = store
+            .search(VectorSearchRequest {
+                query_vectors: vec![vec![1.0, 0.0]],
+                top_k: 1,
+                namespace: Some(namespace.to_string()),
+                kind: Some(SubstrateKind::Entity),
+                embedding_model: None,
+                filter: None,
+                backend_hints: None,
+            })
+            .await
+            .unwrap();
+        assert_eq!(search_hits.len(), 1);
+        assert_eq!(search_hits[0].score, DeterministicScore::from_f64(-1.0));
+    }
+
+    #[tokio::test]
+    async fn score_candidates_rejects_an_empty_query_dimension() {
+        let pool = make_vec_pool();
+        let store = SqliteVecStore::new(
+            pool,
+            false,
+            "empty_query_dimension".to_string(),
+            "empty_query_dimension".to_string(),
+            2,
+            "ns:empty-query".to_string(),
+        )
+        .unwrap();
+
+        let error = store
+            .score_candidates(&[], &[Uuid::from_u128(1)])
+            .await
+            .unwrap_err();
+        match error {
+            StorageError::InvalidInput {
+                operation, message, ..
+            } => {
+                assert_eq!(operation, "score_candidates");
+                assert!(message.contains("query has 0 dims, expected 2"));
+            }
+            other => panic!("expected dimension error, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn score_candidates_breaks_equal_scores_by_lower_id() {
+        let pool = make_vec_pool();
+        let model_key = "candidate_score_ties";
+        let namespace = "ns:candidate-ties";
+        create_vec_table(&pool, model_key, 2);
+        let store = SqliteVecStore::new(
+            pool,
+            false,
+            model_key.to_string(),
+            model_key.to_string(),
+            2,
+            namespace.to_string(),
+        )
+        .unwrap();
+        let lower_id = Uuid::from_u128(1);
+        let higher_id = Uuid::from_u128(2);
+        for id in [higher_id, lower_id] {
+            store
+                .insert(
+                    id,
+                    SubstrateKind::Entity,
+                    namespace,
+                    "body",
+                    vec![vec![1.0, 0.0]],
+                )
+                .await
+                .unwrap();
+        }
+
+        let hits = store
+            .score_candidates(&[1.0, 0.0], &[higher_id, lower_id])
+            .await
+            .unwrap();
+        assert_eq!(
+            hits.iter().map(|hit| hit.subject_id).collect::<Vec<_>>(),
+            vec![lower_id, higher_id]
+        );
+        assert_eq!(
+            hits.iter().map(|hit| hit.rank).collect::<Vec<_>>(),
+            vec![1, 2]
+        );
     }
 
     /// Valid (underscored) model key: batch_exists returns the exact set of IDs

--- a/crates/khive-db/src/stores/vectors.rs
+++ b/crates/khive-db/src/stores/vectors.rs
@@ -1812,6 +1812,114 @@ mod batch_exists_tests {
         assert_eq!(top_hit.rank, 1);
     }
 
+    /// Derivation (checked against sqlite-vec's `distance_cosine_float` in
+    /// sqlite-vec.c, which accumulates `dot`/`aMag`/`bMag` in f32 before
+    /// computing `1 - dot/(sqrt(aMag)*sqrt(bMag))`, still in f32):
+    ///
+    /// For the self-comparison vector `[3.0, 3.0, 3.0]`, each product
+    /// `3.0*3.0 = 9.0` is exact in f32, and `9.0+9.0+9.0 = 27.0` is also
+    /// exact (no rounding at any accumulation step), so
+    /// `dot = aMag = bMag = 27.0f32` bit-for-bit.
+    ///
+    /// `sqrt(27.0)` is not exactly representable, so it is correctly
+    /// rounded to the nearest f32 (`5.1961524f32`); squaring that back in
+    /// f32 lands one f32 ULP *below* 27.0, at `26.999998092651367f32` —
+    /// the round-trip through `sqrt` does not invert exactly. So:
+    ///
+    /// `distance = 1 - 27.0/26.999998092651367 = -1.1920928955078125e-07`
+    ///
+    /// which is exactly `-f32::EPSILON`. That is negative — outside the
+    /// mathematical `[0, 2]` cosine-distance range — yet its magnitude is
+    /// only 1 f32 ULP, far inside the widened `8*f32::EPSILON` boundary
+    /// (~9.537e-7) and enormously outside the old `4*f64::EPSILON`
+    /// tolerance (~8.88e-16) that round one shipped. A driver that still
+    /// used the old f64-scale window would reject this distance outright.
+    #[tokio::test]
+    async fn sqlite_vector_paths_tolerate_real_f32_endpoint_roundoff_below_zero() {
+        let pool = make_vec_pool();
+        let raw_pool = Arc::clone(&pool);
+        let model_key = "f32_endpoint_roundoff_below_zero";
+        let namespace = "ns:f32-roundoff-below-zero";
+        create_vec_table(&pool, model_key, 3);
+        let store = SqliteVecStore::new(
+            pool,
+            false,
+            model_key.to_string(),
+            model_key.to_string(),
+            3,
+            namespace.to_string(),
+        )
+        .unwrap();
+
+        let self_id = Uuid::from_u128(1);
+        let vector = vec![3.0_f32, 3.0, 3.0];
+        store
+            .insert(
+                self_id,
+                SubstrateKind::Entity,
+                namespace,
+                "body",
+                vec![vector.clone()],
+            )
+            .await
+            .unwrap();
+
+        let raw_distance: f64 = {
+            let writer = raw_pool.try_writer().expect("pool writer");
+            let sql = format!(
+                "SELECT vec_distance_cosine(embedding, ?1) FROM vec_{} WHERE subject_id = ?2",
+                model_key
+            );
+            let mut stmt = writer.conn().prepare(&sql).unwrap();
+            stmt.raw_bind_parameter(1, f32_slice_as_bytes(&vector))
+                .unwrap();
+            stmt.raw_bind_parameter(2, self_id.to_string().as_str())
+                .unwrap();
+            let mut rows = stmt.raw_query();
+            let row = rows.next().unwrap().expect("one row");
+            row.get(0).unwrap()
+        };
+
+        assert_eq!(raw_distance, -(f32::EPSILON as f64));
+        assert!(
+            !(0.0..=2.0).contains(&raw_distance),
+            "fixture must land outside the mathematical [0, 2] cosine range, got {raw_distance}"
+        );
+        let boundary_epsilon = 8.0 * f32::EPSILON as f64;
+        assert!(
+            raw_distance.abs() <= boundary_epsilon,
+            "fixture must stay within the widened f32-scale tolerance, got {raw_distance}"
+        );
+        let old_tolerance = 4.0 * f64::EPSILON;
+        assert!(
+            raw_distance.abs() > old_tolerance,
+            "fixture must exceed the old f64-scale tolerance so it would have failed under it, got {raw_distance}"
+        );
+
+        let candidate_hits = store
+            .score_candidates(&vector, &[self_id])
+            .await
+            .unwrap();
+        assert_eq!(candidate_hits.len(), 1);
+        assert_eq!(candidate_hits[0].score, DeterministicScore::from_f64(1.0));
+
+        let search_hits = store
+            .search(VectorSearchRequest {
+                query_vectors: vec![vector],
+                top_k: 1,
+                namespace: Some(namespace.to_string()),
+                kind: Some(SubstrateKind::Entity),
+                embedding_model: None,
+                filter: None,
+                backend_hints: None,
+            })
+            .await
+            .unwrap();
+        assert_eq!(search_hits.len(), 1);
+        assert_eq!(search_hits[0].score, DeterministicScore::from_f64(1.0));
+        assert_eq!(search_hits[0].rank, 1);
+    }
+
     #[tokio::test]
     async fn score_candidates_rejects_an_empty_query_dimension() {
         let pool = make_vec_pool();

--- a/crates/khive-db/src/stores/vectors.rs
+++ b/crates/khive-db/src/stores/vectors.rs
@@ -169,12 +169,16 @@ fn non_finite_vector_error(op: &'static str, idx: usize, value: f32) -> StorageE
 
 /// Convert sqlite-vec's cosine distance through the canonical score contract.
 ///
-/// sqlite-vec exposes the value as SQLite `REAL`. Its arithmetic can drift a
-/// mathematically exact endpoint by a few f64 ULPs (for example, a vector's
-/// distance from itself can be `-f64::EPSILON`). Normalize only that boundary
-/// roundoff, then route through the strict canonical f32 score contract.
+/// sqlite-vec accumulates `dot`/`aMag`/`bMag` in `f32` (see
+/// `distance_cosine_float` in sqlite-vec.c) and only widens the final result
+/// to SQLite's `REAL` (f64) on the way out. The roundoff at a mathematically
+/// exact endpoint therefore lands on the `f32` ULP scale — about
+/// `f32::EPSILON` (~1.19e-7) for a self- or exactly-opposite comparison,
+/// not the `f64::EPSILON` (~2.22e-16) scale of the widening cast itself.
+/// Normalize only that f32-scale boundary roundoff, then route through the
+/// strict canonical f32 score contract.
 fn sqlite_cosine_score(distance: f64) -> Result<DeterministicScore, rusqlite::Error> {
-    const BOUNDARY_EPSILON: f64 = 4.0 * f64::EPSILON;
+    const BOUNDARY_EPSILON: f64 = 8.0 * f32::EPSILON as f64;
 
     let conversion_error = |error| {
         rusqlite::Error::FromSqlConversionFailure(1, rusqlite::types::Type::Real, Box::new(error))
@@ -215,6 +219,16 @@ mod sqlite_cosine_score_tests {
             sqlite_cosine_score(2.0 + f64::EPSILON).unwrap(),
             DeterministicScore::from_f64(-1.0)
         );
+        // f32-scale roundoff, the magnitude sqlite-vec's own f32 accumulation
+        // actually produces for a non-trivial self- or opposite-comparison.
+        assert_eq!(
+            sqlite_cosine_score(-(f32::EPSILON as f64)).unwrap(),
+            DeterministicScore::from_f64(1.0)
+        );
+        assert_eq!(
+            sqlite_cosine_score(2.0 + f32::EPSILON as f64).unwrap(),
+            DeterministicScore::from_f64(-1.0)
+        );
     }
 
     #[test]
@@ -222,8 +236,8 @@ mod sqlite_cosine_score_tests {
         for distance in [
             f64::NAN,
             f64::INFINITY,
-            -8.0 * f64::EPSILON,
-            2.0 + 8.0 * f64::EPSILON,
+            -16.0 * f32::EPSILON as f64,
+            2.0 + 16.0 * f32::EPSILON as f64,
             -0.1,
             2.1,
         ] {
@@ -1712,6 +1726,90 @@ mod batch_exists_tests {
             .unwrap();
         assert_eq!(search_hits.len(), 1);
         assert_eq!(search_hits[0].score, DeterministicScore::from_f64(-1.0));
+    }
+
+    /// sqlite-vec's own `distance_cosine_float` (sqlite-vec.c) accumulates
+    /// `dot`/`aMag`/`bMag` in f32, so a non-axis-aligned vector's self- and
+    /// opposite-comparison lands a few f32 ULPs off the exact 0/2 endpoint —
+    /// not the tighter f64 ULP an in-process helper call would produce. This
+    /// drives the real sqlite-vec extension end to end (not just the
+    /// conversion helper) so the endpoint tolerance is checked against the
+    /// roundoff sqlite-vec actually returns.
+    #[tokio::test]
+    async fn sqlite_vector_paths_tolerate_real_f32_endpoint_roundoff() {
+        let pool = make_vec_pool();
+        let model_key = "f32_endpoint_roundoff";
+        let namespace = "ns:f32-roundoff";
+        create_vec_table(&pool, model_key, 3);
+        let store = SqliteVecStore::new(
+            pool,
+            false,
+            model_key.to_string(),
+            model_key.to_string(),
+            3,
+            namespace.to_string(),
+        )
+        .unwrap();
+
+        let identical_id = Uuid::from_u128(1);
+        let opposite_id = Uuid::from_u128(2);
+        store
+            .insert(
+                identical_id,
+                SubstrateKind::Entity,
+                namespace,
+                "body",
+                vec![vec![0.1, 0.2, 0.3]],
+            )
+            .await
+            .unwrap();
+        store
+            .insert(
+                opposite_id,
+                SubstrateKind::Entity,
+                namespace,
+                "body",
+                vec![vec![-0.1, -0.2, -0.3]],
+            )
+            .await
+            .unwrap();
+
+        let candidate_hits = store
+            .score_candidates(&[0.1, 0.2, 0.3], &[identical_id, opposite_id])
+            .await
+            .unwrap();
+        let identical_score = candidate_hits
+            .iter()
+            .find(|hit| hit.subject_id == identical_id)
+            .expect("identical candidate scored")
+            .score;
+        let opposite_score = candidate_hits
+            .iter()
+            .find(|hit| hit.subject_id == opposite_id)
+            .expect("opposite candidate scored")
+            .score;
+        assert_eq!(identical_score, DeterministicScore::from_f64(1.0));
+        assert_eq!(opposite_score, DeterministicScore::from_f64(-1.0));
+
+        let search_hits = store
+            .search(VectorSearchRequest {
+                query_vectors: vec![vec![0.1, 0.2, 0.3]],
+                top_k: 2,
+                namespace: Some(namespace.to_string()),
+                kind: Some(SubstrateKind::Entity),
+                embedding_model: None,
+                filter: None,
+                backend_hints: None,
+            })
+            .await
+            .unwrap();
+        assert_eq!(search_hits.len(), 2);
+        let top_hit = search_hits
+            .iter()
+            .find(|hit| hit.subject_id == identical_id)
+            .expect("identical vector present in search results");
+        assert_eq!(top_hit.score, DeterministicScore::from_f64(1.0));
+        assert_eq!(top_hit.rank, 1);
     }
 
     #[tokio::test]

--- a/crates/khive-db/src/stores/vectors.rs
+++ b/crates/khive-db/src/stores/vectors.rs
@@ -1813,33 +1813,41 @@ mod batch_exists_tests {
     }
 
     /// Derivation (checked against sqlite-vec's `distance_cosine_float` in
-    /// sqlite-vec.c, which accumulates `dot`/`aMag`/`bMag` in f32 before
-    /// computing `1 - dot/(sqrt(aMag)*sqrt(bMag))`, still in f32):
+    /// sqlite-vec.c, which accumulates `dot`/`aMag`/`bMag` in f32 but calls
+    /// the C `sqrt` — not `sqrtf` — on those f32 accumulators, so the
+    /// square-root, product, and division all run in `double` before the
+    /// final implicit narrowing back to `f32` on return).
     ///
-    /// For the self-comparison vector `[3.0, 3.0, 3.0]`, each product
-    /// `3.0*3.0 = 9.0` is exact in f32, and `9.0+9.0+9.0 = 27.0` is also
-    /// exact (no rounding at any accumulation step), so
-    /// `dot = aMag = bMag = 27.0f32` bit-for-bit.
+    /// Because the widening to `double` happens before the square root, a
+    /// self- or exactly-proportional comparison (`dot == aMag == bMag`
+    /// bit-for-bit in f32) round-trips through `sqrt` at `double` precision
+    /// and lands within `f64::EPSILON` of the exact endpoint — nowhere near
+    /// the `f32::EPSILON` scale. The f32-scale roundoff this driver actually
+    /// exposes instead comes from the *accumulation* step: `dot` and the two
+    /// magnitudes are summed independently, so an exactly anti-parallel pair
+    /// (`query = -1.5 * stored`, mathematical cosine `-1`, ideal distance
+    /// `2`) can still see `dot` round to a f32 value fractionally larger in
+    /// magnitude than `sqrt(aMag) * sqrt(bMag)` would predict.
     ///
-    /// `sqrt(27.0)` is not exactly representable, so it is correctly
-    /// rounded to the nearest f32 (`5.1961524f32`); squaring that back in
-    /// f32 lands one f32 ULP *below* 27.0, at `26.999998092651367f32` —
-    /// the round-trip through `sqrt` does not invert exactly. So:
-    ///
-    /// `distance = 1 - 27.0/26.999998092651367 = -1.1920928955078125e-07`
-    ///
-    /// which is exactly `-f32::EPSILON`. That is negative — outside the
-    /// mathematical `[0, 2]` cosine-distance range — yet its magnitude is
-    /// only 1 f32 ULP, far inside the widened `8*f32::EPSILON` boundary
+    /// For `stored = [-4.8, -0.4, -0.4]` and `query = [7.2, 0.6, 0.6]`, that
+    /// yields a raw distance of `2.0000002384185791` — exactly
+    /// `2 + 2*f32::EPSILON`. Verified against the vendored
+    /// `distance_cosine_float` body compiled standalone under every
+    /// combination of `-O0`/`-O2`/`-O3` and `-ffp-contract=off`/`fast` plus
+    /// explicit `-mavx2 -mfma`, since whether the target architecture fuses
+    /// the per-term multiply-add changes the *path* to this result but not
+    /// the final f32 value — the fixture is architecture-independent. That
+    /// distance is outside the mathematical `[0, 2]` cosine-distance range,
+    /// yet its magnitude is within the widened `8*f32::EPSILON` boundary
     /// (~9.537e-7) and enormously outside the old `4*f64::EPSILON`
     /// tolerance (~8.88e-16) that round one shipped. A driver that still
     /// used the old f64-scale window would reject this distance outright.
     #[tokio::test]
-    async fn sqlite_vector_paths_tolerate_real_f32_endpoint_roundoff_below_zero() {
+    async fn sqlite_vector_paths_tolerate_real_f32_endpoint_roundoff_above_two() {
         let pool = make_vec_pool();
         let raw_pool = Arc::clone(&pool);
-        let model_key = "f32_endpoint_roundoff_below_zero";
-        let namespace = "ns:f32-roundoff-below-zero";
+        let model_key = "f32_endpoint_roundoff_above_two";
+        let namespace = "ns:f32-roundoff-above-two";
         create_vec_table(&pool, model_key, 3);
         let store = SqliteVecStore::new(
             pool,
@@ -1851,15 +1859,16 @@ mod batch_exists_tests {
         )
         .unwrap();
 
-        let self_id = Uuid::from_u128(1);
-        let vector = vec![3.0_f32, 3.0, 3.0];
+        let stored_id = Uuid::from_u128(1);
+        let stored_vector = vec![-4.8_f32, -0.4, -0.4];
+        let query_vector = vec![7.2_f32, 0.6, 0.6];
         store
             .insert(
-                self_id,
+                stored_id,
                 SubstrateKind::Entity,
                 namespace,
                 "body",
-                vec![vector.clone()],
+                vec![stored_vector],
             )
             .await
             .unwrap();
@@ -1871,41 +1880,42 @@ mod batch_exists_tests {
                 model_key
             );
             let mut stmt = writer.conn().prepare(&sql).unwrap();
-            stmt.raw_bind_parameter(1, f32_slice_as_bytes(&vector))
+            stmt.raw_bind_parameter(1, f32_slice_as_bytes(&query_vector))
                 .unwrap();
-            stmt.raw_bind_parameter(2, self_id.to_string().as_str())
+            stmt.raw_bind_parameter(2, stored_id.to_string().as_str())
                 .unwrap();
             let mut rows = stmt.raw_query();
             let row = rows.next().unwrap().expect("one row");
             row.get(0).unwrap()
         };
 
-        assert_eq!(raw_distance, -(f32::EPSILON as f64));
+        assert_eq!(raw_distance, 2.0 + 2.0 * f32::EPSILON as f64);
         assert!(
             !(0.0..=2.0).contains(&raw_distance),
             "fixture must land outside the mathematical [0, 2] cosine range, got {raw_distance}"
         );
+        let deviation_above_two = raw_distance - 2.0;
         let boundary_epsilon = 8.0 * f32::EPSILON as f64;
         assert!(
-            raw_distance.abs() <= boundary_epsilon,
+            deviation_above_two <= boundary_epsilon,
             "fixture must stay within the widened f32-scale tolerance, got {raw_distance}"
         );
         let old_tolerance = 4.0 * f64::EPSILON;
         assert!(
-            raw_distance.abs() > old_tolerance,
+            deviation_above_two > old_tolerance,
             "fixture must exceed the old f64-scale tolerance so it would have failed under it, got {raw_distance}"
         );
 
         let candidate_hits = store
-            .score_candidates(&vector, &[self_id])
+            .score_candidates(&query_vector, &[stored_id])
             .await
             .unwrap();
         assert_eq!(candidate_hits.len(), 1);
-        assert_eq!(candidate_hits[0].score, DeterministicScore::from_f64(1.0));
+        assert_eq!(candidate_hits[0].score, DeterministicScore::from_f64(-1.0));
 
         let search_hits = store
             .search(VectorSearchRequest {
-                query_vectors: vec![vector],
+                query_vectors: vec![query_vector],
                 top_k: 1,
                 namespace: Some(namespace.to_string()),
                 kind: Some(SubstrateKind::Entity),
@@ -1916,7 +1926,7 @@ mod batch_exists_tests {
             .await
             .unwrap();
         assert_eq!(search_hits.len(), 1);
-        assert_eq!(search_hits[0].score, DeterministicScore::from_f64(1.0));
+        assert_eq!(search_hits[0].score, DeterministicScore::from_f64(-1.0));
         assert_eq!(search_hits[0].rank, 1);
     }
 

--- a/crates/khive-fusion/README.md
+++ b/crates/khive-fusion/README.md
@@ -46,7 +46,7 @@ registry, which this crate does not implement.
 
 RRF's score is rank-based and ignores the input scores entirely:
 `score(d) = sum(1 / (k + rank_i(d)))` across every source that ranks `d`, with
-`k` defaulting to 60 (`DEFAULT_RRF_K`, per Craswell et al. 2009). A document
+`k` defaulting to 60 (`DEFAULT_RRF_K`, per Cormack et al. 2009). A document
 that appears in more source lists accumulates more contributions.
 
 ## Where this sits

--- a/crates/khive-fusion/docs/algorithm.md
+++ b/crates/khive-fusion/docs/algorithm.md
@@ -85,7 +85,7 @@ $$\hat{s}_i(d) = \frac{s_i(d) - \min_i}{\max_i - \min_i}$$
 
 When all scores in a source are equal (or the source has one element), every entry receives
 $1.0$ so it still contributes to the weighted combination. This ensures BM25 (unbounded) and
-cosine similarity ($[0, 1]$) contribute proportionally to their configured weights regardless
+cosine similarity ($[-1, 1]$) contribute proportionally to their configured weights regardless
 of original score scale.
 
 ### Weight/source length mismatch

--- a/crates/khive-fusion/docs/design.md
+++ b/crates/khive-fusion/docs/design.md
@@ -33,4 +33,4 @@
   documented in `docs/algorithm.md`. Weights are sanitized (non-finite → 0.0, negative → 0.0)
   before normalization; if all effective weights are zero, equal distribution is applied.
 - Per-source min-max normalization (issues #2496/#2639) ensures BM25 unbounded scores and cosine
-  similarity [0, 1] scores contribute proportionally to their configured weights after fusion.
+  similarity [-1, 1] scores contribute proportionally to their configured weights after fusion.

--- a/crates/khive-fusion/src/strategy.rs
+++ b/crates/khive-fusion/src/strategy.rs
@@ -3,7 +3,7 @@
 use serde::{Deserialize, Serialize};
 use std::fmt;
 
-/// Default RRF constant k=60, standard in literature (Craswell et al., 2009).
+/// Default RRF constant k=60, standard in literature (Cormack et al., 2009).
 pub const DEFAULT_RRF_K: usize = 60;
 
 /// Error returned when a [`FusionStrategy`] fails invariant validation.

--- a/crates/khive-retrieval/src/query_ir.rs
+++ b/crates/khive-retrieval/src/query_ir.rs
@@ -87,7 +87,7 @@ pub enum QueryNode {
 pub enum FuseStrategy {
     /// Reciprocal Rank Fusion with smoothing constant `k`.
     ///
-    /// Standard default: k = 60 (Craswell et al., 2009).
+    /// Standard default: k = 60 (Cormack et al., 2009).
     Rrf {
         /// Smoothing constant.
         k: usize,

--- a/crates/khive-runtime/src/reference_resolution.rs
+++ b/crates/khive-runtime/src/reference_resolution.rs
@@ -83,10 +83,8 @@ const SEARCH_MARGIN_RATIO: f64 = 2.0;
 /// fusion. Lexical hits remain admissible because RRF magnitude encodes rank,
 /// not textual relevance, and genuine partial-name matches score below this floor.
 ///
-/// This is a raw cosine value in `[-1.0, 1.0]`, not the `(1 + cos) / 2`
-/// storage scale vector hits are scored on
-/// (`khive-db` `stores/vectors.rs`) — `hybrid_search_with_vector_similarity_floor`
-/// converts between the two scales at the comparison site.
+/// This is a raw cosine value in `[-1.0, 1.0]`, matching the canonical
+/// vector-store score produced by `khive-db` (`1 - cosine_distance`).
 const SEARCH_VECTOR_SIMILARITY_FLOOR: f64 = 0.3;
 /// Confidence reported on a search-stage `Resolved` outcome: not the raw
 /// RRF score, which lives on a much smaller scale (`sum 1/(k + rank)`, e.g.
@@ -908,9 +906,8 @@ mod tests {
             .expect("vector search");
         assert_eq!(raw_hits.len(), 1);
         assert_eq!(raw_hits[0].subject_id, entity.id);
-        // Identical constant embeddings: raw cosine 1.0, storage score
-        // (1 + 1.0) / 2 == 1.0 — well above 0.65, the storage-scale floor a
-        // raw-cosine bar of 0.3 converts to.
+        // Identical constant embeddings have canonical cosine score 1.0,
+        // well above the raw-cosine floor of 0.3.
         assert!((raw_hits[0].score.to_f64() - 1.0).abs() < 1e-6);
 
         let hits = rt
@@ -934,13 +931,74 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn fallback_stage_resolves_moderate_similarity_semantic_only_candidate() {
+        // A canonical cosine score of 0.5 clears the raw-cosine floor of 0.3.
+        // This guards against reintroducing the legacy `(1 + cos) / 2` floor
+        // conversion, which would incorrectly raise the comparison floor to
+        // 0.65 after vector-store scores moved to the canonical cosine scale.
+        let rt = runtime_with_constant_embeddings();
+        let token = actor_token("resolver-test");
+        let ring = ReferenceRing::new();
+        let dimensions = EmbeddingModel::AllMiniLmL6V2.dimensions();
+
+        let entity = rt
+            .create_entity(
+                &token,
+                "concept",
+                None,
+                "Moderately Similar Candidate",
+                None,
+                None,
+                vec![],
+            )
+            .await
+            .expect("create moderate-similarity entity");
+        let vectors = rt.vectors(&token).expect("vector store");
+        vectors
+            .delete(entity.id)
+            .await
+            .expect("delete generated vector");
+        let aligned = dimensions * 3 / 4;
+        let mut moderate_vector = vec![1.0f32; aligned];
+        moderate_vector.extend(vec![-1.0f32; dimensions - aligned]);
+        vectors
+            .insert(
+                entity.id,
+                SubstrateKind::Entity,
+                token.namespace().as_str(),
+                "entity.body",
+                vec![moderate_vector],
+            )
+            .await
+            .expect("insert moderate-similarity vector");
+
+        let query = "totally-nonexistent-moderate-zzz";
+        let raw_hits = rt
+            .vector_search(&token, None, Some(query), 5, Some(SubstrateKind::Entity))
+            .await
+            .expect("vector search");
+        assert_eq!(raw_hits.len(), 1);
+        assert_eq!(raw_hits[0].subject_id, entity.id);
+        assert!((raw_hits[0].score.to_f64() - 0.5).abs() < 1e-6);
+
+        let resolution = resolve_reference(&rt, &ring, &token, query, 5, None)
+            .await
+            .expect("resolve_reference");
+
+        assert_eq!(
+            resolution,
+            ReferenceResolution::Resolved {
+                id: entity.id,
+                confidence: SEARCH_RESOLVED_CONFIDENCE,
+            }
+        );
+    }
+
+    #[tokio::test]
     async fn fallback_stage_drops_orthogonal_semantic_only_candidate() {
-        // Regression for #1366: an orthogonal vector (raw cosine 0.0) scores
-        // 0.5 on the `(1 + cos) / 2` storage scale, which clears a floor
-        // compared directly against the raw-cosine constant (0.3) even
-        // though the documented contract says it should not. A sole
-        // semantic candidate at this similarity must be dropped, not
-        // resolved.
+        // An orthogonal vector has canonical cosine score 0.0, below the
+        // raw-cosine floor of 0.3. A sole semantic candidate at this
+        // similarity must be dropped, not resolved.
         let rt = runtime_with_constant_embeddings();
         let token = actor_token("resolver-test");
         let ring = ReferenceRing::new();
@@ -987,7 +1045,7 @@ mod tests {
             .await
             .expect("vector search");
         assert_eq!(raw_hits.len(), 1);
-        assert!((raw_hits[0].score.to_f64() - 0.5).abs() < 1e-6);
+        assert!((raw_hits[0].score.to_f64() - 0.0).abs() < 1e-6);
 
         let resolution = resolve_reference(
             &rt,
@@ -1028,10 +1086,10 @@ mod tests {
             .await
             .expect("delete generated vector");
         // A quarter of dimensions aligned, three-quarters opposed against the
-        // constant all-ones query embedding: raw cosine 2*0.25 - 1 == -0.5,
-        // storage score (1 + -0.5) / 2 == 0.25 — below floor without being
-        // the maximally-opposite case, so this exercises a genuine
-        // below-floor mismatch rather than the degenerate cosine -1 extreme.
+        // constant all-ones query embedding: canonical cosine score
+        // 2*0.25 - 1 == -0.5. This is below the floor without being the
+        // maximally-opposite case, so it exercises a genuine below-floor
+        // mismatch rather than the degenerate cosine -1 extreme.
         let quarter = dimensions / 4;
         let mut mismatched_vector = vec![1.0f32; quarter];
         mismatched_vector.extend(vec![-1.0f32; dimensions - quarter]);
@@ -1057,7 +1115,7 @@ mod tests {
             .await
             .expect("vector search");
         assert_eq!(raw_hits.len(), 1);
-        assert!((raw_hits[0].score.to_f64() - 0.25).abs() < 1e-6);
+        assert!((raw_hits[0].score.to_f64() + 0.5).abs() < 1e-6);
 
         let resolution = resolve_reference(&rt, &ring, &token, "totally-nonexistent-zzz", 5, None)
             .await

--- a/crates/khive-runtime/src/retrieval.rs
+++ b/crates/khive-runtime/src/retrieval.rs
@@ -503,12 +503,10 @@ impl KhiveRuntime {
         .await
     }
 
-    /// `vector_similarity_floor` is a raw cosine-similarity value in `[-1.0,
-    /// 1.0]`, matching the scale documented on the `resolve` verb and on
-    /// `SEARCH_VECTOR_SIMILARITY_FLOOR`. Vector store hits are scored on the
-    /// `(1 + cos) / 2` storage scale (`khive-db` `stores/vectors.rs`), so the
-    /// comparison converts the floor to that scale rather than comparing the
-    /// raw cosine value against a storage-scale score directly.
+    /// `vector_similarity_floor` is a cosine-similarity value in `[-1.0,
+    /// 1.0]`, matching both the canonical vector-store score contract and the
+    /// scale documented on the `resolve` verb and on
+    /// `SEARCH_VECTOR_SIMILARITY_FLOOR`.
     #[allow(clippy::too_many_arguments)]
     pub(crate) async fn hybrid_search_with_vector_similarity_floor(
         &self,
@@ -594,15 +592,11 @@ impl KhiveRuntime {
         } else {
             Vec::new()
         };
-        if let Some(raw_cosine_floor) = vector_similarity_floor {
-            // Vector store scores are `(1 + cos) / 2` (khive-db stores/vectors.rs),
-            // so a raw-cosine floor must be converted to that scale before it is
-            // compared against `hit.score` — comparing the raw floor directly
-            // against a storage-scale score only rejects hits below raw cosine
-            // -0.4, letting an orthogonal (cosine 0, storage score 0.5) or
-            // opposite-direction candidate clear a floor meant to reject them.
-            let storage_floor = DeterministicScore::from_f64((1.0 + raw_cosine_floor) / 2.0);
-            vector_hits.retain(|hit| hit.score >= storage_floor);
+        if let Some(cosine_floor) = vector_similarity_floor {
+            // Vector store scores use canonical cosine similarity (`1 - distance`),
+            // so the caller's raw-cosine floor is already on the comparison scale.
+            let score_floor = DeterministicScore::from_f64(cosine_floor);
+            vector_hits.retain(|hit| hit.score >= score_floor);
         }
 
         // Keep the full candidate pool (untruncated) through the alive/kind/tag/property


### PR DESCRIPTION
## Summary

- route both SQLite cosine paths through the canonical `1 - distance` score contract
- reject invalid driver distances while normalizing only tiny endpoint roundoff from sqlite-vec
- validate empty query dimensions before the empty-candidate fast path
- sort candidate scores by score descending then UUID ascending before assigning ranks
- correct the repository's remaining RRF attribution to Cormack, Clarke, and Buettcher

Fixes #1332.
Fixes #1333.

## Behavior

Opposite vectors now score `-1` through both SQLite search paths, matching the canonical
score API. Non-finite and materially out-of-range distances fail. sqlite-vec can report a
mathematically exact endpoint a few f64 ULPs outside `[0, 2]`; the adapter clamps only that
documented boundary noise before calling the strict canonical helper. Empty queries reject as a
dimension mismatch even when the candidate list is empty, and equal-score candidates have the
ADR-030 UUID tiebreak before ranks are assigned.

## Validation

- `cargo test -p khive-db -p khive-fusion -p khive-retrieval -p khive-runtime --all-features`
- focused regression for sqlite-vec negative endpoint roundoff
- `cargo check -p khive-db -p khive-fusion -p khive-retrieval -p khive-runtime --all-targets --all-features`
- `cargo clippy -p khive-db -p khive-fusion -p khive-retrieval -p khive-runtime --all-targets --all-features -- -D warnings`
- `cargo fmt --all --check`
- `RUSTDOCFLAGS='-D warnings' cargo doc -p khive-db -p khive-fusion -p khive-retrieval -p khive-runtime --all-features --no-deps`
- independent code review, repository documentation/SQL/ADR/stub gates, repository-wide stale-attribution sweep, and `git diff --check`

The branch was tested at exact commit `96620989c999c690e6265f78941c798ab5f9426e` on current `main`.

> AI-assisted contribution: Codex prepared this change and PR description.
