### PR TITLE
feat(runtime): select packs from discovered config

### DIFF
--- a/crates/khive-mcp/docs/design.md
+++ b/crates/khive-mcp/docs/design.md
@@ -40,6 +40,8 @@ decisions and rationale.
 
 - `builtin_pack_names()` is sourced from `PackRegistry::discovered_names()` so
   the list always reflects whichever pack crates are linked into the binary.
+- Loaded-pack selection resolves once at startup with precedence `--pack` →
+  `KHIVE_PACKS` → `[runtime].packs` → the built-in production set.
 - Pack registration fails fast on unknown names or unsatisfied dependencies —
   a misconfigured `KHIVE_PACKS` is a boot error, not a silent degradation.
 - `pack.rs` force-references one public symbol per pack crate so the linker

--- a/crates/khive-mcp/src/args.rs
+++ b/crates/khive-mcp/src/args.rs
@@ -52,8 +52,8 @@ pub struct Args {
 
     /// Pack to load into the verb registry. Repeat for multiple
     /// (e.g. `--pack kg --pack gtd`). When unset, falls back to `KHIVE_PACKS`
-    /// (comma- or whitespace-separated), and if that is also unset to the full
-    /// production set: `kg,gtd,memory,brain,comm,schedule,knowledge,session,git,code,workspace`.
+    /// (comma- or whitespace-separated), then `[runtime].packs` in the discovered
+    /// config file, then the built-in production set.
     #[arg(long = "pack")]
     pub pack: Vec<String>,
 

--- a/crates/khive-mcp/src/serve.rs
+++ b/crates/khive-mcp/src/serve.rs
@@ -8,9 +8,9 @@ use std::path::PathBuf;
 use std::sync::Arc;
 
 use khive_runtime::{
-    config_from_env, run_migrations, runtime_config_from_khive_config, BackendConfig, BackendId,
-    BackendKind, ConnectionPool, KhiveConfig, KhiveRuntime, OutputFormat, RuntimeConfig,
-    StorageBackend,
+    config_from_env, parse_pack_list, run_migrations, runtime_config_from_khive_config,
+    BackendConfig, BackendId, BackendKind, ConnectionPool, KhiveConfig, KhiveRuntime, OutputFormat,
+    RuntimeConfig, StorageBackend,
 };
 
 use crate::args::{resolve_cli_namespace, Args};
@@ -2558,7 +2558,8 @@ pub struct RuntimeConfigInputs<'a> {
     pub actor_explicit: bool,
     /// Disable embedding entirely (still resolves actor namespace from config).
     pub no_embed: bool,
-    /// Packs to register. `None` falls back to `RuntimeConfig::default().packs`.
+    /// Explicit CLI packs to register. `None` falls through to `KHIVE_PACKS`,
+    /// `[runtime].packs`, then the built-in production set.
     pub packs: Option<Vec<String>>,
     /// Explicit brain profile ID (highest-priority tier).
     ///
@@ -2588,9 +2589,15 @@ pub fn resolve_runtime_config_with_db_anchor(
     let db_anchor = khive_runtime::resolve_db_anchor(inputs.db);
     let db_path = db_anchor.clone();
 
-    let packs = inputs
-        .packs
-        .unwrap_or_else(|| RuntimeConfig::default().packs);
+    let cli_packs = inputs.packs.filter(|packs| !packs.is_empty());
+    let env_packs = std::env::var("KHIVE_PACKS")
+        .ok()
+        .map(|value| parse_pack_list(&value))
+        .filter(|packs| !packs.is_empty());
+    let packs_overridden = cli_packs.is_some() || env_packs.is_some();
+    let packs = cli_packs
+        .or(env_packs)
+        .unwrap_or_else(RuntimeConfig::built_in_packs);
 
     // Tier-1: explicit CLI --brain-profile only (not env — env is tier-3, after TOML).
     // We must NOT read KHIVE_BRAIN_PROFILE here; RuntimeConfig::default() reads it, so
@@ -2622,7 +2629,12 @@ pub fn resolve_runtime_config_with_db_anchor(
             brain_profile: cli_brain_profile,
             ..RuntimeConfig::no_embeddings()
         };
-        resolve_actor_from_config(inputs.config, no_embed_base, db_path_for_config.as_deref())?
+        resolve_actor_from_config(
+            inputs.config,
+            no_embed_base,
+            db_path_for_config.as_deref(),
+            packs_overridden,
+        )?
     } else {
         let base_config = RuntimeConfig {
             db_path,
@@ -2633,7 +2645,12 @@ pub fn resolve_runtime_config_with_db_anchor(
             brain_profile: cli_brain_profile,
             ..RuntimeConfig::default()
         };
-        resolve_config(inputs.config, base_config, db_path_for_config.as_deref())?
+        resolve_config(
+            inputs.config,
+            base_config,
+            db_path_for_config.as_deref(),
+            packs_overridden,
+        )?
     };
 
     // ADR-096 Fork 2 — per-connection `actor_id` precedence chain (highest to
@@ -2770,11 +2787,13 @@ fn resolve_config(
     config_path: Option<&std::path::Path>,
     base: RuntimeConfig,
     db_path: Option<&std::path::Path>,
+    packs_overridden: bool,
 ) -> anyhow::Result<RuntimeConfig> {
     match KhiveConfig::load_with_home_fallback(config_path, db_path)
         .map_err(|e| anyhow::anyhow!("config error: {e}"))?
     {
         Some(khive_cfg) => {
+            let base = apply_config_pack_selection(&khive_cfg, base, packs_overridden);
             let env_primary = std::env::var("KHIVE_EMBEDDING_MODEL").ok();
             let env_additional = std::env::var("KHIVE_ADDITIONAL_EMBEDDING_MODELS").ok();
             if !khive_cfg.engines.is_empty() && (env_primary.is_some() || env_additional.is_some())
@@ -2808,11 +2827,13 @@ fn resolve_actor_from_config(
     config_path: Option<&std::path::Path>,
     base: RuntimeConfig,
     db_path: Option<&std::path::Path>,
+    packs_overridden: bool,
 ) -> anyhow::Result<RuntimeConfig> {
     match KhiveConfig::load_with_home_fallback(config_path, db_path)
         .map_err(|e| anyhow::anyhow!("config error: {e}"))?
     {
         Some(khive_cfg) => {
+            let base = apply_config_pack_selection(&khive_cfg, base, packs_overridden);
             let resolved = runtime_config_from_khive_config(&khive_cfg, base);
             Ok(RuntimeConfig {
                 embedding_model: None,
@@ -2822,6 +2843,24 @@ fn resolve_actor_from_config(
         }
         None => Ok(base),
     }
+}
+
+fn apply_config_pack_selection(
+    khive_cfg: &KhiveConfig,
+    mut base: RuntimeConfig,
+    packs_overridden: bool,
+) -> RuntimeConfig {
+    if !packs_overridden {
+        if let Some(packs) = khive_cfg
+            .runtime
+            .packs
+            .as_ref()
+            .filter(|packs| !packs.is_empty())
+        {
+            base.packs.clone_from(packs);
+        }
+    }
+    base
 }
 
 #[cfg(test)]
@@ -2866,6 +2905,101 @@ mod tests {
 
     fn kg_test_packs() -> Vec<String> {
         vec!["kg".to_string()]
+    }
+
+    fn resolve_packs(
+        config: &std::path::Path,
+        cli_packs: Option<Vec<String>>,
+        no_embed: bool,
+    ) -> Vec<String> {
+        resolve_runtime_config(RuntimeConfigInputs {
+            db: Some(":memory:"),
+            config: Some(config),
+            namespace: Namespace::parse("local").expect("ns"),
+            namespace_explicit: false,
+            actor_explicit: false,
+            no_embed,
+            packs: cli_packs,
+            brain_profile: None,
+        })
+        .expect("resolve config")
+        .packs
+    }
+
+    #[test]
+    #[serial]
+    fn config_pack_selection_applies_to_both_embedding_paths() {
+        let _env = ClearedKhiveEnvGuard::clear();
+        let dir = tempfile::tempdir().expect("temp dir");
+        let path = write_config(dir.path(), "[runtime]\npacks = [\"kg\", \"gtd\"]\n");
+
+        assert_eq!(resolve_packs(&path, None, false), vec!["kg", "gtd"]);
+        assert_eq!(resolve_packs(&path, None, true), vec!["kg", "gtd"]);
+    }
+
+    #[test]
+    #[serial]
+    fn env_pack_selection_overrides_config_file() {
+        let _env = ClearedKhiveEnvGuard::clear();
+        std::env::set_var("KHIVE_PACKS", "kg, gtd");
+        let dir = tempfile::tempdir().expect("temp dir");
+        let path = write_config(dir.path(), "[runtime]\npacks = [\"kg\", \"memory\"]\n");
+
+        assert_eq!(resolve_packs(&path, None, true), vec!["kg", "gtd"]);
+    }
+
+    #[test]
+    #[serial]
+    fn cli_pack_selection_overrides_env_and_config_file() {
+        let _env = ClearedKhiveEnvGuard::clear();
+        std::env::set_var("KHIVE_PACKS", "kg,gtd");
+        let dir = tempfile::tempdir().expect("temp dir");
+        let path = write_config(dir.path(), "[runtime]\npacks = [\"kg\", \"memory\"]\n");
+
+        assert_eq!(
+            resolve_packs(&path, Some(vec!["kg".to_string()]), true),
+            vec!["kg"]
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn empty_cli_and_env_pack_layers_fall_through_to_config() {
+        let _env = ClearedKhiveEnvGuard::clear();
+        std::env::set_var("KHIVE_PACKS", " ,  ");
+        let dir = tempfile::tempdir().expect("temp dir");
+        let path = write_config(dir.path(), "[runtime]\npacks = [\"kg\", \"memory\"]\n");
+
+        assert_eq!(
+            resolve_packs(&path, Some(Vec::new()), true),
+            vec!["kg", "memory"]
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn empty_config_pack_selection_preserves_built_in_default() {
+        let _env = ClearedKhiveEnvGuard::clear();
+        let dir = tempfile::tempdir().expect("temp dir");
+        let path = write_config(dir.path(), "[runtime]\npacks = []\n");
+
+        assert_eq!(
+            resolve_packs(&path, None, true),
+            RuntimeConfig::built_in_packs()
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn backend_assignment_table_does_not_select_packs() {
+        let _env = ClearedKhiveEnvGuard::clear();
+        let dir = tempfile::tempdir().expect("temp dir");
+        let path = write_config(
+            dir.path(),
+            "[runtime]\npacks = [\"kg\"]\n\n[packs.gtd]\nbackend = \"main\"\n",
+        );
+
+        assert_eq!(resolve_packs(&path, None, true), vec!["kg"]);
     }
 
     // The resolver MUST honor config-file `[[engines]]` over RuntimeConfig

--- a/crates/khive-runtime/docs/design.md
+++ b/crates/khive-runtime/docs/design.md
@@ -115,6 +115,8 @@
 - Pack factories are discovered via `inventory` at link time; missing dependencies are a boot error
 - Missing dependencies are not silently auto-added; the requested set must be explicit
 - `PackRegistry` performs topological sort of packs using Kahn's algorithm
+- Startup selection precedence is `--pack` → `KHIVE_PACKS` → `[runtime].packs` → the built-in
+  production set; `[packs.<name>]` assigns backends and does not select packs for loading
 
 ### Gate Authorization (ADR-029)
 

--- a/crates/khive-runtime/src/config.rs
+++ b/crates/khive-runtime/src/config.rs
@@ -218,7 +218,8 @@ pub struct RuntimeConfig {
     /// The transport layer (e.g. `khive-mcp`) reads this list and instantiates
     /// the matching concrete pack types. Unknown names are reported as errors
     /// by the transport, not silently ignored.
-    /// Default: `["kg"]`.
+    /// Defaults to the shipped production set returned by
+    /// [`RuntimeConfig::built_in_packs`].
     pub packs: Vec<String>,
     /// Identifies this runtime's backend in a multi-backend deployment.
     ///
@@ -300,25 +301,7 @@ impl Default for RuntimeConfig {
             .ok()
             .map(|s| parse_pack_list(&s))
             .filter(|v| !v.is_empty())
-            .unwrap_or_else(|| {
-                vec![
-                    "kg",
-                    "gtd",
-                    "memory",
-                    "brain",
-                    "comm",
-                    "schedule",
-                    "knowledge",
-                    "session",
-                    "git",
-                    "code",
-                    "workspace",
-                    "blob",
-                ]
-                .into_iter()
-                .map(String::from)
-                .collect()
-            });
+            .unwrap_or_else(Self::built_in_packs);
         let brain_profile = std::env::var("KHIVE_BRAIN_PROFILE")
             .ok()
             .filter(|s| !s.trim().is_empty());
@@ -343,6 +326,28 @@ impl Default for RuntimeConfig {
 }
 
 impl RuntimeConfig {
+    /// Return the shipped pack set used when no CLI, environment, or
+    /// configuration-file selection is present.
+    pub fn built_in_packs() -> Vec<String> {
+        [
+            "kg",
+            "gtd",
+            "memory",
+            "brain",
+            "comm",
+            "schedule",
+            "knowledge",
+            "session",
+            "git",
+            "code",
+            "workspace",
+            "blob",
+        ]
+        .into_iter()
+        .map(String::from)
+        .collect()
+    }
+
     /// Build a `RuntimeConfig` with embedding disabled entirely.
     ///
     /// `embedding_model` and `additional_embedding_models` are computed

--- a/crates/khive-runtime/src/engine_config.rs
+++ b/crates/khive-runtime/src/engine_config.rs
@@ -341,7 +341,7 @@ pub struct GitWriteSectionConfig {
 /// Sections consumed today:
 /// - `[[engines]]`: embedding engine declarations
 /// - `[actor]`: default namespace / identity (OSS actor model)
-/// - `[runtime]`: runtime knobs (namespace, brain_profile)
+/// - `[runtime]`: runtime knobs (pack selection, brain profile, output format)
 /// - `[[backends]]`: storage backend declarations (ADR-028)
 /// - `[packs.<name>]`: per-pack backend assignments (ADR-028)
 ///
@@ -408,6 +408,11 @@ pub struct KhiveConfig {
 /// defaults.
 #[derive(Debug, Clone, Deserialize, Default)]
 pub struct RuntimeSectionConfig {
+    /// Packs to load when neither `--pack` nor `KHIVE_PACKS` selects them.
+    /// An absent or empty list preserves the built-in production default.
+    #[serde(default)]
+    pub packs: Option<Vec<String>>,
+
     /// Brain profile ID to use for `memory.feedback` / `knowledge.feedback`
     /// and recall-time score boosting (ADR-035 §Brain profile configuration).
     ///

--- a/crates/khive-runtime/src/runtime.rs
+++ b/crates/khive-runtime/src/runtime.rs
@@ -1282,7 +1282,7 @@ mod tests {
     }
 
     #[test]
-    fn default_config_packs_loads_kg_only() {
+    fn default_config_packs_loads_production_set() {
         let prior = std::env::var("KHIVE_PACKS").ok();
         // SAFETY: test function runs single-threaded; no other threads read or write KHIVE_PACKS.
         unsafe {
@@ -1290,6 +1290,7 @@ mod tests {
         }
         // The default distribution loads all production packs.
         let cfg = RuntimeConfig::default();
+        assert_eq!(cfg.packs, RuntimeConfig::built_in_packs());
         assert!(cfg.packs.contains(&"kg".to_string()));
         assert!(cfg.packs.contains(&"gtd".to_string()));
         assert!(cfg.packs.contains(&"memory".to_string()));

--- a/crates/kkernel/README.md
+++ b/crates/kkernel/README.md
@@ -86,7 +86,7 @@ take precedence).
 | `KHIVE_DB`                        | Database path (also `kkernel mcp --db`)                       |
 | `KHIVE_ACTOR` / `KHIVE_NAMESPACE` | Default namespace (also `--actor` / `--namespace`)            |
 | `KHIVE_NO_EMBED`                  | Disable local embedding model                                 |
-| `KHIVE_PACKS`                     | Comma/whitespace-separated pack list (also repeated `--pack`) |
+| `KHIVE_PACKS`                     | Pack-list override (after `--pack`, before `[runtime].packs`) |
 | `KHIVE_CONFIG`                    | Path to the TOML config file (also `--config`)                |
 | `KHIVE_LOG`                       | Log level for stderr (JSON results on stdout are unaffected)  |
 | `KHIVE_BRAIN_PROFILE`             | Brain profile for feedback routing and recall boosting        |

--- a/docs/adr/ADR-027-dynamic-pack-loading.md
+++ b/docs/adr/ADR-027-dynamic-pack-loading.md
@@ -417,15 +417,15 @@ dependency and an anchor line in `crates/khive-mcp/src/pack.rs`.
 
 ## Amendment 3 (2026-07-21): configuration-file pack selection
 
-**Status**: proposed
+**Status**: accepted
 
 ### Context
 
-Pack selection is specified by this ADR as `--pack` CLI > `KHIVE_PACKS` env > built-in
-default. [ADR-035](ADR-035-cli-config-and-auto-embed.md) additionally lists a
-`runtime.packs` configuration key in its option table, but that key was never
-implemented: the configuration loader parses only `[packs.<name>]` backend assignments
-(ADR-028), and the runtime resolves the loaded set from the environment alone.
+Before this amendment, pack selection was implemented as `--pack` CLI > `KHIVE_PACKS`
+env > built-in default. [ADR-035](ADR-035-cli-config-and-auto-embed.md) additionally
+listed a `runtime.packs` configuration key in its option table, but the runtime did not
+consume it: configuration parsing covered only `[packs.<name>]` backend assignments
+(ADR-028), while startup resolved the loaded set from the environment alone.
 
 Environment-only selection makes the loaded pack set a property of each spawning
 process's environment. Every spawn path — interactive shells, service managers,
@@ -483,7 +483,7 @@ this amendment to reflect the deviation.
 - Service-manager and supervised deployments declare packs once in configuration; the
   environment variable becomes an override, not a load-bearing requirement.
 - One more selection layer to document and test; the resolution order is centralized
-  in the runtime configuration loader and reported by introspection.
+  in the MCP startup configuration resolver and reported by introspection.
 
 ## References
 

--- a/docs/adr/ADR-035-cli-config-and-auto-embed.md
+++ b/docs/adr/ADR-035-cli-config-and-auto-embed.md
@@ -149,12 +149,16 @@ CLI or environment override.
 For each runtime option, precedence is:
 **CLI flag > selected config file > applicable `KHIVE_*` env var > built-in
 default**. Exact option-specific exceptions are listed in the canonical config
-reference (`docs/core/khive-config-example.toml`).
+reference (`docs/khive-config-example.toml`).
+
+Pack selection is the exception specified by ADR-027 Amendment 3: `--pack` >
+`KHIVE_PACKS` > `runtime.packs` > the built-in production set. Each layer replaces
+the complete set; an empty layer falls through rather than selecting zero packs.
 
 | Option             | CLI flag                         | Env var                             | Config key                | Default           |
 | ------------------ | -------------------------------- | ----------------------------------- | ------------------------- | ----------------- |
 | Namespace          | `--namespace`                    | `KHIVE_NAMESPACE`                   | `runtime.namespace`       | `default`         |
-| Loaded packs       | `--pack` (repeat)                | `KHIVE_PACKS`                       | `runtime.packs`           | `kg`              |
+| Loaded packs       | `--pack` (repeat)                | `KHIVE_PACKS`                       | `runtime.packs`           | production set    |
 | DB path            | `--db`                           | `KHIVE_DB`                          | `runtime.db_path`         | `~/.khive/kg.db`  |
 | Recall min_score   | (n/a, per-call)                  | `KHIVE_RECALL_MIN_SCORE`            | `memory.recall.min_score` | `None` (no floor) |
 | Disable embeddings | `kkernel mcp --no-embed`         | `KHIVE_NO_EMBED`                    | (none)                    | `false`           |

--- a/docs/guide/api-reference.md
+++ b/docs/guide/api-reference.md
@@ -19,7 +19,7 @@ An always-machine-readable copy of this page is at
 
 | Pack        | Verbs | Load with                                  | Optional?           |
 | ----------- | ----- | ------------------------------------------ | ------------------- |
-| `kg`        | 19    | `KHIVE_PACKS=kg` (default)                 | No — base substrate |
+| `kg`        | 19    | `KHIVE_PACKS=kg`                           | No — base substrate |
 | `gtd`       | 5     | `KHIVE_PACKS=kg,gtd`                       | Yes                 |
 | `memory`    | 5     | `KHIVE_PACKS=kg,memory`                    | Yes                 |
 | `brain`     | 15    | `KHIVE_PACKS=kg,brain`                     | Yes                 |
@@ -56,8 +56,10 @@ even with no `[storage.blob]` section and no `KHIVE_BLOB_ROOT` set; the verbs on
 unconfigured (erroring until a backend is installed) when the server boots against an
 in-memory backend, which has no directory to default a root beside.
 
-The default binary (no `KHIVE_PACKS`/`--pack` override) loads all 12 packs. Use `verbs()` for the
-current aggregate rather than carrying a second hand-maintained total here.
+Pack selection resolves as `--pack` > `KHIVE_PACKS` > discovered `[runtime].packs` > the
+built-in production set. With no non-empty selection at any of the first three layers, the
+default binary loads all 12 packs. Use `verbs()` for the current aggregate rather than carrying
+a second hand-maintained total here.
 
 Verb names in the `kg` pack are bare (`create`, `search`, `link`, …). Every other pack
 namespaces its verbs with a `pack.` prefix (`gtd.assign`, `memory.recall`,

--- a/docs/guide/specialized-packs.md
+++ b/docs/guide/specialized-packs.md
@@ -1,7 +1,7 @@
 # Specialized Packs
 
-khive's default install loads eleven production packs
-(`kg, gtd, memory, brain, comm, schedule, knowledge, session, git, code, workspace`, per
+khive's default install loads twelve production packs
+(`kg, gtd, memory, brain, comm, schedule, knowledge, session, git, code, workspace, blob`, per
 `RuntimeConfig::default()` in `crates/khive-runtime/src/config.rs`). The `code` pack contributes one verb, `code.ingest` (L1 manifest + L1.5
 import-scan source ingestion into a dedicated map database, see
 [ADR-085](../adr/ADR-085-code-pack.md)), alongside its `finding` note kind and
@@ -26,13 +26,18 @@ base contract already allows.
 
 ### Loading a pack
 
-Packs are selected via the `--pack` CLI flag (repeatable) or the
-`KHIVE_PACKS` environment variable (comma- or whitespace-separated):
+Packs are selected, in descending precedence, by the repeatable `--pack` CLI flag,
+the comma- or whitespace-separated `KHIVE_PACKS` environment variable, or
+`[runtime].packs` in the discovered configuration file. Each non-empty layer replaces
+the complete set; with no selection, khive loads the built-in production set.
 
 ```bash
 kkernel mcp --pack kg --pack gtd --pack formal
 # or
 KHIVE_PACKS="kg,gtd,formal" kkernel mcp
+# or in khive.toml
+# [runtime]
+# packs = ["kg", "gtd", "formal"]
 ```
 
 `formal` declares `REQUIRES = &["kg"]`, so `kg` must also be in the load set.

--- a/docs/khive-config-example.toml
+++ b/docs/khive-config-example.toml
@@ -59,6 +59,12 @@
 # ── [runtime] — runtime knobs ────────────────────────────────────────────────────
 
 [runtime]
+# Packs loaded into the verb registry. This is distinct from [packs.<name>],
+# which only assigns an already-selected pack to a backend. An empty or absent
+# list preserves the built-in production set.
+# Precedence (high→low): --pack → KHIVE_PACKS → this key → built-in set.
+# packs = ["kg", "gtd", "memory"]
+
 # Brain profile id used by memory.feedback / knowledge.feedback and for recall-time
 # score boosting. Absent → the namespace-bound profile (brain.resolve) is tried,
 # then the global tuning prior. Mirrors --brain-profile / KHIVE_BRAIN_PROFILE.
@@ -185,8 +191,9 @@ fusion_weight = 0.5
 #   KHIVE_NAMESPACE=local        Legacy alias for KHIVE_ACTOR; loses to it when both are set.
 #   KHIVE_NO_EMBED=false         Disable the local embedding model (skips vector indexing).
 #                                STRICT bool: only "true"/"false" — "1" is a startup error.
-#   KHIVE_PACKS=kg,gtd,memory,brain,comm,schedule,knowledge,session,git,code,workspace
-#                                Packs to load when --pack is absent. Comma / space separated.
+#   KHIVE_PACKS=kg,gtd,memory,brain,comm,schedule,knowledge,session,git,code,workspace,blob
+#                                Packs to load when --pack is absent. Comma / space separated;
+#                                overrides [runtime].packs.
 #   KHIVE_CONFIG=./khive.toml    Path to THIS config file. Also --config. Overrides the search order.
 #   KHIVE_LOG=warn               Stderr log level (JSON results on stdout are unaffected).
 #   KHIVE_BRAIN_PROFILE=         Brain profile id. Tier 3 — after --brain-profile and


### PR DESCRIPTION
## Summary

- add `[runtime].packs` to discovered TOML configuration
- resolve pack selection as non-empty `--pack` > `KHIVE_PACKS` > `[runtime].packs` > the 12-pack built-in production set
- apply the same selection in embedding-enabled and `--no-embed` startup paths
- keep `[packs.<name>]` exclusively for backend assignment and reconcile the accepted ADR/user guides

Fixes #1211.

## Behavior

Each layer replaces the complete pack set rather than merging. Empty CLI, environment, and
configuration layers fall through. The existing production default remains unchanged, including
`blob`. The discovered config now gives service managers and daemon launches a stable declaration
point without removing per-process CLI or environment overrides.

## Validation

- `cargo test -p khive-runtime -p khive-mcp -p kkernel --all-features`
- `cargo check -p khive-runtime -p khive-mcp -p kkernel --all-targets --all-features`
- `cargo clippy -p khive-runtime -p khive-mcp -p kkernel --all-targets --all-features -- -D warnings`
- `cargo fmt --all --check`
- `RUSTDOCFLAGS='-D warnings' cargo doc -p khive-runtime -p khive-mcp -p kkernel --all-features --no-deps`
- full docs formatting, ADR reference lint, two independent review rounds, and `git diff --check HEAD^ HEAD`

The branch was tested at exact commit `6cc7a4c3416194e013f564103534013c05743cbd`.

> AI-assisted contribution: Codex prepared this change and PR description.
