### PR TITLE
docs(kkernel): define bulk-writer daemon coexistence

### DIFF
--- a/crates/kkernel/docs/design.md
+++ b/crates/kkernel/docs/design.md
@@ -191,6 +191,49 @@ the wrong value would silently ignore an operator's in-memory isolation request.
 the canonical anchor captured alongside `cfg`, threaded through so fallback construction never
 re-reads a changed `HOME`.
 
+### `exec` daemon-bypass second-writer contract (#548; ADR-067, ADR-099)
+
+**Decision:** keep `exec --save-file` and both `exec --ops-file` modes on the in-process path.
+They do not forward through, stop, or lease a live daemon. If that daemon has the same SQLite
+file open, the CLI runtime is a second process with an independent connection pool. ADR-067's
+writer task and `KHIVE_WRITE_QUEUE=1` serialize writes only inside one pool/process; they do not
+coordinate the CLI process with the daemon. The boot/recovery guard in `exec.rs` protects runtime
+construction and schema initialization only and is dropped before request execution.
+
+Cross-process writes therefore use SQLite's WAL writer lock as their only serialization seam.
+Every normal file-backed connection waits for that lock for `KHIVE_BUSY_TIMEOUT_SECS` (30 seconds
+by default). If the other process still holds the lock when that process-local timeout expires,
+the operation fails with SQLite `BUSY`/`database is locked`. `kkernel exec` does not automatically
+retry: a generic replay is unsafe for non-idempotent verbs and could duplicate a write whose
+outcome the caller has not established.
+
+The observable failure contract stays mode-specific:
+
+- `--save-file` may carry read or write verbs. A contended op's error detail is written to that
+  op's JSONL result row; stdout carries the save manifest, whose `summary` reports the failure
+  counts. `--strict` makes any failed op a non-zero exit; a fully failed invocation is non-zero
+  even without `--strict`.
+- Non-atomic `--ops-file` preserves per-op commits and continues collecting results. A contended
+  op can fail after earlier ops committed; the final summary identifies every failed op.
+  `--strict` makes any failure a non-zero exit, while a fully failed file is always non-zero.
+- `--ops-file --atomic` holds one bounded, DML-only `BEGIN IMMEDIATE` during its commit pass, per
+  ADR-099. Daemon writes wait behind that unit and can fail if its hold exceeds their own busy
+  timeout. Admissibility, prepare, and atomic-unit seam errors return a top-level error and a
+  non-zero exit before an atomic result envelope is printed. A plan-level guard or SQL failure
+  instead prints the additive envelope with `atomic.committed=false` and
+  `atomic.rolled_back=true`; the CLI currently exits zero for that rolled-back outcome, and
+  `--strict` is ignored because it is not meaningful in atomic mode. Callers must inspect
+  `atomic.committed`. The op-count guard bounds the unit; operators should run a large atomic file
+  against an idle daemon or in a maintenance window.
+
+Routing these modes through the daemon remains rejected. `--save-file` is a trusted local output
+sink not represented in `DaemonRequestFrame`; bulk apply deliberately avoids the daemon frame cap,
+and atomic bulk apply would require a new daemon transaction protocol. Refusing based on a daemon
+liveness probe would be racy. Any future daemon-routed design must be an explicit protocol change,
+not a liveness-dependent fallback. Until then, operators configure busy timeouts independently in
+both processes, inspect the complete result before retrying, and retry only operations known to be
+idempotent.
+
 ### `exec.rs` regression test notes
 
 - `strict_mode_rejects_before_daemon_forward_when_comm_and_no_actor`: `run_exec_inline` must

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -553,6 +553,33 @@ read-only: it inspects `_schema_migrations`' `MAX(version)` directly rather than
 binary knows, or corresponding to a pre-consolidated-baseline version) into a nonzero exit via
 `anyhow::bail!` (`main.rs:433-445`).
 
+### `exec --save-file` / `exec --ops-file`: daemon coexistence
+
+When they execute operations, both file-oriented `exec` modes deliberately build a local runtime
+instead of forwarding through the warm daemon (`--ops-file --dry-run` stops before runtime
+construction). `--save-file` needs a trusted local result sink; `--ops-file` needs bulk execution,
+including optional whole-file atomic behavior, that the daemon protocol does not expose. If a live
+daemon has the same database open, the command and daemon are independent SQLite clients.
+`KHIVE_WRITE_QUEUE=1` does not combine them into one writer because that queue is process-local.
+
+SQLite serializes their writes through the WAL write lock. Each process waits for
+`KHIVE_BUSY_TIMEOUT_SECS` (30 seconds by default) and then reports `database is locked` if the
+other writer still owns the lock. The CLI does not retry automatically. Configure the environment
+for the daemon and the CLI separately if changing the timeout; setting it for one process does not
+change the other.
+
+For non-atomic `--ops-file`, a busy op can fail after earlier ops committed. Inspect the printed
+failure list and use `--strict` when any failed op must produce a non-zero exit. For
+`--ops-file --atomic`, the whole commit pass holds one bounded write transaction; run large units
+against an idle daemon or in a maintenance window. A plan-level rollback prints
+`atomic.committed=false` but currently exits zero even with `--strict`; inspect that field rather
+than relying on process status. Admissibility, prepare, and atomic-unit seam errors instead exit
+non-zero before printing an atomic result envelope. For `--save-file`, stdout is a manifest whose
+`summary` carries failure counts; the saved JSONL rows carry the per-op error details. Retry only
+after checking the complete result, and only when the operations are known to be idempotent. The
+normative rationale and mode-by-mode exit contract are in
+[the kkernel design note](../crates/kkernel/docs/design.md#exec-daemon-bypass-second-writer-contract-548-adr-067-adr-099).
+
 ### `exec --pending-events`: cron drain for scheduled events
 
 ```bash


### PR DESCRIPTION
## Summary

- define the supported second-writer contract for `kkernel exec --save-file` and `--ops-file` while a daemon has the same SQLite database open
- document process-local writer serialization, WAL/busy-timeout behavior, and why these modes remain local instead of daemon-routed
- spell out partial, strict, and atomic failure/exit behavior, including the current zero exit for a printed atomic rollback envelope
- give operators safe retry and maintenance-window guidance without promising automatic replay

Fixes #548.

## Decision

The file-oriented execution modes remain in-process. Cross-process coordination is SQLite's WAL writer lock plus each process's configured busy timeout; the runtime writer queue does not cross process boundaries. The docs now distinguish per-operation JSONL errors, non-atomic partial commits, pre-envelope atomic failures, and plan-level atomic rollbacks that callers must detect through `atomic.committed`.

## Validation

- `deno fmt --check crates/kkernel/docs/design.md docs/operations.md`
- `make docs-check`
- ADR reference lint and lint self-test
- `git diff --check`
- independent implementation/source review, followed by correction of both reported findings

The branch was validated at exact commit `390044ad2426f04d1d936c60510dec578a5ebb5b`.

> AI-assisted contribution: Codex prepared this change and PR description.
