### PR TITLE
fix(gtd): resolve lifecycle tasks across namespaces

### DIFF
--- a/crates/khive-pack-gtd/README.md
+++ b/crates/khive-pack-gtd/README.md
@@ -17,6 +17,11 @@ over the notes substrate.
 All five verbs are declared in `GTD_HANDLERS` (`src/vocab.rs`) and dispatched
 by `GtdPack::dispatch` (`src/pack.rs`).
 
+`gtd.complete` and `gtd.transition` are by-ID operations: a full UUID or a
+unique 8+ character hexadecimal prefix resolves without a namespace filter,
+as required by ADR-007. The task keeps its original namespace attribution;
+authorization remains the Gate's responsibility.
+
 ## Task lifecycle
 
 The `task` note kind's lifecycle field is `kind_status` (not `status` — that

--- a/crates/khive-pack-gtd/src/handlers.rs
+++ b/crates/khive-pack-gtd/src/handlers.rs
@@ -246,12 +246,12 @@ fn short_id(uuid: Uuid) -> String {
     uuid.as_hyphenated().to_string().chars().take(8).collect()
 }
 
-/// `pub` (widened from `pub(crate)`, ADR-099 B3): the
-/// `--atomic` seam in `kkernel` reuses this exact resolver (full UUID or 8+
-/// hex prefix, namespace-scoped via `resolve_prefix`) to resolve `gtd.transition`
-/// / `gtd.complete` `id` args before atomic prepare, matching what
-/// `handle_transition`/`handle_complete` use — reproducing canonical short-id
-/// acceptance without a duplicated resolution helper.
+/// Resolve a task-create reference as a full UUID or 8+ hex prefix.
+/// Prefix lookup stays scoped to the caller's primary namespace per ADR-016;
+/// task creation applies its primary-namespace mutation checks after this
+/// resolution. Lifecycle by-ID operations use the private
+/// `resolve_lifecycle_uuid` helper
+/// instead.
 pub async fn resolve_uuid(
     s: &str,
     runtime: &KhiveRuntime,
@@ -262,6 +262,26 @@ pub async fn resolve_uuid(
     }
     if s.len() >= 8 && s.chars().all(|c| c.is_ascii_hexdigit()) {
         return match runtime.resolve_prefix(token, s).await? {
+            Some(uuid) => Ok(uuid),
+            None => Err(RuntimeError::InvalidInput(format!(
+                "no record matches prefix: {s:?}"
+            ))),
+        };
+    }
+    Err(RuntimeError::InvalidInput(format!(
+        "invalid UUID (expected full UUID or 8+ hex prefix): {s:?}"
+    )))
+}
+
+/// Resolve a lifecycle verb's by-ID reference without a namespace filter.
+/// `gtd.transition` and `gtd.complete` follow ADR-007's global by-ID contract
+/// for both full UUIDs and short prefixes.
+async fn resolve_lifecycle_uuid(s: &str, runtime: &KhiveRuntime) -> Result<Uuid, RuntimeError> {
+    if let Ok(uuid) = Uuid::from_str(s) {
+        return Ok(uuid);
+    }
+    if s.len() >= 8 && s.chars().all(|c| c.is_ascii_hexdigit()) {
+        return match runtime.resolve_prefix_unfiltered(s).await? {
             Some(uuid) => Ok(uuid),
             None => Err(RuntimeError::InvalidInput(format!(
                 "no record matches prefix: {s:?}"
@@ -480,15 +500,15 @@ async fn fetch_all_matching_tasks(
     Ok(notes)
 }
 
-/// Load a task note and verify (a) it exists, (b) namespace matches, (c) it is
-/// actually `kind = "task"`. Used by `complete` and `transition`.
+/// Load a task note by global ID and verify it is actually `kind = "task"`.
+/// Used by `complete` and `transition`; the task's stored namespace is
+/// attribution and therefore does not gate these by-ID lifecycle operations.
 async fn load_task(
     runtime: &KhiveRuntime,
     token: &NamespaceToken,
     raw_id: &str,
 ) -> Result<(khive_storage::note::Note, String), RuntimeError> {
-    let uuid = resolve_uuid(raw_id, runtime, token).await?;
-    let ns = token.namespace().as_str();
+    let uuid = resolve_lifecycle_uuid(raw_id, runtime).await?;
     let store = runtime.notes(token)?;
     let note = store
         .get_note(uuid)
@@ -496,9 +516,6 @@ async fn load_task(
         .map_err(|e| RuntimeError::Internal(format!("get_note: {e}")))?
         .ok_or_else(|| RuntimeError::NotFound(format!("not found: {raw_id}")))?;
 
-    if note.namespace != ns {
-        return Err(RuntimeError::NotFound(format!("not found: {raw_id}")));
-    }
     if note.kind != "task" {
         return Err(RuntimeError::InvalidInput(format!(
             "expected kind=\"task\", got {:?}",

--- a/crates/khive-pack-gtd/src/vocab.rs
+++ b/crates/khive-pack-gtd/src/vocab.rs
@@ -182,7 +182,7 @@ pub(crate) static GTD_HANDLERS: [HandlerDef; 5] = [
                 name: "id",
                 param_type: "uuid",
                 required: true,
-                description: "UUID of the task to complete.",
+                description: "Full UUID or unique 8+ hex prefix of the task to complete. By-ID resolution is namespace-agnostic (ADR-007).",
             },
             ParamDef {
                 name: "result",
@@ -257,7 +257,7 @@ pub(crate) static GTD_HANDLERS: [HandlerDef; 5] = [
                 name: "id",
                 param_type: "uuid",
                 required: true,
-                description: "UUID of the task to transition.",
+                description: "Full UUID or unique 8+ hex prefix of the task to transition. By-ID resolution is namespace-agnostic (ADR-007).",
             },
             ParamDef {
                 name: "status",

--- a/crates/khive-pack-gtd/tests/integration.rs
+++ b/crates/khive-pack-gtd/tests/integration.rs
@@ -228,6 +228,109 @@ async fn complete_via_short_id_resolves_prefix() {
 }
 
 #[tokio::test]
+async fn lifecycle_by_id_cross_namespace_supports_legacy_tasks() {
+    let runtime = rt();
+    let pack = pack(runtime.clone());
+    let legacy_namespace = Namespace::parse("legacy-gtd").expect("valid legacy namespace");
+    let legacy_token = runtime
+        .authorize(legacy_namespace)
+        .expect("authorize legacy namespace");
+    let task = runtime
+        .create_note(
+            &legacy_token,
+            "task",
+            Some("legacy namespace task"),
+            "legacy namespace task",
+            Some(0.5),
+            Some(json!({"status": "inbox", "priority": "p2"})),
+            vec![],
+        )
+        .await
+        .expect("create task under legacy namespace");
+    let full_id = task.id.as_hyphenated().to_string();
+    let short_id = full_id[..8].to_string();
+
+    let fetched = pack
+        .dispatch("get", json!({"id": full_id}))
+        .await
+        .expect("generic by-ID get must see the legacy task");
+    assert_eq!(fetched["namespace"], "legacy-gtd");
+
+    let transitioned = pack
+        .dispatch("gtd.transition", json!({"id": full_id, "status": "next"}))
+        .await
+        .expect("full-UUID transition must not filter by namespace");
+    assert_eq!(transitioned["from"], "inbox");
+    assert_eq!(transitioned["to"], "next");
+
+    let completed = pack
+        .dispatch("gtd.complete", json!({"id": short_id}))
+        .await
+        .expect("short-prefix completion must not filter by namespace");
+    assert_eq!(completed["from"], "next");
+    assert_eq!(completed["to"], "done");
+
+    let persisted = pack
+        .dispatch("get", json!({"id": full_id}))
+        .await
+        .expect("legacy task must remain readable after lifecycle writes");
+    assert_eq!(persisted["namespace"], "legacy-gtd");
+    assert_eq!(persisted["status"], "done");
+    assert!(persisted["properties"]["completed_at"].is_string());
+}
+
+#[tokio::test]
+async fn assign_dependency_prefix_ignores_collisions_outside_primary_namespace() {
+    use khive_storage::note::Note;
+    use uuid::Uuid;
+
+    let runtime = rt();
+    let pack = pack(runtime.clone());
+    let local_token = runtime
+        .authorize(Namespace::local())
+        .expect("authorize local namespace");
+    let legacy_token = runtime
+        .authorize(Namespace::parse("legacy-gtd").expect("valid legacy namespace"))
+        .expect("authorize legacy namespace");
+    let local_id = Uuid::parse_str("aabbccdd-1111-4000-8000-000000000001").unwrap();
+    let legacy_id = Uuid::parse_str("aabbccdd-2222-4000-8000-000000000002").unwrap();
+
+    let mut local_task = Note::new("local", "task", "local blocker")
+        .with_name("local blocker")
+        .with_properties(json!({"status": "inbox", "priority": "p2"}));
+    local_task.id = local_id;
+    runtime
+        .notes(&local_token)
+        .expect("local note store")
+        .upsert_note(local_task)
+        .await
+        .expect("insert local blocker");
+
+    let mut legacy_task = Note::new("legacy-gtd", "task", "legacy blocker")
+        .with_name("legacy blocker")
+        .with_properties(json!({"status": "inbox", "priority": "p2"}));
+    legacy_task.id = legacy_id;
+    runtime
+        .notes(&legacy_token)
+        .expect("legacy note store")
+        .upsert_note(legacy_task)
+        .await
+        .expect("insert legacy blocker");
+
+    let created = pack
+        .dispatch(
+            "gtd.assign",
+            json!({"title": "local dependent", "depends_on": ["aabbccdd"]}),
+        )
+        .await
+        .expect("primary-scoped dependency prefix must resolve the local task");
+    assert_eq!(
+        created["properties"]["depends_on"][0],
+        local_id.as_hyphenated().to_string()
+    );
+}
+
+#[tokio::test]
 async fn complete_rejects_non_task_notes() {
     // Reach around the pack and create a kg-shaped "observation" note to prove
     // the task-kind guard fires.

--- a/docs/adr/ADR-019-gtd-pack.md
+++ b/docs/adr/ADR-019-gtd-pack.md
@@ -146,12 +146,20 @@ No collision with kg pack's shared CRUD. ADR-017's `VerbRegistry` registers all 
 verbs as `gtd`-owned. The kg pack's `create(kind="note", note_kind="task", ...)`
 path also produces tasks — see "Two equivalent paths" below.
 
+`gtd.complete` and `gtd.transition` follow ADR-007's by-ID contract. Their `id`
+argument accepts a full UUID or a unique 8+ character hexadecimal prefix and
+resolves without a namespace filter. A task created under a legacy namespace is
+therefore directly transitionable and completable by ID; its stored namespace
+remains unchanged attribution, while authorization stays at the Gate.
+
 ### `depends_on` as both property and edge
 
 When `assign` (or shared `create`) creates a task with `depends_on: ["abc12345",
 "def67890"]`:
 
-1. The IDs are resolved within the caller's namespace (full UUID or 8-char prefix).
+1. Each ID accepts a full UUID or unique 8+ character hexadecimal prefix. Prefix
+   resolution is scoped to the caller's primary namespace, and the resolved target
+   must be a task in that namespace before the dependency write proceeds.
 2. The full UUIDs are stored in `properties.depends_on` for self-describing record
    shape.
 3. **Plus**: one `depends_on` edge is created per dependency, with the new task as


### PR DESCRIPTION
## Summary

- make `gtd.transition` and `gtd.complete` resolve full UUIDs and unique short prefixes without a namespace filter
- remove the post-fetch namespace rejection that stranded tasks created under legacy namespace schemes
- preserve namespace-scoped prefix resolution for `gtd.assign` dependency creation
- document the by-ID lifecycle contract and add cross-namespace regressions for both lifecycle and dependency resolution

Fixes #1427.

## Behavior

Task namespace remains immutable attribution. Lifecycle mutations follow the global by-ID contract and continue through the existing Gate and task-kind checks. Creation-side `depends_on` references retain the ADR-016 primary-namespace rule, so an unrelated prefix collision in another namespace cannot make a local dependency ambiguous.

## Validation

- `cargo test -p khive-pack-gtd -p kkernel --all-features`
- `cargo check -p khive-pack-gtd -p kkernel --all-targets --all-features`
- `cargo clippy -p khive-pack-gtd -p kkernel --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS='-D warnings' cargo doc -p khive-pack-gtd -p kkernel --all-features --no-deps`
- `cargo fmt --all --check`
- `deno fmt --check` for the changed Markdown files, full docs checks, and `git diff --check`
- independent contract review; its shared-resolver finding was fixed before the exact-SHA rerun

The branch was validated at exact commit `5097458a727852dc64705e35107b98887d5d07e4`.

> AI-assisted contribution: Codex prepared this change and PR description.
