### PR TITLE
docs(adr): defer pack event-consumer contract

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -144,8 +144,8 @@ Composite scores are always in [0,1]. Typical production floor: 0.3-0.7.
 | `brain.profile`          | Full detail: metadata, snapshot, state summary                                           | Inspect a specific profile                                      |
 | `brain.create_profile`   | Create a new profile with optional seed priors                                           | Custom tuning for a new consumer                                |
 | `brain.resolve`          | Which profile serves a given consumer context?                                           | Before recall — check active tuning                             |
-| `brain.activate`         | Start live update loop for a profile                                                     | Enable feedback-driven tuning                                   |
-| `brain.deactivate`       | Stop live updates, retain state                                                          | Pause tuning without losing progress                            |
+| `brain.activate`         | Move a profile to Active; serving reads state per request                                | Enable active resolution and feedback-driven tuning             |
+| `brain.deactivate`       | Move a profile to Inactive and retain state                                              | Record the inactive lifecycle state without discarding progress |
 | `brain.archive`          | Read-only, audit-retained                                                                | Retire a profile permanently                                    |
 | `brain.reset`            | Reset posteriors to priors (preserves event history)                                     | Start tuning fresh                                              |
 | `brain.feedback`         | Emit explicit feedback event                                                             | Rate a recall result as useful/not_useful/wrong                 |

--- a/crates/khive-pack-brain/README.md
+++ b/crates/khive-pack-brain/README.md
@@ -20,10 +20,12 @@ call time and feed back into via explicit or implicit signals.
   `FeedbackExplicit` event to the shared event log; `brain.auto_feedback` is
   convenience sugar so an agent can credit the top `memory.recall` hit without
   constructing a full feedback call
-- **Deterministic Fold-based state** — `BalancedRecallFold` and
-  `SectionPosteriorFold` each implement `khive_fold::Fold<Event, S>`
-  (`init`/`reduce`/`finalize`) over the append-only event log, so profile state is
-  always a pure replay, never a mutation in place
+- **Deterministic fold reducers** — `BalancedRecallFold` and
+  `SectionPosteriorFold` implement pure `khive_fold::Fold<Event, S>` reducers.
+  Current handlers invoke them synchronously; durable handler mutations append to
+  the private `brain_event_log` and write JSON snapshots. The best-effort
+  `DispatchHook` updates in-memory state without durable replay, while automatic
+  shared-log catch-up remains deferred by ADR-017.
 - **Adapter integrity gating** (`brain.register_adapter`) — records a
   content-hash + base-model-revision pair so an FFN/LoRA router only composes
   adapters that match the currently active base model revision

--- a/crates/khive-pack-brain/docs/design.md
+++ b/crates/khive-pack-brain/docs/design.md
@@ -4,7 +4,10 @@
 
 ### Brain Pack (ADR-032)
 
-The brain pack implements profile-oriented Bayesian auto-tuning over the shared event log.
+The brain pack implements profile-oriented Bayesian auto-tuning through synchronous explicit
+feedback and a best-effort post-dispatch hook. Durable handler-owned mutations append to the
+private `brain_event_log` and write JSON snapshots; the hook updates in-memory state without a
+durability guarantee. Automatic shared-log catch-up and replay remain deferred by ADR-017.
 
 **Profile registry**: `BrainState` holds the profile registry and lifecycle metadata. Posteriors
 live inside each profile's own state, opaque to brain core. This means the brain pack has no
@@ -20,13 +23,13 @@ Posterior mean: $\mu = \alpha / (\alpha + \beta)$
 
 **Feedback signal taxonomy** (`FeedbackSignal` + `FeedbackEventKind`):
 
-| Signal | Update magnitude | Posterior effect |
-|--------|-----------------|-----------------|
-| `useful` / `explicit_positive` | 1.0 / 1.5× | $\alpha += w$ |
-| `not_useful` / `explicit_negative` | 1.0 / 1.5× | $\beta += w$ |
-| `wrong` / `correction` | 1.0 / 2.0× | $\beta += w$ (+ relevance $\beta$ for correction) |
-| `implicit_positive` | 0.5× | $\alpha += w$ |
-| `implicit_negative` | 0.5× | $\beta += w$ |
+| Signal                             | Update magnitude | Posterior effect                                  |
+| ---------------------------------- | ---------------- | ------------------------------------------------- |
+| `useful` / `explicit_positive`     | 1.0 / 1.5×       | $\alpha += w$                                     |
+| `not_useful` / `explicit_negative` | 1.0 / 1.5×       | $\beta += w$                                      |
+| `wrong` / `correction`             | 1.0 / 2.0×       | $\beta += w$ (+ relevance $\beta$ for correction) |
+| `implicit_positive`                | 0.5×             | $\alpha += w$                                     |
+| `implicit_negative`                | 0.5×             | $\beta += w$                                      |
 
 **Profile lifecycle DAG**: `Active ↔ Inactive → Archived`. Archived is terminal. Active profiles
 must go through Inactive before archiving. `brain.reset` is only valid on non-archived profiles.
@@ -49,18 +52,18 @@ ExpertLens, References, Other).
 
 **Default priors per section type**:
 
-| Section | $\alpha$ | $\beta$ | Mean |
-|---------|---------|---------|------|
-| Overview | 2 | 2 | 0.50 |
-| CoreModel | 4 | 2 | 0.67 |
-| BoundaryConditions | 2 | 3 | 0.40 |
-| Formalism | 1.5 | 4 | 0.27 |
-| OperationalGuidance | 6 | 1.5 | 0.80 |
-| Examples | 5 | 2 | 0.71 |
-| FailureModes | 3 | 2 | 0.60 |
-| ExpertLens | 3 | 2 | 0.60 |
-| References | 2 | 2 | 0.50 |
-| Other | 2 | 2 | 0.50 |
+| Section             | $\alpha$ | $\beta$ | Mean |
+| ------------------- | -------- | ------- | ---- |
+| Overview            | 2        | 2       | 0.50 |
+| CoreModel           | 4        | 2       | 0.67 |
+| BoundaryConditions  | 2        | 3       | 0.40 |
+| Formalism           | 1.5      | 4       | 0.27 |
+| OperationalGuidance | 6        | 1.5     | 0.80 |
+| Examples            | 5        | 2       | 0.71 |
+| FailureModes        | 3        | 2       | 0.60 |
+| ExpertLens          | 3        | 2       | 0.60 |
+| References          | 2        | 2       | 0.50 |
+| Other               | 2        | 2       | 0.50 |
 
 **Thompson sampling** (explore mode, `exploration_epoch > 0`):
 

--- a/crates/khive-pack-brain/src/handlers.rs
+++ b/crates/khive-pack-brain/src/handlers.rs
@@ -209,7 +209,7 @@ pub(crate) static BRAIN_HANDLERS: &[HandlerDef] = &[
     },
     HandlerDef {
         name: "brain.deactivate",
-        description: "Move a profile to Inactive (stop live updates, retain state)",
+        description: "Move a profile to Inactive (lifecycle transition; retain state)",
         visibility: khive_types::Visibility::Verb,
         category: khive_types::VerbCategory::Commissive,
         params: &[khive_types::ParamDef {
@@ -2879,9 +2879,11 @@ pub(crate) async fn resolve_auto_feedback_target(
 /// `BrainPack` as a post-dispatch hook.
 ///
 /// When registered via `VerbRegistryBuilder::with_dispatch_hook`, every
-/// successful verb dispatch calls `on_dispatch` with a synthesized `Event`.
-/// The event is fed into `BalancedRecallFold::reduce`, updating the brain's
-/// posteriors in real time — no polling required.
+/// successful non-brain verb dispatch calls `on_dispatch` with a synthetic
+/// `EventView` whose observations are empty. The event is fed into
+/// `BalancedRecallFold::reduce`, updating in-memory posteriors in real time.
+/// This path appends no event and writes no snapshot, so it provides no
+/// durability or replay guarantee.
 #[async_trait]
 impl DispatchHook for BrainPack {
     async fn on_dispatch(&self, view: &EventView) {

--- a/crates/khive-runtime/src/pack.rs
+++ b/crates/khive-runtime/src/pack.rs
@@ -68,10 +68,12 @@ impl SchemaPlan {
     }
 }
 
-/// Hook called after every successful verb dispatch.
+/// Best-effort hook called after every successful verb dispatch.
 ///
-/// Packs observe enriched event views so provenance-aware consumers can use
-/// `view.observations` while legacy folds can still consume `view.event`.
+/// The runtime supplies a synthetic [`EventView`] whose `event` describes the
+/// dispatch outcome and whose `observations` vector is currently empty. Loading
+/// persisted provenance observations belongs to an explicit caller or the
+/// deferred event-consumer contract; this hook does not provide it.
 #[async_trait]
 pub trait DispatchHook: Send + Sync {
     /// Called with the dispatch-outcome event view after a successful pack dispatch.
@@ -363,9 +365,9 @@ pub struct VerbRegistryBuilder {
     event_store: Option<Arc<dyn EventStore>>,
     /// Optional post-dispatch hook.
     ///
-    /// When set, every successful pack dispatch calls `hook.on_dispatch(event)`
-    /// with a synthesized Event describing the outcome. Opt-in: when None,
-    /// no overhead is incurred.
+    /// When set, every successful pack dispatch calls `hook.on_dispatch(view)`
+    /// with a synthetic `EventView` describing the outcome and carrying no
+    /// observations. Opt-in: when None, no overhead is incurred.
     dispatch_hook: Option<Arc<dyn DispatchHook>>,
 }
 
@@ -473,14 +475,14 @@ impl VerbRegistryBuilder {
 
     /// Register a post-dispatch hook.
     ///
-    /// When set, every successful pack dispatch calls `hook.on_dispatch(event)`
-    /// with a synthesized [`Event`] describing the verb outcome. The hook is
-    /// opt-in: registries without a hook incur zero overhead on the dispatch
-    /// hot path.
+    /// When set, every successful pack dispatch calls `hook.on_dispatch(view)`
+    /// with a synthetic [`EventView`] describing the verb outcome. Its
+    /// `observations` vector is empty; callers that need persisted provenance
+    /// must load it explicitly. The hook is opt-in: registries without a hook
+    /// incur zero overhead on the dispatch hot path.
     ///
-    /// Brain pack uses this to update its posteriors in real time without
-    /// polling the EventStore. Errors from `on_dispatch` are logged via
-    /// `tracing::warn!` and never propagated.
+    /// Brain pack uses this as a best-effort in-memory update path. Errors from
+    /// `on_dispatch` are logged via `tracing::warn!` and never propagated.
     pub fn with_dispatch_hook(&mut self, hook: Arc<dyn DispatchHook>) -> &mut Self {
         self.dispatch_hook = Some(hook);
         self

--- a/docs/adr/ADR-004-substrate-observables.md
+++ b/docs/adr/ADR-004-substrate-observables.md
@@ -223,8 +223,9 @@ The canonical total order on events is:
 ```
 
 `event_id` is compared by canonical UUID byte order. It does not encode true insertion
-order; it provides a deterministic tiebreaker when `created_at` ties. Replay consumers
-that need lossless catch-up persist a compound cursor:
+order; it provides a deterministic tiebreaker when `created_at` ties. Any future replay
+consumer that needs lossless catch-up must persist a compound cursor. The following is
+the reserved design shape, not a shipped public type:
 
 ```rust
 pub struct EventCursor {
@@ -236,9 +237,10 @@ pub struct EventCursor {
 This invariant is consumed by:
 
 - ADR-022 §3b — list/replay query shape and the composite index `idx_events_ns_created_id`.
-- ADR-017 — `PackEventConsumer` cursor persistence (state + cursor must be atomic).
-- ADR-024 / ADR-032 — `Fold<Event, State>` deterministic replay: same canonical-order
-  events + same `FoldContext` ⇒ same final state.
+- ADR-017 — the deferred `PackEventConsumer` design would require atomic state + cursor
+  persistence; no consumer or cursor API ships today.
+- ADR-024 / ADR-032 — any future `Fold<Event, State>` replay must preserve the same
+  canonical-order events + `FoldContext` ⇒ same final state invariant.
 
 A monotonic append-sequence counter (`event_seq`) is NOT in v1. The timestamp+id pair
 gives deterministic replay order; a true commit-order counter is a different invariant

--- a/docs/adr/ADR-017-pack-standard.md
+++ b/docs/adr/ADR-017-pack-standard.md
@@ -258,11 +258,42 @@ impl VerbRegistry {
 }
 ```
 
-### `PackEventConsumer`: event delivery contract
+### Deferred design: `PackEventConsumer` event delivery
 
-Packs that derive state from the event log (brain, audit summary, future analytics)
-register as event consumers via the `PackEventConsumer` trait. The runtime delivers
-matching events one at a time; the pack owns reduction, persistence, and replay.
+**Status: deferred; this is not an accepted runtime, pack, or CLI contract.** The
+repository does not ship `PackEventConsumer`, `RuntimeEventContext`, or `EventCursor`;
+consumer registration; a catch-up/live-delivery driver; or `kkernel events replay`.
+The current `EventStore::query_events` API exposes newest-first, offset-based pages and
+cannot express the compound ascending cursor below.
+
+The shipped `DispatchHook` is not this seam. It is an optional best-effort callback
+after a successful in-process verb dispatch; it has no durable consumer identity,
+cursor, catch-up, replay, or failure-recovery contract and therefore cannot be used as
+an implementation shortcut for event-log consumption.
+
+The remainder of this section preserves the proposed shape and its safety constraints
+as design input only. A follow-up ADR must accept all of these prerequisites together
+before any pack or dependent design may rely on event delivery:
+
+1. A cursor-aware event-store query and `EventView` loading API with an explicit
+   ascending replay order and bounded pages.
+2. Host ownership, supervision, registration, and stable consumer identity (including
+   how a pack with multiple profiles identifies the cursor being advanced).
+3. A pack-backend transaction seam that can enforce and test atomic derived-state plus
+   cursor persistence.
+4. Gap-free catch-up-to-live handoff plus pinned retry, duplicate-delivery,
+   idempotence, cancellation, and terminal-failure semantics.
+5. An authenticated, bounded replay CLI with explicit start/end cursors and tests for
+   crash recovery, equal-timestamp ordering, restart, and repeated replay.
+
+Until that contract is accepted and implemented, packs must not register a
+`PackEventConsumer` or assume push delivery, automatic catch-up, or operator replay.
+They may use the shipped event query surface directly or keep work synchronous with
+the handler that owns it, as the proposal worker does in ADR-046.
+
+The deferred design would let packs that derive state from the event log (brain, audit
+summary, future analytics) register as event consumers. The runtime would deliver
+matching events one at a time; the pack would own reduction, persistence, and replay.
 
 ```rust
 pub trait PackEventConsumer: Send + Sync {
@@ -274,9 +305,10 @@ pub trait PackEventConsumer: Send + Sync {
     /// Invoked once per matching event, in canonical replay order
     /// (created_at ASC, event_id ASC — ADR-022 §3b). The consumer receives an
     /// `EventView` (ADR-041 §5) — the raw event plus its pre-joined provenance
-    /// observations. The consumer is responsible for loading state, applying its
-    /// Fold::reduce against the right field of the view (see ADR-041 §5 for the
-    /// two call shapes), and persisting state + cursor atomically.
+    /// observations. The consumer is responsible for loading state, applying the
+    /// canonical Fold<Event, S> to view.event, and persisting state + cursor atomically.
+    /// A replay that makes observations part of its deterministic input must define a
+    /// separate typed fold input rather than using EventView itself (ADR-024, ADR-041 §5).
     async fn on_event(
         &self,
         view: &EventView,
@@ -291,20 +323,19 @@ pub struct RuntimeEventContext {
 }
 ```
 
-#### State + cursor atomicity (MANDATORY)
+#### State + cursor atomicity (future requirement)
 
-A pack consumer MUST persist its derived state and the `EventCursor` of the event it
-just processed in the **same logical transaction**. A crash between state-update and
-cursor-update causes duplicate reduction on restart, breaking replay determinism for
-non-idempotent Folds.
+A future pack consumer MUST persist its derived state and the `EventCursor` of the
+event it just processed in the **same logical transaction**. A crash between
+state-update and cursor-update causes duplicate reduction on restart, breaking replay
+determinism for non-idempotent Folds.
 
 ```rust
 // Inside on_event(view: &EventView, ctx):
 let mut tx = pack.storage.begin().await?;
 let mut state = tx.load_state(profile_id).await?;
-// For Fold<Event, S> impls, pass the raw event:
+// EventView is the consumer envelope; Event is the canonical fold input:
 state = fold.reduce(state, &view.event, &fold_ctx);
-// (For Fold<EventView, S> impls — see ADR-041 §5 — pass `view` instead.)
 tx.save_state(profile_id, &state).await?;
 tx.save_cursor(profile_id, &EventCursor::from(&view.event)).await?;
 tx.commit().await?;
@@ -323,7 +354,7 @@ State and cursor MUST live in the same backend. Packs that use pack-scoped backe
 cross-backend state/cursor split is out of scope (the WAL pattern in ADR-029 is for
 hard-delete cascade, a different invariant — do not reuse for replay continuity).
 
-#### Catch-up on registration / restart
+#### Proposed catch-up on registration / restart
 
 When a consumer registers or restarts:
 
@@ -339,19 +370,20 @@ When a consumer registers or restarts:
 The runtime does NOT persist Fold state. The runtime does NOT execute Folds. It
 delivers events and invokes `on_event` — everything downstream is pack territory.
 
-#### Failure isolation
+#### Proposed failure isolation
 
 If a pack consumer's `on_event` returns an error, the runtime:
 
 1. Logs the error with `(pack_id, profile_id, event_cursor)`.
-2. Does NOT re-deliver the same event automatically (avoids tight retry loops).
+2. Does NOT retry the same event immediately in a tight loop.
 3. Does NOT abort event append for other consumers — the event log is the source of
    truth and survives individual consumer failures.
 4. Leaves the consumer's cursor at its last successful position; the next live event
-   that matches the filter triggers a catch-up that re-attempts the failed event.
+   that matches the filter triggers catch-up and a delayed automatic re-attempt of the
+   failed event.
 
-Operators may force re-processing via `kkernel events replay --pack <id> --from
-<cursor>` (CLI, not MCP — see ADR-032 §11 / concern-6 Q6.5).
+A future operator replay surface may use `kkernel events replay --pack <id> --from
+<cursor>` (CLI, not MCP), but that command is not reserved or shipped by this ADR.
 
 ### Boot-time collision checks
 

--- a/docs/adr/ADR-022-events-query-surface.md
+++ b/docs/adr/ADR-022-events-query-surface.md
@@ -264,10 +264,12 @@ validation reports over event streams, or dashboard counters fit the same abstra
 The combinators from ADR-024 (`SequentialFold`, `FilterFold`, `MapFold`, `DualFold`)
 compose naturally over event streams.
 
-**Dispatch boundary**: the runtime is responsible for event _delivery_, not Fold
-_execution_. Runtime-level Fold registries are out of scope for v1. Pack consumers
-own their state, snapshots, schema migrations, and cursor persistence — see ADR-017's
-`PackEventConsumer` trait for the dispatch contract.
+**Deferred dispatch boundary**: no runtime event-delivery or Fold registry ships in v1.
+ADR-017 now records `PackEventConsumer` as deferred design rather than an accepted
+dispatch contract. The shipped surface is event append plus explicit event queries. A
+future consumer contract may make the runtime responsible for delivery while leaving
+Fold execution, state, snapshots, migrations, and cursor persistence with the pack, but
+must first satisfy ADR-017's implementation prerequisites.
 
 ### 3b. Event ordering — weakly monotonic timestamps + deterministic tiebreaker
 
@@ -294,9 +296,10 @@ insertion order — it only needs to provide a stable total order among events w
 equal `created_at`. UUID v4's randomness is sufficient; UUID v7's time-ordering is
 welcome but not required.
 
-**Timestamp-only cursors are unsafe.** A consumer that resumes with `since=t` after
+**Timestamp-only cursors are unsafe.** A future consumer that resumes with `since=t` after
 processing event `(created_at=t, event_id=A)` may skip `(created_at=t, event_id=B)`.
-Event consumers MUST use a compound cursor:
+Any future event consumer MUST use a compound cursor. `EventCursor` is an illustrative
+design shape here; it is not a shipped storage or runtime type:
 
 ```rust
 pub struct EventCursor {
@@ -322,9 +325,11 @@ ORDER BY created_at DESC, event_id DESC
 ```
 
 `EventStore` implementations that return ordered results MUST include `event_id` as
-the deterministic tiebreaker. The `since` / `until` parameters on `list(kind="event")`
-remain timestamp-only (human-facing); programmatic event consumers persist the full
-`EventCursor` themselves.
+the deterministic tiebreaker. The shipped newest-first query does so. The ascending
+catch-up query above remains deferred with the consumer contract because the current
+API has no order or compound-cursor parameter. The `since` / `until` parameters on
+`list(kind="event")` remain timestamp-only (human-facing); any future programmatic
+consumer must persist the full cursor itself.
 
 **Deferred**: a monotonic append-sequence counter (`event_seq`) is NOT introduced in
 v1. The timestamp+id pair gives deterministic replay order. A true commit-order
@@ -334,10 +339,10 @@ ordering — a different invariant from replay determinism. Add when evidence de
 ### 4. Composite index — schema migration
 
 The existing events table has four single-column indexes (`namespace`, `verb`,
-`substrate`, `created_at DESC`). The dominant query patterns are:
+`substrate`, `created_at DESC`). The current and reserved future query patterns are:
 
 1. Unfiltered listing: `WHERE namespace = ? ORDER BY created_at DESC LIMIT ?`
-2. Cursor-based catch-up (§3b): `WHERE namespace = ? AND (created_at > :ts OR
+2. Future cursor-based catch-up (§3b): `WHERE namespace = ? AND (created_at > :ts OR
    (created_at = :ts AND event_id > :id)) ORDER BY created_at ASC, event_id ASC`
 
 A composite index covering both `created_at` and `event_id` lets the planner satisfy

--- a/docs/adr/ADR-032-brain-profile-orchestration.md
+++ b/docs/adr/ADR-032-brain-profile-orchestration.md
@@ -73,16 +73,19 @@ profile. It is now one profile among many, not the shape of the brain itself.
 
 ## Decision
 
-### 1. Brain is a meta-Fold
+### 1. Brain's target architecture is a meta-Fold
 
-Brain is a `Fold<Event, BrainState>` whose derived state is a set of pipeline parameters.
-In shipped v1, `BrainState` stores both the profile registry and the live Bayesian recall
-state. The built-in `balanced-recall-v1` profile keeps its live posteriors in
-`BrainState.balanced_recall`; user-created Bayesian profiles keep live posteriors in
-`BrainState.profile_states`.
+The target shared-log architecture models Brain as a `Fold<Event, BrainState>` whose derived
+state is a set of pipeline parameters. Shipped v1 does not run that Fold from the shared event
+log. It updates state synchronously through the best-effort `DispatchHook` and explicit
+feedback handlers, then replays its private `brain_event_log` after a snapshot on cold load.
+`BrainState` stores both the profile registry and the live Bayesian recall state. The built-in
+`balanced-recall-v1` profile keeps its live posteriors in `BrainState.balanced_recall`;
+user-created Bayesian profiles keep live posteriors in `BrainState.profile_states`.
 
-Brain observes pack events only. It never processes its own state-transition events. This
-boundary prevents recursive self-tuning loops.
+The shipped interpreter observes successful dispatch-hook callbacks and explicit feedback,
+and ignores brain state-transition verbs. This boundary prevents recursive self-tuning loops;
+it is not durable shared-log delivery.
 
 ### 2. Shipped v1 profile record
 
@@ -122,19 +125,21 @@ persistence writes the full `BrainStateSnapshot` JSON blob into `brain_profile_s
 The generic `Profile` struct, `ProfileMetadata`, `ProfileStateClass`, `SnapshotAdapter`,
 and inference-hook fields remain target architecture and are not shipped v1 API.
 
-`event_filter` makes the ADR-022 §3a unification concrete: every profile declares its
-input substrate slice via `EventFilter`. The brain pack's `PackEventConsumer::event_filter`
-(ADR-017) returns the union of its active profiles' filters, so the runtime's storage
-query pushes the predicate down at the SQL layer — a deployment carrying thousands of
-cold profiles pays index lookup, not per-profile Rust evaluation. Profiles that need
-the `Objective<Event>` typed-shape (e.g., for `FilterFold` composition) use
-`filter.as_objective()`.
+`event_filter` remains target profile metadata, not a shipped consumer registration.
+If ADR-017's deferred `PackEventConsumer` design is accepted later, brain could return
+the union of active-profile filters and push that predicate down at the SQL layer. The
+current brain pack has no durable event-log consumer or live-delivery loop; posterior
+updates use the best-effort `DispatchHook` and explicit feedback paths, and profile
+state is projected at serve time per ADR-104. Future explicit replay or backtest code
+could use `filter.as_objective()`.
 
 ### 3. System-wide event log
 
-All packs emit structured events to a shared, append-only, time-ordered, schema-versioned
-log. Default-on for every pack. Brain reads this log. Today's `brain.events` table generalizes
-into this store.
+All packs emit audit events to a shared, append-only, time-ordered, schema-versioned log.
+Default-on for every pack. Brain's query handlers can read that log, but shipped profile
+evolution does not replay it. Profile mutation and cold-load replay use the synchronous hook /
+feedback paths and the private `brain_event_log` described above. Replacing that private path
+with the shared-log Fold remains deferred with ADR-017.
 
 ```rust
 pub struct Event {
@@ -169,15 +174,16 @@ pub enum EventKind {
 }
 ```
 
-Replay must handle every historical payload schema. A per-kind migration registry upgrades
-old payloads to the current shape before profile evolvers see them. The event log is the
-system of record; profile states are derivable from it.
+A future shared-log replay must handle every historical payload schema. Its follow-up ADR must
+specify a per-kind migration registry that upgrades old payloads before profile evolvers see
+them. Shipped profile state is not claimed to be derivable from the shared event log: cold-load
+replay reads the private `brain_event_log` after the latest brain snapshot.
 
 **Profile-served events carry `served_by_profile_id` in their payload.** Events whose
 production was shaped by a brain-resolved profile — `RecallExecuted`, `RerankExecuted`
 (ADR-042), `FeedbackExplicit` — record the resolved profile id in their
 payload. Other event kinds (`LinkCreated`, `TaskTransitioned`, …) do not carry this
-field — they were never "served" by a profile, just observed by brain.
+field — they were never "served" by a profile.
 
 ```rust
 // Minimum payload shape for profile-served events.
@@ -219,9 +225,11 @@ pub fn interpret(event: &Event) -> BrainSignal {
 }
 ```
 
-There is no `BrainEvent` enum parallel to `Event`. The `interpret()` function is the single
-mapping layer. Any pack that emits events through the standard dispatch path automatically
-feeds brain. To add a new signal source, add one match arm to `interpret()`.
+There is no `BrainEvent` enum parallel to `Event`. The shipped `interpret()` function maps the
+synthetic audit-shaped event passed by `DispatchHook` and explicit feedback records into brain
+signals. A successful standard dispatch invokes that best-effort hook when configured, but it
+does not provide durable shared-log delivery, catch-up, or replay. A future shared-log consumer
+could reuse the mapping only after ADR-017's prerequisites are accepted and implemented.
 
 ### 5. Profile state typology — Bayesian is one class among many
 
@@ -531,15 +539,17 @@ Trajectory → backtest pipeline).
 
 ### 6. Data flow
 
-Brain registers as a `PackEventConsumer` (ADR-017). The runtime delivers events; brain
-fans each delivered event to the matching profiles, applies their `Fold::reduce`, and
-persists `(state, cursor)` atomically per profile. The runtime does NOT execute Folds
-or persist profile state — those are pack territory.
+Brain does not register as a `PackEventConsumer`: ADR-017 defers that runtime seam, and
+ADR-104 explicitly pins activation to a lifecycle transition rather than a live update
+loop. Shipped posterior updates run through the best-effort `DispatchHook` and explicit
+feedback handlers, while serving projects state per request. The live-delivery and
+catch-up branches below are retained only as deferred target design; they are not
+current runtime behavior.
 
 ```
 EVENT LOG (substrate, ADR-022 §3b ordering: created_at ASC, event_id ASC for replay)
    |
-   |-- live delivery:
+   |-- [DEFERRED] live delivery:
    |     runtime queries events matching brain.event_filter()
    |       (union of active-profile filters, pushed down as SQL WHERE)
    |     for each event in canonical order:
@@ -573,7 +583,7 @@ EVENT LOG (substrate, ADR-022 §3b ordering: created_at ASC, event_id ASC for re
    |     emit RecallExecuted event with payload.served_by_profile_id = Some(P.id)
    |       (closes the feedback loop via §4 interpret())
    |
-   |-- catch-up (on registration / restart, ADR-017 PackEventConsumer):
+   |-- [DEFERRED] catch-up (on registration / restart):
    |     for each active profile P:
    |       cursor = tx.load_cursor(P.id) or EventCursor::zero()
    |       events = event_store.query(filter=P.event_filter, after=cursor,
@@ -599,28 +609,29 @@ EVENT LOG (substrate, ADR-022 §3b ordering: created_at ASC, event_id ASC for re
            ruvector-snapshot + ruvector-delta-core blob (generic / Bayesian)
 ```
 
-**Key invariants** (all derived from ADR-017 + ADR-022 §3b):
+**Deferred consumer invariants** (required if ADR-017 is accepted later):
 
-1. The runtime queries events using the §3b cursor-aware ascending replay query —
+1. The runtime would query events using the §3b cursor-aware ascending replay query —
    `(created_at, event_id)` tiebreak guarantees no skipped events at clock-tie boundaries.
-2. State and cursor are persisted in the same transaction in the **same backend** —
+2. State and cursor would be persisted in the same transaction in the **same backend** —
    the pack's primary SQLite store. See §6.1 below for how this works for LoRA-class
    profiles whose A/B matrices look like they want to live as files.
-3. Cold profiles never run Rust-side filtering — their `EventFilter` rolls into the
-   storage query's WHERE clause via the §3a closed-struct lowering (ADR-022).
+3. Cold profiles would not run Rust-side filtering — their `EventFilter` would roll
+   into the storage query's WHERE clause via the §3a closed-struct lowering (ADR-022).
 4. `Fold::reduce` is pure (no async, no IO, no clock — ADR-024 v1 invariants). The
    LoRA evolver's online SGD step (`khive_pack_brain::lora::sgd_step`) is deterministic
    given the same starting weights and signal. Lattice's online `adapt_step` is a
    future primitive (filed as a lattice issue) — until it lands the gradient math
    lives in khive-pack-brain.
 
-#### 6.1 LoRA two-resource atomicity — single-backend primary, SafeTensors as export
+#### 6.1 Future LoRA state/cursor atomicity — single-backend primary
 
-ADR-017 mandates state + cursor in the same transaction in the same backend. LoRA-class
-profile state looks like it wants to span two resources (SQLite for cursor + scalars,
-SafeTensors files for the A/B matrices) — that would be a two-phase commit problem.
-Resolution: **SafeTensors is not the primary persistence layer**, it is an import/export
-format. The primary store is the pack's SQLite, full stop.
+ADR-017's deferred design requires any future consumer to write state + cursor in the
+same transaction and backend. LoRA-class profile state looks like it wants to span two
+resources (SQLite for cursor + scalars, SafeTensors files for the A/B matrices), which
+would be a two-phase commit problem. The prerequisite design decision is:
+**SafeTensors is not the primary persistence layer**; it is an import/export format.
+The pack's SQLite store would be primary if the consumer seam is accepted.
 
 Shipped v1 persistence is JSON snapshot based (V20 migration, `V20_BRAIN_PROFILE_PERSISTENCE`):
 
@@ -649,9 +660,12 @@ used for reload. The LoRA tables (`profile_state_lora_layer`, `profile_state_sca
 `profile_cursor`) and SafeTensors import/export verbs are deferred until a native
 lattice/LoRA rerank call site ships.
 
-This is the right separation: the live state stays in one transactional backend; the
-portable format is for sharing/training-import/audit, where the latency of "flush to
-file" is acceptable and atomicity with the cursor is not required.
+This remains the right separation for a future consumer: durable state would stay in
+one transactional backend, while the portable format serves sharing, training import,
+and audit. Durable handler-owned mutations use the private `brain_event_log` and JSON
+snapshot path above. The best-effort `DispatchHook` mutates in-memory state only; it
+performs no event append or snapshot write and has no durability, cursor, or
+replay-atomicity guarantee.
 
 #### 6.1 Versioned `ModuleName` enum
 
@@ -949,8 +963,8 @@ active fallback profile: `balanced-recall-v1`.
 active  <->  inactive  ->  archived
 ```
 
-- **Active**: the profile can be resolved and updated by feedback.
-- **Inactive**: state is retained and the profile can be inspected, but live updates are stopped.
+- **Active**: lifecycle value eligible for unbound active-profile fallback resolution.
+- **Inactive**: state is retained; the transition itself starts or stops no background work.
 - **Archived**: terminal/read-only/audit-retained. No transition out of `Archived` is legal;
   `brain.activate(profile_id)` rejects archived profiles.
 
@@ -994,7 +1008,7 @@ A typical "train and serve per subagent per project" sequence:
      → derives state by replaying events through the Fold
      → persists snapshot
 3. brain.activate(profile_id=candidate)
-     → live update loop begins
+     → lifecycle changes to active; no live update loop is started (ADR-104)
 4. brain.bind(profile_id=candidate,
               actor="implementer-α",
               namespace="agent:docs",
@@ -1067,11 +1081,12 @@ from the moment it is created. The built-in `balanced-recall-v1` profile uses th
 
 ### 12. Brain registers as a pack
 
-Brain registers as `khive-pack-brain` via the pack registry (ADR-027). It observes pack
-events emitted by the runtime; it never processes events emitted by its own state
-transitions. This self-tuning prevention boundary is enforced by filtering on `EventKind`
-before passing events to profile evolvers — brain-internal kinds (`ProfileResolutionRecommended`,
-etc.) are excluded from the live update loop.
+Brain registers as `khive-pack-brain` via the pack registry (ADR-027), but it does not
+register a durable event-log consumer. The current best-effort `DispatchHook` and
+feedback handlers own state mutation synchronously. If the deferred ADR-017 seam is
+accepted later, its filter must exclude brain-internal events
+(`ProfileResolutionRecommended`, etc.) before passing events to profile evolvers so
+state transitions cannot tune themselves.
 
 ---
 
@@ -1209,8 +1224,9 @@ deployment.
      temporal decay
    - `Selector` that picks top-k under budget
    - `SnapshotAdapter` for the three Beta pairs plus entity LRU cache
-5. Live update loop: brain's `PackEventConsumer::on_event` (ADR-017) dispatches each
-   matching event to active profiles' `evolver.reduce` with atomic state+cursor commit.
+5. **Deferred**: a live update loop based on ADR-017's `PackEventConsumer` design. This
+   is not part of Phase 1 until a follow-up ADR accepts the consumer lifecycle and the
+   runtime ships atomic state+cursor delivery.
 
 ### Phase 2 — Backtest execution
 
@@ -1303,7 +1319,8 @@ As of #1016, newly emitted `FeedbackExplicit` events always persist the effectiv
 - ADR-006 — Deterministic Scoring (`DeterministicScore`, i64 fixed-point, canonical ordering)
 - ADR-017 — Pack Standard (brain registers as `khive-pack-brain`)
 - ADR-021 — Memory Pack (provides the `recall` verb that brain tunes)
-- ADR-022 — Events Query Surface (the substrate event log brain reads and all packs emit to)
+- ADR-022 — Events Query Surface (the shared substrate event log; profile-delivery integration
+  remains deferred)
 - ADR-024 — Fold Cognitive Primitives (`Fold`, `Anchor`, `Objective`, `Selector`,
   composition combinators — the building blocks brain composes into profiles)
 - ADR-025 — Verb Speech Acts (brain verbs classified as assertive, commissive, declaration)
@@ -1313,8 +1330,8 @@ As of #1016, newly emitted `FeedbackExplicit` events always persist the effectiv
 - The legacy v0 brain architecture (event-driven scalar Beta posteriors; the historical
   predecessor to this ADR. The Bayesian mechanics survive as `BalancedRecallProfile`; the
   fixed-shape `BrainState` design is superseded by the profile-orchestration direction here)
-- kkernel crate — the runtime that composes packs, hosts the event log, and runs the live
-  update loop
+- kkernel crate — the runtime that composes packs and hosts the event log; the live
+  update loop remains deferred
 - `ruvector-snapshot` — profile state persistence
 - `ruvector-delta-core` — delta-encoded snapshots
 - `ruvector-temporal-tensor` — time-evolving tiered state for rich-state profiles

--- a/docs/adr/ADR-041-event-provenance-projection.md
+++ b/docs/adr/ADR-041-event-provenance-projection.md
@@ -6,10 +6,10 @@
 **Depends on**:
 
 - ADR-004 (Substrate Observables — Event substrate)
-- ADR-017 (Pack Standard — PackEventConsumer atomicity)
+- ADR-017 (Pack Standard — deferred PackEventConsumer atomicity constraint)
 - ADR-022 (Events Query Surface — EventFilter, ordering, cursor)
 - ADR-024 (Fold Cognitive Primitives)
-- ADR-032 (Brain Profile Orchestration — Fold consumer of events)
+- ADR-032 (Brain Profile Orchestration — target Fold/event-consumer design)
 
 ---
 
@@ -17,8 +17,9 @@
 
 [ADR-022](ADR-022-events-query-surface.md) establishes the event log as an append-only,
 ordered, queryable substrate. Brain (ADR-032), validation pipelines (ADR-034), and
-audit consumers fold over this log via `Fold<Event, State>`. The Event struct carries a
-JSON `payload` field that holds operation-specific structured data:
+audit tooling can query or explicitly fold over this log. Runtime-driven Fold delivery
+is deferred with ADR-017's `PackEventConsumer` design. The Event struct carries a JSON
+`payload` field that holds operation-specific structured data:
 
 ```rust
 pub struct Event {
@@ -45,7 +46,8 @@ The same data, modeled as edges, would make provenance queries graph-native:
 But ADR-002's edge ontology is closed (15 edge relations — closed taxonomy; entity↔entity by default) and
 ADR-022 §3b's append-only ordering invariant rests on events being a separate substrate
 from entities. Promoting events into the entity table to "make them queryable" would
-break replay determinism, cursor semantics, and PackEventConsumer atomicity (ADR-017).
+break replay determinism, cursor semantics, and the atomicity required by any future
+PackEventConsumer contract (ADR-017).
 
 > **Amended ([ADR-055](ADR-055-epistemic-edge-relations.md))**: ADR-055 added 2
 > epistemic relations (`supports`, `refutes`); the current total is 17 edge relations.
@@ -56,9 +58,10 @@ This ADR resolves the tension via a **hybrid** model: the event log stays canoni
 edges expose the projection to GQL/SPARQL without touching the canonical edges table.
 
 The Fold/Objective story (ADR-024 §"Pack-internal aggregators") gets materially cleaner
-as a side effect — Fold consumers receive pre-decoded `EventView`s with typed
-provenance instead of raw payload JSON. EventFilter (ADR-022 §3a) gains
-`Observed(EntityId)` / `Selected(EntityId)` predicates that lower to SQL JOINs.
+as a side effect — explicit callers and any future event consumer can inspect pre-decoded
+`EventView`s with typed provenance instead of raw payload JSON. Canonical event-log Folds still
+receive `Event`, not `EventView`. EventFilter (ADR-022 §3a) gains `Observed(EntityId)` /
+`Selected(EntityId)` predicates that lower to SQL JOINs.
 
 ### Scope
 
@@ -68,7 +71,8 @@ This ADR specifies:
 - The four canonical observation roles (`Candidate`, `Selected`, `Target`, `Signal`).
 - The write-time projection contract: which events project, what they project, in
   what transaction.
-- The `EventView` type passed to `Fold` consumers.
+- The `EventView` storage type available to explicit callers and reserved as a future
+  event-consumer envelope.
 - `EventFilter::Observed(EntityId)` / `Selected(EntityId)` field additions and their
   SQL lowering.
 - Synthetic GQL/SPARQL edge exposure.
@@ -92,7 +96,7 @@ It does NOT:
 │ events                          (ADR-022 — canonical log)   │
 │   id, created_at, namespace, actor, verb, kind, payload     │
 │   append-only, ordered by (created_at, event_id)            │
-│   primary store for Fold consumers (ADR-017 cursor anchor)  │
+│   query source; future Fold cursor anchor (ADR-017 deferred) │
 └─────────────────────────────────────────────────────────────┘
             │
             │  (same transaction, write-time projection)
@@ -222,9 +226,14 @@ defining its role mapping. Existing event kinds with no decoder produce no proje
 rows — backward-compatible. Renaming or restructuring decoded fields requires an event
 payload-schema migration (ADR-032 §3 mentions the migration registry).
 
-### 5. EventView — the Fold consumer surface
+### 5. EventView — storage shape and future consumer envelope
 
-PackEventConsumer (ADR-017) hands Folds enriched event views, not raw events:
+`EventView` is a shipped storage type used by explicit callers and the best-effort
+post-dispatch `DispatchHook`. The current hook receives a synthetic view whose
+`observations` vector is empty; it does not hydrate persisted projection rows. No runtime
+currently rehydrates logged events and invokes a `PackEventConsumer`; that delivery seam
+is deferred by ADR-017. A future consumer dispatcher would use `EventView` as its delivery
+envelope:
 
 ```rust
 pub struct EventView {
@@ -240,43 +249,40 @@ pub struct EventObservation {
 }
 ```
 
-The runtime fetches the `events` row + matching `event_observations` rows in one
-JOIN before invoking `on_event`. The Fold body matches on `view.observations` for
-typed provenance access:
+A future consumer dispatcher must fetch the `events` row plus matching
+`event_observations` rows before invoking `on_event`. Consumer orchestration may inspect
+`view.observations` for typed provenance access before invoking a Fold:
 
 ```rust
-fn reduce(&self, state: S, view: &EventView, _ctx: &FoldContext) -> S {
-    let candidates: Vec<_> = view.observations.iter()
-        .filter(|o| o.role == ObservationRole::Candidate)
-        .collect();
-    let selected = view.observations.iter()
-        .find(|o| o.role == ObservationRole::Selected);
-    // typed access, no JSON-LIKE
-}
+let candidates: Vec<_> = view.observations.iter()
+    .filter(|o| o.role == ObservationRole::Candidate)
+    .collect();
+let selected = view.observations.iter()
+    .find(|o| o.role == ObservationRole::Selected);
+
+// EventView is the consumer envelope; Event is the canonical Fold input.
+state = fold.reduce(state, &view.event, &fold_ctx);
 ```
 
-Fold purity (ADR-024 v1 invariants) holds: the dispatcher does the JOIN; the Fold
-consumes pre-enriched values without IO. Atomicity (ADR-017): cursor + state +
-observations all live in their respective tables, written/read in the dispatcher's
-transaction.
+Under ADR-017's deferred atomicity constraint, event plus observation rows are already
+committed upstream; only derived state plus cursor belong in the pack consumer's transaction.
+The dispatcher performs IO, while the canonical `Fold<Event, S>` remains pure and receives
+`&view.event`.
 
-The `Fold<L, S>` trait stays generic (ADR-024 §1) — `L` is whatever the impl
-declares. PackEventConsumer dispatches by handing the consumer the `EventView`;
-the consumer is responsible for picking the right call shape based on its Fold's
-type parameter:
+The `Fold<L, S>` trait stays generic (ADR-024 §1), but ADR-024 makes `Event` the canonical
+event-log replay input and explicitly reserves `EventView` for query/read surfaces. A future
+`PackEventConsumer` therefore receives `EventView` as an envelope and passes its event field to
+the canonical Fold:
 
 ```rust
-// For Fold<Event, S> impls — explicit unwrap, no Deref magic:
+// EventView is the consumer envelope; Event is the canonical Fold input:
 fold.reduce(state, &view.event, &fold_ctx);
-
-// For Fold<EventView, S> impls (wishing typed observation access):
-fold.reduce(state, view, &fold_ctx);
 ```
 
-Existing `Fold<Event, State>` impls (e.g., `LoraEvolver` in ADR-032 §5b) continue
-to compile unchanged — only their call site at the consumer changes from passing
-an `&Event` directly to passing `&view.event`. New impls that need observation
-access declare `Fold<EventView, State>` and consume `view.observations` directly.
+Existing `Fold<Event, State>` impls (e.g., `LoraEvolver` in ADR-032 §5b) remain
+source-compatible with that future seam. If observations must become part of deterministic
+replay input, the design must define a separate typed input such as `ObservedEvent` and pin its
+ordering/versioning rules; it must not use `EventView` as the Fold input.
 
 EventView does NOT implement `Deref<Target=Event>`. Callers access the underlying
 event explicitly via `view.event`. This prevents replay determinism from leaking
@@ -304,10 +310,10 @@ which only exists after the migration runs. The storage layer MUST reject filter
 that set these fields when `event_observations` is absent (return a clean error,
 not a SQL "no such table"). Same rule for `session_id` on the events column.
 
-Brain profiles whose `event_filter` includes `observed: [memory_id]` wake only for
-events that touched that memory. The earlier "every profile fires on every event"
-fanout becomes "wake on graph-proximity" — meaningful for high-cardinality profile
-deployments (ADR-032 §10).
+A future brain consumer whose `event_filter` includes `observed: [memory_id]` could
+select only events that touched that memory. That would turn the deferred "every
+profile fires on every event" fanout into graph-proximity selection for
+high-cardinality profile deployments (ADR-032 §10).
 
 ### `served_by_profile_id` projection (forward-ref ADR-032)
 
@@ -392,7 +398,7 @@ queryable as a graph at the GQL/SPARQL layer.
 - **No `followed_by` edges.** Session chaining is `(session_id, created_at, event_id)`
   ordering, not stored edges.
 - **No new verbs.** `link`/`create` over events stays prohibited (ADR-022 §1). The
-  projection is read-only via query and Fold consumers.
+  projection is read-only via query and any future event-consumer orchestration.
 - **No payload changes.** Existing event payloads continue to carry the same JSON;
   the projection is a denormalized supplement, not a replacement.
 
@@ -421,8 +427,8 @@ needs to JOIN observations to feedback events — without the projection, that's
 app-side scan.
 
 **Graph-only** (events promoted into entities): wins on graph-query expressiveness,
-loses cursor-based replay (entities don't have monotonic ordering), loses
-PackEventConsumer atomicity (the projection now spans the entity-substrate edge
+loses cursor-based replay (entities don't have monotonic ordering), and would prevent
+future PackEventConsumer atomicity (the projection now spans the entity-substrate edge
 table). And ADR-002's closed relation set forbids adding `observed`/`selected`
 relations without an amendment — a substrate-level change for a denormalization
 concern is the wrong layer.
@@ -435,9 +441,8 @@ touching ADR-002. Each layer carries the semantics it's best at.
 
 Read-time projection (compute observations on the fly when queried) keeps storage small
 but pays the JSON-decode cost on every query. Write-time pays it once per event and
-indexes the result. The Fold consumer rate is much lower than the event emit rate
-(many consumers query the same event repeatedly across replay/backtest/analytics) —
-amortize the decode cost at the write.
+indexes the result. Query, replay, backtest, and analytics callers can read the same
+event repeatedly, so write-time projection amortizes the decode cost.
 
 The cost: emitters must register a payload decoder per event kind. The decoder is
 ~10 lines of `serde_json` extraction per kind; total registry is bounded by the event
@@ -456,8 +461,8 @@ real pattern doesn't fit.
 
 The alternatives were (a) two columns (`entity_id`, `note_id`) with one always NULL, or
 (b) two tables (`event_entity_obs`, `event_note_obs`). (a) splits the index by which
-column is non-NULL; (b) doubles the JOIN code path in Fold consumers. The polymorphic
-column with a discriminator keeps the index dense and the consumer code single-path.
+column is non-NULL; (b) doubles the JOIN code path for callers. The polymorphic column
+with a discriminator keeps the index dense and caller code single-path.
 
 ### Why session_id on events, not a Session entity
 
@@ -475,18 +480,18 @@ follow-up ADR. Today they're context, not content.
 
 ## Alternatives Considered
 
-| Alternative                                                            | Why rejected                                                                                                                   |
-| ---------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------ |
-| JSON-LIKE scans on payload references (status quo)                     | O(N) per query; no index; doesn't scale beyond hobby corpus.                                                                   |
-| Promote events into the entity substrate; use ADR-002 edges            | Breaks cursor ordering, PackEventConsumer atomicity, append-only contract. Substrate-layer change for denormalization concern. |
-| Add new ADR-002 relations (`observed`, `selected`, `target`, `signal`) | Polymorphic source (entity vs event) breaks `edges.source_id REFERENCES entities(id)`. Closed-relation invariant compromised.  |
-| Read-time projection (compute on query)                                | Amortizes wrong — many consumers query same event repeatedly; pay decode cost N times instead of once.                         |
-| Two-table polymorphism (`event_entity_obs`, `event_note_obs`)          | Doubles JOIN paths in Fold consumers and EventFilter; index split by substrate.                                                |
-| `followed_by` event-to-event edges for session chaining                | Millions of rows for session reconstruction that's an indexed range scan. Wrong substrate for transient ordering.              |
-| `Session` as an entity kind                                            | Requires ADR-001 + ADR-002 amendments; sessions are dispatch context, not researchable subjects.                               |
-| Open role string (pack-extensible roles)                               | Query fragmentation — packs invent synonyms that don't aggregate.                                                              |
-| Open referent_kind (any substrate including future)                    | Polymorphism cost grows with substrates; v1's two (entity, note) cover every emit pattern.                                     |
-| Async projection (event row first, observations later)                 | Breaks PackEventConsumer atomicity — a Fold replay between event write and projection write sees incomplete data.              |
+| Alternative                                                            | Why rejected                                                                                                                  |
+| ---------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------- |
+| JSON-LIKE scans on payload references (status quo)                     | O(N) per query; no index; doesn't scale beyond hobby corpus.                                                                  |
+| Promote events into the entity substrate; use ADR-002 edges            | Breaks cursor ordering, future consumer atomicity, append-only contract. Substrate-layer change for denormalization concern.  |
+| Add new ADR-002 relations (`observed`, `selected`, `target`, `signal`) | Polymorphic source (entity vs event) breaks `edges.source_id REFERENCES entities(id)`. Closed-relation invariant compromised. |
+| Read-time projection (compute on query)                                | Amortizes wrong — many callers query the same event repeatedly; pay decode cost N times instead of once.                      |
+| Two-table polymorphism (`event_entity_obs`, `event_note_obs`)          | Doubles JOIN paths for callers and EventFilter; index split by substrate.                                                     |
+| `followed_by` event-to-event edges for session chaining                | Millions of rows for session reconstruction that's an indexed range scan. Wrong substrate for transient ordering.             |
+| `Session` as an entity kind                                            | Requires ADR-001 + ADR-002 amendments; sessions are dispatch context, not researchable subjects.                              |
+| Open role string (pack-extensible roles)                               | Query fragmentation — packs invent synonyms that don't aggregate.                                                             |
+| Open referent_kind (any substrate including future)                    | Polymorphism cost grows with substrates; v1's two (entity, note) cover every emit pattern.                                    |
+| Async projection (event row first, observations later)                 | A future Fold replay could observe incomplete data between the event write and projection write.                              |
 
 ---
 
@@ -496,15 +501,16 @@ follow-up ADR. Today they're context, not content.
 
 - Provenance becomes indexable: O(log N) seek on `(entity_id, role)` instead of O(N)
   JSON-LIKE scans.
-- Fold consumers receive typed `EventView` with pre-decoded observations — payload
-  schema-on-read coupling eliminated.
+- Explicit callers that load projection rows can use typed `EventView` with pre-decoded
+  observations, and any future event consumer can receive the same envelope while retaining
+  `Event` as its canonical Fold input — payload schema-on-read coupling is eliminated.
 - `EventFilter::observed` / `selected` push provenance predicates into the WHERE
-  clause; cold profiles with graph-proximity filters wake only for relevant events.
+  clause; any future cold profile can select only relevant events.
 - GQL/SPARQL pattern matchers can traverse event→entity provenance natively via
   synthetic edges, without touching ADR-002's closed relation set.
 - Session reconstruction is an indexed range scan, not a graph traversal.
-- ADR-022, ADR-017, ADR-024, ADR-002 semantics are preserved verbatim — this ADR is
-  additive.
+- ADR-022, ADR-024, and ADR-002 semantics remain additive; ADR-017's consumer
+  integration remains explicitly deferred.
 
 ### Negative
 
@@ -512,10 +518,9 @@ follow-up ADR. Today they're context, not content.
   registering a decoder and declaring its role mapping.
 - Storage doubles for high-fanout event kinds (1 event row + ~10 observation rows for
   recall). Bounded; SQLite handles 100M-row scale.
-- Cursor + state atomicity guarantee (ADR-017) now spans three tables — `events`,
-  `event_observations`, and the pack's state — all in one transaction. Manageable
-  with SQLite's single-writer model; concurrent writers across multiple connections
-  serialize naturally.
+- Any future consumer has two ordered transaction boundaries: event plus observation
+  projection commits upstream, then pack state plus cursor commits atomically. No
+  cross-boundary three-table transaction is accepted or shipped (ADR-017).
 - `EventView.event` is a plain public field (explicit access). Future maintainers must
   remember observations are NOT in `Event` itself, only in `EventView.observations`.
 
@@ -576,24 +581,26 @@ The generated V13 SQL adds `events.session_id TEXT`, creates `event_observations
 - `FeedbackExplicit`: `event.target_id` → entity **or note** `Signal` row, per
   `event.substrate` (Amendment A1, A2).
 
-### PackEventConsumer dispatch update
+### Deferred PackEventConsumer dispatch integration
 
 No shipped `crates/khive-runtime/src/events.rs`, `observations.rs`, or `event_view.rs`
-files own this behavior. Consumers that need event observations read the shipped
-`EventView` shape from `khive-storage`.
+files own this behavior. No dispatch update is accepted by this ADR. Callers that need
+event observations must explicitly load projection rows into the shipped `EventView`
+shape from `khive-storage`; the best-effort `DispatchHook` supplies an empty observation
+vector. Future automatic delivery must first satisfy ADR-017's prerequisites.
 
 ### Tests
 
-| Scenario                                           | Assert                                                                                                                             |
-| -------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------- |
-| `recall` emits event                               | `event_observations` rows exist for candidates + selected with correct positions                                                   |
-| `link` emits event                                 | Two `Target` rows at positions 0 and 1                                                                                             |
-| EventFilter `observed=[mem_id]`                    | Returns only events that observed `mem_id`; one JOIN in the EXPLAIN plan                                                           |
-| EventView in Fold                                  | `view.observations` is non-empty for projecting kinds; payload accessible via `view.event.payload` (NOT `view.payload` — no Deref) |
-| Synthetic edge in GQL                              | `MATCH (e:event)-[:observed_as_selected]->(m:memory) RETURN m` returns the selected memories                                       |
-| `link(event_id, entity_id, observed_as_candidate)` | Returns `InvalidRelation` — synthetic edges are read-only                                                                          |
-| Session reconstruction                             | `session_id = :sid ORDER BY (created_at, id)` returns events in causal order                                                       |
-| Cross-session reuse JOIN                           | The session-A→session-B JOIN returns correct memory ids                                                                            |
+| Scenario                                           | Assert                                                                                       |
+| -------------------------------------------------- | -------------------------------------------------------------------------------------------- |
+| `recall` emits event                               | `event_observations` rows exist for candidates + selected with correct positions             |
+| `link` emits event                                 | Two `Target` rows at positions 0 and 1                                                       |
+| EventFilter `observed=[mem_id]`                    | Returns only events that observed `mem_id`; one JOIN in the EXPLAIN plan                     |
+| EventView storage shape                            | Payload is accessed via `view.event.payload` (NOT `view.payload` — no Deref)                 |
+| Synthetic edge in GQL                              | `MATCH (e:event)-[:observed_as_selected]->(m:memory) RETURN m` returns the selected memories |
+| `link(event_id, entity_id, observed_as_candidate)` | Returns `InvalidRelation` — synthetic edges are read-only                                    |
+| Session reconstruction                             | `session_id = :sid ORDER BY (created_at, id)` returns events in causal order                 |
+| Cross-session reuse JOIN                           | The session-A→session-B JOIN returns correct memory ids                                      |
 
 ---
 
@@ -697,15 +704,14 @@ referents. `RecallExecuted` and `RerankExecuted` are unchanged by this amendment
   ADR.
 - [ADR-008](ADR-008-query-layer-separation.md): Query layer — host for synthetic-edge
   pattern compilation.
-- [ADR-017](ADR-017-pack-standard.md): PackEventConsumer — `on_event` signature gains
-  `EventView`.
+- [ADR-017](ADR-017-pack-standard.md): deferred PackEventConsumer design — any future
+  `on_event` signature uses `EventView` as its delivery envelope.
 - [ADR-022](ADR-022-events-query-surface.md): Events Query Surface — `EventFilter`
   gains `observed` / `selected` fields with explicit SQL lowering.
-- [ADR-024](ADR-024-fold-cognitive-primitives.md): Fold — consumers receive
-  `EventView`, not raw `Event`.
-- [ADR-032](ADR-032-brain-profile-orchestration.md): Brain — LoRA-class profiles use
-  `EventFilter::observed` to wake on graph-proximity.
-- [ADR-034](ADR-034-kg-validation-pipelines.md): KG validation — streaming rules
-  over `ValidationItem::Event` receive `EventView`s.
-- `crates/khive-runtime/src/events.rs`: emit path + per-kind decoders.
+- [ADR-024](ADR-024-fold-cognitive-primitives.md): Fold — canonical event-log Folds receive
+  `Event`; `EventView` remains a query/read envelope, not replay input.
+- [ADR-032](ADR-032-brain-profile-orchestration.md): Brain — future LoRA-class profiles
+  may use `EventFilter::observed` for graph-proximity selection.
+- [ADR-034](ADR-034-kg-validation-pipelines.md): KG validation — any future streaming event
+  orchestration may inspect `EventView`s while its Fold input follows ADR-024.
 - `crates/khive-storage/src/event.rs`: `EventFilter` extension.

--- a/docs/adr/ADR-043-embedding-model-migration.md
+++ b/docs/adr/ADR-043-embedding-model-migration.md
@@ -219,18 +219,18 @@ given but cannot decide to swap the underlying model. This is the architectural
 boundary: model selection is operator territory; brain-tuned weights and adapters
 are agent-influenced territory.
 
-### 7. New event kinds
+### 7. Reserved event kinds
 
-Added to `EventKind` (ADR-032 §3) and to the closed substrate event log:
+Added to the `EventKind` enum (ADR-032 §3) for the deferred migration worker:
 
 - `EmbeddingModelChanged` — migration started
 - `EmbeddingMigrationCompleted` — swap committed
 - `EmbeddingMigrationFailed` — controller entered `Failed`
 - `EmbeddingDriftDetected` — drift-check threshold breach (advisory)
 
-All four carry `engine_name` and the relevant `_embedding_models.id`(s) in payload.
-None carries `served_by_profile_id` — these are operator/system events, not
-profile-served (ADR-032 §3 rule).
+When a future worker emits them, all four carry `engine_name` and the relevant
+`_embedding_models.id`(s) in payload. None carries `served_by_profile_id` — these are
+operator/system events, not profile-served (ADR-032 §3 rule).
 
 ### 8. Backward compatibility — one-shot startup migration (V14 + V16)
 
@@ -343,12 +343,10 @@ Tracked in `.khive/plans/embedding-version-config.md`.
 
 ### Neutral
 
-- New event kinds: `EmbeddingModelChanged`, `EmbeddingMigrationCompleted`,
-  `EmbeddingMigrationFailed`, `EmbeddingDriftDetected`. Brain folds see these
-  events but typically ignore them (they carry no `served_by_profile_id`).
-- The startup backward-compat migration emits one `EmbeddingModelChanged` event
-  per existing engine. Brain folds replaying history must accept these without
-  side effect.
+- Four event kinds are reserved: `EmbeddingModelChanged`, `EmbeddingMigrationCompleted`,
+  `EmbeddingMigrationFailed`, and `EmbeddingDriftDetected`. No production emitter or durable
+  brain consumer ships today. Any future brain replay must accept these system events without
+  changing profile state merely because they lack `served_by_profile_id`.
 
 ## Implementation
 
@@ -407,10 +405,13 @@ The ADR-043 schema work landed in two ledger versions in
    `_embedding_models` from `[[engines]]`; per-table model-inferred tag rewrite
    for deployments with non-default models (deferred — see §1.1 final paragraph).
 
-### Worker registration
+### Deferred worker registration
 
-`khive-runtime::Pack::on_register` adds `EmbedMigrationWorker` to the
-runtime's `PackEventConsumer` list. The full trait implementation (ADR-017):
+Neither `Pack::on_register` nor a runtime `PackEventConsumer` list ships today, and the
+`kkernel engine migrate` command below remains `NotImplemented`. ADR-017 now defers the
+consumer lifecycle, cursor, and replay seam. Therefore this ADR does not register an
+`EmbedMigrationWorker`; the following snippet preserves only the proposed event filter
+and worker shape for a future ADR:
 
 ```rust
 #[async_trait]

--- a/docs/adr/ADR-046-event-sourced-proposals.md
+++ b/docs/adr/ADR-046-event-sourced-proposals.md
@@ -9,7 +9,7 @@
 - ADR-017 (Pack Standard — KG pack handler surface; async event-consumer worker registration is deferred)
 - ADR-018 (Authorization Gate — gates the apply step)
 - ADR-022 (Events Query Surface — proposals live as events)
-- ADR-032 (Brain Profile Orchestration — brain folds over proposal events)
+- ADR-032 (Brain Profile Orchestration — future proposal-event Fold design; no v1 consumer)
 - ADR-041 (Event Provenance Projection — open-proposal projection lives here)
 
 ## Context
@@ -24,9 +24,10 @@ without a replacement.
 The accepted decision selected option (c) **event-sourced proposals**: the
 proposal lifecycle is encoded purely as events on the existing log substrate
 (ADR-022). No new substrate. No new branch model. No git verbs over MCP. The
-brain already consumes events natively (ADR-032 §6); proposals slot into the
-same fold path. The projection table (ADR-041) handles "show me all open
-proposals" as a query that doesn't require scanning every event.
+proposal events preserve input for a future brain fold, but shipped v1 has no
+automatic shared-log consumer (ADR-032 §6). The projection table (ADR-041)
+handles "show me all open proposals" as a query that doesn't require scanning
+every event.
 
 ### What this ADR adds
 
@@ -565,10 +566,10 @@ supersede, compound). Future arms add to the enum via additive semver bumps.
 
 - Proposal workflow lands without a new substrate, new store trait, or git
   dependency. Minimal incremental complexity.
-- Brain folds over the proposal event stream natively — proposer-quality and
-  reviewer-agreement learning is free signal.
-- Cross-pack proposals work the same way as KG-pack proposals; any pack can
-  consume the four `EventKind`s.
+- Proposal events preserve the signal needed for future proposer-quality and
+  reviewer-agreement folds; v1 brain has no proposal-specific fold or automatic delivery.
+- Cross-pack proposals work the same way as KG-pack proposals. Packs can query the four
+  `EventKind`s explicitly; automatic pack consumption remains deferred with ADR-017.
 - The audit trail is the event log. Review history for a proposal is retrieved
   via the events query surface (ADR-022):
 
@@ -595,8 +596,8 @@ supersede, compound). Future arms add to the enum via additive semver bumps.
 
 ### Neutral
 
-- Brain receives four new event kinds with no v1 fold logic — brain folds
-  ignore them by default (existing `EventFilter` doesn't match).
+- The shared `EventKind` enum gains four proposal kinds, but v1 brain has no
+  proposal-specific fold and receives no automatic shared-log delivery.
 - The three new verbs (`propose`, `review`, `withdraw`) bring the pack-kg
   verb count from 11 to 14. The verb surface stays well under the ADR-016
   single-tool `request` envelope's practical limits.
@@ -742,7 +743,7 @@ Lookup wire shape:
 - ADR-022 (Events Query Surface) — proposal events live as substrate events
 - ADR-016 (Request DSL) — `propose`, `review`, and `withdraw` ride the standard
   single-tool `request` envelope
-- ADR-032 (Brain Profile Orchestration) — brain folds extend to proposal events
+- ADR-032 (Brain Profile Orchestration) — future brain folds may extend to proposal events
   in future ADRs
 - ADR-041 (Event Provenance Projection) — projection-table pattern this ADR
   reuses

--- a/docs/adr/ADR-119-daemon-component-supervision.md
+++ b/docs/adr/ADR-119-daemon-component-supervision.md
@@ -30,10 +30,10 @@ narrow construction boundary has been proved.
 
 Nor does the current evidence establish a need for an event-topic bus. Polling at the
 present fleet scale is not a throughput problem, and no concrete consumer has yet shown
-that freshness requires push. Durable event consumption and replay already have a pack
-contract: ADR-017's `PackEventConsumer` reads the event log through the cursor semantics
-specified by [ADR-022](ADR-022-events-query-surface.md). A
-second at-least-once delivery mechanism would duplicate that authority.
+that freshness requires push. ADR-022 ships a durable event query surface, while ADR-017
+now marks `PackEventConsumer` catch-up and live delivery as deferred design. A future
+push or consumer proposal must reconcile with that durable source of truth rather than
+introduce a second log or cursor authority.
 
 ## Assumptions examined
 
@@ -53,9 +53,10 @@ second at-least-once delivery mechanism would duplicate that authority.
    A future bus must be justified by latency/freshness and staleness-summary ergonomics,
    not by a load-reduction claim.
 5. **“An at-least-once topic is a missing capability.” — Refuted for event-plane facts.**
-   ADR-022 supplies the durable query side and ADR-017 supplies cursor-based pack
-   catch-up plus live delivery. A new ephemeral topic could only be a wake-up
-   optimization over durable state, not a second source of truth.
+   ADR-022 supplies the durable query side. ADR-017 records cursor-based pack catch-up
+   and live delivery only as deferred design. A new ephemeral topic could at most be a
+   wake-up optimization over durable state; it cannot become a second source of truth
+   or silently make the deferred consumer contract real.
 6. **“The change is cheap.” — Unsupported and dropped.** No LOC or complexity estimate
    is accepted without a prototype. This ADR makes no cheapness claim.
 
@@ -253,9 +254,9 @@ must preserve:
 > a fact.
 
 Where the notification refers to an event-plane fact, the durable side is ADR-022's
-event query surface and ADR-017's cursor replay contract. A future topic MUST compose
-with those contracts; it MUST NOT shadow them with a second durable log or cursor
-authority.
+event query surface. A future topic MUST compose with that surface and with any later
+ADR that accepts cursor replay; it MUST NOT shadow them with a second durable log or
+cursor authority.
 
 Minimum tests for any future bus are: rollback-after-publish is unobservable;
 capacity-2 publish-3 yields `Lagged(1)`; a stale cursor yields
@@ -269,7 +270,8 @@ sequence reinterpretation.
 Rejected. It gives pack authors a uniform declaration locus, but both current
 cross-crate candidates depend on MCP-host construction. Adding default trait methods
 would make existing packs compile while still freezing an unproved dependency boundary.
-The event-topic half also lacks a current latency consumer and overlaps ADR-017.
+The event-topic half also lacks a current latency consumer and overlaps ADR-017's
+deferred consumer design.
 
 ### Keep hand-spawned tasks and repair each loop independently
 
@@ -301,8 +303,8 @@ descriptor outward to `Pack` later is additive. Moving a prematurely broad
 
 Splitting event topics is also deliberate. The service registry has current consumers
 and a concrete incident. The bus has estimated magnitudes, no measured latency need,
-and an existing durable consumer contract to reconcile. Combining them would let the
-stronger service case smuggle an unproved bus into acceptance.
+and a durable query surface plus a deferred consumer design to reconcile. Combining
+them would let the stronger service case smuggle an unproved bus into acceptance.
 
 ## Risks and unknowns
 

--- a/docs/guide/api-reference.md
+++ b/docs/guide/api-reference.md
@@ -901,7 +901,8 @@ request(ops="brain.resolve(consumer_kind=\"recall\", actor=\"agent:docs\")")
 
 ### `brain.activate` — Commissive
 
-Move a profile to Active (starts the live update loop).
+Move a profile to Active. This is a lifecycle transition; serving reads profile state
+per request and no background update loop is started.
 
 | Param        | Type   | Required | Notes                |
 | ------------ | ------ | -------- | -------------------- |
@@ -913,7 +914,7 @@ request(ops="brain.activate(profile_id=\"implementer-recall-v1\")")
 
 ### `brain.deactivate` — Commissive
 
-Move a profile to Inactive (stop live updates, retain state).
+Move a profile to Inactive (lifecycle transition; retain state).
 
 | Param        | Type   | Required | Notes                  |
 | ------------ | ------ | -------- | ---------------------- |


### PR DESCRIPTION
## Summary

- mark `PackEventConsumer`, durable cursor delivery, catch-up, retry, and replay CLI behavior as deferred design rather than shipped contract
- distinguish the current best-effort `DispatchHook`, explicit event queries, and Brain's private event-log/snapshot path from future shared-log consumption
- reconcile dependent ADRs for event ordering, provenance projection, Brain, embedding migration, proposals, and daemon supervision
- keep `EventView` as a future delivery envelope while preserving `Event` as the canonical deterministic Fold input
- correct current product and rustdoc claims about Brain lifecycle transitions and observation-empty synthetic hook views

Fixes #1411.

## Contract

No pack may rely on automatic shared-log delivery until a follow-up ADR accepts and implements cursor-aware ascending queries, stable consumer identity and supervision, atomic state-plus-cursor persistence, gap-free catch-up/live handoff, pinned retry/idempotence semantics, and an authenticated bounded replay surface. The shipped runtime remains event append/query plus an optional non-durable post-dispatch hook.

## Validation

- `cargo check -p khive-runtime -p khive-pack-brain --all-targets --all-features`
- `cargo clippy -p khive-runtime -p khive-pack-brain --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS='-D warnings' cargo doc -p khive-runtime -p khive-pack-brain --all-features --no-deps`
- `cargo fmt --all --check`
- Deno formatting for all 12 changed Markdown files and `make docs-check`
- ADR reference lint plus its self-test and `git diff --check HEAD^ HEAD`
- two independent cross-ADR/code review rounds; every reported finding was corrected before the exact-SHA gates

The branch was validated at exact commit `2df0c7ca13ba693e9e89da80a9d0d3071a2c07d1`.

> AI-assisted contribution: Codex prepared this change and PR description.
