### PR TITLE
fix(runtime): audit lineage loss on hard delete

### DIFF
--- a/crates/khive-db/src/stores/event.rs
+++ b/crates/khive-db/src/stores/event.rs
@@ -405,6 +405,78 @@ pub fn event_insert_statements(event: &Event) -> Result<Vec<SqlStatement>, rusql
     Ok(statements)
 }
 
+/// Build commit-time warning inserts for lineage-sensitive incident edges
+/// removed by a hard-delete cascade (ADR-002).
+///
+/// Each statement handles one protected relation and reads `graph_edges`
+/// when it executes, inside the caller's delete transaction. This is
+/// intentionally not a prepare-time edge query: a guarded edge write that
+/// commits immediately before the delete must be represented in the warning
+/// payload before the subsequent cascade statement removes it. Relations
+/// with no matching incident edge insert no event.
+pub fn hard_delete_lineage_warning_statements(
+    namespace: &str,
+    actor: &str,
+    target_id: Uuid,
+    substrate: SubstrateKind,
+) -> Vec<SqlStatement> {
+    const WARNINGS: [(&str, &str); 5] = [
+        ("derived_from", "provenance_loss"),
+        ("supersedes", "replacement_lineage_loss"),
+        ("precedes", "temporal_sequence_loss"),
+        ("supports", "evidential_link_loss"),
+        ("refutes", "evidential_link_loss"),
+    ];
+
+    let target_id = target_id.to_string();
+    let created_at = chrono::Utc::now().timestamp_micros();
+    WARNINGS
+        .into_iter()
+        .map(|(relation, warning)| SqlStatement {
+            sql: "INSERT INTO events \
+                  (id, namespace, verb, substrate, actor, kind, outcome, payload, \
+                   payload_schema_version, profile_state_version, duration_us, target_id, \
+                   session_id, aggregate_kind, aggregate_id, created_at) \
+                  SELECT ?1, ?2, 'delete', ?3, ?4, ?5, ?6, \
+                         json_object( \
+                           'severity', 'warning', \
+                           'warning', ?7, \
+                           'deleted_id', ?8, \
+                           'relation', ?9, \
+                           'edge_count', count(*), \
+                           'edges', json_group_array(json_object( \
+                             'id', incident.id, \
+                             'namespace', incident.namespace, \
+                             'source_id', incident.source_id, \
+                             'target_id', incident.target_id, \
+                             'deleted_at', incident.deleted_at)) \
+                         ), \
+                         1, NULL, 0, ?8, NULL, NULL, NULL, ?10 \
+                  FROM ( \
+                    SELECT id, namespace, source_id, target_id, deleted_at \
+                    FROM graph_edges \
+                    WHERE (source_id = ?8 OR target_id = ?8) AND relation = ?9 \
+                    ORDER BY namespace, id \
+                  ) AS incident \
+                  HAVING count(*) > 0"
+                .into(),
+            params: vec![
+                SqlValue::Text(Uuid::new_v4().to_string()),
+                SqlValue::Text(namespace.to_string()),
+                SqlValue::Text(substrate.name().to_string()),
+                SqlValue::Text(actor.to_string()),
+                SqlValue::Text(EventKind::Audit.name().to_string()),
+                SqlValue::Text(EventOutcome::Success.name().to_string()),
+                SqlValue::Text(warning.to_string()),
+                SqlValue::Text(target_id.clone()),
+                SqlValue::Text(relation.to_string()),
+                SqlValue::Integer(created_at),
+            ],
+            label: Some(format!("hard-delete-{relation}-warning")),
+        })
+        .collect()
+}
+
 /// Insert `event` (and any derived `event_observations` rows) through the
 /// `khive-storage` `SqlWriter` seam, on a transaction the CALLER already
 /// opened and controls the commit/rollback boundary for. Issues no

--- a/crates/khive-pack-memory/src/ann.rs
+++ b/crates/khive-pack-memory/src/ann.rs
@@ -149,6 +149,13 @@ pub(crate) async fn is_current(ann: &SharedAnn, key: &AnnKey) -> bool {
     installed_is_fresh(ann, key, target_generation).await
 }
 
+/// Read the monotonic write generation so mutation-hook tests can assert the
+/// invalidation signal without racing the background rebuild it schedules.
+#[cfg(test)]
+pub(crate) async fn generation_for_test(ann: &SharedAnn, key: &AnnKey) -> u64 {
+    current_generation(ann, key).await
+}
+
 /// Debounce interval for the cross-process durable-epoch query.
 #[cfg(not(test))]
 const DURABLE_EPOCH_CHECK_INTERVAL: std::time::Duration = std::time::Duration::from_secs(5);

--- a/crates/khive-pack-memory/src/pack.rs
+++ b/crates/khive-pack-memory/src/pack.rs
@@ -949,6 +949,7 @@ mod note_mutation_hook_tests {
             "sanity: warm-up recall must leave the ANN cache current before \
              the merge under test"
         );
+        let generation_before = ann::generation_for_test(&ann, &mutation_hook_ann_key()).await;
 
         registry
             .dispatch(
@@ -963,9 +964,15 @@ mod note_mutation_hook_tests {
             .expect("kg merge on memory-kind notes");
 
         assert!(
-            !ann::is_current(&ann, &mutation_hook_ann_key()).await,
+            ann::generation_for_test(&ann, &mutation_hook_ann_key()).await > generation_before,
             "a KG `merge` of two memory-kind notes must invalidate the warm \
              ANN generation (#750)"
+        );
+        ann::wait_until_warm_idle(&ann, &mutation_hook_ann_key()).await;
+        assert!(
+            ann::is_current(&ann, &mutation_hook_ann_key()).await,
+            "the mutation-triggered background rebuild must converge on the \
+             post-merge generation without another recall"
         );
     }
 

--- a/crates/khive-runtime/src/atomic_prepare.rs
+++ b/crates/khive-runtime/src/atomic_prepare.rs
@@ -41,6 +41,7 @@ use khive_db::stores::entity::{
     entity_hard_delete_statement, entity_soft_delete_statement, entity_upsert_statement,
 };
 use khive_db::stores::event::event_insert_statements;
+use khive_db::stores::event::hard_delete_lineage_warning_statements;
 use khive_db::stores::graph::{
     edge_hard_delete_statement, edge_insert_guarded_by_endpoints_statement,
     edge_soft_delete_statement, edge_symmetric_absorb_or_update_inplace_statement,
@@ -1015,6 +1016,7 @@ pub async fn prepare_delete(
     expected_kind: Option<AtomicDeleteKind>,
 ) -> RuntimeResult<AtomicOpPlan> {
     let id = require_uuid(args, "id")?;
+    let actor = format!("{}:{}", token.actor().kind, token.actor().id);
     let hard = obj(args)?
         .get("hard")
         .and_then(|v| v.as_bool())
@@ -1066,6 +1068,19 @@ pub async fn prepare_delete(
                 }]
             };
             if hard {
+                statements.extend(
+                    hard_delete_lineage_warning_statements(
+                        &namespace,
+                        &actor,
+                        id,
+                        SubstrateKind::Entity,
+                    )
+                    .into_iter()
+                    .map(|statement| PlanStatement {
+                        statement,
+                        guard: None,
+                    }),
+                );
                 // Same builder canonical `delete_entity`'s hard-delete
                 // cascade calls (`graph.purge_incident_edges`).
                 statements.push(PlanStatement {
@@ -1138,6 +1153,19 @@ pub async fn prepare_delete(
                 }]
             };
             if hard {
+                statements.extend(
+                    hard_delete_lineage_warning_statements(
+                        &namespace,
+                        &actor,
+                        id,
+                        SubstrateKind::Note,
+                    )
+                    .into_iter()
+                    .map(|statement| PlanStatement {
+                        statement,
+                        guard: None,
+                    }),
+                );
                 statements.push(PlanStatement {
                     statement: purge_incident_edges_statement(id),
                     guard: None,
@@ -1200,7 +1228,7 @@ pub async fn prepare_delete(
                     runtime.get_edge(token, id).await?
                 };
                 match edge {
-                    Some(edge) => prepare_delete_edge(id, edge, hard).await,
+                    Some(edge) => prepare_delete_edge(id, edge, hard, &actor).await,
                     None => Err(RuntimeError::NotFound(format!("entity/note/edge {id}"))),
                 }
             }
@@ -1220,11 +1248,20 @@ async fn prepare_delete_edge(
     id: Uuid,
     edge: khive_storage::types::Edge,
     hard: bool,
+    actor: &str,
 ) -> RuntimeResult<AtomicOpPlan> {
     let namespace = edge.namespace.clone();
     let mut statements: Vec<PlanStatement> = Vec::new();
 
     if hard {
+        statements.extend(
+            hard_delete_lineage_warning_statements(&namespace, actor, id, SubstrateKind::Entity)
+                .into_iter()
+                .map(|statement| PlanStatement {
+                    statement,
+                    guard: None,
+                }),
+        );
         // Mirrors `delete_edge`'s `graph.purge_incident_edges(edge_id)` —
         // unguarded: zero incident edges is a legitimate outcome, not a
         // failure (same reasoning as the entity/note cascade-edges
@@ -2769,6 +2806,63 @@ mod tests {
             );
             assert_eq!(events[0].payload["hard"], json!(hard));
         }
+    }
+
+    #[tokio::test]
+    async fn atomic_hard_delete_emits_lineage_warning_in_commit_unit() {
+        let runtime = scratch_runtime();
+        let token = NamespaceToken::mint_authorized(
+            Namespace::local(),
+            crate::ActorRef::new("agent", "atomic-lineage-deleter"),
+        );
+        let doomed = khive_storage::Entity::new("local", "document", "atomic-doomed");
+        let source = khive_storage::Entity::new("local", "artifact", "atomic-source");
+        let doomed_id = doomed.id;
+        runtime
+            .entities(&token)
+            .expect("entities store")
+            .upsert_entity(doomed)
+            .await
+            .expect("seed doomed entity");
+        runtime
+            .entities(&token)
+            .expect("entities store")
+            .upsert_entity(source.clone())
+            .await
+            .expect("seed source entity");
+        runtime
+            .link(
+                &token,
+                source.id,
+                doomed_id,
+                EdgeRelation::DerivedFrom,
+                1.0,
+                None,
+            )
+            .await
+            .expect("seed protected edge");
+
+        let plan = prepare_delete(
+            &runtime,
+            &token,
+            &json!({"id": doomed_id.to_string(), "hard": true}),
+            None,
+        )
+        .await
+        .expect("prepare hard delete");
+        let outcome = crate::atomic_runner::run_atomic_unit(runtime.sql().as_ref(), vec![plan])
+            .await
+            .expect("delete commit");
+        assert!(matches!(
+            outcome,
+            crate::atomic_runner::AtomicRunOutcome::Committed { .. }
+        ));
+
+        let warnings = events_for_target(&runtime, &token, doomed_id, EventKind::Audit).await;
+        assert_eq!(warnings.len(), 1);
+        assert_eq!(warnings[0].actor, "agent:atomic-lineage-deleter");
+        assert_eq!(warnings[0].payload["relation"], "derived_from");
+        assert_eq!(warnings[0].payload["warning"], "provenance_loss");
     }
 
     /// Atomic soft and hard delete of a note must each append a

--- a/crates/khive-runtime/src/operations.rs
+++ b/crates/khive-runtime/src/operations.rs
@@ -34,6 +34,7 @@ use khive_storage::{Edge, EdgeRelation, Entity, EntityFilter, Event, EventFilter
 use khive_types::{EdgeEndpointRule, EndpointKind, EventKind, KhiveError, SubstrateKind};
 
 use khive_db::stores::entity::{entity_hard_delete_statement, entity_upsert_statement};
+use khive_db::stores::event::hard_delete_lineage_warning_statements;
 use khive_db::stores::graph::{edge_hard_delete_statement, purge_incident_edges_statement};
 use khive_db::stores::note::note_hard_delete_statement;
 use khive_db::stores::text::insert_document_statement;
@@ -4035,7 +4036,10 @@ impl KhiveRuntime {
     /// already purged.
     ///
     /// `row_statement` is the exact hard-delete `DELETE` for the target row
-    /// (entity, note, or edge). Returns `Ok(true)` if the row was deleted,
+    /// (entity, note, or edge). Before the incident-edge purge, the same plan
+    /// appends any ADR-002 lineage-loss warnings from the still-present edge
+    /// rows, so the warning payload and cascade commit or roll back together.
+    /// Returns `Ok(true)` if the row was deleted,
     /// `Ok(false)` if it no longer existed (lost a race with a concurrent
     /// delete of the same row) — never an error for that case, matching the
     /// non-atomic bool-returning shape callers had before this fix.
@@ -4043,19 +4047,29 @@ impl KhiveRuntime {
         &self,
         row_statement: SqlStatement,
         node_id: Uuid,
+        namespace: &str,
+        actor: &str,
+        substrate: SubstrateKind,
     ) -> RuntimeResult<bool> {
+        let mut statements = vec![PlanStatement {
+            statement: row_statement,
+            guard: Some(AffectedRowGuard::exactly(1)),
+        }];
+        statements.extend(
+            hard_delete_lineage_warning_statements(namespace, actor, node_id, substrate)
+                .into_iter()
+                .map(|statement| PlanStatement {
+                    statement,
+                    guard: None,
+                }),
+        );
+        statements.push(PlanStatement {
+            statement: purge_incident_edges_statement(node_id),
+            guard: None,
+        });
         let plan = AtomicOpPlan::Delete(DeletePlan {
             target_id: node_id,
-            statements: vec![
-                PlanStatement {
-                    statement: row_statement,
-                    guard: Some(AffectedRowGuard::exactly(1)),
-                },
-                PlanStatement {
-                    statement: purge_incident_edges_statement(node_id),
-                    guard: None,
-                },
-            ],
+            statements,
             post_commit: PostCommitEffect::None,
         });
         match run_atomic_unit(self.sql().as_ref(), vec![plan]).await {
@@ -4117,6 +4131,7 @@ impl KhiveRuntime {
                 .map_err(|e| RuntimeError::Internal(format!("note namespace invalid: {e}")))?,
         );
         let record_ns = note.namespace.clone();
+        let actor = format!("{}:{}", token.actor().kind, token.actor().id);
 
         // On hard delete, the row delete and the incident-edge cascade (including
         // already-soft-deleted edges) run as ONE write transaction: see
@@ -4124,7 +4139,13 @@ impl KhiveRuntime {
         // commit; it is best-effort and idempotent, unlike the row/edge pair.
         let deleted = if hard {
             let deleted = self
-                .atomic_hard_delete_with_edge_purge(note_hard_delete_statement(id), id)
+                .atomic_hard_delete_with_edge_purge(
+                    note_hard_delete_statement(id),
+                    id,
+                    &record_ns,
+                    &actor,
+                    SubstrateKind::Note,
+                )
                 .await?;
             self.text_for_notes(&record_tok)?
                 .delete_document(&record_ns, id)
@@ -4406,6 +4427,7 @@ impl KhiveRuntime {
             khive_types::Namespace::parse(&entity.namespace)
                 .map_err(|e| RuntimeError::Internal(format!("entity namespace invalid: {e}")))?,
         );
+        let actor = format!("{}:{}", token.actor().kind, token.actor().id);
 
         // On hard delete, the row delete and the incident-edge cascade (including
         // already-soft-deleted edges) run as ONE write transaction: see
@@ -4413,7 +4435,13 @@ impl KhiveRuntime {
         // commit; it is best-effort and idempotent, unlike the row/edge pair.
         let deleted = if hard {
             let deleted = self
-                .atomic_hard_delete_with_edge_purge(entity_hard_delete_statement(id), id)
+                .atomic_hard_delete_with_edge_purge(
+                    entity_hard_delete_statement(id),
+                    id,
+                    &entity.namespace,
+                    &actor,
+                    SubstrateKind::Entity,
+                )
                 .await?;
             self.remove_from_indexes(&record_tok, id).await?;
             deleted
@@ -5091,6 +5119,7 @@ impl KhiveRuntime {
                 .map_err(|e| RuntimeError::Internal(format!("edge namespace invalid: {e}")))?,
         );
         let graph = self.graph(&record_tok)?;
+        let actor = format!("{}:{}", token.actor().kind, token.actor().id);
 
         // Cascade: on hard delete, remove ALL annotates edges targeting this edge — including
         // already-soft-deleted ones: to prevent dangling graph_edges rows. The row
@@ -5099,8 +5128,14 @@ impl KhiveRuntime {
         // On soft delete the cascade is skipped (data-vs-view principle: soft-deleting the base
         // edge does not cascade to annotation edges; only a hard purge cleans up incident rows).
         let deleted = if hard {
-            self.atomic_hard_delete_with_edge_purge(edge_hard_delete_statement(edge_id), edge_id)
-                .await?
+            self.atomic_hard_delete_with_edge_purge(
+                edge_hard_delete_statement(edge_id),
+                edge_id,
+                &record_ns,
+                &actor,
+                SubstrateKind::Entity,
+            )
+            .await?
         } else {
             graph.delete_edge(LinkId::from(edge_id), mode).await?
         };
@@ -11905,6 +11940,329 @@ mod tests {
             Some(SqlValue::Integer(n)) => n as u64,
             _ => panic!("count must return an integer"),
         }
+    }
+
+    async fn lineage_warning_events(
+        rt: &KhiveRuntime,
+        tok: &NamespaceToken,
+        target_id: Uuid,
+    ) -> Vec<Event> {
+        rt.events(tok)
+            .expect("event store")
+            .query_events(
+                EventFilter {
+                    kinds: vec![EventKind::Audit],
+                    ..Default::default()
+                },
+                PageRequest::default(),
+            )
+            .await
+            .expect("query warning events")
+            .items
+            .into_iter()
+            .filter(|event| event.target_id == Some(target_id))
+            .collect()
+    }
+
+    #[tokio::test]
+    async fn hard_delete_emits_relation_specific_lineage_warnings_only() {
+        let rt = rt();
+        let tok = NamespaceToken::local();
+        let doomed = rt
+            .create_entity(&tok, "document", None, "doomed", None, None, vec![])
+            .await
+            .unwrap();
+
+        let provenance_source = rt
+            .create_entity(&tok, "artifact", None, "source", None, None, vec![])
+            .await
+            .unwrap();
+        rt.link(
+            &tok,
+            provenance_source.id,
+            doomed.id,
+            EdgeRelation::DerivedFrom,
+            1.0,
+            None,
+        )
+        .await
+        .unwrap();
+
+        for (kind, name, relation) in [
+            ("document", "old", EdgeRelation::Supersedes),
+            ("document", "next", EdgeRelation::Precedes),
+            ("concept", "supported", EdgeRelation::Supports),
+            ("concept", "refuted", EdgeRelation::Refutes),
+        ] {
+            let target = rt
+                .create_entity(&tok, kind, None, name, None, None, vec![])
+                .await
+                .unwrap();
+            rt.link(&tok, doomed.id, target.id, relation, 1.0, None)
+                .await
+                .unwrap();
+        }
+        let unrelated = rt
+            .create_entity(&tok, "concept", None, "unrelated", None, None, vec![])
+            .await
+            .unwrap();
+        rt.link(
+            &tok,
+            unrelated.id,
+            doomed.id,
+            EdgeRelation::IntroducedBy,
+            1.0,
+            None,
+        )
+        .await
+        .unwrap();
+
+        assert!(rt.delete_entity(&tok, doomed.id, false).await.unwrap());
+        assert!(
+            lineage_warning_events(&rt, &tok, doomed.id)
+                .await
+                .is_empty(),
+            "soft delete must not emit cascade-loss warnings"
+        );
+
+        assert!(rt.delete_entity(&tok, doomed.id, true).await.unwrap());
+        let warnings = lineage_warning_events(&rt, &tok, doomed.id).await;
+        assert_eq!(warnings.len(), 5);
+
+        let mut actual = warnings
+            .iter()
+            .map(|event| {
+                assert_eq!(event.substrate, SubstrateKind::Entity);
+                assert_eq!(event.payload["severity"], "warning");
+                assert_eq!(event.payload["deleted_id"], doomed.id.to_string());
+                assert_eq!(event.payload["edge_count"], 1);
+                assert_eq!(event.payload["edges"].as_array().unwrap().len(), 1);
+                (
+                    event.payload["relation"].as_str().unwrap().to_string(),
+                    event.payload["warning"].as_str().unwrap().to_string(),
+                )
+            })
+            .collect::<Vec<_>>();
+        actual.sort();
+        assert_eq!(
+            actual,
+            vec![
+                ("derived_from".into(), "provenance_loss".into()),
+                ("precedes".into(), "temporal_sequence_loss".into()),
+                ("refutes".into(), "evidential_link_loss".into()),
+                ("supersedes".into(), "replacement_lineage_loss".into()),
+                ("supports".into(), "evidential_link_loss".into()),
+            ]
+        );
+        assert!(warnings
+            .iter()
+            .all(|event| event.payload["relation"] != "introduced_by"));
+    }
+
+    #[tokio::test]
+    async fn hard_delete_lineage_warning_is_filterable_by_caller_actor() {
+        let rt = rt();
+        let tok = NamespaceToken::mint_authorized(
+            Namespace::local(),
+            ActorRef::new("agent", "lineage-deleter"),
+        );
+        let expected_actor = "agent:lineage-deleter";
+        let doomed = rt
+            .create_entity(&tok, "document", None, "actor-doomed", None, None, vec![])
+            .await
+            .unwrap();
+        let source = rt
+            .create_entity(&tok, "artifact", None, "actor-source", None, None, vec![])
+            .await
+            .unwrap();
+        rt.link(
+            &tok,
+            source.id,
+            doomed.id,
+            EdgeRelation::DerivedFrom,
+            1.0,
+            None,
+        )
+        .await
+        .unwrap();
+
+        assert!(rt.delete_entity(&tok, doomed.id, true).await.unwrap());
+
+        let warnings = rt
+            .events(&tok)
+            .expect("event store")
+            .query_events(
+                EventFilter {
+                    kinds: vec![EventKind::Audit],
+                    actors: vec![expected_actor.to_string()],
+                    ..Default::default()
+                },
+                PageRequest::default(),
+            )
+            .await
+            .expect("query actor-filtered warning events")
+            .items
+            .into_iter()
+            .filter(|event| event.target_id == Some(doomed.id))
+            .collect::<Vec<_>>();
+        assert_eq!(warnings.len(), 1);
+        assert_eq!(warnings[0].actor, expected_actor);
+        assert_eq!(warnings[0].payload["relation"], "derived_from");
+    }
+
+    #[tokio::test]
+    async fn hard_delete_warns_for_tombstoned_protected_incident_edge() {
+        let rt = rt();
+        let tok = NamespaceToken::local();
+        let doomed = rt
+            .create_entity(
+                &tok,
+                "document",
+                None,
+                "tombstoned-edge-doomed",
+                None,
+                None,
+                vec![],
+            )
+            .await
+            .unwrap();
+        let source = rt
+            .create_entity(
+                &tok,
+                "artifact",
+                None,
+                "tombstoned-edge-source",
+                None,
+                None,
+                vec![],
+            )
+            .await
+            .unwrap();
+        let edge = rt
+            .link(
+                &tok,
+                source.id,
+                doomed.id,
+                EdgeRelation::DerivedFrom,
+                1.0,
+                None,
+            )
+            .await
+            .unwrap();
+        let edge_id = Uuid::from(edge.id);
+        assert!(rt.delete_edge(&tok, edge_id, false).await.unwrap());
+
+        assert!(rt.delete_entity(&tok, doomed.id, true).await.unwrap());
+
+        let warnings = lineage_warning_events(&rt, &tok, doomed.id).await;
+        assert_eq!(warnings.len(), 1);
+        assert_eq!(warnings[0].payload["edge_count"], 1);
+        let warned_edge = &warnings[0].payload["edges"].as_array().unwrap()[0];
+        assert_eq!(warned_edge["id"], edge_id.to_string());
+        assert!(
+            warned_edge["deleted_at"].is_number(),
+            "warning must preserve the edge's prior tombstone timestamp"
+        );
+        assert!(
+            rt.get_edge_including_deleted(&tok, edge_id)
+                .await
+                .unwrap()
+                .is_none(),
+            "the warned tombstoned edge must still be physically cascaded"
+        );
+    }
+
+    #[tokio::test]
+    async fn hard_delete_note_emits_evidential_lineage_warning() {
+        let rt = rt();
+        let tok = NamespaceToken::local();
+        let evidence = rt
+            .create_note(&tok, "observation", None, "evidence", None, None, vec![])
+            .await
+            .unwrap();
+        let claim = rt
+            .create_note(&tok, "insight", None, "claim", None, None, vec![])
+            .await
+            .unwrap();
+        rt.link(
+            &tok,
+            evidence.id,
+            claim.id,
+            EdgeRelation::Supports,
+            1.0,
+            None,
+        )
+        .await
+        .unwrap();
+
+        assert!(rt.delete_note(&tok, evidence.id, true).await.unwrap());
+        let warnings = lineage_warning_events(&rt, &tok, evidence.id).await;
+        assert_eq!(warnings.len(), 1);
+        assert_eq!(warnings[0].substrate, SubstrateKind::Note);
+        assert_eq!(warnings[0].payload["relation"], "supports");
+        assert_eq!(warnings[0].payload["warning"], "evidential_link_loss");
+    }
+
+    #[tokio::test]
+    async fn lineage_warning_insert_failure_rolls_back_hard_delete_and_cascade() {
+        let rt = rt();
+        let tok = NamespaceToken::local();
+        let doomed = rt
+            .create_entity(&tok, "document", None, "doomed", None, None, vec![])
+            .await
+            .unwrap();
+        let source = rt
+            .create_entity(&tok, "artifact", None, "source", None, None, vec![])
+            .await
+            .unwrap();
+        let edge = rt
+            .link(
+                &tok,
+                source.id,
+                doomed.id,
+                EdgeRelation::DerivedFrom,
+                1.0,
+                None,
+            )
+            .await
+            .unwrap();
+
+        let mut writer = rt.sql().writer().await.expect("sql writer");
+        writer
+            .execute_script(
+                "CREATE TRIGGER reject_lineage_warning \
+                 BEFORE INSERT ON events \
+                 WHEN NEW.kind = 'audit' \
+                   AND json_extract(NEW.payload, '$.severity') = 'warning' \
+                 BEGIN \
+                   SELECT RAISE(ABORT, 'injected lineage warning failure'); \
+                 END;"
+                    .into(),
+            )
+            .await
+            .expect("install warning failure trigger");
+        drop(writer);
+
+        let error = rt.delete_entity(&tok, doomed.id, true).await.unwrap_err();
+        assert!(error
+            .to_string()
+            .contains("injected lineage warning failure"));
+        assert!(
+            rt.entities(&tok)
+                .unwrap()
+                .get_entity(doomed.id)
+                .await
+                .unwrap()
+                .is_some(),
+            "the endpoint row must roll back with the failed warning insert"
+        );
+        assert!(
+            rt.get_edge(&tok, Uuid::from(edge.id))
+                .await
+                .unwrap()
+                .is_some(),
+            "the incident edge must roll back with the failed warning insert"
+        );
     }
 
     #[tokio::test]

--- a/docs/adr/ADR-002-edge-ontology.md
+++ b/docs/adr/ADR-002-edge-ontology.md
@@ -17,6 +17,8 @@ Rationale.
 `Document derived_from Document` — for publication provenance: a curated or filtered
 publication copy of a document points at the canonical source it was produced from. See
 "Base endpoint contract" below and "Why the 2026-07-27 provenance amendment?" in Rationale.
+**Amended 2026-07-31**: hard-delete cascade warnings use the existing `audit` event kind and
+carry a relation-specific payload atomically with the delete, as specified in "Cascade Behavior."
 
 ## Context
 
@@ -469,6 +471,14 @@ For provenance/lineage-sensitive relations, hard-delete cascade emits a warning 
 | `supports` / `refutes` | cascade edge; emit evidential-link-loss warning     |
 | `annotates`            | cascade as documented                               |
 | others                 | cascade normally                                    |
+
+Warnings use the existing `audit` event kind and target the hard-deleted record. The runtime
+emits one warning per affected protected relation, in the same transaction as the delete and
+edge cascade, with payload fields `severity="warning"`, `warning`, `deleted_id`, `relation`,
+`edge_count`, and `edges`. `warning` is `provenance_loss`, `replacement_lineage_loss`,
+`temporal_sequence_loss`, or `evidential_link_loss` as named by the table above; each `edges`
+entry preserves the removed edge's id, namespace, endpoints, and prior `deleted_at` value.
+Relations absent from the incident-edge set emit no warning.
 
 No hard blocks on delete. If stronger provenance guarantees are needed later, add tombstones
 or immutable lineage records in a separate ADR.


### PR DESCRIPTION
## Summary

- emit an actor-attributed audit warning before a hard delete cascades incident lineage or evidential edges
- cover `derived_from`, `supersedes`, `precedes`, `supports`, and `refutes` without warning for unrelated relations or soft deletes
- keep the warning in the same transaction as both canonical and atomic hard-delete paths, including tombstoned incident edges
- document the lineage-loss audit contract in ADR-002

Fixes #1415.

## Behavior

Hard-deleting an entity or note now records one `EventKind::Audit` warning per affected
lineage/evidential edge before the database cascade removes it. The payload identifies only the
deleted record, relation, edge, opposite endpoint, and tombstone state; it does not copy note or
entity content. The event carries the initiating request actor. If the delete transaction rolls
back, its warnings roll back with it, and atomic batches use the same preparation logic as the
canonical path.

## Validation

- `cargo test -p khive-db -p khive-runtime -p khive-pack-memory --all-features`
- `cargo check -p khive-db -p khive-runtime -p khive-pack-memory --all-targets --all-features`
- `cargo clippy -p khive-db -p khive-runtime -p khive-pack-memory --all-targets --all-features -- -D warnings`
- `cargo fmt --all -- --check`
- `RUSTDOCFLAGS='-D warnings' cargo doc -p khive-db -p khive-runtime -p khive-pack-memory --all-features --no-deps`
- `make docs-check`
- `sh scripts/lint-adr-refs.sh`
- `sh scripts/lint-adr-refs.sh --self-test`
- `sh scripts/lint-sql.sh`
- `sh scripts/lint-stub-markers.sh` and `--self-test`
- `git diff --check`

The full package suites passed, including database, runtime, memory-pack,
integration, and doctest coverage. The branch was tested at exact commit
`b0e4a93507dda9638bb1bbc92d1287855fad74b6` on current `main`
`9ae60fceafe15672533a9d25341f45183801ddec`.

> AI-assisted contribution: Codex prepared this change and PR description.
