### PR TITLE
fix(git): report secret-gate write refusals

### DIFF
--- a/crates/khive-pack-git/docs/api/ingest.md
+++ b/crates/khive-pack-git/docs/api/ingest.md
@@ -24,6 +24,22 @@ pass (ADR-088 Amendment 1 `max_items`). Only creation attempts (success or
 failure) consume budget — cheap natural-key "already exists" skips do not,
 since they are not the work the bound exists to limit.
 
+## Secret-gate refusal accounting
+
+`run_ingest` keeps its established per-record fail-closed/continue behavior: a refused
+`create` does not land and freezes that section's cursor, while clean sibling records are
+still attempted. The result makes that partial outcome mechanically visible through
+`IngestReport::writes_refused` and `IngestReport::write_refusals`, in addition to the
+human-readable warning. Only `RuntimeError::SecretDetected` increments this counter;
+ordinary validation, storage, and embedding failures remain warnings but are not
+misclassified as secret-gate refusals.
+
+Each structured detail names `verb=create`, the provenance record kind, and a trusted
+natural key (commit SHA or GitHub number), plus `SecretMatch`'s detector and masked
+excerpt. It never includes the rejected content. Accounting is per ingest call rather
+than process-global daemon telemetry, so a caller can reliably assert
+`writes_refused == 0` even when other digests run concurrently.
+
 ## `NewRecordForRef`
 
 A newly created note this pass, retained so the post-ingestion

--- a/crates/khive-pack-git/src/ingest.rs
+++ b/crates/khive-pack-git/src/ingest.rs
@@ -14,7 +14,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::json;
 use uuid::Uuid;
 
-use khive_runtime::{secret_gate, KhiveRuntime, NamespaceToken, VerbRegistry};
+use khive_runtime::{secret_gate, KhiveRuntime, NamespaceToken, RuntimeError, VerbRegistry};
 use khive_storage::types::{SqlStatement, SqlValue};
 
 use crate::hook;
@@ -99,6 +99,21 @@ struct NewRecordForRef {
     text: String,
 }
 
+/// Caller-visible detail for one content write the secret gate refused.
+///
+/// The record key is a trusted natural key (commit SHA or GitHub number),
+/// and the secret itself is represented only by [`secret_gate::SecretMatch`]'s
+/// detector name and masked excerpt. The rejected content is never copied
+/// into the report.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct IngestWriteRefusal {
+    pub verb: String,
+    pub record_kind: String,
+    pub record_key: String,
+    pub detector: String,
+    pub masked: String,
+}
+
 /// Outcome of one ingest pass. Serializable so CLI callers can emit it as JSON.
 #[derive(Debug, Default, Serialize)]
 pub struct IngestReport {
@@ -112,6 +127,14 @@ pub struct IngestReport {
     /// skipped but commits still ingested (ADR-088 §5 graceful-absence rule).
     pub gh_available: bool,
     pub warnings: Vec<String>,
+    /// Number of per-record content writes refused by the runtime secret gate
+    /// during this pass. Callers can assert this is zero independently of
+    /// unrelated warnings.
+    pub writes_refused: u64,
+    /// Safe structured details for every entry counted by `writes_refused`.
+    /// Each item names the refused verb and record without echoing the
+    /// rejected content.
+    pub write_refusals: Vec<IngestWriteRefusal>,
     /// `false` when `max_items` was exhausted before this pass reached the
     /// end of every included kind's history — callers loop until `true`
     /// (ADR-088 Amendment 1). Always `true` for an unbounded
@@ -166,6 +189,28 @@ pub struct IngestReport {
     /// to compare directly against an independent source of truth (e.g.
     /// `git rev-list --count <ref>`).
     pub commits_total_in_db: u64,
+}
+
+fn record_write_failure(
+    report: &mut IngestReport,
+    verb: &str,
+    record_kind: &str,
+    record_key: String,
+    error: RuntimeError,
+) {
+    if let RuntimeError::SecretDetected(secret) = &error {
+        report.writes_refused += 1;
+        report.write_refusals.push(IngestWriteRefusal {
+            verb: verb.to_string(),
+            record_kind: record_kind.to_string(),
+            record_key: record_key.clone(),
+            detector: secret.detector.to_string(),
+            masked: secret.masked.clone(),
+        });
+    }
+    report
+        .warnings
+        .push(format!("{verb} {record_kind} {record_key}: {error}"));
 }
 
 /// Run one ingest pass over `opts.repo`: issues + PRs first (via `gh`, when
@@ -1084,9 +1129,7 @@ async fn ingest_commits(
                 }
             }
             Err(e) => {
-                report
-                    .warnings
-                    .push(format!("create commit {}: {e}", c.sha));
+                record_write_failure(report, "create", "commit", c.sha.clone(), e);
                 cursor_stalled = true;
             }
         }
@@ -1559,9 +1602,13 @@ async fn ingest_prs(
             {
                 Ok(v) => v,
                 Err(e) => {
-                    report
-                        .warnings
-                        .push(format!("create pull_request #{}: {e}", masked.number));
+                    record_write_failure(
+                        report,
+                        "create",
+                        "pull_request",
+                        format!("#{}", masked.number),
+                        e,
+                    );
                     cursor_stalled = true;
                     continue;
                 }
@@ -1752,7 +1799,7 @@ async fn ingest_issues(
             {
                 Ok(v) => v,
                 Err(e) => {
-                    report.warnings.push(format!("create issue #{number}: {e}"));
+                    record_write_failure(report, "create", "issue", format!("#{number}"), e);
                     cursor_stalled = true;
                     continue;
                 }

--- a/crates/khive-pack-git/src/vocab.rs
+++ b/crates/khive-pack-git/src/vocab.rs
@@ -79,7 +79,8 @@ pub(crate) static GIT_HANDLERS: [HandlerDef; 4] = [
         name: "git.digest",
         description: "Ingest commit/issue/pull_request provenance from a local git repo path or \
                        an https:// URL into the graph. Bounded and cursor-resumable: call \
-                       repeatedly until the response's `done` field is true.",
+                       repeatedly until the response's `done` field is true. Check \
+                       `writes_refused` is zero before treating a completed pass as clean.",
         visibility: Visibility::Verb,
         category: VerbCategory::Commissive,
         params: &[

--- a/crates/khive-pack-git/tests/acceptance.rs
+++ b/crates/khive-pack-git/tests/acceptance.rs
@@ -1885,6 +1885,11 @@ async fn issue_ingest_never_echoes_credential_shaped_state_reason() {
         "the raw credential-shaped stateReason must never appear in report.warnings: {:?}",
         report.warnings
     );
+    assert_eq!(
+        report.writes_refused, 0,
+        "a governed-field validation failure is not a secret-gate refusal"
+    );
+    assert!(report.write_refusals.is_empty());
 
     let issues_list = registry
         .dispatch("list", json!({"kind": "issue", "limit": 10}))
@@ -3135,6 +3140,122 @@ async fn digest_verb_auto_creates_project_and_enriches_references() {
         precedes_hits[0]["id"].as_str().unwrap(),
         closing["id"].as_str().unwrap()
     );
+}
+
+/// A per-record secret-gate refusal remains non-fatal so the rest of the
+/// digest can land, but the public result must make the partial outcome
+/// mechanically detectable and identify the refused write without echoing
+/// the rejected content.
+#[tokio::test]
+async fn digest_verb_counts_and_describes_partial_secret_gate_refusals() {
+    let _guard = ENV_MUTEX.lock().await;
+    let (_rt, _token, registry) = fixture().await;
+
+    let project_id = create(
+        &registry,
+        json!({"kind": "project", "name": "refusal-accounting-repo"}),
+    )
+    .await;
+
+    let dir = tempfile::tempdir().expect("tempdir");
+    let repo: PathBuf = dir.path().join("repo");
+    std::fs::create_dir_all(&repo).expect("mk repo dir");
+    init_repo(&repo);
+
+    let bin_dir = dir.path().join("bin");
+    std::fs::create_dir_all(&bin_dir).expect("mk bin dir");
+    let log_dir = dir.path().join("log");
+    std::fs::create_dir_all(&log_dir).expect("mk log dir");
+
+    const CREDENTIAL: &str = "ghp_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+    let pr_json = json!([
+        {
+            "number": 1,
+            "title": "clean pull request",
+            "author": {"login": "contributor"},
+            "createdAt": "2026-01-01T00:00:00Z",
+            "mergedAt": null,
+            "closedAt": null,
+            "updatedAt": "2026-01-01T00:00:00Z",
+            "baseRefName": "main",
+            "headRefName": "feature/clean",
+            "mergeCommit": null,
+            "body": "ordinary content"
+        },
+        {
+            "number": 2,
+            "title": "refused pull request",
+            "author": {"login": "contributor"},
+            "createdAt": CREDENTIAL,
+            "mergedAt": null,
+            "closedAt": null,
+            "updatedAt": "2026-01-02T00:00:00Z",
+            "baseRefName": "main",
+            "headRefName": "feature/refused",
+            "mergeCommit": null,
+            "body": "ordinary content"
+        }
+    ])
+    .to_string();
+    write_fake_gh(&bin_dir, &log_dir, &pr_json, "[]");
+    let _path_guard = PathGuard::install(&bin_dir);
+
+    let result = registry
+        .dispatch(
+            "git.digest",
+            json!({
+                "source": repo.to_str().expect("utf-8 repo path"),
+                "project": project_id.to_string(),
+                "max_items": 10,
+                "include": ["pull_requests"]
+            }),
+        )
+        .await
+        .expect("a partial refusal remains an in-band digest result");
+
+    assert_eq!(
+        result["prs_ingested"], 1,
+        "the clean write must land: {result}"
+    );
+    assert_eq!(
+        result["writes_refused"], 1,
+        "callers must be able to assert zero refused writes: {result}"
+    );
+    let refusals = result["write_refusals"]
+        .as_array()
+        .expect("write_refusals array");
+    assert_eq!(refusals.len(), 1, "one detail per counted refusal");
+    assert_eq!(refusals[0]["verb"], "create");
+    assert_eq!(refusals[0]["record_kind"], "pull_request");
+    assert_eq!(refusals[0]["record_key"], "#2");
+    assert!(
+        refusals[0]["detector"]
+            .as_str()
+            .is_some_and(|d| !d.is_empty()),
+        "the detector must be named: {refusals:?}"
+    );
+    assert!(
+        refusals[0]["masked"]
+            .as_str()
+            .is_some_and(|m| !m.is_empty()),
+        "the masked diagnostic must be present: {refusals:?}"
+    );
+    assert!(
+        !result.to_string().contains(CREDENTIAL),
+        "the rejected content must never be copied into the result: {result}"
+    );
+
+    let stored = registry
+        .dispatch("list", json!({"kind": "pull_request", "limit": 10}))
+        .await
+        .expect("list pull requests");
+    let numbers: Vec<u64> = stored
+        .as_array()
+        .expect("list result array")
+        .iter()
+        .filter_map(|item| item["properties"]["number"].as_u64())
+        .collect();
+    assert_eq!(numbers, vec![1], "only the clean record may persist");
 }
 
 /// `max_items` bounds work per call and the response is cursor-resumable:

--- a/crates/kkernel/src/git_ingest.rs
+++ b/crates/kkernel/src/git_ingest.rs
@@ -89,13 +89,14 @@ pub async fn run_git_ingest(args: GitIngestArgs) -> Result<()> {
 
     if args.human {
         println!(
-            "commits: {} ingested, {} skipped\nissues: {} ingested, {} skipped\nprs: {} ingested, {} skipped\ngh_available: {}",
+            "commits: {} ingested, {} skipped\nissues: {} ingested, {} skipped\nprs: {} ingested, {} skipped\nwrites refused by secret gate: {}\ngh_available: {}",
             report.commits_ingested,
             report.commits_skipped_existing,
             report.issues_ingested,
             report.issues_skipped_existing,
             report.prs_ingested,
             report.prs_skipped_existing,
+            report.writes_refused,
             report.gh_available,
         );
         for w in &report.warnings {

--- a/docs/adr/ADR-088-amendment-1-git-digest.md
+++ b/docs/adr/ADR-088-amendment-1-git-digest.md
@@ -55,7 +55,13 @@ git.digest(source, project?, max_items?, include?)
 Return shape: the existing `IngestReport` (counts, skips, warnings, `gh_available`)
 extended with `done: bool`, `project_id`, `project_created: bool`, and
 `commit_embeddings_truncated: u64` (count of commits whose vector-embedding input was
-capped this pass; see "Commit embedding truncation" below).
+capped this pass; see "Commit embedding truncation" below). It also includes
+`writes_refused: u64` and `write_refusals: [...]`: a per-call secret-gate refusal count
+and one safe structured diagnostic per refused record write. Each diagnostic names the
+attempted verb, record kind, trusted natural key, detector, and masked excerpt; it never
+copies the rejected content. Per-record refusal remains non-fatal so the pass can surface
+all affected records and ingest clean siblings, but a caller requiring a clean run must
+assert `writes_refused == 0` as well as loop until `done == true`.
 
 ### Remote-URL mode
 
@@ -84,7 +90,10 @@ capped this pass; see "Commit embedding truncation" below).
 - Local-path mode requires an absolute path; relative paths are rejected. The path must
   contain a `.git` directory; arbitrary directory walking is not performed.
 - Secret masking is unchanged: ingested text goes through the same `create`-verb gate
-  (ADR-088 acceptance note 5). Blocked writes surface as report warnings, fail-closed.
+  (ADR-088 acceptance note 5). Blocked writes remain fail-closed and surface both as
+  warnings and through the result's `writes_refused` / `write_refusals` contract. This
+  accounting is call-local rather than a process-global daemon counter, so overlapping
+  digest calls cannot make one caller's zero-refusal assertion ambiguous.
 - Namespace/attribution: writes stamp the caller's token namespace exactly as the CLI
   ingester does today; no new authorization surface. The Gate (ADR-018) remains the
   authorization seam for callers who should not write.

--- a/docs/guide/api-reference.md
+++ b/docs/guide/api-reference.md
@@ -1612,6 +1612,13 @@ response's `done` field is `false`.
 request(ops="git.digest(source=\"https://github.com/org/repo\", max_items=500)")
 ```
 
+The result includes `writes_refused`, a per-call count of record writes blocked by the
+secret gate, and `write_refusals`, one safe structured diagnostic per refusal. Each
+diagnostic names the attempted `verb`, the provenance `record_kind` and natural
+`record_key`, plus the detector and a masked excerpt; rejected content is never returned.
+Because a digest continues after a per-record refusal, callers that require a clean run
+should assert `writes_refused == 0` in addition to waiting for `done == true`.
+
 ### `git.commit` / `git.branch` / `git.push` — Commissive (ADR-108)
 
 Thin write verbs that shell to system git (`std::process::Command::args`, no shell


### PR DESCRIPTION
## Summary

- make every `git.digest` result explicitly report `writes_refused` and structured `write_refusals`
- count only actual `RuntimeError::SecretDetected` content-write refusals while preserving the existing non-fatal cursor-stall behavior
- expose safe diagnostic metadata (verb, kind, source key/SHA, detector, and masked value) without echoing refused content
- cover commit, issue, and pull-request ingestion plus a real mixed clean/refused digest regression

Fixes #1420.

## Behavior

Callers can now treat `writes_refused == 0` as an explicit success condition. A refused write remains
non-fatal, but the normal result reports the count and a diagnostic record for each refusal. Other
runtime errors are not misclassified, and refused records do not advance ingestion cursors, so a later
clean run can retry them. The returned diagnostics contain no raw secret-bearing content.

## Validation

- `cargo test -p khive-pack-git -p kkernel --all-features`
- `cargo check -p khive-pack-git -p kkernel --all-targets --all-features`
- `cargo clippy -p khive-pack-git -p kkernel --all-targets --all-features -- -D warnings`
- `cargo fmt --all -- --check`
- `RUSTDOCFLAGS='-D warnings' cargo doc -p khive-pack-git -p kkernel --all-features --no-deps`
- `make docs-check`
- `sh scripts/lint-adr-refs.sh`
- `deno fmt --check`
- `git diff --check`

The full package suites passed, including 212 `khive-pack-git` unit tests, 55 acceptance tests,
305 `kkernel` unit tests, all affected integration tests, and doctests. The branch was tested at
exact commit `6f47c25a62b948be2ae757e7f51ea4afbea49672` on current `main`
`50dff4e16d77c69e02b99fe252b76e41a2a97867`.

> AI-assisted contribution: Codex prepared this change and PR description.
