### PR TITLE
fix(vectors): make subject deletion atomic

### DIFF
--- a/crates/khive-db/docs/api/vectors.md
+++ b/crates/khive-db/docs/api/vectors.md
@@ -30,12 +30,26 @@ whenever those calls are reached), so there is no double-routing.
 `with_writer_unmanaged` bypasses the WriterTask channel unconditionally
 regardless of `KHIVE_WRITE_QUEUE`. Reserved for closures that manage their
 own transaction — those cannot be sent through the WriterTask channel, which
-already wraps every request in its own transaction. `orphan_sweep`'s
-flag-off path (`Transaction::new_unchecked`, its own manual `BEGIN
-IMMEDIATE`) is the only caller — on the flag-on path `orphan_sweep` routes a
-DML-only closure directly through the WriterTask instead, since routing a
-`Transaction::new_unchecked` through the channel would nest a transaction
-inside the WriterTask's own transaction.
+already wraps every request in its own transaction. The flag-off paths for
+`delete_subjects` and `orphan_sweep` use it with
+`Transaction::new_unchecked` (their own `BEGIN IMMEDIATE`); their flag-on
+paths route DML-only closures directly through the WriterTask instead, since
+routing `Transaction::new_unchecked` through the channel would nest a
+transaction inside the WriterTask's own transaction.
+
+## `delete_subjects` — atomic multi-chunk deletion (#1432)
+
+`delete_subjects` splits inputs into statements of at most 400 IDs to stay
+below SQLite's variable limit, but submits the complete DML loop as one
+WriterTask request when the queue is enabled. The task's own transaction wraps
+the entire input. On the legacy unmanaged path, one RAII
+`Transaction::new_unchecked` wraps the same complete DML loop; its Drop
+rollback also cleans up an open transaction when `COMMIT` itself fails.
+
+The operation is therefore all-or-nothing across the full input. If vector or
+ANN-log DML fails in any later chunk, or the unmanaged commit fails, the store
+rolls back every earlier chunk, including its matching `ann_write_log` rows,
+before returning the error.
 
 ## `replace_vector_row_dml` — shared DELETE-then-INSERT replacement (#546)
 
@@ -81,6 +95,7 @@ second record is the final readable value.
 The sentinel tests (`insert_batch_rollback_restores_deleted_stale_after_post_delete_insert_failure`
 and its `update` counterpart) use a `cfg(test)` failpoint that fires AFTER a
 successful same-namespace DELETE and BEFORE the INSERT. This means:
+
 - The stale row is genuinely gone from the DB when the error fires.
 - Only a correct ROLLBACK TO SAVEPOINT (or `tx.rollback`) restores it.
 - Removing those rollback lines WILL make these tests fail.
@@ -102,8 +117,9 @@ removes the stale row, then the failpoint fires before INSERT.
 
 Expected: `ROLLBACK TO SAVEPOINT vec_batch_record` restores the stale row —
 `batch_exists` finds id_X in ns:a, search with vec1 returns similarity
+
 > 0.999 (not vec2), and `BatchWriteSummary` reports attempted=1, affected=0,
-failed=1.
+> failed=1.
 
 FAILURE MODE: deleting the `ROLLBACK TO SAVEPOINT vec_batch_record` line
 from `insert_batch` makes this test fail — the stale row is gone.
@@ -120,8 +136,9 @@ failpoint fires before INSERT.
 
 Expected: `unchecked_transaction` rolls back, restoring the stale row —
 `batch_exists` finds id_X in ns:a, search with vec1 returns similarity
+
 > 0.999 (not vec2), and `update` returns `Err` (the injected error
-propagates out).
+> propagates out).
 
 FAILURE MODE: removing the transaction's rollback from `update` makes this
 test fail — the stale row is gone.

--- a/crates/khive-db/src/stores/vectors.rs
+++ b/crates/khive-db/src/stores/vectors.rs
@@ -426,6 +426,42 @@ fn log_vector_deletes(
     Ok(())
 }
 
+/// DML-only multi-chunk subject deletion shared by both the legacy
+/// (flag-off) and WriterTask-routed (flag-on) `delete_subjects` paths.
+///
+/// Issues no `BEGIN` / `COMMIT` / `ROLLBACK` / `SAVEPOINT`: the caller owns
+/// one transaction around the complete input so a failure in any later chunk
+/// rolls back every earlier vector deletion and matching ANN-log row.
+fn delete_vector_subjects_dml(
+    conn: &rusqlite::Connection,
+    table: &str,
+    id_strings: &[String],
+) -> Result<u64, rusqlite::Error> {
+    let mut total_deleted = 0u64;
+
+    // Batch in ≤400 IDs per statement to stay within SQLite's variable limit.
+    for chunk in id_strings.chunks(400) {
+        let placeholders = (1..=chunk.len())
+            .map(|i| format!("?{i}"))
+            .collect::<Vec<_>>()
+            .join(", ");
+        let in_clause = format!("subject_id IN ({placeholders})");
+        let params: Vec<&dyn rusqlite::ToSql> =
+            chunk.iter().map(|id| id as &dyn rusqlite::ToSql).collect();
+
+        log_vector_deletes(conn, table, &in_clause, &params)?;
+
+        let sql = format!("DELETE FROM {table} WHERE {in_clause}");
+        let mut stmt = conn.prepare(&sql)?;
+        for (index, id) in chunk.iter().enumerate() {
+            stmt.raw_bind_parameter(index + 1, id.as_str())?;
+        }
+        total_deleted += stmt.raw_execute()? as u64;
+    }
+
+    Ok(total_deleted)
+}
+
 /// Delete `subject_id`'s row from every registered-model vector table, in
 /// `namespace` (#546).
 ///
@@ -1196,55 +1232,48 @@ impl VectorStore for SqliteVecStore {
         }
         let table = self.table_name.clone();
         let id_strings: Vec<String> = ids.iter().map(|id| id.to_string()).collect();
-        let mut total_deleted: u64 = 0;
 
-        // Batch in ≤400 IDs per statement to stay within SQLite's variable limit.
-        for chunk in id_strings.chunks(400) {
-            let placeholders: String = (1..=chunk.len())
-                .map(|i| format!("?{i}"))
-                .collect::<Vec<_>>()
-                .join(", ");
-            let sql = format!("DELETE FROM {table} WHERE subject_id IN ({placeholders})");
-            let in_clause = format!("subject_id IN ({placeholders})");
-            let chunk_owned = chunk.to_vec();
-            let table_cl = table.clone();
-            let table_sp = table.clone();
-            let deleted = self
-                .with_writer("vec_delete_subjects", move |conn| {
-                    conn.execute_batch("SAVEPOINT vec_delete_subjects_log")?;
-                    let result = (|| {
-                        let params: Vec<&dyn rusqlite::ToSql> = chunk_owned
-                            .iter()
-                            .map(|s| s as &dyn rusqlite::ToSql)
-                            .collect();
-                        log_vector_deletes(conn, &table_sp, &in_clause, &params)?;
-                        let mut stmt = conn.prepare(&sql)?;
-                        for (i, id_str) in chunk_owned.iter().enumerate() {
-                            stmt.raw_bind_parameter(i + 1, id_str.as_str())?;
-                        }
-                        stmt.raw_execute().map(|n| n as u64)
-                    })();
-                    match result {
-                        Ok(n) => {
-                            conn.execute_batch("RELEASE SAVEPOINT vec_delete_subjects_log")?;
-                            Ok(n)
-                        }
-                        Err(e) => {
-                            let _ =
-                                conn.execute_batch("ROLLBACK TO SAVEPOINT vec_delete_subjects_log");
-                            let _ = conn.execute_batch("RELEASE SAVEPOINT vec_delete_subjects_log");
-                            Err(e)
-                        }
-                    }
+        // The WriterTask owns one BEGIN IMMEDIATE/COMMIT/ROLLBACK around each
+        // request. Submit the complete chunk loop as one DML-only request so a
+        // failure in any chunk makes the task roll back the complete input.
+        if let Some(writer_task) = &self.writer_task {
+            let table_for_error = table.clone();
+            return writer_task
+                .send(move |conn| {
+                    delete_vector_subjects_dml(conn, &table, &id_strings)
+                        .map_err(|e| map_err(e, "vec_delete_subjects"))
                 })
                 .await
                 .map_err(|e| {
-                    tracing::warn!(error = %e, table = %table_cl, "delete_subjects chunk failed");
+                    tracing::warn!(error = %e, table = %table_for_error, "delete_subjects failed");
                     e
-                })?;
-            total_deleted += deleted;
+                });
         }
-        Ok(total_deleted)
+
+        // The unmanaged path must own an RAII transaction rather than use an
+        // outermost SAVEPOINT. `Transaction` rolls back on early DML errors and
+        // also when COMMIT fails while SQLite leaves the transaction open,
+        // preventing a poisoned transaction from returning to the pool.
+        let table_for_error = table.clone();
+        let origin = self.pool.origin();
+        self.with_writer_unmanaged("vec_delete_subjects", move |conn| {
+            let _tx_handle = khive_storage::tx_registry::register_scoped(
+                Some("vec_delete_subjects".to_string()),
+                origin,
+            );
+            let tx = rusqlite::Transaction::new_unchecked(
+                conn,
+                rusqlite::TransactionBehavior::Immediate,
+            )?;
+            let deleted = delete_vector_subjects_dml(conn, &table, &id_strings)?;
+            tx.commit()?;
+            Ok(deleted)
+        })
+        .await
+        .map_err(|e| {
+            tracing::warn!(error = %e, table = %table_for_error, "delete_subjects failed");
+            e
+        })
     }
 
     async fn batch_exists(
@@ -1947,6 +1976,354 @@ mod capabilities_tests {
         assert_eq!(
             caps1 as *const _, caps2 as *const _,
             "capabilities() must return the same static reference each call"
+        );
+    }
+}
+
+#[cfg(all(test, feature = "vectors"))]
+mod delete_subjects_atomic_tests {
+    use std::sync::Arc;
+
+    use khive_storage::types::VectorRecord;
+    use khive_storage::VectorStore;
+    use khive_types::SubstrateKind;
+    use uuid::Uuid;
+
+    use super::*;
+    use crate::pool::{ConnectionPool, PoolConfig};
+
+    fn create_vec_table(pool: &Arc<ConnectionPool>, model_key: &str, dims: usize) {
+        let ddl = format!(
+            "CREATE VIRTUAL TABLE IF NOT EXISTS vec_{} USING vec0(\
+             subject_id TEXT PRIMARY KEY, \
+             namespace TEXT NOT NULL, \
+             kind TEXT NOT NULL, \
+             field TEXT NOT NULL, \
+             embedding_model TEXT NOT NULL, \
+             embedding float[{}] distance_metric=cosine)",
+            model_key, dims
+        );
+        let writer = pool.try_writer().expect("pool writer");
+        writer.conn().execute_batch(&ddl).expect("create vec table");
+        writer
+            .conn()
+            .execute_batch(crate::migrations::ANN_WRITE_LOG_DDL)
+            .expect("create ann_write_log");
+    }
+
+    async fn assert_later_chunk_failure_rolls_back_all(write_queue_enabled: bool) {
+        crate::extension::ensure_extensions_loaded();
+
+        let model_key = if write_queue_enabled {
+            "delete_subjects_atomic_queue"
+        } else {
+            "delete_subjects_atomic_legacy"
+        };
+        let dims = 4usize;
+        let namespace = "ns:delete_subjects_atomic";
+        let dir = tempfile::tempdir().expect("temporary database directory");
+        let path = dir.path().join(format!("{model_key}.db"));
+        let pool = Arc::new(
+            ConnectionPool::new(PoolConfig {
+                path: Some(path),
+                write_queue_enabled,
+                ..PoolConfig::default()
+            })
+            .expect("file-backed pool"),
+        );
+        create_vec_table(&pool, model_key, dims);
+
+        let store = Arc::new(
+            SqliteVecStore::new(
+                Arc::clone(&pool),
+                true,
+                model_key.to_string(),
+                model_key.to_string(),
+                dims,
+                namespace.to_string(),
+            )
+            .expect("SqliteVecStore::new"),
+        );
+        assert_eq!(
+            pool.writer_task_spawn_count(),
+            if write_queue_enabled { 1 } else { 0 },
+            "test setup must exercise the requested writer mode"
+        );
+        assert_eq!(
+            store.writer_task.is_some(),
+            write_queue_enabled,
+            "the store must retain a WriterTask handle exactly when requested"
+        );
+
+        let ids: Vec<Uuid> = (0..401).map(|_| Uuid::new_v4()).collect();
+        let records = ids
+            .iter()
+            .map(|subject_id| VectorRecord {
+                subject_id: *subject_id,
+                kind: SubstrateKind::Entity,
+                namespace: namespace.to_string(),
+                field: "body".to_string(),
+                embedding_model: None,
+                vectors: vec![vec![0.1, 0.2, 0.3, 0.4]],
+                updated_at: chrono::Utc::now(),
+            })
+            .collect();
+        let summary = store.insert_batch(records).await.expect("seed vectors");
+        assert_eq!(summary.attempted, 401);
+        assert_eq!(summary.affected, 401);
+        assert_eq!(summary.failed, 0);
+
+        {
+            let writer = pool.try_writer().expect("pool writer");
+            writer
+                .conn()
+                .execute("DELETE FROM ann_write_log", [])
+                .expect("clear seed log rows");
+            let trigger = format!(
+                "CREATE TRIGGER fail_second_delete_subjects_chunk \
+                 BEFORE INSERT ON ann_write_log \
+                 WHEN NEW.op = 'delete' AND NEW.subject_id = '{}' \
+                 BEGIN \
+                     SELECT RAISE(ABORT, 'injected later-chunk delete failure'); \
+                 END;",
+                ids[400]
+            );
+            writer
+                .conn()
+                .execute_batch(&trigger)
+                .expect("install later-chunk failure trigger");
+        }
+
+        let delete_result = if write_queue_enabled {
+            // A spawn counter or non-None handle only proves setup. Hold the
+            // WriterTask's single drain slot, start delete_subjects, and
+            // observe its request waiting in the channel to prove this exact
+            // operation uses the queued path.
+            let writer_task = store
+                .writer_task
+                .clone()
+                .expect("queue-enabled store must retain its writer task");
+            let (started_tx, started_rx) = tokio::sync::oneshot::channel::<()>();
+            let (release_tx, release_rx) = tokio::sync::oneshot::channel::<()>();
+            let occupier = {
+                let writer_task = writer_task.clone();
+                tokio::spawn(async move {
+                    writer_task
+                        .send(move |_conn| {
+                            let _ = started_tx.send(());
+                            let _ = release_rx.blocking_recv();
+                            Ok::<(), StorageError>(())
+                        })
+                        .await
+                })
+            };
+
+            started_rx
+                .await
+                .expect("occupier must start inside the writer task");
+            assert_eq!(
+                writer_task.queue_depth(),
+                0,
+                "the channel must be empty after dequeuing the occupier"
+            );
+
+            let delete_task = {
+                let store = Arc::clone(&store);
+                let ids = ids.clone();
+                tokio::spawn(async move { store.delete_subjects(&ids).await })
+            };
+
+            let mut saw_enqueued = false;
+            for _ in 0..100 {
+                if writer_task.queue_depth() >= 1 {
+                    saw_enqueued = true;
+                    break;
+                }
+                tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+            }
+
+            // Always unblock and join both tasks before asserting so a failed
+            // routing assertion cannot strand the blocking occupier.
+            release_tx
+                .send(())
+                .expect("occupier must still be waiting for release");
+            occupier
+                .await
+                .expect("occupier task must not panic")
+                .expect("occupier write must succeed");
+            let result = delete_task.await.expect("delete task must not panic");
+            assert!(
+                saw_enqueued,
+                "delete_subjects never appeared in the WriterTask channel while its drain slot \
+                 was occupied"
+            );
+            result
+        } else {
+            store.delete_subjects(&ids).await
+        };
+
+        let err = delete_result.expect_err("the trigger must fail the second delete chunk");
+        assert!(
+            err.to_string()
+                .contains("injected later-chunk delete failure"),
+            "expected injected failure, got: {err}"
+        );
+
+        let present = store
+            .batch_exists(&ids, namespace)
+            .await
+            .expect("read vectors after rollback");
+        assert_eq!(
+            present.len(),
+            ids.len(),
+            "a later-chunk failure must restore every earlier deleted vector"
+        );
+        assert!(
+            ids.iter().all(|id| present.contains(id)),
+            "all requested vectors must remain after rollback"
+        );
+
+        let delete_log_count: i64 = pool
+            .try_writer()
+            .expect("pool writer")
+            .conn()
+            .query_row(
+                "SELECT COUNT(*) FROM ann_write_log WHERE op = 'delete'",
+                [],
+                |row| row.get(0),
+            )
+            .expect("count delete log rows");
+        assert_eq!(
+            delete_log_count, 0,
+            "rolled-back vector deletes must not leave committed ANN log rows"
+        );
+    }
+
+    #[tokio::test]
+    async fn delete_subjects_later_chunk_failure_rolls_back_all_legacy_writer() {
+        assert_later_chunk_failure_rolls_back_all(false).await;
+    }
+
+    #[tokio::test]
+    async fn delete_subjects_later_chunk_failure_rolls_back_all_writer_task() {
+        assert_later_chunk_failure_rolls_back_all(true).await;
+    }
+
+    #[tokio::test]
+    async fn delete_subjects_unmanaged_commit_failure_rolls_back_and_cleans_connection() {
+        crate::extension::ensure_extensions_loaded();
+
+        let model_key = "delete_subjects_commit_failure";
+        let dims = 4usize;
+        let namespace = "ns:delete_subjects_commit_failure";
+        let dir = tempfile::tempdir().expect("temporary database directory");
+        let path = dir.path().join("delete_subjects_commit_failure.db");
+        let pool = Arc::new(
+            ConnectionPool::new(PoolConfig {
+                path: Some(path),
+                write_queue_enabled: false,
+                ..PoolConfig::default()
+            })
+            .expect("file-backed pool"),
+        );
+        create_vec_table(&pool, model_key, dims);
+
+        let store = SqliteVecStore::new(
+            Arc::clone(&pool),
+            true,
+            model_key.to_string(),
+            model_key.to_string(),
+            dims,
+            namespace.to_string(),
+        )
+        .expect("SqliteVecStore::new");
+        assert!(
+            store.writer_task.is_none(),
+            "commit-failure sentinel must exercise the unmanaged transaction"
+        );
+
+        let subject_id = Uuid::new_v4();
+        let summary = store
+            .insert_batch(vec![VectorRecord {
+                subject_id,
+                kind: SubstrateKind::Entity,
+                namespace: namespace.to_string(),
+                field: "body".to_string(),
+                embedding_model: None,
+                vectors: vec![vec![0.1, 0.2, 0.3, 0.4]],
+                updated_at: chrono::Utc::now(),
+            }])
+            .await
+            .expect("seed vector");
+        assert_eq!(summary.affected, 1);
+
+        {
+            let writer = pool.try_writer().expect("pool writer");
+            let conn = writer.conn();
+            let foreign_keys: i64 = conn
+                .query_row("PRAGMA foreign_keys", [], |row| row.get(0))
+                .expect("read foreign_keys pragma");
+            assert_eq!(foreign_keys, 1, "commit sentinel requires foreign keys");
+            conn.execute_batch(
+                "DELETE FROM ann_write_log;
+                 CREATE TABLE delete_commit_parent (id TEXT PRIMARY KEY);
+                 CREATE TABLE delete_commit_child (
+                     parent_id TEXT NOT NULL REFERENCES delete_commit_parent(id)
+                         DEFERRABLE INITIALLY DEFERRED
+                 );
+                 CREATE TRIGGER fail_delete_subjects_commit
+                 AFTER INSERT ON ann_write_log
+                 WHEN NEW.op = 'delete'
+                 BEGIN
+                     INSERT INTO delete_commit_child(parent_id) VALUES ('missing-parent');
+                 END;",
+            )
+            .expect("install deferred commit-failure sentinel");
+        }
+
+        let err = store
+            .delete_subjects(&[subject_id])
+            .await
+            .expect_err("deferred foreign-key violation must fail COMMIT");
+        assert!(
+            err.to_string().contains("FOREIGN KEY constraint failed"),
+            "expected deferred commit failure, got: {err}"
+        );
+
+        let present = store
+            .batch_exists(&[subject_id], namespace)
+            .await
+            .expect("read vector after failed commit");
+        assert!(
+            present.contains(&subject_id),
+            "failed COMMIT must roll back the vector deletion"
+        );
+
+        let writer = pool.try_writer().expect("pool writer after failed commit");
+        let conn = writer.conn();
+        assert!(
+            conn.is_autocommit(),
+            "RAII cleanup must not return an open transaction to the pool"
+        );
+        let delete_log_count: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM ann_write_log WHERE op = 'delete'",
+                [],
+                |row| row.get(0),
+            )
+            .expect("count delete logs after failed commit");
+        assert_eq!(
+            delete_log_count, 0,
+            "failed COMMIT must roll back ANN delete logs"
+        );
+        let child_count: i64 = conn
+            .query_row("SELECT COUNT(*) FROM delete_commit_child", [], |row| {
+                row.get(0)
+            })
+            .expect("count deferred-FK rows after failed commit");
+        assert_eq!(
+            child_count, 0,
+            "failed COMMIT must roll back trigger side effects"
         );
     }
 }

--- a/crates/khive-storage/src/vectors.rs
+++ b/crates/khive-storage/src/vectors.rs
@@ -170,7 +170,9 @@ pub trait VectorStore: Send + Sync + 'static {
     /// Required when the vec table's PRIMARY KEY is `subject_id` alone (not
     /// `(subject_id, namespace)`): a row from a prior namespace would collide on
     /// re-insert after a relabel, so the pre-insert drop must target by subject
-    /// only. Returns the number of rows deleted across all chunks.
+    /// only. Returns the number of rows deleted across all chunks. The operation
+    /// is atomic across the full input: an error must not leave a prefix of the
+    /// requested subject IDs deleted.
     ///
     /// Default returns [`StorageError::Unsupported`]; backends that store vectors
     /// in a per-subject keyed table should override this method.


### PR DESCRIPTION
## Summary

- execute every chunk of a multi-subject vector deletion in one database transaction
- keep writer-task and unmanaged-connection paths atomic, including ANN-log writes
- document the all-or-nothing contract and cover late-chunk DML and commit failures

Fixes #1432.

## Behavior

Deleting more than 400 vector subjects no longer commits each chunk independently. The request now
uses one writer operation and one transaction, so a failure in a later chunk rolls back earlier
deletions and their ANN-log records. The unmanaged path uses the same transactional contract, and a
deferred foreign-key commit failure also leaves the connection clean and in autocommit mode.

## Validation

- `cargo test -p khive-db -p khive-storage --all-features`
- `cargo check -p khive-db -p khive-storage --all-targets --all-features`
- `cargo clippy -p khive-db -p khive-storage --all-targets --all-features -- -D warnings`
- `cargo fmt --all --check`
- `RUSTDOCFLAGS='-D warnings' cargo doc -p khive-db -p khive-storage --all-features --no-deps`
- `make docs-check`
- `sh scripts/lint-adr-refs.sh`
- `deno fmt --check`
- `git diff --check`

The affected package suites passed, including 544 `khive-db` unit tests, 71 `khive-storage` unit
tests, 14 storage contract tests, 33 compliance tests, 10 vector tests, and all affected integration
tests and doctests. The branch was tested at exact commit
`059e03f3a7184742866615da3499f60c98f949c6` on current `main`
`aab666f41d6729a8b957080b93c3569e10595c17`.

> AI-assisted contribution: Codex prepared this change and PR description.
