### PR TITLE
fix(kg): finalize proposal apply atomically

### DIFF
--- a/crates/khive-pack-kg/src/apply_worker/worker.rs
+++ b/crates/khive-pack-kg/src/apply_worker/worker.rs
@@ -138,29 +138,8 @@ impl ProposalApplyWorker {
                     .iter()
                     .map(|id| Id128::from_u128(id.as_u128()))
                     .collect();
-                self.emit_apply_success(token, proposal_id, created_ids)
+                self.finalize_apply_success(token, proposal_id, created_ids)
                     .await;
-                match self
-                    .projection
-                    .on_proposal_applied(token, proposal_id)
-                    .await
-                {
-                    Ok(true) => {}
-                    Ok(false) => {
-                        tracing::warn!(
-                            proposal_id = %proposal_id,
-                            "ProposalApplyWorker: CAS missed on applied projection update — \
-                             unexpected; KG mutations committed but status may not reflect 'applied'"
-                        );
-                    }
-                    Err(e) => {
-                        tracing::warn!(
-                            proposal_id = %proposal_id,
-                            error = %e,
-                            "ProposalApplyWorker: projection update failed after successful apply (non-fatal)"
-                        );
-                    }
-                }
             }
             Err(e) => {
                 self.emit_apply_failed(token, proposal_id, e.to_string(), 0)
@@ -446,8 +425,8 @@ impl ProposalApplyWorker {
         Ok(ids)
     }
 
-    /// Emit a `ProposalApplied` event with a success result.
-    async fn emit_apply_success(
+    /// Persist the applied projection and success event in one transaction.
+    async fn finalize_apply_success(
         &self,
         token: &NamespaceToken,
         proposal_id: Uuid,
@@ -459,7 +438,31 @@ impl ProposalApplyWorker {
             applied_by: "system:propose-apply".to_string(),
             result: khive_types::ApplyResult::Success { created_records },
         };
-        self.emit_apply_event(token, proposal_id, payload).await;
+        let Some(event) = Self::build_apply_event(token, proposal_id, payload) else {
+            return;
+        };
+        match self
+            .projection
+            .applied_and_emit(token, proposal_id, event)
+            .await
+        {
+            Ok(true) => {}
+            Ok(false) => {
+                tracing::warn!(
+                    proposal_id = %proposal_id,
+                    "ProposalApplyWorker: applied projection CAS missed after successful apply; \
+                     ProposalApplied success event suppressed"
+                );
+            }
+            Err(e) => {
+                tracing::warn!(
+                    proposal_id = %proposal_id,
+                    error = %e,
+                    "ProposalApplyWorker: atomic applied projection/event finalization failed \
+                     after successful apply; success event suppressed"
+                );
+            }
+        }
     }
 
     /// Emit a `ProposalApplied` event with a failure result.
@@ -488,28 +491,9 @@ impl ProposalApplyWorker {
         proposal_id: Uuid,
         payload: ProposalAppliedPayload,
     ) {
-        let ns = token.namespace().as_str().to_owned();
-        let payload_json = match serde_json::to_value(&payload) {
-            Ok(v) => v,
-            Err(e) => {
-                tracing::warn!(
-                    proposal_id = %proposal_id,
-                    error = %e,
-                    "ProposalApplyWorker: failed to serialize ProposalAppliedPayload"
-                );
-                return;
-            }
+        let Some(event) = Self::build_apply_event(token, proposal_id, payload) else {
+            return;
         };
-        let mut event = khive_storage::event::Event::new(
-            &ns,
-            "propose-apply",
-            EventKind::ProposalApplied,
-            khive_storage::SubstrateKind::Entity,
-            "system:propose-apply",
-        );
-        event.payload = payload_json;
-        event.aggregate_kind = Some("proposal".to_string());
-        event.aggregate_id = Some(proposal_id);
 
         let Ok(event_store) = self.runtime.events(token) else {
             tracing::warn!(
@@ -525,5 +509,35 @@ impl ProposalApplyWorker {
                 "ProposalApplyWorker: failed to emit ProposalApplied event (non-fatal)"
             );
         }
+    }
+
+    fn build_apply_event(
+        token: &NamespaceToken,
+        proposal_id: Uuid,
+        payload: ProposalAppliedPayload,
+    ) -> Option<khive_storage::event::Event> {
+        let ns = token.namespace().as_str().to_owned();
+        let payload_json = match serde_json::to_value(&payload) {
+            Ok(v) => v,
+            Err(e) => {
+                tracing::warn!(
+                    proposal_id = %proposal_id,
+                    error = %e,
+                    "ProposalApplyWorker: failed to serialize ProposalAppliedPayload"
+                );
+                return None;
+            }
+        };
+        let mut event = khive_storage::event::Event::new(
+            &ns,
+            "propose-apply",
+            EventKind::ProposalApplied,
+            khive_storage::SubstrateKind::Entity,
+            "system:propose-apply",
+        );
+        event.payload = payload_json;
+        event.aggregate_kind = Some("proposal".to_string());
+        event.aggregate_id = Some(proposal_id);
+        Some(event)
     }
 }

--- a/crates/khive-pack-kg/src/projection_worker/mod.rs
+++ b/crates/khive-pack-kg/src/projection_worker/mod.rs
@@ -131,33 +131,43 @@ impl ProposalsProjectionWorker {
         Ok(rows == 1)
     }
 
-    /// Called after a `ProposalApplied` event is emitted.
-    pub async fn on_proposal_applied(
+    /// Atomically move `applying` to `applied` and publish `ProposalApplied`.
+    pub async fn applied_and_emit(
         &self,
         token: &NamespaceToken,
         proposal_id: Uuid,
+        event: Event,
     ) -> Result<bool, RuntimeError> {
         let now = chrono::Utc::now().timestamp_micros();
         let ns = token.namespace().as_str().to_owned();
+        let projection_stmt = SqlStatement {
+            sql: "UPDATE proposals_open \
+                  SET status = 'applied', updated_at = ?1 \
+                  WHERE proposal_id = ?2 AND namespace = ?3 \
+                    AND status = 'applying'"
+                .to_string(),
+            params: vec![
+                SqlValue::Integer(now),
+                SqlValue::Text(proposal_id.to_string()),
+                SqlValue::Text(ns),
+            ],
+            label: Some("projection_worker.applied_and_emit.cas".into()),
+        };
+        let event_stmt = build_conditional_event_insert(&event, "changes() = 1", vec![]);
+
         let sql = self.runtime.sql();
         let mut writer = sql.writer().await.map_err(RuntimeError::Storage)?;
-        let rows = writer
-            .execute(SqlStatement {
-                sql: "UPDATE proposals_open \
-                      SET status = 'applied', updated_at = ?1 \
-                      WHERE proposal_id = ?2 AND namespace = ?3 \
-                        AND status = 'applying'"
-                    .to_string(),
-                params: vec![
-                    SqlValue::Integer(now),
-                    SqlValue::Text(proposal_id.to_string()),
-                    SqlValue::Text(ns),
-                ],
-                label: Some("projection_worker.proposals_open.applied".into()),
-            })
+        let total_rows = writer
+            .execute_batch(vec![projection_stmt, event_stmt])
             .await
             .map_err(RuntimeError::Storage)?;
-        Ok(rows == 1)
+        let applied = total_rows == 2;
+        if applied {
+            // This atomic path deliberately bypasses EventStore::append_event,
+            // whose successful-append seam normally owns ADR-103 accounting.
+            khive_storage::usage::count(khive_storage::usage::UsageUnit::EventRows, 1);
+        }
+        Ok(applied)
     }
 
     /// Atomically move status `approved` → `applying` before KG mutation.

--- a/crates/khive-pack-kg/src/projection_worker/tests.rs
+++ b/crates/khive-pack-kg/src/projection_worker/tests.rs
@@ -1,6 +1,7 @@
 use super::*;
 use khive_runtime::{KhiveRuntime, Namespace};
-use khive_types::{Id128, ProposalDecision};
+use khive_storage::event::Event;
+use khive_types::{EventKind, Id128, ProposalDecision, SubstrateKind};
 use uuid::Uuid;
 
 fn setup() -> (KhiveRuntime, NamespaceToken) {
@@ -35,6 +36,34 @@ async fn ensure_schema(rt: &KhiveRuntime) {
         })
         .await
         .expect("create table");
+}
+
+fn proposal_applied_event(token: &NamespaceToken, proposal_id: Uuid) -> Event {
+    let mut event = Event::new(
+        token.namespace().as_str(),
+        "propose-apply",
+        EventKind::ProposalApplied,
+        SubstrateKind::Entity,
+        "system:propose-apply",
+    );
+    event.payload = serde_json::json!({ "proposal_id": proposal_id });
+    event.aggregate_kind = Some("proposal".to_string());
+    event.aggregate_id = Some(proposal_id);
+    event
+}
+
+async fn event_exists(rt: &KhiveRuntime, event_id: Uuid) -> bool {
+    let sql = rt.sql();
+    let mut reader = sql.reader().await.expect("reader");
+    reader
+        .query_row(SqlStatement {
+            sql: "SELECT 1 AS present FROM events WHERE id = ?1".to_string(),
+            params: vec![SqlValue::Text(event_id.to_string())],
+            label: Some("test.proposal_applied_event_exists".into()),
+        })
+        .await
+        .expect("query event")
+        .is_some()
 }
 
 #[tokio::test]
@@ -120,7 +149,7 @@ async fn on_proposal_withdrawn_sets_status_withdrawn() {
 }
 
 #[tokio::test]
-async fn on_proposal_applied_sets_status_applied() {
+async fn applied_and_emit_sets_status_applied_and_publishes_success() {
     let (rt, tok) = setup();
     ensure_schema(&rt).await;
     let worker = ProposalsProjectionWorker::new(rt.clone());
@@ -153,12 +182,20 @@ async fn on_proposal_applied_sets_status_applied() {
         "pre_apply_cas must return true when status='approved'"
     );
 
-    // H1: on_proposal_applied now uses WHERE status='applying'.
-    let applied = worker
-        .on_proposal_applied(&tok, pid)
-        .await
-        .expect("on_proposal_applied must succeed");
+    let event = proposal_applied_event(&tok, pid);
+    let event_id = event.id;
+    let usage = khive_runtime::usage::UsageContext::new();
+    let applied = khive_runtime::usage::scope(usage.clone(), async {
+        worker.applied_and_emit(&tok, pid, event).await
+    })
+    .await
+    .expect("applied_and_emit must succeed");
     assert!(applied, "CAS must succeed when status='applying'");
+    assert_eq!(
+        usage.snapshot()["event_rows"],
+        1,
+        "the raw atomic INSERT must preserve EventStore append accounting"
+    );
 
     let row = worker
         .get_proposal_row(&tok, pid)
@@ -167,6 +204,10 @@ async fn on_proposal_applied_sets_status_applied() {
         .expect("row must exist");
 
     assert_eq!(row.status, "applied");
+    assert!(
+        event_exists(&rt, event_id).await,
+        "ProposalApplied success must be published with the applied projection"
+    );
 }
 
 // H1 regression: pre_apply_cas must fail when proposal was already withdrawn.
@@ -617,9 +658,9 @@ async fn same_microsecond_timestamp_no_duplicate_event_changes_guard() {
     );
 }
 
-// H1 regression: on_proposal_applied CAS must fail when status='withdrawn'.
+// A missed finalization CAS must not publish a success event.
 #[tokio::test]
-async fn on_proposal_applied_cas_fails_when_already_withdrawn() {
+async fn applied_and_emit_cas_miss_suppresses_success_event() {
     let (rt, tok) = setup();
     ensure_schema(&rt).await;
     let worker = ProposalsProjectionWorker::new(rt.clone());
@@ -647,14 +688,19 @@ async fn on_proposal_applied_cas_fails_when_already_withdrawn() {
         .await
         .expect("withdraw");
 
-    // on_proposal_applied requires status='applying'; 'withdrawn' fails the CAS.
+    let event = proposal_applied_event(&tok, pid);
+    let event_id = event.id;
     let applied = worker
-        .on_proposal_applied(&tok, pid)
+        .applied_and_emit(&tok, pid, event)
         .await
-        .expect("on_proposal_applied must not error");
+        .expect("applied_and_emit must not error");
     assert!(
         !applied,
-        "H1: on_proposal_applied CAS must return false when status='withdrawn' (not 'applying')"
+        "applied_and_emit must return false when status is not 'applying'"
+    );
+    assert!(
+        !event_exists(&rt, event_id).await,
+        "a missed applied projection CAS must suppress ProposalApplied success"
     );
 
     // Verify the status did not flip back to 'applied'.
@@ -666,5 +712,73 @@ async fn on_proposal_applied_cas_fails_when_already_withdrawn() {
     assert_eq!(
         row.status, "withdrawn",
         "status must remain 'withdrawn' after failed apply CAS"
+    );
+}
+
+// A projection update error must roll back the batch before success is visible.
+#[tokio::test]
+async fn applied_and_emit_projection_error_suppresses_success_event() {
+    let (rt, tok) = setup();
+    ensure_schema(&rt).await;
+    let worker = ProposalsProjectionWorker::new(rt.clone());
+    let pid = Uuid::new_v4();
+
+    worker
+        .on_proposal_created(&tok, pid, "alice", "Projection Failure", None)
+        .await
+        .expect("create");
+    let approve_payload = ProposalReviewedPayload {
+        proposal_id: Id128::from_u128(pid.as_u128()),
+        reviewer: "bob".to_string(),
+        decision: ProposalDecision::Approve,
+        comment: None,
+    };
+    worker
+        .on_proposal_reviewed(&tok, &approve_payload)
+        .await
+        .expect("approve");
+    assert!(
+        worker
+            .pre_apply_cas(&tok, pid)
+            .await
+            .expect("pre_apply_cas"),
+        "precondition: proposal must be applying"
+    );
+
+    let sql = rt.sql();
+    let mut writer = sql.writer().await.expect("writer");
+    writer
+        .execute_script(
+            "CREATE TRIGGER fail_applied_projection \
+             BEFORE UPDATE OF status ON proposals_open \
+             WHEN NEW.status = 'applied' \
+             BEGIN \
+               SELECT RAISE(ABORT, 'forced applied projection failure'); \
+             END"
+            .to_string(),
+        )
+        .await
+        .expect("install failure trigger");
+    drop(writer);
+
+    let event = proposal_applied_event(&tok, pid);
+    let event_id = event.id;
+    worker
+        .applied_and_emit(&tok, pid, event)
+        .await
+        .expect_err("forced projection failure must surface");
+
+    let row = worker
+        .get_proposal_row(&tok, pid)
+        .await
+        .expect("get row")
+        .expect("row must exist");
+    assert_eq!(
+        row.status, "applying",
+        "failed finalization must leave the projection uncommitted"
+    );
+    assert!(
+        !event_exists(&rt, event_id).await,
+        "a projection update error must suppress ProposalApplied success"
     );
 }

--- a/crates/khive-pack-kg/tests/projection_worker.rs
+++ b/crates/khive-pack-kg/tests/projection_worker.rs
@@ -6,8 +6,9 @@
 use khive_pack_kg::projection_worker::ProposalsProjectionWorker;
 
 use khive_runtime::{KhiveRuntime, Namespace, NamespaceToken};
+use khive_storage::event::Event;
 use khive_storage::types::{SqlStatement, SqlValue};
-use khive_types::{Id128, ProposalDecision, ProposalReviewedPayload};
+use khive_types::{EventKind, Id128, ProposalDecision, ProposalReviewedPayload, SubstrateKind};
 use uuid::Uuid;
 
 fn setup() -> (KhiveRuntime, NamespaceToken) {
@@ -42,6 +43,20 @@ async fn ensure_schema(rt: &KhiveRuntime) {
         })
         .await
         .expect("create table");
+}
+
+fn proposal_applied_event(token: &NamespaceToken, proposal_id: Uuid) -> Event {
+    let mut event = Event::new(
+        token.namespace().as_str(),
+        "propose-apply",
+        EventKind::ProposalApplied,
+        SubstrateKind::Entity,
+        "system:propose-apply",
+    );
+    event.payload = serde_json::json!({ "proposal_id": proposal_id });
+    event.aggregate_kind = Some("proposal".to_string());
+    event.aggregate_id = Some(proposal_id);
+    event
 }
 
 #[tokio::test]
@@ -127,7 +142,7 @@ async fn on_proposal_withdrawn_sets_status_withdrawn() {
 }
 
 #[tokio::test]
-async fn on_proposal_applied_sets_status_applied() {
+async fn applied_and_emit_sets_status_applied() {
     let (rt, tok) = setup();
     ensure_schema(&rt).await;
     let worker = ProposalsProjectionWorker::new(rt.clone());
@@ -158,10 +173,11 @@ async fn on_proposal_applied_sets_status_applied() {
         "pre_apply_cas must return true when status='approved'"
     );
 
+    let event = proposal_applied_event(&tok, pid);
     let applied = worker
-        .on_proposal_applied(&tok, pid)
+        .applied_and_emit(&tok, pid, event)
         .await
-        .expect("on_proposal_applied must succeed");
+        .expect("applied_and_emit must succeed");
     assert!(applied, "CAS must succeed when status='applying'");
 
     let row = worker
@@ -565,7 +581,7 @@ async fn same_microsecond_timestamp_no_duplicate_event_changes_guard() {
 }
 
 #[tokio::test]
-async fn on_proposal_applied_cas_fails_when_already_withdrawn() {
+async fn applied_and_emit_cas_fails_when_already_withdrawn() {
     let (rt, tok) = setup();
     ensure_schema(&rt).await;
     let worker = ProposalsProjectionWorker::new(rt.clone());
@@ -592,13 +608,14 @@ async fn on_proposal_applied_cas_fails_when_already_withdrawn() {
         .await
         .expect("withdraw");
 
+    let event = proposal_applied_event(&tok, pid);
     let applied = worker
-        .on_proposal_applied(&tok, pid)
+        .applied_and_emit(&tok, pid, event)
         .await
-        .expect("on_proposal_applied must not error");
+        .expect("applied_and_emit must not error");
     assert!(
         !applied,
-        "H1: on_proposal_applied CAS must return false when status='withdrawn'"
+        "H1: applied_and_emit CAS must return false when status='withdrawn'"
     );
 
     let row = worker

--- a/docs/adr/ADR-046-event-sourced-proposals.md
+++ b/docs/adr/ADR-046-event-sourced-proposals.md
@@ -291,7 +291,11 @@ background worker:
 - `ProposalCreated` → INSERT with status='open'
 - `ProposalReviewed` → UPDATE counts; if `decision = Approve` and approval
   threshold met, set status='approved' (threshold logic in §6)
-- `ProposalApplied` → UPDATE status='applied' (CAS: `WHERE status='applying'`)
+- successful `ProposalApplied` → atomically UPDATE status='applied' (CAS:
+  `WHERE status='applying'`) and INSERT the success event; a missed CAS or update
+  error publishes no success event
+- failed `ProposalApplied` → INSERT the failure event, then best-effort revert
+  status from 'applying' to 'approved'
 - `ProposalWithdrawn` → UPDATE status='withdrawn'
 
 **`applying` — transient in-flight state (V18 amendment):** The apply worker
@@ -300,9 +304,11 @@ before executing any KG mutations. This prevents a concurrent `withdraw` from
 landing while the apply is in progress — `withdraw`'s own CAS requires
 `status NOT IN ('applied', 'applying', 'withdrawn', 'rejected')`, so it fails
 with an error when the apply worker holds `'applying'`. The apply worker
-transitions to `'applied'` on success, or reverts to `'approved'` on failure so
-the proposal is not permanently stuck. `'applying'` is never written to the
-event log — it is a purely transient projection state.
+transitions to `'applied'` and inserts the success event in one transaction, or
+reverts to `'approved'` on failure so the proposal is not permanently stuck.
+The success event INSERT is conditional on the transition changing exactly one
+row, so a missed CAS cannot publish success. `'applying'` is never written to
+the event log — it is a purely transient projection state.
 
 Hard-state (status != 'open' | 'changes_requested') rows are retained for
 audit. A `proposal_cleanup` operator command is deferred; future work must
@@ -342,7 +348,10 @@ Call flow:
 
 1. `handle_review` resolves the proposal id and validates state.
 2. `reviewed_and_emit` atomically advances `proposals_open` and inserts `ProposalReviewed`.
-3. On `Approve`, `ProposalApplyWorker::maybe_apply` claims `approved` to `applying`, applies the changeset, emits `ProposalApplied`, then marks `applied` or reverts to `approved` on failure.
+3. On `Approve`, `ProposalApplyWorker::maybe_apply` claims `approved` to `applying`
+   and applies the changeset. Success atomically marks `applied` and inserts
+   `ProposalApplied`; failure inserts `ProposalApplied { Failed }` and then
+   reverts to `approved`.
 
 Future async worker wiring, if added, must filter by `EventKind::ProposalReviewed`,
 not by verb string. Current v1 code calls the worker directly from `handle_review`.
@@ -362,7 +371,10 @@ On each approved review handled by `handle_review`, `ProposalApplyWorker::maybe_
    - `SupersedeEntity` → adds `supersedes` edge via `runtime.graph.link(...)`
    - `Compound` → recursive within a single transaction (multi-step Compound
      currently rejected before this stage — see the current-restriction note above)
-4. Emits `ProposalApplied` with `Success { created_records }` or `Failed { error }`.
+4. On success, calls `applied_and_emit`, which executes the `applying` →
+   `applied` CAS and the conditional `ProposalApplied { Success { created_records } }`
+   INSERT in one write transaction. On failure, emits
+   `ProposalApplied { Failed { error } }` and best-effort reverts to `approved`.
 
 Authorization (ADR-018) checks the apply attempt. The worker's actor identity
 is (Fix 9):
@@ -460,6 +472,7 @@ verbs and the apply worker each have policy hooks:
 | Proposer withdraws after Approve but before Apply | If `withdraw` arrives before the apply worker claims `'applying'`: `ProposalWithdrawn` emitted; worker sees status≠'approved' (pre-apply CAS fails); skips KG mutations; no `ProposalApplied` emitted. If `withdraw` arrives after the apply worker claims `'applying'`: `withdraw` CAS finds status='applying' and returns an error — the withdraw is rejected. KG mutations proceed and `ProposalApplied` is emitted normally.                                                                                                                                                                                                                                                                        |
 | Apply fails (validation, network, etc.)           | `ProposalApplied { Failed }` emitted; status is reverted from `'applying'` back to `'approved'` (best-effort CAS) so the proposal is not permanently stuck. Apply retry is deferred to a follow-up ADR. v1 behavior: failed applies return to `'approved'`; operators may issue a new `propose` (with `parent_id` referencing the failed proposal) to retry. Direct re-emission of `apply` events is not supported in v1.                                                                                                                                                                                                                                                                               |
 | Apply policy denied                               | Same as Apply fails with `error = "denied by policy"`. Operator adjusts policy and issues a new `propose` (with `parent_id`) to retry; direct `apply` re-emission is not supported in v1.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               |
+| Success finalization CAS misses or errors         | The transaction publishes no `ProposalApplied { Success }` event. A failed batch leaves the projection at `applying`; committed KG mutations remain visible, but event consumers cannot observe success while projection readers still see a non-applied proposal. The condition is logged for operator reconciliation.                                                                                                                                                                                                                                                                                                                                                                                 |
 | Reviewer reverses Approve to Reject               | Each review is its own event; the worker uses the latest decision per reviewer. If a previously-approved proposal hits Reject before Apply fires, status moves to 'rejected'.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
 | Two reviewers race (both Approve simultaneously)  | Each `review(approve)` call invokes the apply worker synchronously after `reviewed_and_emit`. The `reviewed_and_emit` CAS serializes concurrent reviews at the projection layer; the apply worker’s `approved → applying` CAS ensures only one invocation executes the changeset. The worker checks `proposals_open.status` before applying; if already `applied` or `applying`, it returns without re-executing.                                                                                                                                                                                                                                                                                       |
 | Proposal expires                                  | A background sweep (TBD: cron-style, not v1) emits `ProposalWithdrawn` with `by = "system:expiry"` on proposals past their `expiry` timestamp.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
@@ -767,3 +780,15 @@ No dual-emit. Matches PR #109 (`note_id → id`) discipline.
 **Unchanged permanently**: `ProposalCreatedPayload.proposal_id` struct field,
 `proposals_open.proposal_id` DB column, `EventFilter.payload_proposal_id` filter field,
 and all internal worker references.
+
+## Amendment (2026-07-31): atomic success finalization (#1433)
+
+Successful proposal application finalizes the projection and publishes the
+`ProposalApplied { Success }` event through one `execute_batch` transaction. The
+projection CAS runs first; the event INSERT is guarded by connection-local
+`changes() = 1`. A false CAS therefore inserts no event, and any projection or
+event-write error rolls back both statements. The already-committed KG changeset
+is not part of this finalization transaction, but success never becomes externally
+visible while `proposals_open` remains `applying`. Because this path bypasses the
+`EventStore::append_event` seam, it increments ADR-103 `event_rows` exactly once
+after and only after the two-row atomic batch succeeds.


### PR DESCRIPTION
## Summary

- finalize a successful proposal apply with one atomic projection-update/event-write batch
- suppress `ProposalApplied { Success }` when the `applying` → `applied` CAS misses or errors
- preserve ADR-103 event-row accounting and document the corrected lifecycle contract

Fixes #1433.

## Behavior

After the KG changeset commits, the apply worker now moves the proposal projection to `applied` and
inserts its success event in the same database transaction. The event INSERT is conditional on the
projection CAS changing exactly one row. A CAS miss publishes no event, and any statement error
rolls the finalization batch back, preventing event consumers from observing success while the
projection remains `applying`. Failure events and their existing best-effort status reversion are
unchanged.

## Validation

- `cargo test -p khive-pack-kg --all-features`
- `cargo check -p khive-pack-kg --all-targets --all-features`
- `cargo clippy -p khive-pack-kg --all-targets --all-features -- -D warnings`
- `cargo fmt --all --check`
- `RUSTDOCFLAGS='-D warnings' cargo doc -p khive-pack-kg --all-features --no-deps`
- `make docs-check`
- `sh scripts/lint-adr-refs.sh`
- `deno fmt --check`
- `git diff --check`

All 447 affected package tests passed, including regressions for a missed CAS, a forced projection
update error, exact success-event publication, and one-time `event_rows` accounting. The branch was
tested at exact commit `8af01c5a21e6bf7674df8237b9e9c6fe0d4aba73` on current `main`
`aab666f41d6729a8b957080b93c3569e10595c17`.

## ADR

Updates ADR-046's proposal-apply lifecycle and preserves ADR-103 usage accounting for the raw atomic
event INSERT.

> AI-assisted contribution: Codex prepared this change and PR description.
