### PR TITLE
fix(db): decouple checkpoint telemetry from scheduler (#1434)

### DIFF
--- a/crates/khive-db/docs/api/checkpoint.md
+++ b/crates/khive-db/docs/api/checkpoint.md
@@ -56,7 +56,7 @@ The periodic tick stays PASSIVE-only and non-blocking; on top of it,
 `checkpoint_once` also evaluates a much rarer escalation to `PRAGMA
 wal_checkpoint(TRUNCATE)` once the WAL has grown past
 `truncate_high_water_pages` and at least `truncate_min_interval` has elapsed
-since the last TRUNCATE *attempt* (not the last successful reclaim).
+since the last TRUNCATE _attempt_ (not the last successful reclaim).
 
 This is a **single writer checkout per tick**: PASSIVE and any due TRUNCATE
 both run under the one guard `checkpoint_once` already holds — there is
@@ -135,6 +135,24 @@ backend is in-memory and only secondary file-backed tasks are spawned, the
 first secondary task owns emission. Other tasks receive no owner, so the API
 cannot silently discard a caller-supplied event store based on `is_main`.
 
+Lifecycle persistence is isolated from the scheduler (issue #1434). The task
+serializes each outcome and uses a zero-wait `try_send` into a dedicated append
+worker with capacity for one queued event behind the append in progress. If
+both slots are occupied, that outcome is dropped; the first drop in each
+uninterrupted full-queue episode warns, and a later successful enqueue re-arms
+the warning. The worker logs sink failures and continues. This preserves
+accepted-event order and bounds work and memory under writer contention while
+ensuring event-store checkout or SQLite busy waits cannot delay a later
+PASSIVE/TRUNCATE cycle. Checkpoint-task shutdown aborts the scheduler-owned
+async worker instead of waiting for its current append future. That guarantee
+is local to `run_checkpoint_task`, not daemon, runtime, or process shutdown: if
+the event store already admitted the append to `spawn_blocking` or a
+`WriterTask`, aborting the worker does not cancel it, and at most one such sink
+operation may outlive the checkpoint task. If a recovery/drain row meets a full
+queue, the task keeps the elevation episode open and retries that drain on the
+next healthy tick; a dropped enqueue therefore cannot permanently suppress the
+row that closes a previously accepted elevated sequence.
+
 ## Private tx-registry logging helpers (Plank 0)
 
 See `crates/khive-db/src/checkpoint.rs` — `log_tx_registry_oldest_debug`,
@@ -192,8 +210,8 @@ separately: if the oldest entry's `TxId` differs from the previous tick's,
 both latches are force-reset before re-evaluating the new entry's age, even
 though this happens on the SAME tick as the age check (not a separate
 below-threshold tick in between). Without this, an already-latched-`true`
-state from the *departed* entry would silently suppress the crossing for a
-*different* span that replaced it while already stale — naming nobody at
+state from the _departed_ entry would silently suppress the crossing for a
+_different_ span that replaced it while already stale — naming nobody at
 exactly the moment a new long-lived span starts pinning the database, which
 is the scenario this sweep exists to catch. A merely fresher replacement
 still reads as below-threshold either way, so the identity check changes

--- a/crates/khive-db/src/checkpoint.rs
+++ b/crates/khive-db/src/checkpoint.rs
@@ -1199,6 +1199,150 @@ impl CheckpointLifecycleOwner {
     }
 }
 
+/// Maximum number of checkpoint lifecycle events waiting behind the append
+/// currently owned by the worker. One queued row preserves a recent outcome
+/// without allowing sustained writer contention to grow memory without bound.
+const CHECKPOINT_LIFECYCLE_QUEUE_CAPACITY: usize = 1;
+
+/// Zero-wait handoff from the checkpoint scheduler to its lifecycle sink.
+///
+/// The worker serializes appends, preserving the order of every event that is
+/// accepted. The scheduler only calls [`tokio::sync::mpsc::Sender::try_send`]:
+/// if the worker and its single queue slot are both occupied, telemetry is
+/// dropped rather than delaying the next checkpoint cycle. The first drop in
+/// each uninterrupted full-queue episode warns; a successful enqueue re-arms
+/// that warning without producing per-tick log spam.
+struct CheckpointLifecycleEmitter {
+    namespace: Option<String>,
+    sender: Option<tokio::sync::mpsc::Sender<khive_storage::Event>>,
+    worker: Option<tokio::task::JoinHandle<()>>,
+    busy_warning_emitted: bool,
+}
+
+impl CheckpointLifecycleEmitter {
+    fn new(owner: Option<CheckpointLifecycleOwner>) -> Self {
+        let Some(owner) = owner else {
+            return Self {
+                namespace: None,
+                sender: None,
+                worker: None,
+                busy_warning_emitted: false,
+            };
+        };
+
+        let namespace = owner.namespace.clone();
+        let (sender, mut receiver) =
+            tokio::sync::mpsc::channel::<khive_storage::Event>(CHECKPOINT_LIFECYCLE_QUEUE_CAPACITY);
+        let worker = tokio::spawn(async move {
+            while let Some(event) = receiver.recv().await {
+                let kind = event.kind;
+                if let Err(err) = owner.event_store.append_event(event).await {
+                    tracing::warn!(
+                        error = %err,
+                        event_kind = %kind.name(),
+                        "checkpoint lifecycle event append failed"
+                    );
+                }
+            }
+        });
+
+        Self {
+            namespace: Some(namespace),
+            sender: Some(sender),
+            worker: Some(worker),
+            busy_warning_emitted: false,
+        }
+    }
+
+    /// Serialize and enqueue one lifecycle event without awaiting sink I/O.
+    /// Returns whether the row was accepted for delivery (or no sink exists).
+    fn try_emit<P: serde::Serialize>(&mut self, kind: khive_types::EventKind, payload: P) -> bool {
+        let (Some(namespace), Some(sender)) = (&self.namespace, &self.sender) else {
+            return true;
+        };
+        let payload_value = match serde_json::to_value(&payload) {
+            Ok(value) => value,
+            Err(err) => {
+                tracing::warn!(
+                    error = %err,
+                    event_kind = %kind.name(),
+                    "failed to serialize checkpoint lifecycle event payload"
+                );
+                return false;
+            }
+        };
+        let event = khive_storage::Event::new(
+            namespace,
+            "checkpoint.lifecycle",
+            kind,
+            khive_types::SubstrateKind::Event,
+            "daemon:checkpoint_task",
+        )
+        .with_payload(payload_value);
+
+        match sender.try_send(event) {
+            Ok(()) => {
+                self.busy_warning_emitted = false;
+                true
+            }
+            Err(tokio::sync::mpsc::error::TrySendError::Full(event)) => {
+                if !self.busy_warning_emitted {
+                    tracing::warn!(
+                        event_kind = %event.kind.name(),
+                        queue_capacity = CHECKPOINT_LIFECYCLE_QUEUE_CAPACITY,
+                        "checkpoint lifecycle event dropped because the append worker is busy"
+                    );
+                    self.busy_warning_emitted = true;
+                }
+                false
+            }
+            Err(tokio::sync::mpsc::error::TrySendError::Closed(event)) => {
+                tracing::warn!(
+                    event_kind = %event.kind.name(),
+                    "checkpoint lifecycle event dropped because the append worker stopped"
+                );
+                false
+            }
+        }
+    }
+
+    /// Stop the scheduler-owned async worker without making
+    /// [`run_checkpoint_task`] wait for its current append future.
+    ///
+    /// This bounds checkpoint-task shutdown only. If the event store already
+    /// admitted the append to `spawn_blocking` or a `WriterTask`, aborting this
+    /// worker cannot cancel that downstream operation; at most one such sink
+    /// operation may outlive the checkpoint task.
+    async fn shutdown(mut self) {
+        drop(self.sender.take());
+        let Some(worker) = self.worker.take() else {
+            return;
+        };
+        worker.abort();
+        match worker.await {
+            Ok(()) => {}
+            Err(err) if err.is_cancelled() => {}
+            Err(err) => tracing::warn!(
+                error = %err,
+                "checkpoint lifecycle event append worker terminated unexpectedly"
+            ),
+        }
+    }
+}
+
+impl Drop for CheckpointLifecycleEmitter {
+    fn drop(&mut self) {
+        // The normal watch-signal path calls `shutdown` and takes the handle
+        // first. This fallback covers an externally-aborted or panicking
+        // checkpoint task so the scheduler-owned async worker itself is never
+        // detached. One already-admitted downstream sink operation may outlive
+        // it; see `shutdown`'s contract above.
+        if let Some(worker) = &self.worker {
+            worker.abort();
+        }
+    }
+}
+
 /// Run the WAL checkpoint background task.
 ///
 /// Long-running async task — spawn with `tokio::spawn`. Loops until
@@ -1239,11 +1383,13 @@ pub async fn run_checkpoint_task(
     let mut tx_age_state = TxAgeSweepState::default();
     let mut was_above_high_water = false;
     let mut truncate_state = TruncateState::default();
+    let mut lifecycle_emitter = CheckpointLifecycleEmitter::new(lifecycle_owner);
     // Independent of `severity_state` (which owns the WARN-episode ladder
-    // internally): this tracks only the "was the previous observed tick
-    // elevated" edge the ADR-094 event emission needs, so the event path
-    // never has to reach into the severity state machine's private fields.
-    let mut event_was_elevated = false;
+    // internally): this tracks whether an accepted elevated lifecycle row
+    // still needs its matching drain row. A full queue leaves it unchanged,
+    // so a dropped drain is retried on the next healthy tick rather than
+    // leaving consumers with a permanently open elevation episode.
+    let mut event_elevation_open = false;
     // ADR-091 Amendment 3: this task's own backend-scoped view of the
     // registry. `is_main` selects which `TxOriginFilter` variant applies —
     // the caller passes `true` for exactly the one checkpoint task covering
@@ -1385,7 +1531,7 @@ pub async fn run_checkpoint_task(
         // ADR-094: emit every elevated tick, plus exactly one drain row on
         // the tick that observes the episode end — never on every ordinary
         // below-warn tick.
-        if checkpoint_outcome_should_emit(above_warn, event_was_elevated) {
+        if checkpoint_outcome_should_emit(above_warn, event_elevation_open) {
             let payload = khive_storage::CheckpointOutcomeRecordedPayload {
                 wal_pages,
                 warn_pages: config.warn_pages,
@@ -1395,15 +1541,15 @@ pub async fn run_checkpoint_task(
                 above_high_water,
                 above_truncate_high_water,
             };
-            append_checkpoint_lifecycle_event(
-                lifecycle_owner.as_ref(),
-                khive_types::EventKind::CheckpointOutcomeRecorded,
-                payload,
-            )
-            .await;
+            if lifecycle_emitter
+                .try_emit(khive_types::EventKind::CheckpointOutcomeRecorded, payload)
+            {
+                event_elevation_open = above_warn;
+            }
         }
-        event_was_elevated = above_warn;
     }
+
+    lifecycle_emitter.shutdown().await;
 
     #[cfg(unix)]
     if let Some(sidecar) = walpin_state.as_mut() {
@@ -1418,48 +1564,6 @@ pub async fn run_checkpoint_task(
 /// below-warn tick emits nothing.
 fn checkpoint_outcome_should_emit(above_warn: bool, was_elevated: bool) -> bool {
     above_warn || was_elevated
-}
-
-/// Append one ADR-094 lifecycle event on behalf of the checkpoint task.
-///
-/// Best-effort: `lifecycle_owner == None` is a no-op, and an append failure is
-/// logged and swallowed. No lifecycle-append error may ever interrupt or
-/// slow down checkpoint/TRUNCATE work — the checkpoint task's correctness
-/// does not depend on this succeeding.
-async fn append_checkpoint_lifecycle_event<P: serde::Serialize>(
-    lifecycle_owner: Option<&CheckpointLifecycleOwner>,
-    kind: khive_types::EventKind,
-    payload: P,
-) {
-    let Some(owner) = lifecycle_owner else {
-        return;
-    };
-    let payload_value = match serde_json::to_value(&payload) {
-        Ok(v) => v,
-        Err(e) => {
-            tracing::warn!(
-                error = %e,
-                event_kind = %kind.name(),
-                "failed to serialize checkpoint lifecycle event payload"
-            );
-            return;
-        }
-    };
-    let event = khive_storage::Event::new(
-        &owner.namespace,
-        "checkpoint.lifecycle",
-        kind,
-        khive_types::SubstrateKind::Event,
-        "daemon:checkpoint_task",
-    )
-    .with_payload(payload_value);
-    if let Err(err) = owner.event_store.append_event(event).await {
-        tracing::warn!(
-            error = %err,
-            event_kind = %kind.name(),
-            "checkpoint lifecycle event append failed"
-        );
-    }
 }
 
 /// ADR-091 Plank 0 (Amendment 3: takes the tick's already-computed,
@@ -3872,9 +3976,35 @@ mod tests {
 
     // ADR-094: `CheckpointOutcomeRecorded` lifecycle event tests.
 
-    #[derive(Default)]
+    #[derive(Clone, Copy)]
+    enum FakeAppendBehavior {
+        Record,
+        Fail,
+    }
+
     struct FakeEventStore {
         events: std::sync::Mutex<Vec<khive_storage::Event>>,
+        append_attempts: std::sync::atomic::AtomicUsize,
+        append_behavior: FakeAppendBehavior,
+    }
+
+    impl Default for FakeEventStore {
+        fn default() -> Self {
+            Self {
+                events: std::sync::Mutex::new(Vec::new()),
+                append_attempts: std::sync::atomic::AtomicUsize::new(0),
+                append_behavior: FakeAppendBehavior::Record,
+            }
+        }
+    }
+
+    impl FakeEventStore {
+        fn failing() -> Self {
+            Self {
+                append_behavior: FakeAppendBehavior::Fail,
+                ..Self::default()
+            }
+        }
     }
 
     #[async_trait::async_trait]
@@ -3883,8 +4013,17 @@ mod tests {
             &self,
             event: khive_storage::Event,
         ) -> khive_storage::StorageResult<()> {
-            self.events.lock().unwrap().push(event);
-            Ok(())
+            self.append_attempts
+                .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+            match self.append_behavior {
+                FakeAppendBehavior::Record => {
+                    self.events.lock().unwrap().push(event);
+                    Ok(())
+                }
+                FakeAppendBehavior::Fail => Err(khive_storage::StorageError::Internal(
+                    "synthetic checkpoint lifecycle append failure".to_string(),
+                )),
+            }
         }
 
         async fn append_events(
@@ -4007,6 +4146,150 @@ mod tests {
         assert!(
             events.iter().all(|e| e.namespace == "local"),
             "events must be stamped with the namespace passed to run_checkpoint_task"
+        );
+    }
+
+    /// Regression #1434: the event sink's ordinary writer checkout can wait
+    /// five seconds, but a full lifecycle queue must drop telemetry while the
+    /// checkpoint scheduler continues through later elevated ticks. The
+    /// separate in-memory event backend makes that writer contention
+    /// deterministic without also preventing `checkpoint_once` from
+    /// observing the file-backed checkpoint pool.
+    #[tokio::test]
+    #[serial(checkpoint_skip_metrics)]
+    async fn checkpoint_cycles_and_task_shutdown_do_not_wait_for_a_contended_lifecycle_writer() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("outcome_contended_sink.db");
+        let checkpoint_pool = file_pool(&path);
+
+        let event_pool = Arc::new(
+            ConnectionPool::new(PoolConfig {
+                path: None,
+                checkout_timeout: Duration::from_secs(5),
+                write_queue_enabled: false,
+                ..PoolConfig::default()
+            })
+            .expect("event pool"),
+        );
+        {
+            let writer = event_pool.try_writer().expect("initialize event schema");
+            crate::stores::event::ensure_events_schema(writer.conn())
+                .expect("initialize event schema");
+        }
+        let event_store: Arc<dyn khive_storage::EventStore> =
+            Arc::new(crate::stores::event::SqlEventStore::new_scoped(
+                Arc::clone(&event_pool),
+                false,
+                "local",
+            ));
+        let held_event_writer = event_pool
+            .try_writer()
+            .expect("hold the event-store writer");
+
+        let buffer = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+        let subscriber = CaptureSubscriber {
+            events: std::sync::Arc::clone(&buffer),
+        };
+        let _tracing_guard = tracing::subscriber::set_default(subscriber);
+
+        let cfg = CheckpointConfig {
+            interval: Duration::from_millis(10),
+            warn_pages: 0,
+            ..CheckpointConfig::default()
+        };
+        let (shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(());
+        let handle = tokio::spawn(run_checkpoint_task(
+            checkpoint_pool,
+            cfg,
+            Some(CheckpointLifecycleOwner::new(event_store, "local")),
+            shutdown_rx,
+            true,
+        ));
+
+        let dropped = wait_for(Duration::from_secs(2), || {
+            buffer.lock().unwrap().iter().any(|event| {
+                event.message.as_deref()
+                    == Some("checkpoint lifecycle event dropped because the append worker is busy")
+            })
+        })
+        .await;
+        assert!(
+            dropped,
+            "later elevated ticks must reach the non-blocking enqueue while the first append is \
+             still waiting for the held event writer; got: {:?}",
+            buffer.lock().unwrap()
+        );
+
+        shutdown_tx.send(()).expect("send shutdown signal");
+        tokio::time::timeout(Duration::from_secs(1), handle)
+            .await
+            .expect(
+                "the run_checkpoint_task handle must not wait for the event store's \
+                 five-second writer checkout",
+            )
+            .expect("checkpoint task panicked");
+
+        // The bound above is deliberately checkpoint-task-local. Aborting the
+        // lifecycle worker cannot cancel the `spawn_blocking` checkout already
+        // admitted by `SqlEventStore`; release its fixture contention only
+        // after the `run_checkpoint_task` handle has returned.
+        drop(held_event_writer);
+    }
+
+    /// A sink error is observable, and the worker remains alive to accept a
+    /// later checkpoint outcome instead of terminating the scheduler.
+    #[tokio::test]
+    #[serial(checkpoint_skip_metrics)]
+    async fn checkpoint_task_continues_after_lifecycle_append_failure() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("outcome_failing_sink.db");
+        let pool = file_pool(&path);
+        let store = Arc::new(FakeEventStore::failing());
+        let store_dyn: Arc<dyn khive_storage::EventStore> = store.clone();
+
+        let buffer = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+        let subscriber = CaptureSubscriber {
+            events: std::sync::Arc::clone(&buffer),
+        };
+        let _tracing_guard = tracing::subscriber::set_default(subscriber);
+
+        let cfg = CheckpointConfig {
+            interval: Duration::from_millis(10),
+            warn_pages: 0,
+            ..CheckpointConfig::default()
+        };
+        let (shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(());
+        let handle = tokio::spawn(run_checkpoint_task(
+            pool,
+            cfg,
+            Some(CheckpointLifecycleOwner::new(store_dyn, "local")),
+            shutdown_rx,
+            true,
+        ));
+
+        let retried = wait_for(Duration::from_secs(2), || {
+            store
+                .append_attempts
+                .load(std::sync::atomic::Ordering::Relaxed)
+                >= 2
+        })
+        .await;
+        shutdown_tx.send(()).expect("send shutdown signal");
+        tokio::time::timeout(Duration::from_secs(1), handle)
+            .await
+            .expect("checkpoint task should remain responsive after sink failure")
+            .expect("checkpoint task panicked");
+
+        assert!(
+            retried,
+            "a failed append must not terminate the worker or checkpoint task"
+        );
+        let captured = buffer.lock().unwrap().clone();
+        assert!(
+            captured.iter().any(|event| event.message.as_deref()
+                == Some("checkpoint lifecycle event append failed")),
+            "lifecycle append failures must remain observable; got: {:?}",
+            captured
         );
     }
 

--- a/docs/adr/ADR-094-lifecycle-telemetry-events.md
+++ b/docs/adr/ADR-094-lifecycle-telemetry-events.md
@@ -585,7 +585,10 @@ non-goals, not actioned.
   `ConfigLocked` drain inside `VerbRegistry::dispatch`.** Best-effort: `tracing::warn!` and
   continue (Decision 2), matching #606's precedent. The poll/checkpoint loop's primary job
   (polling channels, checking WAL pages) is never blocked by a telemetry write failure, and
-  a failed drain append never fails or delays the dispatch that hosted it.
+  a failed drain append never fails or delays the dispatch that hosted it. For
+  `run_checkpoint_task`, the 2026-08-01 amendment also moves the append behind a bounded,
+  zero-wait handoff: sink latency cannot block the loop, and a full handoff queue drops the
+  event with an edge-triggered warning.
 - **`registry.event_store()` / `dispatcher.event_store_for_checkpoint()` returns `None`**
   (no `EventStore` configured, e.g. a test harness that builds a bare `VerbRegistry` or a
   `DaemonDispatch` implementor that never overrides the default). Every new call site treats
@@ -627,9 +630,11 @@ non-goals, not actioned.
   success emits; (2) the `khive-runtime::config_ledger` pending-emission `Vec` plus its
   companion `AtomicBool` flag, bounded by the number of `OnceLock` config sites (3 today)
   and drained to empty on the next `VerbRegistry::dispatch` call, not on a checkpoint tick.
-  `run_checkpoint_task`'s existing `was_above_warn` bool (Decision 4) is reused as-is, no new
-  state there. Beyond these two additions, `channel_poll_loop`, `VerbRegistry::dispatch`, and
-  `run_checkpoint_task` gain a handful of best-effort `append_event` calls at existing
+  At this ADR's original adoption, `run_checkpoint_task` reused its existing
+  `was_above_warn` bool (Decision 4) and added no state there. The 2026-08-01 amendment below
+  supersedes that checkpoint-specific statement with one bounded emitter and its accepted-row
+  elevation state. Beyond those explicitly documented additions, `channel_poll_loop`,
+  `VerbRegistry::dispatch`, and `run_checkpoint_task` gain only best-effort calls at existing
   decision points computed from data `channel_error_class`, `is_backoff_eligible`,
   `ImapBackoff`, and `crossing_warn` already produce today.
 - `events` table growth increases by roughly 17,280 rows/day/channel steady state (the one
@@ -643,6 +648,38 @@ non-goals, not actioned.
   does not delete them (implementation-time work, out of scope for this docs-only ADR).
 - #599 (daemon stderr loss) and #617 (its own N=3 counter implementation) both remain open,
   tracked separately; this ADR is the shared substrate both build on.
+
+## 2026-08-01 amendment: checkpoint emission cannot delay checkpoint cycles (#1434)
+
+Decision 2's original checkpoint shape awaited `EventStore::append_event` inline. That was
+best-effort with respect to errors, but not with respect to latency: writer checkout can wait
+for the pool's normal `checkout_timeout` (five seconds by default), and SQLite busy handling can
+wait longer than the checkpoint task's 500 ms cadence. An elevated tick could therefore delay
+several later PASSIVE observations or a TRUNCATE opportunity while persisting telemetry about
+the earlier tick.
+
+`run_checkpoint_task` now hands lifecycle rows to one task-owned append worker through a bounded
+Tokio MPSC channel. The scheduler uses `try_send` exclusively and never awaits sink I/O. The
+worker serializes accepted appends, and the channel permits one queued row behind the append in
+progress; when both slots are occupied, the new outcome is dropped. The first drop in each
+uninterrupted full-queue episode emits a `tracing::warn!` with the event kind and queue capacity;
+a later successful enqueue re-arms that warning without creating per-tick log spam. Append errors
+are likewise warned and swallowed, and the worker continues to receive later rows. On
+checkpoint-task shutdown, the scheduler-owned async worker is aborted so `run_checkpoint_task`
+does not await its current append future. This is deliberately not a daemon-, runtime-, or
+process-shutdown guarantee: if the event store already admitted the append to `spawn_blocking` or
+a `WriterTask`, aborting the worker does not cancel that downstream operation, and at most one
+such sink operation may outlive the checkpoint task. The task advances its lifecycle elevation
+state only after `try_send` accepts a row. In particular, a recovery/drain row rejected by a full
+queue is retried on the next healthy tick, so enqueue backpressure cannot permanently omit the
+closing row for a previously accepted elevated sequence.
+
+This amendment supersedes only Decision 2's inline-await shape for `run_checkpoint_task` and the
+checkpoint clause in Failure modes. Channel-poll lifecycle emission and the `ConfigLocked` drain
+remain unchanged. Delivered `CheckpointOutcomeRecorded` rows retain their original order, but
+sustained sink contention can create explicit gaps in the lifecycle sequence; that is preferable
+to telemetry delaying the scheduler it observes. The queue bound also prevents a detached task
+or future from being created for every elevated tick while the writer remains contended.
 
 ## Alternatives considered
 


### PR DESCRIPTION
Closes #1434.

## Summary

- move checkpoint lifecycle persistence behind a single bounded append worker
- use a zero-wait handoff so event-store contention cannot delay later checkpoint cycles
- warn once per continuous full-queue episode, keep append failures non-fatal, and retry a dropped recovery row on a later healthy tick
- document the precise shutdown boundary: the checkpoint task does not await the worker, while an already-admitted downstream write may still finish

## Verification

- `cargo test -p khive-db --all-features` (567 tests passed)
- `cargo check -p khive-db --all-targets --all-features`
- `cargo clippy -p khive-db --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS=-Dwarnings cargo doc -p khive-db --all-features --no-deps`
- `cargo fmt --all -- --check`
- `make docs-check`
- `sh scripts/lint-adr-refs.sh`
- `deno fmt --check docs/`
- `git diff --check origin/main...HEAD`

> AI-assisted contribution: Codex prepared this change and PR description.
