### PR TITLE
fix(hnsw): gate concurrent alias migrations (#1437)

### DIFF
--- a/crates/khive-hnsw/docs/api/alias.md
+++ b/crates/khive-hnsw/docs/api/alias.md
@@ -18,10 +18,16 @@ service offline.
 
 - **Read path**: `parking_lot::RwLock` read guard (adaptive spinning, no OS block for
   short critical sections)
-- **Write path**: Brief exclusive lock for pointer swap only
+- **Write path**: Brief exclusive lock transaction for publication and eligible source
+  retirement
 - **Background build**: `tokio::task::spawn_blocking`, no locks held during build
 - **Lock order**: Operations that need both registries always acquire aliases before
   collections
+- **Concurrent migration ownership**: Publication is a compare-and-switch against the
+  alias target captured before the replacement build. Only one migration that captured a
+  given target can publish; a loser removes its unreferenced candidate and returns
+  `AliasTargetChanged` without changing the alias. The winning switch and eligible source
+  retirement occur under the same aliases-before-collections lock transaction.
 - **Drain**: Retirement is rejected while any alias references the collection; after
   retirement, readers drain through async polling of an `AtomicU64` counter
 

--- a/crates/khive-hnsw/src/alias/error.rs
+++ b/crates/khive-hnsw/src/alias/error.rs
@@ -21,6 +21,17 @@ pub enum AliasError {
     /// An alias with this name already exists.
     AliasAlreadyExists(String),
 
+    /// A migration lost ownership because its alias no longer targets the
+    /// collection captured before the replacement build began.
+    AliasTargetChanged {
+        /// Alias whose migration lost the compare-and-switch race.
+        alias: String,
+        /// Collection captured when the migration began.
+        expected: String,
+        /// Collection targeted when the migration attempted to publish.
+        actual: String,
+    },
+
     /// The pre-swap validation failed.
     ValidationFailed {
         /// Human-readable reason.
@@ -57,6 +68,14 @@ impl fmt::Display for AliasError {
                 write!(f, "collection is still referenced by an alias: {name}")
             }
             Self::AliasAlreadyExists(name) => write!(f, "alias already exists: {name}"),
+            Self::AliasTargetChanged {
+                alias,
+                expected,
+                actual,
+            } => write!(
+                f,
+                "alias target changed during migration: {alias} expected {expected}, found {actual}"
+            ),
             Self::ValidationFailed {
                 reason,
                 recall,

--- a/crates/khive-hnsw/src/alias/manager.rs
+++ b/crates/khive-hnsw/src/alias/manager.rs
@@ -1,6 +1,7 @@
 //! Index alias manager: atomic blue-green swap for zero-downtime HNSW index migration.
 
 use std::collections::HashMap;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
@@ -12,6 +13,11 @@ use super::validation::IndexValidator;
 use crate::config::HnswConfig;
 use crate::HnswIndex;
 use crate::NodeId;
+
+/// Process-wide discriminator for migration collection names created within
+/// the same wall-clock millisecond. Managers do not share registries, but a
+/// single manager can build several candidates concurrently (#1437).
+static MIGRATION_NAME_SEQUENCE: AtomicU64 = AtomicU64::new(0);
 
 /// Metadata for a registered collection.
 struct Collection {
@@ -82,6 +88,18 @@ impl IndexAliasManager {
 
     /// Register a named collection. Fails if the name already exists.
     pub fn register_collection(&self, name: &str, index: HnswIndex) -> Result<(), AliasError> {
+        self.register_collection_and_pin(name, index).map(|_| ())
+    }
+
+    /// Register a named collection and retain the exact index identity that
+    /// was inserted. Holding the returned `Arc` closes the remove/re-register
+    /// gap between exposing a migration candidate and pinning it (#1437).
+    fn register_collection_and_pin(
+        &self,
+        name: &str,
+        index: HnswIndex,
+    ) -> Result<Arc<HnswIndex>, AliasError> {
+        let index = Arc::new(index);
         let mut collections = self.collections.write();
         if collections.contains_key(name) {
             return Err(AliasError::CollectionAlreadyExists(name.to_string()));
@@ -89,11 +107,11 @@ impl IndexAliasManager {
         collections.insert(
             name.to_string(),
             Collection {
-                index: Arc::new(index),
+                index: Arc::clone(&index),
                 readers: Arc::new(ReaderCounter::new()),
             },
         );
-        Ok(())
+        Ok(index)
     }
 
     /// Create an alias pointing to an existing collection.
@@ -246,6 +264,64 @@ impl IndexAliasManager {
         self.switch_alias_inner(alias, new_collection, validator, hook)
     }
 
+    /// Publish a migration candidate only while `alias` still targets the
+    /// exact collection captured before the candidate build began, and retire
+    /// that source atomically when no other alias still references it.
+    ///
+    /// Both the alias comparison and candidate identity check run under the
+    /// canonical aliases -> collections lock order. The `Arc` comparison
+    /// prevents a same-name collection replacement from being published after
+    /// a migration validated a different index (#1438).
+    fn publish_migration_if_current(
+        &self,
+        alias: &str,
+        expected_collection: &str,
+        expected_old_index: &Arc<HnswIndex>,
+        new_collection: &str,
+        expected_new_index: &Arc<HnswIndex>,
+    ) -> Result<Option<Arc<ReaderCounter>>, AliasError> {
+        let mut aliases = self.aliases.write();
+        let mut collections = self.collections.write();
+        let candidate = collections
+            .get(new_collection)
+            .ok_or_else(|| AliasError::CollectionNotFound(new_collection.to_string()))?;
+        if !Arc::ptr_eq(expected_new_index, &candidate.index) {
+            return Err(AliasError::CollectionNotFound(new_collection.to_string()));
+        }
+
+        let actual_collection = aliases
+            .get(alias)
+            .ok_or_else(|| AliasError::AliasNotFound(alias.to_string()))?;
+        if actual_collection != expected_collection {
+            return Err(AliasError::AliasTargetChanged {
+                alias: alias.to_string(),
+                expected: expected_collection.to_string(),
+                actual: actual_collection.clone(),
+            });
+        }
+        let old_collection = collections
+            .get(expected_collection)
+            .ok_or_else(|| AliasError::CollectionNotFound(expected_collection.to_string()))?;
+        if !Arc::ptr_eq(expected_old_index, &old_collection.index) {
+            // The alias name made an ABA transition back to a different
+            // same-name collection while this candidate was building.
+            return Err(AliasError::CollectionNotFound(
+                expected_collection.to_string(),
+            ));
+        }
+
+        aliases.insert(alias.to_string(), new_collection.to_string());
+        if aliases.values().any(|target| target == expected_collection) {
+            // Another alias still owns the source collection (#1438).
+            return Ok(None);
+        }
+
+        let retired = collections
+            .remove(expected_collection)
+            .expect("source identity checked while holding the collections write lock");
+        Ok(Some(Arc::clone(&retired.readers)))
+    }
+
     fn retire_collection(
         &self,
         collection: &str,
@@ -296,7 +372,11 @@ impl IndexAliasManager {
         drain_readers(&counter, self.drain_timeout, self.drain_poll_interval).await
     }
 
-    /// Build new index, validate, swap alias atomically, drain old; returns `MigrationReport`.
+    /// Build and validate a replacement, then publish it only if `alias` still
+    /// targets the collection captured at the start of the migration.
+    ///
+    /// A concurrent migration that publishes first causes this call to clean
+    /// up its candidate and return [`AliasError::AliasTargetChanged`].
     pub async fn migrate(
         &self,
         alias: &str,
@@ -304,6 +384,21 @@ impl IndexAliasManager {
         new_config: HnswConfig,
         validator: Option<Box<dyn IndexValidator>>,
     ) -> Result<MigrationReport, AliasError> {
+        self.migrate_inner(alias, vectors, new_config, validator, |_| {})
+            .await
+    }
+
+    async fn migrate_inner<F>(
+        &self,
+        alias: &str,
+        vectors: Vec<(NodeId, Vec<f32>)>,
+        new_config: HnswConfig,
+        validator: Option<Box<dyn IndexValidator>>,
+        after_candidate_registered: F,
+    ) -> Result<MigrationReport, AliasError>
+    where
+        F: FnOnce(&str),
+    {
         let total_start = Instant::now();
 
         // Resolve current alias to get old collection info
@@ -315,22 +410,26 @@ impl IndexAliasManager {
                 .clone()
         };
 
-        let old_size = {
+        let old_index = {
             let collections = self.collections.read();
-            collections
-                .get(&old_collection_name)
-                .map(|c| c.index.len_live())
-                .unwrap_or(0)
+            Arc::clone(
+                &collections
+                    .get(&old_collection_name)
+                    .ok_or_else(|| AliasError::CollectionNotFound(old_collection_name.clone()))?
+                    .index,
+            )
         };
+        let old_size = old_index.len_live();
 
         // Generate a unique name for the new collection
         let new_collection_name = format!(
-            "{}_migrated_{}",
+            "{}_migrated_{}_{}",
             old_collection_name,
             std::time::SystemTime::now()
                 .duration_since(std::time::UNIX_EPOCH)
                 .unwrap_or_default()
-                .as_millis()
+                .as_millis(),
+            MIGRATION_NAME_SEQUENCE.fetch_add(1, Ordering::Relaxed),
         );
 
         // Build new index on a blocking thread
@@ -349,10 +448,13 @@ impl IndexAliasManager {
         .map_err(|e| AliasError::IndexError(format!("build failed: {e}")))?;
 
         let build_duration = build_start.elapsed();
-        let new_size = new_index.len_live();
 
-        // Register the new collection
-        self.register_collection(&new_collection_name, new_index)?;
+        // Create the candidate identity before registry exposure and retain it
+        // across validation, conditional publication, cleanup, and reporting.
+        // A remove/re-register race can replace the name, but never this Arc.
+        let candidate_index = self.register_collection_and_pin(&new_collection_name, new_index)?;
+        after_candidate_registered(&new_collection_name);
+        let new_size = candidate_index.len_live();
 
         // Validate and swap
         let swap_drain_start = Instant::now();
@@ -362,20 +464,16 @@ impl IndexAliasManager {
 
         // If we have a validator, run it and capture recall
         if let Some(ref v) = validator {
-            // Validation may block on recalls, so retain an index snapshot
-            // without monopolizing collection registry updates.
-            let index = {
-                let collections = self.collections.read();
-                Arc::clone(&collections.get(&new_collection_name).unwrap().index)
-            };
-            match v.validate(&index) {
+            // Validation may block on recalls; the exact candidate snapshot
+            // above avoids monopolizing collection registry updates.
+            match v.validate(&candidate_index) {
                 Ok(()) => {}
                 Err(AliasError::ValidationFailed {
                     recall, min_recall, ..
                 }) => {
                     // Preserve the validation error even if another alias now
                     // owns the candidate or its name refers to a replacement.
-                    let _ = self.retire_collection(&new_collection_name, Some(&index));
+                    let _ = self.retire_collection(&new_collection_name, Some(&candidate_index));
                     return Err(AliasError::ValidationFailed {
                         reason: "recall below threshold".to_string(),
                         recall,
@@ -383,21 +481,41 @@ impl IndexAliasManager {
                     });
                 }
                 Err(e) => {
-                    let _ = self.retire_collection(&new_collection_name, Some(&index));
+                    let _ = self.retire_collection(&new_collection_name, Some(&candidate_index));
                     return Err(e);
                 }
             }
         }
 
-        // Switch the alias
-        self.switch_alias(alias, &new_collection_name, None)?;
+        // Compare-and-switch against the exact target captured before the
+        // build, retiring that source in the same lock transaction when no
+        // other alias needs it. A loser must neither publish nor leak its
+        // replacement.
+        let retired_readers = match self.publish_migration_if_current(
+            alias,
+            &old_collection_name,
+            &old_index,
+            &new_collection_name,
+            &candidate_index,
+        ) {
+            Ok(readers) => readers,
+            Err(error) => {
+                let _ = self.retire_collection(&new_collection_name, Some(&candidate_index));
+                return Err(error);
+            }
+        };
+        // The source is no longer manager-owned when `retired_readers` is
+        // `Some`; release this migration's identity pin before waiting.
+        drop(old_index);
 
-        // Retire and drain the old collection. `drain_and_remove` removes it
-        // from `self.collections` up front, so even if drain times out below
-        // the manager no longer owns it -- outstanding reader guards keep
-        // their own Arc<HnswIndex> clone alive and the memory is reclaimed
-        // normally once the last guard drops (#418).
-        let drain_result = self.drain_and_remove(&old_collection_name).await;
+        // The atomic publish step already retired the old collection when
+        // eligible. Drain its readers without holding either registry lock.
+        let drain_result = match retired_readers {
+            Some(readers) => {
+                drain_readers(&readers, self.drain_timeout, self.drain_poll_interval).await
+            }
+            None => Ok(()),
+        };
 
         let swap_drain_duration = swap_drain_start.elapsed();
         let total_duration = total_start.elapsed();
@@ -407,10 +525,6 @@ impl IndexAliasManager {
             Err(AliasError::DrainTimeout { .. }) => {
                 // The old collection is already retired from manager ownership;
                 // report the completed migration without waiting longer.
-            }
-            Err(AliasError::CollectionInUse(_)) => {
-                // Another alias still needs the old collection, so leaving it
-                // registered is the successful migration outcome for this alias.
             }
             Err(error) => return Err(error),
         }
@@ -740,6 +854,189 @@ mod tests {
         assert_eq!(guard.len(), 8);
         assert_eq!(mgr.reader_count("v1"), None);
         assert_eq!(mgr.collection_count(), 1);
+    }
+
+    /// Regression for #1437: replacing a candidate immediately after it is
+    /// registered must not make the migration validate, publish, or report the
+    /// replacement under the reused name.
+    #[tokio::test]
+    async fn test_migrate_rejects_candidate_replacement_after_registration() {
+        use std::sync::atomic::AtomicUsize;
+
+        struct RecordingPassValidator {
+            validated_size: Arc<AtomicUsize>,
+        }
+
+        impl IndexValidator for RecordingPassValidator {
+            fn validate(&self, index: &HnswIndex) -> Result<(), AliasError> {
+                self.validated_size
+                    .store(index.len_live(), Ordering::SeqCst);
+                Ok(())
+            }
+        }
+
+        let manager = Arc::new(IndexAliasManager::new(Duration::from_secs(5)));
+        manager.register_collection("v1", make_index(4, 5)).unwrap();
+        manager.create_alias("active", "v1").unwrap();
+
+        let validated_size = Arc::new(AtomicUsize::new(0));
+        let hook_manager = Arc::clone(&manager);
+        let result = manager
+            .migrate_inner(
+                "active",
+                (0..8u8)
+                    .map(|i| (NodeId::new([i; 16]), vec![i as f32; 4]))
+                    .collect(),
+                HnswConfig::with_dimensions(4),
+                Some(Box::new(RecordingPassValidator {
+                    validated_size: Arc::clone(&validated_size),
+                })),
+                move |candidate| {
+                    let retired = hook_manager
+                        .retire_collection(candidate, None)
+                        .expect("fresh migration candidate should be unreferenced");
+                    drop(retired);
+                    hook_manager
+                        .register_collection(candidate, make_index(4, 12))
+                        .expect("same-name replacement should register");
+                },
+            )
+            .await;
+
+        let replacement_name = match result {
+            Err(AliasError::CollectionNotFound(name)) => name,
+            other => panic!("replacement identity must prevent publication, got {other:?}"),
+        };
+        assert!(replacement_name.starts_with("v1_migrated_"));
+        assert_eq!(
+            validated_size.load(Ordering::SeqCst),
+            8,
+            "validation must use the originally built candidate, not its same-name replacement"
+        );
+        assert_eq!(manager.resolve_alias("active"), Some("v1".to_string()));
+        assert_eq!(manager.acquire_reader("active").unwrap().len(), 5);
+
+        manager
+            .create_alias("replacement", &replacement_name)
+            .expect("failed migration cleanup must preserve the same-name replacement");
+        assert_eq!(manager.acquire_reader("replacement").unwrap().len(), 12);
+        assert_eq!(manager.collection_count(), 2);
+    }
+
+    /// Regression for #1437: two migrations that both captured `v1` may
+    /// build and validate concurrently, but exactly one may publish and
+    /// retire `v1`. The loser must return an ownership conflict and remove
+    /// its unreferenced candidate.
+    #[test]
+    fn test_concurrent_migrations_compare_and_switch_and_cleanup_loser() {
+        use std::sync::{mpsc, Mutex};
+
+        struct BlockingPassValidator {
+            ready: mpsc::Sender<()>,
+            release: Mutex<mpsc::Receiver<()>>,
+        }
+
+        impl IndexValidator for BlockingPassValidator {
+            fn validate(&self, _index: &HnswIndex) -> Result<(), AliasError> {
+                self.ready.send(()).unwrap();
+                // If test setup fails and drops the sender, unblock the worker
+                // so it cannot remain detached from a panicking test.
+                let _ = self.release.lock().unwrap().recv();
+                Ok(())
+            }
+        }
+
+        let manager = Arc::new(IndexAliasManager::new(Duration::from_secs(5)));
+        manager.register_collection("v1", make_index(4, 5)).unwrap();
+        manager.create_alias("active", "v1").unwrap();
+
+        let (ready_tx, ready_rx) = mpsc::channel();
+        let (first_release_tx, first_release_rx) = mpsc::channel();
+        let (second_release_tx, second_release_rx) = mpsc::channel();
+
+        let spawn_migration = |vector_count: u8, release: mpsc::Receiver<()>| {
+            let manager = Arc::clone(&manager);
+            let ready = ready_tx.clone();
+            std::thread::spawn(move || {
+                let runtime = tokio::runtime::Builder::new_current_thread()
+                    .enable_all()
+                    .build()
+                    .unwrap();
+                let vectors = (0..vector_count)
+                    .map(|i| (NodeId::new([i; 16]), vec![i as f32; 4]))
+                    .collect();
+                runtime.block_on(manager.migrate(
+                    "active",
+                    vectors,
+                    HnswConfig::with_dimensions(4),
+                    Some(Box::new(BlockingPassValidator {
+                        ready,
+                        release: Mutex::new(release),
+                    })),
+                ))
+            })
+        };
+
+        let first = spawn_migration(8, first_release_rx);
+        let second = spawn_migration(12, second_release_rx);
+
+        ready_rx
+            .recv_timeout(Duration::from_secs(5))
+            .expect("first migration did not reach validation");
+        ready_rx
+            .recv_timeout(Duration::from_secs(5))
+            .expect("second migration did not reach validation");
+
+        let candidates_before_switch: Vec<String> = manager
+            .collections
+            .read()
+            .keys()
+            .filter(|name| name.starts_with("v1_migrated_"))
+            .cloned()
+            .collect();
+        assert_eq!(
+            candidates_before_switch.len(),
+            2,
+            "both migrations must own distinct registered candidates before publication"
+        );
+
+        first_release_tx.send(()).unwrap();
+        second_release_tx.send(()).unwrap();
+        let first_result = first.join().unwrap();
+        let second_result = second.join().unwrap();
+
+        let (winner, loser) = match (&first_result, &second_result) {
+            (Ok(winner), Err(loser)) | (Err(loser), Ok(winner)) => (winner, loser),
+            outcomes => panic!("expected one migration winner and one loser, got {outcomes:?}"),
+        };
+        assert!(matches!(
+            loser,
+            AliasError::AliasTargetChanged {
+                alias,
+                expected,
+                actual,
+            } if alias == "active"
+                && expected == "v1"
+                && actual == &winner.new_collection
+        ));
+        assert_eq!(
+            manager.resolve_alias("active"),
+            Some(winner.new_collection.clone()),
+            "the successful report must name the final alias target"
+        );
+        assert_eq!(manager.reader_count("v1"), None);
+        assert_eq!(
+            manager.collection_count(),
+            1,
+            "the loser candidate and original collection must both be retired"
+        );
+        for candidate in candidates_before_switch {
+            assert_eq!(
+                manager.reader_count(&candidate).is_some(),
+                candidate == winner.new_collection.as_str(),
+                "only the winning replacement may remain registered"
+            );
+        }
     }
 
     /// Regression for #1438: migrating one alias must keep an old collection


### PR DESCRIPTION
Closes #1437.

## Summary

- compare-and-switch migration publication against the exact alias target captured before the replacement build
- retire the winning source in the same aliases-before-collections lock transaction and clean up a losing candidate
- retain exact `Arc` identities through validation, publication, cleanup, sizing, and reporting so same-name replacement cannot create an ABA success
- give concurrent candidates collision-free names and document the migration ownership contract

## Verification

- `cargo test -p khive-hnsw --all-features -- --skip checkpoint::checkpoint_integration_tests::load_latest_hnsw_checkpoint` (201 tests passed; one known baseline test filtered)
- `cargo check -p khive-hnsw --all-targets --all-features`
- `cargo clippy -p khive-hnsw --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS=-Dwarnings cargo doc -p khive-hnsw --all-features --no-deps`
- `cargo fmt --all -- --check`
- `make docs-check`
- `sh scripts/lint-adr-refs.sh`
- `deno fmt --check docs/ crates/khive-hnsw/docs/`
- `git diff --check origin/main...HEAD`

The unfiltered crate suite has one deterministic failure in the unrelated existing `checkpoint::checkpoint_integration_tests::load_latest_hnsw_checkpoint`: it expects sleeps between `Checkpoint::new` calls to order records, while `Checkpoint::new` now intentionally initializes `created_at` to the epoch. The same exact test fails on untouched `main` at `aab666f41d6729a8b957080b93c3569e10595c17`; all 135 other library tests passed before Cargo stopped that run.

> AI-assisted contribution: Codex prepared this change and PR description.
