### PR TITLE
fix(kkernel): bound locator cache (#1440)

### DIFF
--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -2592,6 +2592,7 @@ dependencies = [
  "khive-vcs-adapters",
  "lattice-embed",
  "libc",
+ "lru 0.12.5",
  "rmcp",
  "serde",
  "serde_json",

--- a/crates/kkernel/Cargo.toml
+++ b/crates/kkernel/Cargo.toml
@@ -33,6 +33,7 @@ khive-pack-session = { version = "0.5.0", path = "../khive-pack-session" }
 khive-pack-git = { version = "0.5.0", path = "../khive-pack-git" }
 khive-request = { version = "0.5.0", path = "../khive-request" }
 khive-changeset = { version = "0.5.0", path = "../khive-changeset" }
+lru = { workspace = true }
 tokio = { workspace = true }
 async-trait = { workspace = true }
 serde = { workspace = true }

--- a/crates/kkernel/src/coordinator/locator.rs
+++ b/crates/kkernel/src/coordinator/locator.rs
@@ -1,31 +1,52 @@
-//! UUID-to-backend locator cache with lazy TTL eviction.
+//! Bounded UUID-to-backend locator cache with TTL eviction.
 
-use std::collections::HashMap;
-use std::sync::RwLock;
+use std::collections::BTreeSet;
+use std::num::NonZeroUsize;
+use std::sync::Mutex;
 use std::time::{Duration, Instant};
 
 use khive_runtime::BackendId;
+use lru::LruCache;
 use uuid::Uuid;
 
 /// Default TTL for locator cache entries (5 minutes).
 pub(super) const DEFAULT_LOCATOR_TTL: Duration = Duration::from_secs(300);
+/// Default maximum number of locator cache entries.
+pub(super) const DEFAULT_LOCATOR_CAPACITY: usize = 65_536;
 
 struct LocatorEntry {
     backend_id: BackendId,
     inserted_at: Instant,
 }
 
-/// In-memory UUID-to-backend cache with lazy TTL eviction.
+struct LocatorState {
+    entries: LruCache<Uuid, LocatorEntry>,
+    expirations: BTreeSet<(Instant, Uuid)>,
+}
+
+/// In-memory UUID-to-backend cache with TTL and LRU eviction.
 pub struct LocatorCache {
-    entries: RwLock<HashMap<Uuid, LocatorEntry>>,
+    state: Mutex<LocatorState>,
     pub(super) ttl: Duration,
 }
 
 impl LocatorCache {
     /// Construct with the given TTL.
     pub fn with_ttl(ttl: Duration) -> Self {
+        Self::with_ttl_and_capacity(
+            ttl,
+            NonZeroUsize::new(DEFAULT_LOCATOR_CAPACITY)
+                .expect("DEFAULT_LOCATOR_CAPACITY must be non-zero"),
+        )
+    }
+
+    /// Construct with the given TTL and entry capacity.
+    pub fn with_ttl_and_capacity(ttl: Duration, capacity: NonZeroUsize) -> Self {
         Self {
-            entries: RwLock::new(HashMap::new()),
+            state: Mutex::new(LocatorState {
+                entries: LruCache::new(capacity),
+                expirations: BTreeSet::new(),
+            }),
             ttl,
         }
     }
@@ -38,58 +59,82 @@ impl LocatorCache {
     /// Look up the backend that owns `id`.
     ///
     /// Returns `None` on a miss or when the entry has expired.
-    /// Expired entries are removed under a write lock.
+    /// Live hits refresh the LRU position without extending the entry's TTL.
     pub fn get(&self, id: Uuid) -> Option<BackendId> {
         let now = Instant::now();
-        {
-            let guard = self.entries.read().unwrap_or_else(|e| e.into_inner());
-            if let Some(entry) = guard.get(&id) {
-                if now.duration_since(entry.inserted_at) < self.ttl {
-                    return Some(entry.backend_id.clone());
-                }
-            } else {
-                return None;
+        let mut state = self.state.lock().unwrap_or_else(|e| e.into_inner());
+        let is_live = state
+            .entries
+            .peek(&id)
+            .is_some_and(|entry| now.saturating_duration_since(entry.inserted_at) < self.ttl);
+        if !is_live {
+            if let Some(entry) = state.entries.pop(&id) {
+                state.expirations.remove(&(entry.inserted_at, id));
             }
+            return None;
         }
-        let mut guard = self.entries.write().unwrap_or_else(|e| e.into_inner());
-        if let Some(entry) = guard.get(&id) {
-            if now.duration_since(entry.inserted_at) < self.ttl {
-                return Some(entry.backend_id.clone());
-            }
-        }
-        guard.remove(&id);
-        None
+        state.entries.get(&id).map(|entry| entry.backend_id.clone())
     }
 
     /// Remove the cache entry for `id`, if any.
     pub fn remove(&self, id: Uuid) {
-        let mut guard = self.entries.write().unwrap_or_else(|e| e.into_inner());
-        guard.remove(&id);
+        let mut state = self.state.lock().unwrap_or_else(|e| e.into_inner());
+        if let Some(entry) = state.entries.pop(&id) {
+            state.expirations.remove(&(entry.inserted_at, id));
+        }
     }
 
-    /// Insert or refresh the owning backend for `id`.
+    /// Insert or refresh the owning backend for `id`, pruning expired entries first.
     pub fn insert(&self, id: Uuid, backend_id: BackendId) {
-        let mut guard = self.entries.write().unwrap_or_else(|e| e.into_inner());
-        guard.insert(
+        self.insert_at(id, backend_id, Instant::now());
+    }
+
+    fn insert_at(&self, id: Uuid, backend_id: BackendId, now: Instant) {
+        let mut state = self.state.lock().unwrap_or_else(|e| e.into_inner());
+        Self::purge_expired_at(&mut state, self.ttl, now);
+        if let Some((replaced_id, replaced_entry)) = state.entries.push(
             id,
             LocatorEntry {
                 backend_id,
-                inserted_at: Instant::now(),
+                inserted_at: now,
             },
-        );
+        ) {
+            state
+                .expirations
+                .remove(&(replaced_entry.inserted_at, replaced_id));
+        }
+        state.expirations.insert((now, id));
     }
 
     /// Remove all entries whose TTL has elapsed.
     pub fn purge_expired(&self) {
         let now = Instant::now();
-        let mut guard = self.entries.write().unwrap_or_else(|e| e.into_inner());
-        guard.retain(|_, entry| now.duration_since(entry.inserted_at) < self.ttl);
+        let mut state = self.state.lock().unwrap_or_else(|e| e.into_inner());
+        Self::purge_expired_at(&mut state, self.ttl, now);
     }
 
-    /// Number of live entries (including possibly-expired ones not yet purged).
+    fn purge_expired_at(state: &mut LocatorState, ttl: Duration, now: Instant) {
+        while state
+            .expirations
+            .first()
+            .is_some_and(|(inserted_at, _)| now.saturating_duration_since(*inserted_at) >= ttl)
+        {
+            let (inserted_at, id) = state
+                .expirations
+                .pop_first()
+                .expect("expiry checked through the same cache lock");
+            let entry = state
+                .entries
+                .pop(&id)
+                .expect("entry checked through the same cache lock");
+            debug_assert_eq!(entry.inserted_at, inserted_at);
+        }
+    }
+
+    /// Number of retained entries (including possibly-expired ones not yet purged).
     pub fn len(&self) -> usize {
-        let guard = self.entries.read().unwrap_or_else(|e| e.into_inner());
-        guard.len()
+        let state = self.state.lock().unwrap_or_else(|e| e.into_inner());
+        state.entries.len()
     }
 
     /// True if the cache has no entries.
@@ -101,5 +146,69 @@ impl LocatorCache {
 impl Default for LocatorCache {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn insertion_prunes_expired_entries_without_capacity_pressure() {
+        let ttl = Duration::from_secs(10);
+        let cache = LocatorCache::with_ttl_and_capacity(ttl, NonZeroUsize::new(3).unwrap());
+        let start = Instant::now();
+        let expired = Uuid::new_v4();
+        let live = Uuid::new_v4();
+        let trigger = Uuid::new_v4();
+
+        cache.insert_at(expired, BackendId::main(), start);
+        cache.insert_at(live, BackendId::main(), start + Duration::from_secs(5));
+        cache.insert_at(trigger, BackendId::main(), start + ttl);
+
+        let state = cache.state.lock().unwrap_or_else(|e| e.into_inner());
+        assert_eq!(state.entries.len(), 2);
+        assert!(state.entries.peek(&expired).is_none());
+        assert!(state.entries.peek(&live).is_some());
+        assert!(state.entries.peek(&trigger).is_some());
+        assert_eq!(state.expirations.len(), 2);
+    }
+
+    #[test]
+    fn capacity_eviction_removes_expiration_record() {
+        let ttl = Duration::from_secs(10);
+        let cache = LocatorCache::with_ttl_and_capacity(ttl, NonZeroUsize::new(1).unwrap());
+        let start = Instant::now();
+        let first = Uuid::new_v4();
+        let second = Uuid::new_v4();
+        let third = Uuid::new_v4();
+
+        cache.insert_at(first, BackendId::main(), start);
+        cache.insert_at(second, BackendId::main(), start + Duration::from_secs(1));
+        cache.insert_at(third, BackendId::main(), start + Duration::from_secs(11));
+
+        let state = cache.state.lock().unwrap_or_else(|e| e.into_inner());
+        assert_eq!(state.entries.len(), 1);
+        assert!(state.entries.peek(&third).is_some());
+        assert_eq!(state.expirations.len(), 1);
+    }
+
+    #[test]
+    fn refresh_replaces_expiration_record() {
+        let ttl = Duration::from_secs(10);
+        let cache = LocatorCache::with_ttl_and_capacity(ttl, NonZeroUsize::new(2).unwrap());
+        let start = Instant::now();
+        let refreshed = Uuid::new_v4();
+        let other = Uuid::new_v4();
+
+        cache.insert_at(refreshed, BackendId::main(), start);
+        cache.insert_at(refreshed, BackendId::main(), start + Duration::from_secs(1));
+        cache.insert_at(other, BackendId::main(), start + ttl);
+
+        let state = cache.state.lock().unwrap_or_else(|e| e.into_inner());
+        assert_eq!(state.entries.len(), 2);
+        assert!(state.entries.peek(&refreshed).is_some());
+        assert!(state.entries.peek(&other).is_some());
+        assert_eq!(state.expirations.len(), 2);
     }
 }

--- a/crates/kkernel/src/coordinator/tests.rs
+++ b/crates/kkernel/src/coordinator/tests.rs
@@ -1,3 +1,4 @@
+use std::num::NonZeroUsize;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -135,6 +136,39 @@ fn locator_cache_purge_removes_expired() {
     std::thread::sleep(Duration::from_micros(1));
     cache.purge_expired();
     assert_eq!(cache.len(), 0);
+}
+
+#[test]
+fn locator_cache_insert_purges_expired_entry() {
+    let cache = LocatorCache::with_ttl(Duration::from_nanos(1));
+    let expired_id = Uuid::new_v4();
+    cache.insert(expired_id, BackendId::new("main"));
+    std::thread::sleep(Duration::from_micros(1));
+
+    let live_id = Uuid::new_v4();
+    cache.insert(live_id, BackendId::new("main"));
+
+    assert_eq!(cache.len(), 1);
+    assert!(cache.get(expired_id).is_none());
+}
+
+#[test]
+fn locator_cache_evicts_least_recently_used_at_capacity() {
+    let cache =
+        LocatorCache::with_ttl_and_capacity(Duration::from_secs(60), NonZeroUsize::new(2).unwrap());
+    let first = Uuid::new_v4();
+    let second = Uuid::new_v4();
+    let third = Uuid::new_v4();
+    cache.insert(first, BackendId::new("main"));
+    cache.insert(second, BackendId::new("main"));
+    assert!(cache.get(first).is_some());
+
+    cache.insert(third, BackendId::new("main"));
+
+    assert_eq!(cache.len(), 2);
+    assert!(cache.get(second).is_none());
+    assert!(cache.get(first).is_some());
+    assert!(cache.get(third).is_some());
 }
 
 // ---- D2: locate() integration tests ----

--- a/docs/adr/ADR-029-substrate-coordinator.md
+++ b/docs/adr/ADR-029-substrate-coordinator.md
@@ -38,7 +38,7 @@ operations layer:
 | Concern                              | Decision                                                                                                                            |
 | ------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------- |
 | Cross-backend edge representation    | D1: `target_backend` column on `graph_edges`                                                                                        |
-| Node-to-backend resolution           | D2: in-memory lazy locator cache                                                                                                    |
+| Node-to-backend resolution           | D2: in-memory bounded TTL/LRU locator cache                                                                                         |
 | Cross-backend `link()` mechanics     | D3: coordinator-driven, with edge stored on source's backend                                                                        |
 | Substrate-kind search fan-out        | D4: unweighted RRF across backends                                                                                                  |
 | Cross-backend traversal and curation | D5: DEFERRED in shipped code; target design retained below for transparent BFS, cross-backend merge errors, and hard-delete cascade |
@@ -66,7 +66,7 @@ crates do not depend on it.
 kkernel
 ├── coordinator/      ← this ADR
 │   ├── edges.rs      (D1 — target_backend column, link mechanics)
-│   ├── locator.rs    (D2 — DashMap<Uuid, BackendName>)
+│   ├── locator.rs    (D2 — bounded TTL/LRU cache)
 │   ├── search.rs     (D4 — substrate-kind fan-out + RRF)
 │   ├── traversal.rs  (D5 — deferred target: cross-backend BFS)
 │   ├── curation.rs   (D5 — deferred target: update / merge / delete cascade)
@@ -121,12 +121,15 @@ pub struct Edge {
 }
 ```
 
-### D2 — Node locator is an in-memory lazy cache
+### D2 — Node locator is an in-memory bounded TTL/LRU cache
 
 The coordinator owns:
 
 ```text
-Arc<DashMap<Uuid, BackendName>>
+Arc<LocatorCache>
+└── Mutex<LocatorState>
+    ├── LruCache<Uuid, LocatorEntry>
+    └── BTreeSet<(Instant, Uuid)>  // expiration index
 ```
 
 Semantics:
@@ -136,12 +139,17 @@ Semantics:
 - **Lazy on read**: a `locate(uuid)` call hits the cache first; on miss, the coordinator
   issues parallel reads to all backends and caches the first hit (or returns `None` if no
   backend contains the UUID).
+- **TTL pruning**: every insertion removes elapsed five-minute entries through a separate
+  expiration index, so one-time IDs disappear without being queried again. Cache hits
+  update LRU recency without extending the TTL.
+- **Bounded LRU**: the default capacity is 65,536 entries. Inserting beyond the cap
+  evicts the least-recently-used live mapping.
 - **Not persisted**: in-memory only. Across process restarts the cache is empty and warms
   lazily as queries arrive.
 
-Memory budget: 16 bytes (UUID) + ~16 bytes (backend name) ≈ 32 bytes per entry. 1M cached
-entries ≈ 32 MB. Bounded by working set. Currently unbounded; a bounded LRU with operator-
-configurable cap is a follow-up if a deployment hits memory pressure.
+The 65,536-entry default bounds both the LRU and expiration index. Exact resident memory
+depends on backend-name allocations and the map/tree bookkeeping; making the cap
+operator-configurable remains a follow-up if deployments need a different tradeoff.
 
 Cache invalidation:
 
@@ -659,7 +667,8 @@ write queue. `link()` and ordinary writes still hard-fail on partition (see D6).
   the cascade plan. Bounded; only on `hard_delete_entity(hard=true)`.
 - **Incoming neighbors are O(N backends)** per node. Bounded by backend count and
   visited-set pruning.
-- **Locator memory budget grows with working set** — bounded but unmonitored in v1.
+- **Locator memory budget is fixed and unmonitored in v1** — the 65,536-entry default is
+  not yet operator-configurable.
 - **More test surface** — substrate-kind tests, cross-backend link tests, partition tests.
 
 ### Neutral
@@ -684,8 +693,8 @@ empty (one entry per substrate kind, all pointing at `main`).
 
 ## Open Questions
 
-1. **Locator eviction policy.** Default unbounded for v1; bounded LRU with operator-
-   configurable cap if a deployment exceeds ~10M cached UUIDs.
+1. **Locator capacity configuration.** The bounded LRU defaults to 65,536 entries. Add an
+   operator-configurable override if deployments need a different memory/hit-rate tradeoff.
 2. **Stable backend IDs vs. names.** `target_backend` references operator-defined
    strings. Renaming a backend orphans existing values. Mitigation v1: document that
    backend renames require a migration script. Future: a stable `backend_id` UUID


### PR DESCRIPTION
Closes #1440.

## Summary

- replace the unbounded locator map with a 65,536-entry TTL/LRU cache
- maintain a bounded expiration index and prune elapsed one-shot IDs on every insertion
- remove matching expiration metadata on refresh, explicit removal, TTL expiry, and capacity eviction
- retain live-hit backend-scan avoidance while using hits to update LRU recency without extending TTL

## Verification

- `cargo test -p kkernel --all-features` (332 tests passed)
- `cargo check -p kkernel --all-targets --all-features`
- `cargo clippy -p kkernel --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS=-Dwarnings cargo doc -p kkernel --all-features --no-deps`
- `cargo fmt --all -- --check`
- `make docs-check`
- `sh scripts/lint-adr-refs.sh`
- `deno fmt --check docs/`
- `git diff --check origin/main...HEAD`

> AI-assisted contribution: Codex prepared this change and PR description.
