### PR TITLE
fix(comm): make read mark-read best-effort under writer contention

### DIFF
--- a/crates/khive-pack-comm/docs/api/message-lifecycle.md
+++ b/crates/khive-pack-comm/docs/api/message-lifecycle.md
@@ -138,6 +138,33 @@ is keyed on `notes_seq.seq`, which is fixed at first insert and survives such
 churn, so this is defensive rather than load-bearing; a metadata patch should
 never rewrite the row regardless.
 
+The mark-read patch is best-effort: under multi-client burst traffic the
+sqlite writer pool can time out (`checkout_timeout`, 5s default), and the
+read itself has already succeeded by the time the patch runs, so a failed or
+no-op write no longer fails the whole call. This follows the same
+high-level best-effort principle as `handle_reply`'s fold-in mark, which has
+been best-effort since its introduction in PR #85 — not a later
+writer-contention hardening shared with this handler. Three outcomes:
+
+- `Ok(true)` — the row was live and updated: `read: true`, `properties` is
+  the patched value (including the new `read: true`).
+- `Ok(false)` — no live row was found to update (e.g. soft-deleted
+  mid-flight, between this handler's `get_note` and its
+  `update_note_properties` call): `read: false`, `mark_error: "no live row
+  updated"`, `properties` is the note's ORIGINAL stored value (a stored
+  SQL-NULL properties column round-trips as JSON `null`, never `{}`) — the
+  response never claims a write that did not land.
+- `Err(e)` — the patch failed (writer timeout, pool exhaustion, etc.):
+  logged via `tracing::warn!` with the full error detail, then `read:
+  false`, `mark_error` is the error's `Display` string, `properties` is the
+  original stored value (again `null` if that is what was stored).
+
+`id`/`full_id` are returned in all three arms — only the mark degrades, not
+the read. There is no retry loop; a caller polling unread counts simply
+sees the message still unread and can re-issue `comm.read` (self-healing).
+Every validation error that runs before the patch (not found, wrong kind,
+outbound, wrong addressee) is unaffected and stays a hard error.
+
 ## `handlers.rs::handle_reply`
 
 Replies to a message, threading linkage.

--- a/crates/khive-pack-comm/src/handlers.rs
+++ b/crates/khive-pack-comm/src/handlers.rs
@@ -440,18 +440,83 @@ pub(crate) async fn handle_read(
 
     // Patch via a real `UPDATE`, not `upsert_note`'s `INSERT OR REPLACE` (#780
     // silently re-inserts the row on conflict). See docs/api/message-lifecycle.md#handlersrshandle_read
-    let mut props = note.properties.clone().unwrap_or_else(|| json!({}));
+    //
+    // `orig_props` is kept as the stored `Option<Value>` (a SQL-NULL
+    // properties column is a real, distinct state from `{}`) so a degraded
+    // response can report exactly what is stored; `props` is a
+    // separately-normalized object used only for the attempted patch.
+    let orig_props = note.properties.clone();
+    let mut props = orig_props.clone().unwrap_or_else(|| json!({}));
     props["read"] = json!(true);
     let updated_at = Utc::now().timestamp_micros();
 
-    store
+    // Best-effort: under multi-client writer contention the pool checkout can
+    // time out. The read itself already succeeded above — failing the whole
+    // call over a delivery-state patch would throw away a successful read for
+    // a caller who cannot retry the fetch half. Mirrors handle_reply's
+    // fold-in mark-read (#87/#94 precedent): `Ok(false)` (no live row
+    // updated, e.g. soft-deleted mid-flight) and `Err` both degrade to
+    // `read: false` + `mark_error` instead of failing the response. A caller
+    // polling unread counts simply sees the message still unread and can
+    // re-issue `read` — self-healing, no retry loop needed here.
+    let patch_result = store
         .update_note_properties(id, Some(props.clone()), updated_at)
-        .await
-        .map_err(|e| RuntimeError::Internal(format!("read: update_note_properties: {e}")))?;
+        .await;
 
-    Ok(
-        json!({ "id": short_id(id), "full_id": id.as_hyphenated().to_string(), "read": true, "properties": props }),
-    )
+    Ok(read_response(
+        short_id(id),
+        id.as_hyphenated().to_string(),
+        patch_result,
+        orig_props,
+        props,
+    ))
+}
+
+/// Assemble `comm.read`'s response from the mark-read patch outcome.
+///
+/// Factored out so the three degrade arms (`Ok(true)`, `Ok(false)`, `Err`)
+/// are unit-testable directly: the `Ok(false)`/soft-delete-mid-flight race
+/// cannot be arranged honestly through the public dispatch path (`handle_read`
+/// fetches and patches within a single sequential call, with no seam to
+/// inject a concurrent delete between the two), so the response shape is
+/// verified against this pure function instead of a racing integration test.
+fn read_response(
+    short: String,
+    full: String,
+    patch_result: Result<bool, khive_storage::StorageError>,
+    original_properties: Option<Value>,
+    patched_properties: Value,
+) -> Value {
+    match patch_result {
+        Ok(true) => json!({
+            "id": short,
+            "full_id": full,
+            "read": true,
+            "properties": patched_properties,
+        }),
+        Ok(false) => json!({
+            "id": short,
+            "full_id": full,
+            "read": false,
+            "mark_error": "no live row updated",
+            "properties": original_properties,
+        }),
+        Err(e) => {
+            tracing::warn!(
+                id = %full,
+                error = %e,
+                "comm.read: mark-read update failed under writer contention; \
+                 degrading to read:false (best-effort)"
+            );
+            json!({
+                "id": short,
+                "full_id": full,
+                "read": false,
+                "mark_error": e.to_string(),
+                "properties": original_properties,
+            })
+        }
+    }
 }
 
 /// `reply` — reply to a message, threading linkage. See
@@ -2045,9 +2110,11 @@ fn build_references_header(parent_chain: Option<&str>, parent_message_id: &str) 
 mod tests {
     use super::{
         build_references_header, heartbeat_note_id, message_id_match_candidates,
-        parent_references_chain, parent_wire_message_id, sanitize_reference_token, wrap_message_id,
+        parent_references_chain, parent_wire_message_id, read_response, sanitize_reference_token,
+        wrap_message_id,
     };
-    use serde_json::json;
+    use khive_storage::StorageError;
+    use serde_json::{json, Value};
 
     // #606: a delimiter-joined
     // `format!("...:{a}:{b}:{c}")` id encoding is not injective once
@@ -2330,6 +2397,129 @@ mod tests {
         assert_eq!(
             build_references_header(chain, "parent123@example.com"),
             "<parent123@example.com>"
+        );
+    }
+
+    // read_response's three arms are unit-tested directly because the
+    // `Ok(false)` case (a live row vanishing between handle_read's `get_note`
+    // and its `update_note_properties` call) cannot be arranged honestly
+    // through the public dispatch path: the two calls are sequential within
+    // one handler invocation with no seam to inject a concurrent delete.
+
+    #[test]
+    fn read_response_ok_true_reports_read_and_patched_properties() {
+        let original = json!({ "direction": "inbound", "read": false });
+        let patched = json!({ "direction": "inbound", "read": true });
+        let resp = read_response(
+            "abc123".to_string(),
+            "full-uuid".to_string(),
+            Ok(true),
+            Some(original),
+            patched.clone(),
+        );
+        assert_eq!(resp["id"], json!("abc123"));
+        assert_eq!(resp["full_id"], json!("full-uuid"));
+        assert_eq!(resp["read"], json!(true));
+        assert_eq!(resp["properties"], patched);
+        assert!(
+            resp.get("mark_error").is_none(),
+            "a successful mark must not carry mark_error; got {resp}"
+        );
+    }
+
+    #[test]
+    fn read_response_ok_false_degrades_without_claiming_the_patch_landed() {
+        let original = json!({ "direction": "inbound", "read": false });
+        let patched = json!({ "direction": "inbound", "read": true });
+        let resp = read_response(
+            "abc123".to_string(),
+            "full-uuid".to_string(),
+            Ok(false),
+            Some(original.clone()),
+            patched,
+        );
+        assert_eq!(resp["id"], json!("abc123"));
+        assert_eq!(resp["full_id"], json!("full-uuid"));
+        assert_eq!(resp["read"], json!(false));
+        assert_eq!(
+            resp["mark_error"],
+            json!("no live row updated"),
+            "got {resp}"
+        );
+        assert_eq!(
+            resp["properties"], original,
+            "must report the ORIGINAL stored properties, never the attempted \
+             patch, when the write did not land; got {resp}"
+        );
+    }
+
+    #[test]
+    fn read_response_ok_false_preserves_stored_null_properties() {
+        let patched = json!({ "read": true });
+        let resp = read_response(
+            "abc123".to_string(),
+            "full-uuid".to_string(),
+            Ok(false),
+            None,
+            patched,
+        );
+        assert_eq!(resp["id"], json!("abc123"));
+        assert_eq!(resp["full_id"], json!("full-uuid"));
+        assert_eq!(resp["read"], json!(false));
+        assert_eq!(
+            resp["properties"],
+            Value::Null,
+            "a stored SQL-NULL properties column must round-trip as JSON \
+             null, never as {{}}; got {resp}"
+        );
+    }
+
+    #[test]
+    fn read_response_err_degrades_and_reports_the_error_string() {
+        let original = json!({ "direction": "inbound", "read": false });
+        let patched = json!({ "direction": "inbound", "read": true });
+        let err = StorageError::Timeout {
+            operation: "update_note_properties".into(),
+        };
+        let err_text = err.to_string();
+        let resp = read_response(
+            "abc123".to_string(),
+            "full-uuid".to_string(),
+            Err(err),
+            Some(original.clone()),
+            patched,
+        );
+        assert_eq!(resp["id"], json!("abc123"));
+        assert_eq!(resp["full_id"], json!("full-uuid"));
+        assert_eq!(resp["read"], json!(false));
+        assert_eq!(resp["mark_error"], json!(err_text));
+        assert_eq!(
+            resp["properties"], original,
+            "must report the ORIGINAL stored properties on a write error; got {resp}"
+        );
+    }
+
+    #[test]
+    fn read_response_err_preserves_stored_null_properties() {
+        let patched = json!({ "read": true });
+        let err = StorageError::Timeout {
+            operation: "update_note_properties".into(),
+        };
+        let resp = read_response(
+            "abc123".to_string(),
+            "full-uuid".to_string(),
+            Err(err),
+            None,
+            patched,
+        );
+        assert_eq!(resp["id"], json!("abc123"));
+        assert_eq!(resp["full_id"], json!("full-uuid"));
+        assert_eq!(resp["read"], json!(false));
+        assert_eq!(
+            resp["properties"],
+            Value::Null,
+            "a stored SQL-NULL properties column must round-trip as JSON \
+             null, never as {{}}; got {resp}"
         );
     }
 }

--- a/docs/adr/ADR-040-communication-and-schedule-packs.md
+++ b/docs/adr/ADR-040-communication-and-schedule-packs.md
@@ -593,3 +593,31 @@ standard `delete(id)` path.
   `inbox`, `agenda` are assertive; `read`, `cancel` are declarative.
 - ADR-027: Dynamic Pack Loading — self-registration via `inventory::submit!`.
 - ADR-028: Pack-Scoped Backends — `default_backend = "main"` for both packs.
+
+## Amendment (2026-08-01): `comm.read` degraded mark-read contract
+
+The `comm.read` row in the verb table above (line 102) states unconditionally that the
+verb "Set[s] `properties.read = true`" and "Returns the updated message envelope." That
+wording is only accurate when the post-read mark-read patch actually lands. Under
+multi-client writer contention (production incident, 2026-08-01) the mark-read patch can
+time out or find no live row to update, and `handle_read` now degrades instead of failing
+the whole call: the fetch already succeeded, so a delivery-state patch failure should not
+throw away a successful read for a caller who cannot retry the fetch half.
+
+**Corrected contract**: validation errors that run before the patch (not found, wrong
+kind, outbound direction, wrong addressee) remain fatal and unchanged. The post-read
+mark-read patch itself is best-effort:
+
+- On success, the response is as originally specified: `read: true`, `properties` is the
+  updated envelope.
+- On a no-op (no live row updated, e.g. soft-deleted mid-flight) or a storage error, the
+  response degrades to `read: false` with a `mark_error` field (a fixed string for the
+  no-op case, the error's `Display` string otherwise) and `properties` set to the
+  pre-patch stored value — never a value implying the patch landed.
+
+This is eventual consistency on the read flag, not a correctness gap: a caller polling
+unread counts sees the message still unread and can simply re-issue `comm.read`
+(self-healing, no retry loop needed in the handler). See
+`crates/khive-pack-comm/docs/api/message-lifecycle.md#handlersrshandle_read` for the full
+three-arm contract and `crates/khive-pack-comm/src/handlers.rs::read_response` for the
+implementation.


### PR DESCRIPTION
## Summary

`comm.read` marks an inbound message as read in two steps: fetch the note,
then patch `properties.read = true` via `UPDATE`. Under concurrent
multi-client load the sqlite writer pool checkout for that second step can
time out (a production incident on 2026-08-01 surfaced this). The read
itself had already succeeded by that point, so failing the whole call over
a delivery-state patch discarded a successful read for a caller that
cannot retry the fetch half.

`handle_read` now matches on the patch outcome instead of propagating a
fatal error, mirroring the best-effort handling `handle_reply`'s fold-in
mark-read has used since PR #85:

- `Ok(true)` — the row was live and updated: `read: true`, `properties` is
  the patched value.
- `Ok(false)` — no live row was found to update (e.g. soft-deleted
  mid-flight): `read: false`, `mark_error: "no live row updated"`,
  `properties` is the note's **original** stored value (a stored SQL-NULL
  properties column round-trips as JSON `null`, never `{}`).
- `Err(e)` — the patch failed (writer timeout, pool exhaustion, etc.):
  logged via `tracing::warn!`, then `read: false`, `mark_error` is the
  error's `Display` string, `properties` is the original stored value.

`id`/`full_id` are returned in all three arms — only the mark degrades,
never the read. Every validation error that runs before the patch (not
found, wrong kind, outbound direction, wrong addressee) is unaffected and
stays fatal. There is no retry loop; a caller polling unread counts simply
sees the message still unread and can re-issue `comm.read` — self-healing.

Response assembly is factored into a pure `read_response` helper so the
three outcome arms are unit-testable directly: the `Ok(false)`
soft-delete-mid-flight race cannot be arranged honestly through the public
dispatch path (fetch and patch run sequentially within one handler call,
with no seam to inject a concurrent delete), so it's verified against this
pure function instead of a racing integration test.

Also documents the corrected three-arm contract in
`crates/khive-pack-comm/docs/api/message-lifecycle.md` and amends
[ADR-040](docs/adr/ADR-040-communication-and-schedule-packs.md) with the
eventual-consistency rationale.

## Test plan

- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -p khive-pack-comm --all-targets -- -D warnings` — clean
- [x] `cargo test -p khive-pack-comm` — 157 lib/integration tests + 25 probe
      tests + the 5 new `read_response` unit tests, all passing