### PR TITLE
feat(runtime): atomic dual-write for comm messages — one writer transaction per send

### DIFF
--- a/crates/khive-pack-comm/src/message.rs
+++ b/crates/khive-pack-comm/src/message.rs
@@ -468,15 +468,24 @@ mod tests {
         }
     }
 
-    /// Failure injection mid-unit: when the vector-insert statement for one
-    /// note's plan fails, the WHOLE atomic unit — both notes' rows, FTS
-    /// documents, and vector rows — must roll back, not just the failing
-    /// note. Absence is asserted positively via `list_notes`/
-    /// `VectorStore::count`, not by inspecting the error.
+    /// Failure injection mid-unit, proven across a CROSS-namespace send: the
+    /// outbound plan (sender namespace) applies its statements before the
+    /// inbound plan (recipient namespace) runs, so arming the fault on the
+    /// recipient namespace only is what actually exercises "an
+    /// already-applied first plan unwinds" — arming the SAME namespace for
+    /// both copies (as same-namespace sends do) lets the one-shot fault be
+    /// consumed by the outbound plan instead, proving nothing about rollback
+    /// of prior work. Absence is asserted positively — `list_notes`,
+    /// `fts_notes` row counts, `VectorStore::count`, and `ann_write_log` row
+    /// counts — in BOTH namespaces, not by inspecting the error.
     #[tokio::test]
     async fn send_vector_failure_mid_unit_rolls_back_both_notes_and_their_vectors() {
         use async_trait::async_trait;
-        use khive_runtime::{arm_vector_fail_scoped, EmbedderProvider};
+        use khive_runtime::{
+            arm_vector_fail_scoped, AllowAllGate, BackendId, EmbedderProvider, RuntimeConfig,
+        };
+        use khive_storage::types::SqlValue;
+        use khive_storage::SqlStatement;
         use lattice_embed::{EmbedError, EmbeddingModel, EmbeddingService};
 
         const MODEL: &str = "message-vecfail-model";
@@ -515,17 +524,44 @@ mod tests {
             }
         }
 
-        let ns = format!("vecfail-mid-unit-{}", Uuid::new_v4().simple());
-        let (runtime, token) = scratch_runtime_and_token(&ns);
+        let sender_ns = format!("vecfail-sender-{}", Uuid::new_v4().simple());
+        let recipient_ns = format!("vecfail-recipient-{}", Uuid::new_v4().simple());
+
+        let runtime = KhiveRuntime::new(RuntimeConfig {
+            git_write: Default::default(),
+            db_path: None,
+            default_namespace: Namespace::parse(&sender_ns).unwrap(),
+            embedding_model: None,
+            additional_embedding_models: vec![],
+            gate: std::sync::Arc::new(AllowAllGate),
+            packs: vec!["kg".to_string(), "comm".to_string()],
+            backend_id: BackendId::main(),
+            brain_profile: None,
+            visible_namespaces: vec![],
+            allowed_outbound_namespaces: vec![Namespace::parse(&recipient_ns).unwrap()],
+            actor_id: None,
+        })
+        .expect("in-memory runtime");
         runtime.register_embedder(StubProvider);
 
-        let _vec_arm = arm_vector_fail_scoped(&ns);
+        let sender_token = runtime
+            .authorize(Namespace::parse(&sender_ns).unwrap())
+            .expect("authorize sender");
+        let recipient_token = runtime
+            .authorize(Namespace::parse(&recipient_ns).unwrap())
+            .expect("authorize recipient");
+
+        // No from_actor: this is a cross-namespace send, so the inbound copy
+        // lands in recipient_ns (not the caller's namespace). Arm the fault
+        // on recipient_ns — the SECOND plan in send order — so the outbound
+        // plan's statements are already applied when the failure hits.
+        let _vec_arm = arm_vector_fail_scoped(&recipient_ns);
 
         let result = dual_write_message(
             &runtime,
-            &token,
-            &ns,
-            &ns,
+            &sender_token,
+            &sender_ns,
+            &recipient_ns,
             None,
             "vector fail mid-unit",
             None,
@@ -543,24 +579,61 @@ mod tests {
              to fail; got {result:?}"
         );
 
-        let alive = runtime
-            .list_notes(&token, Some("message"), 100, 0)
-            .await
-            .expect("list_notes")
-            .into_iter()
-            .filter(|n| n.deleted_at.is_none())
-            .count();
-        assert_eq!(
-            alive, 0,
-            "no note may survive a mid-unit vector failure; got {alive}"
-        );
+        for (token, ns, label) in [
+            (&sender_token, &sender_ns, "sender"),
+            (&recipient_token, &recipient_ns, "recipient"),
+        ] {
+            let alive = runtime
+                .list_notes(token, Some("message"), 100, 0)
+                .await
+                .expect("list_notes")
+                .into_iter()
+                .filter(|n| n.deleted_at.is_none())
+                .count();
+            assert_eq!(
+                alive, 0,
+                "no note may survive a mid-unit vector failure in {label}_ns; got {alive}"
+            );
 
-        let vs = runtime.vectors_for_model(&token, MODEL).expect("vec store");
-        assert_eq!(
-            vs.count().await.expect("count"),
-            0,
-            "no vector row may survive a mid-unit vector failure"
-        );
+            let mut reader = runtime.sql().reader().await.expect("sql reader");
+            let fts_count = reader
+                .query_scalar(SqlStatement {
+                    sql: "SELECT COUNT(*) FROM fts_notes WHERE namespace = ?1".to_string(),
+                    params: vec![SqlValue::Text(ns.clone())],
+                    label: Some("test-fts-count".to_string()),
+                })
+                .await
+                .expect("fts count query");
+            assert!(
+                matches!(fts_count, Some(SqlValue::Integer(0))),
+                "no FTS document may survive a mid-unit vector failure in {label}_ns; got {fts_count:?}"
+            );
+
+            let vs = runtime.vectors_for_model(token, MODEL).expect("vec store");
+            assert_eq!(
+                vs.count().await.expect("count"),
+                0,
+                "no vector row may survive a mid-unit vector failure in {label}_ns"
+            );
+
+            let ann_count = reader
+                .query_scalar(SqlStatement {
+                    sql: "SELECT COUNT(*) FROM ann_write_log \
+                          WHERE namespace = ?1 AND embedding_model = ?2"
+                        .to_string(),
+                    params: vec![
+                        SqlValue::Text(ns.clone()),
+                        SqlValue::Text(MODEL.to_string()),
+                    ],
+                    label: Some("test-ann-log-count".to_string()),
+                })
+                .await
+                .expect("ann_write_log count query");
+            assert!(
+                matches!(ann_count, Some(SqlValue::Integer(0))),
+                "no ann_write_log row may survive a mid-unit vector failure in {label}_ns; got {ann_count:?}"
+            );
+        }
     }
 
     fn make_note(namespace: &str, content: &str, props: Option<Value>) -> Note {

--- a/crates/khive-pack-comm/src/message.rs
+++ b/crates/khive-pack-comm/src/message.rs
@@ -33,26 +33,6 @@ pub(crate) async fn resolve_id(
     )))
 }
 
-/// Rolls back a partially-written outbound note after a dual-write failure.
-/// See crates/khive-pack-comm/docs/api/message-lifecycle.md#messagersrollback_outbound
-async fn rollback_outbound(
-    runtime: &KhiveRuntime,
-    token: &NamespaceToken,
-    outbound_id: Uuid,
-    context: &str,
-    original: RuntimeError,
-) -> RuntimeError {
-    match runtime
-        .delete_note_row_first_for_compensation(token, outbound_id)
-        .await
-    {
-        Ok(()) => original,
-        Err(rollback_err) => RuntimeError::Internal(format!(
-            "{context}: original error: {original}; outbound rollback failed after row removal attempt for {outbound_id}: {rollback_err}"
-        )),
-    }
-}
-
 pub(crate) fn note_to_message_json(note: &Note) -> Value {
     let props = note.properties.as_ref();
     let full_id = note.id.as_hyphenated().to_string();
@@ -119,25 +99,24 @@ fn build_preview(content: &str) -> String {
 }
 
 /// Writes an outbound copy (caller namespace) and an inbound copy (recipient
-/// namespace), rolling back the outbound note if the inbound write fails
-/// (atomicity guarantee). Returns the outbound `Note` on success.
+/// namespace) as ONE atomic unit (`khive_runtime::create_notes_atomic`): one
+/// writer transaction covers both notes' rows, FTS documents, and vector
+/// rows. Returns the outbound `Note` on success.
 ///
-/// Known gap (external desk review, 2026-07-21): the two `create_note` calls
-/// below are not wrapped in one DB transaction, so a process crash between
-/// them (as opposed to an in-process error, which the rollback above already
-/// handles) can still leave a durable orphan outbound note with no inbound
-/// copy. `khive-runtime` exposes a lower-level atomic primitive
-/// (`run_atomic_unit`/`AtomicOpPlan::AddNote`) that spans one transaction, but
-/// it bypasses `create_note_inner`'s FTS/embedding/decay handling, so using it
-/// here would require re-deriving that logic at the pack layer rather than
-/// wrapping the existing calls. Blocked on `khive-runtime` exposing a
-/// transaction-scoped `create_note` equivalent; not safe to hack around from
-/// this crate.
+/// Resolved gap (external desk review, 2026-07-21; closed by construction
+/// here): the two note writes used to be separate `create_note` calls with
+/// only an in-process rollback compensating an inbound-write failure, so a
+/// process crash between them could leave a durable orphan outbound note
+/// with no inbound copy. `create_notes_atomic` commits both copies under one
+/// `SqlAccess::atomic_unit` — a crash or failure anywhere in the unit rolls
+/// back everything, so no partial pair can ever be observed durably.
 ///
-/// Invariant: when `thread_id` is `None` (root send), both copies are patched
-/// to share the sender's outbound UUID as their canonical `thread_id`, so
-/// `comm.thread` finds replies regardless of which copy they replied to. When
-/// `thread_id` is already supplied (reply path), it is forwarded unchanged.
+/// Invariant: the outbound id is generated BEFORE either write (rather than
+/// patched in after, as the old two-call version did) so both copies can
+/// carry the canonical `thread_id` from their first write: for a root send
+/// (`thread_id: None`), that id IS the canonical thread_id; for a reply, the
+/// caller-supplied `thread_id` is forwarded unchanged. Either way there is no
+/// longer a separate thread_id-patch write.
 ///
 /// See crates/khive-pack-comm/docs/api/message-lifecycle.md#messagersdual_write_message for
 /// the `in_reply_to_message_id`/`references_chain` header-threading contract.
@@ -199,12 +178,22 @@ pub(crate) async fn dual_write_message(
         }
     }
 
+    // Pre-generate the outbound id so the canonical thread_id is known before
+    // any write is attempted — both copies carry it from their first write,
+    // eliminating the separate thread_id-patch transaction the two-call
+    // version needed for root sends.
+    let outbound_id = Uuid::new_v4();
+    let canonical_thread_id: String = match thread_id {
+        Some(tid) => tid.to_string(),
+        None => outbound_id.as_hyphenated().to_string(),
+    };
+
     let mut outbound_props = json!({
         "from": from,
         "to": to,
         "direction": "outbound",
         "subject": subject,
-        "thread_id": thread_id,
+        "thread_id": canonical_thread_id,
         "read": false,
         "sent_at": sent_at,
     });
@@ -226,126 +215,78 @@ pub(crate) async fn dual_write_message(
         }
     }
 
-    let outbound_note = runtime
-        .create_note(
-            caller_token,
-            "message",
-            subject,
-            content,
-            None,
-            Some(outbound_props),
-            Vec::new(),
-        )
-        .await?;
-
-    // Canonical thread_id for both copies:
-    // - If the caller supplied a thread_id (reply path), propagate it as-is.
-    // - If this is a new root message (thread_id is None), use the outbound note's
-    //   UUID so that both copies share the same canonical root across namespaces.
-    let canonical_thread_id: String = match thread_id {
-        Some(tid) => tid.to_string(),
-        None => outbound_note.id.as_hyphenated().to_string(),
+    // When actor labels are provided (ADR-057 actor-addressed path), both copies
+    // land in the caller's namespace — no cross-namespace write occurs.
+    // When sender and recipient are in different namespaces (allowed cross-ns path),
+    // mint a recipient-scoped read+write token used for the inbound write after the
+    // allowlist check so the inbound note lands in the correct inbox. For
+    // same-namespace sends (from == to), use caller_token unchanged (preserves
+    // existing behavior).
+    let cross_ns_token;
+    let inbound_tok: &NamespaceToken = if from_actor.is_some() || from == recipient_ns_str {
+        // Actor-addressed path or same-namespace send: inbound copy stays in caller ns.
+        caller_token
+    } else {
+        cross_ns_token = caller_token.with_namespace(
+            Namespace::parse(recipient_ns_str).expect("recipient_ns_str already validated above"),
+        );
+        &cross_ns_token
     };
 
-    // Patch the outbound note's thread_id to the canonical value (only needed when
-    // this is a root send; reply path already has the correct thread_id stored).
-    if thread_id.is_none() {
-        let store = runtime
-            .notes(caller_token)
-            .map_err(|e| RuntimeError::Internal(format!("dual_write: get outbound store: {e}")))?;
-        let mut patched = outbound_note.clone();
-        let mut props = patched.properties.clone().unwrap_or_else(|| json!({}));
-        props["thread_id"] = json!(canonical_thread_id);
-        patched.properties = Some(props);
-        patched.updated_at = chrono::Utc::now().timestamp_micros();
-        if let Err(patch_err) = store.upsert_note(patched).await {
-            let original = RuntimeError::Internal(format!(
-                "dual_write: patch outbound thread_id: {patch_err}"
-            ));
-            return Err(rollback_outbound(
-                runtime,
-                caller_token,
-                outbound_note.id,
-                "dual_write: patch outbound thread_id rollback",
-                original,
-            )
-            .await);
+    let mut inbound_props = json!({
+        "from": from,
+        "to": to,
+        "direction": "inbound",
+        "subject": subject,
+        "thread_id": canonical_thread_id,
+        "read": false,
+        "sent_at": sent_at,
+        "outbound_ref": outbound_id,
+    });
+    if let Some(fa) = from_actor {
+        inbound_props["from_actor"] = json!(fa);
+    }
+    if let Some(ta) = to_actor {
+        inbound_props["to_actor"] = json!(ta);
+    }
+    if let Some(irt) = in_reply_to_message_id {
+        inbound_props["in_reply_to_message_id"] = json!(irt);
+    }
+    if let Some(refs) = references_chain {
+        inbound_props["references_chain"] = json!(refs);
+    }
+    if let Some(t) = tags {
+        if !t.is_empty() {
+            inbound_props["tags"] = json!(t);
         }
     }
 
-    {
-        // When actor labels are provided (ADR-057 actor-addressed path), both copies
-        // land in the caller's namespace — no cross-namespace write occurs.
-        // When sender and recipient are in different namespaces (allowed cross-ns path),
-        // mint a recipient-scoped read+write token used for exactly one inbound
-        // `create_note` call after the allowlist check so the inbound note lands in the
-        // correct inbox. For same-namespace sends (from == to), use caller_token
-        // unchanged (preserves existing behavior).
-        let cross_ns_token;
-        let inbound_tok: &NamespaceToken = if from_actor.is_some() || from == recipient_ns_str {
-            // Actor-addressed path or same-namespace send: inbound copy stays in caller ns.
-            caller_token
-        } else {
-            cross_ns_token = caller_token.with_namespace(
-                Namespace::parse(recipient_ns_str)
-                    .expect("recipient_ns_str already validated above"),
-            );
-            &cross_ns_token
-        };
-
-        let mut inbound_props = json!({
-            "from": from,
-            "to": to,
-            "direction": "inbound",
-            "subject": subject,
-            "thread_id": canonical_thread_id,
-            "read": false,
-            "sent_at": sent_at,
-            "outbound_ref": outbound_note.id,
-        });
-        if let Some(fa) = from_actor {
-            inbound_props["from_actor"] = json!(fa);
-        }
-        if let Some(ta) = to_actor {
-            inbound_props["to_actor"] = json!(ta);
-        }
-        if let Some(irt) = in_reply_to_message_id {
-            inbound_props["in_reply_to_message_id"] = json!(irt);
-        }
-        if let Some(refs) = references_chain {
-            inbound_props["references_chain"] = json!(refs);
-        }
-        if let Some(t) = tags {
-            if !t.is_empty() {
-                inbound_props["tags"] = json!(t);
-            }
-        }
-
-        let inbound_result = runtime
-            .create_note(
-                inbound_tok,
-                "message",
-                subject,
+    let mut notes = khive_runtime::create_notes_atomic(
+        runtime,
+        vec![
+            khive_runtime::AtomicNoteSpec {
+                token: caller_token,
+                id: Some(outbound_id),
+                kind: "message",
+                name: subject,
                 content,
-                None,
-                Some(inbound_props),
-                Vec::new(),
-            )
-            .await;
+                properties: Some(outbound_props),
+            },
+            khive_runtime::AtomicNoteSpec {
+                token: inbound_tok,
+                id: None,
+                kind: "message",
+                name: subject,
+                content,
+                properties: Some(inbound_props),
+            },
+        ],
+    )
+    .await?;
 
-        if let Err(inbound_err) = inbound_result {
-            return Err(rollback_outbound(
-                runtime,
-                caller_token,
-                outbound_note.id,
-                "dual_write: inbound write rollback",
-                inbound_err,
-            )
-            .await);
-        }
-    }
-
-    Ok(outbound_note)
+    // create_notes_atomic returns notes in the same order as the specs above:
+    // [outbound, inbound].
+    Ok(notes.remove(0))
 }
 
 #[cfg(test)]
@@ -354,21 +295,18 @@ mod tests {
     use khive_storage::note::Note;
     use serde_json::json;
 
-    // Issue #460: dual_write_message must not leave a live outbound note behind
-    // when the inbound write fails AND the rollback's compensation cleanup also
-    // fails. Forces outbound creation to succeed (sender_ns), the inbound create
-    // to fail (recipient_ns, via `arm_fts_fail`), and the rollback's post-row-
-    // removal cleanup to fail (sender_ns, via `arm_rollback_cleanup_fail`). Row-
-    // first ordering in `delete_note_row_first_for_compensation` means the
-    // outbound row is gone before cleanup runs, so it must stay gone even though
-    // cleanup errors; the caller must see that cleanup failure surfaced in the
-    // returned error rather than silently discarded.
+    // Issue #460 / atomic follow-up: dual_write_message must not leave a live
+    // outbound note behind when the inbound copy's write fails. Since the
+    // send-single-txn change, both copies commit under ONE atomic unit, so a
+    // failure on the inbound copy's FTS statement (armed via
+    // `arm_fts_fail_scoped(&recipient_ns)`, now consumed by
+    // `create_notes_atomic` through `consume_fts_fail_fault`) rolls back the
+    // WHOLE unit — including the outbound copy's already-applied statements
+    // in sender_ns. Assert absence positively in BOTH namespaces rather than
+    // inspecting the error string.
     #[tokio::test]
-    async fn dual_write_inbound_failure_rollback_delete_failure_removes_outbound_or_reports_composite(
-    ) {
-        use khive_runtime::{
-            arm_fts_fail_scoped, arm_rollback_cleanup_fail, AllowAllGate, BackendId, RuntimeConfig,
-        };
+    async fn dual_write_inbound_failure_rolls_back_whole_unit_including_outbound() {
+        use khive_runtime::{arm_fts_fail_scoped, AllowAllGate, BackendId, RuntimeConfig};
 
         let sender_ns = format!("t460-sender-{}", Uuid::new_v4().simple());
         let recipient_ns = format!("t460-recipient-{}", Uuid::new_v4().simple());
@@ -392,12 +330,13 @@ mod tests {
         let caller_token = runtime
             .authorize(Namespace::parse(&sender_ns).unwrap())
             .expect("authorize sender");
+        let recipient_token = runtime
+            .authorize(Namespace::parse(&recipient_ns).unwrap())
+            .expect("authorize recipient");
 
-        // Outbound (1st create_note call) targets sender_ns and is unaffected.
-        // Inbound (2nd create_note call) targets recipient_ns and fails.
+        // Outbound copy targets sender_ns; inbound copy targets recipient_ns
+        // and its FTS statement is armed to fail inside the atomic unit.
         let _fts_arm = arm_fts_fail_scoped(&recipient_ns);
-        // The rollback compensation's post-row-removal cleanup also fails.
-        arm_rollback_cleanup_fail(&sender_ns);
 
         let result = dual_write_message(
             &runtime,
@@ -418,16 +357,194 @@ mod tests {
 
         assert!(
             result.is_err(),
-            "dual_write_message must fail when the inbound create fails; got {result:?}"
+            "dual_write_message must fail when the inbound copy's write fails; got {result:?}"
         );
         let err_msg = result.unwrap_err().to_string();
         assert!(
-            err_msg.contains("rollback") || err_msg.contains("cleanup"),
-            "error must explicitly surface the rollback/cleanup failure, not discard it; got: {err_msg}"
+            err_msg.contains("rolled back"),
+            "error must report the atomic unit rolled back; got: {err_msg}"
+        );
+
+        for (token, ns) in [(&caller_token, "sender"), (&recipient_token, "recipient")] {
+            let alive = runtime
+                .list_notes(token, Some("message"), 100, 0)
+                .await
+                .expect("list_notes")
+                .into_iter()
+                .filter(|n| n.deleted_at.is_none())
+                .count();
+            assert_eq!(
+                alive, 0,
+                "no live note may remain in {ns}_ns after the whole unit rolled back; got {alive}"
+            );
+        }
+    }
+
+    /// Build a minimal same-namespace runtime + authorized token for the two
+    /// tests below. The namespace is still generated fresh per call so
+    /// `arm_vector_fail_scoped`/`arm_fts_fail_scoped` — process-wide,
+    /// namespace-keyed statics — never race a concurrently-running test.
+    fn scratch_runtime_and_token(ns: &str) -> (KhiveRuntime, NamespaceToken) {
+        use khive_runtime::{AllowAllGate, BackendId, RuntimeConfig};
+
+        let runtime = KhiveRuntime::new(RuntimeConfig {
+            git_write: Default::default(),
+            db_path: None,
+            default_namespace: Namespace::parse(ns).unwrap(),
+            embedding_model: None,
+            additional_embedding_models: vec![],
+            gate: std::sync::Arc::new(AllowAllGate),
+            packs: vec!["kg".to_string(), "comm".to_string()],
+            backend_id: BackendId::main(),
+            brain_profile: None,
+            visible_namespaces: vec![],
+            allowed_outbound_namespaces: vec![],
+            actor_id: None,
+        })
+        .expect("in-memory runtime");
+        let token = runtime
+            .authorize(Namespace::parse(ns).unwrap())
+            .expect("authorize");
+        (runtime, token)
+    }
+
+    /// A root send (no `thread_id`) must store the SAME canonical thread_id —
+    /// the outbound note's own id — on BOTH copies from their first write,
+    /// not patched in afterward. `created_at == updated_at` on both is the
+    /// positive signal that no later UPDATE ever touched either row
+    /// post-creation.
+    #[tokio::test]
+    async fn send_root_thread_id_is_canonical_without_patch_write() {
+        let ns = format!("thread-id-canonical-{}", Uuid::new_v4().simple());
+        let (runtime, token) = scratch_runtime_and_token(&ns);
+
+        let outbound_note = dual_write_message(
+            &runtime,
+            &token,
+            &ns,
+            &ns,
+            None,
+            "root send thread id",
+            None,
+            "2026-08-01T00:00:00Z",
+            None,
+            None,
+            None,
+            None,
+            None,
+        )
+        .await
+        .expect("dual_write_message succeeds");
+        let outbound_full_id = outbound_note.id.as_hyphenated().to_string();
+
+        let alive: Vec<_> = runtime
+            .list_notes(&token, Some("message"), 100, 0)
+            .await
+            .expect("list_notes")
+            .into_iter()
+            .filter(|n| n.deleted_at.is_none())
+            .collect();
+        assert_eq!(alive.len(), 2, "expected outbound + inbound; got {alive:?}");
+
+        for note in &alive {
+            let thread_id = note
+                .properties
+                .as_ref()
+                .and_then(|p| p.get("thread_id"))
+                .and_then(|v| v.as_str())
+                .expect("thread_id property present");
+            assert_eq!(
+                thread_id, outbound_full_id,
+                "both copies must carry the outbound id as canonical thread_id from \
+                 their first write; note {} had {thread_id}",
+                note.id
+            );
+            assert_eq!(
+                note.created_at, note.updated_at,
+                "no post-creation patch write may have touched note {} \
+                 (created_at must equal updated_at)",
+                note.id
+            );
+        }
+    }
+
+    /// Failure injection mid-unit: when the vector-insert statement for one
+    /// note's plan fails, the WHOLE atomic unit — both notes' rows, FTS
+    /// documents, and vector rows — must roll back, not just the failing
+    /// note. Absence is asserted positively via `list_notes`/
+    /// `VectorStore::count`, not by inspecting the error.
+    #[tokio::test]
+    async fn send_vector_failure_mid_unit_rolls_back_both_notes_and_their_vectors() {
+        use async_trait::async_trait;
+        use khive_runtime::{arm_vector_fail_scoped, EmbedderProvider};
+        use lattice_embed::{EmbedError, EmbeddingModel, EmbeddingService};
+
+        const MODEL: &str = "message-vecfail-model";
+        const DIMS: usize = 4;
+
+        struct StubService;
+        #[async_trait]
+        impl EmbeddingService for StubService {
+            async fn embed(
+                &self,
+                texts: &[String],
+                _model: EmbeddingModel,
+            ) -> std::result::Result<Vec<Vec<f32>>, EmbedError> {
+                Ok(texts.iter().map(|_| vec![0.5_f32; DIMS]).collect())
+            }
+            fn supports_model(&self, _model: EmbeddingModel) -> bool {
+                true
+            }
+            fn name(&self) -> &'static str {
+                MODEL
+            }
+        }
+        struct StubProvider;
+        #[async_trait]
+        impl EmbedderProvider for StubProvider {
+            fn name(&self) -> &str {
+                MODEL
+            }
+            fn dimensions(&self) -> usize {
+                DIMS
+            }
+            async fn build(
+                &self,
+            ) -> khive_runtime::RuntimeResult<std::sync::Arc<dyn EmbeddingService>> {
+                Ok(std::sync::Arc::new(StubService))
+            }
+        }
+
+        let ns = format!("vecfail-mid-unit-{}", Uuid::new_v4().simple());
+        let (runtime, token) = scratch_runtime_and_token(&ns);
+        runtime.register_embedder(StubProvider);
+
+        let _vec_arm = arm_vector_fail_scoped(&ns);
+
+        let result = dual_write_message(
+            &runtime,
+            &token,
+            &ns,
+            &ns,
+            None,
+            "vector fail mid-unit",
+            None,
+            "2026-08-01T00:00:00Z",
+            None,
+            None,
+            None,
+            None,
+            None,
+        )
+        .await;
+        assert!(
+            result.is_err(),
+            "dual_write_message must fail when the vector-insert statement is injected \
+             to fail; got {result:?}"
         );
 
         let alive = runtime
-            .list_notes(&caller_token, Some("message"), 100, 0)
+            .list_notes(&token, Some("message"), 100, 0)
             .await
             .expect("list_notes")
             .into_iter()
@@ -435,8 +552,14 @@ mod tests {
             .count();
         assert_eq!(
             alive, 0,
-            "no live outbound note may remain after rollback, even though the \
-             compensation cleanup itself failed; got {alive}"
+            "no note may survive a mid-unit vector failure; got {alive}"
+        );
+
+        let vs = runtime.vectors_for_model(&token, MODEL).expect("vec store");
+        assert_eq!(
+            vs.count().await.expect("count"),
+            0,
+            "no vector row may survive a mid-unit vector failure"
         );
     }
 

--- a/crates/khive-pack-comm/tests/integration.rs
+++ b/crates/khive-pack-comm/tests/integration.rs
@@ -8115,3 +8115,112 @@ async fn i66_inbox_limit_zero_carries_real_unread_count() {
         "limit=0 must return the caller's real unread count"
     );
 }
+
+// ── send-single-txn: atomic dual-write coverage ────────────────────────────
+//
+// `dual_write_message` now commits both message copies (row + FTS + one
+// vector row per registered embedding model) through
+// `khive_runtime::create_notes_atomic` — ONE writer transaction for the
+// pair instead of one writer acquisition per row/FTS/vector write. This
+// test covers the multi-model vector fan-out count landing inside the
+// single atomic unit.
+
+/// A send must land the outbound + inbound note, an FTS document for each,
+/// and one vector row PER registered embedding model for EACH note, all
+/// inside the single atomic unit. Two stub models are registered: the
+/// vector-row count for each model must be exactly 2 (outbound + inbound).
+#[tokio::test]
+async fn send_lands_outbound_inbound_fts_and_vectors_with_multi_model_counts() {
+    use async_trait::async_trait;
+    use khive_runtime::EmbedderProvider;
+    use lattice_embed::{EmbedError, EmbeddingModel, EmbeddingService};
+
+    macro_rules! stub_model {
+        ($provider:ident, $service:ident, $name:literal, $dims:literal) => {
+            struct $service;
+            #[async_trait]
+            impl EmbeddingService for $service {
+                async fn embed(
+                    &self,
+                    texts: &[String],
+                    _model: EmbeddingModel,
+                ) -> std::result::Result<Vec<Vec<f32>>, EmbedError> {
+                    Ok(texts.iter().map(|_| vec![0.25_f32; $dims]).collect())
+                }
+                fn supports_model(&self, _model: EmbeddingModel) -> bool {
+                    true
+                }
+                fn name(&self) -> &'static str {
+                    $name
+                }
+            }
+            struct $provider;
+            #[async_trait]
+            impl EmbedderProvider for $provider {
+                fn name(&self) -> &str {
+                    $name
+                }
+                fn dimensions(&self) -> usize {
+                    $dims
+                }
+                async fn build(&self) -> khive_runtime::RuntimeResult<Arc<dyn EmbeddingService>> {
+                    Ok(Arc::new($service))
+                }
+            }
+        };
+    }
+    stub_model!(
+        SendCountsModelA,
+        SendCountsServiceA,
+        "send-counts-model-a",
+        4
+    );
+    stub_model!(
+        SendCountsModelB,
+        SendCountsServiceB,
+        "send-counts-model-b",
+        6
+    );
+
+    let (registry, rt) = build_registry_for_ns("lambda:khive");
+    rt.register_embedder(SendCountsModelA);
+    rt.register_embedder(SendCountsModelB);
+
+    registry
+        .dispatch(
+            "comm.send",
+            serde_json::json!({ "to": "lambda:khive", "content": "multi-model counts" }),
+        )
+        .await
+        .expect("send succeeds");
+
+    // Actor-addressed sends land both copies in "local".
+    let local_tok = rt.authorize(Namespace::parse("local").unwrap()).unwrap();
+    let notes = rt
+        .list_notes(&local_tok, Some("message"), 100, 0)
+        .await
+        .expect("list_notes");
+    let alive: Vec<_> = notes.iter().filter(|n| n.deleted_at.is_none()).collect();
+    assert_eq!(alive.len(), 2, "expected outbound + inbound; got {alive:?}");
+
+    let fts = rt.text_for_notes(&local_tok).expect("text store");
+    for note in &alive {
+        assert!(
+            fts.get_document("local", note.id)
+                .await
+                .expect("get_document")
+                .is_some(),
+            "FTS document must exist for note {}",
+            note.id
+        );
+    }
+
+    for model in ["send-counts-model-a", "send-counts-model-b"] {
+        let vs = rt.vectors_for_model(&local_tok, model).expect("vec store");
+        assert_eq!(
+            vs.count().await.expect("count"),
+            2,
+            "expected one vector row per note ({model}): outbound + inbound"
+        );
+    }
+}

--- a/crates/khive-pack-comm/tests/integration.rs
+++ b/crates/khive-pack-comm/tests/integration.rs
@@ -8182,14 +8182,14 @@ async fn send_lands_outbound_inbound_fts_and_vectors_with_multi_model_counts() {
         6
     );
 
-    let (registry, rt) = build_registry_for_ns("lambda:khive");
+    let (registry, rt) = build_registry_for_ns("agent:sender");
     rt.register_embedder(SendCountsModelA);
     rt.register_embedder(SendCountsModelB);
 
     registry
         .dispatch(
             "comm.send",
-            serde_json::json!({ "to": "lambda:khive", "content": "multi-model counts" }),
+            serde_json::json!({ "to": "agent:sender", "content": "multi-model counts" }),
         )
         .await
         .expect("send succeeds");

--- a/crates/khive-runtime/src/atomic_message.rs
+++ b/crates/khive-runtime/src/atomic_message.rs
@@ -1,0 +1,365 @@
+//! Atomic multi-note write primitive: commits a set of notes — each with its
+//! FTS document and every registered embedding model's vector row — in ONE
+//! writer transaction, instead of one `create_note` call per note.
+//!
+//! Built for `khive-pack-comm`'s `dual_write_message` (outbound + inbound
+//! copy of a `comm.send`/`comm.reply`), which previously cost roughly a
+//! dozen separate writer acquisitions per send: two `create_note_inner`
+//! calls (row + FTS + one vector insert per registered model each) plus a
+//! root-send `thread_id` patch. Shaped as `create_notes_atomic(Vec<AtomicNoteSpec>)`
+//! rather than a comm-specific pair primitive so other multi-write verbs
+//! (`memory.remember`, `gtd.assign`) can adopt it later without a new type.
+//!
+//! # Embed-first
+//!
+//! Embedding is slow compute (network/model calls). Every note's embeddings,
+//! across every registered model, are computed **before** any transaction
+//! opens — the writer is held only for synchronous DML, exactly like the
+//! rest of the ADR-099 atomic-unit machinery (`atomic_plan`/`atomic_runner`).
+//! This is the same reason `atomic_prepare::prepare_add_note` defers vector
+//! indexing to a post-commit `PostCommitEffect::ReindexNote`; the difference
+//! here is embeddings are computed *before* commit instead of *after*, so
+//! the vector rows land in the SAME atomic unit as the note row and FTS
+//! document, and no post-commit reindex is needed at all — every plan built
+//! by [`create_notes_atomic`] carries `post_commit: PostCommitEffect::None`.
+//!
+//! # One writer acquisition
+//!
+//! Each note becomes its own [`AddNotePlan`]; every spec's plan is applied by
+//! ONE [`run_atomic_unit`] call — one [`khive_storage::SqlAccess::atomic_unit`],
+//! one writer checkout, one WAL commit for the whole set. A failure on any
+//! note's plan rolls back the ENTIRE unit (`atomic_runner`'s documented
+//! guarantee: a later op's failure unwinds even an earlier op's own
+//! already-`RELEASE`d `SAVEPOINT`), so a crash or guard failure partway
+//! through never leaves an orphan copy — the process-crash gap the two-call
+//! version of `dual_write_message` used to document is closed by
+//! construction.
+
+use serde_json::Value;
+use uuid::Uuid;
+
+use khive_storage::note::Note;
+use khive_storage::types::SqlValue;
+use khive_storage::SqlStatement;
+use khive_types::SubstrateKind;
+
+use crate::atomic_plan::{AddNotePlan, AffectedRowGuard, PlanStatement, PostCommitEffect};
+use crate::atomic_runner::{run_atomic_unit, AtomicOpPlan, AtomicRunOutcome};
+use crate::config::NamespaceToken;
+use crate::curation::note_fts_document;
+use crate::error::{RuntimeError, RuntimeResult};
+use crate::runtime::KhiveRuntime;
+
+/// One note to write as part of an atomic set. Mirrors the subset of
+/// `create_note_inner`'s parameters `comm.send`/`comm.reply` actually use —
+/// no `annotates`, `salience`, `decay_factor`, `embedding_content` override,
+/// or explicit `embedding_model` pin. A future caller needing those can grow
+/// this struct; none of khive-pack-comm's call sites need them today.
+pub struct AtomicNoteSpec<'a> {
+    /// Namespace + actor identity this note is written under.
+    pub token: &'a NamespaceToken,
+    /// Caller-supplied id, when the id must be known before the write (e.g.
+    /// a root send's own id becomes the canonical `thread_id` stored in
+    /// BOTH copies' properties). `None` generates a fresh id, same as
+    /// `Note::new`.
+    pub id: Option<Uuid>,
+    pub kind: &'a str,
+    pub name: Option<&'a str>,
+    pub content: &'a str,
+    pub properties: Option<Value>,
+}
+
+/// Bit-identical to `khive-db`'s private `f32_slice_as_bytes` (native-endian
+/// reinterpretation of the float buffer) but built from safe `to_ne_bytes`
+/// calls instead of an unsafe pointer cast — this crate has no visibility
+/// into that helper, and correctness here only requires this process's
+/// writes and reads agree on layout, which native-endian byte-for-byte
+/// concatenation guarantees identically to the raw cast.
+fn f32_vec_to_bytes(data: &[f32]) -> Vec<u8> {
+    let mut bytes = Vec::with_capacity(data.len() * 4);
+    for f in data {
+        bytes.extend_from_slice(&f.to_ne_bytes());
+    }
+    bytes
+}
+
+/// A harmless no-op `UPDATE` targeting a row that can never exist, guarded
+/// `exactly(1)` so it always fails its guard inside the atomic unit. Spliced
+/// in by test-only fault injection (see [`maybe_inject_fts_failure`]/
+/// [`maybe_inject_vector_failure`]) to prove the whole unit — not just the
+/// failing note's own plan — rolls back.
+#[cfg(any(test, feature = "fault-injection"))]
+fn injected_failure_statement(label: &str) -> PlanStatement {
+    PlanStatement {
+        statement: SqlStatement {
+            sql: "UPDATE notes SET updated_at = updated_at \
+                  WHERE id = '00000000-0000-0000-0000-000000000000'"
+                .to_string(),
+            params: vec![],
+            label: Some(label.to_string()),
+        },
+        guard: Some(AffectedRowGuard::exactly(1)),
+    }
+}
+
+#[cfg(any(test, feature = "fault-injection"))]
+fn maybe_inject_fts_failure(namespace: &str, label: &str) -> Option<PlanStatement> {
+    crate::operations::consume_fts_fail_fault(namespace).then(|| injected_failure_statement(label))
+}
+#[cfg(not(any(test, feature = "fault-injection")))]
+fn maybe_inject_fts_failure(_namespace: &str, _label: &str) -> Option<PlanStatement> {
+    None
+}
+
+#[cfg(any(test, feature = "fault-injection"))]
+fn maybe_inject_vector_failure(namespace: &str, label: &str) -> Option<PlanStatement> {
+    crate::operations::consume_vector_fail_fault(namespace)
+        .then(|| injected_failure_statement(label))
+}
+#[cfg(not(any(test, feature = "fault-injection")))]
+fn maybe_inject_vector_failure(_namespace: &str, _label: &str) -> Option<PlanStatement> {
+    None
+}
+
+/// DELETE-then-INSERT-then-log statements for one (note, model) vector row,
+/// replaying `khive-db::stores::vectors::replace_vector_row_dml`'s DML shape
+/// as plain [`PlanStatement`]s rather than a live `rusqlite::Connection`
+/// call — the same technique `atomic_prepare::push_index_purge_statements`
+/// uses for delete. Unguarded: same convention as the FTS-insert statement
+/// in `atomic_prepare::prepare_add_note` (the row's existence guard is
+/// carried by the plan's primary note-row statement, applied first).
+#[allow(clippy::too_many_arguments)]
+fn vector_insert_statements(
+    table: &str,
+    namespace: &str,
+    subject_id: Uuid,
+    field: &str,
+    embedding_model: &str,
+    embedding: &[f32],
+    label_prefix: &str,
+) -> Vec<PlanStatement> {
+    let subject = subject_id.to_string();
+    let kind_str = SubstrateKind::Note.to_string();
+    let blob = f32_vec_to_bytes(embedding);
+    vec![
+        // Delta-log any pre-existing row this REPLACE is about to evict —
+        // mirrors `log_vector_deletes`'s "replace" predicate exactly.
+        PlanStatement {
+            statement: SqlStatement {
+                sql: format!(
+                    "INSERT INTO ann_write_log \
+                     (namespace, embedding_model, kind, field, subject_id, op) \
+                     SELECT namespace, embedding_model, kind, field, subject_id, 'delete' \
+                     FROM {table} WHERE subject_id = ?1 AND NOT \
+                     (namespace = ?2 AND embedding_model = ?3 AND kind = ?4 AND field = ?5)"
+                ),
+                params: vec![
+                    SqlValue::Text(subject.clone()),
+                    SqlValue::Text(namespace.to_string()),
+                    SqlValue::Text(embedding_model.to_string()),
+                    SqlValue::Text(kind_str.clone()),
+                    SqlValue::Text(field.to_string()),
+                ],
+                label: Some(format!("{label_prefix}-log-delete")),
+            },
+            guard: None,
+        },
+        PlanStatement {
+            statement: SqlStatement {
+                sql: format!("DELETE FROM {table} WHERE subject_id = ?1"),
+                params: vec![SqlValue::Text(subject.clone())],
+                label: Some(format!("{label_prefix}-delete")),
+            },
+            guard: None,
+        },
+        PlanStatement {
+            statement: SqlStatement {
+                sql: format!(
+                    "INSERT INTO {table} \
+                     (subject_id, namespace, kind, field, embedding_model, embedding) \
+                     VALUES (?1, ?2, ?3, ?4, ?5, ?6)"
+                ),
+                params: vec![
+                    SqlValue::Text(subject.clone()),
+                    SqlValue::Text(namespace.to_string()),
+                    SqlValue::Text(kind_str.clone()),
+                    SqlValue::Text(field.to_string()),
+                    SqlValue::Text(embedding_model.to_string()),
+                    SqlValue::Blob(blob),
+                ],
+                label: Some(format!("{label_prefix}-insert")),
+            },
+            guard: None,
+        },
+        PlanStatement {
+            statement: SqlStatement {
+                sql: "INSERT INTO ann_write_log \
+                      (namespace, embedding_model, kind, field, subject_id, op) \
+                      VALUES (?1, ?2, ?3, ?4, ?5, 'upsert')"
+                    .to_string(),
+                params: vec![
+                    SqlValue::Text(namespace.to_string()),
+                    SqlValue::Text(embedding_model.to_string()),
+                    SqlValue::Text(kind_str),
+                    SqlValue::Text(field.to_string()),
+                    SqlValue::Text(subject),
+                ],
+                label: Some(format!("{label_prefix}-log-upsert")),
+            },
+            guard: None,
+        },
+    ]
+}
+
+/// Build and commit `specs` as one atomic unit. Returns the persisted
+/// [`Note`]s in the same order as `specs`. On any failure — pre-write
+/// validation, embedding, or the atomic commit pass itself — NO note, FTS
+/// document, or vector row from any spec is left behind (embed failures
+/// occur before any write is attempted; commit-pass failures roll back the
+/// whole unit per [`run_atomic_unit`]'s guarantee).
+pub async fn create_notes_atomic(
+    runtime: &KhiveRuntime,
+    specs: Vec<AtomicNoteSpec<'_>>,
+) -> RuntimeResult<Vec<Note>> {
+    // ---- 1. Validate + build Note objects (all pre-write checks, same as
+    // create_note_inner, before any embedding or DML is attempted). ----
+    let mut notes: Vec<Note> = Vec::with_capacity(specs.len());
+    for spec in &specs {
+        runtime.validate_note_kind(spec.kind)?;
+        crate::secret_gate::check(spec.content)?;
+        if let Some(n) = spec.name {
+            crate::secret_gate::check(n)?;
+        }
+        if let Some(ref p) = spec.properties {
+            crate::secret_gate::check_json(p)?;
+        }
+
+        let ns = spec.token.namespace().as_str();
+        let mut note = Note::new(ns, spec.kind, spec.content);
+        if let Some(id) = spec.id {
+            note.id = id;
+        }
+        if let Some(n) = spec.name {
+            note = note.with_name(n);
+        }
+        if let Some(p) = spec.properties.clone() {
+            note = note.with_properties(p);
+        }
+        notes.push(note);
+    }
+
+    // ---- 2. Embed every (note, model) pair in parallel, BEFORE opening any
+    // transaction. Any failure aborts here — no write has been attempted. ----
+    let embed_model_names = runtime.registered_embedding_model_names();
+    // (note_idx, model_idx) -> embedding, filled in as embed tasks complete.
+    let mut embeddings: Vec<Vec<Option<Vec<f32>>>> = notes
+        .iter()
+        .map(|_| vec![None; embed_model_names.len()])
+        .collect();
+
+    if !embed_model_names.is_empty() {
+        // Ensure every model's vector table exists before the commit pass —
+        // the same lazy-create side effect `vectors_for_model` performs on
+        // the non-atomic path, done once per model rather than per note.
+        for model_name in &embed_model_names {
+            runtime.vectors_for_model(specs[0].token, model_name)?;
+        }
+
+        let usage_ctx = crate::usage::current();
+        let mut join_set = tokio::task::JoinSet::new();
+        for (note_idx, (spec, note)) in specs.iter().zip(notes.iter()).enumerate() {
+            let text = crate::curation::note_embedding_text(note);
+            for (model_idx, model_name) in embed_model_names.iter().enumerate() {
+                let rt = runtime.clone();
+                let token = spec.token.clone();
+                let name = model_name.clone();
+                let text = text.clone();
+                let ctx = usage_ctx.clone();
+                join_set.spawn(async move {
+                    let fut = rt.embed_document_with_model_for_token(&token, &name, &text);
+                    let result = match ctx {
+                        Some(ctx) => crate::usage::scope(ctx, fut).await,
+                        None => fut.await,
+                    };
+                    (note_idx, model_idx, result)
+                });
+            }
+        }
+
+        while let Some(joined) = join_set.join_next().await {
+            match joined {
+                Ok((note_idx, model_idx, Ok(vector))) => {
+                    embeddings[note_idx][model_idx] = Some(vector);
+                }
+                Ok((_, _, Err(e))) => {
+                    join_set.abort_all();
+                    return Err(e);
+                }
+                Err(join_err) => {
+                    join_set.abort_all();
+                    return Err(RuntimeError::Internal(format!(
+                        "embed task panicked: {join_err}"
+                    )));
+                }
+            }
+        }
+    }
+
+    // ---- 3. Build one AddNotePlan per spec (row + FTS + vector-insert
+    // statements), all pre-computed embeddings already in hand. ----
+    let mut plans: Vec<AtomicOpPlan> = Vec::with_capacity(notes.len());
+    for (note, embeddings_for_note) in notes.iter().zip(embeddings) {
+        let mut statements = vec![PlanStatement {
+            statement: khive_db::stores::note::note_upsert_statement(note),
+            guard: Some(AffectedRowGuard::exactly(1)),
+        }];
+
+        if let Some(fault) = maybe_inject_fts_failure(&note.namespace, "fault-injected-fts") {
+            statements.push(fault);
+        } else {
+            statements.push(PlanStatement {
+                statement: khive_db::stores::text::insert_document_statement(
+                    "fts_notes",
+                    &note_fts_document(note),
+                ),
+                guard: None,
+            });
+        }
+
+        if let Some(fault) = maybe_inject_vector_failure(&note.namespace, "fault-injected-vector") {
+            statements.push(fault);
+        } else {
+            for (model_name, embedding) in embed_model_names.iter().zip(embeddings_for_note) {
+                let embedding = embedding.expect("every model index observed exactly once");
+                let table = format!("vec_{}", crate::config::sanitize_key(model_name));
+                statements.extend(vector_insert_statements(
+                    &table,
+                    &note.namespace,
+                    note.id,
+                    "note.content",
+                    model_name,
+                    &embedding,
+                    &format!("atomic-message-vec-{table}-{}", note.id),
+                ));
+            }
+        }
+
+        plans.push(AtomicOpPlan::AddNote(AddNotePlan {
+            note_id: note.id,
+            statements,
+            post_commit: PostCommitEffect::None,
+        }));
+    }
+
+    // ---- 4. One writer acquisition for the whole set. ----
+    match run_atomic_unit(runtime.sql().as_ref(), plans).await {
+        Ok(AtomicRunOutcome::Committed { .. }) => Ok(notes),
+        Ok(AtomicRunOutcome::RolledBack {
+            failed_op_index,
+            failure,
+        }) => Err(RuntimeError::Internal(format!(
+            "atomic multi-note write rolled back at op {failed_op_index}: {failure:?}"
+        ))),
+        Err(e) => Err(RuntimeError::Storage(e.0)),
+    }
+}

--- a/crates/khive-runtime/src/atomic_message.rs
+++ b/crates/khive-runtime/src/atomic_message.rs
@@ -40,7 +40,7 @@ use uuid::Uuid;
 
 use khive_storage::note::Note;
 use khive_storage::types::SqlValue;
-use khive_storage::SqlStatement;
+use khive_storage::{SqlStatement, StorageCapability, StorageError};
 use khive_types::SubstrateKind;
 
 use crate::atomic_plan::{AddNotePlan, AffectedRowGuard, PlanStatement, PostCommitEffect};
@@ -83,18 +83,46 @@ fn f32_vec_to_bytes(data: &[f32]) -> Vec<u8> {
     bytes
 }
 
-/// A harmless no-op `UPDATE` targeting a row that can never exist, guarded
-/// `exactly(1)` so it always fails its guard inside the atomic unit. Spliced
-/// in by test-only fault injection (see [`maybe_inject_fts_failure`]/
-/// [`maybe_inject_vector_failure`]) to prove the whole unit — not just the
-/// failing note's own plan — rolls back.
+/// Mirrors `khive-db`'s private `non_finite_index` — this crate has no
+/// visibility into that helper, so the check is reproduced here to keep the
+/// atomic path's embedding validation observably identical to the canonical
+/// `create_note_inner` -> `VectorStore::insert` path.
+fn non_finite_index(data: &[f32]) -> Option<usize> {
+    data.iter().position(|v| !v.is_finite())
+}
+
+/// Same error shape (capability, operation label, message) as `khive-db`'s
+/// private `non_finite_vector_error("vec_insert", ..)` — the atomic path
+/// must reject a non-finite embedding exactly as the raw `VectorStore::insert`
+/// DML does, not silently write it.
+fn non_finite_vector_error(idx: usize, value: f32) -> RuntimeError {
+    RuntimeError::Storage(StorageError::InvalidInput {
+        capability: StorageCapability::Vectors,
+        operation: "vec_insert".into(),
+        message: format!(
+            "non-finite value at index {idx}: {value} \
+             (NaN/Inf values corrupt distance computations)"
+        ),
+    })
+}
+
+/// A harmless no-op `UPDATE` with a statically zero-row predicate (`WHERE 1
+/// = 0`, not a match against a specific id), guarded `exactly(1)` so it
+/// always fails its guard inside the atomic unit regardless of which note
+/// ids exist in the store — a fixed nil-UUID predicate would pass its guard
+/// if a caller ever supplied that id. Spliced in by test-only fault
+/// injection (see [`maybe_inject_fts_failure`]/[`maybe_inject_vector_failure`])
+/// to prove the whole unit — not just the failing note's own plan — rolls
+/// back.
+///
+/// `fault-injection` is an ordinary Cargo feature (see this crate's
+/// `Cargo.toml`); it must never be enabled in a packaged/release build —
+/// doing so would compile this fault-injection path into a shipped binary.
 #[cfg(any(test, feature = "fault-injection"))]
 fn injected_failure_statement(label: &str) -> PlanStatement {
     PlanStatement {
         statement: SqlStatement {
-            sql: "UPDATE notes SET updated_at = updated_at \
-                  WHERE id = '00000000-0000-0000-0000-000000000000'"
-                .to_string(),
+            sql: "UPDATE notes SET updated_at = updated_at WHERE 1 = 0".to_string(),
             params: vec![],
             label: Some(label.to_string()),
         },
@@ -305,6 +333,19 @@ pub async fn create_notes_atomic(
         }
     }
 
+    // Reject any non-finite embedding value BEFORE any plan is built — same
+    // validation the canonical `VectorStore::insert` DML performs, applied
+    // here so a bad custom embedding provider never reaches the raw vector
+    // insert on this path (embed-first: no note, FTS document, or vector row
+    // has been written yet).
+    for embeddings_for_note in &embeddings {
+        for embedding in embeddings_for_note.iter().flatten() {
+            if let Some(idx) = non_finite_index(embedding) {
+                return Err(non_finite_vector_error(idx, embedding[idx]));
+            }
+        }
+    }
+
     // ---- 3. Build one AddNotePlan per spec (row + FTS + vector-insert
     // statements), all pre-computed embeddings already in hand. ----
     let mut plans: Vec<AtomicOpPlan> = Vec::with_capacity(notes.len());
@@ -317,6 +358,19 @@ pub async fn create_notes_atomic(
         if let Some(fault) = maybe_inject_fts_failure(&note.namespace, "fault-injected-fts") {
             statements.push(fault);
         } else {
+            // Delete-then-insert upsert — mirrors `text.rs`'s
+            // `upsert_document_dml` exactly, so a caller-supplied/reused note
+            // id never leaves a stale/duplicate FTS document behind (the
+            // note row itself is already an upsert via
+            // `note_upsert_statement`).
+            statements.push(PlanStatement {
+                statement: khive_db::stores::text::delete_document_statement(
+                    "fts_notes",
+                    &note.namespace,
+                    note.id,
+                ),
+                guard: None,
+            });
             statements.push(PlanStatement {
                 statement: khive_db::stores::text::insert_document_statement(
                     "fts_notes",
@@ -361,5 +415,212 @@ pub async fn create_notes_atomic(
             "atomic multi-note write rolled back at op {failed_op_index}: {failure:?}"
         ))),
         Err(e) => Err(RuntimeError::Storage(e.0)),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use async_trait::async_trait;
+    use lattice_embed::{EmbedError, EmbeddingModel, EmbeddingService};
+
+    use khive_types::Namespace;
+
+    use crate::embedder_registry::EmbedderProvider;
+
+    const NAN_MODEL: &str = "atomic-message-nan-model";
+    const NAN_DIMS: usize = 4;
+
+    struct NanService;
+    #[async_trait]
+    impl EmbeddingService for NanService {
+        async fn embed(
+            &self,
+            texts: &[String],
+            _model: EmbeddingModel,
+        ) -> Result<Vec<Vec<f32>>, EmbedError> {
+            Ok(texts.iter().map(|_| vec![f32::NAN; NAN_DIMS]).collect())
+        }
+        fn supports_model(&self, _model: EmbeddingModel) -> bool {
+            true
+        }
+        fn name(&self) -> &'static str {
+            NAN_MODEL
+        }
+    }
+    struct NanProvider;
+    #[async_trait]
+    impl EmbedderProvider for NanProvider {
+        fn name(&self) -> &str {
+            NAN_MODEL
+        }
+        fn dimensions(&self) -> usize {
+            NAN_DIMS
+        }
+        async fn build(&self) -> RuntimeResult<std::sync::Arc<dyn EmbeddingService>> {
+            Ok(std::sync::Arc::new(NanService))
+        }
+    }
+
+    async fn fts_row_count(runtime: &KhiveRuntime, namespace: &str) -> i64 {
+        let mut reader = runtime.sql().reader().await.expect("sql reader");
+        match reader
+            .query_scalar(SqlStatement {
+                sql: "SELECT COUNT(*) FROM fts_notes WHERE namespace = ?1".to_string(),
+                params: vec![SqlValue::Text(namespace.to_string())],
+                label: None,
+            })
+            .await
+            .expect("fts count query")
+        {
+            Some(SqlValue::Integer(n)) => n,
+            other => panic!("unexpected fts count result: {other:?}"),
+        }
+    }
+
+    async fn ann_write_log_count(runtime: &KhiveRuntime, namespace: &str, model: &str) -> i64 {
+        let mut reader = runtime.sql().reader().await.expect("sql reader");
+        match reader
+            .query_scalar(SqlStatement {
+                sql: "SELECT COUNT(*) FROM ann_write_log \
+                      WHERE namespace = ?1 AND embedding_model = ?2"
+                    .to_string(),
+                params: vec![
+                    SqlValue::Text(namespace.to_string()),
+                    SqlValue::Text(model.to_string()),
+                ],
+                label: None,
+            })
+            .await
+            .expect("ann_write_log count query")
+        {
+            Some(SqlValue::Integer(n)) => n,
+            other => panic!("unexpected ann_write_log count result: {other:?}"),
+        }
+    }
+
+    /// A custom embedding provider returning NaN must be rejected BEFORE any
+    /// plan is built — same validation `VectorStore::insert` performs on the
+    /// canonical `create_note_inner` path. No note row, FTS document, vector
+    /// row, or `ann_write_log` row may be committed.
+    #[tokio::test]
+    async fn create_notes_atomic_rejects_non_finite_embedding_before_any_write() {
+        let runtime = KhiveRuntime::memory().expect("in-memory runtime");
+        runtime.register_embedder(NanProvider);
+        let ns = "atomic-message-nan-test";
+        let token = runtime
+            .authorize(Namespace::parse(ns).unwrap())
+            .expect("authorize");
+
+        let result = create_notes_atomic(
+            &runtime,
+            vec![AtomicNoteSpec {
+                token: &token,
+                id: None,
+                kind: "observation",
+                name: None,
+                content: "nan embedding content",
+                properties: None,
+            }],
+        )
+        .await;
+
+        assert!(
+            result.is_err(),
+            "a non-finite embedding must be rejected; got {result:?}"
+        );
+
+        let alive = runtime
+            .list_notes(&token, Some("observation"), 100, 0)
+            .await
+            .expect("list_notes")
+            .into_iter()
+            .filter(|n| n.deleted_at.is_none())
+            .count();
+        assert_eq!(
+            alive, 0,
+            "no note row may be committed when an embedding is non-finite"
+        );
+
+        assert_eq!(
+            fts_row_count(&runtime, ns).await,
+            0,
+            "no FTS document may be committed when an embedding is non-finite"
+        );
+
+        let vs = runtime
+            .vectors_for_model(&token, NAN_MODEL)
+            .expect("vec store");
+        assert_eq!(
+            vs.count().await.expect("count"),
+            0,
+            "no vector row may be committed when an embedding is non-finite"
+        );
+
+        assert_eq!(
+            ann_write_log_count(&runtime, ns, NAN_MODEL).await,
+            0,
+            "no ann_write_log row may be committed when an embedding is non-finite"
+        );
+    }
+
+    /// Calling `create_notes_atomic` twice with the SAME caller-supplied id
+    /// (different content each time) must leave exactly one FTS document for
+    /// that id, reflecting the latest content — not an append of two
+    /// documents (the note row is already an upsert; the FTS half must match).
+    #[tokio::test]
+    async fn create_notes_atomic_upserts_fts_document_for_reused_note_id() {
+        let runtime = KhiveRuntime::memory().expect("in-memory runtime");
+        let ns = "atomic-message-fts-upsert-test";
+        let token = runtime
+            .authorize(Namespace::parse(ns).unwrap())
+            .expect("authorize");
+        let id = Uuid::new_v4();
+
+        create_notes_atomic(
+            &runtime,
+            vec![AtomicNoteSpec {
+                token: &token,
+                id: Some(id),
+                kind: "observation",
+                name: None,
+                content: "first content",
+                properties: None,
+            }],
+        )
+        .await
+        .expect("first write with supplied id");
+
+        create_notes_atomic(
+            &runtime,
+            vec![AtomicNoteSpec {
+                token: &token,
+                id: Some(id),
+                kind: "observation",
+                name: None,
+                content: "second content replacing the first",
+                properties: None,
+            }],
+        )
+        .await
+        .expect("second write reusing the same id");
+
+        assert_eq!(
+            fts_row_count(&runtime, ns).await,
+            1,
+            "exactly one FTS document may exist for the reused id"
+        );
+
+        let text = runtime.text_for_notes(&token).expect("text store");
+        let doc = text
+            .get_document(ns, id)
+            .await
+            .expect("get_document")
+            .expect("document exists for the reused id");
+        assert!(
+            doc.body.contains("second content"),
+            "the surviving FTS document must reflect the latest content; got {:?}",
+            doc.body
+        );
     }
 }

--- a/crates/khive-runtime/src/lib.rs
+++ b/crates/khive-runtime/src/lib.rs
@@ -3,6 +3,7 @@
 //! Wraps `StorageBackend` and query compilation into a single Rust API surface.
 
 pub mod actor_identity;
+pub mod atomic_message;
 pub mod atomic_plan;
 pub mod atomic_prepare;
 pub mod atomic_runner;
@@ -35,6 +36,7 @@ pub use khive_storage::usage;
 pub mod validation;
 
 pub use actor_identity::{actor_is_unattributed, resolve_actor, should_warn_unattributed_actor};
+pub use atomic_message::{create_notes_atomic, AtomicNoteSpec};
 pub use atomic_plan::{
     AddEntityPlan, AddNotePlan, AffectedRowGuard, DeletePlan, GovernanceOp, GovernancePlan,
     GtdCompletePlan, GtdTransitionPlan, LinkPlan, MergePlan, PlanPredicate, PlanStatement,

--- a/crates/khive-runtime/src/operations.rs
+++ b/crates/khive-runtime/src/operations.rs
@@ -269,6 +269,23 @@ pub fn arm_rollback_cleanup_fail(ns: &str) {
     *ROLLBACK_CLEANUP_FAIL_NS.lock().unwrap() = Some(ns.to_string());
 }
 
+/// `atomic_message::create_notes_atomic` equivalents of the `FTS_FAIL_NS`/
+/// `VECTOR_FAIL_NS` checks above, reusing the SAME arm sets (and thus the
+/// SAME `arm_fts_fail_scoped`/`arm_vector_fail_scoped` test API) so a test
+/// can arm one call and exercise either write path. `create_notes_atomic`
+/// builds raw `PlanStatement`s instead of calling `text_for_notes()`/
+/// `vectors_for_model().insert()`, so it cannot reuse `consume_fault`
+/// in-line the way `create_note_inner` does above; these wrappers are the
+/// seam that lets it check the same arms.
+#[cfg(any(test, feature = "fault-injection"))]
+pub(crate) fn consume_fts_fail_fault(ns: &str) -> bool {
+    consume_fault(&FTS_FAIL_NS, ns)
+}
+#[cfg(any(test, feature = "fault-injection"))]
+pub(crate) fn consume_vector_fail_fault(ns: &str) -> bool {
+    consume_fault(&VECTOR_FAIL_NS, ns)
+}
+
 /// A note search result with UUID, salience-weighted RRF score, and display text.
 #[derive(Clone, Debug)]
 pub struct NoteSearchHit {


### PR DESCRIPTION
## Summary

Under concurrent multi-client load, sending a message costs roughly a
dozen separate writer acquisitions: two note writes (outbound +
inbound copy), each with its own row insert, FTS document write, and
one vector-row insert per registered embedding model. Every one of
those is a separate writer checkout, so a burst of concurrent sends
serializes hard on the single writer and a crash between the two note
writes can leave a durable orphan — an outbound copy with no matching
inbound copy.

This change collapses the whole pair into **one writer transaction**:

- **New `khive-runtime` primitive**, `create_notes_atomic()`, built on
  the existing `AddNotePlan`/`run_atomic_unit` atomic-unit machinery,
  extended with vector-insert statements. It creates an arbitrary set
  of notes — each with its row, FTS document, and every registered
  model's vector row — under one `BEGIN IMMEDIATE` transaction.
- **Embed-first**: every note's embeddings, across every registered
  model, are computed *before* the transaction opens, in parallel.
  The writer is held only for synchronous DML — never across an
  embedding call.
- **`dual_write_message` in `khive-pack-comm`** now calls this
  primitive for both the send and reply paths. The outbound message's
  id is pre-generated so the canonical `thread_id` is known before
  either write — both copies carry it from their first write, which
  also removes a separate patch-write that root sends used to need.
- The old in-process rollback compensation (delete the outbound row if
  the inbound write fails) is deleted — it's no longer needed once
  both writes are one transaction, and it never covered a crash
  between the two writes anyway. That gap is now closed by
  construction: any failure inside the unit — from a bad guard to an
  injected fault to a real SQL error — rolls back everything, so no
  partial pair can ever be observed durably.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy -p khive-runtime -p khive-pack-comm --all-targets -- -D warnings`
- [x] `cargo test -p khive-runtime -p khive-pack-comm` (1017 + 238 tests, all passing)
- [x] Fault-injection test proves a mid-unit failure (FTS or vector)
      rolls back the *whole* unit, including an outbound copy already
      applied in a different namespace
- [x] A root send's canonical `thread_id` is asserted to land on both
      copies from their first write (`created_at == updated_at`, i.e.
      no later patch write ever touched either row)
- [x] A multi-model send is asserted to land the expected
      note/FTS/vector row counts for both copies under one atomic unit

🤖 Generated with [Claude Code](https://claude.com/claude-code)