### PR TITLE
fix(comm): make read mark-read best-effort under writer contention

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -161,7 +161,7 @@ Composite scores are always in [0,1]. Typical production floor: 0.3-0.7.
 | ------------- | ---------------------------------------------------------------------- | --------------------------------------------- |
 | `comm.send`   | Send a message (optionally threaded)                                   | Inter-agent or inter-namespace messaging      |
 | `comm.inbox`  | List inbound messages                                                  | Check what's waiting                          |
-| `comm.read`   | Mark an **inbound** message as read                                    | Acknowledge receipt (recipient action)        |
+| `comm.read`   | Mark an **inbound** message as read (best-effort: check `read` in the response; `false` + `mark_error` means re-issue later) | Acknowledge receipt (recipient action)        |
 | `comm.reply`  | Reply to a message (threading linkage)                                 | Respond in-thread                             |
 | `comm.thread` | Retrieve full conversation thread                                      | Read the whole conversation                   |
 | `comm.health` | Per-channel health snapshot (no args)                                  | Check daemon channel-poll state               |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -157,15 +157,15 @@ Composite scores are always in [0,1]. Typical production floor: 0.3-0.7.
 
 ### Comm pack — 7 verbs (`comm.` prefix)
 
-| Verb          | What it does                                                           | When to use                                   |
-| ------------- | ---------------------------------------------------------------------- | --------------------------------------------- |
-| `comm.send`   | Send a message (optionally threaded)                                   | Inter-agent or inter-namespace messaging      |
-| `comm.inbox`  | List inbound messages                                                  | Check what's waiting                          |
+| Verb          | What it does                                                                                                                 | When to use                                   |
+| ------------- | ---------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------- |
+| `comm.send`   | Send a message (optionally threaded)                                                                                         | Inter-agent or inter-namespace messaging      |
+| `comm.inbox`  | List inbound messages                                                                                                        | Check what's waiting                          |
 | `comm.read`   | Mark an **inbound** message as read (best-effort: check `read` in the response; `false` + `mark_error` means re-issue later) | Acknowledge receipt (recipient action)        |
-| `comm.reply`  | Reply to a message (threading linkage)                                 | Respond in-thread                             |
-| `comm.thread` | Retrieve full conversation thread                                      | Read the whole conversation                   |
-| `comm.health` | Per-channel health snapshot (no args)                                  | Check daemon channel-poll state               |
-| `comm.probe`  | Read-only poll for new inbound message metadata and stale unread count | Cheap wake-up check without a full inbox scan |
+| `comm.reply`  | Reply to a message (threading linkage)                                                                                       | Respond in-thread                             |
+| `comm.thread` | Retrieve full conversation thread                                                                                            | Read the whole conversation                   |
+| `comm.health` | Per-channel health snapshot (no args)                                                                                        | Check daemon channel-poll state               |
+| `comm.probe`  | Read-only poll for new inbound message metadata and stale unread count                                                       | Cheap wake-up check without a full inbox scan |
 
 **Inbox shape (ADR-057).** `comm.inbox` is scannable: each entry carries top-level `from`, `to`,
 `subject`, `read`, `direction`, and a derived `preview` (whitespace-collapsed, truncated to 80

--- a/crates/khive-pack-comm/README.md
+++ b/crates/khive-pack-comm/README.md
@@ -10,7 +10,7 @@ dual-write, actor-addressed delivery.
 | ------------- | ------------------------------------------------------------------ |
 | `comm.send`   | Send a message, optionally threaded                                |
 | `comm.inbox`  | List inbound messages for the caller (filter: unread / read / all) |
-| `comm.read`   | Mark an inbound message as read                                    |
+| `comm.read`   | Mark an inbound message as read (best-effort: inspect `read`; `false` plus `mark_error` means re-issue later) |
 | `comm.unread` | Count the caller's unread inbound messages without message payloads |
 | `comm.reply`  | Reply to a message, preserving thread linkage                      |
 | `comm.thread` | Retrieve all messages in a conversation thread, chronologically    |

--- a/crates/khive-pack-comm/README.md
+++ b/crates/khive-pack-comm/README.md
@@ -6,14 +6,14 @@ dual-write, actor-addressed delivery.
 
 ## Verbs
 
-| Verb          | What it does                                                       |
-| ------------- | ------------------------------------------------------------------ |
-| `comm.send`   | Send a message, optionally threaded                                |
-| `comm.inbox`  | List inbound messages for the caller (filter: unread / read / all) |
-| `comm.read`   | Mark an inbound message as read (best-effort: inspect `read`; `false` plus `mark_error` means re-issue later) |
-| `comm.unread` | Count the caller's unread inbound messages without message payloads |
-| `comm.reply`  | Reply to a message, preserving thread linkage                      |
-| `comm.thread` | Retrieve all messages in a conversation thread, chronologically    |
+| Verb          | What it does                                                                                                                                                  |
+| ------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `comm.send`   | Send a message, optionally threaded                                                                                                                           |
+| `comm.inbox`  | List inbound messages for the caller (filter: unread / read / all)                                                                                            |
+| `comm.read`   | Mark an inbound message as read (best-effort: inspect `read`; `false` plus `mark_error` means re-issue later)                                                 |
+| `comm.unread` | Count the caller's unread inbound messages without message payloads                                                                                           |
+| `comm.reply`  | Reply to a message, preserving thread linkage                                                                                                                 |
+| `comm.thread` | Retrieve all messages in a conversation thread, chronologically                                                                                               |
 | `comm.probe`  | Read-only poll for new inbound message metadata and a stale unread count (takes an explicit `actor`; unlike `comm.inbox`, it is not inferred from the caller) |
 
 A sixth handler, `comm.ingest`, is `Visibility::Subhandler` — it lets an

--- a/crates/khive-pack-comm/docs/api/message-lifecycle.md
+++ b/crates/khive-pack-comm/docs/api/message-lifecycle.md
@@ -138,6 +138,32 @@ is keyed on `notes_seq.seq`, which is fixed at first insert and survives such
 churn, so this is defensive rather than load-bearing; a metadata patch should
 never rewrite the row regardless.
 
+The mark-read patch is best-effort: under multi-client burst traffic the
+sqlite writer pool can time out (`checkout_timeout`, 5s default), and the
+read itself has already succeeded by the time the patch runs, so a failed or
+no-op write no longer fails the whole call. This follows the same
+high-level best-effort principle as `handle_reply`'s fold-in mark, which has
+been best-effort since its introduction. Three outcomes:
+
+- `Ok(true)` — the row was live and updated: `read: true`, `properties` is
+  the patched value (including the new `read: true`).
+- `Ok(false)` — no live row was found to update (e.g. soft-deleted
+  mid-flight, between this handler's `get_note` and its
+  `update_note_properties` call): `read: false`, `mark_error: "no live row
+  updated"`, `properties` is the note's ORIGINAL stored value (a stored
+  SQL-NULL properties column round-trips as JSON `null`, never `{}`) — the
+  response never claims a write that did not land.
+- `Err(e)` — the patch failed (writer timeout, pool exhaustion, etc.):
+  logged via `tracing::warn!` with the full error detail, then `read:
+  false`, `mark_error` is the error's `Display` string, `properties` is the
+  original stored value (again `null` if that is what was stored).
+
+`id`/`full_id` are returned in all three arms — only the mark degrades, not
+the read. There is no retry loop; a caller polling unread counts simply
+sees the message still unread and can re-issue `comm.read` (self-healing).
+Every validation error that runs before the patch (not found, wrong kind,
+outbound, wrong addressee) is unaffected and stays a hard error.
+
 ## `handlers.rs::handle_reply`
 
 Replies to a message, threading linkage.

--- a/crates/khive-pack-comm/src/handlers.rs
+++ b/crates/khive-pack-comm/src/handlers.rs
@@ -440,18 +440,83 @@ pub(crate) async fn handle_read(
 
     // Patch via a real `UPDATE`, not `upsert_note`'s `INSERT OR REPLACE` (#780
     // silently re-inserts the row on conflict). See docs/api/message-lifecycle.md#handlersrshandle_read
-    let mut props = note.properties.clone().unwrap_or_else(|| json!({}));
+    //
+    // `orig_props` is kept as the stored `Option<Value>` (a SQL-NULL
+    // properties column is a real, distinct state from `{}`) so a degraded
+    // response can report exactly what is stored; `props` is a
+    // separately-normalized object used only for the attempted patch.
+    let orig_props = note.properties.clone();
+    let mut props = orig_props.clone().unwrap_or_else(|| json!({}));
     props["read"] = json!(true);
     let updated_at = Utc::now().timestamp_micros();
 
-    store
+    // Best-effort: under multi-client writer contention the pool checkout can
+    // time out. The read itself already succeeded above — failing the whole
+    // call over a delivery-state patch would throw away a successful read for
+    // a caller who cannot retry the fetch half. Mirrors handle_reply's
+    // fold-in mark-read: `Ok(false)` (no live row
+    // updated, e.g. soft-deleted mid-flight) and `Err` both degrade to
+    // `read: false` + `mark_error` instead of failing the response. A caller
+    // polling unread counts simply sees the message still unread and can
+    // re-issue `read` — self-healing, no retry loop needed here.
+    let patch_result = store
         .update_note_properties(id, Some(props.clone()), updated_at)
-        .await
-        .map_err(|e| RuntimeError::Internal(format!("read: update_note_properties: {e}")))?;
+        .await;
 
-    Ok(
-        json!({ "id": short_id(id), "full_id": id.as_hyphenated().to_string(), "read": true, "properties": props }),
-    )
+    Ok(read_response(
+        short_id(id),
+        id.as_hyphenated().to_string(),
+        patch_result,
+        orig_props,
+        props,
+    ))
+}
+
+/// Assemble `comm.read`'s response from the mark-read patch outcome.
+///
+/// Factored out so the three degrade arms (`Ok(true)`, `Ok(false)`, `Err`)
+/// are unit-testable directly: the `Ok(false)`/soft-delete-mid-flight race
+/// cannot be arranged honestly through the public dispatch path (`handle_read`
+/// fetches and patches within a single sequential call, with no seam to
+/// inject a concurrent delete between the two), so the response shape is
+/// verified against this pure function instead of a racing integration test.
+fn read_response(
+    short: String,
+    full: String,
+    patch_result: Result<bool, khive_storage::StorageError>,
+    original_properties: Option<Value>,
+    patched_properties: Value,
+) -> Value {
+    match patch_result {
+        Ok(true) => json!({
+            "id": short,
+            "full_id": full,
+            "read": true,
+            "properties": patched_properties,
+        }),
+        Ok(false) => json!({
+            "id": short,
+            "full_id": full,
+            "read": false,
+            "mark_error": "no live row updated",
+            "properties": original_properties,
+        }),
+        Err(e) => {
+            tracing::warn!(
+                id = %full,
+                error = %e,
+                "comm.read: mark-read update failed under writer contention; \
+                 degrading to read:false (best-effort)"
+            );
+            json!({
+                "id": short,
+                "full_id": full,
+                "read": false,
+                "mark_error": e.to_string(),
+                "properties": original_properties,
+            })
+        }
+    }
 }
 
 /// `reply` — reply to a message, threading linkage. See
@@ -2045,9 +2110,11 @@ fn build_references_header(parent_chain: Option<&str>, parent_message_id: &str) 
 mod tests {
     use super::{
         build_references_header, heartbeat_note_id, message_id_match_candidates,
-        parent_references_chain, parent_wire_message_id, sanitize_reference_token, wrap_message_id,
+        parent_references_chain, parent_wire_message_id, read_response, sanitize_reference_token,
+        wrap_message_id,
     };
-    use serde_json::json;
+    use khive_storage::StorageError;
+    use serde_json::{json, Value};
 
     // #606: a delimiter-joined
     // `format!("...:{a}:{b}:{c}")` id encoding is not injective once
@@ -2330,6 +2397,129 @@ mod tests {
         assert_eq!(
             build_references_header(chain, "parent123@example.com"),
             "<parent123@example.com>"
+        );
+    }
+
+    // read_response's three arms are unit-tested directly because the
+    // `Ok(false)` case (a live row vanishing between handle_read's `get_note`
+    // and its `update_note_properties` call) cannot be arranged honestly
+    // through the public dispatch path: the two calls are sequential within
+    // one handler invocation with no seam to inject a concurrent delete.
+
+    #[test]
+    fn read_response_ok_true_reports_read_and_patched_properties() {
+        let original = json!({ "direction": "inbound", "read": false });
+        let patched = json!({ "direction": "inbound", "read": true });
+        let resp = read_response(
+            "abc123".to_string(),
+            "full-uuid".to_string(),
+            Ok(true),
+            Some(original),
+            patched.clone(),
+        );
+        assert_eq!(resp["id"], json!("abc123"));
+        assert_eq!(resp["full_id"], json!("full-uuid"));
+        assert_eq!(resp["read"], json!(true));
+        assert_eq!(resp["properties"], patched);
+        assert!(
+            resp.get("mark_error").is_none(),
+            "a successful mark must not carry mark_error; got {resp}"
+        );
+    }
+
+    #[test]
+    fn read_response_ok_false_degrades_without_claiming_the_patch_landed() {
+        let original = json!({ "direction": "inbound", "read": false });
+        let patched = json!({ "direction": "inbound", "read": true });
+        let resp = read_response(
+            "abc123".to_string(),
+            "full-uuid".to_string(),
+            Ok(false),
+            Some(original.clone()),
+            patched,
+        );
+        assert_eq!(resp["id"], json!("abc123"));
+        assert_eq!(resp["full_id"], json!("full-uuid"));
+        assert_eq!(resp["read"], json!(false));
+        assert_eq!(
+            resp["mark_error"],
+            json!("no live row updated"),
+            "got {resp}"
+        );
+        assert_eq!(
+            resp["properties"], original,
+            "must report the ORIGINAL stored properties, never the attempted \
+             patch, when the write did not land; got {resp}"
+        );
+    }
+
+    #[test]
+    fn read_response_ok_false_preserves_stored_null_properties() {
+        let patched = json!({ "read": true });
+        let resp = read_response(
+            "abc123".to_string(),
+            "full-uuid".to_string(),
+            Ok(false),
+            None,
+            patched,
+        );
+        assert_eq!(resp["id"], json!("abc123"));
+        assert_eq!(resp["full_id"], json!("full-uuid"));
+        assert_eq!(resp["read"], json!(false));
+        assert_eq!(
+            resp["properties"],
+            Value::Null,
+            "a stored SQL-NULL properties column must round-trip as JSON \
+             null, never as {{}}; got {resp}"
+        );
+    }
+
+    #[test]
+    fn read_response_err_degrades_and_reports_the_error_string() {
+        let original = json!({ "direction": "inbound", "read": false });
+        let patched = json!({ "direction": "inbound", "read": true });
+        let err = StorageError::Timeout {
+            operation: "update_note_properties".into(),
+        };
+        let err_text = err.to_string();
+        let resp = read_response(
+            "abc123".to_string(),
+            "full-uuid".to_string(),
+            Err(err),
+            Some(original.clone()),
+            patched,
+        );
+        assert_eq!(resp["id"], json!("abc123"));
+        assert_eq!(resp["full_id"], json!("full-uuid"));
+        assert_eq!(resp["read"], json!(false));
+        assert_eq!(resp["mark_error"], json!(err_text));
+        assert_eq!(
+            resp["properties"], original,
+            "must report the ORIGINAL stored properties on a write error; got {resp}"
+        );
+    }
+
+    #[test]
+    fn read_response_err_preserves_stored_null_properties() {
+        let patched = json!({ "read": true });
+        let err = StorageError::Timeout {
+            operation: "update_note_properties".into(),
+        };
+        let resp = read_response(
+            "abc123".to_string(),
+            "full-uuid".to_string(),
+            Err(err),
+            None,
+            patched,
+        );
+        assert_eq!(resp["id"], json!("abc123"));
+        assert_eq!(resp["full_id"], json!("full-uuid"));
+        assert_eq!(resp["read"], json!(false));
+        assert_eq!(
+            resp["properties"],
+            Value::Null,
+            "a stored SQL-NULL properties column must round-trip as JSON \
+             null, never as {{}}; got {resp}"
         );
     }
 }

--- a/crates/khive-pack-comm/src/vocab.rs
+++ b/crates/khive-pack-comm/src/vocab.rs
@@ -117,7 +117,7 @@ pub(crate) static COMM_HANDLERS: [HandlerDef; 12] = [
     },
     HandlerDef {
         name: "comm.read",
-        description: "Mark an inbound message as read.",
+        description: "Mark an inbound message as read. Best-effort: on a mark-write failure the response still succeeds with read=false and a mark_error field; re-issue later.",
         visibility: Visibility::Verb,
         category: khive_types::VerbCategory::Declaration,
         params: &[ParamDef {

--- a/docs/adr/ADR-040-communication-and-schedule-packs.md
+++ b/docs/adr/ADR-040-communication-and-schedule-packs.md
@@ -593,3 +593,35 @@ standard `delete(id)` path.
   `inbox`, `agenda` are assertive; `read`, `cancel` are declarative.
 - ADR-027: Dynamic Pack Loading — self-registration via `inventory::submit!`.
 - ADR-028: Pack-Scoped Backends — `default_backend = "main"` for both packs.
+
+## Amendment (2026-08-01): `comm.read` degraded mark-read contract
+
+The `comm.read` row in the verb table above (line 102) states unconditionally that the
+verb "Set[s] `properties.read = true`" and "Returns the updated message envelope." That
+wording is only accurate when the post-read mark-read patch actually lands. Under
+multi-client writer contention the mark-read patch can
+time out or find no live row to update, and `handle_read` now degrades instead of failing
+the whole call: the fetch already succeeded, so a delivery-state patch failure should not
+throw away a successful read for a caller who cannot retry the fetch half.
+
+**Corrected contract**: validation errors that run before the patch (not found, wrong
+kind, outbound direction, wrong addressee) remain fatal and unchanged. The post-read
+mark-read patch itself is best-effort:
+
+- On success, the response is as originally specified: `read: true`, `properties` is the
+  updated envelope.
+- On a no-op (no live row updated, e.g. soft-deleted mid-flight) or a storage error, the
+  response degrades to `read: false` with a `mark_error` field (a fixed string for the
+  no-op case, the error's `Display` string otherwise) and `properties` set to the
+  pre-patch stored value — never a value implying the patch landed.
+
+This is eventual consistency on the read flag, not a correctness gap: a caller polling
+unread counts sees the message still unread and can simply re-issue `comm.read`
+(self-healing, no retry loop needed in the handler). See
+`crates/khive-pack-comm/docs/api/message-lifecycle.md#handlersrshandle_read` for the full
+three-arm contract and `crates/khive-pack-comm/src/handlers.rs::read_response` for the
+implementation. The `comm.read` discovery description in
+`crates/khive-pack-comm/src/vocab.rs` and the public guides (`AGENTS.md`,
+`docs/guide/api-reference.md`, `docs/guide/communication.md`, the comm skill) carry the
+best-effort wording; the verbatim `HandlerDef` snippet earlier in this ADR reflects the
+original pre-amendment description.

--- a/docs/guide/api-reference.md
+++ b/docs/guide/api-reference.md
@@ -1104,7 +1104,11 @@ for compatibility, while `short_id` is the compact display-only prefix.
 
 ### `comm.read` — Declaration
 
-Mark an inbound message as read. Outbound messages cannot be marked read.
+Mark an inbound message as read. Outbound messages cannot be marked read. The mark-read
+write is best-effort: validation errors (not found, wrong kind, outbound direction, wrong
+addressee) remain fatal, but when the post-read mark write fails or finds no live row the
+call still succeeds with `read: false` and a `mark_error` field — inspect `read` and
+re-issue later if it is `false`.
 
 | Param | Type   | Required | Notes                                              |
 | ----- | ------ | -------- | -------------------------------------------------- |

--- a/docs/guide/communication.md
+++ b/docs/guide/communication.md
@@ -55,7 +55,9 @@ request(ops="comm.inbox(status=\"all\")")
 
 ### Read
 
-Marks an inbound message read. Outbound messages cannot be marked read.
+Marks an inbound message read. Outbound messages cannot be marked read. The mark write is
+best-effort: a successful response can carry `read: false` plus `mark_error` when the mark
+did not land — check `read` and re-issue later if needed.
 
 ```
 request(ops="comm.read(id=\"<message_id_or_prefix>\")")

--- a/marketplace/khive/skills/comm/SKILL.md
+++ b/marketplace/khive/skills/comm/SKILL.md
@@ -64,6 +64,9 @@ The fields you triage on are surfaced at the **top level** — no digging into `
 
 Scan `from` + `subject` + `preview`, open `content` for the ones that matter, then
 `comm.read(id="<full_id>")` to clear them. Always pass a `limit` — active inboxes are large.
+The mark-read write is best-effort: a successful response can carry `read: false` plus a
+`mark_error` when the mark did not land (e.g. under writer contention). Check `read` in the
+response; if it is `false`, the message stays unread — re-issue `comm.read` later.
 
 ### 4. Reply to thread, don't start a new one
 


### PR DESCRIPTION
## Problem

`comm.read` validates and fetches the message successfully, then fails the WHOLE call when the post-read mark-read patch cannot land — either a writer-pool checkout timeout under concurrent multi-client load, or no live row to update (soft-deleted mid-flight). The fetch half is not retryable by the caller, so a delivery-state patch failure throws away a successful read.

## Change

The mark-read patch becomes best-effort, factored into a pure three-arm `read_response()`:

- `Ok(true)` — row live and updated: `read: true`, patched properties.
- `Ok(false)` — no live row updated: `read: false` + `mark_error`, ORIGINAL stored properties (SQL NULL round-trips as JSON null, never fabricated `{}`).
- `Err` — storage error: `tracing::warn!` + `read: false` + `mark_error`, original properties.

Validation errors before the patch (not found, wrong kind, outbound direction, wrong addressee) remain fatal and unchanged. This is eventual consistency on the read flag: the message stays unread and the caller simply re-issues `comm.read`.

## Docs

- ADR-040 gains a dated amendment for the corrected contract (the verb-table wording was unconditionally 'sets read=true').
- `message-lifecycle.md` documents the three-arm contract.
- The discovery description (`vocab.rs`) and all public guides (`AGENTS.md`, `api-reference.md`, `communication.md`, comm skill) now describe best-effort semantics and tell callers to inspect `read`/`mark_error` and re-issue when `read` is false.

## Tests

Five unit tests pin all three arms, including both SQL-NULL-properties cases, with `id`/`full_id` asserted in every arm. Gates: fmt, clippy `-D warnings`, 58+157+25 tests green.

Supersedes #1564 (recreated with corrected commit metadata and expanded consumer-guidance updates).