### PR TITLE
feat(kg): add stable list cursors

### DIFF
--- a/crates/khive-db/docs/migration.md
+++ b/crates/khive-db/docs/migration.md
@@ -56,6 +56,8 @@ V1 baseline at v0.2.8. The live post-consolidation sequence is:
 - **V13**: Adds immutable entity, note, and edge insertion-sequence ledgers,
   ordered upgrade backfills, and atomic assignment triggers for stable list
   cursors.
+- **V14**: Adds an idempotent compatibility guard enforcing global uniqueness
+  of `graph_edges.id`, ahead of the UUID-keyed edge ledger.
 
 The historical pre-consolidation allocation table remains in ADR-015 for
 provenance; its version numbers do not describe the live migration array.

--- a/crates/khive-db/docs/migration.md
+++ b/crates/khive-db/docs/migration.md
@@ -38,23 +38,27 @@ runtime. To add a migration, append a `VersionedMigration` entry with
 
 ## Per-version notes
 
-- **V2**: `NOTES_DDL` already includes `name TEXT` for in-process schema
-  creation. The migration runner checks column existence before applying V2 to
-  stay idempotent.
-- **V4**: Deduplicates existing `graph_edges` rows sharing the same
-  `(namespace, source_id, target_id, relation)` triple, then adds a unique
-  index.
-- **V5**: `ENTITIES_DDL` already includes `entity_type TEXT`. Same
-  column-existence guard as V2.
-- **V9**: Adds lifecycle columns (`updated_at`, `deleted_at`) and
-  `target_backend` to `graph_edges` via table rebuild.
-- **V13**: Event observability columns. DDL computed at runtime via
-  `build_v13_event_observability_sql` to avoid duplicate-column errors.
-- **V14**: Embedding model registry (`_embedding_models`). DDL computed at
-  runtime to discover existing `vec_*` tables.
-- **V16**: Adds `embedding_model` column to regular `vec_*` tables.
-- **V17**: Preserving rebuild of `vec0` virtual tables to add `field` and
-  `embedding_model` columns without data loss.
+The repository consolidated its earlier V1--V22 development ledger into a new
+V1 baseline at v0.2.8. The live post-consolidation sequence is:
+
+- **V1**: Complete consolidated `initial_schema` baseline.
+- **V2**: Narrows the FTS sections update trigger.
+- **V3**: Backfills domain mirror atoms.
+- **V4**: Consolidates entity and note FTS tables.
+- **V5**: Adds the unique comm external-message-id index.
+- **V6**: Adds the brain retune driver state.
+- **V7**: Adds the durable `notes_seq` ledger.
+- **V8**: Repairs partially populated `notes_seq` ledgers.
+- **V9**: Adds the case-insensitive entity-name index.
+- **V10**: Adds entity `content_ref` storage and its partial index.
+- **V11**: Adds the ANN write-log table.
+- **V12**: Adds the model-leading ANN write-log sequence index.
+- **V13**: Adds immutable entity, note, and edge insertion-sequence ledgers,
+  ordered upgrade backfills, and atomic assignment triggers for stable list
+  cursors.
+
+The historical pre-consolidation allocation table remains in ADR-015 for
+provenance; its version numbers do not describe the live migration array.
 
 ## Legacy API
 

--- a/crates/khive-db/sql/013-list-cursor-sequences.sql
+++ b/crates/khive-db/sql/013-list-cursor-sequences.sql
@@ -1,0 +1,59 @@
+-- V13: durable insertion sequences for stable entity/note/edge list cursors
+-- (khive #1424, #1462).
+--
+-- Wall-clock timestamps plus random UUIDs are a total order, but not an
+-- insertion order: a later commit can share the cursor's microsecond and carry
+-- a lower UUID. These AUTOINCREMENT ledgers are assigned by AFTER INSERT
+-- triggers in the same SQLite transaction as the substrate insert. Values are
+-- immutable, never reused after hard deletion, and unaffected by VACUUM.
+
+CREATE TABLE IF NOT EXISTS entities_seq (
+    seq       INTEGER PRIMARY KEY AUTOINCREMENT,
+    entity_id TEXT NOT NULL UNIQUE
+);
+
+CREATE TABLE IF NOT EXISTS graph_edges_seq (
+    seq     INTEGER PRIMARY KEY AUTOINCREMENT,
+    edge_id TEXT NOT NULL UNIQUE
+);
+
+-- Entity/note upgrade backfills use deterministic `(created_at, id)` order.
+-- Edge backfill preserves the UUID ordering of the public pre-V13 edge cursor,
+-- so an outstanding cursor can resume across the migration without silently
+-- skipping or repeating an existing edge. The notes anti-join intentionally
+-- repairs any ledger hole as well as reusing the existing V7/V8 `notes_seq`
+-- table.
+INSERT OR IGNORE INTO entities_seq (entity_id)
+SELECT id FROM entities ORDER BY created_at ASC, id ASC;
+
+INSERT OR IGNORE INTO notes_seq (note_id)
+SELECT n.id FROM notes n
+WHERE NOT EXISTS (SELECT 1 FROM notes_seq s WHERE s.note_id = n.id)
+ORDER BY n.created_at ASC, n.id ASC;
+
+INSERT OR IGNORE INTO graph_edges_seq (edge_id)
+SELECT id FROM graph_edges ORDER BY id ASC;
+
+CREATE TRIGGER IF NOT EXISTS assign_entity_list_seq
+AFTER INSERT ON entities
+BEGIN
+    -- Explicit UPSERT syntax is load-bearing. An outer `INSERT OR REPLACE`
+    -- overrides legacy `OR IGNORE` inside a trigger and would otherwise replace
+    -- this ledger row, moving an existing entity to a new sequence.
+    INSERT INTO entities_seq (entity_id) VALUES (NEW.id)
+    ON CONFLICT(entity_id) DO NOTHING;
+END;
+
+CREATE TRIGGER IF NOT EXISTS assign_note_list_seq
+AFTER INSERT ON notes
+BEGIN
+    INSERT INTO notes_seq (note_id) VALUES (NEW.id)
+    ON CONFLICT(note_id) DO NOTHING;
+END;
+
+CREATE TRIGGER IF NOT EXISTS assign_graph_edge_list_seq
+AFTER INSERT ON graph_edges
+BEGIN
+    INSERT INTO graph_edges_seq (edge_id) VALUES (NEW.id)
+    ON CONFLICT(edge_id) DO NOTHING;
+END;

--- a/crates/khive-db/sql/013-list-cursor-sequences.sql
+++ b/crates/khive-db/sql/013-list-cursor-sequences.sql
@@ -17,6 +17,19 @@ CREATE TABLE IF NOT EXISTS graph_edges_seq (
     edge_id TEXT NOT NULL UNIQUE
 );
 
+-- Pre-V13 `graph_edges` only enforced `PRIMARY KEY (namespace, id)`, so a
+-- legacy database can hold two edges sharing an id across namespaces. The
+-- backfill below keys the ledger by edge id alone (`INSERT OR IGNORE`), so
+-- such a pair would silently collapse onto one shared sequence row instead
+-- of failing. Enforcing global id uniqueness here, before that backfill
+-- runs, means a legacy duplicate fails this migration's own transaction --
+-- so V13 rolls back in full (no ledger tables, no triggers) rather than
+-- committing an ambiguous ledger for a later migration to discover. See
+-- 014-graph-edges-id-unique.sql, which re-asserts the same index
+-- (IF NOT EXISTS, so idempotent here) for any database that already
+-- committed this V13 migration before this guard existed.
+CREATE UNIQUE INDEX IF NOT EXISTS idx_graph_edges_id_unique ON graph_edges(id);
+
 -- Entity/note upgrade backfills use deterministic `(created_at, id)` order.
 -- Edge backfill preserves the UUID ordering of the public pre-V13 edge cursor,
 -- so an outstanding cursor can resume across the migration without silently

--- a/crates/khive-db/sql/014-graph-edges-id-unique.sql
+++ b/crates/khive-db/sql/014-graph-edges-id-unique.sql
@@ -1,0 +1,23 @@
+-- V14: enforce global uniqueness of graph_edges.id (khive #1424, #1462
+-- follow-up).
+--
+-- The V13 list-cursor ledger (graph_edges_seq) keys its AFTER INSERT trigger
+-- and its seek join on `edge_id` alone, and the multi-namespace cursor merge
+-- in the runtime dedups by edge id alone. Both already assume `id` is
+-- globally unique -- matching the existing UUID-only by-ID contract (get /
+-- update / delete / merge do not scope by namespace). The base
+-- `PRIMARY KEY (namespace, id)` never enforced that assumption: two
+-- namespaces could hold the same edge id, in which case the ledger keeps
+-- only the first namespace's sequence row, so a same-id edge in a second
+-- namespace silently reports the first namespace's insertion boundary
+-- instead of its own, and a multi-namespace cursor walk can drop one of the
+-- pair during id-based deduplication.
+--
+-- This index makes the invariant durable going forward. If a legacy
+-- database already holds a duplicate id across namespaces, this
+-- `CREATE UNIQUE INDEX` fails and the migration aborts rather than silently
+-- leaving the ledger ambiguous -- the same fail-loudly posture
+-- `run_migrations` already takes for a schema version it does not
+-- understand. There is no automatic reconciliation: picking a winner would
+-- mean silently dropping a live edge from whichever namespace loses.
+CREATE UNIQUE INDEX IF NOT EXISTS idx_graph_edges_id_unique ON graph_edges(id);

--- a/crates/khive-db/sql/014-graph-edges-id-unique.sql
+++ b/crates/khive-db/sql/014-graph-edges-id-unique.sql
@@ -13,11 +13,13 @@
 -- instead of its own, and a multi-namespace cursor walk can drop one of the
 -- pair during id-based deduplication.
 --
--- This index makes the invariant durable going forward. If a legacy
--- database already holds a duplicate id across namespaces, this
--- `CREATE UNIQUE INDEX` fails and the migration aborts rather than silently
--- leaving the ledger ambiguous -- the same fail-loudly posture
--- `run_migrations` already takes for a schema version it does not
--- understand. There is no automatic reconciliation: picking a winner would
--- mean silently dropping a live edge from whichever namespace loses.
+-- 013-list-cursor-sequences.sql now creates this same index (IF NOT EXISTS)
+-- before it backfills `graph_edges_seq`, so a legacy cross-namespace
+-- duplicate now fails at V13, before the ambiguous ledger row is ever
+-- created, and V13 itself rolls back in full. This V14 statement is kept as
+-- a compatibility no-op for any database that already committed V13 before
+-- that guard existed -- it re-asserts the invariant one version later
+-- rather than leaving such a database permanently unguarded. There is no
+-- automatic reconciliation: picking a winner would mean silently dropping a
+-- live edge from whichever namespace loses.
 CREATE UNIQUE INDEX IF NOT EXISTS idx_graph_edges_id_unique ON graph_edges(id);

--- a/crates/khive-db/sql/entities-ddl.sql
+++ b/crates/khive-db/sql/entities-ddl.sql
@@ -29,3 +29,21 @@ CREATE INDEX IF NOT EXISTS idx_entities_merged_into ON entities(namespace, merge
 -- running the versioned migration chain (e.g. StorageBackend::memory() test
 -- setups that apply ENTITIES_DDL directly).
 CREATE INDEX IF NOT EXISTS idx_entities_content_ref ON entities(content_ref) WHERE content_ref IS NOT NULL;
+
+-- Durable list-cursor insertion order. This mirrors migration V13 as a
+-- belt-and-suspenders path for fresh/direct store construction that applies
+-- ENTITIES_DDL without running the core migration chain. Existing databases
+-- are backfilled only by V13, in operator context.
+CREATE TABLE IF NOT EXISTS entities_seq (
+    seq       INTEGER PRIMARY KEY AUTOINCREMENT,
+    entity_id TEXT NOT NULL UNIQUE
+);
+
+CREATE TRIGGER IF NOT EXISTS assign_entity_list_seq
+AFTER INSERT ON entities
+BEGIN
+    -- Do not use legacy `OR IGNORE`: an outer `INSERT OR REPLACE` overrides
+    -- that trigger policy and would reassign this immutable sequence.
+    INSERT INTO entities_seq (entity_id) VALUES (NEW.id)
+    ON CONFLICT(entity_id) DO NOTHING;
+END;

--- a/crates/khive-db/sql/graph-ddl.sql
+++ b/crates/khive-db/sql/graph-ddl.sql
@@ -23,3 +23,21 @@ CREATE INDEX IF NOT EXISTS idx_graph_edges_ns_relation ON graph_edges(namespace,
 CREATE INDEX IF NOT EXISTS idx_graph_edges_ns_src_rel ON graph_edges(namespace, source_id, relation);
 CREATE INDEX IF NOT EXISTS idx_graph_edges_ns_tgt_rel ON graph_edges(namespace, target_id, relation);
 CREATE INDEX IF NOT EXISTS idx_graph_edges_target_backend ON graph_edges(target_backend) WHERE target_backend IS NOT NULL;
+
+-- Durable list-cursor insertion order. This mirrors migration V13 as a
+-- belt-and-suspenders path for fresh/direct store construction that applies
+-- GRAPH_DDL without running the core migration chain. Existing databases are
+-- backfilled only by V13, in operator context.
+CREATE TABLE IF NOT EXISTS graph_edges_seq (
+    seq     INTEGER PRIMARY KEY AUTOINCREMENT,
+    edge_id TEXT NOT NULL UNIQUE
+);
+
+CREATE TRIGGER IF NOT EXISTS assign_graph_edge_list_seq
+AFTER INSERT ON graph_edges
+BEGIN
+    -- Explicit UPSERT keeps the ledger immutable even when an outer caller
+    -- uses `INSERT OR REPLACE` (which overrides legacy trigger OR policies).
+    INSERT INTO graph_edges_seq (edge_id) VALUES (NEW.id)
+    ON CONFLICT(edge_id) DO NOTHING;
+END;

--- a/crates/khive-db/sql/graph-ddl.sql
+++ b/crates/khive-db/sql/graph-ddl.sql
@@ -17,6 +17,12 @@ CREATE TABLE IF NOT EXISTS graph_edges (
 );
 
 CREATE UNIQUE INDEX IF NOT EXISTS idx_graph_edges_unique_triple ON graph_edges(namespace, source_id, target_id, relation);
+-- The base PRIMARY KEY is (namespace, id), so it alone would allow the same
+-- UUID in two namespaces. The list-cursor ledger below (graph_edges_seq) and
+-- the by-ID runtime contract (get/update/delete/merge are namespace-agnostic)
+-- both already assume `id` is globally unique; this index makes that
+-- assumption durable instead of merely conventional.
+CREATE UNIQUE INDEX IF NOT EXISTS idx_graph_edges_id_unique ON graph_edges(id);
 CREATE INDEX IF NOT EXISTS idx_graph_edges_ns_source ON graph_edges(namespace, source_id);
 CREATE INDEX IF NOT EXISTS idx_graph_edges_ns_target ON graph_edges(namespace, target_id);
 CREATE INDEX IF NOT EXISTS idx_graph_edges_ns_relation ON graph_edges(namespace, relation);

--- a/crates/khive-db/sql/notes-ddl.sql
+++ b/crates/khive-db/sql/notes-ddl.sql
@@ -36,6 +36,19 @@ CREATE TABLE IF NOT EXISTS notes_seq (
 
 CREATE INDEX IF NOT EXISTS idx_notes_seq_note_id ON notes_seq(note_id);
 
+-- Migration V13 adds this trigger to migrated databases. Keep the idempotent
+-- mirror here so a fresh/direct store built from NOTES_DDL also assigns every
+-- new note its immutable list sequence atomically. The existing explicit
+-- `assign_note_seq` calls remain harmless INSERT OR IGNORE safeguards.
+CREATE TRIGGER IF NOT EXISTS assign_note_list_seq
+AFTER INSERT ON notes
+BEGIN
+    -- Explicit UPSERT keeps the ledger immutable even when an outer caller
+    -- uses `INSERT OR REPLACE` (which overrides legacy trigger OR policies).
+    INSERT INTO notes_seq (note_id) VALUES (NEW.id)
+    ON CONFLICT(note_id) DO NOTHING;
+END;
+
 -- The notes_seq anti-join repair (khive #827) used to run here, on
 -- every `notes_for_namespace` call. On a large, already-repaired ledger that
 -- is a full `notes` scan plus a temp B-tree for the ORDER BY on every single

--- a/crates/khive-db/src/migrations.rs
+++ b/crates/khive-db/src/migrations.rs
@@ -125,6 +125,8 @@ const V11_UP: &str = include_str!("../sql/011-ann-write-log.sql");
 
 const V12_UP: &str = include_str!("../sql/012-ann-write-log-model-seq-index.sql");
 
+const V13_UP: &str = include_str!("../sql/013-list-cursor-sequences.sql");
+
 /// DDL for the `ann_write_log` delta table.
 ///
 /// Shared between migration V11 and the belt-and-suspenders creation in
@@ -208,6 +210,11 @@ pub const MIGRATIONS: &[VersionedMigration] = &[
         version: 12,
         name: "ann_write_log_model_seq_index",
         up: V12_UP,
+    },
+    VersionedMigration {
+        version: 13,
+        name: "list_cursor_sequences",
+        up: V13_UP,
     },
 ];
 

--- a/crates/khive-db/src/migrations.rs
+++ b/crates/khive-db/src/migrations.rs
@@ -127,6 +127,8 @@ const V12_UP: &str = include_str!("../sql/012-ann-write-log-model-seq-index.sql"
 
 const V13_UP: &str = include_str!("../sql/013-list-cursor-sequences.sql");
 
+const V14_UP: &str = include_str!("../sql/014-graph-edges-id-unique.sql");
+
 /// DDL for the `ann_write_log` delta table.
 ///
 /// Shared between migration V11 and the belt-and-suspenders creation in
@@ -215,6 +217,11 @@ pub const MIGRATIONS: &[VersionedMigration] = &[
         version: 13,
         name: "list_cursor_sequences",
         up: V13_UP,
+    },
+    VersionedMigration {
+        version: 14,
+        name: "graph_edges_id_unique",
+        up: V14_UP,
     },
 ];
 

--- a/crates/khive-db/src/migrations_tests.rs
+++ b/crates/khive-db/src/migrations_tests.rs
@@ -989,6 +989,82 @@ fn v13_sequence_trigger_failure_rolls_back_each_substrate_insert() {
     }
 }
 
+// ── V14: graph_edges.id must be globally unique (#1424, #1462 follow-up) ────
+
+#[test]
+fn v14_rejects_legacy_duplicate_edge_id_across_namespaces() {
+    let mut conn = open_memory();
+    conn.execute_batch(MIGRATION_TRACKING_TABLE).unwrap();
+    for migration in MIGRATIONS
+        .iter()
+        .filter(|migration| migration.version <= 13)
+    {
+        let tx = conn.transaction().unwrap();
+        tx.execute_batch(migration.up).unwrap();
+        tx.execute(
+            "INSERT INTO _schema_migrations (version, name, applied_at) VALUES (?1, ?2, 0)",
+            rusqlite::params![migration.version, migration.name],
+        )
+        .unwrap();
+        tx.commit().unwrap();
+    }
+
+    // Pre-V14 schema permits the same edge id in two namespaces because the
+    // base PRIMARY KEY is (namespace, id) -- exactly the legacy state the
+    // list-cursor ledger silently mishandled.
+    for ns in ["ns-a", "ns-b"] {
+        conn.execute(
+            "INSERT INTO graph_edges \
+             (namespace, id, source_id, target_id, relation, created_at, updated_at) \
+             VALUES (?1, 'dup-edge', 's', 't', 'extends', 100, 100)",
+            rusqlite::params![ns],
+        )
+        .unwrap();
+    }
+
+    let result = run_migrations(&mut conn);
+    assert!(
+        result.is_err(),
+        "V14 must fail loudly on a legacy cross-namespace duplicate edge id instead of \
+         silently letting the two namespaces share one ledger row"
+    );
+    assert_eq!(
+        read_schema_version(&conn).unwrap(),
+        13,
+        "a failed V14 migration must leave the database at its last good version"
+    );
+}
+
+#[test]
+fn v14_index_rejects_new_cross_namespace_duplicate_edge_id() {
+    let mut conn = open_memory();
+    run_migrations(&mut conn).unwrap();
+
+    conn.execute(
+        "INSERT INTO graph_edges \
+         (namespace, id, source_id, target_id, relation, created_at, updated_at) \
+         VALUES ('ns-a', 'dup-edge', 's', 't', 'extends', 100, 100)",
+        [],
+    )
+    .unwrap();
+
+    let err = conn
+        .execute(
+            "INSERT INTO graph_edges \
+             (namespace, id, source_id, target_id, relation, created_at, updated_at) \
+             VALUES ('ns-b', 'dup-edge', 's2', 't2', 'extends', 200, 200)",
+            [],
+        )
+        .expect_err(
+            "a second namespace inserting an already-used edge id must hit the unique \
+             index, not silently succeed and share the first namespace's ledger row",
+        );
+    assert!(
+        err.to_string().to_lowercase().contains("unique"),
+        "expected a UNIQUE constraint failure, got: {err}"
+    );
+}
+
 #[test]
 fn read_schema_version_missing_ledger_is_zero() {
     let conn = open_memory();

--- a/crates/khive-db/src/migrations_tests.rs
+++ b/crates/khive-db/src/migrations_tests.rs
@@ -756,7 +756,7 @@ fn v13_upgrade_backfills_all_substrate_ledgers_in_legacy_order() {
         .unwrap();
     }
 
-    assert_eq!(run_migrations(&mut conn).unwrap(), 13);
+    assert_eq!(run_migrations(&mut conn).unwrap(), 14);
 
     fn ordered_ids(conn: &Connection, table: &str, id_column: &str) -> Vec<String> {
         let sql = format!("SELECT {id_column} FROM {table} ORDER BY seq ASC");

--- a/crates/khive-db/src/migrations_tests.rs
+++ b/crates/khive-db/src/migrations_tests.rs
@@ -123,8 +123,11 @@ fn core_tables_exist() {
     run_migrations(&mut conn).expect("migrations");
     for t in [
         "entities",
+        "entities_seq",
         "graph_edges",
+        "graph_edges_seq",
         "notes",
+        "notes_seq",
         "events",
         "event_observations",
         "_embedding_models",
@@ -700,6 +703,290 @@ fn v10_content_ref_defaults_null_and_accepts_a_value() {
         )
         .expect("read content_ref");
     assert_eq!(stored_ref, Some(digest));
+}
+
+// ── V13: stable list-cursor insertion sequences (#1424, #1462) ───────────────
+
+#[test]
+fn v13_upgrade_backfills_all_substrate_ledgers_in_legacy_order() {
+    let mut conn = open_memory();
+    conn.execute_batch(MIGRATION_TRACKING_TABLE).unwrap();
+    for migration in MIGRATIONS
+        .iter()
+        .filter(|migration| migration.version <= 12)
+    {
+        let tx = conn.transaction().unwrap();
+        tx.execute_batch(migration.up).unwrap();
+        tx.execute(
+            "INSERT INTO _schema_migrations (version, name, applied_at) VALUES (?1, ?2, 0)",
+            rusqlite::params![migration.version, migration.name],
+        )
+        .unwrap();
+        tx.commit().unwrap();
+    }
+
+    // Deliberately insert out of order. Entity/note V13 backfills use
+    // `(created_at, id)` ascending; edge backfill must instead preserve the
+    // public pre-V13 cursor's `id` ordering so an outstanding edge cursor can
+    // resume across the migration.
+    for (id, created_at) in [("entity-z", 20), ("entity-b", 10), ("entity-a", 10)] {
+        conn.execute(
+            "INSERT INTO entities (id, namespace, kind, name, created_at, updated_at) \
+             VALUES (?1, 'local', 'concept', ?1, ?2, ?2)",
+            rusqlite::params![id, created_at],
+        )
+        .unwrap();
+    }
+    for (id, created_at) in [("note-z", 20), ("note-b", 10), ("note-a", 10)] {
+        conn.execute(
+            "INSERT INTO notes (id, namespace, kind, content, created_at, updated_at) \
+             VALUES (?1, 'local', 'observation', ?1, ?2, ?2)",
+            rusqlite::params![id, created_at],
+        )
+        .unwrap();
+    }
+    // Timestamp order is z, b, a while the compatibility order is a, b, z.
+    for (id, created_at) in [("edge-a", 30), ("edge-z", 10), ("edge-b", 20)] {
+        conn.execute(
+            "INSERT INTO graph_edges \
+             (namespace, id, source_id, target_id, relation, created_at, updated_at) \
+             VALUES ('local', ?1, ?1 || '-source', ?1 || '-target', 'extends', ?2, ?2)",
+            rusqlite::params![id, created_at],
+        )
+        .unwrap();
+    }
+
+    assert_eq!(run_migrations(&mut conn).unwrap(), 13);
+
+    fn ordered_ids(conn: &Connection, table: &str, id_column: &str) -> Vec<String> {
+        let sql = format!("SELECT {id_column} FROM {table} ORDER BY seq ASC");
+        let mut stmt = conn.prepare(&sql).unwrap();
+        stmt.query_map([], |row| row.get(0))
+            .unwrap()
+            .collect::<Result<Vec<_>, _>>()
+            .unwrap()
+    }
+
+    assert_eq!(
+        ordered_ids(&conn, "entities_seq", "entity_id"),
+        vec![
+            "entity-a".to_string(),
+            "entity-b".to_string(),
+            "entity-z".to_string()
+        ]
+    );
+    assert_eq!(
+        ordered_ids(&conn, "notes_seq", "note_id"),
+        vec![
+            "note-a".to_string(),
+            "note-b".to_string(),
+            "note-z".to_string()
+        ]
+    );
+    assert_eq!(
+        ordered_ids(&conn, "graph_edges_seq", "edge_id"),
+        vec![
+            "edge-a".to_string(),
+            "edge-b".to_string(),
+            "edge-z".to_string()
+        ]
+    );
+}
+
+#[test]
+fn v13_insert_triggers_assign_monotonic_sequences_for_all_substrates() {
+    let mut conn = open_memory();
+    run_migrations(&mut conn).unwrap();
+
+    let sequence = |conn: &Connection, table: &str, id_column: &str, id: &str| -> i64 {
+        conn.query_row(
+            &format!("SELECT seq FROM {table} WHERE {id_column} = ?1"),
+            rusqlite::params![id],
+            |row| row.get(0),
+        )
+        .unwrap()
+    };
+
+    conn.execute(
+        "INSERT INTO entities (id, namespace, kind, name, created_at, updated_at) \
+         VALUES ('f-entity', 'local', 'concept', 'first', 100, 100)",
+        [],
+    )
+    .unwrap();
+    let entity_first = sequence(&conn, "entities_seq", "entity_id", "f-entity");
+    conn.execute(
+        "INSERT OR REPLACE INTO entities (id, namespace, kind, name, created_at, updated_at) \
+         VALUES ('f-entity', 'local', 'concept', 'updated', 999, 999)",
+        [],
+    )
+    .unwrap();
+    assert_eq!(
+        sequence(&conn, "entities_seq", "entity_id", "f-entity"),
+        entity_first,
+        "entity replacement must retain its first-insert sequence"
+    );
+    conn.execute("DELETE FROM entities WHERE id = 'f-entity'", [])
+        .unwrap();
+    conn.execute(
+        "INSERT INTO entities (id, namespace, kind, name, created_at, updated_at) \
+         VALUES ('f-entity', 'local', 'concept', 'resurrected', 1000, 1000)",
+        [],
+    )
+    .unwrap();
+    assert_eq!(
+        sequence(&conn, "entities_seq", "entity_id", "f-entity"),
+        entity_first,
+        "hard-delete plus same-id entity resurrection must retain its first sequence"
+    );
+    conn.execute(
+        "INSERT INTO entities (id, namespace, kind, name, created_at, updated_at) \
+         VALUES ('0-entity', 'local', 'concept', 'later', 100, 100)",
+        [],
+    )
+    .unwrap();
+    assert!(sequence(&conn, "entities_seq", "entity_id", "0-entity") > entity_first);
+
+    conn.execute(
+        "INSERT INTO notes (id, namespace, kind, content, created_at, updated_at) \
+         VALUES ('f-note', 'local', 'observation', 'first', 100, 100)",
+        [],
+    )
+    .unwrap();
+    let note_first = sequence(&conn, "notes_seq", "note_id", "f-note");
+    conn.execute(
+        "INSERT OR REPLACE INTO notes \
+         (id, namespace, kind, content, created_at, updated_at) \
+         VALUES ('f-note', 'local', 'observation', 'updated', 999, 999)",
+        [],
+    )
+    .unwrap();
+    assert_eq!(
+        sequence(&conn, "notes_seq", "note_id", "f-note"),
+        note_first,
+        "note upsert must retain its first-insert sequence"
+    );
+    conn.execute("DELETE FROM notes WHERE id = 'f-note'", [])
+        .unwrap();
+    conn.execute(
+        "INSERT INTO notes (id, namespace, kind, content, created_at, updated_at) \
+         VALUES ('f-note', 'local', 'observation', 'resurrected', 1000, 1000)",
+        [],
+    )
+    .unwrap();
+    assert_eq!(
+        sequence(&conn, "notes_seq", "note_id", "f-note"),
+        note_first,
+        "hard-delete plus same-id note resurrection must retain its first sequence"
+    );
+    conn.execute(
+        "INSERT INTO notes (id, namespace, kind, content, created_at, updated_at) \
+         VALUES ('0-note', 'local', 'observation', 'later', 100, 100)",
+        [],
+    )
+    .unwrap();
+    assert!(sequence(&conn, "notes_seq", "note_id", "0-note") > note_first);
+
+    conn.execute(
+        "INSERT INTO graph_edges \
+         (namespace, id, source_id, target_id, relation, created_at, updated_at) \
+         VALUES ('local', 'f-edge', 's1', 't1', 'extends', 100, 100)",
+        [],
+    )
+    .unwrap();
+    let edge_first = sequence(&conn, "graph_edges_seq", "edge_id", "f-edge");
+    conn.execute(
+        "INSERT OR REPLACE INTO graph_edges \
+         (namespace, id, source_id, target_id, relation, weight, created_at, updated_at) \
+         VALUES ('local', 'f-edge', 's1', 't1', 'extends', 0.5, 999, 999)",
+        [],
+    )
+    .unwrap();
+    assert_eq!(
+        sequence(&conn, "graph_edges_seq", "edge_id", "f-edge"),
+        edge_first,
+        "edge upsert must retain its first-insert sequence"
+    );
+    conn.execute(
+        "DELETE FROM graph_edges WHERE namespace = 'local' AND id = 'f-edge'",
+        [],
+    )
+    .unwrap();
+    conn.execute(
+        "INSERT INTO graph_edges \
+         (namespace, id, source_id, target_id, relation, created_at, updated_at) \
+         VALUES ('local', 'f-edge', 's1', 't1', 'extends', 1000, 1000)",
+        [],
+    )
+    .unwrap();
+    assert_eq!(
+        sequence(&conn, "graph_edges_seq", "edge_id", "f-edge"),
+        edge_first,
+        "hard-delete plus same-id edge resurrection must retain its first sequence"
+    );
+    conn.execute(
+        "INSERT INTO graph_edges \
+         (namespace, id, source_id, target_id, relation, created_at, updated_at) \
+         VALUES ('local', '0-edge', 's2', 't2', 'extends', 100, 100)",
+        [],
+    )
+    .unwrap();
+    assert!(sequence(&conn, "graph_edges_seq", "edge_id", "0-edge") > edge_first);
+}
+
+#[test]
+fn v13_sequence_trigger_failure_rolls_back_each_substrate_insert() {
+    let mut conn = open_memory();
+    run_migrations(&mut conn).unwrap();
+    conn.execute_batch(
+        "CREATE TRIGGER reject_entity_list_seq BEFORE INSERT ON entities_seq
+         WHEN NEW.entity_id = 'reject-entity'
+         BEGIN SELECT RAISE(ABORT, 'reject entity sequence'); END;
+         CREATE TRIGGER reject_note_list_seq BEFORE INSERT ON notes_seq
+         WHEN NEW.note_id = 'reject-note'
+         BEGIN SELECT RAISE(ABORT, 'reject note sequence'); END;
+         CREATE TRIGGER reject_edge_list_seq BEFORE INSERT ON graph_edges_seq
+         WHEN NEW.edge_id = 'reject-edge'
+         BEGIN SELECT RAISE(ABORT, 'reject edge sequence'); END;",
+    )
+    .unwrap();
+
+    assert!(conn
+        .execute(
+            "INSERT INTO entities (id, namespace, kind, name, created_at, updated_at) \
+             VALUES ('reject-entity', 'local', 'concept', 'rejected', 100, 100)",
+            [],
+        )
+        .is_err());
+    assert!(conn
+        .execute(
+            "INSERT INTO notes (id, namespace, kind, content, created_at, updated_at) \
+             VALUES ('reject-note', 'local', 'observation', 'rejected', 100, 100)",
+            [],
+        )
+        .is_err());
+    assert!(conn
+        .execute(
+            "INSERT INTO graph_edges \
+             (namespace, id, source_id, target_id, relation, created_at, updated_at) \
+             VALUES ('local', 'reject-edge', 's', 't', 'extends', 100, 100)",
+            [],
+        )
+        .is_err());
+
+    for (table, id_column, id) in [
+        ("entities", "id", "reject-entity"),
+        ("notes", "id", "reject-note"),
+        ("graph_edges", "id", "reject-edge"),
+    ] {
+        let count: i64 = conn
+            .query_row(
+                &format!("SELECT COUNT(*) FROM {table} WHERE {id_column} = ?1"),
+                rusqlite::params![id],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(count, 0, "failed sequence assignment stranded {table} row");
+    }
 }
 
 #[test]

--- a/crates/khive-db/src/migrations_tests.rs
+++ b/crates/khive-db/src/migrations_tests.rs
@@ -756,7 +756,8 @@ fn v13_upgrade_backfills_all_substrate_ledgers_in_legacy_order() {
         .unwrap();
     }
 
-    assert_eq!(run_migrations(&mut conn).unwrap(), 14);
+    let latest = MIGRATIONS.last().expect("at least one migration").version;
+    assert_eq!(run_migrations(&mut conn).unwrap(), latest);
 
     fn ordered_ids(conn: &Connection, table: &str, id_column: &str) -> Vec<String> {
         let sql = format!("SELECT {id_column} FROM {table} ORDER BY seq ASC");

--- a/crates/khive-db/src/migrations_tests.rs
+++ b/crates/khive-db/src/migrations_tests.rs
@@ -989,15 +989,15 @@ fn v13_sequence_trigger_failure_rolls_back_each_substrate_insert() {
     }
 }
 
-// ── V14: graph_edges.id must be globally unique (#1424, #1462 follow-up) ────
+// ── V13/V14: graph_edges.id must be globally unique (#1424, #1462 follow-up) ─
 
 #[test]
-fn v14_rejects_legacy_duplicate_edge_id_across_namespaces() {
+fn v13_rejects_legacy_duplicate_edge_id_on_upgrade_from_v12() {
     let mut conn = open_memory();
     conn.execute_batch(MIGRATION_TRACKING_TABLE).unwrap();
     for migration in MIGRATIONS
         .iter()
-        .filter(|migration| migration.version <= 13)
+        .filter(|migration| migration.version <= 12)
     {
         let tx = conn.transaction().unwrap();
         tx.execute_batch(migration.up).unwrap();
@@ -1009,9 +1009,10 @@ fn v14_rejects_legacy_duplicate_edge_id_across_namespaces() {
         tx.commit().unwrap();
     }
 
-    // Pre-V14 schema permits the same edge id in two namespaces because the
-    // base PRIMARY KEY is (namespace, id) -- exactly the legacy state the
-    // list-cursor ledger silently mishandled.
+    // A V12 (pre-list-cursor) database permits the same edge id in two
+    // namespaces because the base PRIMARY KEY is (namespace, id) -- exactly
+    // the legacy state the list-cursor ledger's UUID-only backfill would
+    // otherwise silently collapse onto one shared sequence row.
     for ns in ["ns-a", "ns-b"] {
         conn.execute(
             "INSERT INTO graph_edges \
@@ -1022,16 +1023,24 @@ fn v14_rejects_legacy_duplicate_edge_id_across_namespaces() {
         .unwrap();
     }
 
+    // This drives the real upgrade path (unlike a fixture that force-applies
+    // V13 before inserting the duplicate): run_migrations must hit V13's own
+    // uniqueness guard on this legacy pair, not silently backfill a ledger
+    // for V14 to fail on one version later.
     let result = run_migrations(&mut conn);
     assert!(
         result.is_err(),
-        "V14 must fail loudly on a legacy cross-namespace duplicate edge id instead of \
-         silently letting the two namespaces share one ledger row"
+        "V13 must fail loudly on a legacy cross-namespace duplicate edge id instead of \
+         backfilling a ledger that collapses the two rows onto one sequence entry"
     );
     assert_eq!(
         read_schema_version(&conn).unwrap(),
-        13,
-        "a failed V14 migration must leave the database at its last good version"
+        12,
+        "a failed V13 migration must leave the database at its last good version"
+    );
+    assert!(
+        !table_exists(&conn, "graph_edges_seq"),
+        "V13 must roll back in full on a legacy duplicate -- no ledger table, ambiguous or not"
     );
 }
 

--- a/crates/khive-db/src/stores/entity.rs
+++ b/crates/khive-db/src/stores/entity.rs
@@ -4,12 +4,13 @@ use std::collections::HashSet;
 use std::sync::Arc;
 
 use async_trait::async_trait;
+use rusqlite::OptionalExtension;
 use uuid::Uuid;
 
 use khive_storage::entity::{Entity, EntityFilter};
 use khive_storage::error::StorageError;
 use khive_storage::types::{
-    BatchWriteSummary, DeleteMode, Page, PageRequest, SqlStatement, SqlValue,
+    BatchWriteSummary, DeleteMode, Page, PageRequest, SeekCursor, SeekPage, SqlStatement, SqlValue,
 };
 use khive_storage::EntityStore;
 use khive_storage::StorageCapability;
@@ -640,6 +641,19 @@ impl EntityStore for SqlEntityStore {
         .await
     }
 
+    async fn entity_sequence(&self, id: Uuid) -> Result<Option<i64>, StorageError> {
+        let id = id.to_string();
+        self.with_reader("entity_sequence", move |conn| {
+            conn.query_row(
+                "SELECT seq FROM entities_seq WHERE entity_id = ?1",
+                rusqlite::params![id],
+                |row| row.get(0),
+            )
+            .optional()
+        })
+        .await
+    }
+
     async fn delete_entity(&self, id: Uuid, mode: DeleteMode) -> Result<bool, StorageError> {
         match mode {
             DeleteMode::Soft => {
@@ -772,6 +786,71 @@ impl EntityStore for SqlEntityStore {
             }
 
             Ok(Page { items, total })
+        })
+        .await
+    }
+
+    async fn query_entities_after(
+        &self,
+        namespace: &str,
+        filter: EntityFilter,
+        after: Option<SeekCursor>,
+        limit: u32,
+    ) -> Result<SeekPage<Entity>, StorageError> {
+        if limit == 0 {
+            return Ok(SeekPage::default());
+        }
+        if !filter.names_ci.is_empty() {
+            return Err(StorageError::InvalidInput {
+                capability: StorageCapability::Entities,
+                operation: "query_entities_after".into(),
+                message: "names_ci candidate folding is not compatible with seek pagination".into(),
+            });
+        }
+
+        let namespace = namespace.to_string();
+        let limit_usize = limit as usize;
+        let probe_limit_i64 = i64::from(limit) + 1;
+        self.with_reader("query_entities_after", move |conn| {
+            let (mut where_sql, mut params) = build_entity_where(&namespace, &filter);
+            if let Some(cursor) = after {
+                params.push(Box::new(cursor.sequence));
+                where_sql.push_str(&format!(" AND entities_seq.seq > ?{}", params.len()));
+            }
+            params.push(Box::new(probe_limit_i64));
+            let limit_idx = params.len();
+
+            let columns = "id, namespace, kind, entity_type, name, description, properties, tags, \
+                           created_at, updated_at, deleted_at, merged_into, merge_event_id, content_ref";
+            // CROSS JOIN is load-bearing: SQLite must drive the query from the
+            // sequence INTEGER PRIMARY KEY range instead of scanning the
+            // namespace index and sorting all matches into a temp B-tree.
+            let sql = format!(
+                "SELECT {columns}, entities_seq.seq FROM entities_seq \
+                 CROSS JOIN entities ON entities.id = entities_seq.entity_id{where_sql} \
+                 ORDER BY entities_seq.seq ASC LIMIT ?{limit_idx}"
+            );
+            let mut stmt = conn.prepare(&sql)?;
+            let param_refs: Vec<&dyn rusqlite::types::ToSql> =
+                params.iter().map(|param| param.as_ref()).collect();
+            let rows = stmt.query_map(param_refs.as_slice(), |row| {
+                Ok((read_entity(row)?, row.get::<_, i64>(14)?))
+            })?;
+            let mut entries = rows.collect::<Result<Vec<_>, _>>()?;
+            let has_more = entries.len() > limit_usize;
+            if has_more {
+                entries.truncate(limit_usize);
+            }
+            let next_after = if has_more {
+                entries.last().map(|(entity, sequence)| SeekCursor {
+                    sequence: *sequence,
+                    id: entity.id,
+                })
+            } else {
+                None
+            };
+            let items = entries.into_iter().map(|(entity, _)| entity).collect();
+            Ok(SeekPage { items, next_after })
         })
         .await
     }

--- a/crates/khive-db/src/stores/graph.rs
+++ b/crates/khive-db/src/stores/graph.rs
@@ -5,14 +5,15 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use chrono::{DateTime, TimeZone, Utc};
+use rusqlite::OptionalExtension;
 use uuid::Uuid;
 
 use khive_storage::error::StorageError;
 use khive_storage::types::{
     BatchWriteSummary, DeleteMode, DirectedNeighborHit, Direction, Edge, EdgeFilter, EdgeSeekPage,
     EdgeSortField, GraphPath, GuardedBatchOutcome, GuardedBatchRefusal, GuardedWriteOutcome,
-    MissingEndpoints, NeighborHit, NeighborQuery, Page, PageRequest, PathNode, SortDirection,
-    SortOrder, SqlStatement, SqlValue, TraversalRequest,
+    MissingEndpoints, NeighborHit, NeighborQuery, Page, PageRequest, PathNode, SeekCursor,
+    SeekPage, SortDirection, SortOrder, SqlStatement, SqlValue, TraversalRequest,
 };
 use khive_storage::GraphStore;
 use khive_storage::LinkId;
@@ -1295,6 +1296,52 @@ impl GraphStore for SqlGraphStore {
         .await
     }
 
+    async fn edge_sequence(&self, id: Uuid) -> Result<Option<i64>, StorageError> {
+        let id = id.to_string();
+        self.with_reader("edge_sequence", move |conn| {
+            conn.query_row(
+                "SELECT seq FROM graph_edges_seq WHERE edge_id = ?1",
+                rusqlite::params![id],
+                |row| row.get(0),
+            )
+            .optional()
+        })
+        .await
+    }
+
+    async fn edge_sequences(&self, ids: &[Uuid]) -> Result<Vec<(Uuid, i64)>, StorageError> {
+        if ids.is_empty() {
+            return Ok(Vec::new());
+        }
+        let ids = ids.to_vec();
+        self.with_reader("edge_sequences", move |conn| {
+            const CHUNK: usize = 900;
+            let mut resolved = Vec::with_capacity(ids.len());
+            for chunk in ids.chunks(CHUNK) {
+                let placeholders = (1..=chunk.len())
+                    .map(|index| format!("?{index}"))
+                    .collect::<Vec<_>>()
+                    .join(", ");
+                let sql = format!(
+                    "SELECT edge_id, seq FROM graph_edges_seq WHERE edge_id IN ({placeholders})"
+                );
+                let strings = chunk.iter().map(Uuid::to_string).collect::<Vec<_>>();
+                let params = strings
+                    .iter()
+                    .map(|id| id as &dyn rusqlite::types::ToSql)
+                    .collect::<Vec<_>>();
+                let mut stmt = conn.prepare(&sql)?;
+                let rows = stmt.query_map(params.as_slice(), |row| {
+                    let id: String = row.get(0)?;
+                    Ok((parse_uuid(&id)?, row.get::<_, i64>(1)?))
+                })?;
+                resolved.extend(rows.collect::<Result<Vec<_>, _>>()?);
+            }
+            Ok(resolved)
+        })
+        .await
+    }
+
     async fn get_edge_by_natural_key_including_deleted(
         &self,
         namespace: &str,
@@ -1857,6 +1904,61 @@ impl GraphStore for SqlGraphStore {
             };
 
             Ok(EdgeSeekPage { items, next_after })
+        })
+        .await
+    }
+
+    async fn query_edges_sequence_after(
+        &self,
+        filter: EdgeFilter,
+        after: Option<SeekCursor>,
+        limit: u32,
+    ) -> Result<SeekPage<Edge>, StorageError> {
+        if limit == 0 {
+            return Ok(SeekPage::default());
+        }
+        let namespace = self.namespace.clone();
+        let limit_usize = limit as usize;
+        let probe_limit_i64 = i64::from(limit) + 1;
+        self.with_reader("query_edges_sequence_after", move |conn| {
+            let (mut where_clause, mut params) = build_edge_filter_sql(&namespace, &filter);
+            if let Some(cursor) = after {
+                params.push(Box::new(cursor.sequence));
+                where_clause.push_str(&format!(" AND graph_edges_seq.seq > ?{}", params.len()));
+            }
+            params.push(Box::new(probe_limit_i64));
+            let limit_idx = params.len();
+            // CROSS JOIN fixes the ledger as the outer loop, preserving an
+            // indexed `seq > boundary` scan with no full-match sort.
+            let sql = format!(
+                "SELECT namespace, id, source_id, target_id, relation, weight, \
+                        created_at, updated_at, deleted_at, metadata, target_backend, \
+                        graph_edges_seq.seq \
+                 FROM graph_edges_seq CROSS JOIN graph_edges \
+                    ON graph_edges.id = graph_edges_seq.edge_id{where_clause} \
+                 ORDER BY graph_edges_seq.seq ASC LIMIT ?{limit_idx}"
+            );
+            let mut stmt = conn.prepare(&sql)?;
+            let param_refs: Vec<&dyn rusqlite::types::ToSql> =
+                params.iter().map(|param| param.as_ref()).collect();
+            let rows = stmt.query_map(param_refs.as_slice(), |row| {
+                Ok((read_edge(row)?, row.get::<_, i64>(11)?))
+            })?;
+            let mut entries = rows.collect::<Result<Vec<_>, _>>()?;
+            let has_more = entries.len() > limit_usize;
+            if has_more {
+                entries.truncate(limit_usize);
+            }
+            let next_after = if has_more {
+                entries.last().map(|(edge, sequence)| SeekCursor {
+                    sequence: *sequence,
+                    id: Uuid::from(edge.id),
+                })
+            } else {
+                None
+            };
+            let items = entries.into_iter().map(|(edge, _)| edge).collect();
+            Ok(SeekPage { items, next_after })
         })
         .await
     }

--- a/crates/khive-db/src/stores/graph_tests.rs
+++ b/crates/khive-db/src/stores/graph_tests.rs
@@ -198,6 +198,41 @@ async fn test_upsert_and_get_edge() {
     assert!((fetched.weight - 0.8).abs() < 1e-9);
 }
 
+/// The base `PRIMARY KEY (namespace, id)` alone would let two namespaces
+/// hold the same edge id; the list-cursor ledger (`graph_edges_seq`) and the
+/// multi-namespace cursor merge in the runtime both key on `id` alone, so a
+/// shared id would corrupt cursor ordering across namespaces. The
+/// `idx_graph_edges_id_unique` index closes that gap at the write path
+/// itself -- a second namespace cannot silently acquire an id already used
+/// by another namespace's edge.
+#[tokio::test]
+async fn test_upsert_edge_rejects_duplicate_id_across_namespaces() {
+    let store = setup_memory_store();
+
+    let shared_id = Uuid::new_v4();
+    let mut first = make_edge(Uuid::new_v4(), Uuid::new_v4(), EdgeRelation::Extends, 1.0);
+    first.id = shared_id.into();
+    first.namespace = "ns-a".to_string();
+    store.upsert_edge(first).await.unwrap();
+
+    let mut second = make_edge(Uuid::new_v4(), Uuid::new_v4(), EdgeRelation::Extends, 1.0);
+    second.id = shared_id.into();
+    second.namespace = "ns-b".to_string();
+    let result = store.upsert_edge(second).await;
+
+    assert!(
+        result.is_err(),
+        "a second namespace inserting an already-used edge id must fail, not silently \
+         share the first namespace's list-cursor ledger row"
+    );
+
+    let fetched = store.get_edge(shared_id.into()).await.unwrap().unwrap();
+    assert_eq!(
+        fetched.namespace, "ns-a",
+        "the rejected duplicate-id write must leave the original namespace's edge intact"
+    );
+}
+
 #[tokio::test]
 async fn test_delete_edge() {
     let store = setup_memory_store();

--- a/crates/khive-db/src/stores/note.rs
+++ b/crates/khive-db/src/stores/note.rs
@@ -4,12 +4,13 @@ use std::collections::HashSet;
 use std::sync::Arc;
 
 use async_trait::async_trait;
+use rusqlite::OptionalExtension;
 use uuid::Uuid;
 
 use khive_storage::error::StorageError;
 use khive_storage::note::{FilterOp, Note, NoteFilter, SortDir};
 use khive_storage::types::{
-    BatchWriteSummary, DeleteMode, Page, PageRequest, SqlStatement, SqlValue,
+    BatchWriteSummary, DeleteMode, Page, PageRequest, SeekCursor, SeekPage, SqlStatement, SqlValue,
 };
 use khive_storage::NoteStore;
 use khive_storage::StorageCapability;
@@ -875,6 +876,19 @@ impl NoteStore for SqlNoteStore {
         .await
     }
 
+    async fn note_sequence(&self, id: Uuid) -> Result<Option<i64>, StorageError> {
+        let id = id.to_string();
+        self.with_reader("note_sequence", move |conn| {
+            conn.query_row(
+                "SELECT seq FROM notes_seq WHERE note_id = ?1",
+                rusqlite::params![id],
+                |row| row.get(0),
+            )
+            .optional()
+        })
+        .await
+    }
+
     async fn get_notes_batch(&self, ids: &[Uuid]) -> Result<Vec<Note>, StorageError> {
         if ids.is_empty() {
             return Ok(vec![]);
@@ -1052,6 +1066,73 @@ impl NoteStore for SqlNoteStore {
                 &data_sql,
                 &data_params,
             )
+        })
+        .await
+    }
+
+    async fn query_notes_filtered_after(
+        &self,
+        namespace: &str,
+        filter: &NoteFilter,
+        after: Option<SeekCursor>,
+        limit: u32,
+    ) -> Result<SeekPage<Note>, StorageError> {
+        if limit == 0 {
+            return Ok(SeekPage::default());
+        }
+        if filter.order_by.is_some() {
+            return Err(StorageError::InvalidInput {
+                capability: StorageCapability::Notes,
+                operation: "query_notes_filtered_after".into(),
+                message: "custom order_by is not compatible with insertion-sequence pagination"
+                    .into(),
+            });
+        }
+        for property_filter in &filter.property_filters {
+            validate_json_path(&property_filter.json_path)?;
+        }
+
+        let namespace = namespace.to_string();
+        let filter = filter.clone();
+        let limit_usize = limit as usize;
+        let probe_limit_i64 = i64::from(limit) + 1;
+        self.with_reader("query_notes_filtered_after", move |conn| {
+            let (mut where_sql, mut params) = build_note_filter_where(&namespace, &filter)?;
+            if let Some(cursor) = after {
+                params.push(Box::new(cursor.sequence));
+                where_sql.push_str(&format!(" AND notes_seq.seq > ?{}", params.len()));
+            }
+            params.push(Box::new(probe_limit_i64));
+            let limit_idx = params.len();
+            // CROSS JOIN fixes the ledger as the outer loop, preserving an
+            // indexed `seq > boundary` scan with no full-match sort.
+            let sql = format!(
+                "SELECT id, namespace, kind, status, name, content, salience, decay_factor, \
+                 expires_at, properties, created_at, updated_at, deleted_at, notes_seq.seq \
+                 FROM notes_seq CROSS JOIN notes ON notes.id = notes_seq.note_id{where_sql} \
+                 ORDER BY notes_seq.seq ASC LIMIT ?{limit_idx}"
+            );
+            let mut stmt = conn.prepare(&sql)?;
+            let param_refs: Vec<&dyn rusqlite::types::ToSql> =
+                params.iter().map(|param| param.as_ref()).collect();
+            let rows = stmt.query_map(param_refs.as_slice(), |row| {
+                Ok((read_note(row)?, row.get::<_, i64>(13)?))
+            })?;
+            let mut entries = rows.collect::<Result<Vec<_>, _>>()?;
+            let has_more = entries.len() > limit_usize;
+            if has_more {
+                entries.truncate(limit_usize);
+            }
+            let next_after = if has_more {
+                entries.last().map(|(note, sequence)| SeekCursor {
+                    sequence: *sequence,
+                    id: note.id,
+                })
+            } else {
+                None
+            };
+            let items = entries.into_iter().map(|(note, _)| note).collect();
+            Ok(SeekPage { items, next_after })
         })
         .await
     }

--- a/crates/khive-db/src/stores/note_tests.rs
+++ b/crates/khive-db/src/stores/note_tests.rs
@@ -884,11 +884,15 @@ async fn test_try_insert_note_insert_and_seq_assignment_are_atomic() {
 /// failed `assign_note_seq` mid-batch) propagated via `?` straight out of
 /// the closure, skipping `ROLLBACK` and leaving `BEGIN IMMEDIATE` open on
 /// the shared pool-mutex connection. A `BEFORE INSERT` trigger fails the
-/// sequence assignment for the SECOND note in a two-note batch (the first
-/// note's insert and `assign_note_seq` must already have succeeded by the
-/// time this fires); the whole batch must roll back -- neither note must
-/// survive -- and the connection must not be left poisoned: a subsequent
-/// write through the same pool must still succeed.
+/// redundant explicit `assign_note_seq` safeguard for the SECOND note in a
+/// two-note batch, after V13's `AFTER INSERT ON notes` trigger has made the
+/// first, atomic sequence assignment. This keeps the injected error outside
+/// the per-row UPSERT error path (which intentionally reports partial
+/// success): the first note's insert and sequence assignment must already
+/// have succeeded by the time this fires. The whole batch must roll back --
+/// neither note nor sequence row may survive -- and the connection must not
+/// be left poisoned: a subsequent write through the same pool must still
+/// succeed.
 #[tokio::test]
 async fn test_upsert_notes_batch_rolls_back_fully_on_mid_batch_seq_failure() {
     let store = setup_memory_store();
@@ -901,6 +905,7 @@ async fn test_upsert_notes_batch_rolls_back_fully_on_mid_batch_seq_failure() {
             .execute_batch(&format!(
                 "CREATE TRIGGER inject_seq_failure_batch BEFORE INSERT ON notes_seq \
                  WHEN NEW.note_id = '{fail_id}' \
+                   AND EXISTS (SELECT 1 FROM notes_seq WHERE note_id = NEW.note_id) \
                  BEGIN SELECT RAISE(ABORT, 'injected mid-batch failure for #827 test'); END;"
             ))
             .unwrap();

--- a/crates/khive-pack-kg/src/handler_defs.rs
+++ b/crates/khive-pack-kg/src/handler_defs.rs
@@ -152,10 +152,10 @@ pub(crate) static KG_HANDLERS: [HandlerDef; 19] = [
         description: "List records with optional filtering. Requests within the kind's row cap \
                       keep the existing array response. If limit exceeds the cap, the result is \
                       {\"items\": [...], \"requested_limit\": N, \"effective_limit\": CAP, \
-                      \"limit_clamped\": true}. Edge cursor mode keeps its existing \
-                      {\"edges\": [...], \"next_after\": ...} shape and adds the same limit \
-                      metadata when clamped. Caps are entity 500, note 200, edge 1000, event \
-                      1000, and proposal 500.",
+                      \"limit_clamped\": true}. Entity, note, and edge cursor modes return \
+                      {\"entities|notes|edges\": [...], \"next_after\": ...} and add the same \
+                      limit metadata when clamped. Caps are entity 500, note 200, edge 1000, \
+                      event 1000, and proposal 500.",
         visibility: Visibility::Verb,
         category: VerbCategory::Assertive,
         params: &[
@@ -177,24 +177,24 @@ pub(crate) static KG_HANDLERS: [HandlerDef; 19] = [
                 name: "offset",
                 param_type: "integer",
                 required: false,
-                description: "Pagination offset (default 0). For kind=\"edge\" this pages the full \
-                              matching set (capped at 1000 rows per page); for a full-graph walk \
-                              prefer \"after\" instead, which is O(1) at any depth rather than \
-                              O(offset).",
+                description: "Pagination offset (default 0). For complete entity, note, or edge \
+                              walks prefer \"after\", whose indexed seek cost does not grow with \
+                              depth and whose boundaries are not shifted by concurrent inserts. \
+                              Explicit offset and after values are mutually exclusive.",
             },
             ParamDef {
                 name: "after",
-                param_type: "uuid",
+                param_type: "string",
                 required: false,
-                description: "Keyset cursor for kind=\"edge\" only: the id of the last edge from the \
-                              previous page, or \"\" (empty string) to opt into cursor-mode pagination \
-                              starting from the beginning of the set. Seeks via an indexed id range \
-                              scan instead of OFFSET, so cost does not grow with depth. When set, the \
-                              response shape is \
-                              {\"edges\": [...], \"next_after\": <uuid-or-null>}; \
-                              next_after is non-null while more rows remain. Mutually exclusive with \
-                              offset-based paging within a single walk. Over-cap limits add the \
-                              limit metadata described on the verb.",
+                description: "Insertion-sequence cursor for entity, note, and edge lists: the id from \
+                              the prior page's next_after, or \"\" to start cursor mode. A new id is \
+                              assigned a durable database sequence, so later inserts cannot fall behind \
+                              an issued boundary even when timestamps tie. This is a live walk, not an \
+                              MVCC snapshot: inserts may extend it, and rows committed after a terminal \
+                              page require a new walk. Responses are {\"entities\": [...]}, \
+                              {\"notes\": [...]}, or {\"edges\": [...]}, plus next_after. Reuse the \
+                              same filters throughout a walk. A missing, hard-deleted, or out-of-scope \
+                              cursor fails explicitly. Mutually exclusive with offset.",
             },
             ParamDef {
                 name: "entity_kind",

--- a/crates/khive-pack-kg/src/handlers/list.rs
+++ b/crates/khive-pack-kg/src/handlers/list.rs
@@ -3,6 +3,7 @@
 use serde_json::Value;
 
 use khive_runtime::{KhiveRuntime, NamespaceToken, RuntimeError, VerbRegistry};
+use khive_storage::note::Note;
 use khive_storage::types::PageRequest;
 use khive_storage::EntityFilter;
 
@@ -45,6 +46,81 @@ fn add_list_limit_metadata(response: &mut Value, requested: u32, effective: u32)
     response["limit_clamped"] = serde_json::json!(true);
 }
 
+fn parse_after_cursor(raw: &str) -> Result<Option<uuid::Uuid>, RuntimeError> {
+    if raw.is_empty() {
+        return Ok(None);
+    }
+    uuid::Uuid::parse_str(raw).map(Some).map_err(|error| {
+        RuntimeError::InvalidInput(format!("after: invalid UUID {raw:?}: {error}"))
+    })
+}
+
+fn note_matches_message_filters(note: &Note, params: &ListParams) -> bool {
+    let properties = note.properties.as_ref();
+    if let Some(wanted_thread) = params.thread_id.as_deref() {
+        let Some(stored) = properties
+            .and_then(|value| value.get("thread_id"))
+            .and_then(Value::as_str)
+            .filter(|value| !value.is_empty())
+        else {
+            return false;
+        };
+        let matches = stored == wanted_thread
+            || matches!(
+                (stored.get(..8), wanted_thread.get(..8)),
+                (Some(left), Some(right)) if left == right
+            );
+        if !matches {
+            return false;
+        }
+    }
+    if let Some(wanted) = params.direction.as_deref() {
+        let stored = properties
+            .and_then(|value| value.get("direction"))
+            .and_then(Value::as_str)
+            .unwrap_or("");
+        if stored != wanted {
+            return false;
+        }
+    }
+    if let Some(wanted) = params.from.as_deref() {
+        let stored = properties
+            .and_then(|value| value.get("from"))
+            .and_then(Value::as_str)
+            .unwrap_or("");
+        if stored != wanted {
+            return false;
+        }
+    }
+    if let Some(wanted) = params.to.as_deref() {
+        let stored = properties
+            .and_then(|value| value.get("to"))
+            .and_then(Value::as_str)
+            .unwrap_or("");
+        if stored != wanted {
+            return false;
+        }
+    }
+    if let Some(wanted) = params.read {
+        let stored = properties
+            .and_then(|value| value.get("read"))
+            .and_then(Value::as_bool)
+            .unwrap_or(false);
+        if stored != wanted {
+            return false;
+        }
+    }
+    if let Some(wanted) = params.delivered {
+        let stored = properties
+            .and_then(|value| value.get("delivered_at"))
+            .is_some_and(|value| !value.is_null());
+        if stored != wanted {
+            return false;
+        }
+    }
+    true
+}
+
 impl KgPack {
     pub(crate) async fn handle_list(
         &self,
@@ -63,6 +139,16 @@ impl KgPack {
         }
 
         let p: ListParams = deser(params)?;
+        if p.after.is_some() && p.offset.is_some() {
+            return Err(RuntimeError::InvalidInput(
+                "after and offset are mutually exclusive pagination modes".into(),
+            ));
+        }
+        if p.after.is_some() && p.limit == Some(0) {
+            return Err(RuntimeError::InvalidInput(
+                "cursor pagination requires limit greater than zero".into(),
+            ));
+        }
         let spec = resolve_kind_spec(&p.kind, registry)?;
         match spec {
             KindSpec::Entity { specific } => {
@@ -89,6 +175,27 @@ impl KgPack {
                 };
                 let requested = p.limit.unwrap_or(50);
                 let limit = effective_list_limit(requested, ENTITY_LIST_CAP);
+                if let Some(after_raw) = p.after.as_deref() {
+                    let after = parse_after_cursor(after_raw)?;
+                    let tags = p.tags.as_deref().unwrap_or_default();
+                    let (entities, next_after) = self
+                        .runtime
+                        .list_entities_after(
+                            token,
+                            kind_filter.as_deref(),
+                            validated_et.as_deref(),
+                            tags,
+                            after,
+                            limit,
+                        )
+                        .await?;
+                    let mut response = serde_json::json!({
+                        "entities": normalize_entity_timestamps_array(to_json(&entities)?),
+                        "next_after": next_after,
+                    });
+                    add_list_limit_metadata(&mut response, requested, limit);
+                    return Ok(response);
+                }
                 let offset = p.offset.unwrap_or(0);
                 let entities = if let Some(ref tag_list) = p.tags {
                     if tag_list.is_empty() {
@@ -179,15 +286,7 @@ impl KgPack {
                 if let Some(ref after_str) = p.after {
                     // An empty string opts into cursor-mode pagination while
                     // starting from the beginning of the set (no prior page).
-                    let after = if after_str.is_empty() {
-                        None
-                    } else {
-                        Some(uuid::Uuid::parse_str(after_str).map_err(|e| {
-                            RuntimeError::InvalidInput(format!(
-                                "after: invalid UUID {after_str:?}: {e}"
-                            ))
-                        })?)
-                    };
+                    let after = parse_after_cursor(after_str)?;
                     let (edges, next_after) = self
                         .runtime
                         .list_edges_after(token, filter, after, limit)
@@ -216,25 +315,108 @@ impl KgPack {
                 )?;
                 let requested = p.limit.unwrap_or(20);
                 let limit = effective_list_limit(requested, NOTE_LIST_CAP);
-                let offset = p.offset.unwrap_or(0);
-
                 let has_msg_filter = p.thread_id.is_some()
                     || p.direction.is_some()
                     || p.from.is_some()
                     || p.to.is_some()
                     || p.read.is_some()
                     || p.delivered.is_some();
-
-                let thread_id_filter = p.thread_id.as_deref();
-                let direction_filter = p.direction.as_deref();
-                let from_filter = p.from.as_deref();
-                let to_filter = p.to.as_deref();
-                let read_filter = p.read;
-                let delivered_filter = p.delivered;
-
                 const PAGE_SIZE: u32 = 200;
                 const MAX_SCAN_TOTAL: u32 = 10_000;
 
+                if let Some(after_raw) = p.after.as_deref() {
+                    let after = parse_after_cursor(after_raw)?;
+                    let (mut notes, next_after, scan_incomplete) = if has_msg_filter {
+                        let mut collected = Vec::new();
+                        let mut raw_after = after;
+                        let mut scanned = 0u32;
+                        let mut last_scanned = None;
+                        let target = (limit as usize).saturating_add(1);
+
+                        let raw_more = loop {
+                            if scanned >= MAX_SCAN_TOTAL || collected.len() >= target {
+                                break collected.len() >= target;
+                            }
+                            let scan_limit = MAX_SCAN_TOTAL.saturating_sub(scanned).min(PAGE_SIZE);
+                            let (page, next_raw_after) = self
+                                .runtime
+                                .list_notes_after(
+                                    token,
+                                    kind_filter.as_deref(),
+                                    raw_after,
+                                    scan_limit,
+                                )
+                                .await?;
+                            if page.is_empty() {
+                                break false;
+                            }
+                            for note in page {
+                                scanned = scanned.saturating_add(1);
+                                last_scanned = Some(note.id);
+                                if note_matches_message_filters(&note, &p) {
+                                    collected.push(note);
+                                    if collected.len() >= target {
+                                        break;
+                                    }
+                                }
+                            }
+                            if collected.len() >= target {
+                                break true;
+                            }
+                            match next_raw_after {
+                                Some(next) => {
+                                    raw_after = Some(next);
+                                    if scanned >= MAX_SCAN_TOTAL {
+                                        break true;
+                                    }
+                                }
+                                None => break false,
+                            }
+                        };
+
+                        let has_more_match = collected.len() > limit as usize;
+                        let continuation = if has_more_match && limit > 0 {
+                            collected.get(limit as usize - 1).map(|note| note.id)
+                        } else if raw_more && scanned >= MAX_SCAN_TOTAL {
+                            last_scanned
+                        } else {
+                            None
+                        };
+                        collected.truncate(limit as usize);
+                        (
+                            collected,
+                            continuation,
+                            !has_more_match && raw_more && scanned >= MAX_SCAN_TOTAL,
+                        )
+                    } else {
+                        let (notes, next_after) = self
+                            .runtime
+                            .list_notes_after(token, kind_filter.as_deref(), after, limit)
+                            .await?;
+                        (notes, next_after, false)
+                    };
+
+                    let remapped: Vec<Value> = notes
+                        .drain(..)
+                        .map(|note| {
+                            to_json(&note)
+                                .map(normalize_entity_timestamps)
+                                .map(remap_note_status)
+                                .unwrap_or_else(|_| serde_json::json!({}))
+                        })
+                        .collect();
+                    let mut response = serde_json::json!({
+                        "notes": remapped,
+                        "next_after": next_after,
+                    });
+                    if scan_incomplete {
+                        response["scan_incomplete"] = Value::Bool(true);
+                    }
+                    add_list_limit_metadata(&mut response, requested, limit);
+                    return Ok(response);
+                }
+
+                let offset = p.offset.unwrap_or(0);
                 let notes: Vec<_> = if has_msg_filter {
                     let mut collected: Vec<_> = Vec::new();
                     let mut db_offset: u32 = 0;
@@ -250,79 +432,12 @@ impl KgPack {
                             .list_notes(token, kind_filter.as_deref(), remaining_scan, db_offset)
                             .await?;
                         let fetched = page.len() as u32;
-                        for n in page {
-                            if n.deleted_at.is_some() {
+                        for note in page {
+                            if note.deleted_at.is_some() {
                                 continue;
                             }
-                            let props = n.properties.as_ref();
-                            let passes = (|| {
-                                if let Some(wanted_thread) = thread_id_filter {
-                                    let stored = match props
-                                        .and_then(|p| p.get("thread_id"))
-                                        .and_then(Value::as_str)
-                                        .filter(|s| !s.is_empty())
-                                    {
-                                        Some(s) => s,
-                                        None => return false,
-                                    };
-                                    let matches = stored == wanted_thread
-                                        || matches!(
-                                            (stored.get(..8), wanted_thread.get(..8)),
-                                            (Some(a), Some(b)) if a == b
-                                        );
-                                    if !matches {
-                                        return false;
-                                    }
-                                }
-                                if let Some(wanted_dir) = direction_filter {
-                                    let stored = props
-                                        .and_then(|p| p.get("direction"))
-                                        .and_then(Value::as_str)
-                                        .unwrap_or("");
-                                    if stored != wanted_dir {
-                                        return false;
-                                    }
-                                }
-                                if let Some(wanted_from) = from_filter {
-                                    let stored = props
-                                        .and_then(|p| p.get("from"))
-                                        .and_then(Value::as_str)
-                                        .unwrap_or("");
-                                    if stored != wanted_from {
-                                        return false;
-                                    }
-                                }
-                                if let Some(wanted_to) = to_filter {
-                                    let stored = props
-                                        .and_then(|p| p.get("to"))
-                                        .and_then(Value::as_str)
-                                        .unwrap_or("");
-                                    if stored != wanted_to {
-                                        return false;
-                                    }
-                                }
-                                if let Some(wanted_read) = read_filter {
-                                    let stored = props
-                                        .and_then(|p| p.get("read"))
-                                        .and_then(Value::as_bool)
-                                        .unwrap_or(false);
-                                    if stored != wanted_read {
-                                        return false;
-                                    }
-                                }
-                                if let Some(wanted_delivered) = delivered_filter {
-                                    let is_delivered = props
-                                        .and_then(|p| p.get("delivered_at"))
-                                        .map(|v| !v.is_null())
-                                        .unwrap_or(false);
-                                    if is_delivered != wanted_delivered {
-                                        return false;
-                                    }
-                                }
-                                true
-                            })();
-                            if passes {
-                                collected.push(n);
+                            if note_matches_message_filters(&note, &p) {
+                                collected.push(note);
                                 if collected.len() >= target_after_skip {
                                     break;
                                 }
@@ -368,6 +483,12 @@ impl KgPack {
             }
             KindSpec::Proposal => unreachable!("kind=proposal fast-pathed before deser"),
             KindSpec::Event => {
+                if p.after.is_some() {
+                    return Err(RuntimeError::InvalidInput(
+                        "after cursor pagination is supported only for entity, note, and edge lists"
+                            .into(),
+                    ));
+                }
                 let requested = p.limit.unwrap_or(100).max(1);
                 let limit = effective_list_limit(requested, EVENT_LIST_CAP);
                 let offset = p.offset.unwrap_or(0);

--- a/crates/khive-pack-kg/src/handlers/params.rs
+++ b/crates/khive-pack-kg/src/handlers/params.rs
@@ -65,9 +65,9 @@ pub(crate) struct ListParams {
     pub(crate) relations: Option<Vec<String>>,
     pub(crate) min_weight: Option<f64>,
     pub(crate) max_weight: Option<f64>,
-    /// Keyset cursor for `kind="edge"`: the `id` of the last edge from the
-    /// previous page. When set, the response is `{edges, next_after}` instead
-    /// of a bare array — see the `list` verb description.
+    /// Keyset cursor for entity, note, and edge lists: the `id` of the last
+    /// record (or scan boundary for filtered messages) from the previous
+    /// page. An empty string starts cursor mode from the beginning.
     pub(crate) after: Option<String>,
     pub(crate) note_kind: Option<String>,
     pub(crate) thread_id: Option<String>,

--- a/crates/khive-pack-kg/tests/integration.rs
+++ b/crates/khive-pack-kg/tests/integration.rs
@@ -11490,6 +11490,28 @@ async fn list_kind_edge_after_cursor_tiles_full_set() {
     assert_eq!(seen.len(), 5, "cursor walk must tile the full edge set");
 }
 
+#[tokio::test]
+async fn list_cursor_mode_rejects_offset_and_unsupported_event_kind() {
+    let fixture = pack();
+    let mixed = fixture
+        .dispatch("list", json!({"kind": "entity", "after": "", "offset": 0}))
+        .await
+        .expect_err("explicit offset and after must not be silently mixed");
+    assert!(
+        invalid_input_message(&mixed).contains("mutually exclusive"),
+        "unexpected error: {mixed}"
+    );
+
+    let event = fixture
+        .dispatch("list", json!({"kind": "event", "after": ""}))
+        .await
+        .expect_err("event lists do not implement cursor mode");
+    assert!(
+        invalid_input_message(&event).contains("entity, note, and edge"),
+        "unexpected error: {event}"
+    );
+}
+
 /// #702.3: `stats()` must break edge counts down by relation, matching the
 /// created fixtures.
 #[tokio::test]
@@ -11814,6 +11836,40 @@ async fn list_entity_limit_over_cap_truncates_with_metadata() {
     assert_eq!(resp["requested_limit"], 600);
     assert_eq!(resp["effective_limit"], 500);
     assert_eq!(resp["limit_clamped"], true);
+
+    // #1462: cursor mode crosses the cap without asking the caller to advance
+    // an offset by either the requested or effective limit.
+    let first = pack
+        .dispatch("list", json!({"kind": "entity", "limit": 600, "after": ""}))
+        .await
+        .expect("entity cursor page one must succeed");
+    let first_entities = first["entities"]
+        .as_array()
+        .expect("entity cursor envelope must contain entities");
+    assert_eq!(first_entities.len(), 500);
+    let cursor = first["next_after"]
+        .as_str()
+        .expect("a 501-row corpus must continue after the 500-row cap");
+    assert_eq!(first["effective_limit"], 500);
+
+    let second = pack
+        .dispatch(
+            "list",
+            json!({"kind": "entity", "limit": 600, "after": cursor}),
+        )
+        .await
+        .expect("entity cursor page two must succeed");
+    let second_entities = second["entities"]
+        .as_array()
+        .expect("entity cursor envelope must contain entities");
+    assert_eq!(second_entities.len(), 1);
+    assert!(second["next_after"].is_null());
+    let unique_ids: std::collections::HashSet<_> = first_entities
+        .iter()
+        .chain(second_entities)
+        .map(|entity| entity["id"].as_str().expect("entity id"))
+        .collect();
+    assert_eq!(unique_ids.len(), 501, "cursor pages must tile all entities");
 }
 
 /// Same "under cap honored exactly" behavior as the entity test, at the note
@@ -11878,6 +11934,37 @@ async fn list_note_limit_over_cap_truncates_with_metadata() {
     assert_eq!(resp["requested_limit"], 300);
     assert_eq!(resp["effective_limit"], 200);
     assert_eq!(resp["limit_clamped"], true);
+
+    let first = pack
+        .dispatch("list", json!({"kind": "note", "limit": 300, "after": ""}))
+        .await
+        .expect("note cursor page one must succeed");
+    let first_notes = first["notes"]
+        .as_array()
+        .expect("note cursor envelope must contain notes");
+    assert_eq!(first_notes.len(), 200);
+    let cursor = first["next_after"]
+        .as_str()
+        .expect("a 201-row corpus must continue after the 200-row cap");
+
+    let second = pack
+        .dispatch(
+            "list",
+            json!({"kind": "note", "limit": 300, "after": cursor}),
+        )
+        .await
+        .expect("note cursor page two must succeed");
+    let second_notes = second["notes"]
+        .as_array()
+        .expect("note cursor envelope must contain notes");
+    assert_eq!(second_notes.len(), 1);
+    assert!(second["next_after"].is_null());
+    let unique_ids: std::collections::HashSet<_> = first_notes
+        .iter()
+        .chain(second_notes)
+        .map(|note| note["id"].as_str().expect("note id"))
+        .collect();
+    assert_eq!(unique_ids.len(), 201, "cursor pages must tile all notes");
 }
 
 /// `list(kind="edge")` offset mode keeps the existing bare-array shape when

--- a/crates/khive-runtime/src/operations.rs
+++ b/crates/khive-runtime/src/operations.rs
@@ -27,8 +27,8 @@ use khive_score::DeterministicScore;
 use khive_storage::note::Note;
 use khive_storage::types::{
     DeleteMode, DirectedNeighborHit, Direction, EdgeSortField, GraphPath, LinkId, NeighborHit,
-    NeighborQuery, Page, PageRequest, SortOrder, SqlRow, SqlStatement, SqlValue, TextFilter,
-    TextQueryMode, TextSearchRequest, TraversalRequest,
+    NeighborQuery, Page, PageRequest, SeekCursor, SortOrder, SqlRow, SqlStatement, SqlValue,
+    TextFilter, TextQueryMode, TextSearchRequest, TraversalRequest,
 };
 use khive_storage::{Edge, EdgeRelation, Entity, EntityFilter, Event, EventFilter};
 use khive_types::{EdgeEndpointRule, EndpointKind, EventKind, KhiveError, SubstrateKind};
@@ -1570,6 +1570,59 @@ impl KhiveRuntime {
             )
             .await?;
         Ok(page.items)
+    }
+
+    /// List an immutable insertion-sequence page of visible entities.
+    ///
+    /// The public cursor remains the UUID of the last returned entity. We
+    /// resolve its immutable database-assigned sequence before querying so callers do
+    /// not need to serialize storage details. A missing or out-of-scope cursor
+    /// fails explicitly instead of silently resuming from the wrong boundary.
+    pub async fn list_entities_after(
+        &self,
+        token: &NamespaceToken,
+        kind: Option<&str>,
+        entity_type: Option<&str>,
+        tags_any: &[String],
+        after: Option<Uuid>,
+        limit: u32,
+    ) -> RuntimeResult<(Vec<Entity>, Option<Uuid>)> {
+        let store = self.entities(token)?;
+        let after = match after {
+            Some(id) => {
+                let entity = self
+                    .get_entity_including_deleted(token, id)
+                    .await?
+                    .ok_or_else(|| RuntimeError::NotFound(format!("entity cursor {id}")))?;
+                Self::ensure_namespace_visible(&entity.namespace, token)?;
+                let sequence = store.entity_sequence(id).await?.ok_or_else(|| {
+                    RuntimeError::Internal(format!(
+                        "entity cursor {id} has no insertion-sequence ledger row"
+                    ))
+                })?;
+                Some(SeekCursor { sequence, id })
+            }
+            None => None,
+        };
+        let filter = EntityFilter {
+            kinds: kind
+                .map(|value| vec![value.to_string()])
+                .unwrap_or_default(),
+            entity_types: entity_type
+                .map(|value| vec![value.to_string()])
+                .unwrap_or_default(),
+            tags_any: tags_any.to_vec(),
+            namespaces: token
+                .visible_namespaces()
+                .iter()
+                .map(|namespace| namespace.as_str().to_owned())
+                .collect(),
+            ..Default::default()
+        };
+        let page = store
+            .query_entities_after(token.namespace().as_str(), filter, after, limit)
+            .await?;
+        Ok((page.items, page.next_after.map(|cursor| cursor.id)))
     }
 
     /// List entities filtered by kind, optional domain tag, limit, and offset.
@@ -3426,6 +3479,50 @@ impl KhiveRuntime {
         Ok(page.items)
     }
 
+    /// List an immutable insertion-sequence page of visible notes.
+    ///
+    /// Soft-deleting the prior page's last note does not invalidate the
+    /// cursor because the boundary is resolved including tombstones. A hard
+    /// deletion makes the cursor unresolvable and returns an explicit error.
+    pub async fn list_notes_after(
+        &self,
+        token: &NamespaceToken,
+        kind: Option<&str>,
+        after: Option<Uuid>,
+        limit: u32,
+    ) -> RuntimeResult<(Vec<Note>, Option<Uuid>)> {
+        let store = self.notes(token)?;
+        let after = match after {
+            Some(id) => {
+                let note = self
+                    .get_note_including_deleted(token, id)
+                    .await?
+                    .ok_or_else(|| RuntimeError::NotFound(format!("note cursor {id}")))?;
+                Self::ensure_namespace_visible(&note.namespace, token)?;
+                let sequence = store.note_sequence(id).await?.ok_or_else(|| {
+                    RuntimeError::Internal(format!(
+                        "note cursor {id} has no insertion-sequence ledger row"
+                    ))
+                })?;
+                Some(SeekCursor { sequence, id })
+            }
+            None => None,
+        };
+        let filter = khive_storage::note::NoteFilter {
+            kind: kind.map(str::to_string),
+            namespaces: token
+                .visible_namespaces()
+                .iter()
+                .map(|namespace| namespace.as_str().to_owned())
+                .collect(),
+            ..Default::default()
+        };
+        let page = store
+            .query_notes_filtered_after(token.namespace().as_str(), &filter, after, limit)
+            .await?;
+        Ok((page.items, page.next_after.map(|cursor| cursor.id)))
+    }
+
     /// Count notes matching `kind` across the caller's visible namespaces.
     pub async fn count_notes(
         &self,
@@ -4651,16 +4748,17 @@ impl KhiveRuntime {
         Ok(results[start..end].to_vec())
     }
 
-    /// Keyset (seek) page of edges matching `filter`, ordered by edge `id`
-    /// ascending. `after` is the last edge id from the previous page
-    /// (exclusive); omit to start from the beginning. Returns
+    /// Keyset (seek) page of edges matching `filter`, ordered by immutable
+    /// database-assigned insertion sequence. `after` is the last edge id from the
+    /// previous page (exclusive); omit to start from the beginning. Returns
     /// `(items, next_after)` — `next_after` is `Some` when more rows remain
     /// past this page.
     ///
-    /// Unlike [`Self::list_edges`], this is O(log n + limit) at any depth: the
-    /// underlying store issues an indexed `id > ?` range scan instead of an
-    /// `OFFSET` skip, avoiding the O(offset) daemon CPU cost of a naive
-    /// offset-based paging loop over a large edge population.
+    /// Unlike [`Self::list_edges`], this is O(log n + limit) at any depth and
+    /// genuinely new inserts are appended after already-issued boundaries. The
+    /// cursor row is resolved including tombstones; a hard-deleted or
+    /// out-of-scope cursor fails explicitly rather than hiding an incomplete
+    /// traversal.
     pub async fn list_edges_after(
         &self,
         token: &NamespaceToken,
@@ -4671,30 +4769,64 @@ impl KhiveRuntime {
         let limit = limit.clamp(1, Self::EDGE_LIST_MAX_LIMIT);
         let visible = token.visible_namespaces();
         let limit_usize = limit as usize;
+        let cursor_store = self.graph(token)?;
+        let after = match after {
+            Some(id) => {
+                let edge = self
+                    .get_edge_including_deleted(token, id)
+                    .await?
+                    .ok_or_else(|| RuntimeError::NotFound(format!("edge cursor {id}")))?;
+                Self::ensure_namespace_visible(&edge.namespace, token)?;
+                let sequence = cursor_store.edge_sequence(id).await?.ok_or_else(|| {
+                    RuntimeError::Internal(format!(
+                        "edge cursor {id} has no insertion-sequence ledger row"
+                    ))
+                })?;
+                Some(SeekCursor { sequence, id })
+            }
+            None => None,
+        };
 
         if let [ns] = visible {
             let temp = NamespaceToken::for_namespace(ns.clone());
             let page = self
                 .graph(&temp)?
-                .query_edges_after(filter.into(), after, limit)
+                .query_edges_sequence_after(filter.into(), after, limit)
                 .await?;
-            return Ok((page.items, page.next_after));
+            return Ok((page.items, page.next_after.map(|cursor| cursor.id)));
         }
 
         // Multi-namespace visibility: seek each namespace from the same
-        // cursor (ids are globally unique UUIDs), merge, then take the head
-        // of the merged set as this page.
-        let probe_limit = limit + 1;
+        // immutable boundary, merge in global insertion order, then take the head of
+        // the merged set as this page.
+        let probe_limit = limit.saturating_add(1);
         let mut results = Vec::new();
         for ns in visible {
             let temp = NamespaceToken::for_namespace(ns.clone());
             let page = self
                 .graph(&temp)?
-                .query_edges_after(filter.clone().into(), after, probe_limit)
+                .query_edges_sequence_after(filter.clone().into(), after, probe_limit)
                 .await?;
             results.extend(page.items);
         }
-        results.sort_by_key(|e| Uuid::from(e.id));
+        let ids = results
+            .iter()
+            .map(|edge| Uuid::from(edge.id))
+            .collect::<Vec<_>>();
+        let sequences = cursor_store
+            .edge_sequences(&ids)
+            .await?
+            .into_iter()
+            .collect::<HashMap<_, _>>();
+        if let Some(missing) = ids.iter().find(|id| !sequences.contains_key(id)) {
+            return Err(RuntimeError::Internal(format!(
+                "edge {missing} has no insertion-sequence ledger row"
+            )));
+        }
+        results.sort_by_key(|edge| {
+            let id = Uuid::from(edge.id);
+            (sequences[&id], id)
+        });
         results.dedup_by_key(|e| Uuid::from(e.id));
         let has_more = results.len() > limit_usize;
         if has_more {
@@ -6574,9 +6706,8 @@ mod tests {
         );
     }
 
-    /// `list_edges_after` seeks via `id > cursor` against the
-    /// `(namespace, id)` primary key index instead of paging through OFFSET,
-    /// so cost does not grow with how deep the walk goes.
+    /// `list_edges_after` seeks via a durable insertion sequence instead of
+    /// paging through OFFSET, so cost does not grow with walk depth.
     #[tokio::test]
     async fn list_edges_after_keyset_tiles_full_set() {
         let rt = rt();
@@ -6621,11 +6752,8 @@ mod tests {
         seen.dedup();
         assert_eq!(seen.len(), 5, "keyset walk must tile the full edge set");
 
-        // Stability: repeating the same cursor returns the same page — no
-        // drift under a fixed snapshot. The seek is `WHERE id > ?` against
-        // the `(namespace, id)` primary key index with `ORDER BY id ASC`
-        // matching the index order, so this is an indexed range scan, not a
-        // full-table scan+sort (see `query_edges_after` in khive-db).
+        // With no intervening writes, repeating the same cursor returns the
+        // same insertion-sequence page.
         let (first_a, next_a) = rt
             .list_edges_after(&tok, filter.clone(), None, 2)
             .await
@@ -6639,6 +6767,261 @@ mod tests {
             first_b.iter().map(|e| e.id.0).collect::<Vec<_>>(),
         );
         assert_eq!(next_a, next_b);
+    }
+
+    #[tokio::test]
+    async fn list_entities_after_same_timestamp_lower_uuid_insert_is_not_skipped() {
+        let rt = rt();
+        let tok = NamespaceToken::local();
+        let ids = [
+            Uuid::parse_str("f0000000-0000-4000-8000-000000000011").unwrap(),
+            Uuid::parse_str("f0000000-0000-4000-8000-000000000012").unwrap(),
+            Uuid::parse_str("f0000000-0000-4000-8000-000000000013").unwrap(),
+        ];
+        let store = rt.entities(&tok).unwrap();
+        for (index, id) in ids.into_iter().enumerate() {
+            let mut entity = Entity::new("local", "concept", format!("Entity{index}"));
+            entity.id = id;
+            entity.created_at = 1_000_000;
+            entity.updated_at = 1_000_000;
+            store.upsert_entity(entity).await.unwrap();
+        }
+
+        let (first, next) = rt
+            .list_entities_after(&tok, None, None, &[], None, 2)
+            .await
+            .unwrap();
+        assert_eq!(
+            first.iter().map(|entity| entity.id).collect::<Vec<_>>(),
+            ids[..2]
+        );
+        let cursor = next.expect("one original entity remains after page one");
+
+        let low_id = Uuid::parse_str("00000000-0000-4000-8000-000000000011").unwrap();
+        assert!(low_id < cursor);
+        let mut inserted = Entity::new("local", "concept", "InsertedEntity");
+        inserted.id = low_id;
+        inserted.created_at = 1_000_000;
+        inserted.updated_at = 1_000_000;
+        store.upsert_entity(inserted).await.unwrap();
+
+        let (second, final_cursor) = rt
+            .list_entities_after(&tok, None, None, &[], Some(cursor), 2)
+            .await
+            .unwrap();
+        assert_eq!(
+            second.iter().map(|entity| entity.id).collect::<Vec<_>>(),
+            vec![ids[2], low_id]
+        );
+        assert_eq!(final_cursor, None);
+    }
+
+    #[tokio::test]
+    async fn list_notes_after_same_timestamp_lower_uuid_insert_is_not_skipped() {
+        let rt = rt();
+        let tok = NamespaceToken::local();
+        let ids = [
+            Uuid::parse_str("f0000000-0000-4000-8000-000000000021").unwrap(),
+            Uuid::parse_str("f0000000-0000-4000-8000-000000000022").unwrap(),
+            Uuid::parse_str("f0000000-0000-4000-8000-000000000023").unwrap(),
+        ];
+        let store = rt.notes(&tok).unwrap();
+        for (index, id) in ids.into_iter().enumerate() {
+            let mut note = Note::new("local", "observation", format!("Note {index}"));
+            note.id = id;
+            note.created_at = 1_000_000;
+            note.updated_at = 1_000_000;
+            store.upsert_note(note).await.unwrap();
+        }
+
+        let (first, next) = rt.list_notes_after(&tok, None, None, 2).await.unwrap();
+        assert_eq!(
+            first.iter().map(|note| note.id).collect::<Vec<_>>(),
+            ids[..2]
+        );
+        let cursor = next.expect("one original note remains after page one");
+
+        let low_id = Uuid::parse_str("00000000-0000-4000-8000-000000000021").unwrap();
+        assert!(low_id < cursor);
+        let mut inserted = Note::new("local", "observation", "Inserted note");
+        inserted.id = low_id;
+        inserted.created_at = 1_000_000;
+        inserted.updated_at = 1_000_000;
+        store.upsert_note(inserted).await.unwrap();
+
+        let (second, final_cursor) = rt
+            .list_notes_after(&tok, None, Some(cursor), 2)
+            .await
+            .unwrap();
+        assert_eq!(
+            second.iter().map(|note| note.id).collect::<Vec<_>>(),
+            vec![ids[2], low_id]
+        );
+        assert_eq!(final_cursor, None);
+    }
+
+    #[tokio::test]
+    async fn list_edges_after_same_timestamp_lower_uuid_insert_is_not_skipped() {
+        let rt = rt();
+        let tok = NamespaceToken::local();
+        let source = rt
+            .create_entity(&tok, "concept", None, "CursorSource", None, None, vec![])
+            .await
+            .unwrap();
+        let mut targets = Vec::new();
+        for index in 0..4 {
+            targets.push(
+                rt.create_entity(
+                    &tok,
+                    "concept",
+                    None,
+                    &format!("CursorTarget{index}"),
+                    None,
+                    None,
+                    vec![],
+                )
+                .await
+                .unwrap(),
+            );
+        }
+
+        let ids = [
+            Uuid::parse_str("f0000000-0000-4000-8000-000000000001").unwrap(),
+            Uuid::parse_str("f0000000-0000-4000-8000-000000000002").unwrap(),
+            Uuid::parse_str("f0000000-0000-4000-8000-000000000003").unwrap(),
+        ];
+        let graph = rt.graph(&tok).unwrap();
+        let created_at = chrono::DateTime::<chrono::Utc>::from_timestamp_micros(1_000_000).unwrap();
+        for (index, id) in ids.into_iter().enumerate() {
+            graph
+                .upsert_edge(Edge {
+                    id: id.into(),
+                    namespace: "local".into(),
+                    source_id: source.id,
+                    target_id: targets[index].id,
+                    relation: EdgeRelation::Extends,
+                    weight: 1.0,
+                    created_at,
+                    updated_at: created_at,
+                    deleted_at: None,
+                    metadata: None,
+                    target_backend: None,
+                })
+                .await
+                .unwrap();
+        }
+
+        let filter = EdgeListFilter {
+            source_id: Some(source.id),
+            relations: vec![EdgeRelation::Extends],
+            ..Default::default()
+        };
+        let (first, next) = rt
+            .list_edges_after(&tok, filter.clone(), None, 2)
+            .await
+            .unwrap();
+        assert_eq!(
+            first.iter().map(|edge| edge.id.0).collect::<Vec<_>>(),
+            ids[..2]
+        );
+        let cursor = next.expect("one original edge remains after page one");
+
+        // The later insert has the same wall-clock microsecond and sorts before
+        // the cursor UUID. Its database-assigned sequence still places it after
+        // the issued boundary.
+        let low_id = Uuid::parse_str("00000000-0000-4000-8000-000000000001").unwrap();
+        assert!(low_id < cursor);
+        graph
+            .upsert_edge(Edge {
+                id: low_id.into(),
+                namespace: "local".into(),
+                source_id: source.id,
+                target_id: targets[3].id,
+                relation: EdgeRelation::Extends,
+                weight: 1.0,
+                created_at,
+                updated_at: created_at,
+                deleted_at: None,
+                metadata: None,
+                target_backend: None,
+            })
+            .await
+            .unwrap();
+
+        let (second, final_cursor) = rt
+            .list_edges_after(&tok, filter, Some(cursor), 2)
+            .await
+            .unwrap();
+        assert_eq!(
+            second.iter().map(|edge| edge.id.0).collect::<Vec<_>>(),
+            vec![ids[2], low_id]
+        );
+        assert_eq!(final_cursor, None);
+    }
+
+    #[tokio::test]
+    async fn list_entity_cursor_survives_soft_delete_and_rejects_hard_delete_or_hidden_scope() {
+        let rt = rt();
+        let local = NamespaceToken::local();
+        for index in 0..3 {
+            rt.create_entity(
+                &local,
+                "concept",
+                None,
+                &format!("CursorLifecycle{index}"),
+                None,
+                None,
+                vec![],
+            )
+            .await
+            .unwrap();
+        }
+
+        let (_, next) = rt
+            .list_entities_after(&local, None, None, &[], None, 2)
+            .await
+            .unwrap();
+        let cursor = next.expect("three entities require a second page");
+        let store = rt.entities(&local).unwrap();
+        assert!(store.delete_entity(cursor, DeleteMode::Soft).await.unwrap());
+
+        let (remaining, next) = rt
+            .list_entities_after(&local, None, None, &[], Some(cursor), 2)
+            .await
+            .expect("a soft-deleted cursor must retain its sequence boundary");
+        assert_eq!(remaining.len(), 1);
+        assert_eq!(next, None);
+
+        assert!(store.delete_entity(cursor, DeleteMode::Hard).await.unwrap());
+        let hard_deleted = rt
+            .list_entities_after(&local, None, None, &[], Some(cursor), 2)
+            .await;
+        assert!(
+            matches!(hard_deleted, Err(RuntimeError::NotFound(_))),
+            "a hard-deleted cursor must fail explicitly: {hard_deleted:?}"
+        );
+
+        let hidden_ns = Namespace::parse("cursor-hidden").unwrap();
+        let hidden_token = NamespaceToken::for_namespace(hidden_ns);
+        let hidden = rt
+            .create_entity(
+                &hidden_token,
+                "concept",
+                None,
+                "HiddenCursor",
+                None,
+                None,
+                vec![],
+            )
+            .await
+            .unwrap();
+        let out_of_scope = rt
+            .list_entities_after(&local, None, None, &[], Some(hidden.id), 2)
+            .await;
+        assert!(
+            matches!(out_of_scope, Err(RuntimeError::NotFound(_))),
+            "an out-of-scope cursor must not reveal or resume from the hidden row: {out_of_scope:?}"
+        );
     }
 
     #[tokio::test]

--- a/crates/khive-storage/src/entity.rs
+++ b/crates/khive-storage/src/entity.rs
@@ -5,7 +5,9 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use uuid::Uuid;
 
-use crate::types::{BatchWriteSummary, DeleteMode, Page, PageRequest, StorageResult};
+use crate::types::{
+    BatchWriteSummary, DeleteMode, Page, PageRequest, SeekCursor, SeekPage, StorageResult,
+};
 
 /// Storage-level entity record. Flat SQL-friendly representation.
 /// Maps to the `entities` substrate table.
@@ -147,6 +149,32 @@ pub trait EntityStore: Send + Sync + 'static {
         filter: EntityFilter,
         page: PageRequest,
     ) -> StorageResult<Page<Entity>>;
+    /// Resolve an entity id to its immutable insertion sequence.
+    async fn entity_sequence(&self, _id: Uuid) -> StorageResult<Option<i64>> {
+        Err(crate::StorageError::Unsupported {
+            capability: crate::StorageCapability::Entities,
+            operation: "entity_sequence".into(),
+            message: "this backend does not implement entity insertion sequences".into(),
+        })
+    }
+    /// Query an immutable insertion-sequence keyset page.
+    ///
+    /// Backends that do not implement seek pagination may retain the default
+    /// unsupported result; callers must not silently fall back to offset
+    /// paging because that would weaken the no-gap/no-duplicate contract.
+    async fn query_entities_after(
+        &self,
+        _namespace: &str,
+        _filter: EntityFilter,
+        _after: Option<SeekCursor>,
+        _limit: u32,
+    ) -> StorageResult<SeekPage<Entity>> {
+        Err(crate::StorageError::Unsupported {
+            capability: crate::StorageCapability::Entities,
+            operation: "query_entities_after".into(),
+            message: "this backend does not implement entity seek pagination".into(),
+        })
+    }
     /// Count entities in a namespace matching the given filter.
     async fn count_entities(&self, namespace: &str, filter: EntityFilter) -> StorageResult<u64>;
     /// Fetch an entity by UUID regardless of soft-deletion state.

--- a/crates/khive-storage/src/graph.rs
+++ b/crates/khive-storage/src/graph.rs
@@ -9,7 +9,8 @@ use crate::error::StorageError;
 use crate::types::{
     BatchWriteSummary, DeleteMode, DirectedNeighborHit, Direction, Edge, EdgeFilter, EdgeSeekPage,
     EdgeSortField, GraphPath, GuardedBatchOutcome, GuardedWriteOutcome, LinkId, NeighborHit,
-    NeighborQuery, Page, PageRequest, SortOrder, StorageResult, TraversalRequest,
+    NeighborQuery, Page, PageRequest, SeekCursor, SeekPage, SortOrder, StorageResult,
+    TraversalRequest,
 };
 
 /// Directed edge CRUD and graph traversal over the knowledge graph.
@@ -137,14 +138,49 @@ pub trait GraphStore: Send + Sync + 'static {
     /// Seek-pagination page of edges ordered by `id` ascending, using an
     /// indexed range scan (`id > after`) against the `(namespace, id)`
     /// primary key instead of `OFFSET`. `after` is exclusive; `None` starts
-    /// from the beginning of the set. Stable under concurrent writes and
-    /// O(log n + limit) at any depth, unlike offset paging (#702.2).
+    /// from the beginning of the set. This remains an efficient compatibility
+    /// path for a fixed edge set, but random UUIDs inserted concurrently may
+    /// sort behind an issued boundary. Public concurrent walks use
+    /// [`Self::query_edges_sequence_after`] instead (#1424).
     async fn query_edges_after(
         &self,
         filter: EdgeFilter,
         after: Option<Uuid>,
         limit: u32,
     ) -> StorageResult<EdgeSeekPage>;
+    /// Resolve an edge id to its immutable insertion sequence.
+    async fn edge_sequence(&self, _id: Uuid) -> StorageResult<Option<i64>> {
+        Err(StorageError::Unsupported {
+            capability: StorageCapability::Graph,
+            operation: "edge_sequence".into(),
+            message: "this backend does not implement edge insertion sequences".into(),
+        })
+    }
+    /// Resolve edge ids to immutable insertion sequences. Implementations may
+    /// override this to batch the lookup; the default preserves correctness.
+    async fn edge_sequences(&self, ids: &[Uuid]) -> StorageResult<Vec<(Uuid, i64)>> {
+        let mut resolved = Vec::with_capacity(ids.len());
+        for id in ids {
+            if let Some(sequence) = self.edge_sequence(*id).await? {
+                resolved.push((*id, sequence));
+            }
+        }
+        Ok(resolved)
+    }
+    /// Seek-pagination page ordered by immutable insertion sequence. This is
+    /// the stable public-list contract for walks overlapping inserts (#1424).
+    async fn query_edges_sequence_after(
+        &self,
+        _filter: EdgeFilter,
+        _after: Option<SeekCursor>,
+        _limit: u32,
+    ) -> StorageResult<SeekPage<Edge>> {
+        Err(StorageError::Unsupported {
+            capability: StorageCapability::Graph,
+            operation: "query_edges_sequence_after".into(),
+            message: "this backend does not implement insertion-sequence edge pagination".into(),
+        })
+    }
     /// Return immediate neighbors of a graph node.
     async fn neighbors(
         &self,

--- a/crates/khive-storage/src/lib.rs
+++ b/crates/khive-storage/src/lib.rs
@@ -42,12 +42,12 @@ pub use types::{
     BatchWriteSummary, DeleteMode, DirectedNeighborHit, Direction, Edge, EdgeFilter, EdgeSeekPage,
     EdgeSortField, GraphPath, GuardedBatchOutcome, GuardedBatchRefusal, GuardedWriteOutcome,
     IndexRebuildScope, LinkId, MissingEndpoints, NeighborHit, NeighborQuery, OrphanSweepConfig,
-    OrphanSweepResult, Page, PageRequest, PathNode, PropertyFilter, PropertyOp, SortDirection,
-    SortOrder, SparseRecord, SparseSearchHit, SparseSearchRequest, SparseVector, SqlRow,
-    SqlStatement, SqlValue, TextDocument, TextFilter, TextGatherMode, TextIndexStats,
-    TextQueryMode, TextSearchHit, TextSearchOptions, TextSearchRequest, TextTermStats,
-    TextTermStatsRequest, TimeRange, TraversalOptions, TraversalRequest, VectorIndexKind,
-    VectorMetadataFilter, VectorRecord, VectorSearchHit, VectorSearchRequest,
+    OrphanSweepResult, Page, PageRequest, PathNode, PropertyFilter, PropertyOp, SeekCursor,
+    SeekPage, SortDirection, SortOrder, SparseRecord, SparseSearchHit, SparseSearchRequest,
+    SparseVector, SqlRow, SqlStatement, SqlValue, TextDocument, TextFilter, TextGatherMode,
+    TextIndexStats, TextQueryMode, TextSearchHit, TextSearchOptions, TextSearchRequest,
+    TextTermStats, TextTermStatsRequest, TimeRange, TraversalOptions, TraversalRequest,
+    VectorIndexKind, VectorMetadataFilter, VectorRecord, VectorSearchHit, VectorSearchRequest,
     VectorStoreCapabilities, VectorStoreInfo, MAX_SPARSE_SEARCH_TOP_K,
 };
 

--- a/crates/khive-storage/src/note.rs
+++ b/crates/khive-storage/src/note.rs
@@ -5,7 +5,9 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use uuid::Uuid;
 
-use crate::types::{BatchWriteSummary, DeleteMode, Page, PageRequest, SqlValue, StorageResult};
+use crate::types::{
+    BatchWriteSummary, DeleteMode, Page, PageRequest, SeekCursor, SeekPage, SqlValue, StorageResult,
+};
 
 /// A storage-level note record. Flat, SQL-friendly representation.
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -343,6 +345,29 @@ pub trait NoteStore: Send + Sync + 'static {
         filter: &NoteFilter,
         page: PageRequest,
     ) -> StorageResult<Page<Note>>;
+    /// Resolve a note id to its immutable insertion sequence.
+    async fn note_sequence(&self, _id: Uuid) -> StorageResult<Option<i64>> {
+        Err(crate::StorageError::Unsupported {
+            capability: crate::StorageCapability::Notes,
+            operation: "note_sequence".into(),
+            message: "this backend does not implement note insertion sequences".into(),
+        })
+    }
+    /// Query an immutable insertion-sequence keyset page with the same
+    /// predicates as [`Self::query_notes_filtered`].
+    async fn query_notes_filtered_after(
+        &self,
+        _namespace: &str,
+        _filter: &NoteFilter,
+        _after: Option<SeekCursor>,
+        _limit: u32,
+    ) -> StorageResult<SeekPage<Note>> {
+        Err(crate::StorageError::Unsupported {
+            capability: crate::StorageCapability::Notes,
+            operation: "query_notes_filtered_after".into(),
+            message: "this backend does not implement note seek pagination".into(),
+        })
+    }
     /// Fetch up to `max_rows + 1` notes matching `filter` in a single
     /// deterministically-ordered SQL statement, with no separate `COUNT(*)`
     /// and no pagination loop.

--- a/crates/khive-storage/src/types/mod.rs
+++ b/crates/khive-storage/src/types/mod.rs
@@ -18,7 +18,7 @@ pub use graph::{
     NeighborHit, NeighborQuery, PathNode, SortDirection, SortOrder, TimeRange, TraversalOptions,
     TraversalRequest,
 };
-pub use pagination::{Page, PageRequest};
+pub use pagination::{Page, PageRequest, SeekCursor, SeekPage};
 pub use sparse::{
     SparseRecord, SparseSearchHit, SparseSearchRequest, SparseVector, MAX_SPARSE_SEARCH_TOP_K,
 };

--- a/crates/khive-storage/src/types/pagination.rs
+++ b/crates/khive-storage/src/types/pagination.rs
@@ -1,6 +1,35 @@
 //! Pagination types for list operations.
 
 use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+/// Immutable insertion-sequence boundary for record-list pagination.
+///
+/// `sequence` is assigned by the storage backend when an id is first inserted.
+/// It is strictly increasing, never reused, and remains fixed across updates or
+/// soft deletion. `id` is retained as the public continuation value; it is not
+/// part of the storage ordering key.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct SeekCursor {
+    pub sequence: i64,
+    pub id: Uuid,
+}
+
+/// One keyset page plus the boundary needed to continue it.
+#[derive(Clone, Debug)]
+pub struct SeekPage<T> {
+    pub items: Vec<T>,
+    pub next_after: Option<SeekCursor>,
+}
+
+impl<T> Default for SeekPage<T> {
+    fn default() -> Self {
+        Self {
+            items: Vec::new(),
+            next_after: None,
+        }
+    }
+}
 
 /// Raw deserialization target for [`PageRequest`].
 #[derive(Deserialize)]

--- a/docs/adr/ADR-015-schema-migrations.md
+++ b/docs/adr/ADR-015-schema-migrations.md
@@ -138,7 +138,9 @@ above remains the historical pre-consolidation record.
 |      V8 | #827               | notes_seq_repair                   | shipped |
 |      V9 | ADR-104            | entities_name_ci_index             | shipped |
 |     V10 | ADR-111            | entities_content_ref               | shipped |
-|     V11 | ADR-056            | comm_channel_cursor_source_key     | claimed |
+|     V11 | ADR-079            | ann_write_log                      | shipped |
+|     V12 | ADR-118            | ann_write_log_model_seq_index      | shipped |
+|     V13 | #1424 / #1462      | list_cursor_sequences              | shipped |
 
 > **V9 record (2026-07-18)**: `entities_name_ci_index` (ADR-104) ships in the `MIGRATIONS`
 > array as `009-entities-name-ci-index.sql`; its status here was `claimed`, stale from ADR-104,
@@ -147,15 +149,12 @@ above remains the historical pre-consolidation record.
 
 > **V10 record (2026-07-18)**: `entities_content_ref` (ADR-111 BlobStore `content_ref`
 > column, khive#292) shipped in the `MIGRATIONS` array but was not recorded here; it is
-> backfilled so the live sequence is contiguous through the V11 claim below.
+> backfilled so the live sequence remains contiguous through the later shipped migrations.
 
-> **V11 claim (2026-07-18, ADR-056)**: `comm_channel_cursor_source_key` widens
-> `comm_channel_cursor` to the three-column key `(channel_kind, channel_slug, source)` and adds
-> the `anchor` column (ADR-056 Amendment 2026-07-17, §Migration: owner and sequence). Status is
-> `claimed`: this is a docs-first ADR PR, and the `011-comm-channel-cursor-source-key.sql` file
-> ships with the implementation that follows the accepted spec. Like V20/V21 in the
-> pre-consolidation ledger, it is pack-owned logical state whose
-> shipped schema is a core `khive-db` versioned migration, so the ledger records it.
+> **V11–V13 record (2026-08-01)**: V11 and V12 record the shipped ANN write-log
+> table and model-leading tail index. V13 adds durable insertion-sequence ledgers,
+> ordered upgrade backfills, and atomic insert triggers for stable entity, note,
+> and edge list cursors. These entries align the live ledger with `MIGRATIONS`.
 
 > **Invariant**: ADR number order and migration version order are independent. Migration versions reflect schema ledger assignment order. A migration may only depend on schema created by earlier versions.
 
@@ -187,15 +186,10 @@ Pack-auxiliary tables are owned by the pack.
 **The pack-owned-state-in-a-core-migration exception.** V5 (`unique_comm_message_external_id`) and V6
 (`brain_retune_driver`) established the precedent: both are core `khive-db` versioned migrations that
 evolve schema a pack -- comm, brain -- logically owns, because that schema was placed inside a table
-the core ledger already versions rather than in a boot-time pack declaration of its own. V11
-(`comm_channel_cursor_source_key`, ADR-056 Amendment 2026-07-17) follows the same precedent: it widens
-the pack-owned `comm_channel_cursor` table's key and adds a column, shipped as a core `khive-db`
-versioned migration rather than a pack schema declaration, because `comm_channel_cursor` already
-carries a forward-only version history in the core ledger and a boot-time `CREATE TABLE IF NOT EXISTS`
-cannot express a widened uniqueness key or a backward-compatible column add against existing rows the
-way a versioned migration can. The exception is narrow: it applies only to evolving a table's shape
-that a core migration already owns, never to introducing a wholly new pack-auxiliary table through the
-core lane, which remains the pack's own boot-time declaration to make.
+the core ledger already versions rather than in a boot-time pack declaration of its own. The
+exception is narrow: it applies only to evolving a table's shape that a core migration already owns,
+never to introducing a wholly new pack-auxiliary table through the core lane, which remains the pack's
+own boot-time declaration to make.
 
 ### Versioned migration model
 

--- a/docs/adr/ADR-015-schema-migrations.md
+++ b/docs/adr/ADR-015-schema-migrations.md
@@ -141,6 +141,7 @@ above remains the historical pre-consolidation record.
 |     V11 | ADR-079            | ann_write_log                      | shipped |
 |     V12 | ADR-118            | ann_write_log_model_seq_index      | shipped |
 |     V13 | #1424 / #1462      | list_cursor_sequences              | shipped |
+|     V14 | #1424 / #1462      | graph_edges_id_unique              | shipped |
 
 > **V9 record (2026-07-18)**: `entities_name_ci_index` (ADR-104) ships in the `MIGRATIONS`
 > array as `009-entities-name-ci-index.sql`; its status here was `claimed`, stale from ADR-104,

--- a/docs/adr/ADR-023-declarative-pack-format.md
+++ b/docs/adr/ADR-023-declarative-pack-format.md
@@ -636,3 +636,34 @@ the registered handlers, and the live surface is readable with
 `request(ops="verbs(pack=\"kg\")")`.
 
 The decision this ADR records is unchanged. Only the restatements of a number are removed.
+
+## Amendment: stable `list` cursors (2026-08-01)
+
+The kg `list` verb supports keyset pagination for entity, note, and edge substrates.
+Supplying `after=""` selects cursor mode from the beginning; subsequent requests pass
+the prior response's `next_after` UUID while preserving the same filters. The response
+envelope is substrate-specific (`entities`, `notes`, or `edges`) and `next_after` is null
+only when the matching walk is exhausted.
+
+The UUID is resolved to its record's immutable, database-assigned insertion sequence.
+Entity, note, and edge inserts assign that sequence atomically in the substrate write's
+SQLite transaction; the sequence is never reused and does not change on update or soft
+deletion. A genuinely new id committed after an issued cursor therefore sorts after that
+boundary even when its wall-clock timestamp ties or moves backward and its UUID is lower.
+The V13 edge-ledger backfill preserves the prior public edge cursor's UUID ordering, so an
+outstanding edge cursor may resume across the schema migration before later inserts append.
+Soft-deleted cursor rows remain resolvable; a missing, hard-deleted, or out-of-scope cursor
+returns an error rather than silently restarting or skipping a range. `after` and an explicit
+`offset` are mutually exclusive. Event and proposal lists retain their existing pagination
+modes.
+
+This is a live, insertion-stable walk, not an MVCC snapshot. Inserts committed before a
+subsequent page query can extend the walk and are returned once after the prior boundary.
+Once a substrate/namespace query returns its terminal page (`next_after: null`), inserts that
+commit after that query are outside the completed walk and require a new walk from `after=""`.
+Updates or deletes may also change whether an unvisited row matches the preserved filters;
+cursor stability does not freeze mutable row membership.
+
+Message-property filters remain a bounded post-filter scan. In cursor mode, reaching the
+10,000-row safety ceiling returns `scan_incomplete: true` plus the last safe scan boundary,
+so callers can continue instead of mistaking a bounded scan for corpus exhaustion.

--- a/docs/adr/ADR-056-channel-transport-layer.md
+++ b/docs/adr/ADR-056-channel-transport-layer.md
@@ -2068,6 +2068,15 @@ same `ChannelCheckpoint` value, so the reset commits atomically with the rest of
 than as a separate write. This is the precise, API-level statement of the `cursor_get -> poll_page
 -> handle each -> cursor_commit` sequencing described in §Restart durability above.
 
+> **Migration-sequence reconciliation (2026-08-01).** The V11 reservation in the
+> amendment below was never implemented and is superseded. The live post-consolidation
+> ledger now assigns V11 to `ann_write_log`, V12 to its model/sequence index, and V13
+> to stable list-cursor sequences. A future implementation of the
+> `comm_channel_cursor` widening MUST claim the next available version in ADR-015 in
+> the same PR. References below to V10 as the then-current tree and to V11/`011-*` as
+> the target are retained as the amendment's historical snapshot, not as a live schema
+> allocation. The ownership, atomic rebuild, and rollback requirements are unchanged.
+
 **Migration: owner and sequence.** The comm pack owns `comm_channel_cursor` and today ships it
 via a constant `CREATE TABLE IF NOT EXISTS` declaration (`COMM_CHANNEL_CURSOR_SCHEMA_STMT`) with a
 two-column primary key `(channel_kind, channel_slug)` -- idempotent on a fresh database, but a

--- a/docs/guide/api-reference.md
+++ b/docs/guide/api-reference.md
@@ -214,7 +214,8 @@ List records with optional filtering.
 | ---------------------------- | ------------------------ | -------- | ----------------------------------------------------------------------------- |
 | `kind`                       | string                   | yes      | `entity`\|`note`\|`edge`\|`event`\|`proposal`\|`message`, or a granular kind. |
 | `limit`                      | integer                  | no       | Default 20.                                                                   |
-| `offset`                     | integer                  | no       | Default 0.                                                                    |
+| `offset`                     | integer                  | no       | Default 0; mutually exclusive with `after`.                                   |
+| `after`                      | string                   | no       | Entity/note/edge cursor UUID, or `""` to begin cursor mode.                   |
 | `entity_kind`                | string                   | no       | Filter when `kind="entity"`.                                                  |
 | `entity_type`                | string                   | no       | Filter by type field when `kind="entity"`.                                    |
 | `note_kind`                  | string                   | no       | Filter when `kind="note"`.                                                    |
@@ -237,10 +238,26 @@ Requests within the kind's server-side row cap keep the existing array response.
 exceeds the cap, the response is `{"items": [...], "requested_limit": N,
 "effective_limit": CAP, "limit_clamped": true}`. This lets offset-based clients advance by
 the effective limit instead of silently skipping rows. The caps are entity 500, note 200, edge
-1000, event 1000, and proposal 500. Edge cursor mode keeps its existing `{"edges": [...],
-"next_after": ...}` shape and adds the same limit metadata when clamped.
+1000, event 1000, and proposal 500. Entity, note, and edge cursor modes return
+`{"entities": [...], "next_after": ...}`, `{"notes": [...], "next_after": ...}`, or
+`{"edges": [...], "next_after": ...}` and add the same limit metadata when clamped.
 
-Row shape (each item in the array, or in `"items"`/`"edges"` when clamped) depends on `kind`.
+Set `after=""` to begin a stable cursor walk, then pass each non-null `next_after` value into the
+next request with the same filters. The cursor's public value is a UUID; storage resolves it to an
+immutable, database-assigned insertion sequence and performs a sequence seek. Every genuinely new id
+committed after an issued boundary receives a greater sequence, so equal timestamps, backward clock
+movement, and lower UUIDs cannot make it fall behind that boundary.
+
+Cursor mode is a live walk, not an MVCC snapshot. Inserts committed before a later page query may
+extend the walk. After a substrate/namespace query returns `next_after: null`, rows committed after
+that terminal query require a new walk from `after=""`. Updates and deletes can change whether an
+unvisited row matches the filters. A cursor that was hard-deleted, is outside the caller's visible
+namespaces, or otherwise cannot be resolved returns an error instead of silently restarting. Cursor
+mode and `offset` are mutually exclusive. Filtered message walks may additionally return
+`scan_incomplete: true` with a continuation cursor when their 10,000-row safety ceiling is reached
+before another matching message is proven.
+
+Row shape (each item in the array or cursor/clamp envelope) depends on `kind`.
 For `kind="entity"`, `"note"`, `"edge"`, and `"event"`, the row is the **full stored record**
 for that substrate, listed below in its **verbose** form (the shape returned with
 `presentation="verbose"`, which is also the default for `kkernel exec` and the `khive` CLI).


### PR DESCRIPTION
Closes #1424.
Closes #1462.

## Summary

- add V13 immutable AUTOINCREMENT sequence ledgers and atomic insert triggers for entity, note, and edge rows; replacement and same-id resurrection retain the original sequence
- extend UUID-backed cursor mode to entity and note `list` while moving edge walks from random-UUID ordering to the durable insertion sequence
- preserve cursor lookup across soft deletion, reject hard-deleted or out-of-scope cursors, and merge edge pages across visible namespaces in global sequence order
- preserve outstanding pre-V13 edge cursors by backfilling existing edges in their prior public UUID order before later inserts append
- expose bounded continuation metadata when filtered message scans reach their 10,000-row safety ceiling
- add storage/runtime contracts, same-microsecond lower-UUID regressions, migration/trigger rollback and immutability coverage, and public documentation

## Compatibility

Offset paging and its existing response shapes remain available. Cursor mode is selected explicitly with `after=""`, rejects an explicit `offset`, and returns substrate-specific `{entities|notes|edges, next_after}` envelopes. The cursor value remains a UUID; storage resolves it to the internal immutable sequence. This is a live insertion-stable walk rather than an MVCC snapshot: inserts committed before a later page can extend the walk, while inserts after a terminal page require a new walk. Event and proposal pagination are unchanged.

## Verification

- `cargo test -p khive-storage -p khive-db -p khive-runtime -p khive-pack-kg --all-features`
- `cargo check -p khive-storage -p khive-db -p khive-runtime -p khive-pack-kg --all-targets --all-features`
- `cargo clippy -p khive-storage -p khive-db -p khive-runtime -p khive-pack-kg --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS=-Dwarnings cargo doc -p khive-storage -p khive-db -p khive-runtime -p khive-pack-kg --all-features --no-deps`
- `cargo fmt --all -- --check`
- `make docs-check`
- `deno fmt --check` on all changed Markdown files
- `sh scripts/lint-sql.sh`
- `sh scripts/lint-adr-refs.sh`
- `sh scripts/lint-adr-refs.sh --self-test`
- `sh scripts/lint-stub-markers.sh`
- `sh scripts/lint-stub-markers.sh --self-test`
- `git diff --check origin/main...HEAD`

> AI-assisted contribution: Codex prepared this change and PR description.
