### PR TITLE
feat(session): complete list filtering coverage

### DIFF
--- a/crates/khive-pack-session/README.md
+++ b/crates/khive-pack-session/README.md
@@ -10,8 +10,10 @@ over the notes substrate (ADR-083).
   persist a session record. `provider_session_id` is the provider-native
   continuity anchor (not a khive UUID); `(provider, provider_session_id)` is
   the strongest grouping key when both are present.
-- `session.list(limit?, offset?, provider?)` — browse stored sessions, newest
-  first. Summaries omit `content`.
+- `session.list(limit?, offset?, provider?, agent_id?, since?)` — browse
+  stored sessions, newest first. `agent_id` matches the legacy
+  `properties.agent_id` field and `since` is an inclusive RFC 3339 creation
+  timestamp. Summaries omit `content`.
 - `session.resume(id)` — fetch one session's full content by full UUID or
   8+ hex short prefix.
 - `session.export(id, format?)` — serialize a session as `json` (default) or
@@ -20,6 +22,7 @@ over the notes substrate (ADR-083).
 ```text
 request(ops="session.store(content=\"...\", provider=\"codex\", provider_session_id=\"abc\")")
 request(ops="session.list(limit=20, provider=\"codex\")")
+request(ops="session.list(agent_id=\"lambda:worker\", since=\"2026-08-01T00:00:00Z\")")
 request(ops="session.resume(id=\"a1b2c3d4\")")
 request(ops="session.export(id=\"a1b2c3d4\", format=\"markdown\")")
 ```

--- a/crates/khive-pack-session/src/handlers/list.rs
+++ b/crates/khive-pack-session/src/handlers/list.rs
@@ -267,7 +267,10 @@ mod tests {
         .await
         .expect("list since");
 
-        assert_eq!(result["sessions"].as_array().expect("sessions array").len(), 0);
+        assert_eq!(
+            result["sessions"].as_array().expect("sessions array").len(),
+            0
+        );
         assert_eq!(result["total"], 0);
     }
 }

--- a/crates/khive-pack-session/src/handlers/list.rs
+++ b/crates/khive-pack-session/src/handlers/list.rs
@@ -12,6 +12,21 @@ use crate::vocab::{DEFAULT_LIMIT, MAX_LIMIT, SESSION_KIND};
 
 const VERB: &str = "session.list";
 
+/// Round a parsed timestamp up to the nearest whole microsecond.
+///
+/// Storage records `created_at` at microsecond precision, but RFC 3339 permits
+/// finer sub-microsecond fractions. Flooring (`timestamp_micros`) would let a
+/// `since` value that falls strictly after a stored microsecond boundary still
+/// match that boundary, silently admitting a session older than the requested
+/// instant. Ceiling instead preserves the documented inclusive lower bound:
+/// the resulting bound equals the boundary exactly when `since` lands on it,
+/// and moves past it otherwise.
+fn ceil_to_micros<Tz: chrono::TimeZone>(value: &DateTime<Tz>) -> i64 {
+    let secs = value.timestamp();
+    let subsec_nanos = i64::from(value.timestamp_subsec_nanos());
+    secs * 1_000_000 + (subsec_nanos + 999) / 1000
+}
+
 pub(crate) async fn handle_list(
     runtime: &KhiveRuntime,
     token: &NamespaceToken,
@@ -51,7 +66,7 @@ pub(crate) async fn handle_list(
     let min_created_at = p
         .since
         .as_deref()
-        .map(|raw| DateTime::parse_from_rfc3339(raw).map(|value| value.timestamp_micros()))
+        .map(|raw| DateTime::parse_from_rfc3339(raw).map(|value| ceil_to_micros(&value)))
         .transpose()
         .map_err(|_| {
             RuntimeError::InvalidInput(format!(
@@ -92,6 +107,7 @@ pub(crate) async fn handle_list(
 
 #[cfg(test)]
 mod tests {
+    use chrono::DateTime;
     use khive_runtime::{KhiveRuntime, Namespace};
     use serde_json::json;
 
@@ -209,5 +225,49 @@ mod tests {
         };
         assert!(msg.contains("since must be an RFC 3339 timestamp"));
         assert!(msg.contains("yesterday"));
+    }
+
+    #[test]
+    fn ceil_to_micros_preserves_exact_microsecond_boundary() {
+        let value = DateTime::parse_from_rfc3339("2026-01-01T00:00:00.123456Z").unwrap();
+        assert_eq!(super::ceil_to_micros(&value), 1_767_225_600_123_456);
+    }
+
+    #[test]
+    fn ceil_to_micros_rounds_up_sub_microsecond_fraction() {
+        let value = DateTime::parse_from_rfc3339("2026-01-01T00:00:00.1234561Z").unwrap();
+        assert_eq!(super::ceil_to_micros(&value), 1_767_225_600_123_457);
+    }
+
+    #[tokio::test]
+    async fn since_excludes_session_floored_to_an_earlier_microsecond() {
+        use khive_storage::note::Note;
+
+        let rt = KhiveRuntime::memory().expect("in-memory runtime");
+        let token = rt.authorize(Namespace::local()).expect("authorize local");
+
+        let created_at_micros: i64 = 1_767_225_600_123_456; // 2026-01-01T00:00:00.123456Z
+        let mut note = Note::new("local", "session", "boundary session");
+        note.created_at = created_at_micros;
+        note.updated_at = created_at_micros;
+        rt.core()
+            .notes(&token)
+            .expect("notes store")
+            .upsert_note(note)
+            .await
+            .expect("insert boundary session");
+
+        // One tenth of a microsecond after the stored session: floors to the
+        // same microsecond, but is strictly later, so it must exclude it.
+        let result = handle_list(
+            &rt,
+            &token,
+            json!({ "since": "2026-01-01T00:00:00.1234561Z" }),
+        )
+        .await
+        .expect("list since");
+
+        assert_eq!(result["sessions"].as_array().expect("sessions array").len(), 0);
+        assert_eq!(result["total"], 0);
     }
 }

--- a/crates/khive-pack-session/src/handlers/list.rs
+++ b/crates/khive-pack-session/src/handlers/list.rs
@@ -1,5 +1,6 @@
 //! `session.list` - list stored sessions, newest first.
 
+use chrono::DateTime;
 use serde_json::Value;
 
 use khive_runtime::{KhiveRuntime, NamespaceToken, RuntimeError};
@@ -18,6 +19,7 @@ pub(crate) async fn handle_list(
 ) -> Result<Value, RuntimeError> {
     let p: ListParams = deser(params)?;
     require_non_empty_if_present(&p.provider, "provider", VERB)?;
+    require_non_empty_if_present(&p.agent_id, "agent_id", VERB)?;
 
     let limit = match p.limit {
         None => DEFAULT_LIMIT,
@@ -38,11 +40,31 @@ pub(crate) async fn handle_list(
             value: SqlValue::Text(provider.clone()),
         });
     }
+    if let Some(agent_id) = &p.agent_id {
+        property_filters.push(PropertyFilter {
+            json_path: "$.agent_id".to_string(),
+            op: FilterOp::Eq,
+            value: SqlValue::Text(agent_id.clone()),
+        });
+    }
+
+    let min_created_at = p
+        .since
+        .as_deref()
+        .map(|raw| DateTime::parse_from_rfc3339(raw).map(|value| value.timestamp_micros()))
+        .transpose()
+        .map_err(|_| {
+            RuntimeError::InvalidInput(format!(
+                "{VERB}: since must be an RFC 3339 timestamp; valid example: \
+                 2026-01-01T00:00:00Z; got {:?}",
+                p.since.as_deref().unwrap_or_default()
+            ))
+        })?;
 
     let filter = NoteFilter {
         kind: Some(SESSION_KIND.to_string()),
         property_filters,
-        min_created_at: None,
+        min_created_at,
         ..Default::default()
     };
 
@@ -153,5 +175,39 @@ mod tests {
             msg.contains("provider must be a non-empty string when provided"),
             "error must name the blank-provider violation; got: {msg}",
         );
+    }
+
+    #[tokio::test]
+    async fn blank_agent_id_rejected() {
+        let rt = KhiveRuntime::memory().expect("in-memory runtime");
+        let token = rt.authorize(Namespace::local()).expect("authorize local");
+
+        let err = handle_list(&rt, &token, json!({ "agent_id": "  " }))
+            .await
+            .unwrap_err();
+
+        let khive_runtime::RuntimeError::InvalidInput(msg) = err else {
+            panic!("expected InvalidInput, got {err:?}");
+        };
+        assert!(
+            msg.contains("agent_id must be a non-empty string when provided"),
+            "error must name the blank-agent-id violation; got: {msg}",
+        );
+    }
+
+    #[tokio::test]
+    async fn invalid_since_rejected() {
+        let rt = KhiveRuntime::memory().expect("in-memory runtime");
+        let token = rt.authorize(Namespace::local()).expect("authorize local");
+
+        let err = handle_list(&rt, &token, json!({ "since": "yesterday" }))
+            .await
+            .unwrap_err();
+
+        let khive_runtime::RuntimeError::InvalidInput(msg) = err else {
+            panic!("expected InvalidInput, got {err:?}");
+        };
+        assert!(msg.contains("since must be an RFC 3339 timestamp"));
+        assert!(msg.contains("yesterday"));
     }
 }

--- a/crates/khive-pack-session/src/handlers/mod.rs
+++ b/crates/khive-pack-session/src/handlers/mod.rs
@@ -222,6 +222,10 @@ pub(crate) struct ListParams {
     pub offset: Option<u32>,
     #[serde(default)]
     pub provider: Option<String>,
+    #[serde(default)]
+    pub agent_id: Option<String>,
+    #[serde(default)]
+    pub since: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]

--- a/crates/khive-pack-session/src/vocab.rs
+++ b/crates/khive-pack-session/src/vocab.rs
@@ -114,6 +114,18 @@ pub(crate) static SESSION_HANDLERS: [HandlerDef; 4] = [
                 required: false,
                 description: "Exact filter on properties.provider.",
             },
+            ParamDef {
+                name: "agent_id",
+                param_type: "string",
+                required: false,
+                description: "Exact filter on properties.agent_id.",
+            },
+            ParamDef {
+                name: "since",
+                param_type: "string",
+                required: false,
+                description: "RFC 3339 lower bound on note.created_at (inclusive).",
+            },
         ],
     },
     HandlerDef {

--- a/crates/khive-pack-session/tests/integration.rs
+++ b/crates/khive-pack-session/tests/integration.rs
@@ -10,7 +10,7 @@ use std::sync::Arc;
 use khive_pack_kg::KgPack;
 use khive_pack_session::SessionPack;
 use khive_runtime::{
-    AllowAllGate, BackendId, KhiveRuntime, Namespace, RuntimeConfig, VerbRegistry,
+    AllowAllGate, BackendId, KhiveRuntime, Namespace, RuntimeConfig, RuntimeError, VerbRegistry,
     VerbRegistryBuilder,
 };
 use serde_json::{json, Value};
@@ -266,6 +266,58 @@ async fn list_filter_by_unknown_provider_returns_empty() {
 }
 
 #[tokio::test]
+async fn list_filters_by_agent_id_in_storage() {
+    let dir = TempDir::new().expect("tempdir");
+    let rt = file_rt(dir.path().join("list_agent_id.db"));
+    let registry = build_registry(rt);
+
+    for (content, agent_id) in [("alpha", "lambda:alpha"), ("beta", "lambda:beta")] {
+        registry
+            .dispatch(
+                "create",
+                json!({
+                    "kind": "session",
+                    "content": content,
+                    "properties": {"agent_id": agent_id}
+                }),
+            )
+            .await
+            .expect("create attributed session note");
+    }
+
+    let result = registry
+        .dispatch("session.list", json!({"agent_id": "lambda:alpha"}))
+        .await
+        .expect("list by agent_id");
+    let sessions = result["sessions"].as_array().expect("sessions array");
+    assert_eq!(sessions.len(), 1);
+    assert_eq!(result["total"], 1);
+    assert_eq!(sessions[0]["id"].as_str().map(str::len), Some(36));
+}
+
+#[tokio::test]
+async fn list_filters_by_inclusive_since_bound_in_storage() {
+    let dir = TempDir::new().expect("tempdir");
+    let rt = file_rt(dir.path().join("list_since.db"));
+    let registry = build_registry(rt);
+
+    store_session(&registry, "before").await;
+    tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+    let after = store_session(&registry, "after").await;
+    let after_id = after["session"]["id"].as_str().expect("after id");
+    let since = after["session"]["created_at"].as_str().expect("created_at");
+
+    let result = registry
+        .dispatch("session.list", json!({"since": since}))
+        .await
+        .expect("list since");
+    let sessions = result["sessions"].as_array().expect("sessions array");
+    assert_eq!(sessions.len(), 1);
+    assert_eq!(result["total"], 1);
+    assert_eq!(sessions[0]["id"], after_id);
+}
+
+#[tokio::test]
 async fn list_limit_respected() {
     let dir = TempDir::new().expect("tempdir");
     let rt = file_rt(dir.path().join("list_limit.db"));
@@ -438,6 +490,26 @@ async fn resume_rejects_non_session_note() {
     assert!(err.is_err(), "non-session note must be rejected");
 }
 
+#[tokio::test]
+async fn resume_excludes_soft_deleted_session() {
+    let dir = TempDir::new().expect("tempdir");
+    let rt = file_rt(dir.path().join("resume_deleted.db"));
+    let registry = build_registry(rt);
+
+    let stored = store_session(&registry, "deleted resume session").await;
+    let id = stored["session"]["id"].as_str().expect("id").to_string();
+    registry
+        .dispatch("delete", json!({"id": id}))
+        .await
+        .expect("soft delete session");
+
+    let result = registry.dispatch("session.resume", json!({"id": id})).await;
+    assert!(
+        matches!(&result, Err(RuntimeError::NotFound(_))),
+        "resume must report a soft-deleted session as not found: {result:?}"
+    );
+}
+
 // ── session.export tests ──────────────────────────────────────────────────────
 
 #[tokio::test]
@@ -522,6 +594,26 @@ async fn export_rejects_missing_id() {
         .dispatch("session.export", json!({"format": "json"}))
         .await;
     assert!(err.is_err(), "missing required id field must error");
+}
+
+#[tokio::test]
+async fn export_excludes_soft_deleted_session() {
+    let dir = TempDir::new().expect("tempdir");
+    let rt = file_rt(dir.path().join("export_deleted.db"));
+    let registry = build_registry(rt);
+
+    let stored = store_session(&registry, "deleted export session").await;
+    let id = stored["session"]["id"].as_str().expect("id").to_string();
+    registry
+        .dispatch("delete", json!({"id": id}))
+        .await
+        .expect("soft delete session");
+
+    let result = registry.dispatch("session.export", json!({"id": id})).await;
+    assert!(
+        matches!(&result, Err(RuntimeError::NotFound(_))),
+        "export must report a soft-deleted session as not found: {result:?}"
+    );
 }
 
 // ── round-trip regression ────────────────────────────────────────────────────

--- a/crates/khive-pack-session/tests/integration.rs
+++ b/crates/khive-pack-session/tests/integration.rs
@@ -377,6 +377,92 @@ async fn list_offset_pagination() {
     assert_eq!(paged_arr[1]["id"], all_arr[3]["id"]);
 }
 
+#[tokio::test]
+async fn list_filters_before_paginating_sparse_match() {
+    let dir = TempDir::new().expect("tempdir");
+    let rt = file_rt(dir.path().join("list_filter_pagination.db"));
+    let registry = build_registry(rt);
+
+    // A single matching session, buried behind more than one page of newer
+    // nonmatching sessions (sessions list newest-first). An implementation
+    // that fetched an unfiltered page and filtered in memory would miss it.
+    let matching = registry
+        .dispatch(
+            "create",
+            json!({
+                "kind": "session",
+                "content": "matches agent filter",
+                "properties": {"agent_id": "lambda:target"}
+            }),
+        )
+        .await
+        .expect("create matching session");
+    let matching_id = matching["id"].as_str().expect("matching id").to_string();
+    tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+
+    for i in 0..5 {
+        registry
+            .dispatch(
+                "create",
+                json!({
+                    "kind": "session",
+                    "content": format!("noise {i}"),
+                    "properties": {"agent_id": "lambda:other"}
+                }),
+            )
+            .await
+            .expect("create nonmatching session");
+        tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+    }
+
+    let result = registry
+        .dispatch(
+            "session.list",
+            json!({"agent_id": "lambda:target", "limit": 2, "offset": 0}),
+        )
+        .await
+        .expect("filtered and paged list");
+    let sessions = result["sessions"].as_array().expect("sessions array");
+    assert_eq!(
+        sessions.len(),
+        1,
+        "filtering must apply before the page window, not after fetching a page of newer nonmatches"
+    );
+    assert_eq!(sessions[0]["id"], matching_id);
+    assert_eq!(
+        result["total"], 1,
+        "total must reflect the filtered count, not the unfiltered total"
+    );
+
+    // Combined filters: `since` set to the matching session's own timestamp
+    // matches all six sessions (it is the oldest), but adding `agent_id`
+    // must still narrow the result to the one matching session.
+    let matching_created_at = registry
+        .dispatch("session.resume", json!({"id": matching_id}))
+        .await
+        .expect("resume matching session")["session"]["created_at"]
+        .as_str()
+        .expect("created_at present")
+        .to_string();
+
+    let combined = registry
+        .dispatch(
+            "session.list",
+            json!({
+                "agent_id": "lambda:target",
+                "since": matching_created_at,
+                "limit": 2,
+                "offset": 0
+            }),
+        )
+        .await
+        .expect("combined-filter list");
+    let combined_sessions = combined["sessions"].as_array().expect("sessions array");
+    assert_eq!(combined_sessions.len(), 1);
+    assert_eq!(combined_sessions[0]["id"], matching_id);
+    assert_eq!(combined["total"], 1);
+}
+
 // ── session.resume tests ───────────────────────────────────────────────────────
 
 #[tokio::test]

--- a/crates/khive-pack-session/tests/integration.rs
+++ b/crates/khive-pack-session/tests/integration.rs
@@ -463,6 +463,72 @@ async fn list_filters_before_paginating_sparse_match() {
     assert_eq!(combined["total"], 1);
 }
 
+#[tokio::test]
+async fn list_filters_before_paginating_nonzero_offset() {
+    let dir = TempDir::new().expect("tempdir");
+    let rt = file_rt(dir.path().join("list_filter_pagination_offset.db"));
+    let registry = build_registry(rt);
+
+    // Three matching sessions interleaved with newer nonmatching sessions, so
+    // an implementation that pages the raw (unfiltered) row order before
+    // filtering would misalign the offset window against the filtered set.
+    let mut matching_ids = Vec::new();
+    for round in 0..3 {
+        let created = registry
+            .dispatch(
+                "create",
+                json!({
+                    "kind": "session",
+                    "content": format!("matches agent filter {round}"),
+                    "properties": {"agent_id": "lambda:target"}
+                }),
+            )
+            .await
+            .expect("create matching session");
+        matching_ids.push(created["id"].as_str().expect("matching id").to_string());
+        tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+
+        for i in 0..2 {
+            registry
+                .dispatch(
+                    "create",
+                    json!({
+                        "kind": "session",
+                        "content": format!("noise {round}-{i}"),
+                        "properties": {"agent_id": "lambda:other"}
+                    }),
+                )
+                .await
+                .expect("create nonmatching session");
+            tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+        }
+    }
+
+    // Filtered, newest-first order is [match2, match1, match0]; offset=1
+    // with limit=1 must land on match1, the second matching record.
+    let result = registry
+        .dispatch(
+            "session.list",
+            json!({"agent_id": "lambda:target", "limit": 1, "offset": 1}),
+        )
+        .await
+        .expect("filtered and paged list");
+    let sessions = result["sessions"].as_array().expect("sessions array");
+    assert_eq!(
+        sessions.len(),
+        1,
+        "expected exactly one session in the requested page"
+    );
+    assert_eq!(
+        sessions[0]["id"], matching_ids[1],
+        "offset must apply to the filtered set, not an unfiltered pre-filter page"
+    );
+    assert_eq!(
+        result["total"], 3,
+        "total must reflect the filtered count across all three matches"
+    );
+}
+
 // ── session.resume tests ───────────────────────────────────────────────────────
 
 #[tokio::test]

--- a/docs/adr/ADR-080-session-pack-oss-storage-mechanism.md
+++ b/docs/adr/ADR-080-session-pack-oss-storage-mechanism.md
@@ -117,7 +117,8 @@ live declaration has:
 - four `Visibility::Verb` handlers: `session.store`, `session.list`,
   `session.resume`, and `session.export`;
 - `session.store(content, title?, provider?, provider_session_id?, tags?)`;
-- `session.list(limit?, offset?, provider?)`;
+- `session.list(limit?, offset?, provider?, agent_id?, since?)` (ADR-083
+  Amendment 1 adds the two server-side filters without changing `session.store`);
 - `session.resume(id)` by full UUID or an 8+ hex prefix; and
 - `session.export(id, format?)`, where `format` is `json` or `markdown`.
 

--- a/docs/adr/ADR-083-session-pack-t1-verbs.md
+++ b/docs/adr/ADR-083-session-pack-t1-verbs.md
@@ -41,6 +41,18 @@ fixes a code citation (§4).
 
 ## Decision
 
+### Amendment 1 (2026-08-01): complete the list filter contract
+
+Issue #1493 establishes the concrete query need anticipated below: callers
+must be able to page a sparse subset without first loading an unbounded result
+set. `session.list` therefore adds two optional, server-side filters:
+`agent_id`, an exact match on legacy `properties.agent_id`, and `since`, an
+inclusive RFC 3339 lower bound on `notes.created_at`. Both feed the existing
+`query_notes_filtered` storage request before `offset` and `limit` are applied.
+This amendment does not restore `agent_id` or open-ended `metadata` to
+`session.store`; it only makes existing property-bearing session notes
+queryable. No response shape or other verb changes.
+
 ### 1. ADR-080 §3's shipped-surface record is superseded for T1
 
 This accepted ADR supersedes ADR-080 §3's intervening shipped-surface record
@@ -109,15 +121,18 @@ Return shape:
 
 #### `session.list`
 
-| Parameter  | Type    | Required | Description                            |
-| ---------- | ------- | -------- | -------------------------------------- |
-| `limit`    | integer | no       | Page size, 1 through 200, default 20.  |
-| `offset`   | integer | no       | Pagination offset, default 0.          |
-| `provider` | string  | no       | Exact filter on `properties.provider`. |
+| Parameter  | Type    | Required | Description                                           |
+| ---------- | ------- | -------- | ----------------------------------------------------- |
+| `limit`    | integer | no       | Page size, 1 through 200, default 20.                 |
+| `offset`   | integer | no       | Pagination offset, default 0.                         |
+| `provider` | string  | no       | Exact filter on `properties.provider`.                |
+| `agent_id` | string  | no       | Exact filter on legacy `properties.agent_id`.         |
+| `since`    | string  | no       | Inclusive RFC 3339 lower bound on `notes.created_at`. |
 
 List summaries omit `content`; `SessionSummary` carries no `content` field.
 
-Errors: a present-but-empty `provider` is rejected the same way as `session.store`. A `limit` outside
+Errors: a present-but-empty `provider` or `agent_id` is rejected. An invalid
+`since` is rejected with the required RFC 3339 format. A `limit` outside
 `1..=200` is rejected (`session.list: limit must be in 1..=200; valid values: integers 1 through
 200; got {limit}`).
 
@@ -275,7 +290,9 @@ service, and the `session_messages` table. These are shipped today (§5).
   `provider` and `provider_session_id` name the actual continuity anchor T1 needs: which external
   system, and which session in that system. `metadata` (an open-ended object) and `since` (a
   list-time filter) are dropped from the T1 parameter surface; filtering by time can be added later
-  without a breaking change if a real query need appears.
+  without a breaking change if a real query need appears. Amendment 1 records that later query need
+  and restores `agent_id` and `since` only as additive `session.list` filters; the T1 store contract
+  remains unchanged.
 - **Why not fold this into ADR-080.** ADR-080 already carries three same-day amendments (Context,
   §3, §6). A verb-visibility, verb-count, and parameter-vocabulary change is a public-contract
   decision, not a storage-mechanism refinement, which is what ADR-080 is about. A separate ADR that
@@ -330,8 +347,9 @@ repeated here. Alternatives specific to this ADR's verb-surface decision:
 The implementation's integration suite (`crates/khive-pack-session/tests/integration.rs`) covers, by scenario:
 store-to-resume content equality, list visibility (summaries omit `content`), export as JSON, export
 as markdown, UUID short-prefix resolution, provider filtering, invalid-`format` errors listing valid
-values, invalid-`limit` range errors, and rejection of a non-session UUID. All nine scenarios are
-present and passing as of the recorded implementation commit `28215e07`.
+values, invalid-`limit` range errors, and rejection of a non-session UUID. Amendment 1 adds
+server-side `agent_id` and `since` filtering, an exact offset window, and explicit resume/export
+regressions for soft-deleted sessions.
 
 ## References
 

--- a/docs/guide/api-reference.md
+++ b/docs/guide/api-reference.md
@@ -1552,11 +1552,13 @@ request(ops="session.store(content=\"...\", provider=\"claude_code\", title=\"pa
 
 List stored sessions newest first.
 
-| Param      | Type    | Required | Notes                                  |
-| ---------- | ------- | -------- | -------------------------------------- |
-| `limit`    | integer | no       | 1–200, default 20.                     |
-| `offset`   | integer | no       | Default 0.                             |
-| `provider` | string  | no       | Exact filter on `properties.provider`. |
+| Param      | Type    | Required | Notes                                               |
+| ---------- | ------- | -------- | --------------------------------------------------- |
+| `limit`    | integer | no       | 1–200, default 20.                                  |
+| `offset`   | integer | no       | Default 0.                                          |
+| `provider` | string  | no       | Exact filter on `properties.provider`.              |
+| `agent_id` | string  | no       | Exact filter on legacy `properties.agent_id`.       |
+| `since`    | string  | no       | Inclusive RFC 3339 lower bound on session creation. |
 
 ```
 request(ops="session.list(provider=\"claude_code\", limit=10)")

--- a/docs/guide/sessions-and-ingest.md
+++ b/docs/guide/sessions-and-ingest.md
@@ -43,18 +43,24 @@ field.
 
 ### List
 
-| Param      | Type    | Required | Notes                                        |
-| ---------- | ------- | -------- | -------------------------------------------- |
-| `limit`    | integer | no       | 1 to 200; default 20.                        |
-| `offset`   | integer | no       | Default 0.                                   |
-| `provider` | string  | no       | Exact match filter on `properties.provider`. |
+| Param      | Type    | Required | Notes                                            |
+| ---------- | ------- | -------- | ------------------------------------------------ |
+| `limit`    | integer | no       | 1 to 200; default 20.                            |
+| `offset`   | integer | no       | Default 0.                                       |
+| `provider` | string  | no       | Exact match filter on `properties.provider`.     |
+| `agent_id` | string  | no       | Exact match on the legacy `properties.agent_id`. |
+| `since`    | string  | no       | Inclusive RFC 3339 lower bound on `created_at`.  |
 
 ```
 request(ops="session.list(provider=\"codex\", limit=10)")
 ```
 
 Results are ordered newest first and returned as summaries (no `content`
-field) with a `total` count when the underlying store can supply one.
+field) with a `total` count when the underlying store can supply one. All
+filters and pagination are applied by the note store, so a sparse match is not
+lost behind an in-memory overfetch window. `agent_id` is a compatibility query
+for records that already carry that property; it does not add an `agent_id`
+parameter to `session.store`.
 
 ### Resume
 


### PR DESCRIPTION
Closes #1493.

## Summary

- add server-side `agent_id` and RFC 3339 `since` filters to `session.list`
- apply both filters before the existing offset/limit window while retaining the filtered total
- pin offset pagination and soft-delete exclusion for `session.resume` and `session.export` with regression tests
- reconcile the accepted ADRs and public session documentation with the additive wire contract

## Behavior

`agent_id` performs an exact match against the existing session-note `properties.agent_id`; this is a list-only compatibility query and does not change `session.store`. `since` is an inclusive lower bound on `created_at` and rejects malformed timestamps. Blank `agent_id` values are also rejected instead of silently widening the query.

Both predicates are passed to `query_notes_filtered`, so filtering happens before pagination and does not depend on bounded overfetching or in-memory post-processing. Existing response and pagination shapes are unchanged.

## Verification

- `cargo test -p khive-pack-session --all-features` (78 unit, 27 integration, and doc tests)
- `cargo check -p khive-pack-session --all-targets --all-features`
- `cargo clippy -p khive-pack-session --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS='-D warnings' cargo doc -p khive-pack-session --all-features --no-deps`
- `cargo fmt --all -- --check`
- `make docs-check`
- `scripts/lint-sql.sh`
- `scripts/lint-adr-refs.sh` and `scripts/lint-adr-refs.sh --self-test`
- `scripts/lint-stub-markers.sh` and `scripts/lint-stub-markers.sh --self-test`
- `bash scripts/check-json-data.sh`
- `git diff --check`

Verified at exact commit `88456cb4ff1fc22674d7f55bc8df0025fc45a77f` against `main` at `e94aa75afd2392584ba54b2f3e62194836f6f959`.

> AI-assisted contribution: Codex prepared this change and PR description.
