### PR TITLE
test(query): cover pack note kinds in GQL

### DIFF
--- a/crates/khive-pack-comm/tests/integration.rs
+++ b/crates/khive-pack-comm/tests/integration.rs
@@ -12,6 +12,7 @@ use khive_runtime::{
     AllowAllGate, BackendId, KhiveRuntime, Namespace, NamespaceToken, RuntimeConfig, VerbRegistry,
     VerbRegistryBuilder,
 };
+use khive_storage::types::{SqlRow, SqlValue};
 use khive_types::Pack;
 
 fn build_registry() -> (VerbRegistry, KhiveRuntime) {
@@ -37,6 +38,62 @@ fn build_registry_for_ns(ns: &str) -> (VerbRegistry, KhiveRuntime) {
 #[test]
 fn comm_pack_declares_message_note_kind() {
     assert!(CommPack::NOTE_KINDS.contains(&"message"));
+}
+
+#[tokio::test]
+async fn pack_registered_message_notes_are_queryable_through_gql() {
+    let (registry, rt) = build_registry_for_ns("local");
+    assert!(
+        registry.all_note_kinds().contains(&"message"),
+        "the built registry must expose comm's message note kind"
+    );
+
+    registry
+        .dispatch(
+            "comm.send",
+            serde_json::json!({
+                "to": "local",
+                "content": "GQL pack-note regression"
+            }),
+        )
+        .await
+        .expect("self-send creates message notes");
+
+    let token = rt.authorize(Namespace::local()).expect("local token");
+    let by_granular_label = rt
+        .query(&token, "MATCH (m:message) RETURN m.id")
+        .await
+        .expect("pack-registered granular label compiles and executes");
+    let by_note_kind = rt
+        .query(
+            &token,
+            "MATCH (m:note) WHERE m.kind = 'message' RETURN m.id",
+        )
+        .await
+        .expect("note substrate plus kind predicate compiles and executes");
+
+    fn ids(rows: &[SqlRow]) -> Vec<String> {
+        let mut ids: Vec<String> = rows
+            .iter()
+            .map(|row| match row.get("m_id") {
+                Some(SqlValue::Text(id)) => id.clone(),
+                value => panic!("GQL m.id projection must be text; got {value:?}"),
+            })
+            .collect();
+        ids.sort();
+        ids
+    }
+
+    let granular_ids = ids(&by_granular_label);
+    assert!(
+        !granular_ids.is_empty(),
+        "MATCH (m:message) must return the message rows just written"
+    );
+    assert_eq!(
+        granular_ids,
+        ids(&by_note_kind),
+        "granular and substrate-plus-kind spellings must select the same message notes"
+    );
 }
 
 #[test]

--- a/crates/khive-query/docs/api/sql-compilation.md
+++ b/crates/khive-query/docs/api/sql-compilation.md
@@ -26,7 +26,14 @@ All scope values, relation filters, property values, depths, and limits are boun
 
 Inline property equality continues to map arbitrary keys through `json_extract`. In `WHERE`, dedicated fields such as `name` or `content` map directly to columns, while only explicit `properties.<path>` references map to `json_extract(alias.properties, '$.path')`. Unknown direct fields and the bare `properties` container are rejected; the same resolver is used by fixed- and variable-length compilation. Event predicates require a known event column, and edge predicates accept only `relation` and `weight`; neither accepts JSON-property paths. `entity_type` always uses its dedicated column. For `LIKE`-family operations, literal `%`, `_`, and `\` are escaped before compiler-supplied wildcards are added.
 
-Node kind labels `entity`, `note`, `event`, and `edge` select a substrate in the primary-node union; granular values such as `concept` or `task` filter the stored `kind`. No stored row is expected to have the literal granular kind `entity` (issue #849).
+Node kind labels `entity`, `note`, `event`, and `edge` select a substrate in the primary-node union; granular values such as `concept`, `task`, or comm's pack-registered `message` filter the stored `kind`. No stored row is expected to have the literal granular kind `entity` (issue #849).
+
+Granular kind filtering is intentionally data-driven. The compiler has no `VerbRegistry`
+dependency and does not keep a second allowlist of pack-owned kinds: registration validates the
+write, while GQL binds the stored kind as a SQL parameter. `MATCH (m:message)` and
+`MATCH (m:note) WHERE m.kind = "message"` therefore select the same caller-visible message
+notes. GQL's field is `kind`; `note_kind` is terminology from the verb parameter surface and is
+not a query field. Runtime-supplied namespace scopes still apply to every union member.
 
 ## Fixed-length JOIN compilation
 

--- a/docs/adr/ADR-008-query-layer-separation.md
+++ b/docs/adr/ADR-008-query-layer-separation.md
@@ -97,6 +97,23 @@ remains in `khive-runtime` (ADR-001, ADR-003). Query-time filtering by an unknow
 `entity_type` simply returns no rows unless the runtime normalizes the query before
 compilation.
 
+Granular node kinds follow the same read-time boundary. `khive-query` does not receive the
+`VerbRegistry` and must not copy its pack-owned note-kind or entity-kind vocabulary. A granular
+label such as `MATCH (m:message)` is compiled as a bound comparison against the shared `kind`
+column; a substrate label such as `note` is compiled against the union's `substrate_kind`
+discriminator. Consequently these GQL forms are equivalent for caller-visible comm rows:
+
+```text
+MATCH (m:message) RETURN m.id
+MATCH (m:note) WHERE m.kind = "message" RETURN m.id
+```
+
+Registration remains authoritative on the write path: comm registers `message`, the runtime
+admits message notes into the shared `notes` table, and the query compiler can then match the
+stored value without a registry dependency. `note_kind` is a verb-parameter name, not a GQL
+field; GQL uses `kind`. Namespace visibility is still injected by `CompileOptions`, so a query
+does not reveal message copies outside the caller's authorized scopes.
+
 ### Relation validation
 
 `khive-query` validates relation names by delegating to `EdgeRelation::from_str` from

--- a/docs/guide/query-cookbook.md
+++ b/docs/guide/query-cookbook.md
@@ -50,6 +50,7 @@ live read-only checks against a production knowledge graph.
 | Bounded lineage           | What is reachable by one to three `extends` hops?                   | YES via query                | `MATCH (a)-[:extends*1..3]->(b) RETURN a.name, b.name LIMIT 100`                                                                                                 |
 | General expansion         | Expand this known entity two hops with context.                     | YES via `traverse`/`context` | `traverse(roots=["<uuid>"], max_depth=2)`, or `context(entity_ids=["<uuid>"], hops=2, budget=N)`.                                                                |
 | Cross-substrate join      | Which notes annotate concepts, documents, or other notes?           | YES via query                | `MATCH (note:note)-[e:annotates]->(target) RETURN note.name, target.kind, target.name LIMIT 100`                                                                 |
+| Pack-note inventory       | Which caller-visible comm messages exist?                           | YES via query                | `MATCH (m:message) RETURN m.id, m.kind LIMIT 100`; equivalently, use `MATCH (m:note) WHERE m.kind = "message" RETURN m.id, m.kind LIMIT 100`.                    |
 | Kind/type filtering       | Which records use a given entity type?                              | YES via query                | `MATCH (n) WHERE n.entity_type IS NOT NULL RETURN n.entity_type, n.name LIMIT 100`                                                                               |
 | Property filtering        | Which names contain a token, or belong to a set of kinds?           | YES via query                | `WHERE n.name CONTAINS "<text>"`, `STARTS WITH`, or `n.kind IN ["concept", "project"]`.                                                                          |
 | Edge-weight filter        | Which `extends` edges have weight at least 0.8?                     | YES via query                | `MATCH (a)-[e:extends]->(b) WHERE e.weight >= 0.8 RETURN a.name, e.weight, b.name LIMIT 100`                                                                     |
@@ -93,6 +94,11 @@ MATCH (a)-[e:extends|implements]->(b) RETURN a.name, e.relation, b.name LIMIT 10
   its supported substrate columns. Variable-length paths add `_depth` and
   `_total_weight` (a running sum of edge weights along the path, not an
   average).
+- Pack-registered note kinds use the same GQL `kind` field as base kinds. A granular label
+  such as `:message` is shorthand for the stored kind; `:note` selects the note substrate and
+  can be combined with `WHERE m.kind = "message"`. `note_kind` belongs to the verb parameter
+  surface and is not a GQL field. Both forms remain restricted to the caller's authorized
+  namespace scopes.
 - SPARQL variables project as whole nodes (full column expansion), unlike
   GQL's dotted per-field projection.
 


### PR DESCRIPTION
Closes #1470.

## Summary

- prove that pack-registered granular note kinds are queryable directly as GQL labels
- add a real CommPack round-trip asserting `MATCH (m:message)` and `MATCH (m:note) WHERE m.kind = 'message'` return the same message id
- document the shared stored `kind` discriminator, the write-side `note_kind` parameter, namespace filtering, and pack-registration boundary

## Behavior

No production query special case is required: GQL label compilation already targets the substrate's shared `kind` column, so a registered CommPack `message` note is visible through either the granular label or the generic note label plus a kind predicate. Pack registration validates writes; query compilation remains data-driven and does not need the pack registry.

The integration test builds the real CommPack registry, sends a message, runs both query spellings through the runtime, and compares the exact non-empty id sets. The documentation now makes the `kind`/`note_kind` distinction and namespace visibility explicit.

## Verification

- `cargo test -p khive-pack-comm --all-features` (60 unit, 159 integration, 25 probe, and doc tests)
- `cargo test -p khive-query --all-features` (163 library, 91 compile-integration, 8 relation-matrix, and doc tests)
- `cargo check -p khive-query -p khive-pack-comm --all-targets --all-features`
- `cargo clippy -p khive-query -p khive-pack-comm --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS='-D warnings' cargo doc -p khive-query -p khive-pack-comm --all-features --no-deps`
- `cargo fmt --all -- --check`
- `make docs-check` and targeted Deno formatting for all changed Markdown files
- SQL, ADR-reference, and stub-marker validators, including lint self-tests
- `git diff --check`

Verified at exact commit `a16f4d3da528ce0085cb47624e4850f181b2ba93` against `main` at `6029eaf37546e7a495a2ba1fa70ad0927a1f819b`.

> AI-assisted contribution: Codex prepared this change and PR description.
