### PR TITLE
fix(runtime): report actual embedding truncation

### DIFF
--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -2231,6 +2231,7 @@ dependencies = [
  "khive-runtime",
  "khive-storage",
  "khive-types",
+ "lattice-embed",
  "serde",
  "serde_json",
  "tokio",

--- a/crates/khive-pack-comm/src/handlers.rs
+++ b/crates/khive-pack-comm/src/handlers.rs
@@ -20,6 +20,21 @@ use crate::params::{
     ProbeParams, ReadParams, ReplyParams, SendParams, ThreadParams, UnreadParams,
 };
 
+fn add_embedding_truncation_warning(
+    response: &mut Value,
+    report: &khive_runtime::retrieval::EmbeddingTruncationReport,
+) {
+    if !report.any_truncated() {
+        return;
+    }
+    if let Some(object) = response.as_object_mut() {
+        object.insert(
+            "warnings".to_string(),
+            json!([khive_runtime::retrieval::EMBEDDING_INPUT_TRUNCATED_WARNING]),
+        );
+    }
+}
+
 /// Validate an actor label: non-empty, no control characters, ≤255 bytes (ADR-057 Q1 loose).
 fn validate_actor_label(verb: &str, label: &str, field: &str) -> Result<(), RuntimeError> {
     if label.trim().is_empty() {
@@ -113,7 +128,7 @@ pub(crate) async fn handle_send(
     // Pass caller_ns as both `from` and `to` so `from == recipient_ns_str` in
     // dual_write_message, naturally bypassing the cross-namespace allowlist gate
     // (ADR-057 §"Interaction with ADR-040"). Actor labels are stored via from_actor/to_actor.
-    let outbound_note = dual_write_message(
+    let (outbound_note, embedding_truncation) = dual_write_message(
         runtime,
         token,
         &caller_ns,
@@ -130,14 +145,16 @@ pub(crate) async fn handle_send(
     )
     .await?;
 
-    Ok(json!({
+    let mut response = json!({
         "id": short_id(outbound_note.id),
         "full_id": outbound_note.id.as_hyphenated().to_string(),
         "from": from_actor,
         "to": p.to,
         "subject": p.subject,
         "sent_at": sent_at,
-    }))
+    });
+    add_embedding_truncation_warning(&mut response, &embedding_truncation);
+    Ok(response)
 }
 
 /// `inbox` — list inbound messages for the caller's actor label (ADR-057).
@@ -669,7 +686,7 @@ pub(crate) async fn handle_reply(
     // Pass caller_ns as both `from` and `to` so `from == recipient_ns_str` in
     // dual_write_message, naturally bypassing the cross-namespace allowlist gate
     // (ADR-057 §"Interaction with ADR-040"). Actor labels are stored via from_actor/to_actor.
-    let reply_note = dual_write_message(
+    let (reply_note, embedding_truncation) = dual_write_message(
         runtime,
         token,
         &caller_ns,
@@ -734,7 +751,7 @@ pub(crate) async fn handle_reply(
         )
     };
 
-    Ok(json!({
+    let mut response = json!({
         "id": short_id(reply_note.id),
         "full_id": reply_note.id.as_hyphenated().to_string(),
         "thread_id": thread_id,
@@ -743,7 +760,9 @@ pub(crate) async fn handle_reply(
         "subject": reply_subject,
         "sent_at": sent_at,
         "marked_read": marked_read,
-    }))
+    });
+    add_embedding_truncation_warning(&mut response, &embedding_truncation);
+    Ok(response)
 }
 
 /// `thread` — retrieve all messages in a conversation thread, ordered
@@ -2109,12 +2128,28 @@ fn build_references_header(parent_chain: Option<&str>, parent_message_id: &str) 
 #[cfg(test)]
 mod tests {
     use super::{
-        build_references_header, heartbeat_note_id, message_id_match_candidates,
-        parent_references_chain, parent_wire_message_id, read_response, sanitize_reference_token,
-        wrap_message_id,
+        add_embedding_truncation_warning, build_references_header, heartbeat_note_id,
+        message_id_match_candidates, parent_references_chain, parent_wire_message_id,
+        read_response, sanitize_reference_token, wrap_message_id,
     };
     use khive_storage::StorageError;
     use serde_json::{json, Value};
+
+    #[test]
+    fn comm_write_response_reports_atomic_note_embedding_truncation() {
+        let mut response = json!({"id": "abc123"});
+        add_embedding_truncation_warning(
+            &mut response,
+            &khive_runtime::retrieval::EmbeddingTruncationReport {
+                truncated: 2,
+                discarded_bytes: 18,
+            },
+        );
+        assert_eq!(
+            response["warnings"],
+            json!([khive_runtime::retrieval::EMBEDDING_INPUT_TRUNCATED_WARNING])
+        );
+    }
 
     // #606: a delimiter-joined
     // `format!("...:{a}:{b}:{c}")` id encoding is not injective once

--- a/crates/khive-pack-comm/src/message.rs
+++ b/crates/khive-pack-comm/src/message.rs
@@ -99,15 +99,16 @@ fn build_preview(content: &str) -> String {
 }
 
 /// Writes an outbound copy (caller namespace) and an inbound copy (recipient
-/// namespace) as ONE atomic unit (`khive_runtime::create_notes_atomic`): one
-/// writer transaction covers both notes' rows, FTS documents, and vector
-/// rows. Returns the outbound `Note` on success.
+/// namespace) as ONE atomic unit
+/// (`khive_runtime::create_notes_atomic_with_report`): one writer transaction
+/// covers both notes' rows, FTS documents, and vector rows. Returns the
+/// outbound `Note` and aggregate embedding-truncation report on success.
 ///
 /// Resolved gap (external desk review, 2026-07-21; closed by construction
 /// here): the two note writes used to be separate `create_note` calls with
 /// only an in-process rollback compensating an inbound-write failure, so a
 /// process crash between them could leave a durable orphan outbound note
-/// with no inbound copy. `create_notes_atomic` commits both copies under one
+/// with no inbound copy. `create_notes_atomic_with_report` commits both copies under one
 /// `SqlAccess::atomic_unit` — a crash or failure anywhere in the unit rolls
 /// back everything, so no partial pair can ever be observed durably.
 ///
@@ -139,7 +140,7 @@ pub(crate) async fn dual_write_message(
     in_reply_to_message_id: Option<&str>,
     references_chain: Option<&str>,
     tags: Option<&[String]>,
-) -> Result<Note, RuntimeError> {
+) -> Result<(Note, khive_runtime::retrieval::EmbeddingTruncationReport), RuntimeError> {
     let recipient_ns_str = to.trim();
     if from != recipient_ns_str {
         // When actor labels are provided this is an actor-addressed local send;
@@ -261,7 +262,7 @@ pub(crate) async fn dual_write_message(
         }
     }
 
-    let mut notes = khive_runtime::create_notes_atomic(
+    let (mut notes, embedding_truncation) = khive_runtime::create_notes_atomic_with_report(
         runtime,
         vec![
             khive_runtime::AtomicNoteSpec {
@@ -284,9 +285,9 @@ pub(crate) async fn dual_write_message(
     )
     .await?;
 
-    // create_notes_atomic returns notes in the same order as the specs above:
-    // [outbound, inbound].
-    Ok(notes.remove(0))
+    // create_notes_atomic_with_report returns notes in the same order as the
+    // specs above: [outbound, inbound].
+    Ok((notes.remove(0), embedding_truncation))
 }
 
 #[cfg(test)]
@@ -418,7 +419,7 @@ mod tests {
         let ns = format!("thread-id-canonical-{}", Uuid::new_v4().simple());
         let (runtime, token) = scratch_runtime_and_token(&ns);
 
-        let outbound_note = dual_write_message(
+        let (outbound_note, _) = dual_write_message(
             &runtime,
             &token,
             &ns,

--- a/crates/khive-pack-kg/Cargo.toml
+++ b/crates/khive-pack-kg/Cargo.toml
@@ -34,6 +34,7 @@ serde_json = { workspace = true }
 khive-pack-formal = { version = "0.5.0", path = "../khive-pack-formal" }
 # Path-only: cyclic dev-dep pair with khive-pack-gtd; cargo strips it at publish.
 khive-pack-gtd = { path = "../khive-pack-gtd" }
+lattice-embed = { workspace = true }
 
 [[test]]
 name = "integration"

--- a/crates/khive-pack-kg/src/apply_worker/tests.rs
+++ b/crates/khive-pack-kg/src/apply_worker/tests.rs
@@ -1,8 +1,48 @@
 use super::*;
-use khive_runtime::{KhiveRuntime, Namespace, VerbRegistryBuilder};
+use async_trait::async_trait;
+use khive_runtime::{EmbedderProvider, KhiveRuntime, Namespace, VerbRegistryBuilder};
 use khive_storage::types::{PageRequest, SqlStatement, SqlValue};
 use khive_types::{Id128, NoteDraft, ProposalChangeset, ProposalCreatedPayload};
+use lattice_embed::{EmbedError, EmbeddingModel, EmbeddingService, MAX_TEXT_CHARS};
 use uuid::Uuid;
+
+struct TruncationService;
+
+#[async_trait]
+impl EmbeddingService for TruncationService {
+    async fn embed(
+        &self,
+        texts: &[String],
+        _model: EmbeddingModel,
+    ) -> Result<Vec<Vec<f32>>, EmbedError> {
+        Ok(texts.iter().map(|_| vec![0.5]).collect())
+    }
+
+    fn supports_model(&self, _model: EmbeddingModel) -> bool {
+        true
+    }
+
+    fn name(&self) -> &'static str {
+        "proposal-truncation-test"
+    }
+}
+
+struct TruncationProvider;
+
+#[async_trait]
+impl EmbedderProvider for TruncationProvider {
+    fn name(&self) -> &str {
+        "proposal-truncation-test"
+    }
+
+    fn dimensions(&self) -> usize {
+        1
+    }
+
+    async fn build(&self) -> khive_runtime::RuntimeResult<std::sync::Arc<dyn EmbeddingService>> {
+        Ok(std::sync::Arc::new(TruncationService))
+    }
+}
 
 fn setup() -> (KhiveRuntime, NamespaceToken) {
     let rt = KhiveRuntime::memory().expect("in-memory runtime");
@@ -236,6 +276,46 @@ async fn apply_worker_atomic_update_preserves_explicit_description_clear() {
         .await
         .expect("get updated entity");
     assert_eq!(updated.description, None);
+}
+
+#[tokio::test]
+async fn apply_worker_returns_atomic_update_truncation_report() {
+    let (rt, tok) = setup();
+    rt.register_embedder(TruncationProvider);
+    ensure_schema(&rt).await;
+    let entity = rt
+        .create_entity(
+            &tok,
+            "concept",
+            None,
+            "ProposalTruncation",
+            None,
+            None,
+            vec![],
+        )
+        .await
+        .expect("create entity");
+    let proposal_id = Uuid::new_v4();
+    let changeset = ProposalChangeset::UpdateEntity {
+        id: Id128::from_u128(entity.id.as_u128()),
+        patch: khive_types::ProposalEntityPatch {
+            name: None,
+            description: Some(Some("x".repeat(MAX_TEXT_CHARS + 1))),
+            properties: None,
+            tags: None,
+        },
+    };
+    seed_proposal_created_event(&rt, &tok, proposal_id, changeset).await;
+    insert_projection_row(&rt, &tok, proposal_id, "approved").await;
+
+    let registry = build_registry(&rt);
+    let report = ProposalApplyWorker::new(rt)
+        .maybe_apply_with_report(&tok, proposal_id, &registry, None)
+        .await
+        .expect("apply proposal");
+
+    assert_eq!(report.truncated, 1);
+    assert!(report.discarded_bytes > 0);
 }
 
 #[tokio::test]

--- a/crates/khive-pack-kg/src/apply_worker/worker.rs
+++ b/crates/khive-pack-kg/src/apply_worker/worker.rs
@@ -4,10 +4,11 @@ use uuid::Uuid;
 
 use khive_runtime::{
     atomic_prepare::{
-        apply_post_commit_effects, prepare_add_entity, prepare_add_note, prepare_op,
+        apply_post_commit_effects_with_report, prepare_add_entity, prepare_add_note, prepare_op,
         prepare_update_entity_plan,
     },
     curation::{ContentMergeStrategy, EntityDedupMergePolicy, EntityPatch},
+    retrieval::EmbeddingTruncationReport,
     AtomicOpPlan, AtomicRunOutcome, EdgeListFilter, KhiveRuntime, NamespaceToken, RuntimeError,
     VerbRegistry,
 };
@@ -65,13 +66,27 @@ impl ProposalApplyWorker {
         registry: &VerbRegistry,
         max_new_entries: Option<u64>,
     ) -> Result<(), RuntimeError> {
+        self.maybe_apply_with_report(token, proposal_id, registry, max_new_entries)
+            .await
+            .map(|_| ())
+    }
+
+    /// Truncation-reporting form of [`Self::maybe_apply`]. Returns aggregate
+    /// embedding-input truncation observed by a successful apply.
+    pub async fn maybe_apply_with_report(
+        &self,
+        token: &NamespaceToken,
+        proposal_id: Uuid,
+        registry: &VerbRegistry,
+        max_new_entries: Option<u64>,
+    ) -> Result<EmbeddingTruncationReport, RuntimeError> {
         let row = match self.projection.get_proposal_row(token, proposal_id).await? {
             Some(r) => r,
-            None => return Ok(()),
+            None => return Ok(EmbeddingTruncationReport::default()),
         };
 
         if row.status != "approved" || row.reject_count > 0 {
-            return Ok(());
+            return Ok(EmbeddingTruncationReport::default());
         }
 
         let changeset = match self.load_changeset(token, proposal_id).await {
@@ -79,7 +94,7 @@ impl ProposalApplyWorker {
             Err(e) => {
                 self.emit_apply_failed(token, proposal_id, e.to_string(), 0)
                     .await;
-                return Ok(());
+                return Ok(EmbeddingTruncationReport::default());
             }
         };
 
@@ -92,7 +107,7 @@ impl ProposalApplyWorker {
                 0,
             )
             .await;
-            return Ok(());
+            return Ok(EmbeddingTruncationReport::default());
         }
 
         if let Some(max) = max_new_entries {
@@ -109,7 +124,7 @@ impl ProposalApplyWorker {
                     0,
                 )
                 .await;
-                return Ok(());
+                return Ok(EmbeddingTruncationReport::default());
             }
         }
 
@@ -120,7 +135,7 @@ impl ProposalApplyWorker {
                 "ProposalApplyWorker: pre-apply CAS missed — proposal already in \
                  non-approved state (withdrawn or applied concurrently); skipping"
             );
-            return Ok(());
+            return Ok(EmbeddingTruncationReport::default());
         }
 
         let apply_result = self
@@ -132,14 +147,15 @@ impl ProposalApplyWorker {
             )
             .await;
 
-        match apply_result {
-            Ok(created_records) => {
+        let embedding_truncation = match apply_result {
+            Ok((created_records, embedding_truncation)) => {
                 let created_ids: Vec<Id128> = created_records
                     .iter()
                     .map(|id| Id128::from_u128(id.as_u128()))
                     .collect();
                 self.finalize_apply_success(token, proposal_id, created_ids)
                     .await;
+                embedding_truncation
             }
             Err(e) => {
                 self.emit_apply_failed(token, proposal_id, e.to_string(), 0)
@@ -156,10 +172,11 @@ impl ProposalApplyWorker {
                          after failed apply — proposal may be stuck in 'applying'"
                     );
                 }
+                EmbeddingTruncationReport::default()
             }
-        }
+        };
 
-        Ok(())
+        Ok(embedding_truncation)
     }
 
     /// Load the ProposalCreated event payload to get the changeset.
@@ -207,7 +224,7 @@ impl ProposalApplyWorker {
         changeset: &ProposalChangeset,
         registry: &VerbRegistry,
         budget: &mut WriteBudget,
-    ) -> Result<Vec<Uuid>, RuntimeError> {
+    ) -> Result<(Vec<Uuid>, EmbeddingTruncationReport), RuntimeError> {
         match self
             .prepare_changeset(token, changeset, registry, budget)
             .await?
@@ -221,8 +238,19 @@ impl ProposalApplyWorker {
                     .map_err(|error| RuntimeError::Storage(error.0))?;
                 match outcome {
                     AtomicRunOutcome::Committed { post_commit } => {
-                        apply_post_commit_effects(&self.runtime, token, post_commit).await?;
-                        self.resolve_created_records(token, created_records).await
+                        let outcomes = apply_post_commit_effects_with_report(
+                            &self.runtime,
+                            token,
+                            post_commit,
+                        )
+                        .await?;
+                        let mut embedding_truncation = EmbeddingTruncationReport::default();
+                        for outcome in outcomes {
+                            embedding_truncation.merge(outcome.truncation);
+                        }
+                        let created_records =
+                            self.resolve_created_records(token, created_records).await?;
+                        Ok((created_records, embedding_truncation))
                     }
                     AtomicRunOutcome::RolledBack {
                         failed_op_index,
@@ -233,7 +261,8 @@ impl ProposalApplyWorker {
                 }
             }
             PreparedApply::CanonicalMerge { into_id, from_id } => {
-                self.runtime
+                let summary = self
+                    .runtime
                     .merge_entity(
                         token,
                         into_id,
@@ -243,7 +272,7 @@ impl ProposalApplyWorker {
                         false,
                     )
                     .await?;
-                Ok(vec![])
+                Ok((vec![], summary.embedding_truncation))
             }
         }
     }

--- a/crates/khive-pack-kg/src/handlers/create.rs
+++ b/crates/khive-pack-kg/src/handlers/create.rs
@@ -12,6 +12,18 @@ use super::common::{
 };
 use crate::KgPack;
 
+pub(super) fn add_embedding_truncation_warning(response: &mut Value, truncated: bool) {
+    if !truncated {
+        return;
+    }
+    if let Some(obj) = response.as_object_mut() {
+        obj.insert(
+            "warnings".to_string(),
+            json!([khive_runtime::retrieval::EMBEDDING_INPUT_TRUNCATED_WARNING]),
+        );
+    }
+}
+
 impl KgPack {
     pub(crate) async fn handle_create(
         &self,
@@ -305,7 +317,7 @@ impl KgPack {
             None
         };
 
-        let (mut response, new_id) = match p.kind.as_str() {
+        let (mut response, new_id, embedding_input_truncated) = match p.kind.as_str() {
             "entity" => {
                 if p.embedding_content.is_some() {
                     return Err(RuntimeError::InvalidInput(
@@ -322,9 +334,9 @@ impl KgPack {
                 let tags = p.tags.unwrap_or_default();
                 let validated_type =
                     validate_entity_type(&canonical, p.entity_type.as_deref(), registry)?;
-                let entity = self
+                let (entity, embedding_report) = self
                     .runtime
-                    .create_entity(
+                    .create_entity_with_embedding_report(
                         token,
                         &canonical,
                         validated_type.as_deref(),
@@ -335,7 +347,11 @@ impl KgPack {
                     )
                     .await?;
                 let id = entity.id;
-                (normalize_entity_timestamps(to_json(&entity)?), id)
+                (
+                    normalize_entity_timestamps(to_json(&entity)?),
+                    id,
+                    embedding_report.any_truncated(),
+                )
             }
             "note" => {
                 let canonical = sub_kind
@@ -349,9 +365,9 @@ impl KgPack {
                     annotates.push(resolve_uuid_unfiltered(&s, &self.runtime, token).await?);
                 }
                 let properties = super::common::merge_note_tags(p.properties, p.tags)?;
-                let note = self
+                let (note, embedding_report) = self
                     .runtime
-                    .create_note_with_embedding_content(
+                    .create_note_with_embedding_content_and_report(
                         token,
                         &canonical,
                         p.name.as_deref(),
@@ -366,6 +382,7 @@ impl KgPack {
                 (
                     remap_note_status(normalize_entity_timestamps(to_json(&note)?)),
                     id,
+                    embedding_report.any_truncated(),
                 )
             }
             other => {
@@ -374,6 +391,8 @@ impl KgPack {
                 )))
             }
         };
+
+        add_embedding_truncation_warning(&mut response, embedding_input_truncated);
 
         if let Some(ref h) = hook {
             if let Err(e) = h.after_create(&self.runtime, new_id, &params).await {

--- a/crates/khive-pack-kg/src/handlers/merge.rs
+++ b/crates/khive-pack-kg/src/handlers/merge.rs
@@ -85,6 +85,9 @@ impl KgPack {
                 ))
             }
         };
-        to_json(&summary)
+        let truncated = summary.embedding_truncation.any_truncated();
+        let mut response = to_json(&summary)?;
+        super::create::add_embedding_truncation_warning(&mut response, truncated);
+        Ok(response)
     }
 }

--- a/crates/khive-pack-kg/src/handlers/proposal.rs
+++ b/crates/khive-pack-kg/src/handlers/proposal.rs
@@ -321,18 +321,25 @@ impl KgPack {
             )));
         }
 
-        if decision == ProposalDecision::Approve {
+        let embedding_truncation = if decision == ProposalDecision::Approve {
             crate::apply_worker::ProposalApplyWorker::new(self.runtime.clone())
-                .maybe_apply(token, proposal_id, registry, p.max_new_entries)
-                .await?;
-        }
+                .maybe_apply_with_report(token, proposal_id, registry, p.max_new_entries)
+                .await?
+        } else {
+            khive_runtime::retrieval::EmbeddingTruncationReport::default()
+        };
 
-        to_json(&serde_json::json!({
+        let mut response = to_json(&serde_json::json!({
             "id": proposal_id.to_string(),
             "reviewer": actor,
             "decision": p.decision,
             "status": new_status,
-        }))
+        }))?;
+        super::create::add_embedding_truncation_warning(
+            &mut response,
+            embedding_truncation.any_truncated(),
+        );
+        Ok(response)
     }
 
     pub(crate) async fn handle_withdraw(

--- a/crates/khive-pack-kg/src/handlers/tests.rs
+++ b/crates/khive-pack-kg/src/handlers/tests.rs
@@ -1443,6 +1443,224 @@ async fn update_entity_with_note_field_salience_returns_error() {
 
 // ── #764: create's embedding_content wiring ─────────────────────────────────
 
+struct WarningEmbeddingService;
+
+#[async_trait::async_trait]
+impl lattice_embed::EmbeddingService for WarningEmbeddingService {
+    async fn embed(
+        &self,
+        texts: &[String],
+        _model: lattice_embed::EmbeddingModel,
+    ) -> Result<Vec<Vec<f32>>, lattice_embed::EmbedError> {
+        Ok(vec![vec![1.0]; texts.len()])
+    }
+
+    fn supports_model(&self, _model: lattice_embed::EmbeddingModel) -> bool {
+        true
+    }
+
+    fn name(&self) -> &'static str {
+        "warning-test"
+    }
+}
+
+struct WarningEmbedderProvider;
+
+#[async_trait::async_trait]
+impl khive_runtime::EmbedderProvider for WarningEmbedderProvider {
+    fn name(&self) -> &str {
+        "warning-test"
+    }
+
+    fn dimensions(&self) -> usize {
+        1
+    }
+
+    async fn build(
+        &self,
+    ) -> Result<std::sync::Arc<dyn lattice_embed::EmbeddingService>, khive_runtime::RuntimeError>
+    {
+        Ok(std::sync::Arc::new(WarningEmbeddingService))
+    }
+}
+
+struct BarrierEmbeddingService {
+    started: std::sync::Arc<tokio::sync::Notify>,
+    release: std::sync::Arc<tokio::sync::Notify>,
+}
+
+#[async_trait::async_trait]
+impl lattice_embed::EmbeddingService for BarrierEmbeddingService {
+    async fn embed(
+        &self,
+        texts: &[String],
+        _model: lattice_embed::EmbeddingModel,
+    ) -> Result<Vec<Vec<f32>>, lattice_embed::EmbedError> {
+        self.started.notify_one();
+        self.release.notified().await;
+        Ok(vec![vec![1.0]; texts.len()])
+    }
+
+    fn supports_model(&self, _model: lattice_embed::EmbeddingModel) -> bool {
+        true
+    }
+
+    fn name(&self) -> &'static str {
+        "registry-snapshot-barrier"
+    }
+}
+
+struct BarrierEmbedderProvider {
+    started: std::sync::Arc<tokio::sync::Notify>,
+    release: std::sync::Arc<tokio::sync::Notify>,
+}
+
+#[async_trait::async_trait]
+impl khive_runtime::EmbedderProvider for BarrierEmbedderProvider {
+    fn name(&self) -> &str {
+        "registry-snapshot-barrier"
+    }
+
+    fn dimensions(&self) -> usize {
+        1
+    }
+
+    async fn build(
+        &self,
+    ) -> Result<std::sync::Arc<dyn lattice_embed::EmbeddingService>, khive_runtime::RuntimeError>
+    {
+        Ok(std::sync::Arc::new(BarrierEmbeddingService {
+            started: std::sync::Arc::clone(&self.started),
+            release: std::sync::Arc::clone(&self.release),
+        }))
+    }
+}
+
+struct LateShortBudgetProvider;
+
+#[async_trait::async_trait]
+impl khive_runtime::EmbedderProvider for LateShortBudgetProvider {
+    fn name(&self) -> &str {
+        "multilingual-e5-base"
+    }
+
+    fn dimensions(&self) -> usize {
+        1
+    }
+
+    async fn build(
+        &self,
+    ) -> Result<std::sync::Arc<dyn lattice_embed::EmbeddingService>, khive_runtime::RuntimeError>
+    {
+        Ok(std::sync::Arc::new(WarningEmbeddingService))
+    }
+}
+
+#[tokio::test]
+async fn create_dispatch_emits_embedding_truncation_advisory() {
+    use crate::KgPack;
+    use khive_runtime::{KhiveRuntime, VerbRegistryBuilder};
+
+    let rt = KhiveRuntime::memory().expect("in-memory runtime");
+    rt.register_embedder(WarningEmbedderProvider);
+    let mut builder = VerbRegistryBuilder::new();
+    builder.register(KgPack::new(rt));
+    let registry = builder.build().expect("registry build");
+
+    let truncated = registry
+        .dispatch(
+            "create",
+            json!({
+                "kind": "concept",
+                "name": "warning target",
+                "description": "x".repeat(lattice_embed::MAX_TEXT_CHARS),
+                "skip_dedup_check": true,
+            }),
+        )
+        .await
+        .expect("over-limit create");
+    let warnings = truncated["warnings"].as_array().expect("warnings array");
+    assert_eq!(warnings.len(), 1);
+    assert!(warnings[0].as_str().unwrap().contains("truncated"));
+
+    let updated = registry
+        .dispatch(
+            "update",
+            json!({
+                "kind": "entity",
+                "id": truncated["id"],
+                "description": "y".repeat(lattice_embed::MAX_TEXT_CHARS + 1),
+            }),
+        )
+        .await
+        .expect("over-limit update");
+    assert_eq!(
+        updated["description"].as_str().map(str::len),
+        Some(lattice_embed::MAX_TEXT_CHARS + 1),
+        "the stored and FTS-indexed source remains complete"
+    );
+    assert!(
+        updated["warnings"]
+            .as_array()
+            .is_some_and(|warnings| warnings.len() == 1),
+        "a successful over-limit update must report actual truncation: {updated:?}"
+    );
+
+    let normal = registry
+        .dispatch(
+            "create",
+            json!({
+                "kind": "concept",
+                "name": "normal target",
+                "skip_dedup_check": true,
+            }),
+        )
+        .await
+        .expect("normal create");
+    assert!(
+        normal.get("warnings").is_none(),
+        "normal input must not emit an advisory"
+    );
+}
+
+#[tokio::test]
+async fn create_dispatch_uses_registry_snapshot_taken_before_embedding() {
+    use crate::KgPack;
+    use khive_runtime::{KhiveRuntime, VerbRegistryBuilder};
+
+    let rt = KhiveRuntime::memory().expect("in-memory runtime");
+    let started = std::sync::Arc::new(tokio::sync::Notify::new());
+    let release = std::sync::Arc::new(tokio::sync::Notify::new());
+    rt.register_embedder(BarrierEmbedderProvider {
+        started: std::sync::Arc::clone(&started),
+        release: std::sync::Arc::clone(&release),
+    });
+    let mut builder = VerbRegistryBuilder::new();
+    builder.register(KgPack::new(rt.clone()));
+    let registry = builder.build().expect("registry build");
+
+    let create = registry.dispatch(
+        "create",
+        json!({
+            "kind": "concept",
+            "name": "x".repeat(lattice_embed::MAX_TEXT_CHARS),
+            "skip_dedup_check": true,
+        }),
+    );
+    let mutate_registry = async {
+        started.notified().await;
+        rt.register_embedder(LateShortBudgetProvider);
+        release.notify_one();
+    };
+    let (response, ()) = tokio::join!(create, mutate_registry);
+    let response = response.expect("create using the captured registry model set");
+
+    assert!(
+        response.get("warnings").is_none(),
+        "the late E5 provider was outside this write's dispatch snapshot, so it must not affect the warning: {response:?}"
+    );
+}
+
 /// A note create with a proper-prefix `embedding_content` must succeed and
 /// store the full `content`; the override is a runtime-layer concern
 /// (covered by `khive-runtime`'s own unit tests) — this proves the handler

--- a/crates/khive-pack-kg/src/handlers/update.rs
+++ b/crates/khive-pack-kg/src/handlers/update.rs
@@ -194,9 +194,16 @@ impl KgPack {
                     properties: p.properties,
                     tags: p.tags,
                 };
-                Ok(normalize_entity_timestamps(to_json(
-                    &self.runtime.update_entity(token, id, patch).await?,
-                )?))
+                let (entity, report) = self
+                    .runtime
+                    .update_entity_with_embedding_report(token, id, patch)
+                    .await?;
+                let mut response = normalize_entity_timestamps(to_json(&entity)?);
+                super::create::add_embedding_truncation_warning(
+                    &mut response,
+                    report.any_truncated(),
+                );
+                Ok(response)
             }
             KindSpec::Edge => {
                 let relation = p.relation.as_deref().map(parse_relation).transpose()?;
@@ -227,9 +234,16 @@ impl KgPack {
                     p.decay_factor,
                     p.properties,
                 );
-                Ok(normalize_entity_timestamps(to_json(
-                    &self.runtime.update_note(token, id, patch).await?,
-                )?))
+                let (note, report) = self
+                    .runtime
+                    .update_note_with_embedding_report(token, id, patch)
+                    .await?;
+                let mut response = normalize_entity_timestamps(to_json(&note)?);
+                super::create::add_embedding_truncation_warning(
+                    &mut response,
+                    report.any_truncated(),
+                );
+                Ok(response)
             }
             KindSpec::Event => Err(immutable_event_error()),
             KindSpec::Proposal => Err(RuntimeError::InvalidInput(

--- a/crates/khive-pack-knowledge/src/knowledge/index_handler.rs
+++ b/crates/khive-pack-knowledge/src/knowledge/index_handler.rs
@@ -1,5 +1,6 @@
 //! Index handler: embed atoms and build/persist the Vamana ANN index.
 
+use std::collections::BTreeMap;
 use std::sync::Arc;
 
 use serde_json::{json, Value};
@@ -9,9 +10,7 @@ use khive_storage::types::{SqlStatement, SqlValue, VectorRecord};
 use khive_types::SubstrateKind;
 
 use super::schema::{Atom, IndexParams};
-use super::util::{
-    atom_embed_text, atom_from_row, deser, sql_err, DEFAULT_EMBED_BATCH, MAX_EMBED_BYTES,
-};
+use super::util::{atom_embed_text, atom_from_row, deser, sql_err, DEFAULT_EMBED_BATCH};
 use super::vamana;
 use super::KnowledgeHandlers;
 
@@ -102,6 +101,8 @@ impl KnowledgeHandlers {
         let mut indexed = 0usize;
         let mut skipped = 0usize;
         let mut failed = 0usize;
+        let mut truncation_by_model =
+            BTreeMap::<String, khive_runtime::retrieval::EmbeddingTruncationReport>::new();
 
         if let Some(cb) = on_progress {
             cb(0, total as u64);
@@ -121,20 +122,7 @@ impl KnowledgeHandlers {
                 continue;
             }
 
-            let texts: Vec<String> = staged
-                .iter()
-                .map(|(_, t)| {
-                    if t.len() <= MAX_EMBED_BYTES {
-                        t.clone()
-                    } else {
-                        let mut end = MAX_EMBED_BYTES;
-                        while !t.is_char_boundary(end) {
-                            end -= 1;
-                        }
-                        t[..end].to_string()
-                    }
-                })
-                .collect();
+            let texts: Vec<String> = staged.iter().map(|(_, text)| text.clone()).collect();
 
             // Every configured engine embeds and writes its own batch independently
             // (issue #1115): a secondary-engine failure does not affect `indexed`/
@@ -180,6 +168,10 @@ impl KnowledgeHandlers {
                 Ok(outcome) => {
                     indexed += outcome.affected as usize;
                     failed += outcome.failed as usize;
+                    truncation_by_model
+                        .entry(outcome.model_name)
+                        .or_default()
+                        .merge(outcome.truncation);
                 }
                 Err(e) => {
                     tracing::warn!(error = %e, "knowledge index default-model task panicked");
@@ -190,8 +182,14 @@ impl KnowledgeHandlers {
                 // Secondary-engine failures are best-effort (logged inside the
                 // task) and never affect `indexed`/`failed`; only a task panic
                 // needs handling here.
-                if let Err(e) = handle.await {
-                    tracing::warn!(error = %e, "knowledge index secondary-model task panicked");
+                match handle.await {
+                    Ok(outcome) => truncation_by_model
+                        .entry(outcome.model_name)
+                        .or_default()
+                        .merge(outcome.truncation),
+                    Err(e) => {
+                        tracing::warn!(error = %e, "knowledge index secondary-model task panicked");
+                    }
                 }
             }
 
@@ -256,14 +254,17 @@ impl KnowledgeHandlers {
             "total": total,
             "ann_vectors": ann_count,
             "ann_failed": ann_failed,
+            "truncation_by_model": truncation_by_model,
         }))
     }
 }
 
 /// One embedding model's outcome from [`embed_and_insert_model`], counted in vectors.
 struct ModelIndexOutcome {
+    model_name: String,
     affected: u64,
     failed: u64,
+    truncation: khive_runtime::retrieval::EmbeddingTruncationReport,
 }
 
 /// Embed one chunk's staged atoms with `model_name` and batch-insert the resulting
@@ -280,8 +281,8 @@ async fn embed_and_insert_model(
     staged: Arc<Vec<(uuid::Uuid, String)>>,
     texts: Arc<Vec<String>>,
 ) -> ModelIndexOutcome {
-    let embeddings = match runtime
-        .embed_document_batch_with_model(&model_name, &texts)
+    let outcomes = match runtime
+        .embed_document_batch_with_model_outcomes(&model_name, &texts)
         .await
     {
         Ok(e) => e,
@@ -302,31 +303,40 @@ async fn embed_and_insert_model(
                 );
             }
             return ModelIndexOutcome {
+                model_name,
                 affected: 0,
                 failed: if is_default { staged.len() as u64 } else { 0 },
+                truncation: Default::default(),
             };
         }
     };
-    if embeddings.len() != staged.len() {
+    if outcomes.len() != staged.len() {
         if is_default {
             tracing::warn!(
                 expected = staged.len(),
-                got = embeddings.len(),
+                got = outcomes.len(),
                 "embed_batch returned wrong number of vectors; atoms cannot be recalled until reindexed"
             );
         } else {
             tracing::warn!(
                 model = %model_name,
                 expected = staged.len(),
-                got = embeddings.len(),
+                got = outcomes.len(),
                 "knowledge secondary-engine embed_batch returned wrong \
                  vector count; skipping this engine for the batch"
             );
         }
         return ModelIndexOutcome {
+            model_name,
             affected: 0,
             failed: if is_default { staged.len() as u64 } else { 0 },
+            truncation: Default::default(),
         };
+    }
+
+    let mut truncation = khive_runtime::retrieval::EmbeddingTruncationReport::default();
+    for outcome in &outcomes {
+        truncation.observe(outcome);
     }
 
     let vectors = match runtime.vectors_for_model(&token, &model_name) {
@@ -342,8 +352,10 @@ async fn embed_and_insert_model(
                 );
             }
             return ModelIndexOutcome {
+                model_name,
                 affected: 0,
                 failed: if is_default { staged.len() as u64 } else { 0 },
+                truncation,
             };
         }
     };
@@ -351,14 +363,14 @@ async fn embed_and_insert_model(
     let ns_str = token.namespace().as_str().to_string();
     let records: Vec<VectorRecord> = staged
         .iter()
-        .zip(embeddings.iter())
-        .map(|((id, _), emb)| VectorRecord {
+        .zip(outcomes.iter())
+        .map(|((id, _), outcome)| VectorRecord {
             subject_id: *id,
             kind: SubstrateKind::Entity,
             namespace: ns_str.clone(),
             field: "knowledge.atom".to_string(),
             embedding_model: Some(model_name.clone()),
-            vectors: vec![emb.clone()],
+            vectors: vec![outcome.vector.clone()],
             updated_at: chrono::Utc::now(),
         })
         .collect();
@@ -382,8 +394,10 @@ async fn embed_and_insert_model(
                 }
             }
             ModelIndexOutcome {
+                model_name,
                 affected: summary.affected,
                 failed: summary.failed,
+                truncation,
             }
         }
         Err(e) => {
@@ -397,8 +411,10 @@ async fn embed_and_insert_model(
                 );
             }
             ModelIndexOutcome {
+                model_name,
                 affected: 0,
                 failed: if is_default { staged.len() as u64 } else { 0 },
+                truncation,
             }
         }
     }

--- a/crates/khive-pack-knowledge/src/knowledge/sections.rs
+++ b/crates/khive-pack-knowledge/src/knowledge/sections.rs
@@ -1,5 +1,7 @@
 //! Section handlers: edit, import, challenge, adjudicate; markdown parsing helpers.
 
+use std::collections::BTreeMap;
+
 use serde_json::{json, Value};
 use uuid::Uuid;
 
@@ -330,8 +332,10 @@ impl KnowledgeHandlers {
         // through the metadata-only UPDATE branch above and keep their existing vector.
         // The Vamana ANN snapshot rebuild is deferred (per-edit cost too high);
         // approximate ANN recall over new vectors lags until the next kkernel reindex.
-        // Missing embedder: embed_sections returns (0,0,0) immediately, so edit succeeds.
-        embed_sections(runtime, token, false, 32, None, Some(&atom_id)).await?;
+        // Missing embedder: embed_sections returns zero counters and an empty
+        // truncation report immediately, so edit succeeds.
+        let (_, _, _, section_truncation) =
+            embed_sections(runtime, token, false, 32, None, Some(&atom_id)).await?;
 
         // Refresh this atom's vector-store entry (knowledge.atom field) so atom-granularity
         // semantic recall is also fresh. rebuild_ann=false writes the vector immediately
@@ -339,7 +343,7 @@ impl KnowledgeHandlers {
         // taken for sections above.
         // Missing embedder: index early-returns {failed:0, reason:"no embedding model
         // configured"} — failed==0 but nothing was written, so check for reason too.
-        let atom_vector_refreshed = {
+        let (atom_vector_refreshed, mut truncation_by_model) = {
             let atom_params = serde_json::json!({
                 "ids": [atom_id],
                 "rebuild_ann": false,
@@ -353,18 +357,54 @@ impl KnowledgeHandlers {
                     atom_id = %atom_id,
                     failed = failed,
                     "knowledge.edit: atom vector refresh failed; \
-                     hybrid recall for this atom may be stale until next reindex"
+                    hybrid recall for this atom may be stale until next reindex"
                 );
             }
-            failed == 0 && !skipped_no_embedder
+            let truncation_by_model = match result.get("truncation_by_model") {
+                Some(value) => serde_json::from_value::<
+                    BTreeMap<String, khive_runtime::retrieval::EmbeddingTruncationReport>,
+                >(value.clone())
+                .map_err(|e| {
+                    RuntimeError::Internal(format!(
+                        "knowledge.edit: invalid knowledge.index truncation report: {e}"
+                    ))
+                })?,
+                None => BTreeMap::new(),
+            };
+            (failed == 0 && !skipped_no_embedder, truncation_by_model)
         };
 
-        Ok(json!({
+        // The section pass uses the default embedder. Merge its actual outcome
+        // into the atom pass's per-model report before deriving the advisory,
+        // so one response accounts for every embedding input this edit sent.
+        let default_model_name = runtime.default_embedder_name();
+        if !default_model_name.is_empty() {
+            truncation_by_model
+                .entry(default_model_name.to_string())
+                .or_default()
+                .merge(section_truncation);
+        }
+        let any_truncated = truncation_by_model
+            .values()
+            .any(khive_runtime::retrieval::EmbeddingTruncationReport::any_truncated);
+
+        let mut response = json!({
             "atom_id": atom_id,
             "upserted": upserted,
             "sections": section_results,
             "atom_vector_refreshed": atom_vector_refreshed,
-        }))
+            "truncation_by_model": truncation_by_model,
+        });
+        if any_truncated {
+            response
+                .as_object_mut()
+                .expect("edit response is an object")
+                .insert(
+                    "warnings".to_string(),
+                    json!([khive_runtime::retrieval::EMBEDDING_INPUT_TRUNCATED_WARNING]),
+                );
+        }
+        Ok(response)
     }
 
     pub(crate) async fn import(

--- a/crates/khive-pack-knowledge/src/knowledge/sections_index.rs
+++ b/crates/khive-pack-knowledge/src/knowledge/sections_index.rs
@@ -8,7 +8,7 @@
 use khive_runtime::{KhiveRuntime, NamespaceToken, RuntimeError};
 use khive_storage::types::{SqlStatement, SqlValue};
 
-use super::util::{now_us, row_str, sql_err, MAX_EMBED_BYTES};
+use super::util::{now_us, row_str, sql_err};
 
 fn unit_normalize(v: &mut [f32]) {
     let norm = v.iter().map(|x| x * x).sum::<f32>().sqrt();
@@ -27,23 +27,12 @@ fn f32_to_le_bytes(v: &[f32]) -> Vec<u8> {
     out
 }
 
-fn truncate_bytes(t: &str) -> String {
-    if t.len() <= MAX_EMBED_BYTES {
-        return t.to_string();
-    }
-    let mut end = MAX_EMBED_BYTES;
-    while !t.is_char_boundary(end) {
-        end -= 1;
-    }
-    t[..end].to_string()
-}
-
 /// Embed sections in `token`'s namespace into `knowledge_sections.embedding`.
 ///
 /// With `drop_existing`, every section is re-embedded; otherwise only sections
 /// whose `embedding` is currently NULL are filled. When `atom_id` is `Some`, only
 /// sections belonging to that atom are processed (used by `knowledge.edit` for
-/// inline re-embed after a write). Returns `(indexed, skipped, failed)`. Genuine
+/// inline re-embed after a write). Returns `(indexed, skipped, failed, truncation)`. Genuine
 /// skips (blank section text) go to `skipped`; embed errors and vector-count
 /// mismatches go to `failed` (fail-closed contract).
 pub(crate) async fn embed_sections(
@@ -53,9 +42,17 @@ pub(crate) async fn embed_sections(
     batch_size: usize,
     on_progress: Option<&(dyn Fn(u64, u64) + Send + Sync)>,
     atom_id: Option<&str>,
-) -> Result<(usize, usize, usize), RuntimeError> {
+) -> Result<
+    (
+        usize,
+        usize,
+        usize,
+        khive_runtime::retrieval::EmbeddingTruncationReport,
+    ),
+    RuntimeError,
+> {
     if runtime.default_embedder_name().is_empty() {
-        return Ok((0, 0, 0));
+        return Ok((0, 0, 0, Default::default()));
     }
     let ns = token.namespace().as_str().to_owned();
     let sql = runtime.sql();
@@ -109,6 +106,7 @@ pub(crate) async fn embed_sections(
     let mut indexed = 0usize;
     let mut skipped = 0usize;
     let mut failed = 0usize;
+    let mut truncation_report = khive_runtime::retrieval::EmbeddingTruncationReport::default();
     let mut last_id: Option<String> = None;
 
     loop {
@@ -185,15 +183,29 @@ pub(crate) async fn embed_sections(
         // batch, so there is no inner re-chunk. `staged` holds the non-empty rows
         // of this page (≤ batch_size).
         if !staged.is_empty() {
-            let texts: Vec<String> = staged.iter().map(|(_, t)| truncate_bytes(t)).collect();
-            match runtime.embed_document_batch(&texts).await {
-                Ok(embeddings) if embeddings.len() == staged.len() => {
+            let texts: Vec<String> = staged.iter().map(|(_, text)| text.clone()).collect();
+            match runtime.embed_document_batch_outcomes(&texts).await {
+                Ok(outcomes) if outcomes.len() == staged.len() => {
+                    let mut truncation =
+                        khive_runtime::retrieval::EmbeddingTruncationReport::default();
+                    for outcome in &outcomes {
+                        truncation.observe(outcome);
+                    }
+                    truncation_report.merge(truncation.clone());
+                    if truncation.any_truncated() {
+                        tracing::warn!(
+                            truncated = truncation.truncated,
+                            discarded_bytes = truncation.discarded_bytes,
+                            "knowledge section embedding inputs truncated; full section text remains stored"
+                        );
+                    }
                     let mut writer = sql
                         .writer()
                         .await
                         .map_err(|e| sql_err("section index writer", e))?;
                     let now = now_us();
-                    for ((id, _), mut emb) in staged.iter().zip(embeddings) {
+                    for ((id, _), outcome) in staged.iter().zip(outcomes) {
+                        let mut emb = outcome.vector;
                         unit_normalize(&mut emb);
                         if let Err(e) = writer
                             .execute(SqlStatement {
@@ -247,5 +259,5 @@ pub(crate) async fn embed_sections(
         }
     }
 
-    Ok((indexed, skipped, failed))
+    Ok((indexed, skipped, failed, truncation_report))
 }

--- a/crates/khive-pack-knowledge/src/knowledge/util.rs
+++ b/crates/khive-pack-knowledge/src/knowledge/util.rs
@@ -39,7 +39,6 @@ pub(super) const MIN_TERM_LEN: usize = 3;
 /// per batch) — NOT a separate DB-pagination unit. The reindex `--batch-size`
 /// flag overrides it; pagination uses the same value.
 pub(crate) const DEFAULT_EMBED_BATCH: usize = 128;
-pub(super) const MAX_EMBED_BYTES: usize = 32_768;
 
 pub(super) static STOP_WORDS: &[&str] = &[
     "and", "are", "also", "but", "can", "did", "does", "for", "from", "had", "has", "have", "its",

--- a/crates/khive-pack-knowledge/src/lib.rs
+++ b/crates/khive-pack-knowledge/src/lib.rs
@@ -31,9 +31,9 @@ pub struct KnowledgeReindexOptions {
 ///
 /// Library entry for `kkernel reindex` — callable without an MCP server.
 /// Knowledge is single-model (search retrieves via the default embedder's ANN),
-/// so this does not fan out across registered models the way entity/note
-/// reindex does. Returns `{atoms_indexed, sections_indexed, failed, ann_failed,
-/// sections_failed}`.
+/// The atom pass also fans out to secondary registered engines on a best-effort
+/// basis. Returns `{atoms_indexed, sections_indexed, failed, ann_failed,
+/// sections_failed, truncation_by_model}`.
 ///
 /// Optional progress callbacks receive `(processed, total)` after each batch.
 pub async fn reindex_knowledge(
@@ -46,6 +46,7 @@ pub async fn reindex_knowledge(
     let mut atoms_indexed = 0u64;
     let mut failed = 0u64;
     let mut ann_failed = false;
+    let mut truncation_by_model = serde_json::Map::new();
     if opts.atoms {
         let ann = knowledge::vamana::new_shared();
         let mut params = serde_json::Map::new();
@@ -68,6 +69,11 @@ pub async fn reindex_knowledge(
             .get("ann_failed")
             .and_then(|b| b.as_bool())
             .unwrap_or(false);
+        truncation_by_model = result
+            .get("truncation_by_model")
+            .and_then(Value::as_object)
+            .cloned()
+            .unwrap_or_default();
     }
 
     let mut sections_indexed = 0u64;
@@ -77,17 +83,37 @@ pub async fn reindex_knowledge(
             .batch_size
             .map(|b| b as usize)
             .unwrap_or(knowledge::util::DEFAULT_EMBED_BATCH);
-        let (indexed, _skipped, sec_failed) = knowledge::sections_index::embed_sections(
-            runtime,
-            token,
-            opts.drop_existing,
-            batch,
-            on_section_progress,
-            None,
-        )
-        .await?;
+        let (indexed, _skipped, sec_failed, section_truncation) =
+            knowledge::sections_index::embed_sections(
+                runtime,
+                token,
+                opts.drop_existing,
+                batch,
+                on_section_progress,
+                None,
+            )
+            .await?;
         sections_indexed = indexed as u64;
         sections_failed = sec_failed as u64;
+        if section_truncation.any_truncated() {
+            let model = runtime.default_embedder_name().to_string();
+            let existing = truncation_by_model
+                .remove(&model)
+                .and_then(|value| {
+                    serde_json::from_value::<khive_runtime::retrieval::EmbeddingTruncationReport>(
+                        value,
+                    )
+                    .ok()
+                })
+                .unwrap_or_default();
+            let mut combined: khive_runtime::retrieval::EmbeddingTruncationReport = existing;
+            combined.merge(section_truncation);
+            truncation_by_model.insert(
+                model,
+                serde_json::to_value(combined)
+                    .expect("EmbeddingTruncationReport serialization cannot fail"),
+            );
+        }
     }
 
     Ok(json!({
@@ -96,5 +122,6 @@ pub async fn reindex_knowledge(
         "failed": failed,
         "ann_failed": ann_failed,
         "sections_failed": sections_failed,
+        "truncation_by_model": truncation_by_model,
     }))
 }

--- a/crates/khive-pack-knowledge/tests/fixes.rs
+++ b/crates/khive-pack-knowledge/tests/fixes.rs
@@ -3102,7 +3102,7 @@ mod edit_inline_reembed {
     use async_trait::async_trait;
     use khive_runtime::{AllowAllGate, BackendId, EmbedderProvider, RuntimeConfig};
     use khive_types::Namespace;
-    use lattice_embed::{EmbedError, EmbeddingModel, EmbeddingService};
+    use lattice_embed::{EmbedError, EmbeddingModel, EmbeddingService, MAX_TEXT_CHARS};
     use std::sync::Arc;
 
     const MODEL_KEY: &str = "all-minilm-l6-v2";
@@ -3322,6 +3322,57 @@ mod edit_inline_reembed {
             }
             other => panic!("unexpected embedding value for new sibling: {other:?}"),
         }
+    }
+
+    /// The edit response must be derived from the section and atom embedding
+    /// calls that actually ran, including the model that bounded the input.
+    #[tokio::test]
+    async fn edit_reports_actual_section_embedding_truncation_by_model() {
+        let rt = rt_with_embedder();
+        let f = pack(rt.clone());
+
+        f.dispatch(
+            "knowledge.upsert_atoms",
+            json!({
+                "atoms": [{
+                    "slug": "edit-truncation-report",
+                    "name": "Edit Truncation Report",
+                    "content": "dense sparse retrieval corpus benchmark search latency gradient descent transformer attention vector index nearest neighbor ranking fusion pipeline embedding rerank cosine similarity"
+                }]
+            }),
+        )
+        .await
+        .expect("upsert atom");
+
+        let response = f
+            .dispatch(
+                "knowledge.edit",
+                json!({
+                    "id": "edit-truncation-report",
+                    "sections": [{
+                        "section_type": "overview",
+                        "content": format!("{}tail", "x".repeat(MAX_TEXT_CHARS + 1))
+                    }]
+                }),
+            )
+            .await
+            .expect("edit with bounded embedding input");
+
+        assert_eq!(
+            response["truncation_by_model"][MODEL_KEY]["truncated"], 1,
+            "the newly inserted section is the one bounded input: {response}"
+        );
+        assert!(
+            response["truncation_by_model"][MODEL_KEY]["discarded_bytes"]
+                .as_u64()
+                .is_some_and(|bytes| bytes > 0),
+            "the report must include bytes actually discarded by the embedder: {response}"
+        );
+        assert_eq!(
+            response["warnings"],
+            json!([khive_runtime::retrieval::EMBEDDING_INPUT_TRUNCATED_WARNING]),
+            "the wire advisory must be derived from the merged actual outcomes"
+        );
     }
 
     /// knowledge.edit must refresh the atom-level vector-store entry (knowledge.atom field)

--- a/crates/khive-runtime/docs/api/atomic_prepare.md
+++ b/crates/khive-runtime/docs/api/atomic_prepare.md
@@ -41,12 +41,13 @@ Mirrors `khive-runtime::operations::KhiveRuntime::update_edge`'s patch semantics
 entity/note branches' `merge_properties`).
 
 DML shape:
+
 - non-symmetric relation: a single `edge_upsert_statement` call on the patched `Edge` — the same
   builder `update_edge`'s own non-symmetric branch calls via `graph.upsert_edge(edge.clone())`
   (`khive-db::stores::graph::SqlGraphStore::upsert_edge`), so parity is exact by construction.
 - symmetric relation (`competes_with`, `composed_with`): `update_edge` does NOT use the upsert
   builder here, because `upsert_edge` resolves `ON CONFLICT(namespace, id)` first and cannot
-  detect a natural-key collision with a *different* id. Canonical (`update_edge_symmetric_dml`)
+  detect a natural-key collision with a _different_ id. Canonical (`update_edge_symmetric_dml`)
   runs a conflict probe and branches in Rust inside a single uninterrupted transaction, which is
   safe there. This atomic path cannot do that (see the in-source invariant note on
   `prepare_update_edge`).
@@ -64,3 +65,9 @@ best-effort or non-SQL work): the insert is a small number of plain, determinist
 computed entirely from data already on hand at prepare time, unlike the
 `ReindexEntity`/`ReindexNote` post-commit effects this module defers because those need an
 embedding call.
+
+`apply_post_commit_effects_with_report` returns one `PostCommitEmbeddingOutcome` for every reindex
+effect it successfully executes. Each outcome retains the originating effect identity plus its
+typed truncation report, allowing CLI or pack response builders to attach warnings to the exact
+write without rerunning registry prediction. The original `apply_post_commit_effects` remains the
+unit-returning compatibility wrapper.

--- a/crates/khive-runtime/src/atomic_message.rs
+++ b/crates/khive-runtime/src/atomic_message.rs
@@ -490,7 +490,10 @@ mod tests {
             texts: &[String],
             _model: EmbeddingModel,
         ) -> Result<Vec<Vec<f32>>, EmbedError> {
-            Ok(texts.iter().map(|_| vec![0.5]).collect())
+            Ok(texts
+                .iter()
+                .map(|_| vec![0.5; EmbeddingModel::MultilingualE5Base.dimensions()])
+                .collect())
         }
         fn supports_model(&self, _model: EmbeddingModel) -> bool {
             true
@@ -507,7 +510,7 @@ mod tests {
             "multilingual-e5-base"
         }
         fn dimensions(&self) -> usize {
-            1
+            EmbeddingModel::MultilingualE5Base.dimensions()
         }
         async fn build(&self) -> RuntimeResult<std::sync::Arc<dyn EmbeddingService>> {
             Ok(std::sync::Arc::new(TruncationService))

--- a/crates/khive-runtime/src/atomic_message.rs
+++ b/crates/khive-runtime/src/atomic_message.rs
@@ -249,6 +249,16 @@ pub async fn create_notes_atomic(
     runtime: &KhiveRuntime,
     specs: Vec<AtomicNoteSpec<'_>>,
 ) -> RuntimeResult<Vec<Note>> {
+    Ok(create_notes_atomic_with_report(runtime, specs).await?.0)
+}
+
+/// The truncation-reporting form of [`create_notes_atomic`]. The report covers
+/// every note/model embedding actually produced before the atomic commit and is
+/// returned only when the whole note set commits successfully.
+pub async fn create_notes_atomic_with_report(
+    runtime: &KhiveRuntime,
+    specs: Vec<AtomicNoteSpec<'_>>,
+) -> RuntimeResult<(Vec<Note>, crate::retrieval::EmbeddingTruncationReport)> {
     // ---- 1. Validate + build Note objects (all pre-write checks, same as
     // create_note_inner, before any embedding or DML is attempted). ----
     let mut notes: Vec<Note> = Vec::with_capacity(specs.len());
@@ -284,6 +294,7 @@ pub async fn create_notes_atomic(
         .iter()
         .map(|_| vec![None; embed_model_names.len()])
         .collect();
+    let mut embedding_truncation = crate::retrieval::EmbeddingTruncationReport::default();
 
     if !embed_model_names.is_empty() {
         // Ensure every model's vector table exists before the commit pass —
@@ -304,7 +315,7 @@ pub async fn create_notes_atomic(
                 let text = text.clone();
                 let ctx = usage_ctx.clone();
                 join_set.spawn(async move {
-                    let fut = rt.embed_document_with_model_for_token(&token, &name, &text);
+                    let fut = rt.embed_document_with_model_outcome_for_token(&token, &name, &text);
                     let result = match ctx {
                         Some(ctx) => crate::usage::scope(ctx, fut).await,
                         None => fut.await,
@@ -316,8 +327,17 @@ pub async fn create_notes_atomic(
 
         while let Some(joined) = join_set.join_next().await {
             match joined {
-                Ok((note_idx, model_idx, Ok(vector))) => {
-                    embeddings[note_idx][model_idx] = Some(vector);
+                Ok((note_idx, model_idx, Ok(outcome))) => {
+                    embedding_truncation.observe(&outcome);
+                    if outcome.truncated {
+                        tracing::warn!(
+                            model = %outcome.model_name,
+                            source_bytes = outcome.source_bytes,
+                            embedded_bytes = outcome.embedded_bytes,
+                            "atomic note embedding input truncated; full content will be stored unchanged"
+                        );
+                    }
+                    embeddings[note_idx][model_idx] = Some(outcome.vector);
                 }
                 Ok((_, _, Err(e))) => {
                     join_set.abort_all();
@@ -407,7 +427,7 @@ pub async fn create_notes_atomic(
 
     // ---- 4. One writer acquisition for the whole set. ----
     match run_atomic_unit(runtime.sql().as_ref(), plans).await {
-        Ok(AtomicRunOutcome::Committed { .. }) => Ok(notes),
+        Ok(AtomicRunOutcome::Committed { .. }) => Ok((notes, embedding_truncation)),
         Ok(AtomicRunOutcome::RolledBack {
             failed_op_index,
             failure,
@@ -422,7 +442,7 @@ pub async fn create_notes_atomic(
 mod tests {
     use super::*;
     use async_trait::async_trait;
-    use lattice_embed::{EmbedError, EmbeddingModel, EmbeddingService};
+    use lattice_embed::{EmbedError, EmbeddingModel, EmbeddingService, MAX_TEXT_CHARS};
 
     use khive_types::Namespace;
 
@@ -459,6 +479,38 @@ mod tests {
         }
         async fn build(&self) -> RuntimeResult<std::sync::Arc<dyn EmbeddingService>> {
             Ok(std::sync::Arc::new(NanService))
+        }
+    }
+
+    struct TruncationService;
+    #[async_trait]
+    impl EmbeddingService for TruncationService {
+        async fn embed(
+            &self,
+            texts: &[String],
+            _model: EmbeddingModel,
+        ) -> Result<Vec<Vec<f32>>, EmbedError> {
+            Ok(texts.iter().map(|_| vec![0.5]).collect())
+        }
+        fn supports_model(&self, _model: EmbeddingModel) -> bool {
+            true
+        }
+        fn name(&self) -> &'static str {
+            "multilingual-e5-base"
+        }
+    }
+
+    struct TruncationProvider;
+    #[async_trait]
+    impl EmbedderProvider for TruncationProvider {
+        fn name(&self) -> &str {
+            "multilingual-e5-base"
+        }
+        fn dimensions(&self) -> usize {
+            1
+        }
+        async fn build(&self) -> RuntimeResult<std::sync::Arc<dyn EmbeddingService>> {
+            Ok(std::sync::Arc::new(TruncationService))
         }
     }
 
@@ -561,6 +613,38 @@ mod tests {
             ann_write_log_count(&runtime, ns, NAN_MODEL).await,
             0,
             "no ann_write_log row may be committed when an embedding is non-finite"
+        );
+    }
+
+    #[tokio::test]
+    async fn create_notes_atomic_with_report_preserves_truncation_outcome() {
+        let runtime = KhiveRuntime::memory().expect("in-memory runtime");
+        runtime.register_embedder(TruncationProvider);
+        let token = runtime
+            .authorize(Namespace::parse("atomic-message-truncation-test").unwrap())
+            .expect("authorize");
+        let content = "x".repeat(MAX_TEXT_CHARS);
+
+        let (notes, report) = create_notes_atomic_with_report(
+            &runtime,
+            vec![AtomicNoteSpec {
+                token: &token,
+                id: None,
+                kind: "observation",
+                name: None,
+                content: &content,
+                properties: None,
+            }],
+        )
+        .await
+        .expect("atomic note write");
+
+        assert_eq!(notes.len(), 1);
+        assert_eq!(report.truncated, 1);
+        assert_eq!(
+            report.discarded_bytes,
+            "passage: ".len() as u64,
+            "E5 document-prefix reservation must be reflected in the returned report"
         );
     }
 

--- a/crates/khive-runtime/src/atomic_plan.rs
+++ b/crates/khive-runtime/src/atomic_plan.rs
@@ -249,6 +249,11 @@ impl UpdatePlan {
     pub fn edge_natural_key(&self) -> Option<&EdgeNaturalKey> {
         self.edge_natural_key.as_ref()
     }
+
+    /// The deferred post-commit effect assigned by the prepare pass.
+    pub fn post_commit(&self) -> &PostCommitEffect {
+        &self.post_commit
+    }
 }
 
 /// Write plan for an `AddEntity` proposal change: a fresh entity row plus its

--- a/crates/khive-runtime/src/atomic_prepare.rs
+++ b/crates/khive-runtime/src/atomic_prepare.rs
@@ -1484,26 +1484,61 @@ async fn prepare_merge(
 // post-commit effects
 // ---------------------------------------------------------------------------
 
-/// Run every deferred [`PostCommitEffect`] after a committed atomic unit,
-/// outside any transaction. Re-fetches each target's now-committed row and
-/// reuses the existing `reindex_entity`/`reindex_note` (FTS + embedding,
-/// same as the non-atomic path) for exact parity.
+/// Embedding metadata produced by one successfully applied reindex effect.
+///
+/// The effect identity is retained so response builders can attach an advisory
+/// to the exact atomic op that scheduled the reindex. Effects whose target is
+/// no longer present are omitted from the returned outcome list.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct PostCommitEmbeddingOutcome {
+    /// The committed reindex effect that produced this outcome.
+    pub effect: PostCommitEffect,
+    /// Actual input bounding observed while executing the effect.
+    pub truncation: crate::retrieval::EmbeddingTruncationReport,
+}
+
+/// Run every deferred [`PostCommitEffect`] after a committed atomic unit.
 pub async fn apply_post_commit_effects(
     runtime: &KhiveRuntime,
     token: &NamespaceToken,
     effects: CommittedPostCommitEffects,
 ) -> RuntimeResult<()> {
+    apply_post_commit_effects_with_report(runtime, token, effects)
+        .await
+        .map(|_| ())
+}
+
+/// Truncation-reporting form of [`apply_post_commit_effects`]. Re-fetches each
+/// target's now-committed row outside any transaction and reuses the existing
+/// `reindex_entity`/`reindex_note` (FTS + embedding, same as the non-atomic
+/// path) for exact parity. Returns the typed embedding outcome for each reindex
+/// effect so callers can preserve write-response advisories instead of
+/// discarding them after commit.
+pub async fn apply_post_commit_effects_with_report(
+    runtime: &KhiveRuntime,
+    token: &NamespaceToken,
+    effects: CommittedPostCommitEffects,
+) -> RuntimeResult<Vec<PostCommitEmbeddingOutcome>> {
+    let mut embedding_outcomes = Vec::new();
     for effect in effects.into_effects() {
         match effect {
             PostCommitEffect::None => {}
             PostCommitEffect::ReindexEntity { entity_id } => {
                 if let Some(entity) = runtime.entities(token)?.get_entity(entity_id).await? {
-                    runtime.reindex_entity(token, &entity).await?;
+                    let truncation = runtime.reindex_entity(token, &entity).await?;
+                    embedding_outcomes.push(PostCommitEmbeddingOutcome {
+                        effect: PostCommitEffect::ReindexEntity { entity_id },
+                        truncation,
+                    });
                 }
             }
             PostCommitEffect::ReindexNote { note_id } => {
                 if let Some(note) = runtime.notes(token)?.get_note(note_id).await? {
-                    runtime.reindex_note(token, &note).await?;
+                    let truncation = runtime.reindex_note(token, &note).await?;
+                    embedding_outcomes.push(PostCommitEmbeddingOutcome {
+                        effect: PostCommitEffect::ReindexNote { note_id },
+                        truncation,
+                    });
                     // This handler calls `reindex_note` directly, bypassing
                     // `update_note()` and the note-mutation hook it fires
                     // after its own reindex (see `curation.rs`). Fire it
@@ -1535,7 +1570,7 @@ pub async fn apply_post_commit_effects(
             }
         }
     }
-    Ok(())
+    Ok(embedding_outcomes)
 }
 
 #[cfg(test)]
@@ -1543,7 +1578,7 @@ mod tests {
     use super::*;
 
     use async_trait::async_trait;
-    use lattice_embed::{EmbedError, EmbeddingModel, EmbeddingService};
+    use lattice_embed::{EmbedError, EmbeddingModel, EmbeddingService, MAX_TEXT_CHARS};
     use serde_json::json;
 
     use khive_types::Namespace;
@@ -1747,10 +1782,11 @@ mod tests {
             .expect("vec store");
         assert_eq!(vec_store.count().await.expect("count before"), 0);
 
+        let updated_content = format!("freshly-updated-content-xyz{}", "x".repeat(MAX_TEXT_CHARS));
         let plan = prepare_update(
             &runtime,
             &token,
-            &json!({"id": note_id.to_string(), "content": "freshly-updated-content-xyz"}),
+            &json!({"id": note_id.to_string(), "content": updated_content}),
             None,
         )
         .await
@@ -1769,9 +1805,17 @@ mod tests {
             "content change must schedule exactly one ReindexNote post-commit effect"
         );
 
-        apply_post_commit_effects(&runtime, &token, post_commit)
-            .await
-            .expect("apply post-commit effects");
+        let embedding_outcomes =
+            apply_post_commit_effects_with_report(&runtime, &token, post_commit)
+                .await
+                .expect("apply post-commit effects");
+        assert_eq!(embedding_outcomes.len(), 1);
+        assert_eq!(
+            embedding_outcomes[0].effect,
+            PostCommitEffect::ReindexNote { note_id }
+        );
+        assert_eq!(embedding_outcomes[0].truncation.truncated, 1);
+        assert!(embedding_outcomes[0].truncation.discarded_bytes > 0);
 
         // FTS: the note must be recallable under its NEW content.
         let doc = runtime

--- a/crates/khive-runtime/src/curation.rs
+++ b/crates/khive-runtime/src/curation.rs
@@ -25,6 +25,39 @@ use crate::error::{RuntimeError, RuntimeResult};
 use crate::operations::{base_entity_rule_allows, canonical_edge_endpoints, endpoint_matches};
 use crate::runtime::{KhiveRuntime, NamespaceToken};
 
+/// Immutable embedding-registry view for one logical write.
+///
+/// Document byte budgets are derived from the model name at the embedding seam,
+/// so retaining the exact name set keeps merge cleanup, table preparation, and
+/// survivor reindexing on one plan during concurrent registration.
+#[derive(Clone, Debug, Default)]
+struct EmbeddingModelPlan {
+    model_names: Vec<String>,
+}
+
+impl EmbeddingModelPlan {
+    fn capture(runtime: &KhiveRuntime) -> Self {
+        Self {
+            model_names: runtime.registered_embedding_model_names(),
+        }
+    }
+
+    fn is_empty(&self) -> bool {
+        self.model_names.is_empty()
+    }
+
+    fn model_names(&self) -> &[String] {
+        &self.model_names
+    }
+
+    fn vector_tables(&self) -> Vec<String> {
+        self.model_names
+            .iter()
+            .map(|name| format!("vec_{}", crate::config::sanitize_key(name)))
+            .collect()
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Public types
 // ---------------------------------------------------------------------------
@@ -757,11 +790,11 @@ impl KhiveRuntime {
         }
         let ns = token.namespace().as_str().to_owned();
         let fts_table = "fts_entities".to_string();
-        let vec_tables: Vec<String> = self
-            .registered_embedding_model_names()
-            .iter()
-            .map(|name| format!("vec_{}", crate::config::sanitize_key(name)))
-            .collect();
+        // One immutable registry view governs transactional deletion, table
+        // preparation, and survivor reindex. A late model belongs to a later
+        // write/backfill rather than only one leg of this merge.
+        let embedding_plan = EmbeddingModelPlan::capture(self);
+        let vec_tables = embedding_plan.vector_tables();
         // Loaded once here (sync, cheap) so the rewire loop can evaluate the
         // endpoint contract without an async round-trip per edge (khive#1216).
         let pack_rules = self.pack_edge_rules();
@@ -772,7 +805,7 @@ impl KhiveRuntime {
         let _ = self.text(token)?;
         // vectors_for_model (not the default-model-only self.vectors()) so
         // custom-only runtimes (no default embedding_model) still get DDL primed.
-        for model_name in &self.registered_embedding_model_names() {
+        for model_name in embedding_plan.model_names() {
             let _ = self.vectors_for_model(token, model_name)?;
         }
 
@@ -847,8 +880,10 @@ impl KhiveRuntime {
 
         // FTS and vec-deletes already committed inside the transaction above;
         // only the embedding re-insert needs an async step outside it.
-        if !dry_run && !self.registered_embedding_model_names().is_empty() {
-            summary.embedding_truncation = self.reindex_entity(token, &updated_entity).await?;
+        if !dry_run && !embedding_plan.is_empty() {
+            summary.embedding_truncation = self
+                .reindex_entity_with_plan(token, &updated_entity, &embedding_plan)
+                .await?;
         }
 
         // Dry-run is a read-only preview: it must not append a merge event.
@@ -911,15 +946,25 @@ impl KhiveRuntime {
         token: &NamespaceToken,
         entity: &Entity,
     ) -> RuntimeResult<crate::retrieval::EmbeddingTruncationReport> {
+        let embedding_plan = EmbeddingModelPlan::capture(self);
+        self.reindex_entity_with_plan(token, entity, &embedding_plan)
+            .await
+    }
+
+    async fn reindex_entity_with_plan(
+        &self,
+        token: &NamespaceToken,
+        entity: &Entity,
+        embedding_plan: &EmbeddingModelPlan,
+    ) -> RuntimeResult<crate::retrieval::EmbeddingTruncationReport> {
         // Use entity.namespace (authoritative) rather than token.namespace().as_str() (caller claim).
         let ns = entity.namespace.clone();
         let doc = entity_fts_document(entity);
         let embed_body = doc.body.clone();
         self.text(token)?.upsert_document(doc).await?;
 
-        let embed_model_names = self.registered_embedding_model_names();
         let mut report = crate::retrieval::EmbeddingTruncationReport::default();
-        for model_name in &embed_model_names {
+        for model_name in embedding_plan.model_names() {
             match self
                 .embed_document_with_model_outcome_for_token(token, model_name, &embed_body)
                 .await
@@ -991,14 +1036,24 @@ impl KhiveRuntime {
         token: &NamespaceToken,
         note: &khive_storage::note::Note,
     ) -> RuntimeResult<crate::retrieval::EmbeddingTruncationReport> {
+        let embedding_plan = EmbeddingModelPlan::capture(self);
+        self.reindex_note_with_plan(token, note, &embedding_plan)
+            .await
+    }
+
+    async fn reindex_note_with_plan(
+        &self,
+        token: &NamespaceToken,
+        note: &khive_storage::note::Note,
+        embedding_plan: &EmbeddingModelPlan,
+    ) -> RuntimeResult<crate::retrieval::EmbeddingTruncationReport> {
         self.text_for_notes(token)?
             .upsert_document(note_fts_document(note))
             .await?;
 
         let ns = note.namespace.clone();
-        let embed_model_names = self.registered_embedding_model_names();
         let mut report = crate::retrieval::EmbeddingTruncationReport::default();
-        for model_name in &embed_model_names {
+        for model_name in embedding_plan.model_names() {
             match self
                 .embed_document_with_model_outcome_for_token(
                     token,
@@ -1215,11 +1270,10 @@ impl KhiveRuntime {
         }
         let ns = token.namespace().as_str().to_string();
         let fts_table = "fts_notes".to_string();
-        let vec_tables: Vec<String> = self
-            .registered_embedding_model_names()
-            .iter()
-            .map(|name| format!("vec_{}", crate::config::sanitize_key(name)))
-            .collect();
+        // Keep deletion, table preparation, and survivor reindex on the same
+        // immutable registry view; see the entity merge path above.
+        let embedding_plan = EmbeddingModelPlan::capture(self);
+        let vec_tables = embedding_plan.vector_tables();
         let pack_rules = self.pack_edge_rules();
 
         let note_store = self.notes(token)?;
@@ -1237,7 +1291,7 @@ impl KhiveRuntime {
 
         let _ = self.graph(token)?;
         let _ = self.text_for_notes(token)?;
-        for model_name in &self.registered_embedding_model_names() {
+        for model_name in embedding_plan.model_names() {
             let _ = self.vectors_for_model(token, model_name)?;
         }
 
@@ -1291,8 +1345,10 @@ impl KhiveRuntime {
             .map_err(|e| RuntimeError::Internal(e.to_string()))??
         };
 
-        if !dry_run && !self.registered_embedding_model_names().is_empty() {
-            summary.embedding_truncation = self.reindex_note(token, &updated_note).await?;
+        if !dry_run && !embedding_plan.is_empty() {
+            summary.embedding_truncation = self
+                .reindex_note_with_plan(token, &updated_note, &embedding_plan)
+                .await?;
             // A merge changes the same ANN corpus as update_note's text_changed
             // branch, so fire the same mutation hook regardless of which public
             // write path reached the corpus change.
@@ -5767,6 +5823,106 @@ mod tests {
         {
             Ok(std::sync::Arc::new(MergeTestVecService { dims: self.dims }))
         }
+    }
+
+    #[tokio::test]
+    async fn entity_reindex_with_captured_merge_plan_excludes_late_model() {
+        const DIMS: usize = 4;
+        const PLANNED: &str = "merge-entity-plan-existing";
+        const LATE: &str = "merge-entity-plan-late";
+        let rt = KhiveRuntime::memory().unwrap();
+        let ns = crate::Namespace::parse("merge-entity-plan-snapshot").unwrap();
+        let tok = NamespaceToken::for_namespace(ns);
+        let entity = rt
+            .create_entity(
+                &tok,
+                "concept",
+                None,
+                "CapturedEntityPlan",
+                Some("full source remains indexed"),
+                None,
+                vec![],
+            )
+            .await
+            .expect("create entity before registering embedders");
+
+        rt.register_embedder(MergeTestVecProvider::new(PLANNED, DIMS));
+        let embedding_plan = EmbeddingModelPlan::capture(&rt);
+        rt.register_embedder(MergeTestVecProvider::new(LATE, DIMS));
+
+        rt.reindex_entity_with_plan(&tok, &entity, &embedding_plan)
+            .await
+            .expect("reindex entity with captured merge plan");
+
+        assert_eq!(embedding_plan.model_names().len(), 1);
+        assert_eq!(embedding_plan.model_names()[0].as_str(), PLANNED);
+        assert_eq!(
+            rt.vectors_for_model(&tok, PLANNED)
+                .unwrap()
+                .count()
+                .await
+                .unwrap(),
+            1
+        );
+        assert_eq!(
+            rt.vectors_for_model(&tok, LATE)
+                .unwrap()
+                .count()
+                .await
+                .unwrap(),
+            0,
+            "a provider registered after plan capture must not join survivor reindex"
+        );
+    }
+
+    #[tokio::test]
+    async fn note_reindex_with_captured_merge_plan_excludes_late_model() {
+        const DIMS: usize = 4;
+        const PLANNED: &str = "merge-note-plan-existing";
+        const LATE: &str = "merge-note-plan-late";
+        let rt = KhiveRuntime::memory().unwrap();
+        let ns = crate::Namespace::parse("merge-note-plan-snapshot").unwrap();
+        let tok = NamespaceToken::for_namespace(ns);
+        let note = rt
+            .create_note(
+                &tok,
+                "observation",
+                None,
+                "full note source remains indexed",
+                None,
+                None,
+                vec![],
+            )
+            .await
+            .expect("create note before registering embedders");
+
+        rt.register_embedder(MergeTestVecProvider::new(PLANNED, DIMS));
+        let embedding_plan = EmbeddingModelPlan::capture(&rt);
+        rt.register_embedder(MergeTestVecProvider::new(LATE, DIMS));
+
+        rt.reindex_note_with_plan(&tok, &note, &embedding_plan)
+            .await
+            .expect("reindex note with captured merge plan");
+
+        assert_eq!(embedding_plan.model_names().len(), 1);
+        assert_eq!(embedding_plan.model_names()[0].as_str(), PLANNED);
+        assert_eq!(
+            rt.vectors_for_model(&tok, PLANNED)
+                .unwrap()
+                .count()
+                .await
+                .unwrap(),
+            1
+        );
+        assert_eq!(
+            rt.vectors_for_model(&tok, LATE)
+                .unwrap()
+                .count()
+                .await
+                .unwrap(),
+            0,
+            "a provider registered after plan capture must not join survivor reindex"
+        );
     }
 
     /// merge_entity must delete from_id vectors from ALL registered model tables.

--- a/crates/khive-runtime/src/curation.rs
+++ b/crates/khive-runtime/src/curation.rs
@@ -238,6 +238,9 @@ pub struct MergeSummary {
     pub tags_unioned: usize,
     pub content_appended: bool,
     pub dry_run: bool,
+    /// Actual embedding-input truncation observed while reindexing the survivor.
+    #[serde(skip)]
+    pub embedding_truncation: crate::retrieval::EmbeddingTruncationReport,
 }
 
 /// Patch for `update_edge`. Only `Some(_)` fields are applied; `None` means "leave unchanged".
@@ -589,15 +592,29 @@ impl KhiveRuntime {
         id: Uuid,
         patch: EntityPatch,
     ) -> RuntimeResult<Entity> {
+        Ok(self
+            .update_entity_with_embedding_report(token, id, patch)
+            .await?
+            .0)
+    }
+
+    pub async fn update_entity_with_embedding_report(
+        &self,
+        token: &NamespaceToken,
+        id: Uuid,
+        patch: EntityPatch,
+    ) -> RuntimeResult<(Entity, crate::retrieval::EmbeddingTruncationReport)> {
         let (entity, text_changed, changed_fields) =
             self.prepare_update_entity(token, id, patch).await?;
 
         let store = self.entities(token)?;
         store.upsert_entity(entity.clone()).await?;
 
-        if text_changed {
-            self.reindex_entity(token, &entity).await?;
-        }
+        let embedding_report = if text_changed {
+            self.reindex_entity(token, &entity).await?
+        } else {
+            crate::retrieval::EmbeddingTruncationReport::default()
+        };
 
         let event_store = self.events(token)?;
         let event = khive_storage::event::Event::new(
@@ -617,7 +634,7 @@ impl KhiveRuntime {
             RuntimeError::Internal(format!("update_entity: event store write failed: {e}"))
         })?;
 
-        Ok(entity)
+        Ok((entity, embedding_report))
     }
 
     /// Merge `from_id` into `into_id`.
@@ -765,7 +782,7 @@ impl KhiveRuntime {
         // failure degrades to the legacy mutex path rather than failing the merge.
         let writer_task = pool.writer_task_handle().ok().flatten();
 
-        let (summary, updated_entity) = if let Some(writer_task) = writer_task {
+        let (mut summary, updated_entity) = if let Some(writer_task) = writer_task {
             writer_task
                 .send(move |conn| {
                     merge_entity_sql(
@@ -831,7 +848,7 @@ impl KhiveRuntime {
         // FTS and vec-deletes already committed inside the transaction above;
         // only the embedding re-insert needs an async step outside it.
         if !dry_run && !self.registered_embedding_model_names().is_empty() {
-            self.reindex_entity(token, &updated_entity).await?;
+            summary.embedding_truncation = self.reindex_entity(token, &updated_entity).await?;
         }
 
         // Dry-run is a read-only preview: it must not append a merge event.
@@ -893,7 +910,7 @@ impl KhiveRuntime {
         &self,
         token: &NamespaceToken,
         entity: &Entity,
-    ) -> RuntimeResult<()> {
+    ) -> RuntimeResult<crate::retrieval::EmbeddingTruncationReport> {
         // Use entity.namespace (authoritative) rather than token.namespace().as_str() (caller claim).
         let ns = entity.namespace.clone();
         let doc = entity_fts_document(entity);
@@ -901,38 +918,42 @@ impl KhiveRuntime {
         self.text(token)?.upsert_document(doc).await?;
 
         let embed_model_names = self.registered_embedding_model_names();
+        let mut report = crate::retrieval::EmbeddingTruncationReport::default();
         for model_name in &embed_model_names {
             match self
-                .embed_document_with_model_for_token(token, model_name, &embed_body)
+                .embed_document_with_model_outcome_for_token(token, model_name, &embed_body)
                 .await
             {
-                Ok(vector) => match self.vectors_for_model(token, model_name) {
-                    Ok(vs) => {
-                        if let Err(e) = vs
-                            .insert(
-                                entity.id,
-                                SubstrateKind::Entity,
-                                &ns,
-                                "entity.body",
-                                vec![vector],
-                            )
-                            .await
-                        {
+                Ok(outcome) => {
+                    report.observe(&outcome);
+                    match self.vectors_for_model(token, model_name) {
+                        Ok(vs) => {
+                            if let Err(e) = vs
+                                .insert(
+                                    entity.id,
+                                    SubstrateKind::Entity,
+                                    &ns,
+                                    "entity.body",
+                                    vec![outcome.vector],
+                                )
+                                .await
+                            {
+                                tracing::warn!(
+                                    model = model_name,
+                                    id = %entity.id,
+                                    "reindex_entity: vector insert failed, skipping model: {e}"
+                                );
+                            }
+                        }
+                        Err(e) => {
                             tracing::warn!(
                                 model = model_name,
                                 id = %entity.id,
-                                "reindex_entity: vector insert failed, skipping model: {e}"
+                                "reindex_entity: could not access vector store for model, skipping: {e}"
                             );
                         }
                     }
-                    Err(e) => {
-                        tracing::warn!(
-                            model = model_name,
-                            id = %entity.id,
-                            "reindex_entity: could not access vector store for model, skipping: {e}"
-                        );
-                    }
-                },
+                }
                 Err(e) => {
                     tracing::warn!(
                         model = model_name,
@@ -943,7 +964,7 @@ impl KhiveRuntime {
             }
         }
 
-        Ok(())
+        Ok(report)
     }
 
     /// Remove an entity from FTS5 and vector indexes across all registered models.
@@ -969,45 +990,53 @@ impl KhiveRuntime {
         &self,
         token: &NamespaceToken,
         note: &khive_storage::note::Note,
-    ) -> RuntimeResult<()> {
+    ) -> RuntimeResult<crate::retrieval::EmbeddingTruncationReport> {
         self.text_for_notes(token)?
             .upsert_document(note_fts_document(note))
             .await?;
 
         let ns = note.namespace.clone();
         let embed_model_names = self.registered_embedding_model_names();
+        let mut report = crate::retrieval::EmbeddingTruncationReport::default();
         for model_name in &embed_model_names {
             match self
-                .embed_document_with_model_for_token(token, model_name, &note_embedding_text(note))
+                .embed_document_with_model_outcome_for_token(
+                    token,
+                    model_name,
+                    &note_embedding_text(note),
+                )
                 .await
             {
-                Ok(vector) => match self.vectors_for_model(token, model_name) {
-                    Ok(vs) => {
-                        if let Err(e) = vs
-                            .insert(
-                                note.id,
-                                SubstrateKind::Note,
-                                &ns,
-                                "note.content",
-                                vec![vector],
-                            )
-                            .await
-                        {
+                Ok(outcome) => {
+                    report.observe(&outcome);
+                    match self.vectors_for_model(token, model_name) {
+                        Ok(vs) => {
+                            if let Err(e) = vs
+                                .insert(
+                                    note.id,
+                                    SubstrateKind::Note,
+                                    &ns,
+                                    "note.content",
+                                    vec![outcome.vector],
+                                )
+                                .await
+                            {
+                                tracing::warn!(
+                                    model = model_name,
+                                    id = %note.id,
+                                    "reindex_note: vector insert failed, skipping model: {e}"
+                                );
+                            }
+                        }
+                        Err(e) => {
                             tracing::warn!(
                                 model = model_name,
                                 id = %note.id,
-                                "reindex_note: vector insert failed, skipping model: {e}"
+                                "reindex_note: could not access vector store for model, skipping: {e}"
                             );
                         }
                     }
-                    Err(e) => {
-                        tracing::warn!(
-                            model = model_name,
-                            id = %note.id,
-                            "reindex_note: could not access vector store for model, skipping: {e}"
-                        );
-                    }
-                },
+                }
                 Err(e) => {
                     tracing::warn!(
                         model = model_name,
@@ -1017,7 +1046,7 @@ impl KhiveRuntime {
                 }
             }
         }
-        Ok(())
+        Ok(report)
     }
 
     /// Computes the patched `Note` and `text_changed` without writing, mirroring
@@ -1099,20 +1128,38 @@ impl KhiveRuntime {
         id: Uuid,
         patch: NotePatch,
     ) -> RuntimeResult<khive_storage::note::Note> {
+        Ok(self
+            .update_note_with_embedding_report(token, id, patch)
+            .await?
+            .0)
+    }
+
+    pub async fn update_note_with_embedding_report(
+        &self,
+        token: &NamespaceToken,
+        id: Uuid,
+        patch: NotePatch,
+    ) -> RuntimeResult<(
+        khive_storage::note::Note,
+        crate::retrieval::EmbeddingTruncationReport,
+    )> {
         let (note, text_changed) = self.prepare_update_note(token, id, patch).await?;
 
         let store = self.notes(token)?;
         store.upsert_note(note.clone()).await?;
 
-        if text_changed {
-            self.reindex_note(token, &note).await?;
+        let embedding_report = if text_changed {
+            let report = self.reindex_note(token, &note).await?;
             // Notify any pack-owned vector cache (e.g. a warm ANN index) that this
             // note's embedding changed, via a generic hook so khive-runtime/pack-kg
             // never take a dependency on the consuming pack. No-op if unregistered.
             self.fire_note_mutation_hook(&note.kind, note.id).await;
-        }
+            report
+        } else {
+            crate::retrieval::EmbeddingTruncationReport::default()
+        };
 
-        Ok(note)
+        Ok((note, embedding_report))
     }
 
     /// Merge `from_id` note into `into_id` note.
@@ -1197,7 +1244,7 @@ impl KhiveRuntime {
         let pool = self.backend().pool_arc();
         let writer_task = pool.writer_task_handle().ok().flatten();
 
-        let (summary, updated_note) = if let Some(writer_task) = writer_task {
+        let (mut summary, updated_note) = if let Some(writer_task) = writer_task {
             writer_task
                 .send(move |conn| {
                     merge_note_sql(
@@ -1245,7 +1292,7 @@ impl KhiveRuntime {
         };
 
         if !dry_run && !self.registered_embedding_model_names().is_empty() {
-            self.reindex_note(token, &updated_note).await?;
+            summary.embedding_truncation = self.reindex_note(token, &updated_note).await?;
             // A merge changes the same ANN corpus as update_note's text_changed
             // branch, so fire the same mutation hook regardless of which public
             // write path reached the corpus change.
@@ -1909,6 +1956,7 @@ fn merge_entity_sql(
             tags_unioned,
             content_appended,
             dry_run,
+            embedding_truncation: Default::default(),
         },
         updated_entity,
     ))
@@ -2393,6 +2441,7 @@ fn merge_note_sql(
             tags_unioned: 0,
             content_appended,
             dry_run,
+            embedding_truncation: Default::default(),
         },
         updated_note,
     ))

--- a/crates/khive-runtime/src/lib.rs
+++ b/crates/khive-runtime/src/lib.rs
@@ -36,7 +36,7 @@ pub use khive_storage::usage;
 pub mod validation;
 
 pub use actor_identity::{actor_is_unattributed, resolve_actor, should_warn_unattributed_actor};
-pub use atomic_message::{create_notes_atomic, AtomicNoteSpec};
+pub use atomic_message::{create_notes_atomic, create_notes_atomic_with_report, AtomicNoteSpec};
 pub use atomic_plan::{
     AddEntityPlan, AddNotePlan, AffectedRowGuard, DeletePlan, GovernanceOp, GovernancePlan,
     GtdCompletePlan, GtdTransitionPlan, LinkPlan, MergePlan, PlanPredicate, PlanStatement,

--- a/crates/khive-runtime/src/operations.rs
+++ b/crates/khive-runtime/src/operations.rs
@@ -1075,11 +1075,11 @@ fn recompute_total_weight(path: &mut GraphPath) {
 /// await, so detached completion cannot change the operation's usage count.
 /// Each task owns cloned runtime/provider state and only computes an embedding;
 /// storage writes remain in the parent after this drain succeeds.
-async fn drain_embed_join_set(
-    mut join_set: tokio::task::JoinSet<(usize, RuntimeResult<Vec<f32>>)>,
+async fn drain_embed_join_set<T: Send + 'static>(
+    mut join_set: tokio::task::JoinSet<(usize, RuntimeResult<T>)>,
     model_count: usize,
-) -> RuntimeResult<Vec<Vec<f32>>> {
-    let mut vectors: Vec<Option<Vec<f32>>> = (0..model_count).map(|_| None).collect();
+) -> RuntimeResult<Vec<T>> {
+    let mut vectors: Vec<Option<T>> = (0..model_count).map(|_| None).collect();
 
     while let Some(joined) = join_set.join_next().await {
         match joined {
@@ -1197,6 +1197,31 @@ impl KhiveRuntime {
         properties: Option<serde_json::Value>,
         tags: Vec<String>,
     ) -> RuntimeResult<Entity> {
+        Ok(self
+            .create_entity_with_embedding_report(
+                token,
+                kind,
+                entity_type,
+                name,
+                description,
+                properties,
+                tags,
+            )
+            .await?
+            .0)
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub async fn create_entity_with_embedding_report(
+        &self,
+        token: &NamespaceToken,
+        kind: &str,
+        entity_type: Option<&str>,
+        name: &str,
+        description: Option<&str>,
+        properties: Option<serde_json::Value>,
+        tags: Vec<String>,
+    ) -> RuntimeResult<(Entity, crate::retrieval::EmbeddingTruncationReport)> {
         self.validate_entity_kind(kind)?;
         // Secret gate: scan name, description, structured properties, and tags.
         crate::secret_gate::check(name)?;
@@ -1256,38 +1281,43 @@ impl KhiveRuntime {
             }
         };
 
+        let mut embedding_report = crate::retrieval::EmbeddingTruncationReport::default();
         if embed_model_names.len() == 1 {
             let model_name = &embed_model_names[0];
             let vec_result = self
-                .embed_document_with_model_for_token(token, model_name, &embed_body)
+                .embed_document_with_model_outcome_for_token(token, model_name, &embed_body)
                 .await;
 
             #[cfg(any(test, feature = "fault-injection"))]
             let vec_inject = consume_fault(&VECTOR_FAIL_NS, ns);
             #[cfg(not(any(test, feature = "fault-injection")))]
             let vec_inject = false;
-            let vec_result: RuntimeResult<Vec<f32>> = if vec_inject {
-                Err(RuntimeError::Internal(
-                    "injected vector failure".to_string(),
-                ))
-            } else {
-                vec_result
-            };
+            let vec_result: RuntimeResult<crate::retrieval::DocumentEmbeddingOutcome> =
+                if vec_inject {
+                    Err(RuntimeError::Internal(
+                        "injected vector failure".to_string(),
+                    ))
+                } else {
+                    vec_result
+                };
 
             let single_result: RuntimeResult<()> = match vec_result {
-                Ok(vector) => match self.vectors_for_model(token, model_name) {
-                    Ok(vs) => vs
-                        .insert(
-                            entity.id,
-                            SubstrateKind::Entity,
-                            ns,
-                            "entity.body",
-                            vec![vector],
-                        )
-                        .await
-                        .map_err(RuntimeError::from),
-                    Err(e) => Err(e),
-                },
+                Ok(outcome) => {
+                    embedding_report.observe(&outcome);
+                    match self.vectors_for_model(token, model_name) {
+                        Ok(vs) => vs
+                            .insert(
+                                entity.id,
+                                SubstrateKind::Entity,
+                                ns,
+                                "entity.body",
+                                vec![outcome.vector],
+                            )
+                            .await
+                            .map_err(RuntimeError::from),
+                        Err(e) => Err(e),
+                    }
+                }
                 Err(e) => Err(e),
             };
             if let Err(e) = single_result {
@@ -1315,7 +1345,7 @@ impl KhiveRuntime {
                 let ctx = usage_ctx.clone();
                 let token = (*token).clone();
                 join_set.spawn(async move {
-                    let fut = rt.embed_document_with_model_for_token(&token, &name, &text);
+                    let fut = rt.embed_document_with_model_outcome_for_token(&token, &name, &text);
                     let result = match ctx {
                         Some(ctx) => crate::usage::scope(ctx, fut).await,
                         None => fut.await,
@@ -1326,8 +1356,8 @@ impl KhiveRuntime {
             // The first failed or panicked handle aborts and detaches its
             // siblings. Embed usage is counted at dispatch, so a synchronous
             // provider winding down in the background cannot change it.
-            let vectors = match drain_embed_join_set(join_set, embed_model_names.len()).await {
-                Ok(vectors) => vectors,
+            let outcomes = match drain_embed_join_set(join_set, embed_model_names.len()).await {
+                Ok(outcomes) => outcomes,
                 Err(e) => {
                     let cleanup_errors = self
                         .compensate_entity_create(token, entity.id, ns, &[])
@@ -1337,7 +1367,8 @@ impl KhiveRuntime {
             };
             // TODO(P2): parallelize vector inserts
             let mut inserted_models: Vec<String> = Vec::with_capacity(embed_model_names.len());
-            for (model_name, vector) in embed_model_names.iter().zip(vectors) {
+            for (model_name, outcome) in embed_model_names.iter().zip(outcomes) {
+                embedding_report.observe(&outcome);
                 // Count-targetable fault injection for multi-model insert path.
                 #[cfg(any(test, feature = "fault-injection"))]
                 let count_inject = VECTOR_FAIL_AFTER.with(|cell| match cell.get() {
@@ -1366,7 +1397,7 @@ impl KhiveRuntime {
                                 SubstrateKind::Entity,
                                 ns,
                                 "entity.body",
-                                vec![vector],
+                                vec![outcome.vector],
                             )
                             .await
                             .map_err(RuntimeError::from),
@@ -1387,7 +1418,7 @@ impl KhiveRuntime {
             }
         }
 
-        Ok(entity)
+        Ok((entity, embedding_report))
     }
 
     /// Retrieve an entity by ID.
@@ -2802,10 +2833,12 @@ impl KhiveRuntime {
         properties: Option<serde_json::Value>,
         annotates: Vec<Uuid>,
     ) -> RuntimeResult<Note> {
-        self.create_note_inner(
-            token, kind, name, content, None, salience, None, properties, annotates, None,
-        )
-        .await
+        Ok(self
+            .create_note_inner(
+                token, kind, name, content, None, salience, None, properties, annotates, None,
+            )
+            .await?
+            .0)
     }
 
     /// Like [`Self::create_note`], but lets the caller supply a smaller text
@@ -2830,6 +2863,35 @@ impl KhiveRuntime {
         properties: Option<serde_json::Value>,
         annotates: Vec<Uuid>,
     ) -> RuntimeResult<Note> {
+        Ok(self
+            .create_note_inner(
+                token,
+                kind,
+                name,
+                content,
+                embedding_content,
+                salience,
+                None,
+                properties,
+                annotates,
+                None,
+            )
+            .await?
+            .0)
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub async fn create_note_with_embedding_content_and_report(
+        &self,
+        token: &NamespaceToken,
+        kind: &str,
+        name: Option<&str>,
+        content: &str,
+        embedding_content: Option<&str>,
+        salience: Option<f64>,
+        properties: Option<serde_json::Value>,
+        annotates: Vec<Uuid>,
+    ) -> RuntimeResult<(Note, crate::retrieval::EmbeddingTruncationReport)> {
         self.create_note_inner(
             token,
             kind,
@@ -2891,19 +2953,21 @@ impl KhiveRuntime {
         annotates: Vec<Uuid>,
         embedding_model: Option<&str>,
     ) -> RuntimeResult<Note> {
-        self.create_note_inner(
-            token,
-            kind,
-            name,
-            content,
-            None,
-            salience,
-            Some(decay_factor),
-            properties,
-            annotates,
-            embedding_model,
-        )
-        .await
+        Ok(self
+            .create_note_inner(
+                token,
+                kind,
+                name,
+                content,
+                None,
+                salience,
+                Some(decay_factor),
+                properties,
+                annotates,
+                embedding_model,
+            )
+            .await?
+            .0)
     }
 
     /// Insert a note using `INSERT OR IGNORE` semantics for atomic deduplication.
@@ -2964,10 +3028,23 @@ impl KhiveRuntime {
         let embed_model_names = self.registered_embedding_model_names();
         for model_name in &embed_model_names {
             match self
-                .embed_document_with_model_for_token(token, model_name, &note_embedding_text(&note))
+                .embed_document_with_model_outcome_for_token(
+                    token,
+                    model_name,
+                    &note_embedding_text(&note),
+                )
                 .await
             {
-                Ok(vector) => {
+                Ok(outcome) => {
+                    if outcome.truncated {
+                        tracing::warn!(
+                            note_id = %note.id,
+                            model = %outcome.model_name,
+                            source_bytes = outcome.source_bytes,
+                            embedded_bytes = outcome.embedded_bytes,
+                            "try_create_note: embedding input truncated; full content stored unchanged"
+                        );
+                    }
                     if let Ok(vs) = self.vectors_for_model(token, model_name) {
                         if let Err(e) = vs
                             .insert(
@@ -2975,7 +3052,7 @@ impl KhiveRuntime {
                                 SubstrateKind::Note,
                                 ns,
                                 "note.content",
-                                vec![vector],
+                                vec![outcome.vector],
                             )
                             .await
                         {
@@ -3018,7 +3095,7 @@ impl KhiveRuntime {
         properties: Option<serde_json::Value>,
         annotates: Vec<Uuid>,
         embedding_model: Option<&str>,
-    ) -> RuntimeResult<Note> {
+    ) -> RuntimeResult<(Note, crate::retrieval::EmbeddingTruncationReport)> {
         self.validate_note_kind(kind)?;
         // Secret gate: scan content, optional name, and structured properties.
         crate::secret_gate::check(content)?;
@@ -3163,11 +3240,12 @@ impl KhiveRuntime {
         let canonical_embed_text = note_embedding_text(&note);
         let embed_text: &str = embedding_content.unwrap_or(&canonical_embed_text);
 
+        let mut embedding_report = crate::retrieval::EmbeddingTruncationReport::default();
         if embed_model_names.len() == 1 {
             // Single-model path: preserves original sequential behaviour.
             let model_name = &embed_model_names[0];
             let vec_result = self
-                .embed_document_with_model_for_token(token, model_name, embed_text)
+                .embed_document_with_model_outcome_for_token(token, model_name, embed_text)
                 .await;
 
             // Injection: check VECTOR_FAIL_NS (armed by `arm_vector_fail_scoped(ns)`) or
@@ -3197,28 +3275,32 @@ impl KhiveRuntime {
             };
             #[cfg(not(any(test, feature = "fault-injection")))]
             let vec_inject = false;
-            let vec_result: RuntimeResult<Vec<f32>> = if vec_inject {
-                Err(RuntimeError::Internal(
-                    "injected vector failure".to_string(),
-                ))
-            } else {
-                vec_result
-            };
+            let vec_result: RuntimeResult<crate::retrieval::DocumentEmbeddingOutcome> =
+                if vec_inject {
+                    Err(RuntimeError::Internal(
+                        "injected vector failure".to_string(),
+                    ))
+                } else {
+                    vec_result
+                };
 
             let single_model_result: RuntimeResult<()> = match vec_result {
-                Ok(vector) => match self.vectors_for_model(token, model_name) {
-                    Ok(vs) => vs
-                        .insert(
-                            note.id,
-                            SubstrateKind::Note,
-                            ns,
-                            "note.content",
-                            vec![vector],
-                        )
-                        .await
-                        .map_err(RuntimeError::from),
-                    Err(e) => Err(e),
-                },
+                Ok(outcome) => {
+                    embedding_report.observe(&outcome);
+                    match self.vectors_for_model(token, model_name) {
+                        Ok(vs) => vs
+                            .insert(
+                                note.id,
+                                SubstrateKind::Note,
+                                ns,
+                                "note.content",
+                                vec![outcome.vector],
+                            )
+                            .await
+                            .map_err(RuntimeError::from),
+                        Err(e) => Err(e),
+                    }
+                }
                 Err(e) => Err(e),
             };
             if let Err(e) = single_model_result {
@@ -3245,7 +3327,7 @@ impl KhiveRuntime {
                 let ctx = usage_ctx.clone();
                 let token = (*token).clone();
                 join_set.spawn(async move {
-                    let fut = rt.embed_document_with_model_for_token(&token, &name, &text);
+                    let fut = rt.embed_document_with_model_outcome_for_token(&token, &name, &text);
                     let result = match ctx {
                         Some(ctx) => crate::usage::scope(ctx, fut).await,
                         None => fut.await,
@@ -3256,8 +3338,8 @@ impl KhiveRuntime {
             // The first failed or panicked handle aborts and detaches its
             // siblings. Embed usage is counted at dispatch, so a synchronous
             // provider winding down in the background cannot change it.
-            let vectors = match drain_embed_join_set(join_set, embed_model_names.len()).await {
-                Ok(vectors) => vectors,
+            let outcomes = match drain_embed_join_set(join_set, embed_model_names.len()).await {
+                Ok(outcomes) => outcomes,
                 Err(e) => {
                     // Compensate note row + FTS (no vectors inserted yet).
                     if let Ok(store) = self.notes(token) {
@@ -3271,7 +3353,8 @@ impl KhiveRuntime {
             };
             // TODO(P2): parallelize vector inserts
             let mut inserted_models: Vec<String> = Vec::with_capacity(embed_model_names.len());
-            for (model_name, vector) in embed_model_names.iter().zip(vectors) {
+            for (model_name, outcome) in embed_model_names.iter().zip(outcomes) {
+                embedding_report.observe(&outcome);
                 let insert_result = match self.vectors_for_model(token, model_name) {
                     Ok(vs) => vs
                         .insert(
@@ -3279,7 +3362,7 @@ impl KhiveRuntime {
                             SubstrateKind::Note,
                             ns,
                             "note.content",
-                            vec![vector],
+                            vec![outcome.vector],
                         )
                         .await
                         .map_err(RuntimeError::from),
@@ -3391,7 +3474,7 @@ impl KhiveRuntime {
             }
         }
 
-        Ok(note)
+        Ok((note, embedding_report))
     }
 
     /// List notes visible to the token, optionally filtered by kind.
@@ -5532,7 +5615,7 @@ mod tests {
     use crate::{ActorRef, Namespace};
     use async_trait::async_trait;
     use khive_storage::types::PathNode;
-    use lattice_embed::{EmbedError, EmbeddingModel, EmbeddingService};
+    use lattice_embed::{EmbedError, EmbeddingModel, EmbeddingService, MAX_TEXT_CHARS};
     use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
     use std::sync::Arc;
 
@@ -14857,6 +14940,14 @@ mod tests {
             texts: &[String],
             _model: EmbeddingModel,
         ) -> std::result::Result<Vec<Vec<f32>>, EmbedError> {
+            for text in texts {
+                if text.len() > MAX_TEXT_CHARS {
+                    return Err(EmbedError::TextTooLong {
+                        length: text.len(),
+                        max: MAX_TEXT_CHARS,
+                    });
+                }
+            }
             self.captured.lock().unwrap().extend(texts.iter().cloned());
             Ok(texts.iter().map(|_| vec![1.0_f32; self.dims]).collect())
         }
@@ -14892,6 +14983,78 @@ mod tests {
                 captured: Arc::clone(&self.captured),
             }))
         }
+    }
+
+    #[tokio::test]
+    async fn create_bounds_embedding_input_without_truncating_stored_content() {
+        let rt = rt();
+        let tok = NamespaceToken::local();
+        let captured = Arc::new(std::sync::Mutex::new(Vec::new()));
+        rt.register_embedder(CapturingVecProvider {
+            provider_name: "strict-length-test".into(),
+            dims: 4,
+            captured: Arc::clone(&captured),
+        });
+
+        let content = format!("{}\u{1f980}tail", "a".repeat(MAX_TEXT_CHARS - 1));
+        let note = rt
+            .create_note(&tok, "observation", None, &content, None, None, vec![])
+            .await
+            .expect("over-length note create must succeed");
+        let fetched = rt
+            .notes(&tok)
+            .unwrap()
+            .get_note(note.id)
+            .await
+            .unwrap()
+            .expect("created note must be retrievable");
+        assert_eq!(fetched.content, content, "stored content must remain full");
+
+        let embedded = captured.lock().unwrap().clone();
+        assert_eq!(embedded.len(), 1);
+        assert_eq!(embedded[0].len(), MAX_TEXT_CHARS - 1);
+        assert!(embedded[0].is_char_boundary(embedded[0].len()));
+        assert!(!embedded[0].contains('\u{1f980}'));
+
+        let vector_info = rt
+            .vectors_for_model(&tok, "strict-length-test")
+            .expect("vector store")
+            .info()
+            .await
+            .expect("vector info");
+        assert_eq!(vector_info.dimensions, 4);
+        assert_eq!(vector_info.entry_count, 1);
+
+        captured.lock().unwrap().clear();
+        rt.reindex_note(&tok, &fetched)
+            .await
+            .expect("reindex must bound the same stored content");
+        assert_eq!(captured.lock().unwrap()[0].len(), MAX_TEXT_CHARS - 1);
+
+        captured.lock().unwrap().clear();
+        rt.embed_document_batch_with_model("strict-length-test", std::slice::from_ref(&content))
+            .await
+            .expect("batch reindex seam must bound stored content");
+        assert_eq!(captured.lock().unwrap()[0].len(), MAX_TEXT_CHARS - 1);
+
+        let normal = "normal byte-identical embedding input";
+        rt.create_note(&tok, "observation", None, normal, None, None, vec![])
+            .await
+            .expect("normal note create must succeed");
+        assert_eq!(captured.lock().unwrap().last().unwrap(), normal);
+
+        let long_description = format!("{}\u{1f980}tail", "b".repeat(MAX_TEXT_CHARS));
+        rt.create_entity(
+            &tok,
+            "concept",
+            None,
+            "entity",
+            Some(&long_description),
+            None,
+            vec![],
+        )
+        .await
+        .expect("over-length entity create must succeed");
     }
 
     #[tokio::test]

--- a/crates/khive-runtime/src/portability.rs
+++ b/crates/khive-runtime/src/portability.rs
@@ -78,6 +78,10 @@ pub struct ImportSummary {
     /// A non-zero value indicates the archive contained dangling edges (edges
     /// referencing entities not present in the archive or the existing graph).
     pub edges_skipped: usize,
+    /// Aggregate actual outcomes from reindexing imported entities. Source
+    /// text remains complete in the entity store and FTS when this is non-zero.
+    #[serde(default)]
+    pub embedding_truncation: crate::retrieval::EmbeddingTruncationReport,
 }
 
 // ── KhiveRuntime impl ─────────────────────────────────────────────────────────
@@ -206,6 +210,7 @@ impl KhiveRuntime {
 
         let store = self.entities(token)?;
         let mut entities_imported = 0usize;
+        let mut embedding_truncation = crate::retrieval::EmbeddingTruncationReport::default();
         for ee in &archive.entities {
             self.validate_entity_kind(&ee.kind)?;
             let created_micros = ee.created_at.timestamp_micros();
@@ -228,7 +233,7 @@ impl KhiveRuntime {
             };
             store.upsert_entity(entity.clone()).await?;
             // Reindex so imported entities are searchable via hybrid_search immediately.
-            self.reindex_entity(token, &entity).await?;
+            embedding_truncation.merge(self.reindex_entity(token, &entity).await?);
             entities_imported += 1;
         }
 
@@ -314,6 +319,7 @@ impl KhiveRuntime {
             entities_imported,
             edges_imported,
             edges_skipped,
+            embedding_truncation,
         })
     }
 
@@ -335,13 +341,99 @@ impl KhiveRuntime {
 // helpers that would otherwise need to be made pub to test from tests/.
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+
     use super::*;
     use crate::runtime::{KhiveRuntime, NamespaceToken};
-    use crate::Namespace;
+    use crate::{EmbedderProvider, Namespace};
+    use async_trait::async_trait;
     use khive_storage::EdgeRelation;
+    use lattice_embed::{EmbedError, EmbeddingModel, EmbeddingService, MAX_TEXT_CHARS};
+
+    const IMPORT_TEST_MODEL: &str = "all-minilm-l6-v2";
+
+    struct ImportEmbeddingService;
+
+    #[async_trait]
+    impl EmbeddingService for ImportEmbeddingService {
+        async fn embed(
+            &self,
+            texts: &[String],
+            _model: EmbeddingModel,
+        ) -> std::result::Result<Vec<Vec<f32>>, EmbedError> {
+            let dimensions = EmbeddingModel::AllMiniLmL6V2.dimensions();
+            Ok(texts.iter().map(|_| vec![1.0; dimensions]).collect())
+        }
+
+        fn supports_model(&self, _model: EmbeddingModel) -> bool {
+            true
+        }
+
+        fn name(&self) -> &'static str {
+            "kg-import-truncation-test"
+        }
+    }
+
+    struct ImportEmbeddingProvider;
+
+    #[async_trait]
+    impl EmbedderProvider for ImportEmbeddingProvider {
+        fn name(&self) -> &str {
+            IMPORT_TEST_MODEL
+        }
+
+        fn dimensions(&self) -> usize {
+            EmbeddingModel::AllMiniLmL6V2.dimensions()
+        }
+
+        async fn build(&self) -> std::result::Result<Arc<dyn EmbeddingService>, RuntimeError> {
+            Ok(Arc::new(ImportEmbeddingService))
+        }
+    }
 
     async fn make_rt() -> KhiveRuntime {
         KhiveRuntime::memory().expect("in-memory runtime")
+    }
+
+    fn make_rt_with_embedder() -> KhiveRuntime {
+        let runtime = KhiveRuntime::memory().expect("in-memory runtime");
+        runtime.register_embedder(ImportEmbeddingProvider);
+        runtime
+    }
+
+    #[tokio::test]
+    async fn import_summary_reports_actual_embedding_truncation() {
+        let runtime = make_rt_with_embedder();
+        let token = NamespaceToken::local();
+        let archive = KgArchive {
+            format: "khive-kg".to_string(),
+            version: "0.1".to_string(),
+            namespace: "local".to_string(),
+            exported_at: Utc::now(),
+            entities: vec![ExportedEntity {
+                id: Uuid::new_v4(),
+                kind: "concept".to_string(),
+                entity_type: None,
+                name: "Imported long entity".to_string(),
+                description: Some("x".repeat(MAX_TEXT_CHARS + 1)),
+                properties: None,
+                tags: vec![],
+                created_at: Utc::now(),
+                updated_at: Utc::now(),
+            }],
+            edges: vec![],
+        };
+
+        let summary = runtime
+            .import_kg(&archive, &token)
+            .await
+            .expect("import with bounded embedding input");
+
+        assert_eq!(summary.entities_imported, 1);
+        assert_eq!(summary.embedding_truncation.truncated, 1);
+        assert!(summary.embedding_truncation.discarded_bytes > 0);
+        let wire = serde_json::to_value(&summary).expect("serialize import summary");
+        assert_eq!(wire["embedding_truncation"]["truncated"], 1);
     }
 
     /// 1. Roundtrip: 3 entities + 2 edges survive export → import on a fresh runtime.

--- a/crates/khive-runtime/src/retrieval.rs
+++ b/crates/khive-runtime/src/retrieval.rs
@@ -2,7 +2,7 @@
 
 use std::collections::{HashMap, HashSet};
 
-use lattice_embed::EmbeddingModel;
+use lattice_embed::{EmbeddingModel, MAX_TEXT_CHARS};
 use uuid::Uuid;
 
 use crate::config::{parse_embedding_model_alias, sanitize_key};
@@ -84,6 +84,72 @@ const RRF_K: usize = 10;
 /// Candidates pulled per path before fusion. Higher = better recall, more work.
 const CANDIDATE_MULTIPLIER: u32 = 4;
 
+/// Advisory emitted by write verbs when only the embedding input was bounded.
+pub const EMBEDDING_INPUT_TRUNCATED_WARNING: &str =
+    "embedding input was truncated to the embedder maximum; full content was stored unchanged";
+
+/// What the embedding service actually received for one document.
+#[derive(Clone, Debug)]
+pub struct DocumentEmbeddingOutcome {
+    pub model_name: String,
+    pub vector: Vec<f32>,
+    pub source_bytes: usize,
+    pub embedded_bytes: usize,
+    pub truncated: bool,
+}
+
+/// Aggregate truncation accounting for one logical write or reindex batch.
+#[derive(Clone, Debug, Default, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
+pub struct EmbeddingTruncationReport {
+    pub truncated: u64,
+    pub discarded_bytes: u64,
+}
+
+impl EmbeddingTruncationReport {
+    pub fn observe(&mut self, outcome: &DocumentEmbeddingOutcome) {
+        if outcome.truncated {
+            self.truncated += 1;
+            self.discarded_bytes +=
+                outcome.source_bytes.saturating_sub(outcome.embedded_bytes) as u64;
+        }
+    }
+
+    #[must_use]
+    pub const fn any_truncated(&self) -> bool {
+        self.truncated > 0
+    }
+
+    /// Add another batch's counters without wrapping on overflow.
+    pub fn merge(&mut self, other: Self) {
+        self.truncated = self.truncated.saturating_add(other.truncated);
+        self.discarded_bytes = self.discarded_bytes.saturating_add(other.discarded_bytes);
+    }
+}
+
+/// Maximum document bytes accepted before the embedding service adds its model prefix.
+pub fn document_embedding_budget(model_name: &str) -> usize {
+    parse_embedding_model_alias(model_name)
+        .and_then(|model| model.document_instruction())
+        .map_or(MAX_TEXT_CHARS, |prefix| {
+            MAX_TEXT_CHARS.saturating_sub(prefix.len())
+        })
+}
+
+/// Return the longest UTF-8-safe prefix of `text` within `max_bytes` and whether it was shortened.
+pub fn bounded_embedding_input(text: &str, max_bytes: usize) -> (&str, bool) {
+    if text.len() <= max_bytes {
+        return (text, false);
+    }
+
+    let end = text
+        .char_indices()
+        .map(|(index, _)| index)
+        .take_while(|index| *index <= max_bytes)
+        .last()
+        .unwrap_or(0);
+    (&text[..end], true)
+}
+
 impl KhiveRuntime {
     /// Generate an embedding vector for `text` using the configured default model.
     ///
@@ -147,32 +213,47 @@ impl KhiveRuntime {
         model_name: &str,
         text: &str,
     ) -> RuntimeResult<Vec<f32>> {
-        self.embed_document_with_model_inner(None, model_name, text)
+        Ok(self
+            .embed_document_with_model_outcome_inner(None, model_name, text)
+            .await?
+            .vector)
+    }
+
+    pub async fn embed_document_with_model_outcome(
+        &self,
+        model_name: &str,
+        text: &str,
+    ) -> RuntimeResult<DocumentEmbeddingOutcome> {
+        self.embed_document_with_model_outcome_inner(None, model_name, text)
             .await
     }
 
-    pub(crate) async fn embed_document_with_model_for_token(
+    pub(crate) async fn embed_document_with_model_outcome_for_token(
         &self,
         token: &NamespaceToken,
         model_name: &str,
         text: &str,
-    ) -> RuntimeResult<Vec<f32>> {
-        self.embed_document_with_model_inner(Some(token), model_name, text)
+    ) -> RuntimeResult<DocumentEmbeddingOutcome> {
+        self.embed_document_with_model_outcome_inner(Some(token), model_name, text)
             .await
     }
 
-    async fn embed_document_with_model_inner(
+    async fn embed_document_with_model_outcome_inner(
         &self,
         token: Option<&NamespaceToken>,
         model_name: &str,
         text: &str,
-    ) -> RuntimeResult<Vec<f32>> {
+    ) -> RuntimeResult<DocumentEmbeddingOutcome> {
         let model = parse_embedding_model_alias(model_name);
         let service = match token {
             Some(token) => self.embedder_with_token(token, model_name).await?,
             None => self.embedder(model_name).await?,
         };
         let emb_model = model.unwrap_or_default();
+        let source_bytes = text.len();
+        let (text, truncated) =
+            bounded_embedding_input(text, document_embedding_budget(model_name));
+        let embedded_bytes = text.len();
         // Issued-at-dispatch: counted before the await — see embed_with_model.
         crate::usage::count(crate::usage::UsageUnit::EmbedCalls, 1);
         let embeddings = service.embed_passage(&[text.to_string()], emb_model).await;
@@ -180,7 +261,13 @@ impl KhiveRuntime {
             .into_iter()
             .next()
             .ok_or_else(|| RuntimeError::Internal("embed_passage returned empty vec".into()))?;
-        Ok(out)
+        Ok(DocumentEmbeddingOutcome {
+            model_name: model_name.to_owned(),
+            vector: out,
+            source_bytes,
+            embedded_bytes,
+            truncated,
+        })
     }
 
     /// Embed a query string for retrieval using the named model.
@@ -324,6 +411,8 @@ impl KhiveRuntime {
     ///
     /// Applies `EmbeddingService::embed_passage`. Use for all bulk
     /// index/backfill/reindex operations to apply the passage-side prefix.
+    /// A mixed batch is bounded into one ordered owned batch so truncation never
+    /// fragments one provider batch into sequential singleton inference calls.
     ///
     /// **Reindex caveat**: see [`Self::embed_document_with_model`] — the same
     /// incomparability applies to batch-indexed vectors when switching models.
@@ -337,12 +426,58 @@ impl KhiveRuntime {
         if texts.is_empty() {
             return Ok(vec![]);
         }
+        Ok(self
+            .embed_document_batch_with_model_outcomes(model_name, texts)
+            .await?
+            .into_iter()
+            .map(|outcome| outcome.vector)
+            .collect())
+    }
+
+    pub async fn embed_document_batch_with_model_outcomes(
+        &self,
+        model_name: &str,
+        texts: &[String],
+    ) -> RuntimeResult<Vec<DocumentEmbeddingOutcome>> {
+        if texts.is_empty() {
+            return Ok(vec![]);
+        }
         let model = parse_embedding_model_alias(model_name);
         let service = self.embedder(model_name).await?;
         let emb_model = model.unwrap_or_default();
-        let out = service.embed_passage(texts, emb_model).await;
+        let budget = document_embedding_budget(model_name);
+        let out = if texts.iter().all(|text| text.len() <= budget) {
+            service.embed_passage(texts, emb_model).await
+        } else {
+            let bounded_texts: Vec<String> = texts
+                .iter()
+                .map(|text| bounded_embedding_input(text, budget).0.to_owned())
+                .collect();
+            service.embed_passage(&bounded_texts, emb_model).await
+        };
         crate::usage::count(crate::usage::UsageUnit::EmbedCalls, texts.len() as u64);
-        Ok(out?)
+        let vectors = out?;
+        if vectors.len() != texts.len() {
+            return Err(RuntimeError::Internal(format!(
+                "embed_passage returned {} vectors for {} inputs",
+                vectors.len(),
+                texts.len()
+            )));
+        }
+        Ok(texts
+            .iter()
+            .zip(vectors)
+            .map(|(text, vector)| {
+                let (bounded, truncated) = bounded_embedding_input(text, budget);
+                DocumentEmbeddingOutcome {
+                    model_name: model_name.to_owned(),
+                    vector,
+                    source_bytes: text.len(),
+                    embedded_bytes: bounded.len(),
+                    truncated,
+                }
+            })
+            .collect())
     }
 
     /// Embed a batch of documents for indexing using the configured default model.
@@ -360,6 +495,22 @@ impl KhiveRuntime {
             return Err(RuntimeError::Unconfigured("embedding_model".into()));
         }
         self.embed_document_batch_with_model(model_name, texts)
+            .await
+    }
+
+    /// Embed documents with the default model and retain actual input-bounding metadata.
+    pub async fn embed_document_batch_outcomes(
+        &self,
+        texts: &[String],
+    ) -> RuntimeResult<Vec<DocumentEmbeddingOutcome>> {
+        if texts.is_empty() {
+            return Ok(vec![]);
+        }
+        let model_name = self.default_embedder_name();
+        if model_name.is_empty() {
+            return Err(RuntimeError::Unconfigured("embedding_model".into()));
+        }
+        self.embed_document_batch_with_model_outcomes(model_name, texts)
             .await
     }
 
@@ -753,6 +904,7 @@ impl KhiveRuntime {
         let mut total_backfilled = 0u64;
 
         for model_name in &model_names {
+            let mut model_truncation = EmbeddingTruncationReport::default();
             // Must match vec_model_key's naming logic.
             let vec_table = format!("vec_{}", sanitize_key(model_name));
 
@@ -830,10 +982,11 @@ impl KhiveRuntime {
                     }
 
                     match self
-                        .embed_document_with_model_for_token(token, model_name, &desc)
+                        .embed_document_with_model_outcome_for_token(token, model_name, &desc)
                         .await
                     {
-                        Ok(vector) => {
+                        Ok(outcome) => {
+                            model_truncation.observe(&outcome);
                             if let Ok(vs) = self.vectors_for_model(token, model_name) {
                                 match vs
                                     .insert(
@@ -841,7 +994,7 @@ impl KhiveRuntime {
                                         SubstrateKind::Entity,
                                         &ns,
                                         "entity.description",
-                                        vec![vector],
+                                        vec![outcome.vector],
                                     )
                                     .await
                                 {
@@ -960,10 +1113,11 @@ impl KhiveRuntime {
 
                     let content = note.content.clone();
                     match self
-                        .embed_document_with_model_for_token(token, model_name, &content)
+                        .embed_document_with_model_outcome_for_token(token, model_name, &content)
                         .await
                     {
-                        Ok(vector) => {
+                        Ok(outcome) => {
+                            model_truncation.observe(&outcome);
                             if let Ok(vs) = self.vectors_for_model(token, model_name) {
                                 match vs
                                     .insert(
@@ -971,7 +1125,7 @@ impl KhiveRuntime {
                                         SubstrateKind::Note,
                                         &ns,
                                         "note.content",
-                                        vec![vector],
+                                        vec![outcome.vector],
                                     )
                                     .await
                                 {
@@ -1008,6 +1162,8 @@ impl KhiveRuntime {
                 namespace = %ns,
                 entities = entity_total,
                 notes = note_total,
+                truncated = model_truncation.truncated,
+                discarded_bytes = model_truncation.discarded_bytes,
                 "backfill_missing_embeddings: model pass complete"
             );
         }
@@ -1236,6 +1392,30 @@ mod tests {
     use khive_storage::types::{TextSearchHit, VectorSearchHit};
     use khive_types::namespace::Namespace;
     use lattice_embed::EmbeddingModel;
+
+    #[test]
+    fn bounded_embedding_input_reserves_prefix_and_preserves_utf8() {
+        assert_eq!(
+            document_embedding_budget("multilingual-e5-base"),
+            MAX_TEXT_CHARS - "passage: ".len()
+        );
+
+        let input = format!("{}\u{1f980}tail", "a".repeat(MAX_TEXT_CHARS - 1));
+        let (bounded, truncated) = bounded_embedding_input(&input, MAX_TEXT_CHARS);
+        assert!(truncated);
+        assert_eq!(bounded.len(), MAX_TEXT_CHARS - 1);
+        assert!(bounded.is_char_boundary(bounded.len()));
+        assert!(!bounded.contains('\u{1f980}'));
+    }
+
+    #[test]
+    fn bounded_embedding_input_leaves_normal_text_unchanged() {
+        let input = "normal byte-identical embedding input";
+        let (bounded, truncated) = bounded_embedding_input(input, MAX_TEXT_CHARS);
+        assert!(!truncated);
+        assert_eq!(bounded, input);
+        assert_eq!(bounded.as_ptr(), input.as_ptr());
+    }
 
     fn text_hit(id: Uuid, rank: u32, title: &str) -> TextSearchHit {
         TextSearchHit {
@@ -1821,6 +2001,48 @@ mod tests {
         captured: std::sync::Arc<std::sync::Mutex<Vec<Vec<String>>>>,
     }
 
+    struct WrongCardinalityEmbeddingService;
+
+    #[async_trait::async_trait]
+    impl EmbeddingService for WrongCardinalityEmbeddingService {
+        async fn embed(
+            &self,
+            texts: &[String],
+            _model: EmbeddingModel,
+        ) -> std::result::Result<Vec<Vec<f32>>, lattice_embed::EmbedError> {
+            Ok(texts
+                .iter()
+                .take(texts.len().saturating_sub(1))
+                .map(|_| vec![1.0])
+                .collect())
+        }
+
+        fn supports_model(&self, _model: EmbeddingModel) -> bool {
+            true
+        }
+
+        fn name(&self) -> &'static str {
+            "wrong-cardinality-embedding-service"
+        }
+    }
+
+    struct WrongCardinalityEmbedderProvider;
+
+    #[async_trait::async_trait]
+    impl EmbedderProvider for WrongCardinalityEmbedderProvider {
+        fn name(&self) -> &str {
+            "wrong-cardinality-embedding-service"
+        }
+
+        fn dimensions(&self) -> usize {
+            1
+        }
+
+        async fn build(&self) -> crate::error::RuntimeResult<std::sync::Arc<dyn EmbeddingService>> {
+            Ok(std::sync::Arc::new(WrongCardinalityEmbeddingService))
+        }
+    }
+
     #[async_trait::async_trait]
     impl EmbedderProvider for CapturingEmbedderProvider {
         fn name(&self) -> &str {
@@ -1923,6 +2145,57 @@ mod tests {
                 ],
             ],
             "E5 must receive its query prefix through single and batch paths"
+        );
+    }
+
+    #[tokio::test]
+    async fn mixed_document_batch_stays_one_ordered_provider_call() {
+        let model = EmbeddingModel::AllMiniLmL6V2;
+        let (runtime, captured) = runtime_with_capturing_embedder(model);
+        let texts = vec![
+            "first normal document".to_string(),
+            "x".repeat(MAX_TEXT_CHARS + 1),
+            "second normal document".to_string(),
+        ];
+
+        let outcomes = runtime
+            .embed_document_batch_with_model_outcomes(&model.to_string(), &texts)
+            .await
+            .expect("mixed batch must embed");
+        assert_eq!(outcomes.len(), texts.len());
+        assert!(!outcomes[0].truncated);
+        assert_eq!(outcomes[0].source_bytes, outcomes[0].embedded_bytes);
+        assert!(outcomes[1].truncated);
+        assert_eq!(outcomes[1].source_bytes, MAX_TEXT_CHARS + 1);
+        assert_eq!(outcomes[1].embedded_bytes, MAX_TEXT_CHARS);
+        assert!(!outcomes[2].truncated);
+        assert_eq!(
+            captured.lock().unwrap().as_slice(),
+            [vec![
+                texts[0].clone(),
+                "x".repeat(MAX_TEXT_CHARS),
+                texts[2].clone(),
+            ]]
+        );
+    }
+
+    #[tokio::test]
+    async fn truncated_document_batch_rejects_provider_cardinality_mismatch() {
+        let runtime = KhiveRuntime::memory().unwrap();
+        runtime.register_embedder(WrongCardinalityEmbedderProvider);
+        let model_name = "wrong-cardinality-embedding-service";
+        let texts = vec!["x".repeat(MAX_TEXT_CHARS + 1), "normal".to_string()];
+
+        let error = runtime
+            .embed_document_batch_with_model_outcomes(model_name, &texts)
+            .await
+            .expect_err("provider cardinality mismatch must fail the whole batch");
+
+        assert!(
+            error
+                .to_string()
+                .contains("embed_passage returned 1 vectors for 2 inputs"),
+            "unexpected error: {error}"
         );
     }
 

--- a/crates/khive-runtime/src/retrieval.rs
+++ b/crates/khive-runtime/src/retrieval.rs
@@ -257,10 +257,14 @@ impl KhiveRuntime {
         // Issued-at-dispatch: counted before the await — see embed_with_model.
         crate::usage::count(crate::usage::UsageUnit::EmbedCalls, 1);
         let embeddings = service.embed_passage(&[text.to_string()], emb_model).await;
-        let out = embeddings?
-            .into_iter()
-            .next()
-            .ok_or_else(|| RuntimeError::Internal("embed_passage returned empty vec".into()))?;
+        let mut vectors = embeddings?;
+        if vectors.len() != 1 {
+            return Err(RuntimeError::Internal(format!(
+                "embed_passage returned {} vectors for 1 input",
+                vectors.len()
+            )));
+        }
+        let out = vectors.pop().expect("checked len == 1 above");
         Ok(DocumentEmbeddingOutcome {
             model_name: model_name.to_owned(),
             vector: out,
@@ -2043,6 +2047,46 @@ mod tests {
         }
     }
 
+    struct SurplusCardinalityEmbeddingService;
+
+    #[async_trait::async_trait]
+    impl EmbeddingService for SurplusCardinalityEmbeddingService {
+        async fn embed(
+            &self,
+            texts: &[String],
+            _model: EmbeddingModel,
+        ) -> std::result::Result<Vec<Vec<f32>>, lattice_embed::EmbedError> {
+            let mut vectors: Vec<Vec<f32>> = texts.iter().map(|_| vec![1.0]).collect();
+            vectors.push(vec![1.0]);
+            Ok(vectors)
+        }
+
+        fn supports_model(&self, _model: EmbeddingModel) -> bool {
+            true
+        }
+
+        fn name(&self) -> &'static str {
+            "surplus-cardinality-embedding-service"
+        }
+    }
+
+    struct SurplusCardinalityEmbedderProvider;
+
+    #[async_trait::async_trait]
+    impl EmbedderProvider for SurplusCardinalityEmbedderProvider {
+        fn name(&self) -> &str {
+            "surplus-cardinality-embedding-service"
+        }
+
+        fn dimensions(&self) -> usize {
+            1
+        }
+
+        async fn build(&self) -> crate::error::RuntimeResult<std::sync::Arc<dyn EmbeddingService>> {
+            Ok(std::sync::Arc::new(SurplusCardinalityEmbeddingService))
+        }
+    }
+
     #[async_trait::async_trait]
     impl EmbedderProvider for CapturingEmbedderProvider {
         fn name(&self) -> &str {
@@ -2195,6 +2239,44 @@ mod tests {
             error
                 .to_string()
                 .contains("embed_passage returned 1 vectors for 2 inputs"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[tokio::test]
+    async fn singleton_document_embed_rejects_zero_vectors() {
+        let runtime = KhiveRuntime::memory().unwrap();
+        runtime.register_embedder(WrongCardinalityEmbedderProvider);
+        let model_name = "wrong-cardinality-embedding-service";
+
+        let error = runtime
+            .embed_document_with_model_outcome(model_name, "single document")
+            .await
+            .expect_err("provider returning zero vectors must fail closed");
+
+        assert!(
+            error
+                .to_string()
+                .contains("embed_passage returned 0 vectors for 1 input"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[tokio::test]
+    async fn singleton_document_embed_rejects_surplus_vectors() {
+        let runtime = KhiveRuntime::memory().unwrap();
+        runtime.register_embedder(SurplusCardinalityEmbedderProvider);
+        let model_name = "surplus-cardinality-embedding-service";
+
+        let error = runtime
+            .embed_document_with_model_outcome(model_name, "single document")
+            .await
+            .expect_err("provider returning surplus vectors must fail closed");
+
+        assert!(
+            error
+                .to_string()
+                .contains("embed_passage returned 2 vectors for 1 input"),
             "unexpected error: {error}"
         );
     }

--- a/crates/kkernel/docs/design.md
+++ b/crates/kkernel/docs/design.md
@@ -115,7 +115,11 @@ It runs, in order:
    in `kkernel` (not `khive-pack-gtd`) because `AtomicOpPlan`/`PlanStatement` are
    `khive-runtime` atomic-plan vocabulary this CLI orchestrator owns.
 3. The synchronous commit pass (`khive_runtime::atomic_runner::run_atomic_unit`, B2).
-4. The async post-commit reindex pass (`khive_runtime::atomic_prepare::apply_post_commit_effects`).
+4. The async post-commit reindex pass
+   (`khive_runtime::atomic_prepare::apply_post_commit_effects_with_report`).
+   Its typed embedding outcomes are matched back to the originating update plan, so an atomic
+   update whose embedding input was bounded carries the same per-result `warnings` advisory as
+   the canonical non-atomic handler.
 
 **Verbs without a prepare implementation.** `propose`/`review`/`withdraw` are listed in
 `khive_types::pack::ATOMIC_ADMISSIBLE_VERBS` (ADR-099 D3 intends them to eventually gain a

--- a/crates/kkernel/src/atomic_apply.rs
+++ b/crates/kkernel/src/atomic_apply.rs
@@ -32,11 +32,15 @@ fn add_post_commit_embedding_warning(
     effect: Option<&PostCommitEffect>,
     outcomes: &[khive_runtime::atomic_prepare::PostCommitEmbeddingOutcome],
 ) {
+    // More than one atomic update may schedule the same target effect. Treat
+    // those outcomes as one aggregate advisory: a late model registration can
+    // make a later duplicate reindex truncate even when the first did not, and
+    // first-match lookup would silently lose that real outcome.
     let truncated = effect.is_some_and(|effect| {
         outcomes
             .iter()
-            .find(|outcome| &outcome.effect == effect)
-            .is_some_and(|outcome| outcome.truncation.any_truncated())
+            .filter(|outcome| &outcome.effect == effect)
+            .any(|outcome| outcome.truncation.any_truncated())
     });
     if !truncated {
         return;
@@ -972,6 +976,34 @@ mod validate_atomic_args_tests {
         };
         add_post_commit_embedding_warning(&mut unrelated, Some(&other_effect), &outcomes);
         assert!(unrelated.get("warnings").is_none());
+    }
+
+    #[test]
+    fn atomic_duplicate_update_effect_aggregates_later_truncation_outcome() {
+        let note_id = Uuid::new_v4();
+        let effect = PostCommitEffect::ReindexNote { note_id };
+        let outcomes = vec![
+            khive_runtime::atomic_prepare::PostCommitEmbeddingOutcome {
+                effect: effect.clone(),
+                truncation: khive_runtime::retrieval::EmbeddingTruncationReport::default(),
+            },
+            khive_runtime::atomic_prepare::PostCommitEmbeddingOutcome {
+                effect: effect.clone(),
+                truncation: khive_runtime::retrieval::EmbeddingTruncationReport {
+                    truncated: 1,
+                    discarded_bytes: 23,
+                },
+            },
+        ];
+        let mut first_result = json!({"id": note_id});
+        let mut second_result = json!({"id": note_id});
+
+        add_post_commit_embedding_warning(&mut first_result, Some(&effect), &outcomes);
+        add_post_commit_embedding_warning(&mut second_result, Some(&effect), &outcomes);
+
+        let expected = json!([khive_runtime::retrieval::EMBEDDING_INPUT_TRUNCATED_WARNING]);
+        assert_eq!(first_result["warnings"], expected);
+        assert_eq!(second_result["warnings"], expected);
     }
 
     #[test]

--- a/crates/kkernel/src/atomic_apply.rs
+++ b/crates/kkernel/src/atomic_apply.rs
@@ -27,6 +27,28 @@ use khive_storage::{types::SqlValue, SqlStatement};
 
 use crate::exec::OpsFileEntry;
 
+fn add_post_commit_embedding_warning(
+    result: &mut Value,
+    effect: Option<&PostCommitEffect>,
+    outcomes: &[khive_runtime::atomic_prepare::PostCommitEmbeddingOutcome],
+) {
+    let truncated = effect.is_some_and(|effect| {
+        outcomes
+            .iter()
+            .find(|outcome| &outcome.effect == effect)
+            .is_some_and(|outcome| outcome.truncation.any_truncated())
+    });
+    if !truncated {
+        return;
+    }
+    if let Some(object) = result.as_object_mut() {
+        object.insert(
+            "warnings".to_string(),
+            json!([khive_runtime::retrieval::EMBEDDING_INPUT_TRUNCATED_WARNING]),
+        );
+    }
+}
+
 /// Run `ops` as ONE ADR-099 atomic unit against a freshly built in-process
 /// runtime. Returns the additive result envelope
 /// (`{"results", "summary", "atomic"}`) on success or a rolled-back run; the
@@ -165,7 +187,12 @@ pub(crate) async fn execute_atomic_ops_file(
             // functions and never propagated — a missing audit row must
             // never fail an already-committed atomic unit.
             apply_gtd_audit_post_commit_effects(&runtime, post_commit.as_slice()).await;
-            khive_runtime::atomic_prepare::apply_post_commit_effects(&runtime, &token, post_commit)
+            let embedding_outcomes =
+                khive_runtime::atomic_prepare::apply_post_commit_effects_with_report(
+                    &runtime,
+                    &token,
+                    post_commit,
+                )
                 .await
                 .context("post-commit reindex after atomic unit commit")?;
             // ADR-099 B3: render each committed op's
@@ -175,7 +202,7 @@ pub(crate) async fn execute_atomic_ops_file(
             // safe post-commit, same reasoning as the reindex pass above.
             let mut results: Vec<Value> = Vec::with_capacity(ops.len());
             for (idx, op) in ops.iter().enumerate() {
-                let result = build_op_result(
+                let mut result = build_op_result(
                     &runtime,
                     &token,
                     &op.tool,
@@ -190,6 +217,15 @@ pub(crate) async fn execute_atomic_ops_file(
                         op.tool
                     )
                 })?;
+                let embedding_effect = match &plans[idx] {
+                    AtomicOpPlan::Update(plan) => Some(plan.post_commit()),
+                    _ => None,
+                };
+                add_post_commit_embedding_warning(
+                    &mut result,
+                    embedding_effect,
+                    &embedding_outcomes,
+                );
                 results
                     .push(json!({"ok": true, "tool": op.tool, "op_index": idx, "result": result}));
             }
@@ -907,8 +943,36 @@ async fn prepare_gtd_complete(
 /// `kkernel::exec::tests::atomic_update_unknown_field_is_rejected_and_does_not_mutate_row`.
 #[cfg(test)]
 mod validate_atomic_args_tests {
-    use super::validate_atomic_args;
+    use super::{add_post_commit_embedding_warning, validate_atomic_args, PostCommitEffect, Uuid};
     use serde_json::json;
+
+    #[test]
+    fn atomic_update_result_uses_matching_post_commit_truncation_outcome() {
+        let note_id = Uuid::new_v4();
+        let effect = PostCommitEffect::ReindexNote { note_id };
+        let outcomes = vec![khive_runtime::atomic_prepare::PostCommitEmbeddingOutcome {
+            effect: effect.clone(),
+            truncation: khive_runtime::retrieval::EmbeddingTruncationReport {
+                truncated: 1,
+                discarded_bytes: 17,
+            },
+        }];
+        let mut result = json!({"id": note_id});
+
+        add_post_commit_embedding_warning(&mut result, Some(&effect), &outcomes);
+
+        assert_eq!(
+            result["warnings"],
+            json!([khive_runtime::retrieval::EMBEDDING_INPUT_TRUNCATED_WARNING])
+        );
+
+        let mut unrelated = json!({"id": Uuid::new_v4()});
+        let other_effect = PostCommitEffect::ReindexEntity {
+            entity_id: Uuid::new_v4(),
+        };
+        add_post_commit_embedding_warning(&mut unrelated, Some(&other_effect), &outcomes);
+        assert!(unrelated.get("warnings").is_none());
+    }
 
     #[test]
     fn update_rejects_unknown_field() {

--- a/crates/kkernel/src/code_ingest.rs
+++ b/crates/kkernel/src/code_ingest.rs
@@ -9,6 +9,7 @@
 //! `--dry-run` runs the same validation and existence checks but performs
 //! no writes.
 
+use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result};
@@ -60,6 +61,9 @@ pub struct CodeIngestReport {
     pub notes_skipped_existing: u64,
     pub edges_created: u64,
     pub edges_skipped_existing: u64,
+    /// Actual embedding-input truncation grouped by the model that received
+    /// each bounded document. Empty for dry runs and no-embedder runs.
+    pub truncation_by_model: BTreeMap<String, khive_runtime::retrieval::EmbeddingTruncationReport>,
 }
 
 /// Run one `kkernel code-ingest` pass: resolve config, validate the
@@ -87,6 +91,16 @@ pub async fn run_code_ingest(args: CodeIngestArgs) -> Result<()> {
                 ""
             },
         );
+        if report
+            .truncation_by_model
+            .values()
+            .any(khive_runtime::retrieval::EmbeddingTruncationReport::any_truncated)
+        {
+            println!(
+                "embedding truncation: {}",
+                serde_json::to_string(&report.truncation_by_model)?
+            );
+        }
     } else {
         println!("{}", serde_json::to_string_pretty(&report)?);
     }
@@ -178,6 +192,11 @@ where
         .map_err(|e| anyhow::anyhow!("{e}"))
         .context("failed to authorize namespace")?;
 
+    // One immutable model-name snapshot governs this ingest pass. Each report
+    // below is still derived from the corresponding completed embed call, so a
+    // provider cannot appear in execution without also appearing in reporting.
+    let embedding_model_names = runtime.registered_embedding_model_names();
+
     let mut report = CodeIngestReport {
         dry_run: false,
         ..CodeIngestReport::default()
@@ -212,13 +231,18 @@ where
                 );
             }
         }
-        for model_name in runtime.registered_embedding_model_names() {
+        for model_name in &embedding_model_names {
             match runtime
-                .embed_document_with_model(&model_name, &embed_body)
+                .embed_document_with_model_outcome(model_name, &embed_body)
                 .await
             {
-                Ok(vector) => {
-                    if let Ok(vs) = runtime.vectors_for_model(&token, &model_name) {
+                Ok(outcome) => {
+                    report
+                        .truncation_by_model
+                        .entry(model_name.clone())
+                        .or_default()
+                        .observe(&outcome);
+                    if let Ok(vs) = runtime.vectors_for_model(&token, model_name) {
                         if let Err(e) = vs
                             .insert(
                                 entity.id,
@@ -230,7 +254,7 @@ where
                                 // provenance metadata agrees with every
                                 // other write path.
                                 "entity.body",
-                                vec![vector],
+                                vec![outcome.vector],
                             )
                             .await
                         {
@@ -278,20 +302,25 @@ where
                 );
             }
         }
-        for model_name in runtime.registered_embedding_model_names() {
+        for model_name in &embedding_model_names {
             match runtime
-                .embed_document_with_model(&model_name, &note.content)
+                .embed_document_with_model_outcome(model_name, &note.content)
                 .await
             {
-                Ok(vector) => {
-                    if let Ok(vs) = runtime.vectors_for_model(&token, &model_name) {
+                Ok(outcome) => {
+                    report
+                        .truncation_by_model
+                        .entry(model_name.clone())
+                        .or_default()
+                        .observe(&outcome);
+                    if let Ok(vs) = runtime.vectors_for_model(&token, model_name) {
                         if let Err(e) = vs
                             .insert(
                                 note.id,
                                 SubstrateKind::Note,
                                 token.namespace().as_str(),
                                 "note.content",
-                                vec![vector],
+                                vec![outcome.vector],
                             )
                             .await
                         {
@@ -494,7 +523,7 @@ mod tests {
 
     use async_trait::async_trait;
     use khive_runtime::{EmbedderProvider, RuntimeError};
-    use lattice_embed::{EmbedError, EmbeddingModel, EmbeddingService};
+    use lattice_embed::{EmbedError, EmbeddingModel, EmbeddingService, MAX_TEXT_CHARS};
     use serial_test::serial;
 
     use super::*;
@@ -986,6 +1015,51 @@ mod tests {
             }
         }
         assert!(saw_entity_row, "expected at least one entity vector row");
+    }
+
+    #[serial]
+    #[tokio::test]
+    async fn code_ingest_reports_actual_embedding_truncation_by_model() {
+        let tmp = tempfile::TempDir::new().expect("temp dir");
+        let findings = write_valid_findings(tmp.path());
+        let db = tmp.path().join("scratch.db");
+
+        let mut document: serde_json::Value =
+            serde_json::from_slice(&std::fs::read(&findings).expect("read findings fixture"))
+                .expect("parse findings fixture");
+        // Finding-note embeddings use the canonical `title: impact` content,
+        // while evidence remains structured properties only.
+        document["findings"][0]["impact"] =
+            serde_json::Value::String("x".repeat(MAX_TEXT_CHARS + 1));
+        std::fs::write(
+            &findings,
+            serde_json::to_vec(&document).expect("serialize long findings fixture"),
+        )
+        .expect("write long findings fixture");
+
+        let report = code_ingest_batch_with_runtime_setup(base_args(findings, db), |runtime| {
+            for name in runtime.registered_embedding_model_names() {
+                let dimensions = runtime.resolve_embedding_model(Some(&name))?.dimensions();
+                runtime.register_embedder(FixedEmbeddingProvider { name, dimensions });
+            }
+            Ok(())
+        })
+        .await
+        .expect("ingest with bounded embedding input must succeed");
+
+        assert!(
+            !report.truncation_by_model.is_empty(),
+            "configured models that received embeddings must appear in the report"
+        );
+        assert!(
+            report
+                .truncation_by_model
+                .values()
+                .any(|truncation| { truncation.truncated > 0 && truncation.discarded_bytes > 0 }),
+            "the report must reflect the long finding content actually bounded by an embedder: \
+             {:?}",
+            report.truncation_by_model
+        );
     }
 
     /// Query the persisted `finding` note count for a scratch db, independent

--- a/crates/kkernel/src/reindex.rs
+++ b/crates/kkernel/src/reindex.rs
@@ -5,7 +5,7 @@
 //! FTS index. It is NOT a pack verb — it operates on the raw runtime stores
 //! regardless of which packs are loaded.
 
-use std::collections::HashSet;
+use std::collections::{BTreeMap, HashSet};
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::Instant;
@@ -16,6 +16,7 @@ use serde::Serialize;
 use uuid::Uuid;
 
 use khive_mcp::serve::{resolve_runtime_config, RuntimeConfigInputs};
+use khive_runtime::retrieval::EmbeddingTruncationReport;
 use khive_runtime::{entity_fts_document, note_fts_document, KhiveRuntime, Namespace};
 use khive_storage::entity::Entity;
 use khive_storage::error::StorageError;
@@ -23,8 +24,6 @@ use khive_storage::note::Note;
 use khive_storage::types::VectorRecord;
 use khive_storage::VectorStore;
 use khive_types::SubstrateKind;
-
-const MAX_EMBED_BYTES: usize = 32_768;
 
 // ─── progress bar ─────────────────────────────────────────────────────────────
 
@@ -215,6 +214,8 @@ struct ReindexReport {
     /// section embedding fails.
     knowledge_sections_failed: u64,
     models_used: Vec<String>,
+    /// Actual per-model input bounding observed at the embedding seam.
+    truncation_by_model: BTreeMap<String, EmbeddingTruncationReport>,
     elapsed_ms: u64,
     /// Entity/note vector inserts that failed across all engines.
     errors_skipped: u64,
@@ -275,6 +276,7 @@ async fn embed_and_store_batch(
     kind: SubstrateKind,
     field: &str,
     drop_existing: bool,
+    truncation_by_model: &mut BTreeMap<String, EmbeddingTruncationReport>,
 ) -> u64 {
     let mut errors: u64 = 0;
 
@@ -309,25 +311,28 @@ async fn embed_and_store_batch(
             continue;
         }
 
-        let budget = embed_budget(model_name);
-        let texts: Vec<String> = subset
-            .iter()
-            .map(|(_, t)| truncate_text(t, budget))
-            .collect();
-        match rt.embed_document_batch_with_model(model_name, &texts).await {
-            Ok(embeddings) if embeddings.len() == subset.len() => {
+        let texts: Vec<String> = subset.iter().map(|(_, t)| t.clone()).collect();
+        match rt
+            .embed_document_batch_with_model_outcomes(model_name, &texts)
+            .await
+        {
+            Ok(outcomes) if outcomes.len() == subset.len() => {
+                let model_report = truncation_by_model.entry(model_name.clone()).or_default();
+                for outcome in &outcomes {
+                    model_report.observe(outcome);
+                }
                 let expected = subset.len() as u64;
                 let now = chrono::Utc::now();
                 let records = subset
                     .iter()
-                    .zip(embeddings)
-                    .map(|((id, _), embedding)| VectorRecord {
+                    .zip(outcomes)
+                    .map(|((id, _), outcome)| VectorRecord {
                         subject_id: *id,
                         kind,
                         namespace: namespace.to_string(),
                         field: field.to_string(),
                         embedding_model: Some(model_name.clone()),
-                        vectors: vec![embedding],
+                        vectors: vec![outcome.vector],
                         updated_at: now,
                     })
                     .collect();
@@ -520,6 +525,7 @@ pub async fn run_reindex(args: ReindexArgs) -> Result<()> {
     let mut errors_skipped: u64 = 0;
     let mut entities_fts_failed: u64 = 0;
     let mut notes_fts_failed: u64 = 0;
+    let mut truncation_by_model = BTreeMap::new();
 
     let mut epoch_bump_failed = false;
 
@@ -565,6 +571,7 @@ pub async fn run_reindex(args: ReindexArgs) -> Result<()> {
                     SubstrateKind::Entity,
                     "entity.body",
                     drop_existing,
+                    &mut truncation_by_model,
                 )
                 .await;
                 entities_processed += staged.len() as u64;
@@ -618,6 +625,7 @@ pub async fn run_reindex(args: ReindexArgs) -> Result<()> {
                     SubstrateKind::Note,
                     "note.content",
                     drop_existing,
+                    &mut truncation_by_model,
                 )
                 .await;
                 notes_processed += staged.len() as u64;
@@ -705,6 +713,18 @@ pub async fn run_reindex(args: ReindexArgs) -> Result<()> {
         .await
         {
             Ok(v) => {
+                if let Some(per_model) = v.get("truncation_by_model").and_then(|v| v.as_object()) {
+                    for (model, value) in per_model {
+                        if let Ok(report) =
+                            serde_json::from_value::<EmbeddingTruncationReport>(value.clone())
+                        {
+                            truncation_by_model
+                                .entry(model.clone())
+                                .or_default()
+                                .merge(report);
+                        }
+                    }
+                }
                 if do_atoms {
                     knowledge_atoms_indexed =
                         Some(v.get("atoms_indexed").and_then(|n| n.as_u64()).unwrap_or(0));
@@ -752,6 +772,7 @@ pub async fn run_reindex(args: ReindexArgs) -> Result<()> {
         knowledge_ann_failed,
         knowledge_sections_failed,
         models_used: model_names,
+        truncation_by_model,
         elapsed_ms,
         errors_skipped,
         entities_fts_failed,
@@ -1150,90 +1171,80 @@ async fn count_notes(rt: &KhiveRuntime, ns: &str) -> u64 {
     }
 }
 
-// The embed service prepends the model's document instruction (e.g. "passage: "
-// for multilingual-e5) AFTER this truncation, and its input guard rejects the
-// combined length. Reserve the prefix bytes here or a text truncated exactly to
-// the cap fails the whole batch post-prefix.
-fn embed_budget(model_name: &str) -> usize {
-    let normalized = model_name.trim().to_ascii_lowercase().replace('_', "-");
-    let prefix_len = normalized
-        .parse::<lattice_embed::EmbeddingModel>()
-        .ok()
-        .and_then(|m| m.document_instruction())
-        .map_or(0, str::len);
-    MAX_EMBED_BYTES - prefix_len
-}
-
-fn truncate_text(t: &str, max_bytes: usize) -> String {
-    if t.len() <= max_bytes {
-        t.to_string()
+fn render_human_report(report: &ReindexReport) -> String {
+    let atoms = report
+        .knowledge_atoms_indexed
+        .map(|n| format!(", {n} knowledge atoms"))
+        .unwrap_or_default();
+    let sections = report
+        .knowledge_sections_indexed
+        .map(|n| format!(", {n} sections"))
+        .unwrap_or_default();
+    let status = if report.has_failures() {
+        "Reindex completed WITH FAILURES"
     } else {
-        let mut end = max_bytes;
-        while !t.is_char_boundary(end) {
-            end -= 1;
-        }
-        t[..end].to_string()
+        "Reindex complete"
+    };
+    let fts_errors = report.entities_fts_failed + report.notes_fts_failed;
+    let mut output = format!(
+        "{status}: {} entities, {} notes{}{} ({} vector errors, {} FTS errors) in {}ms\n",
+        report.entities_processed,
+        report.notes_processed,
+        atoms,
+        sections,
+        report.errors_skipped,
+        fts_errors,
+        report.elapsed_ms
+    );
+    if report.entities_fts_failed > 0 {
+        output.push_str(&format!(
+            "FTS backfill: {} entity upserts FAILED\n",
+            report.entities_fts_failed
+        ));
     }
+    if report.notes_fts_failed > 0 {
+        output.push_str(&format!(
+            "FTS backfill: {} note upserts FAILED\n",
+            report.notes_fts_failed
+        ));
+    }
+    if report.knowledge_pass_errored {
+        output.push_str("Knowledge pass: FAILED (did not run to completion)\n");
+    } else if report.knowledge_atoms_failed > 0 {
+        output.push_str(&format!(
+            "Knowledge pass: {} atom vector inserts FAILED\n",
+            report.knowledge_atoms_failed
+        ));
+    }
+    if report.knowledge_sections_failed > 0 {
+        output.push_str(&format!(
+            "Knowledge sections: {} section embed/write failures\n",
+            report.knowledge_sections_failed
+        ));
+    }
+    if report.knowledge_ann_failed {
+        output.push_str("Knowledge ANN: FAILED (snapshot not rebuilt/persisted)\n");
+    }
+    if !report.models_used.is_empty() {
+        output.push_str(&format!("Models: {}\n", report.models_used.join(", ")));
+    }
+    for (model, truncation) in &report.truncation_by_model {
+        let input_label = if truncation.truncated == 1 {
+            "input"
+        } else {
+            "inputs"
+        };
+        output.push_str(&format!(
+            "Embedding truncation ({model}): {} {input_label} truncated, {} bytes discarded\n",
+            truncation.truncated, truncation.discarded_bytes
+        ));
+    }
+    output
 }
 
 fn print_report(report: &ReindexReport, human: bool) {
     if human {
-        let atoms = report
-            .knowledge_atoms_indexed
-            .map(|n| format!(", {n} knowledge atoms"))
-            .unwrap_or_default();
-        let sections = report
-            .knowledge_sections_indexed
-            .map(|n| format!(", {n} sections"))
-            .unwrap_or_default();
-        let status = if report.has_failures() {
-            "Reindex completed WITH FAILURES"
-        } else {
-            "Reindex complete"
-        };
-        let fts_errors = report.entities_fts_failed + report.notes_fts_failed;
-        println!(
-            "{status}: {} entities, {} notes{}{} ({} vector errors, {} FTS errors) in {}ms",
-            report.entities_processed,
-            report.notes_processed,
-            atoms,
-            sections,
-            report.errors_skipped,
-            fts_errors,
-            report.elapsed_ms
-        );
-        if report.entities_fts_failed > 0 {
-            println!(
-                "FTS backfill: {} entity upserts FAILED",
-                report.entities_fts_failed
-            );
-        }
-        if report.notes_fts_failed > 0 {
-            println!(
-                "FTS backfill: {} note upserts FAILED",
-                report.notes_fts_failed
-            );
-        }
-        if report.knowledge_pass_errored {
-            println!("Knowledge pass: FAILED (did not run to completion)");
-        } else if report.knowledge_atoms_failed > 0 {
-            println!(
-                "Knowledge pass: {} atom vector inserts FAILED",
-                report.knowledge_atoms_failed
-            );
-        }
-        if report.knowledge_sections_failed > 0 {
-            println!(
-                "Knowledge sections: {} section embed/write failures",
-                report.knowledge_sections_failed
-            );
-        }
-        if report.knowledge_ann_failed {
-            println!("Knowledge ANN: FAILED (snapshot not rebuilt/persisted)");
-        }
-        if !report.models_used.is_empty() {
-            println!("Models: {}", report.models_used.join(", "));
-        }
+        print!("{}", render_human_report(report));
     } else {
         let json = serde_json::to_string(report).expect("serialize ReindexReport");
         println!("{json}");
@@ -1243,29 +1254,6 @@ fn print_report(report: &ReindexReport, human: bool) {
 #[cfg(test)]
 mod tests {
     use super::*;
-    #[test]
-    fn embed_budget_reserves_document_prefix_bytes() {
-        // multilingual-e5 prepends "passage: " (9 bytes) after truncation; the
-        // budget must reserve it or exactly-at-cap texts fail the whole batch.
-        assert_eq!(embed_budget("multilingual-e5-base"), MAX_EMBED_BYTES - 9);
-        assert_eq!(embed_budget("multilingual_e5_small"), MAX_EMBED_BYTES - 9);
-        assert_eq!(embed_budget("all-minilm-l6-v2"), MAX_EMBED_BYTES);
-        assert_eq!(embed_budget("unknown-model"), MAX_EMBED_BYTES);
-    }
-
-    #[test]
-    fn truncate_text_respects_budget_and_char_boundaries() {
-        let long = "a".repeat(MAX_EMBED_BYTES + 100);
-        assert_eq!(
-            truncate_text(&long, MAX_EMBED_BYTES - 9).len(),
-            MAX_EMBED_BYTES - 9
-        );
-        let cjk = "\u{4e2d}".repeat(20_000); // 3 bytes each
-        let out = truncate_text(&cjk, 32_759);
-        assert!(out.len() <= 32_759);
-        assert!(out.chars().all(|c| c == '\u{4e2d}'));
-    }
-
     use crate::dbpath::resolve_db_override;
     use clap::Parser;
     use khive_storage::types::{SqlStatement, SqlValue};
@@ -1738,12 +1726,63 @@ mod tests {
             knowledge_ann_failed: false,
             knowledge_sections_failed: 0,
             models_used: vec![],
+            truncation_by_model: BTreeMap::new(),
             elapsed_ms: 0,
             errors_skipped: errors,
             entities_fts_failed: 0,
             notes_fts_failed: 0,
             epoch_bump_failed: false,
         }
+    }
+
+    #[test]
+    fn report_serializes_per_model_truncation_accounting() {
+        let mut report = report_with(0, 0, false);
+        report.truncation_by_model.insert(
+            "strict-model".to_string(),
+            EmbeddingTruncationReport {
+                truncated: 2,
+                discarded_bytes: 17,
+            },
+        );
+        let json = serde_json::to_value(report).expect("serialize report");
+        assert_eq!(json["truncation_by_model"]["strict-model"]["truncated"], 2);
+        assert_eq!(
+            json["truncation_by_model"]["strict-model"]["discarded_bytes"],
+            17
+        );
+    }
+
+    #[test]
+    fn human_report_renders_per_model_truncation_in_sorted_order() {
+        let mut report = report_with(0, 0, false);
+        report.truncation_by_model.insert(
+            "zeta-model".to_string(),
+            EmbeddingTruncationReport {
+                truncated: 3,
+                discarded_bytes: 29,
+            },
+        );
+        report.truncation_by_model.insert(
+            "alpha-model".to_string(),
+            EmbeddingTruncationReport {
+                truncated: 1,
+                discarded_bytes: 7,
+            },
+        );
+
+        let rendered = render_human_report(&report);
+        let truncation_lines: Vec<&str> = rendered
+            .lines()
+            .filter(|line| line.starts_with("Embedding truncation"))
+            .collect();
+        assert_eq!(
+            truncation_lines,
+            [
+                "Embedding truncation (alpha-model): 1 input truncated, 7 bytes discarded",
+                "Embedding truncation (zeta-model): 3 inputs truncated, 29 bytes discarded",
+            ]
+        );
     }
 
     #[test]
@@ -1775,6 +1814,7 @@ mod tests {
             knowledge_ann_failed: true,
             knowledge_sections_failed: 0,
             models_used: vec![],
+            truncation_by_model: BTreeMap::new(),
             elapsed_ms: 0,
             errors_skipped: 0,
             entities_fts_failed: 0,
@@ -1807,6 +1847,7 @@ mod tests {
             knowledge_ann_failed: false,
             knowledge_sections_failed: 3,
             models_used: vec![],
+            truncation_by_model: BTreeMap::new(),
             elapsed_ms: 0,
             errors_skipped: 0,
             entities_fts_failed: 0,
@@ -2085,6 +2126,7 @@ mod tests {
             SubstrateKind::Note,
             "note.content",
             true,
+            &mut BTreeMap::new(),
         )
         .await;
 
@@ -2141,6 +2183,7 @@ mod tests {
             knowledge_ann_failed: false,
             knowledge_sections_failed: 0,
             models_used: vec![],
+            truncation_by_model: BTreeMap::new(),
             elapsed_ms: 0,
             errors_skipped: 0,
             entities_fts_failed: 0,
@@ -2724,6 +2767,7 @@ mod tests {
             knowledge_ann_failed: false,
             knowledge_sections_failed: 0,
             models_used: vec![],
+            truncation_by_model: BTreeMap::new(),
             elapsed_ms: 0,
             errors_skipped: 0,
             entities_fts_failed: 1,

--- a/docs/guide/api-reference.md
+++ b/docs/guide/api-reference.md
@@ -167,6 +167,10 @@ Declaration = changes institutional status by fiat.
 
 Create an entity or note (singleton) or a batch of entities (bulk via `items`).
 
+Singleton writes preserve the complete source in storage and FTS. If a configured embedder
+receives a UTF-8-safe bounded prefix, the successful response includes a `warnings` array; the
+warning is derived from the embedding outcome, not from a separate registry prediction.
+
 | Param               | Type            | Required    | Notes                                                                                                                                                                                                                                                                                      |
 | ------------------- | --------------- | ----------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | `kind`              | string          | conditional | Substrate (`entity`\|`note`) or granular kind (`concept`, `document`, `observation`, …). Required for the singleton path; not required when `items` is present.                                                                                                                            |
@@ -302,6 +306,9 @@ Patch entity, note, or edge fields. Field set depends on substrate: entities acc
 `name`/`description`/`properties`/`tags`; notes accept
 `name`/`content`/`salience`/`decay_factor`/`properties`; edges accept
 `relation`/`weight`/`properties`.
+
+Entity/note text updates use the same full-source storage and bounded embedding contract as
+singleton `create`; a successful response includes `warnings` when embedding actually truncated.
 
 | Param          | Type            | Required | Notes                                                                     |
 | -------------- | --------------- | -------- | ------------------------------------------------------------------------- |
@@ -590,6 +597,9 @@ request(ops="[{\"tool\":\"propose\",\"args\":{\"title\":\"Add GQE\",\"descriptio
 ### `review` — Declaration
 
 Approve, reject, comment, or request changes on a proposal.
+
+When approval immediately applies an embedding-bearing changeset, the response includes the
+standard `warnings` advisory if that committed apply bounded any embedding input.
 
 | Param      | Type   | Required | Notes                                              |
 | ---------- | ------ | -------- | -------------------------------------------------- |
@@ -1072,6 +1082,9 @@ Actor-to-actor messaging with threading. Optional; load with `KHIVE_PACKS=kg,com
 
 Send a message, optionally threaded.
 
+The atomic outbound/inbound write preserves the full body on both notes. If either copy's
+embedding input is bounded, the successful response includes the standard `warnings` advisory.
+
 | Param       | Type   | Required | Notes                                                                                                                                                                                           |
 | ----------- | ------ | -------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `to`        | string | yes      | Actor label, e.g. `"lambda:leo"`. Both copies land in the caller's namespace; no cross-namespace write occurs.                                                                                  |
@@ -1121,6 +1134,9 @@ request(ops="comm.read(id=\"<message-id>\")")
 ### `comm.reply` — Commissive
 
 Reply to a message, threading linkage.
+
+Replies use the same full-source storage and embedding-truncation `warnings` contract as
+`comm.send`.
 
 | Param     | Type   | Required | Notes                                                       |
 | --------- | ------ | -------- | ----------------------------------------------------------- |

--- a/docs/guide/api-reference.md
+++ b/docs/guide/api-reference.md
@@ -347,6 +347,8 @@ request(ops="delete(id=\"<uuid>\")")
 Deduplicate two entities. Returns `{kept_id, removed_id, edges_rewired,
 properties_merged, tags_unioned, content_appended, dry_run}` — chain with
 `$prev.kept_id`, **not** `$prev.id` (merge has no top-level `id` field).
+When the surviving entity or note is reindexed and an embedder bounds its input, the successful
+response also includes the standard embedding-truncation `warnings` advisory.
 
 | Param     | Type | Required | Notes                                       |
 | --------- | ---- | -------- | ------------------------------------------- |
@@ -1345,6 +1347,10 @@ request(ops="knowledge.stats()")
 
 Backfill embeddings + FTS for atoms/domains.
 
+The response includes `truncation_by_model`, keyed by every model that completed embedding work.
+Each value contains `truncated` and `discarded_bytes` counters derived from the actual embedding
+outcomes; atom source content remains complete in SQL and FTS.
+
 | Param         | Type            | Required | Notes                                                   |
 | ------------- | --------------- | -------- | ------------------------------------------------------- |
 | `ids`         | array\<string\> | no       | Atom slugs/IDs to index; omit to index all.             |
@@ -1431,6 +1437,10 @@ request(ops="knowledge.compose(query=\"FastAPI JWT middleware validation pattern
 ### `knowledge.edit` — Commissive
 
 Upsert sections for an atom without wiping other sections.
+
+The response combines the inline section and atom refresh outcomes in `truncation_by_model` and
+includes the standard `warnings` advisory when any model bounded an embedding input. Stored section
+and atom content remains complete.
 
 | Param      | Type            | Required | Notes                                                                                                                                                                                                                                                                             |
 | ---------- | --------------- | -------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -475,6 +475,11 @@ falls back to the conservative "assume nothing is embedded, re-embed everything"
 re-embed. In both modes the selected graph pass still backfills FTS. There is no
 `--embeds-only` mode.
 
+The default JSON report includes `truncation_by_model`. Each model entry reports `truncated`
+(the number of inputs that were bounded) and `discarded_bytes` (source bytes not sent to that
+embedder). These counters come from the embedding result itself; entity, note, atom, and section
+source text remains complete in SQL and FTS.
+
 **`--best-effort` vs. the fail-closed default**: `ReindexReport::has_failures()`
 (`reindex.rs`) is a single predicate covering eight categories: vector embed/insert
 errors, entity FTS failures, note FTS failures, knowledge atom failures, a knowledge pass that
@@ -492,8 +497,9 @@ exists: a bad `--namespace` value, a config resolution failure, a failed runtime
 **Engine fan-out**: omitting `--model` reindexes against `rt.registered_embedding_model_names()`,
 whatever engines the resolved runtime config actually registers, not a hardcoded list. If that
 list is empty (no embedder configured at all), a warning prints but FTS backfill for entities and
-notes still runs. The knowledge-corpus pass is **not** fanned out across this model list at all:
-it always uses the config's default embedder, independent of `--model`.
+notes still runs. Knowledge atoms use the default model for their primary success counters and
+fan out to secondary registered engines on a best-effort basis; knowledge sections use the
+default model. `--model` still restricts only the graph pass.
 
 **When to reindex** (genuine in-code rationale, not doc-comment fluff): after relabeling a
 namespace (vector rows would otherwise be stranded under the wrong namespace on next write,


### PR DESCRIPTION
## Summary

- return the embedding vector together with the actual source/embedded byte counts and truncation outcome from the provider-dispatch seam
- preserve full stored and FTS content while surfacing a stable warning and per-model truncation reports across KG, comm, knowledge, atomic apply, import, code-ingest, and reindex paths
- capture one immutable embedding-registry plan per logical write/reindex operation, keep mixed batches ordered, and reject provider cardinality mismatches
- cover UTF-8-safe bounding, instruction-prefix budgets, concurrent registry mutation, duplicate atomic effects, and previously unreported write paths

Closes #1453.
Closes #1455.

## Validation

- `cargo test --workspace`
- `cargo check --workspace`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `RUSTDOCFLAGS='-D warnings' cargo doc --workspace --no-deps`
- `cargo fmt --all -- --check`
- `deno fmt --check docs/`
- `sh scripts/lint-sql.sh`
- `sh scripts/lint-adr-refs.sh`
- `sh scripts/lint-adr-refs.sh --self-test`
- `sh scripts/lint-stub-markers.sh`
- `sh scripts/lint-stub-markers.sh --self-test`
- `git diff --check origin/main...HEAD`

## ADR

n/a — this completes the existing embedding write/reindex reporting contract without changing the storage schema or taxonomy.

> AI-assisted contribution: Codex prepared this change and PR description.
