### PR TITLE
fix(storage): make note property sets atomic

### DIFF
--- a/crates/khive-db/docs/persistence.md
+++ b/crates/khive-db/docs/persistence.md
@@ -32,6 +32,12 @@ The backend also provides:
 - `apply_pack_ddl_statements(stmts)` -- run pack-auxiliary DDL (ADR-017)
 - `sql()` -- raw `SqlAccess` bridge for the query compiler
 
+`SqlNoteStore::set_note_property` applies one top-level JSON-key update with a
+single parameterized SQLite `json_set` statement. This is the note capability's
+atomic patch path; whole-document replacement remains a separate explicit
+operation. Keys containing U+0000 are rejected before dispatch because SQLite
+JSON paths cannot address those labels without ambiguous prefix matching.
+
 Each pack DDL plan is applied atomically in one transaction and remains idempotent on repeat application.
 
 ## Connection pooling

--- a/crates/khive-db/src/stores/note.rs
+++ b/crates/khive-db/src/stores/note.rs
@@ -109,8 +109,8 @@ pub fn note_upsert_statement(note: &Note) -> SqlStatement {
 }
 
 /// The exact `properties`/`updated_at` `UPDATE` this store's
-/// `update_note_properties` issues. A real `UPDATE` never triggers SQLite's
-/// `INSERT OR REPLACE` delete+insert, so the row is patched in place (#780).
+/// `update_note_properties` issues. The row is patched in place without
+/// rewriting any other note column or its stable row identity (#780).
 /// The `comm.probe` cursor is keyed on `notes_seq.seq`, which is fixed at
 /// first insert and survives a delete+reinsert of the same note id, so this
 /// is defensive rather than load-bearing for cursor correctness; a metadata
@@ -137,6 +137,48 @@ pub fn note_update_properties_statement(
         ],
         label: Some("note-update-properties".to_string()),
     }
+}
+
+/// The atomic top-level JSON-property `UPDATE` issued by
+/// [`NoteStore::set_note_property`]. The key is encoded as one quoted JSON
+/// path segment, so punctuation is literal rather than interpreted as nested
+/// path syntax. `json(?2)` preserves the bound value's JSON type instead of
+/// storing objects, arrays, booleans, or numbers as JSON strings.
+///
+/// SQL-NULL documents start from `{}`. JSON arrays/scalars/null are not
+/// property objects and are left untouched; the caller receives `false`.
+pub fn note_set_property_statement(
+    id: Uuid,
+    key: &str,
+    value: &serde_json::Value,
+    updated_at: i64,
+) -> Result<SqlStatement, StorageError> {
+    // SQLite JSON-path object labels terminate at U+0000. Passing such a key
+    // through `json_set` can therefore select a shorter sibling key instead
+    // of the requested literal key, so reject it before constructing SQL.
+    if key.contains('\0') {
+        return Err(StorageError::InvalidInput {
+            capability: StorageCapability::Notes,
+            operation: "set_note_property".into(),
+            message: "property key must not contain U+0000".to_string(),
+        });
+    }
+    let path = format!("$.{}", serde_json::Value::String(key.to_string()));
+    Ok(SqlStatement {
+        sql: "UPDATE notes \
+              SET properties = json_set(COALESCE(properties, '{}'), ?1, json(?2)), \
+                  updated_at = ?3 \
+              WHERE id = ?4 AND deleted_at IS NULL \
+                AND (properties IS NULL OR json_type(properties) = 'object')"
+            .to_string(),
+        params: vec![
+            SqlValue::Text(path),
+            SqlValue::Text(value.to_string()),
+            SqlValue::Integer(updated_at),
+            SqlValue::Text(id.to_string()),
+        ],
+        label: Some("note-set-property".to_string()),
+    })
 }
 
 /// The exact soft-delete `UPDATE` this store's `delete_note(Soft)` issues.
@@ -218,12 +260,13 @@ impl SqlNoteStore {
     /// to the legacy pool-mutex path (ADR-067 Component A, Fork C slice 2).
     ///
     /// This is the routing point for single-statement `with_writer` callers
-    /// in this store (`update_note_properties`, `delete_note`). `f` must be
-    /// DML-only — on the flag-on path it runs inside the WriterTask's own
-    /// transaction, so a bare `BEGIN IMMEDIATE` would violate SQLite's
-    /// nested-transaction rule. `upsert_notes` (the batch method) does its
-    /// own flag check and returns early on `Some`, so its fallback call
-    /// into this helper only ever executes on the flag-off path
+    /// in this store (`update_note_properties`, `set_note_property`,
+    /// `delete_note`). `f` must be DML-only — on the flag-on path it runs
+    /// inside the WriterTask's own transaction, so a bare `BEGIN IMMEDIATE`
+    /// would violate SQLite's nested-transaction rule. `upsert_notes` (the
+    /// batch method) does its own flag check and returns early on `Some`, so
+    /// its fallback call into this helper only ever executes on the flag-off
+    /// path
     /// (`self.writer_task` is `None` by construction whenever that call is
     /// reached) — no double-routing. Callers whose `f` issues more than one
     /// DML statement that must land atomically together (`upsert_note`,
@@ -727,6 +770,22 @@ impl NoteStore for SqlNoteStore {
     ) -> Result<bool, StorageError> {
         let statement = note_update_properties_statement(id, &properties, updated_at);
         self.with_writer("update_note_properties", move |conn| {
+            let mut stmt = conn.prepare(&statement.sql)?;
+            bind_params(&mut stmt, &statement.params)?;
+            Ok(stmt.raw_execute()? > 0)
+        })
+        .await
+    }
+
+    async fn set_note_property(
+        &self,
+        id: Uuid,
+        key: &str,
+        value: serde_json::Value,
+        updated_at: i64,
+    ) -> Result<bool, StorageError> {
+        let statement = note_set_property_statement(id, key, &value, updated_at)?;
+        self.with_writer("set_note_property", move |conn| {
             let mut stmt = conn.prepare(&statement.sql)?;
             bind_params(&mut stmt, &statement.params)?;
             Ok(stmt.raw_execute()? > 0)

--- a/crates/khive-db/src/stores/note_tests.rs
+++ b/crates/khive-db/src/stores/note_tests.rs
@@ -458,6 +458,145 @@ async fn test_note_status_field_roundtrip() {
     assert_eq!(fetched.status, "active");
 }
 
+#[tokio::test]
+async fn set_note_property_initializes_null_and_preserves_json_type() {
+    let store = setup_memory_store();
+    let note = make_note("default", "observation", "atomic property set");
+    let id = note.id;
+    let updated_at = note.updated_at + 1;
+    store.upsert_note(note).await.unwrap();
+
+    assert!(store
+        .set_note_property(
+            id,
+            "delivery.stamp",
+            serde_json::json!({ "channel": "email", "attempt": 1 }),
+            updated_at,
+        )
+        .await
+        .unwrap());
+    assert!(store
+        .set_note_property(id, "explicit_null", serde_json::Value::Null, updated_at + 1)
+        .await
+        .unwrap());
+
+    let fetched = store.get_note(id).await.unwrap().unwrap();
+    assert_eq!(
+        fetched.properties,
+        Some(serde_json::json!({
+            "delivery.stamp": { "channel": "email", "attempt": 1 },
+            "explicit_null": null
+        })),
+        "keys must be literal top-level segments and values must keep their JSON types"
+    );
+    assert_eq!(fetched.updated_at, updated_at + 1);
+}
+
+#[tokio::test]
+async fn concurrent_distinct_note_property_sets_both_survive() {
+    let store = Arc::new(setup_memory_store());
+    let note = make_note("default", "message", "concurrent atomic properties")
+        .with_properties(serde_json::json!({ "existing": "preserved" }));
+    let id = note.id;
+    let updated_at = note.updated_at;
+    store.upsert_note(note).await.unwrap();
+
+    let gate = Arc::new(tokio::sync::Barrier::new(3));
+    let left = {
+        let store = Arc::clone(&store);
+        let gate = Arc::clone(&gate);
+        tokio::spawn(async move {
+            gate.wait().await;
+            store
+                .set_note_property(
+                    id,
+                    "delivery_stamp",
+                    serde_json::json!("email"),
+                    updated_at + 1,
+                )
+                .await
+        })
+    };
+    let right = {
+        let store = Arc::clone(&store);
+        let gate = Arc::clone(&gate);
+        tokio::spawn(async move {
+            gate.wait().await;
+            store
+                .set_note_property(id, "ingest_marker", serde_json::json!(true), updated_at + 2)
+                .await
+        })
+    };
+
+    gate.wait().await;
+    assert!(left.await.unwrap().unwrap());
+    assert!(right.await.unwrap().unwrap());
+
+    let fetched = store.get_note(id).await.unwrap().unwrap();
+    assert_eq!(
+        fetched.properties,
+        Some(serde_json::json!({
+            "existing": "preserved",
+            "delivery_stamp": "email",
+            "ingest_marker": true
+        })),
+        "one-statement property sets must not lose a different concurrent key"
+    );
+}
+
+#[tokio::test]
+async fn set_note_property_refuses_non_object_document() {
+    let store = setup_memory_store();
+    let note = make_note("default", "observation", "scalar properties")
+        .with_properties(serde_json::json!(["not", "an", "object"]));
+    let id = note.id;
+    let original_updated_at = note.updated_at;
+    store.upsert_note(note).await.unwrap();
+
+    assert!(!store
+        .set_note_property(id, "read", serde_json::json!(true), original_updated_at + 1)
+        .await
+        .unwrap());
+    let fetched = store.get_note(id).await.unwrap().unwrap();
+    assert_eq!(
+        fetched.properties,
+        Some(serde_json::json!(["not", "an", "object"]))
+    );
+    assert_eq!(fetched.updated_at, original_updated_at);
+}
+
+#[tokio::test]
+async fn set_note_property_rejects_nul_key_without_mutation() {
+    let store = setup_memory_store();
+    let note = make_note("default", "observation", "nul property key").with_properties(
+        serde_json::json!({
+            "a": 0,
+            "a\u{0000}b": 9,
+        }),
+    );
+    let id = note.id;
+    let original_updated_at = note.updated_at;
+    let original_properties = note.properties.clone();
+    store.upsert_note(note).await.unwrap();
+
+    let result = store
+        .set_note_property(
+            id,
+            "a\u{0000}b",
+            serde_json::json!(1),
+            original_updated_at + 1,
+        )
+        .await;
+    assert!(
+        matches!(result, Err(StorageError::InvalidInput { .. })),
+        "expected InvalidInput, got {result:?}"
+    );
+
+    let fetched = store.get_note(id).await.unwrap().unwrap();
+    assert_eq!(fetched.properties, original_properties);
+    assert_eq!(fetched.updated_at, original_updated_at);
+}
+
 // -- query_notes_filtered tests --
 
 fn make_note_with_props(

--- a/crates/khive-db/tests/contract/backend.rs
+++ b/crates/khive-db/tests/contract/backend.rs
@@ -242,6 +242,29 @@ async fn test_note_store(backend: &StorageBackend) {
     assert_eq!(fetched.content, "Test note content");
     assert!(fetched.deleted_at.is_none());
 
+    assert!(store
+        .set_note_property(id, "first", serde_json::json!(1), fetched.updated_at + 1)
+        .await
+        .expect("set first note property"));
+    assert!(store
+        .set_note_property(
+            id,
+            "second",
+            serde_json::json!(true),
+            fetched.updated_at + 2
+        )
+        .await
+        .expect("set second note property"));
+    let patched = store
+        .get_note(id)
+        .await
+        .expect("get patched note")
+        .expect("patched note must exist");
+    assert_eq!(
+        patched.properties,
+        Some(serde_json::json!({ "first": 1, "second": true }))
+    );
+
     // Soft-delete
     let deleted = store
         .delete_note(id, DeleteMode::Soft)

--- a/crates/khive-pack-comm/docs/api/message-lifecycle.md
+++ b/crates/khive-pack-comm/docs/api/message-lifecycle.md
@@ -131,12 +131,11 @@ Marks a message as read. Rejects `read()` on outbound messages — "read" is a
 recipient action; marking an outbound (sent) message as read corrupts the
 read/unread invariant and has no semantic meaning to the sender.
 
-Merges `read: true` into properties and patches in place via a real `UPDATE`
-(not `upsert_note`'s `INSERT OR REPLACE`): the latter silently deletes and
-re-inserts the row on a primary-key conflict (#780). The `comm.probe` cursor
-is keyed on `notes_seq.seq`, which is fixed at first insert and survives such
-churn, so this is defensive rather than load-bearing; a metadata patch should
-never rewrite the row regardless.
+Sets `read: true` through `NoteStore::set_note_property`, which lowers to one
+`UPDATE ... json_set(...)` statement. It never reads and replaces the whole
+properties document, so another writer setting a different key cannot be
+silently overwritten between those two steps (#1483). The operation also
+leaves every non-property column and the row's identity untouched (#780).
 
 The mark-read patch is best-effort: under multi-client burst traffic the
 sqlite writer pool can time out (`checkout_timeout`, 5s default), and the
@@ -149,10 +148,11 @@ been best-effort since its introduction. Three outcomes:
   the patched value (including the new `read: true`).
 - `Ok(false)` — no live row was found to update (e.g. soft-deleted
   mid-flight, between this handler's `get_note` and its
-  `update_note_properties` call): `read: false`, `mark_error: "no live row
-  updated"`, `properties` is the note's ORIGINAL stored value (a stored
-  SQL-NULL properties column round-trips as JSON `null`, never `{}`) — the
-  response never claims a write that did not land.
+  `set_note_property` call), or the stored properties value was not an
+  object: `read: false`, `mark_error: "no live row updated"`, `properties`
+  is the note's ORIGINAL stored value (a stored SQL-NULL properties column
+  round-trips as JSON `null`, never `{}`) — the response never claims a
+  write that did not land.
 - `Err(e)` — the patch failed (writer timeout, pool exhaustion, etc.):
   logged via `tracing::warn!` with the full error detail, then `read:
   false`, `mark_error` is the error's `Display` string, `properties` is the
@@ -191,6 +191,11 @@ Replies to a message, threading linkage.
   regardless of whether the original message carried actor labels. No legacy
   code path can cause `dual_write_message` to mint a token in a foreign
   namespace.
+- Replying folds in the addressee's read mark with the same atomic
+  `set_note_property("read", true)` operation as `comm.read`; it does not
+  re-fetch and replace the properties document. The delivery of the reply is
+  already committed, so this mark remains best-effort and reports
+  `marked_read: false` on a failed/no-op property set.
 
 ## `handlers.rs::handle_thread`
 
@@ -318,7 +323,7 @@ from the struct.
   all.
 - `parent_references_chain`: direction-aware — an inbound parent's chain (as
   received over the wire) lives in `wire_references`; an outbound parent's
-  chain is whatever was persisted on it as `references_chain` when *it* was
+  chain is whatever was persisted on it as `references_chain` when _it_ was
   sent (an outbound note that was a fresh send, not a reply, carries no
   `references_chain`). Returns `None` when the parent has no chain to extend;
   the caller then falls back to the parent's Message-ID alone, matching RFC

--- a/crates/khive-pack-comm/src/handlers.rs
+++ b/crates/khive-pack-comm/src/handlers.rs
@@ -438,8 +438,8 @@ pub(crate) async fn handle_read(
         );
     }
 
-    // Patch via a real `UPDATE`, not `upsert_note`'s `INSERT OR REPLACE` (#780
-    // silently re-inserts the row on conflict). See docs/api/message-lifecycle.md#handlersrshandle_read
+    // Patch via one atomic JSON-property `UPDATE`, not a get/replace cycle or
+    // `upsert_note` (#1483, #780). See docs/api/message-lifecycle.md#handlersrshandle_read
     //
     // `orig_props` is kept as the stored `Option<Value>` (a SQL-NULL
     // properties column is a real, distinct state from `{}`) so a degraded
@@ -447,7 +447,12 @@ pub(crate) async fn handle_read(
     // separately-normalized object used only for the attempted patch.
     let orig_props = note.properties.clone();
     let mut props = orig_props.clone().unwrap_or_else(|| json!({}));
-    props["read"] = json!(true);
+    match props.as_object_mut() {
+        Some(object) => {
+            object.insert("read".to_string(), json!(true));
+        }
+        None => props = json!({ "read": true }),
+    }
     let updated_at = Utc::now().timestamp_micros();
 
     // Best-effort: under multi-client writer contention the pool checkout can
@@ -460,7 +465,7 @@ pub(crate) async fn handle_read(
     // polling unread counts simply sees the message still unread and can
     // re-issue `read` — self-healing, no retry loop needed here.
     let patch_result = store
-        .update_note_properties(id, Some(props.clone()), updated_at)
+        .set_note_property(id, "read", json!(true), updated_at)
         .await;
 
     Ok(read_response(
@@ -711,24 +716,14 @@ pub(crate) async fn handle_reply(
     let marked_read = if original_direction == "outbound" || !caller_is_addressee {
         None
     } else {
-        // Re-fetch: `orig_props` predates the dual write above, so writing it
-        // back wholesale would erase any property another writer set in that
-        // window (the store replaces `properties`, it does not merge).
-        let current = store
-            .get_note(id)
-            .await
-            .ok()
-            .flatten()
-            .and_then(|n| n.properties)
-            .unwrap_or_else(|| orig_props.clone());
-        let mut props = current;
-        props["read"] = json!(true);
         let updated_at = Utc::now().timestamp_micros();
         // `Ok(false)` means no live row was updated (e.g. the original was
-        // soft-deleted mid-flight) — that is not a successful mark.
+        // soft-deleted mid-flight, or its properties ceased to be an object)
+        // — that is not a successful mark. The one-statement property set
+        // preserves every unrelated key without a race window (#1483).
         Some(
             store
-                .update_note_properties(id, Some(props), updated_at)
+                .set_note_property(id, "read", json!(true), updated_at)
                 .await
                 .unwrap_or(false),
         )
@@ -2402,7 +2397,7 @@ mod tests {
 
     // read_response's three arms are unit-tested directly because the
     // `Ok(false)` case (a live row vanishing between handle_read's `get_note`
-    // and its `update_note_properties` call) cannot be arranged honestly
+    // and its `set_note_property` call) cannot be arranged honestly
     // through the public dispatch path: the two calls are sequential within
     // one handler invocation with no seam to inject a concurrent delete.
 
@@ -2479,7 +2474,7 @@ mod tests {
         let original = json!({ "direction": "inbound", "read": false });
         let patched = json!({ "direction": "inbound", "read": true });
         let err = StorageError::Timeout {
-            operation: "update_note_properties".into(),
+            operation: "set_note_property".into(),
         };
         let err_text = err.to_string();
         let resp = read_response(
@@ -2503,7 +2498,7 @@ mod tests {
     fn read_response_err_preserves_stored_null_properties() {
         let patched = json!({ "read": true });
         let err = StorageError::Timeout {
-            operation: "update_note_properties".into(),
+            operation: "set_note_property".into(),
         };
         let resp = read_response(
             "abc123".to_string(),

--- a/crates/khive-pack-comm/tests/integration.rs
+++ b/crates/khive-pack-comm/tests/integration.rs
@@ -1032,9 +1032,9 @@ async fn test_reply_marks_directionless_legacy_original() {
     );
 }
 
-/// The read-patch must not clobber properties written between the original's
-/// fetch and the patch: reply re-reads current properties before setting
-/// `read`, since the store replaces the properties object wholesale.
+/// The read patch must not clobber an unrelated property. Both writes use the
+/// storage layer's one-statement JSON-property setter, so the invariant does
+/// not depend on a best-effort re-read immediately before replacement.
 #[tokio::test]
 async fn test_reply_read_patch_preserves_concurrent_properties() {
     use khive_storage::note::Note;
@@ -1066,15 +1066,15 @@ async fn test_reply_read_patch_preserves_concurrent_properties() {
         .await
         .expect("insert message");
 
-    // Stand in for another writer stamping metadata after the original was
-    // fetched: patch a new property directly, then reply.
-    let mut with_stamp = serde_json::json!({
-        "direction": "inbound", "from": "x", "to": "local", "read": false,
-        "delivery_stamp": "channel-email"
-    });
-    with_stamp["read"] = serde_json::json!(false);
+    // Stand in for another writer stamping metadata, then let reply perform
+    // its independent atomic `read` set.
     store
-        .update_note_properties(id, Some(with_stamp), now + 1)
+        .set_note_property(
+            id,
+            "delivery_stamp",
+            serde_json::json!("channel-email"),
+            now + 1,
+        )
         .await
         .expect("stamp applied");
 

--- a/crates/khive-storage/docs/design.md
+++ b/crates/khive-storage/docs/design.md
@@ -24,6 +24,9 @@ verb, substrate, actor, session, aggregate, and observed/selected referents.
 The `StorageCapability` enum in `capability.rs` identifies which surface produced
 an error (`Sql`, `Notes`, `Entities`, `Graph`, `Events`, `Vectors`, `Sparse`,
 `Text`). Each trait file defines one capability surface as a separate module.
+`NoteStore::set_note_property` is the atomic, top-level JSON-key mutation
+contract: backend implementations must preserve unrelated keys without a
+caller-side read/replace cycle.
 
 ### [ADR-009: Backend Architecture](../../../docs/adr/ADR-009-backend-architecture.md)
 

--- a/crates/khive-storage/src/note.rs
+++ b/crates/khive-storage/src/note.rs
@@ -313,16 +313,33 @@ pub trait NoteStore: Send + Sync + 'static {
     /// `UPDATE`, leaving every other column (including the row's `rowid`)
     /// untouched.
     ///
-    /// Unlike `upsert_note` (an `INSERT OR REPLACE`, which on a primary-key
-    /// conflict is a SQLite DELETE+INSERT that silently reassigns the row's
-    /// implicit `rowid`), this never churns `rowid`, which is required by any
-    /// caller relying on `rowid` as a stable, monotonically-increasing cursor (#780).
+    /// Unlike `upsert_note`, which writes the complete note shape, this leaves
+    /// every non-property column untouched. It also never churns the row's
+    /// implicit `rowid`, which is required by callers relying on stable row
+    /// identity (#780).
     /// Returns `true` when a live (non-soft-deleted) row with this `id` was
     /// found and updated, `false` otherwise.
     async fn update_note_properties(
         &self,
         id: Uuid,
         properties: Option<Value>,
+        updated_at: i64,
+    ) -> StorageResult<bool>;
+    /// Atomically set one top-level key in a note's JSON `properties` object.
+    ///
+    /// The backend must perform the read/modify/write as one storage operation
+    /// so concurrent writes to different keys cannot overwrite each other.
+    /// `value` keeps its JSON type, including explicit JSON `null`. A SQL-NULL
+    /// property document is initialized as an empty object. A live row whose
+    /// stored document is a non-object is not modified and returns `false`, as
+    /// do missing and soft-deleted rows. Keys containing U+0000 must be
+    /// rejected: SQLite JSON-path labels cannot address them without risking
+    /// mutation of a shorter sibling key.
+    async fn set_note_property(
+        &self,
+        id: Uuid,
+        key: &str,
+        value: Value,
         updated_at: i64,
     ) -> StorageResult<bool>;
     /// Query notes by namespace and optional kind with pagination.

--- a/docs/adr/ADR-005-storage-capability-traits.md
+++ b/docs/adr/ADR-005-storage-capability-traits.md
@@ -44,6 +44,10 @@ pub trait NoteStore: Send + Sync + 'static {
     async fn upsert_notes(&self, notes: Vec<Note>) -> StorageResult<BatchWriteSummary>;
     async fn get_note(&self, id: Uuid) -> StorageResult<Option<Note>>;
     async fn delete_note(&self, id: Uuid, mode: DeleteMode) -> StorageResult<bool>;
+    async fn update_note_properties(&self, id: Uuid, properties: Option<Value>,
+                                    updated_at: i64) -> StorageResult<bool>;
+    async fn set_note_property(&self, id: Uuid, key: &str, value: Value,
+                               updated_at: i64) -> StorageResult<bool>;
     async fn query_notes(&self, namespace: &str, kind: Option<&str>,
                          filter: Page) -> StorageResult<Vec<Note>>;
     async fn count_notes(&self, namespace: &str, kind: Option<&str>) -> StorageResult<u64>;
@@ -156,6 +160,23 @@ is the backend's responsibility, not the trait's contract. Backends that support
 only single-vector records reject multi-vector inserts with `StorageError::Unsupported`.
 
 `EventStore` is append-only by construction. There is no `update_event` or `delete_event`.
+
+### Atomic note-property mutation
+
+`update_note_properties` remains the explicit whole-document replacement operation. Callers that
+own only one field must use `set_note_property`: it sets one literal top-level key and refreshes
+`updated_at` as one backend operation. A backend must not implement it as `get_note` followed by
+`update_note_properties`, because two writers setting different keys would still lose the earlier
+write. SQLite lowers the operation to one `UPDATE ... json_set(...)` statement.
+
+The value retains its JSON type, including explicit JSON `null`; this is set semantics, not JSON
+Merge Patch deletion semantics. A SQL-NULL document starts as `{}`. A live row whose stored
+properties value is an array, scalar, or JSON `null` is not an object and is left unchanged, with
+the method returning `false`. Missing and soft-deleted rows also return `false`. The method is a
+storage capability only: runtime/pack code still owns authorization, kind rules, secret checks,
+and reserved-field policy. Keys containing U+0000 are rejected with `InvalidInput`: SQLite's JSON
+path implementation cannot address an object label past that code point and could otherwise mutate
+a shorter sibling key instead of the requested literal key.
 
 ### Dispatch: `Arc<dyn Trait>`
 

--- a/docs/adr/ADR-040-communication-and-schedule-packs.md
+++ b/docs/adr/ADR-040-communication-and-schedule-packs.md
@@ -608,6 +608,10 @@ throw away a successful read for a caller who cannot retry the fetch half.
 kind, outbound direction, wrong addressee) remain fatal and unchanged. The post-read
 mark-read patch itself is best-effort:
 
+The patch uses `NoteStore::set_note_property("read", true)`, an atomic storage-level JSON set.
+It does not replace the properties document, so a concurrent write to another key survives without
+a get/retry loop. This changes no `comm.read` response field or error/degradation rule.
+
 - On success, the response is as originally specified: `read: true`, `properties` is the
   updated envelope.
 - On a no-op (no live row updated, e.g. soft-deleted mid-flight) or a storage error, the

--- a/docs/adr/ADR-124-note-write-identity.md
+++ b/docs/adr/ADR-124-note-write-identity.md
@@ -239,20 +239,18 @@ to send instead: an object containing the keys the caller intends to set.
   `update` and `merge`.
 
 The second claim rests on there being no legitimate writer of those fields after creation, which
-holds at source. Comm's post-write property writes do not go through the `update` verb at all:
-they use the store-level `update_note_properties` at `khive-pack-comm/src/handlers.rs:450`
-(read-marking, writes `read`) and `:2371` (ADR-122 outbox delivery outcome, writing only
-`delivery`, `failed_at`, `last_error`, `delivery_attempts` and `next_attempt_at`,
-`handlers.rs:2320-2366`). No production path writes `from_actor`, `direction` or `sent_at` after
-creation; every other occurrence is a creation-site build (`message.rs:204,298`,
-`handlers.rs:141,681,1193`, `khive-component-email/src/lib.rs:556`) or a test fixture
-(`handlers.rs:2745-2760`).
+holds at source. Comm's post-write read bookkeeping does not go through the `update` verb: both
+`handle_read` and `handle_reply` call the store-level `set_note_property` with the literal key
+`read`. That single-key path prevents unrelated concurrent metadata from being lost, but it does
+not make identity mutation legitimate. No production path writes `from_actor`, `direction`, or
+`sent_at` after creation; every other occurrence is a creation-site build or a test fixture.
 
-The bound, stated so it is recognised rather than rediscovered: `update_note_properties` is a
-store-level path that bypasses the owned-field check entirely. It is safe today because it has no
-verb surface and writes only delivery and read bookkeeping. Giving it a caller-facing surface, or
-using it to write an identity field, reopens the hole this ADR closes; no check is added there
-now.
+The bound, stated so it is recognised rather than rediscovered: both
+`update_note_properties` (whole-document replacement) and `set_note_property` (one-key atomic set)
+are store-level paths that bypass the owned-field check entirely. They are safe only while they
+have no caller-facing verb surface and pack code limits them to its own mutable bookkeeping keys.
+Giving either a caller-facing surface, or using either to write an identity field, reopens the hole
+this ADR closes; no identity check belongs in the kind-agnostic storage layer.
 
 **4. A merge cannot rewrite who sent a message.**
 


### PR DESCRIPTION
## Summary

- add `NoteStore::set_note_property` as a one-operation, top-level JSON property mutation contract
- lower SQLite writes to one parameterized `json_set` update so concurrent writers to distinct keys preserve both values and every unrelated note column
- migrate `comm.read` and reply read-marking away from get/replace cycles without changing their wire responses or best-effort degradation rules
- preserve JSON value types, initialize SQL-NULL documents as objects, refuse non-object/deleted rows, and reject U+0000 keys before SQLite path dispatch to prevent ambiguous sibling mutation

Closes #1483.

## Validation

- `cargo test -p khive-storage -p khive-db -p khive-pack-comm --all-features`
- `cargo test -p khive-db set_note_property --all-features`
- `cargo test --workspace`
- `cargo check --workspace`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `RUSTDOCFLAGS='-D warnings' cargo doc --workspace --no-deps`
- `cargo fmt --all -- --check`
- `deno fmt --check docs/`
- `deno fmt --check` on every changed crate-local Markdown file
- `sh scripts/lint-sql.sh`
- `sh scripts/lint-adr-refs.sh`
- `sh scripts/lint-adr-refs.sh --self-test`
- `sh scripts/lint-stub-markers.sh`
- `sh scripts/lint-stub-markers.sh --self-test`
- `git diff --check origin/main...HEAD`

## ADR

- ADR-005 documents the atomic single-property storage capability and SQLite key constraint.
- ADR-040 documents comm's use of the atomic read-property mutation.
- ADR-124 retains identity-field ownership at the pack/runtime seam.

> AI-assisted contribution: Codex prepared this change and PR description.
