### PR TITLE
fix(knowledge): merge fresh ANN tail at query time

### DIFF
--- a/crates/khive-db/sql/011-ann-write-log.sql
+++ b/crates/khive-db/sql/011-ann-write-log.sql
@@ -18,11 +18,14 @@ CREATE INDEX IF NOT EXISTS idx_ann_write_log_ns_model_seq
     ON ann_write_log (namespace, embedding_model, seq);
 
 -- Durable per-consumer watermark registry gating log compaction. A consumer
--- registers its row at watermark 0 (INSERT OR IGNORE) before persisting or
--- serving any extended-format segment, then raises it monotonically after each
--- segment commit. Compaction deletes only seq <= MIN(watermark) over the
--- (namespace, embedding_model) pair's registered rows, so a stale or
--- crash-frozen row under-compacts (safe) and never hides a consumer's tail.
+-- normally registers its row at watermark 0 (INSERT OR IGNORE) before persist
+-- or serve, then raises it monotonically after each segment commit. The
+-- knowledge consumer additionally uses -1 as a closed force-rebuild sentinel:
+-- every absent row writes -1 before an authoritative scan (local first-use
+-- evidence cannot rule out a stale peer), and only that consumer's fenced full
+-- checkpoint may transition it to S >= 0. Compaction
+-- deletes only seq <= MIN(watermark) over the pair's registered rows, so 0 and
+-- -1 both block unsafe deletion; stale/crash-frozen rows only under-compact.
 CREATE TABLE IF NOT EXISTS ann_consumer_watermark (
     consumer        TEXT NOT NULL,
     namespace       TEXT NOT NULL,

--- a/crates/khive-pack-knowledge/docs/api/vamana.md
+++ b/crates/khive-pack-knowledge/docs/api/vamana.md
@@ -22,9 +22,47 @@ sqlite-vec corpus on cache-miss. `kkernel reindex` re-persists v2 segments and c
 This module exceeds the 700-line soft target because it owns the complete Vamana ANN
 lifecycle for knowledge search: `SharedAnn` type, `AnnKey`, snapshot persistence
 (`warm_known_snapshots` / `ensure_ann_background`), index build (`build_ann`), search
-(`search_loaded`), and all associated SQL queries and serialization logic. These
+(`search_loaded_with_seq` plus the ADR-118 exact tail), and all associated SQL queries and
+serialization logic. These
 responsibilities are tightly coupled through the shared `AnnState` and cannot be split
 without obscuring the generation-fenced install and warm-ownership lock protocol.
+
+## Fresh-tail serving (ADR-118)
+
+`knowledge.search` and `knowledge.suggest` capture ANN candidates and the loaded bridge's
+write-log watermark under one cache read lock, then exact-score the final state of every
+`knowledge.atom` write above that watermark. One SQLite statement reads the consumer row,
+wildcard-inclusive pair minimum, optional live count, selected log suffix, and joined current
+embeddings; separate calls on a pool-backed reader would not guarantee one snapshot. Tail
+upserts replace stale ANN candidates, final deletes remove them, and the merged ordering remains
+one vector source for RRF rather than adding a new fusion leg. Equal scores break by UUID, making
+the result independent of hash-map iteration order. This makes an externally committed vector
+visible on the next query even when the daemon still holds an older segment.
+
+The same snapshot reads the wildcard-inclusive consumer-registry minimum before scanning the
+log. If compaction has advanced beyond the loaded bridge, the current query reloads and searches
+the newly published segment, then revalidates its watermark and reads that segment's own tail in
+one snapshot. Peer checkpoints that advance during revalidation cause a bounded reload retry; the
+terminal fallback serves only the exact suffix above the last same-snapshot registry floor, never
+the original stale candidates under a newer floor. The stale cache generation is retired so the
+normal warm path adopts the published segment for following queries. File-backed checkpoints
+publish their replacement bridge before raising the durable registry watermark, making that
+process's mismatch window empty while preserving crash-safe under-compaction. Pathless checkpoints
+serialize the inverse raise-then-install sequence with the per-key process lock.
+
+When no bridge is serving, the exact leg scans only the newest
+`ceil(KHIVE_ANN_REBUILD_THRESHOLD × live_count)` raw retained log rows, applying the cap before
+final-state coalescing. This is ADR-118's bounded Cold/Empty guarantee, not a corpus-scale exact
+fallback. If the consumer row is absent, the first detector publishes the durable `-1`
+force-rebuild sentinel under the bridge publication lock and rejects or evicts local serving
+state. This applies
+even when that process has no local or persisted bridge: local evidence cannot rule out a stale
+peer. The sentinel writer re-reads the row after acquiring both publication locks; if a rebuild
+already completed while it waited, it preserves the winner instead of demoting the row again.
+Every process rejects cached, v2, and legacy-v1 state while `-1` remains; only a fenced successful
+full scan may transition it to a normal watermark. Failed or Empty scans keep the sentinel so a
+re-created row cannot be mistaken for uninterrupted registry history.
+`KHIVE_ANN_FRESH_TAIL=0` disables the exact leg but does not bypass this registry guard.
 
 ## `AnnState::warm_states` (shared warm lifecycle, issue #566)
 
@@ -57,16 +95,23 @@ flight for it.
 
 ## `save_atomic`
 
-Writes Vamana index segments via `VamanaIndex::save_atomic` (which commits a v2
-`KHVVAMG2` record in `metadata.bin` carrying a `content_hash`), then writes the id-map
-sidecar (`external_ids.bin`) atomically via a tmp-then-rename sequence, stamped with the
-corpus `content_hash` taken from the v2 commit record.
+Acquires `<segment-dir>/.bridge-checkpoint.lock`, writes Vamana index segments via
+`VamanaIndex::save_atomic` (which commits a v2 `KHVVAMG2` record in `metadata.bin` carrying a
+`content_hash`), then writes the id-map sidecar (`external_ids.bin`) atomically via a
+tmp-then-rename sequence stamped with the commit digest. Checkpoint callers retain that same lock
+through mmap re-adoption and the conditional consumer-watermark transition. Sentinel publication
+takes it too, preventing both mixed commit/sidecar pairs and a checkpoint racing registry-loss
+recovery. A per-key process lock wraps the same checkpoint on every runtime, including pathless
+in-memory runtimes, so a later durable raise cannot be followed by an older cache install.
 
 ## `ensure_ann_for_model` load order
 
 First hit wins:
 
-1. **Fast path** — already in the in-memory cache; return immediately.
+1. **Registration guard and fast path** — read the durable consumer row before trusting the
+   cache. A normal row permits an already-current in-memory bridge to return immediately. Every
+   absent row is changed to `-1`, even when this process has no bridge; an existing `-1` marks
+   local force-rebuild state. Both bypass every persisted-state path.
 2. **v2 segment path** — if a `<db-file>.ann/<hex>/` directory exists with a valid
    `metadata.bin`, run the ADR-079 Amendment 1 restart classifier
    (`classify_and_adopt_segment`): a per-write delta log (`ann_write_log`) plus each
@@ -78,9 +123,16 @@ First hit wins:
 3. **v1 JSON snapshot path** — try `retrieval_snapshots`; on hit, validate the
    `CorpusFingerprint` (count + dims) and restore from JSON. On miss / stale / corrupt,
    fall through.
-4. **Rebuild fallthrough** — scan the full sqlite-vec corpus, build the index from
-   scratch, and atomically write a v2 segment directory so the next daemon restart can
-   use path 2. Write failures are logged and do not block search.
+4. **Rebuild fallthrough** — capture full-scan authority, then scan the full sqlite-vec corpus,
+   build the index from scratch, and atomically write a v2 segment directory so the next daemon
+   restart can use path 2. The scan reads the global `ann_write_log` AUTOINCREMENT high-water from
+   `sqlite_sequence` in the same statement as the corpus; unlike retained scoped `MAX(seq)`, that
+   watermark cannot regress after compaction. The checkpoint may clear local force-rebuild state
+   only after its conditional durable transition succeeds at the captured namespace generation.
+   Before writing, every ordinary checkpoint also requires its candidate watermark to be at least
+   the current durable watermark. The conditional raise repeats that monotonic fence, so a stale
+   publisher adopts the winner instead of overwriting it while leaving a newer registry value.
+   Empty and failed authoritative scans leave `-1` in place.
 
 ## `install_if_fresher` (PR #815, covering issue #770's empty-slot scenario)
 

--- a/crates/khive-pack-knowledge/src/knowledge/index_handler.rs
+++ b/crates/khive-pack-knowledge/src/knowledge/index_handler.rs
@@ -220,31 +220,47 @@ impl KnowledgeHandlers {
             // rebuild insertion with the same generation check the warm path uses,
             // instead of the old presence-only `insert_ann_if_absent`.
             let build_generation = vamana::current_generation(ann, &ns);
+            let key = vamana::AnnKey::new(&ns, model_name);
+            let scan_authority = match vamana::prepare_full_corpus_scan(runtime, ann, &key).await {
+                Ok(authority) => Some(authority),
+                Err(e) => {
+                    tracing::error!(error = %e, "failed to establish Vamana full-scan authority");
+                    ann_failed = true;
+                    None
+                }
+            };
             // Build from the shared corpus scan (ORDER BY subject_id) so the persisted
             // v2 content_hash matches the warm-path live_content_hash. Building from
             // atom-iteration order persists a hash the warm path always reads as stale.
-            match vamana::load_and_build_from_vector_store(runtime, token, model_name).await {
-                Ok(Some(bridge)) => {
-                    let n = bridge.num_vectors();
-                    ann_count = Some(n);
-                    let key = vamana::AnnKey::new(&ns, model_name);
-                    vamana::checkpoint_raise_compact_readopt(
-                        runtime,
-                        ann,
-                        &key,
-                        &ns,
-                        model_name,
-                        bridge,
-                        build_generation,
-                    )
-                    .await;
-                    eprintln!("  Vamana ANN built ({n} vectors)");
-                }
-                Ok(None) => {}
-                Err(e) => {
-                    tracing::error!(error = %e, "failed to build Vamana ANN index");
-                    eprintln!("  Vamana ANN build failed: {e}");
-                    ann_failed = true;
+            if let Some(scan_authority) = scan_authority {
+                match vamana::load_and_build_from_vector_store(runtime, token, model_name).await {
+                    Ok(Some(bridge)) => {
+                        let n = bridge.num_vectors();
+                        ann_count = Some(n);
+                        let published = vamana::checkpoint_raise_compact_readopt(
+                            runtime,
+                            ann,
+                            &key,
+                            bridge,
+                            build_generation,
+                            scan_authority,
+                        )
+                        .await;
+                        if published {
+                            eprintln!("  Vamana ANN built ({n} vectors)");
+                        } else {
+                            tracing::warn!(
+                                "Vamana ANN publication was fenced; retrying on the next rebuild"
+                            );
+                            ann_failed = true;
+                        }
+                    }
+                    Ok(None) => {}
+                    Err(e) => {
+                        tracing::error!(error = %e, "failed to build Vamana ANN index");
+                        eprintln!("  Vamana ANN build failed: {e}");
+                        ann_failed = true;
+                    }
                 }
             }
         }

--- a/crates/khive-pack-knowledge/src/knowledge/search.rs
+++ b/crates/khive-pack-knowledge/src/knowledge/search.rs
@@ -42,10 +42,36 @@ struct ScoredHit {
     score: f32,
 }
 
-enum AnnSearchState {
-    Loaded(Vec<(Uuid, f32)>),
+enum AnnAvailability {
+    Ready,
     WarmingTimedOut { corpus_non_empty: bool },
     Absent,
+}
+
+struct AnnSearchState {
+    hits: Vec<(Uuid, f32)>,
+    availability: AnnAvailability,
+}
+
+async fn merge_fresh_tail_for_search(
+    runtime: &KhiveRuntime,
+    ann: &vamana::SharedAnn,
+    key: &vamana::AnnKey,
+    query_embedding: &[f32],
+    k: usize,
+    loaded: Option<(Vec<(Uuid, f32)>, u64)>,
+) -> Vec<(Uuid, f32)> {
+    let (candidates, watermark) = match loaded {
+        Some((candidates, watermark)) => (candidates, Some(watermark)),
+        None => (Vec::new(), None),
+    };
+    match vamana::fresh_tail_leg(runtime, ann, key, query_embedding, k, watermark).await {
+        vamana::FreshTailOutcome::Ops(ops) => {
+            vamana::merge_fresh_tail(candidates, query_embedding, ops)
+        }
+        vamana::FreshTailOutcome::Replace(replacement) => replacement,
+        vamana::FreshTailOutcome::Skipped => candidates,
+    }
 }
 
 /// Search the loaded ANN slot, waiting a bounded time when its warm is in flight.
@@ -57,11 +83,19 @@ async fn search_ann_with_warm_wait(
     query_embedding: &[f32],
     k: usize,
 ) -> AnnSearchState {
-    if let Some(hits) = vamana::search_loaded(ann, key, query_embedding, k).await {
-        return AnnSearchState::Loaded(hits);
+    if let Some(loaded) = vamana::search_loaded_with_seq(ann, key, query_embedding, k).await {
+        return AnnSearchState {
+            hits: merge_fresh_tail_for_search(runtime, ann, key, query_embedding, k, Some(loaded))
+                .await,
+            availability: AnnAvailability::Ready,
+        };
     }
     if !vamana::is_warming_not_loaded(ann, key) {
-        return AnnSearchState::Absent;
+        let hits = merge_fresh_tail_for_search(runtime, ann, key, query_embedding, k, None).await;
+        return AnnSearchState {
+            hits,
+            availability: AnnAvailability::Absent,
+        };
     }
     if vamana::wait_ready(
         ann,
@@ -71,10 +105,14 @@ async fn search_ann_with_warm_wait(
     )
     .await
     {
-        return match vamana::search_loaded(ann, key, query_embedding, k).await {
-            Some(hits) => AnnSearchState::Loaded(hits),
-            None => AnnSearchState::Absent,
+        let loaded = vamana::search_loaded_with_seq(ann, key, query_embedding, k).await;
+        let availability = if loaded.is_some() {
+            AnnAvailability::Ready
+        } else {
+            AnnAvailability::Absent
         };
+        let hits = merge_fresh_tail_for_search(runtime, ann, key, query_embedding, k, loaded).await;
+        return AnnSearchState { hits, availability };
     }
 
     let corpus_non_empty =
@@ -82,7 +120,11 @@ async fn search_ann_with_warm_wait(
             .await
             .map(|fingerprint| fingerprint.vector_count > 0)
             .unwrap_or(false);
-    AnnSearchState::WarmingTimedOut { corpus_non_empty }
+    let hits = merge_fresh_tail_for_search(runtime, ann, key, query_embedding, k, None).await;
+    AnnSearchState {
+        hits,
+        availability: AnnAvailability::WarmingTimedOut { corpus_non_empty },
+    }
 }
 
 // ─── ANN fusion (symmetric RRF) ─────────────────────────────────────────────
@@ -1302,26 +1344,30 @@ impl KnowledgeHandlers {
         let mut ann_unavailable = false;
         if let Ok(query_emb) = runtime.embed_query(&raw_query).await {
             let ann_k = fetch_limit.max(20);
-            let key = vamana::AnnKey::new(&ns, runtime.default_embedder_name());
+            let model = runtime.default_embedder_name();
+            let key = vamana::AnnKey::new(&ns, model);
+            let AnnSearchState {
+                hits: ann_hits,
+                availability,
+            } = search_ann_with_warm_wait(runtime, token, ann, &key, &query_emb, ann_k).await;
 
-            match search_ann_with_warm_wait(runtime, token, ann, &key, &query_emb, ann_k).await {
-                AnnSearchState::Loaded(ann_hits) if !ann_hits.is_empty() => {
-                    fuse_ann_hits(&mut hits, &ann_hits, min_score);
-                    hydrate_empty_hits(runtime, &ns, &mut hits).await;
-                    // ANN-sourced hits bypass the SQL status predicate; apply the
-                    // same exclusion policy here so all result sources are consistent.
-                    filter_by_excluded_statuses(&mut hits, &exclude_statuses_buf);
+            if !ann_hits.is_empty() {
+                fuse_ann_hits(&mut hits, &ann_hits, min_score);
+                hydrate_empty_hits(runtime, &ns, &mut hits).await;
+                // ANN-sourced hits bypass the SQL status predicate; apply the
+                // same exclusion policy here so all result sources are consistent.
+                filter_by_excluded_statuses(&mut hits, &exclude_statuses_buf);
+            }
+            // FTS hits remain valid partial results. Preserve the existing
+            // advisory only for a non-empty corpus with no lexical fallback.
+            if matches!(
+                availability,
+                AnnAvailability::WarmingTimedOut {
+                    corpus_non_empty: true
                 }
-                // FTS hits remain valid partial results. Preserve the existing
-                // advisory only for a non-empty corpus with no lexical fallback.
-                AnnSearchState::WarmingTimedOut { corpus_non_empty }
-                    if corpus_non_empty && hits.is_empty() =>
-                {
-                    ann_unavailable = true;
-                }
-                AnnSearchState::Loaded(_)
-                | AnnSearchState::WarmingTimedOut { .. }
-                | AnnSearchState::Absent => {}
+            ) && hits.is_empty()
+            {
+                ann_unavailable = true;
             }
         }
         // Apply the kind gate unconditionally — both FTS-sourced and ANN-sourced
@@ -1410,24 +1456,26 @@ impl KnowledgeHandlers {
             // 50× over-fetch (floor 200) gives domains a fair chance to appear in the
             // top ANN neighbors before the type gate discards atom hits.
             let ann_k = (limit * 50).max(200);
-            let key = vamana::AnnKey::new(&ns, runtime.default_embedder_name());
+            let model = runtime.default_embedder_name();
+            let key = vamana::AnnKey::new(&ns, model);
+            let AnnSearchState {
+                hits: ann_hits,
+                availability,
+            } = search_ann_with_warm_wait(runtime, token, ann, &key, &query_emb, ann_k).await;
 
-            match search_ann_with_warm_wait(runtime, token, ann, &key, &query_emb, ann_k).await {
-                AnnSearchState::Loaded(ann_hits) if !ann_hits.is_empty() => {
-                    fuse_ann_hits(&mut hits, &ann_hits, 0.0);
-                    hydrate_empty_hits(runtime, &ns, &mut hits).await;
-                    // Apply the same status exclusion to ANN-sourced domain hits.
-                    filter_by_excluded_statuses(&mut hits, SUGGEST_EXCLUDE);
-                    // Drop non-domain ANN hits before rerank/truncate so atom hits do
-                    // not crowd out domain hits in the final ranking.
-                    filter_hits_by_type(&mut hits, Some("domain"));
-                }
-                // Suggest always reports degraded candidate recall for a
-                // non-empty corpus, even when lexical candidates survived.
-                AnnSearchState::WarmingTimedOut { corpus_non_empty } => {
-                    ann_unavailable = corpus_non_empty;
-                }
-                AnnSearchState::Loaded(_) | AnnSearchState::Absent => {}
+            if !ann_hits.is_empty() {
+                fuse_ann_hits(&mut hits, &ann_hits, 0.0);
+                hydrate_empty_hits(runtime, &ns, &mut hits).await;
+                // Apply the same status exclusion to ANN-sourced domain hits.
+                filter_by_excluded_statuses(&mut hits, SUGGEST_EXCLUDE);
+                // Drop non-domain ANN hits before rerank/truncate so atom hits do
+                // not crowd out domain hits in the final ranking.
+                filter_hits_by_type(&mut hits, Some("domain"));
+            }
+            // Suggest always reports degraded candidate recall for a
+            // non-empty corpus, even when lexical candidates survived.
+            if let AnnAvailability::WarmingTimedOut { corpus_non_empty } = availability {
+                ann_unavailable = corpus_non_empty;
             }
         }
 

--- a/crates/khive-pack-knowledge/src/knowledge/vamana.rs
+++ b/crates/khive-pack-knowledge/src/knowledge/vamana.rs
@@ -1,9 +1,10 @@
 // FILE SIZE JUSTIFICATION: This module exceeds the 700-line soft target because it owns
 // the complete Vamana ANN lifecycle for knowledge search: SharedAnn type, AnnKey, snapshot
 // persistence (warm_known_snapshots / ensure_ann_background), index build (build_ann),
-// search (search_loaded), and all associated SQL queries and serialization logic. These
-// responsibilities are tightly coupled through the shared AnnState and its generation-fenced
-// warm/install protocol; splitting them would obscure the lock ordering and ownership contract.
+// search (search_loaded_with_seq plus the fresh-tail exact leg), and all associated SQL
+// queries and serialization logic. These responsibilities are tightly coupled through the
+// shared AnnState and its generation-fenced warm/install protocol; splitting them would obscure
+// the lock ordering and ownership contract.
 
 //! Vamana ANN bridge — parallel semantic signal for `knowledge.search`.
 //!
@@ -15,7 +16,7 @@
 //! crates/khive-pack-knowledge/docs/api/vamana.md for the persistence
 //! fallback chain and the file-size/module-coupling rationale.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 
@@ -134,6 +135,17 @@ pub(crate) struct AnnState {
     /// `install_if_fresher` clears a key's marker whenever it actually
     /// installs a fresh index for that key.
     unavailable: std::sync::Mutex<HashMap<AnnKey, u64>>,
+    /// Keys whose durable consumer registration disappeared while an index
+    /// was serving.  Such a bridge is untrusted because another consumer may
+    /// already have compacted part of its tail (ADR-118 registration
+    /// precondition).  The marker is installed before re-registration and is
+    /// cleared only after an authoritative full-corpus scan publishes at the
+    /// current namespace generation.
+    force_rebuild: std::sync::Mutex<HashSet<AnnKey>>,
+    /// Process-local half of checkpoint publication serialization. File-backed
+    /// runtimes additionally take the directory lock for cross-process safety;
+    /// pathless runtimes need this lock to linearize raise-then-install.
+    checkpoint_locks: std::sync::Mutex<HashMap<AnnKey, std::sync::Weak<tokio::sync::Mutex<()>>>>,
 }
 
 pub(crate) type SharedAnn = Arc<AnnState>;
@@ -145,7 +157,47 @@ pub(crate) fn new_shared() -> SharedAnn {
         next_warm_attempt_id: AtomicU64::new(1),
         generations: std::sync::Mutex::new(HashMap::new()),
         unavailable: std::sync::Mutex::new(HashMap::new()),
+        force_rebuild: std::sync::Mutex::new(HashSet::new()),
+        checkpoint_locks: std::sync::Mutex::new(HashMap::new()),
     })
+}
+
+fn force_rebuild_guard(
+    m: &std::sync::Mutex<HashSet<AnnKey>>,
+) -> std::sync::MutexGuard<'_, HashSet<AnnKey>> {
+    m.lock().unwrap_or_else(std::sync::PoisonError::into_inner)
+}
+
+fn mark_force_rebuild(ann: &SharedAnn, key: &AnnKey) {
+    force_rebuild_guard(&ann.force_rebuild).insert(key.clone());
+}
+
+fn force_rebuild_required(ann: &SharedAnn, key: &AnnKey) -> bool {
+    force_rebuild_guard(&ann.force_rebuild).contains(key)
+}
+
+fn clear_force_rebuild_if_current(ann: &SharedAnn, key: &AnnKey, generation: u64) {
+    if current_generation(ann, &key.namespace) == generation {
+        clear_force_rebuild(ann, key);
+    }
+}
+
+fn clear_force_rebuild(ann: &SharedAnn, key: &AnnKey) {
+    force_rebuild_guard(&ann.force_rebuild).remove(key);
+}
+
+fn checkpoint_lock(ann: &SharedAnn, key: &AnnKey) -> Arc<tokio::sync::Mutex<()>> {
+    let mut locks = ann
+        .checkpoint_locks
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    locks.retain(|_, lock| lock.strong_count() > 0);
+    if let Some(lock) = locks.get(key).and_then(std::sync::Weak::upgrade) {
+        return lock;
+    }
+    let lock = Arc::new(tokio::sync::Mutex::new(()));
+    locks.insert(key.clone(), Arc::downgrade(&lock));
+    lock
 }
 
 // Recover a poisoned generations Mutex rather than aborting: the guarded
@@ -224,7 +276,7 @@ pub(crate) async fn install_if_fresher(ann: &SharedAnn, key: &AnnKey, candidate:
 /// segment with its completed rebuild (rule 8 → rebuild completion). The
 /// A/B-race protection that motivates tie-keeps-incumbent in
 /// `install_if_fresher` does not apply inside a single single-flight task.
-pub(crate) async fn install_replacing(ann: &SharedAnn, key: &AnnKey, candidate: AnnBridge) {
+pub(crate) async fn install_replacing(ann: &SharedAnn, key: &AnnKey, candidate: AnnBridge) -> bool {
     let mut idxs = ann.indexes.write().await;
     let ns_generation = current_generation(ann, &key.namespace);
     if candidate.generation < ns_generation {
@@ -234,10 +286,26 @@ pub(crate) async fn install_replacing(ann: &SharedAnn, key: &AnnKey, candidate: 
             namespace_generation = ns_generation,
             "knowledge ANN replace skipped: candidate predates namespace's current generation"
         );
-        return;
+        return false;
     }
     idxs.insert(key.clone(), candidate);
     unavailable_guard(&ann.unavailable).remove(key);
+    true
+}
+
+async fn has_current_index(ann: &SharedAnn, key: &AnnKey) -> bool {
+    let idxs = ann.indexes.read().await;
+    let current = current_generation(ann, &key.namespace);
+    idxs.get(key)
+        .is_some_and(|bridge| bridge.generation >= current)
+}
+
+async fn has_current_index_at_watermark(ann: &SharedAnn, key: &AnnKey, watermark: u64) -> bool {
+    let idxs = ann.indexes.read().await;
+    let current = current_generation(ann, &key.namespace);
+    idxs.get(key).is_some_and(|bridge| {
+        bridge.generation >= current && bridge.index.last_applied_seq().unwrap_or(0) >= watermark
+    })
 }
 
 // Recover a poisoned warm-state Mutex rather than aborting: each transition is
@@ -452,6 +520,7 @@ pub(crate) async fn clear_namespace(ann: &SharedAnn, namespace: &str) {
 }
 
 /// Search the already-loaded index for `key`. Returns `None` on cache miss.
+#[cfg(test)]
 pub(crate) async fn search_loaded(
     ann: &SharedAnn,
     key: &AnnKey,
@@ -460,6 +529,24 @@ pub(crate) async fn search_loaded(
 ) -> Option<Vec<(Uuid, f32)>> {
     let guard = ann.indexes.read().await;
     guard.get(key).map(|bridge| bridge.search(query, k))
+}
+
+/// Search the loaded bridge and capture the write-log watermark represented by
+/// those candidates under the same read-lock guard. A concurrent checkpoint
+/// therefore cannot pair one bridge's hits with another bridge's watermark.
+pub(crate) async fn search_loaded_with_seq(
+    ann: &SharedAnn,
+    key: &AnnKey,
+    query: &[f32],
+    k: usize,
+) -> Option<(Vec<(Uuid, f32)>, u64)> {
+    let guard = ann.indexes.read().await;
+    guard.get(key).map(|bridge| {
+        (
+            bridge.search(query, k),
+            bridge.index.last_applied_seq().unwrap_or(0),
+        )
+    })
 }
 
 /// Returns `true` when `key` has a current-generation `Warming` owner but its
@@ -739,6 +826,15 @@ impl AnnBridge {
     /// is. See crates/khive-pack-knowledge/docs/api/vamana.md#save_atomic.
     #[allow(dead_code)]
     pub fn save_atomic(&self, dir: &std::path::Path) -> Result<(), String> {
+        let _publication_lock = acquire_bridge_checkpoint_lock(dir)?;
+        self.save_atomic_locked(dir)
+    }
+
+    /// Save while the caller holds this directory's bridge-level publication
+    /// lock.  Keeping the lock above both the Vamana commit and UUID sidecar
+    /// prevents two writers from pairing one commit digest with another
+    /// writer's id map.
+    fn save_atomic_locked(&self, dir: &std::path::Path) -> Result<(), String> {
         let count = self.id_map.len();
         if count != self.index.num_vectors() {
             return Err(format!(
@@ -820,6 +916,34 @@ impl AnnBridge {
     }
 }
 
+fn acquire_bridge_checkpoint_lock(dir: &std::path::Path) -> Result<std::fs::File, String> {
+    std::fs::create_dir_all(dir).map_err(|error| {
+        format!(
+            "create ANN bridge checkpoint directory {}: {error}",
+            dir.display()
+        )
+    })?;
+    let lock_path = dir.join(".bridge-checkpoint.lock");
+    let lock = std::fs::OpenOptions::new()
+        .create(true)
+        .truncate(false)
+        .read(true)
+        .write(true)
+        .open(&lock_path)
+        .map_err(|error| format!("open ANN bridge lock {}: {error}", lock_path.display()))?;
+    lock.lock()
+        .map_err(|error| format!("acquire ANN bridge lock {}: {error}", lock_path.display()))?;
+    Ok(lock)
+}
+
+async fn acquire_bridge_checkpoint_lock_async(
+    dir: std::path::PathBuf,
+) -> Result<std::fs::File, String> {
+    tokio::task::spawn_blocking(move || acquire_bridge_checkpoint_lock(&dir))
+        .await
+        .map_err(|error| format!("ANN bridge lock task failed: {error}"))?
+}
+
 fn l2_normalize(v: &mut [f32]) {
     let norm: f32 = v.iter().map(|x| x * x).sum::<f32>().sqrt();
     if norm > 1e-8 {
@@ -887,6 +1011,7 @@ pub(crate) fn sanitize_model_key(s: &str) -> String {
 /// backend is in-memory (no database file) — skipping persistence is not an error.
 /// `save_atomic` binds the id-map sidecar to the commit-record digest internally;
 /// callers do not need to supply a `CorpusFingerprint`.
+#[cfg(test)]
 pub(crate) fn persist_ann_v2(
     rt: &KhiveRuntime,
     ns: &str,
@@ -896,6 +1021,18 @@ pub(crate) fn persist_ann_v2(
     match ann_segment_dir(rt, ns, model) {
         Some(dir) => bridge.save_atomic(&dir),
         None => Ok(()), // in-memory backend — no filesystem, skip silently
+    }
+}
+
+fn persist_ann_v2_locked(
+    rt: &KhiveRuntime,
+    ns: &str,
+    model: &str,
+    bridge: &AnnBridge,
+) -> Result<(), String> {
+    match ann_segment_dir(rt, ns, model) {
+        Some(dir) => bridge.save_atomic_locked(&dir),
+        None => Ok(()),
     }
 }
 
@@ -924,6 +1061,7 @@ fn ann_rebuild_threshold() -> f64 {
 /// segment for the scope: a row at 0 blocks pair-wide compaction instead of
 /// hiding this consumer from the registry `MIN` (ADR-079 Amendment 1 §A
 /// step 1).
+#[cfg(test)]
 async fn register_consumer(rt: &KhiveRuntime, ns: &str, model: &str) -> Result<(), String> {
     let sql = rt.sql();
     let mut w = sql.writer().await.map_err(|e| e.to_string())?;
@@ -943,8 +1081,72 @@ async fn register_consumer(rt: &KhiveRuntime, ns: &str, model: &str) -> Result<(
     Ok(())
 }
 
-/// Read this consumer's own registry watermark. `None` = no row (decision
-/// rule 4: Cold after re-registering at 0).
+/// Durable sentinel for registry-loss recovery.  `-1` is below every legal
+/// sequence watermark, so it both blocks pair-wide compaction (`MIN = -1`)
+/// and tells every process to reject its loaded/persisted bridge until one
+/// authoritative full-corpus checkpoint raises the row to a normal `S >= 0`.
+async fn write_force_rebuild_sentinel_row(rt: &KhiveRuntime, key: &AnnKey) -> Result<(), String> {
+    let sql = rt.sql();
+    let mut writer = sql.writer().await.map_err(|error| error.to_string())?;
+    writer
+        .execute(SqlStatement {
+            sql: "INSERT INTO ann_consumer_watermark \
+                  (consumer, namespace, embedding_model, watermark) \
+                  VALUES (?1, ?2, ?3, -1) \
+                  ON CONFLICT(consumer, namespace, embedding_model) \
+                  DO UPDATE SET watermark = -1"
+                .into(),
+            params: vec![
+                SqlValue::Text(ANN_CONSUMER.into()),
+                SqlValue::Text(key.namespace.clone()),
+                SqlValue::Text(key.model.clone()),
+            ],
+            label: Some("ann_force_authoritative_rebuild".into()),
+        })
+        .await
+        .map_err(|error| error.to_string())?;
+    Ok(())
+}
+
+async fn write_force_rebuild_sentinel(rt: &KhiveRuntime, key: &AnnKey) -> Result<(), String> {
+    // Serialize the sentinel with the complete bridge+sidecar publication and
+    // watermark transition.  A checkpoint that began before registry loss
+    // therefore either finishes before `-1` is published or observes `-1`
+    // under this same lock and aborts without publishing.
+    let _publication_lock = match ann_segment_dir(rt, &key.namespace, &key.model) {
+        Some(dir) => Some(acquire_bridge_checkpoint_lock_async(dir).await?),
+        None => None,
+    };
+    // The detector may have waited behind a successful authoritative
+    // checkpoint. Revalidate under the publication locks so that a delayed
+    // request cannot demote the winner's normal row back to -1.
+    if matches!(
+        read_own_watermark(rt, &key.namespace, &key.model).await?,
+        Some(watermark) if watermark >= 0
+    ) {
+        return Ok(());
+    }
+    write_force_rebuild_sentinel_row(rt, key).await
+}
+
+/// Establish the cross-process precondition for one authoritative rebuild
+/// after consumer-registry loss.  The local marker is deliberately set
+/// before the first await; the transactional SQL upsert then publishes the
+/// same state to every process before this consumer can be treated as
+/// registered again.
+async fn prepare_authoritative_rebuild(
+    rt: &KhiveRuntime,
+    ann: &SharedAnn,
+    key: &AnnKey,
+) -> Result<(), String> {
+    mark_force_rebuild(ann, key);
+    let local_publication_lock = checkpoint_lock(ann, key);
+    let _local_publication_guard = local_publication_lock.lock().await;
+    write_force_rebuild_sentinel(rt, key).await
+}
+
+/// Read this consumer's own registry watermark. `None` means decision-rule-4
+/// registry loss; knowledge publishes `-1` before its authoritative rebuild.
 async fn read_own_watermark(
     rt: &KhiveRuntime,
     ns: &str,
@@ -978,23 +1180,72 @@ async fn read_own_watermark(
 /// Raise this consumer's registered watermark monotonically after a durable
 /// segment commit at `s` (ADR-079 Amendment 1 §A step 2). A crash before this
 /// leaves the smaller watermark — under-compacts, never over-compacts.
-async fn raise_watermark(rt: &KhiveRuntime, ns: &str, model: &str, s: u64) -> Result<(), String> {
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum CheckpointAuthority {
+    Incremental,
+    FullRegistered,
+    FullSentinel,
+}
+
+/// Capture the durable registry state immediately before a full corpus scan.
+/// An absent row is published as the cross-process sentinel rather than a
+/// plain registration: the scan is authoritative and can safely clear it,
+/// while peers must remain Cold for the entire scan window.
+pub(crate) async fn prepare_full_corpus_scan(
+    rt: &KhiveRuntime,
+    ann: &SharedAnn,
+    key: &AnnKey,
+) -> Result<CheckpointAuthority, String> {
+    match read_own_watermark(rt, &key.namespace, &key.model).await? {
+        Some(watermark) if watermark >= 0 => Ok(CheckpointAuthority::FullRegistered),
+        Some(_) => {
+            mark_force_rebuild(ann, key);
+            Ok(CheckpointAuthority::FullSentinel)
+        }
+        None => {
+            prepare_authoritative_rebuild(rt, ann, key).await?;
+            Ok(CheckpointAuthority::FullSentinel)
+        }
+    }
+}
+
+async fn raise_watermark(
+    rt: &KhiveRuntime,
+    ns: &str,
+    model: &str,
+    s: u64,
+    authority: CheckpointAuthority,
+) -> Result<(), String> {
+    let predicate = match authority {
+        CheckpointAuthority::FullSentinel => "watermark = -1",
+        CheckpointAuthority::Incremental | CheckpointAuthority::FullRegistered => {
+            "watermark >= 0 AND watermark <= ?4"
+        }
+    };
     let sql = rt.sql();
     let mut w = sql.writer().await.map_err(|e| e.to_string())?;
-    w.execute(SqlStatement {
-        sql: "UPDATE ann_consumer_watermark SET watermark = MAX(watermark, ?4) \
-              WHERE consumer = ?1 AND namespace = ?2 AND embedding_model = ?3"
-            .into(),
-        params: vec![
-            SqlValue::Text(ANN_CONSUMER.into()),
-            SqlValue::Text(ns.to_owned()),
-            SqlValue::Text(model.to_owned()),
-            SqlValue::Integer(s as i64),
-        ],
-        label: Some("ann_raise_watermark".into()),
-    })
-    .await
-    .map_err(|e| e.to_string())?;
+    let affected = w
+        .execute(SqlStatement {
+            sql: format!(
+                "UPDATE ann_consumer_watermark SET watermark = MAX(watermark, ?4) \
+                 WHERE consumer = ?1 AND namespace = ?2 AND embedding_model = ?3 \
+                   AND {predicate}"
+            ),
+            params: vec![
+                SqlValue::Text(ANN_CONSUMER.into()),
+                SqlValue::Text(ns.to_owned()),
+                SqlValue::Text(model.to_owned()),
+                SqlValue::Integer(s as i64),
+            ],
+            label: Some("ann_raise_watermark".into()),
+        })
+        .await
+        .map_err(|e| e.to_string())?;
+    if affected != 1 {
+        return Err(format!(
+            "ANN watermark publication fence rejected {authority:?}: affected {affected} rows"
+        ));
+    }
     Ok(())
 }
 
@@ -1230,52 +1481,742 @@ async fn replay_final_states(
     Ok(())
 }
 
-/// Persist `bridge` at its applied watermark, raise this consumer's registry
-/// row, compact the pair's log through the registry MIN, then reopen the
-/// just-written segment via the mmap load path and swap it in for the Owned
-/// build product (ADR-079 Amendment 1 §B). Registration precedes the persist
-/// (§A step 1). On any persist/reopen failure the Owned bridge is installed
-/// instead — correctness first, memory second.
+// ── ADR-118: fresh-tail exact leg ─────────────────────────────────────────
+
+fn fresh_tail_enabled() -> bool {
+    std::env::var("KHIVE_ANN_FRESH_TAIL")
+        .map(|value| value != "0")
+        .unwrap_or(true)
+}
+
+struct FreshTailSnapshot {
+    own_watermark: Option<i64>,
+    registry_min: Option<i64>,
+    live_count: Option<u64>,
+    ops: Vec<(Uuid, Option<Vec<f32>>)>,
+}
+
+/// Read the registry guard, optional live-count cap, selected log suffix, and
+/// every final upsert embedding in one SQLite statement.  A single statement
+/// is the snapshot primitive on every backend, including the in-memory
+/// pool-backed reader whose separate calls may use separate connections.
+async fn fetch_fresh_tail_snapshot(
+    rt: &KhiveRuntime,
+    ns: &str,
+    model: &str,
+    watermark: u64,
+    live_threshold: Option<f64>,
+) -> Result<FreshTailSnapshot, String> {
+    let watermark = i64::try_from(watermark)
+        .map_err(|_| "fresh-tail watermark exceeds SQLite INTEGER range".to_string())?;
+    let table_name = format!("vec_{}", sanitize_model_key(model));
+    let (live_cte, selected_order, live_join, live_column) = match live_threshold {
+        Some(_) => (
+            format!(
+                "live AS (\
+                   SELECT COUNT(*) AS live_count FROM {table_name} \
+                   WHERE namespace = ?1 AND embedding_model = ?2 \
+                     AND field = 'knowledge.atom'\
+                 ),"
+            ),
+            "ORDER BY seq DESC \
+             LIMIT (SELECT CAST(live_count * ?5 AS INTEGER) + \
+                       CASE WHEN CAST(live_count * ?5 AS INTEGER) < live_count * ?5 \
+                            THEN 1 ELSE 0 END FROM live)",
+            "CROSS JOIN live",
+            "live.live_count",
+        ),
+        None => (String::new(), "ORDER BY seq", "", "NULL"),
+    };
+    let mut params = vec![
+        SqlValue::Text(ns.to_owned()),
+        SqlValue::Text(model.to_owned()),
+        SqlValue::Integer(watermark),
+        SqlValue::Text(ANN_CONSUMER.into()),
+    ];
+    if let Some(threshold) = live_threshold {
+        params.push(SqlValue::Float(threshold));
+    }
+
+    let sql = rt.sql();
+    let mut reader = sql.reader().await.map_err(|error| error.to_string())?;
+    let rows = reader
+        .query_all(SqlStatement {
+            sql: format!(
+                "WITH \
+                 registry AS (\
+                   SELECT MIN(watermark) AS registry_min \
+                   FROM ann_consumer_watermark \
+                   WHERE (namespace = ?1 OR namespace = '*') \
+                     AND embedding_model = ?2\
+                 ), \
+                 own AS (\
+                   SELECT (SELECT watermark FROM ann_consumer_watermark \
+                           WHERE consumer = ?4 AND namespace = ?1 \
+                             AND embedding_model = ?2) AS own_watermark\
+                 ), \
+                 {live_cte} \
+                 selected AS (\
+                   SELECT seq, subject_id, op FROM ann_write_log \
+                   WHERE namespace = ?1 AND embedding_model = ?2 \
+                     AND field = 'knowledge.atom' \
+                     AND seq > MAX(\
+                       ?3, COALESCE((SELECT registry_min FROM registry), ?3)\
+                     ) \
+                   {selected_order}\
+                 ) \
+                 SELECT selected.seq, selected.subject_id, selected.op, \
+                        vectors.namespace AS vector_namespace, \
+                        vectors.embedding_model AS vector_model, \
+                        vectors.field AS vector_field, \
+                        vectors.embedding, registry.registry_min, \
+                        own.own_watermark, {live_column} AS live_count \
+                 FROM registry CROSS JOIN own {live_join} \
+                 LEFT JOIN selected ON 1 = 1 \
+                 LEFT JOIN {table_name} AS vectors \
+                   ON vectors.subject_id = selected.subject_id \
+                 ORDER BY selected.seq"
+            ),
+            params,
+            label: Some("knowledge_ann_fresh_tail_snapshot".into()),
+        })
+        .await
+        .map_err(|error| error.to_string())?;
+
+    let first = rows
+        .first()
+        .ok_or_else(|| "fresh-tail snapshot returned no registry row".to_string())?;
+    let read_optional_i64 = |column: &str| -> Result<Option<i64>, String> {
+        match first.get(column) {
+            Some(SqlValue::Integer(value)) => Ok(Some(*value)),
+            Some(SqlValue::Null) | None => Ok(None),
+            other => Err(format!("fresh-tail {column}: unexpected value {other:?}")),
+        }
+    };
+    let own_watermark = read_optional_i64("own_watermark")?;
+    let registry_min = read_optional_i64("registry_min")?;
+    let live_count = match read_optional_i64("live_count")? {
+        Some(value) => {
+            Some(u64::try_from(value).map_err(|_| "negative fresh-tail live_count".to_string())?)
+        }
+        None => None,
+    };
+
+    type RawVector = (
+        Option<String>,
+        Option<String>,
+        Option<String>,
+        Option<Vec<u8>>,
+    );
+    let mut finals: Vec<(Uuid, bool, RawVector)> = Vec::new();
+    let mut index_by_id: HashMap<Uuid, usize> = HashMap::new();
+    for row in &rows {
+        let Some(SqlValue::Integer(_)) = row.get("seq") else {
+            continue;
+        };
+        let subject = match row.get("subject_id") {
+            Some(SqlValue::Text(value)) => Uuid::parse_str(value)
+                .map_err(|error| format!("fresh-tail subject_id {value}: {error}"))?,
+            other => return Err(format!("fresh-tail subject_id: unexpected value {other:?}")),
+        };
+        let is_delete = match row.get("op") {
+            Some(SqlValue::Text(value)) if value == "delete" => true,
+            Some(SqlValue::Text(value)) if value == "upsert" => false,
+            other => return Err(format!("fresh-tail op: unexpected value {other:?}")),
+        };
+        let raw_vector = (
+            match row.get("vector_namespace") {
+                Some(SqlValue::Text(value)) => Some(value.clone()),
+                _ => None,
+            },
+            match row.get("vector_model") {
+                Some(SqlValue::Text(value)) => Some(value.clone()),
+                _ => None,
+            },
+            match row.get("vector_field") {
+                Some(SqlValue::Text(value)) => Some(value.clone()),
+                _ => None,
+            },
+            match row.get("embedding") {
+                Some(SqlValue::Blob(value)) => Some(value.clone()),
+                _ => None,
+            },
+        );
+        match index_by_id.get(&subject) {
+            Some(&index) => finals[index] = (subject, is_delete, raw_vector),
+            None => {
+                index_by_id.insert(subject, finals.len());
+                finals.push((subject, is_delete, raw_vector));
+            }
+        }
+    }
+
+    let mut ops = Vec::with_capacity(finals.len());
+    for (subject, is_delete, (vector_ns, vector_model, vector_field, embedding)) in finals {
+        if is_delete {
+            ops.push((subject, None));
+            continue;
+        }
+        let in_scope = vector_ns.as_deref() == Some(ns)
+            && vector_model.as_deref() == Some(model)
+            && vector_field.as_deref() == Some("knowledge.atom");
+        if !in_scope {
+            return Err(format!(
+                "fresh-tail upsert {subject}: vector row outside consumer scope"
+            ));
+        }
+        let Some(bytes) = embedding else {
+            return Err(format!(
+                "fresh-tail upsert {subject}: embedding is not a blob"
+            ));
+        };
+        if bytes.len() % std::mem::size_of::<f32>() != 0 {
+            return Err(format!(
+                "fresh-tail upsert {subject}: malformed embedding byte length {}",
+                bytes.len()
+            ));
+        }
+        let embedding = bytes
+            .chunks_exact(4)
+            .map(|chunk| f32::from_le_bytes([chunk[0], chunk[1], chunk[2], chunk[3]]))
+            .collect();
+        ops.push((subject, Some(embedding)));
+    }
+    Ok(FreshTailSnapshot {
+        own_watermark,
+        registry_min,
+        live_count,
+        ops,
+    })
+}
+
+fn exact_cosine(query: &[f32], embedding: &[f32]) -> f32 {
+    if query.len() != embedding.len() || query.is_empty() {
+        return 0.0;
+    }
+    let mut query = query.to_vec();
+    let mut embedding = embedding.to_vec();
+    l2_normalize(&mut query);
+    l2_normalize(&mut embedding);
+    query
+        .iter()
+        .zip(embedding.iter())
+        .map(|(left, right)| left * right)
+        .sum::<f32>()
+        .max(0.0)
+}
+
+pub(crate) fn merge_fresh_tail(
+    candidates: Vec<(Uuid, f32)>,
+    query: &[f32],
+    ops: Vec<(Uuid, Option<Vec<f32>>)>,
+) -> Vec<(Uuid, f32)> {
+    if ops.is_empty() {
+        return candidates;
+    }
+    let mut deletes = HashSet::new();
+    let mut upserts = HashMap::new();
+    for (subject, op) in ops {
+        match op {
+            Some(embedding) => {
+                upserts.insert(subject, exact_cosine(query, &embedding));
+            }
+            None => {
+                deletes.insert(subject);
+            }
+        }
+    }
+    let mut merged: Vec<(Uuid, f32)> = candidates
+        .into_iter()
+        .filter(|(subject, _)| !deletes.contains(subject) && !upserts.contains_key(subject))
+        .collect();
+    merged.extend(upserts);
+    merged.sort_by(|left, right| {
+        right
+            .1
+            .partial_cmp(&left.1)
+            .unwrap_or(std::cmp::Ordering::Equal)
+            .then_with(|| left.0.cmp(&right.0))
+    });
+    merged
+}
+
+pub(crate) enum FreshTailOutcome {
+    /// Coalesced final tail operations that are valid against the candidate
+    /// list the caller already captured from its serving bridge.
+    Ops(Vec<(Uuid, Option<Vec<f32>>)>),
+    /// A compaction mismatch forced current-query segment re-resolution. These
+    /// candidates already come from one coherent replacement segment plus its
+    /// own tail and must replace, never merge with, the caller's stale list.
+    Replace(Vec<(Uuid, f32)>),
+    /// The exact leg could not run; retain the caller's existing candidates.
+    Skipped,
+}
+
+pub(crate) async fn fresh_tail_leg(
+    rt: &KhiveRuntime,
+    ann: &SharedAnn,
+    key: &AnnKey,
+    query: &[f32],
+    k: usize,
+    watermark: Option<u64>,
+) -> FreshTailOutcome {
+    let ns = key.namespace.as_str();
+    let model = key.model.as_str();
+    if force_rebuild_required(ann, key) {
+        // The first detector already evicted the untrusted bridge and retired
+        // its Ready ownership.  Do not invalidate the authoritative warm now
+        // in flight on every concurrent query; dropping this query's captured
+        // candidates is sufficient until that warm replaces the cache.
+        return FreshTailOutcome::Replace(Vec::new());
+    }
+    if !fresh_tail_enabled() {
+        return match read_own_watermark(rt, ns, model).await {
+            Ok(Some(watermark)) if watermark >= 0 => FreshTailOutcome::Skipped,
+            Ok(_) => force_cold_after_registry_loss(rt, ann, key).await,
+            Err(error) => {
+                tracing::warn!(
+                    error = %error,
+                    namespace = ns,
+                    model,
+                    "knowledge ANN registry read failed while fresh-tail was disabled"
+                );
+                FreshTailOutcome::Replace(Vec::new())
+            }
+        };
+    }
+
+    match watermark {
+        Some(watermark) => fresh_tail_serving(rt, ann, key, query, k, watermark).await,
+        None => fresh_tail_capped(rt, ann, key).await,
+    }
+}
+
+async fn force_cold_after_registry_loss(
+    rt: &KhiveRuntime,
+    ann: &SharedAnn,
+    key: &AnnKey,
+) -> FreshTailOutcome {
+    // Publish the cross-process fence before yielding or evicting local state.
+    // A peer checkpoint therefore cannot compact/publish through the gap while
+    // this process is transitioning its loaded bridge to Cold.
+    if let Err(error) = prepare_authoritative_rebuild(rt, ann, key).await {
+        tracing::warn!(
+            error = %error,
+            namespace = key.namespace,
+            model = key.model,
+            "knowledge ANN failed to publish registry-loss rebuild sentinel"
+        );
+    }
+    clear_namespace(ann, &key.namespace).await;
+    FreshTailOutcome::Replace(Vec::new())
+}
+
+fn ready_snapshot_watermark(snapshot: &FreshTailSnapshot) -> Option<u64> {
+    snapshot
+        .own_watermark
+        .filter(|watermark| *watermark >= 0)
+        .and_then(|watermark| u64::try_from(watermark).ok())
+}
+
+fn nonnegative_registry_min(snapshot: &FreshTailSnapshot) -> u64 {
+    snapshot
+        .registry_min
+        .filter(|watermark| *watermark >= 0)
+        .and_then(|watermark| u64::try_from(watermark).ok())
+        .unwrap_or(0)
+}
+
+async fn fresh_tail_serving(
+    rt: &KhiveRuntime,
+    ann: &SharedAnn,
+    key: &AnnKey,
+    query: &[f32],
+    k: usize,
+    watermark: u64,
+) -> FreshTailOutcome {
+    let ns = key.namespace.as_str();
+    let model = key.model.as_str();
+    let snapshot = match fetch_fresh_tail_snapshot(rt, ns, model, watermark, None).await {
+        Ok(snapshot) => snapshot,
+        Err(error) => {
+            tracing::warn!(
+                error = %error,
+                namespace = ns,
+                model,
+                "knowledge fresh-tail snapshot failed; dropping stale vector leg"
+            );
+            return FreshTailOutcome::Replace(Vec::new());
+        }
+    };
+    let Some(_own_watermark) = ready_snapshot_watermark(&snapshot) else {
+        return force_cold_after_registry_loss(rt, ann, key).await;
+    };
+
+    let registry_min = nonnegative_registry_min(&snapshot);
+    if registry_min > watermark {
+        // The log may already have been compacted through `registry_min`, so
+        // candidates from the bridge at `watermark` cannot be paired with a
+        // scan floored at that newer value. Prefer the currently published
+        // segment, whose commit watermark must cover the registry minimum.
+        let published_watermark = ann_segment_dir(rt, ns, model)
+            .and_then(|dir| read_commit_info(&dir).ok().flatten())
+            .and_then(|info| info.last_applied_seq)
+            .filter(|published| *published >= registry_min);
+
+        match published_watermark {
+            Some(published_watermark) => {
+                // Retire the stale cache entry now. The query below owns a
+                // local replacement candidate set, while the next request's
+                // normal warm path re-adopts the published segment.
+                clear_namespace(ann, ns).await;
+                return fresh_tail_reresolve(rt, ann, key, query, k, published_watermark).await;
+            }
+            None => {
+                // Re-resolution is not possible in this query. Preserve the
+                // same-snapshot coverage proof above the registry minimum, but
+                // do not mix those operations with candidates from the older
+                // bridge: return an exact-only replacement vector source.
+                clear_namespace(ann, ns).await;
+                return FreshTailOutcome::Replace(merge_fresh_tail(
+                    Vec::new(),
+                    query,
+                    snapshot.ops,
+                ));
+            }
+        }
+    }
+    FreshTailOutcome::Ops(snapshot.ops)
+}
+
+/// Bound re-resolution when peers publish checkpoints faster than one query can
+/// load and validate them. The terminal branch keeps only the exact suffix above
+/// the last same-snapshot registry floor, avoiding an unprovable mixture with
+/// candidates from a segment behind that floor.
+const FRESH_TAIL_RERESOLVE_MAX_ROUNDS: u32 = 3;
+
+/// Load the currently published segment, search it, then validate its watermark
+/// against the registry minimum and fetch its own tail in one SQLite snapshot.
+/// A peer may advance the minimum between the filesystem load and validation;
+/// retry from the newly published segment in that case.
+async fn fresh_tail_reresolve(
+    rt: &KhiveRuntime,
+    ann: &SharedAnn,
+    key: &AnnKey,
+    query: &[f32],
+    k: usize,
+    published_watermark: u64,
+) -> FreshTailOutcome {
+    let ns = key.namespace.as_str();
+    let model = key.model.as_str();
+    let mut expected_watermark = published_watermark;
+    for round in 1..=FRESH_TAIL_RERESOLVE_MAX_ROUNDS {
+        let Some(dir) = ann_segment_dir(rt, ns, model) else {
+            tracing::warn!(
+                key = ?key,
+                namespace = ns,
+                model,
+                "knowledge fresh-tail published segment disappeared during re-resolution"
+            );
+            return FreshTailOutcome::Replace(Vec::new());
+        };
+        let bridge = match AnnBridge::load(&dir) {
+            Ok(bridge) => bridge,
+            Err(error) => {
+                tracing::warn!(
+                    error = %error,
+                    key = ?key,
+                    namespace = ns,
+                    model,
+                    "knowledge fresh-tail published segment load failed"
+                );
+                return FreshTailOutcome::Replace(Vec::new());
+            }
+        };
+        let loaded_watermark = bridge
+            .index
+            .last_applied_seq()
+            .unwrap_or(expected_watermark);
+        let candidates = bridge.search(query, k);
+
+        let snapshot = match fetch_fresh_tail_snapshot(rt, ns, model, loaded_watermark, None).await
+        {
+            Ok(snapshot) => snapshot,
+            Err(error) => {
+                tracing::warn!(
+                    error = %error,
+                    key = ?key,
+                    namespace = ns,
+                    model,
+                    "knowledge fresh-tail re-resolution snapshot failed"
+                );
+                return FreshTailOutcome::Replace(Vec::new());
+            }
+        };
+        let Some(_own_watermark) = ready_snapshot_watermark(&snapshot) else {
+            return force_cold_after_registry_loss(rt, ann, key).await;
+        };
+        let registry_min = nonnegative_registry_min(&snapshot);
+
+        if registry_min <= loaded_watermark {
+            return FreshTailOutcome::Replace(merge_fresh_tail(candidates, query, snapshot.ops));
+        }
+
+        if round == FRESH_TAIL_RERESOLVE_MAX_ROUNDS {
+            tracing::warn!(
+                key = ?key,
+                namespace = ns,
+                model,
+                rounds = round,
+                floor = registry_min,
+                "knowledge fresh-tail re-resolution did not converge; using exact-only floored suffix"
+            );
+            return FreshTailOutcome::Replace(merge_fresh_tail(Vec::new(), query, snapshot.ops));
+        }
+
+        expected_watermark = registry_min;
+    }
+    unreachable!("fresh-tail re-resolution loop returns within its bounded rounds")
+}
+
+async fn fresh_tail_capped(rt: &KhiveRuntime, ann: &SharedAnn, key: &AnnKey) -> FreshTailOutcome {
+    let snapshot = match fetch_fresh_tail_snapshot(
+        rt,
+        &key.namespace,
+        &key.model,
+        0,
+        Some(ann_rebuild_threshold()),
+    )
+    .await
+    {
+        Ok(snapshot) => snapshot,
+        Err(error) => {
+            tracing::warn!(
+                error = %error,
+                namespace = key.namespace,
+                model = key.model,
+                "knowledge capped fresh-tail fetch failed"
+            );
+            return FreshTailOutcome::Skipped;
+        }
+    };
+    if ready_snapshot_watermark(&snapshot).is_none() {
+        return force_cold_after_registry_loss(rt, ann, key).await;
+    }
+    debug_assert!(snapshot.live_count.is_some());
+    FreshTailOutcome::Ops(snapshot.ops)
+}
+
+/// Reconcile a checkpoint after another publisher already advanced the durable
+/// row. The loser must adopt the winner (when persisted) rather than overwrite
+/// a newer segment or demote a recovered row back to `-1`.
+/// `observed_watermark` is the winner's durable lower bound while the caller
+/// still holds the bridge publication lock.
+async fn adopt_checkpoint_winner(
+    rt: &KhiveRuntime,
+    ann: &SharedAnn,
+    key: &AnnKey,
+    generation: u64,
+    observed_watermark: u64,
+) -> bool {
+    let installed = match ann_segment_dir(rt, &key.namespace, &key.model) {
+        Some(dir) => match AnnBridge::load(&dir) {
+            Ok(bridge) if bridge.index.last_applied_seq().unwrap_or(0) >= observed_watermark => {
+                // Any incumbent predates registry-loss recovery. Remove it
+                // before installing the winner; the normal generation fence
+                // still rejects the winner if a local write raced its scan.
+                ann.indexes.write().await.remove(key);
+                install_replacing(ann, key, bridge.with_generation(generation)).await
+            }
+            Ok(bridge) => {
+                tracing::warn!(
+                    key = ?key,
+                    bridge_watermark = bridge.index.last_applied_seq().unwrap_or(0),
+                    observed_watermark,
+                    "checkpoint winner segment trails its durable watermark"
+                );
+                ann.indexes.write().await.remove(key);
+                false
+            }
+            Err(error) => {
+                tracing::warn!(
+                    error = %error,
+                    key = ?key,
+                    "failed to adopt checkpoint race winner"
+                );
+                ann.indexes.write().await.remove(key);
+                false
+            }
+        },
+        // An in-memory runtime has no cross-process segment. A same-process
+        // winner may already be installed in the shared AnnState; otherwise
+        // the next warm retries as ordinary registered Cold.
+        None => {
+            let current = has_current_index_at_watermark(ann, key, observed_watermark).await;
+            if !current {
+                ann.indexes.write().await.remove(key);
+            }
+            current
+        }
+    };
+    clear_force_rebuild(ann, key);
+    installed
+}
+
+/// Persist `bridge` at its applied watermark, reopen and publish the mmap
+/// segment, then raise this consumer's registry row and compact through the
+/// pair MIN. Publishing before the durable raise makes the ADR-118 mismatch
+/// window empty for this process; a crash before the raise merely
+/// under-compacts. Registration still precedes persistence (ADR-079 Amendment
+/// 1 §A step 1). On persist/reopen failure the Owned bridge is installed.
 pub(crate) async fn checkpoint_raise_compact_readopt(
     rt: &KhiveRuntime,
     ann: &SharedAnn,
     key: &AnnKey,
-    ns: &str,
-    model: &str,
     bridge: AnnBridge,
     generation: u64,
-) {
-    let applied = bridge.index.last_applied_seq().unwrap_or(0);
-    if let Err(e) = register_consumer(rt, ns, model).await {
-        tracing::warn!(error = %e, "ann consumer registration failed; serving Owned, no persist");
-        install_replacing(ann, key, bridge.with_generation(generation)).await;
-        return;
-    }
-    if let Err(e) = persist_ann_v2(rt, ns, model, &bridge) {
-        tracing::error!(error = %e, "failed to persist v2 Vamana segment");
-        install_replacing(ann, key, bridge.with_generation(generation)).await;
-        return;
-    }
-    if let Err(e) = raise_watermark(rt, ns, model, applied).await {
-        tracing::warn!(error = %e, "ann watermark raise failed (under-compacts; safe)");
-    } else if let Err(e) = compact_log(rt, ns, model).await {
-        tracing::warn!(error = %e, "ann log compaction failed (retries next checkpoint)");
-    }
-    match ann_segment_dir(rt, ns, model) {
-        Some(dir) => match AnnBridge::load(&dir) {
-            Ok(mmap_bridge) => {
-                install_replacing(ann, key, mmap_bridge.with_generation(generation)).await;
-            }
-            Err(e) => {
-                tracing::warn!(error = %e, "mmap re-adoption failed; serving Owned build");
-                install_replacing(ann, key, bridge.with_generation(generation)).await;
+    authority: CheckpointAuthority,
+) -> bool {
+    let ns = key.namespace.as_str();
+    let model = key.model.as_str();
+    let local_publication_lock = checkpoint_lock(ann, key);
+    let _local_publication_guard = local_publication_lock.lock().await;
+
+    // This lock spans the complete knowledge-level publication: Vamana
+    // segments, UUID sidecar, mmap verification, and the durable registry
+    // transition.  The sentinel writer takes the same lock, so an ordinary
+    // replay checkpoint that predates registry loss cannot publish after -1.
+    let publication_lock = match ann_segment_dir(rt, ns, model) {
+        Some(dir) => match acquire_bridge_checkpoint_lock_async(dir).await {
+            Ok(lock) => Some(lock),
+            Err(error) => {
+                tracing::warn!(error = %error, "failed to acquire ANN checkpoint lock");
+                return false;
             }
         },
-        None => {
-            // In-memory backend: nothing was persisted; serve the Owned build.
-            install_replacing(ann, key, bridge.with_generation(generation)).await;
+        None => None,
+    };
+
+    let applied = bridge.index.last_applied_seq().unwrap_or(0);
+    let own_watermark = match read_own_watermark(rt, ns, model).await {
+        Ok(value) => value,
+        Err(error) => {
+            tracing::warn!(error = %error, "ann checkpoint registry read failed");
+            return false;
+        }
+    };
+    if authority == CheckpointAuthority::FullSentinel {
+        if let Some(observed) = own_watermark.filter(|watermark| *watermark >= 0) {
+            tracing::info!(
+                key = ?key,
+                observed_watermark = observed,
+                "authoritative ANN rebuild lost publication race; adopting winner"
+            );
+            let observed = u64::try_from(observed).unwrap_or(0);
+            return adopt_checkpoint_winner(rt, ann, key, generation, observed).await;
+        }
+    } else if let Some(observed) = own_watermark.filter(|watermark| *watermark >= 0) {
+        let observed = u64::try_from(observed).unwrap_or(0);
+        if observed > applied {
+            tracing::info!(
+                key = ?key,
+                candidate_watermark = applied,
+                observed_watermark = observed,
+                "stale ANN checkpoint lost publication race; adopting winner"
+            );
+            return adopt_checkpoint_winner(rt, ann, key, generation, observed).await;
         }
     }
+    let authorized = match authority {
+        CheckpointAuthority::FullSentinel => own_watermark == Some(-1),
+        CheckpointAuthority::Incremental | CheckpointAuthority::FullRegistered => {
+            own_watermark.is_some_and(|watermark| watermark >= 0)
+        }
+    };
+    if !authorized {
+        mark_force_rebuild(ann, key);
+        if let Err(error) = write_force_rebuild_sentinel_row(rt, key).await {
+            tracing::warn!(error = %error, "failed to fence unauthorized ANN checkpoint");
+        }
+        return false;
+    }
+
+    if let Err(e) = persist_ann_v2_locked(rt, ns, model, &bridge) {
+        tracing::error!(error = %e, "failed to persist v2 Vamana segment");
+        install_replacing(ann, key, bridge.with_generation(generation)).await;
+        return false;
+    }
+    let published = match ann_segment_dir(rt, ns, model) {
+        Some(dir) => match AnnBridge::load(&dir) {
+            Ok(mmap_bridge) => mmap_bridge,
+            Err(e) => {
+                tracing::warn!(error = %e, "mmap re-adoption failed; serving Owned build");
+                bridge
+            }
+        },
+        None => bridge,
+    };
+    // File-backed publication must replace the in-process bridge before the
+    // durable raise, closing the same-process mismatch window. An in-memory
+    // runtime has no cross-process segment or compaction peer, so defer its
+    // install until the conditional raise succeeds; a losing concurrent full
+    // scan then cannot overwrite the winner before discovering the lost race.
+    let file_backed = publication_lock.is_some();
+    let mut pending_in_memory = Some(published.with_generation(generation));
+    let mut installed = false;
+    if file_backed {
+        installed = install_replacing(
+            ann,
+            key,
+            pending_in_memory.take().expect("published bridge"),
+        )
+        .await;
+    }
+
+    // The durable segment already covers `applied`, and this process now
+    // serves that same state. A failed raise only retains extra log rows.
+    if let Err(e) = raise_watermark(rt, ns, model, applied, authority).await {
+        tracing::warn!(error = %e, "ann watermark raise failed (under-compacts; safe)");
+        match read_own_watermark(rt, ns, model).await {
+            Ok(Some(observed)) if observed >= 0 => {
+                let observed = u64::try_from(observed).unwrap_or(0);
+                if observed > applied {
+                    return adopt_checkpoint_winner(rt, ann, key, generation, observed).await;
+                }
+                // Either our conditional transition committed despite an
+                // uncertain client result, or the durable row remains behind
+                // this candidate. Both are safe under-compaction states.
+                if let Some(published) = pending_in_memory.take() {
+                    installed = install_replacing(ann, key, published).await;
+                }
+                clear_force_rebuild(ann, key);
+                return installed || has_current_index_at_watermark(ann, key, observed).await;
+            }
+            Ok(_) => {}
+            Err(read_error) => {
+                tracing::warn!(
+                    error = %read_error,
+                    "failed to reconcile ANN checkpoint race"
+                );
+            }
+        }
+        mark_force_rebuild(ann, key);
+        if let Err(error) = write_force_rebuild_sentinel_row(rt, key).await {
+            tracing::warn!(error = %error, "failed to restore ANN checkpoint fence");
+        }
+        return false;
+    }
+    if let Some(published) = pending_in_memory {
+        installed = install_replacing(ann, key, published).await;
+    }
+    if authority != CheckpointAuthority::Incremental {
+        clear_force_rebuild_if_current(ann, key, generation);
+    }
+    drop(publication_lock);
+    if let Err(e) = compact_log(rt, ns, model).await {
+        tracing::warn!(error = %e, "ann log compaction failed (retries next checkpoint)");
+    }
+    installed
 }
 
 /// Try to load a Vamana snapshot for `namespace`+`model` from `retrieval_snapshots`.
@@ -1364,17 +2305,19 @@ async fn scan_corpus_raw(
         .await
         .map_err(|e| RuntimeError::Internal(e.to_string()))?;
 
-    // The uncorrelated scalar subquery evaluates inside the SAME statement —
-    // and therefore the same SQLite read snapshot — as the corpus rows, so
-    // the captured watermark S describes exactly this scan's state (ADR-079
-    // Amendment 1: watermark capture and corpus read are linearized).
+    // The global AUTOINCREMENT high-water evaluates inside the SAME statement
+    // — and therefore the same SQLite read snapshot — as the corpus rows.
+    // Unlike MAX over retained rows it survives compaction, so an
+    // authoritative recovery checkpoint never regresses below the untrusted
+    // segment it replaces. Future writes have a strictly larger global seq;
+    // rows from sibling scopes below S are irrelevant to this corpus.
     let rows = reader
         .query_all(SqlStatement {
             sql: format!(
                 "SELECT subject_id, embedding, \
-                        (SELECT COALESCE(MAX(seq), 0) FROM ann_write_log \
-                          WHERE namespace = ?1 AND embedding_model = ?2 \
-                            AND field = 'knowledge.atom') AS log_s \
+                        (SELECT COALESCE(\
+                           (SELECT seq FROM sqlite_sequence \
+                            WHERE name = 'ann_write_log'), 0)) AS log_s \
                  FROM {table_name} \
                  WHERE namespace = ?1 AND embedding_model = ?2 \
                    AND field = 'knowledge.atom' \
@@ -1640,6 +2583,9 @@ enum SegmentOutcome {
     Empty,
     /// No trustworthy segment: fall through to the v1 / rebuild paths.
     Cold,
+    /// Registry loss or its durable marker requires a full corpus scan.  The
+    /// caller must bypass both v2 adoption and the legacy-v1 fallback.
+    ForceRebuild,
 }
 
 /// ADR-079 Amendment 1 restart classifier (the 8-rule first-match decision
@@ -1655,6 +2601,10 @@ async fn classify_and_adopt_segment(
     seg_dir: &std::path::Path,
     target_generation: u64,
 ) -> SegmentOutcome {
+    if force_rebuild_required(ann, key) {
+        return SegmentOutcome::ForceRebuild;
+    }
+
     // Rule 1: commit record absent, corrupt, or invalid length → Cold.
     let info = match read_commit_info(seg_dir) {
         Ok(Some(info)) => info,
@@ -1690,19 +2640,22 @@ async fn classify_and_adopt_segment(
         None => return SegmentOutcome::Cold,
     }
 
-    // Rule 4: own registry row absent for an extended-format state → Cold
-    // after re-registering at 0. Registration precedes every persist, so an
-    // absent row means administrative removal or registry loss — compaction
-    // may already have deleted this consumer's tail.
+    // Rule 4: an absent row or the durable -1 sentinel requires an
+    // authoritative full-corpus rebuild.  The sentinel is cross-process and
+    // keeps pair compaction blocked until that rebuild publishes.
     match read_own_watermark(rt, ns, model).await {
-        Ok(Some(_)) => {}
+        Ok(Some(watermark)) if watermark >= 0 => {}
+        Ok(Some(_)) => {
+            mark_force_rebuild(ann, key);
+            return SegmentOutcome::ForceRebuild;
+        }
         Ok(None) => {
             tracing::info!(namespace = %ns, model = %model,
-                "ann consumer registry row absent; re-registering at 0, Cold rebuild");
-            if let Err(e) = register_consumer(rt, ns, model).await {
-                tracing::warn!(error = %e, "ann consumer re-registration failed");
+                "ann consumer registry row absent; fencing for authoritative rebuild");
+            if let Err(error) = prepare_authoritative_rebuild(rt, ann, key).await {
+                tracing::warn!(error = %error, "ann consumer re-registration failed");
             }
-            return SegmentOutcome::Cold;
+            return SegmentOutcome::ForceRebuild;
         }
         Err(e) => {
             tracing::warn!(error = %e, "ann registry read failed; Cold");
@@ -1779,7 +2732,18 @@ async fn classify_and_adopt_segment(
             return SegmentOutcome::Cold;
         }
         bridge.set_applied_seq(new_s);
-        checkpoint_raise_compact_readopt(rt, ann, key, ns, model, bridge, target_generation).await;
+        let checkpointed = checkpoint_raise_compact_readopt(
+            rt,
+            ann,
+            key,
+            bridge,
+            target_generation,
+            CheckpointAuthority::Incremental,
+        )
+        .await;
+        if !checkpointed && force_rebuild_required(ann, key) {
+            return SegmentOutcome::ForceRebuild;
+        }
         return SegmentOutcome::Installed;
     }
 
@@ -1820,6 +2784,37 @@ pub(crate) async fn ensure_ann_for_model(
     let ns = token.namespace().as_str().to_owned();
     let key = AnnKey::new(&ns, model);
 
+    // Registration precedes every scan or legacy serve. Local absence of a
+    // bridge cannot prove global first use: a peer may still hold stale v1 or
+    // Owned state after this row was administratively removed. Every absent
+    // knowledge row therefore publishes the durable force-rebuild sentinel
+    // before any further serving, even in a fresh process.
+    let mut force_rebuild = force_rebuild_required(ann, &key);
+    match read_own_watermark(rt, &ns, model).await {
+        Ok(Some(watermark)) if watermark < 0 => {
+            mark_force_rebuild(ann, &key);
+            force_rebuild = true;
+        }
+        Ok(Some(_)) => {}
+        Ok(None) => {
+            if let Err(error) = prepare_authoritative_rebuild(rt, ann, &key).await {
+                tracing::warn!(error = %error, "failed to fence ANN registry loss");
+                return AnnWarmOutcome::Failed;
+            }
+            force_rebuild = true;
+        }
+        Err(error) => {
+            tracing::warn!(error = %error, "failed to read ANN registration before scan");
+            return AnnWarmOutcome::Failed;
+        }
+    }
+    if force_rebuild && !matches!(read_own_watermark(rt, &ns, model).await, Ok(Some(-1))) {
+        if let Err(error) = prepare_authoritative_rebuild(rt, ann, &key).await {
+            tracing::warn!(error = %error, "failed to establish ANN rebuild sentinel");
+            return AnnWarmOutcome::Failed;
+        }
+    }
+
     // Capture the namespace's write-generation BEFORE anything else (issue
     // #770) — including before the fast path below and before the corpus
     // scan — so a write that lands after this point is guaranteed to be
@@ -1832,79 +2827,119 @@ pub(crate) async fn ensure_ann_for_model(
     // build served from an emptied-then-refilled slot serve indefinitely.
     // Falling through here re-enters the same rebuild path a genuine cache
     // miss would take.
-    if let Some(loaded_generation) = ann
-        .indexes
-        .read()
-        .await
-        .get(&key)
-        .map(|bridge| bridge.generation)
-    {
-        if loaded_generation >= target_generation {
-            return AnnWarmOutcome::Ready;
+    if !force_rebuild {
+        if let Some(loaded_generation) = ann
+            .indexes
+            .read()
+            .await
+            .get(&key)
+            .map(|bridge| bridge.generation)
+        {
+            if loaded_generation >= target_generation {
+                return AnnWarmOutcome::Ready;
+            }
+            tracing::debug!(
+                namespace = %ns,
+                model = %model,
+                loaded_generation,
+                target_generation,
+                "knowledge ANN fast path skipped: cached entry generation stale; rebuilding"
+            );
         }
-        tracing::debug!(
-            namespace = %ns,
-            model = %model,
-            loaded_generation,
-            target_generation,
-            "knowledge ANN fast path skipped: cached entry generation stale; rebuilding"
-        );
     }
 
     // 2. v2 segment path — ADR-079 Amendment 1 watermark classifier. Total,
     // first-match decision table over the persisted commit record, this
     // consumer's registry row, and one same-snapshot (live, tail) read.
-    if let Some(seg_dir) = ann_segment_dir(rt, &ns, model) {
-        match classify_and_adopt_segment(rt, ann, &key, &ns, model, &seg_dir, target_generation)
-            .await
-        {
-            SegmentOutcome::Installed => return AnnWarmOutcome::Ready,
-            SegmentOutcome::Empty => {
-                mark_unavailable(ann, &key, target_generation);
-                return AnnWarmOutcome::Empty;
+    if !force_rebuild {
+        if let Some(seg_dir) = ann_segment_dir(rt, &ns, model) {
+            match classify_and_adopt_segment(rt, ann, &key, &ns, model, &seg_dir, target_generation)
+                .await
+            {
+                SegmentOutcome::Installed => return AnnWarmOutcome::Ready,
+                SegmentOutcome::Empty => {
+                    mark_unavailable(ann, &key, target_generation);
+                    return AnnWarmOutcome::Empty;
+                }
+                SegmentOutcome::Cold => {} // fall through to v1 / rebuild
+                SegmentOutcome::ForceRebuild => force_rebuild = true,
             }
-            SegmentOutcome::Cold => {} // fall through to v1 / rebuild
         }
     }
 
     // 3. v1 JSON snapshot path (backwards-compat transition).
-    if let Some(snapshot) = try_load_snapshot(rt, &ns, model).await {
-        let current_fp = compute_fingerprint(rt, token, model).await;
-        if let Some(fp) = current_fp {
-            if snapshot.fingerprint == fp {
-                match AnnBridge::from_vamana_snapshot(snapshot) {
-                    Ok(bridge) => {
-                        install_if_fresher(ann, &key, bridge.with_generation(target_generation))
+    if !force_rebuild {
+        if let Some(snapshot) = try_load_snapshot(rt, &ns, model).await {
+            let current_fp = compute_fingerprint(rt, token, model).await;
+            if let Some(fp) = current_fp {
+                if snapshot.fingerprint == fp {
+                    match AnnBridge::from_vamana_snapshot(snapshot) {
+                        Ok(bridge) => {
+                            install_if_fresher(
+                                ann,
+                                &key,
+                                bridge.with_generation(target_generation),
+                            )
                             .await;
-                        return AnnWarmOutcome::Ready;
+                            return AnnWarmOutcome::Ready;
+                        }
+                        Err(e) => {
+                            tracing::warn!(error = %e, "corrupt Vamana v1 snapshot; rebuilding");
+                        }
                     }
-                    Err(e) => {
-                        tracing::warn!(error = %e, "corrupt Vamana v1 snapshot; rebuilding");
-                    }
+                } else {
+                    tracing::info!(
+                        namespace = %ns,
+                        model = %model,
+                        "stale Vamana v1 snapshot (fingerprint mismatch); rebuilding"
+                    );
                 }
-            } else {
-                tracing::info!(
-                    namespace = %ns,
-                    model = %model,
-                    "stale Vamana v1 snapshot (fingerprint mismatch); rebuilding"
-                );
             }
         }
     }
 
-    // 4. Rebuild fallthrough — build from vector store, persist v2 segments,
-    // raise the registry watermark, compact the log, and re-adopt as mmap.
+    // 4. Rebuild fallthrough — build from vector store, persist and re-adopt
+    // the v2 segment, then raise the registry watermark and compact the log.
+    let scan_authority = match prepare_full_corpus_scan(rt, ann, &key).await {
+        Ok(authority) => authority,
+        Err(error) => {
+            tracing::warn!(error = %error, "failed to establish ANN full-scan authority");
+            return AnnWarmOutcome::Failed;
+        }
+    };
     match load_and_build_from_vector_store(rt, token, model).await {
         Ok(Some(bridge)) => {
-            checkpoint_raise_compact_readopt(rt, ann, &key, &ns, model, bridge, target_generation)
-                .await;
-            AnnWarmOutcome::Ready
+            let checkpointed = checkpoint_raise_compact_readopt(
+                rt,
+                ann,
+                &key,
+                bridge,
+                target_generation,
+                scan_authority,
+            )
+            .await;
+            if checkpointed {
+                AnnWarmOutcome::Ready
+            } else if force_rebuild_required(ann, &key) {
+                AnnWarmOutcome::Failed
+            } else if has_current_index(ann, &key).await {
+                // A normal cold build may still install an Owned bridge when
+                // persistence fails, and a lost FullSentinel race may adopt
+                // the winner while reporting a fenced local publication.
+                AnnWarmOutcome::Ready
+            } else {
+                AnnWarmOutcome::Failed
+            }
         }
         Ok(None) => {
             // Empty corpus: this scan (at target_generation) proves nothing is
             // buildable right now. Mark it so wait_ready can short-circuit
             // instead of polling out the full warm-wait timeout (issue #1026).
             mark_unavailable(ann, &key, target_generation);
+            // An authoritative Empty scan keeps the durable -1 sentinel: no
+            // segment exists whose publication could advance the row safely.
+            // The first subsequent vector write invalidates this terminal
+            // marker and the next full scan checkpoints normally.
             AnnWarmOutcome::Empty
         }
         Err(e) => {
@@ -1934,6 +2969,94 @@ mod tests {
     use super::*;
     use khive_runtime::KhiveRuntime;
     use khive_storage::types::{SqlStatement, SqlValue};
+    use serde_json::json;
+
+    #[test]
+    fn fresh_tail_merge_deduplicates_and_applies_deletes() {
+        let deleted = Uuid::new_v4();
+        let updated = Uuid::new_v4();
+        let stable = Uuid::new_v4();
+        let candidates = vec![(deleted, 0.99), (updated, 0.1), (stable, 0.5)];
+        let ops = vec![(deleted, None), (updated, Some(vec![1.0, 0.0]))];
+
+        let merged = merge_fresh_tail(candidates, &[1.0, 0.0], ops);
+
+        assert!(
+            !merged.iter().any(|(subject, _)| *subject == deleted),
+            "a final tail delete must remove a stale ANN candidate"
+        );
+        assert_eq!(
+            merged
+                .iter()
+                .filter(|(subject, _)| *subject == updated)
+                .count(),
+            1,
+            "a tail upsert must replace, not duplicate, an ANN candidate"
+        );
+        assert_eq!(merged[0].0, updated, "the exact tail score must win");
+        assert!(merged.iter().any(|(subject, _)| *subject == stable));
+    }
+
+    #[test]
+    fn fresh_tail_merge_breaks_equal_scores_by_uuid() {
+        let low = Uuid::from_u128(1);
+        let middle = Uuid::from_u128(2);
+        let high = Uuid::from_u128(3);
+        let ops = vec![
+            (high, Some(vec![1.0, 0.0])),
+            (low, Some(vec![1.0, 0.0])),
+            (middle, Some(vec![1.0, 0.0])),
+        ];
+
+        let merged = merge_fresh_tail(Vec::new(), &[1.0, 0.0], ops);
+
+        assert_eq!(
+            merged
+                .into_iter()
+                .map(|(subject, _)| subject)
+                .collect::<Vec<_>>(),
+            vec![low, middle, high],
+            "equal-cosine fresh hits must not inherit HashMap iteration order"
+        );
+    }
+
+    #[tokio::test]
+    async fn fresh_tail_missing_registration_publishes_force_rebuild_sentinel() {
+        let rt = KhiveRuntime::memory().expect("in-memory runtime");
+        let ann = new_shared();
+        let namespace = "local";
+        let model = "fresh-tail-registration-test";
+        let key = AnnKey::new(namespace, model);
+
+        let outcome = force_cold_after_registry_loss(&rt, &ann, &key).await;
+
+        assert!(matches!(outcome, FreshTailOutcome::Replace(ref hits) if hits.is_empty()));
+        assert_eq!(
+            read_own_watermark(&rt, namespace, model)
+                .await
+                .expect("registry read"),
+            Some(-1),
+            "registry loss must publish the cross-process rebuild sentinel"
+        );
+        assert!(force_rebuild_required(&ann, &key));
+    }
+
+    #[tokio::test]
+    async fn force_rebuild_queries_do_not_retire_authoritative_warm() {
+        let rt = KhiveRuntime::memory().expect("in-memory runtime");
+        let ann = new_shared();
+        let key = AnnKey::new("local", "force-warm-test");
+        force_cold_after_registry_loss(&rt, &ann, &key).await;
+        simulate_warming_in_flight(&ann, key.clone());
+
+        let outcome = fresh_tail_leg(&rt, &ann, &key, &[1.0], 1, None).await;
+
+        assert!(matches!(outcome, FreshTailOutcome::Replace(ref hits) if hits.is_empty()));
+        assert!(
+            is_warming_not_loaded(&ann, &key),
+            "a concurrent degraded query must not invalidate the authoritative warm"
+        );
+    }
 
     /// #1150 regression: a tombstoned ordinal's stale id-map entry must not
     /// let a later replay op for the old (already-deleted) subject tombstone
@@ -2925,8 +4048,8 @@ mod tests {
     use lattice_embed::{EmbedError, EmbeddingModel, EmbeddingService};
     use tempfile::TempDir;
 
-    const WARM_TEST_MODEL: &str = "ann-test-model";
-    const WARM_DIMS: usize = 4;
+    const WARM_TEST_MODEL: &str = "all-minilm-l6-v2";
+    const WARM_DIMS: usize = 384;
 
     struct ConstVecService;
 
@@ -2966,12 +4089,12 @@ mod tests {
         }
     }
 
-    fn file_rt_with_embedder(db_path: std::path::PathBuf) -> KhiveRuntime {
+    fn rt_with_embedder(db_path: Option<std::path::PathBuf>) -> KhiveRuntime {
         let rt = KhiveRuntime::new(RuntimeConfig {
             git_write: Default::default(),
-            db_path: Some(db_path),
+            db_path,
             default_namespace: Namespace::local(),
-            embedding_model: None,
+            embedding_model: Some(EmbeddingModel::AllMiniLmL6V2),
             additional_embedding_models: vec![],
             gate: Arc::new(AllowAllGate),
             packs: vec!["kg".to_string(), "knowledge".to_string()],
@@ -2981,9 +4104,17 @@ mod tests {
             allowed_outbound_namespaces: vec![],
             actor_id: None,
         })
-        .expect("file-backed runtime");
+        .expect("test runtime");
         rt.register_embedder(TestEmbedderProvider);
         rt
+    }
+
+    fn file_rt_with_embedder(db_path: std::path::PathBuf) -> KhiveRuntime {
+        rt_with_embedder(Some(db_path))
+    }
+
+    fn memory_rt_with_embedder() -> KhiveRuntime {
+        rt_with_embedder(None)
     }
 
     /// Seed `n` distinct rows into the vec0 table for `WARM_TEST_MODEL`.
@@ -3051,6 +4182,156 @@ mod tests {
             .await
             .expect("append write-log row");
         }
+    }
+
+    async fn append_warm_vector(
+        rt: &KhiveRuntime,
+        token: &NamespaceToken,
+        embedding: [f32; WARM_DIMS],
+    ) -> Uuid {
+        let _store = rt
+            .vectors_for_model(token, WARM_TEST_MODEL)
+            .expect("vec store");
+        let table = format!("vec_{}", sanitize_model_key(WARM_TEST_MODEL));
+        let namespace = token.namespace().as_str().to_owned();
+        let subject = Uuid::new_v4();
+        let bytes: Vec<u8> = embedding
+            .iter()
+            .flat_map(|value| value.to_le_bytes())
+            .collect();
+        let sql = rt.sql();
+        let mut writer = sql.writer().await.expect("writer");
+        writer
+            .execute(SqlStatement {
+                sql: format!(
+                    "INSERT INTO {table} \
+                     (subject_id, namespace, kind, field, embedding_model, embedding) \
+                     VALUES (?1, ?2, 'concept', 'knowledge.atom', ?3, ?4)"
+                ),
+                params: vec![
+                    SqlValue::Text(subject.to_string()),
+                    SqlValue::Text(namespace.clone()),
+                    SqlValue::Text(WARM_TEST_MODEL.to_string()),
+                    SqlValue::Blob(bytes),
+                ],
+                label: None,
+            })
+            .await
+            .expect("insert fresh vector");
+        writer
+            .execute(SqlStatement {
+                sql: "INSERT INTO ann_write_log \
+                      (namespace, embedding_model, kind, field, subject_id, op) \
+                      VALUES (?1, ?2, 'concept', 'knowledge.atom', ?3, 'upsert')"
+                    .into(),
+                params: vec![
+                    SqlValue::Text(namespace),
+                    SqlValue::Text(WARM_TEST_MODEL.to_string()),
+                    SqlValue::Text(subject.to_string()),
+                ],
+                label: None,
+            })
+            .await
+            .expect("append fresh-tail log row");
+        subject
+    }
+
+    #[test]
+    fn threshold_sized_tail_cap_scales_with_live_corpus() {
+        let cap = |live: u64, threshold: f64| (live as f64 * threshold).ceil() as u64;
+        assert_eq!(cap(3, 0.20), 1, "small corpora retain one newest row");
+        assert_eq!(cap(5, 0.21), 2, "fractional limits round upward");
+        assert_eq!(
+            cap(1_000_000, 0.20),
+            200_000,
+            "large corpora must not collapse to the retired fixed 20k ceiling"
+        );
+    }
+
+    #[tokio::test]
+    async fn capped_snapshot_selects_newest_threshold_sized_suffix() {
+        let dir = TempDir::new().expect("tempdir");
+        let rt = file_rt_with_embedder(dir.path().join("test.db"));
+        let token = rt.authorize(Namespace::local()).expect("authorize");
+        seed_warm_corpus(&rt, &token, 5).await;
+        register_consumer(&rt, "local", WARM_TEST_MODEL)
+            .await
+            .expect("register");
+
+        let mut reader = rt.sql().reader().await.expect("reader");
+        let newest_rows = reader
+            .query_all(SqlStatement {
+                sql: "SELECT subject_id FROM ann_write_log \
+                      WHERE namespace = 'local' AND embedding_model = ?1 \
+                        AND field = 'knowledge.atom' \
+                      ORDER BY seq DESC LIMIT 2"
+                    .into(),
+                params: vec![SqlValue::Text(WARM_TEST_MODEL.into())],
+                label: None,
+            })
+            .await
+            .expect("latest log rows");
+        let newest: Vec<Uuid> = newest_rows
+            .iter()
+            .map(|row| match row.get("subject_id") {
+                Some(SqlValue::Text(subject)) => Uuid::parse_str(subject).expect("UUID"),
+                other => panic!("unexpected subject: {other:?}"),
+            })
+            .collect();
+
+        let one = fetch_fresh_tail_snapshot(&rt, "local", WARM_TEST_MODEL, 0, Some(0.20))
+            .await
+            .expect("20% snapshot");
+        assert_eq!(one.live_count, Some(5));
+        assert_eq!(one.ops.len(), 1, "ceil(5 × .20) = 1");
+        assert_eq!(
+            one.ops[0].0, newest[0],
+            "the suffix must start newest-first"
+        );
+
+        let two = fetch_fresh_tail_snapshot(&rt, "local", WARM_TEST_MODEL, 0, Some(0.21))
+            .await
+            .expect("21% snapshot");
+        assert_eq!(two.live_count, Some(5));
+        assert_eq!(two.ops.len(), 2, "ceil(5 × .21) = 2");
+        assert_eq!(
+            two.ops
+                .iter()
+                .map(|(subject, _)| *subject)
+                .collect::<Vec<_>>(),
+            vec![newest[1], newest[0]],
+            "selected newest rows are replayed in chronological order"
+        );
+
+        // A repeat op for the newest subject makes the two-row suffix contain
+        // one distinct subject.  The final result must therefore coalesce to
+        // one op, proving LIMIT is applied to raw newest writes before final-
+        // state coalescing (the ADR-118 later-write boundary).
+        let mut writer = rt.sql().writer().await.expect("writer");
+        writer
+            .execute(SqlStatement {
+                sql: "INSERT INTO ann_write_log \
+                      (namespace, embedding_model, kind, field, subject_id, op) \
+                      VALUES ('local', ?1, 'concept', 'knowledge.atom', ?2, 'upsert')"
+                    .into(),
+                params: vec![
+                    SqlValue::Text(WARM_TEST_MODEL.into()),
+                    SqlValue::Text(newest[0].to_string()),
+                ],
+                label: None,
+            })
+            .await
+            .expect("repeat newest write");
+        drop(writer);
+        let repeated = fetch_fresh_tail_snapshot(&rt, "local", WARM_TEST_MODEL, 0, Some(0.40))
+            .await
+            .expect("40% repeated snapshot");
+        assert_eq!(
+            repeated.ops.len(),
+            1,
+            "two newest writes coalesce to one subject"
+        );
+        assert_eq!(repeated.ops[0].0, newest[0]);
     }
 
     /// `ann_segment_dir` encodes a round-trippable hex key that `decode_ann_dir_name` reverses.
@@ -3164,6 +4445,273 @@ mod tests {
             ino_before, ino_after,
             "second call must NOT rewrite metadata.bin — proves the v2 Hot load path, not a rebuild"
         );
+    }
+
+    #[tokio::test]
+    async fn knowledge_search_and_suggest_merge_write_above_loaded_bridge_watermark() {
+        let dir = TempDir::new().expect("tempdir");
+        let rt = file_rt_with_embedder(dir.path().join("test.db"));
+        let token = rt.authorize(Namespace::local()).expect("authorize");
+        seed_warm_corpus(&rt, &token, 4).await;
+
+        let ann = new_shared();
+        ensure_ann_for_model(&rt, &token, &ann, WARM_TEST_MODEL).await;
+        let key = AnnKey::new("local", WARM_TEST_MODEL);
+        let query = vec![1.0; WARM_DIMS];
+        let (_, bridge_watermark) = search_loaded_with_seq(&ann, &key, &query, 20)
+            .await
+            .expect("serving bridge");
+
+        let fresh_id = append_warm_vector(&rt, &token, [1.0; WARM_DIMS]).await;
+        let now = chrono::Utc::now().timestamp_micros();
+        let mut writer = rt.sql().writer().await.expect("writer");
+        writer
+            .execute(SqlStatement {
+                sql: "INSERT INTO knowledge_atoms \
+                      (id, namespace, slug, name, content, tags, properties, status, \
+                       finalized, created_at, updated_at) \
+                      VALUES (?1, 'local', 'opaque-fresh-tail', 'Opaque Fresh Tail', \
+                              'content with no lexical overlap', '[\"type:domain\"]', '{}', 'reviewed', \
+                              1, ?2, ?2)"
+                    .into(),
+                params: vec![SqlValue::Text(fresh_id.to_string()), SqlValue::Integer(now)],
+                label: None,
+            })
+            .await
+            .expect("insert hydratable knowledge atom");
+        drop(writer);
+
+        let (_, still_loaded_watermark) = search_loaded_with_seq(&ann, &key, &query, 20)
+            .await
+            .expect("stale serving bridge remains loaded");
+        assert_eq!(
+            still_loaded_watermark, bridge_watermark,
+            "the simulated external write must not mutate the in-process bridge"
+        );
+
+        let result = super::super::KnowledgeHandlers::search(
+            &rt,
+            &token,
+            json!({
+                "query": "quasar zephyr",
+                "min_score": 0.1,
+                "limit": 10,
+                "rerank": false
+            }),
+            &ann,
+        )
+        .await
+        .expect("knowledge.search");
+        let ids: Vec<&str> = result["results"]
+            .as_array()
+            .expect("results")
+            .iter()
+            .filter_map(|hit| hit["id"].as_str())
+            .collect();
+        let fresh_id = fresh_id.to_string();
+        assert!(
+            ids.contains(&fresh_id.as_str()),
+            "fresh-tail atom must be visible without rebuilding the loaded bridge: {result}"
+        );
+
+        let suggest = super::super::KnowledgeHandlers::suggest(
+            &rt,
+            &token,
+            json!({
+                "query": "quasar zephyr nebula pulsar aurora",
+                "limit": 10
+            }),
+            &ann,
+        )
+        .await
+        .expect("knowledge.suggest");
+        let suggest_ids: Vec<&str> = suggest["results"]
+            .as_array()
+            .expect("suggest results")
+            .iter()
+            .filter_map(|hit| hit["id"].as_str())
+            .collect();
+        assert!(
+            suggest_ids.contains(&fresh_id.as_str()),
+            "fresh-tail domain atom must be visible to knowledge.suggest: {suggest}"
+        );
+    }
+
+    #[tokio::test]
+    async fn fresh_tail_mismatch_replaces_stale_candidates_from_published_segment() {
+        let dir = TempDir::new().expect("tempdir");
+        let rt = file_rt_with_embedder(dir.path().join("test.db"));
+        let token = rt.authorize(Namespace::local()).expect("authorize");
+        seed_warm_corpus(&rt, &token, 4).await;
+
+        let ann = new_shared();
+        ensure_ann_for_model(&rt, &token, &ann, WARM_TEST_MODEL).await;
+        let key = AnnKey::new("local", WARM_TEST_MODEL);
+        let query = vec![1.0; WARM_DIMS];
+        let (old_candidates, old_watermark) = search_loaded_with_seq(&ann, &key, &query, 20)
+            .await
+            .expect("old serving bridge");
+
+        let fresh_id = append_warm_vector(&rt, &token, [1.0; WARM_DIMS]).await;
+        assert!(
+            !old_candidates
+                .iter()
+                .any(|(subject, _)| *subject == fresh_id),
+            "the old bridge must not already contain the peer's fresh write"
+        );
+
+        // Simulate a peer checkpoint: publish a segment covering the fresh
+        // write, raise the shared registry floor, and compact through it while
+        // this process deliberately keeps its old bridge installed.
+        let replacement = load_and_build_from_vector_store(&rt, &token, WARM_TEST_MODEL)
+            .await
+            .expect("scan replacement corpus")
+            .expect("replacement corpus is non-empty");
+        let replacement_watermark = replacement
+            .index
+            .last_applied_seq()
+            .expect("replacement carries a watermark");
+        assert!(replacement_watermark > old_watermark);
+        persist_ann_v2(&rt, "local", WARM_TEST_MODEL, &replacement)
+            .expect("publish replacement segment");
+        raise_watermark(
+            &rt,
+            "local",
+            WARM_TEST_MODEL,
+            replacement_watermark,
+            CheckpointAuthority::Incremental,
+        )
+        .await
+        .expect("raise peer watermark");
+        compact_log(&rt, "local", WARM_TEST_MODEL)
+            .await
+            .expect("compact through peer watermark");
+        assert!(
+            !tail_exists(&rt, "local", WARM_TEST_MODEL, old_watermark)
+                .await
+                .expect("probe compacted old tail"),
+            "the old bridge's tail must be gone so only segment re-resolution can recover it"
+        );
+
+        let generation_before = current_generation(&ann, "local");
+        let outcome = fresh_tail_leg(&rt, &ann, &key, &query, 20, Some(old_watermark)).await;
+        let replacement_candidates = match outcome {
+            FreshTailOutcome::Replace(candidates) => candidates,
+            FreshTailOutcome::Ops(_) => {
+                panic!("a compaction mismatch must replace, not extend, stale candidates")
+            }
+            FreshTailOutcome::Skipped => panic!("mismatch re-resolution must not disappear"),
+        };
+
+        assert!(
+            replacement_candidates
+                .iter()
+                .any(|(subject, _)| *subject == fresh_id),
+            "current-query re-resolution must surface the write covered by the published segment"
+        );
+        assert!(
+            current_generation(&ann, "local") > generation_before,
+            "mismatch handling must retire the stale cache generation"
+        );
+        assert!(
+            search_loaded_with_seq(&ann, &key, &query, 20)
+                .await
+                .is_none(),
+            "the stale in-process bridge must be evicted so normal warming re-adopts the segment"
+        );
+    }
+
+    #[tokio::test]
+    async fn registry_loss_evicts_stale_bridge_and_forces_authoritative_rebuild() {
+        let dir = TempDir::new().expect("tempdir");
+        let rt = file_rt_with_embedder(dir.path().join("test.db"));
+        let token = rt.authorize(Namespace::local()).expect("authorize");
+        seed_warm_corpus(&rt, &token, 4).await;
+
+        let ann = new_shared();
+        ensure_ann_for_model(&rt, &token, &ann, WARM_TEST_MODEL).await;
+        let key = AnnKey::new("local", WARM_TEST_MODEL);
+        let query = vec![1.0; WARM_DIMS];
+        let (_, stale_watermark) = search_loaded_with_seq(&ann, &key, &query, 20)
+            .await
+            .expect("serving bridge");
+        let fresh_id = append_warm_vector(&rt, &token, [1.0; WARM_DIMS]).await;
+
+        // Simulate administrative loss followed by a peer consumer compacting
+        // the interval this process never checkpointed.  The stale bridge can
+        // no longer be repaired from its `> S` tail.
+        let mut writer = rt.sql().writer().await.expect("writer");
+        writer
+            .execute(SqlStatement {
+                sql: "DELETE FROM ann_consumer_watermark \
+                      WHERE consumer = ?1 AND namespace = 'local' \
+                        AND embedding_model = ?2"
+                    .into(),
+                params: vec![
+                    SqlValue::Text(ANN_CONSUMER.into()),
+                    SqlValue::Text(WARM_TEST_MODEL.into()),
+                ],
+                label: None,
+            })
+            .await
+            .expect("delete own registry row");
+        writer
+            .execute(SqlStatement {
+                sql: "INSERT INTO ann_consumer_watermark \
+                      (consumer, namespace, embedding_model, watermark) \
+                      VALUES ('peer:test', 'local', ?1, 999)"
+                    .into(),
+                params: vec![SqlValue::Text(WARM_TEST_MODEL.into())],
+                label: None,
+            })
+            .await
+            .expect("insert peer watermark");
+        drop(writer);
+        compact_log(&rt, "local", WARM_TEST_MODEL)
+            .await
+            .expect("compact missing interval");
+        assert!(
+            !tail_exists(&rt, "local", WARM_TEST_MODEL, stale_watermark)
+                .await
+                .expect("tail probe"),
+            "setup must remove the stale bridge's recovery tail"
+        );
+
+        let outcome = fresh_tail_leg(&rt, &ann, &key, &query, 20, Some(stale_watermark)).await;
+        assert!(
+            matches!(outcome, FreshTailOutcome::Replace(ref hits) if hits.is_empty()),
+            "the query that detects registry loss must discard stale candidates"
+        );
+        assert!(search_loaded_with_seq(&ann, &key, &query, 20)
+            .await
+            .is_none());
+        assert_eq!(
+            read_own_watermark(&rt, "local", WARM_TEST_MODEL)
+                .await
+                .expect("registry read"),
+            Some(-1),
+            "the cross-process sentinel must stay durable through the Cold transition"
+        );
+
+        assert_eq!(
+            ensure_ann_for_model(&rt, &token, &ann, WARM_TEST_MODEL).await,
+            AnnWarmOutcome::Ready
+        );
+        let rebuilt = search_loaded(&ann, &key, &query, 20)
+            .await
+            .expect("authoritative rebuilt bridge");
+        assert!(
+            rebuilt.iter().any(|(subject, _)| *subject == fresh_id),
+            "the next warm must rebuild from the full corpus, not re-adopt the stale segment"
+        );
+        assert!(
+            read_own_watermark(&rt, "local", WARM_TEST_MODEL)
+                .await
+                .expect("registry read")
+                .is_some_and(|watermark| watermark >= 0),
+            "successful authoritative publication must clear the sentinel"
+        );
+        assert!(!force_rebuild_required(&ann, &key));
     }
 
     /// After a corpus mutation the persisted segment has a non-empty tail and the
@@ -3384,9 +4932,15 @@ mod tests {
         );
 
         // A raises to 2 → MIN(2, 99) = 2 → rows 1-2 compact, 3-4 remain.
-        raise_watermark(&rt, "local", WARM_TEST_MODEL, 2)
-            .await
-            .expect("raise");
+        raise_watermark(
+            &rt,
+            "local",
+            WARM_TEST_MODEL,
+            2,
+            CheckpointAuthority::Incremental,
+        )
+        .await
+        .expect("raise");
         compact_log(&rt, "local", WARM_TEST_MODEL)
             .await
             .expect("compact");
@@ -3396,6 +4950,352 @@ mod tests {
         assert_eq!(
             tail_after, 2,
             "compaction must advance exactly to the pair MIN"
+        );
+    }
+
+    #[tokio::test]
+    async fn ordinary_checkpoint_cannot_clear_force_rebuild_sentinel() {
+        let dir = TempDir::new().expect("tempdir");
+        let rt = file_rt_with_embedder(dir.path().join("test.db"));
+        let ann = new_shared();
+        let key = AnnKey::new("local", WARM_TEST_MODEL);
+        prepare_authoritative_rebuild(&rt, &ann, &key)
+            .await
+            .expect("publish sentinel");
+
+        assert!(
+            raise_watermark(
+                &rt,
+                "local",
+                WARM_TEST_MODEL,
+                7,
+                CheckpointAuthority::Incremental,
+            )
+            .await
+            .is_err(),
+            "an ordinary checkpoint must lose the conditional publication fence"
+        );
+        assert_eq!(
+            read_own_watermark(&rt, "local", WARM_TEST_MODEL)
+                .await
+                .expect("read sentinel"),
+            Some(-1)
+        );
+
+        raise_watermark(
+            &rt,
+            "local",
+            WARM_TEST_MODEL,
+            7,
+            CheckpointAuthority::FullSentinel,
+        )
+        .await
+        .expect("authoritative checkpoint clears sentinel");
+        assert_eq!(
+            read_own_watermark(&rt, "local", WARM_TEST_MODEL)
+                .await
+                .expect("read raised watermark"),
+            Some(7)
+        );
+    }
+
+    #[tokio::test]
+    async fn full_scan_checkpoint_clears_local_force_rebuild_marker() {
+        let dir = TempDir::new().expect("tempdir");
+        let rt = file_rt_with_embedder(dir.path().join("test.db"));
+        let token = rt.authorize(Namespace::local()).expect("authorize");
+        seed_warm_corpus(&rt, &token, 4).await;
+
+        let ann = new_shared();
+        let key = AnnKey::new("local", WARM_TEST_MODEL);
+        let authority = prepare_full_corpus_scan(&rt, &ann, &key)
+            .await
+            .expect("establish full-scan authority");
+        assert_eq!(authority, CheckpointAuthority::FullSentinel);
+        assert!(force_rebuild_required(&ann, &key));
+
+        let bridge = load_and_build_from_vector_store(&rt, &token, WARM_TEST_MODEL)
+            .await
+            .expect("scan corpus")
+            .expect("non-empty corpus");
+        assert!(
+            checkpoint_raise_compact_readopt(
+                &rt,
+                &ann,
+                &key,
+                bridge,
+                current_generation(&ann, "local"),
+                authority,
+            )
+            .await,
+            "authoritative full scan must publish"
+        );
+        assert!(
+            !force_rebuild_required(&ann, &key),
+            "the shared checkpoint seam must finish local recovery for direct rebuild callers"
+        );
+
+        let query = vec![1.0; WARM_DIMS];
+        let (_, watermark) = search_loaded_with_seq(&ann, &key, &query, 20)
+            .await
+            .expect("published bridge");
+        assert!(
+            matches!(
+                fresh_tail_leg(&rt, &ann, &key, &query, 20, Some(watermark)).await,
+                FreshTailOutcome::Ops(_)
+            ),
+            "the next query must retain the freshly published bridge"
+        );
+    }
+
+    #[tokio::test]
+    async fn concurrent_full_sentinel_loser_does_not_restore_sentinel() {
+        let rt = memory_rt_with_embedder();
+        let token = rt.authorize(Namespace::local()).expect("authorize");
+        seed_warm_corpus(&rt, &token, 4).await;
+
+        let ann = new_shared();
+        let key = AnnKey::new("local", WARM_TEST_MODEL);
+        let authority_a = prepare_full_corpus_scan(&rt, &ann, &key)
+            .await
+            .expect("first full-scan authority");
+        let authority_b = prepare_full_corpus_scan(&rt, &ann, &key)
+            .await
+            .expect("second full-scan authority");
+        assert_eq!(authority_a, CheckpointAuthority::FullSentinel);
+        assert_eq!(authority_b, CheckpointAuthority::FullSentinel);
+
+        let bridge_a = load_and_build_from_vector_store(&rt, &token, WARM_TEST_MODEL)
+            .await
+            .expect("scan A")
+            .expect("non-empty A");
+        let bridge_b = load_and_build_from_vector_store(&rt, &token, WARM_TEST_MODEL)
+            .await
+            .expect("scan B")
+            .expect("non-empty B");
+        let generation = current_generation(&ann, "local");
+        let (published_a, published_b) = tokio::join!(
+            checkpoint_raise_compact_readopt(&rt, &ann, &key, bridge_a, generation, authority_a,),
+            checkpoint_raise_compact_readopt(&rt, &ann, &key, bridge_b, generation, authority_b,)
+        );
+
+        assert!(published_a || published_b, "one full scan must win");
+        assert!(
+            read_own_watermark(&rt, "local", WARM_TEST_MODEL)
+                .await
+                .expect("read winner watermark")
+                .is_some_and(|watermark| watermark >= 0),
+            "the losing checkpoint must not demote the winner back to -1"
+        );
+        assert!(!force_rebuild_required(&ann, &key));
+        assert!(
+            has_current_index(&ann, &key).await,
+            "the winner must remain available after the losing fence"
+        );
+    }
+
+    #[tokio::test]
+    async fn concurrent_pathless_normal_checkpoints_publish_monotonically() {
+        let rt = memory_rt_with_embedder();
+        let token = rt.authorize(Namespace::local()).expect("authorize");
+        seed_warm_corpus(&rt, &token, 4).await;
+        let ann = new_shared();
+        assert_eq!(
+            ensure_ann_for_model(&rt, &token, &ann, WARM_TEST_MODEL).await,
+            AnnWarmOutcome::Ready
+        );
+
+        let key = AnnKey::new("local", WARM_TEST_MODEL);
+        let old_authority = prepare_full_corpus_scan(&rt, &ann, &key)
+            .await
+            .expect("old authority");
+        let old_bridge = load_and_build_from_vector_store(&rt, &token, WARM_TEST_MODEL)
+            .await
+            .expect("old scan")
+            .expect("old corpus");
+        let old_watermark = old_bridge.index.last_applied_seq().unwrap_or(0);
+
+        let fresh_id = append_warm_vector(&rt, &token, [1.0; WARM_DIMS]).await;
+        let new_authority = prepare_full_corpus_scan(&rt, &ann, &key)
+            .await
+            .expect("new authority");
+        let new_bridge = load_and_build_from_vector_store(&rt, &token, WARM_TEST_MODEL)
+            .await
+            .expect("new scan")
+            .expect("new corpus");
+        let new_watermark = new_bridge.index.last_applied_seq().unwrap_or(0);
+        assert!(new_watermark > old_watermark);
+
+        let generation = current_generation(&ann, "local");
+        let (old_result, new_result) = tokio::join!(
+            checkpoint_raise_compact_readopt(
+                &rt,
+                &ann,
+                &key,
+                old_bridge,
+                generation,
+                old_authority,
+            ),
+            checkpoint_raise_compact_readopt(
+                &rt,
+                &ann,
+                &key,
+                new_bridge,
+                generation,
+                new_authority,
+            )
+        );
+
+        assert!(old_result && new_result);
+        assert_eq!(
+            read_own_watermark(&rt, "local", WARM_TEST_MODEL)
+                .await
+                .expect("registry read"),
+            Some(i64::try_from(new_watermark).expect("watermark range"))
+        );
+        let query = vec![1.0; WARM_DIMS];
+        let (hits, loaded_watermark) = search_loaded_with_seq(&ann, &key, &query, 20)
+            .await
+            .expect("monotone winner");
+        assert_eq!(loaded_watermark, new_watermark);
+        assert!(hits.iter().any(|(subject, _)| *subject == fresh_id));
+    }
+
+    #[tokio::test]
+    async fn stale_normal_checkpoint_adopts_newer_publisher_without_overwrite() {
+        let dir = TempDir::new().expect("tempdir");
+        let rt = file_rt_with_embedder(dir.path().join("test.db"));
+        let token = rt.authorize(Namespace::local()).expect("authorize");
+        seed_warm_corpus(&rt, &token, 4).await;
+
+        let initial_ann = new_shared();
+        assert_eq!(
+            ensure_ann_for_model(&rt, &token, &initial_ann, WARM_TEST_MODEL).await,
+            AnnWarmOutcome::Ready
+        );
+        let key = AnnKey::new("local", WARM_TEST_MODEL);
+        let stale_authority = prepare_full_corpus_scan(&rt, &initial_ann, &key)
+            .await
+            .expect("stale authority");
+        let stale_bridge = load_and_build_from_vector_store(&rt, &token, WARM_TEST_MODEL)
+            .await
+            .expect("stale scan")
+            .expect("stale corpus");
+        let stale_watermark = stale_bridge.index.last_applied_seq().unwrap_or(0);
+
+        let fresh_id = append_warm_vector(&rt, &token, [1.0; WARM_DIMS]).await;
+        let winner_ann = new_shared();
+        let winner_authority = prepare_full_corpus_scan(&rt, &winner_ann, &key)
+            .await
+            .expect("winner authority");
+        let winner_bridge = load_and_build_from_vector_store(&rt, &token, WARM_TEST_MODEL)
+            .await
+            .expect("winner scan")
+            .expect("winner corpus");
+        let winner_watermark = winner_bridge.index.last_applied_seq().unwrap_or(0);
+        assert!(winner_watermark > stale_watermark);
+        assert!(
+            checkpoint_raise_compact_readopt(
+                &rt,
+                &winner_ann,
+                &key,
+                winner_bridge,
+                current_generation(&winner_ann, "local"),
+                winner_authority,
+            )
+            .await,
+            "newer publisher must commit"
+        );
+
+        let stale_ann = new_shared();
+        assert!(
+            checkpoint_raise_compact_readopt(
+                &rt,
+                &stale_ann,
+                &key,
+                stale_bridge,
+                current_generation(&stale_ann, "local"),
+                stale_authority,
+            )
+            .await,
+            "stale publisher must adopt the winner instead of overwriting it"
+        );
+        assert_eq!(
+            read_own_watermark(&rt, "local", WARM_TEST_MODEL)
+                .await
+                .expect("registry read"),
+            Some(i64::try_from(winner_watermark).expect("watermark range"))
+        );
+        let info = read_commit_info(
+            &ann_segment_dir(&rt, "local", WARM_TEST_MODEL).expect("segment directory"),
+        )
+        .expect("commit read")
+        .expect("commit info");
+        assert_eq!(info.last_applied_seq, Some(winner_watermark));
+        assert_eq!(info.vector_count, 5);
+        let query = vec![1.0; WARM_DIMS];
+        assert!(
+            search_loaded(&stale_ann, &key, &query, 20)
+                .await
+                .expect("adopted winner")
+                .iter()
+                .any(|(subject, _)| *subject == fresh_id),
+            "the stale publisher must serve the winner's fresh row"
+        );
+    }
+
+    #[tokio::test]
+    async fn first_use_empty_corpus_retains_cross_process_sentinel() {
+        let dir = TempDir::new().expect("tempdir");
+        let rt = file_rt_with_embedder(dir.path().join("test.db"));
+        let token = rt.authorize(Namespace::local()).expect("authorize");
+        let ann = new_shared();
+        let key = AnnKey::new("local", WARM_TEST_MODEL);
+
+        assert_eq!(
+            ensure_ann_for_model(&rt, &token, &ann, WARM_TEST_MODEL).await,
+            AnnWarmOutcome::Empty
+        );
+        assert_eq!(
+            read_own_watermark(&rt, "local", WARM_TEST_MODEL)
+                .await
+                .expect("registry read"),
+            Some(-1),
+            "even a fresh process must preserve the only cross-process loss signal"
+        );
+        assert!(force_rebuild_required(&ann, &key));
+    }
+
+    #[tokio::test]
+    async fn delayed_sentinel_request_cannot_demote_completed_recovery() {
+        let rt = memory_rt_with_embedder();
+        let token = rt.authorize(Namespace::local()).expect("authorize");
+        seed_warm_corpus(&rt, &token, 4).await;
+        let ann = new_shared();
+        let key = AnnKey::new("local", WARM_TEST_MODEL);
+        assert_eq!(
+            ensure_ann_for_model(&rt, &token, &ann, WARM_TEST_MODEL).await,
+            AnnWarmOutcome::Ready
+        );
+        let winner = read_own_watermark(&rt, "local", WARM_TEST_MODEL)
+            .await
+            .expect("winner watermark")
+            .expect("registered winner");
+        assert!(winner >= 0);
+
+        prepare_authoritative_rebuild(&rt, &ann, &key)
+            .await
+            .expect("delayed sentinel request");
+        assert_eq!(
+            read_own_watermark(&rt, "local", WARM_TEST_MODEL)
+                .await
+                .expect("registry read"),
+            Some(winner),
+            "revalidation under the publication lock must preserve the winner"
+        );
+        assert!(
+            force_rebuild_required(&ann, &key),
+            "the delayed detector must remain Cold until it scans or adopts authoritatively"
         );
     }
 

--- a/docs/adr/ADR-079-ann-persistence-warm-path-integration.md
+++ b/docs/adr/ADR-079-ann-persistence-warm-path-integration.md
@@ -432,8 +432,8 @@ CREATE INDEX idx_ann_write_log_ns_model_seq ON ann_write_log(namespace, embeddin
 -- Durable per-consumer watermark registry, required by the cross-consumer
 -- compaction invariant below. A consumer registers its row (watermark 0)
 -- BEFORE persisting or serving any extended-format segment, and raises it
--- monotonically after each segment commit; a stale row under-compacts
--- (safe), never over-compacts.
+-- monotonically after each segment commit. The knowledge consumer also uses
+-- the closed -1 value as its force-rebuild sentinel after registry loss.
 CREATE TABLE ann_consumer_watermark (
   consumer   TEXT NOT NULL,
   namespace  TEXT NOT NULL,
@@ -459,16 +459,16 @@ CREATE TABLE ann_consumer_watermark (
   checksum, §B). Any other length is corrupt.
 - **Restart classification is a total, versioned decision table**, evaluated per index scope:
 
-  | # | Condition (first match wins)                                                                               | Class                                                                                                                                                                                                                                                                                                                                 |
-  | - | ---------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-  | 1 | commit record absent, corrupt, or not a valid record length                                                | **Cold**                                                                                                                                                                                                                                                                                                                              |
-  | 2 | record readable but pre-amendment (no watermark)                                                           | **Cold**, and log compaction is FORBIDDEN until an extended-format checkpoint commits                                                                                                                                                                                                                                                 |
-  | 3 | configured embedder dimensions for the model (the durable embedder-registry contract) ≠ segment dimensions | **Cold**                                                                                                                                                                                                                                                                                                                              |
-  | 4 | the consumer's own `ann_consumer_watermark` row is absent (record is extended-format)                      | **Cold**, after re-registering the row at watermark 0. Registration precedes every persist (below), so a durable extended segment implies a row was written; absence means administrative removal or registry loss, after which compaction may already have deleted this consumer's tail — the segment cannot be trusted Hot or Stale |
-  | 5 | live corpus row count for the scope (from the same read snapshot) = 0                                      | **Empty**, regardless of tail contents: no ANN candidate is served or replayed — the index is dropped and the existing FTS/degraded path answers; no buildable index is recorded. Covers delete-everything tails, which ADR-052's tombstone op cannot replay down to zero live nodes, and the no-tail zero-live checkpoint            |
-  | 6 | `NOT EXISTS (SELECT 1 FROM ann_write_log WHERE <scope> AND seq > S)`                                       | **Hot**: mmap load, zero corpus IO. This is the post-compaction steady state — an empty scope (`MAX(seq)` NULL) with a valid watermark `S` is Hot, because every post-migration write logs a row and compaction only ever removes rows `<= S`                                                                                         |
-  | 7 | tail rows exist, tail count ≤ `ceil(ann_rebuild_threshold × live vector_count)`                            | **Stale-tail**: mmap load, then final-state tail replay (below). §2 serve-stale applies while the tail applies. Rules 7-8 are reachable only with live vector count > 0 (rule 5 matched first otherwise)                                                                                                                              |
-  | 8 | tail count above threshold                                                                                 | **Stale-rebuild** (amends the §2 state table): the checksum-valid segment loads and serves under the existing `ann_serve_stale` gate while a full rebuild runs in the background. The threshold is a cost decision, not evidence of unreadability — it never demotes a loadable segment to Cold/FTS-only                              |
+  | # | Condition (first match wins)                                                                                 | Class                                                                                                                                                                                                                                                                                                                                                                                                            |
+  | - | ------------------------------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+  | 1 | commit record absent, corrupt, or not a valid record length                                                  | **Cold**                                                                                                                                                                                                                                                                                                                                                                                                         |
+  | 2 | record readable but pre-amendment (no watermark)                                                             | **Cold**, and log compaction is FORBIDDEN until an extended-format checkpoint commits                                                                                                                                                                                                                                                                                                                            |
+  | 3 | configured embedder dimensions for the model (the durable embedder-registry contract) ≠ segment dimensions   | **Cold**                                                                                                                                                                                                                                                                                                                                                                                                         |
+  | 4 | the consumer's own row is absent (or, for the knowledge consumer, its watermark is the closed `-1` sentinel) | **Cold.** Baseline consumers re-register at 0 before rebuilding. The knowledge consumer uses the stronger cross-process recovery fence below: it atomically recreates an absent row at `-1`, and every knowledge process rejects cached, v2, and legacy-v1 state until a fenced full scan transitions `-1 → S`. Absence means administrative removal or registry loss; a compacted interval may already be gone. |
+  | 5 | live corpus row count for the scope (from the same read snapshot) = 0                                        | **Empty**, regardless of tail contents: no ANN candidate is served or replayed — the index is dropped and the existing FTS/degraded path answers; no buildable index is recorded. Covers delete-everything tails, which ADR-052's tombstone op cannot replay down to zero live nodes, and the no-tail zero-live checkpoint                                                                                       |
+  | 6 | `NOT EXISTS (SELECT 1 FROM ann_write_log WHERE <scope> AND seq > S)`                                         | **Hot**: mmap load, zero corpus IO. This is the post-compaction steady state — an empty scope (`MAX(seq)` NULL) with a valid watermark `S` is Hot, because every post-migration write logs a row and compaction only ever removes rows `<= S`                                                                                                                                                                    |
+  | 7 | tail rows exist, tail count ≤ `ceil(ann_rebuild_threshold × live vector_count)`                              | **Stale-tail**: mmap load, then final-state tail replay (below). §2 serve-stale applies while the tail applies. Rules 7-8 are reachable only with live vector count > 0 (rule 5 matched first otherwise)                                                                                                                                                                                                         |
+  | 8 | tail count above threshold                                                                                   | **Stale-rebuild** (amends the §2 state table): the checksum-valid segment loads and serves under the existing `ann_serve_stale` gate while a full rebuild runs in the background. The threshold is a cost decision, not evidence of unreadability — it never demotes a loadable segment to Cold/FTS-only                                                                                                         |
 
 - **Evaluation order of rules 5 and 6.** An implementation may test rule 6's tail predicate (a
   log-table-only query) before rule 5's live count, and adopt Hot without ever running the live
@@ -508,9 +508,13 @@ CREATE TABLE ann_consumer_watermark (
   merge-cleanup sequences: historical intermediate values are unavailable by design and never
   needed.
 - **Watermark capture and publication are linearized per index scope.** The corpus (or tail) read
-  and the watermark read execute inside one SQLite read snapshot;
-  `S = COALESCE(MAX(seq), 0)` within that snapshot, so the serialized state contains exactly the
-  scope's writes `<= S` — never a watermark stamped ahead of (or behind) the state it describes.
+  and the watermark read execute inside one SQLite read snapshot. The baseline capture is
+  `S = COALESCE(MAX(seq), 0)` under the consumer's scope. Knowledge authoritative/full scans use
+  the `ann_write_log` AUTOINCREMENT high-water from `sqlite_sequence` instead: unlike a retained
+  scoped `MAX`, it survives prior compaction, while sibling-scope sequence values below `S` are
+  harmless and every future write is strictly above it. The memory consumer retains its scoped
+  same-snapshot capture and is unchanged by this knowledge-specific refinement. Tail replay stays
+  anchored at the segment's scoped `S`.
   `save_atomic` persists that `S`. Every extended record carries a numeric watermark: zero is the
   defined empty-log baseline (the first post-migration checkpoint), distinct from a MISSING
   watermark (pre-amendment record, rule 2). A zero-watermark segment followed by the first logged
@@ -550,11 +554,31 @@ CREATE TABLE ann_consumer_watermark (
      matches nothing, so an unregistered pair never compacts (consistent with rule 2's compaction
      ban). Never above any registered watermark.
 
+  **Knowledge registry-loss refinement (#1515).** The per-namespace knowledge consumer registers
+  before every full scan or tail-dependent read. Every absent row is written as `-1` under the
+  knowledge bridge's cross-process publication lock, even when the detecting process has no local
+  or persisted bridge: that local evidence cannot prove a stale peer does not exist. The detector
+  rejects or evicts local serving state. Because `-1` is below every legal sequence, it both pins pair `MIN`
+  and tells every knowledge process to bypass cached, v2, and legacy-v1 state. Incremental
+  checkpoints update only a nonnegative row and therefore cannot clear the sentinel. A full scan
+  records whether it began under ordinary registration or `-1`; its checkpoint uses the matching
+  conditional update, and zero affected rows is a fenced failure. Every normal-row checkpoint is
+  also monotone in the segment: before persistence and again in the conditional raise, candidate
+  `S` must be at least the current durable watermark. A stale publisher adopts the winner and must
+  not overwrite its segment or re-publish `-1`. Failed or Empty recovery leaves `-1` durable; a
+  later non-empty full scan may clear it. A per-key process lock linearizes pathless
+  raise-and-install; for file-backed runtimes the bridge lock additionally spans Vamana segment
+  files, `external_ids.bin`, mmap verification, and the conditional registry transition. A
+  checkpoint therefore cannot interleave its sidecar/commit pair with another writer or race
+  sentinel publication. The sentinel writer revalidates absence/negative state after acquiring
+  these locks; a delayed detector preserves a recovery that completed while it waited.
+
   Operational note: a decommissioned consumer's registry row pins the pair's `MIN` at its last
   watermark, so the log for that `(namespace, embedding_model)` grows unbounded until an operator
   removes the row. Removal is an administrative action and is safe precisely because of decision
-  rule 4: a returning consumer finds its row absent, re-registers at 0, and rebuilds Cold instead
-  of trusting a segment whose tail may have been compacted away.
+  rule 4: a returning consumer rebuilds Cold instead of trusting a segment whose tail may have
+  been compacted away. The knowledge consumer publishes `-1` for this interval as described
+  above; baseline consumers re-register at 0.
 
 - **Global-scope consumers.** Some consumers index one corpus across ALL namespaces for a model —
   the memory pack's note index is the canonical case (a single graph over every namespace's
@@ -607,6 +631,10 @@ guard:
   Owned index and defers mmap adoption to the next checkpoint — a newer served state is never
   replaced by an older snapshot. In-flight queries pin their index `Arc` and are unaffected by the
   swap.
+- **Knowledge whole-bridge publication lock.** The knowledge pack holds a lock outside
+  `VamanaIndex::save_atomic` while `external_ids.bin` is digested/written and while its registry
+  transition commits. This prevents two processes from pairing writer A's UUID map with writer
+  B's commit digest and is also the serialization point for knowledge's rule-4 `-1` sentinel.
 - **SQ8 codes become a persisted segment.** The ADR-052 acquisition-tier codec and per-vector
   codes (`gs_codec`/`gs_codes`) are written by `save_atomic` as a fifth checksummed segment file
   (`codes.bin`) whose blake3 hash rides the extended commit record, and are memory-mapped on load.

--- a/docs/adr/ADR-118-fresh-tail-recall-visibility.md
+++ b/docs/adr/ADR-118-fresh-tail-recall-visibility.md
@@ -74,9 +74,11 @@ serving bridge at build/adoption time; `S = 0` when no index is serving):
   nothing for them. If the same subject is also returned by the ANN index, it is dropped
   from the merged candidate list — the tail is authoritative for every subject it names.
 
-The read runs in a single snapshot (log scan + row point-reads in one read transaction), so
-a write committing mid-query is either entirely visible or entirely invisible — never a torn
-log/row pair.
+The read runs in a single snapshot, so a write committing mid-query is either entirely visible
+or entirely invisible — never a torn log/row pair. The knowledge implementation uses one SQL
+statement for the own-row guard, pair minimum, optional live count, selected log suffix, and
+joined current embeddings. This is load-bearing on pool-backed readers, where separate method
+calls are not guaranteed to share one connection even when bracketed by textual `BEGIN`/`COMMIT`.
 
 _Compaction linearization (review follow-up, 2026-07-19)._ A tail scan above `S` proves
 completeness only if the log still retains every row above `S` — and ADR-079 permits
@@ -109,6 +111,20 @@ before any **tail-dependent read path**, not merely before the first segment per
 consumer that finds its registration row absent must register at 0 and treat the log as
 untrusted until rows accumulate under the new registration (the existing Cold classification
 already produces the correct serving behavior for that window).
+
+_Knowledge cross-process refinement (#1515)._ A newly recreated zero row does not itself tell a
+second process that the consumer had been absent, so the knowledge consumer uses `-1` as a durable
+closed recovery state instead. Every absent knowledge row is changed to `-1` under the same
+cross-process lock used to publish the bridge, even when the detecting process has no local or
+persisted bridge; local evidence cannot exclude a stale peer. The detector then rejects or evicts
+local serving state.
+After acquiring the publication locks, the sentinel writer revalidates that the row is still
+absent/negative so a delayed detector cannot demote a completed recovery. Every knowledge process
+treats an absent row or `-1` as Cold and bypasses cached,
+v2, and legacy-v1 state. Only a full-corpus checkpoint tagged with the durable state observed
+before its scan may conditionally transition the row back to `S >= 0`; incremental replay cannot
+clear it. Failed or Empty recovery retains `-1`. This refinement is scoped to the knowledge
+consumer in issue #1515; the memory consumer retains ADR-079's baseline registration behavior.
 
 ### 2. Merge semantics — one source, not a fourth
 
@@ -150,7 +166,8 @@ The exact leg is O(|tail| × dims) per model per query. The tail is small by con
 When no ANN index is serving at all (Cold rebuild in flight, or Empty classification), the
 watermark is 0 and the tail is the entire scope. The exact leg does **not** absorb that case:
 it caps its scan at the threshold-sized tail, taking the highest-seq suffix of the log (the
-newest writes) so the freshest writes stay visible while FTS covers the rest, and otherwise
+newest raw writes, before final-state coalescing) so the freshest writes stay visible while FTS
+covers the rest, and otherwise
 defers to the existing Cold-path behavior (FTS-only serving while the rebuild runs). The leg
 restores freshness on a serving index; it is not a general exact-search fallback. This is
 the second tier of the §"Decision" guarantee stated precisely: with no serving index, a
@@ -192,6 +209,16 @@ external writer that appends log rows (the Amendment 1 write-path rule binds eve
 path) becomes visible to a warm daemon's recall on the daemon's next query. This closes the
 visibility half of issue #752; the invalidation half (getting the index itself rebuilt) is
 unchanged and remains that issue's subject.
+
+For knowledge, bridge publication is serialized across processes over the Vamana commit,
+`external_ids.bin`, mmap re-adoption, registry transition, and `-1` sentinel publication. This
+prevents a query from treating a re-created registry row as continuity with an older bridge and
+prevents concurrent writers from pairing one segment commit with another writer's UUID sidecar.
+Normal checkpoints also fence candidate `S` against the current durable watermark both before
+persistence and in the conditional raise; a stale publisher adopts the newer winner rather than
+overwriting its segment under a registry value whose intervening tail may already be compacted.
+Pathless checkpoints take a per-key process lock so their durable raise and cache install remain
+one monotone publication sequence.
 
 ## Relationship to ADR-107 (partial supersession)
 


### PR DESCRIPTION
## Summary

- merge the exact post-checkpoint `ann_write_log` tail into knowledge search and suggest results so newly embedded sections are immediately recallable
- make full ANN checkpoints cross-process safe with a durable force-rebuild sentinel, monotonic publication, winner adoption, and process/file locking
- document the fresh-tail, watermark, recovery, and staleness contracts in ADR-079, ADR-118, and the Vamana API guide

## Correctness details

- read the corpus, consumer watermark, global log high-water mark, and fresh suffix from one SQLite snapshot
- cap cold/empty fresh-tail work from `KHIVE_ANN_REBUILD_THRESHOLD` and the live corpus size, then coalesce repeated writes before scoring
- publish normal checkpoints only when they cannot regress a newer durable watermark or overwrite a newer bridge generation
- preserve a knowledge-only `-1` sentinel until a fenced full checkpoint succeeds; concurrent losers adopt the authoritative winner instead of restoring stale state
- serialize checkpoint publication per key and, for file-backed bridges, across processes while installing the segment, external-id sidecar, and registry transition
- break equal-score result ties by UUID for deterministic ordering

## Validation

- `cargo test --manifest-path crates/Cargo.toml --workspace`
- `cargo check --manifest-path crates/Cargo.toml --workspace`
- `cargo clippy --manifest-path crates/Cargo.toml --workspace --all-targets -- -D warnings`
- `RUSTDOCFLAGS=-Dwarnings cargo doc --manifest-path crates/Cargo.toml --workspace --no-deps`
- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `scripts/lint-sql.sh`
- `scripts/lint-adr-refs.sh`
- `scripts/lint-stub-markers.sh`
- `deno fmt --check crates/khive-pack-knowledge/docs/api/vamana.md docs/adr/ADR-079-ann-persistence-warm-path-integration.md docs/adr/ADR-118-fresh-tail-recall-visibility.md`
- `git diff --check refs/remotes/origin/main...HEAD`

Closes #1515

> AI-assisted contribution: Codex prepared this change and PR description.
