### PR TITLE
feat(namespace): scope feedback and knowledge reads

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -134,6 +134,8 @@ false, id, full_id, from, to, note: "already in target status"}` — the task fi
 | `memory.vacuum`   | Run SQLite VACUUM to reclaim space freed by soft-deleted rows | Periodic maintenance after heavy prune runs         |
 
 `memory.recall` supports `tags` and `tag_mode` ("any"|"all") for tag-based post-filtering.
+Its optional `namespace` is an exact-match read override; absent means the caller's normal
+visible namespace set.
 Composite scores are always in [0,1]. Typical production floor: 0.3-0.7.
 
 ### Brain pack — 16 verbs (`brain.` prefix)
@@ -156,6 +158,9 @@ Composite scores are always in [0,1]. Typical production floor: 0.3-0.7.
 | `brain.unbind`           | Remove a binding                                                                         | Stop routing                                                    |
 | `brain.bindings`         | List binding rows                                                                        | Audit profile routing                                           |
 | `brain.register_adapter` | Register an adapter integrity record                                                     | Gate adapter composition to the active base-model revision      |
+
+`brain.auto_feedback(namespace=...)` writes and folds feedback only in that exact namespace;
+it does not train the default/live namespace's posterior state.
 
 ### Comm pack — 8 verbs (`comm.` prefix)
 
@@ -217,6 +222,8 @@ or `comm.thread`.
 
 `knowledge.search` supports `decompose=true` for multi-concept query splitting (avoids FTS edge
 cases). Scores are normalized to [0,1] when `rerank` is active (default).
+`knowledge.compose(namespace=...)` uses that exact namespace for corpus, section, KG-blend, and
+brain-profile weight reads; absent preserves the caller-token default.
 Pass `kind=` (`"atom"` or `"domain"`) to filter by result type; `type=` is accepted as a legacy
 alias. `knowledge.list` accepts the same `kind=`/`type=` discriminant.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -223,7 +223,8 @@ or `comm.thread`.
 `knowledge.search` supports `decompose=true` for multi-concept query splitting (avoids FTS edge
 cases). Scores are normalized to [0,1] when `rerank` is active (default).
 `knowledge.compose(namespace=...)` uses that exact namespace for corpus, section, KG-blend, and
-brain-profile weight reads; absent preserves the caller-token default.
+brain-profile weight reads, including its namespace-keyed Tier-3 fallback; absent preserves the
+caller-token default.
 Pass `kind=` (`"atom"` or `"domain"`) to filter by result type; `type=` is accepted as a legacy
 alias. `knowledge.list` accepts the same `kind=`/`type=` discriminant.
 

--- a/crates/khive-brain-core/src/profile.rs
+++ b/crates/khive-brain-core/src/profile.rs
@@ -119,20 +119,19 @@ pub struct ProfileBinding {
 /// binding, or each pack's tier-3 (global tuning prior) would become
 /// unreachable.
 ///
-/// `actor` should be the caller's identity via `NamespaceToken::actor().binding_id()`
-/// so actor-scoped bindings can match; pass `None` for the anonymous caller or
-/// when the call site has no caller identity to thread through (wildcard
-/// `actor="*"` bindings still match in that case). Never pass the anonymous
-/// actor's raw `id` ("local") — it would let an anonymous caller match an
-/// explicit `actor="local"` binding that `None` never can.
+/// The authorized `token` supplies both the actor used for binding matching
+/// and the per-request identity used for the nested dispatch. Anonymous
+/// callers map to `actor: null`; their raw `id` ("local") must never match an
+/// explicit `actor="local"` binding. Reusing the token identity also prevents
+/// a warm registry's construction-baked principal from replacing the outer
+/// caller at the nested Gate boundary (ADR-096).
 ///
 /// Shared by the memory pack (`ConsumerKind::Recall`) and the knowledge pack
 /// (`ConsumerKind::KnowledgeCompose`) — ADR-058 amendment, #542; actor-aware
 /// resolution added by #697.
 pub async fn resolve_consumer_profile(
     registry: &khive_runtime::VerbRegistry,
-    actor: Option<&str>,
-    namespace: &str,
+    token: &khive_runtime::NamespaceToken,
     consumer_kind: ConsumerKind,
 ) -> Option<String> {
     // Without the brain pack loaded there is no binding table to consult;
@@ -141,12 +140,21 @@ pub async fn resolve_consumer_profile(
     if !registry.has_verb("brain.resolve") {
         return None;
     }
+    let actor = token.actor().binding_id();
+    let namespace = token.namespace().as_str();
     let resolve_params = serde_json::json!({
         "actor": actor,
         "namespace": namespace,
         "consumer_kind": consumer_kind.as_str(),
     });
-    match registry.dispatch("brain.resolve", resolve_params).await {
+    match registry
+        .dispatch_with_identity(
+            "brain.resolve",
+            resolve_params,
+            Some(khive_runtime::RequestIdentity::from_token(token)),
+        )
+        .await
+    {
         Ok(v) => {
             let matched_binding = v
                 .get("matched_binding")

--- a/crates/khive-pack-brain/docs/design.md
+++ b/crates/khive-pack-brain/docs/design.md
@@ -109,3 +109,7 @@ $$\text{Beta}(\alpha_1 + \alpha_2 - \alpha_{\text{prior}},\; \beta_1 + \beta_2 -
 - `brain.bind` rejects archived profiles to prevent creating unresolvable bindings (issue C3).
 - `brain.create_profile` enforces a profile-id grammar: alphanumeric + hyphens only, no dots,
   underscores, or wildcards; leading/trailing whitespace is trimmed (issue R3-3).
+- `brain.auto_feedback(namespace=...)` applies ADR-007's exact escape to both sides of the
+  mutation: the feedback event/fold-gate row and the selected namespace's live + durable
+  posterior state. Target IDs remain globally resolvable by ID. Handler-side token derivation
+  protects direct `PackRuntime` callers in addition to registry dispatch (issue #1505).

--- a/crates/khive-pack-brain/docs/design.md
+++ b/crates/khive-pack-brain/docs/design.md
@@ -111,5 +111,6 @@ $$\text{Beta}(\alpha_1 + \alpha_2 - \alpha_{\text{prior}},\; \beta_1 + \beta_2 -
   underscores, or wildcards; leading/trailing whitespace is trimmed (issue R3-3).
 - `brain.auto_feedback(namespace=...)` applies ADR-007's exact escape to both sides of the
   mutation: the feedback event/fold-gate row and the selected namespace's live + durable
-  posterior state. Target IDs remain globally resolvable by ID. Handler-side token derivation
-  protects direct `PackRuntime` callers in addition to registry dispatch (issue #1505).
+  posterior state. Target IDs remain globally resolvable by ID. Direct `PackRuntime` calls must
+  present an authorized token whose namespace matches the parameter; the handler validates that
+  equality and never treats the business parameter itself as authority (issue #1505).

--- a/crates/khive-pack-brain/src/handlers.rs
+++ b/crates/khive-pack-brain/src/handlers.rs
@@ -8,7 +8,7 @@ use serde::Deserialize;
 use serde_json::{json, Value};
 
 use khive_runtime::{
-    micros_to_iso, DispatchHook, EventView, KhiveRuntime, NamespaceToken, RuntimeError,
+    micros_to_iso, DispatchHook, EventView, KhiveRuntime, Namespace, NamespaceToken, RuntimeError,
     VerbRegistry,
 };
 use khive_storage::event::{Event, EventFilter};
@@ -330,6 +330,12 @@ pub(crate) static BRAIN_HANDLERS: &[HandlerDef] = &[
                 param_type: "string",
                 required: false,
                 description: "ADR-081: forwarded verbatim to brain.feedback. Must be supplied together with scorer_run_id.",
+            },
+            khive_types::ParamDef {
+                name: "namespace",
+                param_type: "string",
+                required: false,
+                description: "Exact feedback namespace override (ADR-007 Rev 6 escape hatch). The event and posterior fold are scoped to exactly this namespace; the default namespace state is unchanged. Invalid values are rejected.",
             },
         ],
     },
@@ -1851,6 +1857,10 @@ impl BrainPack {
             // together-or-rejected validation and the dedup/fold-gate logic.
             scorer_run_id: Option<String>,
             serve_ledger_id: Option<String>,
+            /// Exact namespace for the emitted event and posterior fold. The
+            /// registry normally pre-applies this to `token`; retaining the
+            /// field here gives direct `PackRuntime` callers the same contract.
+            namespace: Option<String>,
         }
 
         #[derive(Deserialize)]
@@ -1860,6 +1870,28 @@ impl BrainPack {
 
         let p: AutoFeedbackParams = serde_json::from_value(params)
             .map_err(|e| RuntimeError::InvalidInput(e.to_string()))?;
+
+        // Re-derive dispatch's exact namespace as direct-call defense in
+        // depth. Public registry dispatch already supplies this token, while
+        // direct PackRuntime callers may pass a broader/default token plus the
+        // business parameter. BrainPack owns one live state slot, so switch it
+        // before forwarding into handle_feedback; otherwise a bench-arm event
+        // could be stamped with one namespace while mutating another arm's
+        // in-memory posteriors.
+        let effective_token: NamespaceToken = match p.namespace.as_deref() {
+            Some(ns_str) => {
+                let ns = Namespace::parse(ns_str).map_err(|e| {
+                    RuntimeError::InvalidInput(format!("invalid namespace {ns_str:?}: {e}"))
+                })?;
+                token.with_namespace(ns)
+            }
+            None => token.clone(),
+        };
+        if effective_token.namespace() != token.namespace() {
+            self.ensure_loaded(&effective_token).await?;
+        }
+        let token = &effective_token;
+
         if p.query.trim().is_empty() {
             return Err(RuntimeError::InvalidInput(
                 "auto_feedback: `query` must not be empty".into(),

--- a/crates/khive-pack-brain/src/handlers.rs
+++ b/crates/khive-pack-brain/src/handlers.rs
@@ -1871,26 +1871,20 @@ impl BrainPack {
         let p: AutoFeedbackParams = serde_json::from_value(params)
             .map_err(|e| RuntimeError::InvalidInput(e.to_string()))?;
 
-        // Re-derive dispatch's exact namespace as direct-call defense in
-        // depth. Public registry dispatch already supplies this token, while
-        // direct PackRuntime callers may pass a broader/default token plus the
-        // business parameter. BrainPack owns one live state slot, so switch it
-        // before forwarding into handle_feedback; otherwise a bench-arm event
-        // could be stamped with one namespace while mutating another arm's
-        // in-memory posteriors.
-        let effective_token: NamespaceToken = match p.namespace.as_deref() {
-            Some(ns_str) => {
-                let ns = Namespace::parse(ns_str).map_err(|e| {
-                    RuntimeError::InvalidInput(format!("invalid namespace {ns_str:?}: {e}"))
-                })?;
-                token.with_namespace(ns)
+        // Registry dispatch pre-mints an exact token for an explicit
+        // namespace. Direct PackRuntime callers must supply that same token;
+        // a business parameter is never authority to mint a capability.
+        if let Some(ns_str) = p.namespace.as_deref() {
+            let requested = Namespace::parse(ns_str).map_err(|e| {
+                RuntimeError::InvalidInput(format!("invalid namespace {ns_str:?}: {e}"))
+            })?;
+            if &requested != token.namespace() {
+                return Err(RuntimeError::InvalidInput(format!(
+                    "auto_feedback: namespace {ns_str:?} does not match authorized token namespace {:?}",
+                    token.namespace().as_str()
+                )));
             }
-            None => token.clone(),
-        };
-        if effective_token.namespace() != token.namespace() {
-            self.ensure_loaded(&effective_token).await?;
         }
-        let token = &effective_token;
 
         if p.query.trim().is_empty() {
             return Err(RuntimeError::InvalidInput(

--- a/crates/khive-pack-brain/src/tests.rs
+++ b/crates/khive-pack-brain/src/tests.rs
@@ -3125,6 +3125,55 @@ async fn brain_auto_feedback_accepts_short_note_id_prefix() {
     assert_eq!(result["target_id"].as_str().unwrap_or("").len(), 36);
 }
 
+/// #1505 direct-call defense: PackRuntime callers do not receive the
+/// registry's pre-derived token, so the handler must accept and apply the
+/// explicit namespace itself before touching the single live BrainState slot.
+#[tokio::test]
+async fn brain_auto_feedback_direct_dispatch_honors_exact_namespace() {
+    let (pack, rt) = make_pack();
+    let registry = empty_registry();
+    let local_token = rt.authorize(Namespace::local()).expect("local token");
+    let arm_token = rt
+        .authorize(Namespace::parse("bench-arm-a").expect("arm namespace"))
+        .expect("arm token");
+    let target = create_test_entity(&rt, &local_token).await;
+
+    pack.dispatch(
+        "brain.auto_feedback",
+        json!({
+            "query": "direct namespace regression",
+            "results": [{"id": target}],
+            "namespace": "bench-arm-a",
+        }),
+        &registry,
+        &local_token,
+    )
+    .await
+    .expect("direct auto_feedback accepts namespace");
+
+    let local = pack
+        .dispatch(
+            "brain.profile",
+            json!({"profile_id": "balanced-recall-v1"}),
+            &registry,
+            &local_token,
+        )
+        .await
+        .expect("local profile");
+    let arm = pack
+        .dispatch(
+            "brain.profile",
+            json!({"profile_id": "balanced-recall-v1"}),
+            &registry,
+            &arm_token,
+        )
+        .await
+        .expect("arm profile");
+
+    assert_eq!(local["total_events"], json!(0u64));
+    assert_eq!(arm["total_events"], json!(1u64));
+}
+
 // BRAIN-AUD-001: verify namespace isolation — state from namespace A must
 // not be visible when dispatching under namespace B.
 #[tokio::test]
@@ -3270,6 +3319,17 @@ mod help_tests {
         assert!(
             h.params.iter().any(|p| p.name == "results" && p.required),
             "brain.auto_feedback must have required results param"
+        );
+        let namespace = h
+            .params
+            .iter()
+            .find(|p| p.name == "namespace")
+            .unwrap_or_else(|| panic!("brain.auto_feedback must declare namespace"));
+        assert!(!namespace.required);
+        assert!(
+            namespace.description.contains("Exact") && namespace.description.contains("posterior"),
+            "namespace help must document exact posterior isolation: {:?}",
+            namespace.description
         );
     }
 
@@ -3522,6 +3582,93 @@ mod help_tests {
         builder.register(BrainPack::new(rt.clone()));
         let registry = builder.build().expect("kg+brain registry builds");
         (registry, rt)
+    }
+
+    /// #1505: an explicit auto-feedback namespace is both the event stamp and
+    /// the posterior-state owner. The default/live namespace must remain
+    /// byte-for-byte at its pre-call event count.
+    #[tokio::test]
+    async fn auto_feedback_namespace_does_not_train_default_posteriors() {
+        let (registry, rt) = make_brain_registry();
+        let local_token = rt.authorize(Namespace::local()).expect("local token");
+        let target = create_test_entity(&rt, &local_token).await;
+
+        let profile_total = |value: &serde_json::Value| {
+            value["total_events"]
+                .as_u64()
+                .expect("profile total_events")
+        };
+        let local_before = registry
+            .dispatch("brain.profile", json!({"profile_id": "balanced-recall-v1"}))
+            .await
+            .expect("read local profile before feedback");
+        let arm_before = registry
+            .dispatch(
+                "brain.profile",
+                json!({
+                    "profile_id": "balanced-recall-v1",
+                    "namespace": "bench-arm-a",
+                }),
+            )
+            .await
+            .expect("read arm profile before feedback");
+
+        let feedback = registry
+            .dispatch(
+                "brain.auto_feedback",
+                json!({
+                    "query": "isolated recall measurement",
+                    "results": [{"id": target}],
+                    "namespace": "bench-arm-a",
+                }),
+            )
+            .await
+            .expect("namespace-scoped auto_feedback");
+        assert_eq!(feedback["emitted"], json!(true), "got: {feedback}");
+
+        let arm_after = registry
+            .dispatch(
+                "brain.profile",
+                json!({
+                    "profile_id": "balanced-recall-v1",
+                    "namespace": "bench-arm-a",
+                }),
+            )
+            .await
+            .expect("read arm profile after feedback");
+        let local_after = registry
+            .dispatch("brain.profile", json!({"profile_id": "balanced-recall-v1"}))
+            .await
+            .expect("read local profile after feedback");
+
+        assert_eq!(
+            profile_total(&arm_after),
+            profile_total(&arm_before) + 1,
+            "the explicit arm must receive exactly one feedback fold"
+        );
+        assert_eq!(
+            profile_total(&local_after),
+            profile_total(&local_before),
+            "arm feedback must not train the default/live posterior"
+        );
+
+        let arm_token = rt
+            .authorize(Namespace::parse("bench-arm-a").expect("arm namespace"))
+            .expect("arm token");
+        let event_id = uuid::Uuid::parse_str(
+            feedback["event_id"]
+                .as_str()
+                .expect("feedback response event_id"),
+        )
+        .expect("event UUID");
+        let event = rt
+            .events(&arm_token)
+            .expect("event store")
+            .get_event(event_id)
+            .await
+            .expect("event lookup")
+            .expect("feedback event exists");
+        assert_eq!(event.namespace, "bench-arm-a");
     }
 
     /// brain.bind via VerbRegistry must store the caller-supplied namespace,

--- a/crates/khive-pack-brain/src/tests.rs
+++ b/crates/khive-pack-brain/src/tests.rs
@@ -3125,9 +3125,8 @@ async fn brain_auto_feedback_accepts_short_note_id_prefix() {
     assert_eq!(result["target_id"].as_str().unwrap_or("").len(), 36);
 }
 
-/// #1505 direct-call defense: PackRuntime callers do not receive the
-/// registry's pre-derived token, so the handler must accept and apply the
-/// explicit namespace itself before touching the single live BrainState slot.
+/// #1505 direct-call defense: PackRuntime callers must provide a token for the
+/// explicit namespace instead of treating the business parameter as authority.
 #[tokio::test]
 async fn brain_auto_feedback_direct_dispatch_honors_exact_namespace() {
     let (pack, rt) = make_pack();
@@ -3146,10 +3145,10 @@ async fn brain_auto_feedback_direct_dispatch_honors_exact_namespace() {
             "namespace": "bench-arm-a",
         }),
         &registry,
-        &local_token,
+        &arm_token,
     )
     .await
-    .expect("direct auto_feedback accepts namespace");
+    .expect("direct auto_feedback accepts matching namespace token");
 
     let local = pack
         .dispatch(
@@ -3172,6 +3171,118 @@ async fn brain_auto_feedback_direct_dispatch_honors_exact_namespace() {
 
     assert_eq!(local["total_events"], json!(0u64));
     assert_eq!(arm["total_events"], json!(1u64));
+}
+
+/// #1505: an explicit namespace is not a capability. A direct caller cannot
+/// use a local token to emit or fold feedback into another namespace.
+#[tokio::test]
+async fn brain_auto_feedback_direct_dispatch_rejects_namespace_token_mismatch() {
+    let (pack, rt) = make_pack();
+    let registry = empty_registry();
+    let local_token = rt.authorize(Namespace::local()).expect("local token");
+    let arm_token = rt
+        .authorize(Namespace::parse("bench-arm-a").expect("arm namespace"))
+        .expect("arm token");
+    let target = create_test_entity(&rt, &local_token).await;
+
+    let local_before = pack
+        .dispatch(
+            "brain.profile",
+            json!({"profile_id": "balanced-recall-v1"}),
+            &registry,
+            &local_token,
+        )
+        .await
+        .expect("local profile before mismatch");
+    let arm_before = pack
+        .dispatch(
+            "brain.profile",
+            json!({"profile_id": "balanced-recall-v1"}),
+            &registry,
+            &arm_token,
+        )
+        .await
+        .expect("arm profile before mismatch");
+    let local_log_before = pack
+        .dispatch(
+            "brain.events",
+            json!({"limit": 100}),
+            &registry,
+            &local_token,
+        )
+        .await
+        .expect("local event log before mismatch");
+    let arm_log_before = pack
+        .dispatch("brain.events", json!({"limit": 100}), &registry, &arm_token)
+        .await
+        .expect("arm event log before mismatch");
+
+    let err = pack
+        .dispatch(
+            "brain.auto_feedback",
+            json!({
+                "query": "unauthorized direct namespace",
+                "results": [{"id": target}],
+                "namespace": "bench-arm-a",
+            }),
+            &registry,
+            &local_token,
+        )
+        .await
+        .expect_err("local token must not authorize arm feedback");
+    assert!(
+        matches!(err, RuntimeError::InvalidInput(ref msg) if msg.contains("does not match authorized token namespace")),
+        "expected namespace mismatch InvalidInput, got {err:?}"
+    );
+
+    let local_after = pack
+        .dispatch(
+            "brain.profile",
+            json!({"profile_id": "balanced-recall-v1"}),
+            &registry,
+            &local_token,
+        )
+        .await
+        .expect("local profile after mismatch");
+    let arm_after = pack
+        .dispatch(
+            "brain.profile",
+            json!({"profile_id": "balanced-recall-v1"}),
+            &registry,
+            &arm_token,
+        )
+        .await
+        .expect("arm profile after mismatch");
+    let local_log_after = pack
+        .dispatch(
+            "brain.events",
+            json!({"limit": 100}),
+            &registry,
+            &local_token,
+        )
+        .await
+        .expect("local event log after mismatch");
+    let arm_log_after = pack
+        .dispatch("brain.events", json!({"limit": 100}), &registry, &arm_token)
+        .await
+        .expect("arm event log after mismatch");
+
+    assert_eq!(
+        local_after["total_events"], local_before["total_events"],
+        "rejected feedback must not mutate local posterior state"
+    );
+    assert_eq!(
+        arm_after["total_events"], arm_before["total_events"],
+        "rejected feedback must not mutate arm posterior state"
+    );
+    assert_eq!(
+        local_log_after["count"], local_log_before["count"],
+        "rejected feedback must not append a local event"
+    );
+    assert_eq!(
+        arm_log_after["count"], arm_log_before["count"],
+        "rejected feedback must not append an arm event"
+    );
 }
 
 // BRAIN-AUD-001: verify namespace isolation — state from namespace A must

--- a/crates/khive-pack-knowledge/docs/api/compose-type-weights.md
+++ b/crates/khive-pack-knowledge/docs/api/compose-type-weights.md
@@ -13,6 +13,11 @@ pin each tier's behavior.
    feedback state), falling back to `SectionPosteriorState::default()` only when no
    feedback has been recorded.
 
+An explicit `knowledge.compose(namespace=...)` derives one exact namespace token before this
+ladder runs. `brain.resolve` and the follow-up `brain.profile` dispatch both receive that
+namespace; omitting it from the second dispatch would silently read the default namespace and
+fall through to Tier 3 when the selected profile exists only in the compose arm (#1505).
+
 Each tier is tried in order; the first one present wins. A pre-#346 regression returned
 `SectionPosteriorState::default()` unconditionally from Tier 3, ignoring learned feedback
 entirely — the tests below exist to pin that this cannot recur.

--- a/crates/khive-pack-knowledge/docs/api/compose-type-weights.md
+++ b/crates/khive-pack-knowledge/docs/api/compose-type-weights.md
@@ -9,14 +9,16 @@ pin each tier's behavior.
 1. **Tier 1** — an explicit `brain_profile` passed by the caller.
 2. **Tier 2** — a namespace-bound brain profile registered via `brain.bind`, dispatched
    across the pack boundary through `load_profile_type_weights`.
-3. **Tier 3** — this pack's own tuned `section_posteriors` (Bayesian per-section
-   feedback state), falling back to `SectionPosteriorState::default()` only when no
-   feedback has been recorded.
+3. **Tier 3** — this pack's own namespace-keyed tuned `section_posteriors` (Bayesian
+   per-section feedback state), falling back to `SectionPosteriorState::default()` only
+   when no feedback has been recorded in the effective namespace.
 
-An explicit `knowledge.compose(namespace=...)` derives one exact namespace token before this
-ladder runs. `brain.resolve` and the follow-up `brain.profile` dispatch both receive that
-namespace; omitting it from the second dispatch would silently read the default namespace and
-fall through to Tier 3 when the selected profile exists only in the compose arm (#1505).
+An explicit `knowledge.compose(namespace=...)` uses one exact authorized namespace token before
+this ladder runs. `brain.resolve` and the follow-up `brain.profile` dispatch both receive that
+namespace and preserve the token's per-request actor at their Gate boundaries; omitting either
+would silently read or authorize as the registry's default identity. Direct pack calls first
+validate that the requested namespace matches their authorized token, then narrow any broader
+visible set to the one arm. Tier-3 feedback from another namespace is never inherited (#1505).
 
 Each tier is tried in order; the first one present wins. A pre-#346 regression returned
 `SectionPosteriorState::default()` unconditionally from Tier 3, ignoring learned feedback
@@ -25,8 +27,10 @@ entirely — the tests below exist to pin that this cannot recur.
 ## Tier 3: tuned `section_posteriors` (`resolve_compose_type_weights_reads_tuned_section_posteriors_at_tier3`)
 
 With Tiers 1 and 2 absent (empty registry, no brain pack), Tier 3 must read the pack-local
-`section_posteriors` rather than silently returning fresh default priors. The test skews
-posteriors heavily toward `Formalism` and against `OperationalGuidance` — enough that the
+`section_posteriors` for the effective namespace rather than silently returning fresh default
+priors. A companion isolation test tunes `local` and proves an untouched measurement arm retains
+fresh defaults. The original regression test skews local posteriors heavily toward `Formalism`
+and against `OperationalGuidance` — enough that the
 tuned formalism weight exceeds the tuned operational_guidance weight, the opposite of the
 default prior ordering (`α_og=6, β_og=1.5` vs `α_form=1.5, β_form=4`). Against the old
 `SectionPosteriorState::default()`-inside-`compose` code path, this assertion fails,

--- a/crates/khive-pack-knowledge/docs/design.md
+++ b/crates/khive-pack-knowledge/docs/design.md
@@ -90,9 +90,11 @@
 
 All corpus SQL queries include `AND namespace = ?` predicates scoped to the caller token's
 namespace. The `knowledge.import` verb delegates to `upsert_atoms` and `edit`, which each
-enforce the caller namespace — no cross-namespace write is possible. An explicit `namespace`
-parameter is not supported (it was removed to prevent contract/implementation mismatches;
-see KPK-AUD-006).
+enforce the caller namespace — no cross-namespace write is possible. `knowledge.compose`
+accepts an explicit `namespace` as ADR-007's exact single-namespace escape. The same derived
+token scopes automatic suggestion, corpus/section reads, KG blending, and the cross-pack
+brain-profile weight read; an absent parameter preserves the existing caller-token scope.
+Other corpus handlers continue to consume the registry's transport-level namespace routing.
 
 ## Test Coverage
 

--- a/crates/khive-pack-knowledge/docs/design.md
+++ b/crates/khive-pack-knowledge/docs/design.md
@@ -93,7 +93,10 @@ namespace. The `knowledge.import` verb delegates to `upsert_atoms` and `edit`, w
 enforce the caller namespace — no cross-namespace write is possible. `knowledge.compose`
 accepts an explicit `namespace` as ADR-007's exact single-namespace escape. The same derived
 token scopes automatic suggestion, corpus/section reads, KG blending, and the cross-pack
-brain-profile weight read; an absent parameter preserves the existing caller-token scope.
+brain-profile weight read; Tier-3 pack-local feedback state is keyed by that namespace too.
+Nested profile dispatches preserve the authorized token's per-request actor and scope. Direct
+pack calls must present a matching authorized token, whose visibility is then narrowed to the
+one explicit namespace. An absent parameter preserves the existing caller-token scope.
 Other corpus handlers continue to consume the registry's transport-level namespace routing.
 
 ## Test Coverage

--- a/crates/khive-pack-knowledge/src/handlers.rs
+++ b/crates/khive-pack-knowledge/src/handlers.rs
@@ -6,8 +6,10 @@ use serde::Deserialize;
 use serde_json::{json, Value};
 use uuid::Uuid;
 
-use khive_brain_core::{resolve_consumer_profile, ConsumerKind, FeedbackSignal, SectionType};
-use khive_runtime::{KhiveRuntime, NamespaceToken, RuntimeError, VerbRegistry};
+use khive_brain_core::{
+    resolve_consumer_profile, ConsumerKind, FeedbackSignal, SectionPosteriorState, SectionType,
+};
+use khive_runtime::{KhiveRuntime, NamespaceToken, RequestIdentity, RuntimeError, VerbRegistry};
 use khive_storage::EdgeRelation;
 
 use crate::knowledge::section_feedback::on_section_feedback;
@@ -337,7 +339,7 @@ impl KnowledgePack {
     /// 3-tier profile resolution (ADR-035) — exclusive flow (each tier returns early):
     /// 1. Explicit brain profile in config (`self.brain_profile`) → route via `brain.feedback`
     /// 2. Namespace-bound profile via `brain.resolve(consumer_kind="knowledge_compose")` → route via `brain.feedback`
-    /// 3. Global section_posteriors → update in-memory state directly (tier-3 only when neither 1 nor 2 resolves)
+    /// 3. Namespace-local section_posteriors → update in-memory state directly (tier-3 only when neither 1 nor 2 resolves)
     pub(crate) async fn handle_feedback(
         &self,
         token: &NamespaceToken,
@@ -390,7 +392,13 @@ impl KnowledgePack {
                     "served_by_profile_id": profile_id,
                     "section_signals": section_signals_val,
                 });
-                let result = registry.dispatch("brain.feedback", brain_params).await?;
+                let result = registry
+                    .dispatch_with_identity(
+                        "brain.feedback",
+                        brain_params,
+                        Some(RequestIdentity::from_token(token)),
+                    )
+                    .await?;
                 return Ok(json!({
                     "ok": true,
                     "brain_profile": profile_id,
@@ -405,9 +413,8 @@ impl KnowledgePack {
         // feedback has its own consumer_kind bucket (ADR-058 amendment, #542) so it no
         // longer shares posteriors with the memory pack's recall bucket.
         if let Some(ref tid) = target_id_str {
-            let actor = token.actor().binding_id();
             if let Some(profile_id) =
-                resolve_consumer_profile(registry, actor, &ns, ConsumerKind::KnowledgeCompose).await
+                resolve_consumer_profile(registry, token, ConsumerKind::KnowledgeCompose).await
             {
                 let brain_params = json!({
                     "namespace": ns,
@@ -416,7 +423,13 @@ impl KnowledgePack {
                     "served_by_profile_id": profile_id,
                     "section_signals": section_signals_val,
                 });
-                let result = registry.dispatch("brain.feedback", brain_params).await?;
+                let result = registry
+                    .dispatch_with_identity(
+                        "brain.feedback",
+                        brain_params,
+                        Some(RequestIdentity::from_token(token)),
+                    )
+                    .await?;
                 return Ok(json!({
                     "ok": true,
                     "brain_profile": profile_id,
@@ -426,12 +439,14 @@ impl KnowledgePack {
             }
         }
 
-        // Tier 3: global tuning prior — update pack-local section_posteriors directly.
+        // Tier 3: namespace-local tuning prior — update only this exact
+        // namespace's pack-local section posteriors.
         let total_events = {
-            let mut state = self.section_posteriors.lock().map_err(|_| {
+            let mut states = self.section_posteriors.lock().map_err(|_| {
                 RuntimeError::Internal("section_posteriors lock poisoned".to_string())
             })?;
-            on_section_feedback(&mut state, &signals);
+            let state = states.entry(ns).or_insert_with(SectionPosteriorState::new);
+            on_section_feedback(state, &signals);
             state.total_events
         };
 
@@ -449,7 +464,7 @@ impl KnowledgePack {
     ///
     /// Tier 1: explicit `brain_profile` config → `brain.profile` → extract `weight` per section.
     /// Tier 2: namespace-bound profile via `brain.resolve(consumer_kind="knowledge_compose")` → same.
-    /// Tier 3: pack-local `section_posteriors` mutex → `deterministic_weights()`.
+    /// Tier 3: pack-local, namespace-keyed `section_posteriors` mutex → `deterministic_weights()`.
     /// Fallback: `SectionPosteriorState::default()`.
     pub(crate) async fn resolve_compose_type_weights(
         &self,
@@ -460,28 +475,31 @@ impl KnowledgePack {
 
         // Tier 1: explicit profile from config.
         if let Some(ref profile_id) = self.brain_profile {
-            if let Some(weights) = load_profile_type_weights(registry, profile_id, &ns).await {
+            if let Some(weights) = load_profile_type_weights(registry, profile_id, token).await {
                 return weights;
             }
         }
 
         // Tier 2: namespace-bound profile via brain.resolve(consumer_kind="knowledge_compose").
-        let actor = token.actor().binding_id();
         if let Some(profile_id) =
-            resolve_consumer_profile(registry, actor, &ns, ConsumerKind::KnowledgeCompose).await
+            resolve_consumer_profile(registry, token, ConsumerKind::KnowledgeCompose).await
         {
-            if let Some(weights) = load_profile_type_weights(registry, &profile_id, &ns).await {
+            if let Some(weights) = load_profile_type_weights(registry, &profile_id, token).await {
                 return weights;
             }
         }
 
-        // Tier 3: pack-local section_posteriors (updated by global-tuning feedback).
-        if let Ok(state) = self.section_posteriors.lock() {
-            return state
-                .deterministic_weights()
-                .into_iter()
-                .map(|(st, w)| (st.as_str().to_string(), w as f32))
-                .collect();
+        // Tier 3: exact-namespace pack-local section_posteriors. An arm with
+        // no feedback gets fresh defaults rather than inheriting another
+        // namespace's tuning.
+        if let Ok(states) = self.section_posteriors.lock() {
+            if let Some(state) = states.get(&ns) {
+                return state
+                    .deterministic_weights()
+                    .into_iter()
+                    .map(|(st, w)| (st.as_str().to_string(), w as f32))
+                    .collect();
+            }
         }
 
         // Fallback: fresh default (lock poisoned — should not occur in normal operation).
@@ -504,12 +522,14 @@ impl KnowledgePack {
 async fn load_profile_type_weights(
     registry: &VerbRegistry,
     profile_id: &str,
-    namespace: &str,
+    token: &NamespaceToken,
 ) -> Option<HashMap<String, f32>> {
+    let namespace = token.namespace().as_str();
     let result = registry
-        .dispatch(
+        .dispatch_with_identity(
             "brain.profile",
             json!({ "profile_id": profile_id, "namespace": namespace }),
+            Some(RequestIdentity::from_token(token)),
         )
         .await
         .ok()?;
@@ -618,10 +638,11 @@ mod tests {
         // OperationalGuidance.  Force exploration_epoch=0 so deterministic_weights()
         // uses posterior means directly (no Thompson sampling noise).
         {
-            let mut state = pack.section_posteriors.lock().unwrap();
+            let mut states = pack.section_posteriors.lock().unwrap();
+            let state = states.entry("local".to_string()).or_default();
             for _ in 0..80 {
                 on_section_feedback(
-                    &mut state,
+                    state,
                     &[
                         (SectionType::Formalism, FeedbackSignal::Useful),
                         (SectionType::OperationalGuidance, FeedbackSignal::Wrong),
@@ -666,6 +687,59 @@ mod tests {
         assert!(
             formalism_tuned > og_tuned,
             "after skewing, formalism {formalism_tuned:.4} must outweigh og {og_tuned:.4}"
+        );
+    }
+
+    /// #1505: Tier-3 feedback is isolated by exact namespace. Local/live
+    /// tuning must not alter the fallback weights used by a measurement arm
+    /// that has recorded no feedback of its own.
+    #[tokio::test]
+    async fn tier3_section_posteriors_do_not_cross_namespaces() {
+        let rt = KhiveRuntime::memory().expect("in-memory runtime");
+        let pack = KnowledgePack::new(rt.clone());
+        let registry = VerbRegistryBuilder::new()
+            .build()
+            .expect("empty registry builds");
+        let local_token = rt.authorize(Namespace::local()).expect("local token");
+        let arm_token = rt
+            .authorize(Namespace::parse("bench-arm-a").expect("arm namespace"))
+            .expect("arm token");
+
+        for _ in 0..80 {
+            pack.dispatch(
+                "knowledge.feedback",
+                json!({
+                    "section_signals": {
+                        "formalism": "useful",
+                        "operational_guidance": "wrong"
+                    }
+                }),
+                &registry,
+                &local_token,
+            )
+            .await
+            .expect("local Tier-3 feedback");
+        }
+
+        let local = pack
+            .resolve_compose_type_weights(&registry, &local_token)
+            .await;
+        let arm = pack
+            .resolve_compose_type_weights(&registry, &arm_token)
+            .await;
+        let defaults: HashMap<String, f32> = SectionPosteriorState::default()
+            .deterministic_weights()
+            .into_iter()
+            .map(|(st, w)| (st.as_str().to_string(), w as f32))
+            .collect();
+
+        assert!(
+            local["formalism"] > local["operational_guidance"],
+            "local feedback must tune the local fallback"
+        );
+        assert_eq!(
+            arm, defaults,
+            "an untouched measurement arm must retain fresh Tier-3 defaults"
         );
     }
 

--- a/crates/khive-pack-knowledge/src/handlers.rs
+++ b/crates/khive-pack-knowledge/src/handlers.rs
@@ -460,7 +460,7 @@ impl KnowledgePack {
 
         // Tier 1: explicit profile from config.
         if let Some(ref profile_id) = self.brain_profile {
-            if let Some(weights) = load_profile_type_weights(registry, profile_id).await {
+            if let Some(weights) = load_profile_type_weights(registry, profile_id, &ns).await {
                 return weights;
             }
         }
@@ -470,7 +470,7 @@ impl KnowledgePack {
         if let Some(profile_id) =
             resolve_consumer_profile(registry, actor, &ns, ConsumerKind::KnowledgeCompose).await
         {
-            if let Some(weights) = load_profile_type_weights(registry, &profile_id).await {
+            if let Some(weights) = load_profile_type_weights(registry, &profile_id, &ns).await {
                 return weights;
             }
         }
@@ -504,9 +504,13 @@ impl KnowledgePack {
 async fn load_profile_type_weights(
     registry: &VerbRegistry,
     profile_id: &str,
+    namespace: &str,
 ) -> Option<HashMap<String, f32>> {
     let result = registry
-        .dispatch("brain.profile", json!({ "profile_id": profile_id }))
+        .dispatch(
+            "brain.profile",
+            json!({ "profile_id": profile_id, "namespace": namespace }),
+        )
         .await
         .ok()?;
     let sections = result.get("section_posteriors")?.as_object()?;
@@ -752,6 +756,75 @@ mod tests {
             "Tier-2 bound-profile: formalism {formalism_w:.4} must exceed og {og_w:.4}; \
              ordering reflects seed_priors (formalism β(8,1) >> og β(1,8)), \
              not default priors where og α=6,β=1.5 dominates"
+        );
+    }
+
+    /// #1505: after resolving a binding in a non-default namespace, the
+    /// follow-up `brain.profile` read must stay in that namespace too. Before
+    /// the fix, the second cross-pack dispatch silently fell back to local,
+    /// missed the arm profile, and compose used Tier-3 default weights.
+    #[tokio::test]
+    async fn resolve_compose_type_weights_keeps_nonlocal_namespace_for_profile_read() {
+        use khive_pack_brain::BrainPack;
+        use khive_pack_kg::KgPack;
+
+        let rt = KhiveRuntime::memory().expect("in-memory runtime");
+        let mut builder = VerbRegistryBuilder::new();
+        builder.register(KgPack::new(rt.clone()));
+        builder.register(BrainPack::new(rt.clone()));
+        let registry = builder.build().expect("kg+brain registry builds");
+        let arm_ns = "bench-arm-a";
+
+        registry
+            .dispatch(
+                "brain.create_profile",
+                json!({
+                    "namespace": arm_ns,
+                    "name": "compose-bench-arm-v1",
+                    "consumer_kind": "knowledge_compose",
+                    "seed_priors": {
+                        "section_posteriors": {
+                            "formalism": {"alpha": 8.0, "beta": 1.0},
+                            "operational_guidance": {"alpha": 1.0, "beta": 8.0}
+                        }
+                    }
+                }),
+            )
+            .await
+            .expect("create arm profile");
+        registry
+            .dispatch(
+                "brain.activate",
+                json!({
+                    "namespace": arm_ns,
+                    "profile_id": "compose-bench-arm-v1",
+                }),
+            )
+            .await
+            .expect("activate arm profile");
+        registry
+            .dispatch(
+                "brain.bind",
+                json!({
+                    "namespace": arm_ns,
+                    "profile_id": "compose-bench-arm-v1",
+                    "consumer_kind": "knowledge_compose",
+                }),
+            )
+            .await
+            .expect("bind arm profile");
+
+        let pack = KnowledgePack::new(rt.clone());
+        let token = rt
+            .authorize(Namespace::parse(arm_ns).expect("arm namespace"))
+            .expect("arm token");
+        let weights = pack.resolve_compose_type_weights(&registry, &token).await;
+        let formalism = weights["formalism"];
+        let operational = weights["operational_guidance"];
+        assert!(
+            formalism > operational,
+            "nonlocal Tier-2 profile must supply its inverted weights; got \
+             formalism={formalism:.4}, operational_guidance={operational:.4}"
         );
     }
 

--- a/crates/khive-pack-knowledge/src/knowledge/schema.rs
+++ b/crates/khive-pack-knowledge/src/knowledge/schema.rs
@@ -302,6 +302,10 @@ pub(crate) struct SuggestParams {
 #[derive(Debug, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub(crate) struct ComposeParams {
+    /// Exact read namespace. Registry dispatch pre-applies this to the token;
+    /// the handler retains it for direct-call defense in depth.
+    #[serde(default)]
+    pub namespace: Option<String>,
     #[serde(default)]
     pub domain_ids: Option<Vec<String>>,
     #[serde(default)]

--- a/crates/khive-pack-knowledge/src/knowledge/schema.rs
+++ b/crates/khive-pack-knowledge/src/knowledge/schema.rs
@@ -303,7 +303,8 @@ pub(crate) struct SuggestParams {
 #[serde(deny_unknown_fields)]
 pub(crate) struct ComposeParams {
     /// Exact read namespace. Registry dispatch pre-applies this to the token;
-    /// the handler retains it for direct-call defense in depth.
+    /// direct handlers validate a matching authorized token and narrow any
+    /// broader visibility before reading.
     #[serde(default)]
     pub namespace: Option<String>,
     #[serde(default)]

--- a/crates/khive-pack-knowledge/src/knowledge/search.rs
+++ b/crates/khive-pack-knowledge/src/knowledge/search.rs
@@ -8,7 +8,9 @@ use std::collections::{HashMap, HashSet};
 use serde_json::{json, Value};
 use uuid::Uuid;
 
-use khive_runtime::{hex_prefix_to_uuid_pattern, KhiveRuntime, NamespaceToken, RuntimeError};
+use khive_runtime::{
+    hex_prefix_to_uuid_pattern, KhiveRuntime, Namespace, NamespaceToken, RuntimeError,
+};
 use khive_score::DeterministicScore;
 use khive_storage::types::{PageRequest, SqlStatement, SqlValue};
 use khive_storage::EntityFilter;
@@ -1508,6 +1510,22 @@ impl KnowledgeHandlers {
         type_weights: HashMap<String, f32>,
     ) -> Result<Value, RuntimeError> {
         let p: ComposeParams = deser(params)?;
+
+        // Registry dispatch already mints an exact token for an explicit
+        // namespace. Re-derive it here as defense in depth for direct handler
+        // callers so every compose leg (suggest, corpus/section fetch, and KG
+        // blend) observes the same single-namespace scope.
+        let effective_token: NamespaceToken = match p.namespace.as_deref() {
+            Some(ns_str) => {
+                let ns = Namespace::parse(ns_str).map_err(|e| {
+                    RuntimeError::InvalidInput(format!("invalid namespace {ns_str:?}: {e}"))
+                })?;
+                token.with_namespace(ns)
+            }
+            None => token.clone(),
+        };
+        let token = &effective_token;
+
         let raw_query = p.query.trim().to_string();
         if raw_query.is_empty() {
             return Err(RuntimeError::InvalidInput("query must not be empty".into()));

--- a/crates/khive-pack-knowledge/src/knowledge/search.rs
+++ b/crates/khive-pack-knowledge/src/knowledge/search.rs
@@ -1512,14 +1512,22 @@ impl KnowledgeHandlers {
         let p: ComposeParams = deser(params)?;
 
         // Registry dispatch already mints an exact token for an explicit
-        // namespace. Re-derive it here as defense in depth for direct handler
-        // callers so every compose leg (suggest, corpus/section fetch, and KG
-        // blend) observes the same single-namespace scope.
-        let effective_token: NamespaceToken = match p.namespace.as_deref() {
+        // namespace. Direct handler callers must provide that same authorized
+        // token; never turn an untrusted business parameter into a stronger
+        // namespace capability here.
+        let effective_token = match p.namespace.as_deref() {
             Some(ns_str) => {
                 let ns = Namespace::parse(ns_str).map_err(|e| {
                     RuntimeError::InvalidInput(format!("invalid namespace {ns_str:?}: {e}"))
                 })?;
+                if &ns != token.namespace() {
+                    return Err(RuntimeError::InvalidInput(
+                        "knowledge.compose namespace does not match authorized token namespace"
+                            .to_string(),
+                    ));
+                }
+                // Equality above makes this a safe exact-scope narrowing of
+                // any broader direct-call token.
                 token.with_namespace(ns)
             }
             None => token.clone(),
@@ -1951,6 +1959,31 @@ impl KnowledgeHandlers {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[tokio::test]
+    async fn compose_direct_handler_rejects_namespace_token_mismatch() {
+        let runtime = KhiveRuntime::memory().expect("in-memory runtime");
+        let token = runtime.authorize(Namespace::local()).expect("local token");
+        let ann = vamana::new_shared();
+
+        let err = KnowledgeHandlers::compose(
+            &runtime,
+            &token,
+            json!({
+                "namespace": "bench-arm-a",
+                "query": "must reject before reading",
+            }),
+            &ann,
+            HashMap::new(),
+        )
+        .await
+        .expect_err("a local token must not elevate into a measurement arm");
+
+        assert!(
+            matches!(err, RuntimeError::InvalidInput(ref msg) if msg.contains("does not match authorized token namespace")),
+            "unexpected error: {err:?}"
+        );
+    }
 
     // ── embed-intent regression ───────────────────────────────────────────────
     // Guard that the ANN query paths in `search` and `suggest` use the

--- a/crates/khive-pack-knowledge/src/pack.rs
+++ b/crates/khive-pack-knowledge/src/pack.rs
@@ -1,5 +1,6 @@
 //! `KnowledgePack` struct, factory, and `PackRuntime` impl.
 
+use std::collections::HashMap;
 use std::sync::Mutex;
 
 use async_trait::async_trait;
@@ -24,12 +25,17 @@ use crate::vocab::KNOWLEDGE_HANDLERS;
 pub struct KnowledgePack {
     pub(crate) runtime: KhiveRuntime,
     pub(crate) ann: vamana::SharedAnn,
-    pub(crate) section_posteriors: Mutex<SectionPosteriorState>,
+    /// Pack-local Tier-3 feedback state, isolated by exact namespace.
+    ///
+    /// This fallback is used only when no configured or bound brain profile
+    /// resolves. Keying it by namespace keeps explicit measurement arms from
+    /// inheriting live/default feedback while preserving existing local behavior.
+    pub(crate) section_posteriors: Mutex<HashMap<String, SectionPosteriorState>>,
     /// Explicit brain profile ID from config (ADR-035 §Brain profile configuration).
     ///
     /// Tier-1 of the 3-tier feedback resolution: when set, `knowledge.feedback` directs
     /// feedback to this profile via `brain.feedback`. When absent, tier-2
-    /// (namespace-bound profile) and tier-3 (global prior) are tried in order.
+    /// (namespace-bound profile) and tier-3 (namespace-local prior) are tried in order.
     pub(crate) brain_profile: Option<String>,
 }
 
@@ -48,7 +54,7 @@ impl KnowledgePack {
         Self {
             runtime,
             ann: vamana::new_shared(),
-            section_posteriors: Mutex::new(SectionPosteriorState::new()),
+            section_posteriors: Mutex::new(HashMap::new()),
             brain_profile,
         }
     }
@@ -218,16 +224,25 @@ impl PackRuntime for KnowledgePack {
             }
             "knowledge.compose" => {
                 // Public registry dispatch pre-applies an explicit namespace,
-                // but PackRuntime is also called directly in tests and by
-                // embedders. Derive the exact token before the cross-pack
-                // profile lookup so weights and corpus rows cannot come from
-                // different namespace arms.
+                // while PackRuntime can also be called directly by embedders.
+                // A direct caller must supply a token already authorized for
+                // the requested namespace; handlers may not mint a stronger
+                // capability from an untrusted business parameter.
                 let effective_token = match params.get("namespace") {
                     None => token.clone(),
                     Some(Value::String(ns_str)) => {
                         let ns = Namespace::parse(ns_str).map_err(|e| {
                             RuntimeError::InvalidInput(format!("invalid namespace {ns_str:?}: {e}"))
                         })?;
+                        if &ns != token.namespace() {
+                            return Err(RuntimeError::InvalidInput(
+                                "knowledge.compose namespace does not match authorized token namespace"
+                                    .to_string(),
+                            ));
+                        }
+                        // Equality proves this is capability narrowing, not
+                        // elevation. Replace any broader visible set so every
+                        // compose leg observes exactly the requested arm.
                         token.with_namespace(ns)
                     }
                     Some(_) => {

--- a/crates/khive-pack-knowledge/src/pack.rs
+++ b/crates/khive-pack-knowledge/src/pack.rs
@@ -8,7 +8,9 @@ use uuid::Uuid;
 
 use khive_brain_core::SectionPosteriorState;
 use khive_runtime::pack::{PackByIdResolver, PackRuntime};
-use khive_runtime::{KhiveRuntime, NamespaceToken, Resolved, RuntimeError, VerbRegistry};
+use khive_runtime::{
+    KhiveRuntime, Namespace, NamespaceToken, Resolved, RuntimeError, VerbRegistry,
+};
 use khive_storage::types::{SqlStatement, SqlValue};
 use khive_storage::{PhaseCancelledPayload, PhaseCompletedPayload, PhaseStartedPayload};
 use khive_types::{EventKind, HandlerDef, Pack};
@@ -215,9 +217,36 @@ impl PackRuntime for KnowledgePack {
                 KnowledgeHandlers::suggest(&self.runtime, token, params, &self.ann).await
             }
             "knowledge.compose" => {
-                let type_weights = self.resolve_compose_type_weights(registry, token).await;
-                KnowledgeHandlers::compose(&self.runtime, token, params, &self.ann, type_weights)
-                    .await
+                // Public registry dispatch pre-applies an explicit namespace,
+                // but PackRuntime is also called directly in tests and by
+                // embedders. Derive the exact token before the cross-pack
+                // profile lookup so weights and corpus rows cannot come from
+                // different namespace arms.
+                let effective_token = match params.get("namespace") {
+                    None => token.clone(),
+                    Some(Value::String(ns_str)) => {
+                        let ns = Namespace::parse(ns_str).map_err(|e| {
+                            RuntimeError::InvalidInput(format!("invalid namespace {ns_str:?}: {e}"))
+                        })?;
+                        token.with_namespace(ns)
+                    }
+                    Some(_) => {
+                        return Err(RuntimeError::InvalidInput(
+                            "invalid namespace: expected a string".to_string(),
+                        ));
+                    }
+                };
+                let type_weights = self
+                    .resolve_compose_type_weights(registry, &effective_token)
+                    .await;
+                KnowledgeHandlers::compose(
+                    &self.runtime,
+                    &effective_token,
+                    params,
+                    &self.ann,
+                    type_weights,
+                )
+                .await
             }
             "knowledge.edit" => {
                 KnowledgeHandlers::edit(&self.runtime, token, params, &self.ann).await

--- a/crates/khive-pack-knowledge/src/vocab.rs
+++ b/crates/khive-pack-knowledge/src/vocab.rs
@@ -322,6 +322,12 @@ pub(crate) static KNOWLEDGE_HANDLERS: [HandlerDef; 19] = [
         category: VerbCategory::Assertive,
         params: &[
             ParamDef {
+                name: "namespace",
+                param_type: "string",
+                required: false,
+                description: "Exact-match read namespace override (ADR-007 Rev 6 escape hatch). When absent, compose uses the caller token's namespace. When present, atom, domain, section, KG-blend, and profile-weight reads use exactly this namespace; invalid values are rejected.",
+            },
+            ParamDef {
                 name: "domain_ids",
                 param_type: "array<string>",
                 required: false,
@@ -690,6 +696,7 @@ mod tests {
             (
                 "knowledge.compose",
                 &[
+                    "namespace",
                     "domain_ids",
                     "atom_ids",
                     "query",

--- a/crates/khive-pack-knowledge/tests/feedback.rs
+++ b/crates/khive-pack-knowledge/tests/feedback.rs
@@ -3,7 +3,7 @@
 //! Tier order (exclusive flow per ADR-035):
 //! 1. Explicit brain profile in pack config → route via `brain.feedback`, return early
 //! 2. Namespace-bound profile via `brain.resolve(consumer_kind="knowledge_compose")`, matched_binding=true → return early
-//! 3. Global section_posteriors → update pack-local prior (only when tiers 1 and 2 do not resolve)
+//! 3. Namespace-keyed section_posteriors → update pack-local prior (only when tiers 1 and 2 do not resolve)
 
 use khive_pack_brain::BrainPack;
 use khive_pack_kg::KgPack;
@@ -366,7 +366,7 @@ async fn feedback_tier2_actor_bound_profile_credited() {
 /// unconditionally (before tiers 1/2 were checked), and tier-2 used consumer_kind
 /// "knowledge.search" which never matched recall bindings.
 #[tokio::test]
-async fn feedback_tier3_global_fallback_no_explicit_binding() {
+async fn feedback_tier3_namespace_fallback_no_explicit_binding() {
     // No explicit brain_profile, brain pack loaded but NO explicit binding.
     let rt = make_rt(None, true);
     let ns = Namespace::parse("local").expect("ns");
@@ -425,7 +425,7 @@ async fn feedback_tier3_global_fallback_no_explicit_binding() {
     );
 }
 
-/// Tier-3 without brain pack: feedback always falls through to global prior.
+/// Tier-3 without brain pack: feedback falls through to its namespace-local prior.
 #[tokio::test]
 async fn feedback_tier3_no_brain_pack() {
     let rt = make_rt(None, false);

--- a/crates/khive-pack-knowledge/tests/integration.rs
+++ b/crates/khive-pack-knowledge/tests/integration.rs
@@ -10,8 +10,12 @@
 
 use khive_pack_kg::KgPack;
 use khive_pack_knowledge::KnowledgePack;
-use khive_runtime::{KhiveRuntime, PackRegistry, RuntimeError, VerbRegistry, VerbRegistryBuilder};
+use khive_runtime::{
+    Gate, GateDecision, GateError, GateRequest, KhiveRuntime, PackRegistry, RequestIdentity,
+    RuntimeError, VerbRegistry, VerbRegistryBuilder,
+};
 use serde_json::{json, Value};
+use std::sync::{Arc, Mutex};
 
 // ── test fixture ──────────────────────────────────────────────────────────────
 
@@ -21,6 +25,29 @@ fn rt() -> KhiveRuntime {
 
 struct Fixture {
     registry: VerbRegistry,
+}
+
+#[derive(Debug, Default)]
+struct NestedProfileIdentityGate {
+    requests: Mutex<Vec<(String, String, String)>>,
+}
+
+impl Gate for NestedProfileIdentityGate {
+    fn check(&self, req: &GateRequest) -> Result<GateDecision, GateError> {
+        self.requests.lock().expect("gate request lock").push((
+            req.verb.clone(),
+            req.actor.id.clone(),
+            req.namespace.as_str().to_string(),
+        ));
+        if matches!(req.verb.as_str(), "brain.resolve" | "brain.profile")
+            && req.actor.id != "requester"
+        {
+            return Ok(GateDecision::deny(
+                "nested profile reads require the per-request principal",
+            ));
+        }
+        Ok(GateDecision::allow())
+    }
 }
 
 impl Fixture {
@@ -1913,12 +1940,10 @@ async fn compose_namespace_selects_exact_atom_corpus() {
         .expect("compose exact bench-arm namespace");
     let arm_atom = &arm["data"]["atoms"][0];
     assert_eq!(arm_atom["name"], json!("Bench Arm Compose Marker"));
-    assert!(
-        arm["data"]["markdown"]
-            .as_str()
-            .expect("arm markdown")
-            .contains("Bench arm corpus marker")
-    );
+    assert!(arm["data"]["markdown"]
+        .as_str()
+        .expect("arm markdown")
+        .contains("Bench arm corpus marker"));
     assert!(
         !arm["data"]["markdown"]
             .as_str()
@@ -1940,6 +1965,108 @@ async fn compose_namespace_selects_exact_atom_corpus() {
     assert_eq!(
         local["data"]["atoms"][0]["name"],
         json!("Local Compose Marker")
+    );
+}
+
+/// ADR-096/#1505: nested brain.resolve/profile calls must carry the outer
+/// request's principal and exact namespace, not the registry's baked daemon
+/// identity. The gate denies either nested read under any other actor.
+#[tokio::test]
+async fn compose_nested_profile_reads_preserve_request_identity() {
+    use khive_pack_brain::BrainPack;
+
+    let rt = rt();
+    let gate = Arc::new(NestedProfileIdentityGate::default());
+    let mut builder = VerbRegistryBuilder::new();
+    builder.register(KgPack::new(rt.clone()));
+    builder.register(BrainPack::new(rt.clone()));
+    builder.register(KnowledgePack::new(rt.clone()));
+    builder.with_gate(gate.clone());
+    builder.with_actor_id(Some("daemon".to_string()));
+    let registry = builder.build().expect("registry");
+    let arm_ns = "bench-arm-a";
+
+    registry
+        .dispatch(
+            "brain.create_profile",
+            json!({
+                "namespace": arm_ns,
+                "name": "requester-compose-v1",
+                "consumer_kind": "knowledge_compose",
+            }),
+        )
+        .await
+        .expect("create arm profile");
+    registry
+        .dispatch(
+            "brain.activate",
+            json!({
+                "namespace": arm_ns,
+                "profile_id": "requester-compose-v1",
+            }),
+        )
+        .await
+        .expect("activate arm profile");
+    registry
+        .dispatch(
+            "brain.bind",
+            json!({
+                "namespace": arm_ns,
+                "profile_id": "requester-compose-v1",
+                "consumer_kind": "knowledge_compose",
+            }),
+        )
+        .await
+        .expect("bind arm profile");
+    registry
+        .dispatch(
+            "knowledge.upsert_atoms",
+            json!({
+                "namespace": arm_ns,
+                "atoms": [{
+                    "slug": "requester-compose-atom",
+                    "name": "Requester Compose Atom",
+                    "content": "Per-request identity propagation for nested profile reads with enough retrieval corpus words to satisfy validation and produce a deterministic briefing.",
+                }]
+            }),
+        )
+        .await
+        .expect("upsert arm atom");
+    gate.requests.lock().expect("gate request lock").clear();
+
+    registry
+        .dispatch_with_identity(
+            "knowledge.compose",
+            json!({
+                "namespace": arm_ns,
+                "atom_ids": ["requester-compose-atom"],
+                "query": "per request identity propagation",
+            }),
+            Some(RequestIdentity {
+                namespace: "local".to_string(),
+                actor_id: Some("requester".to_string()),
+                visible_namespaces: vec!["local".to_string()],
+                request_id: Some(1505),
+            }),
+        )
+        .await
+        .expect("compose with request-scoped nested profile reads");
+
+    let requests = gate.requests.lock().expect("gate request lock");
+    let nested: Vec<_> = requests
+        .iter()
+        .filter(|(verb, _, _)| matches!(verb.as_str(), "brain.resolve" | "brain.profile"))
+        .collect();
+    assert_eq!(
+        nested.len(),
+        2,
+        "bound compose must perform both nested profile reads: {requests:?}"
+    );
+    assert!(
+        nested
+            .iter()
+            .all(|(_, actor, namespace)| actor == "requester" && namespace == arm_ns),
+        "nested Gate checks must preserve requester + exact arm identity: {nested:?}"
     );
 }
 
@@ -3261,6 +3388,117 @@ mod kg_blend {
         assert!(
             md.contains("ZipCache"),
             "markdown must render the blended concept's name, got: {md}"
+        );
+    }
+
+    /// #1505 direct-call exactness: even when the authorized token's primary
+    /// namespace matches the explicit arm, a broader visible set must be
+    /// narrowed before KG blending. Otherwise a local-only entity leaks into
+    /// an arm briefing while corpus rows remain correctly arm-scoped.
+    #[tokio::test]
+    async fn direct_compose_narrows_matching_broad_token_before_kg_blend() {
+        use khive_runtime::PackRuntime;
+
+        let rt = rt_with_marker_embedder();
+        let mut builder = VerbRegistryBuilder::new();
+        builder.register(KgPack::new(rt.clone()));
+        let registry = builder.build().expect("kg registry");
+        let local_entity = registry
+            .dispatch(
+                "create",
+                json!({
+                    "kind": "concept",
+                    "name": "LocalOnlyZipCache",
+                    "description": format!(
+                        "{MARKER} local-only paged KV cache quantization technique"
+                    ),
+                }),
+            )
+            .await
+            .expect("create local-only KG entity")["id"]
+            .as_str()
+            .expect("entity id")
+            .to_string();
+
+        let arm_ns = Namespace::parse("bench-arm-a").expect("arm namespace");
+        let arm_entity = registry
+            .dispatch(
+                "create",
+                json!({
+                    "namespace": arm_ns.as_str(),
+                    "kind": "concept",
+                    "name": "ArmOnlyZipCache",
+                    "description": format!(
+                        "{MARKER} arm-only paged KV cache quantization technique"
+                    ),
+                }),
+            )
+            .await
+            .expect("create arm-only KG entity")["id"]
+            .as_str()
+            .expect("arm entity id")
+            .to_string();
+        let broad_arm_token = rt
+            .authorize_with_visibility(arm_ns.clone(), vec![Namespace::local()])
+            .expect("arm token with local visibility");
+        let knowledge = KnowledgePack::new(rt.clone());
+        knowledge
+            .dispatch(
+                "knowledge.upsert_atoms",
+                json!({
+                    "atoms": [{
+                        "slug": "arm-kg-blend-atom",
+                        "name": "Arm KG Blend Atom",
+                        "content": format!("{MARKER} {OVERLAP_CONTENT}"),
+                        "finalized": true,
+                    }]
+                }),
+                &registry,
+                &broad_arm_token,
+            )
+            .await
+            .expect("upsert arm atom");
+        knowledge
+            .dispatch(
+                "knowledge.upsert_domains",
+                json!({
+                    "domains": [{
+                        "slug": "arm-kg-blend-domain",
+                        "name": "Arm KG Blend Domain",
+                        "description": OVERLAP_CONTENT,
+                        "members": ["arm-kg-blend-atom"],
+                    }]
+                }),
+                &registry,
+                &broad_arm_token,
+            )
+            .await
+            .expect("upsert arm domain");
+
+        let resp = knowledge
+            .dispatch(
+                "knowledge.compose",
+                json!({
+                    "namespace": arm_ns.as_str(),
+                    "domain_ids": ["arm-kg-blend-domain"],
+                    "query": QUERY,
+                }),
+                &registry,
+                &broad_arm_token,
+            )
+            .await
+            .expect("direct exact-arm compose");
+        let entities = resp["data"]["entities"]
+            .as_array()
+            .cloned()
+            .unwrap_or_default();
+        assert!(
+            entities.iter().any(|entity| entity["id"] == arm_entity),
+            "the arm KG candidate must prove the blend leg ran: {entities:?}"
+        );
+        assert!(
+            entities.iter().all(|entity| entity["id"] != local_entity),
+            "local-only KG entity leaked through a matching but broad direct-call token: {entities:?}"
         );
     }
 

--- a/crates/khive-pack-knowledge/tests/integration.rs
+++ b/crates/khive-pack-knowledge/tests/integration.rs
@@ -1865,6 +1865,84 @@ async fn compose_returns_markdown_for_atoms() {
     assert_eq!(count, 2);
 }
 
+/// #1505: the public namespace parameter is an exact compose scope, not a
+/// widened visible set. Identical slugs in local and a measurement arm must
+/// resolve to the arm's atom only, while an absent parameter preserves the
+/// unchanged local default.
+#[tokio::test]
+async fn compose_namespace_selects_exact_atom_corpus() {
+    let f = pack(rt());
+    let shared_slug = "namespace-compose-target";
+
+    f.dispatch(
+        "knowledge.upsert_atoms",
+        json!({
+            "atoms": [{
+                "slug": shared_slug,
+                "name": "Local Compose Marker",
+                "content": "Local corpus marker for namespace composition regression coverage with enough distinct retrieval words to satisfy the atom content validation contract and remain readable in generated markdown output."
+            }]
+        }),
+    )
+    .await
+    .expect("upsert local atom");
+    f.dispatch(
+        "knowledge.upsert_atoms",
+        json!({
+            "namespace": "bench-arm-a",
+            "atoms": [{
+                "slug": shared_slug,
+                "name": "Bench Arm Compose Marker",
+                "content": "Bench arm corpus marker for exact namespace composition regression coverage with enough distinct retrieval words to satisfy the atom content validation contract and remain readable in generated markdown output."
+            }]
+        }),
+    )
+    .await
+    .expect("upsert bench-arm atom");
+
+    let arm = f
+        .dispatch(
+            "knowledge.compose",
+            json!({
+                "namespace": "bench-arm-a",
+                "atom_ids": [shared_slug],
+                "query": "namespace composition marker",
+            }),
+        )
+        .await
+        .expect("compose exact bench-arm namespace");
+    let arm_atom = &arm["data"]["atoms"][0];
+    assert_eq!(arm_atom["name"], json!("Bench Arm Compose Marker"));
+    assert!(
+        arm["data"]["markdown"]
+            .as_str()
+            .expect("arm markdown")
+            .contains("Bench arm corpus marker")
+    );
+    assert!(
+        !arm["data"]["markdown"]
+            .as_str()
+            .expect("arm markdown")
+            .contains("Local corpus marker"),
+        "exact arm compose must not blend the same slug from local"
+    );
+
+    let local = f
+        .dispatch(
+            "knowledge.compose",
+            json!({
+                "atom_ids": [shared_slug],
+                "query": "namespace composition marker",
+            }),
+        )
+        .await
+        .expect("compose unchanged local default");
+    assert_eq!(
+        local["data"]["atoms"][0]["name"],
+        json!("Local Compose Marker")
+    );
+}
+
 #[tokio::test]
 async fn compose_returns_markdown_for_domain() {
     let f = pack(rt());

--- a/crates/khive-pack-memory/src/handlers/common.rs
+++ b/crates/khive-pack-memory/src/handlers/common.rs
@@ -230,13 +230,9 @@ pub(super) async fn resolve_serving_profile(
     if let Some(profile_id) = brain_profile {
         return Some(profile_id.clone());
     }
-    let ns = token.namespace().as_str().to_string();
-    // Actor identity is required for actor-scoped, not merely namespace-scoped, bindings.
-    let actor = token.actor().binding_id();
     khive_brain_core::resolve_consumer_profile(
         registry,
-        actor,
-        &ns,
+        token,
         khive_brain_core::ConsumerKind::Recall,
     )
     .await

--- a/crates/khive-pack-memory/src/handlers/feedback.rs
+++ b/crates/khive-pack-memory/src/handlers/feedback.rs
@@ -4,7 +4,7 @@ use serde::Deserialize;
 use serde_json::{json, Value};
 use uuid::Uuid;
 
-use khive_runtime::{NamespaceToken, RuntimeError, VerbRegistry};
+use khive_runtime::{NamespaceToken, RequestIdentity, RuntimeError, VerbRegistry};
 
 use crate::recall_feedback::on_explicit_feedback;
 use crate::MemoryPack;
@@ -85,7 +85,13 @@ async fn route_to_brain(
         "signal": signal,
         "served_by_profile_id": profile_id,
     });
-    registry.dispatch("brain.feedback", brain_params).await
+    registry
+        .dispatch_with_identity(
+            "brain.feedback",
+            brain_params,
+            Some(RequestIdentity::from_token(token)),
+        )
+        .await
 }
 
 // ── Tests ─────────────────────────────────────────────────────────────────────

--- a/crates/khive-pack-memory/src/handlers/recall.rs
+++ b/crates/khive-pack-memory/src/handlers/recall.rs
@@ -12,8 +12,8 @@ use uuid::Uuid;
 use khive_brain_core::{compute_query_class, PackTunable};
 use khive_fusion::FusionStrategy;
 use khive_runtime::{
-    micros_to_iso, KhiveRuntime, Namespace, NamespaceToken, RuntimeError, SearchSource,
-    VerbRegistry,
+    micros_to_iso, KhiveRuntime, Namespace, NamespaceToken, RequestIdentity, RuntimeError,
+    SearchSource, VerbRegistry,
 };
 use khive_storage::types::{EdgeFilter, PageRequest};
 use khive_storage::EdgeRelation;
@@ -33,6 +33,23 @@ use super::common::{
     DEFAULT_SALIENCE_SEMANTIC, PROF_CID, RECALL_CALL_ID, RECALL_SLOW_THRESHOLD_MS,
 };
 
+async fn load_brain_profile(
+    registry: &VerbRegistry,
+    token: &NamespaceToken,
+    profile_id: &str,
+) -> Result<Value, RuntimeError> {
+    registry
+        .dispatch_with_identity(
+            "brain.profile",
+            json!({
+                "namespace": token.namespace().as_str(),
+                "profile_id": profile_id,
+            }),
+            Some(RequestIdentity::from_token(token)),
+        )
+        .await
+}
+
 impl MemoryPack {
     pub(crate) async fn handle_recall(
         &self,
@@ -45,13 +62,21 @@ impl MemoryPack {
         let recall_start = Instant::now();
         let p: RecallParams = deser(params)?;
 
-        // Re-derive dispatch's exact namespace as direct-call defense in depth; all later
-        // candidate, graph, and ledger operations use this shadowed token.
+        // Registry dispatch already supplies an exact token for an explicit
+        // namespace. Direct callers must present a token authorized for the
+        // same primary namespace before its visibility is narrowed to the
+        // requested arm; caller parameters may never elevate a token.
         let effective_token: NamespaceToken = match p.namespace.as_deref() {
             Some(ns_str) => {
                 let ns = Namespace::parse(ns_str).map_err(|e| {
                     RuntimeError::InvalidInput(format!("invalid namespace {ns_str:?}: {e}"))
                 })?;
+                if &ns != token.namespace() {
+                    return Err(RuntimeError::InvalidInput(
+                        "memory.recall namespace does not match authorized token namespace"
+                            .to_string(),
+                    ));
+                }
                 token.with_namespace(ns)
             }
             None => token.clone(),
@@ -145,8 +170,7 @@ impl MemoryPack {
         // Explicit unknown IDs error; unreadable bound state degrades to configured defaults.
         let mut profile_state: Option<khive_brain_core::BalancedRecallState> = None;
         let served_by_profile_id: Option<String> = if let Some(ref pid) = p.profile_id {
-            let resp = registry
-                .dispatch("brain.profile", json!({ "profile_id": pid }))
+            let resp = load_brain_profile(registry, token, pid)
                 .await
                 .map_err(|e| {
                     RuntimeError::InvalidInput(format!(
@@ -159,10 +183,7 @@ impl MemoryPack {
             let mut resolved =
                 super::common::resolve_serving_profile(&self.brain_profile, token, registry).await;
             if let Some(ref profile_id) = resolved {
-                match registry
-                    .dispatch("brain.profile", json!({ "profile_id": profile_id }))
-                    .await
-                {
+                match load_brain_profile(registry, token, profile_id).await {
                     Ok(resp) => {
                         profile_state =
                             super::common::balanced_recall_state_from_profile_response(&resp);
@@ -877,7 +898,14 @@ impl MemoryPack {
                 if let Some(ref profile_id) = served_by_profile_id {
                     ledger_params["served_by_profile_id"] = json!(profile_id);
                 }
-                if let Err(error) = registry.dispatch("brain.record_serve", ledger_params).await {
+                if let Err(error) = registry
+                    .dispatch_with_identity(
+                        "brain.record_serve",
+                        ledger_params,
+                        Some(RequestIdentity::from_token(&token)),
+                    )
+                    .await
+                {
                     tracing::warn!(
                         error = %error,
                         "serve ledger dispatch failed; recall result is unaffected"
@@ -2955,6 +2983,90 @@ mod tests {
         );
     }
 
+    /// #1505: an explicit profile override is resolved in recall's effective
+    /// namespace, not the registry's baked/default namespace. The arm-only
+    /// profile is also applied to scoring, proving this is more than a stamp.
+    #[tokio::test]
+    #[serial(background_tasks)]
+    async fn namespaced_recall_loads_arm_profile_and_applies_its_state() {
+        use khive_pack_brain::BrainPack;
+
+        let rt = build_full_rt_with_brain();
+        let arm_ns = Namespace::parse("bench-arm-a").expect("arm namespace");
+        let arm_token = rt.authorize(arm_ns.clone()).expect("arm token");
+        let note = rt
+            .create_note(
+                &arm_token,
+                "memory",
+                None,
+                "bench arm isolated profile recall note",
+                Some(0.7),
+                None,
+                vec![],
+            )
+            .await
+            .expect("create arm note");
+
+        let mut builder = VerbRegistryBuilder::new();
+        builder.register(KgPack::new(rt.clone()));
+        builder.register(MemoryPack::new(rt.clone()));
+        builder.register(BrainPack::new(rt.clone()));
+        let registry = builder.build().expect("registry");
+
+        registry
+            .dispatch(
+                "brain.create_profile",
+                serde_json::json!({
+                    "namespace": arm_ns.as_str(),
+                    "name": "bench-arm-a-recall-v1",
+                    "consumer_kind": "recall",
+                }),
+            )
+            .await
+            .expect("create arm-only profile");
+        for _ in 0..12 {
+            registry
+                .dispatch(
+                    "brain.feedback",
+                    serde_json::json!({
+                        "namespace": arm_ns.as_str(),
+                        "target_id": note.id.to_string(),
+                        "signal": "useful",
+                        "served_by_profile_id": "bench-arm-a-recall-v1",
+                    }),
+                )
+                .await
+                .expect("tune arm profile");
+        }
+
+        let result = registry
+            .dispatch(
+                "memory.recall",
+                serde_json::json!({
+                    "namespace": arm_ns.as_str(),
+                    "query": "bench arm isolated profile recall note",
+                    "profile_id": "bench-arm-a-recall-v1",
+                    "include_breakdown": true,
+                    "limit": 10,
+                }),
+            )
+            .await
+            .expect("namespaced recall must load the arm-only profile");
+        let hits = result.as_array().expect("bare array result");
+        assert!(!hits.is_empty(), "arm note must be recalled");
+        assert_eq!(
+            hits[0]["served_by_profile_id"],
+            serde_json::json!("bench-arm-a-recall-v1")
+        );
+        let component = hits[0]["breakdown"]["profile_component"]
+            .as_f64()
+            .expect("profile component");
+        assert!(
+            (component - 1.0).abs() > 1e-6,
+            "arm profile feedback must affect scoring, got neutral component {component}"
+        );
+    }
+
     /// Breakdown reports neutral/default profile state and learned entity posterior state.
     #[tokio::test]
     #[serial(background_tasks)]
@@ -3919,6 +4031,32 @@ mod tests {
             HashSet::from([bench_id]),
             "namespace=\"bench-a\" must return exactly the bench-a memory and \
              neither local memory: {hits:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn direct_recall_rejects_namespace_token_mismatch() {
+        let rt = KhiveRuntime::memory().expect("in-memory runtime");
+        let pack = MemoryPack::new(rt.clone());
+        let token = rt.authorize(Namespace::local()).expect("local token");
+        let registry = VerbRegistryBuilder::new()
+            .build()
+            .expect("empty registry builds");
+
+        let err = pack
+            .handle_recall(
+                &token,
+                serde_json::json!({
+                    "namespace": "bench-arm-a",
+                    "query": "direct mismatch regression",
+                }),
+                &registry,
+            )
+            .await
+            .expect_err("a local token must not elevate into a measurement arm");
+        assert!(
+            matches!(err, RuntimeError::InvalidInput(ref msg) if msg.contains("does not match authorized token namespace")),
+            "unexpected error: {err:?}"
         );
     }
 

--- a/crates/khive-runtime/src/pack.rs
+++ b/crates/khive-runtime/src/pack.rs
@@ -802,6 +802,30 @@ pub struct RequestIdentity {
     pub request_id: Option<u64>,
 }
 
+impl RequestIdentity {
+    /// Reconstruct the effective principal and namespace scope carried by an
+    /// already-authorized token for a nested registry dispatch.
+    ///
+    /// Cross-pack calls must still pass through the registry Gate, but using
+    /// the registry's construction-baked identity would silently replace a
+    /// warm daemon request's actor and visibility (ADR-096). This projection
+    /// preserves the token's exact primary namespace, actor, and read-visible
+    /// namespaces. A `NamespaceToken` does not carry the ingress correlation
+    /// id, so nested calls intentionally use `request_id: None`.
+    pub fn from_token(token: &NamespaceToken) -> Self {
+        Self {
+            namespace: token.namespace().as_str().to_string(),
+            actor_id: token.actor().binding_id().map(str::to_string),
+            visible_namespaces: token
+                .visible_namespaces()
+                .iter()
+                .map(|namespace| namespace.as_str().to_string())
+                .collect(),
+            request_id: None,
+        }
+    }
+}
+
 /// A non-blank, out-of-band authenticated principal for [`VerbRegistry::dispatch_as`].
 ///
 /// Embedding hosts authenticate a principal through their own channel (not the

--- a/docs/adr/ADR-035-cli-config-and-auto-embed.md
+++ b/docs/adr/ADR-035-cli-config-and-auto-embed.md
@@ -1,6 +1,6 @@
 # ADR-035: CLI Configuration and Automatic Embedding
 
-**Status**: accepted
+**Status**: accepted (amended 2026-08-01)
 **Date**: 2026-05-23
 **Authors**: khive maintainers
 
@@ -194,14 +194,15 @@ brain_profile = "project-recall-v1"
 2. **Namespace-bound profile**: if no explicit profile is set but a namespace is configured,
    the feedback handler calls `brain.resolve(consumer_kind="recall")` for that
    namespace and uses the resolved profile.
-3. **Global tuning prior**: if neither explicit nor namespace-bound profile resolves, the
-   pack-local in-memory state (`BalancedRecallState` for memory, `SectionPosteriorState` for
-   knowledge) receives the update directly. This is the intended global fallback — it is
-   not a bug.
+3. **Pack-local tuning prior**: if neither explicit nor namespace-bound profile resolves, the
+   pack-local in-memory state receives the update directly. `BalancedRecallState` retains the
+   original memory-pack fallback. As amended by #1505, knowledge's `SectionPosteriorState` is
+   keyed by the effective namespace so an explicit measurement arm cannot inherit live/local
+   compose feedback. The default `local` path remains backward compatible.
 
 This resolution is automatic: packs attempt tiers 1 and 2 silently and fall through to tier 3
-when nothing is bound. No configuration is required for the global-prior behavior to continue
-working as before.
+when nothing is bound. No configuration is required for the default-namespace fallback to
+continue working as before.
 
 ### 3. `[embed]` and `[schema]` sections
 
@@ -463,8 +464,9 @@ as separating source files from build artifacts in a standard software project.
   through the same config path used by namespace — no per-call parameter needed.
 - Deployments that bind a namespace to a brain profile via `brain.bind` benefit automatically
   from tier-2 resolution without any `khive.toml` change.
-- The global tuning prior (tier 3) continues to work unchanged for deployments that do not
-  configure a profile. No existing behavior is removed.
+- The pack-local tuning prior (tier 3) continues without configuration. Memory behavior and the
+  default knowledge namespace remain unchanged; explicit knowledge namespaces receive isolated
+  fallback state instead of sharing local feedback (#1505).
 
 ### Positive
 

--- a/docs/adr/ADR-047-knowledge-pack.md
+++ b/docs/adr/ADR-047-knowledge-pack.md
@@ -11,8 +11,11 @@ preserves the existing caller-token scope. An explicit value is parsed with `Nam
 and scopes the operation to exactly one namespace under ADR-007's precise escape: automatic
 domain suggestion, domain and atom resolution, section loading, KG blending, and brain-profile
 type-weight reads all use the same derived token. Invalid values fail closed. The handler repeats
-the derivation for direct-call defense in depth, while registry dispatch remains the Gate and
-authorization seam.
+the namespace parse for direct-call defense in depth, requires it to match the already-authorized
+token, and then narrows any broader visible set to that exact namespace; it never elevates a token.
+Nested brain dispatches preserve the token's request actor and scope through their own Gate checks.
+The pack-local Tier-3 section-posterior fallback is keyed by namespace so live feedback cannot
+change an untouched measurement arm. Registry dispatch remains the authorization seam.
 
 ## Amendment (2026-06-10b): exclude_status precedence fix; auto-compose member filter; atom status taxonomy clarification
 

--- a/docs/adr/ADR-047-knowledge-pack.md
+++ b/docs/adr/ADR-047-knowledge-pack.md
@@ -1,8 +1,18 @@
 # ADR-047: Knowledge Pack
 
-**Status**: accepted (amended 2026-06-07, 2026-06-10, 2026-06-10b)
+**Status**: accepted (amended 2026-06-07, 2026-06-10, 2026-06-10b, 2026-08-01)
 **Date**: 2026-05-25
 **Authors**: khive maintainers
+
+## Amendment (2026-08-01): exact namespace support for `knowledge.compose`
+
+Issue #1505 adds an optional `namespace` parameter to `knowledge.compose`. An absent parameter
+preserves the existing caller-token scope. An explicit value is parsed with `Namespace::parse`
+and scopes the operation to exactly one namespace under ADR-007's precise escape: automatic
+domain suggestion, domain and atom resolution, section loading, KG blending, and brain-profile
+type-weight reads all use the same derived token. Invalid values fail closed. The handler repeats
+the derivation for direct-call defense in depth, while registry dispatch remains the Gate and
+authorization seam.
 
 ## Amendment (2026-06-10b): exclude_status precedence fix; auto-compose member filter; atom status taxonomy clarification
 
@@ -261,6 +271,17 @@ draft state should not drive agent composition.
 
 **Score bands** (observed in production): `score >= 0.46` reliably on-target,
 `0.42 <= score < 0.46` mixed quality, `score < 0.42` mostly off-target.
+
+#### `knowledge.compose` — namespace-consistent briefing composition
+
+```
+compose(query, namespace?, domain_ids?, atom_ids?, blend_kg?, auto_limit?, max_tokens?, explain?) → {status, data}
+```
+
+When `namespace` is present, every data-dependent leg is scoped to that exact namespace,
+including the bound brain-profile read that supplies section-type weights. Identical atom or
+domain slugs in another namespace cannot enter the briefing. When absent, existing behavior is
+unchanged.
 
 ### 3. `learn` — concept registration with domain promotion
 

--- a/docs/adr/ADR-081-recall-retune-driver.md
+++ b/docs/adr/ADR-081-recall-retune-driver.md
@@ -241,8 +241,9 @@ fields; no existing caller changes shape).
 
 The optional `namespace` follows ADR-007's explicit exact-scope escape. When absent,
 `brain.auto_feedback` retains the caller's normal/default dispatch namespace. When present, the
-runtime mints a single-namespace token and the handler re-derives it for direct-call defense in
-depth; target-ID resolution remains namespace-agnostic, while the emitted event, fold-gate
+runtime mints a single-namespace token and the handler validates that direct callers present a
+token authorized for the same namespace; target-ID resolution remains namespace-agnostic, while
+the emitted event, fold-gate
 accounting key, durable snapshot, and live posterior mutation all belong to exactly that
 namespace. Invalid namespace strings fail closed. In particular, feedback emitted into a
 measurement namespace cannot mutate the default/live namespace's posteriors.

--- a/docs/adr/ADR-081-recall-retune-driver.md
+++ b/docs/adr/ADR-081-recall-retune-driver.md
@@ -6,6 +6,8 @@
 **Measurement evidence**: hook scorer v0 dry run over 19 serve ledgers, 7 sessions (2026-07-02)\
 **Depends on**: [ADR-021](ADR-021-memory-pack.md) (Memory Pack), [ADR-033](ADR-033-recall-pipeline.md) (Recall Pipeline), [ADR-032](ADR-032-brain-profile-orchestration.md) (Brain Profile Orchestration), [ADR-035](ADR-035-cli-config-and-auto-embed.md) (Feedback Profile Resolution Order), [ADR-055](ADR-055-epistemic-edge-relations.md) (Epistemic Relations)\
 **Amends**: the brain feedback weight table (`FeedbackEventKind::update_weight()`, khive-brain-core, issue #268) and the `brain.feedback` / `brain.auto_feedback` parameter surface (additive optional scorer-provenance fields, section 6)\
+**Amended**: 2026-08-01, issue #1505 adds an optional exact `namespace` to
+`brain.auto_feedback`; the selected namespace owns both the event and posterior fold.\
 **GitHub**: #517 (auto_feedback), #394 (recall latency), #391/#393 (resolver legs)
 
 ---
@@ -216,17 +218,19 @@ Scorer batches emit through the existing surface: DSL batches of `brain.auto_fee
 `brain.auto_feedback` cannot be chained through `$prev` (recall returns a bare array),
 so emission is two-step with ids inlined.
 
-**Parameter surface amendment.** The current handlers reject unknown fields
-(`deny_unknown_fields`), so the scorer provenance that sections 2 and 4 require cannot
-ride the verbs as they stand. This ADR amends `brain.feedback` and
-`brain.auto_feedback` with two additive optional parameters:
+**Parameter surface amendment.** The handlers reject unknown fields
+(`deny_unknown_fields`). This ADR amends `brain.feedback` and `brain.auto_feedback` with
+two additive scorer-provenance parameters, and the 2026-08-01 amendment adds the exact
+namespace escape to `brain.auto_feedback`:
 
 | Parameter         | Type   | Required | Semantics                                     |
 | ----------------- | ------ | -------- | --------------------------------------------- |
 | `scorer_run_id`   | string | optional | scorer pass identifier, half of the dedup key |
 | `serve_ledger_id` | string | optional | serve row being graded, half of the dedup key |
+| `namespace`       | string | optional | exact event and posterior-state namespace     |
 
-Both are persisted on the feedback event payload. They must be supplied together: a call
+The two scorer-provenance fields are persisted on the feedback event payload and must be
+supplied together: a call
 carrying exactly one of the two is rejected as invalid parameters (no silent coercion).
 Calls carrying neither remain valid — ordinary non-scorer implicit and explicit feedback
 is unchanged, folds without dedup, and is still subject to the section 2 clamp. When
@@ -234,6 +238,14 @@ both are present, the fold applies the `(scorer_run_id, serve_ledger_id)` dedup 
 the clamp check and backfills the ledger row's grade. The verb-vocabulary and AGENTS.md
 updates for the new parameters ride with the implementation PR (additive optional
 fields; no existing caller changes shape).
+
+The optional `namespace` follows ADR-007's explicit exact-scope escape. When absent,
+`brain.auto_feedback` retains the caller's normal/default dispatch namespace. When present, the
+runtime mints a single-namespace token and the handler re-derives it for direct-call defense in
+depth; target-ID resolution remains namespace-agnostic, while the emitted event, fold-gate
+accounting key, durable snapshot, and live posterior mutation all belong to exactly that
+namespace. Invalid namespace strings fail closed. In particular, feedback emitted into a
+measurement namespace cannot mutate the default/live namespace's posteriors.
 
 ADR-016 batches are per-op independent with no cross-op transaction; that is acceptable
 here **because no correctness property lives on the emission surface**: the clamp and

--- a/docs/benchmarks/recall-arm-isolation.md
+++ b/docs/benchmarks/recall-arm-isolation.md
@@ -47,30 +47,25 @@ the serving profile so scoring weights don't drift mid-measurement.
    `local`. An invalid namespace string is a hard per-op error, not a silent
    fallback.
 
-5. **Tear down** by deleting the arm's memories (`delete(id="...",
+5. **Keep feedback and knowledge composition in the arm** when those paths are
+   part of the measurement:
+
+   ```text
+   brain.auto_feedback(query="...", results=[{"id":"..."}], namespace="bench-arm-a")
+   knowledge.compose(query="...", atom_ids=["..."], namespace="bench-arm-a")
+   ```
+
+   Auto-feedback stamps its event and folds only the arm's posterior state;
+   compose uses the arm for corpus, section, KG-blend, and profile-weight reads.
+
+6. **Tear down** by deleting the arm's memories (`delete(id="...",
    hard=true)` — one call per memory id; `delete` takes `id`/`kind`/`hard`,
    not a `type=` param) once the measurement is done, or simply let the arm
    namespace age out unread — it costs nothing beyond the storage of its own
    rows.
 
-## What is NOT yet isolated
+## Remaining shared machinery
 
-- **Feedback events.** `brain.auto_feedback` / `brain.feedback` write into the
-  _profile's_ live posterior state, not the namespace. If a measurement arm
-  pins an existing (non-scratch) profile via `profile_id`, feedback recorded
-  during the arm still trains that profile's posteriors going forward — there
-  is no namespace-scoped posterior isolation. Use a freshly created,
-  arm-specific profile (step 3) to avoid contaminating a shared profile's
-  state. Tracked as issue #733 remainder.
-- **`knowledge.compose`.** Compose does scope section loading to the caller's
-  token namespace (`WHERE namespace = ?1`) — it is not global. What it lacks
-  is _this feature_: there is no `namespace=` exact-match parameter on
-  compose analogous to the one this slice adds to `memory.recall`, and no
-  `profile_id`-style pinning either. A measurement arm cannot point compose
-  at a specific scratch namespace independent of the caller's token the way
-  it can for recall; compose calls in an arm are scoped by whatever namespace
-  the caller is already authorized for, not covered by recall's new
-  exact-match parameter.
 - **The serve ledger.** `brain.record_serve` stamps the _effective_ namespace
   used for the fetch (the arm namespace when `namespace=` was passed), so
   ledger rows are attributable to the arm — but the ledger itself is a single

--- a/docs/benchmarks/recall-arm-isolation.md
+++ b/docs/benchmarks/recall-arm-isolation.md
@@ -56,7 +56,9 @@ the serving profile so scoring weights don't drift mid-measurement.
    ```
 
    Auto-feedback stamps its event and folds only the arm's posterior state;
-   compose uses the arm for corpus, section, KG-blend, and profile-weight reads.
+   compose uses the arm for corpus, section, KG-blend, profile-weight reads, and
+   its namespace-keyed Tier-3 fallback. Nested profile lookups retain the
+   request actor at their own Gate checks.
 
 6. **Tear down** by deleting the arm's memories (`delete(id="...",
    hard=true)` — one call per memory id; `delete` takes `id`/`kind`/`hard`,

--- a/docs/guide/api-reference.md
+++ b/docs/guide/api-reference.md
@@ -805,6 +805,7 @@ Recall memory notes with decay-aware hybrid ranking. Each hit carries resolved
 | `full_content`      | bool    | no       | Default true; false truncates content to 200 chars.                       |
 | `tags`              | array   | no       | Filter by `properties.tags`.                                              |
 | `tag_mode`          | string  | no       | `any` (default, OR) or `all` (AND).                                       |
+| `namespace`         | string  | no       | Exact-match read scope; absent uses the caller's visible namespace set.   |
 
 ```
 request(ops="memory.recall(query=\"ADR-016 DSL grammar\", limit=5, min_score=0.3)")
@@ -989,14 +990,15 @@ request(ops="brain.feedback(target_id=\"<uuid>\", signal=\"useful\")")
 Emit implicit feedback for recall results supplied by an agent — the convenience verb
 to call right after `memory.recall` instead of hand-building `brain.feedback`.
 
-| Param                  | Type   | Required | Notes                                                                 |
-| ---------------------- | ------ | -------- | --------------------------------------------------------------------- |
-| `query`                | string | yes      | The recall query that produced the results.                           |
-| `results`              | array  | yes      | Recall result objects; the first object's `id` is credited.           |
-| `signal`               | string | no       | Defaults to `implicit_positive`.                                      |
-| `served_by_profile_id` | string | no       | Profile that served the recall.                                       |
-| `scorer_run_id`        | string | no       | Forwarded verbatim to `brain.feedback`; pairs with `serve_ledger_id`. |
-| `serve_ledger_id`      | string | no       | Forwarded verbatim to `brain.feedback`; pairs with `scorer_run_id`.   |
+| Param                  | Type   | Required | Notes                                                                  |
+| ---------------------- | ------ | -------- | ---------------------------------------------------------------------- |
+| `query`                | string | yes      | The recall query that produced the results.                            |
+| `results`              | array  | yes      | Recall result objects; the first object's `id` is credited.            |
+| `signal`               | string | no       | Defaults to `implicit_positive`.                                       |
+| `served_by_profile_id` | string | no       | Profile that served the recall.                                        |
+| `scorer_run_id`        | string | no       | Forwarded verbatim to `brain.feedback`; pairs with `serve_ledger_id`.  |
+| `serve_ledger_id`      | string | no       | Forwarded verbatim to `brain.feedback`; pairs with `scorer_run_id`.    |
+| `namespace`            | string | no       | Exact namespace for the event and posterior fold; invalid values fail. |
 
 ```
 request(ops="memory.recall(query=\"x\", limit=5) | brain.auto_feedback(query=\"x\", results=[{\"id\": \"$prev.items[0].id\"}])")
@@ -1446,11 +1448,12 @@ request(ops="knowledge.suggest(query=\"async middleware retry circuit breaker pa
 
 Compose a markdown briefing from selected knowledge domains and atoms.
 
-| Param        | Type            | Required | Notes                                             |
-| ------------ | --------------- | -------- | ------------------------------------------------- |
-| `domain_ids` | array\<string\> | no       | Domain UUIDs/slugs whose member atoms to include. |
-| `atom_ids`   | array\<string\> | no       | Atom UUIDs/slugs to include directly.             |
-| `query`      | string          | yes      | Reranks the selected atom bodies.                 |
+| Param        | Type            | Required | Notes                                                     |
+| ------------ | --------------- | -------- | --------------------------------------------------------- |
+| `domain_ids` | array\<string\> | no       | Domain UUIDs/slugs whose member atoms to include.         |
+| `atom_ids`   | array\<string\> | no       | Atom UUIDs/slugs to include directly.                     |
+| `query`      | string          | yes      | Reranks the selected atom bodies.                         |
+| `namespace`  | string          | no       | Exact namespace for all compose and profile-weight reads. |
 
 ```
 request(ops="knowledge.compose(query=\"FastAPI JWT middleware validation patterns\", domain_ids=[\"attention\"])")

--- a/docs/khive-config-example.toml
+++ b/docs/khive-config-example.toml
@@ -67,7 +67,8 @@
 
 # Brain profile id used by memory.feedback / knowledge.feedback and for recall-time
 # score boosting. Absent → the namespace-bound profile (brain.resolve) is tried,
-# then the global tuning prior. Mirrors --brain-profile / KHIVE_BRAIN_PROFILE.
+# then the pack-local tuning prior (knowledge keys it by effective namespace).
+# Mirrors --brain-profile / KHIVE_BRAIN_PROFILE.
 # brain_profile = "khive-default"
 
 # Default output serialization (ADR-078). One of:


### PR DESCRIPTION
## Summary

- add explicit, capability-checked namespace selection to `memory.recall`, `brain.auto_feedback`, and `knowledge.compose`
- preserve the authorized request identity through nested brain profile, resolve, feedback, and serve-ledger dispatches
- isolate knowledge section-posterior tuning per namespace so benchmark arms cannot contaminate one another
- document the namespace-scoped recall/composition contract and benchmark workflow

## Validation

- `cargo test --manifest-path crates/Cargo.toml --workspace`
- `cargo check --manifest-path crates/Cargo.toml --workspace`
- `cargo clippy --manifest-path crates/Cargo.toml --workspace --all-targets -- -D warnings`
- `RUSTDOCFLAGS=-Dwarnings cargo doc --manifest-path crates/Cargo.toml --workspace --no-deps`
- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- ADR reference lint, stub-marker lint, Deno formatting check, and independent review

Closes #1505

> AI-assisted contribution: Codex prepared this change and PR description.
