### PR TITLE
fix(brain): make profile state coherent across processes

### DIFF
--- a/crates/khive-pack-brain/docs/api/persist.md
+++ b/crates/khive-pack-brain/docs/api/persist.md
@@ -28,6 +28,13 @@ The event and snapshot share a transaction timestamp chosen as
 `max(wall_clock, previous_updated_at + 1)`, so a writer that waited behind a newer process
 cannot move the replay boundary backward and cause already-snapshotted feedback to replay twice.
 
+`persist_feedback_state_mutation` uses the same generation/rebase boundary, then validates the
+selected profile against that authoritative state. For accepted feedback, the implicit-mass fold
+and dedup claim (when applicable), public `FeedbackExplicit` event, private `brain_event_log` row,
+and replacement snapshot commit in that same atomic unit. An absent or archived profile is
+rejected before any of those writes, so a peer lifecycle transition cannot leave a partial
+feedback trace after the warm process-local preflight has passed.
+
 The monotonically-raised snapshot `updated_at` is the namespace's durable generation.
 `ensure_loaded` checks that primary-key row even for an already-active namespace and reloads
 when another process has advanced it. This keeps profile and binding reads coherent across

--- a/crates/khive-pack-brain/docs/api/persist.md
+++ b/crates/khive-pack-brain/docs/api/persist.md
@@ -16,6 +16,23 @@ transaction wrapping provides the atomicity on the flag-on path, and `run_manual
 (khive-db) preserves the old manual-transaction shape byte-for-byte on the flag-off/in-memory
 path.
 
+The latest namespace snapshot generation is read through the transaction's `SqlWriter` before
+the mutation closure runs. This ordering is the cross-process coherence boundary: SQLite's
+`BEGIN IMMEDIATE` serializes competing writers. A process-local snapshot is reused only when
+its recorded durable generation exactly matches the row read inside the transaction (which
+preserves best-effort hook updates); on a mismatch, the snapshot JSON is fetched, validated,
+and used as the mutation base. Avoiding that full decode on the matched steady-state path keeps
+the writer exclusion window bounded to work the mutation actually needs. The proposed
+`BrainState` is published only after commit.
+The event and snapshot share a transaction timestamp chosen as
+`max(wall_clock, previous_updated_at + 1)`, so a writer that waited behind a newer process
+cannot move the replay boundary backward and cause already-snapshotted feedback to replay twice.
+
+The monotonically-raised snapshot `updated_at` is the namespace's durable generation.
+`ensure_loaded` checks that primary-key row even for an already-active namespace and reloads
+when another process has advanced it. This keeps profile and binding reads coherent across
+long-running processes without a scan, polling loop, or new schema column.
+
 ## Why `persist_brain_state_mutation` takes `&dyn SqlAccess`, not `&KhiveRuntime`
 
 The only thing this function ever needed from the runtime was its `SqlAccess` handle

--- a/crates/khive-pack-brain/docs/design.md
+++ b/crates/khive-pack-brain/docs/design.md
@@ -109,8 +109,10 @@ $$\text{Beta}(\alpha_1 + \alpha_2 - \alpha_{\text{prior}},\; \beta_1 + \beta_2 -
 - Archived profiles are filtered out by `brain.resolve` before scoring so that stale bindings
   pointing at archived profiles do not block resolution of live lower-priority bindings (issue #357).
 - `brain.feedback` validates `target_id` existence against the KG before folding, and validates
-  `served_by_profile_id` lifecycle before updating (must be non-archived). Lifecycle check
-  precedes the event-log append so rejected calls leave no trace in the log (issue C4, R3-1).
+  `served_by_profile_id` lifecycle before updating (must be non-archived). The authoritative
+  lifecycle check runs against the rebased snapshot inside the write transaction before the
+  public event, private event, fold-gate state, or replacement snapshot is written, so a peer
+  archive racing a warm preflight leaves no partial feedback trace (issue C4, R3-1).
 - `brain.unbind` requires at least one filter (`profile_id`, `actor`, `namespace`, or
   `consumer_kind`) to prevent accidental wipe of all bindings (issue C2).
 - `brain.bind` rejects archived profiles to prevent creating unresolvable bindings (issue C3).

--- a/crates/khive-pack-brain/docs/design.md
+++ b/crates/khive-pack-brain/docs/design.md
@@ -13,6 +13,13 @@ durability guarantee. Automatic shared-log catch-up and replay remain deferred b
 live inside each profile's own state, opaque to brain core. This means the brain pack has no
 knowledge of the internal structure of profile state — it stores opaque snapshots.
 
+**Cross-process coherence**: the namespace snapshot's monotonically-raised `updated_at` is its
+durable generation. Warm packs reload when that value advances, and durable mutations read the
+latest generation inside their SQLite write transaction before applying a full-state replacement,
+loading the durable snapshot payload only when the process-local generation differs.
+Concurrent processes therefore observe committed profiles/bindings and cannot silently
+overwrite a newer registry with a stale process-local blob.
+
 **Balanced-recall-v1 profile**: The built-in default profile uses three Beta posteriors:
 
 - `relevance_weight` — prior $\text{Beta}(7, 3)$: warm-starts expecting 70% retrieval relevance

--- a/crates/khive-pack-brain/src/fold_gate.rs
+++ b/crates/khive-pack-brain/src/fold_gate.rs
@@ -140,8 +140,7 @@ pub async fn apply_fold_gate(
 /// Which gating applies to the implicit event participating in the ADR-081
 /// §2/§6 atomic claim+fold+event-append unit
 /// (`apply_fold_gate_and_append_event`). Explicit/correction signals never
-/// reach this — `handlers.rs` keeps their append path unchanged, per ADR-081
-/// §6: "no dedup claim to keep consistent" for those signals.
+/// reach this because they have no dedup claim or implicit mass to update.
 pub enum FeedbackGateMode {
     /// The nominal implicit weight, subject to the ADR-081 §2 mass cap.
     Nominal(f64),
@@ -250,7 +249,7 @@ where
 /// `writer`, which must already be inside an open transaction. Does not
 /// commit or roll back — the caller owns transaction boundaries.
 #[allow(clippy::too_many_arguments)]
-async fn apply_gate_and_append_within_tx<F>(
+pub(crate) async fn apply_gate_and_append_within_tx<F>(
     writer: &mut dyn SqlWriter,
     namespace: &str,
     profile_id: &str,

--- a/crates/khive-pack-brain/src/handlers.rs
+++ b/crates/khive-pack-brain/src/handlers.rs
@@ -1455,7 +1455,9 @@ impl BrainPack {
 
         // Compute the effective serving profile (explicit, else a matching
         // actor+namespace binding, else the system default — #697), then
-        // validate that it exists in the registry and is not Archived.
+        // perform a warm-state fast-path check that it exists and is not
+        // Archived. The persistence transaction repeats this against the
+        // authoritative rebased snapshot before writing any side effect.
         let (effective_profile, profile_resolution) =
             self.resolve_effective_feedback_profile(token, p.served_by_profile_id.as_deref());
         let effective_profile = effective_profile.as_str();
@@ -1528,15 +1530,15 @@ impl BrainPack {
 
         // ADR-081 §2/§6: when both scorer fields are present, the dedup claim
         // is made atomically inside the SAME `BEGIN IMMEDIATE` transaction as
-        // the fold gate's mass check-and-write AND
-        // the durable feedback event append (fold_gate.rs) — the `resolve`
+        // the fold gate's mass check-and-write, the public event, the private
+        // brain event, and the posterior snapshot — the `resolve`
         // check above is a non-atomic fast path only (it still handles the
         // common sequential case and the NotFound / forced-zero-weight
         // determination); this is the authoritative correctness mechanism
         // under concurrent duplicate submissions.
-        let dedup_key: Option<(&str, &str)> =
+        let dedup_key: Option<(String, String)> =
             match (p.scorer_run_id.as_deref(), p.serve_ledger_id.as_deref()) {
-                (Some(r), Some(l)) => Some((r, l)),
+                (Some(r), Some(l)) => Some((r.to_string(), l.to_string())),
                 _ => None,
             };
 
@@ -1575,169 +1577,69 @@ impl BrainPack {
 
         // ADR-081 §2: the bounded-mass fold gate applies only to implicit
         // signals. Explicit/correction signals are never gated (they are the
-        // clamp's own comparator, ADR-081 §1) and — ADR-081 §6 — need not
-        // join the event append into the fold transaction: there is no
-        // dedup claim to keep consistent for them, so their append path
-        // below is unchanged from before this fix.
+        // clamp's own comparator, ADR-081 §1).
         let is_gated_implicit = matches!(
             FeedbackEventKind::from_signal_str(signal),
             Some(FeedbackEventKind::ImplicitPositive) | Some(FeedbackEventKind::ImplicitNegative)
         );
 
-        let event = if is_gated_implicit {
+        let duration_us = feedback_start.elapsed().as_micros().max(1) as i64;
+        let event = Event::new(
+            token.namespace().as_str().to_string(),
+            "brain.feedback",
+            khive_types::EventKind::FeedbackExplicit,
+            target_substrate,
+            format!("{}:{}", token.actor().kind, token.actor().id),
+        )
+        .with_target(target)
+        .with_payload(base_data)
+        .with_duration_us(duration_us);
+
+        let event_write = if is_gated_implicit {
             let nominal_weight = FeedbackEventKind::from_signal_str(signal)
                 .expect("is_gated_implicit implies from_signal_str is Some")
                 .update_weight();
-            // The forced-zero fail-safe path now
-            // runs through the SAME atomic claim+append unit as the nominal
-            // path below — only the mass fold write itself is skipped — so
-            // it participates in the dedup claim instead of bypassing it.
             let gate_mode = if forced_zero_weight {
                 crate::fold_gate::FeedbackGateMode::ForcedZero
             } else {
                 crate::fold_gate::FeedbackGateMode::Nominal(nominal_weight)
             };
-
-            let namespace = token.namespace().as_str().to_string();
-            // ADR-096 per-request identity: stamp the resolved caller actor,
-            // not a hardcoded pack name — matches the `kind:id` convention
-            // the generic Audit event already uses (khive-runtime pack.rs
-            // `build_audit_storage_event`). `ActorRef::anonymous()` resolves
-            // to the explicit `"anonymous:local"` string rather than
-            // silently mislabeling the event, so unresolved-actor calls are
-            // still distinguishable from configured caller attribution.
-            let actor_label = format!("{}:{}", token.actor().kind, token.actor().id);
-            // `apply_fold_gate_and_append_event`'s `build_event` closure is
-            // now required to be `'static` (ADR-067 Component A, Fork C
-            // slice 2 — it is boxed into an `AtomicUnitOp` and may run
-            // inside the writer task's `spawn_blocking`), so it must own
-            // its captures rather than borrow `namespace`/`base_data` — a
-            // separate `namespace_for_event` clone avoids conflicting with
-            // the `&namespace` borrow passed as this call's own argument.
-            let namespace_for_event = namespace.clone();
-            let actor_label_for_event = actor_label.clone();
-            let base_data_for_event = base_data.clone();
-            let outcome = crate::fold_gate::apply_fold_gate_and_append_event(
-                sql.as_ref(),
-                &namespace,
-                effective_profile,
-                &target.to_string(),
+            crate::persist::FeedbackEventWrite::Gated {
+                event,
+                target_id: target.to_string(),
                 gate_mode,
-                now_us,
+                gate_now_us: now_us,
                 dedup_key,
-                move |fold_outcome, forced_zero| {
-                    let mut data = base_data_for_event;
-                    let (effective_weight, mass_before, mass_after) = match fold_outcome {
-                        Some(o) => (o.effective_weight, o.mass_before, o.mass_after),
-                        None => (0.0, 0.0, 0.0),
-                    };
-                    data["gate"] = json!({
-                        "effective_weight": effective_weight,
-                        "mass_before": mass_before,
-                        "mass_after": mass_after,
-                        "forced_zero_weight": forced_zero,
-                    });
-                    let duration_us = feedback_start.elapsed().as_micros().max(1) as i64;
-                    Event::new(
-                        namespace_for_event,
-                        "brain.feedback",
-                        khive_types::EventKind::FeedbackExplicit,
-                        target_substrate,
-                        actor_label_for_event,
-                    )
-                    .with_target(target)
-                    .with_payload(data)
-                    .with_duration_us(duration_us)
-                },
-            )
-            .await?;
-
-            match outcome {
-                // This is now the ONLY place a scorer-tagged
-                // implicit call returns `deduped` — reached only when the
-                // atomic unit's claim conflicted, meaning either a prior call
-                // already committed claim+fold+event together, or (never)
-                // a partially-failed prior attempt, since a failed attempt
-                // rolls back its claim too.
-                crate::fold_gate::GateAndAppendOutcome::Deduped => {
-                    return Ok(json!({
-                        "emitted": false,
-                        "deduped": true,
-                        "verb": "brain.feedback",
-                        "signal": signal,
-                        "target_id": target.to_string(),
-                        "serve_ledger_id": p.serve_ledger_id,
-                        "scorer_run_id": p.scorer_run_id,
-                    }));
-                }
-                crate::fold_gate::GateAndAppendOutcome::Applied(result) => result.event,
             }
         } else {
-            // Unchanged: explicit/correction signals (and non-scorer implicit
-            // feedback would also land here if it ever reached this branch,
-            // but `is_gated_implicit` already routes all implicit signals
-            // above) append through the ordinary `EventStore` path, in its
-            // own transaction — ADR-081 §6 does not require these to join
-            // the fold gate's atomic unit.
-            let duration_us = feedback_start.elapsed().as_micros().max(1) as i64;
-            let event = Event::new(
-                token.namespace().as_str().to_string(),
-                "brain.feedback",
-                khive_types::EventKind::FeedbackExplicit,
-                target_substrate,
-                format!("{}:{}", token.actor().kind, token.actor().id),
-            )
-            .with_target(target)
-            .with_payload(base_data)
-            .with_duration_us(duration_us);
-
-            let store = self.runtime.events(token)?;
-            store
-                .append_event(event.clone())
-                .await
-                .map_err(|e| RuntimeError::InvalidInput(e.to_string()))?;
-            event
+            crate::persist::FeedbackEventWrite::Direct(event)
         };
 
         let serving_profile_owned = effective_profile.to_string();
-
-        let brain_signal = interpret(&event);
-
-        // Issue #458: apply the posterior mutation and make its durability
-        // part of the success contract. `persist_brain_state_mutation` runs
-        // this closure against a *proposed* state copy, then commits the
-        // brain event-log append + snapshot upsert in one transaction —
-        // `self.state` is only replaced with the proposed copy after that
-        // commit succeeds. If persistence fails, this returns `Err` and
-        // `self.state` is left completely untouched (no phantom in-memory
-        // posterior update that vanishes on restart).
-        crate::persist::persist_brain_state_mutation(
+        #[cfg(test)]
+        crate::pack::run_feedback_precommit_hook(effective_profile).await;
+        let event = crate::persist::persist_feedback_state_mutation(
             self.runtime.sql().as_ref(),
             token,
             &self.persistence,
             &self.state,
-            crate::persist::BrainMutationEvent {
-                profile_id: serving_profile_owned.clone(),
-                event_kind: event.verb.clone(),
-                payload: serde_json::to_value(&event)
-                    .map_err(|e| RuntimeError::InvalidInput(e.to_string()))?,
-            },
+            serving_profile_owned.clone(),
+            event_write,
             ENTITY_CACHE_CAPACITY,
             {
-                let brain_signal = brain_signal.clone();
                 let serving_profile_owned = serving_profile_owned.clone();
-                move |state: &mut khive_brain_core::BrainState| -> Result<(), RuntimeError> {
+                move |state: &mut khive_brain_core::BrainState, brain_signal| {
                     let serving_profile = serving_profile_owned.as_str();
 
                     if serving_profile == "balanced-recall-v1" {
-                        state.balanced_recall.apply_signal(&brain_signal);
+                        state.balanced_recall.apply_signal(brain_signal);
                         sync_balanced_recall_record(state);
                     } else if state.profile_states.contains_key(serving_profile) {
                         let ps = state
                             .profile_states
                             .get_mut(serving_profile)
                             .expect("key checked above");
-                        ps.apply_signal(&brain_signal);
+                        ps.apply_signal(brain_signal);
                         let snap = serde_json::to_value(ps.to_snapshot()).ok();
                         let total = ps.total_events;
                         if let Some(record) = state.profiles.get_mut(serving_profile) {
@@ -1745,25 +1647,30 @@ impl BrainPack {
                             record.state_snapshot = snap;
                         }
                     } else {
-                        state.balanced_recall.apply_signal(&brain_signal);
+                        state.balanced_recall.apply_signal(brain_signal);
                         sync_balanced_recall_record(state);
                     }
 
-                    // Seed and backfill section posteriors, then apply the signal.
-                    // Shared contract with the replay path — see `ensure_section_state_seeded`.
-                    {
-                        let section_state = crate::ensure_section_state_seeded(
-                            &mut state.section_states,
-                            &serving_profile_owned,
-                        );
-                        section_state.apply_signal(&brain_signal);
-                    }
-
-                    Ok(())
+                    let section_state = crate::ensure_section_state_seeded(
+                        &mut state.section_states,
+                        &serving_profile_owned,
+                    );
+                    section_state.apply_signal(brain_signal);
                 }
             },
         )
         .await?;
+        let Some(event) = event else {
+            return Ok(json!({
+                "emitted": false,
+                "deduped": true,
+                "verb": "brain.feedback",
+                "signal": signal,
+                "target_id": target.to_string(),
+                "serve_ledger_id": p.serve_ledger_id,
+                "scorer_run_id": p.scorer_run_id,
+            }));
+        };
 
         // lattice-router: build the context vector from the now-published live
         // state and forward through the fann network. This is a best-effort

--- a/crates/khive-pack-brain/src/handlers.rs
+++ b/crates/khive-pack-brain/src/handlers.rs
@@ -1671,6 +1671,7 @@ impl BrainPack {
                 "scorer_run_id": p.scorer_run_id,
             }));
         };
+        khive_storage::usage::count(khive_storage::usage::UsageUnit::EventRows, 1);
 
         // lattice-router: build the context vector from the now-published live
         // state and forward through the fann network. This is a best-effort

--- a/crates/khive-pack-brain/src/pack.rs
+++ b/crates/khive-pack-brain/src/pack.rs
@@ -36,6 +36,46 @@ pub(crate) fn clear_dispatch_interleave_hook() {
     *DISPATCH_INTERLEAVE_HOOK.lock().unwrap() = None;
 }
 
+#[cfg(test)]
+pub(crate) struct FeedbackPrecommitHook {
+    pub profile_id: String,
+    pub reached_tx: tokio::sync::oneshot::Sender<()>,
+    pub proceed_rx: tokio::sync::oneshot::Receiver<()>,
+}
+
+#[cfg(test)]
+pub(crate) static FEEDBACK_PRECOMMIT_HOOK: std::sync::Mutex<Option<FeedbackPrecommitHook>> =
+    std::sync::Mutex::new(None);
+
+#[cfg(test)]
+pub(crate) fn set_feedback_precommit_hook(hook: FeedbackPrecommitHook) {
+    *FEEDBACK_PRECOMMIT_HOOK.lock().unwrap() = Some(hook);
+}
+
+#[cfg(test)]
+pub(crate) fn clear_feedback_precommit_hook() {
+    *FEEDBACK_PRECOMMIT_HOOK.lock().unwrap() = None;
+}
+
+#[cfg(test)]
+pub(crate) async fn run_feedback_precommit_hook(profile_id: &str) {
+    let hook = {
+        let mut slot = FEEDBACK_PRECOMMIT_HOOK.lock().unwrap();
+        if slot
+            .as_ref()
+            .is_some_and(|hook| hook.profile_id == profile_id)
+        {
+            slot.take()
+        } else {
+            None
+        }
+    };
+    if let Some(hook) = hook {
+        let _ = hook.reached_tx.send(());
+        let _ = hook.proceed_rx.await;
+    }
+}
+
 /// Sync the `balanced-recall-v1` profile record to match the live `balanced_recall` state.
 pub(crate) fn sync_balanced_recall_record(state: &mut BrainState) {
     let total_ev = state.balanced_recall.total_events;

--- a/crates/khive-pack-brain/src/pack.rs
+++ b/crates/khive-pack-brain/src/pack.rs
@@ -51,7 +51,7 @@ pub struct BrainPack {
     pub(crate) runtime: KhiveRuntime,
     /// Profile registry + active balanced-recall state.
     pub(crate) state: Mutex<BrainState>,
-    /// Tracks which namespaces are loaded from DB and dirty event counts.
+    /// Tracks loaded namespaces, durable snapshot generations, and dirty counts.
     pub(crate) persistence: Mutex<persist::PersistenceTracker>,
     /// Serialises the (ensure_loaded → handler) pair so no namespace swap can
     /// occur between the two steps.  Must be a tokio async mutex because the

--- a/crates/khive-pack-brain/src/persist.rs
+++ b/crates/khive-pack-brain/src/persist.rs
@@ -40,6 +40,7 @@ pub(crate) fn clear_post_load_hook() {
 use serde_json::Value;
 
 use khive_runtime::{KhiveRuntime, NamespaceToken, RuntimeError};
+use khive_storage::event::Event;
 use khive_storage::types::{SqlStatement, SqlValue};
 use khive_storage::{SqlAccess, SqlReader, SqlWriter};
 
@@ -348,12 +349,34 @@ pub struct BrainMutationEvent {
     pub payload: Value,
 }
 
+/// Public feedback write to join to the authoritative profile-state transaction.
+pub(crate) enum FeedbackEventWrite {
+    Direct(Event),
+    Gated {
+        event: Event,
+        target_id: String,
+        gate_mode: crate::fold_gate::FeedbackGateMode,
+        gate_now_us: i64,
+        dedup_key: Option<(String, String)>,
+    },
+}
+
 enum MutationOutcome<R> {
     Committed {
         result: R,
         state: BrainState,
         snapshot_version: i64,
     },
+    Rejected(RuntimeError),
+}
+
+enum FeedbackMutationOutcome {
+    Committed {
+        event: Event,
+        state: BrainState,
+        snapshot_version: i64,
+    },
+    Deduped,
     Rejected(RuntimeError),
 }
 
@@ -508,6 +531,243 @@ pub async fn persist_brain_state_mutation<R: Send + 'static>(
                 t.mark_loaded_at(namespace, Some(snapshot_version));
             }
             Ok(result)
+        }
+    }
+}
+
+/// Revalidate and commit every feedback side effect against one rebased snapshot.
+#[allow(clippy::too_many_arguments)]
+pub(crate) async fn persist_feedback_state_mutation(
+    sql: &dyn SqlAccess,
+    token: &NamespaceToken,
+    tracker: &Mutex<PersistenceTracker>,
+    state: &Mutex<BrainState>,
+    profile_id: String,
+    event_write: FeedbackEventWrite,
+    entity_capacity: usize,
+    apply: impl FnOnce(&mut BrainState, &BrainSignal) + Send + 'static,
+) -> Result<Option<Event>, RuntimeError> {
+    let namespace = token.namespace().as_str().to_string();
+    let now_us = chrono::Utc::now().timestamp_micros();
+    let (local_version, local_snapshot) = {
+        let tracker = tracker.lock().unwrap();
+        let version = tracker.snapshot_version(&namespace);
+        let snapshot = state.lock().unwrap().to_snapshot();
+        (version, snapshot)
+    };
+
+    let namespace_for_op = namespace.clone();
+    let profile_id_for_op = profile_id;
+    let op: khive_storage::AtomicUnitOp = Box::new(move |writer| {
+        Box::pin(async move {
+            let previous_updated_at = load_snapshot_version_on_reader(writer, &namespace_for_op)
+                .await
+                .map_err(|e| {
+                    khive_storage::StorageError::driver(
+                        khive_storage::StorageCapability::Sql,
+                        "brain_feedback_load_snapshot_version",
+                        e,
+                    )
+                })?;
+            let base_snapshot = match previous_updated_at {
+                Some(updated_at) if local_version == Some(updated_at) => local_snapshot,
+                Some(updated_at) => {
+                    let (durable_snapshot, reloaded_updated_at) =
+                        load_latest_snapshot_on_reader(writer, &namespace_for_op, entity_capacity)
+                            .await
+                            .map_err(|e| {
+                                khive_storage::StorageError::driver(
+                                    khive_storage::StorageCapability::Sql,
+                                    "brain_feedback_load_snapshot",
+                                    e,
+                                )
+                            })?
+                            .ok_or_else(|| {
+                                khive_storage::StorageError::driver(
+                                    khive_storage::StorageCapability::Sql,
+                                    "brain_feedback_load_snapshot",
+                                    "snapshot disappeared inside the write transaction",
+                                )
+                            })?;
+                    if reloaded_updated_at != updated_at {
+                        return Err(khive_storage::StorageError::driver(
+                            khive_storage::StorageCapability::Sql,
+                            "brain_feedback_load_snapshot",
+                            format!(
+                                "snapshot generation changed inside the write transaction: \
+                                 expected {updated_at}, got {reloaded_updated_at}"
+                            ),
+                        ));
+                    }
+                    durable_snapshot
+                }
+                None => local_snapshot,
+            };
+            let mut proposed = BrainState::from_snapshot(base_snapshot, entity_capacity);
+
+            match proposed.profiles.get(&profile_id_for_op) {
+                None => {
+                    return Ok(
+                        Box::new(FeedbackMutationOutcome::Rejected(RuntimeError::NotFound(
+                            format!(
+                                "serving profile {:?} not found in profile registry",
+                                profile_id_for_op
+                            ),
+                        ))) as Box<dyn std::any::Any + Send>,
+                    );
+                }
+                Some(record)
+                    if record.lifecycle == khive_brain_core::ProfileLifecycle::Archived =>
+                {
+                    return Ok(Box::new(FeedbackMutationOutcome::Rejected(
+                        RuntimeError::InvalidInput(format!(
+                            "serving profile {:?} is archived; feedback cannot credit archived profiles",
+                            profile_id_for_op
+                        )),
+                    )) as Box<dyn std::any::Any + Send>);
+                }
+                Some(_) => {}
+            }
+
+            let commit_at_us = previous_updated_at
+                .map(|updated_at| now_us.max(updated_at.saturating_add(1)))
+                .unwrap_or(now_us);
+            let event = match event_write {
+                FeedbackEventWrite::Direct(mut event) => {
+                    event.created_at = commit_at_us;
+                    khive_db::stores::event::append_event_on_writer(writer, &event)
+                        .await
+                        .map_err(|e| {
+                            khive_storage::StorageError::driver(
+                                khive_storage::StorageCapability::Sql,
+                                "brain_feedback_append_public_event",
+                                e,
+                            )
+                        })?;
+                    event
+                }
+                FeedbackEventWrite::Gated {
+                    mut event,
+                    target_id,
+                    gate_mode,
+                    gate_now_us,
+                    dedup_key,
+                } => {
+                    event.created_at = commit_at_us;
+                    let dedup_ref = dedup_key
+                        .as_ref()
+                        .map(|(scorer, ledger)| (scorer.as_str(), ledger.as_str()));
+                    let outcome = crate::fold_gate::apply_gate_and_append_within_tx(
+                        writer,
+                        &namespace_for_op,
+                        &profile_id_for_op,
+                        &target_id,
+                        gate_mode,
+                        gate_now_us,
+                        dedup_ref,
+                        move |fold_outcome, forced_zero| {
+                            let (effective_weight, mass_before, mass_after) = match fold_outcome {
+                                Some(outcome) => (
+                                    outcome.effective_weight,
+                                    outcome.mass_before,
+                                    outcome.mass_after,
+                                ),
+                                None => (0.0, 0.0, 0.0),
+                            };
+                            event.payload["gate"] = serde_json::json!({
+                                "effective_weight": effective_weight,
+                                "mass_before": mass_before,
+                                "mass_after": mass_after,
+                                "forced_zero_weight": forced_zero,
+                            });
+                            event
+                        },
+                    )
+                    .await
+                    .map_err(|e| {
+                        khive_storage::StorageError::driver(
+                            khive_storage::StorageCapability::Sql,
+                            "brain_feedback_gate_and_append",
+                            e,
+                        )
+                    })?;
+                    match outcome {
+                        crate::fold_gate::GateAndAppendOutcome::Deduped => {
+                            return Ok(Box::new(FeedbackMutationOutcome::Deduped)
+                                as Box<dyn std::any::Any + Send>);
+                        }
+                        crate::fold_gate::GateAndAppendOutcome::Applied(result) => result.event,
+                    }
+                }
+            };
+
+            let signal = interpret(&event);
+            apply(&mut proposed, &signal);
+            let snapshot = proposed.to_snapshot();
+            let payload = serde_json::to_value(&event).map_err(|e| {
+                khive_storage::StorageError::driver(
+                    khive_storage::StorageCapability::Sql,
+                    "brain_feedback_serialize_private_event",
+                    e,
+                )
+            })?;
+            append_brain_event_on_writer(
+                writer,
+                &namespace_for_op,
+                &profile_id_for_op,
+                &event.verb,
+                &payload,
+                commit_at_us,
+            )
+            .await
+            .map_err(|e| {
+                khive_storage::StorageError::driver(
+                    khive_storage::StorageCapability::Sql,
+                    "brain_feedback_append_private_event",
+                    e,
+                )
+            })?;
+            upsert_snapshot_on_writer(writer, &namespace_for_op, &snapshot, commit_at_us)
+                .await
+                .map_err(|e| {
+                    khive_storage::StorageError::driver(
+                        khive_storage::StorageCapability::Sql,
+                        "brain_feedback_upsert_snapshot",
+                        e,
+                    )
+                })?;
+
+            Ok(Box::new(FeedbackMutationOutcome::Committed {
+                event,
+                state: proposed,
+                snapshot_version: commit_at_us,
+            }) as Box<dyn std::any::Any + Send>)
+        })
+    });
+
+    let boxed = sql.atomic_unit(op).await?;
+    let outcome = *boxed
+        .downcast::<FeedbackMutationOutcome>()
+        .expect("persist_feedback_state_mutation must return FeedbackMutationOutcome");
+
+    match outcome {
+        FeedbackMutationOutcome::Rejected(error) => Err(error),
+        FeedbackMutationOutcome::Deduped => Ok(None),
+        FeedbackMutationOutcome::Committed {
+            event,
+            state: proposed,
+            snapshot_version,
+        } => {
+            let mut tracker = tracker.lock().unwrap();
+            if !matches!(
+                tracker.snapshot_version(&namespace),
+                Some(current) if current > snapshot_version
+            ) {
+                *state.lock().unwrap() = proposed;
+                tracker.reset_dirty(&namespace);
+                tracker.mark_loaded_at(namespace, Some(snapshot_version));
+            }
+            Ok(Some(event))
         }
     }
 }

--- a/crates/khive-pack-brain/src/persist.rs
+++ b/crates/khive-pack-brain/src/persist.rs
@@ -364,7 +364,7 @@ pub(crate) enum FeedbackEventWrite {
 enum MutationOutcome<R> {
     Committed {
         result: R,
-        state: BrainState,
+        state: Box<BrainState>,
         snapshot_version: i64,
     },
     Rejected(RuntimeError),
@@ -373,7 +373,7 @@ enum MutationOutcome<R> {
 enum FeedbackMutationOutcome {
     Committed {
         event: Event,
-        state: BrainState,
+        state: Box<BrainState>,
         snapshot_version: i64,
     },
     Deduped,
@@ -447,17 +447,19 @@ pub async fn persist_brain_state_mutation<R: Send + 'static>(
                                 khive_storage::StorageError::driver(
                                     khive_storage::StorageCapability::Sql,
                                     "brain_persist_load_snapshot",
-                                    "snapshot disappeared inside the write transaction",
+                                    std::io::Error::other(
+                                        "snapshot disappeared inside the write transaction",
+                                    ),
                                 )
                             })?;
                     if reloaded_updated_at != updated_at {
                         return Err(khive_storage::StorageError::driver(
                             khive_storage::StorageCapability::Sql,
                             "brain_persist_load_snapshot",
-                            format!(
+                            std::io::Error::other(format!(
                                 "snapshot generation changed inside the write transaction: \
                                  expected {updated_at}, got {reloaded_updated_at}"
-                            ),
+                            )),
                         ));
                     }
                     durable_snapshot
@@ -505,7 +507,7 @@ pub async fn persist_brain_state_mutation<R: Send + 'static>(
                 })?;
             Ok(Box::new(MutationOutcome::Committed {
                 result,
-                state: proposed,
+                state: Box::new(proposed),
                 snapshot_version: commit_at_us,
             }) as Box<dyn std::any::Any + Send>)
         })
@@ -526,7 +528,7 @@ pub async fn persist_brain_state_mutation<R: Send + 'static>(
             let mut t = tracker.lock().unwrap();
             if !matches!(t.snapshot_version(&namespace), Some(current) if current > snapshot_version)
             {
-                *state.lock().unwrap() = proposed;
+                *state.lock().unwrap() = *proposed;
                 t.reset_dirty(&namespace);
                 t.mark_loaded_at(namespace, Some(snapshot_version));
             }
@@ -586,17 +588,19 @@ pub(crate) async fn persist_feedback_state_mutation(
                                 khive_storage::StorageError::driver(
                                     khive_storage::StorageCapability::Sql,
                                     "brain_feedback_load_snapshot",
-                                    "snapshot disappeared inside the write transaction",
+                                    std::io::Error::other(
+                                        "snapshot disappeared inside the write transaction",
+                                    ),
                                 )
                             })?;
                     if reloaded_updated_at != updated_at {
                         return Err(khive_storage::StorageError::driver(
                             khive_storage::StorageCapability::Sql,
                             "brain_feedback_load_snapshot",
-                            format!(
+                            std::io::Error::other(format!(
                                 "snapshot generation changed inside the write transaction: \
                                  expected {updated_at}, got {reloaded_updated_at}"
-                            ),
+                            )),
                         ));
                     }
                     durable_snapshot
@@ -739,7 +743,7 @@ pub(crate) async fn persist_feedback_state_mutation(
 
             Ok(Box::new(FeedbackMutationOutcome::Committed {
                 event,
-                state: proposed,
+                state: Box::new(proposed),
                 snapshot_version: commit_at_us,
             }) as Box<dyn std::any::Any + Send>)
         })
@@ -763,7 +767,7 @@ pub(crate) async fn persist_feedback_state_mutation(
                 tracker.snapshot_version(&namespace),
                 Some(current) if current > snapshot_version
             ) {
-                *state.lock().unwrap() = proposed;
+                *state.lock().unwrap() = *proposed;
                 tracker.reset_dirty(&namespace);
                 tracker.mark_loaded_at(namespace, Some(snapshot_version));
             }

--- a/crates/khive-pack-brain/src/persist.rs
+++ b/crates/khive-pack-brain/src/persist.rs
@@ -41,7 +41,7 @@ use serde_json::Value;
 
 use khive_runtime::{KhiveRuntime, NamespaceToken, RuntimeError};
 use khive_storage::types::{SqlStatement, SqlValue};
-use khive_storage::{SqlAccess, SqlWriter};
+use khive_storage::{SqlAccess, SqlReader, SqlWriter};
 
 use khive_brain_core::{
     validate_brain_state_snapshot_with_capacity, BrainSignal, BrainState, BrainStateSnapshot,
@@ -52,6 +52,14 @@ use crate::event::interpret;
 const SNAPSHOT_PROFILE_ID: &str = "__brain__";
 const DEFAULT_SNAPSHOT_BATCH_SIZE: u64 = 5;
 
+fn version_covers(current: Option<i64>, observed: Option<i64>) -> bool {
+    match (current, observed) {
+        (Some(current), Some(observed)) => current >= observed,
+        (Some(_), None) | (None, None) => true,
+        (None, Some(_)) => false,
+    }
+}
+
 /// Tracks loaded namespaces and dirty event counts; owns the per-namespace state map.
 pub struct PersistenceTracker {
     /// Namespace currently reflected in the shared `BrainState` slot, if any.
@@ -61,6 +69,12 @@ pub struct PersistenceTracker {
     saved_states: HashMap<String, BrainState>,
     /// Namespaces for which state has been initialised (from DB or fresh default).
     pub(crate) loaded_namespaces: HashMap<String, ()>,
+    /// Latest durable snapshot version observed for each loaded namespace.
+    ///
+    /// Snapshot `updated_at` is raised monotonically inside every full-state
+    /// mutation transaction. A warm process compares this version before
+    /// reusing its in-memory registry.
+    snapshot_versions: HashMap<String, i64>,
     dirty_counts: HashMap<String, u64>,
     snapshot_batch_size: u64,
     /// Pre-load accumulator for hook signals that arrive before `ensure_loaded` runs.
@@ -90,6 +104,7 @@ impl PersistenceTracker {
             active_namespace: None,
             saved_states: HashMap::new(),
             loaded_namespaces: HashMap::new(),
+            snapshot_versions: HashMap::new(),
             dirty_counts: HashMap::new(),
             snapshot_batch_size: DEFAULT_SNAPSHOT_BATCH_SIZE,
             pending_hook_signals: HashMap::new(),
@@ -110,6 +125,22 @@ impl PersistenceTracker {
     pub fn mark_loaded(&mut self, namespace: String) {
         self.loaded_namespaces.insert(namespace.clone(), ());
         self.active_namespace = Some(namespace);
+    }
+
+    fn mark_loaded_at(&mut self, namespace: String, snapshot_version: Option<i64>) {
+        match snapshot_version {
+            Some(version) => {
+                self.snapshot_versions.insert(namespace.clone(), version);
+            }
+            None => {
+                self.snapshot_versions.remove(&namespace);
+            }
+        }
+        self.mark_loaded(namespace);
+    }
+
+    fn snapshot_version(&self, namespace: &str) -> Option<i64> {
+        self.snapshot_versions.get(namespace).copied()
     }
 
     /// Save `from_state` for `from_namespace`, then activate `to_namespace` (returning saved state if any).
@@ -317,12 +348,23 @@ pub struct BrainMutationEvent {
     pub payload: Value,
 }
 
+enum MutationOutcome<R> {
+    Committed {
+        result: R,
+        state: BrainState,
+        snapshot_version: i64,
+    },
+    Rejected(RuntimeError),
+}
+
 /// Apply a `BrainState` mutation with durability as part of the success
 /// contract (issues #457/#458).
 ///
-/// `mutate` runs against a *proposed* copy of the state (never the live
-/// `state` mutex) built via a snapshot round-trip. Its result and the
-/// resulting snapshot are then persisted — brain event-log append AND
+/// `mutate` runs against a *proposed* state whose generation is verified after
+/// the write transaction begins (never against the live `state` mutex). A
+/// version-matched local copy preserves best-effort hook updates; a mismatch
+/// rebases on the latest durable snapshot. Its result and the resulting
+/// snapshot are then persisted — brain event-log append AND
 /// snapshot upsert — as ONE atomic unit via `SqlAccess::atomic_unit`. Only
 /// after that unit commits does the proposed state replace the live state
 /// and the tracker get marked clean. If `mutate` fails, or the atomic unit
@@ -332,25 +374,23 @@ pub struct BrainMutationEvent {
 /// place. See `crates/khive-pack-brain/docs/api/persist.md` for why this
 /// takes `&dyn SqlAccess` and why it uses `atomic_unit` over a manual
 /// transaction.
-pub async fn persist_brain_state_mutation<R>(
+pub async fn persist_brain_state_mutation<R: Send + 'static>(
     sql: &dyn SqlAccess,
     token: &NamespaceToken,
     tracker: &Mutex<PersistenceTracker>,
     state: &Mutex<BrainState>,
     event: BrainMutationEvent,
     entity_capacity: usize,
-    mutate: impl FnOnce(&mut BrainState) -> Result<R, RuntimeError>,
+    mutate: impl FnOnce(&mut BrainState) -> Result<R, RuntimeError> + Send + 'static,
 ) -> Result<R, RuntimeError> {
     let namespace = token.namespace().as_str().to_string();
     let now_us = chrono::Utc::now().timestamp_micros();
-
-    let mut proposed = {
-        let current = state.lock().unwrap();
-        BrainState::from_snapshot(current.to_snapshot(), entity_capacity)
+    let (local_version, local_snapshot) = {
+        let tracker = tracker.lock().unwrap();
+        let version = tracker.snapshot_version(&namespace);
+        let snapshot = state.lock().unwrap().to_snapshot();
+        (version, snapshot)
     };
-
-    let result = mutate(&mut proposed)?;
-    let snapshot = proposed.to_snapshot();
 
     let namespace_for_op = namespace.clone();
     let profile_id = event.profile_id;
@@ -358,13 +398,70 @@ pub async fn persist_brain_state_mutation<R>(
     let payload = event.payload;
     let op: khive_storage::AtomicUnitOp = Box::new(move |writer| {
         Box::pin(async move {
+            let previous_updated_at = load_snapshot_version_on_reader(writer, &namespace_for_op)
+                .await
+                .map_err(|e| {
+                    khive_storage::StorageError::driver(
+                        khive_storage::StorageCapability::Sql,
+                        "brain_persist_load_snapshot_version",
+                        e,
+                    )
+                })?;
+            let base_snapshot = match previous_updated_at {
+                Some(updated_at) if local_version == Some(updated_at) => local_snapshot,
+                Some(updated_at) => {
+                    let (durable_snapshot, reloaded_updated_at) =
+                        load_latest_snapshot_on_reader(writer, &namespace_for_op, entity_capacity)
+                            .await
+                            .map_err(|e| {
+                                khive_storage::StorageError::driver(
+                                    khive_storage::StorageCapability::Sql,
+                                    "brain_persist_load_snapshot",
+                                    e,
+                                )
+                            })?
+                            .ok_or_else(|| {
+                                khive_storage::StorageError::driver(
+                                    khive_storage::StorageCapability::Sql,
+                                    "brain_persist_load_snapshot",
+                                    "snapshot disappeared inside the write transaction",
+                                )
+                            })?;
+                    if reloaded_updated_at != updated_at {
+                        return Err(khive_storage::StorageError::driver(
+                            khive_storage::StorageCapability::Sql,
+                            "brain_persist_load_snapshot",
+                            format!(
+                                "snapshot generation changed inside the write transaction: \
+                                 expected {updated_at}, got {reloaded_updated_at}"
+                            ),
+                        ));
+                    }
+                    durable_snapshot
+                }
+                None => local_snapshot,
+            };
+            let mut proposed = BrainState::from_snapshot(base_snapshot, entity_capacity);
+
+            let result = match mutate(&mut proposed) {
+                Ok(result) => result,
+                Err(error) => {
+                    return Ok(Box::new(MutationOutcome::<R>::Rejected(error))
+                        as Box<dyn std::any::Any + Send>);
+                }
+            };
+            let snapshot = proposed.to_snapshot();
+            let commit_at_us = previous_updated_at
+                .map(|updated_at| now_us.max(updated_at.saturating_add(1)))
+                .unwrap_or(now_us);
+
             append_brain_event_on_writer(
                 writer,
                 &namespace_for_op,
                 &profile_id,
                 &event_kind,
                 &payload,
-                now_us,
+                commit_at_us,
             )
             .await
             .map_err(|e| {
@@ -374,7 +471,7 @@ pub async fn persist_brain_state_mutation<R>(
                     e,
                 )
             })?;
-            upsert_snapshot_on_writer(writer, &namespace_for_op, &snapshot, now_us)
+            upsert_snapshot_on_writer(writer, &namespace_for_op, &snapshot, commit_at_us)
                 .await
                 .map_err(|e| {
                     khive_storage::StorageError::driver(
@@ -383,31 +480,43 @@ pub async fn persist_brain_state_mutation<R>(
                         e,
                     )
                 })?;
-            Ok(Box::new(()) as Box<dyn std::any::Any + Send>)
+            Ok(Box::new(MutationOutcome::Committed {
+                result,
+                state: proposed,
+                snapshot_version: commit_at_us,
+            }) as Box<dyn std::any::Any + Send>)
         })
     });
 
-    sql.atomic_unit(op).await?;
+    let boxed = sql.atomic_unit(op).await?;
+    let outcome = *boxed
+        .downcast::<MutationOutcome<R>>()
+        .expect("persist_brain_state_mutation must return MutationOutcome");
 
-    {
-        let mut live = state.lock().unwrap();
-        *live = proposed;
+    match outcome {
+        MutationOutcome::Rejected(error) => Err(error),
+        MutationOutcome::Committed {
+            result,
+            state: proposed,
+            snapshot_version,
+        } => {
+            let mut t = tracker.lock().unwrap();
+            if !matches!(t.snapshot_version(&namespace), Some(current) if current > snapshot_version)
+            {
+                *state.lock().unwrap() = proposed;
+                t.reset_dirty(&namespace);
+                t.mark_loaded_at(namespace, Some(snapshot_version));
+            }
+            Ok(result)
+        }
     }
-    {
-        let mut t = tracker.lock().unwrap();
-        t.reset_dirty(&namespace);
-        t.mark_loaded(namespace);
-    }
-
-    Ok(result)
 }
 
-pub async fn load_latest_snapshot(
-    sql: &dyn SqlAccess,
+async fn load_latest_snapshot_on_reader<R: SqlReader + ?Sized>(
+    reader: &mut R,
     namespace: &str,
     entity_capacity: usize,
 ) -> Result<Option<(BrainStateSnapshot, i64)>, RuntimeError> {
-    let mut reader = sql.reader().await.map_err(|e| sql_err("reader", e))?;
     let row = reader
         .query_row(SqlStatement {
             sql: "SELECT snapshot_json, updated_at FROM brain_profile_snapshots WHERE profile_id = ?1 AND namespace = ?2 ORDER BY updated_at DESC LIMIT 1".into(),
@@ -438,6 +547,50 @@ pub async fn load_latest_snapshot(
             Ok(Some((snapshot, updated_at)))
         }
     }
+}
+
+pub async fn load_latest_snapshot(
+    sql: &dyn SqlAccess,
+    namespace: &str,
+    entity_capacity: usize,
+) -> Result<Option<(BrainStateSnapshot, i64)>, RuntimeError> {
+    let mut reader = sql.reader().await.map_err(|e| sql_err("reader", e))?;
+    load_latest_snapshot_on_reader(reader.as_mut(), namespace, entity_capacity).await
+}
+
+async fn load_snapshot_version_on_reader<R: SqlReader + ?Sized>(
+    reader: &mut R,
+    namespace: &str,
+) -> Result<Option<i64>, RuntimeError> {
+    let row = reader
+        .query_scalar(SqlStatement {
+            sql: "SELECT updated_at FROM brain_profile_snapshots WHERE profile_id = ?1 AND namespace = ?2"
+                .into(),
+            params: vec![
+                SqlValue::Text(SNAPSHOT_PROFILE_ID.to_string()),
+                SqlValue::Text(namespace.to_string()),
+            ],
+            label: Some("brain_snapshot_version".into()),
+        })
+        .await
+        .map_err(|e| sql_err("load snapshot version", e))?;
+
+    match row {
+        None => Ok(None),
+        Some(SqlValue::Integer(version)) => Ok(Some(version)),
+        other => Err(sql_err(
+            "load snapshot version",
+            format!("expected integer updated_at, got {other:?}"),
+        )),
+    }
+}
+
+async fn load_snapshot_version(
+    sql: &dyn SqlAccess,
+    namespace: &str,
+) -> Result<Option<i64>, RuntimeError> {
+    let mut reader = sql.reader().await.map_err(|e| sql_err("reader", e))?;
+    load_snapshot_version_on_reader(reader.as_mut(), namespace).await
 }
 
 /// A single row that was quarantined during replay, with enough metadata to
@@ -581,23 +734,26 @@ pub async fn ensure_loaded(
     entity_capacity: usize,
 ) -> Result<(), RuntimeError> {
     let namespace = token.namespace().as_str().to_string();
+    let sql = runtime.sql();
+    let observed_version = load_snapshot_version(sql.as_ref(), &namespace).await?;
 
     {
         let t = tracker.lock().unwrap();
-        if t.is_active(&namespace) {
+        if t.is_active(&namespace)
+            && version_covers(t.snapshot_version(&namespace), observed_version)
+        {
             return Ok(());
         }
     }
 
-    let already_loaded = {
+    let already_current = {
         let t = tracker.lock().unwrap();
-        t.is_loaded(&namespace)
+        t.is_loaded(&namespace) && version_covers(t.snapshot_version(&namespace), observed_version)
     };
 
-    let brain_state: Option<BrainState> = if already_loaded {
+    let brain_state: Option<BrainState> = if already_current {
         None
     } else {
-        let sql = runtime.sql();
         let snapshot_result =
             load_latest_snapshot(sql.as_ref(), &namespace, entity_capacity).await?;
 
@@ -657,19 +813,20 @@ pub async fn ensure_loaded(
     {
         let mut t = tracker.lock().unwrap();
 
-        // Re-check 1: another loader already published this namespace as active.
-        // The shared state slot already contains the live state; return without
-        // clobbering it with our stale cold-loaded copy.
-        if t.is_active(&namespace) {
+        // Another loader or mutation may already have published this namespace
+        // at the same or a newer durable generation while this task awaited DB
+        // reads. Never replace that state with the older copy loaded above.
+        if t.is_active(&namespace)
+            && version_covers(t.snapshot_version(&namespace), observed_version)
+        {
             return Ok(());
         }
 
-        // Re-check 2: another loader completed a cold load for this namespace
-        // (it is now in saved_states) while this task was awaiting the DB.
-        // Our brain_state was derived from a snapshot that is now stale relative
-        // to any mutations that occurred after that loader published.  Discard
-        // it so the save-restore path below uses the live saved state instead.
-        let fresh_brain_state = if t.is_loaded(&namespace) {
+        // The same rule applies when another task published the namespace into
+        // saved_states rather than the active slot.
+        let fresh_brain_state = if t.is_loaded(&namespace)
+            && version_covers(t.snapshot_version(&namespace), observed_version)
+        {
             None
         } else {
             brain_state
@@ -754,13 +911,7 @@ pub async fn ensure_loaded(
         // all consistent; no concurrent dispatch can observe a partial view.
         *state.lock().unwrap() = final_state;
 
-        // For the no-active-namespace (first-load) path swap_namespace was not
-        // called, so we set active_namespace here before marking loaded.
-        if current_ns.is_none() {
-            t.active_namespace = Some(namespace.clone());
-        }
-
-        t.loaded_namespaces.insert(namespace, ());
+        t.mark_loaded_at(namespace, observed_version);
     }
 
     Ok(())

--- a/crates/khive-pack-brain/src/tests.rs
+++ b/crates/khive-pack-brain/src/tests.rs
@@ -3985,6 +3985,285 @@ async fn ensure_loaded_concurrent_same_namespace_is_safe() {
     );
 }
 
+#[tokio::test]
+async fn warm_pack_refreshes_profiles_and_bindings_written_by_peer() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let config = khive_runtime::RuntimeConfig {
+        db_path: Some(dir.path().join("cross-process-visibility.db")),
+        ..khive_runtime::RuntimeConfig::no_embeddings()
+    };
+    let writer_rt = KhiveRuntime::new(config.clone()).expect("writer runtime");
+    let reader_rt = KhiveRuntime::new(config).expect("reader runtime");
+    let writer = BrainPack::new(writer_rt.clone());
+    let reader = BrainPack::new(reader_rt.clone());
+    let registry = empty_registry();
+    let writer_token = writer_rt
+        .authorize(Namespace::local())
+        .expect("writer token");
+    let reader_token = reader_rt
+        .authorize(Namespace::local())
+        .expect("reader token");
+
+    let initial = reader
+        .dispatch("brain.profiles", json!({}), &registry, &reader_token)
+        .await
+        .expect("warm reader profile registry");
+    assert_eq!(initial["count"], json!(1u64));
+
+    writer
+        .dispatch(
+            "brain.create_profile",
+            json!({
+                "name": "peer-visible-profile",
+                "consumer_kind": "recall",
+            }),
+            &registry,
+            &writer_token,
+        )
+        .await
+        .expect("peer creates profile");
+
+    let refreshed = reader
+        .dispatch("brain.profiles", json!({}), &registry, &reader_token)
+        .await
+        .expect("warm reader refreshes profile registry");
+    assert!(
+        refreshed["profiles"]
+            .as_array()
+            .expect("profiles array")
+            .iter()
+            .any(|profile| profile["id"] == json!("peer-visible-profile")),
+        "a warm pack must observe a profile committed by another pack"
+    );
+
+    let target = create_test_entity(&writer_rt, &writer_token).await;
+    let feedback = reader
+        .dispatch(
+            "brain.feedback",
+            json!({
+                "target_id": target,
+                "signal": "useful",
+                "served_by_profile_id": "peer-visible-profile",
+            }),
+            &registry,
+            &reader_token,
+        )
+        .await
+        .expect("warm peer accepts feedback for newly visible profile");
+    assert_eq!(feedback["emitted"], json!(true));
+
+    let profile = writer
+        .dispatch(
+            "brain.profile",
+            json!({"profile_id": "peer-visible-profile"}),
+            &registry,
+            &writer_token,
+        )
+        .await
+        .expect("original writer refreshes peer feedback");
+    assert_eq!(profile["total_events"], json!(1u64));
+
+    writer
+        .dispatch(
+            "brain.bind",
+            json!({
+                "profile_id": "peer-visible-profile",
+                "actor": "peer-actor",
+                "namespace": "local",
+                "consumer_kind": "recall",
+            }),
+            &registry,
+            &writer_token,
+        )
+        .await
+        .expect("peer creates binding");
+
+    let bindings = reader
+        .dispatch(
+            "brain.bindings",
+            json!({"profile_id": "peer-visible-profile"}),
+            &registry,
+            &reader_token,
+        )
+        .await
+        .expect("warm reader refreshes bindings");
+    assert_eq!(bindings["count"], json!(1u64));
+    assert_eq!(bindings["bindings"][0]["actor"], json!("peer-actor"));
+}
+
+#[tokio::test]
+async fn stale_pack_mutation_rebases_on_durable_snapshot() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let config = khive_runtime::RuntimeConfig {
+        db_path: Some(dir.path().join("stale-writer.db")),
+        ..khive_runtime::RuntimeConfig::no_embeddings()
+    };
+    let first_rt = KhiveRuntime::new(config.clone()).expect("first runtime");
+    let stale_rt = KhiveRuntime::new(config.clone()).expect("stale runtime");
+    let observer_rt = KhiveRuntime::new(config).expect("observer runtime");
+    let first = BrainPack::new(first_rt.clone());
+    let stale = BrainPack::new(stale_rt.clone());
+    let observer = BrainPack::new(observer_rt.clone());
+    let registry = empty_registry();
+    let first_token = first_rt.authorize(Namespace::local()).expect("first token");
+    let stale_token = stale_rt.authorize(Namespace::local()).expect("stale token");
+    let observer_token = observer_rt
+        .authorize(Namespace::local())
+        .expect("observer token");
+
+    first
+        .dispatch("brain.profiles", json!({}), &registry, &first_token)
+        .await
+        .expect("warm first pack");
+    stale
+        .dispatch("brain.profiles", json!({}), &registry, &stale_token)
+        .await
+        .expect("warm stale pack before either write");
+
+    first
+        .handle_create_profile(
+            &first_token,
+            json!({"name": "first-process-profile", "consumer_kind": "recall"}),
+        )
+        .await
+        .expect("first process writes profile");
+
+    // Call the handler directly so this pack deliberately skips dispatch's
+    // freshness check. The persistence transaction itself must still read the
+    // latest durable snapshot before applying its mutation.
+    stale
+        .handle_create_profile(
+            &stale_token,
+            json!({"name": "stale-process-profile", "consumer_kind": "recall"}),
+        )
+        .await
+        .expect("stale process rebases its mutation");
+
+    let profiles = observer
+        .dispatch("brain.profiles", json!({}), &registry, &observer_token)
+        .await
+        .expect("fresh observer loads merged registry");
+    let ids: std::collections::HashSet<&str> = profiles["profiles"]
+        .as_array()
+        .expect("profiles array")
+        .iter()
+        .filter_map(|profile| profile["id"].as_str())
+        .collect();
+    assert!(ids.contains("first-process-profile"));
+    assert!(ids.contains("stale-process-profile"));
+}
+
+#[tokio::test]
+async fn matching_generation_reuses_local_snapshot_without_decoding_durable_json() {
+    use khive_storage::types::{SqlStatement, SqlValue};
+
+    let (pack, rt) = make_pack();
+    let registry = empty_registry();
+    let token = rt.authorize(Namespace::local()).expect("local token");
+
+    pack.dispatch(
+        "brain.create_profile",
+        json!({"name": "generation-reuse-seed", "consumer_kind": "recall"}),
+        &registry,
+        &token,
+    )
+    .await
+    .expect("seed durable snapshot and local generation");
+
+    // Poison only the durable JSON while preserving updated_at. This is a
+    // decode sentinel, not a supported external mutation: the next dispatch's
+    // generation check still matches the live local snapshot, so the mutation
+    // transaction must not fetch or deserialize this blob.
+    {
+        let mut writer = rt.sql().writer().await.expect("writer");
+        let changed = writer
+            .execute(SqlStatement {
+                sql: "UPDATE brain_profile_snapshots SET snapshot_json = ?1 \
+                      WHERE profile_id = ?2 AND namespace = ?3"
+                    .into(),
+                params: vec![
+                    SqlValue::Text("{decode-sentinel".to_string()),
+                    SqlValue::Text("__brain__".to_string()),
+                    SqlValue::Text(token.namespace().as_str().to_string()),
+                ],
+                label: Some("brain_test_poison_matching_snapshot".into()),
+            })
+            .await
+            .expect("install decode sentinel without advancing generation");
+        assert_eq!(changed, 1, "decode sentinel must replace the snapshot row");
+    }
+
+    pack.dispatch(
+        "brain.create_profile",
+        json!({"name": "generation-reuse-next", "consumer_kind": "recall"}),
+        &registry,
+        &token,
+    )
+    .await
+    .expect("matching generation must reuse local snapshot");
+
+    let (snapshot, _) = crate::persist::load_latest_snapshot(
+        rt.sql().as_ref(),
+        token.namespace().as_str(),
+        ENTITY_CACHE_CAPACITY,
+    )
+    .await
+    .expect("load replacement snapshot")
+    .expect("replacement snapshot exists");
+    assert!(snapshot.profiles.contains_key("generation-reuse-seed"));
+    assert!(snapshot.profiles.contains_key("generation-reuse-next"));
+}
+
+#[tokio::test]
+async fn mutation_timestamp_advances_past_existing_snapshot() {
+    let rt = KhiveRuntime::memory().expect("in-memory runtime");
+    let token = rt.authorize(Namespace::local()).expect("local token");
+    let namespace = token.namespace().as_str();
+    let future_updated_at = chrono::Utc::now().timestamp_micros() + 1_000_000;
+    let snapshot = khive_brain_core::BrainState::new(ENTITY_CACHE_CAPACITY).to_snapshot();
+    crate::persist::upsert_snapshot(rt.sql().as_ref(), namespace, &snapshot, future_updated_at)
+        .await
+        .expect("seed future-dated snapshot");
+
+    let tracker = std::sync::Mutex::new(crate::persist::PersistenceTracker::new());
+    let state = std::sync::Mutex::new(khive_brain_core::BrainState::new(ENTITY_CACHE_CAPACITY));
+    let event = khive_storage::event::Event::new(
+        namespace,
+        "brain.test_monotonic_timestamp",
+        khive_types::EventKind::Audit,
+        khive_types::SubstrateKind::Event,
+        "brain",
+    )
+    .with_payload(json!({"probe": true}));
+    crate::persist::persist_brain_state_mutation(
+        rt.sql().as_ref(),
+        &token,
+        &tracker,
+        &state,
+        crate::persist::BrainMutationEvent {
+            profile_id: "balanced-recall-v1".to_string(),
+            event_kind: event.verb.clone(),
+            payload: serde_json::to_value(event).expect("test event serializes"),
+        },
+        ENTITY_CACHE_CAPACITY,
+        |_state| Ok::<(), RuntimeError>(()),
+    )
+    .await
+    .expect("persist mutation after future-dated snapshot");
+
+    let (_, updated_at) =
+        crate::persist::load_latest_snapshot(rt.sql().as_ref(), namespace, ENTITY_CACHE_CAPACITY)
+            .await
+            .expect("load snapshot")
+            .expect("snapshot exists");
+    assert!(updated_at > future_updated_at);
+
+    let replay = crate::persist::load_events_since(rt.sql().as_ref(), namespace, future_updated_at)
+        .await
+        .expect("load post-snapshot events");
+    assert_eq!(replay.events.len(), 1);
+}
+
 /// Cross-namespace concurrent loads must not cause one namespace to save the
 /// wrong state under saved_states.  We alternate between two namespaces while
 /// mutating each, then verify each namespace sees only its own state.

--- a/crates/khive-pack-brain/src/tests.rs
+++ b/crates/khive-pack-brain/src/tests.rs
@@ -4329,9 +4329,15 @@ async fn feedback_revalidates_lifecycle_inside_cross_process_transaction() {
         .await
         .expect("read feedback side-effect counts")
         .expect("count row");
-    assert_eq!(row.get("public_events"), Some(&SqlValue::Integer(0)));
-    assert_eq!(row.get("private_events"), Some(&SqlValue::Integer(0)));
-    assert_eq!(row.get("mass_rows"), Some(&SqlValue::Integer(0)));
+    assert!(matches!(
+        row.get("public_events"),
+        Some(SqlValue::Integer(0))
+    ));
+    assert!(matches!(
+        row.get("private_events"),
+        Some(SqlValue::Integer(0))
+    ));
+    assert!(matches!(row.get("mass_rows"), Some(SqlValue::Integer(0))));
 }
 
 #[tokio::test]

--- a/crates/khive-pack-brain/src/tests.rs
+++ b/crates/khive-pack-brain/src/tests.rs
@@ -1458,6 +1458,36 @@ async fn w4_c4_feedback_accepts_valid_target_and_profile() {
     assert_eq!(result["signal"], json!("useful"));
 }
 
+#[tokio::test]
+async fn feedback_success_counts_one_event_row_for_each_append_path() {
+    for signal in ["explicit_positive", "correction", "implicit_positive"] {
+        let (pack, rt) = make_pack();
+        let registry = empty_registry();
+        let token = rt.authorize(Namespace::local()).unwrap();
+        let target = create_test_entity(&rt, &token).await;
+        let usage = khive_storage::usage::UsageContext::new();
+
+        let result = khive_storage::usage::scope(
+            usage.clone(),
+            pack.dispatch(
+                "brain.feedback",
+                json!({"target_id": target, "signal": signal}),
+                &registry,
+                &token,
+            ),
+        )
+        .await
+        .expect("feedback append must commit");
+
+        assert_eq!(result["emitted"], json!(true));
+        assert_eq!(
+            usage.snapshot()["event_rows"],
+            json!(1u64),
+            "signal {signal:?} must count its one committed public event row"
+        );
+    }
+}
+
 /// Regression (#831): a note-target `brain.feedback` signal must resolve via
 /// `observed_as_signal` (previously unreachable — the decoder hard-coded
 /// `ReferentKind::Entity`). See crates/khive-pack-brain/docs/dispatch-namespace-isolation.md#feedback_note_target_resolves_through_observed_as_signal.
@@ -4219,20 +4249,25 @@ async fn feedback_revalidates_lifecycle_inside_cross_process_transaction() {
     let feedback_token_task = Arc::clone(&feedback_token);
     let registry_task = Arc::clone(&registry);
     let target_for_task = target.clone();
-    let feedback_task = tokio::spawn(async move {
-        feedback_pack_task
-            .dispatch(
-                "brain.feedback",
-                json!({
-                    "target_id": target_for_task,
-                    "signal": "implicit_positive",
-                    "served_by_profile_id": profile_id,
-                }),
-                &registry_task,
-                &feedback_token_task,
-            )
-            .await
-    });
+    let feedback_usage = khive_storage::usage::UsageContext::new();
+    let feedback_usage_task = feedback_usage.clone();
+    let feedback_task = tokio::spawn(khive_storage::usage::scope(
+        feedback_usage_task,
+        async move {
+            feedback_pack_task
+                .dispatch(
+                    "brain.feedback",
+                    json!({
+                        "target_id": target_for_task,
+                        "signal": "implicit_positive",
+                        "served_by_profile_id": profile_id,
+                    }),
+                    &registry_task,
+                    &feedback_token_task,
+                )
+                .await
+        },
+    ));
 
     reached_rx
         .await
@@ -4255,6 +4290,10 @@ async fn feedback_revalidates_lifecycle_inside_cross_process_transaction() {
     assert!(
         matches!(error, RuntimeError::InvalidInput(ref message) if message.contains("archived")),
         "rebased feedback rejection must report the archived lifecycle: {error:?}"
+    );
+    assert!(
+        feedback_usage.snapshot().get("event_rows").is_none(),
+        "a lifecycle rejection inside the atomic unit must not count an event row"
     );
 
     let profile = observer_pack
@@ -5668,8 +5707,10 @@ mod adr081_retune_driver_tests {
         .await
         .expect("record_serve");
 
-        let first = pack
-            .dispatch(
+        let first_usage = khive_storage::usage::UsageContext::new();
+        let first = khive_storage::usage::scope(
+            first_usage.clone(),
+            pack.dispatch(
                 "brain.feedback",
                 json!({
                     "target_id": target,
@@ -5679,15 +5720,19 @@ mod adr081_retune_driver_tests {
                 }),
                 &registry,
                 &token,
-            )
-            .await
-            .expect("first emit must succeed");
+            ),
+        )
+        .await
+        .expect("first emit must succeed");
         assert_eq!(first["emitted"], json!(true));
+        assert_eq!(first_usage.snapshot()["event_rows"], json!(1u64));
 
         let sal_beta_after_first = pack.snapshot().balanced_recall.salience.beta();
 
-        let second = pack
-            .dispatch(
+        let second_usage = khive_storage::usage::UsageContext::new();
+        let second = khive_storage::usage::scope(
+            second_usage.clone(),
+            pack.dispatch(
                 "brain.feedback",
                 json!({
                     "target_id": target,
@@ -5697,15 +5742,20 @@ mod adr081_retune_driver_tests {
                 }),
                 &registry,
                 &token,
-            )
-            .await
-            .expect("duplicate emit must be a no-op, not an error");
+            ),
+        )
+        .await
+        .expect("duplicate emit must be a no-op, not an error");
         assert_eq!(
             second["deduped"],
             json!(true),
             "second emit with the same (scorer_run_id, serve_ledger_id) must be deduped"
         );
         assert_eq!(second["emitted"], json!(false));
+        assert!(
+            second_usage.snapshot().get("event_rows").is_none(),
+            "deduped feedback must not count an event row"
+        );
 
         let sal_beta_after_second = pack.snapshot().balanced_recall.salience.beta();
         assert_eq!(
@@ -6354,16 +6404,23 @@ mod durable_write_tests {
                 .expect("drop brain_profile_snapshots to simulate schema drift");
         }
 
-        let err = pack
-            .dispatch(
+        let usage = khive_storage::usage::UsageContext::new();
+        let err = khive_storage::usage::scope(
+            usage.clone(),
+            pack.dispatch(
                 "brain.feedback",
                 json!({"target_id": target, "signal": "useful"}),
                 &registry,
                 &token,
-            )
-            .await
-            .expect_err("brain.feedback must fail when brain-specific persistence fails");
+            ),
+        )
+        .await
+        .expect_err("brain.feedback must fail when brain-specific persistence fails");
         let _ = err;
+        assert!(
+            usage.snapshot().get("event_rows").is_none(),
+            "a rolled-back feedback append must not count an event row"
+        );
 
         let total_after = pack.snapshot().balanced_recall.total_events;
         assert_eq!(

--- a/crates/khive-pack-brain/src/tests.rs
+++ b/crates/khive-pack-brain/src/tests.rs
@@ -4154,6 +4154,148 @@ async fn stale_pack_mutation_rebases_on_durable_snapshot() {
 }
 
 #[tokio::test]
+async fn feedback_revalidates_lifecycle_inside_cross_process_transaction() {
+    use khive_storage::types::{SqlStatement, SqlValue};
+    use std::sync::Arc;
+    use tokio::sync::oneshot;
+
+    struct HookGuard;
+    impl Drop for HookGuard {
+        fn drop(&mut self) {
+            crate::pack::clear_feedback_precommit_hook();
+        }
+    }
+    let _guard = HookGuard;
+
+    let dir = tempfile::tempdir().expect("tempdir");
+    let config = khive_runtime::RuntimeConfig {
+        db_path: Some(dir.path().join("feedback-archive-race.db")),
+        ..khive_runtime::RuntimeConfig::no_embeddings()
+    };
+    let feedback_rt = KhiveRuntime::new(config.clone()).expect("feedback runtime");
+    let archive_rt = KhiveRuntime::new(config.clone()).expect("archive runtime");
+    let observer_rt = KhiveRuntime::new(config).expect("observer runtime");
+    let feedback_pack = Arc::new(BrainPack::new(feedback_rt.clone()));
+    let archive_pack = BrainPack::new(archive_rt.clone());
+    let observer_pack = BrainPack::new(observer_rt.clone());
+    let registry = Arc::new(empty_registry());
+    let feedback_token = Arc::new(
+        feedback_rt
+            .authorize(Namespace::local())
+            .expect("feedback token"),
+    );
+    let archive_token = archive_rt
+        .authorize(Namespace::local())
+        .expect("archive token");
+    let observer_token = observer_rt
+        .authorize(Namespace::local())
+        .expect("observer token");
+    let profile_id = "feedback-archive-race-profile";
+
+    feedback_pack
+        .dispatch(
+            "brain.create_profile",
+            json!({"name": profile_id, "consumer_kind": "recall"}),
+            &registry,
+            &feedback_token,
+        )
+        .await
+        .expect("create feedback profile");
+    archive_pack
+        .dispatch("brain.profiles", json!({}), &registry, &archive_token)
+        .await
+        .expect("archive runtime observes profile");
+    let target = create_test_entity(&feedback_rt, &feedback_token).await;
+
+    let (reached_tx, reached_rx) = oneshot::channel();
+    let (proceed_tx, proceed_rx) = oneshot::channel();
+    crate::pack::set_feedback_precommit_hook(crate::pack::FeedbackPrecommitHook {
+        profile_id: profile_id.to_string(),
+        reached_tx,
+        proceed_rx,
+    });
+
+    let feedback_pack_task = Arc::clone(&feedback_pack);
+    let feedback_token_task = Arc::clone(&feedback_token);
+    let registry_task = Arc::clone(&registry);
+    let target_for_task = target.clone();
+    let feedback_task = tokio::spawn(async move {
+        feedback_pack_task
+            .dispatch(
+                "brain.feedback",
+                json!({
+                    "target_id": target_for_task,
+                    "signal": "implicit_positive",
+                    "served_by_profile_id": profile_id,
+                }),
+                &registry_task,
+                &feedback_token_task,
+            )
+            .await
+    });
+
+    reached_rx
+        .await
+        .expect("feedback reaches post-preflight hook");
+    archive_pack
+        .dispatch(
+            "brain.archive",
+            json!({"profile_id": profile_id}),
+            &registry,
+            &archive_token,
+        )
+        .await
+        .expect("peer archives inactive profile");
+    proceed_tx.send(()).expect("release feedback transaction");
+
+    let error = feedback_task
+        .await
+        .expect("feedback task joins")
+        .expect_err("rebased feedback must reject the archived profile");
+    assert!(
+        matches!(error, RuntimeError::InvalidInput(ref message) if message.contains("archived")),
+        "rebased feedback rejection must report the archived lifecycle: {error:?}"
+    );
+
+    let profile = observer_pack
+        .dispatch(
+            "brain.profile",
+            json!({"profile_id": profile_id}),
+            &registry,
+            &observer_token,
+        )
+        .await
+        .expect("observer reads archived profile");
+    assert_eq!(profile["lifecycle"], json!("archived"));
+    assert_eq!(profile["total_events"], json!(0u64));
+
+    let mut reader = observer_rt.sql().reader().await.expect("observer reader");
+    let row = reader
+        .query_row(SqlStatement {
+            sql: "SELECT \
+                    (SELECT COUNT(*) FROM events \
+                     WHERE namespace = ?1 AND verb = 'brain.feedback') AS public_events, \
+                    (SELECT COUNT(*) FROM brain_event_log \
+                     WHERE namespace = ?1 AND event_kind = 'brain.feedback') AS private_events, \
+                    (SELECT COUNT(*) FROM brain_implicit_mass \
+                     WHERE namespace = ?1 AND profile_id = ?2 AND target_id = ?3) AS mass_rows"
+                .into(),
+            params: vec![
+                SqlValue::Text(observer_token.namespace().as_str().to_string()),
+                SqlValue::Text(profile_id.to_string()),
+                SqlValue::Text(target),
+            ],
+            label: Some("brain_test_feedback_archive_race_counts".into()),
+        })
+        .await
+        .expect("read feedback side-effect counts")
+        .expect("count row");
+    assert_eq!(row.get("public_events"), Some(&SqlValue::Integer(0)));
+    assert_eq!(row.get("private_events"), Some(&SqlValue::Integer(0)));
+    assert_eq!(row.get("mass_rows"), Some(&SqlValue::Integer(0)));
+}
+
+#[tokio::test]
 async fn matching_generation_reuses_local_snapshot_without_decoding_durable_json() {
     use khive_storage::types::{SqlStatement, SqlValue};
 

--- a/docs/adr/ADR-032-brain-profile-orchestration.md
+++ b/docs/adr/ADR-032-brain-profile-orchestration.md
@@ -673,6 +673,10 @@ concurrent writers serialize as read-current → mutate → write-current instea
 stale full-state blob to win last. The event and replacement snapshot use the same
 transaction timestamp, monotonically raised above the prior snapshot timestamp when
 necessary, so lock wait order cannot move the event-replay boundary backward.
+For `brain.feedback`, profile existence and the non-`Archived` lifecycle precondition are checked
+against that rebased state. Only after they pass may the same transaction write the implicit-mass
+fold/dedup claim (when applicable), public `FeedbackExplicit` event, private brain event, and
+replacement snapshot. Rejection therefore commits none of those feedback side effects.
 
 The snapshot row's monotonically-raised `updated_at` is the durable namespace generation.
 Every brain dispatch compares it with the generation represented by its in-memory state. An
@@ -1092,7 +1096,9 @@ from the moment it is created. The built-in `balanced-recall-v1` profile uses th
   and syncs `total_events` + `state_snapshot` to the record.
 - If `served_by_profile_id` is absent, feedback defaults to `balanced-recall-v1`.
 - Archived profiles are rejected on the feedback write path (not just the lifecycle-transition
-  path) — `served_by_profile_id` pointing at an archived profile returns `InvalidInput`.
+  path) — `served_by_profile_id` pointing at an archived profile returns `InvalidInput`. The
+  decisive lifecycle check uses the latest snapshot inside the feedback write transaction, so a
+  peer archive cannot race a warm process-local check and still receive posterior credit.
 
 ### 12. Brain registers as a pack
 

--- a/docs/adr/ADR-032-brain-profile-orchestration.md
+++ b/docs/adr/ADR-032-brain-profile-orchestration.md
@@ -663,9 +663,24 @@ lattice/LoRA rerank call site ships.
 This remains the right separation for a future consumer: durable state would stay in
 one transactional backend, while the portable format serves sharing, training import,
 and audit. Durable handler-owned mutations use the private `brain_event_log` and JSON
-snapshot path above. The best-effort `DispatchHook` mutates in-memory state only; it
-performs no event append or snapshot write and has no durability, cursor, or
-replay-atomicity guarantee.
+snapshot path above. A handler mutation acquires the SQLite write transaction first,
+reads the latest namespace generation inside that transaction, applies its mutation, and
+then appends the private event plus the replacement snapshot atomically. A process-local
+registry may supply the base only when its recorded generation exactly matches the durable
+row read inside the transaction; a mismatch loads and validates the durable snapshot payload
+before rebasing on it. This makes
+concurrent writers serialize as read-current → mutate → write-current instead of allowing a
+stale full-state blob to win last. The event and replacement snapshot use the same
+transaction timestamp, monotonically raised above the prior snapshot timestamp when
+necessary, so lock wait order cannot move the event-replay boundary backward.
+
+The snapshot row's monotonically-raised `updated_at` is the durable namespace generation.
+Every brain dispatch compares it with the generation represented by its in-memory state. An
+advance invalidates the warm copy and reloads the durable snapshot, so profiles and bindings
+committed by another process become visible without restart. The best-effort `DispatchHook`
+mutates in-memory state only; it performs no event append or snapshot write and has no
+durability, cursor, or replay-atomicity guarantee. A durable generation advance may therefore
+replace hook-only local state by design.
 
 #### 6.1 Versioned `ModuleName` enum
 


### PR DESCRIPTION
## Summary

- refresh brain profile and binding snapshots when another process advances the durable generation
- rebase mutations on the authoritative snapshot inside the write transaction, preventing stale-writer clobbering and TOCTOU lifecycle races
- commit feedback events, fold/dedup mass, posterior state, and the snapshot as one atomic unit
- count event-row usage only after a public feedback event actually commits
- add cross-process visibility, stale-writer, archive-race, rollback, and accounting regressions

## Validation

- `cargo test --manifest-path crates/Cargo.toml --workspace`
- `cargo check --manifest-path crates/Cargo.toml --workspace`
- `cargo clippy --manifest-path crates/Cargo.toml --workspace --all-targets -- -D warnings`
- `RUSTDOCFLAGS=-Dwarnings cargo doc --manifest-path crates/Cargo.toml --workspace --no-deps`
- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- ADR reference lint, stub-marker lint, Deno formatting check, and independent review

Closes #1500

> AI-assisted contribution: Codex prepared this change and PR description.
