### PR TITLE
fix(code): quarantine secret-gate refusals in code.ingest

### DIFF
--- a/crates/khive-pack-code/src/manifest.rs
+++ b/crates/khive-pack-code/src/manifest.rs
@@ -33,6 +33,10 @@ const SKIP_DIRS: &[&str] = &[
 #[derive(Debug, Clone)]
 pub(crate) struct ManifestProject {
     pub root: PathBuf,
+    /// The governing manifest file itself (`root` + the per-language
+    /// filename). Diagnostic labels must use this, never content-derived
+    /// names (#1594 quarantine reports).
+    pub manifest_path: PathBuf,
     pub name: String,
     pub language: &'static str,
     /// `(dependency_name, dependency_kind)`.
@@ -124,6 +128,7 @@ pub(crate) fn parse_cargo_toml(root: &Path, text: &str) -> Option<ManifestProjec
 
     Some(ManifestProject {
         root: root.to_path_buf(),
+        manifest_path: root.join("Cargo.toml"),
         name,
         language: "rust",
         dependencies,
@@ -178,6 +183,7 @@ pub(crate) fn parse_pyproject_toml(root: &Path, text: &str) -> Option<ManifestPr
 
     Some(ManifestProject {
         root: root.to_path_buf(),
+        manifest_path: root.join("pyproject.toml"),
         name,
         language: "python",
         dependencies,
@@ -205,6 +211,7 @@ pub(crate) fn parse_package_json(root: &Path, text: &str) -> Option<ManifestProj
 
     Some(ManifestProject {
         root: root.to_path_buf(),
+        manifest_path: root.join("package.json"),
         name,
         language: "typescript",
         dependencies,

--- a/crates/khive-pack-code/src/source_ingest.rs
+++ b/crates/khive-pack-code/src/source_ingest.rs
@@ -715,7 +715,7 @@ pub async fn run_code_ingest(
 
     let mut project_ids: HashMap<String, Uuid> = HashMap::new();
     for m in &manifests {
-        let file_label = m.root.display().to_string();
+        let file_label = m.manifest_path.display().to_string();
         let Some(id) = upsert_project(
             rt,
             token,
@@ -830,7 +830,10 @@ async fn run_import_scan(
         let proj_id = match project_ids.get(&proj_name) {
             Some(id) => *id,
             None => {
-                let proj_label = proj_root.display().to_string();
+                // Label a refused fallback-project write by the source file
+                // whose scan triggered it — a real on-disk location, never
+                // the content-derived project name (#1594).
+                let proj_label = file_label.clone();
                 let Some(id) = upsert_project(
                     rt,
                     token,

--- a/crates/khive-pack-code/src/source_ingest.rs
+++ b/crates/khive-pack-code/src/source_ingest.rs
@@ -2,7 +2,7 @@
 //! (ADR-085 Amendment 2 B3-B6). L2 Scanner/Extractor is out of scope (PR-2).
 //!
 //! Every entity write in this pipeline runs through the runtime secret gate
-//! (ADR-085 D6 #4) via [`upsert_entity`]. A gate refusal quarantines that one
+//! (ADR-085 D6 #4) via `upsert_entity`. A gate refusal quarantines that one
 //! item — it is recorded in [`CodeSourceIngestReport::blocked`] and skipped —
 //! rather than aborting the rest of the sweep (issue #1594), the same
 //! per-record posture `git.digest` already uses for its own write refusals.

--- a/crates/khive-pack-code/src/source_ingest.rs
+++ b/crates/khive-pack-code/src/source_ingest.rs
@@ -1,6 +1,12 @@
 //! `code.ingest` L1 (manifest edges) + L1.5 (import-scan edges) core pipeline
 //! (ADR-085 Amendment 2 B3-B6). L2 Scanner/Extractor is out of scope (PR-2).
 //!
+//! Every entity write in this pipeline runs through the runtime secret gate
+//! (ADR-085 D6 #4) via [`upsert_entity`]. A gate refusal quarantines that one
+//! item — it is recorded in [`CodeSourceIngestReport::blocked`] and skipped —
+//! rather than aborting the rest of the sweep (issue #1594), the same
+//! per-record posture `git.digest` already uses for its own write refusals.
+//!
 //! Identity (B4): every entity this pipeline creates has a `uuid5`-derived
 //! id, so re-ingesting the same path is a pure upsert — no dedup lookups are
 //! needed to avoid duplicate rows. Edge ids are likewise `uuid5`-derived from
@@ -15,7 +21,7 @@ use std::fs;
 use std::path::{Path, PathBuf};
 
 use chrono::{DateTime, Utc};
-use khive_runtime::{KhiveRuntime, NamespaceToken, RuntimeError};
+use khive_runtime::{secret_gate, KhiveRuntime, NamespaceToken, RuntimeError};
 use khive_storage::{Edge, Entity, LinkId};
 use khive_types::EdgeRelation;
 use serde_json::{json, Value};
@@ -24,6 +30,20 @@ use uuid::Uuid;
 use crate::imports::{self, Resolved};
 use crate::ingest::CODE_INGEST_NAMESPACE;
 use crate::manifest;
+
+/// One content write the runtime secret gate refused during this pass.
+///
+/// The record's own identity (the manifest/source file it came from) is
+/// kept; the secret itself is represented only by the detector name and a
+/// masked excerpt (`SecretMatch`'s `first6...N` shape) — the rejected
+/// content is never copied into the report. Mirrors `git.digest`'s
+/// `IngestWriteRefusal` (ADR-088 Amendment 1 precedent).
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct BlockedWrite {
+    pub file: String,
+    pub detector: String,
+    pub masked_excerpt: String,
+}
 
 /// Outcome counters for one `code.ingest` call, mirroring `git.digest`'s
 /// `IngestReport` shape (ADR-088 Amendment 1 precedent).
@@ -41,6 +61,14 @@ pub struct CodeSourceIngestReport {
     /// Per-manifest / per-file failures that did not abort the pass (fail
     /// loud without silently dropping the rest of the run).
     pub warnings: Vec<String>,
+    /// Count of per-item content writes refused by the runtime secret gate
+    /// during this pass, independent of unrelated `warnings` (mirrors
+    /// `git.digest`'s `writes_refused`).
+    pub blocked_count: u64,
+    /// Safe structured detail for every entry counted by `blocked_count`
+    /// (issue #1594): a gate-refused write is quarantined and skipped, it
+    /// never aborts the rest of the ingest.
+    pub blocked: Vec<BlockedWrite>,
     pub db_path: String,
 }
 
@@ -131,15 +159,53 @@ async fn get_entity_opt(
         .map_err(|e| CodeSourceIngestError::Storage(e.to_string()))
 }
 
+/// Runs the runtime secret gate over `entity`'s name and properties, the
+/// same content the gate checks for every other write (ADR-085 D6 #4). The
+/// direct storage-layer call `upsert_entity` wraps does not run this check
+/// on its own path, so callers of this pipeline get no gate coverage unless
+/// it happens here.
+fn gate_check(entity: &Entity) -> Result<(), RuntimeError> {
+    secret_gate::check(&entity.name)?;
+    if let Some(properties) = &entity.properties {
+        secret_gate::check_json(properties)?;
+    }
+    Ok(())
+}
+
+/// Upserts `entity` after running it through [`gate_check`]. Returns
+/// `Ok(false)` without writing anything when the gate refuses the entity:
+/// the refusal is recorded in `report.blocked` keyed by `file`, and the
+/// caller moves on to the next item rather than aborting the whole ingest
+/// (issue #1594 — quarantine, don't abort, mirroring `git.digest`'s
+/// per-record refusal handling). Any other `RuntimeError` — not a gate
+/// refusal — still propagates as an error, since only a gate refusal is
+/// safe to treat as "skip this one item and continue".
 async fn upsert_entity(
     rt: &KhiveRuntime,
     token: &NamespaceToken,
     entity: Entity,
-) -> Result<(), CodeSourceIngestError> {
+    file: &str,
+    report: &mut CodeSourceIngestReport,
+) -> Result<bool, CodeSourceIngestError> {
+    if let Err(err) = gate_check(&entity) {
+        return match err {
+            RuntimeError::SecretDetected(secret) => {
+                report.blocked_count += 1;
+                report.blocked.push(BlockedWrite {
+                    file: file.to_string(),
+                    detector: secret.detector.to_string(),
+                    masked_excerpt: secret.masked,
+                });
+                Ok(false)
+            }
+            other => Err(other.into()),
+        };
+    }
     rt.entities(token)?
         .upsert_entity(entity)
         .await
-        .map_err(|e| CodeSourceIngestError::Storage(e.to_string()))
+        .map_err(|e| CodeSourceIngestError::Storage(e.to_string()))?;
+    Ok(true)
 }
 
 /// Upserts the edge and returns `true` when it did not previously exist
@@ -190,6 +256,10 @@ fn ts(dt: DateTime<Utc>) -> i64 {
 /// Upsert (create or refresh) the `project` entity for `name`, merging the
 /// per-`(source_project, language)` sweep clock (B5) with any prior sweeps
 /// for a different language recorded on the same entity.
+///
+/// Returns `Ok(None)` when the runtime secret gate refuses the write (the
+/// refusal is recorded in `report.blocked`, keyed by `name`) — callers must
+/// treat that project as absent from this sweep rather than indexing it.
 async fn upsert_project(
     rt: &KhiveRuntime,
     token: &NamespaceToken,
@@ -197,7 +267,7 @@ async fn upsert_project(
     language: &str,
     sweep_time: DateTime<Utc>,
     report: &mut CodeSourceIngestReport,
-) -> Result<Uuid, CodeSourceIngestError> {
+) -> Result<Option<Uuid>, CodeSourceIngestError> {
     let id = project_uuid(name);
     let existing = get_entity_opt(rt, token, id).await?;
     let is_new = existing.is_none();
@@ -233,16 +303,21 @@ async fn upsert_project(
     let now = ts(sweep_time);
     entity.created_at = existing.as_ref().map(|e| e.created_at).unwrap_or(now);
     entity.updated_at = now;
-    upsert_entity(rt, token, entity).await?;
+    if !upsert_entity(rt, token, entity, name, report).await? {
+        return Ok(None);
+    }
 
     if is_new {
         report.projects_created += 1;
     } else {
         report.projects_updated += 1;
     }
-    Ok(id)
+    Ok(Some(id))
 }
 
+/// Returns `Ok(None)` when the runtime secret gate refuses the write (the
+/// refusal is recorded in `report.blocked`, keyed by `file`) — callers must
+/// treat that module as absent from this sweep rather than indexing it.
 #[allow(clippy::too_many_arguments)]
 async fn upsert_module(
     rt: &KhiveRuntime,
@@ -252,8 +327,9 @@ async fn upsert_module(
     module_path: &str,
     content_hash: &str,
     sweep_time: DateTime<Utc>,
+    file: &str,
     report: &mut CodeSourceIngestReport,
-) -> Result<Uuid, CodeSourceIngestError> {
+) -> Result<Option<Uuid>, CodeSourceIngestError> {
     let id = module_uuid(source_project, language, module_path);
     let existing = get_entity_opt(rt, token, id).await?;
     let is_new = existing.is_none();
@@ -284,25 +360,33 @@ async fn upsert_module(
     let now = ts(sweep_time);
     entity.created_at = existing.as_ref().map(|e| e.created_at).unwrap_or(now);
     entity.updated_at = now;
-    upsert_entity(rt, token, entity).await?;
+    if !upsert_entity(rt, token, entity, file, report).await? {
+        return Ok(None);
+    }
 
     if is_new {
         report.modules_created += 1;
     } else {
         report.modules_updated += 1;
     }
-    Ok(id)
+    Ok(Some(id))
 }
 
 /// Append `spec` to `entity_id`'s `unresolved_specifiers` (deduped), without
 /// disturbing any other property already stamped this sweep (project/module
 /// upsert already ran first, so this always reads back the row this pass
 /// just wrote).
+///
+/// When the gate refuses the updated properties (e.g. `spec.specifier` is
+/// itself secret-shaped), the refusal is recorded in `report.blocked` keyed
+/// by `file` and the specifier is simply not recorded this sweep — the
+/// entity itself is untouched, since `upsert_entity` blocks before writing.
 async fn record_unresolved(
     rt: &KhiveRuntime,
     token: &NamespaceToken,
     entity_id: Uuid,
     spec: UnresolvedSpec,
+    file: &str,
     report: &mut CodeSourceIngestReport,
 ) -> Result<(), CodeSourceIngestError> {
     let Some(mut entity) = get_entity_opt(rt, token, entity_id).await? else {
@@ -317,7 +401,6 @@ async fn record_unresolved(
         return Ok(());
     }
     list.push(spec);
-    report.unresolved_recorded += 1;
     let mut props = entity
         .properties
         .clone()
@@ -328,7 +411,10 @@ async fn record_unresolved(
         serde_json::to_value(&list).expect("serializes"),
     );
     entity.properties = Some(Value::Object(props));
-    upsert_entity(rt, token, entity).await
+    if upsert_entity(rt, token, entity, file, report).await? {
+        report.unresolved_recorded += 1;
+    }
+    Ok(())
 }
 
 /// The path separator a module path uses in each language's native form
@@ -556,7 +642,7 @@ async fn reresolve_pass(
                 );
             }
             entity.properties = Some(Value::Object(props));
-            upsert_entity(rt, token, entity).await?;
+            upsert_entity(rt, token, entity, &source_project, report).await?;
         }
     }
     Ok(())
@@ -624,14 +710,25 @@ pub async fn run_code_ingest(
 
     let mut project_ids: HashMap<String, Uuid> = HashMap::new();
     for m in &manifests {
-        let id =
-            upsert_project(rt, token, &m.name, m.language, opts.sweep_time, &mut report).await?;
+        let Some(id) =
+            upsert_project(rt, token, &m.name, m.language, opts.sweep_time, &mut report).await?
+        else {
+            // Gate-refused write, already recorded in report.blocked — this
+            // project is absent from the sweep, skip it and keep going
+            // (issue #1594).
+            continue;
+        };
         project_ids.insert(m.name.clone(), id);
     }
 
     // L1: manifest dependency edges (project depends_on project).
     for m in &manifests {
-        let source_id = project_ids[&m.name];
+        let Some(&source_id) = project_ids.get(&m.name) else {
+            // This manifest's own project write was gate-refused above;
+            // nothing to hang dependency edges off of this sweep.
+            continue;
+        };
+        let file_label = m.root.display().to_string();
         for (dep_name, dep_kind) in &m.dependencies {
             let spec = UnresolvedSpec {
                 specifier: dep_name.clone(),
@@ -639,7 +736,7 @@ pub async fn run_code_ingest(
                 dependency_kind: dep_kind.clone(),
                 language: m.language.to_string(),
             };
-            record_unresolved(rt, token, source_id, spec, &mut report).await?;
+            record_unresolved(rt, token, source_id, spec, &file_label, &mut report).await?;
         }
     }
 
@@ -714,11 +811,18 @@ async fn run_import_scan(
             continue;
         };
 
+        let file_label = file.display().to_string();
+
         let proj_id = match project_ids.get(&proj_name) {
             Some(id) => *id,
             None => {
-                let id =
-                    upsert_project(rt, token, &proj_name, language, sweep_time, report).await?;
+                let Some(id) =
+                    upsert_project(rt, token, &proj_name, language, sweep_time, report).await?
+                else {
+                    // Gate-refused write, already recorded in report.blocked
+                    // — move on to the next file (issue #1594).
+                    continue;
+                };
                 project_ids.insert(proj_name.clone(), id);
                 id
             }
@@ -734,7 +838,7 @@ async fn run_import_scan(
             }
         };
         let hash = content_hash(&content);
-        let module_id = upsert_module(
+        let Some(module_id) = upsert_module(
             rt,
             token,
             &proj_name,
@@ -742,9 +846,15 @@ async fn run_import_scan(
             &module_path,
             &hash,
             sweep_time,
+            &file_label,
             report,
         )
-        .await?;
+        .await?
+        else {
+            // Gate-refused write, already recorded in report.blocked — move
+            // on to the next file (issue #1594).
+            continue;
+        };
 
         let contains_edge_id = edge_uuid(EdgeRelation::Contains, proj_id, module_id);
         let contains_created = upsert_edge(
@@ -780,7 +890,7 @@ async fn run_import_scan(
                         dependency_kind: "import".to_string(),
                         language: language.to_string(),
                     };
-                    record_unresolved(rt, token, module_id, spec, report).await?;
+                    record_unresolved(rt, token, module_id, spec, &file_label, report).await?;
                 }
                 Resolved::ExternalProject(target_name) => {
                     let spec = UnresolvedSpec {
@@ -789,7 +899,7 @@ async fn run_import_scan(
                         dependency_kind: "import".to_string(),
                         language: language.to_string(),
                     };
-                    record_unresolved(rt, token, proj_id, spec, report).await?;
+                    record_unresolved(rt, token, proj_id, spec, &file_label, report).await?;
                 }
             }
         }

--- a/crates/khive-pack-code/src/source_ingest.rs
+++ b/crates/khive-pack-code/src/source_ingest.rs
@@ -258,12 +258,16 @@ fn ts(dt: DateTime<Utc>) -> i64 {
 /// for a different language recorded on the same entity.
 ///
 /// Returns `Ok(None)` when the runtime secret gate refuses the write (the
-/// refusal is recorded in `report.blocked`, keyed by `name`) — callers must
-/// treat that project as absent from this sweep rather than indexing it.
+/// refusal is recorded in `report.blocked`, keyed by `source_label` — never
+/// by `name`, since `name` is content-derived from the manifest and may
+/// itself be what the gate refused) — callers must treat that project as
+/// absent from this sweep rather than indexing it.
+#[allow(clippy::too_many_arguments)]
 async fn upsert_project(
     rt: &KhiveRuntime,
     token: &NamespaceToken,
     name: &str,
+    source_label: &str,
     language: &str,
     sweep_time: DateTime<Utc>,
     report: &mut CodeSourceIngestReport,
@@ -303,7 +307,7 @@ async fn upsert_project(
     let now = ts(sweep_time);
     entity.created_at = existing.as_ref().map(|e| e.created_at).unwrap_or(now);
     entity.updated_at = now;
-    if !upsert_entity(rt, token, entity, name, report).await? {
+    if !upsert_entity(rt, token, entity, source_label, report).await? {
         return Ok(None);
     }
 
@@ -642,7 +646,8 @@ async fn reresolve_pass(
                 );
             }
             entity.properties = Some(Value::Object(props));
-            upsert_entity(rt, token, entity, &source_project, report).await?;
+            let entity_label = entity.id.to_string();
+            upsert_entity(rt, token, entity, &entity_label, report).await?;
         }
     }
     Ok(())
@@ -710,8 +715,17 @@ pub async fn run_code_ingest(
 
     let mut project_ids: HashMap<String, Uuid> = HashMap::new();
     for m in &manifests {
-        let Some(id) =
-            upsert_project(rt, token, &m.name, m.language, opts.sweep_time, &mut report).await?
+        let file_label = m.root.display().to_string();
+        let Some(id) = upsert_project(
+            rt,
+            token,
+            &m.name,
+            &file_label,
+            m.language,
+            opts.sweep_time,
+            &mut report,
+        )
+        .await?
         else {
             // Gate-refused write, already recorded in report.blocked — this
             // project is absent from the sweep, skip it and keep going
@@ -816,8 +830,17 @@ async fn run_import_scan(
         let proj_id = match project_ids.get(&proj_name) {
             Some(id) => *id,
             None => {
-                let Some(id) =
-                    upsert_project(rt, token, &proj_name, language, sweep_time, report).await?
+                let proj_label = proj_root.display().to_string();
+                let Some(id) = upsert_project(
+                    rt,
+                    token,
+                    &proj_name,
+                    &proj_label,
+                    language,
+                    sweep_time,
+                    report,
+                )
+                .await?
                 else {
                     // Gate-refused write, already recorded in report.blocked
                     // — move on to the next file (issue #1594).

--- a/crates/khive-pack-code/tests/source_ingest.rs
+++ b/crates/khive-pack-code/tests/source_ingest.rs
@@ -479,6 +479,109 @@ async fn gate_blocked_write_is_quarantined_and_siblings_ingest() {
     );
 }
 
+/// `pkg_secret`'s own manifest-declared project name is itself a
+/// secret-shaped string (`scheme://user:pass@host`) — the value the runtime
+/// secret gate refuses is the entity's `name`, not one of its dependencies.
+/// `pkg_ok` is an ordinary sibling project.
+fn write_gate_blocked_project_name_fixture(root: &Path) {
+    let pkg_secret = root.join("pkg_secret");
+    let pkg_ok = root.join("pkg_ok");
+    std::fs::create_dir_all(pkg_secret.join("src")).unwrap();
+    std::fs::create_dir_all(pkg_ok.join("src")).unwrap();
+
+    std::fs::write(
+        pkg_secret.join("Cargo.toml"),
+        "[package]\nname = \"scheme://user:pass@host\"\n",
+    )
+    .unwrap();
+    std::fs::write(pkg_secret.join("src/lib.rs"), "pub fn call_it() {}\n").unwrap();
+
+    std::fs::write(pkg_ok.join("Cargo.toml"), "[package]\nname = \"pkg_ok\"\n").unwrap();
+    std::fs::write(pkg_ok.join("src/lib.rs"), "pub fn helper() {}\n").unwrap();
+}
+
+/// issue #1594 / gate-report label leak: when the *project name itself* is
+/// secret-shaped, the quarantine report's `blocked[].file` must carry the
+/// trusted manifest path, never the refused name — reusing content-derived
+/// identity as a diagnostic label would re-exfiltrate exactly what the gate
+/// just refused. Mirrors `khive-pack-git`'s full-report masking assertion
+/// (`crates/khive-pack-git/tests/acceptance.rs`, `writes_refused` case).
+#[tokio::test]
+async fn gate_blocked_project_name_reports_safe_manifest_path() {
+    let root = TempDir::new().expect("tempdir");
+    write_gate_blocked_project_name_fixture(root.path());
+    let db = root.path().join("gate_blocked_name.db");
+    let rt = rt_at(&db);
+    let token = rt.authorize(Namespace::local()).expect("token");
+
+    let report = run_code_ingest(
+        &rt,
+        &token,
+        CodeSourceIngestOptions {
+            path: root.path(),
+            languages: all_languages(),
+            sweep_time: Utc::now(),
+        },
+    )
+    .await
+    .unwrap_or_else(|e| panic!("ingest must complete despite one gate-blocked write: {e}"));
+
+    // The manifest-tier upsert and the import-scan-tier upsert each attempt
+    // (and independently refuse) the same secret-shaped project name, so
+    // both are quarantined — every entry must still carry the same safe,
+    // trusted manifest path, never the refused name.
+    assert!(
+        !report.blocked.is_empty(),
+        "expected at least one quarantined write, got: {:?}",
+        report.blocked
+    );
+    assert_eq!(
+        report.blocked_count as usize,
+        report.blocked.len(),
+        "blocked_count must match the number of entries in blocked"
+    );
+
+    let expected_path = root.path().join("pkg_secret").display().to_string();
+    for entry in &report.blocked {
+        assert_eq!(
+            entry.file, expected_path,
+            "blocked[].file must be the trusted manifest path, not the refused project name"
+        );
+        assert_eq!(entry.detector, "url-userinfo");
+        assert!(
+            !entry.masked_excerpt.is_empty(),
+            "masked_excerpt must be present"
+        );
+        assert!(
+            !entry.masked_excerpt.contains("user:pass"),
+            "masked excerpt must not echo the credential-shaped span: {}",
+            entry.masked_excerpt
+        );
+    }
+
+    let serialized = serde_json::to_string(&report).expect("CodeSourceIngestReport serializes");
+    assert!(
+        !serialized.contains("user:pass"),
+        "the complete serialized report must never contain the refused credential-shaped \
+         project name: {serialized}"
+    );
+
+    assert!(
+        report.projects_created >= 1,
+        "the unrelated sibling pkg_ok must still be created, got {} (report: {report:?})",
+        report.projects_created
+    );
+    let names = entity_names(&rt).await;
+    assert!(
+        names.iter().any(|n| n == "pkg_ok"),
+        "unrelated sibling pkg_ok must be ingested: {names:?}"
+    );
+    assert!(
+        !names.iter().any(|n| n.contains("user:pass")),
+        "the gate-blocked project name must never be written as an entity: {names:?}"
+    );
+}
+
 #[tokio::test]
 async fn rejects_nonexistent_path() {
     let root = TempDir::new().expect("tempdir");

--- a/crates/khive-pack-code/tests/source_ingest.rs
+++ b/crates/khive-pack-code/tests/source_ingest.rs
@@ -501,10 +501,11 @@ fn write_gate_blocked_project_name_fixture(root: &Path) {
 }
 
 /// issue #1594 / gate-report label leak: when the *project name itself* is
-/// secret-shaped, the quarantine report's `blocked[].file` must carry the
-/// trusted manifest path, never the refused name — reusing content-derived
-/// identity as a diagnostic label would re-exfiltrate exactly what the gate
-/// just refused. Mirrors `khive-pack-git`'s full-report masking assertion
+/// secret-shaped, the quarantine report's `blocked[].file` must carry a
+/// trusted on-disk file location (the governing manifest for the manifest
+/// tier, the triggering source file for the import-scan fallback), never the
+/// refused name — reusing content-derived identity as a diagnostic label
+/// would re-exfiltrate exactly what the gate just refused. Mirrors `khive-pack-git`'s full-report masking assertion
 /// (`crates/khive-pack-git/tests/acceptance.rs`, `writes_refused` case).
 #[tokio::test]
 async fn gate_blocked_project_name_reports_safe_manifest_path() {
@@ -528,25 +529,40 @@ async fn gate_blocked_project_name_reports_safe_manifest_path() {
 
     // The manifest-tier upsert and the import-scan-tier upsert each attempt
     // (and independently refuse) the same secret-shaped project name, so
-    // both are quarantined — every entry must still carry the same safe,
-    // trusted manifest path, never the refused name.
-    assert!(
-        !report.blocked.is_empty(),
-        "expected at least one quarantined write, got: {:?}",
-        report.blocked
-    );
+    // both routes are quarantined, each labeled by its own trusted on-disk
+    // location: the governing manifest file for the manifest tier, the
+    // triggering source file for the import-scan fallback. Asserting the
+    // exact pair proves BOTH routes carry a real file path, never the
+    // refused name and never a bare directory.
     assert_eq!(
         report.blocked_count as usize,
         report.blocked.len(),
         "blocked_count must match the number of entries in blocked"
     );
-
-    let expected_path = root.path().join("pkg_secret").display().to_string();
+    let expected_manifest = root
+        .path()
+        .join("pkg_secret")
+        .join("Cargo.toml")
+        .display()
+        .to_string();
+    let expected_source = root
+        .path()
+        .join("pkg_secret")
+        .join("src")
+        .join("lib.rs")
+        .display()
+        .to_string();
+    let mut blocked_files: Vec<&str> = report.blocked.iter().map(|b| b.file.as_str()).collect();
+    blocked_files.sort_unstable();
+    let mut expected_files = vec![expected_manifest.as_str(), expected_source.as_str()];
+    expected_files.sort_unstable();
+    assert_eq!(
+        blocked_files, expected_files,
+        "blocked[].file must be exactly the manifest file (manifest tier) and the \
+         triggering source file (import-scan fallback): {:?}",
+        report.blocked
+    );
     for entry in &report.blocked {
-        assert_eq!(
-            entry.file, expected_path,
-            "blocked[].file must be the trusted manifest path, not the refused project name"
-        );
         assert_eq!(entry.detector, "url-userinfo");
         assert!(
             !entry.masked_excerpt.is_empty(),

--- a/crates/khive-pack-code/tests/source_ingest.rs
+++ b/crates/khive-pack-code/tests/source_ingest.rs
@@ -113,6 +113,25 @@ async fn edge_fingerprints(rt: &KhiveRuntime) -> Vec<(String, String, String, St
         .collect()
 }
 
+async fn entity_names(rt: &KhiveRuntime) -> Vec<String> {
+    let sql = rt.sql();
+    let mut reader = sql.reader().await.expect("reader");
+    let rows = reader
+        .query_all(SqlStatement {
+            sql: "SELECT name FROM entities WHERE deleted_at IS NULL".into(),
+            params: vec![],
+            label: Some("test_entity_names".into()),
+        })
+        .await
+        .expect("query entity names");
+    rows.into_iter()
+        .filter_map(|r| match r.get("name") {
+            Some(SqlValue::Text(s)) => Some(s.clone()),
+            _ => None,
+        })
+        .collect()
+}
+
 async fn entity_count(rt: &KhiveRuntime) -> i64 {
     let sql = rt.sql();
     let mut reader = sql.reader().await.expect("reader");
@@ -370,6 +389,93 @@ async fn manifestless_rust_folder_uses_basename_fallback() {
             && tgt == "util"
             && kinds == "import"),
         "expected one crate -> util depends_on edge with dependency_kinds=[\"import\"], got: {edges:?}"
+    );
+}
+
+/// `pkg_a` declares a dependency whose name is itself a secret-shaped string
+/// (`scheme://user:pass@host` — the exact url-userinfo pattern the runtime
+/// secret gate blocks, ADR-085 D6 #4). `pkg_b` is an ordinary sibling
+/// project with no such dependency.
+fn write_gate_blocked_dependency_fixture(root: &Path) {
+    let pkg_a = root.join("pkg_a");
+    let pkg_b = root.join("pkg_b");
+    std::fs::create_dir_all(pkg_a.join("src")).unwrap();
+    std::fs::create_dir_all(pkg_b.join("src")).unwrap();
+
+    std::fs::write(
+        pkg_a.join("Cargo.toml"),
+        "[package]\nname = \"pkg_a\"\n\n[dependencies]\n\"scheme://user:pass@host\" = \"0.1\"\n",
+    )
+    .unwrap();
+    std::fs::write(pkg_a.join("src/lib.rs"), "pub fn call_it() {}\n").unwrap();
+
+    std::fs::write(pkg_b.join("Cargo.toml"), "[package]\nname = \"pkg_b\"\n").unwrap();
+    std::fs::write(pkg_b.join("src/lib.rs"), "pub fn helper() {}\n").unwrap();
+}
+
+/// issue #1594: a single secret-gate refusal during `code.ingest` must
+/// quarantine the refused item, not abort the whole pass. `pkg_a`'s
+/// gate-blocked dependency name is recorded in `report.blocked` and skipped;
+/// both `pkg_a`'s own project entity and the unrelated sibling `pkg_b` are
+/// still ingested normally.
+#[tokio::test]
+async fn gate_blocked_write_is_quarantined_and_siblings_ingest() {
+    let root = TempDir::new().expect("tempdir");
+    write_gate_blocked_dependency_fixture(root.path());
+    let db = root.path().join("gate_blocked.db");
+    let rt = rt_at(&db);
+    let token = rt.authorize(Namespace::local()).expect("token");
+
+    let report = run_code_ingest(
+        &rt,
+        &token,
+        CodeSourceIngestOptions {
+            path: root.path(),
+            languages: all_languages(),
+            sweep_time: Utc::now(),
+        },
+    )
+    .await
+    .unwrap_or_else(|e| panic!("ingest must complete despite one gate-blocked write: {e}"));
+
+    assert_eq!(
+        report.blocked.len(),
+        1,
+        "expected exactly one quarantined write, got: {:?}",
+        report.blocked
+    );
+    assert_eq!(
+        report.blocked_count, 1,
+        "blocked_count must match the single entry in blocked"
+    );
+    for entry in &report.blocked {
+        assert_eq!(entry.detector, "url-userinfo");
+        assert!(
+            !entry.masked_excerpt.contains("user:pass"),
+            "masked excerpt must not echo the credential-shaped span: {}",
+            entry.masked_excerpt
+        );
+    }
+
+    assert!(
+        report.projects_created >= 2,
+        "both pkg_a and the unrelated sibling pkg_b must be created, got {} \
+         (report: {report:?})",
+        report.projects_created
+    );
+
+    let names = entity_names(&rt).await;
+    assert!(
+        names.iter().any(|n| n == "pkg_a"),
+        "pkg_a's own project must still be ingested despite its blocked dependency: {names:?}"
+    );
+    assert!(
+        names.iter().any(|n| n == "pkg_b"),
+        "unrelated sibling pkg_b must be ingested: {names:?}"
+    );
+    assert!(
+        !names.iter().any(|n| n.contains("user:pass")),
+        "the gate-blocked dependency name must never be written as an entity: {names:?}"
     );
 }
 


### PR DESCRIPTION
## Summary

`code.ingest`'s entity writes call `EntityStore::upsert_entity` directly, a
raw storage write that never runs the runtime secret gate. This closes that
gap and, at the same time, makes a gate refusal a per-item skip instead of a
pass-aborting error — following the direction in #1594.

- `upsert_entity` (the helper every entity write in this pipeline funnels
  through) now checks the entity's name and properties against the secret
  gate before writing.
- A refusal is recorded as `{file, detector, masked_excerpt}` on a new
  `blocked` array, with a `blocked_count` counter, on `code.ingest`'s
  response. The refused item is skipped; the rest of the sweep continues
  normally. This mirrors `git.digest`'s existing `IngestWriteRefusal` /
  `writes_refused` shape for its own per-record write refusals.
- Callers (`upsert_project`, `upsert_module`, `record_unresolved`) treat a
  blocked write as "this item is absent from the sweep" — they skip building
  dependent edges against it this pass rather than referencing a phantom id.
- Edge writes are unchanged: edge metadata in this pipeline is always
  deterministic, closed-vocabulary content, never free text from a
  repository, so there is nothing there for the gate to catch.

Out of scope for this PR: the gate's detection logic itself is untouched
(no rules loosened), and the placeholder-credential allowlist idea is a
separate, later change.

## Test plan

- [x] New test: a project declares a dependency whose name is itself a
      secret-shaped string (a URL-userinfo pattern). Asserts the ingest call
      still succeeds, the refusal is recorded with the right detector and a
      masked excerpt, the project owning the bad dependency is still
      created, an unrelated sibling project is still ingested, and no entity
      carrying the raw secret string is ever written.
- [x] Existing `code.ingest` integration tests unchanged and expected to
      still pass (idempotency, cross-order convergence, manifestless
      fallback).
- [ ] `make ci` (relying on CI for this run)

Fixes #1594