### PR TITLE
feat(session): ingest claude.ai conversation exports

### DIFF
--- a/crates/khive-pack-session/docs/api/mirror-ingest.md
+++ b/crates/khive-pack-session/docs/api/mirror-ingest.md
@@ -2,8 +2,8 @@
 
 Technical reference for the bounded tail-read ingest algorithm in
 `crates/khive-pack-session/src/mirror/ingest.rs` — how `mirror_file` and
-`mirror_chatgpt_export_file` read, bound, and durably checkpoint session transcripts. The
-`.rs` file keeps the published contract for those two entry points plus short pointers
+the ChatGPT/claude.ai whole-file entry points read, bound, and durably checkpoint session
+transcripts. The `.rs` file keeps the published contract for those entry points plus short pointers
 back to the sections below.
 
 ## Bounded tail-read algorithm (module overview)
@@ -79,7 +79,7 @@ past the cap — bytes beyond it are scanned for `\n` and dropped immediately,
 bounding this function's own resident memory to `max_line_bytes` (plus one
 `BufRead` internal buffer) no matter how long the real line is.
 
-The same bound applies to the number of bytes *read* per call, not just
+The same bound applies to the number of bytes _read_ per call, not just
 buffered: once a line has crossed `max_line_bytes` without a terminating
 `\n`, the very next `fill_buf` window that still has no `\n` returns
 `OversizedUnterminated` immediately rather than looping `fill_buf`/`consume`
@@ -93,6 +93,7 @@ at EOF — instead of scanning the remainder of the file (or forever, on a
 still-growing file) in a single pass.
 
 `LineRead` variants:
+
 - `Eof` — EOF with nothing read at all.
 - `Partial` — EOF reached before a terminating `\n`: an incomplete trailing
   line, left for the next pass. No bytes are considered consumed by the
@@ -138,7 +139,7 @@ export is retried whole on the next tick, never half-consumed.
 
 `DEFAULT_CHATGPT_MAX_BYTES` (256 MiB), overridable via
 `KHIVE_MIRROR_CHATGPT_MAX_BYTES`: unlike the JSONL line-tail sources, this is
-a ceiling on the *entire file*, not a per-pass delta. An export over this
+a ceiling on the _entire file_, not a per-pass delta. An export over this
 size is skipped for that pass (loudly logged via `tracing::warn!`, never a
 crash or an unbounded `read_to_string`), and the cursor is left untouched so
 the oversized source keeps being retried — and re-warned — on every later
@@ -147,10 +148,24 @@ tick instead of silently dropping forever (PACKSESSION-AUD-003).
 zero env values (a zero ceiling would skip every export unconditionally,
 which is never useful, so it is treated the same as unset).
 
+## claude.ai export whole-file re-parse (`mirror_claude_ai_export_file`)
+
+The claude.ai data export uses the same whole-file/cursor algorithm but a
+distinct parser and source value (`claude_ai_export`). Its incompatible
+`conversations.json` shape carries conversation `uuid` values and
+`chat_messages`, so it is never routed through the ChatGPT mapping-tree
+parser. `KHIVE_MIRROR_CLAUDE_AI_MAX_BYTES` independently overrides the same
+256 MiB default ceiling. Parse, IO, or DB failures leave the cursor untouched;
+successful commits advance it to the full file length.
+
+`WholeFileExportSpec` keeps the shared bound/read/commit mechanism in one
+place while fixing the provider-specific parser, source value, diagnostic
+name, and size environment variable at each public entry point.
+
 ## Write path: `write_events_and_cursor` and friends (ADR-099 D5)
 
 `write_events_and_cursor` is shared by `mirror_file`'s eventful line-tail
-path and `mirror_chatgpt_export_file`'s whole-file path, so the
+path and both provider-export whole-file paths, so the
 session/message row construction and cursor semantics (create-only sessions,
 `INSERT OR IGNORE` message dedup, monotonic `last_seen_at`, cursor advances
 only on success) live in exactly one place.
@@ -253,6 +268,9 @@ test-only byte cap forcing multi-pass behavior instead of giant fixtures:
   parsed, not erroring) and the cursor must stay untouched so the oversized
   source is retried — and re-warned — on the next tick rather than silently
   dropped.
+- **claude.ai export over `max_bytes` is skipped without reading**: the same
+  untouched-cursor guarantee is exercised through the claude.ai-specific
+  entry point and source specification.
 
 ### Replay-idempotency invariant
 

--- a/crates/khive-pack-session/docs/api/mirror-ingest.md
+++ b/crates/khive-pack-session/docs/api/mirror-ingest.md
@@ -158,6 +158,11 @@ parser. `KHIVE_MIRROR_CLAUDE_AI_MAX_BYTES` independently overrides the same
 256 MiB default ceiling. Parse, IO, or DB failures leave the cursor untouched;
 successful commits advance it to the full file length.
 
+The claude.ai parser returns conversation metadata separately from retained
+message events. Every valid conversation therefore creates its create-only
+`sessions` row even when `chat_messages` is empty or contains only unsupported
+display blocks; no synthetic `session_messages` row is introduced.
+
 `WholeFileExportSpec` keeps the shared bound/read/commit mechanism in one
 place while fixing the provider-specific parser, source value, diagnostic
 name, and size environment variable at each public entry point.
@@ -186,10 +191,11 @@ entirely — this function must not, and does not, issue its own
 `BEGIN`/`COMMIT`/`ROLLBACK`. Per-section notes:
 
 - **sessions row (create-only)**: first sight of a session creates the row
-  (`first_seen_at = last_seen_at` = this event's timestamp). Replays are a
-  cheap no-op (`DO NOTHING`), so a pass that inserts no new messages writes
-  no session metadata at all — strict replay idempotency. `last_seen_at` is
-  advanced only when a genuinely new message lands.
+  (`first_seen_at = last_seen_at` = the conversation or first event timestamp).
+  Whole-file parsers may supply session metadata before message events, which
+  preserves valid zero-message conversations. Replays are a cheap no-op
+  (`DO NOTHING`), so they do not rewrite existing session metadata;
+  `last_seen_at` is advanced only when a genuinely new message lands.
 - **session_messages insert**: idempotent via `INSERT OR IGNORE` keyed by the
   event UUID.
 - **advance session metadata only when a new message landed**: keeps
@@ -271,6 +277,10 @@ test-only byte cap forcing multi-pass behavior instead of giant fixtures:
 - **claude.ai export over `max_bytes` is skipped without reading**: the same
   untouched-cursor guarantee is exercised through the claude.ai-specific
   entry point and source specification.
+- **claude.ai zero-message conversations remain sessions**: empty
+  `chat_messages` arrays and conversations containing only unsupported display
+  blocks create one idempotent session row, zero message rows, and advance the
+  cursor only in the same successful atomic commit.
 
 ### Replay-idempotency invariant
 

--- a/crates/khive-pack-session/docs/api/mirror-parse.md
+++ b/crates/khive-pack-session/docs/api/mirror-parse.md
@@ -62,6 +62,14 @@ before it becomes a `ParsedEvent`.
 Malformed conversations are skipped individually; invalid JSON or a non-array
 top level returns `None` so the ingest cursor cannot advance.
 
+The ingest-facing `parse_claude_ai_export_with_sessions` result carries one
+`ParsedSession` for every valid conversation separately from its retained
+`ParsedEvent`s. Consequently, an empty `chat_messages` array—or one containing
+only thinking/unknown blocks—still creates the conversation's session metadata
+without manufacturing a message row. The public `parse_claude_ai_export`
+helper remains the event-only view used by parser tests and callers that do not
+need session metadata.
+
 Both provider exports use the filename `conversations.json`. Each parser also
 rejects a file containing the other provider's conversation shape (including a
 mixed file). This keeps one source from advancing the shared path cursor first

--- a/crates/khive-pack-session/docs/api/mirror-parse.md
+++ b/crates/khive-pack-session/docs/api/mirror-parse.md
@@ -1,8 +1,9 @@
 # Session mirror parse
 
-Technical reference for the ChatGPT-export parsing helpers in
-`crates/khive-pack-session/src/mirror/parse.rs` — the DFS conversation walk, per-conversation
-context, and text/block extraction that turn a raw export tree into mirrored session events.
+Technical reference for the provider-export parsing helpers in
+`crates/khive-pack-session/src/mirror/parse.rs` — the conversation walks, per-conversation
+context, and text/block extraction that turn ChatGPT and claude.ai exports into mirrored
+session events.
 
 ## `parse_chatgpt_export` — DFS walk and per-conversation isolation
 
@@ -14,7 +15,7 @@ event across every conversation it contains.
 Returns `None` when `content` is not valid JSON or the top level is not a
 JSON array. The caller treats that as a per-file error so the mirror cursor
 does not advance: a partially-downloaded export is retried whole on the next
-tick, never half-consumed. A malformed *conversation* inside an otherwise-valid
+tick, never half-consumed. A malformed _conversation_ inside an otherwise-valid
 array is skipped individually (`parse_conversation`) so one bad entry cannot
 sink the rest of the file.
 
@@ -32,6 +33,39 @@ that don't change as the DFS walks the mapping tree: `mapping`,
 `conv_created_at_micros` (conversation-level `create_time` in micros, 0 if
 absent — the fallback used when a message's own `create_time` is
 null/absent), and `slug`.
+
+## `parse_claude_ai_export` — `chat_messages` and active branches
+
+A claude.ai export is also a top-level JSON array, but its shape is distinct:
+conversation identity and title are `uuid` and `name`, and messages live in
+`chat_messages`. Each message's `uuid` becomes the event id, the conversation
+`uuid` becomes `session_id` / `provider_session_id`, `human` is normalized to
+the `user` role, and ISO-8601 `created_at` values are converted to microseconds.
+
+Messages are emitted in ascending `index` order with source-array position as
+the deterministic fallback and tie-breaker. When the export supplies
+`current_leaf_message_uuid`, the parser follows `parent_message_uuid` to mark
+the active path and retains other messages as sidechains. Older flat exports
+without an active-leaf field keep every message on the main path. Root
+sentinels and parents that did not produce a stored event become `None`, so
+stored rows never gain a dangling provider-export parent reference.
+
+Visible text comes from structured `content` blocks using the same text,
+voice-note, and tool-block extraction as the CLI parsers; `thinking` and
+unknown internal blocks are not display text. The parser then appends a
+distinct top-level `text` value because agent turns can carry tool blocks and
+a separate final answer at the same time; when `text` exactly duplicates a
+text block it is emitted only once. Older exports that use `role` instead of
+`sender` retain the same user/assistant normalization. Every extracted text
+and serialized raw message is passed through the canonical secret masker
+before it becomes a `ParsedEvent`.
+Malformed conversations are skipped individually; invalid JSON or a non-array
+top level returns `None` so the ingest cursor cannot advance.
+
+Both provider exports use the filename `conversations.json`. Each parser also
+rejects a file containing the other provider's conversation shape (including a
+mixed file). This keeps one source from advancing the shared path cursor first
+if an operator accidentally configures overlapping export roots.
 
 ## `parse_conversation`
 
@@ -64,13 +98,15 @@ message but was itself skipped as an event (e.g. empty-parts scaffolding)
 still counts — this is provenance linkage, matching how CC parent chains can
 reference events that were never mirrored.
 
-## `extract_text` / `extract_block` (Claude Code + Codex block extraction)
+## `extract_text` / `extract_block` (Claude Code, Codex, and claude.ai blocks)
 
 `extract_text` handles both the string form and the structured-block array
 form of a message `content` value.
 
 `extract_block` extracts a display string from a single content block:
+
 - `"text"` — Claude Code plain text block.
+- `"voice_note"` — claude.ai voice-note transcript text.
 - `"input_text"` / `"output_text"` — Codex user and assistant text blocks
   (same field, `text`, as the Claude Code `"text"` block, hence shared
   extraction logic).

--- a/crates/khive-pack-session/src/mirror/ingest.rs
+++ b/crates/khive-pack-session/src/mirror/ingest.rs
@@ -2724,6 +2724,42 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_claude_ai_export_secret_bearing_title_is_masked_in_stored_slug() {
+        let (rt, _dir) = setup().await;
+        let secret = format!("{}{}", "AKIA", "FAKEKEY1234567890");
+        let export = serde_json::to_string(&json!([{
+            "uuid": "claude-conv-secret-title",
+            "name": format!("prod creds {secret}"),
+            "created_at": "2026-07-31T10:00:00Z",
+            "chat_messages": []
+        }]))
+        .unwrap();
+        let (_file, path) = write_export_file(&export);
+
+        mirror_claude_ai_export_file(&rt, &path, 0)
+            .await
+            .expect("secret-title claude.ai conversation ingest");
+        assert_eq!(count_rows(&rt, "sessions").await, 1);
+
+        let sql = rt.sql();
+        let mut reader = sql.reader().await.expect("reader");
+        let session = reader
+            .query_row(SqlStatement {
+                sql: "SELECT slug FROM sessions WHERE id='claude-conv-secret-title'".into(),
+                params: vec![],
+                label: None,
+            })
+            .await
+            .expect("query secret-title session")
+            .expect("secret-title session row");
+        let Some(SqlValue::Text(slug)) = session.get("slug") else {
+            panic!("stored slug must be text");
+        };
+        assert!(!slug.contains(&secret));
+        assert!(slug.contains("***MASKED***"));
+    }
+
+    #[tokio::test]
     async fn test_claude_ai_export_over_max_bytes_leaves_cursor_untouched() {
         let (rt, _dir) = setup().await;
         let (_file, path) = write_export_file("[]");

--- a/crates/khive-pack-session/src/mirror/ingest.rs
+++ b/crates/khive-pack-session/src/mirror/ingest.rs
@@ -399,6 +399,7 @@ async fn mirror_file_with_limits(
         runtime,
         path,
         MirrorSource::from(source).as_str(),
+        &[],
         &chunk.events,
         chunk.scanned,
         chunk.new_offset,
@@ -418,15 +419,22 @@ const DEFAULT_CLAUDE_AI_MAX_BYTES: u64 = 256 * 1024 * 1024;
 #[derive(Clone, Copy)]
 struct WholeFileExportSpec {
     source: MirrorSource,
-    parser: fn(&str) -> Option<Vec<parse::ParsedEvent>>,
+    parser: fn(&str) -> Option<parse::ParsedExport>,
     operation: &'static str,
     format_name: &'static str,
     max_bytes_env: &'static str,
 }
 
+fn parse_chatgpt_export_for_ingest(content: &str) -> Option<parse::ParsedExport> {
+    parse::parse_chatgpt_export(content).map(|events| parse::ParsedExport {
+        sessions: Vec::new(),
+        events,
+    })
+}
+
 const CHATGPT_EXPORT_SPEC: WholeFileExportSpec = WholeFileExportSpec {
     source: MirrorSource::ChatGptExport,
-    parser: parse::parse_chatgpt_export,
+    parser: parse_chatgpt_export_for_ingest,
     operation: "mirror_chatgpt_export_file",
     format_name: "ChatGPT",
     max_bytes_env: "KHIVE_MIRROR_CHATGPT_MAX_BYTES",
@@ -434,7 +442,7 @@ const CHATGPT_EXPORT_SPEC: WholeFileExportSpec = WholeFileExportSpec {
 
 const CLAUDE_AI_EXPORT_SPEC: WholeFileExportSpec = WholeFileExportSpec {
     source: MirrorSource::ClaudeAiExport,
-    parser: parse::parse_claude_ai_export,
+    parser: parse::parse_claude_ai_export_with_sessions,
     operation: "mirror_claude_ai_export_file",
     format_name: "claude.ai",
     max_bytes_env: "KHIVE_MIRROR_CLAUDE_AI_MAX_BYTES",
@@ -566,27 +574,29 @@ async fn mirror_whole_file_export(
         RuntimeError::Internal(format!("{}: failed to read {path:?}: {e}", spec.operation))
     })?;
 
-    let events = (spec.parser)(&content).ok_or_else(|| {
+    let parsed = (spec.parser)(&content).ok_or_else(|| {
         RuntimeError::Internal(format!(
             "{}: {path:?} is not a valid {} export (expected its conversations.json array shape)",
             spec.operation, spec.format_name
         ))
     })?;
 
-    let scanned = events.len() as u64;
+    let scanned = parsed.events.len() as u64;
 
     write_events_and_cursor(
         runtime,
         path,
         spec.source.as_str(),
-        &events,
+        &parsed.sessions,
+        &parsed.events,
         scanned,
         file_len,
     )
     .await
 }
 
-/// Upsert `events` and the mirror cursor for `path` in one transaction.
+/// Upsert explicit sessions, `events`, and the mirror cursor for `path` in one
+/// transaction.
 /// Shared by `mirror_file`'s line-tail path and both provider-export
 /// whole-file paths. See
 /// `crates/khive-pack-session/docs/api/mirror-ingest.md#write-path-write_events_and_cursor-and-friends-adr-099-d5`
@@ -595,6 +605,7 @@ async fn write_events_and_cursor(
     runtime: &KhiveRuntime,
     path: &Path,
     source_value: &'static str,
+    sessions: &[parse::ParsedSession],
     events: &[parse::ParsedEvent],
     scanned: u64,
     new_offset: u64,
@@ -602,6 +613,7 @@ async fn write_events_and_cursor(
     let now_us = Utc::now().timestamp_micros();
     let sql = runtime.sql();
 
+    let sessions_owned: Vec<parse::ParsedSession> = sessions.to_vec();
     let events_owned: Vec<parse::ParsedEvent> = events.to_vec();
     let path_owned: PathBuf = path.to_path_buf();
 
@@ -611,6 +623,7 @@ async fn write_events_and_cursor(
                 writer,
                 &path_owned,
                 source_value,
+                &sessions_owned,
                 &events_owned,
                 scanned,
                 new_offset,
@@ -638,6 +651,60 @@ async fn write_events_and_cursor(
     }))
 }
 
+/// Create one session row without mutating an existing session. This accepts
+/// metadata separately from [`parse::ParsedEvent`] so whole-file exports can
+/// persist valid zero-message conversations.
+#[allow(clippy::too_many_arguments)]
+async fn ensure_session_on_writer(
+    writer: &mut dyn SqlWriter,
+    source_value: &'static str,
+    session_id: &str,
+    cwd: Option<&str>,
+    git_branch: Option<&str>,
+    slug: Option<&str>,
+    created_at_micros: i64,
+    now_us: i64,
+) -> khive_storage::types::StorageResult<()> {
+    let created_at = if created_at_micros != 0 {
+        created_at_micros
+    } else {
+        now_us
+    };
+
+    writer
+        .execute(SqlStatement {
+            sql: format!(
+                "INSERT INTO sessions \
+                  (id, provider_session_id, source, cwd, git_branch, slug, \
+                   message_count, first_seen_at, last_seen_at, namespace) \
+                  VALUES(?1, ?1, '{}', ?2, ?3, ?4, 0, ?5, ?5, 'local') \
+                  ON CONFLICT(id) DO NOTHING",
+                source_value
+            ),
+            params: vec![
+                SqlValue::Text(session_id.to_string()),
+                cwd.map(|s| SqlValue::Text(s.to_string()))
+                    .unwrap_or(SqlValue::Null),
+                git_branch
+                    .map(|s| SqlValue::Text(s.to_string()))
+                    .unwrap_or(SqlValue::Null),
+                slug.map(|s| SqlValue::Text(s.to_string()))
+                    .unwrap_or(SqlValue::Null),
+                SqlValue::Integer(created_at),
+            ],
+            label: Some("session_mirror_create_session".into()),
+        })
+        .await
+        .map_err(|e| {
+            khive_storage::StorageError::driver(
+                khive_storage::StorageCapability::Sql,
+                "mirror: session create",
+                e,
+            )
+        })?;
+    Ok(())
+}
+
 /// The synchronous-DML body of `write_events_and_cursor`, run inside one
 /// `atomic_unit` closure. Takes a plain `&mut dyn SqlWriter` (not `&mut dyn
 /// SqlTransaction`) because `atomic_unit` owns the transaction boundary
@@ -647,6 +714,7 @@ async fn write_events_and_cursor_on_writer(
     writer: &mut dyn SqlWriter,
     path: &Path,
     source_value: &'static str,
+    sessions: &[parse::ParsedSession],
     events: &[parse::ParsedEvent],
     scanned: u64,
     new_offset: u64,
@@ -654,6 +722,27 @@ async fn write_events_and_cursor_on_writer(
 ) -> khive_storage::types::StorageResult<MirrorStats> {
     let mut inserted: u64 = 0;
     let mut last_session_id: Option<String> = None;
+    let mut ensured_session_ids = std::collections::HashSet::new();
+
+    // Whole-file parsers can identify a valid conversation independently of
+    // whether any of its messages produce displayable events. Create those
+    // session rows first, within the same atomic unit as messages and cursor.
+    for session in sessions {
+        if !ensured_session_ids.insert(session.session_id.clone()) {
+            continue;
+        }
+        ensure_session_on_writer(
+            writer,
+            source_value,
+            &session.session_id,
+            session.cwd.as_deref(),
+            session.git_branch.as_deref(),
+            session.slug.as_deref(),
+            session.created_at_micros,
+            now_us,
+        )
+        .await?;
+    }
 
     for ev in events {
         let created_at = if ev.created_at_micros != 0 {
@@ -664,42 +753,19 @@ async fn write_events_and_cursor_on_writer(
 
         // sessions row: create-only (see docs guide — replay is a no-op via
         // `DO NOTHING`; `last_seen_at` advances below only on a new message).
-        writer
-            .execute(SqlStatement {
-                sql: format!(
-                    "INSERT INTO sessions \
-                      (id, provider_session_id, source, cwd, git_branch, slug, \
-                       message_count, first_seen_at, last_seen_at, namespace) \
-                      VALUES(?1, ?1, '{}', ?2, ?3, ?4, 0, ?5, ?5, 'local') \
-                      ON CONFLICT(id) DO NOTHING",
-                    source_value
-                ),
-                params: vec![
-                    SqlValue::Text(ev.session_id.clone()),
-                    ev.cwd
-                        .as_deref()
-                        .map(|s| SqlValue::Text(s.to_string()))
-                        .unwrap_or(SqlValue::Null),
-                    ev.git_branch
-                        .as_deref()
-                        .map(|s| SqlValue::Text(s.to_string()))
-                        .unwrap_or(SqlValue::Null),
-                    ev.slug
-                        .as_deref()
-                        .map(|s| SqlValue::Text(s.to_string()))
-                        .unwrap_or(SqlValue::Null),
-                    SqlValue::Integer(created_at),
-                ],
-                label: Some("session_mirror_create_session".into()),
-            })
-            .await
-            .map_err(|e| {
-                khive_storage::StorageError::driver(
-                    khive_storage::StorageCapability::Sql,
-                    "mirror: session create",
-                    e,
-                )
-            })?;
+        if ensured_session_ids.insert(ev.session_id.clone()) {
+            ensure_session_on_writer(
+                writer,
+                source_value,
+                &ev.session_id,
+                ev.cwd.as_deref(),
+                ev.git_branch.as_deref(),
+                ev.slug.as_deref(),
+                ev.created_at_micros,
+                now_us,
+            )
+            .await?;
+        }
 
         // session_messages insert, idempotent via INSERT OR IGNORE.
         let affected = writer
@@ -2527,6 +2593,125 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_claude_ai_empty_conversation_creates_session_and_advances_cursor() {
+        let (rt, _dir) = setup().await;
+        let export = serde_json::to_string(&json!([{
+            "uuid": "claude-conv-empty",
+            "name": "Empty Claude Conversation",
+            "created_at": "2026-07-31T10:00:00Z",
+            "chat_messages": []
+        }]))
+        .unwrap();
+        let (_file, path) = write_export_file(&export);
+        let file_len = std::fs::metadata(&path).unwrap().len();
+
+        let first = mirror_claude_ai_export_file(&rt, &path, 0)
+            .await
+            .expect("empty claude.ai conversation ingest");
+        assert_eq!(first.inserted, 0);
+        assert_eq!(first.scanned, 0);
+        assert_eq!(first.new_offset, file_len);
+        assert_eq!(count_rows(&rt, "sessions").await, 1);
+        assert_eq!(count_rows(&rt, "session_messages").await, 0);
+        assert_eq!(
+            cursor_offset(&rt, &path.to_string_lossy()).await,
+            Some(file_len as i64)
+        );
+
+        let replay = mirror_claude_ai_export_file(&rt, &path, 0)
+            .await
+            .expect("empty conversation replay");
+        assert_eq!(replay.inserted, 0);
+        assert_eq!(count_rows(&rt, "sessions").await, 1);
+
+        let sql = rt.sql();
+        let mut reader = sql.reader().await.expect("reader");
+        let session = reader
+            .query_row(SqlStatement {
+                sql: "SELECT provider_session_id, source, slug, message_count \
+                      FROM sessions WHERE id='claude-conv-empty'"
+                    .into(),
+                params: vec![],
+                label: None,
+            })
+            .await
+            .expect("query empty session")
+            .expect("empty session row");
+        assert!(matches!(
+            session.get("provider_session_id"),
+            Some(SqlValue::Text(value)) if value == "claude-conv-empty"
+        ));
+        assert!(matches!(
+            session.get("source"),
+            Some(SqlValue::Text(value)) if value == "claude_ai_export"
+        ));
+        assert!(matches!(
+            session.get("slug"),
+            Some(SqlValue::Text(value)) if value == "Empty Claude Conversation"
+        ));
+        assert!(matches!(
+            session.get("message_count"),
+            Some(SqlValue::Integer(0))
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_claude_ai_unsupported_only_conversation_creates_session() {
+        let (rt, _dir) = setup().await;
+        let export = serde_json::to_string(&json!([{
+            "uuid": "claude-conv-internal-only",
+            "summary": "Internal-only Claude Conversation",
+            "updated_at": "2026-07-31T10:00:00Z",
+            "chat_messages": [{
+                "uuid": "claude-msg-internal-only",
+                "sender": "assistant",
+                "content": [
+                    {"type": "thinking", "thinking": "not display text"},
+                    {"type": "provider_internal", "payload": {"hidden": true}}
+                ]
+            }]
+        }]))
+        .unwrap();
+        let (_file, path) = write_export_file(&export);
+        let file_len = std::fs::metadata(&path).unwrap().len();
+
+        let stats = mirror_claude_ai_export_file(&rt, &path, 0)
+            .await
+            .expect("unsupported-only claude.ai conversation ingest");
+        assert_eq!(stats.inserted, 0);
+        assert_eq!(stats.scanned, 0);
+        assert_eq!(stats.new_offset, file_len);
+        assert_eq!(count_rows(&rt, "sessions").await, 1);
+        assert_eq!(count_rows(&rt, "session_messages").await, 0);
+        assert_eq!(
+            cursor_offset(&rt, &path.to_string_lossy()).await,
+            Some(file_len as i64)
+        );
+
+        let sql = rt.sql();
+        let mut reader = sql.reader().await.expect("reader");
+        let session = reader
+            .query_row(SqlStatement {
+                sql: "SELECT slug, message_count FROM sessions \
+                      WHERE id='claude-conv-internal-only'"
+                    .into(),
+                params: vec![],
+                label: None,
+            })
+            .await
+            .expect("query unsupported-only session")
+            .expect("unsupported-only session row");
+        assert!(matches!(
+            session.get("slug"),
+            Some(SqlValue::Text(value)) if value == "Internal-only Claude Conversation"
+        ));
+        assert!(matches!(
+            session.get("message_count"),
+            Some(SqlValue::Integer(0))
+        ));
+    }
+
+    #[tokio::test]
     async fn test_claude_ai_export_over_max_bytes_leaves_cursor_untouched() {
         let (rt, _dir) = setup().await;
         let (_file, path) = write_export_file("[]");
@@ -2654,6 +2839,7 @@ mod tests {
                     writer,
                     &path,
                     "claude_code",
+                    &[],
                     &events,
                     1,
                     100,
@@ -2751,6 +2937,7 @@ mod tests {
                     writer,
                     &path,
                     "claude_code",
+                    &[],
                     &events,
                     1,
                     100,

--- a/crates/khive-pack-session/src/mirror/ingest.rs
+++ b/crates/khive-pack-session/src/mirror/ingest.rs
@@ -25,9 +25,9 @@ use super::parse;
 /// "Mirror sources — closed set"). Adding a source requires amending that ADR
 /// section and this enum together.
 ///
-/// This is a superset of [`LineTailSource`]: `ChatGptExport` ingests via
-/// whole-file re-parse (`mirror_chatgpt_export_file`), not the per-line
-/// dispatch `LineTailSource` selects, so it has no `LineTailSource` variant.
+/// This is a superset of [`LineTailSource`]: the provider export variants
+/// ingest via whole-file re-parse, not the per-line dispatch
+/// `LineTailSource` selects, so they have no `LineTailSource` variants.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum MirrorSource {
     /// Claude Code (`~/.claude/projects/<slug>/<uuid>.jsonl`).
@@ -36,6 +36,8 @@ pub enum MirrorSource {
     Codex,
     /// ChatGPT data export (`<exports dir>/**/conversations.json`).
     ChatGptExport,
+    /// claude.ai data export (`<exports dir>/**/conversations.json`).
+    ClaudeAiExport,
 }
 
 impl MirrorSource {
@@ -45,6 +47,7 @@ impl MirrorSource {
             MirrorSource::ClaudeCode => "claude_code",
             MirrorSource::Codex => "codex",
             MirrorSource::ChatGptExport => "chatgpt_export",
+            MirrorSource::ClaudeAiExport => "claude_ai_export",
         }
     }
 }
@@ -62,9 +65,10 @@ impl From<LineTailSource> for MirrorSource {
 /// purpose of selecting `mirror_file`'s per-line parser.
 ///
 /// This is narrower than [`MirrorSource`]: it covers only the line-tail
-/// sources (append-only JSONL, tailed by byte offset). ChatGPT export
-/// ingestion is whole-file re-parse, not line-tail, so it has no variant
-/// here — see [`mirror_chatgpt_export_file`].
+/// sources (append-only JSONL, tailed by byte offset). Provider-export
+/// ingestion is whole-file re-parse, not line-tail, so those sources have no
+/// variants here — see [`mirror_chatgpt_export_file`] and
+/// [`mirror_claude_ai_export_file`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum LineTailSource {
     /// Claude Code (`~/.claude/projects/<slug>/<uuid>.jsonl`).
@@ -78,7 +82,7 @@ pub enum LineTailSource {
 pub struct MirrorStats {
     /// Number of new message rows inserted (0 if all were already present).
     pub inserted: u64,
-    /// Number of complete lines scanned (including duplicates).
+    /// Number of complete lines or whole-file events scanned (including duplicates).
     pub scanned: u64,
     /// Byte offset advanced to (only past complete lines; partial trailing line excluded).
     pub new_offset: u64,
@@ -409,17 +413,54 @@ async fn mirror_file_with_limits(
 /// so it is retried on every later tick rather than dropped (PACKSESSION-AUD-003).
 /// See `crates/khive-pack-session/docs/api/mirror-ingest.md#chatgpt-export-whole-file-re-parse-mirror_chatgpt_export_file`.
 const DEFAULT_CHATGPT_MAX_BYTES: u64 = 256 * 1024 * 1024;
+const DEFAULT_CLAUDE_AI_MAX_BYTES: u64 = 256 * 1024 * 1024;
+
+#[derive(Clone, Copy)]
+struct WholeFileExportSpec {
+    source: MirrorSource,
+    parser: fn(&str) -> Option<Vec<parse::ParsedEvent>>,
+    operation: &'static str,
+    format_name: &'static str,
+    max_bytes_env: &'static str,
+}
+
+const CHATGPT_EXPORT_SPEC: WholeFileExportSpec = WholeFileExportSpec {
+    source: MirrorSource::ChatGptExport,
+    parser: parse::parse_chatgpt_export,
+    operation: "mirror_chatgpt_export_file",
+    format_name: "ChatGPT",
+    max_bytes_env: "KHIVE_MIRROR_CHATGPT_MAX_BYTES",
+};
+
+const CLAUDE_AI_EXPORT_SPEC: WholeFileExportSpec = WholeFileExportSpec {
+    source: MirrorSource::ClaudeAiExport,
+    parser: parse::parse_claude_ai_export,
+    operation: "mirror_claude_ai_export_file",
+    format_name: "claude.ai",
+    max_bytes_env: "KHIVE_MIRROR_CLAUDE_AI_MAX_BYTES",
+};
 
 /// Resolve the ChatGPT export size ceiling from `KHIVE_MIRROR_CHATGPT_MAX_BYTES`,
 /// falling back to [`DEFAULT_CHATGPT_MAX_BYTES`] for missing, non-numeric, or
 /// zero values (zero would skip every export unconditionally, so it is
 /// treated the same as unset).
 fn chatgpt_max_bytes() -> u64 {
-    std::env::var("KHIVE_MIRROR_CHATGPT_MAX_BYTES")
+    export_max_bytes(CHATGPT_EXPORT_SPEC.max_bytes_env, DEFAULT_CHATGPT_MAX_BYTES)
+}
+
+fn claude_ai_max_bytes() -> u64 {
+    export_max_bytes(
+        CLAUDE_AI_EXPORT_SPEC.max_bytes_env,
+        DEFAULT_CLAUDE_AI_MAX_BYTES,
+    )
+}
+
+fn export_max_bytes(variable: &str, default: u64) -> u64 {
+    std::env::var(variable)
         .ok()
         .and_then(|v| v.parse::<u64>().ok())
         .filter(|&n| n > 0)
-        .unwrap_or(DEFAULT_CHATGPT_MAX_BYTES)
+        .unwrap_or(default)
 }
 
 /// Read the whole ChatGPT export `conversations.json` at `path`, parse every
@@ -455,10 +496,46 @@ async fn mirror_chatgpt_export_file_with_max_bytes(
     start_offset: u64,
     max_bytes: u64,
 ) -> Result<MirrorStats, RuntimeError> {
+    mirror_whole_file_export(runtime, path, start_offset, max_bytes, CHATGPT_EXPORT_SPEC).await
+}
+
+/// Read a whole claude.ai export `conversations.json`, parse its
+/// `chat_messages` arrays via [`parse::parse_claude_ai_export`], and commit
+/// the resulting sessions, messages, and cursor atomically.
+pub async fn mirror_claude_ai_export_file(
+    runtime: &KhiveRuntime,
+    path: &Path,
+    start_offset: u64,
+) -> Result<MirrorStats, RuntimeError> {
+    mirror_claude_ai_export_file_with_max_bytes(runtime, path, start_offset, claude_ai_max_bytes())
+        .await
+}
+
+async fn mirror_claude_ai_export_file_with_max_bytes(
+    runtime: &KhiveRuntime,
+    path: &Path,
+    start_offset: u64,
+    max_bytes: u64,
+) -> Result<MirrorStats, RuntimeError> {
+    mirror_whole_file_export(
+        runtime,
+        path,
+        start_offset,
+        max_bytes,
+        CLAUDE_AI_EXPORT_SPEC,
+    )
+    .await
+}
+
+async fn mirror_whole_file_export(
+    runtime: &KhiveRuntime,
+    path: &Path,
+    start_offset: u64,
+    max_bytes: u64,
+    spec: WholeFileExportSpec,
+) -> Result<MirrorStats, RuntimeError> {
     let file_len = std::fs::metadata(path).map(|m| m.len()).map_err(|e| {
-        RuntimeError::Internal(format!(
-            "mirror_chatgpt_export_file: failed to stat {path:?}: {e}"
-        ))
+        RuntimeError::Internal(format!("{}: failed to stat {path:?}: {e}", spec.operation))
     })?;
 
     if file_len <= start_offset {
@@ -472,9 +549,11 @@ async fn mirror_chatgpt_export_file_with_max_bytes(
     if file_len > max_bytes {
         tracing::warn!(
             path = %path.display(),
+            source = spec.source.as_str(),
             file_bytes = file_len,
             max_bytes,
-            "session mirror: skipping oversized ChatGPT export (exceeds KHIVE_MIRROR_CHATGPT_MAX_BYTES)"
+            max_bytes_env = spec.max_bytes_env,
+            "session mirror: skipping oversized whole-file export"
         );
         return Ok(MirrorStats {
             inserted: 0,
@@ -484,14 +563,13 @@ async fn mirror_chatgpt_export_file_with_max_bytes(
     }
 
     let content = std::fs::read_to_string(path).map_err(|e| {
-        RuntimeError::Internal(format!(
-            "mirror_chatgpt_export_file: failed to read {path:?}: {e}"
-        ))
+        RuntimeError::Internal(format!("{}: failed to read {path:?}: {e}", spec.operation))
     })?;
 
-    let events = parse::parse_chatgpt_export(&content).ok_or_else(|| {
+    let events = (spec.parser)(&content).ok_or_else(|| {
         RuntimeError::Internal(format!(
-            "mirror_chatgpt_export_file: {path:?} is not a valid ChatGPT export (expected a top-level JSON array)"
+            "{}: {path:?} is not a valid {} export (expected its conversations.json array shape)",
+            spec.operation, spec.format_name
         ))
     })?;
 
@@ -500,7 +578,7 @@ async fn mirror_chatgpt_export_file_with_max_bytes(
     write_events_and_cursor(
         runtime,
         path,
-        MirrorSource::ChatGptExport.as_str(),
+        spec.source.as_str(),
         &events,
         scanned,
         file_len,
@@ -509,8 +587,8 @@ async fn mirror_chatgpt_export_file_with_max_bytes(
 }
 
 /// Upsert `events` and the mirror cursor for `path` in one transaction.
-/// Shared by `mirror_file`'s line-tail path and `mirror_chatgpt_export_file`'s
-/// whole-file path. See
+/// Shared by `mirror_file`'s line-tail path and both provider-export
+/// whole-file paths. See
 /// `crates/khive-pack-session/docs/api/mirror-ingest.md#write-path-write_events_and_cursor-and-friends-adr-099-d5`
 /// for the ADR-099 D5 suspension-free rationale.
 async fn write_events_and_cursor(
@@ -2323,6 +2401,141 @@ mod tests {
             stored_raw.contains("***MASKED***"),
             "stored raw must carry the secret_gate redaction marker"
         );
+    }
+
+    fn claude_ai_happy_export_json() -> String {
+        serde_json::to_string(&json!([{
+            "uuid": "claude-conv-happy",
+            "name": "Synthetic Claude.ai Export",
+            "created_at": "2026-07-31T10:00:00Z",
+            "current_leaf_message_uuid": "claude-msg-main",
+            "chat_messages": [
+                {
+                    "uuid": "claude-msg-user",
+                    "sender": "human",
+                    "index": 0,
+                    "parent_message_uuid": "00000000-0000-4000-8000-000000000000",
+                    "created_at": "2026-07-31T10:00:01Z",
+                    "content": [{"type": "text", "text": "Question"}]
+                },
+                {
+                    "uuid": "claude-msg-main",
+                    "sender": "assistant",
+                    "index": 1,
+                    "parent_message_uuid": "claude-msg-user",
+                    "created_at": "2026-07-31T10:00:02Z",
+                    "content": [{"type": "text", "text": "Current answer"}]
+                },
+                {
+                    "uuid": "claude-msg-alt",
+                    "sender": "assistant",
+                    "index": 2,
+                    "parent_message_uuid": "claude-msg-user",
+                    "created_at": "2026-07-31T10:00:03Z",
+                    "content": [{"type": "text", "text": "Alternate answer"}]
+                }
+            ]
+        }]))
+        .unwrap()
+    }
+
+    #[tokio::test]
+    async fn test_claude_ai_export_ingest_is_idempotent_and_preserves_branches() {
+        let (rt, _dir) = setup().await;
+        let (_file, path) = write_export_file(&claude_ai_happy_export_json());
+        let file_len = std::fs::metadata(&path).unwrap().len();
+
+        let first = mirror_claude_ai_export_file(&rt, &path, 0)
+            .await
+            .expect("claude.ai export ingest");
+        assert_eq!(first.inserted, 3);
+        assert_eq!(first.scanned, 3);
+        assert_eq!(first.new_offset, file_len);
+
+        let replay = mirror_claude_ai_export_file(&rt, &path, 0)
+            .await
+            .expect("idempotent replay");
+        assert_eq!(replay.inserted, 0);
+        assert_eq!(count_rows(&rt, "sessions").await, 1);
+        assert_eq!(count_rows(&rt, "session_messages").await, 3);
+        assert_eq!(
+            cursor_offset(&rt, &path.to_string_lossy()).await,
+            Some(file_len as i64)
+        );
+
+        let sql = rt.sql();
+        let mut reader = sql.reader().await.expect("reader");
+        let session = reader
+            .query_row(SqlStatement {
+                sql: "SELECT provider_session_id, source, slug, message_count \
+                      FROM sessions WHERE id='claude-conv-happy'"
+                    .into(),
+                params: vec![],
+                label: None,
+            })
+            .await
+            .expect("query ok")
+            .expect("session row");
+        assert!(matches!(
+            session.get("provider_session_id"),
+            Some(SqlValue::Text(value)) if value == "claude-conv-happy"
+        ));
+        assert!(matches!(
+            session.get("source"),
+            Some(SqlValue::Text(value)) if value == "claude_ai_export"
+        ));
+        assert!(matches!(
+            session.get("slug"),
+            Some(SqlValue::Text(value)) if value == "Synthetic Claude.ai Export"
+        ));
+        assert!(matches!(
+            session.get("message_count"),
+            Some(SqlValue::Integer(3))
+        ));
+
+        let messages = reader
+            .query_all(SqlStatement {
+                sql: "SELECT id, parent_uuid, is_sidechain FROM session_messages \
+                      WHERE session_id='claude-conv-happy' ORDER BY seq"
+                    .into(),
+                params: vec![],
+                label: None,
+            })
+            .await
+            .expect("message query");
+        assert_eq!(messages.len(), 3);
+        assert!(matches!(
+            messages[0].get("parent_uuid"),
+            Some(SqlValue::Null) | None
+        ));
+        assert!(matches!(
+            messages[1].get("is_sidechain"),
+            Some(SqlValue::Integer(0))
+        ));
+        assert!(matches!(
+            messages[2].get("id"),
+            Some(SqlValue::Text(value)) if value == "claude-msg-alt"
+        ));
+        assert!(matches!(
+            messages[2].get("parent_uuid"),
+            Some(SqlValue::Text(value)) if value == "claude-msg-user"
+        ));
+        assert!(matches!(
+            messages[2].get("is_sidechain"),
+            Some(SqlValue::Integer(1))
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_claude_ai_export_over_max_bytes_leaves_cursor_untouched() {
+        let (rt, _dir) = setup().await;
+        let (_file, path) = write_export_file("[]");
+
+        let stats = mirror_claude_ai_export_file_with_max_bytes(&rt, &path, 0, 1)
+            .await
+            .expect("oversized export is skipped");
+        assert_eq!(stats, MirrorStats::default());
+        assert_eq!(cursor_offset(&rt, &path.to_string_lossy()).await, None);
     }
 
     /// SS6 invariants #4/#5 (error never advances cursor; one transaction per

--- a/crates/khive-pack-session/src/mirror/ingest.rs
+++ b/crates/khive-pack-session/src/mirror/ingest.rs
@@ -625,9 +625,11 @@ async fn write_events_and_cursor(
                 source_value,
                 &sessions_owned,
                 &events_owned,
-                scanned,
-                new_offset,
-                now_us,
+                MirrorWriteProgress {
+                    scanned,
+                    new_offset,
+                    now_us,
+                },
             )
             .await
             .map(|stats| Box::new(stats) as Box<dyn std::any::Any + Send>)
@@ -710,16 +712,26 @@ async fn ensure_session_on_writer(
 /// SqlTransaction`) because `atomic_unit` owns the transaction boundary
 /// entirely — this function must not, and does not, issue its own
 /// `BEGIN`/`COMMIT`/`ROLLBACK`.
+#[derive(Clone, Copy)]
+struct MirrorWriteProgress {
+    scanned: u64,
+    new_offset: u64,
+    now_us: i64,
+}
+
 async fn write_events_and_cursor_on_writer(
     writer: &mut dyn SqlWriter,
     path: &Path,
     source_value: &'static str,
     sessions: &[parse::ParsedSession],
     events: &[parse::ParsedEvent],
-    scanned: u64,
-    new_offset: u64,
-    now_us: i64,
+    progress: MirrorWriteProgress,
 ) -> khive_storage::types::StorageResult<MirrorStats> {
+    let MirrorWriteProgress {
+        scanned,
+        new_offset,
+        now_us,
+    } = progress;
     let mut inserted: u64 = 0;
     let mut last_session_id: Option<String> = None;
     let mut ensured_session_ids = std::collections::HashSet::new();
@@ -2841,9 +2853,11 @@ mod tests {
                     "claude_code",
                     &[],
                     &events,
-                    1,
-                    100,
-                    now_us,
+                    MirrorWriteProgress {
+                        scanned: 1,
+                        new_offset: 100,
+                        now_us,
+                    },
                 )
                 .await
                 .map(|stats| Box::new(stats) as Box<dyn std::any::Any + Send>)
@@ -2939,9 +2953,11 @@ mod tests {
                     "claude_code",
                     &[],
                     &events,
-                    1,
-                    100,
-                    now_us,
+                    MirrorWriteProgress {
+                        scanned: 1,
+                        new_offset: 100,
+                        now_us,
+                    },
                 )
                 .await
                 .map(|stats| Box::new(stats) as Box<dyn std::any::Any + Send>)

--- a/crates/khive-pack-session/src/mirror/mod.rs
+++ b/crates/khive-pack-session/src/mirror/mod.rs
@@ -1,4 +1,4 @@
-//! Background live-mirror service for Claude Code and Codex CLI session transcripts.
+//! Background live-mirror service for CLI transcripts and provider exports.
 //!
 //! Exposes the three sub-modules and re-exports the public surface used by
 //! `SessionPack::warm()` and tests.

--- a/crates/khive-pack-session/src/mirror/parse.rs
+++ b/crates/khive-pack-session/src/mirror/parse.rs
@@ -397,7 +397,8 @@ fn parse_claude_ai_conversation(
                 .get("summary")
                 .and_then(Value::as_str)
                 .filter(|summary| !summary.is_empty())
-        });
+        })
+        .map(|title| secret_gate::mask_secrets(title).into_owned());
     let conversation_created_at_micros = conversation
         .get("created_at")
         .and_then(parse_rfc3339_micros)
@@ -455,7 +456,7 @@ fn parse_claude_ai_conversation(
         if let Some(event) = build_claude_ai_event(
             message,
             session_id,
-            slug,
+            slug.as_deref(),
             conversation_created_at_micros,
             &current_path,
         ) {
@@ -482,7 +483,7 @@ fn parse_claude_ai_conversation(
         created_at_micros: conversation_created_at_micros,
         cwd: None,
         git_branch: None,
-        slug: slug.map(str::to_string),
+        slug,
     })
 }
 
@@ -1378,6 +1379,41 @@ mod tests {
         assert!(events[0].text.as_deref().unwrap().contains("***MASKED***"));
         assert!(!events[0].raw.contains(&secret));
         assert_eq!(events[1].text.as_deref(), Some("Legacy assistant text"));
+    }
+
+    #[test]
+    fn test_claude_ai_export_masks_secret_bearing_title_and_summary() {
+        let secret = format!("{}{}", "AKIA", "FAKEKEY1234567890");
+        let export = serde_json::json!([
+            {
+                "uuid": "claude-conv-secret-name",
+                "name": format!("prod creds {secret}"),
+                "chat_messages": [{
+                    "uuid": "claude-secret-name-user",
+                    "sender": "human",
+                    "text": "hello",
+                    "created_at": "2026-07-31T10:00:00Z"
+                }]
+            },
+            {
+                "uuid": "claude-conv-secret-summary",
+                "summary": format!("key={secret}"),
+                "chat_messages": []
+            }
+        ]);
+
+        let parsed =
+            parse_claude_ai_export_with_sessions(&export.to_string()).expect("secret-title export");
+        assert_eq!(parsed.sessions.len(), 2);
+        for session in &parsed.sessions {
+            let slug = session.slug.as_deref().expect("session slug");
+            assert!(!slug.contains(&secret));
+            assert!(slug.contains("***MASKED***"));
+        }
+        assert_eq!(parsed.events.len(), 1);
+        let event_slug = parsed.events[0].slug.as_deref().expect("event slug");
+        assert!(!event_slug.contains(&secret));
+        assert!(event_slug.contains("***MASKED***"));
     }
 
     #[test]

--- a/crates/khive-pack-session/src/mirror/parse.rs
+++ b/crates/khive-pack-session/src/mirror/parse.rs
@@ -1,9 +1,9 @@
-//! JSONL line parsers for Claude Code and Codex CLI session transcripts.
+//! Parsers for CLI transcripts and provider conversation exports.
 //!
 //! Every function here is deterministic and side-effect-free so the unit tests
 //! can run without any runtime or DB setup.
 
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 
 use chrono::DateTime;
 use khive_runtime::secret_gate;
@@ -18,6 +18,7 @@ pub struct ParsedEvent {
     /// For Codex events (which carry no per-message uuid) this is synthesised
     /// as `"{session_id}:{abs_byte_offset}"`.
     /// For ChatGPT export events this is the mapping node's `message.id`.
+    /// For Claude.ai export events this is `chat_messages[].uuid`.
     pub uuid: String,
     /// Session UUID.
     pub session_id: String,
@@ -25,22 +26,22 @@ pub struct ParsedEvent {
     pub parent_uuid: Option<String>,
     /// Whether this event is on a sidechain.
     pub is_sidechain: bool,
-    /// `message.role` (CC) or `payload.role` (Codex) when present.
+    /// Normalized provider role when present.
     pub role: Option<String>,
-    /// Top-level `type` field.
+    /// Source event or content type.
     pub msg_type: String,
     /// Extracted display text, secrets masked; `None` for non-message events.
     pub text: Option<String>,
-    /// Full original line with secrets masked.
+    /// Original line or serialized export message/node with secrets masked.
     pub raw: String,
-    /// `timestamp` as microseconds since the Unix epoch; 0 if absent or unparseable.
+    /// Source timestamp as microseconds since the Unix epoch; 0 if absent or unparseable.
     pub created_at_micros: i64,
     /// `cwd` if present.
     pub cwd: Option<String>,
     /// `gitBranch` (CC) or `payload.git.branch` (Codex) if present.
     pub git_branch: Option<String>,
-    /// `slug` if present (CC: project slug; ChatGPT export: conversation
-    /// title; Codex files carry no slug concept).
+    /// `slug` if present (CC: project slug; ChatGPT/Claude.ai export:
+    /// conversation title; Codex files carry no slug concept).
     pub slug: Option<String>,
 }
 
@@ -273,11 +274,293 @@ pub fn parse_chatgpt_export(content: &str) -> Option<Vec<ParsedEvent>> {
     let value: Value = serde_json::from_str(content).ok()?;
     let conversations = value.as_array()?;
 
+    // Both providers use the filename `conversations.json`. If operators point
+    // both roots at the same directory, rejecting an unmistakable Claude.ai
+    // file here prevents the ChatGPT ingester from consuming its cursor first.
+    if conversations.iter().any(is_claude_ai_conversation) {
+        return None;
+    }
+
     let mut events = Vec::new();
     for conv in conversations {
         parse_conversation(conv, &mut events);
     }
     Some(events)
+}
+
+/// Parse a claude.ai data-export `conversations.json` file.
+///
+/// Claude.ai exports are a top-level JSON array whose conversation objects
+/// carry `uuid`, `name`, and `chat_messages`. Message UUIDs and conversation
+/// UUIDs are preserved as the idempotency and provider-session anchors. When
+/// `current_leaf_message_uuid` is present, messages outside its parent chain
+/// are retained with `is_sidechain = true`; older flat exports without that
+/// field keep every message on the main path.
+///
+/// Returns `None` when `content` is not valid JSON or the top level is not an
+/// array. Malformed conversation objects inside a valid array are skipped.
+pub fn parse_claude_ai_export(content: &str) -> Option<Vec<ParsedEvent>> {
+    let value: Value = serde_json::from_str(content).ok()?;
+    let conversations = value.as_array()?;
+
+    // Symmetric source-shape check for accidentally overlapping export roots.
+    // Empty and wholly malformed arrays remain valid so per-conversation
+    // isolation keeps its existing semantics.
+    if conversations.iter().any(is_chatgpt_conversation) {
+        return None;
+    }
+
+    let mut events = Vec::new();
+    for conversation in conversations {
+        parse_claude_ai_conversation(conversation, &mut events);
+    }
+    Some(events)
+}
+
+fn is_chatgpt_conversation(conversation: &Value) -> bool {
+    conversation.as_object().is_some_and(|conversation| {
+        conversation
+            .get("id")
+            .and_then(Value::as_str)
+            .is_some_and(|id| !id.is_empty())
+            && conversation.get("mapping").is_some_and(Value::is_object)
+    })
+}
+
+fn is_claude_ai_conversation(conversation: &Value) -> bool {
+    conversation.as_object().is_some_and(|conversation| {
+        conversation
+            .get("uuid")
+            .and_then(Value::as_str)
+            .is_some_and(|id| !id.is_empty())
+            && conversation
+                .get("chat_messages")
+                .is_some_and(Value::is_array)
+    })
+}
+
+fn parse_claude_ai_conversation(conversation: &Value, out: &mut Vec<ParsedEvent>) {
+    let Some(conversation) = conversation.as_object() else {
+        return;
+    };
+    let Some(session_id) = conversation
+        .get("uuid")
+        .and_then(Value::as_str)
+        .filter(|id| !id.is_empty())
+    else {
+        return;
+    };
+    let Some(messages) = conversation.get("chat_messages").and_then(Value::as_array) else {
+        return;
+    };
+
+    let slug = conversation
+        .get("name")
+        .and_then(Value::as_str)
+        .filter(|name| !name.is_empty())
+        .or_else(|| {
+            conversation
+                .get("summary")
+                .and_then(Value::as_str)
+                .filter(|summary| !summary.is_empty())
+        });
+    let conversation_created_at_micros = conversation
+        .get("created_at")
+        .and_then(parse_rfc3339_micros)
+        .or_else(|| {
+            conversation
+                .get("updated_at")
+                .and_then(parse_rfc3339_micros)
+        })
+        .unwrap_or(0);
+
+    let mut parent_by_id: HashMap<String, Option<String>> = HashMap::new();
+    for message in messages {
+        let Some(message) = message.as_object() else {
+            continue;
+        };
+        let Some(uuid) = message
+            .get("uuid")
+            .and_then(Value::as_str)
+            .filter(|id| !id.is_empty())
+        else {
+            continue;
+        };
+        parent_by_id
+            .entry(uuid.to_string())
+            .or_insert_with(|| claude_ai_parent_uuid(message));
+    }
+
+    let current_path = claude_ai_current_path(conversation, &parent_by_id);
+    let mut order: Vec<usize> = (0..messages.len()).collect();
+    order.sort_by_key(|&position| {
+        let source_index = messages[position]
+            .as_object()
+            .and_then(|message| message.get("index"))
+            .and_then(Value::as_i64)
+            .unwrap_or(position as i64);
+        (source_index, position)
+    });
+
+    let mut emitted = HashSet::new();
+    let start = out.len();
+    for position in order {
+        let Some(message) = messages[position].as_object() else {
+            continue;
+        };
+        let Some(uuid) = message
+            .get("uuid")
+            .and_then(Value::as_str)
+            .filter(|id| !id.is_empty())
+        else {
+            continue;
+        };
+        if !emitted.insert(uuid.to_string()) {
+            continue;
+        }
+        if let Some(event) = build_claude_ai_event(
+            message,
+            session_id,
+            slug,
+            conversation_created_at_micros,
+            &current_path,
+        ) {
+            out.push(event);
+        }
+    }
+
+    let stored_ids: HashSet<String> = out[start..]
+        .iter()
+        .map(|event| event.uuid.clone())
+        .collect();
+    for event in &mut out[start..] {
+        if event
+            .parent_uuid
+            .as_ref()
+            .is_some_and(|parent| !stored_ids.contains(parent))
+        {
+            event.parent_uuid = None;
+        }
+    }
+}
+
+fn claude_ai_current_path(
+    conversation: &Map<String, Value>,
+    parent_by_id: &HashMap<String, Option<String>>,
+) -> HashSet<String> {
+    let Some(current_leaf) = conversation
+        .get("current_leaf_message_uuid")
+        .and_then(Value::as_str)
+        .filter(|id| parent_by_id.contains_key(*id))
+    else {
+        return parent_by_id.keys().cloned().collect();
+    };
+
+    let mut path = HashSet::new();
+    let mut cursor = Some(current_leaf.to_string());
+    while let Some(message_id) = cursor {
+        if !path.insert(message_id.clone()) {
+            break;
+        }
+        cursor = parent_by_id.get(&message_id).cloned().flatten();
+    }
+    path
+}
+
+fn build_claude_ai_event(
+    message: &Map<String, Value>,
+    session_id: &str,
+    slug: Option<&str>,
+    conversation_created_at_micros: i64,
+    current_path: &HashSet<String>,
+) -> Option<ParsedEvent> {
+    let uuid = message
+        .get("uuid")
+        .and_then(Value::as_str)
+        .filter(|id| !id.is_empty())?
+        .to_string();
+
+    let role = message
+        .get("sender")
+        .or_else(|| message.get("role"))
+        .and_then(Value::as_str)
+        .filter(|sender| !sender.is_empty())
+        .map(|sender| match sender {
+            "human" | "user" => "user".to_string(),
+            other => other.to_string(),
+        });
+    let text = extract_claude_ai_text(message)?;
+    if text.trim().is_empty() {
+        return None;
+    }
+
+    let created_at_micros = message
+        .get("created_at")
+        .and_then(parse_rfc3339_micros)
+        .or_else(|| message.get("updated_at").and_then(parse_rfc3339_micros))
+        .unwrap_or(conversation_created_at_micros);
+    let parent_uuid = claude_ai_parent_uuid(message);
+    let raw_json = serde_json::to_string(message).unwrap_or_default();
+
+    Some(ParsedEvent {
+        uuid: uuid.clone(),
+        session_id: session_id.to_string(),
+        parent_uuid,
+        is_sidechain: !current_path.contains(&uuid),
+        role,
+        msg_type: "message".to_string(),
+        text: Some(secret_gate::mask_secrets(&text).into_owned()),
+        raw: secret_gate::mask_secrets(&raw_json).into_owned(),
+        created_at_micros,
+        cwd: None,
+        git_branch: None,
+        slug: slug.map(str::to_string),
+    })
+}
+
+fn claude_ai_parent_uuid(message: &Map<String, Value>) -> Option<String> {
+    message
+        .get("parent_message_uuid")
+        .and_then(Value::as_str)
+        .filter(|parent| !parent.is_empty() && *parent != "00000000-0000-4000-8000-000000000000")
+        .map(str::to_string)
+}
+
+fn extract_claude_ai_text(message: &Map<String, Value>) -> Option<String> {
+    let top_level_text = message
+        .get("text")
+        .and_then(Value::as_str)
+        .filter(|text| !text.trim().is_empty());
+    let mut parts = Vec::new();
+
+    match message.get("content") {
+        Some(Value::Array(blocks)) => {
+            for part in blocks
+                .iter()
+                .filter_map(extract_block)
+                .filter(|part| !part.trim().is_empty())
+            {
+                parts.push(part);
+            }
+        }
+        Some(Value::String(text)) if !text.trim().is_empty() => parts.push(text.clone()),
+        Some(_) | None => {}
+    }
+
+    if let Some(text) = top_level_text {
+        if !parts.iter().any(|part| part == text) {
+            parts.push(text.to_string());
+        }
+    }
+
+    (!parts.is_empty()).then(|| parts.join("\n"))
+}
+
+fn parse_rfc3339_micros(value: &Value) -> Option<i64> {
+    value
+        .as_str()
+        .and_then(|timestamp| DateTime::parse_from_rfc3339(timestamp).ok())
+        .map(|timestamp| timestamp.timestamp_micros())
 }
 
 /// Extract a display-friendly text string from a message `content` value
@@ -298,14 +581,15 @@ fn extract_text(content: Option<&Value>) -> Option<String> {
 }
 
 /// Extract a display string from a single content block (`"text"` /
-/// `"input_text"` / `"output_text"` / `"tool_use"` / `"tool_result"`). See
-/// `crates/khive-pack-session/docs/api/mirror-parse.md#extract_text--extract_block-claude-code--codex-block-extraction`.
+/// `"input_text"` / `"output_text"` / `"voice_note"` / `"tool_use"` /
+/// `"tool_result"`). See
+/// `crates/khive-pack-session/docs/api/mirror-parse.md#extract_text--extract_block-claude-code-codex-and-claudeai-blocks`.
 fn extract_block(block: &Value) -> Option<String> {
     let map = block.as_object()?;
     match map.get("type")?.as_str()? {
         // Claude Code text block and Codex user/assistant text blocks all carry
         // their display text in a "text" field — same extraction logic.
-        "text" | "input_text" | "output_text" => {
+        "text" | "input_text" | "output_text" | "voice_note" => {
             map.get("text").and_then(|v| v.as_str()).map(str::to_string)
         }
         "tool_use" => {
@@ -880,6 +1164,224 @@ mod tests {
         let line = r#"{"uuid":"cc-t1","sessionId":"cc-sess","type":"assistant","timestamp":"2026-06-30T09:00:00Z","message":{"role":"assistant","content":[{"type":"text","text":"CC still works"}]}}"#;
         let ev = parse_cc_line(line).expect("CC text block must parse");
         assert_eq!(ev.text.as_deref(), Some("CC still works"));
+    }
+
+    // ── parse_claude_ai_export: direct unit tests ───────────────────────────
+
+    #[test]
+    fn test_claude_ai_export_preserves_ids_order_roles_and_title() {
+        let export = serde_json::json!([{
+            "uuid": "claude-conv-1",
+            "name": "Claude Web Conversation",
+            "created_at": "2026-07-31T10:00:00Z",
+            "current_leaf_message_uuid": "claude-msg-2",
+            "chat_messages": [
+                {
+                    "uuid": "claude-msg-2",
+                    "sender": "assistant",
+                    "index": 1,
+                    "parent_message_uuid": "claude-msg-1",
+                    "created_at": "2026-07-31T10:00:02Z",
+                    "content": [
+                        {"type": "thinking", "thinking": "not display text"},
+                        {"type": "text", "text": "Hello from Claude"}
+                    ]
+                },
+                {
+                    "uuid": "claude-msg-1",
+                    "sender": "human",
+                    "index": 0,
+                    "parent_message_uuid": "00000000-0000-4000-8000-000000000000",
+                    "created_at": "2026-07-31T10:00:01Z",
+                    "content": [{"type": "text", "text": "Hello"}]
+                }
+            ]
+        }]);
+
+        let events = parse_claude_ai_export(&export.to_string()).expect("valid export");
+        assert_eq!(events.len(), 2);
+        assert_eq!(events[0].uuid, "claude-msg-1");
+        assert_eq!(events[0].session_id, "claude-conv-1");
+        assert_eq!(events[0].role.as_deref(), Some("user"));
+        assert_eq!(events[0].text.as_deref(), Some("Hello"));
+        assert_eq!(events[0].parent_uuid, None);
+        assert_eq!(events[0].slug.as_deref(), Some("Claude Web Conversation"));
+        assert!(!events[0].is_sidechain);
+
+        assert_eq!(events[1].uuid, "claude-msg-2");
+        assert_eq!(events[1].role.as_deref(), Some("assistant"));
+        assert_eq!(events[1].text.as_deref(), Some("Hello from Claude"));
+        assert_eq!(events[1].parent_uuid.as_deref(), Some("claude-msg-1"));
+        assert!(!events[1].is_sidechain);
+        assert!(events[1].created_at_micros > events[0].created_at_micros);
+    }
+
+    #[test]
+    fn test_claude_ai_export_preserves_branches_and_marks_inactive_path() {
+        let export = serde_json::json!([{
+            "uuid": "claude-conv-branch",
+            "name": "Branching Claude Conversation",
+            "current_leaf_message_uuid": "claude-main",
+            "chat_messages": [
+                {
+                    "uuid": "claude-user",
+                    "sender": "human",
+                    "index": 0,
+                    "parent_message_uuid": null,
+                    "content": [{"type": "text", "text": "Question"}]
+                },
+                {
+                    "uuid": "claude-main",
+                    "sender": "assistant",
+                    "index": 1,
+                    "parent_message_uuid": "claude-user",
+                    "content": [{"type": "text", "text": "Current answer"}]
+                },
+                {
+                    "uuid": "claude-alt",
+                    "sender": "assistant",
+                    "index": 2,
+                    "parent_message_uuid": "claude-user",
+                    "content": [{"type": "text", "text": "Alternate answer"}]
+                }
+            ]
+        }]);
+
+        let events = parse_claude_ai_export(&export.to_string()).expect("valid branch export");
+        assert_eq!(events.len(), 3, "alternate branches must be retained");
+        assert!(!events[0].is_sidechain);
+        assert!(!events[1].is_sidechain);
+        assert!(events[2].is_sidechain);
+        assert_eq!(events[2].uuid, "claude-alt");
+        assert_eq!(events[2].parent_uuid.as_deref(), Some("claude-user"));
+    }
+
+    #[test]
+    fn test_claude_ai_export_keeps_blocks_and_distinct_top_level_answer() {
+        let export = serde_json::json!([{
+            "uuid": "claude-conv-agent",
+            "chat_messages": [
+                {
+                    "uuid": "claude-agent-turn",
+                    "sender": "assistant",
+                    "text": "Final answer",
+                    "content": [
+                        {"type": "tool_use", "name": "bash_tool", "input": {"command": "pwd"}},
+                        {"type": "tool_result", "content": [{"type": "text", "text": "/tmp"}]}
+                    ]
+                },
+                {
+                    "uuid": "claude-deduplicated-text",
+                    "sender": "assistant",
+                    "text": "Already present",
+                    "content": [{"type": "text", "text": "Already present"}]
+                }
+            ]
+        }]);
+
+        let events = parse_claude_ai_export(&export.to_string()).expect("valid agent export");
+        assert_eq!(events.len(), 2);
+        let agent_text = events[0].text.as_deref().expect("agent turn text");
+        assert!(agent_text.contains("[tool_use: bash_tool]"));
+        assert!(agent_text.contains("[tool_result]"));
+        assert!(agent_text.ends_with("Final answer"));
+        assert_eq!(events[1].text.as_deref(), Some("Already present"));
+    }
+
+    #[test]
+    fn test_claude_ai_export_accepts_legacy_role_and_voice_note_text() {
+        let export = serde_json::json!([{
+            "uuid": "claude-conv-voice",
+            "chat_messages": [{
+                "uuid": "claude-voice-turn",
+                "role": "human",
+                "content": [{"type": "voice_note", "title": "Memo", "text": "Spoken prompt"}]
+            }]
+        }]);
+
+        let events = parse_claude_ai_export(&export.to_string()).expect("valid legacy export");
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].role.as_deref(), Some("user"));
+        assert_eq!(events[0].text.as_deref(), Some("Spoken prompt"));
+    }
+
+    #[test]
+    fn test_claude_ai_export_legacy_flat_text_is_masked() {
+        let secret = format!("{}{}", "AKIA", "FAKEKEY1234567890");
+        let export = serde_json::json!([{
+            "uuid": "claude-conv-flat",
+            "summary": "Legacy export",
+            "chat_messages": [
+                {
+                    "uuid": "claude-flat-user",
+                    "sender": "human",
+                    "text": format!("key={secret}"),
+                    "created_at": "2026-07-31T10:00:00Z"
+                },
+                {
+                    "uuid": "claude-flat-assistant",
+                    "sender": "assistant",
+                    "text": "Legacy assistant text",
+                    "content": [{"type": "thinking", "thinking": "not visible"}],
+                    "created_at": "2026-07-31T10:00:01Z"
+                }
+            ]
+        }]);
+
+        let events = parse_claude_ai_export(&export.to_string()).expect("legacy export");
+        assert_eq!(events.len(), 2);
+        assert!(events.iter().all(|event| !event.is_sidechain));
+        assert_eq!(events[0].slug.as_deref(), Some("Legacy export"));
+        assert!(!events[0].text.as_deref().unwrap().contains(&secret));
+        assert!(events[0].text.as_deref().unwrap().contains("***MASKED***"));
+        assert!(!events[0].raw.contains(&secret));
+        assert_eq!(events[1].text.as_deref(), Some("Legacy assistant text"));
+    }
+
+    #[test]
+    fn test_claude_ai_export_rejects_bad_top_level_and_skips_bad_conversations() {
+        assert!(parse_claude_ai_export("not json").is_none());
+        assert!(parse_claude_ai_export(r#"{"uuid":"not-an-array"}"#).is_none());
+
+        let export = serde_json::json!([
+            {"uuid": "missing-messages"},
+            {
+                "uuid": "claude-valid",
+                "chat_messages": [{
+                    "uuid": "claude-valid-message",
+                    "sender": "human",
+                    "text": "kept"
+                }]
+            }
+        ]);
+        let events = parse_claude_ai_export(&export.to_string()).expect("valid array");
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].session_id, "claude-valid");
+    }
+
+    #[test]
+    fn test_provider_export_parsers_reject_the_other_source_shape() {
+        let claude_ai = serde_json::json!([{
+            "uuid": "claude-conversation",
+            "chat_messages": []
+        }]);
+        assert!(parse_chatgpt_export(&claude_ai.to_string()).is_none());
+
+        let chatgpt = serde_json::json!([{
+            "id": "chatgpt-conversation",
+            "mapping": {}
+        }]);
+        assert!(parse_claude_ai_export(&chatgpt.to_string()).is_none());
+
+        let mixed = serde_json::json!([
+            {"uuid": "claude-conversation", "chat_messages": []},
+            {"id": "chatgpt-conversation", "mapping": {}}
+        ]);
+        assert!(parse_chatgpt_export(&mixed.to_string()).is_none());
+        assert!(parse_claude_ai_export(&mixed.to_string()).is_none());
+
+        assert_eq!(parse_chatgpt_export("[]"), Some(Vec::new()));
+        assert_eq!(parse_claude_ai_export("[]"), Some(Vec::new()));
     }
 
     // ── parse_chatgpt_export: direct unit tests ─────────────────────────────

--- a/crates/khive-pack-session/src/mirror/parse.rs
+++ b/crates/khive-pack-session/src/mirror/parse.rs
@@ -379,19 +379,14 @@ fn parse_claude_ai_conversation(
     conversation: &Value,
     out: &mut Vec<ParsedEvent>,
 ) -> Option<ParsedSession> {
-    let Some(conversation) = conversation.as_object() else {
-        return None;
-    };
-    let Some(session_id) = conversation
+    let conversation = conversation.as_object()?;
+    let session_id = conversation
         .get("uuid")
         .and_then(Value::as_str)
-        .filter(|id| !id.is_empty())
-    else {
-        return None;
-    };
-    let Some(messages) = conversation.get("chat_messages").and_then(Value::as_array) else {
-        return None;
-    };
+        .filter(|id| !id.is_empty())?;
+    let messages = conversation
+        .get("chat_messages")
+        .and_then(Value::as_array)?;
 
     let slug = conversation
         .get("name")

--- a/crates/khive-pack-session/src/mirror/parse.rs
+++ b/crates/khive-pack-session/src/mirror/parse.rs
@@ -45,6 +45,33 @@ pub struct ParsedEvent {
     pub slug: Option<String>,
 }
 
+/// Session metadata parsed independently of retained message events.
+///
+/// Whole-file exports can contain valid conversations with no displayable
+/// messages. Keeping this record separate from [`ParsedEvent`] lets the
+/// ingester create the required `sessions` row without inventing a synthetic
+/// `session_messages` row.
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct ParsedSession {
+    /// Provider conversation/session identifier.
+    pub(crate) session_id: String,
+    /// Source timestamp as microseconds since the Unix epoch; 0 if absent or unparseable.
+    pub(crate) created_at_micros: i64,
+    /// `cwd` if present.
+    pub(crate) cwd: Option<String>,
+    /// Source git branch if present.
+    pub(crate) git_branch: Option<String>,
+    /// Provider conversation title or project slug if present.
+    pub(crate) slug: Option<String>,
+}
+
+/// Parsed whole-file export payload used by the ingest layer.
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct ParsedExport {
+    pub(crate) sessions: Vec<ParsedSession>,
+    pub(crate) events: Vec<ParsedEvent>,
+}
+
 /// Parse one Claude Code JSONL line.
 ///
 /// Returns `None` for:
@@ -300,6 +327,12 @@ pub fn parse_chatgpt_export(content: &str) -> Option<Vec<ParsedEvent>> {
 /// Returns `None` when `content` is not valid JSON or the top level is not an
 /// array. Malformed conversation objects inside a valid array are skipped.
 pub fn parse_claude_ai_export(content: &str) -> Option<Vec<ParsedEvent>> {
+    parse_claude_ai_export_with_sessions(content).map(|parsed| parsed.events)
+}
+
+/// Parse a claude.ai export while retaining conversation metadata even when a
+/// conversation has no displayable messages.
+pub(crate) fn parse_claude_ai_export_with_sessions(content: &str) -> Option<ParsedExport> {
     let value: Value = serde_json::from_str(content).ok()?;
     let conversations = value.as_array()?;
 
@@ -310,11 +343,14 @@ pub fn parse_claude_ai_export(content: &str) -> Option<Vec<ParsedEvent>> {
         return None;
     }
 
+    let mut sessions = Vec::new();
     let mut events = Vec::new();
     for conversation in conversations {
-        parse_claude_ai_conversation(conversation, &mut events);
+        if let Some(session) = parse_claude_ai_conversation(conversation, &mut events) {
+            sessions.push(session);
+        }
     }
-    Some(events)
+    Some(ParsedExport { sessions, events })
 }
 
 fn is_chatgpt_conversation(conversation: &Value) -> bool {
@@ -339,19 +375,22 @@ fn is_claude_ai_conversation(conversation: &Value) -> bool {
     })
 }
 
-fn parse_claude_ai_conversation(conversation: &Value, out: &mut Vec<ParsedEvent>) {
+fn parse_claude_ai_conversation(
+    conversation: &Value,
+    out: &mut Vec<ParsedEvent>,
+) -> Option<ParsedSession> {
     let Some(conversation) = conversation.as_object() else {
-        return;
+        return None;
     };
     let Some(session_id) = conversation
         .get("uuid")
         .and_then(Value::as_str)
         .filter(|id| !id.is_empty())
     else {
-        return;
+        return None;
     };
     let Some(messages) = conversation.get("chat_messages").and_then(Value::as_array) else {
-        return;
+        return None;
     };
 
     let slug = conversation
@@ -442,6 +481,14 @@ fn parse_claude_ai_conversation(conversation: &Value, out: &mut Vec<ParsedEvent>
             event.parent_uuid = None;
         }
     }
+
+    Some(ParsedSession {
+        session_id: session_id.to_string(),
+        created_at_micros: conversation_created_at_micros,
+        cwd: None,
+        git_branch: None,
+        slug: slug.map(str::to_string),
+    })
 }
 
 fn claude_ai_current_path(

--- a/crates/khive-pack-session/src/mirror/service.rs
+++ b/crates/khive-pack-session/src/mirror/service.rs
@@ -1,8 +1,8 @@
 //! Background live-mirror polling service.
 //!
 //! `run_mirror_service` is an infinite loop started by `SessionPack::warm()`.
-//! It discovers `*.jsonl` files under the Claude Code projects directory,
-//! tracks byte offsets, and tails new content every `poll_interval`.
+//! It discovers configured CLI transcripts and provider exports, tracks byte
+//! offsets, and ingests new content every `poll_interval`.
 //!
 //! Design principles:
 //! - Infallible: a per-file error is logged and skipped; the loop continues.
@@ -22,10 +22,10 @@ use super::ingest::{self, LineTailSource};
 
 /// How a discovered file should be ingested.
 ///
-/// `ChatGptExport` is a `MirrorSource` variant (ADR-080's closed mirror-source
-/// set) but deliberately not a `LineTailSource` variant: ChatGPT export
-/// ingestion is whole-file (`mirror_chatgpt_export_file`), not line-tail, so
-/// it does not belong in that narrower per-line dispatch enum.
+/// Provider exports are `MirrorSource` variants (ADR-080's closed
+/// mirror-source set) but deliberately not `LineTailSource` variants: export
+/// ingestion is whole-file, not line-tail, so it does not belong in that
+/// narrower per-line dispatch enum.
 enum DiscoveredKind {
     LineTail {
         source: LineTailSource,
@@ -33,6 +33,7 @@ enum DiscoveredKind {
         session_id: Option<String>,
     },
     ChatGptExport,
+    ClaudeAiExport,
 }
 
 /// A discovered file together with how it should be ingested.
@@ -65,6 +66,14 @@ pub struct MirrorConfig {
     ///
     /// Defaults to `$HOME/.chatgpt/exports`.
     pub chatgpt_exports_dir: PathBuf,
+    /// Whether the claude.ai export mirror is enabled (default: false — opt-in,
+    /// independent of the other source flags).
+    pub claude_ai_enabled: bool,
+    /// Root directory scanned (recursively) for claude.ai `conversations.json`
+    /// export files.
+    ///
+    /// Defaults to `$HOME/.claude/exports`.
+    pub claude_ai_exports_dir: PathBuf,
     /// How long to sleep between polling ticks (default: 2 seconds).
     pub poll_interval: Duration,
     /// When true (default), existing files are mirrored from byte offset 0.
@@ -118,6 +127,8 @@ impl MirrorConfig {
     /// | `KHIVE_MIRROR_CODEX_DIR`       | `$HOME/.codex/sessions`        |
     /// | `KHIVE_MIRROR_CHATGPT_ENABLED` | `false`                        |
     /// | `KHIVE_MIRROR_CHATGPT_DIR`     | `$HOME/.chatgpt/exports`       |
+    /// | `KHIVE_MIRROR_CLAUDE_AI_ENABLED` | `false`                      |
+    /// | `KHIVE_MIRROR_CLAUDE_AI_DIR`   | `$HOME/.claude/exports`        |
     /// | `KHIVE_MIRROR_POLL_SECS`       | `2`                            |
     /// | `KHIVE_MIRROR_BACKFILL`        | `true`                         |
     pub fn from_env() -> Self {
@@ -147,6 +158,14 @@ impl MirrorConfig {
             .map(PathBuf::from)
             .unwrap_or_else(|_| PathBuf::from(&home).join(".chatgpt").join("exports"));
 
+        let claude_ai_enabled = std::env::var("KHIVE_MIRROR_CLAUDE_AI_ENABLED")
+            .map(|v| matches!(v.to_lowercase().as_str(), "1" | "true" | "yes"))
+            .unwrap_or(false);
+
+        let claude_ai_exports_dir = std::env::var("KHIVE_MIRROR_CLAUDE_AI_DIR")
+            .map(PathBuf::from)
+            .unwrap_or_else(|_| PathBuf::from(&home).join(".claude").join("exports"));
+
         let poll_raw = std::env::var("KHIVE_MIRROR_POLL_SECS").ok();
         let poll_secs = parse_mirror_poll_secs(poll_raw.as_deref());
 
@@ -161,6 +180,8 @@ impl MirrorConfig {
             codex_sessions_dir,
             chatgpt_enabled,
             chatgpt_exports_dir,
+            claude_ai_enabled,
+            claude_ai_exports_dir,
             poll_interval: Duration::from_secs(poll_secs),
             backfill,
         }
@@ -169,7 +190,7 @@ impl MirrorConfig {
 
 #[cfg(test)]
 mod config_tests {
-    use super::parse_mirror_poll_secs;
+    use super::{parse_mirror_poll_secs, scan_claude_ai_conversations_files, DiscoveredKind};
 
     /// Regression for PACKSESSION-AUD-002: `KHIVE_MIRROR_POLL_SECS=0` used to
     /// produce a hot polling loop via `Duration::from_secs(0)`. Explicit zero
@@ -203,6 +224,24 @@ mod config_tests {
             "valid nonzero value is honored"
         );
     }
+
+    #[test]
+    fn claude_ai_scanner_accepts_only_nested_conversations_json() {
+        let temp = tempfile::TempDir::new().expect("temp dir");
+        let nested = temp.path().join("download").join("claude-export");
+        std::fs::create_dir_all(&nested).expect("nested export dir");
+        let export = nested.join("conversations.json");
+        std::fs::write(&export, "[]").expect("export fixture");
+        std::fs::write(nested.join("conversations-copy.json"), "[]").expect("non-matching fixture");
+
+        let discovered = scan_claude_ai_conversations_files(temp.path());
+        assert_eq!(discovered.len(), 1);
+        assert_eq!(discovered[0].path, export);
+        assert!(matches!(
+            &discovered[0].kind,
+            DiscoveredKind::ClaudeAiExport
+        ));
+    }
 }
 
 /// Infinite background polling loop.  Returns only on a fatal setup error.
@@ -210,18 +249,22 @@ mod config_tests {
 /// Seed state from the `session_mirror_cursor` table at startup, then loop:
 /// stat each discovered file, tail any new bytes, sleep.
 ///
-/// Claude Code and Codex mirrors are independent: each is enabled by its own
-/// flag and scanned separately each tick.
+/// Every source is independent: each is enabled by its own flag and scanned
+/// separately each tick.
 ///
 /// Per-file errors are logged with `tracing::warn!` and do NOT stop the loop.
 pub async fn run_mirror_service(runtime: KhiveRuntime, config: MirrorConfig) {
     tracing::info!(
         projects_dir = %config.projects_dir.display(),
         codex_sessions_dir = %config.codex_sessions_dir.display(),
+        chatgpt_exports_dir = %config.chatgpt_exports_dir.display(),
+        claude_ai_exports_dir = %config.claude_ai_exports_dir.display(),
         poll_interval_ms = config.poll_interval.as_millis(),
         backfill = config.backfill,
         cc_enabled = config.enabled,
         codex_enabled = config.codex_enabled,
+        chatgpt_enabled = config.chatgpt_enabled,
+        claude_ai_enabled = config.claude_ai_enabled,
         "session mirror service starting"
     );
 
@@ -262,6 +305,12 @@ pub async fn run_mirror_service(runtime: KhiveRuntime, config: MirrorConfig) {
             }
         }
 
+        if config.claude_ai_enabled {
+            for item in scan_claude_ai_conversations_files(&config.claude_ai_exports_dir) {
+                discovered.push(item);
+            }
+        }
+
         let total_tracked = discovered.len();
         let mut files_mirrored: u64 = 0;
         let mut rows_inserted: u64 = 0;
@@ -292,7 +341,7 @@ pub async fn run_mirror_service(runtime: KhiveRuntime, config: MirrorConfig) {
                 continue;
             }
 
-            // Tail (line-tail sources) or whole-file re-read (ChatGPT export).
+            // Tail line sources or re-read provider exports whole.
             let result = match &item.kind {
                 DiscoveredKind::LineTail { source, session_id } => {
                     ingest::mirror_file(
@@ -306,6 +355,9 @@ pub async fn run_mirror_service(runtime: KhiveRuntime, config: MirrorConfig) {
                 }
                 DiscoveredKind::ChatGptExport => {
                     ingest::mirror_chatgpt_export_file(&runtime, &item.path, offset).await
+                }
+                DiscoveredKind::ClaudeAiExport => {
+                    ingest::mirror_claude_ai_export_file(&runtime, &item.path, offset).await
                 }
             };
 
@@ -493,6 +545,43 @@ fn scan_chatgpt_dir_recursive(dir: &std::path::Path, out: &mut Vec<DiscoveredFil
             out.push(DiscoveredFile {
                 path,
                 kind: DiscoveredKind::ChatGptExport,
+            });
+        }
+    }
+}
+
+/// Find `conversations.json` claude.ai export files under `path`.
+///
+/// The configured root is distinct from the ChatGPT export root because the
+/// two providers use the same filename for incompatible JSON shapes.
+fn scan_claude_ai_conversations_files(path: &std::path::Path) -> Vec<DiscoveredFile> {
+    let mut files = Vec::new();
+    if path.is_file() {
+        if path.file_name().and_then(|name| name.to_str()) == Some("conversations.json") {
+            files.push(DiscoveredFile {
+                path: path.to_path_buf(),
+                kind: DiscoveredKind::ClaudeAiExport,
+            });
+        }
+        return files;
+    }
+    scan_claude_ai_dir_recursive(path, &mut files);
+    files
+}
+
+fn scan_claude_ai_dir_recursive(dir: &std::path::Path, out: &mut Vec<DiscoveredFile>) {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return;
+    };
+
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.is_dir() {
+            scan_claude_ai_dir_recursive(&path, out);
+        } else if path.file_name().and_then(|name| name.to_str()) == Some("conversations.json") {
+            out.push(DiscoveredFile {
+                path,
+                kind: DiscoveredKind::ClaudeAiExport,
             });
         }
     }

--- a/crates/khive-pack-session/src/pack.rs
+++ b/crates/khive-pack-session/src/pack.rs
@@ -88,7 +88,11 @@ impl PackRuntime for SessionPack {
 
     async fn warm(&self) {
         let config = crate::mirror::MirrorConfig::from_env();
-        if !config.enabled && !config.codex_enabled && !config.chatgpt_enabled {
+        if !config.enabled
+            && !config.codex_enabled
+            && !config.chatgpt_enabled
+            && !config.claude_ai_enabled
+        {
             return;
         }
         let runtime = self.runtime().clone();

--- a/docs/adr/ADR-080-session-pack-oss-storage-mechanism.md
+++ b/docs/adr/ADR-080-session-pack-oss-storage-mechanism.md
@@ -2,7 +2,7 @@
 
 **Status**: accepted
 **Date**: 2026-06-28
-**Amended**: 2026-07-02 — shipped-surface record (§3), session mirror (§6), scope revision (Context)
+**Amended**: 2026-07-02 — shipped-surface record (§3), session mirror (§6), scope revision (Context); 2026-08-01 — claude.ai export source (§6)
 **Superseded by**: [ADR-083](ADR-083-session-pack-t1-verbs.md) for §3 only; ADR-083 is
 the current authority for the public session verb surface, while the rest of this record
 remains in force.
@@ -203,18 +203,20 @@ spawned from `PackRuntime::warm()` when enabled, that tails known transcript loc
 the local filesystem and lands their content in the pack's auxiliary tables. It shipped as
 the M2 milestone of the session pack build (issue #350, PR #368) with the Claude Code
 source, gained the Codex CLI source in PR #375, and gains the ChatGPT export source with
-this amendment. The mirror is disabled by default and never writes to, moves, or deletes
-the files it reads.
+the 2026-07-02 amendment. The 2026-08-01 amendment adds claude.ai data exports as a
+separate fourth source. The mirror is disabled by default and never writes to, moves, or
+deletes the files it reads.
 
 #### Mirror sources — closed set
 
 `MirrorSource` is a closed enum. Adding a source requires amending this section.
 
-| Source         | `source` value   | Input shape                                        | Ingestion mode |
-| -------------- | ---------------- | -------------------------------------------------- | -------------- |
-| Claude Code    | `claude_code`    | `<projects dir>/**/<session-uuid>.jsonl`           | line-tail      |
-| Codex CLI      | `codex`          | `<sessions dir>/**/rollout-*-<session-uuid>.jsonl` | line-tail      |
-| ChatGPT export | `chatgpt_export` | `<exports dir>/**/conversations.json` (JSON array) | whole-file     |
+| Source           | `source` value     | Input shape                                        | Ingestion mode |
+| ---------------- | ------------------ | -------------------------------------------------- | -------------- |
+| Claude Code      | `claude_code`      | `<projects dir>/**/<session-uuid>.jsonl`           | line-tail      |
+| Codex CLI        | `codex`            | `<sessions dir>/**/rollout-*-<session-uuid>.jsonl` | line-tail      |
+| ChatGPT export   | `chatgpt_export`   | `<exports dir>/**/conversations.json` (JSON array) | whole-file     |
+| claude.ai export | `claude_ai_export` | `<exports dir>/**/conversations.json` (JSON array) | whole-file     |
 
 **Line-tail** (append-only JSONL): each pass reads from the file's stored byte offset,
 parses complete lines, and advances the cursor to the last complete line boundary. A file
@@ -236,6 +238,12 @@ true EOF mid-line), it resolves through the ordinary skip-and-advance path above
 the cursor is set to the file's byte length, so an unchanged export is skipped by the same
 length fast-path on every later pass. On parse failure — including a partially downloaded
 export — the cursor does not advance and the file is retried on the next pass.
+
+ChatGPT and claude.ai both name this file `conversations.json`, while the cursor key is the
+file path. Each export parser therefore rejects a document containing the other provider's
+recognizable conversation shape, and a mixed-provider array is unsupported. This leaves the
+cursor untouched instead of allowing a misconfigured overlapping root to let the wrong source
+consume that path first.
 
 #### Auxiliary schema
 
@@ -284,21 +292,54 @@ array of conversation objects, each carrying a `mapping` of message nodes formin
 - Discovery is a recursive scan of the configured directory for files named exactly
   `conversations.json`, so both a bare file and unpacked export archives work.
 
+#### claude.ai export mapping (Amendment, 2026-08-01)
+
+The claude.ai source ingests the `conversations.json` from Claude's data export through a
+parser distinct from both Claude Code and ChatGPT. Its top-level array contains conversation
+objects with `uuid`, `name`, and `chat_messages` rather than ChatGPT's `id` / `mapping` tree.
+
+- One conversation object becomes one `sessions` row. `id` and
+  `provider_session_id` are the conversation `uuid`; `slug` carries `name` (falling back to
+  `summary`); `cwd` and `git_branch` are null.
+- Each non-empty message with a `uuid` becomes a `session_messages` row keyed on that UUID.
+  `human` is normalized to role `user`; `assistant` remains `assistant`, with legacy `role`
+  accepted when `sender` is absent. Events are emitted by numeric `index`, with source-array
+  position as the deterministic fallback and tie-breaker.
+- `parent_uuid` comes from `parent_message_uuid`. The provider's all-zero root sentinel and
+  parents that did not produce a stored event become null, so the stored graph has no dangling
+  export-only parent reference.
+- When `current_leaf_message_uuid` is present, the parent chain to that leaf is the current
+  path and all other retained messages have `is_sidechain = true`. Older flat exports without
+  an active-leaf field keep every message on the main path. Alternate branches are preserved;
+  selecting one remains a view concern.
+- Timestamps fall back per message: `created_at`, then `updated_at`, then the conversation's
+  `created_at` / `updated_at`, else zero — parsed as RFC 3339 and converted to microseconds.
+- Visible text comes from supported structured blocks (`text`, `voice_note`, `tool_use`,
+  `tool_result`); thinking and unknown internal blocks are not display text. A distinct
+  top-level `text` value is appended after the blocks because agent turns can carry both tool
+  activity and a separate final answer; an exact duplicate of a text block is emitted once.
+  Text and serialized raw messages use the same unconditional secret masking as every source.
+- Discovery recursively scans the independently configured claude.ai export root for files
+  named exactly `conversations.json`; the separate root is necessary because ChatGPT uses the
+  same filename for an incompatible JSON shape.
+
 #### Configuration
 
 Most configuration is environment-driven, read once into `MirrorConfig` when `warm()`
 starts the service:
 
-| Variable                       | Default                  |
-| ------------------------------ | ------------------------ |
-| `KHIVE_MIRROR_ENABLED`         | `false`                  |
-| `KHIVE_MIRROR_PROJECTS_DIR`    | `$HOME/.claude/projects` |
-| `KHIVE_MIRROR_CODEX_ENABLED`   | `false`                  |
-| `KHIVE_MIRROR_CODEX_DIR`       | `$HOME/.codex/sessions`  |
-| `KHIVE_MIRROR_CHATGPT_ENABLED` | `false`                  |
-| `KHIVE_MIRROR_CHATGPT_DIR`     | `$HOME/.chatgpt/exports` |
-| `KHIVE_MIRROR_POLL_SECS`       | `2`                      |
-| `KHIVE_MIRROR_BACKFILL`        | `true`                   |
+| Variable                         | Default                  |
+| -------------------------------- | ------------------------ |
+| `KHIVE_MIRROR_ENABLED`           | `false`                  |
+| `KHIVE_MIRROR_PROJECTS_DIR`      | `$HOME/.claude/projects` |
+| `KHIVE_MIRROR_CODEX_ENABLED`     | `false`                  |
+| `KHIVE_MIRROR_CODEX_DIR`         | `$HOME/.codex/sessions`  |
+| `KHIVE_MIRROR_CHATGPT_ENABLED`   | `false`                  |
+| `KHIVE_MIRROR_CHATGPT_DIR`       | `$HOME/.chatgpt/exports` |
+| `KHIVE_MIRROR_CLAUDE_AI_ENABLED` | `false`                  |
+| `KHIVE_MIRROR_CLAUDE_AI_DIR`     | `$HOME/.claude/exports`  |
+| `KHIVE_MIRROR_POLL_SECS`         | `2`                      |
+| `KHIVE_MIRROR_BACKFILL`          | `true`                   |
 
 `KHIVE_MIRROR_CHATGPT_MAX_BYTES` (default `268435456`, 256 MiB) is read separately, per
 pass, by `mirror_chatgpt_export_file` itself rather than through `MirrorConfig`. It is a
@@ -307,6 +348,9 @@ has no incremental delta to bound the way the line-tail sources do): an export o
 ceiling is skipped for that pass — `tracing::warn!`-logged, never `read_to_string`'d — and
 its cursor is left untouched, so it is retried (and re-warned) on every later tick rather
 than silently dropped forever. A zero or non-numeric value falls back to the default.
+
+`KHIVE_MIRROR_CLAUDE_AI_MAX_BYTES` applies the same 256 MiB default and fallback behavior
+independently to `mirror_claude_ai_export_file`.
 
 #### What remains out of scope
 

--- a/docs/adr/ADR-083-session-pack-t1-verbs.md
+++ b/docs/adr/ADR-083-session-pack-t1-verbs.md
@@ -237,11 +237,11 @@ ADR-071 `BackendHandle` seam per ADR-080 §5.
 ### 5. The session mirror is unaffected
 
 ADR-080 §6 documents the session mirror: a read-only background poll loop, spawned from
-`PackRuntime::warm()`, that tails Claude Code, Codex CLI, and ChatGPT-export transcripts into three
-auxiliary tables (`sessions`, `session_messages`, `session_mirror_cursor`) declared through the
-pack's `SCHEMA_PLAN` (`SESSION_SCHEMA_PLAN_STMTS`, the ADR-028 mechanism). It shipped as the pack's
-M2 milestone (issue #350, PR #368), gained the Codex CLI source in PR #375, and is disabled by
-default.
+`PackRuntime::warm()`, that ingests Claude Code, Codex CLI, ChatGPT-export, and claude.ai-export
+transcripts into three auxiliary tables (`sessions`, `session_messages`,
+`session_mirror_cursor`) declared through the pack's `SCHEMA_PLAN`
+(`SESSION_SCHEMA_PLAN_STMTS`, the ADR-028 mechanism). It shipped as the pack's M2 milestone
+(issue #350, PR #368), gained the Codex CLI source in PR #375, and is disabled by default.
 
 The T1 verb surface and the session mirror are additive, not a replacement. This is a deliberate
 design ruling. T1's four verbs read and write `kind=session` notes in the shared `notes` table.

--- a/docs/adr/ADR-117-session-continuity-search.md
+++ b/docs/adr/ADR-117-session-continuity-search.md
@@ -59,12 +59,12 @@ split that [ADR-083](ADR-083-session-pack-t1-verbs.md) makes deliberately:
 
 1. **Caller-authored session notes.** The four T1 verbs (`session.store` / `list` / `resume` /
    `export`) read and write the shared `notes` table. These are records a caller explicitly stores.
-2. **Passively-mirrored transcript tables.** A background mirror tails Claude Code, Codex CLI, and
-   ChatGPT exports and writes three auxiliary tables — `sessions` (one row per transcript, carrying
-   `provider_session_id`, source, cwd, git_branch, timestamps), `session_messages` (the parsed
-   message text plus raw line), and `session_mirror_cursor` (a byte-offset cursor). ADR-083 keeps
-   these separate from the notes precisely because one is caller-authored and one is passive
-   ingestion.
+2. **Passively-mirrored transcript tables.** A background mirror ingests Claude Code, Codex CLI,
+   ChatGPT exports, and claude.ai exports and writes three auxiliary tables — `sessions` (one row
+   per transcript, carrying `provider_session_id`, source, cwd, git_branch, timestamps),
+   `session_messages` (the parsed message text plus raw source), and `session_mirror_cursor` (a
+   byte-offset cursor). ADR-083 keeps these separate from the notes precisely because one is
+   caller-authored and one is passive ingestion.
 
 Two facts about the mirror as it exists today shape every requirement below, and both were verified
 against source rather than assumed:
@@ -72,12 +72,12 @@ against source rather than assumed:
 - **The persistence identity is a bare global primary key.** `session_messages.id` and `sessions.id`
   are each `TEXT PRIMARY KEY` with no account or tenant component
   (`crates/khive-pack-session/src/vocab.rs`). `session_messages.id` is populated from
-  `ParsedEvent.uuid` — the Claude Code top-level `uuid`, the ChatGPT `message.id`, or the synthesized
-  `"{session_id}:{byte_offset}"` for Codex (`crates/khive-pack-session/src/mirror/parse.rs`). Those
-  are **provider event ids**, unique enough for the single-writer mirror's idempotency, but not
-  tenant-scoped: two accounts that produced the same provider event id would collide on one primary
-  key. The `namespace` column is nullable and is not part of any key. **The mirror is single-tenant
-  by construction.**
+  `ParsedEvent.uuid` — the Claude Code top-level `uuid`, the ChatGPT `message.id`, the claude.ai
+  `chat_messages[].uuid`, or the synthesized `"{session_id}:{byte_offset}"` for Codex
+  (`crates/khive-pack-session/src/mirror/parse.rs`). Those are **provider event ids**, unique enough
+  for the single-writer mirror's idempotency, but not tenant-scoped: two accounts that produced the
+  same provider event id would collide on one primary key. The `namespace` column is nullable and
+  is not part of any key. **The mirror is single-tenant by construction.**
 - **There is no search over message content.** `session.resume` fetches a single session by id;
   `session.list` is a recency browse. The transcript text sits in `session_messages` and is not
   indexed for retrieval.

--- a/docs/adr/ADR-117a-session-identity-tenant-isolation.md
+++ b/docs/adr/ADR-117a-session-identity-tenant-isolation.md
@@ -41,10 +41,11 @@ Three source facts set the mechanism:
    `session_messages.id` are each `TEXT PRIMARY KEY` with no tenant component, and both tables carry
    a nullable `namespace TEXT` column that is part of no key
    (`crates/khive-pack-session/src/vocab.rs`, `SESSION_SCHEMA_PLAN_STMTS`). `session_messages.id` is a
-   provider event id (Claude Code top-level `uuid`, ChatGPT `message.id`, or the synthesized
-   `"{session_id}:{byte_offset}"` for Codex — `mirror/parse.rs`), unique enough for the single-writer
-   mirror's idempotency but not across tenants. The mirror is single-tenant by construction; the
-   latent tenant scope is exactly that unused `namespace` column.
+   provider event id (Claude Code top-level `uuid`, ChatGPT `message.id`, claude.ai
+   `chat_messages[].uuid`, or the synthesized `"{session_id}:{byte_offset}"` for Codex —
+   `mirror/parse.rs`), unique enough for the single-writer mirror's idempotency but not across
+   tenants. The mirror is single-tenant by construction; the latent tenant scope is exactly that
+   unused `namespace` column.
 
 2. **The session schema is pack-owned and applied idempotently.** `SESSION_SCHEMA_PLAN_STMTS` is a set
    of `CREATE TABLE/INDEX IF NOT EXISTS` statements applied at boot via the pack's `schema_plan` hook

--- a/docs/guide/sessions-and-ingest.md
+++ b/docs/guide/sessions-and-ingest.md
@@ -9,8 +9,8 @@ parts that are easy to conflate but serve different purposes:
   `session.export`): explicit, caller-driven persistence of a session record
   as a khive note.
 - **Provider mirror ingest**: an optional background service that tails
-  agent CLI transcript files and ChatGPT data exports into their own SQL
-  tables, entirely separate from the note substrate.
+  agent CLI transcript files and ChatGPT or claude.ai data exports into their
+  own SQL tables, entirely separate from the note substrate.
 
 Do not assume these two share storage. A session stored via `session.store`
 is a `kind=session` note, queryable like any other note. A conversation
@@ -104,7 +104,7 @@ does not create `session` notes.
 
 ### Supported providers
 
-Only three sources are implemented (`MirrorSource` in
+Four sources are implemented (`MirrorSource` in
 [`src/mirror/ingest.rs`](../../crates/khive-pack-session/src/mirror/ingest.rs)):
 
 - **Claude Code CLI transcripts** (`claude_code`): JSONL files under
@@ -114,10 +114,11 @@ Only three sources are implemented (`MirrorSource` in
 - **ChatGPT data exports** (`chatgpt_export`): a `conversations.json` file
   (the format ChatGPT's "export data" produces) under
   `KHIVE_MIRROR_CHATGPT_DIR`.
-
-There is no ingest path for claude.ai (the web product) conversation history.
-If a future provider adds that, it belongs here as a fourth `MirrorSource`
-variant, not folded into the existing ChatGPT or Claude Code parsers.
+- **claude.ai data exports** (`claude_ai_export`): the distinct
+  `conversations.json` shape from Claude's data export, under
+  `KHIVE_MIRROR_CLAUDE_AI_DIR`. Conversation and message UUIDs are preserved;
+  alternate branches are retained when the export supplies parent/active-leaf
+  metadata.
 
 ### Enabling it
 
@@ -132,16 +133,18 @@ not run that daemon warm path. So, like the email channel loops described in
 is what actually starts background ingestion; a stdio session never spawns
 its own mirror poller.
 
-| Variable                       | Default                  |
-| ------------------------------ | ------------------------ |
-| `KHIVE_MIRROR_ENABLED`         | `false`                  |
-| `KHIVE_MIRROR_PROJECTS_DIR`    | `$HOME/.claude/projects` |
-| `KHIVE_MIRROR_CODEX_ENABLED`   | `false`                  |
-| `KHIVE_MIRROR_CODEX_DIR`       | `$HOME/.codex/sessions`  |
-| `KHIVE_MIRROR_CHATGPT_ENABLED` | `false`                  |
-| `KHIVE_MIRROR_CHATGPT_DIR`     | `$HOME/.chatgpt/exports` |
-| `KHIVE_MIRROR_POLL_SECS`       | `2`                      |
-| `KHIVE_MIRROR_BACKFILL`        | `true`                   |
+| Variable                         | Default                  |
+| -------------------------------- | ------------------------ |
+| `KHIVE_MIRROR_ENABLED`           | `false`                  |
+| `KHIVE_MIRROR_PROJECTS_DIR`      | `$HOME/.claude/projects` |
+| `KHIVE_MIRROR_CODEX_ENABLED`     | `false`                  |
+| `KHIVE_MIRROR_CODEX_DIR`         | `$HOME/.codex/sessions`  |
+| `KHIVE_MIRROR_CHATGPT_ENABLED`   | `false`                  |
+| `KHIVE_MIRROR_CHATGPT_DIR`       | `$HOME/.chatgpt/exports` |
+| `KHIVE_MIRROR_CLAUDE_AI_ENABLED` | `false`                  |
+| `KHIVE_MIRROR_CLAUDE_AI_DIR`     | `$HOME/.claude/exports`  |
+| `KHIVE_MIRROR_POLL_SECS`         | `2`                      |
+| `KHIVE_MIRROR_BACKFILL`          | `true`                   |
 
 `KHIVE_MIRROR_POLL_SECS=0` is rejected (falls back to the default rather than
 busy-looping); a non-numeric value likewise falls back to the default, with a
@@ -157,8 +160,9 @@ rather than re-reading from the start. Writes into `sessions` and
 re-processed byte range does not duplicate rows. `provider_session_id`
 values are the mirror's continuity anchor across restarts. Reads are bounded
 in size (a byte/line/event cap per read) so a single oversized file cannot
-stall the tailer; the ChatGPT export path additionally caps the whole file
-at `KHIVE_MIRROR_CHATGPT_MAX_BYTES` (default 256 MiB).
+stall the tailer; the export paths additionally cap each whole file at
+`KHIVE_MIRROR_CHATGPT_MAX_BYTES` or
+`KHIVE_MIRROR_CLAUDE_AI_MAX_BYTES` (both default 256 MiB).
 
 ### Worked example
 

--- a/docs/guide/sessions-and-ingest.md
+++ b/docs/guide/sessions-and-ingest.md
@@ -118,7 +118,8 @@ Four sources are implemented (`MirrorSource` in
   `conversations.json` shape from Claude's data export, under
   `KHIVE_MIRROR_CLAUDE_AI_DIR`. Conversation and message UUIDs are preserved;
   alternate branches are retained when the export supplies parent/active-leaf
-  metadata.
+  metadata. Every valid conversation creates a session row even when it has no
+  displayable messages.
 
 ### Enabling it
 


### PR DESCRIPTION
## Summary

- add a dedicated `claude_ai_export` mirror source and parser for claude.ai `conversations.json`, preserving provider conversation/message IDs, roles, timestamps, titles, parent links, and inactive branches
- discover and ingest claude.ai exports through the session mirror service without conflating their shape with ChatGPT or Claude Code transcripts
- persist valid empty or unsupported-only conversations and the whole-file cursor in the same atomic unit, while retaining idempotent replay and secret masking
- document the fourth session source, its size limit, source discrimination, and storage semantics

## Validation

- `cargo test --workspace`
- `cargo check --workspace`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `RUSTDOCFLAGS=-Dwarnings cargo doc --workspace --no-deps`

Closes #1502

> AI-assisted contribution: Codex prepared this change and PR description.
