### PR TITLE
fix(gtd): surface broken blockers and reject dependency cycles

### DIFF
--- a/crates/khive-db/sql/015-gtd-dependency-cycle-guards.sql
+++ b/crates/khive-db/sql/015-gtd-dependency-cycle-guards.sql
@@ -1,0 +1,162 @@
+-- V15: Commit-time cycle guards for GTD task dependencies.
+--
+-- The GTD pack performs typed, bounded reachability checks before canonical
+-- writes. These triggers are the transaction-time backstop shared by direct
+-- storage writes, concurrent requests, and kkernel's multi-op atomic executor.
+-- They are deliberately narrow: only live `task` note properties and live
+-- task-to-task `depends_on` edges are governed. Other note kinds, relations,
+-- and entity dependency graphs retain their existing behavior.
+
+CREATE TRIGGER IF NOT EXISTS gtd_task_dependency_cycle_notes_bi
+BEFORE INSERT ON notes
+WHEN NEW.kind = 'task'
+    AND NEW.deleted_at IS NULL
+    AND json_type(NEW.properties, '$.depends_on') = 'array'
+BEGIN
+    SELECT CASE WHEN EXISTS (
+        WITH RECURSIVE dependency_walk(id) AS (
+            SELECT value
+            FROM json_each(NEW.properties, '$.depends_on')
+            WHERE type = 'text'
+            UNION
+            SELECT dependency.value
+            FROM dependency_walk AS walk
+            JOIN notes AS task
+                ON task.id = walk.id
+                AND task.namespace = NEW.namespace
+                AND task.kind = 'task'
+                AND task.deleted_at IS NULL
+            JOIN json_each(task.properties, '$.depends_on') AS dependency
+                ON dependency.type = 'text'
+        )
+        SELECT 1
+        FROM dependency_walk
+        WHERE id = NEW.id
+    ) THEN RAISE(ABORT, 'task properties.depends_on dependency cycle') END;
+END;
+
+CREATE TRIGGER IF NOT EXISTS gtd_task_dependency_cycle_notes_bu
+BEFORE UPDATE OF id, namespace, kind, properties, deleted_at ON notes
+WHEN NEW.kind = 'task'
+    AND NEW.deleted_at IS NULL
+    AND json_type(NEW.properties, '$.depends_on') = 'array'
+BEGIN
+    SELECT CASE WHEN EXISTS (
+        WITH RECURSIVE dependency_walk(id) AS (
+            SELECT value
+            FROM json_each(NEW.properties, '$.depends_on')
+            WHERE type = 'text'
+            UNION
+            SELECT dependency.value
+            FROM dependency_walk AS walk
+            JOIN notes AS task
+                ON task.id = walk.id
+                AND task.namespace = NEW.namespace
+                AND task.kind = 'task'
+                AND task.deleted_at IS NULL
+            JOIN json_each(task.properties, '$.depends_on') AS dependency
+                ON dependency.type = 'text'
+        )
+        SELECT 1
+        FROM dependency_walk
+        WHERE id = NEW.id
+    ) THEN RAISE(ABORT, 'task properties.depends_on dependency cycle') END;
+END;
+
+CREATE TRIGGER IF NOT EXISTS gtd_task_dependency_cycle_edges_bi
+BEFORE INSERT ON graph_edges
+WHEN NEW.relation = 'depends_on'
+    AND NEW.deleted_at IS NULL
+    AND EXISTS (
+        SELECT 1
+        FROM notes
+        WHERE id = NEW.source_id
+            AND kind = 'task'
+            AND deleted_at IS NULL
+    )
+    AND EXISTS (
+        SELECT 1
+        FROM notes
+        WHERE id = NEW.target_id
+            AND kind = 'task'
+            AND deleted_at IS NULL
+    )
+BEGIN
+    SELECT CASE WHEN EXISTS (
+        WITH RECURSIVE dependency_walk(id) AS (
+            SELECT NEW.target_id
+            UNION
+            SELECT edge.target_id
+            FROM dependency_walk AS walk
+            JOIN graph_edges AS edge
+                ON edge.source_id = walk.id
+                AND edge.namespace = NEW.namespace
+                AND edge.relation = 'depends_on'
+                AND edge.deleted_at IS NULL
+                AND NOT (
+                    edge.namespace = NEW.namespace
+                    AND edge.id = NEW.id
+                )
+            JOIN notes AS source_task
+                ON source_task.id = edge.source_id
+                AND source_task.kind = 'task'
+                AND source_task.deleted_at IS NULL
+            JOIN notes AS target_task
+                ON target_task.id = edge.target_id
+                AND target_task.kind = 'task'
+                AND target_task.deleted_at IS NULL
+        )
+        SELECT 1
+        FROM dependency_walk
+        WHERE id = NEW.source_id
+    ) THEN RAISE(ABORT, 'task depends_on edge dependency cycle') END;
+END;
+
+CREATE TRIGGER IF NOT EXISTS gtd_task_dependency_cycle_edges_bu
+BEFORE UPDATE OF namespace, id, source_id, target_id, relation, deleted_at ON graph_edges
+WHEN NEW.relation = 'depends_on'
+    AND NEW.deleted_at IS NULL
+    AND EXISTS (
+        SELECT 1
+        FROM notes
+        WHERE id = NEW.source_id
+            AND kind = 'task'
+            AND deleted_at IS NULL
+    )
+    AND EXISTS (
+        SELECT 1
+        FROM notes
+        WHERE id = NEW.target_id
+            AND kind = 'task'
+            AND deleted_at IS NULL
+    )
+BEGIN
+    SELECT CASE WHEN EXISTS (
+        WITH RECURSIVE dependency_walk(id) AS (
+            SELECT NEW.target_id
+            UNION
+            SELECT edge.target_id
+            FROM dependency_walk AS walk
+            JOIN graph_edges AS edge
+                ON edge.source_id = walk.id
+                AND edge.namespace = NEW.namespace
+                AND edge.relation = 'depends_on'
+                AND edge.deleted_at IS NULL
+                AND NOT (
+                    edge.namespace = OLD.namespace
+                    AND edge.id = OLD.id
+                )
+            JOIN notes AS source_task
+                ON source_task.id = edge.source_id
+                AND source_task.kind = 'task'
+                AND source_task.deleted_at IS NULL
+            JOIN notes AS target_task
+                ON target_task.id = edge.target_id
+                AND target_task.kind = 'task'
+                AND target_task.deleted_at IS NULL
+        )
+        SELECT 1
+        FROM dependency_walk
+        WHERE id = NEW.source_id
+    ) THEN RAISE(ABORT, 'task depends_on edge dependency cycle') END;
+END;

--- a/crates/khive-db/sql/015-gtd-dependency-cycle-guards.sql
+++ b/crates/khive-db/sql/015-gtd-dependency-cycle-guards.sql
@@ -6,6 +6,12 @@
 -- They are deliberately narrow: only live `task` note properties and live
 -- task-to-task `depends_on` edges are governed. Other note kinds, relations,
 -- and entity dependency graphs retain their existing behavior.
+--
+-- Typed update paths require lowercase hyphenated UUIDs. The note triggers
+-- still normalize case, hyphens, braces, and the `urn:uuid:` prefix while
+-- comparing keys so a direct-storage writer cannot evade the durable guard
+-- with another spelling accepted by `Uuid::parse_str`. Recursive expansion
+-- is array-only; malformed legacy scalar/object values are not edges.
 
 CREATE TRIGGER IF NOT EXISTS gtd_task_dependency_cycle_notes_bi
 BEFORE INSERT ON notes
@@ -15,23 +21,45 @@ WHEN NEW.kind = 'task'
 BEGIN
     SELECT CASE WHEN EXISTS (
         WITH RECURSIVE dependency_walk(id) AS (
-            SELECT value
+            SELECT lower(replace(replace(replace(
+                CASE
+                    WHEN lower(value) LIKE 'urn:uuid:%' THEN substr(value, 10)
+                    ELSE value
+                END,
+                '-', ''), '{', ''), '}', ''))
             FROM json_each(NEW.properties, '$.depends_on')
             WHERE type = 'text'
             UNION
-            SELECT dependency.value
+            SELECT lower(replace(replace(replace(
+                CASE
+                    WHEN lower(dependency.value) LIKE 'urn:uuid:%'
+                        THEN substr(dependency.value, 10)
+                    ELSE dependency.value
+                END,
+                '-', ''), '{', ''), '}', ''))
             FROM dependency_walk AS walk
             JOIN notes AS task
-                ON task.id = walk.id
+                ON lower(replace(replace(replace(
+                    CASE
+                        WHEN lower(task.id) LIKE 'urn:uuid:%' THEN substr(task.id, 10)
+                        ELSE task.id
+                    END,
+                    '-', ''), '{', ''), '}', '')) = walk.id
                 AND task.namespace = NEW.namespace
                 AND task.kind = 'task'
                 AND task.deleted_at IS NULL
             JOIN json_each(task.properties, '$.depends_on') AS dependency
-                ON dependency.type = 'text'
+                ON json_type(task.properties, '$.depends_on') = 'array'
+                AND dependency.type = 'text'
         )
         SELECT 1
         FROM dependency_walk
-        WHERE id = NEW.id
+        WHERE id = lower(replace(replace(replace(
+            CASE
+                WHEN lower(NEW.id) LIKE 'urn:uuid:%' THEN substr(NEW.id, 10)
+                ELSE NEW.id
+            END,
+            '-', ''), '{', ''), '}', ''))
     ) THEN RAISE(ABORT, 'task properties.depends_on dependency cycle') END;
 END;
 
@@ -43,23 +71,45 @@ WHEN NEW.kind = 'task'
 BEGIN
     SELECT CASE WHEN EXISTS (
         WITH RECURSIVE dependency_walk(id) AS (
-            SELECT value
+            SELECT lower(replace(replace(replace(
+                CASE
+                    WHEN lower(value) LIKE 'urn:uuid:%' THEN substr(value, 10)
+                    ELSE value
+                END,
+                '-', ''), '{', ''), '}', ''))
             FROM json_each(NEW.properties, '$.depends_on')
             WHERE type = 'text'
             UNION
-            SELECT dependency.value
+            SELECT lower(replace(replace(replace(
+                CASE
+                    WHEN lower(dependency.value) LIKE 'urn:uuid:%'
+                        THEN substr(dependency.value, 10)
+                    ELSE dependency.value
+                END,
+                '-', ''), '{', ''), '}', ''))
             FROM dependency_walk AS walk
             JOIN notes AS task
-                ON task.id = walk.id
+                ON lower(replace(replace(replace(
+                    CASE
+                        WHEN lower(task.id) LIKE 'urn:uuid:%' THEN substr(task.id, 10)
+                        ELSE task.id
+                    END,
+                    '-', ''), '{', ''), '}', '')) = walk.id
                 AND task.namespace = NEW.namespace
                 AND task.kind = 'task'
                 AND task.deleted_at IS NULL
             JOIN json_each(task.properties, '$.depends_on') AS dependency
-                ON dependency.type = 'text'
+                ON json_type(task.properties, '$.depends_on') = 'array'
+                AND dependency.type = 'text'
         )
         SELECT 1
         FROM dependency_walk
-        WHERE id = NEW.id
+        WHERE id = lower(replace(replace(replace(
+            CASE
+                WHEN lower(NEW.id) LIKE 'urn:uuid:%' THEN substr(NEW.id, 10)
+                ELSE NEW.id
+            END,
+            '-', ''), '{', ''), '}', ''))
     ) THEN RAISE(ABORT, 'task properties.depends_on dependency cycle') END;
 END;
 

--- a/crates/khive-db/sql/015-gtd-dependency-cycle-guards.sql
+++ b/crates/khive-db/sql/015-gtd-dependency-cycle-guards.sql
@@ -98,6 +98,11 @@ BEGIN
                 AND task.namespace = NEW.namespace
                 AND task.kind = 'task'
                 AND task.deleted_at IS NULL
+                -- OLD remains visible in a BEFORE UPDATE but its old key does not.
+                AND (
+                    OLD.id = NEW.id
+                    OR task.id <> OLD.id
+                )
             JOIN json_each(task.properties, '$.depends_on') AS dependency
                 ON json_type(task.properties, '$.depends_on') = 'array'
                 AND dependency.type = 'text'
@@ -111,6 +116,53 @@ BEGIN
             END,
             '-', ''), '{', ''), '}', ''))
     ) THEN RAISE(ABORT, 'task properties.depends_on dependency cycle') END;
+END;
+
+CREATE TRIGGER IF NOT EXISTS gtd_task_dependency_cycle_note_activation_bi
+BEFORE INSERT ON notes
+WHEN NEW.kind = 'task'
+    AND NEW.deleted_at IS NULL
+BEGIN
+    -- NEW is not visible through notes during a BEFORE INSERT trigger, so
+    -- carry its id explicitly as the endpoint this statement would activate.
+    SELECT CASE WHEN EXISTS (
+        WITH RECURSIVE dependency_walk(namespace, id) AS (
+            SELECT edge.namespace, edge.target_id
+            FROM graph_edges AS edge
+            WHERE edge.source_id = NEW.id
+                AND edge.relation = 'depends_on'
+                AND edge.deleted_at IS NULL
+                AND (
+                    edge.target_id = NEW.id
+                    OR EXISTS (
+                        SELECT 1
+                        FROM notes AS target_task
+                        WHERE target_task.id = edge.target_id
+                            AND target_task.kind = 'task'
+                            AND target_task.deleted_at IS NULL
+                    )
+                )
+            UNION
+            SELECT edge.namespace, edge.target_id
+            FROM dependency_walk AS walk
+            JOIN graph_edges AS edge
+                ON edge.namespace = walk.namespace
+                AND edge.source_id = walk.id
+                AND edge.relation = 'depends_on'
+                AND edge.deleted_at IS NULL
+            WHERE edge.target_id = NEW.id
+                OR EXISTS (
+                    SELECT 1
+                    FROM notes AS target_task
+                    WHERE target_task.id = edge.target_id
+                        AND target_task.kind = 'task'
+                        AND target_task.deleted_at IS NULL
+                )
+        )
+        SELECT 1
+        FROM dependency_walk
+        WHERE id = NEW.id
+    ) THEN RAISE(ABORT, 'task depends_on edge dependency cycle') END;
 END;
 
 CREATE TRIGGER IF NOT EXISTS gtd_task_dependency_cycle_note_activation_bu

--- a/crates/khive-db/sql/015-gtd-dependency-cycle-guards.sql
+++ b/crates/khive-db/sql/015-gtd-dependency-cycle-guards.sql
@@ -113,6 +113,69 @@ BEGIN
     ) THEN RAISE(ABORT, 'task properties.depends_on dependency cycle') END;
 END;
 
+CREATE TRIGGER IF NOT EXISTS gtd_task_dependency_cycle_note_activation_bu
+BEFORE UPDATE OF id, kind, deleted_at ON notes
+WHEN NEW.kind = 'task'
+    AND NEW.deleted_at IS NULL
+    AND (
+        OLD.kind <> 'task'
+        OR OLD.deleted_at IS NOT NULL
+        OR OLD.id <> NEW.id
+    )
+BEGIN
+    -- The row still has its OLD kind/deletion state in a BEFORE trigger, so
+    -- carry NEW.id explicitly as the endpoint this statement would activate.
+    -- Every cycle through that newly-live endpoint has an outgoing edge from
+    -- NEW.id and a same-namespace path back to it. On an id replacement,
+    -- OLD.id is excluded because that endpoint disappears with the update.
+    SELECT CASE WHEN EXISTS (
+        WITH RECURSIVE dependency_walk(namespace, id) AS (
+            SELECT edge.namespace, edge.target_id
+            FROM graph_edges AS edge
+            WHERE edge.source_id = NEW.id
+                AND edge.relation = 'depends_on'
+                AND edge.deleted_at IS NULL
+                AND (
+                    edge.target_id = NEW.id
+                    OR EXISTS (
+                        SELECT 1
+                        FROM notes AS target_task
+                        WHERE target_task.id = edge.target_id
+                            AND target_task.kind = 'task'
+                            AND target_task.deleted_at IS NULL
+                            AND (
+                                OLD.id = NEW.id
+                                OR target_task.id <> OLD.id
+                            )
+                    )
+                )
+            UNION
+            SELECT edge.namespace, edge.target_id
+            FROM dependency_walk AS walk
+            JOIN graph_edges AS edge
+                ON edge.namespace = walk.namespace
+                AND edge.source_id = walk.id
+                AND edge.relation = 'depends_on'
+                AND edge.deleted_at IS NULL
+            WHERE edge.target_id = NEW.id
+                OR EXISTS (
+                    SELECT 1
+                    FROM notes AS target_task
+                    WHERE target_task.id = edge.target_id
+                        AND target_task.kind = 'task'
+                        AND target_task.deleted_at IS NULL
+                        AND (
+                            OLD.id = NEW.id
+                            OR target_task.id <> OLD.id
+                        )
+                )
+        )
+        SELECT 1
+        FROM dependency_walk
+        WHERE id = NEW.id
+    ) THEN RAISE(ABORT, 'task depends_on edge dependency cycle') END;
+END;
+
 CREATE TRIGGER IF NOT EXISTS gtd_task_dependency_cycle_edges_bi
 BEFORE INSERT ON graph_edges
 WHEN NEW.relation = 'depends_on'

--- a/crates/khive-db/src/migrations.rs
+++ b/crates/khive-db/src/migrations.rs
@@ -129,6 +129,8 @@ const V13_UP: &str = include_str!("../sql/013-list-cursor-sequences.sql");
 
 const V14_UP: &str = include_str!("../sql/014-graph-edges-id-unique.sql");
 
+const V15_UP: &str = include_str!("../sql/015-gtd-dependency-cycle-guards.sql");
+
 /// DDL for the `ann_write_log` delta table.
 ///
 /// Shared between migration V11 and the belt-and-suspenders creation in
@@ -222,6 +224,11 @@ pub const MIGRATIONS: &[VersionedMigration] = &[
         version: 14,
         name: "graph_edges_id_unique",
         up: V14_UP,
+    },
+    VersionedMigration {
+        version: 15,
+        name: "gtd_dependency_cycle_guards",
+        up: V15_UP,
     },
 ];
 

--- a/crates/khive-db/src/migrations_tests.rs
+++ b/crates/khive-db/src/migrations_tests.rs
@@ -125,6 +125,7 @@ fn v15_fresh_start_installs_narrow_gtd_dependency_cycle_guards() {
     for trigger in [
         "gtd_task_dependency_cycle_notes_bi",
         "gtd_task_dependency_cycle_notes_bu",
+        "gtd_task_dependency_cycle_note_activation_bu",
         "gtd_task_dependency_cycle_edges_bi",
         "gtd_task_dependency_cycle_edges_bu",
     ] {
@@ -403,6 +404,156 @@ fn v13_edge_guard_ignores_paths_through_soft_deleted_tasks() {
         None,
     )
     .expect("tombstoned task edges must not form a live dependency path");
+}
+
+#[test]
+fn v13_note_activation_rejects_dormant_edge_cycles() {
+    let mut conn = open_memory();
+    run_migrations(&mut conn).expect("migrations should succeed");
+
+    insert_dependency_test_note(&conn, "live-a", "task", "{}", None);
+    insert_dependency_test_note(&conn, "deleted-b", "task", "{}", Some(2));
+    insert_dependency_test_edge(
+        &conn,
+        "live-a-deleted-b",
+        "live-a",
+        "deleted-b",
+        "depends_on",
+        None,
+    )
+    .expect("edge to tombstoned task is dormant");
+    insert_dependency_test_edge(
+        &conn,
+        "deleted-b-live-a",
+        "deleted-b",
+        "live-a",
+        "depends_on",
+        None,
+    )
+    .expect("edge from tombstoned task is dormant");
+
+    let reactivation_error = conn
+        .execute(
+            "UPDATE notes SET deleted_at = NULL WHERE id = 'deleted-b'",
+            [],
+        )
+        .expect_err("reactivating a task endpoint must not expose an edge cycle");
+    assert!(
+        reactivation_error.to_string().contains("dependency cycle"),
+        "unexpected task-reactivation error: {reactivation_error}"
+    );
+    let remains_deleted: bool = conn
+        .query_row(
+            "SELECT deleted_at IS NOT NULL FROM notes WHERE id = 'deleted-b'",
+            [],
+            |row| row.get(0),
+        )
+        .expect("load rejected task reactivation");
+    assert!(remains_deleted, "the rejected reactivation must roll back");
+
+    insert_dependency_test_note(&conn, "live-c", "task", "{}", None);
+    insert_dependency_test_note(&conn, "observation-d", "observation", "{}", None);
+    insert_dependency_test_edge(
+        &conn,
+        "live-c-observation-d",
+        "live-c",
+        "observation-d",
+        "depends_on",
+        None,
+    )
+    .expect("edge to non-task note is dormant");
+    insert_dependency_test_edge(
+        &conn,
+        "observation-d-live-c",
+        "observation-d",
+        "live-c",
+        "depends_on",
+        None,
+    )
+    .expect("edge from non-task note is dormant");
+
+    let conversion_error = conn
+        .execute(
+            "UPDATE notes SET kind = 'task' WHERE id = 'observation-d'",
+            [],
+        )
+        .expect_err("converting a note to a task must not expose an edge cycle");
+    assert!(
+        conversion_error.to_string().contains("dependency cycle"),
+        "unexpected task-conversion error: {conversion_error}"
+    );
+    let persisted_kind: String = conn
+        .query_row(
+            "SELECT kind FROM notes WHERE id = 'observation-d'",
+            [],
+            |row| row.get(0),
+        )
+        .expect("load rejected task conversion");
+    assert_eq!(persisted_kind, "observation");
+}
+
+#[test]
+fn v13_note_activation_preserves_acyclic_and_unrelated_edges() {
+    let mut conn = open_memory();
+    run_migrations(&mut conn).expect("migrations should succeed");
+
+    insert_dependency_test_note(&conn, "live-a", "task", "{}", None);
+    insert_dependency_test_note(&conn, "deleted-b", "task", "{}", Some(2));
+    insert_dependency_test_edge(
+        &conn,
+        "deleted-b-live-a",
+        "deleted-b",
+        "live-a",
+        "depends_on",
+        None,
+    )
+    .expect("acyclic edge from tombstoned task is dormant");
+    conn.execute(
+        "UPDATE notes SET deleted_at = NULL WHERE id = 'deleted-b'",
+        [],
+    )
+    .expect("acyclic task reactivation must remain allowed");
+
+    insert_dependency_test_note(&conn, "observation-c", "observation", "{}", None);
+    insert_dependency_test_edge(
+        &conn,
+        "live-a-observation-c",
+        "live-a",
+        "observation-c",
+        "depends_on",
+        None,
+    )
+    .expect("acyclic edge to non-task note is dormant");
+    conn.execute(
+        "UPDATE notes SET kind = 'task' WHERE id = 'observation-c'",
+        [],
+    )
+    .expect("acyclic task conversion must remain allowed");
+
+    insert_dependency_test_note(&conn, "deleted-d", "task", "{}", Some(2));
+    insert_dependency_test_edge(
+        &conn,
+        "live-a-deleted-d-related",
+        "live-a",
+        "deleted-d",
+        "related_to",
+        None,
+    )
+    .expect("first unrelated edge");
+    insert_dependency_test_edge(
+        &conn,
+        "deleted-d-live-a-related",
+        "deleted-d",
+        "live-a",
+        "related_to",
+        None,
+    )
+    .expect("second unrelated edge");
+    conn.execute(
+        "UPDATE notes SET deleted_at = NULL WHERE id = 'deleted-d'",
+        [],
+    )
+    .expect("unrelated edge cycles must not block task reactivation");
 }
 
 #[test]

--- a/crates/khive-db/src/migrations_tests.rs
+++ b/crates/khive-db/src/migrations_tests.rs
@@ -23,6 +23,38 @@ fn column_exists(conn: &Connection, table: &str, column: &str) -> bool {
     .unwrap_or(false)
 }
 
+fn insert_dependency_test_note(
+    conn: &Connection,
+    id: &str,
+    kind: &str,
+    properties: &str,
+    deleted_at: Option<i64>,
+) {
+    conn.execute(
+        "INSERT INTO notes \
+         (id, namespace, kind, status, name, content, properties, created_at, updated_at, deleted_at) \
+         VALUES (?1, 'local', ?2, 'active', ?1, '', ?3, 1, 1, ?4)",
+        rusqlite::params![id, kind, properties, deleted_at],
+    )
+    .expect("insert dependency-test note");
+}
+
+fn insert_dependency_test_edge(
+    conn: &Connection,
+    id: &str,
+    source_id: &str,
+    target_id: &str,
+    relation: &str,
+    deleted_at: Option<i64>,
+) -> rusqlite::Result<usize> {
+    conn.execute(
+        "INSERT INTO graph_edges \
+         (namespace, id, source_id, target_id, relation, weight, created_at, updated_at, deleted_at) \
+         VALUES ('local', ?1, ?2, ?3, ?4, 1.0, 1, 1, ?5)",
+        rusqlite::params![id, source_id, target_id, relation, deleted_at],
+    )
+}
+
 #[test]
 fn apply_schema_plan_rolls_back_migration_when_ledger_insert_fails() {
     static MIGRATIONS: &[Migration] = &[Migration {
@@ -83,6 +115,264 @@ fn fresh_db_migrates_to_latest() {
         MIGRATIONS.len() as i64,
         "ledger row count must equal the number of migrations"
     );
+}
+
+#[test]
+fn v15_fresh_start_installs_narrow_gtd_dependency_cycle_guards() {
+    let mut conn = open_memory();
+    run_migrations(&mut conn).expect("migrations should succeed");
+
+    for trigger in [
+        "gtd_task_dependency_cycle_notes_bi",
+        "gtd_task_dependency_cycle_notes_bu",
+        "gtd_task_dependency_cycle_edges_bi",
+        "gtd_task_dependency_cycle_edges_bu",
+    ] {
+        let exists: bool = conn
+            .query_row(
+                "SELECT COUNT(*) > 0 FROM sqlite_master WHERE type = 'trigger' AND name = ?1",
+                rusqlite::params![trigger],
+                |row| row.get(0),
+            )
+            .expect("query trigger catalog");
+        assert!(exists, "V15 must install {trigger}");
+    }
+
+    insert_dependency_test_note(&conn, "task-a", "task", r#"{"status":"next"}"#, None);
+    insert_dependency_test_note(&conn, "task-b", "task", r#"{"status":"next"}"#, None);
+    insert_dependency_test_note(&conn, "task-c", "task", r#"{"status":"next"}"#, None);
+    let insert_error = conn
+        .execute(
+            "INSERT INTO notes \
+             (id, namespace, kind, status, content, properties, created_at, updated_at) \
+             VALUES ('task-self', 'local', 'task', 'active', '', \
+                     '{\"depends_on\":[\"task-self\"]}', 1, 1)",
+            [],
+        )
+        .expect_err("the insert trigger must reject a direct property cycle");
+    assert!(
+        insert_error.to_string().contains("dependency cycle"),
+        "unexpected insert trigger error: {insert_error}"
+    );
+
+    conn.execute(
+        r#"UPDATE notes SET properties = '{"status":"next","depends_on":["task-b"]}' WHERE id = 'task-a'"#,
+        [],
+    )
+    .expect("first property dependency");
+    conn.execute(
+        r#"UPDATE notes SET properties = '{"status":"next","depends_on":["task-c"]}' WHERE id = 'task-b'"#,
+        [],
+    )
+    .expect("second property dependency");
+    let property_error = conn
+        .execute(
+            r#"UPDATE notes SET properties = '{"status":"next","depends_on":["task-a"]}' WHERE id = 'task-c'"#,
+            [],
+        )
+        .expect_err("closing a property cycle must fail at write time");
+    assert!(
+        property_error.to_string().contains("dependency cycle"),
+        "unexpected property trigger error: {property_error}"
+    );
+
+    insert_dependency_test_edge(&conn, "edge-a-b", "task-a", "task-b", "depends_on", None)
+        .expect("first edge dependency");
+    insert_dependency_test_edge(&conn, "edge-b-c", "task-b", "task-c", "depends_on", None)
+        .expect("second edge dependency");
+    let edge_error =
+        insert_dependency_test_edge(&conn, "edge-c-a", "task-c", "task-a", "depends_on", None)
+            .expect_err("closing an edge cycle must fail at write time");
+    assert!(
+        edge_error.to_string().contains("dependency cycle"),
+        "unexpected edge trigger error: {edge_error}"
+    );
+
+    // Soft-deleted rows are not live reachability. Removing B -> C from the
+    // live edge graph makes C -> A acyclic even though the tombstone remains.
+    conn.execute(
+        "UPDATE graph_edges SET deleted_at = 2 WHERE id = 'edge-b-c'",
+        [],
+    )
+    .expect("soft-delete dependency edge");
+    insert_dependency_test_edge(&conn, "edge-c-a", "task-c", "task-a", "depends_on", None)
+        .expect("soft-deleted edges must not participate in reachability");
+    let reactivation_error = conn
+        .execute(
+            "UPDATE graph_edges SET deleted_at = NULL WHERE id = 'edge-b-c'",
+            [],
+        )
+        .expect_err("the update trigger must reject reactivating a cycle");
+    assert!(
+        reactivation_error.to_string().contains("dependency cycle"),
+        "unexpected edge-update trigger error: {reactivation_error}"
+    );
+
+    // A soft-deleted task's old properties likewise do not contribute a live
+    // path. Direct storage can still create a broken reference; GTD read-time
+    // diagnostics classify it and typed public hooks reject it earlier.
+    insert_dependency_test_note(
+        &conn,
+        "task-deleted",
+        "task",
+        r#"{"depends_on":["task-a"]}"#,
+        Some(2),
+    );
+    conn.execute(
+        r#"UPDATE notes SET properties = '{"depends_on":["task-deleted"]}' WHERE id = 'task-a'"#,
+        [],
+    )
+    .expect("soft-deleted notes must not participate in reachability");
+
+    // The migration governs only the GTD task dependency graph. Other note
+    // kinds and other edge relations retain their existing write behavior.
+    insert_dependency_test_note(
+        &conn,
+        "observation-self",
+        "observation",
+        r#"{"depends_on":["observation-self"]}"#,
+        None,
+    );
+    insert_dependency_test_edge(&conn, "related-a-b", "task-a", "task-b", "related_to", None)
+        .expect("unrelated edge relation must remain writable");
+    insert_dependency_test_edge(&conn, "related-b-a", "task-b", "task-a", "related_to", None)
+        .expect("unrelated edge cycle must remain writable");
+
+    // Edge reachability is scoped to the edge row's namespace, even though
+    // UUID endpoint resolution itself is namespace-agnostic (ADR-007). An
+    // opposite direction in another graph namespace is independent, while a
+    // cycle completed inside that namespace is still rejected.
+    conn.execute(
+        "INSERT INTO graph_edges \
+         (namespace, id, source_id, target_id, relation, weight, created_at, updated_at) \
+         VALUES ('other', 'other-b-a', 'task-b', 'task-a', 'depends_on', 1.0, 1, 1)",
+        [],
+    )
+    .expect("opposite direction in another edge namespace remains independent");
+    let other_namespace_error = conn
+        .execute(
+            "INSERT INTO graph_edges \
+             (namespace, id, source_id, target_id, relation, weight, created_at, updated_at) \
+             VALUES ('other', 'other-a-b', 'task-a', 'task-b', 'depends_on', 1.0, 1, 1)",
+            [],
+        )
+        .expect_err("a cycle inside the other edge namespace must still fail");
+    assert!(
+        other_namespace_error
+            .to_string()
+            .contains("dependency cycle"),
+        "unexpected cross-namespace guard error: {other_namespace_error}"
+    );
+}
+
+#[test]
+fn v13_serializes_opposite_property_updates_without_committing_a_cycle() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = dir.path().join("gtd-cycle-race.db");
+    let mut setup = Connection::open(&path).expect("open setup connection");
+    run_migrations(&mut setup).expect("migrations should succeed");
+    insert_dependency_test_note(&setup, "race-a", "task", r#"{"status":"next"}"#, None);
+    insert_dependency_test_note(&setup, "race-b", "task", r#"{"status":"next"}"#, None);
+    drop(setup);
+
+    let barrier = std::sync::Arc::new(std::sync::Barrier::new(2));
+    let mut handles = Vec::new();
+    for (source, target) in [("race-a", "race-b"), ("race-b", "race-a")] {
+        let path = path.clone();
+        let barrier = barrier.clone();
+        handles.push(std::thread::spawn(move || {
+            let mut conn = Connection::open(path).expect("open racing connection");
+            conn.busy_timeout(std::time::Duration::from_secs(5))
+                .expect("set busy timeout");
+            barrier.wait();
+            let tx = conn
+                .transaction_with_behavior(rusqlite::TransactionBehavior::Immediate)
+                .expect("begin immediate");
+            let properties = format!(r#"{{"status":"next","depends_on":["{target}"]}}"#);
+            let result = tx.execute(
+                "UPDATE notes SET properties = ?1 WHERE id = ?2",
+                rusqlite::params![properties, source],
+            );
+            match result {
+                Ok(_) => tx.commit().map(|_| ()),
+                Err(error) => {
+                    tx.rollback().expect("rollback rejected update");
+                    Err(error)
+                }
+            }
+        }));
+    }
+
+    let outcomes: Vec<_> = handles
+        .into_iter()
+        .map(|handle| handle.join().expect("race thread"))
+        .collect();
+    assert_eq!(
+        outcomes.iter().filter(|result| result.is_ok()).count(),
+        1,
+        "exactly one direction may commit: {outcomes:?}"
+    );
+    let rejected = outcomes
+        .iter()
+        .find_map(|result| result.as_ref().err())
+        .expect("one direction must be rejected");
+    assert!(
+        rejected.to_string().contains("dependency cycle"),
+        "unexpected race rejection: {rejected}"
+    );
+
+    let verify = Connection::open(path).expect("open verification connection");
+    let dependency_rows: i64 = verify
+        .query_row(
+            "SELECT COUNT(*) FROM notes WHERE id IN ('race-a', 'race-b') \
+             AND json_array_length(properties, '$.depends_on') = 1",
+            [],
+            |row| row.get(0),
+        )
+        .expect("count committed dependency directions");
+    assert_eq!(dependency_rows, 1, "the committed graph must stay acyclic");
+}
+
+#[test]
+fn v13_edge_guard_ignores_paths_through_soft_deleted_tasks() {
+    let mut conn = open_memory();
+    run_migrations(&mut conn).expect("migrations should succeed");
+    insert_dependency_test_note(&conn, "live-a", "task", r#"{"status":"next"}"#, None);
+    insert_dependency_test_note(&conn, "deleted-b", "task", r#"{"status":"next"}"#, None);
+    insert_dependency_test_note(&conn, "live-c", "task", r#"{"status":"next"}"#, None);
+    insert_dependency_test_edge(
+        &conn,
+        "live-a-deleted-b",
+        "live-a",
+        "deleted-b",
+        "depends_on",
+        None,
+    )
+    .expect("first live edge");
+    insert_dependency_test_edge(
+        &conn,
+        "deleted-b-live-c",
+        "deleted-b",
+        "live-c",
+        "depends_on",
+        None,
+    )
+    .expect("second live edge");
+    conn.execute(
+        "UPDATE notes SET status = 'deleted', deleted_at = 2 WHERE id = 'deleted-b'",
+        [],
+    )
+    .expect("soft-delete the intermediate task without deleting its edges");
+
+    insert_dependency_test_edge(
+        &conn,
+        "live-c-live-a",
+        "live-c",
+        "live-a",
+        "depends_on",
+        None,
+    )
+    .expect("tombstoned task edges must not form a live dependency path");
 }
 
 #[test]

--- a/crates/khive-db/src/migrations_tests.rs
+++ b/crates/khive-db/src/migrations_tests.rs
@@ -125,6 +125,7 @@ fn v15_fresh_start_installs_narrow_gtd_dependency_cycle_guards() {
     for trigger in [
         "gtd_task_dependency_cycle_notes_bi",
         "gtd_task_dependency_cycle_notes_bu",
+        "gtd_task_dependency_cycle_note_activation_bi",
         "gtd_task_dependency_cycle_note_activation_bu",
         "gtd_task_dependency_cycle_edges_bi",
         "gtd_task_dependency_cycle_edges_bu",
@@ -490,6 +491,142 @@ fn v13_note_activation_rejects_dormant_edge_cycles() {
         )
         .expect("load rejected task conversion");
     assert_eq!(persisted_kind, "observation");
+}
+
+#[test]
+fn v13_note_insert_rejects_dormant_edge_cycles() {
+    let mut conn = open_memory();
+    run_migrations(&mut conn).expect("migrations should succeed");
+
+    insert_dependency_test_note(&conn, "live-a", "task", "{}", None);
+    insert_dependency_test_edge(
+        &conn,
+        "live-a-missing-b",
+        "live-a",
+        "missing-b",
+        "depends_on",
+        None,
+    )
+    .expect("edge to a missing task is dormant");
+    insert_dependency_test_edge(
+        &conn,
+        "missing-b-live-a",
+        "missing-b",
+        "live-a",
+        "depends_on",
+        None,
+    )
+    .expect("edge from a missing task is dormant");
+
+    let insert_error = conn
+        .execute(
+            "INSERT INTO notes \
+             (id, namespace, kind, status, name, content, properties, created_at, updated_at) \
+             VALUES ('missing-b', 'local', 'task', 'active', 'missing-b', '', '{}', 1, 1)",
+            [],
+        )
+        .expect_err("inserting a task endpoint must not expose an edge cycle");
+    assert!(
+        insert_error.to_string().contains("dependency cycle"),
+        "unexpected task-insert error: {insert_error}"
+    );
+    let rejected_rows: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM notes WHERE id = 'missing-b'",
+            [],
+            |row| row.get(0),
+        )
+        .expect("count rejected task insert");
+    assert_eq!(rejected_rows, 0, "the rejected insert must roll back");
+
+    insert_dependency_test_edge(
+        &conn,
+        "missing-c-live-a",
+        "missing-c",
+        "live-a",
+        "depends_on",
+        None,
+    )
+    .expect("acyclic edge from a missing task is dormant");
+    insert_dependency_test_note(&conn, "missing-c", "task", "{}", None);
+}
+
+#[test]
+fn v13_property_id_replacement_uses_the_post_update_graph() {
+    let mut conn = open_memory();
+    run_migrations(&mut conn).expect("migrations should succeed");
+
+    let old_id = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
+    let middle_id = "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb";
+    let new_id = "cccccccc-cccc-4ccc-8ccc-cccccccccccc";
+    let old_properties = format!(r#"{{"depends_on":["{new_id}"]}}"#);
+    let middle_properties = format!(r#"{{"depends_on":["{old_id}"]}}"#);
+    insert_dependency_test_note(&conn, old_id, "task", &old_properties, None);
+    insert_dependency_test_note(&conn, middle_id, "task", &middle_properties, None);
+
+    let replacement_properties = format!(r#"{{"depends_on":["{middle_id}"]}}"#);
+    conn.execute(
+        "UPDATE notes SET id = ?1, properties = ?2 WHERE id = ?3",
+        rusqlite::params![new_id, replacement_properties, old_id],
+    )
+    .expect("the disappearing old endpoint must not create a phantom property cycle");
+    let replacement_rows: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM notes WHERE id = ?1",
+            rusqlite::params![new_id],
+            |row| row.get(0),
+        )
+        .expect("count replacement task");
+    assert_eq!(replacement_rows, 1);
+    let old_rows: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM notes WHERE id = ?1",
+            rusqlite::params![old_id],
+            |row| row.get(0),
+        )
+        .expect("count disappearing old task");
+    assert_eq!(old_rows, 0);
+
+    let cycle_old_id = "dddddddd-dddd-4ddd-8ddd-dddddddddddd";
+    let cycle_middle_id = "eeeeeeee-eeee-4eee-8eee-eeeeeeeeeeee";
+    let cycle_new_id = "ffffffff-ffff-4fff-8fff-ffffffffffff";
+    insert_dependency_test_note(&conn, cycle_old_id, "task", "{}", None);
+    let cycle_middle_properties = format!(r#"{{"depends_on":["{cycle_new_id}"]}}"#);
+    insert_dependency_test_note(
+        &conn,
+        cycle_middle_id,
+        "task",
+        &cycle_middle_properties,
+        None,
+    );
+
+    let cycle_replacement_properties = format!(r#"{{"depends_on":["{cycle_middle_id}"]}}"#);
+    let cycle_error = conn
+        .execute(
+            "UPDATE notes SET id = ?1, properties = ?2 WHERE id = ?3",
+            rusqlite::params![cycle_new_id, cycle_replacement_properties, cycle_old_id],
+        )
+        .expect_err("a real property cycle through the replacement id must still fail");
+    assert!(
+        cycle_error.to_string().contains("dependency cycle"),
+        "unexpected replacement-cycle error: {cycle_error}"
+    );
+    let preserved_rows: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM notes WHERE id = ?1",
+            rusqlite::params![cycle_old_id],
+            |row| row.get(0),
+        )
+        .expect("count preserved old task");
+    assert_eq!(preserved_rows, 1, "the rejected replacement must roll back");
+    let rejected_new_rows: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM notes WHERE id = ?1",
+            rusqlite::params![cycle_new_id],
+            |row| row.get(0),
+        )
+        .expect("count rejected replacement id");
+    assert_eq!(rejected_new_rows, 0);
 }
 
 #[test]

--- a/crates/khive-db/src/migrations_tests.rs
+++ b/crates/khive-db/src/migrations_tests.rs
@@ -266,20 +266,50 @@ fn v15_fresh_start_installs_narrow_gtd_dependency_cycle_guards() {
 }
 
 #[test]
-fn v13_serializes_opposite_property_updates_without_committing_a_cycle() {
+fn v13_property_guard_ignores_non_array_legacy_dependencies() {
+    let mut conn = open_memory();
+    run_migrations(&mut conn).expect("migrations should succeed");
+    let task_a = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
+    let task_b = "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb";
+    insert_dependency_test_note(&conn, task_a, "task", r#"{"status":"next"}"#, None);
+    let scalar_properties = format!(r#"{{"depends_on":"{task_a}"}}"#);
+    insert_dependency_test_note(&conn, task_b, "task", &scalar_properties, None);
+
+    let array_properties = format!(r#"{{"depends_on":["{task_b}"]}}"#);
+    conn.execute(
+        "UPDATE notes SET properties = ?1 WHERE id = ?2",
+        rusqlite::params![array_properties, task_a],
+    )
+    .expect("a legacy scalar depends_on value is not a traversable dependency edge");
+
+    let persisted: String = conn
+        .query_row(
+            "SELECT properties FROM notes WHERE id = ?1",
+            rusqlite::params![task_a],
+            |row| row.get(0),
+        )
+        .expect("load accepted dependency properties");
+    assert!(persisted.contains(task_b));
+}
+
+#[test]
+fn v13_serializes_alternate_uuid_spelling_updates_without_committing_a_cycle() {
     let dir = tempfile::tempdir().expect("tempdir");
     let path = dir.path().join("gtd-cycle-race.db");
     let mut setup = Connection::open(&path).expect("open setup connection");
     run_migrations(&mut setup).expect("migrations should succeed");
-    insert_dependency_test_note(&setup, "race-a", "task", r#"{"status":"next"}"#, None);
-    insert_dependency_test_note(&setup, "race-b", "task", r#"{"status":"next"}"#, None);
+    let task_a = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
+    let task_b = "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb";
+    insert_dependency_test_note(&setup, task_a, "task", r#"{"status":"next"}"#, None);
+    insert_dependency_test_note(&setup, task_b, "task", r#"{"status":"next"}"#, None);
     drop(setup);
 
     let barrier = std::sync::Arc::new(std::sync::Barrier::new(2));
     let mut handles = Vec::new();
-    for (source, target) in [("race-a", "race-b"), ("race-b", "race-a")] {
+    for (source, target) in [(task_a, task_b), (task_b, task_a)] {
         let path = path.clone();
         let barrier = barrier.clone();
+        let target = target.to_ascii_uppercase();
         handles.push(std::thread::spawn(move || {
             let mut conn = Connection::open(path).expect("open racing connection");
             conn.busy_timeout(std::time::Duration::from_secs(5))
@@ -324,9 +354,9 @@ fn v13_serializes_opposite_property_updates_without_committing_a_cycle() {
     let verify = Connection::open(path).expect("open verification connection");
     let dependency_rows: i64 = verify
         .query_row(
-            "SELECT COUNT(*) FROM notes WHERE id IN ('race-a', 'race-b') \
+            "SELECT COUNT(*) FROM notes WHERE id IN (?1, ?2) \
              AND json_array_length(properties, '$.depends_on') = 1",
-            [],
+            rusqlite::params![task_a, task_b],
             |row| row.get(0),
         )
         .expect("count committed dependency directions");

--- a/crates/khive-pack-gtd/README.md
+++ b/crates/khive-pack-gtd/README.md
@@ -9,7 +9,7 @@ over the notes substrate.
 | Verb             | What it does                                                                  |
 | ---------------- | ----------------------------------------------------------------------------- |
 | `gtd.assign`     | Create a task (note with `kind=task`); defaults `status=inbox`, `priority=p2` |
-| `gtd.next`       | List actionable tasks (`status` in `next`/`active`), priority-sorted          |
+| `gtd.next`       | List actionable tasks; optionally include blocked/broken dependency states    |
 | `gtd.complete`   | Mark a task `done` (or `cancelled`) with an optional result note              |
 | `gtd.tasks`      | Filtered task listing by status, assignee, priority                           |
 | `gtd.transition` | Explicit lifecycle change, validated against the state machine below          |
@@ -45,7 +45,10 @@ The pack also extends the base `depends_on` edge endpoint contract
 ([ADR-002](https://github.com/ohdearquant/khive/blob/main/docs/adr/ADR-002-edge-ontology.md))
 to allow `task`→`task` edges (`GTD_EDGE_RULES`), so task blockers are
 graph-traversable even though the base contract restricts `depends_on` to
-entity→entity.
+entity→entity. Dependency writes reject direct and transitive cycles. Task query
+results include `dependency_state`, `actionable`, and structural `blocked_by`
+diagnostics; `gtd.next(include_blocked=true)` includes blocked or broken candidates
+after ready work for triage.
 
 ## Usage
 

--- a/crates/khive-pack-gtd/docs/api/task-query.md
+++ b/crates/khive-pack-gtd/docs/api/task-query.md
@@ -35,3 +35,22 @@ If `TASK_SCAN_MAX_ROWS + 1` rows come back, the function returns
 callers must narrow the filters (e.g. add an `assignee` filter) so the
 result set stays complete rather than silently dropping matching tasks past
 the row cap.
+
+## Dependency diagnostics
+
+Every task returned by `gtd.tasks` carries `dependency_state`, `actionable`,
+and `blocked_by`. A dependency state is `ready` when every blocker is done,
+`blocked` when at least one live blocker is still pending, and `broken` when a
+blocker is cancelled, soft-deleted, missing after hard deletion, malformed, or
+no longer a compatible task. Each `blocked_by` entry names the blocker id and
+its structural state, so a task does not remain an unexplained plain `next`
+record after its blocker becomes terminal or disappears.
+
+`gtd.next` remains actionable-only by default. Set `include_blocked=true` to
+include blocked and broken `next`/`active` tasks in the same array; ready work
+sorts first, and every returned task's `actionable` field distinguishes work
+that can be scheduled from dependency diagnostics.
+
+The query path batches live blocker reads and probes only unresolved ids for a
+soft-deleted row. A hard-deleted blocker therefore classifies as `missing`,
+while a tombstone classifies as `soft_deleted` without resurrecting it.

--- a/crates/khive-pack-gtd/docs/design.md
+++ b/crates/khive-pack-gtd/docs/design.md
@@ -40,7 +40,9 @@
 - `gtd_lifecycle_audit` table records every `transition` and `complete` invocation for
   replay and compliance. Writes are best-effort (non-fatal on failure).
 - `depends_on` property stores UUIDs of blocking tasks; `gtd.next` excludes tasks whose
-  blockers are not in `done` state.
+  blockers are not in `done` state by default. Query results report `dependency_state`,
+  `actionable`, and structural `blocked_by` diagnostics; `include_blocked=true` makes
+  `gtd.next` include blocked or broken candidates after ready work.
 
 ### Illocutionary verb classification (Searle 1976) (ADR-025)
 
@@ -70,6 +72,8 @@
 - Pre-validation in `gtd.assign` and `TaskHook.prepare_create` ensures the target of each
   `depends_on` UUID is a `task` note before any storage write. This preserves the
   atomicity invariant: no task is persisted if its dependency chain is invalid.
+- The task hook also validates generic KG property updates and task-to-task `depends_on`
+  links, rejecting direct, transitive, and same-batch dependency cycles before writes.
 
 ## Consistency Notes
 

--- a/crates/khive-pack-gtd/src/dependency.rs
+++ b/crates/khive-pack-gtd/src/dependency.rs
@@ -188,6 +188,11 @@ pub(crate) async fn validate_property_update(
     let dependencies = depends_on.as_array().ok_or_else(|| {
         RuntimeError::InvalidInput("task properties.depends_on must be an array of UUIDs".into())
     })?;
+    if dependencies.len() > DEPENDENCY_WALK_MAX_NODES {
+        return Err(RuntimeError::InvalidInput(format!(
+            "depends_on cycle validation exceeded the {DEPENDENCY_WALK_MAX_NODES}-edge safety bound"
+        )));
+    }
     let store = runtime.notes(token)?;
     for dependency in dependencies {
         let raw = dependency.as_str().ok_or_else(|| {
@@ -200,6 +205,12 @@ pub(crate) async fn validate_property_update(
                 "task properties.depends_on entry {raw:?} must be a full UUID"
             ))
         })?;
+        let canonical = dependency_id.as_hyphenated().to_string();
+        if raw != canonical {
+            return Err(RuntimeError::InvalidInput(format!(
+                "task properties.depends_on entry {raw:?} must use the canonical lowercase hyphenated UUID {canonical:?}"
+            )));
+        }
         if dependency_id == task.id {
             return Err(RuntimeError::InvalidInput(format!(
                 "depends_on update would create a dependency cycle: task {} cannot depend on itself",
@@ -251,6 +262,7 @@ async fn property_path_reaches(
     let store = runtime.notes(token)?;
     let mut queue = VecDeque::from([start]);
     let mut visited = HashSet::new();
+    let mut traversed_edges = 0usize;
     while let Some(current) = queue.pop_front() {
         if current == goal {
             return Ok(true);
@@ -277,6 +289,18 @@ async fn property_path_reaches(
         else {
             continue;
         };
+        traversed_edges = traversed_edges
+            .checked_add(dependencies.len())
+            .ok_or_else(|| {
+                RuntimeError::InvalidInput(format!(
+                    "depends_on cycle validation exceeded the {DEPENDENCY_WALK_MAX_NODES}-edge safety bound"
+                ))
+            })?;
+        if traversed_edges > DEPENDENCY_WALK_MAX_NODES {
+            return Err(RuntimeError::InvalidInput(format!(
+                "depends_on cycle validation exceeded the {DEPENDENCY_WALK_MAX_NODES}-edge safety bound"
+            )));
+        }
         queue.extend(dependencies.iter().filter_map(|dependency| {
             dependency
                 .as_str()

--- a/crates/khive-pack-gtd/src/dependency.rs
+++ b/crates/khive-pack-gtd/src/dependency.rs
@@ -1,0 +1,424 @@
+//! GTD dependency validation and read-time diagnostics.
+
+use std::collections::{HashMap, HashSet, VecDeque};
+
+use serde_json::{json, Value};
+use uuid::Uuid;
+
+use khive_runtime::{KhiveRuntime, LinkSpec, NamespaceToken, RuntimeError};
+use khive_storage::note::Note;
+use khive_storage::types::{SqlStatement, SqlValue};
+use khive_storage::EdgeRelation;
+
+const DEPENDENCY_WALK_MAX_NODES: usize = 20_000;
+
+#[derive(Clone, Debug)]
+pub(crate) struct TaskDependencyDiagnostic {
+    state: &'static str,
+    blocked_by: Vec<Value>,
+}
+
+impl TaskDependencyDiagnostic {
+    pub(crate) fn is_ready(&self) -> bool {
+        self.state == "ready"
+    }
+
+    pub(crate) fn render(&self, note: &Note) -> Value {
+        let mut rendered = crate::handlers::render_task(note);
+        let lifecycle_actionable = note
+            .properties
+            .as_ref()
+            .and_then(|properties| properties.get("status"))
+            .and_then(Value::as_str)
+            .is_some_and(|status| matches!(status, "next" | "active"));
+        if let Some(object) = rendered.as_object_mut() {
+            object.insert("dependency_state".into(), json!(self.state));
+            object.insert(
+                "actionable".into(),
+                json!(lifecycle_actionable && self.is_ready()),
+            );
+            object.insert("blocked_by".into(), Value::Array(self.blocked_by.clone()));
+        }
+        rendered
+    }
+}
+
+pub(crate) async fn diagnose_tasks(
+    runtime: &KhiveRuntime,
+    token: &NamespaceToken,
+    tasks: &[Note],
+) -> Result<Vec<TaskDependencyDiagnostic>, RuntimeError> {
+    let mut dependency_ids = HashSet::new();
+    for task in tasks {
+        let Some(dependencies) = task
+            .properties
+            .as_ref()
+            .and_then(|properties| properties.get("depends_on"))
+            .and_then(Value::as_array)
+        else {
+            continue;
+        };
+        dependency_ids.extend(dependencies.iter().filter_map(|dependency| {
+            dependency
+                .as_str()
+                .and_then(|raw| Uuid::parse_str(raw).ok())
+        }));
+    }
+
+    let store = runtime.notes(token)?;
+    let ids: Vec<Uuid> = dependency_ids.iter().copied().collect();
+    let mut notes_by_id: HashMap<Uuid, Option<Note>> = store
+        .get_notes_batch(&ids)
+        .await?
+        .into_iter()
+        .map(|note| (note.id, Some(note)))
+        .collect();
+
+    for id in dependency_ids {
+        if notes_by_id.contains_key(&id) {
+            continue;
+        }
+        notes_by_id.insert(id, store.get_note_including_deleted(id).await?);
+    }
+
+    Ok(tasks
+        .iter()
+        .map(|task| diagnose_task(task, &notes_by_id))
+        .collect())
+}
+
+fn diagnose_task(
+    task: &Note,
+    notes_by_id: &HashMap<Uuid, Option<Note>>,
+) -> TaskDependencyDiagnostic {
+    let mut blocked_by = Vec::new();
+    let mut broken = false;
+    let Some(depends_on) = task
+        .properties
+        .as_ref()
+        .and_then(|properties| properties.get("depends_on"))
+    else {
+        return TaskDependencyDiagnostic {
+            state: "ready",
+            blocked_by,
+        };
+    };
+    let Some(dependencies) = depends_on.as_array() else {
+        return TaskDependencyDiagnostic {
+            state: "broken",
+            blocked_by: vec![json!({"id": depends_on, "state": "invalid"})],
+        };
+    };
+
+    for dependency in dependencies {
+        let Some(raw) = dependency.as_str() else {
+            broken = true;
+            blocked_by.push(json!({"id": dependency, "state": "invalid"}));
+            continue;
+        };
+        let Ok(id) = Uuid::parse_str(raw) else {
+            broken = true;
+            blocked_by.push(json!({"id": raw, "state": "invalid"}));
+            continue;
+        };
+        let Some(Some(blocker)) = notes_by_id.get(&id) else {
+            broken = true;
+            blocked_by.push(json!({"id": raw, "state": "missing"}));
+            continue;
+        };
+        if blocker.namespace != task.namespace {
+            broken = true;
+            blocked_by.push(json!({"id": raw, "state": "different_namespace"}));
+            continue;
+        }
+        if blocker.deleted_at.is_some() {
+            broken = true;
+            blocked_by.push(json!({"id": raw, "state": "soft_deleted"}));
+            continue;
+        }
+        if blocker.kind != "task" {
+            broken = true;
+            blocked_by.push(json!({"id": raw, "state": "wrong_kind"}));
+            continue;
+        }
+        let blocker_status = blocker
+            .properties
+            .as_ref()
+            .and_then(|properties| properties.get("status"))
+            .and_then(Value::as_str)
+            .unwrap_or("inbox");
+        match blocker_status {
+            "done" => {}
+            "cancelled" => {
+                broken = true;
+                blocked_by.push(json!({"id": raw, "state": "cancelled"}));
+            }
+            status => blocked_by.push(json!({
+                "id": raw,
+                "state": "pending",
+                "status": status,
+            })),
+        }
+    }
+
+    TaskDependencyDiagnostic {
+        state: if broken {
+            "broken"
+        } else if blocked_by.is_empty() {
+            "ready"
+        } else {
+            "blocked"
+        },
+        blocked_by,
+    }
+}
+
+pub(crate) async fn validate_property_update(
+    runtime: &KhiveRuntime,
+    token: &NamespaceToken,
+    task: &Note,
+    properties: Option<&Value>,
+) -> Result<(), RuntimeError> {
+    let Some(depends_on) = properties
+        .and_then(Value::as_object)
+        .and_then(|object| object.get("depends_on"))
+    else {
+        return Ok(());
+    };
+    let dependencies = depends_on.as_array().ok_or_else(|| {
+        RuntimeError::InvalidInput("task properties.depends_on must be an array of UUIDs".into())
+    })?;
+    let store = runtime.notes(token)?;
+    for dependency in dependencies {
+        let raw = dependency.as_str().ok_or_else(|| {
+            RuntimeError::InvalidInput(
+                "task properties.depends_on entries must be full UUID strings".into(),
+            )
+        })?;
+        let dependency_id = Uuid::parse_str(raw).map_err(|_| {
+            RuntimeError::InvalidInput(format!(
+                "task properties.depends_on entry {raw:?} must be a full UUID"
+            ))
+        })?;
+        if dependency_id == task.id {
+            return Err(RuntimeError::InvalidInput(format!(
+                "depends_on update would create a dependency cycle: task {} cannot depend on itself",
+                task.id
+            )));
+        }
+        let blocker = store.get_note(dependency_id).await?.ok_or_else(|| {
+            RuntimeError::NotFound(format!(
+                "depends_on target {dependency_id} is missing or deleted"
+            ))
+        })?;
+        if blocker.kind != "task" {
+            return Err(RuntimeError::InvalidInput(format!(
+                "depends_on target {dependency_id} must be a task note; got {:?}",
+                blocker.kind
+            )));
+        }
+        if blocker.namespace != task.namespace {
+            return Err(RuntimeError::InvalidInput(format!(
+                "depends_on target {dependency_id} must share task namespace {:?}",
+                task.namespace
+            )));
+        }
+        if property_path_reaches(
+            runtime,
+            token,
+            dependency_id,
+            task.id,
+            task.namespace.as_str(),
+        )
+        .await?
+        {
+            return Err(RuntimeError::InvalidInput(format!(
+                "depends_on update would create a dependency cycle: blocker {dependency_id} already reaches task {}",
+                task.id
+            )));
+        }
+    }
+    Ok(())
+}
+
+async fn property_path_reaches(
+    runtime: &KhiveRuntime,
+    token: &NamespaceToken,
+    start: Uuid,
+    goal: Uuid,
+    namespace: &str,
+) -> Result<bool, RuntimeError> {
+    let store = runtime.notes(token)?;
+    let mut queue = VecDeque::from([start]);
+    let mut visited = HashSet::new();
+    while let Some(current) = queue.pop_front() {
+        if current == goal {
+            return Ok(true);
+        }
+        if !visited.insert(current) {
+            continue;
+        }
+        if visited.len() > DEPENDENCY_WALK_MAX_NODES {
+            return Err(RuntimeError::InvalidInput(format!(
+                "depends_on cycle validation exceeded the {DEPENDENCY_WALK_MAX_NODES}-task safety bound"
+            )));
+        }
+        let Some(note) = store.get_note(current).await? else {
+            continue;
+        };
+        if note.kind != "task" || note.namespace != namespace {
+            continue;
+        }
+        let Some(dependencies) = note
+            .properties
+            .as_ref()
+            .and_then(|properties| properties.get("depends_on"))
+            .and_then(Value::as_array)
+        else {
+            continue;
+        };
+        queue.extend(dependencies.iter().filter_map(|dependency| {
+            dependency
+                .as_str()
+                .and_then(|raw| Uuid::parse_str(raw).ok())
+        }));
+    }
+    Ok(false)
+}
+
+pub(crate) async fn validate_dependency_links(
+    runtime: &KhiveRuntime,
+    token: &NamespaceToken,
+    links: &[LinkSpec],
+) -> Result<(), RuntimeError> {
+    let store = runtime.notes(token)?;
+    let mut proposed: HashMap<Uuid, Vec<Uuid>> = HashMap::new();
+    let mut task_links = Vec::new();
+    for link in links {
+        if link.relation != EdgeRelation::DependsOn {
+            continue;
+        }
+        let Some(source) = store.get_note(link.source_id).await? else {
+            continue;
+        };
+        if source.kind != "task" {
+            continue;
+        }
+        let target = store.get_note(link.target_id).await?.ok_or_else(|| {
+            RuntimeError::NotFound(format!("depends_on target {} not found", link.target_id))
+        })?;
+        if target.kind != "task" {
+            return Err(RuntimeError::InvalidInput(format!(
+                "depends_on target {} must be a task note; got {:?}",
+                link.target_id, target.kind
+            )));
+        }
+        proposed
+            .entry(link.source_id)
+            .or_default()
+            .push(link.target_id);
+        task_links.push((link.source_id, link.target_id));
+    }
+
+    for (source, target) in task_links {
+        if source == target {
+            return Err(RuntimeError::InvalidInput(format!(
+                "depends_on link would create a dependency cycle: task {source} cannot depend on itself"
+            )));
+        }
+        if edge_path_reaches(
+            runtime,
+            token.namespace().as_str(),
+            target,
+            source,
+            &proposed,
+        )
+        .await?
+        {
+            return Err(RuntimeError::InvalidInput(format!(
+                "depends_on link would create a dependency cycle: {source} -> {target} closes a path back to {source}"
+            )));
+        }
+    }
+    Ok(())
+}
+
+async fn edge_path_reaches(
+    runtime: &KhiveRuntime,
+    namespace: &str,
+    start: Uuid,
+    goal: Uuid,
+    proposed: &HashMap<Uuid, Vec<Uuid>>,
+) -> Result<bool, RuntimeError> {
+    let mut reader = runtime.sql().reader().await?;
+    let mut queue = VecDeque::from([start]);
+    let mut visited = HashSet::new();
+    let mut traversed_edges = 0usize;
+    while let Some(current) = queue.pop_front() {
+        if current == goal {
+            return Ok(true);
+        }
+        if !visited.insert(current) {
+            continue;
+        }
+        if visited.len() > DEPENDENCY_WALK_MAX_NODES {
+            return Err(RuntimeError::InvalidInput(format!(
+                "depends_on edge cycle validation exceeded the {DEPENDENCY_WALK_MAX_NODES}-node safety bound"
+            )));
+        }
+        if let Some(targets) = proposed.get(&current) {
+            traversed_edges += targets.len();
+            queue.extend(targets.iter().copied());
+        }
+        let remaining = DEPENDENCY_WALK_MAX_NODES.saturating_sub(traversed_edges);
+        if remaining == 0 {
+            return Err(RuntimeError::InvalidInput(format!(
+                "depends_on edge cycle validation exceeded the {DEPENDENCY_WALK_MAX_NODES}-edge safety bound"
+            )));
+        }
+        let rows = reader
+            .query_all(SqlStatement {
+                // Soft-deleting a task deliberately leaves its incident graph
+                // edges in place.  Those edges are not part of the live GTD
+                // dependency graph: following them here would make an
+                // otherwise-acyclic link fail merely because a tombstoned task
+                // sits on an old path.  Require both endpoints of every
+                // traversed hop to be live task notes, matching property-walk
+                // and read-diagnostic semantics.
+                sql: "SELECT edge.target_id FROM graph_edges AS edge \
+                      JOIN notes AS source_task \
+                        ON source_task.id = edge.source_id \
+                       AND source_task.kind = 'task' \
+                       AND source_task.deleted_at IS NULL \
+                      JOIN notes AS target_task \
+                        ON target_task.id = edge.target_id \
+                       AND target_task.kind = 'task' \
+                       AND target_task.deleted_at IS NULL \
+                      WHERE edge.source_id = ?1 AND edge.namespace = ?2 \
+                        AND edge.relation = 'depends_on' AND edge.deleted_at IS NULL \
+                      ORDER BY edge.target_id LIMIT ?3"
+                    .into(),
+                params: vec![
+                    SqlValue::Text(current.as_hyphenated().to_string()),
+                    SqlValue::Text(namespace.to_owned()),
+                    SqlValue::Integer((remaining + 1) as i64),
+                ],
+                label: Some("gtd_dependency_cycle_edges".into()),
+            })
+            .await?;
+        if rows.len() > remaining {
+            return Err(RuntimeError::InvalidInput(format!(
+                "depends_on edge cycle validation exceeded the {DEPENDENCY_WALK_MAX_NODES}-edge safety bound"
+            )));
+        }
+        traversed_edges += rows.len();
+        queue.extend(
+            rows.into_iter()
+                .filter_map(|row| match row.get("target_id") {
+                    Some(SqlValue::Text(raw)) => Uuid::parse_str(raw).ok(),
+                    _ => None,
+                }),
+        );
+    }
+    Ok(false)
+}

--- a/crates/khive-pack-gtd/src/handlers.rs
+++ b/crates/khive-pack-gtd/src/handlers.rs
@@ -177,6 +177,8 @@ struct NextParams {
     limit: Option<u32>,
     #[serde(default)]
     assignee: Option<String>,
+    #[serde(default)]
+    include_blocked: Option<bool>,
 }
 
 /// `handle_complete`'s deserialization target. `pub` with private fields:
@@ -897,98 +899,34 @@ impl GtdPack {
         }
         let notes = fetch_all_matching_tasks(self.runtime(), token, property_filters).await?;
 
-        // Build a quick lookup map of task UUID → GTD status so dependency
-        // filtering can check blocker states in O(1). Every
-        // note here already passed the actionable(+assignee) SQL filter above
-        // (and `deleted_at IS NULL`, enforced unconditionally by
-        // `query_notes_filtered`).
-        use std::collections::HashMap;
-        let mut status_by_id: HashMap<uuid::Uuid, String> = notes
+        let diagnostics = crate::dependency::diagnose_tasks(self.runtime(), token, &notes).await?;
+        let include_blocked = p.include_blocked.unwrap_or(false);
+        let mut actionable: Vec<_> = notes
             .iter()
-            .map(|n| (n.id, task_status(n.properties.as_ref())))
-            .collect();
-
-        let candidates: Vec<&khive_storage::note::Note> = notes.iter().collect();
-
-        // Gather all dependency UUIDs referenced by candidates that are not
-        // already in status_by_id — these are blockers whose status isn't
-        // `next`/`active` (the common case: a `done` blocker).  Fetch them in
-        // one batch so the dependency filter below can evaluate their status
-        // correctly regardless of scan-page position.
-        let missing_dep_ids: Vec<uuid::Uuid> = candidates
-            .iter()
-            .flat_map(|n| {
-                n.properties
-                    .as_ref()
-                    .and_then(|p| p.get("depends_on"))
-                    .and_then(|v| v.as_array())
-                    .map(|arr| {
-                        arr.iter()
-                            .filter_map(|v| uuid::Uuid::parse_str(v.as_str().unwrap_or("")).ok())
-                            .collect::<Vec<_>>()
-                    })
-                    .unwrap_or_default()
-            })
-            .filter(|id| !status_by_id.contains_key(id))
-            .collect();
-
-        if !missing_dep_ids.is_empty() {
-            let ns = token.namespace().as_str();
-            let fetched = self
-                .runtime()
-                .notes(token)?
-                .get_notes_batch(&missing_dep_ids)
-                .await
-                .map_err(|e| RuntimeError::Internal(format!("get_notes_batch: {e}")))?;
-            for n in fetched {
-                // Enforce namespace isolation: ignore notes from other tenants.
-                if n.namespace == ns {
-                    status_by_id.insert(n.id, task_status(n.properties.as_ref()));
-                }
-            }
-        }
-
-        // exclude tasks whose `depends_on` contains any
-        // blocker that is NOT in the `done` terminal state.
-        // Dangling UUIDs (not found in status_by_id even after batch fetch)
-        // are treated as incomplete (blocker unknown = not done → keep blocked).
-        let mut actionable: Vec<&khive_storage::note::Note> = candidates
-            .into_iter()
-            .filter(|n| {
-                let deps = n
-                    .properties
-                    .as_ref()
-                    .and_then(|p| p.get("depends_on"))
-                    .and_then(|v| v.as_array());
-                match deps {
-                    None => true, // no dependencies → not blocked
-                    Some(arr) if arr.is_empty() => true,
-                    Some(arr) => arr.iter().all(|dep| {
-                        let dep_str = dep.as_str().unwrap_or("");
-                        let dep_uuid = uuid::Uuid::parse_str(dep_str).ok();
-                        match dep_uuid.and_then(|id| status_by_id.get(&id)) {
-                            Some(s) => s == "done",
-                            // Dep not found or non-UUID → treat as blocked.
-                            None => false,
-                        }
-                    }),
-                }
-            })
+            .zip(diagnostics)
+            .filter(|(_, diagnostic)| include_blocked || diagnostic.is_ready())
             .collect();
 
         // Sort: priority ascending (p0 first), then created_at descending (recent first),
         // then UUID ascending as a deterministic tie-breaker for equal-priority equal-timestamp
         // tasks so callers always observe a stable ordering.
-        actionable.sort_by(|a, b| {
+        actionable.sort_by(|(a, a_diagnostic), (b, b_diagnostic)| {
+            let a_blocked = !a_diagnostic.is_ready();
+            let b_blocked = !b_diagnostic.is_ready();
             let ap = priority_rank(a.properties.as_ref());
             let bp = priority_rank(b.properties.as_ref());
-            ap.cmp(&bp)
+            a_blocked
+                .cmp(&b_blocked)
+                .then(ap.cmp(&bp))
                 .then(b.created_at.cmp(&a.created_at))
                 .then(a.id.cmp(&b.id))
         });
         actionable.truncate(limit as usize);
 
-        let result: Vec<Value> = actionable.iter().map(|n| render_task(n)).collect();
+        let result: Vec<Value> = actionable
+            .iter()
+            .map(|(note, diagnostic)| diagnostic.render(note))
+            .collect();
         Ok(Value::Array(result))
     }
 
@@ -1209,7 +1147,14 @@ impl GtdPack {
             .await
             .map_err(|e| RuntimeError::Internal(format!("query_notes_filtered: {e}")))?;
 
-        let result: Vec<Value> = page.items.iter().map(render_task).collect();
+        let diagnostics =
+            crate::dependency::diagnose_tasks(self.runtime(), token, &page.items).await?;
+        let result: Vec<Value> = page
+            .items
+            .iter()
+            .zip(diagnostics.iter())
+            .map(|(note, diagnostic)| diagnostic.render(note))
+            .collect();
 
         // #96: a bare `[]` is indistinguishable from "no such task" when the
         // *default* terminal-status exclusion is what emptied the result —

--- a/crates/khive-pack-gtd/src/hook.rs
+++ b/crates/khive-pack-gtd/src/hook.rs
@@ -9,7 +9,8 @@ use async_trait::async_trait;
 use serde_json::Value;
 use uuid::Uuid;
 
-use khive_runtime::{KhiveRuntime, KindHook, Namespace, RuntimeError};
+use khive_runtime::{KhiveRuntime, KindHook, LinkSpec, Namespace, NamespaceToken, RuntimeError};
+use khive_storage::Note;
 
 use crate::task_create::{link_depends_on_edges, prepare_task_create, TaskCreateInput};
 
@@ -62,5 +63,24 @@ impl KindHook for TaskHook {
         }
 
         Ok(())
+    }
+
+    async fn validate_note_update(
+        &self,
+        runtime: &KhiveRuntime,
+        token: &NamespaceToken,
+        note: &Note,
+        properties: Option<&Value>,
+    ) -> Result<(), RuntimeError> {
+        crate::dependency::validate_property_update(runtime, token, note, properties).await
+    }
+
+    async fn validate_links(
+        &self,
+        runtime: &KhiveRuntime,
+        token: &NamespaceToken,
+        links: &[LinkSpec],
+    ) -> Result<(), RuntimeError> {
+        crate::dependency::validate_dependency_links(runtime, token, links).await
     }
 }

--- a/crates/khive-pack-gtd/src/lib.rs
+++ b/crates/khive-pack-gtd/src/lib.rs
@@ -3,6 +3,7 @@
 //! Adds the `task` note kind and five verbs (`assign`, `next`, `complete`, `tasks`,
 //! `transition`) with GTD lifecycle semantics over the notes substrate.
 
+pub(crate) mod dependency;
 pub mod handlers;
 pub mod hook;
 mod pack;

--- a/crates/khive-pack-gtd/src/vocab.rs
+++ b/crates/khive-pack-gtd/src/vocab.rs
@@ -169,6 +169,12 @@ pub(crate) static GTD_HANDLERS: [HandlerDef; 5] = [
                 required: false,
                 description: "Filter to this assignee.",
             },
+            ParamDef {
+                name: "include_blocked",
+                param_type: "boolean",
+                required: false,
+                description: "Include status=next/active tasks that are blocked. Returned tasks carry actionable, dependency_state, and blocked_by diagnostics (default false).",
+            },
         ],
     },
     // Declaration: declares a task done or cancelled

--- a/crates/khive-pack-gtd/tests/dependencies.rs
+++ b/crates/khive-pack-gtd/tests/dependencies.rs
@@ -125,6 +125,21 @@ async fn scenario_gtd_c2_next_excludes_tasks_with_incomplete_deps() {
     .await;
     let dep_id = dependent["full_id"].as_str().unwrap().to_string();
 
+    let diagnostic = pack
+        .dispatch("gtd.tasks", json!({"status": "next"}))
+        .await
+        .expect("diagnostic task listing");
+    let dependent_diagnostic = diagnostic
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|task| task["full_id"].as_str() == Some(dep_id.as_str()))
+        .expect("dependent task diagnostic");
+    assert_eq!(dependent_diagnostic["dependency_state"], "blocked");
+    assert_eq!(dependent_diagnostic["actionable"], false);
+    assert_eq!(dependent_diagnostic["blocked_by"][0]["state"], "pending");
+    assert_eq!(dependent_diagnostic["blocked_by"][0]["status"], "inbox");
+
     let result = pack.dispatch("gtd.next", json!({})).await.unwrap();
     let titles: Vec<&str> = result
         .as_array()
@@ -740,6 +755,239 @@ async fn create_task_rejects_nested_depends_on_non_task_without_persisting() {
             .filter_map(|n| n.name.clone())
             .collect::<Vec<_>>()
     );
+}
+
+#[tokio::test]
+async fn dependency_diagnostics_surface_cancelled_soft_deleted_and_missing_blockers() {
+    let fixture = pack(rt());
+
+    let cancelled = assign(
+        &fixture,
+        json!({"title": "cancelled blocker", "status": "inbox"}),
+    )
+    .await;
+    let soft_deleted = assign(
+        &fixture,
+        json!({"title": "soft-deleted blocker", "status": "inbox"}),
+    )
+    .await;
+    let hard_deleted = assign(
+        &fixture,
+        json!({"title": "hard-deleted blocker", "status": "inbox"}),
+    )
+    .await;
+
+    for (title, blocker) in [
+        ("blocked by cancelled", &cancelled),
+        ("blocked by soft delete", &soft_deleted),
+        ("blocked by hard delete", &hard_deleted),
+    ] {
+        assign(
+            &fixture,
+            json!({
+                "title": title,
+                "status": "next",
+                "depends_on": [blocker["full_id"].as_str().unwrap()]
+            }),
+        )
+        .await;
+    }
+
+    fixture
+        .dispatch(
+            "gtd.transition",
+            json!({"id": cancelled["full_id"], "status": "cancelled"}),
+        )
+        .await
+        .expect("cancel blocker");
+    fixture
+        .dispatch("delete", json!({"id": soft_deleted["full_id"]}))
+        .await
+        .expect("soft-delete blocker");
+    fixture
+        .dispatch(
+            "delete",
+            json!({"id": hard_deleted["full_id"], "hard": true}),
+        )
+        .await
+        .expect("hard-delete blocker");
+
+    let tasks = fixture
+        .dispatch("gtd.tasks", json!({"status": "next"}))
+        .await
+        .expect("diagnostic task listing");
+    let tasks = tasks.as_array().expect("tasks array");
+    for (title, blocker_state) in [
+        ("blocked by cancelled", "cancelled"),
+        ("blocked by soft delete", "soft_deleted"),
+        ("blocked by hard delete", "missing"),
+    ] {
+        let task = tasks
+            .iter()
+            .find(|task| task["title"].as_str() == Some(title))
+            .unwrap_or_else(|| panic!("missing diagnostic task {title:?}: {tasks:?}"));
+        assert_eq!(task["dependency_state"], "broken");
+        assert_eq!(task["actionable"], false);
+        assert_eq!(task["blocked_by"][0]["state"], blocker_state);
+    }
+
+    let default_next = fixture
+        .dispatch("gtd.next", json!({}))
+        .await
+        .expect("default next");
+    assert!(default_next.as_array().unwrap().is_empty());
+
+    let diagnostic_next = fixture
+        .dispatch("gtd.next", json!({"include_blocked": true}))
+        .await
+        .expect("diagnostic next");
+    assert_eq!(diagnostic_next.as_array().unwrap().len(), 3);
+    assert!(diagnostic_next
+        .as_array()
+        .unwrap()
+        .iter()
+        .all(|task| { task["dependency_state"] == "broken" && task["actionable"] == false }));
+}
+
+#[tokio::test]
+async fn generic_update_rejects_direct_and_multihop_property_cycles() {
+    let fixture = pack(rt());
+    let a = assign(&fixture, json!({"title": "cycle A"})).await;
+    let b = assign(&fixture, json!({"title": "cycle B"})).await;
+    let c = assign(&fixture, json!({"title": "cycle C"})).await;
+    let a_id = a["full_id"].as_str().unwrap();
+    let b_id = b["full_id"].as_str().unwrap();
+    let c_id = c["full_id"].as_str().unwrap();
+
+    let direct = fixture
+        .dispatch(
+            "update",
+            json!({"id": a_id, "properties": {"depends_on": [a_id]}}),
+        )
+        .await
+        .expect_err("direct property cycle must fail");
+    assert!(direct.to_string().contains("dependency cycle"));
+
+    fixture
+        .dispatch(
+            "update",
+            json!({"id": a_id, "properties": {"depends_on": [b_id]}}),
+        )
+        .await
+        .expect("A depends on B");
+    fixture
+        .dispatch(
+            "update",
+            json!({"id": b_id, "properties": {"depends_on": [c_id]}}),
+        )
+        .await
+        .expect("B depends on C");
+    let multihop = fixture
+        .dispatch(
+            "update",
+            json!({"id": c_id, "properties": {"depends_on": [a_id]}}),
+        )
+        .await
+        .expect_err("C -> A must not close A -> B -> C");
+    assert!(multihop.to_string().contains("dependency cycle"));
+
+    let persisted_c = fixture
+        .dispatch("get", json!({"id": c_id}))
+        .await
+        .expect("load C after rejected update");
+    assert!(persisted_c["properties"].get("depends_on").is_none());
+}
+
+#[tokio::test]
+async fn link_rejects_multihop_and_same_batch_dependency_cycles() {
+    let fixture = pack(rt());
+    let a = assign(&fixture, json!({"title": "edge cycle A"})).await;
+    let b = assign(&fixture, json!({"title": "edge cycle B"})).await;
+    let c = assign(&fixture, json!({"title": "edge cycle C"})).await;
+    let a_id = a["full_id"].as_str().unwrap();
+    let b_id = b["full_id"].as_str().unwrap();
+    let c_id = c["full_id"].as_str().unwrap();
+
+    for (source_id, target_id) in [(a_id, b_id), (b_id, c_id)] {
+        fixture
+            .dispatch(
+                "link",
+                json!({
+                    "source_id": source_id,
+                    "target_id": target_id,
+                    "relation": "depends_on"
+                }),
+            )
+            .await
+            .expect("acyclic dependency link");
+    }
+    let multihop = fixture
+        .dispatch(
+            "link",
+            json!({
+                "source_id": c_id,
+                "target_id": a_id,
+                "relation": "depends_on"
+            }),
+        )
+        .await
+        .expect_err("C -> A must not close A -> B -> C");
+    assert!(multihop.to_string().contains("dependency cycle"));
+
+    let x = assign(&fixture, json!({"title": "batch cycle X"})).await;
+    let y = assign(&fixture, json!({"title": "batch cycle Y"})).await;
+    let same_batch = fixture
+        .dispatch(
+            "link",
+            json!({
+                "links": [
+                    {"source_id": x["full_id"], "target_id": y["full_id"], "relation": "depends_on"},
+                    {"source_id": y["full_id"], "target_id": x["full_id"], "relation": "depends_on"}
+                ]
+            }),
+        )
+        .await
+        .expect_err("atomic batch cycle must fail before either edge is written");
+    assert!(same_batch.to_string().contains("dependency cycle"));
+}
+
+#[tokio::test]
+async fn link_cycle_walk_ignores_paths_through_soft_deleted_tasks() {
+    let fixture = pack(rt());
+    let a = assign(&fixture, json!({"title": "live edge path A"})).await;
+    let tombstone = assign(&fixture, json!({"title": "deleted edge path B"})).await;
+    let c = assign(&fixture, json!({"title": "live edge path C"})).await;
+
+    for (source, target) in [(&a, &tombstone), (&tombstone, &c)] {
+        fixture
+            .dispatch(
+                "link",
+                json!({
+                    "source_id": source["full_id"],
+                    "target_id": target["full_id"],
+                    "relation": "depends_on"
+                }),
+            )
+            .await
+            .expect("seed acyclic dependency path");
+    }
+
+    fixture
+        .dispatch("delete", json!({"id": tombstone["full_id"]}))
+        .await
+        .expect("soft-delete intermediate task");
+
+    fixture
+        .dispatch(
+            "link",
+            json!({
+                "source_id": c["full_id"],
+                "target_id": a["full_id"],
+                "relation": "depends_on"
+            }),
+        )
+        .await
+        .expect("a path through a soft-deleted task is not a live dependency cycle");
 }
 
 // ---- depends_on and context_entity_id must be primary-only -------------------

--- a/crates/khive-pack-gtd/tests/dependencies.rs
+++ b/crates/khive-pack-gtd/tests/dependencies.rs
@@ -899,6 +899,79 @@ async fn generic_update_rejects_direct_and_multihop_property_cycles() {
 }
 
 #[tokio::test]
+async fn generic_update_rejects_noncanonical_dependency_uuid_without_persisting() {
+    let fixture = pack(rt());
+    let task = assign(&fixture, json!({"title": "canonical dependency source"})).await;
+    let blocker = assign(&fixture, json!({"title": "canonical dependency target"})).await;
+    let task_id = task["full_id"].as_str().unwrap();
+    let blocker_id = blocker["full_id"].as_str().unwrap();
+    let compact_blocker_id = blocker_id.replace('-', "");
+
+    let error = fixture
+        .dispatch(
+            "update",
+            json!({
+                "id": task_id,
+                "properties": {"depends_on": [compact_blocker_id]}
+            }),
+        )
+        .await
+        .expect_err("ordinary update must reject an alternate UUID spelling");
+    assert!(
+        error
+            .to_string()
+            .contains("canonical lowercase hyphenated UUID"),
+        "unexpected canonical UUID validation error: {error}"
+    );
+
+    let persisted = fixture
+        .dispatch("get", json!({"id": task_id}))
+        .await
+        .expect("load task after rejected alternate UUID spelling");
+    assert!(persisted["properties"].get("depends_on").is_none());
+}
+
+#[tokio::test]
+async fn generic_update_rejects_duplicate_dependency_walk_over_edge_budget() {
+    let runtime = rt();
+    let fixture = pack(runtime.clone());
+    let token = runtime
+        .authorize(khive_runtime::Namespace::local())
+        .expect("authorize local namespace");
+    let leaf = assign(&fixture, json!({"title": "fanout leaf"})).await;
+    let leaf_id = leaf["full_id"].as_str().unwrap();
+    let repeated_edges = vec![leaf_id.to_string(); 20_001];
+    let fanout = runtime
+        .create_note(
+            &token,
+            "task",
+            Some("duplicate dependency fanout"),
+            "duplicate dependency fanout",
+            Some(0.5),
+            Some(json!({"status": "next", "depends_on": repeated_edges})),
+            vec![],
+        )
+        .await
+        .expect("create legacy task above the typed traversal edge budget");
+    let source = assign(&fixture, json!({"title": "bounded traversal source"})).await;
+
+    let error = fixture
+        .dispatch(
+            "update",
+            json!({
+                "id": source["full_id"],
+                "properties": {"depends_on": [fanout.id.as_hyphenated().to_string()]}
+            }),
+        )
+        .await
+        .expect_err("duplicate dependency entries must consume the edge budget");
+    assert!(
+        error.to_string().contains("20000-edge safety bound"),
+        "unexpected bounded-walk error: {error}"
+    );
+}
+
+#[tokio::test]
 async fn link_rejects_multihop_and_same_batch_dependency_cycles() {
     let fixture = pack(rt());
     let a = assign(&fixture, json!({"title": "edge cycle A"})).await;

--- a/crates/khive-pack-gtd/tests/dependencies.rs
+++ b/crates/khive-pack-gtd/tests/dependencies.rs
@@ -850,6 +850,105 @@ async fn dependency_diagnostics_surface_cancelled_soft_deleted_and_missing_block
 }
 
 #[tokio::test]
+async fn dependency_diagnostics_surface_invalid_different_namespace_and_wrong_kind_blockers() {
+    let rt = rt();
+    let fixture = pack(rt.clone());
+    let token = rt.authorize(khive_runtime::Namespace::local()).unwrap();
+    let store = rt.notes(&token).expect("note store");
+
+    let wrong_kind_blocker = assign(
+        &fixture,
+        json!({"title": "wrong-kind blocker", "status": "inbox"}),
+    )
+    .await;
+    let namespace_blocker = assign(
+        &fixture,
+        json!({"title": "namespace blocker", "status": "inbox"}),
+    )
+    .await;
+
+    for (title, blocker) in [
+        ("blocked by wrong kind", &wrong_kind_blocker),
+        ("blocked by different namespace", &namespace_blocker),
+    ] {
+        assign(
+            &fixture,
+            json!({
+                "title": title,
+                "status": "next",
+                "depends_on": [blocker["full_id"].as_str().unwrap()]
+            }),
+        )
+        .await;
+    }
+
+    let invalid_dependent = assign(
+        &fixture,
+        json!({"title": "blocked by invalid entry", "status": "next"}),
+    )
+    .await;
+
+    // Corrupt each blocker's stored row directly through the note store,
+    // bypassing the pack-level write-time validation that would otherwise
+    // reject these shapes — read-time diagnostics must still catch them.
+    let wrong_kind_id =
+        uuid::Uuid::parse_str(wrong_kind_blocker["full_id"].as_str().unwrap()).unwrap();
+    let mut corrupted_kind = store
+        .get_note(wrong_kind_id)
+        .await
+        .expect("fetch blocker")
+        .expect("blocker exists");
+    corrupted_kind.kind = "observation".to_string();
+    store
+        .upsert_note(corrupted_kind)
+        .await
+        .expect("corrupt blocker kind");
+
+    let namespace_id =
+        uuid::Uuid::parse_str(namespace_blocker["full_id"].as_str().unwrap()).unwrap();
+    let mut corrupted_namespace = store
+        .get_note(namespace_id)
+        .await
+        .expect("fetch blocker")
+        .expect("blocker exists");
+    corrupted_namespace.namespace = "other".to_string();
+    store
+        .upsert_note(corrupted_namespace)
+        .await
+        .expect("corrupt blocker namespace");
+
+    let invalid_id = uuid::Uuid::parse_str(invalid_dependent["full_id"].as_str().unwrap()).unwrap();
+    store
+        .set_note_property(
+            invalid_id,
+            "depends_on",
+            json!(["not-a-uuid"]),
+            chrono::Utc::now().timestamp_micros(),
+        )
+        .await
+        .expect("corrupt dependent depends_on");
+
+    let tasks = fixture
+        .dispatch("gtd.tasks", json!({"status": "next"}))
+        .await
+        .expect("diagnostic task listing");
+    let tasks = tasks.as_array().expect("tasks array");
+    for (title, blocker_state) in [
+        ("blocked by wrong kind", "wrong_kind"),
+        ("blocked by different namespace", "different_namespace"),
+        ("blocked by invalid entry", "invalid"),
+    ] {
+        let task = tasks
+            .iter()
+            .find(|task| task["title"].as_str() == Some(title))
+            .unwrap_or_else(|| panic!("missing diagnostic task {title:?}: {tasks:?}"));
+        assert_eq!(task["dependency_state"], "broken");
+        assert_eq!(task["actionable"], false);
+        assert_eq!(task["blocked_by"][0]["state"], blocker_state);
+    }
+}
+
+#[tokio::test]
 async fn generic_update_rejects_direct_and_multihop_property_cycles() {
     let fixture = pack(rt());
     let a = assign(&fixture, json!({"title": "cycle A"})).await;

--- a/crates/khive-pack-kg/src/dispatch.rs
+++ b/crates/khive-pack-kg/src/dispatch.rs
@@ -209,7 +209,7 @@ impl PackRuntime for KgPack {
                 }
             }
             // Pure graph verbs: always use graph namespace.
-            "link" => self.handle_link(graph_token, params).await,
+            "link" => self.handle_link(graph_token, params, registry).await,
             "neighbors" => self.handle_neighbors(graph_token, params).await,
             "traverse" => self.handle_traverse(graph_token, params).await,
             "context" => self.handle_context(graph_token, params).await,

--- a/crates/khive-pack-kg/src/handlers/link.rs
+++ b/crates/khive-pack-kg/src/handlers/link.rs
@@ -2,7 +2,7 @@
 
 use serde_json::{json, Value};
 
-use khive_runtime::{merge_entry_metadata, LinkSpec, NamespaceToken, RuntimeError};
+use khive_runtime::{merge_entry_metadata, LinkSpec, NamespaceToken, RuntimeError, VerbRegistry};
 
 use super::common::{
     deser, enrich_allowlist_error, format_edge_output, parse_relation, resolve_uuid_unfiltered,
@@ -15,6 +15,7 @@ impl KgPack {
         &self,
         token: &NamespaceToken,
         params: Value,
+        registry: &VerbRegistry,
     ) -> Result<Value, RuntimeError> {
         let p: LinkParams = deser(params)?;
         let verbose = p.verbose.unwrap_or(false);
@@ -58,6 +59,9 @@ impl KgPack {
                         metadata,
                     });
                 }
+                registry
+                    .validate_link_hooks(&self.runtime, token, &specs)
+                    .await?;
                 let edges = self.runtime.link_many(token, specs).await?;
                 let mut resp = serde_json::json!({
                     "attempted": attempted,
@@ -126,6 +130,21 @@ impl KgPack {
                             continue;
                         }
                     };
+                    let spec = LinkSpec {
+                        namespace: Some(token.namespace().as_str().to_owned()),
+                        source_id: source,
+                        target_id: target,
+                        relation,
+                        weight,
+                        metadata: metadata.clone(),
+                    };
+                    if let Err(e) = registry
+                        .validate_link_hooks(&self.runtime, token, std::slice::from_ref(&spec))
+                        .await
+                    {
+                        error_list.push(json!({"index": idx, "error": format!("{e}")}));
+                        continue;
+                    }
                     match self
                         .runtime
                         .link(token, source, target, relation, weight, metadata)
@@ -163,6 +182,17 @@ impl KgPack {
         let weight = validate_weight(p.weight)?;
         let relation = parse_relation(&relation_str)?;
         let metadata = merge_entry_metadata(p.metadata, p.dependency_kind)?;
+        let spec = LinkSpec {
+            namespace: Some(token.namespace().as_str().to_owned()),
+            source_id: source,
+            target_id: target,
+            relation,
+            weight,
+            metadata: metadata.clone(),
+        };
+        registry
+            .validate_link_hooks(&self.runtime, token, std::slice::from_ref(&spec))
+            .await?;
 
         let edge = match self
             .runtime

--- a/crates/khive-pack-kg/src/handlers/tests.rs
+++ b/crates/khive-pack-kg/src/handlers/tests.rs
@@ -918,7 +918,7 @@ async fn seed_entity_with_id(
 // reverse project->concept legal set before this regression fix.
 #[tokio::test]
 async fn bulk_link_symmetric_rejection_preserves_requested_pair_in_both_modes() {
-    let (rt, token, pack, _registry) = configured_kg_endpoint_test_surface();
+    let (rt, token, pack, registry) = configured_kg_endpoint_test_surface();
     let concept_id =
         uuid::Uuid::parse_str("ffffffff-ffff-ffff-ffff-ffffffffffff").expect("high UUID");
     let project_id = uuid::Uuid::nil();
@@ -936,13 +936,13 @@ async fn bulk_link_symmetric_rejection_preserves_requested_pair_in_both_modes() 
             "atomic": atomic,
         });
         let message = if atomic {
-            pack.handle_link(&token, params)
+            pack.handle_link(&token, params, &registry)
                 .await
                 .expect_err("atomic bulk must reject concept competes_with project")
                 .to_string()
         } else {
             let response = pack
-                .handle_link(&token, params)
+                .handle_link(&token, params, &registry)
                 .await
                 .expect("non-atomic bulk reports entry failures in-band");
             response["errors"][0]["error"]

--- a/crates/khive-pack-kg/src/handlers/tests.rs
+++ b/crates/khive-pack-kg/src/handlers/tests.rs
@@ -796,7 +796,7 @@ async fn gtd_task_mismatch_bypasses_enriched_hint_on_real_link_path() {
         "target_id": tgt.id.to_string(),
         "relation": "extends",
     });
-    let result = pack.handle_link(&token, params).await;
+    let result = pack.handle_link(&token, params, &registry).await;
     assert!(result.is_err(), "task->task extends must be rejected");
     let err_msg = format!("{}", result.unwrap_err());
     assert!(
@@ -819,7 +819,7 @@ async fn gtd_task_mismatch_bypasses_enriched_hint_on_real_link_path() {
         "relation": "depends_on",
     });
     assert!(
-        pack.handle_link(&token, params_ok).await.is_ok(),
+        pack.handle_link(&token, params_ok, &registry).await.is_ok(),
         "task->task depends_on must be accepted by the real link path"
     );
 }
@@ -828,7 +828,7 @@ async fn gtd_task_mismatch_bypasses_enriched_hint_on_real_link_path() {
 #[tokio::test]
 async fn link_invalid_relation_error_suggests_valid_relations() {
     use crate::KgPack;
-    use khive_runtime::KhiveRuntime;
+    use khive_runtime::{KhiveRuntime, VerbRegistryBuilder};
 
     let rt = KhiveRuntime::memory().expect("in-memory runtime");
     let token = rt.authorize(khive_runtime::Namespace::local()).unwrap();
@@ -843,6 +843,10 @@ async fn link_invalid_relation_error_suggests_valid_relations() {
         .expect("create target entity");
 
     let pack = KgPack::new(rt.clone());
+    let mut builder = VerbRegistryBuilder::new();
+    builder.register(KgPack::new(rt.clone()));
+    let registry = builder.build().expect("kg registry builds");
+    rt.install_edge_rules(registry.all_edge_rules());
 
     // "depends_on" is a valid relation string but NOT in the concept->concept allowlist.
     let params = json!({
@@ -850,7 +854,7 @@ async fn link_invalid_relation_error_suggests_valid_relations() {
         "target_id": tgt_val.id.to_string(),
         "relation": "depends_on",
     });
-    let result = pack.handle_link(&token, params).await;
+    let result = pack.handle_link(&token, params, &registry).await;
     assert!(
         result.is_err(),
         "#486: depends_on on concept->concept should fail"
@@ -1778,6 +1782,7 @@ async fn configured_kg_pack() -> (
     khive_runtime::KhiveRuntime,
     khive_runtime::NamespaceToken,
     crate::KgPack,
+    khive_runtime::VerbRegistry,
 ) {
     use crate::KgPack;
     use khive_runtime::VerbRegistryBuilder;
@@ -1789,7 +1794,7 @@ async fn configured_kg_pack() -> (
     rt.install_edge_rules(registry.all_edge_rules());
     let token = rt.authorize(khive_runtime::Namespace::local()).unwrap();
     let pack = KgPack::new(rt.clone());
-    (rt, token, pack)
+    (rt, token, pack, registry)
 }
 
 // ADR-087 Amendment 1 §A9: review-round chains are `decision precedes
@@ -1799,7 +1804,7 @@ async fn configured_kg_pack() -> (
 // `depends_on` rule.
 #[tokio::test]
 async fn link_accepts_decision_precedes_decision() {
-    let (rt, token, pack) = configured_kg_pack().await;
+    let (rt, token, pack, registry) = configured_kg_pack().await;
 
     let round1 = rt
         .create_note(
@@ -1832,14 +1837,14 @@ async fn link_accepts_decision_precedes_decision() {
         "relation": "precedes",
     });
     assert!(
-        pack.handle_link(&token, params).await.is_ok(),
+        pack.handle_link(&token, params, &registry).await.is_ok(),
         "decision->decision precedes must be accepted"
     );
 }
 
 #[tokio::test]
 async fn link_rejects_decision_precedes_observation() {
-    let (rt, token, pack) = configured_kg_pack().await;
+    let (rt, token, pack, registry) = configured_kg_pack().await;
 
     let decision = rt
         .create_note(&token, "decision", None, "a decision", None, None, vec![])
@@ -1864,14 +1869,14 @@ async fn link_rejects_decision_precedes_observation() {
         "relation": "precedes",
     });
     assert!(
-        pack.handle_link(&token, params).await.is_err(),
+        pack.handle_link(&token, params, &registry).await.is_err(),
         "decision->observation precedes must be rejected"
     );
 }
 
 #[tokio::test]
 async fn link_rejects_observation_precedes_decision() {
-    let (rt, token, pack) = configured_kg_pack().await;
+    let (rt, token, pack, registry) = configured_kg_pack().await;
 
     let observation = rt
         .create_note(
@@ -1896,14 +1901,14 @@ async fn link_rejects_observation_precedes_decision() {
         "relation": "precedes",
     });
     assert!(
-        pack.handle_link(&token, params).await.is_err(),
+        pack.handle_link(&token, params, &registry).await.is_err(),
         "observation->decision precedes must be rejected"
     );
 }
 
 #[tokio::test]
 async fn link_entity_precedes_entity_unaffected_by_decision_note_rule() {
-    let (rt, token, pack) = configured_kg_pack().await;
+    let (rt, token, pack, registry) = configured_kg_pack().await;
 
     let src = rt
         .create_entity(&token, "project", None, "step 1", None, None, vec![])
@@ -1920,7 +1925,7 @@ async fn link_entity_precedes_entity_unaffected_by_decision_note_rule() {
         "relation": "precedes",
     });
     assert!(
-        pack.handle_link(&token, params).await.is_ok(),
+        pack.handle_link(&token, params, &registry).await.is_ok(),
         "entity->entity precedes must remain accepted under the composed rule set (base ADR-002 contract)"
     );
 }
@@ -2079,7 +2084,7 @@ async fn merge_note_reason_forwarded_through_registry_dispatch() {
 async fn get_dispatch_after_merge_discloses_kept_id() {
     use khive_runtime::RuntimeError;
 
-    let (rt, token, _pack) = configured_kg_pack().await;
+    let (rt, token, _pack, _registry) = configured_kg_pack().await;
     let mut builder = khive_runtime::VerbRegistryBuilder::new();
     builder.register(crate::KgPack::new(rt.clone()));
     let registry = builder.build().expect("registry build");
@@ -2139,7 +2144,7 @@ async fn get_dispatch_after_merge_discloses_kept_id() {
 
 #[tokio::test]
 async fn get_dispatch_short_prefix_with_include_deleted_returns_deleted_entity() {
-    let (rt, token, _pack) = configured_kg_pack().await;
+    let (rt, token, _pack, _registry) = configured_kg_pack().await;
     let mut builder = khive_runtime::VerbRegistryBuilder::new();
     builder.register(crate::KgPack::new(rt.clone()));
     let registry = builder.build().expect("registry build");
@@ -2169,7 +2174,7 @@ async fn get_dispatch_short_prefix_with_include_deleted_returns_deleted_entity()
 async fn get_dispatch_on_plain_deleted_and_absent_ids_unchanged() {
     use khive_runtime::RuntimeError;
 
-    let (rt, token, _pack) = configured_kg_pack().await;
+    let (rt, token, _pack, _registry) = configured_kg_pack().await;
     let mut builder = khive_runtime::VerbRegistryBuilder::new();
     builder.register(crate::KgPack::new(rt.clone()));
     let registry = builder.build().expect("registry build");
@@ -2212,7 +2217,7 @@ async fn get_dispatch_on_plain_deleted_and_absent_ids_unchanged() {
 // resolving an absorbed uuid still reports a bare `not_found` status.
 #[tokio::test]
 async fn resolve_dispatch_on_merged_uuid_stays_bare_not_found() {
-    let (rt, token, _pack) = configured_kg_pack().await;
+    let (rt, token, _pack, _registry) = configured_kg_pack().await;
     let mut builder = khive_runtime::VerbRegistryBuilder::new();
     builder.register(crate::KgPack::new(rt.clone()));
     let registry = builder.build().expect("registry build");

--- a/crates/khive-pack-kg/src/handlers/update.rs
+++ b/crates/khive-pack-kg/src/handlers/update.rs
@@ -221,13 +221,13 @@ impl KgPack {
                     .get_note(id)
                     .await
                     .map_err(RuntimeError::Storage)?;
-                if note
-                    .as_ref()
-                    .is_none_or(|n| specific.as_ref().is_some_and(|k| n.kind != *k))
-                {
+                let Some(note) = note else {
+                    return Err(RuntimeError::NotFound(format!("note {}", p.id)));
+                };
+                if specific.as_ref().is_some_and(|kind| note.kind != *kind) {
                     return Err(RuntimeError::NotFound(format!("note {}", p.id)));
                 }
-                if note.as_ref().is_some_and(|n| n.kind == "scheduled_event") {
+                if note.kind == "scheduled_event" {
                     return Err(RuntimeError::InvalidInput(
                         "scheduled_event notes are not editable via `update` — their creator \
                          identity and action payload are a trust boundary for replay dispatch; \
@@ -235,6 +235,9 @@ impl KgPack {
                             .into(),
                     ));
                 }
+                registry
+                    .validate_note_update_hook(&self.runtime, token, &note, p.properties.as_ref())
+                    .await?;
                 let patch = NotePatch::new(
                     optional_string_patch(p.name, "name")?,
                     p.content,

--- a/crates/khive-runtime/docs/api/atomic_prepare.md
+++ b/crates/khive-runtime/docs/api/atomic_prepare.md
@@ -6,6 +6,14 @@ transaction without invoking the normal async handler. This document covers whic
 in scope, why some are deliberately excluded, and the DML-shape parity guarantees for the
 functions that build those plans.
 
+Pack-owned mutation invariants are adapted at the `kkernel` boundary, where both
+the `VerbRegistry` and this runtime plan vocabulary are visible. For task note
+updates and task dependency links, `kkernel` invokes the same `KindHook` validators
+as canonical KG dispatch after building the substrate plan. Core migration V15's
+transaction-time triggers remain the final backstop: they see earlier statements
+in the same atomic unit and close concurrent check/write races that an async prepare
+pass cannot.
+
 ## Scope: what is excluded and why
 
 `gtd.transition` / `gtd.complete` prepare is deliberately **not** here: their lifecycle

--- a/crates/khive-runtime/src/pack.rs
+++ b/crates/khive-runtime/src/pack.rs
@@ -14,6 +14,7 @@ use std::collections::{HashMap, HashSet, VecDeque};
 use std::sync::Arc;
 use std::time::Instant;
 
+use crate::operations::{LinkSpec, Resolved};
 use crate::runtime::NamespaceToken;
 use async_trait::async_trait;
 use khive_gate::{AllowAllGate, AuditEvent, GateDecision, GateRef, GateRequest};
@@ -257,13 +258,15 @@ pub trait PackRuntime: Send + Sync {
 /// - **Defaults** filled into create args (e.g. `status="inbox"` for tasks)
 /// - **Derived properties** computed from args (e.g. salience from priority)
 /// - **Side-effect writes** after the storage commit (e.g. `depends_on` edges)
+/// - **Cross-pack validation** before shared CRUD mutates an owned kind
 ///
 /// Hooks are stateless from the framework's perspective — they receive the
-/// runtime as a method parameter and operate on the args `Value` directly.
-/// The pack registers them via [`PackRuntime::kind_hook`].
+/// runtime and the current mutation inputs as method parameters. The pack
+/// registers them via [`PackRuntime::kind_hook`].
 ///
 /// Lifecycle verbs (e.g. gtd's `complete`, `transition`) remain pack-owned
-/// verbs and do not flow through this trait — only the create path does.
+/// verbs. Shared `create`, note `update`, and `link` calls flow through this
+/// trait when an endpoint kind has an owning pack hook.
 #[async_trait]
 pub trait KindHook: Send + Sync + std::fmt::Debug {
     /// Mutate args before the storage write. Fill defaults, normalize values,
@@ -291,6 +294,34 @@ pub trait KindHook: Send + Sync + std::fmt::Debug {
         id: uuid::Uuid,
         args: &Value,
     ) -> Result<(), RuntimeError>;
+
+    /// Validate a shared note-property update before storage is mutated.
+    ///
+    /// The default accepts the update. Kind-owning packs override this when a
+    /// property has invariants that generic CRUD cannot know about (for
+    /// example, GTD task dependency acyclicity).
+    async fn validate_note_update(
+        &self,
+        _runtime: &KhiveRuntime,
+        _token: &NamespaceToken,
+        _note: &khive_storage::Note,
+        _properties: Option<&Value>,
+    ) -> Result<(), RuntimeError> {
+        Ok(())
+    }
+
+    /// Validate one or more shared graph links before any edge is written.
+    ///
+    /// A batch is supplied as a unit so a hook can reject a cycle formed only
+    /// by the proposed edges. The default accepts every link.
+    async fn validate_links(
+        &self,
+        _runtime: &KhiveRuntime,
+        _token: &NamespaceToken,
+        _links: &[crate::LinkSpec],
+    ) -> Result<(), RuntimeError> {
+        Ok(())
+    }
 }
 
 /// Optional sub-trait for packs that own private SQL tables and issue UUIDs
@@ -1872,6 +1903,55 @@ impl VerbRegistry {
             }
         }
         None
+    }
+
+    /// Run the owning kind's shared-note-update validator, if it declares one.
+    ///
+    /// Both canonical KG dispatch and user-facing atomic preparation call this
+    /// seam so pack-specific property invariants cannot drift between them.
+    pub async fn validate_note_update_hook(
+        &self,
+        runtime: &KhiveRuntime,
+        token: &NamespaceToken,
+        note: &khive_storage::Note,
+        properties: Option<&Value>,
+    ) -> Result<(), RuntimeError> {
+        if let Some(hook) = self.find_kind_hook(&note.kind) {
+            hook.validate_note_update(runtime, token, note, properties)
+                .await?;
+        }
+        Ok(())
+    }
+
+    /// Run shared-link validators grouped by the owning source-note kind.
+    ///
+    /// Supplying the whole proposed batch lets a kind hook reject an invariant
+    /// violation formed only by multiple entries in that batch. Sources that
+    /// are not live notes, or whose kind has no hook, remain the canonical
+    /// endpoint validator's responsibility.
+    pub async fn validate_link_hooks(
+        &self,
+        runtime: &KhiveRuntime,
+        token: &NamespaceToken,
+        specs: &[LinkSpec],
+    ) -> Result<(), RuntimeError> {
+        let mut specs_by_kind: HashMap<String, Vec<LinkSpec>> = HashMap::new();
+        for spec in specs {
+            let Some(Resolved::Note(source)) = runtime.resolve_by_id(token, spec.source_id).await?
+            else {
+                continue;
+            };
+            specs_by_kind
+                .entry(source.kind)
+                .or_default()
+                .push(spec.clone());
+        }
+        for (kind, kind_specs) in specs_by_kind {
+            if let Some(hook) = self.find_kind_hook(&kind) {
+                hook.validate_links(runtime, token, &kind_specs).await?;
+            }
+        }
+        Ok(())
     }
 
     /// Whether any registered pack declares a handler with this verb name.

--- a/crates/kkernel/docs/design.md
+++ b/crates/kkernel/docs/design.md
@@ -121,6 +121,14 @@ It runs, in order:
    update whose embedding input was bounded carries the same per-result `warnings` advisory as
    the canonical non-atomic handler.
 
+Before prepare, the atomic runtime installs the same aggregate pack edge rules as canonical
+server startup. After each task-note `update` or dependency `link` plan is built, the boundary
+also invokes `VerbRegistry`'s shared `KindHook` validator for typed parity with canonical KG
+dispatch. Since every plan is still prepared before any write, core migration V15 supplies the
+transaction-time task dependency cycle triggers: a later statement sees earlier writes in the
+unit, and a trigger error rolls the entire unit back. The same triggers serialize opposite
+concurrent writers, while leaving unrelated notes and edge relations untouched.
+
 **Verbs without a prepare implementation.** `propose`/`review`/`withdraw` are listed in
 `khive_types::pack::ATOMIC_ADMISSIBLE_VERBS` (ADR-099 D3 intends them to eventually gain a
 seam) but have none yet; the B3 fix rejects them at the same pre-runtime

--- a/crates/kkernel/src/atomic_apply.rs
+++ b/crates/kkernel/src/atomic_apply.rs
@@ -8,7 +8,6 @@
 
 use anyhow::{Context, Result};
 use serde_json::{json, Value};
-#[cfg(test)]
 use uuid::Uuid;
 
 use khive_pack_gtd::handlers::{ensure_audit_schema, write_audit_record};
@@ -19,7 +18,7 @@ use khive_runtime::atomic_plan::{
 use khive_runtime::atomic_runner::{AtomicOpFailure, AtomicOpPlan, AtomicRunOutcome};
 use khive_runtime::pack::{PackRegistry, VerbRegistry, VerbRegistryBuilder};
 use khive_runtime::{
-    EdgeListFilter, KhiveConfig, KhiveRuntime, NamespaceToken, Resolved, RuntimeConfig,
+    EdgeListFilter, KhiveConfig, KhiveRuntime, LinkSpec, NamespaceToken, Resolved, RuntimeConfig,
 };
 use khive_storage::EdgeRelation;
 #[cfg(test)]
@@ -135,6 +134,11 @@ pub(crate) async fn execute_atomic_ops_file(
     let verb_registry = verb_registry_builder
         .build()
         .context("building VerbRegistry for --atomic kind resolution")?;
+    // Canonical server startup installs the aggregate before dispatch. Atomic
+    // preparation calls the same runtime endpoint validator directly, so it
+    // must receive pack extensions too (notably GTD's task->task depends_on
+    // rule) rather than silently behaving like a kg-only runtime.
+    runtime.install_edge_rules(verb_registry.all_edge_rules());
     // #750: every other entry point that
     // builds a `VerbRegistry` from a freshly constructed `KhiveRuntime`
     // (`khive-mcp`'s `serve.rs`/`server.rs`) calls this so a pack-installed
@@ -386,11 +390,58 @@ async fn prepare_one(
             )
             .await
             .map_err(|e| anyhow::anyhow!("{e}"))?;
+            let id = resolved
+                .get("id")
+                .and_then(Value::as_str)
+                .and_then(|raw| Uuid::parse_str(raw).ok())
+                .ok_or_else(|| anyhow::anyhow!("resolved update id must be a full UUID"))?;
+            if let Some(Resolved::Note(note)) = runtime
+                .resolve_by_id(token, id)
+                .await
+                .map_err(|e| anyhow::anyhow!("{e}"))?
+            {
+                let properties = resolved.get("properties").filter(|value| !value.is_null());
+                registry
+                    .validate_note_update_hook(runtime, token, &note, properties)
+                    .await
+                    .map_err(|e| anyhow::anyhow!("{e}"))?;
+            }
             Ok((plan, resolved))
         }
         "link" => {
             let resolved = resolve_kg_ids_in_args(runtime, token, tool, args).await?;
             let plan = khive_runtime::atomic_prepare::prepare_op(runtime, token, tool, &resolved)
+                .await
+                .map_err(|e| anyhow::anyhow!("{e}"))?;
+            let source_id = resolved
+                .get("source_id")
+                .and_then(Value::as_str)
+                .and_then(|raw| Uuid::parse_str(raw).ok())
+                .ok_or_else(|| anyhow::anyhow!("resolved link source_id must be a full UUID"))?;
+            let target_id = resolved
+                .get("target_id")
+                .and_then(Value::as_str)
+                .and_then(|raw| Uuid::parse_str(raw).ok())
+                .ok_or_else(|| anyhow::anyhow!("resolved link target_id must be a full UUID"))?;
+            let relation = resolved
+                .get("relation")
+                .and_then(Value::as_str)
+                .ok_or_else(|| anyhow::anyhow!("resolved link relation must be a string"))?
+                .parse::<EdgeRelation>()
+                .map_err(|e| anyhow::anyhow!("{e}"))?;
+            let spec = LinkSpec {
+                namespace: Some(token.namespace().as_str().to_owned()),
+                source_id,
+                target_id,
+                relation,
+                weight: resolved
+                    .get("weight")
+                    .and_then(Value::as_f64)
+                    .unwrap_or(1.0),
+                metadata: resolved.get("metadata").cloned(),
+            };
+            registry
+                .validate_link_hooks(runtime, token, std::slice::from_ref(&spec))
                 .await
                 .map_err(|e| anyhow::anyhow!("{e}"))?;
             Ok((plan, resolved))

--- a/crates/kkernel/src/code_audit.rs
+++ b/crates/kkernel/src/code_audit.rs
@@ -2050,11 +2050,19 @@ crate-b = 1
             // (namespace, id), so SQLite's `ALTER TABLE ... DROP COLUMN`
             // refuses it ("cannot drop PRIMARY KEY column"); rebuild the
             // table without the column instead to simulate a map missing
-            // ONLY `graph_edges.id`.
+            // ONLY `graph_edges.id`. Drop the GTD integrity triggers first:
+            // they intentionally depend on `graph_edges`, while this fixture
+            // intentionally replaces that table with a malformed schema.
             writer
                 .conn_mut()
                 .execute_batch(
-                    "CREATE TABLE graph_edges_no_id (
+                    "DROP TRIGGER gtd_task_dependency_cycle_notes_bi;
+                     DROP TRIGGER gtd_task_dependency_cycle_notes_bu;
+                     DROP TRIGGER gtd_task_dependency_cycle_note_activation_bi;
+                     DROP TRIGGER gtd_task_dependency_cycle_note_activation_bu;
+                     DROP TRIGGER gtd_task_dependency_cycle_edges_bi;
+                     DROP TRIGGER gtd_task_dependency_cycle_edges_bu;
+                     CREATE TABLE graph_edges_no_id (
                          namespace      TEXT NOT NULL,
                          source_id      TEXT NOT NULL,
                          target_id      TEXT NOT NULL,

--- a/crates/kkernel/src/exec.rs
+++ b/crates/kkernel/src/exec.rs
@@ -3663,6 +3663,125 @@ backend = "sessions"
         );
     }
 
+    /// #1474: the user-facing `--atomic` executor prepares every operation
+    /// before its commit pass. Two individually acyclic task writes can
+    /// therefore form a cycle only inside the unit. The V15 commit-time
+    /// guards must reject the later statement and roll the earlier one back
+    /// for both authoritative dependency stores.
+    #[tokio::test]
+    async fn atomic_ops_file_rejects_same_unit_gtd_dependency_cycles() {
+        let db_file = NamedTempFile::new().expect("temp db");
+        let db_path = db_file.path().to_str().expect("utf8").to_string();
+
+        let (a_id, b_id) = {
+            let server = isolated_server(&db_path);
+            let response = dispatch_json(
+                &server,
+                r#"[gtd.assign(title="AtomicCycleA", status="next"), gtd.assign(title="AtomicCycleB", status="next")]"#,
+            )
+            .await;
+            (
+                response["results"][0]["result"]["full_id"]
+                    .as_str()
+                    .expect("task A id")
+                    .to_string(),
+                response["results"][1]["result"]["full_id"]
+                    .as_str()
+                    .expect("task B id")
+                    .to_string(),
+            )
+        };
+
+        let property_envelope = crate::atomic_apply::execute_atomic_ops_file(
+            vec![
+                atomic_op(
+                    "update",
+                    serde_json::json!({
+                        "id": a_id.clone(),
+                        "properties": {"depends_on": [b_id.clone()]}
+                    }),
+                ),
+                atomic_op(
+                    "update",
+                    serde_json::json!({
+                        "id": b_id.clone(),
+                        "properties": {"depends_on": [a_id.clone()]}
+                    }),
+                ),
+            ],
+            atomic_cfg(&db_path),
+            &KhiveConfig::default(),
+            khive_types::pack::ATOMIC_MAX_OPS_DEFAULT,
+        )
+        .await
+        .expect("cycle is a clean atomic rollback, not a seam failure");
+        assert_eq!(property_envelope["atomic"]["rolled_back"], true);
+        assert_eq!(property_envelope["atomic"]["failed_op_index"], 1);
+        assert!(
+            property_envelope["atomic"]["error"]
+                .as_str()
+                .is_some_and(|error| error.contains("dependency cycle")),
+            "envelope: {property_envelope}"
+        );
+
+        let server = isolated_server(&db_path);
+        for task_id in [&a_id, &b_id] {
+            let response = dispatch_json(&server, &format!(r#"get(id="{task_id}")"#)).await;
+            assert!(
+                response["results"][0]["result"]["properties"]
+                    .get("depends_on")
+                    .is_none(),
+                "the earlier update must roll back too: {response}"
+            );
+        }
+
+        let edge_envelope = crate::atomic_apply::execute_atomic_ops_file(
+            vec![
+                atomic_op(
+                    "link",
+                    serde_json::json!({
+                        "source_id": a_id.clone(),
+                        "target_id": b_id.clone(),
+                        "relation": "depends_on"
+                    }),
+                ),
+                atomic_op(
+                    "link",
+                    serde_json::json!({
+                        "source_id": b_id.clone(),
+                        "target_id": a_id.clone(),
+                        "relation": "depends_on"
+                    }),
+                ),
+            ],
+            atomic_cfg(&db_path),
+            &KhiveConfig::default(),
+            khive_types::pack::ATOMIC_MAX_OPS_DEFAULT,
+        )
+        .await
+        .expect("edge cycle is a clean atomic rollback, not a seam failure");
+        assert_eq!(edge_envelope["atomic"]["rolled_back"], true);
+        assert_eq!(edge_envelope["atomic"]["failed_op_index"], 1);
+        assert!(
+            edge_envelope["atomic"]["error"]
+                .as_str()
+                .is_some_and(|error| error.contains("dependency cycle")),
+            "envelope: {edge_envelope}"
+        );
+
+        let server = isolated_server(&db_path);
+        let response = dispatch_json(
+            &server,
+            &format!(r#"neighbors(id="{a_id}", direction="out", relations=["depends_on"])"#),
+        )
+        .await;
+        assert_eq!(
+            response["results"][0]["result"],
+            serde_json::json!([]),
+            "the earlier link must roll back too: {response}"
+        );
+    }
+
     /// ADR-099 B3 (second half): the inverse
     /// same-unit race — `[link(A, B, competes_with), update(X
     /// extends A-B -> competes_with)]`, where the CANONICAL row the update

--- a/crates/kkernel/src/exec.rs
+++ b/crates/kkernel/src/exec.rs
@@ -3692,6 +3692,49 @@ backend = "sessions"
             )
         };
 
+        let compact_a_id = a_id.replace('-', "");
+        let compact_b_id = b_id.replace('-', "");
+        let alternate_spelling_error = crate::atomic_apply::execute_atomic_ops_file(
+            vec![
+                atomic_op(
+                    "update",
+                    serde_json::json!({
+                        "id": a_id.clone(),
+                        "properties": {"depends_on": [compact_b_id]}
+                    }),
+                ),
+                atomic_op(
+                    "update",
+                    serde_json::json!({
+                        "id": b_id.clone(),
+                        "properties": {"depends_on": [compact_a_id]}
+                    }),
+                ),
+            ],
+            atomic_cfg(&db_path),
+            &KhiveConfig::default(),
+            khive_types::pack::ATOMIC_MAX_OPS_DEFAULT,
+        )
+        .await
+        .expect_err("atomic preparation must reject an alternate dependency UUID spelling");
+        assert!(
+            alternate_spelling_error
+                .to_string()
+                .contains("canonical lowercase hyphenated UUID"),
+            "unexpected alternate-spelling error: {alternate_spelling_error}"
+        );
+
+        {
+            let server = isolated_server(&db_path);
+            let response = dispatch_json(&server, &format!(r#"get(id="{a_id}")"#)).await;
+            assert!(
+                response["results"][0]["result"]["properties"]
+                    .get("depends_on")
+                    .is_none(),
+                "alternate dependency spelling must not persist: {response}"
+            );
+        }
+
         let property_envelope = crate::atomic_apply::execute_atomic_ops_file(
             vec![
                 atomic_op(

--- a/crates/kkernel/src/exec.rs
+++ b/crates/kkernel/src/exec.rs
@@ -3717,11 +3717,10 @@ backend = "sessions"
         )
         .await
         .expect_err("atomic preparation must reject an alternate dependency UUID spelling");
+        let alternate_spelling_message = format!("{alternate_spelling_error:#}");
         assert!(
-            alternate_spelling_error
-                .to_string()
-                .contains("canonical lowercase hyphenated UUID"),
-            "unexpected alternate-spelling error: {alternate_spelling_error}"
+            alternate_spelling_message.contains("canonical lowercase hyphenated UUID"),
+            "unexpected alternate-spelling error: {alternate_spelling_message}"
         );
 
         {

--- a/docs/adr/ADR-015-schema-migrations.md
+++ b/docs/adr/ADR-015-schema-migrations.md
@@ -160,11 +160,11 @@ above remains the historical pre-consolidation record.
 > and edge list cursors. V14 adds the graph-edge identifier compatibility guard.
 > These entries align the live ledger with `MIGRATIONS`.
 
-> **V15 record (2026-08-01, ADR-019 / #1474)**:
+> **V16 record (2026-08-01, ADR-019 / #1474)**:
 > `gtd_dependency_cycle_guards` installs narrowly predicated transaction-time triggers on
 > the core `notes` and `graph_edges` tables. They reject only live task property cycles and
 > live task-to-task `depends_on` edge cycles. Pack `KindHook` validation remains the typed,
-> bounded early-error path; V15 is the cross-process race-safe backstop shared by canonical,
+> bounded early-error path; V16 is the cross-process race-safe backstop shared by canonical,
 > direct-storage, and atomic-unit writers. The migration does not rewrite or reject existing
 > rows while installing the triggers.
 
@@ -203,7 +203,7 @@ exception is narrow: it applies only to evolving a table's shape that a core mig
 never to introducing a wholly new pack-auxiliary table through the core lane, which remains the pack's
 own boot-time declaration to make.
 
-**The core-row invariant-trigger exception.** V15
+**The core-row invariant-trigger exception.** V16
 (`gtd_dependency_cycle_guards`, ADR-019 / #1474) records a second narrow case: a
 pack-owned invariant may use a versioned trigger on a core table when correctness requires
 validation in the same SQLite writer transaction as every mutation. An async pack hook alone

--- a/docs/adr/ADR-015-schema-migrations.md
+++ b/docs/adr/ADR-015-schema-migrations.md
@@ -142,6 +142,7 @@ above remains the historical pre-consolidation record.
 |     V12 | ADR-118            | ann_write_log_model_seq_index      | shipped |
 |     V13 | #1424 / #1462      | list_cursor_sequences              | shipped |
 |     V14 | #1424 / #1462      | graph_edges_id_unique              | shipped |
+|     V15 | ADR-019 / #1474    | gtd_dependency_cycle_guards        | shipped |
 
 > **V9 record (2026-07-18)**: `entities_name_ci_index` (ADR-104) ships in the `MIGRATIONS`
 > array as `009-entities-name-ci-index.sql`; its status here was `claimed`, stale from ADR-104,
@@ -152,10 +153,19 @@ above remains the historical pre-consolidation record.
 > column, khive#292) shipped in the `MIGRATIONS` array but was not recorded here; it is
 > backfilled so the live sequence remains contiguous through the later shipped migrations.
 
-> **V11–V13 record (2026-08-01)**: V11 and V12 record the shipped ANN write-log
+> **V11–V14 record (2026-08-01)**: V11 and V12 record the shipped ANN write-log
 > table and model-leading tail index. V13 adds durable insertion-sequence ledgers,
 > ordered upgrade backfills, and atomic insert triggers for stable entity, note,
-> and edge list cursors. These entries align the live ledger with `MIGRATIONS`.
+> and edge list cursors. V14 adds the graph-edge identifier compatibility guard.
+> These entries align the live ledger with `MIGRATIONS`.
+
+> **V15 record (2026-08-01, ADR-019 / #1474)**:
+> `gtd_dependency_cycle_guards` installs narrowly predicated transaction-time triggers on
+> the core `notes` and `graph_edges` tables. They reject only live task property cycles and
+> live task-to-task `depends_on` edge cycles. Pack `KindHook` validation remains the typed,
+> bounded early-error path; V15 is the cross-process race-safe backstop shared by canonical,
+> direct-storage, and atomic-unit writers. The migration does not rewrite or reject existing
+> rows while installing the triggers.
 
 > **Invariant**: ADR number order and migration version order are independent. Migration versions reflect schema ledger assignment order. A migration may only depend on schema created by earlier versions.
 
@@ -191,6 +201,16 @@ the core ledger already versions rather than in a boot-time pack declaration of 
 exception is narrow: it applies only to evolving a table's shape that a core migration already owns,
 never to introducing a wholly new pack-auxiliary table through the core lane, which remains the pack's
 own boot-time declaration to make.
+
+**The core-row invariant-trigger exception.** V15
+(`gtd_dependency_cycle_guards`, ADR-019 / #1474) records a second narrow case: a
+pack-owned invariant may use a versioned trigger on a core table when correctness requires
+validation in the same SQLite writer transaction as every mutation. An async pack hook alone
+cannot close the cross-process check/write race or see earlier statements in one atomic unit.
+Such a trigger MUST be limited to rows and relations owned by the pack, MUST ignore unrelated
+core writes, MUST treat soft-deleted rows consistently with live-store reads, and MUST ship
+with migration, fresh-start, atomic-unit, and unrelated-write regression coverage. This does
+not authorize pack `SchemaPlan` DDL against core tables; those plans remain auxiliary-only.
 
 ### Versioned migration model
 

--- a/docs/adr/ADR-017-pack-standard.md
+++ b/docs/adr/ADR-017-pack-standard.md
@@ -204,6 +204,23 @@ pub trait KindHook: Send + Sync + std::fmt::Debug {
         id: Uuid,
         args: &Value,
     ) -> Result<(), RuntimeError>;
+
+    /// Validate a generic note-property update before the write. Default: accept.
+    async fn validate_note_update(
+        &self,
+        runtime: &KhiveRuntime,
+        token: &NamespaceToken,
+        note: &Note,
+        properties: Option<&Value>,
+    ) -> Result<(), RuntimeError> { Ok(()) }
+
+    /// Validate a generic link batch before any edge is written. Default: accept.
+    async fn validate_links(
+        &self,
+        runtime: &KhiveRuntime,
+        token: &NamespaceToken,
+        links: &[LinkSpec],
+    ) -> Result<(), RuntimeError> { Ok(()) }
 }
 ```
 
@@ -211,10 +228,14 @@ A pack registers a hook for kinds it wants to specialize. Storage-shape kinds
 (no defaults, no derived data, no side effects) skip the hook entirely and ride pure
 shared CRUD.
 
-`KindHook` is one of many possible specialization points. Future hooks
-(`prepare_update`, `after_update`, `before_delete`) extend the pattern. v1 ships
-`prepare_create` + `after_create` because those cover the common case of "fill
-defaults, fire side effects on creation."
+The 2026-08-01 dependency-integrity amendment adds the two default-accepting
+pre-write validators after GTD demonstrated a cross-record invariant that generic
+CRUD cannot own: task dependency acyclicity. `validate_note_update` receives only
+note-property patches, while `validate_links` receives the whole proposed batch so a
+cycle formed entirely inside one atomic link request cannot evade validation. Packs
+that do not need either hook inherit a no-op and remain source-compatible. Future
+hooks (`after_update`, `before_delete`) can extend the same pattern when a concrete
+consumer requires them.
 
 ### `VerbRegistry`: the runtime's pack catalog
 
@@ -598,6 +619,13 @@ Core substrate tables (entities, notes, edges, events) are NOT pack-owned — th
 owned by `khive-db` and evolve through versioned migrations (ADR-015). Pack schema is
 strictly for pack-auxiliary tables.
 
+The 2026-08-01 dependency-integrity amendment uses ADR-015's narrow core-row
+invariant-trigger exception: GTD's typed `KindHook` checks remain the early-error seam,
+while versioned migration V15 installs transaction-time cycle guards on live `task`
+rows and live task-to-task `depends_on` edges. Those triggers are core migration DDL,
+not GTD `SchemaPlan` statements. They govern only the owned kind/relation combination,
+so unrelated notes, edge relations, and entity dependency graphs are unchanged.
+
 ### Dispatch path
 
 ```text
@@ -836,10 +864,13 @@ dedicated ADR. v1 is compile-time.
 
 - The kg pack's name carries weight beyond its origins (it owns shared CRUD for all
   kinds). Renaming is not justified.
-- `KindHook` covers `prepare_create` + `after_create`. Update and delete hooks extend
-  the pattern when a real consumer asks.
+- `KindHook` covers create specialization plus default-accepting note-update and
+  link-batch validation. Post-update and delete hooks extend the pattern when a real
+  consumer asks.
 - Pack auxiliary schema is non-evolving in v1. If a pack needs to evolve its schema, it
   coordinates with khive-db migrations (ADR-015).
+- A pack invariant that must be race-safe across processes may use ADR-015's narrowly
+  governed core-row trigger exception; it does not widen `SchemaPlan` beyond auxiliary DDL.
 
 ## Implementation
 

--- a/docs/adr/ADR-019-gtd-pack.md
+++ b/docs/adr/ADR-019-gtd-pack.md
@@ -23,8 +23,9 @@ domains without forking the substrate.
 The system must satisfy:
 
 1. **No substrate fork.** Tasks ride on the existing notes table. No new storage
-   trait, no migration, no parallel CRUD path. The `properties` JSON column carries
-   GTD-specific fields.
+   trait or parallel CRUD path exists; the `properties` JSON column carries
+   GTD-specific fields. V15 adds invariant triggers without changing the task row
+   shape.
 2. **Five disjoint verbs.** No collision with the kg pack's shared CRUD. GTD's verbs
    express lifecycle intent (`assign`, `next`, `complete`, `tasks`, `transition`),
    not generic CRUD.
@@ -91,8 +92,10 @@ The `properties` JSON column carries every GTD field:
 }
 ```
 
-The notes table schema is unchanged. The pack's only schema artifact is the additional
-`"task"` value in `note.kind`. No DDL, no migration.
+The notes table's column shape is unchanged: `"task"` in `note.kind` and the JSON
+properties above carry task state. GTD separately owns the auxiliary lifecycle-audit
+table described below. Core migration V15 adds cycle-guard triggers to `notes` and
+`graph_edges`; it adds no task columns or parallel task table.
 
 ### GTD lifecycle
 
@@ -137,7 +140,7 @@ task-specific knowledge in retrieval.
 | Verb             | Purpose                                                                                                                                       |
 | ---------------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
 | `gtd.assign`     | Create a task. Args: `title`, `priority?`, `status?`, `assignee?`, `due?`, `depends_on?`, `tags?`, `description?`. Returns the task envelope. |
-| `gtd.next`       | List actionable tasks (`status ∈ {next, active}`), priority-sorted. Args: `limit?`, `assignee?`.                                              |
+| `gtd.next`       | List actionable tasks (`status ∈ {next, active}`), priority-sorted. Args: `limit?`, `assignee?`, `include_blocked?`.                          |
 | `gtd.complete`   | Validate transition to `done`, record `completed_at` and optional `result`. Args: `id`, `result?`.                                            |
 | `gtd.tasks`      | Filtered list. Args: `status?`, `assignee?`, `priority?`, `limit?`, `offset?`.                                                                |
 | `gtd.transition` | Explicit lifecycle change with full transition validation. Args: `id`, `status`, `note?`.                                                     |
@@ -174,6 +177,43 @@ failures are logged via `tracing::warn!` and do not propagate to the caller — 
 storage write already succeeded. The property captures the same information; a
 missing edge is a degraded result, not a failure.
 
+### Dependency integrity and diagnostics (2026-08-01 amendment)
+
+Task dependency graphs are acyclic at both public write surfaces. Before a generic
+`update` writes `properties.depends_on` on a task, the task kind hook validates full
+UUIDs, live task targets in the same namespace, direct self-dependencies, and
+property reachability. Before the generic `link` verb writes a task-to-task
+`depends_on` edge, the same hook checks edge reachability. Atomic bulk-link input is
+validated as one proposed graph, so a cycle formed entirely inside one batch is
+rejected before any edge is stored. Both walks fail closed at a 20,000-node/edge
+safety bound instead of accepting an unverified dependency.
+
+Typed hooks are necessary for precise request errors but insufficient as the durable
+invariant: two processes can both validate against the same pre-write snapshot, and
+`kkernel exec --ops-file --atomic` prepares every operation before its single commit
+pass. Core migration V15 (`015-gtd-dependency-cycle-guards.sql`) therefore installs
+narrow `BEFORE INSERT`/`BEFORE UPDATE` triggers on `notes` and `graph_edges`. The trigger
+walk runs inside SQLite's serialized writer transaction, sees earlier writes in the
+same atomic unit, and rejects the later direction of an opposite-request race. It
+considers only live task property paths and live task-to-task `depends_on` edges;
+soft-deleted rows and unrelated writes are excluded. Existing cyclic data is not
+rewritten at migration time, but a later governed mutation cannot preserve or close a
+cycle.
+
+Reads keep dependency failure distinct from lifecycle status. Task envelopes returned
+by `gtd.tasks` and `gtd.next` carry:
+
+- `dependency_state`: `ready`, `blocked`, or `broken`;
+- `actionable`: true only for a `next`/`active` task whose dependencies are ready;
+- `blocked_by`: one entry per unresolved blocker, with a structural state such as
+  `pending`, `cancelled`, `soft_deleted`, `missing`, or `invalid`.
+
+`gtd.next` preserves its default actionable-only behavior. Passing
+`include_blocked=true` also returns `next`/`active` tasks whose dependency state is
+blocked or broken, sorted after ready work. This gives operators a diagnostic view
+without silently scheduling broken tasks. `gtd.tasks` always adds diagnostics to the
+tasks on the requested page.
+
 ### `TaskHook`: kind specialization for shared CRUD
 
 The kg pack's shared `create` handles `note_kind="task"` through GTD's `KindHook`:
@@ -202,6 +242,16 @@ impl KindHook for TaskHook {
     ) -> Result<(), RuntimeError> {
         // Resolve depends_on IDs and create depends_on edges (best-effort).
         // Log on failure; do not propagate.
+        // ...
+    }
+
+    async fn validate_note_update(/* ... */) -> Result<(), RuntimeError> {
+        // Reject direct or transitive properties.depends_on cycles.
+        // ...
+    }
+
+    async fn validate_links(/* batch ... */) -> Result<(), RuntimeError> {
+        // Reject direct, transitive, and same-batch depends_on edge cycles.
         // ...
     }
 }
@@ -255,6 +305,9 @@ substrate operations through the request DSL."
 kg `update` — `update` patches arbitrary fields without lifecycle awareness, while
 `transition` validates against the allowed-set table. A `done → inbox` `update` would
 silently succeed; `gtd.transition(id, "inbox")` from `done` returns `InvalidInput`.
+The dependency-integrity amendment is deliberately narrower: the task hook validates
+`properties.depends_on` updates because graph cycles are a cross-record invariant,
+without moving the lifecycle state machine into shared CRUD.
 
 `next` and `tasks` are GTD-specific list queries. `tasks` filters by `status`,
 `assignee`, `priority`. `next` is a specialized form of `tasks` returning actionable
@@ -350,6 +403,11 @@ Every successful op returns a stable task envelope:
   "properties": { ... full property bag ... }
 }
 ```
+
+The `gtd.next` and `gtd.tasks` query renderers add
+`dependency_state`, `actionable`, and `blocked_by` to this base task envelope.
+Creation and by-ID retrieval keep the base envelope because they do not perform
+the blocker-resolution read required to classify dependency state.
 
 `transition` returns a delta envelope:
 
@@ -560,6 +618,12 @@ minimal. Operators who want GTD configure it explicitly.
   - `TaskHook` implementing `KindHook`.
   - `prepare_create`: normalize GTD args into kg shape.
   - `after_create`: fire `depends_on` edges (best-effort, logged on failure).
+  - `validate_note_update` / `validate_links`: reject dependency cycles before writes.
+- `crates/khive-pack-gtd/src/dependency.rs`:
+  - Bounded property and edge reachability validation.
+  - Read-time blocker classification for `next` and `tasks` task envelopes.
+- `crates/khive-db/sql/015-gtd-dependency-cycle-guards.sql`:
+  - Transaction-time property/edge cycle backstops shared by every SQLite write path.
 - `crates/khive-pack-gtd/src/schema.rs`:
   - `gtd_lifecycle_audit` table DDL.
 - `crates/kkernel/src/server.rs` (or pack registration):

--- a/docs/adr/ADR-019-gtd-pack.md
+++ b/docs/adr/ADR-019-gtd-pack.md
@@ -181,12 +181,14 @@ missing edge is a degraded result, not a failure.
 
 Task dependency graphs are acyclic at both public write surfaces. Before a generic
 `update` writes `properties.depends_on` on a task, the task kind hook validates full
-UUIDs, live task targets in the same namespace, direct self-dependencies, and
-property reachability. Before the generic `link` verb writes a task-to-task
-`depends_on` edge, the same hook checks edge reachability. Atomic bulk-link input is
+UUIDs in canonical lowercase-hyphenated form, live task targets in the same namespace,
+direct self-dependencies, and property reachability. Before the generic `link` verb writes a
+task-to-task `depends_on` edge, the same hook checks edge reachability. Atomic bulk-link input is
 validated as one proposed graph, so a cycle formed entirely inside one batch is
 rejected before any edge is stored. Both walks fail closed at a 20,000-node/edge
-safety bound instead of accepting an unverified dependency.
+safety bound instead of accepting an unverified dependency. The property walk charges
+every traversed array entry, including duplicate targets, before adding it to the queue;
+high duplicate fanout therefore cannot evade the edge budget through node deduplication.
 
 Typed hooks are necessary for precise request errors but insufficient as the durable
 invariant: two processes can both validate against the same pre-write snapshot, and
@@ -195,6 +197,9 @@ pass. Core migration V15 (`015-gtd-dependency-cycle-guards.sql`) therefore insta
 narrow `BEFORE INSERT`/`BEFORE UPDATE` triggers on `notes` and `graph_edges`. The trigger
 walk runs inside SQLite's serialized writer transaction, sees earlier writes in the
 same atomic unit, and rejects the later direction of an opposite-request race. It
+normalizes accepted UUID text spellings to one comparison key so an alternate spelling
+cannot bypass that durable check. It traverses only array-valued `depends_on` properties;
+legacy scalar/object values remain diagnostically broken data, not phantom edges. It
 considers only live task property paths and live task-to-task `depends_on` edges;
 soft-deleted rows and unrelated writes are excluded. Existing cyclic data is not
 rewritten at migration time, but a later governed mutation cannot preserve or close a

--- a/docs/adr/ADR-019-gtd-pack.md
+++ b/docs/adr/ADR-019-gtd-pack.md
@@ -202,8 +202,10 @@ cannot bypass that durable check. It traverses only array-valued `depends_on` pr
 legacy scalar/object values remain diagnostically broken data, not phantom edges. It
 considers only live task property paths and live task-to-task `depends_on` edges;
 soft-deleted rows and unrelated writes are excluded. Existing cyclic data is not
-rewritten at migration time, but a later governed mutation cannot preserve or close a
-cycle.
+rewritten at migration time. Reactivating a tombstoned task or converting another note
+kind into a live task is also rejected when its pre-existing `depends_on` edge endpoints
+would thereby expose a live cycle; acyclic and unrelated edge activations remain valid.
+A later governed mutation therefore cannot preserve, expose, or close a cycle.
 
 Reads keep dependency failure distinct from lifecycle status. Task envelopes returned
 by `gtd.tasks` and `gtd.next` carry:

--- a/docs/adr/ADR-019-gtd-pack.md
+++ b/docs/adr/ADR-019-gtd-pack.md
@@ -202,10 +202,13 @@ cannot bypass that durable check. It traverses only array-valued `depends_on` pr
 legacy scalar/object values remain diagnostically broken data, not phantom edges. It
 considers only live task property paths and live task-to-task `depends_on` edges;
 soft-deleted rows and unrelated writes are excluded. Existing cyclic data is not
-rewritten at migration time. Reactivating a tombstoned task or converting another note
-kind into a live task is also rejected when its pre-existing `depends_on` edge endpoints
-would thereby expose a live cycle; acyclic and unrelated edge activations remain valid.
-A later governed mutation therefore cannot preserve, expose, or close a cycle.
+rewritten at migration time. Inserting a live task whose ID already has dangling edge
+endpoints, reactivating a tombstoned task, or converting another note kind into a live
+task is rejected when those pre-existing `depends_on` edges would thereby expose a live
+cycle; acyclic and unrelated edge activations remain valid. An ID replacement excludes
+the disappearing old endpoint from reachability while still rejecting cycles in the
+post-update graph. A later governed mutation therefore cannot preserve, expose, or close
+a cycle.
 
 Reads keep dependency failure distinct from lifecycle status. Task envelopes returned
 by `gtd.tasks` and `gtd.next` carry:

--- a/docs/adr/ADR-056-channel-transport-layer.md
+++ b/docs/adr/ADR-056-channel-transport-layer.md
@@ -480,8 +480,9 @@ Telegram's offset remains in-memory as originally documented.
 - `comm_channel_cursor`'s subhandlers are pack-owned operational bookkeeping and not a new
   MCP-callable verb, exercised in production only through the email component's internal
   dispatch calls. Its table schema was pack-declared through `CREATE TABLE IF NOT EXISTS` when
-  this bullet was written; the 2026-07-17 amendment below moves that schema to core migration
-  `V11`, so the table's schema is core-migrated while its subhandlers stay pack-internal.
+  this bullet was written; the 2026-07-17 amendment below requires a future core migration while
+  its subhandlers stay pack-internal. The 2026-08-01 allocation correction in that amendment is
+  authoritative for the migration version.
 - Telegram's in-memory offset watermark and its restart-durability rationale (Amendment
   2026-07-05) are unchanged by this amendment.
 
@@ -2071,7 +2072,8 @@ than as a separate write. This is the precise, API-level statement of the `curso
 > **Migration-sequence reconciliation (2026-08-01).** The V11 reservation in the
 > amendment below was never implemented and is superseded. The live post-consolidation
 > ledger now assigns V11 to `ann_write_log`, V12 to its model/sequence index, and V13
-> to stable list-cursor sequences. A future implementation of the
+> to stable list-cursor sequences, V14 to the graph-edge identifier compatibility guard,
+> and V15 to GTD dependency-cycle guards. A future implementation of the
 > `comm_channel_cursor` widening MUST claim the next available version in ADR-015 in
 > the same PR. References below to V10 as the then-current tree and to V11/`011-*` as
 > the target are retained as the amendment's historical snapshot, not as a live schema
@@ -2090,31 +2092,27 @@ core `khive-db` versioned migration recorded in the ADR-015 ledger, exactly as
 to a durable unique index over an existing table, and `006-brain-retune-driver.sql` (V6) shipped the
 brain pack's `brain_implicit_mass` accounting table: pack-owned logical state whose evolving schema
 lands as a core `khive-db` versioned migration, so the production ledger records it. This amendment
-therefore ships the cursor change as the next core migration, `V11`
-(`crates/khive-db/sql/011-comm-channel-cursor-source-key.sql`, the slot immediately after the current
-latest migration `V10`/`010-entities-content-ref.sql`), registered in the `MIGRATIONS` array and
-recorded in `_schema_migrations` -- not as a further extension of the constant
+therefore requires the cursor change to ship as a future core migration, registered in the
+`MIGRATIONS` array and recorded in `_schema_migrations` -- not as a further extension of the constant
 `CREATE TABLE IF NOT EXISTS` statement and not a pack-owned versioned migration. It introduces no new
 migration mechanism: it uses the core versioned-migration lane V5 and V6 already exercise for
-pack-owned state, and records `V11` as a new row in ADR-015's canonical migration ledger. Appending
-that ledger row is the ledger's defined bookkeeping for every core migration, not a normative change
-to ADR-015's design.
+pack-owned state. Claiming the next free ledger row is ADR-015's defined bookkeeping for every core
+migration, not a normative change to ADR-015's design.
 
-**Current tree state versus this amendment's target.** This section is a normative specification, not
-a description of the checked-out tree. As of this amendment the tree is at core migration `V10`;
+**Current tree state versus this amendment's target.** This section is a normative specification.
+As of the allocation correction the live ledger is allocated through V13;
 `comm_channel_cursor` exists only in its two-column-primary-key form, minted by the pack constant
 `COMM_CHANNEL_CURSOR_SCHEMA_STMT` (`crates/khive-pack-comm/src/vocab.rs`) and lazily re-declared by
 the two cursor handlers before they query it (`crates/khive-pack-comm/src/handlers.rs`: the
 `cursor_get` read path and the cursor upsert path each `execute_script` that same constant). No
-`011-*.sql` file, no `MIGRATIONS`-array `V11` entry, and no three-column key are present in the tree
-yet. The migration file, its ledger registration, and the constant/bootstrap retirements described
-below are authored in the implementation PR that follows this design amendment, not in this docs
-change. The reconciliation is therefore explicit and single-sourced: **current** = `V10`, the
-two-column constant, and the two lazy handler bootstraps; **target** = `V11` rebuilding
-`comm_channel_cursor` to the three-column `(channel_kind, channel_slug, source)` key with the
-constant and both bootstraps retired so `V11` is the sole creator. Every sentence below that reads in
-the present tense ("the constant is retired", "`V11` is applied by `kkernel db migrate`") states the
-target this amendment mandates, which the implementation PR realizes.
+cursor-widening core migration and no three-column key are present in the tree yet. The migration
+file, its ledger registration, and the constant/bootstrap retirements described below belong in a
+future implementation PR. The reconciliation is therefore explicit and single-sourced:
+**current** = the two-column constant and the two lazy handler bootstraps; **target** = a newly
+allocated core migration rebuilding `comm_channel_cursor` to the three-column
+`(channel_kind, channel_slug, source)` key, with the constant and both bootstraps retired so that
+migration is the sole creator. Present-tense statements below describe that target, not current
+implementation state.
 
 Because `CREATE TABLE IF NOT EXISTS` cannot alter an existing table's primary key, widening the
 uniqueness key to three columns requires a full table rebuild rather than an in-place `ALTER TABLE`.
@@ -2144,24 +2142,26 @@ that makes the rebuild all-or-nothing. This is the reason the change belongs in 
 than a pack boot migration: the core runner already provides apply-and-record in one transaction,
 whereas the pack's idempotent `CREATE TABLE IF NOT EXISTS` path has no ledger and no such guarantee.
 
-Acceptance property: interrupting `kkernel db migrate` at any point during the V11 migration and
-re-running it leaves the database either entirely pre-migration or entirely post-migration -- never a
-half-rebuilt, data-less, or applied-but-unrecorded `comm_channel_cursor` -- because the runner
+Acceptance property: interrupting `kkernel db migrate` at any point during the future cursor
+migration and re-running it leaves the database either entirely pre-migration or entirely
+post-migration -- never a half-rebuilt, data-less, or applied-but-unrecorded
+`comm_channel_cursor` -- because the runner
 commits the rebuild DDL and the `_schema_migrations` record in one transaction, and the version guard
 skips an already-recorded migration on re-run.
 
 The pack's `COMM_CHANNEL_CURSOR_SCHEMA_STMT` constant is retired in the same change -- from
 `COMM_SCHEMA_PLAN_STMTS` (the plain-DDL boot path) and from the two inline lazy bootstraps the cursor
 handlers run, where the `cursor_get` read path and the cursor upsert path each `execute_script` the
-same `CREATE TABLE IF NOT EXISTS` before their own query today -- so the V11 migration is the sole
-creator of `comm_channel_cursor` and no boot path or verb handler mints the stale two-column-PK table
-ahead of it. As a core migration, V11 is applied by `kkernel db migrate` (and auto-applied on
-in-memory and ephemeral backends at creation, per ADR-015's exception for stores with no operator to
+same `CREATE TABLE IF NOT EXISTS` before their own query today -- so the cursor migration is the
+sole creator of `comm_channel_cursor` and no boot path or verb handler mints the stale two-column-PK
+table ahead of it. As a core migration, the cursor migration is applied by `kkernel db migrate`
+(and auto-applied on in-memory and ephemeral backends at creation, per ADR-015's exception for
+stores with no operator to
 invoke it), and the MCP binary's existing fail-fast-on-stale-schema guard refuses to serve until the
 operator has migrated -- so a production database reaches the three-column shape before the daemon
 serves any cursor verb, and a database created through the migration path never lands on the retired
 two-column shape. No new boot-wiring, pack-ordering, or fail-closed-boot semantics are introduced:
-V11 reuses the operator-run migration contract of ADR-015 and ADR-071 unchanged.
+the cursor migration reuses the operator-run migration contract of ADR-015 and ADR-071 unchanged.
 
 Acceptance property: an upgraded database preserves every pre-existing cursor row's progress -- no
 adapter's high-water mark regresses or is lost across the migration -- and a fresh database created
@@ -2593,7 +2593,7 @@ properties and is corrected here.
     session never falls back to a default identity file or an agent-offered key.
 19. The bridge host's `sshd_config` sets `PermitTunnel no` explicitly, and a session opened with
     the daemon's key that requests tunnel-device forwarding is refused.
-20. Interrupting `kkernel db migrate` at any point during the cursor-widening migration (V11) and
+20. Interrupting `kkernel db migrate` at any point during the future cursor-widening migration and
     re-running it leaves the database either entirely pre-migration or entirely post-migration, never
     with a half-rebuilt, data-less, or applied-but-unrecorded `comm_channel_cursor`: the core runner
     commits the rebuild DDL and the `_schema_migrations` record in one transaction, and the version

--- a/docs/guide/api-reference.md
+++ b/docs/guide/api-reference.md
@@ -788,8 +788,8 @@ request(ops="gtd.complete(id=\"<task-id>\", result=\"shipped in PR #600\")")
 List tasks filtered by status, assignee, priority.
 
 Each task reports `dependency_state` (`ready`, `blocked`, or `broken`), `actionable`,
-and a `blocked_by` array whose entries distinguish pending, cancelled, soft-deleted,
-hard-missing, malformed, cross-namespace, and wrong-kind dependencies.
+and a `blocked_by` array whose entries carry a `state` of `pending`, `cancelled`,
+`soft_deleted`, `missing`, `invalid`, `different_namespace`, or `wrong_kind`.
 
 | Param      | Type    | Required | Notes                                                                                              |
 | ---------- | ------- | -------- | -------------------------------------------------------------------------------------------------- |

--- a/docs/guide/api-reference.md
+++ b/docs/guide/api-reference.md
@@ -756,12 +756,14 @@ request(ops="gtd.assign(title=\"Ship API reference\", priority=\"p1\", assignee=
 
 ### `gtd.next` — Assertive
 
-List actionable tasks (status `next` or `active`) by priority.
+List actionable tasks (status `next` or `active`) by priority. By default, tasks with
+unfinished or structurally broken dependencies are omitted.
 
-| Param      | Type    | Required | Notes                    |
-| ---------- | ------- | -------- | ------------------------ |
-| `limit`    | integer | no       | Default 10.              |
-| `assignee` | string  | no       | Filter to this assignee. |
+| Param             | Type    | Required | Notes                                                                             |
+| ----------------- | ------- | -------- | --------------------------------------------------------------------------------- |
+| `limit`           | integer | no       | Default 10.                                                                       |
+| `assignee`        | string  | no       | Filter to this assignee.                                                          |
+| `include_blocked` | boolean | no       | Include blocked/broken candidates after ready work for diagnosis (default false). |
 
 ```
 request(ops="gtd.next(assignee=\"agent:docs\", limit=10)")
@@ -784,6 +786,10 @@ request(ops="gtd.complete(id=\"<task-id>\", result=\"shipped in PR #600\")")
 ### `gtd.tasks` — Assertive
 
 List tasks filtered by status, assignee, priority.
+
+Each task reports `dependency_state` (`ready`, `blocked`, or `broken`), `actionable`,
+and a `blocked_by` array whose entries distinguish pending, cancelled, soft-deleted,
+hard-missing, malformed, cross-namespace, and wrong-kind dependencies.
 
 | Param      | Type    | Required | Notes                                                                                              |
 | ---------- | ------- | -------- | -------------------------------------------------------------------------------------------------- |

--- a/docs/guide/tasks.md
+++ b/docs/guide/tasks.md
@@ -49,6 +49,11 @@ assignee. It defaults to `limit=10` and silently clamps `limit` to 1–200. If
 more than 20,000 actionable tasks match, it returns an error; narrow the query
 (for example with the exact `assignee` filter) and retry.
 
+By default it omits tasks with unfinished or structurally broken dependencies.
+Pass `include_blocked=true` to include those candidates after ready work for
+triage. Both `gtd.next` and `gtd.tasks` annotate tasks with `dependency_state`,
+`actionable`, and `blocked_by` diagnostics.
+
 ```text
 request(ops="gtd.next(assignee=\"docs-maintainer\", limit=10)")
 ```
@@ -82,7 +87,11 @@ only `transitioned`, `id`, `full_id`, `from`, `to`, and `note` are present.
 Pass task identifiers in `depends_on` when creating a task to express blockers.
 The GTD pack adds a `depends_on` endpoint rule for task-to-task edges; other
 note or entity types are not valid dependency targets. `gtd.next` omits a task
-until every listed dependency is `done`.
+until every listed dependency is `done`. A cancelled, soft-deleted, hard-missing,
+malformed, cross-namespace, or wrong-kind dependency makes the task `broken` and
+is identified in `blocked_by`; an unfinished live task makes it `blocked`.
+Dependency writes reject direct and transitive cycles on both generic task-property
+updates and graph links.
 
 ## Gotchas
 

--- a/docs/guide/tasks.md
+++ b/docs/guide/tasks.md
@@ -87,9 +87,10 @@ only `transitioned`, `id`, `full_id`, `from`, `to`, and `note` are present.
 Pass task identifiers in `depends_on` when creating a task to express blockers.
 The GTD pack adds a `depends_on` endpoint rule for task-to-task edges; other
 note or entity types are not valid dependency targets. `gtd.next` omits a task
-until every listed dependency is `done`. A cancelled, soft-deleted, hard-missing,
-malformed, cross-namespace, or wrong-kind dependency makes the task `broken` and
-is identified in `blocked_by`; an unfinished live task makes it `blocked`.
+until every listed dependency is `done`. A dependency with `blocked_by[].state`
+of `cancelled`, `soft_deleted`, `missing`, `invalid`, `different_namespace`, or
+`wrong_kind` makes the task `broken`; an unfinished live task makes it `blocked`
+with a state of `pending`.
 Dependency writes reject direct and transitive cycles on both generic task-property
 updates and graph links.
 

--- a/marketplace/khive/skills/gtd/SKILL.md
+++ b/marketplace/khive/skills/gtd/SKILL.md
@@ -56,9 +56,11 @@ still in `inbox` / `waiting` / `someday`, use `gtd.transition` (`status="cancell
 request(ops="gtd.next(assignee=\"agent:docs\", limit=20)")
 ```
 
-`gtd.next` returns only `next` and `active` tasks, sorted by priority then recency. If it is
-empty, the inbox has unprocessed items or everything is parked. Use `gtd.tasks` for broader
-filtering:
+`gtd.next` returns only ready `next` and `active` tasks by default, sorted by priority then
+recency. Pass `include_blocked=true` to include blocked or structurally broken candidates
+after ready work. Query results carry `dependency_state`, `actionable`, and `blocked_by`
+diagnostics. If it is empty, the inbox has unprocessed items or everything is parked. Use
+`gtd.tasks` for broader filtering:
 
 ```
 request(ops="[


### PR DESCRIPTION
## Summary

- surface cancelled, deleted, missing, and unresolved GTD blockers in `gtd.next` / `gtd.tasks` diagnostics instead of silently hiding dependent work
- reject direct and multi-hop dependency cycles across task assignment, generic KG note updates, edge linking, and atomic ops-file execution
- add append-only SQLite integrity guards so concurrent and alternate write paths cannot bypass the pack-level checks

## Behavior

Task dependency validation now uses one shared GTD implementation for both the authoritative
`depends_on` property and its graph-edge mirror. Task creation and update require canonical task
UUIDs, reject missing or non-task targets, and detect reachability cycles before mutation. The KG
pack invokes the registered note-update hook, link validation covers task dependency edges, and
atomic preparation plus commit-time database triggers close the remaining same-unit and concurrent
write gaps.

`gtd.next` continues to fail closed for unresolved blockers, but no longer does so invisibly.
Responses classify a dependent task's blocker as active, cancelled, deleted, or missing, including
the cases where the dependency was soft-deleted or hard-deleted. Ordinary acyclic scheduling and
terminal `done` dependency behavior are unchanged.

The schema migration is append-only and installs guards for task-note inserts and updates, task
activation, and dependency-edge inserts and updates. Regression coverage exercises direct,
multi-hop, atomic same-unit, activation, alternate UUID spelling, cancelled, soft-deleted, and
hard-deleted cases.

## Validation

- `cargo test --workspace`
- `cargo check --workspace`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `RUSTDOCFLAGS=-Dwarnings cargo doc --workspace --no-deps`

Closes #1473
Closes #1474

> AI-assisted contribution: Codex prepared this change and PR description.
