### PR TITLE
fix(kg): surface legal relations for rejected endpoints

### DIFF
--- a/crates/khive-pack-kg/docs/api/entity-kind-validation.md
+++ b/crates/khive-pack-kg/docs/api/entity-kind-validation.md
@@ -17,7 +17,7 @@ this crate directly, so this is not a crate-graph inversion.
 `resolve_uuid_unfiltered` implements the ADR-007 Rev 6 by-ID contract: UUID resolution for
 get/update/delete/merge is namespace-agnostic — the Gate is the authz seam, not storage-layer
 filtering. Full-UUID inputs were already unfiltered (`resolve_by_id`); this function closes
-the gap for the *prefix* form, which previously fell through to the primary-namespace-only
+the gap for the _prefix_ form, which previously fell through to the primary-namespace-only
 `resolve_prefix` and was invisible for any row stamped with a non-primary namespace (#391
 §3). It is an exact copy of `resolve_uuid_async` except the prefix-resolution branch.
 
@@ -73,3 +73,10 @@ hand-picked pairs.
 entity→entity pair regardless of kind and is skipped (matches the hint function's own scope,
 which never emits "annotates"). `supersedes`/`supports`/`refutes` DO validate entity→entity
 pairs against the same base allowlist the hint function reads, so they stay in scope.
+
+The runtime also uses the shared
+`accepted_entity_relations_for_entities` derivation in every entity-pair rejection, including
+local, cross-backend, atomic, bulk, and update validation paths. An invalid triple therefore
+names the ordered endpoint pair and its complete currently legal relation set under the loaded
+packs, or explicitly says `none`; callers do not need a second probe through the singleton
+`link` handler to discover a valid counter-proposal (#1606).

--- a/crates/khive-pack-kg/src/handlers/common.rs
+++ b/crates/khive-pack-kg/src/handlers/common.rs
@@ -443,26 +443,17 @@ pub(crate) fn valid_relations_for_entity_pair(
     tgt_kind: &str,
     tgt_entity_type: Option<&str>,
 ) -> Vec<&'static str> {
-    let mut relations: Vec<&'static str> = khive_runtime::operations::base_entity_endpoint_rules()
-        .iter()
-        .filter(|(src, _rel, tgt)| (*src == "*" || *src == src_kind) && *tgt == tgt_kind)
-        .map(|(_src, rel, _tgt)| rel.as_str())
-        .collect();
-
     let pack_rules = runtime.pack_edge_rules();
-    for rel in khive_runtime::operations::accepted_pack_relations_for_entities(
+    khive_runtime::operations::accepted_entity_relations_for_entities(
         &pack_rules,
         src_kind,
         src_entity_type,
         tgt_kind,
         tgt_entity_type,
-    ) {
-        relations.push(rel.as_str());
-    }
-
-    relations.sort_unstable();
-    relations.dedup();
-    relations
+    )
+    .into_iter()
+    .map(|relation| relation.as_str())
+    .collect()
 }
 
 pub(crate) async fn enrich_allowlist_error(

--- a/crates/khive-pack-kg/src/handlers/create.rs
+++ b/crates/khive-pack-kg/src/handlers/create.rs
@@ -508,14 +508,12 @@ impl KgPack {
                             continue;
                         }
                     };
-                    let (source, target) = if relation.is_symmetric() && target < new_id {
-                        (target, new_id)
-                    } else {
-                        (new_id, target)
-                    };
+                    // Preserve the requested new-record -> target orientation through
+                    // validation so rejection diagnostics use that ordered kind pair.
+                    // `link` still canonicalizes accepted symmetric edges for persistence.
                     match self
                         .runtime
-                        .link(token, source, target, relation, weight, None)
+                        .link(token, new_id, target, relation, weight, None)
                         .await
                     {
                         Ok(edge) => match to_json(&edge) {

--- a/crates/khive-pack-kg/src/handlers/link.rs
+++ b/crates/khive-pack-kg/src/handlers/link.rs
@@ -37,12 +37,16 @@ impl KgPack {
                     let target =
                         resolve_uuid_unfiltered(&entry.target_id, &self.runtime, token).await?;
                     let relation = parse_relation(&entry.relation)?;
-                    let (source, target) = if relation.is_symmetric() && target < source {
+                    // Canonicalize only the duplicate-detection key. Runtime validation
+                    // must see caller order so a rejected symmetric relation reports the
+                    // legal set for the requested ordered pair; `build_edge` canonicalizes
+                    // the accepted edge before persistence.
+                    let (key_source, key_target) = if relation.is_symmetric() && target < source {
                         (target, source)
                     } else {
                         (source, target)
                     };
-                    let key = format!("{source}::{target}::{}", relation.as_str());
+                    let key = format!("{key_source}::{key_target}::{}", relation.as_str());
                     if !seen.insert(key) {
                         skipped += 1;
                         continue;
@@ -101,12 +105,14 @@ impl KgPack {
                             continue;
                         }
                     };
-                    let (source, target) = if relation.is_symmetric() && target < source {
+                    // Keep caller order for validation/diagnostics; only the dedup key
+                    // needs UUID-canonical endpoints. `link` canonicalizes on success.
+                    let (key_source, key_target) = if relation.is_symmetric() && target < source {
                         (target, source)
                     } else {
                         (source, target)
                     };
-                    let key = format!("{source}::{target}::{}", relation.as_str());
+                    let key = format!("{key_source}::{key_target}::{}", relation.as_str());
                     if !seen.insert(key) {
                         skipped += 1;
                         continue;

--- a/crates/khive-pack-kg/src/handlers/tests.rs
+++ b/crates/khive-pack-kg/src/handlers/tests.rs
@@ -873,6 +873,140 @@ async fn link_invalid_relation_error_suggests_valid_relations() {
     );
 }
 
+fn configured_kg_endpoint_test_surface() -> (
+    khive_runtime::KhiveRuntime,
+    khive_runtime::NamespaceToken,
+    crate::KgPack,
+    khive_runtime::VerbRegistry,
+) {
+    use crate::KgPack;
+    use khive_runtime::{KhiveRuntime, Namespace, VerbRegistryBuilder};
+
+    let rt = KhiveRuntime::memory().expect("in-memory runtime");
+    let mut builder = VerbRegistryBuilder::new();
+    builder.register(KgPack::new(rt.clone()));
+    let registry = builder.build().expect("kg registry builds");
+    rt.install_edge_rules(registry.all_edge_rules());
+    let token = rt.authorize(Namespace::local()).expect("authorize local");
+    let pack = KgPack::new(rt.clone());
+    (rt, token, pack, registry)
+}
+
+async fn seed_entity_with_id(
+    rt: &khive_runtime::KhiveRuntime,
+    token: &khive_runtime::NamespaceToken,
+    id: uuid::Uuid,
+    kind: &str,
+    name: &str,
+) {
+    let mut entity = khive_storage::Entity::new(token.namespace().as_str(), kind, name);
+    entity.id = id;
+    rt.entities(token)
+        .expect("entity store")
+        .upsert_entity(entity)
+        .await
+        .expect("seed fixed-id entity");
+}
+
+// #1606: symmetric relations use canonical UUID order for persistence and bulk
+// duplicate detection, but validation diagnostics must retain caller order. The
+// fixed IDs force target < source, which exposed both bulk modes reporting the
+// reverse project->concept legal set before this regression fix.
+#[tokio::test]
+async fn bulk_link_symmetric_rejection_preserves_requested_pair_in_both_modes() {
+    let (rt, token, pack, _registry) = configured_kg_endpoint_test_surface();
+    let concept_id =
+        uuid::Uuid::parse_str("ffffffff-ffff-ffff-ffff-ffffffffffff").expect("high UUID");
+    let project_id = uuid::Uuid::nil();
+    assert!(project_id < concept_id, "test must exercise UUID reversal");
+    seed_entity_with_id(&rt, &token, concept_id, "concept", "Concept source").await;
+    seed_entity_with_id(&rt, &token, project_id, "project", "Project target").await;
+
+    for atomic in [true, false] {
+        let params = json!({
+            "links": [{
+                "source_id": concept_id.to_string(),
+                "target_id": project_id.to_string(),
+                "relation": "competes_with",
+            }],
+            "atomic": atomic,
+        });
+        let message = if atomic {
+            pack.handle_link(&token, params)
+                .await
+                .expect_err("atomic bulk must reject concept competes_with project")
+                .to_string()
+        } else {
+            let response = pack
+                .handle_link(&token, params)
+                .await
+                .expect("non-atomic bulk reports entry failures in-band");
+            response["errors"][0]["error"]
+                .as_str()
+                .expect("entry error string")
+                .to_string()
+        };
+
+        assert!(
+            message.contains(
+                "currently legal relations for concept -> project under the loaded endpoint rules: none"
+            ),
+            "atomic={atomic} must diagnose the caller-ordered pair; got: {message}"
+        );
+        assert!(
+            !message.contains("currently legal relations for project -> concept"),
+            "atomic={atomic} must not diagnose the UUID-canonical reverse pair; got: {message}"
+        );
+    }
+}
+
+// #1606: attached edges always originate at the newly-created entity. A nil
+// target UUID deterministically sorts before every v4 create UUID, proving that
+// persistence canonicalization cannot reverse the pair used in the error.
+#[tokio::test]
+async fn create_attached_symmetric_edge_rejection_preserves_new_entity_as_source() {
+    let (rt, token, pack, registry) = configured_kg_endpoint_test_surface();
+    let project_id = uuid::Uuid::nil();
+    seed_entity_with_id(&rt, &token, project_id, "project", "Project target").await;
+
+    let response = pack
+        .handle_create(
+            &token,
+            json!({
+                "kind": "concept",
+                "name": "Concept source",
+                "skip_dedup_check": true,
+                "edges": [{
+                    "target_id": project_id.to_string(),
+                    "relation": "competes_with",
+                }],
+            }),
+            &registry,
+        )
+        .await
+        .expect("entity creation succeeds with attached-edge failure reported in-band");
+
+    let created_id = uuid::Uuid::parse_str(response["id"].as_str().expect("created entity id"))
+        .expect("created entity UUID");
+    assert!(
+        project_id < created_id,
+        "test must exercise persistence canonicalization"
+    );
+    let message = response["edge_errors"][0]["error"]
+        .as_str()
+        .expect("attached-edge error string");
+    assert!(
+        message.contains(
+            "currently legal relations for concept -> project under the loaded endpoint rules: none"
+        ),
+        "attached-edge error must diagnose new entity -> requested target; got: {message}"
+    );
+    assert!(
+        !message.contains("currently legal relations for project -> concept"),
+        "attached-edge error must not diagnose the UUID-canonical reverse pair; got: {message}"
+    );
+}
+
 // ── #567 regression: ensure_note_kind must not disclose foreign note metadata ──
 
 #[tokio::test]

--- a/crates/khive-runtime/src/atomic_prepare.rs
+++ b/crates/khive-runtime/src/atomic_prepare.rs
@@ -2180,6 +2180,52 @@ mod tests {
         assert!(matches!(count, Some(SqlValue::Integer(2))));
     }
 
+    /// Atomic prepare validates the requested orientation before canonicalizing
+    /// a symmetric edge for persistence. Fixed UUIDs force target < source so a
+    /// regression would report the reverse ordered pair.
+    #[tokio::test]
+    async fn atomic_link_symmetric_rejection_preserves_requested_pair() {
+        let runtime = scratch_runtime();
+        let token = runtime
+            .authorize(Namespace::parse("local").expect("ns"))
+            .expect("authorize");
+        let entities = runtime.entities(&token).expect("entities store");
+        let concept_id =
+            Uuid::parse_str("ffffffff-ffff-ffff-ffff-ffffffffffff").expect("high UUID");
+        let project_id = Uuid::nil();
+        assert!(project_id < concept_id, "test must exercise UUID reversal");
+
+        let mut concept = khive_storage::Entity::new("local", "concept", "Concept source");
+        concept.id = concept_id;
+        let mut project = khive_storage::Entity::new("local", "project", "Project target");
+        project.id = project_id;
+        entities.upsert_entity(concept).await.expect("seed concept");
+        entities.upsert_entity(project).await.expect("seed project");
+
+        let error = prepare_link(
+            &runtime,
+            &token,
+            &json!({
+                "source_id": concept_id.to_string(),
+                "target_id": project_id.to_string(),
+                "relation": "competes_with",
+            }),
+        )
+        .await
+        .expect_err("atomic link must reject concept competes_with project");
+        let message = error.to_string();
+        assert!(
+            message.contains(
+                "currently legal relations for concept -> project under the loaded endpoint rules: none"
+            ),
+            "atomic validation must diagnose caller order before persistence canonicalization; got: {message}"
+        );
+        assert!(
+            !message.contains("currently legal relations for project -> concept"),
+            "atomic validation must not diagnose the UUID-canonical reverse pair; got: {message}"
+        );
+    }
+
     /// Atomic link must persist an explicit top-level `dependency_kind`
     /// param into edge metadata, and must infer one for `depends_on` edges
     /// when absent: parity with

--- a/crates/khive-runtime/src/operations.rs
+++ b/crates/khive-runtime/src/operations.rs
@@ -532,9 +532,9 @@ pub fn accepted_pack_relations_for_entities(
 /// [`accepted_entity_kind_pairs_for_relation`]. It is shared by validation
 /// errors and pack-layer hints so every write path can tell a caller which
 /// relations would be legal without maintaining a second endpoint table.
-/// Pack declarations for special relations are excluded because the live
-/// validator resolves those relations through the base same-substrate branch
-/// before pack rules are consulted.
+/// Pack declarations for relations with dedicated substrate branches are
+/// excluded because the live validator resolves `annotates` and the three
+/// same-substrate special relations before pack rules are consulted.
 pub fn accepted_entity_relations_for_entities(
     rules: &[EdgeEndpointRule],
     src_kind: &str,
@@ -556,7 +556,9 @@ pub fn accepted_entity_relations_for_entities(
             tgt_entity_type,
         )
         .into_iter()
-        .filter(|relation| !crate::pack::is_special_relation(*relation)),
+        .filter(|relation| {
+            *relation != EdgeRelation::Annotates && !crate::pack::is_special_relation(*relation)
+        }),
     );
     relations.sort_by_key(|relation| relation.as_str());
     relations.dedup();
@@ -11415,12 +11417,28 @@ mod tests {
     }
 
     #[test]
-    fn cross_backend_illegal_entity_pair_names_when_no_relation_is_legal() {
+    fn cross_backend_legal_set_ignores_unenforced_annotates_pack_rule() {
         let rt = rt();
+        rt.install_edge_rules(vec![EdgeEndpointRule {
+            relation: EdgeRelation::Annotates,
+            source: EndpointKind::EntityOfKind("concept"),
+            target: EndpointKind::EntityOfKind("project"),
+        }]);
         let source_id = Uuid::new_v4();
         let target_id = Uuid::new_v4();
         let source = Resolved::Entity(Entity::new("local", "concept", "Concept"));
         let target = Resolved::Entity(Entity::new("local", "project", "Project"));
+
+        rt.validate_link_endpoints_by_resolved(
+            source_id,
+            target_id,
+            EdgeRelation::Annotates,
+            Some(&source),
+            Some(&target),
+        )
+        .expect_err(
+            "an annotates pack rule cannot override the dedicated note-source validator branch",
+        );
 
         let error = rt
             .validate_link_endpoints_by_resolved(
@@ -11436,7 +11454,11 @@ mod tests {
             message.contains(
                 "currently legal relations for concept -> project under the loaded endpoint rules: none"
             ),
-            "cross-backend rejection must say when the ordered pair has no legal relation; got: {message}"
+            "an unenforced entity-source annotates pack rule must not be advertised; got: {message}"
+        );
+        assert!(
+            !message.contains("endpoint rules: annotates"),
+            "the rejection must not call annotates legal when the live validator rejects it; got: {message}"
         );
     }
 

--- a/crates/khive-runtime/src/operations.rs
+++ b/crates/khive-runtime/src/operations.rs
@@ -528,8 +528,8 @@ pub fn accepted_pack_relations_for_entities(
 /// Relations accepted for one resolved entity endpoint pair under the full
 /// live contract: the base allowlist plus the loaded packs' additive rules.
 ///
-/// This is the pair-oriented counterpart to
-/// [`accepted_entity_kind_pairs_for_relation`]. It is shared by validation
+/// This is the pair-oriented counterpart to the private
+/// `accepted_entity_kind_pairs_for_relation` helper. It is shared by validation
 /// errors and pack-layer hints so every write path can tell a caller which
 /// relations would be legal without maintaining a second endpoint table.
 /// Pack declarations for relations with dedicated substrate branches are

--- a/crates/khive-runtime/src/operations.rs
+++ b/crates/khive-runtime/src/operations.rs
@@ -525,6 +525,69 @@ pub fn accepted_pack_relations_for_entities(
     relations
 }
 
+/// Relations accepted for one resolved entity endpoint pair under the full
+/// live contract: the base allowlist plus the loaded packs' additive rules.
+///
+/// This is the pair-oriented counterpart to
+/// [`accepted_entity_kind_pairs_for_relation`]. It is shared by validation
+/// errors and pack-layer hints so every write path can tell a caller which
+/// relations would be legal without maintaining a second endpoint table.
+/// Pack declarations for special relations are excluded because the live
+/// validator resolves those relations through the base same-substrate branch
+/// before pack rules are consulted.
+pub fn accepted_entity_relations_for_entities(
+    rules: &[EdgeEndpointRule],
+    src_kind: &str,
+    src_entity_type: Option<&str>,
+    tgt_kind: &str,
+    tgt_entity_type: Option<&str>,
+) -> Vec<EdgeRelation> {
+    let mut relations: Vec<EdgeRelation> = BASE_ENTITY_ENDPOINT_RULES
+        .iter()
+        .filter(|(src, _relation, tgt)| (*src == "*" || *src == src_kind) && *tgt == tgt_kind)
+        .map(|(_src, relation, _tgt)| *relation)
+        .collect();
+    relations.extend(
+        accepted_pack_relations_for_entities(
+            rules,
+            src_kind,
+            src_entity_type,
+            tgt_kind,
+            tgt_entity_type,
+        )
+        .into_iter()
+        .filter(|relation| !crate::pack::is_special_relation(*relation)),
+    );
+    relations.sort_by_key(|relation| relation.as_str());
+    relations.dedup();
+    relations
+}
+
+fn accepted_entity_relations_description(
+    rules: &[EdgeEndpointRule],
+    src_kind: &str,
+    src_entity_type: Option<&str>,
+    tgt_kind: &str,
+    tgt_entity_type: Option<&str>,
+) -> String {
+    let relations = accepted_entity_relations_for_entities(
+        rules,
+        src_kind,
+        src_entity_type,
+        tgt_kind,
+        tgt_entity_type,
+    );
+    if relations.is_empty() {
+        "none".to_string()
+    } else {
+        relations
+            .iter()
+            .map(EdgeRelation::as_str)
+            .collect::<Vec<_>>()
+            .join(", ")
+    }
+}
+
 /// Hint-only counterpart to [`accepted_pack_relations_for_entities`] that
 /// matches via [`pattern_endpoint_matches`] instead of [`endpoint_matches`],
 /// so an absent `entity_type` is treated as unconstrained rather than an
@@ -1865,6 +1928,13 @@ impl KhiveRuntime {
             match (&src, &tgt) {
                 (Resolved::Entity(src_e), Resolved::Entity(tgt_e)) => {
                     if !base_entity_rule_allows(&src_e.kind, relation, &tgt_e.kind) {
+                        let legal_relations = accepted_entity_relations_description(
+                            &self.pack_edge_rules(),
+                            &src_e.kind,
+                            src_e.entity_type.as_deref(),
+                            &tgt_e.kind,
+                            tgt_e.entity_type.as_deref(),
+                        );
                         let rule_hint = match relation {
                             EdgeRelation::Supports | EdgeRelation::Refutes => {
                                 "requires concept|document|dataset|artifact -> concept \
@@ -1874,8 +1944,9 @@ impl KhiveRuntime {
                         };
                         return Err(RuntimeError::InvalidInput(format!(
                             "({}) -[{rel_name}]-> ({}) is not in the base endpoint \
-                             allowlist; {rel_name} {rule_hint}",
-                            src_e.kind, tgt_e.kind
+                             allowlist; {rel_name} {rule_hint}; currently legal relations for \
+                             {} -> {} under the loaded endpoint rules: {legal_relations}",
+                            src_e.kind, tgt_e.kind, src_e.kind, tgt_e.kind
                         )));
                     }
                 }
@@ -1917,19 +1988,15 @@ impl KhiveRuntime {
             // rules; on miss, fall through to the original base-rule error messages.
             let src_res = self.resolve_edge_endpoint(token, source_id).await?;
             let tgt_res = self.resolve_edge_endpoint(token, target_id).await?;
+            let pack_rules = self.pack_edge_rules();
 
-            if pack_rule_allows(
-                &self.pack_edge_rules(),
-                relation,
-                src_res.as_ref(),
-                tgt_res.as_ref(),
-            ) {
+            if pack_rule_allows(&pack_rules, relation, src_res.as_ref(), tgt_res.as_ref()) {
                 return Ok(());
             }
 
             // Substrate check: both endpoints must be entities.
-            let src_kind = match src_res {
-                Some(Resolved::Entity(e)) => e.kind,
+            let (src_kind, src_entity_type) = match src_res.as_ref() {
+                Some(Resolved::Entity(e)) => (e.kind.as_str(), e.entity_type.as_deref()),
                 Some(_) => {
                     return Err(RuntimeError::InvalidInput(format!(
                         "link source {source_id} must be an entity for relation {relation:?} \
@@ -1948,8 +2015,8 @@ impl KhiveRuntime {
                     )));
                 }
             };
-            let tgt_kind = match tgt_res {
-                Some(Resolved::Entity(e)) => e.kind,
+            let (tgt_kind, tgt_entity_type) = match tgt_res.as_ref() {
+                Some(Resolved::Entity(e)) => (e.kind.as_str(), e.entity_type.as_deref()),
                 Some(_) => {
                     return Err(RuntimeError::InvalidInput(format!(
                         "link target {target_id} must be an entity for relation {relation:?} \
@@ -1968,10 +2035,19 @@ impl KhiveRuntime {
                     )));
                 }
             };
-            if !base_entity_rule_allows(&src_kind, relation, &tgt_kind) {
+            if !base_entity_rule_allows(src_kind, relation, tgt_kind) {
+                let legal_relations = accepted_entity_relations_description(
+                    &pack_rules,
+                    src_kind,
+                    src_entity_type,
+                    tgt_kind,
+                    tgt_entity_type,
+                );
                 return Err(RuntimeError::InvalidInput(format!(
                     "({src_kind}) -[{}]-> ({tgt_kind}) is not in the base endpoint \
-                     allowlist; use pack EDGE_RULES to extend the allowlist",
+                     allowlist; use pack EDGE_RULES to extend the allowlist; currently legal \
+                     relations for {src_kind} -> {tgt_kind} under the loaded endpoint rules: \
+                     {legal_relations}",
                     relation.as_str()
                 )));
             }
@@ -2051,6 +2127,13 @@ impl KhiveRuntime {
             match (src, tgt) {
                 (Resolved::Entity(src_e), Resolved::Entity(tgt_e)) => {
                     if !base_entity_rule_allows(&src_e.kind, relation, &tgt_e.kind) {
+                        let legal_relations = accepted_entity_relations_description(
+                            &self.pack_edge_rules(),
+                            &src_e.kind,
+                            src_e.entity_type.as_deref(),
+                            &tgt_e.kind,
+                            tgt_e.entity_type.as_deref(),
+                        );
                         let rule_hint = match relation {
                             EdgeRelation::Supports | EdgeRelation::Refutes => {
                                 "requires concept|document|dataset|artifact -> concept \
@@ -2060,8 +2143,9 @@ impl KhiveRuntime {
                         };
                         return Err(RuntimeError::InvalidInput(format!(
                             "({}) -[{rel_name}]-> ({}) is not in the base endpoint \
-                             allowlist; {rel_name} {rule_hint}",
-                            src_e.kind, tgt_e.kind
+                             allowlist; {rel_name} {rule_hint}; currently legal relations for \
+                             {} -> {} under the loaded endpoint rules: {legal_relations}",
+                            src_e.kind, tgt_e.kind, src_e.kind, tgt_e.kind
                         )));
                     }
                 }
@@ -2096,12 +2180,13 @@ impl KhiveRuntime {
 
         // All remaining base relations: entity→entity with kind-level restrictions.
         // Consult pack rules installed on this (source) runtime first.
-        if pack_rule_allows(&self.pack_edge_rules(), relation, src, tgt) {
+        let pack_rules = self.pack_edge_rules();
+        if pack_rule_allows(&pack_rules, relation, src, tgt) {
             return Ok(());
         }
 
-        let src_kind = match src {
-            Some(Resolved::Entity(e)) => &e.kind,
+        let (src_kind, src_entity_type) = match src {
+            Some(Resolved::Entity(e)) => (e.kind.as_str(), e.entity_type.as_deref()),
             Some(_) => {
                 return Err(RuntimeError::InvalidInput(format!(
                     "link source {source_id} must be an entity for relation {relation:?} \
@@ -2114,8 +2199,8 @@ impl KhiveRuntime {
                 )));
             }
         };
-        let tgt_kind = match tgt {
-            Some(Resolved::Entity(e)) => &e.kind,
+        let (tgt_kind, tgt_entity_type) = match tgt {
+            Some(Resolved::Entity(e)) => (e.kind.as_str(), e.entity_type.as_deref()),
             Some(_) => {
                 return Err(RuntimeError::InvalidInput(format!(
                     "link target {target_id} must be an entity for relation {relation:?} \
@@ -2130,9 +2215,17 @@ impl KhiveRuntime {
         };
 
         if !base_entity_rule_allows(src_kind, relation, tgt_kind) {
+            let legal_relations = accepted_entity_relations_description(
+                &pack_rules,
+                src_kind,
+                src_entity_type,
+                tgt_kind,
+                tgt_entity_type,
+            );
             return Err(RuntimeError::InvalidInput(format!(
                 "({src_kind}) -[{}]-> ({tgt_kind}) is not in the base endpoint \
-                 allowlist; use pack EDGE_RULES to extend the allowlist",
+                 allowlist; use pack EDGE_RULES to extend the allowlist; currently legal relations \
+                 for {src_kind} -> {tgt_kind} under the loaded endpoint rules: {legal_relations}",
                 relation.as_str()
             )));
         }
@@ -11280,6 +11373,70 @@ mod tests {
             result.is_err(),
             "F010: document->document Extends must be rejected by the base allowlist; \
              current generic entity fallthrough incorrectly accepts it"
+        );
+    }
+
+    #[tokio::test]
+    async fn link_illegal_entity_pair_names_loaded_legal_relations() {
+        let rt = rt();
+        let tok = NamespaceToken::local();
+        rt.install_edge_rules(vec![EdgeEndpointRule {
+            relation: EdgeRelation::DependsOn,
+            source: EndpointKind::EntityOfKind("concept"),
+            target: EndpointKind::EntityOfKind("project"),
+        }]);
+        let concept = rt
+            .create_entity(&tok, "concept", None, "Concept", None, None, vec![])
+            .await
+            .unwrap();
+        let project = rt
+            .create_entity(&tok, "project", None, "Project", None, None, vec![])
+            .await
+            .unwrap();
+
+        let error = rt
+            .link(
+                &tok,
+                concept.id,
+                project.id,
+                EdgeRelation::CompetesWith,
+                1.0,
+                None,
+            )
+            .await
+            .expect_err("concept competes_with project must be rejected");
+        let message = error.to_string();
+        assert!(
+            message.contains(
+                "currently legal relations for concept -> project under the loaded endpoint rules: depends_on"
+            ),
+            "rejection must expose the exact loaded legal set; got: {message}"
+        );
+    }
+
+    #[test]
+    fn cross_backend_illegal_entity_pair_names_when_no_relation_is_legal() {
+        let rt = rt();
+        let source_id = Uuid::new_v4();
+        let target_id = Uuid::new_v4();
+        let source = Resolved::Entity(Entity::new("local", "concept", "Concept"));
+        let target = Resolved::Entity(Entity::new("local", "project", "Project"));
+
+        let error = rt
+            .validate_link_endpoints_by_resolved(
+                source_id,
+                target_id,
+                EdgeRelation::CompetesWith,
+                Some(&source),
+                Some(&target),
+            )
+            .expect_err("concept competes_with project must be rejected");
+        let message = error.to_string();
+        assert!(
+            message.contains(
+                "currently legal relations for concept -> project under the loaded endpoint rules: none"
+            ),
+            "cross-backend rejection must say when the ordered pair has no legal relation; got: {message}"
         );
     }
 

--- a/crates/khive-runtime/tests/integration.rs
+++ b/crates/khive-runtime/tests/integration.rs
@@ -3080,6 +3080,13 @@ async fn update_edge_to_supports_on_disallowed_entity_pair_rejected() {
         msg.contains("supports"),
         "error message must name the relation 'supports'; got: {msg}"
     );
+    assert!(
+        msg.contains(
+            "currently legal relations for person -> concept under the loaded endpoint rules: instance_of"
+        ),
+        "error message must expose the derived legal-relations set from the shared validator \
+         update_edge reaches at operations.rs; got: {msg}"
+    );
 }
 
 /// (c) update_edge note→entity annotates edge → Supports: rejected (cross-substrate).

--- a/crates/kkernel/src/coordinator/tests.rs
+++ b/crates/kkernel/src/coordinator/tests.rs
@@ -9,6 +9,7 @@ use khive_runtime::{
     BackendId, KhiveRuntime, PackRegistry, SearchHit, SearchSource, VerbRegistryBuilder,
 };
 use khive_score::DeterministicScore;
+use khive_storage::types::Direction;
 use khive_storage::EdgeRelation;
 use khive_types::namespace::Namespace;
 
@@ -634,6 +635,86 @@ async fn t2_cross_backend_link_stamps_target_backend() {
     );
     assert_eq!(edge.source_id, src.id, "T2: correct source_id");
     assert_eq!(edge.target_id, tgt.id, "T2: correct target_id");
+}
+
+// ---- T2b: Cross-backend link rejects an illegal entity pair without persisting ----
+
+/// T2b: An illegal cross-backend link (concept -> project, competes_with) is
+/// rejected through the coordinator's own resolved-endpoint validation path
+/// with the same "currently legal relations" diagnostic the same-backend
+/// validator produces, and leaves no edge written on either backend.
+#[tokio::test]
+async fn cross_backend_illegal_entity_pair_rejected_and_not_persisted() {
+    let rt_main = memory_runtime();
+    let rt_lore = memory_runtime();
+
+    let mut registry = BackendRegistry::new();
+    registry.register(BackendId::new("main"), Arc::clone(&rt_main));
+    registry.register(BackendId::new("lore"), Arc::clone(&rt_lore));
+    let coord = SubstrateCoordinator::new(registry);
+    let ns = Namespace::local();
+
+    // Create entity on "main".
+    let tok_main = rt_main.authorize(ns.clone()).unwrap();
+    let src = rt_main
+        .create_entity(
+            &tok_main,
+            "concept",
+            None,
+            "SourceConcept",
+            None,
+            None,
+            vec![],
+        )
+        .await
+        .expect("T2b: create source on main");
+
+    // Create entity on "lore".
+    let tok_lore = rt_lore.authorize(ns.clone()).unwrap();
+    let tgt = rt_lore
+        .create_entity(
+            &tok_lore,
+            "project",
+            None,
+            "TargetProject",
+            None,
+            None,
+            vec![],
+        )
+        .await
+        .expect("T2b: create target on lore");
+
+    // concept -> project competes_with is not in the base allowlist and no
+    // pack rules are installed on either backend, so this must be rejected.
+    let result = coord
+        .link_cross_backend(&ns, src.id, tgt.id, EdgeRelation::CompetesWith, 1.0, None)
+        .await;
+
+    let err = result.expect_err("T2b: illegal cross-backend link must be rejected");
+    assert!(
+        err.contains(
+            "currently legal relations for concept -> project under the loaded endpoint rules: none"
+        ),
+        "T2b: rejection must expose the exact loaded legal set; got: {err}"
+    );
+
+    // No edge must have been persisted on either backend.
+    let main_neighbors = rt_main
+        .neighbors(&tok_main, src.id, Direction::Out, None, None)
+        .await
+        .expect("T2b: main neighbors query");
+    assert!(
+        main_neighbors.is_empty(),
+        "T2b: no edge must be written on the source backend after rejection"
+    );
+    let lore_neighbors = rt_lore
+        .neighbors(&tok_lore, tgt.id, Direction::In, None, None)
+        .await
+        .expect("T2b: lore neighbors query");
+    assert!(
+        lore_neighbors.is_empty(),
+        "T2b: no edge must be written on the target backend after rejection"
+    );
 }
 
 // ---- T3: Fan-out merged from multiple backends ----


### PR DESCRIPTION
## Summary

- derive the complete legal relation set for a resolved entity pair from the runtime's base endpoint table and loaded pack `EDGE_RULES`
- attach that set, or an explicit `none`, to local and cross-backend endpoint-pair rejections so bulk, atomic, update, and direct runtime paths are actionable
- reuse the shared derivation in the KG singleton-link hint and cover both loaded pack additions and empty ordered-pair results

## Validation

- `cargo test --workspace`
- `cargo check --workspace`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `RUSTDOCFLAGS=-Dwarnings cargo doc --workspace --no-deps`

Closes #1606

> AI-assisted contribution: Codex prepared this change and PR description.
