### PR TITLE
fix(retrieval): align hybrid fusion contracts

### DIFF
--- a/crates/khive-fusion/docs/algorithm.md
+++ b/crates/khive-fusion/docs/algorithm.md
@@ -11,7 +11,7 @@ Does not cover storage, embedding, or retrieval engine internals.
 
 **Benchmarks:** `benches/fusion_bench.rs` — see `docs/benchmarks.md` for the ledger and run command
 
-**Last reviewed:** 2026-06-06
+**Last reviewed:** 2026-08-01
 
 ---
 
@@ -21,8 +21,8 @@ Does not cover storage, embedding, or retrieval engine internals.
   to score distribution differences between retrieval sources.
 - **Weighted**: Linear combination of per-source min-max normalized scores with configurable weights.
 - **Union**: Takes the maximum score per ID across all sources.
-- **VectorOnly**: Passes through vector search results without fusion (exactly one source required).
-- **KeywordOnly**: Passes through keyword search results without fusion (exactly one source required).
+- **VectorOnly**: Passes through source slot 0 without fusion; a lone source is authoritative.
+- **KeywordOnly**: Passes through source slot 1 without fusion; a lone source is authoritative.
 
 ---
 
@@ -104,18 +104,19 @@ any retriever, without rank-based aggregation.
 
 ## VectorOnly / KeywordOnly
 
-Passthrough strategies: exactly one source must be supplied. Supplying multiple sources is
-a wiring error; `fuse()` returns an empty vector in both debug and release builds so the
-error is detectable without panicking on caller input.
+Passthrough strategies select a positional source without changing its scores or order.
+With multiple sources, `VectorOnly` selects slot 0 and `KeywordOnly` selects slot 1.
+Two-arm hybrid callers therefore supply `[vector, keyword]`; other callers own and document
+their positional meaning. When only one source is supplied, it is authoritative for either
+passthrough strategy so a one-arm query does not disappear.
 
 ---
 
 ## `fuse()` dispatcher
 
 `fuse()` in `src/fuse.rs` is the main entry point. It accepts any `FusionStrategy`, delegates
-to the appropriate algorithm, then applies `top_k` truncation using a partial sort
-(`select_nth_unstable_by`) that is O(n) for partitioning and O(k log k) for the final sort.
-This avoids a full O(n log n) sort when `top_k << n`.
+to the appropriate algorithm, then takes the first `top_k` results from that algorithm's
+deterministically sorted output. Passthrough modes preserve the selected source's input order.
 
 Individual algorithm functions (`reciprocal_rank_fusion`, `weighted_fusion`, `union_fusion`)
 do not apply `top_k` truncation — they return the full fused list.
@@ -128,7 +129,8 @@ do not apply `top_k` truncation — they return the full fused list.
 | -------------------------------------------- | ------------------------------------------------------------- |
 | Empty sources                                | Returns empty vec                                             |
 | `top_k == 0`                                 | Returns empty vec                                             |
-| VectorOnly/KeywordOnly with multiple sources | Returns empty vec (wiring error)                              |
+| VectorOnly/KeywordOnly with multiple sources | Selects slot 0/slot 1, respectively                           |
+| VectorOnly/KeywordOnly with one source       | Returns that authoritative source unchanged                   |
 | All-zero or all-negative weights             | Falls back to equal weight distribution                       |
 | Non-finite weights in `weighted_fusion`      | Treated as 0.0 (lossy); use `try_normalize_weights` to reject |
 
@@ -158,7 +160,7 @@ let fused = fuse(
     vec![vector_results, keyword_results],
     &FusionStrategy::Rrf { k: 60 },
     5,
-);
+).unwrap();
 
 // doc_b appears in both sources → highest RRF score
 assert_eq!(fused[0].0, "doc_b");

--- a/crates/khive-fusion/docs/design.md
+++ b/crates/khive-fusion/docs/design.md
@@ -23,9 +23,11 @@
 ### Multi-Engine Retrieval (ADR-031)
 
 - The `fuse()` dispatcher accepts results from any number of retrieval sources and routes them
-  through the appropriate strategy. VectorOnly and KeywordOnly are single-source passthrough
-  strategies — supplying multiple sources for these returns an empty vector so wiring errors are
-  detectable without panicking.
+  through the appropriate strategy. Positional source meaning belongs to each caller:
+  two-arm hybrid search uses `[vector, keyword]`, multi-engine fusion uses registry order,
+  and dual-index migration uses `[primary, legacy]`. VectorOnly selects slot 0 and KeywordOnly
+  slot 1 when both hybrid slots are present; a lone source is authoritative for either
+  passthrough mode.
 
 ## Consistency Notes
 

--- a/crates/khive-pack-memory/docs/api/recall-pipeline.md
+++ b/crates/khive-pack-memory/docs/api/recall-pipeline.md
@@ -48,17 +48,21 @@ When no installed graph is available after the readiness attempt — except when
 
 ## Fusion
 
-Retrieval sources are labeled `text`, `vector`, or `both`. Per-model vector lists are unioned by UUID before cross-source fusion, retaining the best vector score for duplicates.
+Retrieval sources are labeled `text`, `vector`, or `both`. How per-model vector lists reach fusion depends on the configured strategy:
+
+- `rrf` and `union` keep each embedding model's vector hits as a separate source, in `vector_hits_per_model` order, followed by the text source. A note ranking in more than one model's results gets one rank contribution per model instead of being collapsed to its best raw score.
+- `weighted` first unions all per-model vector hits into one combined vector source by UUID (retaining the best score per duplicate), then fuses `[combined_vector, text]` under the configured vector/keyword weights.
+- `vector_only` and `keyword_only` union per-model vector hits the same way as `weighted` and route only the relevant arm; the unused arm is passed as an explicit empty source so the two-arm `[vector, keyword]` positions stay stable rather than being rebound.
 
 Supported strategies are:
 
-| Request value | Behavior |
-| --- | --- |
-| `rrf` | Reciprocal-rank fusion with `k = 60`. |
-| `weighted` | Weighted text/vector fusion; configured pack weights govern values. |
-| `union` | Union candidate sets. |
-| `vector_only` | Ignore text candidates. |
-| `keyword_only` | Ignore vector candidates. |
+| Request value  | Behavior                                                            |
+| -------------- | ------------------------------------------------------------------- |
+| `rrf`          | Reciprocal-rank fusion with `k = 60`.                               |
+| `weighted`     | Weighted text/vector fusion; configured pack weights govern values. |
+| `union`        | Union candidate sets.                                               |
+| `vector_only`  | Ignore text candidates.                                             |
+| `keyword_only` | Ignore vector candidates.                                           |
 
 Unknown strategy names return `InvalidInput`. Candidate count defaults to `max(limit * candidate_multiplier, 40)` unless `candidate_limit` is explicit.
 

--- a/crates/khive-pack-memory/src/handlers/common.rs
+++ b/crates/khive-pack-memory/src/handlers/common.rs
@@ -629,9 +629,9 @@ pub(super) fn fuse_candidates(
     let is_weighted = matches!(&cfg.fuse_strategy, FusionStrategy::Weighted { .. });
 
     let sources: Vec<Vec<_>> = if vector_only {
-        vec![combine_vector_sources_union(vector_sources)]
+        vec![combine_vector_sources_union(vector_sources), vec![]]
     } else if keyword_only {
-        vec![text_source]
+        vec![vec![], text_source]
     } else if is_weighted && vector_sources.len() > 1 {
         let combined_vector = combine_vector_sources_union(vector_sources);
         vec![combined_vector, text_source]

--- a/crates/khive-pack-memory/src/handlers/tests.rs
+++ b/crates/khive-pack-memory/src/handlers/tests.rs
@@ -382,6 +382,160 @@ fn vector_only_fusion_unions_hits_across_every_engine() {
     );
 }
 
+// ── Two-arm positional contract (ADR-033 §6.3): VectorOnly/KeywordOnly must
+// preserve both `[vector, keyword]` slots even with zero registered vector
+// models, rather than collapsing to a single source. ────────────────────────
+
+#[test]
+fn vector_only_with_zero_vector_models_never_leaks_text_hits() {
+    use khive_storage::types::TextSearchHit;
+    use std::collections::HashSet;
+    use uuid::Uuid;
+
+    let id_text_only = Uuid::from_u128(0x3333);
+    let text_hits = vec![TextSearchHit {
+        subject_id: id_text_only,
+        score: 0.9_f64.into(),
+        rank: 1,
+        title: None,
+        snippet: None,
+    }];
+    let memory_ids: HashSet<Uuid> = [id_text_only].into_iter().collect();
+
+    let candidates = RecallCandidateSet {
+        namespace: "local".to_string(),
+        text_hits,
+        vector_hits_per_model: vec![],
+        visible_namespaces: vec!["local".to_string()],
+        ann_degraded: false,
+    };
+    let cfg = RecallConfig {
+        fuse_strategy: FusionStrategy::VectorOnly,
+        ..RecallConfig::default()
+    };
+
+    let results = fuse_candidates(&candidates, &memory_ids, &cfg, 10);
+
+    assert!(
+        results.is_empty(),
+        "VectorOnly with zero registered vector models must return no hits, \
+         even though text hits are present — the keyword slot must stay a \
+         distinct, empty position rather than being read as the vector arm; \
+         got {:?}",
+        results.iter().map(|h| h.entity_id).collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn keyword_only_with_zero_vector_models_still_returns_text_hits() {
+    use khive_storage::types::TextSearchHit;
+    use std::collections::HashSet;
+    use uuid::Uuid;
+
+    let id_a = Uuid::from_u128(0x4444);
+    let id_b = Uuid::from_u128(0x5555);
+    let text_hits = vec![
+        TextSearchHit {
+            subject_id: id_a,
+            score: 0.9_f64.into(),
+            rank: 1,
+            title: None,
+            snippet: None,
+        },
+        TextSearchHit {
+            subject_id: id_b,
+            score: 0.5_f64.into(),
+            rank: 2,
+            title: None,
+            snippet: None,
+        },
+    ];
+    let memory_ids: HashSet<Uuid> = [id_a, id_b].into_iter().collect();
+
+    let candidates = RecallCandidateSet {
+        namespace: "local".to_string(),
+        text_hits,
+        vector_hits_per_model: vec![],
+        visible_namespaces: vec!["local".to_string()],
+        ann_degraded: false,
+    };
+    let cfg = RecallConfig {
+        fuse_strategy: FusionStrategy::KeywordOnly,
+        ..RecallConfig::default()
+    };
+
+    let results = fuse_candidates(&candidates, &memory_ids, &cfg, 10);
+    let ids: Vec<Uuid> = results.iter().map(|h| h.entity_id).collect();
+
+    assert_eq!(
+        ids,
+        vec![id_a, id_b],
+        "KeywordOnly with zero registered vector models must still serve the \
+         text arm from its dedicated keyword slot, in score order; got {ids:?}"
+    );
+}
+
+#[test]
+fn multi_engine_rrf_gives_each_engine_a_separate_rank_contribution() {
+    use khive_storage::types::VectorSearchHit;
+    use std::collections::HashSet;
+    use uuid::Uuid;
+
+    // id_dual appears in both engines (rank 2 in A, rank 1 in B) and so must
+    // accumulate two RRF rank contributions. id_solo appears only in engine A
+    // at rank 1. If per-model vector hits were unioned into one source before
+    // RRF (max score per ID) instead of staying separate, id_solo's higher
+    // raw score (0.90) would put it ahead of id_dual (0.50) in the unioned
+    // ranking — the opposite of the outcome asserted below.
+    let id_dual = Uuid::from_u128(0x6666);
+    let id_solo = Uuid::from_u128(0x7777);
+
+    let hits_engine_a = vec![
+        VectorSearchHit {
+            subject_id: id_solo,
+            score: 0.90_f64.into(),
+            rank: 1,
+        },
+        VectorSearchHit {
+            subject_id: id_dual,
+            score: 0.50_f64.into(),
+            rank: 2,
+        },
+    ];
+    let hits_engine_b = vec![VectorSearchHit {
+        subject_id: id_dual,
+        score: 0.50_f64.into(),
+        rank: 1,
+    }];
+    let memory_ids: HashSet<Uuid> = [id_dual, id_solo].into_iter().collect();
+
+    let candidates = RecallCandidateSet {
+        namespace: "local".to_string(),
+        text_hits: vec![],
+        vector_hits_per_model: vec![
+            ("engine-a".to_string(), hits_engine_a),
+            ("engine-b".to_string(), hits_engine_b),
+        ],
+        visible_namespaces: vec!["local".to_string()],
+        ann_degraded: false,
+    };
+    let cfg = RecallConfig {
+        fuse_strategy: FusionStrategy::Rrf { k: 60 },
+        ..RecallConfig::default()
+    };
+
+    let results = fuse_candidates(&candidates, &memory_ids, &cfg, 10);
+    let ids: Vec<Uuid> = results.iter().map(|h| h.entity_id).collect();
+
+    assert_eq!(
+        ids.first(),
+        Some(&id_dual),
+        "multi-engine RRF must keep each engine as a separate source so a \
+         note present in both engines outranks a single-engine hit with a \
+         higher raw score, not the pre-union collapse; got {ids:?}"
+    );
+}
+
 #[test]
 fn compute_score_weighted_strategy_formula() {
     let cfg = RecallConfig {

--- a/crates/khive-retrieval/README.md
+++ b/crates/khive-retrieval/README.md
@@ -38,8 +38,12 @@ for (id, score) in &fused {
 
 `HybridConfig::new(top_k)` defaults to RRF fusion (k=60); chain
 `.with_fusion_strategy(..)`, `.with_pool_size(..)`, `.with_min_score(..)`, or
-`.with_weights(vector, keyword)` to customize. `fuse_search_results` falls back
-to RRF if a `Weighted` strategy's weight count doesn't match the source count;
+`.with_weights(vector, keyword)` to customize. Fusion sources and positional
+weights always use `[vector, keyword]`; retain an empty arm as an empty vector
+instead of removing it, so the remaining source keeps its assigned position.
+Even a single supplied source is transformed by the configured strategy before
+`min_score` is applied. `fuse_search_results` falls back
+to RRF if a `Weighted` strategy is not given exactly those two source slots;
 `fuse_search_results_checked` returns `Err` in that case instead.
 
 ## Configuration (Cargo features)

--- a/crates/khive-retrieval/README.md
+++ b/crates/khive-retrieval/README.md
@@ -15,7 +15,8 @@ scoring throughout.
   `khive-fusion`, and `lattice-embed` types are re-exported so a caller depends
   on this one crate for the full hybrid path
 - **`DualIndexRouter`** — routes queries between a primary and legacy vector
-  index during a migration, with a configurable auto-switch threshold
+  index during a migration, with positional `[primary, legacy]` fusion and a
+  configurable auto-switch threshold
 - **Timeout/cancellation wrappers** — `search_with_timeout`,
   `search_with_deadline`, `search_with_cancellation` around any search future
 - **Feature-gated extensions** — see Configuration below
@@ -38,12 +39,14 @@ for (id, score) in &fused {
 
 `HybridConfig::new(top_k)` defaults to RRF fusion (k=60); chain
 `.with_fusion_strategy(..)`, `.with_pool_size(..)`, `.with_min_score(..)`, or
-`.with_weights(vector, keyword)` to customize. Fusion sources and positional
-weights always use `[vector, keyword]`; retain an empty arm as an empty vector
-instead of removing it, so the remaining source keeps its assigned position.
-Even a single supplied source is transformed by the configured strategy before
-`min_score` is applied. `fuse_search_results` falls back
-to RRF if a `Weighted` strategy is not given exactly those two source slots;
+`.with_weights(vector, keyword)` to customize. In the two-arm vector/text
+hybrid API, fusion sources and positional weights use `[vector, keyword]`;
+retain an empty arm as an empty vector instead of removing it, so the remaining
+source keeps its assigned position. Generic RRF and Union callers may supply N
+sources in their own documented order. Even a single supplied source is
+transformed by the configured strategy before `min_score` is applied.
+`fuse_search_results` falls back to RRF if a `Weighted` hybrid strategy is not
+given exactly the two vector/text source slots;
 `fuse_search_results_checked` returns `Err` in that case instead.
 
 ## Configuration (Cargo features)

--- a/crates/khive-retrieval/src/hybrid/dual_index.rs
+++ b/crates/khive-retrieval/src/hybrid/dual_index.rs
@@ -146,6 +146,10 @@ where
     }
 
     /// Merge results from primary and legacy indexes using the configured strategy.
+    ///
+    /// Positional strategies use `[primary, legacy]`. This migration-specific
+    /// contract is independent of the `[vector, keyword]` order used by
+    /// two-arm hybrid search APIs.
     pub fn merge_results(
         &self,
         primary_results: Vec<(Id, DeterministicScore)>,
@@ -371,6 +375,21 @@ mod tests {
         assert!(ids.contains(&"a"));
         assert!(ids.contains(&"b"));
         assert!(ids.contains(&"c"));
+    }
+
+    #[test]
+    fn test_merge_weighted_uses_primary_then_legacy_order() {
+        let config = DualIndexConfig::default().with_strategy(DualIndexStrategy::Weighted {
+            primary_weight: 0.8,
+        });
+        let router = DualIndexRouter::<String>::new(config);
+
+        let primary = make_results(vec![("primary", 0.9)]);
+        let legacy = make_results(vec![("legacy", 0.9)]);
+        let merged = router.merge_results(primary, legacy, 10);
+
+        assert_eq!(merged[0].0, "primary");
+        assert!(merged[0].1 > merged[1].1);
     }
 
     #[test]

--- a/crates/khive-retrieval/src/hybrid/searcher.rs
+++ b/crates/khive-retrieval/src/hybrid/searcher.rs
@@ -65,18 +65,20 @@ pub trait Reranker<Id: Send + Sync + 'static>: Send + Sync {
 ///
 /// This can be used by implementors of [`HybridSearcher`] to fuse results
 /// from their [`VectorSearch`] and [`KeywordSearch`] implementations.
-/// Sources use the canonical positional order `[vector, keyword]`. Keep empty
-/// arms in that order so positional weighted strategies cannot rebind a
-/// keyword-only result set to the vector weight (or vice versa).
+/// Two-arm vector/text callers use the positional order `[vector, keyword]`.
+/// Keep empty arms in that order so positional weighted strategies cannot
+/// rebind a keyword-only result set to the vector weight (or vice versa).
+/// Generic RRF and Union callers may supply N sources in a caller-defined,
+/// documented order.
 ///
 /// `Ord` is required for deterministic tie-breaking when scores are equal.
 ///
 /// # Weighted strategy validation
 ///
 /// When `config.fusion_strategy` is `Weighted`, this function validates that
-/// exactly 2 canonical source slots are provided in all builds. A missing arm
-/// is represented by an empty slot; any other source count falls back to RRF
-/// to prevent silent positional rebinding. Use
+/// exactly 2 vector/text source slots are provided in all builds. A missing
+/// arm is represented by an empty slot; any other source count falls back to
+/// RRF to prevent silent positional rebinding. Use
 /// [`fuse_search_results_checked`] if you need an explicit error instead.
 pub fn fuse_search_results<Id: Eq + Hash + Clone + Ord>(
     sources: Vec<Vec<(Id, DeterministicScore)>>,
@@ -114,7 +116,7 @@ pub fn fuse_search_results<Id: Eq + Hash + Clone + Ord>(
 }
 
 /// Like [`fuse_search_results`] but returns `Err` when `Weighted` fusion is
-/// configured without exactly two canonical source slots.
+/// configured without exactly two vector/text source slots.
 ///
 /// Use this in code paths that should not silently fall back to RRF.
 pub fn fuse_search_results_checked<Id: Eq + Hash + Clone + Ord>(

--- a/crates/khive-retrieval/src/hybrid/searcher.rs
+++ b/crates/khive-retrieval/src/hybrid/searcher.rs
@@ -65,31 +65,25 @@ pub trait Reranker<Id: Send + Sync + 'static>: Send + Sync {
 ///
 /// This can be used by implementors of [`HybridSearcher`] to fuse results
 /// from their [`VectorSearch`] and [`KeywordSearch`] implementations.
+/// Sources use the canonical positional order `[vector, keyword]`. Keep empty
+/// arms in that order so positional weighted strategies cannot rebind a
+/// keyword-only result set to the vector weight (or vice versa).
 ///
 /// `Ord` is required for deterministic tie-breaking when scores are equal.
 ///
 /// # Weighted strategy validation
 ///
 /// When `config.fusion_strategy` is `Weighted`, this function validates that
-/// exactly 2 sources are provided in all builds. If the source count does not
-/// match the weight vector length, the function falls back to RRF to prevent
-/// silent data corruption. Use [`fuse_search_results_checked`] if you need an
-/// explicit error instead of a fallback.
+/// exactly 2 canonical source slots are provided in all builds. A missing arm
+/// is represented by an empty slot; any other source count falls back to RRF
+/// to prevent silent positional rebinding. Use
+/// [`fuse_search_results_checked`] if you need an explicit error instead.
 pub fn fuse_search_results<Id: Eq + Hash + Clone + Ord>(
     sources: Vec<Vec<(Id, DeterministicScore)>>,
     config: &HybridConfig,
 ) -> Vec<(Id, DeterministicScore)> {
     if sources.is_empty() {
         return Vec::new();
-    }
-
-    if sources.len() == 1 {
-        let mut results = sources.into_iter().next().unwrap();
-        if let Some(min_score) = config.min_score {
-            results.retain(|(_, score)| *score >= min_score);
-        }
-        results.truncate(config.top_k);
-        return results;
     }
 
     // Determine fusion strategy — Custom falls back to RRF (same as Weighted
@@ -120,7 +114,7 @@ pub fn fuse_search_results<Id: Eq + Hash + Clone + Ord>(
 }
 
 /// Like [`fuse_search_results`] but returns `Err` when `Weighted` fusion is
-/// configured with a source count that doesn't match the expected 2 weights.
+/// configured without exactly two canonical source slots.
 ///
 /// Use this in code paths that should not silently fall back to RRF.
 pub fn fuse_search_results_checked<Id: Eq + Hash + Clone + Ord>(
@@ -167,6 +161,8 @@ mod tests {
 
         assert_eq!(results.len(), 2);
         assert_eq!(results[0].0, "a");
+        assert_eq!(results[0].1, khive_score::rrf_score(1, 60));
+        assert_eq!(results[1].1, khive_score::rrf_score(2, 60));
     }
 
     #[test]
@@ -189,6 +185,20 @@ mod tests {
     }
 
     #[test]
+    fn weighted_sources_use_vector_then_keyword_order() {
+        let vector = vec![("vector".to_string(), DeterministicScore::from_f64(0.9))];
+        let keyword = vec![("keyword".to_string(), DeterministicScore::from_f64(0.9))];
+        let config = HybridConfig::new(10)
+            .with_fusion_strategy(FusionStrategy::weighted(vec![0.7, 0.3]))
+            .with_weights(0.7, 0.3);
+
+        let results = fuse_search_results(vec![vector, keyword], &config);
+
+        assert_eq!(results[0].0, "vector");
+        assert!(results[0].1 > results[1].1);
+    }
+
+    #[test]
     fn test_fuse_with_min_score() {
         let sources = vec![vec![
             ("a".to_string(), DeterministicScore::from_f64(0.9)),
@@ -198,9 +208,10 @@ mod tests {
         let config = HybridConfig::new(10).with_min_score(DeterministicScore::from_f64(0.5));
         let results = fuse_search_results(sources, &config);
 
-        // b should be filtered out (RRF score ~0.016 < 0.5)
-        // Actually RRF scores are very small, let's use a lower threshold
-        assert!(!results.is_empty());
+        assert!(
+            results.is_empty(),
+            "the one-arm RRF transform must run before the fused-domain score floor"
+        );
     }
 
     #[test]
@@ -269,5 +280,20 @@ mod tests {
         let result = fuse_search_results_checked(vec![source1, source2], &config);
         assert!(result.is_ok(), "2-source Weighted must succeed");
         assert_eq!(result.unwrap().len(), 2);
+    }
+
+    #[test]
+    fn test_fuse_search_results_checked_weighted_empty_arm_keeps_slot() {
+        let config = HybridConfig::new(10)
+            .with_fusion_strategy(FusionStrategy::weighted(vec![0.7, 0.3]))
+            .with_weights(0.7, 0.3);
+        let keyword = vec![("keyword".to_string(), DeterministicScore::from_f64(0.8))];
+
+        let result = fuse_search_results_checked(vec![Vec::new(), keyword], &config)
+            .expect("an empty vector arm still occupies its canonical slot");
+
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].0, "keyword");
+        assert!((result[0].1.to_f64() - 0.3).abs() < 1e-9);
     }
 }

--- a/crates/khive-runtime/src/fusion.rs
+++ b/crates/khive-runtime/src/fusion.rs
@@ -629,6 +629,29 @@ mod tests {
         assert!(live.contains(&hits[0].entity_id));
     }
 
+    #[tokio::test]
+    async fn hybrid_default_rrf_alive_filter_refills_below_complete_four_x_prefix() {
+        let (rt, tok, query_text, query_vector, _text_hits, _vector_hits, live) =
+            stale_full_prefix_fixture().await;
+
+        let hits = rt
+            .hybrid_search(
+                &tok,
+                query_text,
+                Some(query_vector),
+                1,
+                None,
+                None,
+                &[],
+                None,
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(hits.len(), 1);
+        assert!(live.contains(&hits[0].entity_id));
+    }
+
     // 9. Roundtrip serde preserves variant
     #[test]
     fn serde_roundtrip() {

--- a/crates/khive-runtime/src/fusion.rs
+++ b/crates/khive-runtime/src/fusion.rs
@@ -232,7 +232,7 @@ mod tests {
     use super::*;
     use chrono::Utc;
     use khive_storage::types::{TextDocument, TextSearchHit, VectorSearchHit, VectorSearchRequest};
-    use khive_types::Entity;
+    use khive_storage::Entity;
     use lattice_embed::EmbeddingModel;
 
     use crate::RuntimeConfig;

--- a/crates/khive-runtime/src/fusion.rs
+++ b/crates/khive-runtime/src/fusion.rs
@@ -156,7 +156,7 @@ impl KhiveRuntime {
                     },
                     PageRequest {
                         offset: 0,
-                        limit: fused.len() as u32,
+                        limit: u32::try_from(fused.len()).unwrap_or(u32::MAX),
                     },
                 )
                 .await?;
@@ -216,9 +216,12 @@ impl KhiveRuntime {
             Vec::new()
         };
 
-        // Keep the full over-fetched pool through ranking and the alive check;
-        // truncating first lets a stale hit consume a final top-k slot.
-        let fused = fuse_with_strategy(text_hits, vector_hits, &strategy, candidates as usize)?;
+        // Each arm fetched `candidates` independently, so their union can contain
+        // twice that many distinct IDs. Keep the complete fetched pool through
+        // ranking and the alive check; truncating it first lets stale hits hide
+        // live candidates from the other arm.
+        let fusion_limit = text_hits.len().saturating_add(vector_hits.len());
+        let fused = fuse_with_strategy(text_hits, vector_hits, &strategy, fusion_limit)?;
         self.retain_alive_search_hits(token, fused, limit as usize)
             .await
     }
@@ -227,7 +230,12 @@ impl KhiveRuntime {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use khive_storage::types::{TextSearchHit, VectorSearchHit};
+    use chrono::Utc;
+    use khive_storage::types::{TextDocument, TextSearchHit, VectorSearchHit, VectorSearchRequest};
+    use khive_types::Entity;
+    use lattice_embed::EmbeddingModel;
+
+    use crate::RuntimeConfig;
 
     fn text_hit(id: Uuid, score: f64, title: &str) -> TextSearchHit {
         TextSearchHit {
@@ -245,6 +253,135 @@ mod tests {
             score: DeterministicScore::from_f64(score),
             rank: 1,
         }
+    }
+
+    fn cosine_fixture_vector(dimensions: usize, x: f32, y: f32) -> Vec<f32> {
+        let mut vector = vec![0.0; dimensions];
+        vector[0] = x;
+        vector[1] = y;
+        vector
+    }
+
+    async fn stale_full_prefix_fixture() -> (
+        KhiveRuntime,
+        NamespaceToken,
+        &'static str,
+        Vec<f32>,
+        Vec<TextSearchHit>,
+        Vec<VectorSearchHit>,
+        HashSet<Uuid>,
+    ) {
+        let model = EmbeddingModel::AllMiniLmL6V2;
+        let dimensions = model.dimensions();
+        let rt = KhiveRuntime::new(RuntimeConfig {
+            db_path: None,
+            embedding_model: Some(model),
+            additional_embedding_models: vec![],
+            ..RuntimeConfig::default()
+        })
+        .unwrap();
+        let tok = NamespaceToken::local();
+        let query_text = "fusionrefillterm";
+        let query_vector = cosine_fixture_vector(dimensions, 1.0, 0.0);
+
+        let common_stale_a = Uuid::from_u128(1);
+        let common_stale_b = Uuid::from_u128(2);
+        let text_only_stale = Uuid::from_u128(3);
+        let vector_only_stale = Uuid::from_u128(4);
+
+        let live_text = Entity::new("local", "concept", "live text candidate");
+        let live_vector = Entity::new("local", "concept", "live vector candidate");
+        rt.entities(&tok)
+            .unwrap()
+            .upsert_entities(vec![live_text.clone(), live_vector.clone()])
+            .await
+            .unwrap();
+
+        let document = |subject_id, repetitions: usize| TextDocument {
+            subject_id,
+            kind: SubstrateKind::Entity,
+            namespace: "local".to_string(),
+            title: None,
+            body: std::iter::repeat_n(query_text, repetitions)
+                .collect::<Vec<_>>()
+                .join(" "),
+            tags: vec![],
+            metadata: None,
+            updated_at: Utc::now(),
+        };
+        rt.text(&tok)
+            .unwrap()
+            .upsert_documents(vec![
+                document(common_stale_a, 12),
+                document(common_stale_b, 8),
+                document(text_only_stale, 4),
+                document(live_text.id, 1),
+            ])
+            .await
+            .unwrap();
+
+        let vectors = rt.vectors(&tok).unwrap();
+        for (id, vector) in [
+            (common_stale_a, cosine_fixture_vector(dimensions, 1.0, 0.0)),
+            (common_stale_b, cosine_fixture_vector(dimensions, 0.8, 0.6)),
+            (
+                vector_only_stale,
+                cosine_fixture_vector(dimensions, 0.5, 0.866_025_4),
+            ),
+            (live_vector.id, cosine_fixture_vector(dimensions, -1.0, 0.0)),
+        ] {
+            vectors
+                .insert(
+                    id,
+                    SubstrateKind::Entity,
+                    "local",
+                    "entity.body",
+                    vec![vector],
+                )
+                .await
+                .unwrap();
+        }
+
+        let text_hits = rt
+            .text(&tok)
+            .unwrap()
+            .search(TextSearchRequest {
+                query: query_text.to_string(),
+                mode: TextQueryMode::Plain,
+                filter: Some(TextFilter {
+                    namespaces: vec!["local".to_string()],
+                    ..TextFilter::default()
+                }),
+                top_k: CANDIDATE_MULTIPLIER,
+                snippet_chars: 0,
+            })
+            .await
+            .unwrap();
+        let vector_hits = vectors
+            .search(VectorSearchRequest {
+                query_vectors: vec![query_vector.clone()],
+                top_k: CANDIDATE_MULTIPLIER,
+                namespace: Some("local".to_string()),
+                kind: Some(SubstrateKind::Entity),
+                embedding_model: None,
+                filter: None,
+                backend_hints: None,
+            })
+            .await
+            .unwrap();
+
+        assert_eq!(text_hits.len(), CANDIDATE_MULTIPLIER as usize);
+        assert_eq!(vector_hits.len(), CANDIDATE_MULTIPLIER as usize);
+        let live = HashSet::from([live_text.id, live_vector.id]);
+        (
+            rt,
+            tok,
+            query_text,
+            query_vector,
+            text_hits,
+            vector_hits,
+            live,
+        )
     }
 
     // 1. RRF with custom k produces different ordering than k=60
@@ -442,42 +579,54 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn alive_filter_refills_top_k_from_the_ranked_candidate_pool() {
-        let rt = KhiveRuntime::memory().unwrap();
-        let tok = NamespaceToken::local();
-        let live = rt
-            .create_entity(
+    async fn hybrid_union_alive_filter_refills_below_complete_four_x_prefix() {
+        let (rt, tok, query_text, query_vector, text_hits, vector_hits, live) =
+            stale_full_prefix_fixture().await;
+        let truncated = fuse_with_strategy(
+            text_hits,
+            vector_hits,
+            &FusionStrategy::Union,
+            CANDIDATE_MULTIPLIER as usize,
+        )
+        .unwrap();
+        assert!(truncated.iter().all(|hit| !live.contains(&hit.entity_id)));
+
+        let hits = rt
+            .hybrid_search_with_strategy(
                 &tok,
-                "concept",
-                None,
-                "live refill candidate",
-                None,
-                None,
-                vec![],
+                query_text,
+                Some(query_vector),
+                FusionStrategy::Union,
+                1,
             )
             .await
             .unwrap();
-        let stale = Uuid::new_v4();
-        let fused = vec![
-            SearchHit {
-                entity_id: stale,
-                score: DeterministicScore::from_f64(0.9),
-                source: SearchSource::Text,
-                title: Some("stale".into()),
-                snippet: None,
-            },
-            SearchHit {
-                entity_id: live.id,
-                score: DeterministicScore::from_f64(0.8),
-                source: SearchSource::Text,
-                title: Some("live".into()),
-                snippet: None,
-            },
-        ];
 
-        let hits = rt.retain_alive_search_hits(&tok, fused, 1).await.unwrap();
         assert_eq!(hits.len(), 1);
-        assert_eq!(hits[0].entity_id, live.id);
+        assert!(live.contains(&hits[0].entity_id));
+    }
+
+    #[tokio::test]
+    async fn hybrid_rrf_alive_filter_refills_below_complete_four_x_prefix() {
+        let (rt, tok, query_text, query_vector, text_hits, vector_hits, live) =
+            stale_full_prefix_fixture().await;
+        let strategy = FusionStrategy::Rrf { k: 60 };
+        let truncated = fuse_with_strategy(
+            text_hits,
+            vector_hits,
+            &strategy,
+            CANDIDATE_MULTIPLIER as usize,
+        )
+        .unwrap();
+        assert!(truncated.iter().all(|hit| !live.contains(&hit.entity_id)));
+
+        let hits = rt
+            .hybrid_search_with_strategy(&tok, query_text, Some(query_vector), strategy, 1)
+            .await
+            .unwrap();
+
+        assert_eq!(hits.len(), 1);
+        assert!(live.contains(&hits[0].entity_id));
     }
 
     // 9. Roundtrip serde preserves variant

--- a/crates/khive-runtime/src/fusion.rs
+++ b/crates/khive-runtime/src/fusion.rs
@@ -20,6 +20,7 @@ pub use khive_fusion::FusionStrategy;
 const CANDIDATE_MULTIPLIER: u32 = 4;
 
 /// Fuse text and vector hits using the given strategy, returning at most `limit` results.
+/// Positional weighted strategies use `[vector, keyword]` order.
 pub fn fuse_with_strategy(
     text_hits: Vec<TextSearchHit>,
     vector_hits: Vec<VectorSearchHit>,
@@ -91,10 +92,9 @@ fn fuse_sources(
         })
         .collect();
 
-    let sources: Vec<Vec<(Uuid, DeterministicScore)>> = vec![text_source, vector_source]
-        .into_iter()
-        .filter(|s| !s.is_empty())
-        .collect();
+    // Canonical positional order is [vector, keyword]. Empty arms remain in
+    // place: removing one would shift the surviving arm onto the wrong weight.
+    let sources: Vec<Vec<(Uuid, DeterministicScore)>> = vec![vector_source, text_source];
 
     Ok(khive_fusion::fuse(sources, strategy, limit)?
         .into_iter()
@@ -136,6 +136,38 @@ fn merge_sources(left: SearchSource, right: SearchSource) -> SearchSource {
 }
 
 impl KhiveRuntime {
+    async fn retain_alive_search_hits(
+        &self,
+        token: &NamespaceToken,
+        mut fused: Vec<SearchHit>,
+        limit: usize,
+    ) -> RuntimeResult<Vec<SearchHit>> {
+        // Filter out soft-deleted entities. A single query fetches all alive IDs from the
+        // fused candidate pool; any ID absent from the result has been soft-deleted.
+        if !fused.is_empty() {
+            let candidate_ids: Vec<Uuid> = fused.iter().map(|h| h.entity_id).collect();
+            let alive_page = self
+                .entities(token)?
+                .query_entities(
+                    token.namespace().as_str(),
+                    EntityFilter {
+                        ids: candidate_ids,
+                        ..EntityFilter::default()
+                    },
+                    PageRequest {
+                        offset: 0,
+                        limit: fused.len() as u32,
+                    },
+                )
+                .await?;
+            let alive: HashSet<Uuid> = alive_page.items.into_iter().map(|e| e.id).collect();
+            fused.retain(|h| alive.contains(&h.entity_id));
+        }
+
+        fused.truncate(limit);
+        Ok(fused)
+    }
+
     /// Hybrid search with a caller-supplied fusion strategy.
     pub async fn hybrid_search_with_strategy(
         &self,
@@ -184,31 +216,11 @@ impl KhiveRuntime {
             Vec::new()
         };
 
-        let mut fused = fuse_with_strategy(text_hits, vector_hits, &strategy, limit as usize)?;
-
-        // Filter out soft-deleted entities. A single query fetches all alive IDs from the
-        // fused set; any ID absent from the result has been soft-deleted (deleted_at IS NOT NULL).
-        if !fused.is_empty() {
-            let candidate_ids: Vec<Uuid> = fused.iter().map(|h| h.entity_id).collect();
-            let alive_page = self
-                .entities(token)?
-                .query_entities(
-                    token.namespace().as_str(),
-                    EntityFilter {
-                        ids: candidate_ids,
-                        ..EntityFilter::default()
-                    },
-                    PageRequest {
-                        offset: 0,
-                        limit: fused.len() as u32,
-                    },
-                )
-                .await?;
-            let alive: HashSet<Uuid> = alive_page.items.into_iter().map(|e| e.id).collect();
-            fused.retain(|h| alive.contains(&h.entity_id));
-        }
-
-        Ok(fused)
+        // Keep the full over-fetched pool through ranking and the alive check;
+        // truncating first lets a stale hit consume a final top-k slot.
+        let fused = fuse_with_strategy(text_hits, vector_hits, &strategy, candidates as usize)?;
+        self.retain_alive_search_hits(token, fused, limit as usize)
+            .await
     }
 }
 
@@ -255,7 +267,7 @@ mod tests {
         assert!(hits_k1[0].score > hits_k60[0].score);
     }
 
-    // 2. Weighted [0.7, 0.3] gives different ordering than [0.3, 0.7]
+    // 2. Canonical [vector, keyword] weights change ordering as documented.
     #[test]
     fn weighted_ordering_depends_on_weights() {
         let a = Uuid::new_v4();
@@ -264,7 +276,7 @@ mod tests {
         let text = vec![text_hit(a, 0.9, "a"), text_hit(b, 0.1, "b")];
         let vec_hits = vec![vector_hit(b, 0.9), vector_hit(a, 0.1)];
 
-        let heavy_text = fuse_with_strategy(
+        let heavy_vector = fuse_with_strategy(
             text.clone(),
             vec_hits.clone(),
             &FusionStrategy::Weighted {
@@ -273,7 +285,7 @@ mod tests {
             10,
         )
         .unwrap();
-        let heavy_vec = fuse_with_strategy(
+        let heavy_keyword = fuse_with_strategy(
             text,
             vec_hits,
             &FusionStrategy::Weighted {
@@ -283,8 +295,8 @@ mod tests {
         )
         .unwrap();
 
-        assert_eq!(heavy_text[0].entity_id, a);
-        assert_eq!(heavy_vec[0].entity_id, b);
+        assert_eq!(heavy_vector[0].entity_id, b);
+        assert_eq!(heavy_keyword[0].entity_id, a);
     }
 
     // 3. Weighted [7.0, 3.0] = Weighted [0.7, 0.3] (normalization)
@@ -346,18 +358,37 @@ mod tests {
     fn weighted_negative_weight_clamped() {
         let a = Uuid::new_v4();
         let text = vec![text_hit(a, 0.9, "a")];
-        // Negative vector weight → only text contributes
+        // Negative vector weight → only keyword/text contributes.
         let hits = fuse_with_strategy(
             text,
             vec![],
             &FusionStrategy::Weighted {
-                weights: vec![1.0, -0.5],
+                weights: vec![-0.5, 1.0],
             },
             10,
         )
         .unwrap();
         assert_eq!(hits.len(), 1);
         assert_eq!(hits[0].entity_id, a);
+    }
+
+    #[test]
+    fn weighted_empty_arm_keeps_canonical_position() {
+        let text_only = Uuid::new_v4();
+        let hits = fuse_with_strategy(
+            vec![text_hit(text_only, 0.9, "text")],
+            vec![],
+            &FusionStrategy::Weighted {
+                // Canonical [vector, keyword]: the only non-empty arm has zero weight.
+                weights: vec![1.0, 0.0],
+            },
+            10,
+        )
+        .unwrap();
+        assert!(
+            hits.is_empty(),
+            "dropping the empty vector arm would incorrectly rebind text to its weight"
+        );
     }
 
     // 6. Union returns max score per entity when same id appears in both lists
@@ -388,10 +419,65 @@ mod tests {
         assert!(hits[0].title.is_none());
     }
 
+    #[test]
+    fn keyword_only_drops_vector() {
+        let text_id = Uuid::new_v4();
+        let vector_id = Uuid::new_v4();
+        let hits = fuse_with_strategy(
+            vec![text_hit(text_id, 0.8, "text")],
+            vec![vector_hit(vector_id, 0.9)],
+            &FusionStrategy::KeywordOnly,
+            10,
+        )
+        .unwrap();
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].entity_id, text_id);
+        assert_eq!(hits[0].source, SearchSource::Text);
+    }
+
     // 8. Default strategy is Rrf{k:60}
     #[test]
     fn default_strategy_is_rrf_k60() {
         assert_eq!(FusionStrategy::default(), FusionStrategy::Rrf { k: 60 });
+    }
+
+    #[tokio::test]
+    async fn alive_filter_refills_top_k_from_the_ranked_candidate_pool() {
+        let rt = KhiveRuntime::memory().unwrap();
+        let tok = NamespaceToken::local();
+        let live = rt
+            .create_entity(
+                &tok,
+                "concept",
+                None,
+                "live refill candidate",
+                None,
+                None,
+                vec![],
+            )
+            .await
+            .unwrap();
+        let stale = Uuid::new_v4();
+        let fused = vec![
+            SearchHit {
+                entity_id: stale,
+                score: DeterministicScore::from_f64(0.9),
+                source: SearchSource::Text,
+                title: Some("stale".into()),
+                snippet: None,
+            },
+            SearchHit {
+                entity_id: live.id,
+                score: DeterministicScore::from_f64(0.8),
+                source: SearchSource::Text,
+                title: Some("live".into()),
+                snippet: None,
+            },
+        ];
+
+        let hits = rt.retain_alive_search_hits(&tok, fused, 1).await.unwrap();
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].entity_id, live.id);
     }
 
     // 9. Roundtrip serde preserves variant
@@ -405,6 +491,7 @@ mod tests {
             },
             FusionStrategy::Union,
             FusionStrategy::VectorOnly,
+            FusionStrategy::KeywordOnly,
         ];
         for strategy in cases {
             let json = serde_json::to_string(&strategy).expect("serialize");

--- a/crates/khive-runtime/src/retrieval.rs
+++ b/crates/khive-runtime/src/retrieval.rs
@@ -754,10 +754,12 @@ impl KhiveRuntime {
             vector_hits.retain(|hit| hit.score >= score_floor);
         }
 
-        // Keep the full candidate pool (untruncated) through the alive/kind/tag/property
-        // filter below, so matching hits ranked below `limit` in the raw fusion aren't
-        // lost when higher-ranked candidates get excluded by a filter.
-        let mut fused = rrf_fuse(text_hits, vector_hits, candidates as usize, query_text);
+        // Each arm fetched `candidates` independently, so their union can contain
+        // twice that many distinct IDs. Keep the complete fetched pool through
+        // ranking and the alive/kind/tag/property filters below; reusing one arm's
+        // cap here lets stale or filtered hits hide live candidates from the other.
+        let fusion_limit = text_hits.len().saturating_add(vector_hits.len());
+        let mut fused = rrf_fuse(text_hits, vector_hits, fusion_limit, query_text);
 
         // tags_any has a SQL column and is pushed into query_entities; properties
         // filtering has no SQL column and is applied in Rust below on the fetched records.
@@ -777,7 +779,7 @@ impl KhiveRuntime {
                     },
                     PageRequest {
                         offset: 0,
-                        limit: fused.len() as u32,
+                        limit: u32::try_from(fused.len()).unwrap_or(u32::MAX),
                     },
                 )
                 .await?;

--- a/docs/adr/ADR-012-retrieval-composition.md
+++ b/docs/adr/ADR-012-retrieval-composition.md
@@ -128,12 +128,14 @@ pub enum FusionStrategy {
 }
 ```
 
-Positional fusion sources and weights use one canonical order everywhere:
+The two-arm vector/text hybrid APIs use one positional order:
 `[vector, keyword]`. Both positions remain present when an arm is empty; deleting
 an empty arm would rebind the surviving source to the wrong positional weight.
 RRF, weighted, and union transforms still run when only one arm has results, so
 post-fusion score floors operate in the same score domain for one-arm and
-two-arm queries.
+two-arm queries. This order is not a global rule for the generic fusion
+primitive: N-engine fusion preserves engine-registry order (ADR-031), while
+dual-index migration uses `[primary, legacy]`.
 
 `Custom` is the openness mechanism. khive's memory pack registers a `decay_weighted`
 strategy that weights candidates by salience and time decay. A brain pack may register
@@ -263,7 +265,7 @@ IS NOT NULL) and superseded notes must not appear in retrieval results. The aliv
 is a single batch query against `EntityStore` or `NoteStore` after fusion:
 
 ```rust
-// After fusion ranks the over-fetched pool, before final top-k truncation.
+// Fuse up to the sum of all fetched arm lengths, then alive-check before top-k.
 let alive_set = entities.query_entities(
     token.namespace(),
     EntityFilter { ids: candidate_ids, ..Default::default() },
@@ -383,8 +385,10 @@ small RRF score range. `hybrid_search_with_strategy` uses the caller's strategy
 `khive-retrieval::HybridConfig` defaults to a 5× pool, while its higher-level
 balanced `SearchConfig`/query-IR preset uses 3×. These pool sizes are
 API-specific latency/quality policies rather than `FusionStrategy` semantics;
-all paths must retain their selected pool through post-fusion alive/filter
-checks before applying the final requested limit.
+all paths must retain the complete fetched pool through post-fusion alive/filter
+checks before applying the final requested limit. When two arms each fetch a
+pool, the fusion cap must admit their combined lengths rather than reusing one
+arm's pool size.
 
 **What v1 deliberately defers:**
 

--- a/docs/adr/ADR-012-retrieval-composition.md
+++ b/docs/adr/ADR-012-retrieval-composition.md
@@ -118,6 +118,8 @@ pub enum FusionStrategy {
     Union,
     /// Drop non-vector hits; return vector hits only.
     VectorOnly,
+    /// Drop non-keyword hits; return keyword hits only.
+    KeywordOnly,
     /// Pack-defined or user-defined custom strategy, dispatched by name.
     Custom {
         name: String,
@@ -125,6 +127,13 @@ pub enum FusionStrategy {
     },
 }
 ```
+
+Positional fusion sources and weights use one canonical order everywhere:
+`[vector, keyword]`. Both positions remain present when an arm is empty; deleting
+an empty arm would rebind the surviving source to the wrong positional weight.
+RRF, weighted, and union transforms still run when only one arm has results, so
+post-fusion score floors operate in the same score domain for one-arm and
+two-arm queries.
 
 `Custom` is the openness mechanism. khive's memory pack registers a `decay_weighted`
 strategy that weights candidates by salience and time decay. A brain pack may register
@@ -254,18 +263,20 @@ IS NOT NULL) and superseded notes must not appear in retrieval results. The aliv
 is a single batch query against `EntityStore` or `NoteStore` after fusion:
 
 ```rust
-// After fusion produces candidate IDs (namespace derived from NamespaceToken)
+// After fusion ranks the over-fetched pool, before final top-k truncation.
 let alive_set = entities.query_entities(
     token.namespace(),
     EntityFilter { ids: candidate_ids, ..Default::default() },
     PageRequest { offset: 0, limit: candidates.len() as u32 },
 ).await?;
 fused.retain(|h| alive_set.contains(&h.entity_id));
+fused.truncate(limit);
 ```
 
 This is the right layer for the check. Storage filters by `deleted_at IS NULL`; the
-runtime composes the check after fusion so the candidate pool stays large enough that
-filtering doesn't deplete top-K.
+runtime composes the check after fusion ranking but before final top-K truncation,
+so a stale high-ranked candidate cannot consume a returned slot while live
+candidates remain in the over-fetched pool.
 
 ### Cross-substrate retrieval
 
@@ -349,20 +360,31 @@ retrieval paths.
 
 **What v1 ships:**
 
-| Capability                                                                | Where it lives                                                 |
-| ------------------------------------------------------------------------- | -------------------------------------------------------------- |
-| RRF fusion (k configurable, default 60)                                   | `khive_score::rrf_score`, `khive-runtime::retrieval::rrf_fuse` |
-| Weighted linear fusion (min-max normalized)                               | `khive-runtime::fusion::fuse_with_strategy`                    |
-| `FusionStrategy` enum: `Rrf`, `Weighted`, `Union`, `VectorOnly`, `Custom` | `khive-runtime::fusion`                                        |
-| Custom strategy registration                                              | `khive-runtime::FusionRegistry`                                |
-| Hybrid search composition (vector + text)                                 | `khive-runtime::retrieval::hybrid_search`                      |
-| Strategy-parameterized hybrid search                                      | `khive-runtime::fusion::hybrid_search_with_strategy`           |
-| Graph BFS (depth-bounded, direction + relation filters)                   | `khive-runtime::graph_traversal::bfs_traverse`                 |
-| Bidirectional shortest-path                                               | `khive-runtime::graph_traversal::shortest_path`                |
-| Exact KNN                                                                 | `khive-runtime::retrieval::knn`                                |
-| Candidate-set rerank                                                      | `khive-runtime::retrieval::rerank`                             |
-| Cross-substrate search                                                    | `khive-runtime::retrieval::search_mixed`                       |
-| Alive-check after fusion                                                  | `khive-runtime::retrieval` (mandatory in every fusion path)    |
+| Capability                                                                               | Where it lives                                                    |
+| ---------------------------------------------------------------------------------------- | ----------------------------------------------------------------- |
+| Generic RRF fusion (k configurable, default 60)                                          | `khive_score::rrf_score`, `khive-fusion`, `khive-runtime::fusion` |
+| Weighted linear fusion (min-max normalized)                                              | `khive-runtime::fusion::fuse_with_strategy`                       |
+| `FusionStrategy` enum: `Rrf`, `Weighted`, `Union`, `VectorOnly`, `KeywordOnly`, `Custom` | `khive-runtime::fusion`                                           |
+| Custom strategy registration                                                             | `khive-runtime::FusionRegistry`                                   |
+| Hybrid search composition (vector + text)                                                | `khive-runtime::retrieval::hybrid_search`                         |
+| Strategy-parameterized hybrid search                                                     | `khive-runtime::fusion::hybrid_search_with_strategy`              |
+| Graph BFS (depth-bounded, direction + relation filters)                                  | `khive-runtime::graph_traversal::bfs_traverse`                    |
+| Bidirectional shortest-path                                                              | `khive-runtime::graph_traversal::shortest_path`                   |
+| Exact KNN                                                                                | `khive-runtime::retrieval::knn`                                   |
+| Candidate-set rerank                                                                     | `khive-runtime::retrieval::rerank`                                |
+| Cross-substrate search                                                                   | `khive-runtime::retrieval::search_mixed`                          |
+| Alive-check after fusion                                                                 | `khive-runtime::retrieval` (mandatory in every fusion path)       |
+
+The older entity-oriented `KhiveRuntime::hybrid_search` path is an explicit
+method-local exception to the generic RRF default: it uses fixed `k=10`, a 4×
+candidate pool, and a `0.5` exact-title boost so exact entity names dominate its
+small RRF score range. `hybrid_search_with_strategy` uses the caller's strategy
+(whose default RRF value is `k=60`) and a 4× pool. Reusable
+`khive-retrieval::HybridConfig` defaults to a 5× pool, while its higher-level
+balanced `SearchConfig`/query-IR preset uses 3×. These pool sizes are
+API-specific latency/quality policies rather than `FusionStrategy` semantics;
+all paths must retain their selected pool through post-fusion alive/filter
+checks before applying the final requested limit.
 
 **What v1 deliberately defers:**
 
@@ -424,8 +446,10 @@ becomes a natural composition, not a special-case feature.
 
 If the alive-check happens before fusion, the candidate pool may be depleted before
 ranking — top-K from a 200-candidate pool that's been pre-filtered to 50 candidates
-returns lower-quality results. Filtering after fusion preserves the candidate pool
-through ranking.
+returns lower-quality results. Fusion therefore ranks the complete over-fetched
+pool first. The alive-check then filters that ranked pool, and only afterward does
+the runtime truncate to top-K; truncating before the alive-check would underfill
+the response whenever a stale hit occupied a leading slot.
 
 The cost is one extra batch query per search. Acceptable for the quality gain.
 

--- a/docs/adr/ADR-031-multi-engine-retrieval.md
+++ b/docs/adr/ADR-031-multi-engine-retrieval.md
@@ -435,13 +435,14 @@ async fn handle_recall(args):
         per_engine_hits.push(filtered)
 
     # Step 3 — weighted RRF across engines
+    # Both arrays preserve registry declaration order: [engine_0, ..., engine_n].
     weights      = registry.engines().iter().map(|e| e.config.weight as f64).collect()
     vector_fused = khive_fusion::fuse(
         per_engine_hits, FusionStrategy::Weighted { weights }, candidate_pool_size)
 
     # Step 4 — layer FTS5 keyword path and final fusion
     text_hits = self.runtime.text(args.namespace).search(...)
-    fused     = fuse(vector_fused, text_hits, args.fusion_strategy, args.limit)
+    fused     = fuse([vector_fused, text_hits], args.fusion_strategy, args.limit)
 
     # Step 5 — pack-specific scoring
     return apply_pack_scoring(fused, args)
@@ -472,6 +473,12 @@ per-corpus retuning is operator responsibility.
 corpus. BGE's English semantic strength, mE5's multilingual coverage, Qwen3's instruction-
 tuned recall — operators set weights from empirical retrieval quality. `FusionStrategy::Weighted`
 already exists in `khive-fusion`; pack handlers wire `EngineConfig.weight` into it.
+
+The positional contract at this stage is N-engine registry order: the source at
+index `i` is weighted by the config at index `i`. The later two-arm hybrid stage
+uses `[combined_vector, text]` (the runtime/retrieval `[vector, keyword]`
+contract). Neither rule changes the dual-index migration router's independent
+`[primary, legacy]` contract.
 
 **This is engine-level weighted RRF — distinct from the backend-level unweighted RRF in
 ADR-029 §D4.** ADR-029's D4 fuses ranked lists across backends at the substrate-search layer,

--- a/docs/adr/ADR-033-recall-pipeline.md
+++ b/docs/adr/ADR-033-recall-pipeline.md
@@ -345,10 +345,10 @@ When `recall` is called without an explicit `embedding_model` parameter:
 3. `RecallCandidateSet.vector_hits_per_model` collects `(model_name, Vec<VectorSearchHit>)`
    tuples — one per model.
 4. `fuse_candidates` builds N vector sources (one per model) plus 1 text source and passes all
-   sources to `khive_retrieval::fuse_search_results`. For N=0 models an empty placeholder
-   source is prepended to maintain the 2-source layout required for consistent fusion
-   strategy behavior (RRF and Weighted do not apply their full algorithm to a single-source
-   input — `fuse_search_results` returns raw scores when `sources.len() == 1`).
+   sources to `khive_retrieval::fuse_search_results`. RRF and Union transform a singleton
+   source exactly as configured; there is no raw-score bypass. For N=0 models an empty vector
+   placeholder is still prepended so the two-arm `[vector, keyword]` positions remain explicit
+   for `VectorOnly`, `KeywordOnly`, and Weighted behavior instead of rebinding text to slot 0.
 
 **Wire shape:** `recall` always returns `[{id, score, ...}]`. The
 per-model vector breakdown is only exposed via the `recall.candidates` sub-handler's
@@ -361,7 +361,9 @@ vector store (single-model path). `recall.candidates` will not include
 **Strategy guidance for N > 1 models:** The shipped weighted fusion path first unions
 per-model vector hits into one combined vector source, then fuses `[combined_vector, text]`
 with the configured vector/text weights. `"rrf"` and `"union"` still accept N separate
-vector sources; `"weighted"` operates on the combined-vector plus text layout.
+vector sources in `vector_hits_per_model` order followed by text; `"weighted"` operates
+on the combined-vector plus text layout. This N-engine ordering is distinct from the
+dual-index router's `[primary, legacy]` migration contract.
 
 ### 7. Calibration protocol
 


### PR DESCRIPTION
## Summary

- apply the configured fusion transform to one-arm retrieval results before fused-domain score filtering
- standardize hybrid positional source and weight order as `[vector, keyword]`, retaining empty slots so weights never rebind to the wrong arm
- keep the full over-fetched runtime candidate pool through alive filtering and truncate only afterward, allowing live lower-ranked hits to refill top-k
- reconcile ADR-012 with the generic RRF default, the intentional exact-match entity-search exception, and API-specific candidate-pool policies

## Validation

- `cargo test --workspace`
- `cargo check --workspace`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `RUSTDOCFLAGS=-Dwarnings cargo doc --workspace --no-deps`

Closes #1329
Closes #1330
Closes #1331

> AI-assisted contribution: Codex prepared this change and PR description.
