### PR TITLE
fix(git): report per-source digest coverage

### DIFF
--- a/crates/khive-pack-git/docs/api/handlers.md
+++ b/crates/khive-pack-git/docs/api/handlers.md
@@ -19,3 +19,13 @@ classified `GitLogError` (the caller has already verified
 operate on the cache slot for `canonical_url`, which is the same path
 `_repo` already names (`crate::cache`'s slot layout is keyed by URL, not
 passed through).
+
+## GitHub source capability
+
+Before constructing `IngestOptions`, the `git.digest` handler resolves whether the
+selected source has a usable GitHub remote. Remote-URL sources reuse their parsed
+`gh_slug`; local sources inspect the configured `origin` through the same URL
+normalization rules. The original `include` selection is preserved when GitHub is
+unavailable so `run_ingest` can emit machine-readable `remote_not_github` outcomes
+for requested issue and pull-request sources. This source fact is independent of
+`gh_available`, which reports only whether the `gh` CLI probe succeeded.

--- a/crates/khive-pack-git/docs/api/ingest.md
+++ b/crates/khive-pack-git/docs/api/ingest.md
@@ -3,9 +3,10 @@
 Long-form rationale extracted from `crates/khive-pack-git/src/ingest.rs`
 doc-comments. Everything documented here is a non-public (private or
 `pub(crate)`) item — internal notes, not the published API reference (the
-crate's public surface — `IngestInclude`, `IngestOptions`, `IngestReport`,
-`run_ingest`, `resolve_project_id` — keeps its complete doc-comments in the
-source file itself).
+crate's public surface — `GithubRemoteCapability`, `IngestInclude`,
+`IngestOptions`, `IngestReport`, `IngestSourceOutcome`,
+`IngestSourceReason`, `IngestSourceState`, `run_ingest`, and
+`resolve_project_id` — keeps its complete doc-comments in the source file itself).
 
 ## Module overview
 
@@ -40,11 +41,37 @@ excerpt. It never includes the rejected content. Accounting is per ingest call r
 than process-global daemon telemetry, so a caller can reliably assert
 `writes_refused == 0` even when other digests run concurrently.
 
+## GitHub source coverage
+
+`IngestReport::gh_available` is narrowly the result of the `gh --version`
+CLI-presence probe. Repository capability and query execution are reported
+separately through `IngestReport::issues` and
+`IngestReport::pull_requests`, each an `IngestSourceOutcome` containing
+`state`, `reason`, and `count`.
+
+`state=ingested` has `reason=null`; its count includes records newly ingested
+or already present. `state=skipped` always names `not_requested`,
+`gh_cli_absent`, `remote_not_github`, or `budget_exhausted`.
+`state=failed` names `gh_error` and retains the count successfully handled
+before the failure. This makes an empty successful query (`ingested`, count
+zero) distinct from a source that was never reached.
+
+`IngestOptions::github_remote` carries a source resolver's knowledge into the
+shared ingest core. `git.digest` always supplies `Usable` or `Unavailable`:
+remote URLs already carry `gh_slug`, while local paths inspect their
+configured `origin` through `source::github_remote_usable`. The public
+`IngestOptions::unbounded` constructor uses `Unknown` for historical direct
+callers, which lets the `gh` command itself determine usability and reports a
+command failure as `gh_error`.
+
+The human-readable warnings remain, and `IngestReport::done` remains strictly
+the budget/cursor completion signal. It is not a coverage indicator.
+
 ## `NewRecordForRef`
 
 A newly created note this pass, retained so the post-ingestion
 reference-extraction sweep (`link_references`) can resolve cross-references
-between records created in the *same* pass regardless of ingestion order
+between records created in the _same_ pass regardless of ingestion order
 (PRs and issues are ingested before commits) without re-reading them from
 storage.
 
@@ -80,7 +107,7 @@ namespace (matches the by-ID resolution contract used by `get`/`update`).
 ## `link_references`
 
 Post-ingestion sweep (ADR-088 Amendment 1 ingest enrichment): extracts
-GitHub reference-grammar mentions from every note created *this pass*
+GitHub reference-grammar mentions from every note created _this pass_
 (commits, issues, PRs — order-independent, since all three are already in
 `new_records` by the time this runs) and materializes `annotates` edges to
 the referenced issue/PR note, carrying `ref_kind` ("closes" | "mentions")
@@ -169,7 +196,7 @@ available), and any other error (including an unclassified `GitLogError` or
 a non-`GitLogError` failure) is returned immediately without ever calling
 `recover`. A later repair attempt's strategy replaces the pending warning
 rather than accumulating one per attempt, so exactly one success warning is
-ever returned — describing the *last* repair that was needed, not every
+ever returned — describing the _last_ repair that was needed, not every
 one tried.
 
 ## Masking boundaries (`MaskedCommitFields`, `MaskedIssueFields`, `MaskedPrFields`)

--- a/crates/khive-pack-git/src/handlers.rs
+++ b/crates/khive-pack-git/src/handlers.rs
@@ -17,11 +17,11 @@ use khive_storage::types::{SqlStatement, SqlValue};
 use crate::cache::{self, CacheError};
 use crate::ingest::{
     resolve_project_id, run_ingest, run_ingest_with_commit_recovery, CacheRepairStrategy,
-    GitLogError, IngestInclude, IngestOptions, RecoveredRepo,
+    GitLogError, GithubRemoteCapability, IngestInclude, IngestOptions, RecoveredRepo,
 };
 use crate::source::{
-    parse_source, redact_repo_url, remote_url_to_slug, repo_basename, repo_identity, DigestSource,
-    REPO_SLUG_PROPERTY,
+    github_remote_usable, parse_source, redact_repo_url, remote_url_to_slug, repo_basename,
+    repo_identity, DigestSource, REPO_SLUG_PROPERTY,
 };
 use crate::GitPack;
 
@@ -132,12 +132,17 @@ impl GitPack {
             Some(v) => parse_include(v)?,
         };
 
-        let mut warnings: Vec<String> = Vec::new();
-
         // Resolve a local repo path -- remote sources clone/fetch into the
         // scratch cache first (ADR-088 Amendment 1 §Remote-URL mode).
-        let (repo_path, gh_capable) = match &source {
-            DigestSource::Local(p) => (p.clone(), true),
+        let (repo_path, github_remote) = match &source {
+            DigestSource::Local(p) => {
+                let capability = if github_remote_usable(&source).await {
+                    GithubRemoteCapability::Usable
+                } else {
+                    GithubRemoteCapability::Unavailable
+                };
+                (p.clone(), capability)
+            }
             DigestSource::Remote { canonical, gh_slug } => {
                 let cloned = cache::ensure_clone(canonical).map_err(|e| {
                     RuntimeError::InvalidInput(format!(
@@ -145,14 +150,12 @@ impl GitPack {
                         redact_repo_url(canonical)
                     ))
                 })?;
-                if gh_slug.is_none() {
-                    warnings.push(format!(
-                        "host for {:?} is not github.com; issue/pull_request \
-                         ingestion is skipped (commits-only degradation, ADR-088 Amendment 1)",
-                        redact_repo_url(canonical)
-                    ));
-                }
-                (cloned, gh_slug.is_some())
+                let capability = if gh_slug.is_some() {
+                    GithubRemoteCapability::Usable
+                } else {
+                    GithubRemoteCapability::Unavailable
+                };
+                (cloned, capability)
             }
         };
 
@@ -179,17 +182,12 @@ impl GitPack {
         let project_id = resolution.id;
         let project_created = resolution.created;
 
-        let effective_include = IngestInclude {
-            commits: include.commits,
-            issues: include.issues && gh_capable,
-            pull_requests: include.pull_requests && gh_capable,
-        };
-
         let opts = IngestOptions {
             repo: repo_path,
             project: project_id.to_string(),
             max_items: Some(max_items),
-            include: effective_include,
+            include,
+            github_remote,
         };
 
         // Only a remote-URL source has a disposable cache to repair (ADR-088
@@ -207,7 +205,6 @@ impl GitPack {
         }
         .map_err(|e| RuntimeError::InvalidInput(e.to_string()))?;
 
-        report.warnings.extend(warnings);
         if !resolution.slug_duplicates.is_empty() {
             report.warnings.push(format!(
                 "multiple live project anchors match the same repo identity; selected oldest {}; duplicates: {}",

--- a/crates/khive-pack-git/src/ingest.rs
+++ b/crates/khive-pack-git/src/ingest.rs
@@ -40,6 +40,20 @@ impl Default for IngestInclude {
     }
 }
 
+/// What the caller knows about whether the repository has a GitHub remote.
+///
+/// `Unknown` preserves the shared ingester's historical behavior: invoke
+/// `gh` and let that command report whether the current repository is usable.
+/// The `git.digest` handler resolves local and remote sources before calling
+/// the ingester, so its agent-facing report always uses `Usable` or
+/// `Unavailable` instead.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GithubRemoteCapability {
+    Unknown,
+    Usable,
+    Unavailable,
+}
+
 /// Options for one ingest pass.
 #[derive(Debug, Clone)]
 pub struct IngestOptions {
@@ -53,6 +67,8 @@ pub struct IngestOptions {
     pub max_items: Option<u64>,
     /// Which record kinds to ingest this pass.
     pub include: IngestInclude,
+    /// Whether the repository has a remote the `gh` CLI can serve.
+    pub github_remote: GithubRemoteCapability,
 }
 
 impl IngestOptions {
@@ -64,6 +80,7 @@ impl IngestOptions {
             project,
             max_items: None,
             include: IngestInclude::default(),
+            github_remote: GithubRemoteCapability::Unknown,
         }
     }
 }
@@ -114,6 +131,70 @@ pub struct IngestWriteRefusal {
     pub masked: String,
 }
 
+/// Machine-readable coverage state for one optional GitHub source.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum IngestSourceState {
+    Ingested,
+    Skipped,
+    Failed,
+}
+
+/// Why an optional GitHub source was skipped or failed.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum IngestSourceReason {
+    NotRequested,
+    GhCliAbsent,
+    RemoteNotGithub,
+    GhError,
+    BudgetExhausted,
+}
+
+/// Outcome for one issue/PR source in this ingest pass.
+///
+/// `count` is the number of records successfully handled as either newly
+/// ingested or already present. A successful empty query is therefore
+/// `ingested` with count zero, distinct from every skip/failure state.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct IngestSourceOutcome {
+    pub state: IngestSourceState,
+    pub reason: Option<IngestSourceReason>,
+    pub count: u64,
+}
+
+impl IngestSourceOutcome {
+    fn ingested(count: u64) -> Self {
+        Self {
+            state: IngestSourceState::Ingested,
+            reason: None,
+            count,
+        }
+    }
+
+    fn skipped(reason: IngestSourceReason) -> Self {
+        Self {
+            state: IngestSourceState::Skipped,
+            reason: Some(reason),
+            count: 0,
+        }
+    }
+
+    fn failed(reason: IngestSourceReason, count: u64) -> Self {
+        Self {
+            state: IngestSourceState::Failed,
+            reason: Some(reason),
+            count,
+        }
+    }
+}
+
+impl Default for IngestSourceOutcome {
+    fn default() -> Self {
+        Self::skipped(IngestSourceReason::NotRequested)
+    }
+}
+
 /// Outcome of one ingest pass. Serializable so CLI callers can emit it as JSON.
 #[derive(Debug, Default, Serialize)]
 pub struct IngestReport {
@@ -123,9 +204,14 @@ pub struct IngestReport {
     pub issues_skipped_existing: u64,
     pub prs_ingested: u64,
     pub prs_skipped_existing: u64,
-    /// `false` when the `gh` CLI was not found on PATH — issues/PRs were
-    /// skipped but commits still ingested (ADR-088 §5 graceful-absence rule).
+    /// Whether the `gh --version` CLI-presence probe succeeded. This says
+    /// nothing about remote usability or per-source success; inspect
+    /// `issues` and `pull_requests` for those outcomes.
     pub gh_available: bool,
+    /// Machine-readable issue-source coverage for this pass.
+    pub issues: IngestSourceOutcome,
+    /// Machine-readable pull-request-source coverage for this pass.
+    pub pull_requests: IngestSourceOutcome,
     pub warnings: Vec<String>,
     /// Number of per-record content writes refused by the runtime secret gate
     /// during this pass. Callers can assert this is zero independently of
@@ -245,6 +331,7 @@ pub(crate) async fn run_ingest_with_commit_recovery(
         done: true,
         ..IngestReport::default()
     };
+    report.gh_available = gh_cli_available(&opts.repo);
 
     let project_id = resolve_id(runtime, token, &opts.project)
         .await?
@@ -258,59 +345,103 @@ pub(crate) async fn run_ingest_with_commit_recovery(
     };
     let mut new_records: Vec<NewRecordForRef> = Vec::new();
 
-    // Graceful degradation covers both "gh is not on PATH" and "gh is present
-    // but this repo has no usable GitHub remote" (e.g. a synthetic/local-only
-    // repo) — either way, issues/PRs are skipped with a warning and commits
-    // still ingest (ADR-088 §5). A hard `gh` failure must never abort the
-    // whole pass.
+    // Graceful degradation keeps issue/PR source coverage explicit while
+    // commits continue. `done` remains solely the budget/cursor contract;
+    // callers inspect these source outcomes for remote coverage (#1617).
     if opts.include.issues || opts.include.pull_requests {
-        if gh_available(&opts.repo) {
-            report.gh_available = true;
-            if opts.include.pull_requests && !budget.exhausted() {
-                match ingest_prs(
-                    runtime,
-                    token,
-                    registry,
-                    &opts.repo,
-                    project_id,
-                    &mut report,
-                    &mut merge_sha_to_pr,
-                    &mut number_to_pr,
-                    &mut budget,
-                    &mut new_records,
-                )
-                .await
-                {
-                    Ok(()) => {}
-                    Err(e) => report
-                        .warnings
-                        .push(format!("gh pr list failed, skipping pull requests: {e}")),
-                }
+        if opts.github_remote == GithubRemoteCapability::Unavailable {
+            if opts.include.pull_requests {
+                report.pull_requests =
+                    IngestSourceOutcome::skipped(IngestSourceReason::RemoteNotGithub);
             }
-            if opts.include.issues && !budget.exhausted() {
-                if let Err(e) = ingest_issues(
-                    runtime,
-                    token,
-                    registry,
-                    &opts.repo,
-                    project_id,
-                    &mut report,
-                    &mut budget,
-                    &mut new_records,
-                )
-                .await
-                {
-                    report
-                        .warnings
-                        .push(format!("gh issue list failed, skipping issues: {e}"));
-                }
+            if opts.include.issues {
+                report.issues = IngestSourceOutcome::skipped(IngestSourceReason::RemoteNotGithub);
             }
-        } else {
-            report.gh_available = false;
             report.warnings.push(
-                "gh CLI not found on PATH; skipped issues and pull requests — commits still ingest"
+                "repository has no github.com remote usable by gh; skipped requested issues and pull requests — commits still ingest"
                     .to_string(),
             );
+        } else if !report.gh_available {
+            if opts.include.pull_requests {
+                report.pull_requests =
+                    IngestSourceOutcome::skipped(IngestSourceReason::GhCliAbsent);
+            }
+            if opts.include.issues {
+                report.issues = IngestSourceOutcome::skipped(IngestSourceReason::GhCliAbsent);
+            }
+            report.warnings.push(
+                "gh CLI not found on PATH; skipped requested issues and pull requests — commits still ingest"
+                    .to_string(),
+            );
+        } else {
+            if opts.include.pull_requests {
+                if budget.exhausted() {
+                    report.pull_requests =
+                        IngestSourceOutcome::skipped(IngestSourceReason::BudgetExhausted);
+                } else {
+                    let outcome = ingest_prs(
+                        runtime,
+                        token,
+                        registry,
+                        &opts.repo,
+                        project_id,
+                        &mut report,
+                        &mut merge_sha_to_pr,
+                        &mut number_to_pr,
+                        &mut budget,
+                        &mut new_records,
+                    )
+                    .await;
+                    let count = report
+                        .prs_ingested
+                        .saturating_add(report.prs_skipped_existing);
+                    match outcome {
+                        Ok(()) => {
+                            report.pull_requests = IngestSourceOutcome::ingested(count);
+                        }
+                        Err(e) => {
+                            report.pull_requests =
+                                IngestSourceOutcome::failed(IngestSourceReason::GhError, count);
+                            report
+                                .warnings
+                                .push(format!("gh pr list failed, skipping pull requests: {e}"));
+                        }
+                    }
+                }
+            }
+            if opts.include.issues {
+                if budget.exhausted() {
+                    report.issues =
+                        IngestSourceOutcome::skipped(IngestSourceReason::BudgetExhausted);
+                } else {
+                    let outcome = ingest_issues(
+                        runtime,
+                        token,
+                        registry,
+                        &opts.repo,
+                        project_id,
+                        &mut report,
+                        &mut budget,
+                        &mut new_records,
+                    )
+                    .await;
+                    let count = report
+                        .issues_ingested
+                        .saturating_add(report.issues_skipped_existing);
+                    match outcome {
+                        Ok(()) => {
+                            report.issues = IngestSourceOutcome::ingested(count);
+                        }
+                        Err(e) => {
+                            report.issues =
+                                IngestSourceOutcome::failed(IngestSourceReason::GhError, count);
+                            report
+                                .warnings
+                                .push(format!("gh issue list failed, skipping issues: {e}"));
+                        }
+                    }
+                }
+            }
         }
     }
 
@@ -460,8 +591,9 @@ async fn link_references(
     }
 }
 
-/// `true` when `gh` is on PATH and can run inside `repo`.
-fn gh_available(repo: &Path) -> bool {
+/// `true` when the `gh` executable is present and its version probe succeeds.
+/// Remote usability is reported separately through per-source outcomes.
+fn gh_cli_available(repo: &Path) -> bool {
     Command::new("gh")
         .arg("--version")
         .current_dir(repo)

--- a/crates/khive-pack-git/src/recovery_tests.rs
+++ b/crates/khive-pack-git/src/recovery_tests.rs
@@ -208,6 +208,7 @@ fn commits_only_opts(
             issues: false,
             pull_requests: false,
         },
+        github_remote: crate::ingest::GithubRemoteCapability::Unknown,
     }
 }
 

--- a/crates/khive-pack-git/src/source.rs
+++ b/crates/khive-pack-git/src/source.rs
@@ -352,6 +352,25 @@ async fn local_origin_remote_url(canonical_repo_path: &Path) -> Option<String> {
     .flatten()
 }
 
+/// Whether `source` names a repository that the `gh` CLI can serve.
+///
+/// Remote URL sources carry this fact from `parse_source`. Local sources
+/// derive it from their configured `origin`, accepting every Git remote
+/// spelling that `remote_url_to_slug` normalizes. CLI presence is a separate
+/// capability reported by the ingester.
+pub async fn github_remote_usable(source: &DigestSource) -> bool {
+    match source {
+        DigestSource::Remote { gh_slug, .. } => gh_slug.is_some(),
+        DigestSource::Local(path) => {
+            let canonical = std::fs::canonicalize(path).unwrap_or_else(|_| path.clone());
+            local_origin_remote_url(&canonical)
+                .await
+                .and_then(|origin| remote_url_to_slug(&origin))
+                .is_some_and(|slug| slug.split('/').next() == Some("github.com"))
+        }
+    }
+}
+
 /// Resolve the canonical repo-anchor identity (issue #1173) for a digest
 /// source -- the value stored in `properties.repo_slug` and matched on by
 /// `resolve_or_create_project`.
@@ -704,6 +723,31 @@ mod tests {
                 .expect("spawn git");
             assert!(status.success(), "git {args:?} failed");
         }
+    }
+
+    #[tokio::test]
+    async fn github_remote_capability_uses_local_origin_host() {
+        let github = tempfile::tempdir().expect("github tempdir");
+        init_repo_with_origin(github.path(), "git@github.com:org/repo.git");
+        assert!(github_remote_usable(&DigestSource::Local(github.path().to_path_buf())).await);
+
+        let gitlab = tempfile::tempdir().expect("gitlab tempdir");
+        init_repo_with_origin(gitlab.path(), "https://gitlab.com/org/repo.git");
+        assert!(!github_remote_usable(&DigestSource::Local(gitlab.path().to_path_buf())).await);
+    }
+
+    #[tokio::test]
+    async fn github_remote_capability_is_false_without_origin() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let status = Command::new("git")
+            .arg("-C")
+            .arg(dir.path())
+            .args(["init", "-q"])
+            .status()
+            .expect("spawn git init");
+        assert!(status.success());
+
+        assert!(!github_remote_usable(&DigestSource::Local(dir.path().to_path_buf())).await);
     }
 
     #[tokio::test]

--- a/crates/khive-pack-git/tests/acceptance.rs
+++ b/crates/khive-pack-git/tests/acceptance.rs
@@ -13,7 +13,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, LazyLock, Mutex};
 
 use async_trait::async_trait;
-use khive_pack_git::ingest::{run_ingest, IngestOptions};
+use khive_pack_git::ingest::{run_ingest, IngestOptions, IngestSourceReason, IngestSourceState};
 use khive_pack_git::GitPack;
 use khive_pack_kg::KgPack;
 use khive_runtime::{
@@ -2069,6 +2069,49 @@ async fn issue_and_pr_idempotency_is_scoped_per_project() {
 
 // ── gh boundary contract + per-record warning aggregation ───────────────────
 
+#[tokio::test]
+async fn gh_command_failure_has_a_structured_source_outcome() {
+    let _guard = ENV_MUTEX.lock().await;
+    let (rt, token, registry) = fixture().await;
+    let project_id = create(
+        &registry,
+        json!({"kind": "project", "name": "gh-failure-repo"}),
+    )
+    .await;
+
+    let dir = tempfile::tempdir().expect("tempdir");
+    let repo = dir.path().join("repo");
+    std::fs::create_dir_all(&repo).expect("mk repo dir");
+    init_repo(&repo);
+    let bin_dir = dir.path().join("bin");
+    std::fs::create_dir_all(&bin_dir).expect("mk bin dir");
+    let log_dir = dir.path().join("log");
+    std::fs::create_dir_all(&log_dir).expect("mk log dir");
+    write_fake_gh(&bin_dir, &log_dir, "not-json", "[]");
+    let _path_guard = PathGuard::install(&bin_dir);
+
+    let mut opts = IngestOptions::unbounded(repo, project_id.to_string());
+    opts.include.commits = false;
+    opts.include.issues = false;
+    let report = run_ingest(&rt, &token, &registry, opts)
+        .await
+        .expect("a gh source failure stays in-band");
+
+    assert!(report.gh_available, "the fake CLI probe succeeded");
+    assert_eq!(report.pull_requests.state, IngestSourceState::Failed);
+    assert_eq!(
+        report.pull_requests.reason,
+        Some(IngestSourceReason::GhError)
+    );
+    assert_eq!(report.pull_requests.count, 0);
+    assert_eq!(report.issues.state, IngestSourceState::Skipped);
+    assert_eq!(report.issues.reason, Some(IngestSourceReason::NotRequested));
+    assert!(report
+        .warnings
+        .iter()
+        .any(|warning| warning.contains("gh pr list failed")));
+}
+
 /// End-to-end over a PATH-shadowing fake `gh`: locks the four demo-found
 /// regression classes ((a) no `-C`, correct cwd; (b) empty `stateReason`
 /// omitted; (c) uppercase enum values lowercased; (d) all four governed
@@ -2145,10 +2188,16 @@ async fn gh_boundary_contract_and_partial_ingest_failure() {
         "fake gh must be found on PATH: {report:?}"
     );
     assert_eq!(report.prs_ingested, 1, "{report:?}");
+    assert_eq!(report.pull_requests.state, IngestSourceState::Ingested);
+    assert_eq!(report.pull_requests.reason, None);
+    assert_eq!(report.pull_requests.count, 1);
     assert_eq!(
         report.issues_ingested, 5,
         "5 of 6 issues land, #3 warns-and-skips: {report:?}"
     );
+    assert_eq!(report.issues.state, IngestSourceState::Ingested);
+    assert_eq!(report.issues.reason, None);
+    assert_eq!(report.issues.count, 5);
     assert_eq!(
         report
             .warnings
@@ -2990,6 +3039,72 @@ async fn pr_ingest_retries_tie_at_cursor_timestamp() {
 
 // ── `git.digest` verb (ADR-088 Amendment 1) ─────────────────────────────────
 
+#[tokio::test]
+async fn digest_verb_reports_non_github_source_skips_even_when_gh_is_installed() {
+    let _guard = ENV_MUTEX.lock().await;
+    let (_rt, _token, registry) = fixture().await;
+
+    let dir = tempfile::tempdir().expect("tempdir");
+    let repo = dir.path().join("repo");
+    std::fs::create_dir_all(&repo).expect("mk repo dir");
+    init_repo(&repo);
+    git(
+        &repo,
+        &[
+            "remote",
+            "add",
+            "origin",
+            "https://gitlab.com/example/non-github-repo.git",
+        ],
+    );
+
+    let bin_dir = dir.path().join("bin");
+    std::fs::create_dir_all(&bin_dir).expect("mk bin dir");
+    let log_dir = dir.path().join("log");
+    std::fs::create_dir_all(&log_dir).expect("mk log dir");
+    write_fake_gh(&bin_dir, &log_dir, "[]", "[]");
+    let _path_guard = PathGuard::install(&bin_dir);
+
+    let result = registry
+        .dispatch(
+            "git.digest",
+            json!({
+                "source": repo.to_str().expect("utf-8 repo path"),
+                "max_items": 10,
+                "include": ["issues", "pull_requests"]
+            }),
+        )
+        .await
+        .expect("non-GitHub degradation stays in-band");
+
+    assert_eq!(result["gh_available"], true, "the fake gh CLI is present");
+    assert_eq!(
+        result["issues"],
+        json!({"state": "skipped", "reason": "remote_not_github", "count": 0})
+    );
+    assert_eq!(
+        result["pull_requests"],
+        json!({"state": "skipped", "reason": "remote_not_github", "count": 0})
+    );
+    assert_eq!(result["done"], true, "done remains a cursor/budget signal");
+    assert!(result["warnings"]
+        .as_array()
+        .expect("warnings array")
+        .iter()
+        .any(|warning| warning
+            .as_str()
+            .is_some_and(|text| text.contains("no github.com remote"))));
+
+    let args_log = std::fs::read_to_string(log_dir.join("args.log")).expect("read args log");
+    assert!(args_log.lines().any(|line| line == "--version"));
+    assert!(
+        !args_log
+            .lines()
+            .any(|line| line.starts_with("pr ") || line.starts_with("issue ")),
+        "remote-not-GitHub must skip source commands: {args_log}"
+    );
+}
+
 /// End-to-end over the `git.digest` verb itself (not `run_ingest` directly):
 /// no `project` argument auto-creates the repo-anchor entity (reported via
 /// `project_created`), a `Closes #N` commit message materializes an
@@ -3161,6 +3276,15 @@ async fn digest_verb_counts_and_describes_partial_secret_gate_refusals() {
     let repo: PathBuf = dir.path().join("repo");
     std::fs::create_dir_all(&repo).expect("mk repo dir");
     init_repo(&repo);
+    git(
+        &repo,
+        &[
+            "remote",
+            "add",
+            "origin",
+            "https://github.com/example/refusal-accounting-repo.git",
+        ],
+    );
 
     let bin_dir = dir.path().join("bin");
     std::fs::create_dir_all(&bin_dir).expect("mk bin dir");

--- a/docs/adr/ADR-088-amendment-1-git-digest.md
+++ b/docs/adr/ADR-088-amendment-1-git-digest.md
@@ -63,6 +63,30 @@ copies the rejected content. Per-record refusal remains non-fatal so the pass ca
 all affected records and ingest clean siblings, but a caller requiring a clean run must
 assert `writes_refused == 0` as well as loop until `done == true`.
 
+### Per-source coverage amendment (issue #1617, 2026-08-01)
+
+`gh_available` reports only whether the `gh --version` CLI-presence probe succeeded. It
+does not claim that the repository has a GitHub remote or that either GitHub query ran.
+The report adds `issues` and `pull_requests` outcome objects with this stable shape:
+
+```json
+{ "state": "ingested|skipped|failed", "reason": null, "count": 0 }
+```
+
+- `ingested` means the source query ran; `reason` is null. `count` is the number of
+  records successfully handled as newly ingested or already present, so a successful
+  empty repository is mechanically distinct from an unreached source.
+- `skipped` always carries one of `not_requested`, `gh_cli_absent`,
+  `remote_not_github`, or `budget_exhausted`.
+- `failed` carries `gh_error`; its count preserves records successfully handled before
+  the source failure.
+
+For a local path, GitHub capability is derived from the configured `origin` using the
+same normalized remote grammar as repo-anchor identity. A non-GitHub or missing origin
+therefore degrades requested issue/PR sources to `remote_not_github` even when `gh` is
+installed. Human-readable warnings remain additive. `done` is unchanged: it reports
+budget/cursor exhaustion only and must not be interpreted as source coverage.
+
 ### Remote-URL mode
 
 1. Clone to a daemon-owned scratch directory (`~/.khive/scratch/git-digest/<hash>/`),

--- a/docs/guide/api-reference.md
+++ b/docs/guide/api-reference.md
@@ -1804,6 +1804,14 @@ diagnostic names the attempted `verb`, the provenance `record_kind` and natural
 Because a digest continues after a per-record refusal, callers that require a clean run
 should assert `writes_refused == 0` in addition to waiting for `done == true`.
 
+`gh_available` reports only whether the `gh --version` presence probe succeeds.
+Inspect the separate `issues` and `pull_requests` objects for source coverage. Each reports
+`state` (`ingested`, `skipped`, or `failed`), a machine-readable `reason`, and the
+number of records successfully handled. Skip reasons are `not_requested`,
+`gh_cli_absent`, `remote_not_github`, and `budget_exhausted`; command failures use
+`gh_error`. A successful empty query is `ingested` with count 0. The top-level `done`
+field remains a cursor/budget signal, not a coverage claim.
+
 ### `git.commit` / `git.branch` / `git.push` — Commissive (ADR-108)
 
 Thin write verbs that shell to system git (`std::process::Command::args`, no shell


### PR DESCRIPTION
## Summary

- make `git.digest` report stable machine-readable outcome objects for the issue and pull-request sources, including `status`, `reason`, and `count`
- reserve `gh_available` for the GitHub CLI presence probe and report remote compatibility, command failures, budget exhaustion, and caller opt-out through the per-source outcomes
- preserve the existing human warnings, item budget, cursor semantics, and aggregate `done` meaning while documenting the additive contract in ADR-088 and the public API guide

## Source outcomes

- `ingested`: the source command succeeded, including a valid empty result
- `skipped`: `not_requested`, `remote_not_github`, `gh_cli_absent`, or `budget_exhausted`
- `failed`: the source command failed with `gh_error`

The two source objects are independent, so partial coverage no longer has to be inferred from `gh_available`, warnings, or a zero aggregate count.

## Validation

- `cargo test --manifest-path crates/Cargo.toml -p khive-pack-git` (216 unit tests and 57 acceptance tests)
- `cargo test --manifest-path crates/Cargo.toml --workspace`
- `cargo check --manifest-path crates/Cargo.toml --workspace`
- `cargo clippy --manifest-path crates/Cargo.toml --workspace --all-targets -- -D warnings`
- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `RUSTDOCFLAGS=-Dwarnings cargo doc --manifest-path crates/Cargo.toml --workspace --no-deps`

Closes #1617.

> AI-assisted contribution: Codex prepared this change and PR description.
