### PR TITLE
feat(git): expose commit path provenance

### DIFF
--- a/crates/khive-pack-git/docs/api/hooks.md
+++ b/crates/khive-pack-git/docs/api/hooks.md
@@ -19,7 +19,9 @@ In addition to the governed SHA, parent, and short-SHA shapes,
 validated when present. It must be an array of non-empty, repository-relative
 `/`-separated strings without empty, `.` or `..` components, and the array
 must already be sorted and deduplicated. The git ingester always supplies that
-canonical shape, including `[]` for an empty commit.
+canonical shape, including `[]` for an empty commit. POSIX-absolute paths and
+the Windows absolute shapes (drive-letter with either separator, `\\`-prefixed
+UNC) are rejected.
 
 ## `IssueLikeHook`
 

--- a/crates/khive-pack-git/docs/api/hooks.md
+++ b/crates/khive-pack-git/docs/api/hooks.md
@@ -16,12 +16,13 @@ generic `create(kind=..., annotates=[...])` call; the runtime's own
 
 In addition to the governed SHA, parent, and short-SHA shapes,
 `properties.changed_paths` is optional for manually created commit notes but
-validated when present. It must be an array of non-empty, repository-relative
-`/`-separated strings without empty, `.` or `..` components, and the array
-must already be sorted and deduplicated. The git ingester always supplies that
-canonical shape, including `[]` for an empty commit. POSIX-absolute paths and
-the Windows absolute shapes (drive-letter with either separator, `\\`-prefixed
-UNC) are rejected.
+validated when present. An explicit JSON `null` is treated the same as an
+absent property. When present, it must be an array of non-empty,
+repository-relative `/`-separated strings without empty, `.` or `..`
+components, and the array must already be sorted and deduplicated. The git
+ingester always supplies that canonical shape, including `[]` for an empty
+commit. POSIX-absolute paths, any path containing a backslash, and any `X:`
+drive prefix (absolute or drive-relative) are rejected.
 
 ## `IssueLikeHook`
 

--- a/crates/khive-pack-git/docs/api/hooks.md
+++ b/crates/khive-pack-git/docs/api/hooks.md
@@ -5,12 +5,21 @@ Extracted from `crates/khive-pack-git/src/hook.rs` doc-comments.
 ## Module overview
 
 Validation only — this pack introduces no new edges at `after_create` time.
-Provenance edges (`annotates` -> project / document / merging PR) are
+Provenance edges (`annotates` -> project / document / code module / merging PR) are
 supplied by the caller (the ingester, see `src/ingest.rs`) as part of the
 generic `create(kind=..., annotates=[...])` call; the runtime's own
 `create_note` path validates and links them atomically, so no
 `after_create` edge-creation logic is needed here (unlike gtd's
 `TaskHook::after_create`).
+
+## `CommitHook`
+
+In addition to the governed SHA, parent, and short-SHA shapes,
+`properties.changed_paths` is optional for manually created commit notes but
+validated when present. It must be an array of non-empty, repository-relative
+`/`-separated strings without empty, `.` or `..` components, and the array
+must already be sorted and deduplicated. The git ingester always supplies that
+canonical shape, including `[]` for an empty commit.
 
 ## `IssueLikeHook`
 

--- a/crates/khive-pack-git/docs/api/hooks.md
+++ b/crates/khive-pack-git/docs/api/hooks.md
@@ -21,8 +21,13 @@ absent property. When present, it must be an array of non-empty,
 repository-relative `/`-separated strings without empty, `.` or `..`
 components, and the array must already be sorted and deduplicated. The git
 ingester always supplies that canonical shape, including `[]` for an empty
-commit. POSIX-absolute paths, any path containing a backslash, and any `X:`
-drive prefix (absolute or drive-relative) are rejected.
+commit, except that the property is omitted when the raw touched set was
+non-empty but every path was filtered as non-canonical — the all-filtered
+third state named by
+`docs/api/ingest.md#changed-paths-and-code-module-annotations` (the hook's
+optional treatment above is what keeps the omitted shape valid). POSIX-absolute
+paths, any path containing a backslash, and any `X:` drive prefix (absolute or
+drive-relative) are rejected.
 
 ## `IssueLikeHook`
 

--- a/crates/khive-pack-git/docs/api/ingest.md
+++ b/crates/khive-pack-git/docs/api/ingest.md
@@ -316,8 +316,17 @@ The commit snapshot's `git log -z --name-only --no-renames
 --diff-merges=first-parent` pass is the authority for
 `commit.properties.changed_paths`. NUL-delimited paths bypass Git's quoted
 display encoding and are decoded with the same lossy UTF-8 normalization as
-ADR-085's filesystem path producer. Tabs, newlines, quotes, backslashes, and
-non-ASCII text therefore retain their path identity. Rename detection is
+ADR-085's filesystem path producer. At this parse stage tabs, newlines,
+quotes, backslashes, and non-ASCII text retain their path identity — but
+parsing identity is not storage identity. `changed_paths` storage is
+governed by `CommitHook`'s canonical repo-relative shape (see
+docs/api/hooks.md): a valid Unix filename containing a `\` byte or starting
+with an `X:` drive prefix can never round-trip through it. Before create,
+the ingester filters exactly those elements out of the array (the same
+predicate the hook enforces), keeps the canonical remainder, stores the
+commit, and counts the dropped paths in
+`IngestReport.changed_paths_filtered_noncanonical` with one bounded warning
+per run. Rename detection is
 pinned off (`--no-renames`) so a rename always surfaces as the delete + add
 pair `--name-only` reports without it; because Git does not mark which entry
 is the rename source, leaving detection on could silently swap one side of
@@ -337,7 +346,9 @@ when both `properties.source_revision` equals that HEAD and
 revision prevents an identically named path in another repository snapshot
 from receiving a fabricated annotation. If more than one live module still
 has the same `(source_revision, source_path)`, the binding is ambiguous and no
-candidate is annotated. There is no suffix match, inferred rename, entity
+candidate is annotated; each such skipped binding is counted in
+`IngestReport.code_module_ambiguous_path_skips` so the deliberate skip is
+visible per run. There is no suffix match, inferred rename, entity
 creation, or arbitrary winner. A failure to load the module index degrades
 the pass to no module annotation with a warning instead of aborting it,
 because the annotation is best-effort enrichment while `changed_paths` is

--- a/crates/khive-pack-git/docs/api/ingest.md
+++ b/crates/khive-pack-git/docs/api/ingest.md
@@ -323,10 +323,14 @@ governed by `CommitHook`'s canonical repo-relative shape (see
 docs/api/hooks.md): a valid Unix filename containing a `\` byte or starting
 with an `X:` drive prefix can never round-trip through it. Before create,
 the ingester filters exactly those elements out of the array (the same
-predicate the hook enforces), keeps the canonical remainder, stores the
-commit, and counts the dropped paths in
+predicate the hook enforces: a NUL byte, a backslash, an `X:` drive prefix,
+a leading `/`, or an empty/`.`/`..` component), keeps the canonical
+remainder, stores the commit, and counts the dropped paths in
 `IngestReport.changed_paths_filtered_noncanonical` with one bounded warning
-per run. Only actual predicate rejections count as drops: the BTreeSet
+per run. The predicate runs on the RAW path, not the masked one: a secret
+token can itself contain a rejected byte (the masker's tokens are
+whitespace-delimited), and filtering after masking would flip the verdict
+from reject to accept; masking applies only to the paths that survive. Only actual predicate rejections count as drops: the BTreeSet
 dedup and post-masking collisions the sorted array also performs are not
 drops and are neither counted nor warned. Rename detection is
 pinned off (`--no-renames`) so a rename always surfaces as the delete + add
@@ -334,7 +338,8 @@ pair `--name-only` reports without it; because Git does not mark which entry
 is the rename source, leaving detection on could silently swap one side of
 the pair away from the exact path facts that join against ADR-085 modules.
 A merge commit carries one canonical path set: its diff against the first
-parent. Paths are secret-masked, sorted, and deduplicated before storage.
+parent. Paths that survive the canonical filter are secret-masked, sorted,
+and deduplicated before storage.
 The stored property has exactly three states: `[]` for a genuinely empty
 commit — and only for one; the canonical remainder array when at least one
 touched path survives the filter; and an omitted `changed_paths` (the hook
@@ -346,24 +351,42 @@ stream fails the phase (retried on the next pass via the cursor contract),
 and a walked commit with no recorded path set is skipped with a warning and
 a stalled cursor rather than stored with a fabricated `[]`. One residual
 parser ambiguity is deliberate: a non-header token is indistinguishable from
-a real path of the most recent header's commit, so a header lost mid-stream
-attaches its record's paths to the previous commit. The parser does not
-guess at path content; the containment is that the missing sha has no
-path-set entry, so the run warns and stalls the cursor.
+a real path of the most recent header's commit. The `--name-only` walk is
+newest-first, so a header lost mid-stream attaches its record's path tokens
+to that NEWER commit — the commit already walked in the same stream — never
+to an older one. The parser does not guess at path content; containment is
+per-record, not per-stream: the missing sha has no path-set entry, so the
+run warns and stalls the cursor, but the polluted newer commit is created as
+usual — the orphaned tokens ride into its `changed_paths`, and commit notes
+are immutable, so the pollution persists (a re-ingest skips the stored sha;
+repair requires deleting the note and re-ingesting).
+`ingest_stalls_cursor_for_commit_missing_touched_paths` pins both halves:
+its shim's `tr` round-trip splits git's combined `<header>\n<first-path>`
+token into two lines, so `grep -av` removes only the header line and the
+deleted commit's path token survives in the stream as the orphan.
 
 Before walking commits, the ingester loads the same-namespace live ADR-085
-module index once for the repository snapshot HEAD. A module is eligible only
+module index once for the repository snapshot HEAD. That snapshot is never
+truncated: `walk_commits` issues one unbounded `git log {since}..HEAD`, and
+`max_items` bounds only the create loop (a budget check after the snapshot
+loads), never the walk — so the snapshot HEAD is always the true repository
+HEAD of this pass, and the index anchors to modules-as-of-HEAD regardless of
+how many commits the budget lets this pass create. A module is eligible only
 when both `properties.source_revision` equals that HEAD and
 `properties.source_path` exactly equals the changed path. Requiring the
 revision prevents an identically named path in another repository snapshot
 from receiving a fabricated annotation. If more than one live module still
 has the same `(source_revision, source_path)`, the binding is ambiguous and no
-candidate is annotated (a row whose `id` does not parse as a UUID counts
-toward that ambiguity — it is a second live row for the key — but can never
-itself be the annotated candidate). Each skip is counted in
-`IngestReport.code_module_ambiguous_path_skips` only when an ingested
-commit's path actually hits the ambiguous key, so ambiguous keys untouched
-by the pass never inflate the count. There is no suffix match, inferred rename, entity
+candidate is annotated. The skip folds two shapes into one counter,
+`IngestReport.code_module_ambiguous_path_skips`: an ambiguous key (more than
+one live row, at most one with a parseable id — a row whose `id` does not
+parse as a UUID is still a live row for the key, so it marks the pair
+ambiguous, but can never itself be the annotated candidate) and the
+single-row sub-case whose one row's id does not parse (not ambiguous — just
+no bindable candidate). Each skip is counted only when an ingested commit's
+path actually hits the key, so unusable keys untouched by the pass never
+inflate the count, and the run's bounded warning names the first skipped
+paths (masked, truncated) so the count is actionable. There is no suffix match, inferred rename, entity
 creation, or arbitrary winner. A failure to load the module index degrades
 the pass to no module annotation with a warning instead of aborting it,
 because the annotation is best-effort enrichment while `changed_paths` is

--- a/crates/khive-pack-git/docs/api/ingest.md
+++ b/crates/khive-pack-git/docs/api/ingest.md
@@ -326,18 +326,30 @@ the ingester filters exactly those elements out of the array (the same
 predicate the hook enforces), keeps the canonical remainder, stores the
 commit, and counts the dropped paths in
 `IngestReport.changed_paths_filtered_noncanonical` with one bounded warning
-per run. Rename detection is
+per run. Only actual predicate rejections count as drops: the BTreeSet
+dedup and post-masking collisions the sorted array also performs are not
+drops and are neither counted nor warned. Rename detection is
 pinned off (`--no-renames`) so a rename always surfaces as the delete + add
 pair `--name-only` reports without it; because Git does not mark which entry
 is the rename source, leaving detection on could silently swap one side of
 the pair away from the exact path facts that join against ADR-085 modules.
 A merge commit carries one canonical path set: its diff against the first
 parent. Paths are secret-masked, sorted, and deduplicated before storage.
-Every ingested commit carries the array, including an empty array for a
-genuinely empty commit — and only for one: a malformed `--name-only` token
+The stored property has exactly three states: `[]` for a genuinely empty
+commit — and only for one; the canonical remainder array when at least one
+touched path survives the filter; and an omitted `changed_paths` (the hook
+treats it as optional) when the raw touched set was non-empty but every
+path was filtered — the all-filtered third state, whose evidence is the
+run's `changed_paths_filtered_noncanonical` count and bounded warning. A
+malformed `--name-only` token
 stream fails the phase (retried on the next pass via the cursor contract),
 and a walked commit with no recorded path set is skipped with a warning and
-a stalled cursor rather than stored with a fabricated `[]`.
+a stalled cursor rather than stored with a fabricated `[]`. One residual
+parser ambiguity is deliberate: a non-header token is indistinguishable from
+a real path of the most recent header's commit, so a header lost mid-stream
+attaches its record's paths to the previous commit. The parser does not
+guess at path content; the containment is that the missing sha has no
+path-set entry, so the run warns and stalls the cursor.
 
 Before walking commits, the ingester loads the same-namespace live ADR-085
 module index once for the repository snapshot HEAD. A module is eligible only
@@ -346,9 +358,12 @@ when both `properties.source_revision` equals that HEAD and
 revision prevents an identically named path in another repository snapshot
 from receiving a fabricated annotation. If more than one live module still
 has the same `(source_revision, source_path)`, the binding is ambiguous and no
-candidate is annotated; each such skipped binding is counted in
-`IngestReport.code_module_ambiguous_path_skips` so the deliberate skip is
-visible per run. There is no suffix match, inferred rename, entity
+candidate is annotated (a row whose `id` does not parse as a UUID counts
+toward that ambiguity — it is a second live row for the key — but can never
+itself be the annotated candidate). Each skip is counted in
+`IngestReport.code_module_ambiguous_path_skips` only when an ingested
+commit's path actually hits the ambiguous key, so ambiguous keys untouched
+by the pass never inflate the count. There is no suffix match, inferred rename, entity
 creation, or arbitrary winner. A failure to load the module index degrades
 the pass to no module annotation with a warning instead of aborting it,
 because the annotation is best-effort enrichment while `changed_paths` is

--- a/crates/khive-pack-git/docs/api/ingest.md
+++ b/crates/khive-pack-git/docs/api/ingest.md
@@ -378,9 +378,10 @@ revision prevents an identically named path in another repository snapshot
 from receiving a fabricated annotation. If more than one live module still
 has the same `(source_revision, source_path)`, the binding is ambiguous and no
 candidate is annotated. The skip folds two shapes into one counter,
-`IngestReport.code_module_ambiguous_path_skips`: an ambiguous key (more than
-one live row, at most one with a parseable id — a row whose `id` does not
-parse as a UUID is still a live row for the key, so it marks the pair
+`IngestReport.code_module_ambiguous_path_skips`: an ambiguous key (two or
+more live rows, including the simplest case where both rows have parseable
+ids, or the case where at most one has a parseable id — a row whose `id` does
+not parse as a UUID is still a live row for the key, so it marks the pair
 ambiguous, but can never itself be the annotated candidate) and the
 single-row sub-case whose one row's id does not parse (not ambiguous — just
 no bindable candidate). Each skip is counted only when an ingested commit's

--- a/crates/khive-pack-git/docs/api/ingest.md
+++ b/crates/khive-pack-git/docs/api/ingest.md
@@ -312,15 +312,23 @@ not a complete signal.
 
 ## Changed paths and code-module annotations
 
-The commit snapshot's `git log -z --name-only
+The commit snapshot's `git log -z --name-only --no-renames
 --diff-merges=first-parent` pass is the authority for
 `commit.properties.changed_paths`. NUL-delimited paths bypass Git's quoted
 display encoding and are decoded with the same lossy UTF-8 normalization as
 ADR-085's filesystem path producer. Tabs, newlines, quotes, backslashes, and
-non-ASCII text therefore retain their path identity. A merge commit carries
-one canonical path set: its diff against the first parent. Paths are
-secret-masked, sorted, and deduplicated before storage. Every ingested commit
-carries the array, including an empty array for a genuinely empty commit.
+non-ASCII text therefore retain their path identity. Rename detection is
+pinned off (`--no-renames`) so a rename always surfaces as the delete + add
+pair `--name-only` reports without it; because Git does not mark which entry
+is the rename source, leaving detection on could silently swap one side of
+the pair away from the exact path facts that join against ADR-085 modules.
+A merge commit carries one canonical path set: its diff against the first
+parent. Paths are secret-masked, sorted, and deduplicated before storage.
+Every ingested commit carries the array, including an empty array for a
+genuinely empty commit — and only for one: a malformed `--name-only` token
+stream fails the phase (retried on the next pass via the cursor contract),
+and a walked commit with no recorded path set is skipped with a warning and
+a stalled cursor rather than stored with a fabricated `[]`.
 
 Before walking commits, the ingester loads the same-namespace live ADR-085
 module index once for the repository snapshot HEAD. A module is eligible only
@@ -330,7 +338,10 @@ revision prevents an identically named path in another repository snapshot
 from receiving a fabricated annotation. If more than one live module still
 has the same `(source_revision, source_path)`, the binding is ambiguous and no
 candidate is annotated. There is no suffix match, inferred rename, entity
-creation, or arbitrary winner. This makes module churn and repeated
+creation, or arbitrary winner. A failure to load the module index degrades
+the pass to no module annotation with a warning instead of aborting it,
+because the annotation is best-effort enrichment while `changed_paths` is
+the durable fact. This makes module churn and repeated
 cross-project co-change derivable from incoming `annotates` graph reads while
 retaining `changed_paths` as a durable path fact when no matching code map
 exists.

--- a/crates/khive-pack-git/docs/api/ingest.md
+++ b/crates/khive-pack-git/docs/api/ingest.md
@@ -44,7 +44,7 @@ than process-global daemon telemetry, so a caller can reliably assert
 
 A newly created note this pass, retained so the post-ingestion
 reference-extraction sweep (`link_references`) can resolve cross-references
-between records created in the *same* pass regardless of ingestion order
+between records created in the _same_ pass regardless of ingestion order
 (PRs and issues are ingested before commits) without re-reading them from
 storage.
 
@@ -80,7 +80,7 @@ namespace (matches the by-ID resolution contract used by `get`/`update`).
 ## `link_references`
 
 Post-ingestion sweep (ADR-088 Amendment 1 ingest enrichment): extracts
-GitHub reference-grammar mentions from every note created *this pass*
+GitHub reference-grammar mentions from every note created _this pass_
 (commits, issues, PRs — order-independent, since all three are already in
 `new_records` by the time this runs) and materializes `annotates` edges to
 the referenced issue/PR note, carrying `ref_kind` ("closes" | "mentions")
@@ -169,7 +169,7 @@ available), and any other error (including an unclassified `GitLogError` or
 a non-`GitLogError` failure) is returned immediately without ever calling
 `recover`. A later repair attempt's strategy replaces the pending warning
 rather than accumulating one per attempt, so exactly one success warning is
-ever returned — describing the *last* repair that was needed, not every
+ever returned — describing the _last_ repair that was needed, not every
 one tried.
 
 ## Masking boundaries (`MaskedCommitFields`, `MaskedIssueFields`, `MaskedPrFields`)
@@ -309,3 +309,28 @@ not a complete signal.
   Resolution now happens in one query/snapshot: both candidates are
   visible to the same `SELECT`, and the `ORDER BY` — not read ordering —
   decides the exact match wins.
+
+## Changed paths and code-module annotations
+
+The commit snapshot's `git log -z --name-only
+--diff-merges=first-parent` pass is the authority for
+`commit.properties.changed_paths`. NUL-delimited paths bypass Git's quoted
+display encoding and are decoded with the same lossy UTF-8 normalization as
+ADR-085's filesystem path producer. Tabs, newlines, quotes, backslashes, and
+non-ASCII text therefore retain their path identity. A merge commit carries
+one canonical path set: its diff against the first parent. Paths are
+secret-masked, sorted, and deduplicated before storage. Every ingested commit
+carries the array, including an empty array for a genuinely empty commit.
+
+Before walking commits, the ingester loads the same-namespace live ADR-085
+module index once for the repository snapshot HEAD. A module is eligible only
+when both `properties.source_revision` equals that HEAD and
+`properties.source_path` exactly equals the changed path. Requiring the
+revision prevents an identically named path in another repository snapshot
+from receiving a fabricated annotation. If more than one live module still
+has the same `(source_revision, source_path)`, the binding is ambiguous and no
+candidate is annotated. There is no suffix match, inferred rename, entity
+creation, or arbitrary winner. This makes module churn and repeated
+cross-project co-change derivable from incoming `annotates` graph reads while
+retaining `changed_paths` as a durable path fact when no matching code map
+exists.

--- a/crates/khive-pack-git/src/hook.rs
+++ b/crates/khive-pack-git/src/hook.rs
@@ -15,6 +15,19 @@ fn is_40_hex(s: &str) -> bool {
     s.len() == 40 && s.chars().all(|c| c.is_ascii_hexdigit())
 }
 
+fn is_repo_relative_path(path: &str) -> bool {
+    let bytes = path.as_bytes();
+    let windows_absolute =
+        bytes.len() >= 3 && bytes[0].is_ascii_alphabetic() && bytes[1] == b':' && bytes[2] == b'/';
+    !path.is_empty()
+        && !path.starts_with('/')
+        && !windows_absolute
+        && !path.contains('\0')
+        && path
+            .split('/')
+            .all(|component| !component.is_empty() && component != "." && component != "..")
+}
+
 fn properties_obj(args: &Value) -> Result<&serde_json::Map<String, Value>, RuntimeError> {
     args.get("properties")
         .and_then(Value::as_object)
@@ -28,8 +41,9 @@ fn properties_obj(args: &Value) -> Result<&serde_json::Map<String, Value>, Runti
 /// `KindHook` for the immutable `commit` note kind.
 ///
 /// Validates `properties.sha` (required, 40-hex) and, when present,
-/// `properties.parents` (array of 40-hex strings). Commits have no lifecycle
-/// and no `after_create` edge work.
+/// `properties.parents` (array of 40-hex strings) and `properties.changed_paths`
+/// (array of repository-relative path strings). Commits have no lifecycle and
+/// no `after_create` edge work.
 #[derive(Debug, Default)]
 pub struct CommitHook;
 
@@ -75,6 +89,34 @@ impl KindHook for CommitHook {
                 return Err(RuntimeError::InvalidInput(format!(
                     "commit properties.short_sha {short:?} must be a non-empty prefix of sha {sha:?}"
                 )));
+            }
+        }
+
+        if let Some(paths) = props.get("changed_paths") {
+            let arr = paths.as_array().ok_or_else(|| {
+                RuntimeError::InvalidInput(
+                    "commit properties.changed_paths must be an array".into(),
+                )
+            })?;
+            let mut previous: Option<&str> = None;
+            for (idx, path) in arr.iter().enumerate() {
+                let Some(path) = path.as_str() else {
+                    return Err(RuntimeError::InvalidInput(format!(
+                        "commit properties.changed_paths[{idx}] must be a string"
+                    )));
+                };
+                if !is_repo_relative_path(path) {
+                    return Err(RuntimeError::InvalidInput(format!(
+                        "commit properties.changed_paths[{idx}] must be a non-empty \
+                         repository-relative '/'-separated path without '.' or '..' components"
+                    )));
+                }
+                if previous.is_some_and(|prior| path <= prior) {
+                    return Err(RuntimeError::InvalidInput(
+                        "commit properties.changed_paths must be sorted and deduplicated".into(),
+                    ));
+                }
+                previous = Some(path);
             }
         }
 

--- a/crates/khive-pack-git/src/hook.rs
+++ b/crates/khive-pack-git/src/hook.rs
@@ -15,7 +15,12 @@ fn is_40_hex(s: &str) -> bool {
     s.len() == 40 && s.chars().all(|c| c.is_ascii_hexdigit())
 }
 
-fn is_repo_relative_path(path: &str) -> bool {
+/// The canonical `changed_paths` element shape. `pub(crate)` so the ingester
+/// filters the raw `git log -z --name-only` stream against exactly the rule
+/// this hook enforces, instead of handing the hook paths it must reject
+/// (a Unix filename may legitimately contain `\` or start `X:`; those can
+/// never round-trip through `changed_paths`).
+pub(crate) fn is_repo_relative_path(path: &str) -> bool {
     let bytes = path.as_bytes();
     // Any `X:` prefix is a Windows drive reference — absolute (`C:/...`) or
     // drive-relative (`C:foo`). The canonical shape is `/`-separated

--- a/crates/khive-pack-git/src/hook.rs
+++ b/crates/khive-pack-git/src/hook.rs
@@ -17,14 +17,15 @@ fn is_40_hex(s: &str) -> bool {
 
 fn is_repo_relative_path(path: &str) -> bool {
     let bytes = path.as_bytes();
-    let windows_drive_absolute = bytes.len() >= 3
-        && bytes[0].is_ascii_alphabetic()
-        && bytes[1] == b':'
-        && (bytes[2] == b'/' || bytes[2] == b'\\');
+    // Any `X:` prefix is a Windows drive reference — absolute (`C:/...`) or
+    // drive-relative (`C:foo`). The canonical shape is `/`-separated
+    // repo-relative, so reject the prefix regardless of what follows it.
+    let windows_drive_prefix =
+        bytes.len() >= 2 && bytes[0].is_ascii_alphabetic() && bytes[1] == b':';
     !path.is_empty()
         && !path.starts_with('/')
-        && !path.starts_with('\\')
-        && !windows_drive_absolute
+        && !path.contains('\\')
+        && !windows_drive_prefix
         && !path.contains('\0')
         && path
             .split('/')
@@ -45,8 +46,9 @@ fn properties_obj(args: &Value) -> Result<&serde_json::Map<String, Value>, Runti
 ///
 /// Validates `properties.sha` (required, 40-hex) and, when present,
 /// `properties.parents` (array of 40-hex strings) and `properties.changed_paths`
-/// (array of repository-relative path strings). Commits have no lifecycle and
-/// no `after_create` edge work.
+/// (array of repository-relative path strings; an explicit JSON `null` is
+/// treated the same as an absent property). Commits have no lifecycle and no
+/// `after_create` edge work.
 #[derive(Debug, Default)]
 pub struct CommitHook;
 
@@ -95,7 +97,10 @@ impl KindHook for CommitHook {
             }
         }
 
-        if let Some(paths) = props.get("changed_paths") {
+        // An explicit JSON `null` carries no path facts and is treated the
+        // same as an absent property; anything else must be the canonical
+        // sorted, deduplicated array.
+        if let Some(paths) = props.get("changed_paths").filter(|value| !value.is_null()) {
             let arr = paths.as_array().ok_or_else(|| {
                 RuntimeError::InvalidInput(
                     "commit properties.changed_paths must be an array".into(),

--- a/crates/khive-pack-git/src/hook.rs
+++ b/crates/khive-pack-git/src/hook.rs
@@ -17,11 +17,14 @@ fn is_40_hex(s: &str) -> bool {
 
 fn is_repo_relative_path(path: &str) -> bool {
     let bytes = path.as_bytes();
-    let windows_absolute =
-        bytes.len() >= 3 && bytes[0].is_ascii_alphabetic() && bytes[1] == b':' && bytes[2] == b'/';
+    let windows_drive_absolute = bytes.len() >= 3
+        && bytes[0].is_ascii_alphabetic()
+        && bytes[1] == b':'
+        && (bytes[2] == b'/' || bytes[2] == b'\\');
     !path.is_empty()
         && !path.starts_with('/')
-        && !windows_absolute
+        && !path.starts_with('\\')
+        && !windows_drive_absolute
         && !path.contains('\0')
         && path
             .split('/')

--- a/crates/khive-pack-git/src/hook.rs
+++ b/crates/khive-pack-git/src/hook.rs
@@ -121,7 +121,8 @@ impl KindHook for CommitHook {
                 if !is_repo_relative_path(path) {
                     return Err(RuntimeError::InvalidInput(format!(
                         "commit properties.changed_paths[{idx}] must be a non-empty \
-                         repository-relative '/'-separated path without '.' or '..' components"
+                         repository-relative path using '/' separators, with no empty, '.' or \
+                         '..' components, leading '/', drive prefix, backslash, or NUL byte"
                     )));
                 }
                 if previous.is_some_and(|prior| path <= prior) {

--- a/crates/khive-pack-git/src/ingest.rs
+++ b/crates/khive-pack-git/src/ingest.rs
@@ -595,18 +595,22 @@ async fn find_document_for_path(
 /// module's `source_revision` to equal the snapshot HEAD keeps unrelated maps
 /// out; a path with more than one matching live row remains ambiguous and is
 /// deliberately represented by `None` rather than selecting or annotating an
-/// arbitrary candidate.
+/// arbitrary candidate. A row whose `id` does not parse as a UUID still
+/// counts toward that ambiguity — it is evidence of a second live row for
+/// the same key — but can never itself serve as a binding target.
 ///
-/// A load failure returns `None` instead of aborting the pass: module
-/// annotation is best-effort enrichment (ADR-088 Amendment 1), while the
-/// durable `changed_paths` fact must still be recorded.
+/// A reader/query failure returns `Err` carrying the underlying error text;
+/// the caller degrades to no module annotation with a warning that includes
+/// it rather than aborting the pass: module annotation is best-effort
+/// enrichment (ADR-088 Amendment 1), while the durable `changed_paths` fact
+/// must still be recorded.
 async fn load_code_modules_by_snapshot_path(
     runtime: &KhiveRuntime,
     token: &NamespaceToken,
     source_revision: &str,
-) -> Option<HashMap<String, Option<Uuid>>> {
+) -> Result<HashMap<String, Option<Uuid>>> {
     let sql = runtime.sql();
-    let mut r = sql.reader().await.map_err(|e| anyhow!("{e}")).ok()?;
+    let mut r = sql.reader().await.map_err(|e| anyhow!("{e}"))?;
     let rows = r
         .query_all(SqlStatement {
             sql: "SELECT id, json_extract(properties,'$.source_path') AS source_path \
@@ -623,21 +627,24 @@ async fn load_code_modules_by_snapshot_path(
             label: Some("git_ingest_load_code_modules_by_snapshot_path".into()),
         })
         .await
-        .map_err(|e| anyhow!("{e}"))
-        .ok()?;
+        .map_err(|e| anyhow!("{e}"))?;
 
     let mut modules: HashMap<String, Option<Uuid>> = HashMap::new();
     for row in rows {
-        let Some(id) = row_uuid(&row) else { continue };
         let Some(SqlValue::Text(path)) = row.get("source_path") else {
             continue;
         };
+        // A row whose id does not parse is still a live row for its
+        // `(source_revision, source_path)` key: it occupies the slot (so any
+        // second row for the same key marks the pair ambiguous) but can
+        // never bind as an annotation target itself.
+        let id = row_uuid(&row);
         modules
             .entry(path.clone())
             .and_modify(|candidate| *candidate = None)
-            .or_insert(Some(id));
+            .or_insert(id);
     }
-    Some(modules)
+    Ok(modules)
 }
 
 /// Read the last-ingested cursor value for `(project_id, kind)`, if any.
@@ -1178,14 +1185,15 @@ async fn ingest_commits(
         .sha
         .clone();
     // Module annotation is best-effort enrichment: a failed index load
-    // degrades to no module annotation with a warning rather than aborting
-    // the pass that records the durable `changed_paths` facts.
+    // degrades to no module annotation with a warning carrying the load
+    // error's text rather than aborting the pass that records the durable
+    // `changed_paths` facts.
     let code_modules_by_source_path =
         match load_code_modules_by_snapshot_path(runtime, token, &snapshot_head).await {
-            Some(modules) => modules,
-            None => {
+            Ok(modules) => modules,
+            Err(e) => {
                 report.warnings.push(format!(
-                    "code module index load failed for snapshot {snapshot_head}; \
+                    "code module index load failed for snapshot {snapshot_head}: {e}; \
                      commits ingest without code-module annotation"
                 ));
                 HashMap::new()
@@ -2464,6 +2472,155 @@ mod find_document_for_path_tests {
             Some(exact_id),
             "a single query covering both exact and broadened candidates \
              must still rank the exact match first, regardless of insertion order"
+        );
+    }
+}
+
+/// `load_code_modules_by_snapshot_path` ambiguity and error-surface
+/// regression tests. See
+/// crates/khive-pack-git/docs/api/ingest.md#test-module-notes.
+#[cfg(test)]
+mod module_index_loader_tests {
+    use super::*;
+    use khive_runtime::Namespace;
+
+    const REVISION: &str = "1111111111111111111111111111111111111111";
+    const AMBIGUOUS_PATH: &str = "crates/ambig/src/lib.rs";
+
+    fn rt_and_token() -> (KhiveRuntime, NamespaceToken) {
+        let rt = KhiveRuntime::memory().unwrap();
+        let token = rt.authorize(Namespace::local()).unwrap();
+        (rt, token)
+    }
+
+    async fn create_module(
+        rt: &KhiveRuntime,
+        token: &NamespaceToken,
+        name: &str,
+        path: &str,
+    ) -> Uuid {
+        rt.create_entity(
+            token,
+            "concept",
+            Some("module"),
+            name,
+            None,
+            Some(json!({
+                "source_path": path,
+                "source_revision": REVISION
+            })),
+            vec![],
+        )
+        .await
+        .unwrap()
+        .id
+    }
+
+    /// A live module row whose `id` does not parse as a UUID — a shape the
+    /// normal `create` path never writes, inserted raw to prove the loader
+    /// still counts it toward ambiguity.
+    async fn insert_unparsable_module_row(
+        rt: &KhiveRuntime,
+        token: &NamespaceToken,
+        name: &str,
+        path: &str,
+    ) {
+        let mut writer = rt.sql().writer().await.unwrap();
+        writer
+            .execute(SqlStatement {
+                sql: "INSERT INTO entities \
+                      (id, namespace, kind, entity_type, name, properties, created_at, updated_at) \
+                      VALUES (?1, ?2, 'concept', 'module', ?3, ?4, 0, 0)"
+                    .into(),
+                params: vec![
+                    SqlValue::Text("not-a-parseable-uuid".to_string()),
+                    SqlValue::Text(token.namespace().as_str().to_string()),
+                    SqlValue::Text(name.to_string()),
+                    SqlValue::Text(
+                        json!({
+                            "source_path": path,
+                            "source_revision": REVISION
+                        })
+                        .to_string(),
+                    ),
+                ],
+                label: Some("test_insert_unparsable_module_row".into()),
+            })
+            .await
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn single_valid_module_row_binds() {
+        let (rt, token) = rt_and_token();
+        let id = create_module(&rt, &token, "solo_module", AMBIGUOUS_PATH).await;
+
+        let index = load_code_modules_by_snapshot_path(&rt, &token, REVISION)
+            .await
+            .unwrap();
+        assert_eq!(index.get(AMBIGUOUS_PATH), Some(&Some(id)));
+    }
+
+    /// Contract: more than one live module with the same
+    /// `(source_revision, source_path)` is ambiguous and annotates none. An
+    /// unparsable-id row is still a live row for that key, so it must mark
+    /// the pair ambiguous even though it can never bind itself.
+    #[tokio::test]
+    async fn unparsable_module_row_counts_toward_ambiguity() {
+        let (rt, token) = rt_and_token();
+        let valid_id = create_module(&rt, &token, "valid_module", AMBIGUOUS_PATH).await;
+        insert_unparsable_module_row(&rt, &token, "malformed_module", AMBIGUOUS_PATH).await;
+
+        let index = load_code_modules_by_snapshot_path(&rt, &token, REVISION)
+            .await
+            .unwrap();
+        assert_eq!(
+            index.get(AMBIGUOUS_PATH),
+            Some(&None),
+            "a malformed row is evidence of a second live module for \
+             {AMBIGUOUS_PATH}; the valid row {valid_id} must not be selected"
+        );
+    }
+
+    #[tokio::test]
+    async fn unparsable_module_row_alone_never_binds() {
+        let (rt, token) = rt_and_token();
+        insert_unparsable_module_row(&rt, &token, "lonely_malformed", AMBIGUOUS_PATH).await;
+
+        let index = load_code_modules_by_snapshot_path(&rt, &token, REVISION)
+            .await
+            .unwrap();
+        assert_eq!(
+            index.get(AMBIGUOUS_PATH),
+            Some(&None),
+            "an unparsable id can never serve as an annotation target"
+        );
+    }
+
+    /// A failed index load must surface its cause: the caller includes this
+    /// error text in the degradation warning, so persistent SQL/schema
+    /// problems stay diagnosable.
+    #[tokio::test]
+    async fn load_failure_surfaces_error_text() {
+        let (rt, token) = rt_and_token();
+        // Break the substrate directly: the index query then fails with a
+        // real SQL error that must reach the caller.
+        let mut writer = rt.sql().writer().await.unwrap();
+        writer
+            .execute(SqlStatement {
+                sql: "DROP TABLE entities".into(),
+                params: vec![],
+                label: Some("test_drop_entities".into()),
+            })
+            .await
+            .unwrap();
+
+        let err = load_code_modules_by_snapshot_path(&rt, &token, REVISION)
+            .await
+            .expect_err("a failed index load must return Err");
+        assert!(
+            format!("{err}").contains("no such table"),
+            "the error must carry the underlying SQL cause: {err}"
         );
     }
 }

--- a/crates/khive-pack-git/src/ingest.rs
+++ b/crates/khive-pack-git/src/ingest.rs
@@ -200,12 +200,12 @@ pub struct IngestReport {
     pub changed_paths_filtered_noncanonical: u64,
     /// Changed paths whose `(source_revision, source_path)` module binding
     /// was unusable and therefore received no code-module annotation. Two
-    /// shapes fold into this counter: an ambiguous key (more than one live
-    /// row, at most one with a parseable id) and the single-row sub-case
-    /// whose one row's id does not parse (not ambiguous — just no bindable
-    /// candidate). Counted only when an ingested commit's path actually
-    /// hits the key, so unusable keys untouched by this pass never inflate
-    /// the count.
+    /// shapes fold into this counter: an ambiguous key (two or more live
+    /// rows, whether two or more have parseable ids or at most one has a
+    /// parseable id) and the single-row sub-case whose one row's id does not
+    /// parse (not ambiguous — just no bindable candidate). Counted only when
+    /// an ingested commit's path actually hits the key, so unusable keys
+    /// untouched by this pass never inflate the count.
     pub code_module_ambiguous_path_skips: u64,
 }
 
@@ -614,13 +614,14 @@ async fn find_document_for_path(
 /// out; a path with more than one matching live row remains ambiguous and is
 /// deliberately represented by `None` rather than selecting or annotating an
 /// arbitrary candidate. That `None` folds two distinct shapes, both
-/// counted in the same skip counter: (a) two or more rows of which at most
-/// one has a parseable id (true ambiguity), and (b) exactly ONE row whose
-/// id does not parse — a key that is not ambiguous but has no bindable
-/// candidate, so it must skip for the same reason. Shape (b) is a live row
-/// for the key exactly like any other; it occupies the slot (a second row
-/// for the same key marks the pair ambiguous under shape (a)) but can never
-/// itself serve as a binding target.
+/// counted in the same skip counter: (a) two or more rows, including two or
+/// more rows with parseable ids and the case where at most one has a
+/// parseable id (true ambiguity), and (b) exactly ONE row whose id does not
+/// parse — a key that is not ambiguous but has no bindable candidate, so it
+/// must skip for the same reason. Shape (b) is a live row for the key exactly
+/// like any other; it occupies the slot (a second row for the same key marks
+/// the pair ambiguous under shape (a)) but can never itself serve as a
+/// binding target.
 ///
 /// A reader/query failure returns `Err` carrying the underlying error text;
 /// the caller degrades to no module annotation with a warning that includes
@@ -925,9 +926,12 @@ fn parse_touched_files(bytes: &[u8]) -> Result<HashMap<String, Vec<String>>> {
         }
         if let Some(header) = token.strip_prefix(TOUCHED_HEADER_PREFIX) {
             if header.len() < 40 || !header[..40].iter().all(u8::is_ascii_hexdigit) {
+                let lossy = String::from_utf8_lossy(header);
+                let masked = secret_gate::mask_secrets(lossy.as_ref());
+                let display = refs::truncate_chars(masked.as_ref(), 80);
                 return Err(anyhow!(
                     "git log --name-only output contains a malformed commit header {:?}",
-                    String::from_utf8_lossy(&header[..header.len().min(80)])
+                    display
                 ));
             }
             let sha = String::from_utf8_lossy(&header[..40]).into_owned();
@@ -952,11 +956,12 @@ fn parse_touched_files(bytes: &[u8]) -> Result<HashMap<String, Vec<String>>> {
             // Path bytes are attacker/repo-controlled, so the error snippet
             // is secret-masked the same way stored changed_paths are —
             // never raw token bytes in a log/error path.
-            let lossy = String::from_utf8_lossy(&token[..token.len().min(80)]);
-            let masked = secret_gate::mask_secrets(&lossy);
+            let lossy = String::from_utf8_lossy(token);
+            let masked = secret_gate::mask_secrets(lossy.as_ref());
+            let display = refs::truncate_chars(masked.as_ref(), 80);
             return Err(anyhow!(
                 "git log --name-only output contains a path token before any \
-                 commit header: {masked:?}"
+                 commit header: {display:?}"
             ));
         };
         map.get_mut(sha)
@@ -1023,6 +1028,32 @@ mod touched_file_parser_tests {
         // stored changed_paths, never raw token bytes.
         let fake_token = "ghp_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
         let raw = format!("src/{fake_token}.rs\0");
+
+        let err = parse_touched_files(raw.as_bytes()).expect_err("orphan path must fail");
+        let text = format!("{err}");
+        assert!(!text.contains(fake_token), "{text}");
+        assert!(text.contains("MASKED"), "{text}");
+    }
+
+    #[test]
+    fn masks_a_secret_shaped_malformed_header_in_the_error() {
+        let fake_token = "ghp_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+        let raw = format!("/\x1e{fake_token}\0");
+
+        let err = parse_touched_files(raw.as_bytes()).expect_err("bad header must fail");
+        let text = format!("{err}");
+        assert!(!text.contains(fake_token), "{text}");
+        assert!(text.contains("MASKED"), "{text}");
+    }
+
+    #[test]
+    fn masks_an_orphan_secret_before_truncating_the_error() {
+        let fake_token = "ghp_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+        // The credential crosses the old byte-80 cut, so masking only the
+        // prefix would leave the raw secret in the error path.
+        let token = format!("{} {fake_token}", "x".repeat(59));
+        assert!(token.len() > 80);
+        let raw = format!("{token}\0");
 
         let err = parse_touched_files(raw.as_bytes()).expect_err("orphan path must fail");
         let text = format!("{err}");
@@ -1317,10 +1348,28 @@ async fn ingest_commits(
         // the contract reserves for a genuinely empty commit.
         let Some(touched_paths) = files_by_sha.get(&c.sha) else {
             cursor_stalled = true;
+            let recipient_detail = commits
+                .iter()
+                .position(|candidate| candidate.sha == c.sha)
+                .and_then(|index| {
+                    commits
+                        .iter()
+                        .skip(index + 1)
+                        .find(|candidate| files_by_sha.contains_key(&candidate.sha))
+                })
+                .map(|recipient| {
+                    format!(
+                        "; orphaned paths may have been absorbed by newer commit {}",
+                        recipient.sha
+                    )
+                })
+                .unwrap_or_else(|| {
+                    "; no newer path-set recipient was identifiable from this snapshot".to_string()
+                });
             report.warnings.push(format!(
                 "create commit {}: no touched-path set recorded by the \
-                 --name-only pass; not ingested",
-                c.sha
+                 --name-only pass; not ingested{}",
+                c.sha, recipient_detail
             ));
             continue;
         };
@@ -1374,15 +1423,17 @@ async fn ingest_commits(
                     annotates.insert(module_id.to_string());
                 }
                 // The key is unusable — either more than one live row binds
-                // it (at most one with a parseable id) or its single row's
-                // id does not parse — so no candidate is annotated. Both
-                // shapes count once per commit path that hits the key (the
+                // it (including the two-parseable-row case) or its single
+                // row's id does not parse — so no candidate is annotated.
+                // Both shapes count once per commit path that hits the key (the
                 // path is also remembered for the bounded per-run warning
                 // below); see `load_code_modules_by_snapshot_path` for the
                 // fold.
                 Some(None) => {
                     report.code_module_ambiguous_path_skips += 1;
-                    ambiguous_module_skip_paths.push(path.clone());
+                    if ambiguous_module_skip_paths.len() < AMBIGUOUS_SKIP_DETAIL_CAP {
+                        ambiguous_module_skip_paths.push(path.clone());
+                    }
                 }
                 None => {}
             }
@@ -1520,8 +1571,8 @@ async fn ingest_commits(
         ));
     }
     if report.code_module_ambiguous_path_skips > 0 {
-        // Every skip records its masked path above, so the vec length is the
-        // exact count; only the displayed sample is capped.
+        // Every skip increments the exact counter above; only the retained
+        // masked path sample is capped at AMBIGUOUS_SKIP_DETAIL_CAP.
         let shown = ambiguous_module_skip_paths
             .len()
             .min(AMBIGUOUS_SKIP_DETAIL_CAP);
@@ -1533,7 +1584,9 @@ async fn ingest_commits(
             })
             .collect::<Vec<_>>()
             .join(", ");
-        let remaining = ambiguous_module_skip_paths.len() - shown;
+        let remaining = report
+            .code_module_ambiguous_path_skips
+            .saturating_sub(shown as u64);
         let suffix = if remaining > 0 {
             format!(", +{remaining} more")
         } else {
@@ -2745,6 +2798,22 @@ mod module_index_loader_tests {
             Some(&None),
             "a malformed row is evidence of a second live module for \
              {AMBIGUOUS_PATH}; the valid row {valid_id} must not be selected"
+        );
+    }
+
+    #[tokio::test]
+    async fn two_parseable_module_rows_fold_to_ambiguity() {
+        let (rt, token) = rt_and_token();
+        let first_id = create_module(&rt, &token, "first_module", AMBIGUOUS_PATH).await;
+        let second_id = create_module(&rt, &token, "second_module", AMBIGUOUS_PATH).await;
+
+        let index = load_code_modules_by_snapshot_path(&rt, &token, REVISION)
+            .await
+            .unwrap();
+        assert_eq!(
+            index.get(AMBIGUOUS_PATH),
+            Some(&None),
+            "two live parseable rows ({first_id}, {second_id}) must not select a winner"
         );
     }
 

--- a/crates/khive-pack-git/src/ingest.rs
+++ b/crates/khive-pack-git/src/ingest.rs
@@ -596,13 +596,17 @@ async fn find_document_for_path(
 /// out; a path with more than one matching live row remains ambiguous and is
 /// deliberately represented by `None` rather than selecting or annotating an
 /// arbitrary candidate.
+///
+/// A load failure returns `None` instead of aborting the pass: module
+/// annotation is best-effort enrichment (ADR-088 Amendment 1), while the
+/// durable `changed_paths` fact must still be recorded.
 async fn load_code_modules_by_snapshot_path(
     runtime: &KhiveRuntime,
     token: &NamespaceToken,
     source_revision: &str,
-) -> Result<HashMap<String, Option<Uuid>>> {
+) -> Option<HashMap<String, Option<Uuid>>> {
     let sql = runtime.sql();
-    let mut r = sql.reader().await.map_err(|e| anyhow!("{e}"))?;
+    let mut r = sql.reader().await.map_err(|e| anyhow!("{e}")).ok()?;
     let rows = r
         .query_all(SqlStatement {
             sql: "SELECT id, json_extract(properties,'$.source_path') AS source_path \
@@ -619,7 +623,8 @@ async fn load_code_modules_by_snapshot_path(
             label: Some("git_ingest_load_code_modules_by_snapshot_path".into()),
         })
         .await
-        .map_err(|e| anyhow!("{e}"))?;
+        .map_err(|e| anyhow!("{e}"))
+        .ok()?;
 
     let mut modules: HashMap<String, Option<Uuid>> = HashMap::new();
     for row in rows {
@@ -632,7 +637,7 @@ async fn load_code_modules_by_snapshot_path(
             .and_modify(|candidate| *candidate = None)
             .or_insert(Some(id));
     }
-    Ok(modules)
+    Some(modules)
 }
 
 /// Read the last-ingested cursor value for `(project_id, kind)`, if any.
@@ -817,7 +822,11 @@ fn walk_commits(repo: &Path, since_sha: Option<&str>) -> Result<Vec<RawCommit>> 
 /// separate NUL-delimited `--name-only` pass. Merge commits use their
 /// first-parent diff as the one canonical path set. The resulting paths drive
 /// document/module annotations and the durable
-/// `commit.properties.changed_paths` fact.
+/// `commit.properties.changed_paths` fact. Rename detection is pinned off so
+/// a rename always surfaces as the delete + add pair `--name-only` reports
+/// without it: those exact path facts are the ADR-085 module join keys, and
+/// Git does not mark which entry is the rename source, so an inferred rename
+/// could otherwise silently swap one side of the pair away.
 fn touched_files(repo: &Path) -> Result<HashMap<String, Vec<String>>> {
     let output = Command::new("git")
         .arg("-C")
@@ -825,6 +834,7 @@ fn touched_files(repo: &Path) -> Result<HashMap<String, Vec<String>>> {
         .arg("log")
         .arg("-z")
         .arg("--name-only")
+        .arg("--no-renames")
         .arg("--diff-merges=first-parent")
         // Git paths are always repository-relative, so no tracked path token
         // can start with `/`. This absolute-looking prefix is therefore an
@@ -838,10 +848,17 @@ fn touched_files(repo: &Path) -> Result<HashMap<String, Vec<String>>> {
             stderr: String::from_utf8_lossy(&output.stderr).into_owned(),
         }));
     }
-    Ok(parse_touched_files(&output.stdout))
+    parse_touched_files(&output.stdout)
 }
 
-fn parse_touched_files(bytes: &[u8]) -> HashMap<String, Vec<String>> {
+/// Decode the `-z --name-only` stream [`touched_files`] produces. The stream
+/// is unambiguous only when every token is either a `/\x1e<40-hex-sha>`
+/// header (optionally followed by one newline and the commit's first path)
+/// or a path belonging to the most recent header; anything else fails the
+/// phase rather than storing a silently partial path set. A bare `[]` is
+/// therefore meaningful: it is a genuinely empty commit, never the residue
+/// of a parser/git-output mismatch.
+fn parse_touched_files(bytes: &[u8]) -> Result<HashMap<String, Vec<String>>> {
     let mut map: HashMap<String, Vec<String>> = HashMap::new();
     // With `-z`, git emits paths verbatim and NUL-terminates each one. Git
     // may place either one or two NULs between adjacent commit sections, so
@@ -856,8 +873,10 @@ fn parse_touched_files(bytes: &[u8]) -> HashMap<String, Vec<String>> {
         }
         if let Some(header) = token.strip_prefix(TOUCHED_HEADER_PREFIX) {
             if header.len() < 40 || !header[..40].iter().all(u8::is_ascii_hexdigit) {
-                current_sha = None;
-                continue;
+                return Err(anyhow!(
+                    "git log --name-only output contains a malformed commit header {:?}",
+                    String::from_utf8_lossy(&header[..header.len().min(80)])
+                ));
             }
             let sha = String::from_utf8_lossy(&header[..40]).into_owned();
             let files = map.entry(sha.clone()).or_default();
@@ -865,17 +884,30 @@ fn parse_touched_files(bytes: &[u8]) -> HashMap<String, Vec<String>> {
                 if !first_path.is_empty() {
                     files.push(String::from_utf8_lossy(first_path).into_owned());
                 }
+            } else if !header[40..].is_empty() {
+                // Anything after the SHA that does not start with the one
+                // newline separator is a shape git never emits; guessing at
+                // it could drop or fabricate a first path.
+                return Err(anyhow!(
+                    "git log --name-only header for commit {sha} carries a \
+                     malformed first-path separator"
+                ));
             }
             current_sha = Some(sha);
             continue;
         }
-        if let Some(sha) = &current_sha {
-            map.get_mut(sha)
-                .expect("current SHA was inserted with its header")
-                .push(String::from_utf8_lossy(token).into_owned());
-        }
+        let Some(sha) = &current_sha else {
+            return Err(anyhow!(
+                "git log --name-only output contains a path token before any \
+                 commit header: {:?}",
+                String::from_utf8_lossy(&token[..token.len().min(80)])
+            ));
+        };
+        map.get_mut(sha)
+            .expect("current SHA was inserted with its header")
+            .push(String::from_utf8_lossy(token).into_owned());
     }
-    map
+    Ok(map)
 }
 
 #[cfg(test)]
@@ -890,7 +922,7 @@ mod touched_file_parser_tests {
         let raw =
             format!("/\x1e{sha_a}\nfirst.rs\0second.rs\0/\x1e{sha_b}\nthird.rs\0\0/\x1e{sha_c}\0");
 
-        let parsed = parse_touched_files(raw.as_bytes());
+        let parsed = parse_touched_files(raw.as_bytes()).expect("well-formed stream");
         assert_eq!(
             parsed[sha_a],
             vec!["first.rs".to_string(), "second.rs".to_string()]
@@ -905,7 +937,7 @@ mod touched_file_parser_tests {
         let mut raw = format!("/\x1e{sha}\n").into_bytes();
         raw.extend_from_slice(b"src/caf\xc3\xa9\t\"quoted\"\\leaf\nline.rs\0bad-\xff.rs\0");
 
-        let parsed = parse_touched_files(&raw);
+        let parsed = parse_touched_files(&raw).expect("well-formed stream");
         assert_eq!(
             parsed[sha],
             vec![
@@ -913,6 +945,43 @@ mod touched_file_parser_tests {
                 "bad-�.rs".to_string(),
             ]
         );
+    }
+
+    #[test]
+    fn rejects_a_path_token_before_any_header() {
+        // Silently dropping this token could store `[]` for a commit that
+        // touched files; failing the phase preserves the retry contract.
+        let sha = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+        let raw = format!("orphan.rs\0/\x1e{sha}\nfirst.rs\0");
+
+        let err = parse_touched_files(raw.as_bytes()).expect_err("orphan path must fail");
+        assert!(
+            format!("{err}").contains("before any commit header"),
+            "{err}"
+        );
+    }
+
+    #[test]
+    fn rejects_a_malformed_header_sha() {
+        let raw = "/\x1enot-hex-at-all\nfirst.rs\0second.rs\0";
+
+        let err = parse_touched_files(raw.as_bytes()).expect_err("bad header must fail");
+        assert!(
+            format!("{err}").contains("malformed commit header"),
+            "{err}"
+        );
+    }
+
+    #[test]
+    fn rejects_a_header_remainder_without_the_newline_separator() {
+        // A header remainder that does not start with exactly one newline is
+        // a shape git never emits; silently discarding it could lose the
+        // first path or misread it as a leading-newline path.
+        let sha = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+        let raw = format!("/\x1e{sha}XXfirst.rs\0");
+
+        let err = parse_touched_files(raw.as_bytes()).expect_err("bad separator must fail");
+        assert!(format!("{err}").contains("first-path separator"), "{err}");
     }
 }
 
@@ -1108,8 +1177,20 @@ async fn ingest_commits(
         .expect("non-empty commit snapshot checked above")
         .sha
         .clone();
+    // Module annotation is best-effort enrichment: a failed index load
+    // degrades to no module annotation with a warning rather than aborting
+    // the pass that records the durable `changed_paths` facts.
     let code_modules_by_source_path =
-        load_code_modules_by_snapshot_path(runtime, token, &snapshot_head).await?;
+        match load_code_modules_by_snapshot_path(runtime, token, &snapshot_head).await {
+            Some(modules) => modules,
+            None => {
+                report.warnings.push(format!(
+                    "code module index load failed for snapshot {snapshot_head}; \
+                     commits ingest without code-module annotation"
+                ));
+                HashMap::new()
+            }
+        };
 
     // `cursor_stalled` freezes `last_sha` at the last contiguous successfully
     // processed commit: once a record fails to create, later records in this
@@ -1148,10 +1229,21 @@ async fn ingest_commits(
             format!("{}\n\n{}", masked.subject, masked.body)
         };
 
-        let changed_paths: Vec<String> = files_by_sha
-            .get(&c.sha)
-            .into_iter()
-            .flatten()
+        // Both `git log` passes walk the same history, so every walked
+        // commit should have a path-set entry. A missing entry means the two
+        // passes disagree; surface it instead of silently storing the `[]`
+        // the contract reserves for a genuinely empty commit.
+        let Some(touched_paths) = files_by_sha.get(&c.sha) else {
+            cursor_stalled = true;
+            report.warnings.push(format!(
+                "create commit {}: no touched-path set recorded by the \
+                 --name-only pass; not ingested",
+                c.sha
+            ));
+            continue;
+        };
+        let changed_paths: Vec<String> = touched_paths
+            .iter()
             .map(|path| secret_gate::mask_secrets(path).into_owned())
             .collect::<BTreeSet<_>>()
             .into_iter()

--- a/crates/khive-pack-git/src/ingest.rs
+++ b/crates/khive-pack-git/src/ingest.rs
@@ -192,14 +192,17 @@ pub struct IngestReport {
     /// Touched paths the `--name-only` pass recorded but `changed_paths`
     /// storage cannot carry: valid Unix filenames that violate the hook's
     /// canonical shape (a `\` byte, an `X:` drive prefix, a leading `/`,
-    /// or an empty/`.`/`..` component). Dropped before create rather than
-    /// failing the whole commit — see
+    /// or an empty/`.`/`..` component). Only actual predicate rejections
+    /// count — dedup/post-masking collisions in the stored array are not
+    /// drops. Dropped before create rather than failing the whole commit —
+    /// see
     /// crates/khive-pack-git/docs/api/ingest.md#changed-paths-and-code-module-annotations.
     pub changed_paths_filtered_noncanonical: u64,
     /// Changed paths whose `(source_revision, source_path)` module binding
-    /// was ambiguous (more than one live row) and therefore received no
-    /// code-module annotation — counted once per skipped binding so the
-    /// skip is visible without an unbounded per-path log.
+    /// was ambiguous (more than one live row, at most one with a parseable
+    /// id) and therefore received no code-module annotation — counted only
+    /// when an ingested commit's path actually hits the ambiguous key, so
+    /// ambiguous keys untouched by this pass never inflate the count.
     pub code_module_ambiguous_path_skips: u64,
 }
 
@@ -617,14 +620,15 @@ async fn find_document_for_path(
 /// enrichment (ADR-088 Amendment 1), while the durable `changed_paths` fact
 /// must still be recorded.
 ///
-/// The returned count is the number of paths whose binding is ambiguous
-/// (mapped to `None`) — surfaced in the ingest report so the deliberate
-/// skip is visible per run.
+/// The map alone is returned; the caller counts a skip only when a commit
+/// path actually hits an ambiguous (`None`) key, so ambiguous keys no
+/// ingested commit touches never inflate
+/// `IngestReport.code_module_ambiguous_path_skips`.
 async fn load_code_modules_by_snapshot_path(
     runtime: &KhiveRuntime,
     token: &NamespaceToken,
     source_revision: &str,
-) -> Result<(HashMap<String, Option<Uuid>>, u64)> {
+) -> Result<HashMap<String, Option<Uuid>>> {
     let sql = runtime.sql();
     let mut r = sql.reader().await.map_err(|e| anyhow!("{e}"))?;
     let rows = r
@@ -660,11 +664,7 @@ async fn load_code_modules_by_snapshot_path(
             .and_modify(|candidate| *candidate = None)
             .or_insert(id);
     }
-    let ambiguous = modules
-        .values()
-        .filter(|candidate| candidate.is_none())
-        .count() as u64;
-    Ok((modules, ambiguous))
+    Ok(modules)
 }
 
 /// Read the last-ingested cursor value for `(project_id, kind)`, if any.
@@ -885,6 +885,16 @@ fn touched_files(repo: &Path) -> Result<HashMap<String, Vec<String>>> {
 /// phase rather than storing a silently partial path set. A bare `[]` is
 /// therefore meaningful: it is a genuinely empty commit, never the residue
 /// of a parser/git-output mismatch.
+///
+/// One ambiguity this layer cannot resolve: a non-header token is
+/// indistinguishable from a real path of the most recent header's commit, so
+/// a header that goes missing mid-stream (with its NUL separator) leaves the
+/// deleted record's paths attached to the previous commit. Detecting that
+/// would require judging path content against a commit the parse never saw,
+/// so the parser deliberately does not try; the containment is upstream —
+/// `ingest_commits` finds no path-set entry for the missing sha, warns, and
+/// stalls the cursor (`ingest_stalls_cursor_for_commit_missing_touched_paths`
+/// also pins that the previous commit keeps exactly its own paths).
 fn parse_touched_files(bytes: &[u8]) -> Result<HashMap<String, Vec<String>>> {
     let mut map: HashMap<String, Vec<String>> = HashMap::new();
     // With `-z`, git emits paths verbatim and NUL-terminates each one. Git
@@ -924,10 +934,14 @@ fn parse_touched_files(bytes: &[u8]) -> Result<HashMap<String, Vec<String>>> {
             continue;
         }
         let Some(sha) = &current_sha else {
+            // Path bytes are attacker/repo-controlled, so the error snippet
+            // is secret-masked the same way stored changed_paths are —
+            // never raw token bytes in a log/error path.
+            let lossy = String::from_utf8_lossy(&token[..token.len().min(80)]);
+            let masked = secret_gate::mask_secrets(&lossy);
             return Err(anyhow!(
                 "git log --name-only output contains a path token before any \
-                 commit header: {:?}",
-                String::from_utf8_lossy(&token[..token.len().min(80)])
+                 commit header: {masked:?}"
             ));
         };
         map.get_mut(sha)
@@ -986,6 +1000,19 @@ mod touched_file_parser_tests {
             format!("{err}").contains("before any commit header"),
             "{err}"
         );
+    }
+
+    #[test]
+    fn masks_a_secret_shaped_orphan_token_in_the_error() {
+        // The error snippet is a log path: it must carry the same masking as
+        // stored changed_paths, never raw token bytes.
+        let fake_token = "ghp_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+        let raw = format!("src/{fake_token}.rs\0");
+
+        let err = parse_touched_files(raw.as_bytes()).expect_err("orphan path must fail");
+        let text = format!("{err}");
+        assert!(!text.contains(fake_token), "{text}");
+        assert!(text.contains("MASKED"), "{text}");
     }
 
     #[test]
@@ -1210,10 +1237,7 @@ async fn ingest_commits(
     // `changed_paths` facts.
     let code_modules_by_source_path =
         match load_code_modules_by_snapshot_path(runtime, token, &snapshot_head).await {
-            Ok((modules, ambiguous)) => {
-                report.code_module_ambiguous_path_skips += ambiguous;
-                modules
-            }
+            Ok(modules) => modules,
             Err(e) => {
                 report.warnings.push(format!(
                     "code module index load failed for snapshot {snapshot_head}: {e}; \
@@ -1279,20 +1303,50 @@ async fn ingest_commits(
         // them, which would fail the whole commit create and stall the
         // cursor on every pass). Filter them here, against the same
         // predicate the hook enforces, and surface the per-run count below.
+        // Only actual predicate rejections count as drops: BTreeSet dedup
+        // and post-masking collisions are not drops and are neither counted
+        // nor warned.
+        let mut noncanonical = 0_u64;
         let changed_paths: Vec<String> = touched_paths
             .iter()
             .map(|path| secret_gate::mask_secrets(path).into_owned())
-            .filter(|path| hook::is_repo_relative_path(path))
+            .filter(|path| {
+                let canonical = hook::is_repo_relative_path(path);
+                if !canonical {
+                    noncanonical += 1;
+                }
+                canonical
+            })
             .collect::<BTreeSet<_>>()
             .into_iter()
             .collect();
-        let noncanonical = touched_paths.len() as u64 - changed_paths.len() as u64;
         report.changed_paths_filtered_noncanonical += noncanonical;
+        // Distinguish the three stored states the contract defines: a
+        // genuinely empty commit stores `[]`; a commit whose raw touched
+        // paths were ALL rejected omits `changed_paths` entirely (the drop
+        // count in `changed_paths_filtered_noncanonical` and the per-run
+        // warning carry the evidence); anything else stores the canonical
+        // remainder. The hook treats a missing `changed_paths` as optional,
+        // so the omitted shape still validates.
+        let changed_paths_property = if touched_paths.is_empty() || !changed_paths.is_empty() {
+            Some(changed_paths.clone())
+        } else {
+            None
+        };
         let mut annotates = BTreeSet::from([project_id.to_string()]);
 
         for path in &changed_paths {
-            if let Some(Some(module_id)) = code_modules_by_source_path.get(path) {
-                annotates.insert(module_id.to_string());
+            match code_modules_by_source_path.get(path) {
+                Some(Some(module_id)) => {
+                    annotates.insert(module_id.to_string());
+                }
+                // More than one live row binds this `(source_revision,
+                // source_path)` key (at most one of them with a parseable
+                // id — an unparsable-id row only ever occupies the slot):
+                // no candidate is annotated, and the skip is counted once
+                // per commit path that actually hit the ambiguous key.
+                Some(None) => report.code_module_ambiguous_path_skips += 1,
+                None => {}
             }
             if path.starts_with("docs/adr/") {
                 if let Some(doc_id) = find_document_for_path(runtime, token, path).await? {
@@ -1320,15 +1374,17 @@ async fn ingest_commits(
             annotates.insert(pr_id.to_string());
         }
 
-        let properties = json!({
+        let mut properties = json!({
             "sha": masked.sha,
             "short_sha": masked.short_sha,
             "author": masked.author,
             "author_email": masked.author_email,
             "committed_at": masked.committed_at,
             "parents": masked.parents,
-            "changed_paths": changed_paths,
         });
+        if let Some(paths) = changed_paths_property {
+            properties["changed_paths"] = json!(paths);
+        }
 
         let name = refs::truncate_chars(
             &format!("{} {}", masked.short_sha, masked.subject),
@@ -2599,11 +2655,10 @@ mod module_index_loader_tests {
         let (rt, token) = rt_and_token();
         let id = create_module(&rt, &token, "solo_module", AMBIGUOUS_PATH).await;
 
-        let (index, ambiguous) = load_code_modules_by_snapshot_path(&rt, &token, REVISION)
+        let index = load_code_modules_by_snapshot_path(&rt, &token, REVISION)
             .await
             .unwrap();
         assert_eq!(index.get(AMBIGUOUS_PATH), Some(&Some(id)));
-        assert_eq!(ambiguous, 0);
     }
 
     /// Contract: more than one live module with the same
@@ -2616,7 +2671,7 @@ mod module_index_loader_tests {
         let valid_id = create_module(&rt, &token, "valid_module", AMBIGUOUS_PATH).await;
         insert_unparsable_module_row(&rt, &token, "malformed_module", AMBIGUOUS_PATH).await;
 
-        let (index, ambiguous) = load_code_modules_by_snapshot_path(&rt, &token, REVISION)
+        let index = load_code_modules_by_snapshot_path(&rt, &token, REVISION)
             .await
             .unwrap();
         assert_eq!(
@@ -2625,7 +2680,6 @@ mod module_index_loader_tests {
             "a malformed row is evidence of a second live module for \
              {AMBIGUOUS_PATH}; the valid row {valid_id} must not be selected"
         );
-        assert_eq!(ambiguous, 1, "the ambiguous key is counted for the report");
     }
 
     #[tokio::test]
@@ -2633,7 +2687,7 @@ mod module_index_loader_tests {
         let (rt, token) = rt_and_token();
         insert_unparsable_module_row(&rt, &token, "lonely_malformed", AMBIGUOUS_PATH).await;
 
-        let (index, ambiguous) = load_code_modules_by_snapshot_path(&rt, &token, REVISION)
+        let index = load_code_modules_by_snapshot_path(&rt, &token, REVISION)
             .await
             .unwrap();
         assert_eq!(
@@ -2641,7 +2695,6 @@ mod module_index_loader_tests {
             Some(&None),
             "an unparsable id can never serve as an annotation target"
         );
-        assert_eq!(ambiguous, 1);
     }
 
     /// A failed index load must surface its cause: the caller includes this

--- a/crates/khive-pack-git/src/ingest.rs
+++ b/crates/khive-pack-git/src/ingest.rs
@@ -189,6 +189,18 @@ pub struct IngestReport {
     /// to compare directly against an independent source of truth (e.g.
     /// `git rev-list --count <ref>`).
     pub commits_total_in_db: u64,
+    /// Touched paths the `--name-only` pass recorded but `changed_paths`
+    /// storage cannot carry: valid Unix filenames that violate the hook's
+    /// canonical shape (a `\` byte, an `X:` drive prefix, a leading `/`,
+    /// or an empty/`.`/`..` component). Dropped before create rather than
+    /// failing the whole commit — see
+    /// crates/khive-pack-git/docs/api/ingest.md#changed-paths-and-code-module-annotations.
+    pub changed_paths_filtered_noncanonical: u64,
+    /// Changed paths whose `(source_revision, source_path)` module binding
+    /// was ambiguous (more than one live row) and therefore received no
+    /// code-module annotation — counted once per skipped binding so the
+    /// skip is visible without an unbounded per-path log.
+    pub code_module_ambiguous_path_skips: u64,
 }
 
 fn record_write_failure(
@@ -604,11 +616,15 @@ async fn find_document_for_path(
 /// it rather than aborting the pass: module annotation is best-effort
 /// enrichment (ADR-088 Amendment 1), while the durable `changed_paths` fact
 /// must still be recorded.
+///
+/// The returned count is the number of paths whose binding is ambiguous
+/// (mapped to `None`) — surfaced in the ingest report so the deliberate
+/// skip is visible per run.
 async fn load_code_modules_by_snapshot_path(
     runtime: &KhiveRuntime,
     token: &NamespaceToken,
     source_revision: &str,
-) -> Result<HashMap<String, Option<Uuid>>> {
+) -> Result<(HashMap<String, Option<Uuid>>, u64)> {
     let sql = runtime.sql();
     let mut r = sql.reader().await.map_err(|e| anyhow!("{e}"))?;
     let rows = r
@@ -644,7 +660,11 @@ async fn load_code_modules_by_snapshot_path(
             .and_modify(|candidate| *candidate = None)
             .or_insert(id);
     }
-    Ok(modules)
+    let ambiguous = modules
+        .values()
+        .filter(|candidate| candidate.is_none())
+        .count() as u64;
+    Ok((modules, ambiguous))
 }
 
 /// Read the last-ingested cursor value for `(project_id, kind)`, if any.
@@ -1190,7 +1210,10 @@ async fn ingest_commits(
     // `changed_paths` facts.
     let code_modules_by_source_path =
         match load_code_modules_by_snapshot_path(runtime, token, &snapshot_head).await {
-            Ok(modules) => modules,
+            Ok((modules, ambiguous)) => {
+                report.code_module_ambiguous_path_skips += ambiguous;
+                modules
+            }
             Err(e) => {
                 report.warnings.push(format!(
                     "code module index load failed for snapshot {snapshot_head}: {e}; \
@@ -1250,12 +1273,21 @@ async fn ingest_commits(
             ));
             continue;
         };
+        // The `-z` stream is verbatim: a Unix filename may legitimately
+        // contain `\` or start `X:`, and the hook's canonical
+        // `changed_paths` shape can never carry those (CommitHook rejects
+        // them, which would fail the whole commit create and stall the
+        // cursor on every pass). Filter them here, against the same
+        // predicate the hook enforces, and surface the per-run count below.
         let changed_paths: Vec<String> = touched_paths
             .iter()
             .map(|path| secret_gate::mask_secrets(path).into_owned())
+            .filter(|path| hook::is_repo_relative_path(path))
             .collect::<BTreeSet<_>>()
             .into_iter()
             .collect();
+        let noncanonical = touched_paths.len() as u64 - changed_paths.len() as u64;
+        report.changed_paths_filtered_noncanonical += noncanonical;
         let mut annotates = BTreeSet::from([project_id.to_string()]);
 
         for path in &changed_paths {
@@ -1379,6 +1411,18 @@ async fn ingest_commits(
 
     if let Some(sha) = last_sha {
         write_cursor(runtime, project_id, "commits", &sha).await?;
+    }
+    // One bounded line per run (never one per path): filenames are
+    // attacker/repo-controlled and may be long, so the count alone is
+    // surfaced; the paths themselves remain recoverable from the raw
+    // `git log -z --name-only` stream if an operator needs them.
+    if report.changed_paths_filtered_noncanonical > 0 {
+        report.warnings.push(format!(
+            "{} touched path(s) dropped from changed_paths: outside the \
+             canonical repo-relative shape (backslash, `X:` drive prefix, \
+             leading `/`, or empty/`.`/`..` component)",
+            report.changed_paths_filtered_noncanonical
+        ));
     }
     if let Some(warning) = recovery_warning {
         report.warnings.push(warning);
@@ -2555,10 +2599,11 @@ mod module_index_loader_tests {
         let (rt, token) = rt_and_token();
         let id = create_module(&rt, &token, "solo_module", AMBIGUOUS_PATH).await;
 
-        let index = load_code_modules_by_snapshot_path(&rt, &token, REVISION)
+        let (index, ambiguous) = load_code_modules_by_snapshot_path(&rt, &token, REVISION)
             .await
             .unwrap();
         assert_eq!(index.get(AMBIGUOUS_PATH), Some(&Some(id)));
+        assert_eq!(ambiguous, 0);
     }
 
     /// Contract: more than one live module with the same
@@ -2571,7 +2616,7 @@ mod module_index_loader_tests {
         let valid_id = create_module(&rt, &token, "valid_module", AMBIGUOUS_PATH).await;
         insert_unparsable_module_row(&rt, &token, "malformed_module", AMBIGUOUS_PATH).await;
 
-        let index = load_code_modules_by_snapshot_path(&rt, &token, REVISION)
+        let (index, ambiguous) = load_code_modules_by_snapshot_path(&rt, &token, REVISION)
             .await
             .unwrap();
         assert_eq!(
@@ -2580,6 +2625,7 @@ mod module_index_loader_tests {
             "a malformed row is evidence of a second live module for \
              {AMBIGUOUS_PATH}; the valid row {valid_id} must not be selected"
         );
+        assert_eq!(ambiguous, 1, "the ambiguous key is counted for the report");
     }
 
     #[tokio::test]
@@ -2587,7 +2633,7 @@ mod module_index_loader_tests {
         let (rt, token) = rt_and_token();
         insert_unparsable_module_row(&rt, &token, "lonely_malformed", AMBIGUOUS_PATH).await;
 
-        let index = load_code_modules_by_snapshot_path(&rt, &token, REVISION)
+        let (index, ambiguous) = load_code_modules_by_snapshot_path(&rt, &token, REVISION)
             .await
             .unwrap();
         assert_eq!(
@@ -2595,6 +2641,7 @@ mod module_index_loader_tests {
             Some(&None),
             "an unparsable id can never serve as an annotation target"
         );
+        assert_eq!(ambiguous, 1);
     }
 
     /// A failed index load must surface its cause: the caller includes this

--- a/crates/khive-pack-git/src/ingest.rs
+++ b/crates/khive-pack-git/src/ingest.rs
@@ -4,7 +4,7 @@
 //! the standard `create` verb. See crates/khive-pack-git/docs/api/ingest.md for
 //! the full module overview.
 
-use std::collections::HashMap;
+use std::collections::{BTreeSet, HashMap};
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
@@ -589,6 +589,52 @@ async fn find_document_for_path(
     Ok(row.and_then(|r| row_uuid(&r)))
 }
 
+/// Load the live code-map module index for the exact repository snapshot
+/// being digested. ADR-085's `source_path` is relative to a repository root,
+/// so path alone is not a safe cross-repository join key. Requiring the
+/// module's `source_revision` to equal the snapshot HEAD keeps unrelated maps
+/// out; a path with more than one matching live row remains ambiguous and is
+/// deliberately represented by `None` rather than selecting or annotating an
+/// arbitrary candidate.
+async fn load_code_modules_by_snapshot_path(
+    runtime: &KhiveRuntime,
+    token: &NamespaceToken,
+    source_revision: &str,
+) -> Result<HashMap<String, Option<Uuid>>> {
+    let sql = runtime.sql();
+    let mut r = sql.reader().await.map_err(|e| anyhow!("{e}"))?;
+    let rows = r
+        .query_all(SqlStatement {
+            sql: "SELECT id, json_extract(properties,'$.source_path') AS source_path \
+                  FROM entities WHERE kind='concept' AND entity_type='module' \
+                  AND namespace=?1 AND deleted_at IS NULL \
+                  AND json_type(properties,'$.source_path')='text' \
+                  AND json_extract(properties,'$.source_revision')=?2 \
+                  ORDER BY source_path, id"
+                .into(),
+            params: vec![
+                SqlValue::Text(token.namespace().as_str().to_string()),
+                SqlValue::Text(source_revision.to_string()),
+            ],
+            label: Some("git_ingest_load_code_modules_by_snapshot_path".into()),
+        })
+        .await
+        .map_err(|e| anyhow!("{e}"))?;
+
+    let mut modules: HashMap<String, Option<Uuid>> = HashMap::new();
+    for row in rows {
+        let Some(id) = row_uuid(&row) else { continue };
+        let Some(SqlValue::Text(path)) = row.get("source_path") else {
+            continue;
+        };
+        modules
+            .entry(path.clone())
+            .and_modify(|candidate| *candidate = None)
+            .or_insert(Some(id));
+    }
+    Ok(modules)
+}
+
 /// Read the last-ingested cursor value for `(project_id, kind)`, if any.
 async fn read_cursor(
     runtime: &KhiveRuntime,
@@ -650,6 +696,7 @@ async fn write_cursor(
 
 const RECORD_SEP: char = '\u{1e}';
 const FIELD_SEP: char = '\u{1f}';
+const TOUCHED_HEADER_PREFIX: &[u8] = b"/\x1e";
 
 struct RawCommit {
     sha: String,
@@ -767,14 +814,22 @@ fn walk_commits(repo: &Path, since_sha: Option<&str>) -> Result<Vec<RawCommit>> 
 }
 
 /// `sha -> \[touched paths\]` for every commit in `repo`'s history, via a
-/// separate `--name-only` pass.
+/// separate NUL-delimited `--name-only` pass. Merge commits use their
+/// first-parent diff as the one canonical path set. The resulting paths drive
+/// document/module annotations and the durable
+/// `commit.properties.changed_paths` fact.
 fn touched_files(repo: &Path) -> Result<HashMap<String, Vec<String>>> {
     let output = Command::new("git")
         .arg("-C")
         .arg(repo)
         .arg("log")
+        .arg("-z")
         .arg("--name-only")
-        .arg(format!("--pretty=format:{RECORD_SEP}%H"))
+        .arg("--diff-merges=first-parent")
+        // Git paths are always repository-relative, so no tracked path token
+        // can start with `/`. This absolute-looking prefix is therefore an
+        // unambiguous header sentinel in the NUL-delimited token stream.
+        .arg(format!("--pretty=format:/{RECORD_SEP}%H"))
         .output()
         .context("spawning git log --name-only")?;
     if !output.status.success() {
@@ -783,15 +838,82 @@ fn touched_files(repo: &Path) -> Result<HashMap<String, Vec<String>>> {
             stderr: String::from_utf8_lossy(&output.stderr).into_owned(),
         }));
     }
-    let text = String::from_utf8_lossy(&output.stdout);
+    Ok(parse_touched_files(&output.stdout))
+}
+
+fn parse_touched_files(bytes: &[u8]) -> HashMap<String, Vec<String>> {
     let mut map: HashMap<String, Vec<String>> = HashMap::new();
-    for block in text.split(RECORD_SEP) {
-        let mut lines = block.lines().filter(|l| !l.trim().is_empty());
-        let Some(sha) = lines.next() else { continue };
-        let files: Vec<String> = lines.map(str::to_string).collect();
-        map.insert(sha.trim().to_string(), files);
+    // With `-z`, git emits paths verbatim and NUL-terminates each one. Git
+    // may place either one or two NULs between adjacent commit sections, so
+    // parse individual tokens and recognize only the impossible-path header
+    // prefix above. The header and its first path share a token, separated by
+    // one newline; removing exactly that one byte preserves a filename whose
+    // own first byte is a newline.
+    let mut current_sha: Option<String> = None;
+    for token in bytes.split(|byte| *byte == 0) {
+        if token.is_empty() {
+            continue;
+        }
+        if let Some(header) = token.strip_prefix(TOUCHED_HEADER_PREFIX) {
+            if header.len() < 40 || !header[..40].iter().all(u8::is_ascii_hexdigit) {
+                current_sha = None;
+                continue;
+            }
+            let sha = String::from_utf8_lossy(&header[..40]).into_owned();
+            let files = map.entry(sha.clone()).or_default();
+            if let Some(first_path) = header[40..].strip_prefix(b"\n") {
+                if !first_path.is_empty() {
+                    files.push(String::from_utf8_lossy(first_path).into_owned());
+                }
+            }
+            current_sha = Some(sha);
+            continue;
+        }
+        if let Some(sha) = &current_sha {
+            map.get_mut(sha)
+                .expect("current SHA was inserted with its header")
+                .push(String::from_utf8_lossy(token).into_owned());
+        }
     }
-    Ok(map)
+    map
+}
+
+#[cfg(test)]
+mod touched_file_parser_tests {
+    use super::parse_touched_files;
+
+    #[test]
+    fn accepts_single_or_double_nul_commit_boundaries() {
+        let sha_a = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+        let sha_b = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+        let sha_c = "cccccccccccccccccccccccccccccccccccccccc";
+        let raw =
+            format!("/\x1e{sha_a}\nfirst.rs\0second.rs\0/\x1e{sha_b}\nthird.rs\0\0/\x1e{sha_c}\0");
+
+        let parsed = parse_touched_files(raw.as_bytes());
+        assert_eq!(
+            parsed[sha_a],
+            vec!["first.rs".to_string(), "second.rs".to_string()]
+        );
+        assert_eq!(parsed[sha_b], vec!["third.rs".to_string()]);
+        assert!(parsed[sha_c].is_empty());
+    }
+
+    #[test]
+    fn preserves_delimiters_and_uses_lossy_utf8_path_normalization() {
+        let sha = "dddddddddddddddddddddddddddddddddddddddd";
+        let mut raw = format!("/\x1e{sha}\n").into_bytes();
+        raw.extend_from_slice(b"src/caf\xc3\xa9\t\"quoted\"\\leaf\nline.rs\0bad-\xff.rs\0");
+
+        let parsed = parse_touched_files(&raw);
+        assert_eq!(
+            parsed[sha],
+            vec![
+                "src/café\t\"quoted\"\\leaf\nline.rs".to_string(),
+                "bad-�.rs".to_string(),
+            ]
+        );
+    }
 }
 
 /// The two `git log` passes a commit-ingest phase needs, loaded together so
@@ -978,6 +1100,17 @@ async fn ingest_commits(
         return Ok(());
     }
 
+    // `walk_commits` is oldest-first and includes HEAD whenever this phase
+    // has work, so the last record is the exact repository snapshot against
+    // which ADR-085 `source_revision` must bind.
+    let snapshot_head = commits
+        .last()
+        .expect("non-empty commit snapshot checked above")
+        .sha
+        .clone();
+    let code_modules_by_source_path =
+        load_code_modules_by_snapshot_path(runtime, token, &snapshot_head).await?;
+
     // `cursor_stalled` freezes `last_sha` at the last contiguous successfully
     // processed commit: once a record fails to create, later records in this
     // same pass are still attempted (so a run surfaces every failure it can,
@@ -1015,15 +1148,23 @@ async fn ingest_commits(
             format!("{}\n\n{}", masked.subject, masked.body)
         };
 
-        let mut annotates = vec![project_id.to_string()];
+        let changed_paths: Vec<String> = files_by_sha
+            .get(&c.sha)
+            .into_iter()
+            .flatten()
+            .map(|path| secret_gate::mask_secrets(path).into_owned())
+            .collect::<BTreeSet<_>>()
+            .into_iter()
+            .collect();
+        let mut annotates = BTreeSet::from([project_id.to_string()]);
 
-        if let Some(paths) = files_by_sha.get(&c.sha) {
-            for p in paths {
-                if !p.starts_with("docs/adr/") {
-                    continue;
-                }
-                if let Some(doc_id) = find_document_for_path(runtime, token, p).await? {
-                    annotates.push(doc_id.to_string());
+        for path in &changed_paths {
+            if let Some(Some(module_id)) = code_modules_by_source_path.get(path) {
+                annotates.insert(module_id.to_string());
+            }
+            if path.starts_with("docs/adr/") {
+                if let Some(doc_id) = find_document_for_path(runtime, token, path).await? {
+                    annotates.insert(doc_id.to_string());
                 }
             }
         }
@@ -1044,7 +1185,7 @@ async fn ingest_commits(
             },
         };
         if let Some(pr_id) = pr_id {
-            annotates.push(pr_id.to_string());
+            annotates.insert(pr_id.to_string());
         }
 
         let properties = json!({
@@ -1054,6 +1195,7 @@ async fn ingest_commits(
             "author_email": masked.author_email,
             "committed_at": masked.committed_at,
             "parents": masked.parents,
+            "changed_paths": changed_paths,
         });
 
         let name = refs::truncate_chars(
@@ -1067,7 +1209,7 @@ async fn ingest_commits(
             "name": name,
             "content": content,
             "properties": properties,
-            "annotates": annotates,
+            "annotates": annotates.into_iter().collect::<Vec<_>>(),
         });
         if let Some(head) = embedding_head {
             create_request["embedding_content"] = json!(head);

--- a/crates/khive-pack-git/src/ingest.rs
+++ b/crates/khive-pack-git/src/ingest.rs
@@ -199,10 +199,13 @@ pub struct IngestReport {
     /// crates/khive-pack-git/docs/api/ingest.md#changed-paths-and-code-module-annotations.
     pub changed_paths_filtered_noncanonical: u64,
     /// Changed paths whose `(source_revision, source_path)` module binding
-    /// was ambiguous (more than one live row, at most one with a parseable
-    /// id) and therefore received no code-module annotation — counted only
-    /// when an ingested commit's path actually hits the ambiguous key, so
-    /// ambiguous keys untouched by this pass never inflate the count.
+    /// was unusable and therefore received no code-module annotation. Two
+    /// shapes fold into this counter: an ambiguous key (more than one live
+    /// row, at most one with a parseable id) and the single-row sub-case
+    /// whose one row's id does not parse (not ambiguous — just no bindable
+    /// candidate). Counted only when an ingested commit's path actually
+    /// hits the key, so unusable keys untouched by this pass never inflate
+    /// the count.
     pub code_module_ambiguous_path_skips: u64,
 }
 
@@ -610,9 +613,14 @@ async fn find_document_for_path(
 /// module's `source_revision` to equal the snapshot HEAD keeps unrelated maps
 /// out; a path with more than one matching live row remains ambiguous and is
 /// deliberately represented by `None` rather than selecting or annotating an
-/// arbitrary candidate. A row whose `id` does not parse as a UUID still
-/// counts toward that ambiguity — it is evidence of a second live row for
-/// the same key — but can never itself serve as a binding target.
+/// arbitrary candidate. That `None` folds two distinct shapes, both
+/// counted in the same skip counter: (a) two or more rows of which at most
+/// one has a parseable id (true ambiguity), and (b) exactly ONE row whose
+/// id does not parse — a key that is not ambiguous but has no bindable
+/// candidate, so it must skip for the same reason. Shape (b) is a live row
+/// for the key exactly like any other; it occupies the slot (a second row
+/// for the same key marks the pair ambiguous under shape (a)) but can never
+/// itself serve as a binding target.
 ///
 /// A reader/query failure returns `Err` carrying the underlying error text;
 /// the caller degrades to no module annotation with a warning that includes
@@ -887,14 +895,21 @@ fn touched_files(repo: &Path) -> Result<HashMap<String, Vec<String>>> {
 /// of a parser/git-output mismatch.
 ///
 /// One ambiguity this layer cannot resolve: a non-header token is
-/// indistinguishable from a real path of the most recent header's commit, so
-/// a header that goes missing mid-stream (with its NUL separator) leaves the
-/// deleted record's paths attached to the previous commit. Detecting that
-/// would require judging path content against a commit the parse never saw,
-/// so the parser deliberately does not try; the containment is upstream —
-/// `ingest_commits` finds no path-set entry for the missing sha, warns, and
-/// stalls the cursor (`ingest_stalls_cursor_for_commit_missing_touched_paths`
-/// also pins that the previous commit keeps exactly its own paths).
+/// indistinguishable from a real path of the most recent header's commit.
+/// The `--name-only` walk is newest-first, so a header lost mid-stream (with
+/// its NUL separator) leaves the deleted record's path tokens attached to
+/// that NEWER commit — the commit already walked in the same stream — never
+/// to an older one. Containment is partial and per-record, not per-stream:
+/// the missing sha has no path-set entry, so `ingest_commits` skips it,
+/// warns, and stalls the cursor
+/// (`ingest_stalls_cursor_for_commit_missing_touched_paths` pins both), but
+/// the polluted NEWER commit is created as usual — the orphaned tokens ride
+/// into its `changed_paths`, and commit notes are immutable, so the
+/// pollution persists (a re-ingest skips the already-stored sha; repair
+/// requires deleting the note and re-ingesting). The fixture asserts
+/// exactly that pollution.
+/// The parser deliberately does not try to detect it: that would require
+/// judging path content against a commit the parse never saw.
 fn parse_touched_files(bytes: &[u8]) -> Result<HashMap<String, Vec<String>>> {
     let mut map: HashMap<String, Vec<String>> = HashMap::new();
     // With `-z`, git emits paths verbatim and NUL-terminates each one. Git
@@ -1225,7 +1240,13 @@ async fn ingest_commits(
 
     // `walk_commits` is oldest-first and includes HEAD whenever this phase
     // has work, so the last record is the exact repository snapshot against
-    // which ADR-085 `source_revision` must bind.
+    // which ADR-085 `source_revision` must bind. The walk itself is never
+    // truncated: it issues one unbounded `git log {since}..HEAD`, and
+    // `max_items` bounds only the create loop below (a budget check AFTER
+    // this point), never the snapshot. `snapshot_head` is therefore always
+    // the true repository HEAD of this pass, and the module index anchors to
+    // modules-as-of-HEAD regardless of how many commits the budget lets this
+    // pass create.
     let snapshot_head = commits
         .last()
         .expect("non-empty commit snapshot checked above")
@@ -1258,6 +1279,12 @@ async fn ingest_commits(
     // sha natural key), so a retried pass never double-creates them.
     let mut last_sha: Option<String> = since;
     let mut cursor_stalled = false;
+    // Bounded detail for the per-run ambiguous-module-skip warning: the
+    // masked skipped paths in encounter order, capped so one pathological
+    // run cannot bloat the report (the full count is always exact).
+    const AMBIGUOUS_SKIP_DETAIL_CAP: usize = 5;
+    const AMBIGUOUS_SKIP_PATH_DISPLAY_CHARS: usize = 80;
+    let mut ambiguous_module_skip_paths: Vec<String> = Vec::new();
     // Parent SHA -> note id for commits created earlier THIS pass (walked
     // oldest-first) — combined with `find_commit_by_sha`'s DB lookup below,
     // this resolves parent edges regardless of which pass the parent landed
@@ -1303,13 +1330,18 @@ async fn ingest_commits(
         // them, which would fail the whole commit create and stall the
         // cursor on every pass). Filter them here, against the same
         // predicate the hook enforces, and surface the per-run count below.
-        // Only actual predicate rejections count as drops: BTreeSet dedup
-        // and post-masking collisions are not drops and are neither counted
+        // The predicate runs on the RAW path, not the masked one: a secret
+        // token can itself contain a rejected byte (the masker's tokens are
+        // whitespace-delimited, so a backslash or NUL inside a token is
+        // redacted along with it), and filtering post-masking would then
+        // flip the verdict from reject to accept. Masking is applied only
+        // to the paths that survive the raw filter, for storage. Only
+        // actual predicate rejections count as drops: BTreeSet dedup and
+        // post-masking collisions are not drops and are neither counted
         // nor warned.
         let mut noncanonical = 0_u64;
         let changed_paths: Vec<String> = touched_paths
             .iter()
-            .map(|path| secret_gate::mask_secrets(path).into_owned())
             .filter(|path| {
                 let canonical = hook::is_repo_relative_path(path);
                 if !canonical {
@@ -1317,6 +1349,7 @@ async fn ingest_commits(
                 }
                 canonical
             })
+            .map(|path| secret_gate::mask_secrets(path).into_owned())
             .collect::<BTreeSet<_>>()
             .into_iter()
             .collect();
@@ -1340,12 +1373,17 @@ async fn ingest_commits(
                 Some(Some(module_id)) => {
                     annotates.insert(module_id.to_string());
                 }
-                // More than one live row binds this `(source_revision,
-                // source_path)` key (at most one of them with a parseable
-                // id — an unparsable-id row only ever occupies the slot):
-                // no candidate is annotated, and the skip is counted once
-                // per commit path that actually hit the ambiguous key.
-                Some(None) => report.code_module_ambiguous_path_skips += 1,
+                // The key is unusable — either more than one live row binds
+                // it (at most one with a parseable id) or its single row's
+                // id does not parse — so no candidate is annotated. Both
+                // shapes count once per commit path that hits the key (the
+                // path is also remembered for the bounded per-run warning
+                // below); see `load_code_modules_by_snapshot_path` for the
+                // fold.
+                Some(None) => {
+                    report.code_module_ambiguous_path_skips += 1;
+                    ambiguous_module_skip_paths.push(path.clone());
+                }
                 None => {}
             }
             if path.starts_with("docs/adr/") {
@@ -1469,15 +1507,43 @@ async fn ingest_commits(
         write_cursor(runtime, project_id, "commits", &sha).await?;
     }
     // One bounded line per run (never one per path): filenames are
-    // attacker/repo-controlled and may be long, so the count alone is
-    // surfaced; the paths themselves remain recoverable from the raw
-    // `git log -z --name-only` stream if an operator needs them.
+    // attacker/repo-controlled and may be long, so the count is the
+    // load-bearing fact; a bounded masked path sample rides along so the
+    // count is actionable, and the full set remains recoverable from the
+    // raw `git log -z --name-only` stream if an operator needs it.
     if report.changed_paths_filtered_noncanonical > 0 {
         report.warnings.push(format!(
             "{} touched path(s) dropped from changed_paths: outside the \
-             canonical repo-relative shape (backslash, `X:` drive prefix, \
-             leading `/`, or empty/`.`/`..` component)",
+             canonical repo-relative shape (NUL byte, backslash, `X:` \
+             drive prefix, leading `/`, or empty/`.`/`..` component)",
             report.changed_paths_filtered_noncanonical
+        ));
+    }
+    if report.code_module_ambiguous_path_skips > 0 {
+        // Every skip records its masked path above, so the vec length is the
+        // exact count; only the displayed sample is capped.
+        let shown = ambiguous_module_skip_paths
+            .len()
+            .min(AMBIGUOUS_SKIP_DETAIL_CAP);
+        let detail = ambiguous_module_skip_paths[..shown]
+            .iter()
+            .map(|path| {
+                let display = refs::truncate_chars(path, AMBIGUOUS_SKIP_PATH_DISPLAY_CHARS);
+                format!("{display:?}")
+            })
+            .collect::<Vec<_>>()
+            .join(", ");
+        let remaining = ambiguous_module_skip_paths.len() - shown;
+        let suffix = if remaining > 0 {
+            format!(", +{remaining} more")
+        } else {
+            String::new()
+        };
+        report.warnings.push(format!(
+            "{} changed path(s) skipped code-module annotation: no usable \
+             (source_revision, source_path) binding (first {shown}: \
+             [{detail}]{suffix})",
+            report.code_module_ambiguous_path_skips
         ));
     }
     if let Some(warning) = recovery_warning {

--- a/crates/khive-pack-git/tests/acceptance.rs
+++ b/crates/khive-pack-git/tests/acceptance.rs
@@ -131,6 +131,31 @@ async fn create(registry: &VerbRegistry, body: Value) -> Uuid {
     Uuid::parse_str(resp["id"].as_str().expect("id present")).expect("id is uuid")
 }
 
+async fn incoming_annotating_ids(
+    registry: &VerbRegistry,
+    target_id: Uuid,
+) -> std::collections::BTreeSet<String> {
+    registry
+        .dispatch(
+            "neighbors",
+            json!({
+                "id": target_id.to_string(),
+                "direction": "incoming",
+                "relations": ["annotates"]
+            }),
+        )
+        .await
+        .expect("target neighbors")
+        .as_array()
+        .expect("neighbor array")
+        .iter()
+        .map(|neighbor| {
+            assert_eq!(neighbor["kind"], "commit");
+            neighbor["id"].as_str().expect("commit id").to_string()
+        })
+        .collect()
+}
+
 fn git(repo: &Path, args: &[&str]) {
     let out = Command::new("git")
         .arg("-C")
@@ -381,6 +406,361 @@ async fn ingest_links_commits_to_document_and_pr_by_provenance_query() {
     );
 }
 
+/// Issue #1604: changed-path properties and exact ADR-085 `source_path`
+/// annotations make module churn and repeated cross-project co-change
+/// computable from graph reads without reopening git history.
+#[tokio::test]
+async fn ingest_records_changed_paths_and_links_code_modules() {
+    let _guard = ENV_MUTEX.lock().await;
+    let (rt, token, registry) = fixture().await;
+
+    let project_id = create(
+        &registry,
+        json!({"kind": "project", "name": "path-provenance-repo"}),
+    )
+    .await;
+
+    let dir = tempfile::tempdir().expect("tempdir");
+    let repo = dir.path();
+    init_repo(repo);
+
+    write(repo, "crates/crate-a/src/lib.rs", "pub fn a() {}\n");
+    write(repo, "crates/crate-b/src/lib.rs", "pub fn b() {}\n");
+    commit(
+        repo,
+        &["crates/crate-a/src/lib.rs", "crates/crate-b/src/lib.rs"],
+        "Add both crates",
+    );
+    let both_1 = head_sha(repo);
+
+    write(
+        repo,
+        "crates/crate-a/src/lib.rs",
+        "pub fn a() {}\npub fn a2() {}\n",
+    );
+    commit(repo, &["crates/crate-a/src/lib.rs"], "Change crate A");
+    let only_a = head_sha(repo);
+
+    write(
+        repo,
+        "crates/crate-a/src/lib.rs",
+        "pub fn a() {}\npub fn a2() {}\npub fn a3() {}\n",
+    );
+    write(
+        repo,
+        "crates/crate-b/src/lib.rs",
+        "pub fn b() {}\npub fn b2() {}\n",
+    );
+    commit(
+        repo,
+        &["crates/crate-a/src/lib.rs", "crates/crate-b/src/lib.rs"],
+        "Change both crates again",
+    );
+    let both_2 = head_sha(repo);
+
+    // ADR-085 scopes physical paths to a repository snapshot. A second map
+    // can legitimately carry the same relative path, so the revision must
+    // participate in the binding or digesting this repository would
+    // fabricate an annotation to the other repository's module.
+    let other_dir = tempfile::tempdir().expect("other tempdir");
+    let other_repo = other_dir.path();
+    init_repo(other_repo);
+    write(
+        other_repo,
+        "crates/crate-a/src/lib.rs",
+        "pub fn from_other_repo() {}\n",
+    );
+    commit(
+        other_repo,
+        &["crates/crate-a/src/lib.rs"],
+        "Other repository",
+    );
+    let other_revision = head_sha(other_repo);
+    assert_ne!(both_2, other_revision);
+
+    let module_a = create(
+        &registry,
+        json!({
+            "kind": "concept",
+            "entity_type": "module",
+            "name": "crate_a",
+            "properties": {
+                "source_project": "crate-a",
+                "source_path": "crates/crate-a/src/lib.rs",
+                "source_revision": both_2.clone()
+            }
+        }),
+    )
+    .await;
+    let module_b = create(
+        &registry,
+        json!({
+            "kind": "concept",
+            "entity_type": "module",
+            "name": "crate_b",
+            "properties": {
+                "source_project": "crate-b",
+                "source_path": "crates/crate-b/src/lib.rs",
+                "source_revision": both_2.clone()
+            }
+        }),
+    )
+    .await;
+    let other_repo_module = create(
+        &registry,
+        json!({
+            "kind": "concept",
+            "entity_type": "module",
+            "name": "other_crate_a",
+            "properties": {
+                "source_project": "other-crate-a",
+                "source_path": "crates/crate-a/src/lib.rs",
+                "source_revision": other_revision
+            }
+        }),
+    )
+    .await;
+
+    let report = run_ingest(
+        &rt,
+        &token,
+        &registry,
+        IngestOptions::unbounded(repo.to_path_buf(), project_id.to_string()),
+    )
+    .await
+    .expect("ingest ok");
+    assert_eq!(report.commits_ingested, 3, "{report:?}");
+
+    let commits = registry
+        .dispatch("list", json!({"kind": "commit", "limit": 10}))
+        .await
+        .expect("list commits");
+    let paths_by_sha: std::collections::HashMap<String, Vec<String>> = commits
+        .as_array()
+        .expect("commit array")
+        .iter()
+        .map(|note| {
+            let sha = note["properties"]["sha"].as_str().expect("sha").to_string();
+            let paths = note["properties"]["changed_paths"]
+                .as_array()
+                .expect("changed_paths array")
+                .iter()
+                .map(|path| path.as_str().expect("path string").to_string())
+                .collect();
+            (sha, paths)
+        })
+        .collect();
+    let both_paths = vec![
+        "crates/crate-a/src/lib.rs".to_string(),
+        "crates/crate-b/src/lib.rs".to_string(),
+    ];
+    assert_eq!(paths_by_sha[&both_1], both_paths);
+    assert_eq!(
+        paths_by_sha[&only_a],
+        vec!["crates/crate-a/src/lib.rs".to_string()]
+    );
+    assert_eq!(paths_by_sha[&both_2], both_paths);
+
+    let module_a_commits = incoming_annotating_ids(&registry, module_a).await;
+    let module_b_commits = incoming_annotating_ids(&registry, module_b).await;
+    assert_eq!(module_a_commits.len(), 3, "crate-a churn");
+    assert_eq!(module_b_commits.len(), 2, "crate-b churn");
+    assert!(
+        incoming_annotating_ids(&registry, other_repo_module)
+            .await
+            .is_empty(),
+        "same relative path from another repository must not cross-annotate"
+    );
+    assert_eq!(
+        module_a_commits.intersection(&module_b_commits).count(),
+        2,
+        "the cross-crate pair co-changed in two commits"
+    );
+}
+
+/// A shared revision can occur in two forks. Revision-plus-path narrows the
+/// repository snapshot, but it must not become an arbitrary tie-breaker when
+/// two live module rows still claim that identity.
+#[tokio::test]
+async fn ingest_skips_ambiguous_snapshot_path_bindings() {
+    let _guard = ENV_MUTEX.lock().await;
+    let (rt, token, registry) = fixture().await;
+    let project_id = create(
+        &registry,
+        json!({"kind": "project", "name": "ambiguous-path-repo"}),
+    )
+    .await;
+
+    let dir = tempfile::tempdir().expect("tempdir");
+    let repo = dir.path();
+    init_repo(repo);
+    write(repo, "src/lib.rs", "pub fn shared() {}\n");
+    commit(repo, &["src/lib.rs"], "Shared snapshot");
+    let revision = head_sha(repo);
+
+    let first = create(
+        &registry,
+        json!({
+            "kind": "concept",
+            "entity_type": "module",
+            "name": "first_shared_module",
+            "properties": {
+                "source_project": "first-project",
+                "source_path": "src/lib.rs",
+                "source_revision": revision.clone()
+            }
+        }),
+    )
+    .await;
+    let second = create(
+        &registry,
+        json!({
+            "kind": "concept",
+            "entity_type": "module",
+            "name": "second_shared_module",
+            "properties": {
+                "source_project": "second-project",
+                "source_path": "src/lib.rs",
+                "source_revision": revision
+            }
+        }),
+    )
+    .await;
+
+    let report = run_ingest(
+        &rt,
+        &token,
+        &registry,
+        IngestOptions::unbounded(repo.to_path_buf(), project_id.to_string()),
+    )
+    .await
+    .expect("ingest ok");
+    assert_eq!(report.commits_ingested, 1, "{report:?}");
+    assert!(incoming_annotating_ids(&registry, first).await.is_empty());
+    assert!(incoming_annotating_ids(&registry, second).await.is_empty());
+}
+
+/// Issue #1604: `git log -z` is required for an exact path identity. Git's
+/// display form quotes non-ASCII and delimiter-bearing names, which would not
+/// equal ADR-085's filesystem-derived `source_path`.
+#[cfg(unix)]
+#[tokio::test]
+async fn ingest_preserves_unicode_and_delimiter_bearing_changed_paths() {
+    let _guard = ENV_MUTEX.lock().await;
+    let (rt, token, registry) = fixture().await;
+    let project_id = create(
+        &registry,
+        json!({"kind": "project", "name": "raw-path-repo"}),
+    )
+    .await;
+
+    let dir = tempfile::tempdir().expect("tempdir");
+    let repo = dir.path();
+    init_repo(repo);
+    let unusual_path = "src/café\t\"quoted\"\\leaf\nline.rs";
+    write(repo, unusual_path, "pub fn unusual() {}\n");
+    commit(repo, &[unusual_path], "Add unusual path");
+    let revision = head_sha(repo);
+
+    let module_id = create(
+        &registry,
+        json!({
+            "kind": "concept",
+            "entity_type": "module",
+            "name": "unusual_module",
+            "properties": {
+                "source_project": "raw-path-repo",
+                "source_path": unusual_path,
+                "source_revision": revision
+            }
+        }),
+    )
+    .await;
+
+    let report = run_ingest(
+        &rt,
+        &token,
+        &registry,
+        IngestOptions::unbounded(repo.to_path_buf(), project_id.to_string()),
+    )
+    .await
+    .expect("ingest ok");
+    assert_eq!(report.commits_ingested, 1, "{report:?}");
+
+    let commits = registry
+        .dispatch("list", json!({"kind": "commit", "limit": 10}))
+        .await
+        .expect("list commits");
+    assert_eq!(
+        commits.as_array().expect("commit array")[0]["properties"]["changed_paths"],
+        json!([unusual_path])
+    );
+    assert_eq!(
+        incoming_annotating_ids(&registry, module_id).await.len(),
+        1,
+        "raw path must retain its exact module binding"
+    );
+}
+
+/// Issue #1604: merge commits use their first-parent diff as their one
+/// canonical changed-path set. This records the change introduced to the
+/// destination branch without producing one path set per parent.
+#[tokio::test]
+async fn ingest_records_first_parent_paths_for_merge_commits() {
+    let _guard = ENV_MUTEX.lock().await;
+    let (rt, token, registry) = fixture().await;
+    let project_id = create(
+        &registry,
+        json!({"kind": "project", "name": "merge-path-repo"}),
+    )
+    .await;
+
+    let dir = tempfile::tempdir().expect("tempdir");
+    let repo = dir.path();
+    init_repo(repo);
+    write(repo, "base.rs", "pub fn base() {}\n");
+    commit(repo, &["base.rs"], "Base");
+
+    git(repo, &["checkout", "-q", "-b", "feature"]);
+    write(repo, "feature.rs", "pub fn feature() {}\n");
+    commit(repo, &["feature.rs"], "Feature");
+
+    git(repo, &["checkout", "-q", "main"]);
+    write(repo, "main.rs", "pub fn main_change() {}\n");
+    commit(repo, &["main.rs"], "Main change");
+    git(
+        repo,
+        &["merge", "-q", "--no-ff", "feature", "-m", "Merge feature"],
+    );
+    let merge_sha = head_sha(repo);
+
+    let report = run_ingest(
+        &rt,
+        &token,
+        &registry,
+        IngestOptions::unbounded(repo.to_path_buf(), project_id.to_string()),
+    )
+    .await
+    .expect("ingest ok");
+    assert_eq!(report.commits_ingested, 4, "{report:?}");
+
+    let commits = registry
+        .dispatch("list", json!({"kind": "commit", "limit": 10}))
+        .await
+        .expect("list commits");
+    let merge = commits
+        .as_array()
+        .expect("commit array")
+        .iter()
+        .find(|note| note["properties"]["sha"] == merge_sha)
+        .expect("merge commit");
+    assert_eq!(
+        merge["properties"]["changed_paths"],
+        json!(["feature.rs"]),
+        "merge path set is the diff against its first parent"
+    );
+}
+
 /// Coordinator addendum requirement: a commit message containing a
 /// credential-shaped token must be masked before it is stored.
 #[tokio::test]
@@ -427,6 +807,47 @@ async fn ingest_masks_secrets_in_commit_message() {
         stored_content.contains("***MASKED***") || stored_content.contains("MASKED"),
         "masked marker must be present: {stored_content:?}"
     );
+}
+
+#[tokio::test]
+async fn ingest_masks_secret_shaped_changed_paths() {
+    let _guard = ENV_MUTEX.lock().await;
+    let (rt, token, registry) = fixture().await;
+    let project_id = create(
+        &registry,
+        json!({"kind": "project", "name": "secret-path-repo"}),
+    )
+    .await;
+
+    let dir = tempfile::tempdir().expect("tempdir");
+    let repo = dir.path();
+    init_repo(repo);
+    let fake_token = "ghp_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+    let rel = format!("src/{fake_token}.rs");
+    write(repo, &rel, "pub fn safe() {}\n");
+    commit(repo, &[rel.as_str()], "Add source file");
+
+    let report = run_ingest(
+        &rt,
+        &token,
+        &registry,
+        IngestOptions::unbounded(repo.to_path_buf(), project_id.to_string()),
+    )
+    .await
+    .expect("ingest ok");
+    assert_eq!(report.commits_ingested, 1, "{report:?}");
+    assert_eq!(report.writes_refused, 0, "{report:?}");
+
+    let commits = registry
+        .dispatch("list", json!({"kind": "commit", "limit": 10}))
+        .await
+        .expect("list commits");
+    let commit = &commits.as_array().expect("commit array")[0];
+    let stored_path = commit["properties"]["changed_paths"][0]
+        .as_str()
+        .expect("changed path");
+    assert!(!stored_path.contains(fake_token), "{stored_path:?}");
+    assert!(stored_path.contains("MASKED"), "{stored_path:?}");
 }
 
 /// Issue #763 exact acceptance repro: a PR body containing a bare 64-char hex
@@ -1930,6 +2351,36 @@ async fn commit_hook_requires_properties_sha() {
         .await
         .expect_err("missing sha must be rejected");
     assert!(format!("{err}").contains("sha"));
+}
+
+#[tokio::test]
+async fn commit_hook_rejects_invalid_changed_path_shapes() {
+    let (_rt, _token, registry) = fixture().await;
+    for changed_paths in [
+        json!("src/lib.rs"),
+        json!(["/absolute.rs"]),
+        json!(["C:/absolute.rs"]),
+        json!(["src/../secret.rs"]),
+        json!([7]),
+        json!(["z.rs", "a.rs"]),
+        json!(["same.rs", "same.rs"]),
+    ] {
+        let err = registry
+            .dispatch(
+                "create",
+                json!({
+                    "kind": "commit",
+                    "content": "invalid changed path fixture",
+                    "properties": {
+                        "sha": "0000000000000000000000000000000000000000",
+                        "changed_paths": changed_paths
+                    }
+                }),
+            )
+            .await
+            .expect_err("invalid changed_paths must be rejected");
+        assert!(format!("{err}").contains("changed_paths"), "{err}");
+    }
 }
 
 // ── project-scoped idempotency ──────────────────────────────────────────

--- a/crates/khive-pack-git/tests/acceptance.rs
+++ b/crates/khive-pack-git/tests/acceptance.rs
@@ -1002,6 +1002,186 @@ exec "$REAL_GIT" "$@"
     );
 }
 
+/// Unix filenames may legitimately contain `\` or start `X:` — shapes the
+/// hook's canonical `changed_paths` contract can never carry. The ingester
+/// must drop exactly those elements, still store the commit with the
+/// canonical remainder (never fail the create and stall the cursor), count
+/// the dropped paths, and warn once per run.
+#[cfg(unix)]
+#[tokio::test]
+async fn ingest_filters_noncanonical_changed_paths_but_keeps_commit() {
+    let _guard = ENV_MUTEX.lock().await;
+    let (rt, token, registry) = fixture().await;
+    let project_id = create(
+        &registry,
+        json!({"kind": "project", "name": "noncanonical-path-repo"}),
+    )
+    .await;
+
+    let dir = tempfile::tempdir().expect("tempdir");
+    let repo = dir.path();
+    init_repo(repo);
+    write(repo, "good.rs", "pub fn good() {}\n");
+    write(repo, "src/back\\slash.rs", "pub fn backslash() {}\n");
+    write(repo, "X:drive.rs", "pub fn drive() {}\n");
+    commit(
+        repo,
+        &["good.rs", "src/back\\slash.rs", "X:drive.rs"],
+        "Add canonical and non-canonical paths",
+    );
+
+    let report = run_ingest(
+        &rt,
+        &token,
+        &registry,
+        IngestOptions {
+            repo: repo.to_path_buf(),
+            project: project_id.to_string(),
+            max_items: None,
+            include: IngestInclude {
+                commits: true,
+                issues: false,
+                pull_requests: false,
+            },
+        },
+    )
+    .await
+    .expect("a non-canonical path must not fail the pass");
+    assert_eq!(report.commits_ingested, 1, "{report:?}");
+    assert_eq!(
+        report.changed_paths_filtered_noncanonical, 2,
+        "exactly the backslash and drive-prefixed paths are dropped: {report:?}"
+    );
+    let filter_warnings: Vec<&str> = report
+        .warnings
+        .iter()
+        .map(String::as_str)
+        .filter(|w| w.contains("dropped from changed_paths"))
+        .collect();
+    assert_eq!(
+        filter_warnings.len(),
+        1,
+        "one bounded warning per run, never one per path: {:?}",
+        report.warnings
+    );
+    assert!(
+        filter_warnings[0].contains('2'),
+        "the warning carries the dropped count: {}",
+        filter_warnings[0]
+    );
+
+    let commits = registry
+        .dispatch("list", json!({"kind": "commit", "limit": 10}))
+        .await
+        .expect("list commits");
+    let stored = &commits.as_array().expect("commit array")[0];
+    assert_eq!(
+        stored["properties"]["changed_paths"],
+        json!(["good.rs"]),
+        "the commit lands with exactly the canonical remainder"
+    );
+
+    let cursor = read_git_cursor(&rt, project_id, "commits")
+        .await
+        .expect("cursor must be written");
+    assert_eq!(
+        cursor,
+        head_sha(repo),
+        "the cursor advances past the commit: filtered paths never stall a run"
+    );
+}
+
+/// The stalled-cursor contract relies on sha-keyed dedup: a record that
+/// lands AFTER a stall is re-walked by the next pass (the cursor froze
+/// before it) and must come out as `skipped_existing`, never a duplicate
+/// row. Pass 1 stalls on commit B (injected embedder failure) while later
+/// commit C still lands; pass 2 re-walks `first..HEAD`, retries B
+/// successfully, and re-encounters C — total stored rows must stay exactly
+/// one per sha.
+#[tokio::test]
+async fn ingest_repeat_pass_after_stall_creates_no_duplicates() {
+    let _guard = ENV_MUTEX.lock().await;
+    let (rt, token, registry) = fixture().await;
+    rt.register_embedder(FailOnceEmbedderProvider);
+    let project_id = create(
+        &registry,
+        json!({"kind": "project", "name": "stall-redo-repo"}),
+    )
+    .await;
+
+    let dir = tempfile::tempdir().expect("tempdir");
+    let repo = dir.path();
+    init_repo(repo);
+    write(repo, "a.rs", "pub fn a() {}\n");
+    commit(repo, &["a.rs"], "Add a");
+    let sha_a = head_sha(repo);
+    write(repo, "b.rs", "pub fn b() {}\n");
+    commit(repo, &["b.rs"], &format!("Add b {CURSOR_FAIL_SENTINEL}"));
+    let sha_b = head_sha(repo);
+    write(repo, "c.rs", "pub fn c() {}\n");
+    commit(repo, &["c.rs"], "Add c");
+    let sha_c = head_sha(repo);
+
+    let opts = || IngestOptions {
+        repo: repo.to_path_buf(),
+        project: project_id.to_string(),
+        max_items: None,
+        include: IngestInclude {
+            commits: true,
+            issues: false,
+            pull_requests: false,
+        },
+    };
+
+    let report1 = run_ingest(&rt, &token, &registry, opts())
+        .await
+        .expect("pass 1 completes despite the injected failure");
+    assert_eq!(
+        report1.commits_ingested, 2,
+        "A and C land; B fails once on the injected embedder error: {report1:?}"
+    );
+    assert_eq!(
+        read_git_cursor(&rt, project_id, "commits").await.as_deref(),
+        Some(sha_a.as_str()),
+        "pass 1 cursor stalls at A, before failed B"
+    );
+
+    let report2 = run_ingest(&rt, &token, &registry, opts())
+        .await
+        .expect("pass 2 completes");
+    assert_eq!(
+        report2.commits_ingested, 1,
+        "only B is newly created on the retry: {report2:?}"
+    );
+    assert_eq!(
+        report2.commits_skipped_existing, 1,
+        "C is re-walked from the stalled cursor and deduplicated by sha: {report2:?}"
+    );
+    assert_eq!(
+        read_git_cursor(&rt, project_id, "commits").await.as_deref(),
+        Some(sha_c.as_str()),
+        "pass 2 cursor advances to HEAD"
+    );
+
+    let commits = registry
+        .dispatch("list", json!({"kind": "commit", "limit": 10}))
+        .await
+        .expect("list commits");
+    let mut shas: Vec<&str> = commits
+        .as_array()
+        .expect("commit array")
+        .iter()
+        .map(|note| note["properties"]["sha"].as_str().expect("sha"))
+        .collect();
+    shas.sort_unstable();
+    let mut expected = [sha_a.as_str(), sha_b.as_str(), sha_c.as_str()];
+    expected.sort_unstable();
+    assert_eq!(
+        shas, expected,
+        "exactly one stored row per sha after the repeat pass"
+    );
+}
+
 /// Coordinator addendum requirement: a commit message containing a
 /// credential-shaped token must be masked before it is stored.
 #[tokio::test]
@@ -2606,6 +2786,11 @@ async fn commit_hook_rejects_invalid_changed_path_shapes() {
         json!(["src\\file.rs"]),
         json!(["\\\\server\\share\\file.rs"]),
         json!(["src/../secret.rs"]),
+        json!([""]),
+        json!(["src//file.rs"]),
+        json!(["./src/file.rs"]),
+        json!(["src/./file.rs"]),
+        json!(["src/file.rs\0trailing"]),
         json!([7]),
         json!(["z.rs", "a.rs"]),
         json!(["same.rs", "same.rs"]),
@@ -2687,6 +2872,28 @@ async fn commit_hook_accepts_canonical_changed_paths() {
         )
         .await
         .expect("a sorted, deduplicated repo-relative path array is accepted");
+
+    // The multi-element canonical shape the ingester emits: every element
+    // repo-relative, the whole array sorted and deduplicated.
+    registry
+        .dispatch(
+            "create",
+            json!({
+                "kind": "commit",
+                "content": "canonical multi-path fixture",
+                "properties": {
+                    "sha": "3333333333333333333333333333333333333333",
+                    "changed_paths": [
+                        "crates/a/src/lib.rs",
+                        "crates/b/src/lib.rs",
+                        "docs/api/ingest.md",
+                        "src/main.rs"
+                    ]
+                }
+            }),
+        )
+        .await
+        .expect("a sorted multi-element repo-relative path array is accepted");
 }
 
 // ── project-scoped idempotency ──────────────────────────────────────────

--- a/crates/khive-pack-git/tests/acceptance.rs
+++ b/crates/khive-pack-git/tests/acceptance.rs
@@ -13,7 +13,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, LazyLock, Mutex};
 
 use async_trait::async_trait;
-use khive_pack_git::ingest::{run_ingest, IngestOptions};
+use khive_pack_git::ingest::{run_ingest, IngestInclude, IngestOptions};
 use khive_pack_git::GitPack;
 use khive_pack_kg::KgPack;
 use khive_runtime::{
@@ -196,6 +196,19 @@ fn head_sha(repo: &Path) -> String {
         .args(["rev-parse", "HEAD"])
         .output()
         .expect("rev-parse");
+    String::from_utf8_lossy(&out.stdout).trim().to_string()
+}
+
+/// Absolute path of the real `git` binary, resolved BEFORE any test shadows
+/// `PATH` — shims delegate every invocation they do not script to it (same
+/// technique as `src/recovery_tests.rs`).
+fn resolve_real_git() -> String {
+    let out = Command::new("sh")
+        .arg("-c")
+        .arg("command -v git")
+        .output()
+        .expect("resolve real git");
+    assert!(out.status.success(), "could not resolve real git on PATH");
     String::from_utf8_lossy(&out.stdout).trim().to_string()
 }
 
@@ -657,7 +670,12 @@ async fn ingest_preserves_unicode_and_delimiter_bearing_changed_paths() {
     let dir = tempfile::tempdir().expect("tempdir");
     let repo = dir.path();
     init_repo(repo);
-    let unusual_path = "src/café\t\"quoted\"\\leaf\nline.rs";
+    // Backslash is deliberately absent: the hook's canonical shape is
+    // `/`-separated repo-relative and rejects `\` anywhere, so a
+    // backslash-bearing filesystem name can never round-trip through
+    // `changed_paths`. Tab, quote, newline, and non-ASCII coverage remain —
+    // all of them still trigger git's quoted display form without `-z`.
+    let unusual_path = "src/café\t\"quoted\"leaf\nline.rs";
     write(repo, unusual_path, "pub fn unusual() {}\n");
     commit(repo, &[unusual_path], "Add unusual path");
     let revision = head_sha(repo);
@@ -857,6 +875,130 @@ async fn ingest_records_both_sides_of_a_rename() {
         rename["properties"]["changed_paths"],
         json!(["new.rs", "old.rs"]),
         "a rename records both the deleted and the added path"
+    );
+}
+
+/// A walked commit with no touched-path entry must never be stored with a
+/// fabricated `[]`: the run warns naming the commit, stalls the cursor at
+/// the last contiguous successful commit, and still completes (see
+/// docs/api/ingest.md#changed-paths-and-code-module-annotations).
+#[tokio::test]
+async fn ingest_stalls_cursor_for_commit_missing_touched_paths() {
+    let _guard = ENV_MUTEX.lock().await;
+    let (rt, token, registry) = fixture().await;
+    let project_id = create(
+        &registry,
+        json!({"kind": "project", "name": "touched-gap-repo"}),
+    )
+    .await;
+
+    let dir = tempfile::tempdir().expect("tempdir");
+    let repo = dir.path();
+    init_repo(repo);
+    write(repo, "first.rs", "pub fn first() {}\n");
+    commit(repo, &["first.rs"], "First");
+    let first_sha = head_sha(repo);
+    write(repo, "second.rs", "pub fn second() {}\n");
+    commit(repo, &["second.rs"], "Second");
+    let second_sha = head_sha(repo);
+    write(repo, "third.rs", "pub fn third() {}\n");
+    commit(repo, &["third.rs"], "Third");
+    let third_sha = head_sha(repo);
+
+    // The `--name-only` pass is the sole authority for touched paths. This
+    // PATH-shadowing shim deletes the middle commit's header from that one
+    // stream so the two snapshot passes disagree exactly the way the
+    // degradation branch handles; every other invocation delegates to the
+    // real git binary (same technique as `src/recovery_tests.rs`).
+    let real_git = resolve_real_git();
+    let bin_dir = dir.path().join("bin");
+    std::fs::create_dir_all(&bin_dir).expect("create bin dir");
+    std::fs::write(
+        bin_dir.join("git"),
+        format!(
+            r#"#!/bin/sh
+REAL_GIT="{real_git}"
+case " $* " in
+  *" --name-only "*)
+    "$REAL_GIT" "$@" | tr '\0' '\n' | grep -av '{second_sha}' | tr '\n' '\0'
+    exit 0
+    ;;
+esac
+exec "$REAL_GIT" "$@"
+"#,
+            real_git = real_git,
+            second_sha = second_sha,
+        ),
+    )
+    .expect("write git shim");
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let mut perms = std::fs::metadata(bin_dir.join("git"))
+            .expect("shim metadata")
+            .permissions();
+        perms.set_mode(0o755);
+        std::fs::set_permissions(bin_dir.join("git"), perms).expect("chmod shim");
+    }
+    let _path_guard = PathGuard::install(&bin_dir);
+
+    let report = run_ingest(
+        &rt,
+        &token,
+        &registry,
+        IngestOptions {
+            repo: repo.to_path_buf(),
+            project: project_id.to_string(),
+            max_items: None,
+            include: IngestInclude {
+                commits: true,
+                issues: false,
+                pull_requests: false,
+            },
+        },
+    )
+    .await
+    .expect("the run completes despite the touched-path gap");
+    assert!(report.done, "an unbounded pass still finishes: {report:?}");
+    assert!(
+        report
+            .warnings
+            .iter()
+            .any(|w| w.contains("no touched-path set recorded") && w.contains(&second_sha)),
+        "the gap must surface as a warning naming the stalled commit: {:?}",
+        report.warnings
+    );
+    assert_eq!(
+        report.commits_ingested, 2,
+        "the two commits with recorded path sets still land: {report:?}"
+    );
+
+    let cursor = read_git_cursor(&rt, project_id, "commits")
+        .await
+        .expect("cursor must be written");
+    assert_eq!(
+        cursor, first_sha,
+        "the cursor must stall at the last contiguous successful commit, \
+         never advance past the gap"
+    );
+
+    let commits = registry
+        .dispatch("list", json!({"kind": "commit", "limit": 10}))
+        .await
+        .expect("list commits");
+    let stored_shas: Vec<&str> = commits
+        .as_array()
+        .expect("commit array")
+        .iter()
+        .map(|note| note["properties"]["sha"].as_str().expect("sha"))
+        .collect();
+    assert!(
+        !stored_shas.contains(&second_sha.as_str()),
+        "the gap commit must never be stored with a fabricated []: {stored_shas:?}"
+    );
+    assert!(
+        stored_shas.contains(&third_sha.as_str()),
+        "a commit after the gap is still attempted and lands: {stored_shas:?}"
     );
 }
 
@@ -2460,6 +2602,8 @@ async fn commit_hook_rejects_invalid_changed_path_shapes() {
         json!(["/absolute.rs"]),
         json!(["C:/absolute.rs"]),
         json!(["C:\\absolute.rs"]),
+        json!(["C:drive-relative.rs"]),
+        json!(["src\\file.rs"]),
         json!(["\\\\server\\share\\file.rs"]),
         json!(["src/../secret.rs"]),
         json!([7]),
@@ -2504,6 +2648,45 @@ async fn commit_hook_accepts_empty_changed_paths() {
         )
         .await
         .expect("an empty changed_paths array is the canonical empty-commit shape");
+
+    // An explicit JSON `null` carries no path facts and is treated the same
+    // as an absent property.
+    registry
+        .dispatch(
+            "create",
+            json!({
+                "kind": "commit",
+                "content": "null changed_paths fixture",
+                "properties": {
+                    "sha": "1111111111111111111111111111111111111111",
+                    "changed_paths": null
+                }
+            }),
+        )
+        .await
+        .expect("null changed_paths is optional, same as absent");
+}
+
+/// The must-keep control for the canonical shape: a sorted, deduplicated
+/// array of `/`-separated repo-relative paths is accepted (e.g. `src/lib.rs`
+/// survives the tightened path-shape validation unchanged).
+#[tokio::test]
+async fn commit_hook_accepts_canonical_changed_paths() {
+    let (_rt, _token, registry) = fixture().await;
+    registry
+        .dispatch(
+            "create",
+            json!({
+                "kind": "commit",
+                "content": "canonical changed_paths fixture",
+                "properties": {
+                    "sha": "2222222222222222222222222222222222222222",
+                    "changed_paths": ["src/lib.rs"]
+                }
+            }),
+        )
+        .await
+        .expect("a sorted, deduplicated repo-relative path array is accepted");
 }
 
 // ── project-scoped idempotency ──────────────────────────────────────────

--- a/crates/khive-pack-git/tests/acceptance.rs
+++ b/crates/khive-pack-git/tests/acceptance.rs
@@ -611,6 +611,29 @@ async fn ingest_skips_ambiguous_snapshot_path_bindings() {
     commit(repo, &["src/lib.rs"], "Shared snapshot");
     let revision = head_sha(repo);
 
+    // An ambiguous key (two live rows, one `source_path`) NO ingested
+    // commit touches must not inflate the skip count: only a commit path
+    // that actually hits the ambiguous key counts.
+    for name in [
+        "untouched_ambiguous_module_a",
+        "untouched_ambiguous_module_b",
+    ] {
+        create(
+            &registry,
+            json!({
+                "kind": "concept",
+                "entity_type": "module",
+                "name": name,
+                "properties": {
+                    "source_project": "untouched-project",
+                    "source_path": "src/untouched.rs",
+                    "source_revision": revision.clone()
+                }
+            }),
+        )
+        .await;
+    }
+
     let first = create(
         &registry,
         json!({
@@ -649,6 +672,10 @@ async fn ingest_skips_ambiguous_snapshot_path_bindings() {
     .await
     .expect("ingest ok");
     assert_eq!(report.commits_ingested, 1, "{report:?}");
+    assert_eq!(
+        report.code_module_ambiguous_path_skips, 1,
+        "only the commit-touched ambiguous key counts; the untouched one does not: {report:?}"
+    );
     assert!(incoming_annotating_ids(&registry, first).await.is_empty());
     assert!(incoming_annotating_ids(&registry, second).await.is_empty());
 }
@@ -986,9 +1013,8 @@ exec "$REAL_GIT" "$@"
         .dispatch("list", json!({"kind": "commit", "limit": 10}))
         .await
         .expect("list commits");
-    let stored_shas: Vec<&str> = commits
-        .as_array()
-        .expect("commit array")
+    let commit_notes = commits.as_array().expect("commit array");
+    let stored_shas: Vec<&str> = commit_notes
         .iter()
         .map(|note| note["properties"]["sha"].as_str().expect("sha"))
         .collect();
@@ -999,6 +1025,88 @@ exec "$REAL_GIT" "$@"
     assert!(
         stored_shas.contains(&third_sha.as_str()),
         "a commit after the gap is still attempted and lands: {stored_shas:?}"
+    );
+    let first_note = commit_notes
+        .iter()
+        .find(|note| note["properties"]["sha"].as_str() == Some(first_sha.as_str()))
+        .expect("the first commit is stored");
+    assert_eq!(
+        first_note["properties"]["changed_paths"],
+        json!(["first.rs"]),
+        "the deleted middle header must not pollute the previous commit's \
+         path set with the deleted commit's own paths"
+    );
+}
+
+/// A commit whose raw touched paths are ALL noncanonical is the third
+/// stored state: not a genuinely empty commit (`[]`), so `changed_paths`
+/// is omitted entirely and the run's
+/// `changed_paths_filtered_noncanonical` count carries the evidence.
+#[cfg(unix)]
+#[tokio::test]
+async fn ingest_omits_changed_paths_when_all_paths_filtered() {
+    let _guard = ENV_MUTEX.lock().await;
+    let (rt, token, registry) = fixture().await;
+    let project_id = create(
+        &registry,
+        json!({"kind": "project", "name": "all-filtered-path-repo"}),
+    )
+    .await;
+
+    let dir = tempfile::tempdir().expect("tempdir");
+    let repo = dir.path();
+    init_repo(repo);
+    // Both shapes the canonical contract can never carry: a `\\` byte and
+    // an `X:` drive prefix.
+    write(repo, "src/back\\slash.rs", "pub fn backslash() {}\n");
+    write(repo, "X:drive.rs", "pub fn drive() {}\n");
+    commit(
+        repo,
+        &["src/back\\slash.rs", "X:drive.rs"],
+        "Only non-canonical paths",
+    );
+
+    let report = run_ingest(
+        &rt,
+        &token,
+        &registry,
+        IngestOptions {
+            repo: repo.to_path_buf(),
+            project: project_id.to_string(),
+            max_items: None,
+            include: IngestInclude {
+                commits: true,
+                issues: false,
+                pull_requests: false,
+            },
+        },
+    )
+    .await
+    .expect("an all-filtered commit must not fail the pass");
+    assert_eq!(report.commits_ingested, 1, "{report:?}");
+    assert_eq!(
+        report.changed_paths_filtered_noncanonical, 2,
+        "both noncanonical paths are counted as drops: {report:?}"
+    );
+
+    let commits = registry
+        .dispatch("list", json!({"kind": "commit", "limit": 10}))
+        .await
+        .expect("list commits");
+    let stored = &commits.as_array().expect("commit array")[0];
+    assert!(
+        stored["properties"].get("changed_paths").is_none(),
+        "an all-filtered commit omits changed_paths rather than storing the \
+         [] reserved for a genuinely empty commit: {stored:?}"
+    );
+
+    let cursor = read_git_cursor(&rt, project_id, "commits")
+        .await
+        .expect("cursor must be written");
+    assert_eq!(
+        cursor,
+        head_sha(repo),
+        "the cursor advances: an all-filtered commit is still ingested"
     );
 }
 

--- a/crates/khive-pack-git/tests/acceptance.rs
+++ b/crates/khive-pack-git/tests/acceptance.rs
@@ -761,6 +761,105 @@ async fn ingest_records_first_parent_paths_for_merge_commits() {
     );
 }
 
+/// Issue #1604: `[]` is the canonical shape for a genuinely empty commit
+/// (ADR-088: "the git ingester always supplies it, including an empty array
+/// for an empty commit"). Exercise the `--allow-empty` path end to end so
+/// the contract cannot silently rot.
+#[tokio::test]
+async fn ingest_records_empty_changed_paths_for_empty_commits() {
+    let _guard = ENV_MUTEX.lock().await;
+    let (rt, token, registry) = fixture().await;
+    let project_id = create(
+        &registry,
+        json!({"kind": "project", "name": "empty-commit-repo"}),
+    )
+    .await;
+
+    let dir = tempfile::tempdir().expect("tempdir");
+    let repo = dir.path();
+    init_repo(repo);
+    write(repo, "base.rs", "pub fn base() {}\n");
+    commit(repo, &["base.rs"], "Base");
+    git(
+        repo,
+        &["commit", "-q", "--allow-empty", "-m", "Empty marker"],
+    );
+    let empty_sha = head_sha(repo);
+
+    let report = run_ingest(
+        &rt,
+        &token,
+        &registry,
+        IngestOptions::unbounded(repo.to_path_buf(), project_id.to_string()),
+    )
+    .await
+    .expect("ingest ok");
+    assert_eq!(report.commits_ingested, 2, "{report:?}");
+
+    let commits = registry
+        .dispatch("list", json!({"kind": "commit", "limit": 10}))
+        .await
+        .expect("list commits");
+    let empty = commits
+        .as_array()
+        .expect("commit array")
+        .iter()
+        .find(|note| note["properties"]["sha"] == empty_sha)
+        .expect("empty commit");
+    assert_eq!(
+        empty["properties"]["changed_paths"],
+        json!([]),
+        "an empty commit carries an empty changed-path array"
+    );
+}
+
+/// Issue #1604: rename detection is pinned off, so a rename surfaces as the
+/// delete + add path pair that keeps `changed_paths` an exact join key for
+/// ADR-085's filesystem-derived `source_path`. Without the pin, whether the
+/// old path appears in `--name-only` output would depend on the rename
+/// detection settings of whatever git build runs the ingest.
+#[tokio::test]
+async fn ingest_records_both_sides_of_a_rename() {
+    let _guard = ENV_MUTEX.lock().await;
+    let (rt, token, registry) = fixture().await;
+    let project_id = create(&registry, json!({"kind": "project", "name": "rename-repo"})).await;
+
+    let dir = tempfile::tempdir().expect("tempdir");
+    let repo = dir.path();
+    init_repo(repo);
+    write(repo, "old.rs", "pub fn renamed() {}\n");
+    commit(repo, &["old.rs"], "Add old.rs");
+    git(repo, &["mv", "old.rs", "new.rs"]);
+    git(repo, &["commit", "-q", "-m", "Rename old.rs to new.rs"]);
+    let rename_sha = head_sha(repo);
+
+    let report = run_ingest(
+        &rt,
+        &token,
+        &registry,
+        IngestOptions::unbounded(repo.to_path_buf(), project_id.to_string()),
+    )
+    .await
+    .expect("ingest ok");
+    assert_eq!(report.commits_ingested, 2, "{report:?}");
+
+    let commits = registry
+        .dispatch("list", json!({"kind": "commit", "limit": 10}))
+        .await
+        .expect("list commits");
+    let rename = commits
+        .as_array()
+        .expect("commit array")
+        .iter()
+        .find(|note| note["properties"]["sha"] == rename_sha)
+        .expect("rename commit");
+    assert_eq!(
+        rename["properties"]["changed_paths"],
+        json!(["new.rs", "old.rs"]),
+        "a rename records both the deleted and the added path"
+    );
+}
+
 /// Coordinator addendum requirement: a commit message containing a
 /// credential-shaped token must be masked before it is stored.
 #[tokio::test]
@@ -2360,6 +2459,8 @@ async fn commit_hook_rejects_invalid_changed_path_shapes() {
         json!("src/lib.rs"),
         json!(["/absolute.rs"]),
         json!(["C:/absolute.rs"]),
+        json!(["C:\\absolute.rs"]),
+        json!(["\\\\server\\share\\file.rs"]),
         json!(["src/../secret.rs"]),
         json!([7]),
         json!(["z.rs", "a.rs"]),
@@ -2381,6 +2482,28 @@ async fn commit_hook_rejects_invalid_changed_path_shapes() {
             .expect_err("invalid changed_paths must be rejected");
         assert!(format!("{err}").contains("changed_paths"), "{err}");
     }
+}
+
+/// The contract's canonical shape for a genuinely empty commit is `[]`;
+/// the hook must accept it (a missing or null `changed_paths` is likewise
+/// optional for manually created commit notes).
+#[tokio::test]
+async fn commit_hook_accepts_empty_changed_paths() {
+    let (_rt, _token, registry) = fixture().await;
+    registry
+        .dispatch(
+            "create",
+            json!({
+                "kind": "commit",
+                "content": "empty commit fixture",
+                "properties": {
+                    "sha": "0000000000000000000000000000000000000000",
+                    "changed_paths": []
+                }
+            }),
+        )
+        .await
+        .expect("an empty changed_paths array is the canonical empty-commit shape");
 }
 
 // ── project-scoped idempotency ──────────────────────────────────────────

--- a/crates/khive-pack-git/tests/acceptance.rs
+++ b/crates/khive-pack-git/tests/acceptance.rs
@@ -1022,11 +1022,12 @@ exec "$REAL_GIT" "$@"
     .expect("the run completes despite the touched-path gap");
     assert!(report.done, "an unbounded pass still finishes: {report:?}");
     assert!(
-        report
-            .warnings
-            .iter()
-            .any(|w| w.contains("no touched-path set recorded") && w.contains(&second_sha)),
-        "the gap must surface as a warning naming the stalled commit: {:?}",
+        report.warnings.iter().any(|w| {
+            w.contains("no touched-path set recorded")
+                && w.contains(&second_sha)
+                && w.contains(&third_sha)
+        }),
+        "the gap warning must name both the stalled commit and the newer polluted recipient: {:?}",
         report.warnings
     );
     assert_eq!(

--- a/crates/khive-pack-git/tests/acceptance.rs
+++ b/crates/khive-pack-git/tests/acceptance.rs
@@ -676,6 +676,24 @@ async fn ingest_skips_ambiguous_snapshot_path_bindings() {
         report.code_module_ambiguous_path_skips, 1,
         "only the commit-touched ambiguous key counts; the untouched one does not: {report:?}"
     );
+    let skip_warnings: Vec<&str> = report
+        .warnings
+        .iter()
+        .map(String::as_str)
+        .filter(|w| w.contains("skipped code-module annotation"))
+        .collect();
+    assert_eq!(
+        skip_warnings.len(),
+        1,
+        "one bounded skip warning per run: {:?}",
+        report.warnings
+    );
+    assert!(
+        skip_warnings[0].contains("src/lib.rs"),
+        "the bounded warning names the first skipped path so the count is \
+         actionable: {}",
+        skip_warnings[0]
+    );
     assert!(incoming_annotating_ids(&registry, first).await.is_empty());
     assert!(incoming_annotating_ids(&registry, second).await.is_empty());
 }
@@ -909,6 +927,19 @@ async fn ingest_records_both_sides_of_a_rename() {
 /// fabricated `[]`: the run warns naming the commit, stalls the cursor at
 /// the last contiguous successful commit, and still completes (see
 /// docs/api/ingest.md#changed-paths-and-code-module-annotations).
+///
+/// The shim below builds the REAL orphan-token shape, not a whole-record
+/// deletion: its `tr '\0' '\n'` round-trip splits git's combined
+/// `<header>\n<first-path>` token into two lines, so `grep -av` removes
+/// only the middle commit's header LINE while its path token survives in
+/// the stream. Because the `--name-only` walk is newest-first, the parser
+/// attaches that orphan token to the most recent header — the NEWER (third)
+/// commit — and the walk-commits pass (unshimmed) still walks all three
+/// shas. Containment is therefore per-record, not per-stream: the middle
+/// commit never lands (no path-set entry), the cursor stalls, but the
+/// orphaned token pollutes the stored newer commit's immutable
+/// `changed_paths` — asserted explicitly below, because commit notes are
+/// immutable and the pollution persists until re-ingest.
 #[tokio::test]
 async fn ingest_stalls_cursor_for_commit_missing_touched_paths() {
     let _guard = ENV_MUTEX.lock().await;
@@ -933,10 +964,13 @@ async fn ingest_stalls_cursor_for_commit_missing_touched_paths() {
     let third_sha = head_sha(repo);
 
     // The `--name-only` pass is the sole authority for touched paths. This
-    // PATH-shadowing shim deletes the middle commit's header from that one
-    // stream so the two snapshot passes disagree exactly the way the
-    // degradation branch handles; every other invocation delegates to the
-    // real git binary (same technique as `src/recovery_tests.rs`).
+    // PATH-shadowing shim deletes ONLY the middle commit's header line from
+    // that one stream — the `tr` round-trip puts the header and its first
+    // path on separate lines, so `grep -av` strips just the header and the
+    // middle commit's path token stays in the stream as an orphan — making
+    // the two snapshot passes disagree exactly the way the degradation
+    // branch handles; every other invocation delegates to the real git
+    // binary (same technique as `src/recovery_tests.rs`).
     let real_git = resolve_real_git();
     let bin_dir = dir.path().join("bin");
     std::fs::create_dir_all(&bin_dir).expect("create bin dir");
@@ -1033,8 +1067,22 @@ exec "$REAL_GIT" "$@"
     assert_eq!(
         first_note["properties"]["changed_paths"],
         json!(["first.rs"]),
-        "the deleted middle header must not pollute the previous commit's \
-         path set with the deleted commit's own paths"
+        "the newest-first walk attaches the orphan token to the most \
+         recent header (the NEWER commit), so the older commit keeps \
+         exactly its own paths"
+    );
+    let third_note = commit_notes
+        .iter()
+        .find(|note| note["properties"]["sha"].as_str() == Some(third_sha.as_str()))
+        .expect("the newer commit is stored");
+    assert_eq!(
+        third_note["properties"]["changed_paths"],
+        json!(["second.rs", "third.rs"]),
+        "the orphaned path token of the deleted header rides into the \
+         stored NEWER commit's changed_paths: containment is per-record \
+         (the missing sha never lands, the cursor stalls), never \
+         per-stream — commit notes are immutable, so the pollution \
+         persists (a re-ingest skips the stored sha)"
     );
 }
 
@@ -1177,6 +1225,12 @@ async fn ingest_filters_noncanonical_changed_paths_but_keeps_commit() {
         "the warning carries the dropped count: {}",
         filter_warnings[0]
     );
+    assert!(
+        filter_warnings[0].contains("NUL"),
+        "the warning names every rejected shape the predicate enforces, \
+         including the NUL byte: {}",
+        filter_warnings[0]
+    );
 
     let commits = registry
         .dispatch("list", json!({"kind": "commit", "limit": 10}))
@@ -1196,6 +1250,67 @@ async fn ingest_filters_noncanonical_changed_paths_but_keeps_commit() {
         cursor,
         head_sha(repo),
         "the cursor advances past the commit: filtered paths never stall a run"
+    );
+}
+
+/// The canonical filter runs on the RAW path, never the masked one: a
+/// secret-shaped token can itself contain a rejected byte (the masker's
+/// tokens are whitespace-delimited, so a backslash inside the token is
+/// redacted along with it), and filtering after masking would flip the
+/// verdict from reject to accept — storing `src/***MASKED***` for a file
+/// whose real name is non-canonical. The defect must be dropped and
+/// counted, not laundered into a canonical-looking masked path.
+#[cfg(unix)]
+#[tokio::test]
+async fn ingest_filters_noncanonical_path_even_when_masking_hides_the_defect() {
+    let _guard = ENV_MUTEX.lock().await;
+    let (rt, token, registry) = fixture().await;
+    let project_id = create(
+        &registry,
+        json!({"kind": "project", "name": "masked-defect-path-repo"}),
+    )
+    .await;
+
+    let dir = tempfile::tempdir().expect("tempdir");
+    let repo = dir.path();
+    init_repo(repo);
+    write(repo, "good.rs", "pub fn good() {}\n");
+    // Secret-shaped (github-token: `ghp_` + 36 base62 chars) AND
+    // non-canonical (a `\` byte inside the token).
+    let fake_token = "ghp_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+    let rel = format!("src/{fake_token}\\back.rs");
+    write(repo, &rel, "pub fn secret_defect() {}\n");
+    commit(repo, &["good.rs", rel.as_str()], "Mixed paths");
+
+    let report = run_ingest(
+        &rt,
+        &token,
+        &registry,
+        IngestOptions::unbounded(repo.to_path_buf(), project_id.to_string()),
+    )
+    .await
+    .expect("ingest ok");
+    assert_eq!(report.commits_ingested, 1, "{report:?}");
+    assert_eq!(
+        report.changed_paths_filtered_noncanonical, 1,
+        "the raw path's backslash rejects it even though masking would \
+         redact that byte away: {report:?}"
+    );
+
+    let commits = registry
+        .dispatch("list", json!({"kind": "commit", "limit": 10}))
+        .await
+        .expect("list commits");
+    let stored = &commits.as_array().expect("commit array")[0];
+    assert_eq!(
+        stored["properties"]["changed_paths"],
+        json!(["good.rs"]),
+        "the non-canonical path must be dropped, not stored as a \
+         canonical-looking masked residue: {stored:?}"
+    );
+    assert!(
+        !format!("{stored}").contains(fake_token),
+        "the raw token must not survive anywhere in the stored record"
     );
 }
 

--- a/docs/adr/ADR-088-amendment-1-git-digest.md
+++ b/docs/adr/ADR-088-amendment-1-git-digest.md
@@ -137,6 +137,20 @@ in scope for this amendment:
 2. **Readable names.** Provenance notes currently carry `name=null`, so neighbors/GQL
    render placeholders and force a `get()` per hop. Set `name` at ingest: issues/PRs
    `"#<number> <title>"` (truncated), commits `"<short-sha> <subject>"` (truncated).
+3. **Changed-path and code-map enrichment.** Persist each commit's sorted, deduplicated,
+   repository-relative touched paths in `properties.changed_paths`. Read paths from Git's
+   NUL-delimited raw output, applying ADR-085's lossy UTF-8 filesystem-path normalization;
+   for merges, use the diff against the first parent as the single canonical path set.
+   When ADR-085 modules with an exact `(source_revision=repository snapshot HEAD,
+   source_path=changed path)` match already exist in the same database and namespace,
+   include the uniquely matching module in the commit note's `annotates` targets. Multiple
+   live matches are ambiguous and therefore annotate none. The existing document
+   enrichment remains unchanged. A missing or ambiguous module match is best-effort and
+   never creates a code entity; path properties remain sufficient for later graph-side
+   joins. Touched paths pass through the same secret-masking boundary as other
+   repository-authored commit fields before they enter properties or path resolution.
+   This rider relies on ADR-085 Amendment 5 and adds neither a storage column nor an edge
+   relation.
 
 Data-fidelity checks from the same evidence run were verified clean: `closed_at` values
 that cluster at one instant reflect real GitHub bulk-close events (confirmed against

--- a/docs/adr/ADR-088-git-lifecycle-pack.md
+++ b/docs/adr/ADR-088-git-lifecycle-pack.md
@@ -61,8 +61,12 @@ New pack crate `khive-pack-git`, `REQUIRES = ["kg"]`, following `khive-pack-form
    `committed_at`, `parents` (array of parent SHA strings — a plain property, not a graph
    edge; see Alternatives A2 for why commit-to-commit lineage is deliberately not an edge
    in v1), and optional `changed_paths` (a sorted, deduplicated array of non-empty,
-   repository-relative `/`-separated path strings; the git ingester always supplies it,
-   including an empty array for an empty commit). No lifecycle — commits are immutable
+   repository-relative `/`-separated path strings; the git ingester always supplies that
+   canonical shape, including an empty array for an empty commit, except that the property
+   is omitted when the raw touched set was non-empty but every path was filtered as
+   non-canonical — the all-filtered third state named by
+   `crates/khive-pack-git/docs/api/ingest.md#changed-paths-and-code-module-annotations`,
+   whose evidence is the run's drop count and warning). No lifecycle — commits are immutable
    once created, so `commit` carries no `kind_status`.
 
 3. **`issue` properties**: `number`, `title`, `author`, `created_at`, `closed_at`

--- a/docs/adr/ADR-088-git-lifecycle-pack.md
+++ b/docs/adr/ADR-088-git-lifecycle-pack.md
@@ -60,8 +60,10 @@ New pack crate `khive-pack-git`, `REQUIRES = ["kg"]`, following `khive-pack-form
    CLAUDE.md's "Scope = secrets only, not general PII" rule; no masking required),
    `committed_at`, `parents` (array of parent SHA strings — a plain property, not a graph
    edge; see Alternatives A2 for why commit-to-commit lineage is deliberately not an edge
-   in v1). No lifecycle — commits are immutable once created, so `commit` carries no
-   `kind_status`.
+   in v1), and optional `changed_paths` (a sorted, deduplicated array of non-empty,
+   repository-relative `/`-separated path strings; the git ingester always supplies it,
+   including an empty array for an empty commit). No lifecycle — commits are immutable
+   once created, so `commit` carries no `kind_status`.
 
 3. **`issue` properties**: `number`, `title`, `author`, `created_at`, `closed_at`
    (optional), `labels` (array), `state_reason` (optional: `completed` / `not_planned` / `reopened` / `duplicate` — the GitHub `stateReason` enum, normalized to lowercase).
@@ -262,3 +264,17 @@ Decision text.
    unmasked secret patterns. The ingester calls the same masking helper the gate uses
    before submitting commit-message and issue/PR-body content, so ingested provenance text
    is redacted rather than rejected outright.
+
+6. **Commit path facts and code-map annotations.** The ingester stores paths read from
+   `git log -z --name-only --diff-merges=first-parent` in
+   `commit.properties.changed_paths`. NUL framing preserves raw path boundaries; bytes use
+   ADR-085's lossy UTF-8 filesystem-path normalization, and a merge's one path set is its
+   first-parent diff. When the same namespace contains live ADR-085 `concept/module`
+   entities, a module is eligible only when its `source_revision` equals the repository
+   snapshot HEAD and its `source_path` equals the changed path. The module index is read
+   once per commit-ingest phase. Exactly one matching row adds that module to the commit's
+   existing `annotates` targets; zero or multiple rows are a best-effort skip, preventing
+   same-path modules from another repository snapshot from being selected or
+   cross-annotated. No code entity or new relation is created. This enrichment depends on
+   ADR-085 Amendment 5's path-and-revision contract and supports module churn and
+   cross-project co-change queries directly over the graph.


### PR DESCRIPTION
## Summary

- retain canonical, secret-masked changed paths for every commit ingested by `git.digest`
- annotate code modules only through an exact, unique `(snapshot revision, source path)` match so repository or revision collisions fail closed
- parse Git's NUL-delimited history stream without pathname delimiter or Unicode assumptions and document first-parent merge semantics

## Behavior

Commit provenance notes now carry sorted, deduplicated `changed_paths` derived from Git's raw
NUL-delimited output. The parser accepts both observed one- and two-NUL commit boundaries, preserves
delimiter-bearing and non-UTF-8 pathnames through deterministic lossy normalization, represents
empty commits, and uses first-parent diffs for merges. Credential-shaped path fragments are masked
before persistence.

When code-ingest data is present, module annotations are resolved against the source snapshot's
exact HEAD revision and source path. A unique match produces the commit-to-module link; duplicate,
cross-repository, or otherwise ambiguous candidates are skipped instead of fabricating provenance.
These facts make churn and co-change analysis derivable from the stored graph.

This is a stacked draft on #1619 because its exact snapshot-revision binding consumes the code-ingest
provenance contract introduced there. Issues #1600, #1603, and #1605 remain scoped exclusively to
the parent draft.

## Validation

- full `khive-pack-git` unit, acceptance, and documentation tests
- direct full-history parser probe: 859 / 859 commits represented
- `cargo test --manifest-path crates/Cargo.toml --workspace`
- `cargo check --manifest-path crates/Cargo.toml --workspace`
- `cargo clippy --manifest-path crates/Cargo.toml --workspace --all-targets -- -D warnings`
- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `RUSTDOCFLAGS=-Dwarnings cargo doc --manifest-path crates/Cargo.toml --workspace --no-deps`

Closes #1604

> AI-assisted contribution: Codex prepared this change and PR description.
