### PR TITLE
chore: bump workspace version to 0.7.0

### DIFF
--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -1840,7 +1840,7 @@ dependencies = [
 
 [[package]]
 name = "khive-bm25"
-version = "0.5.0"
+version = "0.7.0"
 dependencies = [
  "criterion",
  "khive-score",
@@ -1854,7 +1854,7 @@ dependencies = [
 
 [[package]]
 name = "khive-brain-core"
-version = "0.5.0"
+version = "0.7.0"
 dependencies = [
  "chrono",
  "criterion",
@@ -1869,7 +1869,7 @@ dependencies = [
 
 [[package]]
 name = "khive-changeset"
-version = "0.5.0"
+version = "0.7.0"
 dependencies = [
  "khive-types",
  "proptest",
@@ -1880,7 +1880,7 @@ dependencies = [
 
 [[package]]
 name = "khive-channel"
-version = "0.5.0"
+version = "0.7.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1894,7 +1894,7 @@ dependencies = [
 
 [[package]]
 name = "khive-channel-email"
-version = "0.5.0"
+version = "0.7.0"
 dependencies = [
  "async-imap",
  "async-native-tls",
@@ -1918,7 +1918,7 @@ dependencies = [
 
 [[package]]
 name = "khive-channel-telegram"
-version = "0.5.0"
+version = "0.7.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1933,7 +1933,7 @@ dependencies = [
 
 [[package]]
 name = "khive-db"
-version = "0.5.0"
+version = "0.7.0"
 dependencies = [
  "async-trait",
  "blake3",
@@ -1966,7 +1966,7 @@ dependencies = [
 
 [[package]]
 name = "khive-fold"
-version = "0.5.0"
+version = "0.7.0"
 dependencies = [
  "blake3",
  "chrono",
@@ -1981,7 +1981,7 @@ dependencies = [
 
 [[package]]
 name = "khive-fusion"
-version = "0.5.0"
+version = "0.7.0"
 dependencies = [
  "criterion",
  "khive-score",
@@ -1991,7 +1991,7 @@ dependencies = [
 
 [[package]]
 name = "khive-gate"
-version = "0.5.0"
+version = "0.7.0"
 dependencies = [
  "chrono",
  "khive-types",
@@ -2002,7 +2002,7 @@ dependencies = [
 
 [[package]]
 name = "khive-gate-rego"
-version = "0.5.0"
+version = "0.7.0"
 dependencies = [
  "khive-gate",
  "khive-types",
@@ -2014,7 +2014,7 @@ dependencies = [
 
 [[package]]
 name = "khive-hnsw"
-version = "0.5.0"
+version = "0.7.0"
 dependencies = [
  "criterion",
  "khive-fold",
@@ -2033,7 +2033,7 @@ dependencies = [
 
 [[package]]
 name = "khive-mcp"
-version = "0.5.0"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2079,7 +2079,7 @@ dependencies = [
 
 [[package]]
 name = "khive-pack-blob"
-version = "0.5.0"
+version = "0.7.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2097,7 +2097,7 @@ dependencies = [
 
 [[package]]
 name = "khive-pack-brain"
-version = "0.5.0"
+version = "0.7.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2123,7 +2123,7 @@ dependencies = [
 
 [[package]]
 name = "khive-pack-code"
-version = "0.5.0"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2145,7 +2145,7 @@ dependencies = [
 
 [[package]]
 name = "khive-pack-comm"
-version = "0.5.0"
+version = "0.7.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2169,7 +2169,7 @@ dependencies = [
 
 [[package]]
 name = "khive-pack-formal"
-version = "0.5.0"
+version = "0.7.0"
 dependencies = [
  "async-trait",
  "inventory",
@@ -2181,7 +2181,7 @@ dependencies = [
 
 [[package]]
 name = "khive-pack-git"
-version = "0.5.0"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2204,7 +2204,7 @@ dependencies = [
 
 [[package]]
 name = "khive-pack-gtd"
-version = "0.5.0"
+version = "0.7.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2223,7 +2223,7 @@ dependencies = [
 
 [[package]]
 name = "khive-pack-kg"
-version = "0.5.0"
+version = "0.7.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2245,7 +2245,7 @@ dependencies = [
 
 [[package]]
 name = "khive-pack-knowledge"
-version = "0.5.0"
+version = "0.7.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2273,7 +2273,7 @@ dependencies = [
 
 [[package]]
 name = "khive-pack-memory"
-version = "0.5.0"
+version = "0.7.0"
 dependencies = [
  "async-trait",
  "blake3",
@@ -2305,7 +2305,7 @@ dependencies = [
 
 [[package]]
 name = "khive-pack-schedule"
-version = "0.5.0"
+version = "0.7.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2328,7 +2328,7 @@ dependencies = [
 
 [[package]]
 name = "khive-pack-session"
-version = "0.5.0"
+version = "0.7.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2348,7 +2348,7 @@ dependencies = [
 
 [[package]]
 name = "khive-pack-template"
-version = "0.5.0"
+version = "0.7.0"
 dependencies = [
  "async-trait",
  "inventory",
@@ -2361,7 +2361,7 @@ dependencies = [
 
 [[package]]
 name = "khive-pack-workspace"
-version = "0.5.0"
+version = "0.7.0"
 dependencies = [
  "async-trait",
  "inventory",
@@ -2378,7 +2378,7 @@ dependencies = [
 
 [[package]]
 name = "khive-quant"
-version = "0.5.0"
+version = "0.7.0"
 dependencies = [
  "criterion",
  "rand 0.8.7",
@@ -2387,7 +2387,7 @@ dependencies = [
 
 [[package]]
 name = "khive-query"
-version = "0.5.0"
+version = "0.7.0"
 dependencies = [
  "criterion",
  "khive-types",
@@ -2397,7 +2397,7 @@ dependencies = [
 
 [[package]]
 name = "khive-request"
-version = "0.5.0"
+version = "0.7.0"
 dependencies = [
  "criterion",
  "khive-types",
@@ -2407,7 +2407,7 @@ dependencies = [
 
 [[package]]
 name = "khive-retrieval"
-version = "0.5.0"
+version = "0.7.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2436,7 +2436,7 @@ dependencies = [
 
 [[package]]
 name = "khive-runtime"
-version = "0.5.0"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2471,7 +2471,7 @@ dependencies = [
 
 [[package]]
 name = "khive-score"
-version = "0.5.0"
+version = "0.7.0"
 dependencies = [
  "criterion",
  "khive-types",
@@ -2481,7 +2481,7 @@ dependencies = [
 
 [[package]]
 name = "khive-storage"
-version = "0.5.0"
+version = "0.7.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2496,7 +2496,7 @@ dependencies = [
 
 [[package]]
 name = "khive-text"
-version = "0.5.0"
+version = "0.7.0"
 dependencies = [
  "criterion",
  "rust-stemmers",
@@ -2505,7 +2505,7 @@ dependencies = [
 
 [[package]]
 name = "khive-types"
-version = "0.5.0"
+version = "0.7.0"
 dependencies = [
  "blake3",
  "serde",
@@ -2514,7 +2514,7 @@ dependencies = [
 
 [[package]]
 name = "khive-vamana"
-version = "0.5.0"
+version = "0.7.0"
 dependencies = [
  "blake3",
  "bytemuck",
@@ -2535,7 +2535,7 @@ dependencies = [
 
 [[package]]
 name = "khive-vcs"
-version = "0.5.0"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2556,7 +2556,7 @@ dependencies = [
 
 [[package]]
 name = "khive-vcs-adapters"
-version = "0.5.0"
+version = "0.7.0"
 dependencies = [
  "khive-types",
  "serde",
@@ -2567,7 +2567,7 @@ dependencies = [
 
 [[package]]
 name = "kkernel"
-version = "0.5.0"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/crates/Cargo.toml
+++ b/crates/Cargo.toml
@@ -51,7 +51,7 @@ exclude = ["khive-merge"]
 # keep this exclusion from members.
 
 [workspace.package]
-version = "0.5.0"
+version = "0.7.0"
 edition = "2021"
 # lattice-embed and lattice-fann 0.6 require Rust 1.93, setting the workspace MSRV.
 # The previous 1.91 floor came from floor_char_boundary use (issue #398).

--- a/crates/khive-bm25/Cargo.toml
+++ b/crates/khive-bm25/Cargo.toml
@@ -15,8 +15,8 @@ description = "BM25 (Okapi BM25) keyword index with deterministic scoring"
 bench = false
 
 [dependencies]
-khive-score = { version = "0.5.0", path = "../khive-score" }
-khive-text = { version = "0.5.0", path = "../khive-text" }
+khive-score = { version = "0.7.0", path = "../khive-score" }
+khive-text = { version = "0.7.0", path = "../khive-text" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/khive-brain-core/Cargo.toml
+++ b/crates/khive-brain-core/Cargo.toml
@@ -15,7 +15,7 @@ description = "Brain primitives — Beta posteriors, section types, profile stat
 bench = false
 
 [dependencies]
-khive-runtime = { version = "0.5.0", path = "../khive-runtime" }
+khive-runtime = { version = "0.7.0", path = "../khive-runtime" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 uuid = { workspace = true }

--- a/crates/khive-changeset/Cargo.toml
+++ b/crates/khive-changeset/Cargo.toml
@@ -12,7 +12,7 @@ categories.workspace = true
 description = "Producer-agnostic KG change-set op-list model and NDJSON-delta serialization"
 
 [dependencies]
-khive-types = { version = "0.5.0", path = "../khive-types", features = ["serde"] }
+khive-types = { version = "0.7.0", path = "../khive-types", features = ["serde"] }
 serde = { workspace = true }
 # float_roundtrip: the default float parser is a fast approximation that does
 # not always recover the exact f64 bits a prior serialize wrote (weight/

--- a/crates/khive-channel-email/Cargo.toml
+++ b/crates/khive-channel-email/Cargo.toml
@@ -12,7 +12,7 @@ categories.workspace = true
 description = "Email (SMTP/IMAP) channel adapter for khive (ADR-056)"
 
 [dependencies]
-khive-channel = { version = "0.5.0", path = "../khive-channel" }
+khive-channel = { version = "0.7.0", path = "../khive-channel" }
 async-trait = { workspace = true }
 thiserror = { workspace = true }
 serde = { workspace = true }

--- a/crates/khive-channel-telegram/Cargo.toml
+++ b/crates/khive-channel-telegram/Cargo.toml
@@ -12,7 +12,7 @@ categories.workspace = true
 description = "Telegram Bot API channel adapter for khive (ADR-056)"
 
 [dependencies]
-khive-channel = { version = "0.5.0", path = "../khive-channel" }
+khive-channel = { version = "0.7.0", path = "../khive-channel" }
 async-trait = { workspace = true }
 thiserror = { workspace = true }
 serde = { workspace = true }

--- a/crates/khive-db/Cargo.toml
+++ b/crates/khive-db/Cargo.toml
@@ -15,9 +15,9 @@ description = "SQLite storage backend: entities, edges, notes, events, FTS5, sql
 bench = false
 
 [dependencies]
-khive-storage = { version = "0.5.0", path = "../khive-storage" }
-khive-score = { version = "0.5.0", path = "../khive-score" }
-khive-types = { version = "0.5.0", path = "../khive-types", features = ["serde"] }
+khive-storage = { version = "0.7.0", path = "../khive-storage" }
+khive-score = { version = "0.7.0", path = "../khive-score" }
+khive-types = { version = "0.7.0", path = "../khive-types", features = ["serde"] }
 tokio = { workspace = true }
 async-trait = { workspace = true }
 uuid = { workspace = true }
@@ -56,8 +56,8 @@ windows-sys = { version = "0.61", features = [
 tokio = { workspace = true, features = ["full", "test-util"] }
 rusqlite = { workspace = true, features = ["bundled", "column_decltype", "hooks", "limits"] }
 bytes = "1"
-khive-storage = { version = "0.5.0", path = "../khive-storage" }
-khive-types = { version = "0.5.0", path = "../khive-types", features = ["serde"] }
+khive-storage = { version = "0.7.0", path = "../khive-storage" }
+khive-types = { version = "0.7.0", path = "../khive-types", features = ["serde"] }
 uuid = { workspace = true }
 criterion = { workspace = true }
 rand = { workspace = true }

--- a/crates/khive-fold/Cargo.toml
+++ b/crates/khive-fold/Cargo.toml
@@ -21,10 +21,10 @@ default = ["serde"]
 serde = ["dep:serde"]
 
 [dependencies]
-khive-score = { version = "0.5.0", path = "../khive-score" }
+khive-score = { version = "0.7.0", path = "../khive-score" }
 # ADR-024 boundary: khive-types + khive-score only.
 # blake3 feature enables Hash32::from_blake3 for checkpoint hashing.
-khive-types = { version = "0.5.0", path = "../khive-types", features = ["blake3", "serde"] }
+khive-types = { version = "0.7.0", path = "../khive-types", features = ["blake3", "serde"] }
 # serde: optional, gated by the `serde` feature above.
 serde = { workspace = true, optional = true }
 # serde_json: kept direct — serde_json::Value is used in FoldContext.extra,

--- a/crates/khive-fusion/Cargo.toml
+++ b/crates/khive-fusion/Cargo.toml
@@ -15,7 +15,7 @@ description = "Rank fusion strategies (RRF, Weighted, Union) with deterministic 
 bench = false
 
 [dependencies]
-khive-score = { version = "0.5.0", path = "../khive-score" }
+khive-score = { version = "0.7.0", path = "../khive-score" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 

--- a/crates/khive-gate-rego/Cargo.toml
+++ b/crates/khive-gate-rego/Cargo.toml
@@ -13,12 +13,12 @@ description = "Rego (Open Policy Agent) backend for khive-gate, powered by regor
 readme = "README.md"
 
 [dependencies]
-khive-gate = { version = "0.5.0", path = "../khive-gate" }
+khive-gate = { version = "0.7.0", path = "../khive-gate" }
 serde_json = { workspace = true }
 tracing = { workspace = true }
 
 regorus = { workspace = true }
 
 [dev-dependencies]
-khive-types = { version = "0.5.0", path = "../khive-types", features = ["serde"] }
+khive-types = { version = "0.7.0", path = "../khive-types", features = ["serde"] }
 tracing-subscriber = { workspace = true }

--- a/crates/khive-gate/Cargo.toml
+++ b/crates/khive-gate/Cargo.toml
@@ -12,7 +12,7 @@ categories.workspace = true
 description = "Pluggable authorization gate trait + default AllowAllGate impl for khive verb dispatch."
 
 [dependencies]
-khive-types = { version = "0.5.0", path = "../khive-types", features = ["serde"] }
+khive-types = { version = "0.7.0", path = "../khive-types", features = ["serde"] }
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/khive-hnsw/Cargo.toml
+++ b/crates/khive-hnsw/Cargo.toml
@@ -15,9 +15,9 @@ description = "HNSW (Hierarchical Navigable Small World) vector index with INT8 
 bench = false
 
 [dependencies]
-khive-score = { version = "0.5.0", path = "../khive-score" }
-khive-types = { version = "0.5.0", path = "../khive-types", features = ["serde"] }
-khive-fold = { version = "0.5.0", path = "../khive-fold", optional = true }
+khive-score = { version = "0.7.0", path = "../khive-score" }
+khive-types = { version = "0.7.0", path = "../khive-types", features = ["serde"] }
+khive-fold = { version = "0.7.0", path = "../khive-fold", optional = true }
 lattice-embed = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/khive-mcp/Cargo.toml
+++ b/crates/khive-mcp/Cargo.toml
@@ -12,23 +12,23 @@ categories.workspace = true
 description = "khive MCP server library — served via the kkernel binary"
 
 [dependencies]
-khive-db = { version = "0.5.0", path = "../khive-db" }
-khive-runtime = { version = "0.5.0", path = "../khive-runtime" }
-khive-storage = { version = "0.5.0", path = "../khive-storage" }
-khive-types = { version = "0.5.0", path = "../khive-types", features = ["serde"] }
-khive-request = { version = "0.5.0", path = "../khive-request" }
-khive-pack-kg = { version = "0.5.0", path = "../khive-pack-kg" }
-khive-pack-gtd = { version = "0.5.0", path = "../khive-pack-gtd" }
-khive-pack-memory = { version = "0.5.0", path = "../khive-pack-memory" }
-khive-pack-brain = { version = "0.5.0", path = "../khive-pack-brain" }
-khive-pack-comm = { version = "0.5.0", path = "../khive-pack-comm" }
-khive-pack-schedule = { version = "0.5.0", path = "../khive-pack-schedule" }
-khive-pack-knowledge = { version = "0.5.0", path = "../khive-pack-knowledge" }
-khive-pack-session = { version = "0.5.0", path = "../khive-pack-session" }
-khive-pack-git = { version = "0.5.0", path = "../khive-pack-git" }
-khive-pack-code = { version = "0.5.0", path = "../khive-pack-code" }
-khive-pack-blob = { version = "0.5.0", path = "../khive-pack-blob" }
-khive-pack-workspace = { version = "0.5.0", path = "../khive-pack-workspace" }
+khive-db = { version = "0.7.0", path = "../khive-db" }
+khive-runtime = { version = "0.7.0", path = "../khive-runtime" }
+khive-storage = { version = "0.7.0", path = "../khive-storage" }
+khive-types = { version = "0.7.0", path = "../khive-types", features = ["serde"] }
+khive-request = { version = "0.7.0", path = "../khive-request" }
+khive-pack-kg = { version = "0.7.0", path = "../khive-pack-kg" }
+khive-pack-gtd = { version = "0.7.0", path = "../khive-pack-gtd" }
+khive-pack-memory = { version = "0.7.0", path = "../khive-pack-memory" }
+khive-pack-brain = { version = "0.7.0", path = "../khive-pack-brain" }
+khive-pack-comm = { version = "0.7.0", path = "../khive-pack-comm" }
+khive-pack-schedule = { version = "0.7.0", path = "../khive-pack-schedule" }
+khive-pack-knowledge = { version = "0.7.0", path = "../khive-pack-knowledge" }
+khive-pack-session = { version = "0.7.0", path = "../khive-pack-session" }
+khive-pack-git = { version = "0.7.0", path = "../khive-pack-git" }
+khive-pack-code = { version = "0.7.0", path = "../khive-pack-code" }
+khive-pack-blob = { version = "0.7.0", path = "../khive-pack-blob" }
+khive-pack-workspace = { version = "0.7.0", path = "../khive-pack-workspace" }
 uuid = { workspace = true }
 inventory = { workspace = true }
 rmcp = { workspace = true, features = ["server", "transport-io"] }
@@ -47,9 +47,9 @@ sha2 = { workspace = true }
 chrono = { workspace = true }
 tempfile = { workspace = true }
 lattice-embed = { workspace = true, optional = true }
-khive-channel = { version = "0.5.0", path = "../khive-channel", optional = true }
-khive-channel-email = { version = "0.5.0", path = "../khive-channel-email", optional = true }
-khive-channel-telegram = { version = "0.5.0", path = "../khive-channel-telegram", optional = true }
+khive-channel = { version = "0.7.0", path = "../khive-channel", optional = true }
+khive-channel-email = { version = "0.7.0", path = "../khive-channel-email", optional = true }
+khive-channel-telegram = { version = "0.7.0", path = "../khive-channel-telegram", optional = true }
 
 [features]
 # bench-embedder: inject deterministic FNV-1a hash embedder into the serve path.
@@ -68,5 +68,5 @@ tokio = { workspace = true, features = ["test-util"] }
 rmcp = { workspace = true, features = ["server", "transport-io", "client"] }
 async-trait = { workspace = true }
 serial_test = { workspace = true }
-khive-pack-knowledge = { version = "0.5.0", path = "../khive-pack-knowledge" }
+khive-pack-knowledge = { version = "0.7.0", path = "../khive-pack-knowledge" }
 rusqlite = { workspace = true, features = ["bundled"] }

--- a/crates/khive-merge/Cargo.lock
+++ b/crates/khive-merge/Cargo.lock
@@ -1224,7 +1224,7 @@ dependencies = [
 
 [[package]]
 name = "khive-db"
-version = "0.5.0"
+version = "0.7.0"
 dependencies = [
  "async-trait",
  "blake3",
@@ -1253,7 +1253,7 @@ dependencies = [
 
 [[package]]
 name = "khive-fold"
-version = "0.5.0"
+version = "0.7.0"
 dependencies = [
  "blake3",
  "chrono",
@@ -1267,7 +1267,7 @@ dependencies = [
 
 [[package]]
 name = "khive-fusion"
-version = "0.5.0"
+version = "0.7.0"
 dependencies = [
  "khive-score",
  "serde",
@@ -1276,7 +1276,7 @@ dependencies = [
 
 [[package]]
 name = "khive-gate"
-version = "0.5.0"
+version = "0.7.0"
 dependencies = [
  "chrono",
  "khive-types",
@@ -1287,7 +1287,7 @@ dependencies = [
 
 [[package]]
 name = "khive-merge"
-version = "0.5.0"
+version = "0.7.0"
 dependencies = [
  "chrono",
  "khive-runtime",
@@ -1301,7 +1301,7 @@ dependencies = [
 
 [[package]]
 name = "khive-query"
-version = "0.5.0"
+version = "0.7.0"
 dependencies = [
  "khive-types",
  "thiserror",
@@ -1309,7 +1309,7 @@ dependencies = [
 
 [[package]]
 name = "khive-runtime"
-version = "0.5.0"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1339,7 +1339,7 @@ dependencies = [
 
 [[package]]
 name = "khive-score"
-version = "0.5.0"
+version = "0.7.0"
 dependencies = [
  "khive-types",
  "serde",
@@ -1347,7 +1347,7 @@ dependencies = [
 
 [[package]]
 name = "khive-storage"
-version = "0.5.0"
+version = "0.7.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1362,7 +1362,7 @@ dependencies = [
 
 [[package]]
 name = "khive-types"
-version = "0.5.0"
+version = "0.7.0"
 dependencies = [
  "blake3",
  "serde",

--- a/crates/khive-merge/Cargo.toml
+++ b/crates/khive-merge/Cargo.toml
@@ -5,7 +5,7 @@
 # [workspace.package] below declares the shared version for this standalone workspace.
 
 [workspace.package]
-version = "0.5.0"
+version = "0.7.0"
 
 [package]
 name = "khive-merge"
@@ -18,8 +18,8 @@ homepage = "https://github.com/ohdearquant"
 description = "KG three-way merge with conflict detection (ADR-039)"
 
 [dependencies]
-khive-runtime = { version = "0.5.0", path = "../khive-runtime" }
-khive-storage = { version = "0.5.0", path = "../khive-storage" }
+khive-runtime = { version = "0.7.0", path = "../khive-runtime" }
+khive-storage = { version = "0.7.0", path = "../khive-storage" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 thiserror = "2.0"

--- a/crates/khive-pack-blob/Cargo.toml
+++ b/crates/khive-pack-blob/Cargo.toml
@@ -12,9 +12,9 @@ categories.workspace = true
 description = "Blob verb pack — thin MCP verbs (put/get/stat) over the existing BlobStore CAS"
 
 [dependencies]
-khive-types = { version = "0.5.0", path = "../khive-types", features = ["serde"] }
-khive-runtime = { version = "0.5.0", path = "../khive-runtime" }
-khive-storage = { version = "0.5.0", path = "../khive-storage" }
+khive-types = { version = "0.7.0", path = "../khive-types", features = ["serde"] }
+khive-runtime = { version = "0.7.0", path = "../khive-runtime" }
+khive-storage = { version = "0.7.0", path = "../khive-storage" }
 async-trait = { workspace = true }
 base64 = { workspace = true }
 blake3 = { workspace = true }
@@ -24,7 +24,7 @@ serde_json = { workspace = true }
 tokio = { workspace = true }
 
 [dev-dependencies]
-khive-db = { version = "0.5.0", path = "../khive-db" }
+khive-db = { version = "0.7.0", path = "../khive-db" }
 tempfile = { workspace = true }
 
 [[test]]

--- a/crates/khive-pack-brain/Cargo.toml
+++ b/crates/khive-pack-brain/Cargo.toml
@@ -15,18 +15,18 @@ description = "Brain pack — profile-oriented orchestration via Fold + Objectiv
 bench = false
 
 [dependencies]
-khive-brain-core = { version = "0.5.0", path = "../khive-brain-core" }
-khive-types = { version = "0.5.0", path = "../khive-types", features = ["serde"] }
-khive-runtime = { version = "0.5.0", path = "../khive-runtime" }
-khive-fold = { version = "0.5.0", path = "../khive-fold" }
-khive-storage = { version = "0.5.0", path = "../khive-storage" }
+khive-brain-core = { version = "0.7.0", path = "../khive-brain-core" }
+khive-types = { version = "0.7.0", path = "../khive-types", features = ["serde"] }
+khive-runtime = { version = "0.7.0", path = "../khive-runtime" }
+khive-fold = { version = "0.7.0", path = "../khive-fold" }
+khive-storage = { version = "0.7.0", path = "../khive-storage" }
 # ADR-081 §2/§6 (findings 1+2): the fold gate needs the event
 # append on the SAME held `SqlWriter` transaction as the dedup claim + mass
 # fold, so it calls khive-db's transaction-enlisted `append_event_on_writer`
 # seam directly rather than going through the higher-level `EventStore`
 # trait (which always opens its own transaction). No cycle: khive-db does not
 # depend on this crate.
-khive-db = { version = "0.5.0", path = "../khive-db" }
+khive-db = { version = "0.7.0", path = "../khive-db" }
 inventory = { workspace = true }
 async-trait = { workspace = true }
 lattice-fann = { workspace = true, optional = true }
@@ -41,7 +41,7 @@ lattice-router = ["dep:lattice-fann"]
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["test-util"] }
-khive-pack-kg = { version = "0.5.0", path = "../khive-pack-kg" }
+khive-pack-kg = { version = "0.7.0", path = "../khive-pack-kg" }
 # Dev-only: exercises the real memory.recall -> BrainPack dispatch-hook path
 # (issue #459 regression). khive-pack-memory already carries khive-pack-brain
 # as a dev-dependency for its own tests; Cargo permits cyclic dev-dependencies

--- a/crates/khive-pack-code/Cargo.toml
+++ b/crates/khive-pack-code/Cargo.toml
@@ -12,9 +12,9 @@ categories.workspace = true
 description = "Code ontology pack - typed edge rules and audit findings vocabulary"
 
 [dependencies]
-khive-types = { version = "0.5.0", path = "../khive-types", features = ["serde"] }
-khive-runtime = { version = "0.5.0", path = "../khive-runtime" }
-khive-storage = { version = "0.5.0", path = "../khive-storage" }
+khive-types = { version = "0.7.0", path = "../khive-types", features = ["serde"] }
+khive-runtime = { version = "0.7.0", path = "../khive-runtime" }
+khive-storage = { version = "0.7.0", path = "../khive-storage" }
 inventory = { workspace = true }
 async-trait = { workspace = true }
 chrono = { workspace = true }
@@ -27,6 +27,6 @@ regex = { workspace = true }
 anyhow = { workspace = true }
 
 [dev-dependencies]
-khive-pack-kg = { version = "0.5.0", path = "../khive-pack-kg" }
+khive-pack-kg = { version = "0.7.0", path = "../khive-pack-kg" }
 tokio = { workspace = true, features = ["full"] }
 tempfile = { workspace = true }

--- a/crates/khive-pack-comm/Cargo.toml
+++ b/crates/khive-pack-comm/Cargo.toml
@@ -15,9 +15,9 @@ description = "Communication pack — inter-agent messaging (send, inbox, read, 
 bench = false
 
 [dependencies]
-khive-types = { version = "0.5.0", path = "../khive-types", features = ["serde"] }
-khive-runtime = { version = "0.5.0", path = "../khive-runtime" }
-khive-storage = { version = "0.5.0", path = "../khive-storage" }
+khive-types = { version = "0.7.0", path = "../khive-types", features = ["serde"] }
+khive-runtime = { version = "0.7.0", path = "../khive-runtime" }
+khive-storage = { version = "0.7.0", path = "../khive-storage" }
 inventory = { workspace = true }
 async-trait = { workspace = true }
 serde = { workspace = true }
@@ -28,11 +28,11 @@ tracing = { workspace = true }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["full"] }
-khive-pack-kg = { version = "0.5.0", path = "../khive-pack-kg" }
-khive-db = { version = "0.5.0", path = "../khive-db" }
+khive-pack-kg = { version = "0.7.0", path = "../khive-pack-kg" }
+khive-db = { version = "0.7.0", path = "../khive-db" }
 criterion = { workspace = true }
 toml = { workspace = true }
-khive-runtime = { version = "0.5.0", path = "../khive-runtime", features = ["fault-injection"] }
+khive-runtime = { version = "0.7.0", path = "../khive-runtime", features = ["fault-injection"] }
 lattice-embed = { workspace = true }
 rusqlite = { workspace = true, features = ["bundled", "column_decltype"] }
 tempfile = { workspace = true }

--- a/crates/khive-pack-formal/Cargo.toml
+++ b/crates/khive-pack-formal/Cargo.toml
@@ -12,8 +12,8 @@ categories.workspace = true
 description = "Formal-math ontology pack — typed edge rules for theorem/definition/structure/instance/axiom/goal subtypes"
 
 [dependencies]
-khive-types = { version = "0.5.0", path = "../khive-types", features = ["serde"] }
-khive-runtime = { version = "0.5.0", path = "../khive-runtime" }
+khive-types = { version = "0.7.0", path = "../khive-types", features = ["serde"] }
+khive-runtime = { version = "0.7.0", path = "../khive-runtime" }
 inventory = { workspace = true }
 async-trait = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/khive-pack-git/Cargo.toml
+++ b/crates/khive-pack-git/Cargo.toml
@@ -12,10 +12,10 @@ categories.workspace = true
 description = "Git-lifecycle pack — commit/issue/pull_request provenance notes over the notes substrate (ADR-088)"
 
 [dependencies]
-khive-types = { version = "0.5.0", path = "../khive-types", features = ["serde"] }
-khive-runtime = { version = "0.5.0", path = "../khive-runtime" }
+khive-types = { version = "0.7.0", path = "../khive-types", features = ["serde"] }
+khive-runtime = { version = "0.7.0", path = "../khive-runtime" }
 inventory = { workspace = true }
-khive-storage = { version = "0.5.0", path = "../khive-storage" }
+khive-storage = { version = "0.7.0", path = "../khive-storage" }
 async-trait = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
@@ -29,7 +29,7 @@ blake3 = { workspace = true }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["full"] }
-khive-pack-kg = { version = "0.5.0", path = "../khive-pack-kg" }
+khive-pack-kg = { version = "0.7.0", path = "../khive-pack-kg" }
 tempfile = { workspace = true }
-khive-runtime = { version = "0.5.0", path = "../khive-runtime", features = ["fault-injection"] }
+khive-runtime = { version = "0.7.0", path = "../khive-runtime", features = ["fault-injection"] }
 lattice-embed = { workspace = true }

--- a/crates/khive-pack-gtd/Cargo.toml
+++ b/crates/khive-pack-gtd/Cargo.toml
@@ -15,10 +15,10 @@ description = "GTD verb pack — task lifecycle (assign/next/complete/transition
 bench = false
 
 [dependencies]
-khive-types = { version = "0.5.0", path = "../khive-types", features = ["serde"] }
-khive-runtime = { version = "0.5.0", path = "../khive-runtime" }
+khive-types = { version = "0.7.0", path = "../khive-types", features = ["serde"] }
+khive-runtime = { version = "0.7.0", path = "../khive-runtime" }
 inventory = { workspace = true }
-khive-storage = { version = "0.5.0", path = "../khive-storage" }
+khive-storage = { version = "0.7.0", path = "../khive-storage" }
 async-trait = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
@@ -28,7 +28,7 @@ tracing = { workspace = true }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["full"] }
-khive-pack-kg = { version = "0.5.0", path = "../khive-pack-kg" }
+khive-pack-kg = { version = "0.7.0", path = "../khive-pack-kg" }
 criterion = { workspace = true }
 
 [[bench]]

--- a/crates/khive-pack-kg/Cargo.toml
+++ b/crates/khive-pack-kg/Cargo.toml
@@ -15,11 +15,11 @@ description = "KG verb pack — entity/note CRUD, graph traversal, hybrid search
 bench = false
 
 [dependencies]
-khive-types = { version = "0.5.0", path = "../khive-types", features = ["serde"] }
-khive-runtime = { version = "0.5.0", path = "../khive-runtime" }
-khive-query = { version = "0.5.0", path = "../khive-query" }
+khive-types = { version = "0.7.0", path = "../khive-types", features = ["serde"] }
+khive-runtime = { version = "0.7.0", path = "../khive-runtime" }
+khive-query = { version = "0.7.0", path = "../khive-query" }
 inventory = { workspace = true }
-khive-storage = { version = "0.5.0", path = "../khive-storage" }
+khive-storage = { version = "0.7.0", path = "../khive-storage" }
 async-trait = { workspace = true }
 chrono = { workspace = true }
 serde = { workspace = true }
@@ -31,7 +31,7 @@ tracing = { workspace = true }
 tokio = { workspace = true, features = ["test-util"] }
 criterion = { workspace = true }
 serde_json = { workspace = true }
-khive-pack-formal = { version = "0.5.0", path = "../khive-pack-formal" }
+khive-pack-formal = { version = "0.7.0", path = "../khive-pack-formal" }
 # Path-only: cyclic dev-dep pair with khive-pack-gtd; cargo strips it at publish.
 khive-pack-gtd = { path = "../khive-pack-gtd" }
 lattice-embed = { workspace = true }

--- a/crates/khive-pack-knowledge/Cargo.toml
+++ b/crates/khive-pack-knowledge/Cargo.toml
@@ -15,14 +15,14 @@ description = "Knowledge verb pack — lore corpus (atoms/domains), TF-IDF retri
 bench = false
 
 [dependencies]
-khive-types = { version = "0.5.0", path = "../khive-types", features = ["serde"] }
-khive-brain-core = { version = "0.5.0", path = "../khive-brain-core" }
-khive-runtime = { version = "0.5.0", path = "../khive-runtime" }
-khive-storage = { version = "0.5.0", path = "../khive-storage" }
-khive-fold = { version = "0.5.0", path = "../khive-fold" }
-khive-fusion = { version = "0.5.0", path = "../khive-fusion" }
-khive-score = { version = "0.5.0", path = "../khive-score" }
-khive-vamana = { version = "0.5.0", path = "../khive-vamana" }
+khive-types = { version = "0.7.0", path = "../khive-types", features = ["serde"] }
+khive-brain-core = { version = "0.7.0", path = "../khive-brain-core" }
+khive-runtime = { version = "0.7.0", path = "../khive-runtime" }
+khive-storage = { version = "0.7.0", path = "../khive-storage" }
+khive-fold = { version = "0.7.0", path = "../khive-fold" }
+khive-fusion = { version = "0.7.0", path = "../khive-fusion" }
+khive-score = { version = "0.7.0", path = "../khive-score" }
+khive-vamana = { version = "0.7.0", path = "../khive-vamana" }
 inventory = { workspace = true }
 tokio = { workspace = true }
 async-trait = { workspace = true }
@@ -34,9 +34,9 @@ chrono = { workspace = true }
 sha2 = { workspace = true }
 
 [dev-dependencies]
-khive-pack-kg = { version = "0.5.0", path = "../khive-pack-kg" }
-khive-pack-brain = { version = "0.5.0", path = "../khive-pack-brain" }
-khive-storage = { version = "0.5.0", path = "../khive-storage" }
+khive-pack-kg = { version = "0.7.0", path = "../khive-pack-kg" }
+khive-pack-brain = { version = "0.7.0", path = "../khive-pack-brain" }
+khive-storage = { version = "0.7.0", path = "../khive-storage" }
 tokio = { workspace = true, features = ["test-util"] }
 lattice-embed = { workspace = true }
 criterion = { workspace = true }

--- a/crates/khive-pack-memory/Cargo.toml
+++ b/crates/khive-pack-memory/Cargo.toml
@@ -15,16 +15,16 @@ description = "Memory verb pack — remember/recall semantics with decay-aware r
 bench = false
 
 [dependencies]
-khive-types = { version = "0.5.0", path = "../khive-types", features = ["serde"] }
-khive-runtime = { version = "0.5.0", path = "../khive-runtime" }
-khive-fusion = { version = "0.5.0", path = "../khive-fusion" }
-khive-retrieval = { version = "0.5.0", path = "../khive-retrieval" }
-khive-score = { version = "0.5.0", path = "../khive-score" }
-khive-brain-core = { version = "0.5.0", path = "../khive-brain-core" }
-khive-vamana = { version = "0.5.0", path = "../khive-vamana" }
+khive-types = { version = "0.7.0", path = "../khive-types", features = ["serde"] }
+khive-runtime = { version = "0.7.0", path = "../khive-runtime" }
+khive-fusion = { version = "0.7.0", path = "../khive-fusion" }
+khive-retrieval = { version = "0.7.0", path = "../khive-retrieval" }
+khive-score = { version = "0.7.0", path = "../khive-score" }
+khive-brain-core = { version = "0.7.0", path = "../khive-brain-core" }
+khive-vamana = { version = "0.7.0", path = "../khive-vamana" }
 blake3 = { workspace = true }
 inventory = { workspace = true }
-khive-storage = { version = "0.5.0", path = "../khive-storage" }
+khive-storage = { version = "0.7.0", path = "../khive-storage" }
 async-trait = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
@@ -36,9 +36,9 @@ lru = { workspace = true }
 parking_lot = { workspace = true }
 
 [dev-dependencies]
-khive-db = { version = "0.5.0", path = "../khive-db" }
-khive-pack-kg = { version = "0.5.0", path = "../khive-pack-kg" }
-khive-pack-brain = { version = "0.5.0", path = "../khive-pack-brain" }
+khive-db = { version = "0.7.0", path = "../khive-db" }
+khive-pack-kg = { version = "0.7.0", path = "../khive-pack-kg" }
+khive-pack-brain = { version = "0.7.0", path = "../khive-pack-brain" }
 tokio = { workspace = true, features = ["test-util"] }
 lattice-embed = { workspace = true }
 async-trait = { workspace = true }

--- a/crates/khive-pack-schedule/Cargo.toml
+++ b/crates/khive-pack-schedule/Cargo.toml
@@ -15,10 +15,10 @@ description = "Schedule pack — time-triggered intent storage (remind, schedule
 bench = false
 
 [dependencies]
-khive-types = { version = "0.5.0", path = "../khive-types", features = ["serde"] }
-khive-runtime = { version = "0.5.0", path = "../khive-runtime" }
-khive-storage = { version = "0.5.0", path = "../khive-storage" }
-khive-request = { version = "0.5.0", path = "../khive-request" }
+khive-types = { version = "0.7.0", path = "../khive-types", features = ["serde"] }
+khive-runtime = { version = "0.7.0", path = "../khive-runtime" }
+khive-storage = { version = "0.7.0", path = "../khive-storage" }
+khive-request = { version = "0.7.0", path = "../khive-request" }
 inventory = { workspace = true }
 async-trait = { workspace = true }
 serde = { workspace = true }
@@ -29,10 +29,10 @@ tracing = { workspace = true }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["full"] }
-khive-pack-kg = { version = "0.5.0", path = "../khive-pack-kg" }
-khive-pack-comm = { version = "0.5.0", path = "../khive-pack-comm" }
-khive-pack-brain = { version = "0.5.0", path = "../khive-pack-brain" }
-khive-pack-git = { version = "0.5.0", path = "../khive-pack-git" }
+khive-pack-kg = { version = "0.7.0", path = "../khive-pack-kg" }
+khive-pack-comm = { version = "0.7.0", path = "../khive-pack-comm" }
+khive-pack-brain = { version = "0.7.0", path = "../khive-pack-brain" }
+khive-pack-git = { version = "0.7.0", path = "../khive-pack-git" }
 criterion = { workspace = true }
 
 [[bench]]

--- a/crates/khive-pack-session/Cargo.toml
+++ b/crates/khive-pack-session/Cargo.toml
@@ -12,10 +12,10 @@ categories.workspace = true
 description = "Session verb pack - store/list/resume/export over the notes substrate"
 
 [dependencies]
-khive-types = { version = "0.5.0", path = "../khive-types", features = ["serde"] }
-khive-runtime = { version = "0.5.0", path = "../khive-runtime" }
+khive-types = { version = "0.7.0", path = "../khive-types", features = ["serde"] }
+khive-runtime = { version = "0.7.0", path = "../khive-runtime" }
 inventory = { workspace = true }
-khive-storage = { version = "0.5.0", path = "../khive-storage" }
+khive-storage = { version = "0.7.0", path = "../khive-storage" }
 async-trait = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
@@ -26,7 +26,7 @@ tokio = { workspace = true }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["full"] }
-khive-pack-kg = { version = "0.5.0", path = "../khive-pack-kg" }
+khive-pack-kg = { version = "0.7.0", path = "../khive-pack-kg" }
 tempfile = { workspace = true }
 # Test-only: builds a bare `PoolConfig { write_queue_enabled: true, .. }` +
 # `SqlBridge` directly (no `KhiveRuntime`, no `KHIVE_WRITE_QUEUE` env var) for
@@ -34,4 +34,4 @@ tempfile = { workspace = true }
 # established pattern in khive-pack-brain's `fold_gate.rs` and `persist.rs`
 # (documented there: env-var mutation races other tests' `KhiveRuntime::new`
 # calls in the same binary; a literal `PoolConfig` sidesteps that).
-khive-db = { version = "0.5.0", path = "../khive-db" }
+khive-db = { version = "0.7.0", path = "../khive-db" }

--- a/crates/khive-pack-template/Cargo.toml
+++ b/crates/khive-pack-template/Cargo.toml
@@ -12,12 +12,12 @@ categories.workspace = true
 description = "Reference template for new khive packs (ADR-023 §8). Copy this crate to get a working pack scaffold."
 
 [dependencies]
-khive-types = { version = "0.5.0", path = "../khive-types", features = ["serde"] }
-khive-runtime = { version = "0.5.0", path = "../khive-runtime" }
+khive-types = { version = "0.7.0", path = "../khive-types", features = ["serde"] }
+khive-runtime = { version = "0.7.0", path = "../khive-runtime" }
 inventory = { workspace = true }
 async-trait = { workspace = true }
 serde_json = { workspace = true }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["test-util"] }
-khive-pack-kg = { version = "0.5.0", path = "../khive-pack-kg" }
+khive-pack-kg = { version = "0.7.0", path = "../khive-pack-kg" }

--- a/crates/khive-pack-workspace/Cargo.toml
+++ b/crates/khive-pack-workspace/Cargo.toml
@@ -11,8 +11,8 @@ categories.workspace = true
 description = "Workspace pack  -  pack-owned `workspace` entity kind with typed `contains` membership edges to issue/pull_request/commit/task/session records (issue #873)"
 
 [dependencies]
-khive-types = { version = "0.5.0", path = "../khive-types", features = ["serde"] }
-khive-runtime = { version = "0.5.0", path = "../khive-runtime" }
+khive-types = { version = "0.7.0", path = "../khive-types", features = ["serde"] }
+khive-runtime = { version = "0.7.0", path = "../khive-runtime" }
 inventory = { workspace = true }
 async-trait = { workspace = true }
 serde_json = { workspace = true }
@@ -20,7 +20,7 @@ uuid = { workspace = true }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["full"] }
-khive-pack-kg = { version = "0.5.0", path = "../khive-pack-kg" }
-khive-pack-gtd = { version = "0.5.0", path = "../khive-pack-gtd" }
-khive-pack-git = { version = "0.5.0", path = "../khive-pack-git" }
-khive-pack-session = { version = "0.5.0", path = "../khive-pack-session" }
+khive-pack-kg = { version = "0.7.0", path = "../khive-pack-kg" }
+khive-pack-gtd = { version = "0.7.0", path = "../khive-pack-gtd" }
+khive-pack-git = { version = "0.7.0", path = "../khive-pack-git" }
+khive-pack-session = { version = "0.7.0", path = "../khive-pack-session" }

--- a/crates/khive-query/Cargo.toml
+++ b/crates/khive-query/Cargo.toml
@@ -15,7 +15,7 @@ description = "GQL and SPARQL parsers with SQL compiler for knowledge graph quer
 bench = false
 
 [dependencies]
-khive-types = { version = "0.5.0", path = "../khive-types" }
+khive-types = { version = "0.7.0", path = "../khive-types" }
 thiserror = { workspace = true }
 
 [dev-dependencies]

--- a/crates/khive-request/Cargo.toml
+++ b/crates/khive-request/Cargo.toml
@@ -15,7 +15,7 @@ description = "Request DSL — parses verb-dispatch strings (function-call, JSON
 bench = false
 
 [dependencies]
-khive-types = { version = "0.5.0", path = "../khive-types" }
+khive-types = { version = "0.7.0", path = "../khive-types" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 

--- a/crates/khive-retrieval/Cargo.toml
+++ b/crates/khive-retrieval/Cargo.toml
@@ -15,15 +15,15 @@ description = "Hybrid retrieval composer (HNSW + BM25 + fusion + graph + cross-e
 bench = false
 
 [dependencies]
-khive-hnsw    = { version = "0.5.0", path = "../khive-hnsw" }
-khive-bm25    = { version = "0.5.0", path = "../khive-bm25" }
-khive-fusion  = { version = "0.5.0", path = "../khive-fusion" }
-khive-score   = { version = "0.5.0", path = "../khive-score" }
-khive-types   = { version = "0.5.0", path = "../khive-types" }
-khive-fold    = { version = "0.5.0", path = "../khive-fold", optional = true }
-khive-storage = { version = "0.5.0", path = "../khive-storage", optional = true }
-khive-db      = { version = "0.5.0", path = "../khive-db" }
-khive-gate    = { version = "0.5.0", path = "../khive-gate", optional = true }
+khive-hnsw    = { version = "0.7.0", path = "../khive-hnsw" }
+khive-bm25    = { version = "0.7.0", path = "../khive-bm25" }
+khive-fusion  = { version = "0.7.0", path = "../khive-fusion" }
+khive-score   = { version = "0.7.0", path = "../khive-score" }
+khive-types   = { version = "0.7.0", path = "../khive-types" }
+khive-fold    = { version = "0.7.0", path = "../khive-fold", optional = true }
+khive-storage = { version = "0.7.0", path = "../khive-storage", optional = true }
+khive-db      = { version = "0.7.0", path = "../khive-db" }
+khive-gate    = { version = "0.7.0", path = "../khive-gate", optional = true }
 lattice-embed = { workspace = true }
 
 serde = { workspace = true }
@@ -62,8 +62,8 @@ embed = []
 
 [dev-dependencies]
 criterion = { workspace = true }
-khive-score = { version = "0.5.0", path = "../khive-score" }
-khive-fusion = { version = "0.5.0", path = "../khive-fusion" }
+khive-score = { version = "0.7.0", path = "../khive-score" }
+khive-fusion = { version = "0.7.0", path = "../khive-fusion" }
 
 [[bench]]
 name = "fusion_bench"

--- a/crates/khive-runtime/Cargo.toml
+++ b/crates/khive-runtime/Cargo.toml
@@ -15,14 +15,14 @@ description = "Composable Service API: entity/note CRUD, graph traversal, hybrid
 fault-injection = []
 
 [dependencies]
-khive-types = { version = "0.5.0", path = "../khive-types", features = ["serde"] }
-khive-storage = { version = "0.5.0", path = "../khive-storage" }
-khive-score = { version = "0.5.0", path = "../khive-score" }
-khive-fusion = { version = "0.5.0", path = "../khive-fusion" }
-khive-fold = { version = "0.5.0", path = "../khive-fold" }
-khive-db = { version = "0.5.0", path = "../khive-db", features = ["vectors"] }
-khive-query = { version = "0.5.0", path = "../khive-query" }
-khive-gate = { version = "0.5.0", path = "../khive-gate" }
+khive-types = { version = "0.7.0", path = "../khive-types", features = ["serde"] }
+khive-storage = { version = "0.7.0", path = "../khive-storage" }
+khive-score = { version = "0.7.0", path = "../khive-score" }
+khive-fusion = { version = "0.7.0", path = "../khive-fusion" }
+khive-fold = { version = "0.7.0", path = "../khive-fold" }
+khive-db = { version = "0.7.0", path = "../khive-db", features = ["vectors"] }
+khive-query = { version = "0.7.0", path = "../khive-query" }
+khive-gate = { version = "0.7.0", path = "../khive-gate" }
 inventory = { workspace = true }
 tokio = { workspace = true }
 tokio-util = { workspace = true }
@@ -41,7 +41,7 @@ libc = { workspace = true }
 anyhow = { workspace = true }
 
 [dev-dependencies]
-khive-gate-rego = { version = "0.5.0", path = "../khive-gate-rego" }
+khive-gate-rego = { version = "0.7.0", path = "../khive-gate-rego" }
 tokio = { workspace = true, features = ["test-util"] }
 tempfile = { workspace = true }
 tracing-subscriber = { workspace = true }

--- a/crates/khive-score/Cargo.toml
+++ b/crates/khive-score/Cargo.toml
@@ -18,7 +18,7 @@ default = ["serde"]
 serde = ["dep:serde"]
 
 [dependencies]
-khive-types = { version = "0.5.0", path = "../khive-types" }
+khive-types = { version = "0.7.0", path = "../khive-types" }
 serde = { workspace = true, optional = true, features = ["derive"] }
 
 [dev-dependencies]

--- a/crates/khive-storage/Cargo.toml
+++ b/crates/khive-storage/Cargo.toml
@@ -13,8 +13,8 @@ categories.workspace = true
 [dependencies]
 async-trait = { workspace = true }
 chrono = { workspace = true }
-khive-score = { version = "0.5.0", path = "../khive-score" }
-khive-types = { version = "0.5.0", path = "../khive-types", features = ["serde"] }
+khive-score = { version = "0.7.0", path = "../khive-score" }
+khive-types = { version = "0.7.0", path = "../khive-types", features = ["serde"] }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/khive-vamana/Cargo.toml
+++ b/crates/khive-vamana/Cargo.toml
@@ -27,7 +27,7 @@ serde = { workspace = true }
 thiserror = { workspace = true }
 blake3 = { workspace = true }
 uuid = { workspace = true, optional = true }
-khive-quant = { version = "0.5.0", path = "../khive-quant", default-features = false }
+khive-quant = { version = "0.7.0", path = "../khive-quant", default-features = false }
 
 [target.'cfg(unix)'.dependencies]
 libc = { workspace = true }

--- a/crates/khive-vcs-adapters/Cargo.toml
+++ b/crates/khive-vcs-adapters/Cargo.toml
@@ -10,7 +10,7 @@ homepage.workspace = true
 description = "KG import/export format adapters — CSV, JSON, and future format support (ADR-036)"
 
 [dependencies]
-khive-types = { version = "0.5.0", path = "../khive-types" }
+khive-types = { version = "0.7.0", path = "../khive-types" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/khive-vcs/Cargo.toml
+++ b/crates/khive-vcs/Cargo.toml
@@ -10,9 +10,9 @@ homepage.workspace = true
 description = "KG versioning — git-native core types, canonical hash, and NDJSON-to-SQLite sync (ADR-010/ADR-020)"
 
 [dependencies]
-khive-runtime = { version = "0.5.0", path = "../khive-runtime" }
-khive-storage = { version = "0.5.0", path = "../khive-storage" }
-khive-types = { version = "0.5.0", path = "../khive-types" }
+khive-runtime = { version = "0.7.0", path = "../khive-runtime" }
+khive-storage = { version = "0.7.0", path = "../khive-storage" }
+khive-types = { version = "0.7.0", path = "../khive-types" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
@@ -26,5 +26,5 @@ tempfile = { workspace = true }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["rt", "macros"] }
-khive-vcs-adapters = { version = "0.5.0", path = "../khive-vcs-adapters" }
-khive-db = { version = "0.5.0", path = "../khive-db" }
+khive-vcs-adapters = { version = "0.7.0", path = "../khive-vcs-adapters" }
+khive-db = { version = "0.7.0", path = "../khive-db" }

--- a/crates/kkernel/Cargo.toml
+++ b/crates/kkernel/Cargo.toml
@@ -12,29 +12,29 @@ categories.workspace = true
 description = "khive kernel — stdio MCP server binary and admin CLI (sync, pack introspection, db ops)"
 
 [dependencies]
-khive-runtime = { version = "0.5.0", path = "../khive-runtime" }
-khive-mcp = { version = "0.5.0", path = "../khive-mcp" }
-khive-score = { version = "0.5.0", path = "../khive-score" }
-khive-db = { version = "0.5.0", path = "../khive-db" }
-khive-storage = { version = "0.5.0", path = "../khive-storage" }
-khive-types = { version = "0.5.0", path = "../khive-types" }
-khive-vcs = { version = "0.5.0", path = "../khive-vcs" }
-khive-vcs-adapters = { version = "0.5.0", path = "../khive-vcs-adapters" }
-khive-pack-kg = { version = "0.5.0", path = "../khive-pack-kg" }
-khive-pack-gtd = { version = "0.5.0", path = "../khive-pack-gtd" }
-khive-pack-memory = { version = "0.5.0", path = "../khive-pack-memory" }
-khive-pack-brain = { version = "0.5.0", path = "../khive-pack-brain" }
-khive-pack-comm = { version = "0.5.0", path = "../khive-pack-comm" }
-khive-pack-schedule = { version = "0.5.0", path = "../khive-pack-schedule" }
-khive-pack-formal = { version = "0.5.0", path = "../khive-pack-formal" }
-khive-pack-code = { version = "0.5.0", path = "../khive-pack-code" }
-khive-pack-knowledge = { version = "0.5.0", path = "../khive-pack-knowledge" }
-khive-pack-session = { version = "0.5.0", path = "../khive-pack-session" }
-khive-pack-git = { version = "0.5.0", path = "../khive-pack-git" }
-khive-pack-blob = { version = "0.5.0", path = "../khive-pack-blob" }
-khive-pack-workspace = { version = "0.5.0", path = "../khive-pack-workspace" }
-khive-request = { version = "0.5.0", path = "../khive-request" }
-khive-changeset = { version = "0.5.0", path = "../khive-changeset" }
+khive-runtime = { version = "0.7.0", path = "../khive-runtime" }
+khive-mcp = { version = "0.7.0", path = "../khive-mcp" }
+khive-score = { version = "0.7.0", path = "../khive-score" }
+khive-db = { version = "0.7.0", path = "../khive-db" }
+khive-storage = { version = "0.7.0", path = "../khive-storage" }
+khive-types = { version = "0.7.0", path = "../khive-types" }
+khive-vcs = { version = "0.7.0", path = "../khive-vcs" }
+khive-vcs-adapters = { version = "0.7.0", path = "../khive-vcs-adapters" }
+khive-pack-kg = { version = "0.7.0", path = "../khive-pack-kg" }
+khive-pack-gtd = { version = "0.7.0", path = "../khive-pack-gtd" }
+khive-pack-memory = { version = "0.7.0", path = "../khive-pack-memory" }
+khive-pack-brain = { version = "0.7.0", path = "../khive-pack-brain" }
+khive-pack-comm = { version = "0.7.0", path = "../khive-pack-comm" }
+khive-pack-schedule = { version = "0.7.0", path = "../khive-pack-schedule" }
+khive-pack-formal = { version = "0.7.0", path = "../khive-pack-formal" }
+khive-pack-code = { version = "0.7.0", path = "../khive-pack-code" }
+khive-pack-knowledge = { version = "0.7.0", path = "../khive-pack-knowledge" }
+khive-pack-session = { version = "0.7.0", path = "../khive-pack-session" }
+khive-pack-git = { version = "0.7.0", path = "../khive-pack-git" }
+khive-pack-blob = { version = "0.7.0", path = "../khive-pack-blob" }
+khive-pack-workspace = { version = "0.7.0", path = "../khive-pack-workspace" }
+khive-request = { version = "0.7.0", path = "../khive-request" }
+khive-changeset = { version = "0.7.0", path = "../khive-changeset" }
 lru = { workspace = true }
 tokio = { workspace = true }
 async-trait = { workspace = true }


### PR DESCRIPTION
Bumps the workspace package version and all intra-workspace dependency pins from 0.5.0 to 0.7.0, refreshing Cargo.lock accordingly.

- `crates/Cargo.toml` `workspace.package.version` 0.5.0 -> 0.7.0
- All internal dependency version pins across 38 crate manifests updated to match
- `Cargo.lock` regenerated via `cargo check --workspace` (42 workspace crates now at 0.7.0)

No code changes. Prepares the 0.7.0 release cut.