### PR TITLE
test(mcp): gate parallel daemon recovery

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -213,6 +213,9 @@ jobs:
       - name: Channel-email feature tests
         if: env.CI_SUITE == 'full' && matrix.shard == 1
         run: ../scripts/ci.sh channel-email
+      - name: Daemon recovery flake gate
+        if: matrix.shard == 1
+        run: ../scripts/ci.sh daemon-recovery-flake
       - name: No-default-features check
         if: env.CI_SUITE == 'full' && matrix.shard == 1
         run: ../scripts/ci.sh no-default-features

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -213,8 +213,18 @@ jobs:
       - name: Channel-email feature tests
         if: env.CI_SUITE == 'full' && matrix.shard == 1
         run: ../scripts/ci.sh channel-email
+      # Gated like every other shard-1 phase in this job: the introducing
+      # commit (cad6479dc) left no rationale for the lone ungated condition,
+      # and the macos-pr lane already runs the whole khive-mcp suite once via
+      # macos-pr-tests, so the focused portability lane keeps one serial run
+      # of the pair while push/nightly/manual full lanes repeat it 25x per OS
+      # (ADR-049 Amendment 3). timeout-minutes: a warm iteration measures
+      # ~0.6s of test time locally (2 tests, serial); 25 iterations plus
+      # per-iteration cargo overhead stays far below 10 minutes even on
+      # slower runners.
       - name: Daemon recovery flake gate
-        if: matrix.shard == 1
+        if: env.CI_SUITE == 'full' && matrix.shard == 1
+        timeout-minutes: 10
         run: ../scripts/ci.sh daemon-recovery-flake
       - name: No-default-features check
         if: env.CI_SUITE == 'full' && matrix.shard == 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -219,12 +219,14 @@ jobs:
       # macos-pr-tests, so the focused portability lane keeps one serial run
       # of the pair while push/nightly/manual full lanes repeat it 25x per OS
       # (ADR-049 Amendment 3). timeout-minutes: a warm iteration measures
-      # ~0.6s of test time locally (2 tests, serial); 25 iterations plus
-      # per-iteration cargo overhead stays far below 10 minutes even on
-      # slower runners.
+      # Observed on ubuntu-latest runners: ~24s per iteration (2 tests,
+      # serial, plus per-iteration cargo overhead), so 25 iterations need
+      # ~10 minutes of test time alone before the initial build. Budget
+      # accordingly; a timeout here means the gate ran out of wall clock,
+      # not that a recovery flake was caught.
       - name: Daemon recovery flake gate
         if: env.CI_SUITE == 'full' && matrix.shard == 1
-        timeout-minutes: 10
+        timeout-minutes: 25
         run: ../scripts/ci.sh daemon-recovery-flake
       - name: No-default-features check
         if: env.CI_SUITE == 'full' && matrix.shard == 1

--- a/crates/khive-mcp/Cargo.toml
+++ b/crates/khive-mcp/Cargo.toml
@@ -65,6 +65,7 @@ channel-telegram = ["khive-channel", "khive-channel-telegram"]
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["test-util"] }
+khive-runtime = { version = "0.7.0", path = "../khive-runtime", features = ["fault-injection"] }
 rmcp = { workspace = true, features = ["server", "transport-io", "client"] }
 async-trait = { workspace = true }
 serial_test = { workspace = true }

--- a/crates/khive-mcp/docs/api/daemon-lifecycle.md
+++ b/crates/khive-mcp/docs/api/daemon-lifecycle.md
@@ -23,7 +23,7 @@ own boot lock — before `confirm_genuinely_dead` runs, and holds it through
 kill + spawn. This makes recovery mutually exclusive across recoverers
 without risking a deadlock against a booting daemon: the daemon itself never
 acquires this lock, only `kill_and_respawn` does. A bounded, deadline-aware
-acquisition (`RECOVERER_LOCK_TIMEOUT_MS` = 8000, generous enough to cover a
+acquisition (`RECOVERER_LOCK_TIMEOUT_MS` = 16000, generous enough to cover a
 peer's full worst-case critical section) is used instead of an unbounded
 `flock` so a second recoverer never blocks forever on a wedged first one.
 
@@ -45,15 +45,31 @@ behavior as `Skipped` but reported distinctly so it is never conflated with a
 positive "confirmed alive" result. `Dead` (confirmed, recoverer lock held) →
 kill + spawn → `Spawned`.
 
-Two test-only barriers (`RECOVERY_RACE_BARRIER`, `SPAWN_COMMIT_BARRIER`)
-force concurrent recoverers under test to reach, respectively, the
-classification-complete point and the commit-to-spawn point at the same
-instant — without them, normal tokio scheduling lets one recoverer finish
-before the other's rounds even observe anything, and the two-recoverer
-regression test would pass even with the recoverer lock deleted.
-`SPAWN_COMMIT_BARRIER` falls through after its bound rather than waiting
-forever, since a recoverer still blocked on the *real* recoverer lock must
-not be forced to rendezvous.
+The test-only `RECOVERY_RACE_BARRIER` forces eight recoverers to reach the
+classification-complete point at the same instant. Without it, normal Tokio
+scheduling can let one recoverer finish before the others observe anything,
+and a nominally parallel test can pass without exercising the lock race.
+
+The recovery launcher is an explicit seam. Production closures still launch
+`current_exe() mcp --daemon` and return the owned child handle unchanged. The
+shared `daemon/test_harness.rs` fixture instead launches the real
+`run_daemon` server in-process on a multi-thread Tokio runtime, so the test can
+observe the server-side ownership fence. Its stable oracle is one responsive
+daemon, one socket/PID rendezvous, and one successful `stats()` exchange after
+quiescence. It deliberately does not require exactly one launch attempt: the
+client releases its recovery lock before a launched daemon binds, so losing
+attempts are legal as long as the server fence converges to one owner.
+Because in-process candidates share a PID, the harness uses an explicit
+fault-injection entry point that lets a responsive same-PID incumbent win;
+ordinary startup retains its PID-reuse-safe behavior. A losing candidate still
+cancels the runtime's process-wide component token, so this fixture deliberately
+uses a component-free dispatcher and makes no component-lifecycle claim.
+
+The companion eight-client ParseFailure test closes every connection only
+after all real frames have been read. Every client must return the stable
+ambiguous-forward error, while kill/spawn counters remain zero and the server
+observes no follow-up connection. `scripts/ci.sh daemon-recovery-flake` runs
+the paired scenarios 25 times on each CI operating system.
 
 ## `confirm_genuinely_dead` — closing the fork-to-flock gap (#758)
 

--- a/crates/khive-mcp/src/daemon.rs
+++ b/crates/khive-mcp/src/daemon.rs
@@ -1228,6 +1228,11 @@ where
     kill_and_respawn_with_launcher(config_id, namespace, &launcher).await
 }
 
+/// Test-only shim over [`kill_and_respawn_with_launcher_and_exit_timeout`]:
+/// same production code path, with only the launcher construction and the
+/// exit-timeout parameter (production passes its own constant through
+/// [`kill_and_respawn`]) supplied by the test. Keep it a pure forwarder —
+/// any logic added here would drift from the non-test path.
 #[cfg(test)]
 async fn kill_and_respawn_with_exit_timeout<F>(
     config_id: &str,
@@ -5102,6 +5107,13 @@ mod tests {
     /// is one live, responsive owner after quiescence — not an exact spawn-call
     /// count, because a launch can legitimately lose the server-side ownership
     /// fence before it binds.
+    ///
+    /// Deliberately NOT `launched_count() == 1`: racing launches are tolerated
+    /// by design. The recoverer lock is best-effort serialization (it shrinks
+    /// the raced-launch window; it is not the correctness mechanism), and the
+    /// server-side boot fence alone guarantees convergence — so removing the
+    /// lock would degrade this test to more raced launches without violating
+    /// its oracle, and that is the intended contract, not a coverage gap.
     #[tokio::test(flavor = "multi_thread", worker_threads = 12)]
     #[serial]
     async fn parallel_no_socket_recovery_converges_to_one_usable_daemon() {

--- a/crates/khive-mcp/src/daemon.rs
+++ b/crates/khive-mcp/src/daemon.rs
@@ -5150,20 +5150,20 @@ mod tests {
             });
         }
 
-        let (spawned, skipped_or_uncertain) =
+        let (spawned, skipped, uncertain) =
             tokio::time::timeout(std::time::Duration::from_secs(30), async move {
                 let mut spawned: Vec<InProcessDaemonHandle> = Vec::new();
-                let mut skipped_or_uncertain = 0usize;
+                let mut skipped = 0usize;
+                let mut uncertain = 0usize;
                 while let Some(result) = recoverers.join_next().await {
                     match result.expect("recoverer task must not panic") {
                         Ok(RecoveryOutcome::Spawned(handle)) => spawned.push(handle),
-                        Ok(RecoveryOutcome::Skipped | RecoveryOutcome::Uncertain) => {
-                            skipped_or_uncertain += 1;
-                        }
+                        Ok(RecoveryOutcome::Skipped) => skipped += 1,
+                        Ok(RecoveryOutcome::Uncertain) => uncertain += 1,
                         Err(error) => panic!("parallel NoSocket recovery failed: {error:?}"),
                     }
                 }
-                (spawned, skipped_or_uncertain)
+                (spawned, skipped, uncertain)
             })
             .await
             .expect("parallel recoverers must quiesce within 30s");
@@ -5172,10 +5172,15 @@ mod tests {
             "at least one recoverer must launch a daemon"
         );
         assert_eq!(
-            spawned.len() + skipped_or_uncertain,
+            spawned.len() + skipped + uncertain,
             CLIENTS,
             "every parallel recoverer must reach a classified outcome"
         );
+        // Uncertain is a deadline-bound degraded outcome per
+        // docs/api/daemon-lifecycle.md. The healthy parallel path resolves
+        // losers as Skipped well inside the 16s deadline, so any Uncertain
+        // here is a regression signal, not noise.
+        assert_eq!(uncertain, 0, "healthy parallel recovery must not time out");
         assert_eq!(
             launcher.launched_count(),
             spawned.len(),

--- a/crates/khive-mcp/src/daemon.rs
+++ b/crates/khive-mcp/src/daemon.rs
@@ -25,77 +25,14 @@ use tokio::net::UnixStream;
 
 use crate::tools::request::RequestParams;
 
-// ── test instrumentation seams ────────────────────────────────────────────────
-//
-// These counters are only compiled in `#[cfg(test)]` builds. They allow tests
-// to assert that kill_stale_daemon_inner and spawn_daemon were called exactly
-// the expected number of times — making the recheck-under-lock test
-// fail-if-reverted: without the recheck, both counters would be non-zero even
-// when a fresh daemon is already alive.
+#[cfg(test)]
+mod test_harness;
 
 #[cfg(test)]
-pub(crate) static KILL_COUNT: std::sync::atomic::AtomicUsize =
-    std::sync::atomic::AtomicUsize::new(0);
-
-#[cfg(test)]
-pub(crate) static SPAWN_COUNT: std::sync::atomic::AtomicUsize =
-    std::sync::atomic::AtomicUsize::new(0);
-
-/// When set to `true` in tests, `classify_pid_identity` identifies any positive
-/// live PID as a daemon. This makes every PID file entry SIGTERM-eligible so
-/// that a reverted recheck-under-lock would cause `kill_stale_daemon_inner` to
-/// attempt SIGTERM against the real daemon PID — the `KILL_COUNT` assertion
-/// catches both the SIGTERM-eligible and the skip-SIGTERM paths.
-#[cfg(test)]
-pub(crate) static FORCE_PID_IS_DAEMON: std::sync::atomic::AtomicBool =
-    std::sync::atomic::AtomicBool::new(false);
-
-#[cfg(test)]
-static FORCE_PID_IS_FOREIGN: std::sync::atomic::AtomicBool =
-    std::sync::atomic::AtomicBool::new(false);
-
-/// Counts how many times the daemon's dispatcher has been invoked for a
-/// NON-probe request.  The exactly-once test asserts this is exactly 1
-/// across the entire recovery path.  A reverted fix (real request used as
-/// probe + re-forwarded at the call site) yields 2 and fails the assertion.
-#[cfg(test)]
-pub(crate) static DAEMON_DISPATCH: std::sync::atomic::AtomicUsize =
-    std::sync::atomic::AtomicUsize::new(0);
-
-/// Test-only rendezvous point: when set, every [`kill_and_respawn`] call
-/// waits on this barrier right after its own initial probe independently
-/// classifies the daemon `Dead` and BEFORE it attempts the recoverer lock —
-/// forces concurrent recoverers under test to race on the lock itself
-/// rather than on scheduler luck (#838). See
-/// `crates/khive-mcp/docs/api/daemon-lifecycle.md`.
-#[cfg(test)]
-pub(crate) static RECOVERY_RACE_BARRIER: std::sync::Mutex<
-    Option<std::sync::Arc<tokio::sync::Barrier>>,
-> = std::sync::Mutex::new(None);
-
-/// Test-only second rendezvous point, right before a recoverer that
-/// classified `Dead` commits to kill+spawn. Bounded (falls through after its
-/// bound rather than waiting forever) so a recoverer still blocked on the
-/// real recoverer lock cannot deadlock it. See
-/// `crates/khive-mcp/docs/api/daemon-lifecycle.md` for the jitter window
-/// this closes.
-#[cfg(test)]
-pub(crate) static SPAWN_COMMIT_BARRIER: std::sync::Mutex<
-    Option<std::sync::Arc<tokio::sync::Barrier>>,
-> = std::sync::Mutex::new(None);
-
-#[cfg(test)]
-pub(crate) fn reset_counters() {
-    KILL_COUNT.store(0, std::sync::atomic::Ordering::SeqCst);
-    SPAWN_COUNT.store(0, std::sync::atomic::Ordering::SeqCst);
-    FORCE_PID_IS_DAEMON.store(false, std::sync::atomic::Ordering::SeqCst);
-    FORCE_PID_IS_FOREIGN.store(false, std::sync::atomic::Ordering::SeqCst);
-    DAEMON_DISPATCH.store(0, std::sync::atomic::Ordering::SeqCst);
-    *RECOVERY_RACE_BARRIER
-        .lock()
-        .expect("barrier mutex poisoned") = None;
-    *SPAWN_COMMIT_BARRIER.lock().expect("barrier mutex poisoned") = None;
-}
+use test_harness::{
+    reset_counters, DAEMON_DISPATCH, FORCE_PID_IS_DAEMON, FORCE_PID_IS_FOREIGN, KILL_COUNT,
+    RECOVERY_RACE_BARRIER, SPAWN_COUNT,
+};
 
 // ── local-dispatch fallback telemetry ─────────────────────────────────────────
 //
@@ -159,16 +96,12 @@ impl FallbackReason {
             FallbackReason::ConfigMismatch | FallbackReason::NamespaceMismatch => {
                 FallbackSeverity::Illegitimate
             }
-            // `ParseFailure` and `ProtocolMismatch` are this module's own
-            // "stale/rolling daemon" bucket: both trigger the same
-            // kill-and-respawn recovery path (see the `ForwardOutcome::ParseFailure
-            // | ForwardOutcome::ProtocolMismatch` handling above) and both
-            // represent a transient protocol-version drift during a rolling
-            // upgrade, not a persistent misconfiguration. SPEC_DRAFT §3 D2's
-            // table names only `version_mismatch` explicitly; `ParseFailure`
-            // is folded into the same `RolloutTransient` tier because the
-            // code already treats it identically to `ProtocolMismatch`
-            // everywhere else in this file.
+            // `ParseFailure` and `ProtocolMismatch` retain their historical
+            // rollout-transient telemetry tier, but neither is a production
+            // fallback anymore. Once the real frame is fully written, both
+            // outcomes are terminal exactly-once errors: no retry, local
+            // dispatch, kill, or respawn (#644/#539). The variants stay in the
+            // closed metrics vocabulary for wire compatibility.
             FallbackReason::ProtocolMismatch | FallbackReason::ParseFailure => {
                 FallbackSeverity::RolloutTransient
             }
@@ -187,7 +120,8 @@ enum FallbackSeverity {
     /// A real misconfiguration. Elevated to an error-level event (plus a
     /// dedicated violation counter) when `KHIVE_DAEMON_STRICT=1`.
     Illegitimate,
-    /// Expected during a rolling upgrade; self-heals via kill-and-respawn.
+    /// Historical rollout-transient telemetry tier. These outcomes are now
+    /// terminal after a real write, but remain in the closed metrics vocabulary.
     /// Never elevated, in strict mode or otherwise.
     RolloutTransient,
     /// No daemon to forward to at all. Never elevated — this is the
@@ -526,9 +460,9 @@ enum ForwardOutcome {
     /// does not match [`PROTOCOL_VERSION`] even though `version_mismatch` is false.
     /// This is the new-client + old-daemon (pre-versioning) scenario: the old daemon
     /// ignores the unknown request field and returns a decodable response whose
-    /// protocol fields default to `false`/`0`. The client must treat this exactly
-    /// like `ParseFailure`: kill the stale daemon, respawn once, and return a clear
-    /// error if the replacement still has the wrong version.
+    /// protocol fields default to `false`/`0`. Since the real request was already
+    /// written, the client must treat this exactly like `ParseFailure`: return a
+    /// hard error without retrying, locally dispatching, killing, or respawning.
     ProtocolMismatch,
 }
 
@@ -550,13 +484,13 @@ async fn try_forward_inner(frame: &DaemonRequestFrame) -> ForwardOutcome {
         Err(e) => {
             // The request was sent but the daemon closed the connection before
             // sending a response frame — likely a daemon crash or panic during
-            // dispatch. Treat as ParseFailure (not NoSocket) so the stale daemon
-            // is killed and a fresh one is spawned, preventing the caller from
-            // silently falling back to local dispatch against a broken daemon.
+            // dispatch. Treat as ParseFailure (not NoSocket): the request may
+            // already have committed, so the caller must return a terminal
+            // ambiguity error without lifecycle actions or local dispatch.
             tracing::warn!(
                 error = %e,
                 "daemon closed connection without sending a response \
-                 (crash during dispatch?) — treating as stale"
+                 (crash during dispatch?) — returning terminal ambiguity"
             );
             return ForwardOutcome::ParseFailure;
         }
@@ -568,16 +502,15 @@ async fn try_forward_inner(frame: &DaemonRequestFrame) -> ForwardOutcome {
             // `version_mismatch` is also false because the old daemon never set
             // it — making `map_response` accept the stale response when
             // `served_config_id` happens to match. Detect this here so the
-            // caller can route it through the same kill/respawn path.
+            // caller can route it through the same terminal no-retry path.
             //
             // Also catch the explicit-mismatch / auto-upgrade case (#156): when a
             // warm OLD daemon receives a request from a NEWER client it responds
             // with `version_mismatch=true` and its own (lower) version number.
             // `daemon_protocol_version < PROTOCOL_VERSION` means the daemon is
-            // stale — route through kill+respawn exactly like the implicit case
-            // above.  If `daemon_protocol_version > PROTOCOL_VERSION` the client
-            // binary is behind; kill+respawn cannot fix that, so let map_response
-            // return a hard error.
+            // stale — route through the same terminal error as the implicit case
+            // above. If `daemon_protocol_version > PROTOCOL_VERSION` the client
+            // binary is behind; let `map_response` return its hard error too.
             let is_stale_daemon = frame.daemon_protocol_version != PROTOCOL_VERSION
                 && (!frame.version_mismatch || frame.daemon_protocol_version < PROTOCOL_VERSION);
             if is_stale_daemon {
@@ -585,7 +518,7 @@ async fn try_forward_inner(frame: &DaemonRequestFrame) -> ForwardOutcome {
                     daemon_version = frame.daemon_protocol_version,
                     expected = PROTOCOL_VERSION,
                     explicit_mismatch = frame.version_mismatch,
-                    "daemon protocol version mismatch (stale daemon) — treating as stale",
+                    "daemon protocol version mismatch after request write — rejecting without retry",
                 );
                 return ForwardOutcome::ProtocolMismatch;
             }
@@ -595,7 +528,7 @@ async fn try_forward_inner(frame: &DaemonRequestFrame) -> ForwardOutcome {
             tracing::warn!(
                 error = %e,
                 bytes = resp.len(),
-                "daemon response could not be decoded — stale daemon binary on {}?",
+                "daemon response could not be decoded after request write on {}",
                 sock.display()
             );
             ForwardOutcome::ParseFailure
@@ -1115,20 +1048,45 @@ async fn probe_daemon_identity(config_id: &str, namespace: &str, timeout_ms: u64
     }
 }
 
+/// Launch seam for daemon recovery.
+///
+/// Production closures return a real [`std::process::Child`]. The test harness
+/// supplies an in-process handle around the real [`daemon::run_daemon`] server,
+/// allowing parallel recovery to assert server convergence without forking the
+/// test binary with synthetic CLI arguments (#539/#544).
+trait DaemonLauncher: Sync {
+    type Handle: std::fmt::Debug;
+
+    fn launch(&self) -> std::io::Result<Self::Handle>;
+}
+
+struct ProcessDaemonLauncher<'a, F>(&'a F);
+
+impl<F> DaemonLauncher for ProcessDaemonLauncher<'_, F>
+where
+    F: Fn() -> std::io::Result<std::process::Child> + Sync,
+{
+    type Handle = std::process::Child;
+
+    fn launch(&self) -> std::io::Result<Self::Handle> {
+        (self.0)()
+    }
+}
+
 /// Outcome returned by [`kill_and_respawn`] to the call site.
 #[derive(Debug)]
-enum RecoveryOutcome {
+enum RecoveryOutcome<H = std::process::Child> {
     /// A concurrent client already replaced the daemon; forward the real request
     /// via the normal path (no new spawn occurred).
     Skipped,
     /// This client killed the stale daemon and spawned a replacement; caller
-    /// must wait for readiness then forward the real request. Carries the
-    /// spawned [`std::process::Child`] (#898) so `forward_or_spawn` can, once
-    /// it is otherwise about to give up and fall back locally, positively
-    /// confirm whether that specific respawn attempt already exited instead
-    /// of ever binding the socket — turning a version-skewed binary's silent,
-    /// forever-repeating respawn failure into a loud, caller-visible error.
-    Spawned(std::process::Child),
+    /// must wait for readiness then forward the real request. The production
+    /// launcher returns a [`std::process::Child`] (#898), so
+    /// `forward_or_spawn` can, once it is otherwise about to give up and fall
+    /// back locally, positively confirm whether that specific respawn attempt
+    /// already exited instead of ever binding the socket. The test launcher
+    /// carries an in-process task handle with the same ownership role.
+    Spawned(H),
     /// Could not obtain a positive confirmation either way within the
     /// deadline-bound recovery window (the recoverer lock or the boot/recovery
     /// lock stayed contended past its deadline) — #838. The
@@ -1266,15 +1224,11 @@ async fn kill_and_respawn<F>(
 where
     F: Fn() -> std::io::Result<std::process::Child> + Sync,
 {
-    kill_and_respawn_with_exit_timeout(
-        config_id,
-        namespace,
-        spawn,
-        std::time::Duration::from_secs(INCUMBENT_EXIT_TIMEOUT_SECS),
-    )
-    .await
+    let launcher = ProcessDaemonLauncher(spawn);
+    kill_and_respawn_with_launcher(config_id, namespace, &launcher).await
 }
 
+#[cfg(test)]
 async fn kill_and_respawn_with_exit_timeout<F>(
     config_id: &str,
     namespace: &str,
@@ -1283,6 +1237,37 @@ async fn kill_and_respawn_with_exit_timeout<F>(
 ) -> Result<RecoveryOutcome, RecoveryError>
 where
     F: Fn() -> std::io::Result<std::process::Child> + Sync,
+{
+    let launcher = ProcessDaemonLauncher(spawn);
+    kill_and_respawn_with_launcher_and_exit_timeout(config_id, namespace, &launcher, exit_timeout)
+        .await
+}
+
+async fn kill_and_respawn_with_launcher<L>(
+    config_id: &str,
+    namespace: &str,
+    launcher: &L,
+) -> Result<RecoveryOutcome<L::Handle>, RecoveryError>
+where
+    L: DaemonLauncher,
+{
+    kill_and_respawn_with_launcher_and_exit_timeout(
+        config_id,
+        namespace,
+        launcher,
+        std::time::Duration::from_secs(INCUMBENT_EXIT_TIMEOUT_SECS),
+    )
+    .await
+}
+
+async fn kill_and_respawn_with_launcher_and_exit_timeout<L>(
+    config_id: &str,
+    namespace: &str,
+    launcher: &L,
+    exit_timeout: std::time::Duration,
+) -> Result<RecoveryOutcome<L::Handle>, RecoveryError>
+where
+    L: DaemonLauncher,
 {
     let initial_probe = {
         let _lock = acquire_recovery_lock();
@@ -1350,24 +1335,6 @@ where
             Ok(RecoveryOutcome::Uncertain)
         }
         ProbeOutcome::Dead => {
-            // Test-only second rendezvous (see `SPAWN_COMMIT_BARRIER`):
-            // bounded wait so two recoverers that both independently
-            // classified Dead commit to spawning at the same instant,
-            // instead of one's real jitter-driven head start giving the
-            // fake-daemon watcher time to save the slower one.
-            #[cfg(test)]
-            {
-                let barrier = SPAWN_COMMIT_BARRIER
-                    .lock()
-                    .expect("barrier mutex poisoned")
-                    .clone();
-                if let Some(barrier) = barrier {
-                    let _ =
-                        tokio::time::timeout(std::time::Duration::from_millis(80), barrier.wait())
-                            .await;
-                }
-            }
-
             // Also take the shared boot/recovery lock for the kill+spawn step
             // itself, matching `acquire_recovery_lock`'s existing role of
             // serializing this against the daemon server's own
@@ -1376,7 +1343,8 @@ where
             // and dropped entirely within this arm.
             let _boot_lock = acquire_recovery_lock();
             kill_stale_daemon_inner(exit_timeout).await?;
-            spawn()
+            launcher
+                .launch()
                 .map(RecoveryOutcome::Spawned)
                 .map_err(RecoveryError::Spawn)
         }
@@ -2132,6 +2100,10 @@ where
 
 #[cfg(test)]
 mod tests {
+    use super::test_harness::{
+        clear_daemon_env, connect_when_ready, exchange, HarnessDispatch, InProcessDaemonHandle,
+        InProcessDaemonLauncher, RecoveryTestGuard,
+    };
     use super::*;
     use khive_runtime::daemon::run_daemon;
     use serial_test::serial;
@@ -2192,76 +2164,6 @@ mod tests {
             },
             memory_runtime_config(),
         )
-    }
-
-    fn clear_daemon_env() {
-        std::env::remove_var("KHIVE_SOCKET");
-        std::env::remove_var("KHIVE_PID");
-        std::env::remove_var("KHIVE_NO_DAEMON");
-        std::env::remove_var("KHIVE_LOCK");
-        std::env::remove_var("KHIVE_RECOVERER_LOCK");
-        std::env::remove_var("KHIVE_PROCESS_REF");
-    }
-
-    struct RecoveryTestGuard {
-        child: Option<std::process::Child>,
-    }
-
-    impl RecoveryTestGuard {
-        fn new() -> Self {
-            Self { child: None }
-        }
-
-        fn track_child(&mut self, child: std::process::Child) -> u32 {
-            let pid = child.id();
-            self.child = Some(child);
-            pid
-        }
-
-        fn child_mut(&mut self) -> &mut std::process::Child {
-            self.child.as_mut().expect("test child must be tracked")
-        }
-
-        fn kill_and_reap_child(&mut self) {
-            if let Some(mut child) = self.child.take() {
-                let _ = child.kill();
-                let _ = child.wait();
-            }
-        }
-    }
-
-    impl Drop for RecoveryTestGuard {
-        fn drop(&mut self) {
-            self.kill_and_reap_child();
-            reset_counters();
-            clear_daemon_env();
-        }
-    }
-
-    async fn connect_when_ready(sock: &std::path::Path) -> UnixStream {
-        let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(5);
-        loop {
-            if let Ok(s) = UnixStream::connect(sock).await {
-                return s;
-            }
-            assert!(
-                tokio::time::Instant::now() < deadline,
-                "daemon never bound {sock:?} within 5s"
-            );
-            tokio::time::sleep(std::time::Duration::from_millis(20)).await;
-        }
-    }
-
-    async fn exchange(sock: &std::path::Path, frame: &DaemonRequestFrame) -> DaemonResponseFrame {
-        let mut stream = UnixStream::connect(sock)
-            .await
-            .expect("connect to daemon socket");
-        let payload = serde_json::to_vec(frame).expect("serialize request frame");
-        write_frame(&mut stream, &payload)
-            .await
-            .expect("write request frame");
-        let resp = read_frame(&mut stream).await.expect("read response frame");
-        serde_json::from_slice(&resp).expect("decode response frame")
     }
 
     // ── map_response (pure, MCP-specific) ─────────────────────────────────────
@@ -2511,15 +2413,12 @@ mod tests {
 
     // ── daemon_fallback telemetry: counters (ADR-091 F1) ──────────────────────
     //
-    // `no_socket` / `parse_failure` / `protocol_mismatch` are only reachable
-    // inside `forward_or_spawn` on paths that require a real daemon subprocess
-    // or multi-second connect timeouts (the existing suite deliberately avoids
-    // that cost elsewhere in this file — see `try_forward_inner_returns_parse_
-    // failure_when_daemon_closes_without_response` above, which asserts the
-    // `ForwardOutcome` discriminant directly rather than driving the full
-    // `forward_or_spawn` retry loop). `record_fallback` is the single function
-    // every one of those call sites invokes, so exercising it directly gives
-    // the same counter-correctness guarantee without the slow paths.
+    // `no_socket` remains a production fallback. `parse_failure` and
+    // `protocol_mismatch` are reserved closed-vocabulary counters with no
+    // production `record_fallback` call site after #644: both are terminal
+    // once a real request is written. Exercise all three directly here so
+    // their metrics compatibility remains explicit without implying that a
+    // post-write ambiguity can still reach local dispatch.
 
     #[test]
     #[serial]
@@ -2766,8 +2665,8 @@ mod tests {
             assert_eq!(
                 fallback_strict_violations(),
                 0,
-                "ProtocolMismatch is the rollout-transient (version_mismatch) tier — \
-                 it must NEVER be elevated, even in strict mode (D2-R3)"
+                "the reserved ProtocolMismatch metric retains its historical \
+                 rollout-transient tier and is never a strict violation"
             );
         });
     }
@@ -2781,8 +2680,8 @@ mod tests {
             assert_eq!(
                 fallback_strict_violations(),
                 0,
-                "ParseFailure is folded into the rollout-transient tier alongside \
-                 ProtocolMismatch (see FallbackReason::severity) — never elevated"
+                "the reserved ParseFailure metric retains its historical \
+                 rollout-transient tier and is never a strict violation"
             );
         });
     }
@@ -4052,14 +3951,13 @@ mod tests {
     // was false and `served_config_id` matched — the stale daemon was trusted.
     //
     // After the fix, `try_forward_inner` detects `daemon_protocol_version == 0 != 1`
-    // and returns `ForwardOutcome::ProtocolMismatch`, which `forward_or_spawn` routes
-    // through kill/respawn/error rather than accepting.
+    // and returns `ForwardOutcome::ProtocolMismatch`, which `forward_or_spawn`
+    // rejects without retry, local dispatch, kill, or respawn.
     //
     // The test verifies at the `forward_or_spawn` level (not just `map_response`)
     // that:
     //   1. The stale response is NOT accepted.
-    //   2. At most one recovery attempt is made (the fake socket closes after one
-    //      exchange; a second attempt sees NoSocket rather than looping).
+    //   2. No second connection or recovery attempt is made.
     //   3. A clear "protocol mismatch" error is returned.
 
     /// Minimal "old daemon" frame: has `served_config_id` but omits the
@@ -4112,16 +4010,14 @@ mod tests {
 
         // Bind the fake old-daemon socket BEFORE starting the client.
         let listener = tokio::net::UnixListener::bind(&sock).expect("bind fake old-daemon socket");
-        // Write a placeholder PID file so kill_stale_daemon finds a PID to look at.
-        // We use the current process's PID, which classify_pid_identity() will reject
-        // because the current exe is the test binary (not "kkernel"), so no SIGTERM
-        // will be sent — this is the safe path we want to exercise.
+        // A PID file makes the fake daemon's rendezvous realistic. The terminal
+        // mismatch path must leave it untouched.
         std::fs::write(&pid_file, std::process::id().to_string()).expect("write pid file");
 
         let old_resp = old_daemon_response(config_id);
         // Serve exactly one exchange, then let the listener drop (no second connection
-        // will be served — this enforces the "at most one recovery attempt" constraint:
-        // if forward_or_spawn tried the old socket a second time it would get NoSocket).
+        // will be served — any second connection would therefore expose an
+        // incorrect retry as `NoSocket` rather than hiding it in the fixture.
         let fake_handle = tokio::spawn(serve_one_response(listener, old_resp));
 
         let frame = DaemonRequestFrame {
@@ -4180,23 +4076,15 @@ mod tests {
     // returned `ForwardOutcome::NoSocket` on the `read_frame` error, causing
     // `forward_or_spawn` to return `None` — a silent fallback to local dispatch.
     //
-    // The fix promotes the `read_frame` error to `ForwardOutcome::ParseFailure`
-    // so the stale daemon is killed and the client does NOT silently accept a
-    // potentially broken daemon state for subsequent requests.
+    // The fix promotes the `read_frame` error to `ForwardOutcome::ParseFailure`.
+    // Since the real frame was fully written, `forward_or_spawn` turns that
+    // classification into a terminal ambiguity error and performs no recovery.
     //
     // This test binds a fake socket that reads the request but immediately drops
     // the connection without writing a response (simulating a crash during
-    // dispatch), then asserts that `forward_or_spawn` falls back to `None`
-    // (because the respawn attempt also sees no socket) with the WARN log
-    // rather than silently accepting the empty response.
-    //
-    // We cannot assert an `Err` here because after killing the stale daemon the
-    // respawn path calls `spawn_daemon()` (which tries to exec the real binary),
-    // fails or times out, and returns `None`. The critical invariant is that
-    // `NoSocket` is NOT returned directly on read failure — the `ParseFailure`
-    // path is taken instead (logging the crash and killing the stale process).
-    // The `try_forward_inner` unit test below validates the exact `ForwardOutcome`
-    // discriminant.
+    // dispatch). This focused test validates the exact `ForwardOutcome`
+    // discriminant; the parallel test validates the terminal call-site behavior
+    // and zero lifecycle actions.
 
     /// Serve one connection: read the request frame, then drop the stream
     /// without writing any response (simulating a daemon crash mid-dispatch).
@@ -4225,9 +4113,8 @@ mod tests {
 
         let listener =
             tokio::net::UnixListener::bind(&sock).expect("bind fake crash-daemon socket");
-        // Write a placeholder PID file with the current process PID so
-        // kill_stale_daemon has something to look at (it will skip SIGTERM
-        // because the exe basename is not "kkernel" — which is the safe path).
+        // A PID file makes the fake daemon's rendezvous realistic; this focused
+        // classifier test must not touch it.
         std::fs::write(&pid_file, std::process::id().to_string()).expect("write pid file");
 
         // Serve one connection that crashes without replying.
@@ -4517,8 +4404,8 @@ mod tests {
     //
     //   1. A real daemon is running (via run_daemon).
     //   2. A recovering client calls kill_and_respawn directly — simulating a
-    //      client that observed ParseFailure (from a now-dead OLD daemon) and
-    //      wants to replace it, but a concurrent first-recoverer has ALREADY
+    //      client that observed pre-write `NoSocket`, but a concurrent first
+    //      recoverer has ALREADY
     //      spawned a healthy daemon before this client reached the lock.
     //   3. Under the lock, kill_and_respawn sends a probe_only frame and finds a
     //      responsive, identity-matching daemon → returns RecoveryOutcome::Skipped.
@@ -4634,7 +4521,7 @@ mod tests {
     // sends a small explicit error frame (ok=false, "response too large") instead
     // of closing the connection without a response.  The client receives this as
     // ForwardOutcome::Response (decodable frame) → map_response → Some(Err(..));
-    // NOT ParseFailure, so no kill/respawn is triggered.
+    // NOT the less-actionable ambiguous-forward ParseFailure error.
     //
     // This test drives the REAL handle_conn server path via run_daemon with a
     // BigDispatch that returns a string larger than MAX_FRAME_BYTES.  The client
@@ -4645,8 +4532,9 @@ mod tests {
     // > MAX_FRAME_BYTES` branch that sends the small error frame) is removed,
     // handle_conn falls through to write_frame with the oversized payload, which
     // write_frame REJECTS (its own guard returns Err), causing the connection to
-    // close without a response → the client sees ParseFailure → kill_and_respawn
-    // runs → KILL_COUNT > 0 and the PID file assertion fails.
+    // close without a response → the client sees the generic terminal
+    // ambiguous-forward error instead of the precise "response too large"
+    // refusal asserted below.
 
     /// A minimal DaemonDispatch that returns a payload larger than MAX_FRAME_BYTES
     /// so handle_conn's oversized guard fires and emits the "response too large"
@@ -4793,18 +4681,17 @@ mod tests {
         std::env::remove_var("KHIVE_LOCK");
     }
 
-    // ── EXACTLY-ONCE: real request dispatched exactly once on recovery path ────
+    // ── probe-only recovery primitive never dispatches a real request ─────────
     //
     // Scenario:
-    //   1. A fake "stale" socket reads one request frame then closes without
-    //      responding (simulating a crashed old daemon on the first forward).
-    //   2. `forward_or_spawn` sees ParseFailure → enters kill_and_respawn.
-    //   3. Under the lock, probe_daemon_identity sends a probe_only frame to a
+    //   1. Recovery is invoked directly after an independently established
+    //      pre-write liveness failure (`NoSocket` is the only production caller).
+    //   2. Under the lock, probe_daemon_identity sends a probe_only frame to a
     //      REAL CountingDispatch daemon (already running).  The daemon's
     //      handle_conn returns an identity frame without calling dispatch() —
     //      DAEMON_DISPATCH stays 0.
-    //   4. kill_and_respawn returns RecoveryOutcome::Skipped (live daemon found).
-    //   5. The call site forwards the REAL request once via try_forward_inner.
+    //   3. kill_and_respawn returns RecoveryOutcome::Skipped (live daemon found).
+    //   4. The call site forwards the REAL request once via try_forward_inner.
     //      CountingDispatch.dispatch() is called → DAEMON_DISPATCH == 1.
     //
     // Fail-if-reverted: if kill_and_respawn is reverted to use the real frame as
@@ -4812,13 +4699,9 @@ mod tests {
     // is called for the probe (DAEMON_DISPATCH == 1), and again at the call site
     // (DAEMON_DISPATCH == 2).  The assert_eq!(DAEMON_DISPATCH, 1) then fails.
     //
-    // FOLLOWUP: this test calls kill_and_respawn + try_forward_inner directly to
-    // avoid the two-socket problem (stale socket for first forward, real socket
-    // for probe).  A future enhancement could drive the full forward_or_spawn
-    // entry point using a proxy fake-socket that serves garbage on the first
-    // connection then falls through to the real daemon — catching any future
-    // call-site that double-forwards after RecoveryOutcome::Skipped without
-    // going through the seam functions.  File a follow-up issue if needed.
+    // This intentionally exercises the recovery primitive directly. A
+    // post-write ParseFailure cannot reach it after #644; the parallel terminal
+    // test below guards that call-site boundary separately.
 
     /// A minimal DaemonDispatch that increments DAEMON_DISPATCH on every real
     /// (non-probe) dispatch.  probe_only frames never reach dispatch() — they
@@ -4892,10 +4775,9 @@ mod tests {
             tokio::net::UnixListener::bind(&stale_sock).expect("bind stale socket");
         let stale_handle = tokio::spawn(serve_crash_on_dispatch(stale_listener));
 
-        // Now point the client at the STALE socket so its first try_forward_inner
-        // sees ParseFailure (the stale socket crashes after reading the request).
-        // The recovery lock and PID file point at the stale path so kill_stale_daemon
-        // looks at a non-kkernel PID (the current test process) and skips SIGTERM.
+        // The stale fixture documents the historical failure shape, while the
+        // actual recovery assertion below starts from the live daemon path. A
+        // real post-write ParseFailure no longer enters recovery.
         let stale_pid_file = dir.path().join("stale.pid");
         std::fs::write(&stale_pid_file, std::process::id().to_string()).expect("write stale pid");
         std::env::set_var("KHIVE_SOCKET", &stale_sock);
@@ -4911,12 +4793,6 @@ mod tests {
         // connection attempt (the probe) goes to the same path, but the stale
         // listener is now gone.  Instead we use real_sock for the probe by
         // redirecting KHIVE_SOCKET before the probe fires.
-        //
-        // The cleanest approach: let forward_or_spawn do everything from the stale
-        // socket (ParseFailure), then kill_and_respawn calls probe_daemon_identity
-        // which uses socket_path() — still pointing at stale_sock (now dead).
-        // probe_daemon_identity sees NoSocket → ProbeOutcome::Dead → kill+spawn
-        // path.  That's NOT the scenario we want to test (double-dispatch on Skipped).
         //
         // To get the "Skipped" (live daemon under lock) scenario without a real
         // spawn: call kill_and_respawn directly with KHIVE_SOCKET pointing at the
@@ -5219,122 +5095,284 @@ mod tests {
         std::env::remove_var("KHIVE_LOCK");
     }
 
-    // ── #838: two concurrent recoverers
-    // must not double-spawn ─────────────────────────────────────────────────
-    //
-    // Regression for the missing linearization point: before the recoverer
-    // lock, two clients racing `kill_and_respawn` from a genuinely dead daemon
-    // (no socket, no pid file at all) could both classify `Dead` via
-    // `confirm_genuinely_dead` and both fall through to `kill_stale_daemon_inner`
-    // + `spawn_daemon`, spawning two replacement daemons. The recoverer lock
-    // (a SEPARATE file from the daemon's own boot lock, so it cannot deadlock
-    // against a peer daemon's boot) makes the whole
-    // confirm-through-spawn critical section mutually exclusive across
-    // recoverers: only the first to acquire it proceeds to `Spawned`; the
-    // second observes `Skipped` (freshly spawned daemon now answers its
-    // re-probe under the lock) or `Uncertain`, but never spawns.
-    //
-    // #838: this test previously let the two `kill_and_respawn`
-    // calls reach the recoverer-lock attempt on whatever schedule the tokio
-    // executor happened to give them, with the watcher below triggering off
-    // `SPAWN_COUNT` alone. That meant the test passed 6/6 even with the
-    // recoverer lock's acquisition removed entirely (sabotage-proven by
-    // review): normal scheduling let the first call run far enough ahead
-    // that its full classify+kill+spawn completed (making the watcher's fake
-    // daemon live) before the second call's own classification rounds ever
-    // observed anything, so the "lock" was never actually exercised as the
-    // thing preventing the double-spawn. `RECOVERY_RACE_BARRIER` forces both
-    // calls to reach "independently classified Dead" at the exact same
-    // instant, so it is genuinely the recoverer lock (or its absence) that
-    // decides whether one or both proceed to kill+spawn.
-    //
-    // Fail-if-reverted: without the recoverer lock serializing this section,
-    // both concurrent calls independently pass their own `confirm_genuinely_dead`
-    // and both call `spawn_daemon()`, making `SPAWN_COUNT == 2`.
-    #[tokio::test]
+    // ── #539/#544: real parallel recovery and terminal post-write failure ───
+
+    /// Eight clients independently observe `NoSocket`, rendezvous before the
+    /// recoverer lock, and launch the real in-process daemon server. The oracle
+    /// is one live, responsive owner after quiescence — not an exact spawn-call
+    /// count, because a launch can legitimately lose the server-side ownership
+    /// fence before it binds.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 12)]
     #[serial]
-    async fn concurrent_recoverers_spawn_exactly_one_replacement_daemon() {
+    async fn parallel_no_socket_recovery_converges_to_one_usable_daemon() {
+        const CLIENTS: usize = 8;
+
+        let _cleanup = RecoveryTestGuard::new();
         clear_daemon_env();
         reset_counters();
         *RECOVERY_RACE_BARRIER
             .lock()
             .expect("barrier mutex poisoned") =
-            Some(std::sync::Arc::new(tokio::sync::Barrier::new(2)));
-        *SPAWN_COMMIT_BARRIER.lock().expect("barrier mutex poisoned") =
-            Some(std::sync::Arc::new(tokio::sync::Barrier::new(2)));
+            Some(std::sync::Arc::new(tokio::sync::Barrier::new(CLIENTS)));
+
         let dir = tempfile::tempdir().expect("tempdir");
         let sock = dir.path().join("khived.sock");
         let pid_file = dir.path().join("khived.pid");
-        let lock_file = dir.path().join("khived.recovery.lock");
-        let recoverer_lock_file = dir.path().join("khived.recoverer.lock");
-
         std::env::set_var("KHIVE_SOCKET", &sock);
         std::env::set_var("KHIVE_PID", &pid_file);
-        std::env::set_var("KHIVE_LOCK", &lock_file);
-        std::env::set_var("KHIVE_RECOVERER_LOCK", &recoverer_lock_file);
+        std::env::set_var("KHIVE_LOCK", dir.path().join("khived.recovery.lock"));
+        std::env::set_var(
+            "KHIVE_RECOVERER_LOCK",
+            dir.path().join("khived.recoverer.lock"),
+        );
         std::env::remove_var("KHIVE_NO_DAEMON");
 
-        // Genuinely no daemon at all: no socket, no pid file. Both recoverers
-        // must observe Dead on every probe they take.
-        let config_id = "packs=[kg];db=:memory:;embed=none;extra=[];backend=main".to_string();
+        let config_id = "packs=[kg];db=:memory:;embed=none;extra=[];backend=main";
+        let dispatcher = HarnessDispatch::new("test", config_id);
+        let launcher = InProcessDaemonLauncher::new(dispatcher.clone());
+        let mut recoverers = tokio::task::JoinSet::new();
+        for _ in 0..CLIENTS {
+            let launcher = launcher.clone();
+            recoverers.spawn(async move {
+                kill_and_respawn_with_launcher(config_id, "test", &launcher).await
+            });
+        }
 
-        // `spawn_daemon()` in this test process just forks the test binary
-        // with bad args — it exits almost immediately without ever binding
-        // anything (the same tolerated pattern used elsewhere in this file,
-        // e.g. `forward_or_spawn_blocks_on_boot_quiescence_before_local_fallback`).
-        // To prove the recoverer lock's linearization actually matters (not
-        // merely that nothing ever comes up so there is nothing to race),
-        // this watcher simulates "the first recoverer's spawned child became
-        // live" the instant `spawn_daemon()` is genuinely called: it binds
-        // the fake socket + pid file and starts answering `probe_only`
-        // frames, so the SECOND recoverer's own `confirm_genuinely_dead`
-        // (which can only proceed once the first has released the recoverer
-        // lock) observes a live daemon and skips instead of also spawning.
-        let watcher_config_id = config_id.clone();
-        let watcher_sock = sock.clone();
-        let watcher_pid_file = pid_file.clone();
-        let watcher = tokio::spawn(async move {
-            let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(5);
-            while SPAWN_COUNT.load(std::sync::atomic::Ordering::SeqCst) == 0 {
-                assert!(
-                    tokio::time::Instant::now() < deadline,
-                    "no recoverer reached spawn_daemon() within 5s"
-                );
-                tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+        let (spawned, skipped_or_uncertain) =
+            tokio::time::timeout(std::time::Duration::from_secs(30), async move {
+                let mut spawned: Vec<InProcessDaemonHandle> = Vec::new();
+                let mut skipped_or_uncertain = 0usize;
+                while let Some(result) = recoverers.join_next().await {
+                    match result.expect("recoverer task must not panic") {
+                        Ok(RecoveryOutcome::Spawned(handle)) => spawned.push(handle),
+                        Ok(RecoveryOutcome::Skipped | RecoveryOutcome::Uncertain) => {
+                            skipped_or_uncertain += 1;
+                        }
+                        Err(error) => panic!("parallel NoSocket recovery failed: {error:?}"),
+                    }
+                }
+                (spawned, skipped_or_uncertain)
+            })
+            .await
+            .expect("parallel recoverers must quiesce within 30s");
+        assert!(
+            !spawned.is_empty(),
+            "at least one recoverer must launch a daemon"
+        );
+        assert_eq!(
+            spawned.len() + skipped_or_uncertain,
+            CLIENTS,
+            "every parallel recoverer must reach a classified outcome"
+        );
+        assert_eq!(
+            launcher.launched_count(),
+            spawned.len(),
+            "every launch attempt must return its owned test handle"
+        );
+
+        drop(connect_when_ready(&sock).await);
+        let frame = DaemonRequestFrame {
+            ops: "stats()".to_string(),
+            presentation: None,
+            presentation_per_op: None,
+            namespace: "test".to_string(),
+            actor_id: None,
+            process_ref: None,
+            visible_namespaces: Vec::new(),
+            config_id: config_id.to_string(),
+            protocol_version: PROTOCOL_VERSION,
+            probe_only: false,
+            metrics_only: false,
+            format: None,
+            format_per_op: None,
+            from_wire: false,
+            request_id: None,
+        };
+        let response = exchange(&sock, &frame).await;
+        assert!(
+            response.ok,
+            "the surviving daemon must answer stats(): {response:?}"
+        );
+        assert_eq!(
+            dispatcher.dispatch_count(),
+            1,
+            "probe traffic must not dispatch; the one stats exchange must dispatch once"
+        );
+
+        launcher.wait_for_running_count(1).await;
+        let handle_deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(5);
+        let active_handles = loop {
+            let active = spawned
+                .iter()
+                .filter(|handle| !handle.is_finished())
+                .count();
+            if active == 1 {
+                break active;
             }
-            let listener =
-                tokio::net::UnixListener::bind(&watcher_sock).expect("bind simulated-spawn socket");
-            std::fs::write(&watcher_pid_file, std::process::id().to_string())
-                .expect("write simulated-spawn pid file");
-            serve_probe_ack_forever(listener, watcher_config_id).await;
+            assert!(
+                tokio::time::Instant::now() < handle_deadline,
+                "launched daemon handles did not converge to one active task; active={active}"
+            );
+            tokio::task::yield_now().await;
+        };
+        assert_eq!(
+            active_handles,
+            1,
+            "server-side ownership must converge to one live daemon handle; launched={} running={}",
+            launcher.launched_count(),
+            launcher.running_count()
+        );
+        assert!(
+            sock.exists(),
+            "the surviving daemon must own one socket path"
+        );
+        assert_eq!(
+            std::fs::read_to_string(&pid_file)
+                .expect("surviving pid file")
+                .trim(),
+            std::process::id().to_string(),
+            "the surviving in-process daemon must own the sole PID rendezvous"
+        );
+
+        for handle in spawned {
+            handle.stop().await;
+        }
+        launcher.wait_for_running_count(0).await;
+        let _ = std::fs::remove_file(&sock);
+        let _ = std::fs::remove_file(&pid_file);
+        assert!(
+            !sock.exists(),
+            "test teardown must remove the daemon socket"
+        );
+        assert!(
+            !pid_file.exists(),
+            "test teardown must remove the daemon pid file"
+        );
+    }
+
+    /// A post-write response loss is ambiguous and therefore terminal. All
+    /// clients return the exactly-once refusal, with no kill, spawn, retry, or
+    /// follow-up socket connection.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 12)]
+    #[serial]
+    async fn parallel_parse_failure_is_terminal_and_never_recovers() {
+        const CLIENTS: usize = 8;
+
+        let _cleanup = RecoveryTestGuard::new();
+        clear_daemon_env();
+        reset_counters();
+        let dir = tempfile::tempdir().expect("tempdir");
+        let sock = dir.path().join("khived.sock");
+        std::env::set_var("KHIVE_SOCKET", &sock);
+        std::env::set_var("KHIVE_PID", dir.path().join("khived.pid"));
+        std::env::set_var("KHIVE_LOCK", dir.path().join("khived.recovery.lock"));
+        std::env::set_var(
+            "KHIVE_RECOVERER_LOCK",
+            dir.path().join("khived.recoverer.lock"),
+        );
+        std::env::remove_var("KHIVE_NO_DAEMON");
+
+        let listener = tokio::net::UnixListener::bind(&sock).expect("bind crash fixture socket");
+        let release = std::sync::Arc::new(tokio::sync::Barrier::new(CLIENTS));
+        let (done_tx, mut done_rx) = tokio::sync::oneshot::channel::<()>();
+        let server = tokio::spawn(async move {
+            let mut accepted = 0usize;
+            let mut connections = tokio::task::JoinSet::new();
+            loop {
+                tokio::select! {
+                    _ = &mut done_rx => break,
+                    incoming = listener.accept() => {
+                        let (mut stream, _) = incoming.expect("accept client frame");
+                        accepted += 1;
+                        if accepted > CLIENTS {
+                            // A retry is itself the regression oracle. Do not put
+                            // it into the first-wave barrier or teardown would
+                            // deadlock waiting for another full cohort.
+                            drop(stream);
+                            continue;
+                        }
+                        let release = std::sync::Arc::clone(&release);
+                        connections.spawn(async move {
+                            read_frame(&mut stream).await.expect("read complete client frame");
+                            release.wait().await;
+                            // Drop without a response: the request may have dispatched,
+                            // so the client must classify this as ParseFailure.
+                        });
+                    }
+                }
+            }
+            while let Some(connection) = connections.join_next().await {
+                connection.expect("crash fixture connection task must not panic");
+            }
+            accepted
         });
 
-        let (a, b) = tokio::join!(
-            kill_and_respawn(&config_id, "test", &spawn_daemon),
-            kill_and_respawn(&config_id, "test", &spawn_daemon),
-        );
-        let spawned_count = [&a, &b]
-            .iter()
-            .filter(|r| matches!(r, Ok(RecoveryOutcome::Spawned(_))))
-            .count();
+        let frame = std::sync::Arc::new(DaemonRequestFrame {
+            ops: "stats()".to_string(),
+            presentation: None,
+            presentation_per_op: None,
+            namespace: "test".to_string(),
+            actor_id: None,
+            process_ref: None,
+            visible_namespaces: Vec::new(),
+            config_id: CFG.to_string(),
+            protocol_version: PROTOCOL_VERSION,
+            probe_only: false,
+            metrics_only: false,
+            format: None,
+            format_per_op: None,
+            from_wire: false,
+            request_id: None,
+        });
+        let mut clients = tokio::task::JoinSet::new();
+        for _ in 0..CLIENTS {
+            let frame = std::sync::Arc::clone(&frame);
+            clients.spawn(async move { forward_or_spawn(&frame).await });
+        }
+
+        let terminal_errors = tokio::time::timeout(
+            std::time::Duration::from_secs(10),
+            async move {
+                let mut terminal_errors = 0usize;
+                while let Some(result) = clients.join_next().await {
+                    match result.expect("client task must not panic") {
+                        Some(Err(error)) => {
+                            assert!(
+                                error
+                                    .message
+                                    .contains("response lost after request was sent"),
+                                "ParseFailure must return the stable ambiguous-forward refusal: {error:?}"
+                            );
+                            terminal_errors += 1;
+                        }
+                        other => {
+                            panic!("ParseFailure must be a terminal hard error, got {other:?}")
+                        }
+                    }
+                }
+                terminal_errors
+            },
+        )
+        .await
+        .expect("parallel ParseFailure clients must terminate within 10s");
+        done_tx.send(()).expect("crash fixture still running");
+        let accepted = server.await.expect("crash fixture must not panic");
+
+        assert_eq!(terminal_errors, CLIENTS);
         assert_eq!(
-            spawned_count, 1,
-            "exactly one of two concurrent recoverers racing from a genuinely \
-             dead daemon must spawn a replacement; got a={a:?} b={b:?}"
+            accepted, CLIENTS,
+            "terminal ParseFailure must not make any follow-up connection"
+        );
+        assert_eq!(
+            KILL_COUNT.load(std::sync::atomic::Ordering::SeqCst),
+            0,
+            "post-write ambiguity must never trigger daemon lifecycle actions"
         );
         assert_eq!(
             SPAWN_COUNT.load(std::sync::atomic::Ordering::SeqCst),
-            1,
-            "spawn_daemon must be called exactly once across two concurrent \
-             recoverers racing the same dead-daemon state; got a={a:?} b={b:?}"
+            0,
+            "post-write ambiguity must never spawn a replacement"
         );
-
-        watcher.abort();
-        let _ = watcher.await;
-        reset_counters();
-        clear_daemon_env();
-        std::env::remove_var("KHIVE_LOCK");
-        std::env::remove_var("KHIVE_RECOVERER_LOCK");
     }
 
     // ── probe classifier is fail-CLOSED for same-protocol pre-probe daemons ──
@@ -5547,18 +5585,18 @@ mod tests {
         std::env::remove_var("KHIVE_LOCK");
     }
 
-    // ── explicit version_mismatch from stale daemon routes to recovery (#156) ──
+    // ── explicit version_mismatch is terminal after the real write (#156) ─────
     //
     // Regression for #156: when a NEWER client connects to an OLD warm daemon,
     // the old daemon responds with `version_mismatch=true` and its own (lower)
     // `daemon_protocol_version`. Before the fix, this went to the generic
-    // `Response` arm → `map_response` → hard MCP error, leaving the stale daemon
-    // alive instead of triggering kill+respawn.
+    // `Response` arm → `map_response` → hard MCP error without a stable
+    // stale-daemon classification.
     //
     // After the fix, `try_forward_inner` detects `version_mismatch=true` &&
     // `daemon_protocol_version < PROTOCOL_VERSION` and returns
-    // `ForwardOutcome::ProtocolMismatch`, routing it through kill_and_respawn
-    // exactly like the implicit (no version_mismatch flag) old-daemon case.
+    // `ForwardOutcome::ProtocolMismatch`, routing it through the terminal
+    // no-retry/no-lifecycle path exactly like the implicit old-daemon case.
     //
     // This test serves one connection returning the protocol-v3 shape that a
     // still-warm pre-process_ref daemon reports to a v4 client
@@ -5631,8 +5669,8 @@ mod tests {
         assert!(
             matches!(outcome, ForwardOutcome::ProtocolMismatch),
             "explicit version_mismatch=true with daemon_protocol_version < PROTOCOL_VERSION \
-             must classify as ProtocolMismatch (triggers kill+respawn), not Response \
-             (which would surface a hard error and leave the stale daemon alive)"
+             must classify as ProtocolMismatch (terminal no-retry path), not Response \
+             (which would lose the stable stale-daemon classification)"
         );
 
         clear_daemon_env();
@@ -5715,7 +5753,7 @@ mod tests {
             matches!(outcome, ForwardOutcome::Response(_)),
             "version_mismatch=true with daemon_protocol_version > PROTOCOL_VERSION \
              must yield Response (hard error via map_response), not ProtocolMismatch \
-             (kill+respawn cannot fix a stale client binary)"
+             (the client binary, not the daemon, is stale)"
         );
 
         clear_daemon_env();

--- a/crates/khive-mcp/src/daemon.rs
+++ b/crates/khive-mcp/src/daemon.rs
@@ -5313,6 +5313,21 @@ mod tests {
                     }
                 }
             }
+            // Teardown race: done_tx fires the instant the last client has its
+            // terminal error, but a regression-produced follow-up connect may
+            // already sit queued in the listener backlog. Dropping the listener
+            // immediately would let it escape uncounted. Quiesce-drain instead:
+            // every first-wave connection is already accepted (done only fires
+            // after all CLIENTS completed), so anything still arriving here is
+            // a retry, and counting it makes `accepted == CLIENTS` below fail
+            // the test rather than pass silently.
+            while let Ok(incoming) =
+                tokio::time::timeout(std::time::Duration::from_millis(250), listener.accept()).await
+            {
+                let (stream, _) = incoming.expect("accept client frame");
+                accepted += 1;
+                drop(stream);
+            }
             while let Some(connection) = connections.join_next().await {
                 connection.expect("crash fixture connection task must not panic");
             }

--- a/crates/khive-mcp/src/daemon/test_harness.rs
+++ b/crates/khive-mcp/src/daemon/test_harness.rs
@@ -224,31 +224,44 @@ impl<D> InProcessDaemonLauncher<D> {
 }
 
 pub(super) struct InProcessDaemonHandle {
-    task: tokio::task::JoinHandle<anyhow::Result<()>>,
+    task: Option<tokio::task::JoinHandle<anyhow::Result<()>>>,
 }
 
 impl std::fmt::Debug for InProcessDaemonHandle {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("InProcessDaemonHandle")
-            .field("finished", &self.task.is_finished())
+            .field(
+                "finished",
+                &self
+                    .task
+                    .as_ref()
+                    .map(tokio::task::JoinHandle::is_finished)
+                    .unwrap_or(true),
+            )
             .finish()
     }
 }
 
 impl InProcessDaemonHandle {
     pub(super) fn is_finished(&self) -> bool {
-        self.task.is_finished()
+        self.task
+            .as_ref()
+            .map(tokio::task::JoinHandle::is_finished)
+            .unwrap_or(true)
     }
 
-    pub(super) async fn stop(self) {
-        let aborted = !self.task.is_finished();
+    pub(super) async fn stop(mut self) {
+        let Some(task) = self.task.take() else {
+            return;
+        };
+        let aborted = !task.is_finished();
         if aborted {
             // Abort IS the teardown contract for a serving in-process daemon:
             // it otherwise serves until SIGTERM, which tests have no channel
             // to deliver. A still-running task is cancelled here on purpose.
-            self.task.abort();
+            task.abort();
         }
-        match self.task.await {
+        match task.await {
             Ok(result) => result.expect("in-process daemon task must exit without error"),
             Err(join_error) if aborted && join_error.is_cancelled() => {
                 // The expected outcome of this stop()'s own abort.
@@ -263,6 +276,14 @@ impl InProcessDaemonHandle {
             Err(join_error) => {
                 panic!("in-process daemon task failed: {join_error:?}");
             }
+        }
+    }
+}
+
+impl Drop for InProcessDaemonHandle {
+    fn drop(&mut self) {
+        if let Some(task) = self.task.take() {
+            task.abort();
         }
     }
 }
@@ -282,6 +303,43 @@ where
             let _running = RunningTaskGuard(state);
             run_daemon_in_process_test(dispatcher).await
         });
-        Ok(InProcessDaemonHandle { task })
+        Ok(InProcessDaemonHandle { task: Some(task) })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn in_process_daemon_handle_drop_aborts_task() {
+        let started = Arc::new(AtomicBool::new(false));
+        let completed = Arc::new(AtomicBool::new(false));
+        let task_started = Arc::clone(&started);
+        let task_completed = Arc::clone(&completed);
+        let task = tokio::spawn(async move {
+            task_started.store(true, Ordering::SeqCst);
+            tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+            task_completed.store(true, Ordering::SeqCst);
+            Ok(())
+        });
+        let handle = InProcessDaemonHandle { task: Some(task) };
+
+        tokio::time::timeout(std::time::Duration::from_secs(1), async {
+            while !started.load(Ordering::SeqCst) {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("drop regression fixture task must start");
+
+        drop(handle);
+        for _ in 0..20 {
+            assert!(
+                !completed.load(Ordering::SeqCst),
+                "dropping an in-process daemon handle must abort its task"
+            );
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        }
     }
 }

--- a/crates/khive-mcp/src/daemon/test_harness.rs
+++ b/crates/khive-mcp/src/daemon/test_harness.rs
@@ -90,7 +90,9 @@ pub(super) async fn connect_when_ready(sock: &std::path::Path) -> UnixStream {
             tokio::time::Instant::now() < deadline,
             "daemon never bound {sock:?} within 5s"
         );
-        tokio::task::yield_now().await;
+        // Sleep, not yield_now(): the daemon binds on its own task, and a
+        // millisecond-scale sleep keeps this poll from hot-spinning a worker.
+        tokio::time::sleep(std::time::Duration::from_millis(10)).await;
     }
 }
 
@@ -213,7 +215,10 @@ impl<D> InProcessDaemonLauncher<D> {
                 self.launched_count(),
                 self.running_count()
             );
-            tokio::task::yield_now().await;
+            // Sleep, not yield_now(): launched daemons progress on other
+            // workers (blocking flock boot); polling at millisecond scale
+            // avoids a hot spin.
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
         }
     }
 }
@@ -236,10 +241,29 @@ impl InProcessDaemonHandle {
     }
 
     pub(super) async fn stop(self) {
-        if !self.task.is_finished() {
+        let aborted = !self.task.is_finished();
+        if aborted {
+            // Abort IS the teardown contract for a serving in-process daemon:
+            // it otherwise serves until SIGTERM, which tests have no channel
+            // to deliver. A still-running task is cancelled here on purpose.
             self.task.abort();
         }
-        let _ = self.task.await;
+        match self.task.await {
+            Ok(result) => result.expect("in-process daemon task must exit without error"),
+            Err(join_error) if aborted && join_error.is_cancelled() => {
+                // The expected outcome of this stop()'s own abort.
+            }
+            Err(join_error) if join_error.is_panic() => {
+                // Never swallow a panic: resume it so the failure surfaces
+                // with its original payload and backtrace. A losing candidate
+                // exits Ok(()) through the ownership fence, so a panic here
+                // is a real regression in the server path.
+                std::panic::resume_unwind(join_error.into_panic());
+            }
+            Err(join_error) => {
+                panic!("in-process daemon task failed: {join_error:?}");
+            }
+        }
     }
 }
 

--- a/crates/khive-mcp/src/daemon/test_harness.rs
+++ b/crates/khive-mcp/src/daemon/test_harness.rs
@@ -1,0 +1,263 @@
+//! Shared daemon recovery and framing fixtures.
+//!
+//! The daemon tests mutate process-global socket/PID environment variables and
+//! exercise real Unix framing. Keeping their counters, cleanup guard, frame
+//! exchange helpers, and in-process launcher together gives recovery tests one
+//! fail-closed teardown path instead of open-coded variants in `daemon.rs`.
+
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use khive_runtime::daemon::{
+    run_daemon_in_process_test, write_frame, DaemonDispatch, DaemonRequestFrame,
+    DaemonResponseFrame,
+};
+use tokio::net::UnixStream;
+
+pub(super) static KILL_COUNT: AtomicUsize = AtomicUsize::new(0);
+pub(super) static SPAWN_COUNT: AtomicUsize = AtomicUsize::new(0);
+pub(super) static FORCE_PID_IS_DAEMON: AtomicBool = AtomicBool::new(false);
+pub(super) static FORCE_PID_IS_FOREIGN: AtomicBool = AtomicBool::new(false);
+pub(super) static DAEMON_DISPATCH: AtomicUsize = AtomicUsize::new(0);
+
+/// Rendezvous after every recoverer independently observes an absent daemon.
+pub(super) static RECOVERY_RACE_BARRIER: std::sync::Mutex<Option<Arc<tokio::sync::Barrier>>> =
+    std::sync::Mutex::new(None);
+
+pub(super) fn reset_counters() {
+    KILL_COUNT.store(0, Ordering::SeqCst);
+    SPAWN_COUNT.store(0, Ordering::SeqCst);
+    FORCE_PID_IS_DAEMON.store(false, Ordering::SeqCst);
+    FORCE_PID_IS_FOREIGN.store(false, Ordering::SeqCst);
+    DAEMON_DISPATCH.store(0, Ordering::SeqCst);
+    *RECOVERY_RACE_BARRIER
+        .lock()
+        .expect("barrier mutex poisoned") = None;
+}
+
+pub(super) fn clear_daemon_env() {
+    std::env::remove_var("KHIVE_SOCKET");
+    std::env::remove_var("KHIVE_PID");
+    std::env::remove_var("KHIVE_NO_DAEMON");
+    std::env::remove_var("KHIVE_LOCK");
+    std::env::remove_var("KHIVE_RECOVERER_LOCK");
+    std::env::remove_var("KHIVE_PROCESS_REF");
+}
+
+pub(super) struct RecoveryTestGuard {
+    child: Option<std::process::Child>,
+}
+
+impl RecoveryTestGuard {
+    pub(super) fn new() -> Self {
+        Self { child: None }
+    }
+
+    pub(super) fn track_child(&mut self, child: std::process::Child) -> u32 {
+        let pid = child.id();
+        self.child = Some(child);
+        pid
+    }
+
+    pub(super) fn child_mut(&mut self) -> &mut std::process::Child {
+        self.child.as_mut().expect("test child must be tracked")
+    }
+
+    pub(super) fn kill_and_reap_child(&mut self) {
+        if let Some(mut child) = self.child.take() {
+            let _ = child.kill();
+            let _ = child.wait();
+        }
+    }
+}
+
+impl Drop for RecoveryTestGuard {
+    fn drop(&mut self) {
+        self.kill_and_reap_child();
+        reset_counters();
+        clear_daemon_env();
+    }
+}
+
+pub(super) async fn connect_when_ready(sock: &std::path::Path) -> UnixStream {
+    let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(5);
+    loop {
+        if let Ok(stream) = UnixStream::connect(sock).await {
+            return stream;
+        }
+        assert!(
+            tokio::time::Instant::now() < deadline,
+            "daemon never bound {sock:?} within 5s"
+        );
+        tokio::task::yield_now().await;
+    }
+}
+
+pub(super) async fn exchange(
+    sock: &std::path::Path,
+    frame: &DaemonRequestFrame,
+) -> DaemonResponseFrame {
+    let mut stream = UnixStream::connect(sock)
+        .await
+        .expect("connect to daemon socket");
+    let payload = serde_json::to_vec(frame).expect("serialize request frame");
+    write_frame(&mut stream, &payload)
+        .await
+        .expect("write request frame");
+    let response = khive_runtime::daemon::read_frame(&mut stream)
+        .await
+        .expect("read response frame");
+    serde_json::from_slice(&response).expect("decode response frame")
+}
+
+/// Small real dispatcher used by the in-process daemon launcher. Probe-only
+/// frames bypass `dispatch`, so `dispatch_count` is also the test's exact
+/// non-probe exchange oracle.
+#[derive(Clone)]
+pub(super) struct HarnessDispatch {
+    namespace: Arc<str>,
+    config_id: Arc<str>,
+    dispatch_count: Arc<AtomicUsize>,
+}
+
+impl HarnessDispatch {
+    pub(super) fn new(namespace: &str, config_id: &str) -> Self {
+        Self {
+            namespace: Arc::from(namespace),
+            config_id: Arc::from(config_id),
+            dispatch_count: Arc::new(AtomicUsize::new(0)),
+        }
+    }
+
+    pub(super) fn dispatch_count(&self) -> usize {
+        self.dispatch_count.load(Ordering::SeqCst)
+    }
+}
+
+#[async_trait]
+impl DaemonDispatch for HarnessDispatch {
+    async fn dispatch(
+        &self,
+        _ops: String,
+        _presentation: Option<String>,
+        _presentation_per_op: Option<Vec<Option<String>>>,
+        _format: Option<String>,
+        _format_per_op: Option<Vec<Option<String>>>,
+        _from_wire: bool,
+        _identity: Option<khive_runtime::RequestIdentity>,
+    ) -> Result<String, String> {
+        self.dispatch_count.fetch_add(1, Ordering::SeqCst);
+        Ok(r#"{"entities":0,"edges":0,"notes":0}"#.to_string())
+    }
+
+    async fn warm_all(&self) {}
+
+    fn namespace(&self) -> &str {
+        &self.namespace
+    }
+
+    fn config_id(&self) -> &str {
+        &self.config_id
+    }
+}
+
+#[derive(Default)]
+struct LauncherState {
+    launched: AtomicUsize,
+    running: AtomicUsize,
+}
+
+struct RunningTaskGuard(Arc<LauncherState>);
+
+impl Drop for RunningTaskGuard {
+    fn drop(&mut self) {
+        self.0.running.fetch_sub(1, Ordering::SeqCst);
+    }
+}
+
+/// Test launcher that exercises the real daemon server without forking the
+/// test binary. Tests using it must run on a multi-thread Tokio runtime: every
+/// launched daemon performs a blocking `flock` during boot. Losing in-process
+/// candidates take the real socket/PID ownership exit, which also cancels the
+/// runtime's process-wide component token; use only the component-free
+/// [`HarnessDispatch`] fixture.
+#[derive(Clone)]
+pub(super) struct InProcessDaemonLauncher<D> {
+    dispatcher: D,
+    state: Arc<LauncherState>,
+}
+
+impl<D> InProcessDaemonLauncher<D> {
+    pub(super) fn new(dispatcher: D) -> Self {
+        Self {
+            dispatcher,
+            state: Arc::new(LauncherState::default()),
+        }
+    }
+
+    pub(super) fn launched_count(&self) -> usize {
+        self.state.launched.load(Ordering::SeqCst)
+    }
+
+    pub(super) fn running_count(&self) -> usize {
+        self.state.running.load(Ordering::SeqCst)
+    }
+
+    pub(super) async fn wait_for_running_count(&self, expected: usize) {
+        let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(5);
+        while self.running_count() != expected {
+            assert!(
+                tokio::time::Instant::now() < deadline,
+                "in-process daemon count did not converge to {expected}; launched={} running={}",
+                self.launched_count(),
+                self.running_count()
+            );
+            tokio::task::yield_now().await;
+        }
+    }
+}
+
+pub(super) struct InProcessDaemonHandle {
+    task: tokio::task::JoinHandle<anyhow::Result<()>>,
+}
+
+impl std::fmt::Debug for InProcessDaemonHandle {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("InProcessDaemonHandle")
+            .field("finished", &self.task.is_finished())
+            .finish()
+    }
+}
+
+impl InProcessDaemonHandle {
+    pub(super) fn is_finished(&self) -> bool {
+        self.task.is_finished()
+    }
+
+    pub(super) async fn stop(self) {
+        if !self.task.is_finished() {
+            self.task.abort();
+        }
+        let _ = self.task.await;
+    }
+}
+
+impl<D> super::DaemonLauncher for InProcessDaemonLauncher<D>
+where
+    D: DaemonDispatch,
+{
+    type Handle = InProcessDaemonHandle;
+
+    fn launch(&self) -> std::io::Result<Self::Handle> {
+        self.state.launched.fetch_add(1, Ordering::SeqCst);
+        self.state.running.fetch_add(1, Ordering::SeqCst);
+        let dispatcher = self.dispatcher.clone();
+        let state = Arc::clone(&self.state);
+        let task = tokio::spawn(async move {
+            let _running = RunningTaskGuard(state);
+            run_daemon_in_process_test(dispatcher).await
+        });
+        Ok(InProcessDaemonHandle { task })
+    }
+}

--- a/crates/khive-runtime/src/daemon.rs
+++ b/crates/khive-runtime/src/daemon.rs
@@ -2142,8 +2142,18 @@ mod tests {
             pid_can_name_incumbent(current, current, true),
             "the in-process harness must let a responsive same-PID owner win"
         );
+        // A fixed probe PID, not one derived from `current`: eligibility must
+        // hold for ANY distinct PID, and deriving the probe from the value
+        // under test could mask an off-by-one regression that special-cased
+        // adjacent PIDs. The precondition keeps the assertion logically exact
+        // even in the (astronomically unlikely) PID-collision case.
+        const DISTINCT_PROBE_PID: u32 = 40_000;
+        assert_ne!(
+            DISTINCT_PROBE_PID, current,
+            "probe PID must differ from this process's PID"
+        );
         assert!(
-            pid_can_name_incumbent(current.saturating_add(1), current, false),
+            pid_can_name_incumbent(DISTINCT_PROBE_PID, current, false),
             "a distinct PID remains eligible under ordinary production rules"
         );
     }

--- a/crates/khive-runtime/src/daemon.rs
+++ b/crates/khive-runtime/src/daemon.rs
@@ -2142,18 +2142,16 @@ mod tests {
             pid_can_name_incumbent(current, current, true),
             "the in-process harness must let a responsive same-PID owner win"
         );
-        // A fixed probe PID, not one derived from `current`: eligibility must
-        // hold for ANY distinct PID, and deriving the probe from the value
-        // under test could mask an off-by-one regression that special-cased
-        // adjacent PIDs. The precondition keeps the assertion logically exact
-        // even in the (astronomically unlikely) PID-collision case.
-        const DISTINCT_PROBE_PID: u32 = 40_000;
+        // Keep the probe two away from `current` so the fixture preserves the
+        // off-by-one regression check for adjacent PIDs; wrapping_add avoids
+        // making the test overflow-sensitive at the u32 boundary.
+        let distinct_probe_pid = current.wrapping_add(2);
         assert_ne!(
-            DISTINCT_PROBE_PID, current,
+            distinct_probe_pid, current,
             "probe PID must differ from this process's PID"
         );
         assert!(
-            pid_can_name_incumbent(DISTINCT_PROBE_PID, current, false),
+            pid_can_name_incumbent(distinct_probe_pid, current, false),
             "a distinct PID remains eligible under ordinary production rules"
         );
     }

--- a/crates/khive-runtime/src/daemon.rs
+++ b/crates/khive-runtime/src/daemon.rs
@@ -1202,7 +1202,28 @@ where
 #[cfg(unix)]
 pub async fn run_daemon<D: DaemonDispatch>(dispatcher: D) -> anyhow::Result<()> {
     let boot_guard = Some(acquire_daemon_boot_guard()?);
-    run_daemon_with_boot_guard(dispatcher, boot_guard).await
+    run_daemon_with_boot_guard_inner(dispatcher, boot_guard, false).await
+}
+
+/// Run a real daemon server for an in-process multi-launch test.
+///
+/// Separate production daemon candidates have distinct PIDs, so the boot fence
+/// recognizes a responsive incumbent and makes later candidates exit. Parallel
+/// test launchers share one OS process and therefore one PID; this explicit
+/// fault-injection entry point preserves the production fence semantics by
+/// allowing a responsive same-PID incumbent to win. Ordinary daemon startup
+/// continues to treat a same-PID rendezvous as stale, protecting PID-reuse
+/// cleanup behavior.
+///
+/// A losing candidate still follows the ordinary daemon-exit path and cancels
+/// the process-wide component shutdown token. Callers must therefore use a
+/// component-free dispatcher; this seam validates socket/PID ownership, not
+/// multi-candidate component lifecycle.
+#[cfg(all(unix, any(test, feature = "fault-injection")))]
+#[doc(hidden)]
+pub async fn run_daemon_in_process_test<D: DaemonDispatch>(dispatcher: D) -> anyhow::Result<()> {
+    let boot_guard = Some(acquire_daemon_boot_guard()?);
+    run_daemon_with_boot_guard_inner(dispatcher, boot_guard, true).await
 }
 
 /// Vet the socket's parent directory, re-permissioning it only when it is the
@@ -1444,6 +1465,15 @@ pub async fn run_daemon_with_boot_guard<D: DaemonDispatch>(
     dispatcher: D,
     boot_guard: Option<std::fs::File>,
 ) -> anyhow::Result<()> {
+    run_daemon_with_boot_guard_inner(dispatcher, boot_guard, false).await
+}
+
+#[cfg(unix)]
+async fn run_daemon_with_boot_guard_inner<D: DaemonDispatch>(
+    dispatcher: D,
+    boot_guard: Option<std::fs::File>,
+    allow_same_process_incumbent: bool,
+) -> anyhow::Result<()> {
     // ADR-119: components may have been started by the serve path before this
     // function established (or failed to establish) daemon ownership. Cancel
     // the process-wide shutdown token on EVERY exit — setup failures below,
@@ -1484,7 +1514,7 @@ pub async fn run_daemon_with_boot_guard<D: DaemonDispatch>(
     // same process, which would self-deadlock on `flock`.
     let _startup_lock = boot_guard;
 
-    if !cleanup_stale_daemon(&sock, &pid_file).await {
+    if !cleanup_stale_daemon(&sock, &pid_file, allow_same_process_incumbent).await {
         tracing::info!("a responsive khived is already running; exiting");
         return Ok(());
     }
@@ -1520,7 +1550,9 @@ pub async fn run_daemon_with_boot_guard<D: DaemonDispatch>(
                 drop(listener);
                 let _ = std::fs::remove_file(&sock);
             }
-            if pid_file_names_a_reachable_daemon(&pid_file, &sock).await {
+            if pid_file_names_a_reachable_daemon(&pid_file, &sock, allow_same_process_incumbent)
+                .await
+            {
                 tracing::info!(
                     "a replacement khived already claimed the pid/socket rendezvous; exiting"
                 );
@@ -1779,11 +1811,26 @@ fn is_process_running(pid: u32) -> bool {
     classify_kill_result(rc, errno).is_running()
 }
 
+/// Whether a PID may identify an incumbent from this candidate's point of view.
+///
+/// Production rejects the current PID so a stale rendezvous left by a prior
+/// process whose PID was reused cannot protect an unrelated socket. The
+/// in-process daemon harness opts in to the same-PID case because all of its
+/// otherwise independent boot candidates necessarily share one OS process.
 #[cfg(unix)]
-async fn cleanup_stale_daemon(sock: &std::path::Path, pid_file: &std::path::Path) -> bool {
+fn pid_can_name_incumbent(pid: u32, current_pid: u32, allow_same_process_incumbent: bool) -> bool {
+    allow_same_process_incumbent || pid != current_pid
+}
+
+#[cfg(unix)]
+async fn cleanup_stale_daemon(
+    sock: &std::path::Path,
+    pid_file: &std::path::Path,
+    allow_same_process_incumbent: bool,
+) -> bool {
     if let Ok(pid_str) = std::fs::read_to_string(pid_file) {
         if let Ok(pid) = pid_str.trim().parse::<u32>() {
-            if pid != std::process::id()
+            if pid_can_name_incumbent(pid, std::process::id(), allow_same_process_incumbent)
                 && is_process_running(pid)
                 && sock.exists()
                 && UnixStream::connect(sock).await.is_ok()
@@ -1826,14 +1873,16 @@ fn write_pid_file_exclusive(pid_file: &std::path::Path) -> std::io::Result<()> {
     Ok(())
 }
 
-/// Return `true` if `pid_file` currently names a different, live process that
+/// Return `true` if `pid_file` currently names an eligible live process that
 /// still answers on `sock` — i.e. a daemon already owns this rendezvous and it
 /// is safe to defer to it rather than treat the `AlreadyExists` PID-file
-/// collision as a boot failure.
+/// collision as a boot failure. Eligibility requires a different PID in
+/// production; the explicit in-process harness may allow the current PID.
 #[cfg(unix)]
 async fn pid_file_names_a_reachable_daemon(
     pid_file: &std::path::Path,
     sock: &std::path::Path,
+    allow_same_process_incumbent: bool,
 ) -> bool {
     let Ok(pid_str) = std::fs::read_to_string(pid_file) else {
         return false;
@@ -1841,7 +1890,7 @@ async fn pid_file_names_a_reachable_daemon(
     let Ok(pid) = pid_str.trim().parse::<u32>() else {
         return false;
     };
-    pid != std::process::id()
+    pid_can_name_incumbent(pid, std::process::id(), allow_same_process_incumbent)
         && is_process_running(pid)
         && sock.exists()
         && UnixStream::connect(sock).await.is_ok()
@@ -2079,6 +2128,23 @@ mod tests {
             classify_kill_result(-1, libc::EPERM).is_running(),
             "EPERM must be unknown-safe: treated as running, never as a basis \
              for stale cleanup to unlink a live daemon's rendezvous files"
+        );
+    }
+
+    #[test]
+    fn same_process_pid_requires_explicit_in_process_harness_opt_in() {
+        let current = std::process::id();
+        assert!(
+            !pid_can_name_incumbent(current, current, false),
+            "production startup must not trust a same-PID stale rendezvous"
+        );
+        assert!(
+            pid_can_name_incumbent(current, current, true),
+            "the in-process harness must let a responsive same-PID owner win"
+        );
+        assert!(
+            pid_can_name_incumbent(current.saturating_add(1), current, false),
+            "a distinct PID remains eligible under ordinary production rules"
         );
     }
 

--- a/docs/adr/ADR-049-khived-daemon.md
+++ b/docs/adr/ADR-049-khived-daemon.md
@@ -222,6 +222,10 @@ codes: `config_mismatch`, `namespace_mismatch`, `no_socket`, `parse_failure`,
   deployment never produces these. Fallback is logged at ERROR and counted in a dedicated
   strict-violations metric alongside the per-reason fallback counters.
 
+Amendment 3 supersedes the rollout behavior in the second bullet: the two codes remain in the
+metrics vocabulary, but a post-write `protocol_mismatch` or `parse_failure` is now terminal and
+never falls back or enters daemon recovery.
+
 Under `KHIVE_DAEMON_STRICT=1`, a request that would fall back for **any** reason is instead
 rejected with a structured error carrying the reason code and a stable machine-checkable
 marker, so "strict mode active and fallback count zero" is a sound proof that every served
@@ -247,3 +251,29 @@ The daemon remains an optimization for warm-state reuse; the thin-client archite
 socket protocol, and background warm behavior of this ADR are unaffected. Quiet local
 dispatch remains the contract for genuinely daemonless environments (`no_socket` without a
 confirmed failed recovery attempt, and the `KHIVE_NO_DAEMON=1` opt-out).
+
+## Amendment 3 (2026-08-01): exactly-once recovery boundary and parallel convergence
+
+This amendment corrects Amendment 2's rollout-transient description after the exactly-once
+boundary introduced by #644. `NoSocket` is the only forward outcome eligible to enter daemon
+recovery: connection establishment or the frame write failed, so the request is proven not to
+have reached dispatch. A `ParseFailure` or `ProtocolMismatch` observed after the real frame was
+fully written is terminal. The client returns a hard error and performs no retry, local dispatch,
+kill, or respawn, because the mutation may already have committed before its response was lost.
+The two reason codes remain reserved in the closed fallback-metrics vocabulary for compatibility;
+they are not production local-fallback events.
+
+Parallel `NoSocket` recovery is required to converge after quiescence to exactly one live,
+identity-matching daemon owning the socket/PID rendezvous. The client-side recoverer lock
+serializes confirmation and launch decisions, while the daemon-side boot fence chooses the sole
+owner. The contract does **not** require exactly one launch attempt: the recovery lock can be
+released before a launched child binds, so another caller may legitimately attempt a launch that
+later loses the daemon-side fence.
+
+The executable gate uses eight synchronized clients. One scenario begins from `NoSocket`, runs the
+real daemon server through the test launcher seam on a multi-thread runtime, and requires one live
+owner plus a successful `stats()` exchange and complete teardown. The other makes all eight clients
+lose their response only after the real frame is read and requires eight terminal ambiguity errors,
+zero lifecycle actions, and no follow-up connections. Both scenarios repeat 25 times on every CI
+operating system. Shared recovery counters, framing fixtures, environment cleanup, and the
+in-process launcher live in `crates/khive-mcp/src/daemon/test_harness.rs`.

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -203,10 +203,42 @@ run_daemon_recovery_repeats() {
     # intentionally create maximal recovery contention. Run them serially
     # inside each process, but repeat the paired scenario enough times on every
     # supported CI OS to expose scheduler-sensitive ownership leaks.
+    #
+    # Fail-closed count gate: a libtest name filter that matches zero tests
+    # still exits 0, so renaming or moving either test would silently turn
+    # this gate into a no-op. Enumerate the exact expected test names, capture
+    # the harness summary on every iteration, and require exactly that many
+    # passes; any mismatch (including zero) exits 1 naming the filter.
+    expected_test_names="\
+        daemon::tests::parallel_no_socket_recovery_converges_to_one_usable_daemon \
+        daemon::tests::parallel_parse_failure_is_terminal_and_never_recovers"
+    expected_tests=0
+    for name in $expected_test_names; do
+        expected_tests=$((expected_tests + 1))
+    done
     repeat=1
     while [ "$repeat" -le 25 ]; do
         echo "daemon recovery repeat ${repeat}/25"
-        cargo test -p khive-mcp --lib 'daemon::tests::parallel_' -- --test-threads=1
+        output_file=$(mktemp)
+        # --test-threads=1: the pair mutates process-global rendezvous state.
+        # The explicit failure branch keeps this gate fail-fast regardless of
+        # the caller's shell mode (the script runs `set -e`, but a pipeline or
+        # a future context change must not be able to disarm it).
+        # shellcheck disable=SC2086
+        cargo test -p khive-mcp --lib -- --test-threads=1 $expected_test_names \
+            > "$output_file" 2>&1 || {
+                cat "$output_file" >&2
+                rm -f "$output_file"
+                echo "FAIL: daemon recovery repeat ${repeat}/25: cargo test exited non-zero (filter: ${expected_test_names})" >&2
+                exit 1
+            }
+        cat "$output_file"
+        ran_count=$(sed -n 's/^test result: ok\. \{0,\}\([0-9][0-9]*\) passed;.*/\1/p' "$output_file" | head -n 1)
+        rm -f "$output_file"
+        if [ -z "$ran_count" ] || [ "$ran_count" -ne "$expected_tests" ]; then
+            echo "FAIL: daemon recovery repeat ${repeat}/25 ran ${ran_count:-0} tests, expected ${expected_tests} (filter: ${expected_test_names}) — the gate must run exactly the enumerated tests" >&2
+            exit 1
+        fi
         repeat=$((repeat + 1))
     done
 }

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -206,7 +206,8 @@ run_daemon_recovery_repeats() {
     #
     # Fail-closed count gate: a libtest name filter that matches zero tests
     # still exits 0, so renaming or moving either test would silently turn
-    # this gate into a no-op. Enumerate the exact expected test names, capture
+    # this gate into a no-op. Enumerate the exact expected test names, pass
+    # --exact because libtest filters are substring matches by default, capture
     # the harness summary on every iteration, and require exactly that many
     # passes; any mismatch (including zero) exits 1 naming the filter.
     expected_test_names="\
@@ -225,7 +226,7 @@ run_daemon_recovery_repeats() {
         # the caller's shell mode (the script runs `set -e`, but a pipeline or
         # a future context change must not be able to disarm it).
         # shellcheck disable=SC2086
-        cargo test -p khive-mcp --lib -- --test-threads=1 $expected_test_names \
+        cargo test -p khive-mcp --lib -- --test-threads=1 --exact $expected_test_names \
             > "$output_file" 2>&1 || {
                 cat "$output_file" >&2
                 rm -f "$output_file"

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -198,6 +198,26 @@ phase_channel_email() {
     cargo test -p khive-mcp --features channel-email
 }
 
+run_daemon_recovery_repeats() {
+    # #539/#544: both tests mutate the process-global daemon rendezvous and
+    # intentionally create maximal recovery contention. Run them serially
+    # inside each process, but repeat the paired scenario enough times on every
+    # supported CI OS to expose scheduler-sensitive ownership leaks.
+    repeat=1
+    while [ "$repeat" -le 25 ]; do
+        echo "daemon recovery repeat ${repeat}/25"
+        cargo test -p khive-mcp --lib 'daemon::tests::parallel_' -- --test-threads=1
+        repeat=$((repeat + 1))
+    done
+}
+
+phase_daemon_recovery_flake() {
+    echo "=== Daemon Recovery Flake Gate (25 repeats) ==="
+    # One guard around the complete repeat batch detects any default-store
+    # mutation without re-hashing a potentially large operator store 50 times.
+    run_with_store_sentinel run_daemon_recovery_repeats
+}
+
 phase_no_default_features() {
     echo "=== No-Default-Features Check ==="
     cargo check --workspace --no-default-features
@@ -269,6 +289,7 @@ run_phase() {
         tests) phase_tests ;;
         tests-doc) phase_tests_doc ;;
         channel-email) phase_channel_email ;;
+        daemon-recovery-flake) phase_daemon_recovery_flake ;;
         no-default-features) phase_no_default_features ;;
         release) phase_release ;;
         contract-tests) phase_contract_tests ;;
@@ -280,7 +301,7 @@ run_phase() {
         macos-pr-tests) phase_macos_pr_tests ;;
         *)
             echo "Unknown CI phase: $1" >&2
-            echo "Valid phases: no-stubs-scan lockfile forward-deployed lint no-stubs clippy docs tests tests-doc channel-email no-default-features release contract-tests deno-tests smoke-tests vector-smoke contract-suite macos-pr-check macos-pr-tests" >&2
+            echo "Valid phases: no-stubs-scan lockfile forward-deployed lint no-stubs clippy docs tests tests-doc channel-email daemon-recovery-flake no-default-features release contract-tests deno-tests smoke-tests vector-smoke contract-suite macos-pr-check macos-pr-tests" >&2
             exit 2
             ;;
     esac
@@ -297,6 +318,7 @@ run_all() {
         docs \
         tests \
         channel-email \
+        daemon-recovery-flake \
         no-default-features \
         release \
         contract-tests \


### PR DESCRIPTION
## Summary

- extract reusable daemon recovery/framing test infrastructure, including an explicit in-process launcher seam for deterministic lifecycle tests
- cover eight concurrent pre-write `NoSocket` recoverers converging on one usable daemon, while preserving post-write `ParseFailure` as a terminal exactly-once boundary
- gate the paired recovery scenarios with 25 serial repetitions on Linux and macOS, and align the lifecycle documentation and ADR with the tested contract

## Contract details

- production recovery still uses the process launcher and the normal incumbent-exit timeout
- the in-process harness is available only through the explicit fault-injection/test path
- the stable contention oracle is one live, responsive daemon after quiescence; redundant spawn attempts may occur before readiness, as documented
- a post-write parse failure performs no kill, spawn, or follow-up connection
- the default-store sentinel wraps the complete 25-repeat batch, preserving mutation detection without repeatedly hashing the operator store

## Validation

- `cargo test --manifest-path crates/Cargo.toml --workspace`
- `cargo check --manifest-path crates/Cargo.toml --workspace`
- `cargo clippy --manifest-path crates/Cargo.toml --workspace --all-targets -- -D warnings`
- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `RUSTDOCFLAGS=-Dwarnings cargo doc --manifest-path crates/Cargo.toml --workspace --no-deps`
- 25 consecutive focused repetitions of `cargo test --manifest-path crates/Cargo.toml -p khive-mcp --lib 'daemon::tests::parallel_' -- --test-threads=1`
- independent final review: APPROVE, zero findings

Closes #539
Closes #544

> AI-assisted contribution: Codex prepared this change and PR description.
