### PR TITLE
feat(comm): add inbox long polling

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -168,7 +168,7 @@ it does not train the default/live namespace's posterior state.
 | ---------------- | ------------------------------------------------------------------------------------------------------ | --------------------------------------------- |
 | `comm.send`      | Send a message (optionally threaded)                                                                   | Inter-agent or inter-namespace messaging      |
 | `comm.delivered` | Confirm the internal inbound sibling for an outbound UUID                                              | Resolve an ambiguous atomic-write outcome     |
-| `comm.inbox`     | Page and filter inbound messages                                                                       | Check or triage what's waiting                |
+| `comm.inbox`     | Page/filter inbound messages; `wait_ms?` enables a bounded long poll                                   | Check, triage, or wait for what's next        |
 | `comm.unread`    | Count-only view of unread inbound messages (no args, no payloads)                                      | Cheap unread check without listing            |
 | `comm.read`      | Mark one or more **inbound** messages as read (best-effort: inspect each result's `read`/`mark_error`) | Acknowledge receipt (recipient action)        |
 | `comm.reply`     | Reply to a message (threading linkage)                                                                 | Respond in-thread                             |
@@ -188,6 +188,12 @@ Use `offset=<next_offset>` with otherwise-identical `comm.inbox` arguments until
 changing read state. Filters include exact/prefix/excluded sender, inclusive `since`, exclusive
 `before`, and case-insensitive `subject_contains`/`content_contains`; time bounds use the
 response's top-level `created_at`.
+
+**Inbox long poll.** Pass `wait_ms` (1–30,000) to wait only when the initial
+fully filtered page is empty. Existing matches return immediately; new messages
+re-run the same actor/status/sender/time/text-filtered query with the same offset,
+and the paginated response shape is unchanged. Omit it (or pass `0`) for the
+snapshot behavior.
 
 **`comm.read` is inbound-only.** It marks a received message as read; calling it on an outbound
 (sent) message returns `read: message <uuid> is outbound; only received (inbound) messages can be

--- a/crates/khive-mcp/tests/integration.rs
+++ b/crates/khive-mcp/tests/integration.rs
@@ -2394,6 +2394,7 @@ async fn inbox_help_returns_optional_pagination_and_filters() -> anyhow::Result<
         "limit",
         "offset",
         "status",
+        "wait_ms",
         "from_actor",
         "from_prefix",
         "exclude_from_actor",

--- a/crates/khive-pack-comm/Cargo.toml
+++ b/crates/khive-pack-comm/Cargo.toml
@@ -25,9 +25,10 @@ serde_json = { workspace = true }
 uuid = { workspace = true }
 chrono = { workspace = true }
 tracing = { workspace = true }
+tokio = { workspace = true }
 
 [dev-dependencies]
-tokio = { workspace = true, features = ["full"] }
+tokio = { workspace = true, features = ["full", "test-util"] }
 khive-pack-kg = { version = "0.7.0", path = "../khive-pack-kg" }
 khive-db = { version = "0.7.0", path = "../khive-db" }
 criterion = { workspace = true }

--- a/crates/khive-pack-comm/README.md
+++ b/crates/khive-pack-comm/README.md
@@ -10,7 +10,7 @@ delivery confirmation, and channel polling observability.
 | ---------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `comm.send`      | Send a message, optionally threaded                                                                                                                           |
 | `comm.delivered` | Confirm the internal inbound sibling for an outbound UUID                                                                                                     |
-| `comm.inbox`     | Page and filter inbound messages for the caller                                                                                                               |
+| `comm.inbox`     | Page and filter inbound messages for the caller, optionally waiting up to 30 seconds for a new matching message                                              |
 | `comm.read`      | Mark one or up to 500 inbound messages as read (best-effort: inspect each result's `read`/`mark_error`)                                                       |
 | `comm.unread`    | Count the caller's unread inbound messages without message payloads                                                                                           |
 | `comm.reply`     | Reply to a message, preserving thread linkage                                                                                                                 |
@@ -21,6 +21,20 @@ delivery confirmation, and channel polling observability.
 The internal `comm.ingest` handler is `Visibility::Subhandler` — it lets an
 out-of-band channel adapter (email, Telegram, etc.) write an inbound message
 directly, deduplicated by `external_id`, but it is not callable on the MCP wire.
+
+## `comm.inbox` — optional long poll
+
+`wait_ms` is optional and defaults to `0`, preserving the immediate snapshot
+behavior. When it is positive and the initial filtered query is empty, the
+call waits for a newly committed message and re-runs the same actor, status,
+and sender-filtered query. The maximum is 30,000 ms. Existing messages still
+return immediately, and `limit=0` never waits.
+
+The wake signal is process-local and advisory; the database remains the source
+of truth. Successful `comm.send`/`comm.reply` deliveries and successful,
+non-deduplicated `comm.ingest` writes publish after commit. An unrelated wake
+only causes a filtered re-query, so it cannot leak another actor's message or
+make a filtered call return early with an empty page.
 
 ## `comm.probe` — polling contract
 
@@ -128,6 +142,7 @@ registry
     .await?;
 
 let inbox = registry.dispatch("comm.inbox", json!({"limit": 20})).await?;
+let next = registry.dispatch("comm.inbox", json!({"limit": 20, "wait_ms": 30_000})).await?;
 ```
 
 `comm.inbox` returns `has_more`/`next_offset`; pass the latter back as `offset`

--- a/crates/khive-pack-comm/docs/api/message-lifecycle.md
+++ b/crates/khive-pack-comm/docs/api/message-lifecycle.md
@@ -170,6 +170,30 @@ the top-level note `created_at` exposed in the response, not optional transport
 metadata in `properties.sent_at`. Empty substring filters are rejected, and a
 missing/non-string subject does not match `subject_contains`.
 
+`wait_ms` (#1499) adds bounded long-polling without changing the response
+shape. Omission or `0` returns the first query immediately; values from 1
+through 30,000 wait only when that query is empty. `limit=0` remains a
+count-only immediate return and never waits. The deadline is established before
+the initial storage query, so query time reduces the remaining signal-wait
+budget. The timeout-edge final query and response serialization can add ordinary
+request-processing time after that deadline.
+
+One process-local `InboxSignal` belongs to each `CommPack` instance. It combines
+`tokio::sync::Notify` with a monotonically increasing generation. The handler
+captures the generation before every query, preventing a commit between the
+empty query and waiter registration from becoming a lost wakeup. A wake always
+re-runs the complete namespace, actor, status, and sender-filtered query; an
+unrelated message therefore causes only a re-query and the caller keeps waiting
+within the original deadline. A final query closes the race at deadline expiry.
+
+`comm.send` and `comm.reply` publish after their dual-write has committed.
+`comm.ingest` publishes only after `try_create_note` returns a newly committed
+note; the deduplicated path does not publish. The signal carries no message or
+identity data and is not a delivery or authorization boundary. It is intentionally
+not cross-process pubsub: direct writes through another registry/process become
+visible on the timeout-edge final query or a subsequent call, while normal daemon
+dispatches share the same pack instance and wake immediately.
+
 ## `handlers.rs::handle_read`
 
 Marks a message as read. Rejects `read()` on outbound messages — "read" is a

--- a/crates/khive-pack-comm/docs/api/message-lifecycle.md
+++ b/crates/khive-pack-comm/docs/api/message-lifecycle.md
@@ -184,7 +184,9 @@ captures the generation before every query, preventing a commit between the
 empty query and waiter registration from becoming a lost wakeup. A wake always
 re-runs the complete namespace, actor, status, and sender-filtered query; an
 unrelated message therefore causes only a re-query and the caller keeps waiting
-within the original deadline. A final query closes the race at deadline expiry.
+within the original deadline. A final query at deadline expiry observes any commit
+visible before that query takes its storage snapshot; a commit that lands after
+the snapshot is left to the caller's next request.
 
 `comm.send` and `comm.reply` publish after their dual-write has committed.
 `comm.ingest` publishes only after `try_create_note` returns a newly committed
@@ -214,7 +216,7 @@ back an earlier successful item.
 Patches only the `read` key via `NoteStore::try_patch_note_property`, a
 storage-side `json_set`, not a caller-side merge-then-overwrite of the whole
 `properties` column: the write re-evaluates namespace, message kind, direction,
-and addressee against the row's *current* state in the same `UPDATE`, so a
+and addressee against the row's _current_ state in the same `UPDATE`, so a
 property written by another caller between validation and this call (the bulk
 form's window can span up to 500 targets) survives untouched, and an
 eligibility change in that window degrades the mark instead of silently

--- a/crates/khive-pack-comm/src/handlers.rs
+++ b/crates/khive-pack-comm/src/handlers.rs
@@ -511,7 +511,9 @@ where
         let response = query().await?;
         let is_empty = response["messages"]
             .as_array()
-            .expect("inbox response always contains a messages array")
+            .ok_or_else(|| {
+                RuntimeError::Internal("inbox: response is missing the `messages` array".into())
+            })?
             .is_empty();
         if !is_empty || deadline.is_none() {
             return Ok(response);
@@ -2742,6 +2744,104 @@ mod tests {
         assert_eq!(
             response["messages"][0]["content"],
             json!("committed during query")
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn inbox_wait_rejects_response_without_messages_array() {
+        let signal = InboxSignal::new();
+        let result = wait_for_inbox_response(&signal, None, || async { Ok(json!({})) }).await;
+        let err = result.expect_err("a response without `messages` must error, not panic");
+        assert!(
+            matches!(err, khive_runtime::RuntimeError::Internal(_)),
+            "missing `messages` must surface as an internal error: {err}"
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn inbox_final_query_after_timeout_returns_newly_visible_message() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+        use std::sync::Arc;
+
+        let signal = InboxSignal::new();
+        let query_calls = Arc::new(AtomicUsize::new(0));
+        let deadline = Some(tokio::time::Instant::now() + std::time::Duration::from_millis(250));
+
+        let query = || {
+            let query_calls = Arc::clone(&query_calls);
+            async move {
+                let call = query_calls.fetch_add(1, Ordering::SeqCst);
+                if call == 0 {
+                    Ok(json!({ "messages": [] }))
+                } else {
+                    Ok(json!({ "messages": [{ "content": "visible at the timeout edge" }] }))
+                }
+            }
+        };
+
+        // No publish happens, so the timer wins the select; the final query
+        // must still surface the row that became visible by deadline expiry.
+        let response = wait_for_inbox_response(&signal, deadline, query)
+            .await
+            .expect("timeout-edge final query succeeds");
+        assert_eq!(query_calls.load(Ordering::SeqCst), 2);
+        assert_eq!(
+            response["messages"][0]["content"],
+            json!("visible at the timeout edge")
+        );
+    }
+
+    #[tokio::test]
+    async fn ingest_dedup_hit_does_not_publish() {
+        use khive_runtime::{AllowAllGate, BackendId, Namespace, RuntimeConfig};
+        use uuid::Uuid;
+
+        let ns = format!("ingest-dedup-{}", Uuid::new_v4().simple());
+        let runtime = super::KhiveRuntime::new(RuntimeConfig {
+            git_write: Default::default(),
+            db_path: None,
+            default_namespace: Namespace::parse(&ns).unwrap(),
+            embedding_model: None,
+            additional_embedding_models: vec![],
+            gate: std::sync::Arc::new(AllowAllGate),
+            packs: vec!["kg".to_string(), "comm".to_string()],
+            backend_id: BackendId::main(),
+            brain_profile: None,
+            visible_namespaces: vec![],
+            allowed_outbound_namespaces: vec![],
+            actor_id: None,
+        })
+        .expect("in-memory runtime");
+        let token = runtime
+            .authorize(Namespace::parse(&ns).unwrap())
+            .expect("authorize");
+        let signal = InboxSignal::new();
+
+        let body = json!({
+            "from": "email:sender@example.com",
+            "to": "local",
+            "content": "dedup probe",
+            "external_id": "imap:long-poll:dedup:1",
+        });
+
+        let first = super::handle_ingest(&runtime, &signal, &token, body.clone())
+            .await
+            .expect("first ingest succeeds");
+        assert_eq!(first["deduplicated"].as_bool(), Some(false));
+        let generation_after_commit = signal.snapshot();
+        assert_ne!(
+            generation_after_commit, 0,
+            "a newly committed ingest must publish a wake"
+        );
+
+        let second = super::handle_ingest(&runtime, &signal, &token, body)
+            .await
+            .expect("deduplicated ingest succeeds");
+        assert_eq!(second["deduplicated"].as_bool(), Some(true));
+        assert_eq!(
+            signal.snapshot(),
+            generation_after_commit,
+            "a deduplicated ingest must not publish a wake"
         );
     }
 

--- a/crates/khive-pack-comm/src/handlers.rs
+++ b/crates/khive-pack-comm/src/handlers.rs
@@ -14,6 +14,7 @@ use khive_runtime::{KhiveRuntime, NamespaceToken, RuntimeError};
 use khive_storage::note::{FilterOp, Note, NoteFilter, PropertyFilter};
 use khive_storage::types::{PageRequest, SqlValue};
 
+use crate::inbox_signal::InboxSignal;
 use crate::message::{
     dual_write_message, note_to_message_json, resolve_id, short_id, COMM_SCHEMA_VERSION,
     COMM_STABLE_PROPERTY_KEYS,
@@ -193,6 +194,7 @@ fn canonicalize_ingest_sent_at(raw: &str) -> Result<String, RuntimeError> {
 /// See crates/khive-pack-comm/docs/api/message-lifecycle.md#handlersrshandle_send
 pub(crate) async fn handle_send(
     runtime: &KhiveRuntime,
+    inbox_signal: &InboxSignal,
     token: &NamespaceToken,
     params: Value,
 ) -> Result<Value, RuntimeError> {
@@ -265,6 +267,7 @@ pub(crate) async fn handle_send(
         p.tags.as_deref(),
     )
     .await?;
+    inbox_signal.publish();
 
     let mut response = json!({
         "id": short_id(outbound_note.id),
@@ -345,12 +348,21 @@ pub(crate) async fn handle_delivered(
 
 /// `inbox` — list inbound messages for the caller's actor label (ADR-057).
 /// See crates/khive-pack-comm/docs/api/message-lifecycle.md#handlersrshandle_inbox
+const MAX_INBOX_WAIT_MS: u64 = 30_000;
+
 pub(crate) async fn handle_inbox(
     runtime: &KhiveRuntime,
+    inbox_signal: &InboxSignal,
     token: &NamespaceToken,
     params: Value,
 ) -> Result<Value, RuntimeError> {
     let p: InboxParams = deser(params)?;
+    let wait_ms = p.wait_ms.unwrap_or(0);
+    if wait_ms > MAX_INBOX_WAIT_MS {
+        return Err(RuntimeError::InvalidInput(format!(
+            "inbox: `wait_ms` must be at most {MAX_INBOX_WAIT_MS}"
+        )));
+    }
     let raw_limit = p.limit.unwrap_or(20);
     let offset = p.offset.unwrap_or(0);
     if offset > i64::MAX as u64 {
@@ -454,7 +466,8 @@ pub(crate) async fn handle_inbox(
         ..Default::default()
     };
     let store = runtime.notes(token)?;
-
+    let deadline = (wait_ms > 0)
+        .then(|| tokio::time::Instant::now() + std::time::Duration::from_millis(wait_ms));
     let subject_needle = p
         .subject_contains
         .as_ref()
@@ -463,8 +476,87 @@ pub(crate) async fn handle_inbox(
         .content_contains
         .as_ref()
         .map(|value| value.to_lowercase());
-    let has_post_filter = p.from_prefix.is_some()
-        || p.exclude_from_actor.is_some()
+
+    let store = store.as_ref();
+    let namespace = token.namespace().as_str();
+    wait_for_inbox_response(inbox_signal, deadline, || {
+        query_inbox_response(
+            store,
+            namespace,
+            &filter,
+            &p,
+            before_micros,
+            subject_needle.as_deref(),
+            content_needle.as_deref(),
+            offset,
+            limit,
+        )
+    })
+    .await
+}
+
+async fn wait_for_inbox_response<Query, QueryFuture>(
+    inbox_signal: &InboxSignal,
+    deadline: Option<tokio::time::Instant>,
+    mut query: Query,
+) -> Result<Value, RuntimeError>
+where
+    Query: FnMut() -> QueryFuture,
+    QueryFuture: std::future::Future<Output = Result<Value, RuntimeError>>,
+{
+    loop {
+        // Snapshot before querying. If a writer commits between this query and
+        // waiter registration, the generation change makes the wait immediately ready.
+        let observed = inbox_signal.snapshot();
+        let response = query().await?;
+        let is_empty = response["messages"]
+            .as_array()
+            .expect("inbox response always contains a messages array")
+            .is_empty();
+        if !is_empty || deadline.is_none() {
+            return Ok(response);
+        }
+
+        // Enforce one fixed deadline before registering another wait. If the
+        // query itself crossed that deadline, only a publish observed during
+        // the query earns one final re-query; unrelated publish streams can
+        // never reset the budget.
+        let deadline_at = *deadline.as_ref().expect("non-empty wait has a deadline");
+        if tokio::time::Instant::now() >= deadline_at {
+            // The query itself may have crossed the deadline. If a writer
+            // published after that query took its storage snapshot, returning
+            // `response` here would lose the wake. Re-query once to observe the
+            // committed row; the fixed deadline still prevents another wait.
+            if inbox_signal.snapshot() != observed {
+                return query().await;
+            }
+            return Ok(response);
+        }
+
+        let wait_result =
+            tokio::time::timeout_at(deadline_at, inbox_signal.wait_for_change(observed)).await;
+        if wait_result.is_err() {
+            // Close the timeout-edge race: a commit concurrent with deadline
+            // expiry is still visible even if the timer wins the select.
+            return query().await;
+        }
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn query_inbox_response(
+    store: &dyn khive_storage::NoteStore,
+    namespace: &str,
+    filter: &NoteFilter,
+    params: &InboxParams,
+    before_micros: Option<i64>,
+    subject_needle: Option<&str>,
+    content_needle: Option<&str>,
+    offset: u64,
+    limit: usize,
+) -> Result<Value, RuntimeError> {
+    let has_post_filter = params.from_prefix.is_some()
+        || params.exclude_from_actor.is_some()
         || before_micros.is_some()
         || subject_needle.is_some()
         || content_needle.is_some();
@@ -480,8 +572,8 @@ pub(crate) async fn handle_inbox(
         loop {
             let page = store
                 .query_notes_filtered(
-                    token.namespace().as_str(),
-                    &filter,
+                    namespace,
+                    filter,
                     PageRequest {
                         limit: PAGE_SIZE,
                         offset: db_offset,
@@ -490,13 +582,7 @@ pub(crate) async fn handle_inbox(
                 .await?;
             let fetched = page.items.len() as u32;
             for n in &page.items {
-                if !inbox_note_matches(
-                    n,
-                    &p,
-                    before_micros,
-                    subject_needle.as_deref(),
-                    content_needle.as_deref(),
-                ) {
+                if !inbox_note_matches(n, params, before_micros, subject_needle, content_needle) {
                     continue;
                 }
                 if matched < offset {
@@ -519,8 +605,8 @@ pub(crate) async fn handle_inbox(
     } else {
         let page = store
             .query_notes_filtered(
-                token.namespace().as_str(),
-                &filter,
+                namespace,
+                filter,
                 PageRequest {
                     limit: (limit + 1) as u32,
                     offset,
@@ -936,6 +1022,7 @@ fn read_response(
 /// crates/khive-pack-comm/docs/api/message-lifecycle.md#handlersrshandle_reply
 pub(crate) async fn handle_reply(
     runtime: &KhiveRuntime,
+    inbox_signal: &InboxSignal,
     token: &NamespaceToken,
     params: Value,
 ) -> Result<Value, RuntimeError> {
@@ -1100,6 +1187,7 @@ pub(crate) async fn handle_reply(
         p.tags.as_deref(),
     )
     .await?;
+    inbox_signal.publish();
 
     // Replying is the strongest possible read signal, and callers universally
     // chained `reply | read` to say so — fold it in. Skips only an explicitly
@@ -1483,6 +1571,7 @@ enum AfterCursor {
 /// crates/khive-pack-comm/docs/api/message-lifecycle.md#handlersrshandle_ingest
 pub(crate) async fn handle_ingest(
     runtime: &KhiveRuntime,
+    inbox_signal: &InboxSignal,
     token: &NamespaceToken,
     params: Value,
 ) -> Result<Value, RuntimeError> {
@@ -1745,6 +1834,7 @@ pub(crate) async fn handle_ingest(
             }));
         }
     };
+    inbox_signal.publish();
 
     Ok(json!({
         "id": short_id(note.id),
@@ -2602,10 +2692,58 @@ mod tests {
         add_embedding_truncation_warning, build_references_header, channel_stalled,
         heartbeat_note_id, mark_read_target, message_id_match_candidates, parent_references_chain,
         parent_wire_message_id, read_response, sanitize_reference_token, validate_read_target,
-        wrap_message_id,
+        wait_for_inbox_response, wrap_message_id,
     };
+    use crate::inbox_signal::InboxSignal;
     use khive_storage::StorageError;
     use serde_json::{json, Value};
+
+    #[tokio::test(start_paused = true)]
+    async fn inbox_query_crossing_deadline_requeries_after_publish() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+        use std::sync::Arc;
+
+        let signal = InboxSignal::new();
+        let query_started = Arc::new(tokio::sync::Barrier::new(2));
+        let release_query = Arc::new(tokio::sync::Notify::new());
+        let query_calls = Arc::new(AtomicUsize::new(0));
+        let deadline = Some(tokio::time::Instant::now() + std::time::Duration::from_millis(250));
+
+        let query = || {
+            let query_started = Arc::clone(&query_started);
+            let release_query = Arc::clone(&release_query);
+            let query_calls = Arc::clone(&query_calls);
+            async move {
+                let call = query_calls.fetch_add(1, Ordering::SeqCst);
+                if call == 0 {
+                    query_started.wait().await;
+                    release_query.notified().await;
+                    Ok(json!({ "messages": [] }))
+                } else {
+                    Ok(json!({ "messages": [{ "content": "committed during query" }] }))
+                }
+            }
+        };
+
+        let commit_during_query = async {
+            query_started.wait().await;
+            tokio::time::advance(std::time::Duration::from_millis(250)).await;
+            signal.publish();
+            release_query.notify_one();
+        };
+
+        let (response, ()) = tokio::join!(
+            wait_for_inbox_response(&signal, deadline, query),
+            commit_during_query,
+        );
+        let response = response.expect("deadline-edge re-query succeeds");
+
+        assert_eq!(query_calls.load(Ordering::SeqCst), 2);
+        assert_eq!(
+            response["messages"][0]["content"],
+            json!("committed during query")
+        );
+    }
 
     #[test]
     fn channel_stalled_uses_strict_three_interval_threshold() {

--- a/crates/khive-pack-comm/src/inbox_signal.rs
+++ b/crates/khive-pack-comm/src/inbox_signal.rs
@@ -1,0 +1,57 @@
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use tokio::sync::Notify;
+
+/// Process-local wake signal for newly committed inbox messages.
+pub(crate) struct InboxSignal {
+    generation: AtomicU64,
+    notify: Notify,
+}
+
+impl InboxSignal {
+    pub(crate) fn new() -> Self {
+        Self {
+            generation: AtomicU64::new(0),
+            notify: Notify::new(),
+        }
+    }
+
+    pub(crate) fn snapshot(&self) -> u64 {
+        self.generation.load(Ordering::Acquire)
+    }
+
+    pub(crate) fn publish(&self) {
+        self.generation.fetch_add(1, Ordering::Release);
+        self.notify.notify_waiters();
+    }
+
+    pub(crate) async fn wait_for_change(&self, observed: u64) {
+        loop {
+            let notified = self.notify.notified();
+            tokio::pin!(notified);
+            notified.as_mut().enable();
+            if self.snapshot() != observed {
+                return;
+            }
+            notified.await;
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use super::InboxSignal;
+
+    #[tokio::test]
+    async fn publish_before_wait_is_not_lost() {
+        let signal = InboxSignal::new();
+        let observed = signal.snapshot();
+        signal.publish();
+
+        tokio::time::timeout(Duration::from_millis(20), signal.wait_for_change(observed))
+            .await
+            .expect("generation change must make the wait immediately ready");
+    }
+}

--- a/crates/khive-pack-comm/src/lib.rs
+++ b/crates/khive-pack-comm/src/lib.rs
@@ -1,6 +1,7 @@
 //! pack-comm — Actor-addressed communication verbs and channel subhandlers.
 
 pub mod handlers;
+pub(crate) mod inbox_signal;
 pub(crate) mod message;
 pub(crate) mod pack;
 pub(crate) mod params;

--- a/crates/khive-pack-comm/src/pack.rs
+++ b/crates/khive-pack-comm/src/pack.rs
@@ -8,6 +8,7 @@ use khive_runtime::{KhiveRuntime, NamespaceToken, RuntimeError, SchemaPlan, Verb
 use khive_types::{HandlerDef, Pack};
 
 use crate::handlers;
+use crate::inbox_signal::InboxSignal;
 use crate::vocab::{COMM_HANDLERS, COMM_SCHEMA_PLAN_STMTS};
 
 /// Communication pack providing the public `comm.*` verbs and channel subhandlers.
@@ -16,6 +17,7 @@ use crate::vocab::{COMM_HANDLERS, COMM_SCHEMA_PLAN_STMTS};
 /// metadata lives in the `properties` JSON column.
 pub struct CommPack {
     runtime: KhiveRuntime,
+    inbox_signal: InboxSignal,
 }
 
 impl Pack for CommPack {
@@ -29,7 +31,10 @@ impl Pack for CommPack {
 impl CommPack {
     /// Create a new `CommPack` bound to the given runtime.
     pub fn new(runtime: KhiveRuntime) -> Self {
-        Self { runtime }
+        Self {
+            runtime,
+            inbox_signal: InboxSignal::new(),
+        }
     }
     pub(crate) fn runtime(&self) -> &KhiveRuntime {
         &self.runtime
@@ -85,14 +90,22 @@ impl PackRuntime for CommPack {
         token: &NamespaceToken,
     ) -> Result<Value, RuntimeError> {
         match verb {
-            "comm.send" => handlers::handle_send(self.runtime(), token, params).await,
+            "comm.send" => {
+                handlers::handle_send(self.runtime(), &self.inbox_signal, token, params).await
+            }
             "comm.delivered" => handlers::handle_delivered(self.runtime(), token, params).await,
-            "comm.inbox" => handlers::handle_inbox(self.runtime(), token, params).await,
+            "comm.inbox" => {
+                handlers::handle_inbox(self.runtime(), &self.inbox_signal, token, params).await
+            }
             "comm.read" => handlers::handle_read(self.runtime(), token, params).await,
             "comm.unread" => handlers::handle_unread(self.runtime(), token, params).await,
-            "comm.reply" => handlers::handle_reply(self.runtime(), token, params).await,
+            "comm.reply" => {
+                handlers::handle_reply(self.runtime(), &self.inbox_signal, token, params).await
+            }
             "comm.thread" => handlers::handle_thread(self.runtime(), token, params).await,
-            "comm.ingest" => handlers::handle_ingest(self.runtime(), token, params).await,
+            "comm.ingest" => {
+                handlers::handle_ingest(self.runtime(), &self.inbox_signal, token, params).await
+            }
             "comm.heartbeat" => handlers::handle_heartbeat(self.runtime(), token, params).await,
             "comm.health" => handlers::handle_health(self.runtime(), token, params).await,
             "comm.probe" => handlers::handle_probe(self.runtime(), token, params).await,
@@ -177,7 +190,7 @@ mod help_tests {
     }
 
     #[test]
-    fn inbox_has_optional_limit_and_status() {
+    fn inbox_has_optional_limit_status_and_wait() {
         let h = find_handler("comm.inbox");
         assert!(!h.params.is_empty(), "inbox must have non-empty params");
         let limit = h
@@ -192,6 +205,13 @@ mod help_tests {
             .find(|p| p.name == "status")
             .expect("inbox must have 'status'");
         assert!(!status.required, "inbox.status must be optional");
+        let wait_ms = h
+            .params
+            .iter()
+            .find(|p| p.name == "wait_ms")
+            .expect("inbox must have 'wait_ms'");
+        assert_eq!(wait_ms.param_type, "integer");
+        assert!(!wait_ms.required, "inbox.wait_ms must be optional");
     }
 
     #[test]

--- a/crates/khive-pack-comm/src/params.rs
+++ b/crates/khive-pack-comm/src/params.rs
@@ -42,6 +42,9 @@ pub(crate) struct InboxParams {
     pub offset: Option<u64>,
     #[serde(default)]
     pub status: Option<String>,
+    /// Long-poll budget. Zero or omission preserves the immediate-return path.
+    #[serde(default)]
+    pub wait_ms: Option<u64>,
     /// Exact match on `properties.from_actor`. Mutually exclusive with `from_prefix`.
     #[serde(default)]
     pub from_actor: Option<String>,

--- a/crates/khive-pack-comm/src/vocab.rs
+++ b/crates/khive-pack-comm/src/vocab.rs
@@ -107,7 +107,7 @@ pub(crate) static COMM_HANDLERS: [HandlerDef; 13] = [
     },
     HandlerDef {
         name: "comm.inbox",
-        description: "List and page through filtered inbound messages for the caller.",
+        description: "List and page through filtered inbound messages for the caller, optionally waiting for a new matching message.",
         visibility: Visibility::Verb,
         category: khive_types::VerbCategory::Assertive,
         params: &[
@@ -128,6 +128,12 @@ pub(crate) static COMM_HANDLERS: [HandlerDef; 13] = [
                 param_type: "string",
                 required: false,
                 description: "Filter by read status: \"unread\" (default) | \"read\" | \"all\".",
+            },
+            ParamDef {
+                name: "wait_ms",
+                param_type: "integer",
+                required: false,
+                description: "Long-poll budget in milliseconds. Returns immediately when the initial query matches; otherwise waits for a new matching message, up to 30000 ms. Default 0 (no wait).",
             },
             ParamDef {
                 name: "from_actor",

--- a/crates/khive-pack-comm/tests/integration.rs
+++ b/crates/khive-pack-comm/tests/integration.rs
@@ -494,6 +494,49 @@ async fn inbox_long_poll_wakes_after_concurrent_ingest() {
     assert!(inbox["next_offset"].is_null());
 }
 
+#[tokio::test]
+async fn inbox_long_poll_wakes_after_concurrent_send() {
+    let (registry, _rt) = build_registry_for_ns("local");
+    let waiter_registry = registry.clone();
+    let mut waiter = tokio::spawn(async move {
+        waiter_registry
+            .dispatch(
+                "comm.inbox",
+                serde_json::json!({ "status": "all", "wait_ms": 5_000 }),
+            )
+            .await
+    });
+
+    tokio::time::sleep(std::time::Duration::from_millis(25)).await;
+    assert!(
+        !waiter.is_finished(),
+        "empty inbox must remain blocked before a matching send"
+    );
+
+    registry
+        .dispatch(
+            "comm.send",
+            serde_json::json!({ "to": "local", "content": "send wakes the inbox" }),
+        )
+        .await
+        .expect("concurrent send succeeds");
+
+    let inbox = match tokio::time::timeout(std::time::Duration::from_secs(1), &mut waiter).await {
+        Ok(joined) => joined
+            .expect("long-poll task must not panic")
+            .expect("long-poll inbox succeeds"),
+        Err(_) => {
+            waiter.abort();
+            panic!("long-poll inbox did not wake within one second of send");
+        }
+    };
+    assert_eq!(inbox["count"].as_u64(), Some(1));
+    assert_eq!(
+        inbox["messages"][0]["content"].as_str(),
+        Some("send wakes the inbox")
+    );
+}
+
 #[tokio::test(start_paused = true)]
 async fn inbox_long_poll_stops_at_requested_budget() {
     let (registry, _rt) = build_registry_for_ns("local");
@@ -526,6 +569,65 @@ async fn inbox_rejects_wait_budget_above_thirty_seconds() {
     assert!(
         err.to_string().contains("wait_ms") && err.to_string().contains("30000"),
         "error must name wait_ms and its maximum: {err}"
+    );
+}
+
+#[tokio::test(start_paused = true)]
+async fn inbox_count_only_never_waits() {
+    let (registry, _rt) = build_registry_for_ns("local");
+    let started = tokio::time::Instant::now();
+
+    let inbox = registry
+        .dispatch(
+            "comm.inbox",
+            serde_json::json!({ "limit": 0, "wait_ms": 5_000 }),
+        )
+        .await
+        .expect("count-only inbox succeeds");
+
+    assert_eq!(inbox["count"].as_u64(), Some(0));
+    assert!(
+        inbox["messages"]
+            .as_array()
+            .is_some_and(|rows| rows.is_empty()),
+        "count-only inbox returns no message payloads: {inbox}"
+    );
+    assert_eq!(
+        tokio::time::Instant::now().duration_since(started),
+        std::time::Duration::ZERO,
+        "limit=0 must return immediately even with a positive wait_ms"
+    );
+}
+
+#[tokio::test]
+async fn inbox_long_poll_returns_immediately_when_matches_exist() {
+    let (registry, _rt) = build_registry_for_ns("local");
+
+    registry
+        .dispatch(
+            "comm.send",
+            serde_json::json!({ "to": "local", "content": "already waiting" }),
+        )
+        .await
+        .expect("send succeeds");
+
+    let started = std::time::Instant::now();
+    let inbox = registry
+        .dispatch(
+            "comm.inbox",
+            serde_json::json!({ "status": "all", "wait_ms": 5_000 }),
+        )
+        .await
+        .expect("long poll over a non-empty inbox succeeds");
+
+    assert!(
+        started.elapsed() < std::time::Duration::from_secs(1),
+        "an initial query with matches must return without waiting out the budget"
+    );
+    assert_eq!(inbox["count"].as_u64(), Some(1));
+    assert_eq!(
+        inbox["messages"][0]["content"].as_str(),
+        Some("already waiting")
     );
 }
 

--- a/crates/khive-pack-comm/tests/integration.rs
+++ b/crates/khive-pack-comm/tests/integration.rs
@@ -394,6 +394,142 @@ async fn delivered_rejects_short_or_malformed_ids() {
 }
 
 #[tokio::test]
+async fn inbox_long_poll_wakes_after_concurrent_ingest() {
+    let (registry, _rt) = build_registry_for_ns("local");
+    let waiter_registry = registry.clone();
+    let started = std::time::Instant::now();
+    let mut waiter = tokio::spawn(async move {
+        waiter_registry
+            .dispatch(
+                "comm.inbox",
+                serde_json::json!({
+                    "status": "all",
+                    "from_actor": "email:sender@example.com",
+                    "content_contains": "wake the blocked inbox",
+                    "wait_ms": 5_000,
+                }),
+            )
+            .await
+    });
+
+    tokio::time::sleep(std::time::Duration::from_millis(25)).await;
+    assert!(
+        !waiter.is_finished(),
+        "empty inbox must remain blocked before a matching ingest"
+    );
+
+    registry
+        .dispatch(
+            "comm.ingest",
+            serde_json::json!({
+                "namespace": "local",
+                "from": "email:other@example.com",
+                "to": "local",
+                "content": "unrelated wake",
+                "external_id": "imap:long-poll:1:1",
+            }),
+        )
+        .await
+        .expect("unrelated ingest succeeds");
+    tokio::time::sleep(std::time::Duration::from_millis(25)).await;
+    assert!(
+        !waiter.is_finished(),
+        "an unrelated signal must re-query and keep waiting"
+    );
+
+    registry
+        .dispatch(
+            "comm.ingest",
+            serde_json::json!({
+                "namespace": "local",
+                "from": "email:sender@example.com",
+                "to": "local",
+                "content": "same sender, wrong content",
+                "external_id": "imap:long-poll:1:content-miss",
+            }),
+        )
+        .await
+        .expect("same-sender non-matching ingest succeeds");
+    tokio::time::sleep(std::time::Duration::from_millis(25)).await;
+    assert!(
+        !waiter.is_finished(),
+        "a wake that fails a post-query text filter must keep waiting"
+    );
+
+    let ingest = registry
+        .dispatch(
+            "comm.ingest",
+            serde_json::json!({
+                "namespace": "local",
+                "from": "email:sender@example.com",
+                "to": "local",
+                "content": "wake the blocked inbox",
+                "external_id": "imap:long-poll:1:2",
+            }),
+        )
+        .await
+        .expect("concurrent ingest succeeds");
+    assert_eq!(ingest["deduplicated"].as_bool(), Some(false));
+
+    let inbox = match tokio::time::timeout(std::time::Duration::from_secs(1), &mut waiter).await {
+        Ok(joined) => joined
+            .expect("long-poll task must not panic")
+            .expect("long-poll inbox succeeds"),
+        Err(_) => {
+            waiter.abort();
+            panic!("long-poll inbox did not wake within one second of ingest");
+        }
+    };
+    assert!(
+        started.elapsed() < std::time::Duration::from_secs(1),
+        "signal wake must beat the five-second polling baseline"
+    );
+    assert_eq!(inbox["count"].as_u64(), Some(1));
+    assert_eq!(
+        inbox["messages"][0]["content"].as_str(),
+        Some("wake the blocked inbox")
+    );
+    assert_eq!(inbox["offset"].as_u64(), Some(0));
+    assert_eq!(inbox["has_more"].as_bool(), Some(false));
+    assert!(inbox["next_offset"].is_null());
+}
+
+#[tokio::test(start_paused = true)]
+async fn inbox_long_poll_stops_at_requested_budget() {
+    let (registry, _rt) = build_registry_for_ns("local");
+    let started = tokio::time::Instant::now();
+
+    let inbox = registry
+        .dispatch(
+            "comm.inbox",
+            serde_json::json!({ "status": "all", "wait_ms": 250 }),
+        )
+        .await
+        .expect("empty long poll succeeds at its deadline");
+
+    assert_eq!(inbox["count"].as_u64(), Some(0));
+    assert_eq!(
+        tokio::time::Instant::now().duration_since(started),
+        std::time::Duration::from_millis(250),
+        "the signal wait must use one fixed budget rather than resetting it"
+    );
+}
+
+#[tokio::test]
+async fn inbox_rejects_wait_budget_above_thirty_seconds() {
+    let (registry, _rt) = build_registry();
+
+    let err = registry
+        .dispatch("comm.inbox", serde_json::json!({ "wait_ms": 30_001 }))
+        .await
+        .expect_err("oversized long-poll budget must be rejected");
+    assert!(
+        err.to_string().contains("wait_ms") && err.to_string().contains("30000"),
+        "error must name wait_ms and its maximum: {err}"
+    );
+}
+
+#[tokio::test]
 async fn read_marks_message_as_read() {
     let (registry, rt) = build_registry_for_ns("local");
 

--- a/crates/khive-pack-comm/tests/integration.rs
+++ b/crates/khive-pack-comm/tests/integration.rs
@@ -631,6 +631,175 @@ async fn inbox_long_poll_returns_immediately_when_matches_exist() {
     );
 }
 
+#[tokio::test(start_paused = true)]
+async fn inbox_long_poll_accepts_thirty_second_budget() {
+    let (registry, _rt) = build_registry_for_ns("local");
+    let started = tokio::time::Instant::now();
+
+    let inbox = registry
+        .dispatch(
+            "comm.inbox",
+            serde_json::json!({ "status": "all", "wait_ms": 30_000 }),
+        )
+        .await
+        .expect("the inclusive maximum wait_ms must be accepted");
+
+    assert_eq!(inbox["count"].as_u64(), Some(0));
+    assert_eq!(
+        tokio::time::Instant::now().duration_since(started),
+        std::time::Duration::from_millis(30_000),
+        "wait_ms=30000 is the inclusive boundary and must run its full budget"
+    );
+}
+
+#[tokio::test]
+async fn inbox_rejects_non_numeric_wait_ms() {
+    let (registry, _rt) = build_registry();
+
+    let err = registry
+        .dispatch("comm.inbox", serde_json::json!({ "wait_ms": "soon" }))
+        .await
+        .expect_err("a non-numeric wait_ms must be rejected");
+    assert!(
+        err.to_string().contains("invalid input"),
+        "a non-numeric wait_ms must fail parameter deserialization: {err}"
+    );
+
+    let err = registry
+        .dispatch("comm.inbox", serde_json::json!({ "wait_ms": -5 }))
+        .await
+        .expect_err("a negative wait_ms must be rejected");
+    assert!(
+        err.to_string().contains("invalid input"),
+        "a negative wait_ms must fail parameter deserialization: {err}"
+    );
+}
+
+#[tokio::test]
+async fn inbox_long_poll_wakes_after_concurrent_reply() {
+    let (registry, _rt) = build_registry_for_ns("local");
+    let waiter_registry = registry.clone();
+    let mut waiter = tokio::spawn(async move {
+        waiter_registry
+            .dispatch(
+                "comm.inbox",
+                serde_json::json!({
+                    "status": "all",
+                    "content_contains": "reply wake arrives",
+                    "wait_ms": 5_000,
+                }),
+            )
+            .await
+    });
+
+    tokio::time::sleep(std::time::Duration::from_millis(25)).await;
+    assert!(
+        !waiter.is_finished(),
+        "empty inbox must remain blocked before a matching reply"
+    );
+
+    let original = registry
+        .dispatch(
+            "comm.send",
+            serde_json::json!({ "to": "local", "content": "original for reply wake" }),
+        )
+        .await
+        .expect("send succeeds");
+    let original_full_id = original["full_id"].as_str().expect("send returns full_id");
+
+    tokio::time::sleep(std::time::Duration::from_millis(25)).await;
+    assert!(
+        !waiter.is_finished(),
+        "a send that fails the content filter must keep the reply waiter waiting"
+    );
+
+    registry
+        .dispatch(
+            "comm.reply",
+            serde_json::json!({ "id": original_full_id, "content": "reply wake arrives" }),
+        )
+        .await
+        .expect("reply succeeds");
+
+    let inbox = match tokio::time::timeout(std::time::Duration::from_secs(1), &mut waiter).await {
+        Ok(joined) => joined
+            .expect("long-poll task must not panic")
+            .expect("long-poll inbox succeeds"),
+        Err(_) => {
+            waiter.abort();
+            panic!("long-poll inbox did not wake within one second of reply");
+        }
+    };
+    assert_eq!(inbox["count"].as_u64(), Some(1));
+    assert_eq!(
+        inbox["messages"][0]["content"].as_str(),
+        Some("reply wake arrives")
+    );
+}
+
+#[tokio::test]
+async fn inbox_long_poll_with_offset_wakes_and_pages() {
+    let (registry, _rt) = build_registry_for_ns("local");
+
+    registry
+        .dispatch(
+            "comm.send",
+            serde_json::json!({ "to": "local", "content": "page: first" }),
+        )
+        .await
+        .expect("first send succeeds");
+    tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+    registry
+        .dispatch(
+            "comm.send",
+            serde_json::json!({ "to": "local", "content": "page: second" }),
+        )
+        .await
+        .expect("second send succeeds");
+    tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+
+    let waiter_registry = registry.clone();
+    let mut waiter = tokio::spawn(async move {
+        waiter_registry
+            .dispatch(
+                "comm.inbox",
+                serde_json::json!({ "status": "all", "offset": 2, "wait_ms": 5_000 }),
+            )
+            .await
+    });
+
+    tokio::time::sleep(std::time::Duration::from_millis(25)).await;
+    assert!(
+        !waiter.is_finished(),
+        "an offset beyond the current last page must keep waiting"
+    );
+
+    registry
+        .dispatch(
+            "comm.send",
+            serde_json::json!({ "to": "local", "content": "page: third" }),
+        )
+        .await
+        .expect("third send succeeds");
+
+    let inbox = match tokio::time::timeout(std::time::Duration::from_secs(1), &mut waiter).await {
+        Ok(joined) => joined
+            .expect("long-poll task must not panic")
+            .expect("long-poll inbox succeeds"),
+        Err(_) => {
+            waiter.abort();
+            panic!("long-poll inbox did not wake within one second of the third send");
+        }
+    };
+    assert_eq!(inbox["count"].as_u64(), Some(1));
+    assert_eq!(inbox["offset"].as_u64(), Some(2));
+    assert_eq!(
+        inbox["messages"][0]["content"].as_str(),
+        Some("page: first"),
+        "the same-offset re-query must page from the newest-first filtered sequence"
+    );
+}
+
 #[tokio::test]
 async fn read_marks_message_as_read() {
     let (registry, rt) = build_registry_for_ns("local");

--- a/docs/adr/ADR-040-communication-and-schedule-packs.md
+++ b/docs/adr/ADR-040-communication-and-schedule-packs.md
@@ -96,13 +96,13 @@ caller's namespace) or `outbound` (message sent by the caller). This is set by `
 
 #### Five verbs
 
-| Verb          | Speech act (ADR-025) | Args                                      | What it does                                                                                                                                                                                                                                                                              |
-| ------------- | -------------------- | ----------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `comm.send`   | commissive           | `to`, `subject?`, `content`, `thread_id?` | Create a message note in the recipient's namespace (`direction=inbound`) and an outbound copy in the caller's namespace (`direction=outbound`). `from` is set to the caller's identity. Both writes are atomic: if the inbound write fails, the outbound copy is rolled back.             |
+| Verb          | Speech act (ADR-025) | Args                                      | What it does                                                                                                                                                                                                                                                                                     |
+| ------------- | -------------------- | ----------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `comm.send`   | commissive           | `to`, `subject?`, `content`, `thread_id?` | Create a message note in the recipient's namespace (`direction=inbound`) and an outbound copy in the caller's namespace (`direction=outbound`). `from` is set to the caller's identity. Both writes are atomic: if the inbound write fails, the outbound copy is rolled back.                    |
 | `comm.inbox`  | assertive            | `limit?`, `offset?`, filters, `wait_ms?`  | List inbound messages (`direction=inbound`) for the caller. `status` filters on `read`: `unread` (default), `read`, or `all`. Offset pagination and sender/time/text filters apply without changing message state; a bounded long poll waits only when the fully filtered initial page is empty. |
-| `comm.read`   | declaration          | `id?`, `ids?`                             | Set `properties.read = true` on one or more **inbound** messages. Exactly one of `id` or `ids` is required. Outbound messages cannot be marked read.                                                                                                                                      |
-| `comm.reply`  | commissive           | `id`, `content`                           | Fetch the target message's `thread_id` (or use the message's own UUID as the thread root). Create a new message with the same `thread_id`, `to` set to the other party, `subject` prefixed with `"Re: "` if not already. Uses dual-write for inbound delivery to the recipient.           |
-| `comm.thread` | assertive            | `id`, `limit?`                            | Validate the root message by UUID (must exist, must be `kind=message`), then return the root plus all messages whose `properties.thread_id` equals the root UUID, sorted by `created_at` ascending (chronological). Uses a paginated scan. `id` accepts 8-char short prefix or full UUID. |
+| `comm.read`   | declaration          | `id?`, `ids?`                             | Set `properties.read = true` on one or more **inbound** messages. Exactly one of `id` or `ids` is required. Outbound messages cannot be marked read.                                                                                                                                             |
+| `comm.reply`  | commissive           | `id`, `content`                           | Fetch the target message's `thread_id` (or use the message's own UUID as the thread root). Create a new message with the same `thread_id`, `to` set to the other party, `subject` prefixed with `"Re: "` if not already. Uses dual-write for inbound delivery to the recipient.                  |
+| `comm.thread` | assertive            | `id`, `limit?`                            | Validate the root message by UUID (must exist, must be `kind=message`), then return the root plus all messages whose `properties.thread_id` equals the root UUID, sorted by `created_at` ascending (chronological). Uses a paginated scan. `id` accepts 8-char short prefix or full UUID.        |
 
 #### Inbox pagination, richer filters, and bulk read amendment (2026-08-01)
 
@@ -696,7 +696,9 @@ inbox handler snapshots the generation before every query, so a commit between
 an empty query and waiter registration cannot be lost. The signal is deliberately
 payload-free and unscoped: every wake is followed by the normal authorized query,
 and an unrelated actor/namespace/filter result causes the call to continue waiting
-within its original deadline. A final query closes the deadline-edge race.
+within its original deadline. A final query at deadline expiry observes commits
+visible before that query takes its storage snapshot; a commit landing after the
+snapshot is left to the caller's next request.
 
 Successful `comm.send` and `comm.reply` handlers publish only after their atomic
 dual-write commits. `comm.ingest` publishes only after `try_create_note` returns a

--- a/docs/adr/ADR-040-communication-and-schedule-packs.md
+++ b/docs/adr/ADR-040-communication-and-schedule-packs.md
@@ -1,7 +1,7 @@
 # ADR-040: Communication and Schedule Packs
 
-**Status**: accepted\
-**Date**: 2026-05-23\
+**Status**: accepted (amended 2026-08-01 — bounded inbox long poll)\
+**Date**: 2026-05-23 (amended 2026-08-01)\
 **Authors**: khive maintainers
 
 ## Context
@@ -36,8 +36,9 @@ The system must satisfy:
 3. **Event observable disambiguation.** The substrate's `Event` type (ADR-004) is a read-only
    audit observable. The schedule pack's `scheduled_event` note kind is user-authored future
    intent. These must not be conflated.
-4. **Mailbox model for comm.** No real-time delivery mechanism. Agents poll via `inbox`.
-   This matches the agent-scale interaction model and avoids network/pubsub dependencies.
+4. **Mailbox model for comm.** No network/pubsub delivery mechanism. Agents originally polled
+   via `inbox`; the 2026-08-01 amendment adds a bounded process-local long poll without changing
+   the durable mailbox model or adding infrastructure dependencies.
 5. **Intent storage for schedule.** The pack stores what should happen and when. Trigger
    evaluation (replay the stored verb+args payload at the designated time) is the runtime's
    and execution environment's responsibility — the pack does not own a polling loop.
@@ -98,7 +99,7 @@ caller's namespace) or `outbound` (message sent by the caller). This is set by `
 | Verb          | Speech act (ADR-025) | Args                                      | What it does                                                                                                                                                                                                                                                                              |
 | ------------- | -------------------- | ----------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `comm.send`   | commissive           | `to`, `subject?`, `content`, `thread_id?` | Create a message note in the recipient's namespace (`direction=inbound`) and an outbound copy in the caller's namespace (`direction=outbound`). `from` is set to the caller's identity. Both writes are atomic: if the inbound write fails, the outbound copy is rolled back.             |
-| `comm.inbox`  | assertive            | `limit?`, `offset?`, filters              | List inbound messages (`direction=inbound`) for the caller. `status` filters on `read`: `unread` (default), `read`, or `all`. Offset pagination and sender/time/text filters apply without changing message state.                                                                        |
+| `comm.inbox`  | assertive            | `limit?`, `offset?`, filters, `wait_ms?`  | List inbound messages (`direction=inbound`) for the caller. `status` filters on `read`: `unread` (default), `read`, or `all`. Offset pagination and sender/time/text filters apply without changing message state; a bounded long poll waits only when the fully filtered initial page is empty. |
 | `comm.read`   | declaration          | `id?`, `ids?`                             | Set `properties.read = true` on one or more **inbound** messages. Exactly one of `id` or `ids` is required. Outbound messages cannot be marked read.                                                                                                                                      |
 | `comm.reply`  | commissive           | `id`, `content`                           | Fetch the target message's `thread_id` (or use the message's own UUID as the thread root). Create a new message with the same `thread_id`, `to` set to the other party, `subject` prefixed with `"Re: "` if not already. Uses dual-write for inbound delivery to the recipient.           |
 | `comm.thread` | assertive            | `id`, `limit?`                            | Validate the root message by UUID (must exist, must be `kind=message`), then return the root plus all messages whose `properties.thread_id` equals the root UUID, sorted by `created_at` ascending (chronological). Uses a paginated scan. `id` accepts 8-char short prefix or full UUID. |
@@ -491,6 +492,11 @@ and retry mechanics — none of which belong in the pack layer. Agents operate a
 interaction cadence and avoids hard infrastructure dependencies in the binary. Operators
 who need real-time delivery build atop the mailbox by polling.
 
+The 2026-08-01 amendment below supersedes only the polling-latency conclusion:
+`comm.inbox(wait_ms=...)` may now wait on a process-local commit signal. The
+database-backed mailbox remains authoritative, and there is still no network
+pubsub, persistent delivery socket, or independent delivery-guarantee layer.
+
 ### Why intent-only for schedule
 
 The pack cannot know what polling infrastructure exists in the execution environment. A pack
@@ -673,3 +679,35 @@ implementation. The `comm.read` discovery description in
 `docs/guide/api-reference.md`, `docs/guide/communication.md`, the comm skill) carry the
 best-effort wording; the verbatim `HandlerDef` snippet earlier in this ADR reflects the
 original pre-amendment description.
+
+## Amendment (2026-08-01): bounded `comm.inbox` long poll (#1499)
+
+`comm.inbox` accepts optional `wait_ms` in the inclusive range 0 through
+30,000. Omission and zero preserve the original immediate snapshot. A positive
+value establishes one deadline before the initial query; if that fully scoped
+query finds a message, the call returns immediately. Otherwise it waits for a
+process-local message-commit signal and re-runs the same namespace, actor,
+status, and sender-filtered query. `limit=0` remains an immediate count-only
+operation and never waits. The response schema is unchanged.
+
+Each `CommPack` instance owns an `InboxSignal` consisting of
+`tokio::sync::Notify` plus a monotonically increasing generation counter. The
+inbox handler snapshots the generation before every query, so a commit between
+an empty query and waiter registration cannot be lost. The signal is deliberately
+payload-free and unscoped: every wake is followed by the normal authorized query,
+and an unrelated actor/namespace/filter result causes the call to continue waiting
+within its original deadline. A final query closes the deadline-edge race.
+
+Successful `comm.send` and `comm.reply` handlers publish only after their atomic
+dual-write commits. `comm.ingest` publishes only after `try_create_note` returns a
+newly committed note; an `external_id` dedup hit does not publish. Publishing in
+the comm handler is both more precise and narrower than teaching each channel
+poll loop to interpret an ingest response. It also requires no post-construction
+injection: the waiting and writing handlers already execute on the same immutable,
+registry-owned `CommPack` instance.
+
+This is an in-process latency optimization, not a second source of delivery
+truth. Direct database writes or a distinct process/registry do not share the
+signal; the timeout-edge final query or the caller's next request observes them
+from durable storage. No notification carries message content, actor identity,
+or authorization, and no wake bypasses ADR-018/ADR-057 filtering.

--- a/docs/adr/ADR-056-channel-transport-layer.md
+++ b/docs/adr/ADR-056-channel-transport-layer.md
@@ -1,15 +1,16 @@
 # ADR-056: Channel Transport Layer -- `khive-channel` and External Messaging Adapters
 
-**Status**: Accepted (amended 2026-07-02 -- inbound authentication hardening; amended 2026-07-03
+**Status**: Accepted (amended 2026-08-01 -- bounded inbox long poll; amended 2026-07-02 -- inbound authentication hardening; amended 2026-07-03
 -- Exchange Online no-authserv-id boundary; amended 2026-07-05 -- Telegram adapter
 implementation and two-way chat; amended 2026-07-09 -- durable IMAP UID cursor; amended
 2026-07-17 -- iMessage channel over an SSH bridge; see
+[§Amendment 2026-08-01](#amendment-2026-08-01----bounded-inbox-long-poll),
 [§Amendment 2026-07-02](#amendment-2026-07-02----inbound-authentication-hardening),
 [§Amendment 2026-07-03](#amendment-2026-07-03----exchange-online-no-authserv-id-boundary),
 [§Amendment 2026-07-05](#amendment-2026-07-05----telegram-adapter-implementation-and-two-way-chat),
 [§Amendment 2026-07-09](#amendment-2026-07-09----durable-imap-uid-cursor),
 [§Amendment 2026-07-17](#amendment-2026-07-17----imessage-channel-over-an-ssh-bridge))\
-**Date**: 2026-06-14 (amended 2026-07-02, 2026-07-03, 2026-07-05, 2026-07-09, 2026-07-17)\
+**Date**: 2026-06-14 (amended 2026-07-02, 2026-07-03, 2026-07-05, 2026-07-09, 2026-07-17, 2026-08-01)\
 **Authors**: khive maintainers
 **Amended by**: [ADR-122](ADR-122-email-outbound-delivery.md) (email outbound
 delivery now runs as an externally linked supervised component)\
@@ -20,7 +21,38 @@ ADR-108 (Git Write Surface -- hardened shell-out argv pattern reused by this ame
 statement; its SessionStore design was not carried forward\
 **Related issues**: #112 (khive-channel umbrella), #113 (Telegram adapter), #114 (email adapter),
 #448 (inbound header spoofing -- resolved by this amendment), #449 (IMAP UID progress -- resolved
-by the 2026-07-09 amendment)
+by the 2026-07-09 amendment), #1499 (inbox long poll -- resolved by the 2026-08-01 amendment)
+
+## Amendment 2026-08-01 -- Bounded inbox long poll
+
+Channel ingestion remains a gated `comm.ingest` dispatch and durable note write.
+After a successful, non-deduplicated insert, the comm handler now publishes a
+process-local wake signal; the channel loop does not interpret the response or
+own a second signaling path. This places the signal at the only point that knows
+both that the insert committed and that it was not suppressed by the durable
+`external_id` dedup constraint.
+
+`comm.inbox(wait_ms=N)` with `1 <= N <= 30000` first runs its normal scoped
+query. It returns immediately on a match, or waits on the signal until the
+deadline and re-runs the same query after each wake. Omission or zero preserves
+the immediate behavior, and `limit=0` never waits. The response shape is
+unchanged. `comm.send` and `comm.reply` publish the same signal after their
+successful atomic dual-writes, so the public long poll covers every comm-owned
+message creation path, not only external adapters.
+
+The signal is owned by the immutable `CommPack` instance constructed by
+`PackFactory::create(runtime)`. No post-construction injection is needed: both
+the waiting `comm.inbox` handler and the publishing write handlers already run
+through that instance. A generation counter paired with `tokio::sync::Notify`
+prevents a commit between query and waiter registration from being lost.
+
+This is not transport delivery state, cross-process pubsub, or an authorization
+boundary. The signal is payload-free and may wake calls for unrelated actors or
+filters; every wake re-runs the ordinary ADR-057/namespace-scoped database query
+and continues waiting if it is still empty. Durable storage remains authoritative,
+and a timeout-edge final query observes commits that arrive without this process's
+signal. The amendment changes wake latency only; channel lifecycle, dedup,
+checkpointing, and gate ownership are unchanged.
 
 ## Amendment 2026-07-02 -- Inbound authentication hardening
 

--- a/docs/adr/ADR-056-channel-transport-layer.md
+++ b/docs/adr/ADR-056-channel-transport-layer.md
@@ -51,8 +51,10 @@ boundary. The signal is payload-free and may wake calls for unrelated actors or
 filters; every wake re-runs the ordinary ADR-057/namespace-scoped database query
 and continues waiting if it is still empty. Durable storage remains authoritative,
 and a timeout-edge final query observes commits that arrive without this process's
-signal. The amendment changes wake latency only; channel lifecycle, dedup,
-checkpointing, and gate ownership are unchanged.
+signal when they are visible before that query takes its storage snapshot; a commit
+landing after the snapshot is left to the caller's next request. The amendment
+changes wake latency only; channel lifecycle, dedup, checkpointing, and gate
+ownership are unchanged.
 
 ## Amendment 2026-07-02 -- Inbound authentication hardening
 

--- a/docs/guide/api-reference.md
+++ b/docs/guide/api-reference.md
@@ -1220,13 +1220,16 @@ request(ops="comm.delivered(id=\"<full-outbound-uuid>\")")
 
 ### `comm.inbox` — Assertive
 
-List and page through filtered inbound messages for the caller.
+List and page through filtered inbound messages for the caller. With `wait_ms`,
+an initially empty fully filtered page waits for a newly committed matching
+message and otherwise returns at the deadline.
 
 | Param                | Type    | Required | Notes                                                                     |
 | -------------------- | ------- | -------- | ------------------------------------------------------------------------- |
 | `limit`              | integer | no       | Default 20, max 200.                                                      |
 | `offset`             | integer | no       | Default 0; offset after every supplied filter.                            |
 | `status`             | string  | no       | `unread` (default)\|`read`\|`all`.                                        |
+| `wait_ms`            | integer | no       | Long-poll only when the initial page is empty; default 0, max 30,000.     |
 | `from_actor`         | string  | no       | Exact sender; mutually exclusive with `from_prefix`.                      |
 | `from_prefix`        | string  | no       | Sender prefix; mutually exclusive with `from_actor`.                      |
 | `exclude_from_actor` | string  | no       | Exclude an exact sender actor label.                                      |
@@ -1238,7 +1241,11 @@ List and page through filtered inbound messages for the caller.
 ```
 request(ops="comm.inbox(limit=10)")
 request(ops="comm.inbox(status=\"all\", content_contains=\"timeout\", offset=200)")
+request(ops="comm.inbox(limit=10, wait_ms=30000)")
 ```
+
+The long-poll wake is process-local and carries no payload. Every wake re-runs
+the same scoped query, and the response shape is identical to an immediate inbox call.
 
 Every returned message uses the hyphenated full UUID for `id`, so the value is
 always accepted unchanged by `comm.read`, `comm.reply`, or `comm.thread`, even

--- a/docs/guide/communication.md
+++ b/docs/guide/communication.md
@@ -84,6 +84,7 @@ the structured error and therefore does not know the server-generated UUID.
 | `limit`              | integer | no       | Default 20, max 200.                                                         |
 | `offset`             | integer | no       | Default 0; offset in the fully-filtered newest-first result set.             |
 | `status`             | string  | no       | `"unread"` (default) \| `"read"` \| `"all"`.                                 |
+| `wait_ms`            | integer | no       | Long-poll only when the initial page is empty; default 0, max 30,000.        |
 | `from_actor`         | string  | no       | Exact sender; mutually exclusive with `from_prefix`.                         |
 | `from_prefix`        | string  | no       | Sender prefix; mutually exclusive with `from_actor`.                         |
 | `exclude_from_actor` | string  | no       | Exclude an exact sender actor label.                                         |
@@ -96,6 +97,7 @@ the structured error and therefore does not know the server-generated UUID.
 request(ops="comm.inbox(limit=10)")
 request(ops="comm.inbox(status=\"all\")")
 request(ops="comm.inbox(status=\"all\", content_contains=\"timeout\", since=\"2026-07-31T00:00:00Z\")")
+request(ops="comm.inbox(limit=10, wait_ms=30000)")
 ```
 
 Responses include `offset`, `has_more`, and `next_offset`. Repeat the same call
@@ -103,6 +105,12 @@ with `offset=<next_offset>` until `next_offset` is null to enumerate every
 matching message without changing its read state. Filters are ANDed and offsets
 apply after all filters. Time bounds use the always-present top-level
 `created_at`, not optional transport `sent_at` metadata.
+
+Long-polling preserves that paginated response shape and every actor/status/
+sender/time/text filter, including the requested offset. Existing matches
+return immediately. A new committed message wakes the call and causes the full
+filtered query to run again; unrelated messages cannot leak through or end the
+wait early. `limit=0` remains immediate.
 
 ### Read
 

--- a/marketplace/khive/skills/comm/SKILL.md
+++ b/marketplace/khive/skills/comm/SKILL.md
@@ -56,6 +56,7 @@ request(ops="comm.send(to=\"lambda:leo\", subject=\"CI status\", content=\"all 7
 
 ```
 request(ops="comm.inbox(limit=10)")
+request(ops="comm.inbox(limit=10, wait_ms=30000)")
 ```
 
 The fields you triage on are surfaced at the **top level** — no digging into `properties`:
@@ -79,6 +80,11 @@ messages read. Use `content_contains` when automated notifications omit `subject
 exact/prefix/exclusion, RFC3339 `since`/`before`, and subject/content substring filters can be
 combined. Mark writes are best-effort and cross-message updates are not atomic: inspect every
 result's `read`/`mark_error`, and re-issue failures later.
+
+Use `wait_ms` (maximum 30,000) when you need the next message promptly without
+repeated polling. It waits only if the fully filtered page is initially empty
+and returns the ordinary paginated inbox response as soon as a matching
+message commits.
 
 ### 4. Reply to thread, don't start a new one
 


### PR DESCRIPTION
> AI-assisted contribution: Codex prepared this change and PR description.

## Summary

- add optional, bounded `wait_ms` long-poll semantics to `comm.inbox` while preserving the existing filtering and pagination response shapes
- wake blocked inbox calls after successful local sends, replies, and non-deduplicated ingests using a generation-counted process-local signal that does not lose notifications between query and wait
- make the deadline edge race-safe with a final generation-aware query, cap waits at 30 seconds, and document process-local versus cross-process behavior
- add concurrent-ingest, filtering, timeout, cap, zero-wait, missed-wakeup, and deadline-crossing regressions

Closes #1499.

## Test plan

- [x] `cargo test --manifest-path crates/Cargo.toml --workspace`
- [x] `cargo check --manifest-path crates/Cargo.toml --workspace`
- [x] `cargo clippy --manifest-path crates/Cargo.toml --workspace --all-targets -- -D warnings`
- [x] `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- [x] `RUSTDOCFLAGS=-Dwarnings cargo doc --manifest-path crates/Cargo.toml --workspace --no-deps`

All commands passed at `0a0c7e515b051f243eb1d3a73928c35bb2857527` after rebasing onto current `main` (`a152ead3e577b8c01b03024687fdb66d94a00cac`).

## ADR

- update ADR-040 with the public `wait_ms` contract and response-shape guarantees
- update ADR-056 with signal ownership, generation semantics, publication points, deadline behavior, and the cross-process boundary

## AI-assisted contribution checklist

- [x] Every claim in this PR description matches the actual diff
- [x] Any agent-authored comment / PR body starts with an attribution line
- [x] Full workspace behavior, lint, formatting, and documentation gates passed
- [x] No entity, note, edge, namespace, delivery, or threading semantics changed

## Out of scope

- cross-process push notification; external writers are observed by the final deadline query rather than waking the process-local signal immediately
- changing channel transport poll intervals
- changing inbox pagination or filter semantics
