### PR TITLE
perf(reindex): reduce canonical embedding overhead

### DIFF
--- a/crates/khive-db/docs/api/vectors.md
+++ b/crates/khive-db/docs/api/vectors.md
@@ -65,13 +65,19 @@ transaction or savepoint and its rollback semantics, so this can run equally
 inside a plain `Connection`, an `unchecked_transaction()`, or a named
 `SAVEPOINT`.
 
-Before deleting, the helper compares the stored row's complete ANN log
-identity (`namespace`, `embedding_model`, `kind`, and `field`) with the
-incoming identity. When they differ, it copies the stored row's identity into
-`ann_write_log` as a `delete`, then deletes the vector and records the incoming
-row as an `upsert`. All three writes share the caller's transaction/savepoint,
-so they commit or roll back together. A same-identity replacement emits only
-the incoming `upsert`; it does not create redundant delete/upsert churn.
+The helper first attempts an identity-constrained delete using `subject_id`,
+`namespace`, `embedding_model`, `kind`, and `field`. That delete is the common
+steady-state path: an affected row proves the old and incoming ANN identities
+match, so the incoming `upsert` log is sufficient and no delete-log
+`INSERT ... SELECT` is prepared. This reduces the common replacement from four
+DML statements to three.
+
+If the constrained delete affects no row, the helper runs the delete-log scan
+by `subject_id`. A returned row carries a different stored identity, so the
+helper logs that identity as `delete` before removing it; no returned row means
+the subject is new and needs no second delete. Cross-identity repair therefore
+retains the original delete-then-upsert log order. Every statement shares the
+caller's transaction/savepoint, so all of them commit or roll back together.
 
 `failpoint_flag`, when `Some` in a `cfg(test)` build, is checked between the
 DELETE and the INSERT so tests can force an error at that exact point and

--- a/crates/khive-db/src/stores/vectors.rs
+++ b/crates/khive-db/src/stores/vectors.rs
@@ -421,25 +421,32 @@ fn replace_vector_row_dml(
         ));
     }
 
-    // Vector tables use subject_id as their primary key. Replace by that same
-    // identity so a successful write also repairs stale namespace metadata.
+    // Vector tables use subject_id as their primary key. Delete the common
+    // same-identity row directly; its incoming upsert log is sufficient. Only
+    // the metadata-repair path needs to discover and log the old ANN identity.
     // The caller's transaction/savepoint restores the prior row on failure.
     let subject_id = row.subject_id.to_string();
-    log_vector_deletes(
-        conn,
-        table,
-        "subject_id = ?1 AND NOT (namespace = ?2 AND embedding_model = ?3 \
-         AND kind = ?4 AND field = ?5)",
-        &[
+    let delete_same_identity_sql = format!(
+        "DELETE FROM {table} WHERE subject_id = ?1 AND namespace = ?2 \
+         AND embedding_model = ?3 AND kind = ?4 AND field = ?5"
+    );
+    let deleted_same_identity = conn.execute(
+        &delete_same_identity_sql,
+        rusqlite::params![
             &subject_id,
-            &row.namespace,
-            &row.embedding_model,
-            &row.kind,
-            &row.field,
+            row.namespace,
+            row.embedding_model,
+            row.kind,
+            row.field
         ],
     )?;
-    let del_sql = format!("DELETE FROM {table} WHERE subject_id = ?1");
-    conn.execute(&del_sql, rusqlite::params![subject_id])?;
+    if deleted_same_identity == 0 {
+        let logged = log_vector_deletes(conn, table, "subject_id = ?1", &[&subject_id])?;
+        if logged > 0 {
+            let delete_prior_identity_sql = format!("DELETE FROM {table} WHERE subject_id = ?1");
+            conn.execute(&delete_prior_identity_sql, rusqlite::params![&subject_id])?;
+        }
+    }
 
     // Failpoint: fires only in cfg(test) when the guard is active. DELETE has
     // already run; if the caller's rollback (transaction or SAVEPOINT) is
@@ -463,7 +470,7 @@ fn replace_vector_row_dml(
     conn.execute(
         &ins_sql,
         rusqlite::params![
-            row.subject_id.to_string(),
+            &subject_id,
             row.namespace,
             row.kind,
             row.field,
@@ -482,7 +489,7 @@ fn replace_vector_row_dml(
             row.embedding_model,
             row.kind,
             row.field,
-            row.subject_id.to_string()
+            &subject_id
         ],
     )?;
 
@@ -492,20 +499,20 @@ fn replace_vector_row_dml(
 /// Log `'delete'` rows into `ann_write_log` for every vector row in `table`
 /// matching `where_clause` (a predicate over the vec0 table's own columns).
 /// Must run in the same transaction as — and before — the corresponding
-/// `DELETE`, so the logged set is exactly the deleted set.
+/// `DELETE`, so the logged set is exactly the deleted set. Returns the number
+/// of identities logged.
 fn log_vector_deletes(
     conn: &rusqlite::Connection,
     table: &str,
     where_clause: &str,
     params: &[&dyn rusqlite::ToSql],
-) -> Result<(), rusqlite::Error> {
+) -> Result<usize, rusqlite::Error> {
     let sql = format!(
         "INSERT INTO ann_write_log (namespace, embedding_model, kind, field, subject_id, op) \
          SELECT namespace, embedding_model, kind, field, subject_id, 'delete' \
          FROM {table} WHERE {where_clause}"
     );
-    conn.execute(&sql, params)?;
-    Ok(())
+    conn.execute(&sql, params)
 }
 
 /// DML-only multi-chunk subject deletion shared by both the legacy
@@ -2732,11 +2739,13 @@ mod delete_subjects_atomic_tests {
 
 #[cfg(all(test, feature = "vectors"))]
 mod atomic_replace_tests {
+    use std::sync::atomic::{AtomicUsize, Ordering};
     use std::sync::Arc;
 
     use khive_storage::types::VectorRecord;
     use khive_storage::VectorStore;
     use khive_types::SubstrateKind;
+    use rusqlite::hooks::{AuthAction, AuthContext, Authorization};
     use uuid::Uuid;
 
     use super::*;
@@ -3276,6 +3285,26 @@ mod atomic_replace_tests {
             .expect("initial insert");
         clear_ann_write_log(&pool);
 
+        let prepared_log_inserts = Arc::new(AtomicUsize::new(0));
+        {
+            let prepared_log_inserts = Arc::clone(&prepared_log_inserts);
+            pool.try_writer()
+                .expect("pool writer")
+                .conn()
+                .authorizer(Some(move |context: AuthContext<'_>| {
+                    if matches!(
+                        context.action,
+                        AuthAction::Insert {
+                            table_name: "ann_write_log"
+                        }
+                    ) {
+                        prepared_log_inserts.fetch_add(1, Ordering::SeqCst);
+                    }
+                    Authorization::Allow
+                }))
+                .expect("install statement authorizer");
+        }
+
         store
             .update(
                 id,
@@ -3292,6 +3321,16 @@ mod atomic_replace_tests {
             vec![ann_write_log_row(ns, model_key, "upsert")],
             "same-identity replacement must not emit delete/upsert churn"
         );
+        assert_eq!(
+            prepared_log_inserts.load(Ordering::SeqCst),
+            1,
+            "the common replacement path must prepare only the required upsert log statement"
+        );
+        pool.try_writer()
+            .expect("pool writer")
+            .conn()
+            .authorizer(None::<fn(AuthContext<'_>) -> Authorization>)
+            .expect("remove statement authorizer");
     }
 
     // True ROLLBACK TO SAVEPOINT sentinels (failpoint-driven) — see

--- a/crates/khive-runtime/src/atomic_message.rs
+++ b/crates/khive-runtime/src/atomic_message.rs
@@ -35,6 +35,8 @@
 //! version of `dual_write_message` used to document is closed by
 //! construction.
 
+use std::sync::Arc;
+
 use serde_json::Value;
 use uuid::Uuid;
 
@@ -149,13 +151,15 @@ fn maybe_inject_vector_failure(_namespace: &str, _label: &str) -> Option<PlanSta
     None
 }
 
-/// DELETE-then-INSERT-then-log statements for one (note, model) vector row,
-/// replaying `khive-db::stores::vectors::replace_vector_row_dml`'s DML shape
-/// as plain [`PlanStatement`]s rather than a live `rusqlite::Connection`
-/// call — the same technique `atomic_prepare::push_index_purge_statements`
-/// uses for delete. Unguarded: same convention as the FTS-insert statement
-/// in `atomic_prepare::prepare_add_note` (the row's existence guard is
-/// carried by the plan's primary note-row statement, applied first).
+/// DELETE-then-INSERT-then-log statements for one (note, model) vector row.
+/// This static atomic plan cannot branch on an identity-constrained DELETE's
+/// affected-row count, so it retains the general delete-log scan used before
+/// `khive-db::stores::vectors::replace_vector_row_dml` gained its live-
+/// connection fast path. It uses the same plain-[`PlanStatement`] technique
+/// as `atomic_prepare::push_index_purge_statements`. Unguarded: same
+/// convention as the FTS-insert statement in
+/// `atomic_prepare::prepare_add_note` (the row's existence guard is carried by
+/// the plan's primary note-row statement, applied first).
 #[allow(clippy::too_many_arguments)]
 fn vector_insert_statements(
     table: &str,
@@ -307,15 +311,21 @@ pub async fn create_notes_atomic_with_report(
         let usage_ctx = crate::usage::current();
         let mut join_set = tokio::task::JoinSet::new();
         for (note_idx, (spec, note)) in specs.iter().zip(notes.iter()).enumerate() {
-            let text = crate::curation::note_embedding_text(note);
+            // Spawned tasks need owned text; share one content allocation across
+            // every model instead of cloning the note body per task.
+            let text: Arc<str> = Arc::from(crate::curation::note_embedding_text_ref(note));
             for (model_idx, model_name) in embed_model_names.iter().enumerate() {
                 let rt = runtime.clone();
                 let token = spec.token.clone();
                 let name = model_name.clone();
-                let text = text.clone();
+                let text = Arc::clone(&text);
                 let ctx = usage_ctx.clone();
                 join_set.spawn(async move {
-                    let fut = rt.embed_document_with_model_outcome_for_token(&token, &name, &text);
+                    let fut = rt.embed_document_with_model_outcome_for_token(
+                        &token,
+                        &name,
+                        text.as_ref(),
+                    );
                     let result = match ctx {
                         Some(ctx) => crate::usage::scope(ctx, fut).await,
                         None => fut.await,

--- a/crates/khive-runtime/src/curation.rs
+++ b/crates/khive-runtime/src/curation.rs
@@ -1183,7 +1183,7 @@ impl KhiveRuntime {
                 .embed_document_with_model_outcome_for_token(
                     token,
                     model_name,
-                    &note_embedding_text(note),
+                    note_embedding_text_ref(note),
                 )
                 .await
             {
@@ -1564,7 +1564,13 @@ pub fn entity_embedding_text(entity: &Entity) -> String {
 /// Build the canonical text embedded for a note when no explicit bounded
 /// embedding prefix was supplied at creation time.
 pub fn note_embedding_text(note: &Note) -> String {
-    note.content.clone()
+    note_embedding_text_ref(note).to_owned()
+}
+
+/// Borrow the canonical note embedding text for runtime paths that do not
+/// require ownership.
+pub(crate) fn note_embedding_text_ref(note: &Note) -> &str {
+    &note.content
 }
 
 /// Build the `TextDocument` for an entity. This is the single source of truth for
@@ -2842,6 +2848,20 @@ mod tests {
             .map(|index| char::from(ALPHANUMERIC[(index * 17 + 11) % ALPHANUMERIC.len()]))
             .collect();
         format!("secret value: {candidate}")
+    }
+
+    #[test]
+    fn note_embedding_text_ref_borrows_stored_content() {
+        let note = Note::new("embedding-borrow", "observation", "borrow this content");
+        let text = note_embedding_text_ref(&note);
+
+        assert_eq!(text, note.content.as_str());
+        assert!(
+            std::ptr::eq(text, note.content.as_str()),
+            "internal canonical note text must borrow instead of cloning"
+        );
+        let owned: String = note_embedding_text(&note);
+        assert_eq!(owned.as_str(), note.content.as_str());
     }
 
     async fn restore_edge_preimage(

--- a/crates/khive-runtime/src/operations.rs
+++ b/crates/khive-runtime/src/operations.rs
@@ -45,7 +45,7 @@ use crate::atomic_plan::{
     AddEntityPlan, AffectedRowGuard, DeletePlan, PlanStatement, PostCommitEffect,
 };
 use crate::atomic_runner::{run_atomic_unit, AtomicOpFailure, AtomicOpPlan, AtomicRunOutcome};
-use crate::curation::{entity_fts_document, note_embedding_text, note_fts_document};
+use crate::curation::{entity_fts_document, note_embedding_text_ref, note_fts_document};
 use crate::error::{GuardedWriteFailure, RuntimeError, RuntimeResult};
 use crate::runtime::{KhiveRuntime, NamespaceToken};
 
@@ -3199,7 +3199,7 @@ impl KhiveRuntime {
                 .embed_document_with_model_outcome_for_token(
                     token,
                     model_name,
-                    &note_embedding_text(&note),
+                    note_embedding_text_ref(&note),
                 )
                 .await
             {
@@ -3405,8 +3405,8 @@ impl KhiveRuntime {
         // capped override when present, otherwise the full stored content.
         // FTS indexing above always used the full `note.content` — this cap
         // affects only the vector-embedding input.
-        let canonical_embed_text = note_embedding_text(&note);
-        let embed_text: &str = embedding_content.unwrap_or(&canonical_embed_text);
+        let canonical_embed_text = note_embedding_text_ref(&note);
+        let embed_text = embedding_content.unwrap_or(canonical_embed_text);
 
         let mut embedding_report = crate::retrieval::EmbeddingTruncationReport::default();
         if embed_model_names.len() == 1 {
@@ -3485,17 +3485,23 @@ impl KhiveRuntime {
             // Multi-model path: embed with each model in parallel via spawned tasks,
             // then insert one VectorRecord per model.
             let rt_clone = self.clone();
-            let content_owned = embed_text.to_string();
+            // JoinSet tasks require owned text; an Arc keeps this to one
+            // content-sized allocation rather than one clone per model.
+            let content_owned: std::sync::Arc<str> = std::sync::Arc::from(embed_text);
             let usage_ctx = crate::usage::current();
             let mut join_set = tokio::task::JoinSet::new();
             for (idx, model_name) in embed_model_names.iter().enumerate() {
                 let rt = rt_clone.clone();
-                let text = content_owned.clone();
+                let text = std::sync::Arc::clone(&content_owned);
                 let name = model_name.clone();
                 let ctx = usage_ctx.clone();
                 let token = (*token).clone();
                 join_set.spawn(async move {
-                    let fut = rt.embed_document_with_model_outcome_for_token(&token, &name, &text);
+                    let fut = rt.embed_document_with_model_outcome_for_token(
+                        &token,
+                        &name,
+                        text.as_ref(),
+                    );
                     let result = match ctx {
                         Some(ctx) => crate::usage::scope(ctx, fut).await,
                         None => fut.await,

--- a/crates/kkernel/src/reindex.rs
+++ b/crates/kkernel/src/reindex.rs
@@ -17,7 +17,10 @@ use uuid::Uuid;
 
 use khive_mcp::serve::{resolve_runtime_config, RuntimeConfigInputs};
 use khive_runtime::retrieval::EmbeddingTruncationReport;
-use khive_runtime::{entity_fts_document, note_fts_document, KhiveRuntime, Namespace};
+use khive_runtime::{
+    entity_embedding_text, entity_fts_document, note_embedding_text, note_fts_document,
+    KhiveRuntime, Namespace,
+};
 use khive_storage::entity::Entity;
 use khive_storage::error::StorageError;
 use khive_storage::note::Note;
@@ -245,6 +248,18 @@ impl ReindexReport {
             || self.knowledge_sections_failed > 0
             || self.epoch_bump_failed
     }
+}
+
+fn entity_has_embedding_text(entity: &Entity) -> bool {
+    !entity.name.trim().is_empty()
+        || entity
+            .description
+            .as_deref()
+            .is_some_and(|description| !description.trim().is_empty())
+}
+
+fn note_has_embedding_text(note: &Note) -> bool {
+    !note.content.trim().is_empty()
 }
 
 /// Embed `staged` with every model in `model_names` and store one vector record
@@ -550,32 +565,36 @@ pub async fn run_reindex(args: ReindexArgs) -> Result<()> {
                 break;
             }
 
-            let mut staged: Vec<(Uuid, String)> = Vec::with_capacity(n);
-            for entity in &batch {
-                let text = match &entity.description {
-                    Some(d) if !d.is_empty() => format!("{} {}", entity.name, d),
-                    _ => entity.name.clone(),
-                };
-                if !text.trim().is_empty() {
-                    staged.push((entity.id, text));
+            let embeddable = if model_names.is_empty() {
+                batch
+                    .iter()
+                    .filter(|entity| entity_has_embedding_text(entity))
+                    .count()
+            } else {
+                let mut staged = Vec::with_capacity(n);
+                for entity in &batch {
+                    if entity_has_embedding_text(entity) {
+                        staged.push((entity.id, entity_embedding_text(entity)));
+                    }
                 }
-            }
 
-            if !staged.is_empty() {
-                errors_skipped += embed_and_store_batch(
-                    &rt,
-                    &token,
-                    &model_names,
-                    &ns_str,
-                    &staged,
-                    SubstrateKind::Entity,
-                    "entity.body",
-                    drop_existing,
-                    &mut truncation_by_model,
-                )
-                .await;
-                entities_processed += staged.len() as u64;
-            }
+                if !staged.is_empty() {
+                    errors_skipped += embed_and_store_batch(
+                        &rt,
+                        &token,
+                        &model_names,
+                        &ns_str,
+                        &staged,
+                        SubstrateKind::Entity,
+                        "entity.body",
+                        drop_existing,
+                        &mut truncation_by_model,
+                    )
+                    .await;
+                }
+                staged.len()
+            };
+            entities_processed += embeddable as u64;
 
             // FTS backfill: index every entity in this batch regardless of whether
             // it had content to embed. Mirrors the upsert_document call in
@@ -607,29 +626,36 @@ pub async fn run_reindex(args: ReindexArgs) -> Result<()> {
                 break;
             }
 
-            let mut staged: Vec<(Uuid, String)> = Vec::with_capacity(n);
-            for note in &batch {
-                let text = note.content.clone();
-                if !text.trim().is_empty() {
-                    staged.push((note.id, text));
+            let embeddable = if model_names.is_empty() {
+                batch
+                    .iter()
+                    .filter(|note| note_has_embedding_text(note))
+                    .count()
+            } else {
+                let mut staged = Vec::with_capacity(n);
+                for note in &batch {
+                    if note_has_embedding_text(note) {
+                        staged.push((note.id, note_embedding_text(note)));
+                    }
                 }
-            }
 
-            if !staged.is_empty() {
-                errors_skipped += embed_and_store_batch(
-                    &rt,
-                    &token,
-                    &model_names,
-                    &ns_str,
-                    &staged,
-                    SubstrateKind::Note,
-                    "note.content",
-                    drop_existing,
-                    &mut truncation_by_model,
-                )
-                .await;
-                notes_processed += staged.len() as u64;
-            }
+                if !staged.is_empty() {
+                    errors_skipped += embed_and_store_batch(
+                        &rt,
+                        &token,
+                        &model_names,
+                        &ns_str,
+                        &staged,
+                        SubstrateKind::Note,
+                        "note.content",
+                        drop_existing,
+                        &mut truncation_by_model,
+                    )
+                    .await;
+                }
+                staged.len()
+            };
+            notes_processed += embeddable as u64;
 
             // FTS backfill: index every note in this batch regardless of whether
             // it had content to embed. Mirrors the upsert_document call in
@@ -1258,6 +1284,32 @@ mod tests {
     use clap::Parser;
     use khive_storage::types::{SqlStatement, SqlValue};
     use serial_test::serial;
+
+    #[test]
+    fn allocation_free_embedding_eligibility_matches_canonical_text() {
+        let entities = [
+            Entity::new("eligibility", "concept", "named"),
+            Entity::new("eligibility", "concept", "").with_description("description only"),
+            Entity::new("eligibility", "concept", "   ").with_description("\t"),
+        ];
+        for entity in &entities {
+            assert_eq!(
+                entity_has_embedding_text(entity),
+                !entity_embedding_text(entity).trim().is_empty()
+            );
+        }
+
+        let notes = [
+            Note::new("eligibility", "observation", "content"),
+            Note::new("eligibility", "observation", "  \n\t"),
+        ];
+        for note in &notes {
+            assert_eq!(
+                note_has_embedding_text(note),
+                !note_embedding_text(note).trim().is_empty()
+            );
+        }
+    }
 
     #[tokio::test]
     async fn test_reindex_invalidates_vamana_snapshots() {


### PR DESCRIPTION
> AI-assisted contribution: Codex prepared this change and PR description.

## Summary

- avoid constructing canonical embedding strings during FTS-only reindex runs while preserving embeddable-record accounting
- keep the public owned `note_embedding_text` API compatible, add an internal borrowed form, and share one `Arc<str>` across multi-model spawned embedding tasks instead of cloning content per model
- make same-identity vector replacement use an identity-constrained delete fast path, reserving the delete-log identity scan for actual metadata repair
- add parity, allocation/borrowing, same-identity statement-count, mismatch-repair, and rollback coverage

Closes #1338.

## Test plan

- [x] `cargo test --manifest-path crates/Cargo.toml --workspace`
- [x] `cargo check --manifest-path crates/Cargo.toml --workspace`
- [x] `cargo clippy --manifest-path crates/Cargo.toml --workspace --all-targets -- -D warnings`
- [x] `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- [x] `RUSTDOCFLAGS=-Dwarnings cargo doc --manifest-path crates/Cargo.toml --workspace --no-deps`

All commands passed at `83f827aeaff2ec4556ce340bb9e0976bc8835eb3` on current `main` (`a152ead3e577b8c01b03024687fdb66d94a00cac`).

## ADR

n/a — this removes avoidable allocation and probe work without changing the embedding text, vector identity, transaction, or public API contracts. The vector API documentation is updated to describe the optimized DML path.

## AI-assisted contribution checklist

- [x] Every claim in this PR description matches the actual diff
- [x] Any agent-authored comment / PR body starts with an attribution line
- [x] Full workspace behavior, lint, formatting, and documentation gates passed
- [x] Existing public helper signatures and vector rollback/log ordering remain covered

## Out of scope

- changing canonical embedding content or truncation behavior
- changing FTS document shape or reindex result accounting
- changing vector primary keys, ANN identity, or transaction boundaries
