### PR TITLE
docs(adr): reword ADR-121 boundary line to conform to the identifier ban

### DIFF
--- a/docs/adr/ADR-121-attachments-first-class.md
+++ b/docs/adr/ADR-121-attachments-first-class.md
@@ -109,7 +109,7 @@ a paper delivered through a conversation is content worth naming, which makes it
 message note `annotates` it. The test: "is this byte payload another form of what this record
 itself says, or an independent thing?" Text that fits a text column stays in the text column;
 attachments are for bytes that do not belong there. The dividing line is modality and size,
-never importance.
+not significance.
 
 External references are not attachments. A URL (an arXiv link, a web page) lives in record
 properties as it does today; the attachment map holds only content the store physically holds.


### PR DESCRIPTION
The khive-contract suite's `test_no_importance_identifiers_in_repo` (ADR-021 §2 rename enforcement) scans the whole repository for the banned identifier and fails on ADR-121 line 112, where the word appears in ordinary prose ("The dividing line is modality and size, never importance."). The line was introduced by the 2026-07-31 ADR corpus sync.

This rewords the sentence to "not significance." — same meaning, conformant with the repo-wide ban, no test or allowlist change.

Note: current CI does not catch this because the test skips when ripgrep is not present on the runner; a separate issue will track that silent-skip gap.