### PR TITLE
perf(session): bound cold mirror polling

### DIFF
--- a/crates/khive-pack-session/README.md
+++ b/crates/khive-pack-session/README.md
@@ -49,7 +49,10 @@ actively growing transcripts directly, and samples cold transcripts through
 fixed round-robin budgets. Quiet-tick metadata work therefore stays bounded as
 the historical transcript corpus grows; directory changes prioritize their
 cold files, with the ordinary bounded sweep covering filesystems where append
-does not update parent-directory mtime.
+does not update parent-directory mtime. The priority ordering is bounded but
+not fair under continuous directory churn: repeated changes can keep the
+priority queue ahead of the ordinary cold sweep, while productive cold-file
+metadata probes remain capped at 256 per tick.
 
 ## Where this sits
 

--- a/crates/khive-pack-session/README.md
+++ b/crates/khive-pack-session/README.md
@@ -44,6 +44,12 @@ and billing are deferred; see
 The session mirror (transcript parsing and ingestion into `session_messages`)
 is a separate, already-shipped concern — see
 [ADR-080 §6](https://github.com/ohdearquant/khive/blob/main/docs/adr/ADR-080-session-pack-oss-storage-mechanism.md#6-the-session-mirror-amendment-2026-07-02).
+After its startup discovery pass, the mirror caches directory listings, polls
+actively growing transcripts directly, and samples cold transcripts through
+fixed round-robin budgets. Quiet-tick metadata work therefore stays bounded as
+the historical transcript corpus grows; directory changes prioritize their
+cold files, with the ordinary bounded sweep covering filesystems where append
+does not update parent-directory mtime.
 
 ## Where this sits
 

--- a/crates/khive-pack-session/src/mirror/ingest.rs
+++ b/crates/khive-pack-session/src/mirror/ingest.rs
@@ -155,6 +155,48 @@ pub async fn mirror_file(
     .await
 }
 
+/// Dispatch-loop variant of [`mirror_file`]: identical, except that a pass
+/// which consumed bytes but parsed no events does NOT commit the cursor
+/// itself. The caller commits it via [`commit_empty_advance`] only when
+/// dispatch ends without any candidate inserting rows for the span. This
+/// keeps the empty advance's cursor commit atomic with respect to the
+/// candidate dispatch order: bytes are never skipped ahead of a later
+/// candidate that could parse them, and an interrupt between candidates
+/// cannot leave the cursor advanced past bytes no candidate inserted.
+pub async fn mirror_file_deferred(
+    runtime: &KhiveRuntime,
+    path: &Path,
+    start_offset: u64,
+    source: LineTailSource,
+    codex_session_id: Option<&str>,
+) -> Result<MirrorStats, RuntimeError> {
+    mirror_file_inner(
+        runtime,
+        path,
+        start_offset,
+        source,
+        codex_session_id,
+        MirrorLimits::production(),
+        false,
+    )
+    .await
+}
+
+/// Commit the cursor for an empty advance (bytes consumed, zero rows) that
+/// [`mirror_file_deferred`] deliberately left uncommitted. Call this only
+/// when dispatch for the span ends with no inserting candidate. The commit
+/// is a single `INSERT ... ON CONFLICT DO UPDATE` on the cursor row; on
+/// failure the error propagates and the in-memory offset is not applied, so
+/// the bytes are re-read (bounded, idempotent) on a later pass instead of
+/// being silently skipped.
+pub async fn commit_empty_advance(
+    runtime: &KhiveRuntime,
+    path: &Path,
+    new_offset: u64,
+) -> Result<(), RuntimeError> {
+    write_cursor_only(runtime, path, &None, new_offset).await
+}
+
 /// A single bounded read pass: at most `limits.max_bytes_per_pass` bytes and
 /// `limits.max_events_per_pass` parsed events, stopping on a line boundary.
 struct MirrorChunk {
@@ -360,6 +402,33 @@ async fn mirror_file_with_limits(
     codex_session_id: Option<&str>,
     limits: MirrorLimits,
 ) -> Result<MirrorStats, RuntimeError> {
+    mirror_file_inner(
+        runtime,
+        path,
+        start_offset,
+        source,
+        codex_session_id,
+        limits,
+        true,
+    )
+    .await
+}
+
+/// Implementation of [`mirror_file`]. When `commit_empty_advance` is false,
+/// a pass that consumed bytes but parsed no events does NOT commit the
+/// cursor — the dispatch loop commits it via [`commit_empty_advance`] only
+/// if no later candidate inserts rows for the same span (see
+/// `candidate_dispatch` in `service.rs`). When true (every non-dispatch
+/// caller and test), the cursor is committed immediately as before.
+async fn mirror_file_inner(
+    runtime: &KhiveRuntime,
+    path: &Path,
+    start_offset: u64,
+    source: LineTailSource,
+    codex_session_id: Option<&str>,
+    limits: MirrorLimits,
+    commit_empty_advance: bool,
+) -> Result<MirrorStats, RuntimeError> {
     let chunk =
         read_bounded_chunk(path, start_offset, source, codex_session_id, limits).map_err(|e| {
             RuntimeError::Internal(format!(
@@ -379,15 +448,22 @@ async fn mirror_file_with_limits(
     }
 
     if chunk.events.is_empty() {
-        // Apply cursor update even when there are no parseable events — e.g.
-        // a chunk made entirely of blank lines, unparseable lines, or
-        // skipped oversized lines — so we don't re-read the same bytes on
-        // the next call. `chunk.new_offset > start_offset` here (checked
-        // above), so real bytes were durably consumed even though
-        // `chunk.scanned` may be 0. A failure here must propagate — silently
-        // swallowing it would let the cursor and the already-consumed bytes
-        // drift apart.
-        write_cursor_only(runtime, path, &None, chunk.new_offset).await?;
+        // Bytes were consumed (`chunk.new_offset > start_offset` here,
+        // checked above) but nothing parsed — e.g. a chunk made entirely of
+        // blank lines, unparseable lines, or skipped oversized lines. With
+        // `commit_empty_advance`, apply the cursor update immediately so we
+        // don't re-read the same bytes on the next call. Without it (the
+        // dispatch loop), the commit is deferred to
+        // [`commit_empty_advance`], which the loop calls only when no later
+        // candidate inserted rows for the span — so the cursor never moves
+        // past bytes another provider candidate might still parse, and an
+        // interrupt between candidates cannot strand a committed empty
+        // advance ahead of unconsumed rows. A failure here must propagate —
+        // silently swallowing it would let the cursor and the
+        // already-consumed bytes drift apart.
+        if commit_empty_advance {
+            write_cursor_only(runtime, path, &None, chunk.new_offset).await?;
+        }
         return Ok(MirrorStats {
             inserted: 0,
             scanned: chunk.scanned,
@@ -911,6 +987,12 @@ async fn write_events_and_cursor_on_writer(
 /// Upsert the `session_mirror_cursor` row for `path` inside the open
 /// `atomic_unit` transaction — issues only the one cursor DML statement, no
 /// transaction control of its own.
+///
+/// The row is keyed by `path.to_string_lossy()` — the same lossy text
+/// that [`write_cursor_only`] and the mirror service's `delete_cursors`
+/// use for their DELETE, so an insert and a later delete target the same
+/// row even when the path is not valid UTF-8. Do not switch one side to a
+/// stricter keying without switching all three.
 async fn upsert_cursor_on_writer(
     writer: &mut dyn SqlWriter,
     path: &Path,
@@ -954,6 +1036,11 @@ async fn upsert_cursor_on_writer(
 /// but produced no parseable events, so the offset still advances past
 /// blank/unparseable content. A failure here must propagate — see
 /// `crates/khive-pack-session/docs/api/mirror-ingest.md#write-path-write_events_and_cursor-and-friends-adr-099-d5`.
+///
+/// The row is keyed by `path.to_string_lossy()`, the same lossy text used
+/// by [`upsert_cursor_on_writer`] (the insert path) and by the mirror
+/// service's `delete_cursors`, so insert and delete always target the same
+/// row even for non-UTF-8 paths.
 async fn write_cursor_only(
     runtime: &KhiveRuntime,
     path: &Path,
@@ -1642,6 +1729,77 @@ mod tests {
             offset, file_len,
             "all blank lines eventually consumed to EOF"
         );
+    }
+
+    /// Regression for the multi-candidate atomicity finding: the deferred
+    /// dispatch variant must NOT commit the cursor on an empty advance —
+    /// the commit is the dispatch loop's final step, vetoable until then.
+    #[tokio::test]
+    async fn deferred_empty_advance_leaves_cursor_uncommitted_until_commit_empty_advance() {
+        let (rt, _dir) = setup().await;
+
+        let mut file = NamedTempFile::new().expect("tmpfile");
+        for _ in 0..16 {
+            writeln!(file).unwrap(); // blank line: just "\n"
+        }
+        let path = file.path().to_path_buf();
+        let file_len = std::fs::metadata(&path).unwrap().len();
+
+        let stats = mirror_file_deferred(&rt, &path, 0, LineTailSource::ClaudeCode, None)
+            .await
+            .expect("deferred blank-line pass");
+        assert_eq!(stats.inserted, 0);
+        assert_eq!(
+            stats.new_offset, file_len,
+            "bytes were consumed off the file"
+        );
+        assert_eq!(
+            cursor_offset(&rt, &path.to_string_lossy()).await,
+            None,
+            "the deferred pass must not commit the cursor itself"
+        );
+
+        // Dispatch ends without an inserting candidate: the loop commits.
+        commit_empty_advance(&rt, &path, stats.new_offset)
+            .await
+            .expect("end-of-dispatch commit");
+        assert_eq!(
+            cursor_offset(&rt, &path.to_string_lossy()).await,
+            Some(file_len as i64),
+            "the commit lands exactly where the deferred pass consumed"
+        );
+    }
+
+    /// A deferred pass that DOES parse events commits rows and cursor in one
+    /// transaction, exactly like the immediate variant.
+    #[tokio::test]
+    async fn deferred_pass_with_events_commits_rows_and_cursor_together() {
+        let (rt, _dir) = setup().await;
+
+        let mut file = NamedTempFile::new().expect("tmpfile");
+        let session_id = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee";
+        for index in 0..3 {
+            writeln!(
+                file,
+                "{}",
+                user_line(&format!("u{index}"), session_id, "hello")
+            )
+            .unwrap();
+        }
+        let path = file.path().to_path_buf();
+        let file_len = std::fs::metadata(&path).unwrap().len();
+
+        let stats = mirror_file_deferred(&rt, &path, 0, LineTailSource::ClaudeCode, None)
+            .await
+            .expect("deferred event pass");
+        assert_eq!(stats.inserted, 3);
+        assert_eq!(stats.new_offset, file_len);
+        assert_eq!(
+            cursor_offset(&rt, &path.to_string_lossy()).await,
+            Some(file_len as i64),
+            "an inserting pass commits its cursor inside the same atomic unit"
+        );
+        assert_eq!(count_rows(&rt, "session_messages").await, 3);
     }
 
     #[tokio::test]

--- a/crates/khive-pack-session/src/mirror/ingest.rs
+++ b/crates/khive-pack-session/src/mirror/ingest.rs
@@ -162,7 +162,9 @@ pub async fn mirror_file(
 /// keeps the empty advance's cursor commit atomic with respect to the
 /// candidate dispatch order: bytes are never skipped ahead of a later
 /// candidate that could parse them, and an interrupt between candidates
-/// cannot leave the cursor advanced past bytes no candidate inserted.
+/// cannot leave the cursor advanced past bytes no candidate inserted. The
+/// service additionally vetoes that commit when ANY candidate errors during
+/// the pass, even if another candidate returned an empty advance.
 pub async fn mirror_file_deferred(
     runtime: &KhiveRuntime,
     path: &Path,
@@ -188,7 +190,8 @@ pub async fn mirror_file_deferred(
 /// is a single `INSERT ... ON CONFLICT DO UPDATE` on the cursor row; on
 /// failure the error propagates and the in-memory offset is not applied, so
 /// the bytes are re-read (bounded, idempotent) on a later pass instead of
-/// being silently skipped.
+/// being silently skipped. The service-level caller also vetoes this commit
+/// when ANY candidate errored in the dispatch pass.
 pub async fn commit_empty_advance(
     runtime: &KhiveRuntime,
     path: &Path,

--- a/crates/khive-pack-session/src/mirror/service.rs
+++ b/crates/khive-pack-session/src/mirror/service.rs
@@ -372,10 +372,22 @@ impl CandidateDispatch {
     ///
     /// An advance with zero inserts (a cursor-only pass over
     /// blank/unparseable/oversized lines, `mirror_file_with_limits`) is
-    /// recorded — the bytes really were consumed — but does NOT end
+    /// recorded — the bytes were consumed off the file — but does NOT end
     /// dispatch: under misconfigured overlapping roots, a wrong provider
     /// candidate could otherwise swallow bytes that a later, correct
-    /// provider candidate would have parsed into rows.
+    /// provider candidate would have parsed into rows. Its cursor commit is
+    /// deferred (`mirror_file_deferred`) and committed by the dispatch loop
+    /// only when no inserting candidate claims the span and no candidate
+    /// errored.
+    ///
+    /// Recording precedence: an advancing result (`new_offset >
+    /// start_offset`) always replaces a recorded non-advancing one, so a
+    /// later empty advance cannot be hidden behind an earlier no-progress
+    /// candidate — the in-memory offset must track the durably committed
+    /// cursor. Among advancing results the first recorded wins (an empty
+    /// advance never overwrites an inserting one, and an inserting
+    /// candidate ends dispatch anyway). A non-advancing success is
+    /// recorded only when nothing is recorded yet.
     fn record(
         &mut self,
         result: Result<ingest::MirrorStats, RuntimeError>,
@@ -387,9 +399,18 @@ impl CandidateDispatch {
                 true
             }
             Ok(stats) if stats.new_offset > start_offset => {
-                // Empty advance: cursor durably committed, but no rows were
-                // inserted — fall through to remaining candidates.
-                if self.stats.is_none() {
+                // Empty advance: bytes consumed, but no rows were inserted —
+                // fall through to remaining candidates. (The cursor commit is
+                // deferred to the end of dispatch by `mirror_file_deferred`;
+                // an inserting candidate or an erroring candidate can still
+                // veto it.) Always replace a recorded non-advancing result so
+                // the in-memory offset follows the furthest consumed byte;
+                // keep the first advancing record.
+                let recorded_advancing = self
+                    .stats
+                    .as_ref()
+                    .is_some_and(|recorded| recorded.new_offset > start_offset);
+                if !recorded_advancing {
                     self.stats = Some(stats);
                 }
                 false
@@ -699,11 +720,26 @@ impl DiscoveryIndex {
                     self.remove_directory_tree(&path, true);
                 }
                 Err(error) => {
-                    tracing::debug!(
-                        path = %path.display(),
-                        error = %error,
-                        "session mirror: directory metadata probe failed"
-                    );
+                    // A wedged directory must not stay invisible in debug
+                    // logs forever: count the failure toward the same
+                    // escalation as a failed refresh walk. NotFound is
+                    // excluded — it removes the tree above, not an error.
+                    let failures = self.record_refresh_failure(&path);
+                    if failures == DIRECTORY_REFRESH_FAILURES_BEFORE_WARN {
+                        tracing::warn!(
+                            path = %path.display(),
+                            error = %error,
+                            consecutive_failures = failures,
+                            "session mirror: directory metadata probe keeps failing"
+                        );
+                    } else {
+                        tracing::debug!(
+                            path = %path.display(),
+                            error = %error,
+                            consecutive_failures = failures,
+                            "session mirror: directory metadata probe failed"
+                        );
+                    }
                 }
             }
 
@@ -1130,11 +1166,41 @@ fn should_mark_cold(unchanged_polls: u8, modified: Option<SystemTime>, now: Syst
     }
 }
 
+/// Tally one dispatch pass's outcome against the file's error streak.
+/// Returns `true` exactly on the tick whose streak crosses
+/// `FILE_ERROR_POLLS_BEFORE_COLD` (the caller's one-shot warn).
+///
+/// A pass counts as an error poll when no candidate advanced the offset and
+/// at least one candidate errored — including mixed passes where one
+/// candidate reported a no-progress success (e.g. a whole-file size ceiling
+/// below the current file length) while another errored. Treating only
+/// all-error passes as error polls would let such a mixed file stay hot and
+/// be re-dispatched every tick forever.
+fn tally_dispatch_errors(
+    discovery: &mut DiscoveryIndex,
+    path: &Path,
+    advanced: bool,
+    had_errors: bool,
+) -> bool {
+    if advanced {
+        discovery.clear_error_polls(path);
+        return false;
+    }
+    had_errors && discovery.record_error_poll(path)
+}
+
 fn classify_entry(
     directory_kind: DirectoryKind,
     path: &Path,
     is_directory: bool,
 ) -> Option<ClassifiedEntry> {
+    // `is_directory` comes from `DirEntry::file_type()`, which does not
+    // follow symlinks: a symlinked directory arrives here as NOT a
+    // directory and is never queued for traversal by `add_directory_tree`
+    // or `refresh_directory`, so discovery cannot loop on symlink cycles.
+    // Traversal depth is therefore bounded by the real on-disk tree depth,
+    // and `remove_directory_tree` (which descends only into tracked
+    // directories) inherits the same bound — no depth cap is needed.
     if is_directory {
         return match directory_kind {
             DirectoryKind::ClaudeCodeRoot => {
@@ -1221,8 +1287,12 @@ pub async fn run_mirror_service(runtime: KhiveRuntime, config: MirrorConfig) {
     // Cursor rows whose deletion failed, retried on later ticks. A stale
     // row that survives to a daemon restart is reloaded by `load_cursors`,
     // and a recreated same-path file would then resume from the old offset
-    // and silently skip bytes — so failed deletions must be retried until
-    // they succeed, not dropped (bounded by `CURSOR_DELETE_RETRY_LIMIT`).
+    // and silently skip bytes — so failed deletions are retried on every
+    // later tick. The retry set itself is bounded by
+    // `CURSOR_DELETE_RETRY_LIMIT`: beyond it the oldest entry is evicted
+    // with an ERROR log naming that residual risk (see
+    // `queue_cursor_deletes`), rather than letting the set grow without
+    // bound during a store outage.
     let mut pending_cursor_deletes: VecDeque<PathBuf> = VecDeque::new();
 
     loop {
@@ -1237,7 +1307,13 @@ pub async fn run_mirror_service(runtime: KhiveRuntime, config: MirrorConfig) {
             }
             queue_cursor_deletes(&mut pending_cursor_deletes, &removed_files);
         }
-        drain_pending_cursor_deletes(&runtime, &discovery, &mut pending_cursor_deletes).await;
+        drain_pending_cursor_deletes(
+            &runtime,
+            &discovery,
+            &mut offsets,
+            &mut pending_cursor_deletes,
+        )
+        .await;
         let scheduled = discovery.schedule_files();
         let total_tracked = discovery.tracked_files();
         let mut files_mirrored: u64 = 0;
@@ -1296,10 +1372,18 @@ pub async fn run_mirror_service(runtime: KhiveRuntime, config: MirrorConfig) {
                 continue;
             };
             let mut candidate_dispatch = CandidateDispatch::default();
+            let mut ended_by_inserting = false;
             for kind in kinds {
                 let result = match kind {
                     DiscoveredKind::LineTail { source, session_id } => {
-                        ingest::mirror_file(
+                        // Deferred variant: an empty advance (bytes consumed,
+                        // zero rows) does NOT commit its cursor inline, so the
+                        // commit cannot race ahead of a later candidate that
+                        // would parse the same span, and an interrupt between
+                        // candidates cannot strand a committed cursor past
+                        // uninserted rows. The commit happens below, only when
+                        // dispatch ends without an inserting candidate.
+                        ingest::mirror_file_deferred(
                             &runtime,
                             &scheduled_file.path,
                             offset,
@@ -1318,6 +1402,7 @@ pub async fn run_mirror_service(runtime: KhiveRuntime, config: MirrorConfig) {
                     }
                 };
                 if candidate_dispatch.record(result, offset) {
+                    ended_by_inserting = true;
                     break;
                 }
             }
@@ -1332,28 +1417,64 @@ pub async fn run_mirror_service(runtime: KhiveRuntime, config: MirrorConfig) {
                 );
             }
 
+            // Commit a deferred empty advance only when dispatch ended with
+            // no inserting candidate AND no candidate error. An erroring
+            // candidate might have parsed the span had it succeeded, so the
+            // cursor stays at the old offset and a later pass re-reads the
+            // bytes (bounded and idempotent) rather than skipping them. On
+            // commit failure the in-memory offset is likewise NOT applied.
+            let stats = match stats {
+                Some(stats)
+                    if !ended_by_inserting && stats.inserted == 0 && stats.new_offset > offset =>
+                {
+                    if had_errors {
+                        tracing::debug!(
+                            path = %scheduled_file.path.display(),
+                            new_offset = stats.new_offset,
+                            "session mirror: deferring empty-advance cursor commit because a \
+                             candidate errored; the span will be re-read on a later pass"
+                        );
+                        None
+                    } else {
+                        match ingest::commit_empty_advance(
+                            &runtime,
+                            &scheduled_file.path,
+                            stats.new_offset,
+                        )
+                        .await
+                        {
+                            Ok(()) => Some(stats),
+                            Err(error) => {
+                                tracing::warn!(
+                                    path = %scheduled_file.path.display(),
+                                    error = %error,
+                                    new_offset = stats.new_offset,
+                                    "session mirror: empty-advance cursor commit failed; \
+                                     offset held back for a bounded re-read"
+                                );
+                                None
+                            }
+                        }
+                    }
+                }
+                other => other,
+            };
+
             // A successful advance ends the error streak; a tick on which
-            // every candidate errored grows it toward demotion.
+            // no candidate advanced and at least one errored grows it toward
+            // demotion. A no-progress success from one candidate does not
+            // make the file healthy while another candidate errors: without
+            // this, a misconfigured file with one capped-out provider and
+            // one broken provider would stay hot forever.
             let advanced = stats
                 .as_ref()
                 .is_some_and(|stats| stats.new_offset > offset);
-            if advanced {
-                discovery.clear_error_polls(&scheduled_file.path);
-            } else if stats.is_none() && had_errors {
-                // Every source candidate errored this tick: the offset did
-                // not advance and nothing was recorded. Without
-                // intervention the file would stay hot and be re-dispatched
-                // every tick forever; after `FILE_ERROR_POLLS_BEFORE_COLD`
-                // consecutive such ticks, demote it to the cold sample,
-                // whose ordinary cadence retries it (no separate retry
-                // machinery).
-                if discovery.record_error_poll(&scheduled_file.path) {
-                    tracing::warn!(
-                        path = %scheduled_file.path.display(),
-                        consecutive_error_polls = FILE_ERROR_POLLS_BEFORE_COLD,
-                        "session mirror: demoting persistently erroring file to cold"
-                    );
-                }
+            if tally_dispatch_errors(&mut discovery, &scheduled_file.path, advanced, had_errors) {
+                tracing::warn!(
+                    path = %scheduled_file.path.display(),
+                    consecutive_error_polls = FILE_ERROR_POLLS_BEFORE_COLD,
+                    "session mirror: demoting persistently erroring file to cold"
+                );
             }
 
             if let Some(stats) = stats {
@@ -1452,29 +1573,54 @@ async fn load_cursors(runtime: &KhiveRuntime) -> Result<HashMap<PathBuf, u64>, R
 /// recreated same-path file then resumes from the old offset and silently
 /// skips the bytes written in between. Idempotent `INSERT OR IGNORE` does
 /// not cover this case because the skipped bytes are never read at all.
-async fn delete_cursors(runtime: &KhiveRuntime, paths: &[PathBuf]) -> Result<(), RuntimeError> {
+///
+/// Returns the paths whose DELETE failed (empty on full success); `Err`
+/// only when the writer cannot be acquired at all. A failing path must not
+/// block the rest of the batch — head-of-line blocking would let one bad
+/// row stall every later deletion, and the failed paths are retried on
+/// later ticks via the pending-delete set either way.
+///
+/// The DELETE keys on `path.to_string_lossy()` — the same lossy text the
+/// ingest cursor upserts (`upsert_cursor_on_writer`, `write_cursor_only`)
+/// use as the row key — so a delete always targets the row the inserts
+/// wrote, even for non-UTF-8 paths.
+async fn delete_cursors(
+    runtime: &KhiveRuntime,
+    paths: &[PathBuf],
+) -> Result<Vec<PathBuf>, RuntimeError> {
     let sql = runtime.sql();
     let mut writer = sql
         .writer()
         .await
         .map_err(|e| RuntimeError::Internal(format!("mirror: cursor writer: {e}")))?;
 
+    let mut failed = Vec::new();
     for path in paths {
-        writer
+        if let Err(error) = writer
             .execute(SqlStatement {
                 sql: "DELETE FROM session_mirror_cursor WHERE file_path=?1".into(),
                 params: vec![SqlValue::Text(path.to_string_lossy().into_owned())],
                 label: Some("mirror_cursor_delete".into()),
             })
             .await
-            .map_err(|e| RuntimeError::Internal(format!("mirror: cursor delete: {e}")))?;
+        {
+            tracing::debug!(
+                path = %path.display(),
+                error = %error,
+                "session mirror: cursor delete failed for one path; continuing batch"
+            );
+            failed.push(path.clone());
+        }
     }
-    Ok(())
+    Ok(failed)
 }
 
 /// Add removed paths to the pending cursor-delete set, deduplicating and
-/// evicting (warn-logged) beyond `CURSOR_DELETE_RETRY_LIMIT` so an outage
-/// cannot grow the set without bound.
+/// evicting (ERROR-logged) beyond `CURSOR_DELETE_RETRY_LIMIT` so an outage
+/// cannot grow the set without bound. Eviction is the escape valve, not a
+/// neutral log: an evicted path's stale cursor row can survive a daemon
+/// restart and skip bytes if the path is recreated — the error names that
+/// consequence.
 fn queue_cursor_deletes(pending: &mut VecDeque<PathBuf>, removed: &[PathBuf]) {
     for path in removed {
         if pending.contains(path) {
@@ -1482,10 +1628,12 @@ fn queue_cursor_deletes(pending: &mut VecDeque<PathBuf>, removed: &[PathBuf]) {
         }
         if pending.len() >= CURSOR_DELETE_RETRY_LIMIT {
             let dropped = pending.pop_front();
-            tracing::warn!(
+            tracing::error!(
                 dropped = %dropped.map(|p| p.display().to_string()).unwrap_or_default(),
                 limit = CURSOR_DELETE_RETRY_LIMIT,
-                "session mirror: cursor-delete retry set full; dropping oldest entry"
+                "session mirror: cursor-delete retry set full; evicting oldest entry — \
+                 its stale cursor row can survive a daemon restart and skip bytes if \
+                 the path is recreated"
             );
         }
         pending.push_back(path.clone());
@@ -1495,32 +1643,82 @@ fn queue_cursor_deletes(pending: &mut VecDeque<PathBuf>, removed: &[PathBuf]) {
 /// Drain the pending cursor-delete set against the store. A path re-tracked
 /// since its removal seeds a fresh in-memory offset and rewrites its cursor
 /// row on the next successful ingest, so its pending delete is cancelled
-/// instead of removing the fresh row out from under it. On failure the set
-/// is kept for retry on later ticks (escalated to warn: a dropped failure
-/// leaves the stale row in place across restarts). Paths deleted before the
-/// error stay in the set and are re-deleted idempotently later.
+/// instead of removing the fresh row out from under it. When the removal
+/// already dropped the in-memory offset, the cancel restores it from the
+/// preserved cursor row — otherwise the next seed falls back to `file_len`
+/// (`backfill=false`) and silently skips bytes the preserved row proves
+/// were already mirrored. On failure only the failed paths are kept for
+/// retry on later ticks (escalated to warn: a dropped failure leaves the
+/// stale row in place across restarts); paths deleted before a failure are
+/// not retried.
 async fn drain_pending_cursor_deletes(
     runtime: &KhiveRuntime,
     discovery: &DiscoveryIndex,
+    offsets: &mut HashMap<PathBuf, u64>,
     pending: &mut VecDeque<PathBuf>,
 ) {
     if pending.is_empty() {
         return;
     }
-    pending.retain(|path| !discovery.files.contains_key(path));
+    let mut cancelled = Vec::new();
+    pending.retain(|path| {
+        if discovery.files.contains_key(path) {
+            cancelled.push(path.clone());
+            false
+        } else {
+            true
+        }
+    });
+    for path in &cancelled {
+        if offsets.contains_key(path) {
+            continue;
+        }
+        if let Some(offset) = read_cursor_offset(runtime, path).await {
+            offsets.insert(path.clone(), offset);
+        }
+    }
     if pending.is_empty() {
         return;
     }
     let paths: Vec<PathBuf> = pending.iter().cloned().collect();
     match delete_cursors(runtime, &paths).await {
-        Ok(()) => pending.clear(),
+        Ok(failed) if failed.is_empty() => pending.clear(),
+        Ok(failed) => {
+            tracing::warn!(
+                failed = failed.len(),
+                remaining = failed.len(),
+                "session mirror: cursor cleanup partially failed; retrying failed paths next tick"
+            );
+            *pending = failed.into();
+        }
         Err(error) => {
             tracing::warn!(
                 error = %error,
                 remaining = pending.len(),
-                "session mirror: cursor cleanup failed; retrying next tick"
+                "session mirror: cursor cleanup failed before any delete; retrying next tick"
             );
         }
+    }
+}
+
+/// Read one persisted cursor offset, or `None` when the table is missing,
+/// the path has no row, or the reader cannot be acquired. Used by the
+/// delete-cancel path to restore an in-memory offset that the removal
+/// handling already dropped.
+async fn read_cursor_offset(runtime: &KhiveRuntime, path: &Path) -> Option<u64> {
+    let sql = runtime.sql();
+    let mut reader = sql.reader().await.ok()?;
+    let rows = reader
+        .query_all(SqlStatement {
+            sql: "SELECT byte_offset FROM session_mirror_cursor WHERE file_path=?1".into(),
+            params: vec![SqlValue::Text(path.to_string_lossy().into_owned())],
+            label: Some("mirror_cursor_read".into()),
+        })
+        .await
+        .ok()?;
+    match rows.first().and_then(|row| row.get("byte_offset")) {
+        Some(SqlValue::Integer(offset)) => Some(*offset as u64),
+        _ => None,
     }
 }
 
@@ -2085,6 +2283,108 @@ mod discovery_tests {
         assert_eq!(stats.new_offset, start_offset + 40);
     }
 
+    /// Regression for the recording-precedence finding: a no-progress
+    /// candidate recorded first must not hide a later empty advance, or the
+    /// in-memory offset stays behind a durably committed cursor.
+    #[test]
+    fn later_empty_advance_replaces_earlier_no_progress_record() {
+        let start_offset = 100;
+        let mut dispatch = CandidateDispatch::default();
+
+        // Candidate A: no progress (whole-file ceiling below the current
+        // length). Recorded only because nothing else is recorded yet.
+        assert!(!dispatch.record(
+            Ok(MirrorStats {
+                inserted: 0,
+                scanned: 0,
+                new_offset: start_offset,
+            }),
+            start_offset,
+        ));
+
+        // Candidate B: empty advance past start_offset. Must replace A's
+        // non-advancing record so the in-memory offset follows the cursor.
+        assert!(!dispatch.record(
+            Ok(MirrorStats {
+                inserted: 0,
+                scanned: 0,
+                new_offset: start_offset + 64,
+            }),
+            start_offset,
+        ));
+
+        let stats = dispatch.stats.expect("empty advance recorded");
+        assert_eq!(
+            stats.new_offset,
+            start_offset + 64,
+            "the advancing result wins over the earlier no-progress record"
+        );
+        assert_eq!(stats.inserted, 0);
+    }
+
+    /// An advancing record is kept against a later empty advance (first
+    /// advancing record wins; an inserting candidate ends dispatch anyway).
+    #[test]
+    fn first_advancing_record_is_kept_against_later_empty_advance() {
+        let start_offset = 50;
+        let mut dispatch = CandidateDispatch::default();
+
+        assert!(!dispatch.record(
+            Ok(MirrorStats {
+                inserted: 0,
+                scanned: 0,
+                new_offset: start_offset + 30,
+            }),
+            start_offset,
+        ));
+        assert!(!dispatch.record(
+            Ok(MirrorStats {
+                inserted: 0,
+                scanned: 0,
+                new_offset: start_offset + 90,
+            }),
+            start_offset,
+        ));
+
+        assert_eq!(
+            dispatch
+                .stats
+                .expect("first advancing record kept")
+                .new_offset,
+            start_offset + 30
+        );
+    }
+
+    /// Item 6: a mixed poll — one candidate's no-progress success plus
+    /// another candidate's error — must count toward demotion; otherwise the
+    /// file stays hot forever.
+    #[test]
+    fn mixed_no_progress_and_error_polls_count_toward_demotion() {
+        let mut discovery = DiscoveryIndex::default();
+        let path = PathBuf::from("/projects/mixed.jsonl");
+        discovery.add_file(path.clone(), DiscoveredKind::ChatGptExport, false);
+
+        for _ in 1..FILE_ERROR_POLLS_BEFORE_COLD {
+            assert!(
+                !super::tally_dispatch_errors(&mut discovery, &path, false, true),
+                "below the threshold no demotion"
+            );
+            assert!(!discovery.files[&path].cold);
+        }
+        assert!(
+            super::tally_dispatch_errors(&mut discovery, &path, false, true),
+            "the crossing tick reports the one-shot demotion warn"
+        );
+        assert!(
+            discovery.files[&path].cold,
+            "the mixed no-progress+error file is demoted to cold"
+        );
+
+        // A successful advance resets the streak.
+        super::tally_dispatch_errors(&mut discovery, &path, true, false);
+        assert_eq!(discovery.files[&path].consecutive_error_polls, 0);
+    }
+
     #[test]
     fn refresh_failure_counter_crosses_the_warn_threshold_once_per_episode() {
         let mut discovery = DiscoveryIndex::default();
@@ -2211,6 +2511,7 @@ mod cursor_retry_tests {
     use crate::vocab::SESSION_SCHEMA_PLAN_STMTS;
     use khive_runtime::{AllowAllGate, BackendId, KhiveRuntime, Namespace, RuntimeConfig};
     use khive_storage::types::{SqlStatement, SqlValue};
+    use std::collections::HashMap;
     use std::collections::VecDeque;
     use std::path::PathBuf;
     use std::sync::Arc;
@@ -2290,11 +2591,12 @@ mod cursor_retry_tests {
         let mut pending = VecDeque::new();
         queue_cursor_deletes(&mut pending, std::slice::from_ref(&path));
         assert_eq!(pending.len(), 1);
+        let mut offsets = HashMap::new();
 
         // No cursor table yet: the delete fails and the entry must stay
         // pending — dropping it would let a stale row survive a daemon
         // restart and skip bytes on a recreated file.
-        drain_pending_cursor_deletes(&rt, &discovery, &mut pending).await;
+        drain_pending_cursor_deletes(&rt, &discovery, &mut offsets, &mut pending).await;
         assert_eq!(
             pending.len(),
             1,
@@ -2305,7 +2607,7 @@ mod cursor_retry_tests {
         // the next tick's retry deletes it and drains the set.
         apply_session_schema(&rt).await;
         insert_cursor_row(&rt, &path, 4096).await;
-        drain_pending_cursor_deletes(&rt, &discovery, &mut pending).await;
+        drain_pending_cursor_deletes(&rt, &discovery, &mut offsets, &mut pending).await;
         assert!(pending.is_empty(), "successful retry drains the set");
         assert!(
             !cursor_row_exists(&rt, &path).await,
@@ -2324,13 +2626,69 @@ mod cursor_retry_tests {
         let mut discovery = DiscoveryIndex::default();
         let mut pending = VecDeque::new();
         queue_cursor_deletes(&mut pending, std::slice::from_ref(&path));
+        let mut offsets = HashMap::new();
 
         // The file is re-discovered before the delete drains: its fresh
         // cursor row must not be deleted out from under it.
         discovery.add_file(path.clone(), DiscoveredKind::ChatGptExport, false);
-        drain_pending_cursor_deletes(&rt, &discovery, &mut pending).await;
+        drain_pending_cursor_deletes(&rt, &discovery, &mut offsets, &mut pending).await;
         assert!(pending.is_empty(), "re-tracked path cancels its delete");
         assert!(cursor_row_exists(&rt, &path).await, "fresh row preserved");
+        assert_eq!(
+            offsets.get(&path),
+            Some(&512),
+            "canceling the delete restores the in-memory offset from the preserved row"
+        );
+    }
+
+    /// Item 3 regression: remove + re-add in the same pass. The removal
+    /// drops the in-memory offset and queues the cursor delete; the re-add
+    /// cancels the delete. The cancel must restore the offset from the
+    /// preserved cursor row — otherwise the next seed falls back to
+    /// `file_len` (`backfill=false`) and skips bytes the preserved row
+    /// proves were already mirrored.
+    #[tokio::test]
+    async fn same_pass_remove_and_readd_restores_offset_from_preserved_cursor_row() {
+        let (rt, _dir) = runtime_without_schema();
+        apply_session_schema(&rt).await;
+
+        let path = PathBuf::from("/projects/flap.jsonl");
+        insert_cursor_row(&rt, &path, 4096).await;
+
+        let mut discovery = DiscoveryIndex::default();
+        discovery.add_file(path.clone(), DiscoveredKind::ChatGptExport, false);
+
+        // Same-pass removal: discovery reports the file gone, the service
+        // loop drops the in-memory offset and queues the cursor delete.
+        discovery.remove_file(&path, false);
+        let removed = discovery.take_removed_files();
+        assert_eq!(removed, vec![path.clone()]);
+        let mut offsets = HashMap::from([(path.clone(), 4096u64)]);
+        for removed_path in &removed {
+            offsets.remove(removed_path);
+        }
+        let mut pending = VecDeque::new();
+        queue_cursor_deletes(&mut pending, &removed);
+        assert!(offsets.is_empty(), "removal dropped the in-memory offset");
+
+        // Same-pass re-discovery: the file is back before the delete drains.
+        discovery.add_file(path.clone(), DiscoveredKind::ChatGptExport, false);
+        drain_pending_cursor_deletes(&rt, &discovery, &mut offsets, &mut pending).await;
+
+        assert!(
+            pending.is_empty(),
+            "re-added path cancels its pending delete"
+        );
+        assert!(
+            cursor_row_exists(&rt, &path).await,
+            "the preserved cursor row survives the cancel"
+        );
+        assert_eq!(
+            offsets.get(&path),
+            Some(&4096),
+            "the cancel restores the in-memory offset from the preserved row, \
+             so backfill=false seeding never falls back to EOF and skips bytes"
+        );
     }
 
     #[tokio::test]
@@ -2349,20 +2707,63 @@ mod cursor_retry_tests {
             CURSOR_DELETE_RETRY_LIMIT,
             "the retry set is bounded; oldest entries are evicted"
         );
+        assert!(
+            !pending.contains(&path),
+            "the oldest entry is the one evicted under the bound"
+        );
     }
 
     #[tokio::test]
-    async fn delete_cursors_reports_the_sql_error_for_retry() {
+    async fn delete_cursors_reports_per_path_failures_without_aborting_the_batch() {
         let (rt, _dir) = runtime_without_schema();
         let path = PathBuf::from("/projects/gone.jsonl");
-        let error = delete_cursors(&rt, &[path])
+        let failed = delete_cursors(&rt, std::slice::from_ref(&path))
             .await
-            .expect_err("missing table must surface as an error, not silence");
-        let message = error.to_string();
-        assert!(
-            message.contains("mirror: cursor delete"),
-            "error names the failing operation; got: {message}"
+            .expect("writer acquisition succeeds even when the table is missing");
+        assert_eq!(
+            failed,
+            vec![path],
+            "the failing path is reported for retry instead of aborting the batch"
         );
+    }
+
+    /// Item 7 regression: a failing DELETE must not block later paths in the
+    /// batch (head-of-line blocking). With the cursor table missing, every
+    /// path fails — and every path is still attempted and reported, rather
+    /// than the batch aborting at the first failure.
+    #[tokio::test]
+    async fn head_of_line_cursor_delete_failure_does_not_block_the_batch() {
+        let (rt, _dir) = runtime_without_schema();
+        let first = PathBuf::from("/projects/first.jsonl");
+        let second = PathBuf::from("/projects/second.jsonl");
+        let third = PathBuf::from("/projects/third.jsonl");
+        let failed = delete_cursors(&rt, &[first.clone(), second.clone(), third.clone()])
+            .await
+            .expect("writer acquisition succeeds even when the table is missing");
+        assert_eq!(
+            failed,
+            vec![first, second, third],
+            "every path is attempted past the first failure; the failed paths \
+             are retained for retry"
+        );
+    }
+
+    /// The happy path still drains the whole batch and reports nothing.
+    #[tokio::test]
+    async fn delete_cursors_drains_the_batch_when_every_delete_succeeds() {
+        let (rt, _dir) = runtime_without_schema();
+        apply_session_schema(&rt).await;
+        let first = PathBuf::from("/projects/a.jsonl");
+        let second = PathBuf::from("/projects/b.jsonl");
+        insert_cursor_row(&rt, &first, 10).await;
+        insert_cursor_row(&rt, &second, 20).await;
+
+        let failed = delete_cursors(&rt, &[first.clone(), second.clone()])
+            .await
+            .expect("delete batch");
+        assert!(failed.is_empty(), "no per-path failures on the happy path");
+        assert!(!cursor_row_exists(&rt, &first).await);
+        assert!(!cursor_row_exists(&rt, &second).await);
     }
 }
 

--- a/crates/khive-pack-session/src/mirror/service.rs
+++ b/crates/khive-pack-session/src/mirror/service.rs
@@ -543,6 +543,12 @@ impl DiscoveryIndex {
                     self.add_file(path, file_kind, true);
                     continue;
                 }
+                // Keep a pinned configured root as a directory placeholder
+                // even when startup finds an unexpected file at that path.
+                // The probe path retains the same identity for a runtime
+                // directory-to-file transition, allowing a later directory
+                // reversion to be discovered.
+                Ok(_) if is_pinned => None,
                 Ok(_) => continue,
                 Err(_) if is_pinned => None,
                 Err(_) => continue,
@@ -1189,6 +1195,59 @@ fn tally_dispatch_errors(
     had_errors && discovery.record_error_poll(path)
 }
 
+/// Finish dispatch bookkeeping for a deferred empty advance. The service
+/// vetoes the cursor commit when any candidate errored, and a commit failure
+/// itself becomes an error poll so persistent failures reach cold cadence.
+async fn finalize_dispatch_stats(
+    runtime: &KhiveRuntime,
+    path: &Path,
+    offset: u64,
+    ended_by_inserting: bool,
+    stats: Option<ingest::MirrorStats>,
+    mut had_errors: bool,
+) -> (Option<ingest::MirrorStats>, bool) {
+    // Commit a deferred empty advance only when dispatch ended with no
+    // inserting candidate AND no candidate error. An erroring candidate might
+    // have parsed the span had it succeeded, so the cursor stays at the old
+    // offset and a later pass re-reads the bytes (bounded and idempotent)
+    // rather than skipping them. On commit failure the in-memory offset is
+    // likewise NOT applied.
+    let stats = match stats {
+        Some(stats) if !ended_by_inserting && stats.inserted == 0 && stats.new_offset > offset => {
+            if had_errors {
+                tracing::debug!(
+                    path = %path.display(),
+                    new_offset = stats.new_offset,
+                    "session mirror: deferring empty-advance cursor commit because a \
+                     candidate errored; the span will be re-read on a later pass"
+                );
+                None
+            } else {
+                match ingest::commit_empty_advance(runtime, path, stats.new_offset).await {
+                    Ok(()) => Some(stats),
+                    Err(error) => {
+                        // A failed deferred cursor commit is an ingest error
+                        // for cadence purposes: the file made no durable
+                        // progress and must eventually be demoted to the cold
+                        // retry cadence just like any other failed pass.
+                        had_errors = true;
+                        tracing::warn!(
+                            path = %path.display(),
+                            error = %error,
+                            new_offset = stats.new_offset,
+                            "session mirror: empty-advance cursor commit failed; \
+                             offset held back for a bounded re-read"
+                        );
+                        None
+                    }
+                }
+            }
+        }
+        other => other,
+    };
+    (stats, had_errors)
+}
+
 fn classify_entry(
     directory_kind: DirectoryKind,
     path: &Path,
@@ -1307,14 +1366,20 @@ pub async fn run_mirror_service(runtime: KhiveRuntime, config: MirrorConfig) {
             }
             queue_cursor_deletes(&mut pending_cursor_deletes, &removed_files);
         }
-        drain_pending_cursor_deletes(
+        let blocked_cursor_restores = drain_pending_cursor_deletes(
             &runtime,
             &discovery,
             &mut offsets,
             &mut pending_cursor_deletes,
         )
         .await;
-        let scheduled = discovery.schedule_files();
+        let scheduled = discovery
+            .schedule_files()
+            .into_iter()
+            .filter(|scheduled_file| {
+                !blocked_cursor_restores.contains(scheduled_file.path.as_path())
+            })
+            .collect::<Vec<_>>();
         let total_tracked = discovery.tracked_files();
         let mut files_mirrored: u64 = 0;
         let mut rows_inserted: u64 = 0;
@@ -1417,48 +1482,15 @@ pub async fn run_mirror_service(runtime: KhiveRuntime, config: MirrorConfig) {
                 );
             }
 
-            // Commit a deferred empty advance only when dispatch ended with
-            // no inserting candidate AND no candidate error. An erroring
-            // candidate might have parsed the span had it succeeded, so the
-            // cursor stays at the old offset and a later pass re-reads the
-            // bytes (bounded and idempotent) rather than skipping them. On
-            // commit failure the in-memory offset is likewise NOT applied.
-            let stats = match stats {
-                Some(stats)
-                    if !ended_by_inserting && stats.inserted == 0 && stats.new_offset > offset =>
-                {
-                    if had_errors {
-                        tracing::debug!(
-                            path = %scheduled_file.path.display(),
-                            new_offset = stats.new_offset,
-                            "session mirror: deferring empty-advance cursor commit because a \
-                             candidate errored; the span will be re-read on a later pass"
-                        );
-                        None
-                    } else {
-                        match ingest::commit_empty_advance(
-                            &runtime,
-                            &scheduled_file.path,
-                            stats.new_offset,
-                        )
-                        .await
-                        {
-                            Ok(()) => Some(stats),
-                            Err(error) => {
-                                tracing::warn!(
-                                    path = %scheduled_file.path.display(),
-                                    error = %error,
-                                    new_offset = stats.new_offset,
-                                    "session mirror: empty-advance cursor commit failed; \
-                                     offset held back for a bounded re-read"
-                                );
-                                None
-                            }
-                        }
-                    }
-                }
-                other => other,
-            };
+            let (stats, had_errors) = finalize_dispatch_stats(
+                &runtime,
+                &scheduled_file.path,
+                offset,
+                ended_by_inserting,
+                stats,
+                had_errors,
+            )
+            .await;
 
             // A successful advance ends the error streak; a tick on which
             // no candidate advanced and at least one errored grows it toward
@@ -1647,18 +1679,19 @@ fn queue_cursor_deletes(pending: &mut VecDeque<PathBuf>, removed: &[PathBuf]) {
 /// already dropped the in-memory offset, the cancel restores it from the
 /// preserved cursor row — otherwise the next seed falls back to `file_len`
 /// (`backfill=false`) and silently skips bytes the preserved row proves
-/// were already mirrored. On failure only the failed paths are kept for
-/// retry on later ticks (escalated to warn: a dropped failure leaves the
-/// stale row in place across restarts); paths deleted before a failure are
-/// not retried.
+/// were already mirrored. A failed restore keeps the pending entry and
+/// returns the path in the blocked set so this tick cannot seed or schedule
+/// it; the cursor row remains authoritative until a successful read restores
+/// the offset. Paths deleted before a failure are retried independently.
 async fn drain_pending_cursor_deletes(
     runtime: &KhiveRuntime,
     discovery: &DiscoveryIndex,
     offsets: &mut HashMap<PathBuf, u64>,
     pending: &mut VecDeque<PathBuf>,
-) {
+) -> HashSet<PathBuf> {
+    let mut blocked = HashSet::new();
     if pending.is_empty() {
-        return;
+        return blocked;
     }
     let mut cancelled = Vec::new();
     pending.retain(|path| {
@@ -1669,27 +1702,54 @@ async fn drain_pending_cursor_deletes(
             true
         }
     });
+    let mut restore_failed = Vec::new();
     for path in &cancelled {
         if offsets.contains_key(path) {
             continue;
         }
-        if let Some(offset) = read_cursor_offset(runtime, path).await {
-            offsets.insert(path.clone(), offset);
+        match read_cursor_offset(runtime, path).await {
+            Ok(Some(offset)) => {
+                offsets.insert(path.clone(), offset);
+            }
+            Ok(None) => {}
+            Err(error) => {
+                tracing::warn!(
+                    path = %path.display(),
+                    error = %error,
+                    "session mirror: failed to restore cancelled cursor; retrying before scheduling"
+                );
+                restore_failed.push(path.clone());
+                blocked.insert(path.clone());
+            }
         }
     }
+    // A failed restore remains pending, but must not be sent through the
+    // delete batch while the path is tracked: its preserved row is still
+    // authoritative, and scheduling it with no offset would seed at EOF.
+    pending.extend(restore_failed);
     if pending.is_empty() {
-        return;
+        return blocked;
     }
-    let paths: Vec<PathBuf> = pending.iter().cloned().collect();
+    let paths: Vec<PathBuf> = pending
+        .iter()
+        .filter(|path| !blocked.contains(path.as_path()))
+        .cloned()
+        .collect();
+    if paths.is_empty() {
+        return blocked;
+    }
+    let blocked_pending = blocked.iter().cloned().collect::<VecDeque<_>>();
     match delete_cursors(runtime, &paths).await {
-        Ok(failed) if failed.is_empty() => pending.clear(),
+        Ok(failed) if failed.is_empty() => *pending = blocked_pending,
         Ok(failed) => {
+            let mut remaining = blocked_pending;
+            remaining.extend(failed.iter().cloned());
             tracing::warn!(
                 failed = failed.len(),
-                remaining = failed.len(),
+                remaining = remaining.len(),
                 "session mirror: cursor cleanup partially failed; retrying failed paths next tick"
             );
-            *pending = failed.into();
+            *pending = remaining;
         }
         Err(error) => {
             tracing::warn!(
@@ -1699,27 +1759,29 @@ async fn drain_pending_cursor_deletes(
             );
         }
     }
+    blocked
 }
 
-/// Read one persisted cursor offset, or `None` when the table is missing,
-/// the path has no row, or the reader cannot be acquired. Used by the
-/// delete-cancel path to restore an in-memory offset that the removal
-/// handling already dropped.
-async fn read_cursor_offset(runtime: &KhiveRuntime, path: &Path) -> Option<u64> {
+/// Read one persisted cursor offset. `Ok(None)` means the query succeeded but
+/// no row exists; an acquisition or query failure is returned so a cancelled
+/// delete can remain pending instead of allowing an EOF seed.
+async fn read_cursor_offset(
+    runtime: &KhiveRuntime,
+    path: &Path,
+) -> Result<Option<u64>, RuntimeError> {
     let sql = runtime.sql();
-    let mut reader = sql.reader().await.ok()?;
+    let mut reader = sql.reader().await?;
     let rows = reader
         .query_all(SqlStatement {
             sql: "SELECT byte_offset FROM session_mirror_cursor WHERE file_path=?1".into(),
             params: vec![SqlValue::Text(path.to_string_lossy().into_owned())],
             label: Some("mirror_cursor_read".into()),
         })
-        .await
-        .ok()?;
-    match rows.first().and_then(|row| row.get("byte_offset")) {
+        .await?;
+    Ok(match rows.first().and_then(|row| row.get("byte_offset")) {
         Some(SqlValue::Integer(offset)) => Some(*offset as u64),
         _ => None,
-    }
+    })
 }
 
 /// Extract the session UUID from a Codex filename of the form
@@ -2472,6 +2534,41 @@ mod discovery_tests {
     }
 
     #[test]
+    fn pinned_file_placeholder_at_startup_reverts_to_a_directory() {
+        let temp = tempfile::TempDir::new().expect("temp dir");
+        let root = temp.path().join("codex-sessions");
+        std::fs::write(&root, "unexpected regular file").expect("startup file fixture");
+
+        let mut discovery = DiscoveryIndex::default();
+        discovery.add_directory_tree(&root, DirectoryKind::Codex, true);
+
+        let placeholder = discovery
+            .directories
+            .get(&root)
+            .expect("pinned file gets a directory placeholder");
+        assert!(placeholder.pinned);
+        assert!(placeholder.kinds.contains(&DirectoryKind::Codex));
+        assert!(!discovery.files.contains_key(&root));
+
+        std::fs::remove_file(&root).expect("remove startup file");
+        std::fs::create_dir(&root).expect("recreate configured root as directory");
+        let day = root.join("2026/08/05");
+        std::fs::create_dir_all(&day).expect("date directory");
+        let transcript =
+            day.join("rollout-2026-08-05T12-00-00-019a731e-4a58-71b1-a71f-a8d2f9782113.jsonl");
+        std::fs::write(&transcript, "{}\n").expect("reversion transcript");
+
+        discovery.probe_directories();
+
+        let directory = discovery
+            .directories
+            .get(&root)
+            .expect("placeholder remains scheduled after reversion");
+        assert!(directory.pinned);
+        assert!(discovery.files.contains_key(&transcript));
+    }
+
+    #[test]
     fn force_rescan_without_fingerprint_change_does_not_reprioritize_cold_files() {
         let temp = tempfile::TempDir::new().expect("temp dir");
         let project = temp.path().join("project-slug");
@@ -2505,17 +2602,20 @@ mod discovery_tests {
 #[cfg(test)]
 mod cursor_retry_tests {
     use super::{
-        delete_cursors, drain_pending_cursor_deletes, queue_cursor_deletes, DiscoveredKind,
-        DiscoveryIndex, CURSOR_DELETE_RETRY_LIMIT,
+        delete_cursors, drain_pending_cursor_deletes, finalize_dispatch_stats,
+        queue_cursor_deletes, tally_dispatch_errors, DiscoveredKind, DiscoveryIndex,
+        CURSOR_DELETE_RETRY_LIMIT, FILE_ERROR_POLLS_BEFORE_COLD,
     };
+    use crate::mirror::ingest::{mirror_file, LineTailSource, MirrorStats};
     use crate::vocab::SESSION_SCHEMA_PLAN_STMTS;
     use khive_runtime::{AllowAllGate, BackendId, KhiveRuntime, Namespace, RuntimeConfig};
     use khive_storage::types::{SqlStatement, SqlValue};
     use std::collections::HashMap;
     use std::collections::VecDeque;
+    use std::io::Write;
     use std::path::PathBuf;
     use std::sync::Arc;
-    use tempfile::TempDir;
+    use tempfile::{NamedTempFile, TempDir};
 
     /// File-backed runtime WITHOUT the session schema applied — cursor DML
     /// fails with "no such table", which doubles as the fault injection for
@@ -2689,6 +2789,117 @@ mod cursor_retry_tests {
             "the cancel restores the in-memory offset from the preserved row, \
              so backfill=false seeding never falls back to EOF and skips bytes"
         );
+    }
+
+    #[tokio::test]
+    async fn failed_cancelled_cursor_restore_blocks_eof_seed_until_retry() {
+        let (rt, _dir) = runtime_without_schema();
+        let mut file = NamedTempFile::new().expect("tmpfile");
+        let prefix = b"already mirrored\n";
+        let new_line = br#"{"uuid":"uuid-restored","sessionId":"sess-restored","type":"user","timestamp":"2026-08-05T10:00:00Z","message":{"role":"user","content":"restored"}}"#;
+        file.write_all(prefix).expect("prefix");
+        file.write_all(new_line).expect("new line");
+        file.write_all(b"\n").expect("line terminator");
+        let path = file.path().to_path_buf();
+        let true_offset = prefix.len() as u64;
+        let file_len = std::fs::metadata(&path).expect("file metadata").len();
+
+        let mut discovery = DiscoveryIndex::default();
+        discovery.add_file(path.clone(), DiscoveredKind::ChatGptExport, false);
+        let gone = path.with_file_name("gone.jsonl");
+        let mut pending = VecDeque::new();
+        queue_cursor_deletes(&mut pending, &[path.clone(), gone.clone()]);
+        let mut offsets = HashMap::new();
+
+        // The missing schema injects a cursor-read failure. The cancellation
+        // remains pending and the tracked path is explicitly blocked from the
+        // scheduling pass, so backfill=false cannot seed it at EOF.
+        let blocked =
+            drain_pending_cursor_deletes(&rt, &discovery, &mut offsets, &mut pending).await;
+        assert!(blocked.contains(path.as_path()));
+        assert!(pending.contains(&path));
+        assert!(
+            pending.contains(&gone),
+            "an unrelated failed delete remains pending"
+        );
+        let scheduled = discovery
+            .schedule_files()
+            .into_iter()
+            .filter(|file| !blocked.contains(file.path.as_path()))
+            .collect::<Vec<_>>();
+        assert!(scheduled.is_empty(), "failed restore must block this tick");
+        assert!(
+            !offsets.contains_key(&path),
+            "failed restore must not insert an EOF seed before retry"
+        );
+
+        // Once the schema and preserved row are available, the next drain
+        // restores the true offset and removes the pending cancellation.
+        apply_session_schema(&rt).await;
+        insert_cursor_row(&rt, &path, true_offset as i64).await;
+        let blocked =
+            drain_pending_cursor_deletes(&rt, &discovery, &mut offsets, &mut pending).await;
+        assert!(blocked.is_empty());
+        assert!(pending.is_empty());
+        assert_eq!(offsets.get(&path), Some(&true_offset));
+
+        // The restored offset points at the new line, proving the retry does
+        // not skip bytes that followed the already mirrored prefix.
+        let restored_offset = *offsets.entry(path.clone()).or_insert(file_len);
+        assert_eq!(restored_offset, true_offset);
+        let stats = mirror_file(
+            &rt,
+            &path,
+            restored_offset,
+            LineTailSource::ClaudeCode,
+            None,
+        )
+        .await
+        .expect("mirror bytes after restored cursor");
+        assert_eq!(
+            stats.inserted, 1,
+            "bytes after the preserved cursor are mirrored"
+        );
+    }
+
+    #[tokio::test]
+    async fn failed_empty_advance_commit_counts_as_error_for_cold_demotion() {
+        let (rt, _dir) = runtime_without_schema();
+        let path = PathBuf::from("/projects/blank.jsonl");
+        let mut discovery = DiscoveryIndex::default();
+        discovery.add_file(path.clone(), DiscoveredKind::ChatGptExport, false);
+
+        let (stats, had_errors) = finalize_dispatch_stats(
+            &rt,
+            &path,
+            0,
+            false,
+            Some(MirrorStats {
+                inserted: 0,
+                scanned: 0,
+                new_offset: 64,
+            }),
+            false,
+        )
+        .await;
+        assert!(stats.is_none(), "failed commit must hold back the offset");
+        assert!(had_errors, "failed commit must become an error poll");
+
+        for _ in 1..FILE_ERROR_POLLS_BEFORE_COLD {
+            assert!(!tally_dispatch_errors(
+                &mut discovery,
+                &path,
+                false,
+                had_errors
+            ));
+        }
+        assert!(tally_dispatch_errors(
+            &mut discovery,
+            &path,
+            false,
+            had_errors
+        ));
+        assert!(discovery.files[&path].cold);
     }
 
     #[tokio::test]

--- a/crates/khive-pack-session/src/mirror/service.rs
+++ b/crates/khive-pack-session/src/mirror/service.rs
@@ -334,10 +334,18 @@ impl CandidateDispatch {
                 self.stats = Some(stats);
                 true
             }
-            Ok(stats) => {
+            Ok(stats) if stats.new_offset >= start_offset => {
                 if self.stats.is_none() {
                     self.stats = Some(stats);
                 }
+                false
+            }
+            Ok(_) => {
+                // The ingest contract guarantees `new_offset >= start_offset`
+                // (read_bounded_chunk only advances from start_offset; export
+                // paths return start_offset or the file length after a
+                // `file_len <= start_offset` guard). Defend against future
+                // drift: never record a regressing cursor.
                 false
             }
             Err(error) => {
@@ -365,6 +373,9 @@ struct DiscoveryIndex {
     priority_cold_enqueued: HashSet<PathBuf>,
     cold_queue: VecDeque<PathBuf>,
     cold_enqueued: HashSet<PathBuf>,
+    /// Paths removed from `files` since the last drain, so the service loop
+    /// can prune their in-memory offsets and persisted cursor rows.
+    removed_files: Vec<PathBuf>,
 }
 
 enum ClassifiedEntry {
@@ -544,9 +555,18 @@ impl DiscoveryIndex {
 
             match std::fs::metadata(&path) {
                 Ok(metadata) if metadata.is_dir() => {
+                    // A path tracked as a directory that is one again must
+                    // not keep a stale file record left by an intervening
+                    // file phase (the directory-to-file transition below).
+                    if self.files.contains_key(&path) {
+                        self.remove_file(&path, false);
+                    }
                     let fingerprint = DirectoryFingerprint::from_metadata(&metadata);
                     if force_rescan || Some(fingerprint) != stored_fingerprint {
-                        if let Err(error) = self.refresh_directory(&path, &kinds, fingerprint) {
+                        let changed = Some(fingerprint) != stored_fingerprint;
+                        if let Err(error) =
+                            self.refresh_directory(&path, &kinds, fingerprint, changed)
+                        {
                             tracing::debug!(
                                 path = %path.display(),
                                 error = %error,
@@ -568,7 +588,10 @@ impl DiscoveryIndex {
                         .directories
                         .get(&path)
                         .is_some_and(|directory| directory.pinned);
-                    self.remove_directory_tree(&path, false);
+                    // Keep pinned identity (as the NotFound/other arms do) so
+                    // a configured root that became a file and later reverts to
+                    // a directory stays scheduled instead of being dropped.
+                    self.remove_directory_tree(&path, true);
                     for kind in kinds {
                         let file_kind = match kind {
                             DirectoryKind::ChatGptExport => Some(DiscoveredKind::ChatGptExport),
@@ -580,7 +603,15 @@ impl DiscoveryIndex {
                         }
                     }
                 }
-                Ok(_) => self.remove_directory_tree(&path, true),
+                Ok(_) => {
+                    // A stale file record from an intervening file phase must
+                    // not shadow the retained directory identity while the
+                    // path holds an unrelated entry.
+                    if self.files.contains_key(&path) {
+                        self.remove_file(&path, false);
+                    }
+                    self.remove_directory_tree(&path, true);
+                }
                 Err(error) if error.kind() == io::ErrorKind::NotFound => {
                     self.remove_directory_tree(&path, true);
                 }
@@ -606,16 +637,35 @@ impl DiscoveryIndex {
         path: &Path,
         kinds: &[DirectoryKind],
         fingerprint: DirectoryFingerprint,
+        prioritize: bool,
     ) -> io::Result<()> {
         let read_dir = std::fs::read_dir(path)?;
         let mut entries = HashSet::new();
         let mut directories = Vec::new();
         let mut files = Vec::new();
+        let mut complete = true;
 
         for entry in read_dir {
-            let entry = entry?;
+            // A faulty entry (raced removal, unreadable metadata) must not
+            // abort the whole refresh and freeze discovery of the directory's
+            // other files: skip it, and mark the listing incomplete so the
+            // stored fingerprint is cleared and the next probe retries —
+            // matching `add_directory_tree`'s non-fatal entry handling.
+            let entry = match entry {
+                Ok(entry) => entry,
+                Err(_) => {
+                    complete = false;
+                    continue;
+                }
+            };
             let child_path = entry.path();
-            let file_type = entry.file_type()?;
+            let file_type = match entry.file_type() {
+                Ok(file_type) => file_type,
+                Err(_) => {
+                    complete = false;
+                    continue;
+                }
+            };
             for kind in kinds {
                 let Some(classified) = classify_entry(*kind, &child_path, file_type.is_dir())
                 else {
@@ -633,17 +683,23 @@ impl DiscoveryIndex {
             }
         }
 
-        let removed = self
-            .directories
-            .get(path)
-            .map(|directory| {
-                directory
-                    .entries
-                    .difference(&entries)
-                    .cloned()
-                    .collect::<Vec<_>>()
-            })
-            .unwrap_or_default();
+        let removed = if complete {
+            self.directories
+                .get(path)
+                .map(|directory| {
+                    directory
+                        .entries
+                        .difference(&entries)
+                        .cloned()
+                        .collect::<Vec<_>>()
+                })
+                .unwrap_or_default()
+        } else {
+            // An incomplete listing cannot prove entries are gone; defer
+            // removals until a complete read (the cleared fingerprint below
+            // retries on the next probe).
+            Vec::new()
+        };
 
         for removed_path in removed {
             if self.directories.contains_key(&removed_path) {
@@ -656,7 +712,11 @@ impl DiscoveryIndex {
         for (file_path, file_kind) in files {
             let already_tracked = self.files.contains_key(&file_path);
             self.add_file(file_path.clone(), file_kind, false);
-            if already_tracked {
+            // Only a real fingerprint change carries a change signal worth
+            // reprioritizing cold files for; a forced rescan of an unchanged
+            // directory would otherwise periodically flood the priority queue
+            // and starve the ordinary cold round-robin.
+            if prioritize && already_tracked {
                 self.prioritize_cold(&file_path);
             }
         }
@@ -665,8 +725,16 @@ impl DiscoveryIndex {
         }
 
         if let Some(directory) = self.directories.get_mut(path) {
-            directory.fingerprint = Some(fingerprint);
-            directory.entries = entries;
+            if complete {
+                directory.fingerprint = Some(fingerprint);
+                directory.entries = entries;
+            } else {
+                // Keep the last complete snapshot: a partial listing could
+                // drop still-present paths from `entries` and hide their
+                // later removal from the difference computation. The cleared
+                // fingerprint retries the listing on the next probe.
+                directory.fingerprint = None;
+            }
             directory.unchanged_probes = 0;
         }
 
@@ -696,6 +764,8 @@ impl DiscoveryIndex {
             }
         } else {
             self.directories.remove(path);
+            self.directory_queue.retain(|queued| queued != path);
+            self.directory_enqueued.remove(path);
         }
     }
 
@@ -703,8 +773,23 @@ impl DiscoveryIndex {
         if preserve_pinned && self.files.get(path).is_some_and(|file| file.pinned) {
             return;
         }
-        self.files.remove(path);
+        if self.files.remove(path).is_none() {
+            return;
+        }
         self.hot_files.remove(path);
+        // Drop stale scheduler state so a later re-add of this path starts
+        // with clean queues instead of being shadowed by leftover entries.
+        self.cold_queue.retain(|queued| queued != path);
+        self.cold_enqueued.remove(path);
+        self.priority_cold_queue.retain(|queued| queued != path);
+        self.priority_cold_enqueued.remove(path);
+        self.removed_files.push(path.to_path_buf());
+    }
+
+    /// Drain paths removed from tracking since the last call so the service
+    /// loop can prune their cursors.
+    fn take_removed_files(&mut self) -> Vec<PathBuf> {
+        std::mem::take(&mut self.removed_files)
     }
 
     fn reactivate_file(&mut self, path: &Path) {
@@ -838,10 +923,12 @@ fn should_mark_cold(unchanged_polls: u8, modified: Option<SystemTime>, now: Syst
         return false;
     }
 
-    match modified {
-        Some(modified) => now
-            .duration_since(modified)
-            .is_ok_and(|age| age >= FILE_COLD_AGE),
+    // A modified time that cannot be compared against `now` (e.g. a
+    // future-dated mtime from clock skew) is treated like a missing mtime:
+    // fall back to the unchanged-poll threshold instead of keeping the file
+    // hot indefinitely.
+    match modified.and_then(|modified| now.duration_since(modified).ok()) {
+        Some(age) => age >= FILE_COLD_AGE,
         None => unchanged_polls >= FILE_UNCHANGED_POLLS_WITHOUT_MTIME,
     }
 }
@@ -937,6 +1024,18 @@ pub async fn run_mirror_service(runtime: KhiveRuntime, config: MirrorConfig) {
 
     loop {
         let directory_work = discovery.probe_directories();
+        // Files removed from discovery must not leave stale cursors behind:
+        // a recreated same-path file would otherwise inherit its
+        // predecessor's offset and skip early data.
+        let removed_files = discovery.take_removed_files();
+        if !removed_files.is_empty() {
+            for removed in &removed_files {
+                offsets.remove(removed);
+            }
+            if let Err(error) = delete_cursors(&runtime, &removed_files).await {
+                tracing::debug!(error = %error, "session mirror: cursor cleanup failed");
+            }
+        }
         let scheduled = discovery.schedule_files();
         let total_tracked = discovery.tracked_files();
         let mut files_mirrored: u64 = 0;
@@ -957,6 +1056,12 @@ pub async fn run_mirror_service(runtime: KhiveRuntime, config: MirrorConfig) {
                             path = %scheduled_file.path.display(),
                             error = %e,
                             "session mirror: stat failed"
+                        );
+                    } else {
+                        tracing::debug!(
+                            path = %scheduled_file.path.display(),
+                            error = %e,
+                            "session mirror: file missing during probe"
                         );
                     }
                     continue;
@@ -1025,7 +1130,12 @@ pub async fn run_mirror_service(runtime: KhiveRuntime, config: MirrorConfig) {
             }
 
             if let Some(stats) = stats {
-                offsets.insert(scheduled_file.path.clone(), stats.new_offset);
+                // `CandidateDispatch::record` already rejects regressing
+                // cursors; guard the write side too so the stored offset can
+                // only advance or hold.
+                if stats.new_offset >= offset {
+                    offsets.insert(scheduled_file.path.clone(), stats.new_offset);
+                }
                 if stats.inserted > 0 || stats.new_offset > offset {
                     files_mirrored += 1;
                     rows_inserted += stats.inserted;
@@ -1105,6 +1215,33 @@ async fn load_cursors(runtime: &KhiveRuntime) -> Result<HashMap<PathBuf, u64>, R
     }
 }
 
+/// Delete persisted cursor rows for files that left discovery.
+///
+/// A recreated same-path file must start from a fresh cursor instead of
+/// inheriting its predecessor's offset (and skipping early data). The caller
+/// logs errors and continues: the in-memory offset map is already pruned, so
+/// a failure here only risks a stale row being reloaded on restart, never
+/// data loss (ingest is idempotent via `INSERT OR IGNORE`).
+async fn delete_cursors(runtime: &KhiveRuntime, paths: &[PathBuf]) -> Result<(), RuntimeError> {
+    let sql = runtime.sql();
+    let mut writer = sql
+        .writer()
+        .await
+        .map_err(|e| RuntimeError::Internal(format!("mirror: cursor writer: {e}")))?;
+
+    for path in paths {
+        writer
+            .execute(SqlStatement {
+                sql: "DELETE FROM session_mirror_cursor WHERE file_path=?1".into(),
+                params: vec![SqlValue::Text(path.to_string_lossy().into_owned())],
+                label: Some("mirror_cursor_delete".into()),
+            })
+            .await
+            .map_err(|e| RuntimeError::Internal(format!("mirror: cursor delete: {e}")))?;
+    }
+    Ok(())
+}
+
 /// Extract the session UUID from a Codex filename of the form
 /// `rollout-<timestamp>-<uuid>.jsonl`.
 ///
@@ -1144,14 +1281,14 @@ fn extract_codex_session_id(path: &std::path::Path) -> Option<String> {
 mod discovery_tests {
     use super::{
         should_mark_cold, CandidateDispatch, DirectoryKind, DiscoveredKind, DiscoveryIndex,
-        COLD_FILE_PROBES_PER_TICK, DIRECTORY_PROBES_PER_TICK, FILE_COLD_AGE,
-        FILE_UNCHANGED_POLLS_BEFORE_COLD,
+        COLD_FILE_PROBES_PER_TICK, DIRECTORY_FORCE_RESCAN_PROBES, DIRECTORY_PROBES_PER_TICK,
+        FILE_COLD_AGE, FILE_UNCHANGED_POLLS_BEFORE_COLD, FILE_UNCHANGED_POLLS_WITHOUT_MTIME,
     };
     use crate::mirror::ingest::MirrorStats;
     use std::fs::OpenOptions;
     use std::io::Write;
     use std::path::{Path, PathBuf};
-    use std::time::{SystemTime, UNIX_EPOCH};
+    use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
     fn mark_cold(discovery: &mut DiscoveryIndex, path: &Path) {
         let file = discovery.files.get_mut(path).expect("tracked file");
@@ -1371,6 +1508,221 @@ mod discovery_tests {
             Some(now),
             now
         ));
+    }
+
+    #[test]
+    fn future_mtime_falls_back_to_unchanged_poll_threshold() {
+        let now = SystemTime::now();
+        let future = now
+            .checked_add(Duration::from_secs(3600))
+            .expect("future timestamp");
+        assert!(
+            !should_mark_cold(FILE_UNCHANGED_POLLS_WITHOUT_MTIME - 1, Some(future), now),
+            "below the no-mtime threshold an unusable mtime must not mark cold"
+        );
+        assert!(
+            should_mark_cold(FILE_UNCHANGED_POLLS_WITHOUT_MTIME, Some(future), now),
+            "a future-dated mtime must fall back to the unchanged-poll threshold"
+        );
+    }
+
+    #[test]
+    fn regressing_candidate_offset_is_never_recorded() {
+        let start_offset = 100;
+        let mut dispatch = CandidateDispatch::default();
+
+        assert!(!dispatch.record(
+            Ok(MirrorStats {
+                inserted: 4,
+                scanned: 4,
+                new_offset: start_offset - 60,
+            }),
+            start_offset,
+        ));
+        assert!(
+            dispatch.stats.is_none(),
+            "a regressing cursor must not be recorded"
+        );
+
+        assert!(dispatch.record(
+            Ok(MirrorStats {
+                inserted: 1,
+                scanned: 1,
+                new_offset: start_offset + 50,
+            }),
+            start_offset,
+        ));
+        assert_eq!(
+            dispatch
+                .stats
+                .expect("advancing candidate recorded")
+                .new_offset,
+            150
+        );
+    }
+
+    #[test]
+    fn remove_file_clears_scheduler_state_and_readd_starts_clean() {
+        let mut discovery = DiscoveryIndex::default();
+        let path = PathBuf::from("/cold/session.jsonl");
+        discovery.add_file(path.clone(), DiscoveredKind::ChatGptExport, false);
+        mark_cold(&mut discovery, &path);
+        assert!(discovery.cold_enqueued.contains(&path));
+
+        discovery.remove_file(&path, false);
+        assert!(discovery.cold_queue.iter().all(|queued| queued != &path));
+        assert!(!discovery.cold_enqueued.contains(&path));
+        assert!(discovery
+            .priority_cold_queue
+            .iter()
+            .all(|queued| queued != &path));
+        assert!(!discovery.priority_cold_enqueued.contains(&path));
+
+        // A re-added path is scheduled on the next tick instead of being
+        // shadowed by leftover queue state.
+        discovery.add_file(path.clone(), DiscoveredKind::ChatGptExport, false);
+        mark_cold(&mut discovery, &path);
+        assert!(discovery
+            .schedule_files()
+            .iter()
+            .any(|file| file.path == path && file.was_cold));
+    }
+
+    #[test]
+    fn remove_directory_tree_clears_directory_schedule_state() {
+        let temp = tempfile::TempDir::new().expect("temp dir");
+        let root = temp.path().join("projects");
+        std::fs::create_dir_all(&root).expect("root dir");
+
+        let mut discovery = DiscoveryIndex::default();
+        discovery.add_directory_tree(&root, DirectoryKind::ClaudeCodeRoot, false);
+        assert!(discovery.directory_enqueued.contains(&root));
+
+        discovery.remove_directory_tree(&root, false);
+        assert!(discovery
+            .directory_queue
+            .iter()
+            .all(|queued| queued != &root));
+        assert!(!discovery.directory_enqueued.contains(&root));
+
+        // A re-added directory is probed again instead of waiting for a
+        // stale queue entry to drain.
+        discovery.add_directory_tree(&root, DirectoryKind::ClaudeCodeRoot, false);
+        let stats = discovery.probe_directories();
+        assert_eq!(stats.metadata_probes, 1);
+    }
+
+    #[test]
+    fn removed_files_are_reported_once_for_cursor_cleanup() {
+        let mut discovery = DiscoveryIndex::default();
+        let path = PathBuf::from("/exports/conversations.json");
+        discovery.add_file(path.clone(), DiscoveredKind::ChatGptExport, false);
+
+        discovery.remove_file(&path, false);
+        assert_eq!(discovery.take_removed_files(), vec![path.clone()]);
+        assert!(discovery.take_removed_files().is_empty());
+
+        // A pinned file that survives removal is not reported as removed.
+        discovery.add_file(path.clone(), DiscoveredKind::ChatGptExport, true);
+        discovery.remove_file(&path, true);
+        assert!(discovery.files.contains_key(&path));
+        assert!(discovery.take_removed_files().is_empty());
+    }
+
+    #[test]
+    fn pinned_missing_file_stays_tracked_and_hot_for_retry() {
+        let mut discovery = DiscoveryIndex::default();
+        let pinned = PathBuf::from("/exports/conversations.json");
+        discovery.add_file(pinned.clone(), DiscoveredKind::ChatGptExport, true);
+
+        discovery.record_probe_error(&pinned, false, true);
+        assert!(discovery.files.contains_key(&pinned));
+        assert!(discovery.hot_files.contains(&pinned));
+        assert!(discovery
+            .schedule_files()
+            .iter()
+            .any(|file| file.path == pinned && !file.was_cold));
+
+        let transient = PathBuf::from("/projects/gone.jsonl");
+        discovery.add_file(transient.clone(), DiscoveredKind::ChatGptExport, false);
+        discovery.record_probe_error(&transient, false, true);
+        assert!(!discovery.files.contains_key(&transient));
+        assert!(!discovery.hot_files.contains(&transient));
+    }
+
+    #[test]
+    fn export_directory_becoming_a_file_keeps_pinned_identity_for_reversion() {
+        let temp = tempfile::TempDir::new().expect("temp dir");
+        let root = temp.path().join("conversations.json");
+        std::fs::create_dir(&root).expect("root directory");
+
+        let mut discovery = DiscoveryIndex::default();
+        discovery.add_directory_tree(&root, DirectoryKind::ChatGptExport, true);
+
+        // The configured root is replaced by a regular export file.
+        std::fs::remove_dir(&root).expect("remove root directory");
+        std::fs::write(&root, "[]").expect("export file fixture");
+        discovery.probe_directories();
+
+        let file = discovery.files.get(&root).expect("export file tracked");
+        assert!(file.pinned);
+        assert!(file.kinds.contains(&DiscoveredKind::ChatGptExport));
+        let directory = discovery
+            .directories
+            .get(&root)
+            .expect("directory identity retained while the path is a file");
+        assert!(directory.pinned);
+        assert!(directory.kinds.contains(&DirectoryKind::ChatGptExport));
+
+        // The path reverts to a directory containing an export file.
+        std::fs::remove_file(&root).expect("remove export file");
+        std::fs::create_dir(&root).expect("recreate root directory");
+        std::fs::write(root.join("conversations.json"), "[]").expect("nested export fixture");
+        discovery.probe_directories();
+
+        let directory = discovery
+            .directories
+            .get(&root)
+            .expect("configured root still scheduled after reversion");
+        assert!(directory.pinned);
+        assert!(directory.kinds.contains(&DirectoryKind::ChatGptExport));
+        assert!(
+            !discovery.files.contains_key(&root),
+            "the stale file record from the file phase must not shadow the directory"
+        );
+        assert!(discovery
+            .files
+            .contains_key(&root.join("conversations.json")));
+    }
+
+    #[test]
+    fn force_rescan_without_fingerprint_change_does_not_reprioritize_cold_files() {
+        let temp = tempfile::TempDir::new().expect("temp dir");
+        let project = temp.path().join("project-slug");
+        std::fs::create_dir(&project).expect("project dir");
+        let transcript = project.join("session.jsonl");
+        std::fs::write(&transcript, "first\n").expect("transcript fixture");
+
+        let mut discovery = DiscoveryIndex::default();
+        discovery.add_directory_tree(temp.path(), DirectoryKind::ClaudeCodeRoot, true);
+        mark_cold(&mut discovery, &transcript);
+
+        // Drain the startup enqueue with an unchanged probe.
+        discovery.probe_directories();
+
+        discovery
+            .directories
+            .get_mut(&project)
+            .expect("tracked project directory")
+            .unchanged_probes = DIRECTORY_FORCE_RESCAN_PROBES;
+
+        let stats = discovery.probe_directories();
+        assert_eq!(stats.walks, 1);
+        assert!(
+            discovery.priority_cold_queue.is_empty(),
+            "a forced rescan of an unchanged directory carries no change signal"
+        );
+        assert!(discovery.cold_enqueued.contains(&transcript));
     }
 }
 

--- a/crates/khive-pack-session/src/mirror/service.rs
+++ b/crates/khive-pack-session/src/mirror/service.rs
@@ -6,14 +6,15 @@
 //!
 //! Design principles:
 //! - Infallible: a per-file error is logged and skipped; the loop continues.
-//! - Cheap when idle: each tick performs only `metadata().len()` stat calls;
-//!   actual reads happen only when the file has grown.
+//! - Cheap when idle: directory listings are cached and cold-file metadata
+//!   probes are scheduled through fixed per-tick budgets.
 //! - Idempotent: offset tracking + `INSERT OR IGNORE` in `mirror_file` ensure
 //!   running multiple times or restarting the daemon is safe.
 
-use std::collections::HashMap;
-use std::path::PathBuf;
-use std::time::Duration;
+use std::collections::{HashMap, HashSet, VecDeque};
+use std::io;
+use std::path::{Path, PathBuf};
+use std::time::{Duration, SystemTime};
 
 use khive_runtime::{KhiveRuntime, RuntimeError};
 use khive_storage::types::{SqlStatement, SqlValue};
@@ -26,6 +27,7 @@ use super::ingest::{self, LineTailSource};
 /// mirror-source set) but deliberately not `LineTailSource` variants: export
 /// ingestion is whole-file, not line-tail, so it does not belong in that
 /// narrower per-line dispatch enum.
+#[derive(Clone, PartialEq, Eq)]
 enum DiscoveredKind {
     LineTail {
         source: LineTailSource,
@@ -36,11 +38,12 @@ enum DiscoveredKind {
     ClaudeAiExport,
 }
 
-/// A discovered file together with how it should be ingested.
-struct DiscoveredFile {
-    path: PathBuf,
-    kind: DiscoveredKind,
-}
+const DIRECTORY_PROBES_PER_TICK: usize = 64;
+const COLD_FILE_PROBES_PER_TICK: usize = 256;
+const DIRECTORY_FORCE_RESCAN_PROBES: u16 = 30;
+const FILE_UNCHANGED_POLLS_BEFORE_COLD: u8 = 2;
+const FILE_COLD_AGE: Duration = Duration::from_secs(5 * 60);
+const FILE_UNCHANGED_POLLS_WITHOUT_MTIME: u8 = 30;
 
 /// Configuration for the mirror service.
 ///
@@ -190,7 +193,7 @@ impl MirrorConfig {
 
 #[cfg(test)]
 mod config_tests {
-    use super::{parse_mirror_poll_secs, scan_claude_ai_conversations_files, DiscoveredKind};
+    use super::{parse_mirror_poll_secs, DirectoryKind, DiscoveredKind, DiscoveryIndex};
 
     /// Regression for PACKSESSION-AUD-002: `KHIVE_MIRROR_POLL_SECS=0` used to
     /// produce a hot polling loop via `Duration::from_secs(0)`. Explicit zero
@@ -234,23 +237,677 @@ mod config_tests {
         std::fs::write(&export, "[]").expect("export fixture");
         std::fs::write(nested.join("conversations-copy.json"), "[]").expect("non-matching fixture");
 
-        let discovered = scan_claude_ai_conversations_files(temp.path());
-        assert_eq!(discovered.len(), 1);
-        assert_eq!(discovered[0].path, export);
+        let mut discovery = DiscoveryIndex::default();
+        discovery.add_directory_tree(temp.path(), DirectoryKind::ClaudeAiExport, true);
+        assert_eq!(discovery.files.len(), 1);
         assert!(matches!(
-            &discovered[0].kind,
-            DiscoveredKind::ClaudeAiExport
+            discovery
+                .files
+                .get(&export)
+                .and_then(|file| file.kinds.first()),
+            Some(&DiscoveredKind::ClaudeAiExport)
         ));
+    }
+
+    #[test]
+    fn overlapping_export_roots_retain_both_parser_candidates() {
+        let temp = tempfile::TempDir::new().expect("temp dir");
+        let export = temp.path().join("conversations.json");
+        std::fs::write(&export, "[]").expect("export fixture");
+
+        let mut discovery = DiscoveryIndex::default();
+        discovery.add_directory_tree(temp.path(), DirectoryKind::ChatGptExport, true);
+        discovery.add_directory_tree(temp.path(), DirectoryKind::ClaudeAiExport, true);
+        discovery.probe_directories();
+
+        let kinds = &discovery.files.get(&export).expect("tracked export").kinds;
+        assert_eq!(kinds.len(), 2);
+        assert!(matches!(
+            kinds.first(),
+            Some(&DiscoveredKind::ChatGptExport)
+        ));
+        assert!(matches!(
+            kinds.get(1),
+            Some(&DiscoveredKind::ClaudeAiExport)
+        ));
+    }
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum DirectoryKind {
+    ClaudeCodeRoot,
+    ClaudeCodeProject,
+    Codex,
+    ChatGptExport,
+    ClaudeAiExport,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct DirectoryFingerprint {
+    modified: Option<SystemTime>,
+    len: u64,
+}
+
+impl DirectoryFingerprint {
+    fn from_metadata(metadata: &std::fs::Metadata) -> Self {
+        Self {
+            modified: metadata.modified().ok(),
+            len: metadata.len(),
+        }
+    }
+}
+
+struct TrackedDirectory {
+    kinds: Vec<DirectoryKind>,
+    fingerprint: Option<DirectoryFingerprint>,
+    entries: HashSet<PathBuf>,
+    unchanged_probes: u16,
+    pinned: bool,
+}
+
+struct TrackedFile {
+    kinds: Vec<DiscoveredKind>,
+    cold: bool,
+    unchanged_polls: u8,
+    pinned: bool,
+}
+
+struct ScheduledFile {
+    path: PathBuf,
+    was_cold: bool,
+}
+
+#[derive(Default)]
+struct CandidateDispatch {
+    stats: Option<ingest::MirrorStats>,
+    errors: Vec<RuntimeError>,
+}
+
+impl CandidateDispatch {
+    fn record(
+        &mut self,
+        result: Result<ingest::MirrorStats, RuntimeError>,
+        start_offset: u64,
+    ) -> bool {
+        match result {
+            Ok(stats) if stats.new_offset > start_offset => {
+                self.stats = Some(stats);
+                true
+            }
+            Ok(stats) => {
+                if self.stats.is_none() {
+                    self.stats = Some(stats);
+                }
+                false
+            }
+            Err(error) => {
+                self.errors.push(error);
+                false
+            }
+        }
+    }
+}
+
+#[derive(Default)]
+struct DirectoryProbeStats {
+    metadata_probes: usize,
+    walks: usize,
+}
+
+#[derive(Default)]
+struct DiscoveryIndex {
+    directories: HashMap<PathBuf, TrackedDirectory>,
+    directory_queue: VecDeque<PathBuf>,
+    directory_enqueued: HashSet<PathBuf>,
+    files: HashMap<PathBuf, TrackedFile>,
+    hot_files: HashSet<PathBuf>,
+    priority_cold_queue: VecDeque<PathBuf>,
+    priority_cold_enqueued: HashSet<PathBuf>,
+    cold_queue: VecDeque<PathBuf>,
+    cold_enqueued: HashSet<PathBuf>,
+}
+
+enum ClassifiedEntry {
+    Directory(DirectoryKind),
+    File(DiscoveredKind),
+}
+
+impl DiscoveryIndex {
+    fn from_config(config: &MirrorConfig) -> Self {
+        let mut discovery = Self::default();
+
+        if config.enabled {
+            discovery.add_directory_tree(&config.projects_dir, DirectoryKind::ClaudeCodeRoot, true);
+        }
+        if config.codex_enabled {
+            discovery.add_directory_tree(&config.codex_sessions_dir, DirectoryKind::Codex, true);
+        }
+        if config.chatgpt_enabled {
+            discovery.add_export_root(
+                &config.chatgpt_exports_dir,
+                DirectoryKind::ChatGptExport,
+                DiscoveredKind::ChatGptExport,
+            );
+        }
+        if config.claude_ai_enabled {
+            discovery.add_export_root(
+                &config.claude_ai_exports_dir,
+                DirectoryKind::ClaudeAiExport,
+                DiscoveredKind::ClaudeAiExport,
+            );
+        }
+
+        discovery
+    }
+
+    fn add_export_root(
+        &mut self,
+        path: &Path,
+        directory_kind: DirectoryKind,
+        file_kind: DiscoveredKind,
+    ) {
+        if path.is_file() {
+            if path.file_name().and_then(|name| name.to_str()) == Some("conversations.json") {
+                self.add_file(path.to_path_buf(), file_kind, true);
+            }
+        } else {
+            self.add_directory_tree(path, directory_kind, true);
+        }
+    }
+
+    fn add_directory_tree(&mut self, root: &Path, kind: DirectoryKind, pinned: bool) {
+        let mut pending = vec![(root.to_path_buf(), kind, pinned)];
+
+        while let Some((path, directory_kind, is_pinned)) = pending.pop() {
+            if let Some(directory) = self.directories.get_mut(&path) {
+                directory.pinned |= is_pinned;
+                if !directory.kinds.contains(&directory_kind) {
+                    directory.kinds.push(directory_kind);
+                    directory.fingerprint = None;
+                }
+                continue;
+            }
+            if self.files.contains_key(&path) {
+                self.remove_file(&path, false);
+            }
+
+            let metadata = match std::fs::metadata(&path) {
+                Ok(metadata) if metadata.is_dir() => Some(metadata),
+                Ok(metadata)
+                    if is_pinned
+                        && metadata.is_file()
+                        && path.file_name().and_then(|name| name.to_str())
+                            == Some("conversations.json") =>
+                {
+                    let file_kind = match directory_kind {
+                        DirectoryKind::ChatGptExport => DiscoveredKind::ChatGptExport,
+                        DirectoryKind::ClaudeAiExport => DiscoveredKind::ClaudeAiExport,
+                        _ => continue,
+                    };
+                    self.add_file(path, file_kind, true);
+                    continue;
+                }
+                Ok(_) => continue,
+                Err(_) if is_pinned => None,
+                Err(_) => continue,
+            };
+
+            let mut fingerprint = metadata.as_ref().map(DirectoryFingerprint::from_metadata);
+            let mut entries = HashSet::new();
+            let mut children = Vec::new();
+
+            if metadata.is_some() {
+                match std::fs::read_dir(&path) {
+                    Ok(read_dir) => {
+                        for entry in read_dir {
+                            let Ok(entry) = entry else {
+                                fingerprint = None;
+                                continue;
+                            };
+                            let child_path = entry.path();
+                            let Ok(file_type) = entry.file_type() else {
+                                fingerprint = None;
+                                continue;
+                            };
+                            let Some(classified) =
+                                classify_entry(directory_kind, &child_path, file_type.is_dir())
+                            else {
+                                continue;
+                            };
+                            entries.insert(child_path.clone());
+                            match classified {
+                                ClassifiedEntry::Directory(child_kind) => {
+                                    children.push((child_path, child_kind, false));
+                                }
+                                ClassifiedEntry::File(file_kind) => {
+                                    self.add_file(child_path, file_kind, false);
+                                }
+                            }
+                        }
+                    }
+                    Err(_) => fingerprint = None,
+                }
+            }
+
+            self.directories.insert(
+                path.clone(),
+                TrackedDirectory {
+                    kinds: vec![directory_kind],
+                    fingerprint,
+                    entries,
+                    unchanged_probes: 0,
+                    pinned: is_pinned,
+                },
+            );
+            self.enqueue_directory(&path);
+            pending.extend(children);
+        }
+    }
+
+    fn add_file(&mut self, path: PathBuf, kind: DiscoveredKind, pinned: bool) {
+        if let Some(file) = self.files.get_mut(&path) {
+            file.pinned |= pinned;
+            if !file.kinds.contains(&kind) {
+                file.kinds.push(kind);
+            }
+            return;
+        }
+
+        self.files.insert(
+            path.clone(),
+            TrackedFile {
+                kinds: vec![kind],
+                cold: false,
+                unchanged_polls: 0,
+                pinned,
+            },
+        );
+        self.hot_files.insert(path);
+    }
+
+    fn probe_directories(&mut self) -> DirectoryProbeStats {
+        let mut stats = DirectoryProbeStats::default();
+        let scheduled = self.directory_queue.len().min(DIRECTORY_PROBES_PER_TICK);
+
+        for _ in 0..scheduled {
+            let Some(path) = self.directory_queue.pop_front() else {
+                break;
+            };
+            self.directory_enqueued.remove(&path);
+            let Some(directory) = self.directories.get(&path) else {
+                continue;
+            };
+            let kinds = directory.kinds.clone();
+            let stored_fingerprint = directory.fingerprint;
+            let force_rescan = directory.unchanged_probes >= DIRECTORY_FORCE_RESCAN_PROBES;
+            stats.metadata_probes += 1;
+
+            match std::fs::metadata(&path) {
+                Ok(metadata) if metadata.is_dir() => {
+                    let fingerprint = DirectoryFingerprint::from_metadata(&metadata);
+                    if force_rescan || Some(fingerprint) != stored_fingerprint {
+                        if let Err(error) = self.refresh_directory(&path, &kinds, fingerprint) {
+                            tracing::debug!(
+                                path = %path.display(),
+                                error = %error,
+                                "session mirror: directory refresh failed"
+                            );
+                        } else {
+                            stats.walks += 1;
+                        }
+                    } else if let Some(directory) = self.directories.get_mut(&path) {
+                        directory.unchanged_probes = directory.unchanged_probes.saturating_add(1);
+                    }
+                }
+                Ok(metadata)
+                    if metadata.is_file()
+                        && path.file_name().and_then(|name| name.to_str())
+                            == Some("conversations.json") =>
+                {
+                    let pinned = self
+                        .directories
+                        .get(&path)
+                        .is_some_and(|directory| directory.pinned);
+                    self.remove_directory_tree(&path, false);
+                    for kind in kinds {
+                        let file_kind = match kind {
+                            DirectoryKind::ChatGptExport => Some(DiscoveredKind::ChatGptExport),
+                            DirectoryKind::ClaudeAiExport => Some(DiscoveredKind::ClaudeAiExport),
+                            _ => None,
+                        };
+                        if let Some(file_kind) = file_kind {
+                            self.add_file(path.clone(), file_kind, pinned);
+                        }
+                    }
+                }
+                Ok(_) => self.remove_directory_tree(&path, true),
+                Err(error) if error.kind() == io::ErrorKind::NotFound => {
+                    self.remove_directory_tree(&path, true);
+                }
+                Err(error) => {
+                    tracing::debug!(
+                        path = %path.display(),
+                        error = %error,
+                        "session mirror: directory metadata probe failed"
+                    );
+                }
+            }
+
+            if self.directories.contains_key(&path) {
+                self.enqueue_directory(&path);
+            }
+        }
+
+        stats
+    }
+
+    fn refresh_directory(
+        &mut self,
+        path: &Path,
+        kinds: &[DirectoryKind],
+        fingerprint: DirectoryFingerprint,
+    ) -> io::Result<()> {
+        let read_dir = std::fs::read_dir(path)?;
+        let mut entries = HashSet::new();
+        let mut directories = Vec::new();
+        let mut files = Vec::new();
+
+        for entry in read_dir {
+            let entry = entry?;
+            let child_path = entry.path();
+            let file_type = entry.file_type()?;
+            for kind in kinds {
+                let Some(classified) = classify_entry(*kind, &child_path, file_type.is_dir())
+                else {
+                    continue;
+                };
+                entries.insert(child_path.clone());
+                match classified {
+                    ClassifiedEntry::Directory(child_kind) => {
+                        directories.push((child_path.clone(), child_kind));
+                    }
+                    ClassifiedEntry::File(file_kind) => {
+                        files.push((child_path.clone(), file_kind));
+                    }
+                }
+            }
+        }
+
+        let removed = self
+            .directories
+            .get(path)
+            .map(|directory| {
+                directory
+                    .entries
+                    .difference(&entries)
+                    .cloned()
+                    .collect::<Vec<_>>()
+            })
+            .unwrap_or_default();
+
+        for removed_path in removed {
+            if self.directories.contains_key(&removed_path) {
+                self.remove_directory_tree(&removed_path, true);
+            } else {
+                self.remove_file(&removed_path, true);
+            }
+        }
+
+        for (file_path, file_kind) in files {
+            let already_tracked = self.files.contains_key(&file_path);
+            self.add_file(file_path.clone(), file_kind, false);
+            if already_tracked {
+                self.prioritize_cold(&file_path);
+            }
+        }
+        for (directory_path, directory_kind) in directories {
+            self.add_directory_tree(&directory_path, directory_kind, false);
+        }
+
+        if let Some(directory) = self.directories.get_mut(path) {
+            directory.fingerprint = Some(fingerprint);
+            directory.entries = entries;
+            directory.unchanged_probes = 0;
+        }
+
+        Ok(())
+    }
+
+    fn remove_directory_tree(&mut self, path: &Path, keep_pinned: bool) {
+        let Some(directory) = self.directories.get(path) else {
+            return;
+        };
+        let entries = directory.entries.iter().cloned().collect::<Vec<_>>();
+        let pinned = directory.pinned;
+
+        for entry in entries {
+            if self.directories.contains_key(&entry) {
+                self.remove_directory_tree(&entry, true);
+            } else {
+                self.remove_file(&entry, true);
+            }
+        }
+
+        if keep_pinned && pinned {
+            if let Some(directory) = self.directories.get_mut(path) {
+                directory.fingerprint = None;
+                directory.entries.clear();
+                directory.unchanged_probes = 0;
+            }
+        } else {
+            self.directories.remove(path);
+        }
+    }
+
+    fn remove_file(&mut self, path: &Path, preserve_pinned: bool) {
+        if preserve_pinned && self.files.get(path).is_some_and(|file| file.pinned) {
+            return;
+        }
+        self.files.remove(path);
+        self.hot_files.remove(path);
+    }
+
+    fn reactivate_file(&mut self, path: &Path) {
+        if let Some(file) = self.files.get_mut(path) {
+            file.cold = false;
+            file.unchanged_polls = 0;
+            self.hot_files.insert(path.to_path_buf());
+        }
+    }
+
+    fn schedule_files(&mut self) -> Vec<ScheduledFile> {
+        let mut scheduled = self
+            .hot_files
+            .iter()
+            .filter(|path| self.files.contains_key(*path))
+            .cloned()
+            .map(|path| ScheduledFile {
+                path,
+                was_cold: false,
+            })
+            .collect::<Vec<_>>();
+        let mut remaining_cold_probes = COLD_FILE_PROBES_PER_TICK;
+        let mut selected_cold = HashSet::new();
+        let priority_candidates = self.priority_cold_queue.len();
+
+        for _ in 0..priority_candidates {
+            if remaining_cold_probes == 0 {
+                break;
+            }
+            let Some(path) = self.priority_cold_queue.pop_front() else {
+                break;
+            };
+            self.priority_cold_enqueued.remove(&path);
+            if self.files.get(&path).is_some_and(|file| file.cold)
+                && selected_cold.insert(path.clone())
+            {
+                scheduled.push(ScheduledFile {
+                    path,
+                    was_cold: true,
+                });
+                remaining_cold_probes -= 1;
+            }
+        }
+
+        let cold_candidates = self.cold_queue.len();
+
+        for _ in 0..cold_candidates {
+            if remaining_cold_probes == 0 {
+                break;
+            }
+            let Some(path) = self.cold_queue.pop_front() else {
+                break;
+            };
+            self.cold_enqueued.remove(&path);
+            if self.files.get(&path).is_some_and(|file| file.cold)
+                && selected_cold.insert(path.clone())
+            {
+                scheduled.push(ScheduledFile {
+                    path,
+                    was_cold: true,
+                });
+                remaining_cold_probes -= 1;
+            }
+        }
+
+        scheduled
+    }
+
+    fn record_unchanged(
+        &mut self,
+        path: &Path,
+        was_cold: bool,
+        modified: Option<SystemTime>,
+        now: SystemTime,
+    ) {
+        let Some(file) = self.files.get_mut(path) else {
+            return;
+        };
+
+        if was_cold || file.cold {
+            file.cold = true;
+            self.enqueue_cold(path);
+            return;
+        }
+
+        file.unchanged_polls = file.unchanged_polls.saturating_add(1);
+        if should_mark_cold(file.unchanged_polls, modified, now) {
+            file.cold = true;
+            self.hot_files.remove(path);
+            self.enqueue_cold(path);
+        }
+    }
+
+    fn record_probe_error(&mut self, path: &Path, was_cold: bool, missing: bool) {
+        let pinned = self.files.get(path).is_some_and(|file| file.pinned);
+        if missing && !pinned {
+            self.remove_file(path, false);
+        } else if was_cold {
+            self.enqueue_cold(path);
+        }
+    }
+
+    fn enqueue_cold(&mut self, path: &Path) {
+        if self.files.contains_key(path) && self.cold_enqueued.insert(path.to_path_buf()) {
+            self.cold_queue.push_back(path.to_path_buf());
+        }
+    }
+
+    fn prioritize_cold(&mut self, path: &Path) {
+        if self.files.get(path).is_some_and(|file| file.cold)
+            && self.priority_cold_enqueued.insert(path.to_path_buf())
+        {
+            self.priority_cold_queue.push_back(path.to_path_buf());
+        }
+    }
+
+    fn enqueue_directory(&mut self, path: &Path) {
+        if self.directories.contains_key(path) && self.directory_enqueued.insert(path.to_path_buf())
+        {
+            self.directory_queue.push_back(path.to_path_buf());
+        }
+    }
+
+    fn tracked_files(&self) -> usize {
+        self.files.len()
+    }
+}
+
+fn should_mark_cold(unchanged_polls: u8, modified: Option<SystemTime>, now: SystemTime) -> bool {
+    if unchanged_polls < FILE_UNCHANGED_POLLS_BEFORE_COLD {
+        return false;
+    }
+
+    match modified {
+        Some(modified) => now
+            .duration_since(modified)
+            .is_ok_and(|age| age >= FILE_COLD_AGE),
+        None => unchanged_polls >= FILE_UNCHANGED_POLLS_WITHOUT_MTIME,
+    }
+}
+
+fn classify_entry(
+    directory_kind: DirectoryKind,
+    path: &Path,
+    is_directory: bool,
+) -> Option<ClassifiedEntry> {
+    if is_directory {
+        return match directory_kind {
+            DirectoryKind::ClaudeCodeRoot => {
+                Some(ClassifiedEntry::Directory(DirectoryKind::ClaudeCodeProject))
+            }
+            DirectoryKind::ClaudeCodeProject => None,
+            DirectoryKind::Codex => Some(ClassifiedEntry::Directory(DirectoryKind::Codex)),
+            DirectoryKind::ChatGptExport => {
+                Some(ClassifiedEntry::Directory(DirectoryKind::ChatGptExport))
+            }
+            DirectoryKind::ClaudeAiExport => {
+                Some(ClassifiedEntry::Directory(DirectoryKind::ClaudeAiExport))
+            }
+        };
+    }
+
+    match directory_kind {
+        DirectoryKind::ClaudeCodeProject
+            if path.extension().and_then(|extension| extension.to_str()) == Some("jsonl") =>
+        {
+            Some(ClassifiedEntry::File(DiscoveredKind::LineTail {
+                source: LineTailSource::ClaudeCode,
+                session_id: None,
+            }))
+        }
+        DirectoryKind::Codex
+            if path.extension().and_then(|extension| extension.to_str()) == Some("jsonl") =>
+        {
+            extract_codex_session_id(path).map(|session_id| {
+                ClassifiedEntry::File(DiscoveredKind::LineTail {
+                    source: LineTailSource::Codex,
+                    session_id: Some(session_id),
+                })
+            })
+        }
+        DirectoryKind::ChatGptExport
+            if path.file_name().and_then(|name| name.to_str()) == Some("conversations.json") =>
+        {
+            Some(ClassifiedEntry::File(DiscoveredKind::ChatGptExport))
+        }
+        DirectoryKind::ClaudeAiExport
+            if path.file_name().and_then(|name| name.to_str()) == Some("conversations.json") =>
+        {
+            Some(ClassifiedEntry::File(DiscoveredKind::ClaudeAiExport))
+        }
+        _ => None,
     }
 }
 
 /// Infinite background polling loop.  Returns only on a fatal setup error.
 ///
-/// Seed state from the `session_mirror_cursor` table at startup, then loop:
-/// stat each discovered file, tail any new bytes, sleep.
+/// Seed state from the `session_mirror_cursor` table and one initial discovery
+/// pass at startup, then loop: probe changed directories and active files,
+/// sample a bounded cold-file set, tail new bytes, sleep.
 ///
-/// Every source is independent: each is enabled by its own flag and scanned
-/// separately each tick.
+/// Every source is independent: each is enabled by its own flag and indexed
+/// under its own configured root.
 ///
 /// Per-file errors are logged with `tracing::warn!` and do NOT stop the loop.
 pub async fn run_mirror_service(runtime: KhiveRuntime, config: MirrorConfig) {
@@ -276,111 +933,108 @@ pub async fn run_mirror_service(runtime: KhiveRuntime, config: MirrorConfig) {
             HashMap::new()
         }
     };
+    let mut discovery = DiscoveryIndex::from_config(&config);
 
     loop {
-        // Collect all files to process this tick.
-        let mut discovered: Vec<DiscoveredFile> = Vec::new();
-
-        if config.enabled {
-            for path in scan_cc_jsonl_files(&config.projects_dir) {
-                discovered.push(DiscoveredFile {
-                    path,
-                    kind: DiscoveredKind::LineTail {
-                        source: LineTailSource::ClaudeCode,
-                        session_id: None,
-                    },
-                });
-            }
-        }
-
-        if config.codex_enabled {
-            for item in scan_codex_jsonl_files(&config.codex_sessions_dir) {
-                discovered.push(item);
-            }
-        }
-
-        if config.chatgpt_enabled {
-            for item in scan_chatgpt_conversations_files(&config.chatgpt_exports_dir) {
-                discovered.push(item);
-            }
-        }
-
-        if config.claude_ai_enabled {
-            for item in scan_claude_ai_conversations_files(&config.claude_ai_exports_dir) {
-                discovered.push(item);
-            }
-        }
-
-        let total_tracked = discovered.len();
+        let directory_work = discovery.probe_directories();
+        let scheduled = discovery.schedule_files();
+        let total_tracked = discovery.tracked_files();
         let mut files_mirrored: u64 = 0;
         let mut rows_inserted: u64 = 0;
 
-        for item in &discovered {
-            // Seed offset for newly discovered files.
-            if !offsets.contains_key(&item.path) {
-                let start = if config.backfill {
-                    0
-                } else {
-                    std::fs::metadata(&item.path).map(|m| m.len()).unwrap_or(0)
-                };
-                offsets.insert(item.path.clone(), start);
-            }
-
-            let offset = *offsets.get(&item.path).unwrap_or(&0);
-
-            // Fast path: skip if file hasn't grown.
-            let file_len = match std::fs::metadata(&item.path).map(|m| m.len()) {
-                Ok(len) => len,
+        for scheduled_file in scheduled {
+            let metadata = match std::fs::metadata(&scheduled_file.path) {
+                Ok(metadata) => metadata,
                 Err(e) => {
-                    tracing::warn!(path = %item.path.display(), error = %e, "session mirror: stat failed");
+                    let missing = e.kind() == io::ErrorKind::NotFound;
+                    discovery.record_probe_error(
+                        &scheduled_file.path,
+                        scheduled_file.was_cold,
+                        missing,
+                    );
+                    if !missing {
+                        tracing::warn!(
+                            path = %scheduled_file.path.display(),
+                            error = %e,
+                            "session mirror: stat failed"
+                        );
+                    }
                     continue;
                 }
             };
+            let file_len = metadata.len();
+            let modified = metadata.modified().ok();
+
+            let offset = *offsets
+                .entry(scheduled_file.path.clone())
+                .or_insert(if config.backfill { 0 } else { file_len });
 
             if file_len <= offset {
+                discovery.record_unchanged(
+                    &scheduled_file.path,
+                    scheduled_file.was_cold,
+                    modified,
+                    SystemTime::now(),
+                );
                 continue;
             }
+            discovery.reactivate_file(&scheduled_file.path);
 
             // Tail line sources or re-read provider exports whole.
-            let result = match &item.kind {
-                DiscoveredKind::LineTail { source, session_id } => {
-                    ingest::mirror_file(
-                        &runtime,
-                        &item.path,
-                        offset,
-                        *source,
-                        session_id.as_deref(),
-                    )
-                    .await
-                }
-                DiscoveredKind::ChatGptExport => {
-                    ingest::mirror_chatgpt_export_file(&runtime, &item.path, offset).await
-                }
-                DiscoveredKind::ClaudeAiExport => {
-                    ingest::mirror_claude_ai_export_file(&runtime, &item.path, offset).await
-                }
+            let Some(kinds) = discovery
+                .files
+                .get(&scheduled_file.path)
+                .map(|file| file.kinds.clone())
+            else {
+                continue;
             };
-
-            match result {
-                Ok(stats) => {
-                    offsets.insert(item.path.clone(), stats.new_offset);
-                    if stats.inserted > 0 || stats.new_offset > offset {
-                        files_mirrored += 1;
-                        rows_inserted += stats.inserted;
-                        tracing::debug!(
-                            path = %item.path.display(),
-                            inserted = stats.inserted,
-                            scanned = stats.scanned,
-                            new_offset = stats.new_offset,
-                            "session mirror: tailed file"
-                        );
+            let mut candidate_dispatch = CandidateDispatch::default();
+            for kind in kinds {
+                let result = match kind {
+                    DiscoveredKind::LineTail { source, session_id } => {
+                        ingest::mirror_file(
+                            &runtime,
+                            &scheduled_file.path,
+                            offset,
+                            source,
+                            session_id.as_deref(),
+                        )
+                        .await
                     }
+                    DiscoveredKind::ChatGptExport => {
+                        ingest::mirror_chatgpt_export_file(&runtime, &scheduled_file.path, offset)
+                            .await
+                    }
+                    DiscoveredKind::ClaudeAiExport => {
+                        ingest::mirror_claude_ai_export_file(&runtime, &scheduled_file.path, offset)
+                            .await
+                    }
+                };
+                if candidate_dispatch.record(result, offset) {
+                    break;
                 }
-                Err(e) => {
-                    tracing::warn!(
-                        path = %item.path.display(),
-                        error = %e,
-                        "session mirror: per-file error (skipping)"
+            }
+
+            let CandidateDispatch { stats, errors } = candidate_dispatch;
+            for error in errors {
+                tracing::warn!(
+                    path = %scheduled_file.path.display(),
+                    error = %error,
+                    "session mirror: per-file source candidate error"
+                );
+            }
+
+            if let Some(stats) = stats {
+                offsets.insert(scheduled_file.path.clone(), stats.new_offset);
+                if stats.inserted > 0 || stats.new_offset > offset {
+                    files_mirrored += 1;
+                    rows_inserted += stats.inserted;
+                    tracing::debug!(
+                        path = %scheduled_file.path.display(),
+                        inserted = stats.inserted,
+                        scanned = stats.scanned,
+                        new_offset = stats.new_offset,
+                        "session mirror: tailed file"
                     );
                 }
             }
@@ -391,10 +1045,17 @@ pub async fn run_mirror_service(runtime: KhiveRuntime, config: MirrorConfig) {
                 files_mirrored,
                 rows_inserted,
                 total_tracked,
+                directory_metadata_probes = directory_work.metadata_probes,
+                directory_walks = directory_work.walks,
                 "session mirror tick"
             );
         } else {
-            tracing::debug!(total_tracked, "session mirror: quiet tick");
+            tracing::debug!(
+                total_tracked,
+                directory_metadata_probes = directory_work.metadata_probes,
+                directory_walks = directory_work.walks,
+                "session mirror: quiet tick"
+            );
         }
 
         tokio::time::sleep(config.poll_interval).await;
@@ -444,149 +1105,6 @@ async fn load_cursors(runtime: &KhiveRuntime) -> Result<HashMap<PathBuf, u64>, R
     }
 }
 
-/// Scan `projects_dir` for Claude Code `*.jsonl` files one level deep.
-///
-/// Expects the layout: `<projects_dir>/<project-slug>/<session-uuid>.jsonl`.
-/// Silently skips unreadable subdirectories.
-fn scan_cc_jsonl_files(projects_dir: &std::path::Path) -> Vec<PathBuf> {
-    let mut files = Vec::new();
-
-    let Ok(top_entries) = std::fs::read_dir(projects_dir) else {
-        return files;
-    };
-
-    for top_entry in top_entries.flatten() {
-        let slug_dir = top_entry.path();
-        if !slug_dir.is_dir() {
-            continue;
-        }
-        let Ok(sub_entries) = std::fs::read_dir(&slug_dir) else {
-            continue;
-        };
-        for sub_entry in sub_entries.flatten() {
-            let path = sub_entry.path();
-            if path.extension().and_then(|e| e.to_str()) == Some("jsonl") {
-                files.push(path);
-            }
-        }
-    }
-
-    files
-}
-
-/// Recursively scan `sessions_dir` for Codex `rollout-*.jsonl` files.
-///
-/// Expects the date-nested layout:
-/// `<sessions_dir>/YYYY/MM/DD/rollout-<ts>-<uuid>.jsonl`.
-/// The session UUID is parsed from the filename stem.
-/// Silently skips unreadable directories or filenames that do not match the
-/// expected `rollout-…-<uuid>` pattern.
-fn scan_codex_jsonl_files(sessions_dir: &std::path::Path) -> Vec<DiscoveredFile> {
-    let mut files = Vec::new();
-    scan_codex_dir_recursive(sessions_dir, &mut files);
-    files
-}
-
-/// Recursive helper for `scan_codex_jsonl_files`.
-fn scan_codex_dir_recursive(dir: &std::path::Path, out: &mut Vec<DiscoveredFile>) {
-    let Ok(entries) = std::fs::read_dir(dir) else {
-        return;
-    };
-
-    for entry in entries.flatten() {
-        let path = entry.path();
-        if path.is_dir() {
-            scan_codex_dir_recursive(&path, out);
-        } else if path.extension().and_then(|e| e.to_str()) == Some("jsonl") {
-            if let Some(session_id) = extract_codex_session_id(&path) {
-                out.push(DiscoveredFile {
-                    path,
-                    kind: DiscoveredKind::LineTail {
-                        source: LineTailSource::Codex,
-                        session_id: Some(session_id),
-                    },
-                });
-            }
-        }
-    }
-}
-
-/// Find `conversations.json` ChatGPT export files under `path`.
-///
-/// If `path` is itself a file, it is accepted only when its basename is
-/// exactly `conversations.json`; otherwise `path` is scanned recursively.
-/// Silently skips unreadable directories, like the other scanners.
-fn scan_chatgpt_conversations_files(path: &std::path::Path) -> Vec<DiscoveredFile> {
-    let mut files = Vec::new();
-    if path.is_file() {
-        if path.file_name().and_then(|n| n.to_str()) == Some("conversations.json") {
-            files.push(DiscoveredFile {
-                path: path.to_path_buf(),
-                kind: DiscoveredKind::ChatGptExport,
-            });
-        }
-        return files;
-    }
-    scan_chatgpt_dir_recursive(path, &mut files);
-    files
-}
-
-/// Recursive helper for `scan_chatgpt_conversations_files`.
-fn scan_chatgpt_dir_recursive(dir: &std::path::Path, out: &mut Vec<DiscoveredFile>) {
-    let Ok(entries) = std::fs::read_dir(dir) else {
-        return;
-    };
-
-    for entry in entries.flatten() {
-        let path = entry.path();
-        if path.is_dir() {
-            scan_chatgpt_dir_recursive(&path, out);
-        } else if path.file_name().and_then(|n| n.to_str()) == Some("conversations.json") {
-            out.push(DiscoveredFile {
-                path,
-                kind: DiscoveredKind::ChatGptExport,
-            });
-        }
-    }
-}
-
-/// Find `conversations.json` claude.ai export files under `path`.
-///
-/// The configured root is distinct from the ChatGPT export root because the
-/// two providers use the same filename for incompatible JSON shapes.
-fn scan_claude_ai_conversations_files(path: &std::path::Path) -> Vec<DiscoveredFile> {
-    let mut files = Vec::new();
-    if path.is_file() {
-        if path.file_name().and_then(|name| name.to_str()) == Some("conversations.json") {
-            files.push(DiscoveredFile {
-                path: path.to_path_buf(),
-                kind: DiscoveredKind::ClaudeAiExport,
-            });
-        }
-        return files;
-    }
-    scan_claude_ai_dir_recursive(path, &mut files);
-    files
-}
-
-fn scan_claude_ai_dir_recursive(dir: &std::path::Path, out: &mut Vec<DiscoveredFile>) {
-    let Ok(entries) = std::fs::read_dir(dir) else {
-        return;
-    };
-
-    for entry in entries.flatten() {
-        let path = entry.path();
-        if path.is_dir() {
-            scan_claude_ai_dir_recursive(&path, out);
-        } else if path.file_name().and_then(|name| name.to_str()) == Some("conversations.json") {
-            out.push(DiscoveredFile {
-                path,
-                kind: DiscoveredKind::ClaudeAiExport,
-            });
-        }
-    }
-}
-
 /// Extract the session UUID from a Codex filename of the form
 /// `rollout-<timestamp>-<uuid>.jsonl`.
 ///
@@ -619,6 +1137,240 @@ fn extract_codex_session_id(path: &std::path::Path) -> Option<String> {
             );
             None
         }
+    }
+}
+
+#[cfg(test)]
+mod discovery_tests {
+    use super::{
+        should_mark_cold, CandidateDispatch, DirectoryKind, DiscoveredKind, DiscoveryIndex,
+        COLD_FILE_PROBES_PER_TICK, DIRECTORY_PROBES_PER_TICK, FILE_COLD_AGE,
+        FILE_UNCHANGED_POLLS_BEFORE_COLD,
+    };
+    use crate::mirror::ingest::MirrorStats;
+    use std::fs::OpenOptions;
+    use std::io::Write;
+    use std::path::{Path, PathBuf};
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    fn mark_cold(discovery: &mut DiscoveryIndex, path: &Path) {
+        let file = discovery.files.get_mut(path).expect("tracked file");
+        file.cold = true;
+        file.unchanged_polls = FILE_UNCHANGED_POLLS_BEFORE_COLD;
+        discovery.hot_files.remove(path);
+        discovery.enqueue_cold(path);
+    }
+
+    #[test]
+    fn cold_scheduler_has_a_fixed_per_tick_file_probe_ceiling() {
+        let mut discovery = DiscoveryIndex::default();
+        let count = COLD_FILE_PROBES_PER_TICK * 8;
+        for index in 0..count {
+            let path = PathBuf::from(format!("/cold/session-{index}.jsonl"));
+            discovery.add_file(path.clone(), DiscoveredKind::ChatGptExport, false);
+            mark_cold(&mut discovery, &path);
+        }
+
+        let scheduled = discovery.schedule_files();
+        assert_eq!(scheduled.len(), COLD_FILE_PROBES_PER_TICK);
+        assert!(scheduled.iter().all(|file| file.was_cold));
+        assert_eq!(discovery.tracked_files(), count);
+    }
+
+    #[test]
+    fn divergent_provider_limit_no_progress_does_not_block_next_candidate() {
+        let start_offset = 41;
+        let mut dispatch = CandidateDispatch::default();
+
+        assert!(!dispatch.record(
+            Ok(MirrorStats {
+                inserted: 0,
+                scanned: 0,
+                new_offset: start_offset,
+            }),
+            start_offset,
+        ));
+        assert!(dispatch.record(
+            Ok(MirrorStats {
+                inserted: 2,
+                scanned: 2,
+                new_offset: 97,
+            }),
+            start_offset,
+        ));
+
+        let stats = dispatch.stats.expect("progressing provider candidate");
+        assert_eq!(stats.new_offset, 97);
+        assert_eq!(stats.inserted, 2);
+    }
+
+    #[test]
+    fn directory_scheduler_has_a_fixed_per_tick_metadata_ceiling() {
+        let temp = tempfile::TempDir::new().expect("temp dir");
+        let mut discovery = DiscoveryIndex::default();
+        for index in 0..DIRECTORY_PROBES_PER_TICK * 4 {
+            discovery.add_directory_tree(
+                &temp.path().join(format!("missing-{index}")),
+                DirectoryKind::Codex,
+                true,
+            );
+        }
+
+        let stats = discovery.probe_directories();
+        assert_eq!(stats.metadata_probes, DIRECTORY_PROBES_PER_TICK);
+        assert_eq!(stats.walks, 0);
+    }
+
+    #[test]
+    fn parent_mtime_change_prioritizes_a_cold_growing_file_in_that_cycle() {
+        let temp = tempfile::TempDir::new().expect("temp dir");
+        let project = temp.path().join("project-slug");
+        std::fs::create_dir(&project).expect("project dir");
+        let transcript = project.join("session.jsonl");
+        std::fs::write(&transcript, "first\n").expect("transcript fixture");
+
+        let mut discovery = DiscoveryIndex::default();
+        discovery.add_directory_tree(temp.path(), DirectoryKind::ClaudeCodeRoot, true);
+        mark_cold(&mut discovery, &transcript);
+
+        OpenOptions::new()
+            .append(true)
+            .open(&transcript)
+            .expect("open transcript")
+            .write_all(b"second\n")
+            .expect("grow transcript");
+        discovery
+            .directories
+            .get_mut(&project)
+            .expect("tracked project directory")
+            .fingerprint = None;
+
+        let stats = discovery.probe_directories();
+        assert_eq!(stats.walks, 1);
+        assert!(!discovery.hot_files.contains(&transcript));
+        assert!(discovery
+            .schedule_files()
+            .iter()
+            .any(|file| file.path == transcript && file.was_cold));
+    }
+
+    #[test]
+    fn cold_round_robin_is_a_fallback_when_append_does_not_change_parent_mtime() {
+        let mut discovery = DiscoveryIndex::default();
+        let count = COLD_FILE_PROBES_PER_TICK * 3 + 1;
+        let target = PathBuf::from(format!("/cold/session-{}.jsonl", count - 1));
+
+        for index in 0..count {
+            let path = PathBuf::from(format!("/cold/session-{index}.jsonl"));
+            discovery.add_file(path.clone(), DiscoveredKind::ChatGptExport, false);
+            mark_cold(&mut discovery, &path);
+        }
+
+        let mut found_on_cycle = None;
+        for cycle in 1..=4 {
+            let scheduled = discovery.schedule_files();
+            if scheduled.iter().any(|file| file.path == target) {
+                found_on_cycle = Some(cycle);
+                break;
+            }
+            for file in scheduled {
+                discovery.record_unchanged(
+                    &file.path,
+                    file.was_cold,
+                    Some(UNIX_EPOCH),
+                    SystemTime::now(),
+                );
+            }
+        }
+
+        assert_eq!(found_on_cycle, Some(4));
+    }
+
+    #[test]
+    fn missing_configured_root_stays_tracked_until_it_appears() {
+        let temp = tempfile::TempDir::new().expect("temp dir");
+        let root = temp.path().join("codex-sessions");
+        let mut discovery = DiscoveryIndex::default();
+        discovery.add_directory_tree(&root, DirectoryKind::Codex, true);
+
+        discovery.probe_directories();
+        assert!(discovery.directories.contains_key(&root));
+
+        let day = root.join("2026/08/02");
+        std::fs::create_dir_all(&day).expect("date tree");
+        let transcript =
+            day.join("rollout-2026-08-02T12-00-00-019a731e-4a58-71b1-a71f-a8d2f9782113.jsonl");
+        std::fs::write(&transcript, "{}\n").expect("codex transcript");
+
+        discovery.probe_directories();
+        assert!(discovery.files.contains_key(&transcript));
+        assert!(discovery.hot_files.contains(&transcript));
+    }
+
+    #[test]
+    fn nested_configured_root_keeps_identity_across_ancestor_remove_and_recreate() {
+        let temp = tempfile::TempDir::new().expect("temp dir");
+        let ancestor = temp.path().join("exports");
+        let nested = ancestor.join("claude-ai");
+        std::fs::create_dir_all(&nested).expect("nested export root");
+        let export = nested.join("conversations.json");
+        std::fs::write(&export, "[]").expect("export fixture");
+
+        let mut discovery = DiscoveryIndex::default();
+        discovery.add_directory_tree(&ancestor, DirectoryKind::ChatGptExport, true);
+        discovery.add_directory_tree(&nested, DirectoryKind::ClaudeAiExport, true);
+
+        std::fs::remove_dir_all(&nested).expect("remove nested configured root");
+        discovery
+            .directories
+            .get_mut(&ancestor)
+            .expect("tracked ancestor")
+            .fingerprint = None;
+        discovery.probe_directories();
+
+        let missing_root = discovery
+            .directories
+            .get(&nested)
+            .expect("configured nested root remains scheduled");
+        assert!(missing_root.pinned);
+        assert!(missing_root.kinds.contains(&DirectoryKind::ClaudeAiExport));
+
+        std::fs::create_dir_all(&nested).expect("recreate nested configured root");
+        std::fs::write(&export, "[]").expect("recreated export fixture");
+        discovery
+            .directories
+            .get_mut(&ancestor)
+            .expect("tracked ancestor")
+            .fingerprint = None;
+        discovery.probe_directories();
+
+        let kinds = &discovery
+            .files
+            .get(&export)
+            .expect("recreated export discovered")
+            .kinds;
+        assert!(kinds.contains(&DiscoveredKind::ClaudeAiExport));
+    }
+
+    #[test]
+    fn old_unchanged_files_become_cold_only_after_the_threshold() {
+        let now = SystemTime::now();
+        let old = now.checked_sub(FILE_COLD_AGE).expect("old timestamp");
+        assert!(!should_mark_cold(
+            FILE_UNCHANGED_POLLS_BEFORE_COLD - 1,
+            Some(old),
+            now
+        ));
+        assert!(should_mark_cold(
+            FILE_UNCHANGED_POLLS_BEFORE_COLD,
+            Some(old),
+            now
+        ));
+        assert!(!should_mark_cold(
+            FILE_UNCHANGED_POLLS_BEFORE_COLD,
+            Some(now),
+            now
+        ));
     }
 }
 

--- a/crates/khive-pack-session/src/mirror/service.rs
+++ b/crates/khive-pack-session/src/mirror/service.rs
@@ -40,10 +40,33 @@ enum DiscoveredKind {
 
 const DIRECTORY_PROBES_PER_TICK: usize = 64;
 const COLD_FILE_PROBES_PER_TICK: usize = 256;
+/// Worst-case number of STALE cold-queue pops per tick. A stale pop is a
+/// queue entry that turns out to be reactivated, removed, or already
+/// selected — it performs no filesystem work, but lazily invalidated
+/// residue must still be bounded so one tick cannot drain an arbitrary
+/// backlog. Productive pops remain capped by `COLD_FILE_PROBES_PER_TICK`,
+/// independently of this budget (ADR-080 §6).
+const COLD_STALE_POPS_PER_TICK: usize = COLD_FILE_PROBES_PER_TICK * 4;
 const DIRECTORY_FORCE_RESCAN_PROBES: u16 = 30;
 const FILE_UNCHANGED_POLLS_BEFORE_COLD: u8 = 2;
 const FILE_COLD_AGE: Duration = Duration::from_secs(5 * 60);
 const FILE_UNCHANGED_POLLS_WITHOUT_MTIME: u8 = 30;
+/// Consecutive probes on which every source candidate for a file errors
+/// before the file is demoted from hot polling to the cold sample. The
+/// ordinary cold cadence retries it; no separate retry machinery exists.
+const FILE_ERROR_POLLS_BEFORE_COLD: u8 = 3;
+/// Consecutive NotFound probes required before a non-pinned file is removed
+/// from tracking. A single NotFound can be transient (an atomic replace or
+/// a filesystem hiccup); immediate removal would also delete the cursor
+/// row, so a file recreated one tick later would be reseeded to EOF
+/// (`backfill = false`) and skip the bytes written in between.
+const FILE_MISSING_PROBES_BEFORE_REMOVAL: u8 = 2;
+/// Bound on cursor-row deletions awaiting retry after a failed cleanup.
+const CURSOR_DELETE_RETRY_LIMIT: usize = 1024;
+/// Consecutive directory-refresh failures before the failure log escalates
+/// from debug to warn. The counter resets on success, so one warn is
+/// emitted per failure episode, not per tick.
+const DIRECTORY_REFRESH_FAILURES_BEFORE_WARN: u16 = 3;
 
 /// Configuration for the mirror service.
 ///
@@ -303,6 +326,9 @@ struct TrackedDirectory {
     entries: HashSet<PathBuf>,
     unchanged_probes: u16,
     pinned: bool,
+    /// Consecutive refresh failures; drives the one-shot debug→warn
+    /// escalation and resets on success.
+    refresh_failures: u16,
 }
 
 struct TrackedFile {
@@ -310,6 +336,15 @@ struct TrackedFile {
     cold: bool,
     unchanged_polls: u8,
     pinned: bool,
+    /// Probes in a row on which every source candidate errored while the
+    /// file was hot. Resets on any successful advance; at
+    /// `FILE_ERROR_POLLS_BEFORE_COLD` the file is demoted to cold.
+    consecutive_error_polls: u8,
+    /// Consecutive probes on which `stat` reported the file missing.
+    /// Resets on any successful probe; removal requires
+    /// `FILE_MISSING_PROBES_BEFORE_REMOVAL` in a row so a transient
+    /// NotFound (atomic replace, FS hiccup) gets one grace probe.
+    missing_probes: u8,
 }
 
 struct ScheduledFile {
@@ -324,15 +359,40 @@ struct CandidateDispatch {
 }
 
 impl CandidateDispatch {
+    /// Record one candidate's result. Returns `true` when this candidate
+    /// should end dispatch for the file: it advanced the offset past
+    /// `start_offset` AND inserted rows.
+    ///
+    /// Invariant relied on (ADR-080 §6 invariant 4): an `Err` never advances
+    /// the cursor — every ingest path commits the cursor only inside the
+    /// same successful write that consumed the bytes (`write_events_and_cursor`
+    /// is one transaction; `write_cursor_only` failures propagate; export
+    /// paths set `new_offset` only after a successful parse+commit). An
+    /// advancing candidate has therefore durably consumed its byte range.
+    ///
+    /// An advance with zero inserts (a cursor-only pass over
+    /// blank/unparseable/oversized lines, `mirror_file_with_limits`) is
+    /// recorded — the bytes really were consumed — but does NOT end
+    /// dispatch: under misconfigured overlapping roots, a wrong provider
+    /// candidate could otherwise swallow bytes that a later, correct
+    /// provider candidate would have parsed into rows.
     fn record(
         &mut self,
         result: Result<ingest::MirrorStats, RuntimeError>,
         start_offset: u64,
     ) -> bool {
         match result {
-            Ok(stats) if stats.new_offset > start_offset => {
+            Ok(stats) if stats.new_offset > start_offset && stats.inserted > 0 => {
                 self.stats = Some(stats);
                 true
+            }
+            Ok(stats) if stats.new_offset > start_offset => {
+                // Empty advance: cursor durably committed, but no rows were
+                // inserted — fall through to remaining candidates.
+                if self.stats.is_none() {
+                    self.stats = Some(stats);
+                }
+                false
             }
             Ok(stats) if stats.new_offset >= start_offset => {
                 if self.stats.is_none() {
@@ -436,6 +496,10 @@ impl DiscoveryIndex {
                     directory.kinds.push(directory_kind);
                     directory.fingerprint = None;
                 }
+                // The queued invariant is non-local (a directory is only
+                // guaranteed to be in `directory_queue` while its own probe
+                // cycle is intact), so re-assert it on every re-entry.
+                self.enqueue_directory(&path);
                 continue;
             }
             if self.files.contains_key(&path) {
@@ -508,6 +572,7 @@ impl DiscoveryIndex {
                     entries,
                     unchanged_probes: 0,
                     pinned: is_pinned,
+                    refresh_failures: 0,
                 },
             );
             self.enqueue_directory(&path);
@@ -531,6 +596,8 @@ impl DiscoveryIndex {
                 cold: false,
                 unchanged_polls: 0,
                 pinned,
+                consecutive_error_polls: 0,
+                missing_probes: 0,
             },
         );
         self.hot_files.insert(path);
@@ -567,12 +634,28 @@ impl DiscoveryIndex {
                         if let Err(error) =
                             self.refresh_directory(&path, &kinds, fingerprint, changed)
                         {
-                            tracing::debug!(
-                                path = %path.display(),
-                                error = %error,
-                                "session mirror: directory refresh failed"
-                            );
+                            // Escalate once per failure episode: the counter
+                            // crosses the threshold exactly once until a
+                            // success resets it, so a wedged directory is
+                            // visible without per-tick warn spam.
+                            let failures = self.record_refresh_failure(&path);
+                            if failures == DIRECTORY_REFRESH_FAILURES_BEFORE_WARN {
+                                tracing::warn!(
+                                    path = %path.display(),
+                                    error = %error,
+                                    consecutive_failures = failures,
+                                    "session mirror: directory refresh keeps failing"
+                                );
+                            } else {
+                                tracing::debug!(
+                                    path = %path.display(),
+                                    error = %error,
+                                    consecutive_failures = failures,
+                                    "session mirror: directory refresh failed"
+                                );
+                            }
                         } else {
+                            self.clear_refresh_failures(&path);
                             stats.walks += 1;
                         }
                     } else if let Some(directory) = self.directories.get_mut(&path) {
@@ -762,10 +845,20 @@ impl DiscoveryIndex {
                 directory.entries.clear();
                 directory.unchanged_probes = 0;
             }
+            // The queued invariant is non-local — this path's queue entry
+            // may have been popped earlier in the current tick without a
+            // re-enqueue yet — so re-assert it: a retained pinned root must
+            // stay scheduled or its later reappearance is never noticed.
+            self.enqueue_directory(path);
         } else {
             self.directories.remove(path);
-            self.directory_queue.retain(|queued| queued != path);
-            self.directory_enqueued.remove(path);
+            // Queue residue is invalidated lazily: `probe_directories` skips
+            // popped paths that are no longer tracked, and a recursive
+            // O(queue) retain per removed node would make deep tree removals
+            // quadratic. The enqueue flag is deliberately left set until the
+            // residue is popped: it means "an entry is queued", and clearing
+            // it early would let a re-add enqueue a duplicate that gets
+            // probed twice in one tick.
         }
     }
 
@@ -777,11 +870,13 @@ impl DiscoveryIndex {
             return;
         }
         self.hot_files.remove(path);
-        // Drop stale scheduler state so a later re-add of this path starts
-        // with clean queues instead of being shadowed by leftover entries.
-        self.cold_queue.retain(|queued| queued != path);
+        // Cold-queue entries for the removed path are invalidated lazily:
+        // `schedule_files` pops them under the counted stale-pop budget and
+        // skips them because the path is no longer tracked. An O(queue)
+        // `retain` per removal would scan the whole cold ring for residue
+        // that drains itself; clearing the enqueue flags is enough for a
+        // later re-add to start clean.
         self.cold_enqueued.remove(path);
-        self.priority_cold_queue.retain(|queued| queued != path);
         self.priority_cold_enqueued.remove(path);
         self.removed_files.push(path.to_path_buf());
     }
@@ -793,9 +888,18 @@ impl DiscoveryIndex {
     }
 
     fn reactivate_file(&mut self, path: &Path) {
+        // Deliberately does NOT purge `cold_queue` / `priority_cold_queue`:
+        // reactivation can race queued entries, and they are invalidated
+        // lazily by `schedule_files`' counted stale-pop skip instead of an
+        // O(queue) scan here.
         if let Some(file) = self.files.get_mut(path) {
             file.cold = false;
             file.unchanged_polls = 0;
+            // A successful growth probe ends the missing-file streak.
+            file.missing_probes = 0;
+            // ...and starts a fresh error-streak window: "consecutive
+            // error ticks" counts between successful probes.
+            file.consecutive_error_polls = 0;
             self.hot_files.insert(path.to_path_buf());
         }
     }
@@ -811,12 +915,21 @@ impl DiscoveryIndex {
                 was_cold: false,
             })
             .collect::<Vec<_>>();
+        // Productive pops (a still-cold file that gets scheduled and
+        // stat'ed) consume `remaining_cold_probes`, keeping the ADR-080 §6
+        // "at most 256 cold-file metadata probes" ceiling exact. Stale pops
+        // — reactivated, removed, or duplicate entries, invalidated lazily
+        // instead of `retain`-purged on every hot/reactivate/remove path —
+        // do no filesystem work but are still bounded by
+        // `remaining_stale_pops`, so one tick can drain at most a fixed
+        // backlog of residue instead of an arbitrary queue.
         let mut remaining_cold_probes = COLD_FILE_PROBES_PER_TICK;
+        let mut remaining_stale_pops = COLD_STALE_POPS_PER_TICK;
         let mut selected_cold = HashSet::new();
         let priority_candidates = self.priority_cold_queue.len();
 
         for _ in 0..priority_candidates {
-            if remaining_cold_probes == 0 {
+            if remaining_stale_pops == 0 {
                 break;
             }
             let Some(path) = self.priority_cold_queue.pop_front() else {
@@ -826,18 +939,27 @@ impl DiscoveryIndex {
             if self.files.get(&path).is_some_and(|file| file.cold)
                 && selected_cold.insert(path.clone())
             {
+                if remaining_cold_probes == 0 {
+                    // Productive entry popped but the probe budget is
+                    // spent: hand it back and stop.
+                    self.priority_cold_queue.push_front(path.clone());
+                    self.priority_cold_enqueued.insert(path);
+                    break;
+                }
                 scheduled.push(ScheduledFile {
                     path,
                     was_cold: true,
                 });
                 remaining_cold_probes -= 1;
+            } else {
+                remaining_stale_pops -= 1;
             }
         }
 
         let cold_candidates = self.cold_queue.len();
 
         for _ in 0..cold_candidates {
-            if remaining_cold_probes == 0 {
+            if remaining_stale_pops == 0 {
                 break;
             }
             let Some(path) = self.cold_queue.pop_front() else {
@@ -847,11 +969,18 @@ impl DiscoveryIndex {
             if self.files.get(&path).is_some_and(|file| file.cold)
                 && selected_cold.insert(path.clone())
             {
+                if remaining_cold_probes == 0 {
+                    self.cold_queue.push_front(path.clone());
+                    self.cold_enqueued.insert(path);
+                    break;
+                }
                 scheduled.push(ScheduledFile {
                     path,
                     was_cold: true,
                 });
                 remaining_cold_probes -= 1;
+            } else {
+                remaining_stale_pops -= 1;
             }
         }
 
@@ -868,6 +997,8 @@ impl DiscoveryIndex {
         let Some(file) = self.files.get_mut(path) else {
             return;
         };
+        // A successful probe ends any missing-file streak.
+        file.missing_probes = 0;
 
         if was_cold || file.cold {
             file.cold = true;
@@ -886,9 +1017,55 @@ impl DiscoveryIndex {
     fn record_probe_error(&mut self, path: &Path, was_cold: bool, missing: bool) {
         let pinned = self.files.get(path).is_some_and(|file| file.pinned);
         if missing && !pinned {
-            self.remove_file(path, false);
+            // A single NotFound can be transient (an atomic replace or a
+            // filesystem hiccup). Removal also queues the cursor row for
+            // deletion, after which a recreated file would be reseeded to
+            // EOF when `backfill` is off and silently skip the bytes
+            // written in between — so require a second consecutive
+            // NotFound before removing (one-tick grace).
+            let remove = if let Some(file) = self.files.get_mut(path) {
+                file.missing_probes = file.missing_probes.saturating_add(1);
+                file.missing_probes >= FILE_MISSING_PROBES_BEFORE_REMOVAL
+            } else {
+                false
+            };
+            if remove {
+                self.remove_file(path, false);
+            } else if was_cold {
+                self.enqueue_cold(path);
+            }
         } else if was_cold {
             self.enqueue_cold(path);
+        }
+    }
+
+    /// Count a probe on which every source candidate errored. Returns
+    /// `true` exactly on the tick whose streak crosses
+    /// `FILE_ERROR_POLLS_BEFORE_COLD` — the caller's one-shot warn for the
+    /// demotion. A streak of `N` keeps a persistently broken file demoted
+    /// on every later reactivated probe without re-warning, and any
+    /// successful advance resets the streak via [`Self::clear_error_polls`].
+    fn record_error_poll(&mut self, path: &Path) -> bool {
+        let Some(file) = self.files.get_mut(path) else {
+            return false;
+        };
+        file.consecutive_error_polls = file.consecutive_error_polls.saturating_add(1);
+        let crossed_threshold = file.consecutive_error_polls == FILE_ERROR_POLLS_BEFORE_COLD;
+        if file.consecutive_error_polls >= FILE_ERROR_POLLS_BEFORE_COLD && !file.cold {
+            // Demote to the cold sample: the ordinary cold cadence retries
+            // the file, so no separate retry machinery is needed.
+            file.cold = true;
+            file.unchanged_polls = 0;
+            self.hot_files.remove(path);
+            self.enqueue_cold(path);
+        }
+        crossed_threshold
+    }
+
+    /// Reset the consecutive-error streak after a successful cursor advance.
+    fn clear_error_polls(&mut self, path: &Path) {
+        if let Some(file) = self.files.get_mut(path) {
+            file.consecutive_error_polls = 0;
         }
     }
 
@@ -910,6 +1087,26 @@ impl DiscoveryIndex {
         if self.directories.contains_key(path) && self.directory_enqueued.insert(path.to_path_buf())
         {
             self.directory_queue.push_back(path.to_path_buf());
+        }
+    }
+
+    /// Bump the consecutive refresh-failure counter for a directory and
+    /// return the new value (0 when untracked). The caller escalates to
+    /// warn exactly when it crosses `DIRECTORY_REFRESH_FAILURES_BEFORE_WARN`.
+    fn record_refresh_failure(&mut self, path: &Path) -> u16 {
+        self.directories
+            .get_mut(path)
+            .map(|directory| {
+                directory.refresh_failures = directory.refresh_failures.saturating_add(1);
+                directory.refresh_failures
+            })
+            .unwrap_or(0)
+    }
+
+    /// Reset the refresh-failure counter after a successful walk.
+    fn clear_refresh_failures(&mut self, path: &Path) {
+        if let Some(directory) = self.directories.get_mut(path) {
+            directory.refresh_failures = 0;
         }
     }
 
@@ -1021,6 +1218,12 @@ pub async fn run_mirror_service(runtime: KhiveRuntime, config: MirrorConfig) {
         }
     };
     let mut discovery = DiscoveryIndex::from_config(&config);
+    // Cursor rows whose deletion failed, retried on later ticks. A stale
+    // row that survives to a daemon restart is reloaded by `load_cursors`,
+    // and a recreated same-path file would then resume from the old offset
+    // and silently skip bytes — so failed deletions must be retried until
+    // they succeed, not dropped (bounded by `CURSOR_DELETE_RETRY_LIMIT`).
+    let mut pending_cursor_deletes: VecDeque<PathBuf> = VecDeque::new();
 
     loop {
         let directory_work = discovery.probe_directories();
@@ -1032,10 +1235,9 @@ pub async fn run_mirror_service(runtime: KhiveRuntime, config: MirrorConfig) {
             for removed in &removed_files {
                 offsets.remove(removed);
             }
-            if let Err(error) = delete_cursors(&runtime, &removed_files).await {
-                tracing::debug!(error = %error, "session mirror: cursor cleanup failed");
-            }
+            queue_cursor_deletes(&mut pending_cursor_deletes, &removed_files);
         }
+        drain_pending_cursor_deletes(&runtime, &discovery, &mut pending_cursor_deletes).await;
         let scheduled = discovery.schedule_files();
         let total_tracked = discovery.tracked_files();
         let mut files_mirrored: u64 = 0;
@@ -1121,12 +1323,37 @@ pub async fn run_mirror_service(runtime: KhiveRuntime, config: MirrorConfig) {
             }
 
             let CandidateDispatch { stats, errors } = candidate_dispatch;
+            let had_errors = !errors.is_empty();
             for error in errors {
                 tracing::warn!(
                     path = %scheduled_file.path.display(),
                     error = %error,
                     "session mirror: per-file source candidate error"
                 );
+            }
+
+            // A successful advance ends the error streak; a tick on which
+            // every candidate errored grows it toward demotion.
+            let advanced = stats
+                .as_ref()
+                .is_some_and(|stats| stats.new_offset > offset);
+            if advanced {
+                discovery.clear_error_polls(&scheduled_file.path);
+            } else if stats.is_none() && had_errors {
+                // Every source candidate errored this tick: the offset did
+                // not advance and nothing was recorded. Without
+                // intervention the file would stay hot and be re-dispatched
+                // every tick forever; after `FILE_ERROR_POLLS_BEFORE_COLD`
+                // consecutive such ticks, demote it to the cold sample,
+                // whose ordinary cadence retries it (no separate retry
+                // machinery).
+                if discovery.record_error_poll(&scheduled_file.path) {
+                    tracing::warn!(
+                        path = %scheduled_file.path.display(),
+                        consecutive_error_polls = FILE_ERROR_POLLS_BEFORE_COLD,
+                        "session mirror: demoting persistently erroring file to cold"
+                    );
+                }
             }
 
             if let Some(stats) = stats {
@@ -1219,9 +1446,12 @@ async fn load_cursors(runtime: &KhiveRuntime) -> Result<HashMap<PathBuf, u64>, R
 ///
 /// A recreated same-path file must start from a fresh cursor instead of
 /// inheriting its predecessor's offset (and skipping early data). The caller
-/// logs errors and continues: the in-memory offset map is already pruned, so
-/// a failure here only risks a stale row being reloaded on restart, never
-/// data loss (ingest is idempotent via `INSERT OR IGNORE`).
+/// retries failures via the pending-delete set: the in-memory offset map is
+/// already pruned, so an *unretried* failure here is worse than wasted work —
+/// `load_cursors` reloads the stale row on the next daemon restart, and a
+/// recreated same-path file then resumes from the old offset and silently
+/// skips the bytes written in between. Idempotent `INSERT OR IGNORE` does
+/// not cover this case because the skipped bytes are never read at all.
 async fn delete_cursors(runtime: &KhiveRuntime, paths: &[PathBuf]) -> Result<(), RuntimeError> {
     let sql = runtime.sql();
     let mut writer = sql
@@ -1240,6 +1470,58 @@ async fn delete_cursors(runtime: &KhiveRuntime, paths: &[PathBuf]) -> Result<(),
             .map_err(|e| RuntimeError::Internal(format!("mirror: cursor delete: {e}")))?;
     }
     Ok(())
+}
+
+/// Add removed paths to the pending cursor-delete set, deduplicating and
+/// evicting (warn-logged) beyond `CURSOR_DELETE_RETRY_LIMIT` so an outage
+/// cannot grow the set without bound.
+fn queue_cursor_deletes(pending: &mut VecDeque<PathBuf>, removed: &[PathBuf]) {
+    for path in removed {
+        if pending.contains(path) {
+            continue;
+        }
+        if pending.len() >= CURSOR_DELETE_RETRY_LIMIT {
+            let dropped = pending.pop_front();
+            tracing::warn!(
+                dropped = %dropped.map(|p| p.display().to_string()).unwrap_or_default(),
+                limit = CURSOR_DELETE_RETRY_LIMIT,
+                "session mirror: cursor-delete retry set full; dropping oldest entry"
+            );
+        }
+        pending.push_back(path.clone());
+    }
+}
+
+/// Drain the pending cursor-delete set against the store. A path re-tracked
+/// since its removal seeds a fresh in-memory offset and rewrites its cursor
+/// row on the next successful ingest, so its pending delete is cancelled
+/// instead of removing the fresh row out from under it. On failure the set
+/// is kept for retry on later ticks (escalated to warn: a dropped failure
+/// leaves the stale row in place across restarts). Paths deleted before the
+/// error stay in the set and are re-deleted idempotently later.
+async fn drain_pending_cursor_deletes(
+    runtime: &KhiveRuntime,
+    discovery: &DiscoveryIndex,
+    pending: &mut VecDeque<PathBuf>,
+) {
+    if pending.is_empty() {
+        return;
+    }
+    pending.retain(|path| !discovery.files.contains_key(path));
+    if pending.is_empty() {
+        return;
+    }
+    let paths: Vec<PathBuf> = pending.iter().cloned().collect();
+    match delete_cursors(runtime, &paths).await {
+        Ok(()) => pending.clear(),
+        Err(error) => {
+            tracing::warn!(
+                error = %error,
+                remaining = pending.len(),
+                "session mirror: cursor cleanup failed; retrying next tick"
+            );
+        }
+    }
 }
 
 /// Extract the session UUID from a Codex filename of the form
@@ -1281,10 +1563,13 @@ fn extract_codex_session_id(path: &std::path::Path) -> Option<String> {
 mod discovery_tests {
     use super::{
         should_mark_cold, CandidateDispatch, DirectoryKind, DiscoveredKind, DiscoveryIndex,
-        COLD_FILE_PROBES_PER_TICK, DIRECTORY_FORCE_RESCAN_PROBES, DIRECTORY_PROBES_PER_TICK,
-        FILE_COLD_AGE, FILE_UNCHANGED_POLLS_BEFORE_COLD, FILE_UNCHANGED_POLLS_WITHOUT_MTIME,
+        TrackedDirectory, COLD_FILE_PROBES_PER_TICK, COLD_STALE_POPS_PER_TICK,
+        DIRECTORY_FORCE_RESCAN_PROBES, DIRECTORY_PROBES_PER_TICK,
+        DIRECTORY_REFRESH_FAILURES_BEFORE_WARN, FILE_COLD_AGE, FILE_ERROR_POLLS_BEFORE_COLD,
+        FILE_UNCHANGED_POLLS_BEFORE_COLD, FILE_UNCHANGED_POLLS_WITHOUT_MTIME,
     };
     use crate::mirror::ingest::MirrorStats;
+    use std::collections::HashSet;
     use std::fs::OpenOptions;
     use std::io::Write;
     use std::path::{Path, PathBuf};
@@ -1570,13 +1855,15 @@ mod discovery_tests {
         assert!(discovery.cold_enqueued.contains(&path));
 
         discovery.remove_file(&path, false);
-        assert!(discovery.cold_queue.iter().all(|queued| queued != &path));
+        // Queue residue is invalidated lazily: the entry may still sit in
+        // the cold queue, but it must never schedule again, and the enqueue
+        // flags are cleared so a re-add starts clean.
         assert!(!discovery.cold_enqueued.contains(&path));
-        assert!(discovery
-            .priority_cold_queue
-            .iter()
-            .all(|queued| queued != &path));
         assert!(!discovery.priority_cold_enqueued.contains(&path));
+        assert!(discovery
+            .schedule_files()
+            .iter()
+            .all(|file| file.path != path));
 
         // A re-added path is scheduled on the next tick instead of being
         // shadowed by leftover queue state.
@@ -1599,14 +1886,14 @@ mod discovery_tests {
         assert!(discovery.directory_enqueued.contains(&root));
 
         discovery.remove_directory_tree(&root, false);
-        assert!(discovery
-            .directory_queue
-            .iter()
-            .all(|queued| queued != &root));
-        assert!(!discovery.directory_enqueued.contains(&root));
+        // Queue residue is invalidated lazily: the entry may still sit in
+        // the queue, but an untracked path is skipped on pop, and the
+        // enqueue flag stays set until that pop so a re-add cannot enqueue
+        // a duplicate.
+        assert!(discovery.directory_enqueued.contains(&root));
 
-        // A re-added directory is probed again instead of waiting for a
-        // stale queue entry to drain.
+        // A re-added directory is probed exactly once on the next tick
+        // instead of twice (once per queue entry).
         discovery.add_directory_tree(&root, DirectoryKind::ClaudeCodeRoot, false);
         let stats = discovery.probe_directories();
         assert_eq!(stats.metadata_probes, 1);
@@ -1642,12 +1929,201 @@ mod discovery_tests {
             .schedule_files()
             .iter()
             .any(|file| file.path == pinned && !file.was_cold));
+    }
 
+    #[test]
+    fn transient_not_found_gets_one_grace_probe_before_removal() {
+        let mut discovery = DiscoveryIndex::default();
         let transient = PathBuf::from("/projects/gone.jsonl");
         discovery.add_file(transient.clone(), DiscoveredKind::ChatGptExport, false);
+
+        // One NotFound (an atomic replace or FS hiccup) keeps the file and
+        // its cursor so a promptly recreated path resumes from its old
+        // offset instead of being reseeded to EOF.
+        discovery.record_probe_error(&transient, false, true);
+        assert!(discovery.files.contains_key(&transient));
+        assert!(discovery.hot_files.contains(&transient));
+        assert!(discovery.take_removed_files().is_empty());
+
+        // A successful probe in between resets the streak entirely.
+        discovery.record_unchanged(&transient, false, None, SystemTime::now());
+        discovery.record_probe_error(&transient, false, true);
+        assert!(discovery.files.contains_key(&transient));
+
+        // A second consecutive NotFound removes the file and queues cursor
+        // cleanup.
         discovery.record_probe_error(&transient, false, true);
         assert!(!discovery.files.contains_key(&transient));
         assert!(!discovery.hot_files.contains(&transient));
+        assert_eq!(discovery.take_removed_files(), vec![transient.clone()]);
+    }
+
+    #[test]
+    fn stale_cold_queue_residue_is_pop_bounded_and_hot_files_still_scheduled() {
+        let mut discovery = DiscoveryIndex::default();
+
+        // A large backlog of stale entries at the queue head: files that
+        // were cold, enqueued, then reactivated (e.g. growth noticed via a
+        // directory priority sweep) — their queue entries are invalidated
+        // lazily instead of by an O(queue) purge on reactivation.
+        let stale_count = COLD_STALE_POPS_PER_TICK * 5;
+        for index in 0..stale_count {
+            let path = PathBuf::from(format!("/stale/session-{index}.jsonl"));
+            discovery.add_file(path.clone(), DiscoveredKind::ChatGptExport, false);
+            mark_cold(&mut discovery, &path);
+            discovery.reactivate_file(&path);
+        }
+        // Fresh cold files behind the residue.
+        let fresh_count = COLD_FILE_PROBES_PER_TICK * 3;
+        let first_fresh = PathBuf::from("/cold/session-0.jsonl");
+        for index in 0..fresh_count {
+            let path = PathBuf::from(format!("/cold/session-{index}.jsonl"));
+            discovery.add_file(path.clone(), DiscoveredKind::ChatGptExport, false);
+            mark_cold(&mut discovery, &path);
+        }
+        // A hot file must still be scheduled in the same tick.
+        let hot = PathBuf::from("/hot/session.jsonl");
+        discovery.add_file(hot.clone(), DiscoveredKind::ChatGptExport, false);
+
+        let queue_before = discovery.cold_queue.len();
+        assert_eq!(queue_before, stale_count + fresh_count);
+
+        let mut scheduled = discovery.schedule_files();
+        assert!(
+            scheduled
+                .iter()
+                .any(|file| file.path == hot && !file.was_cold),
+            "hot scheduling is unaffected by the residue backlog"
+        );
+        // One tick cannot drain the arbitrary stale backlog: with residue
+        // at the queue head, total pops are bounded by the stale-pop budget
+        // plus the productive probe budget.
+        let drained = queue_before - discovery.cold_queue.len();
+        assert!(drained <= COLD_STALE_POPS_PER_TICK + COLD_FILE_PROBES_PER_TICK);
+        assert!(
+            discovery.cold_queue.len() > fresh_count / 2,
+            "most of the backlog survives one tick"
+        );
+
+        // Bounded lag, no starvation: the residue drains at the stale-pop
+        // rate and the fresh cold files are scheduled once it clears.
+        let mut ticks = 1;
+        while !scheduled.iter().any(|file| file.path == first_fresh) {
+            scheduled = discovery.schedule_files();
+            ticks += 1;
+            assert!(
+                ticks <= (stale_count / COLD_STALE_POPS_PER_TICK) + 2,
+                "stale residue must drain at the bounded per-tick rate"
+            );
+        }
+        assert!(
+            scheduled.iter().filter(|file| file.was_cold).count() <= COLD_FILE_PROBES_PER_TICK,
+            "the productive metadata-probe ceiling holds on the catch-up tick"
+        );
+    }
+
+    #[test]
+    fn persistently_erroring_hot_file_is_demoted_to_cold_and_recovers() {
+        let mut discovery = DiscoveryIndex::default();
+        let path = PathBuf::from("/broken/session.jsonl");
+        discovery.add_file(path.clone(), DiscoveredKind::ChatGptExport, false);
+        assert!(discovery.hot_files.contains(&path));
+
+        // Below the threshold the file stays hot.
+        for _tick in 1..FILE_ERROR_POLLS_BEFORE_COLD {
+            assert!(!discovery.record_error_poll(&path));
+            assert!(discovery.hot_files.contains(&path));
+            assert!(!discovery.files[&path].cold);
+        }
+        // Crossing the threshold demotes to cold exactly once (the one-shot
+        // warn tick) and enqueues it for the ordinary cold cadence.
+        assert!(discovery.record_error_poll(&path));
+        assert!(!discovery.hot_files.contains(&path));
+        assert!(discovery.files[&path].cold);
+        assert!(discovery.cold_enqueued.contains(&path));
+
+        // Further error ticks keep it cold without re-crossing.
+        assert!(!discovery.record_error_poll(&path));
+
+        // Recovery reactivates through the normal hot path and resets the
+        // streak.
+        discovery.reactivate_file(&path);
+        assert!(discovery.hot_files.contains(&path));
+        assert!(!discovery.files[&path].cold);
+        for _ in 1..FILE_ERROR_POLLS_BEFORE_COLD {
+            assert!(!discovery.record_error_poll(&path));
+        }
+        assert!(discovery.record_error_poll(&path));
+    }
+
+    #[test]
+    fn empty_advance_candidate_does_not_mask_inserting_provider() {
+        let start_offset = 10;
+        let mut dispatch = CandidateDispatch::default();
+
+        // A wrong provider can advance the cursor while inserting nothing
+        // (a cursor-only pass over unparseable lines); that must not end
+        // dispatch and hide the provider that parses the same bytes.
+        assert!(!dispatch.record(
+            Ok(MirrorStats {
+                inserted: 0,
+                scanned: 0,
+                new_offset: start_offset + 40,
+            }),
+            start_offset,
+        ));
+        assert!(dispatch.record(
+            Ok(MirrorStats {
+                inserted: 3,
+                scanned: 3,
+                new_offset: start_offset + 40,
+            }),
+            start_offset,
+        ));
+        let stats = dispatch.stats.expect("inserting provider recorded");
+        assert_eq!(stats.inserted, 3);
+        assert_eq!(stats.new_offset, start_offset + 40);
+    }
+
+    #[test]
+    fn refresh_failure_counter_crosses_the_warn_threshold_once_per_episode() {
+        let mut discovery = DiscoveryIndex::default();
+        let path = PathBuf::from("/projects/wedged");
+        discovery.directories.insert(
+            path.clone(),
+            TrackedDirectory {
+                kinds: vec![DirectoryKind::ClaudeCodeRoot],
+                fingerprint: None,
+                entries: HashSet::new(),
+                unchanged_probes: 0,
+                pinned: false,
+                refresh_failures: 0,
+            },
+        );
+
+        for _ in 1..DIRECTORY_REFRESH_FAILURES_BEFORE_WARN {
+            assert_ne!(
+                discovery.record_refresh_failure(&path),
+                DIRECTORY_REFRESH_FAILURES_BEFORE_WARN,
+                "below the threshold the log stays at debug"
+            );
+        }
+        assert_eq!(
+            discovery.record_refresh_failure(&path),
+            DIRECTORY_REFRESH_FAILURES_BEFORE_WARN,
+            "exactly one escalation per episode"
+        );
+        assert_ne!(
+            discovery.record_refresh_failure(&path),
+            DIRECTORY_REFRESH_FAILURES_BEFORE_WARN,
+            "subsequent failures in the same episode do not re-escalate"
+        );
+
+        discovery.clear_refresh_failures(&path);
+        assert_eq!(
+            discovery.directories[&path].refresh_failures, 0,
+            "a successful walk resets the episode"
+        );
     }
 
     #[test]
@@ -1723,6 +2199,170 @@ mod discovery_tests {
             "a forced rescan of an unchanged directory carries no change signal"
         );
         assert!(discovery.cold_enqueued.contains(&transcript));
+    }
+}
+
+#[cfg(test)]
+mod cursor_retry_tests {
+    use super::{
+        delete_cursors, drain_pending_cursor_deletes, queue_cursor_deletes, DiscoveredKind,
+        DiscoveryIndex, CURSOR_DELETE_RETRY_LIMIT,
+    };
+    use crate::vocab::SESSION_SCHEMA_PLAN_STMTS;
+    use khive_runtime::{AllowAllGate, BackendId, KhiveRuntime, Namespace, RuntimeConfig};
+    use khive_storage::types::{SqlStatement, SqlValue};
+    use std::collections::VecDeque;
+    use std::path::PathBuf;
+    use std::sync::Arc;
+    use tempfile::TempDir;
+
+    /// File-backed runtime WITHOUT the session schema applied — cursor DML
+    /// fails with "no such table", which doubles as the fault injection for
+    /// the retry path. Caller keeps the `TempDir` alive.
+    fn runtime_without_schema() -> (KhiveRuntime, TempDir) {
+        let dir = TempDir::new().expect("tempdir");
+        let db_path = dir.path().join("test.db");
+        let rt = KhiveRuntime::new(RuntimeConfig {
+            git_write: Default::default(),
+            db_path: Some(db_path),
+            default_namespace: Namespace::local(),
+            embedding_model: None,
+            additional_embedding_models: vec![],
+            gate: Arc::new(AllowAllGate),
+            packs: vec!["kg".to_string()],
+            backend_id: BackendId::main(),
+            brain_profile: None,
+            visible_namespaces: vec![],
+            allowed_outbound_namespaces: vec![],
+            actor_id: None,
+        })
+        .expect("file-backed runtime");
+        (rt, dir)
+    }
+
+    async fn apply_session_schema(rt: &KhiveRuntime) {
+        let sql = rt.sql();
+        let mut writer = sql.writer().await.expect("writer");
+        for stmt in &SESSION_SCHEMA_PLAN_STMTS {
+            writer
+                .execute_script(stmt.to_string())
+                .await
+                .expect("schema stmt");
+        }
+    }
+
+    async fn insert_cursor_row(rt: &KhiveRuntime, path: &std::path::Path, offset: i64) {
+        let mut writer = rt.sql().writer().await.expect("writer");
+        writer
+            .execute(SqlStatement {
+                sql: "INSERT INTO session_mirror_cursor(file_path, session_id, byte_offset, updated_at) \
+                      VALUES(?1, NULL, ?2, 0)"
+                    .into(),
+                params: vec![
+                    SqlValue::Text(path.to_string_lossy().into_owned()),
+                    SqlValue::Integer(offset),
+                ],
+                label: None,
+            })
+            .await
+            .expect("cursor insert");
+    }
+
+    async fn cursor_row_exists(rt: &KhiveRuntime, path: &std::path::Path) -> bool {
+        let mut reader = rt.sql().reader().await.expect("reader");
+        let rows = reader
+            .query_all(SqlStatement {
+                sql: "SELECT byte_offset FROM session_mirror_cursor WHERE file_path = ?1".into(),
+                params: vec![SqlValue::Text(path.to_string_lossy().into_owned())],
+                label: None,
+            })
+            .await
+            .expect("cursor query");
+        !rows.is_empty()
+    }
+
+    #[tokio::test]
+    async fn failed_cursor_delete_stays_pending_and_is_retried_next_tick() {
+        let (rt, _dir) = runtime_without_schema();
+        let discovery = DiscoveryIndex::default();
+        let path = PathBuf::from("/projects/gone.jsonl");
+
+        let mut pending = VecDeque::new();
+        queue_cursor_deletes(&mut pending, std::slice::from_ref(&path));
+        assert_eq!(pending.len(), 1);
+
+        // No cursor table yet: the delete fails and the entry must stay
+        // pending — dropping it would let a stale row survive a daemon
+        // restart and skip bytes on a recreated file.
+        drain_pending_cursor_deletes(&rt, &discovery, &mut pending).await;
+        assert_eq!(
+            pending.len(),
+            1,
+            "failed delete must remain in the retry set"
+        );
+
+        // The table appears (schema applied) and a row exists for the path:
+        // the next tick's retry deletes it and drains the set.
+        apply_session_schema(&rt).await;
+        insert_cursor_row(&rt, &path, 4096).await;
+        drain_pending_cursor_deletes(&rt, &discovery, &mut pending).await;
+        assert!(pending.is_empty(), "successful retry drains the set");
+        assert!(
+            !cursor_row_exists(&rt, &path).await,
+            "stale row deleted on retry"
+        );
+    }
+
+    #[tokio::test]
+    async fn retracked_path_cancels_its_pending_cursor_delete() {
+        let (rt, _dir) = runtime_without_schema();
+        apply_session_schema(&rt).await;
+
+        let path = PathBuf::from("/projects/recreated.jsonl");
+        insert_cursor_row(&rt, &path, 512).await;
+
+        let mut discovery = DiscoveryIndex::default();
+        let mut pending = VecDeque::new();
+        queue_cursor_deletes(&mut pending, std::slice::from_ref(&path));
+
+        // The file is re-discovered before the delete drains: its fresh
+        // cursor row must not be deleted out from under it.
+        discovery.add_file(path.clone(), DiscoveredKind::ChatGptExport, false);
+        drain_pending_cursor_deletes(&rt, &discovery, &mut pending).await;
+        assert!(pending.is_empty(), "re-tracked path cancels its delete");
+        assert!(cursor_row_exists(&rt, &path).await, "fresh row preserved");
+    }
+
+    #[tokio::test]
+    async fn queue_cursor_deletes_deduplicates_and_is_bounded() {
+        let mut pending = VecDeque::new();
+        let path = PathBuf::from("/projects/gone.jsonl");
+        queue_cursor_deletes(&mut pending, &[path.clone(), path.clone()]);
+        assert_eq!(pending.len(), 1, "duplicate removals collapse to one entry");
+
+        for index in 0..(CURSOR_DELETE_RETRY_LIMIT + 8) {
+            let extra = PathBuf::from(format!("/projects/extra-{index}.jsonl"));
+            queue_cursor_deletes(&mut pending, &[extra]);
+        }
+        assert_eq!(
+            pending.len(),
+            CURSOR_DELETE_RETRY_LIMIT,
+            "the retry set is bounded; oldest entries are evicted"
+        );
+    }
+
+    #[tokio::test]
+    async fn delete_cursors_reports_the_sql_error_for_retry() {
+        let (rt, _dir) = runtime_without_schema();
+        let path = PathBuf::from("/projects/gone.jsonl");
+        let error = delete_cursors(&rt, &[path])
+            .await
+            .expect_err("missing table must surface as an error, not silence");
+        let message = error.to_string();
+        assert!(
+            message.contains("mirror: cursor delete"),
+            "error names the failing operation; got: {message}"
+        );
     }
 }
 

--- a/docs/adr/ADR-080-session-pack-oss-storage-mechanism.md
+++ b/docs/adr/ADR-080-session-pack-oss-storage-mechanism.md
@@ -245,9 +245,13 @@ recognizable conversation shape, and a mixed-provider array is unsupported. This
 cursor untouched instead of allowing a misconfigured overlapping root to let the wrong source
 consume that path first. Candidate dispatch claims the path only when a pass advances its
 cursor and inserts rows; an empty advance (a cursor-only pass over blank or unparseable
-lines) records its committed offset but falls through to the next configured provider
-candidate, as does a no-progress success such as one provider's lower whole-file size
-ceiling.
+lines) records its consumed offset and falls through to the next configured provider
+candidate, committing its cursor only if dispatch ends without any candidate inserting
+rows for the span and without any candidate erroring. The commit is a single cursor
+upsert at the end of dispatch, so an interrupted or partially failing dispatch can never
+strand the cursor past bytes that no candidate inserted — the bytes are re-read on a
+later pass, bounded and idempotent. A no-progress success, such as one provider's lower
+whole-file size ceiling, likewise falls through without committing.
 
 #### Delta-proportional polling (Amendment, 2026-08-02)
 
@@ -261,9 +265,11 @@ completed transcript:
   puts its directly contained cold transcripts at the front of the bounded probe schedule;
   newly discovered transcripts enter the active set immediately.
 - A file remains active while it is growing, while ingest is catching up to its cursor, or
-  while a per-file error requires retry; once every source candidate has errored on three
-  consecutive probes the file is demoted to the cold sample (logged once at demotion), whose
-  ordinary cadence retries it. Once its cursor is caught up, two unchanged probes
+  while a per-file error requires retry; once three consecutive probes end with no candidate
+  advancing the offset and at least one source candidate erroring — including a mixed probe
+  where one candidate reports a no-progress success such as its whole-file size ceiling
+  while another errors — the file is demoted to the cold sample (logged once at demotion),
+  whose ordinary cadence retries it. Once its cursor is caught up, two unchanged probes
   and an mtime at least five minutes old make it cold. Filesystems that do not report mtime
   use 30 unchanged probes instead.
 - Cold files are sampled through a round-robin queue capped at 256 metadata probes per tick.
@@ -288,9 +294,17 @@ root: removing and recreating the ancestor cannot discard the nested root's sour
 A non-pinned file is removed from tracking only after two consecutive probes report it
 missing; a single NotFound (a transient atomic replace or filesystem hiccup) keeps the file
 and its cursor for one grace probe so a promptly recreated path resumes from its old offset
-instead of being reseeded to EOF. Cursor rows whose deletion fails are retried on later
-ticks until deleted, because a stale row reloaded after a restart would let a recreated
-same-path file silently skip bytes.
+instead of being reseeded to EOF.
+A directory-difference removal deliberately bypasses that grace: a complete directory
+listing is a positive enumeration of its contents, so an absent entry is stronger evidence
+of removal than a single probe NotFound; a refresh whose listing is incomplete defers
+removals until a complete read. When a removal is cancelled by a same-pass reappearance,
+the in-memory offset is restored from the preserved cursor row so the next seed never
+falls back to EOF while the preserved row proves bytes were already mirrored. Cursor rows
+whose deletion fails are retried on every later tick, because a stale row reloaded after a
+restart would let a recreated same-path file silently skip bytes; the retry set is bounded,
+and evicting an entry beyond the bound logs an error naming that residual skip risk
+rather than growing the set without bound.
 
 #### Auxiliary schema
 

--- a/docs/adr/ADR-080-session-pack-oss-storage-mechanism.md
+++ b/docs/adr/ADR-080-session-pack-oss-storage-mechanism.md
@@ -277,6 +277,9 @@ completed transcript:
   directory mtime on every supported filesystem. Consequently a resumed cold transcript is
   noticed within the priority sweep started by a parent-directory change, or within one
   complete bounded cold-file sweep even without that change.
+  The priority ordering is bounded but not fair under continuous directory churn: repeated
+  changes can keep refilling the priority queue ahead of the ordinary cold sweep. The
+  productive cold-file metadata-probe cap remains 256 per tick.
   Queue entries left behind by reactivation or removal are invalidated lazily and drained at
   a bounded rate (at most four times the probe cap of stale pops per tick, each performing
   no filesystem work), so residue can neither drain unbounded in one tick nor starve
@@ -298,7 +301,10 @@ instead of being reseeded to EOF.
 A directory-difference removal deliberately bypasses that grace: a complete directory
 listing is a positive enumeration of its contents, so an absent entry is stronger evidence
 of removal than a single probe NotFound; a refresh whose listing is incomplete defers
-removals until a complete read. When a removal is cancelled by a same-pass reappearance,
+removals until a complete read. Children newly discovered during such a partial listing
+remain independently queued; if the parent later disappears, their NotFound probes reap
+non-pinned orphans. Pinned configured roots are intentionally retained as placeholders and
+can remain queued until they reappear. When a removal is cancelled by a same-pass reappearance,
 the in-memory offset is restored from the preserved cursor row so the next seed never
 falls back to EOF while the preserved row proves bytes were already mirrored. Cursor rows
 whose deletion fails are retried on every later tick, because a stale row reloaded after a

--- a/docs/adr/ADR-080-session-pack-oss-storage-mechanism.md
+++ b/docs/adr/ADR-080-session-pack-oss-storage-mechanism.md
@@ -244,8 +244,10 @@ file path. Each export parser therefore rejects a document containing the other 
 recognizable conversation shape, and a mixed-provider array is unsupported. This leaves the
 cursor untouched instead of allowing a misconfigured overlapping root to let the wrong source
 consume that path first. Candidate dispatch claims the path only when a pass advances its
-cursor; a no-progress success such as one provider's lower whole-file size ceiling falls
-through to the next configured provider candidate.
+cursor and inserts rows; an empty advance (a cursor-only pass over blank or unparseable
+lines) records its committed offset but falls through to the next configured provider
+candidate, as does a no-progress success such as one provider's lower whole-file size
+ceiling.
 
 #### Delta-proportional polling (Amendment, 2026-08-02)
 
@@ -259,7 +261,9 @@ completed transcript:
   puts its directly contained cold transcripts at the front of the bounded probe schedule;
   newly discovered transcripts enter the active set immediately.
 - A file remains active while it is growing, while ingest is catching up to its cursor, or
-  while a per-file error requires retry. Once its cursor is caught up, two unchanged probes
+  while a per-file error requires retry; once every source candidate has errored on three
+  consecutive probes the file is demoted to the cold sample (logged once at demotion), whose
+  ordinary cadence retries it. Once its cursor is caught up, two unchanged probes
   and an mtime at least five minutes old make it cold. Filesystems that do not report mtime
   use 30 unchanged probes instead.
 - Cold files are sampled through a round-robin queue capped at 256 metadata probes per tick.
@@ -267,6 +271,10 @@ completed transcript:
   directory mtime on every supported filesystem. Consequently a resumed cold transcript is
   noticed within the priority sweep started by a parent-directory change, or within one
   complete bounded cold-file sweep even without that change.
+  Queue entries left behind by reactivation or removal are invalidated lazily and drained at
+  a bounded rate (at most four times the probe cap of stale pops per tick, each performing
+  no filesystem work), so residue can neither drain unbounded in one tick nor starve
+  productive probes.
 
 Once the historical corpus is cold, a quiet tick performs at most 64 directory metadata probes,
 256 cold-file metadata probes, and one metadata probe per active file; those fixed terms do not
@@ -277,6 +285,12 @@ limits, idempotency, and the rule that errors do not advance cursors are unchang
 roots that do not exist at startup remain in the directory schedule so later creation is
 discovered. The same pinned identity applies to a configured root nested below another source
 root: removing and recreating the ancestor cannot discard the nested root's source kinds.
+A non-pinned file is removed from tracking only after two consecutive probes report it
+missing; a single NotFound (a transient atomic replace or filesystem hiccup) keeps the file
+and its cursor for one grace probe so a promptly recreated path resumes from its old offset
+instead of being reseeded to EOF. Cursor rows whose deletion fails are retried on later
+ticks until deleted, because a stale row reloaded after a restart would let a recreated
+same-path file silently skip bytes.
 
 #### Auxiliary schema
 

--- a/docs/adr/ADR-080-session-pack-oss-storage-mechanism.md
+++ b/docs/adr/ADR-080-session-pack-oss-storage-mechanism.md
@@ -2,7 +2,7 @@
 
 **Status**: accepted
 **Date**: 2026-06-28
-**Amended**: 2026-07-02 — shipped-surface record (§3), session mirror (§6), scope revision (Context); 2026-08-01 — claude.ai export source (§6)
+**Amended**: 2026-07-02 — shipped-surface record (§3), session mirror (§6), scope revision (Context); 2026-08-01 — claude.ai export source (§6); 2026-08-02 — delta-proportional mirror polling (§6)
 **Superseded by**: [ADR-083](ADR-083-session-pack-t1-verbs.md) for §3 only; ADR-083 is
 the current authority for the public session verb surface, while the rest of this record
 remains in force.
@@ -243,7 +243,40 @@ ChatGPT and claude.ai both name this file `conversations.json`, while the cursor
 file path. Each export parser therefore rejects a document containing the other provider's
 recognizable conversation shape, and a mixed-provider array is unsupported. This leaves the
 cursor untouched instead of allowing a misconfigured overlapping root to let the wrong source
-consume that path first.
+consume that path first. Candidate dispatch claims the path only when a pass advances its
+cursor; a no-progress success such as one provider's lower whole-file size ceiling falls
+through to the next configured provider candidate.
+
+#### Delta-proportional polling (Amendment, 2026-08-02)
+
+The service performs one full discovery pass at startup, then keeps an in-memory directory
+and file index. Steady-state polling does not re-walk every transcript tree or stat every
+completed transcript:
+
+- Known directories are checked round-robin, at most 64 metadata probes per tick. A directory
+  is listed only when its `(mtime, length)` fingerprint changes, or after 30 unchanged probes
+  as a bounded fallback for coarse or unreliable filesystem timestamps. A changed directory
+  puts its directly contained cold transcripts at the front of the bounded probe schedule;
+  newly discovered transcripts enter the active set immediately.
+- A file remains active while it is growing, while ingest is catching up to its cursor, or
+  while a per-file error requires retry. Once its cursor is caught up, two unchanged probes
+  and an mtime at least five minutes old make it cold. Filesystems that do not report mtime
+  use 30 unchanged probes instead.
+- Cold files are sampled through a round-robin queue capped at 256 metadata probes per tick.
+  This is a correctness fallback because appending to a file does not update its parent
+  directory mtime on every supported filesystem. Consequently a resumed cold transcript is
+  noticed within the priority sweep started by a parent-directory change, or within one
+  complete bounded cold-file sweep even without that change.
+
+Once the historical corpus is cold, a quiet tick performs at most 64 directory metadata probes,
+256 cold-file metadata probes, and one metadata probe per active file; those fixed terms do not
+grow with the cold-file count. Work may still scale with the actual delta: startup discovery, a
+directory whose entry set changed, backfill, and simultaneously growing files are processed
+rather than silently dropped. Persisted cursor semantics, source selection, per-file ingest
+limits, idempotency, and the rule that errors do not advance cursors are unchanged. Configured
+roots that do not exist at startup remain in the directory schedule so later creation is
+discovered. The same pinned identity applies to a configured root nested below another source
+root: removing and recreating the ancestor cannot discard the nested root's source kinds.
 
 #### Auxiliary schema
 


### PR DESCRIPTION
> AI-assisted contribution: Codex prepared this change and PR description.

## Summary

- replace repeated recursive metadata walks with a cached directory/file index and hard round-robin ceilings of 64 directory probes and 256 cold-file probes per tick
- keep recently active files on the hot path, transition unchanged files to cold polling after two probes and five minutes (or 30 probes without usable timestamps), and prioritize cold files when their parent directory changes
- retain a bounded global cold sweep so appends are still discovered on filesystems that do not update parent-directory metadata
- preserve source candidates across overlapping and nested configured roots, continue to the next provider parser after a no-progress result, and retain pinned source identity through directory removal and recreation
- add regressions for probe ceilings, cold transitions, parent invalidation, timestamp fallbacks, missing-root appearance, overlapping providers, divergent size limits, and nested-root churn

Closes #1512.

## Test plan

- [x] `cargo test --manifest-path crates/Cargo.toml --workspace`
- [x] `cargo check --manifest-path crates/Cargo.toml --workspace`
- [x] `cargo clippy --manifest-path crates/Cargo.toml --workspace --all-targets -- -D warnings`
- [x] `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- [x] `RUSTDOCFLAGS=-Dwarnings cargo doc --manifest-path crates/Cargo.toml --workspace --no-deps`

All five gates passed against reviewed SHA `6bad171d4a3fa3fa41dee6eb3ab5d5788bca3b55` on unchanged `main` base `a152ead3e577b8c01b03024687fdb66d94a00cac` before this draft was opened.

## ADR

- amend ADR-080 with the bounded polling/index lifecycle, no-progress provider fallback, and pinned-root churn contracts

## AI-assisted contribution checklist

- [x] Every claim in this PR description matches the actual diff
- [x] Any agent-authored comment / PR body starts with an attribution line
- [x] Per-tick filesystem work is explicitly bounded
- [x] Existing cursor, error, source-parser, and missing-root semantics remain covered

## Out of scope

- changing mirrored session or event identity
- adding new export providers or watch-service dependencies
- relying on parent-directory timestamps as the only append signal
