### PR TITLE
fix(knowledge): index only searchable model

### DIFF
--- a/crates/khive-pack-knowledge/docs/api/scoring-and-retrieval.md
+++ b/crates/khive-pack-knowledge/docs/api/scoring-and-retrieval.md
@@ -44,6 +44,10 @@ where $\alpha$ = `rerank_alpha` (default 0.7, TF-IDF dominant) and $\hat{s}_{\te
 is the TF-IDF score normalized to $[0, 1]$ by dividing by the maximum TF-IDF score in the
 candidate set.
 
+Knowledge retrieval uses the default embedder for both query and atom vectors. Accordingly,
+`knowledge.index` writes only default-model atom vectors; additional registered models are not
+indexed until a knowledge read path can select or fuse them.
+
 ### Vamana ANN Signal
 
 In parallel with TF-IDF, if a Vamana ANN index is warm (populated via `knowledge.index

--- a/crates/khive-pack-knowledge/src/knowledge/index_handler.rs
+++ b/crates/khive-pack-knowledge/src/knowledge/index_handler.rs
@@ -1,7 +1,6 @@
 //! Index handler: embed atoms and build/persist the Vamana ANN index.
 
 use std::collections::BTreeMap;
-use std::sync::Arc;
 
 use serde_json::{json, Value};
 
@@ -32,15 +31,6 @@ impl KnowledgeHandlers {
                 json!({ "indexed": 0, "skipped": 0, "failed": 0, "total": 0, "reason": "no embedding model configured" }),
             );
         }
-        // Every other registered engine gets the same batch, best-effort (issue
-        // #1115): a secondary-engine failure does not affect indexed/failed/
-        // skipped, which stay keyed on the default model as before this fix.
-        let secondary_model_names: Vec<String> = runtime
-            .registered_embedding_model_names()
-            .into_iter()
-            .filter(|m| m != default_model_name)
-            .collect();
-
         let sql = runtime.sql();
         let batch_size = p.batch_size.unwrap_or(DEFAULT_EMBED_BATCH).clamp(1, 1000);
         // insert_only is accepted for API compatibility but no longer drives a
@@ -124,36 +114,6 @@ impl KnowledgeHandlers {
 
             let texts: Vec<String> = staged.iter().map(|(_, text)| text.clone()).collect();
 
-            // Every configured engine embeds and writes its own batch independently
-            // (issue #1115): a secondary-engine failure does not affect `indexed`/
-            // `failed`, which stay keyed on the default model, as before this fix.
-            // Fan the models out concurrently — each is an independent embed call
-            // plus vector write, so serializing them only adds up their latencies.
-            let staged = Arc::new(staged);
-            let texts = Arc::new(texts);
-
-            let default_handle = tokio::spawn(embed_and_insert_model(
-                runtime.clone(),
-                token.clone(),
-                default_model_name.to_string(),
-                true,
-                Arc::clone(&staged),
-                Arc::clone(&texts),
-            ));
-            let secondary_handles: Vec<_> = secondary_model_names
-                .iter()
-                .map(|model_name| {
-                    tokio::spawn(embed_and_insert_model(
-                        runtime.clone(),
-                        token.clone(),
-                        model_name.clone(),
-                        false,
-                        Arc::clone(&staged),
-                        Arc::clone(&texts),
-                    ))
-                })
-                .collect();
-
             // Track which atoms in this chunk had their vector persisted, so a
             // failed insert is reported as `failed` rather than silently counted
             // as `indexed`. A failed vector write means recall cannot retrieve
@@ -164,34 +124,19 @@ impl KnowledgeHandlers {
             // that record's DELETE and the prior vector survives (no-worse-than-
             // stale). A separate pre-delete committed before insert would
             // re-introduce the stranding window.
-            match default_handle.await {
-                Ok(outcome) => {
-                    indexed += outcome.affected as usize;
-                    failed += outcome.failed as usize;
-                    truncation_by_model
-                        .entry(outcome.model_name)
-                        .or_default()
-                        .merge(outcome.truncation);
-                }
-                Err(e) => {
-                    tracing::warn!(error = %e, "knowledge index default-model task panicked");
-                    failed += staged.len();
-                }
-            }
-            for handle in secondary_handles {
-                // Secondary-engine failures are best-effort (logged inside the
-                // task) and never affect `indexed`/`failed`; only a task panic
-                // needs handling here.
-                match handle.await {
-                    Ok(outcome) => truncation_by_model
-                        .entry(outcome.model_name)
-                        .or_default()
-                        .merge(outcome.truncation),
-                    Err(e) => {
-                        tracing::warn!(error = %e, "knowledge index secondary-model task panicked");
-                    }
-                }
-            }
+            // Knowledge retrieval embeds and probes only the default model. Keep
+            // atom indexing on that same model so every vector written has a read
+            // path; secondary-model fan-out belongs with model-aware retrieval.
+            // Await in the dispatch task so usage accounting observes the work.
+            let outcome =
+                embed_and_insert_default_model(runtime, token, default_model_name, &staged, &texts)
+                    .await;
+            indexed += outcome.affected as usize;
+            failed += outcome.failed as usize;
+            truncation_by_model
+                .entry(default_model_name.to_string())
+                .or_default()
+                .merge(outcome.truncation);
 
             if let Some(cb) = on_progress {
                 cb(indexed as u64, total as u64);
@@ -275,77 +220,50 @@ impl KnowledgeHandlers {
     }
 }
 
-/// One embedding model's outcome from [`embed_and_insert_model`], counted in vectors.
+/// One default-model indexing outcome, counted in vectors.
 struct ModelIndexOutcome {
-    model_name: String,
     affected: u64,
     failed: u64,
     truncation: khive_runtime::retrieval::EmbeddingTruncationReport,
 }
 
-/// Embed one chunk's staged atoms with `model_name` and batch-insert the resulting
-/// vectors. Split out of `index` so the default model and every secondary model
-/// (issue #1115) can run as independent `tokio::spawn` tasks instead of embedding
-/// and writing serially, one model at a time. `is_default` only selects tracing
-/// wording — the default model's outcome is applied to the caller's `indexed`/
-/// `failed` counters; secondary-model outcomes are best-effort and only logged.
-async fn embed_and_insert_model(
-    runtime: KhiveRuntime,
-    token: NamespaceToken,
-    model_name: String,
-    is_default: bool,
-    staged: Arc<Vec<(uuid::Uuid, String)>>,
-    texts: Arc<Vec<String>>,
+/// Embed one chunk's staged atoms with the default model and batch-insert the
+/// resulting vectors. Knowledge search has no model selector or multi-model
+/// fusion, so this helper deliberately cannot target a secondary model.
+async fn embed_and_insert_default_model(
+    runtime: &KhiveRuntime,
+    token: &NamespaceToken,
+    model_name: &str,
+    staged: &[(uuid::Uuid, String)],
+    texts: &[String],
 ) -> ModelIndexOutcome {
     let outcomes = match runtime
-        .embed_document_batch_with_model_outcomes(&model_name, &texts)
+        .embed_document_batch_with_model_outcomes(model_name, texts)
         .await
     {
         Ok(e) => e,
         Err(e) => {
-            if is_default {
-                tracing::warn!(
-                    batch_size = staged.len(),
-                    error = %e,
-                    "embed_batch failed; atoms cannot be recalled until reindexed"
-                );
-            } else {
-                tracing::warn!(
-                    model = %model_name,
-                    batch_size = staged.len(),
-                    error = %e,
-                    "knowledge secondary-engine embed_batch failed; \
-                     atoms miss a vector for this engine until backfill"
-                );
-            }
+            tracing::warn!(
+                batch_size = staged.len(),
+                error = %e,
+                "embed_batch failed; atoms cannot be recalled until reindexed"
+            );
             return ModelIndexOutcome {
-                model_name,
                 affected: 0,
-                failed: if is_default { staged.len() as u64 } else { 0 },
+                failed: staged.len() as u64,
                 truncation: Default::default(),
             };
         }
     };
     if outcomes.len() != staged.len() {
-        if is_default {
-            tracing::warn!(
-                expected = staged.len(),
-                got = outcomes.len(),
-                "embed_batch returned wrong number of vectors; atoms cannot be recalled until reindexed"
-            );
-        } else {
-            tracing::warn!(
-                model = %model_name,
-                expected = staged.len(),
-                got = outcomes.len(),
-                "knowledge secondary-engine embed_batch returned wrong \
-                 vector count; skipping this engine for the batch"
-            );
-        }
+        tracing::warn!(
+            expected = staged.len(),
+            got = outcomes.len(),
+            "embed_batch returned wrong number of vectors; atoms cannot be recalled until reindexed"
+        );
         return ModelIndexOutcome {
-            model_name,
             affected: 0,
-            failed: if is_default { staged.len() as u64 } else { 0 },
+            failed: staged.len() as u64,
             truncation: Default::default(),
         };
     }
@@ -355,22 +273,13 @@ async fn embed_and_insert_model(
         truncation.observe(outcome);
     }
 
-    let vectors = match runtime.vectors_for_model(&token, &model_name) {
+    let vectors = match runtime.vectors_for_model(token, model_name) {
         Ok(v) => v,
         Err(e) => {
-            if is_default {
-                tracing::warn!(error = %e, "knowledge vector store unavailable");
-            } else {
-                tracing::warn!(
-                    model = %model_name,
-                    error = %e,
-                    "knowledge secondary-engine vector store unavailable"
-                );
-            }
+            tracing::warn!(error = %e, "knowledge vector store unavailable");
             return ModelIndexOutcome {
-                model_name,
                 affected: 0,
-                failed: if is_default { staged.len() as u64 } else { 0 },
+                failed: staged.len() as u64,
                 truncation,
             };
         }
@@ -385,7 +294,7 @@ async fn embed_and_insert_model(
             kind: SubstrateKind::Entity,
             namespace: ns_str.clone(),
             field: "knowledge.atom".to_string(),
-            embedding_model: Some(model_name.clone()),
+            embedding_model: Some(model_name.to_string()),
             vectors: vec![outcome.vector.clone()],
             updated_at: chrono::Utc::now(),
         })
@@ -394,42 +303,23 @@ async fn embed_and_insert_model(
     match vectors.insert_batch(records).await {
         Ok(summary) => {
             if summary.failed > 0 {
-                if is_default {
-                    tracing::warn!(
-                        failed = summary.failed,
-                        error = %summary.first_error,
-                        "knowledge vector batch insert had failures"
-                    );
-                } else {
-                    tracing::warn!(
-                        model = %model_name,
-                        failed = summary.failed,
-                        error = %summary.first_error,
-                        "knowledge secondary-engine vector batch insert had failures"
-                    );
-                }
+                tracing::warn!(
+                    failed = summary.failed,
+                    error = %summary.first_error,
+                    "knowledge vector batch insert had failures"
+                );
             }
             ModelIndexOutcome {
-                model_name,
                 affected: summary.affected,
                 failed: summary.failed,
                 truncation,
             }
         }
         Err(e) => {
-            if is_default {
-                tracing::warn!(error = %e, "knowledge vector store unavailable");
-            } else {
-                tracing::warn!(
-                    model = %model_name,
-                    error = %e,
-                    "knowledge secondary-engine vector store unavailable"
-                );
-            }
+            tracing::warn!(error = %e, "knowledge vector store unavailable");
             ModelIndexOutcome {
-                model_name,
                 affected: 0,
-                failed: if is_default { staged.len() as u64 } else { 0 },
+                failed: staged.len() as u64,
                 truncation,
             }
         }

--- a/crates/khive-pack-knowledge/src/lib.rs
+++ b/crates/khive-pack-knowledge/src/lib.rs
@@ -30,10 +30,9 @@ pub struct KnowledgeReindexOptions {
 /// ANN snapshot.
 ///
 /// Library entry for `kkernel reindex` — callable without an MCP server.
-/// Knowledge is single-model (search retrieves via the default embedder's ANN),
-/// The atom pass also fans out to secondary registered engines on a best-effort
-/// basis. Returns `{atoms_indexed, sections_indexed, failed, ann_failed,
-/// sections_failed, truncation_by_model}`.
+/// Knowledge is single-model: atom indexing, section indexing, and search all
+/// use the default embedder. Returns `{atoms_indexed, sections_indexed, failed,
+/// ann_failed, sections_failed, truncation_by_model}`.
 ///
 /// Optional progress callbacks receive `(processed, total)` after each batch.
 pub async fn reindex_knowledge(

--- a/crates/khive-pack-knowledge/tests/fixes.rs
+++ b/crates/khive-pack-knowledge/tests/fixes.rs
@@ -1997,7 +1997,10 @@ mod embed_failure_tests {
     use khive_runtime::{AllowAllGate, BackendId, EmbedderProvider, RuntimeConfig};
     use khive_types::Namespace;
     use lattice_embed::{EmbedError, EmbeddingModel, EmbeddingService};
-    use std::sync::Arc;
+    use std::sync::{
+        atomic::{AtomicUsize, Ordering},
+        Arc,
+    };
 
     const MODEL_KEY: &str = "all-minilm-l6-v2";
 
@@ -2211,15 +2214,17 @@ mod embed_failure_tests {
         );
     }
 
-    /// Issue #1115: `knowledge.index` must write a vector for every configured
-    /// engine, not just the default. Fake providers stand in for both engines
-    /// so the test doesn't load real lattice weights.
+    /// Issue #1513: `knowledge.index` must embed and write only the default model
+    /// because every knowledge retrieval path reads only that model. Fake
+    /// providers stand in for both engines so the test does not load lattice
+    /// weights and can prove that the secondary provider is never called.
     #[tokio::test]
-    async fn index_writes_vector_for_every_configured_engine() {
+    async fn index_writes_only_the_searchable_default_model() {
         const SECONDARY_KEY: &str = "paraphrase-multilingual-minilm-l12-v2";
 
         struct FixedVecService {
             seed: f32,
+            calls: Arc<AtomicUsize>,
         }
 
         #[async_trait]
@@ -2229,6 +2234,7 @@ mod embed_failure_tests {
                 texts: &[String],
                 _model: EmbeddingModel,
             ) -> std::result::Result<Vec<Vec<f32>>, EmbedError> {
+                self.calls.fetch_add(1, Ordering::Relaxed);
                 Ok(texts.iter().map(|_| vec![self.seed; 384]).collect())
             }
 
@@ -2244,6 +2250,7 @@ mod embed_failure_tests {
         struct FixedVecProvider {
             key: &'static str,
             seed: f32,
+            calls: Arc<AtomicUsize>,
         }
 
         #[async_trait]
@@ -2260,9 +2267,15 @@ mod embed_failure_tests {
                 &self,
             ) -> std::result::Result<Arc<dyn EmbeddingService>, khive_runtime::RuntimeError>
             {
-                Ok(Arc::new(FixedVecService { seed: self.seed }))
+                Ok(Arc::new(FixedVecService {
+                    seed: self.seed,
+                    calls: Arc::clone(&self.calls),
+                }))
             }
         }
+
+        let primary_calls = Arc::new(AtomicUsize::new(0));
+        let secondary_calls = Arc::new(AtomicUsize::new(0));
 
         let rt = KhiveRuntime::new(RuntimeConfig {
             git_write: Default::default(),
@@ -2282,13 +2295,17 @@ mod embed_failure_tests {
         rt.register_embedder(FixedVecProvider {
             key: MODEL_KEY,
             seed: 0.5,
+            calls: Arc::clone(&primary_calls),
         });
         rt.register_embedder(FixedVecProvider {
             key: SECONDARY_KEY,
             seed: 0.6,
+            calls: Arc::clone(&secondary_calls),
         });
 
         let f = fixture_with_two_atoms(rt).await;
+        let primary_before = primary_calls.load(Ordering::Relaxed);
+        let secondary_before = secondary_calls.load(Ordering::Relaxed);
         let result = f
             .dispatch("knowledge.index", json!({}))
             .await
@@ -2297,6 +2314,16 @@ mod embed_failure_tests {
             result["indexed"].as_u64().unwrap_or(0),
             2,
             "both atoms must index via the default engine: {result:?}"
+        );
+        assert_eq!(
+            primary_calls.load(Ordering::Relaxed),
+            primary_before + 1,
+            "one default-model batch must be embedded"
+        );
+        assert_eq!(
+            secondary_calls.load(Ordering::Relaxed),
+            secondary_before,
+            "the unread secondary model must not incur an embed call"
         );
 
         let row_primary = f
@@ -2310,15 +2337,17 @@ mod embed_failure_tests {
             "primary engine table must have a row"
         );
 
-        let row_secondary = f
+        let secondary_table = f
             .sql_query_one(
-                "SELECT subject_id FROM vec_paraphrase_multilingual_minilm_l12_v2 LIMIT 1",
-                vec![],
+                "SELECT name FROM sqlite_master WHERE type = 'table' AND name = ? LIMIT 1",
+                vec![SqlValue::Text(
+                    "vec_paraphrase_multilingual_minilm_l12_v2".to_string(),
+                )],
             )
             .await;
         assert!(
-            row_secondary.is_some(),
-            "secondary engine table must have a row — issue #1115 write-path coverage"
+            secondary_table.is_none(),
+            "the unread secondary engine table must not even be initialized"
         );
     }
 

--- a/docs/adr/ADR-031-multi-engine-retrieval.md
+++ b/docs/adr/ADR-031-multi-engine-retrieval.md
@@ -18,12 +18,13 @@ SparseStore + memory.recall_* verbs)\
 - ADR-029 (SubstrateCoordinator) — backend-level unweighted RRF is distinct from the engine-level weighted RRF here
 - ADR-033 (Recall Pipeline) — memory recall consumes the pack fan-out pattern specified here
 - ADR-035 (CLI Config) — project-vs-user TOML override semantics extended by this ADR
+- ADR-051 (Knowledge Section Embeddings) — knowledge uses only its searchable default model
 
 ## Context
 
-An earlier implementation delivered multi-engine embedding: N peer models run concurrently, each with
-its own HNSW index, every write embedding with all N models, every query fusing per-engine
-rankings via weighted RRF. `deploy/engine.toml` was the canonical config; per-engine
+An earlier implementation delivered multi-engine embedding: N peer models run concurrently, each
+with its own HNSW index, with participating writes embedding in all N models and corresponding
+queries fusing per-engine rankings via weighted RRF. `deploy/engine.toml` was the canonical config; per-engine
 normalization parameters (`noise_floor`, `max_similarity`, `threshold`) were tuned during the
 2026-03-26 Chinese-blindspot crisis (mE5 migration). That crisis confirmed empirically that
 no single embedding model dominates across languages and corpus types — multilingual and
@@ -50,16 +51,27 @@ peer after HNSW namespace split." The current release erased this without an ADR
 ### What "multi-engine" means
 
 Distinct from multi-actor namespace isolation (per ADR-007) and distinct from model migration
-(single model, swap atomically). Multi-engine means:
+(single model, swap atomically). For a substrate with a multi-engine read path, multi-engine means:
 
 - N peer embedding services run concurrently in the same process
 - Each service may be a different provider (lattice-embed native, OpenAI API, custom)
 - Each service has its own vector index — one `vec_*` table per (model_id, dim)
-- Every write embeds with all N services and stores in all N indices
-- Every query embeds with all N services, searches all N indices in parallel, then fuses
+- Every participating write embeds with all N services and stores in all N indices
+- Every corresponding query embeds with all N services, searches all N indices in parallel, then fuses
 - Results merge via weighted RRF using per-engine weight
 - Per-engine score normalization (noise_floor, max_similarity, threshold) calibrates
   cross-engine comparability
+
+### Amendment 1 (2026-08-01): readable-model symmetry for knowledge
+
+The fan-out contract is write/read symmetric, not permission to create vectors no serving path
+can consume. Entity, note, and memory paths retain multi-engine write and read fan-out. Knowledge
+search, ANN warming, fresh-tail fusion, and compose currently select only the default embedder and
+expose no model selector or cross-model fusion, so `knowledge.index` writes only that default
+model. ADR-051 Amendment 1 records the same knowledge-specific decision. Multi-model knowledge
+indexing must land together with a model-aware or fused knowledge read path; until then secondary
+knowledge vectors are dead embedding and storage work. This supersedes Phase C's unqualified
+"pack handlers fan out" wording and Open Question 2's deferral for this specific substrate.
 
 ### Why "engine" not "model"
 
@@ -736,7 +748,8 @@ preserved — the single engine is now the built-in default, passed explicitly b
 handler rather than owned by the runtime.
 
 **Phase C — Multi-engine config + pack fan-out (D3 full, D5, D6)**. `[[engines]]` TOML
-schema activated; pack handlers fan out across all configured engines. `SparseStore` trait
+schema activated; handlers with multi-engine reads fan out across all configured engines.
+`SparseStore` trait
 added. `memory.recall_*` dotted verbs added. New deployments get multi-engine by declaring the array;
 existing single-engine deployments see no behavior change.
 
@@ -745,9 +758,10 @@ existing single-engine deployments see no behavior change.
 1. **`MultiEngineSearcher` helper extraction.** Defer until three or more packs need
    identical fan-out code. Pack handlers copy the pattern; extract when the duplication
    threshold is reached.
-2. **Multi-engine write policy.** Default: every engine embeds every write. A future
-   `write_engines` allowlist on `EngineConfig` (or `PackConfig`) would allow a pack to store
-   writes in a subset of engines, reading from all. Deferred to v2.
+2. **Multi-engine write policy.** Default for a multi-engine read path: every engine embeds every
+   write. A future `write_engines` allowlist on `EngineConfig` (or `PackConfig`) would allow a pack
+   to store writes in a subset of engines while reading from all. Deferred to v2. Knowledge's
+   default-only policy is a different case: it writes exactly the one engine it can read.
 3. **Remote-API engine config.** A `[[engines]] provider = "openai"` shape needs `api_key_env`
    / `endpoint` / `timeout` fields on `EngineConfig`. The `Embedder` trait supports it; the
    TOML schema is lattice-shaped for v1. Future ADR when a concrete remote-API provider ships.

--- a/docs/adr/ADR-035-cli-config-and-auto-embed.md
+++ b/docs/adr/ADR-035-cli-config-and-auto-embed.md
@@ -295,7 +295,7 @@ The shipped behavior has two parts:
 Examples using only shipped flags:
 
 ```bash
-# Re-embed entities, notes, and knowledge with every configured engine.
+# Re-embed entities and notes with every configured engine; knowledge uses the default.
 kkernel reindex --db ~/.khive/khive.db --namespace local
 
 # Repair only the graph substrate and keep vectors that already exist.

--- a/docs/adr/ADR-047-knowledge-pack.md
+++ b/docs/adr/ADR-047-knowledge-pack.md
@@ -216,9 +216,11 @@ stats() → {atoms: N, domains: N, ...}
 index(ids?: [<slug|uuid>], batch_size?: 500, insert_only?: false) → {indexed: N}
 ```
 
-Backfills embedding vectors and FTS content. When `ids` is omitted, indexes the
-entire corpus in batches. `insert_only` skips the delete-then-reinsert cycle for
-fresh corpus backfill.
+Backfills default-model embedding vectors and FTS content. The knowledge retrieval
+paths read only the default model, so secondary registered models are not embedded
+until a model-aware or fused knowledge read path exists. When `ids` is omitted,
+indexes the entire corpus in batches. `insert_only` skips the delete-then-reinsert
+cycle for fresh corpus backfill.
 
 #### `knowledge.fold` — budget-constrained selection
 

--- a/docs/adr/ADR-051-section-embeddings-hybrid-compose.md
+++ b/docs/adr/ADR-051-section-embeddings-hybrid-compose.md
@@ -28,6 +28,16 @@ tracked for the read side in issue #6.
 
 Restore section-level embeddings and hybrid compose, adapted to the current schema.
 
+### Amendment 1 (2026-08-01): searchable-model-only atom indexing
+
+Knowledge atom vectors are also single-model. `knowledge.index` embeds and writes only the
+default model because `knowledge.search`, ANN warming, fresh-tail fusion, and compose all embed
+and probe only that model. Writing secondary-model atom vectors without a model selector or fused
+knowledge retrieval pays embedding and storage cost for rows no knowledge read path can consume.
+Multi-model atom indexing must therefore land together with a model-aware or fused knowledge read
+path; configuring additional models continues to fan out entity, note, and memory retrieval work.
+This records the default-only disposition selected in issue #1513.
+
 ### Storage — reuse the existing column, single-model
 
 The spec proposed a **separate** `section_embeddings` table (its engine_v1 target

--- a/docs/adr/ADR-103-resource-attribution-model.md
+++ b/docs/adr/ADR-103-resource-attribution-model.md
@@ -718,8 +718,8 @@ their joined child tasks.
 The remaining gaps are observable in current code and are not papered over by this status:
 
 - `ann_jobs_consumed` has no production increment site, so it is always absent/zero.
-- spawned per-model work in `memory.recall` and `knowledge.index` does not re-enter the usage
-  scope, so those child tasks can under-report `embed_calls`, `vector_passes`, and related work;
+- spawned per-model work in `memory.recall` does not re-enter the usage scope, so those child
+  tasks can under-report `embed_calls`, `vector_passes`, and related work;
 - `db_round_trips` is instrumented at graph-read seams, not as a universal counter for every SQL
   or storage call; and
 - Part 5's `[request] max_ops` deployment setting is not parsed or enforced. The shipped parser
@@ -793,11 +793,9 @@ vector-search functions, `batch_neighbors` (adjacency entries returned), the inl
 ANN consumer drain, and the event append path. Handlers do not thread a context
 parameter; the choke points are few and already centralized.
 
-Plain task-local storage is **not sufficient** as the propagation mechanism: several
-request-owned paths run their per-model work on spawned tasks that are then joined
-(`memory.recall`'s per-model embed and ANN fan-out,
-`crates/khive-pack-memory/src/handlers/common.rs`; `knowledge.index`'s per-model
-embed-and-insert, `crates/khive-pack-knowledge/src/knowledge/index_handler.rs`), and
+Plain task-local storage is **not sufficient** as the propagation mechanism: `memory.recall`
+runs its per-model embed and ANN fan-out on spawned tasks that are then joined
+(`crates/khive-pack-memory/src/handlers/common.rs`), and
 Tokio task-locals do not cross `tokio::spawn`. The context is therefore an explicitly
 propagated handle (an `Arc`-shared accumulator or equivalent) with the following
 scope contract:

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -428,8 +428,9 @@ binary.
 ## 3. Reindex
 
 `kkernel reindex` rebuilds embedding vectors and FTS documents for entities, notes, and (unless
-excluded) the knowledge corpus, fanning out across every embedding engine registered in the
-resolved config, the same resolution `kkernel mcp` uses (§1). Full flag reference
+excluded) the knowledge corpus. The graph entity/note pass fans out across every embedding engine
+registered in the resolved config; knowledge atoms and sections use the default engine that their
+read paths query. Engine resolution is the same one `kkernel mcp` uses (§1). Full flag reference
 (`reindex.rs:134-194`):
 
 | Flag                              | Default                                     | Effect                                                                                  |
@@ -494,19 +495,19 @@ completion epoch bump is the eighth category. What
 exists: a bad `--namespace` value, a config resolution failure, a failed runtime open, a failed
 `authorize`, or a failed page-list call abort the whole run via `?` regardless of the flag.
 
-**Engine fan-out**: omitting `--model` reindexes against `rt.registered_embedding_model_names()`,
-whatever engines the resolved runtime config actually registers, not a hardcoded list. If that
-list is empty (no embedder configured at all), a warning prints but FTS backfill for entities and
-notes still runs. Knowledge atoms use the default model for their primary success counters and
-fan out to secondary registered engines on a best-effort basis; knowledge sections use the
-default model. `--model` still restricts only the graph pass.
+**Engine fan-out**: omitting `--model` reindexes graph entities and notes against
+`rt.registered_embedding_model_names()`, whatever engines the resolved runtime config actually
+registers, not a hardcoded list. If that list is empty (no embedder configured at all), a warning
+prints but FTS backfill for entities and notes still runs. Knowledge atoms and sections use only
+the default model because every knowledge-search vector path reads only that model. `--model`
+still restricts only the graph pass.
 
 **When to reindex** (genuine in-code rationale, not doc-comment fluff): after relabeling a
 namespace (vector rows would otherwise be stranded under the wrong namespace on next write,
-`reindex.rs:239-250`); after adding or removing an embedding model in config (so on-disk vectors
-match the currently-configured engine set, `reindex.rs:483-490`); and to force a stale Vamana ANN
-snapshot rebuild, since reindex explicitly invalidates ANN snapshots so the next warm-load
-rebuilds against the freshly re-embedded vectors (`reindex.rs:627-636`).
+`reindex.rs:239-250`); after adding or removing a graph embedding model in config (so entity/note
+vectors match the currently configured engine set, `reindex.rs:483-490`); and to force a stale
+Vamana ANN snapshot rebuild, since reindex explicitly invalidates ANN snapshots so the next
+warm-load rebuilds against the freshly re-embedded vectors (`reindex.rs:627-636`).
 
 ### `kkernel engine`: read-only inspection only, today
 


### PR DESCRIPTION
> AI-assisted contribution: Codex prepared this change and PR description.

## Summary

- make `knowledge.index` embed and persist atoms with only the configured default model, matching the model selected by every current knowledge search, suggest, compose, and section-retrieval path
- stop building, invoking, and writing unread secondary knowledge embeddings while retaining multi-model behavior for substrates that actually fan out retrieval
- await the default-model indexing batch in the dispatch task so its work remains represented by the request's usage accounting
- add a two-engine regression proving the default provider is called, the secondary provider is not called, primary vectors are written, and no secondary vector table is initialized
- reconcile operations guidance and ADRs around the current default-model contract and the symmetry required before future knowledge multi-model fanout

Closes #1513.

## Test plan

- [x] `cargo test --manifest-path crates/Cargo.toml --workspace`
- [x] `cargo check --manifest-path crates/Cargo.toml --workspace`
- [x] `cargo clippy --manifest-path crates/Cargo.toml --workspace --all-targets -- -D warnings`
- [x] `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- [x] `RUSTDOCFLAGS=-Dwarnings cargo doc --manifest-path crates/Cargo.toml --workspace --no-deps`

All five gates passed against independently reviewed SHA `74669ec50052573bbd40defa610f7644b5278869` on unchanged `main` base `c32ea3541063ca5626058dd52e9d5f419f7f2181` before this draft was opened.

## ADR

- amend ADR-031 to require readable-model symmetry before a writer fans out across embedding models
- align ADR-035, ADR-047, ADR-051, and ADR-103 with the knowledge pack's current default-model indexing and retrieval contract

## AI-assisted contribution checklist

- [x] Every claim in this PR description matches the actual diff
- [x] Any agent-authored comment / PR body starts with an attribution line
- [x] The regression uses fake providers and performs no model download
- [x] Full workspace behavior, lint, formatting, and documentation gates passed

## Out of scope

- adding multi-model knowledge retrieval
- migrating section embeddings to model-keyed storage (#1511)
- changing multi-model indexing or retrieval behavior in memory, communication, or generic KG paths
