### PR TITLE
fix(ci): make contract sentinels authoritative

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -159,6 +159,21 @@ jobs:
           deno-version: v2.x
       - uses: astral-sh/setup-uv@v5
         if: env.CI_SUITE == 'full' && matrix.shard == 1
+      # The identifier-ban contract performs a repo-wide ripgrep scan and
+      # fails (rather than skips) when CI lacks rg (#1636). ubuntu-latest does
+      # not include it, so provision the instrument in every full-suite shard
+      # that runs khive-contract.
+      - name: Install khive-contract scan dependency (Linux)
+        if: env.CI_SUITE == 'full' && matrix.shard == 1 && runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install --yes ripgrep
+          rg --version
+      - name: Install khive-contract scan dependency (macOS)
+        if: env.CI_SUITE == 'full' && matrix.shard == 1 && runner.os == 'macOS'
+        run: |
+          brew install ripgrep
+          rg --version
       # SECURITY ORDERING (#560): the placeholder-stub scan runs before any cargo
       # phase so no PR-controlled build script or proc-macro executes before the
       # guard; it reads the pristine checkout. Keep this step ahead of every cargo

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,6 +46,13 @@ The full CI pipeline is in `scripts/ci.sh` and can be run locally with:
 make ci
 ```
 
+The Rust test and doctest phases run under a fresh temporary `HOME`, while preserving the
+caller's `CARGO_HOME` and `RUSTUP_HOME`. This keeps the store-isolation tripwire meaningful on a
+workstation that is also running a khive daemon: accidental default-path writes are detected in
+the temporary home, and unrelated writes to the operator's live `~/.khive` store cannot make the
+suite fail. Tests that need persistent fixtures must pass an explicit temporary `db_path` rather
+than depend on the operator's home directory.
+
 Individual targets: `make check`, `make clippy`, `make test`, `make fmt`.
 
 ## Pull Request Workflow

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -100,12 +100,12 @@ phase_docs() {
 
 # #1204 tripwire (shared by phase_tests and phase_tests_doc):
 # RuntimeConfig::default() resolves db_path to $HOME/.khive/khive.db, and
-# migrations apply on open (forward-only, ADR-015). A test that boots a
-# runtime through a config path inheriting that default reaches the
-# operator's/runner's real store instead of an isolated one. Fingerprint the
-# sentinel file set before the suite and compare after; any change fails the
-# gate loudly instead of leaving the drift for a later direct-open to
-# discover. Covered paths are khive.db, khive.db-wal, khive.db-shm,
+# migrations apply on open (forward-only, ADR-015). Run each guarded phase in
+# an ephemeral HOME, while preserving the operator's Cargo and rustup homes,
+# then fingerprint that isolated store before and after. A test that inherits
+# the default path still fails loudly, but an unrelated live daemon can mutate
+# the operator's real store without creating a false attribution (#1627).
+# Covered paths are khive.db, khive.db-wal, khive.db-shm,
 # khive.db.walpin/**, and khive.db.ann/**.
 # A WAL-mode open can leave the main file unchanged until checkpoint, while
 # WAL-pin attribution and ANN persistence write the adjacent directories.
@@ -144,21 +144,46 @@ sentinel_fingerprint() {
 # executes workspace tests of any kind (unit/integration or doctests) must go
 # through this wrapper so no test-execution path escapes the default-store
 # isolation invariant.
-run_with_store_sentinel() {
+run_with_store_sentinel() (
+    operator_home=${HOME:-}
+    isolated_home=$(mktemp -d "${TMPDIR:-/tmp}/khive-ci-home.XXXXXX")
+    trap 'rm -rf -- "$isolated_home"' 0
+    trap 'exit 130' HUP INT TERM
+
+    # `cargo` and `rustup` normally keep their toolchains below HOME. Preserve
+    # those locations before swapping HOME so isolation does not trigger a
+    # toolchain download or make `cargo` disappear on developer machines.
+    if [ -z "${CARGO_HOME+x}" ] && [ -n "$operator_home" ]; then
+        CARGO_HOME="$operator_home/.cargo"
+        export CARGO_HOME
+    fi
+    if [ -z "${RUSTUP_HOME+x}" ] && [ -n "$operator_home" ]; then
+        RUSTUP_HOME="$operator_home/.rustup"
+        export RUSTUP_HOME
+    fi
+    HOME=$isolated_home
+    export HOME
+
     sentinel_before=$(sentinel_fingerprint)
 
-    "$@"
+    if "$@"; then
+        command_status=0
+    else
+        command_status=$?
+    fi
 
     sentinel_after=$(sentinel_fingerprint)
     if [ "$sentinel_after" != "$sentinel_before" ]; then
-        echo "FAIL: test suite touched the real default store under \$HOME/.khive — a test opened/migrated it instead of an isolated db_path/HOME (#1204)" >&2
+        echo "FAIL: test suite touched the default store in its isolated sentinel HOME — a test opened/migrated it instead of using an explicit temporary db_path (#1204)" >&2
         echo "before:" >&2
         printf '%s\n' "$sentinel_before" >&2
         echo "after:" >&2
         printf '%s\n' "$sentinel_after" >&2
         exit 1
     fi
-}
+
+    exit "$command_status"
+)
 
 phase_tests() {
     echo "=== Tests ==="

--- a/tests/khive-contract/tests/test_no_importance_in_manifest.py
+++ b/tests/khive-contract/tests/test_no_importance_in_manifest.py
@@ -116,6 +116,11 @@ def test_no_importance_identifiers_in_repo() -> None:
     """
     rg = _find_rg()
     if rg is None:
+        if os.environ.get("CI", "").lower() in {"1", "true", "yes"}:
+            pytest.fail(
+                "ripgrep (rg) is required for the repository identifier-ban "
+                "contract in CI; the check must not silently skip"
+            )
         pytest.skip("ripgrep (rg) not found on PATH — install ripgrep to run this test")
 
     cmd = [rg, "--no-heading", "-n", "importance"] + EXCLUDED_GLOBS


### PR DESCRIPTION
> AI-assisted contribution: Codex prepared this change and PR description.

## Summary

- run each Rust test/doctest sentinel phase under a fresh temporary `HOME`, while preserving the caller's Cargo and rustup homes
- retain the wrapped command's failure status, detect any default-store writes in the isolated home, and clean the temporary home on every exit path
- make the repository identifier-ban contract fail in CI when `rg` is unavailable, and explicitly provision/verify ripgrep on the Linux and macOS full-suite shard that runs it
- document the isolated-store contract for contributors

## Validation

Validated commit `6afc39505b117d9e279dd1a3a2ade688f95d2c62` against `main` at `c32ea3541063ca5626058dd52e9d5f419f7f2181`:

- `cargo test --manifest-path crates/Cargo.toml --workspace`
- `cargo check --manifest-path crates/Cargo.toml --workspace`
- `cargo clippy --manifest-path crates/Cargo.toml --workspace --all-targets -- -D warnings`
- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `RUSTDOCFLAGS=-Dwarnings cargo doc --manifest-path crates/Cargo.toml --workspace --no-deps`

Closes #1627
Closes #1636
