### PR TITLE
fix(code): index source maps for search

### DIFF
--- a/crates/khive-mcp/src/pending_events.rs
+++ b/crates/khive-mcp/src/pending_events.rs
@@ -148,6 +148,20 @@ pub async fn run_pending_events(
     namespace: &str,
     verbose: bool,
 ) -> Result<DrainSummary> {
+    run_pending_events_with_config(db, None, namespace, verbose).await
+}
+
+/// One-shot drain with an explicit configuration-file selection.
+///
+/// This is the `kkernel exec --pending-events --config …` entrypoint. The
+/// compatibility wrapper above retains the original discovery behavior for
+/// callers that do not carry a config path.
+pub async fn run_pending_events_with_config(
+    db: Option<&str>,
+    config: Option<&std::path::Path>,
+    namespace: &str,
+    verbose: bool,
+) -> Result<DrainSummary> {
     // Resolve through the SAME multi-backend-aware construction the daemon
     // boot path uses (`khive-mcp::serve::build_server_with_explicit_namespace`),
     // rather than a throwaway `RuntimeConfig::default()` (PR #782):
@@ -162,10 +176,9 @@ pub async fn run_pending_events(
     // (single- or multi-backend), so replayed actions route through the
     // correct per-pack backend exactly like the daemon tick now does — not a
     // single runtime standing in for every pack (the same issue this fix
-    // closes for the daemon-resident tick). `kkernel exec` has no
-    // `--config` flag today (see `kkernel::exec::run_exec`'s own
-    // `resolve_runtime_config` call), so this mirrors that: `config: None`
-    // still triggers `khive.toml`'s standard cwd/home search order inside
+    // closes for the daemon-resident tick). An explicit `kkernel exec
+    // --config` path is forwarded unchanged; otherwise `config: None` still
+    // triggers `khive.toml`'s standard cwd/home search order inside
     // `resolve_runtime_config`.
     //
     // This does NOT call `crate::serve::build_server` directly (PR #782):
@@ -201,7 +214,7 @@ pub async fn run_pending_events(
         namespace: None,
         no_embed: false,
         pack: Vec::new(),
-        config: None,
+        config: config.map(std::path::Path::to_path_buf),
         daemon: false,
         transport: None,
         bind: None,

--- a/crates/khive-pack-code/docs/code-ontology.md
+++ b/crates/khive-pack-code/docs/code-ontology.md
@@ -24,3 +24,11 @@ The pack depends on `kg`, registers the finding hook and vocabulary, and contrib
 database. `findings.json` ingestion is an admin CLI path through `kkernel code-ingest`, not an
 MCP operation. Unknown dispatch attempts fail
 with `RuntimeError::InvalidInput` rather than silently succeeding.
+
+The dedicated map is an ordinary khive database, not a private code-pack format. Every
+non-blocked entity upsert also updates its FTS document, and `code.ingest` reports the completed
+count as `fts_indexed`; a failed FTS write fails the ingest instead of returning an unqualified
+success for an unsearchable map. Point a normal `kkernel` process at the map through a
+`[[backends]]` entry in a selected config to use generic KG reads such as `search`, `resolve`,
+`neighbors`, `traverse`, and `context`. `kkernel code-audit` remains the separate policy-driven,
+read-only report surface for the same database.

--- a/crates/khive-pack-code/src/source_ingest.rs
+++ b/crates/khive-pack-code/src/source_ingest.rs
@@ -21,7 +21,7 @@ use std::fs;
 use std::path::{Path, PathBuf};
 
 use chrono::{DateTime, Utc};
-use khive_runtime::{secret_gate, KhiveRuntime, NamespaceToken, RuntimeError};
+use khive_runtime::{entity_fts_document, secret_gate, KhiveRuntime, NamespaceToken, RuntimeError};
 use khive_storage::{Edge, Entity, LinkId};
 use khive_types::EdgeRelation;
 use serde_json::{json, Value};
@@ -57,6 +57,10 @@ pub struct CodeSourceIngestReport {
     pub edges_updated: u64,
     pub unresolved_recorded: u64,
     pub unresolved_resolved: u64,
+    /// Entity documents successfully written to the map database's FTS index.
+    /// A successful ingest indexes every non-blocked entity upsert, so generic
+    /// KG `search` and query-anchored `context` can read the resulting map.
+    pub fts_indexed: u64,
     pub languages: Vec<String>,
     /// Per-manifest / per-file failures that did not abort the pass (fail
     /// loud without silently dropping the rest of the run).
@@ -201,10 +205,20 @@ async fn upsert_entity(
             other => Err(other.into()),
         };
     }
+    let document = entity_fts_document(&entity);
     rt.entities(token)?
         .upsert_entity(entity)
         .await
         .map_err(|e| CodeSourceIngestError::Storage(e.to_string()))?;
+    // This direct ingest path intentionally bypasses the runtime create/update
+    // verbs, so it must compose the same FTS write itself. Fail the call if the
+    // index write fails: returning an apparently healthy but unsearchable map
+    // makes an empty search result indistinguishable from a correct answer.
+    rt.text(token)?
+        .upsert_document(document)
+        .await
+        .map_err(|e| CodeSourceIngestError::Storage(format!("entity FTS indexing: {e}")))?;
+    report.fts_indexed += 1;
     Ok(true)
 }
 

--- a/crates/khive-pack-code/tests/source_ingest.rs
+++ b/crates/khive-pack-code/tests/source_ingest.rs
@@ -11,8 +11,10 @@ use std::path::Path;
 
 use chrono::Utc;
 use khive_pack_code::source_ingest::{run_code_ingest, CodeSourceIngestOptions};
-use khive_runtime::{KhiveRuntime, Namespace, RuntimeConfig};
+use khive_pack_kg::KgPack;
+use khive_runtime::{KhiveRuntime, Namespace, RuntimeConfig, VerbRegistryBuilder};
 use khive_storage::types::{SqlStatement, SqlValue};
+use serde_json::json;
 use tempfile::TempDir;
 
 fn all_languages() -> BTreeSet<&'static str> {
@@ -262,6 +264,48 @@ async fn reingesting_same_fixture_is_idempotent() {
     assert_eq!(
         second.modules_created, 0,
         "second pass must create zero new modules"
+    );
+}
+
+/// Issue #1590: `code.ingest` writes an ordinary khive map database, so a
+/// successful ingest must populate the FTS documents that the generic KG
+/// `search` verb reads. Entity rows without these documents made exact-name
+/// searches return an indistinguishable empty result.
+#[tokio::test]
+async fn ingested_map_entities_are_visible_to_generic_search() {
+    let root = TempDir::new().expect("tempdir");
+    write_two_package_fixture(root.path());
+    let db = root.path().join("searchable.db");
+    let rt = rt_at(&db);
+    let token = rt.authorize(Namespace::local()).expect("token");
+
+    let report = run_code_ingest(
+        &rt,
+        &token,
+        CodeSourceIngestOptions {
+            path: root.path(),
+            languages: all_languages(),
+            sweep_time: Utc::now(),
+        },
+    )
+    .await
+    .expect("source ingest succeeds");
+    assert!(
+        report.fts_indexed > 0,
+        "successful report must expose populated FTS work: {report:?}"
+    );
+
+    let mut builder = VerbRegistryBuilder::new();
+    builder.register(KgPack::new(rt));
+    let registry = builder.build().expect("kg registry builds");
+    let result = registry
+        .dispatch("search", json!({"kind": "entity", "query": "pkg_a"}))
+        .await
+        .expect("generic search against map succeeds");
+    let hits = result.as_array().expect("search returns an array");
+    assert!(
+        hits.iter().any(|hit| hit["name"] == "pkg_a"),
+        "exact ingested project name must be searchable; got {hits:?}"
     );
 }
 

--- a/crates/kkernel/src/exec.rs
+++ b/crates/kkernel/src/exec.rs
@@ -199,6 +199,11 @@ pub struct ExecArgs {
     #[arg(long, env = "KHIVE_DB")]
     pub db: Option<String>,
 
+    /// Explicit khive configuration file. This selects the same engine,
+    /// backend-topology, and actor configuration used by `kkernel mcp`.
+    #[arg(long, env = "KHIVE_CONFIG")]
+    pub config: Option<PathBuf>,
+
     /// Namespace to operate in.
     #[arg(long, default_value = "local")]
     pub namespace: String,
@@ -521,9 +526,13 @@ async fn apply_ops_file(
 pub async fn run_exec(args: ExecArgs) -> Result<()> {
     // ── pending-events drain ─────────────────────────────────────────────────
     if args.pending_events {
-        let summary =
-            pending_events::run_pending_events(args.db.as_deref(), &args.namespace, args.verbose)
-                .await?;
+        let summary = pending_events::run_pending_events_with_config(
+            args.db.as_deref(),
+            args.config.as_deref(),
+            &args.namespace,
+            args.verbose,
+        )
+        .await?;
         pending_events::print_summary(&summary);
         return Ok(());
     }
@@ -559,7 +568,7 @@ pub async fn run_exec(args: ExecArgs) -> Result<()> {
     let (mut cfg, db_anchor) =
         khive_mcp::serve::resolve_runtime_config_with_db_anchor(RuntimeConfigInputs {
             db: args.db.as_deref(),
-            config: None, // `kkernel exec` has no `--config` flag today
+            config: args.config.as_deref(),
             namespace,
             // `--namespace` has a clap `default_value = "local"`, so it is always
             // present — there is no way to distinguish "operator typed --namespace
@@ -606,6 +615,7 @@ pub async fn run_exec(args: ExecArgs) -> Result<()> {
     let db_context = ExecDbContext {
         raw: args.db,
         anchor: db_anchor,
+        config: args.config,
     };
 
     match mode {
@@ -729,6 +739,7 @@ enum ExecMode {
 struct ExecDbContext {
     raw: Option<String>,
     anchor: Option<PathBuf>,
+    config: Option<PathBuf>,
 }
 
 async fn run_exec_inline(
@@ -803,9 +814,8 @@ async fn run_exec_inline_with_forward(
     // topology (further below) resolve from the identical TOML file the
     // daemon's own boot path loads (`serve.rs`'s `build_server`:
     // `KhiveConfig::load_with_home_fallback(args.config.as_deref(),
-    // config_discovery_db_anchor(args.db.as_deref()).as_deref())` —
-    // `kkernel exec` has no `--config` flag, so the first argument here is
-    // always `None`, exactly like there. The second argument is the raw
+    // config_discovery_db_anchor(args.db.as_deref()).as_deref())`. The second
+    // argument is the raw
     // `--db`/`KHIVE_DB` discovery anchor (`None` unless `--db` was set) rather
     // than `cfg.db_path` — `cfg.db_path` materializes the `$HOME/.khive`
     // default when `--db` is unset (#689), which would incorrectly re-anchor
@@ -820,9 +830,12 @@ async fn run_exec_inline_with_forward(
     // `ConfigMismatch` and silently fell back to the cold in-process path on
     // every call.
     let db_path_for_config = config_discovery_db_anchor(db_context.raw.as_deref());
-    let khive_cfg = KhiveConfig::load_with_home_fallback(None, db_path_for_config.as_deref())
-        .map_err(|e| anyhow::anyhow!("config error: {e}"))?
-        .unwrap_or_default();
+    let khive_cfg = KhiveConfig::load_with_home_fallback(
+        db_context.config.as_deref(),
+        db_path_for_config.as_deref(),
+    )
+    .map_err(|e| anyhow::anyhow!("config error: {e}"))?
+    .unwrap_or_default();
 
     // #1226: apply the same --db/[[backends]] conflict guard the in-process
     // fallback below applies, BEFORE the daemon fast-path — otherwise a warm
@@ -990,9 +1003,12 @@ async fn run_exec_ops_file(
     // path — see `build_local_fallback_server`.
     enforce_strict_actor_mode(cfg.actor_id.as_deref(), &cfg.packs)?;
     let db_path_for_config = config_discovery_db_anchor(db_context.raw.as_deref());
-    let khive_cfg = KhiveConfig::load_with_home_fallback(None, db_path_for_config.as_deref())
-        .map_err(|e| anyhow::anyhow!("config error: {e}"))?
-        .unwrap_or_default();
+    let khive_cfg = KhiveConfig::load_with_home_fallback(
+        db_context.config.as_deref(),
+        db_path_for_config.as_deref(),
+    )
+    .map_err(|e| anyhow::anyhow!("config error: {e}"))?
+    .unwrap_or_default();
 
     if atomic {
         let max_ops = atomic_max_ops.unwrap_or(khive_types::pack::ATOMIC_MAX_OPS_DEFAULT);
@@ -1205,6 +1221,20 @@ mod tests {
         let args = ExecArgs::parse_from(["exec", "stats()"]);
         std::env::remove_var("KHIVE_DB");
         assert_eq!(args.db.as_deref(), Some("/tmp/kkernel-exec-env.db"));
+    }
+
+    #[test]
+    fn explicit_config_flag_parses_for_exec() {
+        let args = ExecArgs::parse_from([
+            "exec",
+            "stats()",
+            "--config",
+            "/tmp/kkernel-exec-config.toml",
+        ]);
+        assert_eq!(
+            args.config.as_deref(),
+            Some(std::path::Path::new("/tmp/kkernel-exec-config.toml"))
+        );
     }
 
     #[test]
@@ -1544,9 +1574,8 @@ default = true
 
         let ns = Namespace::parse("local").expect("ns");
 
-        // exec-shaped inputs: `config: None` (kkernel exec has no `--config`
-        // flag today), `namespace_explicit: true` (the choice made in `run_exec`
-        // above).
+        // Exec-shaped inputs with no explicit config in this scenario and
+        // `namespace_explicit: true` (the choice made in `run_exec` above).
         // Pin the pack list explicitly rather than inheriting `KHIVE_PACKS`
         // from the ambient environment (same rationale as `isolated_server`
         // above, #1276): `RuntimeConfig::default()` reads `KHIVE_PACKS` fresh
@@ -3174,6 +3203,88 @@ id = "lambda:fallback"
     #[cfg(unix)]
     #[tokio::test]
     #[serial]
+    async fn explicit_config_is_loaded_for_exec_forward_frame() {
+        std::env::remove_var("KHIVE_EMBEDDING_MODEL");
+        std::env::remove_var("KHIVE_ADDITIONAL_EMBEDDING_MODELS");
+        std::env::remove_var("KHIVE_ACTOR");
+        std::env::remove_var("KHIVE_REQUIRE_ATTRIBUTED_ACTOR");
+        let (prev_home, _home_dir) = isolate_home_for_test();
+        SPY_CAPTURED_CONFIG_ID.with(|captured| *captured.borrow_mut() = None);
+
+        let fixture = tempfile::tempdir().expect("config fixture tempdir");
+        let config_path = fixture.path().join("code-map.toml");
+        let main_backend_path = fixture.path().join("code-map.db");
+        let sessions_backend_path = fixture.path().join("sessions.db");
+        std::fs::write(
+            &config_path,
+            format!(
+                r#"
+[[backends]]
+name = "main"
+kind = "sqlite"
+path = "{}"
+
+[[backends]]
+name = "sessions"
+kind = "sqlite"
+path = "{}"
+"#,
+                main_backend_path.display(),
+                sessions_backend_path.display(),
+            ),
+        )
+        .expect("write explicit exec config");
+
+        let cfg = resolve_runtime_config(RuntimeConfigInputs {
+            db: None,
+            config: Some(&config_path),
+            namespace: Namespace::parse("local").expect("namespace"),
+            namespace_explicit: true,
+            actor_explicit: false,
+            no_embed: true,
+            packs: Some(vec!["kg".to_string()]),
+            brain_profile: None,
+        })
+        .expect("resolve explicit exec config");
+
+        let result = run_exec_inline_with_forward(
+            "stats()".to_string(),
+            cfg.clone(),
+            None,
+            None,
+            None,
+            ExecDbContext {
+                raw: None,
+                anchor: None,
+                config: Some(config_path.clone()),
+            },
+            false,
+            spy_capture_config_id,
+        )
+        .await;
+        assert!(
+            result.is_ok(),
+            "explicit-config dispatch failed: {result:?}"
+        );
+
+        let captured = SPY_CAPTURED_CONFIG_ID
+            .with(|value| value.borrow_mut().take())
+            .expect("spy must capture the forwarded config id");
+        let khive_cfg = KhiveConfig::load_with_home_fallback(Some(&config_path), None)
+            .expect("load explicit config")
+            .expect("explicit config must exist");
+        let expected = compute_config_id(&cfg, Some(&khive_cfg));
+        restore_home(prev_home);
+
+        assert_eq!(
+            captured, expected,
+            "the exec forward frame must fold the explicitly selected backend topology"
+        );
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    #[serial]
     async fn exec_frame_config_id_matches_daemon_config_id_for_multi_backend_project_toml() {
         std::env::remove_var("KHIVE_EMBEDDING_MODEL");
         std::env::remove_var("KHIVE_ADDITIONAL_EMBEDDING_MODELS");
@@ -3398,6 +3509,7 @@ backend = "sessions"
             ExecDbContext {
                 raw: Some(matching_override.clone()),
                 anchor: khive_runtime::resolve_db_anchor(Some(&matching_override)),
+                config: None,
             },
             false,
             spy_capture_config_id,
@@ -3421,6 +3533,7 @@ backend = "sessions"
             ExecDbContext {
                 raw: Some(conflicting_override.display().to_string()),
                 anchor: None,
+                config: None,
             },
             false,
             spy_capture_config_id,

--- a/crates/kkernel/tests/actor_pin_default_read_scope.rs
+++ b/crates/kkernel/tests/actor_pin_default_read_scope.rs
@@ -50,6 +50,7 @@ fn base_args(db: &str, actor: Option<&str>, ops: &str, save_file: &str) -> ExecA
         ops: Some(ops.to_string()),
         pending_events: false,
         db: Some(db.to_string()),
+        config: None,
         namespace: "local".to_string(),
         actor: actor.map(str::to_string),
         expect_actor: None,

--- a/crates/kkernel/tests/config_discovery_reload_anchor.rs
+++ b/crates/kkernel/tests/config_discovery_reload_anchor.rs
@@ -110,6 +110,7 @@ path = "{}"
         ops: Some("stats()".to_string()),
         pending_events: false,
         db: None, // the repro shape: --db left unset
+        config: None,
         namespace: "local".to_string(),
         actor: None,
         expect_actor: None,

--- a/crates/kkernel/tests/daemon_forward_frame_actor_pin.rs
+++ b/crates/kkernel/tests/daemon_forward_frame_actor_pin.rs
@@ -68,6 +68,7 @@ fn base_args(db: &str, actor: Option<&str>) -> ExecArgs {
         ops: Some("stats()".to_string()),
         pending_events: false,
         db: Some(db.to_string()),
+        config: None,
         namespace: "local".to_string(),
         actor: actor.map(str::to_string),
         expect_actor: None,

--- a/docs/adr/ADR-085-code-pack.md
+++ b/docs/adr/ADR-085-code-pack.md
@@ -661,6 +661,17 @@ symbols and modules an agent's work has actually referenced, into the shared
 production database is a separate, explicit curation or import path, distinct
 from and never performed by `code.ingest`.
 
+The dedicated target uses the ordinary khive graph and text-search substrates. Each entity upsert
+in L1/L1.5 is paired with `entity_fts_document` in the map's text store; a successful
+`code.ingest` response therefore means generic KG `search` and query-anchored `context` can read
+the entities it reports. An FTS write failure fails the ingest and is repaired by an idempotent
+retry, rather than returning an unqualified success for a graph whose empty search results would
+look authoritative. The report exposes the number of completed document writes as `fts_indexed`.
+Interactive reads select the map with a dedicated `[[backends]]` config and `--config`. The
+multi-backend safety contract refuses a conflicting concrete `--db` override, while permitting
+`:memory:` and normalizing a path that canonically matches the declared `main` backend. The
+policy-derived `kkernel code-audit` admin command remains a separate, documented read surface.
+
 ### B8: Acceptance
 
 An implementation of this amendment is acceptance-tested against three

--- a/docs/guide/api-reference.md
+++ b/docs/guide/api-reference.md
@@ -1875,6 +1875,34 @@ becomes known.
 request(ops="code.ingest(path=\"/repo/crates/my-crate\")")
 ```
 
+The success report includes `fts_indexed`, the number of entity documents written to the map's
+full-text index. Entity and FTS writes are a single success postcondition for this verb: an FTS
+failure makes the ingest fail rather than returning a structurally populated but unsearchable map.
+
+The map database uses the ordinary khive schema. To explore it with the generic KG read verbs,
+select it as a backend in a dedicated config:
+
+```toml
+[[backends]]
+name = "main"
+kind = "sqlite"
+path = "/absolute/path/to/code-map.db"
+```
+
+```sh
+kkernel exec --config /absolute/path/to/code-map.toml \
+  'search(kind="entity", query="my-crate")'
+kkernel exec --config /absolute/path/to/code-map.toml \
+  'resolve(refs=["my-crate"])'
+```
+
+Use `--config` without `--db` for this read path. With `[[backends]]` configured, a conflicting
+concrete `--db` override is refused; `:memory:` remains an explicit ephemeral override, and a path
+that canonically matches the declared `main` backend is normalized as a no-op. A warning that a
+daemon has a different configuration and local fallback is required is expected and prevents
+accidentally serving the production database. `kkernel code-audit` is the distinct policy-driven
+reporting surface over a code-map database.
+
 ---
 
 ## `blob` pack — 3 verbs


### PR DESCRIPTION
> AI-assisted contribution: Codex prepared this change and PR description.

## Summary

- pair every successful `code.ingest` entity upsert with the canonical FTS document write, fail loudly when indexing fails, and report the completed count as `fts_indexed`
- add an end-to-end regression proving entities in a dedicated code-map database are visible through the ordinary KG `search` verb
- add `kkernel exec --config` / `KHIVE_CONFIG` support across inline dispatch, daemon forwarding, ops files, and pending-event drains so generic KG reads can select the map's declared backend topology
- preserve the existing multi-backend override guard: conflicting concrete `--db` paths are refused, while `:memory:` and a canonical match to the declared `main` backend remain valid
- document the code-map read surface and its distinction from the policy-derived `kkernel code-audit` command

## Validation

Validated commit `0ee3810a377f829479a7fabc68acf629933d25f8` against `main` at `c32ea3541063ca5626058dd52e9d5f419f7f2181`:

- `cargo test --manifest-path crates/Cargo.toml --workspace`
- `cargo check --manifest-path crates/Cargo.toml --workspace`
- `cargo clippy --manifest-path crates/Cargo.toml --workspace --all-targets -- -D warnings`
- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `RUSTDOCFLAGS=-Dwarnings cargo doc --manifest-path crates/Cargo.toml --workspace --no-deps`

Closes #1590
