### PR TITLE
fix(publish): move khive-text ahead of khive-bm25 in the publish ladder

### DIFF
--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -53,8 +53,8 @@ CRATES=(
     khive-vamana
     khive-fold
     khive-storage
+    khive-text          # khive-bm25 depends on it (normal dep); the old dev-dep cycle is gone
     khive-bm25
-    khive-text          # dev-dep on khive-bm25 (versioned), so publish after it
     khive-fusion
     khive-db
     khive-hnsw


### PR DESCRIPTION
The publish ladder listed khive-bm25 before khive-text on the strength of a stale comment describing a dev-dep cycle that no longer exists. khive-bm25 has a normal dependency on khive-text (^0.7.0), so a live publish fails at khive-bm25 when khive-text is not yet on the index.

This swaps the two entries and corrects the comment. The full 40-crate ladder was re-verified against `cargo metadata` (normal deps only): zero ordering violations.

Caught during the 0.7.0 live publish; the run was resumed successfully after this fix thanks to the skip-if-published guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)