### PR TITLE
chore(release): v0.7.1 — lattice 0.7.0 dependency adoption

### DIFF
--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -317,58 +317,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "axum"
-version = "0.8.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
-dependencies = [
- "axum-core",
- "bytes",
- "form_urlencoded",
- "futures-util",
- "http",
- "http-body",
- "http-body-util",
- "hyper",
- "hyper-util",
- "itoa",
- "matchit",
- "memchr",
- "mime",
- "percent-encoding",
- "pin-project-lite",
- "serde_core",
- "serde_json",
- "serde_path_to_error",
- "serde_urlencoded",
- "sync_wrapper",
- "tokio",
- "tower",
- "tower-layer",
- "tower-service",
- "tracing",
-]
-
-[[package]]
-name = "axum-core"
-version = "0.5.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
-dependencies = [
- "bytes",
- "futures-core",
- "http",
- "http-body",
- "http-body-util",
- "mime",
- "pin-project-lite",
- "sync_wrapper",
- "tower-layer",
- "tower-service",
- "tracing",
-]
-
-[[package]]
 name = "base64"
 version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1460,7 +1408,6 @@ dependencies = [
  "http",
  "http-body",
  "httparse",
- "httpdate",
  "itoa",
  "pin-project-lite",
  "smallvec",
@@ -1840,7 +1787,7 @@ dependencies = [
 
 [[package]]
 name = "khive-bm25"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "criterion",
  "khive-score",
@@ -1854,7 +1801,7 @@ dependencies = [
 
 [[package]]
 name = "khive-brain-core"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "chrono",
  "criterion",
@@ -1869,7 +1816,7 @@ dependencies = [
 
 [[package]]
 name = "khive-changeset"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "khive-types",
  "proptest",
@@ -1880,7 +1827,7 @@ dependencies = [
 
 [[package]]
 name = "khive-channel"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1894,7 +1841,7 @@ dependencies = [
 
 [[package]]
 name = "khive-channel-email"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "async-imap",
  "async-native-tls",
@@ -1918,7 +1865,7 @@ dependencies = [
 
 [[package]]
 name = "khive-channel-telegram"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1933,7 +1880,7 @@ dependencies = [
 
 [[package]]
 name = "khive-db"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "async-trait",
  "blake3",
@@ -1966,7 +1913,7 @@ dependencies = [
 
 [[package]]
 name = "khive-fold"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "blake3",
  "chrono",
@@ -1981,7 +1928,7 @@ dependencies = [
 
 [[package]]
 name = "khive-fusion"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "criterion",
  "khive-score",
@@ -1991,7 +1938,7 @@ dependencies = [
 
 [[package]]
 name = "khive-gate"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "chrono",
  "khive-types",
@@ -2002,7 +1949,7 @@ dependencies = [
 
 [[package]]
 name = "khive-gate-rego"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "khive-gate",
  "khive-types",
@@ -2014,7 +1961,7 @@ dependencies = [
 
 [[package]]
 name = "khive-hnsw"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "criterion",
  "khive-fold",
@@ -2033,7 +1980,7 @@ dependencies = [
 
 [[package]]
 name = "khive-mcp"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2079,7 +2026,7 @@ dependencies = [
 
 [[package]]
 name = "khive-pack-blob"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2097,7 +2044,7 @@ dependencies = [
 
 [[package]]
 name = "khive-pack-brain"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2123,7 +2070,7 @@ dependencies = [
 
 [[package]]
 name = "khive-pack-code"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2145,7 +2092,7 @@ dependencies = [
 
 [[package]]
 name = "khive-pack-comm"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2169,7 +2116,7 @@ dependencies = [
 
 [[package]]
 name = "khive-pack-formal"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "async-trait",
  "inventory",
@@ -2181,7 +2128,7 @@ dependencies = [
 
 [[package]]
 name = "khive-pack-git"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2204,7 +2151,7 @@ dependencies = [
 
 [[package]]
 name = "khive-pack-gtd"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2223,7 +2170,7 @@ dependencies = [
 
 [[package]]
 name = "khive-pack-kg"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2245,7 +2192,7 @@ dependencies = [
 
 [[package]]
 name = "khive-pack-knowledge"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2273,7 +2220,7 @@ dependencies = [
 
 [[package]]
 name = "khive-pack-memory"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "async-trait",
  "blake3",
@@ -2305,7 +2252,7 @@ dependencies = [
 
 [[package]]
 name = "khive-pack-schedule"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2328,7 +2275,7 @@ dependencies = [
 
 [[package]]
 name = "khive-pack-session"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2348,7 +2295,7 @@ dependencies = [
 
 [[package]]
 name = "khive-pack-template"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "async-trait",
  "inventory",
@@ -2361,7 +2308,7 @@ dependencies = [
 
 [[package]]
 name = "khive-pack-workspace"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "async-trait",
  "inventory",
@@ -2378,7 +2325,7 @@ dependencies = [
 
 [[package]]
 name = "khive-quant"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "criterion",
  "rand 0.8.7",
@@ -2387,7 +2334,7 @@ dependencies = [
 
 [[package]]
 name = "khive-query"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "criterion",
  "khive-types",
@@ -2397,7 +2344,7 @@ dependencies = [
 
 [[package]]
 name = "khive-request"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "criterion",
  "khive-types",
@@ -2407,7 +2354,7 @@ dependencies = [
 
 [[package]]
 name = "khive-retrieval"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2436,7 +2383,7 @@ dependencies = [
 
 [[package]]
 name = "khive-runtime"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2471,7 +2418,7 @@ dependencies = [
 
 [[package]]
 name = "khive-score"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "criterion",
  "khive-types",
@@ -2481,7 +2428,7 @@ dependencies = [
 
 [[package]]
 name = "khive-storage"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2496,7 +2443,7 @@ dependencies = [
 
 [[package]]
 name = "khive-text"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "criterion",
  "rust-stemmers",
@@ -2505,7 +2452,7 @@ dependencies = [
 
 [[package]]
 name = "khive-types"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "blake3",
  "serde",
@@ -2514,7 +2461,7 @@ dependencies = [
 
 [[package]]
 name = "khive-vamana"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "blake3",
  "bytemuck",
@@ -2535,7 +2482,7 @@ dependencies = [
 
 [[package]]
 name = "khive-vcs"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2556,7 +2503,7 @@ dependencies = [
 
 [[package]]
 name = "khive-vcs-adapters"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "khive-types",
  "serde",
@@ -2567,7 +2514,7 @@ dependencies = [
 
 [[package]]
 name = "kkernel"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2615,9 +2562,9 @@ dependencies = [
 
 [[package]]
 name = "lattice-embed"
-version = "0.6.1"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "188e4627dabd63544da5a57daabfe3105bf4d4970840f2e5a5c7f01123835ecb"
+checksum = "1f3af50558cf953df225b68ec160f1ea49b0965564f10a9b8577d15ac8452542"
 dependencies = [
  "async-trait",
  "blake3",
@@ -2634,9 +2581,9 @@ dependencies = [
 
 [[package]]
 name = "lattice-fann"
-version = "0.6.1"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e57e52553ecec092567bb4443e3990fa99f4cb24b5789c0e084c5f468e33a511"
+checksum = "0138e146ca872be0179dc409810601ceb31ee95365d7fd2b1ff6b5a84405e228"
 dependencies = [
  "rand 0.8.7",
  "rand_distr",
@@ -2646,16 +2593,15 @@ dependencies = [
 
 [[package]]
 name = "lattice-inference"
-version = "0.6.1"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b113852e4c522b6607cd8e01842b5dff7de307d4cc9223dfd798b0136e2aa62b"
+checksum = "439a555d0b66e489e1c1291522143780fd9e0bbf0475c9f23fd299fa35df68a2"
 dependencies = [
- "axum",
  "clap",
- "futures",
  "half",
  "image",
  "indexmap",
+ "libc",
  "memmap2",
  "rayon",
  "rustc-hash",
@@ -2663,7 +2609,6 @@ dependencies = [
  "serde_json",
  "sha2",
  "thiserror 2.0.18",
- "tokio",
  "tracing",
  "ureq",
 ]
@@ -2798,12 +2743,6 @@ checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
 dependencies = [
  "regex-automata",
 ]
-
-[[package]]
-name = "matchit"
-version = "0.8.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
 name = "md-5"
@@ -4115,17 +4054,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_path_to_error"
-version = "0.1.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10a9ff822e371bb5403e391ecd83e182e0e77ba7f6fe0160b795797109d1b457"
-dependencies = [
- "itoa",
- "serde",
- "serde_core",
-]
-
-[[package]]
 name = "serde_spanned"
 version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4579,7 +4507,6 @@ dependencies = [
  "tokio",
  "tower-layer",
  "tower-service",
- "tracing",
 ]
 
 [[package]]
@@ -4618,7 +4545,6 @@ version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
- "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",

--- a/crates/Cargo.toml
+++ b/crates/Cargo.toml
@@ -51,9 +51,9 @@ exclude = ["khive-merge"]
 # keep this exclusion from members.
 
 [workspace.package]
-version = "0.7.0"
+version = "0.7.1"
 edition = "2021"
-# lattice-embed and lattice-fann 0.6 require Rust 1.93, setting the workspace MSRV.
+# lattice-embed and lattice-fann 0.7 require Rust 1.93, setting the workspace MSRV.
 # The previous 1.91 floor came from floor_char_boundary use (issue #398).
 rust-version = "1.93.0"
 authors = ["Ocean <ocean@lionagi.ai>"]
@@ -83,8 +83,8 @@ chrono = { version = "0.4", default-features = false, features = ["serde", "cloc
 async-trait = "0.1"
 clap = { version = "4.5", features = ["derive", "env"] }
 dotenvy = "0.15"
-lattice-embed = "0.6.0"
-lattice-fann = "0.6.0"
+lattice-embed = "0.7.0"
+lattice-fann = "0.7.0"
 parking_lot = "0.12"
 rand = "0.8"
 rand_distr = "0.4"

--- a/crates/khive-merge/Cargo.lock
+++ b/crates/khive-merge/Cargo.lock
@@ -138,58 +138,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "axum"
-version = "0.8.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
-dependencies = [
- "axum-core",
- "bytes",
- "form_urlencoded",
- "futures-util",
- "http",
- "http-body",
- "http-body-util",
- "hyper",
- "hyper-util",
- "itoa",
- "matchit",
- "memchr",
- "mime",
- "percent-encoding",
- "pin-project-lite",
- "serde_core",
- "serde_json",
- "serde_path_to_error",
- "serde_urlencoded",
- "sync_wrapper",
- "tokio",
- "tower",
- "tower-layer",
- "tower-service",
- "tracing",
-]
-
-[[package]]
-name = "axum-core"
-version = "0.5.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
-dependencies = [
- "bytes",
- "futures-core",
- "http",
- "http-body",
- "http-body-util",
- "mime",
- "pin-project-lite",
- "sync_wrapper",
- "tower-layer",
- "tower-service",
- "tracing",
-]
-
-[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -797,8 +745,6 @@ version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
- "allocator-api2",
- "equivalent",
  "foldhash 0.1.5",
 ]
 
@@ -808,6 +754,8 @@ version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 dependencies = [
+ "allocator-api2",
+ "equivalent",
  "foldhash 0.2.0",
 ]
 
@@ -875,12 +823,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
-name = "httpdate"
-version = "1.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
-
-[[package]]
 name = "humantime"
 version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -909,7 +851,6 @@ dependencies = [
  "http",
  "http-body",
  "httparse",
- "httpdate",
  "itoa",
  "pin-project-lite",
  "smallvec",
@@ -1224,7 +1165,7 @@ dependencies = [
 
 [[package]]
 name = "khive-db"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "async-trait",
  "blake3",
@@ -1253,7 +1194,7 @@ dependencies = [
 
 [[package]]
 name = "khive-fold"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "blake3",
  "chrono",
@@ -1267,7 +1208,7 @@ dependencies = [
 
 [[package]]
 name = "khive-fusion"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "khive-score",
  "serde",
@@ -1276,7 +1217,7 @@ dependencies = [
 
 [[package]]
 name = "khive-gate"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "chrono",
  "khive-types",
@@ -1301,7 +1242,7 @@ dependencies = [
 
 [[package]]
 name = "khive-query"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "khive-types",
  "thiserror",
@@ -1309,7 +1250,7 @@ dependencies = [
 
 [[package]]
 name = "khive-runtime"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1339,7 +1280,7 @@ dependencies = [
 
 [[package]]
 name = "khive-score"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "khive-types",
  "serde",
@@ -1347,7 +1288,7 @@ dependencies = [
 
 [[package]]
 name = "khive-storage"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1362,7 +1303,7 @@ dependencies = [
 
 [[package]]
 name = "khive-types"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "blake3",
  "serde",
@@ -1371,9 +1312,9 @@ dependencies = [
 
 [[package]]
 name = "lattice-embed"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b2844bae6b81b016ab5b1fbf0429b4ccec864e901fa7e265e3df93042e343cc"
+checksum = "1f3af50558cf953df225b68ec160f1ea49b0965564f10a9b8577d15ac8452542"
 dependencies = [
  "async-trait",
  "blake3",
@@ -1390,16 +1331,15 @@ dependencies = [
 
 [[package]]
 name = "lattice-inference"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f84427773b992aa51d76f47d5585ccc36fe99b28350a7635de3e5565d140e2d0"
+checksum = "439a555d0b66e489e1c1291522143780fd9e0bbf0475c9f23fd299fa35df68a2"
 dependencies = [
- "axum",
  "clap",
- "futures",
  "half",
  "image",
  "indexmap",
+ "libc",
  "memmap2",
  "rayon",
  "rustc-hash",
@@ -1407,7 +1347,6 @@ dependencies = [
  "serde_json",
  "sha2",
  "thiserror",
- "tokio",
  "tracing",
  "ureq",
 ]
@@ -1464,11 +1403,11 @@ checksum = "953f07c43838f8e6f9758cab68bf5bed85465e7587ebe0b823f1bcd81978ad3a"
 
 [[package]]
 name = "lru"
-version = "0.12.5"
+version = "0.16.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
+checksum = "7f66e8d5d03f609abc3a39e6f08e4164ebf1447a732906d39eb9b99b7919ef39"
 dependencies = [
- "hashbrown 0.15.5",
+ "hashbrown 0.16.1",
 ]
 
 [[package]]
@@ -1476,12 +1415,6 @@ name = "lru-slab"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
-
-[[package]]
-name = "matchit"
-version = "0.8.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
 name = "md-5"
@@ -1507,12 +1440,6 @@ checksum = "d1219ed1b7f229ee7104d281dd01d6802fe28bb6e95d292942c4daacdeb798c0"
 dependencies = [
  "libc",
 ]
-
-[[package]]
-name = "mime"
-version = "0.3.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
 name = "miniz_oxide"
@@ -2128,17 +2055,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_path_to_error"
-version = "0.1.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10a9ff822e371bb5403e391ecd83e182e0e77ba7f6fe0160b795797109d1b457"
-dependencies = [
- "itoa",
- "serde",
- "serde_core",
-]
-
-[[package]]
 name = "serde_spanned"
 version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2477,7 +2393,6 @@ dependencies = [
  "tokio",
  "tower-layer",
  "tower-service",
- "tracing",
 ]
 
 [[package]]
@@ -2516,7 +2431,6 @@ version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
- "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",

--- a/crates/khive-pack-kg/src/apply_worker/tests.rs
+++ b/crates/khive-pack-kg/src/apply_worker/tests.rs
@@ -3,7 +3,7 @@ use async_trait::async_trait;
 use khive_runtime::{EmbedderProvider, KhiveRuntime, Namespace, VerbRegistryBuilder};
 use khive_storage::types::{PageRequest, SqlStatement, SqlValue};
 use khive_types::{Id128, NoteDraft, ProposalChangeset, ProposalCreatedPayload};
-use lattice_embed::{EmbedError, EmbeddingModel, EmbeddingService, MAX_TEXT_CHARS};
+use lattice_embed::{EmbedError, EmbeddingModel, EmbeddingService, MAX_TEXT_BYTES};
 use uuid::Uuid;
 
 struct TruncationService;
@@ -300,7 +300,7 @@ async fn apply_worker_returns_atomic_update_truncation_report() {
         id: Id128::from_u128(entity.id.as_u128()),
         patch: khive_types::ProposalEntityPatch {
             name: None,
-            description: Some(Some("x".repeat(MAX_TEXT_CHARS + 1))),
+            description: Some(Some("x".repeat(MAX_TEXT_BYTES + 1))),
             properties: None,
             tags: None,
         },

--- a/crates/khive-pack-kg/src/handlers/tests.rs
+++ b/crates/khive-pack-kg/src/handlers/tests.rs
@@ -1715,7 +1715,7 @@ async fn create_dispatch_emits_embedding_truncation_advisory() {
             json!({
                 "kind": "concept",
                 "name": "warning target",
-                "description": "x".repeat(lattice_embed::MAX_TEXT_CHARS),
+                "description": "x".repeat(lattice_embed::MAX_TEXT_BYTES),
                 "skip_dedup_check": true,
             }),
         )
@@ -1731,14 +1731,14 @@ async fn create_dispatch_emits_embedding_truncation_advisory() {
             json!({
                 "kind": "entity",
                 "id": truncated["id"],
-                "description": "y".repeat(lattice_embed::MAX_TEXT_CHARS + 1),
+                "description": "y".repeat(lattice_embed::MAX_TEXT_BYTES + 1),
             }),
         )
         .await
         .expect("over-limit update");
     assert_eq!(
         updated["description"].as_str().map(str::len),
-        Some(lattice_embed::MAX_TEXT_CHARS + 1),
+        Some(lattice_embed::MAX_TEXT_BYTES + 1),
         "the stored and FTS-indexed source remains complete"
     );
     assert!(
@@ -1785,7 +1785,7 @@ async fn create_dispatch_uses_registry_snapshot_taken_before_embedding() {
         "create",
         json!({
             "kind": "concept",
-            "name": "x".repeat(lattice_embed::MAX_TEXT_CHARS),
+            "name": "x".repeat(lattice_embed::MAX_TEXT_BYTES),
             "skip_dedup_check": true,
         }),
     );

--- a/crates/khive-pack-knowledge/tests/fixes.rs
+++ b/crates/khive-pack-knowledge/tests/fixes.rs
@@ -3102,7 +3102,7 @@ mod edit_inline_reembed {
     use async_trait::async_trait;
     use khive_runtime::{AllowAllGate, BackendId, EmbedderProvider, RuntimeConfig};
     use khive_types::Namespace;
-    use lattice_embed::{EmbedError, EmbeddingModel, EmbeddingService, MAX_TEXT_CHARS};
+    use lattice_embed::{EmbedError, EmbeddingModel, EmbeddingService, MAX_TEXT_BYTES};
     use std::sync::Arc;
 
     const MODEL_KEY: &str = "all-minilm-l6-v2";
@@ -3351,7 +3351,7 @@ mod edit_inline_reembed {
                     "id": "edit-truncation-report",
                     "sections": [{
                         "section_type": "overview",
-                        "content": format!("{}tail", "x".repeat(MAX_TEXT_CHARS + 1))
+                        "content": format!("{}tail", "x".repeat(MAX_TEXT_BYTES + 1))
                     }]
                 }),
             )

--- a/crates/khive-runtime/src/atomic_message.rs
+++ b/crates/khive-runtime/src/atomic_message.rs
@@ -442,7 +442,7 @@ pub async fn create_notes_atomic_with_report(
 mod tests {
     use super::*;
     use async_trait::async_trait;
-    use lattice_embed::{EmbedError, EmbeddingModel, EmbeddingService, MAX_TEXT_CHARS};
+    use lattice_embed::{EmbedError, EmbeddingModel, EmbeddingService, MAX_TEXT_BYTES};
 
     use khive_types::Namespace;
 
@@ -626,7 +626,7 @@ mod tests {
         let token = runtime
             .authorize(Namespace::parse("atomic-message-truncation-test").unwrap())
             .expect("authorize");
-        let content = "x".repeat(MAX_TEXT_CHARS);
+        let content = "x".repeat(MAX_TEXT_BYTES);
 
         let (notes, report) = create_notes_atomic_with_report(
             &runtime,

--- a/crates/khive-runtime/src/atomic_prepare.rs
+++ b/crates/khive-runtime/src/atomic_prepare.rs
@@ -1578,7 +1578,7 @@ mod tests {
     use super::*;
 
     use async_trait::async_trait;
-    use lattice_embed::{EmbedError, EmbeddingModel, EmbeddingService, MAX_TEXT_CHARS};
+    use lattice_embed::{EmbedError, EmbeddingModel, EmbeddingService, MAX_TEXT_BYTES};
     use serde_json::json;
 
     use khive_types::Namespace;
@@ -1782,7 +1782,7 @@ mod tests {
             .expect("vec store");
         assert_eq!(vec_store.count().await.expect("count before"), 0);
 
-        let updated_content = format!("freshly-updated-content-xyz{}", "x".repeat(MAX_TEXT_CHARS));
+        let updated_content = format!("freshly-updated-content-xyz{}", "x".repeat(MAX_TEXT_BYTES));
         let plan = prepare_update(
             &runtime,
             &token,

--- a/crates/khive-runtime/src/embedder_registry.rs
+++ b/crates/khive-runtime/src/embedder_registry.rs
@@ -12,7 +12,7 @@ use std::sync::{Arc, OnceLock};
 use async_trait::async_trait;
 use lattice_embed::{
     CachedEmbeddingService, EmbeddingModel, EmbeddingService, NativeEmbeddingService,
-    DEFAULT_MAX_BATCH_SIZE, MAX_TEXT_CHARS,
+    DEFAULT_MAX_BATCH_SIZE, MAX_TEXT_BYTES,
 };
 use tokio::sync::OnceCell;
 
@@ -26,9 +26,9 @@ enum EmbeddingCall {
 }
 
 const EMBEDDING_QUEUE_CAPACITY: usize = 32;
-const EMBEDDING_MAX_JOB_BYTES: usize = DEFAULT_MAX_BATCH_SIZE * MAX_TEXT_CHARS;
+const EMBEDDING_MAX_JOB_BYTES: usize = DEFAULT_MAX_BATCH_SIZE * MAX_TEXT_BYTES;
 // 32 queue slots × the normal 128-text batch × 32 KiB/text = 128 MiB in flight.
-const EMBEDDING_QUEUE_BYTE_BUDGET: usize = EMBEDDING_QUEUE_CAPACITY * 128 * MAX_TEXT_CHARS;
+const EMBEDDING_QUEUE_BYTE_BUDGET: usize = EMBEDDING_QUEUE_CAPACITY * 128 * MAX_TEXT_BYTES;
 
 struct InFlightBytes {
     counter: Arc<AtomicUsize>,
@@ -132,10 +132,10 @@ impl<S: EmbeddingService + 'static> BlockingEmbeddingService<S> {
                 texts.len()
             )));
         }
-        if let Some(text) = texts.iter().find(|text| text.len() > MAX_TEXT_CHARS) {
+        if let Some(text) = texts.iter().find(|text| text.len() > MAX_TEXT_BYTES) {
             return Err(lattice_embed::EmbedError::TextTooLong {
                 length: text.len(),
-                max: MAX_TEXT_CHARS,
+                max: MAX_TEXT_BYTES,
             });
         }
         Ok(input_bytes)
@@ -795,7 +795,7 @@ mod tests {
     async fn blocking_adapter_rejects_oversized_job_before_enqueue() {
         let service = BlockingEmbeddingService::new(Arc::new(ConstVecService { dims: 1 }));
         let oversized =
-            "x".repeat(lattice_embed::DEFAULT_MAX_BATCH_SIZE * lattice_embed::MAX_TEXT_CHARS + 1);
+            "x".repeat(lattice_embed::DEFAULT_MAX_BATCH_SIZE * lattice_embed::MAX_TEXT_BYTES + 1);
 
         let error = service
             .embed(&[oversized], EmbeddingModel::default())
@@ -822,7 +822,7 @@ mod tests {
             byte_budget,
         ));
         let max_texts = Arc::new(vec![
-            "x".repeat(lattice_embed::MAX_TEXT_CHARS);
+            "x".repeat(lattice_embed::MAX_TEXT_BYTES);
             lattice_embed::DEFAULT_MAX_BATCH_SIZE
         ]);
         let mut admitted = Vec::with_capacity(ADMITTED_JOBS);

--- a/crates/khive-runtime/src/operations.rs
+++ b/crates/khive-runtime/src/operations.rs
@@ -5862,7 +5862,7 @@ mod tests {
     use crate::{ActorRef, Namespace};
     use async_trait::async_trait;
     use khive_storage::types::PathNode;
-    use lattice_embed::{EmbedError, EmbeddingModel, EmbeddingService, MAX_TEXT_CHARS};
+    use lattice_embed::{EmbedError, EmbeddingModel, EmbeddingService, MAX_TEXT_BYTES};
     use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
     use std::sync::Arc;
 
@@ -15644,10 +15644,10 @@ mod tests {
             _model: EmbeddingModel,
         ) -> std::result::Result<Vec<Vec<f32>>, EmbedError> {
             for text in texts {
-                if text.len() > MAX_TEXT_CHARS {
+                if text.len() > MAX_TEXT_BYTES {
                     return Err(EmbedError::TextTooLong {
                         length: text.len(),
-                        max: MAX_TEXT_CHARS,
+                        max: MAX_TEXT_BYTES,
                     });
                 }
             }
@@ -15699,7 +15699,7 @@ mod tests {
             captured: Arc::clone(&captured),
         });
 
-        let content = format!("{}\u{1f980}tail", "a".repeat(MAX_TEXT_CHARS - 1));
+        let content = format!("{}\u{1f980}tail", "a".repeat(MAX_TEXT_BYTES - 1));
         let note = rt
             .create_note(&tok, "observation", None, &content, None, None, vec![])
             .await
@@ -15715,7 +15715,7 @@ mod tests {
 
         let embedded = captured.lock().unwrap().clone();
         assert_eq!(embedded.len(), 1);
-        assert_eq!(embedded[0].len(), MAX_TEXT_CHARS - 1);
+        assert_eq!(embedded[0].len(), MAX_TEXT_BYTES - 1);
         assert!(embedded[0].is_char_boundary(embedded[0].len()));
         assert!(!embedded[0].contains('\u{1f980}'));
 
@@ -15732,13 +15732,13 @@ mod tests {
         rt.reindex_note(&tok, &fetched)
             .await
             .expect("reindex must bound the same stored content");
-        assert_eq!(captured.lock().unwrap()[0].len(), MAX_TEXT_CHARS - 1);
+        assert_eq!(captured.lock().unwrap()[0].len(), MAX_TEXT_BYTES - 1);
 
         captured.lock().unwrap().clear();
         rt.embed_document_batch_with_model("strict-length-test", std::slice::from_ref(&content))
             .await
             .expect("batch reindex seam must bound stored content");
-        assert_eq!(captured.lock().unwrap()[0].len(), MAX_TEXT_CHARS - 1);
+        assert_eq!(captured.lock().unwrap()[0].len(), MAX_TEXT_BYTES - 1);
 
         let normal = "normal byte-identical embedding input";
         rt.create_note(&tok, "observation", None, normal, None, None, vec![])
@@ -15746,7 +15746,7 @@ mod tests {
             .expect("normal note create must succeed");
         assert_eq!(captured.lock().unwrap().last().unwrap(), normal);
 
-        let long_description = format!("{}\u{1f980}tail", "b".repeat(MAX_TEXT_CHARS));
+        let long_description = format!("{}\u{1f980}tail", "b".repeat(MAX_TEXT_BYTES));
         rt.create_entity(
             &tok,
             "concept",

--- a/crates/khive-runtime/src/portability.rs
+++ b/crates/khive-runtime/src/portability.rs
@@ -348,7 +348,7 @@ mod tests {
     use crate::{EmbedderProvider, Namespace};
     use async_trait::async_trait;
     use khive_storage::EdgeRelation;
-    use lattice_embed::{EmbedError, EmbeddingModel, EmbeddingService, MAX_TEXT_CHARS};
+    use lattice_embed::{EmbedError, EmbeddingModel, EmbeddingService, MAX_TEXT_BYTES};
 
     const IMPORT_TEST_MODEL: &str = "all-minilm-l6-v2";
 
@@ -415,7 +415,7 @@ mod tests {
                 kind: "concept".to_string(),
                 entity_type: None,
                 name: "Imported long entity".to_string(),
-                description: Some("x".repeat(MAX_TEXT_CHARS + 1)),
+                description: Some("x".repeat(MAX_TEXT_BYTES + 1)),
                 properties: None,
                 tags: vec![],
                 created_at: Utc::now(),

--- a/crates/khive-runtime/src/retrieval.rs
+++ b/crates/khive-runtime/src/retrieval.rs
@@ -2,7 +2,7 @@
 
 use std::collections::{HashMap, HashSet};
 
-use lattice_embed::{EmbeddingModel, MAX_TEXT_CHARS};
+use lattice_embed::{EmbeddingModel, MAX_TEXT_BYTES};
 use uuid::Uuid;
 
 use crate::config::{parse_embedding_model_alias, sanitize_key};
@@ -130,8 +130,8 @@ impl EmbeddingTruncationReport {
 pub fn document_embedding_budget(model_name: &str) -> usize {
     parse_embedding_model_alias(model_name)
         .and_then(|model| model.document_instruction())
-        .map_or(MAX_TEXT_CHARS, |prefix| {
-            MAX_TEXT_CHARS.saturating_sub(prefix.len())
+        .map_or(MAX_TEXT_BYTES, |prefix| {
+            MAX_TEXT_BYTES.saturating_sub(prefix.len())
         })
 }
 
@@ -1397,13 +1397,13 @@ mod tests {
     fn bounded_embedding_input_reserves_prefix_and_preserves_utf8() {
         assert_eq!(
             document_embedding_budget("multilingual-e5-base"),
-            MAX_TEXT_CHARS - "passage: ".len()
+            MAX_TEXT_BYTES - "passage: ".len()
         );
 
-        let input = format!("{}\u{1f980}tail", "a".repeat(MAX_TEXT_CHARS - 1));
-        let (bounded, truncated) = bounded_embedding_input(&input, MAX_TEXT_CHARS);
+        let input = format!("{}\u{1f980}tail", "a".repeat(MAX_TEXT_BYTES - 1));
+        let (bounded, truncated) = bounded_embedding_input(&input, MAX_TEXT_BYTES);
         assert!(truncated);
-        assert_eq!(bounded.len(), MAX_TEXT_CHARS - 1);
+        assert_eq!(bounded.len(), MAX_TEXT_BYTES - 1);
         assert!(bounded.is_char_boundary(bounded.len()));
         assert!(!bounded.contains('\u{1f980}'));
     }
@@ -1411,7 +1411,7 @@ mod tests {
     #[test]
     fn bounded_embedding_input_leaves_normal_text_unchanged() {
         let input = "normal byte-identical embedding input";
-        let (bounded, truncated) = bounded_embedding_input(input, MAX_TEXT_CHARS);
+        let (bounded, truncated) = bounded_embedding_input(input, MAX_TEXT_BYTES);
         assert!(!truncated);
         assert_eq!(bounded, input);
         assert_eq!(bounded.as_ptr(), input.as_ptr());
@@ -2194,7 +2194,7 @@ mod tests {
         let (runtime, captured) = runtime_with_capturing_embedder(model);
         let texts = vec![
             "first normal document".to_string(),
-            "x".repeat(MAX_TEXT_CHARS + 1),
+            "x".repeat(MAX_TEXT_BYTES + 1),
             "second normal document".to_string(),
         ];
 
@@ -2206,14 +2206,14 @@ mod tests {
         assert!(!outcomes[0].truncated);
         assert_eq!(outcomes[0].source_bytes, outcomes[0].embedded_bytes);
         assert!(outcomes[1].truncated);
-        assert_eq!(outcomes[1].source_bytes, MAX_TEXT_CHARS + 1);
-        assert_eq!(outcomes[1].embedded_bytes, MAX_TEXT_CHARS);
+        assert_eq!(outcomes[1].source_bytes, MAX_TEXT_BYTES + 1);
+        assert_eq!(outcomes[1].embedded_bytes, MAX_TEXT_BYTES);
         assert!(!outcomes[2].truncated);
         assert_eq!(
             captured.lock().unwrap().as_slice(),
             [vec![
                 texts[0].clone(),
-                "x".repeat(MAX_TEXT_CHARS),
+                "x".repeat(MAX_TEXT_BYTES),
                 texts[2].clone(),
             ]]
         );
@@ -2224,7 +2224,7 @@ mod tests {
         let runtime = KhiveRuntime::memory().unwrap();
         runtime.register_embedder(WrongCardinalityEmbedderProvider);
         let model_name = "wrong-cardinality-embedding-service";
-        let texts = vec!["x".repeat(MAX_TEXT_CHARS + 1), "normal".to_string()];
+        let texts = vec!["x".repeat(MAX_TEXT_BYTES + 1), "normal".to_string()];
 
         let error = runtime
             .embed_document_batch_with_model_outcomes(model_name, &texts)

--- a/crates/kkernel/src/code_ingest.rs
+++ b/crates/kkernel/src/code_ingest.rs
@@ -523,7 +523,7 @@ mod tests {
 
     use async_trait::async_trait;
     use khive_runtime::{EmbedderProvider, RuntimeError};
-    use lattice_embed::{EmbedError, EmbeddingModel, EmbeddingService, MAX_TEXT_CHARS};
+    use lattice_embed::{EmbedError, EmbeddingModel, EmbeddingService, MAX_TEXT_BYTES};
     use serial_test::serial;
 
     use super::*;
@@ -1030,7 +1030,7 @@ mod tests {
         // Finding-note embeddings use the canonical `title: impact` content,
         // while evidence remains structured properties only.
         document["findings"][0]["impact"] =
-            serde_json::Value::String("x".repeat(MAX_TEXT_CHARS + 1));
+            serde_json::Value::String("x".repeat(MAX_TEXT_BYTES + 1));
         std::fs::write(
             &findings,
             serde_json::to_vec(&document).expect("serialize long findings fixture"),

--- a/crates/target
+++ b/crates/target
@@ -1,1 +1,0 @@
-/private/tmp/khive-071-target

--- a/crates/target
+++ b/crates/target
@@ -1,0 +1,1 @@
+/private/tmp/khive-071-target


### PR DESCRIPTION
Release 0.7.1: adopt the published lattice 0.7.0 crates.

## Changes

- Workspace version 0.7.0 → 0.7.1; `lattice-embed` and `lattice-fann`
  requirements bumped to `0.7.0` (published on crates.io; verified on the
  index per crate against the 0.6.1 pre-state). Lockfiles regenerated,
  including the excluded `khive-merge` workspace.
- MSRV comment updated: lattice 0.7 requires Rust 1.93, which was already
  the workspace floor.
- `MAX_TEXT_CHARS` → `MAX_TEXT_BYTES` across 10 files, following the
  lattice-embed 0.7.0 deprecation (same 32768 value; the constant counts
  UTF-8 bytes, which is what the byte-based production guard always
  enforced — behaviorally identical admission set).
- Removed a stray `crates/target` symlink that had been committed (a
  `target/` gitignore pattern matches directories only, not symlinks).

## Compatibility gate (run before the lattice release was published)

Against the lattice 0.7.0 release candidate, with the patch resolution
hard-asserted via `cargo metadata` (a `[patch.crates-io]` entry whose
version does not satisfy the requirement is silently ignored — the gate
aborts rather than green-lighting a registry build):

- Full workspace check + clippy clean.
- The lattice 0.7.0 chars→bytes text-limit change is invisible through
  khive: the sole production ingress guard was already byte-based, and
  chars ≤ bytes in UTF-8 means an identical admission set.

## Verification on this branch

- `make ci` green end to end (no-stub guards, lockfile freshness,
  forward-deployed crate checks, fmt, lints, full test suite, release
  build, contract tests: 127 passed).
- ADR-135 F4 hold-time release gate passed with ~10x margin:
  `comm.send` median 776µs / p95 993µs (bounds 8.5ms / 11ms),
  `comm.reply` median 891µs / p95 1.15ms (bounds 9.5ms / 12.5ms).
