### PR TITLE
build: keep symbol names in release binaries, strip only debuginfo

### DIFF
--- a/crates/Cargo.toml
+++ b/crates/Cargo.toml
@@ -124,7 +124,11 @@ object_store = { version = "=0.14.1", default-features = false, features = ["aws
 opt-level = 3
 lto = "thin"
 codegen-units = 1
-strip = "symbols"
+# Keep function symbol names so production profilers (sample/atos) can resolve
+# frames on release binaries; drop only the DWARF debug sections. With
+# strip = "symbols" a live-process sample yields anonymous offsets, which makes
+# post-hoc analysis of a stall or contention window impossible.
+strip = "debuginfo"
 
 # lattice 0.3.0 published — use crates.io directly. Restore [patch.crates-io]
 # block below to point at local lattice when iterating on lattice-side fixes.


### PR DESCRIPTION
## Summary

One-line release-profile change: `strip = "symbols"` → `strip = "debuginfo"`.

With `strip = "symbols"`, a live-process profiler (`sample`/`atos`) resolves release-binary frames only to anonymous offsets, so a stall or contention window captured in production cannot be analyzed after the fact. `strip = "debuginfo"` keeps the symbol table (function names) while still dropping the much larger DWARF sections, so release binaries stay small but profilable.

## Testing

Manifest-only change; CI builds validate the profile. Symbol presence in a release build is verifiable with `nm target/release/kkernel | wc -l` (thousands of named symbols vs ~300 undefined imports when stripped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)