### PR TITLE
fix(khive-db): run WAL checkpoints on a dedicated connection instead of the pool writer

### DIFF
--- a/crates/khive-db/docs/api/checkpoint.md
+++ b/crates/khive-db/docs/api/checkpoint.md
@@ -3,10 +3,12 @@
 The checkpoint task (`crates/khive-db/src/checkpoint.rs`) is a periodic
 background `tokio::spawn` that keeps the SQLite WAL file from growing
 unbounded and surfaces pressure/staleness signals to operators (ADR-091: WAL
-checkpoint pressure telemetry + TRUNCATE escalation + tx-age sweep). Public
-item contracts stay complete in their doc-comments; this file is the
-function-specific technical reference for the private helpers, metrics
-surface, and the test suite that pins down each guarantee.
+checkpoint pressure telemetry + TRUNCATE escalation + tx-age sweep;
+dedicated-checkpoint-connection amendment, 2026-08-02 — see the ADR's own
+amendment section for the full rationale). Public item contracts stay
+complete in their doc-comments; this file is the function-specific technical
+reference for the private helpers, metrics surface, and the test suite that
+pins down each guarantee.
 
 ## Module overview (ADR-091 Planks 0/1/2)
 
@@ -15,39 +17,60 @@ See `crates/khive-db/src/checkpoint.rs` module doc.
 The periodic task issues `PRAGMA wal_checkpoint(PASSIVE)` on every tick,
 including when the WAL page count exceeds the high-water mark. Ordinary
 ticks stay PASSIVE-only and non-blocking; a rare, separately-gated escalation
-may additionally run `PRAGMA wal_checkpoint(TRUNCATE)` under the same writer
-guard with a shortened busy timeout (Plank 2, below).
+may additionally run `PRAGMA wal_checkpoint(TRUNCATE)` on the same dedicated
+connection with a shortened busy timeout (Plank 2, below).
 
-**Non-contending design**: `checkpoint_once` uses `try_writer_nowait`
-(zero-wait `try_lock`) so a tick is skipped immediately when any writer holds
-the mutex, rather than blocking for up to `checkout_timeout`. The checkpoint
-task must never stall active write traffic — a skipped tick is always
-preferable.
+**Non-contending design (2026-08-02 amendment — supersedes the original
+`try_writer_nowait` design below).** The task opens its own dedicated,
+long-lived standalone connection (`CheckpointConnection`, opened once at
+task startup via `ConnectionPool::open_standalone_writer`) and runs PASSIVE
+(and, when armed, TRUNCATE) on it every tick — `checkpoint_once` never
+checks out the pool's writer mutex at all. `PRAGMA wal_checkpoint` takes
+SQLite's CKPT lock, not the WRITE lock, so a concurrent pool writer can
+commit while a checkpoint tick runs; serializing the two through one
+application-level mutex, as the original design did, imposed contention
+SQLite itself never required. Production evidence for the original design's
+cost: 22 caller-side `pool.writer()` admission timeouts on 2026-08-02 across
+the fleet, sustained bursts, against a persistent 64MiB WAL — a PASSIVE pass
+over a WAL that large ran long enough to starve every concurrent writer for
+the tick's duration. A tick is `Skipped` only when the dedicated connection
+itself is unavailable (never opened yet, e.g. an in-memory or read-only
+pool, or dropped after a prior tick's connection-level pragma failure, which
+`CheckpointConnection::ensure_open` lazily reopens on the next tick) — a busy
+pool writer no longer produces a Skipped tick at all; PASSIVE now runs
+unconditionally on every tick regardless of concurrent write traffic.
+
+_Original design (superseded above, kept for history):_ `checkpoint_once`
+used `try_writer_nowait` (zero-wait `try_lock`) so a tick was skipped
+immediately when any writer held the pool's writer mutex, rather than
+blocking for up to `checkout_timeout`.
 
 **Why TRUNCATE is excluded from every ordinary tick**: TRUNCATE inherits
 RESTART semantics — it waits for active readers to release their WAL
 snapshots and invokes the busy handler before acquiring the exclusive lock
-needed to reset the WAL file. With `PoolConfig`'s 30s `busy_timeout`, blindly
-running it every tick could sit inside SQLite holding the sole writer
-connection for up to 30s, stalling all normal write traffic. PASSIVE never
-waits for readers; it checkpoints as many frames as currently possible and
-returns promptly. When WAL pressure is sustained (`high_water_pages`
-exceeded), the task emits a WARNING; once WAL pressure reaches the much
-higher `truncate_high_water_pages` mark, the rare Plank 2 escalation may
+needed to reset the WAL file. Blindly running it every tick could sit inside
+SQLite holding the dedicated checkpoint connection for the length of its
+(shortened) `truncate_busy_timeout`. PASSIVE never waits for readers; it
+checkpoints as many frames as currently possible and returns promptly. When
+WAL pressure is sustained (`high_water_pages` exceeded), the task emits a
+WARNING; once WAL pressure reaches the much higher
+`truncate_high_water_pages` mark, the rare Plank 2 escalation may
 additionally attempt a bounded, rate-limited TRUNCATE under a deliberately
 shortened busy timeout — replacing what used to be a purely
-operator-scheduled manual step.
+operator-scheduled manual step. Because TRUNCATE also now runs on the
+dedicated connection rather than the pool writer, its bounded busy-wait cost
+falls on that connection alone, never on a concurrent `pool.writer()` caller.
 
 **Threshold-crossing WARN semantics**: both the `warn_pages` and
 `high_water_pages` warnings fire at most once per below→above crossing.
-Skipped ticks (writer busy) leave the crossing state unchanged so that a
-skip cannot spuriously re-arm the rate limit while WAL pressure is still
-elevated. The ADR-091 Plank 0 open-transaction-registry WARNs (oldest-entry
-escalation and the high-water snapshot enumeration) ride the SAME crossing
-gates — they are not independently rate-limited, so they never repeat on
-consecutive ticks that remain above a threshold. Only the per-tick `debug!`
-trace of the oldest open entry, and the Plank 1 age sweep, run
-unconditionally on every tick — including a Skipped one; the sweep's own
+Skipped ticks (dedicated connection unavailable) leave the crossing state
+unchanged so that a skip cannot spuriously re-arm the rate limit while WAL
+pressure is still elevated. The ADR-091 Plank 0 open-transaction-registry
+WARNs (oldest-entry escalation and the high-water snapshot enumeration) ride
+the SAME crossing gates — they are not independently rate-limited, so they
+never repeat on consecutive ticks that remain above a threshold. Only the
+per-tick `debug!` trace of the oldest open entry, and the Plank 1 age sweep,
+run unconditionally on every tick — including a Skipped one; the sweep's own
 emissions stay edge-triggered per rung via `TxAgeSweepState`.
 
 ### Plank 2: rare TRUNCATE escalation
@@ -58,19 +81,19 @@ wal_checkpoint(TRUNCATE)` once the WAL has grown past
 `truncate_high_water_pages` and at least `truncate_min_interval` has elapsed
 since the last TRUNCATE _attempt_ (not the last successful reclaim).
 
-This is a **single writer checkout per tick**: PASSIVE and any due TRUNCATE
-both run under the one guard `checkpoint_once` already holds — there is
-never a second concurrent checkout for TRUNCATE. If the writer mutex is
-busy, both PASSIVE and any due TRUNCATE are skipped for that tick, and
-`last_truncate_attempt` is left untouched so the next tick where the writer
-is free is immediately eligible rather than waiting out the full interval
-again. `last_truncate_attempt` only advances on a tick that actually
-attempted TRUNCATE (writer held, threshold crossed, interval elapsed) —
-never on a skip for any reason (writer busy, below threshold, interval not
-yet up).
+This runs on the **same dedicated connection** `checkpoint_once` already
+holds — there is never a second connection or a pool checkout for TRUNCATE.
+If the dedicated connection is unavailable, both PASSIVE and any due
+TRUNCATE are skipped for that tick, and `last_truncate_attempt` is left
+untouched so the next tick where the connection is available is immediately
+eligible rather than waiting out the full interval again.
+`last_truncate_attempt` only advances on a tick that actually attempted
+TRUNCATE (connection available, threshold crossed, interval elapsed) — never
+on a skip for any reason (connection unavailable, below threshold, interval
+not yet up).
 
 TRUNCATE runs under a temporarily shortened `busy_timeout`
-(`truncate_busy_timeout`), restored on the writer connection immediately
+(`truncate_busy_timeout`), restored on the dedicated connection immediately
 after the attempt, win or lose. No transaction is ever killed or aborted
 here — the tx_registry is only read for diagnostics; Plank 1 owns the
 registry's own bound.
@@ -88,9 +111,9 @@ delivered for writes by a later ADR.
 
 What ships here instead is the part of Plank 1 that still applies to every
 registered span regardless of which mechanism created it: on EVERY tick —
-Skipped as well as Observed, since a registered `WriterGuard::transaction`
-span holds the writer mutex for its whole lifetime and would otherwise make
-the busiest, most relevant tick invisible to this sweep — `TxAgeSweepState`
+Skipped as well as Observed, since the sweep must not go blind for the
+duration of a Skipped outage (dedicated connection unavailable) any more
+than for an ordinary busy tick — `TxAgeSweepState`
 checks `khive_storage::tx_registry::oldest()`'s age against
 `tx_warn_secs`/`tx_max_age_secs` and escalates to `warn!`/`error!` on each
 below→above crossing (same debounce idiom as the WAL-pressure ladder — a
@@ -172,12 +195,14 @@ below→above crossing (`warn_pages` / `high_water_pages` respectively, via
 
 See `crates/khive-db/src/checkpoint.rs` — private fn `maybe_truncate`.
 
-Runs under the writer guard the caller already holds — never performs its
-own checkout. No-ops unless BOTH `wal_pages >= truncate_high_water_pages`
-AND no prior attempt or `truncate_min_interval` has elapsed since the last
-one. `truncate_state.last_attempt` is stamped ONLY immediately before the
-TRUNCATE pragma itself runs (writer held, threshold crossed, interval
-elapsed, AND the temporary busy_timeout override successfully applied) —
+Runs on the same dedicated checkpoint connection the caller already holds —
+never performs its own checkout, and never touches the pool's writer mutex.
+No-ops unless BOTH `wal_pages >= truncate_high_water_pages` AND no prior
+attempt or `truncate_min_interval` has elapsed since the last one.
+`truncate_state.last_attempt` is stamped ONLY immediately before the
+TRUNCATE pragma itself runs (connection available, threshold crossed,
+interval elapsed, AND the temporary busy_timeout override successfully
+applied) —
 every earlier return is a skip, not an attempt, and never touches it,
 matching the ADR's "skip must not stamp" requirement. The oldest-pinning
 snapshot is logged (reusing Plank 0's `tx_registry`) before the attempt.
@@ -278,6 +303,50 @@ TRUNCATE regression blocks for ~2000ms — a 4x safety margin on both sides.
 An idle reader connection (no `BEGIN`) does NOT pin frames and would not
 cause TRUNCATE to wait — an actual open read transaction is required for
 the isomorphism to hold.
+
+### `checkpoint_once_proceeds_and_can_attempt_truncate_while_pool_writer_held` (dedicated-connection fix, 2026-08-02)
+
+The fix this module exists to prove, at the unit level: holding the POOL's
+writer mutex (`pool.try_writer()`) must NOT cause `checkpoint_once` to skip
+or block — PASSIVE (and, if armed, TRUNCATE) run on the task's own dedicated
+connection, which never contends with the pool writer at all. Before the
+fix, this exact setup made `checkpoint_once` return `Skipped` via
+`try_writer_nowait()`. Replaces the old `busy_writer_skips_both_passive_and_truncate`
+test, whose entire premise (a busy pool writer causes a skip) is no longer
+true.
+
+See `crates/khive-db/tests/checkpoint_dedicated_connection.rs` for the
+integration-level companion: a real `checkpoint_once` call against a
+genuinely fat (≥32MiB) WAL, run concurrently with a `pool.writer()`
+admission attempt, proving the converse direction — the writer is never
+blocked behind the checkpoint either.
+
+### `open_standalone_writer_fails_on_in_memory_pool`
+
+An in-memory pool has no on-disk file for `ConnectionPool::open_standalone_writer`
+to open a second connection against. This is exactly the precondition that
+makes `CheckpointConnection::ensure_open` return `None` and
+`run_checkpoint_task` report `Skipped` — `checkpoint_once` itself is never
+even called for an in-memory pool. Replaces the old
+`checkpoint_once_is_noop_on_in_memory_pool` test, which called
+`checkpoint_once` directly against an in-memory pool — no longer possible
+once `checkpoint_once` takes an already-open dedicated connection as an
+argument rather than acquiring one itself.
+
+### `checkpoint_task_sweeps_stale_entry_even_when_dedicated_connection_is_unavailable_every_tick`
+
+Renamed and re-mechanized from
+`checkpoint_task_sweeps_stale_entry_even_when_writer_is_busy_every_tick`:
+since the dedicated-connection fix, holding the pool's writer mutex no
+longer produces a Skipped tick at all, so the original mechanism (hold
+`pool.try_writer()` for the task's whole run) can no longer drive the
+Skipped path this regression exists to cover. Drives Skipped the way it
+actually happens now instead: a read-only pool, on which
+`ConnectionPool::open_standalone_writer` always fails, so
+`CheckpointConnection::ensure_open` can never open a dedicated connection.
+The underlying regression this test guards — the Plank 1 age sweep must
+still run and escalate on a Skipped tick, not just an Observed one — is
+unchanged; only the mechanism that produces the Skipped tick moved.
 
 ### `checkpoint_config_rejects_reversed_tx_thresholds`
 

--- a/crates/khive-db/docs/api/checkpoint.md
+++ b/crates/khive-db/docs/api/checkpoint.md
@@ -58,8 +58,15 @@ WARNING; once WAL pressure reaches the much higher
 additionally attempt a bounded, rate-limited TRUNCATE under a deliberately
 shortened busy timeout — replacing what used to be a purely
 operator-scheduled manual step. Because TRUNCATE also now runs on the
-dedicated connection rather than the pool writer, its bounded busy-wait cost
-falls on that connection alone, never on a concurrent `pool.writer()` caller.
+dedicated connection rather than the pool writer, a concurrent
+`pool.writer()` checkout is no longer queued behind it — that is an
+ADMISSION-only guarantee. At the SQLite level TRUNCATE still additionally
+acquires SQLite's writer lock (RESTART semantics plus TRUNCATE's own
+exclusive step) and blocks new write transactions on every connection, this
+process or any other, for up to `truncate_busy_timeout` while it waits on a
+pinning reader — that bounded blocking window is unchanged by this
+connection split; see the ADR-091 Amendment 5 dedicated-connection section
+for the full admission-vs-SQLite-lock distinction.
 
 **Threshold-crossing WARN semantics**: both the `warn_pages` and
 `high_water_pages` warnings fire at most once per below→above crossing.

--- a/crates/khive-db/src/checkpoint.rs
+++ b/crates/khive-db/src/checkpoint.rs
@@ -8,10 +8,15 @@
 //! the last attempt (Plank 2); both run on the task's own dedicated
 //! standalone connection (`CheckpointConnection`), opened once at task
 //! startup and reused for every tick — `checkpoint_once` never checks out the
-//! pool's writer mutex at all, so a concurrent pool writer can never be
-//! blocked behind (or block) a checkpoint tick. `PRAGMA wal_checkpoint`
-//! itself takes SQLite's CKPT lock, not the WRITE lock, so this reflects
-//! actual SQLite lock semantics rather than an application-level convenience.
+//! pool's writer mutex at all, so a concurrent `pool.writer()` checkout can
+//! never queue behind a checkpoint tick's ADMISSION. That guarantee is
+//! admission-only: PASSIVE takes SQLite's CKPT lock, not the WRITE lock, so
+//! it never blocks writers at the SQLite level either — but TRUNCATE
+//! additionally acquires SQLite's writer lock and can still block a
+//! concurrent write transaction, on any connection, for up to
+//! `truncate_busy_timeout` while it waits on a pinning reader, exactly as
+//! before this connection split.
+//!
 //! If the dedicated connection is unavailable (never opened yet, or dropped
 //! after a prior tick's connection-level pragma failure), the tick reports
 //! `CheckpointTick::Skipped` and the next tick lazily reopens it — this is
@@ -1364,10 +1369,21 @@ impl Drop for CheckpointLifecycleEmitter {
 /// The checkpoint task's dedicated, long-lived standalone connection to the
 /// same database file — opened once at task startup and reused for every
 /// tick's PASSIVE (and, when armed, TRUNCATE) pragma. NEVER the pool's writer
-/// mutex: `PRAGMA wal_checkpoint` takes SQLite's CKPT lock, not the WRITE
-/// lock, so a concurrent pool writer can commit while a checkpoint runs on
-/// this connection — serializing the two through an application-level mutex
-/// (the pre-fix design) imposed contention SQLite itself does not require.
+/// mutex, which is what removes the pool-mutex ADMISSION path: a concurrent
+/// `pool.writer()` checkout no longer queues behind a checkpoint tick.
+///
+/// That removal is scoped to admission, not to SQLite-level blocking in
+/// general. `PRAGMA wal_checkpoint(PASSIVE)` takes only SQLite's CKPT lock,
+/// not the WRITE lock, so a concurrent writer can commit while a PASSIVE pass
+/// runs on this connection — true of PASSIVE specifically, not of TRUNCATE.
+/// TRUNCATE inherits RESTART semantics and additionally acquires SQLite's
+/// writer lock, so it can still block a concurrent write transaction, on any
+/// connection, for up to `truncate_busy_timeout` while it waits on a pinning
+/// reader — the same bounded cost that existed pre-fix, now paid on this
+/// dedicated connection instead of the pool writer. Serializing checkpoint
+/// admission behind the pool's writer mutex (the pre-fix design) imposed
+/// contention SQLite itself does not require; TRUNCATE's own SQLite-level
+/// write-blocking window is unaffected by that removal.
 ///
 /// `None` between ticks means the connection is unavailable (never opened
 /// yet, or dropped after a prior tick's connection-level pragma failure) —
@@ -1375,11 +1391,22 @@ impl Drop for CheckpointLifecycleEmitter {
 /// one. This is now the ONLY source of a `Skipped` tick.
 struct CheckpointConnection {
     conn: Option<rusqlite::Connection>,
+    /// Consecutive failed `open_standalone_writer` attempts since the last
+    /// successful open (or since task startup). Drives the WARN-once /
+    /// debug-thereafter log rate-limiting in `ensure_open`: a file-backed
+    /// pool that transiently loses its dedicated connection would otherwise
+    /// log a WARN on every tick (default 500ms) for as long as the outage
+    /// lasts, which for a read-only or in-memory pool — where the open can
+    /// never succeed — means permanent per-tick WARN spam.
+    consecutive_open_failures: u32,
 }
 
 impl CheckpointConnection {
     fn new() -> Self {
-        Self { conn: None }
+        Self {
+            conn: None,
+            consecutive_open_failures: 0,
+        }
     }
 
     /// Ensure a usable connection is open, lazily (re)opening from `pool`
@@ -1388,20 +1415,45 @@ impl CheckpointConnection {
     /// which applies the same pragmas (including `busy_timeout` from the pool
     /// config) as any other standalone connection. Returns `None` if opening
     /// fails — an in-memory pool (no on-disk file to open a second connection
-    /// against), a read-only pool, or a transient filesystem error — logging
-    /// once per failed attempt rather than every tick would require extra
-    /// state for no operational benefit at this cadence, so this logs each
-    /// time.
+    /// against), a read-only pool, or a transient filesystem error.
+    ///
+    /// Logging is rate-limited across a failure streak: the FIRST failure of
+    /// a streak logs at `warn!`, every subsequent identical failure (while
+    /// still failing) logs at `debug!` instead, and a successful open that
+    /// ends a streak logs one `info!` recovery line. Without this, a
+    /// permanently-unopenable pool (read-only or in-memory, selected by
+    /// `checkpoint_pool_for`) would WARN on every tick forever.
     fn ensure_open(&mut self, pool: &ConnectionPool) -> Option<&rusqlite::Connection> {
         if self.conn.is_none() {
             match pool.open_standalone_writer() {
-                Ok(conn) => self.conn = Some(conn),
+                Ok(conn) => {
+                    if self.consecutive_open_failures > 0 {
+                        tracing::info!(
+                            prior_consecutive_failures = self.consecutive_open_failures,
+                            "dedicated checkpoint connection opened successfully, ending a \
+                             failure streak"
+                        );
+                    }
+                    self.consecutive_open_failures = 0;
+                    self.conn = Some(conn);
+                }
                 Err(e) => {
-                    tracing::warn!(
-                        error = %e,
-                        "failed to open the dedicated checkpoint connection; \
-                         this tick is skipped and the open retried next tick"
-                    );
+                    if self.consecutive_open_failures == 0 {
+                        tracing::warn!(
+                            error = %e,
+                            "failed to open the dedicated checkpoint connection; \
+                             this tick is skipped and the open retried next tick"
+                        );
+                    } else {
+                        tracing::debug!(
+                            error = %e,
+                            consecutive_failures = self.consecutive_open_failures,
+                            "dedicated checkpoint connection still unavailable; \
+                             this tick is skipped and the open retried next tick"
+                        );
+                    }
+                    self.consecutive_open_failures =
+                        self.consecutive_open_failures.saturating_add(1);
                     return None;
                 }
             }

--- a/crates/khive-db/src/checkpoint.rs
+++ b/crates/khive-db/src/checkpoint.rs
@@ -63,7 +63,7 @@ static TRUNCATE_ATTEMPTS: AtomicU64 = AtomicU64::new(0);
 static TRUNCATE_CONSECUTIVE_FAILURES: AtomicU64 = AtomicU64::new(0);
 
 /// Count of checkpoint ticks skipped because the task's dedicated
-/// [`CheckpointConnection`] was unavailable that tick (never opened yet, or
+/// `CheckpointConnection` was unavailable that tick (never opened yet, or
 /// dropped after a prior connection-level pragma failure — ADR-091
 /// checkpoint-pressure telemetry), across this process's lifetime. Never
 /// reset outside `#[cfg(test)]`.
@@ -151,7 +151,7 @@ pub(crate) fn reset_checkpoint_metrics_for_tests() {
 
 /// Outcome of a single checkpoint attempt.
 ///
-/// `Skipped` is returned when the task's dedicated [`CheckpointConnection`]
+/// `Skipped` is returned when the task's dedicated `CheckpointConnection`
 /// is unavailable that tick (the tick is a no-op) — never because a
 /// concurrent pool writer was busy; a checkpoint tick no longer checks out
 /// the pool's writer mutex at all. `Observed` carries the WAL page count read
@@ -1479,11 +1479,11 @@ impl CheckpointConnection {
 /// makes that check unreachable (issue #774).
 ///
 /// Issues `PRAGMA wal_checkpoint(PASSIVE)` every tick on the task's dedicated
-/// [`CheckpointConnection`] — never the pool's writer mutex, so a concurrent
+/// `CheckpointConnection` — never the pool's writer mutex, so a concurrent
 /// `pool.writer()` checkout can never queue behind a checkpoint tick. That
 /// guarantee is admission-only: an armed TRUNCATE still takes SQLite's writer
 /// lock and can block new write transactions, on any connection, for up to
-/// `truncate_busy_timeout` (see [`CheckpointConnection`]'s contract). A tick is
+/// `truncate_busy_timeout` (see `CheckpointConnection`'s contract). A tick is
 /// `Skipped` only when that dedicated connection is itself unavailable. A
 /// WARNING fires once per below→above threshold crossing, not every tick.
 ///
@@ -1773,7 +1773,7 @@ fn log_tx_registry_snapshot_warn(wal_pages: u64) {
 }
 
 /// Issue one checkpoint cycle against the task's dedicated checkpoint
-/// connection (`conn` — see [`CheckpointConnection`]; NEVER the pool's writer
+/// connection (`conn` — see `CheckpointConnection`; NEVER the pool's writer
 /// mutex).
 ///
 /// Returns the observed WAL page count on success. Returns `Err` only for a

--- a/crates/khive-db/src/checkpoint.rs
+++ b/crates/khive-db/src/checkpoint.rs
@@ -1,14 +1,22 @@
-//! Periodic WAL checkpoint task for the connection pool (ADR-091).
+//! Periodic WAL checkpoint task for the connection pool (ADR-091; dedicated
+//! checkpoint connection amendment, see below).
 //!
 //! Issues `PRAGMA wal_checkpoint(PASSIVE)` on every tick — non-blocking, never
 //! waits for readers. A rare, separately-gated escalation may additionally run
 //! `PRAGMA wal_checkpoint(TRUNCATE)` once WAL pressure crosses
 //! `truncate_high_water_pages` and `truncate_min_interval` has elapsed since
-//! the last attempt (Plank 2); both run under the single writer checkout
-//! `checkpoint_once` holds for that tick. `checkpoint_once` uses
-//! `try_writer_nowait` (zero-wait `try_lock`) so a tick is skipped immediately
-//! when the writer mutex is held, rather than blocking — a skipped tick is
-//! always preferable to stalling write traffic.
+//! the last attempt (Plank 2); both run on the task's own dedicated
+//! standalone connection (`CheckpointConnection`), opened once at task
+//! startup and reused for every tick — `checkpoint_once` never checks out the
+//! pool's writer mutex at all, so a concurrent pool writer can never be
+//! blocked behind (or block) a checkpoint tick. `PRAGMA wal_checkpoint`
+//! itself takes SQLite's CKPT lock, not the WRITE lock, so this reflects
+//! actual SQLite lock semantics rather than an application-level convenience.
+//! If the dedicated connection is unavailable (never opened yet, or dropped
+//! after a prior tick's connection-level pragma failure), the tick reports
+//! `CheckpointTick::Skipped` and the next tick lazily reopens it — this is
+//! now the ONLY source of a Skipped tick; a busy pool writer no longer causes
+//! one.
 //!
 //! `warn_pages` / `high_water_pages` WARNs fire at most once per below→above
 //! crossing; a skipped tick leaves crossing state unchanged. An age-based
@@ -20,7 +28,7 @@
 //!
 //! See crates/khive-db/docs/api/checkpoint.md#module-overview-adr-091-planks-012
 //! for full ADR-091 Plank 0/1/2 design rationale (why TRUNCATE is excluded
-//! from ordinary ticks, the single-writer-checkout invariant, and why Plank 1
+//! from ordinary ticks, the dedicated-connection invariant, and why Plank 1
 //! is a sweep rather than the ADR's originally-described per-statement guard).
 
 use std::path::{Path, PathBuf};
@@ -28,7 +36,7 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
-use crate::pool::{ConnectionPool, WriterGuard};
+use crate::pool::ConnectionPool;
 
 // ── metrics read-surface (load/perf harness) ─────────────────────────────
 // Read-only process-wide gauges (never reset outside #[cfg(test)]). See
@@ -49,14 +57,17 @@ static TRUNCATE_ATTEMPTS: AtomicU64 = AtomicU64::new(0);
 /// gauge every time `note_truncate_outcome` runs.
 static TRUNCATE_CONSECUTIVE_FAILURES: AtomicU64 = AtomicU64::new(0);
 
-/// Count of checkpoint ticks skipped because the writer mutex was already
-/// held (ADR-091 checkpoint-pressure telemetry), across this process's
-/// lifetime. Never reset outside `#[cfg(test)]`.
+/// Count of checkpoint ticks skipped because the task's dedicated
+/// [`CheckpointConnection`] was unavailable that tick (never opened yet, or
+/// dropped after a prior connection-level pragma failure — ADR-091
+/// checkpoint-pressure telemetry), across this process's lifetime. Never
+/// reset outside `#[cfg(test)]`.
 static CHECKPOINT_SKIPPED_TICKS: AtomicU64 = AtomicU64::new(0);
 
 /// Current run-length of consecutive skipped ticks. Reset to 0 the next time
-/// a tick is actually observed (writer free), so a sustained skip streak is
-/// visible even between two successful observations.
+/// a tick is actually observed (dedicated connection available), so a
+/// sustained skip streak is visible even between two successful
+/// observations.
 static CHECKPOINT_CONSECUTIVE_SKIPS: AtomicU64 = AtomicU64::new(0);
 
 /// WAL page count as of the most recent *observed* tick, snapshotted at the
@@ -83,7 +94,8 @@ pub fn truncate_consecutive_failures() -> u64 {
     TRUNCATE_CONSECUTIVE_FAILURES.load(Ordering::Relaxed)
 }
 
-/// Total checkpoint ticks skipped (writer busy) in this process's lifetime.
+/// Total checkpoint ticks skipped (dedicated connection unavailable) in this
+/// process's lifetime.
 pub fn checkpoint_skipped_ticks() -> u64 {
     CHECKPOINT_SKIPPED_TICKS.load(Ordering::Relaxed)
 }
@@ -102,9 +114,10 @@ pub fn checkpoint_last_skip_wal_pages() -> Option<u64> {
     }
 }
 
-/// A tick's writer checkout was skipped (mutex busy): bump the lifetime and
-/// consecutive-skip counters and snapshot the last-known WAL pressure so an
-/// operator can see how bad the WAL was heading into the skip streak.
+/// A tick's dedicated checkpoint connection was unavailable: bump the
+/// lifetime and consecutive-skip counters and snapshot the last-known WAL
+/// pressure so an operator can see how bad the WAL was heading into the skip
+/// streak.
 fn note_checkpoint_skipped() {
     CHECKPOINT_SKIPPED_TICKS.fetch_add(1, Ordering::Relaxed);
     CHECKPOINT_CONSECUTIVE_SKIPS.fetch_add(1, Ordering::Relaxed);
@@ -133,14 +146,18 @@ pub(crate) fn reset_checkpoint_metrics_for_tests() {
 
 /// Outcome of a single checkpoint attempt.
 ///
-/// `Skipped` is returned when the writer mutex is already held (the tick is a
-/// no-op). `Observed` carries the WAL page count read during the tick. The
-/// distinction matters for threshold-crossing WARN rate-limiting: a skipped tick
-/// must leave the above/below state unchanged so that a busy tick cannot
-/// spuriously re-arm the rate limit while WAL pressure is still elevated.
+/// `Skipped` is returned when the task's dedicated [`CheckpointConnection`]
+/// is unavailable that tick (the tick is a no-op) — never because a
+/// concurrent pool writer was busy; a checkpoint tick no longer checks out
+/// the pool's writer mutex at all. `Observed` carries the WAL page count read
+/// during the tick. The distinction matters for threshold-crossing WARN
+/// rate-limiting: a skipped tick must leave the above/below state unchanged
+/// so that it cannot spuriously re-arm the rate limit while WAL pressure is
+/// still elevated.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum CheckpointTick {
-    /// The writer mutex was busy; no checkpoint was issued this tick.
+    /// The dedicated checkpoint connection was unavailable; no checkpoint
+    /// was issued this tick.
     Skipped,
     /// A checkpoint was issued; the value is the observed WAL page count.
     Observed(u64),
@@ -202,10 +219,11 @@ pub struct CheckpointConfig {
 
     /// Minimum spacing between TRUNCATE *attempts* (not successes).
     ///
-    /// A skipped tick (writer busy, below threshold, or interval not yet
-    /// elapsed) never advances the "last attempt" clock, so the next tick
-    /// where the writer is free and the threshold is still crossed is
-    /// immediately eligible rather than waiting out the full interval again.
+    /// A skipped tick (dedicated connection unavailable, below threshold, or
+    /// interval not yet elapsed) never advances the "last attempt" clock, so
+    /// the next tick where the connection is available and the threshold is
+    /// still crossed is immediately eligible rather than waiting out the
+    /// full interval again.
     ///
     /// Overridable via `KHIVE_WAL_TRUNCATE_MIN_INTERVAL_SECS`.
     /// Default: 300 seconds (5 minutes).
@@ -1343,6 +1361,62 @@ impl Drop for CheckpointLifecycleEmitter {
     }
 }
 
+/// The checkpoint task's dedicated, long-lived standalone connection to the
+/// same database file — opened once at task startup and reused for every
+/// tick's PASSIVE (and, when armed, TRUNCATE) pragma. NEVER the pool's writer
+/// mutex: `PRAGMA wal_checkpoint` takes SQLite's CKPT lock, not the WRITE
+/// lock, so a concurrent pool writer can commit while a checkpoint runs on
+/// this connection — serializing the two through an application-level mutex
+/// (the pre-fix design) imposed contention SQLite itself does not require.
+///
+/// `None` between ticks means the connection is unavailable (never opened
+/// yet, or dropped after a prior tick's connection-level pragma failure) —
+/// the caller must report that tick `Skipped` and retry the open on the next
+/// one. This is now the ONLY source of a `Skipped` tick.
+struct CheckpointConnection {
+    conn: Option<rusqlite::Connection>,
+}
+
+impl CheckpointConnection {
+    fn new() -> Self {
+        Self { conn: None }
+    }
+
+    /// Ensure a usable connection is open, lazily (re)opening from `pool`
+    /// when the current one is absent. Reuses the crate's existing
+    /// standalone-connection open path (`ConnectionPool::open_standalone_writer`),
+    /// which applies the same pragmas (including `busy_timeout` from the pool
+    /// config) as any other standalone connection. Returns `None` if opening
+    /// fails — an in-memory pool (no on-disk file to open a second connection
+    /// against), a read-only pool, or a transient filesystem error — logging
+    /// once per failed attempt rather than every tick would require extra
+    /// state for no operational benefit at this cadence, so this logs each
+    /// time.
+    fn ensure_open(&mut self, pool: &ConnectionPool) -> Option<&rusqlite::Connection> {
+        if self.conn.is_none() {
+            match pool.open_standalone_writer() {
+                Ok(conn) => self.conn = Some(conn),
+                Err(e) => {
+                    tracing::warn!(
+                        error = %e,
+                        "failed to open the dedicated checkpoint connection; \
+                         this tick is skipped and the open retried next tick"
+                    );
+                    return None;
+                }
+            }
+        }
+        self.conn.as_ref()
+    }
+
+    /// Drop the current connection after a connection-level pragma failure so
+    /// the next tick's `ensure_open` reopens it fresh rather than repeatedly
+    /// retrying a connection already known to be broken.
+    fn drop_connection(&mut self) {
+        self.conn = None;
+    }
+}
+
 /// Run the WAL checkpoint background task.
 ///
 /// Long-running async task — spawn with `tokio::spawn`. Loops until
@@ -1352,10 +1426,11 @@ impl Drop for CheckpointLifecycleEmitter {
 /// reaching zero; a sibling owner (e.g. `event_store`) holding its own clone
 /// makes that check unreachable (issue #774).
 ///
-/// Issues `PRAGMA wal_checkpoint(PASSIVE)` every tick via `try_writer_nowait`
-/// (zero-wait try-lock): a busy writer skips the tick rather than stalling
-/// write traffic. A WARNING fires once per below→above threshold crossing,
-/// not every tick.
+/// Issues `PRAGMA wal_checkpoint(PASSIVE)` every tick on the task's dedicated
+/// [`CheckpointConnection`] — never the pool's writer mutex, so a concurrent
+/// writer cannot block (or be blocked by) a checkpoint tick. A tick is
+/// `Skipped` only when that dedicated connection is itself unavailable. A
+/// WARNING fires once per below→above threshold crossing, not every tick.
 ///
 /// `lifecycle_owner` (ADR-094): exactly one task in a multi-backend fan-out
 /// should receive `Some`. That task appends a best-effort
@@ -1424,6 +1499,12 @@ pub async fn run_checkpoint_task(
         sidecar.register_beacon().await;
     }
 
+    // Opened once here, at task startup; `ensure_open` is a no-op in steady
+    // state and only reopens after a connection-level failure or (for an
+    // in-memory/read-only pool) retries the open on every subsequent tick.
+    let mut checkpoint_conn = CheckpointConnection::new();
+    checkpoint_conn.ensure_open(&pool);
+
     loop {
         // A closed sender (the daemon returning without an explicit send)
         // makes `changed()` resolve with `Err` immediately, which `select!`
@@ -1434,21 +1515,38 @@ pub async fn run_checkpoint_task(
             _ = shutdown_rx.changed() => break,
         }
 
-        let tick = checkpoint_once(&pool, &config, &mut truncate_state);
+        let tick = match checkpoint_conn.ensure_open(&pool) {
+            None => {
+                note_checkpoint_skipped();
+                CheckpointTick::Skipped
+            }
+            Some(conn) => match checkpoint_once(&pool, conn, &config, &mut truncate_state) {
+                Ok(wal_pages) => CheckpointTick::Observed(wal_pages),
+                Err(e) => {
+                    tracing::warn!(
+                        error = %e,
+                        "dedicated checkpoint connection failed a pragma; \
+                         dropping it for a fresh reopen next tick"
+                    );
+                    checkpoint_conn.drop_connection();
+                    note_checkpoint_skipped();
+                    CheckpointTick::Skipped
+                }
+            },
+        };
 
         // ADR-091 Plank 1: age-based sweep over the registry's oldest entry
         // MUST run on every tick, including a Skipped one — deliberately
-        // BEFORE the Skipped early-continue below. A registered
-        // `WriterGuard::transaction` span (`pool.rs`) holds the writer mutex
-        // for its entire registered lifetime, so exactly the long-running
-        // transaction this sweep exists to name is the one that makes an
-        // ordinary checkpoint tick observe `Skipped` — gating the sweep on
-        // `Observed` would silence it for precisely that scenario, defeating
-        // the WAL-independent diagnostic the ADR specifies. Independent of
-        // WAL page pressure by the same design: a registered span can go
-        // stale (KHIVE_TX_WARN_SECS / KHIVE_TX_MAX_AGE_SECS) while
-        // wal_pages sits well under warn_pages, or isn't sampled at all this
-        // tick. Edge-triggered per rung, same debounce idiom as the severity
+        // BEFORE the Skipped early-continue below. Since the dedicated
+        // checkpoint connection amendment, a `Skipped` tick means that
+        // connection was itself unavailable, not that some registered span
+        // was holding the pool's writer mutex (a checkpoint tick no longer
+        // touches it at all) — but the sweep still must not go blind for the
+        // duration of that outage, and the two failure surfaces are
+        // independent: a registry span can go stale
+        // (KHIVE_TX_WARN_SECS / KHIVE_TX_MAX_AGE_SECS) while wal_pages sits
+        // well under warn_pages, or while the checkpoint connection itself is
+        // down. Edge-triggered per rung, same debounce idiom as the severity
         // ladder below, so a sustained stale span logs once per rung rather
         // than once per tick.
         let oldest_tx = tx_filter
@@ -1619,58 +1717,50 @@ fn log_tx_registry_snapshot_warn(wal_pages: u64) {
     }
 }
 
-/// Issue one checkpoint cycle against the writer connection.
+/// Issue one checkpoint cycle against the task's dedicated checkpoint
+/// connection (`conn` — see [`CheckpointConnection`]; NEVER the pool's writer
+/// mutex).
 ///
-/// Returns [`CheckpointTick::Skipped`] when the writer mutex is already held
-/// (the tick is a no-op) and [`CheckpointTick::Observed`] with the WAL page
-/// count otherwise. All checkpoint errors are logged at warn level and treated
-/// as non-fatal; the next tick retries.
+/// Returns the observed WAL page count on success. Returns `Err` only for a
+/// connection-level pragma failure (the PASSIVE pragma itself erroring) — the
+/// caller (`run_checkpoint_task`) treats that as a signal to drop `conn` and
+/// lazily reopen a fresh one next tick, reporting the tick `Skipped`. Every
+/// other error (e.g. a TRUNCATE attempt failing) is logged at warn level and
+/// treated as non-fatal; the next tick retries against the same connection.
 ///
-/// Uses `try_writer_nowait` so that a busy active writer causes this tick to
-/// be skipped immediately rather than stalling for up to `checkout_timeout`.
-/// The caller (`run_checkpoint_task`) owns all threshold-crossing WARN logging
-/// so that warnings fire at most once per crossing, not every tick.
+/// The caller owns all threshold-crossing WARN logging so that warnings fire
+/// at most once per crossing, not every tick.
 ///
 /// ADR-091 Plank 2: after the PASSIVE pass, this is also the single point
-/// that may escalate to TRUNCATE (`maybe_truncate`) — under the SAME writer
-/// guard acquired above, never a second checkout. A busy writer (`Skipped`)
-/// short-circuits before either PASSIVE or TRUNCATE run.
+/// that may escalate to TRUNCATE (`maybe_truncate`) — on the SAME dedicated
+/// connection, never a second connection or a pool checkout.
 pub fn checkpoint_once(
     pool: &ConnectionPool,
+    conn: &rusqlite::Connection,
     config: &CheckpointConfig,
     truncate_state: &mut TruncateState,
-) -> CheckpointTick {
-    let writer = match pool.try_writer_nowait() {
-        Ok(w) => w,
-        Err(_) => {
-            note_checkpoint_skipped();
-            return CheckpointTick::Skipped;
-        }
-    };
+) -> Result<u64, rusqlite::Error> {
+    let wal_pages = query_wal_pages(conn);
 
-    let wal_pages = query_wal_pages(writer.conn());
-
-    if let Err(e) = writer
-        .conn()
-        .execute_batch("PRAGMA wal_checkpoint(PASSIVE)")
-    {
+    if let Err(e) = conn.execute_batch("PRAGMA wal_checkpoint(PASSIVE)") {
         tracing::warn!(error = %e, "WAL checkpoint failed");
-    } else {
-        tracing::debug!(wal_pages, "WAL checkpoint issued");
+        return Err(e);
     }
+    tracing::debug!(wal_pages, "WAL checkpoint issued");
 
-    maybe_truncate(pool, &writer, config, wal_pages, truncate_state);
+    maybe_truncate(pool, conn, config, wal_pages, truncate_state);
 
-    CheckpointTick::Observed(wal_pages)
+    Ok(wal_pages)
 }
 
-/// Evaluate and, if due, attempt a TRUNCATE escalation under the writer
-/// guard the caller already holds (never its own checkout). `last_attempt`
+/// Evaluate and, if due, attempt a TRUNCATE escalation on the same dedicated
+/// checkpoint connection the caller already holds (never its own checkout —
+/// there is no pool writer involved on this path at all). `last_attempt`
 /// is stamped ONLY on an actual attempt, never on a skip. See
 /// crates/khive-db/docs/api/checkpoint.md#maybe_truncate--truncate-attempt-gating-plank-2
 fn maybe_truncate(
     pool: &ConnectionPool,
-    writer: &WriterGuard<'_>,
+    conn: &rusqlite::Connection,
     config: &CheckpointConfig,
     wal_pages_before: u64,
     truncate_state: &mut TruncateState,
@@ -1689,7 +1779,6 @@ fn maybe_truncate(
     // it is available even if the attempt itself succeeds.
     log_tx_registry_snapshot_warn(wal_pages_before);
 
-    let conn = writer.conn();
     let original_busy_timeout = pool.config().busy_timeout;
 
     if let Err(e) = conn.busy_timeout(config.truncate_busy_timeout) {
@@ -2322,6 +2411,14 @@ mod tests {
         Arc::new(ConnectionPool::new(cfg).expect("pool open"))
     }
 
+    /// Test helper: open the same dedicated standalone connection
+    /// `run_checkpoint_task` opens in production, for tests that drive
+    /// `checkpoint_once` directly.
+    fn checkpoint_conn(pool: &ConnectionPool) -> rusqlite::Connection {
+        pool.open_standalone_writer()
+            .expect("open dedicated checkpoint connection")
+    }
+
     struct TruncateReportHookGuard;
 
     impl Drop for TruncateReportHookGuard {
@@ -2453,6 +2550,7 @@ mod tests {
         let buffer = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
         let thread_buffer = std::sync::Arc::clone(&buffer);
         let checkpoint_pool = Arc::clone(&pool);
+        let dedicated_conn = checkpoint_conn(&checkpoint_pool);
         let checkpoint = std::thread::spawn(move || {
             let subscriber = CaptureSubscriber {
                 events: thread_buffer,
@@ -2460,6 +2558,7 @@ mod tests {
             tracing::subscriber::with_default(subscriber, || {
                 checkpoint_once(
                     &checkpoint_pool,
+                    &dedicated_conn,
                     &CheckpointConfig {
                         truncate_high_water_pages: 0,
                         truncate_min_interval: Duration::ZERO,
@@ -2484,7 +2583,7 @@ mod tests {
         proceed_tx
             .send(())
             .expect("allow no-progress reporting to continue");
-        checkpoint.join().expect("checkpoint thread");
+        let _ = checkpoint.join().expect("checkpoint thread");
 
         let events = buffer.lock().expect("captured events");
         assert!(
@@ -2523,26 +2622,31 @@ mod tests {
                 .unwrap();
         }
 
+        let conn = checkpoint_conn(&pool);
         checkpoint_once(
             &pool,
+            &conn,
             &CheckpointConfig::default(),
             &mut TruncateState::default(),
-        );
+        )
+        .expect("checkpoint_once must succeed against a healthy dedicated connection");
     }
 
+    /// In-memory pools have no on-disk file to open a second, dedicated
+    /// standalone connection against — this is exactly the precondition that
+    /// makes `CheckpointConnection::ensure_open` return `None` and
+    /// `run_checkpoint_task` report the tick `Skipped`, so `checkpoint_once`
+    /// is never even called for one.
     #[test]
-    #[serial(checkpoint_skip_metrics)]
-    fn checkpoint_once_is_noop_on_in_memory_pool() {
-        // In-memory databases do not use WAL; checkpoint_once must not panic.
+    fn open_standalone_writer_fails_on_in_memory_pool() {
         let cfg = PoolConfig {
             path: None,
             ..PoolConfig::default()
         };
         let pool = Arc::new(ConnectionPool::new(cfg).expect("in-memory pool"));
-        checkpoint_once(
-            &pool,
-            &CheckpointConfig::default(),
-            &mut TruncateState::default(),
+        assert!(
+            pool.open_standalone_writer().is_err(),
+            "an in-memory pool must not be able to open a dedicated checkpoint connection"
         );
     }
 
@@ -2749,12 +2853,15 @@ mod tests {
                 .unwrap();
         }
 
+        let conn = checkpoint_conn(&pool);
         let start = std::time::Instant::now();
         checkpoint_once(
             &pool,
+            &conn,
             &CheckpointConfig::default(),
             &mut TruncateState::default(),
-        );
+        )
+        .expect("checkpoint_once must succeed against a healthy dedicated connection");
         let elapsed = start.elapsed();
 
         // Commit and release the read snapshot only after checkpoint_once returns.
@@ -2992,8 +3099,9 @@ mod tests {
             "precondition: no attempt has run yet"
         );
 
-        let tick = checkpoint_once(&pool, &config, &mut state);
-        assert!(matches!(tick, CheckpointTick::Observed(_)));
+        let conn = checkpoint_conn(&pool);
+        checkpoint_once(&pool, &conn, &config, &mut state)
+            .expect("checkpoint_once must succeed against a healthy dedicated connection");
         assert!(
             state.last_attempt.is_some(),
             "an attempt must be stamped once the high-water threshold is crossed"
@@ -3026,7 +3134,9 @@ mod tests {
         };
         let mut state = TruncateState::default();
 
-        checkpoint_once(&pool, &config, &mut state);
+        let conn = checkpoint_conn(&pool);
+        checkpoint_once(&pool, &conn, &config, &mut state)
+            .expect("checkpoint_once must succeed against a healthy dedicated connection");
 
         assert!(
             state.last_attempt.is_none(),
@@ -3060,14 +3170,18 @@ mod tests {
             ..CheckpointConfig::default()
         };
         let mut state = TruncateState::default();
+        let conn = checkpoint_conn(&pool);
 
-        checkpoint_once(&pool, &config, &mut state);
+        checkpoint_once(&pool, &conn, &config, &mut state)
+            .expect("checkpoint_once must succeed against a healthy dedicated connection");
         let first_attempt = state.last_attempt.expect("first tick must attempt");
 
-        // Second tick, immediately after: still above threshold, but the
-        // min-interval has clearly not elapsed — must skip and leave
-        // last_attempt exactly as it was.
-        checkpoint_once(&pool, &config, &mut state);
+        // Second tick, immediately after, on the SAME dedicated connection
+        // (mirroring how `run_checkpoint_task` reuses one connection across
+        // ticks): still above threshold, but the min-interval has clearly
+        // not elapsed — must skip and leave last_attempt exactly as it was.
+        checkpoint_once(&pool, &conn, &config, &mut state)
+            .expect("checkpoint_once must succeed against a healthy dedicated connection");
         let second_attempt = state.last_attempt.expect("attempt timestamp must persist");
 
         assert_eq!(
@@ -3076,15 +3190,20 @@ mod tests {
         );
     }
 
-    /// Busy fallback: when the writer mutex is already held, `checkpoint_once`
-    /// must return `Skipped` and never touch the TRUNCATE state at all — both
-    /// PASSIVE and any due TRUNCATE are skipped together (one writer checkout
-    /// per tick). Also asserts #646 checkpoint-pressure telemetry: a skipped
-    /// tick must bump the skipped/consecutive-skip counters and snapshot the
-    /// last-known WAL pressure.
+    /// The fix this module exists to prove: holding the POOL's writer mutex
+    /// (via `pool.try_writer()`, exactly like a concurrent write in
+    /// progress) must NOT cause `checkpoint_once` to skip — PASSIVE (and, if
+    /// armed, TRUNCATE) run on the task's own dedicated connection, which
+    /// never contends with the pool writer at all. Before the dedicated-
+    /// connection fix, this same setup made `checkpoint_once` return
+    /// `Skipped` via `try_writer_nowait()`. See also the standalone
+    /// integration reproducer in `tests/checkpoint_dedicated_connection.rs`,
+    /// which demonstrates the converse: a fat WAL held busy by
+    /// `checkpoint_once` no longer blocks a concurrent `pool.writer()`
+    /// admission either.
     #[test]
     #[serial(tx_registry, checkpoint_skip_metrics)]
-    fn busy_writer_skips_both_passive_and_truncate() {
+    fn checkpoint_once_proceeds_and_can_attempt_truncate_while_pool_writer_held() {
         reset_checkpoint_metrics_for_tests();
 
         let dir = tempfile::tempdir().unwrap();
@@ -3101,22 +3220,11 @@ mod tests {
                 .unwrap();
         }
 
-        // An observed tick first, so the skip below has a last-known WAL
-        // pressure snapshot to carry forward.
-        let mut warmup_state = TruncateState::default();
-        let warmup_tick = checkpoint_once(&pool, &CheckpointConfig::default(), &mut warmup_state);
-        let observed_pages = match warmup_tick {
-            CheckpointTick::Observed(n) => n,
-            CheckpointTick::Skipped => panic!("warmup tick must observe, not skip"),
-        };
-        assert_eq!(
-            checkpoint_consecutive_skips(),
-            0,
-            "an observed tick must not itself count as a skip"
-        );
+        let conn = checkpoint_conn(&pool);
 
-        // Hold the writer mutex for the duration of the checkpoint_once call so
-        // try_writer_nowait() fails, exactly like a concurrent write in progress.
+        // Hold the POOL's writer mutex for the duration of the checkpoint_once
+        // call, acquired BEFORE the call so the dedicated connection cannot
+        // possibly race a still-free writer.
         let _held = pool.try_writer().unwrap();
 
         let config = CheckpointConfig {
@@ -3125,33 +3233,25 @@ mod tests {
         };
         let mut state = TruncateState::default();
 
-        let tick = checkpoint_once(&pool, &config, &mut state);
-
-        assert_eq!(
-            tick,
-            CheckpointTick::Skipped,
-            "a busy writer must skip the tick entirely"
+        checkpoint_once(&pool, &conn, &config, &mut state).expect(
+            "checkpoint_once must observe normally on its own dedicated connection even \
+             while a concurrent caller holds the pool's writer mutex",
         );
+
         assert!(
-            state.last_attempt.is_none(),
-            "a skipped tick (writer busy) must never stamp last_attempt, \
-             even with a threshold that would otherwise arm immediately"
+            state.last_attempt.is_some(),
+            "a threshold-armed tick must still evaluate (and attempt) TRUNCATE even while \
+             the pool writer is held — the dedicated connection is unaffected by it"
         );
-
         assert_eq!(
             checkpoint_skipped_ticks(),
-            1,
-            "one skipped tick must bump the lifetime skipped-tick counter"
+            0,
+            "a busy pool writer must no longer count as a skipped checkpoint tick"
         );
         assert_eq!(
             checkpoint_consecutive_skips(),
-            1,
-            "one skipped tick must bump the consecutive-skip run length"
-        );
-        assert_eq!(
-            checkpoint_last_skip_wal_pages(),
-            Some(observed_pages),
-            "the skip must snapshot the last-observed WAL pressure"
+            0,
+            "a busy pool writer must not bump the consecutive-skip run length"
         );
     }
 
@@ -3228,9 +3328,14 @@ mod tests {
         );
     }
 
-    /// Observation branch: a checkpoint tick that is actually observed (writer
-    /// free) must close out a prior skip streak, resetting the
-    /// consecutive-skip counter to 0 without touching the lifetime total.
+    /// Observation branch: a checkpoint tick that is actually observed
+    /// (dedicated connection available) must close out a prior skip streak,
+    /// resetting the consecutive-skip counter to 0 without touching the
+    /// lifetime total. Drives `note_checkpoint_skipped()` directly for the
+    /// skipped ticks — exactly what `run_checkpoint_task` calls when
+    /// `CheckpointConnection::ensure_open` returns `None` — rather than
+    /// through pool-writer contention, which (since the dedicated-connection
+    /// fix) no longer produces a skipped tick at all.
     #[test]
     #[serial(tx_registry, checkpoint_skip_metrics)]
     fn observed_tick_resets_consecutive_skips_but_not_lifetime_total() {
@@ -3250,22 +3355,18 @@ mod tests {
                 .unwrap();
         }
 
-        // Two consecutive skipped ticks.
-        {
-            let _held = pool.try_writer().unwrap();
-            let mut state = TruncateState::default();
-            for _ in 0..2 {
-                let tick = checkpoint_once(&pool, &CheckpointConfig::default(), &mut state);
-                assert_eq!(tick, CheckpointTick::Skipped);
-            }
-        }
+        // Two consecutive skipped ticks (dedicated connection unavailable).
+        note_checkpoint_skipped();
+        note_checkpoint_skipped();
         assert_eq!(checkpoint_skipped_ticks(), 2);
         assert_eq!(checkpoint_consecutive_skips(), 2);
 
-        // Now the writer is free: an observed tick must reset the streak.
+        // Now the dedicated connection is available: an observed tick must
+        // reset the streak.
+        let conn = checkpoint_conn(&pool);
         let mut state = TruncateState::default();
-        let tick = checkpoint_once(&pool, &CheckpointConfig::default(), &mut state);
-        assert!(matches!(tick, CheckpointTick::Observed(_)));
+        checkpoint_once(&pool, &conn, &CheckpointConfig::default(), &mut state)
+            .expect("checkpoint_once must succeed against a healthy dedicated connection");
 
         assert_eq!(
             checkpoint_skipped_ticks(),
@@ -3846,11 +3947,9 @@ mod tests {
             }
         }
 
-        let tick = checkpoint_once(&pool, &config, &mut TruncateState::default());
-        let wal_pages = match tick {
-            CheckpointTick::Observed(n) => n,
-            CheckpointTick::Skipped => panic!("writer must not be busy in this test"),
-        };
+        let conn = checkpoint_conn(&pool);
+        let wal_pages = checkpoint_once(&pool, &conn, &config, &mut TruncateState::default())
+            .expect("checkpoint_once must succeed against a healthy dedicated connection");
         assert!(
             wal_pages >= config.high_water_pages,
             "test setup must actually drive wal_pages ({wal_pages}) past high_water_pages \
@@ -4519,28 +4618,51 @@ mod tests {
         );
     }
 
-    /// (3) High-finding regression: a writer-busy tick must NOT silence the
-    /// age sweep. Holds the pool's writer mutex (via `pool.try_writer()`,
-    /// never released for the task's entire run) across several checkpoint
-    /// intervals alongside a stale registered entry, and asserts the age
-    /// alert still fires even though `checkpoint_once` observes
-    /// `CheckpointTick::Skipped` on every single tick. Before the fix, the
-    /// sweep call sat after the `Skipped` early-continue and never ran here.
+    /// (3) High-finding regression: a Skipped tick must NOT silence the age
+    /// sweep. Since the dedicated-connection fix, holding the pool's writer
+    /// mutex no longer produces a Skipped tick at all (see
+    /// `checkpoint_once_proceeds_and_can_attempt_truncate_while_pool_writer_held`),
+    /// so this drives Skipped the way it now actually happens in production:
+    /// a read-only pool, on which `ConnectionPool::open_standalone_writer`
+    /// always fails, so `CheckpointConnection::ensure_open` can never open a
+    /// dedicated connection and every tick reports `Skipped`. Asserts the age
+    /// alert still fires across several such ticks alongside a stale
+    /// registered entry. Before the original fix (#845 predecessor), the
+    /// sweep call sat after the `Skipped` early-continue and never ran here;
+    /// this regression must keep holding under the new skip mechanism too.
     #[tokio::test]
     #[serial(tx_registry, checkpoint_skip_metrics)]
-    async fn checkpoint_task_sweeps_stale_entry_even_when_writer_is_busy_every_tick() {
+    async fn checkpoint_task_sweeps_stale_entry_even_when_dedicated_connection_is_unavailable_every_tick(
+    ) {
         reset_checkpoint_metrics_for_tests();
 
         let dir = tempfile::tempdir().unwrap();
-        let path = dir.path().join("tx_age_sweep_task_writer_busy.db");
-        let pool = file_pool(&path);
+        let path = dir.path().join("tx_age_sweep_task_conn_unavailable.db");
         {
-            let writer = pool.try_writer().unwrap();
+            // Seed the schema with an ordinary read-write pool, then drop it
+            // (releasing its connections) before reopening the same file
+            // read-only below.
+            let seed_pool = file_pool(&path);
+            let writer = seed_pool.try_writer().unwrap();
             writer
                 .conn()
                 .execute_batch("CREATE TABLE IF NOT EXISTS t (x INTEGER);")
                 .unwrap();
         }
+
+        let pool = Arc::new(
+            ConnectionPool::new(PoolConfig {
+                path: Some(path.clone()),
+                read_only: true,
+                ..PoolConfig::default()
+            })
+            .expect("read-only pool open"),
+        );
+        assert!(
+            pool.open_standalone_writer().is_err(),
+            "test precondition: a read-only pool must never be able to open a dedicated \
+             checkpoint connection"
+        );
 
         let buffer = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
         let subscriber = CaptureSubscriber {
@@ -4549,13 +4671,8 @@ mod tests {
         let _tracing_guard = tracing::subscriber::set_default(subscriber);
 
         let _tx_handle = khive_storage::tx_registry::register(Some(
-            "checkpoint_task_writer_busy_sweep_test".to_string(),
+            "checkpoint_task_conn_unavailable_sweep_test".to_string(),
         ));
-
-        // Held for the checkpoint task's entire run, acquired BEFORE spawn
-        // (and with no `.await` in between) so the task cannot possibly
-        // observe a free writer on any tick.
-        let _writer_guard = pool.try_writer().expect("acquire writer for busy hold");
 
         let cfg = CheckpointConfig {
             interval: Duration::from_millis(10),
@@ -4573,9 +4690,9 @@ mod tests {
             true,
         ));
 
-        // Wait until the task has actually recorded a writer-busy Skipped
-        // tick rather than sleeping a fixed real-time budget: each tick also
-        // does registry queries and sidecar filesystem writes, so under
+        // Wait until the task has actually recorded a Skipped tick rather
+        // than sleeping a fixed real-time budget: each tick also does
+        // registry queries and sidecar filesystem writes, so under
         // instrumented (coverage) or loaded runners a fixed sleep races the
         // first completed tick. Bounded, fail-loud.
         let deadline = tokio::time::Instant::now() + Duration::from_secs(10);
@@ -4591,7 +4708,7 @@ mod tests {
         loop {
             let events = buffer.lock().unwrap().clone();
             if events.iter().any(|e| {
-                e.tx_label.as_deref() == Some("checkpoint_task_writer_busy_sweep_test")
+                e.tx_label.as_deref() == Some("checkpoint_task_conn_unavailable_sweep_test")
                     && e.message
                         .as_deref()
                         .is_some_and(|m| m.contains("stale-op cap"))
@@ -4600,8 +4717,8 @@ mod tests {
             }
             assert!(
                 tokio::time::Instant::now() < deadline,
-                "expected the age sweep to fire even though every tick's writer checkout \
-                 was skipped within 10s, got: {events:?}"
+                "expected the age sweep to fire even though every tick's dedicated \
+                 connection was unavailable within 10s, got: {events:?}"
             );
             tokio::time::sleep(Duration::from_millis(10)).await;
         }
@@ -4611,8 +4728,6 @@ mod tests {
             .await
             .expect("checkpoint task should exit within 1s")
             .expect("checkpoint task panicked");
-
-        drop(_writer_guard);
         drop(_tx_handle);
     }
 

--- a/crates/khive-db/src/checkpoint.rs
+++ b/crates/khive-db/src/checkpoint.rs
@@ -1480,7 +1480,10 @@ impl CheckpointConnection {
 ///
 /// Issues `PRAGMA wal_checkpoint(PASSIVE)` every tick on the task's dedicated
 /// [`CheckpointConnection`] — never the pool's writer mutex, so a concurrent
-/// writer cannot block (or be blocked by) a checkpoint tick. A tick is
+/// `pool.writer()` checkout can never queue behind a checkpoint tick. That
+/// guarantee is admission-only: an armed TRUNCATE still takes SQLite's writer
+/// lock and can block new write transactions, on any connection, for up to
+/// `truncate_busy_timeout` (see [`CheckpointConnection`]'s contract). A tick is
 /// `Skipped` only when that dedicated connection is itself unavailable. A
 /// WARNING fires once per below→above threshold crossing, not every tick.
 ///

--- a/crates/khive-db/tests/checkpoint_dedicated_connection.rs
+++ b/crates/khive-db/tests/checkpoint_dedicated_connection.rs
@@ -3,11 +3,16 @@
 //! caller's `pool.writer()` admission.
 //!
 //! Pre-fix, `checkpoint_once` acquired the pool's writer mutex
-//! (`try_writer_nowait`) and held it across `PRAGMA wal_checkpoint(PASSIVE)`
-//! for the whole tick. Over a large WAL that pragma can run for seconds, so
-//! every concurrent `pool.writer()` caller timed out at `checkout_timeout`
-//! (production evidence: 22 caller-side admission timeouts on 2026-08-02
-//! across the fleet, sustained bursts, against a persistent 64MiB WAL).
+//! (`try_writer_nowait`) and held it across the whole tick: the PASSIVE pass
+//! AND, when armed, the TRUNCATE escalation — which busy-waits up to
+//! `truncate_busy_timeout` (seconds) on any live read snapshot pinning the
+//! WAL. That bounded busy-wait under the pool's writer mutex is the
+//! multi-second hold this test reproduces; a PASSIVE pass alone over tens of
+//! MiB completes in tens of milliseconds on modern SSDs and does not
+//! contend measurably (measured while building this fixture). Production
+//! evidence: 22+ caller-side admission timeouts on 2026-08-02 across the
+//! fleet, sustained bursts, against a persistent 64MiB WAL pinned by
+//! long-lived readers.
 //! `PRAGMA wal_checkpoint(PASSIVE)` takes SQLite's CKPT lock, not the WRITE
 //! lock — a writer can commit concurrently with a passive checkpoint: the
 //! pool-mutex serialization was an application-level constraint SQLite
@@ -19,6 +24,17 @@ use khive_db::{CheckpointConfig, ConnectionPool, PoolConfig};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
+
+/// How long the TRUNCATE escalation busy-waits on the pinning reader below.
+/// This is the reproduced hold: a PASSIVE pass alone over a 32MiB WAL
+/// completes in tens of milliseconds on modern SSDs (measured — too fast to
+/// contend with a 250ms admission timeout), but a TRUNCATE armed against a
+/// WAL pinned by a live read snapshot busy-waits for this entire duration,
+/// and on the pre-fix design it did so while holding the pool's writer
+/// mutex. That bounded multi-second hold is the production failure shape
+/// (persistent 64MiB WAL pinned by long-lived readers, admission timeouts in
+/// bursts).
+const TRUNCATE_BUSY: Duration = Duration::from_secs(2);
 
 /// Fixture floor: the `-wal` file must reach at least this size before the
 /// test proceeds, so a vacuous pass (WAL never actually grew, PASSIVE
@@ -111,6 +127,31 @@ fn checkpoint_once_does_not_block_a_concurrent_pool_writer_admission() {
          a genuinely fat WAL for checkpoint_once to churn through"
     );
 
+    // A live read snapshot pinning the WAL: TRUNCATE must wait for readers
+    // whose snapshot predates the WAL's end, so with this transaction open
+    // the armed TRUNCATE below busy-waits for the full TRUNCATE_BUSY bound.
+    // (Any standalone connection works; BEGIN + a SELECT materializes the
+    // snapshot.)
+    let pinning_reader = pool
+        .open_standalone_writer()
+        .expect("open the pinning-reader connection");
+    pinning_reader
+        .execute_batch("BEGIN")
+        .expect("open the pinning read transaction");
+    let _pin: i64 = pinning_reader
+        .query_row("SELECT COUNT(*) FROM blobs", [], |r| r.get(0))
+        .expect("materialize the read snapshot");
+
+    // TRUNCATE armed deterministically: threshold trivially crossed, no
+    // interval gate, and a busy bound long enough for thread B to land
+    // inside the hold window with wide margins.
+    let config = CheckpointConfig {
+        truncate_high_water_pages: 1,
+        truncate_min_interval: Duration::ZERO,
+        truncate_busy_timeout: TRUNCATE_BUSY,
+        ..CheckpointConfig::default()
+    };
+
     // The checkpoint task's dedicated connection, opened exactly the way
     // `run_checkpoint_task` opens its own (`CheckpointConnection::ensure_open`
     // -> `ConnectionPool::open_standalone_writer`).
@@ -119,20 +160,22 @@ fn checkpoint_once_does_not_block_a_concurrent_pool_writer_admission() {
         .open_standalone_writer()
         .expect("open dedicated checkpoint connection");
 
-    // Thread A: run the real `checkpoint_once` once, against the fat WAL.
+    // Thread A: run the real `checkpoint_once` once — PASSIVE over the fat
+    // WAL, then the armed TRUNCATE busy-waiting ~TRUNCATE_BUSY on the
+    // pinning reader.
     let thread_a = std::thread::spawn(move || {
         checkpoint_once(
             &checkpoint_pool,
             &dedicated_conn,
-            &CheckpointConfig::default(),
+            &config,
             &mut TruncateState::default(),
         )
     });
 
-    // Thread B starts ~50ms after A — enough head start for A to have
-    // entered the PASSIVE pragma on a pre-fix build, where it would be
-    // holding the pool's writer mutex for the whole multi-second pass.
-    std::thread::sleep(Duration::from_millis(50));
+    // Thread B starts 500ms after A — safely inside A's TRUNCATE busy-wait
+    // window ([~tens of ms, ~2s]) on a pre-fix build, where that whole wait
+    // happened under the pool's writer mutex.
+    std::thread::sleep(Duration::from_millis(500));
 
     let writer_pool = Arc::clone(&pool);
     let start = Instant::now();

--- a/crates/khive-db/tests/checkpoint_dedicated_connection.rs
+++ b/crates/khive-db/tests/checkpoint_dedicated_connection.rs
@@ -1,6 +1,8 @@
 //! Reproducer for the checkpoint-isolation fix: `checkpoint_once` must run
-//! on its own dedicated connection and never contend with a concurrent
-//! caller's `pool.writer()` admission.
+//! on its own dedicated connection and a concurrent caller's `pool.writer()`
+//! ADMISSION must never queue behind it — even during an armed TRUNCATE.
+//! This is an admission guarantee, not a claim that TRUNCATE's own
+//! SQLite-level write-blocking window disappeared; see below.
 //!
 //! Pre-fix, `checkpoint_once` acquired the pool's writer mutex
 //! (`try_writer_nowait`) and held it across the whole tick: the PASSIVE pass
@@ -13,11 +15,21 @@
 //! evidence: 22+ caller-side admission timeouts on 2026-08-02 across the
 //! fleet, sustained bursts, against a persistent 64MiB WAL pinned by
 //! long-lived readers.
-//! `PRAGMA wal_checkpoint(PASSIVE)` takes SQLite's CKPT lock, not the WRITE
-//! lock — a writer can commit concurrently with a passive checkpoint: the
-//! pool-mutex serialization was an application-level constraint SQLite
-//! itself never required. This test proves the fixed design no longer
-//! imposes it.
+//!
+//! `PRAGMA wal_checkpoint(PASSIVE)` takes only SQLite's CKPT lock, not the
+//! WRITE lock — a writer can commit concurrently with a passive checkpoint.
+//! TRUNCATE additionally acquires SQLite's writer lock and still blocks new
+//! write transactions, on any connection, for up to `truncate_busy_timeout`
+//! while it waits on a pinning reader — that SQLite-level cost is unchanged
+//! by this fix. What the pre-fix design added on top was an
+//! application-level constraint SQLite itself never required: serializing
+//! checkpoint ADMISSION behind the pool's writer mutex, so a caller could not
+//! even be admitted to attempt its own write until the checkpoint tick
+//! (PASSIVE, or a busy-waiting TRUNCATE) released that mutex. This test
+//! arms TRUNCATE deliberately (see `TRUNCATE_BUSY` below) and asserts that
+//! `pool.writer()` is still admitted promptly during its busy-wait — proving
+//! the fixed design no longer imposes that admission-path constraint, not
+//! that TRUNCATE stopped blocking writes at the SQLite level.
 
 use khive_db::checkpoint::{checkpoint_once, TruncateState};
 use khive_db::{CheckpointConfig, ConnectionPool, PoolConfig};
@@ -172,10 +184,52 @@ fn checkpoint_once_does_not_block_a_concurrent_pool_writer_admission() {
         )
     });
 
-    // Thread B starts 500ms after A — safely inside A's TRUNCATE busy-wait
-    // window ([~tens of ms, ~2s]) on a pre-fix build, where that whole wait
-    // happened under the pool's writer mutex.
-    std::thread::sleep(Duration::from_millis(500));
+    // Observe, rather than time-guess, the moment thread A's TRUNCATE actually
+    // arms and starts holding SQLite's writer lock: a separate probe
+    // connection with `busy_timeout=0` attempts `BEGIN IMMEDIATE` in a tight
+    // poll. While no writer lock is held, the probe's own `BEGIN IMMEDIATE`
+    // succeeds immediately (and is rolled back to release it before the next
+    // attempt); the instant it instead fails with `SQLITE_BUSY`, that failure
+    // *is* the observation that thread A now holds the writer lock — not an
+    // inference from elapsed wall-clock time. Bounded by a 5s deadline so a
+    // TRUNCATE that never arms (a fixture regression) fails loudly instead of
+    // this test passing vacuously.
+    let probe = pool
+        .open_standalone_writer()
+        .expect("open the TRUNCATE-arming probe connection");
+    probe
+        .busy_timeout(Duration::ZERO)
+        .expect("set zero busy_timeout on the probe connection");
+
+    let handshake_deadline = Instant::now() + Duration::from_secs(5);
+    loop {
+        match probe.execute_batch("BEGIN IMMEDIATE") {
+            Ok(()) => {
+                probe
+                    .execute_batch("ROLLBACK")
+                    .expect("release the probe's own BEGIN IMMEDIATE");
+            }
+            Err(rusqlite::Error::SqliteFailure(e, _))
+                if e.code == rusqlite::ErrorCode::DatabaseBusy =>
+            {
+                break;
+            }
+            Err(err) => panic!(
+                "probe's BEGIN IMMEDIATE failed with an unexpected error (expected \
+                 SQLITE_BUSY): {err:?}"
+            ),
+        }
+        if Instant::now() >= handshake_deadline {
+            panic!(
+                "fixture INVALID: TRUNCATE never armed within 5s — the probe's BEGIN \
+                 IMMEDIATE kept succeeding the whole time, meaning thread A's \
+                 checkpoint_once never held SQLite's writer lock; this test would \
+                 otherwise pass vacuously without ever observing the hold it exists to \
+                 reproduce"
+            );
+        }
+        std::thread::sleep(Duration::from_millis(10));
+    }
 
     let writer_pool = Arc::clone(&pool);
     let start = Instant::now();

--- a/crates/khive-db/tests/checkpoint_dedicated_connection.rs
+++ b/crates/khive-db/tests/checkpoint_dedicated_connection.rs
@@ -1,0 +1,166 @@
+//! Reproducer for the checkpoint-isolation fix: `checkpoint_once` must run
+//! on its own dedicated connection and never contend with a concurrent
+//! caller's `pool.writer()` admission.
+//!
+//! Pre-fix, `checkpoint_once` acquired the pool's writer mutex
+//! (`try_writer_nowait`) and held it across `PRAGMA wal_checkpoint(PASSIVE)`
+//! for the whole tick. Over a large WAL that pragma can run for seconds, so
+//! every concurrent `pool.writer()` caller timed out at `checkout_timeout`
+//! (production evidence: 22 caller-side admission timeouts on 2026-08-02
+//! across the fleet, sustained bursts, against a persistent 64MiB WAL).
+//! `PRAGMA wal_checkpoint(PASSIVE)` takes SQLite's CKPT lock, not the WRITE
+//! lock — a writer can commit concurrently with a passive checkpoint: the
+//! pool-mutex serialization was an application-level constraint SQLite
+//! itself never required. This test proves the fixed design no longer
+//! imposes it.
+
+use khive_db::checkpoint::{checkpoint_once, TruncateState};
+use khive_db::{CheckpointConfig, ConnectionPool, PoolConfig};
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+/// Fixture floor: the `-wal` file must reach at least this size before the
+/// test proceeds, so a vacuous pass (WAL never actually grew, PASSIVE
+/// finishes trivially fast either way) fails loudly instead of silently.
+const MIN_WAL_BYTES: u64 = 32 * 1024 * 1024;
+
+/// The pool's `checkout_timeout` under test — short, so a regression to the
+/// pre-fix pool-mutex serialization times out quickly instead of the test
+/// hanging for the production default (5s).
+const CHECKOUT_TIMEOUT: Duration = Duration::from_millis(250);
+
+fn wal_path(db_path: &Path) -> PathBuf {
+    let mut wal = db_path.as_os_str().to_owned();
+    wal.push("-wal");
+    PathBuf::from(wal)
+}
+
+/// Safety bound on the fattening loop below: 200,000 rows * 64 KiB caps
+/// worst-case disk usage at ~12.2 GiB instead of an unbounded loop if the
+/// WAL threshold is never reached for some unexpected reason.
+const MAX_FATTEN_ROWS: u32 = 200_000;
+
+/// Insert 64 KiB blobs, each its own committed (autocommit) transaction, so
+/// `checkpoint_once` has real, checkpointable frames waiting, until the
+/// `-wal` file reaches `MIN_WAL_BYTES`. Disables `PRAGMA wal_autocheckpoint`
+/// on this connection first — otherwise SQLite's own default auto-checkpoint
+/// threshold (~4000 pages / 16 MiB, well under `MIN_WAL_BYTES`) fires on
+/// every commit past that point, capping the WAL near that default forever
+/// instead of letting it grow, which turns this loop into a runaway
+/// insert-and-immediately-reclaim cycle instead of a bounded fixture.
+fn fatten_wal(pool: &ConnectionPool, db_path: &Path) {
+    let writer = pool.writer().expect("acquire writer to seed the WAL");
+    writer
+        .conn()
+        .execute_batch(
+            "PRAGMA wal_autocheckpoint = 0; \
+             CREATE TABLE blobs (v BLOB NOT NULL);",
+        )
+        .expect("disable auto-checkpoint and create table");
+
+    let payload = vec![0xABu8; 64 * 1024];
+    let wal = wal_path(db_path);
+    for row in 0..MAX_FATTEN_ROWS {
+        writer
+            .conn()
+            .execute("INSERT INTO blobs (v) VALUES (?1)", [payload.as_slice()])
+            .expect("insert blob row");
+        // Checking file size on every insert is wasteful syscall churn;
+        // every 32 rows (~2 MiB) is fine granularity for a 32 MiB target.
+        if row % 32 != 0 {
+            continue;
+        }
+        let size = std::fs::metadata(&wal).map(|m| m.len()).unwrap_or(0);
+        if size >= MIN_WAL_BYTES {
+            return;
+        }
+    }
+    panic!(
+        "fixture safety bound: inserted {MAX_FATTEN_ROWS} rows without the -wal file \
+         reaching {MIN_WAL_BYTES} bytes; wal_autocheckpoint may not be disabled as expected"
+    );
+}
+
+#[test]
+fn checkpoint_once_does_not_block_a_concurrent_pool_writer_admission() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = dir.path().join("fat_wal_checkpoint_isolation.db");
+
+    let pool = Arc::new(
+        ConnectionPool::new(PoolConfig {
+            path: Some(path.clone()),
+            checkout_timeout: CHECKOUT_TIMEOUT,
+            ..PoolConfig::default()
+        })
+        .expect("pool open"),
+    );
+
+    fatten_wal(&pool, &path);
+
+    // Fixture's positive control: if the WAL didn't actually grow, the rest
+    // of this test would pass vacuously (nothing for PASSIVE to churn
+    // through, so there'd be no contention to observe either way).
+    let wal_size = std::fs::metadata(wal_path(&path))
+        .expect("-wal file must exist after uncheckpointed writes")
+        .len();
+    assert!(
+        wal_size >= MIN_WAL_BYTES,
+        "fixture setup failed: -wal file only reached {wal_size} bytes, expected at least \
+         {MIN_WAL_BYTES} — this test would be INVALID (not a real regression check) without \
+         a genuinely fat WAL for checkpoint_once to churn through"
+    );
+
+    // The checkpoint task's dedicated connection, opened exactly the way
+    // `run_checkpoint_task` opens its own (`CheckpointConnection::ensure_open`
+    // -> `ConnectionPool::open_standalone_writer`).
+    let checkpoint_pool = Arc::clone(&pool);
+    let dedicated_conn = checkpoint_pool
+        .open_standalone_writer()
+        .expect("open dedicated checkpoint connection");
+
+    // Thread A: run the real `checkpoint_once` once, against the fat WAL.
+    let thread_a = std::thread::spawn(move || {
+        checkpoint_once(
+            &checkpoint_pool,
+            &dedicated_conn,
+            &CheckpointConfig::default(),
+            &mut TruncateState::default(),
+        )
+    });
+
+    // Thread B starts ~50ms after A — enough head start for A to have
+    // entered the PASSIVE pragma on a pre-fix build, where it would be
+    // holding the pool's writer mutex for the whole multi-second pass.
+    std::thread::sleep(Duration::from_millis(50));
+
+    let writer_pool = Arc::clone(&pool);
+    let start = Instant::now();
+    let thread_b = std::thread::spawn(move || {
+        let result = writer_pool.writer();
+        (result.is_ok(), start.elapsed())
+    });
+
+    let (writer_admitted, elapsed) = thread_b.join().expect("thread B panicked");
+    thread_a.join().expect("thread A panicked").expect(
+        "checkpoint_once must succeed against a healthy dedicated connection over a fat WAL",
+    );
+
+    // Generous margin (structural lock-ownership test, not a latency
+    // benchmark): the assertion is that admission never waits behind a
+    // checkpoint at all, so it should clear in well under one
+    // checkout_timeout, let alone several.
+    let generous_bound = CHECKOUT_TIMEOUT * 4;
+    assert!(
+        writer_admitted,
+        "pool.writer() must succeed while checkpoint_once runs concurrently on its own \
+         dedicated connection (elapsed: {elapsed:?}); a timeout here means the checkpoint \
+         pragma is still serialized behind the pool's writer mutex — the exact regression \
+         this test guards against"
+    );
+    assert!(
+        elapsed < generous_bound,
+        "pool.writer() took {elapsed:?} to admit a concurrent checkpoint; expected well \
+         under {generous_bound:?} since it should never contend with a checkpoint tick at all"
+    );
+}

--- a/crates/khive-runtime/src/daemon.rs
+++ b/crates/khive-runtime/src/daemon.rs
@@ -569,10 +569,10 @@ pub struct MetricsSnapshot {
     /// bring the WAL back below `warn_pages`; resets to 0 the next time an
     /// attempt clears it.
     pub wal_truncate_consecutive_failures: u64,
-    /// Total checkpoint ticks skipped because the writer mutex was busy
-    /// (ADR-091 checkpoint-pressure telemetry), across this process's
-    /// lifetime. `#[serde(default)]` so an older client decoding a newer
-    /// daemon's snapshot (or vice versa) does not fail.
+    /// Total checkpoint ticks skipped because the dedicated checkpoint
+    /// connection was unavailable (ADR-091 checkpoint-pressure telemetry),
+    /// across this process's lifetime. `#[serde(default)]` so an older client
+    /// decoding a newer daemon's snapshot (or vice versa) does not fail.
     #[serde(default)]
     pub wal_checkpoint_skipped_ticks: u64,
     /// Current consecutive-skip run length; 0 once the next tick is observed.

--- a/crates/khive-runtime/src/daemon.rs
+++ b/crates/khive-runtime/src/daemon.rs
@@ -2728,15 +2728,16 @@ mod tests {
                 .expect("seed writes");
         }
 
-        let tick = khive_db::checkpoint_once(
+        let dedicated_conn = pool
+            .open_standalone_writer()
+            .expect("open dedicated checkpoint connection");
+        khive_db::checkpoint_once(
             &pool,
+            &dedicated_conn,
             &CheckpointConfig::default(),
             &mut khive_db::checkpoint::TruncateState::default(),
-        );
-        assert!(
-            matches!(tick, khive_db::CheckpointTick::Observed(_)),
-            "checkpoint_once on a freshly-writer-held pool must observe, not skip: {tick:?}"
-        );
+        )
+        .expect("checkpoint_once must observe on a healthy dedicated connection");
 
         let dispatcher = MockDispatch {
             namespace: "local".to_string(),

--- a/docs/adr/ADR-091-wal-snapshot-lifetime.md
+++ b/docs/adr/ADR-091-wal-snapshot-lifetime.md
@@ -1087,3 +1087,67 @@ public ceiling and the over-budget sentinel, and snapshot tests must prove a
 live statement is attributed while no registry entry survives the statement.
 Changing any numeric ceiling, partial-result rule, traversal ordering guarantee,
 or snapshot consistency model requires another ADR amendment.
+
+### 2026-08-02 amendment (Amendment 5): dedicated checkpoint connection — supersedes `try_writer_nowait`
+
+**Motivation.** Production evidence (2026-08-02): 22 caller-side `pool.writer()`
+admission timeouts across the fleet, sustained bursts, against a persistent
+64MiB WAL. `checkpoint_once` acquired the pool's writer mutex via
+`try_writer_nowait` (Plank 2, above) and held that same guard across `PRAGMA
+wal_checkpoint(PASSIVE)` — and, when armed, the TRUNCATE escalation — for the
+whole tick. Over a large WAL a PASSIVE pass can run long enough that every
+concurrent `pool.writer()` caller times out at `checkout_timeout`. This was an
+unforced application-level constraint, not a SQLite requirement: `PRAGMA
+wal_checkpoint` takes SQLite's CKPT lock, not the WRITE lock, so a writer can
+commit concurrently with a passive checkpoint. Serializing checkpoint and
+writers through one mutex imposed contention SQLite itself never required.
+
+**This amendment supersedes, and directly contradicts, several statements
+made earlier in this document** (Plank 2's own section, above, and the
+Non-goals section's "does not redesign writer serialization" — that statement
+was true of the pool's general-purpose write path, which this amendment does
+not touch, but was never meant to bless serializing the checkpoint task's own
+pragmas behind that same mutex). Both are corrected by this amendment; the
+earlier text is left in place, unedited, as the historical record of the
+original (now-superseded) design, per this document's own convention for
+prior amendments.
+
+**Design.** The checkpoint task now owns a dedicated, long-lived standalone
+connection to the same database file (`CheckpointConnection` in
+`checkpoint.rs`), opened once at task startup via the crate's existing
+standalone-connection open path (`ConnectionPool::open_standalone_writer` —
+same pragmas as any other standalone connection, including `busy_timeout`
+from the pool config). `checkpoint_once` runs PASSIVE — and, when armed,
+`maybe_truncate`'s TRUNCATE escalation, on the SAME dedicated connection,
+never a second checkout — on this connection and never checks out the pool's
+writer mutex at all. `try_writer_nowait` is no longer used anywhere on this
+path.
+
+**Skip semantics changed.** Previously a busy pool writer caused
+`checkpoint_once` to return `CheckpointTick::Skipped` for that tick (a busy
+writer skip). That mechanism is gone: PASSIVE now runs unconditionally on
+every tick regardless of concurrent write traffic, because it no longer
+contends with that traffic at all. `CheckpointTick::Skipped` still exists, but
+is now produced only when the dedicated connection itself is unavailable —
+never opened yet (an in-memory or read-only pool has no on-disk file, or no
+write permission, for `open_standalone_writer` to open a second connection
+against), or dropped after a prior tick's connection-level pragma failure.
+`CheckpointConnection::ensure_open` lazily reopens on the next tick in that
+case; a dropped connection never crashes the task.
+
+**TRUNCATE's bounded blocking cost is unaffected in kind, only in which
+connection pays it.** TRUNCATE still inherits RESTART semantics and can block
+for up to `truncate_busy_timeout` waiting on active readers — that accepted,
+bounded cost (already governed by `truncate_busy_timeout` and the
+`truncate_min_interval` gate) now falls on the dedicated connection alone,
+never on a concurrent `pool.writer()` caller.
+
+**What did not change.** Every counter, WARN-once threshold-crossing
+semantic, the tx-registry age sweep (Plank 1, including its running on a
+Skipped tick — the reason changed, from "writer busy" to "dedicated
+connection unavailable," but the invariant that the sweep must not go blind
+during a Skipped streak did not), the severity ladder (Plank 0), and the
+walpin sidecar heartbeat (Amendment 2 Plank B) are behavior-neutral under
+this amendment — only which connection/lock a checkpoint tick runs on
+changed. `run_checkpoint_task`'s public signature, and every other daemon
+call site, are also unchanged.

--- a/docs/adr/ADR-091-wal-snapshot-lifetime.md
+++ b/docs/adr/ADR-091-wal-snapshot-lifetime.md
@@ -1135,12 +1135,26 @@ against), or dropped after a prior tick's connection-level pragma failure.
 `CheckpointConnection::ensure_open` lazily reopens on the next tick in that
 case; a dropped connection never crashes the task.
 
-**TRUNCATE's bounded blocking cost is unaffected in kind, only in which
-connection pays it.** TRUNCATE still inherits RESTART semantics and can block
-for up to `truncate_busy_timeout` waiting on active readers — that accepted,
-bounded cost (already governed by `truncate_busy_timeout` and the
-`truncate_min_interval` gate) now falls on the dedicated connection alone,
-never on a concurrent `pool.writer()` caller.
+**What actually changed is admission, not SQLite-level blocking — this
+distinction matters and must not be flattened.** The dedicated connection
+removes the pool-mutex ADMISSION path: a `pool.writer()` checkout no longer
+queues behind a checkpoint tick, because that tick no longer holds the pool's
+writer mutex at all. SQLite-level lock semantics are otherwise unchanged by
+this amendment: PASSIVE takes only the CKPT lock and never blocks writers, at
+the SQLite level, on any connection. TRUNCATE inherits RESTART semantics and
+*additionally* acquires SQLite's writer lock, blocking new write transactions
+on ALL connections — this process or any other, pool-checked-out or
+standalone — while it waits on pinning readers, bounded by
+`truncate_busy_timeout` (see
+[`sqlite3_wal_checkpoint_v2`](https://www.sqlite.org/c3ref/wal_checkpoint_v2.html)).
+So during an armed TRUNCATE, a concurrent caller is still ADMITTED promptly —
+that is what the reproducer in
+`crates/khive-db/tests/checkpoint_dedicated_connection.rs` asserts — but a
+write transaction it then attempts can still wait, at the SQLite level, for
+the bounded TRUNCATE window, exactly as before this amendment. "Never falls on
+a concurrent `pool.writer()` caller" is true of admission only; it must not be
+read, here or anywhere else in this document or the accompanying source, as a
+claim that TRUNCATE's SQLite-level write-blocking window disappeared.
 
 **What did not change.** Every counter, WARN-once threshold-crossing
 semantic, the tx-registry age sweep (Plank 1, including its running on a

--- a/docs/adr/ADR-091-wal-snapshot-lifetime.md
+++ b/docs/adr/ADR-091-wal-snapshot-lifetime.md
@@ -1142,7 +1142,7 @@ queues behind a checkpoint tick, because that tick no longer holds the pool's
 writer mutex at all. SQLite-level lock semantics are otherwise unchanged by
 this amendment: PASSIVE takes only the CKPT lock and never blocks writers, at
 the SQLite level, on any connection. TRUNCATE inherits RESTART semantics and
-*additionally* acquires SQLite's writer lock, blocking new write transactions
+_additionally_ acquires SQLite's writer lock, blocking new write transactions
 on ALL connections — this process or any other, pool-checked-out or
 standalone — while it waits on pinning readers, bounded by
 `truncate_busy_timeout` (see


### PR DESCRIPTION
## Summary

`checkpoint_once` acquired the pool's writer mutex (`try_writer_nowait`) and held it across `PRAGMA wal_checkpoint(PASSIVE)` — and, when armed, the TRUNCATE escalation — for the entire tick. Over a large WAL (production carries a persistent 64MiB one) a PASSIVE pass runs long enough that every concurrent `pool.writer()` caller times out at `checkout_timeout` (22 caller-side admission timeouts observed on 2026-08-02, in sustained bursts).

`PRAGMA wal_checkpoint` takes SQLite's CKPT lock, not the WRITE lock — a writer can commit concurrently with a passive checkpoint. The pool-mutex serialization was an application-level constraint SQLite never required.

## Changes

- `CheckpointConnection`: the checkpoint task owns a dedicated long-lived standalone connection (opened once at startup via the existing `open_standalone_writer` path, same pragmas), lazily reopened after connection-level pragma failures. `checkpoint_once` never touches the pool's writer mutex.
- Skip semantics: PASSIVE runs every tick unconditionally; `CheckpointTick::Skipped` now means only that the dedicated connection was unavailable. All counters and WARN-once crossing semantics preserved.
- `maybe_truncate` runs on the same dedicated connection; its bounded `truncate_busy_timeout` and min-interval gates are unchanged.
- ADR-091 Amendment 5 documents the change and marks the superseded statements in place.

## Reproducer

`crates/khive-db/tests/checkpoint_dedicated_connection.rs`: fattens a WAL past 32MiB (with a positive control that fails loudly if the WAL never grew), runs the real `checkpoint_once` on one thread and a concurrent `pool.writer()` admission on another. On the previous design the admission times out behind the checkpoint's writer-mutex hold; on this design it is admitted immediately. Pre-fix failure demonstration output is included in the review thread.

## Testing

- `cargo test -p khive-db` (580 incl. new reproducer) and `cargo test -p khive-runtime` — pass
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo fmt --all --check` — clean
- Full `cargo test --workspace` — running, result posted before ready

🤖 Generated with [Claude Code](https://claude.com/claude-code)