### PR TITLE
fix(khive-db): strict write routing — queue-first SqlBridge, migrated maintenance writers, fail-closed mode

### DIFF
--- a/crates/khive-db/src/checkpoint.rs
+++ b/crates/khive-db/src/checkpoint.rs
@@ -1389,6 +1389,12 @@ impl Drop for CheckpointLifecycleEmitter {
 /// yet, or dropped after a prior tick's connection-level pragma failure) —
 /// the caller must report that tick `Skipped` and retry the open on the next
 /// one. This is now the ONLY source of a `Skipped` tick.
+///
+/// ADR-136 D1 gate 5 classification: **checkpoint writer**. Explicitly
+/// exempt from `WriterTask`/queue routing by design (see the admission-path
+/// note above), never `SqlAccess`-reachable, never counted as a
+/// `direct_route_violation` — see the classification table in
+/// `writer_task`'s module doc.
 struct CheckpointConnection {
     conn: Option<rusqlite::Connection>,
     /// Consecutive failed `open_standalone_writer` attempts since the last

--- a/crates/khive-db/src/pool.rs
+++ b/crates/khive-db/src/pool.rs
@@ -79,6 +79,16 @@ pub struct PoolConfig {
     /// Overridable via `KHIVE_WRITE_QUEUE_CAPACITY`. Default: 256 pending
     /// operations (ADR-067 Component A recommended default).
     pub write_queue_capacity: usize,
+    /// ADR-136 D1: when `true`, every write path that would otherwise
+    /// silently degrade to the legacy pool-mutex/standalone-connection path
+    /// on a missing or failed `WriterTask` handle instead returns an error.
+    /// Exercises the completed routing (ADR-135 F2's strict-routing
+    /// precondition) without changing behavior for callers that never set
+    /// the env var.
+    ///
+    /// Overridable via `KHIVE_WRITE_ROUTING` (value `"strict"`,
+    /// case-insensitive; anything else, or unset, leaves this `false`).
+    pub write_routing_strict: bool,
 }
 
 impl Default for PoolConfig {
@@ -119,6 +129,9 @@ impl Default for PoolConfig {
                 .and_then(|v| v.parse::<usize>().ok())
                 .filter(|&n| n > 0)
                 .unwrap_or(DEFAULT_WRITE_QUEUE_CAPACITY),
+            write_routing_strict: std::env::var("KHIVE_WRITE_ROUTING")
+                .map(|v| v.eq_ignore_ascii_case("strict"))
+                .unwrap_or(false),
         }
     }
 }
@@ -1047,13 +1060,14 @@ mod tests {
         }
     }
 
-    const POOL_ENV_VARS: [&str; 6] = [
+    const POOL_ENV_VARS: [&str; 7] = [
         "KHIVE_BUSY_TIMEOUT_SECS",
         "KHIVE_CHECKOUT_TIMEOUT_SECS",
         "KHIVE_WAL_AUTOCHECKPOINT_PAGES",
         "KHIVE_JOURNAL_SIZE_LIMIT_BYTES",
         "KHIVE_WRITE_QUEUE",
         "KHIVE_WRITE_QUEUE_CAPACITY",
+        "KHIVE_WRITE_ROUTING",
     ];
 
     struct PoolEnvGuard {
@@ -1188,6 +1202,41 @@ mod tests {
         let cfg = PoolConfig::default();
         std::env::remove_var("KHIVE_WRITE_QUEUE");
         assert!(cfg.write_queue_enabled);
+    }
+
+    #[test]
+    #[serial]
+    fn pool_config_write_routing_strict_defaults_off() {
+        let _pool_env = clear_pool_env();
+        let cfg = PoolConfig::default();
+        assert!(!cfg.write_routing_strict);
+    }
+
+    #[test]
+    #[serial]
+    fn pool_config_env_override_write_routing_strict() {
+        std::env::set_var("KHIVE_WRITE_ROUTING", "strict");
+        let cfg = PoolConfig::default();
+        std::env::remove_var("KHIVE_WRITE_ROUTING");
+        assert!(cfg.write_routing_strict);
+    }
+
+    #[test]
+    #[serial]
+    fn pool_config_env_override_write_routing_strict_case_insensitive() {
+        std::env::set_var("KHIVE_WRITE_ROUTING", "STRICT");
+        let cfg = PoolConfig::default();
+        std::env::remove_var("KHIVE_WRITE_ROUTING");
+        assert!(cfg.write_routing_strict);
+    }
+
+    #[test]
+    #[serial]
+    fn pool_config_env_write_routing_ignores_unrecognized_value() {
+        std::env::set_var("KHIVE_WRITE_ROUTING", "eventual");
+        let cfg = PoolConfig::default();
+        std::env::remove_var("KHIVE_WRITE_ROUTING");
+        assert!(!cfg.write_routing_strict);
     }
 
     #[test]

--- a/crates/khive-db/src/sql_bridge.rs
+++ b/crates/khive-db/src/sql_bridge.rs
@@ -232,9 +232,10 @@ struct SqliteWriter {
     /// `None` at construction when a `WriterTaskHandle` was obtained (ADR-136
     /// D1 gate 1: queue-first `writer()` skips the standalone open in that
     /// case). Lazily opened by [`SqliteWriter::ensure_conn`] on first read
-    /// (`query_row`/`query_all`) — no production caller reads via a
-    /// `writer()` handle today, but the `SqlReader` supertrait still
-    /// requires the capability.
+    /// (`query_row`/`query_all`) — production callers do read through a
+    /// `writer()` handle (e.g. `khive-pack-comm` and `khive-pack-gtd`), so
+    /// the `SqlReader` supertrait's lazy-open path is live, not just a
+    /// capability formality.
     conn: Option<rusqlite::Connection>,
     /// ADR-067 Component A: when the write queue is enabled, `execute_batch`
     /// routes the whole caller-supplied statement list through the
@@ -255,11 +256,22 @@ struct SqliteWriter {
 }
 
 impl SqliteWriter {
-    /// Return `conn` if already open, else open a standalone writer
-    /// connection now. See the `conn` field doc comment for when this lazy
-    /// path is reached.
+    /// Return `conn` if already open, else lazily open a standalone
+    /// **read-only** connection now. See the `conn` field doc comment for
+    /// when this lazy path is reached — it is only reached from the
+    /// `SqlReader` methods (`query_row`/`query_all`), never from a
+    /// `SqlWriter` method: every `SqlWriter` method on this type either
+    /// routes through `writer_task` (when present, the same condition that
+    /// causes `conn` to start `None`) or uses the writer connection opened
+    /// eagerly at construction (when `writer_task` is absent). Opening a
+    /// read-only connection here (ADR-136 D1 gate 3 amendment) closes the
+    /// gap where a caller holding a queue-backed writer handle could issue
+    /// an `INSERT ... RETURNING` (or any other DML) through `query_row` /
+    /// `query_all` and have it execute on an untracked read-write
+    /// connection, outside the `WriterTask` — SQLite rejects DML against a
+    /// read-only connection instead.
     fn ensure_conn(&self) -> khive_storage::types::StorageResult<rusqlite::Connection> {
-        open_standalone_writer(&self.pool)
+        open_standalone_reader(&self.pool)
     }
 }
 
@@ -1081,11 +1093,12 @@ impl khive_storage::SqlAccess for SqlBridge {
                     crate::timeout_sink::Site::DirectRouteSqlBridgeWriter,
                 );
             }
-            // A standalone connection is opened only when there is no queue
-            // handle to route writes through — `SqliteWriter`'s `SqlReader`
-            // methods (`query_row`/`query_all`) lazily open one on first use
-            // in the handle-present case (no production caller reads via a
-            // `writer()` handle today; see `SqliteWriter::ensure_conn`).
+            // A standalone read-write connection is opened only when there is
+            // no queue handle to route writes through — `SqliteWriter`'s
+            // `SqlReader` methods (`query_row`/`query_all`) lazily open a
+            // read-only one on first use in the handle-present case;
+            // production callers do read through a `writer()` handle, so
+            // this lazy path is live (see `SqliteWriter::ensure_conn`).
             let conn = if writer_task.is_none() {
                 Some(open_standalone_writer(&self.pool)?)
             } else {
@@ -1518,13 +1531,149 @@ mod tests {
         );
     }
 
-    /// ADR-136 D1 acceptance arm: a 5-op batch shaped like
-    /// `[send, read, read, read, read]` at the storage layer, issued while 3
-    /// concurrent writers contend the write path, must complete every op —
-    /// no checkout timeout — once routing is strict and the queue is on.
+    /// ADR-136 D1 gate 3 amendment: production DOES read through a
+    /// queue-backed `writer()` handle — `khive-pack-comm`'s handlers obtain
+    /// a writer then call `w.query_row(...)` cursor-style, and
+    /// `khive-pack-gtd`'s bootstrap calls `w.query_all("PRAGMA
+    /// table_info...")` on one. Exercise that exact shape under a strict,
+    /// queue-enabled pool: write through the handle, then read the same row
+    /// back through it before it is dropped.
+    #[tokio::test]
+    async fn writer_handle_supports_read_after_write_under_strict_queue() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("writer_read_after_write.db");
+        let config = PoolConfig {
+            path: Some(path),
+            write_queue_enabled: true,
+            write_routing_strict: true,
+            ..PoolConfig::default()
+        };
+        let pool = Arc::new(ConnectionPool::new(config).unwrap());
+        {
+            let guard = pool.writer().unwrap();
+            guard
+                .conn()
+                .execute_batch(
+                    "CREATE TABLE IF NOT EXISTS writer_cursor_test \
+                     (id INTEGER PRIMARY KEY, val TEXT NOT NULL)",
+                )
+                .unwrap();
+        }
+
+        let bridge = SqlBridge::new(Arc::clone(&pool), true);
+
+        let mut w = bridge.writer().await.unwrap();
+        w.execute(SqlStatement {
+            sql: "INSERT INTO writer_cursor_test (id, val) VALUES (?1, ?2)".into(),
+            params: vec![SqlValue::Integer(1), SqlValue::Text("via-writer".into())],
+            label: None,
+        })
+        .await
+        .unwrap();
+
+        let row = w
+            .query_row(SqlStatement {
+                sql: "SELECT val FROM writer_cursor_test WHERE id = ?1".into(),
+                params: vec![SqlValue::Integer(1)],
+                label: None,
+            })
+            .await
+            .unwrap()
+            .expect("row inserted through the same writer handle must be visible to it");
+        assert!(
+            matches!(&row.columns[0].value, SqlValue::Text(v) if v == "via-writer"),
+            "query_row through a queue-backed writer handle must see its own \
+             committed write; got {:?}",
+            row.columns[0].value
+        );
+    }
+
+    /// ADR-136 D1 gate 3 amendment: `SqlWriter::query_row`/`query_all` carry
+    /// no read-only restriction at the trait level — a caller could hand a
+    /// DML-with-RETURNING statement to `query_row` expecting it to behave
+    /// like any other query. Under a queue-backed handle, the standalone
+    /// connection `SqliteWriter::ensure_conn` lazily opens must be
+    /// read-only, so SQLite rejects the statement outright instead of
+    /// quietly mutating the row on an untracked connection outside the
+    /// `WriterTask`. Red-proof: reverting `ensure_conn` to
+    /// `open_standalone_writer` makes this test fail (the UPDATE succeeds
+    /// and mutates the row).
+    #[tokio::test]
+    async fn writer_query_row_rejects_dml_with_returning_on_queue_backed_handle() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("writer_readonly_returning.db");
+        let config = PoolConfig {
+            path: Some(path),
+            write_queue_enabled: true,
+            write_routing_strict: true,
+            ..PoolConfig::default()
+        };
+        let pool = Arc::new(ConnectionPool::new(config).unwrap());
+        {
+            let guard = pool.writer().unwrap();
+            guard
+                .conn()
+                .execute_batch(
+                    "CREATE TABLE IF NOT EXISTS writer_returning_test \
+                     (id INTEGER PRIMARY KEY, val TEXT NOT NULL);
+                     INSERT INTO writer_returning_test (id, val) VALUES (1, 'original');",
+                )
+                .unwrap();
+        }
+
+        let bridge = SqlBridge::new(Arc::clone(&pool), true);
+
+        let mut w = bridge.writer().await.unwrap();
+        let result = w
+            .query_row(SqlStatement {
+                sql: "UPDATE writer_returning_test SET val = 'mutated' \
+                      WHERE id = ?1 RETURNING val"
+                    .into(),
+                params: vec![SqlValue::Integer(1)],
+                label: None,
+            })
+            .await;
+        assert!(
+            result.is_err(),
+            "a DML-with-RETURNING statement through query_row on a \
+             queue-backed writer handle must be rejected, not executed on \
+             an untracked read-write connection; got {result:?}"
+        );
+
+        let mut reader = bridge.reader().await.unwrap();
+        let val = reader
+            .query_scalar(SqlStatement {
+                sql: "SELECT val FROM writer_returning_test WHERE id = ?1".into(),
+                params: vec![SqlValue::Integer(1)],
+                label: None,
+            })
+            .await
+            .unwrap();
+        assert!(
+            matches!(&val, Some(SqlValue::Text(v)) if v == "original"),
+            "the rejected UPDATE...RETURNING must not have altered the row; got {val:?}"
+        );
+    }
+
+    /// ADR-136 D1 acceptance arm: a 5-op batch shaped like `[send, mark,
+    /// mark, mark, mark]` at the storage layer — every "mark" op is a real
+    /// `UPDATE` against its own pre-seeded row, so (like `send`) it routes
+    /// through the writer task rather than bypassing it as a `SELECT` would
+    /// — issued while 3 concurrent writers contend the write path, must
+    /// complete every op — no checkout timeout — once routing is strict and
+    /// the queue is on. An occupier holds the writer task's single drain
+    /// slot until all 8 requests (3 contenders + send + 4 marks) are
+    /// provably enqueued behind it (`queue_depth() >= 8`, the same
+    /// occupier/`queue_depth()` discriminator the migrated-call-site tests
+    /// use), so this proves genuine contention instead of a scheduler that
+    /// happens to drain the tiny writes before the others even enqueue.
     /// Mirrors the measured production failure ADR-136's Context section
     /// documents (middle ops of a batch starving while a sibling write wins
-    /// under the legacy fixed-deadline pool mutex).
+    /// under the legacy fixed-deadline pool mutex). Red-proofed: reverting
+    /// the marks back to `bridge.reader()` `SELECT`s (the pre-fix shape)
+    /// makes the `queue_depth() >= 8` wait time out and fail, since a read
+    /// never reaches the writer task's channel — confirming this version
+    /// actually requires all four marks to be real writes.
     #[tokio::test]
     async fn acceptance_five_op_batch_completes_under_concurrent_write_contention() {
         let dir = tempfile::tempdir().unwrap();
@@ -1542,12 +1691,47 @@ mod tests {
                 .conn()
                 .execute_batch(
                     "CREATE TABLE IF NOT EXISTS acceptance_batch \
-                     (id INTEGER PRIMARY KEY, val TEXT NOT NULL)",
+                     (id INTEGER PRIMARY KEY, val TEXT NOT NULL);
+                     INSERT INTO acceptance_batch (id, val) VALUES \
+                     (200, 'seed-0'), (201, 'seed-1'), (202, 'seed-2'), (203, 'seed-3');",
                 )
                 .unwrap();
         }
 
         let bridge = Arc::new(SqlBridge::new(Arc::clone(&pool), true));
+
+        let writer_task = pool
+            .writer_task_handle()
+            .unwrap()
+            .expect("writer task must be spawned for a file-backed pool with the flag on");
+
+        // Occupier: holds the single writer-task drain slot until released,
+        // so every op below is provably queued behind it rather than racing
+        // to finish before the others even enqueue (same technique as
+        // `rename_namespace_routes_through_writer_task_when_flag_enabled` in
+        // `stores::text_tests`).
+        let (started_tx, started_rx) = tokio::sync::oneshot::channel::<()>();
+        let (release_tx, release_rx) = tokio::sync::oneshot::channel::<()>();
+        let occupier = {
+            let writer_task = writer_task.clone();
+            tokio::spawn(async move {
+                writer_task
+                    .send(move |_conn| {
+                        let _ = started_tx.send(());
+                        let _ = release_rx.blocking_recv();
+                        Ok::<(), StorageError>(())
+                    })
+                    .await
+            })
+        };
+        started_rx
+            .await
+            .expect("occupier must signal it has started running inside the writer task");
+        assert_eq!(
+            writer_task.queue_depth(),
+            0,
+            "channel must start empty once the occupier has been dequeued and is running"
+        );
 
         // 3 concurrent writers contending the write path — each a
         // self-contained `execute()` through `SqlBridge::writer()`, matching
@@ -1572,7 +1756,7 @@ mod tests {
             })
             .collect();
 
-        // The 5-op batch: [send, read, read, read, read].
+        // The 5-op batch: [send, mark, mark, mark, mark].
         let send = {
             let bridge = Arc::clone(&bridge);
             tokio::spawn(async move {
@@ -1586,21 +1770,50 @@ mod tests {
                     .await
             })
         };
-        let reads: Vec<_> = (0..4)
-            .map(|_| {
+        let marks: Vec<_> = (0..4)
+            .map(|i| {
                 let bridge = Arc::clone(&bridge);
                 tokio::spawn(async move {
-                    let mut reader = bridge.reader().await?;
-                    reader
-                        .query_scalar(SqlStatement {
-                            sql: "SELECT COUNT(*) FROM acceptance_batch".into(),
-                            params: vec![],
+                    let mut writer = bridge.writer().await?;
+                    writer
+                        .execute(SqlStatement {
+                            sql: "UPDATE acceptance_batch SET val = ?2 WHERE id = ?1".into(),
+                            params: vec![
+                                SqlValue::Integer(200 + i),
+                                SqlValue::Text(format!("marked-{i}")),
+                            ],
                             label: None,
                         })
                         .await
                 })
             })
             .collect();
+
+        // All 8 requests must actually reach the writer task's channel
+        // while the occupier still holds the single drain slot.
+        let mut saw_all_enqueued = false;
+        for _ in 0..200 {
+            if writer_task.queue_depth() >= 8 {
+                saw_all_enqueued = true;
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+        }
+        assert!(
+            saw_all_enqueued,
+            "not all 8 contending writes (3 contenders + send + 4 marks) reached \
+             the writer task's channel while the occupier held the single drain \
+             slot — got depth {}",
+            writer_task.queue_depth()
+        );
+
+        release_tx
+            .send(())
+            .expect("occupier must still be waiting on the release signal");
+        occupier
+            .await
+            .expect("occupier task must not panic")
+            .expect("occupier write must succeed");
 
         for c in contenders {
             c.await
@@ -1610,10 +1823,15 @@ mod tests {
         send.await
             .expect("send task must not panic")
             .expect("send op must complete without a checkout timeout");
-        for r in reads {
-            r.await
-                .expect("read task must not panic")
-                .expect("read op must complete without a checkout timeout — no starvation");
+        for (i, m) in marks.into_iter().enumerate() {
+            let affected = m
+                .await
+                .expect("mark task must not panic")
+                .expect("mark op must complete without a checkout timeout — no starvation");
+            assert_eq!(
+                affected, 1,
+                "mark {i} must have updated exactly its own row"
+            );
         }
 
         let mut reader = bridge.reader().await.unwrap();
@@ -1626,8 +1844,25 @@ mod tests {
             .await
             .unwrap();
         assert!(
-            matches!(count, Some(SqlValue::Integer(4))),
-            "all 3 contenders plus the batch's own send must have committed; got {count:?}"
+            matches!(count, Some(SqlValue::Integer(8))),
+            "the 4 seeded mark rows plus 3 contenders plus the batch's own send \
+             must all be present; got {count:?}"
         );
+
+        for i in 0..4i64 {
+            let mut reader = bridge.reader().await.unwrap();
+            let val = reader
+                .query_scalar(SqlStatement {
+                    sql: "SELECT val FROM acceptance_batch WHERE id = ?1".into(),
+                    params: vec![SqlValue::Integer(200 + i)],
+                    label: None,
+                })
+                .await
+                .unwrap();
+            assert!(
+                matches!(&val, Some(SqlValue::Text(v)) if *v == format!("marked-{i}")),
+                "mark row {i} must reflect the persisted UPDATE after release; got {val:?}"
+            );
+        }
     }
 }

--- a/crates/khive-db/src/sql_bridge.rs
+++ b/crates/khive-db/src/sql_bridge.rs
@@ -229,6 +229,12 @@ impl khive_storage::SqlReader for SqliteReader {
 // =============================================================================
 
 struct SqliteWriter {
+    /// `None` at construction when a `WriterTaskHandle` was obtained (ADR-136
+    /// D1 gate 1: queue-first `writer()` skips the standalone open in that
+    /// case). Lazily opened by [`SqliteWriter::ensure_conn`] on first read
+    /// (`query_row`/`query_all`) — no production caller reads via a
+    /// `writer()` handle today, but the `SqlReader` supertrait still
+    /// requires the capability.
     conn: Option<rusqlite::Connection>,
     /// ADR-067 Component A: when the write queue is enabled, `execute_batch`
     /// routes the whole caller-supplied statement list through the
@@ -243,6 +249,18 @@ struct SqliteWriter {
     /// captured at construction so the standalone-path busy/locked mapping
     /// below doesn't need a `&ConnectionPool` reference to report against.
     db: String,
+    /// Needed only for [`Self::ensure_conn`]'s lazy standalone-connection
+    /// open when `conn` was skipped at construction (`writer_task` present).
+    pool: Arc<ConnectionPool>,
+}
+
+impl SqliteWriter {
+    /// Return `conn` if already open, else open a standalone writer
+    /// connection now. See the `conn` field doc comment for when this lazy
+    /// path is reached.
+    fn ensure_conn(&self) -> khive_storage::types::StorageResult<rusqlite::Connection> {
+        open_standalone_writer(&self.pool)
+    }
 }
 
 #[async_trait]
@@ -251,10 +269,16 @@ impl khive_storage::SqlReader for SqliteWriter {
         &mut self,
         statement: SqlStatement,
     ) -> khive_storage::types::StorageResult<Option<SqlRow>> {
-        let conn = self.conn.take().ok_or_else(|| StorageError::Pool {
-            operation: "writer.query_row".into(),
-            message: "connection already consumed".into(),
-        })?;
+        let conn = match self.conn.take() {
+            Some(conn) => conn,
+            None if self.writer_task.is_some() => self.ensure_conn()?,
+            None => {
+                return Err(StorageError::Pool {
+                    operation: "writer.query_row".into(),
+                    message: "connection already consumed".into(),
+                })
+            }
+        };
         let (conn, result) = tokio::task::spawn_blocking(move || {
             let res = execute_query(&conn, &statement);
             (conn, res)
@@ -270,10 +294,16 @@ impl khive_storage::SqlReader for SqliteWriter {
         &mut self,
         statement: SqlStatement,
     ) -> khive_storage::types::StorageResult<Vec<SqlRow>> {
-        let conn = self.conn.take().ok_or_else(|| StorageError::Pool {
-            operation: "writer.query_all".into(),
-            message: "connection already consumed".into(),
-        })?;
+        let conn = match self.conn.take() {
+            Some(conn) => conn,
+            None if self.writer_task.is_some() => self.ensure_conn()?,
+            None => {
+                return Err(StorageError::Pool {
+                    operation: "writer.query_all".into(),
+                    message: "connection already consumed".into(),
+                })
+            }
+        };
         let (conn, result) = tokio::task::spawn_blocking(move || {
             let res = execute_query(&conn, &statement);
             (conn, res)
@@ -1014,16 +1044,59 @@ impl khive_storage::SqlAccess for SqlBridge {
                     message: "backend is read-only".into(),
                 });
             }
-            let conn = open_standalone_writer(&self.pool)?;
-            // Best-effort: a lookup failure (no runtime context) degrades to the
-            // standalone-connection path in `execute_batch` rather than failing
-            // handle construction (mirrors every other migrated store).
-            let writer_task = self.pool.writer_task_handle().ok().flatten();
+            let db = crate::timeout_sink::db_label(&self.pool);
+            // ADR-136 D1 gate 1: queue-first. The handle lookup runs BEFORE
+            // any standalone connection is opened, and a lookup failure is
+            // propagated (never silently degraded) when strict routing is
+            // on. Only the flag-off/degraded case still opens a standalone
+            // connection.
+            let writer_task = match self.pool.writer_task_handle() {
+                Ok(handle) => handle,
+                Err(e) => {
+                    if self.pool.config().write_routing_strict {
+                        return Err(e);
+                    }
+                    tracing::warn!(
+                        error = %e,
+                        "KHIVE_WRITE_ROUTING is not strict; writer() degrades to the \
+                         standalone-connection path"
+                    );
+                    None
+                }
+            };
+            if writer_task.is_none() && self.pool.config().write_routing_strict {
+                return Err(StorageError::Pool {
+                    operation: "writer".into(),
+                    message: "KHIVE_WRITE_ROUTING=strict but no writer-task handle is \
+                              available; refusing to fall back to a direct connection"
+                        .into(),
+                });
+            }
+            if writer_task.is_none() && self.pool.config().write_queue_enabled {
+                // The queue is enabled but this call didn't get a handle
+                // (spawn/runtime degrade) — a direct-route violation in the
+                // making once this writer's execute*/query* methods run.
+                crate::timeout_sink::emit_direct_route_violation(
+                    &db,
+                    crate::timeout_sink::Site::DirectRouteSqlBridgeWriter,
+                );
+            }
+            // A standalone connection is opened only when there is no queue
+            // handle to route writes through — `SqliteWriter`'s `SqlReader`
+            // methods (`query_row`/`query_all`) lazily open one on first use
+            // in the handle-present case (no production caller reads via a
+            // `writer()` handle today; see `SqliteWriter::ensure_conn`).
+            let conn = if writer_task.is_none() {
+                Some(open_standalone_writer(&self.pool)?)
+            } else {
+                None
+            };
             Ok(Box::new(SqliteWriter {
-                conn: Some(conn),
+                conn,
                 writer_task,
                 origin: self.pool.origin(),
-                db: crate::timeout_sink::db_label(&self.pool),
+                db,
+                pool: Arc::clone(&self.pool),
             }))
         } else {
             Ok(Box::new(PoolBackedWriter {
@@ -1055,8 +1128,25 @@ impl khive_storage::SqlAccess for SqlBridge {
             }
             // Best-effort, same guard `writer()` uses: `Ok(None)` on flag-off;
             // `Err(WriterTaskNoRuntime)` propagates loud rather than silently
-            // falling back to a competing connection from a sync caller.
-            if let Some(writer_task) = self.pool.writer_task_handle()? {
+            // falling back to a competing connection from a sync caller. ADR-136
+            // D1 gate 3: `Ok(None)` under strict routing is ALSO a fail-closed
+            // error (queue was requested but unavailable), not just a degrade.
+            let handle = self.pool.writer_task_handle()?;
+            if handle.is_none() && self.pool.config().write_routing_strict {
+                return Err(StorageError::Pool {
+                    operation: "atomic_unit".into(),
+                    message: "KHIVE_WRITE_ROUTING=strict but no writer-task handle is \
+                              available; refusing to fall back to a direct connection"
+                        .into(),
+                });
+            }
+            if handle.is_none() && self.pool.config().write_queue_enabled {
+                crate::timeout_sink::emit_direct_route_violation(
+                    &crate::timeout_sink::db_label(&self.pool),
+                    crate::timeout_sink::Site::DirectRouteAtomicUnit,
+                );
+            }
+            if let Some(writer_task) = handle {
                 // Flag-on: ONE queued WriteRequest. `run_writer_task` already
                 // has an open `BEGIN IMMEDIATE` on its dedicated connection
                 // before this closure runs and issues `COMMIT`/`ROLLBACK`
@@ -1092,6 +1182,7 @@ impl khive_storage::SqlAccess for SqlBridge {
                 writer_task: None,
                 origin: self.pool.origin(),
                 db: crate::timeout_sink::db_label(&self.pool),
+                pool: Arc::clone(&self.pool),
             };
             run_manual_atomic_unit(&mut writer, op, self.pool.origin()).await
         } else {
@@ -1355,6 +1446,188 @@ mod tests {
             matches!(count, Some(SqlValue::Integer(1))),
             "the well-behaved atomic_unit call after the Pending misuse must \
              have actually committed its write; got {count:?}"
+        );
+    }
+
+    /// ADR-136 D1 gate 1/3: with `KHIVE_WRITE_ROUTING=strict` and no writer
+    /// task available, `SqlBridge::writer()` must error instead of silently
+    /// degrading to a standalone connection — even when the reason no handle
+    /// exists is simply that the queue itself was never enabled. Strict
+    /// routing without an enabled queue is a caller misconfiguration this
+    /// gate refuses rather than silently no-ops: an operator who set
+    /// `KHIVE_WRITE_ROUTING=strict` believing every write is single-admission
+    /// must be told loudly if `KHIVE_WRITE_QUEUE` was never turned on, not
+    /// left thinking strict routing is in effect when it is not.
+    #[tokio::test]
+    async fn writer_strict_routing_fails_closed_without_writer_task() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("strict_writer.db");
+        let config = PoolConfig {
+            path: Some(path),
+            write_queue_enabled: false,
+            write_routing_strict: true,
+            ..PoolConfig::default()
+        };
+        let pool = Arc::new(ConnectionPool::new(config).unwrap());
+        let bridge = SqlBridge::new(Arc::clone(&pool), true);
+
+        let result = bridge.writer().await;
+        let err = match result {
+            Ok(_) => panic!(
+                "KHIVE_WRITE_ROUTING=strict with no writer task must fail closed, not \
+                 silently degrade to a standalone connection"
+            ),
+            Err(e) => e,
+        };
+        assert!(
+            err.to_string().contains("strict"),
+            "error must name strict routing, got: {err}"
+        );
+    }
+
+    /// ADR-136 D1 gate 3/4: with `KHIVE_WRITE_ROUTING=strict` and no writer
+    /// task available, `SqlBridge::atomic_unit` must error instead of
+    /// silently falling back to a manual `BEGIN IMMEDIATE` on a standalone
+    /// connection.
+    #[tokio::test]
+    async fn atomic_unit_strict_routing_fails_closed_without_writer_task() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("strict_atomic_unit.db");
+        let config = PoolConfig {
+            path: Some(path),
+            write_queue_enabled: false,
+            write_routing_strict: true,
+            ..PoolConfig::default()
+        };
+        let pool = Arc::new(ConnectionPool::new(config).unwrap());
+        let bridge = SqlBridge::new(Arc::clone(&pool), true);
+
+        let op: AtomicUnitOp = Box::new(|_writer| {
+            Box::pin(async move { Ok(Box::new(()) as Box<dyn std::any::Any + Send>) })
+        });
+        let result = bridge.atomic_unit(op).await;
+        assert!(
+            result.is_err(),
+            "KHIVE_WRITE_ROUTING=strict but the queue is off (no writer task handle) must \
+             fail closed instead of falling back to a manual BEGIN IMMEDIATE; got {result:?}"
+        );
+        let msg = result.unwrap_err().to_string();
+        assert!(
+            msg.contains("strict"),
+            "error must name strict routing, got: {msg}"
+        );
+    }
+
+    /// ADR-136 D1 acceptance arm: a 5-op batch shaped like
+    /// `[send, read, read, read, read]` at the storage layer, issued while 3
+    /// concurrent writers contend the write path, must complete every op —
+    /// no checkout timeout — once routing is strict and the queue is on.
+    /// Mirrors the measured production failure ADR-136's Context section
+    /// documents (middle ops of a batch starving while a sibling write wins
+    /// under the legacy fixed-deadline pool mutex).
+    #[tokio::test]
+    async fn acceptance_five_op_batch_completes_under_concurrent_write_contention() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("acceptance_batch.db");
+        let config = PoolConfig {
+            path: Some(path),
+            write_queue_enabled: true,
+            write_routing_strict: true,
+            ..PoolConfig::default()
+        };
+        let pool = Arc::new(ConnectionPool::new(config).unwrap());
+        {
+            let guard = pool.writer().unwrap();
+            guard
+                .conn()
+                .execute_batch(
+                    "CREATE TABLE IF NOT EXISTS acceptance_batch \
+                     (id INTEGER PRIMARY KEY, val TEXT NOT NULL)",
+                )
+                .unwrap();
+        }
+
+        let bridge = Arc::new(SqlBridge::new(Arc::clone(&pool), true));
+
+        // 3 concurrent writers contending the write path — each a
+        // self-contained `execute()` through `SqlBridge::writer()`, matching
+        // the "several short acquisitions" shape ADR-136's Context section
+        // measures (a logical write is many short holds, not one long one).
+        let contenders: Vec<_> = (0..3)
+            .map(|i| {
+                let bridge = Arc::clone(&bridge);
+                tokio::spawn(async move {
+                    let mut writer = bridge.writer().await?;
+                    writer
+                        .execute(SqlStatement {
+                            sql: "INSERT INTO acceptance_batch (id, val) VALUES (?1, ?2)".into(),
+                            params: vec![
+                                SqlValue::Integer(100 + i),
+                                SqlValue::Text(format!("contender-{i}")),
+                            ],
+                            label: None,
+                        })
+                        .await
+                })
+            })
+            .collect();
+
+        // The 5-op batch: [send, read, read, read, read].
+        let send = {
+            let bridge = Arc::clone(&bridge);
+            tokio::spawn(async move {
+                let mut writer = bridge.writer().await?;
+                writer
+                    .execute(SqlStatement {
+                        sql: "INSERT INTO acceptance_batch (id, val) VALUES (?1, ?2)".into(),
+                        params: vec![SqlValue::Integer(1), SqlValue::Text("send".into())],
+                        label: None,
+                    })
+                    .await
+            })
+        };
+        let reads: Vec<_> = (0..4)
+            .map(|_| {
+                let bridge = Arc::clone(&bridge);
+                tokio::spawn(async move {
+                    let mut reader = bridge.reader().await?;
+                    reader
+                        .query_scalar(SqlStatement {
+                            sql: "SELECT COUNT(*) FROM acceptance_batch".into(),
+                            params: vec![],
+                            label: None,
+                        })
+                        .await
+                })
+            })
+            .collect();
+
+        for c in contenders {
+            c.await
+                .expect("contender task must not panic")
+                .expect("contender write must complete without a checkout timeout");
+        }
+        send.await
+            .expect("send task must not panic")
+            .expect("send op must complete without a checkout timeout");
+        for r in reads {
+            r.await
+                .expect("read task must not panic")
+                .expect("read op must complete without a checkout timeout — no starvation");
+        }
+
+        let mut reader = bridge.reader().await.unwrap();
+        let count = reader
+            .query_scalar(SqlStatement {
+                sql: "SELECT COUNT(*) FROM acceptance_batch".into(),
+                params: vec![],
+                label: None,
+            })
+            .await
+            .unwrap();
+        assert!(
+            matches!(count, Some(SqlValue::Integer(4))),
+            "all 3 contenders plus the batch's own send must have committed; got {count:?}"
         );
     }
 }

--- a/crates/khive-db/src/stores/text.rs
+++ b/crates/khive-db/src/stores/text.rs
@@ -23,6 +23,36 @@ use crate::pool::ConnectionPool;
 use crate::sql_bridge::bind_params;
 use crate::writer_task::WriterTaskHandle;
 
+/// ADR-136 D1 gate 3: called immediately before a `with_writer_unmanaged`
+/// fallback so this store's one remaining direct-writer call site
+/// (`rename_namespace`) fails closed under strict routing instead of
+/// silently bypassing an enabled queue. Under non-strict routing this is a
+/// no-op except for a `direct_route_violation` sink row when the queue is
+/// enabled (ADR-136 D1 gate 6c) — observable, but not yet fatal. Mirrors
+/// `stores::vectors::refuse_direct_route_if_strict`; kept as a separate copy
+/// rather than a shared export to avoid coupling the two stores' internals.
+fn refuse_direct_route_if_strict(
+    pool: &ConnectionPool,
+    site: crate::timeout_sink::Site,
+    op: &'static str,
+) -> Result<(), StorageError> {
+    if pool.config().write_routing_strict {
+        return Err(StorageError::Pool {
+            operation: op.into(),
+            message: "KHIVE_WRITE_ROUTING=strict but no writer-task handle is available; \
+                      refusing to fall back to a direct connection"
+                .into(),
+        });
+    }
+    if pool.config().write_queue_enabled {
+        crate::timeout_sink::emit_direct_route_violation(
+            &crate::timeout_sink::db_label(pool),
+            site,
+        );
+    }
+    Ok(())
+}
+
 /// The exact `DELETE` this store's `delete_document` issues, for a given
 /// FTS table (ADR-099 B3 r6 structural cut — see `entity.rs`'s sibling
 /// block). `table` must already be a trusted, sanitized table name (this
@@ -1416,84 +1446,128 @@ impl Fts5TextSearch {
         let old_ns = old_namespace.to_string();
         let new_ns = new_namespace.to_string();
 
+        // ADR-136 D1 gate 2: queue-first, DML-only closure. `run_writer_task`
+        // already owns the enclosing `BEGIN IMMEDIATE`/`COMMIT`/`ROLLBACK` for
+        // this request, so the SELECT enumerating rows-to-move runs INSIDE
+        // that same transaction as the DELETE+INSERT that consumes it —
+        // closing the TOCTOU window the pre-migration path had (its SELECT
+        // ran before its own `BEGIN IMMEDIATE`, so a writer landing between
+        // the two could resurrect a stale row or lose one mid-rename).
+        if let Some(writer_task) = &self.writer_task {
+            let table2 = table.clone();
+            return writer_task
+                .send(move |conn| {
+                    rename_namespace_dml(conn, &table2, &old_ns, &new_ns)
+                        .map_err(|e| map_err(e, "fts_rename_namespace"))
+                })
+                .await;
+        }
+
+        refuse_direct_route_if_strict(
+            &self.pool,
+            crate::timeout_sink::Site::DirectRouteFtsRenameNamespace,
+            "fts_rename_namespace",
+        )?;
+
         let origin = self.pool.origin();
         self.with_writer_unmanaged("fts_rename_namespace", move |conn| {
-            let sel_sql = format!(
-                "SELECT subject_id, kind, title, body, tags, metadata, updated_at \
-                 FROM {} WHERE namespace = ?1",
-                table
-            );
-            struct Row {
-                subject_id: String,
-                kind: String,
-                title: String,
-                body: String,
-                tags: String,
-                metadata: Option<String>,
-                updated_at: i64,
-            }
-            let rows: Vec<Row> = {
-                let mut stmt = conn.prepare(&sel_sql)?;
-                let iter = stmt.query_map(rusqlite::params![&old_ns], |row| {
-                    Ok(Row {
-                        subject_id: row.get(0)?,
-                        kind: row.get(1)?,
-                        title: row.get(2)?,
-                        body: row.get(3)?,
-                        tags: row.get(4)?,
-                        metadata: row.get(5)?,
-                        updated_at: row.get(6)?,
-                    })
-                })?;
-                iter.collect::<Result<Vec<_>, _>>()?
-            };
-            let moved = rows.len() as u64;
-            if moved == 0 {
-                return Ok(0u64);
-            }
-
             conn.execute_batch("BEGIN IMMEDIATE")?;
             let _tx_handle = khive_storage::tx_registry::register_scoped(
                 Some("text_rename_namespace".to_string()),
                 origin,
             );
-
-            let del_sql = format!("DELETE FROM {} WHERE namespace = ?1", table);
-            if let Err(e) = conn.execute(&del_sql, rusqlite::params![&old_ns]) {
-                let _ = conn.execute_batch("ROLLBACK");
-                return Err(e);
-            }
-
-            let ins_sql = format!(
-                "INSERT INTO {} \
-                 (subject_id, kind, title, body, tags, namespace, metadata, updated_at) \
-                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
-                table
-            );
-            for row in &rows {
-                if let Err(e) = conn.execute(
-                    &ins_sql,
-                    rusqlite::params![
-                        row.subject_id,
-                        row.kind,
-                        row.title,
-                        row.body,
-                        row.tags,
-                        &new_ns,
-                        row.metadata,
-                        row.updated_at,
-                    ],
-                ) {
+            // The SELECT now runs inside this same `BEGIN IMMEDIATE` — same
+            // TOCTOU fix as the queue path above, applied to the legacy
+            // standalone-connection path too.
+            match rename_namespace_dml(conn, &table, &old_ns, &new_ns) {
+                Ok(moved) => {
+                    conn.execute_batch("COMMIT")?;
+                    Ok(moved)
+                }
+                Err(e) => {
                     let _ = conn.execute_batch("ROLLBACK");
-                    return Err(e);
+                    Err(e)
                 }
             }
-
-            conn.execute_batch("COMMIT")?;
-            Ok(moved)
         })
         .await
     }
+}
+
+struct FtsRenameRow {
+    subject_id: String,
+    kind: String,
+    title: String,
+    body: String,
+    tags: String,
+    metadata: Option<String>,
+    updated_at: i64,
+}
+
+/// Move every FTS5 document row from `old_ns` to `new_ns` in `table`.
+/// DML-only — issues no `BEGIN`/`COMMIT`/`ROLLBACK` of its own, so it is safe
+/// to call both inside an already-open transaction (the `WriterTask` queue
+/// path) and wrapped by a caller-managed one (the legacy standalone path).
+/// The `SELECT` enumerating rows-to-move and the `DELETE`+`INSERT` that
+/// consumes it always run inside the SAME transaction the caller opened —
+/// see `Fts5TextSearch::rename_namespace`'s TOCTOU note.
+fn rename_namespace_dml(
+    conn: &rusqlite::Connection,
+    table: &str,
+    old_ns: &str,
+    new_ns: &str,
+) -> Result<u64, rusqlite::Error> {
+    let sel_sql = format!(
+        "SELECT subject_id, kind, title, body, tags, metadata, updated_at \
+         FROM {} WHERE namespace = ?1",
+        table
+    );
+    let rows: Vec<FtsRenameRow> = {
+        let mut stmt = conn.prepare(&sel_sql)?;
+        let iter = stmt.query_map(rusqlite::params![old_ns], |row| {
+            Ok(FtsRenameRow {
+                subject_id: row.get(0)?,
+                kind: row.get(1)?,
+                title: row.get(2)?,
+                body: row.get(3)?,
+                tags: row.get(4)?,
+                metadata: row.get(5)?,
+                updated_at: row.get(6)?,
+            })
+        })?;
+        iter.collect::<Result<Vec<_>, _>>()?
+    };
+    let moved = rows.len() as u64;
+    if moved == 0 {
+        return Ok(0);
+    }
+
+    let del_sql = format!("DELETE FROM {} WHERE namespace = ?1", table);
+    conn.execute(&del_sql, rusqlite::params![old_ns])?;
+
+    let ins_sql = format!(
+        "INSERT INTO {} \
+         (subject_id, kind, title, body, tags, namespace, metadata, updated_at) \
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
+        table
+    );
+    for row in &rows {
+        conn.execute(
+            &ins_sql,
+            rusqlite::params![
+                row.subject_id,
+                row.kind,
+                row.title,
+                row.body,
+                row.tags,
+                new_ns,
+                row.metadata,
+                row.updated_at,
+            ],
+        )?;
+    }
+
+    Ok(moved)
 }
 
 #[cfg(test)]

--- a/crates/khive-db/src/stores/text.rs
+++ b/crates/khive-db/src/stores/text.rs
@@ -181,6 +181,21 @@ impl Fts5TextSearch {
             .map_err(|e| map_sqlite_err(e, "open_fts_reader"))
     }
 
+    /// Re-derive writer-task availability at write time instead of trusting
+    /// only the field cached at construction (ADR-136 D1 gate 3 amendment).
+    /// `self.writer_task` permanently caches `None` when this store was
+    /// constructed outside a Tokio runtime (`writer_task_handle()` returns
+    /// `Err(WriterTaskNoRuntime)`, which construction collapses via
+    /// `.ok().flatten()`) — every later write, even ones running inside a
+    /// runtime, would otherwise silently keep bypassing an enabled queue.
+    /// `ConnectionPool::writer_task_handle()` is a cheap `OnceCell` read once
+    /// resolved, so re-checking here costs nothing on the hot path.
+    fn current_writer_task(&self) -> Option<WriterTaskHandle> {
+        self.writer_task
+            .clone()
+            .or_else(|| self.pool.writer_task_handle().ok().flatten())
+    }
+
     /// Route a single-row write through the pool-wide `WriterTask` when
     /// `KHIVE_WRITE_QUEUE=1` and a handle is available; otherwise fall back
     /// to the legacy standalone-connection / pool-mutex path (ADR-067
@@ -192,12 +207,17 @@ impl Fts5TextSearch {
         F: FnOnce(&rusqlite::Connection) -> Result<R, rusqlite::Error> + Send + 'static,
         R: Send + 'static,
     {
-        if let Some(writer_task) = &self.writer_task {
+        if let Some(writer_task) = self.current_writer_task() {
             return writer_task
                 .send(move |conn| f(conn).map_err(|e| map_err(e, op)))
                 .await;
         }
 
+        refuse_direct_route_if_strict(
+            &self.pool,
+            crate::timeout_sink::Site::DirectRouteFtsGeneralWrite,
+            op,
+        )?;
         self.with_writer_unmanaged(op, f).await
     }
 
@@ -777,8 +797,13 @@ impl TextSearch for Fts5TextSearch {
         // ADR-067 Component A: when the write queue is enabled, route
         // through the pool-wide WriterTask. DML-only closure — no BEGIN
         // IMMEDIATE/COMMIT/ROLLBACK here, since the WriterTask's run loop
-        // owns the transaction.
-        if let Some(writer_task) = &self.writer_task {
+        // owns the transaction. `current_writer_task()` (ADR-136 D1 gate 3
+        // amendment) re-checks past a construction-time `None` cache so a
+        // handle that only became available later is still used here rather
+        // than falling to `with_writer`'s BEGIN-IMMEDIATE-wrapped closure
+        // below (that closure is not safe to send through the queue, which
+        // already wraps its own transaction).
+        if let Some(writer_task) = self.current_writer_task() {
             let table2 = table.clone();
             return writer_task
                 .send(move |conn| {
@@ -820,8 +845,10 @@ impl TextSearch for Fts5TextSearch {
         // through the pool-wide WriterTask. DML-only closure (the per-row
         // `SAVEPOINT fts_upsert_doc` is preserved unchanged — only the OUTER
         // BEGIN IMMEDIATE/COMMIT is removed, since the WriterTask's run loop
-        // owns the enclosing transaction).
-        if let Some(writer_task) = &self.writer_task {
+        // owns the enclosing transaction). `current_writer_task()` re-checks
+        // past a construction-time `None` cache — see `upsert_document`'s
+        // matching note.
+        if let Some(writer_task) = self.current_writer_task() {
             let table2 = table.clone();
             return writer_task
                 .send(move |conn| {

--- a/crates/khive-db/src/stores/text_tests.rs
+++ b/crates/khive-db/src/stores/text_tests.rs
@@ -2644,3 +2644,115 @@ async fn rename_namespace_strict_routing_fails_closed_without_writer_task() {
         "error must name strict routing, got: {err}"
     );
 }
+
+/// ADR-136 D1 gate 3 amendment: a store built on a thread with no ambient
+/// Tokio runtime caches `writer_task: None` at construction — the pool
+/// returns `Err(WriterTaskNoRuntime)`, which `Fts5TextSearch::new` collapses
+/// via `.ok().flatten()` (a documented, deliberate best-effort degrade). The
+/// bug this guards against: without `with_writer`'s write-time re-lookup
+/// (`current_writer_task`), that construction-time `None` would stick
+/// forever, so a *normal* FTS write (`upsert_document`, routed through the
+/// general `with_writer` helper, not a maintenance path) issued later inside
+/// a real runtime would silently bypass the queue via the direct-connection
+/// path instead of routing through the shared `WriterTask` like every other
+/// write on this pool. Same occupier / `queue_depth()` discriminator as
+/// `rename_namespace_routes_through_writer_task_when_flag_enabled` above,
+/// proving genuine queue routing rather than a `writer_task_spawn_count() ==
+/// 1` false positive.
+///
+/// Deliberately `#[test]`, not `#[tokio::test]`: construction must happen
+/// with no ambient runtime, which a `#[tokio::test]` function body would
+/// not give it (the whole test body already runs on a Tokio worker thread).
+/// Red-proof: reverting `with_writer`'s `self.current_writer_task()` check
+/// back to `&self.writer_task` makes `saw_enqueued` stay `false` and this
+/// test fail — the write takes the direct-connection path immediately
+/// instead of ever appearing in the writer task's channel.
+#[test]
+fn general_write_routes_through_writer_task_when_store_built_outside_runtime() {
+    let table_key = "general_write_no_runtime_construction";
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("general_write_no_runtime_construction.db");
+    let pool_cfg = PoolConfig {
+        path: Some(path.clone()),
+        write_queue_enabled: true,
+        ..PoolConfig::default()
+    };
+    let pool = Arc::new(ConnectionPool::new(pool_cfg).unwrap());
+    {
+        let writer = pool.writer().unwrap();
+        ensure_fts5_schema(writer.conn(), table_key).unwrap();
+    }
+
+    assert!(
+        tokio::runtime::Handle::try_current().is_err(),
+        "sanity: this test body must not already be running inside a Tokio runtime"
+    );
+    // Construction happens here, outside any runtime — reproduces the
+    // permanent-`None`-cache scenario `writer_task_handle()`'s doc comment
+    // describes.
+    let store = Fts5TextSearch::new(Arc::clone(&pool), true, table_key.to_string());
+
+    let rt = tokio::runtime::Runtime::new().unwrap();
+    rt.block_on(async move {
+        let writer_task = pool
+            .writer_task_handle()
+            .unwrap()
+            .expect("writer task must be available now that a runtime exists");
+
+        let (started_tx, started_rx) = tokio::sync::oneshot::channel::<()>();
+        let (release_tx, release_rx) = tokio::sync::oneshot::channel::<()>();
+        let occupier = {
+            let writer_task = writer_task.clone();
+            tokio::spawn(async move {
+                writer_task
+                    .send(move |_conn| {
+                        let _ = started_tx.send(());
+                        let _ = release_rx.blocking_recv();
+                        Ok::<(), StorageError>(())
+                    })
+                    .await
+            })
+        };
+        started_rx
+            .await
+            .expect("occupier must signal it has started running inside the writer task");
+        assert_eq!(
+            writer_task.queue_depth(),
+            0,
+            "channel must start empty once the occupier has been dequeued and is running"
+        );
+
+        let write_task = tokio::spawn(async move {
+            store
+                .upsert_document(make_document(Uuid::new_v4(), "outside-runtime", "body"))
+                .await
+        });
+
+        let mut saw_enqueued = false;
+        for _ in 0..100 {
+            if writer_task.queue_depth() >= 1 {
+                saw_enqueued = true;
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+        }
+        assert!(
+            saw_enqueued,
+            "upsert_document's write request never appeared in the writer task's channel \
+             while the occupier held the single drain slot — a store built outside a \
+             runtime is not re-checking writer-task availability at write time"
+        );
+
+        release_tx
+            .send(())
+            .expect("occupier must still be waiting on the release signal");
+        occupier
+            .await
+            .expect("occupier task must not panic")
+            .expect("occupier write must succeed");
+        write_task
+            .await
+            .expect("write task must not panic")
+            .expect("upsert_document must succeed once unblocked");
+    });
+}

--- a/crates/khive-db/src/stores/text_tests.rs
+++ b/crates/khive-db/src/stores/text_tests.rs
@@ -2519,3 +2519,128 @@ async fn test_search_rank_within_cap_counts_two_fts_passes() {
 
     assert_eq!(ctx.snapshot()["fts_passes"], 2);
 }
+
+/// ADR-136 D1 gate 2/4: `rename_namespace`'s flag-on path must route through
+/// the pool-wide `WriterTask`, not `with_writer_unmanaged`'s
+/// standalone-connection path, when the write queue is enabled — same
+/// occupier / `queue_depth()` technique as
+/// `upsert_documents_routes_through_writer_task_when_flag_enabled` above (a
+/// `writer_task_spawn_count() == 1` assertion alone is a false positive:
+/// `upsert_document` setup calls already spawn/use the task). Red-proof:
+/// reverting the `if let Some(writer_task) = &self.writer_task` branch in
+/// `rename_namespace` (forcing every call through `with_writer_unmanaged`)
+/// makes `saw_enqueued` stay `false` and this test fail — see the impl
+/// report for the exact revert/run/restore transcript.
+#[tokio::test]
+async fn rename_namespace_routes_through_writer_task_when_flag_enabled() {
+    let table_key = "write_queue_rename_namespace";
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("write_queue_rename_namespace.db");
+    let pool_cfg = PoolConfig {
+        path: Some(path.clone()),
+        write_queue_enabled: true,
+        ..PoolConfig::default()
+    };
+    let pool = Arc::new(ConnectionPool::new(pool_cfg).unwrap());
+    {
+        let writer = pool.writer().unwrap();
+        ensure_fts5_schema(writer.conn(), table_key).unwrap();
+    }
+
+    let store = Fts5TextSearch::new(Arc::clone(&pool), true, table_key.to_string());
+
+    let subject = Uuid::new_v4();
+    let mut doc = make_document(subject, "Doc A", "body a");
+    doc.namespace = "old_ns".to_string();
+    store.upsert_document(doc).await.unwrap();
+
+    let writer_task = pool
+        .writer_task_handle()
+        .unwrap()
+        .expect("writer task must be spawned for a file-backed pool with the flag on");
+
+    let (started_tx, started_rx) = tokio::sync::oneshot::channel::<()>();
+    let (release_tx, release_rx) = tokio::sync::oneshot::channel::<()>();
+    let occupier = {
+        let writer_task = writer_task.clone();
+        tokio::spawn(async move {
+            writer_task
+                .send(move |_conn| {
+                    let _ = started_tx.send(());
+                    let _ = release_rx.blocking_recv();
+                    Ok::<(), StorageError>(())
+                })
+                .await
+        })
+    };
+
+    started_rx
+        .await
+        .expect("occupier must signal it has started running inside the writer task");
+    assert_eq!(
+        writer_task.queue_depth(),
+        0,
+        "channel must start empty once the occupier has been dequeued and is running"
+    );
+
+    let rename_task = tokio::spawn(async move { store.rename_namespace("old_ns", "new_ns").await });
+
+    let mut saw_enqueued = false;
+    for _ in 0..100 {
+        if writer_task.queue_depth() >= 1 {
+            saw_enqueued = true;
+            break;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+    }
+    assert!(
+        saw_enqueued,
+        "rename_namespace's write request never appeared in the writer task's channel \
+         while the occupier held the single drain slot — rename_namespace is not routing \
+         through the shared writer task"
+    );
+
+    release_tx
+        .send(())
+        .expect("occupier must still be waiting on the release signal");
+    occupier
+        .await
+        .expect("occupier task must not panic")
+        .expect("occupier write must succeed");
+    let moved = rename_task
+        .await
+        .expect("rename task must not panic")
+        .expect("rename_namespace must succeed once unblocked");
+    assert_eq!(moved, 1);
+}
+
+/// ADR-136 D1 gate 3/4: with `KHIVE_WRITE_ROUTING=strict` and no writer task
+/// available, `rename_namespace` must error instead of silently falling back
+/// to `with_writer_unmanaged`'s standalone-connection path.
+#[tokio::test]
+async fn rename_namespace_strict_routing_fails_closed_without_writer_task() {
+    let table_key = "strict_rename_namespace";
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("strict_rename_namespace.db");
+    let pool_cfg = PoolConfig {
+        path: Some(path.clone()),
+        write_queue_enabled: false,
+        write_routing_strict: true,
+        ..PoolConfig::default()
+    };
+    let pool = Arc::new(ConnectionPool::new(pool_cfg).unwrap());
+    {
+        let writer = pool.writer().unwrap();
+        ensure_fts5_schema(writer.conn(), table_key).unwrap();
+    }
+
+    let store = Fts5TextSearch::new(Arc::clone(&pool), true, table_key.to_string());
+    let err = store.rename_namespace("old_ns", "new_ns").await.expect_err(
+        "KHIVE_WRITE_ROUTING=strict with no writer task must fail closed, not silently \
+             fall back to with_writer_unmanaged",
+    );
+    assert!(
+        err.to_string().contains("strict"),
+        "error must name strict routing, got: {err}"
+    );
+}

--- a/crates/khive-db/src/stores/vectors.rs
+++ b/crates/khive-db/src/stores/vectors.rs
@@ -22,6 +22,34 @@ use crate::error::SqliteError;
 use crate::pool::ConnectionPool;
 use crate::sql_bridge::bind_params;
 
+/// ADR-136 D1 gate 3: called immediately before a `with_writer_unmanaged`
+/// fallback so this store's two remaining direct-writer call sites
+/// (`vec_delete_subjects`, `orphan_sweep`) fail closed under strict routing
+/// instead of silently bypassing an enabled queue. Under non-strict routing
+/// this is a no-op except for a `direct_route_violation` sink row when the
+/// queue is enabled (ADR-136 D1 gate 6c) — observable, but not yet fatal.
+fn refuse_direct_route_if_strict(
+    pool: &ConnectionPool,
+    site: crate::timeout_sink::Site,
+    op: &'static str,
+) -> Result<(), StorageError> {
+    if pool.config().write_routing_strict {
+        return Err(StorageError::Pool {
+            operation: op.into(),
+            message: "KHIVE_WRITE_ROUTING=strict but no writer-task handle is available; \
+                      refusing to fall back to a direct connection"
+                .into(),
+        });
+    }
+    if pool.config().write_queue_enabled {
+        crate::timeout_sink::emit_direct_route_violation(
+            &crate::timeout_sink::db_label(pool),
+            site,
+        );
+    }
+    Ok(())
+}
+
 /// The exact `DELETE` this store's `delete` issues, for a given vector table
 /// (ADR-099 B3 r6 structural cut — see `stores::entity`'s sibling block).
 /// `table` must already be a trusted, sanitized table name (mirrors
@@ -1332,6 +1360,11 @@ impl VectorStore for SqliteVecStore {
         // outermost SAVEPOINT. `Transaction` rolls back on early DML errors and
         // also when COMMIT fails while SQLite leaves the transaction open,
         // preventing a poisoned transaction from returning to the pool.
+        refuse_direct_route_if_strict(
+            &self.pool,
+            crate::timeout_sink::Site::DirectRouteVecDeleteSubjects,
+            "vec_delete_subjects",
+        )?;
         let table_for_error = table.clone();
         let origin = self.pool.origin();
         self.with_writer_unmanaged("vec_delete_subjects", move |conn| {
@@ -1469,6 +1502,11 @@ impl VectorStore for SqliteVecStore {
         // Flag-off (default) path: byte-for-byte unchanged from pre-ADR-067
         // behavior — the closure owns its own transaction via
         // `Transaction::new_unchecked`.
+        refuse_direct_route_if_strict(
+            &self.pool,
+            crate::timeout_sink::Site::DirectRouteOrphanSweep,
+            "orphan_sweep",
+        )?;
         let origin = self.pool.origin();
         self.with_writer_unmanaged("orphan_sweep", move |conn| {
             // `Transaction::new_unchecked` issues `BEGIN IMMEDIATE` and RAII-manages
@@ -4647,6 +4685,212 @@ mod write_queue_tests {
             msg.contains("cannot start a transaction within a transaction"),
             "expected the deterministic nested-transaction failure (SQLite's own message \
              for a second BEGIN issued inside an already-open transaction), got: {msg}"
+        );
+    }
+
+    /// ADR-136 D1 gate 2/4: `vec_delete_subjects`'s flag-on path must route
+    /// through the pool-wide `WriterTask`, not `with_writer_unmanaged`'s
+    /// pool-mutex path, when the write queue is enabled — same occupier /
+    /// `queue_depth()` technique as
+    /// `orphan_sweep_routes_through_writer_task_when_flag_enabled` above (a
+    /// `writer_task_spawn_count() == 1` assertion alone is a false positive:
+    /// `SqliteVecStore::new` and the setup insert already spawn/use the
+    /// task). Red-proof: reverting the `if let Some(writer_task) =
+    /// &self.writer_task` branch in `vec_delete_subjects` (forcing every
+    /// call through `with_writer_unmanaged`) makes `saw_enqueued` stay
+    /// `false` and this test fail — see the impl report for the exact
+    /// revert/run/restore transcript.
+    #[tokio::test]
+    async fn vec_delete_subjects_routes_through_writer_task_when_flag_enabled() {
+        crate::extension::ensure_extensions_loaded();
+
+        let model_key = "write_queue_vec_delete_subjects";
+        let dims = 4usize;
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("write_queue_vec_delete_subjects.db");
+        let pool = Arc::new(
+            ConnectionPool::new(PoolConfig {
+                path: Some(path),
+                write_queue_enabled: true,
+                ..PoolConfig::default()
+            })
+            .expect("file-backed pool"),
+        );
+        create_vec_table(&pool, model_key, dims);
+
+        let store = SqliteVecStore::new(
+            Arc::clone(&pool),
+            true,
+            model_key.to_string(),
+            model_key.to_string(),
+            dims,
+            "ns:test".to_string(),
+        )
+        .expect("SqliteVecStore::new");
+
+        let id = Uuid::new_v4();
+        store
+            .insert(
+                id,
+                SubstrateKind::Entity,
+                "ns:test",
+                "body",
+                vec![vec![0.1, 0.2, 0.3, 0.4]],
+            )
+            .await
+            .expect("insert vector");
+
+        let writer_task = pool
+            .writer_task_handle()
+            .expect("writer task handle")
+            .expect("writer task must be spawned for a file-backed pool with the flag on");
+
+        let (started_tx, started_rx) = tokio::sync::oneshot::channel::<()>();
+        let (release_tx, release_rx) = tokio::sync::oneshot::channel::<()>();
+        let occupier = {
+            let writer_task = writer_task.clone();
+            tokio::spawn(async move {
+                writer_task
+                    .send(move |_conn| {
+                        let _ = started_tx.send(());
+                        let _ = release_rx.blocking_recv();
+                        Ok::<(), StorageError>(())
+                    })
+                    .await
+            })
+        };
+
+        started_rx
+            .await
+            .expect("occupier must signal it has started running inside the writer task");
+        assert_eq!(
+            writer_task.queue_depth(),
+            0,
+            "channel must start empty once the occupier has been dequeued and is running"
+        );
+
+        let delete_task = tokio::spawn(async move { store.delete_subjects(&[id]).await });
+
+        let mut saw_enqueued = false;
+        for _ in 0..100 {
+            if writer_task.queue_depth() >= 1 {
+                saw_enqueued = true;
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(5)).await;
+        }
+        assert!(
+            saw_enqueued,
+            "vec_delete_subjects's write request never appeared in the writer task's channel \
+             while the occupier held the single drain slot — vec_delete_subjects is not \
+             routing through the shared writer task"
+        );
+
+        release_tx
+            .send(())
+            .expect("occupier must still be waiting on the release signal");
+        occupier
+            .await
+            .expect("occupier task must not panic")
+            .expect("occupier write must succeed");
+        let deleted = delete_task
+            .await
+            .expect("delete task must not panic")
+            .expect("vec_delete_subjects must succeed once unblocked");
+        assert_eq!(deleted, 1);
+    }
+
+    /// ADR-136 D1 gate 3/4: with `KHIVE_WRITE_ROUTING=strict` and no writer
+    /// task available, `vec_delete_subjects` must error instead of silently
+    /// falling back to `with_writer_unmanaged`'s pool-mutex path.
+    #[tokio::test]
+    async fn vec_delete_subjects_strict_routing_fails_closed_without_writer_task() {
+        crate::extension::ensure_extensions_loaded();
+
+        let model_key = "strict_vec_delete_subjects";
+        let dims = 4usize;
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("strict_vec_delete_subjects.db");
+        let pool = Arc::new(
+            ConnectionPool::new(PoolConfig {
+                path: Some(path),
+                write_queue_enabled: false,
+                write_routing_strict: true,
+                ..PoolConfig::default()
+            })
+            .expect("file-backed pool"),
+        );
+        create_vec_table(&pool, model_key, dims);
+
+        let store = SqliteVecStore::new(
+            Arc::clone(&pool),
+            true,
+            model_key.to_string(),
+            model_key.to_string(),
+            dims,
+            "ns:test".to_string(),
+        )
+        .expect("SqliteVecStore::new");
+
+        let id = Uuid::new_v4();
+        let err = store.delete_subjects(&[id]).await.expect_err(
+            "KHIVE_WRITE_ROUTING=strict with no writer task must fail closed, not silently \
+             fall back to with_writer_unmanaged",
+        );
+        assert!(
+            err.to_string().contains("strict"),
+            "error must name strict routing, got: {err}"
+        );
+    }
+
+    /// ADR-136 D1 gate 3/4: same fail-closed contract as
+    /// `vec_delete_subjects_strict_routing_fails_closed_without_writer_task`,
+    /// for `orphan_sweep`'s own `with_writer_unmanaged` fallback.
+    #[tokio::test]
+    async fn orphan_sweep_strict_routing_fails_closed_without_writer_task() {
+        crate::extension::ensure_extensions_loaded();
+
+        let model_key = "strict_orphan_sweep";
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("strict_orphan_sweep.db");
+        let pool = Arc::new(
+            ConnectionPool::new(PoolConfig {
+                path: Some(path),
+                write_queue_enabled: false,
+                write_routing_strict: true,
+                ..PoolConfig::default()
+            })
+            .expect("file-backed pool"),
+        );
+        create_substrate_tables(&pool);
+        create_vec_table(&pool, model_key, 4);
+
+        let store = SqliteVecStore::new(
+            Arc::clone(&pool),
+            true,
+            model_key.to_string(),
+            model_key.to_string(),
+            4,
+            "ns:test".to_string(),
+        )
+        .expect("SqliteVecStore::new");
+
+        let err = store
+            .orphan_sweep(&OrphanSweepConfig {
+                subject_id_allowlist: None,
+                namespaces: vec![],
+                substrate_kinds: vec![],
+                max_delete: 100,
+                dry_run: true,
+            })
+            .await
+            .expect_err(
+                "KHIVE_WRITE_ROUTING=strict with no writer task must fail closed, not \
+                 silently fall back to with_writer_unmanaged",
+            );
+        assert!(
+            err.to_string().contains("strict"),
+            "error must name strict routing, got: {err}"
         );
     }
 }

--- a/crates/khive-db/src/stores/vectors.rs
+++ b/crates/khive-db/src/stores/vectors.rs
@@ -363,6 +363,21 @@ impl SqliteVecStore {
         Ok(conn)
     }
 
+    /// Re-derive writer-task availability at write time instead of trusting
+    /// only the field cached at construction (ADR-136 D1 gate 3 amendment).
+    /// `self.writer_task` permanently caches `None` when this store was
+    /// constructed outside a Tokio runtime (`writer_task_handle()` returns
+    /// `Err(WriterTaskNoRuntime)`, which construction collapses via
+    /// `.ok().flatten()`) — every later write, even ones running inside a
+    /// runtime, would otherwise silently keep bypassing an enabled queue.
+    /// `ConnectionPool::writer_task_handle()` is a cheap `OnceCell` read once
+    /// resolved, so re-checking here costs nothing on the hot path.
+    fn current_writer_task(&self) -> Option<crate::writer_task::WriterTaskHandle> {
+        self.writer_task
+            .clone()
+            .or_else(|| self.pool.writer_task_handle().ok().flatten())
+    }
+
     /// Route a single-row DML-only write through the pool-wide `WriterTask`
     /// when available, else fall back to `with_writer_unmanaged`. See
     /// crates/khive-db/docs/api/vectors.md#with_writer--with_writer_unmanaged--writertask-routing-adr-067-component-a-fork-c-slice-2
@@ -371,12 +386,17 @@ impl SqliteVecStore {
         F: FnOnce(&rusqlite::Connection) -> Result<R, rusqlite::Error> + Send + 'static,
         R: Send + 'static,
     {
-        if let Some(writer_task) = &self.writer_task {
+        if let Some(writer_task) = self.current_writer_task() {
             return writer_task
                 .send(move |conn| f(conn).map_err(|e| map_err(e, op)))
                 .await;
         }
 
+        refuse_direct_route_if_strict(
+            &self.pool,
+            crate::timeout_sink::Site::DirectRouteVecGeneralWrite,
+            op,
+        )?;
         self.with_writer_unmanaged(op, f).await
     }
 
@@ -908,7 +928,7 @@ impl VectorStore for SqliteVecStore {
         // named SAVEPOINT rather than `conn.unchecked_transaction()`,
         // which would attempt a nested `BEGIN` and fail under the
         // WriterTask's already-open transaction.
-        if let Some(writer_task) = &self.writer_task {
+        if let Some(writer_task) = self.current_writer_task() {
             let table2 = table.clone();
             let namespace2 = namespace.clone();
             let field2 = field.clone();
@@ -992,7 +1012,7 @@ impl VectorStore for SqliteVecStore {
         // `SAVEPOINT vec_batch_record` is preserved unchanged — only the
         // OUTER BEGIN IMMEDIATE/COMMIT is removed, since the WriterTask's
         // run loop owns the enclosing transaction).
-        if let Some(writer_task) = &self.writer_task {
+        if let Some(writer_task) = self.current_writer_task() {
             let table2 = table.clone();
             let store_embedding_model2 = store_embedding_model.clone();
             return writer_task
@@ -1078,7 +1098,7 @@ impl VectorStore for SqliteVecStore {
         // named SAVEPOINT rather than `conn.unchecked_transaction()`,
         // which would attempt a nested `BEGIN` and fail under the
         // WriterTask's already-open transaction.
-        if let Some(writer_task) = &self.writer_task {
+        if let Some(writer_task) = self.current_writer_task() {
             let table2 = table.clone();
             let namespace2 = namespace.clone();
             let field2 = field.clone();
@@ -4892,5 +4912,136 @@ mod write_queue_tests {
             err.to_string().contains("strict"),
             "error must name strict routing, got: {err}"
         );
+    }
+
+    /// ADR-136 D1 gate 3 amendment: a store built on a thread with no
+    /// ambient Tokio runtime caches `writer_task: None` at construction —
+    /// the pool returns `Err(WriterTaskNoRuntime)`, which `SqliteVecStore::
+    /// new` collapses via `.ok().flatten()` (a documented, deliberate
+    /// best-effort degrade). The bug this guards against: without
+    /// `with_writer`'s write-time re-lookup (`current_writer_task`), that
+    /// construction-time `None` would stick forever, so a *normal* vector
+    /// write (`insert`, routed through the general `with_writer` helper, not
+    /// a maintenance path) issued later inside a real runtime would silently
+    /// bypass the queue via the direct-connection path instead of routing
+    /// through the shared `WriterTask` like every other write on this pool.
+    /// Same occupier / `queue_depth()` discriminator as
+    /// `vec_delete_subjects_routes_through_writer_task_when_flag_enabled`
+    /// above, proving genuine queue routing rather than a
+    /// `writer_task_spawn_count() == 1` false positive.
+    ///
+    /// Deliberately `#[test]`, not `#[tokio::test]`: construction must
+    /// happen with no ambient runtime, which a `#[tokio::test]` function
+    /// body would not give it (the whole test body already runs on a Tokio
+    /// worker thread). Red-proof: reverting `with_writer`'s
+    /// `self.current_writer_task()` check back to `&self.writer_task` makes
+    /// `saw_enqueued` stay `false` and this test fail — the write takes the
+    /// direct-connection path immediately instead of ever appearing in the
+    /// writer task's channel.
+    #[test]
+    fn general_write_routes_through_writer_task_when_store_built_outside_runtime() {
+        crate::extension::ensure_extensions_loaded();
+
+        let model_key = "general_write_no_runtime_construction";
+        let dims = 4usize;
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("general_write_no_runtime_construction.db");
+        let pool = Arc::new(
+            ConnectionPool::new(PoolConfig {
+                path: Some(path),
+                write_queue_enabled: true,
+                ..PoolConfig::default()
+            })
+            .expect("file-backed pool"),
+        );
+        create_vec_table(&pool, model_key, dims);
+
+        assert!(
+            tokio::runtime::Handle::try_current().is_err(),
+            "sanity: this test body must not already be running inside a Tokio runtime"
+        );
+        // Construction happens here, outside any runtime — reproduces the
+        // permanent-`None`-cache scenario `writer_task_handle()`'s doc
+        // comment describes.
+        let store = SqliteVecStore::new(
+            Arc::clone(&pool),
+            true,
+            model_key.to_string(),
+            model_key.to_string(),
+            dims,
+            "ns:test".to_string(),
+        )
+        .expect("SqliteVecStore::new");
+
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        rt.block_on(async move {
+            let writer_task = pool
+                .writer_task_handle()
+                .unwrap()
+                .expect("writer task must be available now that a runtime exists");
+
+            let (started_tx, started_rx) = tokio::sync::oneshot::channel::<()>();
+            let (release_tx, release_rx) = tokio::sync::oneshot::channel::<()>();
+            let occupier = {
+                let writer_task = writer_task.clone();
+                tokio::spawn(async move {
+                    writer_task
+                        .send(move |_conn| {
+                            let _ = started_tx.send(());
+                            let _ = release_rx.blocking_recv();
+                            Ok::<(), StorageError>(())
+                        })
+                        .await
+                })
+            };
+            started_rx
+                .await
+                .expect("occupier must signal it has started running inside the writer task");
+            assert_eq!(
+                writer_task.queue_depth(),
+                0,
+                "channel must start empty once the occupier has been dequeued and is running"
+            );
+
+            let id = Uuid::new_v4();
+            let write_task = tokio::spawn(async move {
+                store
+                    .insert(
+                        id,
+                        SubstrateKind::Entity,
+                        "ns:test",
+                        "body",
+                        vec![vec![0.1, 0.2, 0.3, 0.4]],
+                    )
+                    .await
+            });
+
+            let mut saw_enqueued = false;
+            for _ in 0..100 {
+                if writer_task.queue_depth() >= 1 {
+                    saw_enqueued = true;
+                    break;
+                }
+                tokio::time::sleep(Duration::from_millis(5)).await;
+            }
+            assert!(
+                saw_enqueued,
+                "insert's write request never appeared in the writer task's channel while \
+                 the occupier held the single drain slot — a store built outside a runtime \
+                 is not re-checking writer-task availability at write time"
+            );
+
+            release_tx
+                .send(())
+                .expect("occupier must still be waiting on the release signal");
+            occupier
+                .await
+                .expect("occupier task must not panic")
+                .expect("occupier write must succeed");
+            write_task
+                .await
+                .expect("write task must not panic")
+                .expect("insert must succeed once unblocked");
+        });
     }
 }

--- a/crates/khive-db/src/timeout_sink.rs
+++ b/crates/khive-db/src/timeout_sink.rs
@@ -220,6 +220,14 @@ pub(crate) enum Site {
     /// `stores::text::rename_namespace`'s `with_writer_unmanaged` fallback,
     /// taken while the write queue is enabled.
     DirectRouteFtsRenameNamespace,
+    /// `stores::text::Fts5TextSearch::with_writer`'s general-helper
+    /// `with_writer_unmanaged` fallback, taken while the write queue is
+    /// enabled (ADR-136 D1 gate 3 amendment — the general FTS write path).
+    DirectRouteFtsGeneralWrite,
+    /// `stores::vectors::SqliteVecStore::with_writer`'s general-helper
+    /// `with_writer_unmanaged` fallback, taken while the write queue is
+    /// enabled (ADR-136 D1 gate 3 amendment — the general vector write path).
+    DirectRouteVecGeneralWrite,
 }
 
 impl Site {
@@ -235,6 +243,8 @@ impl Site {
             Site::DirectRouteVecDeleteSubjects => "direct_route:vec_delete_subjects",
             Site::DirectRouteOrphanSweep => "direct_route:orphan_sweep",
             Site::DirectRouteFtsRenameNamespace => "direct_route:fts_rename_namespace",
+            Site::DirectRouteFtsGeneralWrite => "direct_route:fts_general_write",
+            Site::DirectRouteVecGeneralWrite => "direct_route:vec_general_write",
         }
     }
 }

--- a/crates/khive-db/src/timeout_sink.rs
+++ b/crates/khive-db/src/timeout_sink.rs
@@ -205,6 +205,21 @@ pub(crate) enum Site {
     StandaloneText,
     /// A standalone writer connection opened by `sql_bridge`.
     StandaloneSqlBridge,
+    /// `SqlBridge::writer()`'s standalone-connection fallback, taken while
+    /// the write queue is enabled (ADR-136 D1 gate 6c).
+    DirectRouteSqlBridgeWriter,
+    /// `SqlBridge::atomic_unit()`'s flag-off manual-transaction fallback,
+    /// taken while the write queue is enabled (ADR-136 D1 gate 6c).
+    DirectRouteAtomicUnit,
+    /// `stores::vectors::vec_delete_subjects`'s `with_writer_unmanaged`
+    /// fallback, taken while the write queue is enabled.
+    DirectRouteVecDeleteSubjects,
+    /// `stores::vectors::orphan_sweep`'s `with_writer_unmanaged` fallback,
+    /// taken while the write queue is enabled.
+    DirectRouteOrphanSweep,
+    /// `stores::text::rename_namespace`'s `with_writer_unmanaged` fallback,
+    /// taken while the write queue is enabled.
+    DirectRouteFtsRenameNamespace,
 }
 
 impl Site {
@@ -215,19 +230,33 @@ impl Site {
             Site::StandaloneEvent => "standalone:event",
             Site::StandaloneText => "standalone:text",
             Site::StandaloneSqlBridge => "standalone:sql_bridge",
+            Site::DirectRouteSqlBridgeWriter => "direct_route:sql_bridge_writer",
+            Site::DirectRouteAtomicUnit => "direct_route:atomic_unit",
+            Site::DirectRouteVecDeleteSubjects => "direct_route:vec_delete_subjects",
+            Site::DirectRouteOrphanSweep => "direct_route:orphan_sweep",
+            Site::DirectRouteFtsRenameNamespace => "direct_route:fts_rename_namespace",
         }
     }
 }
 
-/// A fully-formatted timeout event, ready to hand off to the writer thread.
+/// A fully-formatted sink event, ready to hand off to the writer thread.
 /// Built entirely on the caller's thread (no I/O) and pushed through a
 /// bounded channel — this is the only thing a database caller path ever
-/// does. `error` is already truncated to [`MAX_ERROR_BYTES`].
+/// does. `error` is already truncated to [`MAX_ERROR_BYTES`] where present.
+///
+/// `kind` distinguishes the four durable row shapes this sink emits:
+/// `"timeout"` (a writer-admission or busy/locked timeout, carries `site` +
+/// `error`), `"queue_saturation"` (a caller-visible `WriteQueueFull`, carries
+/// `timeout_ms`), `"writer_task_retirement"` (a `WriterTask` terminal
+/// retirement, carries `error` as the retirement reason), and
+/// `"direct_route_violation"` (a direct writer acquisition bypassing an
+/// enabled queue, carries `site`).
 struct QueuedEvent {
     ts_utc: String,
+    kind: &'static str,
     db: String,
-    site: &'static str,
-    error: String,
+    site: Option<&'static str>,
+    error: Option<String>,
     timeout_ms: Option<u64>,
 }
 
@@ -538,10 +567,10 @@ fn write_event(sink: &mut AppendSink<File>, dropped: &AtomicU64, event: QueuedEv
     }
     let line = build_line(
         event.ts_utc,
-        "timeout",
+        event.kind,
         &event.db,
-        Some(event.site),
-        Some(&event.error),
+        event.site,
+        event.error.as_deref(),
         event.timeout_ms,
         None,
         None,
@@ -850,10 +879,72 @@ pub(crate) fn emit_timeout(db: &str, site: Site, error: &str, timeout_ms: Option
     };
     let event = QueuedEvent {
         ts_utc: now_rfc3339(),
+        kind: "timeout",
         db: db.to_string(),
-        site: site.as_str(),
-        error: truncate_error(error, MAX_ERROR_BYTES),
+        site: Some(site.as_str()),
+        error: Some(truncate_error(error, MAX_ERROR_BYTES)),
         timeout_ms,
+    };
+    enqueue(&handle.sender, &handle.dropped, event);
+}
+
+/// Record a `queue_saturation` event: a caller-visible
+/// `StorageError::WriteQueueFull` — the bounded `WriterTask` channel was
+/// full for the caller's whole `send_with_timeout` deadline and the request
+/// was never accepted (ADR-136 D1 gate 6a). Before this, `WriteQueueFull`
+/// reached the caller with no sink emission at all.
+pub(crate) fn emit_queue_saturation(db: &str, timeout_ms: u64) {
+    let Some(handle) = SINK.get() else {
+        return;
+    };
+    let event = QueuedEvent {
+        ts_utc: now_rfc3339(),
+        kind: "queue_saturation",
+        db: db.to_string(),
+        site: None,
+        error: None,
+        timeout_ms: Some(timeout_ms),
+    };
+    enqueue(&handle.sender, &handle.dropped, event);
+}
+
+/// Record a `writer_task_retirement` event: the `WriterTask` drain loop
+/// reached a terminal request or connection state and is closing admission
+/// permanently (ADR-136 D1 gate 6b). Before this, retirement was observable
+/// only through a `tracing::error!` line before the queue closed.
+pub(crate) fn emit_writer_task_retirement(db: &str, reason: &str) {
+    let Some(handle) = SINK.get() else {
+        return;
+    };
+    let event = QueuedEvent {
+        ts_utc: now_rfc3339(),
+        kind: "writer_task_retirement",
+        db: db.to_string(),
+        site: None,
+        error: Some(truncate_error(reason, MAX_ERROR_BYTES)),
+        timeout_ms: None,
+    };
+    enqueue(&handle.sender, &handle.dropped, event);
+}
+
+/// Record a `direct_route_violation` event: a write path acquired a writer
+/// connection directly (standalone connection or pool mutex), bypassing the
+/// `WriterTask` queue, while `PoolConfig::write_queue_enabled` was `true`
+/// (ADR-136 D1 gate 6c). Emitted on the degrade path itself — never gated on
+/// `write_routing_strict`, since strict mode turns the same condition into a
+/// caller-visible error instead of a degrade, so there is no bypass left to
+/// report there.
+pub(crate) fn emit_direct_route_violation(db: &str, site: Site) {
+    let Some(handle) = SINK.get() else {
+        return;
+    };
+    let event = QueuedEvent {
+        ts_utc: now_rfc3339(),
+        kind: "direct_route_violation",
+        db: db.to_string(),
+        site: Some(site.as_str()),
+        error: None,
+        timeout_ms: None,
     };
     enqueue(&handle.sender, &handle.dropped, event);
 }
@@ -949,9 +1040,10 @@ mod tests {
         let dropped = AtomicU64::new(0);
         let make_event = || QueuedEvent {
             ts_utc: now_rfc3339(),
+            kind: "timeout",
             db: "test-db".to_string(),
-            site: Site::PoolAdmission.as_str(),
-            error: "boom".to_string(),
+            site: Some(Site::PoolAdmission.as_str()),
+            error: Some("boom".to_string()),
             timeout_ms: Some(5),
         };
 
@@ -1125,9 +1217,10 @@ mod tests {
                 thread::spawn(move || {
                     let event = QueuedEvent {
                         ts_utc: now_rfc3339(),
+                        kind: "timeout",
                         db: "concurrent-test".to_string(),
-                        site: Site::StandaloneGraph.as_str(),
-                        error: format!("contention-{i}"),
+                        site: Some(Site::StandaloneGraph.as_str()),
+                        error: Some(format!("contention-{i}")),
                         timeout_ms: Some(i as u64),
                     };
                     enqueue(&sender, &dropped, event);
@@ -1145,10 +1238,10 @@ mod tests {
         while let Ok(event) = receiver.try_recv() {
             let line = build_line(
                 event.ts_utc,
-                "timeout",
+                event.kind,
                 &event.db,
-                Some(event.site),
-                Some(&event.error),
+                event.site,
+                event.error.as_deref(),
                 event.timeout_ms,
                 None,
                 None,

--- a/crates/khive-db/src/writer_task.rs
+++ b/crates/khive-db/src/writer_task.rs
@@ -13,6 +13,30 @@
 //! See `crates/khive-db/docs/api/writer-task.md` for migration-slice scope
 //! (which write paths currently route through this vs. the legacy
 //! pool-mutex path) and the ADR-067 component breakdown.
+//!
+//! ## ADR-136 D1 gate 5: writer classification
+//!
+//! Every connection that issues writes against a khive-db file falls into
+//! exactly one of the rows below. `SqlAccess`-reachable is the dividing
+//! line: only requests reachable through `khive_storage::SqlAccess`
+//! (`SqlBridge::writer`/`atomic_unit`, and the `stores::*` methods built on
+//! them) are subject to `PoolConfig::write_queue_enabled` /
+//! `write_routing_strict` routing at all. Everything else here is an
+//! explicit, intentional exemption — not an implicit gap left over from an
+//! incomplete migration.
+//!
+//! | Writer | Connection | `SqlAccess`-reachable | Routing |
+//! | --- | --- | --- | --- |
+//! | Request-path writes (`create`, `update`, batch upserts, …) | `WriterTaskHandle` (queue-first) or a standalone/pool-mutex connection on degrade | Yes | Queue-first (ADR-136 D1 gate 1); strict routing fails closed on degrade |
+//! | Startup / schema migrations (`migrations::run_migrations`, `apply_schema_plan`) | The pool's own writer-mutex connection (`ConnectionPool::new`, before the `WriterTask` is ever spawned) | No | Exempt — runs once at boot, before any queue handle exists to route through |
+//! | Checkpointing (`checkpoint::CheckpointConnection`) | Dedicated standalone connection, opened once at task startup (ADR-091 Amendment 5, #1652) | No | Exempt by design — the whole point of that fix was moving checkpoint I/O OFF the pool writer's admission path; routing it back through the write queue would reintroduce the contention it removed |
+//! | Recovery (`walpin` beacon/sidecar bookkeeping) | None — file-level bookkeeping (PID beacons, heartbeats) alongside the database, not a SQL connection against it | No | N/A — never acquires a database writer connection |
+//! | Top-level maintenance (`VACUUM` via `execute_script_top_level`/`WriterTaskHandle::send_top_level`) | `WriterTaskHandle`, skipping the per-request `BEGIN IMMEDIATE`/`COMMIT` wrap only | Yes | Routed through the SAME single writer owner as every other queued request — only the transaction wrap is skipped, never the queue |
+//!
+//! A `direct_route_violation` sink row (`timeout_sink::emit_direct_route_violation`,
+//! ADR-136 D1 gate 6c) is emitted ONLY for the first row's degrade path — a
+//! `SqlAccess`-reachable write that bypassed an enabled queue. The other four
+//! rows are exempt by design and never emit that row.
 
 use rusqlite::Connection;
 use std::panic::{catch_unwind, AssertUnwindSafe};
@@ -288,6 +312,11 @@ fn writer_task_terminated(request_state: WriterTaskRequestState) -> StorageError
 #[derive(Clone, Debug)]
 pub struct WriterTaskHandle {
     tx: mpsc::Sender<Box<dyn AnyWriteRequest + Send>>,
+    /// This handle's pool's writer-timeout sink identity (`timeout_sink::db_label`),
+    /// captured at spawn so `send_with_timeout`'s `WriteQueueFull` path can
+    /// report a `queue_saturation` sink row (ADR-136 D1 gate 6a) without
+    /// needing a `&ConnectionPool` reference.
+    db: String,
 }
 
 impl WriterTaskHandle {
@@ -386,9 +415,9 @@ impl WriterTaskHandle {
             Ok(Ok(reply_rx)) => reply_rx,
             Ok(Err(e)) => return Err(e),
             Err(_elapsed) => {
-                return Err(StorageError::WriteQueueFull {
-                    timeout_ms: timeout.as_millis() as u64,
-                })
+                let timeout_ms = timeout.as_millis() as u64;
+                crate::timeout_sink::emit_queue_saturation(&self.db, timeout_ms);
+                return Err(StorageError::WriteQueueFull { timeout_ms });
             }
         };
 
@@ -461,9 +490,10 @@ impl WriterTaskHandle {
 pub fn spawn(pool: &ConnectionPool, capacity: usize) -> Result<WriterTaskHandle, SqliteError> {
     let conn = pool.open_standalone_writer()?;
     let origin = pool.origin();
+    let db = crate::timeout_sink::db_label(pool);
     let (tx, rx) = mpsc::channel(capacity.max(1));
-    tokio::spawn(run_writer_task(conn, rx, origin));
-    Ok(WriterTaskHandle { tx })
+    tokio::spawn(run_writer_task(conn, rx, origin, db.clone()));
+    Ok(WriterTaskHandle { tx, db })
 }
 
 /// Permanently close admission, then reply to every request that was already
@@ -497,6 +527,7 @@ async fn run_writer_task(
     mut conn: Connection,
     mut rx: mpsc::Receiver<Box<dyn AnyWriteRequest + Send>>,
     origin: khive_storage::tx_registry::TxOrigin,
+    db: String,
 ) {
     while let Some(request) = rx.recv().await {
         let origin = origin.clone();
@@ -562,6 +593,10 @@ async fn run_writer_task(
                     "writer task reached a terminal request or connection state; closing and \
                      failing the queue without restarting"
                 );
+                crate::timeout_sink::emit_writer_task_retirement(
+                    &db,
+                    &format!("terminal request state: {request_state}"),
+                );
                 close_and_fail_queued_requests(&mut rx).await;
                 return;
             }
@@ -570,6 +605,10 @@ async fn run_writer_task(
                     error = %join_err,
                     "writer task blocking closure failed outside the request \
                      panic boundary; closing and failing the queue without restarting"
+                );
+                crate::timeout_sink::emit_writer_task_retirement(
+                    &db,
+                    &format!("blocking closure join failure: {join_err}"),
                 );
                 close_and_fail_queued_requests(&mut rx).await;
                 return;
@@ -785,7 +824,10 @@ mod tests {
         // channel is full" instead of racing a real writer task's
         // processing speed.
         let (tx, _rx) = mpsc::channel::<Box<dyn AnyWriteRequest + Send>>(1);
-        let handle = WriterTaskHandle { tx };
+        let handle = WriterTaskHandle {
+            tx,
+            db: "test".to_string(),
+        };
 
         // First send fills the sole channel slot. Its reply never arrives
         // since nothing drains `_rx`, so run it in the background.
@@ -819,7 +861,10 @@ mod tests {
     #[tokio::test]
     async fn send_with_timeout_maps_full_channel_to_write_queue_full() {
         let (tx, _rx) = mpsc::channel::<Box<dyn AnyWriteRequest + Send>>(1);
-        let handle = WriterTaskHandle { tx };
+        let handle = WriterTaskHandle {
+            tx,
+            db: "test".to_string(),
+        };
 
         let first = tokio::spawn({
             let handle = handle.clone();
@@ -1540,7 +1585,10 @@ mod tests {
         let (tx, rx) = mpsc::channel::<Box<dyn AnyWriteRequest + Send>>(4);
         drop(rx);
 
-        let handle = WriterTaskHandle { tx };
+        let handle = WriterTaskHandle {
+            tx,
+            db: "test".to_string(),
+        };
         let send_result = handle.send(|_conn| Ok::<(), StorageError>(())).await;
         assert_writer_task_terminal_state(send_result, WriterTaskRequestState::NotStarted);
 
@@ -1561,7 +1609,10 @@ mod tests {
         // The handle cannot prove whether its closure ran, so the oneshot
         // fallback must conservatively report SideEffectsUnknown.
         let (tx, mut rx) = mpsc::channel::<Box<dyn AnyWriteRequest + Send>>(1);
-        let handle = WriterTaskHandle { tx };
+        let handle = WriterTaskHandle {
+            tx,
+            db: "test".to_string(),
+        };
         let request_ran = Arc::new(AtomicBool::new(false));
         let request_ran_in_op = Arc::clone(&request_ran);
 


### PR DESCRIPTION
Implements ADR-136 D1 (strict write routing). Closes the remaining paths where a write could open a standalone connection while the WriterTask queue was available, and adds an opt-in strict mode that fails closed instead of degrading.

## Changes

- **`SqlBridge::writer()` / `atomic_unit()` are queue-first**: both now look up the shared `WriterTask` handle before opening a standalone writer connection. Under `KHIVE_WRITE_ROUTING=strict`, a missing handle (lookup error or queue not enabled) is an error, never a silent fallback.
- **Migrated the three remaining unmanaged-writer call sites**: `vec_delete_subjects` and `orphan_sweep` gain strict enforcement on their fallback branch; `rename_namespace` (FTS5) gains a queue-first branch it never had, with its SELECT+DELETE+INSERT extracted into a DML-only helper. This also fixes a TOCTOU defect: the row-enumerating SELECT previously ran outside the transaction that consumed it, so a concurrent writer could resurrect a stale row or lose one mid-rename. Both routing paths now run the SELECT inside the same `BEGIN IMMEDIATE`.
- **`KHIVE_WRITE_ROUTING=strict`** (new, default off): with the variable unset, every path's behavior is byte-for-byte unchanged. Strict mode treats "queue never enabled" as a refused misconfiguration rather than a no-op — strict routing is a promise about write admission, and silently voiding it seemed the worse failure mode. Flagged for review in case a narrower contract was intended.
- **Writer classification table**: `writer_task.rs` module doc now enumerates every writer-connection class (request path, startup/migrations, checkpointing, recovery, top-level maintenance) with its routing contract; `CheckpointConnection` cross-links its exemption instead of leaving it implicit.
- **Durable sink telemetry**: three new event kinds in the timeout sink — `queue_saturation` (queue-full admission failures), `writer_task_retirement` (terminal drain-loop exits that previously only logged), `direct_route_violation` (a write took the standalone path while the queue was enabled, with the emitting site named). All follow the sink's existing fail-open, non-blocking contract.

## Testing

- Routing tests use an occupier/`queue_depth()` discriminator (park an occupier in the WriterTask's single drain slot, assert the queued request is observed) rather than spawn counts, which are a documented false positive. The `vec_delete_subjects` and `rename_namespace` routing tests were red-proofed against the pre-fix code paths.
- Strict-mode fail-closed tests for all five enforcement sites.
- Acceptance test: a mixed five-op batch completes under concurrent `SqlBridge`-level write contention with strict+queue routing enabled.
- `cargo test -p khive-db --features vectors` (620 tests), `cargo check --workspace`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo fmt --all -- --check` all pass.

Refs #1654, ADR-136.