### PR TITLE
fix(code): resolve package __init__.py relative imports inside the package

### DIFF
--- a/crates/khive-pack-code/src/imports.rs
+++ b/crates/khive-pack-code/src/imports.rs
@@ -205,10 +205,15 @@ fn classify_python(
         for _ in 1..level {
             base.pop();
         }
+        // A relative import that climbs to or above the scanner's project
+        // root cannot be attributed — Python itself rejects relative imports
+        // beyond the top-level package — so never record a root-level guess
+        // that a later same-name module would silently satisfy.
+        if base.is_empty() {
+            return Resolved::Skip;
+        }
         let target = if rest.is_empty() {
             base.join(".")
-        } else if base.is_empty() {
-            rest.to_string()
         } else {
             format!("{}.{}", base.join("."), rest)
         };
@@ -424,6 +429,30 @@ mod tests {
         assert_eq!(
             classify_import("python", ".", "pkg.x", "pkg", true),
             Resolved::Skip
+        );
+    }
+
+    #[test]
+    fn python_relative_import_above_project_root_is_skipped() {
+        // Climbing to or above the scanner's project root is unattributable
+        // (Python rejects relative imports beyond the top-level package) —
+        // never a root-level intra-project target. Both declarer shapes.
+        assert_eq!(
+            classify_import("python", "..outside", "pkg", "pkg", true),
+            Resolved::Skip
+        );
+        assert_eq!(
+            classify_import("python", "..outside", "pkg.mod", "pkg", false),
+            Resolved::Skip
+        );
+        assert_eq!(
+            classify_import("python", "...outside", "pkg.x", "pkg", true),
+            Resolved::Skip
+        );
+        // One level short of the root still resolves normally.
+        assert_eq!(
+            classify_import("python", "..a", "pkg.x.y", "pkg", false),
+            Resolved::IntraModule("pkg.a".to_string())
         );
     }
 

--- a/crates/khive-pack-code/src/imports.rs
+++ b/crates/khive-pack-code/src/imports.rs
@@ -133,10 +133,11 @@ pub(crate) fn classify_import(
     raw: &str,
     current_module_path: &str,
     project_name: &str,
+    is_package: bool,
 ) -> Resolved {
     match language {
         "rust" => classify_rust(raw, current_module_path, project_name),
-        "python" => classify_python(raw, current_module_path, project_name),
+        "python" => classify_python(raw, current_module_path, project_name, is_package),
         "typescript" => classify_typescript(raw),
         _ => Resolved::Skip,
     }
@@ -179,7 +180,12 @@ fn module_or_skip(module_path: &str) -> Resolved {
     }
 }
 
-fn classify_python(raw: &str, current_module_path: &str, project_name: &str) -> Resolved {
+fn classify_python(
+    raw: &str,
+    current_module_path: &str,
+    project_name: &str,
+    is_package: bool,
+) -> Resolved {
     if let Some(stripped) = raw.strip_prefix('.') {
         let mut level = 1usize;
         let mut rest = stripped;
@@ -188,19 +194,28 @@ fn classify_python(raw: &str, current_module_path: &str, project_name: &str) -> 
             rest = s;
         }
         let mut base: Vec<&str> = current_module_path.split('.').collect();
-        // The declaring module's own containing package is one level up
-        // from itself; a single leading dot means "this package".
-        base.pop();
+        // A single leading dot means "the containing package". For a regular
+        // module that is one level up from its own path; for a package
+        // (`__init__.py`) it is the module path itself, because
+        // `module_path_for_file` already collapsed `pkg/__init__.py` to
+        // `pkg` — popping again would resolve into the parent package.
+        if !is_package {
+            base.pop();
+        }
         for _ in 1..level {
             base.pop();
         }
-        if rest.is_empty() {
-            return module_or_skip(&base.join("."));
+        let target = if rest.is_empty() {
+            base.join(".")
+        } else if base.is_empty() {
+            rest.to_string()
+        } else {
+            format!("{}.{}", base.join("."), rest)
+        };
+        if target == current_module_path {
+            return Resolved::Skip;
         }
-        if base.is_empty() {
-            return Resolved::IntraModule(rest.to_string());
-        }
-        return Resolved::IntraModule(format!("{}.{}", base.join("."), rest));
+        return module_or_skip(&target);
     }
     if raw.is_empty() {
         return Resolved::Skip;
@@ -346,15 +361,21 @@ mod tests {
     #[test]
     fn rust_classify_external_vs_intra() {
         assert_eq!(
-            classify_import("rust", "serde::Serialize", "crate", "mycrate"),
+            classify_import("rust", "serde::Serialize", "crate", "mycrate", false),
             Resolved::ExternalProject("serde".to_string())
         );
         assert_eq!(
-            classify_import("rust", "mycrate::foo::Bar", "crate", "mycrate"),
+            classify_import("rust", "mycrate::foo::Bar", "crate", "mycrate", false),
             Resolved::IntraModule("foo::Bar".to_string())
         );
         assert_eq!(
-            classify_import("rust", "std::collections::HashMap", "crate", "mycrate"),
+            classify_import(
+                "rust",
+                "std::collections::HashMap",
+                "crate",
+                "mycrate",
+                false
+            ),
             Resolved::Skip
         );
     }
@@ -362,23 +383,58 @@ mod tests {
     #[test]
     fn python_classify_relative_import() {
         assert_eq!(
-            classify_import("python", ".sibling", "pkg.mod", "pkg"),
+            classify_import("python", ".sibling", "pkg.mod", "pkg", false),
             Resolved::IntraModule("pkg.sibling".to_string())
         );
         assert_eq!(
-            classify_import("python", "requests", "pkg.mod", "pkg"),
+            classify_import("python", "requests", "pkg.mod", "pkg", false),
             Resolved::ExternalProject("requests".to_string())
+        );
+    }
+
+    #[test]
+    fn python_relative_import_from_package_init_stays_in_package() {
+        // `from .x import A` in `pkg/x/__init__.py` (module path `pkg.x`):
+        // the leading dot refers to `pkg.x` itself, so the target is the
+        // same-name submodule `pkg.x.x`, never a self-loop on `pkg.x`.
+        assert_eq!(
+            classify_import("python", ".x", "pkg.x", "pkg", true),
+            Resolved::IntraModule("pkg.x.x".to_string())
+        );
+        // `from .y import B` in `pkg/x/__init__.py` -> `pkg.x.y`.
+        assert_eq!(
+            classify_import("python", ".y", "pkg.x", "pkg", true),
+            Resolved::IntraModule("pkg.x.y".to_string())
+        );
+        // Regular-module behavior unchanged: `from .y import C` in
+        // `pkg/x/z.py` -> `pkg.x.y`.
+        assert_eq!(
+            classify_import("python", ".y", "pkg.x.z", "pkg", false),
+            Resolved::IntraModule("pkg.x.y".to_string())
+        );
+        // Each additional dot climbs one package from the declarer's own
+        // package: `from ..a import D` in `pkg/x/__init__.py` -> `pkg.a`.
+        assert_eq!(
+            classify_import("python", "..a", "pkg.x", "pkg", true),
+            Resolved::IntraModule("pkg.a".to_string())
+        );
+        // `from . import x` in `pkg/x/__init__.py` resolves to the package
+        // itself — a self-reference, skipped rather than recorded as a
+        // self-loop edge.
+        assert_eq!(
+            classify_import("python", ".", "pkg.x", "pkg", true),
+            Resolved::Skip
         );
     }
 
     #[test]
     fn typescript_classify_relative_vs_package() {
         assert_eq!(
-            classify_import("typescript", "./util", "", ""),
+            classify_import("typescript", "./util", "", "", false),
             Resolved::IntraModule("./util".to_string())
         );
         assert_eq!(
-            classify_import("typescript", "left-pad", "", ""),
+            classify_import("typescript", "left-pad", "", "", false),
             Resolved::ExternalProject("left-pad".to_string())
         );
     }

--- a/crates/khive-pack-code/src/source_ingest.rs
+++ b/crates/khive-pack-code/src/source_ingest.rs
@@ -900,12 +900,13 @@ async fn run_import_scan(
             report.edges_updated += 1;
         }
 
+        let is_package = file.file_name().is_some_and(|name| name == "__init__.py");
         for raw in imports::extract_raw_imports(language, &content) {
             let resolved = if language == "typescript" && raw.starts_with('.') {
                 let rel_dir = file_dir.strip_prefix(&proj_root).unwrap_or(Path::new(""));
                 Resolved::IntraModule(imports::resolve_relative_ts_module(rel_dir, &raw))
             } else {
-                imports::classify_import(language, &raw, &module_path, &proj_name)
+                imports::classify_import(language, &raw, &module_path, &proj_name, is_package)
             };
             match resolved {
                 Resolved::Skip => {}

--- a/crates/khive-pack-code/tests/source_ingest.rs
+++ b/crates/khive-pack-code/tests/source_ingest.rs
@@ -325,6 +325,72 @@ async fn rust_item_import_resolves_to_containing_module_after_reingest() {
     );
 }
 
+/// Relative imports declared in a package `__init__.py` must resolve inside
+/// that package, not its parent (#1662): `module_path_for_file` collapses
+/// `pkg/x/__init__.py` to `pkg.x`, so the single leading dot already names
+/// the package itself. Before the fix, `from .x import A` in
+/// `pkg/x/__init__.py` resolved to `pkg.x` — a self-loop — and every other
+/// `__init__` relative import landed one package too high.
+fn write_python_init_reexport_fixture(root: &Path) {
+    let pkg_x = root.join("pkg/x");
+    std::fs::create_dir_all(&pkg_x).unwrap();
+    std::fs::write(
+        root.join("pyproject.toml"),
+        "[project]\nname = \"pyproj\"\n",
+    )
+    .unwrap();
+    std::fs::write(root.join("pkg/__init__.py"), "").unwrap();
+    std::fs::write(
+        pkg_x.join("__init__.py"),
+        "from .x import A\nfrom .y import B\n",
+    )
+    .unwrap();
+    std::fs::write(pkg_x.join("x.py"), "A = 1\n").unwrap();
+    std::fs::write(pkg_x.join("y.py"), "B = 2\n").unwrap();
+    std::fs::write(pkg_x.join("z.py"), "from .y import B\n").unwrap();
+}
+
+#[tokio::test]
+async fn python_init_reexport_resolves_in_package_without_self_loop() {
+    let root = TempDir::new().expect("tempdir");
+    write_python_init_reexport_fixture(root.path());
+    let db = root.path().join("init_reexport.db");
+    let rt = rt_at(&db);
+    let token = rt.authorize(Namespace::local()).expect("token");
+
+    let opts = || CodeSourceIngestOptions {
+        path: root.path(),
+        languages: all_languages(),
+        sweep_time: Utc::now(),
+    };
+    run_code_ingest(&rt, &token, opts())
+        .await
+        .expect("first ingest succeeds");
+    run_code_ingest(&rt, &token, opts())
+        .await
+        .expect("second ingest succeeds");
+
+    let edges = edge_fingerprints(&rt).await;
+    for (src, tgt) in [
+        ("pkg.x", "pkg.x.x"),
+        ("pkg.x", "pkg.x.y"),
+        ("pkg.x.z", "pkg.x.y"),
+    ] {
+        assert!(
+            edges.iter().any(|(rel, s, t, kinds)| rel == "depends_on"
+                && s == src
+                && t == tgt
+                && kinds == "import"),
+            "expected {src} -> {tgt} depends_on import edge, got: {edges:?}"
+        );
+    }
+    let self_loops: Vec<_> = edges.iter().filter(|(_, s, t, _)| s == t).collect();
+    assert!(
+        self_loops.is_empty(),
+        "same-name submodule re-export must not produce self-loop edges, got: {self_loops:?}"
+    );
+}
+
 /// A manifestless folder (no `Cargo.toml`/`pyproject.toml`/`package.json`
 /// anywhere above its source files) must still produce project/module
 /// entities and import edges under the basename-fallback identity rule


### PR DESCRIPTION
## Defect (#1662)

`module_path_for_file` collapses `pkg/__init__.py` to `pkg`, but `classify_python` resolved level-1 relative imports with an unconditional pop of the declaring module's last path component. For imports declared in an `__init__.py` the pop removed the package itself, so every level-1 relative import resolved into the parent package: `from .x import A` in `pkg/x/__init__.py` produced `pkg.x` (a self-loop), and `from .y import B` produced `pkg.y` instead of `pkg.x.y`.

## Fix

The ingest walk computes `is_package` (file name == `__init__.py`) and threads it through `classify_import` into `classify_python`. For a package declarer the first leading dot names the module path itself (no pop); each additional dot pops one level, as before. Regular-module resolution is unchanged; Rust and TypeScript paths are untouched (Rust's `super::` from a collapsed `mod.rs` path is already correct because `super` means the parent module, not the containing package).

A resolved relative target equal to the declaring module (`from . import x` in an `__init__.py`) is now skipped as a self-reference instead of being recorded as a self-loop edge.

## Acceptance (all from #1662, executed)

- `pkg/x/__init__.py` with `from .x import A` → `pkg.x.x`, no self-loop
- `pkg/x/__init__.py` with `from .y import B` → `pkg.x.y`
- `pkg/x/z.py` with `from .y import B` → `pkg.x.y` (unchanged)
- `..a` from `pkg/x/__init__.py` → `pkg.a`
- Ingest-level regression: fixture tree with a same-name submodule re-export produces the three expected `depends_on` edges and zero self-loop edges (test fails on the pre-fix resolver, verified by disabling the package detection)

## Tests

- 5 new unit arms in `imports.rs`
- New integration test `python_init_reexport_resolves_in_package_without_self_loop` in `tests/source_ingest.rs`
- `cargo test -p khive-pack-code` 57 passed; clippy `-D warnings` clean; `cargo check --workspace` clean