### PR TITLE
fix(kkernel): pass single-contributor search results through instead of rank-fusing them

### DIFF
--- a/crates/khive-mcp/src/server.rs
+++ b/crates/khive-mcp/src/server.rs
@@ -1374,12 +1374,41 @@ async fn dispatch_via_coordinator_inner(
                             )
                             .await;
 
-                        // Shape result to match the kg search handler's output fields exactly.
-                        // Entity hits: [{id, entity_kind, score, title, snippet}]
+                        // Shape result to match the kg search handler's output fields.
+                        // Entity hits: [{id, entity_kind, score, score_kind, title, snippet}]
                         //   - entity_kind: real kind string fetched from the owning backend
-                        //   - score: RRF-merged, subject to min_score floor
-                        // Note hits:   [{id, note_kind, score, title, snippet}]
+                        //   - score: subject to min_score floor; see score_kind
+                        // Note hits:   [{id, note_kind, score, score_kind, title, snippet}]
                         //   - note_kind: real kind string fetched from the owning backend
+                        //
+                        // `score` is not one quantity. When a single backend contributed
+                        // hits they pass through carrying that backend's own fused
+                        // relevance score; when two or more contributed, the merge emits a
+                        // Reciprocal Rank Fusion value derived from ranks alone, which is
+                        // not comparable to a relevance score and cannot be thresholded
+                        // like one. `score_kind` says which of the two a caller is reading.
+                        let entity_score_kind = if coord_result
+                            .per_backend
+                            .iter()
+                            .filter(|r| !r.entity_hits.is_empty())
+                            .count()
+                            > 1
+                        {
+                            "fused_rank"
+                        } else {
+                            "backend"
+                        };
+                        let note_score_kind = if coord_result
+                            .per_backend
+                            .iter()
+                            .filter(|r| !r.note_hits.is_empty())
+                            .count()
+                            > 1
+                        {
+                            "fused_rank"
+                        } else {
+                            "backend"
+                        };
                         let result_val = if !coord_result.note_hits.is_empty()
                             || (coord_result.entity_hits.is_empty()
                                 && coord_result.note_hits.is_empty())
@@ -1395,6 +1424,7 @@ async fn dispatch_via_coordinator_inner(
                                         "id": h.note_id.to_string(),
                                         "note_kind": note_kind,
                                         "score": h.score.to_f64(),
+                                        "score_kind": note_score_kind,
                                         "source": h.source.as_str(),
                                         "title": h.title,
                                         "snippet": h.snippet,
@@ -1414,6 +1444,7 @@ async fn dispatch_via_coordinator_inner(
                                         "id": h.entity_id.to_string(),
                                         "entity_kind": entity_kind,
                                         "score": h.score.to_f64(),
+                                        "score_kind": entity_score_kind,
                                         "source": h.source.as_str(),
                                         "title": h.title,
                                         "snippet": h.snippet,

--- a/crates/khive-pack-kg/src/handlers/search.rs
+++ b/crates/khive-pack-kg/src/handlers/search.rs
@@ -151,6 +151,11 @@ impl KgPack {
                             "entity_kind": entity_kind,
                             "name": h.title,
                             "score": h.score.to_f64(),
+                            // This path always serves one backend's own fused relevance
+                            // score. The multi-backend daemon path can instead serve a
+                            // rank-derived fusion value, which is not comparable to this
+                            // one, so every search row states which it carries.
+                            "score_kind": "backend",
                             "source": h.source.as_str(),
                             "title": h.title,
                             "snippet": h.snippet,
@@ -268,6 +273,7 @@ impl KgPack {
                             "note_kind": note_kind,
                             "name": name,
                             "score": h.score.to_f64(),
+                            "score_kind": "backend",
                             "source": h.source.as_str(),
                             "title": h.title,
                             "snippet": h.snippet,

--- a/crates/kkernel/src/coordinator/dispatch.rs
+++ b/crates/kkernel/src/coordinator/dispatch.rs
@@ -629,8 +629,20 @@ struct RrfMergeBucket {
 }
 
 /// Merge multiple ranked entity hit lists via Reciprocal Rank Fusion (k=60).
+///
+/// Fusion runs only when two or more backends actually CONTRIBUTED hits. With a
+/// single contributing list there is nothing to fuse, and running RRF anyway would
+/// replace each backend score with `1/(60 + position)` — a rank artifact emitted
+/// into the field callers read as relevance. The single-contributor list is
+/// therefore passed through with its backend scores intact.
 pub(super) fn rrf_merge_entity_hits(lists: Vec<Vec<SearchHit>>, limit: usize) -> Vec<SearchHit> {
     const K: f64 = 60.0;
+
+    if lists.len() == 1 {
+        let mut only = lists.into_iter().next().unwrap_or_default();
+        only.truncate(limit);
+        return only;
+    }
 
     let mut scores: HashMap<Uuid, RrfMergeBucket> = HashMap::new();
 
@@ -673,8 +685,20 @@ pub(super) fn rrf_merge_entity_hits(lists: Vec<Vec<SearchHit>>, limit: usize) ->
 }
 
 /// Merge multiple ranked note hit lists via Reciprocal Rank Fusion (k=60).
-fn rrf_merge_note_hits(lists: Vec<Vec<NoteSearchHit>>, limit: usize) -> Vec<NoteSearchHit> {
+///
+/// Single-contributor passthrough applies here for the same reason as the entity
+/// merge above.
+pub(super) fn rrf_merge_note_hits(
+    lists: Vec<Vec<NoteSearchHit>>,
+    limit: usize,
+) -> Vec<NoteSearchHit> {
     const K: f64 = 60.0;
+
+    if lists.len() == 1 {
+        let mut only = lists.into_iter().next().unwrap_or_default();
+        only.truncate(limit);
+        return only;
+    }
 
     let mut scores: HashMap<Uuid, RrfMergeBucket> = HashMap::new();
 

--- a/crates/kkernel/src/coordinator/tests.rs
+++ b/crates/kkernel/src/coordinator/tests.rs
@@ -6,7 +6,8 @@ use uuid::Uuid;
 
 use khive_runtime::Namespace as RuntimeNamespace;
 use khive_runtime::{
-    BackendId, KhiveRuntime, PackRegistry, SearchHit, SearchSource, VerbRegistryBuilder,
+    BackendId, KhiveRuntime, NoteSearchHit, PackRegistry, SearchHit, SearchSource,
+    VerbRegistryBuilder,
 };
 use khive_score::DeterministicScore;
 use khive_storage::types::Direction;
@@ -335,6 +336,123 @@ fn cross_backend_entity_merge_preserves_retrieval_leg_membership() {
     assert_eq!(sources[&text_on_both], SearchSource::Text);
     assert_eq!(sources[&vector_on_both], SearchSource::Vector);
     assert_eq!(sources[&both_and_vector], SearchSource::Both);
+}
+
+fn scored_hit(entity_id: Uuid, source: SearchSource, score: f64) -> SearchHit {
+    SearchHit {
+        entity_id,
+        score: DeterministicScore::from_f64(score),
+        source,
+        title: None,
+        snippet: None,
+    }
+}
+
+fn scored_note_hit(note_id: Uuid, source: SearchSource, score: f64) -> NoteSearchHit {
+    NoteSearchHit {
+        note_id,
+        score: DeterministicScore::from_f64(score),
+        source,
+        title: None,
+        snippet: None,
+    }
+}
+
+/// One contributing backend means there is nothing to fuse. Running RRF anyway
+/// replaced every backend score with `1/(60 + position)`, so an exact-title hit
+/// and an unrelated one at the next position scored 0.016393 and 0.016129 — a
+/// rank artifact in the field callers threshold on. The passthrough must preserve
+/// the backend's own scores exactly.
+#[test]
+fn single_contributing_backend_passes_backend_scores_through() {
+    let exact = Uuid::new_v4();
+    let partial = Uuid::new_v4();
+
+    // 0.681818… is what the entity fusion path emits for an exact title match
+    // (two arms at rank 1 with k=10, plus the exact-match boost).
+    let merged = super::dispatch::rrf_merge_entity_hits(
+        vec![vec![
+            scored_hit(exact, SearchSource::Both, 0.681_818_181_818),
+            scored_hit(partial, SearchSource::Vector, 0.083_333_333_333),
+        ]],
+        10,
+    );
+
+    assert_eq!(merged.len(), 2);
+    assert_eq!(merged[0].entity_id, exact);
+    assert_eq!(merged[1].entity_id, partial);
+    assert_eq!(
+        merged[0].score,
+        DeterministicScore::from_f64(0.681_818_181_818),
+        "single-contributor passthrough must keep the backend score"
+    );
+    assert_eq!(
+        merged[1].score,
+        DeterministicScore::from_f64(0.083_333_333_333)
+    );
+    // The defect this guards against is positional: both scores collapsing onto
+    // 1/(60 + position) regardless of what retrieval found.
+    let positional_first = DeterministicScore::from_f64(1.0 / 61.0);
+    assert_ne!(
+        merged[0].score, positional_first,
+        "a rank artifact must not be served as a relevance score"
+    );
+}
+
+#[test]
+fn single_contributing_backend_passthrough_respects_limit() {
+    let hits: Vec<SearchHit> = (0..5)
+        .map(|i| scored_hit(Uuid::new_v4(), SearchSource::Text, 1.0 - f64::from(i) * 0.1))
+        .collect();
+    let merged = super::dispatch::rrf_merge_entity_hits(vec![hits], 2);
+    assert_eq!(merged.len(), 2);
+}
+
+#[test]
+fn single_contributing_backend_note_passthrough_keeps_scores() {
+    let note = Uuid::new_v4();
+    let merged = super::dispatch::rrf_merge_note_hits(
+        vec![vec![scored_note_hit(note, SearchSource::Both, 0.42)]],
+        10,
+    );
+    assert_eq!(merged.len(), 1);
+    assert_eq!(merged[0].score, DeterministicScore::from_f64(0.42));
+}
+
+/// Two contributing backends genuinely need rank fusion — scores from different
+/// backends are not comparable. This pins the RRF math so the passthrough above
+/// cannot be widened into "never fuse".
+#[test]
+fn two_contributing_backends_still_fuse_by_rank() {
+    let on_both = Uuid::new_v4();
+    let on_one = Uuid::new_v4();
+
+    let merged = super::dispatch::rrf_merge_entity_hits(
+        vec![
+            vec![
+                scored_hit(on_both, SearchSource::Text, 0.9),
+                scored_hit(on_one, SearchSource::Text, 0.8),
+            ],
+            vec![scored_hit(on_both, SearchSource::Vector, 0.1)],
+        ],
+        10,
+    );
+
+    assert_eq!(merged.len(), 2);
+    assert_eq!(merged[0].entity_id, on_both, "rank-1 in both lists wins");
+    assert_eq!(
+        merged[0].score,
+        DeterministicScore::from_f64(1.0 / 61.0 + 1.0 / 61.0),
+        "fused score sums the per-list RRF contributions"
+    );
+    assert_eq!(
+        merged[1].score,
+        DeterministicScore::from_f64(1.0 / 62.0),
+        "rank-2 in one list only"
+    );
+    // The backend scores must NOT survive a real fusion: 0.9 is not comparable
+    // to 0.1 across backends, which is the reason RRF is used here at all.
+    assert_ne!(merged[0].score, DeterministicScore::from_f64(0.9));
 }
 
 #[tokio::test]


### PR DESCRIPTION
Closes #1674 (partially — see "Not in this PR" below).

## What was wrong

`rrf_merge_entity_hits` / `rrf_merge_note_hits` in the coordinator recomputed every score as `1.0 / (60.0 + rank)` from each hit's position in its backend's list, throwing away the score the backend produced. The merge engaged whenever two or more backends were **configured**, but fusion is only meaningful when two or more actually **contributed** hits. With a single contributor there is nothing to fuse, so the result was a positional artifact served in the field callers read as relevance:

- An exact-title match and an unrelated hit one position below scored `0.016393` and `0.016129`.
- The sequence was identical for every query, including a nonsense-token query.
- `source: "both"` was carried through untouched, so a hit found by both retrieval arms still reported a single-arm-shaped number.
- `min_score` and any caller-side threshold compared against rank positions.

Independently corroborated on a second store: taking `1/score` per row gives perfectly consecutive integers (61…70) through the daemon, versus `11,12,13,14,15,17,18,19,20,21` in-process. The skip from 15 to 17 is the discriminating artifact — a positional ladder cannot emit a non-consecutive reciprocal, so the in-process arm still carries fusion structure that the merge overwrote. That test is stronger than the absolute values because it does not depend on knowing the RRF constant on either side.

## What this changes

1. **Fusion keys on contributing backends.** A single contributing list is passed through with its scores intact (truncated to `limit`). RRF is untouched and still runs for the genuine multi-contributor case — scores from different backends are not comparable, which is exactly why rank fusion exists there.
2. **`score_kind` on every search row.** `"backend"` when a single backend's own fused relevance score is served, `"fused_rank"` when a real multi-backend merge produced a rank-derived value. The field was silently two different quantities depending on deployment shape and dispatch path; now it says which. The single-backend handler path emits `"backend"` for the same reason.

## Verification

- `cargo test -p kkernel -p khive-mcp -p khive-pack-kg` green; `cargo clippy --all-targets -D warnings` clean; `cargo fmt --check` clean (exit code read unpiped).
- Four new tests. Two are real detectors: no-oping the new branch and re-running makes `single_contributing_backend_passes_backend_scores_through` and `single_contributing_backend_note_passthrough_keeps_scores` fail, and restoring it makes them pass. The other two are guards — the limit test and `two_contributing_backends_still_fuse_by_rank`, which pins the RRF arithmetic (rank-1-in-both = `1/61 + 1/61`, rank-2-in-one = `1/62`) so the passthrough cannot later be widened into never fusing.

## Not in this PR

The multi-backend path also drops `kind`, `name`, and `created_at`, which the handler path emits. That is a separate defect in the coordinator's row assembly, not a consequence of the merge, and the passthrough here does not fix it — those fields are absent at the type level before the merge is reached. It has real consequence: a field-keyed check against these rows returns a confident, clean, wrong answer, which is a failure mode worth its own regression test. Filed separately.