### PR TITLE
feat(db): slow_write sink rows — record queued-write latency, not only failures

### DIFF
--- a/crates/khive-db/src/timeout_sink.rs
+++ b/crates/khive-db/src/timeout_sink.rs
@@ -127,6 +127,37 @@ const DRAIN_BATCH_CAP: usize = 256;
 /// writer thread's lifetime at startup, and a no-op when unset.
 const WRITE_DELAY_MS_OVERRIDE_ENV: &str = "KHIVE_WRITER_TIMEOUT_SINK_WRITE_DELAY_MS";
 
+/// Caller-experienced write latency at or above this bound produces a
+/// `slow_write` sink row. Exists because the ADR-136 write queue converts
+/// what used to be a caller-visible admission FAILURE (a `timeout` row) into
+/// caller-visible WAITING: under burst, contention now presents as latency,
+/// which the failure-shaped rows are structurally unable to record — a
+/// quiet sink no longer means an uncontended writer. The bound is on the
+/// whole send-to-reply span (enqueue wait + queue depth + execution), i.e.
+/// the quantity a blocked caller actually experiences.
+const SLOW_WRITE_THRESHOLD: Duration = Duration::from_secs(1);
+
+/// Override for [`SLOW_WRITE_THRESHOLD`], in milliseconds. `0` disables
+/// slow-write rows entirely. Read once per spawned `WriterTask` handle (at
+/// spawn, not per write), so tests get a deterministic value by setting it
+/// before spawning their own writer task.
+const SLOW_WRITE_THRESHOLD_MS_OVERRIDE_ENV: &str = "KHIVE_SLOW_WRITE_THRESHOLD_MS";
+
+/// Resolve the slow-write latency bound: env override if parseable, else
+/// [`SLOW_WRITE_THRESHOLD`]. `Some(0)` from the override resolves to `None`
+/// (disabled) — a zero bound would stamp every write and turn the sink into
+/// a write log, which it is not.
+pub(crate) fn slow_write_threshold() -> Option<Duration> {
+    match std::env::var(SLOW_WRITE_THRESHOLD_MS_OVERRIDE_ENV) {
+        Ok(v) => match v.parse::<u64>() {
+            Ok(0) => None,
+            Ok(ms) => Some(Duration::from_millis(ms)),
+            Err(_) => Some(SLOW_WRITE_THRESHOLD),
+        },
+        Err(_) => Some(SLOW_WRITE_THRESHOLD),
+    }
+}
+
 /// Per-process NDJSON file name — see the module docs' "FILES ARE
 /// PER-PROCESS" section for why this is not a single shared file.
 fn ndjson_file_name() -> String {
@@ -254,13 +285,15 @@ impl Site {
 /// bounded channel — this is the only thing a database caller path ever
 /// does. `error` is already truncated to [`MAX_ERROR_BYTES`] where present.
 ///
-/// `kind` distinguishes the four durable row shapes this sink emits:
+/// `kind` distinguishes the five durable row shapes this sink emits:
 /// `"timeout"` (a writer-admission or busy/locked timeout, carries `site` +
 /// `error`), `"queue_saturation"` (a caller-visible `WriteQueueFull`, carries
 /// `timeout_ms`), `"writer_task_retirement"` (a `WriterTask` terminal
-/// retirement, carries `error` as the retirement reason), and
+/// retirement, carries `error` as the retirement reason),
 /// `"direct_route_violation"` (a direct writer acquisition bypassing an
-/// enabled queue, carries `site`).
+/// enabled queue, carries `site`), and `"slow_write"` (a queued write whose
+/// send-to-reply span met [`SLOW_WRITE_THRESHOLD`], carries `elapsed_ms` +
+/// `queue_depth`).
 struct QueuedEvent {
     ts_utc: String,
     kind: &'static str,
@@ -268,6 +301,8 @@ struct QueuedEvent {
     site: Option<&'static str>,
     error: Option<String>,
     timeout_ms: Option<u64>,
+    elapsed_ms: Option<u64>,
+    queue_depth: Option<u64>,
 }
 
 /// Process-global handle to the writer thread's inbox. Set at most once per
@@ -299,6 +334,10 @@ struct EventRecord<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
     timeout_ms: Option<u64>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    elapsed_ms: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    queue_depth: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pid: Option<u32>,
     #[serde(skip_serializing_if = "Option::is_none")]
     version: Option<&'a str>,
@@ -312,6 +351,8 @@ fn build_line(
     site: Option<&str>,
     error: Option<&str>,
     timeout_ms: Option<u64>,
+    elapsed_ms: Option<u64>,
+    queue_depth: Option<u64>,
     pid: Option<u32>,
     version: Option<&str>,
 ) -> String {
@@ -322,6 +363,8 @@ fn build_line(
         site,
         error,
         timeout_ms,
+        elapsed_ms,
+        queue_depth,
         pid,
         version,
     };
@@ -350,6 +393,8 @@ fn build_line_now(
         site,
         error,
         timeout_ms,
+        None,
+        None,
         pid,
         version,
     )
@@ -582,6 +627,8 @@ fn write_event(sink: &mut AppendSink<File>, dropped: &AtomicU64, event: QueuedEv
         event.site,
         event.error.as_deref(),
         event.timeout_ms,
+        event.elapsed_ms,
+        event.queue_depth,
         None,
         None,
     );
@@ -894,6 +941,8 @@ pub(crate) fn emit_timeout(db: &str, site: Site, error: &str, timeout_ms: Option
         site: Some(site.as_str()),
         error: Some(truncate_error(error, MAX_ERROR_BYTES)),
         timeout_ms,
+        elapsed_ms: None,
+        queue_depth: None,
     };
     enqueue(&handle.sender, &handle.dropped, event);
 }
@@ -914,6 +963,8 @@ pub(crate) fn emit_queue_saturation(db: &str, timeout_ms: u64) {
         site: None,
         error: None,
         timeout_ms: Some(timeout_ms),
+        elapsed_ms: None,
+        queue_depth: None,
     };
     enqueue(&handle.sender, &handle.dropped, event);
 }
@@ -933,6 +984,8 @@ pub(crate) fn emit_writer_task_retirement(db: &str, reason: &str) {
         site: None,
         error: Some(truncate_error(reason, MAX_ERROR_BYTES)),
         timeout_ms: None,
+        elapsed_ms: None,
+        queue_depth: None,
     };
     enqueue(&handle.sender, &handle.dropped, event);
 }
@@ -955,6 +1008,31 @@ pub(crate) fn emit_direct_route_violation(db: &str, site: Site) {
         site: Some(site.as_str()),
         error: None,
         timeout_ms: None,
+        elapsed_ms: None,
+        queue_depth: None,
+    };
+    enqueue(&handle.sender, &handle.dropped, event);
+}
+
+/// Record a `slow_write` event: a queued write whose whole send-to-reply
+/// span (enqueue wait + queue depth + execution) met the slow-write
+/// threshold. Emitted by `WriterTaskHandle`'s send paths on completion —
+/// success or error alike, since the caller experienced the latency either
+/// way. `queue_depth` is the backlog snapshot taken when the send STARTED,
+/// so a reader can separate "queue was deep" from "one op was slow".
+pub(crate) fn emit_slow_write(db: &str, elapsed_ms: u64, queue_depth: usize) {
+    let Some(handle) = SINK.get() else {
+        return;
+    };
+    let event = QueuedEvent {
+        ts_utc: now_rfc3339(),
+        kind: "slow_write",
+        db: db.to_string(),
+        site: None,
+        error: None,
+        timeout_ms: None,
+        elapsed_ms: Some(elapsed_ms),
+        queue_depth: Some(queue_depth as u64),
     };
     enqueue(&handle.sender, &handle.dropped, event);
 }
@@ -1015,6 +1093,49 @@ mod tests {
     }
 
     #[test]
+    fn slow_write_threshold_env_override_and_zero_disable() {
+        std::env::remove_var(SLOW_WRITE_THRESHOLD_MS_OVERRIDE_ENV);
+        assert_eq!(slow_write_threshold(), Some(SLOW_WRITE_THRESHOLD));
+
+        std::env::set_var(SLOW_WRITE_THRESHOLD_MS_OVERRIDE_ENV, "250");
+        assert_eq!(slow_write_threshold(), Some(Duration::from_millis(250)));
+
+        // 0 = disabled entirely, never "emit every write".
+        std::env::set_var(SLOW_WRITE_THRESHOLD_MS_OVERRIDE_ENV, "0");
+        assert_eq!(slow_write_threshold(), None);
+
+        // Unparseable falls back to the default, never to disabled — a typo
+        // in the override must not silently turn the instrument off.
+        std::env::set_var(SLOW_WRITE_THRESHOLD_MS_OVERRIDE_ENV, "not-a-number");
+        assert_eq!(slow_write_threshold(), Some(SLOW_WRITE_THRESHOLD));
+        std::env::remove_var(SLOW_WRITE_THRESHOLD_MS_OVERRIDE_ENV);
+    }
+
+    #[test]
+    fn slow_write_line_carries_elapsed_and_depth_and_omits_inapplicable_fields() {
+        let line = build_line(
+            now_rfc3339(),
+            "slow_write",
+            "test-db",
+            None,
+            None,
+            None,
+            Some(1234),
+            Some(7),
+            None,
+            None,
+        );
+        let parsed: serde_json::Value = serde_json::from_str(line.trim()).unwrap();
+        assert_eq!(parsed["kind"], "slow_write");
+        assert_eq!(parsed["elapsed_ms"], 1234);
+        assert_eq!(parsed["queue_depth"], 7);
+        // Inapplicable fields are omitted, not null (existing sink contract).
+        assert!(parsed.get("site").is_none());
+        assert!(parsed.get("error").is_none());
+        assert!(parsed.get("timeout_ms").is_none());
+    }
+
+    #[test]
     fn truncate_error_leaves_short_strings_untouched() {
         let short = "database is locked";
         assert_eq!(truncate_error(short, MAX_ERROR_BYTES), short);
@@ -1055,6 +1176,8 @@ mod tests {
             site: Some(Site::PoolAdmission.as_str()),
             error: Some("boom".to_string()),
             timeout_ms: Some(5),
+            elapsed_ms: None,
+            queue_depth: None,
         };
 
         enqueue(&sender, &dropped, make_event());
@@ -1232,6 +1355,8 @@ mod tests {
                         site: Some(Site::StandaloneGraph.as_str()),
                         error: Some(format!("contention-{i}")),
                         timeout_ms: Some(i as u64),
+                        elapsed_ms: None,
+                        queue_depth: None,
                     };
                     enqueue(&sender, &dropped, event);
                 })
@@ -1253,6 +1378,8 @@ mod tests {
                 event.site,
                 event.error.as_deref(),
                 event.timeout_ms,
+                event.elapsed_ms,
+                event.queue_depth,
                 None,
                 None,
             );

--- a/crates/khive-db/src/writer_task.rs
+++ b/crates/khive-db/src/writer_task.rs
@@ -317,6 +317,12 @@ pub struct WriterTaskHandle {
     /// report a `queue_saturation` sink row (ADR-136 D1 gate 6a) without
     /// needing a `&ConnectionPool` reference.
     db: String,
+    /// Slow-write latency bound (`timeout_sink::slow_write_threshold`),
+    /// resolved once at spawn. `None` disables slow-write rows. Captured
+    /// here rather than read per send so the caller path pays no env lookup
+    /// and tests get a deterministic value by setting the override before
+    /// spawning their own writer task.
+    slow_write_threshold: Option<std::time::Duration>,
 }
 
 impl WriterTaskHandle {
@@ -382,10 +388,13 @@ impl WriterTaskHandle {
         R: Send + 'static,
         F: FnOnce(&Connection) -> Result<R, StorageError> + Send + 'static,
     {
+        let observation = self.begin_latency_observation();
         let reply_rx = self.enqueue(op).await?;
-        reply_rx
+        let result = reply_rx
             .await
-            .map_err(|_| writer_task_terminated(WriterTaskRequestState::SideEffectsUnknown))?
+            .map_err(|_| writer_task_terminated(WriterTaskRequestState::SideEffectsUnknown))?;
+        self.finish_latency_observation(observation);
+        result
     }
 
     /// Like [`Self::send`], but bounds the wait for the bounded channel to
@@ -411,6 +420,7 @@ impl WriterTaskHandle {
         R: Send + 'static,
         F: FnOnce(&Connection) -> Result<R, StorageError> + Send + 'static,
     {
+        let observation = self.begin_latency_observation();
         let reply_rx = match tokio::time::timeout(timeout, self.enqueue(op)).await {
             Ok(Ok(reply_rx)) => reply_rx,
             Ok(Err(e)) => return Err(e),
@@ -421,9 +431,11 @@ impl WriterTaskHandle {
             }
         };
 
-        reply_rx
+        let result = reply_rx
             .await
-            .map_err(|_| writer_task_terminated(WriterTaskRequestState::SideEffectsUnknown))?
+            .map_err(|_| writer_task_terminated(WriterTaskRequestState::SideEffectsUnknown))?;
+        self.finish_latency_observation(observation);
+        result
     }
 
     /// Send a write operation that MUST run outside any open transaction
@@ -442,10 +454,44 @@ impl WriterTaskHandle {
         R: Send + 'static,
         F: FnOnce(&Connection) -> Result<R, StorageError> + Send + 'static,
     {
+        let observation = self.begin_latency_observation();
         let reply_rx = self.enqueue_inner(op, true).await?;
-        reply_rx
+        let result = reply_rx
             .await
-            .map_err(|_| writer_task_terminated(WriterTaskRequestState::SideEffectsUnknown))?
+            .map_err(|_| writer_task_terminated(WriterTaskRequestState::SideEffectsUnknown))?;
+        self.finish_latency_observation(observation);
+        result
+    }
+
+    /// Snapshot the start instant and the queue backlog for one send, if
+    /// slow-write observation is enabled for this handle. The depth is
+    /// captured at send START — after completion the drain loop has already
+    /// consumed this request, so a completion-time read would systematically
+    /// understate the backlog the caller actually waited behind.
+    fn begin_latency_observation(&self) -> Option<(std::time::Instant, usize)> {
+        self.slow_write_threshold
+            .map(|_| (std::time::Instant::now(), self.queue_depth()))
+    }
+
+    /// Emit a `slow_write` sink row if this send's whole span met the
+    /// threshold. Called on the reply path — success or typed error alike,
+    /// since the caller experienced the latency either way. Never called
+    /// when the reply channel itself is severed (writer-task terminated),
+    /// which is reported through its own retirement row.
+    fn finish_latency_observation(&self, observation: Option<(std::time::Instant, usize)>) {
+        let (Some(threshold), Some((start, depth_at_entry))) =
+            (self.slow_write_threshold, observation)
+        else {
+            return;
+        };
+        let elapsed = start.elapsed();
+        if elapsed >= threshold {
+            crate::timeout_sink::emit_slow_write(
+                &self.db,
+                elapsed.as_millis() as u64,
+                depth_at_entry,
+            );
+        }
     }
 
     /// Current write-queue backlog depth: requests enqueued but not yet
@@ -493,7 +539,11 @@ pub fn spawn(pool: &ConnectionPool, capacity: usize) -> Result<WriterTaskHandle,
     let db = crate::timeout_sink::db_label(pool);
     let (tx, rx) = mpsc::channel(capacity.max(1));
     tokio::spawn(run_writer_task(conn, rx, origin, db.clone()));
-    Ok(WriterTaskHandle { tx, db })
+    Ok(WriterTaskHandle {
+        tx,
+        db,
+        slow_write_threshold: crate::timeout_sink::slow_write_threshold(),
+    })
 }
 
 /// Permanently close admission, then reply to every request that was already
@@ -827,6 +877,7 @@ mod tests {
         let handle = WriterTaskHandle {
             tx,
             db: "test".to_string(),
+            slow_write_threshold: None,
         };
 
         // First send fills the sole channel slot. Its reply never arrives
@@ -864,6 +915,7 @@ mod tests {
         let handle = WriterTaskHandle {
             tx,
             db: "test".to_string(),
+            slow_write_threshold: None,
         };
 
         let first = tokio::spawn({
@@ -1588,6 +1640,7 @@ mod tests {
         let handle = WriterTaskHandle {
             tx,
             db: "test".to_string(),
+            slow_write_threshold: None,
         };
         let send_result = handle.send(|_conn| Ok::<(), StorageError>(())).await;
         assert_writer_task_terminal_state(send_result, WriterTaskRequestState::NotStarted);
@@ -1612,6 +1665,7 @@ mod tests {
         let handle = WriterTaskHandle {
             tx,
             db: "test".to_string(),
+            slow_write_threshold: None,
         };
         let request_ran = Arc::new(AtomicBool::new(false));
         let request_ran_in_op = Arc::clone(&request_ran);

--- a/crates/khive-db/tests/writer_timeout_sink.rs
+++ b/crates/khive-db/tests/writer_timeout_sink.rs
@@ -39,6 +39,12 @@ const EVENTS_DDL: &str = include_str!("../sql/events-ddl.sql");
 static SINK_DIR: OnceLock<tempfile::TempDir> = OnceLock::new();
 static SET_ENV: Once = Once::new();
 
+/// Serializes the two slow-write tests' env-override + writer-task-spawn
+/// windows: the threshold env var is process-global and read at spawn, so
+/// concurrent set/spawn from both tests would let one test's value leak
+/// into the other's handle.
+static SLOW_ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
 /// Point the sink at a directory this process controls and keeps alive for
 /// its whole lifetime, instead of letting it resolve against whichever
 /// test's own (eventually-dropped) tempdir happens to boot the first pool.
@@ -402,5 +408,113 @@ async fn text_busy_standalone_writer_emits_ndjson_row() {
     assert!(
         matched,
         "expected a standalone:text busy row naming {db_marker}, got: {contents}"
+    );
+}
+
+/// A queued write whose send-to-reply span meets the slow-write threshold
+/// must produce a `"kind":"slow_write"` row carrying `elapsed_ms` and
+/// `queue_depth`, naming this pool's own database path. Threshold is forced
+/// to 1ms (env override, read at writer-task spawn) and the op itself
+/// sleeps 50ms, so the span is guaranteed over-threshold without depending
+/// on scheduler timing.
+#[tokio::test]
+async fn slow_queued_write_emits_slow_write_row() {
+    ensure_sink_dir();
+
+    let dir = tempfile::tempdir().unwrap();
+    let db_path = dir.path().join("slow_write_sink_test.db");
+    let handle = {
+        let _guard = SLOW_ENV_LOCK.lock().unwrap();
+        std::env::set_var("KHIVE_SLOW_WRITE_THRESHOLD_MS", "1");
+        let cfg = PoolConfig {
+            path: Some(db_path.clone()),
+            write_queue_enabled: true,
+            ..PoolConfig::default()
+        };
+        let pool = ConnectionPool::new(cfg).expect("file-backed pool should open");
+        let handle = pool
+            .writer_task_handle()
+            .expect("runtime is present")
+            .expect("write queue enabled must spawn a writer task");
+        std::env::remove_var("KHIVE_SLOW_WRITE_THRESHOLD_MS");
+        handle
+    };
+
+    let value = handle
+        .send(|_conn| {
+            std::thread::sleep(Duration::from_millis(50));
+            Ok(42u8)
+        })
+        .await
+        .expect("queued write should succeed");
+    assert_eq!(value, 42);
+
+    let canonical_db: PathBuf = db_path.canonicalize().unwrap_or(db_path);
+    let db_marker = canonical_db.display().to_string();
+    let is_slow_row = |line: &str| {
+        line.contains("\"kind\":\"slow_write\"")
+            && line.contains("\"elapsed_ms\":")
+            && line.contains("\"queue_depth\":")
+            && line.contains(&db_marker)
+    };
+    let contents = wait_for_ndjson_line(is_slow_row, Duration::from_secs(5));
+    assert!(
+        contents.lines().any(is_slow_row),
+        "expected a slow_write row naming {db_marker}, got: {contents}"
+    );
+}
+
+/// The disable arm: threshold override `0` must spawn a handle that never
+/// emits `slow_write`, even for an over-any-threshold op. Uses its own pool
+/// and db path so the assertion ("no slow_write row for THIS db") cannot
+/// collide with the positive test's rows in the shared sink file.
+#[tokio::test]
+async fn slow_write_disabled_by_zero_threshold_emits_nothing() {
+    ensure_sink_dir();
+
+    let dir = tempfile::tempdir().unwrap();
+    let db_path = dir.path().join("slow_write_disabled_test.db");
+
+    // Race note: the positive test sets this var to "1" concurrently. Spawn
+    // the writer task inside a scope that forces "0", then restore. The env
+    // is process-global, so serialize the two tests' spawn windows with a
+    // lock rather than hoping for ordering.
+    let handle = {
+        let _guard = SLOW_ENV_LOCK.lock().unwrap();
+        std::env::set_var("KHIVE_SLOW_WRITE_THRESHOLD_MS", "0");
+        let cfg = PoolConfig {
+            path: Some(db_path.clone()),
+            write_queue_enabled: true,
+            ..PoolConfig::default()
+        };
+        let pool = ConnectionPool::new(cfg).expect("file-backed pool should open");
+        let handle = pool
+            .writer_task_handle()
+            .expect("runtime is present")
+            .expect("write queue enabled must spawn a writer task");
+        std::env::remove_var("KHIVE_SLOW_WRITE_THRESHOLD_MS");
+        handle
+    };
+
+    handle
+        .send(|_conn| {
+            std::thread::sleep(Duration::from_millis(50));
+            Ok(())
+        })
+        .await
+        .expect("queued write should succeed");
+
+    // Give the sink's writer thread a real chance to drain anything the
+    // handle might (wrongly) have emitted before asserting absence — an
+    // instant read would pass even against a buggy emit still in flight.
+    std::thread::sleep(Duration::from_millis(300));
+    let canonical_db: PathBuf = db_path.canonicalize().unwrap_or(db_path);
+    let db_marker = canonical_db.display().to_string();
+    let contents = read_sink_ndjson();
+    assert!(
+        !contents
+            .lines()
+            .any(|l| l.contains("\"kind\":\"slow_write\"") && l.contains(&db_marker)),
+        "threshold 0 must disable slow_write rows for this db, got: {contents}"
     );
 }


### PR DESCRIPTION
## Problem

The ADR-136 write queue converts writer-admission failures into waiting. Under burst, contention now presents as caller-visible latency — but the writer-timeout sink only records failure shapes (`timeout`, `queue_saturation`). A quiet sink no longer means an uncontended writer: the instrument is blind in exactly the regime the queue creates.

Observed operationally as caller-side deadline overruns while the sink read clean.

## Change

New `slow_write` row kind, emitted by `WriterTaskHandle::send` / `send_with_timeout` / `send_top_level` when the whole send-to-reply span meets a threshold:

- default 1s; `KHIVE_SLOW_WRITE_THRESHOLD_MS` overrides; `0` disables; unparseable falls back to the default (a typo must not silently disable the instrument)
- rows carry `elapsed_ms` + `queue_depth` snapshotted at send **start** (a completion-time depth read would systematically understate the backlog the caller waited behind)
- threshold resolved once at writer-task spawn, so the caller path pays no env lookup
- emission reuses the sink's non-blocking bounded-channel enqueue — the instrument cannot add latency to the path it measures, and cannot join a stampede it is recording
- emitted on success and typed-error replies alike (the caller experienced the latency either way); not on a severed reply channel, which has its own retirement row

## Tests

- unit: threshold resolution arms (default / override / 0-disable / unparseable→default), line shape + field-omission contract
- integration (real writer task, real sink file): over-threshold queued write produces the row; 0-threshold handle produces nothing, asserted after a drain wait and scoped to its own db path
- mutation control: with the emit no-op'd, the positive integration test fails

`cargo test -p khive-db` 585 lib + all integration suites green; clippy `-D warnings` clean; fmt clean.