### PR TITLE
fix(runtime): enforce ADR-124 owner-established properties on note update

### DIFF
--- a/crates/khive-mcp/src/serve.rs
+++ b/crates/khive-mcp/src/serve.rs
@@ -1811,6 +1811,22 @@ fn build_registry_for_multi_backend_inner(
     // update/delete verbs notify caching packs even though there is no
     // crate-level dependency between them.
     registry.call_register_note_mutation_hooks(&default_runtime);
+    // Note-write identity: the pack-owned kind set drives `update`'s
+    // properties refusal so a pack-owned note's identity properties cannot
+    // be overwritten by a caller-supplied `properties` patch. Each per-pack
+    // runtime is constructed independently in the multi-backend boot path
+    // (unlike the single-backend `KhiveMcpServer::with_packs` path), so the
+    // registry must be installed on every runtime that could actually serve
+    // a generic `update` for a pack-owned kind, not just `default_runtime`.
+    let owned_note_kinds: Vec<String> = registry
+        .pack_owned_note_kinds()
+        .into_iter()
+        .map(str::to_string)
+        .collect();
+    default_runtime.install_pack_owned_note_kinds(owned_note_kinds.clone());
+    for rt in per_pack_runtimes_local.values() {
+        rt.install_pack_owned_note_kinds(owned_note_kinds.clone());
+    }
 
     let backend_for_pack: HashMap<&str, &StorageBackend> = per_pack_runtimes_local
         .iter()
@@ -3990,6 +4006,135 @@ id = "lambda:project-actor"
             first_comm_ok,
             Some(true),
             "comm.send must succeed; response: {comm_resp}"
+        );
+    }
+
+    /// ADR-124 note-write identity guard: the pack-owned note kind set must
+    /// be installed on the multi-backend boot path, not only on
+    /// `KhiveMcpServer::with_packs` (single-backend). Routes `kg` and `comm`
+    /// to the same "main" backend through the real `build_server_multi_backend`
+    /// builder — no manual `install_pack_owned_note_kinds` call, unlike
+    /// `build_registry_with_owned_kinds` in the `khive-pack-comm` integration
+    /// tests — so this test exercises the actual boot wiring rather than a
+    /// hand-simulated one. Without the install this fix added in `serve.rs`
+    /// (alongside the edge-rules/note-mutation-hook installs), a generic
+    /// `update(properties={from_actor: ...})` on an inbound message note
+    /// would silently succeed on a served multi-backend instance. Verified by
+    /// temporarily reverting the `install_pack_owned_note_kinds` calls in
+    /// `build_registry_for_multi_backend_inner` and re-running this test: it
+    /// fails (`from_actor` forgery succeeds) without the fix and passes with
+    /// it restored.
+    #[tokio::test]
+    #[serial]
+    async fn multi_backend_boot_installs_owned_note_kinds_so_update_is_refused() {
+        use crate::tools::request::RequestParams;
+
+        let khive_cfg = KhiveConfig {
+            backends: vec![BackendConfig {
+                name: "main".to_string(),
+                kind: BackendKind::Memory,
+                path: None,
+                cache_mb: None,
+                journal_mode: None,
+                read_only: false,
+            }],
+            ..KhiveConfig::default()
+        };
+
+        let base_cfg = base_runtime_config_for_multi_backend();
+
+        let server = build_server_multi_backend(base_cfg, &khive_cfg, None)
+            .expect("multi-backend boot must succeed");
+
+        let send_resp = server
+            .dispatch_request_local(RequestParams {
+                ops: r#"comm.send(to="local", content="adr-124 multi-backend boot probe")"#
+                    .to_string(),
+                presentation: None,
+                presentation_per_op: None,
+                save_to: None,
+                format: None,
+                format_per_op: None,
+                request_id: None,
+            })
+            .await
+            .expect("comm.send dispatch must not error");
+        let send_json: serde_json::Value =
+            serde_json::from_str(&send_resp).expect("send response is valid JSON");
+        assert_eq!(
+            send_json["results"][0]["ok"].as_bool(),
+            Some(true),
+            "comm.send must succeed; response: {send_resp}"
+        );
+        let full_id = send_json["results"][0]["result"]["full_id"]
+            .as_str()
+            .expect("send must return full_id")
+            .to_string();
+
+        let get_before_resp = server
+            .dispatch_request_local(RequestParams {
+                ops: format!(r#"get(id="{full_id}")"#),
+                presentation: None,
+                presentation_per_op: None,
+                save_to: None,
+                format: None,
+                format_per_op: None,
+                request_id: None,
+            })
+            .await
+            .expect("get dispatch must not error");
+        let get_before_json: serde_json::Value =
+            serde_json::from_str(&get_before_resp).expect("get response is valid JSON");
+        let original_from_actor =
+            get_before_json["results"][0]["result"]["properties"]["from_actor"].clone();
+
+        let update_resp = server
+            .dispatch_request_local(RequestParams {
+                ops: format!(
+                    r#"update(id="{full_id}", properties={{"from_actor": "forged-actor"}})"#
+                ),
+                presentation: None,
+                presentation_per_op: None,
+                save_to: None,
+                format: None,
+                format_per_op: None,
+                request_id: None,
+            })
+            .await
+            .expect("update dispatch must not error");
+        let update_json: serde_json::Value =
+            serde_json::from_str(&update_resp).expect("update response is valid JSON");
+        assert_eq!(
+            update_json["results"][0]["ok"].as_bool(),
+            Some(false),
+            "update forging `from_actor` on a message note must be refused on a served \
+             multi-backend instance; response: {update_resp}"
+        );
+        let error_msg = update_json["results"][0]["error"]
+            .as_str()
+            .unwrap_or_default();
+        assert!(
+            error_msg.contains("from_actor"),
+            "refusal error must name `from_actor`; got: {error_msg}"
+        );
+
+        let get_after_resp = server
+            .dispatch_request_local(RequestParams {
+                ops: format!(r#"get(id="{full_id}")"#),
+                presentation: None,
+                presentation_per_op: None,
+                save_to: None,
+                format: None,
+                format_per_op: None,
+                request_id: None,
+            })
+            .await
+            .expect("get dispatch must not error");
+        let get_after_json: serde_json::Value =
+            serde_json::from_str(&get_after_resp).expect("get response is valid JSON");
+        assert_eq!(
+            get_after_json["results"][0]["result"]["properties"]["from_actor"], original_from_actor,
+            "stored from_actor must be unchanged after the refused forgery attempt"
         );
     }
 

--- a/crates/khive-mcp/src/server.rs
+++ b/crates/khive-mcp/src/server.rs
@@ -432,6 +432,16 @@ impl KhiveMcpServer {
         // update/delete verbs notify caching packs even though there is no
         // crate-level dependency between them.
         registry.call_register_note_mutation_hooks(&runtime);
+        // Note-write identity: the pack-owned kind set drives `update`'s
+        // properties refusal so a pack-owned note's identity properties
+        // cannot be overwritten by a caller-supplied `properties` patch.
+        runtime.install_pack_owned_note_kinds(
+            registry
+                .pack_owned_note_kinds()
+                .into_iter()
+                .map(str::to_string)
+                .collect(),
+        );
         // Apply pack-auxiliary schema plans at startup so pack tables are
         // present before any handler runs. Errors are logged but not propagated
         // so a single pack's schema failure cannot abort startup.

--- a/crates/khive-pack-comm/tests/integration.rs
+++ b/crates/khive-pack-comm/tests/integration.rs
@@ -9640,9 +9640,10 @@ fn build_registry_with_owned_kinds() -> (VerbRegistry, KhiveRuntime) {
 ///
 /// Table-driven over every key in `OWNER_ESTABLISHED_PROPERTIES`
 /// (khive-runtime's `curation.rs`, kept in sync by hand here since the
-/// const is crate-private and this is a different crate) so a future key
-/// added there without a matching arm here is caught by a length mismatch
-/// rather than silently under-covered. For each key, a complete snapshot of
+/// const is crate-private and this is a different crate). Nothing here
+/// detects that drift: a key added to the const without an arm added below
+/// leaves this test green and that key uncovered, so a change that protects
+/// a new key adds its arm here in the same change. For each key, a complete snapshot of
 /// the note's stored `properties` is compared before and after the refused
 /// attempt — not just a handful of named fields — so a forgery that lands
 /// on any untested field is still caught.

--- a/crates/khive-pack-comm/tests/integration.rs
+++ b/crates/khive-pack-comm/tests/integration.rs
@@ -9637,6 +9637,15 @@ fn build_registry_with_owned_kinds() -> (VerbRegistry, KhiveRuntime) {
 /// `from_actor` on a `message` note. This is the central regression test —
 /// send a message, forge via update, assert the forgery is refused and the
 /// stored value is unchanged.
+///
+/// Table-driven over every key in `OWNER_ESTABLISHED_PROPERTIES`
+/// (khive-runtime's `curation.rs`, kept in sync by hand here since the
+/// const is crate-private and this is a different crate) so a future key
+/// added there without a matching arm here is caught by a length mismatch
+/// rather than silently under-covered. For each key, a complete snapshot of
+/// the note's stored `properties` is compared before and after the refused
+/// attempt — not just a handful of named fields — so a forgery that lands
+/// on any untested field is still caught.
 #[tokio::test]
 async fn update_refuses_to_forge_owner_established_properties_on_message_note() {
     let (registry, _rt) = build_registry_with_owned_kinds();
@@ -9654,18 +9663,23 @@ async fn update_refuses_to_forge_owner_established_properties_on_message_note() 
         .expect("send must return full_id")
         .to_string();
 
-    let before = registry
-        .dispatch("get", serde_json::json!({"id": full_id}))
-        .await
-        .expect("get must succeed");
-    let original_from_actor = before["properties"]["from_actor"].clone();
-
     for (key, forged_value) in [
         ("from_actor", "lambda:leo"),
+        ("to_actor", "lambda:leo"),
         ("direction", "inbound"),
         ("sent_at", "1970-01-01T00:00:00Z"),
+        ("outbound_ref", "00000000-0000-0000-0000-000000000000"),
         ("thread_id", "forged-thread"),
+        ("subject", "forged-subject"),
+        ("wire_message_id", "<forged@example.com>"),
+        ("external_id", "<forged-external@example.com>"),
     ] {
+        let before = registry
+            .dispatch("get", serde_json::json!({"id": full_id}))
+            .await
+            .expect("get must succeed");
+        let before_props = before["properties"].clone();
+
         let err = registry
             .dispatch(
                 "update",
@@ -9685,24 +9699,19 @@ async fn update_refuses_to_forge_owner_established_properties_on_message_note() 
             "refusal error must never echo the attempted value `{forged_value}` \
              (secret-gate discipline applies to error strings); got: {msg}"
         );
-    }
 
-    let after = registry
-        .dispatch("get", serde_json::json!({"id": full_id}))
-        .await
-        .expect("get must succeed");
-    assert_eq!(
-        after["properties"]["from_actor"], original_from_actor,
-        "stored from_actor must be unchanged after every refused forgery attempt"
-    );
-    assert_eq!(
-        after["properties"]["direction"],
-        before["properties"]["direction"]
-    );
-    assert_eq!(
-        after["properties"]["sent_at"],
-        before["properties"]["sent_at"]
-    );
+        let after = registry
+            .dispatch("get", serde_json::json!({"id": full_id}))
+            .await
+            .expect("get must succeed");
+        assert_eq!(
+            after["properties"],
+            before_props,
+            "refused update naming `{key}` must leave the ENTIRE stored properties \
+             object unchanged; got before={before_props} after={after}",
+            after = after["properties"]
+        );
+    }
 }
 
 /// Positive arm: a non-owned property update on the same `message` note must

--- a/crates/khive-pack-comm/tests/integration.rs
+++ b/crates/khive-pack-comm/tests/integration.rs
@@ -9613,3 +9613,204 @@ async fn i1422_rejects_invalid_filter_and_bulk_shapes() {
         .await
         .is_err());
 }
+
+// ---- ADR-124 note-write identity guard: update-path refusal on pack-owned kinds ----
+
+/// Build a registry the same way as [`build_registry`] but also install the
+/// pack-owned note kind set, mirroring `khive-mcp`'s boot path
+/// (`KhiveMcpServer::with_packs`). Without this the runtime never learns
+/// `message` is pack-owned and the guard stays inert.
+fn build_registry_with_owned_kinds() -> (VerbRegistry, KhiveRuntime) {
+    let (registry, rt) = build_registry();
+    rt.install_pack_owned_note_kinds(
+        registry
+            .pack_owned_note_kinds()
+            .into_iter()
+            .map(str::to_string)
+            .collect(),
+    );
+    (registry, rt)
+}
+
+/// The confirmed hole, reproduced as a test: a generic `update(properties=
+/// {from_actor: ...})` must no longer be able to forge the handler-stamped
+/// `from_actor` on a `message` note. This is the central regression test —
+/// send a message, forge via update, assert the forgery is refused and the
+/// stored value is unchanged.
+#[tokio::test]
+async fn update_refuses_to_forge_owner_established_properties_on_message_note() {
+    let (registry, _rt) = build_registry_with_owned_kinds();
+
+    let sent = registry
+        .dispatch(
+            "comm.send",
+            serde_json::json!({"to": "local", "content": "identity guard probe"}),
+        )
+        .await
+        .expect("self-send must succeed");
+    let full_id = sent
+        .get("full_id")
+        .and_then(serde_json::Value::as_str)
+        .expect("send must return full_id")
+        .to_string();
+
+    let before = registry
+        .dispatch("get", serde_json::json!({"id": full_id}))
+        .await
+        .expect("get must succeed");
+    let original_from_actor = before["properties"]["from_actor"].clone();
+
+    for (key, forged_value) in [
+        ("from_actor", "lambda:leo"),
+        ("direction", "inbound"),
+        ("sent_at", "1970-01-01T00:00:00Z"),
+        ("thread_id", "forged-thread"),
+    ] {
+        let err = registry
+            .dispatch(
+                "update",
+                serde_json::json!({"id": full_id, "properties": {key: forged_value}}),
+            )
+            .await
+            .expect_err(&format!(
+                "update naming `{key}` on a message note must be refused"
+            ));
+        let msg = format!("{err}");
+        assert!(
+            msg.contains(key),
+            "refusal error must name the offending key `{key}`; got: {msg}"
+        );
+        assert!(
+            !msg.contains(forged_value),
+            "refusal error must never echo the attempted value `{forged_value}` \
+             (secret-gate discipline applies to error strings); got: {msg}"
+        );
+    }
+
+    let after = registry
+        .dispatch("get", serde_json::json!({"id": full_id}))
+        .await
+        .expect("get must succeed");
+    assert_eq!(
+        after["properties"]["from_actor"], original_from_actor,
+        "stored from_actor must be unchanged after every refused forgery attempt"
+    );
+    assert_eq!(
+        after["properties"]["direction"],
+        before["properties"]["direction"]
+    );
+    assert_eq!(
+        after["properties"]["sent_at"],
+        before["properties"]["sent_at"]
+    );
+}
+
+/// Positive arm: a non-owned property update on the same `message` note must
+/// still succeed and round-trip — the guard admits everything it does not
+/// specifically name.
+#[tokio::test]
+async fn update_admits_non_owned_properties_on_message_note() {
+    let (registry, _rt) = build_registry_with_owned_kinds();
+
+    let sent = registry
+        .dispatch(
+            "comm.send",
+            serde_json::json!({"to": "local", "content": "identity guard positive arm"}),
+        )
+        .await
+        .expect("self-send must succeed");
+    let full_id = sent
+        .get("full_id")
+        .and_then(serde_json::Value::as_str)
+        .expect("send must return full_id")
+        .to_string();
+
+    registry
+        .dispatch(
+            "update",
+            serde_json::json!({"id": full_id, "properties": {"blocked_on": "review"}}),
+        )
+        .await
+        .expect("update naming only a non-owned key must succeed");
+
+    let after = registry
+        .dispatch("get", serde_json::json!({"id": full_id}))
+        .await
+        .expect("get must succeed");
+    assert_eq!(
+        after["properties"]["blocked_on"], "review",
+        "non-owned property must round-trip"
+    );
+    assert!(
+        after["properties"]["from_actor"].is_string(),
+        "from_actor must still be present and untouched by the unrelated patch"
+    );
+}
+
+/// The guard fires only on pack-owned kinds: naming `from_actor` on a base
+/// kg note kind (e.g. `observation`) must succeed.
+#[tokio::test]
+async fn update_permits_from_actor_key_on_generic_note_kind() {
+    let (registry, _rt) = build_registry_with_owned_kinds();
+
+    let created = registry
+        .dispatch(
+            "create",
+            serde_json::json!({"kind": "observation", "content": "generic-kind arm"}),
+        )
+        .await
+        .expect("create observation must succeed");
+    let id = created
+        .get("id")
+        .and_then(serde_json::Value::as_str)
+        .expect("create must return id")
+        .to_string();
+
+    registry
+        .dispatch(
+            "update",
+            serde_json::json!({"id": id, "properties": {"from_actor": "anyone"}}),
+        )
+        .await
+        .expect("`from_actor` is not a reserved key on a non-pack-owned note kind");
+
+    let after = registry
+        .dispatch("get", serde_json::json!({"id": id}))
+        .await
+        .expect("get must succeed");
+    assert_eq!(after["properties"]["from_actor"], "anyone");
+}
+
+/// A non-object `properties` patch on a `message` note is refused: it would
+/// replace the whole property object (erasing every owned key) rather than
+/// merging into it.
+#[tokio::test]
+async fn update_refuses_non_object_properties_patch_on_message_note() {
+    let (registry, _rt) = build_registry_with_owned_kinds();
+
+    let sent = registry
+        .dispatch(
+            "comm.send",
+            serde_json::json!({"to": "local", "content": "non-object patch arm"}),
+        )
+        .await
+        .expect("self-send must succeed");
+    let full_id = sent
+        .get("full_id")
+        .and_then(serde_json::Value::as_str)
+        .expect("send must return full_id")
+        .to_string();
+
+    let err = registry
+        .dispatch(
+            "update",
+            serde_json::json!({"id": full_id, "properties": "not-an-object"}),
+        )
+        .await
+        .expect_err("a non-object properties patch on a pack-owned note must be refused");
+    let msg = format!("{err}");
+    assert!(
+        msg.contains("object"),
+        "refusal error must explain the object requirement; got: {msg}"
+    );
+}

--- a/crates/khive-runtime/src/curation.rs
+++ b/crates/khive-runtime/src/curation.rs
@@ -1288,6 +1288,47 @@ impl KhiveRuntime {
             note.decay_factor = decay_patch;
         }
         if let Some(props) = patch.properties {
+            // On a pack-owned note kind, the properties in
+            // `OWNER_ESTABLISHED_PROPERTIES` are established by the owning pack
+            // and read back by it to decide something structural — who wrote
+            // the record and when, which author-side record it copies, which
+            // conversation it belongs to. A caller cannot patch them here.
+            // Only a patch that *names* one of them is refused, and naming is
+            // the exact test: the merge below is `PreferFrom`, so a patch that
+            // names an owned key would overwrite it while a patch that does
+            // not name it leaves it intact. Every other key still merges
+            // normally — arbitrary metadata on a pack-owned record (a
+            // `blocked_on` note on a `task`) has no other write path and must
+            // keep working.
+            if self.is_pack_owned_note_kind(&note.kind) {
+                // A non-object patch names nothing, so it slips past the
+                // named-key check below and then takes `merge_json`'s
+                // non-object `PreferFrom` arm, which replaces the whole
+                // property object rather than merging into it — erasing
+                // every owned key. Refused on every pack-owned kind, not only
+                // rows that currently carry an owned key, so an identical
+                // call cannot succeed or fail on state the caller cannot see.
+                if !props.is_object() {
+                    return Err(RuntimeError::InvalidInput(format!(
+                        "properties on a `{}` note must be patched with an object: a non-object \
+                         patch names no key, so it would replace the whole property object rather \
+                         than merging into it. Pass an object containing the keys you intend to \
+                         set.",
+                        note.kind
+                    )));
+                }
+                if let Some(named) = owner_established_property_named_in(&props) {
+                    return Err(RuntimeError::InvalidInput(format!(
+                        "`{named}` is not patchable on a `{}` note: the pack that owns this \
+                         kind establishes it and reads it back — to decide how the record is \
+                         attributed and grouped, or to reproduce it verbatim when the record \
+                         is re-emitted — so it is written by the owner and immutable to a \
+                         caller patch. Patch any other property key here, or omit \
+                         `{named}` from this patch.",
+                        note.kind
+                    )));
+                }
+            }
             let (merged, _) = merge_properties(
                 &note.properties,
                 &Some(props),
@@ -2729,6 +2770,54 @@ pub(crate) fn merge_string_field(
         EntityDedupMergePolicy::PreferInto | EntityDedupMergePolicy::Union => into.to_string(),
         EntityDedupMergePolicy::PreferFrom => from.to_string(),
     }
+}
+
+/// Property keys on a pack-owned note that the owning pack establishes and
+/// then reads back to decide something structural about the record.
+///
+/// The test for membership is that both halves hold: the key is written
+/// under the owner's authority rather than from caller input, AND its value
+/// is read to decide identity, grouping, routing, lifecycle, visibility,
+/// authorization, deduplication, or membership. `from_actor`, `direction` and
+/// `sent_at` answer "who wrote this, in which direction, when"; `outbound_ref`
+/// and `thread_id` answer "which record is this one's author-side original,
+/// and which conversation does it belong to". `subject` is reproduced
+/// verbatim when a record is re-emitted; `wire_message_id` and `external_id`
+/// are the author-side citation and correlation key a reply is routed
+/// against. The set is therefore not "keys that identify a party" — it is
+/// "keys the owner established and later trusts".
+///
+/// Naming one of these in a caller-supplied `properties` patch is refused by
+/// `update` on a pack-owned kind (see [`owner_established_property_named_in`]).
+///
+/// Membership here governs writes to an EXISTING record only. Introducing one
+/// of these keys at create time is a separate question and is not addressed
+/// by this constant.
+pub(crate) const OWNER_ESTABLISHED_PROPERTIES: &[&str] = &[
+    "from_actor",
+    "direction",
+    "sent_at",
+    "outbound_ref",
+    "thread_id",
+    "subject",
+    "wire_message_id",
+    "external_id",
+];
+
+/// The first [`OWNER_ESTABLISHED_PROPERTIES`] key a caller-supplied
+/// `properties` patch names, if any.
+///
+/// Naming a key is the whole test: `update_note` folds the patch with
+/// `PreferFrom`, so a named key overwrites the stored value and an unnamed one
+/// leaves it untouched. A non-object patch names nothing.
+pub(crate) fn owner_established_property_named_in(patch: &Value) -> Option<&'static str> {
+    let Value::Object(map) = patch else {
+        return None;
+    };
+    OWNER_ESTABLISHED_PROPERTIES
+        .iter()
+        .copied()
+        .find(|key| map.contains_key(*key))
 }
 
 /// Merge two property objects. Returns (merged, count_of_fields_from_from_that_were_added).

--- a/crates/khive-runtime/src/curation.rs
+++ b/crates/khive-runtime/src/curation.rs
@@ -2790,11 +2790,19 @@ pub(crate) fn merge_string_field(
 /// Naming one of these in a caller-supplied `properties` patch is refused by
 /// `update` on a pack-owned kind (see [`owner_established_property_named_in`]).
 ///
+/// `to_actor` belongs here alongside `from_actor`: comm establishes it at
+/// send time from the `to=` param, and `comm.read` trusts a present string
+/// value to decide whether the caller is the addressee, failing open only
+/// when the key is absent or non-string. A caller must not be able to
+/// retarget a delivered message's addressee via a patch that names no other
+/// currently-protected key.
+///
 /// Membership here governs writes to an EXISTING record only. Introducing one
 /// of these keys at create time is a separate question and is not addressed
 /// by this constant.
 pub(crate) const OWNER_ESTABLISHED_PROPERTIES: &[&str] = &[
     "from_actor",
+    "to_actor",
     "direction",
     "sent_at",
     "outbound_ref",

--- a/crates/khive-runtime/src/pack.rs
+++ b/crates/khive-runtime/src/pack.rs
@@ -32,6 +32,15 @@ pub use khive_types::VerbDef;
 
 use crate::validation::ValidationRule;
 
+/// Name of the pack providing the shared CRUD verbs and the general-purpose
+/// note kinds those verbs exist to serve.
+///
+/// Its note kinds are the ones any caller may author freely through `create`
+/// and `update`; every other pack's note kinds are records maintained by that
+/// pack's own verbs. Used by
+/// [`VerbRegistry::pack_owned_note_kinds`].
+pub const GENERIC_CRUD_PACK: &str = "kg";
+
 /// Pack-auxiliary schema plan.
 ///
 /// Declares `CREATE TABLE IF NOT EXISTS` statements for pack-owned tables that
@@ -2040,6 +2049,33 @@ impl VerbRegistry {
             .iter()
             .flat_map(|p| p.note_kinds().iter().copied())
             .filter(|k| seen.insert(*k))
+            .collect()
+    }
+
+    /// Note kinds owned by a pack, i.e. every kind in [`all_note_kinds`] that
+    /// is not one of the generic-CRUD pack's own kinds.
+    ///
+    /// [`GENERIC_CRUD_PACK`] declares the general-purpose note kinds the shared
+    /// CRUD verbs exist to serve (`observation`, `insight`, …); every other
+    /// pack's kinds are records that pack's own verbs create and maintain.
+    /// Derived from the packs' `NOTE_KINDS` constants, so a pack that adds or
+    /// drops a kind moves this set with it — nothing is hardcoded here but the
+    /// name of the generic pack itself.
+    ///
+    /// [`all_note_kinds`]: Self::all_note_kinds
+    pub fn pack_owned_note_kinds(&self) -> Vec<&'static str> {
+        let generic: std::collections::HashSet<&'static str> = self
+            .packs
+            .iter()
+            .filter(|p| p.name() == GENERIC_CRUD_PACK)
+            .flat_map(|p| p.note_kinds().iter().copied())
+            .collect();
+        let mut seen = std::collections::HashSet::new();
+        self.packs
+            .iter()
+            .filter(|p| p.name() != GENERIC_CRUD_PACK)
+            .flat_map(|p| p.note_kinds().iter().copied())
+            .filter(|k| !generic.contains(k) && seen.insert(*k))
             .collect()
     }
 

--- a/crates/khive-runtime/src/runtime.rs
+++ b/crates/khive-runtime/src/runtime.rs
@@ -103,6 +103,13 @@ pub struct KhiveRuntime {
     /// no pack cares about note-mutation notifications) — the call becomes a
     /// no-op check of an `Option`.
     note_mutation_hook: Arc<RwLock<Option<NoteMutationHookFn>>>,
+    /// Pack-owned note kinds — every note kind declared by a pack other than
+    /// the generic-CRUD pack, installed by the transport from the registry
+    /// (see `VerbRegistry::pack_owned_note_kinds`). Records of these kinds are
+    /// maintained by their owning pack's own verbs, so `update`'s `properties`
+    /// patch is refused on them at the runtime layer. Empty until installed
+    /// (bare runtime), which leaves the rule inert.
+    pack_owned_note_kinds: Arc<RwLock<Vec<String>>>,
     /// The config-resolved `BlobStore` (ADR-111 Amendment 2), installed by
     /// the boot path (`khive-mcp`'s single- and multi-backend startup paths)
     /// via [`install_blob_store`](Self::install_blob_store) once `khive.toml`'s
@@ -149,6 +156,7 @@ impl KhiveRuntime {
             valid_note_kinds: Arc::new(RwLock::new(Vec::new())),
             entity_type_validator: Arc::new(RwLock::new(None)),
             note_mutation_hook: Arc::new(RwLock::new(None)),
+            pack_owned_note_kinds: Arc::new(RwLock::new(Vec::new())),
             blob_store: Arc::new(RwLock::new(None)),
         })
     }
@@ -179,6 +187,7 @@ impl KhiveRuntime {
             valid_note_kinds: Arc::new(RwLock::new(Vec::new())),
             entity_type_validator: Arc::new(RwLock::new(None)),
             note_mutation_hook: Arc::new(RwLock::new(None)),
+            pack_owned_note_kinds: Arc::new(RwLock::new(Vec::new())),
             blob_store: Arc::new(RwLock::new(None)),
         })
     }
@@ -208,6 +217,7 @@ impl KhiveRuntime {
             valid_note_kinds: Arc::new(RwLock::new(Vec::new())),
             entity_type_validator: Arc::new(RwLock::new(None)),
             note_mutation_hook: Arc::new(RwLock::new(None)),
+            pack_owned_note_kinds: Arc::new(RwLock::new(Vec::new())),
             blob_store: Arc::new(RwLock::new(None)),
         }
     }
@@ -266,6 +276,7 @@ impl KhiveRuntime {
                     valid_note_kinds: self.valid_note_kinds.clone(),
                     entity_type_validator: self.entity_type_validator.clone(),
                     note_mutation_hook: self.note_mutation_hook.clone(),
+                    pack_owned_note_kinds: self.pack_owned_note_kinds.clone(),
                     blob_store: self.blob_store.clone(),
                 }
             }
@@ -658,6 +669,28 @@ impl KhiveRuntime {
         if let Ok(mut guard) = self.valid_note_kinds.write() {
             *guard = note_kinds;
         }
+    }
+
+    /// Install the pack-owned note kinds aggregated from the pack registry.
+    ///
+    /// Called by the transport after the `VerbRegistry` is built, same timing
+    /// as [`install_kind_registry`](Self::install_kind_registry).
+    pub fn install_pack_owned_note_kinds(&self, kinds: Vec<String>) {
+        if let Ok(mut guard) = self.pack_owned_note_kinds.write() {
+            *guard = kinds;
+        }
+    }
+
+    /// Whether `kind` is a note kind owned by a pack (see
+    /// [`install_pack_owned_note_kinds`](Self::install_pack_owned_note_kinds)).
+    ///
+    /// Always `false` before the transport installs the list — a bare runtime
+    /// has no packs, so no kind is pack-owned there.
+    pub fn is_pack_owned_note_kind(&self, kind: &str) -> bool {
+        self.pack_owned_note_kinds
+            .read()
+            .map(|g| g.iter().any(|k| k == kind))
+            .unwrap_or(false)
     }
 
     /// Validate that `kind` is a pack-registered entity kind.


### PR DESCRIPTION
## What

Enforce ADR-124's owner-established property rule on the note `update` path.

A generic `update(id, properties={...})` on a **pack-owned** note kind could overwrite
properties the owning pack establishes and later reads back to decide attribution and grouping.
The clearest case: a message note's `from_actor`, stamped by the message handler from the
authenticated caller, could be replaced by an arbitrary caller-supplied value through a plain
`update`. ADR-124 (`docs/adr/ADR-124-note-write-identity.md`) specifies these properties are
immutable to a caller patch; the update path did not enforce it.

## Change

On a pack-owned note kind, `update` now refuses:
- a **non-object** `properties` patch — the property merge is `PreferFrom`, so a non-object
  patch replaces the whole property object and would erase every owner-established key at once; and
- an object patch that **names** any owner-established key:
  `from_actor`, `direction`, `sent_at`, `outbound_ref`, `thread_id`, `subject`,
  `wire_message_id`, `external_id`.

The refusal error names the offending key and the note kind only — never the attempted value.
Any other property key still merges normally, so arbitrary metadata on a pack-owned record keeps
working. The guard fires only on pack-owned kinds; base KG note kinds (`observation`, …) are
unaffected.

Supporting wiring: a runtime pack-owned-note-kind registry
(`is_pack_owned_note_kind`), populated at MCP server boot from the loaded packs, so the guard is
active on the served binary.

## Tests

`crates/khive-pack-comm/tests/integration.rs`, four new tests. The central one is structured as
the exploit itself: send a message (handler stamps `from_actor`), attempt to forge it via a
generic `update`, assert the update is refused and the stored value is unchanged — across
`from_actor`, `direction`, `sent_at`, and `thread_id`. It also asserts the error text names the
key and does not contain the forged value. Plus a positive arm (a non-owned key round-trips), a
generic-kind arm (the guard does not fire on a base note kind), and a non-object-patch arm.

## Scope and follow-ups (not addressed here)

This closes the **update** path only. Two related paths are left as separate follow-ups; both are
distinct mechanisms, not covered by the update-path refusal:

1. **Create path.** A raw `create(kind="message", properties={from_actor: ...})` currently stores
   the caller-supplied `from_actor` directly — the create path has no owner-established derivation
   step. Closing this needs a create-time guard (a comm-pack create hook, or a note-write
   derivation mechanism), tracked separately.
2. **Merge path.** A note merge that resolves properties with a prefer-from strategy can overwrite
   an owner-established key on the surviving record. No preservation of these keys exists on the
   merge path yet.

A third, narrower point: the enforced set is eight keys. A related tree carries a ninth
(`forwarded`) protecting an assembled provenance block; it is outside the attribution-integrity
scope of this change and intentionally not included.

## Verification

`cargo check --workspace`, `cargo clippy -p khive-runtime -p khive-mcp -p khive-pack-comm
--all-targets -- -D warnings`, `cargo test -p khive-runtime` (94 pass), `cargo test -p
khive-pack-comm` (integration 185 incl. the 4 new; probe 25), `cargo fmt --all -- --check` — all
green.
