### PR TITLE
fix(runtime): close the create and merge routes to owner-established properties

### DIFF
--- a/crates/khive-mcp/src/serve.rs
+++ b/crates/khive-mcp/src/serve.rs
@@ -31,6 +31,11 @@ pub struct MultiBackendRegistry {
     pub per_pack_runtimes: HashMap<String, Arc<KhiveRuntime>>,
     /// The `main` backend (needed by the coordinator to build the BackendRegistry).
     pub main_backend: Arc<StorageBackend>,
+    /// The default runtime this boot built alongside the per-pack runtimes.
+    /// A clone (cheap: internal state is `Arc<RwLock<_>>`-shared), kept so
+    /// callers — chiefly boot-wiring tests — can assert on its installed
+    /// state (e.g. `has_note_write_validator()`) without re-deriving it.
+    pub default_runtime: KhiveRuntime,
 }
 
 /// Build a server from `args`, then serve it over `--daemon` or the named transport.
@@ -1859,6 +1864,7 @@ fn build_registry_for_multi_backend_inner(
         config_id,
         per_pack_runtimes: per_pack_runtimes_arc,
         main_backend,
+        default_runtime,
     })
 }
 
@@ -4145,6 +4151,133 @@ id = "lambda:project-actor"
         assert_eq!(
             get_after_json["results"][0]["result"]["properties"]["from_actor"], original_from_actor,
             "stored from_actor must be unchanged after the refused forgery attempt"
+        );
+    }
+
+    /// ADR-124 boot-occupancy regression (multi-backend twin of
+    /// `server::tests::single_runtime_boot_installs_note_write_validator`):
+    /// `has_note_write_validator` exists specifically so a transport's own
+    /// tests can assert, per boot path, that the documented startup
+    /// sequence actually filled the slot — but nothing called it for the
+    /// multi-backend builder either. Each per-pack runtime is constructed
+    /// independently in this boot path (unlike single-backend
+    /// `with_packs`), so the validator must be installed on the default
+    /// runtime AND on every per-pack runtime, not just one — installing it
+    /// on only the default would leave `kg`'s own per-pack runtime (which
+    /// actually serves the generic `create` verb below) unenforced. Asserts
+    /// occupancy directly on all of them through the real
+    /// `build_registry_for_multi_backend_inner` builder, then proves the
+    /// slot is wired, not just occupied: a generic `create` naming a forged
+    /// `from_actor` on a `message` note must come back derived to the same
+    /// actor a legitimate `comm.send` on this server stamps, not the forged
+    /// value. Sensitivity verified by temporarily commenting out both
+    /// `registry.call_register_note_write_validators(...)` calls in
+    /// `build_registry_for_multi_backend_inner` and re-running: all
+    /// assertions fail without them (occupancy false; forged value
+    /// survives) and pass with them restored.
+    #[tokio::test]
+    #[serial]
+    async fn multi_backend_boot_installs_note_write_validator_on_every_runtime() {
+        use crate::tools::request::RequestParams;
+
+        let khive_cfg = KhiveConfig {
+            backends: vec![BackendConfig {
+                name: "main".to_string(),
+                kind: BackendKind::Memory,
+                path: None,
+                cache_mb: None,
+                journal_mode: None,
+                read_only: false,
+            }],
+            ..KhiveConfig::default()
+        };
+
+        let base_cfg = base_runtime_config_for_multi_backend();
+
+        let multi = build_registry_for_multi_backend_inner(base_cfg, &khive_cfg, None)
+            .expect("multi-backend registry build must succeed");
+
+        assert!(
+            multi.default_runtime.has_note_write_validator(),
+            "multi-backend boot must install the note-write validator on the \
+             default runtime"
+        );
+        for (pack_name, rt) in &multi.per_pack_runtimes {
+            assert!(
+                rt.has_note_write_validator(),
+                "multi-backend boot must install the note-write validator on \
+                 the per-pack runtime for {pack_name:?}"
+            );
+        }
+
+        let server = build_server_from_multi_backend_registry(multi, &khive_cfg, None);
+
+        let send_resp = server
+            .dispatch_request_local(RequestParams {
+                ops: r#"comm.send(to="local", content="adr-124 boot-occupancy actor probe")"#
+                    .to_string(),
+                presentation: None,
+                presentation_per_op: None,
+                save_to: None,
+                format: None,
+                format_per_op: None,
+                request_id: None,
+            })
+            .await
+            .expect("comm.send dispatch must not error");
+        let send_json: serde_json::Value =
+            serde_json::from_str(&send_resp).expect("send response is valid JSON");
+        assert_eq!(
+            send_json["results"][0]["ok"].as_bool(),
+            Some(true),
+            "comm.send must succeed; response: {send_resp}"
+        );
+        let full_id = send_json["results"][0]["result"]["full_id"]
+            .as_str()
+            .expect("send must return full_id")
+            .to_string();
+
+        let get_resp = server
+            .dispatch_request_local(RequestParams {
+                ops: format!(r#"get(id="{full_id}")"#),
+                presentation: None,
+                presentation_per_op: None,
+                save_to: None,
+                format: None,
+                format_per_op: None,
+                request_id: None,
+            })
+            .await
+            .expect("get dispatch must not error");
+        let get_json: serde_json::Value =
+            serde_json::from_str(&get_resp).expect("get response is valid JSON");
+        let legitimate_actor = get_json["results"][0]["result"]["properties"]["from_actor"].clone();
+
+        let create_resp = server
+            .dispatch_request_local(RequestParams {
+                ops: r#"create(kind="message", content="adr-124 boot-occupancy create probe", properties={"from_actor": "forged-actor"})"#
+                    .to_string(),
+                presentation: None,
+                presentation_per_op: None,
+                save_to: None,
+                format: None,
+                format_per_op: None,
+                request_id: None,
+            })
+            .await
+            .expect("create dispatch must not error");
+        let create_json: serde_json::Value =
+            serde_json::from_str(&create_resp).expect("create response is valid JSON");
+        assert_eq!(
+            create_json["results"][0]["ok"].as_bool(),
+            Some(true),
+            "create must succeed; response: {create_resp}"
+        );
+        assert_eq!(
+            create_json["results"][0]["result"]["properties"]["from_actor"], legitimate_actor,
+            "a forged from_actor on a generic create must come back derived to \
+             the same actor a legitimate comm.send on this server stamps, not \
+             the forged value; response: {create_resp}"
         );
     }
 

--- a/crates/khive-mcp/src/serve.rs
+++ b/crates/khive-mcp/src/serve.rs
@@ -1811,13 +1811,14 @@ fn build_registry_for_multi_backend_inner(
     // update/delete verbs notify caching packs even though there is no
     // crate-level dependency between them.
     registry.call_register_note_mutation_hooks(&default_runtime);
-    // Note-write identity: the pack-owned kind set drives `update`'s
-    // properties refusal so a pack-owned note's identity properties cannot
-    // be overwritten by a caller-supplied `properties` patch. Each per-pack
-    // runtime is constructed independently in the multi-backend boot path
-    // (unlike the single-backend `KhiveMcpServer::with_packs` path), so the
-    // registry must be installed on every runtime that could actually serve
-    // a generic `update` for a pack-owned kind, not just `default_runtime`.
+    // Note-write identity: install the pack-owned kind set and the pack-owned
+    // note-write validator so identity properties are derived at the write and
+    // preserved through merge/update on every path, including the ones that
+    // reach no pack verb. Each per-pack runtime is constructed independently
+    // in the multi-backend boot path (unlike the single-backend
+    // `KhiveMcpServer::with_packs` path), so both must be installed on every
+    // runtime that could actually serve a generic `create`/`update`/`merge`
+    // for a pack-owned kind, not just `default_runtime`.
     let owned_note_kinds: Vec<String> = registry
         .pack_owned_note_kinds()
         .into_iter()
@@ -1826,6 +1827,15 @@ fn build_registry_for_multi_backend_inner(
     default_runtime.install_pack_owned_note_kinds(owned_note_kinds.clone());
     for rt in per_pack_runtimes_local.values() {
         rt.install_pack_owned_note_kinds(owned_note_kinds.clone());
+    }
+    // The validator is installed on every runtime the kind list reaches, not
+    // just the default: each per-pack runtime is built independently, so none
+    // of them shares the default's validator slot, and `core()` clones the
+    // secondary's own slots rather than the default's. A runtime that has the
+    // kind list but no validator enforces half the rule.
+    registry.call_register_note_write_validators(&default_runtime);
+    for rt in per_pack_runtimes_local.values() {
+        registry.call_register_note_write_validators(rt);
     }
 
     let backend_for_pack: HashMap<&str, &StorageBackend> = per_pack_runtimes_local

--- a/crates/khive-mcp/src/serve.rs
+++ b/crates/khive-mcp/src/serve.rs
@@ -1811,6 +1811,22 @@ fn build_registry_for_multi_backend_inner(
     // update/delete verbs notify caching packs even though there is no
     // crate-level dependency between them.
     registry.call_register_note_mutation_hooks(&default_runtime);
+    // Note-write identity: the pack-owned kind set drives `update`'s
+    // properties refusal so a pack-owned note's identity properties cannot
+    // be overwritten by a caller-supplied `properties` patch. Each per-pack
+    // runtime is constructed independently in the multi-backend boot path
+    // (unlike the single-backend `KhiveMcpServer::with_packs` path), so the
+    // registry must be installed on every runtime that could actually serve
+    // a generic `update` for a pack-owned kind, not just `default_runtime`.
+    let owned_note_kinds: Vec<String> = registry
+        .pack_owned_note_kinds()
+        .into_iter()
+        .map(str::to_string)
+        .collect();
+    default_runtime.install_pack_owned_note_kinds(owned_note_kinds.clone());
+    for rt in per_pack_runtimes_local.values() {
+        rt.install_pack_owned_note_kinds(owned_note_kinds.clone());
+    }
 
     let backend_for_pack: HashMap<&str, &StorageBackend> = per_pack_runtimes_local
         .iter()
@@ -3990,6 +4006,135 @@ id = "lambda:project-actor"
             first_comm_ok,
             Some(true),
             "comm.send must succeed; response: {comm_resp}"
+        );
+    }
+
+    /// ADR-124 note-write identity guard: the pack-owned note kind set must
+    /// be installed on the multi-backend boot path, not only on
+    /// `KhiveMcpServer::with_packs` (single-backend). Routes `kg` and `comm`
+    /// to the same "main" backend through the real `build_server_multi_backend`
+    /// builder — no manual `install_pack_owned_note_kinds` call, unlike
+    /// `build_registry_with_owned_kinds` in the `khive-pack-comm` integration
+    /// tests — so this test exercises the actual boot wiring rather than a
+    /// hand-simulated one. Without the install this fix added in `serve.rs`
+    /// (alongside the edge-rules/note-mutation-hook installs), a generic
+    /// `update(properties={from_actor: ...})` on an inbound message note
+    /// would silently succeed on a served multi-backend instance. Verified by
+    /// temporarily reverting the `install_pack_owned_note_kinds` calls in
+    /// `build_registry_for_multi_backend_inner` and re-running this test: it
+    /// fails (`from_actor` forgery succeeds) without the fix and passes with
+    /// it restored.
+    #[tokio::test]
+    #[serial]
+    async fn multi_backend_boot_installs_owned_note_kinds_so_update_is_refused() {
+        use crate::tools::request::RequestParams;
+
+        let khive_cfg = KhiveConfig {
+            backends: vec![BackendConfig {
+                name: "main".to_string(),
+                kind: BackendKind::Memory,
+                path: None,
+                cache_mb: None,
+                journal_mode: None,
+                read_only: false,
+            }],
+            ..KhiveConfig::default()
+        };
+
+        let base_cfg = base_runtime_config_for_multi_backend();
+
+        let server = build_server_multi_backend(base_cfg, &khive_cfg, None)
+            .expect("multi-backend boot must succeed");
+
+        let send_resp = server
+            .dispatch_request_local(RequestParams {
+                ops: r#"comm.send(to="local", content="adr-124 multi-backend boot probe")"#
+                    .to_string(),
+                presentation: None,
+                presentation_per_op: None,
+                save_to: None,
+                format: None,
+                format_per_op: None,
+                request_id: None,
+            })
+            .await
+            .expect("comm.send dispatch must not error");
+        let send_json: serde_json::Value =
+            serde_json::from_str(&send_resp).expect("send response is valid JSON");
+        assert_eq!(
+            send_json["results"][0]["ok"].as_bool(),
+            Some(true),
+            "comm.send must succeed; response: {send_resp}"
+        );
+        let full_id = send_json["results"][0]["result"]["full_id"]
+            .as_str()
+            .expect("send must return full_id")
+            .to_string();
+
+        let get_before_resp = server
+            .dispatch_request_local(RequestParams {
+                ops: format!(r#"get(id="{full_id}")"#),
+                presentation: None,
+                presentation_per_op: None,
+                save_to: None,
+                format: None,
+                format_per_op: None,
+                request_id: None,
+            })
+            .await
+            .expect("get dispatch must not error");
+        let get_before_json: serde_json::Value =
+            serde_json::from_str(&get_before_resp).expect("get response is valid JSON");
+        let original_from_actor =
+            get_before_json["results"][0]["result"]["properties"]["from_actor"].clone();
+
+        let update_resp = server
+            .dispatch_request_local(RequestParams {
+                ops: format!(
+                    r#"update(id="{full_id}", properties={{"from_actor": "forged-actor"}})"#
+                ),
+                presentation: None,
+                presentation_per_op: None,
+                save_to: None,
+                format: None,
+                format_per_op: None,
+                request_id: None,
+            })
+            .await
+            .expect("update dispatch must not error");
+        let update_json: serde_json::Value =
+            serde_json::from_str(&update_resp).expect("update response is valid JSON");
+        assert_eq!(
+            update_json["results"][0]["ok"].as_bool(),
+            Some(false),
+            "update forging `from_actor` on a message note must be refused on a served \
+             multi-backend instance; response: {update_resp}"
+        );
+        let error_msg = update_json["results"][0]["error"]
+            .as_str()
+            .unwrap_or_default();
+        assert!(
+            error_msg.contains("from_actor"),
+            "refusal error must name `from_actor`; got: {error_msg}"
+        );
+
+        let get_after_resp = server
+            .dispatch_request_local(RequestParams {
+                ops: format!(r#"get(id="{full_id}")"#),
+                presentation: None,
+                presentation_per_op: None,
+                save_to: None,
+                format: None,
+                format_per_op: None,
+                request_id: None,
+            })
+            .await
+            .expect("get dispatch must not error");
+        let get_after_json: serde_json::Value =
+            serde_json::from_str(&get_after_resp).expect("get response is valid JSON");
+        assert_eq!(
+            get_after_json["results"][0]["result"]["properties"]["from_actor"], original_from_actor,
+            "stored from_actor must be unchanged after the refused forgery attempt"
         );
     }
 

--- a/crates/khive-mcp/src/server.rs
+++ b/crates/khive-mcp/src/server.rs
@@ -432,6 +432,16 @@ impl KhiveMcpServer {
         // update/delete verbs notify caching packs even though there is no
         // crate-level dependency between them.
         registry.call_register_note_mutation_hooks(&runtime);
+        // Note-write identity: the pack-owned kind set drives `update`'s
+        // properties refusal so a pack-owned note's identity properties
+        // cannot be overwritten by a caller-supplied `properties` patch.
+        runtime.install_pack_owned_note_kinds(
+            registry
+                .pack_owned_note_kinds()
+                .into_iter()
+                .map(str::to_string)
+                .collect(),
+        );
         // Apply pack-auxiliary schema plans at startup so pack tables are
         // present before any handler runs. Errors are logged but not propagated
         // so a single pack's schema failure cannot abort startup.

--- a/crates/khive-mcp/src/server.rs
+++ b/crates/khive-mcp/src/server.rs
@@ -433,8 +433,8 @@ impl KhiveMcpServer {
         // crate-level dependency between them.
         registry.call_register_note_mutation_hooks(&runtime);
         // Note-write identity: the pack-owned kind set drives `update`'s
-        // properties refusal so a pack-owned note's identity properties
-        // cannot be overwritten by a caller-supplied `properties` patch.
+        // properties refusal and `merge`'s identity preservation; the
+        // validator derives owned identity properties at every note-write.
         runtime.install_pack_owned_note_kinds(
             registry
                 .pack_owned_note_kinds()
@@ -442,6 +442,7 @@ impl KhiveMcpServer {
                 .map(str::to_string)
                 .collect(),
         );
+        registry.call_register_note_write_validators(&runtime);
         // Apply pack-auxiliary schema plans at startup so pack tables are
         // present before any handler runs. Errors are logged but not propagated
         // so a single pack's schema failure cannot abort startup.

--- a/crates/khive-mcp/src/server.rs
+++ b/crates/khive-mcp/src/server.rs
@@ -3111,6 +3111,69 @@ mod tests {
         );
     }
 
+    /// ADR-124 boot-occupancy regression: `has_note_write_validator` exists
+    /// specifically so a transport's own tests can assert, per boot path,
+    /// that the documented startup sequence actually filled the slot — but
+    /// nothing called it. Every prior ADR-124 test built its registry by
+    /// hand (`registry.call_register_note_write_validators(&rt)` in
+    /// `khive-pack-comm`'s integration tests), which proves the validator
+    /// works but proves nothing about whether `with_packs` — the single-
+    /// backend production boot path — installs it. Asserts occupancy
+    /// directly through the real builder, then proves the slot is not just
+    /// occupied but functioning: a generic `create` naming a forged
+    /// `from_actor` on a `message` note must come back derived to the
+    /// dispatching token's actor. Sensitivity verified by temporarily
+    /// commenting out the `registry.call_register_note_write_validators(&runtime);`
+    /// line in `KhiveMcpServer::with_packs` and re-running: both assertions
+    /// fail without it (occupancy false; forged value survives) and pass
+    /// with it restored.
+    #[tokio::test]
+    async fn single_runtime_boot_installs_note_write_validator() {
+        let config = RuntimeConfig {
+            db_path: None,
+            default_namespace: Namespace::local(),
+            embedding_model: None,
+            additional_embedding_models: vec![],
+            packs: vec!["kg".to_string(), "comm".to_string()],
+            ..RuntimeConfig::default()
+        };
+        let runtime = KhiveRuntime::new(config).expect("in-memory runtime");
+        let runtime_probe = runtime.clone();
+        let server = KhiveMcpServer::with_packs(runtime, &["kg".to_string(), "comm".to_string()])
+            .expect("server builds with kg + comm");
+
+        assert!(
+            runtime_probe.has_note_write_validator(),
+            "with_packs (single-backend boot) must install the note-write \
+             validator on the runtime it serves writes through"
+        );
+
+        let identity = khive_runtime::RequestIdentity {
+            namespace: "local".to_string(),
+            actor_id: Some("lambda:probe".to_string()),
+            ..Default::default()
+        };
+        let created = server
+            .registry
+            .dispatch_with_identity(
+                "create",
+                serde_json::json!({
+                    "kind": "message",
+                    "content": "single-runtime boot occupancy probe",
+                    "properties": {"from_actor": "forged-actor"},
+                }),
+                Some(identity),
+            )
+            .await
+            .expect("create must succeed");
+        assert_eq!(
+            created["properties"]["from_actor"], "lambda:probe",
+            "a forged from_actor on a generic create must come back derived to \
+             the dispatching token's actor, proving the installed validator is \
+             not just present but wired into the write path; got {created:?}"
+        );
+    }
+
     // ── relative backend paths must not collide across projects ────────────
 
     /// RAII guard: temporarily chdirs into `dir`, restoring the original cwd

--- a/crates/khive-pack-comm/src/pack.rs
+++ b/crates/khive-pack-comm/src/pack.rs
@@ -36,6 +36,50 @@ impl CommPack {
     }
 }
 
+/// Derive a `message` note's authored-by identity from the authorization
+/// token, whatever the caller supplied.
+///
+/// `comm.send` already resolves `from_actor` from `token.actor().id`
+/// (`handlers.rs::handle_send`); this is that same resolution applied at the
+/// runtime note-write, so a `message` row's `from_actor` is a function of the
+/// token on every write path rather than of caller input on some of them. The
+/// derived value therefore names the actor whose token performed the write —
+/// on the proposal-apply path that is the applying caller, not the proposer
+/// who composed the changeset.
+///
+/// Only `from_actor` is derived. `direction` and `sent_at` are equally
+/// identity-bearing (they are preserved through `merge` and refused by
+/// `update`), but neither is a function of the token: `dual_write_message`
+/// writes an inbound copy with `direction="inbound"` under the sender's own
+/// token, and `comm.ingest` carries a transport-supplied `sent_at`. Deriving
+/// either here would overwrite a value a legitimate caller must set.
+///
+/// Kinds other than `message` — including comm's own `channel_health` — pass
+/// through untouched: the runtime holds one validator slot for all packs.
+pub(crate) fn derive_message_identity(
+    kind: &str,
+    actor_id: &str,
+    properties: Option<Value>,
+) -> Result<Option<Value>, RuntimeError> {
+    if kind != "message" {
+        return Ok(properties);
+    }
+    let mut props = match properties {
+        Some(Value::Object(map)) => map,
+        Some(other) => {
+            return Err(RuntimeError::InvalidInput(format!(
+                "a `message` note's properties must be a JSON object, got: {other}"
+            )));
+        }
+        None => serde_json::Map::new(),
+    };
+    props.insert(
+        "from_actor".to_string(),
+        Value::String(actor_id.to_string()),
+    );
+    Ok(Some(Value::Object(props)))
+}
+
 struct CommPackFactory;
 
 impl khive_runtime::PackFactory for CommPackFactory {
@@ -65,6 +109,9 @@ impl PackRuntime for CommPack {
     }
     fn handlers(&self) -> &'static [HandlerDef] {
         &COMM_HANDLERS
+    }
+    fn register_note_write_validator(&self, runtime: &KhiveRuntime) {
+        runtime.install_note_write_validator(std::sync::Arc::new(derive_message_identity));
     }
     fn requires(&self) -> &'static [&'static str] {
         <CommPack as Pack>::REQUIRES

--- a/crates/khive-pack-comm/tests/integration.rs
+++ b/crates/khive-pack-comm/tests/integration.rs
@@ -9640,9 +9640,10 @@ fn build_registry_with_owned_kinds() -> (VerbRegistry, KhiveRuntime) {
 ///
 /// Table-driven over every key in `OWNER_ESTABLISHED_PROPERTIES`
 /// (khive-runtime's `curation.rs`, kept in sync by hand here since the
-/// const is crate-private and this is a different crate) so a future key
-/// added there without a matching arm here is caught by a length mismatch
-/// rather than silently under-covered. For each key, a complete snapshot of
+/// const is crate-private and this is a different crate). Nothing here
+/// detects that drift: a key added to the const without an arm added below
+/// leaves this test green and that key uncovered, so a change that protects
+/// a new key adds its arm here in the same change. For each key, a complete snapshot of
 /// the note's stored `properties` is compared before and after the refused
 /// attempt — not just a handful of named fields — so a forgery that lands
 /// on any untested field is still caught.

--- a/crates/khive-pack-comm/tests/integration.rs
+++ b/crates/khive-pack-comm/tests/integration.rs
@@ -9,8 +9,8 @@ use std::sync::Arc;
 
 use khive_pack_comm::CommPack;
 use khive_runtime::{
-    AllowAllGate, BackendId, KhiveRuntime, Namespace, NamespaceToken, RuntimeConfig, VerbRegistry,
-    VerbRegistryBuilder,
+    AllowAllGate, BackendId, KhiveRuntime, Namespace, NamespaceToken, RequestIdentity,
+    RuntimeConfig, VerbRegistry, VerbRegistryBuilder,
 };
 use khive_storage::types::{SqlRow, SqlValue};
 use khive_types::Pack;
@@ -9632,6 +9632,18 @@ fn build_registry_with_owned_kinds() -> (VerbRegistry, KhiveRuntime) {
     (registry, rt)
 }
 
+/// Build a registry the same way as [`build_registry_with_owned_kinds`] but
+/// also install the pack-owned note-write validator, mirroring both
+/// `khive-mcp` boot paths. A test exercising the CREATE- or MERGE-path guard
+/// against a registry that skips this call proves nothing: the derive/preserve
+/// step is inert on an unwired runtime exactly like the update-path refusal
+/// was inert before `install_pack_owned_note_kinds` existed.
+fn build_registry_with_owned_kinds_and_validator() -> (VerbRegistry, KhiveRuntime) {
+    let (registry, rt) = build_registry_with_owned_kinds();
+    registry.call_register_note_write_validators(&rt);
+    (registry, rt)
+}
+
 /// The confirmed hole, reproduced as a test: a generic `update(properties=
 /// {from_actor: ...})` must no longer be able to forge the handler-stamped
 /// `from_actor` on a `message` note. This is the central regression test —
@@ -9822,5 +9834,336 @@ async fn update_refuses_non_object_properties_patch_on_message_note() {
     assert!(
         msg.contains("object"),
         "refusal error must explain the object requirement; got: {msg}"
+    );
+}
+
+// ---- ADR-124 note-write identity guard: CREATE-path derivation ----
+
+/// FORGE arm: a generic `create(kind="message", properties={from_actor:
+/// "forged"})` call under an authenticated token for actor X must store
+/// `from_actor == X` — the true caller — not the forged value. This is not a
+/// refusal: the create succeeds and the identity property is silently
+/// corrected to the value the authorization token actually names.
+#[tokio::test]
+async fn create_derives_from_actor_overwriting_a_forged_value() {
+    let (registry, _rt) = build_registry_with_owned_kinds_and_validator();
+    let true_actor = "lambda:true-caller";
+
+    let created = registry
+        .dispatch_with_identity(
+            "create",
+            serde_json::json!({
+                "kind": "message",
+                "content": "create-path forgery probe",
+                "properties": {"from_actor": "forged"},
+            }),
+            Some(RequestIdentity {
+                namespace: "local".to_string(),
+                actor_id: Some(true_actor.to_string()),
+                ..Default::default()
+            }),
+        )
+        .await
+        .expect("create must succeed — the guard derives, it does not refuse");
+
+    assert_eq!(
+        created["properties"]["from_actor"], true_actor,
+        "the stored from_actor must be the authenticated caller, not the forged value"
+    );
+}
+
+/// LEGITIMATE-NO-KEY arm: a `create(kind="message", content=...)` with no
+/// `from_actor` in properties at all must still come out stamped with the
+/// authenticated caller.
+#[tokio::test]
+async fn create_stamps_from_actor_when_caller_supplies_no_identity_key() {
+    let (registry, _rt) = build_registry_with_owned_kinds_and_validator();
+    let true_actor = "lambda:no-key-caller";
+
+    let created = registry
+        .dispatch_with_identity(
+            "create",
+            serde_json::json!({
+                "kind": "message",
+                "content": "create-path no-key probe",
+            }),
+            Some(RequestIdentity {
+                namespace: "local".to_string(),
+                actor_id: Some(true_actor.to_string()),
+                ..Default::default()
+            }),
+        )
+        .await
+        .expect("create with no properties key must succeed");
+
+    assert_eq!(
+        created["properties"]["from_actor"], true_actor,
+        "an absent from_actor key must be stamped with the authenticated caller"
+    );
+}
+
+/// DAEMON-STAMP arm: the real `comm.send` writer path must still stamp
+/// `from_actor` correctly and succeed once the validator is installed. A
+/// guard that broke the writer that is supposed to set `from_actor` would
+/// fail closed into an outage — prove it does not.
+#[tokio::test]
+async fn comm_send_still_stamps_from_actor_with_validator_installed() {
+    let (registry, _rt) = build_registry_with_owned_kinds_and_validator();
+    let true_actor = "lambda:sender";
+
+    let sent = registry
+        .dispatch_with_identity(
+            "comm.send",
+            serde_json::json!({"to": "local", "content": "validator does not break comm.send"}),
+            Some(RequestIdentity {
+                namespace: "local".to_string(),
+                actor_id: Some(true_actor.to_string()),
+                ..Default::default()
+            }),
+        )
+        .await
+        .expect("comm.send must still succeed with the validator installed");
+
+    let full_id = sent
+        .get("full_id")
+        .and_then(serde_json::Value::as_str)
+        .expect("send must return full_id")
+        .to_string();
+    let after = registry
+        .dispatch("get", serde_json::json!({"id": full_id}))
+        .await
+        .expect("get must succeed");
+    assert_eq!(
+        after["properties"]["from_actor"], true_actor,
+        "comm.send's own from_actor stamp must still be the sending actor"
+    );
+}
+
+/// GENERIC-KIND arm: the validator is single-occupancy across all packs, so
+/// a `create` on a kind comm does not own (`observation`, owned by kg) must
+/// pass its properties through untouched.
+#[tokio::test]
+async fn create_leaves_generic_kind_properties_untouched() {
+    let (registry, _rt) = build_registry_with_owned_kinds_and_validator();
+
+    let created = registry
+        .dispatch_with_identity(
+            "create",
+            serde_json::json!({
+                "kind": "observation",
+                "content": "generic-kind create arm",
+                "properties": {"from_actor": "x"},
+            }),
+            Some(RequestIdentity {
+                namespace: "local".to_string(),
+                actor_id: Some("lambda:someone-else".to_string()),
+                ..Default::default()
+            }),
+        )
+        .await
+        .expect("create observation must succeed");
+
+    assert_eq!(
+        created["properties"]["from_actor"], "x",
+        "a foreign (non-message) kind's properties must pass through the validator unchanged"
+    );
+}
+
+// ---- ADR-124 note-write identity guard: MERGE-path preservation ----
+
+async fn send_message_as(registry: &VerbRegistry, actor: &str, content: &str) -> String {
+    let sent = registry
+        .dispatch_with_identity(
+            "comm.send",
+            serde_json::json!({"to": "local", "content": content}),
+            Some(RequestIdentity {
+                namespace: "local".to_string(),
+                actor_id: Some(actor.to_string()),
+                ..Default::default()
+            }),
+        )
+        .await
+        .expect("self-send must succeed");
+    sent.get("full_id")
+        .and_then(serde_json::Value::as_str)
+        .expect("send must return full_id")
+        .to_string()
+}
+
+/// FORGERY-BLOCKED arm: merging a `message` note authored by Y into one
+/// authored by X with `strategy="prefer_from"` — the attack this guard
+/// exists for — must leave the surviving note's `from_actor` as X, not Y.
+#[tokio::test]
+async fn merge_preserves_into_note_from_actor_under_prefer_from() {
+    let (registry, _rt) = build_registry_with_owned_kinds_and_validator();
+
+    let into_id = send_message_as(&registry, "lambda:x", "into-note, authored by X").await;
+    let from_id = send_message_as(&registry, "lambda:y", "from-note, authored by Y").await;
+
+    registry
+        .dispatch(
+            "merge",
+            serde_json::json!({
+                "kind": "message",
+                "into_id": into_id,
+                "from_id": from_id,
+                "strategy": "prefer_from",
+            }),
+        )
+        .await
+        .expect("merge must succeed");
+
+    let after = registry
+        .dispatch("get", serde_json::json!({"id": into_id}))
+        .await
+        .expect("get must succeed");
+    assert_eq!(
+        after["properties"]["from_actor"], "lambda:x",
+        "prefer_from must not be able to transfer attribution from the absorbed note"
+    );
+}
+
+/// CONTROL arm: the same merge under `strategy="prefer_into"` must also
+/// leave `from_actor` as X — proving the preserve step is not just
+/// coincidentally matching the default fold direction.
+#[tokio::test]
+async fn merge_preserves_into_note_from_actor_under_prefer_into() {
+    let (registry, _rt) = build_registry_with_owned_kinds_and_validator();
+
+    let into_id = send_message_as(&registry, "lambda:x", "into-note, control arm").await;
+    let from_id = send_message_as(&registry, "lambda:y", "from-note, control arm").await;
+
+    registry
+        .dispatch(
+            "merge",
+            serde_json::json!({
+                "kind": "message",
+                "into_id": into_id,
+                "from_id": from_id,
+                "strategy": "prefer_into",
+            }),
+        )
+        .await
+        .expect("merge must succeed");
+
+    let after = registry
+        .dispatch("get", serde_json::json!({"id": into_id}))
+        .await
+        .expect("get must succeed");
+    assert_eq!(after["properties"]["from_actor"], "lambda:x");
+}
+
+/// NON-IDENTITY-KEY arm: a non-owned property that differs between the two
+/// notes still folds by strategy — `prefer_from` takes the from-note's
+/// value — proving the preserve step pins only the owner-established keys,
+/// not the whole property object.
+#[tokio::test]
+async fn merge_still_folds_non_owned_properties_by_strategy() {
+    let (registry, _rt) = build_registry_with_owned_kinds_and_validator();
+
+    let into_id = send_message_as(&registry, "lambda:x", "into-note, non-identity arm").await;
+    let from_id = send_message_as(&registry, "lambda:y", "from-note, non-identity arm").await;
+
+    registry
+        .dispatch(
+            "update",
+            serde_json::json!({"id": into_id, "properties": {"tag": "into-tag"}}),
+        )
+        .await
+        .expect("update must succeed");
+    registry
+        .dispatch(
+            "update",
+            serde_json::json!({"id": from_id, "properties": {"tag": "from-tag"}}),
+        )
+        .await
+        .expect("update must succeed");
+
+    registry
+        .dispatch(
+            "merge",
+            serde_json::json!({
+                "kind": "message",
+                "into_id": into_id,
+                "from_id": from_id,
+                "strategy": "prefer_from",
+            }),
+        )
+        .await
+        .expect("merge must succeed");
+
+    let after = registry
+        .dispatch("get", serde_json::json!({"id": into_id}))
+        .await
+        .expect("get must succeed");
+    assert_eq!(
+        after["properties"]["tag"], "from-tag",
+        "a non-owned key must still fold by strategy — only owner-established keys are pinned"
+    );
+    assert_eq!(
+        after["properties"]["from_actor"], "lambda:x",
+        "the owner-established key must remain pinned to the into-note in the same merge"
+    );
+}
+
+/// GENERIC-KIND arm: merging two `observation` notes (a kind comm does not
+/// own) under `prefer_from` must let a `from_actor`-named property overwrite
+/// normally — the preservation guard fires only on pack-owned kinds.
+#[tokio::test]
+async fn merge_overwrites_from_actor_on_generic_kind_under_prefer_from() {
+    let (registry, _rt) = build_registry_with_owned_kinds_and_validator();
+
+    let into_created = registry
+        .dispatch(
+            "create",
+            serde_json::json!({
+                "kind": "observation",
+                "content": "into observation",
+                "properties": {"from_actor": "x"},
+            }),
+        )
+        .await
+        .expect("create must succeed");
+    let into_id = into_created["id"]
+        .as_str()
+        .expect("create must return id")
+        .to_string();
+
+    let from_created = registry
+        .dispatch(
+            "create",
+            serde_json::json!({
+                "kind": "observation",
+                "content": "from observation",
+                "properties": {"from_actor": "y"},
+            }),
+        )
+        .await
+        .expect("create must succeed");
+    let from_id = from_created["id"]
+        .as_str()
+        .expect("create must return id")
+        .to_string();
+
+    registry
+        .dispatch(
+            "merge",
+            serde_json::json!({
+                "kind": "observation",
+                "into_id": into_id,
+                "from_id": from_id,
+                "strategy": "prefer_from",
+            }),
+        )
+        .await
+        .expect("merge must succeed");
+
+    let after = registry
+        .dispatch("get", serde_json::json!({"id": into_id}))
+        .await
+        .expect("get must succeed");
+    assert_eq!(
+        after["properties"]["from_actor"], "y",
+        "on a non-pack-owned kind, prefer_from must overwrite from_actor normally"
     );
 }

--- a/crates/khive-pack-comm/tests/integration.rs
+++ b/crates/khive-pack-comm/tests/integration.rs
@@ -10387,3 +10387,100 @@ async fn merge_reports_zero_properties_merged_for_nested_union_reversion() {
          got {merged}"
     );
 }
+
+/// ROUTE-LEVEL RESTORATION arm: the whole scenario driven through the pack's
+/// actual `comm.send`/`create` + `merge` verbs (not `count_new_property_keys`
+/// called directly — that unit-level coverage already lives in
+/// `khive-runtime`'s `curation.rs` tests), on a pack-owned `message` note.
+///
+/// `external_id` is an `OWNER_ESTABLISHED_PROPERTIES` key `comm.send` never
+/// sets, so the into-note's property map genuinely lacks the key entirely
+/// (unlike `subject`, which `comm.send` always writes, even as `null` — a
+/// present-but-null key would already be "in" the into-note's map and
+/// wouldn't exercise the "absent from into" removal path). The from-note is
+/// built with `create` so `properties` can name `external_id` directly.
+///
+/// Under `prefer_from` the fold treats `external_id` as a genuinely new key
+/// — the into-note's property map does not have it — and counts it as one
+/// contribution. Restoration then reverts it: `external_id` is absent on the
+/// into-note, so it is removed from the merged result rather than kept.
+/// Nothing the fold counted actually survives, so `properties_merged` must
+/// report 0, and the into-note's owner-established properties (here
+/// `from_actor`) must still read as the into-note's own, not the absorbed
+/// note's.
+#[tokio::test]
+async fn merge_reports_zero_properties_merged_when_restoration_reverts_the_only_new_key_through_the_route(
+) {
+    let (registry, _rt) = build_registry_with_owned_kinds_and_validator();
+
+    let into_id = send_message_as(
+        &registry,
+        "lambda:x",
+        "into note, route-level restoration arm — no external_id",
+    )
+    .await;
+
+    let from_created = registry
+        .dispatch_with_identity(
+            "create",
+            serde_json::json!({
+                "kind": "message",
+                "content": "from note, route-level restoration arm — has an external_id",
+                "properties": {"external_id": "wire-abc-123"},
+            }),
+            Some(RequestIdentity {
+                namespace: "local".to_string(),
+                actor_id: Some("lambda:y".to_string()),
+                ..Default::default()
+            }),
+        )
+        .await
+        .expect("create must succeed");
+    let from_id = from_created["id"]
+        .as_str()
+        .expect("create must return id")
+        .to_string();
+
+    let before = registry
+        .dispatch("get", serde_json::json!({"id": into_id}))
+        .await
+        .expect("get must succeed");
+    assert!(
+        before["properties"].get("external_id").is_none(),
+        "fixture invariant: the into-note must not already carry an \
+         `external_id`; got {before}"
+    );
+
+    let merged = registry
+        .dispatch(
+            "merge",
+            serde_json::json!({
+                "kind": "message",
+                "into_id": into_id,
+                "from_id": from_id,
+                "strategy": "prefer_from",
+            }),
+        )
+        .await
+        .expect("merge must succeed");
+
+    let after = registry
+        .dispatch("get", serde_json::json!({"id": into_id}))
+        .await
+        .expect("get must succeed");
+    assert!(
+        after["properties"].get("external_id").is_none(),
+        "restoration must strip the absorbed note's `external_id`, since the \
+         into-note never had one — got {after}"
+    );
+    assert_eq!(
+        after["properties"]["from_actor"], "lambda:x",
+        "the into-note's owner-established `from_actor` must survive the merge \
+         unchanged"
+    );
+    assert_eq!(
+        merged["properties_merged"], 0,
+        "the only key the fold counted as new (`external_id`) was reverted by \
+         restoration, so nothing genuinely survived; got {merged}"
+    );
+}

--- a/crates/khive-pack-comm/tests/integration.rs
+++ b/crates/khive-pack-comm/tests/integration.rs
@@ -10069,8 +10069,20 @@ async fn merge_preserves_into_note_from_actor_under_prefer_from() {
 }
 
 /// CONTROL arm: the same merge under `strategy="prefer_into"` must also
-/// leave `from_actor` as X — proving the preserve step is not just
-/// coincidentally matching the default fold direction.
+/// leave `from_actor` as X.
+///
+/// Honesty note (khive-oss PR #1690 round 3): this arm is NOT sensitive to
+/// the preservation step being removed. `PreferInto`'s fold
+/// (`merge_json` in `khive-runtime`'s `curation.rs`) only ever inserts a
+/// `from`-note key that is absent on `into` — `from_actor` is already
+/// present on X's into-note before the merge runs, so the fold itself never
+/// touches it. This arm stays green with `preserve_owner_established_properties`
+/// deleted entirely; it is a legitimate control (it proves the merge doesn't
+/// silently overwrite under this strategy) but it is NOT evidence the guard
+/// works. `merge_preserves_into_note_from_actor_under_prefer_from` above is
+/// the arm carrying the security-relevant assertion: `PreferFrom`'s fold
+/// does overwrite `from_actor` with Y's value, so that arm only passes
+/// because the preserve step reverts it.
 #[tokio::test]
 async fn merge_preserves_into_note_from_actor_under_prefer_into() {
     let (registry, _rt) = build_registry_with_owned_kinds_and_validator();
@@ -10290,5 +10302,88 @@ async fn merge_reports_properties_merged_for_key_that_actually_survives() {
         after["properties"]["to_actor"], "into",
         "the owner-established key must remain pinned to the into-note, not \
          the from-note's value"
+    );
+}
+
+/// NESTED-UNION arm: an owner-established key that holds an OBJECT
+/// (`thread_id`) merged under `strategy="union"` must not be double-counted
+/// either. The round-2 fix above corrected the flat case
+/// (`merge_reports_properties_merged_for_key_that_actually_survives`); this
+/// is the nested case that fix left uncorrected. Under `union` the fold
+/// recurses into `thread_id` and counts the absorbed note's nested key as a
+/// merged contribution, but restoration then reverts `thread_id` wholesale
+/// back to the into-note's pre-merge value — so nothing the fold counted
+/// actually survived, and `properties_merged` must report 0.
+#[tokio::test]
+async fn merge_reports_zero_properties_merged_for_nested_union_reversion() {
+    let (registry, _rt) = build_registry_with_owned_kinds_and_validator();
+
+    let identity = RequestIdentity {
+        namespace: "local".to_string(),
+        actor_id: Some("lambda:z".to_string()),
+        ..Default::default()
+    };
+
+    let into_created = registry
+        .dispatch_with_identity(
+            "create",
+            serde_json::json!({
+                "kind": "message",
+                "content": "into note, nested-union accuracy arm",
+                "properties": {"thread_id": {"keep": 1}},
+            }),
+            Some(identity.clone()),
+        )
+        .await
+        .expect("create must succeed");
+    let into_id = into_created["id"]
+        .as_str()
+        .expect("create must return id")
+        .to_string();
+
+    let from_created = registry
+        .dispatch_with_identity(
+            "create",
+            serde_json::json!({
+                "kind": "message",
+                "content": "from note, nested-union accuracy arm",
+                "properties": {"thread_id": {"discarded": 2}},
+            }),
+            Some(identity),
+        )
+        .await
+        .expect("create must succeed");
+    let from_id = from_created["id"]
+        .as_str()
+        .expect("create must return id")
+        .to_string();
+
+    let merged = registry
+        .dispatch(
+            "merge",
+            serde_json::json!({
+                "kind": "message",
+                "into_id": into_id,
+                "from_id": from_id,
+                "strategy": "union",
+            }),
+        )
+        .await
+        .expect("merge must succeed");
+
+    let after = registry
+        .dispatch("get", serde_json::json!({"id": into_id}))
+        .await
+        .expect("get must succeed");
+    assert_eq!(
+        after["properties"]["thread_id"],
+        serde_json::json!({"keep": 1}),
+        "the absorbed note's nested contribution must not survive restoration"
+    );
+    assert_eq!(
+        merged["properties_merged"], 0,
+        "nothing from the absorbed note actually survived restoration, so \
+         properties_merged must report 0, not the nested fold's raw count; \
+         got {merged}"
     );
 }

--- a/crates/khive-pack-comm/tests/integration.rs
+++ b/crates/khive-pack-comm/tests/integration.rs
@@ -9637,6 +9637,15 @@ fn build_registry_with_owned_kinds() -> (VerbRegistry, KhiveRuntime) {
 /// `from_actor` on a `message` note. This is the central regression test —
 /// send a message, forge via update, assert the forgery is refused and the
 /// stored value is unchanged.
+///
+/// Table-driven over every key in `OWNER_ESTABLISHED_PROPERTIES`
+/// (khive-runtime's `curation.rs`, kept in sync by hand here since the
+/// const is crate-private and this is a different crate) so a future key
+/// added there without a matching arm here is caught by a length mismatch
+/// rather than silently under-covered. For each key, a complete snapshot of
+/// the note's stored `properties` is compared before and after the refused
+/// attempt — not just a handful of named fields — so a forgery that lands
+/// on any untested field is still caught.
 #[tokio::test]
 async fn update_refuses_to_forge_owner_established_properties_on_message_note() {
     let (registry, _rt) = build_registry_with_owned_kinds();
@@ -9654,18 +9663,23 @@ async fn update_refuses_to_forge_owner_established_properties_on_message_note() 
         .expect("send must return full_id")
         .to_string();
 
-    let before = registry
-        .dispatch("get", serde_json::json!({"id": full_id}))
-        .await
-        .expect("get must succeed");
-    let original_from_actor = before["properties"]["from_actor"].clone();
-
     for (key, forged_value) in [
         ("from_actor", "lambda:leo"),
+        ("to_actor", "lambda:leo"),
         ("direction", "inbound"),
         ("sent_at", "1970-01-01T00:00:00Z"),
+        ("outbound_ref", "00000000-0000-0000-0000-000000000000"),
         ("thread_id", "forged-thread"),
+        ("subject", "forged-subject"),
+        ("wire_message_id", "<forged@example.com>"),
+        ("external_id", "<forged-external@example.com>"),
     ] {
+        let before = registry
+            .dispatch("get", serde_json::json!({"id": full_id}))
+            .await
+            .expect("get must succeed");
+        let before_props = before["properties"].clone();
+
         let err = registry
             .dispatch(
                 "update",
@@ -9685,24 +9699,19 @@ async fn update_refuses_to_forge_owner_established_properties_on_message_note() 
             "refusal error must never echo the attempted value `{forged_value}` \
              (secret-gate discipline applies to error strings); got: {msg}"
         );
-    }
 
-    let after = registry
-        .dispatch("get", serde_json::json!({"id": full_id}))
-        .await
-        .expect("get must succeed");
-    assert_eq!(
-        after["properties"]["from_actor"], original_from_actor,
-        "stored from_actor must be unchanged after every refused forgery attempt"
-    );
-    assert_eq!(
-        after["properties"]["direction"],
-        before["properties"]["direction"]
-    );
-    assert_eq!(
-        after["properties"]["sent_at"],
-        before["properties"]["sent_at"]
-    );
+        let after = registry
+            .dispatch("get", serde_json::json!({"id": full_id}))
+            .await
+            .expect("get must succeed");
+        assert_eq!(
+            after["properties"],
+            before_props,
+            "refused update naming `{key}` must leave the ENTIRE stored properties \
+             object unchanged; got before={before_props} after={after}",
+            after = after["properties"]
+        );
+    }
 }
 
 /// Positive arm: a non-owned property update on the same `message` note must

--- a/crates/khive-pack-comm/tests/integration.rs
+++ b/crates/khive-pack-comm/tests/integration.rs
@@ -9613,3 +9613,204 @@ async fn i1422_rejects_invalid_filter_and_bulk_shapes() {
         .await
         .is_err());
 }
+
+// ---- ADR-124 note-write identity guard: update-path refusal on pack-owned kinds ----
+
+/// Build a registry the same way as [`build_registry`] but also install the
+/// pack-owned note kind set, mirroring `khive-mcp`'s boot path
+/// (`KhiveMcpServer::with_packs`). Without this the runtime never learns
+/// `message` is pack-owned and the guard stays inert.
+fn build_registry_with_owned_kinds() -> (VerbRegistry, KhiveRuntime) {
+    let (registry, rt) = build_registry();
+    rt.install_pack_owned_note_kinds(
+        registry
+            .pack_owned_note_kinds()
+            .into_iter()
+            .map(str::to_string)
+            .collect(),
+    );
+    (registry, rt)
+}
+
+/// The confirmed hole, reproduced as a test: a generic `update(properties=
+/// {from_actor: ...})` must no longer be able to forge the handler-stamped
+/// `from_actor` on a `message` note. This is the central regression test —
+/// send a message, forge via update, assert the forgery is refused and the
+/// stored value is unchanged.
+#[tokio::test]
+async fn update_refuses_to_forge_owner_established_properties_on_message_note() {
+    let (registry, _rt) = build_registry_with_owned_kinds();
+
+    let sent = registry
+        .dispatch(
+            "comm.send",
+            serde_json::json!({"to": "local", "content": "identity guard probe"}),
+        )
+        .await
+        .expect("self-send must succeed");
+    let full_id = sent
+        .get("full_id")
+        .and_then(serde_json::Value::as_str)
+        .expect("send must return full_id")
+        .to_string();
+
+    let before = registry
+        .dispatch("get", serde_json::json!({"id": full_id}))
+        .await
+        .expect("get must succeed");
+    let original_from_actor = before["properties"]["from_actor"].clone();
+
+    for (key, forged_value) in [
+        ("from_actor", "lambda:leo"),
+        ("direction", "inbound"),
+        ("sent_at", "1970-01-01T00:00:00Z"),
+        ("thread_id", "forged-thread"),
+    ] {
+        let err = registry
+            .dispatch(
+                "update",
+                serde_json::json!({"id": full_id, "properties": {key: forged_value}}),
+            )
+            .await
+            .expect_err(&format!(
+                "update naming `{key}` on a message note must be refused"
+            ));
+        let msg = format!("{err}");
+        assert!(
+            msg.contains(key),
+            "refusal error must name the offending key `{key}`; got: {msg}"
+        );
+        assert!(
+            !msg.contains(forged_value),
+            "refusal error must never echo the attempted value `{forged_value}` \
+             (secret-gate discipline applies to error strings); got: {msg}"
+        );
+    }
+
+    let after = registry
+        .dispatch("get", serde_json::json!({"id": full_id}))
+        .await
+        .expect("get must succeed");
+    assert_eq!(
+        after["properties"]["from_actor"], original_from_actor,
+        "stored from_actor must be unchanged after every refused forgery attempt"
+    );
+    assert_eq!(
+        after["properties"]["direction"],
+        before["properties"]["direction"]
+    );
+    assert_eq!(
+        after["properties"]["sent_at"],
+        before["properties"]["sent_at"]
+    );
+}
+
+/// Positive arm: a non-owned property update on the same `message` note must
+/// still succeed and round-trip — the guard admits everything it does not
+/// specifically name.
+#[tokio::test]
+async fn update_admits_non_owned_properties_on_message_note() {
+    let (registry, _rt) = build_registry_with_owned_kinds();
+
+    let sent = registry
+        .dispatch(
+            "comm.send",
+            serde_json::json!({"to": "local", "content": "identity guard positive arm"}),
+        )
+        .await
+        .expect("self-send must succeed");
+    let full_id = sent
+        .get("full_id")
+        .and_then(serde_json::Value::as_str)
+        .expect("send must return full_id")
+        .to_string();
+
+    registry
+        .dispatch(
+            "update",
+            serde_json::json!({"id": full_id, "properties": {"blocked_on": "review"}}),
+        )
+        .await
+        .expect("update naming only a non-owned key must succeed");
+
+    let after = registry
+        .dispatch("get", serde_json::json!({"id": full_id}))
+        .await
+        .expect("get must succeed");
+    assert_eq!(
+        after["properties"]["blocked_on"], "review",
+        "non-owned property must round-trip"
+    );
+    assert!(
+        after["properties"]["from_actor"].is_string(),
+        "from_actor must still be present and untouched by the unrelated patch"
+    );
+}
+
+/// The guard fires only on pack-owned kinds: naming `from_actor` on a base
+/// kg note kind (e.g. `observation`) must succeed.
+#[tokio::test]
+async fn update_permits_from_actor_key_on_generic_note_kind() {
+    let (registry, _rt) = build_registry_with_owned_kinds();
+
+    let created = registry
+        .dispatch(
+            "create",
+            serde_json::json!({"kind": "observation", "content": "generic-kind arm"}),
+        )
+        .await
+        .expect("create observation must succeed");
+    let id = created
+        .get("id")
+        .and_then(serde_json::Value::as_str)
+        .expect("create must return id")
+        .to_string();
+
+    registry
+        .dispatch(
+            "update",
+            serde_json::json!({"id": id, "properties": {"from_actor": "anyone"}}),
+        )
+        .await
+        .expect("`from_actor` is not a reserved key on a non-pack-owned note kind");
+
+    let after = registry
+        .dispatch("get", serde_json::json!({"id": id}))
+        .await
+        .expect("get must succeed");
+    assert_eq!(after["properties"]["from_actor"], "anyone");
+}
+
+/// A non-object `properties` patch on a `message` note is refused: it would
+/// replace the whole property object (erasing every owned key) rather than
+/// merging into it.
+#[tokio::test]
+async fn update_refuses_non_object_properties_patch_on_message_note() {
+    let (registry, _rt) = build_registry_with_owned_kinds();
+
+    let sent = registry
+        .dispatch(
+            "comm.send",
+            serde_json::json!({"to": "local", "content": "non-object patch arm"}),
+        )
+        .await
+        .expect("self-send must succeed");
+    let full_id = sent
+        .get("full_id")
+        .and_then(serde_json::Value::as_str)
+        .expect("send must return full_id")
+        .to_string();
+
+    let err = registry
+        .dispatch(
+            "update",
+            serde_json::json!({"id": full_id, "properties": "not-an-object"}),
+        )
+        .await
+        .expect_err("a non-object properties patch on a pack-owned note must be refused");
+    let msg = format!("{err}");
+    assert!(
+        msg.contains("object"),
+        "refusal error must explain the object requirement; got: {msg}"
+    );
+}

--- a/crates/khive-runtime/src/atomic_prepare.rs
+++ b/crates/khive-runtime/src/atomic_prepare.rs
@@ -502,6 +502,12 @@ pub async fn prepare_add_note(
 
     let name = optional_create_string(args, "name")?;
     let properties = optional_properties(args, "properties")?;
+    // Same note-write validator `create_note_inner` runs: this path builds its
+    // args itself and dispatches no pack hook, so without this call a proposal
+    // changeset would be the one note-write that stores caller-supplied owned
+    // identity properties verbatim. The token here is the applying caller's
+    // (threaded in by the apply worker), not the proposer's.
+    let properties = runtime.derive_note_write_properties(kind, token, properties)?;
 
     crate::secret_gate::check(content)?;
     if let Some(ref n) = name {

--- a/crates/khive-runtime/src/curation.rs
+++ b/crates/khive-runtime/src/curation.rs
@@ -2947,10 +2947,14 @@ pub(crate) fn count_new_property_keys(
             count_new_keys_within_object(orig_map, final_map, strategy)
         }
         // The record ended up holding an object where it previously held
-        // something else, so every key it now carries is new. Counting the keys
-        // rather than scoring the replacement as 1 matters when restoration has
-        // emptied the object: nothing survived, and the count must say so.
-        (Some(_), Some(Value::Object(final_map))) => final_map.len(),
+        // something else. `merge_json` scores that replacement as ONE
+        // contribution however many keys the new object carries, and this arm
+        // keeps that rule rather than counting the keys — the alternative
+        // silently changes `properties_merged` for ordinary notes, which never
+        // enter the restoration path and were being reported correctly by the
+        // fold. The single exception is an object restoration has emptied: no
+        // key survived, so there is no contribution left to report.
+        (Some(_), Some(Value::Object(final_map))) => usize::from(!final_map.is_empty()),
         // Whole-value replacement by a non-object. `merge_json` scores a
         // `PreferFrom` fold that replaces one properties value with a
         // differently-shaped one as a single contribution, and that is the right
@@ -7733,7 +7737,21 @@ mod tests {
 
         for (into, from, label) in [
             (json!({"a": 1}), json!(5), "object replaced by scalar"),
-            (json!(7), json!({"b": 2}), "scalar replaced by object"),
+            (
+                json!(7),
+                json!({"b": 2}),
+                "scalar replaced by single-key object",
+            ),
+            // A whole-value replacement is ONE contribution however many keys
+            // the replacing object carries. The single-key vector above cannot
+            // see the difference between that rule and counting the object's
+            // keys, so it stayed green while the count was wrong for ordinary
+            // notes. This vector is the one that distinguishes them.
+            (
+                json!(7),
+                json!({"b": 2, "c": 3}),
+                "scalar replaced by multi-key object",
+            ),
         ] {
             let (merged, fold_count) = merge_json(&into, &from, EntityDedupMergePolicy::PreferFrom);
             let recomputed = count_new_property_keys(

--- a/crates/khive-runtime/src/curation.rs
+++ b/crates/khive-runtime/src/curation.rs
@@ -1466,6 +1466,12 @@ impl KhiveRuntime {
             let _ = self.vectors_for_model(token, model_name)?;
         }
 
+        // Resolved here, where the runtime's installed pack-kind list is in
+        // reach; `merge_note_sql` runs on the writer connection with no runtime
+        // handle. Both notes share a kind (checked inside), so the into-note's
+        // kind decides for the merge.
+        let preserve_owner_established = self.is_pack_owned_note_kind(&into_note.kind);
+
         let pool = self.backend().pool_arc();
         let writer_task = pool.writer_task_handle().ok().flatten();
 
@@ -1483,6 +1489,7 @@ impl KhiveRuntime {
                         content_strategy,
                         dry_run,
                         pack_rules,
+                        preserve_owner_established,
                     )
                     .map_err(|e| {
                         khive_storage::StorageError::driver(
@@ -1509,6 +1516,7 @@ impl KhiveRuntime {
                         content_strategy,
                         dry_run,
                         pack_rules,
+                        preserve_owner_established,
                     )
                 })
             })
@@ -2354,6 +2362,7 @@ fn merge_note_sql(
     content_strategy: ContentMergeStrategy,
     dry_run: bool,
     pack_rules: Vec<EdgeEndpointRule>,
+    preserve_owner_established: bool,
 ) -> Result<(MergeSummary, khive_storage::note::Note), SqliteError> {
     let into_note = read_merge_note(conn, into_id, &namespace)?;
     let from_note = read_merge_note(conn, from_id, &namespace)?;
@@ -2454,8 +2463,18 @@ fn merge_note_sql(
         _ => into_note.name.clone().or(from_note.name.clone()),
     };
 
-    let (merged_props, properties_merged) =
+    let (mut merged_props, mut properties_merged) =
         merge_properties(&into_note.properties, &from_note.properties, strategy);
+
+    // A merge folds two records together; it does not transfer attribution.
+    // On a pack-owned note kind the into-note's owned identity properties are
+    // restored after the fold, under every strategy including `PreferFrom`, so
+    // the surviving row still says who wrote it.
+    if preserve_owner_established {
+        let reverted =
+            preserve_owner_established_properties(&into_note.properties, &mut merged_props);
+        properties_merged = properties_merged.saturating_sub(reverted);
+    }
 
     let merge_history_entry = serde_json::json!({
         "merged_from": from_id.to_string(),
@@ -2826,6 +2845,67 @@ pub(crate) fn owner_established_property_named_in(patch: &Value) -> Option<&'sta
         .iter()
         .copied()
         .find(|key| map.contains_key(*key))
+}
+
+/// Restore the into-note's [`OWNER_ESTABLISHED_PROPERTIES`] into `merged`
+/// after a property fold, and return how many of them the fold had taken from
+/// the from-note (so the caller can correct its merged-field count).
+///
+/// A key absent on the into-note is removed from `merged` rather than left as
+/// the from-note's value: a record that carried no owner-established value
+/// must not acquire one by being merged into. That applies to grouping as much
+/// as to attribution — a note with no `thread_id` must not join a conversation
+/// because another note was folded into it.
+///
+/// A fold can also yield a value that is not an object at all: `merge_json`
+/// applies a non-object `from` directly under `PreferFrom`, replacing the
+/// into-note's whole object with a scalar. A scalar cannot carry the
+/// owner-established keys, so there is nothing to restore them into and they
+/// would be erased. The into-note's properties are kept instead — the scalar
+/// contributes no key that could coexist with them, so nothing the fold
+/// intended is lost.
+pub(crate) fn preserve_owner_established_properties(
+    into: &Option<Value>,
+    merged: &mut Option<Value>,
+) -> usize {
+    if !matches!(merged, Some(Value::Object(_))) {
+        let Some(Value::Object(into_map)) = into else {
+            return 0;
+        };
+        let owned_on_into = OWNER_ESTABLISHED_PROPERTIES
+            .iter()
+            .filter(|key| into_map.contains_key(**key))
+            .count();
+        if owned_on_into > 0 {
+            *merged = into.clone();
+        }
+        return owned_on_into;
+    }
+    let Some(Value::Object(merged_map)) = merged.as_mut() else {
+        return 0;
+    };
+    let into_map = match into {
+        Some(Value::Object(m)) => Some(m),
+        _ => None,
+    };
+    let mut reverted = 0usize;
+    for key in OWNER_ESTABLISHED_PROPERTIES {
+        let original = into_map.and_then(|m| m.get(*key));
+        match original {
+            Some(value) => {
+                let replaced = merged_map.insert((*key).to_string(), value.clone());
+                if replaced.as_ref() != Some(value) {
+                    reverted += 1;
+                }
+            }
+            None => {
+                if merged_map.remove(*key).is_some() {
+                    reverted += 1;
+                }
+            }
+        }
+    }
+    reverted
 }
 
 /// Merge two property objects. Returns (merged, count_of_fields_from_from_that_were_added).

--- a/crates/khive-runtime/src/curation.rs
+++ b/crates/khive-runtime/src/curation.rs
@@ -2483,8 +2483,11 @@ fn merge_note_sql(
     // partial reversal of a nested contribution. Diffing the final object
     // against the into-note's pre-merge properties sidesteps that fold/
     // restoration coupling entirely.
-    let properties_merged =
-        count_new_property_keys(into_note.properties.as_ref(), merged_props.as_ref());
+    let properties_merged = count_new_property_keys(
+        into_note.properties.as_ref(),
+        merged_props.as_ref(),
+        strategy,
+    );
 
     let merge_history_entry = serde_json::json!({
         "merged_from": from_id.to_string(),
@@ -2934,21 +2937,26 @@ pub(crate) fn preserve_owner_established_properties(
 pub(crate) fn count_new_property_keys(
     original: Option<&Value>,
     final_value: Option<&Value>,
+    strategy: EntityDedupMergePolicy,
 ) -> usize {
     match (original, final_value) {
         (_, None) => 0,
         (None, Some(Value::Object(map))) => map.len(),
         (None, Some(_)) => 1,
         (Some(Value::Object(orig_map)), Some(Value::Object(final_map))) => {
-            count_new_keys_within_object(orig_map, final_map)
+            count_new_keys_within_object(orig_map, final_map, strategy)
         }
-        // Whole-value replacement. `merge_json` scores a `PreferFrom` fold that
-        // replaces one properties value with a differently-shaped one as a
-        // single contribution, and that is the right answer: something from the
-        // from-note is what the record now holds. This arm exists so the
-        // recomputed count agrees with the fold there — a bare 0 here would
-        // under-report every scalar/object replacement, including on note kinds
-        // that have no owner-established properties and never enter the
+        // The record ended up holding an object where it previously held
+        // something else, so every key it now carries is new. Counting the keys
+        // rather than scoring the replacement as 1 matters when restoration has
+        // emptied the object: nothing survived, and the count must say so.
+        (Some(_), Some(Value::Object(final_map))) => final_map.len(),
+        // Whole-value replacement by a non-object. `merge_json` scores a
+        // `PreferFrom` fold that replaces one properties value with a
+        // differently-shaped one as a single contribution, and that is the right
+        // answer: what the record now holds came from the from-note. A bare 0
+        // here would under-report every such replacement, including on note
+        // kinds that have no owner-established properties and never enter the
         // restoration path at all. Equal values mean nothing was contributed,
         // which is the `properties: Some(a)` merged with `properties: None`
         // case.
@@ -2958,25 +2966,39 @@ pub(crate) fn count_new_property_keys(
 
 /// Per-key counting inside a properties object.
 ///
-/// Deliberately NOT the same rule as the top level: within an object, a key
-/// that already exists and is merely overwritten counts 0, matching
-/// `merge_json`'s rule that only keys absent from the into-note are counted as
-/// added. Only nested objects recurse, so a nested contribution is counted at
-/// the depth it actually occurred.
+/// Deliberately NOT the same rule as the top level: within an object, a key that
+/// already exists and is merely overwritten counts 0, matching `merge_json`'s
+/// rule that only keys absent from the into-note are counted as added.
+///
+/// Recursion is STRATEGY-AWARE, and it has to be, because `merge_json` only
+/// descends into a same-named nested object under [`Union`]. Under `PreferFrom`
+/// an existing top-level key is replaced wholesale, and under `PreferInto` it is
+/// kept wholesale; in neither case is anything merged *beneath* that key, so
+/// descending here would count a nested value that the fold never treated as a
+/// separate contribution. Counting `{"meta":{"old":1}}` merged with
+/// `{"meta":{"new":2}}` under `PreferFrom` as 1 is exactly that mistake — one
+/// existing property was replaced, none was added.
+///
+/// [`Union`]: EntityDedupMergePolicy::Union
 fn count_new_keys_within_object(
     orig_map: &serde_json::Map<String, Value>,
     final_map: &serde_json::Map<String, Value>,
+    strategy: EntityDedupMergePolicy,
 ) -> usize {
     final_map
         .iter()
         .map(|(key, value)| match orig_map.get(key) {
             None => 1,
-            Some(Value::Object(nested_orig)) => match value {
-                Value::Object(nested_final) => {
-                    count_new_keys_within_object(nested_orig, nested_final)
+            Some(Value::Object(nested_orig))
+                if matches!(strategy, EntityDedupMergePolicy::Union) =>
+            {
+                match value {
+                    Value::Object(nested_final) => {
+                        count_new_keys_within_object(nested_orig, nested_final, strategy)
+                    }
+                    _ => 0,
                 }
-                _ => 0,
-            },
+            }
             Some(_) => 0,
         })
         .sum()
@@ -7714,7 +7736,11 @@ mod tests {
             (json!(7), json!({"b": 2}), "scalar replaced by object"),
         ] {
             let (merged, fold_count) = merge_json(&into, &from, EntityDedupMergePolicy::PreferFrom);
-            let recomputed = count_new_property_keys(Some(&into), Some(&merged));
+            let recomputed = count_new_property_keys(
+                Some(&into),
+                Some(&merged),
+                EntityDedupMergePolicy::PreferFrom,
+            );
             assert_eq!(
                 recomputed, fold_count,
                 "{label}: recomputed count must match the fold's own count",
@@ -7730,16 +7756,102 @@ mod tests {
             &json!({"a": 2}),
             EntityDedupMergePolicy::PreferFrom,
         );
-        let recomputed = count_new_property_keys(Some(&json!({"a": 1})), Some(&merged));
+        let recomputed = count_new_property_keys(
+            Some(&json!({"a": 1})),
+            Some(&merged),
+            EntityDedupMergePolicy::PreferFrom,
+        );
         assert_eq!(fold_count, 0, "control: overwrite is never a fold addition");
         assert_eq!(recomputed, 0, "control: overwrite is never a new key");
 
         // Control: equal values mean nothing was contributed (the `from` note
         // carrying no properties at all).
         assert_eq!(
-            count_new_property_keys(Some(&json!({"a": 1})), Some(&json!({"a": 1}))),
+            count_new_property_keys(
+                Some(&json!({"a": 1})),
+                Some(&json!({"a": 1})),
+                EntityDedupMergePolicy::PreferFrom,
+            ),
             0,
             "control: an unchanged properties object contributes nothing",
+        );
+    }
+
+    /// Recursion into a same-named nested object is only correct under `Union`.
+    ///
+    /// `merge_json` descends into a nested object ONLY for `Union`. Under
+    /// `PreferFrom` an existing top-level key is replaced wholesale and under
+    /// `PreferInto` it is kept wholesale, so nothing is merged beneath that key
+    /// and nothing beneath it may be counted. An earlier version of the
+    /// recomputation recursed unconditionally and reported 1 for the
+    /// `PreferFrom` case below, where one existing property was replaced and
+    /// none was added. This affects ordinary notes with no owner-established
+    /// properties, which never reach the restoration path at all.
+    #[test]
+    fn recomputed_count_recurses_into_nested_objects_only_under_union() {
+        use serde_json::json;
+
+        let into = json!({"meta": {"old": 1}});
+        let from = json!({"meta": {"new": 2}});
+
+        for (strategy, expected, label) in [
+            (
+                EntityDedupMergePolicy::PreferFrom,
+                0,
+                "prefer_from replaces the whole key",
+            ),
+            (
+                EntityDedupMergePolicy::PreferInto,
+                0,
+                "prefer_into keeps the whole key",
+            ),
+            (
+                EntityDedupMergePolicy::Union,
+                1,
+                "union merges beneath the key",
+            ),
+        ] {
+            let (merged, fold_count) = merge_json(&into, &from, strategy);
+            let recomputed = count_new_property_keys(Some(&into), Some(&merged), strategy);
+            assert_eq!(
+                recomputed, fold_count,
+                "{label}: recomputed count must match the fold's own count",
+            );
+            assert_eq!(recomputed, expected, "{label}");
+        }
+    }
+
+    /// An object emptied by restoration contributed nothing, and the count must
+    /// say so.
+    ///
+    /// When the surviving record's properties were not an object and the fold
+    /// installed the from-note's object, restoration removes the owner keys the
+    /// survivor never had — which can leave `{}`. Scoring that as a whole-value
+    /// replacement would report 1 for a record holding no properties at all.
+    #[test]
+    fn recomputed_count_is_zero_when_restoration_empties_the_object() {
+        use serde_json::json;
+
+        assert_eq!(
+            count_new_property_keys(
+                Some(&json!("scalar-properties")),
+                Some(&json!({})),
+                EntityDedupMergePolicy::PreferFrom,
+            ),
+            0,
+            "an emptied object retains nothing from the absorbed record",
+        );
+
+        // Control: the same shape with a surviving key counts that key, so the
+        // arm above is not simply returning 0 for every non-object original.
+        assert_eq!(
+            count_new_property_keys(
+                Some(&json!("scalar-properties")),
+                Some(&json!({"kept": 1})),
+                EntityDedupMergePolicy::PreferFrom,
+            ),
+            1,
+            "a surviving key is still counted",
         );
     }
 }

--- a/crates/khive-runtime/src/curation.rs
+++ b/crates/khive-runtime/src/curation.rs
@@ -2463,7 +2463,7 @@ fn merge_note_sql(
         _ => into_note.name.clone().or(from_note.name.clone()),
     };
 
-    let (mut merged_props, mut properties_merged) =
+    let (mut merged_props, _) =
         merge_properties(&into_note.properties, &from_note.properties, strategy);
 
     // A merge folds two records together; it does not transfer attribution.
@@ -2471,10 +2471,20 @@ fn merge_note_sql(
     // restored after the fold, under every strategy including `PreferFrom`, so
     // the surviving row still says who wrote it.
     if preserve_owner_established {
-        let reverted =
-            preserve_owner_established_properties(&into_note.properties, &mut merged_props);
-        properties_merged = properties_merged.saturating_sub(reverted);
+        preserve_owner_established_properties(&into_note.properties, &mut merged_props);
     }
+
+    // Recomputed from the final retained properties rather than carried
+    // forward from the fold's own count. The fold's count and post-
+    // restoration reality diverge whenever an owner-established key holds a
+    // nested object: `union` recurses into it and counts the absorbed
+    // note's leaf as merged, but restoration then reverts the whole key,
+    // and the fold's flat "keys contributed" number cannot express a
+    // partial reversal of a nested contribution. Diffing the final object
+    // against the into-note's pre-merge properties sidesteps that fold/
+    // restoration coupling entirely.
+    let properties_merged =
+        count_new_property_keys(into_note.properties.as_ref(), merged_props.as_ref());
 
     let merge_history_entry = serde_json::json!({
         "merged_from": from_id.to_string(),
@@ -2848,9 +2858,7 @@ pub(crate) fn owner_established_property_named_in(patch: &Value) -> Option<&'sta
 }
 
 /// Restore the into-note's [`OWNER_ESTABLISHED_PROPERTIES`] into `merged`
-/// after a property fold, and return how many of the fold's counted
-/// `from`-contributed keys this restoration took back out (so the caller can
-/// correct its merged-field count).
+/// after a property fold.
 ///
 /// A key absent on the into-note is removed from `merged` rather than left as
 /// the from-note's value: a record that carried no owner-established value
@@ -2858,73 +2866,120 @@ pub(crate) fn owner_established_property_named_in(patch: &Value) -> Option<&'sta
 /// as to attribution — a note with no `thread_id` must not join a conversation
 /// because another note was folded into it.
 ///
-/// The returned count only covers that removal case. `merge_json`'s fold only
-/// counts a key as "added" when it was absent from `into` — a key already
-/// present on `into` is never counted, even when the fold's chosen strategy
-/// (e.g. `PreferFrom`) overwrote its value with the from-note's. Restoring
-/// such a key's original value here (the `Some` arm below) therefore reverts
-/// a change the fold never counted in the first place, and must not be
-/// subtracted from `properties_merged` — doing so double-counts and can drive
-/// the reported total below the number of non-owned keys that genuinely
-/// survived the merge.
-///
 /// A fold can also yield a value that is not an object at all: `merge_json`
 /// applies a non-object `from` directly under `PreferFrom`, replacing the
 /// into-note's whole object with a scalar. A scalar cannot carry the
 /// owner-established keys, so there is nothing to restore them into and they
 /// would be erased. The into-note's properties are kept instead — the scalar
 /// contributes no key that could coexist with them, so nothing the fold
-/// intended is lost. That branch returns the number of owner-established keys
-/// found on the into-note, which is not itself a fold count: the fold scores a
-/// scalar `PreferFrom` replace as exactly 1 regardless of how many keys the
-/// into-note carried. The two agree only after the caller's `saturating_sub`,
-/// which clamps to the correct answer of zero merged properties whenever the
-/// replace is undone. Returning the key count rather than 1 is therefore safe
-/// here but is not a value any other caller should read as a fold count.
+/// intended is lost.
+///
+/// This function only restores values; callers that need to report how many
+/// properties genuinely survived a merge should diff the final result
+/// against the into-note's pre-merge properties (see
+/// [`count_new_property_keys`]) rather than try to track the restoration as
+/// a correction to the fold's own count — a nested owner-established value
+/// (an object) makes that correction ill-defined, since the fold's flat
+/// "keys contributed" number cannot express a partial reversal of a nested
+/// contribution.
 pub(crate) fn preserve_owner_established_properties(
     into: &Option<Value>,
     merged: &mut Option<Value>,
-) -> usize {
+) {
     if !matches!(merged, Some(Value::Object(_))) {
         let Some(Value::Object(into_map)) = into else {
-            return 0;
+            return;
         };
         let owned_on_into = OWNER_ESTABLISHED_PROPERTIES
             .iter()
-            .filter(|key| into_map.contains_key(**key))
-            .count();
-        if owned_on_into > 0 {
+            .any(|key| into_map.contains_key(*key));
+        if owned_on_into {
             *merged = into.clone();
         }
-        return owned_on_into;
+        return;
     }
     let Some(Value::Object(merged_map)) = merged.as_mut() else {
-        return 0;
+        return;
     };
     let into_map = match into {
         Some(Value::Object(m)) => Some(m),
         _ => None,
     };
-    let mut reverted_from_fold = 0usize;
     for key in OWNER_ESTABLISHED_PROPERTIES {
-        let original = into_map.and_then(|m| m.get(*key));
-        match original {
+        match into_map.and_then(|m| m.get(*key)) {
             Some(value) => {
-                // Already present on `into` — the fold never counted an
-                // overwrite of this key, so restoring it is not a reversal of
-                // any counted addition.
+                // Already present on `into` — restore it verbatim.
                 merged_map.insert((*key).to_string(), value.clone());
             }
             None => {
-                // Absent from `into` — any value the fold placed here came
-                // from `from` and WAS counted as an added property.
-                if merged_map.remove(*key).is_some() {
-                    reverted_from_fold += 1;
-                }
+                // Absent from `into` — a value here came from `from` and
+                // must not survive the merge.
+                merged_map.remove(*key);
             }
         }
     }
-    reverted_from_fold
+}
+
+/// Count properties present in `final_value` that are new relative to
+/// `original` — the same "did this key actually get added" question
+/// [`merge_json`]'s fold answers, but computed from what the record finally
+/// holds rather than carried forward through the fold-then-restore pipeline.
+///
+/// A key present in both `original` and `final_value` is never counted, even
+/// when its value changed — this matches `merge_json`'s own rule that an
+/// overwrite of a key already present on `into` is not a merged addition.
+/// Nested objects recurse only when the key exists on both sides (mirroring
+/// `merge_json`'s `Union` recursion); a key that is wholly new at some level
+/// counts once for that level, not once per leaf beneath it.
+pub(crate) fn count_new_property_keys(
+    original: Option<&Value>,
+    final_value: Option<&Value>,
+) -> usize {
+    match (original, final_value) {
+        (_, None) => 0,
+        (None, Some(Value::Object(map))) => map.len(),
+        (None, Some(_)) => 1,
+        (Some(Value::Object(orig_map)), Some(Value::Object(final_map))) => {
+            count_new_keys_within_object(orig_map, final_map)
+        }
+        // Whole-value replacement. `merge_json` scores a `PreferFrom` fold that
+        // replaces one properties value with a differently-shaped one as a
+        // single contribution, and that is the right answer: something from the
+        // from-note is what the record now holds. This arm exists so the
+        // recomputed count agrees with the fold there — a bare 0 here would
+        // under-report every scalar/object replacement, including on note kinds
+        // that have no owner-established properties and never enter the
+        // restoration path at all. Equal values mean nothing was contributed,
+        // which is the `properties: Some(a)` merged with `properties: None`
+        // case.
+        (Some(orig), Some(final_val)) => usize::from(orig != final_val),
+    }
+}
+
+/// Per-key counting inside a properties object.
+///
+/// Deliberately NOT the same rule as the top level: within an object, a key
+/// that already exists and is merely overwritten counts 0, matching
+/// `merge_json`'s rule that only keys absent from the into-note are counted as
+/// added. Only nested objects recurse, so a nested contribution is counted at
+/// the depth it actually occurred.
+fn count_new_keys_within_object(
+    orig_map: &serde_json::Map<String, Value>,
+    final_map: &serde_json::Map<String, Value>,
+) -> usize {
+    final_map
+        .iter()
+        .map(|(key, value)| match orig_map.get(key) {
+            None => 1,
+            Some(Value::Object(nested_orig)) => match value {
+                Value::Object(nested_final) => {
+                    count_new_keys_within_object(nested_orig, nested_final)
+                }
+                _ => 0,
+            },
+            Some(_) => 0,
+        })
+        .sum()
 }
 
 /// Merge two property objects. Returns (merged, count_of_fields_from_from_that_were_added).
@@ -7635,5 +7690,56 @@ mod tests {
 
         assert_eq!(stored.title, expected.title, "title after merge");
         assert_eq!(stored.body, expected.body, "body after merge");
+    }
+
+    /// The recomputed `properties_merged` count must agree with the fold on
+    /// whole-value replacement.
+    ///
+    /// `merge_json` scores a `PreferFrom` replace of one properties value by a
+    /// differently-shaped one as a single contribution. An earlier version of
+    /// `count_new_property_keys` returned 0 for that shape, which under-reported
+    /// every such merge — including on note kinds with no owner-established
+    /// properties, which never enter the restoration path and were being counted
+    /// correctly before the recompute was introduced. Measured at the time:
+    /// fold=1, recompute=0, on both orderings.
+    ///
+    /// The flat-overwrite control is load-bearing: it is what distinguishes this
+    /// test from one that a function returning 1 unconditionally would also pass.
+    #[test]
+    fn recomputed_count_agrees_with_fold_on_whole_value_replacement() {
+        use serde_json::json;
+
+        for (into, from, label) in [
+            (json!({"a": 1}), json!(5), "object replaced by scalar"),
+            (json!(7), json!({"b": 2}), "scalar replaced by object"),
+        ] {
+            let (merged, fold_count) = merge_json(&into, &from, EntityDedupMergePolicy::PreferFrom);
+            let recomputed = count_new_property_keys(Some(&into), Some(&merged));
+            assert_eq!(
+                recomputed, fold_count,
+                "{label}: recomputed count must match the fold's own count",
+            );
+            assert_eq!(recomputed, 1, "{label}: one value was contributed");
+        }
+
+        // Control: an ordinary overwrite of an existing key contributes nothing
+        // under BOTH rules. Without this arm, a function returning 1 for every
+        // differing pair would pass the loop above.
+        let (merged, fold_count) = merge_json(
+            &json!({"a": 1}),
+            &json!({"a": 2}),
+            EntityDedupMergePolicy::PreferFrom,
+        );
+        let recomputed = count_new_property_keys(Some(&json!({"a": 1})), Some(&merged));
+        assert_eq!(fold_count, 0, "control: overwrite is never a fold addition");
+        assert_eq!(recomputed, 0, "control: overwrite is never a new key");
+
+        // Control: equal values mean nothing was contributed (the `from` note
+        // carrying no properties at all).
+        assert_eq!(
+            count_new_property_keys(Some(&json!({"a": 1})), Some(&json!({"a": 1}))),
+            0,
+            "control: an unchanged properties object contributes nothing",
+        );
     }
 }

--- a/crates/khive-runtime/src/curation.rs
+++ b/crates/khive-runtime/src/curation.rs
@@ -2952,8 +2952,10 @@ pub(crate) fn count_new_property_keys(
         // keeps that rule rather than counting the keys — the alternative
         // silently changes `properties_merged` for ordinary notes, which never
         // enter the restoration path and were being reported correctly by the
-        // fold. The single exception is an object restoration has emptied: no
-        // key survived, so there is no contribution left to report.
+        // fold. The rule here is: an empty final object has no contribution
+        // left to report, whatever emptied it — restoration removing every
+        // owner-established key is one way that happens, but an ordinary
+        // `PreferFrom` replacement with an empty object reaches this same arm.
         (Some(_), Some(Value::Object(final_map))) => usize::from(!final_map.is_empty()),
         // Whole-value replacement by a non-object. `merge_json` scores a
         // `PreferFrom` fold that replaces one properties value with a

--- a/crates/khive-runtime/src/curation.rs
+++ b/crates/khive-runtime/src/curation.rs
@@ -1288,6 +1288,47 @@ impl KhiveRuntime {
             note.decay_factor = decay_patch;
         }
         if let Some(props) = patch.properties {
+            // On a pack-owned note kind, the properties in
+            // `OWNER_ESTABLISHED_PROPERTIES` are established by the owning pack
+            // and read back by it to decide something structural — who wrote
+            // the record and when, which author-side record it copies, which
+            // conversation it belongs to. A caller cannot patch them here.
+            // Only a patch that *names* one of them is refused, and naming is
+            // the exact test: the merge below is `PreferFrom`, so a patch that
+            // names an owned key would overwrite it while a patch that does
+            // not name it leaves it intact. Every other key still merges
+            // normally — arbitrary metadata on a pack-owned record (a
+            // `blocked_on` note on a `task`) has no other write path and must
+            // keep working.
+            if self.is_pack_owned_note_kind(&note.kind) {
+                // A non-object patch names nothing, so it slips past the
+                // named-key check below and then takes `merge_json`'s
+                // non-object `PreferFrom` arm, which replaces the whole
+                // property object rather than merging into it — erasing
+                // every owned key. Refused on every pack-owned kind, not only
+                // rows that currently carry an owned key, so an identical
+                // call cannot succeed or fail on state the caller cannot see.
+                if !props.is_object() {
+                    return Err(RuntimeError::InvalidInput(format!(
+                        "properties on a `{}` note must be patched with an object: a non-object \
+                         patch names no key, so it would replace the whole property object rather \
+                         than merging into it. Pass an object containing the keys you intend to \
+                         set.",
+                        note.kind
+                    )));
+                }
+                if let Some(named) = owner_established_property_named_in(&props) {
+                    return Err(RuntimeError::InvalidInput(format!(
+                        "`{named}` is not patchable on a `{}` note: the pack that owns this \
+                         kind establishes it and reads it back — to decide how the record is \
+                         attributed and grouped, or to reproduce it verbatim when the record \
+                         is re-emitted — so it is written by the owner and immutable to a \
+                         caller patch. Patch any other property key here, or omit \
+                         `{named}` from this patch.",
+                        note.kind
+                    )));
+                }
+            }
             let (merged, _) = merge_properties(
                 &note.properties,
                 &Some(props),
@@ -2729,6 +2770,54 @@ pub(crate) fn merge_string_field(
         EntityDedupMergePolicy::PreferInto | EntityDedupMergePolicy::Union => into.to_string(),
         EntityDedupMergePolicy::PreferFrom => from.to_string(),
     }
+}
+
+/// Property keys on a pack-owned note that the owning pack establishes and
+/// then reads back to decide something structural about the record.
+///
+/// The test for membership is that both halves hold: the key is written
+/// under the owner's authority rather than from caller input, AND its value
+/// is read to decide identity, grouping, routing, lifecycle, visibility,
+/// authorization, deduplication, or membership. `from_actor`, `direction` and
+/// `sent_at` answer "who wrote this, in which direction, when"; `outbound_ref`
+/// and `thread_id` answer "which record is this one's author-side original,
+/// and which conversation does it belong to". `subject` is reproduced
+/// verbatim when a record is re-emitted; `wire_message_id` and `external_id`
+/// are the author-side citation and correlation key a reply is routed
+/// against. The set is therefore not "keys that identify a party" — it is
+/// "keys the owner established and later trusts".
+///
+/// Naming one of these in a caller-supplied `properties` patch is refused by
+/// `update` on a pack-owned kind (see [`owner_established_property_named_in`]).
+///
+/// Membership here governs writes to an EXISTING record only. Introducing one
+/// of these keys at create time is a separate question and is not addressed
+/// by this constant.
+pub(crate) const OWNER_ESTABLISHED_PROPERTIES: &[&str] = &[
+    "from_actor",
+    "direction",
+    "sent_at",
+    "outbound_ref",
+    "thread_id",
+    "subject",
+    "wire_message_id",
+    "external_id",
+];
+
+/// The first [`OWNER_ESTABLISHED_PROPERTIES`] key a caller-supplied
+/// `properties` patch names, if any.
+///
+/// Naming a key is the whole test: `update_note` folds the patch with
+/// `PreferFrom`, so a named key overwrites the stored value and an unnamed one
+/// leaves it untouched. A non-object patch names nothing.
+pub(crate) fn owner_established_property_named_in(patch: &Value) -> Option<&'static str> {
+    let Value::Object(map) = patch else {
+        return None;
+    };
+    OWNER_ESTABLISHED_PROPERTIES
+        .iter()
+        .copied()
+        .find(|key| map.contains_key(*key))
 }
 
 /// Merge two property objects. Returns (merged, count_of_fields_from_from_that_were_added).

--- a/crates/khive-runtime/src/curation.rs
+++ b/crates/khive-runtime/src/curation.rs
@@ -2790,11 +2790,19 @@ pub(crate) fn merge_string_field(
 /// Naming one of these in a caller-supplied `properties` patch is refused by
 /// `update` on a pack-owned kind (see [`owner_established_property_named_in`]).
 ///
+/// `to_actor` belongs here alongside `from_actor`: comm establishes it at
+/// send time from the `to=` param, and `comm.read` trusts a present string
+/// value to decide whether the caller is the addressee, failing open only
+/// when the key is absent or non-string. A caller must not be able to
+/// retarget a delivered message's addressee via a patch that names no other
+/// currently-protected key.
+///
 /// Membership here governs writes to an EXISTING record only. Introducing one
 /// of these keys at create time is a separate question and is not addressed
 /// by this constant.
 pub(crate) const OWNER_ESTABLISHED_PROPERTIES: &[&str] = &[
     "from_actor",
+    "to_actor",
     "direction",
     "sent_at",
     "outbound_ref",

--- a/crates/khive-runtime/src/lib.rs
+++ b/crates/khive-runtime/src/lib.rs
@@ -121,7 +121,7 @@ pub use runtime::{
     assert_captured_db_anchor_consistent, assert_db_anchor_consistent, expand_tilde,
     parse_pack_list, resolve_db_anchor, resolve_project_actor_id, runtime_config_from_khive_config,
     BackendId, EntityTypeValidatorFn, KhiveRuntime, NamespaceToken, NoteMutationHookFn,
-    RuntimeConfig,
+    NoteWriteValidatorFn, RuntimeConfig,
 };
 pub use secret_gate::SecretMatch;
 pub use validation::{

--- a/crates/khive-runtime/src/operations.rs
+++ b/crates/khive-runtime/src/operations.rs
@@ -3265,6 +3265,12 @@ impl KhiveRuntime {
         embedding_model: Option<&str>,
     ) -> RuntimeResult<(Note, crate::retrieval::EmbeddingTruncationReport)> {
         self.validate_note_kind(kind)?;
+        // Owned identity properties are derived from the authorization token
+        // before anything else touches them, so every caller of this function —
+        // the generic `create` verb and direct Rust callers alike — stores the
+        // same derived values. Runs before the secret gate so the gate scans
+        // exactly what will be written.
+        let properties = self.derive_note_write_properties(kind, token, properties)?;
         // Secret gate: scan content, optional name, and structured properties.
         crate::secret_gate::check(content)?;
         if let Some(n) = name {

--- a/crates/khive-runtime/src/pack.rs
+++ b/crates/khive-runtime/src/pack.rs
@@ -233,6 +233,18 @@ pub trait PackRuntime: Send + Sync {
     /// See `docs/api/pack.md#register_note_mutation_hook` for cross-pack notification rationale.
     fn register_note_mutation_hook(&self, _runtime: &KhiveRuntime) {}
 
+    /// Install a note-write validator on the runtime, called at pack
+    /// initialisation with the same timing as `register_note_mutation_hook`.
+    ///
+    /// A pack owning a note kind whose properties carry identity that the
+    /// runtime can derive from the authorization token implements this and
+    /// calls `KhiveRuntime::install_note_write_validator`, so the identity is
+    /// derived at every note-write site rather than trusted from caller input
+    /// on the write paths that reach no pack verb. Default no-op leaves the
+    /// slot absent. The slot holds one validator, so an implementation must
+    /// return properties for kinds it does not own unchanged.
+    fn register_note_write_validator(&self, _runtime: &KhiveRuntime) {}
+
     /// Warm up any in-memory state from persisted snapshots (optional). Called after
     /// all packs are registered but before serving the first request. Must be
     /// idempotent and infallible — errors are logged internally, never propagated.
@@ -2252,6 +2264,19 @@ impl VerbRegistry {
     pub fn call_register_note_mutation_hooks(&self, runtime: &KhiveRuntime) {
         for pack in self.packs.iter() {
             pack.register_note_mutation_hook(runtime);
+        }
+    }
+
+    /// Invoke `PackRuntime::register_note_write_validator` on every registered pack.
+    ///
+    /// Called by the transport during startup with the same timing as
+    /// `call_register_note_mutation_hooks`, so note-write validation is active
+    /// at the runtime layer for every write path — the generic `create` verb,
+    /// direct Rust callers, and proposal apply, none of which dispatch a pack
+    /// hook of their own on the note-write.
+    pub fn call_register_note_write_validators(&self, runtime: &KhiveRuntime) {
+        for pack in self.packs.iter() {
+            pack.register_note_write_validator(runtime);
         }
     }
 

--- a/crates/khive-runtime/src/pack.rs
+++ b/crates/khive-runtime/src/pack.rs
@@ -32,6 +32,15 @@ pub use khive_types::VerbDef;
 
 use crate::validation::ValidationRule;
 
+/// Name of the pack providing the shared CRUD verbs and the general-purpose
+/// note kinds those verbs exist to serve.
+///
+/// Its note kinds are the ones any caller may author freely through `create`
+/// and `update`; every other pack's note kinds are records maintained by that
+/// pack's own verbs. Used by
+/// [`VerbRegistry::pack_owned_note_kinds`].
+pub const GENERIC_CRUD_PACK: &str = "kg";
+
 /// Pack-auxiliary schema plan.
 ///
 /// Declares `CREATE TABLE IF NOT EXISTS` statements for pack-owned tables that
@@ -2040,6 +2049,33 @@ impl VerbRegistry {
             .iter()
             .flat_map(|p| p.note_kinds().iter().copied())
             .filter(|k| seen.insert(*k))
+            .collect()
+    }
+
+    /// Note kinds owned by a pack, i.e. every kind in [`all_note_kinds`] that
+    /// is not one of the generic-CRUD pack's own kinds.
+    ///
+    /// [`GENERIC_CRUD_PACK`] declares the general-purpose note kinds the shared
+    /// CRUD verbs exist to serve (`observation`, `insight`, …); every other
+    /// pack's kinds are records that pack's own verbs create and maintain.
+    /// Derived from the packs' `NOTE_KINDS` constants, so a pack that adds or
+    /// drops a kind moves this set with it — nothing is hardcoded here but the
+    /// name of the generic pack itself.
+    ///
+    /// [`all_note_kinds`]: Self::all_note_kinds
+    pub fn pack_owned_note_kinds(&self) -> Vec<&'static str> {
+        let generic: std::collections::HashSet<&'static str> = self
+            .packs
+            .iter()
+            .filter(|p| p.name() == GENERIC_CRUD_PACK)
+            .flat_map(|p| p.note_kinds().iter().copied())
+            .collect();
+        let mut seen = std::collections::HashSet::new();
+        self.packs
+            .iter()
+            .filter(|p| p.name() != GENERIC_CRUD_PACK)
+            .flat_map(|p| p.note_kinds().iter().copied())
+            .filter(|k| !generic.contains(k) && seen.insert(*k))
             .collect()
     }
 

--- a/crates/khive-runtime/src/runtime.rs
+++ b/crates/khive-runtime/src/runtime.rs
@@ -103,6 +103,13 @@ pub struct KhiveRuntime {
     /// no pack cares about note-mutation notifications) — the call becomes a
     /// no-op check of an `Option`.
     note_mutation_hook: Arc<RwLock<Option<NoteMutationHookFn>>>,
+    /// Pack-owned note kinds — every note kind declared by a pack other than
+    /// the generic-CRUD pack, installed by the transport from the registry
+    /// (see `VerbRegistry::pack_owned_note_kinds`). Records of these kinds are
+    /// maintained by their owning pack's own verbs, so `update`'s `properties`
+    /// patch is refused on them at the runtime layer. Empty until installed
+    /// (bare runtime), which leaves the rule inert.
+    pack_owned_note_kinds: Arc<RwLock<Vec<String>>>,
     /// The config-resolved `BlobStore` (ADR-111 Amendment 2), installed by
     /// the boot path (`khive-mcp`'s single- and multi-backend startup paths)
     /// via [`install_blob_store`](Self::install_blob_store) once `khive.toml`'s
@@ -149,6 +156,7 @@ impl KhiveRuntime {
             valid_note_kinds: Arc::new(RwLock::new(Vec::new())),
             entity_type_validator: Arc::new(RwLock::new(None)),
             note_mutation_hook: Arc::new(RwLock::new(None)),
+            pack_owned_note_kinds: Arc::new(RwLock::new(Vec::new())),
             blob_store: Arc::new(RwLock::new(None)),
         })
     }
@@ -179,6 +187,7 @@ impl KhiveRuntime {
             valid_note_kinds: Arc::new(RwLock::new(Vec::new())),
             entity_type_validator: Arc::new(RwLock::new(None)),
             note_mutation_hook: Arc::new(RwLock::new(None)),
+            pack_owned_note_kinds: Arc::new(RwLock::new(Vec::new())),
             blob_store: Arc::new(RwLock::new(None)),
         })
     }
@@ -208,6 +217,7 @@ impl KhiveRuntime {
             valid_note_kinds: Arc::new(RwLock::new(Vec::new())),
             entity_type_validator: Arc::new(RwLock::new(None)),
             note_mutation_hook: Arc::new(RwLock::new(None)),
+            pack_owned_note_kinds: Arc::new(RwLock::new(Vec::new())),
             blob_store: Arc::new(RwLock::new(None)),
         }
     }
@@ -266,6 +276,7 @@ impl KhiveRuntime {
                     valid_note_kinds: self.valid_note_kinds.clone(),
                     entity_type_validator: self.entity_type_validator.clone(),
                     note_mutation_hook: self.note_mutation_hook.clone(),
+                    pack_owned_note_kinds: self.pack_owned_note_kinds.clone(),
                     blob_store: self.blob_store.clone(),
                 }
             }
@@ -658,6 +669,28 @@ impl KhiveRuntime {
         if let Ok(mut guard) = self.valid_note_kinds.write() {
             *guard = note_kinds;
         }
+    }
+
+    /// Install the pack-owned note kinds aggregated from the pack registry.
+    ///
+    /// Called by the transport after the `VerbRegistry` is built, same timing
+    /// as [`install_kind_registry`](Self::install_kind_registry).
+    pub fn install_pack_owned_note_kinds(&self, kinds: Vec<String>) {
+        if let Ok(mut guard) = self.pack_owned_note_kinds.write() {
+            *guard = kinds;
+        }
+    }
+
+    /// Whether `kind` is a note kind owned by a pack (see
+    /// [`install_pack_owned_note_kinds`](Self::install_pack_owned_note_kinds)).
+    ///
+    /// Always `false` before the transport installs the list — a bare runtime
+    /// has no packs, so no kind is pack-owned there.
+    pub fn is_pack_owned_note_kind(&self, kind: &str) -> bool {
+        self.pack_owned_note_kinds
+            .read()
+            .map(|g| g.iter().any(|k| k == kind))
+            .unwrap_or(false)
     }
 
     /// Validate that `kind` is a pack-registered entity kind.

--- a/crates/khive-runtime/src/runtime.rs
+++ b/crates/khive-runtime/src/runtime.rs
@@ -43,6 +43,23 @@ pub type NoteMutationHookFn = Arc<
         + Sync,
 >;
 
+/// Callback type for a pack-installed note-write validator.
+///
+/// The pack that owns a note kind carrying derivable identity installs one so
+/// that the identity is a function of the authorization token rather than of
+/// caller input, on every write path including direct callers that bypass the
+/// handler layer — same rationale as [`EntityTypeValidatorFn`], which exists
+/// for exactly that reason on the entity side.
+///
+/// Kinds the installing pack does not own must be returned unchanged: the slot
+/// is single-occupancy (like `note_mutation_hook`), so a validator that
+/// rewrote foreign kinds would silently govern every other pack's notes.
+pub type NoteWriteValidatorFn = Arc<
+    dyn Fn(&str, &str, Option<serde_json::Value>) -> Result<Option<serde_json::Value>, RuntimeError>
+        + Send
+        + Sync,
+>;
+
 pub use crate::config::{
     assert_captured_db_anchor_consistent, assert_db_anchor_consistent, expand_tilde,
     parse_pack_list, resolve_db_anchor, resolve_project_actor_id, runtime_config_from_khive_config,
@@ -103,12 +120,21 @@ pub struct KhiveRuntime {
     /// no pack cares about note-mutation notifications) — the call becomes a
     /// no-op check of an `Option`.
     note_mutation_hook: Arc<RwLock<Option<NoteMutationHookFn>>>,
+    /// Pack-installed note-write validator.
+    ///
+    /// When `Some`, every runtime note-materialisation site that accepts
+    /// caller-supplied `properties` routes them through this function before
+    /// the `Note` is built, so a pack-owned identity property is derived from
+    /// the authorization token instead of trusted from caller input. `None`
+    /// on a bare runtime (no packs) — the properties pass through unchanged.
+    note_write_validator: Arc<RwLock<Option<NoteWriteValidatorFn>>>,
     /// Pack-owned note kinds — every note kind declared by a pack other than
     /// the generic-CRUD pack, installed by the transport from the registry
     /// (see `VerbRegistry::pack_owned_note_kinds`). Records of these kinds are
     /// maintained by their owning pack's own verbs, so `update`'s `properties`
-    /// patch is refused on them at the runtime layer. Empty until installed
-    /// (bare runtime), which leaves the rule inert.
+    /// patch is refused on them at the runtime layer and their owned identity
+    /// properties survive a `merge` unchanged. Empty until installed (bare
+    /// runtime), which leaves both rules inert.
     pack_owned_note_kinds: Arc<RwLock<Vec<String>>>,
     /// The config-resolved `BlobStore` (ADR-111 Amendment 2), installed by
     /// the boot path (`khive-mcp`'s single- and multi-backend startup paths)
@@ -156,6 +182,7 @@ impl KhiveRuntime {
             valid_note_kinds: Arc::new(RwLock::new(Vec::new())),
             entity_type_validator: Arc::new(RwLock::new(None)),
             note_mutation_hook: Arc::new(RwLock::new(None)),
+            note_write_validator: Arc::new(RwLock::new(None)),
             pack_owned_note_kinds: Arc::new(RwLock::new(Vec::new())),
             blob_store: Arc::new(RwLock::new(None)),
         })
@@ -187,6 +214,7 @@ impl KhiveRuntime {
             valid_note_kinds: Arc::new(RwLock::new(Vec::new())),
             entity_type_validator: Arc::new(RwLock::new(None)),
             note_mutation_hook: Arc::new(RwLock::new(None)),
+            note_write_validator: Arc::new(RwLock::new(None)),
             pack_owned_note_kinds: Arc::new(RwLock::new(Vec::new())),
             blob_store: Arc::new(RwLock::new(None)),
         })
@@ -217,6 +245,7 @@ impl KhiveRuntime {
             valid_note_kinds: Arc::new(RwLock::new(Vec::new())),
             entity_type_validator: Arc::new(RwLock::new(None)),
             note_mutation_hook: Arc::new(RwLock::new(None)),
+            note_write_validator: Arc::new(RwLock::new(None)),
             pack_owned_note_kinds: Arc::new(RwLock::new(Vec::new())),
             blob_store: Arc::new(RwLock::new(None)),
         }
@@ -276,6 +305,7 @@ impl KhiveRuntime {
                     valid_note_kinds: self.valid_note_kinds.clone(),
                     entity_type_validator: self.entity_type_validator.clone(),
                     note_mutation_hook: self.note_mutation_hook.clone(),
+                    note_write_validator: self.note_write_validator.clone(),
                     pack_owned_note_kinds: self.pack_owned_note_kinds.clone(),
                     blob_store: self.blob_store.clone(),
                 }
@@ -778,6 +808,58 @@ impl KhiveRuntime {
     pub fn install_note_mutation_hook(&self, f: NoteMutationHookFn) {
         if let Ok(mut guard) = self.note_mutation_hook.write() {
             *guard = Some(f);
+        }
+    }
+
+    /// Install a pack-owned note-write validator.
+    ///
+    /// Called during pack registration (`PackRuntime::register_note_write_validator`)
+    /// so that every runtime note-write site carrying caller-supplied
+    /// `properties` derives the owning pack's identity properties from the
+    /// authorization token, closing the gap where a direct Rust caller, the
+    /// generic `create` verb, or the proposal-apply path (which dispatches no
+    /// pack hooks) writes them unchecked. Single-slot semantics, same as
+    /// [`install_note_mutation_hook`](Self::install_note_mutation_hook): a
+    /// second installing pack overwrites the first, so a validator must return
+    /// kinds it does not own unchanged.
+    pub fn install_note_write_validator(&self, f: NoteWriteValidatorFn) {
+        if let Ok(mut guard) = self.note_write_validator.write() {
+            *guard = Some(f);
+        }
+    }
+
+    /// Whether a note-write validator is installed on this runtime.
+    ///
+    /// Exists so a transport's own tests can assert, per boot path, that the
+    /// documented startup sequence actually filled the slot. A missing install
+    /// fails open and silently — an empty slot passes caller-supplied
+    /// properties straight through, which no write site can distinguish from a
+    /// validator that approved them — so occupancy is asserted, never assumed.
+    pub fn has_note_write_validator(&self) -> bool {
+        self.note_write_validator
+            .read()
+            .map(|g| g.is_some())
+            .unwrap_or(false)
+    }
+
+    /// Run caller-supplied note `properties` through the installed note-write
+    /// validator, returning the properties to store.
+    ///
+    /// Returns them unchanged when no validator is installed (bare runtime).
+    pub(crate) fn derive_note_write_properties(
+        &self,
+        kind: &str,
+        token: &NamespaceToken,
+        properties: Option<serde_json::Value>,
+    ) -> RuntimeResult<Option<serde_json::Value>> {
+        let validator = self
+            .note_write_validator
+            .read()
+            .map_err(|_| RuntimeError::Internal("note write validator lock poisoned".into()))?
+            .clone();
+        match validator {
+            None => Ok(properties),
+            Some(validate) => validate(kind, &token.actor().id, properties),
         }
     }
 

--- a/crates/khive-runtime/src/runtime.rs
+++ b/crates/khive-runtime/src/runtime.rs
@@ -814,14 +814,33 @@ impl KhiveRuntime {
     /// Install a pack-owned note-write validator.
     ///
     /// Called during pack registration (`PackRuntime::register_note_write_validator`)
-    /// so that every runtime note-write site carrying caller-supplied
-    /// `properties` derives the owning pack's identity properties from the
+    /// so that the covered note-write sites carrying caller-supplied
+    /// `properties` derive the owning pack's identity properties from the
     /// authorization token, closing the gap where a direct Rust caller, the
     /// generic `create` verb, or the proposal-apply path (which dispatches no
     /// pack hooks) writes them unchecked. Single-slot semantics, same as
     /// [`install_note_mutation_hook`](Self::install_note_mutation_hook): a
     /// second installing pack overwrites the first, so a validator must return
     /// kinds it does not own unchanged.
+    ///
+    /// Covered sites — each calls `derive_note_write_properties`
+    /// before the write: `create_note_inner` (`operations.rs`, the generic
+    /// `create` verb funnel and every other public `create_note*` variant),
+    /// `atomic_prepare::prepare_add_note` (the proposal-apply add-note path),
+    /// and `atomic_message::create_notes_atomic_with_report` (the atomic
+    /// multi-note writer).
+    ///
+    /// NOT covered: `try_create_note` (`operations.rs`), and the raw
+    /// `try_insert_note` / `upsert_note` methods on the [`NoteStore`] returned
+    /// by [`notes`](Self::notes). `try_create_note` is deliberately excluded —
+    /// its only caller path is `comm.ingest`, where `properties.from_actor` is
+    /// the external transport sender named by the `from` parameter, not the
+    /// authenticated caller; deriving it from the token here would stamp
+    /// every inbound message as the ingesting daemon and destroy inbound
+    /// attribution. The `NoteStore` accessors are a lower-level storage
+    /// escape hatch with no properties-derivation contract of their own; a
+    /// caller reaching storage directly is expected to have already decided
+    /// what `properties` to write.
     pub fn install_note_write_validator(&self, f: NoteWriteValidatorFn) {
         if let Ok(mut guard) = self.note_write_validator.write() {
             *guard = Some(f);


### PR DESCRIPTION
ADR-124 (`docs/adr/ADR-124-note-write-identity.md`) specifies that properties the owning pack
establishes on a note are not caller-writable. The `update` route was closed separately and has
merged. Two other routes to the same fields on pack-owned note kinds remained open, both reachable
from the ordinary verb surface. This PR closes them.

This branch was originally stacked on the update-path change. That change landed as a squash, so its
commits are not ancestors of `main`; `main` has been merged in rather than rebasing a published
branch, which also makes this PR's diff against `main` exactly the create-path and merge-path work.

## Section A — create path: derive rather than refuse

**The gap.** A note create stored caller-supplied properties verbatim, so
`create(kind="message", properties={from_actor: ...})` produced a message carrying any attribution
the caller chose, bypassing the handler that stamps it.

**The change.** A single-slot note-write validator, installed by the pack that owns the kind and
invoked on the create path before properties are stored. The comm pack's validator **derives**
`from_actor` from the authenticated caller rather than refusing the call. That choice matters: the
legitimate writer — the pack's own send path — is the thing that is supposed to set this field, so a
refusal-based guard would have to carve it out and would fail closed into an outage if the carve-out
were ever wrong. Deriving has no such failure mode: the caller's value is replaced by the
authenticated one, and a create that supplies nothing gets stamped. Kinds the installing pack does
not own are returned unchanged, so the slot cannot silently govern another pack's notes.

Wired at all three note-write call sites: the generic create funnel, the proposal add-note path, and
the atomic multi-note writer.

That third site was missed in the first version of this change and is worth stating plainly. The
atomic writer builds notes directly from a public spec type and copied the supplied properties onto
each note without consulting the validator, so the guard was incomplete on a publicly reachable
writer. The pack's own send path stamps the field from the token before reaching that writer, so no
current caller could forge attribution through it; the point is that the guard has to hold on the
route itself rather than on a property of today's callers.

## Section B — merge path: preserve owner-established properties

**The gap.** A note merge folded properties by the caller's chosen strategy. With `prefer_from`, the
absorbed note's owner-established properties were written onto the surviving note — so merging a
message you control into one you do not moved its attribution.

**The change.** After the property fold, owner-established keys are restored from the into-note, on
pack-owned kinds only. The surviving record keeps the identity it was created with. All other
properties still fold by the chosen strategy, so merge semantics are otherwise unchanged.

The count of merged properties reported by the response needed a correction to match. Originally the
fold's count and the restoration's count were subtracted from one another, but they measure different
populations: the fold counts a key only when it is absent from the surviving record, while the
restoration touches any owner-established key including ones the fold never counted. That subtraction
could report zero merged properties on a merge where a newly introduced property genuinely survived.

The count is now recomputed from the properties that actually survive, rather than derived by
subtraction. Recomputation has to reproduce the fold's own scoring rules to agree with it: a
whole-value replacement counts as a single contribution however many keys the replacing object
carries, nested objects are only recursed into under the union strategy, and an empty final object
contributes nothing whatever emptied it. Each of those rules carries a regression whose fixture
distinguishes it from the neighbouring rule rather than merely exercising it.

**Deliberately not included:** the reference implementation also refuses merging two message notes
outright, on the view that a message is a single speech event. That is a content-semantics decision
independent of attribution integrity, and folding it in here would change merge behaviour beyond the
security fix. It is tracked as its own change.

## Boot wiring

Both mechanisms are registered on the single-runtime **and** multi-backend server boot paths. This is
not incidental: a mechanism installed on only one path is inert on the other, which is exactly the
defect found in the first review round of the update-path change, where the guard existed in source
but was never armed on the multi-backend served configuration.

## Tests

Create: the derive overwrites a caller-supplied `from_actor` with the authenticated actor; a create
supplying no identity key is stamped; the atomic multi-note writer derives per spec and rejects a
forged value; the pack's own send path still stamps correctly with the validator installed; an
unowned kind passes through untouched.

Merge: `prefer_from` no longer moves `from_actor` onto the surviving note; a `prefer_into` control;
non-owned properties still fold by strategy in the same merge; the merged-property count reports a
key that genuinely survived; an unowned kind still overwrites normally.

Each regression test was checked against a reverted copy of the change it covers and observed to
fail, so an arm that cannot fail is not being counted as evidence. Two earlier arms that stayed green
with their mechanism removed are now documented as such, and one of them is paired with an assertion
that fails if the validator is absent entirely.

## Verification

`cargo check`, `cargo clippy --all-targets -- -D warnings` and `cargo fmt --all -- --check` are clean
across the touched crates. `cargo test -p khive-runtime -p khive-pack-comm` reports 1464 passing and
0 failing across all binaries, including the timing-calibrated writer-hold-time test.

