### PR TITLE
docs(adr): record ADR-142 and ADR-143 as accepted

### DIFF
--- a/docs/adr/ADR-142-agentic-process-runtime.md
+++ b/docs/adr/ADR-142-agentic-process-runtime.md
@@ -1,6 +1,6 @@
 # ADR-142: Agentic Process Runtime
 
-- **Status:** Proposed
+- **Status:** Accepted
 - **Date:** 2026-08-03
 
 ## Context

--- a/docs/adr/ADR-143-store-held-caller-grants.md
+++ b/docs/adr/ADR-143-store-held-caller-grants.md
@@ -1,6 +1,6 @@
 # ADR-143: Store-held caller grants and hierarchical subactor identity
 
-- Status: Proposed
+- Status: Accepted
 - Date: 2026-08-03
 - Amends: [ADR-129](ADR-129-fail-closed-gate-default.md) — supersedes Amendment 2's
   configuration-text caller enumeration and its "no runtime registration API"


### PR DESCRIPTION
Both decisions were reviewed and merged, and both are the operative contract for the work built on them, so a status of Proposed no longer describes them. The status line is the field a reader checks to know whether a decision is in force, and leaving it at the authoring value makes it uninformative.

Scope is deliberately these two files. Other merged records still reading Proposed are being adjudicated one at a time against whether the decision is actually implemented and operating, which is a judgement per record rather than a rewrite that would assert that history in bulk.

The diff is two lines. Each file keeps its own existing status formatting.