### PR TITLE
docs(adr): record that the fail-closed verb class has no live member

### DIFF
--- a/docs/adr/ADR-018-authorization-gate.md
+++ b/docs/adr/ADR-018-authorization-gate.md
@@ -786,14 +786,22 @@ the Gate's former fail-open one, and remains the construction-primary defense fo
 `session.search` (ADR-117a) is the first member. Future verbs that return cross-tenant-sensitive rows
 join by the same handler-seam contract.
 
+_Implementation status (2026-08-04)._ `session.search` does not exist. No pack registers it — the
+session pack registers `session.export`, `session.list`, `session.resume`, and `session.store` — and
+neither the migration nor the no-scope-refusal tests ADR-117a specifies have landed. The class
+contract above is in force for any verb that joins it, but the class has no live member today, so
+nothing in this amendment is currently exercised by shipped code. ADR-117a requires the verb, the
+migration, and the enforcement predicate to land as one change; only the contract half reached this
+record. Remove this note when `session.search` ships.
+
 ### Consequences
 
 - The Gate model is unchanged; this adds a named handler-seam obligation, not a new Gate mode.
 - A fail-closed-class member is safe under `AllowAllGate` and under a gate `Err`, because its isolation
   never depended on the Gate returning `Deny`.
 - Membership is a per-verb contract a pack declares; the enforcement lives in the member's handler and
-  is proven by that verb's isolation and no-scope-refusal tests (ADR-117a discharges both for
-  `session.search`).
+  is proven by that verb's isolation and no-scope-refusal tests (ADR-117a specifies both for
+  `session.search`; see the implementation-status note above for what has actually landed).
 
 ---
 


### PR DESCRIPTION
## What

ADR-018 Amendment 2 defines a fail-closed verb class and names `session.search`
as its first member, and its consequences bullet states that ADR-117a
"discharges" that verb's isolation and no-scope-refusal tests.

Neither holds at `main`:

- `session.search` is registered by no pack. The session pack registers
  `session.export`, `session.list`, `session.resume`, `session.store`.
- The migration and the no-scope-refusal tests ADR-117a specifies have not
  landed.

Verified with `git grep` at `origin/main`; the same predicate finds the four
session verbs that do exist, so the empty result is a real absence rather than a
failed search.

## Why it matters

ADR-018 is accepted. An amendment merged into an accepted record carries that
record's authority from the moment it lands, so a reader of ADR-018 alone sees a
settled contract with a live member and a discharged test obligation. A status
field is not the only place a record asserts liveness.

## What this changes

- Adds an implementation-status note directly after the sentence that names the
  first member, saying what has and has not landed.
- Changes the consequences bullet from "discharges" to "specifies", pointing at
  that note.

The class contract is unchanged and stays in force for any verb that joins it.
The note names `session.search` explicitly so a later audit can find it, and
states the condition for removing it.

## Alternative considered

Marking the amendment itself with a status value. Rejected: amendments in this
repository do not carry status, so that would introduce a new convention and
apply it retroactively to one record. It would also put the correction one
indirection away from the sentence that misleads.

## Gates

`scripts/lint-adr-refs.sh` passes (356 files, 189 titled references). Docs-only
change; no code paths touched.
