### PR TITLE
fix(db): resolve the write-queue default where the backing store is known

### DIFF
--- a/crates/khive-db/src/backend.rs
+++ b/crates/khive-db/src/backend.rs
@@ -1236,7 +1236,7 @@ mod tests {
         let config = crate::pool::PoolConfig {
             path: Some(path.clone()),
             busy_timeout: std::time::Duration::from_millis(200),
-            write_queue_enabled,
+            write_queue_enabled: Some(write_queue_enabled),
             ..crate::pool::PoolConfig::default()
         };
         let pool = ConnectionPool::new(config).expect("fresh tenant-shaped pool should open");
@@ -1315,7 +1315,7 @@ mod tests {
     /// `OnceLock`s) opened against the SAME tenant DB file — the shape a
     /// per-store (rather than per-backend) pool construction would produce.
     /// Entity writes go through pool A, the FTS write through pool B, each
-    /// with `write_queue_enabled: true` so each independently spawns its own
+    /// with `write_queue_enabled: Some(true)` so each independently spawns its own
     /// WriterTask on first access.
     #[tokio::test]
     async fn issue_1029_two_pools_same_file_write_queue_on() {
@@ -1325,7 +1325,7 @@ mod tests {
         let cfg = |p: std::path::PathBuf| crate::pool::PoolConfig {
             path: Some(p),
             busy_timeout: std::time::Duration::from_millis(200),
-            write_queue_enabled: true,
+            write_queue_enabled: Some(true),
             ..crate::pool::PoolConfig::default()
         };
 

--- a/crates/khive-db/src/checkpoint.rs
+++ b/crates/khive-db/src/checkpoint.rs
@@ -4361,7 +4361,7 @@ mod tests {
             ConnectionPool::new(PoolConfig {
                 path: None,
                 checkout_timeout: Duration::from_secs(5),
-                write_queue_enabled: false,
+                write_queue_enabled: Some(false),
                 ..PoolConfig::default()
             })
             .expect("event pool"),

--- a/crates/khive-db/src/pool.rs
+++ b/crates/khive-db/src/pool.rs
@@ -5,7 +5,7 @@ use rusqlite::{Connection, OpenFlags};
 use std::fs;
 use std::ops::{Deref, DerefMut};
 use std::path::{Path, PathBuf};
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, OnceLock};
 use std::thread;
 use std::time::{Duration, Instant};
@@ -76,6 +76,11 @@ pub struct PoolConfig {
     /// resolves it once `path` is known, defaulting to `true` for file-backed
     /// pools and `false` for in-memory ones. `Some(_)` is an explicit
     /// preference and always wins, in both directions, over that default.
+    /// An explicit `Some(true)` on an in-memory pool is accepted DELIBERATELY
+    /// and degrades silently to the legacy path — an in-memory pool cannot
+    /// host a writer task (`writer_task::spawn`'s standalone-connection open
+    /// fails); see `ConnectionPool::writer_task_handle` and the
+    /// `explicit_true_stays_on_for_memory_backed_pool` test.
     ///
     /// Overridable via `KHIVE_WRITE_QUEUE` (`"1"` or `"true"`,
     /// case-insensitive, sets `Some(true)`; any other value sets `Some(false)`;
@@ -271,6 +276,11 @@ pub struct ConnectionPool {
     /// JoinHandle detaches the task, which is exactly the pre-existing
     /// behavior.
     writer_task_join: Mutex<Option<tokio::task::JoinHandle<()>>>,
+    /// Monotonic "a writer-task JoinHandle was stored at least once" flag
+    /// backing [`Self::set_writer_task_join`]'s at-most-once guard: it holds
+    /// the invariant even after [`Self::take_writer_task_join`] empties the
+    /// slot, so a second store never re-arms it.
+    writer_task_join_stored: AtomicBool,
     /// This pool's ADR-091 backend-scoped attribution origin, minted exactly
     /// once at construction (see [`mint_db_identity`]): `Database(_)` for a
     /// file-backed pool, `Memory` for an in-memory pool. Every
@@ -499,6 +509,7 @@ impl ConnectionPool {
             config,
             writer_task: OnceLock::new(),
             writer_task_join: Mutex::new(None),
+            writer_task_join_stored: AtomicBool::new(false),
             origin,
             identity_path,
             #[cfg(test)]
@@ -693,6 +704,26 @@ impl ConnectionPool {
         self.identity_path.as_deref()
     }
 
+    /// Whether the write queue is effectively enabled for this pool: the
+    /// resolved `write_queue_enabled` flag AND file-backed.
+    ///
+    /// `ConnectionPool::new` resolves the "no preference" (`None`) preference
+    /// to a concrete `Some(..)` once `path` is known, so every reader of
+    /// `config.write_queue_enabled` sees a resolved value; the `debug_assert`
+    /// pins that invariant and a `None` that slipped past would read as
+    /// disabled. Bypassing `ConnectionPool::new` to construct a pool is a
+    /// construction-path bug. Use this instead of repeating
+    /// `config().write_queue_enabled.unwrap_or(false) && config().path.is_some()`
+    /// at every routing/violation site.
+    pub fn write_queue_active(&self) -> bool {
+        debug_assert!(
+            self.config.write_queue_enabled.is_some(),
+            "write_queue_enabled must be resolved to Some(..) by ConnectionPool::new \
+             before any write_queue_active read"
+        );
+        self.config.write_queue_enabled.unwrap_or(false) && self.config.path.is_some()
+    }
+
     /// Return the pool-wide ADR-067 Component A writer task, spawning it
     /// lazily on first access if `PoolConfig::write_queue_enabled` is set.
     /// Exactly one writer task exists per `ConnectionPool` (per DB file); see
@@ -717,11 +748,13 @@ impl ConnectionPool {
     /// fail loud on a genuine misconfiguration (write queue requested but no
     /// runtime to run it on) can propagate the `Err` directly.
     pub fn writer_task_handle(&self) -> Result<Option<WriterTaskHandle>, StorageError> {
-        // Pinned invariant: `ConnectionPool::new` resolves `None` ("no
-        // preference") to a concrete `Some(..)` once `path` is known, so by
-        // the time any reader sees this config it is resolved. A `None` here
-        // would mean a future construction path skipped that resolution and
-        // would silently read as disabled — trip loudly in debug instead.
+        // Same pinned invariant `write_queue_active` asserts, kept inline
+        // here because this gate keys on the flag ALONE: an explicit
+        // `Some(true)` on an in-memory pool must still attempt the spawn
+        // and degrade (documented + tested in
+        // `explicit_true_stays_on_for_memory_backed_pool`), so the
+        // file-backed half of `write_queue_active` cannot gate this early
+        // return.
         debug_assert!(
             self.config.write_queue_enabled.is_some(),
             "write_queue_enabled must be resolved to Some(..) by ConnectionPool::new \
@@ -778,22 +811,26 @@ impl ConnectionPool {
     /// the same `writer_task` OnceLock init that makes spawn at-most-once
     /// per pool makes this write at-most-once per pool.
     ///
-    /// First-wins: if a handle is already stored, the existing handle is
-    /// kept and the new one is dropped (dropping a `JoinHandle` detaches
-    /// its task without cancelling it). A second store violates the
+    /// First-wins: if a handle was ever stored (including one a caller has
+    /// since taken — `writer_task_join_stored` remembers), the existing
+    /// state is kept and the new handle is dropped (dropping a `JoinHandle`
+    /// detaches its task without cancelling it). A second store violates the
     /// at-most-once contract and trips the debug_assert in debug builds;
     /// release builds keep the first handle rather than silently swapping
     /// the drain owner out from under whichever caller already took it.
     pub(crate) fn set_writer_task_join(&self, join: tokio::task::JoinHandle<()>) {
-        let mut slot = self.writer_task_join.lock();
-        let first_store = slot.is_none();
+        // `swap(true)` returns the prior value: `true` means a handle was
+        // stored at least once before, so this is a second store — even when
+        // the slot itself is empty because `take_writer_task_join` already
+        // ran (the slot alone cannot tell "never stored" from "taken").
+        let first_store = !self.writer_task_join_stored.swap(true, Ordering::SeqCst);
         debug_assert!(
             first_store,
-            "writer task JoinHandle stored twice; the writer_task OnceLock is \
-             supposed to make spawn at-most-once per pool"
+            "writer task JoinHandle stored twice (even counting a taken one); \
+             the writer_task OnceLock is supposed to make spawn at-most-once per pool"
         );
         if first_store {
-            *slot = Some(join);
+            *self.writer_task_join.lock() = Some(join);
         }
     }
 
@@ -1394,6 +1431,28 @@ mod tests {
         assert_eq!(cfg.write_queue_enabled, Some(false));
     }
 
+    /// A SET-but-non-Unicode `KHIVE_WRITE_QUEUE` value (invalid UTF-8 on
+    /// unix) must count as SET — `Some(false)` ("any SET value other than
+    /// 1/true means off"), never a fall-through to the file-backed default.
+    /// That is why `PoolConfig::default()` reads `var_os`, not `var`.
+    #[cfg(unix)]
+    #[test]
+    #[serial]
+    fn pool_config_env_override_write_queue_non_unicode_value_is_explicit_off() {
+        use std::os::unix::ffi::OsStrExt;
+        let previous = std::env::var_os("KHIVE_WRITE_QUEUE");
+        std::env::set_var(
+            "KHIVE_WRITE_QUEUE",
+            std::ffi::OsStr::from_bytes(b"\xff\xfe"),
+        );
+        let cfg = PoolConfig::default();
+        match previous {
+            Some(v) => std::env::set_var("KHIVE_WRITE_QUEUE", v),
+            None => std::env::remove_var("KHIVE_WRITE_QUEUE"),
+        }
+        assert_eq!(cfg.write_queue_enabled, Some(false));
+    }
+
     #[test]
     #[serial]
     fn pool_config_env_override_write_queue_invalid_value_is_explicit_off() {
@@ -1793,14 +1852,24 @@ mod tests {
             .expect("runtime is present")
             .expect("write queue enabled must spawn a writer task");
 
-        assert!(
-            pool.take_writer_task_join().is_some(),
-            "the first take must return the spawned task's JoinHandle"
-        );
+        let join = pool
+            .take_writer_task_join()
+            .expect("the first take must return the spawned task's JoinHandle");
         assert!(
             pool.take_writer_task_join().is_none(),
             "the second take must return None — the handle is one-shot"
         );
+
+        // Await the taken handle before the test exits instead of dropping
+        // it detached. The writer task only exits once every
+        // `WriterTaskHandle` clone (the mpsc senders) is gone, and the pool's
+        // own `writer_task` OnceLock holds one, so the pool must drop first —
+        // the same drop-then-await order the batch-ingest drain relies on.
+        drop(pool);
+        tokio::time::timeout(Duration::from_secs(5), join)
+            .await
+            .expect("the writer task must exit once every handle clone is dropped")
+            .expect("the writer task must not panic");
     }
 
     /// Debug half of the first-wins contract: a second
@@ -1812,6 +1881,20 @@ mod tests {
     async fn set_writer_task_join_second_store_trips_debug_assert() {
         let pool = ConnectionPool::new(PoolConfig::default()).expect("in-memory pool should open");
         pool.set_writer_task_join(tokio::spawn(async {}));
+        pool.set_writer_task_join(tokio::spawn(async {}));
+    }
+
+    /// The at-most-once guard holds across the TAKEN state too: once the
+    /// handle has been taken, the slot is empty, but a second store is still
+    /// a construction bug and must trip the same debug_assert (the
+    /// `writer_task_join_stored` flag remembers the first store).
+    #[cfg(debug_assertions)]
+    #[tokio::test]
+    #[should_panic(expected = "writer task JoinHandle stored twice")]
+    async fn set_writer_task_join_second_store_after_take_trips_debug_assert() {
+        let pool = ConnectionPool::new(PoolConfig::default()).expect("in-memory pool should open");
+        pool.set_writer_task_join(tokio::spawn(async {}));
+        assert!(pool.take_writer_task_join().is_some());
         pool.set_writer_task_join(tokio::spawn(async {}));
     }
 

--- a/crates/khive-db/src/pool.rs
+++ b/crates/khive-db/src/pool.rs
@@ -128,9 +128,14 @@ impl Default for PoolConfig {
                 .and_then(|v| v.parse::<i64>().ok())
                 .unwrap_or(DEFAULT_JOURNAL_SIZE_LIMIT_BYTES),
             read_only: false,
-            write_queue_enabled: std::env::var("KHIVE_WRITE_QUEUE")
-                .ok()
-                .map(|v| v == "1" || v.eq_ignore_ascii_case("true")),
+            // `var_os`, not `var`: the documented contract is "any SET value
+            // other than 1/true means Some(false)" — a set-but-non-Unicode
+            // value must count as set (var() would return Err and silently
+            // fall through to the file-backed default of enabled).
+            write_queue_enabled: std::env::var_os("KHIVE_WRITE_QUEUE").map(|v| {
+                v.to_str()
+                    .is_some_and(|v| v == "1" || v.eq_ignore_ascii_case("true"))
+            }),
             write_queue_capacity: std::env::var("KHIVE_WRITE_QUEUE_CAPACITY")
                 .ok()
                 .and_then(|v| v.parse::<usize>().ok())

--- a/crates/khive-db/src/pool.rs
+++ b/crates/khive-db/src/pool.rs
@@ -77,9 +77,10 @@ pub struct PoolConfig {
     /// pools and `false` for in-memory ones. `Some(_)` is an explicit
     /// preference and always wins, in both directions, over that default.
     /// An explicit `Some(true)` on an in-memory pool is accepted DELIBERATELY
-    /// and degrades silently to the legacy path — an in-memory pool cannot
-    /// host a writer task (`writer_task::spawn`'s standalone-connection open
-    /// fails); see `ConnectionPool::writer_task_handle` and the
+    /// and emits a warning before degrading to the legacy path — an in-memory
+    /// pool cannot host a writer task (`writer_task::spawn`'s
+    /// standalone-connection open fails); see
+    /// `ConnectionPool::writer_task_handle` and the
     /// `explicit_true_stays_on_for_memory_backed_pool` test.
     ///
     /// Overridable via `KHIVE_WRITE_QUEUE` (`"1"` or `"true"`,
@@ -484,8 +485,16 @@ impl ConnectionPool {
         // file-backed pools, off for in-memory ones. An explicit `Some(_)`
         // preference is left untouched and always wins.
         let mut config = config;
+        let inert_memory_queue_request =
+            config.path.is_none() && config.write_queue_enabled == Some(true);
         config.write_queue_enabled =
             Some(config.write_queue_enabled.unwrap_or(config.path.is_some()));
+        if inert_memory_queue_request {
+            tracing::warn!(
+                "write queue explicitly requested for an in-memory pool; it is inert because \
+                 in-memory pools cannot host a writer task"
+            );
+        }
 
         let writer = open_writer_connection(&config)?;
         let wal_enabled = configure_writer_connection(&writer, &config)?;
@@ -722,6 +731,15 @@ impl ConnectionPool {
              before any write_queue_active read"
         );
         self.config.write_queue_enabled.unwrap_or(false) && self.config.path.is_some()
+    }
+
+    /// Whether a writer-task JoinHandle has been stored at least once.
+    ///
+    /// Unlike [`Self::take_writer_task_join`], this remains true after the
+    /// one-shot handle slot is emptied, distinguishing a task that never
+    /// spawned from a handle another caller already consumed.
+    pub fn writer_task_join_was_stored(&self) -> bool {
+        self.writer_task_join_stored.load(Ordering::SeqCst)
     }
 
     /// Return the pool-wide ADR-067 Component A writer task, spawning it
@@ -1256,6 +1274,50 @@ mod tests {
     use super::*;
     use serial_test::serial;
 
+    struct WarningCapture {
+        messages: Arc<std::sync::Mutex<Vec<String>>>,
+    }
+
+    impl tracing::Subscriber for WarningCapture {
+        fn enabled(&self, _: &tracing::Metadata<'_>) -> bool {
+            true
+        }
+
+        fn new_span(&self, _: &tracing::span::Attributes<'_>) -> tracing::span::Id {
+            tracing::span::Id::from_u64(1)
+        }
+
+        fn record(&self, _: &tracing::span::Id, _: &tracing::span::Record<'_>) {}
+
+        fn record_follows_from(&self, _: &tracing::span::Id, _: &tracing::span::Id) {}
+
+        fn event(&self, event: &tracing::Event<'_>) {
+            struct Visitor(Option<String>);
+
+            impl tracing::field::Visit for Visitor {
+                fn record_debug(
+                    &mut self,
+                    field: &tracing::field::Field,
+                    value: &dyn std::fmt::Debug,
+                ) {
+                    if field.name() == "message" {
+                        self.0 = Some(format!("{value:?}"));
+                    }
+                }
+            }
+
+            let mut visitor = Visitor(None);
+            event.record(&mut visitor);
+            if let Some(message) = visitor.0 {
+                self.messages.lock().unwrap().push(message);
+            }
+        }
+
+        fn enter(&self, _: &tracing::span::Id) {}
+
+        fn exit(&self, _: &tracing::span::Id) {}
+    }
+
     /// Restores the process CWD on drop — including on panic — so a mid-test
     /// assertion failure (or an unexpected panic from the code under test)
     /// can never leave the process chdir'd into a `tempfile::tempdir()` that
@@ -1440,16 +1502,12 @@ mod tests {
     #[serial]
     fn pool_config_env_override_write_queue_non_unicode_value_is_explicit_off() {
         use std::os::unix::ffi::OsStrExt;
-        let previous = std::env::var_os("KHIVE_WRITE_QUEUE");
+        let _pool_env = clear_pool_env();
         std::env::set_var(
             "KHIVE_WRITE_QUEUE",
             std::ffi::OsStr::from_bytes(b"\xff\xfe"),
         );
         let cfg = PoolConfig::default();
-        match previous {
-            Some(v) => std::env::set_var("KHIVE_WRITE_QUEUE", v),
-            None => std::env::remove_var("KHIVE_WRITE_QUEUE"),
-        }
         assert_eq!(cfg.write_queue_enabled, Some(false));
     }
 
@@ -1638,6 +1696,55 @@ mod tests {
         assert!(
             pool.take_writer_task_join().is_none(),
             "a degraded spawn stores no JoinHandle to drain"
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn explicit_true_on_memory_pool_warns_but_false_and_none_do_not() {
+        let _pool_env = clear_pool_env();
+        let messages = Arc::new(std::sync::Mutex::new(Vec::new()));
+        let subscriber = WarningCapture {
+            messages: Arc::clone(&messages),
+        };
+
+        tracing::subscriber::with_default(subscriber, || {
+            let _explicit_true = ConnectionPool::new(PoolConfig {
+                path: None,
+                write_queue_enabled: Some(true),
+                ..PoolConfig::default()
+            })
+            .expect("in-memory pool should open");
+            let _explicit_false = ConnectionPool::new(PoolConfig {
+                path: None,
+                write_queue_enabled: Some(false),
+                ..PoolConfig::default()
+            })
+            .expect("in-memory pool should open");
+            let _unset = ConnectionPool::new(PoolConfig {
+                path: None,
+                write_queue_enabled: None,
+                ..PoolConfig::default()
+            })
+            .expect("in-memory pool should open");
+        });
+
+        let messages = messages.lock().unwrap();
+        assert_eq!(
+            messages
+                .iter()
+                .filter(|message| message.contains("write queue explicitly requested"))
+                .count(),
+            1,
+            "only an explicit in-memory queue request should warn: {messages:?}"
+        );
+        let warning = messages
+            .iter()
+            .find(|message| message.contains("write queue explicitly requested"))
+            .expect("explicit in-memory queue warning should be captured");
+        assert!(
+            warning.contains("in-memory pools cannot host a writer task"),
+            "warning must explain why the request is inert: {messages:?}"
         );
     }
 
@@ -1848,9 +1955,11 @@ mod tests {
             pool.take_writer_task_join().is_none(),
             "before spawn there is no JoinHandle to take"
         );
+        assert!(!pool.writer_task_join_was_stored());
         pool.writer_task_handle()
             .expect("runtime is present")
             .expect("write queue enabled must spawn a writer task");
+        assert!(pool.writer_task_join_was_stored());
 
         let join = pool
             .take_writer_task_join()

--- a/crates/khive-db/src/pool.rs
+++ b/crates/khive-db/src/pool.rs
@@ -258,6 +258,14 @@ pub struct ConnectionPool {
     /// see that method's doc comment for why this lives here rather than on
     /// each store.
     writer_task: OnceLock<Option<WriterTaskHandle>>,
+    /// The `tokio::spawn` JoinHandle of the writer task above, stored by
+    /// [`crate::writer_task::spawn`] so short-lived callers (batch CLI
+    /// paths) can await the task's exit — and therefore its connection's
+    /// close-time WAL checkpoint — before treating the database file state
+    /// as settled. Long-running callers never take it; dropping an untaken
+    /// JoinHandle detaches the task, which is exactly the pre-existing
+    /// behavior.
+    writer_task_join: Mutex<Option<tokio::task::JoinHandle<()>>>,
     /// This pool's ADR-091 backend-scoped attribution origin, minted exactly
     /// once at construction (see [`mint_db_identity`]): `Database(_)` for a
     /// file-backed pool, `Memory` for an in-memory pool. Every
@@ -485,6 +493,7 @@ impl ConnectionPool {
             max_readers,
             config,
             writer_task: OnceLock::new(),
+            writer_task_join: Mutex::new(None),
             origin,
             identity_path,
             #[cfg(test)]
@@ -747,6 +756,29 @@ impl ConnectionPool {
     pub(crate) fn writer_task_spawn_count(&self) -> usize {
         self.writer_task_spawn_count
             .load(std::sync::atomic::Ordering::SeqCst)
+    }
+
+    /// Record the writer task's `tokio::spawn` JoinHandle. Called exactly
+    /// once, by [`crate::writer_task::spawn`], immediately after spawning —
+    /// the same `writer_task` OnceLock init that makes spawn at-most-once
+    /// per pool makes this write at-most-once per pool.
+    pub(crate) fn set_writer_task_join(&self, join: tokio::task::JoinHandle<()>) {
+        *self.writer_task_join.lock() = Some(join);
+    }
+
+    /// Take the writer task's JoinHandle, if a writer task was spawned and
+    /// the handle has not already been taken.
+    ///
+    /// Intended for short-lived batch callers that drop every
+    /// [`WriterTaskHandle`] clone (closing the queue) and then need to await
+    /// the task's exit before treating the database file as settled: the
+    /// task's connection close fires SQLite's close-time WAL checkpoint, so
+    /// until the task exits the file bytes can still move after the caller's
+    /// last write returned. `None` means either the write queue never
+    /// spawned (disabled, or spawn degraded) or another caller already took
+    /// the handle — in both cases there is nothing further to await here.
+    pub fn take_writer_task_join(&self) -> Option<tokio::task::JoinHandle<()>> {
+        self.writer_task_join.lock().take()
     }
 
     /// Compatibility method: returns the writer connection wrapped in `Arc<Mutex>`.

--- a/crates/khive-db/src/pool.rs
+++ b/crates/khive-db/src/pool.rs
@@ -712,6 +712,16 @@ impl ConnectionPool {
     /// fail loud on a genuine misconfiguration (write queue requested but no
     /// runtime to run it on) can propagate the `Err` directly.
     pub fn writer_task_handle(&self) -> Result<Option<WriterTaskHandle>, StorageError> {
+        // Pinned invariant: `ConnectionPool::new` resolves `None` ("no
+        // preference") to a concrete `Some(..)` once `path` is known, so by
+        // the time any reader sees this config it is resolved. A `None` here
+        // would mean a future construction path skipped that resolution and
+        // would silently read as disabled — trip loudly in debug instead.
+        debug_assert!(
+            self.config.write_queue_enabled.is_some(),
+            "write_queue_enabled must be resolved to Some(..) by ConnectionPool::new \
+             before any writer_task_handle read"
+        );
         if !self.config.write_queue_enabled.unwrap_or(false) {
             return Ok(None);
         }
@@ -762,13 +772,24 @@ impl ConnectionPool {
     /// once, by [`crate::writer_task::spawn`], immediately after spawning —
     /// the same `writer_task` OnceLock init that makes spawn at-most-once
     /// per pool makes this write at-most-once per pool.
+    ///
+    /// First-wins: if a handle is already stored, the existing handle is
+    /// kept and the new one is dropped (dropping a `JoinHandle` detaches
+    /// its task without cancelling it). A second store violates the
+    /// at-most-once contract and trips the debug_assert in debug builds;
+    /// release builds keep the first handle rather than silently swapping
+    /// the drain owner out from under whichever caller already took it.
     pub(crate) fn set_writer_task_join(&self, join: tokio::task::JoinHandle<()>) {
-        let prev = self.writer_task_join.lock().replace(join);
+        let mut slot = self.writer_task_join.lock();
+        let first_store = slot.is_none();
         debug_assert!(
-            prev.is_none(),
+            first_store,
             "writer task JoinHandle stored twice; the writer_task OnceLock is \
              supposed to make spawn at-most-once per pool"
         );
+        if first_store {
+            *slot = Some(join);
+        }
     }
 
     /// Take the writer task's JoinHandle, if a writer task was spawned and
@@ -779,9 +800,15 @@ impl ConnectionPool {
     /// the task's exit before treating the database file as settled: the
     /// task's connection close fires SQLite's close-time WAL checkpoint, so
     /// until the task exits the file bytes can still move after the caller's
-    /// last write returned. `None` means either the write queue never
-    /// spawned (disabled, or spawn degraded) or another caller already took
-    /// the handle — in both cases there is nothing further to await here.
+    /// last write returned.
+    ///
+    /// One-shot: `None` means either the write queue never spawned
+    /// (disabled, or spawn degraded) or another caller already took the
+    /// handle — in both cases there is nothing further to await here.
+    /// Exactly one subsystem may own the drain: the single caller that
+    /// receives `Some(_)` is the sole owner of the task-exit await (and of
+    /// the close-time WAL checkpoint that settles the database file); every
+    /// later caller receives `None` and must not arrange its own await.
     pub fn take_writer_task_join(&self) -> Option<tokio::task::JoinHandle<()>> {
         self.writer_task_join.lock().take()
     }
@@ -1364,6 +1391,18 @@ mod tests {
 
     #[test]
     #[serial]
+    fn pool_config_env_override_write_queue_invalid_value_is_explicit_off() {
+        // Documented contract (`write_queue_enabled` docs): `"1"`/`"true"`
+        // (case-insensitive) set `Some(true)`; any other value — garbage
+        // included — sets `Some(false)`, never `None`.
+        std::env::set_var("KHIVE_WRITE_QUEUE", "banana");
+        let cfg = PoolConfig::default();
+        std::env::remove_var("KHIVE_WRITE_QUEUE");
+        assert_eq!(cfg.write_queue_enabled, Some(false));
+    }
+
+    #[test]
+    #[serial]
     fn pool_config_write_routing_strict_defaults_off() {
         let _pool_env = clear_pool_env();
         let cfg = PoolConfig::default();
@@ -1505,9 +1544,9 @@ mod tests {
         assert_eq!(pool.config().write_queue_enabled, Some(false));
     }
 
-    #[test]
+    #[tokio::test]
     #[serial]
-    fn explicit_true_stays_on_for_memory_backed_pool() {
+    async fn explicit_true_stays_on_for_memory_backed_pool() {
         let _pool_env = clear_pool_env();
         let pool = ConnectionPool::new(PoolConfig {
             path: None,
@@ -1516,6 +1555,26 @@ mod tests {
         })
         .expect("in-memory pool should open");
         assert_eq!(pool.config().write_queue_enabled, Some(true));
+        // Pinned behavioral contract: the explicit-on preference survives in
+        // the stored config, but an in-memory pool cannot host a writer
+        // task — `writer_task::spawn` fails its standalone-connection open
+        // and degrades to no writer task, so callers fall back to the
+        // legacy pool-mutex write path and there is no JoinHandle to drain.
+        assert!(
+            pool.writer_task_handle()
+                .expect("spawn degrade must resolve without error")
+                .is_none(),
+            "explicit-on in-memory pool must degrade to no writer task"
+        );
+        assert_eq!(
+            pool.writer_task_spawn_count(),
+            1,
+            "the spawn attempt must happen exactly once and degrade, not retry"
+        );
+        assert!(
+            pool.take_writer_task_join().is_none(),
+            "a degraded spawn stores no JoinHandle to drain"
+        );
     }
 
     #[test]
@@ -1701,6 +1760,93 @@ mod tests {
             pool.writer_task_spawn_count(),
             0,
             "the guard must reject before ever attempting tokio::spawn"
+        );
+    }
+
+    /// Join-handle lifecycle: a spawn-configured pool stores exactly one
+    /// JoinHandle — the first `take_writer_task_join` after spawn returns
+    /// it, and every later take returns `None` (the one-shot contract that
+    /// lets exactly one subsystem own the drain).
+    #[tokio::test]
+    async fn take_writer_task_join_returns_some_once_then_none() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("join_lifecycle.db");
+        let pool = ConnectionPool::new(PoolConfig {
+            path: Some(path),
+            write_queue_enabled: Some(true),
+            ..PoolConfig::default()
+        })
+        .expect("file-backed pool should open");
+
+        // Spawning is lazy: nothing to take before the first
+        // `writer_task_handle()` call actually spawns the task.
+        assert!(
+            pool.take_writer_task_join().is_none(),
+            "before spawn there is no JoinHandle to take"
+        );
+        pool.writer_task_handle()
+            .expect("runtime is present")
+            .expect("write queue enabled must spawn a writer task");
+
+        assert!(
+            pool.take_writer_task_join().is_some(),
+            "the first take must return the spawned task's JoinHandle"
+        );
+        assert!(
+            pool.take_writer_task_join().is_none(),
+            "the second take must return None — the handle is one-shot"
+        );
+    }
+
+    /// Debug half of the first-wins contract: a second
+    /// `set_writer_task_join` call is a construction bug, and debug builds
+    /// trip the method's debug_assert loudly instead of carrying on.
+    #[cfg(debug_assertions)]
+    #[tokio::test]
+    #[should_panic(expected = "writer task JoinHandle stored twice")]
+    async fn set_writer_task_join_second_store_trips_debug_assert() {
+        let pool = ConnectionPool::new(PoolConfig::default()).expect("in-memory pool should open");
+        pool.set_writer_task_join(tokio::spawn(async {}));
+        pool.set_writer_task_join(tokio::spawn(async {}));
+    }
+
+    /// Release half of the first-wins contract: with the debug_assert
+    /// compiled out, a second `set_writer_task_join` call keeps the
+    /// EXISTING handle and drops the new one. The stored handle is
+    /// therefore the first task's, so awaiting the taken handle completes
+    /// the FIRST task's observable effect.
+    #[cfg(not(debug_assertions))]
+    #[tokio::test]
+    async fn set_writer_task_join_first_wins_keeps_existing_handle() {
+        let pool = ConnectionPool::new(PoolConfig::default()).expect("in-memory pool should open");
+
+        // First task: completes promptly and signals completion — the
+        // observable effect the bounded await below asserts on.
+        let (first_done_tx, first_done_rx) = tokio::sync::oneshot::channel::<()>();
+        let first = tokio::spawn(async move {
+            let _ = first_done_tx.send(());
+        });
+        // Second task: parks on a receiver nobody sends to, so it never
+        // completes on its own. If first-wins failed and this task's handle
+        // were the stored one, the bounded await below would time out.
+        let (_never_sent, never_rx) = tokio::sync::oneshot::channel::<()>();
+        let second = tokio::spawn(async move {
+            let _ = never_rx.await;
+        });
+
+        pool.set_writer_task_join(first);
+        pool.set_writer_task_join(second);
+
+        let taken = pool
+            .take_writer_task_join()
+            .expect("the first handle must still be stored");
+        tokio::time::timeout(Duration::from_secs(5), taken)
+            .await
+            .expect("stored handle must be the first task's; the second never completes")
+            .expect("the first task must not panic");
+        assert!(
+            first_done_rx.await.is_ok(),
+            "completing the taken handle must mean the FIRST task ran to completion"
         );
     }
 

--- a/crates/khive-db/src/pool.rs
+++ b/crates/khive-db/src/pool.rs
@@ -72,9 +72,15 @@ pub struct PoolConfig {
     /// single-writer guarantee — other write paths still open their own
     /// writers until later slices migrate them.
     ///
+    /// `None` means the caller expressed no preference: [`ConnectionPool::new`]
+    /// resolves it once `path` is known, defaulting to `true` for file-backed
+    /// pools and `false` for in-memory ones. `Some(_)` is an explicit
+    /// preference and always wins, in both directions, over that default.
+    ///
     /// Overridable via `KHIVE_WRITE_QUEUE` (`"1"` or `"true"`,
-    /// case-insensitive, enables it; anything else, or unset, leaves it off).
-    pub write_queue_enabled: bool,
+    /// case-insensitive, sets `Some(true)`; any other value sets `Some(false)`;
+    /// unset leaves it `None`).
+    pub write_queue_enabled: Option<bool>,
     /// Bounded channel capacity for the `WriterTask` write queue.
     ///
     /// Overridable via `KHIVE_WRITE_QUEUE_CAPACITY`. Default: 256 pending
@@ -123,8 +129,8 @@ impl Default for PoolConfig {
                 .unwrap_or(DEFAULT_JOURNAL_SIZE_LIMIT_BYTES),
             read_only: false,
             write_queue_enabled: std::env::var("KHIVE_WRITE_QUEUE")
-                .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
-                .unwrap_or(false),
+                .ok()
+                .map(|v| v == "1" || v.eq_ignore_ascii_case("true")),
             write_queue_capacity: std::env::var("KHIVE_WRITE_QUEUE_CAPACITY")
                 .ok()
                 .and_then(|v| v.parse::<usize>().ok())
@@ -451,6 +457,13 @@ impl ConnectionPool {
     pub fn new(config: PoolConfig) -> Result<Self, SqliteError> {
         refuse_home_data_store_in_tests(&config)?;
 
+        // Resolve "no preference" (`None`) now that `path` is known: on for
+        // file-backed pools, off for in-memory ones. An explicit `Some(_)`
+        // preference is left untouched and always wins.
+        let mut config = config;
+        config.write_queue_enabled =
+            Some(config.write_queue_enabled.unwrap_or(config.path.is_some()));
+
         let writer = open_writer_connection(&config)?;
         let wal_enabled = configure_writer_connection(&writer, &config)?;
         let max_readers = effective_reader_count(&config, wal_enabled);
@@ -690,7 +703,7 @@ impl ConnectionPool {
     /// fail loud on a genuine misconfiguration (write queue requested but no
     /// runtime to run it on) can propagate the `Err` directly.
     pub fn writer_task_handle(&self) -> Result<Option<WriterTaskHandle>, StorageError> {
-        if !self.config.write_queue_enabled {
+        if !self.config.write_queue_enabled.unwrap_or(false) {
             return Ok(None);
         }
         // Fast path: already resolved (spawned, degraded, or off) by an
@@ -1261,10 +1274,10 @@ mod tests {
 
     #[test]
     #[serial]
-    fn pool_config_write_queue_defaults_off() {
+    fn pool_config_write_queue_defaults_unset() {
         let _pool_env = clear_pool_env();
         let cfg = PoolConfig::default();
-        assert!(!cfg.write_queue_enabled);
+        assert_eq!(cfg.write_queue_enabled, None);
         assert_eq!(cfg.write_queue_capacity, DEFAULT_WRITE_QUEUE_CAPACITY);
     }
 
@@ -1291,7 +1304,7 @@ mod tests {
         std::env::set_var("KHIVE_WRITE_QUEUE", "1");
         let cfg = PoolConfig::default();
         std::env::remove_var("KHIVE_WRITE_QUEUE");
-        assert!(cfg.write_queue_enabled);
+        assert_eq!(cfg.write_queue_enabled, Some(true));
     }
 
     #[test]
@@ -1300,7 +1313,16 @@ mod tests {
         std::env::set_var("KHIVE_WRITE_QUEUE", "True");
         let cfg = PoolConfig::default();
         std::env::remove_var("KHIVE_WRITE_QUEUE");
-        assert!(cfg.write_queue_enabled);
+        assert_eq!(cfg.write_queue_enabled, Some(true));
+    }
+
+    #[test]
+    #[serial]
+    fn pool_config_env_override_write_queue_enabled_accepts_zero_as_explicit_off() {
+        std::env::set_var("KHIVE_WRITE_QUEUE", "0");
+        let cfg = PoolConfig::default();
+        std::env::remove_var("KHIVE_WRITE_QUEUE");
+        assert_eq!(cfg.write_queue_enabled, Some(false));
     }
 
     #[test]
@@ -1385,6 +1407,62 @@ mod tests {
         let pool = ConnectionPool::new(cfg).expect("file-backed pool should open");
         assert!(path.exists());
         assert!(pool.max_readers() > 0);
+    }
+
+    #[test]
+    #[serial]
+    fn unset_write_queue_resolves_on_for_file_backed_pool() {
+        let _pool_env = clear_pool_env();
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("unset_file_backed.db");
+        let pool = ConnectionPool::new(PoolConfig {
+            path: Some(path),
+            write_queue_enabled: None,
+            ..PoolConfig::default()
+        })
+        .expect("file-backed pool should open");
+        assert_eq!(pool.config().write_queue_enabled, Some(true));
+    }
+
+    #[test]
+    #[serial]
+    fn unset_write_queue_resolves_off_for_memory_backed_pool() {
+        let _pool_env = clear_pool_env();
+        let pool = ConnectionPool::new(PoolConfig {
+            path: None,
+            write_queue_enabled: None,
+            ..PoolConfig::default()
+        })
+        .expect("in-memory pool should open");
+        assert_eq!(pool.config().write_queue_enabled, Some(false));
+    }
+
+    #[test]
+    #[serial]
+    fn explicit_false_stays_off_for_file_backed_pool() {
+        let _pool_env = clear_pool_env();
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("explicit_false_file_backed.db");
+        let pool = ConnectionPool::new(PoolConfig {
+            path: Some(path),
+            write_queue_enabled: Some(false),
+            ..PoolConfig::default()
+        })
+        .expect("file-backed pool should open");
+        assert_eq!(pool.config().write_queue_enabled, Some(false));
+    }
+
+    #[test]
+    #[serial]
+    fn explicit_true_stays_on_for_memory_backed_pool() {
+        let _pool_env = clear_pool_env();
+        let pool = ConnectionPool::new(PoolConfig {
+            path: None,
+            write_queue_enabled: Some(true),
+            ..PoolConfig::default()
+        })
+        .expect("in-memory pool should open");
+        assert_eq!(pool.config().write_queue_enabled, Some(true));
     }
 
     #[test]
@@ -1554,7 +1632,7 @@ mod tests {
         let path = dir.path().join("writer_task_no_runtime.db");
         let cfg = PoolConfig {
             path: Some(path),
-            write_queue_enabled: true,
+            write_queue_enabled: Some(true),
             ..PoolConfig::default()
         };
         let pool = ConnectionPool::new(cfg).expect("file-backed pool should open");

--- a/crates/khive-db/src/pool.rs
+++ b/crates/khive-db/src/pool.rs
@@ -763,7 +763,12 @@ impl ConnectionPool {
     /// the same `writer_task` OnceLock init that makes spawn at-most-once
     /// per pool makes this write at-most-once per pool.
     pub(crate) fn set_writer_task_join(&self, join: tokio::task::JoinHandle<()>) {
-        *self.writer_task_join.lock() = Some(join);
+        let prev = self.writer_task_join.lock().replace(join);
+        debug_assert!(
+            prev.is_none(),
+            "writer task JoinHandle stored twice; the writer_task OnceLock is \
+             supposed to make spawn at-most-once per pool"
+        );
     }
 
     /// Take the writer task's JoinHandle, if a writer task was spawned and
@@ -1441,9 +1446,9 @@ mod tests {
         assert!(pool.max_readers() > 0);
     }
 
-    #[test]
+    #[tokio::test]
     #[serial]
-    fn unset_write_queue_resolves_on_for_file_backed_pool() {
+    async fn unset_write_queue_resolves_on_for_file_backed_pool() {
         let _pool_env = clear_pool_env();
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("unset_file_backed.db");
@@ -1454,11 +1459,19 @@ mod tests {
         })
         .expect("file-backed pool should open");
         assert_eq!(pool.config().write_queue_enabled, Some(true));
+        // Behavioral half: the resolved value actually routes — a writer
+        // task spawns for this pool, not merely a config field flipping.
+        assert!(
+            pool.writer_task_handle()
+                .expect("spawn inside a runtime context must not error")
+                .is_some(),
+            "resolved-on file-backed pool must actually spawn the writer task"
+        );
     }
 
-    #[test]
+    #[tokio::test]
     #[serial]
-    fn unset_write_queue_resolves_off_for_memory_backed_pool() {
+    async fn unset_write_queue_resolves_off_for_memory_backed_pool() {
         let _pool_env = clear_pool_env();
         let pool = ConnectionPool::new(PoolConfig {
             path: None,
@@ -1467,6 +1480,14 @@ mod tests {
         })
         .expect("in-memory pool should open");
         assert_eq!(pool.config().write_queue_enabled, Some(false));
+        // Behavioral half: resolved-off means no writer task, even inside a
+        // runtime context where one could spawn.
+        assert!(
+            pool.writer_task_handle()
+                .expect("disabled queue must resolve without error")
+                .is_none(),
+            "resolved-off in-memory pool must not spawn a writer task"
+        );
     }
 
     #[test]

--- a/crates/khive-db/src/sql_bridge.rs
+++ b/crates/khive-db/src/sql_bridge.rs
@@ -1075,7 +1075,7 @@ impl khive_storage::SqlAccess for SqlBridge {
                         .into(),
                 });
             }
-            if writer_task.is_none() && self.pool.config().write_queue_enabled {
+            if writer_task.is_none() && self.pool.config().write_queue_enabled.unwrap_or(false) {
                 // The queue is enabled but this call didn't get a handle
                 // (spawn/runtime degrade) — a direct-route violation in the
                 // making once this writer's execute*/query* methods run.
@@ -1144,7 +1144,7 @@ impl khive_storage::SqlAccess for SqlBridge {
                         .into(),
                 });
             }
-            if handle.is_none() && self.pool.config().write_queue_enabled {
+            if handle.is_none() && self.pool.config().write_queue_enabled.unwrap_or(false) {
                 crate::timeout_sink::emit_direct_route_violation(
                     &crate::timeout_sink::db_label(&self.pool),
                     crate::timeout_sink::Site::DirectRouteAtomicUnit,
@@ -1219,7 +1219,7 @@ mod tests {
         let path = dir.path().join("write_queue_execute_batch.db");
         let config = PoolConfig {
             path: Some(path.clone()),
-            write_queue_enabled: true,
+            write_queue_enabled: Some(true),
             ..PoolConfig::default()
         };
         let pool = Arc::new(ConnectionPool::new(config).unwrap());
@@ -1286,7 +1286,7 @@ mod tests {
         let path = dir.path().join("write_queue_execute_batch_rollback.db");
         let config = PoolConfig {
             path: Some(path.clone()),
-            write_queue_enabled: true,
+            write_queue_enabled: Some(true),
             ..PoolConfig::default()
         };
         let pool = Arc::new(ConnectionPool::new(config).unwrap());
@@ -1362,7 +1362,7 @@ mod tests {
     /// call immediately afterward.
     ///
     /// Not `#[serial]` / no env var: builds the pool directly with
-    /// `write_queue_enabled: true` in the `PoolConfig` literal, same
+    /// `write_queue_enabled: Some(true)` in the `PoolConfig` literal, same
     /// technique as this round's other new routing tests.
     #[tokio::test]
     async fn atomic_unit_pending_future_errors_without_killing_writer_task() {
@@ -1370,7 +1370,7 @@ mod tests {
         let path = dir.path().join("atomic_unit_pending_future.db");
         let config = PoolConfig {
             path: Some(path.clone()),
-            write_queue_enabled: true,
+            write_queue_enabled: Some(true),
             ..PoolConfig::default()
         };
         let pool = Arc::new(ConnectionPool::new(config).unwrap());
@@ -1468,7 +1468,7 @@ mod tests {
         let path = dir.path().join("strict_writer.db");
         let config = PoolConfig {
             path: Some(path),
-            write_queue_enabled: false,
+            write_queue_enabled: Some(false),
             write_routing_strict: true,
             ..PoolConfig::default()
         };
@@ -1499,7 +1499,7 @@ mod tests {
         let path = dir.path().join("strict_atomic_unit.db");
         let config = PoolConfig {
             path: Some(path),
-            write_queue_enabled: false,
+            write_queue_enabled: Some(false),
             write_routing_strict: true,
             ..PoolConfig::default()
         };
@@ -1535,7 +1535,7 @@ mod tests {
         let path = dir.path().join("writer_read_after_write.db");
         let config = PoolConfig {
             path: Some(path),
-            write_queue_enabled: true,
+            write_queue_enabled: Some(true),
             write_routing_strict: true,
             ..PoolConfig::default()
         };
@@ -1595,7 +1595,7 @@ mod tests {
         let path = dir.path().join("writer_readonly_returning.db");
         let config = PoolConfig {
             path: Some(path),
-            write_queue_enabled: true,
+            write_queue_enabled: Some(true),
             write_routing_strict: true,
             ..PoolConfig::default()
         };
@@ -1671,7 +1671,7 @@ mod tests {
         let path = dir.path().join("acceptance_batch.db");
         let config = PoolConfig {
             path: Some(path),
-            write_queue_enabled: true,
+            write_queue_enabled: Some(true),
             write_routing_strict: true,
             ..PoolConfig::default()
         };
@@ -1862,7 +1862,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let config = PoolConfig {
             path: Some(dir.path().join("bridge_writer_acquisitions.db")),
-            write_queue_enabled: false,
+            write_queue_enabled: Some(false),
             ..PoolConfig::default()
         };
         let pool = Arc::new(ConnectionPool::new(config).unwrap());

--- a/crates/khive-db/src/sql_bridge.rs
+++ b/crates/khive-db/src/sql_bridge.rs
@@ -1075,10 +1075,7 @@ impl khive_storage::SqlAccess for SqlBridge {
                         .into(),
                 });
             }
-            if writer_task.is_none()
-                && self.pool.config().write_queue_enabled.unwrap_or(false)
-                && self.pool.config().path.is_some()
-            {
+            if writer_task.is_none() && self.pool.write_queue_active() {
                 // The queue is enabled but this call didn't get a handle
                 // (spawn/runtime degrade) — a direct-route violation in the
                 // making once this writer's execute*/query* methods run.
@@ -1150,10 +1147,7 @@ impl khive_storage::SqlAccess for SqlBridge {
                         .into(),
                 });
             }
-            if handle.is_none()
-                && self.pool.config().write_queue_enabled.unwrap_or(false)
-                && self.pool.config().path.is_some()
-            {
+            if handle.is_none() && self.pool.write_queue_active() {
                 crate::timeout_sink::emit_direct_route_violation(
                     &crate::timeout_sink::db_label(&self.pool),
                     crate::timeout_sink::Site::DirectRouteAtomicUnit,

--- a/crates/khive-db/src/sql_bridge.rs
+++ b/crates/khive-db/src/sql_bridge.rs
@@ -1075,10 +1075,16 @@ impl khive_storage::SqlAccess for SqlBridge {
                         .into(),
                 });
             }
-            if writer_task.is_none() && self.pool.config().write_queue_enabled.unwrap_or(false) {
+            if writer_task.is_none()
+                && self.pool.config().write_queue_enabled.unwrap_or(false)
+                && self.pool.config().path.is_some()
+            {
                 // The queue is enabled but this call didn't get a handle
                 // (spawn/runtime degrade) — a direct-route violation in the
                 // making once this writer's execute*/query* methods run.
+                // In-memory pools are excluded: they never spawn a writer
+                // task by documented design (explicit `Some(true)` degrades),
+                // so a violation row there would be noise, not signal.
                 crate::timeout_sink::emit_direct_route_violation(
                     &db,
                     crate::timeout_sink::Site::DirectRouteSqlBridgeWriter,
@@ -1144,7 +1150,10 @@ impl khive_storage::SqlAccess for SqlBridge {
                         .into(),
                 });
             }
-            if handle.is_none() && self.pool.config().write_queue_enabled.unwrap_or(false) {
+            if handle.is_none()
+                && self.pool.config().write_queue_enabled.unwrap_or(false)
+                && self.pool.config().path.is_some()
+            {
                 crate::timeout_sink::emit_direct_route_violation(
                     &crate::timeout_sink::db_label(&self.pool),
                     crate::timeout_sink::Site::DirectRouteAtomicUnit,

--- a/crates/khive-db/src/stores/entity_tests.rs
+++ b/crates/khive-db/src/stores/entity_tests.rs
@@ -953,7 +953,7 @@ async fn page_offset_over_i64max_rejected() {
 /// the trip through the type-erased channel intact, and both rows are
 /// actually committed and independently readable back through the store.
 ///
-/// Constructed via a `PoolConfig` literal (`write_queue_enabled: true`), not
+/// Constructed via a `PoolConfig` literal (`write_queue_enabled: Some(true)`), not
 /// the `KHIVE_WRITE_QUEUE` env var — that env var is process-global and this
 /// crate's other tests are NOT `#[serial]` against it, so a window where it
 /// is set here could leak into a concurrently-scheduled test's own pool
@@ -964,7 +964,7 @@ async fn upsert_entities_routes_through_writer_task_when_flag_enabled() {
     let path = dir.path().join("write_queue_entities.db");
     let pool_cfg = PoolConfig {
         path: Some(path.clone()),
-        write_queue_enabled: true,
+        write_queue_enabled: Some(true),
         ..PoolConfig::default()
     };
     let pool = Arc::new(ConnectionPool::new(pool_cfg).unwrap());
@@ -1028,7 +1028,7 @@ async fn upsert_entities_legacy_path_unchanged_when_flag_is_off() {
 /// the writer task exactly once; every store resolves to a clone of the one
 /// pool-owned handle (`ConnectionPool::writer_task_handle`).
 ///
-/// Constructed via a `PoolConfig` literal (`write_queue_enabled: true`), not
+/// Constructed via a `PoolConfig` literal (`write_queue_enabled: Some(true)`), not
 /// the `KHIVE_WRITE_QUEUE` env var — see the sibling
 /// `upsert_entities_routes_through_writer_task_when_flag_enabled` test's doc
 /// comment for the race this avoids.
@@ -1038,7 +1038,7 @@ async fn multiple_stores_over_one_pool_share_a_single_writer_task() {
     let path = dir.path().join("write_queue_shared_writer.db");
     let pool_cfg = PoolConfig {
         path: Some(path.clone()),
-        write_queue_enabled: true,
+        write_queue_enabled: Some(true),
         ..PoolConfig::default()
     };
     let pool = Arc::new(ConnectionPool::new(pool_cfg).unwrap());
@@ -1079,7 +1079,7 @@ async fn multiple_stores_over_one_pool_share_a_single_writer_task() {
 /// caller, session-mirror ingest, converted to `atomic_unit`), so this test
 /// no longer exercises it.
 ///
-/// Constructed via a `PoolConfig` literal (`write_queue_enabled: true`), not
+/// Constructed via a `PoolConfig` literal (`write_queue_enabled: Some(true)`), not
 /// the `KHIVE_WRITE_QUEUE` env var — see the sibling
 /// `upsert_entities_routes_through_writer_task_when_flag_enabled` test's doc
 /// comment for the race this avoids.
@@ -1096,7 +1096,7 @@ async fn concurrent_writes_across_all_migrated_stores_share_one_writer_task() {
     let path = dir.path().join("write_queue_all_paths_shared_writer.db");
     let pool_cfg = PoolConfig {
         path: Some(path.clone()),
-        write_queue_enabled: true,
+        write_queue_enabled: Some(true),
         ..PoolConfig::default()
     };
     let pool = Arc::new(ConnectionPool::new(pool_cfg).unwrap());
@@ -1242,7 +1242,7 @@ async fn concurrent_writes_across_all_migrated_stores_share_one_writer_task() {
 /// take the legacy branch makes this assertion fail, see khive-db PR history
 /// for Fork C slice 2).
 ///
-/// Constructed via a `PoolConfig` literal (`write_queue_enabled: true`), not
+/// Constructed via a `PoolConfig` literal (`write_queue_enabled: Some(true)`), not
 /// the `KHIVE_WRITE_QUEUE` env var — see
 /// `upsert_entities_routes_through_writer_task_when_flag_enabled`'s doc
 /// comment for the race this avoids.
@@ -1252,7 +1252,7 @@ async fn upsert_entity_routes_through_writer_task_when_flag_enabled() {
     let path = dir.path().join("write_queue_entity_single.db");
     let pool_cfg = PoolConfig {
         path: Some(path.clone()),
-        write_queue_enabled: true,
+        write_queue_enabled: Some(true),
         ..PoolConfig::default()
     };
     let pool = Arc::new(ConnectionPool::new(pool_cfg).unwrap());

--- a/crates/khive-db/src/stores/event_tests.rs
+++ b/crates/khive-db/src/stores/event_tests.rs
@@ -963,7 +963,7 @@ async fn append_events_routes_through_writer_task_when_flag_enabled() {
     let path = dir.path().join("write_queue_events.db");
     let pool_cfg = PoolConfig {
         path: Some(path.clone()),
-        write_queue_enabled: true,
+        write_queue_enabled: Some(true),
         ..PoolConfig::default()
     };
     let pool = Arc::new(ConnectionPool::new(pool_cfg).unwrap());

--- a/crates/khive-db/src/stores/graph_tests.rs
+++ b/crates/khive-db/src/stores/graph_tests.rs
@@ -3426,7 +3426,7 @@ async fn traverse_max_depth_over_public_cap_rejected() {
 /// routes through the WriterTask channel instead of the pool-mutex path, and
 /// both edges are actually committed and independently readable back.
 ///
-/// Constructed via a `PoolConfig` literal (`write_queue_enabled: true`), not
+/// Constructed via a `PoolConfig` literal (`write_queue_enabled: Some(true)`), not
 /// the `KHIVE_WRITE_QUEUE` env var — that env var is process-global and this
 /// crate's other tests are NOT `#[serial]` against it, so a window where it
 /// is set here could leak into a concurrently-scheduled test's own pool
@@ -3437,7 +3437,7 @@ async fn upsert_edges_routes_through_writer_task_when_flag_enabled() {
     let path = dir.path().join("write_queue_graph.db");
     let pool_cfg = PoolConfig {
         path: Some(path.clone()),
-        write_queue_enabled: true,
+        write_queue_enabled: Some(true),
         ..PoolConfig::default()
     };
     let pool = Arc::new(ConnectionPool::new(pool_cfg).unwrap());
@@ -3485,7 +3485,7 @@ async fn upsert_edges_routes_through_writer_task_when_flag_enabled() {
 /// slot open (parked on a oneshot via `blocking_recv`, not a sleep/timing
 /// race).
 ///
-/// Constructed via a `PoolConfig` literal (`write_queue_enabled: true`), not
+/// Constructed via a `PoolConfig` literal (`write_queue_enabled: Some(true)`), not
 /// the `KHIVE_WRITE_QUEUE` env var — see
 /// `upsert_edges_routes_through_writer_task_when_flag_enabled`'s doc comment
 /// for the race this avoids.
@@ -3495,7 +3495,7 @@ async fn upsert_edge_routes_through_writer_task_when_flag_enabled() {
     let path = dir.path().join("write_queue_graph_single.db");
     let pool_cfg = PoolConfig {
         path: Some(path.clone()),
-        write_queue_enabled: true,
+        write_queue_enabled: Some(true),
         ..PoolConfig::default()
     };
     let pool = Arc::new(ConnectionPool::new(pool_cfg).unwrap());
@@ -3789,7 +3789,7 @@ async fn upsert_edge_guarded_probe_is_atomic_with_insert_on_file_backed_singleto
 
     let pool_cfg = PoolConfig {
         path: Some(path.clone()),
-        write_queue_enabled: false,
+        write_queue_enabled: Some(false),
         ..PoolConfig::default()
     };
     let pool = Arc::new(ConnectionPool::new(pool_cfg).unwrap());

--- a/crates/khive-db/src/stores/note_tests.rs
+++ b/crates/khive-db/src/stores/note_tests.rs
@@ -321,7 +321,7 @@ async fn assert_page_count_and_items_share_snapshot(query: SnapshotPageQuery) {
     let pool = Arc::new(
         ConnectionPool::new(PoolConfig {
             path: Some(path),
-            write_queue_enabled: false,
+            write_queue_enabled: Some(false),
             ..PoolConfig::default()
         })
         .unwrap(),
@@ -1197,7 +1197,7 @@ async fn page_offset_over_i64max_rejected() {
 /// routes through the WriterTask channel instead of the pool-mutex path, and
 /// both rows are actually committed and independently readable back.
 ///
-/// Constructed via a `PoolConfig` literal (`write_queue_enabled: true`), not
+/// Constructed via a `PoolConfig` literal (`write_queue_enabled: Some(true)`), not
 /// the `KHIVE_WRITE_QUEUE` env var — that env var is process-global and this
 /// crate's other tests are NOT `#[serial]` against it, so a window where it
 /// is set here could leak into a concurrently-scheduled test's own pool
@@ -1208,7 +1208,7 @@ async fn upsert_notes_routes_through_writer_task_when_flag_enabled() {
     let path = dir.path().join("write_queue_notes.db");
     let pool_cfg = PoolConfig {
         path: Some(path.clone()),
-        write_queue_enabled: true,
+        write_queue_enabled: Some(true),
         ..PoolConfig::default()
     };
     let pool = Arc::new(ConnectionPool::new(pool_cfg).unwrap());
@@ -1255,7 +1255,7 @@ async fn upsert_notes_routes_through_writer_task_when_flag_enabled() {
 /// because it runs inside the writer task's own `spawn_blocking`, not a
 /// sleep/timing race).
 ///
-/// Constructed via a `PoolConfig` literal (`write_queue_enabled: true`), not
+/// Constructed via a `PoolConfig` literal (`write_queue_enabled: Some(true)`), not
 /// the `KHIVE_WRITE_QUEUE` env var — see
 /// `upsert_notes_routes_through_writer_task_when_flag_enabled`'s doc comment
 /// for the race this avoids.
@@ -1265,7 +1265,7 @@ async fn upsert_note_routes_through_writer_task_when_flag_enabled() {
     let path = dir.path().join("write_queue_note_single.db");
     let pool_cfg = PoolConfig {
         path: Some(path.clone()),
-        write_queue_enabled: true,
+        write_queue_enabled: Some(true),
         ..PoolConfig::default()
     };
     let pool = Arc::new(ConnectionPool::new(pool_cfg).unwrap());

--- a/crates/khive-db/src/stores/sparse.rs
+++ b/crates/khive-db/src/stores/sparse.rs
@@ -953,7 +953,7 @@ mod tests {
     /// channel instead of the pool-mutex path, and both rows are actually
     /// committed and independently searchable back.
     ///
-    /// Constructed via a `PoolConfig` literal (`write_queue_enabled: true`),
+    /// Constructed via a `PoolConfig` literal (`write_queue_enabled: Some(true)`),
     /// not the `KHIVE_WRITE_QUEUE` env var — that env var is process-global
     /// and this crate's other tests are NOT `#[serial]` against it, so a
     /// window where it is set here could leak into a
@@ -969,7 +969,7 @@ mod tests {
         let path = dir.path().join("write_queue_sparse.db");
         let pool_cfg = PoolConfig {
             path: Some(path.clone()),
-            write_queue_enabled: true,
+            write_queue_enabled: Some(true),
             ..PoolConfig::default()
         };
         let pool = Arc::new(ConnectionPool::new(pool_cfg).expect("pool"));

--- a/crates/khive-db/src/stores/text.rs
+++ b/crates/khive-db/src/stores/text.rs
@@ -44,7 +44,7 @@ fn refuse_direct_route_if_strict(
                 .into(),
         });
     }
-    if pool.config().write_queue_enabled.unwrap_or(false) && pool.config().path.is_some() {
+    if pool.write_queue_active() {
         // In-memory pools never spawn a writer task by documented design
         // (explicit `Some(true)` degrades), so a violation row there would
         // be noise, not signal.

--- a/crates/khive-db/src/stores/text.rs
+++ b/crates/khive-db/src/stores/text.rs
@@ -44,7 +44,10 @@ fn refuse_direct_route_if_strict(
                 .into(),
         });
     }
-    if pool.config().write_queue_enabled.unwrap_or(false) {
+    if pool.config().write_queue_enabled.unwrap_or(false) && pool.config().path.is_some() {
+        // In-memory pools never spawn a writer task by documented design
+        // (explicit `Some(true)` degrades), so a violation row there would
+        // be noise, not signal.
         crate::timeout_sink::emit_direct_route_violation(
             &crate::timeout_sink::db_label(pool),
             site,

--- a/crates/khive-db/src/stores/text.rs
+++ b/crates/khive-db/src/stores/text.rs
@@ -44,7 +44,7 @@ fn refuse_direct_route_if_strict(
                 .into(),
         });
     }
-    if pool.config().write_queue_enabled {
+    if pool.config().write_queue_enabled.unwrap_or(false) {
         crate::timeout_sink::emit_direct_route_violation(
             &crate::timeout_sink::db_label(pool),
             site,

--- a/crates/khive-db/src/stores/text_tests.rs
+++ b/crates/khive-db/src/stores/text_tests.rs
@@ -2207,7 +2207,7 @@ async fn upsert_documents_first_error_populated_on_item_failure() {
 /// routes through the WriterTask channel instead of the pool-mutex path, and
 /// both documents are actually committed and independently readable back.
 ///
-/// Constructed via a `PoolConfig` literal (`write_queue_enabled: true`), not
+/// Constructed via a `PoolConfig` literal (`write_queue_enabled: Some(true)`), not
 /// the `KHIVE_WRITE_QUEUE` env var — that env var is process-global and this
 /// crate's other tests are NOT `#[serial]` against it, so a window where it
 /// is set here could leak into a concurrently-scheduled test's own pool
@@ -2219,7 +2219,7 @@ async fn upsert_documents_routes_through_writer_task_when_flag_enabled() {
     let path = dir.path().join("write_queue_text.db");
     let pool_cfg = PoolConfig {
         path: Some(path.clone()),
-        write_queue_enabled: true,
+        write_queue_enabled: Some(true),
         ..PoolConfig::default()
     };
     let pool = Arc::new(ConnectionPool::new(pool_cfg).unwrap());
@@ -2538,7 +2538,7 @@ async fn rename_namespace_routes_through_writer_task_when_flag_enabled() {
     let path = dir.path().join("write_queue_rename_namespace.db");
     let pool_cfg = PoolConfig {
         path: Some(path.clone()),
-        write_queue_enabled: true,
+        write_queue_enabled: Some(true),
         ..PoolConfig::default()
     };
     let pool = Arc::new(ConnectionPool::new(pool_cfg).unwrap());
@@ -2624,7 +2624,7 @@ async fn rename_namespace_strict_routing_fails_closed_without_writer_task() {
     let path = dir.path().join("strict_rename_namespace.db");
     let pool_cfg = PoolConfig {
         path: Some(path.clone()),
-        write_queue_enabled: false,
+        write_queue_enabled: Some(false),
         write_routing_strict: true,
         ..PoolConfig::default()
     };
@@ -2674,7 +2674,7 @@ fn general_write_routes_through_writer_task_when_store_built_outside_runtime() {
     let path = dir.path().join("general_write_no_runtime_construction.db");
     let pool_cfg = PoolConfig {
         path: Some(path.clone()),
-        write_queue_enabled: true,
+        write_queue_enabled: Some(true),
         ..PoolConfig::default()
     };
     let pool = Arc::new(ConnectionPool::new(pool_cfg).unwrap());

--- a/crates/khive-db/src/stores/vectors.rs
+++ b/crates/khive-db/src/stores/vectors.rs
@@ -41,7 +41,7 @@ fn refuse_direct_route_if_strict(
                 .into(),
         });
     }
-    if pool.config().write_queue_enabled.unwrap_or(false) && pool.config().path.is_some() {
+    if pool.write_queue_active() {
         // In-memory pools never spawn a writer task by documented design
         // (explicit `Some(true)` degrades), so a violation row there would
         // be noise, not signal.

--- a/crates/khive-db/src/stores/vectors.rs
+++ b/crates/khive-db/src/stores/vectors.rs
@@ -41,7 +41,10 @@ fn refuse_direct_route_if_strict(
                 .into(),
         });
     }
-    if pool.config().write_queue_enabled.unwrap_or(false) {
+    if pool.config().write_queue_enabled.unwrap_or(false) && pool.config().path.is_some() {
+        // In-memory pools never spawn a writer task by documented design
+        // (explicit `Some(true)` degrades), so a violation row there would
+        // be noise, not signal.
         crate::timeout_sink::emit_direct_route_violation(
             &crate::timeout_sink::db_label(pool),
             site,

--- a/crates/khive-db/src/stores/vectors.rs
+++ b/crates/khive-db/src/stores/vectors.rs
@@ -41,7 +41,7 @@ fn refuse_direct_route_if_strict(
                 .into(),
         });
     }
-    if pool.config().write_queue_enabled {
+    if pool.config().write_queue_enabled.unwrap_or(false) {
         crate::timeout_sink::emit_direct_route_violation(
             &crate::timeout_sink::db_label(pool),
             site,
@@ -2486,7 +2486,7 @@ mod delete_subjects_atomic_tests {
         let pool = Arc::new(
             ConnectionPool::new(PoolConfig {
                 path: Some(path),
-                write_queue_enabled,
+                write_queue_enabled: Some(write_queue_enabled),
                 ..PoolConfig::default()
             })
             .expect("file-backed pool"),
@@ -2681,7 +2681,7 @@ mod delete_subjects_atomic_tests {
         let pool = Arc::new(
             ConnectionPool::new(PoolConfig {
                 path: Some(path),
-                write_queue_enabled: false,
+                write_queue_enabled: Some(false),
                 ..PoolConfig::default()
             })
             .expect("file-backed pool"),
@@ -4342,7 +4342,7 @@ mod write_queue_tests {
             .expect("create ann_write_log");
     }
 
-    /// Constructed via a `PoolConfig` literal (`write_queue_enabled: true`),
+    /// Constructed via a `PoolConfig` literal (`write_queue_enabled: Some(true)`),
     /// not the `KHIVE_WRITE_QUEUE` env var — that env var is process-global
     /// and this crate's other tests are NOT `#[serial]` against it, so a
     /// window where it is set here could leak into a
@@ -4361,7 +4361,7 @@ mod write_queue_tests {
         let pool = Arc::new(
             ConnectionPool::new(PoolConfig {
                 path: Some(path),
-                write_queue_enabled: true,
+                write_queue_enabled: Some(true),
                 ..PoolConfig::default()
             })
             .expect("file-backed pool"),
@@ -4465,7 +4465,7 @@ mod write_queue_tests {
         let pool = Arc::new(
             ConnectionPool::new(PoolConfig {
                 path: Some(path),
-                write_queue_enabled: true,
+                write_queue_enabled: Some(true),
                 ..PoolConfig::default()
             })
             .expect("file-backed pool"),
@@ -4664,7 +4664,7 @@ mod write_queue_tests {
         let pool = Arc::new(
             ConnectionPool::new(PoolConfig {
                 path: Some(path),
-                write_queue_enabled: true,
+                write_queue_enabled: Some(true),
                 ..PoolConfig::default()
             })
             .expect("file-backed pool"),
@@ -4731,7 +4731,7 @@ mod write_queue_tests {
         let pool = Arc::new(
             ConnectionPool::new(PoolConfig {
                 path: Some(path),
-                write_queue_enabled: true,
+                write_queue_enabled: Some(true),
                 ..PoolConfig::default()
             })
             .expect("file-backed pool"),
@@ -4834,7 +4834,7 @@ mod write_queue_tests {
         let pool = Arc::new(
             ConnectionPool::new(PoolConfig {
                 path: Some(path),
-                write_queue_enabled: false,
+                write_queue_enabled: Some(false),
                 write_routing_strict: true,
                 ..PoolConfig::default()
             })
@@ -4876,7 +4876,7 @@ mod write_queue_tests {
         let pool = Arc::new(
             ConnectionPool::new(PoolConfig {
                 path: Some(path),
-                write_queue_enabled: false,
+                write_queue_enabled: Some(false),
                 write_routing_strict: true,
                 ..PoolConfig::default()
             })
@@ -4949,7 +4949,7 @@ mod write_queue_tests {
         let pool = Arc::new(
             ConnectionPool::new(PoolConfig {
                 path: Some(path),
-                write_queue_enabled: true,
+                write_queue_enabled: Some(true),
                 ..PoolConfig::default()
             })
             .expect("file-backed pool"),

--- a/crates/khive-db/src/writer_task.rs
+++ b/crates/khive-db/src/writer_task.rs
@@ -1431,7 +1431,7 @@ mod tests {
         let path = dir.path().join("writer_task_wrapped_panic.db");
         let cfg = PoolConfig {
             path: Some(path),
-            write_queue_enabled: true,
+            write_queue_enabled: Some(true),
             write_queue_capacity: 8,
             ..PoolConfig::default()
         };

--- a/crates/khive-db/src/writer_task.rs
+++ b/crates/khive-db/src/writer_task.rs
@@ -544,13 +544,17 @@ pub fn spawn(pool: &ConnectionPool, capacity: usize) -> Result<WriterTaskHandle,
     let origin = pool.origin();
     let db = crate::timeout_sink::db_label(pool);
     let (tx, rx) = mpsc::channel(capacity.max(1));
-    tokio::spawn(run_writer_task(
+    let join = tokio::spawn(run_writer_task(
         conn,
         rx,
         origin,
         db.clone(),
         acquisition_counters,
     ));
+    // Stored on the pool (not returned) so the handle's clone-and-share
+    // contract stays untouched; see ConnectionPool::take_writer_task_join
+    // for who awaits it and why.
+    pool.set_writer_task_join(join);
     Ok(WriterTaskHandle {
         tx,
         db,

--- a/crates/khive-db/tests/writer_timeout_sink.rs
+++ b/crates/khive-db/tests/writer_timeout_sink.rs
@@ -366,12 +366,15 @@ async fn event_busy_standalone_writer_emits_ndjson_row() {
 /// `standalone:text` busy site regardless of the file-backed write-queue
 /// default.
 ///
-/// Env restore ordering is safe as written: `StorageBackend::sqlite` reads
-/// `PoolConfig::default()` off the env and `ConnectionPool::new` resolves the
-/// `None` preference synchronously before that constructor returns
-/// (crates/khive-db/src/backend.rs:38-45, crates/khive-db/src/pool.rs:465-473),
-/// so the pool's resolved `Some(false)` config is already baked in by the
-/// time the variables are restored below.
+/// Env restore ordering is safe as written: `StorageBackend::sqlite`
+/// (crates/khive-db/src/backend.rs:38-45) builds its `PoolConfig` via
+/// `PoolConfig::default()` — which reads `KHIVE_WRITE_QUEUE` synchronously
+/// (crates/khive-db/src/pool.rs:140-143) — and passes it to
+/// `ConnectionPool::new`, which resolves the `None` preference to a concrete
+/// `Some(..)` synchronously before that constructor returns
+/// (crates/khive-db/src/pool.rs:483-488). No pool construction on this path
+/// is lazy: the resolved `Some(false)` config is already baked in by the time
+/// the variables are restored below.
 #[tokio::test]
 #[serial_test::serial(writer_timeout_sink_busy_env)]
 async fn text_busy_standalone_writer_emits_ndjson_row() {

--- a/crates/khive-db/tests/writer_timeout_sink.rs
+++ b/crates/khive-db/tests/writer_timeout_sink.rs
@@ -365,6 +365,13 @@ async fn event_busy_standalone_writer_emits_ndjson_row() {
 /// standalone-writer path so this test keeps exercising the
 /// `standalone:text` busy site regardless of the file-backed write-queue
 /// default.
+///
+/// Env restore ordering is safe as written: `StorageBackend::sqlite` reads
+/// `PoolConfig::default()` off the env and `ConnectionPool::new` resolves the
+/// `None` preference synchronously before that constructor returns
+/// (crates/khive-db/src/backend.rs:38-45, crates/khive-db/src/pool.rs:465-473),
+/// so the pool's resolved `Some(false)` config is already baked in by the
+/// time the variables are restored below.
 #[tokio::test]
 #[serial_test::serial(writer_timeout_sink_busy_env)]
 async fn text_busy_standalone_writer_emits_ndjson_row() {

--- a/crates/khive-db/tests/writer_timeout_sink.rs
+++ b/crates/khive-db/tests/writer_timeout_sink.rs
@@ -154,6 +154,10 @@ async fn sql_bridge_busy_standalone_writer_emits_ndjson_row() {
     let pool_cfg = PoolConfig {
         path: Some(db_path.clone()),
         busy_timeout: Duration::from_millis(100),
+        // Force the legacy standalone-writer path so this test keeps
+        // exercising the `standalone:sql_bridge` busy site regardless of
+        // the file-backed write-queue default.
+        write_queue_enabled: Some(false),
         ..PoolConfig::default()
     };
     let pool = Arc::new(ConnectionPool::new(pool_cfg).unwrap());
@@ -222,6 +226,10 @@ async fn graph_busy_standalone_writer_emits_ndjson_row() {
     let pool_cfg = PoolConfig {
         path: Some(db_path.clone()),
         busy_timeout: Duration::from_millis(100),
+        // Force the legacy standalone-writer path so this test keeps
+        // exercising the `standalone:graph` busy site regardless of the
+        // file-backed write-queue default.
+        write_queue_enabled: Some(false),
         ..PoolConfig::default()
     };
     let pool = Arc::new(ConnectionPool::new(pool_cfg).unwrap());
@@ -290,6 +298,10 @@ async fn event_busy_standalone_writer_emits_ndjson_row() {
     let pool_cfg = PoolConfig {
         path: Some(db_path.clone()),
         busy_timeout: Duration::from_millis(100),
+        // Force the legacy standalone-writer path so this test keeps
+        // exercising the `standalone:event` busy site regardless of the
+        // file-backed write-queue default.
+        write_queue_enabled: Some(false),
         ..PoolConfig::default()
     };
     let pool = Arc::new(ConnectionPool::new(pool_cfg).unwrap());
@@ -346,10 +358,13 @@ async fn event_busy_standalone_writer_emits_ndjson_row() {
 /// itself is crate-private, so this goes through the public
 /// `StorageBackend::sqlite`/`.text()` surface instead of constructing the
 /// store type directly. `#[serial]` because, unlike the other tests here,
-/// this one must read `KHIVE_BUSY_TIMEOUT_SECS` off `PoolConfig::default()`
-/// (there is no field to override directly through `StorageBackend`) —
-/// serializing avoids a hypothetical future test in this file racing the
-/// same env var.
+/// this one must read `KHIVE_BUSY_TIMEOUT_SECS` and `KHIVE_WRITE_QUEUE` off
+/// `PoolConfig::default()` (there is no field to override directly through
+/// `StorageBackend`) — serializing avoids a hypothetical future test in this
+/// file racing the same env vars. `KHIVE_WRITE_QUEUE=0` forces the legacy
+/// standalone-writer path so this test keeps exercising the
+/// `standalone:text` busy site regardless of the file-backed write-queue
+/// default.
 #[tokio::test]
 #[serial_test::serial(writer_timeout_sink_busy_env)]
 async fn text_busy_standalone_writer_emits_ndjson_row() {
@@ -359,11 +374,17 @@ async fn text_busy_standalone_writer_emits_ndjson_row() {
     let db_path = dir.path().join("text_busy_sink_test.db");
 
     let previous_busy_timeout = std::env::var_os("KHIVE_BUSY_TIMEOUT_SECS");
+    let previous_write_queue = std::env::var_os("KHIVE_WRITE_QUEUE");
     std::env::set_var("KHIVE_BUSY_TIMEOUT_SECS", "1");
+    std::env::set_var("KHIVE_WRITE_QUEUE", "0");
     let backend = khive_db::StorageBackend::sqlite(&db_path).expect("file-backed backend");
     match previous_busy_timeout {
         Some(v) => std::env::set_var("KHIVE_BUSY_TIMEOUT_SECS", v),
         None => std::env::remove_var("KHIVE_BUSY_TIMEOUT_SECS"),
+    }
+    match previous_write_queue {
+        Some(v) => std::env::set_var("KHIVE_WRITE_QUEUE", v),
+        None => std::env::remove_var("KHIVE_WRITE_QUEUE"),
     }
 
     let store = backend.text("wts_busy_test").expect("text search");
@@ -428,7 +449,7 @@ async fn slow_queued_write_emits_slow_write_row() {
         std::env::set_var("KHIVE_SLOW_WRITE_THRESHOLD_MS", "1");
         let cfg = PoolConfig {
             path: Some(db_path.clone()),
-            write_queue_enabled: true,
+            write_queue_enabled: Some(true),
             ..PoolConfig::default()
         };
         let pool = ConnectionPool::new(cfg).expect("file-backed pool should open");
@@ -484,7 +505,7 @@ async fn slow_write_disabled_by_zero_threshold_emits_nothing() {
         std::env::set_var("KHIVE_SLOW_WRITE_THRESHOLD_MS", "0");
         let cfg = PoolConfig {
             path: Some(db_path.clone()),
-            write_queue_enabled: true,
+            write_queue_enabled: Some(true),
             ..PoolConfig::default()
         };
         let pool = ConnectionPool::new(cfg).expect("file-backed pool should open");

--- a/crates/khive-pack-brain/src/fold_gate.rs
+++ b/crates/khive-pack-brain/src/fold_gate.rs
@@ -434,25 +434,12 @@ async fn fold_within_tx(
 
 // ADR-067 Component A (Fork C slice 2): `apply_fold_gate`/
 // `apply_fold_gate_and_append_event` no longer issue their own manual
-// `BEGIN IMMEDIATE`/`COMMIT`/`ROLLBACK` via this helper (that now lives in
-// `SqlBridge::atomic_unit`'s `run_manual_atomic_unit`) — this remains only
-// as a small test-seeding utility.
-#[cfg(test)]
-async fn exec_stmt(
-    writer: &mut dyn SqlWriter,
-    sql: &str,
-    params: Vec<SqlValue>,
-    label: &str,
-) -> khive_storage::StorageResult<()> {
-    writer
-        .execute(SqlStatement {
-            sql: sql.to_string(),
-            params,
-            label: Some(label.to_string()),
-        })
-        .await?;
-    Ok(())
-}
+// `BEGIN IMMEDIATE`/`COMMIT`/`ROLLBACK`; that logic lives in
+// `SqlBridge::atomic_unit`'s `run_manual_atomic_unit`. The `exec_stmt`
+// test-seeding helper that once lived here is gone with the last manual
+// seed transaction: under a write-queue-enabled pool every statement is
+// wrapped in the writer task's own transaction, so test seeding issues
+// plain DML through the writer handle instead.
 
 #[cfg(test)]
 mod tests {
@@ -628,8 +615,10 @@ mod tests {
     }
 
     /// Shared setup for the file-backed concurrency/skew tests below: only a
-    /// real file-backed pool opens a standalone `rusqlite::Connection` per
-    /// `writer()` call (module doc above) — the property production needs
+    /// real file-backed pool resolves `write_queue_enabled` to true (ADR-136
+    /// write-queue default where the backing store is known), so `writer()`
+    /// hands out a handle whose statements run inside the pool's shared
+    /// writer task's own `BEGIN IMMEDIATE` — the property production needs
     /// and the in-memory pool cannot exercise.
     fn file_backed_runtime(db_name: &str) -> (khive_runtime::KhiveRuntime, tempfile::TempDir) {
         use khive_runtime::{BackendId, KhiveRuntime, Namespace, RuntimeConfig};
@@ -1047,7 +1036,14 @@ mod tests {
     /// The failure is injected by making `build_event` return an `Event`
     /// whose `id` collides with a row already seeded in `events` (`id` is
     /// that table's `PRIMARY KEY`) — a real, deterministic SQLite
-    /// constraint violation on the INSERT, not a mock. `append_event_on_writer`'s
+    /// constraint violation on the INSERT, not a mock. The seed runs in the
+    /// fixture writer's own transaction (the queue-routed writer task wraps
+    /// each drained request in `BEGIN IMMEDIATE`, so a manual bare `BEGIN`
+    /// here would nest and fail `cannot start a transaction within a
+    /// transaction`); the collision itself still bites inside the unit
+    /// under test's separate `atomic_unit` transaction, where the injected
+    /// event INSERT conflicts with the by-then-committed seeded row.
+    /// `append_event_on_writer`'s
     /// INSERT has no `OR IGNORE`, so the conflict surfaces as an `Err` from
     /// `SqlWriter::execute`, propagating out of `apply_fold_gate_and_append_event`
     /// before `COMMIT` — exercising the previously untested rollback path
@@ -1072,12 +1068,17 @@ mod tests {
         let event_target = uuid::Uuid::new_v4();
         let colliding_id = uuid::Uuid::new_v4();
 
-        // Seed a colliding `events` row outside the unit under test.
+        // Seed a colliding `events` row outside the unit under test, inside
+        // the fixture writer's own transaction: this file-backed pool routes
+        // `writer()` statements through the shared writer task, which opens
+        // its own `BEGIN IMMEDIATE` per drained request — a manual bare
+        // `BEGIN` here would nest inside it and fail `cannot start a
+        // transaction within a transaction`, and a bare `COMMIT` would close
+        // the writer task's transaction early. The single insert therefore
+        // runs as one queued statement (atomic on its own), and the seeded
+        // row is durable before the unit under test runs.
         {
             let mut writer = sql.writer().await.expect("writer");
-            exec_stmt(writer.as_mut(), "BEGIN IMMEDIATE", vec![], "seed_begin")
-                .await
-                .expect("begin seed txn");
             let seed_event = Event {
                 id: colliding_id,
                 ..Event::new(
@@ -1091,9 +1092,6 @@ mod tests {
             khive_db::stores::event::append_event_on_writer(writer.as_mut(), &seed_event)
                 .await
                 .expect("seed colliding event");
-            exec_stmt(writer.as_mut(), "COMMIT", vec![], "seed_commit")
-                .await
-                .expect("commit seed txn");
         }
 
         // First attempt: claim succeeds, mass folds, but the event append

--- a/crates/khive-pack-brain/src/fold_gate.rs
+++ b/crates/khive-pack-brain/src/fold_gate.rs
@@ -682,7 +682,7 @@ mod tests {
     /// manual seed transaction hit "cannot start a transaction within a
     /// transaction" under `cargo test`'s default parallelism before this test
     /// was rewritten to avoid the env var). Constructing the pool directly
-    /// with `write_queue_enabled: true` in the config literal, and driving
+    /// with `write_queue_enabled: Some(true)` in the config literal, and driving
     /// `apply_fold_gate` over a bare `SqlBridge` instead of a full
     /// `KhiveRuntime`, sidesteps global mutable state entirely — no
     /// `#[serial]` needed, and no risk to any other test in this binary.
@@ -692,7 +692,7 @@ mod tests {
         let db_path = dir.path().join("fold-gate-write-queue-routing.db");
         let pool_cfg = khive_db::PoolConfig {
             path: Some(db_path),
-            write_queue_enabled: true,
+            write_queue_enabled: Some(true),
             ..khive_db::PoolConfig::default()
         };
         let pool = std::sync::Arc::new(khive_db::ConnectionPool::new(pool_cfg).expect("pool"));

--- a/crates/khive-pack-brain/src/persist.rs
+++ b/crates/khive-pack-brain/src/persist.rs
@@ -1910,7 +1910,7 @@ mod persist_write_queue_routing {
         let db_path = dir.path().join("persist-write-queue-routing.db");
         let pool_cfg = khive_db::PoolConfig {
             path: Some(db_path),
-            write_queue_enabled: true,
+            write_queue_enabled: Some(true),
             ..khive_db::PoolConfig::default()
         };
         let pool = std::sync::Arc::new(khive_db::ConnectionPool::new(pool_cfg).expect("pool"));

--- a/crates/khive-pack-brain/src/serve_ledger.rs
+++ b/crates/khive-pack-brain/src/serve_ledger.rs
@@ -564,7 +564,7 @@ mod tests {
         let pool = Arc::new(
             khive_db::ConnectionPool::new(khive_db::PoolConfig {
                 path: Some(db_path),
-                write_queue_enabled: false,
+                write_queue_enabled: Some(false),
                 ..khive_db::PoolConfig::default()
             })
             .expect("pool"),
@@ -654,7 +654,7 @@ mod tests {
     /// (see `fold_gate::tests::fold_gate_apply_routes_through_writer_task_when_flag_enabled`'s
     /// doc comment for the concrete failure this caused before both tests
     /// were rewritten to avoid the env var). Constructing the pool directly
-    /// with `write_queue_enabled: true` in the config literal, and driving
+    /// with `write_queue_enabled: Some(true)` in the config literal, and driving
     /// `record_serve` over a bare `SqlBridge` instead of a full
     /// `KhiveRuntime`, sidesteps global mutable state entirely.
     #[tokio::test]
@@ -663,7 +663,7 @@ mod tests {
         let db_path = dir.path().join("serve-ledger-write-queue-routing.db");
         let pool_cfg = khive_db::PoolConfig {
             path: Some(db_path),
-            write_queue_enabled: true,
+            write_queue_enabled: Some(true),
             ..khive_db::PoolConfig::default()
         };
         let pool = std::sync::Arc::new(khive_db::ConnectionPool::new(pool_cfg).expect("pool"));

--- a/crates/khive-pack-memory/src/handlers/prune.rs
+++ b/crates/khive-pack-memory/src/handlers/prune.rs
@@ -625,7 +625,7 @@ mod vacuum_write_queue_tests {
         let db_path = dir.path().join("memory-vacuum-write-queue.db");
         let pool_cfg = khive_db::PoolConfig {
             path: Some(db_path),
-            write_queue_enabled: true,
+            write_queue_enabled: Some(true),
             ..khive_db::PoolConfig::default()
         };
         let pool = std::sync::Arc::new(khive_db::ConnectionPool::new(pool_cfg).expect("pool"));

--- a/crates/khive-pack-session/src/mirror/ingest.rs
+++ b/crates/khive-pack-session/src/mirror/ingest.rs
@@ -2843,7 +2843,7 @@ mod tests {
     fn write_queue_pool(db_path: std::path::PathBuf) -> Arc<khive_db::ConnectionPool> {
         let pool_cfg = khive_db::PoolConfig {
             path: Some(db_path),
-            write_queue_enabled: true,
+            write_queue_enabled: Some(true),
             ..khive_db::PoolConfig::default()
         };
         let pool = Arc::new(khive_db::ConnectionPool::new(pool_cfg).expect("pool"));

--- a/crates/khive-runtime/src/atomic_runner.rs
+++ b/crates/khive-runtime/src/atomic_runner.rs
@@ -403,7 +403,7 @@ mod tests {
 
     /// A scratch pool wired exactly like the daemon.rs / sql_bridge.rs
     /// tests above it: file-backed (atomic_unit's single-writer path is
-    /// only reachable file-backed), `write_queue_enabled: true` so
+    /// only reachable file-backed), `write_queue_enabled: Some(true)` so
     /// `atomic_unit` routes through the real `WriterTask` + `block_on_sync`
     /// seam rather than the flag-off manual-transaction fallback — the
     /// suspend-trap contract only fires on this path.
@@ -413,7 +413,7 @@ mod tests {
         let pool = StdArc::new(
             ConnectionPool::new(PoolConfig {
                 path: Some(path),
-                write_queue_enabled: true,
+                write_queue_enabled: Some(true),
                 ..PoolConfig::default()
             })
             .expect("pool open"),

--- a/crates/khive-runtime/src/daemon.rs
+++ b/crates/khive-runtime/src/daemon.rs
@@ -2819,7 +2819,7 @@ mod tests {
         let enabled_pool = Arc::new(
             ConnectionPool::new(khive_db::PoolConfig {
                 path: Some(dir.path().join("wq_enabled.db")),
-                write_queue_enabled: true,
+                write_queue_enabled: Some(true),
                 ..khive_db::PoolConfig::default()
             })
             .expect("pool open"),
@@ -2841,7 +2841,7 @@ mod tests {
         let disabled_pool = Arc::new(
             ConnectionPool::new(khive_db::PoolConfig {
                 path: Some(dir.path().join("wq_disabled.db")),
-                write_queue_enabled: false,
+                write_queue_enabled: Some(false),
                 ..khive_db::PoolConfig::default()
             })
             .expect("pool open"),

--- a/crates/khive-runtime/src/operations.rs
+++ b/crates/khive-runtime/src/operations.rs
@@ -9124,7 +9124,7 @@ mod tests {
     // delete against the guarded write via `tokio::join!` with no explicit
     // ordering control, so the scheduler could run them fully sequentially
     // on one thread without ever exercising real interleaving, and neither
-    // the file-backed storage path nor `write_queue_enabled: true`
+    // the file-backed storage path nor `write_queue_enabled: Some(true)`
     // (`KHIVE_WRITE_QUEUE=1`, the `WriterTask`-routed write path in
     // `SqlGraphStore`) is covered at all. The four tests below close both
     // gaps: file-backed databases, one run with the writer queue off

--- a/crates/khive-vcs/src/sync.rs
+++ b/crates/khive-vcs/src/sync.rs
@@ -2530,7 +2530,7 @@ mod tests {
 // `memory.vacuum` regression test in khive-pack-memory's `prune.rs` — this
 // drives the underlying mechanism directly at the `SqlBridge` level: the same
 // `execute_script_top_level("PRAGMA wal_checkpoint(TRUNCATE);")` call that
-// `checkpoint_wal` makes, over a `PoolConfig { write_queue_enabled: true, .. }`
+// `checkpoint_wal` makes, over a `PoolConfig { write_queue_enabled: Some(true), .. }`
 // literal (no env var mutation, no cross-test race).
 #[cfg(test)]
 mod checkpoint_wal_write_queue_tests {
@@ -2540,7 +2540,7 @@ mod checkpoint_wal_write_queue_tests {
         let db_path = dir.path().join("vcs-checkpoint-write-queue.db");
         let pool_cfg = khive_db::PoolConfig {
             path: Some(db_path),
-            write_queue_enabled: true,
+            write_queue_enabled: Some(true),
             ..khive_db::PoolConfig::default()
         };
         let pool = std::sync::Arc::new(khive_db::ConnectionPool::new(pool_cfg).expect("pool"));
@@ -2576,7 +2576,7 @@ mod checkpoint_wal_write_queue_tests {
         let db_path = dir.path().join("vcs-checkpoint-write-queue-regression.db");
         let pool_cfg = khive_db::PoolConfig {
             path: Some(db_path),
-            write_queue_enabled: true,
+            write_queue_enabled: Some(true),
             ..khive_db::PoolConfig::default()
         };
         let pool = std::sync::Arc::new(khive_db::ConnectionPool::new(pool_cfg).expect("pool"));

--- a/crates/kkernel/src/code_ingest.rs
+++ b/crates/kkernel/src/code_ingest.rs
@@ -23,6 +23,14 @@ use khive_pack_code::{ingest_findings_json, CodeIngestBatch, CodeIngestOptions};
 use khive_runtime::{entity_fts_document, note_fts_document, secret_gate, KhiveRuntime, Namespace};
 use khive_storage::{SqlStatement, SqlValue, SubstrateKind};
 
+/// Upper bound on how long the real ingest path waits for the pool's writer
+/// task to exit after the last write returned. Generous relative to any
+/// realistic queue depth for a findings batch; hitting it means something is
+/// holding a `WriterTaskHandle` clone alive (the queue never closed) or the
+/// writer is wedged, and the caller is told loudly rather than returning
+/// with the database file still in motion.
+const WRITER_DRAIN_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
+
 /// Arguments for `kkernel code-ingest`.
 #[derive(Parser, Debug)]
 pub struct CodeIngestArgs {
@@ -358,6 +366,34 @@ where
             .upsert_edge(edge.clone())
             .await
             .map_err(|e| anyhow::anyhow!("{e}"))?;
+    }
+
+    // The migrated stores above route writes through the pool's shared
+    // writer task (ADR-067 Component A), which owns its own SQLite
+    // connection and exits only after every WriterTaskHandle clone has
+    // dropped and the queue has drained. That connection's close fires
+    // SQLite's close-time WAL checkpoint, so until the task exits the
+    // database file bytes can still move after this function returns. Drop
+    // every handle owner (the stores, then the runtime and its pool — which
+    // closes the queue), then await the task's exit with a bounded, loud
+    // timeout: a returned `Ok(report)` implies settled file state.
+    let writer_join = runtime.backend().pool().take_writer_task_join();
+    drop(graph);
+    drop(notes);
+    drop(entities);
+    drop(token);
+    drop(runtime);
+    if let Some(join) = writer_join {
+        match tokio::time::timeout(WRITER_DRAIN_TIMEOUT, join).await {
+            Ok(Ok(())) => {}
+            Ok(Err(join_err)) => anyhow::bail!(
+                "writer task terminated abnormally after ingest completed: {join_err}"
+            ),
+            Err(_elapsed) => anyhow::bail!(
+                "writer task did not drain within {WRITER_DRAIN_TIMEOUT:?} after ingest; \
+                 database file state may still be unsettled"
+            ),
+        }
     }
 
     Ok(report)
@@ -760,6 +796,54 @@ mod tests {
         assert_eq!(
             bytes_before, bytes_after,
             "a dry run against an existing db must not change a single byte of it"
+        );
+    }
+
+    /// The contract the writer-task drain in `code_ingest_batch` exists to
+    /// provide, pinned as its own test: a real ingest's RETURN implies the
+    /// database file state is settled. Without the drain, the pool's writer
+    /// task exits asynchronously after the last `WriterTaskHandle` clone
+    /// drops, and its connection's close-time WAL checkpoint moves the file
+    /// bytes after `code_ingest_batch` has already returned — which is the
+    /// race the sibling dry-run byte test used to lose. That test passing
+    /// is a consequence of this contract, not a substitute for it.
+    #[serial]
+    #[tokio::test]
+    async fn code_ingest_return_implies_settled_file_state() {
+        let tmp = tempfile::TempDir::new().expect("temp dir");
+        let findings = write_valid_findings(tmp.path());
+        let db = tmp.path().join("settled.db");
+
+        code_ingest_batch(base_args(findings, db.clone()))
+            .await
+            .expect("real ingest must succeed");
+
+        // Every connection — the pool's synchronous ones and the writer
+        // task's own — must be closed by the time the call returns, so
+        // SQLite's last-close checkpoint has already run and removed the
+        // WAL sidecars.
+        let wal_path = wal_sidecar_path(&db);
+        let shm_path = shm_sidecar_path(&db);
+        assert!(
+            !wal_path.exists(),
+            "ingest return must imply the -wal sidecar was checkpointed and removed"
+        );
+        assert!(
+            !shm_path.exists(),
+            "ingest return must imply the -shm sidecar was removed"
+        );
+
+        let bytes_at_return = std::fs::read(&db).expect("read db at the return boundary");
+
+        // Give any (incorrectly) still-pending async writer a generous
+        // window: if the writer task were still alive past the return
+        // boundary, its close-time checkpoint would move these bytes.
+        tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+
+        let bytes_later = std::fs::read(&db).expect("re-read db after the settle window");
+        assert_eq!(
+            bytes_at_return, bytes_later,
+            "no byte of the database may move after code_ingest_batch has returned"
         );
     }
 

--- a/crates/kkernel/src/code_ingest.rs
+++ b/crates/kkernel/src/code_ingest.rs
@@ -387,10 +387,56 @@ where
     // out (success or error); dropping the runtime here closes the queue.
     // Then await the task's exit with a bounded, loud timeout — on BOTH
     // paths, so an early error return cannot leave the file still moving.
-    let writer_join = runtime.backend().pool().take_writer_task_join();
+    let writer_join = take_writer_task_join_or_warn(runtime.backend().pool());
     drop(runtime);
+
+    settle_writer_drain(ingest_result, writer_join, WRITER_DRAIN_TIMEOUT).await
+}
+
+/// Take the pool's writer-task JoinHandle for the drain, warning loudly when
+/// the pool is file-backed with the write queue resolved ON but no handle is
+/// available at take time.
+///
+/// Absence has two causes: (1) the writer task never spawned during this
+/// ingest — no queue-routed write ever touched the pool (e.g. an all-skipped
+/// re-ingest), or spawn degraded with its own logged warning — in which case
+/// there is nothing to drain; or (2) a double drain: `take_writer_task_join`
+/// is one-shot (pool.rs), so another caller already took ownership of the
+/// task-exit await, and this call's "return implies settled" contract now
+/// rides on THAT drain instead of its own. Either way this call does not
+/// await the task's exit itself — say so loudly rather than silently
+/// skipping the drain.
+fn take_writer_task_join_or_warn(
+    pool: &khive_db::ConnectionPool,
+) -> Option<tokio::task::JoinHandle<()>> {
+    let writer_join = pool.take_writer_task_join();
+    if writer_join.is_none() && pool.write_queue_active() {
+        tracing::warn!(
+            "writer-task JoinHandle absent on a file-backed, write-queue-enabled pool \
+             (already taken by another drain owner, or the task never spawned); \
+             'return implies settled' is not enforced by this call"
+        );
+    }
+    writer_join
+}
+
+/// Await the taken writer-task JoinHandle and reconcile the drain outcome
+/// with the ingest outcome — the "return implies settled" contract's
+/// enforcement point (extracted from `code_ingest_batch_with_runtime_setup`
+/// so each outcome arm is unit-testable with a synthetic handle).
+///
+/// `timeout` bounds the drain wait (production passes [`WRITER_DRAIN_TIMEOUT`]).
+/// Returns the ingest result unchanged on a clean drain, and — when the
+/// ingest itself failed — also unchanged on a drain problem (the ingest error
+/// is primary; a drain problem is logged, never masks it). Bails when the
+/// ingest succeeded but the drain did not settle.
+async fn settle_writer_drain(
+    ingest_result: Result<CodeIngestReport>,
+    writer_join: Option<tokio::task::JoinHandle<()>>,
+    timeout: std::time::Duration,
+) -> Result<CodeIngestReport> {
     if let Some(join) = writer_join {
-        let drained = tokio::time::timeout(WRITER_DRAIN_TIMEOUT, join).await;
+        let drained = tokio::time::timeout(timeout, join).await;
         match (&ingest_result, drained) {
             (_, Ok(Ok(()))) => {}
             // The ingest itself failed: that error is the primary one. A
@@ -401,20 +447,26 @@ where
             }
             (Err(_), Err(_elapsed)) => {
                 tracing::warn!(
-                    timeout = ?WRITER_DRAIN_TIMEOUT,
+                    timeout = ?timeout,
                     "writer task did not drain after failed ingest; database file state may still be unsettled"
                 );
             }
             (Ok(_), Ok(Err(join_err))) => anyhow::bail!(
                 "writer task terminated abnormally after ingest completed: {join_err}"
             ),
+            // Pinned behavior (fail-loud is the deliberate choice): the ingest
+            // reported success, so some or all of its writes may already be in
+            // the file; we bail anyway because "return implies settled" cannot
+            // be proven until the writer task has exited. The JoinHandle is
+            // consumed by `timeout()` above, so the task DETACHES and keeps
+            // running after this bail — its close-time WAL checkpoint may
+            // still move the database bytes after this function returns.
             (Ok(_), Err(_elapsed)) => anyhow::bail!(
-                "writer task did not drain within {WRITER_DRAIN_TIMEOUT:?} after ingest; \
+                "writer task did not drain within {timeout:?} after ingest; \
                  database file state may still be unsettled"
             ),
         }
     }
-
     ingest_result
 }
 
@@ -1177,6 +1229,256 @@ mod tests {
              {:?}",
             report.truncation_by_model
         );
+    }
+
+    /// The drain-finalization matrix, tested through the extracted
+    /// `settle_writer_drain` with synthetic JoinHandles: the real writer
+    /// task never produces a join ERROR (every documented failure mode —
+    /// op panic, commit failure, poisoned connection — is caught inside the
+    /// request wrapper or exits the task normally; see writer_task.rs's
+    /// `run_writer_task`), and a real drain TIMEOUT would need to exceed the
+    /// 30s production bound, so those two success-path arms are not
+    /// constructible end-to-end with standing infra. The arms below pin the
+    /// contract the production drain relies on.
+    fn ok_report() -> CodeIngestReport {
+        CodeIngestReport {
+            dry_run: false,
+            ..CodeIngestReport::default()
+        }
+    }
+
+    /// 3(b): a join ERROR after a successful ingest surfaces as a bail whose
+    /// message names the writer task.
+    #[tokio::test]
+    async fn settle_writer_drain_join_error_after_success_bails_naming_writer_task() {
+        let join = tokio::spawn(async {
+            panic!("synthetic writer task explosion");
+        });
+        let err = settle_writer_drain(
+            Ok(ok_report()),
+            Some(join),
+            std::time::Duration::from_secs(5),
+        )
+        .await
+        .expect_err("a panicked writer task must fail the settled-file contract");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("writer task terminated abnormally after ingest completed"),
+            "the error must name the writer task: {msg}"
+        );
+    }
+
+    /// 3(c): a drain TIMEOUT after a successful ingest bails — pinning the
+    /// current fail-loud behavior (report discarded, JoinHandle consumed by
+    /// `timeout()` so the task detaches; see the bail-site doc comment).
+    #[tokio::test]
+    async fn settle_writer_drain_timeout_after_success_bails() {
+        let join = tokio::spawn(std::future::pending::<()>());
+        let err = settle_writer_drain(
+            Ok(ok_report()),
+            Some(join),
+            std::time::Duration::from_millis(50),
+        )
+        .await
+        .expect_err("an undrained writer task must fail the settled-file contract");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("did not drain within"),
+            "the error must name the drain timeout: {msg}"
+        );
+    }
+
+    /// 3(a) unit half: when the ingest itself failed, the PRIMARY ingest
+    /// error is what surfaces — a join error on the drain is logged, not
+    /// substituted.
+    #[tokio::test]
+    async fn settle_writer_drain_failed_ingest_error_survives_join_error() {
+        let join = tokio::spawn(async {
+            panic!("synthetic writer task explosion");
+        });
+        let primary: Result<CodeIngestReport> = Err(anyhow::anyhow!("primary ingest failure"));
+        let err = settle_writer_drain(primary, Some(join), std::time::Duration::from_secs(5))
+            .await
+            .expect_err("the primary ingest error must surface");
+        assert_eq!(err.to_string(), "primary ingest failure");
+    }
+
+    /// 3(a) unit half: same for a drain timeout on the failure path — the
+    /// ingest error is primary, the timeout is logged only.
+    #[tokio::test]
+    async fn settle_writer_drain_failed_ingest_error_survives_timeout() {
+        let join = tokio::spawn(std::future::pending::<()>());
+        let primary: Result<CodeIngestReport> = Err(anyhow::anyhow!("primary ingest failure"));
+        let err = settle_writer_drain(primary, Some(join), std::time::Duration::from_millis(50))
+            .await
+            .expect_err("the primary ingest error must surface");
+        assert_eq!(err.to_string(), "primary ingest failure");
+    }
+
+    /// Clean-drain passthrough: a settled task returns the report unchanged,
+    /// and a missing handle (queue off / never spawned) is a no-op.
+    #[tokio::test]
+    async fn settle_writer_drain_clean_passes_report_through() {
+        let join = tokio::spawn(async {});
+        let out = settle_writer_drain(
+            Ok(ok_report()),
+            Some(join),
+            std::time::Duration::from_secs(5),
+        )
+        .await
+        .expect("clean drain must pass the report through");
+        assert!(!out.dry_run);
+        let out = settle_writer_drain(Ok(ok_report()), None, std::time::Duration::from_secs(5))
+            .await
+            .expect("no handle means nothing to await");
+        assert!(!out.dry_run);
+    }
+
+    /// 2: the already-taken arm of `take_writer_task_join_or_warn` — a
+    /// file-backed, queue-enabled pool whose JoinHandle was already taken
+    /// must get `None` back AND a loud warning naming the contract gap.
+    #[serial]
+    #[tokio::test]
+    async fn take_writer_task_join_or_warn_already_taken_warns_loudly() {
+        // The helper reads the resolved config only, but the pool's
+        // `PoolConfig::default()` reads KHIVE_WRITE_QUEUE at construction, so
+        // pin the variable unset to get the file-backed queue-ON default.
+        let previous_write_queue = std::env::var_os("KHIVE_WRITE_QUEUE");
+        std::env::remove_var("KHIVE_WRITE_QUEUE");
+
+        let dir = tempfile::TempDir::new().expect("temp dir");
+        let pool = khive_db::ConnectionPool::new(khive_db::PoolConfig {
+            path: Some(dir.path().join("already_taken.db")),
+            ..khive_db::PoolConfig::default()
+        })
+        .expect("file-backed pool should open");
+        assert!(
+            pool.write_queue_active(),
+            "unset preference on a file-backed pool must resolve the queue ON"
+        );
+        pool.writer_task_handle()
+            .expect("runtime is present")
+            .expect("queue-ON file-backed pool must spawn");
+        let taken = pool
+            .take_writer_task_join()
+            .expect("the first take must return the handle");
+
+        // Capture the tracing output of the second (already-taken) attempt.
+        #[derive(Clone, Default)]
+        struct Capture(Arc<std::sync::Mutex<Vec<u8>>>);
+        impl std::io::Write for Capture {
+            fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+                self.0.lock().unwrap().extend_from_slice(buf);
+                Ok(buf.len())
+            }
+            fn flush(&mut self) -> std::io::Result<()> {
+                Ok(())
+            }
+        }
+        struct MakeCapture(Capture);
+        impl<'a> tracing_subscriber::fmt::MakeWriter<'a> for MakeCapture {
+            type Writer = Capture;
+            fn make_writer(&'a self) -> Self::Writer {
+                self.0.clone()
+            }
+        }
+        let capture = Capture::default();
+        let subscriber = tracing_subscriber::fmt()
+            .with_writer(MakeCapture(capture.clone()))
+            .with_ansi(false)
+            .finish();
+        let guard = tracing::subscriber::set_default(subscriber);
+        let second = take_writer_task_join_or_warn(&pool);
+        drop(guard);
+
+        assert!(
+            second.is_none(),
+            "the one-shot take must yield None once the handle is gone"
+        );
+        let log = String::from_utf8_lossy(&capture.0.lock().unwrap()).to_string();
+        assert!(
+            log.contains("JoinHandle absent"),
+            "the already-taken arm must warn loudly about the drain contract gap: {log}"
+        );
+
+        // Clean exit: await the taken handle (drop the pool first so the
+        // writer task's last handle clone goes and the task can exit).
+        drop(pool);
+        tokio::time::timeout(std::time::Duration::from_secs(5), taken)
+            .await
+            .expect("writer task must exit once every handle clone is dropped")
+            .expect("writer task must not panic");
+
+        match previous_write_queue {
+            Some(v) => std::env::set_var("KHIVE_WRITE_QUEUE", v),
+            None => std::env::remove_var("KHIVE_WRITE_QUEUE"),
+        }
+    }
+
+    /// 3(a) end-to-end half: a real ingest that fails mid-write still drains
+    /// the writer task before returning, and the PRIMARY ingest error — not
+    /// any drain outcome — is what surfaces. A `BEFORE INSERT` trigger on
+    /// `notes` is installed in `runtime_setup` so the entity writes land
+    /// (spawning the writer task) and the finding-note upsert then fails.
+    /// (A trigger, not `DROP TABLE`: `notes_for_namespace` re-runs
+    /// `ensure_notes_schema` on every store acquisition, which would silently
+    /// heal a dropped table — see crates/khive-db/src/backend.rs:229-230.)
+    #[serial]
+    #[tokio::test]
+    async fn code_ingest_failed_ingest_still_drains_and_surfaces_primary_error() {
+        let previous_write_queue = std::env::var_os("KHIVE_WRITE_QUEUE");
+        std::env::remove_var("KHIVE_WRITE_QUEUE");
+
+        let tmp = tempfile::TempDir::new().expect("temp dir");
+        let findings = write_valid_findings(tmp.path());
+        let db = tmp.path().join("failed_ingest_drain.db");
+
+        let err =
+            code_ingest_batch_with_runtime_setup(base_args(findings, db.clone()), |runtime| {
+                // Sabotage AFTER migrations but BEFORE any store is acquired:
+                // entity writes succeed through the writer task, then the
+                // finding-note INSERT trips the trigger and fails the ingest.
+                let writer = runtime
+                    .backend()
+                    .pool()
+                    .try_writer()
+                    .map_err(|e| anyhow::anyhow!("{e}"))?;
+                writer
+                    .execute_batch(
+                        "CREATE TRIGGER code_ingest_test_block_notes \
+                     BEFORE INSERT ON notes \
+                     BEGIN SELECT RAISE(ABORT, 'synthetic notes insert failure'); END",
+                    )
+                    .map_err(|e| anyhow::anyhow!("{e}"))?;
+                Ok(())
+            })
+            .await
+            .expect_err("ingest into a trigger-blocked notes table must fail");
+
+        let msg = err.to_string();
+        assert!(
+            msg.contains("synthetic notes insert failure"),
+            "the PRIMARY ingest error (the notes write) must surface, got: {msg}"
+        );
+        assert!(
+            !msg.contains("writer task did not drain")
+                && !msg.contains("writer task terminated abnormally"),
+            "a drain problem must not mask the primary ingest error: {msg}"
+        );
+
+        // Drain proof: every connection — the pool's and the writer task's —
+        // is closed by return time, so SQLite's last-close checkpoint has
+        // removed the WAL sidecar even though the ingest failed mid-batch.
+        assert!(
+            !wal_sidecar_path(&db).exists(),
+            "a failed ingest must still drain the writer task and settle the file"
+        );
+        assert!(!shm_sidecar_path(&db).exists());
+
+        match previous_write_queue {
+            Some(v) => std::env::set_var("KHIVE_WRITE_QUEUE", v),
+            None => std::env::remove_var("KHIVE_WRITE_QUEUE"),
+        }
     }
 
     /// Query the persisted `finding` note count for a scratch db, independent

--- a/crates/kkernel/src/code_ingest.rs
+++ b/crates/kkernel/src/code_ingest.rs
@@ -833,7 +833,10 @@ mod tests {
         // resolves the write queue ON, so this test exercises the writer-task
         // drain rather than silently passing through the queue-off path an
         // ambient KHIVE_WRITE_QUEUE=0 would select. (#[serial] guards the
-        // env mutation.)
+        // env mutation.) Save the prior value so the restore at the end of
+        // the test leaves the process environment exactly as this test
+        // found it.
+        let previous_write_queue = std::env::var_os("KHIVE_WRITE_QUEUE");
         std::env::remove_var("KHIVE_WRITE_QUEUE");
         let tmp = tempfile::TempDir::new().expect("temp dir");
         let findings = write_valid_findings(tmp.path());
@@ -870,6 +873,11 @@ mod tests {
             bytes_at_return, bytes_later,
             "no byte of the database may move after code_ingest_batch has returned"
         );
+
+        match previous_write_queue {
+            Some(v) => std::env::set_var("KHIVE_WRITE_QUEUE", v),
+            None => std::env::remove_var("KHIVE_WRITE_QUEUE"),
+        }
     }
 
     /// The `-shm` sidecar path SQLite uses alongside a WAL-mode database file.

--- a/crates/kkernel/src/code_ingest.rs
+++ b/crates/kkernel/src/code_ingest.rs
@@ -193,210 +193,229 @@ where
     }
 
     let runtime = KhiveRuntime::new(cfg).map_err(|e| anyhow::anyhow!("{e}"))?;
-    runtime_setup(&runtime)?;
-    let resolved_ns = runtime.config().default_namespace.clone();
-    let token = runtime
-        .authorize(resolved_ns)
-        .map_err(|e| anyhow::anyhow!("{e}"))
-        .context("failed to authorize namespace")?;
+    // Every path out of the write section below — success or error — must
+    // still drain the pool's writer task before this function returns, so
+    // the section runs as an inner block and the drain happens once, after
+    // it, on the captured result.
+    let ingest_result: Result<CodeIngestReport> = async {
+        runtime_setup(&runtime)?;
+        let resolved_ns = runtime.config().default_namespace.clone();
+        let token = runtime
+            .authorize(resolved_ns)
+            .map_err(|e| anyhow::anyhow!("{e}"))
+            .context("failed to authorize namespace")?;
 
-    // One immutable model-name snapshot governs this ingest pass. Each report
-    // below is still derived from the corresponding completed embed call, so a
-    // provider cannot appear in execution without also appearing in reporting.
-    let embedding_model_names = runtime.registered_embedding_model_names();
+        // One immutable model-name snapshot governs this ingest pass. Each report
+        // below is still derived from the corresponding completed embed call, so a
+        // provider cannot appear in execution without also appearing in reporting.
+        let embedding_model_names = runtime.registered_embedding_model_names();
 
-    let mut report = CodeIngestReport {
-        dry_run: false,
-        ..CodeIngestReport::default()
-    };
+        let mut report = CodeIngestReport {
+            dry_run: false,
+            ..CodeIngestReport::default()
+        };
 
-    let entities = runtime
-        .entities(&token)
-        .map_err(|e| anyhow::anyhow!("{e}"))?;
-    for entity in &batch.entities {
-        let existing = entities
-            .get_entity(entity.id)
-            .await
+        let entities = runtime
+            .entities(&token)
             .map_err(|e| anyhow::anyhow!("{e}"))?;
-        if existing.is_some() {
-            report.entities_skipped_existing += 1;
-            continue;
-        }
-        report.entities_created += 1;
-        entities
-            .upsert_entity(entity.clone())
-            .await
-            .map_err(|e| anyhow::anyhow!("{e}"))?;
-
-        let doc = entity_fts_document(entity);
-        let embed_body = doc.body.clone();
-        if let Ok(fts) = runtime.text(&token) {
-            if let Err(e) = fts.upsert_document(doc).await {
-                tracing::warn!(
-                    entity_id = %entity.id,
-                    error = %e,
-                    "code-ingest: entity FTS indexing failed (non-fatal)"
-                );
-            }
-        }
-        for model_name in &embedding_model_names {
-            match runtime
-                .embed_document_with_model_outcome(model_name, &embed_body)
+        for entity in &batch.entities {
+            let existing = entities
+                .get_entity(entity.id)
                 .await
-            {
-                Ok(outcome) => {
-                    report
-                        .truncation_by_model
-                        .entry(model_name.clone())
-                        .or_default()
-                        .observe(&outcome);
-                    if let Ok(vs) = runtime.vectors_for_model(&token, model_name) {
-                        if let Err(e) = vs
-                            .insert(
-                                entity.id,
-                                SubstrateKind::Entity,
-                                token.namespace().as_str(),
-                                // Canonical field label for the entity body
-                                // vector (khive-runtime/src/operations.rs,
-                                // curation.rs) — must match so vector
-                                // provenance metadata agrees with every
-                                // other write path.
-                                "entity.body",
-                                vec![outcome.vector],
-                            )
-                            .await
-                        {
-                            tracing::warn!(
-                                entity_id = %entity.id,
-                                model = %model_name,
-                                error = %e,
-                                "code-ingest: entity vector insert failed (non-fatal)"
-                            );
+                .map_err(|e| anyhow::anyhow!("{e}"))?;
+            if existing.is_some() {
+                report.entities_skipped_existing += 1;
+                continue;
+            }
+            report.entities_created += 1;
+            entities
+                .upsert_entity(entity.clone())
+                .await
+                .map_err(|e| anyhow::anyhow!("{e}"))?;
+
+            let doc = entity_fts_document(entity);
+            let embed_body = doc.body.clone();
+            if let Ok(fts) = runtime.text(&token) {
+                if let Err(e) = fts.upsert_document(doc).await {
+                    tracing::warn!(
+                        entity_id = %entity.id,
+                        error = %e,
+                        "code-ingest: entity FTS indexing failed (non-fatal)"
+                    );
+                }
+            }
+            for model_name in &embedding_model_names {
+                match runtime
+                    .embed_document_with_model_outcome(model_name, &embed_body)
+                    .await
+                {
+                    Ok(outcome) => {
+                        report
+                            .truncation_by_model
+                            .entry(model_name.clone())
+                            .or_default()
+                            .observe(&outcome);
+                        if let Ok(vs) = runtime.vectors_for_model(&token, model_name) {
+                            if let Err(e) = vs
+                                .insert(
+                                    entity.id,
+                                    SubstrateKind::Entity,
+                                    token.namespace().as_str(),
+                                    // Canonical field label for the entity body
+                                    // vector (khive-runtime/src/operations.rs,
+                                    // curation.rs) — must match so vector
+                                    // provenance metadata agrees with every
+                                    // other write path.
+                                    "entity.body",
+                                    vec![outcome.vector],
+                                )
+                                .await
+                            {
+                                tracing::warn!(
+                                    entity_id = %entity.id,
+                                    model = %model_name,
+                                    error = %e,
+                                    "code-ingest: entity vector insert failed (non-fatal)"
+                                );
+                            }
                         }
                     }
+                    Err(e) => tracing::warn!(
+                        entity_id = %entity.id,
+                        model = %model_name,
+                        error = %e,
+                        "code-ingest: entity embedding failed (non-fatal)"
+                    ),
                 }
-                Err(e) => tracing::warn!(
-                    entity_id = %entity.id,
-                    model = %model_name,
-                    error = %e,
-                    "code-ingest: entity embedding failed (non-fatal)"
-                ),
             }
         }
-    }
 
-    let notes = runtime.notes(&token).map_err(|e| anyhow::anyhow!("{e}"))?;
-    for note in &batch.notes {
-        let existing = notes
-            .get_note(note.id)
-            .await
-            .map_err(|e| anyhow::anyhow!("{e}"))?;
-        if existing.is_some() {
-            report.notes_skipped_existing += 1;
-            continue;
-        }
-        report.notes_created += 1;
-        notes
-            .upsert_note(note.clone())
-            .await
-            .map_err(|e| anyhow::anyhow!("{e}"))?;
-
-        if let Ok(fts) = runtime.text_for_notes(&token) {
-            if let Err(e) = fts.upsert_document(note_fts_document(note)).await {
-                tracing::warn!(
-                    note_id = %note.id,
-                    error = %e,
-                    "code-ingest: note FTS indexing failed (non-fatal)"
-                );
-            }
-        }
-        for model_name in &embedding_model_names {
-            match runtime
-                .embed_document_with_model_outcome(model_name, &note.content)
+        let notes = runtime.notes(&token).map_err(|e| anyhow::anyhow!("{e}"))?;
+        for note in &batch.notes {
+            let existing = notes
+                .get_note(note.id)
                 .await
-            {
-                Ok(outcome) => {
-                    report
-                        .truncation_by_model
-                        .entry(model_name.clone())
-                        .or_default()
-                        .observe(&outcome);
-                    if let Ok(vs) = runtime.vectors_for_model(&token, model_name) {
-                        if let Err(e) = vs
-                            .insert(
-                                note.id,
-                                SubstrateKind::Note,
-                                token.namespace().as_str(),
-                                "note.content",
-                                vec![outcome.vector],
-                            )
-                            .await
-                        {
-                            tracing::warn!(
-                                note_id = %note.id,
-                                model = %model_name,
-                                error = %e,
-                                "code-ingest: note vector insert failed (non-fatal)"
-                            );
+                .map_err(|e| anyhow::anyhow!("{e}"))?;
+            if existing.is_some() {
+                report.notes_skipped_existing += 1;
+                continue;
+            }
+            report.notes_created += 1;
+            notes
+                .upsert_note(note.clone())
+                .await
+                .map_err(|e| anyhow::anyhow!("{e}"))?;
+
+            if let Ok(fts) = runtime.text_for_notes(&token) {
+                if let Err(e) = fts.upsert_document(note_fts_document(note)).await {
+                    tracing::warn!(
+                        note_id = %note.id,
+                        error = %e,
+                        "code-ingest: note FTS indexing failed (non-fatal)"
+                    );
+                }
+            }
+            for model_name in &embedding_model_names {
+                match runtime
+                    .embed_document_with_model_outcome(model_name, &note.content)
+                    .await
+                {
+                    Ok(outcome) => {
+                        report
+                            .truncation_by_model
+                            .entry(model_name.clone())
+                            .or_default()
+                            .observe(&outcome);
+                        if let Ok(vs) = runtime.vectors_for_model(&token, model_name) {
+                            if let Err(e) = vs
+                                .insert(
+                                    note.id,
+                                    SubstrateKind::Note,
+                                    token.namespace().as_str(),
+                                    "note.content",
+                                    vec![outcome.vector],
+                                )
+                                .await
+                            {
+                                tracing::warn!(
+                                    note_id = %note.id,
+                                    model = %model_name,
+                                    error = %e,
+                                    "code-ingest: note vector insert failed (non-fatal)"
+                                );
+                            }
                         }
                     }
+                    Err(e) => tracing::warn!(
+                        note_id = %note.id,
+                        model = %model_name,
+                        error = %e,
+                        "code-ingest: note embedding failed (non-fatal)"
+                    ),
                 }
-                Err(e) => tracing::warn!(
-                    note_id = %note.id,
-                    model = %model_name,
-                    error = %e,
-                    "code-ingest: note embedding failed (non-fatal)"
-                ),
             }
         }
-    }
 
-    let graph = runtime.graph(&token).map_err(|e| anyhow::anyhow!("{e}"))?;
-    for edge in &batch.edges {
-        let existing = graph
-            .get_edge(edge.id)
-            .await
-            .map_err(|e| anyhow::anyhow!("{e}"))?;
-        if existing.is_some() {
-            report.edges_skipped_existing += 1;
-            continue;
+        let graph = runtime.graph(&token).map_err(|e| anyhow::anyhow!("{e}"))?;
+        for edge in &batch.edges {
+            let existing = graph
+                .get_edge(edge.id)
+                .await
+                .map_err(|e| anyhow::anyhow!("{e}"))?;
+            if existing.is_some() {
+                report.edges_skipped_existing += 1;
+                continue;
+            }
+            report.edges_created += 1;
+            graph
+                .upsert_edge(edge.clone())
+                .await
+                .map_err(|e| anyhow::anyhow!("{e}"))?;
         }
-        report.edges_created += 1;
-        graph
-            .upsert_edge(edge.clone())
-            .await
-            .map_err(|e| anyhow::anyhow!("{e}"))?;
+
+        Ok(report)
     }
+    .await;
 
     // The migrated stores above route writes through the pool's shared
     // writer task (ADR-067 Component A), which owns its own SQLite
     // connection and exits only after every WriterTaskHandle clone has
     // dropped and the queue has drained. That connection's close fires
     // SQLite's close-time WAL checkpoint, so until the task exits the
-    // database file bytes can still move after this function returns. Drop
-    // every handle owner (the stores, then the runtime and its pool — which
-    // closes the queue), then await the task's exit with a bounded, loud
-    // timeout: a returned `Ok(report)` implies settled file state.
+    // database file bytes can still move after this function returns. The
+    // inner block above dropped every store handle and the token on its way
+    // out (success or error); dropping the runtime here closes the queue.
+    // Then await the task's exit with a bounded, loud timeout — on BOTH
+    // paths, so an early error return cannot leave the file still moving.
     let writer_join = runtime.backend().pool().take_writer_task_join();
-    drop(graph);
-    drop(notes);
-    drop(entities);
-    drop(token);
     drop(runtime);
     if let Some(join) = writer_join {
-        match tokio::time::timeout(WRITER_DRAIN_TIMEOUT, join).await {
-            Ok(Ok(())) => {}
-            Ok(Err(join_err)) => anyhow::bail!(
+        let drained = tokio::time::timeout(WRITER_DRAIN_TIMEOUT, join).await;
+        match (&ingest_result, drained) {
+            (_, Ok(Ok(()))) => {}
+            // The ingest itself failed: that error is the primary one. A
+            // drain problem on this path is logged, not returned, so it
+            // cannot mask the actual failure.
+            (Err(_), Ok(Err(join_err))) => {
+                tracing::warn!(error = %join_err, "writer task terminated abnormally after failed ingest");
+            }
+            (Err(_), Err(_elapsed)) => {
+                tracing::warn!(
+                    timeout = ?WRITER_DRAIN_TIMEOUT,
+                    "writer task did not drain after failed ingest; database file state may still be unsettled"
+                );
+            }
+            (Ok(_), Ok(Err(join_err))) => anyhow::bail!(
                 "writer task terminated abnormally after ingest completed: {join_err}"
             ),
-            Err(_elapsed) => anyhow::bail!(
+            (Ok(_), Err(_elapsed)) => anyhow::bail!(
                 "writer task did not drain within {WRITER_DRAIN_TIMEOUT:?} after ingest; \
                  database file state may still be unsettled"
             ),
         }
     }
 
-    Ok(report)
+    ingest_result
 }
 
 /// Scan every entity/note content field and nested property value in `batch`
@@ -810,6 +829,12 @@ mod tests {
     #[serial]
     #[tokio::test]
     async fn code_ingest_return_implies_settled_file_state() {
+        // Pin the queue default: with the variable unset, a file-backed pool
+        // resolves the write queue ON, so this test exercises the writer-task
+        // drain rather than silently passing through the queue-off path an
+        // ambient KHIVE_WRITE_QUEUE=0 would select. (#[serial] guards the
+        // env mutation.)
+        std::env::remove_var("KHIVE_WRITE_QUEUE");
         let tmp = tempfile::TempDir::new().expect("temp dir");
         let findings = write_valid_findings(tmp.path());
         let db = tmp.path().join("settled.db");

--- a/crates/kkernel/src/code_ingest.rs
+++ b/crates/kkernel/src/code_ingest.rs
@@ -394,26 +394,20 @@ where
 }
 
 /// Take the pool's writer-task JoinHandle for the drain, warning loudly when
-/// the pool is file-backed with the write queue resolved ON but no handle is
-/// available at take time.
+/// a previously stored handle is unavailable at take time.
 ///
-/// Absence has two causes: (1) the writer task never spawned during this
-/// ingest — no queue-routed write ever touched the pool (e.g. an all-skipped
-/// re-ingest), or spawn degraded with its own logged warning — in which case
-/// there is nothing to drain; or (2) a double drain: `take_writer_task_join`
-/// is one-shot (pool.rs), so another caller already took ownership of the
-/// task-exit await, and this call's "return implies settled" contract now
-/// rides on THAT drain instead of its own. Either way this call does not
-/// await the task's exit itself — say so loudly rather than silently
-/// skipping the drain.
+/// A missing handle is benign when no writer-task handle was ever stored: no
+/// queue-routed write occurred, or writer-task setup degraded before a handle
+/// could be stored. It is a drain-ownership problem only when a handle was
+/// stored and another caller already consumed the one-shot slot.
 fn take_writer_task_join_or_warn(
     pool: &khive_db::ConnectionPool,
 ) -> Option<tokio::task::JoinHandle<()>> {
     let writer_join = pool.take_writer_task_join();
-    if writer_join.is_none() && pool.write_queue_active() {
+    if writer_join.is_none() && pool.write_queue_active() && pool.writer_task_join_was_stored() {
         tracing::warn!(
-            "writer-task JoinHandle absent on a file-backed, write-queue-enabled pool \
-             (already taken by another drain owner, or the task never spawned); \
+            "writer-task JoinHandle was stored but is absent at drain time; \
+             another caller may have taken the one-shot drain handle, so \
              'return implies settled' is not enforced by this call"
         );
     }
@@ -635,6 +629,51 @@ mod tests {
 
     use super::*;
 
+    struct WriteQueueEnvGuard {
+        previous: Option<std::ffi::OsString>,
+    }
+
+    impl WriteQueueEnvGuard {
+        fn unset() -> Self {
+            let previous = std::env::var_os("KHIVE_WRITE_QUEUE");
+            std::env::remove_var("KHIVE_WRITE_QUEUE");
+            Self { previous }
+        }
+    }
+
+    impl Drop for WriteQueueEnvGuard {
+        fn drop(&mut self) {
+            match &self.previous {
+                Some(value) => std::env::set_var("KHIVE_WRITE_QUEUE", value),
+                None => std::env::remove_var("KHIVE_WRITE_QUEUE"),
+            }
+        }
+    }
+
+    #[derive(Clone, Default)]
+    struct Capture(Arc<std::sync::Mutex<Vec<u8>>>);
+
+    impl std::io::Write for Capture {
+        fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+            self.0.lock().unwrap().extend_from_slice(buf);
+            Ok(buf.len())
+        }
+
+        fn flush(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
+    }
+
+    struct MakeCapture(Capture);
+
+    impl<'a> tracing_subscriber::fmt::MakeWriter<'a> for MakeCapture {
+        type Writer = Capture;
+
+        fn make_writer(&'a self) -> Self::Writer {
+            self.0.clone()
+        }
+    }
+
     struct FixedEmbeddingService {
         dimensions: usize,
     }
@@ -751,6 +790,39 @@ mod tests {
         assert_eq!(second.notes_skipped_existing, 1);
         assert_eq!(second.entities_skipped_existing, 1);
         assert_eq!(second.edges_skipped_existing, 1);
+    }
+
+    #[serial]
+    #[tokio::test]
+    async fn code_ingest_with_no_queue_writes_does_not_warn_on_drain() {
+        let _write_queue_env = WriteQueueEnvGuard::unset();
+        let tmp = tempfile::TempDir::new().expect("temp dir");
+        let findings = write_valid_findings(tmp.path());
+        let db = tmp.path().join("no_queue_writes.db");
+
+        code_ingest_batch(base_args(findings.clone(), db.clone()))
+            .await
+            .expect("initial ingest must succeed");
+
+        let capture = Capture::default();
+        let subscriber = tracing_subscriber::fmt()
+            .with_writer(MakeCapture(capture.clone()))
+            .with_ansi(false)
+            .finish();
+        let guard = tracing::subscriber::set_default(subscriber);
+        let report = code_ingest_batch(base_args(findings, db))
+            .await
+            .expect("all-skipped ingest must succeed");
+        drop(guard);
+
+        assert_eq!(report.entities_created, 0);
+        assert_eq!(report.notes_created, 0);
+        assert_eq!(report.edges_created, 0);
+        let log = String::from_utf8_lossy(&capture.0.lock().unwrap()).to_string();
+        assert!(
+            !log.contains("writer-task JoinHandle"),
+            "an ingest with no queue-routed writes must not warn at drain time: {log}"
+        );
     }
 
     #[serial]
@@ -885,11 +957,8 @@ mod tests {
         // resolves the write queue ON, so this test exercises the writer-task
         // drain rather than silently passing through the queue-off path an
         // ambient KHIVE_WRITE_QUEUE=0 would select. (#[serial] guards the
-        // env mutation.) Save the prior value so the restore at the end of
-        // the test leaves the process environment exactly as this test
-        // found it.
-        let previous_write_queue = std::env::var_os("KHIVE_WRITE_QUEUE");
-        std::env::remove_var("KHIVE_WRITE_QUEUE");
+        // env mutation.)
+        let _write_queue_env = WriteQueueEnvGuard::unset();
         let tmp = tempfile::TempDir::new().expect("temp dir");
         let findings = write_valid_findings(tmp.path());
         let db = tmp.path().join("settled.db");
@@ -925,11 +994,6 @@ mod tests {
             bytes_at_return, bytes_later,
             "no byte of the database may move after code_ingest_batch has returned"
         );
-
-        match previous_write_queue {
-            Some(v) => std::env::set_var("KHIVE_WRITE_QUEUE", v),
-            None => std::env::remove_var("KHIVE_WRITE_QUEUE"),
-        }
     }
 
     /// The `-shm` sidecar path SQLite uses alongside a WAL-mode database file.
@@ -1343,8 +1407,7 @@ mod tests {
         // The helper reads the resolved config only, but the pool's
         // `PoolConfig::default()` reads KHIVE_WRITE_QUEUE at construction, so
         // pin the variable unset to get the file-backed queue-ON default.
-        let previous_write_queue = std::env::var_os("KHIVE_WRITE_QUEUE");
-        std::env::remove_var("KHIVE_WRITE_QUEUE");
+        let _write_queue_env = WriteQueueEnvGuard::unset();
 
         let dir = tempfile::TempDir::new().expect("temp dir");
         let pool = khive_db::ConnectionPool::new(khive_db::PoolConfig {
@@ -1364,24 +1427,6 @@ mod tests {
             .expect("the first take must return the handle");
 
         // Capture the tracing output of the second (already-taken) attempt.
-        #[derive(Clone, Default)]
-        struct Capture(Arc<std::sync::Mutex<Vec<u8>>>);
-        impl std::io::Write for Capture {
-            fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
-                self.0.lock().unwrap().extend_from_slice(buf);
-                Ok(buf.len())
-            }
-            fn flush(&mut self) -> std::io::Result<()> {
-                Ok(())
-            }
-        }
-        struct MakeCapture(Capture);
-        impl<'a> tracing_subscriber::fmt::MakeWriter<'a> for MakeCapture {
-            type Writer = Capture;
-            fn make_writer(&'a self) -> Self::Writer {
-                self.0.clone()
-            }
-        }
         let capture = Capture::default();
         let subscriber = tracing_subscriber::fmt()
             .with_writer(MakeCapture(capture.clone()))
@@ -1397,7 +1442,7 @@ mod tests {
         );
         let log = String::from_utf8_lossy(&capture.0.lock().unwrap()).to_string();
         assert!(
-            log.contains("JoinHandle absent"),
+            log.contains("JoinHandle was stored but is absent"),
             "the already-taken arm must warn loudly about the drain contract gap: {log}"
         );
 
@@ -1408,11 +1453,6 @@ mod tests {
             .await
             .expect("writer task must exit once every handle clone is dropped")
             .expect("writer task must not panic");
-
-        match previous_write_queue {
-            Some(v) => std::env::set_var("KHIVE_WRITE_QUEUE", v),
-            None => std::env::remove_var("KHIVE_WRITE_QUEUE"),
-        }
     }
 
     /// 3(a) end-to-end half: a real ingest that fails mid-write still drains
@@ -1426,8 +1466,7 @@ mod tests {
     #[serial]
     #[tokio::test]
     async fn code_ingest_failed_ingest_still_drains_and_surfaces_primary_error() {
-        let previous_write_queue = std::env::var_os("KHIVE_WRITE_QUEUE");
-        std::env::remove_var("KHIVE_WRITE_QUEUE");
+        let _write_queue_env = WriteQueueEnvGuard::unset();
 
         let tmp = tempfile::TempDir::new().expect("temp dir");
         let findings = write_valid_findings(tmp.path());
@@ -1474,11 +1513,6 @@ mod tests {
             "a failed ingest must still drain the writer task and settle the file"
         );
         assert!(!shm_sidecar_path(&db).exists());
-
-        match previous_write_queue {
-            Some(v) => std::env::set_var("KHIVE_WRITE_QUEUE", v),
-            None => std::env::remove_var("KHIVE_WRITE_QUEUE"),
-        }
     }
 
     /// Query the persisted `finding` note count for a scratch db, independent


### PR DESCRIPTION
## What

`PoolConfig::write_queue_enabled` changes from `bool` to `Option<bool>`, and the
default is resolved at pool construction instead of once per process.

## Why

The flag was resolved in `PoolConfig::default()` from `KHIVE_WRITE_QUEUE`, falling back
to `false`. At that point `path` is `None`, so whether the pool will be file-backed is
not knowable at the site that decides the default.

A `bool` also cannot represent "the caller expressed no preference". Without that state,
a default that depends on the backing store would have to guess what an explicit `false`
means, and silently promoting the sites that pass `false` deliberately would be a
behaviour change against stated intent.

## How

`None` means unset. `ConnectionPool::new` resolves it from `config.path`, which the
constructor already inspects to choose between a database-backed and an in-memory
transaction origin, so no new predicate is introduced. An explicit `Some` is left
untouched and wins in both directions.

`KHIVE_WRITE_QUEUE` keeps its meaning when set, including `KHIVE_WRITE_QUEUE=0`, which
now yields `Some(false)`.

`write_routing_strict` is unchanged. It gates a hard refusal and is a separate flag.

## Tests

Four cases, each separable by test rather than by argument:

| config | backing store | result |
| --- | --- | --- |
| unset | file-backed | on |
| unset | in-memory | off |
| explicit `false` | file-backed | off |
| explicit `true` | in-memory | on |

The last two are what prove an explicit preference wins in both directions; a fixture
exercising only the unset cases would pass while that guarantee was absent.

The resolution logic was deleted to confirm the intended arms redden and no others, with
the expected set written down before the run: the two unset arms failed and the two
explicit arms stayed green, since resolution never touches an already-`Some` value. The
logic was then restored and verified byte-identical before the gates were re-run.

## Scope

Remaining struct-literal changes are mechanical `Some(..)` wrapping with no change of
intent, across `khive-db`, `khive-runtime`, `khive-vcs`, `khive-pack-brain`,
`khive-pack-memory` and `khive-pack-session`.

`cargo test -p khive-db`: 631 passed, 0 failed. `cargo clippy --all-targets -D warnings`
clean on every crate touched. `cargo check --workspace --all-targets` clean, since the
field crosses crate boundaries.
