### PR TITLE
docs(adr): record that the release gate described in ADR-066 is not in force

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,9 +4,10 @@ name: Release
 # tag push does NOT publish: an old `v*` tag checks out an older release.yml whose
 # SemVer gate predates #216, so tag-triggered publishing is an ungated path. Making
 # main-dispatch the sole publisher means "the workflow that publishes" always equals
-# "the gate-carrying workflow on main". The `publish` environment's ref allowlist is
-# restricted to `main` (scripts/apply-autonomous-merge.sh), so even if an old tag's
-# old workflow runs, its publish job cannot deploy.
+# "the gate-carrying workflow on main". A ref allowlist on the `publish` environment
+# was intended as a second barrier here, but no deployment-branch policy is currently
+# configured on it, so the sole-trigger property above is what actually restricts this
+# workflow today.
 #
 # Builds Rust binaries per-platform, publishes each khive-kernel-{platform}
 # npm subpackage, then publishes the umbrella khive package.
@@ -189,13 +190,16 @@ jobs:
     needs: [build-platform, semver-gate]
     runs-on: ubuntu-latest
     # ADR-066 release gate: in the autonomous-merge model the human approval
-    # moves from per-PR to per-release. This job publishes to npm; the
-    # 'publish' environment carries a required reviewer (Ocean), so even an
-    # automated or accidental tag pauses here until a human authorizes the
-    # deployment. The environment is created by scripts/apply-autonomous-merge.sh
-    # (STEP=release-gate). Until that runs, the gate is dormant (the environment
-    # auto-creates unprotected on first use) — apply the release gate before
-    # flipping the ruleset to zero approvals.
+    # moves from per-PR to per-release. This job publishes to npm through the
+    # 'publish' environment, which is intended to carry a required reviewer so
+    # that a person authorizes each deployment.
+    #
+    # That protection is NOT currently configured. The environment auto-created
+    # unprotected on first use and has no protection rules and no
+    # deployment-branch policy, so this job does not pause for anyone today.
+    # Verify before relying on it:
+    #   gh api repos/<owner>/<repo>/environments/publish \
+    #     --jq '{protection_rules, deployment_branch_policy}'
     environment: publish
 
     steps:

--- a/docs/adr/ADR-066-autonomous-merge-pipeline.md
+++ b/docs/adr/ADR-066-autonomous-merge-pipeline.md
@@ -143,6 +143,24 @@ The gate-defining path routing in section 3 documents this risk and the structur
 
 Merging to `main` is not a release. Publishing is a separate step, gated on human approval.
 
+> **Implementation status (2026-08-04): this gate is not in force.** The `publish` environment
+> exists but carries no protection rules and no deployment-branch policy. Read it with
+> `gh api repos/<owner>/<repo>/environments/publish --jq '{protection_rules, deployment_branch_policy}'`;
+> it returns an empty rule list and a null policy. The environment auto-created unprotected on
+> first use, and step 2 of the activation order below, which adds the required reviewer and
+> validates that the gate fires, was never completed.
+>
+> Everything in this section describing a required reviewer, a pinned deployment-branch policy,
+> or a human approving each deployment describes the intended design, not the current state.
+> The same applies to the backstop claim later in this section and to the publishing bullet
+> under Consequences.
+>
+> What is actually true today: `release.yml` triggers only on `workflow_dispatch`, so there is
+> no tag-push publish path, and the reachable exposure is that an actor with write access can
+> publish from any ref without a second person approving. Whether to activate the gate or to
+> amend this record to match how releases are actually run is an open decision; this note states
+> the measured state and does not settle it.
+
 `release.yml` triggers only on `workflow_dispatch` (the `v*` tag-push trigger was removed in
 #222). It builds platform binaries and publishes the npm packages; the crates.io library publish is the separate
 `scripts/publish.sh` (`make publish`) path. The npm publish job (`publish-all`) runs in a GitHub
@@ -226,8 +244,9 @@ These properties are enforced at all times and are never relaxed:
   change after a dependent change has landed can break the build. The dependency chain is
   foundation to platform to features. Post-merge monitoring and fast revert discipline are the
   operational backstops.
-- Publishing stays human-gated. The npm release is held by the `publish` environment's required
-  reviewer (section 3); the crates.io library publish is a maintainer-run `make publish` with no
+- Publishing is intended to stay human-gated, held by the `publish` environment's required
+  reviewer (section 3). That protection is not currently configured; see the implementation-status
+  note in section 3. the crates.io library publish is a maintainer-run `make publish` with no
   autonomous CI path. A published version cannot be unpublished after the registry retains it.
 
 ## Activation order


### PR DESCRIPTION
## What

ADR-066 section 3 describes a human approval gate on publishing. The gate is not
configured. This change records that, and corrects the workflow comments that describe
the same control.

## Measured state

```
gh api repos/<owner>/<repo>/environments/publish \
  --jq '{protection_rules, deployment_branch_policy}'
{"deployment_branch_policy":null,"protection_rules":[]}
```

The empty rule list is an absence rather than a permissions redaction: the same token
and the same call shape return a populated `protection_rules` and a real
`deployment_branch_policy` for this repository's `github-pages` environment.

The environment auto-created unprotected on first use, which the workflow comment
itself predicted. The activation step that adds the required reviewer and validates
that the gate fires was never completed.

## Why this is a correctness change and not a wording change

The record asserts the control in several places: as a required reviewer on the
environment, as a deployment-branch policy pinned to `main`, as the universal backstop
for every publish path, and as a consequence of the autonomous-merge model. A reader
implementing or auditing against it would conclude that no release reaches the registry
without a second person. None of that is in force.

## Scope of the exposure

`release.yml` triggers only on `workflow_dispatch`. The whole `on:` block was read, not
a fragment. There is no tag-push publish path, so the "an old tag's old workflow runs"
premise in the header comment is not currently reachable.

What is reachable: an actor with write access can publish to npm from any ref with no
second person approving, against a record stating that a human holds every release.

## The open decision

This change does not settle it. Two options, both viable:

1. **Activate the gate.** Add the required reviewer to the `publish` environment and
   pin its deployment-branch policy to `main`, matching what the record already says.
   The record then becomes true with no further edits, and publishing gains a second
   pair of eyes at the cost of a wait on every release.

2. **Amend the record.** If releases are deliberately run without a second approver,
   the honest fix is to remove the human-gate claims from ADR-066 rather than to
   configure a gate nobody wants. Section 3 would then describe the trigger restriction
   as the actual control.

This PR stops the record asserting a control that is not there. It does not choose
between them.
