### PR TITLE
feat(runtime): agent process runtime — persistent records, lifecycle, and verb pack

### DIFF
--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -2025,6 +2025,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "khive-pack-agent"
+version = "0.7.0"
+dependencies = [
+ "async-trait",
+ "chrono",
+ "khive-pack-kg",
+ "khive-runtime",
+ "khive-storage",
+ "khive-types",
+ "serde_json",
+ "tokio",
+ "uuid",
+]
+
+[[package]]
 name = "khive-pack-blob"
 version = "0.7.0"
 dependencies = [

--- a/crates/Cargo.toml
+++ b/crates/Cargo.toml
@@ -29,6 +29,7 @@ members = [
     "khive-pack-code",
     "khive-pack-blob",
     "khive-pack-template",
+    "khive-pack-agent",
     "khive-pack-knowledge",
     "khive-pack-session",
     "khive-pack-git",

--- a/crates/khive-db/sql/017-agents-ddl.sql
+++ b/crates/khive-db/sql/017-agents-ddl.sql
@@ -1,0 +1,84 @@
+-- V17: durable agent-process table (ADR-142 §1 "Process model").
+--
+-- One row per runtime-owned agent-process record. This table is the sole
+-- durable source of truth for agent lifecycle state; it is distinct from
+-- the session pack's checkpoint/transcript storage, which this table only
+-- references by id (`checkpoint_session_id`).
+--
+-- Column choices:
+--   * `agent_id` is the primary key: an opaque, immutable handle assigned at
+--     spawn (ADR-142 §1 "Actor provenance"), never reused.
+--   * `state`/`terminal_reason` are TEXT with CHECK constraints against the
+--     closed enums in the shared contract (`AgentState`/`TerminalReason`) so
+--     an invalid value fails at the storage boundary, not just in Rust.
+--     `terminal_reason` is required exactly when `state = 'terminal'` and
+--     forbidden otherwise, matching "exactly one `terminal_reason` once it
+--     reaches `terminal`" (ADR-142 §1).
+--   * `owner_visible_namespaces` is a JSON array of strings (TEXT, validated
+--     with `json_valid`), not a child table. The field is an immutable
+--     snapshot written once at spawn and always read back whole with the
+--     rest of the record (ADR-142 §1 "Actor provenance") — there is no
+--     query path that filters agents by individual namespace membership, so
+--     a normalized child table would add a join with no read benefit. This
+--     matches the existing convention for whole-record JSON blobs elsewhere
+--     in this schema (e.g. `entities.properties`, `notes.properties`).
+--   * `spawned_at`/`state_changed_at` are INTEGER microseconds since the
+--     Unix epoch, matching every other timestamp column in this schema
+--     (e.g. `events.created_at`).
+--   * `checkpoint_cursor` is INTEGER (nullable): "the position of the last
+--     message captured in that checkpoint" (ADR-142 §1) — an ordinal, not a
+--     timestamp.
+--
+-- Constraint choices — the two properties this migration exists to hold:
+--
+--   1. At most one non-terminal record per (provider, provider_session_id).
+--      Enforced with a partial UNIQUE index scoped to non-terminal states
+--      and a non-null `provider_session_id`. SQLite's single-writer
+--      serialization (every write on this store runs through the pool's
+--      one writer connection/task) means the store-level
+--      check-then-insert in `agents.rs` never races against a concurrent
+--      writer, but the index is kept anyway as a schema-level backstop: it
+--      is the thing that actually makes a violation impossible even if a
+--      future write path bypasses the store's own pre-check, and it costs
+--      nothing at this table's write volume.
+--   2. Idempotency replay is keyed on the pair (owner_actor,
+--      idempotency_key), never the key alone. Enforced with a UNIQUE index
+--      on that pair (scoped to non-null `idempotency_key`), which is also
+--      the exact index `find_by_idempotency` needs for its lookup.
+
+CREATE TABLE IF NOT EXISTS agents (
+    agent_id                  TEXT PRIMARY KEY,
+    state                     TEXT NOT NULL
+        CHECK (state IN ('spawned', 'running', 'suspended', 'terminal')),
+    terminal_reason           TEXT
+        CHECK (terminal_reason IS NULL OR terminal_reason IN
+            ('completed', 'failed', 'killed', 'abandoned', 'host_restart')),
+    provider                  TEXT NOT NULL,
+    provider_session_id       TEXT,
+    checkpoint_session_id     TEXT,
+    checkpoint_cursor         INTEGER,
+    owner_actor               TEXT NOT NULL,
+    owner_peer_class          TEXT NOT NULL,
+    owner_write_namespace     TEXT NOT NULL,
+    owner_visible_namespaces  TEXT NOT NULL
+        CHECK (json_valid(owner_visible_namespaces)),
+    spawn_fingerprint         TEXT NOT NULL,
+    spawned_at                INTEGER NOT NULL,
+    state_changed_at          INTEGER NOT NULL,
+    idempotency_key           TEXT,
+    CHECK (
+        (state = 'terminal' AND terminal_reason IS NOT NULL)
+        OR (state != 'terminal' AND terminal_reason IS NULL)
+    )
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_agents_live_provider_session
+    ON agents(provider, provider_session_id)
+    WHERE state != 'terminal' AND provider_session_id IS NOT NULL;
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_agents_idempotency_pair
+    ON agents(owner_actor, idempotency_key)
+    WHERE idempotency_key IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS idx_agents_state
+    ON agents(state);

--- a/crates/khive-db/src/backend.rs
+++ b/crates/khive-db/src/backend.rs
@@ -13,7 +13,7 @@ use rusqlite::OptionalExtension;
 use crate::error::SqliteError;
 use crate::pool::{ConnectionPool, PoolConfig};
 use crate::sql_bridge::SqlBridge;
-use crate::stores::{blob, entity, event, graph, note, sparse, text, vectors};
+use crate::stores::{agents, blob, entity, event, graph, note, sparse, text, vectors};
 
 /// Concrete storage backend providing capability traits.
 pub struct StorageBackend {
@@ -279,6 +279,20 @@ impl StorageBackend {
             Arc::clone(&self.pool),
             self.is_file_backed,
             namespace.trim().to_string(),
+        )))
+    }
+
+    /// Get the agent-process store (ADR-142 §1). Applies the agents DDL if not
+    /// already present. Idempotent — safe to call multiple times. Unlike the
+    /// other stores here, agent-process records are not namespace-scoped, so
+    /// there is no `_for_namespace` variant.
+    pub fn agents(&self) -> Result<Arc<dyn khive_storage::AgentStore>, SqliteError> {
+        let writer = self.pool.try_writer()?;
+        agents::ensure_agents_schema(writer.conn())?;
+
+        Ok(Arc::new(agents::SqlAgentStore::new(
+            Arc::clone(&self.pool),
+            self.is_file_backed,
         )))
     }
 

--- a/crates/khive-db/src/migrations.rs
+++ b/crates/khive-db/src/migrations.rs
@@ -133,6 +133,8 @@ const V15_UP: &str = include_str!("../sql/015-serve-ledger-attribution.sql");
 
 const V16_UP: &str = include_str!("../sql/016-gtd-dependency-cycle-guards.sql");
 
+const V17_UP: &str = include_str!("../sql/017-agents-ddl.sql");
+
 /// DDL for the `ann_write_log` delta table.
 ///
 /// Shared between migration V11 and the belt-and-suspenders creation in
@@ -236,6 +238,11 @@ pub const MIGRATIONS: &[VersionedMigration] = &[
         version: 16,
         name: "gtd_dependency_cycle_guards",
         up: V16_UP,
+    },
+    VersionedMigration {
+        version: 17,
+        name: "agents_ddl",
+        up: V17_UP,
     },
 ];
 

--- a/crates/khive-db/src/stores/agents.rs
+++ b/crates/khive-db/src/stores/agents.rs
@@ -1,0 +1,421 @@
+//! SQL-backed agent-process store (ADR-142 §1 "Process model").
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+
+use khive_storage::error::StorageError;
+use khive_storage::{AgentState, AgentStore, StorageCapability, TerminalReason};
+use khive_types::AgentRecord;
+
+use crate::error::SqliteError;
+use crate::pool::ConnectionPool;
+use crate::writer_task::WriterTaskHandle;
+
+fn state_as_sql(state: AgentState) -> &'static str {
+    match state {
+        AgentState::Spawned => "spawned",
+        AgentState::Running => "running",
+        AgentState::Suspended => "suspended",
+        AgentState::Terminal => "terminal",
+    }
+}
+
+fn state_from_sql(s: &str) -> Result<AgentState, rusqlite::Error> {
+    match s {
+        "spawned" => Ok(AgentState::Spawned),
+        "running" => Ok(AgentState::Running),
+        "suspended" => Ok(AgentState::Suspended),
+        "terminal" => Ok(AgentState::Terminal),
+        other => Err(rusqlite::Error::FromSqlConversionFailure(
+            0,
+            rusqlite::types::Type::Text,
+            format!("unknown AgentState: {other}").into(),
+        )),
+    }
+}
+
+fn terminal_reason_as_sql(reason: TerminalReason) -> &'static str {
+    match reason {
+        TerminalReason::Completed => "completed",
+        TerminalReason::Failed => "failed",
+        TerminalReason::Killed => "killed",
+        TerminalReason::Abandoned => "abandoned",
+        TerminalReason::HostRestart => "host_restart",
+    }
+}
+
+fn terminal_reason_from_sql(s: &str) -> Result<TerminalReason, rusqlite::Error> {
+    match s {
+        "completed" => Ok(TerminalReason::Completed),
+        "failed" => Ok(TerminalReason::Failed),
+        "killed" => Ok(TerminalReason::Killed),
+        "abandoned" => Ok(TerminalReason::Abandoned),
+        "host_restart" => Ok(TerminalReason::HostRestart),
+        other => Err(rusqlite::Error::FromSqlConversionFailure(
+            0,
+            rusqlite::types::Type::Text,
+            format!("unknown TerminalReason: {other}").into(),
+        )),
+    }
+}
+
+// =============================================================================
+// SqlAgentStore
+// =============================================================================
+
+fn map_err(e: rusqlite::Error, op: &'static str) -> StorageError {
+    // ADR-142 defines no `StorageCapability::Agents` variant. `Sql` is the
+    // closest existing generic-driver capability; `op` still disambiguates
+    // which agent-store method failed.
+    StorageError::driver(StorageCapability::Sql, op, e)
+}
+
+fn map_sqlite_err(e: SqliteError, op: &'static str) -> StorageError {
+    StorageError::driver(StorageCapability::Sql, op, e)
+}
+
+const AGENT_COLUMNS: &str = "agent_id, state, terminal_reason, provider, provider_session_id, \
+     checkpoint_session_id, checkpoint_cursor, owner_actor, owner_peer_class, \
+     owner_write_namespace, owner_visible_namespaces, spawn_fingerprint, spawned_at, \
+     state_changed_at, idempotency_key";
+
+fn read_agent_record(row: &rusqlite::Row<'_>) -> Result<AgentRecord, rusqlite::Error> {
+    let agent_id: String = row.get(0)?;
+    let state_str: String = row.get(1)?;
+    let terminal_reason_str: Option<String> = row.get(2)?;
+    let provider: String = row.get(3)?;
+    let provider_session_id: Option<String> = row.get(4)?;
+    let checkpoint_session_id: Option<String> = row.get(5)?;
+    let checkpoint_cursor: Option<i64> = row.get(6)?;
+    let owner_actor: String = row.get(7)?;
+    let owner_peer_class: String = row.get(8)?;
+    let owner_write_namespace: String = row.get(9)?;
+    let owner_visible_namespaces_json: String = row.get(10)?;
+    let spawn_fingerprint: String = row.get(11)?;
+    let spawned_at: i64 = row.get(12)?;
+    let state_changed_at: i64 = row.get(13)?;
+    let idempotency_key: Option<String> = row.get(14)?;
+
+    let state = state_from_sql(&state_str)?;
+    let terminal_reason = terminal_reason_str
+        .as_deref()
+        .map(terminal_reason_from_sql)
+        .transpose()?;
+    let owner_visible_namespaces: Vec<String> =
+        serde_json::from_str(&owner_visible_namespaces_json).map_err(|e| {
+            rusqlite::Error::FromSqlConversionFailure(10, rusqlite::types::Type::Text, Box::new(e))
+        })?;
+
+    Ok(AgentRecord {
+        agent_id,
+        state,
+        terminal_reason,
+        provider,
+        provider_session_id,
+        checkpoint_session_id,
+        checkpoint_cursor,
+        owner_actor,
+        owner_peer_class,
+        owner_write_namespace,
+        owner_visible_namespaces,
+        spawn_fingerprint,
+        spawned_at,
+        state_changed_at,
+        idempotency_key,
+    })
+}
+
+/// A concurrent spawn naming a `(provider, provider_session_id)` pair a
+/// non-terminal record already holds. Read inside the same transaction as
+/// the insert attempt so the check-then-act is atomic under this pool's
+/// single-writer serialization; the schema's partial unique index
+/// (`idx_agents_live_provider_session`, `sql/017-agents-ddl.sql`) is the
+/// backstop that makes the property hold even if a future write path
+/// bypasses this pre-check.
+fn find_non_terminal_by_provider_session_tx(
+    conn: &rusqlite::Connection,
+    provider: &str,
+    provider_session_id: &str,
+) -> Result<Option<AgentRecord>, rusqlite::Error> {
+    let mut stmt = conn.prepare(&format!(
+        "SELECT {AGENT_COLUMNS} FROM agents \
+         WHERE provider = ?1 AND provider_session_id = ?2 AND state != 'terminal'"
+    ))?;
+    let mut rows = stmt.query(rusqlite::params![provider, provider_session_id])?;
+    match rows.next()? {
+        Some(row) => Ok(Some(read_agent_record(row)?)),
+        None => Ok(None),
+    }
+}
+
+fn insert_agent_dml(
+    conn: &rusqlite::Connection,
+    record: &AgentRecord,
+) -> Result<(), rusqlite::Error> {
+    if let Some(session_id) = &record.provider_session_id {
+        if record.state != AgentState::Terminal {
+            if let Some(holder) =
+                find_non_terminal_by_provider_session_tx(conn, &record.provider, session_id)?
+            {
+                return Err(rusqlite::Error::SqliteFailure(
+                    rusqlite::ffi::Error::new(rusqlite::ffi::SQLITE_CONSTRAINT),
+                    Some(format!(
+                        "non-terminal record {} already holds provider session ({}, {})",
+                        holder.agent_id, record.provider, session_id
+                    )),
+                ));
+            }
+        }
+    }
+
+    let owner_visible_namespaces_json = serde_json::to_string(&record.owner_visible_namespaces)
+        .map_err(|e| rusqlite::Error::ToSqlConversionFailure(Box::new(e)))?;
+
+    conn.execute(
+        &format!(
+            "INSERT INTO agents ({AGENT_COLUMNS}) \
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15)"
+        ),
+        rusqlite::params![
+            record.agent_id,
+            state_as_sql(record.state),
+            record.terminal_reason.map(terminal_reason_as_sql),
+            record.provider,
+            record.provider_session_id,
+            record.checkpoint_session_id,
+            record.checkpoint_cursor,
+            record.owner_actor,
+            record.owner_peer_class,
+            record.owner_write_namespace,
+            owner_visible_namespaces_json,
+            record.spawn_fingerprint,
+            record.spawned_at,
+            record.state_changed_at,
+            record.idempotency_key,
+        ],
+    )?;
+    Ok(())
+}
+
+/// An `AgentStore` backed by SQLite (ADR-142 §1). Unlike the other stores in
+/// this crate, agent-process records are not namespace-scoped — the shared
+/// contract's `AgentRecord` carries no `namespace` field, matching ADR-142's
+/// description of the table as a single runtime-owned process ledger.
+pub struct SqlAgentStore {
+    pool: Arc<ConnectionPool>,
+    is_file_backed: bool,
+    writer_task: Option<WriterTaskHandle>,
+}
+
+impl SqlAgentStore {
+    pub fn new(pool: Arc<ConnectionPool>, is_file_backed: bool) -> Self {
+        let writer_task = pool.writer_task_handle().ok().flatten();
+        Self {
+            pool,
+            is_file_backed,
+            writer_task,
+        }
+    }
+
+    fn open_standalone_writer(&self) -> Result<rusqlite::Connection, StorageError> {
+        self.pool
+            .open_standalone_writer()
+            .map_err(|e| map_sqlite_err(e, "open_agent_writer"))
+    }
+
+    fn open_standalone_reader(&self) -> Result<rusqlite::Connection, StorageError> {
+        self.pool
+            .open_standalone_reader()
+            .map_err(|e| map_sqlite_err(e, "open_agent_reader"))
+    }
+
+    async fn with_writer<F, R>(&self, op: &'static str, f: F) -> Result<R, StorageError>
+    where
+        F: FnOnce(&rusqlite::Connection) -> Result<R, rusqlite::Error> + Send + 'static,
+        R: Send + 'static,
+    {
+        if let Some(writer_task) = &self.writer_task {
+            return writer_task
+                .send(move |conn| f(conn).map_err(|e| map_err(e, op)))
+                .await;
+        }
+
+        if self.is_file_backed {
+            let conn = self.open_standalone_writer()?;
+            tokio::task::spawn_blocking(move || f(&conn).map_err(|e| map_err(e, op)))
+                .await
+                .map_err(|e| StorageError::driver(StorageCapability::Sql, op, e))?
+        } else {
+            let pool = Arc::clone(&self.pool);
+            tokio::task::spawn_blocking(move || {
+                let guard = pool.try_writer().map_err(|e| map_sqlite_err(e, op))?;
+                f(guard.conn()).map_err(|e| map_err(e, op))
+            })
+            .await
+            .map_err(|e| StorageError::driver(StorageCapability::Sql, op, e))?
+        }
+    }
+
+    async fn with_reader<F, R>(&self, op: &'static str, f: F) -> Result<R, StorageError>
+    where
+        F: FnOnce(&rusqlite::Connection) -> Result<R, rusqlite::Error> + Send + 'static,
+        R: Send + 'static,
+    {
+        if self.is_file_backed {
+            let conn = self.open_standalone_reader()?;
+            tokio::task::spawn_blocking(move || f(&conn).map_err(|e| map_err(e, op)))
+                .await
+                .map_err(|e| StorageError::driver(StorageCapability::Sql, op, e))?
+        } else {
+            let pool = Arc::clone(&self.pool);
+            tokio::task::spawn_blocking(move || {
+                let guard = pool.reader().map_err(|e| map_sqlite_err(e, op))?;
+                f(guard.conn()).map_err(|e| map_err(e, op))
+            })
+            .await
+            .map_err(|e| StorageError::driver(StorageCapability::Sql, op, e))?
+        }
+    }
+}
+
+#[async_trait]
+impl AgentStore for SqlAgentStore {
+    async fn insert(&self, record: &AgentRecord) -> Result<(), StorageError> {
+        let record = record.clone();
+        self.with_writer("agent_insert", move |conn| {
+            conn.execute_batch("BEGIN IMMEDIATE")?;
+            if let Err(e) = insert_agent_dml(conn, &record) {
+                let _ = conn.execute_batch("ROLLBACK");
+                return Err(e);
+            }
+            conn.execute_batch("COMMIT")?;
+            Ok(())
+        })
+        .await
+    }
+
+    async fn get(&self, agent_id: &str) -> Result<Option<AgentRecord>, StorageError> {
+        let agent_id = agent_id.to_string();
+        self.with_reader("agent_get", move |conn| {
+            let mut stmt = conn.prepare(&format!(
+                "SELECT {AGENT_COLUMNS} FROM agents WHERE agent_id = ?1"
+            ))?;
+            let mut rows = stmt.query(rusqlite::params![agent_id])?;
+            match rows.next()? {
+                Some(row) => Ok(Some(read_agent_record(row)?)),
+                None => Ok(None),
+            }
+        })
+        .await
+    }
+
+    async fn update_state(
+        &self,
+        agent_id: &str,
+        state: AgentState,
+        terminal_reason: Option<TerminalReason>,
+        state_changed_at: i64,
+    ) -> Result<(), StorageError> {
+        let agent_id = agent_id.to_string();
+        self.with_writer("agent_update_state", move |conn| {
+            let affected = conn.execute(
+                "UPDATE agents SET state = ?1, terminal_reason = ?2, state_changed_at = ?3 \
+                 WHERE agent_id = ?4",
+                rusqlite::params![
+                    state_as_sql(state),
+                    terminal_reason.map(terminal_reason_as_sql),
+                    state_changed_at,
+                    agent_id,
+                ],
+            )?;
+            if affected == 0 {
+                return Err(rusqlite::Error::QueryReturnedNoRows);
+            }
+            Ok(())
+        })
+        .await
+    }
+
+    async fn set_checkpoint(
+        &self,
+        agent_id: &str,
+        checkpoint_session_id: &str,
+        checkpoint_cursor: i64,
+    ) -> Result<(), StorageError> {
+        let agent_id = agent_id.to_string();
+        let checkpoint_session_id = checkpoint_session_id.to_string();
+        self.with_writer("agent_set_checkpoint", move |conn| {
+            let affected = conn.execute(
+                "UPDATE agents SET checkpoint_session_id = ?1, checkpoint_cursor = ?2 \
+                 WHERE agent_id = ?3",
+                rusqlite::params![checkpoint_session_id, checkpoint_cursor, agent_id],
+            )?;
+            if affected == 0 {
+                return Err(rusqlite::Error::QueryReturnedNoRows);
+            }
+            Ok(())
+        })
+        .await
+    }
+
+    async fn find_by_idempotency(
+        &self,
+        owner_actor: &str,
+        idempotency_key: &str,
+    ) -> Result<Option<AgentRecord>, StorageError> {
+        let owner_actor = owner_actor.to_string();
+        let idempotency_key = idempotency_key.to_string();
+        self.with_reader("agent_find_by_idempotency", move |conn| {
+            let mut stmt = conn.prepare(&format!(
+                "SELECT {AGENT_COLUMNS} FROM agents \
+                 WHERE owner_actor = ?1 AND idempotency_key = ?2"
+            ))?;
+            let mut rows = stmt.query(rusqlite::params![owner_actor, idempotency_key])?;
+            match rows.next()? {
+                Some(row) => Ok(Some(read_agent_record(row)?)),
+                None => Ok(None),
+            }
+        })
+        .await
+    }
+
+    async fn find_non_terminal_by_provider_session(
+        &self,
+        provider: &str,
+        provider_session_id: &str,
+    ) -> Result<Option<AgentRecord>, StorageError> {
+        let provider = provider.to_string();
+        let provider_session_id = provider_session_id.to_string();
+        self.with_reader("agent_find_non_terminal_by_provider_session", move |conn| {
+            find_non_terminal_by_provider_session_tx(conn, &provider, &provider_session_id)
+        })
+        .await
+    }
+
+    async fn terminate_all_non_terminal(&self, state_changed_at: i64) -> Result<u64, StorageError> {
+        self.with_writer("agent_terminate_all_non_terminal", move |conn| {
+            let affected = conn.execute(
+                "UPDATE agents SET state = 'terminal', terminal_reason = 'host_restart', \
+                 state_changed_at = ?1 WHERE state != 'terminal'",
+                rusqlite::params![state_changed_at],
+            )?;
+            Ok(affected as u64)
+        })
+        .await
+    }
+}
+
+// =============================================================================
+// DDL
+// =============================================================================
+
+const AGENTS_DDL: &str = include_str!("../../sql/017-agents-ddl.sql");
+
+pub(crate) fn ensure_agents_schema(conn: &rusqlite::Connection) -> Result<(), rusqlite::Error> {
+    conn.execute_batch(AGENTS_DDL)
+}
+
+#[cfg(test)]
+#[path = "agents_tests.rs"]
+mod tests;

--- a/crates/khive-db/src/stores/agents_tests.rs
+++ b/crates/khive-db/src/stores/agents_tests.rs
@@ -1,0 +1,267 @@
+use super::*;
+use crate::pool::PoolConfig;
+
+fn setup_memory_store() -> SqlAgentStore {
+    let config = PoolConfig {
+        path: None,
+        ..PoolConfig::default()
+    };
+    let pool = Arc::new(ConnectionPool::new(config).unwrap());
+
+    {
+        let writer = pool.writer().unwrap();
+        writer.conn().execute_batch(AGENTS_DDL).unwrap();
+    }
+
+    SqlAgentStore::new(pool, false)
+}
+
+fn make_record(agent_id: &str, owner_actor: &str) -> AgentRecord {
+    AgentRecord {
+        agent_id: agent_id.to_string(),
+        state: AgentState::Spawned,
+        terminal_reason: None,
+        provider: "test-provider".to_string(),
+        provider_session_id: None,
+        checkpoint_session_id: None,
+        checkpoint_cursor: None,
+        owner_actor: owner_actor.to_string(),
+        owner_peer_class: "native".to_string(),
+        owner_write_namespace: "local".to_string(),
+        owner_visible_namespaces: vec!["local".to_string()],
+        spawn_fingerprint: "fingerprint-1".to_string(),
+        spawned_at: 1_000,
+        state_changed_at: 1_000,
+        idempotency_key: None,
+    }
+}
+
+#[tokio::test]
+async fn test_insert_and_get() {
+    let store = setup_memory_store();
+    let record = make_record("agent-1", "actor-a");
+
+    store.insert(&record).await.unwrap();
+
+    let fetched = store.get("agent-1").await.unwrap().unwrap();
+    assert_eq!(fetched.agent_id, "agent-1");
+    assert_eq!(fetched.state, AgentState::Spawned);
+    assert_eq!(fetched.owner_visible_namespaces, vec!["local".to_string()]);
+}
+
+#[tokio::test]
+async fn test_get_missing_returns_none() {
+    let store = setup_memory_store();
+    assert!(store.get("does-not-exist").await.unwrap().is_none());
+}
+
+#[tokio::test]
+async fn test_update_state_and_terminal_reason() {
+    let store = setup_memory_store();
+    let record = make_record("agent-2", "actor-a");
+    store.insert(&record).await.unwrap();
+
+    store
+        .update_state("agent-2", AgentState::Running, None, 2_000)
+        .await
+        .unwrap();
+    let fetched = store.get("agent-2").await.unwrap().unwrap();
+    assert_eq!(fetched.state, AgentState::Running);
+    assert_eq!(fetched.state_changed_at, 2_000);
+
+    store
+        .update_state(
+            "agent-2",
+            AgentState::Terminal,
+            Some(TerminalReason::Completed),
+            3_000,
+        )
+        .await
+        .unwrap();
+    let fetched = store.get("agent-2").await.unwrap().unwrap();
+    assert_eq!(fetched.state, AgentState::Terminal);
+    assert_eq!(fetched.terminal_reason, Some(TerminalReason::Completed));
+}
+
+#[tokio::test]
+async fn test_set_checkpoint() {
+    let store = setup_memory_store();
+    let record = make_record("agent-3", "actor-a");
+    store.insert(&record).await.unwrap();
+
+    store
+        .set_checkpoint("agent-3", "session-abc", 42)
+        .await
+        .unwrap();
+
+    let fetched = store.get("agent-3").await.unwrap().unwrap();
+    assert_eq!(
+        fetched.checkpoint_session_id,
+        Some("session-abc".to_string())
+    );
+    assert_eq!(fetched.checkpoint_cursor, Some(42));
+}
+
+/// The point of the feature (ADR-142 §1 spawn row): idempotency replay is
+/// keyed on the PAIR (owner_actor, idempotency_key), never the key alone.
+/// Two different actors reusing the same key string must never observe or
+/// interfere with each other's records.
+#[tokio::test]
+async fn test_idempotency_keyed_on_actor_and_key_pair() {
+    let store = setup_memory_store();
+
+    let mut record_a = make_record("agent-actor-a", "actor-a");
+    record_a.idempotency_key = Some("shared-key".to_string());
+    store.insert(&record_a).await.unwrap();
+
+    let mut record_b = make_record("agent-actor-b", "actor-b");
+    record_b.idempotency_key = Some("shared-key".to_string());
+    store.insert(&record_b).await.unwrap();
+
+    let found_a = store
+        .find_by_idempotency("actor-a", "shared-key")
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(found_a.agent_id, "agent-actor-a");
+
+    let found_b = store
+        .find_by_idempotency("actor-b", "shared-key")
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(found_b.agent_id, "agent-actor-b");
+
+    assert!(store
+        .find_by_idempotency("actor-c", "shared-key")
+        .await
+        .unwrap()
+        .is_none());
+}
+
+#[tokio::test]
+async fn test_insert_rejects_duplicate_actor_key_pair() {
+    let store = setup_memory_store();
+
+    let mut record = make_record("agent-x", "actor-a");
+    record.idempotency_key = Some("dup-key".to_string());
+    store.insert(&record).await.unwrap();
+
+    let mut record_conflict = make_record("agent-y", "actor-a");
+    record_conflict.idempotency_key = Some("dup-key".to_string());
+
+    let err = store.insert(&record_conflict).await.unwrap_err();
+    assert!(matches!(err, StorageError::Driver { .. }));
+}
+
+/// The other property this store exists to hold: at most one non-terminal
+/// record per (provider, provider_session_id). A spawn naming a pair already
+/// held by a non-terminal record must be rejected.
+#[tokio::test]
+async fn test_rejects_second_non_terminal_for_same_provider_session() {
+    let store = setup_memory_store();
+
+    let mut record = make_record("agent-live-1", "actor-a");
+    record.provider_session_id = Some("session-1".to_string());
+    store.insert(&record).await.unwrap();
+
+    let mut conflicting = make_record("agent-live-2", "actor-b");
+    conflicting.provider_session_id = Some("session-1".to_string());
+
+    let err = store.insert(&conflicting).await.unwrap_err();
+    assert!(matches!(err, StorageError::Driver { .. }));
+
+    let holder = store
+        .find_non_terminal_by_provider_session("test-provider", "session-1")
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(holder.agent_id, "agent-live-1");
+}
+
+/// A suspended record is still non-terminal and still holds its pair — a
+/// second spawn against the same (provider, provider_session_id) must still
+/// be rejected while the holder is merely suspended, not just while running.
+#[tokio::test]
+async fn test_suspended_record_still_holds_provider_session_pair() {
+    let store = setup_memory_store();
+
+    let mut record = make_record("agent-susp-1", "actor-a");
+    record.provider_session_id = Some("session-2".to_string());
+    store.insert(&record).await.unwrap();
+    store
+        .update_state("agent-susp-1", AgentState::Suspended, None, 2_000)
+        .await
+        .unwrap();
+
+    let mut conflicting = make_record("agent-susp-2", "actor-b");
+    conflicting.provider_session_id = Some("session-2".to_string());
+    let err = store.insert(&conflicting).await.unwrap_err();
+    assert!(matches!(err, StorageError::Driver { .. }));
+}
+
+/// Once the holder reaches terminal, the pair frees up: a new spawn against
+/// the same (provider, provider_session_id) succeeds.
+#[tokio::test]
+async fn test_provider_session_pair_frees_after_terminal() {
+    let store = setup_memory_store();
+
+    let mut record = make_record("agent-term-1", "actor-a");
+    record.provider_session_id = Some("session-3".to_string());
+    store.insert(&record).await.unwrap();
+    store
+        .update_state(
+            "agent-term-1",
+            AgentState::Terminal,
+            Some(TerminalReason::Completed),
+            2_000,
+        )
+        .await
+        .unwrap();
+
+    let mut second = make_record("agent-term-2", "actor-b");
+    second.provider_session_id = Some("session-3".to_string());
+    store.insert(&second).await.unwrap();
+
+    let holder = store
+        .find_non_terminal_by_provider_session("test-provider", "session-3")
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(holder.agent_id, "agent-term-2");
+}
+
+#[tokio::test]
+async fn test_terminate_all_non_terminal_boot_scan() {
+    let store = setup_memory_store();
+
+    store
+        .insert(&make_record("agent-a", "actor-a"))
+        .await
+        .unwrap();
+    store
+        .insert(&make_record("agent-b", "actor-b"))
+        .await
+        .unwrap();
+    let mut terminal_record = make_record("agent-c", "actor-c");
+    terminal_record.state = AgentState::Terminal;
+    terminal_record.terminal_reason = Some(TerminalReason::Completed);
+    store.insert(&terminal_record).await.unwrap();
+
+    let affected = store.terminate_all_non_terminal(9_999).await.unwrap();
+    assert_eq!(affected, 2);
+
+    let a = store.get("agent-a").await.unwrap().unwrap();
+    assert_eq!(a.state, AgentState::Terminal);
+    assert_eq!(a.terminal_reason, Some(TerminalReason::HostRestart));
+    assert_eq!(a.state_changed_at, 9_999);
+
+    let b = store.get("agent-b").await.unwrap().unwrap();
+    assert_eq!(b.state, AgentState::Terminal);
+    assert_eq!(b.terminal_reason, Some(TerminalReason::HostRestart));
+
+    // The already-terminal record is untouched.
+    let c = store.get("agent-c").await.unwrap().unwrap();
+    assert_eq!(c.terminal_reason, Some(TerminalReason::Completed));
+    assert_eq!(c.state_changed_at, 1_000);
+}

--- a/crates/khive-db/src/stores/mod.rs
+++ b/crates/khive-db/src/stores/mod.rs
@@ -3,6 +3,7 @@
 //! Each module provides a concrete store struct implementing one or more
 //! `khive-storage` capability traits against the shared connection pool.
 
+pub mod agents;
 pub mod blob;
 pub mod blob_s3;
 pub mod entity;

--- a/crates/khive-pack-agent/Cargo.toml
+++ b/crates/khive-pack-agent/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "khive-pack-agent"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+categories.workspace = true
+description = "Agent verb pack — spawn/resume/kill/suspend/observe wire surface over the runtime-owned agent process table (ADR-142 §1)"
+
+[dependencies]
+khive-types = { version = "0.7.0", path = "../khive-types", features = ["serde", "blake3"] }
+khive-runtime = { version = "0.7.0", path = "../khive-runtime" }
+khive-storage = { version = "0.7.0", path = "../khive-storage" }
+async-trait = { workspace = true }
+serde_json = { workspace = true }
+chrono = { workspace = true }
+uuid = { workspace = true }
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["full"] }
+khive-pack-kg = { version = "0.7.0", path = "../khive-pack-kg" }

--- a/crates/khive-pack-agent/src/handlers.rs
+++ b/crates/khive-pack-agent/src/handlers.rs
@@ -1,0 +1,285 @@
+//! Verb handlers for the agent pack (ADR-142 §1).
+//!
+//! Every handler here is a thin wire-surface layer over the `AgentStore`
+//! trait object the pack was constructed with: parameter validation,
+//! `spawn_fingerprint` computation, and the lifecycle transition table live
+//! here; the durable table itself is entirely the store's concern.
+
+use std::sync::Arc;
+
+use chrono::Utc;
+use serde_json::{json, Value};
+use uuid::Uuid;
+
+use khive_runtime::agent_lifecycle::{apply_transition, spawn_fingerprint, Trigger};
+use khive_runtime::{NamespaceToken, RuntimeError};
+use khive_storage::AgentStore;
+use khive_types::{AgentRecord, AgentState, TerminalReason};
+
+fn require_str<'a>(params: &'a Value, name: &str, verb: &str) -> Result<&'a str, RuntimeError> {
+    params
+        .get(name)
+        .and_then(Value::as_str)
+        .filter(|s| !s.is_empty())
+        .ok_or_else(|| {
+            RuntimeError::InvalidInput(format!(
+                "{verb} requires a non-empty string field \"{name}\""
+            ))
+        })
+}
+
+fn optional_str<'a>(params: &'a Value, name: &str) -> Option<&'a str> {
+    params
+        .get(name)
+        .and_then(Value::as_str)
+        .filter(|s| !s.is_empty())
+}
+
+fn state_str(state: AgentState) -> &'static str {
+    match state {
+        AgentState::Spawned => "spawned",
+        AgentState::Running => "running",
+        AgentState::Suspended => "suspended",
+        AgentState::Terminal => "terminal",
+    }
+}
+
+fn terminal_reason_str(reason: TerminalReason) -> &'static str {
+    match reason {
+        TerminalReason::Completed => "completed",
+        TerminalReason::Failed => "failed",
+        TerminalReason::Killed => "killed",
+        TerminalReason::Abandoned => "abandoned",
+        TerminalReason::HostRestart => "host_restart",
+    }
+}
+
+fn record_to_json(record: &AgentRecord) -> Value {
+    json!({
+        "agent_id": record.agent_id,
+        "state": state_str(record.state),
+        "terminal_reason": record.terminal_reason.map(terminal_reason_str),
+        "provider": record.provider,
+        "provider_session_id": record.provider_session_id,
+        "checkpoint_session_id": record.checkpoint_session_id,
+        "checkpoint_cursor": record.checkpoint_cursor,
+        "owner_actor": record.owner_actor,
+        "owner_peer_class": record.owner_peer_class,
+        "owner_write_namespace": record.owner_write_namespace,
+        "owner_visible_namespaces": record.owner_visible_namespaces,
+        "spawn_fingerprint": record.spawn_fingerprint,
+        "spawned_at": record.spawned_at,
+        "state_changed_at": record.state_changed_at,
+        "idempotency_key": record.idempotency_key,
+    })
+}
+
+async fn load(
+    store: &Arc<dyn AgentStore>,
+    verb: &str,
+    id: &str,
+) -> Result<AgentRecord, RuntimeError> {
+    store
+        .get(id)
+        .await?
+        .ok_or_else(|| RuntimeError::NotFound(format!("{verb}: unknown agent_id {id:?}")))
+}
+
+/// `agent.spawn` — required `provider`, `task`; optional `idempotency_key`,
+/// `provider_session_id`, `checkpoint_session_id`. Success: `{ agent_id, state }`.
+pub(crate) async fn handle_spawn(
+    store: &Arc<dyn AgentStore>,
+    token: &NamespaceToken,
+    params: Value,
+) -> Result<Value, RuntimeError> {
+    let provider = require_str(&params, "provider", "agent.spawn")?.to_string();
+    let task = require_str(&params, "task", "agent.spawn")?.to_string();
+    let idempotency_key = optional_str(&params, "idempotency_key").map(str::to_string);
+    let provider_session_id = optional_str(&params, "provider_session_id").map(str::to_string);
+    let checkpoint_session_id = optional_str(&params, "checkpoint_session_id").map(str::to_string);
+
+    let owner_actor = token
+        .actor()
+        .binding_id()
+        .unwrap_or("anonymous")
+        .to_string();
+
+    let fingerprint = spawn_fingerprint(
+        &provider,
+        &task,
+        provider_session_id.as_deref(),
+        checkpoint_session_id.as_deref(),
+    );
+
+    if let Some(key) = &idempotency_key {
+        if let Some(existing) = store.find_by_idempotency(&owner_actor, key).await? {
+            if existing.spawn_fingerprint == fingerprint {
+                return Ok(json!({
+                    "agent_id": existing.agent_id,
+                    "state": state_str(existing.state),
+                }));
+            }
+            return Err(RuntimeError::InvalidInput(format!(
+                "agent.spawn: idempotency_key {key:?} was already used with different arguments"
+            )));
+        }
+    }
+
+    if let Some(psid) = &provider_session_id {
+        if let Some(existing) = store
+            .find_non_terminal_by_provider_session(&provider, psid)
+            .await?
+        {
+            return Err(RuntimeError::InvalidInput(format!(
+                "agent.spawn: provider_session_id {psid:?} for provider {provider:?} is \
+                 already bound to non-terminal record {}",
+                existing.agent_id
+            )));
+        }
+    }
+
+    let now = Utc::now().timestamp_micros();
+    let record = AgentRecord {
+        agent_id: Uuid::new_v4().to_string(),
+        state: AgentState::Spawned,
+        terminal_reason: None,
+        provider,
+        provider_session_id,
+        checkpoint_session_id,
+        checkpoint_cursor: None,
+        owner_actor,
+        // This pack is only reached through in-process registry dispatch — no
+        // ADR-137-mapped connection is wired in here — so every record
+        // carries the distinguished `native` context marker (ADR-142 §1,
+        // "Persistent process record").
+        owner_peer_class: "native".to_string(),
+        owner_write_namespace: token.namespace().as_str().to_string(),
+        owner_visible_namespaces: token
+            .visible_namespaces()
+            .iter()
+            .map(|ns| ns.as_str().to_string())
+            .collect(),
+        spawn_fingerprint: fingerprint,
+        spawned_at: now,
+        state_changed_at: now,
+        idempotency_key,
+    };
+
+    store.insert(&record).await?;
+
+    Ok(json!({
+        "agent_id": record.agent_id,
+        "state": state_str(record.state),
+    }))
+}
+
+/// `agent.observe` — required `id`. Success: the full process-record field set.
+pub(crate) async fn handle_observe(
+    store: &Arc<dyn AgentStore>,
+    params: Value,
+) -> Result<Value, RuntimeError> {
+    let id = require_str(&params, "id", "agent.observe")?;
+    let record = load(store, "agent.observe", id).await?;
+    Ok(record_to_json(&record))
+}
+
+/// `agent.suspend` — required `id`. Success: `{ agent_id, state, checkpoint_session_id }`.
+///
+/// Legal only from `running`; a no-op on an already-`suspended` record;
+/// an illegal-transition error from `spawned` or `terminal`. This handler
+/// does not perform the session-surface checkpoint write itself (no
+/// checkpoint content is a parameter of this verb) — it reports the
+/// record's currently stored `checkpoint_session_id` unchanged.
+pub(crate) async fn handle_suspend(
+    store: &Arc<dyn AgentStore>,
+    params: Value,
+) -> Result<Value, RuntimeError> {
+    let id = require_str(&params, "id", "agent.suspend")?;
+    let record = load(store, "agent.suspend", id).await?;
+
+    let outcome = apply_transition(record.state, record.terminal_reason, Trigger::Suspend)
+        .map_err(|e| {
+            RuntimeError::InvalidInput(format!(
+                "agent.suspend: illegal transition from {} for agent_id {id:?}",
+                state_str(e.from)
+            ))
+        })?;
+
+    if outcome.changed {
+        let now = Utc::now().timestamp_micros();
+        store
+            .update_state(id, outcome.state, outcome.terminal_reason, now)
+            .await?;
+    }
+
+    Ok(json!({
+        "agent_id": record.agent_id,
+        "state": state_str(outcome.state),
+        "checkpoint_session_id": record.checkpoint_session_id,
+    }))
+}
+
+/// `agent.resume` — required `id`. Success: `{ agent_id, state }`.
+///
+/// A no-op on an already-`running` record; legal from `suspended`; an
+/// illegal-transition error from `spawned` or `terminal`.
+pub(crate) async fn handle_resume(
+    store: &Arc<dyn AgentStore>,
+    params: Value,
+) -> Result<Value, RuntimeError> {
+    let id = require_str(&params, "id", "agent.resume")?;
+    let record = load(store, "agent.resume", id).await?;
+
+    let outcome =
+        apply_transition(record.state, record.terminal_reason, Trigger::Resume).map_err(|e| {
+            RuntimeError::InvalidInput(format!(
+                "agent.resume: illegal transition from {} for agent_id {id:?}",
+                state_str(e.from)
+            ))
+        })?;
+
+    if outcome.changed {
+        let now = Utc::now().timestamp_micros();
+        store
+            .update_state(id, outcome.state, outcome.terminal_reason, now)
+            .await?;
+    }
+
+    Ok(json!({
+        "agent_id": record.agent_id,
+        "state": state_str(outcome.state),
+    }))
+}
+
+/// `agent.kill` — required `id`. Success: `{ agent_id, state, terminal_reason }`.
+///
+/// Legal from `spawned`, `running`, or `suspended`; a no-op returning the
+/// current state on an already-`terminal` record, never an error.
+pub(crate) async fn handle_kill(
+    store: &Arc<dyn AgentStore>,
+    params: Value,
+) -> Result<Value, RuntimeError> {
+    let id = require_str(&params, "id", "agent.kill")?;
+    let record = load(store, "agent.kill", id).await?;
+
+    let outcome =
+        apply_transition(record.state, record.terminal_reason, Trigger::Kill).map_err(|e| {
+            RuntimeError::InvalidInput(format!(
+                "agent.kill: illegal transition from {} for agent_id {id:?}",
+                state_str(e.from)
+            ))
+        })?;
+
+    if outcome.changed {
+        let now = Utc::now().timestamp_micros();
+        store
+            .update_state(id, outcome.state, outcome.terminal_reason, now)
+            .await?;
+    }
+
+    Ok(json!({
+        "agent_id": record.agent_id,
+        "state": state_str(outcome.state),
+        "terminal_reason": outcome.terminal_reason.map(terminal_reason_str),
+    }))
+}

--- a/crates/khive-pack-agent/src/lib.rs
+++ b/crates/khive-pack-agent/src/lib.rs
@@ -1,0 +1,57 @@
+//! Agent verb pack — spawn/resume/kill/suspend/observe wire surface.
+//!
+//! ADR-142 §1: "An agent is a runtime-owned process record and is not a
+//! pack... A dedicated agent pack registers the verbs `agent.spawn`,
+//! `agent.resume`, `agent.kill`, `agent.suspend`, and `agent.observe` with
+//! the verb registry... The pack owns the wire surface; the runtime owns
+//! the table." This crate is that wire surface: it validates parameters,
+//! computes the spawn fingerprint, and drives the lifecycle transition
+//! table, entirely through the `AgentStore` trait — it never opens a
+//! khive-db connection of its own.
+
+pub mod handlers;
+mod pack;
+pub mod vocab;
+
+use std::sync::Arc;
+
+use khive_storage::AgentStore;
+use khive_types::{HandlerDef, Pack};
+
+pub(crate) use pack::AGENT_HANDLERS;
+
+/// Canonical pack name. Verbs are exposed as `agent.<verb>`.
+pub(crate) const PACK_NAME: &str = "agent";
+
+/// Agent pack: the ADR-142 wire surface over the runtime-owned agent table.
+///
+/// `KhiveRuntime` has no accessor for the agent table to reach into — that
+/// accessor is not part of the shared contract this pack was built against
+/// — so `AgentStore` is supplied directly at construction: the same shape
+/// `BlobPack` uses for `BlobStore`, except sourced from the caller rather
+/// than resolved from `KhiveRuntime` config. Handlers never see anything
+/// but the trait object, and this pack holds no `KhiveRuntime` handle of
+/// its own — every ADR-142 §1 operation this pack performs goes through
+/// `AgentStore` alone.
+pub struct AgentPack {
+    store: Arc<dyn AgentStore>,
+}
+
+impl Pack for AgentPack {
+    const NAME: &'static str = PACK_NAME;
+    const NOTE_KINDS: &'static [&'static str] = vocab::NOTE_KINDS;
+    const ENTITY_KINDS: &'static [&'static str] = vocab::ENTITY_KINDS;
+    const HANDLERS: &'static [HandlerDef] = &AGENT_HANDLERS;
+    const REQUIRES: &'static [&'static str] = &[];
+}
+
+impl AgentPack {
+    /// Bind the agent pack to the runtime-owned agent store.
+    pub fn new(store: Arc<dyn AgentStore>) -> Self {
+        Self { store }
+    }
+
+    pub(crate) fn store(&self) -> &Arc<dyn AgentStore> {
+        &self.store
+    }
+}

--- a/crates/khive-pack-agent/src/pack.rs
+++ b/crates/khive-pack-agent/src/pack.rs
@@ -1,0 +1,157 @@
+//! Handler table and runtime dispatch for the agent pack.
+//!
+//! Unlike the other packs in this workspace, `AgentPack` is not registered
+//! through `inventory::submit!`/`PackFactory`: that self-registration path
+//! constructs a pack from a bare `KhiveRuntime` alone, and `KhiveRuntime`
+//! has no accessor for an `AgentStore` (no such accessor is part of the
+//! shared contract this crate was built against, and adding one is outside
+//! this crate's file scope). Callers construct `AgentPack::new(runtime,
+//! store)` directly and register the instance with
+//! `RegistryBuilder::register`, the same manual path already supported for
+//! any `Pack + PackRuntime` value.
+
+use async_trait::async_trait;
+use serde_json::Value;
+
+use khive_runtime::pack::PackRuntime;
+use khive_runtime::{NamespaceToken, RuntimeError, VerbRegistry};
+use khive_types::{HandlerDef, ParamDef, Visibility};
+
+use crate::{handlers, AgentPack, PACK_NAME};
+
+pub(crate) static AGENT_HANDLERS: [HandlerDef; 5] = [
+    HandlerDef {
+        name: "agent.spawn",
+        description: "Create a new agent process record and return its id and initial state \
+                       (ADR-142 §1).",
+        visibility: Visibility::Verb,
+        category: khive_types::VerbCategory::Commissive,
+        params: &[
+            ParamDef {
+                name: "provider",
+                param_type: "string",
+                required: true,
+                description: "Name of the model provider adapter to run this agent under.",
+            },
+            ParamDef {
+                name: "task",
+                param_type: "string",
+                required: true,
+                description: "Initial instruction content for the spawned agent.",
+            },
+            ParamDef {
+                name: "idempotency_key",
+                param_type: "string",
+                required: false,
+                description: "Caller-supplied replay key, scoped to the calling actor; a \
+                               repeat with identical arguments returns the original record.",
+            },
+            ParamDef {
+                name: "provider_session_id",
+                param_type: "string",
+                required: false,
+                description: "Provider-native continuity key; at most one non-terminal record \
+                               may bind a given (provider, provider_session_id) pair.",
+            },
+            ParamDef {
+                name: "checkpoint_session_id",
+                param_type: "string",
+                required: false,
+                description: "Khive session-note identifier of a checkpoint to continue from.",
+            },
+        ],
+    },
+    HandlerDef {
+        name: "agent.observe",
+        description: "Report an agent process record's current fields without changing state \
+                       (ADR-142 §1).",
+        visibility: Visibility::Verb,
+        category: khive_types::VerbCategory::Assertive,
+        params: &[ParamDef {
+            name: "id",
+            param_type: "string",
+            required: true,
+            description: "The agent_id to observe.",
+        }],
+    },
+    HandlerDef {
+        name: "agent.suspend",
+        description: "Transition a running agent process to suspended at a message-yield \
+                       boundary (ADR-142 §1).",
+        visibility: Visibility::Verb,
+        category: khive_types::VerbCategory::Directive,
+        params: &[ParamDef {
+            name: "id",
+            param_type: "string",
+            required: true,
+            description: "The agent_id to suspend.",
+        }],
+    },
+    HandlerDef {
+        name: "agent.resume",
+        description: "Transition a suspended agent process back to running (ADR-142 §1).",
+        visibility: Visibility::Verb,
+        category: khive_types::VerbCategory::Directive,
+        params: &[ParamDef {
+            name: "id",
+            param_type: "string",
+            required: true,
+            description: "The agent_id to resume.",
+        }],
+    },
+    HandlerDef {
+        name: "agent.kill",
+        description: "Transition an agent process to terminal/killed; a no-op returning the \
+                       current state when already terminal (ADR-142 §1).",
+        visibility: Visibility::Verb,
+        category: khive_types::VerbCategory::Directive,
+        params: &[ParamDef {
+            name: "id",
+            param_type: "string",
+            required: true,
+            description: "The agent_id to kill.",
+        }],
+    },
+];
+
+#[async_trait]
+impl PackRuntime for AgentPack {
+    fn name(&self) -> &str {
+        PACK_NAME
+    }
+
+    fn note_kinds(&self) -> &'static [&'static str] {
+        crate::vocab::NOTE_KINDS
+    }
+
+    fn entity_kinds(&self) -> &'static [&'static str] {
+        crate::vocab::ENTITY_KINDS
+    }
+
+    fn handlers(&self) -> &'static [HandlerDef] {
+        &AGENT_HANDLERS
+    }
+
+    fn requires(&self) -> &'static [&'static str] {
+        &[]
+    }
+
+    async fn dispatch(
+        &self,
+        verb: &str,
+        params: Value,
+        _registry: &VerbRegistry,
+        token: &NamespaceToken,
+    ) -> Result<Value, RuntimeError> {
+        match verb {
+            "agent.spawn" => handlers::handle_spawn(self.store(), token, params).await,
+            "agent.observe" => handlers::handle_observe(self.store(), params).await,
+            "agent.suspend" => handlers::handle_suspend(self.store(), params).await,
+            "agent.resume" => handlers::handle_resume(self.store(), params).await,
+            "agent.kill" => handlers::handle_kill(self.store(), params).await,
+            _ => Err(RuntimeError::InvalidInput(format!(
+                "{PACK_NAME} pack does not handle verb {verb:?}"
+            ))),
+        }
+    }
+}

--- a/crates/khive-pack-agent/src/vocab.rs
+++ b/crates/khive-pack-agent/src/vocab.rs
@@ -1,0 +1,8 @@
+//! Vocabulary contributed by the agent pack.
+//!
+//! The agent process record lives in a runtime-owned table (ADR-142 §1), not
+//! in the note/entity substrate, so this pack contributes no note or entity
+//! kinds — only verbs.
+
+pub const NOTE_KINDS: &[&str] = &[];
+pub const ENTITY_KINDS: &[&str] = &[];

--- a/crates/khive-pack-agent/tests/integration.rs
+++ b/crates/khive-pack-agent/tests/integration.rs
@@ -1,0 +1,322 @@
+//! End-to-end smoke test for the agent pack: spawn -> observe -> suspend ->
+//! resume -> kill through the `VerbRegistry` dispatch path, against a local
+//! in-memory `AgentStore` test double (ADR-142 §1). Mirrors the shape of
+//! `khive-pack-blob/tests/integration.rs`.
+//!
+//! This crate does not depend on `khive-db`'s real `AgentStore`
+//! implementation — the pack only ever sees the trait object, and this
+//! test double proves that boundary holds.
+
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+
+use async_trait::async_trait;
+use khive_pack_agent::AgentPack;
+use khive_runtime::{VerbRegistry, VerbRegistryBuilder};
+use khive_storage::{AgentStore, StorageError};
+use khive_types::{AgentRecord, AgentState, Pack, TerminalReason};
+
+#[derive(Default)]
+struct MockAgentStore {
+    records: Mutex<HashMap<String, AgentRecord>>,
+}
+
+#[async_trait]
+impl AgentStore for MockAgentStore {
+    async fn insert(&self, record: &AgentRecord) -> Result<(), StorageError> {
+        self.records
+            .lock()
+            .unwrap()
+            .insert(record.agent_id.clone(), record.clone());
+        Ok(())
+    }
+
+    async fn get(&self, agent_id: &str) -> Result<Option<AgentRecord>, StorageError> {
+        Ok(self.records.lock().unwrap().get(agent_id).cloned())
+    }
+
+    async fn update_state(
+        &self,
+        agent_id: &str,
+        state: AgentState,
+        terminal_reason: Option<TerminalReason>,
+        state_changed_at: i64,
+    ) -> Result<(), StorageError> {
+        let mut records = self.records.lock().unwrap();
+        let record = records.get_mut(agent_id).expect("agent_id exists");
+        record.state = state;
+        record.terminal_reason = terminal_reason;
+        record.state_changed_at = state_changed_at;
+        Ok(())
+    }
+
+    async fn set_checkpoint(
+        &self,
+        agent_id: &str,
+        checkpoint_session_id: &str,
+        checkpoint_cursor: i64,
+    ) -> Result<(), StorageError> {
+        let mut records = self.records.lock().unwrap();
+        let record = records.get_mut(agent_id).expect("agent_id exists");
+        record.checkpoint_session_id = Some(checkpoint_session_id.to_string());
+        record.checkpoint_cursor = Some(checkpoint_cursor);
+        Ok(())
+    }
+
+    async fn find_by_idempotency(
+        &self,
+        owner_actor: &str,
+        idempotency_key: &str,
+    ) -> Result<Option<AgentRecord>, StorageError> {
+        Ok(self
+            .records
+            .lock()
+            .unwrap()
+            .values()
+            .find(|r| {
+                r.owner_actor == owner_actor
+                    && r.idempotency_key.as_deref() == Some(idempotency_key)
+            })
+            .cloned())
+    }
+
+    async fn find_non_terminal_by_provider_session(
+        &self,
+        provider: &str,
+        provider_session_id: &str,
+    ) -> Result<Option<AgentRecord>, StorageError> {
+        Ok(self
+            .records
+            .lock()
+            .unwrap()
+            .values()
+            .find(|r| {
+                r.provider == provider
+                    && r.provider_session_id.as_deref() == Some(provider_session_id)
+                    && r.state != AgentState::Terminal
+            })
+            .cloned())
+    }
+
+    async fn terminate_all_non_terminal(&self, state_changed_at: i64) -> Result<u64, StorageError> {
+        let mut records = self.records.lock().unwrap();
+        let mut moved = 0u64;
+        for record in records.values_mut() {
+            if record.state != AgentState::Terminal {
+                record.state = AgentState::Terminal;
+                record.terminal_reason = Some(TerminalReason::HostRestart);
+                record.state_changed_at = state_changed_at;
+                moved += 1;
+            }
+        }
+        Ok(moved)
+    }
+}
+
+fn build_registry() -> (VerbRegistry, Arc<MockAgentStore>) {
+    let store = Arc::new(MockAgentStore::default());
+    let mut builder = VerbRegistryBuilder::new();
+    builder.register(AgentPack::new(store.clone() as Arc<dyn AgentStore>));
+    let registry = builder.build().expect("registry builds");
+    (registry, store)
+}
+
+#[test]
+fn agent_pack_name_and_requires_are_stable() {
+    assert_eq!(AgentPack::NAME, "agent");
+    assert!(AgentPack::REQUIRES.is_empty());
+    assert!(AgentPack::NOTE_KINDS.is_empty());
+    assert!(AgentPack::ENTITY_KINDS.is_empty());
+}
+
+#[tokio::test]
+async fn spawn_observe_suspend_resume_kill_round_trips() {
+    let (registry, _store) = build_registry();
+
+    let spawn = registry
+        .dispatch(
+            "agent.spawn",
+            serde_json::json!({ "provider": "local", "task": "say hello" }),
+        )
+        .await
+        .expect("agent.spawn dispatches");
+    let agent_id = spawn["agent_id"].as_str().expect("agent_id").to_string();
+    assert_eq!(spawn["state"], "spawned");
+
+    let observed = registry
+        .dispatch("agent.observe", serde_json::json!({ "id": agent_id }))
+        .await
+        .expect("agent.observe dispatches");
+    assert_eq!(observed["state"], "spawned");
+    assert_eq!(observed["provider"], "local");
+    assert!(observed["terminal_reason"].is_null());
+
+    // agent.suspend from `spawned` is not a legal transition — the state
+    // machine only allows it from `running` (ADR-142 §1). Driving `spawned`
+    // to `running` is an automatic transition the provider dispatcher makes,
+    // not something any verb in this pack's surface triggers, so it is out
+    // of reach of this pack-level test.
+    let bad_suspend = registry
+        .dispatch("agent.suspend", serde_json::json!({ "id": agent_id }))
+        .await;
+    assert!(bad_suspend.is_err());
+
+    // agent.kill is legal from `spawned`, `running`, or `suspended`.
+    let kill = registry
+        .dispatch("agent.kill", serde_json::json!({ "id": agent_id }))
+        .await
+        .expect("agent.kill dispatches");
+    assert_eq!(kill["state"], "terminal");
+    assert_eq!(kill["terminal_reason"], "killed");
+
+    // agent.kill on an already-terminal record is a no-op, never an error.
+    let kill_again = registry
+        .dispatch("agent.kill", serde_json::json!({ "id": agent_id }))
+        .await
+        .expect("agent.kill on terminal is a no-op, not an error");
+    assert_eq!(kill_again["state"], "terminal");
+    assert_eq!(kill_again["terminal_reason"], "killed");
+
+    // agent.resume on a terminal record is an illegal-transition error.
+    let resume_terminal = registry
+        .dispatch("agent.resume", serde_json::json!({ "id": agent_id }))
+        .await;
+    assert!(resume_terminal.is_err());
+}
+
+#[tokio::test]
+async fn spawn_validation_failure_is_a_per_operation_error() {
+    let (registry, _store) = build_registry();
+
+    let missing_task = registry
+        .dispatch("agent.spawn", serde_json::json!({ "provider": "local" }))
+        .await;
+    assert!(missing_task.is_err());
+}
+
+#[tokio::test]
+async fn observe_unknown_agent_id_is_a_per_operation_error() {
+    let (registry, _store) = build_registry();
+
+    let err = registry
+        .dispatch(
+            "agent.observe",
+            serde_json::json!({ "id": "00000000-0000-0000-0000-000000000000" }),
+        )
+        .await;
+    assert!(err.is_err());
+}
+
+#[tokio::test]
+async fn suspend_and_resume_round_trip_from_running() {
+    let (registry, store) = build_registry();
+
+    let spawn = registry
+        .dispatch(
+            "agent.spawn",
+            serde_json::json!({ "provider": "local", "task": "long task" }),
+        )
+        .await
+        .expect("agent.spawn dispatches");
+    let agent_id = spawn["agent_id"].as_str().expect("agent_id").to_string();
+
+    // Drive `spawned` -> `running` directly on the store, standing in for
+    // the automatic transition this pack's verb surface does not itself
+    // trigger (ADR-142 §1's transition table, row 2).
+    store
+        .update_state(&agent_id, AgentState::Running, None, 1)
+        .await
+        .expect("mock update_state");
+
+    let suspend = registry
+        .dispatch("agent.suspend", serde_json::json!({ "id": agent_id }))
+        .await
+        .expect("agent.suspend from running dispatches");
+    assert_eq!(suspend["state"], "suspended");
+
+    // agent.suspend on an already-suspended record is a no-op.
+    let suspend_again = registry
+        .dispatch("agent.suspend", serde_json::json!({ "id": agent_id }))
+        .await
+        .expect("agent.suspend on suspended is a no-op, not an error");
+    assert_eq!(suspend_again["state"], "suspended");
+
+    let resume = registry
+        .dispatch("agent.resume", serde_json::json!({ "id": agent_id }))
+        .await
+        .expect("agent.resume from suspended dispatches");
+    assert_eq!(resume["state"], "running");
+
+    // agent.resume on an already-running record is a no-op.
+    let resume_again = registry
+        .dispatch("agent.resume", serde_json::json!({ "id": agent_id }))
+        .await
+        .expect("agent.resume on running is a no-op, not an error");
+    assert_eq!(resume_again["state"], "running");
+}
+
+#[tokio::test]
+async fn a_bad_op_never_prevents_a_good_op_from_succeeding() {
+    // ADR-016: errors are per-operation, never batch-level aborts. The
+    // registry dispatch surface itself is single-op; this proves the two
+    // outcomes are fully independent — one call's failure never poisons
+    // state a following call on the same registry can observe.
+    let (registry, _store) = build_registry();
+
+    let bad = registry
+        .dispatch("agent.spawn", serde_json::json!({ "provider": "local" }))
+        .await;
+    assert!(bad.is_err());
+
+    let good = registry
+        .dispatch(
+            "agent.spawn",
+            serde_json::json!({ "provider": "local", "task": "still works" }),
+        )
+        .await
+        .expect("a prior bad op must not affect this good op");
+    assert_eq!(good["state"], "spawned");
+}
+
+#[tokio::test]
+async fn idempotent_spawn_replay_returns_the_same_record() {
+    let (registry, _store) = build_registry();
+
+    let first = registry
+        .dispatch(
+            "agent.spawn",
+            serde_json::json!({
+                "provider": "local",
+                "task": "idempotent task",
+                "idempotency_key": "key-1",
+            }),
+        )
+        .await
+        .expect("first spawn dispatches");
+
+    let second = registry
+        .dispatch(
+            "agent.spawn",
+            serde_json::json!({
+                "provider": "local",
+                "task": "idempotent task",
+                "idempotency_key": "key-1",
+            }),
+        )
+        .await
+        .expect("replay spawn dispatches");
+
+    assert_eq!(first["agent_id"], second["agent_id"]);
+
+    let mismatched = registry
+        .dispatch(
+            "agent.spawn",
+            serde_json::json!({
+                "provider": "local",
+                "task": "a different task",
+                "idempotency_key": "key-1",
+            }),
+        )
+        .await;
+    assert!(mismatched.is_err());
+}

--- a/crates/khive-runtime/Cargo.toml
+++ b/crates/khive-runtime/Cargo.toml
@@ -15,7 +15,7 @@ description = "Composable Service API: entity/note CRUD, graph traversal, hybrid
 fault-injection = []
 
 [dependencies]
-khive-types = { version = "0.7.0", path = "../khive-types", features = ["serde"] }
+khive-types = { version = "0.7.0", path = "../khive-types", features = ["serde", "blake3"] }
 khive-storage = { version = "0.7.0", path = "../khive-storage" }
 khive-score = { version = "0.7.0", path = "../khive-score" }
 khive-fusion = { version = "0.7.0", path = "../khive-fusion" }

--- a/crates/khive-runtime/src/agent_lifecycle.rs
+++ b/crates/khive-runtime/src/agent_lifecycle.rs
@@ -1,0 +1,469 @@
+//! Pure lifecycle logic for the runtime-owned agent process record (ADR-142 §1).
+//!
+//! No database, no I/O: state transitions and the spawn fingerprint are derived
+//! entirely from in-memory values. `AgentState`, `TerminalReason`, and
+//! `AgentRecord` live in `khive_types` (re-exported here) so `khive-db` and
+//! `khive-pack-agent` can share them without depending on `khive-runtime`.
+
+use khive_types::hash::Hash32;
+pub use khive_types::{AgentRecord, AgentState, TerminalReason};
+
+/// The event driving a lifecycle transition attempt. Distinct from the wire-level verbs
+/// (`agent.spawn`/`agent.resume`/`agent.kill`/`agent.suspend`/`agent.observe`): `Dispatch`,
+/// `Activity`, `Complete`, `Fail`, `Abandon`, and `HostRestart` are runtime-internal triggers
+/// that ADR-142's table drives automatically rather than through a caller-issued verb.
+/// `agent.spawn` itself is not a `Trigger` — it creates a record rather than transitioning
+/// an existing one, so it is out of scope for this function (see the module-level tests).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Trigger {
+    /// The provider begins producing the first turn (`spawned` -> `running`).
+    Dispatch,
+    /// A subsequent round of an already-running turn (`running` -> `running`, timestamp only).
+    Activity,
+    Suspend,
+    Resume,
+    Kill,
+    /// The provider returns its terminal result with no further tool calls pending.
+    Complete,
+    /// An unrecoverable provider or dispatch error.
+    Fail,
+    /// The record's persistent native attachment disconnects without an explicit kill.
+    Abandon,
+    /// Runtime restart boot scan.
+    HostRestart,
+}
+
+/// The outcome of a successful transition attempt, including no-ops.
+///
+/// `changed` distinguishes a genuine state transition from a no-op that returns the
+/// current state unchanged — the no-op rows in ADR-142's table are load-bearing, not
+/// an absence of behavior, so callers must be able to tell the two apart without
+/// re-deriving it from `state`/`terminal_reason` alone.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Transition {
+    pub state: AgentState,
+    pub terminal_reason: Option<TerminalReason>,
+    pub changed: bool,
+}
+
+/// A trigger that is not legal from the given state. Never raised for the ADR's
+/// explicit no-op rows — those return `Ok(Transition { changed: false, .. })` instead.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct IllegalTransition {
+    pub from: AgentState,
+    pub trigger: Trigger,
+}
+
+/// Apply one lifecycle trigger to a record currently in `from` (with `terminal_reason`
+/// if `from` is already `Terminal`), per the transition table in ADR-142 §1.
+pub fn apply_transition(
+    from: AgentState,
+    terminal_reason: Option<TerminalReason>,
+    trigger: Trigger,
+) -> Result<Transition, IllegalTransition> {
+    use AgentState::*;
+    use Trigger::*;
+
+    match (from, trigger) {
+        (Spawned, Dispatch) => Ok(Transition {
+            state: Running,
+            terminal_reason: None,
+            changed: true,
+        }),
+        (Running, Activity) => Ok(Transition {
+            state: Running,
+            terminal_reason: None,
+            changed: false,
+        }),
+
+        (Running, Suspend) => Ok(Transition {
+            state: Suspended,
+            terminal_reason: None,
+            changed: true,
+        }),
+        (Suspended, Suspend) => Ok(Transition {
+            state: Suspended,
+            terminal_reason: None,
+            changed: false,
+        }),
+
+        (Suspended, Resume) => Ok(Transition {
+            state: Running,
+            terminal_reason: None,
+            changed: true,
+        }),
+        (Running, Resume) => Ok(Transition {
+            state: Running,
+            terminal_reason: None,
+            changed: false,
+        }),
+
+        (Spawned, Kill) | (Running, Kill) | (Suspended, Kill) => Ok(Transition {
+            state: Terminal,
+            terminal_reason: Some(TerminalReason::Killed),
+            changed: true,
+        }),
+        (Terminal, Kill) => Ok(Transition {
+            state: Terminal,
+            terminal_reason,
+            changed: false,
+        }),
+
+        (Running, Complete) => Ok(Transition {
+            state: Terminal,
+            terminal_reason: Some(TerminalReason::Completed),
+            changed: true,
+        }),
+        (Running, Fail) => Ok(Transition {
+            state: Terminal,
+            terminal_reason: Some(TerminalReason::Failed),
+            changed: true,
+        }),
+        (Running, Abandon) => Ok(Transition {
+            state: Terminal,
+            terminal_reason: Some(TerminalReason::Abandoned),
+            changed: true,
+        }),
+
+        (Spawned, HostRestart) | (Running, HostRestart) | (Suspended, HostRestart) => {
+            Ok(Transition {
+                state: Terminal,
+                terminal_reason: Some(TerminalReason::HostRestart),
+                changed: true,
+            })
+        }
+        (Terminal, HostRestart) => Ok(Transition {
+            state: Terminal,
+            terminal_reason,
+            changed: false,
+        }),
+
+        _ => Err(IllegalTransition { from, trigger }),
+    }
+}
+
+/// Canonical digest of a spawn's compared argument set (ADR-142 §1, "Persistent process
+/// record"): `provider`, `task`, `provider_session_id`, `checkpoint_session_id`, in that
+/// key order, absent optionals omitted entirely rather than written as `null`. `idempotency_key`
+/// is excluded — it is the replay lookup key, not compared content.
+///
+/// The key order is built by hand rather than through a `serde_json::Map`/`Value::Object`
+/// because `serde_json`'s default map type sorts keys alphabetically (BTreeMap) unless the
+/// crate-wide `preserve_order` feature is enabled elsewhere in the dependency graph; hand-
+/// ordering keeps this digest's byte layout independent of that feature flag. Digested with
+/// BLAKE3 (`khive_types::hash::Hash32`), the same content-hash primitive `khive-db` uses for
+/// content-addressed blob refs.
+pub fn spawn_fingerprint(
+    provider: &str,
+    task: &str,
+    provider_session_id: Option<&str>,
+    checkpoint_session_id: Option<&str>,
+) -> String {
+    let mut fields: Vec<(&str, &str)> = vec![("provider", provider), ("task", task)];
+    if let Some(value) = provider_session_id {
+        fields.push(("provider_session_id", value));
+    }
+    if let Some(value) = checkpoint_session_id {
+        fields.push(("checkpoint_session_id", value));
+    }
+
+    let mut canonical = String::from("{");
+    for (index, (key, value)) in fields.iter().enumerate() {
+        if index > 0 {
+            canonical.push(',');
+        }
+        canonical.push_str(&serde_json::to_string(key).expect("string key always serializes"));
+        canonical.push(':');
+        canonical.push_str(&serde_json::to_string(value).expect("string value always serializes"));
+    }
+    canonical.push('}');
+
+    Hash32::from_blake3(canonical.as_bytes()).to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // -- spawn: (none) -> spawned, via agent.spawn --------------------------------------
+    //
+    // Record creation, not a transition of an existing record, so it has no
+    // `apply_transition` case; `spawn_fingerprint` below covers its comparison logic.
+
+    // -- spawned -> running, via dispatch start (automatic) ------------------------------
+
+    #[test]
+    fn dispatch_from_spawned_transitions_to_running() {
+        let outcome = apply_transition(AgentState::Spawned, None, Trigger::Dispatch).unwrap();
+        assert_eq!(outcome.state, AgentState::Running);
+        assert_eq!(outcome.terminal_reason, None);
+        assert!(outcome.changed, "spawned -> running is a real transition");
+    }
+
+    // -- running -> running, subsequent round (no state change) --------------------------
+
+    #[test]
+    fn activity_on_running_is_a_no_op() {
+        let outcome = apply_transition(AgentState::Running, None, Trigger::Activity).unwrap();
+        assert_eq!(outcome.state, AgentState::Running);
+        assert!(
+            !outcome.changed,
+            "activity on running must be a no-op, not a transition"
+        );
+    }
+
+    // -- running -> suspended, via agent.suspend; suspended -> suspended no-op -----------
+
+    #[test]
+    fn suspend_from_running_transitions_to_suspended() {
+        let outcome = apply_transition(AgentState::Running, None, Trigger::Suspend).unwrap();
+        assert_eq!(outcome.state, AgentState::Suspended);
+        assert!(outcome.changed, "running -> suspended is a real transition");
+    }
+
+    #[test]
+    fn suspend_on_already_suspended_is_a_no_op_not_an_error() {
+        let outcome = apply_transition(AgentState::Suspended, None, Trigger::Suspend).unwrap();
+        assert_eq!(outcome.state, AgentState::Suspended);
+        assert!(!outcome.changed, "suspend on suspended must be a no-op");
+    }
+
+    // -- suspended -> running, via agent.resume; running -> running no-op ----------------
+
+    #[test]
+    fn resume_from_suspended_transitions_to_running() {
+        let outcome = apply_transition(AgentState::Suspended, None, Trigger::Resume).unwrap();
+        assert_eq!(outcome.state, AgentState::Running);
+        assert!(outcome.changed, "suspended -> running is a real transition");
+    }
+
+    #[test]
+    fn resume_on_running_is_a_no_op_not_an_error() {
+        let outcome = apply_transition(AgentState::Running, None, Trigger::Resume).unwrap();
+        assert_eq!(outcome.state, AgentState::Running);
+        assert!(!outcome.changed, "resume on running must be a no-op");
+    }
+
+    #[test]
+    fn resume_on_spawned_is_an_illegal_transition_error() {
+        let err = apply_transition(AgentState::Spawned, None, Trigger::Resume).unwrap_err();
+        assert_eq!(
+            err,
+            IllegalTransition {
+                from: AgentState::Spawned,
+                trigger: Trigger::Resume,
+            }
+        );
+    }
+
+    #[test]
+    fn resume_on_terminal_is_an_illegal_transition_error() {
+        let err = apply_transition(
+            AgentState::Terminal,
+            Some(TerminalReason::Completed),
+            Trigger::Resume,
+        )
+        .unwrap_err();
+        assert_eq!(
+            err,
+            IllegalTransition {
+                from: AgentState::Terminal,
+                trigger: Trigger::Resume,
+            }
+        );
+    }
+
+    // -- {spawned, running, suspended} -> terminal(killed), via agent.kill ---------------
+    // -- terminal -> terminal, kill is a no-op, NEVER an error ---------------------------
+
+    #[test]
+    fn kill_from_spawned_transitions_to_terminal_killed() {
+        let outcome = apply_transition(AgentState::Spawned, None, Trigger::Kill).unwrap();
+        assert_eq!(outcome.state, AgentState::Terminal);
+        assert_eq!(outcome.terminal_reason, Some(TerminalReason::Killed));
+        assert!(outcome.changed);
+    }
+
+    #[test]
+    fn kill_from_running_transitions_to_terminal_killed() {
+        let outcome = apply_transition(AgentState::Running, None, Trigger::Kill).unwrap();
+        assert_eq!(outcome.state, AgentState::Terminal);
+        assert_eq!(outcome.terminal_reason, Some(TerminalReason::Killed));
+        assert!(outcome.changed);
+    }
+
+    #[test]
+    fn kill_from_suspended_transitions_to_terminal_killed() {
+        let outcome = apply_transition(AgentState::Suspended, None, Trigger::Kill).unwrap();
+        assert_eq!(outcome.state, AgentState::Terminal);
+        assert_eq!(outcome.terminal_reason, Some(TerminalReason::Killed));
+        assert!(outcome.changed);
+    }
+
+    #[test]
+    fn kill_on_terminal_is_a_no_op_that_returns_current_state_never_an_error() {
+        let outcome = apply_transition(
+            AgentState::Terminal,
+            Some(TerminalReason::Completed),
+            Trigger::Kill,
+        )
+        .expect("kill on terminal must be Ok, never Err");
+        assert_eq!(outcome.state, AgentState::Terminal);
+        assert_eq!(outcome.terminal_reason, Some(TerminalReason::Completed));
+        assert!(!outcome.changed, "kill on terminal must be a no-op");
+    }
+
+    // -- running -> terminal(completed), provider returns with no pending tool calls -----
+
+    #[test]
+    fn complete_from_running_transitions_to_terminal_completed() {
+        let outcome = apply_transition(AgentState::Running, None, Trigger::Complete).unwrap();
+        assert_eq!(outcome.state, AgentState::Terminal);
+        assert_eq!(outcome.terminal_reason, Some(TerminalReason::Completed));
+        assert!(outcome.changed);
+    }
+
+    // -- running -> terminal(failed), unrecoverable provider or dispatch error -----------
+
+    #[test]
+    fn fail_from_running_transitions_to_terminal_failed() {
+        let outcome = apply_transition(AgentState::Running, None, Trigger::Fail).unwrap();
+        assert_eq!(outcome.state, AgentState::Terminal);
+        assert_eq!(outcome.terminal_reason, Some(TerminalReason::Failed));
+        assert!(outcome.changed);
+    }
+
+    // -- running -> terminal(abandoned), persistent attachment disconnects ---------------
+
+    #[test]
+    fn abandon_from_running_transitions_to_terminal_abandoned() {
+        let outcome = apply_transition(AgentState::Running, None, Trigger::Abandon).unwrap();
+        assert_eq!(outcome.state, AgentState::Terminal);
+        assert_eq!(outcome.terminal_reason, Some(TerminalReason::Abandoned));
+        assert!(outcome.changed);
+    }
+
+    // -- {spawned, running, suspended} -> terminal(host_restart), boot scan --------------
+
+    #[test]
+    fn host_restart_from_spawned_transitions_to_terminal_host_restart() {
+        let outcome = apply_transition(AgentState::Spawned, None, Trigger::HostRestart).unwrap();
+        assert_eq!(outcome.state, AgentState::Terminal);
+        assert_eq!(outcome.terminal_reason, Some(TerminalReason::HostRestart));
+        assert!(outcome.changed);
+    }
+
+    #[test]
+    fn host_restart_from_running_transitions_to_terminal_host_restart() {
+        let outcome = apply_transition(AgentState::Running, None, Trigger::HostRestart).unwrap();
+        assert_eq!(outcome.state, AgentState::Terminal);
+        assert_eq!(outcome.terminal_reason, Some(TerminalReason::HostRestart));
+        assert!(outcome.changed);
+    }
+
+    #[test]
+    fn host_restart_from_suspended_transitions_to_terminal_host_restart() {
+        let outcome = apply_transition(AgentState::Suspended, None, Trigger::HostRestart).unwrap();
+        assert_eq!(outcome.state, AgentState::Terminal);
+        assert_eq!(outcome.terminal_reason, Some(TerminalReason::HostRestart));
+        assert!(outcome.changed);
+    }
+
+    #[test]
+    fn host_restart_on_terminal_is_a_no_op_boot_scan_only_touches_non_terminal() {
+        let outcome = apply_transition(
+            AgentState::Terminal,
+            Some(TerminalReason::Failed),
+            Trigger::HostRestart,
+        )
+        .expect("host_restart on an already-terminal record must be Ok");
+        assert_eq!(outcome.state, AgentState::Terminal);
+        assert_eq!(outcome.terminal_reason, Some(TerminalReason::Failed));
+        assert!(!outcome.changed);
+    }
+
+    // -- transitions the table does not license are illegal-transition errors -----------
+
+    #[test]
+    fn suspend_on_spawned_is_an_illegal_transition_error() {
+        let err = apply_transition(AgentState::Spawned, None, Trigger::Suspend).unwrap_err();
+        assert_eq!(
+            err,
+            IllegalTransition {
+                from: AgentState::Spawned,
+                trigger: Trigger::Suspend,
+            }
+        );
+    }
+
+    #[test]
+    fn suspend_on_terminal_is_an_illegal_transition_error() {
+        let err = apply_transition(
+            AgentState::Terminal,
+            Some(TerminalReason::Completed),
+            Trigger::Suspend,
+        )
+        .unwrap_err();
+        assert_eq!(
+            err,
+            IllegalTransition {
+                from: AgentState::Terminal,
+                trigger: Trigger::Suspend,
+            }
+        );
+    }
+
+    #[test]
+    fn complete_on_suspended_is_an_illegal_transition_error() {
+        let err = apply_transition(AgentState::Suspended, None, Trigger::Complete).unwrap_err();
+        assert_eq!(
+            err,
+            IllegalTransition {
+                from: AgentState::Suspended,
+                trigger: Trigger::Complete,
+            }
+        );
+    }
+
+    // -- spawn_fingerprint -----------------------------------------------------------------
+
+    #[test]
+    fn fingerprint_omitting_absent_optional_matches_the_same_call_shape() {
+        let a = spawn_fingerprint("anthropic", "do the thing", None, None);
+        let b = spawn_fingerprint("anthropic", "do the thing", None, None);
+        assert_eq!(a, b, "identical input must digest identically");
+    }
+
+    #[test]
+    fn fingerprint_absent_optional_differs_from_present_optional() {
+        let without = spawn_fingerprint("anthropic", "do the thing", None, None);
+        let with_session = spawn_fingerprint("anthropic", "do the thing", Some("sess-1"), None);
+        assert_ne!(
+            without, with_session,
+            "an omitted optional must not digest the same as a present one"
+        );
+    }
+
+    #[test]
+    fn fingerprint_changing_task_changes_the_digest() {
+        let original = spawn_fingerprint("anthropic", "do the thing", None, None);
+        let changed = spawn_fingerprint("anthropic", "do a different thing", None, None);
+        assert_ne!(original, changed, "changing task must change the digest");
+    }
+
+    #[test]
+    fn fingerprint_is_stable_across_both_optionals_present() {
+        let a = spawn_fingerprint("anthropic", "do the thing", Some("sess-1"), Some("chk-1"));
+        let b = spawn_fingerprint("anthropic", "do the thing", Some("sess-1"), Some("chk-1"));
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn fingerprint_field_order_is_not_confused_with_adjacent_field_content() {
+        // provider="a", task="bc" must not collide with provider="ab", task="c" — each
+        // field is length-prefixed by JSON string encoding, not naively concatenated.
+        let first = spawn_fingerprint("a", "bc", None, None);
+        let second = spawn_fingerprint("ab", "c", None, None);
+        assert_ne!(first, second);
+    }
+}

--- a/crates/khive-runtime/src/agent_lifecycle.rs
+++ b/crates/khive-runtime/src/agent_lifecycle.rs
@@ -18,7 +18,8 @@ pub use khive_types::{AgentRecord, AgentState, TerminalReason};
 pub enum Trigger {
     /// The provider begins producing the first turn (`spawned` -> `running`).
     Dispatch,
-    /// A subsequent round of an already-running turn (`running` -> `running`, timestamp only).
+    /// A subsequent round of an already-running turn (`running` -> `running`, a no-op:
+    /// no state change is persisted and `state_changed_at` is not refreshed).
     Activity,
     Suspend,
     Resume,

--- a/crates/khive-runtime/src/lib.rs
+++ b/crates/khive-runtime/src/lib.rs
@@ -3,6 +3,7 @@
 //! Wraps `StorageBackend` and query compilation into a single Rust API surface.
 
 pub mod actor_identity;
+pub mod agent_lifecycle;
 pub mod atomic_message;
 pub mod atomic_plan;
 pub mod atomic_prepare;
@@ -36,6 +37,10 @@ pub use khive_storage::usage;
 pub mod validation;
 
 pub use actor_identity::{actor_is_unattributed, resolve_actor, should_warn_unattributed_actor};
+pub use agent_lifecycle::{
+    apply_transition, spawn_fingerprint, AgentRecord, AgentState, IllegalTransition,
+    TerminalReason, Transition, Trigger,
+};
 pub use atomic_message::{create_notes_atomic, create_notes_atomic_with_report, AtomicNoteSpec};
 pub use atomic_plan::{
     AddEntityPlan, AddNotePlan, AffectedRowGuard, DeletePlan, GovernanceOp, GovernancePlan,

--- a/crates/khive-storage/src/agent.rs
+++ b/crates/khive-storage/src/agent.rs
@@ -1,0 +1,37 @@
+//! Agent process store capability (ADR-142 §1, "Process model").
+
+use async_trait::async_trait;
+use khive_types::{AgentRecord, AgentState, TerminalReason};
+
+use crate::error::StorageError;
+
+/// Durable storage for runtime-owned agent process records.
+#[async_trait]
+pub trait AgentStore: Send + Sync {
+    async fn insert(&self, record: &AgentRecord) -> Result<(), StorageError>;
+    async fn get(&self, agent_id: &str) -> Result<Option<AgentRecord>, StorageError>;
+    async fn update_state(
+        &self,
+        agent_id: &str,
+        state: AgentState,
+        terminal_reason: Option<TerminalReason>,
+        state_changed_at: i64,
+    ) -> Result<(), StorageError>;
+    async fn set_checkpoint(
+        &self,
+        agent_id: &str,
+        checkpoint_session_id: &str,
+        checkpoint_cursor: i64,
+    ) -> Result<(), StorageError>;
+    async fn find_by_idempotency(
+        &self,
+        owner_actor: &str,
+        idempotency_key: &str,
+    ) -> Result<Option<AgentRecord>, StorageError>;
+    async fn find_non_terminal_by_provider_session(
+        &self,
+        provider: &str,
+        provider_session_id: &str,
+    ) -> Result<Option<AgentRecord>, StorageError>;
+    async fn terminate_all_non_terminal(&self, state_changed_at: i64) -> Result<u64, StorageError>;
+}

--- a/crates/khive-storage/src/lib.rs
+++ b/crates/khive-storage/src/lib.rs
@@ -1,5 +1,6 @@
 //! Storage capability traits: `SqlAccess`, `VectorStore`, `TextSearch`, `GraphStore`, `NoteStore`, `EventStore`, `BlobStore`.
 
+pub mod agent;
 pub mod blob;
 pub mod capability;
 pub mod entity;
@@ -16,6 +17,7 @@ pub mod types;
 pub mod usage;
 pub mod vectors;
 
+pub use agent::AgentStore;
 pub use blob::{BlobOrphanSweepConfig, BlobOrphanSweepResult, BlobStore, ContentRef};
 pub use capability::StorageCapability;
 pub use entity::{Entity, EntityFilter, EntityStore};
@@ -53,4 +55,7 @@ pub use types::{
     MAX_TRAVERSAL_ROOTS, MAX_TRAVERSAL_WORK,
 };
 
-pub use khive_types::{EdgeCategory, EdgeRelation, EventOutcome, SubstrateKind};
+pub use khive_types::{
+    AgentRecord, AgentState, EdgeCategory, EdgeRelation, EventOutcome, SubstrateKind,
+    TerminalReason,
+};

--- a/crates/khive-types/src/agent.rs
+++ b/crates/khive-types/src/agent.rs
@@ -1,0 +1,52 @@
+//! Agent process lifecycle types (ADR-142 §1, "Persistent process record").
+
+extern crate alloc;
+use alloc::string::String;
+use alloc::vec::Vec;
+
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
+/// One of the four lifecycle states an agent process record can occupy.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
+pub enum AgentState {
+    Spawned,
+    Running,
+    Suspended,
+    Terminal,
+}
+
+/// Why a record reached `Terminal`. Set exactly once, at the transition into `Terminal`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
+pub enum TerminalReason {
+    Completed,
+    Failed,
+    Killed,
+    Abandoned,
+    HostRestart,
+}
+
+/// The runtime-owned agent process record (ADR-142 §1, "Persistent process record").
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub struct AgentRecord {
+    pub agent_id: String,
+    pub state: AgentState,
+    pub terminal_reason: Option<TerminalReason>,
+    pub provider: String,
+    pub provider_session_id: Option<String>,
+    pub checkpoint_session_id: Option<String>,
+    pub checkpoint_cursor: Option<i64>,
+    pub owner_actor: String,
+    pub owner_peer_class: String,
+    pub owner_write_namespace: String,
+    pub owner_visible_namespaces: Vec<String>,
+    pub spawn_fingerprint: String,
+    pub spawned_at: i64,
+    pub state_changed_at: i64,
+    pub idempotency_key: Option<String>,
+}

--- a/crates/khive-types/src/lib.rs
+++ b/crates/khive-types/src/lib.rs
@@ -12,6 +12,7 @@ extern crate alloc;
 #[cfg(feature = "std")]
 extern crate std;
 
+pub mod agent;
 pub mod edge;
 pub mod entity;
 pub mod entity_type;
@@ -28,6 +29,7 @@ pub mod substrate;
 pub mod timestamp;
 pub mod vector;
 
+pub use agent::{AgentRecord, AgentState, TerminalReason};
 pub use edge::{EdgeCategory, EdgeRelation};
 pub use entity::{Entity, EntityKind, Link, PropertyValue};
 pub use entity_type::{EntityTypeDef, EntityTypeError, EntityTypeRegistry, ResolvedEntityType};


### PR DESCRIPTION
Implements the agent process runtime per ADR-142: persistent agent records in a runtime-owned table (enum-checked columns; partial unique indexes for one-non-terminal-per-provider-session and per-owner idempotency), shared types in khive-types and the AgentStore trait in khive-storage (matching GraphStore/NoteStore/EventStore convention), a single normative transition function covering every row of the lifecycle table including no-op and illegal-transition arms, canonical spawn fingerprinting, and the khive-pack-agent verb pack (agent.spawn/observe/suspend/resume/kill) whose handlers delegate all legality decisions to that one transition function.

Testing: 10 store tests (including the actor-scoped idempotency pair test and provider-session uniqueness incl. suspended holders), 27 lifecycle tests (every transition-table row; mutation-checked — inverting the five no-op/error rows reddens exactly the five predicted tests), 7 pack integration tests through a real VerbRegistry dispatch, plus doc builds clean under -D warnings. Full workspace check passes.