### PR TITLE
fix(comm): reject sends onto an unresolvable thread_id

### DIFF
--- a/crates/khive-pack-comm/docs/api/message-lifecycle.md
+++ b/crates/khive-pack-comm/docs/api/message-lifecycle.md
@@ -57,6 +57,16 @@ When `thread_id` is already supplied, the handler first parses it and serializes
 the UUID in full-hyphenated form, then forwards that canonical value unchanged
 to both copies.
 
+A supplied `thread_id` must also resolve to an existing thread (issue #1673):
+at least one live `message` note in the caller's namespace must carry that
+`thread_id`, checked against the same spelling set `comm.thread` probes. Shape
+validation alone would accept any UUID-shaped value, and a send onto a root no
+note carries would succeed silently while no reader could ever reconstruct the
+thread — the failure would degrade the shared artifact (a reply missing from
+its conversation) rather than the caller's state. An unresolvable `thread_id`
+is therefore rejected with an invalid-input error naming the id, and no
+message row is persisted. Omit `thread_id` to start a new thread.
+
 `in_reply_to_message_id` is the parent's wire Message-ID (angle-bracketed),
 when this write is a reply to a message with a known one (issue #403). It is
 stored verbatim on both copies as `in_reply_to_message_id`; the outbox

--- a/crates/khive-pack-comm/src/handlers.rs
+++ b/crates/khive-pack-comm/src/handlers.rs
@@ -84,6 +84,59 @@ fn canonicalize_thread_id(verb: &str, raw: &str) -> Result<String, RuntimeError>
         })
 }
 
+/// Fail-closed resolution for a caller-supplied thread root (issue #1673):
+/// shape validation alone accepts any UUID-shaped value, and an unresolvable
+/// one strands the new message — `comm.thread` cannot reconstruct a thread
+/// whose root row no live note points at, so the phantom send would succeed
+/// silently while no reader could ever see the conversation whole. A supplied
+/// root therefore has to resolve to at least one live `message` note in the
+/// caller's namespace carrying that `thread_id` (probing the alternate
+/// spellings a pre-v1 handler could have stored, exactly as thread lookup
+/// does), or the send is rejected and nothing is persisted.
+async fn require_existing_thread_root(
+    runtime: &KhiveRuntime,
+    token: &NamespaceToken,
+    verb: &str,
+    canonical_thread_id: &str,
+) -> Result<(), RuntimeError> {
+    let root_uuid = canonical_thread_id
+        .parse::<Uuid>()
+        .expect("canonicalize_thread_id produced this value from a parsed UUID");
+    let spellings = thread_id_query_spellings(root_uuid, None)
+        .into_iter()
+        .map(SqlValue::Text)
+        .collect();
+    let filter = NoteFilter {
+        kind: Some("message".to_string()),
+        property_filters: vec![PropertyFilter {
+            json_path: "$.thread_id".to_string(),
+            op: FilterOp::In(spellings),
+            value: SqlValue::Null,
+        }],
+        ..Default::default()
+    };
+    let store = runtime.notes(token)?;
+    let page = store
+        .query_notes_filtered(
+            token.namespace().as_str(),
+            &filter,
+            PageRequest {
+                limit: 1,
+                offset: 0,
+            },
+        )
+        .await?;
+    if page.items.is_empty() {
+        return Err(RuntimeError::InvalidInput(format!(
+            "{verb}: `thread_id` {canonical_thread_id:?} does not resolve to an existing \
+             thread: no live message in this namespace carries that thread_id. Refusing to \
+             strand the message on a phantom thread -- omit `thread_id` to \
+             start a new thread, or pass the `full_id` of an existing message (see comm.thread)."
+        )));
+    }
+    Ok(())
+}
+
 fn validate_inbox_substring(field: &str, value: Option<&str>) -> Result<(), RuntimeError> {
     if value.is_some_and(|raw| raw.trim().is_empty()) {
         return Err(RuntimeError::InvalidInput(format!(
@@ -208,6 +261,9 @@ pub(crate) async fn handle_send(
         .as_deref()
         .map(|raw| canonicalize_thread_id("send", raw))
         .transpose()?;
+    if let Some(ref tid) = thread_id {
+        require_existing_thread_root(runtime, token, "send", tid).await?;
+    }
 
     let caller_ns = token.namespace().as_str().to_string();
     let from_actor = token.actor().id.clone();

--- a/crates/khive-pack-comm/tests/integration.rs
+++ b/crates/khive-pack-comm/tests/integration.rs
@@ -1588,22 +1588,33 @@ async fn test_inbox_returns_self_send_as_inbound() {
 async fn test_list_message_thread_id_filter() {
     let (send_registry, rt) = build_registry_for_ns("lambda:khive");
 
-    // Send two messages — one with a thread_id, one without.
-    let msg1 = send_registry
+    // Establish a real thread root, then send one message onto it and one
+    // outside it (a fabricated thread_id is rejected at the send boundary,
+    // so the filter fixture must thread onto an existing root).
+    let root = send_registry
+        .dispatch(
+            "comm.send",
+            serde_json::json!({ "to": "lambda:khive", "content": "thread root" }),
+        )
+        .await
+        .expect("send root succeeds");
+    let thread_id = root
+        .get("full_id")
+        .and_then(|v| v.as_str())
+        .expect("root full_id")
+        .to_string();
+
+    send_registry
         .dispatch(
             "comm.send",
             serde_json::json!({
                 "to": "lambda:khive",
                 "content": "threaded message",
-                "thread_id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+                "thread_id": thread_id
             }),
         )
         .await
-        .expect("send msg1 succeeds");
-    let _thread_id = msg1
-        .get("full_id")
-        .and_then(|v| v.as_str())
-        .expect("msg1 full_id");
+        .expect("send threaded message succeeds");
 
     send_registry
         .dispatch(
@@ -1625,14 +1636,19 @@ async fn test_list_message_thread_id_filter() {
             "list",
             serde_json::json!({
                 "kind": "message",
-                "thread_id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+                "thread_id": thread_id
             }),
         )
         .await
         .expect("list with thread_id filter succeeds");
 
     let items = result.as_array().expect("list returns an array");
-    // Every returned message must have the requested thread_id.
+    // The filter must actually select rows (a vacuously empty pass proves
+    // nothing) and every returned message must carry the requested thread_id.
+    assert!(
+        !items.is_empty(),
+        "CC-2 C1 regression: list(thread_id=X) returned no rows for a thread with a live message"
+    );
     for item in items {
         let stored_thread = item
             .get("properties")
@@ -1640,7 +1656,7 @@ async fn test_list_message_thread_id_filter() {
             .and_then(|v| v.as_str())
             .unwrap_or("");
         assert_eq!(
-            stored_thread, "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+            stored_thread, thread_id,
             "CC-2 C1 regression: list(thread_id=X) must only return messages in that thread; got {item}"
         );
     }
@@ -3073,6 +3089,119 @@ async fn send_rejects_malformed_thread_id() {
     assert!(
         err.is_err(),
         "send with malformed thread_id must fail; got: {err:?}"
+    );
+}
+
+/// send with a UUID-shaped but unresolvable thread_id must fail closed (issue
+/// #1673): the error names the unresolvable id and no message row is persisted.
+#[tokio::test]
+async fn send_rejects_unresolvable_thread_id() {
+    use khive_storage::note::{FilterOp, NoteFilter, PropertyFilter};
+    use khive_storage::types::PageRequest;
+
+    let (registry, rt) = build_registry_for_ns("local");
+
+    let phantom_thread_id = uuid::Uuid::new_v4().as_hyphenated().to_string();
+    let err = registry
+        .dispatch(
+            "comm.send",
+            serde_json::json!({
+                "to": "local",
+                "content": "stranded reply",
+                "thread_id": phantom_thread_id,
+            }),
+        )
+        .await
+        .expect_err("send with a thread_id no message carries must fail");
+    let err_text = format!("{err:?}");
+    assert!(
+        err_text.contains(&phantom_thread_id),
+        "the error must name the unresolvable thread_id {phantom_thread_id:?}; got {err_text}"
+    );
+
+    let token = rt.authorize(Namespace::local()).expect("local token");
+    let store = rt.notes(&token).expect("note store");
+    let stranded_filter = NoteFilter {
+        kind: Some("message".to_string()),
+        property_filters: vec![PropertyFilter {
+            json_path: "$.thread_id".to_string(),
+            op: FilterOp::Eq,
+            value: SqlValue::Text(phantom_thread_id.clone()),
+        }],
+        ..Default::default()
+    };
+    let stranded = store
+        .query_notes_filtered("local", &stranded_filter, PageRequest::default())
+        .await
+        .expect("filtered query");
+    assert!(
+        stranded.items.is_empty(),
+        "a rejected send must leave no message row behind; got {:?}",
+        stranded
+            .items
+            .iter()
+            .map(|n| &n.content)
+            .collect::<Vec<_>>()
+    );
+    let all = rt
+        .list_notes(&token, Some("message"), 100, 0)
+        .await
+        .expect("list messages");
+    assert!(
+        all.is_empty(),
+        "a rejected send must persist nothing at all; got {:?}",
+        all.iter().map(|n| &n.content).collect::<Vec<_>>()
+    );
+}
+
+/// send with a thread_id that resolves to an existing thread must still
+/// thread correctly (issue #1673 must not regress legitimate threading).
+#[tokio::test]
+async fn send_accepts_resolvable_thread_id() {
+    let (registry, _rt) = build_registry_for_ns("local");
+
+    let root = registry
+        .dispatch(
+            "comm.send",
+            serde_json::json!({ "to": "local", "content": "root message" }),
+        )
+        .await
+        .expect("root send succeeds");
+    let root_id = root
+        .get("full_id")
+        .and_then(|v| v.as_str())
+        .expect("full_id present")
+        .to_string();
+
+    registry
+        .dispatch(
+            "comm.send",
+            serde_json::json!({
+                "to": "local",
+                "content": "threaded follow-up",
+                "thread_id": root_id,
+            }),
+        )
+        .await
+        .expect("send threaded onto an existing root must succeed");
+
+    let thread = registry
+        .dispatch("comm.thread", serde_json::json!({ "id": root_id }))
+        .await
+        .expect("thread lookup succeeds");
+    let messages = thread["messages"].as_array().expect("messages array");
+    for expected_content in ["root message", "threaded follow-up"] {
+        assert!(
+            messages
+                .iter()
+                .any(|message| message["content"].as_str() == Some(expected_content)),
+            "thread must contain {expected_content:?}; got {thread}"
+        );
+    }
+    assert_eq!(
+        thread["thread_id"].as_str(),
+        Some(root_id.as_str()),
+        "the follow-up must land on the supplied root thread; got {thread}"
     );
 }
 


### PR DESCRIPTION
## Problem

`comm.send` validated `thread_id` by shape only (UUID parse) and forwarded it verbatim into the dual write. A fabricated UUID-shaped value was accepted silently and the message stranded on a phantom thread: `comm.thread` on that id fails because no live root resolves, and nothing signals the caller.

Closes #1673.

## Change

Fail closed at the send boundary: a supplied `thread_id` that resolves to no live message root in the caller's namespace returns a per-operation invalid-input error naming the id, and nothing is persisted. All stored spellings (compact, braced, URN, upper-hex) are probed via the same helper the thread reader uses, in one indexed query. Omitting `thread_id` still starts a new thread; `comm.reply` is unaffected (it derives the root from the resolved parent).

Scope: the ingest path deliberately keeps lax acceptance — inbound transport threading must not hard-fail on roots the store has never seen; phantom-root rejection there is a separate decision.

The pre-existing list-filter fixture fabricated a thread_id and relied on the lax behavior; it now threads onto a real root and asserts the filter selects non-vacuously.

## Tests

Phantom `thread_id` rejects with the id in the error and leaves no message rows behind (absence asserted). A resolvable `thread_id` still threads correctly and `comm.thread` returns both messages. Existing canonicalization and shape-validation coverage unchanged.

`cargo test -p khive-pack-comm`: 294 passing. Clippy clean with `-D warnings`.