### PR TITLE
fix(code): keep imported names from dotless relative imports

### DIFF
--- a/crates/khive-pack-code/src/imports.rs
+++ b/crates/khive-pack-code/src/imports.rs
@@ -39,7 +39,9 @@ fn python_import_re() -> &'static Regex {
 
 fn python_from_re() -> &'static Regex {
     static RE: OnceLock<Regex> = OnceLock::new();
-    RE.get_or_init(|| Regex::new(r"(?m)^\s*from\s+([.]*[A-Za-z0-9_.]*)\s+import").unwrap())
+    RE.get_or_init(|| {
+        Regex::new(r"(?m)^\s*from\s+([.]*[A-Za-z0-9_.]*)\s+import\s+([^\n#;]+)").unwrap()
+    })
 }
 
 fn ts_import_re() -> &'static Regex {
@@ -50,6 +52,23 @@ fn ts_import_re() -> &'static Regex {
 fn ts_require_re() -> &'static Regex {
     static RE: OnceLock<Regex> = OnceLock::new();
     RE.get_or_init(|| Regex::new(r#"require\(\s*['"]([^'"]+)['"]\s*\)"#).unwrap())
+}
+
+/// The plain names bound by a `from ... import <names>` clause: splits on
+/// commas, drops `as` aliases and empty entries, and stops before `*` or any
+/// parenthesized form (neither names a resolvable module).
+fn python_imported_names(names: &str) -> Vec<&str> {
+    names
+        .split(',')
+        .filter_map(|part| part.split_whitespace().next())
+        .filter(|name| {
+            !name.is_empty()
+                && *name != "*"
+                && name
+                    .chars()
+                    .all(|ch| ch.is_ascii_alphanumeric() || ch == '_')
+        })
+        .collect()
 }
 
 /// Extract raw, unclassified import specifiers from `content`.
@@ -69,7 +88,33 @@ pub(crate) fn extract_raw_imports(language: &str, content: &str) -> Vec<String> 
                 out.push(c[1].to_string());
             }
             for c in python_from_re().captures_iter(content) {
-                out.push(c[1].to_string());
+                let module = c[1].to_string();
+                if module.chars().all(|ch| ch == '.') {
+                    // A dots-only specifier names only the containing
+                    // package: for `from . import z` the imported name *is*
+                    // the target module, so emit one specifier per name for
+                    // `classify_python` to resolve against the package base.
+                    // Attribute imports (`from . import run` where `run` is a
+                    // function) resolve to their containing module via the
+                    // resolver's longest-prefix fallback
+                    // (`module_candidate_specifiers`). When no plain name can
+                    // be extracted (star or parenthesized forms), fall back to
+                    // the bare package specifier so the pre-expansion behavior
+                    // is preserved rather than dropping the reference.
+                    let names = python_imported_names(&c[2]);
+                    if names.is_empty() {
+                        out.push(module);
+                    } else {
+                        for name in names {
+                            out.push(format!("{module}{name}"));
+                        }
+                    }
+                } else {
+                    // `from .mod import ...` / `from pkg.mod import ...`: the
+                    // module specifier already names the target — keep the
+                    // imported names out of the specifier.
+                    out.push(module);
+                }
             }
         }
         "typescript" => {
@@ -212,6 +257,9 @@ fn classify_python(
         if base.is_empty() {
             return Resolved::Skip;
         }
+        // A raw specifier that is still dots-only here (`from . import` with
+        // no resolvable names, e.g. a star or parenthesized import) names the
+        // package itself.
         let target = if rest.is_empty() {
             base.join(".")
         } else {
@@ -423,13 +471,45 @@ mod tests {
             classify_import("python", "..a", "pkg.x", "pkg", true),
             Resolved::IntraModule("pkg.a".to_string())
         );
-        // `from . import x` in `pkg/x/__init__.py` resolves to the package
+        // A genuinely nameless relative import in `pkg/x/__init__.py` (a
+        // star or parenthesized `from . import`) resolves to the package
         // itself — a self-reference, skipped rather than recorded as a
-        // self-loop edge.
+        // self-loop edge. Named submodule imports never reach this shape:
+        // `extract_raw_imports` expands them per imported name (#1692).
         assert_eq!(
             classify_import("python", ".", "pkg.x", "pkg", true),
             Resolved::Skip
         );
+    }
+
+    #[test]
+    fn python_dotless_from_import_expands_imported_names() {
+        // `from . import z` keeps the imported name — for a dotless relative
+        // import the name *is* the target module (#1692).
+        let raw = extract_raw_imports("python", "from . import z\n");
+        assert_eq!(raw, vec![".z".to_string()]);
+        // Comma-separated and aliased names expand one specifier per name.
+        let raw = extract_raw_imports("python", "from .. import a, b as _b\n");
+        assert_eq!(raw, vec!["..a".to_string(), "..b".to_string()]);
+        // Star imports extract no plain name; the bare package specifier is
+        // kept so the pre-expansion behavior (a package-level reference) is
+        // preserved rather than dropped.
+        let raw = extract_raw_imports("python", "from . import *\n");
+        assert_eq!(raw, vec![".".to_string()]);
+        // Parenthesized groups fall back to the bare package specifier
+        // rather than fabricating a name (multi-line groups stay out of
+        // scope for the line-based scanner).
+        let raw = extract_raw_imports("python", "from . import (a, b)\n");
+        assert_eq!(raw, vec![".".to_string()]);
+        // A specifier with a real module part is unchanged — the imported
+        // names stay out of it.
+        let raw = extract_raw_imports("python", "from .x import A\n");
+        assert_eq!(raw, vec![".x".to_string()]);
+        let raw = extract_raw_imports("python", "from pkg.mod import thing\n");
+        assert_eq!(raw, vec!["pkg.mod".to_string()]);
+        // Trailing comments are not part of the name list.
+        let raw = extract_raw_imports("python", "from . import z  # re-export\n");
+        assert_eq!(raw, vec![".z".to_string()]);
     }
 
     #[test]

--- a/crates/khive-pack-code/tests/source_ingest.rs
+++ b/crates/khive-pack-code/tests/source_ingest.rs
@@ -391,6 +391,63 @@ async fn python_init_reexport_resolves_in_package_without_self_loop() {
     );
 }
 
+/// A dotless relative import keeps its imported name (#1692): for
+/// `from . import z` the name *is* the target module, so the package
+/// `__init__` records a `depends_on` edge to the submodule — not nothing
+/// (self-reference skip) and not a package-level edge. The `__init__` and
+/// regular-module cases resolve to different targets, so neither can be
+/// satisfied by one collapsed answer.
+fn write_python_dotless_from_import_fixture(root: &Path) {
+    let pkg_x = root.join("pkg/x");
+    std::fs::create_dir_all(&pkg_x).unwrap();
+    std::fs::write(
+        root.join("pyproject.toml"),
+        "[project]\nname = \"pyproj\"\n",
+    )
+    .unwrap();
+    std::fs::write(root.join("pkg/__init__.py"), "").unwrap();
+    std::fs::write(pkg_x.join("__init__.py"), "from . import z\n").unwrap();
+    std::fs::write(pkg_x.join("w.py"), "from . import z\n").unwrap();
+    std::fs::write(pkg_x.join("z.py"), "VALUE = 1\n").unwrap();
+}
+
+#[tokio::test]
+async fn python_dotless_from_import_emits_submodule_edges() {
+    let root = TempDir::new().expect("tempdir");
+    write_python_dotless_from_import_fixture(root.path());
+    let db = root.path().join("dotless_from.db");
+    let rt = rt_at(&db);
+    let token = rt.authorize(Namespace::local()).expect("token");
+
+    let opts = || CodeSourceIngestOptions {
+        path: root.path(),
+        languages: all_languages(),
+        sweep_time: Utc::now(),
+    };
+    run_code_ingest(&rt, &token, opts())
+        .await
+        .expect("first ingest succeeds");
+    run_code_ingest(&rt, &token, opts())
+        .await
+        .expect("second ingest succeeds");
+
+    let edges = edge_fingerprints(&rt).await;
+    for (src, tgt) in [("pkg.x", "pkg.x.z"), ("pkg.x.w", "pkg.x.z")] {
+        assert!(
+            edges.iter().any(|(rel, s, t, kinds)| rel == "depends_on"
+                && s == src
+                && t == tgt
+                && kinds == "import"),
+            "expected {src} -> {tgt} depends_on import edge, got: {edges:?}"
+        );
+    }
+    let self_loops: Vec<_> = edges.iter().filter(|(_, s, t, _)| s == t).collect();
+    assert!(
+        self_loops.is_empty(),
+        "dotless relative import must not produce self-loop edges, got: {self_loops:?}"
+    );
+}
+
 /// A manifestless folder (no `Cargo.toml`/`pyproject.toml`/`package.json`
 /// anywhere above its source files) must still produce project/module
 /// entities and import edges under the basename-fallback identity rule


### PR DESCRIPTION
## Problem

The Python import scanner's `from` pattern captured only the module portion, so a dotless relative import (`from . import z`) lost the imported name before classification. In a package `__init__.py` the dots-only specifier resolved to the declaring package and was skipped — no `depends_on` edge for the re-exported submodule. In a regular module it produced an edge to the containing package instead of the sibling module.

Closes #1692.

## Change

Capture the imported-name list; for dots-only specifiers emit one specifier per plain name (`from . import z` → `.z`, `from .. import a, b` → `..a`, `..b`) so the resolver sees the real target. Star and parenthesized forms extract no plain name and fall back to the bare package specifier, preserving the previous package-level reference instead of dropping it. Attribute imports resolve to their containing module via the existing longest-prefix fallback, so the worst case equals prior behavior.

The related Rust braced-`use` under-attribution noted in the issue is the same mechanism in a separate scanner path; left for its own change.

## Tests

Unit: extraction contract for named, aliased, star, parenthesized, and comment-trailing forms. End-to-end: fixture package proving `pkg.x → pkg.x.z` (the previously missing `__init__` edge) and `pkg.x.w → pkg.x.z` (previously mis-pointed at the package), no self-loops.

`cargo test -p khive-pack-code`: 60 passing. Clippy clean with `-D warnings`.