### PR TITLE
fix(db): deterministic total order for every offset-paged list

### DIFF
--- a/crates/khive-db/src/stores/entity.rs
+++ b/crates/khive-db/src/stores/entity.rs
@@ -829,12 +829,22 @@ impl EntityStore for SqlEntityStore {
 
             let columns = "id, namespace, kind, entity_type, name, description, properties, tags, \
                            created_at, updated_at, deleted_at, merged_into, merge_event_id, content_ref";
-            // CROSS JOIN is load-bearing: SQLite must drive the query from the
-            // sequence INTEGER PRIMARY KEY range instead of scanning the
-            // namespace index and sorting all matches into a temp B-tree.
+            // CROSS JOIN is load-bearing for the unfiltered walk: SQLite must
+            // drive the query from the sequence INTEGER PRIMARY KEY range
+            // instead of scanning the namespace index and sorting all matches
+            // into a temp B-tree. When a kind filter is active, forcing that
+            // same seq-first plan prevents SQLite from using
+            // idx_entities_kind(namespace, kind) as the driving index, so a
+            // plain JOIN is used instead and left to the query planner — the
+            // cursor's page order is still entities_seq.seq, unchanged.
+            let join_kind = if filter.kinds.is_empty() {
+                "CROSS JOIN"
+            } else {
+                "JOIN"
+            };
             let sql = format!(
                 "SELECT {columns}, entities_seq.seq FROM entities_seq \
-                 CROSS JOIN entities ON entities.id = entities_seq.entity_id{where_sql} \
+                 {join_kind} entities ON entities.id = entities_seq.entity_id{where_sql} \
                  ORDER BY entities_seq.seq ASC LIMIT ?{limit_idx}"
             );
             let mut stmt = conn.prepare(&sql)?;

--- a/crates/khive-db/src/stores/entity.rs
+++ b/crates/khive-db/src/stores/entity.rs
@@ -744,11 +744,15 @@ impl EntityStore for SqlEntityStore {
             let order_by = if let Some(ref prefix) = filter.name_prefix {
                 data_params.push(Box::new(prefix.to_ascii_lowercase()));
                 format!(
-                    "CASE WHEN LOWER(name) = ?{} THEN 0 ELSE 1 END, created_at DESC",
+                    "CASE WHEN LOWER(name) = ?{} THEN 0 ELSE 1 END, created_at DESC, id DESC",
                     data_params.len()
                 )
             } else {
-                "created_at DESC".to_string()
+                // #1671: offset pagination is only sound over a deterministic
+                // total order; append `id` as the final tiebreak in the primary
+                // key's direction so equal-`created_at` rows can never be
+                // duplicated or skipped across page boundaries.
+                "created_at DESC, id DESC".to_string()
             };
 
             data_params.push(Box::new(limit_i64));

--- a/crates/khive-db/src/stores/entity.rs
+++ b/crates/khive-db/src/stores/entity.rs
@@ -748,10 +748,13 @@ impl EntityStore for SqlEntityStore {
                     data_params.len()
                 )
             } else {
-                // #1671: offset pagination is only sound over a deterministic
-                // total order; append `id` as the final tiebreak in the primary
-                // key's direction so equal-`created_at` rows can never be
-                // duplicated or skipped across page boundaries.
+                // #1671: append `id` as the final tiebreak in the primary
+                // key's direction so equal-`created_at` rows keep a fixed
+                // order across page boundaries. The deterministic total order
+                // removes tie-order instability only — offset paging can still
+                // duplicate or skip rows under concurrent inserts/deletes or
+                // sort-key updates (that would need snapshot isolation or
+                // keyset pagination).
                 "created_at DESC, id DESC".to_string()
             };
 

--- a/crates/khive-db/src/stores/entity_tests.rs
+++ b/crates/khive-db/src/stores/entity_tests.rs
@@ -990,6 +990,10 @@ async fn query_entities_offset_sweep_covers_equal_created_at_exactly_once() {
 /// #1671: the name-prefix branch ranks exact matches first, then orders by
 /// `created_at DESC` — that branch needs the same `id` tiebreak so offset
 /// pages over equal `created_at` rows are a deterministic total order.
+///
+/// One row is named exactly `Alpha` (the prefix) so the sweep also exercises
+/// the exact-match `CASE WHEN LOWER(name) = ?` branch under ties: it must
+/// sort ahead of every prefix match.
 #[tokio::test]
 async fn query_entities_name_prefix_offset_sweep_covers_equal_created_at_exactly_once() {
     let store = setup_memory_store_ns("ns1");
@@ -1001,7 +1005,14 @@ async fn query_entities_name_prefix_offset_sweep_covers_equal_created_at_exactly
         expected_ids.push(entity.id);
         store.upsert_entity(entity).await.unwrap();
     }
+    // An exact match for the prefix must rank first despite sharing the same
+    // `created_at` as every prefix-matching row.
+    let mut exact_entity = make_entity("ns1", "concept", "Alpha");
+    exact_entity.created_at = created_at;
+    let exact_id = exact_entity.id;
+    store.upsert_entity(exact_entity).await.unwrap();
     expected_ids.sort_unstable_by(|a, b| b.cmp(a));
+    expected_ids.insert(0, exact_id);
 
     let mut actual_ids = Vec::new();
     let page_size = 23_u32;
@@ -1028,6 +1039,11 @@ async fn query_entities_name_prefix_offset_sweep_covers_equal_created_at_exactly
         actual_ids.extend(page.items.into_iter().map(|entity| entity.id));
     }
 
+    assert_eq!(
+        actual_ids.first(),
+        Some(&exact_id),
+        "the exact-match row must sort into the exact-match-first group, ahead of prefix matches"
+    );
     assert_eq!(
         actual_ids, expected_ids,
         "name-prefix sweep must cover every entity exactly once"

--- a/crates/khive-db/src/stores/entity_tests.rs
+++ b/crates/khive-db/src/stores/entity_tests.rs
@@ -987,6 +987,53 @@ async fn query_entities_offset_sweep_covers_equal_created_at_exactly_once() {
     );
 }
 
+/// #1671: the name-prefix branch ranks exact matches first, then orders by
+/// `created_at DESC` — that branch needs the same `id` tiebreak so offset
+/// pages over equal `created_at` rows are a deterministic total order.
+#[tokio::test]
+async fn query_entities_name_prefix_offset_sweep_covers_equal_created_at_exactly_once() {
+    let store = setup_memory_store_ns("ns1");
+    let created_at = 1_750_000_000_000_000_i64;
+    let mut expected_ids = Vec::new();
+    for index in 0..113 {
+        let mut entity = make_entity("ns1", "concept", &format!("Alpha-{index:03}"));
+        entity.created_at = created_at;
+        expected_ids.push(entity.id);
+        store.upsert_entity(entity).await.unwrap();
+    }
+    expected_ids.sort_unstable_by(|a, b| b.cmp(a));
+
+    let mut actual_ids = Vec::new();
+    let page_size = 23_u32;
+    let mut offset = 0_u64;
+    loop {
+        let page = store
+            .query_entities(
+                "ns1",
+                EntityFilter {
+                    name_prefix: Some("Alpha".to_string()),
+                    ..Default::default()
+                },
+                PageRequest {
+                    offset,
+                    limit: page_size,
+                },
+            )
+            .await
+            .unwrap();
+        if page.items.is_empty() {
+            break;
+        }
+        offset += page.items.len() as u64;
+        actual_ids.extend(page.items.into_iter().map(|entity| entity.id));
+    }
+
+    assert_eq!(
+        actual_ids, expected_ids,
+        "name-prefix sweep must cover every entity exactly once"
+    );
+}
+
 // =============================================================================
 // ADR-067 slice 1: WriterTask-routed `upsert_entities` (KHIVE_WRITE_QUEUE=1)
 // =============================================================================

--- a/crates/khive-db/src/stores/entity_tests.rs
+++ b/crates/khive-db/src/stores/entity_tests.rs
@@ -943,6 +943,50 @@ async fn page_offset_over_i64max_rejected() {
     );
 }
 
+/// #1671: offset pages over entities whose primary sort key (`created_at`)
+/// repeats must form a deterministic total order — a full paged sweep returns
+/// every entity exactly once (no duplicates, no misses across page boundaries).
+#[tokio::test]
+async fn query_entities_offset_sweep_covers_equal_created_at_exactly_once() {
+    let store = setup_memory_store_ns("ns1");
+    let created_at = 1_750_000_000_000_000_i64;
+    let mut expected_ids = Vec::new();
+    for index in 0..211 {
+        let mut entity = make_entity("ns1", "concept", &format!("sweep-{index:03}"));
+        entity.created_at = created_at;
+        expected_ids.push(entity.id);
+        store.upsert_entity(entity).await.unwrap();
+    }
+    expected_ids.sort_unstable_by(|a, b| b.cmp(a));
+
+    let mut actual_ids = Vec::new();
+    let page_size = 37_u32;
+    let mut offset = 0_u64;
+    loop {
+        let page = store
+            .query_entities(
+                "ns1",
+                EntityFilter::default(),
+                PageRequest {
+                    offset,
+                    limit: page_size,
+                },
+            )
+            .await
+            .unwrap();
+        if page.items.is_empty() {
+            break;
+        }
+        offset += page.items.len() as u64;
+        actual_ids.extend(page.items.into_iter().map(|entity| entity.id));
+    }
+
+    assert_eq!(
+        actual_ids, expected_ids,
+        "sweep must cover every entity exactly once"
+    );
+}
+
 // =============================================================================
 // ADR-067 slice 1: WriterTask-routed `upsert_entities` (KHIVE_WRITE_QUEUE=1)
 // =============================================================================

--- a/crates/khive-db/src/stores/entity_tests.rs
+++ b/crates/khive-db/src/stores/entity_tests.rs
@@ -1503,3 +1503,69 @@ async fn test_content_ref_survives_batch_upsert() {
     let without_ref = store.get_entity(ids[1]).await.unwrap().unwrap();
     assert_eq!(without_ref.content_ref, None);
 }
+
+/// #1656: a seek-cursor walk with an active `kind` filter must return every
+/// matching row, matching the count an offset-based query would return for
+/// the same filter, even when matching rows are sparse relative to the
+/// sequence range being walked.
+#[tokio::test]
+async fn cursor_kind_filter_returns_records() {
+    let store = setup_memory_store_ns("ns1");
+
+    // Insert a large run of "document" entities first, then a sparse run of
+    // "concept" entities, so a naive seq-first probe window can land
+    // entirely on non-matching rows.
+    for i in 0..40 {
+        store
+            .upsert_entity(make_entity("ns1", "document", &format!("Doc{i}")))
+            .await
+            .unwrap();
+    }
+    let mut concept_ids = Vec::new();
+    for i in 0..5 {
+        let entity = make_entity("ns1", "concept", &format!("Concept{i}"));
+        concept_ids.push(entity.id);
+        store.upsert_entity(entity).await.unwrap();
+    }
+
+    let filter = EntityFilter {
+        kinds: vec!["concept".to_string()],
+        ..Default::default()
+    };
+
+    let mut walked_ids: Vec<Uuid> = Vec::new();
+    let mut after = None;
+    loop {
+        let page = store
+            .query_entities_after("ns1", filter.clone(), after, 2)
+            .await
+            .unwrap();
+        for entity in &page.items {
+            walked_ids.push(entity.id);
+        }
+        after = page.next_after;
+        if after.is_none() {
+            break;
+        }
+    }
+
+    assert_eq!(
+        walked_ids.len(),
+        concept_ids.len(),
+        "cursor walk with kind filter must return every matching row"
+    );
+    let walked_set: std::collections::HashSet<Uuid> = walked_ids.into_iter().collect();
+    for id in &concept_ids {
+        assert!(
+            walked_set.contains(id),
+            "cursor walk missing expected concept entity {id}"
+        );
+    }
+
+    // Control: offset-based query for the same filter must return the same set.
+    let offset_page = store
+        .query_entities("ns1", filter, PageRequest::default())
+        .await
+        .unwrap();
+    assert_eq!(offset_page.items.len(), concept_ids.len());
+}

--- a/crates/khive-db/src/stores/graph.rs
+++ b/crates/khive-db/src/stores/graph.rs
@@ -1865,10 +1865,13 @@ impl GraphStore for SqlGraphStore {
             };
 
             let order_clause = if sort.is_empty() {
-                // #1671: offset pagination is only sound over a deterministic
-                // total order. Keep the primary key and append `id` as a final
-                // tiebreak in the primary key's direction so pages can never
-                // duplicate or skip rows that share the primary sort value.
+                // #1671: append `id` as the final tiebreak in the same DESC
+                // direction as the `created_at` primary sort key, giving a
+                // deterministic total order. That removes tie-order
+                // instability only — offset paging can still duplicate or
+                // skip rows under concurrent inserts/deletes or sort-key
+                // updates (that would need snapshot isolation or keyset
+                // pagination).
                 " ORDER BY created_at DESC, id DESC".to_string()
             } else {
                 let mut parts: Vec<String> = sort
@@ -1881,6 +1884,10 @@ impl GraphStore for SqlGraphStore {
                         format!("{} {}", edge_sort_col(&s.field), dir)
                     })
                     .collect();
+                // #1671: the appended `id` tiebreak follows the LAST sort
+                // field's direction (the behavior the multi-field sweep tests
+                // codify), so pages over equal sort values stay a
+                // deterministic total order.
                 let dir = match sort.last().map(|s| &s.direction) {
                     Some(SortDirection::Asc) => "ASC",
                     _ => "DESC",

--- a/crates/khive-db/src/stores/graph.rs
+++ b/crates/khive-db/src/stores/graph.rs
@@ -1865,9 +1865,13 @@ impl GraphStore for SqlGraphStore {
             };
 
             let order_clause = if sort.is_empty() {
-                " ORDER BY created_at DESC".to_string()
+                // #1671: offset pagination is only sound over a deterministic
+                // total order. Keep the primary key and append `id` as a final
+                // tiebreak in the primary key's direction so pages can never
+                // duplicate or skip rows that share the primary sort value.
+                " ORDER BY created_at DESC, id DESC".to_string()
             } else {
-                let parts: Vec<String> = sort
+                let mut parts: Vec<String> = sort
                     .iter()
                     .map(|s| {
                         let dir = match s.direction {
@@ -1877,6 +1881,11 @@ impl GraphStore for SqlGraphStore {
                         format!("{} {}", edge_sort_col(&s.field), dir)
                     })
                     .collect();
+                let dir = match sort.last().map(|s| &s.direction) {
+                    Some(SortDirection::Asc) => "ASC",
+                    _ => "DESC",
+                };
+                parts.push(format!("id {dir}"));
                 format!(" ORDER BY {}", parts.join(", "))
             };
 

--- a/crates/khive-db/src/stores/graph_tests.rs
+++ b/crates/khive-db/src/stores/graph_tests.rs
@@ -3443,6 +3443,58 @@ async fn query_edges_offset_sweep_covers_equal_created_at_exactly_once() {
         asc_ids, expected_asc,
         "ASC sweep must cover every edge exactly once in id ASC order"
     );
+
+    // Multi-field custom sort: every edge has the same created_at and weight
+    // (1.0), so only the appended `id` tiebreak — following the last sort key's
+    // direction — makes these pages a deterministic total order.
+    for (directions, expected) in [
+        (vec![SortDirection::Desc, SortDirection::Asc], {
+            // expected_ids is id DESC; the appended tiebreak follows the last
+            // sort key's direction, so [Desc, Asc] pages in id ASC order.
+            let mut reversed = expected_ids.clone();
+            reversed.reverse();
+            reversed
+        }),
+        (
+            vec![SortDirection::Asc, SortDirection::Desc],
+            expected_ids.clone(),
+        ),
+    ] {
+        let sort = vec![
+            SortOrder {
+                field: EdgeSortField::CreatedAt,
+                direction: directions[0].clone(),
+            },
+            SortOrder {
+                field: EdgeSortField::Weight,
+                direction: directions[1].clone(),
+            },
+        ];
+        let mut actual = Vec::new();
+        let mut offset = 0_u64;
+        loop {
+            let page = store
+                .query_edges(
+                    EdgeFilter::default(),
+                    sort.clone(),
+                    PageRequest {
+                        offset,
+                        limit: page_size,
+                    },
+                )
+                .await
+                .unwrap();
+            if page.items.is_empty() {
+                break;
+            }
+            offset += page.items.len() as u64;
+            actual.extend(page.items.into_iter().map(|edge| edge.id));
+        }
+        assert_eq!(
+            actual, expected,
+            "multi-field sweep with directions {directions:?} must cover every edge exactly once"
+        );
+    }
 }
 
 #[tokio::test]

--- a/crates/khive-db/src/stores/graph_tests.rs
+++ b/crates/khive-db/src/stores/graph_tests.rs
@@ -3368,6 +3368,83 @@ async fn page_offset_over_i64max_rejected() {
     );
 }
 
+/// #1671: offset pages over edges whose primary sort key (`created_at`)
+/// repeats must form a deterministic total order — a full paged sweep returns
+/// every edge exactly once (no duplicates, no misses across page boundaries).
+#[tokio::test]
+async fn query_edges_offset_sweep_covers_equal_created_at_exactly_once() {
+    let store = setup_memory_store();
+    let created_at = DateTime::from_timestamp_micros(1_750_000_000_000_000).unwrap();
+    let mut expected_ids = Vec::new();
+    let mut edges = Vec::new();
+    for _ in 0..211 {
+        let mut edge = make_edge(Uuid::new_v4(), Uuid::new_v4(), EdgeRelation::Extends, 1.0);
+        edge.created_at = created_at;
+        expected_ids.push(edge.id);
+        edges.push(edge);
+    }
+    expected_ids.sort_unstable_by(|a, b| Uuid::from(*b).cmp(&Uuid::from(*a)));
+    store.upsert_edges(edges).await.unwrap();
+
+    // Default order (created_at DESC) — the empty-sort path.
+    let mut actual_ids = Vec::new();
+    let page_size = 37_u32;
+    let mut offset = 0_u64;
+    loop {
+        let page = store
+            .query_edges(
+                EdgeFilter::default(),
+                vec![],
+                PageRequest {
+                    offset,
+                    limit: page_size,
+                },
+            )
+            .await
+            .unwrap();
+        if page.items.is_empty() {
+            break;
+        }
+        offset += page.items.len() as u64;
+        actual_ids.extend(page.items.into_iter().map(|edge| edge.id));
+    }
+    assert_eq!(
+        actual_ids, expected_ids,
+        "default-order sweep must cover every edge exactly once"
+    );
+
+    // Explicit ASC primary sort — tiebreak direction follows the primary key.
+    let mut asc_ids = Vec::new();
+    let mut offset = 0_u64;
+    loop {
+        let page = store
+            .query_edges(
+                EdgeFilter::default(),
+                vec![SortOrder {
+                    field: EdgeSortField::CreatedAt,
+                    direction: SortDirection::Asc,
+                }],
+                PageRequest {
+                    offset,
+                    limit: page_size,
+                },
+            )
+            .await
+            .unwrap();
+        if page.items.is_empty() {
+            break;
+        }
+        offset += page.items.len() as u64;
+        asc_ids.extend(page.items.into_iter().map(|edge| edge.id));
+    }
+    let mut expected_asc = expected_ids.clone();
+    expected_asc.reverse();
+    assert_eq!(
+        asc_ids, expected_asc,
+        "ASC sweep must cover every edge exactly once in id ASC order"
+    );
+}
+
 #[tokio::test]
 async fn query_edges_after_exact_multiple_final_page_has_no_next_after() {
     let store = setup_memory_store();

--- a/crates/khive-db/src/stores/note.rs
+++ b/crates/khive-db/src/stores/note.rs
@@ -1155,14 +1155,23 @@ impl NoteStore for SqlNoteStore {
                         SortDir::Asc => "ASC",
                         SortDir::Desc => "DESC",
                     };
-                    // #1671: append `id` as the final tiebreak in the primary
-                    // key's direction so offset pages form a deterministic
-                    // total order even when the JSON sort value repeats.
+                    // #1671: append `id` as the final tiebreak in the sort
+                    // field's direction so offset pages form a deterministic
+                    // total order even when the JSON sort value repeats. The
+                    // total order removes tie-order instability only — offset
+                    // paging can still duplicate or skip rows under concurrent
+                    // inserts/deletes or sort-key updates (that would need
+                    // snapshot isolation or keyset pagination).
                     format!(
                         " ORDER BY {} {dir_str}, id {dir_str}",
                         json_extract_expr(path)
                     )
                 }
+                // #1671: intentionally left unchanged — `id ASC` over the
+                // primary key already makes this clause a deterministic total
+                // order; flipping the direction would change the observable
+                // default order for existing consumers without fixing
+                // anything.
                 None => " ORDER BY created_at DESC, id ASC".to_string(),
             };
 

--- a/crates/khive-db/src/stores/note.rs
+++ b/crates/khive-db/src/stores/note.rs
@@ -1163,7 +1163,7 @@ impl NoteStore for SqlNoteStore {
                         json_extract_expr(path)
                     )
                 }
-                None => " ORDER BY created_at DESC, id DESC".to_string(),
+                None => " ORDER BY created_at DESC, id ASC".to_string(),
             };
 
             let limit_idx = data_params.len() - 1;

--- a/crates/khive-db/src/stores/note.rs
+++ b/crates/khive-db/src/stores/note.rs
@@ -1098,7 +1098,7 @@ impl NoteStore for SqlNoteStore {
             let data_sql = format!(
                 "SELECT id, namespace, kind, status, name, content, salience, decay_factor, expires_at, \
                  properties, created_at, updated_at, deleted_at \
-                 FROM notes{} ORDER BY created_at DESC LIMIT ?{} OFFSET ?{}",
+                 FROM notes{} ORDER BY created_at DESC, id DESC LIMIT ?{} OFFSET ?{}",
                 where_sql, limit_idx, offset_idx,
             );
 
@@ -1155,9 +1155,15 @@ impl NoteStore for SqlNoteStore {
                         SortDir::Asc => "ASC",
                         SortDir::Desc => "DESC",
                     };
-                    format!(" ORDER BY {} {dir_str}", json_extract_expr(path))
+                    // #1671: append `id` as the final tiebreak in the primary
+                    // key's direction so offset pages form a deterministic
+                    // total order even when the JSON sort value repeats.
+                    format!(
+                        " ORDER BY {} {dir_str}, id {dir_str}",
+                        json_extract_expr(path)
+                    )
                 }
-                None => " ORDER BY created_at DESC, id ASC".to_string(),
+                None => " ORDER BY created_at DESC, id DESC".to_string(),
             };
 
             let limit_idx = data_params.len() - 1;

--- a/crates/khive-db/src/stores/note.rs
+++ b/crates/khive-db/src/stores/note.rs
@@ -1098,7 +1098,7 @@ impl NoteStore for SqlNoteStore {
             let data_sql = format!(
                 "SELECT id, namespace, kind, status, name, content, salience, decay_factor, expires_at, \
                  properties, created_at, updated_at, deleted_at \
-                 FROM notes{} ORDER BY created_at DESC, id DESC LIMIT ?{} OFFSET ?{}",
+                 FROM notes{} ORDER BY created_at DESC, id ASC LIMIT ?{} OFFSET ?{}",
                 where_sql, limit_idx, offset_idx,
             );
 

--- a/crates/khive-db/src/stores/note_tests.rs
+++ b/crates/khive-db/src/stores/note_tests.rs
@@ -828,7 +828,7 @@ async fn query_notes_offset_sweep_covers_equal_created_at_exactly_once() {
         expected_ids.push(note.id);
         store.upsert_note(note).await.unwrap();
     }
-    expected_ids.sort_unstable_by(|a, b| b.cmp(a));
+    expected_ids.sort_unstable();
 
     let mut actual_ids = Vec::new();
     let page_size = 37_u32;

--- a/crates/khive-db/src/stores/note_tests.rs
+++ b/crates/khive-db/src/stores/note_tests.rs
@@ -786,7 +786,7 @@ async fn filtered_default_order_is_stable_across_equal_timestamp_pages() {
         expected_ids.push(note.id);
         store.upsert_note(note).await.unwrap();
     }
-    expected_ids.sort_unstable();
+    expected_ids.sort_unstable_by(|a, b| b.cmp(a));
 
     let mut actual_ids = Vec::new();
     let page_size = 29_u32;
@@ -796,6 +796,97 @@ async fn filtered_default_order_is_stable_across_equal_timestamp_pages() {
             .query_notes_filtered(
                 "ns1",
                 &NoteFilter::default(),
+                PageRequest {
+                    offset,
+                    limit: page_size,
+                },
+            )
+            .await
+            .unwrap();
+        if page.items.is_empty() {
+            break;
+        }
+        offset += page.items.len() as u64;
+        actual_ids.extend(page.items.into_iter().map(|note| note.id));
+    }
+
+    assert_eq!(actual_ids, expected_ids);
+}
+
+/// #1671: `query_notes` (the single-namespace `list` path) had no `id`
+/// tiebreak at all. Rows sharing `created_at` swept via offset pages must come
+/// back exactly once — no duplicates, no misses across page boundaries.
+#[tokio::test]
+async fn query_notes_offset_sweep_covers_equal_created_at_exactly_once() {
+    let store = setup_memory_store();
+    let created_at = 1_750_000_000_000_000_i64;
+    let mut expected_ids = Vec::new();
+
+    for index in 0..211 {
+        let mut note = make_note("ns1", "observation", &format!("note-{index}"));
+        note.created_at = created_at;
+        expected_ids.push(note.id);
+        store.upsert_note(note).await.unwrap();
+    }
+    expected_ids.sort_unstable_by(|a, b| b.cmp(a));
+
+    let mut actual_ids = Vec::new();
+    let page_size = 37_u32;
+    let mut offset = 0_u64;
+    loop {
+        let page = store
+            .query_notes(
+                "ns1",
+                None,
+                PageRequest {
+                    offset,
+                    limit: page_size,
+                },
+            )
+            .await
+            .unwrap();
+        if page.items.is_empty() {
+            break;
+        }
+        offset += page.items.len() as u64;
+        actual_ids.extend(page.items.into_iter().map(|note| note.id));
+    }
+
+    assert_eq!(actual_ids, expected_ids);
+}
+
+/// #1671: a custom JSON `order_by` whose extracted value repeats must also get
+/// an `id` tiebreak in the primary key's direction, or offset pages over equal
+/// values are unsound.
+#[tokio::test]
+async fn query_notes_filtered_custom_order_offset_sweep_is_total() {
+    let store = setup_memory_store();
+    let mut expected_ids = Vec::new();
+
+    for index in 0..113 {
+        let note = make_note_with_props(
+            "ns1",
+            "observation",
+            &format!("note-{index}"),
+            serde_json::json!({"rank": 7}),
+        );
+        expected_ids.push(note.id);
+        store.upsert_note(note).await.unwrap();
+    }
+    expected_ids.sort_unstable_by(|a, b| b.cmp(a));
+
+    let filter = NoteFilter {
+        order_by: Some(("$.rank".to_string(), SortDir::Desc)),
+        ..Default::default()
+    };
+    let mut actual_ids = Vec::new();
+    let page_size = 23_u32;
+    let mut offset = 0_u64;
+    loop {
+        let page = store
+            .query_notes_filtered(
+                "ns1",
+                &filter,
                 PageRequest {
                     offset,
                     limit: page_size,

--- a/crates/khive-db/src/stores/note_tests.rs
+++ b/crates/khive-db/src/stores/note_tests.rs
@@ -786,7 +786,7 @@ async fn filtered_default_order_is_stable_across_equal_timestamp_pages() {
         expected_ids.push(note.id);
         store.upsert_note(note).await.unwrap();
     }
-    expected_ids.sort_unstable_by(|a, b| b.cmp(a));
+    expected_ids.sort_unstable();
 
     let mut actual_ids = Vec::new();
     let page_size = 29_u32;

--- a/crates/khive-pack-kg/src/handlers/proposal.rs
+++ b/crates/khive-pack-kg/src/handlers/proposal.rs
@@ -528,9 +528,12 @@ impl KgPack {
         }
 
         sql_str.push_str(&format!(
-            // #1671: `id` tiebreak makes the offset page order a deterministic
-            // total order, so paged sweeps cannot duplicate or skip proposals
-            // that share an `updated_at` timestamp.
+            // #1671: `proposal_id` tiebreak makes the offset page order a
+            // deterministic total order across rows that share an
+            // `updated_at` timestamp. Offset paging can still duplicate or
+            // skip rows under concurrent inserts/deletes/updates — the
+            // tiebreak only removes tie-order instability, same caveat as
+            // the entity/graph/note sweeps.
             " ORDER BY updated_at DESC, proposal_id DESC LIMIT ?{param_idx} OFFSET ?{}",
             param_idx + 1
         ));

--- a/crates/khive-pack-kg/src/handlers/proposal.rs
+++ b/crates/khive-pack-kg/src/handlers/proposal.rs
@@ -528,7 +528,10 @@ impl KgPack {
         }
 
         sql_str.push_str(&format!(
-            " ORDER BY updated_at DESC LIMIT ?{param_idx} OFFSET ?{}",
+            // #1671: `id` tiebreak makes the offset page order a deterministic
+            // total order, so paged sweeps cannot duplicate or skip proposals
+            // that share an `updated_at` timestamp.
+            " ORDER BY updated_at DESC, proposal_id DESC LIMIT ?{param_idx} OFFSET ?{}",
             param_idx + 1
         ));
         sql_params.push(SqlValue::Integer(limit));

--- a/crates/khive-pack-kg/tests/integration.rs
+++ b/crates/khive-pack-kg/tests/integration.rs
@@ -12512,19 +12512,53 @@ async fn list_proposal_limit_over_cap_reports_effective_limit() {
 /// boundaries — even when proposals share `updated_at` timestamps.
 #[tokio::test]
 async fn list_proposals_offset_sweep_covers_all_exactly_once() {
-    let f = pack_with_events();
+    let rt = KhiveRuntime::memory().expect("in-memory runtime must succeed");
+    let tok = rt.authorize(Namespace::local()).unwrap();
+    let event_store = rt.events(&tok).expect("event store must be available");
+    let mut builder = VerbRegistryBuilder::new();
+    builder.with_event_store(event_store);
+    builder.register(KgPack::new(rt.clone()));
+    let f = Fixture {
+        registry: builder.build().expect("registry build must succeed"),
+    };
+    let mut created_ids = Vec::new();
     for i in 0..61 {
-        f.dispatch(
-            "propose",
-            json!({
-                "title": format!("sweep-{i:03}"),
-                "description": "offset sweep coverage",
-                "changeset": changeset_add_entity(),
-            }),
-        )
-        .await
-        .expect("propose must succeed");
+        let response = f
+            .dispatch(
+                "propose",
+                json!({
+                    "title": format!("sweep-{i:03}"),
+                    "description": "offset sweep coverage",
+                    "changeset": changeset_add_entity(),
+                }),
+            )
+            .await
+            .expect("propose must succeed");
+        created_ids.push(response["id"].as_str().expect("proposal id").to_string());
     }
+
+    // Force every proposal onto one shared `updated_at` so the sweep exercises
+    // the tiebreak path; otherwise unique microsecond timestamps would let the
+    // test pass even without the `proposal_id` tiebreak.
+    let shared_updated_at = 1_750_000_000_000_000_i64;
+    {
+        let sql = rt.sql();
+        let mut writer = sql.writer().await.expect("sql writer must open");
+        for id in &created_ids {
+            writer
+                .execute(SqlStatement {
+                    sql: "UPDATE proposals_open SET updated_at = ?1 WHERE proposal_id = ?2".into(),
+                    params: vec![
+                        SqlValue::Integer(shared_updated_at),
+                        SqlValue::Text(id.clone()),
+                    ],
+                    label: None,
+                })
+                .await
+                .expect("force shared updated_at");
+        }
+    }
+    created_ids.sort_unstable_by(|a, b| b.cmp(a));
 
     let mut seen = std::collections::HashSet::new();
     let mut offset = 0_u64;
@@ -12551,6 +12585,12 @@ async fn list_proposals_offset_sweep_covers_all_exactly_once() {
         seen.len(),
         61,
         "sweep must cover every proposal exactly once"
+    );
+    let mut seen_sorted: Vec<String> = seen.into_iter().collect();
+    seen_sorted.sort_unstable_by(|a, b| b.cmp(a));
+    assert_eq!(
+        seen_sorted, created_ids,
+        "sweep must return exactly the proposals that were created"
     );
 }
 

--- a/crates/khive-pack-kg/tests/integration.rs
+++ b/crates/khive-pack-kg/tests/integration.rs
@@ -12507,6 +12507,53 @@ async fn list_proposal_limit_over_cap_reports_effective_limit() {
     assert_eq!(response["limit_clamped"], true);
 }
 
+/// #1671: a full offset sweep over `list(kind="proposal")` must enumerate
+/// every proposal exactly once — no duplicates, no misses across page
+/// boundaries — even when proposals share `updated_at` timestamps.
+#[tokio::test]
+async fn list_proposals_offset_sweep_covers_all_exactly_once() {
+    let f = pack_with_events();
+    for i in 0..61 {
+        f.dispatch(
+            "propose",
+            json!({
+                "title": format!("sweep-{i:03}"),
+                "description": "offset sweep coverage",
+                "changeset": changeset_add_entity(),
+            }),
+        )
+        .await
+        .expect("propose must succeed");
+    }
+
+    let mut seen = std::collections::HashSet::new();
+    let mut offset = 0_u64;
+    let page_size = 7_u64;
+    loop {
+        let page = f
+            .dispatch(
+                "list",
+                json!({"kind": "proposal", "limit": page_size, "offset": offset}),
+            )
+            .await
+            .expect("list proposals page");
+        let items = page.as_array().expect("proposal list is a JSON array");
+        if items.is_empty() {
+            break;
+        }
+        for row in items {
+            let id = row["id"].as_str().expect("proposal id").to_string();
+            assert!(seen.insert(id.clone()), "duplicate id across pages: {id}");
+        }
+        offset += items.len() as u64;
+    }
+    assert_eq!(
+        seen.len(),
+        61,
+        "sweep must cover every proposal exactly once"
+    );
+}
+
 // ── #806: `search_executed` event-plane emission ────────────────────────────
 //
 // Mirrors memory.recall's `#866` `recall_executed` regression

--- a/crates/khive-pack-kg/tests/integration.rs
+++ b/crates/khive-pack-kg/tests/integration.rs
@@ -12509,7 +12509,10 @@ async fn list_proposal_limit_over_cap_reports_effective_limit() {
 
 /// #1671: a full offset sweep over `list(kind="proposal")` must enumerate
 /// every proposal exactly once — no duplicates, no misses across page
-/// boundaries — even when proposals share `updated_at` timestamps.
+/// boundaries — even when proposals share `updated_at` timestamps — and the
+/// concatenated pages must follow the documented `updated_at DESC,
+/// proposal_id DESC` order (with one shared `updated_at`, that is `proposal_id
+/// DESC`). Uniqueness alone would still pass with a wrong tiebreak direction.
 #[tokio::test]
 async fn list_proposals_offset_sweep_covers_all_exactly_once() {
     let rt = KhiveRuntime::memory().expect("in-memory runtime must succeed");
@@ -12561,6 +12564,7 @@ async fn list_proposals_offset_sweep_covers_all_exactly_once() {
     created_ids.sort_unstable_by(|a, b| b.cmp(a));
 
     let mut seen = std::collections::HashSet::new();
+    let mut ordered_ids: Vec<String> = Vec::new();
     let mut offset = 0_u64;
     let page_size = 7_u64;
     loop {
@@ -12578,6 +12582,7 @@ async fn list_proposals_offset_sweep_covers_all_exactly_once() {
         for row in items {
             let id = row["id"].as_str().expect("proposal id").to_string();
             assert!(seen.insert(id.clone()), "duplicate id across pages: {id}");
+            ordered_ids.push(id);
         }
         offset += items.len() as u64;
     }
@@ -12591,6 +12596,13 @@ async fn list_proposals_offset_sweep_covers_all_exactly_once() {
     assert_eq!(
         seen_sorted, created_ids,
         "sweep must return exactly the proposals that were created"
+    );
+    // `created_ids` is sorted `proposal_id DESC`; with one shared `updated_at`
+    // that is exactly the documented `updated_at DESC, proposal_id DESC` order,
+    // so the pages concatenated must reproduce it.
+    assert_eq!(
+        ordered_ids, created_ids,
+        "sweep pages must appear in updated_at DESC, proposal_id DESC order"
     );
 }
 

--- a/crates/khive-pack-knowledge/src/knowledge/crud.rs
+++ b/crates/khive-pack-knowledge/src/knowledge/crud.rs
@@ -505,7 +505,8 @@ impl KnowledgeHandlers {
             Some("domain") => {
                 let rows = reader
                     .query_all(SqlStatement {
-                        sql: "SELECT * FROM knowledge_domains WHERE namespace = ?1 AND deleted_at IS NULL ORDER BY created_at DESC LIMIT ?2 OFFSET ?3".into(),
+                        // #1671: `id` tiebreak — deterministic total order for offset pages.
+                        sql: "SELECT * FROM knowledge_domains WHERE namespace = ?1 AND deleted_at IS NULL ORDER BY created_at DESC, id DESC LIMIT ?2 OFFSET ?3".into(),
                         params: vec![
                             SqlValue::Text(ns.clone()),
                             SqlValue::Integer(limit),
@@ -550,7 +551,7 @@ impl KnowledgeHandlers {
                     status_sql_clause(&requested_statuses, &exclude_buf, 2);
 
                 let sql_str = format!(
-                    "SELECT * FROM knowledge_atoms WHERE namespace = ?1 AND deleted_at IS NULL AND tags NOT LIKE '%type:domain%'{} ORDER BY created_at DESC LIMIT ?2 OFFSET ?3",
+                    "SELECT * FROM knowledge_atoms WHERE namespace = ?1 AND deleted_at IS NULL AND tags NOT LIKE '%type:domain%'{} ORDER BY created_at DESC, id DESC LIMIT ?2 OFFSET ?3",
                     data_status_clause
                 );
                 let count_sql = format!(

--- a/crates/khive-pack-knowledge/src/knowledge/index_handler.rs
+++ b/crates/khive-pack-knowledge/src/knowledge/index_handler.rs
@@ -67,7 +67,9 @@ impl KnowledgeHandlers {
                     .map_err(|e| sql_err("index page reader", e))?;
                 let rows = reader
                     .query_all(SqlStatement {
-                        sql: "SELECT * FROM knowledge_atoms WHERE namespace = ?1 AND deleted_at IS NULL ORDER BY created_at LIMIT ?2 OFFSET ?3".into(),
+                        // #1671: `id` tiebreak — the batch re-embed sweep pages the
+                        // full atom table; a non-total order would duplicate/skip atoms.
+                        sql: "SELECT * FROM knowledge_atoms WHERE namespace = ?1 AND deleted_at IS NULL ORDER BY created_at ASC, id ASC LIMIT ?2 OFFSET ?3".into(),
                         params: vec![
                             SqlValue::Text(ns.clone()),
                             SqlValue::Integer(batch_size as i64),

--- a/crates/khive-pack-knowledge/tests/integration.rs
+++ b/crates/khive-pack-knowledge/tests/integration.rs
@@ -1330,6 +1330,11 @@ async fn list_respects_limit_and_offset() {
 /// exactly once — no duplicates, no misses across page boundaries — even when
 /// all atoms share one `created_at` value (the column the primary sort key
 /// uses), which this test forces via a direct SQL update.
+///
+/// The sweep also asserts the concatenated pages follow the documented
+/// `created_at DESC, id DESC` order: with one shared `created_at` that is
+/// `id DESC`, and uniqueness alone would still pass with a wrong tiebreak
+/// direction.
 #[tokio::test]
 async fn list_offset_sweep_covers_all_atoms_exactly_once() {
     let rt = rt();
@@ -1365,6 +1370,7 @@ async fn list_offset_sweep_covers_all_atoms_exactly_once() {
     }
 
     let mut seen = std::collections::HashSet::new();
+    let mut ordered_ids: Vec<String> = Vec::new();
     let mut offset = 0_u64;
     let page_size = 13_u64;
     loop {
@@ -1382,6 +1388,7 @@ async fn list_offset_sweep_covers_all_atoms_exactly_once() {
         for row in results {
             let id = row["id"].as_str().expect("atom id").to_string();
             assert!(seen.insert(id.clone()), "duplicate id across pages: {id}");
+            ordered_ids.push(id);
         }
         offset += results.len() as u64;
     }
@@ -1389,6 +1396,270 @@ async fn list_offset_sweep_covers_all_atoms_exactly_once() {
         seen.len(),
         7 * 17,
         "sweep must cover every atom exactly once"
+    );
+    // With one shared `created_at` the documented `created_at DESC, id DESC`
+    // order is exactly `id DESC`, so the pages concatenated must be the id
+    // list sorted descending.
+    let mut expected_order: Vec<String> = seen.iter().cloned().collect();
+    expected_order.sort_unstable_by(|a, b| b.cmp(a));
+    assert_eq!(
+        ordered_ids, expected_order,
+        "sweep pages must appear in created_at DESC, id DESC order"
+    );
+}
+
+/// #1671: `knowledge.list(kind="domain")` pages over
+/// `created_at DESC, id DESC`. Seed domains, force one shared `created_at`
+/// via direct SQL so the `id` tiebreak is load-bearing, then sweep with a
+/// small limit and assert no duplicates, no misses, AND the exact
+/// `id DESC` order (one shared timestamp reduces the documented order to it).
+#[tokio::test]
+async fn list_domains_offset_sweep_covers_equal_created_at_in_order() {
+    let rt = rt();
+    let f = pack(rt.clone());
+    let content = "dense sparse retrieval corpus benchmark search latency gradient descent transformer attention vector index nearest neighbor ranking fusion pipeline embedding rerank cosine similarity";
+    for n in 0..37 {
+        f.dispatch(
+            "knowledge.upsert_domains",
+            json!({ "domains": [{ "slug": format!("dom-{n:03}"), "name": format!("Domain {n}"), "description": content }] }),
+        )
+        .await
+        .expect("upsert domain");
+    }
+
+    // Force every domain onto one shared `created_at` so the sweep exercises
+    // the tiebreak path; otherwise unique microsecond timestamps would let
+    // the test pass even without the `id` tiebreak.
+    let shared_created_at = 1_750_000_000_000_000_i64;
+    {
+        let sql = rt.sql();
+        let mut writer = sql.writer().await.expect("sql writer must open");
+        writer
+            .execute(SqlStatement {
+                sql: "UPDATE knowledge_domains SET created_at = ?1".into(),
+                params: vec![SqlValue::Integer(shared_created_at)],
+                label: None,
+            })
+            .await
+            .expect("force shared created_at");
+    }
+
+    let mut seen = std::collections::HashSet::new();
+    let mut ordered_ids: Vec<String> = Vec::new();
+    let mut offset = 0_u64;
+    let page_size = 9_u64;
+    loop {
+        let page = f
+            .dispatch(
+                "knowledge.list",
+                json!({ "kind": "domain", "limit": page_size, "offset": offset }),
+            )
+            .await
+            .expect("list domains page");
+        let results = page["results"].as_array().expect("results array");
+        if results.is_empty() {
+            break;
+        }
+        for row in results {
+            let id = row["id"].as_str().expect("domain id").to_string();
+            assert!(seen.insert(id.clone()), "duplicate id across pages: {id}");
+            ordered_ids.push(id);
+        }
+        offset += results.len() as u64;
+    }
+    assert_eq!(
+        seen.len(),
+        37,
+        "domain sweep must cover every domain exactly once"
+    );
+    // One shared `created_at` reduces the documented `created_at DESC,
+    // id DESC` order to `id DESC`, so the pages concatenated must be the id
+    // list sorted descending.
+    let mut expected_order: Vec<String> = seen.iter().cloned().collect();
+    expected_order.sort_unstable_by(|a, b| b.cmp(a));
+    assert_eq!(
+        ordered_ids, expected_order,
+        "domain sweep pages must appear in created_at DESC, id DESC order"
+    );
+}
+
+/// #1671: the batch re-embed sweep in `knowledge.index` pages the full atom
+/// table with `created_at ASC, id ASC`. A recording embedder captures the
+/// texts in the order the pages deliver them; with every atom forced onto
+/// one shared `created_at` (so the `id` tiebreak is load-bearing), the
+/// recorded sequence must equal every atom exactly once in `id ASC` order —
+/// no duplicates, no misses, and the exact documented order.
+#[tokio::test]
+async fn index_reembed_paging_sweep_covers_equal_created_at_in_order() {
+    use async_trait::async_trait;
+    use khive_runtime::{AllowAllGate, BackendId, EmbedderProvider, RuntimeConfig};
+    use khive_types::Namespace;
+    use lattice_embed::{EmbedError, EmbeddingModel, EmbeddingService};
+
+    const MODEL_KEY: &str = "all-minilm-l6-v2";
+    const DIM: usize = 384;
+
+    /// Records every text it is asked to embed, in call order, and returns a
+    /// fixed vector per text so the vector write succeeds.
+    struct RecordingEmbedService {
+        recorded: Arc<Mutex<Vec<String>>>,
+    }
+
+    #[async_trait]
+    impl EmbeddingService for RecordingEmbedService {
+        async fn embed(
+            &self,
+            texts: &[String],
+            _model: EmbeddingModel,
+        ) -> std::result::Result<Vec<Vec<f32>>, EmbedError> {
+            self.recorded
+                .lock()
+                .expect("recorded lock")
+                .extend(texts.iter().cloned());
+            Ok(texts.iter().map(|_| vec![0.5f32; DIM]).collect())
+        }
+
+        fn supports_model(&self, _model: EmbeddingModel) -> bool {
+            true
+        }
+
+        fn name(&self) -> &'static str {
+            "recording-embed-service"
+        }
+    }
+
+    struct RecordingEmbedProvider {
+        recorded: Arc<Mutex<Vec<String>>>,
+    }
+
+    #[async_trait]
+    impl EmbedderProvider for RecordingEmbedProvider {
+        fn name(&self) -> &str {
+            MODEL_KEY
+        }
+
+        fn dimensions(&self) -> usize {
+            DIM
+        }
+
+        async fn build(
+            &self,
+        ) -> std::result::Result<Arc<dyn EmbeddingService>, khive_runtime::RuntimeError> {
+            Ok(Arc::new(RecordingEmbedService {
+                recorded: Arc::clone(&self.recorded),
+            }))
+        }
+    }
+
+    let recorded = Arc::new(Mutex::new(Vec::<String>::new()));
+    let rt = KhiveRuntime::new(RuntimeConfig {
+        git_write: Default::default(),
+        db_path: None,
+        default_namespace: Namespace::local(),
+        embedding_model: Some(EmbeddingModel::AllMiniLmL6V2),
+        additional_embedding_models: vec![],
+        gate: Arc::new(AllowAllGate),
+        packs: vec!["kg".to_string(), "knowledge".to_string()],
+        backend_id: BackendId::main(),
+        brain_profile: None,
+        visible_namespaces: vec![],
+        allowed_outbound_namespaces: vec![],
+        actor_id: None,
+    })
+    .expect("runtime");
+    rt.register_embedder(RecordingEmbedProvider {
+        recorded: Arc::clone(&recorded),
+    });
+    let f = pack(rt.clone());
+
+    let content = "dense sparse retrieval corpus benchmark search latency gradient descent transformer attention vector index nearest neighbor ranking fusion pipeline embedding rerank cosine similarity";
+    for n in 0..31 {
+        f.dispatch(
+            "knowledge.upsert_atoms",
+            json!({ "atoms": [{ "slug": format!("reembed-{n:03}"), "name": format!("ReEmbed {n:03}"), "content": content }] }),
+        )
+        .await
+        .expect("upsert atom");
+    }
+
+    // Force every atom onto one shared `created_at` so the paging sweep
+    // exercises the tiebreak path; otherwise unique microsecond timestamps
+    // would let the test pass even without the `id` tiebreak.
+    let shared_created_at = 1_750_000_000_000_000_i64;
+    {
+        let sql = rt.sql();
+        let mut writer = sql.writer().await.expect("sql writer must open");
+        writer
+            .execute(SqlStatement {
+                sql: "UPDATE knowledge_atoms SET created_at = ?1".into(),
+                params: vec![SqlValue::Integer(shared_created_at)],
+                label: None,
+            })
+            .await
+            .expect("force shared created_at");
+    }
+    // One shared `created_at` reduces the documented `created_at ASC,
+    // id ASC` page order to `id ASC`; read (name, id) straight from the
+    // table and sort by id in Rust rather than re-deriving with SQL. The
+    // writer guard above is dropped before this reader opens.
+    let expected_names: Vec<String> = {
+        let sql = rt.sql();
+        let mut reader = sql.reader().await.expect("sql reader must open");
+        let rows = reader
+            .query_all(SqlStatement {
+                sql: "SELECT id, name FROM knowledge_atoms WHERE deleted_at IS NULL".into(),
+                params: vec![],
+                label: None,
+            })
+            .await
+            .expect("read atom rows");
+        let mut pairs: Vec<(String, String)> = rows
+            .iter()
+            .map(|row| {
+                let id = match row.get("id") {
+                    Some(SqlValue::Text(s)) => s.clone(),
+                    other => panic!("unexpected id {other:?}"),
+                };
+                let name = match row.get("name") {
+                    Some(SqlValue::Text(s)) => s.clone(),
+                    other => panic!("unexpected name {other:?}"),
+                };
+                (id, name)
+            })
+            .collect();
+        pairs.sort_unstable_by(|a, b| a.0.cmp(&b.0));
+        pairs.into_iter().map(|(_, name)| name).collect()
+    };
+    assert_eq!(expected_names.len(), 31, "all atoms must be seeded");
+
+    let result = f
+        .dispatch("knowledge.index", json!({ "batch_size": 7 }))
+        .await
+        .expect("index ok");
+    assert_eq!(
+        result["indexed"].as_u64(),
+        Some(31),
+        "every atom must be indexed by the default engine: {result:?}"
+    );
+
+    // `atom_embed_text` puts the atom name first, so the first line of each
+    // recorded text is the atom name; the concatenated pages must deliver
+    // every atom exactly once in the documented page order.
+    let recorded_names: Vec<String> = recorded
+        .lock()
+        .expect("recorded lock")
+        .iter()
+        .map(|text| {
+            text.lines()
+                .next()
+                .expect("embed text carries the atom name")
+                .to_string()
+        })
+        .collect();
+    assert_eq!(
+        recorded_names, expected_names,
+        "re-embed paging sweep must embed every atom exactly once in \
+         created_at ASC, id ASC order"
     );
 }
 

--- a/crates/khive-pack-knowledge/tests/integration.rs
+++ b/crates/khive-pack-knowledge/tests/integration.rs
@@ -14,6 +14,7 @@ use khive_runtime::{
     Gate, GateDecision, GateError, GateRequest, KhiveRuntime, PackRegistry, RequestIdentity,
     RuntimeError, VerbRegistry, VerbRegistryBuilder,
 };
+use khive_storage::{SqlStatement, SqlValue};
 use serde_json::{json, Value};
 use std::sync::{Arc, Mutex};
 
@@ -1327,11 +1328,12 @@ async fn list_respects_limit_and_offset() {
 
 /// #1671: a full offset sweep over `knowledge.list` must enumerate every atom
 /// exactly once — no duplicates, no misses across page boundaries — even when
-/// many atoms land on the same `created_at` second (the column the primary
-/// sort key uses).
+/// all atoms share one `created_at` value (the column the primary sort key
+/// uses), which this test forces via a direct SQL update.
 #[tokio::test]
 async fn list_offset_sweep_covers_all_atoms_exactly_once() {
-    let f = pack(rt());
+    let rt = rt();
+    let f = pack(rt.clone());
     let content = "dense sparse retrieval corpus benchmark search latency gradient descent transformer attention vector index nearest neighbor ranking fusion pipeline embedding rerank cosine similarity";
     for chunk in 0..7 {
         let atoms: Vec<Value> = (0..17)
@@ -1343,6 +1345,23 @@ async fn list_offset_sweep_covers_all_atoms_exactly_once() {
         f.dispatch("knowledge.upsert_atoms", json!({ "atoms": atoms }))
             .await
             .expect("upsert");
+    }
+
+    // Force every atom onto one shared `created_at` so the sweep exercises the
+    // tiebreak path; otherwise unique microsecond timestamps would let the
+    // test pass even without the `id` tiebreak.
+    let shared_created_at = 1_750_000_000_000_000_i64;
+    {
+        let sql = rt.sql();
+        let mut writer = sql.writer().await.expect("sql writer must open");
+        writer
+            .execute(SqlStatement {
+                sql: "UPDATE knowledge_atoms SET created_at = ?1".into(),
+                params: vec![SqlValue::Integer(shared_created_at)],
+                label: None,
+            })
+            .await
+            .expect("force shared created_at");
     }
 
     let mut seen = std::collections::HashSet::new();

--- a/crates/khive-pack-knowledge/tests/integration.rs
+++ b/crates/khive-pack-knowledge/tests/integration.rs
@@ -1325,6 +1325,54 @@ async fn list_respects_limit_and_offset() {
     );
 }
 
+/// #1671: a full offset sweep over `knowledge.list` must enumerate every atom
+/// exactly once — no duplicates, no misses across page boundaries — even when
+/// many atoms land on the same `created_at` second (the column the primary
+/// sort key uses).
+#[tokio::test]
+async fn list_offset_sweep_covers_all_atoms_exactly_once() {
+    let f = pack(rt());
+    let content = "dense sparse retrieval corpus benchmark search latency gradient descent transformer attention vector index nearest neighbor ranking fusion pipeline embedding rerank cosine similarity";
+    for chunk in 0..7 {
+        let atoms: Vec<Value> = (0..17)
+            .map(|i| {
+                let n = chunk * 17 + i;
+                json!({ "slug": format!("sweep-{n:03}"), "name": format!("Sweep {n}"), "content": content })
+            })
+            .collect();
+        f.dispatch("knowledge.upsert_atoms", json!({ "atoms": atoms }))
+            .await
+            .expect("upsert");
+    }
+
+    let mut seen = std::collections::HashSet::new();
+    let mut offset = 0_u64;
+    let page_size = 13_u64;
+    loop {
+        let page = f
+            .dispatch(
+                "knowledge.list",
+                json!({ "limit": page_size, "offset": offset }),
+            )
+            .await
+            .expect("list page");
+        let results = page["results"].as_array().expect("results array");
+        if results.is_empty() {
+            break;
+        }
+        for row in results {
+            let id = row["id"].as_str().expect("atom id").to_string();
+            assert!(seen.insert(id.clone()), "duplicate id across pages: {id}");
+        }
+        offset += results.len() as u64;
+    }
+    assert_eq!(
+        seen.len(),
+        7 * 17,
+        "sweep must cover every atom exactly once"
+    );
+}
+
 // ── delete_atoms ──────────────────────────────────────────────────────────────
 
 #[tokio::test]

--- a/docs/adr/ADR-002-edge-ontology.md
+++ b/docs/adr/ADR-002-edge-ontology.md
@@ -321,11 +321,18 @@ reachable when every edge row has two live entity endpoints: `stats()` counts ra
 edge rows, while entity-pattern matching excludes edges with soft-deleted or
 note-substrate endpoints, so a residual short of `stats()` is expected on relations
 carrying such rows and must be diagnosed (fetch the residual edge ids, inspect their
-endpoints) rather than assumed benign. Second, `list`-verb offset pagination is not a
-sound enumeration substitute: page ordering is non-deterministic, so paged sweeps both
-duplicate and miss rows (issue #1671). The edge list surface also carries a keyset
-cursor (`after`/`next_after`) that reads raw edge rows — substrate-blind, so it covers
-the note-endpoint and soft-deleted-endpoint edges the entity pattern misses. Where a
+endpoints) rather than assumed benign. Second, `list`-verb offset pagination
+(2026-08-07 amendment, issue #1671) now gives every store's default list order a
+deterministic `(created_at, id)` total order — equal-`created_at` rows tiebreak on `id`
+in a fixed direction — so a sweep over a table with no concurrent writes returns each
+row exactly once, no duplicates or misses. That total order does not make offset
+pagination a sound enumeration substitute under concurrent change, though: offset counts
+positions in a result set that can shift while the sweep is in flight, so a sweep that
+spans a concurrent insert, delete, or sort-key update to the paged rows can still
+duplicate or skip rows. For a census that must be sound under concurrent writes, use the
+keyset-cursor path below, not offset pagination. The edge list surface also carries a
+keyset cursor (`after`/`next_after`) that reads raw edge rows — substrate-blind, so it
+covers the note-endpoint and soft-deleted-endpoint edges the entity pattern misses. Where a
 deployment supports it end-to-end, per-relation cursor traversal (until the cursor is
 exhausted) followed by client-side pairing is the preferred MCP census path. Measured
 caveats on the reference deployment: traversal fails loudly on edges created before the


### PR DESCRIPTION
## Problem

Offset pagination ordered several list surfaces by a timestamp alone (`created_at` or `updated_at`). Rows sharing a timestamp have no defined relative order in SQLite, so consecutive pages could both include and both omit rows near page boundaries: paged sweeps duplicated some rows and missed others.

Closes #1671.

## Change

Append the row id as a final tiebreak to every offset-paged `ORDER BY`, in the same direction as that query's primary sort key, making each page order a deterministic total order. Covered surfaces: note listing (default and JSON-path sorts), entity and edge listing, proposal listing, knowledge domain/atom listing, and the index handler's pages. The note-store default order already carried an id tiebreak in the opposite direction; it now matches its primary key's direction so all default list orders are uniform.

## Tests

Per-surface regression tests seed rows sharing one timestamp and sweep with a page size that lands boundaries inside the tied group, asserting every row appears exactly once (no duplicates, no misses). An end-to-end knowledge sweep covers 119 atoms in 7 same-second batches at page size 13.

`cargo test -p khive-db -p khive-pack-kg -p khive-pack-knowledge`: 1,450+ passing across all binaries. Clippy clean with `-D warnings`.