### PR TITLE
fix(pack-memory): mark empty degraded recall results instead of returning a bare empty set

### DIFF
--- a/crates/khive-pack-memory/src/handlers/common.rs
+++ b/crates/khive-pack-memory/src/handlers/common.rs
@@ -444,6 +444,12 @@ pub(super) fn make_pipeline(cfg: &RecallConfig) -> MemoryRecallPipeline {
     )
 }
 
+/// #1657: machine-readable degradation label. `collect_model_ann_hits_inner`'s
+/// bounded-wait arm and the `collect_model_ann_hits` wrapper's error arm are
+/// the only producers of a degraded outcome; an empty degraded response cites
+/// that failure-site reason and falls back to this label only if it is absent.
+pub(super) const ANN_DEGRADED_REASON: &str = "ann_unavailable";
+
 pub(super) struct RecallCandidateSet {
     pub(super) namespace: String,
     pub(super) text_hits: Vec<TextSearchHit>,
@@ -455,6 +461,10 @@ pub(super) struct RecallCandidateSet {
     /// #836: true when at least one model's vector leg degraded to FTS-only
     /// after hitting the bounded ANN readiness wait.
     pub(super) ann_degraded: bool,
+    /// #1657: the first degraded model's failure-site reason; `None` when no
+    /// model degraded. Surfaced on empty degraded responses so they are
+    /// distinguishable from a genuine no-match.
+    pub(super) ann_degraded_reason: Option<String>,
 }
 
 impl RecallCandidateSet {
@@ -535,6 +545,9 @@ pub(super) struct RecallVectorCandidateResult {
     pub(super) vector_hits_per_model: Vec<(String, Vec<VectorSearchHit>)>,
     /// Whether any model timed out to FTS-only while its tracked build continued.
     pub(super) ann_degraded: bool,
+    /// #1657: the first degraded model's failure-site reason; `None` when no
+    /// model degraded.
+    pub(super) ann_degraded_reason: Option<String>,
 }
 
 pub(super) fn retrieval_hybrid_config(strategy: &FusionStrategy, limit: usize) -> HybridConfig {
@@ -850,6 +863,7 @@ impl MemoryPack {
             vector_hits_per_model: vector_result.vector_hits_per_model,
             visible_namespaces: visible,
             ann_degraded: vector_result.ann_degraded,
+            ann_degraded_reason: vector_result.ann_degraded_reason,
         })
     }
 
@@ -883,6 +897,9 @@ impl MemoryPack {
         let call_id = PROF_CID.with(|c| c.get());
 
         let mut ann_degraded = false;
+        // #1657: first degraded model's failure-site reason, propagated so an
+        // empty degraded response can cite it verbatim.
+        let mut ann_degraded_reason: Option<String> = None;
         let model_names: Vec<String> = if let Some(m) = embedding_model {
             vec![m.to_string()]
         } else {
@@ -1064,6 +1081,9 @@ impl MemoryPack {
             for r in &per_model_results {
                 if r.degraded {
                     ann_degraded = true;
+                    if ann_degraded_reason.is_none() {
+                        ann_degraded_reason = r.degraded_reason.clone();
+                    }
                 }
                 if r.used_sqlite_vec_fallback {
                     ann_route = "sqlite_vec";
@@ -1092,6 +1112,7 @@ impl MemoryPack {
         Ok(RecallVectorCandidateResult {
             vector_hits_per_model,
             ann_degraded,
+            ann_degraded_reason,
         })
     }
 
@@ -1151,7 +1172,10 @@ pub(super) struct PerModelAnnHits {
     model_name: String,
     hits: Vec<VectorSearchHit>,
     /// This model's warm ANN wait was bounded out (#836); recall degraded to FTS-only for it.
-    degraded: bool,
+    pub(super) degraded: bool,
+    /// The degradation reason captured at the failure site with `{:?}` formatting;
+    /// `Some` iff `degraded`.
+    pub(super) degraded_reason: Option<String>,
     /// This model fell through to the exact sqlite-vec scan instead of warm ANN.
     used_sqlite_vec_fallback: bool,
 }
@@ -1203,6 +1227,13 @@ pub(super) async fn collect_model_ann_hits(
                 model_name: degrade_name,
                 hits: Vec::new(),
                 degraded: true,
+                degraded_reason: Some(format!(
+                    "{}{e:?}",
+                    concat!(
+                        "per-model recall retrieval failed; degrading this engine ",
+                        "to FTS-only: "
+                    )
+                )),
                 used_sqlite_vec_fallback: false,
             })
         }
@@ -1246,7 +1277,9 @@ async fn collect_model_ann_hits_inner(
     // Bound genuine-miss readiness, but never drop the build itself: a tracked task
     // owns ensure and its phase span while this request races only the result channel.
     // Per-model single flight prevents duplicate detached builds.
-    let mut model_ann_timed_out = false;
+    // Degradation reason, captured at the failure site when this model's
+    // bounded readiness wait gives up; `None` while the ANN leg is healthy.
+    let mut model_ann_degrade_reason: Option<String> = None;
     let initial_raw_hits: Option<(Vec<(Uuid, f32)>, u64)> = match search_result {
         Ok(Some(hits_and_seq)) => Some(hits_and_seq),
         Ok(None) => {
@@ -1290,7 +1323,13 @@ async fn collect_model_ann_hits_inner(
                          without a result; degrading recall to \
                          FTS-only for this model (#836)"
                     );
-                    model_ann_timed_out = true;
+                    model_ann_degrade_reason = Some(
+                        concat!(
+                            "memory ANN detached build task ended without a result; ",
+                            "degrading recall to FTS-only for this model"
+                        )
+                        .to_string(),
+                    );
                     None
                 }
                 Err(_elapsed) => {
@@ -1303,7 +1342,12 @@ async fn collect_model_ann_hits_inner(
                          model and detaching the build to finish \
                          in the background (#836)"
                     );
-                    model_ann_timed_out = true;
+                    model_ann_degrade_reason = Some(format!(
+                        "{}{}{}",
+                        "memory ANN not ready within bounded wait of ",
+                        ann_ready_timeout_ms,
+                        "ms; degrading recall to FTS-only for this model"
+                    ));
                     None
                 }
             }
@@ -1320,7 +1364,7 @@ async fn collect_model_ann_hits_inner(
         }
     };
 
-    if model_ann_timed_out {
+    if let Some(degrade_reason) = model_ann_degrade_reason {
         // No serving index is available for this model within the bounded
         // wait. Rather than replace it with an O(corpus) exact scan, ADR-118
         // §3's second tier guarantees visibility of the newest
@@ -1346,6 +1390,7 @@ async fn collect_model_ann_hits_inner(
             model_name,
             hits,
             degraded: true,
+            degraded_reason: Some(degrade_reason),
             used_sqlite_vec_fallback: false,
         });
     }
@@ -1468,6 +1513,7 @@ async fn collect_model_ann_hits_inner(
             model_name,
             hits,
             degraded: false,
+            degraded_reason: None,
             used_sqlite_vec_fallback: false,
         });
     }
@@ -1512,6 +1558,7 @@ async fn collect_model_ann_hits_inner(
         model_name,
         hits: all_hits,
         degraded: false,
+        degraded_reason: None,
         used_sqlite_vec_fallback: true,
     })
 }

--- a/crates/khive-pack-memory/src/handlers/recall.rs
+++ b/crates/khive-pack-memory/src/handlers/recall.rs
@@ -321,6 +321,11 @@ impl MemoryPack {
         // #836: at least one embedding model's vector leg hit the bounded
         // ANN readiness wait and was served FTS-only for this recall.
         let ann_degraded = candidates.ann_degraded;
+        // #1657: the third state needs a machine-readable marker even when the
+        // degraded result set is empty; keep the failure-site reason so an
+        // empty degraded response can cite it verbatim (a genuine no-match
+        // carries neither).
+        let ann_degraded_reason: Option<String> = candidates.ann_degraded_reason.clone();
 
         if prof {
             if let Some(ref t) = t_stage {
@@ -374,6 +379,20 @@ impl MemoryPack {
             );
             if let Ok(mut state) = self.recall_state.lock() {
                 on_recall_miss(&mut state);
+            }
+            // #1657: an empty degraded response is a third state — surface the
+            // marker here too, otherwise a bare [] is indistinguishable from a
+            // genuine no-match.
+            if ann_degraded {
+                let reason = ann_degraded_reason
+                    .unwrap_or_else(|| super::common::ANN_DEGRADED_REASON.to_string());
+                return to_json(&json!({
+                    "results": Vec::<Value>::new(),
+                    "degraded": true,
+                    // Captured at the failure site (see
+                    // collect_model_ann_hits_inner / collect_model_ann_hits).
+                    "degraded_reason": reason,
+                }));
             }
             return to_json(&Vec::<Value>::new());
         }
@@ -874,6 +893,25 @@ impl MemoryPack {
             }));
         }
 
+        if results.is_empty() && ann_degraded {
+            // #1657: mirror the budget-cap precedent — an empty degraded
+            // response changes shape to {results: [], degraded: true,
+            // degraded_reason} because a bare [] would be indistinguishable
+            // from a genuine no-match. Non-empty degraded responses keep the
+            // bare-array shape with per-item "degraded": "ann_unavailable"
+            // stamps (load-bearing for callers that index the top-level
+            // array).
+            let reason = ann_degraded_reason
+                .unwrap_or_else(|| super::common::ANN_DEGRADED_REASON.to_string());
+            return to_json(&json!({
+                "results": results,
+                "degraded": true,
+                // Captured at the failure site (see
+                // collect_model_ann_hits_inner / collect_model_ann_hits).
+                "degraded_reason": reason,
+            }));
+        }
+
         to_json(&results)
     }
 
@@ -1330,10 +1368,13 @@ mod tests {
         }
     }
 
-    /// ANN timeout plus no FTS match returns an empty result, never an error.
+    /// #1657: ANN timeout plus no FTS match is a third state — the response
+    /// must carry the machine-readable degraded marker and a non-empty reason
+    /// captured at the failure site, never a bare [] (indistinguishable from a
+    /// genuine no-match) and never an error.
     #[tokio::test]
-    async fn recall_836_degraded_with_zero_fts_hits_returns_empty_not_error() {
-        const MODEL: &str = "recall-836-ann-timeout-empty-model";
+    async fn recall_1657_degraded_with_zero_fts_hits_carries_marker_and_reason() {
+        const MODEL: &str = "recall-1657-ann-timeout-empty-model";
         const DIMS: usize = 16;
 
         let rt = KhiveRuntime::memory().expect("in-memory runtime");
@@ -1343,8 +1384,8 @@ mod tests {
         });
 
         // Deliberately no notes seeded: the FTS leg has nothing to match, so
-        // an ANN-degraded recall must still resolve to an empty array rather
-        // than propagating an error.
+        // an ANN-degraded recall resolves to an empty result set that must
+        // still carry the degradation evidence.
         let pack = MemoryPack::new(rt.clone());
         let ann_handle = pack.ann.clone();
 
@@ -1368,10 +1409,175 @@ mod tests {
             .await
             .expect("recall must not error when both legs come up empty under ANN degradation");
 
+        let obj = result.as_object().expect(
+            "#1657 degraded-empty recall must return an object carrying the degraded marker, not a bare array",
+        );
+        assert_eq!(
+            obj.get("results"),
+            Some(&serde_json::json!([])),
+            "#1657 degraded-empty recall must carry an empty results array, got: {result:?}"
+        );
+        assert_eq!(
+            obj.get("degraded").and_then(Value::as_bool),
+            Some(true),
+            "#1657 degraded-empty recall must set degraded: true, got: {result:?}"
+        );
+        let reason = obj
+            .get("degraded_reason")
+            .and_then(Value::as_str)
+            .expect("#1657 degraded-empty recall must carry a degraded_reason string");
+        assert!(
+            !reason.trim().is_empty(),
+            "#1657 degraded_reason must be non-empty (captured at the failure site), got: {result:?}"
+        );
+    }
+
+    /// #1657 companion arm: a genuine no-match (no degradation) keeps the
+    /// marker absent — the two empty outcomes must stay distinguishable.
+    #[tokio::test]
+    async fn recall_1657_genuine_empty_match_has_no_degraded_marker() {
+        const MODEL: &str = "recall-1657-genuine-empty-model";
+        const DIMS: usize = 16;
+
+        let rt = KhiveRuntime::memory().expect("in-memory runtime");
+        rt.register_embedder(HashVecProvider {
+            model_name: MODEL.to_owned(),
+            dims: DIMS,
+        });
+
+        // No notes seeded and no lock held: the store genuinely has nothing
+        // and every engine serves normally, so the response must be a bare
+        // empty array with no degraded marker.
+        let mut builder = VerbRegistryBuilder::new();
+        builder.register(KgPack::new(rt.clone()));
+        builder.register(MemoryPack::new(rt.clone()));
+        let registry = builder.build().expect("registry");
+
+        let result = registry
+            .dispatch(
+                "memory.recall",
+                serde_json::json!({
+                    "query": "no such content exists anywhere",
+                    "limit": 10
+                }),
+            )
+            .await
+            .expect("recall must succeed on a genuinely empty store");
+
         assert_eq!(
             result,
             serde_json::json!([]),
-            "#836 degraded recall with no FTS hits must return an empty array, not an error"
+            "#1657 a genuine no-match must stay a bare empty array with no degraded marker, got: {result:?}"
+        );
+    }
+
+    /// #1657 failure-site arms: `collect_model_ann_hits` converts a per-model
+    /// retrieval failure into a degraded outcome (ADR-031 engine isolation)
+    /// and must capture the reason at the failure site with {:?} formatting —
+    /// never assemble it later from memory of the failure. The bounded-wait
+    /// timeout arm likewise records why this model served FTS-only.
+    #[tokio::test]
+    #[serial(background_tasks)]
+    async fn recall_1657_degraded_outcome_captures_reason_at_failure_site() {
+        const MODEL: &str = "recall-1657-failure-site-model";
+        const COLD_MODEL: &str = "recall-1657-failure-site-cold-model";
+        const DIMS: usize = 16;
+        const NOTE_TEXT: &str = "issue 1657 failure site reason capture note";
+
+        let rt = KhiveRuntime::memory().expect("in-memory runtime");
+        rt.register_embedder(HashVecProvider {
+            model_name: MODEL.to_owned(),
+            dims: DIMS,
+        });
+        rt.register_embedder(HashVecProvider {
+            model_name: COLD_MODEL.to_owned(),
+            dims: DIMS,
+        });
+
+        let ns = Namespace::parse("local").expect("local namespace");
+        let token = rt.authorize(ns).expect("authorize local");
+
+        rt.create_note(&token, "memory", None, NOTE_TEXT, Some(0.7), None, vec![])
+            .await
+            .expect("create note");
+
+        let ann = crate::ann::new_shared();
+        let key = crate::ann::AnnKey::new(MODEL);
+
+        // Build a real warm index so the failpoint fails the warm-ANN leg
+        // itself (not an empty/never-built index).
+        crate::ann::ensure_ann_for_model(&rt, &token, &ann, MODEL)
+            .await
+            .expect("ensure ANN for the seeded note");
+        assert!(
+            crate::ann::is_current(&ann, &key).await,
+            "the ensured ANN must be current before the failure is injected"
+        );
+
+        // Arm 1 — retrieval failure: the failpoint makes the inner warm-ANN
+        // search return an error; the wrapper must degrade (not propagate) and
+        // capture the actual error with {:?} at the failure site.
+        super::super::common::retrieval_failpoints::fail_ann(MODEL);
+        let outcome = super::super::common::collect_model_ann_hits(
+            &rt,
+            &ann,
+            &token,
+            "local",
+            &["local".to_string()],
+            MODEL.to_string(),
+            vec![0.0_f32; DIMS],
+            10,
+            40,
+            2,
+            1_000,
+        )
+        .await
+        .expect("the wrapper must degrade to FTS-only, never propagate a retrieval failure");
+        super::super::common::retrieval_failpoints::clear_ann(MODEL);
+
+        assert!(
+            outcome.degraded,
+            "#1657 a failed warm-ANN leg must mark the per-model outcome degraded"
+        );
+        let reason = outcome
+            .degraded_reason
+            .expect("#1657 a degraded per-model outcome must carry a failure-site reason");
+        assert!(
+            reason.contains("test-injected ANN retrieval failure"),
+            "#1657 the reason must be captured at the failure site from the actual \
+             error with {{:?}} formatting, got: {reason:?}"
+        );
+
+        // Arm 2 — bounded-wait timeout: a cold model (no index ever ensured)
+        // with a near-zero readiness wait expires the bounded wait and
+        // degrades to FTS-only with the timeout recorded as the reason.
+        let outcome2 = super::super::common::collect_model_ann_hits(
+            &rt,
+            &ann,
+            &token,
+            "local",
+            &["local".to_string()],
+            COLD_MODEL.to_string(),
+            vec![0.0_f32; DIMS],
+            10,
+            40,
+            2,
+            0,
+        )
+        .await
+        .expect("the wrapper must degrade to FTS-only, never propagate a retrieval failure");
+
+        assert!(
+            outcome2.degraded,
+            "#1657 a bounded-out readiness wait must mark the per-model outcome degraded"
+        );
+        let reason2 = outcome2
+            .degraded_reason
+            .expect("#1657 a timed-out per-model outcome must carry a failure-site reason");
+        assert!(
+            reason2.contains("bounded wait"),
+            "#1657 the timeout arm must record the bounded wait as the reason, \
+             got: {reason2:?}"
         );
     }
 

--- a/crates/khive-pack-memory/src/handlers/tests.rs
+++ b/crates/khive-pack-memory/src/handlers/tests.rs
@@ -291,6 +291,7 @@ fn fusion_strategy_change_produces_observable_ordering_difference() {
         vector_hits_per_model: vec![("mock".to_string(), vector_hits.clone())],
         visible_namespaces: vec!["local".to_string()],
         ann_degraded: false,
+        ann_degraded_reason: None,
     };
     let cfg_rrf = RecallConfig {
         fuse_strategy: FusionStrategy::Rrf { k: 60 },
@@ -305,6 +306,7 @@ fn fusion_strategy_change_produces_observable_ordering_difference() {
         vector_hits_per_model: vec![("mock".to_string(), vector_hits)],
         visible_namespaces: vec!["local".to_string()],
         ann_degraded: false,
+        ann_degraded_reason: None,
     };
     let cfg_weighted = RecallConfig {
         fuse_strategy: FusionStrategy::Weighted {
@@ -363,6 +365,7 @@ fn vector_only_fusion_unions_hits_across_every_engine() {
         ],
         visible_namespaces: vec!["local".to_string()],
         ann_degraded: false,
+        ann_degraded_reason: None,
     };
     let cfg = RecallConfig {
         fuse_strategy: FusionStrategy::VectorOnly,
@@ -408,6 +411,7 @@ fn vector_only_with_zero_vector_models_never_leaks_text_hits() {
         vector_hits_per_model: vec![],
         visible_namespaces: vec!["local".to_string()],
         ann_degraded: false,
+        ann_degraded_reason: None,
     };
     let cfg = RecallConfig {
         fuse_strategy: FusionStrategy::VectorOnly,
@@ -458,6 +462,7 @@ fn keyword_only_with_zero_vector_models_still_returns_text_hits() {
         vector_hits_per_model: vec![],
         visible_namespaces: vec!["local".to_string()],
         ann_degraded: false,
+        ann_degraded_reason: None,
     };
     let cfg = RecallConfig {
         fuse_strategy: FusionStrategy::KeywordOnly,
@@ -518,6 +523,7 @@ fn multi_engine_rrf_gives_each_engine_a_separate_rank_contribution() {
         ],
         visible_namespaces: vec!["local".to_string()],
         ann_degraded: false,
+        ann_degraded_reason: None,
     };
     let cfg = RecallConfig {
         fuse_strategy: FusionStrategy::Rrf { k: 60 },
@@ -851,6 +857,7 @@ fn vector_candidates_per_model_shape_is_array_of_model_objects() {
         ],
         visible_namespaces: vec!["test".to_string()],
         ann_degraded: false,
+        ann_degraded_reason: None,
     };
 
     let per_model: Vec<Value> = candidates


### PR DESCRIPTION
Closes #1657.

An ANN-degraded recall that produced zero hits returned a bare `[]`, indistinguishable from a genuine no-match. Non-empty degraded responses already stamp each row `"degraded": "ann_unavailable"`, and the budget-cap path already marks its empty set for exactly this reason.

## Changes

- Both empty-set exits (the `fused.is_empty()` early return and the final fallthrough) now return `{"results": [], "degraded": true, "degraded_reason": <reason>}` when ANN degradation occurred, mirroring the budget-cap precedent.
- The reason is captured at the failure site itself, not reconstructed at verdict time: the per-model wrapper records the actual retrieval error (`{:?}`), and the bounded-wait arms record whether the detached build ended without a result or the readiness wait timed out.
- Genuine no-matches still return a bare `[]`; non-empty responses are unchanged (bare top-level array with per-item stamps, load-bearing for callers that index the array).

## Tests

- Degraded empty set carries marker + non-empty reason (forced degradation via held warm lock).
- Genuine empty match stays a bare `[]` with no marker.
- Failure-site capture driven directly through the per-model wrapper: one arm injects an ANN retrieval failure and asserts the reason contains the injected error text; one arm uses a cold model with a zero readiness timeout and asserts the bounded-wait reason.

All 90 package tests green; clippy and rustfmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)