### PR TITLE
fix(git): per-source digest status with skip-on-refusal and walk-exhaustion reporting

### DIFF
--- a/crates/khive-pack-git/docs/api/ingest.md
+++ b/crates/khive-pack-git/docs/api/ingest.md
@@ -69,6 +69,19 @@ purely additive — `done`, `cursor_stalled`, and `writes_refused` keep their
 existing meanings, and existing consumers (the `git.digest` handler,
 `kkernel git-ingest`) serialize the same struct with no behavior change.
 
+Two edge semantics, stated explicitly:
+
+- `history_exhausted` is **vacuously `true` when `include` is empty**: no
+  source was requested, so nothing can count against it. It is a statement
+  about the REQUESTED sources, not about the repository.
+- The tri-state is additive, but `done`'s VALUE can still move: a
+  walked-then-failed source (the walk ran — possibly to completion — and a
+  post-walk step such as the final cursor write then failed) downgrades to
+  `stopped_early` and forces `done = false` at the call site, even when the
+  walk itself recorded completion. `done` keeps its existing MEANING ("call
+  until `true`"); the walked-then-failed arms are simply new events that
+  make it `false`, like budget exhaustion.
+
 ## `NewRecordForRef`
 
 A newly created note this pass, retained so the post-ingestion
@@ -146,6 +159,12 @@ failure (see the `cursor_stalled` handling in each `ingest_*` loop) — so
 the next pass re-walks from before the failure and retries it, while
 records that already landed (including ones ingested later in a stalled
 pass) are no-ops via natural-key dedupe.
+While a pass is stalled, the persisted floor also never advances on the
+strength of an ALREADY-EXISTING record walked after the stall point (its
+natural-key lookup proves only its own landing): advancing past one would
+persist a cursor strictly newer than the refused record's timestamp, and
+the next pass's inclusive `updated >= cursor` filter would skip the refused
+record forever instead of retrying it.
 
 ## Issue #765: commit-snapshot recovery
 
@@ -284,6 +303,10 @@ later records in this pass are still attempted (so every failure surfaces
 in this pass's warnings), but `max_updated` no longer advances past the
 stall point — the next pass re-fetches from before the failure and retries
 it, while already-landed records are no-ops via the natural key.
+The freeze applies on every `max_updated` advance, including the
+already-existing-record branch: while stalled, a later existing record with
+a newer timestamp must not pull the floor past the refused record (see
+`write_cursor` above).
 
 Each page is already `sort:updated-asc` server-side, but `--search` makes
 no hard ordering guarantee across ties — both loops re-sort defensively so

--- a/crates/khive-pack-git/docs/api/ingest.md
+++ b/crates/khive-pack-git/docs/api/ingest.md
@@ -40,6 +40,35 @@ excerpt. It never includes the rejected content. Accounting is per ingest call r
 than process-global daemon telemetry, so a caller can reliably assert
 `writes_refused == 0` even when other digests run concurrently.
 
+## Per-source tri-state and walk exhaustion (issue #1617)
+
+`done` is a budget-cursor statement ("callers loop until `true`"), and
+`warnings[]` is prose — neither lets a program distinguish "this repo has no
+issues/PRs" from "issues/PRs were never reached". `IngestReport::sources`
+closes that gap: every source requested by `include` reports exactly one
+state, written by the walk path itself rather than reconstructed at report
+time:
+
+- `completed` — the source was walked to the end of its history this pass
+  (an idempotent empty-range walk over an ancestor cursor counts).
+- `stopped_early` — the source was visited but not exhausted; `reason`
+  names the cause (budget exhausted mid-source, an incomplete `gh` paging
+  window, or a per-record write failure that froze the cursor — the same
+  events that force `done = false` / `cursor_stalled`).
+- `skipped` — the source was never walked; `reason` names the cause (budget
+  exhausted before an earlier-ordered source finished, `gh` CLI absent, or
+  `gh` itself failed). A gate refusal therefore never terminates the walk:
+  it is recorded on the source and the pass continues to the remaining
+  sources.
+
+`IngestReport::history_exhausted` is the top-level roll-up: `true` only when
+every requested source is `completed`, so a reader can tell "silence means
+nothing left" apart from "stopped before the end". Sources not requested by
+`include` are `null` and do not count against exhaustion. Both fields are
+purely additive — `done`, `cursor_stalled`, and `writes_refused` keep their
+existing meanings, and existing consumers (the `git.digest` handler,
+`kkernel git-ingest`) serialize the same struct with no behavior change.
+
 ## `NewRecordForRef`
 
 A newly created note this pass, retained so the post-ingestion

--- a/crates/khive-pack-git/docs/api/ingest.md
+++ b/crates/khive-pack-git/docs/api/ingest.md
@@ -56,18 +56,24 @@ time:
   window, or a per-record write failure that froze the cursor — the same
   events that force `done = false` / `cursor_stalled`).
 - `skipped` — the source was never walked; `reason` names the cause (budget
-  exhausted before an earlier-ordered source finished, `gh` CLI absent, or
-  `gh` itself failed). A gate refusal therefore never terminates the walk:
+  exhausted before an earlier-ordered source finished, `gh` CLI absent, a
+  `gh` listing failure, or a local cursor/database read failure before remote
+  listing). A gate refusal therefore never terminates the walk:
   it is recorded on the source and the pass continues to the remaining
   sources.
 
 `IngestReport::history_exhausted` is the top-level roll-up: `true` only when
 every requested source is `completed`, so a reader can tell "silence means
 nothing left" apart from "stopped before the end". Sources not requested by
-`include` are `null` and do not count against exhaustion. Both fields are
-purely additive — `done`, `cursor_stalled`, and `writes_refused` keep their
-existing meanings, and existing consumers (the `git.digest` handler,
-`kkernel git-ingest`) serialize the same struct with no behavior change.
+`include` are `null` and do not count against exhaustion. The source fields
+are additive to the serialized report, but `done` has an intentional behavior
+change for a walked-then-failed source: if a walk ran (even to apparent
+completion) and a later operation such as the final cursor write failed, the
+source is downgraded to `stopped_early` and `done` is forced to `false`.
+Budget exhaustion and cursor stalls continue to force `done` to `false`; a
+first-fetch remote failure or a pre-listing local cursor read failure does not,
+because no source walk consumed the budget. Consumers using `done` as a resume
+signal must handle these newly reported false values.
 
 Two edge semantics, stated explicitly:
 

--- a/crates/khive-pack-git/src/ingest.rs
+++ b/crates/khive-pack-git/src/ingest.rs
@@ -114,6 +114,38 @@ pub struct IngestWriteRefusal {
     pub masked: String,
 }
 
+/// Machine-readable state of one ingest source (`commits`, `issues`,
+/// `pull_requests`) after a pass — issue #1617. A reader no longer has to
+/// infer coverage from `done` (a budget-cursor statement) or parse prose
+/// out of `warnings[]`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(tag = "state", content = "reason", rename_all = "snake_case")]
+pub enum IngestSourceState {
+    /// The source was walked to the end of its history this pass.
+    Completed,
+    /// The source was visited but not exhausted: the budget ran out, a
+    /// paging window was left incomplete, or a per-record write failure
+    /// froze the cursor (`cursor_stalled`). The reason names the cause.
+    StoppedEarly(String),
+    /// The source was never walked this pass. The reason names the cause:
+    /// the budget was already exhausted before the source was reached, the
+    /// `gh` CLI was unusable, the source's remote is not github.com, or
+    /// `gh` itself failed.
+    Skipped(String),
+}
+
+/// Per-source ingest coverage for one pass (issue #1617): which sources
+/// were walked to completion, which stopped early and why, and which were
+/// never reached. Written by the walk paths themselves, not reconstructed
+/// at report time, so the states stay truthful when a new walk path is
+/// added later.
+#[derive(Debug, Default, Clone, PartialEq, Eq, Serialize)]
+pub struct IngestSourceStatus {
+    pub commits: Option<IngestSourceState>,
+    pub issues: Option<IngestSourceState>,
+    pub pull_requests: Option<IngestSourceState>,
+}
+
 /// Outcome of one ingest pass. Serializable so CLI callers can emit it as JSON.
 #[derive(Debug, Default, Serialize)]
 pub struct IngestReport {
@@ -200,6 +232,19 @@ pub struct IngestReport {
     /// to compare directly against an independent source of truth (e.g.
     /// `git rev-list --count <ref>`).
     pub commits_total_in_db: u64,
+    /// Per-source ingest coverage for this pass (issue #1617): each
+    /// included source reports `completed`, `stopped_early { reason }`, or
+    /// `skipped { reason }`, so a gate refusal, budget exhaustion, and a
+    /// `gh`/remote skip are distinguishable without parsing `warnings[]`.
+    /// Additive companion to `done`/`cursor_stalled`, which keep their
+    /// existing budget-cursor meaning.
+    pub sources: IngestSourceStatus,
+    /// `true` only when every included source was walked to the end of its
+    /// history this pass — "silence means nothing left", as opposed to
+    /// "stopped before the end" (budget exhausted, incomplete paging
+    /// window, or a frozen cursor). Unlike `done`, this is a coverage
+    /// statement, not a resume-loop signal (issue #1617).
+    pub history_exhausted: bool,
 }
 
 fn record_write_failure(
@@ -268,6 +313,14 @@ pub(crate) async fn run_ingest_with_commit_recovery(
         remaining: opts.max_items,
     };
     let mut new_records: Vec<NewRecordForRef> = Vec::new();
+    // Per-source completion flags folded into `report.sources` at the end of
+    // the pass (issue #1617). The flags are seeded by the failure/walk paths
+    // themselves (`ingest_commits`/`ingest_prs`/`ingest_issues` set them
+    // false on a budget break, incomplete paging window, or frozen cursor),
+    // never reconstructed from counts at report time.
+    let mut commits_complete = false;
+    let mut prs_complete = false;
+    let mut issues_complete = false;
 
     // Graceful degradation covers both "gh is not on PATH" and "gh is present
     // but this repo has no usable GitHub remote" (e.g. a synthetic/local-only
@@ -289,14 +342,24 @@ pub(crate) async fn run_ingest_with_commit_recovery(
                     &mut number_to_pr,
                     &mut budget,
                     &mut new_records,
+                    &mut prs_complete,
                 )
                 .await
                 {
                     Ok(()) => {}
-                    Err(e) => report
-                        .warnings
-                        .push(format!("gh pr list failed, skipping pull requests: {e}")),
+                    Err(e) => {
+                        report
+                            .warnings
+                            .push(format!("gh pr list failed, skipping pull requests: {e}"));
+                        report.sources.pull_requests = Some(IngestSourceState::Skipped(format!(
+                            "gh pr list failed: {e}"
+                        )));
+                    }
                 }
+            } else if opts.include.pull_requests {
+                report.sources.pull_requests = Some(IngestSourceState::Skipped(
+                    "budget exhausted before pull requests were reached".to_string(),
+                ));
             }
             if opts.include.issues && !budget.exhausted() {
                 if let Err(e) = ingest_issues(
@@ -308,13 +371,21 @@ pub(crate) async fn run_ingest_with_commit_recovery(
                     &mut report,
                     &mut budget,
                     &mut new_records,
+                    &mut issues_complete,
                 )
                 .await
                 {
                     report
                         .warnings
                         .push(format!("gh issue list failed, skipping issues: {e}"));
+                    report.sources.issues = Some(IngestSourceState::Skipped(format!(
+                        "gh issue list failed: {e}"
+                    )));
                 }
+            } else if opts.include.issues {
+                report.sources.issues = Some(IngestSourceState::Skipped(
+                    "budget exhausted before issues were reached".to_string(),
+                ));
             }
         } else {
             report.gh_available = Some(false);
@@ -322,6 +393,16 @@ pub(crate) async fn run_ingest_with_commit_recovery(
                 "gh CLI not found on PATH; skipped issues and pull requests — commits still ingest"
                     .to_string(),
             );
+            if opts.include.pull_requests {
+                report.sources.pull_requests = Some(IngestSourceState::Skipped(
+                    "gh CLI not found on PATH".to_string(),
+                ));
+            }
+            if opts.include.issues {
+                report.sources.issues = Some(IngestSourceState::Skipped(
+                    "gh CLI not found on PATH".to_string(),
+                ));
+            }
         }
     }
 
@@ -338,13 +419,58 @@ pub(crate) async fn run_ingest_with_commit_recovery(
             &mut budget,
             &mut new_records,
             &mut recover,
+            &mut commits_complete,
         )
         .await?;
+    } else if opts.include.commits {
+        report.sources.commits = Some(IngestSourceState::Skipped(
+            "budget exhausted before commits were reached".to_string(),
+        ));
     }
 
     if budget.exhausted() {
         report.done = false;
     }
+
+    // Fold the walk-recorded completion flags into the per-source tri-state
+    // (issue #1617) — a source with no state yet was walked: Completed when
+    // its flag held, StoppedEarly otherwise. The walk paths clear their flag
+    // at the exact point they stop early, so the reason names the real cause.
+    if report.sources.pull_requests.is_none() && opts.include.pull_requests {
+        report.sources.pull_requests = Some(if prs_complete {
+            IngestSourceState::Completed
+        } else {
+            IngestSourceState::StoppedEarly("stopped before the PR history was exhausted".into())
+        });
+    }
+    if report.sources.issues.is_none() && opts.include.issues {
+        report.sources.issues = Some(if issues_complete {
+            IngestSourceState::Completed
+        } else {
+            IngestSourceState::StoppedEarly("stopped before the issue history was exhausted".into())
+        });
+    }
+    if report.sources.commits.is_none() && opts.include.commits {
+        report.sources.commits = Some(if commits_complete {
+            IngestSourceState::Completed
+        } else {
+            IngestSourceState::StoppedEarly(
+                "stopped before the commit history was exhausted".into(),
+            )
+        });
+    }
+    // A source left `None` was not requested by `include`, so it cannot
+    // count against exhaustion.
+    report.history_exhausted = [
+        &report.sources.commits,
+        &report.sources.issues,
+        &report.sources.pull_requests,
+    ]
+    .into_iter()
+    .all(|s| {
+        s.as_ref()
+            .is_none_or(|state| matches!(state, IngestSourceState::Completed))
+    });
 
     link_references(
         runtime,
@@ -975,6 +1101,7 @@ async fn ingest_commits(
     budget: &mut Budget,
     new_records: &mut Vec<NewRecordForRef>,
     recover: &mut (dyn FnMut(&Path, &GitLogError) -> Result<Option<RecoveredRepo>> + Send),
+    walk_complete: &mut bool,
 ) -> Result<()> {
     let since = read_cursor(runtime, project_id, "commits").await?;
     let (snapshot, recovery_warning) = recover_commit_snapshot(repo, since.as_deref(), recover)?;
@@ -1003,6 +1130,9 @@ async fn ingest_commits(
         if let Some(warning) = recovery_warning {
             report.warnings.push(warning);
         }
+        // An empty `{cursor}..HEAD` range over an ancestor cursor means the
+        // walk genuinely reached the tip: the commit source is exhausted.
+        *walk_complete = true;
         return Ok(());
     }
 
@@ -1033,6 +1163,9 @@ async fn ingest_commits(
         }
 
         if budget.exhausted() {
+            report.sources.commits = Some(IngestSourceState::StoppedEarly(
+                "budget exhausted before the commit history was exhausted".into(),
+            ));
             break;
         }
 
@@ -1166,6 +1299,13 @@ async fn ingest_commits(
     if cursor_stalled {
         report.cursor_stalled = true;
         report.done = false;
+        report.sources.commits = Some(IngestSourceState::StoppedEarly(
+            "a per-record write failure froze the commits cursor (cursor_stalled)".into(),
+        ));
+    } else if report.sources.commits.is_none() {
+        // Neither a budget break nor a stall fired: the loop visited every
+        // commit in the snapshot.
+        *walk_complete = true;
     }
     if let Some(sha) = last_sha {
         write_cursor(runtime, project_id, "commits", &sha).await?;
@@ -1557,6 +1697,7 @@ async fn ingest_prs(
     number_to_pr: &mut HashMap<u64, Uuid>,
     budget: &mut Budget,
     new_records: &mut Vec<NewRecordForRef>,
+    walk_complete: &mut bool,
 ) -> Result<()> {
     let since = read_cursor(runtime, project_id, "prs").await?;
 
@@ -1714,6 +1855,9 @@ async fn ingest_prs(
         // not a complete signal; report `done = false` regardless of budget
         // state so the caller's resume loop keeps going.
         report.done = false;
+        report.sources.pull_requests = Some(IngestSourceState::StoppedEarly(
+            "budget exhausted or the paging floor stalled before the PR window completed".into(),
+        ));
     }
     if cursor_stalled {
         // A stalled PR cursor means records past the frozen floor were never
@@ -1721,6 +1865,12 @@ async fn ingest_prs(
         // complete when it is permanently behind (issue #1645).
         report.cursor_stalled = true;
         report.done = false;
+        report.sources.pull_requests = Some(IngestSourceState::StoppedEarly(
+            "a per-record write failure froze the pull_requests cursor (cursor_stalled)".into(),
+        ));
+    }
+    if window_complete && !cursor_stalled {
+        *walk_complete = true;
     }
 
     if let Some(cursor) = max_updated {
@@ -1739,6 +1889,7 @@ async fn ingest_issues(
     report: &mut IngestReport,
     budget: &mut Budget,
     new_records: &mut Vec<NewRecordForRef>,
+    walk_complete: &mut bool,
 ) -> Result<()> {
     let since = read_cursor(runtime, project_id, "issues").await?;
 
@@ -1904,6 +2055,9 @@ async fn ingest_issues(
 
     if !window_complete {
         report.done = false;
+        report.sources.issues = Some(IngestSourceState::StoppedEarly(
+            "budget exhausted or the paging floor stalled before the issue window completed".into(),
+        ));
     }
     if cursor_stalled {
         // Same contract as the commits and PR paths: a frozen issue cursor
@@ -1911,6 +2065,12 @@ async fn ingest_issues(
         // complete (issue #1645).
         report.cursor_stalled = true;
         report.done = false;
+        report.sources.issues = Some(IngestSourceState::StoppedEarly(
+            "a per-record write failure froze the issues cursor (cursor_stalled)".into(),
+        ));
+    }
+    if window_complete && !cursor_stalled {
+        *walk_complete = true;
     }
 
     if let Some(cursor) = max_updated {

--- a/crates/khive-pack-git/src/ingest.rs
+++ b/crates/khive-pack-git/src/ingest.rs
@@ -128,9 +128,14 @@ pub enum IngestSourceState {
     /// froze the cursor (`cursor_stalled`). The reason names the cause.
     StoppedEarly(String),
     /// The source was never walked this pass. The reason names the cause:
-    /// the budget was already exhausted before the source was reached, the
-    /// `gh` CLI was unusable, the source's remote is not github.com, or
-    /// `gh` itself failed.
+    /// the budget was already exhausted before the source was reached, or
+    /// the `gh` CLI was unusable — absent from PATH (a repo whose remote is
+    /// not github.com takes this same arm: `gh_available` probes only
+    /// `gh --version`, so such a repo skips only when `gh` is absent, and
+    /// when `gh` IS present it takes the walker-failure path, whose reason
+    /// carries `gh`'s own stderr) — or `gh` itself failed before the walk
+    /// began (a failure after the walk began is `StoppedEarly`, never
+    /// `Skipped`).
     Skipped(String),
 }
 
@@ -321,6 +326,12 @@ pub(crate) async fn run_ingest_with_commit_recovery(
     let mut commits_complete = false;
     let mut prs_complete = false;
     let mut issues_complete = false;
+    // Set when a gh walker returned Err AFTER recording a walk state
+    // (walked-then-failed): the source states stay as the walker left them
+    // (possibly `completed`), but the pass itself failed, so
+    // `history_exhausted` must not claim total coverage on their strength
+    // alone.
+    let mut gh_walk_failed_after_walk = false;
 
     // Graceful degradation covers both "gh is not on PATH" and "gh is present
     // but this repo has no usable GitHub remote" (e.g. a synthetic/local-only
@@ -348,12 +359,55 @@ pub(crate) async fn run_ingest_with_commit_recovery(
                 {
                     Ok(()) => {}
                     Err(e) => {
+                        // The walker is fallible AFTER visiting records
+                        // (continuation-page fetches, per-record existence
+                        // lookups, and the final cursor write can all fail
+                        // mid/post-walk). Only a failure on the first page
+                        // fetch means the source was never walked; the
+                        // walker signals that case by leaving its
+                        // `pull_requests` state unset. Anything else
+                        // preserves the state the walker already wrote.
+                        let walked = report.sources.pull_requests.is_some();
                         report
                             .warnings
                             .push(format!("gh pr list failed, skipping pull requests: {e}"));
-                        report.sources.pull_requests = Some(IngestSourceState::Skipped(format!(
-                            "gh pr list failed: {e}"
-                        )));
+                        if !walked {
+                            report.sources.pull_requests = Some(IngestSourceState::Skipped(
+                                format!("gh pr list failed: {e}"),
+                            ));
+                        } else {
+                            match report.sources.pull_requests.as_mut() {
+                                Some(IngestSourceState::StoppedEarly(reason)) => {
+                                    reason.push_str(&format!(
+                                        "; pass then failed after the walk: {e}"
+                                    ));
+                                }
+                                // A walk that completed and then failed
+                                // (only the post-loop cursor write can do
+                                // this) is downgraded to stopped-early:
+                                // the records were walked but the pass's
+                                // durability is unproven, and `completed`
+                                // would feed `history_exhausted` a total
+                                // -coverage claim the failure contradicts.
+                                Some(state @ IngestSourceState::Completed) => {
+                                    *state = IngestSourceState::StoppedEarly(format!(
+                                        "walk completed but the pass then failed: {e}"
+                                    ));
+                                }
+                                Some(IngestSourceState::Skipped(_)) | None => {}
+                            }
+                            // Walked-then-failed leaves the walk's
+                            // durability unproven (e.g. the cursor write
+                            // never landed): the resume loop must not
+                            // treat the source as finished. A first-fetch
+                            // failure (the `!walked` arm) pins nothing —
+                            // it is deterministic (`no git remotes found`)
+                            // and `done` keeps its budget-cursor meaning
+                            // for such repos.
+                            report.done = false;
+                            gh_walk_failed_after_walk = true;
+                        }
+                        prs_complete = false;
                     }
                 }
             } else if opts.include.pull_requests {
@@ -378,9 +432,37 @@ pub(crate) async fn run_ingest_with_commit_recovery(
                     report
                         .warnings
                         .push(format!("gh issue list failed, skipping issues: {e}"));
-                    report.sources.issues = Some(IngestSourceState::Skipped(format!(
-                        "gh issue list failed: {e}"
-                    )));
+                    // See the PR arm above: `Skipped` only when the walk
+                    // never began (the walker signals that by leaving its
+                    // state unset); a walked-then-failed source keeps the
+                    // state the walker already wrote.
+                    if report.sources.issues.is_none() {
+                        report.sources.issues = Some(IngestSourceState::Skipped(format!(
+                            "gh issue list failed: {e}"
+                        )));
+                    } else {
+                        match report.sources.issues.as_mut() {
+                            Some(IngestSourceState::StoppedEarly(reason)) => {
+                                reason.push_str(&format!("; pass then failed after the walk: {e}"));
+                            }
+                            // See the PR arm above: a completed walk whose
+                            // pass then fails is downgraded to
+                            // stopped-early so the failure is never
+                            // invisible next to a `completed` claim.
+                            Some(state @ IngestSourceState::Completed) => {
+                                *state = IngestSourceState::StoppedEarly(format!(
+                                    "walk completed but the pass then failed: {e}"
+                                ));
+                            }
+                            Some(IngestSourceState::Skipped(_)) | None => {}
+                        }
+                        // See the PR arm above: walked-then-failed is not a
+                        // finished source; a first-fetch failure pins
+                        // nothing.
+                        report.done = false;
+                        gh_walk_failed_after_walk = true;
+                    }
+                    issues_complete = false;
                 }
             } else if opts.include.issues {
                 report.sources.issues = Some(IngestSourceState::Skipped(
@@ -433,44 +515,67 @@ pub(crate) async fn run_ingest_with_commit_recovery(
     }
 
     // Fold the walk-recorded completion flags into the per-source tri-state
-    // (issue #1617) — a source with no state yet was walked: Completed when
-    // its flag held, StoppedEarly otherwise. The walk paths clear their flag
-    // at the exact point they stop early, so the reason names the real cause.
+    // (issue #1617). Every walker records its own state by the time it
+    // returns (PR/issue walkers pre-seed `stopped_early` when the walk
+    // begins and upgrade on completion; `ingest_commits` writes its state
+    // at every exit), so each arm below is a release-mode belt-and-braces
+    // fallback for a walker that returned without recording anything — an
+    // instrumentation gap, not a normal stop, and its reason says so
+    // loudly instead of dressing the gap up as one.
     if report.sources.pull_requests.is_none() && opts.include.pull_requests {
+        debug_assert!(
+            false,
+            "pull_requests walker returned without recording its source state"
+        );
         report.sources.pull_requests = Some(if prs_complete {
             IngestSourceState::Completed
         } else {
-            IngestSourceState::StoppedEarly("stopped before the PR history was exhausted".into())
+            IngestSourceState::StoppedEarly(
+                "state not recorded by walker; stopped before the PR history was exhausted".into(),
+            )
         });
     }
     if report.sources.issues.is_none() && opts.include.issues {
+        debug_assert!(
+            false,
+            "issues walker returned without recording its source state"
+        );
         report.sources.issues = Some(if issues_complete {
             IngestSourceState::Completed
         } else {
-            IngestSourceState::StoppedEarly("stopped before the issue history was exhausted".into())
+            IngestSourceState::StoppedEarly(
+                "state not recorded by walker; stopped before the issue history was exhausted"
+                    .into(),
+            )
         });
     }
     if report.sources.commits.is_none() && opts.include.commits {
+        debug_assert!(
+            false,
+            "commits walker returned without recording its source state"
+        );
         report.sources.commits = Some(if commits_complete {
             IngestSourceState::Completed
         } else {
             IngestSourceState::StoppedEarly(
-                "stopped before the commit history was exhausted".into(),
+                "state not recorded by walker; stopped before the commit history was exhausted"
+                    .into(),
             )
         });
     }
     // A source left `None` was not requested by `include`, so it cannot
     // count against exhaustion.
-    report.history_exhausted = [
-        &report.sources.commits,
-        &report.sources.issues,
-        &report.sources.pull_requests,
-    ]
-    .into_iter()
-    .all(|s| {
-        s.as_ref()
-            .is_none_or(|state| matches!(state, IngestSourceState::Completed))
-    });
+    report.history_exhausted = !gh_walk_failed_after_walk
+        && [
+            &report.sources.commits,
+            &report.sources.issues,
+            &report.sources.pull_requests,
+        ]
+        .into_iter()
+        .all(|s| {
+            s.as_ref()
+                .is_none_or(|state| matches!(state, IngestSourceState::Completed))
+        });
 
     link_references(
         runtime,
@@ -1116,8 +1221,9 @@ async fn ingest_commits(
         // whatever advanced the cursor (measured: a scratch clone whose HEAD
         // trailed the cursor by weeks walked nothing and reported a clean
         // pass, issue #1644) — surface it and refuse the completion claim.
-        if let Some(since_sha) = last_sha_of(&since) {
-            if !is_ancestor_of_head(repo, since_sha) {
+        let cursor_not_ancestor = last_sha_of(&since).is_some_and(|since_sha| {
+            let not_ancestor = !is_ancestor_of_head(repo, since_sha);
+            if not_ancestor {
                 report.warnings.push(format!(
                     "commits cursor {since_sha} is not an ancestor of this \
                      source's HEAD: the walked history lags or diverged from \
@@ -1126,13 +1232,28 @@ async fn ingest_commits(
                 ));
                 report.done = false;
             }
-        }
+            not_ancestor
+        });
         if let Some(warning) = recovery_warning {
             report.warnings.push(warning);
         }
         // An empty `{cursor}..HEAD` range over an ancestor cursor means the
         // walk genuinely reached the tip: the commit source is exhausted.
-        *walk_complete = true;
+        // The source state is recorded HERE, not left for the end-of-pass
+        // fill (whose arms are now loud instrumentation-gap tripwires): the
+        // diverged-cursor refusal is a stop-early — the walk cannot claim
+        // it covered this source's history — while the ancestor case is a
+        // genuine completion.
+        if cursor_not_ancestor {
+            report.sources.commits = Some(IngestSourceState::StoppedEarly(
+                "commits cursor is not an ancestor of this source's HEAD: the walked history \
+                 lags or diverged from the history that advanced the cursor (issue #1644)"
+                    .into(),
+            ));
+        } else {
+            report.sources.commits = Some(IngestSourceState::Completed);
+            *walk_complete = true;
+        }
         return Ok(());
     }
 
@@ -1304,7 +1425,10 @@ async fn ingest_commits(
         ));
     } else if report.sources.commits.is_none() {
         // Neither a budget break nor a stall fired: the loop visited every
-        // commit in the snapshot.
+        // commit in the snapshot. Recorded HERE, like the budget and stall
+        // arms — every walker exit records its own state so the end-of-pass
+        // fill is a pure instrumentation-gap fallback.
+        report.sources.commits = Some(IngestSourceState::Completed);
         *walk_complete = true;
     }
     if let Some(sha) = last_sha {
@@ -1712,7 +1836,24 @@ async fn ingest_prs(
     let mut window_complete = true;
 
     'paging: loop {
-        let mut page = fetch_pr_page(repo, floor.as_deref())?;
+        // The FIRST fetch failing must report `skipped` (never walked);
+        // every later failure happens mid/post-walk. The call site reads
+        // that distinction off this state slot, so the marker goes up as
+        // soon as the walk begins and pre-seeds the stopped-early state:
+        // leaving the loop before the window completes IS stopping early,
+        // and the arms below specialize the reason when they fire.
+        let first_page = report.sources.pull_requests.is_none();
+        let mut page = match fetch_pr_page(repo, floor.as_deref()) {
+            Ok(page) => {
+                if first_page {
+                    report.sources.pull_requests = Some(IngestSourceState::StoppedEarly(
+                        "walk began but did not report completion".into(),
+                    ));
+                }
+                page
+            }
+            Err(e) => return Err(e),
+        };
         let page_len = page.len();
         // Each page is already `sort:updated-asc` server-side, but `--search`
         // makes no hard ordering guarantee across ties — re-sort defensively
@@ -1726,12 +1867,6 @@ async fn ingest_prs(
         let last_updated_at = page.last().and_then(|pr| pr.updated_at.clone());
 
         for pr in page {
-            let is_new = since
-                .as_deref()
-                .zip(pr.updated_at.as_deref())
-                .map(|(cursor, updated)| updated >= cursor)
-                .unwrap_or(true);
-
             if let Some(existing) =
                 find_by_number(runtime, token, "pull_request", project_id, pr.number).await?
             {
@@ -1740,23 +1875,45 @@ async fn ingest_prs(
                     merge_sha_to_pr.insert(oid, existing);
                 }
                 report.prs_skipped_existing += 1;
-                if !cursor_stalled {
-                    if let Some(u) = &pr.updated_at {
-                        if max_updated
-                            .as_deref()
-                            .map(|m| u.as_str() > m)
-                            .unwrap_or(true)
-                        {
-                            max_updated = Some(u.clone());
-                        }
+                // Cursor advancement past an existing record is always safe:
+                // the record provably landed (natural-key lookup), so no
+                // stall can strand it. Restricting this to `!cursor_stalled`
+                // would freeze the cursor at the pass floor on any pass
+                // whose page is all-existing (the common resumed-pass
+                // shape), re-fetching the same full window forever.
+                if let Some(u) = &pr.updated_at {
+                    if max_updated
+                        .as_deref()
+                        .map(|m| u.as_str() > m)
+                        .unwrap_or(true)
+                    {
+                        max_updated = Some(u.clone());
                     }
                 }
                 continue;
             }
+            // Computed AFTER the existence lookup: a record fetched by gh
+            // because of the inclusive cursor tie (`updated >= since`) that
+            // then lands is covered by its own create — walking past it
+            // must not freeze the cursor at the pass floor.
+            let is_new = since
+                .as_deref()
+                .zip(pr.updated_at.as_deref())
+                .map(|(cursor, updated)| updated >= cursor)
+                .unwrap_or(true);
             if !is_new {
                 continue;
             }
             if budget.exhausted() {
+                // Records after this point in the window were never
+                // visited: the walk stops early even when the page itself
+                // is short (a short page only proves the REMOTE window
+                // ended, not that the local walk covered it). This is also
+                // the exact-budget boundary: the budget counter cannot
+                // distinguish "ran out exactly at the last record" from
+                // "records remained", and the conservative answer is
+                // stopped-early — a resumed pass completes idempotently.
+                window_complete = false;
                 break;
             }
 
@@ -1855,9 +2012,15 @@ async fn ingest_prs(
         // not a complete signal; report `done = false` regardless of budget
         // state so the caller's resume loop keeps going.
         report.done = false;
-        report.sources.pull_requests = Some(IngestSourceState::StoppedEarly(
-            "budget exhausted or the paging floor stalled before the PR window completed".into(),
-        ));
+        *report
+            .sources
+            .pull_requests
+            .as_mut()
+            .expect("pull_requests state set when the walk began") =
+            IngestSourceState::StoppedEarly(
+                "budget exhausted or the paging floor stalled before the PR window completed"
+                    .into(),
+            );
     }
     if cursor_stalled {
         // A stalled PR cursor means records past the frozen floor were never
@@ -1865,11 +2028,20 @@ async fn ingest_prs(
         // complete when it is permanently behind (issue #1645).
         report.cursor_stalled = true;
         report.done = false;
-        report.sources.pull_requests = Some(IngestSourceState::StoppedEarly(
-            "a per-record write failure froze the pull_requests cursor (cursor_stalled)".into(),
-        ));
+        *report
+            .sources
+            .pull_requests
+            .as_mut()
+            .expect("pull_requests state set when the walk began") =
+            IngestSourceState::StoppedEarly(
+                "a per-record write failure froze the pull_requests cursor (cursor_stalled)".into(),
+            );
     }
     if window_complete && !cursor_stalled {
+        // Completion is recorded HERE too — every walker exit leaves the
+        // state slot final, so the end-of-pass fill is a pure
+        // instrumentation-gap fallback, not part of the normal path.
+        report.sources.pull_requests = Some(IngestSourceState::Completed);
         *walk_complete = true;
     }
 
@@ -1904,7 +2076,22 @@ async fn ingest_issues(
     let mut window_complete = true;
 
     'paging: loop {
-        let page = fetch_issue_page(repo, floor.as_deref())?;
+        // See `ingest_prs`: the first fetch failing must report `skipped`
+        // (never walked); the call site reads that off this state slot, so
+        // the walk-start marker also pre-seeds the stopped-early state that
+        // leaving the loop early implies.
+        let first_page = report.sources.issues.is_none();
+        let page = match fetch_issue_page(repo, floor.as_deref()) {
+            Ok(page) => {
+                if first_page {
+                    report.sources.issues = Some(IngestSourceState::StoppedEarly(
+                        "walk began but did not report completion".into(),
+                    ));
+                }
+                page
+            }
+            Err(e) => return Err(e),
+        };
         let page_len = page.len();
         // The ENTIRE fetched page is classified (masked strings, canonicalized
         // timestamps, governed-enum `state_reason`) before anything else --
@@ -1926,34 +2113,42 @@ async fn ingest_issues(
         let last_updated_at = masked_page.last().and_then(|i| i.updated_at.clone());
 
         for masked in masked_page {
-            let is_new = since
-                .as_deref()
-                .zip(masked.updated_at.as_deref())
-                .map(|(cursor, updated)| updated >= cursor)
-                .unwrap_or(true);
-
             if find_by_number(runtime, token, "issue", project_id, masked.number)
                 .await?
                 .is_some()
             {
                 report.issues_skipped_existing += 1;
-                if !cursor_stalled {
-                    if let Some(u) = &masked.updated_at {
-                        if max_updated
-                            .as_deref()
-                            .map(|m| u.as_str() > m)
-                            .unwrap_or(true)
-                        {
-                            max_updated = Some(u.clone());
-                        }
+                // See `ingest_prs`: cursor advancement past an existing
+                // record is always safe — the natural-key lookup proves the
+                // record landed, so no stall can strand it, and freezing
+                // here would re-fetch the same all-existing window forever.
+                if let Some(u) = &masked.updated_at {
+                    if max_updated
+                        .as_deref()
+                        .map(|m| u.as_str() > m)
+                        .unwrap_or(true)
+                    {
+                        max_updated = Some(u.clone());
                     }
                 }
                 continue;
             }
+            // Computed AFTER the existence lookup (see `ingest_prs`): a
+            // cursor-tie record that lands is covered by its own create.
+            let is_new = since
+                .as_deref()
+                .zip(masked.updated_at.as_deref())
+                .map(|(cursor, updated)| updated >= cursor)
+                .unwrap_or(true);
             if !is_new {
                 continue;
             }
             if budget.exhausted() {
+                // See `ingest_prs`: unvisited records remain, so the walk
+                // stops early even when the page is short; the
+                // exact-budget boundary resolves conservatively and a
+                // resumed pass completes idempotently.
+                window_complete = false;
                 break;
             }
 
@@ -2055,9 +2250,13 @@ async fn ingest_issues(
 
     if !window_complete {
         report.done = false;
-        report.sources.issues = Some(IngestSourceState::StoppedEarly(
+        *report
+            .sources
+            .issues
+            .as_mut()
+            .expect("issues state set when the walk began") = IngestSourceState::StoppedEarly(
             "budget exhausted or the paging floor stalled before the issue window completed".into(),
-        ));
+        );
     }
     if cursor_stalled {
         // Same contract as the commits and PR paths: a frozen issue cursor
@@ -2065,11 +2264,18 @@ async fn ingest_issues(
         // complete (issue #1645).
         report.cursor_stalled = true;
         report.done = false;
-        report.sources.issues = Some(IngestSourceState::StoppedEarly(
+        *report
+            .sources
+            .issues
+            .as_mut()
+            .expect("issues state set when the walk began") = IngestSourceState::StoppedEarly(
             "a per-record write failure froze the issues cursor (cursor_stalled)".into(),
-        ));
+        );
     }
     if window_complete && !cursor_stalled {
+        // See `ingest_prs`: completion is recorded at the exit, not left
+        // for the end-of-pass fill.
+        report.sources.issues = Some(IngestSourceState::Completed);
         *walk_complete = true;
     }
 

--- a/crates/khive-pack-git/src/ingest.rs
+++ b/crates/khive-pack-git/src/ingest.rs
@@ -248,7 +248,10 @@ pub struct IngestReport {
     /// history this pass — "silence means nothing left", as opposed to
     /// "stopped before the end" (budget exhausted, incomplete paging
     /// window, or a frozen cursor). Unlike `done`, this is a coverage
-    /// statement, not a resume-loop signal (issue #1617).
+    /// statement, not a resume-loop signal (issue #1617). Vacuously `true`
+    /// when `include` is empty: no source was requested, so nothing can
+    /// count against it — it is a statement about the REQUESTED sources,
+    /// not about the repository.
     pub history_exhausted: bool,
 }
 
@@ -272,6 +275,27 @@ fn record_write_failure(
     report
         .warnings
         .push(format!("{verb} {record_kind} {record_key}: {error}"));
+}
+
+/// Overwrite a walker's source slot with `StoppedEarly(reason)` from an
+/// end-of-walk arm. Seed invariant: every end-of-walk arm
+/// (`!window_complete` / `cursor_stalled`) is reachable only after at least
+/// one successful page fetch, and each walk seeds its slot on its FIRST
+/// successful fetch — so the slot is `Some` on every path today. The
+/// `None` arm keeps that a release-mode soft fallback: it constructs the
+/// state instead of panicking, with a debug tripwire for the
+/// instrumentation gap.
+fn pin_stopped_early(slot: &mut Option<IngestSourceState>, reason: String) {
+    match slot {
+        Some(state) => *state = IngestSourceState::StoppedEarly(reason),
+        None => {
+            debug_assert!(
+                false,
+                "walker reached an end-of-walk arm without seeding its source state"
+            );
+            *slot = Some(IngestSourceState::StoppedEarly(reason));
+        }
+    }
 }
 
 /// Run one ingest pass over `opts.repo`: issues + PRs first (via `gh`, when
@@ -368,9 +392,21 @@ pub(crate) async fn run_ingest_with_commit_recovery(
                         // `pull_requests` state unset. Anything else
                         // preserves the state the walker already wrote.
                         let walked = report.sources.pull_requests.is_some();
-                        report
-                            .warnings
-                            .push(format!("gh pr list failed, skipping pull requests: {e}"));
+                        if walked {
+                            // Align the prose with the structured state:
+                            // the walk happened, so nothing was "skipped" —
+                            // name how far it got before the pass failed.
+                            let visited = report.prs_ingested + report.prs_skipped_existing;
+                            let noun = if visited == 1 { "record" } else { "records" };
+                            report.warnings.push(format!(
+                                "gh pr list failed after walking {visited} {noun} — \
+                                 stopped early, not skipped: {e}"
+                            ));
+                        } else {
+                            report
+                                .warnings
+                                .push(format!("gh pr list failed, skipping pull requests: {e}"));
+                        }
                         if !walked {
                             report.sources.pull_requests = Some(IngestSourceState::Skipped(
                                 format!("gh pr list failed: {e}"),
@@ -429,9 +465,21 @@ pub(crate) async fn run_ingest_with_commit_recovery(
                 )
                 .await
                 {
-                    report
-                        .warnings
-                        .push(format!("gh issue list failed, skipping issues: {e}"));
+                    // See the PR arm above: "skipping" is only accurate for
+                    // a first-fetch failure; a walked-then-failed source
+                    // names how far the walk got.
+                    if report.sources.issues.is_some() {
+                        let visited = report.issues_ingested + report.issues_skipped_existing;
+                        let noun = if visited == 1 { "record" } else { "records" };
+                        report.warnings.push(format!(
+                            "gh issue list failed after walking {visited} {noun} — \
+                             stopped early, not skipped: {e}"
+                        ));
+                    } else {
+                        report
+                            .warnings
+                            .push(format!("gh issue list failed, skipping issues: {e}"));
+                    }
                     // See the PR arm above: `Skipped` only when the walk
                     // never began (the walker signals that by leaving its
                     // state unset); a walked-then-failed source keeps the
@@ -489,7 +537,7 @@ pub(crate) async fn run_ingest_with_commit_recovery(
     }
 
     if opts.include.commits && !budget.exhausted() {
-        ingest_commits(
+        match ingest_commits(
             runtime,
             token,
             registry,
@@ -503,7 +551,45 @@ pub(crate) async fn run_ingest_with_commit_recovery(
             &mut recover,
             &mut commits_complete,
         )
-        .await?;
+        .await
+        {
+            Ok(()) => {}
+            Err(e) => {
+                // `ingest_commits` records its source slot at every walker
+                // exit, so a `Some` slot beside an Err means the walk ran
+                // (possibly to completion) and the pass failed AFTER it —
+                // the final cursor write is the canonical case. Handle that
+                // in-band exactly like the gh walkers: downgrade to
+                // stopped-early and report, never abort the whole ingest
+                // over a failure that leaves the walked records landed. A
+                // `None` slot is a pre-walk failure (snapshot recovery,
+                // cursor read) and stays a hard error — the recovery
+                // contract depends on those surfacing.
+                if report.sources.commits.is_some() {
+                    match report.sources.commits.as_mut() {
+                        Some(IngestSourceState::StoppedEarly(reason)) => {
+                            reason.push_str(&format!("; pass then failed after the walk: {e}"));
+                        }
+                        // See the gh arms above: a completed walk whose pass
+                        // then fails is downgraded so the failure is never
+                        // invisible next to a `completed` claim.
+                        Some(state @ IngestSourceState::Completed) => {
+                            *state = IngestSourceState::StoppedEarly(format!(
+                                "walk completed but the pass then failed: {e}"
+                            ));
+                        }
+                        Some(IngestSourceState::Skipped(_)) | None => {}
+                    }
+                    report
+                        .warnings
+                        .push(format!("commit ingest failed after the walk: {e}"));
+                    report.done = false;
+                    commits_complete = false;
+                } else {
+                    return Err(e);
+                }
+            }
+        }
     } else if opts.include.commits {
         report.sources.commits = Some(IngestSourceState::Skipped(
             "budget exhausted before commits were reached".to_string(),
@@ -521,7 +607,14 @@ pub(crate) async fn run_ingest_with_commit_recovery(
     // at every exit), so each arm below is a release-mode belt-and-braces
     // fallback for a walker that returned without recording anything — an
     // instrumentation gap, not a normal stop, and its reason says so
-    // loudly instead of dressing the gap up as one.
+    // loudly instead of dressing the gap up as one. Fabrication risk, named
+    // for the next maintainer: in release builds the `debug_assert!` is a
+    // no-op and these arms synthesize a state from the bare completion flag
+    // alone — a future walker that sets a completion flag WITHOUT recording
+    // a source state would silently report a fabricated `completed` /
+    // `stopped_early` here with no real reason behind it. Every walker exit
+    // must record its own state; these arms exist only so a gap degrades to
+    // a loud placeholder instead of leaving the slot empty.
     if report.sources.pull_requests.is_none() && opts.include.pull_requests {
         debug_assert!(
             false,
@@ -1272,6 +1365,14 @@ async fn ingest_commits(
     // oldest-first) — combined with `find_commit_by_sha`'s DB lookup below,
     // this resolves parent edges regardless of which pass the parent landed
     // in.
+    //
+    // Stall guard on every `last_sha` advance below (`!cursor_stalled`):
+    // once a commit create fails, the persisted cursor must freeze at the
+    // last contiguous success — advancing it past a refused/failed record
+    // (including on a later EXISTING record, whose natural-key lookup
+    // proves only its own landing, not the failed record's) would strand
+    // the failed commit behind the floor and skip it forever instead of
+    // retrying it next pass.
     let mut local_sha_to_id: HashMap<String, Uuid> = HashMap::new();
     for c in &commits {
         if let Some(existing) = find_commit_by_sha(runtime, token, &c.sha).await? {
@@ -1432,6 +1533,12 @@ async fn ingest_commits(
         *walk_complete = true;
     }
     if let Some(sha) = last_sha {
+        // A stalled cursor has already frozen `last_sha` at the last
+        // contiguous success above; the write persists exactly that floor.
+        // A failure here surfaces at the call site, which distinguishes it
+        // from a pre-walk failure by the already-recorded source state and
+        // downgrades the pass to stopped-early in-band (never a hard
+        // abort of the whole ingest).
         write_cursor(runtime, project_id, "commits", &sha).await?;
     }
     if let Some(warning) = recovery_warning {
@@ -1875,19 +1982,26 @@ async fn ingest_prs(
                     merge_sha_to_pr.insert(oid, existing);
                 }
                 report.prs_skipped_existing += 1;
-                // Cursor advancement past an existing record is always safe:
-                // the record provably landed (natural-key lookup), so no
-                // stall can strand it. Restricting this to `!cursor_stalled`
-                // would freeze the cursor at the pass floor on any pass
-                // whose page is all-existing (the common resumed-pass
-                // shape), re-fetching the same full window forever.
-                if let Some(u) = &pr.updated_at {
-                    if max_updated
-                        .as_deref()
-                        .map(|m| u.as_str() > m)
-                        .unwrap_or(true)
-                    {
-                        max_updated = Some(u.clone());
+                // The natural-key lookup proves THIS record landed — but
+                // while this pass is stalled, records walked after the stall
+                // point sort at/after the refused record (pages are sorted
+                // ascending by `updated_at`). Advancing the floor past them
+                // would persist a cursor strictly newer than the refused
+                // record's timestamp, so the next pass's inclusive
+                // `updated >= cursor` filter would never re-fetch it —
+                // the refusal would be skipped forever instead of retried.
+                // The guard only fires on a stalled pass: a clean
+                // all-existing pass (the common resumed-pass shape) still
+                // advances normally and never re-fetches its window twice.
+                if !cursor_stalled {
+                    if let Some(u) = &pr.updated_at {
+                        if max_updated
+                            .as_deref()
+                            .map(|m| u.as_str() > m)
+                            .unwrap_or(true)
+                        {
+                            max_updated = Some(u.clone());
+                        }
                     }
                 }
                 continue;
@@ -2012,15 +2126,14 @@ async fn ingest_prs(
         // not a complete signal; report `done = false` regardless of budget
         // state so the caller's resume loop keeps going.
         report.done = false;
-        *report
-            .sources
-            .pull_requests
-            .as_mut()
-            .expect("pull_requests state set when the walk began") =
-            IngestSourceState::StoppedEarly(
-                "budget exhausted or the paging floor stalled before the PR window completed"
-                    .into(),
-            );
+        // Seed invariant (see `pin_stopped_early`): this arm is reachable
+        // only after at least one successful page fetch, and the first
+        // successful fetch seeds the slot above — the helper's `None` arm
+        // is a release-mode soft fallback, never a panic.
+        pin_stopped_early(
+            &mut report.sources.pull_requests,
+            "budget exhausted or the paging floor stalled before the PR window completed".into(),
+        );
     }
     if cursor_stalled {
         // A stalled PR cursor means records past the frozen floor were never
@@ -2028,14 +2141,11 @@ async fn ingest_prs(
         // complete when it is permanently behind (issue #1645).
         report.cursor_stalled = true;
         report.done = false;
-        *report
-            .sources
-            .pull_requests
-            .as_mut()
-            .expect("pull_requests state set when the walk began") =
-            IngestSourceState::StoppedEarly(
-                "a per-record write failure froze the pull_requests cursor (cursor_stalled)".into(),
-            );
+        // See the `!window_complete` arm above for the seed invariant.
+        pin_stopped_early(
+            &mut report.sources.pull_requests,
+            "a per-record write failure froze the pull_requests cursor (cursor_stalled)".into(),
+        );
     }
     if window_complete && !cursor_stalled {
         // Completion is recorded HERE too — every walker exit leaves the
@@ -2118,17 +2228,21 @@ async fn ingest_issues(
                 .is_some()
             {
                 report.issues_skipped_existing += 1;
-                // See `ingest_prs`: cursor advancement past an existing
-                // record is always safe — the natural-key lookup proves the
-                // record landed, so no stall can strand it, and freezing
-                // here would re-fetch the same all-existing window forever.
-                if let Some(u) = &masked.updated_at {
-                    if max_updated
-                        .as_deref()
-                        .map(|m| u.as_str() > m)
-                        .unwrap_or(true)
-                    {
-                        max_updated = Some(u.clone());
+                // See `ingest_prs`: while this pass is stalled, advancing
+                // the floor past records walked after the stall point would
+                // persist a cursor strictly newer than the refused record's
+                // timestamp and skip it forever instead of retrying it. A
+                // clean (non-stalled) all-existing pass still advances
+                // normally.
+                if !cursor_stalled {
+                    if let Some(u) = &masked.updated_at {
+                        if max_updated
+                            .as_deref()
+                            .map(|m| u.as_str() > m)
+                            .unwrap_or(true)
+                        {
+                            max_updated = Some(u.clone());
+                        }
                     }
                 }
                 continue;
@@ -2250,11 +2364,11 @@ async fn ingest_issues(
 
     if !window_complete {
         report.done = false;
-        *report
-            .sources
-            .issues
-            .as_mut()
-            .expect("issues state set when the walk began") = IngestSourceState::StoppedEarly(
+        // Seed invariant (see `pin_stopped_early`): this arm is reachable
+        // only after at least one successful page fetch, and the first
+        // successful fetch seeds the slot above.
+        pin_stopped_early(
+            &mut report.sources.issues,
             "budget exhausted or the paging floor stalled before the issue window completed".into(),
         );
     }
@@ -2264,11 +2378,9 @@ async fn ingest_issues(
         // complete (issue #1645).
         report.cursor_stalled = true;
         report.done = false;
-        *report
-            .sources
-            .issues
-            .as_mut()
-            .expect("issues state set when the walk began") = IngestSourceState::StoppedEarly(
+        // See the `!window_complete` arm above for the seed invariant.
+        pin_stopped_early(
+            &mut report.sources.issues,
             "a per-record write failure froze the issues cursor (cursor_stalled)".into(),
         );
     }

--- a/crates/khive-pack-git/src/ingest.rs
+++ b/crates/khive-pack-git/src/ingest.rs
@@ -134,8 +134,9 @@ pub enum IngestSourceState {
     /// `gh --version`, so such a repo skips only when `gh` is absent, and
     /// when `gh` IS present it takes the walker-failure path, whose reason
     /// carries `gh`'s own stderr) — or `gh` itself failed before the walk
-    /// began (a failure after the walk began is `StoppedEarly`, never
-    /// `Skipped`).
+    /// began. A local cursor/database read failure before remote listing is
+    /// also `Skipped`, with a distinct local-failure reason. A failure after
+    /// the walk began is `StoppedEarly`, never `Skipped`.
     Skipped(String),
 }
 
@@ -391,7 +392,10 @@ pub(crate) async fn run_ingest_with_commit_recovery(
                         // walker signals that case by leaving its
                         // `pull_requests` state unset. Anything else
                         // preserves the state the walker already wrote.
-                        let walked = report.sources.pull_requests.is_some();
+                        let walked = matches!(
+                            report.sources.pull_requests.as_ref(),
+                            Some(IngestSourceState::Completed | IngestSourceState::StoppedEarly(_))
+                        );
                         if walked {
                             // Align the prose with the structured state:
                             // the walk happened, so nothing was "skipped" —
@@ -402,16 +406,20 @@ pub(crate) async fn run_ingest_with_commit_recovery(
                                 "gh pr list failed after walking {visited} {noun} — \
                                  stopped early, not skipped: {e}"
                             ));
-                        } else {
+                        } else if report.sources.pull_requests.is_none() {
                             report
                                 .warnings
                                 .push(format!("gh pr list failed, skipping pull requests: {e}"));
+                        } else {
+                            report.warnings.push(format!(
+                                "pull request ingest failed before remote listing; local source failure retained: {e}"
+                            ));
                         }
-                        if !walked {
+                        if !walked && report.sources.pull_requests.is_none() {
                             report.sources.pull_requests = Some(IngestSourceState::Skipped(
                                 format!("gh pr list failed: {e}"),
                             ));
-                        } else {
+                        } else if walked {
                             match report.sources.pull_requests.as_mut() {
                                 Some(IngestSourceState::StoppedEarly(reason)) => {
                                     reason.push_str(&format!(
@@ -468,27 +476,35 @@ pub(crate) async fn run_ingest_with_commit_recovery(
                     // See the PR arm above: "skipping" is only accurate for
                     // a first-fetch failure; a walked-then-failed source
                     // names how far the walk got.
-                    if report.sources.issues.is_some() {
+                    let walked = matches!(
+                        report.sources.issues.as_ref(),
+                        Some(IngestSourceState::Completed | IngestSourceState::StoppedEarly(_))
+                    );
+                    if walked {
                         let visited = report.issues_ingested + report.issues_skipped_existing;
                         let noun = if visited == 1 { "record" } else { "records" };
                         report.warnings.push(format!(
                             "gh issue list failed after walking {visited} {noun} — \
                              stopped early, not skipped: {e}"
                         ));
-                    } else {
+                    } else if report.sources.issues.is_none() {
                         report
                             .warnings
                             .push(format!("gh issue list failed, skipping issues: {e}"));
+                    } else {
+                        report.warnings.push(format!(
+                            "issue ingest failed before remote listing; local source failure retained: {e}"
+                        ));
                     }
                     // See the PR arm above: `Skipped` only when the walk
                     // never began (the walker signals that by leaving its
                     // state unset); a walked-then-failed source keeps the
                     // state the walker already wrote.
-                    if report.sources.issues.is_none() {
+                    if !walked && report.sources.issues.is_none() {
                         report.sources.issues = Some(IngestSourceState::Skipped(format!(
                             "gh issue list failed: {e}"
                         )));
-                    } else {
+                    } else if walked {
                         match report.sources.issues.as_mut() {
                             Some(IngestSourceState::StoppedEarly(reason)) => {
                                 reason.push_str(&format!("; pass then failed after the walk: {e}"));
@@ -1232,6 +1248,13 @@ const NAME_MAX_CHARS: usize = 120;
 /// stored and FTS-indexed; only the candidate vector input is capped.
 const MAX_COMMIT_EMBED_BYTES: usize = 32_768;
 
+/// Sentinel reason seeded into the commit source slot when a walk begins.
+/// A slot still holding this exact reason at the end of the pass means the
+/// walk ran to the end of its snapshot without a budget break or a stall,
+/// and is rewritten to `Completed`; any other reason was written by a real
+/// early-stop arm and is preserved.
+const COMMIT_WALK_SEED_REASON: &str = "walk began but did not report completion";
+
 /// Returns a UTF-8-valid, proper head prefix of `content` when it exceeds
 /// `MAX_COMMIT_EMBED_BYTES`, or `None` when `content` is at or under the cap
 /// (nothing to truncate — the full text is a valid embedding input as-is).
@@ -1349,6 +1372,14 @@ async fn ingest_commits(
         }
         return Ok(());
     }
+
+    // A non-empty snapshot means the commit walk is now underway. Seed the
+    // source before the first natural-key lookup so a mid-walk database error
+    // is reported in-band as walked-then-failed rather than as a pre-walk
+    // hard error. Cursor and snapshot failures above remain pre-walk errors.
+    report.sources.commits = Some(IngestSourceState::StoppedEarly(
+        COMMIT_WALK_SEED_REASON.into(),
+    ));
 
     // `cursor_stalled` freezes `last_sha` at the last contiguous successfully
     // processed commit: once a record fails to create, later records in this
@@ -1524,13 +1555,21 @@ async fn ingest_commits(
         report.sources.commits = Some(IngestSourceState::StoppedEarly(
             "a per-record write failure froze the commits cursor (cursor_stalled)".into(),
         ));
-    } else if report.sources.commits.is_none() {
-        // Neither a budget break nor a stall fired: the loop visited every
-        // commit in the snapshot. Recorded HERE, like the budget and stall
-        // arms — every walker exit records its own state so the end-of-pass
-        // fill is a pure instrumentation-gap fallback.
-        report.sources.commits = Some(IngestSourceState::Completed);
-        *walk_complete = true;
+    } else {
+        let walk_ended_clean = match &report.sources.commits {
+            None => true,
+            Some(IngestSourceState::StoppedEarly(reason)) => reason == COMMIT_WALK_SEED_REASON,
+            Some(_) => false,
+        };
+        if walk_ended_clean {
+            // Neither a budget break nor a stall fired: the loop visited
+            // every commit in the snapshot, so the walk-start seed (or a
+            // `None` from an instrumentation gap) is rewritten to
+            // `Completed`. Any other reason was written by a real
+            // early-stop arm and is preserved.
+            report.sources.commits = Some(IngestSourceState::Completed);
+            *walk_complete = true;
+        }
     }
     if let Some(sha) = last_sha {
         // A stalled cursor has already frozen `last_sha` at the last
@@ -1930,7 +1969,15 @@ async fn ingest_prs(
     new_records: &mut Vec<NewRecordForRef>,
     walk_complete: &mut bool,
 ) -> Result<()> {
-    let since = read_cursor(runtime, project_id, "prs").await?;
+    let since = match read_cursor(runtime, project_id, "prs").await {
+        Ok(since) => since,
+        Err(e) => {
+            report.sources.pull_requests = Some(IngestSourceState::Skipped(format!(
+                "local cursor/database read failed before pull request listing: {e}"
+            )));
+            return Err(e);
+        }
+    };
 
     // `cursor_stalled` mirrors `ingest_commits`: once one PR fails to create,
     // later PRs in this pass are still attempted (so every failure surfaces
@@ -1941,6 +1988,7 @@ async fn ingest_prs(
     let mut cursor_stalled = false;
     let mut floor = since.clone();
     let mut window_complete = true;
+    let mut stop_reason: Option<&'static str> = None;
 
     'paging: loop {
         // The FIRST fetch failing must report `skipped` (never walked);
@@ -2028,6 +2076,7 @@ async fn ingest_prs(
                 // "records remained", and the conservative answer is
                 // stopped-early — a resumed pass completes idempotently.
                 window_complete = false;
+                stop_reason = Some("budget exhausted before the pull request window completed");
                 break;
             }
 
@@ -2112,8 +2161,16 @@ async fn ingest_prs(
             budget.exhausted(),
         ) {
             PageOutcome::WindowComplete => break 'paging,
-            PageOutcome::StopBudgetExhausted | PageOutcome::StopFloorStalled => {
+            PageOutcome::StopBudgetExhausted => {
                 window_complete = false;
+                stop_reason = Some("budget exhausted before the pull request window completed");
+                break 'paging;
+            }
+            PageOutcome::StopFloorStalled => {
+                window_complete = false;
+                stop_reason = Some(
+                    "full page returned but the pull request paging floor stalled before the window completed",
+                );
                 break 'paging;
             }
             PageOutcome::Continue(next_floor) => floor = Some(next_floor),
@@ -2132,7 +2189,9 @@ async fn ingest_prs(
         // is a release-mode soft fallback, never a panic.
         pin_stopped_early(
             &mut report.sources.pull_requests,
-            "budget exhausted or the paging floor stalled before the PR window completed".into(),
+            stop_reason
+                .unwrap_or("the pull request paging window was not proven complete")
+                .into(),
         );
     }
     if cursor_stalled {
@@ -2173,7 +2232,15 @@ async fn ingest_issues(
     new_records: &mut Vec<NewRecordForRef>,
     walk_complete: &mut bool,
 ) -> Result<()> {
-    let since = read_cursor(runtime, project_id, "issues").await?;
+    let since = match read_cursor(runtime, project_id, "issues").await {
+        Ok(since) => since,
+        Err(e) => {
+            report.sources.issues = Some(IngestSourceState::Skipped(format!(
+                "local cursor/database read failed before issue listing: {e}"
+            )));
+            return Err(e);
+        }
+    };
 
     // `cursor_stalled` mirrors `ingest_commits`/`ingest_prs`: a per-record
     // create failure is aggregated as a warning and later records in this
@@ -2184,6 +2251,7 @@ async fn ingest_issues(
     let mut cursor_stalled = false;
     let mut floor = since.clone();
     let mut window_complete = true;
+    let mut stop_reason: Option<&'static str> = None;
 
     'paging: loop {
         // See `ingest_prs`: the first fetch failing must report `skipped`
@@ -2263,6 +2331,7 @@ async fn ingest_issues(
                 // exact-budget boundary resolves conservatively and a
                 // resumed pass completes idempotently.
                 window_complete = false;
+                stop_reason = Some("budget exhausted before the issue window completed");
                 break;
             }
 
@@ -2354,8 +2423,16 @@ async fn ingest_issues(
             budget.exhausted(),
         ) {
             PageOutcome::WindowComplete => break 'paging,
-            PageOutcome::StopBudgetExhausted | PageOutcome::StopFloorStalled => {
+            PageOutcome::StopBudgetExhausted => {
                 window_complete = false;
+                stop_reason = Some("budget exhausted before the issue window completed");
+                break 'paging;
+            }
+            PageOutcome::StopFloorStalled => {
+                window_complete = false;
+                stop_reason = Some(
+                    "full page returned but the issue paging floor stalled before the window completed",
+                );
                 break 'paging;
             }
             PageOutcome::Continue(next_floor) => floor = Some(next_floor),
@@ -2369,7 +2446,9 @@ async fn ingest_issues(
         // successful fetch seeds the slot above.
         pin_stopped_early(
             &mut report.sources.issues,
-            "budget exhausted or the paging floor stalled before the issue window completed".into(),
+            stop_reason
+                .unwrap_or("the issue paging window was not proven complete")
+                .into(),
         );
     }
     if cursor_stalled {

--- a/crates/khive-pack-git/tests/acceptance.rs
+++ b/crates/khive-pack-git/tests/acceptance.rs
@@ -3417,6 +3417,194 @@ async fn digest_verb_max_items_is_bounded_and_resumable() {
     );
 }
 
+// ── issue #1617: per-source tri-state + history-exhaustion reporting ───────
+
+/// A clean full pass marks every included source `completed` and reports
+/// `history_exhausted: true` — "nothing walked past this point" is now
+/// distinguishable from silence (issue #1617).
+#[tokio::test]
+async fn digest_verb_sources_completed_and_history_exhausted_on_full_walk() {
+    let _guard = ENV_MUTEX.lock().await;
+    let (_rt, _token, registry) = fixture().await;
+
+    let dir = tempfile::tempdir().expect("tempdir");
+    let repo = dir.path();
+    init_repo(repo);
+    for i in 0..2 {
+        write(repo, "f.txt", &format!("v{i}\n"));
+        commit(repo, &["f.txt"], &format!("commit {i}"));
+    }
+
+    // No fake `gh` on PATH: issues/PRs take the gh_cli_absent skip arm.
+    let resp = registry
+        .dispatch(
+            "git.digest",
+            json!({
+                "source": repo.to_str().unwrap(),
+                "include": ["commits", "issues", "pull_requests"]
+            }),
+        )
+        .await
+        .expect("digest ok");
+
+    assert_eq!(resp["commits_ingested"].as_u64().unwrap(), 2);
+    assert_eq!(
+        resp["sources"]["commits"],
+        json!({"state": "completed"}),
+        "a walked-to-the-tip commit source completes: {resp:?}"
+    );
+    assert_eq!(
+        resp["sources"]["issues"]["state"], "skipped",
+        "gh absent must surface as a structured skip, not prose: {resp:?}"
+    );
+    assert_eq!(resp["sources"]["pull_requests"]["state"], "skipped");
+    assert!(
+        !resp["history_exhausted"].as_bool().unwrap(),
+        "skipped sources mean the walk did not cover everything requested: {resp:?}"
+    );
+
+    // A commits-only pass walks every requested source to the end.
+    let commits_only = registry
+        .dispatch(
+            "git.digest",
+            json!({
+                "source": repo.to_str().unwrap(),
+                "include": ["commits"]
+            }),
+        )
+        .await
+        .expect("digest ok");
+    assert_eq!(
+        commits_only["sources"]["commits"],
+        json!({"state": "completed"}),
+        "an idempotent empty-range walk is still a completion: {commits_only:?}"
+    );
+    assert!(
+        commits_only["history_exhausted"].as_bool().unwrap(),
+        "every requested source completed: {commits_only:?}"
+    );
+    assert!(
+        commits_only["done"].as_bool().unwrap(),
+        "done keeps its budget-cursor meaning alongside: {commits_only:?}"
+    );
+}
+
+/// Budget exhaustion marks the source `stopped_early` and
+/// `history_exhausted: false`, while `done: false` keeps its existing
+/// resume-loop meaning (issue #1617).
+#[tokio::test]
+async fn digest_verb_sources_stopped_early_on_budget_exhaustion() {
+    let _guard = ENV_MUTEX.lock().await;
+    let (_rt, _token, registry) = fixture().await;
+
+    let dir = tempfile::tempdir().expect("tempdir");
+    let repo = dir.path();
+    init_repo(repo);
+    for i in 0..3 {
+        write(repo, "f.txt", &format!("v{i}\n"));
+        commit(repo, &["f.txt"], &format!("commit {i}"));
+    }
+
+    let resp = registry
+        .dispatch(
+            "git.digest",
+            json!({"source": repo.to_str().unwrap(), "max_items": 1, "include": ["commits"]}),
+        )
+        .await
+        .expect("digest ok");
+
+    assert_eq!(resp["commits_ingested"].as_u64().unwrap(), 1);
+    assert!(
+        !resp["done"].as_bool().unwrap(),
+        "budget exhausted with commits unwalked: {resp:?}"
+    );
+    assert_eq!(
+        resp["sources"]["commits"]["state"], "stopped_early",
+        "budget exhaustion is a stop-early, not a completion: {resp:?}"
+    );
+    assert!(
+        resp["sources"]["commits"]["reason"]
+            .as_str()
+            .is_some_and(|r| r.contains("budget")),
+        "the reason names the budget as the cause: {resp:?}"
+    );
+    assert!(
+        !resp["history_exhausted"].as_bool().unwrap(),
+        "a budget-stopped walk is not exhaustion: {resp:?}"
+    );
+}
+
+/// A per-record write refusal on one commit skips that record and the walk
+/// continues: later commits in the same pass still land. The source is
+/// `stopped_early` (cursor frozen for retry, issue #1645 semantics) and the
+/// refusal is mechanically attributable to the commits source (issue #1617).
+/// The deterministic failure uses the design-mandated fail-once embedder
+/// (see `pr_ingest_sorts_by_updated_at_so_frozen_cursor_survives_out_of_order_listing`
+/// for why a leaked-credential fixture no longer forces a create failure).
+#[tokio::test]
+async fn digest_verb_sources_gate_refusal_skips_record_and_walk_continues() {
+    let _guard = ENV_MUTEX.lock().await;
+    let (rt, _token, registry) = fixture().await;
+    rt.register_embedder(FailOnceEmbedderProvider);
+
+    let dir = tempfile::tempdir().expect("tempdir");
+    let repo = dir.path();
+    init_repo(repo);
+    // Oldest first: clean, refused (sentinel body), clean.
+    write(repo, "f.txt", "v0\n");
+    commit(repo, &["f.txt"], "commit 0");
+    write(repo, "f.txt", "v1\n");
+    commit(
+        repo,
+        &["f.txt"],
+        &format!("commit 1\n\n{CURSOR_FAIL_SENTINEL}"),
+    );
+    write(repo, "f.txt", "v2\n");
+    commit(repo, &["f.txt"], "commit 2");
+
+    let resp = registry
+        .dispatch(
+            "git.digest",
+            json!({"source": repo.to_str().unwrap(), "include": ["commits"]}),
+        )
+        .await
+        .expect("a per-record refusal must stay an in-band digest result");
+
+    assert_eq!(
+        resp["commits_ingested"].as_u64().unwrap(),
+        2,
+        "the refusal never terminates the walk — the later commit lands: {resp:?}"
+    );
+    assert_eq!(
+        resp["warnings"]
+            .as_array()
+            .expect("warnings")
+            .iter()
+            .filter(|w| w.as_str().is_some_and(|w| w.contains("create commit")))
+            .count(),
+        1,
+        "exactly one warning records the refused commit write: {resp:?}"
+    );
+    assert_eq!(
+        resp["sources"]["commits"]["state"], "stopped_early",
+        "a frozen cursor is a stop-early, distinct from budget and skip: {resp:?}"
+    );
+    assert!(
+        resp["sources"]["commits"]["reason"]
+            .as_str()
+            .is_some_and(|r| r.contains("cursor_stalled")),
+        "the reason names the frozen cursor as the cause: {resp:?}"
+    );
+    assert!(
+        !resp["history_exhausted"].as_bool().unwrap(),
+        "an unretried refused record means the history is not exhausted: {resp:?}"
+    );
+    assert!(
+        !resp["done"].as_bool().unwrap(),
+        "cursor_stalled still forces done:false beside the new fields: {resp:?}"
+    );
+}
+
 /// Source validation surfaces as a normal verb error (ssh:// rejected,
 /// ADR-088 Amendment 1 security posture) rather than panicking or silently
 /// no-op'ing.

--- a/crates/khive-pack-git/tests/acceptance.rs
+++ b/crates/khive-pack-git/tests/acceptance.rs
@@ -3605,6 +3605,502 @@ async fn digest_verb_sources_gate_refusal_skips_record_and_walk_continues() {
     );
 }
 
+// ── issue #1617: PR/issue source states over a stubbed `gh` ─────
+
+/// `gh {pr,issue} list --json` field sets, mirrored from `ingest.rs`'s
+/// private constants so the fixtures below fail loudly (parse error) if the
+/// production field set ever drifts.
+fn pr_fixture(number: u64, title: &str, updated_at: &str) -> Value {
+    json!({
+        "number": number,
+        "title": title,
+        "author": {"login": "octocat"},
+        "createdAt": "2026-01-01T00:00:00Z",
+        "mergedAt": null,
+        "closedAt": null,
+        "updatedAt": updated_at,
+        "baseRefName": "main",
+        "headRefName": "feature/x",
+        "mergeCommit": null,
+        "body": format!("body of PR #{number}")
+    })
+}
+
+fn issue_fixture(number: u64, title: &str, updated_at: &str) -> Value {
+    json!({
+        "number": number,
+        "title": title,
+        "author": {"login": "octocat"},
+        "createdAt": "2026-01-01T00:00:00Z",
+        "closedAt": null,
+        "updatedAt": updated_at,
+        "labels": [],
+        "stateReason": "",
+        "body": format!("body of issue #{number}")
+    })
+}
+
+/// A happy-path pass over a PATH-shadowing fake `gh`: the PR and issue
+/// walkers report `completed`, records land, and `history_exhausted` is
+/// true — the PR/issue half of the tri-state that previously only had
+/// commit-side coverage (issue #1617).
+#[tokio::test]
+async fn digest_verb_pr_issue_sources_completed_on_happy_path() {
+    let _guard = ENV_MUTEX.lock().await;
+    let (rt, token, registry) = fixture().await;
+
+    let project_id = create(
+        &registry,
+        json!({"kind": "project", "name": "tristate-happy-repo"}),
+    )
+    .await;
+
+    let dir = tempfile::tempdir().expect("tempdir");
+    let repo: PathBuf = dir.path().join("repo");
+    std::fs::create_dir_all(&repo).expect("mk repo dir");
+    init_repo(&repo);
+    write(&repo, "README.md", "hello\n");
+    commit(&repo, &["README.md"], "Initial commit");
+
+    let bin_dir = dir.path().join("bin");
+    std::fs::create_dir_all(&bin_dir).expect("mk bin dir");
+    let log_dir = dir.path().join("log");
+    std::fs::create_dir_all(&log_dir).expect("mk log dir");
+
+    let pr_json = json!([
+        pr_fixture(1, "Add feature", "2026-01-01T00:00:01Z"),
+        pr_fixture(2, "Fix bug", "2026-01-01T00:00:02Z"),
+    ])
+    .to_string();
+    let issue_json = json!([
+        issue_fixture(10, "Bug report", "2026-01-01T00:00:01Z"),
+        issue_fixture(11, "Feature request", "2026-01-01T00:00:02Z"),
+    ])
+    .to_string();
+
+    write_fake_gh(&bin_dir, &log_dir, &pr_json, &issue_json);
+    let _path_guard = PathGuard::install(&bin_dir);
+
+    let report = run_ingest(
+        &rt,
+        &token,
+        &registry,
+        IngestOptions::unbounded(repo.clone(), project_id.to_string()),
+    )
+    .await
+    .expect("ingest ok");
+
+    assert_eq!(report.prs_ingested, 2, "{report:?}");
+    assert_eq!(report.issues_ingested, 2, "{report:?}");
+    assert_eq!(
+        report.sources.pull_requests,
+        Some(khive_pack_git::ingest::IngestSourceState::Completed),
+        "a PR window walked to the end completes: {report:?}"
+    );
+    assert_eq!(
+        report.sources.issues,
+        Some(khive_pack_git::ingest::IngestSourceState::Completed),
+        "an issue window walked to the end completes: {report:?}"
+    );
+    assert_eq!(
+        report.sources.commits,
+        Some(khive_pack_git::ingest::IngestSourceState::Completed),
+        "{report:?}"
+    );
+    assert!(
+        report.history_exhausted,
+        "every included source completed: {report:?}"
+    );
+    assert!(report.done, "{report:?}");
+}
+
+/// With the budget spent mid-walk, a walker that breaks inside its record
+/// loop reports `stopped_early` (visited, not exhausted) while sources
+/// never even reached report `skipped` with the pre-reached budget reason
+/// — stopped_early and skipped side by side in one pass (issue #1617).
+/// Walk order is pull_requests → issues → commits, so `max_items: 1`
+/// lands the first PR, stops the PR walk on its second record, and skips
+/// issues and commits outright.
+#[tokio::test]
+async fn digest_verb_pr_issue_sources_stopped_early_on_budget_stop() {
+    let _guard = ENV_MUTEX.lock().await;
+    let (rt, token, registry) = fixture().await;
+
+    let project_id = create(
+        &registry,
+        json!({"kind": "project", "name": "tristate-budget-repo"}),
+    )
+    .await;
+
+    let dir = tempfile::tempdir().expect("tempdir");
+    let repo: PathBuf = dir.path().join("repo");
+    std::fs::create_dir_all(&repo).expect("mk repo dir");
+    init_repo(&repo);
+    write(&repo, "README.md", "hello\n");
+    commit(&repo, &["README.md"], "Initial commit");
+
+    let bin_dir = dir.path().join("bin");
+    std::fs::create_dir_all(&bin_dir).expect("mk bin dir");
+    let log_dir = dir.path().join("log");
+    std::fs::create_dir_all(&log_dir).expect("mk log dir");
+
+    let pr_json = json!([
+        pr_fixture(1, "Add feature", "2026-01-01T00:00:01Z"),
+        pr_fixture(2, "Fix bug", "2026-01-01T00:00:02Z"),
+    ])
+    .to_string();
+    let issue_json = json!([
+        issue_fixture(10, "Bug report", "2026-01-01T00:00:01Z"),
+        issue_fixture(11, "Feature request", "2026-01-01T00:00:02Z"),
+    ])
+    .to_string();
+
+    write_fake_gh(&bin_dir, &log_dir, &pr_json, &issue_json);
+    let _path_guard = PathGuard::install(&bin_dir);
+
+    // max_items = 1: the first PR lands, the PR walk breaks on its second
+    // record, and issues/commits are never reached at all. (An in-walk
+    // budget break for BOTH gh walkers in one pass is unreachable with
+    // this fixture: the last budget unit is always spendable on a record
+    // — `budget.exhausted()` gates the NEXT record, not the current one —
+    // so the first walker to run consumes what the second would have
+    // needed. The issue walker's own stopped-early machinery is covered
+    // by `issue_full_page_never_leaks_raw_updated_at_into_paging_floor`
+    // and the frozen-cursor coverage.)
+    let mut opts = IngestOptions::unbounded(repo.clone(), project_id.to_string());
+    opts.max_items = Some(1);
+    let report = run_ingest(&rt, &token, &registry, opts)
+        .await
+        .expect("ingest ok");
+
+    assert_eq!(
+        report.prs_ingested, 1,
+        "the first PR lands before the budget runs out: {report:?}"
+    );
+    assert_eq!(report.issues_ingested, 0, "{report:?}");
+    assert_eq!(report.commits_ingested, 0, "{report:?}");
+    match &report.sources.pull_requests {
+        Some(khive_pack_git::ingest::IngestSourceState::StoppedEarly(reason)) => {
+            assert!(
+                reason.contains("budget"),
+                "the reason names the budget as the cause: {reason:?}"
+            );
+        }
+        other => panic!("a budget-stopped walk is stopped_early, got {other:?}"),
+    }
+    assert_eq!(
+        report.sources.issues,
+        Some(khive_pack_git::ingest::IngestSourceState::Skipped(
+            "budget exhausted before issues were reached".to_string()
+        )),
+        "issues were never reached — a genuine skip: {report:?}"
+    );
+    assert_eq!(
+        report.sources.commits,
+        Some(khive_pack_git::ingest::IngestSourceState::Skipped(
+            "budget exhausted before commits were reached".to_string()
+        )),
+        "commits were never reached — a genuine skip: {report:?}"
+    );
+    assert!(
+        !report.history_exhausted,
+        "budget-stopped sources are not exhaustion: {report:?}"
+    );
+    assert!(!report.done, "{report:?}");
+}
+
+/// The full-page paging stop: a `PAGE_LIMIT`-sized PR page forces the
+/// walker to stop with the remote window unproven — `stopped_early`, not
+/// `completed` (issue #1617; the issue walker's paging stop is
+/// already covered by
+/// `issue_full_page_never_leaks_raw_updated_at_into_paging_floor`).
+///
+/// Then the walked-then-failed arm (the walked-then-failed finding): the stub
+/// is swapped to fail, and the second pass's FIRST fetch errors. Because
+/// the walk-start marker is only written after the first page lands, a
+/// fresh pass whose first fetch fails was genuinely never walked — so
+/// `skipped` remains correct HERE, and the never-overwrite invariant is
+/// instead pinned by the cursor-write-failure test below (the one
+/// post-visit Err site reachable with the standing stub infra). A
+/// `stopped_early`-after-full-window pass is also not completable with
+/// this stub infra: the canned stub cannot honor the `updated:>=` search
+/// floor, so a resumed pass re-fetches the identical full page and the
+/// floor legitimately stalls (`StopFloorStalled`) — the `completed` state
+/// is covered by the happy-path and budget-stop tests instead.
+#[tokio::test]
+async fn digest_verb_pr_source_stopped_early_on_full_page_then_refetch_failure_stays_skipped() {
+    let _guard = ENV_MUTEX.lock().await;
+    let (rt, token, registry) = fixture().await;
+
+    let project_id = create(
+        &registry,
+        json!({"kind": "project", "name": "tristate-paging-repo"}),
+    )
+    .await;
+
+    let dir = tempfile::tempdir().expect("tempdir");
+    let repo: PathBuf = dir.path().join("repo");
+    std::fs::create_dir_all(&repo).expect("mk repo dir");
+    init_repo(&repo);
+    write(&repo, "README.md", "hello\n");
+    commit(&repo, &["README.md"], "Initial commit");
+
+    let bin_dir = dir.path().join("bin");
+    std::fs::create_dir_all(&bin_dir).expect("mk bin dir");
+    let log_dir = dir.path().join("log");
+    std::fs::create_dir_all(&log_dir).expect("mk log dir");
+
+    // Mirrors `ingest.rs`'s private `PAGE_LIMIT`.
+    const PAGE_LIMIT: usize = 1000;
+    let prs: Vec<Value> = (1..=PAGE_LIMIT as u64)
+        .map(|i| pr_fixture(i, &format!("pr {i}"), "2026-01-01T00:16:00Z"))
+        .collect();
+    write_fake_gh(&bin_dir, &log_dir, &Value::Array(prs).to_string(), "[]");
+    let _path_guard = PathGuard::install(&bin_dir);
+
+    let mut opts = IngestOptions::unbounded(repo.clone(), project_id.to_string());
+    opts.include.commits = false;
+    opts.include.issues = false;
+    let report = run_ingest(&rt, &token, &registry, opts.clone())
+        .await
+        .expect("ingest ok");
+
+    assert_eq!(report.prs_ingested, PAGE_LIMIT as u64, "{report:?}");
+    match &report.sources.pull_requests {
+        Some(khive_pack_git::ingest::IngestSourceState::StoppedEarly(reason)) => {
+            assert!(
+                reason.contains("window"),
+                "the reason names the incomplete paging window: {reason:?}"
+            );
+        }
+        other => panic!("a full page with an unproven window is stopped_early, got {other:?}"),
+    }
+    assert!(
+        !report.done && !report.history_exhausted,
+        "the resume loop must keep going past an unproven window: {report:?}"
+    );
+
+    // A fresh pass whose FIRST fetch fails was never walked: `skipped`
+    // stays accurate (the marker distinguishes "failed before the walk"
+    // from "failed after it").
+    let script = r#"#!/bin/sh
+case "$1" in
+  --version)
+    echo "gh version 2.0.0 (fake)"
+    ;;
+  *)
+    echo "fake gh: simulated listing outage" 1>&2
+    exit 1
+    ;;
+esac
+"#;
+    std::fs::write(bin_dir.join("gh"), script).expect("swap stub to failing");
+
+    let report2 = run_ingest(&rt, &token, &registry, opts)
+        .await
+        .expect("a gh listing failure must stay an in-band ingest result");
+    match &report2.sources.pull_requests {
+        Some(khive_pack_git::ingest::IngestSourceState::Skipped(reason)) => {
+            assert!(
+                reason.contains("gh pr list failed"),
+                "a first-fetch failure reports skipped with the cause: {reason:?}"
+            );
+        }
+        other => panic!("a never-walked source must report skipped, got {other:?}"),
+    }
+    assert!(
+        report2
+            .warnings
+            .iter()
+            .any(|w| w.contains("gh pr list failed")),
+        "the failure also surfaces as a warning: {:?}",
+        report2.warnings
+    );
+}
+
+/// The walked-then-failed invariant (the walked-then-failed finding), driven
+/// through the one post-visit Err site the standing stub infra can reach:
+/// the cursor write at the end of the issue walk. A pass that walks the
+/// window to completion and THEN fails persisting the cursor must never
+/// regress to `skipped` ("never walked") — and must not stay `completed`
+/// either: the walk happened but the pass failed, so the state downgrades
+/// to `stopped_early` with the failure in the reason, and neither `done`
+/// nor `history_exhausted` may claim the source is finished.
+#[tokio::test]
+async fn ingest_walked_then_cursor_write_fails_never_reports_skipped() {
+    let _guard = ENV_MUTEX.lock().await;
+    let (rt, token, registry) = fixture().await;
+
+    let project_id = create(
+        &registry,
+        json!({"kind": "project", "name": "walked-then-failed-repo"}),
+    )
+    .await;
+
+    let dir = tempfile::tempdir().expect("tempdir");
+    let repo: PathBuf = dir.path().join("repo");
+    std::fs::create_dir_all(&repo).expect("mk repo dir");
+    init_repo(&repo);
+    write(&repo, "README.md", "hello\n");
+    commit(&repo, &["README.md"], "Initial commit");
+
+    let bin_dir = dir.path().join("bin");
+    std::fs::create_dir_all(&bin_dir).expect("mk bin dir");
+    let log_dir = dir.path().join("log");
+    std::fs::create_dir_all(&log_dir).expect("mk log dir");
+
+    let issue_json = json!([issue_fixture(1, "Bug report", "2026-01-01T00:00:01Z")]).to_string();
+    write_fake_gh(&bin_dir, &log_dir, "[]", &issue_json);
+    let _path_guard = PathGuard::install(&bin_dir);
+
+    // Sabotage ONLY the cursor write: read_cursor must keep working (it is
+    // the walker's first statement, before any page fetch), so the table
+    // stays, with a trigger that aborts every INSERT. The walker then runs
+    // the full pass — records land, completion states are recorded — and
+    // fails at the final `write_cursor`, after the walk.
+    let mut writer = rt.sql().writer().await.expect("writer");
+    writer
+        .execute(SqlStatement {
+            sql: "CREATE TRIGGER fail_cursor_write BEFORE INSERT ON git_mirror_cursor \
+                  BEGIN SELECT RAISE(ABORT, 'sabotaged cursor write'); END"
+                .into(),
+            params: vec![],
+            label: Some("test_fail_cursor_write".into()),
+        })
+        .await
+        .expect("install sabotage trigger");
+
+    let mut opts = IngestOptions::unbounded(repo.clone(), project_id.to_string());
+    opts.include.commits = false;
+    opts.include.pull_requests = false;
+    let report = run_ingest(&rt, &token, &registry, opts)
+        .await
+        .expect("a post-walk cursor-write failure must stay in-band");
+
+    assert_eq!(
+        report.issues_ingested, 1,
+        "the record landed before the cursor write failed: {report:?}"
+    );
+    match &report.sources.issues {
+        Some(khive_pack_git::ingest::IngestSourceState::StoppedEarly(reason)) => {
+            assert!(
+                reason.contains("walk completed but the pass then failed")
+                    && reason.contains("sabotaged cursor write"),
+                "the completed walk downgrades to stopped-early with the cause: {reason:?}"
+            );
+        }
+        other => panic!("a walked-then-failed source is never skipped or completed: {other:?}"),
+    }
+    assert!(
+        report
+            .warnings
+            .iter()
+            .any(|w| w.contains("gh issue list failed")),
+        "the failure surfaces as a warning beside the preserved state: {:?}",
+        report.warnings
+    );
+    assert!(
+        !report.history_exhausted,
+        "a failed pass must not claim exhaustion: {report:?}"
+    );
+    assert!(
+        !report.done,
+        "the resume loop must re-walk a source whose pass failed: {report:?}"
+    );
+}
+
+/// A `gh pr list`/`gh issue list` failure on the FIRST fetch — the stub
+/// answers the `--version` probe but exits 1 on listing — leaves both
+/// sources `skipped` with the failure in the reason: the source was never
+/// walked, which is exactly what `skipped` means (issue #1617).
+/// Commits are unaffected (ADR-088 §5 graceful absence).
+#[tokio::test]
+async fn digest_verb_pr_issue_sources_skipped_on_gh_list_failure() {
+    let _guard = ENV_MUTEX.lock().await;
+    let (_rt, _token, registry) = fixture().await;
+
+    let dir = tempfile::tempdir().expect("tempdir");
+    let repo: PathBuf = dir.path().join("repo");
+    std::fs::create_dir_all(&repo).expect("mk repo dir");
+    init_repo(&repo);
+    write(&repo, "README.md", "hello\n");
+    commit(&repo, &["README.md"], "Initial commit");
+
+    let bin_dir = dir.path().join("bin");
+    std::fs::create_dir_all(&bin_dir).expect("mk bin dir");
+
+    // Present enough to pass the `gh --version` probe; every listing fails.
+    let script = r#"#!/bin/sh
+case "$1" in
+  --version)
+    echo "gh version 2.0.0 (fake)"
+    ;;
+  *)
+    echo "fake gh: simulated listing outage" 1>&2
+    exit 1
+    ;;
+esac
+"#;
+    let script_path = bin_dir.join("gh");
+    std::fs::write(&script_path, script).expect("write failing gh stub");
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let mut perms = std::fs::metadata(&script_path)
+            .expect("stub metadata")
+            .permissions();
+        perms.set_mode(0o755);
+        std::fs::set_permissions(&script_path, perms).expect("chmod stub");
+    }
+    let _path_guard = PathGuard::install(&bin_dir);
+
+    let resp = registry
+        .dispatch(
+            "git.digest",
+            json!({
+                "source": repo.to_str().unwrap(),
+                "include": ["commits", "issues", "pull_requests"]
+            }),
+        )
+        .await
+        .expect("a gh listing failure must stay an in-band digest result");
+
+    assert_eq!(resp["commits_ingested"].as_u64().unwrap(), 1, "{resp:?}");
+    for source in ["pull_requests", "issues"] {
+        assert_eq!(
+            resp["sources"][source]["state"], "skipped",
+            "{source}: a first-fetch failure means the source was never walked: {resp:?}"
+        );
+        let reason = resp["sources"][source]["reason"]
+            .as_str()
+            .unwrap_or_else(|| panic!("{source}: skipped carries a reason: {resp:?}"));
+        assert!(
+            reason.contains("list failed") && reason.contains("simulated listing outage"),
+            "{source}: the reason names the failing command and gh's stderr: {reason:?}"
+        );
+    }
+    assert_eq!(
+        resp["sources"]["commits"],
+        json!({"state": "completed"}),
+        "commits are unaffected by a gh listing failure: {resp:?}"
+    );
+    assert!(
+        !resp["history_exhausted"].as_bool().unwrap(),
+        "skipped sources mean the pass did not cover everything requested: {resp:?}"
+    );
+    let warnings: Vec<&str> = resp["warnings"]
+        .as_array()
+        .expect("warnings")
+        .iter()
+        .filter_map(Value::as_str)
+        .collect();
+    assert!(
+        warnings.iter().any(|w| w.contains("gh pr list failed"))
+            && warnings.iter().any(|w| w.contains("gh issue list failed")),
+        "both walker failures surface as warnings: {warnings:?}"
+    );
+}
+
 /// Source validation surfaces as a normal verb error (ssh:// rejected,
 /// ADR-088 Amendment 1 security posture) rather than panicking or silently
 /// no-op'ing.

--- a/crates/khive-pack-git/tests/acceptance.rs
+++ b/crates/khive-pack-git/tests/acceptance.rs
@@ -3992,11 +3992,19 @@ async fn ingest_walked_then_cursor_write_fails_never_reports_skipped() {
         other => panic!("a walked-then-failed source is never skipped or completed: {other:?}"),
     }
     assert!(
+        report.warnings.iter().any(
+            |w| w.contains("gh issue list failed after walking 1 record")
+                && w.contains("stopped early, not skipped")
+        ),
+        "the warning names the walked-then-failed shape, not a skip: {:?}",
+        report.warnings
+    );
+    assert!(
         report
             .warnings
             .iter()
-            .any(|w| w.contains("gh issue list failed")),
-        "the failure surfaces as a warning beside the preserved state: {:?}",
+            .all(|w| !w.contains("skipping issues")),
+        "a walked-then-failed source must never be described as skipped: {:?}",
         report.warnings
     );
     assert!(
@@ -4006,6 +4014,354 @@ async fn ingest_walked_then_cursor_write_fails_never_reports_skipped() {
     assert!(
         !report.done,
         "the resume loop must re-walk a source whose pass failed: {report:?}"
+    );
+}
+
+/// The cursor-floor guard while stalled (round-2 finding 1): while a pass
+/// is stalled on a refused record, an ALREADY-EXISTING record walked after
+/// the stall point — with a strictly newer `updated_at` — must not advance
+/// the persisted floor past the refused record. The natural-key lookup
+/// proves only the existing record's own landing; advancing past it would
+/// persist a cursor strictly newer than the refused record's timestamp, so
+/// the next pass's inclusive `updated >= cursor` filter would never
+/// re-fetch the refused record — skipping it forever instead of retrying
+/// it. Without the guard, this fixture's persisted cursor would be #10's
+/// 2026-01-03, past refused #20's 2026-01-01.
+#[tokio::test]
+async fn pr_cursor_does_not_advance_past_refused_record_on_later_existing() {
+    let _guard = ENV_MUTEX.lock().await;
+    let (rt, token, registry) = fixture().await;
+    rt.register_embedder(FailOnceEmbedderProvider);
+
+    let project_id = create(
+        &registry,
+        json!({"kind": "project", "name": "stalled-floor-existing-repo"}),
+    )
+    .await;
+
+    let dir = tempfile::tempdir().expect("tempdir");
+    let repo: PathBuf = dir.path().join("repo");
+    std::fs::create_dir_all(&repo).expect("mk repo dir");
+    init_repo(&repo);
+    write(&repo, "README.md", "hello\n");
+    commit(&repo, &["README.md"], "Initial commit");
+
+    // Pre-land PR #10 as if an earlier pass created it, with the NEWEST
+    // timestamp of the three — it is the record walked after the stall
+    // point whose timestamp the unguarded advance would persist.
+    create(
+        &registry,
+        json!({
+            "kind": "pull_request",
+            "name": "#10 pre-existing PR",
+            "content": "landed in an earlier pass",
+            "properties": {
+                "number": 10,
+                "project_id": project_id.to_string()
+            },
+            "annotates": [project_id.to_string()]
+        }),
+    )
+    .await;
+
+    let bin_dir = dir.path().join("bin");
+    std::fs::create_dir_all(&bin_dir).expect("mk bin dir");
+    let log_dir = dir.path().join("log");
+    std::fs::create_dir_all(&log_dir).expect("mk log dir");
+
+    // Ascending by updatedAt: #5 (good), #20 (refused once), #10 (existing,
+    // newest). The stall fires at #20; the guard must keep #10's newer
+    // timestamp out of the persisted floor.
+    let pr_json = json!([
+        {"number": 5, "title": "pr5-oldest-good", "author": {"login": "a"}, "createdAt": "2026-01-01T00:00:00Z", "mergedAt": null, "closedAt": null, "updatedAt": "2025-12-01T00:00:00Z", "baseRefName": "main", "headRefName": "f5", "mergeCommit": null, "body": ""},
+        {"number": 20, "title": "pr20-refused", "author": {"login": "a"}, "createdAt": "2026-01-01T00:00:00Z", "mergedAt": null, "closedAt": null, "updatedAt": "2026-01-01T00:00:00Z", "baseRefName": "main", "headRefName": "f20", "mergeCommit": null, "body": CURSOR_FAIL_SENTINEL},
+        {"number": 10, "title": "pr10-existing-newest", "author": {"login": "a"}, "createdAt": "2026-01-01T00:00:00Z", "mergedAt": null, "closedAt": null, "updatedAt": "2026-01-03T00:00:00Z", "baseRefName": "main", "headRefName": "f10", "mergeCommit": null, "body": ""}
+    ])
+    .to_string();
+
+    write_fake_gh(&bin_dir, &log_dir, &pr_json, "[]");
+    let _path_guard = PathGuard::install(&bin_dir);
+
+    let mut opts = IngestOptions::unbounded(repo.clone(), project_id.to_string());
+    opts.include.commits = false;
+    opts.include.issues = false;
+
+    let report = run_ingest(&rt, &token, &registry, opts.clone())
+        .await
+        .expect("ingest ok (pass 1)");
+
+    assert_eq!(
+        report.prs_ingested, 1,
+        "#5 lands, #20 is refused once, #10 is found by natural key: {report:?}"
+    );
+    assert_eq!(report.prs_skipped_existing, 1, "{report:?}");
+    assert!(
+        report.cursor_stalled,
+        "the refused #20 freezes the PR cursor: {report:?}"
+    );
+
+    let cursor_after_pass1 = read_git_cursor(&rt, project_id, "prs")
+        .await
+        .expect("cursor must be written (#5 landed before the stall)");
+    assert_eq!(
+        cursor_after_pass1, "2025-12-01T00:00:00Z",
+        "the stalled floor must not advance past refused #20 (2026-01-01) on \
+         the strength of later EXISTING #10's newer 2026-01-03 timestamp — \
+         that would strand #20 behind the cursor forever: {cursor_after_pass1:?}"
+    );
+
+    // The embedder's one-shot fuse is spent: pass 2 re-walks from the frozen
+    // floor, retries #20, lands it, and only then does the floor advance to
+    // the newest walked timestamp.
+    let report2 = run_ingest(&rt, &token, &registry, opts)
+        .await
+        .expect("ingest ok (pass 2)");
+    assert_eq!(
+        report2.prs_ingested, 1,
+        "the refused record is retried and lands once the upstream failure clears: {report2:?}"
+    );
+    assert_eq!(report2.prs_skipped_existing, 2, "{report2:?}");
+    assert!(!report2.cursor_stalled, "{report2:?}");
+
+    let cursor_after_pass2 = read_git_cursor(&rt, project_id, "prs")
+        .await
+        .expect("cursor must be written");
+    assert_eq!(
+        cursor_after_pass2, "2026-01-03T00:00:00Z",
+        "after recovery the floor advances to the newest walked record: {cursor_after_pass2:?}"
+    );
+}
+
+/// Issue-side mirror of `pr_cursor_does_not_advance_past_refused_record_on_later_existing`
+/// (round-2 finding 1): the refusal mechanism here is the deterministic
+/// ungoverned-`stateReason` rejection, and the pre-landed record is an
+/// issue with the newest timestamp.
+#[tokio::test]
+async fn issue_cursor_does_not_advance_past_refused_record_on_later_existing() {
+    let _guard = ENV_MUTEX.lock().await;
+    let (rt, token, registry) = fixture().await;
+
+    let project_id = create(
+        &registry,
+        json!({"kind": "project", "name": "stalled-floor-existing-issue-repo"}),
+    )
+    .await;
+
+    let dir = tempfile::tempdir().expect("tempdir");
+    let repo: PathBuf = dir.path().join("repo");
+    std::fs::create_dir_all(&repo).expect("mk repo dir");
+    init_repo(&repo);
+    write(&repo, "README.md", "hello\n");
+    commit(&repo, &["README.md"], "Initial commit");
+
+    create(
+        &registry,
+        json!({
+            "kind": "issue",
+            "name": "#10 pre-existing issue",
+            "content": "landed in an earlier pass",
+            "properties": {
+                "number": 10,
+                "project_id": project_id.to_string()
+            },
+            "annotates": [project_id.to_string()]
+        }),
+    )
+    .await;
+
+    let bin_dir = dir.path().join("bin");
+    std::fs::create_dir_all(&bin_dir).expect("mk bin dir");
+    let log_dir = dir.path().join("log");
+    std::fs::create_dir_all(&log_dir).expect("mk log dir");
+
+    let issue_json = json!([
+        {"number": 5, "title": "issue5-oldest-good", "author": {"login": "a"}, "createdAt": "2026-01-01T00:00:00Z", "closedAt": null, "updatedAt": "2025-12-01T00:00:00Z", "labels": [], "stateReason": "", "body": ""},
+        {"number": 20, "title": "issue20-refused", "author": {"login": "a"}, "createdAt": "2026-01-01T00:00:00Z", "closedAt": null, "updatedAt": "2026-01-01T00:00:00Z", "labels": [], "stateReason": "bogus_ungoverned_value", "body": ""},
+        {"number": 10, "title": "issue10-existing-newest", "author": {"login": "a"}, "createdAt": "2026-01-01T00:00:00Z", "closedAt": null, "updatedAt": "2026-01-03T00:00:00Z", "labels": [], "stateReason": "", "body": ""}
+    ])
+    .to_string();
+
+    write_fake_gh(&bin_dir, &log_dir, "[]", &issue_json);
+    let _path_guard = PathGuard::install(&bin_dir);
+
+    let mut opts = IngestOptions::unbounded(repo.clone(), project_id.to_string());
+    opts.include.commits = false;
+    opts.include.pull_requests = false;
+
+    let report = run_ingest(&rt, &token, &registry, opts.clone())
+        .await
+        .expect("ingest ok (pass 1)");
+
+    assert_eq!(report.issues_ingested, 1, "{report:?}");
+    assert_eq!(report.issues_skipped_existing, 1, "{report:?}");
+    assert!(report.cursor_stalled, "{report:?}");
+
+    let cursor_after_pass1 = read_git_cursor(&rt, project_id, "issues")
+        .await
+        .expect("cursor must be written (#5 landed before the stall)");
+    assert_eq!(
+        cursor_after_pass1, "2025-12-01T00:00:00Z",
+        "the stalled floor must not advance past refused #20 on the strength \
+         of later EXISTING #10's newer timestamp: {cursor_after_pass1:?}"
+    );
+
+    // Upstream correction: #20's stateReason becomes governed — pass 2
+    // retries the refused record from the frozen floor and lands it.
+    let corrected = json!([
+        {"number": 5, "title": "issue5-oldest-good", "author": {"login": "a"}, "createdAt": "2026-01-01T00:00:00Z", "closedAt": null, "updatedAt": "2025-12-01T00:00:00Z", "labels": [], "stateReason": "", "body": ""},
+        {"number": 20, "title": "issue20-refused", "author": {"login": "a"}, "createdAt": "2026-01-01T00:00:00Z", "closedAt": null, "updatedAt": "2026-01-01T00:00:00Z", "labels": [], "stateReason": "completed", "body": ""},
+        {"number": 10, "title": "issue10-existing-newest", "author": {"login": "a"}, "createdAt": "2026-01-01T00:00:00Z", "closedAt": null, "updatedAt": "2026-01-03T00:00:00Z", "labels": [], "stateReason": "", "body": ""}
+    ])
+    .to_string();
+    std::fs::write(log_dir.join("issue_response.json"), corrected)
+        .expect("rewrite issue fixture with corrected stateReason");
+
+    let report2 = run_ingest(&rt, &token, &registry, opts)
+        .await
+        .expect("ingest ok (pass 2)");
+    assert_eq!(report2.issues_ingested, 1, "{report2:?}");
+    assert_eq!(report2.issues_skipped_existing, 2, "{report2:?}");
+    assert!(!report2.cursor_stalled, "{report2:?}");
+
+    let cursor_after_pass2 = read_git_cursor(&rt, project_id, "issues")
+        .await
+        .expect("cursor must be written");
+    assert_eq!(
+        cursor_after_pass2, "2026-01-03T00:00:00Z",
+        "{cursor_after_pass2:?}"
+    );
+}
+
+/// The commit walker's post-walk cursor-write failure (round-2 finding 4):
+/// the walk records `completed` and THEN the final cursor write fails (here
+/// via the same sabotage trigger the issue-side test uses). The call site
+/// must handle that in-band exactly like the gh walkers — downgrade to
+/// `stopped_early`, warn, force `done = false` — instead of aborting the
+/// whole ingest with an Err.
+#[tokio::test]
+async fn ingest_commit_walked_then_cursor_write_fails_stays_in_band() {
+    let _guard = ENV_MUTEX.lock().await;
+    let (rt, token, registry) = fixture().await;
+
+    let project_id = create(
+        &registry,
+        json!({"kind": "project", "name": "commit-walked-then-failed-repo"}),
+    )
+    .await;
+
+    let dir = tempfile::tempdir().expect("tempdir");
+    let repo: PathBuf = dir.path().join("repo");
+    std::fs::create_dir_all(&repo).expect("mk repo dir");
+    init_repo(&repo);
+    write(&repo, "README.md", "hello\n");
+    commit(&repo, &["README.md"], "Initial commit");
+
+    // Sabotage ONLY the cursor write: the commit itself must land first, so
+    // the walker records `completed` before the final `write_cursor` fails.
+    let mut writer = rt.sql().writer().await.expect("writer");
+    writer
+        .execute(SqlStatement {
+            sql: "CREATE TRIGGER fail_cursor_write BEFORE INSERT ON git_mirror_cursor \
+                  BEGIN SELECT RAISE(ABORT, 'sabotaged cursor write'); END"
+                .into(),
+            params: vec![],
+            label: Some("test_fail_cursor_write".into()),
+        })
+        .await
+        .expect("install sabotage trigger");
+
+    let mut opts = IngestOptions::unbounded(repo.clone(), project_id.to_string());
+    opts.include.issues = false;
+    opts.include.pull_requests = false;
+    let report = run_ingest(&rt, &token, &registry, opts)
+        .await
+        .expect("a post-walk commit cursor failure must stay in-band, not abort the pass");
+
+    assert_eq!(
+        report.commits_ingested, 1,
+        "the commit landed before the cursor write failed: {report:?}"
+    );
+    match &report.sources.commits {
+        Some(khive_pack_git::ingest::IngestSourceState::StoppedEarly(reason)) => {
+            assert!(
+                reason.contains("walk completed but the pass then failed")
+                    && reason.contains("sabotaged cursor write"),
+                "the completed commit walk downgrades to stopped-early with the cause: {reason:?}"
+            );
+        }
+        other => {
+            panic!("a walked-then-failed commit source is never skipped or completed: {other:?}")
+        }
+    }
+    assert!(
+        !report.cursor_stalled,
+        "no PER-RECORD write failed — the cursor write did; the two signals stay distinct: {report:?}"
+    );
+    assert!(
+        report
+            .warnings
+            .iter()
+            .any(|w| w.contains("commit ingest failed after the walk")),
+        "the failure surfaces as a warning beside the downgraded state: {:?}",
+        report.warnings
+    );
+    assert!(
+        !report.done,
+        "the resume loop must re-walk a source whose pass failed: {report:?}"
+    );
+    assert!(
+        !report.history_exhausted,
+        "a failed pass must not claim exhaustion: {report:?}"
+    );
+}
+
+/// Sources not requested by `include` serialize as JSON `null` in
+/// `IngestReport.sources` (round-2 finding 6): `Option<IngestSourceState>`
+/// with serde's default `None` encoding, asserted explicitly so a future
+/// `skip_serializing_if` or repr change cannot silently drop the
+/// distinction between "not requested" and "requested but state lost".
+#[tokio::test]
+async fn digest_report_serializes_omitted_sources_as_null() {
+    let _guard = ENV_MUTEX.lock().await;
+    let (rt, token, registry) = fixture().await;
+
+    let project_id = create(
+        &registry,
+        json!({"kind": "project", "name": "null-sources-repo"}),
+    )
+    .await;
+
+    let dir = tempfile::tempdir().expect("tempdir");
+    let repo: PathBuf = dir.path().join("repo");
+    std::fs::create_dir_all(&repo).expect("mk repo dir");
+    init_repo(&repo);
+    write(&repo, "README.md", "hello\n");
+    commit(&repo, &["README.md"], "Initial commit");
+
+    // Commits only: no gh probe, no gh fixture needed.
+    let mut opts = IngestOptions::unbounded(repo.clone(), project_id.to_string());
+    opts.include.issues = false;
+    opts.include.pull_requests = false;
+    let report = run_ingest(&rt, &token, &registry, opts)
+        .await
+        .expect("ingest ok");
+
+    let serialized = serde_json::to_value(&report).expect("report serializes");
+    assert_eq!(
+        serialized["sources"]["commits"]["state"], "completed",
+        "the requested source carries its walk state: {serialized}"
+    );
+    assert!(
+        serialized["sources"]["issues"].is_null(),
+        "an unrequested source is JSON null, not an absent key or a state: {serialized}"
+    );
+    assert!(
+        serialized["sources"]["pull_requests"].is_null(),
+        "an unrequested source is JSON null, not an absent key or a state: {serialized}"
+    );
+    assert_eq!(
+        serialized["history_exhausted"], true,
+        "a fully walked requested source exhausts the pass: {serialized}"
     );
 }
 

--- a/crates/khive-pack-git/tests/acceptance.rs
+++ b/crates/khive-pack-git/tests/acceptance.rs
@@ -2831,6 +2831,13 @@ async fn empty_walk_with_non_ancestor_cursor_refuses_completion() {
         "nothing to walk in the empty range: {report2:?}"
     );
     assert!(
+        matches!(
+            report2.sources.commits.as_ref(),
+            Some(khive_pack_git::ingest::IngestSourceState::StoppedEarly(_))
+        ),
+        "a diverged empty range records a stopped-early commit source: {report2:?}"
+    );
+    assert!(
         !report2.done,
         "an empty walk from a non-ancestor cursor is not a completion \
          (issue #1644): {report2:?}"
@@ -3553,6 +3560,7 @@ async fn digest_verb_sources_gate_refusal_skips_record_and_walk_continues() {
     // Oldest first: clean, refused (sentinel body), clean.
     write(repo, "f.txt", "v0\n");
     commit(repo, &["f.txt"], "commit 0");
+    let sha0 = head_sha(repo);
     write(repo, "f.txt", "v1\n");
     commit(
         repo,
@@ -3561,6 +3569,7 @@ async fn digest_verb_sources_gate_refusal_skips_record_and_walk_continues() {
     );
     write(repo, "f.txt", "v2\n");
     commit(repo, &["f.txt"], "commit 2");
+    let sha2 = head_sha(repo);
 
     let resp = registry
         .dispatch(
@@ -3569,6 +3578,12 @@ async fn digest_verb_sources_gate_refusal_skips_record_and_walk_continues() {
         )
         .await
         .expect("a per-record refusal must stay an in-band digest result");
+    let project_id = Uuid::parse_str(
+        resp["project_id"]
+            .as_str()
+            .expect("the digest response carries its project id"),
+    )
+    .expect("project id is a UUID");
 
     assert_eq!(
         resp["commits_ingested"].as_u64().unwrap(),
@@ -3602,6 +3617,33 @@ async fn digest_verb_sources_gate_refusal_skips_record_and_walk_continues() {
     assert!(
         !resp["done"].as_bool().unwrap(),
         "cursor_stalled still forces done:false beside the new fields: {resp:?}"
+    );
+
+    let cursor_after_pass1 = read_git_cursor(&rt, project_id, "commits")
+        .await
+        .expect("the successful prefix persists a cursor");
+    assert_eq!(
+        cursor_after_pass1, sha0,
+        "the cursor freezes before the refused commit and does not skip it: {resp:?}"
+    );
+
+    let resp2 = registry
+        .dispatch(
+            "git.digest",
+            json!({"source": repo.to_str().unwrap(), "include": ["commits"]}),
+        )
+        .await
+        .expect("the next pass retries the frozen commit");
+    assert_eq!(
+        resp2["commits_ingested"].as_u64().unwrap(),
+        1,
+        "the refused commit is retried and lands on the next pass: {resp2:?}"
+    );
+    assert!(!resp2["cursor_stalled"].as_bool().unwrap(), "{resp2:?}");
+    assert_eq!(
+        read_git_cursor(&rt, project_id, "commits").await,
+        Some(sha2),
+        "the cursor advances through the recovered commit after retry: {resp2:?}"
     );
 }
 
@@ -3714,6 +3756,33 @@ async fn digest_verb_pr_issue_sources_completed_on_happy_path() {
     assert!(report.done, "{report:?}");
 }
 
+/// With no source requested, exhaustion is vacuously true.
+#[tokio::test]
+async fn digest_history_exhausted_is_true_when_include_is_empty() {
+    let _guard = ENV_MUTEX.lock().await;
+    let (rt, token, registry) = fixture().await;
+    let project_id = create(
+        &registry,
+        json!({"kind": "project", "name": "empty-include-repo"}),
+    )
+    .await;
+    let dir = tempfile::tempdir().expect("tempdir");
+    let mut opts = IngestOptions::unbounded(dir.path().to_path_buf(), project_id.to_string());
+    opts.include.commits = false;
+    opts.include.issues = false;
+    opts.include.pull_requests = false;
+
+    let report = run_ingest(&rt, &token, &registry, opts)
+        .await
+        .expect("an empty include completes without walking a source");
+
+    assert!(report.history_exhausted, "{report:?}");
+    assert!(report.done, "{report:?}");
+    assert!(report.sources.commits.is_none(), "{report:?}");
+    assert!(report.sources.issues.is_none(), "{report:?}");
+    assert!(report.sources.pull_requests.is_none(), "{report:?}");
+}
+
 /// With the budget spent mid-walk, a walker that breaks inside its record
 /// loop reports `stopped_early` (visited, not exhausted) while sources
 /// never even reached report `skipped` with the pre-reached budget reason
@@ -3782,7 +3851,7 @@ async fn digest_verb_pr_issue_sources_stopped_early_on_budget_stop() {
     match &report.sources.pull_requests {
         Some(khive_pack_git::ingest::IngestSourceState::StoppedEarly(reason)) => {
             assert!(
-                reason.contains("budget"),
+                reason.contains("budget exhausted"),
                 "the reason names the budget as the cause: {reason:?}"
             );
         }
@@ -3869,8 +3938,8 @@ async fn digest_verb_pr_source_stopped_early_on_full_page_then_refetch_failure_s
     match &report.sources.pull_requests {
         Some(khive_pack_git::ingest::IngestSourceState::StoppedEarly(reason)) => {
             assert!(
-                reason.contains("window"),
-                "the reason names the incomplete paging window: {reason:?}"
+                reason.contains("full page"),
+                "the reason names the full-page floor stop: {reason:?}"
             );
         }
         other => panic!("a full page with an unproven window is stopped_early, got {other:?}"),
@@ -3915,6 +3984,10 @@ esac
             .any(|w| w.contains("gh pr list failed")),
         "the failure also surfaces as a warning: {:?}",
         report2.warnings
+    );
+    assert!(
+        report2.done,
+        "a first-fetch listing failure leaves the budget-cursor signal unchanged: {report2:?}"
     );
 }
 
@@ -4232,6 +4305,74 @@ async fn issue_cursor_does_not_advance_past_refused_record_on_later_existing() {
     );
 }
 
+/// A database error during the first commit lookup is reported after the
+/// commit walk has started, not as a pre-walk hard failure.
+#[tokio::test]
+async fn ingest_commit_lookup_failure_is_reported_in_band_after_walk_start() {
+    let _guard = ENV_MUTEX.lock().await;
+    let (rt, token, registry) = fixture().await;
+    let project_id = create(
+        &registry,
+        json!({"kind": "project", "name": "commit-lookup-failure-repo"}),
+    )
+    .await;
+
+    let dir = tempfile::tempdir().expect("tempdir");
+    let repo: PathBuf = dir.path().join("repo");
+    std::fs::create_dir_all(&repo).expect("mk repo dir");
+    init_repo(&repo);
+    write(&repo, "README.md", "hello\n");
+    commit(&repo, &["README.md"], "Initial commit");
+
+    // The comm external-id index evaluates json_extract over properties on
+    // every insert, so a malformed-JSON row cannot land while it exists.
+    // Drop it (test database only) so the sabotage row is storable; the
+    // lookup's own json_extract then fails at query time, mid-walk.
+    let mut writer = rt.sql().writer().await.expect("writer");
+    writer
+        .execute(SqlStatement {
+            sql: "DROP INDEX IF EXISTS idx_comm_message_external_id".into(),
+            params: vec![],
+            label: Some("test_drop_json_index".into()),
+        })
+        .await
+        .expect("drop json-evaluating index");
+    writer
+        .execute(SqlStatement {
+            sql: "INSERT INTO notes(id, namespace, kind, content, properties, created_at, updated_at) \
+                  VALUES(?1, ?2, 'commit', '', ?3, 0, 0)"
+                .into(),
+            params: vec![
+                SqlValue::Text(Uuid::new_v4().to_string()),
+                SqlValue::Text("local".into()),
+                SqlValue::Text("not-json".into()),
+            ],
+            label: Some("test_malformed_commit_properties".into()),
+        })
+        .await
+        .expect("insert malformed lookup row");
+    drop(writer);
+
+    let mut opts = IngestOptions::unbounded(repo, project_id.to_string());
+    opts.include.issues = false;
+    opts.include.pull_requests = false;
+    let report = run_ingest(&rt, &token, &registry, opts)
+        .await
+        .expect("a mid-walk lookup failure stays in-band");
+
+    match &report.sources.commits {
+        Some(khive_pack_git::ingest::IngestSourceState::StoppedEarly(reason)) => {
+            assert!(
+                reason.contains("walk began") && reason.contains("pass then failed after the walk"),
+                "the source records a walked-then-failed lookup: {reason:?}"
+            );
+        }
+        other => panic!("a mid-walk lookup failure must be stopped-early: {other:?}"),
+    }
+    assert!(!report.done, "{report:?}");
+    assert!(!report.history_exhausted, "{report:?}");
+}
+
 /// The commit walker's post-walk cursor-write failure (round-2 finding 4):
 /// the walk records `completed` and THEN the final cursor write fails (here
 /// via the same sabotage trigger the issue-side test uses). The call site
@@ -4365,6 +4506,75 @@ async fn digest_report_serializes_omitted_sources_as_null() {
     );
 }
 
+/// A local cursor read failure happens before either remote listing. It keeps
+/// the source-level failure distinct from a remote listing skip.
+#[tokio::test]
+async fn digest_verb_local_cursor_read_failure_is_not_remote_listing_skip() {
+    let _guard = ENV_MUTEX.lock().await;
+    let (rt, token, registry) = fixture().await;
+    let project_id = create(
+        &registry,
+        json!({"kind": "project", "name": "cursor-read-failure-repo"}),
+    )
+    .await;
+
+    let dir = tempfile::tempdir().expect("tempdir");
+    let repo: PathBuf = dir.path().join("repo");
+    std::fs::create_dir_all(&repo).expect("mk repo dir");
+    init_repo(&repo);
+    let bin_dir = dir.path().join("bin");
+    std::fs::create_dir_all(&bin_dir).expect("mk bin dir");
+    let log_dir = dir.path().join("log");
+    std::fs::create_dir_all(&log_dir).expect("mk log dir");
+    write_fake_gh(&bin_dir, &log_dir, "[]", "[]");
+    let _path_guard = PathGuard::install(&bin_dir);
+
+    let mut writer = rt.sql().writer().await.expect("writer");
+    writer
+        .execute(SqlStatement {
+            sql: "DROP TABLE git_mirror_cursor".into(),
+            params: vec![],
+            label: Some("test_drop_cursor_table".into()),
+        })
+        .await
+        .expect("drop cursor table");
+    drop(writer);
+
+    let mut opts = IngestOptions::unbounded(repo, project_id.to_string());
+    opts.include.commits = false;
+    let report = run_ingest(&rt, &token, &registry, opts)
+        .await
+        .expect("a local cursor read failure stays in-band");
+
+    for (source, state) in [
+        ("pull requests", &report.sources.pull_requests),
+        ("issues", &report.sources.issues),
+    ] {
+        match state {
+            Some(khive_pack_git::ingest::IngestSourceState::Skipped(reason)) => {
+                assert!(
+                    reason.contains("local cursor/database read failed"),
+                    "{source}: local cursor failure is classified explicitly: {reason:?}"
+                );
+                assert!(
+                    !reason.contains("gh pr list failed")
+                        && !reason.contains("gh issue list failed"),
+                    "{source}: the state is not a remote listing failure: {reason:?}"
+                );
+            }
+            other => panic!("{source}: expected local cursor read classification, got {other:?}"),
+        }
+    }
+    assert!(
+        report
+            .warnings
+            .iter()
+            .all(|warning| !warning.contains("list failed, skipping")),
+        "a local cursor failure must not use the remote-skip warning: {:?}",
+        report.warnings
+    );
+}
+
 /// A `gh pr list`/`gh issue list` failure on the FIRST fetch — the stub
 /// answers the `--version` probe but exits 1 on listing — leaves both
 /// sources `skipped` with the failure in the reason: the source was never
@@ -4443,6 +4653,10 @@ esac
     assert!(
         !resp["history_exhausted"].as_bool().unwrap(),
         "skipped sources mean the pass did not cover everything requested: {resp:?}"
+    );
+    assert_eq!(
+        resp["done"], true,
+        "a first-fetch listing failure does not consume the budget-cursor signal: {resp:?}"
     );
     let warnings: Vec<&str> = resp["warnings"]
         .as_array()

--- a/docs/guide/api-reference.md
+++ b/docs/guide/api-reference.md
@@ -1861,6 +1861,16 @@ diagnostic names the attempted `verb`, the provenance `record_kind` and natural
 Because a digest continues after a per-record refusal, callers that require a clean run
 should assert `writes_refused == 0` in addition to waiting for `done == true`.
 
+Per-source coverage is machine-readable via `sources` and `history_exhausted`. Every
+source requested by `include` reports one of `completed`, `stopped_early` (with a
+`reason`: budget exhausted, incomplete `gh` paging window, or a frozen cursor), or
+`skipped` (with a `reason`: budget exhausted before the source was reached, `gh` CLI
+absent, or a `gh` failure) — so "this repo has no issues/PRs" is distinguishable from
+"issues/PRs were never reached" without parsing `warnings[]`. `history_exhausted` is
+`true` only when every requested source completed: it separates "the walk visited
+everything" from "the walk stopped before the end", a distinction `done`'s
+budget-cursor semantics do not carry.
+
 ### `git.commit` / `git.branch` / `git.push` — Commissive (ADR-108)
 
 Thin write verbs that shell to system git (`std::process::Command::args`, no shell


### PR DESCRIPTION
git.digest reported a single aggregate shape, so a source frozen by a write refusal or stopped by budget exhaustion presented the same as a completed walk. Each source (commits/issues/pull_requests) now reports completed | stopped_early {reason} | skipped {reason}, and an additive `history_exhausted` flag distinguishes a fully-visited history from a walk that stopped before the end. Refusal-non-termination (already correct on main) is locked in by a regression test: a mid-list refusal freezes that source's cursor while later records still land.

Wire change is additive (serde keys; no consumer pattern-matches the struct exhaustively). khive-pack-git lib 215 + acceptance 59 green, clippy clean, fmt clean.