### PR TITLE
fix(runtime): allow document derived_from document per ADR-002 amendment

### DIFF
--- a/crates/khive-runtime/src/operations.rs
+++ b/crates/khive-runtime/src/operations.rs
@@ -806,6 +806,9 @@ pub const BASE_ENTITY_ENDPOINT_RULES: &[(&str, EdgeRelation, &str)] = &[
     ("artifact", EdgeRelation::DerivedFrom, "document"),
     ("artifact", EdgeRelation::DerivedFrom, "project"),
     ("artifact", EdgeRelation::DerivedFrom, "artifact"),
+    // ADR-002 amendment 2026-07-27: publication provenance — a curated or
+    // filtered publication copy points at the canonical source document.
+    ("document", EdgeRelation::DerivedFrom, "document"),
     // Temporal
     ("document", EdgeRelation::Precedes, "document"),
     ("dataset", EdgeRelation::Precedes, "dataset"),
@@ -6422,6 +6425,51 @@ mod tests {
             note.content,
             "issue-396 regression: model-less remember must succeed"
         );
+    }
+
+    #[tokio::test]
+    async fn document_derived_from_document_is_legal_per_adr002_amendment() {
+        assert!(base_entity_rule_allows(
+            "document",
+            EdgeRelation::DerivedFrom,
+            "document"
+        ));
+        let rt = rt();
+        let tok = NamespaceToken::local();
+        let canonical = rt
+            .create_entity(
+                &tok,
+                "document",
+                None,
+                "canonical source",
+                None,
+                None,
+                vec![],
+            )
+            .await
+            .unwrap();
+        let publication = rt
+            .create_entity(
+                &tok,
+                "document",
+                None,
+                "publication copy",
+                None,
+                None,
+                vec![],
+            )
+            .await
+            .unwrap();
+        rt.link(
+            &tok,
+            publication.id,
+            canonical.id,
+            EdgeRelation::DerivedFrom,
+            1.0,
+            None,
+        )
+        .await
+        .expect("ADR-002 2026-07-27 amendment: publication provenance edge must be accepted");
     }
 
     #[tokio::test]


### PR DESCRIPTION
The 2026-07-27 ADR-002 amendment added `Document derived_from Document` for publication provenance, but `BASE_ENTITY_ENDPOINT_RULES` was never updated: the runtime rejected every such link and `link(help=true)` omitted the row, while the ADR prose described 60 base rows against 59 enforced.

This adds the missing rule row and a regression test asserting both the pure membership check (`base_entity_rule_allows`) and a live `link` between two document entities.

A follow-up issue will track the structural gap this instance exposed: there is no conformance fixture comparing the runtime allowlist against an ADR-derived matrix, which is why the drift persisted undetected.