### PR TITLE
docs(adr): ADR-144 — operation-level write-visibility fence for memory recall

### DIFF
--- a/docs/adr/ADR-144-memory-write-visibility-fence.md
+++ b/docs/adr/ADR-144-memory-write-visibility-fence.md
@@ -14,7 +14,7 @@ model source before fusion. That merge is deliberately silent — a result list
 can contain both ANN-served and exactly-scored hits with no per-hit marker, and
 nothing in the response distinguishes them.
 
-What the surface does not offer is any way for a caller to *prove* that a
+What the surface does not offer is any way for a caller to _prove_ that a
 specific write is visible to a subsequent recall:
 
 - `memory.remember` returns `id`, `kind`, `salience`, `decay_factor`,

--- a/docs/adr/ADR-144-memory-write-visibility-fence.md
+++ b/docs/adr/ADR-144-memory-write-visibility-fence.md
@@ -1,6 +1,7 @@
 # ADR-144: Operation-Level Write-Visibility Fence for Memory Recall
 
-- Status: Proposed
+- Status: Accepted
+- Decision: Arm A — additive write receipt plus session read fence
 - Date: 2026-08-05
 - Related: ADR-118 (fresh exact tail), #1084 (per-hit route labels, declined shape),
   #1161 (Cold/Empty cap divergence, separate lane)
@@ -40,7 +41,7 @@ legitimately contain both origins, and a route summary cannot prove that one
 particular write is covered. Origin labels are diagnostics, not a correctness
 primitive.
 
-## Decision (proposed — the fork below is the sign-off question)
+## Decision (accepted: Arm A — the fork below records the sign-off question as posed)
 
 Add an additive, operation-scoped visibility contract to the memory pack:
 
@@ -61,9 +62,9 @@ Add an additive, operation-scoped visibility contract to the memory pack:
 3. **Diagnostics stay diagnostics.** Verbose responses may report per-hit
    origin and per-model watermarks, but no correctness claim rides on them.
 
-### The fork requiring sign-off
+### The fork as posed at sign-off (resolved: Arm A)
 
-- **Arm A (this proposal):** the receipt/fence contract above.
+- **Arm A (accepted):** the receipt/fence contract above.
 - **Arm B (explicit null):** formally decide that `memory.remember`
   acknowledges storage durability only, that search visibility is best-effort,
   and document that contract at the verb surface. This is a legitimate product
@@ -113,7 +114,17 @@ Add an additive, operation-scoped visibility contract to the memory pack:
 
 ## Acceptance
 
-This record is accepted only with an explicit choice of Arm A or Arm B. If
-Arm A: implementation follows as tracked work (receipt first, fence second;
-both additive). If Arm B: the verb documentation change lands with the
-acceptance and this record stands as the decision trail.
+Accepted with Arm A, under four conditions recorded here as part of the
+decision:
+
+1. This record's Status and Decision lines name the accepted arm before the
+   record merges.
+2. Sequencing is as written: receipt first, fence second, both additive.
+   Implementation is tracked follow-up work and does not preempt existing
+   scheduled priorities.
+3. The one-consistent-snapshot property of the coverage proof (see
+   Consequences) is review-blocking at implementation time: a coverage proof
+   assembled from two separately read clocks must fail review.
+4. The session-fence wait carries a server-side maximum timeout cap;
+   caller-provided timeouts bound below that cap and can never request an
+   unbounded hold.

--- a/docs/adr/ADR-144-memory-write-visibility-fence.md
+++ b/docs/adr/ADR-144-memory-write-visibility-fence.md
@@ -1,0 +1,119 @@
+# ADR-144: Operation-Level Write-Visibility Fence for Memory Recall
+
+- Status: Proposed
+- Date: 2026-08-05
+- Related: ADR-118 (fresh exact tail), #1084 (per-hit route labels, declined shape),
+  #1161 (Cold/Empty cap divergence, separate lane)
+
+## Context
+
+ADR-118 gives recall a fresh exact tail: rows written after the last ANN segment
+publication are scored exactly and merged with ANN candidates into a single
+model source before fusion. That merge is deliberately silent — a result list
+can contain both ANN-served and exactly-scored hits with no per-hit marker, and
+nothing in the response distinguishes them.
+
+What the surface does not offer is any way for a caller to *prove* that a
+specific write is visible to a subsequent recall:
+
+- `memory.remember` returns `id`, `kind`, `salience`, `decay_factor`,
+  `memory_type`, `created_at`, and optionally `edge_id`. It returns no log
+  sequence, generation, or visibility state for the vectors it wrote.
+- `memory.recall` accepts no consistency parameter. Its only inspected
+  degradation field is `ann_unavailable`.
+- `VectorSearchHit` is `subject_id`, `score`, `rank`; `ScoreBreakdown` exposes
+  ranking components, not retrieval origin.
+
+Mature vector and search systems place their strongest freshness control at the
+write/request consistency boundary rather than in per-hit provenance:
+Elasticsearch `refresh=wait_for` blocks the write acknowledgement until the
+change is search-visible; Lucene exposes an index generation callers can wait
+on; Milvus Session consistency maps the client's latest write timestamp into
+the read guarantee; Qdrant `wait=true` returns a write only once it is applied
+and searchable; LanceDB searches unindexed rows by brute force unless the
+caller opts out with `fast_search=True`. The mechanisms differ, but each makes
+the freshness/latency trade visible at operation or query scope.
+
+The previously proposed alternative (#1084) — a per-model `ann | exact` route
+label on responses — cannot express ADR-118's design: one model source may
+legitimately contain both origins, and a route summary cannot prove that one
+particular write is covered. Origin labels are diagnostics, not a correctness
+primitive.
+
+## Decision (proposed — the fork below is the sign-off question)
+
+Add an additive, operation-scoped visibility contract to the memory pack:
+
+1. **Write receipt.** `memory.remember` additionally returns a
+   `visibility_token`: the namespace plus one `{model, ann_write_log_seq}`
+   fence per vector written. Existing fields are unchanged; callers that
+   ignore the token see today's behavior.
+
+2. **Read fence.** `memory.recall` accepts an optional
+   `consistency: "eventual" | "session"` parameter together with either a
+   previously returned `visibility_token` or an equivalent `after` fence.
+   - `eventual` (default) is today's behavior, unchanged.
+   - `session` succeeds only when every requested model proves coverage of the
+     fence by `segment_watermark ∪ exact_tail_snapshot`. When coverage cannot
+     be proven it waits up to a caller-provided timeout, then returns a typed
+     `freshness_unmet` result. It never silently serves an uncovered state.
+
+3. **Diagnostics stay diagnostics.** Verbose responses may report per-hit
+   origin and per-model watermarks, but no correctness claim rides on them.
+
+### The fork requiring sign-off
+
+- **Arm A (this proposal):** the receipt/fence contract above.
+- **Arm B (explicit null):** formally decide that `memory.remember`
+  acknowledges storage durability only, that search visibility is best-effort,
+  and document that contract at the verb surface. This is a legitimate product
+  decision; today's state is Arm B in behavior but undocumented, which is the
+  actual defect. Accepting either arm closes it; leaving the surface silent
+  does not.
+
+## Alternatives considered
+
+- **Per-hit origin labels (#1084 shape).** Rejected as the primitive: cannot
+  prove visibility of a specific write, and ADR-118's merged model source makes
+  the label set (`ann | exact`) incomplete. Retained only as optional
+  diagnostics under this design.
+- **Force-visible writes** (Elasticsearch `refresh=true` analog: every
+  `remember` blocks until searchable). Rejected: taxes every write with
+  worst-case publication latency to serve the minority of callers that need a
+  fence, and removes the caller's ability to choose.
+- **Global read-your-writes session state held server-side.** Rejected for the
+  additive stage: khive's callers span processes and namespaces; an explicit
+  token keeps the fence self-describing, replayable across processes, and free
+  of server session affinity.
+
+## Consequences
+
+- Callers that need read-your-writes get a provable, bounded-wait contract;
+  callers that do not pay nothing.
+- The fence is per-model, so a mixed-model recall degrades precisely: a
+  `freshness_unmet` result names the models that failed coverage.
+- The exact-tail snapshot participates in coverage proofs, so under normal
+  operation a `session` recall issued immediately after `remember` succeeds
+  without waiting for segment publication — the tail already covers the fence.
+- `freshness_unmet` is a new typed degradation state and must follow the
+  established degradation-marking rules (flag says whether, log says why).
+- Implementation risk concentrates in the coverage proof
+  (`segment_watermark ∪ exact_tail_snapshot` per model, one snapshot); it must
+  be read from one consistent snapshot to avoid proving coverage with two
+  clocks.
+
+## Out of scope
+
+- The Cold/Empty cap divergence (fixed 20,000-row constant vs ADR-118's
+  threshold-relative text vs the knowledge pack's corpus-relative
+  implementation) is a live divergence tracked in #1161 and belongs to an
+  ADR-118 alignment, not this contract.
+- Knowledge-pack freshness: the fresh-tail helper landed (#1589) and the pack
+  proves no current gap; this ADR adds no knowledge-pack requirement.
+
+## Acceptance
+
+This record is accepted only with an explicit choice of Arm A or Arm B. If
+Arm A: implementation follows as tracked work (receipt first, fence second;
+both additive). If Arm B: the verb documentation change lands with the
+acceptance and this record stands as the decision trail.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -150,6 +150,7 @@ The same head-binding governs review: a verdict authorizes only the exact commit
 | [ADR-141](ADR-141-store-backup-runner.md)                               | Executable store backup runner                                                                             |
 | [ADR-142](ADR-142-agentic-process-runtime.md)                           | Agentic Process Runtime                                                                                    |
 | [ADR-143](ADR-143-store-held-caller-grants.md)                          | Store-held caller grants and hierarchical subactor identity                                                |
+| [ADR-144](ADR-144-memory-write-visibility-fence.md)                     | Operation-level write-visibility fence for memory recall                                                   |
 
 <!-- END GENERATED ADR CATALOG -->
 


### PR DESCRIPTION
## Summary

Decision record (Status: Proposed) for the missing freshness contract on the memory surface. At current main, `memory.remember` returns no visibility state (remember.rs response fields: id/kind/salience/decay_factor/memory_type/created_at + optional edge_id) and `memory.recall` accepts no consistency parameter (only degradation field: `ann_unavailable`), so no caller can prove a specific write is visible to a subsequent recall — ADR-118's exact-tail merge is deliberately silent about origin.

The record proposes an additive two-part contract (write receipt `visibility_token` + `consistency: eventual|session` read fence with typed `freshness_unmet`), states the explicit null alternative (formally document best-effort visibility at the verb surface), and requires acceptance to pick one arm. Per-hit origin labels (#1084) are analyzed and retained only as diagnostics.

Out of scope: the Cold/Empty cap divergence (#1161) — separate ADR-118 alignment lane.

## Verification
- Surface claims re-derived at main 58a864ccc: remember response shape (handlers/remember.rs:168-178), recall parameter absence (grep), `VectorSearchHit` fields (khive-storage/src/types/vector.rs:203-207).

🤖 Generated with [Claude Code](https://claude.com/claude-code)