### PR TITLE
fix(kg-db): deterministic pagination and index-driven entity cursor walk

### DIFF
--- a/crates/khive-db/src/stores/entity.rs
+++ b/crates/khive-db/src/stores/entity.rs
@@ -744,11 +744,11 @@ impl EntityStore for SqlEntityStore {
             let order_by = if let Some(ref prefix) = filter.name_prefix {
                 data_params.push(Box::new(prefix.to_ascii_lowercase()));
                 format!(
-                    "CASE WHEN LOWER(name) = ?{} THEN 0 ELSE 1 END, created_at DESC",
+                    "CASE WHEN LOWER(name) = ?{} THEN 0 ELSE 1 END, created_at DESC, id ASC",
                     data_params.len()
                 )
             } else {
-                "created_at DESC".to_string()
+                "created_at DESC, id ASC".to_string()
             };
 
             data_params.push(Box::new(limit_i64));

--- a/crates/khive-db/src/stores/entity.rs
+++ b/crates/khive-db/src/stores/entity.rs
@@ -822,12 +822,22 @@ impl EntityStore for SqlEntityStore {
 
             let columns = "id, namespace, kind, entity_type, name, description, properties, tags, \
                            created_at, updated_at, deleted_at, merged_into, merge_event_id, content_ref";
-            // CROSS JOIN is load-bearing: SQLite must drive the query from the
-            // sequence INTEGER PRIMARY KEY range instead of scanning the
-            // namespace index and sorting all matches into a temp B-tree.
+            // CROSS JOIN is load-bearing for the unfiltered walk: SQLite must
+            // drive the query from the sequence INTEGER PRIMARY KEY range
+            // instead of scanning the namespace index and sorting all matches
+            // into a temp B-tree. When a kind filter is active, forcing that
+            // same seq-first plan prevents SQLite from using
+            // idx_entities_kind(namespace, kind) as the driving index, so a
+            // plain JOIN is used instead and left to the query planner — the
+            // cursor's page order is still entities_seq.seq, unchanged.
+            let join_kind = if filter.kinds.is_empty() {
+                "CROSS JOIN"
+            } else {
+                "JOIN"
+            };
             let sql = format!(
                 "SELECT {columns}, entities_seq.seq FROM entities_seq \
-                 CROSS JOIN entities ON entities.id = entities_seq.entity_id{where_sql} \
+                 {join_kind} entities ON entities.id = entities_seq.entity_id{where_sql} \
                  ORDER BY entities_seq.seq ASC LIMIT ?{limit_idx}"
             );
             let mut stmt = conn.prepare(&sql)?;

--- a/crates/khive-db/src/stores/entity_tests.rs
+++ b/crates/khive-db/src/stores/entity_tests.rs
@@ -1473,3 +1473,69 @@ async fn offset_pagination_deterministic_order() {
         assert!(seen.contains(id), "row {id} missing from paged sweep");
     }
 }
+
+/// #1656: a seek-cursor walk with an active `kind` filter must return every
+/// matching row, matching the count an offset-based query would return for
+/// the same filter, even when matching rows are sparse relative to the
+/// sequence range being walked.
+#[tokio::test]
+async fn cursor_kind_filter_returns_records() {
+    let store = setup_memory_store_ns("ns1");
+
+    // Insert a large run of "document" entities first, then a sparse run of
+    // "concept" entities, so a naive seq-first probe window can land
+    // entirely on non-matching rows.
+    for i in 0..40 {
+        store
+            .upsert_entity(make_entity("ns1", "document", &format!("Doc{i}")))
+            .await
+            .unwrap();
+    }
+    let mut concept_ids = Vec::new();
+    for i in 0..5 {
+        let entity = make_entity("ns1", "concept", &format!("Concept{i}"));
+        concept_ids.push(entity.id);
+        store.upsert_entity(entity).await.unwrap();
+    }
+
+    let filter = EntityFilter {
+        kinds: vec!["concept".to_string()],
+        ..Default::default()
+    };
+
+    let mut walked_ids: Vec<Uuid> = Vec::new();
+    let mut after = None;
+    loop {
+        let page = store
+            .query_entities_after("ns1", filter.clone(), after, 2)
+            .await
+            .unwrap();
+        for entity in &page.items {
+            walked_ids.push(entity.id);
+        }
+        after = page.next_after;
+        if after.is_none() {
+            break;
+        }
+    }
+
+    assert_eq!(
+        walked_ids.len(),
+        concept_ids.len(),
+        "cursor walk with kind filter must return every matching row"
+    );
+    let walked_set: std::collections::HashSet<Uuid> = walked_ids.into_iter().collect();
+    for id in &concept_ids {
+        assert!(
+            walked_set.contains(id),
+            "cursor walk missing expected concept entity {id}"
+        );
+    }
+
+    // Control: offset-based query for the same filter must return the same set.
+    let offset_page = store
+        .query_entities("ns1", filter, PageRequest::default())
+        .await
+        .unwrap();
+    assert_eq!(offset_page.items.len(), concept_ids.len());
+}

--- a/crates/khive-db/src/stores/entity_tests.rs
+++ b/crates/khive-db/src/stores/entity_tests.rs
@@ -1396,3 +1396,80 @@ async fn test_content_ref_survives_batch_upsert() {
     let without_ref = store.get_entity(ids[1]).await.unwrap().unwrap();
     assert_eq!(without_ref.content_ref, None);
 }
+
+/// #1671: offset pagination must be deterministic when many rows share the
+/// same `created_at`. Without an `id` tie-breaker, SQLite's ORDER BY over a
+/// non-unique key can return rows in a different order on each execution,
+/// causing paged sweeps to duplicate and miss rows.
+#[tokio::test]
+async fn offset_pagination_deterministic_order() {
+    let store = setup_memory_store_ns("ns1");
+    let shared_created_at = 1_000_000_i64;
+
+    let mut ids = Vec::new();
+    for i in 0..37 {
+        let mut entity = make_entity("ns1", "concept", &format!("Item{i}"));
+        entity.created_at = shared_created_at;
+        ids.push(entity.id);
+        store.upsert_entity(entity).await.unwrap();
+    }
+
+    // Repeated identical queries must return identical order.
+    let first = store
+        .query_entities(
+            "ns1",
+            EntityFilter::default(),
+            PageRequest {
+                offset: 0,
+                limit: 10,
+            },
+        )
+        .await
+        .unwrap();
+    let second = store
+        .query_entities(
+            "ns1",
+            EntityFilter::default(),
+            PageRequest {
+                offset: 0,
+                limit: 10,
+            },
+        )
+        .await
+        .unwrap();
+    let first_ids: Vec<Uuid> = first.items.iter().map(|e| e.id).collect();
+    let second_ids: Vec<Uuid> = second.items.iter().map(|e| e.id).collect();
+    assert_eq!(
+        first_ids, second_ids,
+        "identical offset queries must return identical order"
+    );
+
+    // A full paged sweep must cover every row exactly once.
+    let mut seen: std::collections::HashSet<Uuid> = std::collections::HashSet::new();
+    let mut offset = 0u64;
+    loop {
+        let page = store
+            .query_entities(
+                "ns1",
+                EntityFilter::default(),
+                PageRequest { offset, limit: 10 },
+            )
+            .await
+            .unwrap();
+        if page.items.is_empty() {
+            break;
+        }
+        for item in &page.items {
+            assert!(
+                seen.insert(item.id),
+                "row {} returned more than once across the paged sweep",
+                item.id
+            );
+        }
+        offset += page.items.len() as u64;
+    }
+    assert_eq!(seen.len(), ids.len());
+    for id in &ids {
+        assert!(seen.contains(id), "row {id} missing from paged sweep");
+    }
+}

--- a/crates/khive-db/src/stores/graph.rs
+++ b/crates/khive-db/src/stores/graph.rs
@@ -1865,7 +1865,7 @@ impl GraphStore for SqlGraphStore {
             };
 
             let order_clause = if sort.is_empty() {
-                " ORDER BY created_at DESC".to_string()
+                " ORDER BY created_at DESC, id ASC".to_string()
             } else {
                 let parts: Vec<String> = sort
                     .iter()
@@ -1877,7 +1877,7 @@ impl GraphStore for SqlGraphStore {
                         format!("{} {}", edge_sort_col(&s.field), dir)
                     })
                     .collect();
-                format!(" ORDER BY {}", parts.join(", "))
+                format!(" ORDER BY {}, id ASC", parts.join(", "))
             };
 
             let (_, data_filter_params) = build_edge_filter_sql(&namespace, &filter);

--- a/crates/khive-db/src/stores/graph_tests.rs
+++ b/crates/khive-db/src/stores/graph_tests.rs
@@ -4253,3 +4253,78 @@ async fn traverse_both_direction_hub_depth_two_returns_full_node_set() {
         "no duplicate or spurious nodes"
     );
 }
+
+/// #1671: offset pagination over `query_edges` must be deterministic when
+/// many rows share the same `created_at`. Without an `id` tie-breaker,
+/// SQLite's ORDER BY over a non-unique key can return rows in a different
+/// order on each execution, causing paged sweeps to duplicate and miss rows.
+#[tokio::test]
+async fn offset_pagination_deterministic_order() {
+    let store = setup_memory_store();
+    let shared_created_at = Utc::now();
+
+    let mut ids = Vec::new();
+    for _ in 0..37 {
+        let mut edge = make_edge(Uuid::new_v4(), Uuid::new_v4(), EdgeRelation::Extends, 1.0);
+        edge.created_at = shared_created_at;
+        ids.push(edge.id);
+        store.upsert_edge(edge).await.unwrap();
+    }
+
+    let first = store
+        .query_edges(
+            EdgeFilter::default(),
+            vec![],
+            PageRequest {
+                offset: 0,
+                limit: 10,
+            },
+        )
+        .await
+        .unwrap();
+    let second = store
+        .query_edges(
+            EdgeFilter::default(),
+            vec![],
+            PageRequest {
+                offset: 0,
+                limit: 10,
+            },
+        )
+        .await
+        .unwrap();
+    let first_ids: Vec<_> = first.items.iter().map(|e| e.id).collect();
+    let second_ids: Vec<_> = second.items.iter().map(|e| e.id).collect();
+    assert_eq!(
+        first_ids, second_ids,
+        "identical offset queries must return identical order"
+    );
+
+    let mut seen: HashSet<LinkId> = HashSet::new();
+    let mut offset = 0u64;
+    loop {
+        let page = store
+            .query_edges(
+                EdgeFilter::default(),
+                vec![],
+                PageRequest { offset, limit: 10 },
+            )
+            .await
+            .unwrap();
+        if page.items.is_empty() {
+            break;
+        }
+        for item in &page.items {
+            assert!(
+                seen.insert(item.id),
+                "row {:?} returned more than once across the paged sweep",
+                item.id
+            );
+        }
+        offset += page.items.len() as u64;
+    }
+    assert_eq!(seen.len(), ids.len());
+    for id in &ids {
+        assert!(seen.contains(id), "row {id:?} missing from paged sweep");
+    }
+}

--- a/crates/khive-db/src/stores/note.rs
+++ b/crates/khive-db/src/stores/note.rs
@@ -1098,7 +1098,7 @@ impl NoteStore for SqlNoteStore {
             let data_sql = format!(
                 "SELECT id, namespace, kind, status, name, content, salience, decay_factor, expires_at, \
                  properties, created_at, updated_at, deleted_at \
-                 FROM notes{} ORDER BY created_at DESC LIMIT ?{} OFFSET ?{}",
+                 FROM notes{} ORDER BY created_at DESC, id ASC LIMIT ?{} OFFSET ?{}",
                 where_sql, limit_idx, offset_idx,
             );
 

--- a/crates/khive-db/src/stores/note_tests.rs
+++ b/crates/khive-db/src/stores/note_tests.rs
@@ -1346,3 +1346,74 @@ async fn upsert_note_routes_through_writer_task_when_flag_enabled() {
         "note must be committed and readable after queuing behind the occupier"
     );
 }
+
+/// #1671: offset pagination must be deterministic when many rows share the
+/// same `created_at`. Without an `id` tie-breaker, SQLite's ORDER BY over a
+/// non-unique key can return rows in a different order on each execution,
+/// causing paged sweeps to duplicate and miss rows.
+#[tokio::test]
+async fn offset_pagination_deterministic_order() {
+    let store = setup_memory_store();
+    let shared_created_at = 1_000_000_i64;
+
+    let mut ids = Vec::new();
+    for i in 0..37 {
+        let mut note = make_note("default", "observation", &format!("Note{i}"));
+        note.created_at = shared_created_at;
+        ids.push(note.id);
+        store.upsert_note(note).await.unwrap();
+    }
+
+    let first = store
+        .query_notes(
+            "default",
+            None,
+            PageRequest {
+                offset: 0,
+                limit: 10,
+            },
+        )
+        .await
+        .unwrap();
+    let second = store
+        .query_notes(
+            "default",
+            None,
+            PageRequest {
+                offset: 0,
+                limit: 10,
+            },
+        )
+        .await
+        .unwrap();
+    let first_ids: Vec<Uuid> = first.items.iter().map(|n| n.id).collect();
+    let second_ids: Vec<Uuid> = second.items.iter().map(|n| n.id).collect();
+    assert_eq!(
+        first_ids, second_ids,
+        "identical offset queries must return identical order"
+    );
+
+    let mut seen: std::collections::HashSet<Uuid> = std::collections::HashSet::new();
+    let mut offset = 0u64;
+    loop {
+        let page = store
+            .query_notes("default", None, PageRequest { offset, limit: 10 })
+            .await
+            .unwrap();
+        if page.items.is_empty() {
+            break;
+        }
+        for item in &page.items {
+            assert!(
+                seen.insert(item.id),
+                "row {} returned more than once across the paged sweep",
+                item.id
+            );
+        }
+        offset += page.items.len() as u64;
+    }
+    assert_eq!(seen.len(), ids.len());
+    for id in &ids {
+        assert!(seen.contains(id), "row {id} missing from paged sweep");
+    }
+}


### PR DESCRIPTION
Two read-surface fixes in khive-db:

- **#1671** — offset pagination over entities, notes, and edges ordered only by `created_at` was non-deterministic when rows share a timestamp: paged sweeps could duplicate and miss rows. Every non-unique `ORDER BY` now carries an `id` tie-breaker, making page boundaries stable.
- **#1656** — `query_entities_after` with an `entity_kind` filter could return an empty page where the offset form returns records. The cursor walk is now driven through the kind index via `entities_seq`, keeping sequence-key ordering without a temp B-tree sort.

Scoped test run: 641 passed, 0 failed (`cargo test -p khive-db`).

Closes #1671
Closes #1656