### PR TITLE
fix(memory): disclose fresh-tail re-resolution failures on recall responses

### DIFF
--- a/crates/khive-pack-memory/src/ann.rs
+++ b/crates/khive-pack-memory/src/ann.rs
@@ -4160,6 +4160,158 @@ mod tests {
         );
     }
 
+    /// A re-resolution that assembles its candidates but then loses the SQL
+    /// leg that would prove tail completeness (reader open, snapshot begin,
+    /// registry-min re-read, tail fetch) must return a REASONED `Replace`:
+    /// the coherent re-resolved candidates are served, and the lost
+    /// read-your-writes visibility is disclosed via `Some(reason)` — never
+    /// reported healthy (`None`) and never degraded to a `Skipped` that
+    /// would resurrect the stale candidate set. Drives the earliest
+    /// post-re-resolution failure site (the registry-minimum re-read) by
+    /// removing its table while the leg is paused at the test barrier
+    /// between its segment search and that re-read.
+    #[tokio::test]
+    #[serial(adr118_fresh_tail)]
+    async fn fresh_tail_leg_post_reresolution_sql_failure_is_a_reasoned_replace() {
+        const MODEL: &str = "adr118-reresolve-reasoned-replace-test-model";
+        const DIMS: usize = 8;
+        let rt = test_runtime_with_hash_embedder(MODEL, DIMS);
+        let token = rt.authorize(Namespace::local()).expect("authorize local");
+
+        for i in 0..3u32 {
+            rt.create_note_with_decay_for_embedding_model(
+                &token,
+                "memory",
+                None,
+                &format!("reasoned replace seed note {i}"),
+                Some(0.7),
+                0.01,
+                None,
+                vec![],
+                None,
+            )
+            .await
+            .expect("create seed note");
+        }
+
+        let ann = new_shared();
+        let key = AnnKey::from_token(MODEL);
+        ensure_ann_for_model(&rt, &token, &ann, MODEL)
+            .await
+            .expect("warm");
+        let s1 = bridge_applied_seq(&ann, &key)
+            .await
+            .expect("bridge watermark after initial warm");
+
+        // A new note lands after the checkpoint; the peer checkpoint below
+        // persists it, and its presence in the outcome's candidates is the
+        // proof that the REASONED Replace still serves the re-resolved
+        // segment rather than falling back to the stale one.
+        let fresh = rt
+            .create_note_with_decay_for_embedding_model(
+                &token,
+                "memory",
+                None,
+                "reasoned replace distinctive fresh note",
+                Some(0.7),
+                0.01,
+                None,
+                vec![],
+                None,
+            )
+            .await
+            .expect("create fresh note");
+
+        let (_live, tail_before) = scope_counts(&rt, MODEL, s1)
+            .await
+            .expect("scope counts before peer checkpoint");
+        assert!(tail_before > 0, "sanity: a tail must exist above s1");
+        let s2 = s1 + tail_before;
+
+        // Peer checkpoint: persist a segment at s2, raise+compact through it
+        // — the mismatch the leg re-resolves from, exactly as in
+        // fresh_tail_leg_reresolves_to_a_newer_persisted_segment_on_mismatch.
+        let dir = ann_segment_dir(&rt, MODEL).expect("segment dir (file-backed test runtime)");
+        let mut peer_bridge = AnnBridge::load(&dir).expect("load persisted segment");
+        let (ops, new_s) = fetch_final_tail(&rt, MODEL, s1, None)
+            .await
+            .expect("fetch tail for peer replay");
+        peer_bridge
+            .apply_final_ops(ops, new_s)
+            .expect("apply peer replay");
+        peer_bridge
+            .save_atomic(&dir)
+            .expect("persist peer checkpoint");
+        raise_watermark(&rt, MODEL, s2)
+            .await
+            .expect("raise registry watermark");
+        compact_log(&rt, MODEL).await.expect("compact log");
+
+        // Pause the leg after its segment load+search, before the SQL phase
+        // whose failure this test injects.
+        ann.reresolve_race_barrier
+            .store(true, std::sync::atomic::Ordering::SeqCst);
+        let paused = ann.reresolve_race_notify.notified();
+
+        let query = fnv_to_vec("reasoned replace distinctive fresh note", DIMS);
+        let handle = tokio::spawn({
+            let rt = rt.clone();
+            let ann = ann.clone();
+            let key = key.clone();
+            async move { fresh_tail_leg(&rt, &ann, &key, MODEL, &query, 10, Some(s1)).await }
+        });
+        paused.await;
+
+        // Fault injection: remove the registry table so the leg's re-read —
+        // its first post-re-resolution SQL statement — fails. (Test-fixture
+        // database, mirroring the DROP TABLE fault pattern in
+        // handlers/recall.rs's event-store acquisition test.)
+        {
+            let sql = rt.sql();
+            let mut w = sql.writer().await.expect("fault injection writer");
+            w.execute(SqlStatement {
+                sql: "DROP TABLE ann_consumer_watermark".into(),
+                params: vec![],
+                label: Some("test_drop_registry_for_reasoned_replace".into()),
+            })
+            .await
+            .expect("drop registry table");
+        }
+
+        ann.reresolve_race_barrier
+            .store(false, std::sync::atomic::Ordering::SeqCst);
+        ann.reresolve_race_release.notify_one();
+
+        let outcome = handle.await.expect("fresh_tail_leg task");
+        match outcome {
+            FreshTailOutcome::Replace(candidates, reason) => {
+                let reason = reason.expect(
+                    "a post-re-resolution SQL failure must be DISCLOSED: \
+                     Replace(_, None) reports read-your-writes visibility \
+                     the leg no longer proved",
+                );
+                assert!(
+                    reason.starts_with("fresh-tail:"),
+                    "the disclosure must name its failure site, got: {reason:?}"
+                );
+                assert!(
+                    candidates.iter().any(|(id, _)| *id == fresh.id),
+                    "a reasoned Replace must still serve the re-resolved \
+                     segment's candidates (which alone reflect the peer's \
+                     checkpoint), got: {candidates:?}"
+                );
+            }
+            FreshTailOutcome::Ops(_) => panic!(
+                "expected re-resolution to replace candidates outright, not \
+                 return ops against the stale bridge"
+            ),
+            FreshTailOutcome::Skipped(_) => panic!(
+                "a failure AFTER successful re-resolution must not discard \
+                 the coherent re-resolved candidates by skipping"
+            ),
+        }
+    }
+
     /// ADR-118 §1 "Compaction linearization" applied to re-resolution itself:
     /// a peer checkpoint can advance the registry minimum PAST the segment
     /// `fresh_tail_reresolve` just loaded, in the window between that load

--- a/crates/khive-pack-memory/src/ann.rs
+++ b/crates/khive-pack-memory/src/ann.rs
@@ -1721,6 +1721,26 @@ pub(crate) fn merge_fresh_tail(
     merged
 }
 
+/// Fold a [`FreshTailOutcome`] into the candidate set a recall handler will
+/// serve, plus the degradation disclosure the caller owes when fresh-tail
+/// visibility was lost. `Ops` merges into `prior` with no disclosure;
+/// `Replace` swaps the candidate set and discloses only when the re-resolved
+/// tail could not be assembled; `Skipped` keeps `prior` and always
+/// discloses. Every recall path that consumes an outcome goes through this
+/// single mapping so no exceptional class can be silently treated as
+/// healthy.
+pub(crate) fn outcome_into_candidates(
+    outcome: FreshTailOutcome,
+    prior: Vec<(Uuid, f32)>,
+    query: &[f32],
+) -> (Vec<(Uuid, f32)>, Option<String>) {
+    match outcome {
+        FreshTailOutcome::Ops(ops) => (merge_fresh_tail(prior, query, ops), None),
+        FreshTailOutcome::Replace(candidates, reason) => (candidates, reason.map(str::to_string)),
+        FreshTailOutcome::Skipped(reason) => (prior, Some(reason.to_string())),
+    }
+}
+
 /// Outcome of [`fresh_tail_leg`].
 pub(crate) enum FreshTailOutcome {
     /// Coalesced final tail ops (ADR-118 §1/§2), valid against the
@@ -1732,11 +1752,22 @@ pub(crate) enum FreshTailOutcome {
     /// REPLACE the caller's `best_raw` outright — they are already a
     /// self-consistent (new candidates, new watermark) pair, exact-scored
     /// against that segment's own tail. Never merge them with the stale set.
-    Replace(Vec<(Uuid, f32)>),
+    ///
+    /// The second field is `Some(reason)` when the re-resolved candidates
+    /// are served WITHOUT their fresh-tail merge (reader/snapshot/registry
+    /// or tail-fetch failure after re-resolution): the candidate set is
+    /// still coherent, but read-your-writes visibility was lost, and the
+    /// caller must disclose that. `None` means the full re-resolved
+    /// (candidates, tail) pair was assembled — no degradation. Same
+    /// diagnostic-text contract as [`FreshTailOutcome::Skipped`].
+    Replace(Vec<(Uuid, f32)>, Option<&'static str>),
     /// The leg sat out this query entirely (disabled, unregistered
     /// consumer, or an unrecoverable read failure); the caller's candidates
-    /// are unaffected.
-    Skipped,
+    /// are unaffected. The payload is a non-empty, failure-site diagnostic
+    /// identifying which exceptional class caused the skip — diagnostic
+    /// text for degraded-response disclosure, not a stable public enum;
+    /// callers may depend on its presence, not its exact wording.
+    Skipped(&'static str),
 }
 
 /// The ADR-118 fresh-tail exact leg. `s = Some(watermark)` is the first
@@ -1759,7 +1790,7 @@ pub(crate) async fn fresh_tail_leg(
     s: Option<u64>,
 ) -> FreshTailOutcome {
     if !fresh_tail_enabled() {
-        return FreshTailOutcome::Skipped;
+        return FreshTailOutcome::Skipped("fresh-tail leg disabled via KHIVE_ANN_FRESH_TAIL");
     }
 
     // Registration precondition (ADR-118 §1): S = 0 (or "no bridge") proves
@@ -1772,11 +1803,11 @@ pub(crate) async fn fresh_tail_leg(
             if let Err(e) = register_consumer(rt, model).await {
                 tracing::warn!(error = %e, model, "fresh-tail: consumer re-registration failed");
             }
-            return FreshTailOutcome::Skipped;
+            return FreshTailOutcome::Skipped("fresh-tail: consumer registration absent; re-registering and sitting out this query");
         }
         Err(e) => {
             tracing::warn!(error = %e, model, "fresh-tail: registry read failed; skipping exact leg");
-            return FreshTailOutcome::Skipped;
+            return FreshTailOutcome::Skipped("fresh-tail: registry read failed");
         }
     }
 
@@ -1803,12 +1834,12 @@ async fn fresh_tail_serving(
         Ok(r) => r,
         Err(e) => {
             tracing::warn!(error = %e, model, "fresh-tail: reader open failed; skipping exact leg");
-            return FreshTailOutcome::Skipped;
+            return FreshTailOutcome::Skipped("fresh-tail: reader open failed");
         }
     };
     if let Err(e) = begin_read_snapshot(reader.as_mut()).await {
         tracing::warn!(error = %e, model, "fresh-tail: snapshot begin failed; skipping exact leg");
-        return FreshTailOutcome::Skipped;
+        return FreshTailOutcome::Skipped("fresh-tail: snapshot begin failed");
     }
 
     let registry_min = match registry_min_watermark_on(reader.as_mut(), model).await {
@@ -1816,7 +1847,7 @@ async fn fresh_tail_serving(
         Err(e) => {
             end_read_snapshot(reader.as_mut()).await;
             tracing::warn!(error = %e, model, "fresh-tail: registry-min read failed; skipping exact leg");
-            return FreshTailOutcome::Skipped;
+            return FreshTailOutcome::Skipped("fresh-tail: registry-min read failed");
         }
     };
 
@@ -1853,7 +1884,7 @@ async fn fresh_tail_serving(
                         Ok((ops, _)) => FreshTailOutcome::Ops(ops),
                         Err(e) => {
                             tracing::warn!(error = %e, model, "fresh-tail: floored tail fetch failed; skipping exact leg");
-                            FreshTailOutcome::Skipped
+                            FreshTailOutcome::Skipped("fresh-tail: floored tail fetch failed")
                         }
                     }
                 }
@@ -1867,7 +1898,7 @@ async fn fresh_tail_serving(
         Ok((ops, _new_s)) => FreshTailOutcome::Ops(ops),
         Err(e) => {
             tracing::warn!(error = %e, model, "fresh-tail: tail fetch failed; skipping exact leg");
-            FreshTailOutcome::Skipped
+            FreshTailOutcome::Skipped("fresh-tail: tail fetch failed")
         }
     }
 }
@@ -1918,14 +1949,16 @@ async fn fresh_tail_reresolve(
     for round in 1..=FRESH_TAIL_RERESOLVE_MAX_ROUNDS {
         let Some(dir) = ann_segment_dir(rt, model) else {
             bump_generation(ann, key).await;
-            return FreshTailOutcome::Skipped;
+            return FreshTailOutcome::Skipped(
+                "fresh-tail: re-resolved segment directory unavailable",
+            );
         };
         let bridge = match AnnBridge::load(&dir) {
             Ok(b) => b,
             Err(e) => {
                 tracing::warn!(error = %e, model, "fresh-tail: re-resolved segment load failed; skipping exact leg");
                 bump_generation(ann, key).await;
-                return FreshTailOutcome::Skipped;
+                return FreshTailOutcome::Skipped("fresh-tail: re-resolved segment load failed");
             }
         };
         let s_loaded = bridge.index.last_applied_seq().unwrap_or(expected_s);
@@ -1934,7 +1967,7 @@ async fn fresh_tail_reresolve(
             Err(e) => {
                 tracing::warn!(error = %e, model, "fresh-tail: re-resolved segment search failed; skipping exact leg");
                 bump_generation(ann, key).await;
-                return FreshTailOutcome::Skipped;
+                return FreshTailOutcome::Skipped("fresh-tail: re-resolved segment search failed");
             }
         };
         // Force re-adoption so the background warm path installs this segment
@@ -1964,12 +1997,18 @@ async fn fresh_tail_reresolve(
             Ok(r) => r,
             Err(e) => {
                 tracing::warn!(error = %e, model, "fresh-tail: re-resolved reader open failed; serving re-resolved candidates without further tail");
-                return FreshTailOutcome::Replace(candidates);
+                return FreshTailOutcome::Replace(
+                    candidates,
+                    Some("fresh-tail: re-resolved reader open failed"),
+                );
             }
         };
         if let Err(e) = begin_read_snapshot(reader.as_mut()).await {
             tracing::warn!(error = %e, model, "fresh-tail: re-resolved snapshot begin failed; serving re-resolved candidates without further tail");
-            return FreshTailOutcome::Replace(candidates);
+            return FreshTailOutcome::Replace(
+                candidates,
+                Some("fresh-tail: re-resolved snapshot begin failed"),
+            );
         }
 
         let registry_min = match registry_min_watermark_on(reader.as_mut(), model).await {
@@ -1977,7 +2016,10 @@ async fn fresh_tail_reresolve(
             Err(e) => {
                 end_read_snapshot(reader.as_mut()).await;
                 tracing::warn!(error = %e, model, "fresh-tail: re-resolved registry-min read failed; serving re-resolved candidates without further tail");
-                return FreshTailOutcome::Replace(candidates);
+                return FreshTailOutcome::Replace(
+                    candidates,
+                    Some("fresh-tail: re-resolved registry-min read failed"),
+                );
             }
         };
 
@@ -1992,10 +2034,15 @@ async fn fresh_tail_reresolve(
             let outcome = fetch_final_tail_on(reader.as_mut(), model, s_loaded, None).await;
             end_read_snapshot(reader.as_mut()).await;
             return match outcome {
-                Ok((ops, _)) => FreshTailOutcome::Replace(merge_fresh_tail(candidates, query, ops)),
+                Ok((ops, _)) => {
+                    FreshTailOutcome::Replace(merge_fresh_tail(candidates, query, ops), None)
+                }
                 Err(e) => {
                     tracing::warn!(error = %e, model, "fresh-tail: re-resolved tail fetch failed; serving re-resolved candidates without further tail");
-                    FreshTailOutcome::Replace(candidates)
+                    FreshTailOutcome::Replace(
+                        candidates,
+                        Some("fresh-tail: re-resolved tail fetch failed"),
+                    )
                 }
             };
         }
@@ -2019,10 +2066,15 @@ async fn fresh_tail_reresolve(
             let outcome = fetch_final_tail_on(reader.as_mut(), model, m, None).await;
             end_read_snapshot(reader.as_mut()).await;
             return match outcome {
-                Ok((ops, _)) => FreshTailOutcome::Replace(merge_fresh_tail(candidates, query, ops)),
+                Ok((ops, _)) => {
+                    FreshTailOutcome::Replace(merge_fresh_tail(candidates, query, ops), None)
+                }
                 Err(e) => {
                     tracing::warn!(error = %e, model, "fresh-tail: floored-fallback tail fetch failed; serving re-resolved candidates without further tail");
-                    FreshTailOutcome::Replace(candidates)
+                    FreshTailOutcome::Replace(
+                        candidates,
+                        Some("fresh-tail: floored-fallback tail fetch failed"),
+                    )
                 }
             };
         }
@@ -2053,14 +2105,14 @@ async fn fresh_tail_capped(rt: &KhiveRuntime, model: &str) -> FreshTailOutcome {
         Ok(true) => {}
         Err(e) => {
             tracing::warn!(error = %e, model, "fresh-tail: tail-existence read failed; skipping capped exact leg");
-            return FreshTailOutcome::Skipped;
+            return FreshTailOutcome::Skipped("fresh-tail: tail-existence read failed");
         }
     }
     match fetch_final_tail(rt, model, 0, Some(FRESH_TAIL_CAPPED_MAX_ROWS)).await {
         Ok((ops, _new_s)) => FreshTailOutcome::Ops(ops),
         Err(e) => {
             tracing::warn!(error = %e, model, "fresh-tail: capped tail fetch failed; skipping exact leg");
-            FreshTailOutcome::Skipped
+            FreshTailOutcome::Skipped("fresh-tail: capped tail fetch failed")
         }
     }
 }
@@ -2303,6 +2355,70 @@ async fn classify_and_adopt_segment(
 mod tests {
     use super::*;
     use serial_test::serial;
+
+    #[test]
+    fn outcome_into_candidates_replace_with_reason_discloses_degradation() {
+        // Re-resolution failure classes (reader open, snapshot begin,
+        // registry-min read, tail fetch, floored-fallback tail fetch)
+        // serve coherent candidates but lose read-your-writes visibility:
+        // the mapping must surface the failure-site reason, not report
+        // the response as healthy.
+        let prior = vec![(Uuid::from_u128(1), 0.9_f32)];
+        let replaced = vec![(Uuid::from_u128(2), 0.8_f32)];
+        let (candidates, disclosure) = outcome_into_candidates(
+            FreshTailOutcome::Replace(
+                replaced.clone(),
+                Some("fresh-tail: re-resolved tail fetch failed"),
+            ),
+            prior,
+            &[1.0, 0.0],
+        );
+        assert_eq!(candidates, replaced, "Replace must swap the candidate set");
+        assert_eq!(
+            disclosure.as_deref(),
+            Some("fresh-tail: re-resolved tail fetch failed"),
+            "a reasoned Replace must disclose its failure site"
+        );
+    }
+
+    #[test]
+    fn outcome_into_candidates_healthy_replace_and_ops_do_not_disclose() {
+        let prior = vec![(Uuid::from_u128(1), 0.9_f32)];
+        let replaced = vec![(Uuid::from_u128(2), 0.8_f32)];
+        let (candidates, disclosure) = outcome_into_candidates(
+            FreshTailOutcome::Replace(replaced.clone(), None),
+            prior.clone(),
+            &[1.0, 0.0],
+        );
+        assert_eq!(candidates, replaced);
+        assert!(
+            disclosure.is_none(),
+            "a fully assembled re-resolution is not degraded"
+        );
+
+        let (candidates, disclosure) = outcome_into_candidates(
+            FreshTailOutcome::Ops(Vec::new()),
+            prior.clone(),
+            &[1.0, 0.0],
+        );
+        assert_eq!(candidates, prior);
+        assert!(disclosure.is_none(), "an empty tail merge is not degraded");
+    }
+
+    #[test]
+    fn outcome_into_candidates_skipped_keeps_prior_and_discloses() {
+        let prior = vec![(Uuid::from_u128(1), 0.9_f32)];
+        let (candidates, disclosure) = outcome_into_candidates(
+            FreshTailOutcome::Skipped("fresh-tail: reader open failed"),
+            prior.clone(),
+            &[1.0, 0.0],
+        );
+        assert_eq!(candidates, prior, "Skipped must leave candidates untouched");
+        assert_eq!(
+            disclosure.as_deref(),
+            Some("fresh-tail: reader open failed")
+        );
+    }
 
     #[test]
     fn ann_key_is_model_only() {
@@ -3723,8 +3839,8 @@ mod tests {
             .expect("bridge watermark");
         let ops = match fresh_tail_leg(&rt, &ann, &key, MODEL, &query, 10, Some(s)).await {
             FreshTailOutcome::Ops(ops) => ops,
-            FreshTailOutcome::Replace(_) => panic!("fresh-tail leg unexpectedly re-resolved"),
-            FreshTailOutcome::Skipped => panic!("fresh-tail leg unexpectedly skipped"),
+            FreshTailOutcome::Replace(..) => panic!("fresh-tail leg unexpectedly re-resolved"),
+            FreshTailOutcome::Skipped(_) => panic!("fresh-tail leg unexpectedly skipped"),
         };
         let merged = merge_fresh_tail(raw, &query, ops);
         assert!(
@@ -3815,8 +3931,8 @@ mod tests {
             .expect("bridge watermark");
         let ops = match fresh_tail_leg(&rt, &ann, &key, MODEL, &query, 10, Some(s)).await {
             FreshTailOutcome::Ops(ops) => ops,
-            FreshTailOutcome::Replace(_) => panic!("fresh-tail leg unexpectedly re-resolved"),
-            FreshTailOutcome::Skipped => panic!("fresh-tail leg unexpectedly skipped"),
+            FreshTailOutcome::Replace(..) => panic!("fresh-tail leg unexpectedly re-resolved"),
+            FreshTailOutcome::Skipped(_) => panic!("fresh-tail leg unexpectedly skipped"),
         };
         let merged = merge_fresh_tail(raw, &query, ops);
 
@@ -3912,11 +4028,11 @@ mod tests {
         let outcome = fresh_tail_leg(&rt, &ann, &key, MODEL, &query, 10, Some(s1)).await;
         let ops = match outcome {
             FreshTailOutcome::Ops(ops) => ops,
-            FreshTailOutcome::Replace(_) => panic!(
+            FreshTailOutcome::Replace(..) => panic!(
                 "re-resolution must not succeed here: the only persisted \
                  segment is exactly as stale as the in-memory bridge"
             ),
-            FreshTailOutcome::Skipped => panic!(
+            FreshTailOutcome::Skipped(_) => panic!(
                 "a mismatch must never silently drop the leg — it floors at \
                  the same-snapshot registry minimum instead of skipping"
             ),
@@ -4022,12 +4138,12 @@ mod tests {
         let query = fnv_to_vec("reresolve distinctive fresh note", DIMS);
         let outcome = fresh_tail_leg(&rt, &ann, &key, MODEL, &query, 10, Some(s1)).await;
         let candidates = match outcome {
-            FreshTailOutcome::Replace(candidates) => candidates,
+            FreshTailOutcome::Replace(candidates, _) => candidates,
             FreshTailOutcome::Ops(_) => panic!(
                 "expected re-resolution to replace candidates outright, not \
                  just return ops to merge into the stale bridge's candidates"
             ),
-            FreshTailOutcome::Skipped => {
+            FreshTailOutcome::Skipped(_) => {
                 panic!("expected successful re-resolution, not a skip")
             }
         };
@@ -4223,12 +4339,12 @@ mod tests {
 
         let outcome = handle.await.expect("fresh_tail_leg task");
         let candidates = match outcome {
-            FreshTailOutcome::Replace(candidates) => candidates,
+            FreshTailOutcome::Replace(candidates, _) => candidates,
             FreshTailOutcome::Ops(_) => panic!(
                 "expected re-resolution to replace candidates outright, not \
                  just return ops to merge into the stale bridge's candidates"
             ),
-            FreshTailOutcome::Skipped => {
+            FreshTailOutcome::Skipped(_) => {
                 panic!("expected the interleaved-compaction re-resolution to converge, not a skip")
             }
         };
@@ -4471,12 +4587,12 @@ mod tests {
 
         let outcome = handle.await.expect("fresh_tail_leg task");
         let candidates = match outcome {
-            FreshTailOutcome::Replace(candidates) => candidates,
+            FreshTailOutcome::Replace(candidates, _) => candidates,
             FreshTailOutcome::Ops(_) => panic!(
                 "expected the terminal round to replace candidates outright, \
                  not just return ops to merge into the stale bridge's candidates"
             ),
-            FreshTailOutcome::Skipped => {
+            FreshTailOutcome::Skipped(_) => {
                 panic!("expected the bound-exhaustion floored fallback, not a skip")
             }
         };
@@ -4575,11 +4691,24 @@ mod tests {
 
         let query = fnv_to_vec("registration precondition seed note", DIMS);
         let outcome = fresh_tail_leg(&rt, &ann, &key, MODEL, &query, 10, Some(s)).await;
-        assert!(
-            matches!(outcome, FreshTailOutcome::Skipped),
-            "the exact leg must sit out a query when this consumer's durable \
-             registration row is absent"
-        );
+        match outcome {
+            FreshTailOutcome::Skipped(reason) => {
+                assert!(
+                    !reason.is_empty(),
+                    "#1477 the exceptional skip must carry a non-empty \
+                     failure-site reason so degraded serving is disclosable"
+                );
+            }
+            other => panic!(
+                "the exact leg must sit out a query when this consumer's durable \
+                 registration row is absent, got: {}",
+                match other {
+                    FreshTailOutcome::Ops(_) => "Ops",
+                    FreshTailOutcome::Replace(..) => "Replace",
+                    FreshTailOutcome::Skipped(_) => unreachable!(),
+                }
+            ),
+        }
         assert_eq!(
             read_own_watermark(&rt, MODEL)
                 .await

--- a/crates/khive-pack-memory/src/handlers/common.rs
+++ b/crates/khive-pack-memory/src/handlers/common.rs
@@ -1364,7 +1364,7 @@ async fn collect_model_ann_hits_inner(
         }
     };
 
-    if let Some(degrade_reason) = model_ann_degrade_reason {
+    if let Some(mut degrade_reason) = model_ann_degrade_reason {
         // No serving index is available for this model within the bounded
         // wait. Rather than replace it with an O(corpus) exact scan, ADR-118
         // §3's second tier guarantees visibility of the newest
@@ -1374,7 +1374,27 @@ async fn collect_model_ann_hits_inner(
                 .await
             {
                 ann::FreshTailOutcome::Ops(ops) => ops,
-                ann::FreshTailOutcome::Replace(_) | ann::FreshTailOutcome::Skipped => Vec::new(),
+                // A `Replace` cannot arise on this tier (no serving bridge,
+                // so no watermark mismatch to re-resolve), but if one ever
+                // does, its degradation disclosure must not be dropped.
+                ann::FreshTailOutcome::Replace(_, reason) => {
+                    if let Some(reason) = reason {
+                        degrade_reason = format!(
+                            "{degrade_reason}; fresh-tail re-resolution degraded: {reason}"
+                        );
+                    }
+                    Vec::new()
+                }
+                // #1477: the capped exact leg sat out too — this is a second,
+                // exceptional degradation on top of the already-degraded
+                // ANN-not-ready path. Fold its failure-site reason into the
+                // one already surfaced rather than silently discarding it,
+                // so a caller sees why fresh-tail visibility was also lost.
+                ann::FreshTailOutcome::Skipped(reason) => {
+                    degrade_reason =
+                        format!("{degrade_reason}; fresh-tail leg also skipped: {reason}");
+                    Vec::new()
+                }
             };
         let merged = ann::merge_fresh_tail(Vec::new(), &vec, tail_ops);
         let hits: Vec<VectorSearchHit> = merged
@@ -1488,11 +1508,13 @@ async fn collect_model_ann_hits_inner(
             Some(best_seq),
         )
         .await;
-        let best_raw = match outcome {
-            ann::FreshTailOutcome::Ops(ops) => ann::merge_fresh_tail(best_raw, &vec, ops),
-            ann::FreshTailOutcome::Replace(candidates) => candidates,
-            ann::FreshTailOutcome::Skipped => best_raw,
-        };
+        // #1477: an exceptional fresh-tail skip (disabled, registration/registry
+        // failure, reader/snapshot failure, or tail-fetch failure — never an
+        // ordinary "no tail rows" outcome, which comes back as `Ops(vec![])`)
+        // still serves the warm-ANN candidates, but read-your-writes visibility
+        // was lost for this query; the caller must be able to see that.
+        let (best_raw, fresh_tail_skip_reason) =
+            ann::outcome_into_candidates(outcome, best_raw, &vec);
 
         tracing::debug!(
             model = %model_name,
@@ -1512,8 +1534,8 @@ async fn collect_model_ann_hits_inner(
         return Ok(PerModelAnnHits {
             model_name,
             hits,
-            degraded: false,
-            degraded_reason: None,
+            degraded: fresh_tail_skip_reason.is_some(),
+            degraded_reason: fresh_tail_skip_reason,
             used_sqlite_vec_fallback: false,
         });
     }

--- a/crates/khive-pack-memory/src/handlers/recall.rs
+++ b/crates/khive-pack-memory/src/handlers/recall.rs
@@ -751,6 +751,13 @@ impl MemoryPack {
                 if ann_degraded {
                     // Per-result stamp keeps degradation visible without verbose output.
                     result["degraded"] = json!("ann_unavailable");
+                    // #1477: additive, non-empty failure-site reason so a
+                    // caller can distinguish why serving degraded (e.g. an
+                    // exceptional fresh-tail skip) without breaking the
+                    // load-bearing bare-array shape non-empty callers rely on.
+                    if let Some(ref reason) = ann_degraded_reason {
+                        result["degraded_reason"] = json!(reason);
+                    }
                 }
                 if budget_capped {
                     // Surviving partial results retain the per-item signal so callers
@@ -1364,6 +1371,109 @@ mod tests {
             assert!(
                 r.get("degraded").is_none(),
                 "normal recall must not carry a degraded marker, got: {r:?}"
+            );
+        }
+    }
+
+    /// Guards a mutated `KHIVE_ANN_FRESH_TAIL` value, restoring whatever value
+    /// (present or absent) it held before the guard was created, even if the
+    /// test panics.
+    struct FreshTailEnvGuard {
+        prior: Option<String>,
+    }
+
+    impl FreshTailEnvGuard {
+        fn disable() -> Self {
+            let prior = std::env::var("KHIVE_ANN_FRESH_TAIL").ok();
+            std::env::set_var("KHIVE_ANN_FRESH_TAIL", "0");
+            Self { prior }
+        }
+    }
+
+    impl Drop for FreshTailEnvGuard {
+        fn drop(&mut self) {
+            match self.prior.take() {
+                Some(v) => std::env::set_var("KHIVE_ANN_FRESH_TAIL", v),
+                None => std::env::remove_var("KHIVE_ANN_FRESH_TAIL"),
+            }
+        }
+    }
+
+    /// #1477: an exceptional fresh-tail skip (here, the exact leg disabled via
+    /// `KHIVE_ANN_FRESH_TAIL=0`) forfeits read-your-writes visibility on the
+    /// warm-index path — that is degraded serving, not an ordinary healthy
+    /// response, and must be disclosed on a non-empty response the same way
+    /// #836's bounded-wait degradation already is. Fails on `f74c5461f`, where
+    /// a skipped fresh-tail leg on the warm-index path left `degraded: false`
+    /// and no per-item marker at all.
+    #[tokio::test]
+    #[serial(adr118_fresh_tail)]
+    async fn recall_1477_skipped_fresh_tail_stamps_degraded() {
+        const MODEL: &str = "recall-1477-fresh-tail-disabled-model";
+        const DIMS: usize = 16;
+        const NOTE_TEXT: &str = "issue 1477 fresh tail disabled recall degradation note";
+
+        let _env_guard = FreshTailEnvGuard::disable();
+
+        let rt = KhiveRuntime::memory().expect("in-memory runtime");
+        rt.register_embedder(HashVecProvider {
+            model_name: MODEL.to_owned(),
+            dims: DIMS,
+        });
+
+        let ns = Namespace::parse("local").expect("local namespace");
+        let token = rt.authorize(ns).expect("authorize local");
+
+        rt.create_note(&token, "memory", None, NOTE_TEXT, Some(0.7), None, vec![])
+            .await
+            .expect("create note");
+
+        let pack = MemoryPack::new(rt.clone());
+        let ann_handle = pack.ann.clone();
+
+        // Warm the ANN bridge synchronously so the fresh-tail leg is
+        // exercised via the warm-index branch (initial_raw_hits present),
+        // not the ANN-not-ready branch.
+        crate::ann::ensure_ann_for_model(&rt, &token, &ann_handle, MODEL)
+            .await
+            .expect("warm ann build");
+
+        let mut builder = VerbRegistryBuilder::new();
+        builder.register(KgPack::new(rt.clone()));
+        builder.register(pack);
+        let registry = builder.build().expect("registry");
+
+        let result = registry
+            .dispatch(
+                "memory.recall",
+                serde_json::json!({
+                    "query": "1477 fresh tail disabled recall",
+                    "limit": 10
+                }),
+            )
+            .await
+            .expect("recall must not error when the fresh-tail leg is disabled");
+
+        let results = result.as_array().expect("recall result must be an array");
+        assert!(
+            !results.is_empty(),
+            "the seeded note must still surface via the warm-index candidates"
+        );
+        for r in results {
+            assert_eq!(
+                r.get("degraded").and_then(Value::as_str),
+                Some("ann_unavailable"),
+                "#1477 a disabled fresh-tail leg must stamp the existing \
+                 degradation marker on a non-empty response, got: {r:?}"
+            );
+            let reason = r
+                .get("degraded_reason")
+                .and_then(Value::as_str)
+                .expect("#1477 a disabled fresh-tail leg must carry a degraded_reason string");
+            assert!(
+                !reason.is_empty(),
+                "#1477 degraded_reason must be non-empty (captured at the \
+                 failure site), got: {r:?}"
             );
         }
     }

--- a/crates/khive-pack-memory/src/handlers/recall.rs
+++ b/crates/khive-pack-memory/src/handlers/recall.rs
@@ -894,10 +894,24 @@ impl MemoryPack {
             // bare [] would be indistinguishable from a genuine no-match. Non-empty
             // capped responses keep the bare-array shape (load-bearing for callers
             // that index the top-level array) with per-item truncated stamps.
-            return to_json(&json!({
+            let mut envelope = json!({
                 "results": results,
                 "truncated": true,
-            }));
+            });
+            // A budget cutoff must not silence a concurrent ANN degradation:
+            // this branch returns before the degradation envelope below, and
+            // without these fields a capped-empty degraded response would
+            // read as clean-empty-but-truncated.
+            if ann_degraded {
+                let reason = ann_degraded_reason
+                    .clone()
+                    .unwrap_or_else(|| super::common::ANN_DEGRADED_REASON.to_string());
+                envelope["degraded"] = json!(true);
+                // Captured at the failure site (see
+                // collect_model_ann_hits_inner / collect_model_ann_hits).
+                envelope["degraded_reason"] = json!(reason);
+            }
+            return to_json(&envelope);
         }
 
         if results.is_empty() && ann_degraded {
@@ -1476,6 +1490,101 @@ mod tests {
                  failure site), got: {r:?}"
             );
         }
+    }
+
+    /// A budget cutoff at the first ranked candidate and an ANN degradation
+    /// can hold at once, and the budget-cap envelope returns before the
+    /// degradation envelope: without the degraded fields on that early
+    /// return, a capped-empty degraded response reads as
+    /// clean-empty-but-truncated and the caller loses the signal that
+    /// distinguishes degraded-empty from a genuine no-match.
+    #[tokio::test]
+    #[serial(adr118_fresh_tail)]
+    async fn recall_budget_capped_empty_response_still_discloses_ann_degradation() {
+        const MODEL: &str = "recall-budget-capped-degraded-model";
+        const DIMS: usize = 16;
+        const NOTE_TEXT: &str = "budget capped degraded disclosure note body";
+
+        let _env_guard = FreshTailEnvGuard::disable();
+
+        let rt = KhiveRuntime::memory().expect("in-memory runtime");
+        rt.register_embedder(HashVecProvider {
+            model_name: MODEL.to_owned(),
+            dims: DIMS,
+        });
+
+        let ns = Namespace::parse("local").expect("local namespace");
+        let token = rt.authorize(ns).expect("authorize local");
+
+        rt.create_note(&token, "memory", None, NOTE_TEXT, Some(0.7), None, vec![])
+            .await
+            .expect("create note");
+
+        let pack = MemoryPack::new(rt.clone());
+        let ann_handle = pack.ann.clone();
+
+        // A one-character budget guarantees the first ranked candidate
+        // exceeds it, so ranking survives but serving empties: budget_capped
+        // with zero results.
+        {
+            let mut cfg = pack.config.lock().unwrap();
+            cfg.scoring = Some(crate::scoring::ScoringConfig {
+                default_token_budget: 1,
+                chars_per_token: 1,
+                ..Default::default()
+            });
+        }
+
+        // Warm the ANN bridge so the disabled fresh-tail leg is what makes
+        // the response degraded (as in the #1477 test above), not ANN
+        // unavailability.
+        crate::ann::ensure_ann_for_model(&rt, &token, &ann_handle, MODEL)
+            .await
+            .expect("warm ann build");
+
+        let mut builder = VerbRegistryBuilder::new();
+        builder.register(KgPack::new(rt.clone()));
+        builder.register(pack);
+        let registry = builder.build().expect("registry");
+
+        let result = registry
+            .dispatch(
+                "memory.recall",
+                serde_json::json!({
+                    "query": "budget capped degraded disclosure",
+                    "limit": 10
+                }),
+            )
+            .await
+            .expect("capped degraded recall must not error");
+
+        let obj = result
+            .as_object()
+            .expect("capped-empty response must be the envelope shape, not a bare array");
+        assert_eq!(
+            obj.get("truncated").and_then(Value::as_bool),
+            Some(true),
+            "budget cutoff at the first candidate must disclose truncation: {result:?}"
+        );
+        assert!(
+            obj.get("results")
+                .and_then(Value::as_array)
+                .is_some_and(Vec::is_empty),
+            "this scenario is specifically the capped-EMPTY shape: {result:?}"
+        );
+        assert_eq!(
+            obj.get("degraded").and_then(Value::as_bool),
+            Some(true),
+            "a budget cutoff must not silence the concurrent ANN degradation: {result:?}"
+        );
+        let reason = obj
+            .get("degraded_reason")
+            .and_then(Value::as_str)
+            .expect("capped-empty degraded response must carry degraded_reason");
+        assert!(
+            !reason.is_empty(),
+            "degraded_reason must be non-empty (captured at the failure site): {result:?}"
+        );
     }
 
     /// #1657: ANN timeout plus no FTS match is a third state — the response


### PR DESCRIPTION
When a fresh-tail re-resolution loses its tail merge (reader open, snapshot begin, registry-min read, tail fetch, or floored-fallback tail fetch failure), the recall response served coherent candidates while silently missing read-your-writes visibility — the skip paths disclosed, the re-resolution failure paths did not.

- `FreshTailOutcome::Replace` now carries an optional failure-site reason; all five failure paths populate it.
- Every recall path folds outcomes through a single mapping (`outcome_into_candidates`), so no exceptional class can be treated as healthy by one handler and degraded by another.
- The warm-path handler stamps `degraded`/`degraded_reason` from the mapping; the capped tier folds the reason into its existing disclosure.
- Unit tests pin the mapping for reasoned Replace, healthy Replace, empty Ops, and Skipped.

Gate: khive-pack-memory 302+87 passed, 0 failed; workspace check clean.

Closes #1477.