### PR TITLE
fix(runtime): enforce ADR-002's document derived_from document endpoint, with a drift-catching conformance test

### DIFF
--- a/crates/khive-pack-kg/src/handler_defs.rs
+++ b/crates/khive-pack-kg/src/handler_defs.rs
@@ -572,7 +572,7 @@ pub(crate) static KG_HANDLERS: [HandlerDef; 20] = [
                     instance_of: *->concept (any source kind), service->project. \
                     extends: concept->concept. variant_of: concept->concept, artifact->artifact. \
                     introduced_by: concept->document, concept->person, concept->org, artifact->document, document->person, document->org. \
-                    derived_from: artifact->dataset, artifact->document, artifact->project, artifact->artifact. \
+                    derived_from: artifact->dataset, artifact->document, artifact->project, artifact->artifact, document->document. \
                     precedes: document->document, dataset->dataset, artifact->artifact, service->service, project->project. \
                     depends_on: project->project, service->project, service->service, service->artifact, service->dataset, artifact->project, artifact->service, document->document. \
                     enables: concept->concept, service->concept, dataset->concept. \

--- a/crates/khive-runtime/src/operations.rs
+++ b/crates/khive-runtime/src/operations.rs
@@ -16110,8 +16110,7 @@ mod tests {
         // rename cannot silently disarm this gate. From a published package
         // tarball neither exists; skip with disclosure instead of failing an
         // environment that cannot carry the canonical document.
-        let workspace_manifest =
-            format!("{}/../Cargo.toml", env!("CARGO_MANIFEST_DIR"));
+        let workspace_manifest = format!("{}/../Cargo.toml", env!("CARGO_MANIFEST_DIR"));
         if !std::path::Path::new(&workspace_manifest).exists() {
             eprintln!(
                 "skipping ADR-002 conformance: workspace manifest not present \

--- a/crates/khive-runtime/src/operations.rs
+++ b/crates/khive-runtime/src/operations.rs
@@ -806,6 +806,9 @@ pub const BASE_ENTITY_ENDPOINT_RULES: &[(&str, EdgeRelation, &str)] = &[
     ("artifact", EdgeRelation::DerivedFrom, "document"),
     ("artifact", EdgeRelation::DerivedFrom, "project"),
     ("artifact", EdgeRelation::DerivedFrom, "artifact"),
+    // ADR-002 amendment 2026-07-27: publication provenance — a curated or
+    // filtered publication copy points at the canonical source document.
+    ("document", EdgeRelation::DerivedFrom, "document"),
     // Temporal
     ("document", EdgeRelation::Precedes, "document"),
     ("dataset", EdgeRelation::Precedes, "dataset"),
@@ -16005,5 +16008,122 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(count, 0, "a rejected create must leave no note behind");
+    }
+
+    // ── ADR-002 base endpoint contract conformance (issue #1715) ────────────
+    // Parses the "### Base endpoint contract" tables straight out of
+    // docs/adr/ADR-002-edge-ontology.md and asserts set-equality against
+    // `BASE_ENTITY_ENDPOINT_RULES`. The ADR and the runtime allowlist are
+    // maintained by hand in two places with nothing else comparing them; this
+    // is the comparator, so a future amendment landing in only one of the two
+    // fails CI instead of shipping a silent false refusal (or a silent
+    // over-grant).
+
+    /// Subsections of the "Base endpoint contract" that are intentionally
+    /// excluded from `BASE_ENTITY_ENDPOINT_RULES`:
+    /// - "Annotation relation": `Note -> any substrate UUID` is a substrate-level
+    ///   rule (source is always a note), not an entity-kind pair.
+    /// - "KG pack extensions": additive rows declared via the KG pack's
+    ///   `EDGE_RULES`, not part of the runtime's base allowlist.
+    const ADR002_EXCLUDED_SUBSECTIONS: &[&str] = &["Annotation relation", "KG pack extensions"];
+
+    /// Parse the ADR-002 "Base endpoint contract" markdown tables into the same
+    /// `(source_kind, relation, target_kind)` shape as `BASE_ENTITY_ENDPOINT_RULES`.
+    fn parse_adr002_base_entity_endpoint_matrix(
+    ) -> std::collections::HashSet<(String, EdgeRelation, String)> {
+        let adr_path = format!(
+            "{}/../../docs/adr/ADR-002-edge-ontology.md",
+            env!("CARGO_MANIFEST_DIR")
+        );
+        let text = std::fs::read_to_string(&adr_path)
+            .unwrap_or_else(|e| panic!("failed to read {adr_path}: {e}"));
+        let lines: Vec<&str> = text.lines().collect();
+
+        let start = lines
+            .iter()
+            .position(|l| l.trim() == "### Base endpoint contract")
+            .expect("ADR-002 must contain a '### Base endpoint contract' heading");
+        let end = lines[start + 1..]
+            .iter()
+            .position(|l| l.starts_with("## "))
+            .map(|i| start + 1 + i)
+            .unwrap_or(lines.len());
+        let section = &lines[start..end];
+
+        let mut triples = std::collections::HashSet::new();
+        let mut excluded = false;
+
+        for line in section {
+            let trimmed = line.trim();
+            if let Some(title) = trimmed.strip_prefix("#### ") {
+                excluded = ADR002_EXCLUDED_SUBSECTIONS
+                    .iter()
+                    .any(|ex| title.starts_with(ex));
+                continue;
+            }
+            if excluded || !trimmed.starts_with('|') {
+                continue;
+            }
+
+            let cells: Vec<&str> = trimmed
+                .trim_matches('|')
+                .split('|')
+                .map(|c| c.trim())
+                .collect();
+            if cells.len() != 3 {
+                continue;
+            }
+            let is_header = cells[0].eq_ignore_ascii_case("Source");
+            let is_separator = cells
+                .iter()
+                .all(|c| !c.is_empty() && c.chars().all(|ch| ch == '-'));
+            if is_header || is_separator {
+                continue;
+            }
+
+            let src_raw = cells[0].trim_matches('`');
+            let rel_raw = cells[1].trim_matches('`');
+            let tgt_raw = cells[2].trim_matches('`');
+
+            let relation: EdgeRelation = rel_raw.parse().unwrap_or_else(|_| {
+                panic!("ADR-002 base endpoint contract row has unparseable relation: {trimmed:?}")
+            });
+
+            let src = if src_raw.eq_ignore_ascii_case("any entity") {
+                "*".to_string()
+            } else {
+                src_raw.to_ascii_lowercase()
+            };
+            let tgt = tgt_raw.to_ascii_lowercase();
+
+            triples.insert((src, relation, tgt));
+        }
+
+        triples
+    }
+
+    #[test]
+    fn base_entity_endpoint_rules_match_adr002_base_endpoint_contract() {
+        let adr_matrix = parse_adr002_base_entity_endpoint_matrix();
+        assert!(
+            !adr_matrix.is_empty(),
+            "parsed zero rows from ADR-002's base endpoint contract — parser or heading drift"
+        );
+
+        let runtime_rules: std::collections::HashSet<(String, EdgeRelation, String)> =
+            base_entity_endpoint_rules()
+                .iter()
+                .map(|(src, rel, tgt)| (src.to_string(), *rel, tgt.to_string()))
+                .collect();
+
+        let missing_from_runtime: Vec<_> = adr_matrix.difference(&runtime_rules).collect();
+        let extra_in_runtime: Vec<_> = runtime_rules.difference(&adr_matrix).collect();
+
+        assert!(
+            missing_from_runtime.is_empty() && extra_in_runtime.is_empty(),
+            "BASE_ENTITY_ENDPOINT_RULES has drifted from ADR-002's base endpoint contract.\n\
+             In the ADR but not enforced by the runtime: {missing_from_runtime:#?}\n\
+             Enforced by the runtime but not in the ADR: {extra_in_runtime:#?}"
+        );
     }
 }

--- a/crates/khive-runtime/src/operations.rs
+++ b/crates/khive-runtime/src/operations.rs
@@ -16104,6 +16104,21 @@ mod tests {
 
     #[test]
     fn base_entity_endpoint_rules_match_adr002_base_endpoint_contract() {
+        // ADR-002 lives at the repository root, outside this crate's package.
+        // In the repository the workspace manifest sits two levels up and the
+        // ADR must be readable — a missing file there is a hard failure so a
+        // rename cannot silently disarm this gate. From a published package
+        // tarball neither exists; skip with disclosure instead of failing an
+        // environment that cannot carry the canonical document.
+        let workspace_manifest =
+            format!("{}/../Cargo.toml", env!("CARGO_MANIFEST_DIR"));
+        if !std::path::Path::new(&workspace_manifest).exists() {
+            eprintln!(
+                "skipping ADR-002 conformance: workspace manifest not present \
+                 (published-package context); the check runs in the repository"
+            );
+            return;
+        }
         let adr_matrix = parse_adr002_base_entity_endpoint_matrix();
         assert!(
             !adr_matrix.is_empty(),


### PR DESCRIPTION
`ADR-002` declared `Document derived_from Document` in its 2026-07-27 amendment, but the runtime endpoint allowlist never gained the pair, so the edge was documented and refused.

- Adds the missing rule to `BASE_ENTITY_ENDPOINT_RULES`.
- Adds a table-driven conformance test that **parses the ADR's base endpoint matrix out of the markdown** and asserts set equality against `base_entity_endpoint_rules()`, reporting drift in both directions. Any future ADR-or-runtime change that moves one without the other now fails the suite, rather than this one pair being fixed by hand. The parser deliberately excludes the annotation-relation and pack-extension subsections (substrate-level and pack-declared respectively, not part of the base allowlist) and panics on an unparseable relation token rather than skipping the row.
- Syncs the one hand-maintained dependent surface, the `link` verb's relation help text, which has its own live-derived test that the new rule would otherwise have broken.

Negative control recorded both ways: with the rule removed the conformance test fails naming exactly the missing pair; with it restored, `khive-runtime --lib` is 1105 passed / 0 failed. `khive-pack-kg` 270+11 passed (including the endpoint-signature certificate tests, so the added rule introduces no signature collision). Clippy, fmt, and `cargo check --workspace` clean.

Closes #1715.