### PR TITLE
docs(adr): separate commit visibility from crash durability in ADR-133/134

### DIFF
--- a/docs/adr/ADR-133-incidental-writes-off-the-request-hot-path.md
+++ b/docs/adr/ADR-133-incidental-writes-off-the-request-hot-path.md
@@ -282,15 +282,18 @@ follow-on inherits the multi-daemon case.
 
 ### D2 — A classifier at the event-production seam decides commit-failure handling
 
-An earlier draft used the classifier to decide **routing** — which rows may be batched. Under D1
-that question no longer exists: every row rides the same committed (store-visible) batch, and on
-the success path every dispatch waits for it, so no row is deferred past its own return and there
-is nothing to route away from. The one exception is D1's carve-out — a pure-observability row
-whose commit fails persistently — and that is a failure outcome rather than a routing choice,
-which is exactly why the classifier's remaining job is failure semantics.
+An earlier draft used the classifier to decide **routing** in the sense of which rows may be
+batched at all. That question is gone under D1 — every row is batched, and no row is deferred
+past its own return — but a narrower routing decision exists again under ADR-134 D2a:
+classification selects the **lane**, and with it the committing connection, at enqueue
+(obligation-bearing rows to the durable-sync writer, pure observability rows to the shared
+writer). Within a lane there is still nothing to route away from: every row in the lane rides
+that lane's committed (store-visible) batch, and on the success path every dispatch waits for
+it. D1's carve-out — a pure-observability row whose commit fails persistently — remains a
+failure outcome rather than a routing choice.
 
-The classifier survives, for a sharper reason. It decides **what a failed commit does to the
-caller**:
+The classifier therefore has exactly two jobs, decided at the same seam: lane selection
+(ADR-134 D2a) and **what a failed commit does to the caller**:
 
 - **Accounting-, authorization-, and security-audit-bearing rows.** A dispatch must not report
   success when the record that accounts for, authorizes, or audits it did not commit. Reporting
@@ -489,9 +492,10 @@ of this record, and the read-your-own-audit caveat it carried is withdrawn.
 It claims writer _acquisitions_ fall. Whether any verb reaches zero writes is a question the
 revised census answers, not something this record asserts.
 
-**Not addressed here.** Remaining genuine writes still serialize on one writer. Raising that
-ceiling is the group-commit work, sequenced after this record so it is designed against the
-post-change profile.
+**Not addressed here.** Remaining genuine writes still serialize on one writer within each lane,
+and the two lane writers (ADR-134 D2a) additionally contend on SQLite's write lock between
+themselves. Raising that ceiling is the group-commit work, sequenced after this record so it is
+designed against the post-change profile.
 
 ## Acceptance
 

--- a/docs/adr/ADR-133-incidental-writes-off-the-request-hot-path.md
+++ b/docs/adr/ADR-133-incidental-writes-off-the-request-hot-path.md
@@ -274,9 +274,9 @@ follow-on inherits the multi-daemon case.
 An earlier draft used the classifier to decide **routing** — which rows may be batched. Under D1
 that question no longer exists: every row rides the same committed (store-visible) batch, and on
 the success path every dispatch waits for it, so no row is deferred past its own return and there
-is nothing to route away from. The one exception is D1's carve-out — a pure-observability row whose commit fails
-persistently — and that is a failure outcome rather than a routing choice, which is exactly why the
-classifier's remaining job is failure semantics.
+is nothing to route away from. The one exception is D1's carve-out — a pure-observability row
+whose commit fails persistently — and that is a failure outcome rather than a routing choice,
+which is exactly why the classifier's remaining job is failure semantics.
 
 The classifier survives, for a sharper reason. It decides **what a failed commit does to the
 caller**:
@@ -559,8 +559,9 @@ reading an earlier draft left open by not stating D1's waiting clause, and it is
 version of this decision but a different one. A returned operation whose row is still in memory can
 lose a row the current implementation would have kept, since today's append is committed
 (store-visible) at dispatch whenever it succeeds. That violates INV-4 directly, and for an
-accounting-bearing row it violates INV-1. It also buys nothing this record does not already obtain: the acquisition count falls
-because rows share a transaction, not because the caller stopped waiting.
+accounting-bearing row it violates INV-1. It also buys nothing this record does not already
+obtain: the acquisition count falls because rows share a transaction, not because the caller
+stopped waiting.
 
 **Exempt accounting rows from batching to keep them durable.** Rejected, having been the previous
 draft's D3. Under ADR-103 the usage object rides every per-dispatch audit row, so the exemption

--- a/docs/adr/ADR-133-incidental-writes-off-the-request-hot-path.md
+++ b/docs/adr/ADR-133-incidental-writes-off-the-request-hot-path.md
@@ -104,7 +104,7 @@ payload) lives at the payload level, not the kind level.
 
 ## Decision
 
-### D1 — Batch audit appends durably, and the dispatch waits for its own batch to commit
+### D1 — Batch audit appends share one transaction, and the dispatch waits for its own batch to commit
 
 Audit appends are accumulated and written as a **single transaction**. The flush is a real
 committed (store-visible) transaction, not an in-memory retention with best-effort persistence.
@@ -273,8 +273,8 @@ follow-on inherits the multi-daemon case.
 
 An earlier draft used the classifier to decide **routing** — which rows may be batched. Under D1
 that question no longer exists: every row rides the same committed (store-visible) batch, and on
-the success path every dispatch waits for it, so no row is deferred past its own return and there is nothing to
-route away from. The one exception is D1's carve-out — a pure-observability row whose commit fails
+the success path every dispatch waits for it, so no row is deferred past its own return and there
+is nothing to route away from. The one exception is D1's carve-out — a pure-observability row whose commit fails
 persistently — and that is a failure outcome rather than a routing choice, which is exactly why the
 classifier's remaining job is failure semantics.
 
@@ -558,8 +558,8 @@ row is the accounting record.
 reading an earlier draft left open by not stating D1's waiting clause, and it is not a smaller
 version of this decision but a different one. A returned operation whose row is still in memory can
 lose a row the current implementation would have kept, since today's append is committed
-(store-visible) at dispatch whenever it succeeds. That violates INV-4 directly, and for an accounting-bearing row it violates
-INV-1. It also buys nothing this record does not already obtain: the acquisition count falls
+(store-visible) at dispatch whenever it succeeds. That violates INV-4 directly, and for an
+accounting-bearing row it violates INV-1. It also buys nothing this record does not already obtain: the acquisition count falls
 because rows share a transaction, not because the caller stopped waiting.
 
 **Exempt accounting rows from batching to keep them durable.** Rejected, having been the previous

--- a/docs/adr/ADR-133-incidental-writes-off-the-request-hot-path.md
+++ b/docs/adr/ADR-133-incidental-writes-off-the-request-hot-path.md
@@ -106,8 +106,8 @@ payload) lives at the payload level, not the kind level.
 
 ### D1 — Batch audit appends durably, and the dispatch waits for its own batch to commit
 
-Audit appends are accumulated and written as a **single transaction**. The flush is a real durable
-commit, not an in-memory retention with best-effort persistence.
+Audit appends are accumulated and written as a **single transaction**. The flush is a real
+committed (store-visible) transaction, not an in-memory retention with best-effort persistence.
 
 **A dispatch does not return before the batch carrying its audit row has committed.** This is the
 load-bearing clause of the whole record and an earlier draft left it unstated, which made the
@@ -120,8 +120,8 @@ fails it.
 
 For **pure observability rows** it binds on the success path only. The dispatch waits for the batch
 in the normal case — so observability rows are batched, share the acquisition reduction, and are
-durable at return whenever the commit succeeds — but a **persistent** commit failure releases the
-dispatch successfully and routes the failure to instrumentation.
+committed (store-visible) at return whenever the commit succeeds — but a **persistent** commit
+failure releases the dispatch successfully and routes the failure to instrumentation.
 
 That carve-out is not a durability regression, and the reason is worth stating because it is the
 only thing that makes the carve-out legitimate. The current implementation already swallows a failed
@@ -272,8 +272,8 @@ follow-on inherits the multi-daemon case.
 ### D2 — A classifier at the event-production seam decides commit-failure handling
 
 An earlier draft used the classifier to decide **routing** — which rows may be batched. Under D1
-that question no longer exists: every row rides the same durable batch, and on the success path
-every dispatch waits for it, so no row is deferred past its own return and there is nothing to
+that question no longer exists: every row rides the same committed (store-visible) batch, and on
+the success path every dispatch waits for it, so no row is deferred past its own return and there is nothing to
 route away from. The one exception is D1's carve-out — a pure-observability row whose commit fails
 persistently — and that is a failure outcome rather than a routing choice, which is exactly why the
 classifier's remaining job is failure semantics.
@@ -326,11 +326,13 @@ same shape as a check that works.
 The classifier is a total function over the classification input, implemented as an **exhaustive
 match with no wildcard arm**, so adding a variant fails to compile until its class is stated.
 
-### D3 — An accounting-bearing dispatch does not return before its accounting row is durable
+### D3 — An accounting-bearing dispatch does not return before its accounting row is committed (store-visible)
 
 A dispatch whose audit row carries an accounting payload (`resource.units` and the associated
-`cost_unit` / `cpu_us` fields per ADR-103) does not report success until that row is durably
-committed.
+`cost_unit` / `cpu_us` fields per ADR-103) does not report success until that row is committed
+(store-visible). Whether that commit also survives an OS crash or power loss is a distinct
+property, governed by the store's `synchronous` posture — see ADR-134, in particular its INV-3
+prerequisite before any consumer may depend on the row for a resource-usage outcome.
 
 Under D1 this is satisfied by the ordinary path rather than by an exemption from it: a dispatch
 already waits for its batch to commit, and for this class D1's waiting clause binds
@@ -386,8 +388,8 @@ dispatches into one and N statements into one transaction.
 is batched in the D1 sense — its statement shares a transaction with whatever else is committing —
 and it is never made asynchronous, optional, or deferred past its own return. The unread surface is
 load-bearing for other subsystems: the inbox monitor's stale check reads these flags, and a `comm.read` that
-returned before its flag was durable would make that check read stale state. This decision changes
-how many acquisitions a sweep costs, not what a read means.
+returned before its flag was committed (store-visible) would make that check read stale state. This
+decision changes how many acquisitions a sweep costs, not what a read means.
 
 ### D7 — Serve-ledger writes are batched per call
 
@@ -555,8 +557,8 @@ row is the accounting record.
 **Batch without waiting — let the dispatch return and flush behind it.** Rejected. It is the
 reading an earlier draft left open by not stating D1's waiting clause, and it is not a smaller
 version of this decision but a different one. A returned operation whose row is still in memory can
-lose a row the current implementation would have kept, since today's append is durable at dispatch
-whenever it succeeds. That violates INV-4 directly, and for an accounting-bearing row it violates
+lose a row the current implementation would have kept, since today's append is committed
+(store-visible) at dispatch whenever it succeeds. That violates INV-4 directly, and for an accounting-bearing row it violates
 INV-1. It also buys nothing this record does not already obtain: the acquisition count falls
 because rows share a transaction, not because the caller stopped waiting.
 

--- a/docs/adr/ADR-133-incidental-writes-off-the-request-hot-path.md
+++ b/docs/adr/ADR-133-incidental-writes-off-the-request-hot-path.md
@@ -139,9 +139,11 @@ upper bound, not as the normal trigger.
 
 The consequences of the waiting clause, all of which follow from it directly:
 
-- **Durability is unchanged at the moment of return.** A row that is committed today before the
-  dispatch returns is still committed before the dispatch returns. INV-4 holds by construction
-  rather than by assertion.
+- **Store visibility is unchanged at the moment of return.** A row that is committed today before
+  the dispatch returns is still committed before the dispatch returns. INV-4 holds by construction
+  rather than by assertion. "Committed" here is write-path store visibility under the store's
+  configured posture; whether a committed row survives an OS crash is the store's durability
+  posture, which is ADR-134's subject, not this clause's.
 - **Acquisitions stop scaling with request rate.** Under concurrency the acquisition rate is
   bounded by one per commit cycle instead of one per dispatch. This is the entire objective.
 - **Under contention this reduces latency rather than adding it.** Today each dispatch queues for
@@ -252,8 +254,17 @@ repeated work while believing it was preventing duplication.
 
 ### D1b — This is intra-process group commit, and the scope is load-bearing
 
-The batching in D1 is one daemon process committing, on **one connection**, rows produced by the
-many concurrent dispatches it is serving. Those dispatches are tasks inside one process, so
+**Lane note (ADR-134 D2a).** "One connection" describes the mechanism's scope, not a global
+count: once ADR-134's posture target lands, obligation-bearing rows commit on a second,
+pool-owned connection running a durable-sync posture, and this shared connection carries pure
+observability rows only. Lane selection rides D1's classification at enqueue, so a batch on
+either connection is single-lane by construction — a mixed batch on the shared writer would
+bypass ADR-134's durability guarantee while passing every invariant here, which is why the
+split is stated in both records. Each lane runs this same group-commit mechanism on its own
+connection.
+
+The batching in D1 is one daemon process committing, on **one connection per lane**, rows
+produced by the many concurrent dispatches it is serving. Those dispatches are tasks inside one process, so
 sharing a transaction between them is ordinary intra-process group commit and it is available.
 
 It is **not** group commit across client processes. SQLite has no cross-process commit

--- a/docs/adr/ADR-134-store-durability-posture.md
+++ b/docs/adr/ADR-134-store-durability-posture.md
@@ -70,15 +70,18 @@ windows. This record fixes the posture; ADR-091 fixes how long the exposure last
 This costs no throughput and closes the part of the exposure that was genuinely alarming, which was
 that nobody had decided it.
 
-### D2 — The target posture is a forced durable sync on the accounting path specifically
+### D2 — The target posture is a forced durable sync on the obligation lane, not store-wide `FULL`
 
 The intended end state is not store-wide `FULL`. It is `NORMAL` generally, with the accounting path
 forced to a durable sync through the same primitive the store already uses to select a posture:
 `PRAGMA synchronous=FULL`, scoped to the connection that commits the accounting-bearing row rather
 than applied to the pool as a whole. `synchronous` is a per-connection setting — SQLite does not
-require every connection open on a database to share one value — so a connection dedicated to
-accounting-bearing commits can pay the fsync on every commit it makes while every other connection
-(note, entity, vector, and non-accounting audit writes) keeps paying nothing beyond `NORMAL`.
+require every connection open on a database to share one value — so the connection dedicated to
+obligation-lane commits (D2a) can pay the fsync on every commit it makes while every other
+connection (note, entity, vector, and the observability lane's audit writes) keeps paying nothing
+beyond `NORMAL`. Accounting is the row class whose loss creates the exposure this record exists
+for; authorization and security-audit rows share the lane as co-tenants (D2a) and receive the same
+sync as a consequence of the lane topology, not as a separately analyzed requirement.
 
 That is the trade-off this target buys against store-wide `FULL`: the fsync cost lands only on the
 commits that need the guarantee, not on the store's full write volume. It is still a real,
@@ -103,11 +106,15 @@ see the gap. The split is therefore normative:
   exhaustive and wildcard-free, and an unclassified row resolves to the durable-sync
   connection — the stricter posture — for the same reason it already resolves to the stricter
   failure handling.
-- **The lane is the obligation class, not accounting alone.** This record's motivating row is
-  accounting, but the lane covers everything ADR-133 marks obligation-bearing (accounting,
-  authorization, security audit): those rows already share the never-return-without-commit
-  property, and splitting them across postures would force a third lane for no measured
-  benefit. D3's pricing therefore measures the whole obligation lane's commit volume.
+- **The lane is the obligation class, not accounting alone — but the requirement is
+  accounting's.** The lane covers everything ADR-133 marks obligation-bearing (accounting,
+  authorization, security audit) because that classification already exists at the enqueue seam
+  and splitting the class across postures would force a third lane for no measured benefit.
+  The durable-sync **requirement** this record establishes is analyzed for accounting only
+  (D1/D4); authorization and security-audit rows ride the lane as co-tenants and receive the
+  sync as a consequence, which is the stricter direction and costs nothing beyond what the
+  lane's commit volume already pays. D3's pricing therefore measures the lane's whole commit
+  volume — the cost the connection actually pays — never accounting's share alone.
 - **The durable-sync connection is a distinct pool-owned writer**, opened with
   `PRAGMA synchronous=FULL`, carrying no other traffic. Ownership sits with the pool, beside
   the shared writer, so the posture is set once at open. Toggling `synchronous` around
@@ -135,7 +142,10 @@ Two numbers are required before any posture change:
 
 1. Throughput delta between `NORMAL` and `FULL` on a **file-backed** store at a **stated
    concurrency level**.
-2. The cost of a forced durable sync on the accounting path alone.
+2. The commit-volume cost of the durable-sync lane — the whole obligation class (D2a), of
+   which accounting is the analyzed component — at a stated concurrency level. The lane's
+   connection pays per commit regardless of which class the batch carries, so a number
+   measured on accounting traffic alone under-prices the lane.
 
 Both must be measured on a file-backed store. An in-memory backend cannot exercise this at all, and
 a single-writer number does not transfer, because contention is the whole question.
@@ -221,12 +231,16 @@ record rather than inherited from this one.
    what** — process crash and OS crash/power loss stated separately, never merged into "a crash".
 2. A measured throughput comparison between the current setting and `FULL`, on a file-backed store,
    at a stated concurrency level, so D2 is chosen against numbers.
-3. A measured cost for the targeted accounting-path sync, so the two options are compared rather
-   than one being assumed cheaper.
-4. If the accounting path is treated differently from the general path, a test asserts the
-   accounting write is durable under the configured posture — with a fixture that configures it
-   wrongly on purpose and must make the test fail. A durability test that passes against a
-   misconfigured store is measuring nothing.
+3. A measured cost for the targeted obligation-lane sync (D2a's lane, priced at its whole
+   commit volume per D3), so the two options are compared rather than one being assumed
+   cheaper.
+4. If the obligation lane is treated differently from the general path, a test asserts an
+   obligation-lane write — the accounting row as the exemplar — is durable under the configured
+   posture, with a fixture that configures it wrongly on purpose and must make the test fail. A
+   durability test that passes against a misconfigured store is measuring nothing. The test
+   also asserts lane routing: an accounting-bearing row committed through the shared writer's
+   connection must make it fail, because a correct posture on an unused connection protects
+   nothing.
 5. A check that fails when a store holding INV-1 records has an unrecorded posture, so this class is
    caught by construction rather than by an ad-hoc configuration comparison.
 

--- a/docs/adr/ADR-134-store-durability-posture.md
+++ b/docs/adr/ADR-134-store-durability-posture.md
@@ -72,9 +72,18 @@ that nobody had decided it.
 
 ### D2 — The target posture is a forced durable sync on the accounting path specifically
 
-The intended end state is not store-wide `FULL`. It is `NORMAL` generally with a forced durable sync
-on the accounting path, because that is the only option that serves durability and throughput at the
-same time.
+The intended end state is not store-wide `FULL`. It is `NORMAL` generally, with the accounting path
+forced to a durable sync through the same primitive the store already uses to select a posture:
+`PRAGMA synchronous=FULL`, scoped to the connection that commits the accounting-bearing row rather
+than applied to the pool as a whole. `synchronous` is a per-connection setting — SQLite does not
+require every connection open on a database to share one value — so a connection dedicated to
+accounting-bearing commits can pay the fsync on every commit it makes while every other connection
+(note, entity, vector, and non-accounting audit writes) keeps paying nothing beyond `NORMAL`.
+
+That is the trade-off this target buys against store-wide `FULL`: the fsync cost lands only on the
+commits that need the guarantee, not on the store's full write volume. It is still a real,
+per-commit cost on that one connection, and it is that cost — not the store-wide one — that D3's
+second number prices.
 
 This is a target, not an implementation, and D3 gates it.
 
@@ -100,6 +109,13 @@ whichever the D3 numbers favour.
 
 The condition is tied to the arrival of accounted usage rather than to a release or a calendar date,
 because the exposure begins when a record starts determining a resource-usage outcome and not before.
+
+**Prerequisite.** This decision is conditioned on ADR-133 INV-1 holding in the implementation, not
+merely in the record. A durable sync protects a committed row against loss after commit; it says
+nothing about whether that row was produced exactly once before the sync ran. A sync applied to a
+row ADR-133's write path could still duplicate makes the duplicate exactly as durable as the
+original. D4 is not satisfied by adding the sync alone — ADR-133 INV-1 must hold first, or the sync
+is protecting the wrong property.
 
 ### D5 — The loss direction is recorded, because it is why the interim window is tolerable
 

--- a/docs/adr/ADR-134-store-durability-posture.md
+++ b/docs/adr/ADR-134-store-durability-posture.md
@@ -10,8 +10,8 @@
 ### What was found
 
 The store runs `synchronous=NORMAL` under WAL. It is set in the pool
-(`crates/khive-db/src/pool.rs:762`, `:787`, `:1102`) and again per store
-(`crates/khive-db/src/stores/note.rs:211`, `entity.rs:183`, `vectors.rs:250`). Every setting found
+(`crates/khive-db/src/pool.rs:956`, `:979`, `:1200`) and again per store
+(`crates/khive-db/src/stores/entity.rs:184`, `note.rs:253`, `vectors.rs:363`). Every setting found
 was `NORMAL`; no `FULL` was found, which is a search result and not a proof of absence.
 
 Under WAL, `synchronous=NORMAL` means a commit returns **without** fsyncing the WAL. The two
@@ -86,6 +86,48 @@ per-commit cost on that one connection, and it is that cost — not the store-wi
 second number prices.
 
 This is a target, not an implementation, and D3 gates it.
+
+### D2a — Routing split: which connection commits an obligation-bearing row
+
+D2's target is reachable only if the rows it covers never ride the shared writer's
+transactions. ADR-133 D1/D1b commits incidental rows in contention-formed batches on **one**
+pooled writer connection, and a batch there mixes obligation-bearing and observability rows.
+A mixed batch committed at `NORMAL` would satisfy every ADR-133 write-path invariant while
+silently bypassing this record's durability target, and no reader of either ADR alone would
+see the gap. The split is therefore normative:
+
+- **Classification decides the connection, at enqueue.** ADR-133 already classifies every row
+  (obligation-bearing vs pure observability, D1; unclassified resolves strictly, D5/INV-2).
+  That classification gains a second consequence: an obligation-bearing row routes to the
+  durable-sync connection, a pure observability row to the shared writer. The match stays
+  exhaustive and wildcard-free, and an unclassified row resolves to the durable-sync
+  connection — the stricter posture — for the same reason it already resolves to the stricter
+  failure handling.
+- **The lane is the obligation class, not accounting alone.** This record's motivating row is
+  accounting, but the lane covers everything ADR-133 marks obligation-bearing (accounting,
+  authorization, security audit): those rows already share the never-return-without-commit
+  property, and splitting them across postures would force a third lane for no measured
+  benefit. D3's pricing therefore measures the whole obligation lane's commit volume.
+- **The durable-sync connection is a distinct pool-owned writer**, opened with
+  `PRAGMA synchronous=FULL`, carrying no other traffic. Ownership sits with the pool, beside
+  the shared writer, so the posture is set once at open. Toggling `synchronous` around
+  individual commits on the shared connection is rejected: the setting is per-connection, a
+  toggle races with in-flight batches, and a missed reset silently re-prices every later
+  commit.
+- **Batching survives, per lane.** Obligation-bearing rows batch with obligation-bearing rows
+  under the same contention-formed rule (ADR-133 D1b's intra-process group commit, on this
+  connection); one fsync covers the whole batch commit, which is the guarantee — durable at
+  commit — not a dilution of it. Mixed batches are prevented by construction: the two lanes
+  have disjoint queues, and lane selection happens at classification, before enqueue, never
+  at commit time.
+- **The two writers serialise on SQLite's write lock.** A second writer connection is a real
+  contention cost inside one process, and it is part of what D3's measurement must price at a
+  stated concurrency level; the split is not exempt from the gate.
+
+This resolves the apparent conflict between ADR-133's one-connection description and this
+record's per-connection posture: ADR-133 D1b's mechanism is the shared lane, and the
+obligation lane is a second instance of the same mechanism on its own connection. ADR-133
+carries the matching cross-reference at D1b.
 
 ### D3 — The posture change is gated on measurement, not on argument
 


### PR DESCRIPTION
Closes #1416.

ADR-133 described a committed audit row as "durable" in six places. Under the store's `synchronous=NORMAL` posture a `COMMIT` returns without fsyncing the WAL, so what those sentences actually assert is store-visibility: the row survives a process crash, not necessarily an OS crash or power loss. ADR-134 D1 states the same fact plainly, and ADR-134 D4 records that the accounting path is not yet durably synced, so the two records contradicted each other on a property a reader could reasonably depend on.

The pragma setting was confirmed at this ref before relying on it: every `synchronous` update in the db crate sets `NORMAL`, and no `FULL` appears anywhere in it.

**ADR-133** — six occurrences changed to "committed (store-visible)", each one a sentence claiming a row *is durable* at the moment of commit or return. D3 additionally gains a sentence pointing the crash-durability question at ADR-134. Occurrences meaning "committed to the store at all", as against an in-memory buffer that commits nothing, are left alone: that usage is not a crash-safety claim. The D1 heading is aligned with the body it introduces.

**ADR-134** — D4 gains a normative prerequisite on ADR-133 INV-1. A durable sync protects a committed row against loss after commit; it says nothing about whether the row was produced exactly once beforehand, and a sync applied to a row the write path could still duplicate makes the duplicate exactly as durable as the original.

**ADR-134 D2/D3** — the fork is resolved by naming the primitive: `PRAGMA synchronous=FULL` scoped to the connection committing accounting-bearing rows, not applied pool-wide. `synchronous` is per-connection, so the fsync cost lands only on the commits that need the guarantee. D3's gate is untouched; this concretizes the target rather than shipping it.

Documentation only. No code changes.

Noted while reading, not fixed here: ADR-134's line-number citations for the pragma call sites have drifted from the current tree. The claim they support still holds.