### PR TITLE
fix: fail closed on invalid validation inputs

### DIFF
--- a/crates/khive-pack-knowledge/src/knowledge/search.rs
+++ b/crates/khive-pack-knowledge/src/knowledge/search.rs
@@ -1288,6 +1288,13 @@ impl KnowledgeHandlers {
         let limit = p.limit.unwrap_or(10).clamp(1, 100);
         let min_score = p.min_score.unwrap_or(0.0) as f32;
         let w = Weights::from_opts(&p);
+        if let Some(kind) = p.kind.as_deref() {
+            if !matches!(kind, "atom" | "domain") {
+                return Err(RuntimeError::InvalidInput(format!(
+                    "kind must be one of: atom, domain; got {kind:?}"
+                )));
+            }
+        }
         let type_filter = p.kind.as_deref();
         let do_decompose = p.decompose.unwrap_or(false);
         let decompose_threshold = p.decompose_threshold.unwrap_or(4);
@@ -1315,6 +1322,13 @@ impl KnowledgeHandlers {
             .as_deref()
             .map(str::trim)
             .filter(|s| !s.is_empty());
+        if let Some(status) = exclude_status_normalized {
+            if !matches!(status, "draft" | "reviewed" | "deprecated") {
+                return Err(RuntimeError::InvalidInput(format!(
+                    "exclude_status must be one of: draft, reviewed, deprecated; got {status:?}"
+                )));
+            }
+        }
 
         // Precedence (highest to lowest, matches ADR-047 §Status filtering):
         //   1. explicit status=  → no exclusion; SQL handles the allowlist

--- a/crates/khive-pack-knowledge/tests/integration.rs
+++ b/crates/khive-pack-knowledge/tests/integration.rs
@@ -1738,6 +1738,44 @@ async fn search_rejects_empty_query() {
 }
 
 #[tokio::test]
+async fn search_rejects_invalid_kind_value() {
+    let f = pack(rt());
+    let err = f
+        .dispatch(
+            "knowledge.search",
+            json!({ "query": "attention", "kind": "atoms", "rerank": false }),
+        )
+        .await
+        .expect_err("unknown kind must fail closed");
+    assert!(
+        err.to_string()
+            .contains("kind must be one of: atom, domain"),
+        "got: {err}"
+    );
+}
+
+#[tokio::test]
+async fn search_rejects_invalid_exclude_status_value() {
+    let f = pack(rt());
+    let err = f
+        .dispatch(
+            "knowledge.search",
+            json!({
+                "query": "attention",
+                "exclude_status": "deprectaed",
+                "rerank": false
+            }),
+        )
+        .await
+        .expect_err("unknown exclusion status must fail closed");
+    assert!(
+        err.to_string()
+            .contains("exclude_status must be one of: draft, reviewed, deprecated"),
+        "got: {err}"
+    );
+}
+
+#[tokio::test]
 async fn search_type_filter_returns_only_atoms() {
     let f = pack(rt());
     seed_search_corpus(&f).await;

--- a/crates/khive-pack-knowledge/tests/integration.rs
+++ b/crates/khive-pack-knowledge/tests/integration.rs
@@ -1748,6 +1748,10 @@ async fn search_rejects_invalid_kind_value() {
         .await
         .expect_err("unknown kind must fail closed");
     assert!(
+        matches!(err, RuntimeError::InvalidInput(_)),
+        "must be InvalidInput, got: {err:?}"
+    );
+    assert!(
         err.to_string()
             .contains("kind must be one of: atom, domain"),
         "got: {err}"
@@ -1768,6 +1772,10 @@ async fn search_rejects_invalid_exclude_status_value() {
         )
         .await
         .expect_err("unknown exclusion status must fail closed");
+    assert!(
+        matches!(err, RuntimeError::InvalidInput(_)),
+        "must be InvalidInput, got: {err:?}"
+    );
     assert!(
         err.to_string()
             .contains("exclude_status must be one of: draft, reviewed, deprecated"),

--- a/crates/kkernel/docs/design.md
+++ b/crates/kkernel/docs/design.md
@@ -69,8 +69,10 @@
 
 ### KG validation and init (ADR-034, ADR-035)
 
-- `kkernel kg validate` runs three built-in structural checks (duplicate UUIDs, sort
-  order, referential integrity) plus configurable rules from `rules.toml`.
+- `kkernel kg validate` runs seven unconditional structural checks: six error-severity
+  input/schema/identity/reference/taxonomy checks plus warning-severity sort order. A conditional
+  error-severity note-kind check also runs when `notes.ndjson` is present. Configurable rules from
+  `rules.toml` run afterward.
 - `kkernel kg init` creates `.khive/kg/` and writes `khive.toml` with defaults.
 - See `docs/kg-rules.md` for the rule TOML format.
 

--- a/crates/kkernel/docs/kg-rules.md
+++ b/crates/kkernel/docs/kg-rules.md
@@ -1,7 +1,7 @@
 # KG Rule Configuration
 
 **ADRs**: ADR-034 (KG validation), ADR-035 (kg init and vcs status)
-**Last reviewed**: 2026-06-06
+**Last reviewed**: 2026-08-06
 
 ## Overview
 
@@ -45,12 +45,17 @@ message = "Edges must not be self-loops"
 
 ## Built-in Checks
 
-The following structural checks run before configurable rules and cannot be disabled:
+Seven structural checks run unconditionally before configurable rules and cannot be disabled:
 
-- **Duplicate UUIDs** — each entity and edge ID must be unique within its NDJSON file.
-- **Referential integrity** — every edge `source_id` and `target_id` must reference a known entity.
-- **Valid entity kinds** — entity `kind` must be one of the 8 closed kinds (ADR-001).
-- **Valid edge relations** — edge `relation` must be one of the 15 closed relations (ADR-002).
+- **Required input files** (`error`) — `entities.ndjson` and `edges.ndjson` must be readable UTF-8; `notes.ndjson` is optional when absent but must also be readable UTF-8 when present.
+- **Schema compliance** (`error`) — every nonblank NDJSON line must be valid JSON and carry the substrate's required string fields.
+- **No duplicate UUIDs** (`error`) — each entity ID must be unique in `entities.ndjson`.
+- **Sort order** (`warning`) — entity IDs and edge `(source_id, target_id, relation)` tuples must be in canonical order.
+- **Referential integrity** (`error`) — every edge `source_id` and `target_id` must resolve to an entity, note, or edge record in the repository inputs.
+- **Valid entity kinds** (`error`) — entity `kind` must belong to the taxonomy merged from all registered packs.
+- **Valid edge relations** (`error`) — edge `relation` must belong to the compile-time `EdgeRelation` vocabulary (ADR-002).
+
+When `notes.ndjson` is present, an eighth **valid note kinds** check runs at `error` severity against the note-kind taxonomy merged from all registered packs. The optional file's absence does not add that rule to the report.
 
 ## CLI Options
 

--- a/crates/kkernel/src/kg/validate.rs
+++ b/crates/kkernel/src/kg/validate.rs
@@ -204,6 +204,7 @@ fn structural_checks(
     taxonomy: &KgTaxonomy,
 ) -> Vec<RuleResult> {
     let mut results = vec![
+        check_required_input_files(entities_path, edges_path, notes_path),
         check_schema_compliance(entities_path, edges_path, notes_path),
         check_no_duplicate_uuids(entities_path),
         check_sort_order(entities_path, edges_path),
@@ -215,6 +216,70 @@ fn structural_checks(
         results.push(check_valid_note_kinds(notes_path, &taxonomy.note_kinds));
     }
     results
+}
+
+fn check_required_input_files(
+    entities_path: &Path,
+    edges_path: &Path,
+    notes_path: &Path,
+) -> RuleResult {
+    let mut violations = Vec::new();
+    for path in [entities_path, edges_path] {
+        if let Err(error) = std::fs::read_to_string(path) {
+            violations.push(Violation {
+                entity_id: None,
+                entity_name: None,
+                entity_kind: None,
+                rule_id: "required-input-files".into(),
+                severity: "error",
+                message: format!("cannot read mandatory input {}: {error}", path.display()),
+                fixable: false,
+            });
+        }
+    }
+
+    // notes.ndjson is optional only when absent. Once a path is present it is
+    // part of the validation input and must be readable UTF-8 just like the
+    // mandatory files. Use symlink_metadata so a dangling symlink is treated
+    // as a present-but-unreadable input rather than as an absent optional file.
+    match std::fs::symlink_metadata(notes_path) {
+        Ok(_) => {
+            if let Err(error) = std::fs::read_to_string(notes_path) {
+                violations.push(Violation {
+                    entity_id: None,
+                    entity_name: None,
+                    entity_kind: None,
+                    rule_id: "required-input-files".into(),
+                    severity: "error",
+                    message: format!(
+                        "cannot read optional input {} when present: {error}",
+                        notes_path.display()
+                    ),
+                    fixable: false,
+                });
+            }
+        }
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+        Err(error) => violations.push(Violation {
+            entity_id: None,
+            entity_name: None,
+            entity_kind: None,
+            rule_id: "required-input-files".into(),
+            severity: "error",
+            message: format!(
+                "cannot inspect optional input {}: {error}",
+                notes_path.display()
+            ),
+            fixable: false,
+        }),
+    }
+
+    RuleResult {
+        id: "required-input-files".into(),
+        severity: "error",
+        passed: violations.is_empty(),
+        violations,
+    }
 }
 
 fn schema_violation(file: &str, line_no: usize, message: impl std::fmt::Display) -> Violation {
@@ -2116,6 +2181,48 @@ mod tests {
             "well-formed KG with absent notes.ndjson must pass: {:?}",
             result.violations
         );
+    }
+
+    #[test]
+    fn required_input_files_reject_missing_and_unreadable_paths() {
+        let tmp = TempDir::new().unwrap();
+        let kg_dir = make_kg_dir(&tmp);
+        let entities_path = kg_dir.join("entities.ndjson");
+        let edges_path = kg_dir.join("edges.ndjson");
+        std::fs::create_dir(&entities_path).unwrap();
+
+        let result =
+            check_required_input_files(&entities_path, &edges_path, &kg_dir.join("notes.ndjson"));
+
+        assert!(!result.passed);
+        assert_eq!(result.violations.len(), 2);
+        assert!(result
+            .violations
+            .iter()
+            .any(|violation| violation.message.contains("entities.ndjson")));
+        assert!(result
+            .violations
+            .iter()
+            .any(|violation| violation.message.contains("edges.ndjson")));
+    }
+
+    #[test]
+    fn required_input_files_rejects_unreadable_optional_notes_when_present() {
+        let tmp = TempDir::new().unwrap();
+        let kg_dir = make_kg_dir(&tmp);
+        let entities_path = kg_dir.join("entities.ndjson");
+        let edges_path = kg_dir.join("edges.ndjson");
+        let notes_path = kg_dir.join("notes.ndjson");
+        std::fs::write(&entities_path, "").unwrap();
+        std::fs::write(&edges_path, "").unwrap();
+        std::fs::write(&notes_path, [0xff, 0xfe]).unwrap();
+
+        let result = check_required_input_files(&entities_path, &edges_path, &notes_path);
+
+        assert!(!result.passed);
+        assert_eq!(result.violations.len(), 1);
+        assert!(result.violations[0].message.contains("notes.ndjson"));
+        assert!(result.violations[0].message.contains("when present"));
     }
 
     #[test]

--- a/crates/kkernel/tests/kg_validate_builtin_rule_classes.rs
+++ b/crates/kkernel/tests/kg_validate_builtin_rule_classes.rs
@@ -213,3 +213,94 @@ fn kg_validate_no_rules_flag_skips_all_builtin_rule_classes() {
         "structural checks must still fail under --no-rules"
     );
 }
+
+#[test]
+fn kg_validate_fails_when_a_mandatory_input_file_is_missing() {
+    let tmp = TempDir::new().expect("create temp dir");
+    let kg_dir = tmp.path().join(".khive/kg");
+    std::fs::create_dir_all(&kg_dir).expect("create .khive/kg");
+    std::fs::write(kg_dir.join("edges.ndjson"), "").expect("write edges.ndjson");
+
+    let output = Command::new(kkernel_bin())
+        .args([
+            "kg",
+            "validate",
+            "--repo",
+            tmp.path().to_str().expect("utf8 tmp path"),
+            "--format",
+            "json",
+            "--no-rules",
+        ])
+        .output()
+        .expect("run kkernel kg validate");
+
+    assert!(
+        !output.status.success(),
+        "missing entities.ndjson must fail validation; stdout={}, stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let report: serde_json::Value = serde_json::from_slice(&output.stdout)
+        .expect("failed validation still returns the JSON report");
+    let required = report["rules"]
+        .as_array()
+        .and_then(|rules| {
+            rules
+                .iter()
+                .find(|rule| rule["id"] == "required-input-files")
+        })
+        .expect("required-input-files rule");
+    assert_eq!(required["passed"], false);
+    assert!(required["violations"][0]["message"]
+        .as_str()
+        .is_some_and(|message| message.contains("entities.ndjson")));
+}
+
+#[test]
+fn kg_validate_fails_when_present_optional_notes_are_not_utf8() {
+    let tmp = TempDir::new().expect("create temp dir");
+    let kg_dir = tmp.path().join(".khive/kg");
+    std::fs::create_dir_all(&kg_dir).expect("create .khive/kg");
+    std::fs::write(kg_dir.join("entities.ndjson"), "").expect("write entities.ndjson");
+    std::fs::write(kg_dir.join("edges.ndjson"), "").expect("write edges.ndjson");
+    std::fs::write(kg_dir.join("notes.ndjson"), [0xff, 0xfe])
+        .expect("write invalid UTF-8 notes.ndjson");
+
+    let output = Command::new(kkernel_bin())
+        .args([
+            "kg",
+            "validate",
+            "--repo",
+            tmp.path().to_str().expect("utf8 tmp path"),
+            "--format",
+            "json",
+            "--no-rules",
+        ])
+        .output()
+        .expect("run kkernel kg validate");
+
+    assert!(
+        !output.status.success(),
+        "unreadable present notes.ndjson must fail validation; stdout={}, stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let report: serde_json::Value = serde_json::from_slice(&output.stdout)
+        .expect("failed validation still returns the JSON report");
+    let required = report["rules"]
+        .as_array()
+        .and_then(|rules| {
+            rules
+                .iter()
+                .find(|rule| rule["id"] == "required-input-files")
+        })
+        .expect("required-input-files rule");
+    assert_eq!(required["passed"], false);
+    assert!(required["violations"]
+        .as_array()
+        .is_some_and(|violations| violations.iter().any(|violation| {
+            violation["message"]
+                .as_str()
+                .is_some_and(|message| message.contains("notes.ndjson"))
+        })));
+}

--- a/docs/adr/ADR-034-kg-validation-pipelines.md
+++ b/docs/adr/ADR-034-kg-validation-pipelines.md
@@ -4,12 +4,22 @@
 **Date**: 2026-05-23
 **Authors**: khive maintainers
 
+## Amendment (2026-08-06): validation input readability
+
+`entities.ndjson` and `edges.ndjson` are mandatory validator inputs. The unconditional
+`required-input-files` structural rule fails when either path is absent, unreadable, or not
+valid UTF-8. `notes.ndjson` remains optional when absent, but a present notes path must also be
+readable UTF-8. Even where a downstream rule skips an unreadable file, the unconditional
+structural rule ensures that an input read failure cannot produce a passing aggregate report.
+
 ## Context
 
-[ADR-020](ADR-020-git-native-kg-implementation.md) introduced `kkernel kg validate` with
-six built-in checks that guard the structural invariants git-native versioning depends on:
-schema compliance, referential integrity, no duplicate UUIDs, sort order, remote resolution,
-and cross-repo reference format. These checks are unconditional and apply to every KG.
+[ADR-020](ADR-020-git-native-kg-implementation.md) introduced `kkernel kg validate` to guard the
+structural invariants git-native versioning depends on. The current pass has seven unconditional
+checks: `required-input-files`, `schema-compliance`, `no-duplicate-uuids`,
+`referential-integrity`, `valid-entity-kinds`, and `valid-edge-relations` at error severity, plus
+`sort-order` at warning severity. The error-severity `valid-note-kinds` check is conditional on
+`notes.ndjson` being present.
 
 Projects building domain-specific KGs need validation beyond these structural invariants.
 A biology team requires all concept entities to carry a `taxa_rank` property. A research
@@ -44,9 +54,10 @@ This ADR documents the shipped `kkernel kg validate` validation surface:
 
 ### What changes and what does not
 
-- ADR-020 `khive kg validate` built-in structural checks: **unchanged**. This ADR adds
-  an optional TOML RulePass that runs after the structural pass when
-  `.khive/kg/rules.toml` exists and `--no-rules` is not set.
+- ADR-020 `khive kg validate` built-in structural checks: **amended** by the unconditional
+  `required-input-files` readability rule above. This ADR also adds an optional TOML RulePass
+  that runs after the structural pass when `.khive/kg/rules.toml` exists and `--no-rules` is not
+  set.
 - ADR-023 pack standard: **extended by the shipped Rust validator API** (`PackRuntime::validation_rules`,
   `VerbRegistry::all_validation_rules`). What remains deferred is CLI runner integration —
   `kkernel kg validate` does not yet call these methods against live corpus data.
@@ -310,8 +321,9 @@ The `fix` callback receives the same `ValidationContext` and the violations emit
 
 The validation pipeline runs in a defined sequence:
 
-1. **ADR-020 structural checks** (schema compliance, referential integrity, duplicate
-   UUIDs, sort order, remote resolution). Run first; results always included.
+1. **ADR-020 structural checks**: seven unconditional checks run first, with six at error severity
+   and `sort-order` at warning severity. `valid-note-kinds` additionally runs at error severity
+   when `notes.ndjson` is present. Results for every applicable check are always included.
 2. **Configurable TOML rules** from `.khive/kg/rules.toml`, when the file exists and
    `--no-rules` is not set. Rules run in file order.
 3. **Pack-provided validation rules** (§9): the Rust API is shipped; CLI runner integration
@@ -497,8 +509,9 @@ into a single non-zero exit code obscures which action is needed.
 
 ### Neutral
 
-- The ADR-020 structural pass is unchanged. Existing `kkernel kg validate` invocations
-  continue to work and gain the new rules transparently.
+- The ADR-020 structural pass gains the `required-input-files` rule. Existing clean
+  `kkernel kg validate` invocations remain compatible; inputs that are absent or unreadable now
+  fail closed.
 - The JSON output format (`--format json`) extends the ADR-020 exit-code contract: 0 for
   clean, 1 for violations, 2 for rule-file parse or unsupported-format errors. The text format is a superset
   of the ADR-020 single-line-per-check output.

--- a/docs/adr/ADR-047-knowledge-pack.md
+++ b/docs/adr/ADR-047-knowledge-pack.md
@@ -1,8 +1,16 @@
 # ADR-047: Knowledge Pack
 
-**Status**: accepted (amended 2026-06-07, 2026-06-10, 2026-06-10b, 2026-08-01)
+**Status**: accepted (amended 2026-06-07, 2026-06-10, 2026-06-10b, 2026-08-01, 2026-08-06)
 **Date**: 2026-05-25
 **Authors**: khive maintainers
+
+## Amendment (2026-08-06): fail-closed search filter values
+
+`knowledge.search` accepts only `atom` or `domain` for `kind`/`type`. Its atom-status
+vocabulary is closed to `draft`, `reviewed`, and `deprecated`, so a non-blank
+`exclude_status` outside that set is invalid. Both cases return `InvalidInput`; an unknown
+kind never falls through to atom search, and a misspelled exclusion never replaces the safe
+default status filter.
 
 ## Amendment (2026-08-01): exact namespace support for `knowledge.compose`
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -206,16 +206,19 @@ kkernel kg validate --repo . [--strict] [--format text|json|github] [--fix] [--r
 ```
 
 Bails immediately (not just a warning) if `.khive/kg/` doesn't exist: "run `kkernel kg init`
-first" (`kg/validate.rs:76-81`). Runs seven built-in structural checks, always at `error`
-severity, that `--no-rules` cannot silence: `schema-compliance` (every NDJSON line must parse and
-carry required fields, malformed lines are reported, not skipped, "so corrupt NDJSON cannot pass
-`kg validate` only to fail later in `kkernel sync`/`kg import`"), `no-duplicate-uuids`,
-`sort-order`, `referential-integrity` (every edge `source_id`/`target_id` must resolve, note this
-is the NDJSON wire field name, distinct from the `source`/`target` Rust struct fields used by the
-export/import archive types), `valid-entity-kinds` (against the merged pack taxonomy),
-`valid-edge-relations` (against the closed `EdgeRelation` enum, not the pack registry, edge
-relations are compile-time closed per ADR-002), and `valid-note-kinds` (only if `notes.ndjson`
-exists).
+first" (`kg/validate.rs:76-81`). Runs seven unconditional built-in structural checks: six at
+`error` severity and `sort-order` at `warning` severity. An eighth error-severity check,
+`valid-note-kinds`, runs only when `notes.ndjson` exists. `--no-rules` cannot silence any
+applicable structural check: `schema-compliance` (every NDJSON line must parse and carry required
+fields, malformed lines are reported, not skipped, "so corrupt NDJSON cannot pass `kg validate`
+only to fail later in `kkernel sync`/`kg import`"), `no-duplicate-uuids`, `sort-order`,
+`referential-integrity` (every edge `source_id`/`target_id` must resolve, note this is the NDJSON
+wire field name, distinct from the `source`/`target` Rust struct fields used by the export/import
+archive types), `valid-entity-kinds` (against the merged pack taxonomy), `valid-edge-relations`
+(against the closed `EdgeRelation` enum, not the pack registry, edge relations are compile-time
+closed per ADR-002), and conditional `valid-note-kinds`. `required-input-files` runs first and
+fails closed when mandatory `entities.ndjson` or `edges.ndjson` cannot be read. `notes.ndjson` is
+optional when absent, but if present it must also be readable UTF-8.
 
 On top of those, an optional `rules.toml` (default `.khive/kg/rules.toml`, override with
 `--rules`, skip entirely with `--no-rules`) adds configurable `warning`/`info`/`error` rules;


### PR DESCRIPTION
> AI-assisted contribution: Codex prepared this change and PR description.

## Summary

- reject unsupported `knowledge.search` `kind`/`type` and nonblank `exclude_status` values instead of silently widening or changing the query
- add an unconditional `required-input-files` KG validation rule so missing or unreadable mandatory inputs fail closed
- keep `notes.ndjson` optional when absent, but reject a present notes input that cannot be inspected or read as UTF-8
- align ADR-034, ADR-047, and operator documentation with the tested validation contracts

## Behavior

`knowledge.search` now returns `InvalidInput` unless `kind` is `atom` or `domain`, and unless a supplied nonblank `exclude_status` is one of `draft`, `reviewed`, or `deprecated`. Existing explicit-status precedence and blank-exclusion behavior remain unchanged.

`kkernel kg validate` now evaluates `required-input-files` before its other structural rules. The rule remains active under `--no-rules` and emits ordinary structured error violations for unreadable `entities.ndjson` or `edges.ndjson`. An absent `notes.ndjson` is still valid; once present, it must be readable UTF-8 rather than being silently treated as an empty corpus.

## Validation

- `cargo test --manifest-path crates/Cargo.toml --workspace`
- `cargo check --manifest-path crates/Cargo.toml --workspace`
- `cargo clippy --manifest-path crates/Cargo.toml --workspace --all-targets -- -D warnings`
- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `RUSTDOCFLAGS=-Dwarnings cargo doc --manifest-path crates/Cargo.toml --workspace --no-deps`
- focused invalid-value, mandatory-input, and present-invalid-notes regressions
- independent final review of `f780f42bc1603fe357220e3726de4f1d81905d95`: READY, no findings

Closes #1747
Closes #1748
