### PR TITLE
fix: keep MCP alive when diagnostics fail

### DIFF
--- a/crates/khive-mcp/src/daemon.rs
+++ b/crates/khive-mcp/src/daemon.rs
@@ -812,16 +812,30 @@ fn spawn_daemon_with_exe_and_config(
     // installation is atomically replacing `kkernel`. Retry only that precise
     // error, with a short finite budget; every other spawn failure remains
     // immediate and unchanged.
-    const EXECUTABLE_BUSY_BACKOFF_MS: [u64; 3] = [5, 20, 50];
-    for delay_ms in EXECUTABLE_BUSY_BACKOFF_MS {
-        match cmd.spawn() {
+    spawn_retrying_executable_busy(&EXECUTABLE_BUSY_BACKOFF_MS, || cmd.spawn())
+}
+
+/// Short finite backoff budget for a transient `ExecutableFileBusy` spawn
+/// failure — see the call site in [`spawn_daemon_with_exe_and_config`].
+const EXECUTABLE_BUSY_BACKOFF_MS: [u64; 3] = [5, 20, 50];
+
+/// Retry `spawn` up to `delays_ms.len()` extra times, sleeping the
+/// corresponding delay between attempts, but only when the failure is
+/// `ErrorKind::ExecutableFileBusy`. Any other error — or the final attempt
+/// after the backoff budget is exhausted — is returned immediately.
+fn spawn_retrying_executable_busy<T>(
+    delays_ms: &[u64],
+    mut spawn: impl FnMut() -> std::io::Result<T>,
+) -> std::io::Result<T> {
+    for delay_ms in delays_ms {
+        match spawn() {
             Err(error) if error.kind() == std::io::ErrorKind::ExecutableFileBusy => {
-                std::thread::sleep(std::time::Duration::from_millis(delay_ms));
+                std::thread::sleep(std::time::Duration::from_millis(*delay_ms));
             }
             outcome => return outcome,
         }
     }
-    cmd.spawn()
+    spawn()
 }
 
 /// Return `true` if `args` (the full `ps -o args=` output for a process)
@@ -3164,6 +3178,55 @@ mod tests {
         release.join().expect("fixture writer release thread");
         let status = child.wait().expect("wait for executable fixture");
         assert!(status.success(), "fixture must exit 0: {status}");
+    }
+
+    /// The helper behind the retry above must actually retry the exact
+    /// number of times ETXTBSY is injected, then succeed on the next
+    /// attempt — a fixture that merely holds a file open (as the test above
+    /// does) never proves an initial ETXTBSY was observed or counts
+    /// attempts, so it passes even against a no-retry implementation on a
+    /// filesystem that permits executing a writable-open file.
+    #[test]
+    fn spawn_retrying_executable_busy_retries_exact_count_then_succeeds() {
+        let attempts = std::sync::atomic::AtomicUsize::new(0);
+        let result: std::io::Result<()> =
+            spawn_retrying_executable_busy(&EXECUTABLE_BUSY_BACKOFF_MS, || {
+                let n = attempts.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                if n < 2 {
+                    Err(std::io::Error::from(std::io::ErrorKind::ExecutableFileBusy))
+                } else {
+                    Ok(())
+                }
+            });
+
+        assert!(result.is_ok(), "must succeed once ETXTBSY stops recurring");
+        assert_eq!(
+            attempts.load(std::sync::atomic::Ordering::SeqCst),
+            3,
+            "must retry exactly until success: 2 injected ETXTBSY failures + 1 success"
+        );
+    }
+
+    /// A non-ETXTBSY error must never be retried, even though the backoff
+    /// budget has room left.
+    #[test]
+    fn spawn_retrying_executable_busy_does_not_retry_other_errors() {
+        let attempts = std::sync::atomic::AtomicUsize::new(0);
+        let result: std::io::Result<()> =
+            spawn_retrying_executable_busy(&EXECUTABLE_BUSY_BACKOFF_MS, || {
+                attempts.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                Err(std::io::Error::from(std::io::ErrorKind::PermissionDenied))
+            });
+
+        assert!(
+            result.is_err(),
+            "a non-ETXTBSY error must surface, not be swallowed"
+        );
+        assert_eq!(
+            attempts.load(std::sync::atomic::Ordering::SeqCst),
+            1,
+            "a non-ETXTBSY error must not retry"
+        );
     }
 
     #[derive(Clone, Default)]

--- a/crates/khive-mcp/src/daemon.rs
+++ b/crates/khive-mcp/src/daemon.rs
@@ -806,6 +806,21 @@ fn spawn_daemon_with_exe_and_config(
     // `mcp --daemon` (version skew) exits immediately with a clap parse
     // error; without this handle that failure was invisible to everything
     // except `khived.log`.
+    // A just-written executable can transiently fail `execve(2)` with
+    // ETXTBSY on instrumented/contended filesystems. This is especially easy
+    // to hit in the argv-forwarding tests, but it can also occur while a real
+    // installation is atomically replacing `kkernel`. Retry only that precise
+    // error, with a short finite budget; every other spawn failure remains
+    // immediate and unchanged.
+    const EXECUTABLE_BUSY_BACKOFF_MS: [u64; 3] = [5, 20, 50];
+    for delay_ms in EXECUTABLE_BUSY_BACKOFF_MS {
+        match cmd.spawn() {
+            Err(error) if error.kind() == std::io::ErrorKind::ExecutableFileBusy => {
+                std::thread::sleep(std::time::Duration::from_millis(delay_ms));
+            }
+            outcome => return outcome,
+        }
+    }
     cmd.spawn()
 }
 
@@ -3125,6 +3140,30 @@ mod tests {
             "mcp --daemon --db /tmp/main.db",
             "the concrete override handed to the spawn seam must reach the daemon command line"
         );
+    }
+
+    /// A writer that momentarily still owns the fixture inode must not turn
+    /// the argv-forwarding family into an ETXTBSY flake. The production spawn
+    /// seam retries only ExecutableFileBusy, so holding this file open for
+    /// writing forces the exact failure class reported by coverage CI.
+    #[test]
+    fn spawn_daemon_retries_a_transient_executable_file_busy_error() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let exe = daemon_script_fixture(&dir, "temporarily-busy.sh", "#!/bin/sh\nexit 0\n");
+        let writer = std::fs::OpenOptions::new()
+            .write(true)
+            .open(&exe)
+            .expect("hold executable fixture open for writing");
+        let release = std::thread::spawn(move || {
+            std::thread::sleep(std::time::Duration::from_millis(15));
+            drop(writer);
+        });
+
+        let mut child = spawn_daemon_with_exe_and_config(&exe, None, None)
+            .expect("transient ETXTBSY must be retried");
+        release.join().expect("fixture writer release thread");
+        let status = child.wait().expect("wait for executable fixture");
+        assert!(status.success(), "fixture must exit 0: {status}");
     }
 
     #[derive(Clone, Default)]

--- a/crates/kkernel/docs/usage.md
+++ b/crates/kkernel/docs/usage.md
@@ -7,7 +7,8 @@ library crate consumed by `kkernel`.
 
 All subcommands emit JSON on stdout by default; pass `--human` where supported for a
 readable table. `--log <level>` (env `KHIVE_LOG`, default `warn`) is global and goes
-to stderr — stdout stays clean for JSON / MCP traffic.
+to stderr — stdout stays clean for JSON / MCP traffic. Stderr is diagnostic-only and
+best-effort; disconnecting its consumer does not terminate the stdin/stdout MCP transport.
 
 `kkernel -V` reports the package version; `kkernel --version` also reports the full source
 revision (including `-dirty` when applicable) and UTC build time.

--- a/crates/kkernel/src/cli.rs
+++ b/crates/kkernel/src/cli.rs
@@ -650,6 +650,29 @@ async fn cmd_db_check(args: DbCheckArgs) -> Result<()> {
     Ok(())
 }
 
+/// Writer adapter for process-lifetime diagnostics.
+///
+/// `tracing-subscriber` reports a failed event write with `eprintln!`. If the
+/// subscriber itself writes to a closed stderr pipe, that fallback panics and
+/// takes the stdio MCP transport down with it. Logging is auxiliary to the
+/// stdin/stdout protocol, so make every stderr write best-effort before it
+/// reaches the subscriber's error-reporting path.
+struct BestEffortWriter<W>(W);
+
+impl<W: std::io::Write> std::io::Write for BestEffortWriter<W> {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        match self.0.write(buf) {
+            Ok(written) => Ok(written),
+            Err(_) => Ok(buf.len()),
+        }
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        let _ = self.0.flush();
+        Ok(())
+    }
+}
+
 fn init_tracing(level: &str) {
     // Tracing goes to stderr — stdout is reserved for JSON / MCP results.
     //
@@ -664,7 +687,7 @@ fn init_tracing(level: &str) {
     // silently filtered for every operator who never sets KHIVE_LOG.
     let filter = format!("{level},khive.boot=info,lattice_inference=error");
     tracing_subscriber::fmt()
-        .with_writer(std::io::stderr)
+        .with_writer(|| BestEffortWriter(std::io::stderr()))
         .with_env_filter(filter)
         .with_ansi(false)
         .init();

--- a/crates/kkernel/tests/mcp_closed_stderr.rs
+++ b/crates/kkernel/tests/mcp_closed_stderr.rs
@@ -1,0 +1,175 @@
+//! Regression coverage for issue #1716: stderr is a diagnostic side channel,
+//! not a liveness dependency of the stdin/stdout MCP transport.
+
+use std::io::{BufRead, BufReader, Write};
+use std::process::{Child, Command, Stdio};
+use std::sync::mpsc;
+use std::time::Duration;
+
+fn kkernel_binary() -> &'static str {
+    env!("CARGO_BIN_EXE_kkernel")
+}
+
+fn kill_and_wait(child: &mut Child) {
+    let _ = child.kill();
+    let _ = child.wait();
+}
+
+#[test]
+fn stdio_mcp_survives_when_the_stderr_consumer_disconnects() {
+    let home = tempfile::tempdir().expect("isolated HOME");
+    let mut child = Command::new(kkernel_binary())
+        .arg("mcp")
+        .arg("--db")
+        .arg(":memory:")
+        .arg("--no-embed")
+        .arg("--pack")
+        .arg("kg")
+        .env("HOME", home.path())
+        // rmcp emits an initialization event at INFO after the request below.
+        // Keeping that event enabled makes the regression deterministic even
+        // if every startup diagnostic was already written before we close the
+        // pipe.
+        .env("KHIVE_LOG", "trace")
+        .env_remove("KHIVE_CONFIG")
+        .env_remove("KHIVE_DB")
+        .env_remove("KHIVE_PACKS")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn kkernel mcp");
+
+    let stderr = child.stderr.take().expect("piped stderr");
+    let (first_log_tx, first_log_rx) = mpsc::sync_channel(1);
+    let stderr_reader = std::thread::spawn(move || {
+        let mut reader = BufReader::new(stderr);
+        let mut logs = String::new();
+        let result = loop {
+            let mut line = String::new();
+            match reader.read_line(&mut line) {
+                Ok(0) => break Ok(()),
+                Ok(_) => {
+                    let saw_database_disclosure = line.contains("database:");
+                    logs.push_str(&line);
+                    if saw_database_disclosure {
+                        break Ok(());
+                    }
+                }
+                Err(error) => break Err(error),
+            }
+        };
+        // Returning drops the only consumer of the child's stderr pipe.
+        first_log_tx.send((result, logs)).ok();
+    });
+    let (first_log_result, first_log) = match first_log_rx.recv_timeout(Duration::from_secs(10)) {
+        Ok(result) => result,
+        Err(error) => {
+            kill_and_wait(&mut child);
+            panic!("timed out waiting for the startup diagnostic: {error}");
+        }
+    };
+    first_log_result.expect("read startup diagnostic");
+    assert!(
+        first_log.contains("database:"),
+        "expected the khive.boot database disclosure, got {first_log:?}"
+    );
+    stderr_reader.join().expect("stderr reader thread");
+
+    let stdout = child.stdout.take().expect("piped stdout");
+    let (response_tx, response_rx) = mpsc::sync_channel(2);
+    let stdout_reader = std::thread::spawn(move || {
+        let mut reader = BufReader::new(stdout);
+        for _ in 0..2 {
+            let mut line = String::new();
+            let result = reader.read_line(&mut line);
+            let reached_eof = matches!(result, Ok(0));
+            if response_tx.send((result, line)).is_err() || reached_eof {
+                break;
+            }
+        }
+    });
+
+    let initialize = serde_json::json!({
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "initialize",
+        "params": {
+            "protocolVersion": "2025-06-18",
+            "capabilities": {},
+            "clientInfo": {"name": "closed-stderr-regression", "version": "1"}
+        }
+    });
+    let stdin = child.stdin.as_mut().expect("piped stdin");
+    writeln!(stdin, "{initialize}").expect("send initialize request");
+    stdin.flush().expect("flush initialize request");
+
+    let (response_result, response) = match response_rx.recv_timeout(Duration::from_secs(10)) {
+        Ok(result) => result,
+        Err(error) => {
+            kill_and_wait(&mut child);
+            stdout_reader
+                .join()
+                .expect("stdout reader thread after kill");
+            panic!("timed out waiting for initialize response: {error}");
+        }
+    };
+    response_result.expect("read initialize response");
+
+    let response: serde_json::Value = serde_json::from_str(&response).unwrap_or_else(|error| {
+        let status = child.try_wait().expect("inspect child status");
+        panic!("invalid initialize response {response:?} ({error}); child status: {status:?}")
+    });
+    assert_eq!(response["id"], 1);
+    assert!(
+        response.get("result").is_some(),
+        "initialize must succeed after stderr disconnect: {response}"
+    );
+
+    // rmcp emits its "Service initialized as server" tracing event after it
+    // has put the initialize response on stdout. A reverted writer can panic
+    // after that first response is already buffered, so synchronize beyond the
+    // event with another protocol round-trip instead of checking process state
+    // in the race window.
+    let initialized = serde_json::json!({
+        "jsonrpc": "2.0",
+        "method": "notifications/initialized"
+    });
+    let ping = serde_json::json!({"jsonrpc": "2.0", "id": 2, "method": "ping"});
+    let stdin = child.stdin.as_mut().expect("piped stdin");
+    writeln!(stdin, "{initialized}").expect("send initialized notification");
+    writeln!(stdin, "{ping}").expect("send post-handshake ping");
+    stdin.flush().expect("flush post-handshake requests");
+
+    let (ping_result, ping_response) = match response_rx.recv_timeout(Duration::from_secs(10)) {
+        Ok(result) => result,
+        Err(error) => {
+            kill_and_wait(&mut child);
+            stdout_reader
+                .join()
+                .expect("stdout reader thread after kill");
+            panic!("timed out waiting for post-handshake ping response: {error}");
+        }
+    };
+    ping_result.expect("read post-handshake ping response");
+    let ping_response: serde_json::Value =
+        serde_json::from_str(&ping_response).unwrap_or_else(|error| {
+            let status = child.try_wait().expect("inspect child status");
+            panic!(
+                "invalid post-handshake response {ping_response:?} ({error}); child status: {status:?}"
+            )
+        });
+    assert_eq!(ping_response["id"], 2);
+    assert!(
+        ping_response.get("result").is_some(),
+        "post-handshake ping must succeed after stderr disconnect: {ping_response}"
+    );
+    assert_eq!(
+        child.try_wait().expect("inspect MCP process"),
+        None,
+        "MCP server must remain alive after its stderr consumer disconnects"
+    );
+
+    kill_and_wait(&mut child);
+    stdout_reader.join().expect("stdout reader thread");
+}

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -63,7 +63,8 @@ effect of listing backends.
   writes an archive file rather than emitting a JSON summary line; and the pending-events drain
   prints its summary as pretty-printed (multi-line) JSON, not a single line
   (`pending_events.rs:731-745`). Logs (tracing) always go to stderr, so piping stdout never mixes
-  log noise into the JSON (`main.rs:449-461`).
+  log noise into the JSON (`kkernel/src/cli.rs:init_tracing`). Stderr logging is best-effort: a
+  failed or closed stderr consumer does not terminate the stdin/stdout MCP serving loop.
 - **Log level**: `--log <level>` or `KHIVE_LOG` (global arg, default `warn`,
   `main.rs:41-43`). The `lattice_inference` tokenizer-size warning is filtered to `error`
   regardless of the requested level (`main.rs:456`).


### PR DESCRIPTION
> AI-assisted contribution: Codex prepared this change and PR description.

## Summary

- make the global tracing stderr writer swallow diagnostic write failures before tracing-subscriber reaches its panicking fallback path
- prove the stdin/stdout MCP server survives a closed stderr consumer through initialization and a post-handshake ping
- retry only transient `ExecutableFileBusy` daemon spawn failures with a bounded four-attempt, 75 ms budget
- document stderr as a best-effort diagnostic channel rather than an MCP liveness dependency

## Behavior

The default tracing formatter now writes through a small adapter that preserves successful writes but treats a failed write or flush as consumed. This prevents tracing-subscriber from trying to report its own writer error with `eprintln!`, which panics when the same stderr pipe has no reader. Stdout and the JSON-RPC protocol are unchanged.

Daemon spawning retains immediate behavior for every error except `ExecutableFileBusy`. That precise failure receives three short backoffs before one final attempt; all other spawn failures return on the first attempt. The regression holds a fixture executable open for writing to exercise the same ETXTBSY class observed in coverage CI.

## Validation

- `cargo test --manifest-path crates/Cargo.toml --workspace`
- `cargo check --manifest-path crates/Cargo.toml --workspace`
- `cargo clippy --manifest-path crates/Cargo.toml --workspace --all-targets -- -D warnings`
- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `RUSTDOCFLAGS=-Dwarnings cargo doc --manifest-path crates/Cargo.toml --workspace --no-deps`
- focused closed-stderr MCP, transient-ETXTBSY, and concrete-DB-argv regressions
- independent static review: READY, zero remaining findings

Closes #1716
Closes #1736
