### PR TITLE
build: verify local artifact before install

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -363,8 +363,11 @@ make fmt-check  # verify without modifying
 # Build release binary
 make build      # cargo build --workspace --release
 
+# Build + verify Cargo's exact reported local artifact without installing or stopping the daemon
+make verify-local-artifact  # receipt-bound daemonless verbs() probe; requires all requested packs and >=90 verbs
+
 # Build + install locally (ALWAYS use this after code changes)
-make local      # build release khive-mcp → kill stale → codesign → install to ~/.cargo/bin/
+make local      # depends on verify-local-artifact, then codesigns + installs kkernel → kills stale daemon
                 # then /mcp in Claude Code to reconnect
 
 # Publish to crates.io

--- a/Makefile
+++ b/Makefile
@@ -112,7 +112,21 @@ local: verify-local-artifact
 	  rm -f "$$DEST.new"; \
 	  exit 1; \
 	fi; \
-	codesign -s - -f "$$DEST.new" 2>/dev/null || true; \
+	if ! codesign -s - -f "$$DEST.new"; then \
+	  echo "==> ERROR: codesign failed on $$DEST.new — refusing to install"; \
+	  rm -f "$$DEST.new"; \
+	  exit 1; \
+	fi; \
+	echo "==> Re-verifying the SIGNED artifact (codesign rewrites the file, so the pre-sign verification does not cover the bytes that get installed)..."; \
+	if ! python3 scripts/verify_local_artifact.py \
+	  --artifact "$$DEST.new" \
+	  --packs "$(FULL_PACKS)" \
+	  --min-verbs "$(LOCAL_VERB_FLOOR)" >/dev/null; then \
+	  echo "==> ERROR: signed artifact failed verification — refusing to install"; \
+	  rm -f "$$DEST.new"; \
+	  exit 1; \
+	fi; \
+	SIGNED_SHA256=$$({ shasum -a 256 "$$DEST.new" 2>/dev/null || sha256sum "$$DEST.new"; } | awk '{print $$1}'); \
 	STAGED_HASH=$$(md5 -q "$$DEST.new"); \
 	echo "==> Atomically moving into place..."; \
 	mv "$$DEST.new" "$$DEST"; \
@@ -131,6 +145,11 @@ local: verify-local-artifact
 	DEST_MTIME=$$(stat -f '%Sm' "$$DEST"); \
 	if [ "$$STAGED_HASH" != "$$DEST_HASH" ]; then \
 	  echo "==> ERROR: post-mv hash drift! staged=$$STAGED_HASH dest=$$DEST_HASH"; \
+	  exit 1; \
+	fi; \
+	DEST_SHA256=$$({ shasum -a 256 "$$DEST" 2>/dev/null || sha256sum "$$DEST"; } | awk '{print $$1}'); \
+	if [ "$$SIGNED_SHA256" != "$$DEST_SHA256" ]; then \
+	  echo "==> ERROR: installed bytes differ from the verified signed artifact! signed=$$SIGNED_SHA256 installed=$$DEST_SHA256"; \
 	  exit 1; \
 	fi; \
 	echo "==> Installed: $$DEST ($$DEST_HASH, $$DEST_SIZE bytes, $$DEST_MTIME, $$VERIFIED_VERBS verified verbs)"; \

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,14 @@
 # The full pack set the installed daemon must serve. `make local` verifies the
-# INSTALLED binary registers the whole set by positive artifact (a verbs()
-# count from the binary itself) — a build that silently drops a pack's
-# inventory registration fails here instead of shipping.
+# freshly built artifact before installation by running verbs() against that
+# exact binary. The floor is the current 90-verb production surface: additions
+# pass without a Makefile change, while any loss remains fail-closed.
 FULL_PACKS := kg,gtd,memory,comm,schedule,session,workspace,blob,git,knowledge,brain,code,formal
+LOCAL_VERB_FLOOR := 90
+CARGO ?= cargo
+LOCAL_BUILD_RECEIPT := crates/target/khive-local-build.json
+LOCAL_VERIFY_STAMP := $(LOCAL_BUILD_RECEIPT).verified
 
-.PHONY: check clippy test contract-test fmt fmt-check build clean ci docs-check publish publish-dry local check-fwd bench-1m bench-1m-ci hold-time-gate
+.PHONY: check clippy test contract-test fmt fmt-check build build-local verify-local-artifact clean ci docs-check publish publish-dry local check-fwd bench-1m bench-1m-ci hold-time-gate
 
 check:
 	cd crates && cargo check --workspace
@@ -28,6 +32,22 @@ fmt-check:
 
 build:
 	cd crates && cargo build --workspace --release
+
+build-local:
+	@echo "==> Building kkernel (release, channel-email, channel-telegram)..."
+	@python3 scripts/build_local_artifact.py \
+		--cargo "$(CARGO)" \
+		--manifest-path crates/Cargo.toml \
+		--package kkernel \
+		--features channel-email,channel-telegram \
+		--receipt "$(LOCAL_BUILD_RECEIPT)"
+
+verify-local-artifact: build-local
+	@python3 scripts/verify_local_artifact.py \
+		--build-receipt "$(LOCAL_BUILD_RECEIPT)" \
+		--packs "$(FULL_PACKS)" \
+		--min-verbs "$(LOCAL_VERB_FLOOR)" \
+		--stamp "$(LOCAL_VERIFY_STAMP)"
 
 clean:
 	cd crates && cargo clean
@@ -63,17 +83,35 @@ hold-time-gate:
 	@echo "==> ADR-135 F4 release gate: per-shape writer hold-time regression coverage..."
 	cd crates && cargo test -p khive-pack-comm --test hold_time_regression -- --nocapture
 
-local:
-	@echo "==> Building kkernel (release, channel-email, channel-telegram)..."
-	@cargo build --release -p kkernel --features channel-email,channel-telegram --manifest-path crates/Cargo.toml
-	@SRC=$${CARGO_TARGET_DIR:-crates/target}/release/kkernel; \
+local: verify-local-artifact
+	@if ! VERIFIED_ASSIGNMENTS=$$(python3 scripts/verify_local_artifact.py \
+	  --build-receipt "$(LOCAL_BUILD_RECEIPT)" \
+	  --inspect-stamp "$(LOCAL_VERIFY_STAMP)" \
+	  --min-verbs "$(LOCAL_VERB_FLOOR)"); then \
+	  exit 1; \
+	fi; \
+	if ! eval "$$VERIFIED_ASSIGNMENTS"; then \
+	  echo "==> ERROR: could not load verified-artifact fields"; \
+	  exit 1; \
+	fi; \
 	DEST=$$HOME/.cargo/bin/kkernel; \
 	if [ ! -f "$$SRC" ]; then echo "==> ERROR: build artifact $$SRC missing"; exit 1; fi; \
+	SRC_SHA256=$$({ shasum -a 256 "$$SRC" 2>/dev/null || sha256sum "$$SRC"; } | awk '{print $$1}'); \
+	if [ "$$VERIFIED_SHA256" != "$$SRC_SHA256" ]; then \
+	  echo "==> ERROR: build artifact changed after verification! verified=$$VERIFIED_SHA256 current=$$SRC_SHA256"; \
+	  exit 1; \
+	fi; \
 	SRC_HASH=$$(md5 -q "$$SRC"); \
 	SRC_SIZE=$$(stat -f '%z' "$$SRC"); \
-	echo "==> Source:  $$SRC ($$SRC_HASH, $$SRC_SIZE bytes)"; \
+	echo "==> Source:  $$SRC ($$SRC_HASH, $$SRC_SIZE bytes, $$VERIFIED_VERBS verified verbs)"; \
 	echo "==> Staging + codesigning $$DEST.new..."; \
 	cp "$$SRC" "$$DEST.new"; \
+	COPIED_SHA256=$$({ shasum -a 256 "$$DEST.new" 2>/dev/null || sha256sum "$$DEST.new"; } | awk '{print $$1}'); \
+	if [ "$$VERIFIED_SHA256" != "$$COPIED_SHA256" ]; then \
+	  echo "==> ERROR: staged bytes differ from the verified build artifact! verified=$$VERIFIED_SHA256 staged=$$COPIED_SHA256"; \
+	  rm -f "$$DEST.new"; \
+	  exit 1; \
+	fi; \
 	codesign -s - -f "$$DEST.new" 2>/dev/null || true; \
 	STAGED_HASH=$$(md5 -q "$$DEST.new"); \
 	echo "==> Atomically moving into place..."; \
@@ -95,19 +133,6 @@ local:
 	  echo "==> ERROR: post-mv hash drift! staged=$$STAGED_HASH dest=$$DEST_HASH"; \
 	  exit 1; \
 	fi; \
-	echo "==> Verifying installed binary loads the full pack set..."; \
-	PROBE_OUT=$$(mktemp); \
-	if KHIVE_NO_DAEMON=1 KHIVE_PACKS="$(FULL_PACKS)" \
-	  perl -e 'alarm 120; exec @ARGV or die' -- "$$DEST" exec --output-format json 'verbs()' > "$$PROBE_OUT" 2>/dev/null; then \
-	  VERBS=$$(python3 -c 'import json,sys; r=json.load(sys.stdin); e=r["results"][0]; v=e["result"]["verbs"]; sys.exit(1) if (e.get("ok") is not True or not isinstance(v, list)) else print(len(v))' < "$$PROBE_OUT" 2>/dev/null || echo 0); \
-	else \
-	  VERBS=0; \
-	fi; \
-	rm -f "$$PROBE_OUT"; \
-	if [ "$$VERBS" -lt 80 ]; then \
-	  echo "==> ERROR: installed binary registered $$VERBS verbs (expected >= 80) — full pack set did not load"; \
-	  exit 1; \
-	fi; \
-	echo "==> Installed: $$DEST ($$DEST_HASH, $$DEST_SIZE bytes, $$DEST_MTIME, $$VERBS verbs)"; \
+	echo "==> Installed: $$DEST ($$DEST_HASH, $$DEST_SIZE bytes, $$DEST_MTIME, $$VERIFIED_VERBS verified verbs)"; \
 	"$$DEST" --version
 	@echo "==> Done. Run /mcp in Claude Code to reconnect."

--- a/docs/adr/ADR-026-rust-binary-packaging.md
+++ b/docs/adr/ADR-026-rust-binary-packaging.md
@@ -321,3 +321,54 @@ Convergence is complete: each release builds one binary per platform (`kkernel`)
 Rationale: the kkernel unification absorbed `khive-mcp` as a library crate, reducing the
 shipped artifact to a single binary per platform. Build pipelines and subpackage manifests
 should reference `kkernel` only.
+
+## Amendment 2 (2026-08-06): pre-install local artifact verification
+
+Issue #1745 identified a fail-open ordering defect in the source-build install path. The
+`make local` recipe previously installed `kkernel`, replaced the running daemon, and only
+then ran `verbs()` against the installed binary. A successful Rust build does not prove that
+inventory-linked packs registered in the resulting runtime, so a reduced verb surface was
+first detected after the previous known-good binary and daemon were already unavailable.
+
+The local install contract is now build, verify, then install:
+
+1. `build-local` builds `kkernel` with the same `channel-email,channel-telegram` feature set
+   used by the developer install. Cargo runs with JSON artifact messages; the build gate
+   accepts exactly one `kkernel` binary `compiler-artifact` event and atomically records its
+   canonical executable path, SHA-256, and a fresh build identifier in
+   `crates/target/khive-local-build.json`. Cargo therefore remains authoritative when
+   configuration changes the target directory or adds a target-triple subdirectory; the gate
+   never guesses `${target-dir}/release/kkernel`.
+2. `verify-local-artifact` depends on `build-local`, validates that receipt, and executes its
+   exact artifact. The probe runs `verbs()` with daemon and embeddings disabled, an in-memory
+   database, an empty
+   explicit config, an isolated home/current directory, and the Makefile-owned full pack
+   selection. It never reads the installed `kkernel`, touches `~/.cargo/bin`, or stops the
+   daemon. A configured cross-target artifact that cannot execute on the developer host fails
+   closed at this probe rather than falling back to a stale host artifact. The MCP client waits
+   for and validates a successful `initialize` response before sending the initialized
+   notification and `tools/call`; one absolute deadline covers initialization, the verb-catalog
+   call, and process shutdown.
+3. The probe is fail-closed. A missing or non-executable artifact, launch failure, timeout,
+   nonzero exit, malformed JSON or response shape, inconsistent `total` / catalog /
+   `pack_counts`, missing requested pack (including a zero-verb pack), or a total below the
+   **90-verb floor** fails verification. The floor is deliberately a minimum rather than a
+   version string or equality assertion: it witnesses runtime registration, permits additive
+   verbs, and makes a surface reduction an explicit reviewed contract change.
+4. Success records the build identifier, canonical artifact path, SHA-256, and observed verb
+   count in an atomic, canonical JSON stamp beside the build receipt. The count is a bounded
+   JSON integer, never a shell integer expression. `local` asks the verifier to revalidate the
+   receipt/stamp pair and current artifact, then re-hashes the source before staging and verifies
+   the unsigned staging copy has the same SHA-256. Only then may codesigning, installation, or
+   daemon interruption occur. A changed artifact, mismatched receipt, or stale/noncanonical/
+   malformed stamp fails before those side effects.
+
+The existing install-copy integrity check remains: the MD5 of the codesigned staging file
+must equal the installed destination after the atomic move. This amendment adds a runtime
+provenance gate before that copy check; it does not replace it.
+
+A zero-downtime daemon cut-over remains outside this amendment. `make local` still replaces
+the installed binary and stops the old daemon after verification so bridges can respawn the
+new artifact under ADR-049. The ordering guarantee is narrower: no install or daemon
+interruption is reachable unless the exact artifact being staged has passed the pack/verb
+surface probe.

--- a/docs/adr/ADR-026-rust-binary-packaging.md
+++ b/docs/adr/ADR-026-rust-binary-packaging.md
@@ -366,6 +366,7 @@ The local install contract is now build, verify, then install:
 The existing install-copy integrity check remains: the MD5 of the codesigned staging file
 must equal the installed destination after the atomic move. This amendment adds a runtime
 provenance gate before that copy check; it does not replace it.
+Post-`mv` hash drift exits nonzero but is not rolled back because the previous binary has already been replaced.
 
 A zero-downtime daemon cut-over remains outside this amendment. `make local` still replaces
 the installed binary and stops the old daemon after verification so bridges can respawn the

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -44,6 +44,26 @@ cargo build --release -p kkernel
 # Binary at target/release/kkernel (relative to crates/)
 ```
 
+For the guarded developer install, run from the repository root:
+
+```bash
+make verify-local-artifact  # build + verify only
+# or
+make local                  # build + verify + install
+```
+
+`verify-local-artifact` builds the same feature set as `local`, takes the exact
+binary path from Cargo's `compiler-artifact` event (including configured target
+directories or target triples), then runs a daemonless `verbs()` probe against
+that receipt-bound artifact with an in-memory database and isolated
+configuration. It fails on probe errors, malformed output, a missing requested
+pack, or fewer than the documented 90-verb floor, without touching
+`~/.cargo/bin` or stopping the running daemon.
+If Cargo reports a cross-target binary that the host cannot execute, the probe
+fails instead of falling back to an older host artifact.
+`local` depends on that gate and rechecks the verified SHA-256 before staging;
+installation and daemon replacement are unreachable unless the artifact passes.
+
 ## Connect to your MCP client
 
 ### Claude Code

--- a/scripts/build_local_artifact.py
+++ b/scripts/build_local_artifact.py
@@ -1,0 +1,286 @@
+#!/usr/bin/env python3
+"""Build kkernel and record the exact executable path reported by Cargo."""
+
+from __future__ import annotations
+
+import argparse
+from dataclasses import dataclass
+import hashlib
+import json
+import os
+from pathlib import Path
+import re
+import secrets
+import subprocess
+import sys
+import tempfile
+
+
+RECEIPT_SCHEMA = 1
+HEX_32 = re.compile(r"[0-9a-f]{32}\Z")
+HEX_64 = re.compile(r"[0-9a-f]{64}\Z")
+
+
+class BuildReceiptError(RuntimeError):
+    pass
+
+
+@dataclass(frozen=True)
+class BuildReceipt:
+    build_id: str
+    artifact: Path
+    artifact_hash: str
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def canonical_json(payload: object) -> str:
+    return json.dumps(payload, sort_keys=True, separators=(",", ":")) + "\n"
+
+
+def atomic_write(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, temporary_name = tempfile.mkstemp(
+        prefix=f".{path.name}.", dir=path.parent, text=True
+    )
+    temporary_path = Path(temporary_name)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            handle.write(content)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(temporary_path, path)
+    finally:
+        temporary_path.unlink(missing_ok=True)
+
+
+def _canonical_absolute_path(raw: object, field: str) -> Path:
+    if not isinstance(raw, str) or not raw or "\x00" in raw:
+        raise BuildReceiptError(f"build receipt has an invalid {field}")
+    path = Path(raw)
+    if not path.is_absolute():
+        raise BuildReceiptError(f"build receipt {field} must be absolute")
+    canonical = path.resolve()
+    if str(canonical) != raw:
+        raise BuildReceiptError(f"build receipt {field} is not canonical")
+    return canonical
+
+
+def load_build_receipt(path: Path, *, verify_artifact: bool = True) -> BuildReceipt:
+    try:
+        raw = path.read_text(encoding="utf-8")
+        payload = json.loads(raw)
+    except (OSError, UnicodeError, json.JSONDecodeError) as error:
+        raise BuildReceiptError(f"cannot read build receipt {path}: {error}") from error
+    if not isinstance(payload, dict):
+        raise BuildReceiptError("build receipt must be a JSON object")
+    expected_keys = {"artifact", "build_id", "schema", "sha256"}
+    if set(payload) != expected_keys:
+        raise BuildReceiptError("build receipt has an invalid field set")
+    if raw != canonical_json(payload):
+        raise BuildReceiptError("build receipt is not canonical JSON")
+    schema = payload.get("schema")
+    if (
+        not isinstance(schema, int)
+        or isinstance(schema, bool)
+        or schema != RECEIPT_SCHEMA
+    ):
+        raise BuildReceiptError("build receipt has an unsupported schema")
+
+    build_id = payload.get("build_id")
+    if not isinstance(build_id, str) or HEX_32.fullmatch(build_id) is None:
+        raise BuildReceiptError("build receipt has an invalid build_id")
+    artifact_hash = payload.get("sha256")
+    if not isinstance(artifact_hash, str) or HEX_64.fullmatch(artifact_hash) is None:
+        raise BuildReceiptError("build receipt has an invalid SHA-256")
+    artifact = _canonical_absolute_path(payload.get("artifact"), "artifact path")
+
+    if verify_artifact:
+        if not artifact.is_file():
+            raise BuildReceiptError(f"build artifact is missing: {artifact}")
+        if not os.access(artifact, os.X_OK):
+            raise BuildReceiptError(f"build artifact is not executable: {artifact}")
+        current_hash = sha256_file(artifact)
+        if current_hash != artifact_hash:
+            raise BuildReceiptError(
+                "build artifact no longer matches the Cargo build receipt: "
+                f"recorded={artifact_hash} current={current_hash}"
+            )
+    return BuildReceipt(build_id, artifact, artifact_hash)
+
+
+def write_build_receipt(path: Path, artifact: Path) -> BuildReceipt:
+    canonical_artifact = artifact.resolve()
+    if not canonical_artifact.is_file():
+        raise BuildReceiptError(
+            f"Cargo-reported build artifact is missing: {canonical_artifact}"
+        )
+    if not os.access(canonical_artifact, os.X_OK):
+        raise BuildReceiptError(
+            f"Cargo-reported build artifact is not executable: {canonical_artifact}"
+        )
+    receipt = BuildReceipt(
+        build_id=secrets.token_hex(16),
+        artifact=canonical_artifact,
+        artifact_hash=sha256_file(canonical_artifact),
+    )
+    payload = {
+        "artifact": str(receipt.artifact),
+        "build_id": receipt.build_id,
+        "schema": RECEIPT_SCHEMA,
+        "sha256": receipt.artifact_hash,
+    }
+    atomic_write(path, canonical_json(payload))
+    return receipt
+
+
+def cargo_build(
+    *,
+    cargo: str,
+    manifest_path: Path,
+    package: str,
+    features: str,
+) -> Path:
+    command = [
+        cargo,
+        "build",
+        "--release",
+        "-p",
+        package,
+        "--features",
+        features,
+        "--manifest-path",
+        str(manifest_path.resolve()),
+        "--message-format=json-render-diagnostics",
+    ]
+    try:
+        process = subprocess.Popen(
+            command,
+            stdout=subprocess.PIPE,
+            text=True,
+            encoding="utf-8",
+        )
+    except OSError as error:
+        raise BuildReceiptError(f"could not launch Cargo: {error}") from error
+    if process.stdout is None:
+        process.kill()
+        process.wait()
+        raise BuildReceiptError("could not capture Cargo artifact messages")
+
+    artifacts: list[Path] = []
+    parse_error: BuildReceiptError | None = None
+    build_finished = False
+    for line_number, line in enumerate(process.stdout, start=1):
+        if not line.strip():
+            continue
+        try:
+            message = json.loads(line)
+        except json.JSONDecodeError as error:
+            if parse_error is None:
+                parse_error = BuildReceiptError(
+                    f"Cargo emitted invalid JSON on line {line_number}: {error}"
+                )
+            continue
+        if not isinstance(message, dict):
+            if parse_error is None:
+                parse_error = BuildReceiptError(
+                    f"Cargo emitted a non-object message on line {line_number}"
+                )
+            continue
+
+        reason = message.get("reason")
+        if reason == "compiler-message":
+            diagnostic = message.get("message")
+            if isinstance(diagnostic, dict):
+                rendered = diagnostic.get("rendered")
+                if isinstance(rendered, str) and rendered:
+                    print(rendered, file=sys.stderr, end="" if rendered.endswith("\n") else "\n")
+        elif reason == "compiler-artifact":
+            target = message.get("target")
+            executable = message.get("executable")
+            if (
+                isinstance(target, dict)
+                and target.get("name") == package
+                and isinstance(target.get("kind"), list)
+                and "bin" in target["kind"]
+                and isinstance(executable, str)
+                and executable
+            ):
+                artifacts.append(Path(executable).resolve())
+        elif reason == "build-finished":
+            build_finished = message.get("success") is True
+
+    return_code = process.wait()
+    if return_code != 0:
+        raise BuildReceiptError(f"Cargo build exited with status {return_code}")
+    if parse_error is not None:
+        raise parse_error
+    if not build_finished:
+        raise BuildReceiptError("Cargo did not report a successful build-finished event")
+    if len(artifacts) != 1:
+        rendered = ", ".join(str(path) for path in artifacts) or "none"
+        raise BuildReceiptError(
+            "Cargo did not report exactly one executable compiler-artifact event for "
+            f"binary target {package!r}: {rendered}"
+        )
+    return artifacts[0]
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Build kkernel and record Cargo's exact executable artifact."
+    )
+    parser.add_argument("--cargo", default="cargo")
+    parser.add_argument("--manifest-path", type=Path, default=Path("crates/Cargo.toml"))
+    parser.add_argument("--package", default="kkernel")
+    parser.add_argument("--features", default="channel-email,channel-telegram")
+    parser.add_argument("--receipt", required=True, type=Path)
+    parser.add_argument(
+        "--print-artifact",
+        action="store_true",
+        help="validate an existing receipt and print its artifact path",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    receipt_path = args.receipt.expanduser().resolve()
+    try:
+        if args.print_artifact:
+            receipt = load_build_receipt(receipt_path)
+            print(receipt.artifact)
+            return 0
+
+        receipt_path.parent.mkdir(parents=True, exist_ok=True)
+        receipt_path.unlink(missing_ok=True)
+        receipt_path.with_name(f"{receipt_path.name}.verified").unlink(missing_ok=True)
+        if not args.cargo:
+            raise BuildReceiptError("--cargo must not be empty")
+        if not args.package:
+            raise BuildReceiptError("--package must not be empty")
+        artifact = cargo_build(
+            cargo=args.cargo,
+            manifest_path=args.manifest_path,
+            package=args.package,
+            features=args.features,
+        )
+        receipt = write_build_receipt(receipt_path, artifact)
+        print(
+            f"Cargo artifact: {receipt.artifact} "
+            f"(sha256={receipt.artifact_hash}, build_id={receipt.build_id})"
+        )
+        return 0
+    except (BuildReceiptError, OSError, ValueError) as error:
+        print(f"build-local: ERROR: {error}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -36,6 +36,9 @@ phase_lint() {
 
     echo "=== ADR Reference Lint Self-Test ==="
     sh "$SCRIPT_DIR/lint-adr-refs.sh" --self-test
+
+    echo "=== Local Build Artifact Verification Tests ==="
+    python3 "$SCRIPT_DIR/tests/test_verify_local_artifact.py"
 }
 
 phase_no_stubs_scan() {

--- a/scripts/tests/test_verify_local_artifact.py
+++ b/scripts/tests/test_verify_local_artifact.py
@@ -916,7 +916,7 @@ class MakefileGateContractTests(unittest.TestCase):
             root = fixture / "workspace"
             root.mkdir()
             (root / "Makefile").write_text(recipe_makefile, encoding="utf-8")
-            if fixture_shape == "git-dir":
+            if fixture_shape in ("git-dir", "real-make"):
                 subprocess.run(
                     ["git", "init", "-q", str(root)],
                     check=True,
@@ -988,7 +988,7 @@ class MakefileGateContractTests(unittest.TestCase):
                 textwrap.dedent(
                     f"""\
                     #!/bin/sh
-                    printf 'called\n' >> "$CODESIGN_RECORD"
+                    printf 'called\\n' >> "$CODESIGN_RECORD"
                     [ {codesign_exit} -ne 0 ] && exit {codesign_exit}
                     for a in "$@"; do target="$a"; done
                     printf '\\n# signed\\n' >> "$target"
@@ -996,6 +996,9 @@ class MakefileGateContractTests(unittest.TestCase):
                     """
                 ),
                 encoding="utf-8",
+            )
+            (root / "scripts" / "build_local_artifact.py").write_text(
+                "raise SystemExit(0)\n", encoding="utf-8"
             )
             for noop in ("pkill", "pgrep"):
                 (stub_bin / noop).write_text("#!/bin/sh\nexit 1\n", encoding="utf-8")
@@ -1008,25 +1011,41 @@ class MakefileGateContractTests(unittest.TestCase):
             env["PYTHONDONTWRITEBYTECODE"] = "1"
             env["CODESIGN_RECORD"] = str(codesign_record)
             env["SIGNED_PROBE_RECORD"] = str(signed_probe_record)
+            env.pop("MAKEFLAGS", None)
+            env.pop("MAKELEVEL", None)
 
             rc = 0
             chunks: list[str] = []
             signed_bytes: bytes | None = None
-            for cmd in commands:
+            if fixture_shape == "real-make":
                 proc = subprocess.run(
-                    ["sh", "-c", cmd],
+                    ["make", "-f", "Makefile", "local"],
                     cwd=root,
                     env=env,
                     capture_output=True,
                     text=True,
                 )
                 chunks.append(
-                    f"$ {cmd[:120]}...\n[rc={proc.returncode}]\n"
+                    f"$ make -f Makefile local\n[rc={proc.returncode}]\n"
                     f"{proc.stdout}{proc.stderr}"
                 )
-                rc = proc.returncode
-                if rc != 0:
-                    break
+                rc = 0 if proc.returncode == 0 else 1
+            else:
+                for cmd in commands:
+                    proc = subprocess.run(
+                        ["sh", "-c", cmd],
+                        cwd=root,
+                        env=env,
+                        capture_output=True,
+                        text=True,
+                    )
+                    chunks.append(
+                        f"$ {cmd[:120]}...\n[rc={proc.returncode}]\n"
+                        f"{proc.stdout}{proc.stderr}"
+                    )
+                    rc = proc.returncode
+                    if rc != 0:
+                        break
 
             staged = dest_dir / "kkernel.new"
             installed_bytes = dest.read_bytes() if dest.exists() else None
@@ -1068,6 +1087,24 @@ class MakefileGateContractTests(unittest.TestCase):
             run.signed_probe_invocations,
         )
 
+    def _condition_signed_probe(self, condition: str) -> str:
+        start = self.makefile.index(
+            '\techo "==> Re-verifying the SIGNED artifact'
+        )
+        end = self.makefile.index("\tSIGNED_SHA256=", start)
+        probe = self.makefile[start:end]
+        nested_probe = "".join(
+            f"\t  {line[1:]}" if line.startswith("\t") else line
+            for line in probe.splitlines(keepends=True)
+        )
+        return (
+            self.makefile[:start]
+            + f"\tif {condition}; then \\\n"
+            + nested_probe
+            + "\tfi; \\\n"
+            + self.makefile[end:]
+        )
+
     def _run_local_recipe_variants(
         self,
         *,
@@ -1084,18 +1121,51 @@ class MakefileGateContractTests(unittest.TestCase):
             )
             for shape in ("bare", "git-dir", "git-file")
         }
+        runs["real-make"] = self._run_local_recipe(
+            signed_probe_exit=signed_probe_exit,
+            codesign_exit=codesign_exit,
+            makefile_text=makefile_text,
+            fixture_shape="real-make",
+        )
         bare_behavior = self._verification_behavior(runs["bare"])
-        for shape in ("git-dir", "git-file"):
-            with self.subTest(fixture_shape=shape, check="environment-parity"):
-                self.assertEqual(
-                    self._verification_behavior(runs[shape]),
-                    bare_behavior,
-                    "the local recipe's verification behavior changed with the "
-                    f"checkout environment ({shape})\n"
-                    f"bare run:\n{runs['bare'].output}\n"
-                    f"{shape} run:\n{runs[shape].output}",
-                )
+        for shape in ("git-dir", "git-file", "real-make"):
+            self.assertEqual(
+                self._verification_behavior(runs[shape]),
+                bare_behavior,
+                "the local recipe's verification behavior changed with the "
+                f"checkout environment ({shape})\n"
+                f"bare run:\n{runs['bare'].output}\n"
+                f"{shape} run:\n{runs[shape].output}",
+            )
         return runs
+
+    def test_parity_rejects_git_conditioned_signed_probe(self) -> None:
+        forged = self._condition_signed_probe("[ ! -e .git ]")
+
+        with self.assertRaisesRegex(
+            AssertionError,
+            r"verification behavior changed with the checkout environment \(git-dir\)",
+        ):
+            self._run_local_recipe_variants(
+                signed_probe_exit=1, makefile_text=forged
+            )
+
+    def test_parity_rejects_makelevel_conditioned_signed_probe(self) -> None:
+        forged = self._condition_signed_probe('[ -z "$$MAKELEVEL" ]')
+
+        with self.assertRaisesRegex(
+            AssertionError,
+            r"verification behavior changed with the checkout environment \(real-make\)",
+        ):
+            self._run_local_recipe_variants(
+                signed_probe_exit=1, makefile_text=forged
+            )
+
+    def test_extracted_recipe_ignores_harness_fingerprints(self) -> None:
+        recipe = "\n".join(self._extract_local_recipe(self.makefile))
+
+        self.assertNotIn("CODESIGN_RECORD", recipe)
+        self.assertNotIn("SIGNED_PROBE_RECORD", recipe)
 
     def test_local_dependency_chain_is_build_then_verify_then_install(self) -> None:
         self.assertIn("verify-local-artifact: build-local\n", self.makefile)

--- a/scripts/tests/test_verify_local_artifact.py
+++ b/scripts/tests/test_verify_local_artifact.py
@@ -7,6 +7,7 @@ import hashlib
 import json
 import os
 from pathlib import Path
+import re
 import subprocess
 import sys
 import tempfile
@@ -807,10 +808,198 @@ class BuildLocalArtifactTests(unittest.TestCase):
         self.assertFalse(self.receipt.exists())
 
 
+class RecipeRun:
+    """Outcome of executing the real `local:` recipe in a sandbox."""
+
+    def __init__(
+        self,
+        *,
+        rc: int,
+        output: str,
+        installed: bool,
+        installed_bytes: bytes | None,
+        signed_bytes: bytes | None,
+        staging_file_left_behind: bool,
+    ) -> None:
+        self.rc = rc
+        self.output = output
+        self.installed = installed
+        self.installed_bytes = installed_bytes
+        self.signed_bytes = signed_bytes
+        self.staging_file_left_behind = staging_file_left_behind
+
+
+PRE_EXISTING_INSTALL = b"#!/bin/sh\necho PRE-EXISTING\n"
+
+
 class MakefileGateContractTests(unittest.TestCase):
     @classmethod
     def setUpClass(cls) -> None:
         cls.makefile = MAKEFILE.read_text(encoding="utf-8")
+
+    # -- behavioural harness -------------------------------------------------
+    #
+    # Runs the ACTUAL `local:` recipe text extracted from the Makefile, with
+    # every irreversible edge redirected into a temp tree: HOME (and therefore
+    # DEST) points at the sandbox, and the verifier is a stub whose exit code
+    # the test controls. Nothing here touches the real installed daemon.
+
+    @staticmethod
+    def _extract_local_recipe(makefile_text: str) -> list[str]:
+        """Return the shell commands make would run for `local:`, expanded."""
+        variables = dict(
+            re.findall(r"^([A-Z_][A-Z0-9_]*)\s*:=\s*(.*)$", makefile_text, re.M)
+        )
+        body = makefile_text[makefile_text.index("local: verify-local-artifact") :]
+        body = body[body.index("\n") + 1 :]
+
+        lines: list[str] = []
+        for raw in body.split("\n"):
+            if not raw.startswith("\t"):
+                if raw.strip() == "":
+                    continue
+                break
+            lines.append(raw[1:])
+
+        # Re-join make lines: a trailing backslash continues the SAME shell.
+        commands: list[str] = []
+        current: list[str] = []
+        for line in lines:
+            current.append(line)
+            if not line.rstrip().endswith("\\"):
+                commands.append("\n".join(current))
+                current = []
+        if current:
+            commands.append("\n".join(current))
+
+        expanded: list[str] = []
+        for cmd in commands:
+            cmd = cmd.lstrip("@")
+            # Variable values may themselves reference variables
+            # (LOCAL_VERIFY_STAMP is built from LOCAL_BUILD_RECEIPT), so expand
+            # to a fixpoint. A single pass leaves a stray `$(NAME)` that the
+            # shell then reads as command substitution.
+            for _ in range(10):
+                before = cmd
+                for name, value in variables.items():
+                    cmd = cmd.replace(f"$({name})", value.strip())
+                if cmd == before:
+                    break
+            else:  # pragma: no cover - only on a cyclic definition
+                raise AssertionError(f"variable expansion did not converge: {cmd!r}")
+            leftover = re.search(r"\$\([A-Z_][A-Z0-9_]*\)", cmd)
+            self_check = leftover.group(0) if leftover else None
+            assert self_check is None, f"unexpanded make variable {self_check} in recipe"
+            # make collapses `$$` to a single `$` before handing to the shell.
+            cmd = cmd.replace("$$", "$")
+            expanded.append(cmd)
+        return expanded
+
+    def _run_local_recipe(
+        self,
+        *,
+        signed_probe_exit: int = 0,
+        codesign_exit: int = 0,
+        makefile_text: str | None = None,
+    ) -> RecipeRun:
+        commands = self._extract_local_recipe(makefile_text or self.makefile)
+        self.assertTrue(commands, "no recipe extracted from the Makefile")
+
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            home = root / "home"
+            dest_dir = home / ".cargo" / "bin"
+            dest_dir.mkdir(parents=True)
+            dest = dest_dir / "kkernel"
+            dest.write_bytes(PRE_EXISTING_INSTALL)
+            dest.chmod(0o755)
+
+            src = root / "build" / "kkernel"
+            src.parent.mkdir(parents=True)
+            src.write_bytes(b"#!/bin/sh\necho FRESH-BUILD 0.0.0-test\n")
+            src.chmod(0o755)
+            src_sha = hashlib.sha256(src.read_bytes()).hexdigest()
+
+            # Stub verifier: serves the stamp inspection, and its --artifact
+            # (post-signing) probe exits with the code this test chose.
+            (root / "scripts").mkdir()
+            (root / "scripts" / "verify_local_artifact.py").write_text(
+                textwrap.dedent(
+                    f"""\
+                    import sys
+                    argv = sys.argv[1:]
+                    if "--inspect-stamp" in argv:
+                        print('SRC={src}')
+                        print('VERIFIED_SHA256={src_sha}')
+                        print('VERIFIED_VERBS=90')
+                        sys.exit(0)
+                    if "--artifact" in argv:
+                        sys.exit({signed_probe_exit})
+                    sys.exit(0)
+                    """
+                ),
+                encoding="utf-8",
+            )
+
+            # codesign genuinely REWRITES the file, which is the whole reason
+            # the pre-sign verification does not cover the installed bytes.
+            stub_bin = root / "stub-bin"
+            stub_bin.mkdir()
+            (stub_bin / "codesign").write_text(
+                textwrap.dedent(
+                    f"""\
+                    #!/bin/sh
+                    [ {codesign_exit} -ne 0 ] && exit {codesign_exit}
+                    for a in "$@"; do target="$a"; done
+                    printf '\\n# signed\\n' >> "$target"
+                    exit 0
+                    """
+                ),
+                encoding="utf-8",
+            )
+            for noop in ("pkill", "pgrep"):
+                (stub_bin / noop).write_text("#!/bin/sh\nexit 1\n", encoding="utf-8")
+            for tool in ("codesign", "pkill", "pgrep"):
+                (stub_bin / tool).chmod(0o755)
+
+            env = dict(os.environ)
+            env["HOME"] = str(home)
+            env["PATH"] = f"{stub_bin}:{env.get('PATH', '')}"
+            env["PYTHONDONTWRITEBYTECODE"] = "1"
+
+            rc = 0
+            chunks: list[str] = []
+            signed_bytes: bytes | None = None
+            for cmd in commands:
+                proc = subprocess.run(
+                    ["sh", "-c", cmd],
+                    cwd=root,
+                    env=env,
+                    capture_output=True,
+                    text=True,
+                )
+                chunks.append(
+                    f"$ {cmd[:120]}...\n[rc={proc.returncode}]\n"
+                    f"{proc.stdout}{proc.stderr}"
+                )
+                rc = proc.returncode
+                if rc != 0:
+                    break
+
+            staged = dest_dir / "kkernel.new"
+            installed_bytes = dest.read_bytes() if dest.exists() else None
+            # What SHOULD have landed: the source with the signature appended.
+            if codesign_exit == 0:
+                signed_bytes = src.read_bytes() + b"\n# signed\n"
+
+            return RecipeRun(
+                rc=rc,
+                output="\n".join(chunks),
+                installed=installed_bytes != PRE_EXISTING_INSTALL,
+                installed_bytes=installed_bytes,
+                signed_bytes=signed_bytes,
+                staging_file_left_behind=staged.exists(),
+            )
 
     def test_local_dependency_chain_is_build_then_verify_then_install(self) -> None:
         self.assertIn("verify-local-artifact: build-local\n", self.makefile)
@@ -842,32 +1031,82 @@ class MakefileGateContractTests(unittest.TestCase):
         """`codesign` rewrites the staged file, so every pre-sign check is void
         for the bytes that actually get installed. The gate must therefore fail
         closed on a signing error and re-probe the SIGNED artifact before the
-        move, then bind the installed path to the post-sign digest."""
-        local_recipe = self.makefile[self.makefile.index("local: verify-local-artifact") :]
+        move, then bind the installed path to the post-sign digest.
 
-        # A mutating step inside the install gate may never be ignored.
-        self.assertNotIn('codesign -s - -f "$$DEST.new" 2>/dev/null || true', local_recipe)
-        self.assertNotIn("codesign -s - -f \"$$DEST.new\" || true", local_recipe)
-        self.assertIn('if ! codesign -s - -f "$$DEST.new"; then', local_recipe)
-
-        staged_check = local_recipe.index('if [ "$$VERIFIED_SHA256" != "$$COPIED_SHA256" ]')
-        sign = local_recipe.index('codesign -s - -f "$$DEST.new"')
-        resign_verify = local_recipe.index('--artifact "$$DEST.new"')
-        signed_digest = local_recipe.index("SIGNED_SHA256=")
-        install = local_recipe.index('mv "$$DEST.new" "$$DEST"')
-        installed_check = local_recipe.index(
-            'if [ "$$SIGNED_SHA256" != "$$DEST_SHA256" ]'
+        This is deliberately a BEHAVIOURAL test. An earlier version of this
+        guard asserted only that certain substrings appeared in a certain
+        order, which a recipe that merely echoed those substrings satisfied
+        while probing nothing. Text cannot distinguish a probe from a mention
+        of a probe, so the recipe is executed instead.
+        """
+        control = self._run_local_recipe(signed_probe_exit=0)
+        self.assertTrue(
+            control.installed,
+            "positive control failed: the recipe must install when every probe "
+            f"passes, but the installed binary was unchanged. rc={control.rc}\n"
+            f"{control.output}",
+        )
+        self.assertEqual(control.rc, 0, control.output)
+        self.assertEqual(
+            control.installed_bytes,
+            control.signed_bytes,
+            "control: the installed bytes must be exactly the signed, probed bytes",
         )
 
-        # The signed artifact is re-probed with the full pack set and the same
-        # verb floor, not merely re-hashed: a hash cannot show the binary still
-        # loads every pack.
-        self.assertIn('--packs "$(FULL_PACKS)"', local_recipe)
-        self.assertLess(staged_check, sign)
-        self.assertLess(sign, resign_verify)
-        self.assertLess(resign_verify, signed_digest)
-        self.assertLess(signed_digest, install)
-        self.assertLess(install, installed_check)
+        mutant = self._run_local_recipe(signed_probe_exit=1)
+        self.assertFalse(
+            mutant.installed,
+            "the post-signing probe FAILED and the binary was installed anyway: "
+            "unverified bytes reached the install path\n" + mutant.output,
+        )
+        self.assertNotEqual(
+            mutant.rc, 0, "a failed signed-artifact probe must exit nonzero\n" + mutant.output
+        )
+        self.assertFalse(
+            mutant.staging_file_left_behind,
+            "the failure path must remove the staged file, not leave it for a "
+            "later run to pick up\n" + mutant.output,
+        )
+
+    def test_a_signing_failure_cannot_reach_the_install_path(self) -> None:
+        """`codesign` failure was previously swallowed by `|| true`. Signing is
+        a mutating step inside the install gate, so its failure must abort."""
+        control = self._run_local_recipe(codesign_exit=0)
+        self.assertTrue(control.installed, "positive control failed\n" + control.output)
+
+        mutant = self._run_local_recipe(codesign_exit=1)
+        self.assertFalse(
+            mutant.installed,
+            "codesign failed and the binary was installed anyway\n" + mutant.output,
+        )
+        self.assertNotEqual(mutant.rc, 0, mutant.output)
+
+    def test_the_recipe_harness_can_detect_a_reverted_fix(self) -> None:
+        """Mutation control for the harness itself. A finding-only instrument
+        that never reddens proves nothing, so point it at the pre-fix recipe
+        and require it to catch the defect that motivated this PR."""
+        pre_fix = self.makefile.replace(
+            'if ! codesign -s - -f "$$DEST.new"; then \\\n'
+            '\t  echo "==> ERROR: codesign failed on $$DEST.new — refusing to install"; \\\n'
+            '\t  rm -f "$$DEST.new"; \\\n'
+            "\t  exit 1; \\\n"
+            "\tfi; \\\n",
+            'codesign -s - -f "$$DEST.new" 2>/dev/null || true; \\\n',
+        )
+        self.assertNotEqual(
+            pre_fix, self.makefile, "the fix text was not found; update this control"
+        )
+        # Strip the post-signing re-probe as well, reproducing the old recipe.
+        start = pre_fix.index('echo "==> Re-verifying the SIGNED artifact')
+        end = pre_fix.index("SIGNED_SHA256=")
+        pre_fix = pre_fix[:start] + pre_fix[end:]
+
+        reverted = self._run_local_recipe(signed_probe_exit=1, makefile_text=pre_fix)
+        self.assertTrue(
+            reverted.installed,
+            "the harness did not reproduce the original defect, so a green "
+            "result from it is not evidence\n" + reverted.output,
+        )
 
     def test_cargo_receipt_drives_verifier_and_ci_runs_regression_suite(self) -> None:
         self.assertIn("scripts/build_local_artifact.py", self.makefile)

--- a/scripts/tests/test_verify_local_artifact.py
+++ b/scripts/tests/test_verify_local_artifact.py
@@ -1,0 +1,856 @@
+#!/usr/bin/env python3
+"""Regression tests for the pre-install local build verification gate."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+from pathlib import Path
+import subprocess
+import sys
+import tempfile
+import textwrap
+import unittest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+BUILD_SCRIPT = REPO_ROOT / "scripts" / "build_local_artifact.py"
+VERIFY_SCRIPT = REPO_ROOT / "scripts" / "verify_local_artifact.py"
+MAKEFILE = REPO_ROOT / "Makefile"
+CI_SCRIPT = REPO_ROOT / "scripts" / "ci.sh"
+TEST_PACKS = "kg,workspace,formal"
+
+
+def canonical_json(payload: object) -> str:
+    return json.dumps(payload, sort_keys=True, separators=(",", ":")) + "\n"
+
+
+def write_build_receipt(
+    path: Path, artifact: Path, *, build_id: str = "a" * 32
+) -> None:
+    path.write_text(
+        canonical_json(
+            {
+                "artifact": str(artifact.resolve()),
+                "build_id": build_id,
+                "schema": 1,
+                "sha256": hashlib.sha256(artifact.read_bytes()).hexdigest(),
+            }
+        ),
+        encoding="utf-8",
+    )
+
+
+FAKE_ARTIFACT = r"""#!/usr/bin/env python3
+import json
+import os
+from pathlib import Path
+import select
+import sys
+import time
+
+def read_message():
+    raw = bytearray()
+    while True:
+        chunk = os.read(sys.stdin.fileno(), 1)
+        if not chunk:
+            return None
+        if chunk == b"\n":
+            break
+        raw.extend(chunk)
+    return json.loads(raw.decode("utf-8"))
+
+mode = os.environ.get("FAKE_MODE", "ok")
+record = os.environ.get("FAKE_RECORD")
+config_path = Path(sys.argv[5]) if len(sys.argv) > 5 else Path("missing")
+if record:
+    Path(record).write_text(json.dumps({
+        "args": sys.argv[1:],
+        "cwd": os.getcwd(),
+        "home": os.environ.get("HOME"),
+        "config": os.environ.get("KHIVE_CONFIG"),
+        "config_was_file": config_path.is_file(),
+        "db": os.environ.get("KHIVE_DB"),
+        "log": os.environ.get("KHIVE_LOG"),
+        "no_daemon": os.environ.get("KHIVE_NO_DAEMON"),
+        "no_embed": os.environ.get("KHIVE_NO_EMBED"),
+        "packs": os.environ.get("KHIVE_PACKS"),
+        "leak": os.environ.get("KHIVE_LEAK_SENTINEL"),
+    }))
+
+expected_shape = (
+    len(sys.argv) == 9
+    and sys.argv[1:5] == ["mcp", "--db", ":memory:", "--config"]
+    and sys.argv[6:] == ["--no-embed", "--log", "error"]
+    and config_path.is_file()
+    and Path(os.environ["HOME"]).resolve() == Path.cwd().resolve()
+    and os.environ.get("KHIVE_CONFIG") == str(config_path)
+    and os.environ.get("KHIVE_DB") == ":memory:"
+    and os.environ.get("KHIVE_NO_DAEMON") == "1"
+    and os.environ.get("KHIVE_NO_EMBED") == "1"
+    and os.environ.get("KHIVE_LEAK_SENTINEL") is None
+)
+if not expected_shape:
+    print("probe was not isolated or did not use the expected CLI shape", file=sys.stderr)
+    raise SystemExit(19)
+if mode == "error":
+    print("synthetic probe failure", file=sys.stderr)
+    raise SystemExit(7)
+if mode == "timeout":
+    time.sleep(2)
+if mode == "mutate":
+    with Path(__file__).open("a", encoding="utf-8") as handle:
+        handle.write("\n# mutation during probe\n")
+
+initialize = read_message()
+expected_initialize = (
+    isinstance(initialize, dict)
+    and initialize.get("jsonrpc") == "2.0"
+    and initialize.get("id") == 1
+    and initialize.get("method") == "initialize"
+    and initialize.get("params", {}).get("protocolVersion") == "2024-11-05"
+)
+if not expected_initialize:
+    print("probe did not send a valid initialize request", file=sys.stderr)
+    raise SystemExit(20)
+
+init_failure_modes = {
+    "init-error",
+    "init-missing",
+    "init-malformed-json",
+    "init-malformed-shape",
+}
+if mode not in init_failure_modes and select.select(
+    [sys.stdin.fileno()], [], [], 0
+)[0]:
+    print("probe sent messages before initialize completed", file=sys.stderr)
+    raise SystemExit(21)
+
+if mode == "split-timeout":
+    time.sleep(0.3)
+if mode == "init-error":
+    print(json.dumps({
+        "jsonrpc": "2.0",
+        "id": 1,
+        "error": {"code": -32000, "message": "synthetic initialize failure"},
+    }), flush=True)
+elif mode == "init-missing":
+    pass
+elif mode == "init-malformed-json":
+    print("not-json", flush=True)
+elif mode == "init-malformed-shape":
+    print(json.dumps({
+        "jsonrpc": "2.0",
+        "id": 1,
+        "result": {"serverInfo": {"name": "khive-mcp", "version": "fixture"}},
+    }), flush=True)
+else:
+    print(json.dumps({
+        "jsonrpc": "2.0",
+        "id": 1,
+        "result": {
+            "protocolVersion": "2024-11-05",
+            "capabilities": {"tools": {}},
+            "serverInfo": {"name": "khive-mcp", "version": "fixture"},
+        },
+    }), flush=True)
+
+initialized = read_message()
+tools_call = read_message()
+expected_requests = (
+    isinstance(initialized, dict)
+    and initialized.get("method") == "notifications/initialized"
+    and isinstance(tools_call, dict)
+    and tools_call.get("id") == 2
+    and tools_call.get("method") == "tools/call"
+    and tools_call.get("params", {}).get("name") == "request"
+    and tools_call.get("params", {}).get("arguments")
+    == {"ops": "verbs()", "format": "json"}
+)
+if not expected_requests:
+    print("probe did not use the expected MCP request sequence", file=sys.stderr)
+    raise SystemExit(22)
+if mode == "malformed":
+    print("not-json", flush=True)
+    raise SystemExit(0)
+if mode == "split-timeout":
+    time.sleep(0.3)
+
+packs = os.environ["KHIVE_PACKS"].split(",")
+total = 2 if mode == "low" else 3
+pack_counts = {pack: 0 for pack in packs}
+pack_counts[packs[0]] = total
+if mode == "missing-pack":
+    del pack_counts[packs[-1]]
+if mode == "count-mismatch":
+    pack_counts[packs[0]] += 1
+verbs = [
+    {"verb": f"{packs[0]}.verb-{index}", "pack": packs[0]}
+    for index in range(total)
+]
+if mode == "missing-verb":
+    del verbs[0]["verb"]
+if mode == "blank-verb":
+    verbs[0]["verb"] = "   "
+if mode == "duplicate-verb":
+    verbs[1]["verb"] = verbs[0]["verb"]
+    verbs[1]["pack"] = packs[1]
+    pack_counts[packs[0]] -= 1
+    pack_counts[packs[1]] = 1
+if mode == "whitespace-pack":
+    pack_counts[packs[0]] = 0
+    pack_counts["   "] = total
+    for verb in verbs:
+        verb["pack"] = "   "
+if mode == "padded-verb":
+    verbs[0]["verb"] = f" {verbs[0]['verb']} "
+probe_payload = {
+    "results": [{
+        "ok": mode != "unsuccessful",
+        "tool": "verbs",
+        "result": {"verbs": verbs, "total": total, "pack_counts": pack_counts},
+    }]
+}
+if mode == "mixed-result-error":
+    probe_payload["results"][0]["error"] = "synthetic error alongside result"
+content = [{"type": "text", "text": json.dumps(probe_payload)}]
+if mode == "extra-content":
+    content.append({"type": "image", "data": "AA==", "mimeType": "image/png"})
+if mode == "malformed-extra-content":
+    content.append({"unexpected": True})
+print(json.dumps({
+    "jsonrpc": "2.0",
+    "id": 2,
+    "result": {
+        "content": content,
+        "isError": False,
+    },
+}), flush=True)
+"""
+
+
+FAKE_CARGO = r"""#!/usr/bin/env python3
+import json
+import os
+from pathlib import Path
+import sys
+
+mode = os.environ.get("FAKE_CARGO_MODE", "ok")
+artifact = os.environ.get("FAKE_CARGO_ARTIFACT")
+record = os.environ.get("FAKE_CARGO_RECORD")
+if record:
+    Path(record).write_text(json.dumps(sys.argv[1:]))
+if mode == "error":
+    raise SystemExit(7)
+if mode == "malformed":
+    print("not-json")
+    raise SystemExit(0)
+if mode != "missing":
+    print(json.dumps({
+        "reason": "compiler-artifact",
+        "target": {"name": "kkernel", "kind": ["lib"]},
+        "executable": None,
+    }))
+    print(json.dumps({
+        "reason": "compiler-artifact",
+        "target": {"name": "kkernel", "kind": ["bin"]},
+        "executable": artifact,
+    }))
+if mode == "duplicate-event":
+    print(json.dumps({
+        "reason": "compiler-artifact",
+        "target": {"name": "kkernel", "kind": ["bin"]},
+        "executable": artifact,
+    }))
+if mode == "multiple":
+    print(json.dumps({
+        "reason": "compiler-artifact",
+        "target": {"name": "kkernel", "kind": ["bin"]},
+        "executable": artifact + ".other",
+    }))
+print(json.dumps({"reason": "build-finished", "success": True}))
+"""
+
+
+class VerifyLocalArtifactTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temporary = tempfile.TemporaryDirectory()
+        self.root = Path(self.temporary.name)
+        self.artifact = self.root / "kkernel"
+        self.artifact.write_text(textwrap.dedent(FAKE_ARTIFACT), encoding="utf-8")
+        self.artifact.chmod(0o755)
+        self.stamp = self.root / "kkernel.verified"
+        self.record = self.root / "record.json"
+
+    def tearDown(self) -> None:
+        self.temporary.cleanup()
+
+    def run_probe(
+        self,
+        mode: str = "ok",
+        *,
+        minimum: int = 3,
+        timeout: float = 5.0,
+    ) -> subprocess.CompletedProcess[str]:
+        environment = os.environ.copy()
+        environment.update(
+            {
+                "FAKE_MODE": mode,
+                "FAKE_RECORD": str(self.record),
+                "KHIVE_LEAK_SENTINEL": "must-be-cleared",
+            }
+        )
+        return subprocess.run(
+            [
+                sys.executable,
+                str(VERIFY_SCRIPT),
+                "--artifact",
+                str(self.artifact),
+                "--packs",
+                TEST_PACKS,
+                "--min-verbs",
+                str(minimum),
+                "--stamp",
+                str(self.stamp),
+                "--timeout-seconds",
+                str(timeout),
+            ],
+            cwd=REPO_ROOT,
+            env=environment,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
+    def run_receipt_probe(
+        self, receipt: Path, stamp: Path
+    ) -> subprocess.CompletedProcess[str]:
+        environment = os.environ.copy()
+        environment.update(
+            {
+                "FAKE_MODE": "ok",
+                "FAKE_RECORD": str(self.record),
+            }
+        )
+        return subprocess.run(
+            [
+                sys.executable,
+                str(VERIFY_SCRIPT),
+                "--build-receipt",
+                str(receipt),
+                "--packs",
+                TEST_PACKS,
+                "--min-verbs",
+                "3",
+                "--stamp",
+                str(stamp),
+                "--timeout-seconds",
+                "5",
+            ],
+            cwd=REPO_ROOT,
+            env=environment,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
+    def test_success_records_exact_artifact_hash_and_isolated_probe(self) -> None:
+        completed = self.run_probe()
+        self.assertEqual(completed.returncode, 0, completed.stderr)
+        stamp = json.loads(self.stamp.read_text(encoding="utf-8"))
+        self.assertEqual(
+            stamp["sha256"],
+            hashlib.sha256(self.artifact.read_bytes()).hexdigest(),
+        )
+        self.assertEqual(stamp["artifact"], str(self.artifact.resolve()))
+        self.assertEqual(stamp["verb_count"], 3)
+        self.assertIsNone(stamp["build_id"])
+        self.assertEqual(
+            self.stamp.read_text(encoding="utf-8"), canonical_json(stamp)
+        )
+
+        record = json.loads(self.record.read_text(encoding="utf-8"))
+        self.assertEqual(record["packs"], TEST_PACKS)
+        self.assertEqual(record["db"], ":memory:")
+        self.assertEqual(record["no_daemon"], "1")
+        self.assertEqual(record["no_embed"], "1")
+        self.assertTrue(record["config_was_file"])
+        self.assertEqual(Path(record["home"]).resolve(), Path(record["cwd"]).resolve())
+        self.assertIsNone(record["leak"])
+
+    def test_every_probe_or_contract_failure_removes_stale_stamp(self) -> None:
+        for mode in (
+            "low",
+            "missing-pack",
+            "count-mismatch",
+            "malformed",
+            "unsuccessful",
+            "error",
+        ):
+            with self.subTest(mode=mode):
+                self.stamp.write_text("stale 999\n", encoding="utf-8")
+                completed = self.run_probe(mode)
+                self.assertNotEqual(completed.returncode, 0, completed.stdout)
+                self.assertFalse(self.stamp.exists())
+
+    def test_initialize_failure_missing_and_malformed_responses_fail_closed(self) -> None:
+        cases = (
+            ("init-error", "initialize returned an MCP error", 5.0),
+            ("init-missing", "timed out", 0.2),
+            ("init-malformed-json", "invalid JSON for initialize", 5.0),
+            ("init-malformed-shape", "invalid protocolVersion", 5.0),
+        )
+        for mode, expected, timeout in cases:
+            with self.subTest(mode=mode):
+                self.stamp.write_text("stale 999\n", encoding="utf-8")
+                completed = self.run_probe(mode, timeout=timeout)
+                self.assertNotEqual(completed.returncode, 0, completed.stdout)
+                self.assertIn(expected, completed.stderr)
+                self.assertFalse(self.stamp.exists())
+
+    def test_catalog_requires_nonblank_globally_unique_verb_names(self) -> None:
+        cases = (
+            ("missing-verb", "does not name an exact nonblank verb"),
+            ("blank-verb", "does not name an exact nonblank verb"),
+            ("duplicate-verb", "contains duplicate verb"),
+        )
+        for mode, expected in cases:
+            with self.subTest(mode=mode):
+                self.stamp.write_text("stale 999\n", encoding="utf-8")
+                completed = self.run_probe(mode)
+                self.assertNotEqual(completed.returncode, 0, completed.stdout)
+                self.assertIn(expected, completed.stderr)
+                self.assertFalse(self.stamp.exists())
+
+    def test_mixed_success_error_operation_shape_fails_closed(self) -> None:
+        self.stamp.write_text("stale 999\n", encoding="utf-8")
+        completed = self.run_probe("mixed-result-error")
+        self.assertNotEqual(completed.returncode, 0, completed.stdout)
+        self.assertIn("invalid result/error shape", completed.stderr)
+        self.assertFalse(self.stamp.exists())
+
+    def test_extra_or_malformed_mcp_content_blocks_fail_closed(self) -> None:
+        for mode in ("extra-content", "malformed-extra-content"):
+            with self.subTest(mode=mode):
+                self.stamp.write_text("stale 999\n", encoding="utf-8")
+                completed = self.run_probe(mode)
+                self.assertNotEqual(completed.returncode, 0, completed.stdout)
+                self.assertIn("exactly one text content block", completed.stderr)
+                self.assertFalse(self.stamp.exists())
+
+    def test_pack_and_verb_names_use_exact_nonblank_vocabulary(self) -> None:
+        cases = (
+            ("whitespace-pack", "invalid pack name"),
+            ("padded-verb", "exact nonblank verb"),
+        )
+        for mode, expected in cases:
+            with self.subTest(mode=mode):
+                self.stamp.write_text("stale 999\n", encoding="utf-8")
+                completed = self.run_probe(mode)
+                self.assertNotEqual(completed.returncode, 0, completed.stdout)
+                self.assertIn(expected, completed.stderr)
+                self.assertFalse(self.stamp.exists())
+
+    def test_timeout_is_a_failure_and_removes_stale_stamp(self) -> None:
+        self.stamp.write_text("stale 999\n", encoding="utf-8")
+        completed = self.run_probe("timeout", timeout=0.1)
+        self.assertNotEqual(completed.returncode, 0)
+        self.assertIn("timed out", completed.stderr)
+        self.assertFalse(self.stamp.exists())
+
+    def test_timeout_is_one_absolute_handshake_deadline(self) -> None:
+        completed = self.run_probe("split-timeout", timeout=0.45)
+        self.assertNotEqual(completed.returncode, 0)
+        self.assertIn("timed out", completed.stderr)
+        self.assertFalse(self.stamp.exists())
+
+    def test_artifact_mutation_during_probe_fails_closed(self) -> None:
+        completed = self.run_probe("mutate")
+        self.assertNotEqual(completed.returncode, 0)
+        self.assertIn("changed while", completed.stderr)
+        self.assertFalse(self.stamp.exists())
+
+    def test_missing_or_non_executable_artifacts_fail_closed(self) -> None:
+        self.artifact.unlink()
+        missing = self.run_probe()
+        self.assertNotEqual(missing.returncode, 0)
+        self.assertIn("missing", missing.stderr)
+
+        self.artifact.write_text("not executable", encoding="utf-8")
+        self.artifact.chmod(0o644)
+        non_executable = self.run_probe()
+        self.assertNotEqual(non_executable.returncode, 0)
+        self.assertIn("not executable", non_executable.stderr)
+
+    def test_stamp_is_restricted_to_the_artifact_sidecar(self) -> None:
+        protected = self.root / "unrelated"
+        protected.write_text("keep", encoding="utf-8")
+        completed = subprocess.run(
+            [
+                sys.executable,
+                str(VERIFY_SCRIPT),
+                "--artifact",
+                str(self.artifact),
+                "--packs",
+                TEST_PACKS,
+                "--min-verbs",
+                "3",
+                "--stamp",
+                str(protected),
+            ],
+            cwd=REPO_ROOT,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        self.assertNotEqual(completed.returncode, 0)
+        self.assertEqual(protected.read_text(encoding="utf-8"), "keep")
+
+    def test_build_receipt_binds_probe_stamp_and_install_fields(self) -> None:
+        artifact_with_spaces = self.root / "kkernel with ' quote"
+        self.artifact.rename(artifact_with_spaces)
+        self.artifact = artifact_with_spaces
+        receipt = self.root / "build.json"
+        stamp = self.root / "build.json.verified"
+        write_build_receipt(receipt, self.artifact)
+
+        completed = self.run_receipt_probe(receipt, stamp)
+        self.assertEqual(completed.returncode, 0, completed.stderr)
+        stamp_payload = json.loads(stamp.read_text(encoding="utf-8"))
+        self.assertEqual(stamp_payload["build_id"], "a" * 32)
+        self.assertEqual(stamp_payload["artifact"], str(self.artifact.resolve()))
+
+        inspected = subprocess.run(
+            [
+                sys.executable,
+                str(VERIFY_SCRIPT),
+                "--build-receipt",
+                str(receipt),
+                "--inspect-stamp",
+                str(stamp),
+                "--min-verbs",
+                "3",
+            ],
+            cwd=REPO_ROOT,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        self.assertEqual(inspected.returncode, 0, inspected.stderr)
+        round_trip = subprocess.run(
+            [
+                "/bin/sh",
+                "-c",
+                'eval "$1"; printf "%s\\n%s\\n%s\\n" "$SRC" "$VERIFIED_SHA256" "$VERIFIED_VERBS"',
+                "sh",
+                inspected.stdout,
+            ],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        self.assertEqual(round_trip.returncode, 0, round_trip.stderr)
+        fields = round_trip.stdout.splitlines()
+        self.assertEqual(fields[0], str(self.artifact.resolve()))
+        self.assertEqual(
+            fields[1], hashlib.sha256(self.artifact.read_bytes()).hexdigest()
+        )
+        self.assertEqual(fields[2], "3")
+
+        write_build_receipt(receipt, self.artifact, build_id="b" * 32)
+        stale = subprocess.run(
+            [
+                sys.executable,
+                str(VERIFY_SCRIPT),
+                "--build-receipt",
+                str(receipt),
+                "--inspect-stamp",
+                str(stamp),
+                "--min-verbs",
+                "3",
+            ],
+            cwd=REPO_ROOT,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        self.assertNotEqual(stale.returncode, 0)
+        self.assertIn("current Cargo build", stale.stderr)
+
+    def test_stamp_count_is_canonical_bounded_and_never_shell_parsed(self) -> None:
+        receipt = self.root / "build.json"
+        stamp = self.root / "build.json.verified"
+        write_build_receipt(receipt, self.artifact)
+        completed = self.run_receipt_probe(receipt, stamp)
+        self.assertEqual(completed.returncode, 0, completed.stderr)
+        valid_payload = json.loads(stamp.read_text(encoding="utf-8"))
+
+        cases = (
+            (10**100, "bounded verb count"),
+            ("000003", "bounded verb count"),
+            (True, "bounded verb count"),
+        )
+        for verb_count, expected in cases:
+            with self.subTest(verb_count=verb_count):
+                payload = {**valid_payload, "verb_count": verb_count}
+                stamp.write_text(canonical_json(payload), encoding="utf-8")
+                inspected = subprocess.run(
+                    [
+                        sys.executable,
+                        str(VERIFY_SCRIPT),
+                        "--build-receipt",
+                        str(receipt),
+                        "--inspect-stamp",
+                        str(stamp),
+                        "--min-verbs",
+                        "3",
+                    ],
+                    cwd=REPO_ROOT,
+                    capture_output=True,
+                    text=True,
+                    check=False,
+                )
+                self.assertNotEqual(inspected.returncode, 0)
+                self.assertIn(expected, inspected.stderr)
+
+        stamp.write_text(json.dumps(valid_payload, indent=2), encoding="utf-8")
+        noncanonical = subprocess.run(
+            [
+                sys.executable,
+                str(VERIFY_SCRIPT),
+                "--build-receipt",
+                str(receipt),
+                "--inspect-stamp",
+                str(stamp),
+                "--min-verbs",
+                "3",
+            ],
+            cwd=REPO_ROOT,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        self.assertNotEqual(noncanonical.returncode, 0)
+        self.assertIn("canonical JSON", noncanonical.stderr)
+
+    def test_receipt_hash_closes_build_verify_and_verify_install_windows(self) -> None:
+        receipt = self.root / "build.json"
+        stamp = self.root / "build.json.verified"
+        write_build_receipt(receipt, self.artifact)
+        self.artifact.write_text("changed after Cargo", encoding="utf-8")
+        stamp.write_text("stale", encoding="utf-8")
+        before_probe = self.run_receipt_probe(receipt, stamp)
+        self.assertNotEqual(before_probe.returncode, 0)
+        self.assertIn("changed after Cargo", before_probe.stderr)
+        self.assertFalse(stamp.exists())
+
+        self.artifact.write_text(textwrap.dedent(FAKE_ARTIFACT), encoding="utf-8")
+        self.artifact.chmod(0o755)
+        write_build_receipt(receipt, self.artifact)
+        verified = self.run_receipt_probe(receipt, stamp)
+        self.assertEqual(verified.returncode, 0, verified.stderr)
+        self.artifact.write_text("changed before install", encoding="utf-8")
+        inspected = subprocess.run(
+            [
+                sys.executable,
+                str(VERIFY_SCRIPT),
+                "--build-receipt",
+                str(receipt),
+                "--inspect-stamp",
+                str(stamp),
+                "--min-verbs",
+                "3",
+            ],
+            cwd=REPO_ROOT,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        self.assertNotEqual(inspected.returncode, 0)
+        self.assertIn("no longer matches", inspected.stderr)
+
+    def test_timeout_must_be_finite(self) -> None:
+        for timeout in ("nan", "inf", "-inf"):
+            with self.subTest(timeout=timeout):
+                completed = subprocess.run(
+                    [
+                        sys.executable,
+                        str(VERIFY_SCRIPT),
+                        "--artifact",
+                        str(self.artifact),
+                        "--packs",
+                        TEST_PACKS,
+                        "--min-verbs",
+                        "3",
+                        f"--timeout-seconds={timeout}",
+                    ],
+                    cwd=REPO_ROOT,
+                    capture_output=True,
+                    text=True,
+                    check=False,
+                )
+                self.assertEqual(completed.returncode, 2)
+                self.assertIn("finite number greater than 0", completed.stderr)
+
+
+class BuildLocalArtifactTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temporary = tempfile.TemporaryDirectory()
+        self.root = Path(self.temporary.name)
+        self.fake_cargo = self.root / "fake cargo"
+        self.fake_cargo.write_text(textwrap.dedent(FAKE_CARGO), encoding="utf-8")
+        self.fake_cargo.chmod(0o755)
+        self.receipt = self.root / "state" / "local-build.json"
+        self.record = self.root / "cargo-args.json"
+
+    def tearDown(self) -> None:
+        self.temporary.cleanup()
+
+    def run_build(
+        self, artifact: Path, *, mode: str = "ok"
+    ) -> subprocess.CompletedProcess[str]:
+        environment = os.environ.copy()
+        environment.update(
+            {
+                "CARGO_TARGET_DIR": str(self.root / "configured-but-not-guessed"),
+                "FAKE_CARGO_ARTIFACT": str(artifact),
+                "FAKE_CARGO_MODE": mode,
+                "FAKE_CARGO_RECORD": str(self.record),
+            }
+        )
+        return subprocess.run(
+            [
+                sys.executable,
+                str(BUILD_SCRIPT),
+                "--cargo",
+                str(self.fake_cargo),
+                "--manifest-path",
+                str(REPO_ROOT / "crates" / "Cargo.toml"),
+                "--package",
+                "kkernel",
+                "--features",
+                "channel-email,channel-telegram",
+                "--receipt",
+                str(self.receipt),
+            ],
+            cwd=REPO_ROOT,
+            env=environment,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
+    def test_cargo_reported_target_dir_and_target_triple_are_authoritative(self) -> None:
+        artifact = (
+            self.root
+            / "user configured target"
+            / "aarch64-unknown-linux-gnu"
+            / "release"
+            / "kkernel"
+        )
+        artifact.parent.mkdir(parents=True)
+        artifact.write_text("exact cross-target fixture", encoding="utf-8")
+        artifact.chmod(0o755)
+
+        completed = self.run_build(artifact)
+        self.assertEqual(completed.returncode, 0, completed.stderr)
+        receipt = json.loads(self.receipt.read_text(encoding="utf-8"))
+        self.assertEqual(receipt["artifact"], str(artifact.resolve()))
+        self.assertEqual(
+            receipt["sha256"], hashlib.sha256(artifact.read_bytes()).hexdigest()
+        )
+        self.assertEqual(
+            self.receipt.read_text(encoding="utf-8"), canonical_json(receipt)
+        )
+        cargo_args = json.loads(self.record.read_text(encoding="utf-8"))
+        self.assertIn("--message-format=json-render-diagnostics", cargo_args)
+
+        printed = subprocess.run(
+            [
+                sys.executable,
+                str(BUILD_SCRIPT),
+                "--receipt",
+                str(self.receipt),
+                "--print-artifact",
+            ],
+            cwd=REPO_ROOT,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        self.assertEqual(printed.returncode, 0, printed.stderr)
+        self.assertEqual(printed.stdout.strip(), str(artifact.resolve()))
+
+    def test_every_cargo_contract_failure_removes_stale_receipts(self) -> None:
+        artifact = self.root / "kkernel"
+        artifact.write_text("fixture", encoding="utf-8")
+        artifact.chmod(0o755)
+        for mode in ("error", "malformed", "missing", "multiple"):
+            with self.subTest(mode=mode):
+                self.receipt.parent.mkdir(parents=True, exist_ok=True)
+                self.receipt.write_text("stale", encoding="utf-8")
+                verified = self.receipt.with_name(f"{self.receipt.name}.verified")
+                verified.write_text("stale", encoding="utf-8")
+                completed = self.run_build(artifact, mode=mode)
+                self.assertNotEqual(completed.returncode, 0, completed.stdout)
+                self.assertFalse(self.receipt.exists())
+                self.assertFalse(verified.exists())
+
+    def test_duplicate_matching_cargo_artifact_events_fail_closed(self) -> None:
+        artifact = self.root / "kkernel"
+        artifact.write_text("fixture", encoding="utf-8")
+        artifact.chmod(0o755)
+        completed = self.run_build(artifact, mode="duplicate-event")
+        self.assertNotEqual(completed.returncode, 0, completed.stdout)
+        self.assertIn("exactly one executable compiler-artifact event", completed.stderr)
+        self.assertFalse(self.receipt.exists())
+
+
+class MakefileGateContractTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.makefile = MAKEFILE.read_text(encoding="utf-8")
+
+    def test_local_dependency_chain_is_build_then_verify_then_install(self) -> None:
+        self.assertIn("verify-local-artifact: build-local\n", self.makefile)
+        self.assertIn("local: verify-local-artifact\n", self.makefile)
+        self.assertIn("LOCAL_VERB_FLOOR := 90", self.makefile)
+
+        local_recipe = self.makefile[self.makefile.index("local: verify-local-artifact") :]
+        self.assertNotIn("cargo build", local_recipe)
+        stamp_check = local_recipe.index('--inspect-stamp "$(LOCAL_VERIFY_STAMP)"')
+        assignments = local_recipe.index('eval "$$VERIFIED_ASSIGNMENTS"')
+        hash_check = local_recipe.index(
+            'if [ "$$VERIFIED_SHA256" != "$$SRC_SHA256" ]'
+        )
+        copy = local_recipe.index('cp "$$SRC" "$$DEST.new"')
+        staged_check = local_recipe.index(
+            'if [ "$$VERIFIED_SHA256" != "$$COPIED_SHA256" ]'
+        )
+        install = local_recipe.index('mv "$$DEST.new" "$$DEST"')
+        daemon_stop = local_recipe.index("pkill -f 'kkernel mcp --daemon'")
+        self.assertNotIn('"$$VERIFIED_VERBS" -lt', local_recipe)
+        self.assertLess(stamp_check, assignments)
+        self.assertLess(assignments, hash_check)
+        self.assertLess(hash_check, copy)
+        self.assertLess(copy, staged_check)
+        self.assertLess(staged_check, install)
+        self.assertLess(install, daemon_stop)
+
+    def test_cargo_receipt_drives_verifier_and_ci_runs_regression_suite(self) -> None:
+        self.assertIn("scripts/build_local_artifact.py", self.makefile)
+        self.assertIn("scripts/verify_local_artifact.py", self.makefile)
+        self.assertIn('--build-receipt "$(LOCAL_BUILD_RECEIPT)"', self.makefile)
+        self.assertIn('--min-verbs "$(LOCAL_VERB_FLOOR)"', self.makefile)
+        self.assertIn('--stamp "$(LOCAL_VERIFY_STAMP)"', self.makefile)
+        self.assertNotIn("LOCAL_ARTIFACT", self.makefile)
+        self.assertNotIn("/release/kkernel", self.makefile)
+        self.assertIn(
+            'python3 "$SCRIPT_DIR/tests/test_verify_local_artifact.py"',
+            CI_SCRIPT.read_text(encoding="utf-8"),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/tests/test_verify_local_artifact.py
+++ b/scripts/tests/test_verify_local_artifact.py
@@ -838,6 +838,37 @@ class MakefileGateContractTests(unittest.TestCase):
         self.assertLess(staged_check, install)
         self.assertLess(install, daemon_stop)
 
+    def test_signing_cannot_slip_unverified_bytes_past_the_install_gate(self) -> None:
+        """`codesign` rewrites the staged file, so every pre-sign check is void
+        for the bytes that actually get installed. The gate must therefore fail
+        closed on a signing error and re-probe the SIGNED artifact before the
+        move, then bind the installed path to the post-sign digest."""
+        local_recipe = self.makefile[self.makefile.index("local: verify-local-artifact") :]
+
+        # A mutating step inside the install gate may never be ignored.
+        self.assertNotIn('codesign -s - -f "$$DEST.new" 2>/dev/null || true', local_recipe)
+        self.assertNotIn("codesign -s - -f \"$$DEST.new\" || true", local_recipe)
+        self.assertIn('if ! codesign -s - -f "$$DEST.new"; then', local_recipe)
+
+        staged_check = local_recipe.index('if [ "$$VERIFIED_SHA256" != "$$COPIED_SHA256" ]')
+        sign = local_recipe.index('codesign -s - -f "$$DEST.new"')
+        resign_verify = local_recipe.index('--artifact "$$DEST.new"')
+        signed_digest = local_recipe.index("SIGNED_SHA256=")
+        install = local_recipe.index('mv "$$DEST.new" "$$DEST"')
+        installed_check = local_recipe.index(
+            'if [ "$$SIGNED_SHA256" != "$$DEST_SHA256" ]'
+        )
+
+        # The signed artifact is re-probed with the full pack set and the same
+        # verb floor, not merely re-hashed: a hash cannot show the binary still
+        # loads every pack.
+        self.assertIn('--packs "$(FULL_PACKS)"', local_recipe)
+        self.assertLess(staged_check, sign)
+        self.assertLess(sign, resign_verify)
+        self.assertLess(resign_verify, signed_digest)
+        self.assertLess(signed_digest, install)
+        self.assertLess(install, installed_check)
+
     def test_cargo_receipt_drives_verifier_and_ci_runs_regression_suite(self) -> None:
         self.assertIn("scripts/build_local_artifact.py", self.makefile)
         self.assertIn("scripts/verify_local_artifact.py", self.makefile)

--- a/scripts/tests/test_verify_local_artifact.py
+++ b/scripts/tests/test_verify_local_artifact.py
@@ -820,6 +820,8 @@ class RecipeRun:
         installed_bytes: bytes | None,
         signed_bytes: bytes | None,
         staging_file_left_behind: bool,
+        codesign_invocations: int,
+        signed_probe_invocations: int,
     ) -> None:
         self.rc = rc
         self.output = output
@@ -827,6 +829,8 @@ class RecipeRun:
         self.installed_bytes = installed_bytes
         self.signed_bytes = signed_bytes
         self.staging_file_left_behind = staging_file_left_behind
+        self.codesign_invocations = codesign_invocations
+        self.signed_probe_invocations = signed_probe_invocations
 
 
 PRE_EXISTING_INSTALL = b"#!/bin/sh\necho PRE-EXISTING\n"
@@ -901,12 +905,40 @@ class MakefileGateContractTests(unittest.TestCase):
         signed_probe_exit: int = 0,
         codesign_exit: int = 0,
         makefile_text: str | None = None,
+        fixture_shape: str = "bare",
     ) -> RecipeRun:
-        commands = self._extract_local_recipe(makefile_text or self.makefile)
+        recipe_makefile = makefile_text or self.makefile
+        commands = self._extract_local_recipe(recipe_makefile)
         self.assertTrue(commands, "no recipe extracted from the Makefile")
 
         with tempfile.TemporaryDirectory() as tmp:
-            root = Path(tmp)
+            fixture = Path(tmp)
+            root = fixture / "workspace"
+            root.mkdir()
+            (root / "Makefile").write_text(recipe_makefile, encoding="utf-8")
+            if fixture_shape == "git-dir":
+                subprocess.run(
+                    ["git", "init", "-q", str(root)],
+                    check=True,
+                    capture_output=True,
+                    text=True,
+                )
+            elif fixture_shape == "git-file":
+                subprocess.run(
+                    [
+                        "git",
+                        "init",
+                        "-q",
+                        f"--separate-git-dir={fixture / 'git-dir'}",
+                        str(root),
+                    ],
+                    check=True,
+                    capture_output=True,
+                    text=True,
+                )
+            elif fixture_shape != "bare":
+                raise AssertionError(f"unknown recipe fixture shape: {fixture_shape}")
+
             home = root / "home"
             dest_dir = home / ".cargo" / "bin"
             dest_dir.mkdir(parents=True)
@@ -919,6 +951,8 @@ class MakefileGateContractTests(unittest.TestCase):
             src.write_bytes(b"#!/bin/sh\necho FRESH-BUILD 0.0.0-test\n")
             src.chmod(0o755)
             src_sha = hashlib.sha256(src.read_bytes()).hexdigest()
+            signed_probe_record = root / "signed-probe-invocations"
+            codesign_record = root / "codesign-invocations"
 
             # Stub verifier: serves the stamp inspection, and its --artifact
             # (post-signing) probe exits with the code this test chose.
@@ -926,6 +960,7 @@ class MakefileGateContractTests(unittest.TestCase):
             (root / "scripts" / "verify_local_artifact.py").write_text(
                 textwrap.dedent(
                     f"""\
+                    import os
                     import sys
                     argv = sys.argv[1:]
                     if "--inspect-stamp" in argv:
@@ -934,6 +969,10 @@ class MakefileGateContractTests(unittest.TestCase):
                         print('VERIFIED_VERBS=90')
                         sys.exit(0)
                     if "--artifact" in argv:
+                        with open(
+                            os.environ["SIGNED_PROBE_RECORD"], "a", encoding="utf-8"
+                        ) as record:
+                            record.write("called\\n")
                         sys.exit({signed_probe_exit})
                     sys.exit(0)
                     """
@@ -949,6 +988,7 @@ class MakefileGateContractTests(unittest.TestCase):
                 textwrap.dedent(
                     f"""\
                     #!/bin/sh
+                    printf 'called\n' >> "$CODESIGN_RECORD"
                     [ {codesign_exit} -ne 0 ] && exit {codesign_exit}
                     for a in "$@"; do target="$a"; done
                     printf '\\n# signed\\n' >> "$target"
@@ -966,6 +1006,8 @@ class MakefileGateContractTests(unittest.TestCase):
             env["HOME"] = str(home)
             env["PATH"] = f"{stub_bin}:{env.get('PATH', '')}"
             env["PYTHONDONTWRITEBYTECODE"] = "1"
+            env["CODESIGN_RECORD"] = str(codesign_record)
+            env["SIGNED_PROBE_RECORD"] = str(signed_probe_record)
 
             rc = 0
             chunks: list[str] = []
@@ -992,6 +1034,17 @@ class MakefileGateContractTests(unittest.TestCase):
             if codesign_exit == 0:
                 signed_bytes = src.read_bytes() + b"\n# signed\n"
 
+            codesign_invocations = (
+                len(codesign_record.read_text(encoding="utf-8").splitlines())
+                if codesign_record.exists()
+                else 0
+            )
+            signed_probe_invocations = (
+                len(signed_probe_record.read_text(encoding="utf-8").splitlines())
+                if signed_probe_record.exists()
+                else 0
+            )
+
             return RecipeRun(
                 rc=rc,
                 output="\n".join(chunks),
@@ -999,7 +1052,50 @@ class MakefileGateContractTests(unittest.TestCase):
                 installed_bytes=installed_bytes,
                 signed_bytes=signed_bytes,
                 staging_file_left_behind=staged.exists(),
+                codesign_invocations=codesign_invocations,
+                signed_probe_invocations=signed_probe_invocations,
             )
+
+    @staticmethod
+    def _verification_behavior(run: RecipeRun) -> tuple[object, ...]:
+        return (
+            run.rc,
+            run.installed,
+            run.installed_bytes,
+            run.signed_bytes,
+            run.staging_file_left_behind,
+            run.codesign_invocations,
+            run.signed_probe_invocations,
+        )
+
+    def _run_local_recipe_variants(
+        self,
+        *,
+        signed_probe_exit: int = 0,
+        codesign_exit: int = 0,
+        makefile_text: str | None = None,
+    ) -> dict[str, RecipeRun]:
+        runs = {
+            shape: self._run_local_recipe(
+                signed_probe_exit=signed_probe_exit,
+                codesign_exit=codesign_exit,
+                makefile_text=makefile_text,
+                fixture_shape=shape,
+            )
+            for shape in ("bare", "git-dir", "git-file")
+        }
+        bare_behavior = self._verification_behavior(runs["bare"])
+        for shape in ("git-dir", "git-file"):
+            with self.subTest(fixture_shape=shape, check="environment-parity"):
+                self.assertEqual(
+                    self._verification_behavior(runs[shape]),
+                    bare_behavior,
+                    "the local recipe's verification behavior changed with the "
+                    f"checkout environment ({shape})\n"
+                    f"bare run:\n{runs['bare'].output}\n"
+                    f"{shape} run:\n{runs[shape].output}",
+                )
+        return runs
 
     def test_local_dependency_chain_is_build_then_verify_then_install(self) -> None:
         self.assertIn("verify-local-artifact: build-local\n", self.makefile)
@@ -1039,47 +1135,71 @@ class MakefileGateContractTests(unittest.TestCase):
         while probing nothing. Text cannot distinguish a probe from a mention
         of a probe, so the recipe is executed instead.
         """
-        control = self._run_local_recipe(signed_probe_exit=0)
-        self.assertTrue(
-            control.installed,
-            "positive control failed: the recipe must install when every probe "
-            f"passes, but the installed binary was unchanged. rc={control.rc}\n"
-            f"{control.output}",
-        )
-        self.assertEqual(control.rc, 0, control.output)
-        self.assertEqual(
-            control.installed_bytes,
-            control.signed_bytes,
-            "control: the installed bytes must be exactly the signed, probed bytes",
-        )
+        for shape, control in self._run_local_recipe_variants(
+            signed_probe_exit=0
+        ).items():
+            with self.subTest(fixture_shape=shape, probe="passes"):
+                self.assertTrue(
+                    control.installed,
+                    "positive control failed: the recipe must install when every probe "
+                    f"passes, but the installed binary was unchanged. rc={control.rc}\n"
+                    f"{control.output}",
+                )
+                self.assertEqual(control.rc, 0, control.output)
+                self.assertEqual(
+                    control.installed_bytes,
+                    control.signed_bytes,
+                    "control: the installed bytes must be exactly the signed, probed bytes",
+                )
+                self.assertEqual(control.codesign_invocations, 1, control.output)
+                self.assertEqual(control.signed_probe_invocations, 1, control.output)
 
-        mutant = self._run_local_recipe(signed_probe_exit=1)
-        self.assertFalse(
-            mutant.installed,
-            "the post-signing probe FAILED and the binary was installed anyway: "
-            "unverified bytes reached the install path\n" + mutant.output,
-        )
-        self.assertNotEqual(
-            mutant.rc, 0, "a failed signed-artifact probe must exit nonzero\n" + mutant.output
-        )
-        self.assertFalse(
-            mutant.staging_file_left_behind,
-            "the failure path must remove the staged file, not leave it for a "
-            "later run to pick up\n" + mutant.output,
-        )
+        for shape, mutant in self._run_local_recipe_variants(
+            signed_probe_exit=1
+        ).items():
+            with self.subTest(fixture_shape=shape, probe="fails"):
+                self.assertFalse(
+                    mutant.installed,
+                    "the post-signing probe FAILED and the binary was installed anyway: "
+                    "unverified bytes reached the install path\n" + mutant.output,
+                )
+                self.assertNotEqual(
+                    mutant.rc,
+                    0,
+                    "a failed signed-artifact probe must exit nonzero\n" + mutant.output,
+                )
+                self.assertFalse(
+                    mutant.staging_file_left_behind,
+                    "the failure path must remove the staged file, not leave it for a "
+                    "later run to pick up\n" + mutant.output,
+                )
+                self.assertEqual(mutant.codesign_invocations, 1, mutant.output)
+                self.assertEqual(mutant.signed_probe_invocations, 1, mutant.output)
 
     def test_a_signing_failure_cannot_reach_the_install_path(self) -> None:
         """`codesign` failure was previously swallowed by `|| true`. Signing is
         a mutating step inside the install gate, so its failure must abort."""
-        control = self._run_local_recipe(codesign_exit=0)
-        self.assertTrue(control.installed, "positive control failed\n" + control.output)
+        for shape, control in self._run_local_recipe_variants(
+            codesign_exit=0
+        ).items():
+            with self.subTest(fixture_shape=shape, codesign="passes"):
+                self.assertTrue(
+                    control.installed, "positive control failed\n" + control.output
+                )
+                self.assertEqual(control.codesign_invocations, 1, control.output)
+                self.assertEqual(control.signed_probe_invocations, 1, control.output)
 
-        mutant = self._run_local_recipe(codesign_exit=1)
-        self.assertFalse(
-            mutant.installed,
-            "codesign failed and the binary was installed anyway\n" + mutant.output,
-        )
-        self.assertNotEqual(mutant.rc, 0, mutant.output)
+        for shape, mutant in self._run_local_recipe_variants(
+            codesign_exit=1
+        ).items():
+            with self.subTest(fixture_shape=shape, codesign="fails"):
+                self.assertFalse(
+                    mutant.installed,
+                    "codesign failed and the binary was installed anyway\n" + mutant.output,
+                )
+                self.assertNotEqual(mutant.rc, 0, mutant.output)
+                self.assertEqual(mutant.codesign_invocations, 1, mutant.output)
+                self.assertEqual(mutant.signed_probe_invocations, 0, mutant.output)
 
     def test_the_recipe_harness_can_detect_a_reverted_fix(self) -> None:
         """Mutation control for the harness itself. A finding-only instrument
@@ -1101,12 +1221,15 @@ class MakefileGateContractTests(unittest.TestCase):
         end = pre_fix.index("SIGNED_SHA256=")
         pre_fix = pre_fix[:start] + pre_fix[end:]
 
-        reverted = self._run_local_recipe(signed_probe_exit=1, makefile_text=pre_fix)
-        self.assertTrue(
-            reverted.installed,
-            "the harness did not reproduce the original defect, so a green "
-            "result from it is not evidence\n" + reverted.output,
-        )
+        for shape, reverted in self._run_local_recipe_variants(
+            signed_probe_exit=1, makefile_text=pre_fix
+        ).items():
+            with self.subTest(fixture_shape=shape):
+                self.assertTrue(
+                    reverted.installed,
+                    "the harness did not reproduce the original defect, so a green "
+                    "result from it is not evidence\n" + reverted.output,
+                )
 
     def test_cargo_receipt_drives_verifier_and_ci_runs_regression_suite(self) -> None:
         self.assertIn("scripts/build_local_artifact.py", self.makefile)

--- a/scripts/verify_local_artifact.py
+++ b/scripts/verify_local_artifact.py
@@ -1,0 +1,707 @@
+#!/usr/bin/env python3
+"""Fail-closed runtime verification for a freshly built kkernel artifact."""
+
+from __future__ import annotations
+
+import argparse
+from collections import Counter
+import json
+import math
+import os
+from pathlib import Path
+import re
+import select
+import shlex
+import subprocess
+import sys
+import tempfile
+import time
+
+from build_local_artifact import (
+    BuildReceipt,
+    BuildReceiptError,
+    atomic_write,
+    canonical_json,
+    load_build_receipt,
+    sha256_file,
+)
+
+
+STAMP_SCHEMA = 1
+MAX_VERB_COUNT = 1_000_000
+MCP_PROTOCOL_VERSION = "2024-11-05"
+HEX_32 = re.compile(r"[0-9a-f]{32}\Z")
+HEX_64 = re.compile(r"[0-9a-f]{64}\Z")
+
+
+class VerificationError(RuntimeError):
+    pass
+
+
+def positive_int(value: str) -> int:
+    parsed = int(value)
+    if parsed < 1:
+        raise argparse.ArgumentTypeError("must be at least 1")
+    return parsed
+
+
+def positive_float(value: str) -> float:
+    parsed = float(value)
+    if not math.isfinite(parsed) or parsed <= 0:
+        raise argparse.ArgumentTypeError("must be a finite number greater than 0")
+    return parsed
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Probe verbs() on an exact kkernel build artifact before installation."
+    )
+    source = parser.add_mutually_exclusive_group()
+    source.add_argument("--artifact", type=Path)
+    source.add_argument("--build-receipt", type=Path)
+    parser.add_argument("--packs")
+    parser.add_argument("--min-verbs", required=True, type=positive_int)
+    parser.add_argument("--stamp", type=Path)
+    parser.add_argument(
+        "--inspect-stamp",
+        type=Path,
+        help="validate a verified build receipt and emit shell-safe install fields",
+    )
+    parser.add_argument("--timeout-seconds", type=positive_float, default=120.0)
+    args = parser.parse_args()
+    if args.inspect_stamp is not None:
+        if args.build_receipt is None:
+            parser.error("--inspect-stamp requires --build-receipt")
+        if args.artifact is not None or args.packs is not None or args.stamp is not None:
+            parser.error(
+                "--inspect-stamp cannot be combined with --artifact, --packs, or --stamp"
+            )
+    else:
+        if args.artifact is None and args.build_receipt is None:
+            parser.error("one of --artifact or --build-receipt is required")
+        if args.packs is None:
+            parser.error("--packs is required when verifying an artifact")
+    return args
+
+
+def parse_packs(raw: str) -> list[str]:
+    packs = [part.strip() for part in raw.split(",")]
+    if not packs or any(not pack for pack in packs):
+        raise VerificationError("--packs must be a non-empty comma-separated list")
+    if len(set(packs)) != len(packs):
+        raise VerificationError("--packs contains duplicate names")
+    return packs
+
+
+def validate_probe(payload: object, required_packs: list[str], minimum: int) -> int:
+    if not isinstance(payload, dict):
+        raise VerificationError("probe output must be a JSON object")
+    results = payload.get("results")
+    if not isinstance(results, list) or len(results) != 1:
+        raise VerificationError("probe output must contain exactly one result")
+    entry = results[0]
+    if not isinstance(entry, dict) or entry.get("ok") is not True:
+        raise VerificationError("verbs() did not return a successful result")
+    if entry.get("tool") != "verbs":
+        raise VerificationError("probe result does not identify the verbs() operation")
+    if "result" not in entry or "error" in entry:
+        raise VerificationError("verbs() returned an invalid result/error shape")
+    result = entry["result"]
+    if not isinstance(result, dict):
+        raise VerificationError("verbs() result must be an object")
+
+    verbs = result.get("verbs")
+    total = result.get("total")
+    pack_counts = result.get("pack_counts")
+    if not isinstance(verbs, list):
+        raise VerificationError("verbs() result is missing the verb catalog")
+    if (
+        not isinstance(total, int)
+        or isinstance(total, bool)
+        or total < 0
+        or total > MAX_VERB_COUNT
+    ):
+        raise VerificationError("verbs() result has an invalid total")
+    if not isinstance(pack_counts, dict):
+        raise VerificationError("verbs() result is missing pack_counts")
+    if len(verbs) != total:
+        raise VerificationError(
+            f"verbs() total {total} does not match catalog length {len(verbs)}"
+        )
+
+    parsed_counts: dict[str, int] = {}
+    for pack, count in pack_counts.items():
+        if not isinstance(pack, str) or not pack.strip() or pack != pack.strip():
+            raise VerificationError("verbs() pack_counts contains an invalid pack name")
+        if not isinstance(count, int) or isinstance(count, bool) or count < 0:
+            raise VerificationError(
+                f"verbs() pack_counts contains an invalid count for {pack!r}"
+            )
+        parsed_counts[pack] = count
+
+    missing = [pack for pack in required_packs if pack not in parsed_counts]
+    if missing:
+        raise VerificationError(
+            "verbs() omitted requested packs: " + ", ".join(sorted(missing))
+        )
+    unexpected = sorted(set(parsed_counts) - set(required_packs))
+    if unexpected:
+        raise VerificationError(
+            "verbs() returned packs outside the requested vocabulary: "
+            + ", ".join(unexpected)
+        )
+    if sum(parsed_counts.values()) != total:
+        raise VerificationError(
+            f"verbs() pack_counts sum {sum(parsed_counts.values())} does not equal total {total}"
+        )
+
+    observed: Counter[str] = Counter()
+    observed_verbs: set[str] = set()
+    for index, verb in enumerate(verbs):
+        pack_name = verb.get("pack") if isinstance(verb, dict) else None
+        if (
+            not isinstance(verb, dict)
+            or not isinstance(pack_name, str)
+            or not pack_name.strip()
+            or pack_name != pack_name.strip()
+        ):
+            raise VerificationError(
+                f"verbs() catalog entry {index} does not name its pack"
+            )
+        verb_name = verb.get("verb")
+        if (
+            not isinstance(verb_name, str)
+            or not verb_name.strip()
+            or verb_name != verb_name.strip()
+        ):
+            raise VerificationError(
+                f"verbs() catalog entry {index} does not name an exact nonblank verb"
+            )
+        if verb_name in observed_verbs:
+            raise VerificationError(
+                f"verbs() catalog contains duplicate verb {verb_name!r}"
+            )
+        observed_verbs.add(verb_name)
+        observed[pack_name] += 1
+    unknown = sorted(set(observed) - set(parsed_counts))
+    if unknown:
+        raise VerificationError(
+            "verbs() catalog names packs absent from pack_counts: " + ", ".join(unknown)
+        )
+    for pack, count in parsed_counts.items():
+        if observed[pack] != count:
+            raise VerificationError(
+                f"verbs() pack_counts[{pack!r}]={count}, catalog contains {observed[pack]}"
+            )
+
+    if total < minimum:
+        raise VerificationError(
+            f"artifact registered {total} verbs; expected at least {minimum}"
+        )
+    return total
+
+
+def initialize_request() -> dict[str, object]:
+    return {
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "initialize",
+        "params": {
+            "protocolVersion": MCP_PROTOCOL_VERSION,
+            "capabilities": {},
+            "clientInfo": {
+                "name": "khive-local-build-verifier",
+                "version": "1",
+            },
+        },
+    }
+
+
+def initialized_notification() -> dict[str, object]:
+    return {
+        "jsonrpc": "2.0",
+        "method": "notifications/initialized",
+        "params": {},
+    }
+
+
+def tools_call_request() -> dict[str, object]:
+    return {
+        "jsonrpc": "2.0",
+        "id": 2,
+        "method": "tools/call",
+        "params": {
+            "name": "request",
+            "arguments": {"ops": "verbs()", "format": "json"},
+        },
+    }
+
+
+def _probe_timeout(timeout_seconds: float) -> VerificationError:
+    return VerificationError(
+        f"artifact probe timed out after {timeout_seconds:g} seconds"
+    )
+
+
+def _send_mcp_message(
+    process: subprocess.Popen[bytes], message: dict[str, object], stage: str
+) -> None:
+    if process.stdin is None:
+        raise VerificationError(f"artifact probe has no stdin for {stage}")
+    encoded = (json.dumps(message, separators=(",", ":")) + "\n").encode("utf-8")
+    try:
+        process.stdin.write(encoded)
+        process.stdin.flush()
+    except (BrokenPipeError, OSError) as error:
+        raise VerificationError(
+            f"artifact probe closed stdin before {stage}: {error}"
+        ) from error
+
+
+def _read_mcp_message(
+    process: subprocess.Popen[bytes],
+    buffered: bytearray,
+    *,
+    deadline: float,
+    timeout_seconds: float,
+    stage: str,
+) -> object:
+    if process.stdout is None:
+        raise VerificationError(f"artifact probe has no stdout for {stage}")
+    while b"\n" not in buffered:
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            raise _probe_timeout(timeout_seconds)
+        try:
+            ready, _, _ = select.select([process.stdout], [], [], remaining)
+        except InterruptedError:
+            continue
+        except (OSError, ValueError) as error:
+            raise VerificationError(
+                f"artifact probe could not read the {stage} response: {error}"
+            ) from error
+        if not ready:
+            raise _probe_timeout(timeout_seconds)
+        try:
+            chunk = os.read(process.stdout.fileno(), 64 * 1024)
+        except OSError as error:
+            raise VerificationError(
+                f"artifact probe could not read the {stage} response: {error}"
+            ) from error
+        if not chunk:
+            if buffered:
+                raise VerificationError(
+                    f"artifact probe closed stdout with an incomplete {stage} response"
+                )
+            raise VerificationError(
+                f"artifact probe closed stdout before the {stage} response"
+            )
+        buffered.extend(chunk)
+
+    raw_line, _, remainder = buffered.partition(b"\n")
+    buffered[:] = remainder
+    try:
+        line = raw_line.decode("utf-8")
+    except UnicodeDecodeError as error:
+        raise VerificationError(
+            f"artifact probe returned non-UTF-8 JSON for {stage}: {error}"
+        ) from error
+    if not line.strip():
+        raise VerificationError(f"artifact probe returned a blank {stage} response")
+    try:
+        return json.loads(line)
+    except json.JSONDecodeError as error:
+        raise VerificationError(
+            f"artifact probe returned invalid JSON for {stage}: {error}"
+        ) from error
+
+
+def _successful_mcp_result(response: object, expected_id: int, stage: str) -> object:
+    if not isinstance(response, dict) or response.get("jsonrpc") != "2.0":
+        raise VerificationError(
+            f"artifact probe returned an invalid JSON-RPC {stage} response"
+        )
+    response_id = response.get("id")
+    if (
+        not isinstance(response_id, int)
+        or isinstance(response_id, bool)
+        or response_id != expected_id
+    ):
+        raise VerificationError(
+            f"artifact probe returned the wrong id for {stage}: {response_id!r}"
+        )
+    has_result = "result" in response
+    has_error = "error" in response
+    if has_result == has_error:
+        raise VerificationError(
+            f"artifact probe returned an invalid {stage} result/error shape"
+        )
+    if has_error:
+        raise VerificationError(
+            f"artifact probe {stage} returned an MCP error: {response['error']!r}"
+        )
+    return response["result"]
+
+
+def validate_initialize_response(response: object) -> None:
+    result = _successful_mcp_result(response, 1, "initialize")
+    if not isinstance(result, dict):
+        raise VerificationError("artifact probe returned an invalid initialize result")
+    if result.get("protocolVersion") != MCP_PROTOCOL_VERSION:
+        raise VerificationError(
+            "artifact probe initialize result has an invalid protocolVersion"
+        )
+    if not isinstance(result.get("capabilities"), dict):
+        raise VerificationError(
+            "artifact probe initialize result has invalid capabilities"
+        )
+    server_info = result.get("serverInfo")
+    if not isinstance(server_info, dict):
+        raise VerificationError(
+            "artifact probe initialize result is missing serverInfo"
+        )
+    if server_info.get("name") != "khive-mcp":
+        raise VerificationError(
+            "artifact probe initialize result has an unexpected serverInfo.name"
+        )
+    version = server_info.get("version")
+    if not isinstance(version, str) or not version.strip():
+        raise VerificationError(
+            "artifact probe initialize result has an invalid serverInfo.version"
+        )
+
+
+def parse_mcp_probe(response: object) -> object:
+    result = _successful_mcp_result(response, 2, "tools/call")
+    if not isinstance(result, dict):
+        raise VerificationError("artifact probe returned an invalid MCP tool result")
+    is_error = result.get("isError")
+    if is_error is not None and is_error is not False:
+        raise VerificationError("artifact probe returned an MCP tool error")
+    content = result.get("content")
+    if not isinstance(content, list) or len(content) != 1:
+        raise VerificationError("artifact probe must return exactly one text content block")
+    block = content[0]
+    if (
+        not isinstance(block, dict)
+        or block.get("type") != "text"
+        or not isinstance(block.get("text"), str)
+    ):
+        raise VerificationError("artifact probe returned a malformed text content block")
+    try:
+        return json.loads(block["text"])
+    except json.JSONDecodeError as error:
+        raise VerificationError(f"verbs() content is not valid JSON: {error}") from error
+
+
+def _stop_probe(process: subprocess.Popen[bytes]) -> None:
+    if process.stdin is not None:
+        try:
+            process.stdin.close()
+        except OSError:
+            pass
+        process.stdin = None
+    if process.poll() is None:
+        try:
+            process.kill()
+        except ProcessLookupError:
+            pass
+    if process.stdout is not None:
+        process.stdout.close()
+    try:
+        process.wait(timeout=1)
+    except subprocess.TimeoutExpired:
+        # SIGKILL normally makes this immediate. Do not replace the verifier's
+        # bounded protocol failure with an unbounded cleanup wait.
+        pass
+
+
+def _diagnostic_tail(diagnostic: object) -> str:
+    diagnostic.flush()
+    diagnostic.seek(0)
+    raw = diagnostic.read()
+    if not isinstance(raw, bytes):
+        return "no diagnostic output"
+    rendered = raw.decode("utf-8", errors="replace").strip()
+    return rendered[-2000:] or "no diagnostic output"
+
+
+def run_mcp_probe(
+    command: list[str],
+    *,
+    cwd: Path,
+    environment: dict[str, str],
+    timeout_seconds: float,
+) -> object:
+    """Perform the ordered MCP handshake and verbs() call under one deadline."""
+    deadline = time.monotonic() + timeout_seconds
+    with tempfile.TemporaryFile(mode="w+b") as diagnostic:
+        try:
+            process = subprocess.Popen(
+                command,
+                cwd=cwd,
+                env=environment,
+                stdin=subprocess.PIPE,
+                stdout=subprocess.PIPE,
+                stderr=diagnostic,
+            )
+        except OSError as error:
+            raise VerificationError(f"artifact probe could not run: {error}") from error
+
+        buffered = bytearray()
+        try:
+            _send_mcp_message(process, initialize_request(), "initialize request")
+            initialize = _read_mcp_message(
+                process,
+                buffered,
+                deadline=deadline,
+                timeout_seconds=timeout_seconds,
+                stage="initialize",
+            )
+            validate_initialize_response(initialize)
+
+            _send_mcp_message(
+                process,
+                initialized_notification(),
+                "initialized notification",
+            )
+            _send_mcp_message(process, tools_call_request(), "tools/call request")
+            tools_response = _read_mcp_message(
+                process,
+                buffered,
+                deadline=deadline,
+                timeout_seconds=timeout_seconds,
+                stage="tools/call",
+            )
+            payload = parse_mcp_probe(tools_response)
+
+            if process.stdin is not None:
+                process.stdin.close()
+                process.stdin = None
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                raise _probe_timeout(timeout_seconds)
+            try:
+                stdout_tail, _ = process.communicate(timeout=remaining)
+            except subprocess.TimeoutExpired as error:
+                raise _probe_timeout(timeout_seconds) from error
+            if process.returncode != 0:
+                raise VerificationError(
+                    f"artifact probe exited {process.returncode}: "
+                    f"{_diagnostic_tail(diagnostic)}"
+                )
+            if (bytes(buffered) + stdout_tail).strip():
+                raise VerificationError(
+                    "artifact probe returned unexpected output after tools/call"
+                )
+            return payload
+        except BaseException:
+            _stop_probe(process)
+            raise
+
+
+def write_stamp(
+    path: Path,
+    artifact: Path,
+    artifact_hash: str,
+    verb_count: int,
+    build_id: str | None,
+) -> None:
+    if not path.parent.is_dir():
+        raise VerificationError(f"stamp directory does not exist: {path.parent}")
+    if not 1 <= verb_count <= MAX_VERB_COUNT:
+        raise VerificationError("verified verb count is outside the supported range")
+    payload = {
+        "artifact": str(artifact),
+        "build_id": build_id,
+        "schema": STAMP_SCHEMA,
+        "sha256": artifact_hash,
+        "verb_count": verb_count,
+    }
+    atomic_write(path, canonical_json(payload))
+
+
+def load_stamp(path: Path) -> tuple[Path, str, int, str | None]:
+    try:
+        raw = path.read_text(encoding="utf-8")
+        payload = json.loads(raw)
+    except (OSError, UnicodeError, json.JSONDecodeError) as error:
+        raise VerificationError(f"cannot read verification stamp {path}: {error}") from error
+    if not isinstance(payload, dict):
+        raise VerificationError("verification stamp must be a JSON object")
+    expected_keys = {"artifact", "build_id", "schema", "sha256", "verb_count"}
+    if set(payload) != expected_keys:
+        raise VerificationError("verification stamp has an invalid field set")
+    if raw != canonical_json(payload):
+        raise VerificationError("verification stamp is not canonical JSON")
+    schema = payload.get("schema")
+    if (
+        not isinstance(schema, int)
+        or isinstance(schema, bool)
+        or schema != STAMP_SCHEMA
+    ):
+        raise VerificationError("verification stamp has an unsupported schema")
+
+    raw_artifact = payload.get("artifact")
+    if not isinstance(raw_artifact, str) or not raw_artifact or "\x00" in raw_artifact:
+        raise VerificationError("verification stamp has an invalid artifact path")
+    artifact = Path(raw_artifact)
+    if not artifact.is_absolute() or str(artifact.resolve()) != raw_artifact:
+        raise VerificationError("verification stamp artifact path is not canonical")
+
+    artifact_hash = payload.get("sha256")
+    if not isinstance(artifact_hash, str) or HEX_64.fullmatch(artifact_hash) is None:
+        raise VerificationError("verification stamp has an invalid SHA-256")
+    verb_count = payload.get("verb_count")
+    if (
+        not isinstance(verb_count, int)
+        or isinstance(verb_count, bool)
+        or not 1 <= verb_count <= MAX_VERB_COUNT
+    ):
+        raise VerificationError("verification stamp has an invalid bounded verb count")
+    build_id = payload.get("build_id")
+    if build_id is not None and (
+        not isinstance(build_id, str) or HEX_32.fullmatch(build_id) is None
+    ):
+        raise VerificationError("verification stamp has an invalid build_id")
+    return artifact, artifact_hash, verb_count, build_id
+
+
+def inspect_stamp(args: argparse.Namespace) -> str:
+    receipt_path = args.build_receipt.expanduser().resolve()
+    stamp_path = args.inspect_stamp.expanduser().resolve()
+    expected_stamp = receipt_path.with_name(f"{receipt_path.name}.verified")
+    if stamp_path != expected_stamp:
+        raise VerificationError(
+            f"verification stamp must be the build-receipt sidecar {expected_stamp}"
+        )
+    receipt = load_build_receipt(receipt_path)
+    artifact, artifact_hash, verb_count, build_id = load_stamp(stamp_path)
+    if build_id != receipt.build_id:
+        raise VerificationError("verification stamp does not match the current Cargo build")
+    if artifact != receipt.artifact:
+        raise VerificationError("verification stamp names a different Cargo artifact")
+    if artifact_hash != receipt.artifact_hash:
+        raise VerificationError("verification stamp hash differs from the Cargo build receipt")
+    if verb_count < args.min_verbs:
+        raise VerificationError(
+            f"verified verb count {verb_count} is below floor {args.min_verbs}"
+        )
+    return "\n".join(
+        (
+            f"SRC={shlex.quote(str(artifact))}",
+            f"VERIFIED_SHA256={shlex.quote(artifact_hash)}",
+            f"VERIFIED_VERBS={shlex.quote(str(verb_count))}",
+        )
+    )
+
+
+def verify(args: argparse.Namespace) -> tuple[Path, str, int, int]:
+    receipt: BuildReceipt | None = None
+    if args.build_receipt is not None:
+        receipt_path = args.build_receipt.expanduser().resolve()
+        expected_stamp = receipt_path.with_name(f"{receipt_path.name}.verified")
+    else:
+        artifact = args.artifact.expanduser().resolve()
+        expected_stamp = artifact.with_name(f"{artifact.name}.verified")
+    stamp = args.stamp.expanduser().resolve() if args.stamp else None
+    if stamp is not None and stamp != expected_stamp:
+        raise VerificationError(
+            f"verification stamp must be the source sidecar {expected_stamp}"
+        )
+    if stamp is not None:
+        try:
+            stamp.unlink(missing_ok=True)
+        except OSError as error:
+            raise VerificationError(
+                f"cannot remove stale verification stamp: {error}"
+            ) from error
+
+    if args.build_receipt is not None:
+        receipt = load_build_receipt(receipt_path, verify_artifact=False)
+        artifact = receipt.artifact
+
+    if not artifact.is_file():
+        raise VerificationError(f"build artifact is missing: {artifact}")
+    if not os.access(artifact, os.X_OK):
+        raise VerificationError(f"build artifact is not executable: {artifact}")
+    required_packs = parse_packs(args.packs)
+    before_hash = sha256_file(artifact)
+    if receipt is not None and before_hash != receipt.artifact_hash:
+        raise VerificationError(
+            "build artifact changed after Cargo reported it: "
+            f"recorded={receipt.artifact_hash} current={before_hash}"
+        )
+
+    with tempfile.TemporaryDirectory(prefix="khive-build-verify-") as temporary_dir:
+        isolated_root = Path(temporary_dir)
+        config = isolated_root / "khive.toml"
+        config.write_text("", encoding="utf-8")
+        environment = {
+            key: value
+            for key, value in os.environ.items()
+            if not key.startswith("KHIVE_")
+        }
+        environment.update(
+            {
+                "HOME": str(isolated_root),
+                "KHIVE_CONFIG": str(config),
+                "KHIVE_DB": ":memory:",
+                "KHIVE_LOG": "error",
+                "KHIVE_NO_DAEMON": "1",
+                "KHIVE_NO_EMBED": "1",
+                "KHIVE_PACKS": ",".join(required_packs),
+            }
+        )
+        command = [
+            str(artifact),
+            "mcp",
+            "--db",
+            ":memory:",
+            "--config",
+            str(config),
+            "--no-embed",
+            "--log",
+            "error",
+        ]
+        payload = run_mcp_probe(
+            command,
+            cwd=isolated_root,
+            environment=environment,
+            timeout_seconds=args.timeout_seconds,
+        )
+    verb_count = validate_probe(payload, required_packs, args.min_verbs)
+
+    after_hash = sha256_file(artifact)
+    if before_hash != after_hash:
+        raise VerificationError("build artifact changed while its runtime surface was probed")
+    if stamp is not None:
+        write_stamp(
+            stamp,
+            artifact,
+            after_hash,
+            verb_count,
+            receipt.build_id if receipt is not None else None,
+        )
+    return artifact, after_hash, verb_count, len(required_packs)
+
+
+def main() -> int:
+    try:
+        args = parse_args()
+        if args.inspect_stamp is not None:
+            print(inspect_stamp(args))
+            return 0
+        artifact, artifact_hash, verb_count, pack_count = verify(args)
+    except (BuildReceiptError, VerificationError, OSError, ValueError) as error:
+        print(f"==> ERROR: local build verification failed: {error}", file=sys.stderr)
+        return 1
+    print(
+        f"==> Verified build artifact: {artifact} "
+        f"({artifact_hash}, {verb_count} verbs across {pack_count} requested packs)"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
> AI-assisted contribution: Codex prepared this change and PR description.

## Summary

- split the developer install into `build-local`, `verify-local-artifact`, and
  the existing side-effecting `local` step so an unverified binary can never
  replace the installed `kkernel` or stop its daemon
- consume Cargo's JSON artifact event instead of guessing a target path, then
  bind build receipt, runtime verification stamp, and install staging to the
  exact canonical path, build ID, and SHA-256
- perform an isolated, daemonless MCP initialize + `verbs()` probe with one
  deadline and fail closed on malformed protocol/output, pack-count drift,
  missing zero-verb packs, artifact mutation, or fewer than 90 verbs
- add 21 adversarial Python regressions, CI coverage, developer guidance, and
  ADR-026 Amendment 2 documenting the pre-install contract

## Scope

This closes the build-only verification defect. The related zero-downtime
daemon cut-over remains explicitly outside this amendment: `make local` still
replaces the installed binary and then stops the old daemon, but neither side
effect is reachable until the exact staged artifact has passed verification.

## Validation

- [x] Independent exact-head review: **READY, no actionable findings**
- [x] Current-main rebase: parent
  `9f96ca818094ac6afe82f67c75d3a72093d663b6`; stable patch ID unchanged
- [x] `python3 scripts/tests/test_verify_local_artifact.py` (21/21)
- [x] real exact-head `make verify-local-artifact`: 90 verbs across 13 requested
  packs; artifact SHA-256
  `a7564f752d1d448cd9b9b58bcffcae96d1bf565f586b76b981770d33d34dbdd3`
- [x] `cargo test --manifest-path crates/Cargo.toml --workspace`
- [x] `cargo check --manifest-path crates/Cargo.toml --workspace`
- [x] `cargo clippy --manifest-path crates/Cargo.toml --workspace --all-targets -- -D warnings`
- [x] `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- [x] `RUSTDOCFLAGS=-Dwarnings cargo doc --manifest-path crates/Cargo.toml --workspace --no-deps`
- [x] `git diff --check 9f96ca818094ac6afe82f67c75d3a72093d663b6..HEAD`

Closes #1745
