### PR TITLE
fix(knowledge): refill eligible search candidates

### DIFF
--- a/crates/khive-pack-knowledge/docs/api/scoring-and-retrieval.md
+++ b/crates/khive-pack-knowledge/docs/api/scoring-and-retrieval.md
@@ -58,6 +58,36 @@ $$
 \mathrm{RRF}(d) = \sum_{r \in \text{rankers}} \frac{1}{k + \mathrm{rank}_r(d)}
 $$
 
+### Candidate Admission and Degradation
+
+The FTS leg is a recall stage, not the final ranker. It ORs the de-duplicated non-stop query
+terms, including the scorer's singular/plural expansions, so candidates with matching terms
+separated in their text remain eligible for in-memory TF-IDF scoring. FTS candidates are ordered
+by BM25, with slug as a deterministic tie-break. Deletion, status, and atom/domain kind
+eligibility are applied in SQL before the bounded candidate-window `LIMIT`; ineligible rows
+therefore cannot consume the window and hide eligible rows beyond it. The bounded full-scan
+fallback applies the same pre-limit eligibility rules. Status precedence is resolved once for
+candidate admission and final scoring: an explicit `exclude_status` excludes exactly that status,
+so `deprecated` remains eligible unless the resolved policy excludes it; default and
+`include_drafts=true` searches continue to exclude deprecated rows.
+
+ANN-only candidates are hydrated from the canonical atom/domain tables before eligibility or RRF
+admission. If deletion, status, or kind filtering consumes the initial ANN top-k, retrieval widens
+the deterministic ANN prefix until the eligible target is filled or the vector corpus is
+exhausted. Exhaustion is measured on the ANN prefix before fresh-tail deletes are merged, and a
+live vector-store count is not used as a hard serving-bridge bound, so a newly deleted leading
+candidate cannot make a full prefix look exhausted. Ineligible candidates therefore neither
+consume returned slots nor distort eligible RRF ranks. Hydration queries are chunked below
+SQLite's portable bind-variable ceiling. A stale id
+or storage-read failure degrades the candidate pool but does not discard a valid lexical response.
+Unresolved shells are never returned, and a partial response reports the number under
+`degraded.hydration_failures`. The field is omitted when the count is zero. This diagnostic
+composes with `knowledge.suggest`'s existing ANN-unavailable degradation object and is propagated
+through auto-`knowledge.compose` when its internal suggestion is degraded.
+
+Eligibility refill does not override caller-requested score semantics: `min_score` is reapplied
+after status multipliers, so a genuine score-floor rejection may still return fewer than `limit`.
+
 ## Fold (`knowledge.fold`)
 
 Uses a greedy knapsack selector from `khive-fold`. Candidates are sorted by

--- a/crates/khive-pack-knowledge/src/knowledge/ann_degrade_tests.rs
+++ b/crates/khive-pack-knowledge/src/knowledge/ann_degrade_tests.rs
@@ -400,9 +400,9 @@ async fn suggest_sets_ann_unavailable_when_warming_times_out() {
 /// `compose` in auto-mode delegates to `suggest` and must surface
 /// `data["ann_unavailable"] = true` when the underlying `suggest` sets the flag.
 ///
-/// Auto-mode is triggered when `domain_ids` and `atom_ids` are absent.  Because
-/// `suggest` finds no domain hits, `compose` returns early with the no-domains
-/// response, placing `ann_unavailable` in `result["data"]["ann_unavailable"]`.
+/// Auto-mode is triggered when `domain_ids` and `atom_ids` are absent. A live
+/// lexical domain with no members makes compose reach the separate "No atoms
+/// found" early return after degraded suggest has already selected a domain.
 #[tokio::test]
 async fn compose_propagates_ann_unavailable_in_auto_mode() {
     let _serial = TIMEOUT_OVERRIDE_SERIAL.lock().await;
@@ -414,17 +414,18 @@ async fn compose_propagates_ann_unavailable_in_auto_mode() {
 
     registry
         .dispatch(
-            "knowledge.upsert_atoms",
+            "knowledge.upsert_domains",
             json!({
-                "atoms": [{
-                    "slug": "degrade-compose-atom",
-                    "name": "Degrade Compose Atom",
-                    "content": "attention mechanism self-attention transformer encoder decoder positional embedding layer normalization residual connection feed forward dense sparse retrieval vector nearest neighbor"
+                "domains": [{
+                    "slug": "degrade-empty-compose-domain",
+                    "name": "Degrade Empty Compose Domain",
+                    "description": "machine learning neural network transformer attention architecture multi head self attention retrieval composition domain with intentionally empty membership for reliable production operations",
+                    "members": []
                 }]
             }),
         )
         .await
-        .expect("upsert atom");
+        .expect("upsert empty domain");
 
     registry
         .dispatch("knowledge.index", json!({ "rebuild_ann": false }))
@@ -438,7 +439,7 @@ async fn compose_propagates_ann_unavailable_in_auto_mode() {
 
     let token = rt.authorize(Namespace::local()).expect("authorize");
     // Auto-mode requires ≥10 words; no domain_ids/atom_ids.
-    // type_weights are not reached on the ANN-degrade path (returns before section scoring).
+    // type_weights are not reached because the selected domain has no members.
     let result = KnowledgeHandlers::compose(
         &rt,
         &token,
@@ -459,6 +460,10 @@ async fn compose_propagates_ann_unavailable_in_auto_mode() {
         Some(true),
         "compose must propagate ann_unavailable=true from its internal suggest call; \
          got: {result}"
+    );
+    assert_eq!(
+        result["data"]["markdown"], "# Knowledge Briefing\n\nNo atoms found.",
+        "the regression must exercise the empty-member early return; got: {result}"
     );
 }
 
@@ -572,7 +577,7 @@ async fn suggest_reports_degraded_candidates_or_lexical_only_from_ranking_conseq
                     {
                         "slug": "degrade-semantic-domain",
                         "name": "Opaque Systems Domain",
-                        "description": "SEMANTIC_TARGET serving throughput latency batching cache scheduling gpu utilization request queuing parallelism autoscaling deployment topology load balancing production workloads resource management observability reliability"
+                        "description": "SEMANTIC_TARGET speculative serving throughput decoding latency batching inference cache scheduling acceleration gpu utilization techniques request queuing large scale parallelism language aware autoscaling models deployment topology load balancing production workloads resource management observability reliability"
                     },
                     {
                         "slug": "degrade-lexical-collision",

--- a/crates/khive-pack-knowledge/src/knowledge/search.rs
+++ b/crates/khive-pack-knowledge/src/knowledge/search.rs
@@ -32,6 +32,7 @@ use super::KnowledgeHandlers;
 
 // ─── scored hit (internal) ────────────────────────────────────────────────────
 
+#[derive(Clone)]
 struct ScoredHit {
     id: String,
     slug: String,
@@ -53,6 +54,15 @@ enum AnnAvailability {
 struct AnnSearchState {
     hits: Vec<(Uuid, f32)>,
     availability: AnnAvailability,
+    /// Whether the ANN source itself returned fewer than `k` entries.
+    /// Fresh-tail deletes may shrink `hits` afterward without proving that
+    /// deeper ANN candidates do not exist.
+    source_exhausted: bool,
+}
+
+struct FreshTailSearchState {
+    hits: Vec<(Uuid, f32)>,
+    source_exhausted: bool,
 }
 
 async fn merge_fresh_tail_for_search(
@@ -62,17 +72,30 @@ async fn merge_fresh_tail_for_search(
     query_embedding: &[f32],
     k: usize,
     loaded: Option<(Vec<(Uuid, f32)>, u64)>,
-) -> Vec<(Uuid, f32)> {
-    let (candidates, watermark) = match loaded {
-        Some((candidates, watermark)) => (candidates, Some(watermark)),
-        None => (Vec::new(), None),
+) -> FreshTailSearchState {
+    let (candidates, watermark, source_exhausted) = match loaded {
+        Some((candidates, watermark)) => {
+            let source_exhausted = candidates.len() < k;
+            (candidates, Some(watermark), source_exhausted)
+        }
+        None => (Vec::new(), None, true),
     };
     match vamana::fresh_tail_leg(runtime, ann, key, query_embedding, k, watermark).await {
-        vamana::FreshTailOutcome::Ops(ops) => {
-            vamana::merge_fresh_tail(candidates, query_embedding, ops)
-        }
-        vamana::FreshTailOutcome::Replace(replacement) => replacement,
-        vamana::FreshTailOutcome::Skipped => candidates,
+        vamana::FreshTailOutcome::Ops(ops) => FreshTailSearchState {
+            hits: vamana::merge_fresh_tail(candidates, query_embedding, ops),
+            source_exhausted,
+        },
+        vamana::FreshTailOutcome::Replace {
+            candidates,
+            source_exhausted,
+        } => FreshTailSearchState {
+            hits: candidates,
+            source_exhausted,
+        },
+        vamana::FreshTailOutcome::Skipped => FreshTailSearchState {
+            hits: candidates,
+            source_exhausted,
+        },
     }
 }
 
@@ -86,17 +109,20 @@ async fn search_ann_with_warm_wait(
     k: usize,
 ) -> AnnSearchState {
     if let Some(loaded) = vamana::search_loaded_with_seq(ann, key, query_embedding, k).await {
+        let tail =
+            merge_fresh_tail_for_search(runtime, ann, key, query_embedding, k, Some(loaded)).await;
         return AnnSearchState {
-            hits: merge_fresh_tail_for_search(runtime, ann, key, query_embedding, k, Some(loaded))
-                .await,
+            hits: tail.hits,
             availability: AnnAvailability::Ready,
+            source_exhausted: tail.source_exhausted,
         };
     }
     if !vamana::is_warming_not_loaded(ann, key) {
-        let hits = merge_fresh_tail_for_search(runtime, ann, key, query_embedding, k, None).await;
+        let tail = merge_fresh_tail_for_search(runtime, ann, key, query_embedding, k, None).await;
         return AnnSearchState {
-            hits,
+            hits: tail.hits,
             availability: AnnAvailability::Absent,
+            source_exhausted: tail.source_exhausted,
         };
     }
     if vamana::wait_ready(
@@ -113,8 +139,12 @@ async fn search_ann_with_warm_wait(
         } else {
             AnnAvailability::Absent
         };
-        let hits = merge_fresh_tail_for_search(runtime, ann, key, query_embedding, k, loaded).await;
-        return AnnSearchState { hits, availability };
+        let tail = merge_fresh_tail_for_search(runtime, ann, key, query_embedding, k, loaded).await;
+        return AnnSearchState {
+            hits: tail.hits,
+            availability,
+            source_exhausted: tail.source_exhausted,
+        };
     }
 
     let corpus_non_empty =
@@ -122,10 +152,11 @@ async fn search_ann_with_warm_wait(
             .await
             .map(|fingerprint| fingerprint.vector_count > 0)
             .unwrap_or(false);
-    let hits = merge_fresh_tail_for_search(runtime, ann, key, query_embedding, k, None).await;
+    let tail = merge_fresh_tail_for_search(runtime, ann, key, query_embedding, k, None).await;
     AnnSearchState {
-        hits,
+        hits: tail.hits,
         availability: AnnAvailability::WarmingTimedOut { corpus_non_empty },
+        source_exhausted: tail.source_exhausted,
     }
 }
 
@@ -141,7 +172,7 @@ fn normalize_rrf_score(raw: f32, source_count: usize, k: usize) -> f32 {
     (raw / theoretical_max).clamp(0.0, 1.0)
 }
 
-fn fuse_ann_hits(fts_hits: &mut Vec<ScoredHit>, ann_hits: &[(Uuid, f32)], min_score: f32) {
+fn fuse_ann_hits(fts_hits: &mut Vec<ScoredHit>, ann_hits: &[ScoredHit], min_score: f32) {
     let drained: Vec<ScoredHit> = std::mem::take(fts_hits);
 
     let fts_source: Vec<(String, DeterministicScore)> = drained
@@ -154,8 +185,11 @@ fn fuse_ann_hits(fts_hits: &mut Vec<ScoredHit>, ann_hits: &[(Uuid, f32)], min_sc
         .collect();
     let ann_source: Vec<(String, DeterministicScore)> = ann_hits
         .iter()
-        .map(|(uuid, score)| (uuid.to_string(), DeterministicScore::from_f32(*score)))
+        .map(|hit| (hit.id.clone(), DeterministicScore::from_f32(hit.score)))
         .collect();
+    for hit in ann_hits {
+        by_id.entry(hit.id.clone()).or_insert_with(|| hit.clone());
+    }
 
     let source_count = usize::from(!fts_source.is_empty()) + usize::from(!ann_source.is_empty());
     let fused = khive_fusion::reciprocal_rank_fusion(vec![fts_source, ann_source], RRF_K);
@@ -170,18 +204,6 @@ fn fuse_ann_hits(fts_hits: &mut Vec<ScoredHit>, ann_hits: &[(Uuid, f32)], min_sc
         if let Some(mut hit) = by_id.remove(&id) {
             hit.score = score;
             fts_hits.push(hit);
-        } else {
-            fts_hits.push(ScoredHit {
-                id,
-                slug: String::new(),
-                name: String::new(),
-                content: None,
-                tags: None,
-                finalized: false,
-                is_domain: false,
-                status: None,
-                score,
-            });
         }
     }
 }
@@ -189,10 +211,6 @@ fn fuse_ann_hits(fts_hits: &mut Vec<ScoredHit>, ann_hits: &[(Uuid, f32)], min_sc
 // ─── status filtering (post-hydration) ───────────────────────────────────────
 
 /// Remove hits whose `status` is in `exclude_statuses` after hydration.
-///
-/// This is the shared gate for both the SQL path (where exclusion is enforced
-/// in the query) and the ANN-only path (where hydration happens after fusion
-/// and the SQL predicate was never applied to the ANN-sourced IDs).
 fn filter_by_excluded_statuses(hits: &mut Vec<ScoredHit>, exclude_statuses: &[&str]) {
     if exclude_statuses.is_empty() {
         return;
@@ -201,6 +219,36 @@ fn filter_by_excluded_statuses(hits: &mut Vec<ScoredHit>, exclude_statuses: &[&s
         let status = hit.status.as_deref().unwrap_or("");
         !exclude_statuses.contains(&status)
     });
+}
+
+/// Apply the complete public status contract to hydrated hits.
+///
+/// An explicit `status=` is an allowlist, not merely a request to disable the
+/// default exclusions. This distinction is load-bearing for ANN candidates,
+/// which do not pass through the FTS SQL predicate.
+fn filter_hits_by_status(
+    hits: &mut Vec<ScoredHit>,
+    statuses: &[String],
+    exclude_statuses: &[&str],
+) {
+    if statuses.is_empty() {
+        filter_by_excluded_statuses(hits, exclude_statuses);
+        return;
+    }
+
+    hits.retain(|hit| {
+        hit.status
+            .as_deref()
+            .is_some_and(|status| statuses.iter().any(|allowed| allowed == status))
+    });
+}
+
+fn deprecated_allowed_by_status_policy(statuses: &[String], exclude_statuses: &[&str]) -> bool {
+    if statuses.is_empty() {
+        !exclude_statuses.contains(&"deprecated")
+    } else {
+        explicitly_requested_status(statuses, "deprecated")
+    }
 }
 
 // ─── type filtering (post-hydration) ─────────────────────────────────────────
@@ -213,8 +261,8 @@ fn filter_by_excluded_statuses(hits: &mut Vec<ScoredHit>, exclude_statuses: &[&s
 /// - `Some(other)` where other is non-empty keeps only non-domain hits.
 /// - `None` or `Some("")` is a no-op.
 ///
-/// Applied after ANN fusion + hydration so that ANN-sourced hits go through
-/// the same kind gate as SQL-sourced candidates.
+/// Applied to hydrated ANN candidates before fusion/refill and again to the
+/// fused pool as a final shared-source guard.
 fn filter_hits_by_type(hits: &mut Vec<ScoredHit>, type_filter: Option<&str>) {
     let filt = match type_filter {
         Some(f) if !f.is_empty() => f,
@@ -262,11 +310,58 @@ fn enforce_min_score_floor(hits: &mut Vec<ScoredHit>, min_score: f32) {
     hits.retain(|hit| hit.score >= min_score);
 }
 
-// ─── FTS5 phrase quoting ─────────────────────────────────────────────────────
+// ─── FTS5 candidate expression ───────────────────────────────────────────────
 
 fn quote_fts5_phrase(raw_query: &str) -> String {
     let escaped = raw_query.replace('"', "\"\"");
     format!("\"{escaped}\"")
+}
+
+/// Build a recall-oriented FTS expression from the same lexical terms the
+/// in-memory scorer consumes.
+///
+/// FTS is only the candidate generator; TF-IDF remains the ranker. Requiring
+/// the whole raw query as one phrase drops candidates whose matching terms are
+/// separated in the document. OR-ing the de-duplicated, non-stop terms keeps
+/// those non-contiguous matches in the pool for the scorer to judge. Queries
+/// with no scoreable term retain the exact-phrase fallback used by the
+/// exact-name-only path.
+fn fts5_candidate_expression(raw_query: &str) -> String {
+    let mut seen = HashSet::new();
+    let mut terms: Vec<String> = matching::tokenize_field(raw_query)
+        .into_iter()
+        .filter(|term| term.len() >= MIN_TERM_LEN && !is_stop(term))
+        .filter(|term| seen.insert(term.clone()))
+        .collect();
+
+    if terms.is_empty() {
+        quote_fts5_phrase(raw_query)
+    } else {
+        // Candidate recall observes the same singular/plural expansion as the
+        // scorer. The returned set is used by IDF weighting later; expansion's
+        // mutation of `terms` is the only result needed here.
+        let _ = expand_terms(&mut terms);
+        terms
+            .iter()
+            .map(|term| quote_fts5_phrase(term))
+            .collect::<Vec<_>>()
+            .join(" OR ")
+    }
+}
+
+/// SQL eligibility predicate for the public atom/domain kind filter.
+///
+/// Domain mirrors are atoms carrying the exact `type:domain` tag. Applying
+/// this predicate in the FTS/full-scan query is load-bearing: filtering after
+/// `LIMIT` lets the wrong kind consume every candidate slot.
+fn type_eligibility_sql(type_filter: Option<&str>, atom_alias: &str) -> String {
+    match type_filter {
+        Some("domain") => format!(" AND {atom_alias}.tags LIKE '%\"type:domain\"%'"),
+        Some(filter) if !filter.is_empty() => {
+            format!(" AND {atom_alias}.tags NOT LIKE '%\"type:domain\"%'")
+        }
+        _ => String::new(),
+    }
 }
 
 // ─── FTS5 candidate pool fetch ────────────────────────────────────────────────
@@ -286,30 +381,70 @@ async fn fetch_fts_candidates(
         .await
         .map_err(|e| sql_err("search fts reader", e))?;
 
-    let match_expr = quote_fts5_phrase(raw_query);
+    let match_expr = fts5_candidate_expression(raw_query);
+    let (status_clause, status_params) = status_sql_clause(statuses, exclude_statuses, 4);
+    let type_clause = type_eligibility_sql(type_filter, "a");
+    let mut params = vec![
+        SqlValue::Text(match_expr.clone()),
+        SqlValue::Text(ns.to_owned()),
+        SqlValue::Integer(fetch_limit as i64),
+    ];
+    params.extend(status_params);
+
+    // Join the canonical atom row before LIMIT so deleted, status-ineligible,
+    // and wrong-kind FTS rows cannot consume the bounded candidate window.
+    // bm25 orders the eligible matches before the cap; slug is the stable tie
+    // break for equal lexical rank.
     let fts_rows = reader
         .query_all(SqlStatement {
-            sql: "SELECT id FROM fts_knowledge WHERE fts_knowledge MATCH ?1 AND namespace = ?2 LIMIT ?3".into(),
-            params: vec![
-                SqlValue::Text(match_expr),
-                SqlValue::Text(ns.to_owned()),
-                SqlValue::Integer(fetch_limit as i64),
-            ],
+            sql: format!(
+                "SELECT a.* FROM fts_knowledge \
+                 JOIN knowledge_atoms AS a ON a.rowid = fts_knowledge.rowid \
+                 WHERE fts_knowledge MATCH ?1 \
+                   AND fts_knowledge.namespace = ?2 \
+                   AND a.namespace = ?2 \
+                   AND a.deleted_at IS NULL{status_clause}{type_clause} \
+                 ORDER BY bm25(fts_knowledge), a.slug \
+                 LIMIT ?3"
+            ),
+            params,
             label: None,
         })
         .await
         .map_err(|e| sql_err("search fts query", e))?;
 
     if fts_rows.is_empty() {
-        // FTS returned nothing — fall back to full scan (small corpora) capped at CANDIDATE_POOL.
+        // Preserve the fallback's established meaning: it is for a lexical
+        // miss, not for a lexical match whose rows were all ineligible. In the
+        // latter case an empty result is correct; a full scan could otherwise
+        // admit unrelated zero-score rows when min_score is the default 0.
+        let raw_fts_match = reader
+            .query_row(SqlStatement {
+                sql: "SELECT 1 AS present FROM fts_knowledge \
+                      WHERE fts_knowledge MATCH ?1 AND namespace = ?2 LIMIT 1"
+                    .to_string(),
+                params: vec![SqlValue::Text(match_expr), SqlValue::Text(ns.to_owned())],
+                label: None,
+            })
+            .await
+            .map_err(|e| sql_err("search fts eligibility probe", e))?;
+        if raw_fts_match.is_some() {
+            return Ok(Vec::new());
+        }
+
+        // FTS returned nothing — fall back to a bounded full scan. Eligibility
+        // remains inside SQL so the cap is filled from rows the caller can
+        // actually receive.
         let (status_clause, status_params) = status_sql_clause(statuses, exclude_statuses, 3);
+        let type_clause = type_eligibility_sql(type_filter, "a");
         let sql_str = format!(
-            "SELECT * FROM knowledge_atoms WHERE namespace = ?1 AND deleted_at IS NULL{} ORDER BY created_at DESC LIMIT ?2",
-            status_clause
+            "SELECT a.* FROM knowledge_atoms AS a \
+             WHERE a.namespace = ?1 AND a.deleted_at IS NULL{status_clause}{type_clause} \
+             ORDER BY a.created_at DESC, a.slug LIMIT ?2"
         );
         let mut params = vec![
             SqlValue::Text(ns.to_owned()),
-            SqlValue::Integer(CANDIDATE_POOL as i64),
+            SqlValue::Integer(fetch_limit as i64),
         ];
         params.extend(status_params);
 
@@ -322,48 +457,10 @@ async fn fetch_fts_candidates(
             .await
             .map_err(|e| sql_err("search full scan", e))?;
 
-        let mut atoms: Vec<Atom> = rows.iter().filter_map(atom_from_row).collect();
-        if let Some(filt) = type_filter {
-            let want_domain = filt == "domain";
-            atoms.retain(|a| {
-                let tags_arr: Vec<String> = serde_json::from_str(&a.tags).unwrap_or_default();
-                let is_domain = tags_arr.iter().any(|t| t == "type:domain");
-                if want_domain {
-                    is_domain
-                } else {
-                    !is_domain
-                }
-            });
-        }
-        return Ok(atoms);
+        return Ok(rows.iter().filter_map(atom_from_row).collect());
     }
 
-    let ids: Vec<String> = fts_rows.iter().filter_map(|r| row_str(r, "id")).collect();
-    let placeholders: String = ids
-        .iter()
-        .enumerate()
-        .map(|(i, _)| format!("?{}", i + 2))
-        .collect::<Vec<_>>()
-        .join(",");
-
-    let (status_clause, status_params) =
-        status_sql_clause(statuses, exclude_statuses, ids.len() + 2);
-    let mut params: Vec<SqlValue> = vec![SqlValue::Text(ns.to_owned())];
-    params.extend(ids.iter().map(|id| SqlValue::Text(id.clone())));
-    params.extend(status_params);
-
-    let rows = reader
-        .query_all(SqlStatement {
-            sql: format!(
-                "SELECT * FROM knowledge_atoms WHERE namespace = ?1 AND id IN ({placeholders}) AND deleted_at IS NULL{status_clause}"
-            ),
-            params,
-            label: None,
-        })
-        .await
-        .map_err(|e| sql_err("search load atoms", e))?;
-
-    Ok(rows.iter().filter_map(atom_from_row).collect())
+    Ok(fts_rows.iter().filter_map(atom_from_row).collect())
 }
 
 // ─── search context ───────────────────────────────────────────────────────────
@@ -653,41 +750,73 @@ fn cosine_similarity(a: &[f32], b: &[f32]) -> f32 {
 
 // ─── hit hydration ────────────────────────────────────────────────────────────
 
-async fn hydrate_empty_hits(runtime: &KhiveRuntime, ns: &str, hits: &mut Vec<ScoredHit>) {
+// Keep one namespace bind plus the ID binds comfortably below SQLite's
+// portable 999-variable ceiling.
+const HYDRATION_ID_CHUNK: usize = 900;
+
+/// Hydrate ANN-only hit shells from the canonical corpus tables.
+///
+/// Returns the number of candidate rows that could not be hydrated. Missing
+/// rows (for example a stale ANN id) and storage-read failures both degrade the
+/// candidate pool instead of failing an otherwise-useful lexical response, but
+/// unresolved shells are always removed and the count is surfaced to callers.
+async fn hydrate_empty_hits(runtime: &KhiveRuntime, ns: &str, hits: &mut Vec<ScoredHit>) -> usize {
     let ids: Vec<String> = hits
         .iter()
         .filter(|hit| hit.slug.is_empty())
         .map(|hit| hit.id.clone())
         .collect();
     if ids.is_empty() {
-        return;
+        return 0;
     }
 
     let sql = runtime.sql();
     let mut reader = match sql.reader().await {
         Ok(r) => r,
-        Err(_) => return,
+        Err(error) => {
+            tracing::warn!(
+                namespace = ns,
+                requested = ids.len(),
+                error = %error,
+                "knowledge candidate hydration could not acquire a reader"
+            );
+            hits.retain(|hit| !hit.slug.is_empty());
+            return ids.len();
+        }
     };
 
-    let placeholders = ids
-        .iter()
-        .enumerate()
-        .map(|(i, _)| format!("?{}", i + 2))
-        .collect::<Vec<_>>()
-        .join(",");
-    let mut params = vec![SqlValue::Text(ns.to_owned())];
-    params.extend(ids.iter().cloned().map(SqlValue::Text));
+    let mut atom_rows = Vec::new();
+    for chunk in ids.chunks(HYDRATION_ID_CHUNK) {
+        let placeholders = chunk
+            .iter()
+            .enumerate()
+            .map(|(i, _)| format!("?{}", i + 2))
+            .collect::<Vec<_>>()
+            .join(",");
+        let mut params = vec![SqlValue::Text(ns.to_owned())];
+        params.extend(chunk.iter().cloned().map(SqlValue::Text));
 
-    let atom_rows = reader
-        .query_all(SqlStatement {
-            sql: format!(
-                "SELECT id, slug, name, content, tags, finalized, status FROM knowledge_atoms WHERE namespace = ?1 AND id IN ({placeholders}) AND deleted_at IS NULL"
-            ),
-            params,
-            label: None,
-        })
-        .await
-        .unwrap_or_default();
+        match reader
+            .query_all(SqlStatement {
+                sql: format!(
+                    "SELECT id, slug, name, content, tags, finalized, status FROM knowledge_atoms WHERE namespace = ?1 AND id IN ({placeholders}) AND deleted_at IS NULL"
+                ),
+                params,
+                label: None,
+            })
+            .await
+        {
+            Ok(rows) => atom_rows.extend(rows),
+            Err(error) => {
+                tracing::warn!(
+                    namespace = ns,
+                    requested = chunk.len(),
+                    error = %error,
+                    "knowledge atom candidate hydration chunk degraded"
+                );
+            }
+        }
+    }
 
     let mut atom_rows_by_id: HashMap<String, khive_storage::types::SqlRow> = HashMap::new();
     for row in atom_rows {
@@ -719,28 +848,41 @@ async fn hydrate_empty_hits(runtime: &KhiveRuntime, ns: &str, hits: &mut Vec<Sco
         .map(|hit| hit.id.clone())
         .collect();
     if missing_ids.is_empty() {
-        return;
+        return 0;
     }
 
-    let placeholders = missing_ids
-        .iter()
-        .enumerate()
-        .map(|(i, _)| format!("?{}", i + 2))
-        .collect::<Vec<_>>()
-        .join(",");
-    let mut params = vec![SqlValue::Text(ns.to_owned())];
-    params.extend(missing_ids.iter().cloned().map(SqlValue::Text));
+    let mut domain_rows = Vec::new();
+    for chunk in missing_ids.chunks(HYDRATION_ID_CHUNK) {
+        let placeholders = chunk
+            .iter()
+            .enumerate()
+            .map(|(i, _)| format!("?{}", i + 2))
+            .collect::<Vec<_>>()
+            .join(",");
+        let mut params = vec![SqlValue::Text(ns.to_owned())];
+        params.extend(chunk.iter().cloned().map(SqlValue::Text));
 
-    let domain_rows = reader
-        .query_all(SqlStatement {
-            sql: format!(
-                "SELECT id, slug, name, description, tags FROM knowledge_domains WHERE namespace = ?1 AND id IN ({placeholders}) AND deleted_at IS NULL"
-            ),
-            params,
-            label: None,
-        })
-        .await
-        .unwrap_or_default();
+        match reader
+            .query_all(SqlStatement {
+                sql: format!(
+                    "SELECT id, slug, name, description, tags, status FROM knowledge_domains WHERE namespace = ?1 AND id IN ({placeholders}) AND deleted_at IS NULL"
+                ),
+                params,
+                label: None,
+            })
+            .await
+        {
+            Ok(rows) => domain_rows.extend(rows),
+            Err(error) => {
+                tracing::warn!(
+                    namespace = ns,
+                    requested = chunk.len(),
+                    error = %error,
+                    "knowledge domain candidate hydration chunk degraded"
+                );
+            }
+        }
+    }
 
     let mut domain_rows_by_id: HashMap<String, khive_storage::types::SqlRow> = HashMap::new();
     for row in domain_rows {
@@ -757,10 +899,118 @@ async fn hydrate_empty_hits(runtime: &KhiveRuntime, ns: &str, hits: &mut Vec<Sco
             hit.tags = row_str(row, "tags");
             hit.finalized = false;
             hit.is_domain = true;
+            hit.status = row_str(row, "status");
         }
     }
 
+    let failed = hits.iter().filter(|hit| hit.slug.is_empty()).count();
     hits.retain(|hit| !hit.slug.is_empty());
+    if failed > 0 {
+        tracing::warn!(
+            namespace = ns,
+            requested = ids.len(),
+            failed,
+            "knowledge candidate hydration returned a degraded pool"
+        );
+    }
+    failed
+}
+
+/// Add hydration degradation to a response without disturbing another
+/// degradation diagnostic (for example suggest's ANN-unavailable object).
+fn attach_hydration_degradation(out: &mut Value, hydration_failures: usize) {
+    if hydration_failures == 0 {
+        return;
+    }
+
+    if !out
+        .get("degraded")
+        .is_some_and(serde_json::Value::is_object)
+    {
+        out["degraded"] = json!({});
+    }
+    out["degraded"]["hydration_failures"] = json!(hydration_failures);
+}
+
+struct EligibleAnnSearchState {
+    hits: Vec<ScoredHit>,
+    availability: AnnAvailability,
+    hydration_failures: usize,
+}
+
+/// Retrieve an ANN pool whose bounded, rank-preserving truncation happens only
+/// after canonical hydration and caller eligibility.
+///
+/// Vamana has no metadata predicate, so a selective status/kind filter may
+/// consume the first raw top-k. Widen exponentially and re-evaluate the full
+/// deterministic prefix until the eligible target is filled or the vector
+/// corpus is exhausted. The common case performs one ANN search and one
+/// hydration pass; only filtered/invalid prefixes pay for widening.
+async fn search_eligible_ann_with_refill(
+    ctx: &SearchCtx<'_>,
+    token: &NamespaceToken,
+    ann: &vamana::SharedAnn,
+    key: &vamana::AnnKey,
+    query_embedding: &[f32],
+    target_eligible: usize,
+    initial_k: usize,
+) -> EligibleAnnSearchState {
+    let runtime = ctx.runtime;
+    let target_eligible = target_eligible.max(1);
+    let mut request_k = initial_k.max(target_eligible).max(1);
+
+    loop {
+        let AnnSearchState {
+            hits: raw_hits,
+            availability,
+            source_exhausted,
+        } = search_ann_with_warm_wait(runtime, token, ann, key, query_embedding, request_k).await;
+
+        let mut seen = HashSet::with_capacity(raw_hits.len());
+        let mut hits: Vec<ScoredHit> = raw_hits
+            .into_iter()
+            .filter(|(id, _)| seen.insert(*id))
+            .map(|(id, score)| ScoredHit {
+                id: id.to_string(),
+                slug: String::new(),
+                name: String::new(),
+                content: None,
+                tags: None,
+                finalized: false,
+                is_domain: false,
+                status: None,
+                score,
+            })
+            .collect();
+
+        let hydration_failures = hydrate_empty_hits(runtime, ctx.ns, &mut hits).await;
+        filter_hits_by_status(&mut hits, ctx.statuses, ctx.exclude_statuses);
+        filter_hits_by_type(&mut hits, ctx.type_filter);
+
+        if hits.len() >= target_eligible || source_exhausted {
+            hits.truncate(target_eligible);
+            return EligibleAnnSearchState {
+                hits,
+                availability,
+                hydration_failures,
+            };
+        }
+
+        // The live vector-store count is not a sound upper bound for a serving
+        // bridge: a fresh delete removes the canonical vector before its tail
+        // tombstone is merged into that older bridge. Widen until the ANN
+        // source itself proves exhaustion.
+        let next_k = request_k.saturating_mul(2);
+        if next_k == request_k {
+            hits.truncate(target_eligible);
+            return EligibleAnnSearchState {
+                hits,
+                availability,
+                hydration_failures,
+            };
+        }
+        request_k = next_k;
+    }
 }
 
 // ─── compose helpers ──────────────────────────────────────────────────────────
@@ -1304,7 +1554,6 @@ impl KnowledgeHandlers {
 
         let ns = token.namespace().as_str().to_owned();
         let requested_statuses = status_values(p.status.as_ref());
-        let include_deprecated = explicitly_requested_status(&requested_statuses, "deprecated");
 
         // Normalize exclude_status once: trim whitespace, treat blank as absent.
         // This single normalized value feeds both the SQL predicate (via SearchCtx)
@@ -1317,12 +1566,12 @@ impl KnowledgeHandlers {
             .filter(|s| !s.is_empty());
 
         // Precedence (highest to lowest, matches ADR-047 §Status filtering):
-        //   1. explicit status=  → no exclusion; SQL handles the allowlist
+        //   1. explicit status=  → no exclusion; SQL and hydrated ANN use the allowlist
         //   2. no status=, explicit exclude_status= (non-blank) → use that exclusion
         //   3. no status=, include_drafts=true → exclude only deprecated
         //   4. default (no status params / blank exclude_status) → exclude draft and deprecated
-        let exclude_statuses_buf: Vec<&str> = if !requested_statuses.is_empty() {
-            // Caller specified exact status; no exclusion needed — SQL allowlist wins.
+        let effective_exclude_statuses: Vec<&str> = if !requested_statuses.is_empty() {
+            // Caller specified exact status; the shared allowlist wins.
             vec![]
         } else if let Some(ex) = exclude_status_normalized {
             vec![ex]
@@ -1334,6 +1583,12 @@ impl KnowledgeHandlers {
                 vec!["draft", "deprecated"]
             }
         };
+        // The zero multiplier for deprecated is also a final eligibility gate.
+        // Resolve its override from the same precedence policy used before FTS
+        // caps and ANN refill; otherwise explicit exclude_status can admit a
+        // row early only for the multiplier stage to remove it later.
+        let allow_deprecated =
+            deprecated_allowed_by_status_policy(&requested_statuses, &effective_exclude_statuses);
 
         let ctx = SearchCtx {
             runtime,
@@ -1344,7 +1599,7 @@ impl KnowledgeHandlers {
             w: &w,
             fetch_limit,
             statuses: &requested_statuses,
-            exclude_statuses: &exclude_statuses_buf,
+            exclude_statuses: &effective_exclude_statuses,
         };
 
         let mut hits = if do_decompose && non_stop_count >= decompose_threshold {
@@ -1357,21 +1612,21 @@ impl KnowledgeHandlers {
         vamana::ensure_ann_background(runtime, token, ann);
 
         let mut ann_unavailable = false;
+        let mut hydration_failures = 0usize;
         if let Ok(query_emb) = runtime.embed_query(&raw_query).await {
             let ann_k = fetch_limit.max(20);
             let model = runtime.default_embedder_name();
             let key = vamana::AnnKey::new(&ns, model);
-            let AnnSearchState {
+            let EligibleAnnSearchState {
                 hits: ann_hits,
                 availability,
-            } = search_ann_with_warm_wait(runtime, token, ann, &key, &query_emb, ann_k).await;
+                hydration_failures: ann_hydration_failures,
+            } = search_eligible_ann_with_refill(&ctx, token, ann, &key, &query_emb, ann_k, ann_k)
+                .await;
+            hydration_failures += ann_hydration_failures;
 
             if !ann_hits.is_empty() {
                 fuse_ann_hits(&mut hits, &ann_hits, min_score);
-                hydrate_empty_hits(runtime, &ns, &mut hits).await;
-                // ANN-sourced hits bypass the SQL status predicate; apply the
-                // same exclusion policy here so all result sources are consistent.
-                filter_by_excluded_statuses(&mut hits, &exclude_statuses_buf);
             }
             // FTS hits remain valid partial results. Preserve the existing
             // advisory only for a non-empty corpus with no lexical fallback.
@@ -1385,17 +1640,16 @@ impl KnowledgeHandlers {
                 ann_unavailable = true;
             }
         }
-        // Apply the kind gate unconditionally — both FTS-sourced and ANN-sourced
-        // hits must pass the type filter regardless of whether ANN ran.
-        // Previously this was inside the ANN block, so FTS atom hits were never
-        // filtered when ANN was warming or returned no results.
+        // Apply shared eligibility unconditionally so every source observes the
+        // same final status and kind contract even when ANN did not run.
+        filter_hits_by_status(&mut hits, &requested_statuses, &effective_exclude_statuses);
         filter_hits_by_type(&mut hits, type_filter);
 
         if do_rerank && !hits.is_empty() {
             rerank_with_embeddings(runtime, &raw_query, &mut hits, rerank_alpha).await?;
         }
 
-        apply_status_multipliers(&mut hits, include_deprecated);
+        apply_status_multipliers(&mut hits, allow_deprecated);
         enforce_min_score_floor(&mut hits, min_score);
         hits.truncate(limit);
 
@@ -1421,6 +1675,7 @@ impl KnowledgeHandlers {
         if ann_unavailable {
             out["ann_unavailable"] = json!(true);
         }
+        attach_hydration_degradation(&mut out, hydration_failures);
         Ok(out)
     }
 
@@ -1466,6 +1721,7 @@ impl KnowledgeHandlers {
 
         vamana::ensure_ann_background(runtime, token, ann);
         let mut ann_unavailable = false;
+        let mut hydration_failures = 0usize;
         if let Ok(query_emb) = runtime.embed_query(&raw_query).await {
             // Over-fetch aggressively: the corpus is ~27% domains / ~73% atoms, so
             // limit*3 would return mostly atoms that all get dropped after type filtering.
@@ -1474,19 +1730,24 @@ impl KnowledgeHandlers {
             let ann_k = (limit * 50).max(200);
             let model = runtime.default_embedder_name();
             let key = vamana::AnnKey::new(&ns, model);
-            let AnnSearchState {
+            let EligibleAnnSearchState {
                 hits: ann_hits,
                 availability,
-            } = search_ann_with_warm_wait(runtime, token, ann, &key, &query_emb, ann_k).await;
+                hydration_failures: ann_hydration_failures,
+            } = search_eligible_ann_with_refill(
+                &ctx,
+                token,
+                ann,
+                &key,
+                &query_emb,
+                ctx.fetch_limit,
+                ann_k,
+            )
+            .await;
+            hydration_failures += ann_hydration_failures;
 
             if !ann_hits.is_empty() {
                 fuse_ann_hits(&mut hits, &ann_hits, 0.0);
-                hydrate_empty_hits(runtime, &ns, &mut hits).await;
-                // Apply the same status exclusion to ANN-sourced domain hits.
-                filter_by_excluded_statuses(&mut hits, SUGGEST_EXCLUDE);
-                // Drop non-domain ANN hits before rerank/truncate so atom hits do
-                // not crowd out domain hits in the final ranking.
-                filter_hits_by_type(&mut hits, Some("domain"));
             }
             // Suggest always reports degraded candidate recall for a
             // non-empty corpus, even when lexical candidates survived.
@@ -1494,6 +1755,9 @@ impl KnowledgeHandlers {
                 ann_unavailable = corpus_non_empty;
             }
         }
+
+        filter_hits_by_status(&mut hits, &[], SUGGEST_EXCLUDE);
+        filter_hits_by_type(&mut hits, Some("domain"));
 
         let fresh_rerank_applied =
             rerank_with_embeddings(runtime, &raw_query, &mut hits, D_SUGGEST_RERANK_ALPHA).await?;
@@ -1561,6 +1825,7 @@ impl KnowledgeHandlers {
                 "note": note,
             });
         }
+        attach_hydration_degradation(&mut out, hydration_failures);
         Ok(out)
     }
 
@@ -1622,6 +1887,7 @@ impl KnowledgeHandlers {
         let atom_ids_only = domain_ids.is_empty() && !atom_ids.is_empty();
         let blend_kg = p.blend_kg.unwrap_or(true) && !atom_ids_only;
         let mut suggest_ann_unavailable = false;
+        let mut suggest_hydration_failures = 0usize;
         if is_auto {
             let word_count = raw_query.split_whitespace().count();
             if word_count < 10 {
@@ -1670,6 +1936,11 @@ impl KnowledgeHandlers {
                         .get("ann_unavailable")
                         .and_then(|f| f.as_bool())
                         .unwrap_or(false);
+                    suggest_hydration_failures = v
+                        .pointer("/degraded/hydration_failures")
+                        .and_then(Value::as_u64)
+                        .and_then(|count| usize::try_from(count).ok())
+                        .unwrap_or(0);
                     v
                 }
                 Err(e) => {
@@ -1707,6 +1978,7 @@ impl KnowledgeHandlers {
                 if suggest_ann_unavailable {
                     data["ann_unavailable"] = json!(true);
                 }
+                attach_hydration_degradation(&mut data, suggest_hydration_failures);
                 let response = json!({ "status": "ok", "data": data });
                 timing.finish(0);
                 return Ok(response);
@@ -1754,16 +2026,18 @@ impl KnowledgeHandlers {
         }
 
         if ordered_atoms.is_empty() {
-            let response = json!({
-                "status": "ok",
-                "data": {
-                    "query": raw_query,
-                    "markdown": "# Knowledge Briefing\n\nNo atoms found.",
-                    "domains": [],
-                    "atoms": [],
-                    "count": 0,
-                },
+            let mut data = json!({
+                "query": raw_query,
+                "markdown": "# Knowledge Briefing\n\nNo atoms found.",
+                "domains": [],
+                "atoms": [],
+                "count": 0,
             });
+            if suggest_ann_unavailable {
+                data["ann_unavailable"] = json!(true);
+            }
+            attach_hydration_degradation(&mut data, suggest_hydration_failures);
+            let response = json!({ "status": "ok", "data": data });
             timing.finish(0);
             return Ok(response);
         }
@@ -2008,6 +2282,7 @@ impl KnowledgeHandlers {
         if suggest_ann_unavailable {
             data["ann_unavailable"] = json!(true);
         }
+        attach_hydration_degradation(&mut data, suggest_hydration_failures);
 
         let response = json!({
             "status": "ok",
@@ -2045,6 +2320,119 @@ mod tests {
             matches!(err, RuntimeError::InvalidInput(ref msg) if msg.contains("does not match authorized token namespace")),
             "unexpected error: {err:?}"
         );
+    }
+
+    #[test]
+    fn fts_candidate_expression_recalls_non_contiguous_terms() {
+        assert_eq!(
+            fts5_candidate_expression("alpha beta alpha and"),
+            "\"alpha\" OR \"alphas\" OR \"beta\" OR \"betas\""
+        );
+        assert_eq!(fts5_candidate_expression("RAG"), "\"rag\" OR \"rags\"");
+        assert_eq!(
+            fts5_candidate_expression("the and"),
+            "\"the and\"",
+            "stop-only queries retain the exact-phrase fallback"
+        );
+    }
+
+    #[tokio::test]
+    async fn missing_ann_hydration_is_dropped_and_reported() {
+        let runtime = KhiveRuntime::memory().expect("in-memory runtime");
+        let mut hits = vec![ScoredHit {
+            id: "00000000-0000-0000-0000-000000001763".to_string(),
+            slug: String::new(),
+            name: String::new(),
+            content: None,
+            tags: None,
+            finalized: false,
+            is_domain: false,
+            status: None,
+            score: 0.8,
+        }];
+
+        let failures = hydrate_empty_hits(&runtime, "local", &mut hits).await;
+        assert_eq!(failures, 1);
+        assert!(hits.is_empty(), "unhydrated shells must never be returned");
+
+        let mut response = json!({"results": [], "total": 0});
+        attach_hydration_degradation(&mut response, failures);
+        assert_eq!(response["degraded"]["hydration_failures"], 1);
+    }
+
+    #[test]
+    fn zero_hydration_failures_do_not_change_the_response() {
+        let mut response = json!({"results": [], "total": 0});
+        attach_hydration_degradation(&mut response, 0);
+        assert!(response.get("degraded").is_none());
+    }
+
+    #[test]
+    fn hydration_degradation_preserves_existing_diagnostics() {
+        let mut response = json!({
+            "results": [],
+            "total": 0,
+            "degraded": {
+                "reason": "ann_unavailable",
+                "cache_safe": false,
+            }
+        });
+        attach_hydration_degradation(&mut response, 7);
+        assert_eq!(response["degraded"]["reason"], "ann_unavailable");
+        assert_eq!(response["degraded"]["cache_safe"], false);
+        assert_eq!(response["degraded"]["hydration_failures"], 7);
+    }
+
+    #[tokio::test]
+    async fn hydration_chunks_candidate_sets_above_sqlite_bind_ceiling() {
+        let runtime = KhiveRuntime::memory().expect("in-memory runtime");
+        {
+            let access = runtime.sql();
+            let mut writer = access.writer().await.expect("writer");
+            writer
+                .execute(SqlStatement {
+                    sql: "WITH RECURSIVE x(n) AS ( \
+                              VALUES(0) UNION ALL SELECT n + 1 FROM x WHERE n < 20 \
+                          ), y(n) AS ( \
+                              VALUES(0) UNION ALL SELECT n + 1 FROM y WHERE n < 49 \
+                          ) \
+                          INSERT INTO knowledge_atoms ( \
+                              id, namespace, slug, name, content, tags, properties, finalized, \
+                              status, source_uri, source_type, created_at, updated_at, deleted_at \
+                          ) \
+                          SELECT \
+                              printf('70000000-0000-0000-0000-%012d', x.n * 50 + y.n), \
+                              'local', printf('hydrate-%04d', x.n * 50 + y.n), \
+                              printf('Hydrate %04d', x.n * 50 + y.n), 'hydration content', \
+                              '[]', NULL, 1, 'reviewed', NULL, NULL, \
+                              x.n * 50 + y.n, x.n * 50 + y.n, NULL \
+                          FROM x CROSS JOIN y WHERE x.n * 50 + y.n < 1005"
+                        .to_string(),
+                    params: Vec::new(),
+                    label: None,
+                })
+                .await
+                .expect("seed hydration rows");
+        }
+
+        let mut hits: Vec<ScoredHit> = (0..1005)
+            .map(|i| ScoredHit {
+                id: format!("70000000-0000-0000-0000-{i:012}"),
+                slug: String::new(),
+                name: String::new(),
+                content: None,
+                tags: None,
+                finalized: false,
+                is_domain: false,
+                status: None,
+                score: 1.0,
+            })
+            .collect();
+
+        let failures = hydrate_empty_hits(&runtime, "local", &mut hits).await;
+        assert_eq!(failures, 0);
+        assert_eq!(hits.len(), 1005);
+        assert!(hits.iter().all(|hit| hit.slug.starts_with("hydrate-")));
     }
 
     // ── embed-intent regression ───────────────────────────────────────────────
@@ -2098,6 +2486,37 @@ mod tests {
             status: status.map(str::to_string),
             score,
         }
+    }
+
+    #[test]
+    fn explicit_status_is_an_exact_allowlist_for_hydrated_hits() {
+        let mut hits = vec![
+            make_hit("reviewed", Some("reviewed"), 0.9),
+            make_hit("draft", Some("draft"), 0.8),
+            make_hit("deprecated", Some("deprecated"), 0.7),
+            make_hit("missing-status", None, 0.6),
+        ];
+        filter_hits_by_status(&mut hits, &["draft".to_string()], &[]);
+        let ids: Vec<&str> = hits.iter().map(|hit| hit.id.as_str()).collect();
+        assert_eq!(ids, ["draft"]);
+    }
+
+    #[test]
+    fn deprecated_multiplier_gate_uses_resolved_status_policy() {
+        assert!(!deprecated_allowed_by_status_policy(
+            &[],
+            &["draft", "deprecated"]
+        ));
+        assert!(!deprecated_allowed_by_status_policy(&[], &["deprecated"]));
+        assert!(deprecated_allowed_by_status_policy(&[], &["reviewed"]));
+        assert!(!deprecated_allowed_by_status_policy(
+            &["reviewed".to_string()],
+            &[]
+        ));
+        assert!(deprecated_allowed_by_status_policy(
+            &["deprecated".to_string()],
+            &[]
+        ));
     }
 
     #[test]

--- a/crates/khive-pack-knowledge/src/knowledge/vamana.rs
+++ b/crates/khive-pack-knowledge/src/knowledge/vamana.rs
@@ -1748,7 +1748,12 @@ pub(crate) enum FreshTailOutcome {
     /// A compaction mismatch forced current-query segment re-resolution. These
     /// candidates already come from one coherent replacement segment plus its
     /// own tail and must replace, never merge with, the caller's stale list.
-    Replace(Vec<(Uuid, f32)>),
+    Replace {
+        candidates: Vec<(Uuid, f32)>,
+        /// Whether the replacement ANN source returned fewer than the
+        /// requested `k` candidates before its own fresh tail was merged.
+        source_exhausted: bool,
+    },
     /// The exact leg could not run; retain the caller's existing candidates.
     Skipped,
 }
@@ -1768,7 +1773,10 @@ pub(crate) async fn fresh_tail_leg(
         // its Ready ownership.  Do not invalidate the authoritative warm now
         // in flight on every concurrent query; dropping this query's captured
         // candidates is sufficient until that warm replaces the cache.
-        return FreshTailOutcome::Replace(Vec::new());
+        return FreshTailOutcome::Replace {
+            candidates: Vec::new(),
+            source_exhausted: true,
+        };
     }
     if !fresh_tail_enabled() {
         return match read_own_watermark(rt, ns, model).await {
@@ -1781,7 +1789,10 @@ pub(crate) async fn fresh_tail_leg(
                     model,
                     "knowledge ANN registry read failed while fresh-tail was disabled"
                 );
-                FreshTailOutcome::Replace(Vec::new())
+                FreshTailOutcome::Replace {
+                    candidates: Vec::new(),
+                    source_exhausted: true,
+                }
             }
         };
     }
@@ -1809,7 +1820,10 @@ async fn force_cold_after_registry_loss(
         );
     }
     clear_namespace(ann, &key.namespace).await;
-    FreshTailOutcome::Replace(Vec::new())
+    FreshTailOutcome::Replace {
+        candidates: Vec::new(),
+        source_exhausted: true,
+    }
 }
 
 fn ready_snapshot_watermark(snapshot: &FreshTailSnapshot) -> Option<u64> {
@@ -1846,7 +1860,10 @@ async fn fresh_tail_serving(
                 model,
                 "knowledge fresh-tail snapshot failed; dropping stale vector leg"
             );
-            return FreshTailOutcome::Replace(Vec::new());
+            return FreshTailOutcome::Replace {
+                candidates: Vec::new(),
+                source_exhausted: true,
+            };
         }
     };
     let Some(_own_watermark) = ready_snapshot_watermark(&snapshot) else {
@@ -1878,11 +1895,10 @@ async fn fresh_tail_serving(
                 // do not mix those operations with candidates from the older
                 // bridge: return an exact-only replacement vector source.
                 clear_namespace(ann, ns).await;
-                return FreshTailOutcome::Replace(merge_fresh_tail(
-                    Vec::new(),
-                    query,
-                    snapshot.ops,
-                ));
+                return FreshTailOutcome::Replace {
+                    candidates: merge_fresh_tail(Vec::new(), query, snapshot.ops),
+                    source_exhausted: true,
+                };
             }
         }
     }
@@ -1918,7 +1934,10 @@ async fn fresh_tail_reresolve(
                 model,
                 "knowledge fresh-tail published segment disappeared during re-resolution"
             );
-            return FreshTailOutcome::Replace(Vec::new());
+            return FreshTailOutcome::Replace {
+                candidates: Vec::new(),
+                source_exhausted: true,
+            };
         };
         let bridge = match AnnBridge::load(&dir) {
             Ok(bridge) => bridge,
@@ -1930,7 +1949,10 @@ async fn fresh_tail_reresolve(
                     model,
                     "knowledge fresh-tail published segment load failed"
                 );
-                return FreshTailOutcome::Replace(Vec::new());
+                return FreshTailOutcome::Replace {
+                    candidates: Vec::new(),
+                    source_exhausted: true,
+                };
             }
         };
         let loaded_watermark = bridge
@@ -1938,6 +1960,7 @@ async fn fresh_tail_reresolve(
             .last_applied_seq()
             .unwrap_or(expected_watermark);
         let candidates = bridge.search(query, k);
+        let source_exhausted = candidates.len() < k;
 
         let snapshot = match fetch_fresh_tail_snapshot(rt, ns, model, loaded_watermark, None).await
         {
@@ -1950,7 +1973,10 @@ async fn fresh_tail_reresolve(
                     model,
                     "knowledge fresh-tail re-resolution snapshot failed"
                 );
-                return FreshTailOutcome::Replace(Vec::new());
+                return FreshTailOutcome::Replace {
+                    candidates: Vec::new(),
+                    source_exhausted: true,
+                };
             }
         };
         let Some(_own_watermark) = ready_snapshot_watermark(&snapshot) else {
@@ -1959,7 +1985,10 @@ async fn fresh_tail_reresolve(
         let registry_min = nonnegative_registry_min(&snapshot);
 
         if registry_min <= loaded_watermark {
-            return FreshTailOutcome::Replace(merge_fresh_tail(candidates, query, snapshot.ops));
+            return FreshTailOutcome::Replace {
+                candidates: merge_fresh_tail(candidates, query, snapshot.ops),
+                source_exhausted,
+            };
         }
 
         if round == FRESH_TAIL_RERESOLVE_MAX_ROUNDS {
@@ -1971,7 +2000,10 @@ async fn fresh_tail_reresolve(
                 floor = registry_min,
                 "knowledge fresh-tail re-resolution did not converge; using exact-only floored suffix"
             );
-            return FreshTailOutcome::Replace(merge_fresh_tail(Vec::new(), query, snapshot.ops));
+            return FreshTailOutcome::Replace {
+                candidates: merge_fresh_tail(Vec::new(), query, snapshot.ops),
+                source_exhausted: true,
+            };
         }
 
         expected_watermark = registry_min;
@@ -3030,7 +3062,11 @@ mod tests {
 
         let outcome = force_cold_after_registry_loss(&rt, &ann, &key).await;
 
-        assert!(matches!(outcome, FreshTailOutcome::Replace(ref hits) if hits.is_empty()));
+        assert!(matches!(
+            outcome,
+            FreshTailOutcome::Replace { ref candidates, source_exhausted: true }
+                if candidates.is_empty()
+        ));
         assert_eq!(
             read_own_watermark(&rt, namespace, model)
                 .await
@@ -3051,7 +3087,11 @@ mod tests {
 
         let outcome = fresh_tail_leg(&rt, &ann, &key, &[1.0], 1, None).await;
 
-        assert!(matches!(outcome, FreshTailOutcome::Replace(ref hits) if hits.is_empty()));
+        assert!(matches!(
+            outcome,
+            FreshTailOutcome::Replace { ref candidates, source_exhausted: true }
+                if candidates.is_empty()
+        ));
         assert!(
             is_warming_not_loaded(&ann, &key),
             "a concurrent degraded query must not invalidate the authoritative warm"
@@ -4596,7 +4636,7 @@ mod tests {
         let generation_before = current_generation(&ann, "local");
         let outcome = fresh_tail_leg(&rt, &ann, &key, &query, 20, Some(old_watermark)).await;
         let replacement_candidates = match outcome {
-            FreshTailOutcome::Replace(candidates) => candidates,
+            FreshTailOutcome::Replace { candidates, .. } => candidates,
             FreshTailOutcome::Ops(_) => {
                 panic!("a compaction mismatch must replace, not extend, stale candidates")
             }
@@ -4679,7 +4719,11 @@ mod tests {
 
         let outcome = fresh_tail_leg(&rt, &ann, &key, &query, 20, Some(stale_watermark)).await;
         assert!(
-            matches!(outcome, FreshTailOutcome::Replace(ref hits) if hits.is_empty()),
+            matches!(
+                outcome,
+                FreshTailOutcome::Replace { ref candidates, source_exhausted: true }
+                    if candidates.is_empty()
+            ),
             "the query that detects registry loss must discard stale candidates"
         );
         assert!(search_loaded_with_seq(&ann, &key, &query, 20)

--- a/crates/khive-pack-knowledge/tests/search_candidate_refill.rs
+++ b/crates/khive-pack-knowledge/tests/search_candidate_refill.rs
@@ -1,0 +1,650 @@
+//! Regression coverage for knowledge-search candidate refill (#1763).
+//!
+//! These tests exercise the public verb surface against in-memory storage. The
+//! large candidate sets are inserted with bounded recursive CTEs so the tests
+//! cross the real 2,000-row candidate cap without thousands of dispatch calls.
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use khive_pack_kg::KgPack;
+use khive_pack_knowledge::KnowledgePack;
+use khive_runtime::{
+    AllowAllGate, BackendId, EmbedderProvider, KhiveRuntime, RuntimeConfig, RuntimeError,
+    VerbRegistry, VerbRegistryBuilder,
+};
+use khive_storage::{SqlStatement, SqlValue};
+use khive_types::Namespace;
+use lattice_embed::{EmbedError, EmbeddingModel, EmbeddingService};
+use serde_json::{json, Value};
+use uuid::Uuid;
+
+struct Fixture {
+    registry: VerbRegistry,
+    runtime: KhiveRuntime,
+}
+
+impl Fixture {
+    fn new() -> Self {
+        Self::with_runtime(KhiveRuntime::memory().expect("in-memory runtime"))
+    }
+
+    fn with_runtime(runtime: KhiveRuntime) -> Self {
+        let mut builder = VerbRegistryBuilder::new();
+        builder.register(KgPack::new(runtime.clone()));
+        builder.register(KnowledgePack::new(runtime.clone()));
+        let registry = builder.build().expect("registry builds");
+        runtime.install_edge_rules(registry.all_edge_rules());
+        Self { registry, runtime }
+    }
+
+    async fn dispatch(&self, verb: &str, args: Value) -> Result<Value, RuntimeError> {
+        self.registry.dispatch(verb, args).await
+    }
+
+    async fn execute(&self, sql: &str) {
+        let access = self.runtime.sql();
+        let mut writer = access.writer().await.expect("writer");
+        writer
+            .execute(SqlStatement {
+                sql: sql.to_string(),
+                params: Vec::<SqlValue>::new(),
+                label: None,
+            })
+            .await
+            .expect("fixture SQL executes");
+    }
+}
+
+const MODEL_KEY: &str = "all-minilm-l6-v2";
+const EMBEDDING_DIMENSIONS: usize = 384;
+
+/// Deterministic vectors put each test's ineligible prefix ahead of its
+/// eligible tail without relying on approximate-search tie behavior.
+struct RefillVectorService;
+
+fn refill_vector(text: &str) -> Vec<f32> {
+    let mut vector = vec![0.0; EMBEDDING_DIMENSIONS];
+    if text.contains("ANN Deleted Leader") {
+        vector[0] = 1.0;
+    } else if text.contains("ANN Reviewed Prefix") || text.contains("ANN Draft") {
+        vector[0] = 0.98;
+        vector[1] = 0.2;
+    } else if text.contains("ANN Deprecated Tail") || text.contains("ANN Reviewed") {
+        vector[0] = 0.6;
+        vector[1] = 0.8;
+    } else {
+        vector[0] = 1.0;
+    }
+
+    let fixture_ordinal = text
+        .split_whitespace()
+        .find_map(|word| word.parse::<usize>().ok())
+        .unwrap_or(0);
+    vector[2 + fixture_ordinal % (EMBEDDING_DIMENSIONS - 2)] = 0.01;
+    let norm = vector.iter().map(|value| value * value).sum::<f32>().sqrt();
+    for value in &mut vector {
+        *value /= norm;
+    }
+    vector
+}
+
+#[async_trait]
+impl EmbeddingService for RefillVectorService {
+    async fn embed(
+        &self,
+        texts: &[String],
+        _model: EmbeddingModel,
+    ) -> Result<Vec<Vec<f32>>, EmbedError> {
+        Ok(texts.iter().map(|text| refill_vector(text)).collect())
+    }
+
+    async fn embed_query(
+        &self,
+        texts: &[String],
+        _model: EmbeddingModel,
+    ) -> Result<Vec<Vec<f32>>, EmbedError> {
+        Ok(texts
+            .iter()
+            .map(|_| {
+                let mut vector = vec![0.0; EMBEDDING_DIMENSIONS];
+                vector[0] = 1.0;
+                vector
+            })
+            .collect())
+    }
+
+    fn supports_model(&self, _model: EmbeddingModel) -> bool {
+        true
+    }
+
+    fn name(&self) -> &'static str {
+        "candidate-refill-vector"
+    }
+}
+
+struct RefillVectorProvider;
+
+#[async_trait]
+impl EmbedderProvider for RefillVectorProvider {
+    fn name(&self) -> &str {
+        MODEL_KEY
+    }
+
+    fn dimensions(&self) -> usize {
+        EMBEDDING_DIMENSIONS
+    }
+
+    async fn build(&self) -> Result<Arc<dyn EmbeddingService>, RuntimeError> {
+        Ok(Arc::new(RefillVectorService))
+    }
+}
+
+fn runtime_with_embedder() -> KhiveRuntime {
+    let runtime = KhiveRuntime::new(RuntimeConfig {
+        git_write: Default::default(),
+        db_path: None,
+        default_namespace: Namespace::local(),
+        embedding_model: Some(EmbeddingModel::AllMiniLmL6V2),
+        additional_embedding_models: vec![],
+        gate: Arc::new(AllowAllGate),
+        packs: vec!["kg".to_string(), "knowledge".to_string()],
+        backend_id: BackendId::main(),
+        brain_profile: None,
+        visible_namespaces: vec![],
+        allowed_outbound_namespaces: vec![],
+        actor_id: None,
+    })
+    .expect("runtime");
+    runtime.register_embedder(RefillVectorProvider);
+    runtime
+}
+
+fn result_slugs(response: &Value) -> Vec<&str> {
+    response["results"]
+        .as_array()
+        .expect("results array")
+        .iter()
+        .filter_map(|result| result["slug"].as_str())
+        .collect()
+}
+
+#[tokio::test]
+async fn candidate_cap_is_applied_after_status_and_kind_eligibility() {
+    let fixture = Fixture::new();
+
+    // Exactly fill the historical 2,000-row FTS window with drafts. Five
+    // reviewed matches inserted afterward must refill the default-search pool
+    // instead of disappearing behind those ineligible rows.
+    fixture
+        .execute(
+            "WITH RECURSIVE x(n) AS ( \
+                 VALUES(0) UNION ALL SELECT n + 1 FROM x WHERE n < 49 \
+             ), y(n) AS ( \
+                 VALUES(0) UNION ALL SELECT n + 1 FROM y WHERE n < 39 \
+             ) \
+             INSERT INTO knowledge_atoms ( \
+                 id, namespace, slug, name, content, tags, properties, finalized, status, \
+                 source_uri, source_type, created_at, updated_at, deleted_at \
+             ) \
+             SELECT \
+                 printf('10000000-0000-0000-0000-%012d', x.n * 40 + y.n), \
+                 'local', \
+                 printf('status-draft-%04d', x.n * 40 + y.n), \
+                 printf('Status Draft %04d', x.n * 40 + y.n), \
+                 'statusrefill candidate shared terms lexical retrieval ranking corpus', \
+                 '[]', NULL, 0, 'draft', NULL, NULL, \
+                 x.n * 40 + y.n, x.n * 40 + y.n, NULL \
+             FROM x CROSS JOIN y",
+        )
+        .await;
+    fixture
+        .execute(
+            "WITH RECURSIVE n(v) AS ( \
+                 VALUES(0) UNION ALL SELECT v + 1 FROM n WHERE v < 4 \
+             ) \
+             INSERT INTO knowledge_atoms ( \
+                 id, namespace, slug, name, content, tags, properties, finalized, status, \
+                 source_uri, source_type, created_at, updated_at, deleted_at \
+             ) \
+             SELECT \
+                 printf('20000000-0000-0000-0000-%012d', v), \
+                 'local', printf('status-reviewed-%02d', v), printf('Status Reviewed %02d', v), \
+                 'statusrefill candidate shared terms lexical retrieval ranking corpus', \
+                 '[]', NULL, 1, 'reviewed', NULL, NULL, 3000 + v, 3000 + v, NULL \
+             FROM n",
+        )
+        .await;
+
+    let status_response = fixture
+        .dispatch(
+            "knowledge.search",
+            json!({
+                "query": "statusrefill candidate shared terms",
+                "limit": 5,
+                "rerank": false
+            }),
+        )
+        .await
+        .expect("status-refill search succeeds");
+    let status_slugs = result_slugs(&status_response);
+    assert_eq!(status_slugs.len(), 5, "response: {status_response}");
+    assert!(
+        status_slugs
+            .iter()
+            .all(|slug| slug.starts_with("status-reviewed-")),
+        "draft rows must not consume candidate slots: {status_response}"
+    );
+
+    // Fill another 2,000-row window with reviewed non-domain atoms, then add
+    // three reviewed domain mirrors. A domain search must cap after the kind
+    // predicate and return all three mirrors.
+    fixture
+        .execute(
+            "WITH RECURSIVE x(n) AS ( \
+                 VALUES(0) UNION ALL SELECT n + 1 FROM x WHERE n < 49 \
+             ), y(n) AS ( \
+                 VALUES(0) UNION ALL SELECT n + 1 FROM y WHERE n < 39 \
+             ) \
+             INSERT INTO knowledge_atoms ( \
+                 id, namespace, slug, name, content, tags, properties, finalized, status, \
+                 source_uri, source_type, created_at, updated_at, deleted_at \
+             ) \
+             SELECT \
+                 printf('30000000-0000-0000-0000-%012d', x.n * 40 + y.n), \
+                 'local', \
+                 printf('type-atom-%04d', x.n * 40 + y.n), \
+                 printf('Type Atom %04d', x.n * 40 + y.n), \
+                 'typerefill candidate shared terms lexical retrieval ranking corpus', \
+                 '[]', NULL, 1, 'reviewed', NULL, NULL, \
+                 4000 + x.n * 40 + y.n, 4000 + x.n * 40 + y.n, NULL \
+             FROM x CROSS JOIN y",
+        )
+        .await;
+    fixture
+        .execute(
+            "WITH RECURSIVE n(v) AS ( \
+                 VALUES(0) UNION ALL SELECT v + 1 FROM n WHERE v < 2 \
+             ) \
+             INSERT INTO knowledge_atoms ( \
+                 id, namespace, slug, name, content, tags, properties, finalized, status, \
+                 source_uri, source_type, created_at, updated_at, deleted_at \
+             ) \
+             SELECT \
+                 printf('40000000-0000-0000-0000-%012d', v), \
+                 'local', printf('type-domain-%02d', v), printf('Type Domain %02d', v), \
+                 'typerefill candidate shared terms lexical retrieval ranking corpus', \
+                 '[\"type:domain\"]', NULL, 1, 'reviewed', NULL, NULL, \
+                 7000 + v, 7000 + v, NULL \
+             FROM n",
+        )
+        .await;
+
+    let type_response = fixture
+        .dispatch(
+            "knowledge.search",
+            json!({
+                "query": "typerefill candidate shared terms",
+                "kind": "domain",
+                "limit": 3,
+                "rerank": false
+            }),
+        )
+        .await
+        .expect("kind-refill search succeeds");
+    let type_slugs = result_slugs(&type_response);
+    assert_eq!(type_slugs.len(), 3, "response: {type_response}");
+    assert!(
+        type_response["results"]
+            .as_array()
+            .expect("results")
+            .iter()
+            .all(|result| result["kind"] == "domain"),
+        "non-domain rows must not consume candidate slots: {type_response}"
+    );
+}
+
+#[tokio::test]
+async fn explicit_exclude_status_controls_deprecated_fts_eligibility_before_cap() {
+    let fixture = Fixture::new();
+
+    fixture
+        .execute(
+            "WITH RECURSIVE x(n) AS ( \
+                 VALUES(0) UNION ALL SELECT n + 1 FROM x WHERE n < 49 \
+             ), y(n) AS ( \
+                 VALUES(0) UNION ALL SELECT n + 1 FROM y WHERE n < 39 \
+             ) \
+             INSERT INTO knowledge_atoms ( \
+                 id, namespace, slug, name, content, tags, properties, finalized, status, \
+                 source_uri, source_type, created_at, updated_at, deleted_at \
+             ) \
+             SELECT \
+                 printf('41000000-0000-0000-0000-%012d', x.n * 40 + y.n), \
+                 'local', \
+                 printf('zzz-explicit-exclude-deprecated-%04d', x.n * 40 + y.n), \
+                 printf('Final Gate Deprecated %04d', x.n * 40 + y.n), \
+                 'finalgatecap candidate shared terms lexical retrieval ranking corpus', \
+                 '[]', NULL, 1, 'deprecated', NULL, NULL, \
+                 x.n * 40 + y.n, x.n * 40 + y.n, NULL \
+             FROM x CROSS JOIN y",
+        )
+        .await;
+    fixture
+        .execute(
+            "WITH RECURSIVE n(v) AS ( \
+                 VALUES(0) UNION ALL SELECT v + 1 FROM n WHERE v < 4 \
+             ) \
+             INSERT INTO knowledge_atoms ( \
+                 id, namespace, slug, name, content, tags, properties, finalized, status, \
+                 source_uri, source_type, created_at, updated_at, deleted_at \
+             ) \
+             SELECT \
+                 printf('42000000-0000-0000-0000-%012d', v), \
+                 'local', printf('aaa-explicit-exclude-reviewed-%02d', v), \
+                 printf('Final Gate Reviewed %02d', v), \
+                 'finalgatecap candidate shared terms lexical retrieval ranking corpus', \
+                 '[]', NULL, 1, 'reviewed', NULL, NULL, 3000 + v, 3000 + v, NULL \
+             FROM n",
+        )
+        .await;
+
+    let response = fixture
+        .dispatch(
+            "knowledge.search",
+            json!({
+                "query": "finalgatecap candidate shared terms",
+                "exclude_status": "reviewed",
+                "limit": 5,
+                "rerank": false
+            }),
+        )
+        .await
+        .expect("explicit-exclude FTS search succeeds");
+    let results = response["results"].as_array().expect("results");
+    assert_eq!(results.len(), 5, "response: {response}");
+    assert!(
+        results
+            .iter()
+            .all(|result| result["status"] == "deprecated"),
+        "explicit exclude_status must admit deprecated rows through the shared final gate: {response}"
+    );
+}
+
+#[tokio::test]
+async fn lexical_candidate_recall_includes_non_contiguous_query_terms() {
+    let fixture = Fixture::new();
+    fixture
+        .dispatch(
+            "knowledge.upsert_atoms",
+            json!({
+                "atoms": [
+                    {
+                        "slug": "ordered-phrase",
+                        "name": "Ordered Phrase",
+                        "content": "orderedlex alpha beta candidate retrieval scoring corpus ranking semantic search index pipeline model evaluation production monitoring quality relevance precision recall",
+                        "finalized": true
+                    },
+                    {
+                        "slug": "separated-terms",
+                        "name": "Separated Terms",
+                        "content": "orderedlex alpha intervening beta candidate retrieval scoring corpus ranking semantic search index pipeline model evaluation production monitoring quality relevance precision recall",
+                        "finalized": true
+                    }
+                ]
+            }),
+        )
+        .await
+        .expect("seed lexical candidates");
+
+    let response = fixture
+        .dispatch(
+            "knowledge.search",
+            json!({
+                "query": "orderedlex alpha beta",
+                "limit": 10,
+                "rerank": false
+            }),
+        )
+        .await
+        .expect("lexical search succeeds");
+    let slugs = result_slugs(&response);
+    assert!(slugs.contains(&"ordered-phrase"), "response: {response}");
+    assert!(
+        slugs.contains(&"separated-terms"),
+        "a matching term gap must not remove a candidate before ranking: {response}"
+    );
+}
+
+#[tokio::test]
+async fn ann_refill_survives_fresh_tail_delete_from_full_prefix() {
+    let fixture = Fixture::with_runtime(runtime_with_embedder());
+
+    // The first ANN request for limit=5 is k=20. A deleted leader and 24
+    // draft vectors precede five reviewed atoms. The fresh delete shrinks the
+    // merged first prefix to 19 without exhausting the underlying ANN index;
+    // reviewed results require widening despite that post-tail shortfall.
+    fixture
+        .execute(
+            "INSERT INTO knowledge_atoms ( \
+                 id, namespace, slug, name, content, tags, properties, finalized, status, \
+                 source_uri, source_type, created_at, updated_at, deleted_at \
+             ) VALUES ( \
+                 '50000000-0000-0000-0000-000000000000', 'local', \
+                 'ann-deleted-leader', 'ANN Deleted Leader', \
+                 'annstatus blocker lexical query fresh deletion candidate prefix', \
+                 '[]', NULL, 0, 'draft', NULL, NULL, 0, 0, NULL \
+             )",
+        )
+        .await;
+    fixture
+        .execute(
+            "WITH RECURSIVE n(v) AS ( \
+                 VALUES(0) UNION ALL SELECT v + 1 FROM n WHERE v < 23 \
+             ) \
+             INSERT INTO knowledge_atoms ( \
+                 id, namespace, slug, name, content, tags, properties, finalized, status, \
+                 source_uri, source_type, created_at, updated_at, deleted_at \
+             ) \
+             SELECT \
+                 printf('50100000-0000-0000-0000-%012d', v), \
+                 'local', printf('ann-draft-%02d', v), printf('ANN Draft %02d', v), \
+                 'annstatus blocker lexical query ineligible prefix candidate', \
+                 '[]', NULL, 0, 'draft', NULL, NULL, 100 + v, 100 + v, NULL \
+             FROM n",
+        )
+        .await;
+    fixture
+        .execute(
+            "WITH RECURSIVE n(v) AS ( \
+                 VALUES(0) UNION ALL SELECT v + 1 FROM n WHERE v < 4 \
+             ) \
+             INSERT INTO knowledge_atoms ( \
+                 id, namespace, slug, name, content, tags, properties, finalized, status, \
+                 source_uri, source_type, created_at, updated_at, deleted_at \
+             ) \
+             SELECT \
+                 printf('60000000-0000-0000-0000-%012d', v), \
+                 'local', printf('ann-reviewed-%02d', v), printf('ANN Reviewed %02d', v), \
+                 'opaque semantic vector document with no shared candidate vocabulary', \
+                 '[]', NULL, 1, 'reviewed', NULL, NULL, 200 + v, 200 + v, NULL \
+             FROM n",
+        )
+        .await;
+
+    let index = fixture
+        .dispatch("knowledge.index", json!({"rebuild_ann": true}))
+        .await
+        .expect("ANN index builds");
+    assert_eq!(index["indexed"], 30, "index response: {index}");
+
+    let token = fixture
+        .runtime
+        .authorize(Namespace::local())
+        .expect("authorize vector deletion");
+    let deleted = fixture
+        .runtime
+        .vectors(&token)
+        .expect("vector store")
+        .delete(Uuid::parse_str("50000000-0000-0000-0000-000000000000").expect("uuid"))
+        .await
+        .expect("delete leading vector");
+    assert!(deleted, "fixture leader vector must exist");
+    fixture
+        .execute(
+            "UPDATE knowledge_atoms SET deleted_at = 1 \
+             WHERE id = '50000000-0000-0000-0000-000000000000'",
+        )
+        .await;
+
+    let response = fixture
+        .dispatch(
+            "knowledge.search",
+            json!({
+                "query": "annstatus blocker lexical query",
+                "status": "reviewed",
+                "limit": 5,
+                "rerank": false
+            }),
+        )
+        .await
+        .expect("ANN refill search succeeds");
+    let results = response["results"].as_array().expect("results");
+    assert_eq!(results.len(), 5, "response: {response}");
+    assert!(
+        results.iter().all(|result| result["status"] == "reviewed"),
+        "explicit status must gate ANN candidates exactly: {response}"
+    );
+    assert!(
+        results.iter().all(|result| result["slug"]
+            .as_str()
+            .is_some_and(|slug| slug.starts_with("ann-reviewed-"))),
+        "eligible ANN candidates beyond the initial top-k must refill the pool: {response}"
+    );
+}
+
+#[tokio::test]
+async fn explicit_exclude_status_controls_deprecated_ann_refill_and_final_gate() {
+    let fixture = Fixture::with_runtime(runtime_with_embedder());
+    fixture
+        .execute(
+            "WITH RECURSIVE n(v) AS ( \
+                 VALUES(0) UNION ALL SELECT v + 1 FROM n WHERE v < 24 \
+             ) \
+             INSERT INTO knowledge_atoms ( \
+                 id, namespace, slug, name, content, tags, properties, finalized, status, \
+                 source_uri, source_type, created_at, updated_at, deleted_at \
+             ) \
+             SELECT \
+                 printf('61000000-0000-0000-0000-%012d', v), \
+                 'local', printf('ann-reviewed-prefix-%02d', v), \
+                 printf('ANN Reviewed Prefix %02d', v), \
+                 'annexclude blocker lexical query reviewed candidate prefix', \
+                 '[]', NULL, 1, 'reviewed', NULL, NULL, v, v, NULL \
+             FROM n",
+        )
+        .await;
+    fixture
+        .execute(
+            "WITH RECURSIVE n(v) AS ( \
+                 VALUES(0) UNION ALL SELECT v + 1 FROM n WHERE v < 4 \
+             ) \
+             INSERT INTO knowledge_atoms ( \
+                 id, namespace, slug, name, content, tags, properties, finalized, status, \
+                 source_uri, source_type, created_at, updated_at, deleted_at \
+             ) \
+             SELECT \
+                 printf('62000000-0000-0000-0000-%012d', v), \
+                 'local', printf('ann-deprecated-tail-%02d', v), \
+                 printf('ANN Deprecated Tail %02d', v), \
+                 'opaque semantic vector document without shared query vocabulary', \
+                 '[]', NULL, 1, 'deprecated', NULL, NULL, 100 + v, 100 + v, NULL \
+             FROM n",
+        )
+        .await;
+    let index = fixture
+        .dispatch("knowledge.index", json!({"rebuild_ann": true}))
+        .await
+        .expect("ANN index builds");
+    assert_eq!(index["indexed"], 30, "index response: {index}");
+
+    let response = fixture
+        .dispatch(
+            "knowledge.search",
+            json!({
+                "query": "annexclude blocker lexical query",
+                "exclude_status": "reviewed",
+                "limit": 5,
+                "rerank": false
+            }),
+        )
+        .await
+        .expect("ANN explicit-exclude refill succeeds");
+    let results = response["results"].as_array().expect("results");
+    assert_eq!(results.len(), 5, "response: {response}");
+    assert!(
+        results
+            .iter()
+            .all(|result| result["status"] == "deprecated"),
+        "deprecated ANN rows admitted by explicit exclude_status must refill and survive scoring: {response}"
+    );
+}
+
+#[tokio::test]
+async fn auto_compose_propagates_suggest_hydration_degradation() {
+    let fixture = Fixture::with_runtime(runtime_with_embedder());
+    fixture
+        .dispatch(
+            "knowledge.upsert_domains",
+            json!({
+                "domains": [
+                    {
+                        "slug": "stale-compose-domain",
+                        "name": "Stale Compose Domain",
+                        "description": "semantic retrieval ranking fusion candidate hydration degradation propagation for automatic composition across vector search and canonical storage boundaries in production systems",
+                        "members": []
+                    },
+                    {
+                        "slug": "live-empty-compose-domain",
+                        "name": "Live Empty Compose Domain",
+                        "description": "semantic retrieval ranking fusion candidate hydration degradation propagation for automatic composition across vector search and canonical storage boundaries in production systems",
+                        "members": []
+                    }
+                ]
+            }),
+        )
+        .await
+        .expect("seed stale and live empty domains");
+    let index = fixture
+        .dispatch("knowledge.index", json!({"rebuild_ann": true}))
+        .await
+        .expect("ANN index builds");
+    assert_eq!(index["indexed"], 2, "index response: {index}");
+
+    // Leave the loaded ANN slot intact while making its canonical id stale.
+    fixture
+        .execute("UPDATE knowledge_atoms SET deleted_at = 1 WHERE slug = 'stale-compose-domain'")
+        .await;
+    fixture
+        .execute("UPDATE knowledge_domains SET deleted_at = 1 WHERE slug = 'stale-compose-domain'")
+        .await;
+
+    let response = fixture
+        .dispatch(
+            "knowledge.compose",
+            json!({
+                "query": "explain semantic retrieval ranking fusion candidate hydration degradation propagation across automatic knowledge composition"
+            }),
+        )
+        .await
+        .expect("auto-compose returns a degraded response");
+    assert_eq!(
+        response["data"]["degraded"]["hydration_failures"], 1,
+        "compose must preserve internal suggest degradation: {response}"
+    );
+    assert_eq!(
+        response["data"]["markdown"], "# Knowledge Briefing\n\nNo atoms found.",
+        "the regression must exercise the empty-member early return: {response}"
+    );
+    assert_eq!(response["data"]["count"], 0, "response: {response}");
+}


### PR DESCRIPTION
> AI-assisted contribution: Codex prepared this change and PR description.

## Summary

- apply deletion, status, and atom/domain eligibility before bounded FTS and
  full-scan candidate caps, and use a recall-oriented FTS expression so
  non-contiguous matching terms reach the scorer
- hydrate ANN candidates before fusion, widen the deterministic ANN prefix
  until the eligible target is filled or the source is truly exhausted, and
  preserve fresh-tail deletion semantics while doing so
- drop unresolved ANN shells, query hydration IDs below SQLite's bind ceiling,
  and surface partial hydration as `degraded.hydration_failures`
- propagate ANN and hydration degradation through `knowledge.suggest` and
  auto-`knowledge.compose`, including both empty-result return paths
- align explicit `status` / `exclude_status` handling across FTS, ANN, final
  filtering, and deprecated scoring

## Contract notes

Eligibility refill does not override score semantics: status multipliers and
`min_score` still run after fusion, so genuine score-floor rejection may return
fewer than `limit`. Hydration degradation is additive and omitted when zero.

## Validation

- [x] Independent post-repair review: **READY, no actionable findings**
- [x] Current-main parent: `9f96ca818094ac6afe82f67c75d3a72093d663b6`
- [x] Focused ANN-degradation tests (6/6)
- [x] Candidate-refill integration tests (6/6)
- [x] `cargo test --manifest-path crates/Cargo.toml --workspace`
- [x] `cargo check --manifest-path crates/Cargo.toml --workspace`
- [x] `cargo clippy --manifest-path crates/Cargo.toml --workspace --all-targets -- -D warnings`
- [x] `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- [x] `RUSTDOCFLAGS=-Dwarnings cargo doc --manifest-path crates/Cargo.toml --workspace --no-deps`
- [x] `git diff --check 9f96ca818094ac6afe82f67c75d3a72093d663b6..HEAD`

Closes #1763
