### PR TITLE
feat(retrieval): add reproducible quality evaluation

### DIFF
--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -2229,6 +2229,7 @@ dependencies = [
  "sha2",
  "tempfile",
  "tokio",
+ "toml",
  "tracing",
  "uuid",
 ]

--- a/crates/khive-pack-knowledge/Cargo.toml
+++ b/crates/khive-pack-knowledge/Cargo.toml
@@ -32,6 +32,7 @@ uuid = { workspace = true }
 tracing = { workspace = true }
 chrono = { workspace = true }
 sha2 = { workspace = true }
+toml = { workspace = true }
 
 [dev-dependencies]
 khive-pack-kg = { version = "0.7.0", path = "../khive-pack-kg" }

--- a/crates/khive-pack-knowledge/benches/knowledge_bench.rs
+++ b/crates/khive-pack-knowledge/benches/knowledge_bench.rs
@@ -40,6 +40,7 @@ fn build_registry(rt: KhiveRuntime) -> VerbRegistry {
     builder.register(KgPack::new(rt.clone()));
     builder.register(KnowledgePack::new(rt.clone()));
     let registry = builder.build().expect("registry");
+    registry.apply_schema_plans(rt.backend());
     rt.install_edge_rules(registry.all_edge_rules());
     registry
 }
@@ -202,8 +203,12 @@ fn bench_stats(c: &mut Criterion) {
     seed_atoms(&registry, &rt_tokio, 50);
 
     group.bench_function("stats_query", |b| {
-        b.to_async(&rt_tokio)
-            .iter(|| registry.dispatch("knowledge.stats", black_box(json!({}))));
+        b.to_async(&rt_tokio).iter(|| async {
+            registry
+                .dispatch("knowledge.stats", black_box(json!({})))
+                .await
+                .expect("knowledge.stats benchmark dispatch")
+        });
     });
 
     group.finish();

--- a/crates/khive-pack-knowledge/docs/design.md
+++ b/crates/khive-pack-knowledge/docs/design.md
@@ -9,6 +9,8 @@
 - **Section tier** — structured subsections per atom (10-value closed enum: overview, core_model,
   boundary_conditions, formalism, operational_guidance, examples, failure_modes, expert_lens,
   references, other)
+- **Evaluation tier** — operator-triggered, draft-inclusive retrieval evaluation with summaries
+  stored in the pack-owned `knowledge_eval_runs` table
 - **KG concept tier** — `learn` / `cite` / `topic` verbs as sugar over the KG entity layer
 
 ## ADR Compliance
@@ -47,15 +49,27 @@
 - `KnowledgePackFactory` is submitted via `inventory::submit!` so the runtime can discover and
   load this pack by name without explicit wiring. `REQUIRES = ["kg"]` declares the dependency.
 
+### Retrieval Quality Measurement (ADR-082)
+
+- `knowledge.eval_retrieval` is an operator-only `Subhandler`, so it does not change the 19-verb
+  MCP surface. It searches only atoms at a fixed k of 5 and includes drafts so retrieval quality
+  remains independent of finalization coverage.
+- Query-set validation is fail-fast. Successful runs persist namespace-scoped aggregate
+  precision, recall, and MRR for `knowledge.stats`. Query-set paths must be absolute and are
+  canonicalized before reads and persistence so daemon launch directories cannot change a run.
+
 ### Edge Ontology (ADR-002)
 
 - `knowledge.cite` creates an `introduced_by` edge from a concept entity to a source entity
   (document, person, or org). The edge direction is concept → source.
 
-### Schema Migration (ADR-015)
+### Schema Ownership (ADR-015, ADR-028)
 
 - Corpus tables (`knowledge_atoms`, `knowledge_domains`) are added in V19 migration.
 - Section table (`knowledge_sections`) is added in a subsequent migration.
+- `knowledge_eval_runs` is auxiliary Knowledge-pack state declared through the pack's static and
+  runtime schema plans. Centralized startup applies its idempotent DDL to the backend assigned to
+  Knowledge; it does not claim a core migration-ledger version.
 
 ### ADR-016: Request DSL
 
@@ -64,10 +78,6 @@
 
 ## Consistency Notes
 
-- `knowledge/mod.rs` exceeds the 700-line soft limit by design. The corpus handler logic is
-  kept together to avoid requiring ~30 private helpers to become `pub(crate)` and to avoid
-  duplicating context structs across submodules. This will be revisited when the section-read
-  verb surface stabilizes.
 - `knowledge/vamana.rs` also exceeds 700 lines by design: the ANN lifecycle (SharedAnn type,
   snapshot persistence, build, search) is tightly coupled through the shared `AnnState`
   generation and warm-ownership locks and cannot be split without obscuring their ordering.
@@ -76,15 +86,17 @@
 
 ## Module Boundaries
 
-| Module                  | Responsibility                                                               |
-| ----------------------- | ---------------------------------------------------------------------------- |
-| `lib.rs`                | Pack registration, `Pack` trait impl, `PackRuntime::dispatch` shim           |
-| `vocab.rs`              | `KNOWLEDGE_HANDLERS` static array — 19 verb descriptors                      |
-| `handlers.rs`           | `learn`, `cite`, `topic` verbs (KG concept tier sugar)                       |
-| `knowledge/mod.rs`      | Corpus handler implementations (19 verbs) and all shared SQL/scoring helpers |
-| `knowledge/schema.rs`   | Param and record types for serde deserialization and SQL row mapping         |
-| `knowledge/vamana.rs`   | Shared Vamana ANN index lifecycle (warm-start, build, search, RRF fusion)    |
-| `knowledge/matching.rs` | TF-IDF term matching primitives (tokenize, exact match, count)               |
+| Module                  | Responsibility                                                              |
+| ----------------------- | --------------------------------------------------------------------------- |
+| `lib.rs`                | Public exports and the operator-facing `reindex_knowledge` library entry    |
+| `pack.rs`               | Pack registration, `Pack` trait impl, `PackRuntime::dispatch` shim          |
+| `vocab.rs`              | Pack schema statements and 20 handler descriptors (19 verbs + 1 subhandler) |
+| `handlers.rs`           | `learn`, `cite`, `topic` verbs (KG concept tier sugar)                      |
+| `knowledge/mod.rs`      | Knowledge handler module boundaries and shared exports                      |
+| `knowledge/eval.rs`     | Offline query-set validation, atom retrieval scoring, and run persistence   |
+| `knowledge/schema.rs`   | Param and record types for serde deserialization and SQL row mapping        |
+| `knowledge/vamana.rs`   | Shared Vamana ANN index lifecycle (warm-start, build, search, RRF fusion)   |
+| `knowledge/matching.rs` | TF-IDF term matching primitives (tokenize, exact match, count)              |
 
 ## Namespace Isolation
 
@@ -98,9 +110,13 @@ Nested profile dispatches preserve the authorized token's per-request actor and 
 pack calls must present a matching authorized token, whose visibility is then narrowed to the
 one explicit namespace. An absent parameter preserves the existing caller-token scope.
 Other corpus handlers continue to consume the registry's transport-level namespace routing.
+The evaluation runner derives the same token namespace for draft-inclusive search and persisted
+run summaries; `knowledge.stats` reads only summaries from that namespace.
 
 ## Test Coverage
 
 - `tests/integration.rs` — full verb surface, happy path + edge cases
 - `tests/fixes.rs` — targeted regression coverage for audit-identified invariants
+- `tests/eval_retrieval.rs` — schema routing/idempotence, validation, draft-corpus scoring,
+  persistence, and namespace isolation
 - `tests/bench.rs` — warm-latency smoke test (ignored by default; see `docs/benchmarks.md`)

--- a/crates/khive-pack-knowledge/docs/design.md
+++ b/crates/khive-pack-knowledge/docs/design.md
@@ -90,7 +90,7 @@
 | ----------------------- | --------------------------------------------------------------------------- |
 | `lib.rs`                | Public exports and the operator-facing `reindex_knowledge` library entry    |
 | `pack.rs`               | Pack registration, `Pack` trait impl, `PackRuntime::dispatch` shim          |
-| `vocab.rs`              | Pack schema statements and 20 handler descriptors (19 verbs + 1 subhandler) |
+| `vocab.rs`              | Pack schema statements and the handler descriptor table (19 public verbs + 1 subhandler) |
 | `handlers.rs`           | `learn`, `cite`, `topic` verbs (KG concept tier sugar)                      |
 | `knowledge/mod.rs`      | Knowledge handler module boundaries and shared exports                      |
 | `knowledge/eval.rs`     | Offline query-set validation, atom retrieval scoring, and run persistence   |

--- a/crates/khive-pack-knowledge/src/knowledge/crud.rs
+++ b/crates/khive-pack-knowledge/src/knowledge/crud.rs
@@ -742,6 +742,26 @@ impl KnowledgeHandlers {
             .await
             .map_err(|e| sql_err("stats events", e))?;
 
+        let retrieval_eval_run_count = reader
+            .query_scalar(SqlStatement {
+                sql: "SELECT COUNT(*) FROM knowledge_eval_runs WHERE namespace = ?1".into(),
+                params: vec![SqlValue::Text(ns.clone())],
+                label: Some("knowledge.stats.eval_run_count".into()),
+            })
+            .await
+            .map_err(|e| sql_err("stats eval run count", e))?;
+
+        let latest_retrieval_eval = reader
+            .query_row(SqlStatement {
+                sql: "SELECT run_at, precision_at_5, mrr FROM knowledge_eval_runs \
+                      WHERE namespace = ?1 ORDER BY run_at DESC, rowid DESC LIMIT 1"
+                    .into(),
+                params: vec![SqlValue::Text(ns.clone())],
+                label: Some("knowledge.stats.latest_eval_run".into()),
+            })
+            .await
+            .map_err(|e| sql_err("stats latest eval run", e))?;
+
         let total_atoms = match atom_count {
             Some(SqlValue::Integer(n)) => n,
             _ => 0,
@@ -758,6 +778,33 @@ impl KnowledgeHandlers {
             Some(SqlValue::Integer(n)) => n,
             _ => 0,
         };
+        let retrieval_eval_run_count = match retrieval_eval_run_count {
+            Some(SqlValue::Integer(n)) => n,
+            _ => 0,
+        };
+        let retrieval_eval_coverage = latest_retrieval_eval
+            .as_ref()
+            .and_then(|row| match row.get("precision_at_5") {
+                Some(SqlValue::Float(value)) => Some(*value),
+                Some(SqlValue::Integer(value)) => Some(*value as f64),
+                _ => None,
+            })
+            .unwrap_or(0.0);
+        let retrieval_eval_last_run_at =
+            latest_retrieval_eval
+                .as_ref()
+                .and_then(|row| match row.get("run_at") {
+                    Some(SqlValue::Integer(value)) => Some(*value),
+                    _ => None,
+                });
+        let retrieval_eval_last_mrr =
+            latest_retrieval_eval
+                .as_ref()
+                .and_then(|row| match row.get("mrr") {
+                    Some(SqlValue::Float(value)) => Some(*value),
+                    Some(SqlValue::Integer(value)) => Some(*value as f64),
+                    _ => None,
+                });
 
         let eval_coverage = if total_atoms > 0 {
             finalized as f64 / total_atoms as f64
@@ -774,6 +821,10 @@ impl KnowledgeHandlers {
             "total_events": total_events,
             "eval_coverage": eval_coverage,
             "embedding_coverage": embedding_coverage,
+            "retrieval_eval_coverage": retrieval_eval_coverage,
+            "retrieval_eval_run_count": retrieval_eval_run_count,
+            "retrieval_eval_last_run_at": retrieval_eval_last_run_at,
+            "retrieval_eval_last_mrr": retrieval_eval_last_mrr,
             "namespace": ns,
         }))
     }

--- a/crates/khive-pack-knowledge/src/knowledge/eval.rs
+++ b/crates/khive-pack-knowledge/src/knowledge/eval.rs
@@ -1,0 +1,330 @@
+//! Offline retrieval-quality evaluation for the knowledge corpus.
+
+use std::collections::HashSet;
+use std::path::{Path, PathBuf};
+
+use chrono::Utc;
+use khive_runtime::{KhiveRuntime, NamespaceToken, RuntimeError};
+use khive_storage::types::{SqlStatement, SqlValue};
+use serde::Deserialize;
+use serde_json::{json, Value};
+use uuid::Uuid;
+
+use super::util::sql_err;
+use super::{vamana, KnowledgeHandlers};
+
+const EVAL_K: usize = 5;
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct EvalRetrievalParams {
+    query_set: String,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct QuerySetFile {
+    #[serde(default)]
+    queries: Vec<QuerySetEntry>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct QuerySetEntry {
+    #[serde(default)]
+    query: Option<String>,
+    #[serde(default)]
+    expected_slugs: Option<Vec<String>>,
+}
+
+#[derive(Debug)]
+struct ValidatedQuery {
+    query: String,
+    expected_slugs: HashSet<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+struct QueryMetrics {
+    precision_at_5: f64,
+    recall_at_5: f64,
+    mrr: f64,
+}
+
+fn parse_query_set(path: &Path, contents: &str) -> Result<Vec<ValidatedQuery>, RuntimeError> {
+    let parsed: QuerySetFile = toml::from_str(contents).map_err(|error| {
+        RuntimeError::InvalidInput(format!(
+            "knowledge.eval_retrieval: invalid TOML syntax in query set {}: {error}",
+            path.display()
+        ))
+    })?;
+    if parsed.queries.is_empty() {
+        return Err(RuntimeError::InvalidInput(format!(
+            "knowledge.eval_retrieval: query set {} contains no queries",
+            path.display()
+        )));
+    }
+
+    parsed
+        .queries
+        .into_iter()
+        .enumerate()
+        .map(|(index, entry)| {
+            let query = entry.query.unwrap_or_default().trim().to_string();
+            if query.is_empty() {
+                return Err(RuntimeError::InvalidInput(format!(
+                    "knowledge.eval_retrieval: query set {} entry [{index}] has empty query text",
+                    path.display()
+                )));
+            }
+            let expected_slugs = entry.expected_slugs.unwrap_or_default();
+            if expected_slugs.is_empty() {
+                return Err(RuntimeError::InvalidInput(format!(
+                    "knowledge.eval_retrieval: query set {} entry [{index}] has empty expected_slugs",
+                    path.display()
+                )));
+            }
+            let expected_slugs: HashSet<String> = expected_slugs
+                .into_iter()
+                .map(|slug| slug.trim().to_string())
+                .collect();
+            if expected_slugs.iter().any(String::is_empty) {
+                return Err(RuntimeError::InvalidInput(format!(
+                    "knowledge.eval_retrieval: query set {} entry [{index}] contains an empty expected slug",
+                    path.display()
+                )));
+            }
+            Ok(ValidatedQuery {
+                query,
+                expected_slugs,
+            })
+        })
+        .collect()
+}
+
+fn score_query(expected_slugs: &HashSet<String>, returned_slugs: &[String]) -> QueryMetrics {
+    let mut top_five = returned_slugs.iter().take(EVAL_K);
+    let returned_set: HashSet<&str> = top_five.clone().map(String::as_str).collect();
+    let hits = expected_slugs
+        .iter()
+        .filter(|slug| returned_set.contains(slug.as_str()))
+        .count();
+    let mrr = top_five
+        .position(|slug| expected_slugs.contains(slug))
+        .map(|position| 1.0 / (position + 1) as f64)
+        .unwrap_or(0.0);
+    QueryMetrics {
+        precision_at_5: hits as f64 / EVAL_K as f64,
+        recall_at_5: hits as f64 / expected_slugs.len() as f64,
+        mrr,
+    }
+}
+
+impl KnowledgeHandlers {
+    pub(crate) async fn eval_retrieval(
+        runtime: &KhiveRuntime,
+        token: &NamespaceToken,
+        params: Value,
+        ann: &vamana::SharedAnn,
+    ) -> Result<Value, RuntimeError> {
+        let p: EvalRetrievalParams = serde_json::from_value(params).map_err(|error| {
+            RuntimeError::InvalidInput(format!("knowledge.eval_retrieval: invalid params: {error}"))
+        })?;
+        if p.query_set.trim().is_empty() {
+            return Err(RuntimeError::InvalidInput(
+                "knowledge.eval_retrieval: query_set must not be empty".into(),
+            ));
+        }
+
+        let requested_query_set = PathBuf::from(p.query_set.trim());
+        if !requested_query_set.is_absolute() {
+            return Err(RuntimeError::InvalidInput(format!(
+                "knowledge.eval_retrieval: query_set must be an absolute path, got {}",
+                requested_query_set.display()
+            )));
+        }
+        let query_set = tokio::fs::canonicalize(&requested_query_set)
+            .await
+            .map_err(|error| {
+                RuntimeError::InvalidInput(format!(
+                    "knowledge.eval_retrieval: cannot resolve query set {}: {error}",
+                    requested_query_set.display()
+                ))
+            })?;
+        let persisted_query_set = query_set
+            .to_str()
+            .ok_or_else(|| {
+                RuntimeError::InvalidInput(format!(
+                    "knowledge.eval_retrieval: canonical query-set path is not valid UTF-8: {}",
+                    query_set.display()
+                ))
+            })?
+            .to_owned();
+        let contents = tokio::fs::read_to_string(&query_set)
+            .await
+            .map_err(|error| {
+                RuntimeError::InvalidInput(format!(
+                    "knowledge.eval_retrieval: cannot read query set {}: {error}",
+                    query_set.display()
+                ))
+            })?;
+        let queries = parse_query_set(&query_set, &contents)?;
+
+        let mut precision_at_5 = 0.0;
+        let mut recall_at_5 = 0.0;
+        let mut mrr = 0.0;
+        for query in &queries {
+            let response = Self::search(
+                runtime,
+                token,
+                json!({
+                    "query": query.query.as_str(),
+                    "type": "atom",
+                    "limit": EVAL_K,
+                    "include_drafts": true,
+                }),
+                ann,
+            )
+            .await?;
+            let results = response
+                .get("results")
+                .and_then(Value::as_array)
+                .ok_or_else(|| {
+                    RuntimeError::Internal(
+                        "knowledge.eval_retrieval: search response omitted results".into(),
+                    )
+                })?;
+            let returned_slugs: Vec<String> = results
+                .iter()
+                .map(|result| {
+                    result
+                        .get("slug")
+                        .and_then(Value::as_str)
+                        .map(str::to_owned)
+                        .ok_or_else(|| {
+                            RuntimeError::Internal(
+                                "knowledge.eval_retrieval: search result omitted slug".into(),
+                            )
+                        })
+                })
+                .collect::<Result<_, _>>()?;
+            let metrics = score_query(&query.expected_slugs, &returned_slugs);
+            precision_at_5 += metrics.precision_at_5;
+            recall_at_5 += metrics.recall_at_5;
+            mrr += metrics.mrr;
+        }
+
+        let total_queries = queries.len() as i64;
+        let denominator = total_queries as f64;
+        precision_at_5 /= denominator;
+        recall_at_5 /= denominator;
+        mrr /= denominator;
+
+        let run_id = Uuid::new_v4().to_string();
+        let run_at = Utc::now().timestamp_millis();
+        let namespace = token.namespace().as_str().to_string();
+        let sql = runtime.sql();
+        let mut writer = sql
+            .writer()
+            .await
+            .map_err(|error| sql_err("eval_retrieval writer", error))?;
+        writer
+            .execute(SqlStatement {
+                sql: "INSERT INTO knowledge_eval_runs \
+                      (id, namespace, run_at, query_set, total_queries, precision_at_5, \
+                       recall_at_5, mrr, notes) \
+                      VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, NULL)"
+                    .into(),
+                params: vec![
+                    SqlValue::Text(run_id.clone()),
+                    SqlValue::Text(namespace),
+                    SqlValue::Integer(run_at),
+                    SqlValue::Text(persisted_query_set),
+                    SqlValue::Integer(total_queries),
+                    SqlValue::Float(precision_at_5),
+                    SqlValue::Float(recall_at_5),
+                    SqlValue::Float(mrr),
+                ],
+                label: Some("knowledge.eval_retrieval.persist".into()),
+            })
+            .await
+            .map_err(|error| sql_err("eval_retrieval insert", error))?;
+
+        Ok(json!({
+            "run_id": run_id,
+            "total_queries": total_queries,
+            "precision_at_5": precision_at_5,
+            "recall_at_5": recall_at_5,
+            "mrr": mrr,
+        }))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn expected_set_metrics_use_fixed_k_and_ranked_first_hit() {
+        let expected = HashSet::from(["alpha".to_string(), "beta".to_string()]);
+        let returned = vec!["noise".to_string(), "beta".to_string(), "alpha".to_string()];
+        let metrics = score_query(&expected, &returned);
+        assert_eq!(metrics.precision_at_5, 0.4);
+        assert_eq!(metrics.recall_at_5, 1.0);
+        assert_eq!(metrics.mrr, 0.5);
+    }
+
+    #[test]
+    fn results_beyond_fixed_k_do_not_count() {
+        let expected = HashSet::from(["expected".to_string()]);
+        let returned = ["a", "b", "c", "d", "e", "expected"]
+            .into_iter()
+            .map(str::to_string)
+            .collect::<Vec<_>>();
+        let metrics = score_query(&expected, &returned);
+        assert_eq!(metrics.precision_at_5, 0.0);
+        assert_eq!(metrics.recall_at_5, 0.0);
+        assert_eq!(metrics.mrr, 0.0);
+    }
+
+    #[test]
+    fn query_set_validation_names_the_invalid_entry() {
+        let error = parse_query_set(
+            Path::new("fixture.toml"),
+            r#"
+                [[queries]]
+                query = "valid"
+                expected_slugs = ["alpha"]
+
+                [[queries]]
+                query = " "
+                expected_slugs = ["beta"]
+            "#,
+        )
+        .expect_err("blank query must fail");
+        let message = error.to_string();
+        assert!(message.contains("fixture.toml"));
+        assert!(message.contains("[1]"));
+    }
+
+    #[test]
+    fn empty_query_set_is_a_whole_file_validation_error() {
+        for contents in ["", "# no queries yet\n"] {
+            let error = parse_query_set(Path::new("fixture.toml"), contents)
+                .expect_err("query set without entries must fail");
+            let message = error.to_string();
+            assert!(message.contains("fixture.toml"));
+            assert!(message.contains("contains no queries"));
+            assert!(!message.contains("invalid TOML syntax"));
+        }
+    }
+
+    #[test]
+    fn shipped_query_set_is_valid_and_publicly_bounded() {
+        let queries = parse_query_set(
+            Path::new("eval_set.toml"),
+            include_str!("../../tests/fixtures/eval_set.toml"),
+        )
+        .expect("shipped query set must validate");
+        assert_eq!(queries.len(), 10);
+    }
+}

--- a/crates/khive-pack-knowledge/src/knowledge/mod.rs
+++ b/crates/khive-pack-knowledge/src/knowledge/mod.rs
@@ -8,6 +8,7 @@ pub(crate) mod vamana;
 
 mod compose;
 mod crud;
+mod eval;
 mod fold_handler;
 mod index_handler;
 mod search;

--- a/crates/khive-pack-knowledge/src/pack.rs
+++ b/crates/khive-pack-knowledge/src/pack.rs
@@ -10,7 +10,8 @@ use uuid::Uuid;
 use khive_brain_core::SectionPosteriorState;
 use khive_runtime::pack::{PackByIdResolver, PackRuntime};
 use khive_runtime::{
-    KhiveRuntime, Namespace, NamespaceToken, Resolved, RuntimeError, VerbRegistry,
+    KhiveRuntime, Namespace, NamespaceToken, PackSchemaPlan, Resolved, RuntimeError, SchemaPlan,
+    VerbRegistry,
 };
 use khive_storage::types::{SqlStatement, SqlValue};
 use khive_storage::{PhaseCancelledPayload, PhaseCompletedPayload, PhaseStartedPayload};
@@ -19,7 +20,7 @@ use khive_types::{EventKind, HandlerDef, Pack};
 use crate::knowledge::util::{atom_from_row, atom_to_json, domain_from_row, domain_to_json};
 use crate::knowledge::vamana;
 use crate::knowledge::KnowledgeHandlers;
-use crate::vocab::KNOWLEDGE_HANDLERS;
+use crate::vocab::{KNOWLEDGE_HANDLERS, KNOWLEDGE_SCHEMA_PLAN_STMTS};
 
 /// Knowledge corpus pack — atoms, domains, TF-IDF search, fold, import, and KG concept verbs.
 pub struct KnowledgePack {
@@ -47,6 +48,10 @@ impl Pack for KnowledgePack {
         &[khive_brain_core::ConsumerKind::KnowledgeCompose.as_str()];
     const HANDLERS: &'static [HandlerDef] = &KNOWLEDGE_HANDLERS;
     const REQUIRES: &'static [&'static str] = &["kg"];
+    const SCHEMA_PLAN: Option<PackSchemaPlan> = Some(PackSchemaPlan {
+        pack: "knowledge",
+        statements: &KNOWLEDGE_SCHEMA_PLAN_STMTS,
+    });
 }
 
 impl KnowledgePack {
@@ -111,6 +116,13 @@ impl PackRuntime for KnowledgePack {
 
     fn requires(&self) -> &'static [&'static str] {
         <KnowledgePack as Pack>::REQUIRES
+    }
+
+    fn schema_plan(&self) -> SchemaPlan {
+        SchemaPlan {
+            pack: "knowledge",
+            statements: &KNOWLEDGE_SCHEMA_PLAN_STMTS,
+        }
     }
 
     async fn warm(&self) {
@@ -218,6 +230,9 @@ impl PackRuntime for KnowledgePack {
                 KnowledgeHandlers::delete_atoms(&self.runtime, token, params).await
             }
             "knowledge.stats" => KnowledgeHandlers::stats(&self.runtime, token, params).await,
+            "knowledge.eval_retrieval" => {
+                KnowledgeHandlers::eval_retrieval(&self.runtime, token, params, &self.ann).await
+            }
             "knowledge.index" => {
                 KnowledgeHandlers::index(&self.runtime, token, params, &self.ann, None).await
             }

--- a/crates/khive-pack-knowledge/src/vocab.rs
+++ b/crates/khive-pack-knowledge/src/vocab.rs
@@ -1,8 +1,29 @@
-//! Static verb descriptor table for the knowledge pack (19 verbs).
+//! Static handler descriptor table for the knowledge pack (19 verbs + 1 subhandler).
 
 use khive_types::{HandlerDef, ParamDef, VerbCategory, Visibility};
 
-pub(crate) static KNOWLEDGE_HANDLERS: [HandlerDef; 19] = [
+/// Pack-owned schema for persisted retrieval-evaluation summaries.
+///
+/// These statements stay in the Knowledge pack's schema plan rather than the
+/// core migration ledger so multi-backend boot applies them to Knowledge's
+/// assigned backend. Both statements are idempotent for repeated startup.
+pub(crate) static KNOWLEDGE_SCHEMA_PLAN_STMTS: [&str; 2] = [
+    "CREATE TABLE IF NOT EXISTS knowledge_eval_runs (\
+        id              TEXT PRIMARY KEY,\
+        namespace       TEXT NOT NULL,\
+        run_at          INTEGER NOT NULL,\
+        query_set       TEXT NOT NULL,\
+        total_queries   INTEGER NOT NULL,\
+        precision_at_5  REAL NOT NULL,\
+        recall_at_5     REAL NOT NULL,\
+        mrr             REAL NOT NULL,\
+        notes           TEXT\
+    )",
+    "CREATE INDEX IF NOT EXISTS idx_knowledge_eval_runs_ns_run_at \
+        ON knowledge_eval_runs(namespace, run_at DESC)",
+];
+
+pub(crate) static KNOWLEDGE_HANDLERS: [HandlerDef; 20] = [
     // ── corpus tier ──────────────────────────────────────────────────────────
     HandlerDef {
         name: "knowledge.upsert_atoms",
@@ -120,6 +141,18 @@ pub(crate) static KNOWLEDGE_HANDLERS: [HandlerDef; 19] = [
         visibility: Visibility::Verb,
         category: VerbCategory::Assertive,
         params: &[],
+    },
+    HandlerDef {
+        name: "knowledge.eval_retrieval",
+        description: "Run a labeled, draft-inclusive atom-retrieval query set and persist aggregate quality metrics",
+        visibility: Visibility::Subhandler,
+        category: VerbCategory::Commissive,
+        params: &[ParamDef {
+            name: "query_set",
+            param_type: "string",
+            required: true,
+            description: "Absolute path to a TOML query set containing query and expected_slugs entries",
+        }],
     },
     HandlerDef {
         name: "knowledge.index",
@@ -662,6 +695,7 @@ mod tests {
             ),
             ("knowledge.delete_atoms", &["ids", "cascade"]),
             ("knowledge.stats", &[]),
+            ("knowledge.eval_retrieval", &["query_set"]),
             (
                 "knowledge.index",
                 &["ids", "batch_size", "insert_only", "rebuild_ann"],

--- a/crates/khive-pack-knowledge/tests/eval_retrieval.rs
+++ b/crates/khive-pack-knowledge/tests/eval_retrieval.rs
@@ -1,0 +1,446 @@
+use std::collections::HashMap;
+use std::io::Write;
+use std::sync::Arc;
+
+use khive_pack_kg::KgPack;
+use khive_pack_knowledge::KnowledgePack;
+use khive_runtime::{
+    KhiveRuntime, PackRuntime, RuntimeConfig, RuntimeError, StorageBackend, VerbRegistry,
+    VerbRegistryBuilder,
+};
+use khive_storage::types::{SqlStatement, SqlValue};
+use khive_types::Pack;
+use serde_json::{json, Value};
+use tempfile::NamedTempFile;
+
+fn runtime() -> KhiveRuntime {
+    KhiveRuntime::new(RuntimeConfig {
+        db_path: None,
+        ..RuntimeConfig::no_embeddings()
+    })
+    .expect("in-memory runtime")
+}
+
+fn unbooted_registry(runtime: &KhiveRuntime, namespace: &str) -> VerbRegistry {
+    let mut builder = VerbRegistryBuilder::new();
+    builder.with_default_namespace(namespace);
+    builder.register(KgPack::new(runtime.clone()));
+    builder.register(KnowledgePack::new(runtime.clone()));
+    let registry = builder.build().expect("registry builds");
+    runtime.install_edge_rules(registry.all_edge_rules());
+    registry
+}
+
+fn registry(runtime: &KhiveRuntime, namespace: &str) -> VerbRegistry {
+    let registry = unbooted_registry(runtime, namespace);
+    registry.apply_schema_plans(runtime.backend());
+    registry
+}
+
+async fn seed_atom(registry: &VerbRegistry, slug: &str, signal: &str, finalized: bool) {
+    registry
+        .dispatch(
+            "knowledge.upsert_atoms",
+            json!({
+                "atoms": [{
+                    "slug": slug,
+                    "name": format!("{slug} evaluation atom"),
+                    "content": format!(
+                        "{signal} retrieval evaluation fixture provides deterministic lexical evidence \
+                         for ranked corpus search quality metrics while preserving realistic knowledge \
+                         atom content validation requirements across repeated offline benchmark runs"
+                    ),
+                    "finalized": finalized
+                }]
+            }),
+        )
+        .await
+        .expect("seed atom");
+}
+
+fn query_set(contents: &str) -> NamedTempFile {
+    let mut file = NamedTempFile::new().expect("query-set tempfile");
+    file.write_all(contents.as_bytes())
+        .expect("write query set");
+    file.flush().expect("flush query set");
+    file
+}
+
+fn canonical_query_set_path(file: &NamedTempFile) -> String {
+    std::fs::canonicalize(file.path())
+        .expect("canonical query-set path")
+        .to_string_lossy()
+        .into_owned()
+}
+
+async fn stats(registry: &VerbRegistry) -> Value {
+    registry
+        .dispatch("knowledge.stats", json!({}))
+        .await
+        .expect("knowledge stats")
+}
+
+fn assert_close(actual: f64, expected: f64) {
+    assert!(
+        (actual - expected).abs() < 1e-12,
+        "expected {expected}, got {actual}"
+    );
+}
+
+#[test]
+fn knowledge_pack_declares_the_eval_table_as_pack_owned_schema() {
+    let declared = <KnowledgePack as Pack>::SCHEMA_PLAN
+        .expect("KnowledgePack must declare its auxiliary schema statically");
+    assert_eq!(declared.pack, "knowledge");
+    assert_eq!(declared.statements.len(), 2);
+
+    let runtime_plan = KnowledgePack::new(runtime()).schema_plan();
+    assert_eq!(runtime_plan.pack, declared.pack);
+    assert_eq!(runtime_plan.statements, declared.statements);
+
+    let combined = declared.statements.join(" ");
+    assert!(combined.contains("CREATE TABLE IF NOT EXISTS knowledge_eval_runs"));
+    assert!(combined.contains("CREATE INDEX IF NOT EXISTS idx_knowledge_eval_runs_ns_run_at"));
+}
+
+#[tokio::test]
+async fn knowledge_schema_plan_boot_is_idempotent_and_enables_stats() {
+    let runtime = runtime();
+    let registry = unbooted_registry(&runtime, "local");
+
+    registry.apply_schema_plans(runtime.backend());
+    registry.apply_schema_plans(runtime.backend());
+
+    let booted_stats = stats(&registry).await;
+    assert_eq!(booted_stats["retrieval_eval_coverage"], 0.0);
+    assert_eq!(booted_stats["retrieval_eval_run_count"], 0);
+    assert!(booted_stats["retrieval_eval_last_run_at"].is_null());
+    assert!(booted_stats["retrieval_eval_last_mrr"].is_null());
+}
+
+#[tokio::test]
+async fn knowledge_schema_plan_routes_only_to_the_assigned_backend() {
+    let default_backend = Arc::new(StorageBackend::memory().expect("default memory backend"));
+    let knowledge_backend = Arc::new(StorageBackend::memory().expect("knowledge memory backend"));
+    let knowledge_runtime =
+        KhiveRuntime::from_backend(knowledge_backend.clone(), RuntimeConfig::no_embeddings());
+    let registry = unbooted_registry(&knowledge_runtime, "local");
+    let mut backend_map: HashMap<&str, &StorageBackend> = HashMap::new();
+    backend_map.insert("knowledge", knowledge_backend.as_ref());
+
+    registry
+        .apply_schema_plans_with_map(&backend_map, default_backend.as_ref())
+        .expect("pack schema routing must succeed");
+
+    let schema_count = |label: &str| SqlStatement {
+        sql: "SELECT COUNT(*) FROM sqlite_master \
+              WHERE (type = 'table' AND name = 'knowledge_eval_runs') \
+                 OR (type = 'index' AND name = 'idx_knowledge_eval_runs_ns_run_at')"
+            .into(),
+        params: vec![],
+        label: Some(label.into()),
+    };
+
+    let knowledge_sql = knowledge_backend.sql();
+    let mut knowledge_reader = knowledge_sql.reader().await.expect("knowledge reader");
+    let knowledge_objects = knowledge_reader
+        .query_scalar(schema_count("knowledge.schema_plan.assigned_backend"))
+        .await
+        .expect("inspect knowledge schema");
+    assert!(matches!(knowledge_objects, Some(SqlValue::Integer(2))));
+
+    let default_sql = default_backend.sql();
+    let mut default_reader = default_sql.reader().await.expect("default reader");
+    let default_objects = default_reader
+        .query_scalar(schema_count("knowledge.schema_plan.default_backend"))
+        .await
+        .expect("inspect default schema");
+    assert!(matches!(default_objects, Some(SqlValue::Integer(0))));
+}
+
+#[tokio::test]
+async fn malformed_query_set_reports_path_and_parser_position_without_persisting() {
+    let runtime = runtime();
+    let registry = registry(&runtime, "local");
+    let malformed = query_set(
+        r#"
+            [[queries]]
+            query = "unterminated
+            expected_slugs = ["alpha"]
+        "#,
+    );
+    let path = malformed.path().display().to_string();
+    let canonical_path = canonical_query_set_path(&malformed);
+
+    let error = registry
+        .dispatch(
+            "knowledge.eval_retrieval",
+            json!({"query_set": path.clone()}),
+        )
+        .await
+        .expect_err("malformed TOML must fail before retrieval");
+    assert!(matches!(&error, RuntimeError::InvalidInput(_)));
+    let message = error.to_string();
+    assert!(
+        message.contains(&canonical_path),
+        "error must name {canonical_path}: {message}"
+    );
+    assert!(
+        message.contains("line"),
+        "error must name a line: {message}"
+    );
+    assert!(
+        message.contains("column"),
+        "error must name a column: {message}"
+    );
+    assert_eq!(stats(&registry).await["retrieval_eval_run_count"], 0);
+}
+
+#[tokio::test]
+async fn relative_query_set_is_rejected_before_retrieval_or_persistence() {
+    let runtime = runtime();
+    let registry = registry(&runtime, "local");
+
+    let error = registry
+        .dispatch(
+            "knowledge.eval_retrieval",
+            json!({"query_set": "tests/fixtures/eval_set.toml"}),
+        )
+        .await
+        .expect_err("relative query-set paths must fail before evaluation");
+    assert!(matches!(&error, RuntimeError::InvalidInput(_)));
+    let message = error.to_string();
+    assert!(message.contains("must be an absolute path"), "{message}");
+    assert!(
+        message.contains("tests/fixtures/eval_set.toml"),
+        "{message}"
+    );
+    assert_eq!(stats(&registry).await["retrieval_eval_run_count"], 0);
+}
+
+#[tokio::test]
+async fn eval_subhandler_persists_complete_runs_and_stats_reads_latest() {
+    let runtime = runtime();
+    let registry = registry(&runtime, "local");
+    assert!(registry.is_subhandler_verb("knowledge.eval_retrieval"));
+    assert!(!registry
+        .all_verbs()
+        .iter()
+        .any(|handler| handler.name == "knowledge.eval_retrieval"));
+    assert!(registry
+        .all_handlers_with_names()
+        .iter()
+        .any(|(_, handler)| handler.name == "knowledge.eval_retrieval"));
+
+    seed_atom(&registry, "alpha", "alphasignal", true).await;
+    let before = stats(&registry).await;
+    assert_eq!(before["eval_coverage"], 1.0);
+    assert_eq!(before["retrieval_eval_coverage"], 0.0);
+    assert_eq!(before["retrieval_eval_run_count"], 0);
+    assert!(before["retrieval_eval_last_run_at"].is_null());
+    assert!(before["retrieval_eval_last_mrr"].is_null());
+
+    let invalid = query_set(
+        r#"
+            [[queries]]
+            query = "alphasignal"
+            expected_slugs = ["alpha"]
+
+            [[queries]]
+            query = " "
+            expected_slugs = ["missing"]
+        "#,
+    );
+    let invalid_path = invalid.path().display().to_string();
+    let canonical_invalid_path = canonical_query_set_path(&invalid);
+    let error = registry
+        .dispatch(
+            "knowledge.eval_retrieval",
+            json!({"query_set": invalid_path.clone()}),
+        )
+        .await
+        .expect_err("invalid set must fail before a run is written");
+    assert!(matches!(&error, RuntimeError::InvalidInput(_)));
+    let message = error.to_string();
+    assert!(
+        message.contains(&canonical_invalid_path),
+        "error must name {canonical_invalid_path}: {message}"
+    );
+    assert!(
+        message.contains("[1]"),
+        "error must name semantic entry [1]: {message}"
+    );
+    assert_eq!(stats(&registry).await["retrieval_eval_run_count"], 0);
+
+    let miss = query_set(
+        r#"
+            [[queries]]
+            query = "alphasignal"
+            expected_slugs = ["missing"]
+        "#,
+    );
+    let miss_result = registry
+        .dispatch(
+            "knowledge.eval_retrieval",
+            json!({"query_set": miss.path().to_string_lossy()}),
+        )
+        .await
+        .expect("complete miss run");
+    assert_eq!(miss_result["total_queries"], 1);
+    assert_eq!(miss_result["precision_at_5"], 0.0);
+    assert_eq!(miss_result["recall_at_5"], 0.0);
+    assert_eq!(miss_result["mrr"], 0.0);
+
+    let hit = query_set(
+        r#"
+            [[queries]]
+            query = "alphasignal"
+            expected_slugs = ["alpha"]
+        "#,
+    );
+    let hit_path = hit
+        .path()
+        .parent()
+        .expect("query-set parent")
+        .join(".")
+        .join(hit.path().file_name().expect("query-set filename"));
+    let canonical_hit_path = canonical_query_set_path(&hit);
+    let hit_result = registry
+        .dispatch(
+            "knowledge.eval_retrieval",
+            json!({"query_set": hit_path.to_string_lossy()}),
+        )
+        .await
+        .expect("complete hit run");
+    assert_close(
+        hit_result["precision_at_5"]
+            .as_f64()
+            .expect("precision number"),
+        0.2,
+    );
+    assert_close(
+        hit_result["recall_at_5"].as_f64().expect("recall number"),
+        1.0,
+    );
+    assert_close(hit_result["mrr"].as_f64().expect("mrr number"), 1.0);
+
+    let sql = runtime.sql();
+    let mut reader = sql.reader().await.expect("eval-run reader");
+    let persisted_query_set = reader
+        .query_scalar(SqlStatement {
+            sql: "SELECT query_set FROM knowledge_eval_runs \
+                  WHERE namespace = ?1 ORDER BY run_at DESC, rowid DESC LIMIT 1"
+                .into(),
+            params: vec![SqlValue::Text("local".into())],
+            label: Some("knowledge.eval_retrieval.persisted_query_set".into()),
+        })
+        .await
+        .expect("read persisted query-set path");
+    match persisted_query_set {
+        Some(SqlValue::Text(path)) => assert_eq!(path, canonical_hit_path),
+        other => panic!("expected persisted canonical query-set path, got {other:?}"),
+    }
+
+    let after = stats(&registry).await;
+    assert_eq!(after["eval_coverage"], 1.0);
+    assert_eq!(after["retrieval_eval_run_count"], 2);
+    assert_close(
+        after["retrieval_eval_coverage"]
+            .as_f64()
+            .expect("coverage number"),
+        0.2,
+    );
+    assert_close(
+        after["retrieval_eval_last_mrr"]
+            .as_f64()
+            .expect("last mrr number"),
+        1.0,
+    );
+    assert!(after["retrieval_eval_last_run_at"].is_i64());
+}
+
+#[tokio::test]
+async fn eval_includes_draft_atoms_from_an_unfinalized_corpus() {
+    let runtime = runtime();
+    let registry = registry(&runtime, "local");
+    seed_atom(&registry, "draft-alpha", "draftalphasignal", false).await;
+
+    let ordinary_search = registry
+        .dispatch(
+            "knowledge.search",
+            json!({"query": "draftalphasignal", "type": "atom", "limit": 5}),
+        )
+        .await
+        .expect("ordinary search");
+    assert_eq!(ordinary_search["results"], json!([]));
+
+    let set = query_set(
+        r#"
+            [[queries]]
+            query = "draftalphasignal"
+            expected_slugs = ["draft-alpha"]
+        "#,
+    );
+    let result = registry
+        .dispatch(
+            "knowledge.eval_retrieval",
+            json!({"query_set": set.path().to_string_lossy()}),
+        )
+        .await
+        .expect("draft-inclusive eval run");
+
+    assert_close(
+        result["precision_at_5"].as_f64().expect("precision number"),
+        0.2,
+    );
+    assert_close(result["recall_at_5"].as_f64().expect("recall number"), 1.0);
+    assert_close(result["mrr"].as_f64().expect("mrr number"), 1.0);
+}
+
+#[tokio::test]
+async fn eval_runs_and_stats_are_namespace_scoped() {
+    let runtime = runtime();
+    let local = registry(&runtime, "local");
+    seed_atom(&local, "alpha", "alphasignal", true).await;
+    local
+        .dispatch(
+            "knowledge.upsert_atoms",
+            json!({
+                "namespace": "other",
+                "atoms": [{
+                    "slug": "beta",
+                    "name": "beta evaluation atom",
+                    "content": "betasignal retrieval evaluation fixture provides deterministic lexical evidence for ranked corpus search quality metrics while preserving realistic knowledge atom content validation requirements across repeated offline benchmark runs",
+                    "finalized": true
+                }]
+            }),
+        )
+        .await
+        .expect("seed other-namespace atom");
+
+    let set = query_set(
+        r#"
+            [[queries]]
+            query = "alphasignal"
+            expected_slugs = ["alpha"]
+        "#,
+    );
+    local
+        .dispatch(
+            "knowledge.eval_retrieval",
+            json!({"query_set": set.path().to_string_lossy()}),
+        )
+        .await
+        .expect("local eval run");
+
+    let local_stats = stats(&local).await;
+    let other_stats = local
+        .dispatch("knowledge.stats", json!({"namespace": "other"}))
+        .await
+        .expect("other-namespace knowledge stats");
+    assert_eq!(local_stats["namespace"], "local");
+    assert_eq!(local_stats["retrieval_eval_run_count"], 1);
+    assert_eq!(other_stats["namespace"], "other");
+    assert_eq!(other_stats["retrieval_eval_run_count"], 0);
+    assert!(other_stats["retrieval_eval_last_run_at"].is_null());
+}

--- a/crates/khive-pack-knowledge/tests/fixes.rs
+++ b/crates/khive-pack-knowledge/tests/fixes.rs
@@ -66,6 +66,7 @@ fn pack(rt: KhiveRuntime) -> Fixture {
     builder.register(KgPack::new(rt.clone()));
     builder.register(KnowledgePack::new(rt.clone()));
     let registry = builder.build().expect("registry builds");
+    registry.apply_schema_plans(rt.backend());
     rt.install_edge_rules(registry.all_edge_rules());
     Fixture {
         registry,
@@ -3054,6 +3055,7 @@ fn pack_with_events(rt: KhiveRuntime) -> Fixture {
     builder.register(KgPack::new(rt.clone()));
     builder.register(KnowledgePack::new(rt.clone()));
     let registry = builder.build().expect("registry builds");
+    registry.apply_schema_plans(rt.backend());
     rt.install_edge_rules(registry.all_edge_rules());
     Fixture {
         registry,

--- a/crates/khive-pack-knowledge/tests/fixtures/eval_set.toml
+++ b/crates/khive-pack-knowledge/tests/fixtures/eval_set.toml
@@ -1,0 +1,39 @@
+[[queries]]
+query = "retrieval augmented generation retrieves passages before generation"
+expected_slugs = ["rag"]
+
+[[queries]]
+query = "low rank adapters for parameter efficient fine tuning"
+expected_slugs = ["lora"]
+
+[[queries]]
+query = "memory efficient exact attention with tiled kernels"
+expected_slugs = ["flash-attention"]
+
+[[queries]]
+query = "grouped query attention reduces key value cache size"
+expected_slugs = ["gqa"]
+
+[[queries]]
+query = "rotary positional embeddings encode relative token positions"
+expected_slugs = ["rope"]
+
+[[queries]]
+query = "language model agent plans and invokes tools"
+expected_slugs = ["agent"]
+
+[[queries]]
+query = "chain of thought exposes intermediate reasoning steps"
+expected_slugs = ["chain-of-thought"]
+
+[[queries]]
+query = "speculative decoding verifies draft model tokens in parallel"
+expected_slugs = ["speculative"]
+
+[[queries]]
+query = "weight quantization reduces model memory and compute"
+expected_slugs = ["quantization"]
+
+[[queries]]
+query = "direct preference optimization trains from preference pairs"
+expected_slugs = ["dpo"]

--- a/crates/khive-pack-knowledge/tests/integration.rs
+++ b/crates/khive-pack-knowledge/tests/integration.rs
@@ -61,6 +61,7 @@ fn pack(rt: KhiveRuntime) -> Fixture {
     builder.register(KgPack::new(rt.clone()));
     builder.register(KnowledgePack::new(rt.clone()));
     let registry = builder.build().expect("registry builds");
+    registry.apply_schema_plans(rt.backend());
     rt.install_edge_rules(registry.all_edge_rules());
     Fixture { registry }
 }

--- a/crates/khive-pack-memory/src/config.rs
+++ b/crates/khive-pack-memory/src/config.rs
@@ -364,11 +364,11 @@ impl RecallFtsGatherConfig {
     }
 }
 
-// Tuning artifact: tests/khive-contract/tune/ swept 116 configs but the synthetic corpus
+// The historical 2026-05-25 tuning artifact swept 116 configs, but the synthetic corpus
 // produced an identical recall@10 = 0.9333 for every config — i.e. a flat landscape that
 // cannot empirically distinguish these parameters. Defaults below stay at the prior values
 // until a harder corpus (embed-enabled, synonym queries, partial matches) provides signal.
-// See tests/khive-contract/tune/REPORT.md for the analysis.
+// See tests/khive-contract/tune/README.md for the retained limitation.
 //
 // Default strategy: RRF k=10 (restored 2026-07-21). CC-6 flipped this to
 // Weighted [0.7, 0.3] to let salience act as a tiebreaker, but the live golden-suite
@@ -573,6 +573,7 @@ pub struct WeightedContributions {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serde::Deserialize;
 
     // ── DecayModel ────────────────────────────────────────────────────────────
 
@@ -815,6 +816,53 @@ mod tests {
             cfg.fuse_strategy
         );
         assert!(!cfg.include_breakdown);
+    }
+
+    #[test]
+    fn tuning_grid_contains_the_runtime_default() {
+        #[derive(Deserialize)]
+        struct CandidatePool {
+            candidate_multiplier: u32,
+            candidate_limit: u32,
+        }
+
+        #[derive(Deserialize)]
+        struct FixedDimensions {
+            min_score: f64,
+        }
+
+        #[derive(Deserialize)]
+        struct TuningGrid {
+            weight_triples: Vec<[f64; 3]>,
+            candidate_pools: Vec<CandidatePool>,
+            fusion_configs: Vec<FusionStrategy>,
+            decay_models: Vec<DecayModel>,
+            temporal_half_life_days: Vec<f64>,
+            min_salience_values: Vec<f64>,
+            fixed: FixedDimensions,
+        }
+
+        let grid: TuningGrid =
+            serde_json::from_str(include_str!("../testdata/recall_tuning_grid.json"))
+                .expect("recall tuning grid must be valid JSON");
+        let cfg = RecallConfig::default();
+
+        assert!(grid.weight_triples.iter().any(|weights| {
+            (weights[0] - cfg.relevance_weight).abs() < 1e-12
+                && (weights[1] - cfg.salience_weight).abs() < 1e-12
+                && (weights[2] - cfg.temporal_weight).abs() < 1e-12
+        }));
+        assert!(grid.candidate_pools.iter().any(|pool| {
+            pool.candidate_multiplier == cfg.candidate_multiplier
+                && Some(pool.candidate_limit) == cfg.candidate_limit
+        }));
+        assert!(grid.fusion_configs.contains(&cfg.fuse_strategy));
+        assert!(grid.decay_models.contains(&cfg.decay_model));
+        assert!(grid
+            .temporal_half_life_days
+            .contains(&cfg.temporal_half_life_days));
+        assert!(grid.min_salience_values.contains(&cfg.min_salience));
+        assert!((grid.fixed.min_score - cfg.min_score).abs() < 1e-12);
     }
 
     #[test]

--- a/crates/khive-pack-memory/testdata/recall_tuning_grid.json
+++ b/crates/khive-pack-memory/testdata/recall_tuning_grid.json
@@ -1,0 +1,27 @@
+{
+  "weight_triples": [
+    [0.7, 0.2, 0.1],
+    [0.6, 0.3, 0.1],
+    [0.6, 0.2, 0.2],
+    [0.8, 0.1, 0.1]
+  ],
+  "candidate_pools": [
+    { "candidate_multiplier": 20, "candidate_limit": 100 },
+    { "candidate_multiplier": 20, "candidate_limit": 150 }
+  ],
+  "fusion_configs": [
+    { "rrf": { "k": 10 } },
+    { "rrf": { "k": 20 } },
+    { "rrf": { "k": 60 } },
+    { "rrf": { "k": 100 } },
+    { "weighted": { "weights": [1.0, 0.0] } },
+    { "weighted": { "weights": [0.75, 0.25] } },
+    { "weighted": { "weights": [0.5, 0.5] } },
+    { "weighted": { "weights": [0.25, 0.75] } },
+    { "weighted": { "weights": [0.0, 1.0] } }
+  ],
+  "decay_models": ["exponential", "hyperbolic", "none"],
+  "temporal_half_life_days": [14.0, 30.0, 60.0],
+  "min_salience_values": [0.0, 0.4],
+  "fixed": { "min_score": 0.0 }
+}

--- a/docs/adr/ADR-082-retrieval-quality-measurement-loop.md
+++ b/docs/adr/ADR-082-retrieval-quality-measurement-loop.md
@@ -1,10 +1,10 @@
 # ADR-082: Retrieval Quality Measurement Loop
 
-**Status**: proposed
+**Status**: accepted (implemented 2026-08-07)
 **Date**: 2026-07-02
 **Authors**: khive maintainers
 **Depends on**: [ADR-015](ADR-015-schema-migrations.md) (Schema Migrations), [ADR-023](ADR-023-declarative-pack-format.md) (Pack Verb Surface, Visibility, and Composition — `Visibility::Subhandler`), [ADR-047](ADR-047-knowledge-pack.md) (Knowledge Pack)
-**GitHub**: #80
+**GitHub**: #80 (original report), #1487 (public implementation issue)
 **Note**: this number was previously used by a retired v0-series draft ("Engine
 Configuration Schema") consolidated into [ADR-031](ADR-031-multi-engine-retrieval.md);
 that draft was archived at the 2026-05-23 v0→v1 ADR renumbering and does not refer to
@@ -19,10 +19,10 @@ observes that `knowledge.stats()` reports `eval_coverage: 0.0` and reads this as
 that retrieval quality on the 68k-atom production corpus is unmeasured — "faith-based."
 
 The diagnosis of the underlying problem is correct; the field it names is not the field
-at fault. `eval_coverage` is computed in
-`crates/khive-pack-knowledge/src/knowledge/crud.rs` (`stats`, lines 604-680) as
-`finalized_atoms / total_atoms` (lines 631-638, 658, 667-668), where `finalized_atoms`
-counts rows with `finalized = 1` in `knowledge_atoms`. It is a **finalization-coverage**
+at fault. `eval_coverage` is computed by `KnowledgeHandlers::stats` in
+`crates/khive-pack-knowledge/src/knowledge/crud.rs` as
+`finalized_atoms / total_atoms`, where `finalized_atoms` counts rows with
+`finalized = 1` in `knowledge_atoms`. It is a **finalization-coverage**
 metric — what fraction of atoms have passed a human review gate — not a
 **retrieval-quality** metric. The production corpus was ingested without
 `finalized: true`, so `0.0` is an honest finalization reading, not a broken retrieval
@@ -66,16 +66,27 @@ expansion. This ADR formalizes the 2026-07-02 decisions on the two escalations
 (D1, D2 below) and fixes the normative shape of slice-1. It does not reopen the forks;
 it records the decisions and specifies what ships.
 
+### Acceptance correction for #1487
+
+D1 and D2 below explicitly correct and supersede #1487's generic acceptance wording.
+In particular, a completed retrieval run does **not** redefine the existing
+`eval_coverage` finalization metric, and the evaluation handler is an operator-only
+`Subhandler`, not a new MCP verb. A pull request claiming to close #1487 MUST call out
+those corrected criteria and identify `retrieval_eval_coverage`,
+`retrieval_eval_run_count`, and the returned precision/recall/MRR fields as the shipped
+retrieval-quality contract; it must not claim that `eval_coverage` changed semantics or
+that agents gained a new MCP-callable verb.
+
 ## Decision
 
 ### Scope — slice-1
 
 This ADR specifies the smallest increment that moves retrieval-quality measurement off
-"nonexistent" with an honest number: a versioned `knowledge_eval_runs` table, a labeled
+"nonexistent" with an honest number: a pack-owned `knowledge_eval_runs` table, a labeled
 query-set format (synthetic and public by default, path-overridable), a CLI-only eval
 runner that reuses `knowledge.search` as its retrieval path with its own expected-set
-metric contract (§"Eval runner mechanics"), hit-rate/MRR persisted per run, and
-`knowledge.stats()` reading the most recent run. Feedback-grown query-set expansion
+metric contract (§"Eval runner mechanics"), precision-at-5/recall-at-5/MRR persisted per
+run, and `knowledge.stats()` reading the most recent run. Feedback-grown query-set expansion
 (issue #80's optional third bullet: accumulating labeled pairs from `brain.feedback`-style
 signals emitted by agents) is explicitly **out of scope** for this ADR. It requires its
 own accumulation-table design, its own OSS/private data-policy enforcement, and its own
@@ -84,11 +95,11 @@ ADR, and is deferred to a future slice.
 ### D1 — Additive field; `eval_coverage` is not renamed or redefined
 
 `eval_coverage` in `knowledge.stats()` keeps its current name and its current semantics:
-`finalized_atoms / total_atoms`, exactly as implemented today at
-`crud.rs:667-668`. It is a legitimate metric and stays exactly as it is. No wire-shape
-change, no consumer of the existing field is affected, and the existing integration-test
-assertion (`crates/khive-pack-knowledge/tests/integration.rs:1125-1129`, `eval_coverage
-== 0.5` for 1 of 2 finalized atoms) continues to hold unmodified.
+`finalized_atoms / total_atoms`, exactly as implemented by `KnowledgeHandlers::stats`.
+It is a legitimate metric and stays exactly as it is. No existing field's shape or
+semantics changes, no consumer of the existing field is affected, and the existing
+`stats_reflects_current_corpus` integration assertion (`eval_coverage == 0.5` for 1 of 2
+finalized atoms) continues to hold unmodified.
 
 Retrieval quality is reported through **new, additive** fields on the same response:
 
@@ -107,7 +118,8 @@ Retrieval quality is reported through **new, additive** fields on the same respo
 }
 ```
 
-`retrieval_eval_coverage` reports the most recent run's `precision_at_5` (§7). Before any
+`retrieval_eval_coverage` reports the most recent run's `precision_at_5`
+(§"Eval runner mechanics"). Before any
 run has ever executed, all four `retrieval_eval_*` fields report their zero/null
 sentinels (`0.0` / `0` / `null` / `null`) — a state distinguishable from "measured and
 scored zero" by `retrieval_eval_run_count == 0`. `finalization` and `retrieval quality`
@@ -122,7 +134,7 @@ in `crates/khive-pack-knowledge/src/vocab.rs` with `visibility: Visibility::Subh
 kkernel CLI's verb-DSL `exec` subcommand:
 
 ```bash
-kkernel exec 'knowledge.eval_retrieval(query_set="crates/khive-pack-knowledge/tests/fixtures/eval_set.toml")'
+kkernel exec 'knowledge.eval_retrieval(query_set="/absolute/path/to/eval_set.toml")'
 ```
 
 This is the same pattern already shipped for `memory.recall_embed` and
@@ -145,26 +157,25 @@ if usage ever justifies it, needs its own ADR-023 amendment and `AGENTS.md` sync
 its own justification. The broader verb-count convention question is a separate,
 unrelated open thread and this ADR does not couple to it in either direction.
 
-### Schema — `knowledge_eval_runs`
+### Schema — pack-owned `knowledge_eval_runs`
 
-A new table, versioned per the standard migration mechanism (ADR-015: append a new
-`VersionedMigration` with `version = <current ceiling> + 1`, backed by a new
-`crates/khive-db/sql/NNN-<name>.sql` file; `V1` is never edited). As of this writing the
-live migration ceiling is `V5` (`unique_comm_message_external_id`,
-`crates/khive-db/sql/005-unique-comm-external-id.sql`), so this table is expected to land
-at `V6`; the implementer verifies the exact next version against
-`crates/khive-db/src/migrations.rs` at merge time, since other migrations may land first.
-The migration file itself — the literal `.sql` and its `VersionedMigration` registration
-— is authored in the implementation PR, per repository convention; this ADR fixes the
-schema:
+`knowledge_eval_runs` is a Knowledge-pack auxiliary table, not a core substrate table.
+Per ADR-015's non-overlapping schema ownership rule, its table and index are declared as
+idempotent statements in `KNOWLEDGE_SCHEMA_PLAN_STMTS`, exposed through both
+`KnowledgePack::SCHEMA_PLAN` and `KnowledgePack::schema_plan()`. Runtime boot therefore
+applies them to the backend assigned to the Knowledge pack, including multi-backend
+deployments. No `khive-db` versioned migration or canonical migration-ledger claim is made
+for this table. Direct `VerbRegistry` fixtures and embedders that bypass production server
+boot must call `apply_schema_plans` after `build` before dispatching Knowledge handlers.
+The schema-plan statements are:
 
 ```sql
--- 006-knowledge-eval-runs.sql (illustrative filename; exact version per migrations.rs at merge time)
+-- KNOWLEDGE_SCHEMA_PLAN_STMTS (table statement followed by index statement)
 CREATE TABLE IF NOT EXISTS knowledge_eval_runs (
     id              TEXT PRIMARY KEY,
     namespace       TEXT NOT NULL,
     run_at          INTEGER NOT NULL,   -- unix ms
-    query_set       TEXT NOT NULL,      -- filesystem path used for this run
+    query_set       TEXT NOT NULL,      -- canonical absolute path used for this run
     total_queries   INTEGER NOT NULL,
     precision_at_5  REAL NOT NULL,
     recall_at_5     REAL NOT NULL,
@@ -176,8 +187,9 @@ CREATE INDEX IF NOT EXISTS idx_knowledge_eval_runs_ns_run_at
     ON knowledge_eval_runs(namespace, run_at DESC);
 ```
 
-Purely additive: no existing table, column, or index is touched, and no data migration
-runs against `knowledge_atoms` or any other table.
+Purely additive and idempotent: repeated boot is a no-op after the first application. No
+existing table, column, or index is touched, and no data migration runs against
+`knowledge_atoms` or any other table.
 
 ### Labeled query-set format
 
@@ -202,22 +214,27 @@ per-run parameter; a future ADR may add configurable search depth alongside the
 dynamic-`k` metric storage that would require.
 
 The shipped public fixture, `crates/khive-pack-knowledge/tests/fixtures/eval_set.toml`,
-is synthetic: 10-15 queries built over the same domain vocabulary already seeded in the
-integration test corpus (`rag`, `lora`, `flash-attention`, `gqa`, `rope`, `agent`,
-`chain-of-thought`, `speculative`, `quantization`, `dpo` —
-`crates/khive-pack-knowledge/tests/integration.rs:1216-1225`). It is safe for the public
-repository.
+is synthetic: 10-15 queries built over the same domain vocabulary already seeded by
+`search_and_compose_workflow` in the integration corpus (`rag`, `lora`,
+`flash-attention`, `gqa`, `rope`, `agent`, `chain-of-thought`, `speculative`,
+`quantization`, `dpo`). It is safe for the public repository.
 
 Real-usage query sets — including the 2026-06-10 12-probe study and any future set
 derived from production corpus topics or agent feedback — are **excluded from the OSS
 repository** by data policy. Committing them would expose what topics live in private
-operator corpora, leaking corpus composition. `query_set` accepts an arbitrary filesystem
-path, so operators point it at a private, gitignored location such as `.khive/eval/` to
-run against their own labeled data without touching the repository.
+operator corpora, leaking corpus composition. `query_set` accepts an arbitrary absolute
+filesystem path, so operators point it at a private, gitignored location outside the
+repository to run against their own labeled data without touching the repository.
 
 ### Eval runner mechanics
 
 `knowledge.eval_retrieval(query_set: <path>)`:
+
+**The path is absolute and canonical.** Relative `query_set` values fail before file I/O,
+retrieval, or persistence. The runner canonicalizes an absolute input before reading it
+and stores that canonical absolute path in `knowledge_eval_runs`. This keeps both the
+file selected by `kkernel exec` and the audit record independent of the persistent
+daemon's launch directory.
 
 **Namespace is derived, not a parameter.** The runner takes no `namespace` argument. It
 derives its namespace from the dispatch token exactly the way `knowledge.stats` and
@@ -236,26 +253,36 @@ schema above hard-codes `precision_at_5`/`recall_at_5` columns precisely because
 fixes the contract at one k — and is out of scope here; a future ADR may add configurable
 k alongside the storage change it requires.
 
-1. Parse the TOML query set at `query_set`, and validate every `[[queries]]` entry before
-   running anything. **Fail-fast contract**: if the file fails to parse, or any entry is
-   invalid (empty/missing `query` text, or an empty `expected_slugs` list), the run
-   **aborts** — no `knowledge_eval_runs` row is written — and `knowledge.eval_retrieval`
-   returns a validation error naming the file path and the 0-indexed position of the
-   offending entry in the `[[queries]]` array. Partial runs are never recorded, so
+1. Require an absolute `query_set`, canonicalize it, parse the TOML file at that canonical
+   path, and validate every `[[queries]]` entry before running anything. **Fail-fast
+   contract**: a relative or unresolvable path aborts with a path-specific validation error
+   before file reading. If TOML syntax fails to parse, the run **aborts** — no
+   `knowledge_eval_runs` row is written — and the validation error names the canonical
+   file path plus the parser's line and column. Once syntax has parsed, an invalid
+   entry (empty/missing `query` text, or an empty `expected_slugs` list) also aborts before
+   retrieval and names the file path plus the offending entry's 0-indexed position in the
+   `[[queries]]` array. A syntactically valid file with no query entries, including an
+   empty or comment-only file, is a whole-file validation error and names the file path.
+   Partial runs are never recorded, so
    `retrieval_eval_run_count` (introduced in D1 above) only ever counts complete, valid
    runs.
-2. For each query, invoke the existing `knowledge.search` runtime path with `limit = 5`
-   and `type = "atom"` (scoped to the runner's namespace, above), collecting the returned
-   atom slugs in rank order (`search` already returns a `slug` field per hit —
-   `crates/khive-pack-knowledge/src/knowledge/search.rs`). Pinning the result type is
-   required, not optional: `search` defaults to `type = "both"`
-   (`crates/khive-pack-knowledge/src/vocab.rs:180-184`), and under that default, domain
-   mirror rows (`"kind": "domain"`,
-   `crates/khive-pack-knowledge/src/knowledge/search.rs:1102-1110`) can occupy top-5
-   slots. Slice 1 is atom-level evaluation — `expected_slugs` are atom slugs by the
-   step-1 contract — so the runner requests atoms at the search call rather than
-   filtering domains out of a mixed top 5 afterwards, which would silently hand the
-   metrics fewer than 5 atom candidates. Call this ordered list
+2. For each query, invoke the existing `knowledge.search` runtime path with `limit = 5`,
+   `type = "atom"`, and `include_drafts = true` (scoped to the runner's namespace, above),
+   collecting the returned atom slugs in rank order (`search` already returns a `slug`
+   field per hit in `crates/khive-pack-knowledge/src/knowledge/search.rs`). Pinning the
+   result type is required, not optional: `search` defaults to `type = "both"`, under
+   which domain mirror rows can occupy top-5 slots. Slice 1 is atom-level evaluation —
+   `expected_slugs` are atom slugs by the step-1 contract — so the runner requests atoms
+   at the search call rather than filtering domains out of a mixed top 5 afterwards,
+   which would silently hand the metrics fewer than 5 atom candidates.
+
+   The draft override is likewise deliberate and fixed, not caller-configurable. Normal
+   agent search excludes draft atoms as its quality-serving default (ADR-047), but the
+   corpus that motivated this ADR was imported without `finalized: true`. Offline
+   evaluation measures retrieval over the complete non-deprecated corpus so retrieval
+   quality does not collapse to zero merely because finalization coverage is zero. This
+   preserves D1's separation between finalization and retrieval quality; it does not
+   change the public `knowledge.search` default. Call this ordered list
    `top_5_returned_slugs`; it may have fewer than 5 entries if the corpus has fewer than 5
    matches.
 3. Score the query directly against `expected_slugs` by set intersection — no
@@ -292,7 +319,7 @@ k alongside the storage change it requires.
 
 ### `knowledge.stats()` reads the last run
 
-`stats()` (`crud.rs:604`) gains two additional reads against `knowledge_eval_runs`, both
+`KnowledgeHandlers::stats` gains two additional reads against `knowledge_eval_runs`, both
 filtered to the token's namespace. Two reads are required by the storage API's shapes:
 `query_scalar` returns the first column of the first row as one `Option<SqlValue>`
 (`crates/khive-storage/src/sql.rs`), so no single scalar read can supply both an
@@ -300,7 +327,7 @@ aggregate count and the latest row's metric columns.
 
 1. A `query_scalar` `COUNT(*)` over the namespace's rows supplies
    `retrieval_eval_run_count`, following the same pattern as the existing
-   `finalized_count` query at `crud.rs:631-638`. Every stored row is a complete valid
+   `finalized_count` query. Every stored row is a complete valid
    run (the fail-fast contract in §"Eval runner mechanics" writes no partial rows), so
    the row count is the run count.
 2. A `query_row` read selecting the most recent row (`ORDER BY run_at DESC LIMIT 1`)
@@ -361,7 +388,7 @@ produces the zero/null sentinel values described above.
 | Alternative                                                                                   | Why rejected                                                                                                                                                                                                                          |
 | --------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | MCP-exposed `knowledge.eval` verb now (Fork 1, Option A)                                      | No demonstrated agent-side demand for triggering evaluation mid-session; would force an immediate ADR-023 amendment and `AGENTS.md` verb-count sync ahead of any measured need. Ruled against (D2); revisit only if usage demands it. |
-| Redefine or rename `eval_coverage` to mean retrieval precision (Fork 3, Option A/rename path) | Breaking change to a legitimate, already-correct finalization metric; breaks the existing `integration.rs:1125` assertion; conflates two orthogonal signals in one field name. Ruled against (D1).                                    |
+| Redefine or rename `eval_coverage` to mean retrieval precision (Fork 3, Option A/rename path) | Breaking change to a legitimate, already-correct finalization metric; breaks the existing `stats_reflects_current_corpus` assertion; conflates two orthogonal signals in one field name. Ruled against (D1).                          |
 | Fold evaluation into `knowledge.index` behind an `--eval` flag (Fork 1, Option C)             | Overloads a verb whose contract is embedding backfill with unrelated evaluation semantics; harder to test the two concerns in isolation.                                                                                              |
 | Async auto-refresh of retrieval-quality on a schedule or post-index hook (Fork 3, Option C)   | Couples eval cadence to indexing/daemon lifecycle; real scope increase (daemon changes) with no corresponding need established for slice-1. Deferred, not rejected outright.                                                          |
 | Feedback-grown query set from `brain.feedback` signals now (Fork 4)                           | Requires a new accumulation table, a labeling contract for `knowledge.search` callers, and its own OSS/private data-policy enforcement — a distinct feature with its own design surface. Deferred to a future ADR.                    |
@@ -369,11 +396,12 @@ produces the zero/null sentinel values described above.
 ## References
 
 - GitHub #80 — retrieval quality measurement loop
+- GitHub #1487 — public implementation issue for the retrieval quality loop
 - Local issue-80 scoping notes — design forks and escalations this ADR resolves
-- [ADR-015](ADR-015-schema-migrations.md) — schema migration mechanism; append-only `VersionedMigration` convention used by §"Schema"
+- [ADR-015](ADR-015-schema-migrations.md) — non-overlapping schema ownership; the pack-owned `SchemaPlan` mechanism used by §"Schema"
 - [ADR-023](ADR-023-declarative-pack-format.md) — `Visibility::{Verb, Subhandler}`; kkernel `exec` CLI verb-DSL; the mechanism D2 relies on
 - [ADR-047](ADR-047-knowledge-pack.md) — Knowledge Pack; `knowledge.stats`, `knowledge.search`, and the 19-verb baseline this ADR extends
 - `crates/khive-retrieval/src/eval/engine_eval.rs` — existing label-based retrieval eval library (`RetrievalLabel`, `LabeledResult`, `recall_at_k`, `precision_at_k`, `ndcg_at_k`, `mrr`, `compute_all`); referenced for contrast in §"Eval runner mechanics" — not called by the runner
-- `crates/khive-pack-knowledge/src/knowledge/crud.rs` — `stats()` (lines 604-680), the `eval_coverage` computation this ADR leaves unchanged
+- `crates/khive-pack-knowledge/src/knowledge/crud.rs` — `KnowledgeHandlers::stats`, including the `eval_coverage` computation this ADR leaves unchanged
 - `crates/khive-pack-knowledge/src/knowledge/search.rs` — atom search result shape (`slug` field) consumed by the eval runner
-- `crates/khive-pack-knowledge/tests/integration.rs` — existing `eval_coverage` assertion (line 1125) and domain-vocabulary fixture corpus (lines 1216-1225)
+- `crates/khive-pack-knowledge/tests/integration.rs` — existing `stats_reflects_current_corpus` assertion and `search_and_compose_workflow` domain-vocabulary fixture corpus

--- a/tests/khive-contract/tests/test_recall_grid_defaults.py
+++ b/tests/khive-contract/tests/test_recall_grid_defaults.py
@@ -1,3 +1,17 @@
+"""Recall tuning-grid defaults contract tests.
+
+ADR: ADR-033
+section: 1. RecallConfig — all weights are parameters
+
+Pins the tuning grid to the shipped `RecallConfig` defaults, so a grid that no
+longer covers what production actually serves cannot silently report a tuning
+result for a configuration space the runtime never occupies. Specifically:
+`fuse_strategy` default `Rrf { k: 10 }`, `candidate_multiplier` default 20, and
+an explicit `candidate_limit` on every candidate pool. Also covers that a tuned
+config round-trips `candidate_limit`, and that the runtime-default baseline
+sends no request-level config at all.
+"""
+
 from __future__ import annotations
 
 import tomllib
@@ -10,6 +24,10 @@ from tune.grid_search import (
     load_grid_dimensions,
     write_results,
 )
+
+# Bare verb name, matching both the sibling modules' convention and the call
+# this suite actually asserts at the RecordingSession call site.
+VERBS_UNDER_TEST = {"recall"}
 
 
 class RecordingSession:

--- a/tests/khive-contract/tests/test_recall_grid_defaults.py
+++ b/tests/khive-contract/tests/test_recall_grid_defaults.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+import tomllib
+from pathlib import Path
+from typing import Any
+
+from tune.grid_search import (
+    evaluate_config,
+    generate_grid,
+    load_grid_dimensions,
+    write_results,
+)
+
+
+class RecordingSession:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, dict[str, Any]]] = []
+
+    def verb(self, verb: str, args: dict[str, Any]) -> list[dict[str, Any]]:
+        self.calls.append((verb, args))
+        return []
+
+
+def test_grid_contains_shipped_rrf_and_candidate_pool_defaults() -> None:
+    dimensions = load_grid_dimensions()
+    assert {"rrf": {"k": 10}} in dimensions["fusion_configs"]
+    assert {
+        "candidate_multiplier": 20,
+        "candidate_limit": 150,
+    } in dimensions["candidate_pools"]
+    assert all(pool["candidate_limit"] is not None for pool in dimensions["candidate_pools"])
+
+    grid = generate_grid()
+    assert len(grid) == 1296
+    assert any(config["fuse_strategy"] == {"rrf": {"k": 10}} for config in grid)
+    assert any(
+        config["candidate_multiplier"] == 20 and config["candidate_limit"] == 150 for config in grid
+    )
+    assert len(generate_grid(quick=True)) == 130
+
+
+def test_tuned_config_round_trips_candidate_limit(tmp_path: Path) -> None:
+    config = generate_grid()[0]
+    result = {
+        "config_index": 0,
+        "config": config,
+        "recall_at_10": 1.0,
+        "mrr": 1.0,
+        "mean_latency_ms": 1.0,
+    }
+
+    write_results(
+        [result],
+        tmp_path,
+        t_total_seconds=1.0,
+        n_eval_queries=1,
+    )
+
+    tuned = tomllib.loads((tmp_path / "tuned-config.toml").read_text())
+    assert tuned["recall"]["candidate_limit"] == config["candidate_limit"]
+
+
+def test_runtime_default_baseline_omits_request_config() -> None:
+    session = RecordingSession()
+    metrics = evaluate_config(
+        session,  # type: ignore[arg-type]
+        None,
+        [{"query": "runtime default", "relevant_indices": []}],
+        {},
+    )
+
+    assert metrics["recall_at_10"] == 0.0
+    assert session.calls == [("recall", {"query": "runtime default", "limit": 10})]

--- a/tests/khive-contract/tests/test_recall_grid_defaults.py
+++ b/tests/khive-contract/tests/test_recall_grid_defaults.py
@@ -25,9 +25,10 @@ from tune.grid_search import (
     write_results,
 )
 
-# Bare verb name, matching both the sibling modules' convention and the call
-# this suite actually asserts at the RecordingSession call site.
-VERBS_UNDER_TEST = {"recall"}
+# Dotted pack.verb form: `memory.recall` is the product wire verb (the bare
+# `recall` name is not on the memory pack's dispatch surface), matching the
+# sibling corpus contract's declaration and the name the live harness sends.
+VERBS_UNDER_TEST = {"memory.recall"}
 
 
 class RecordingSession:
@@ -88,4 +89,4 @@ def test_runtime_default_baseline_omits_request_config() -> None:
     )
 
     assert metrics["recall_at_10"] == 0.0
-    assert session.calls == [("recall", {"query": "runtime default", "limit": 10})]
+    assert session.calls == [("memory.recall", {"query": "runtime default", "limit": 10})]

--- a/tests/khive-contract/tune/README.md
+++ b/tests/khive-contract/tune/README.md
@@ -21,8 +21,8 @@ harness spawns it via stdio).
 
 ```bash
 cd tests/khive-contract
-uv run python -m tune --quick                    # ~10 sec, every 10th config
-uv run python -m tune                            # ~2 min, all 116 configs
+uv run python -m tune --quick                    # balanced 130-config sample
+uv run python -m tune                            # full 1,296-config grid
 uv run python -m tune --output-dir /tmp/my-run   # custom output location
 ```
 
@@ -32,6 +32,17 @@ uv run python -m tune --output-dir /tmp/my-run   # custom output location
 - `tuned-config.toml` — recommended config (synthesized from the best-scoring
   set; see REPORT.md for honesty about how meaningful this is)
 - `REPORT.md` — analysis writeup
+
+Grid dimensions live in
+`crates/khive-pack-memory/testdata/recall_tuning_grid.json`. The Python runner
+and a Rust conformance test consume that same file, and the default comparison
+omits the request-level config so it measures the runtime's actual
+`RecallConfig::default()`.
+
+Every candidate uses an explicit `candidate_limit`. TOML cannot distinguish
+`candidate_limit = None` from an omitted field, and omission restores the
+runtime default of 150, so multiplier-only candidates are excluded to keep the
+generated `tuned-config.toml` reproducible.
 
 ## Known limitation
 

--- a/tests/khive-contract/tune/grid_search.py
+++ b/tests/khive-contract/tune/grid_search.py
@@ -44,6 +44,9 @@ RANDOM_SEED = 42
 _HERE = Path(__file__).parent
 DEFAULT_CORPUS = _HERE.parent / "fixtures" / "memories_corpus.json"
 DEFAULT_OUTPUT = _HERE
+GRID_DIMENSIONS = (
+    _HERE.parents[2] / "crates" / "khive-pack-memory" / "testdata" / "recall_tuning_grid.json"
+)
 
 # Weight constants for the combined discriminating score (v2 only)
 _MRR_WEIGHT = 0.5
@@ -75,6 +78,24 @@ def load_corpus(path: Path) -> tuple[list[dict[str, Any]], list[dict[str, Any]],
     eval_queries: list[dict[str, Any]] = data["eval_queries"]
     version = _detect_corpus_version(data)
     return memories, eval_queries, version
+
+
+def load_grid_dimensions(path: Path = GRID_DIMENSIONS) -> dict[str, Any]:
+    """Load the grid dimensions shared with the Rust default-conformance test."""
+    data = json.loads(path.read_text())
+    required = {
+        "weight_triples",
+        "candidate_pools",
+        "fusion_configs",
+        "decay_models",
+        "temporal_half_life_days",
+        "min_salience_values",
+        "fixed",
+    }
+    missing = sorted(required - data.keys())
+    if missing:
+        raise ValueError(f"grid dimensions missing required keys: {', '.join(missing)}")
+    return data
 
 
 # ---------------------------------------------------------------------------
@@ -166,7 +187,7 @@ def _resolve_relevant_ids_v2(
 
 def evaluate_config(
     session: KhiveMcpSession,
-    config_dict: dict[str, Any],
+    config_dict: dict[str, Any] | None,
     eval_queries: list[dict[str, Any]],
     note_id_map: dict[str, str],
     *,
@@ -211,10 +232,10 @@ def evaluate_config(
 
         t0 = time.perf_counter()
         try:
-            hits = session.verb(
-                "recall",
-                {"query": query, "limit": limit, "config": config_dict},
-            )
+            args: dict[str, Any] = {"query": query, "limit": limit}
+            if config_dict is not None:
+                args["config"] = config_dict
+            hits = session.verb("recall", args)
         except Exception:
             hits = []
         latency_ms = (time.perf_counter() - t0) * 1000.0
@@ -300,8 +321,8 @@ def evaluate_config(
 def generate_grid(quick: bool = False) -> list[dict[str, Any]]:
     """Generate the FTS-only RecallConfig parameter grid.
 
-    Full grid (v2): 4 × 4 × 8 × 3 × 3 × 2 = 2304 configs
-    Quick grid:     every 20th config (deterministic sort) ≈ 116 configs
+    Full grid (v2): 4 × 2 × 9 × 3 × 3 × 2 = 1296 configs
+    Quick grid:     one in ten configs, balanced by min_salience = 130 configs
 
     v2 adds min_salience variation which DOES discriminate on the v2 corpus:
     - min_salience=0.0: retrieves all items including low-salience traps
@@ -313,48 +334,24 @@ def generate_grid(quick: bool = False) -> list[dict[str, Any]]:
     weighted configs with high vector alpha will score poorly — this is
     expected and meaningful for the grid.
     """
-    weight_triples = [
-        # (relevance_weight, salience_weight, temporal_weight)
-        (0.70, 0.20, 0.10),  # default
-        (0.60, 0.30, 0.10),
-        (0.60, 0.20, 0.20),
-        (0.80, 0.10, 0.10),
-    ]
-
-    candidate_pools = [
-        # (candidate_multiplier, candidate_limit)
-        (10, None),
-        (20, None),   # default
-        (40, None),
-        (20, 100),
-    ]
-
-    # 3 RRF + 5 weighted = 8 fusion configs
-    fusion_configs: list[dict[str, Any]] = [
-        {"rrf": {"k": 20}},
-        {"rrf": {"k": 60}},   # default
-        {"rrf": {"k": 100}},
-        {"weighted": {"weights": [1.0, 0.0]}},    # text-only
-        {"weighted": {"weights": [0.75, 0.25]}},
-        {"weighted": {"weights": [0.5, 0.5]}},
-        {"weighted": {"weights": [0.25, 0.75]}},
-        {"weighted": {"weights": [0.0, 1.0]}},    # vector-only
-    ]
-
-    decay_models = ["exponential", "hyperbolic", "none"]
-    half_lives = [14.0, 30.0, 60.0]
-
-    # min_salience variation: the key discriminating dimension for v2 corpus.
-    # 0.0 includes all items (even low-salience traps).
-    # 0.40 filters out importance_trap memories (salience 0.26-0.35) from results,
-    # which FAILS importance_trap queries (those expected items have salience < 0.40).
-    # This creates measurable discrimination: configs with min_salience=0.0 find trap
-    # items; configs with min_salience=0.40 do not.
-    min_salience_values = [0.0, 0.40]
+    dimensions = load_grid_dimensions()
+    weight_triples = dimensions["weight_triples"]
+    candidate_pools = dimensions["candidate_pools"]
+    fusion_configs = dimensions["fusion_configs"]
+    decay_models = dimensions["decay_models"]
+    half_lives = dimensions["temporal_half_life_days"]
+    min_salience_values = dimensions["min_salience_values"]
+    min_score = dimensions["fixed"]["min_score"]
 
     configs: list[dict[str, Any]] = []
     for rw, iw, tw in weight_triples:
-        for cm, cl in candidate_pools:
+        for pool in candidate_pools:
+            cm = pool["candidate_multiplier"]
+            cl = pool["candidate_limit"]
+            if cl is None:
+                raise ValueError(
+                    "candidate_limit must be explicit so tuned TOML can reproduce the candidate"
+                )
             for fuse in fusion_configs:
                 for decay in decay_models:
                     for hl in half_lives:
@@ -364,26 +361,19 @@ def generate_grid(quick: bool = False) -> list[dict[str, Any]]:
                                 "salience_weight": iw,
                                 "temporal_weight": tw,
                                 "candidate_multiplier": cm,
+                                "candidate_limit": cl,
                                 "fuse_strategy": fuse,
                                 "decay_model": decay,
                                 "temporal_half_life_days": hl,
-                                "min_score": 0.0,
+                                "min_score": min_score,
                                 "min_salience": ms,
                             }
-                            if cl is not None:
-                                cfg["candidate_limit"] = cl
                             configs.append(cfg)
 
     if quick:
-        # Sample the grid to get ~116 configs while preserving both min_salience values.
-        # Because min_salience alternates as the innermost dimension, we take every 10th
-        # config from the even positions (ms=0.0 group) and every 10th from the odd
-        # positions (ms=0.4 group), then interleave them. This ensures both values appear.
-        ms0_configs = configs[::2]   # every even index = min_salience=0.0
-        ms04_configs = configs[1::2] # every odd index = min_salience=0.40
-        sampled_ms0 = ms0_configs[::10]    # ~58 configs
-        sampled_ms04 = ms04_configs[::10]  # ~58 configs
-        configs = sampled_ms0 + sampled_ms04  # ~116 total
+        ms0_configs = configs[::2]
+        ms04_configs = configs[1::2]
+        configs = ms0_configs[::10] + ms04_configs[::10]
 
     return configs
 
@@ -486,11 +476,9 @@ def write_results(
     toml_filename = "tuned-config.toml" if version == "v1" else "tuned-config-v2.toml"
     fuse_toml = _fuse_to_toml(cfg["fuse_strategy"])
     decay_model_str = cfg["decay_model"] if isinstance(cfg["decay_model"], str) else json.dumps(cfg["decay_model"])
-    cl_line = (
-        f"candidate_limit = {cfg['candidate_limit']}"
-        if cfg.get("candidate_limit") is not None
-        else "# candidate_limit = null  (use multiplier only)"
-    )
+    candidate_limit = cfg.get("candidate_limit")
+    if candidate_limit is None:
+        raise ValueError("winning candidate_limit must be explicit so tuned TOML can reproduce it")
     score_comment = (
         f"# combined_score = {winner['combined_score']:.4f}  "
         f"(mrr_expected={winner['mrr_expected']:.4f} precision_at_k={winner['precision_at_k']:.4f} "
@@ -512,7 +500,7 @@ temporal_weight = {cfg['temporal_weight']}
 temporal_half_life_days = {cfg['temporal_half_life_days']}
 decay_model = "{decay_model_str}"
 candidate_multiplier = {cfg['candidate_multiplier']}
-{cl_line}
+candidate_limit = {candidate_limit}
 fuse_strategy = {fuse_toml}
 min_score = {cfg['min_score']}
 min_salience = {cfg['min_salience']}
@@ -536,9 +524,10 @@ min_salience = {cfg['min_salience']}
             fuse_str = str(fuse)
         decay_str = c["decay_model"] if isinstance(c["decay_model"], str) else json.dumps(c["decay_model"])
         ms = c.get("min_salience", 0.0)
+        candidate_limit = c.get("candidate_limit")
         return (
             f"rel={c['relevance_weight']} sal={c['salience_weight']} "
-            f"tmp={c['temporal_weight']} cand={c['candidate_multiplier']} "
+            f"tmp={c['temporal_weight']} cand={c['candidate_multiplier']}/{candidate_limit} "
             f"fuse={fuse_str} decay={decay_str} hl={c['temporal_half_life_days']} "
             f"ms={ms}"
         )
@@ -583,7 +572,7 @@ min_salience = {cfg['min_salience']}
 | recall_at_10 | {default_config_metrics['recall_at_10']:.4f} | {winner['recall_at_10']:.4f} | {winner['recall_at_10'] - default_config_metrics['recall_at_10']:+.4f} |
 | mean latency | {default_config_metrics['mean_latency_ms']:.1f}ms | {winner['mean_latency_ms']:.1f}ms | {winner['mean_latency_ms'] - default_config_metrics['mean_latency_ms']:+.1f}ms |
 
-Default config: relevance=0.70 salience=0.20 temporal=0.10 candidate_multiplier=20 fuse=rrf(k=60) decay=exponential half_life=30.0
+Default config: runtime `RecallConfig::default()` (evaluated without a request override).
 """
         else:
             default_section = f"""
@@ -595,7 +584,7 @@ Default config: relevance=0.70 salience=0.20 temporal=0.10 candidate_multiplier=
 | MRR | {default_config_metrics['mrr']:.4f} | {winner['mrr']:.4f} | {winner['mrr'] - default_config_metrics['mrr']:+.4f} |
 | mean latency | {default_config_metrics['mean_latency_ms']:.1f}ms | {winner['mean_latency_ms']:.1f}ms | {winner['mean_latency_ms'] - default_config_metrics['mean_latency_ms']:+.1f}ms |
 
-Default config: relevance=0.70 salience=0.20 temporal=0.10 candidate_multiplier=20 fuse=rrf(k=60) decay=exponential half_life=30.0
+Default config: runtime `RecallConfig::default()` (evaluated without a request override).
 """
 
     if version == "v2":
@@ -669,18 +658,6 @@ Parameters: `{_cfg_summary(winner)}`
 # CLI entry point
 # ---------------------------------------------------------------------------
 
-_DEFAULT_CONFIG = {
-    "relevance_weight": 0.70,
-    "salience_weight": 0.20,
-    "temporal_weight": 0.10,
-    "candidate_multiplier": 20,
-    "fuse_strategy": {"rrf": {"k": 60}},
-    "decay_model": "exponential",
-    "temporal_half_life_days": 30.0,
-    "min_score": 0.0,
-    "min_salience": 0.0,
-}
-
 
 def main() -> None:
     parser = argparse.ArgumentParser(
@@ -721,9 +698,9 @@ def main() -> None:
     t_start = time.perf_counter()
     session, note_id_map = setup_session(memories, version=version)
     try:
-        # Evaluate default config for the comparison table
+        # Omitting config exercises the runtime's actual RecallConfig::default().
         default_metrics = evaluate_config(
-            session, _DEFAULT_CONFIG, eval_queries, note_id_map, version=version
+            session, None, eval_queries, note_id_map, version=version
         )
         if version == "v2":
             print(

--- a/tests/khive-contract/tune/grid_search.py
+++ b/tests/khive-contract/tune/grid_search.py
@@ -140,7 +140,7 @@ def setup_session(
         if mem.get("tags"):
             args["tags"] = mem["tags"]
 
-        result = session.verb("remember", args)
+        result = session.verb("memory.remember", args)
         note_id = result["id"] if result else None
         if not note_id:
             raise RuntimeError(f"remember() returned no id for memory {i}: {result!r}")
@@ -235,7 +235,7 @@ def evaluate_config(
             args: dict[str, Any] = {"query": query, "limit": limit}
             if config_dict is not None:
                 args["config"] = config_dict
-            hits = session.verb("recall", args)
+            hits = session.verb("memory.recall", args)
         except Exception:
             hits = []
         latency_ms = (time.perf_counter() - t0) * 1000.0

--- a/tests/khive-contract/tune/tuned-config.toml
+++ b/tests/khive-contract/tune/tuned-config.toml
@@ -11,7 +11,7 @@ temporal_weight = 0.1
 temporal_half_life_days = 14.0
 decay_model = "hyperbolic"
 candidate_multiplier = 10
-# candidate_limit = null  (use multiplier only)
+candidate_limit = 150
 fuse_strategy = {weighted = {weights = [1.0, 0.0]}}
 min_score = 0.0
 min_salience = 0.0


### PR DESCRIPTION
> AI-assisted contribution: Codex prepared this change and PR description.

## Summary

- add a reproducible, extensible TOML query-set format and a fixed-`k=5`
  retrieval evaluator that persists namespace-scoped precision, recall, and MRR
  runs
- expose the latest evaluation state through additive
  `knowledge.stats()` fields while preserving the established finalization
  meaning of `eval_coverage`
- keep `knowledge.eval_retrieval` operator-only as a registry subhandler, so it
  is callable by administrative tooling but is absent from the public MCP verb
  catalog
- make the recall tuning grid consume one shared machine-readable dimension
  definition, include the shipped RRF `k=10` and candidate-limit `150`
  defaults, and fail when Rust defaults drift from the grid
- document the accepted ADR-082 measurement contract and include a ten-query
  fixture that can grow without a schema migration

## Contract notes

Issue #1487 predates the accepted ADR-082 decision. This implementation follows
that decision rather than redefining the existing `eval_coverage` field:

- `eval_coverage` continues to measure finalized knowledge atoms
- retrieval evaluation adds `retrieval_eval_coverage`,
  `retrieval_eval_run_count`, `retrieval_eval_last_run_at`, and
  `retrieval_eval_last_mrr`
- each evaluation response reports `precision_at_5`, `recall_at_5`, and `mrr`
- evaluation is an operator/admin subhandler, not a public MCP verb

Query-set paths must be absolute and resolve canonically. Invalid TOML, empty
queries, empty expected-slug sets, and persistence failures fail before a
successful run is reported. Runs and stats are scoped to the explicit request
namespace.

## Validation

- [x] Independent exact-head review: **READY, no findings**
- [x] Exact head: `0f4b15522f1b0c138af90c0f3f8676a95b5d5128`
- [x] Current-main parent: `80eb3947cee774941a3c55af759c826786883ea1`
- [x] `cargo test --manifest-path crates/Cargo.toml --workspace`
- [x] `cargo check --manifest-path crates/Cargo.toml --workspace`
- [x] `cargo clippy --manifest-path crates/Cargo.toml --workspace --all-targets -- -D warnings`
- [x] `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- [x] `RUSTDOCFLAGS=-Dwarnings cargo doc --manifest-path crates/Cargo.toml --workspace --no-deps`
- [x] `uv run pytest tests/khive-contract/tests/test_recall_grid_defaults.py` (3/3)
- [x] `git diff --check 80eb3947cee774941a3c55af759c826786883ea1..HEAD`

Closes #1487
Closes #1746
