### PR TITLE
fix(gtd): enforce canonical task writes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -120,10 +120,16 @@ Full `gtd.transition` allowed transitions:
 `done` and `cancelled` are terminal.
 
 `gtd.transition` returns one of two shapes. On a real transition: `{transitioned: true, id, full_id,
-from, to, is_terminal, title, priority, assignee, due}` — `is_terminal: true` when the task reaches
-`done` or `cancelled`. On an idempotent no-op (the task is already in the requested status): `{transitioned:
-false, id, full_id, from, to, note: "already in target status"}` — the task fields (`title`, `priority`,
-`assignee`, `due`, `is_terminal`) are omitted. Branch on `transitioned` before reading those fields.
+from, to, is_terminal, title, priority, assignee, due, audit_persisted}` — `is_terminal: true` when
+the task reaches `done` or `cancelled`; `audit_persisted: false` means the state change committed but
+its best-effort lifecycle-audit append failed. On an idempotent no-op (the task is already in the
+requested status): `{transitioned: false, id, full_id, from, to, note: "already in target status"}` —
+the task fields (`title`, `priority`, `assignee`, `due`, `is_terminal`) are omitted. Canonical
+dispatch with a caller-supplied transition note additionally returns `note_recorded` and, when that
+note write wins its guard, `audit_persisted`; atomic v1 treats every same-status transition as a
+mutation-free guarded assertion and does not persist that note. The assertion revalidates the exact
+prepare snapshot so an earlier op in the same atomic unit cannot make the no-op stale. Branch on
+`transitioned` before reading those fields.
 
 ### Memory pack — 5 verbs (`memory.` prefix, [ADR-021](docs/adr/ADR-021-memory-pack.md))
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -256,7 +256,7 @@ Load with `KHIVE_PACKS=kg,gtd` or `--pack gtd`. Adds the `task` note kind.
 | ---------------- | ---------------------------------------------------------------------------- | ----------------------------------------------------------- |
 | `gtd.assign`     | `title`, `priority?`, `status?`, `assignee?`, `due?`, `depends_on?`, `tags?` | Create a task (defaults: status=inbox, priority=p2)         |
 | `gtd.next`       | `limit?`, `assignee?`                                                        | List actionable tasks (status ∈ next/active), priority-sort |
-| `gtd.complete`   | `id`, `result?`                                                              | Validate transition → done, record `completed_at`           |
+| `gtd.complete`   | `id`, `status?` (`done` or `cancelled`), `result?`                            | Validate a terminal transition (default `done`), record `completed_at` |
 | `gtd.tasks`      | `status?`, `assignee?`, `priority?`, `limit?`, `offset?`                     | Filtered task listing                                       |
 | `gtd.transition` | `id`, `status`, `note?`                                                      | Explicit lifecycle change with `can_transition` validation  |
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -252,13 +252,13 @@ Mixing a granular `kind` with a contradicting `entity_kind`/`note_kind` sub-filt
 
 Load with `KHIVE_PACKS=kg,gtd` or `--pack gtd`. Adds the `task` note kind.
 
-| Verb             | Args                                                                         | What it does                                                |
-| ---------------- | ---------------------------------------------------------------------------- | ----------------------------------------------------------- |
-| `gtd.assign`     | `title`, `priority?`, `status?`, `assignee?`, `due?`, `depends_on?`, `tags?` | Create a task (defaults: status=inbox, priority=p2)         |
-| `gtd.next`       | `limit?`, `assignee?`                                                        | List actionable tasks (status ∈ next/active), priority-sort |
-| `gtd.complete`   | `id`, `status?` (`done` or `cancelled`), `result?`                            | Validate a terminal transition (default `done`), record `completed_at` |
-| `gtd.tasks`      | `status?`, `assignee?`, `priority?`, `limit?`, `offset?`                     | Filtered task listing                                       |
-| `gtd.transition` | `id`, `status`, `note?`                                                      | Explicit lifecycle change with `can_transition` validation  |
+| Verb             | Args                                                                         | What it does                                                           |
+| ---------------- | ---------------------------------------------------------------------------- | ---------------------------------------------------------------------- |
+| `gtd.assign`     | `title`, `priority?`, `status?`, `assignee?`, `due?`, `depends_on?`, `tags?` | Create a task (defaults: status=inbox, priority=p2)                    |
+| `gtd.next`       | `limit?`, `assignee?`                                                        | List actionable tasks (status ∈ next/active), priority-sort            |
+| `gtd.complete`   | `id`, `status?` (`done` or `cancelled`), `result?`                           | Validate a terminal transition (default `done`), record `completed_at` |
+| `gtd.tasks`      | `status?`, `assignee?`, `priority?`, `limit?`, `offset?`                     | Filtered task listing                                                  |
+| `gtd.transition` | `id`, `status`, `note?`                                                      | Explicit lifecycle change with `can_transition` validation             |
 
 ### Memory pack verbs (5 — ADR-021, optional)
 

--- a/crates/khive-db/src/stores/note.rs
+++ b/crates/khive-db/src/stores/note.rs
@@ -109,6 +109,70 @@ pub fn note_upsert_statement(note: &Note) -> SqlStatement {
     }
 }
 
+/// Full-note compare-and-swap update used after caller-side normalization was
+/// derived from a read snapshot. Unlike [`note_upsert_statement`], this never
+/// inserts and cannot overwrite a row whose revision or deletion marker moved
+/// after the snapshot was read. The replacement revision must also be strictly
+/// greater than the persisted snapshot revision; equality is a refused CAS,
+/// never a successful write with an unchanged concurrency token.
+pub fn note_replace_if_unchanged_statement(
+    note: &Note,
+    expected_updated_at: i64,
+    expected_deleted_at: Option<i64>,
+) -> SqlStatement {
+    let properties_str = note
+        .properties
+        .as_ref()
+        .map(|v| serde_json::to_string(v).unwrap_or_default());
+    SqlStatement {
+        sql: "UPDATE notes SET \
+                namespace = ?1, kind = ?2, status = ?3, name = ?4, content = ?5, \
+                salience = ?6, decay_factor = ?7, expires_at = ?8, properties = ?9, \
+                updated_at = ?10, deleted_at = ?11 \
+              WHERE id = ?12 AND updated_at = ?13 AND deleted_at IS ?14 \
+                AND ?10 > updated_at"
+            .to_string(),
+        params: vec![
+            SqlValue::Text(note.namespace.clone()),
+            SqlValue::Text(note.kind.to_string()),
+            SqlValue::Text(note.status.clone()),
+            match &note.name {
+                Some(name) => SqlValue::Text(name.clone()),
+                None => SqlValue::Null,
+            },
+            SqlValue::Text(note.content.clone()),
+            match note.salience {
+                Some(value) => SqlValue::Float(value),
+                None => SqlValue::Null,
+            },
+            match note.decay_factor {
+                Some(value) => SqlValue::Float(value),
+                None => SqlValue::Null,
+            },
+            match note.expires_at {
+                Some(value) => SqlValue::Integer(value),
+                None => SqlValue::Null,
+            },
+            match properties_str {
+                Some(value) => SqlValue::Text(value),
+                None => SqlValue::Null,
+            },
+            SqlValue::Integer(note.updated_at),
+            match note.deleted_at {
+                Some(value) => SqlValue::Integer(value),
+                None => SqlValue::Null,
+            },
+            SqlValue::Text(note.id.to_string()),
+            SqlValue::Integer(expected_updated_at),
+            match expected_deleted_at {
+                Some(value) => SqlValue::Integer(value),
+                None => SqlValue::Null,
+            },
+        ],
+        label: Some("note-replace-if-unchanged".to_string()),
+    }
+}
+
 /// The exact `properties`/`updated_at` `UPDATE` this store's
 /// `update_note_properties` issues. The row is patched in place without
 /// rewriting any other note column or its stable row identity (#780).
@@ -672,6 +736,15 @@ fn build_note_filter_where(
                     n = params.len()
                 ));
             }
+            FilterOp::TextEqOrNonText => {
+                let expr = json_extract_expr(&pf.json_path);
+                let type_expr = json_type_expr(&pf.json_path);
+                params.push(sql_value_param(&pf.value)?);
+                let n = params.len();
+                conditions.push(format!(
+                    "CASE WHEN {type_expr} = 'text' THEN {expr} ELSE ?{n} END = ?{n}"
+                ));
+            }
             FilterOp::JsonTypeEq => {
                 let type_expr = json_type_expr(&pf.json_path);
                 params.push(sql_value_param(&pf.value)?);
@@ -723,6 +796,7 @@ fn build_note_filter_where(
                     FilterOp::Gt => ">",
                     FilterOp::Gte => ">=",
                     FilterOp::EqOrMissing
+                    | FilterOp::TextEqOrNonText
                     | FilterOp::JsonTypeEq
                     | FilterOp::JsonTypeNeMissing
                     | FilterOp::In(_)
@@ -759,6 +833,22 @@ impl NoteStore for SqlNoteStore {
             stmt.raw_execute()?;
             assign_note_seq(conn, &id_str)?;
             Ok(())
+        })
+        .await
+    }
+
+    async fn replace_note_if_unchanged(
+        &self,
+        note: Note,
+        expected_updated_at: i64,
+        expected_deleted_at: Option<i64>,
+    ) -> Result<bool, StorageError> {
+        let statement =
+            note_replace_if_unchanged_statement(&note, expected_updated_at, expected_deleted_at);
+        self.with_writer("replace_note_if_unchanged", move |conn| {
+            let mut stmt = conn.prepare(&statement.sql)?;
+            bind_params(&mut stmt, &statement.params)?;
+            Ok(stmt.raw_execute()? > 0)
         })
         .await
     }

--- a/crates/khive-db/src/stores/note_tests.rs
+++ b/crates/khive-db/src/stores/note_tests.rs
@@ -92,6 +92,48 @@ async fn test_upsert_and_get_note() {
 }
 
 #[tokio::test]
+async fn replace_note_cas_requires_new_revision_strictly_greater_than_snapshot() {
+    let store = setup_memory_store();
+    let mut original = make_note("default", "observation", "original");
+    original.created_at = 100;
+    original.updated_at = 100;
+    let id = original.id;
+    store.upsert_note(original.clone()).await.unwrap();
+
+    for refused_revision in [99, 100] {
+        let mut replacement = original.clone();
+        replacement.content = format!("must-not-land-{refused_revision}");
+        replacement.updated_at = refused_revision;
+        assert!(
+            !store
+                .replace_note_if_unchanged(replacement, original.updated_at, original.deleted_at)
+                .await
+                .unwrap(),
+            "CAS must refuse replacement revision {refused_revision} when the snapshot revision is {}",
+            original.updated_at
+        );
+        assert_eq!(
+            store.get_note(id).await.unwrap().unwrap().content,
+            "original"
+        );
+    }
+
+    let mut advanced = original.clone();
+    advanced.content = "advanced".to_string();
+    advanced.updated_at = 101;
+    assert!(
+        store
+            .replace_note_if_unchanged(advanced, original.updated_at, original.deleted_at)
+            .await
+            .unwrap(),
+        "a strictly newer revision must still satisfy the CAS"
+    );
+    let persisted = store.get_note(id).await.unwrap().unwrap();
+    assert_eq!(persisted.content, "advanced");
+    assert_eq!(persisted.updated_at, 101);
+}
+
+#[tokio::test]
 async fn test_kind_roundtrip_all_variants() {
     let store = setup_memory_store();
     for kind in [

--- a/crates/khive-pack-gtd/README.md
+++ b/crates/khive-pack-gtd/README.md
@@ -22,6 +22,11 @@ unique 8+ character hexadecimal prefix resolves without a namespace filter,
 as required by ADR-007. The task keeps its original namespace attribution;
 authorization remains the Gate's responsibility.
 
+`gtd.complete` accepts every non-terminal lifecycle state, matching the same
+transition table as `gtd.transition`. Successful state changes report
+`audit_persisted`; `false` means the task write committed but the best-effort
+lifecycle-audit append failed.
+
 ## Task lifecycle
 
 The `task` note kind's lifecycle field is `kind_status` (not `status` — that

--- a/crates/khive-pack-gtd/docs/api/lifecycle-audit.md
+++ b/crates/khive-pack-gtd/docs/api/lifecycle-audit.md
@@ -1,8 +1,8 @@
 # Lifecycle audit trail (`src/handlers.rs`)
 
-Every `gtd.transition` and `gtd.complete` invocation is recorded into a
-`gtd_lifecycle_audit` table for replay and compliance (ADR-019). This
-document covers the write path's implementation details that don't belong
+Every state-changing `gtd.transition` and `gtd.complete` invocation attempts
+to append to a `gtd_lifecycle_audit` table for replay and compliance (ADR-019).
+This document covers the write path's implementation details that don't belong
 in the caller-facing contract on `handle_transition`/`handle_complete`.
 
 ## `ensure_audit_schema` — why per-call, not `OnceLock`
@@ -16,9 +16,9 @@ without the audit table. In production this per-call DDL is idempotent and
 cheap: SQLite skips an `IF NOT EXISTS` table creation near-instantly once
 the table already exists.
 
-## Why `ensure_audit_schema` and `write_audit_record` are `pub`
+## Why the lifecycle-audit helpers are `pub`
 
-Unlike every other helper in `handlers.rs`, these two are `pub` rather than
+Unlike every other helper in `handlers.rs`, these are `pub` rather than
 module-private. The ADR-099 `--atomic` CLI surface's `gtd.transition`/
 `gtd.complete` prepare functions live in `kkernel` (a crate that already
 depends on both `khive-runtime` and `khive-pack-gtd` — see that crate's
@@ -30,18 +30,30 @@ statement a second time in `kkernel`.
 
 Audit writes are best-effort: a failure to write the audit row is logged and
 does not fail the transition/complete call itself, since the state change
-already committed successfully.
+already committed successfully. `write_audit_record_with_status` returns a
+boolean, and the canonical and atomic real-transition response builders expose
+it as `audit_persisted`. The original public `write_audit_record` remains a
+unit-returning compatibility wrapper. This keeps the auxiliary append non-fatal
+without silently claiming a complete audit trail.
 
-## Same-status rows: note-bearing no-ops are audited
+## Same-status rows: canonical and atomic behavior
 
 A `gtd.transition` call where `current == target` normally writes no audit
-row — an idempotent no-op is not a lifecycle event. The one exception is a
-no-op that carries a caller-supplied `note`: the note is persisted to
-`properties.transition_note` (last-write-wins), and a same-status audit row
-(`from_state == to_state`) is written so each overwritten note keeps a
-durable trail. Consumers counting or replaying *real* transitions must
-therefore filter `from_state != to_state`; same-status rows are note events,
-not lifecycle changes.
+row — an idempotent no-op is not a lifecycle event. On canonical dispatch, a
+no-op that carries a caller-supplied `note` is the exception: the note is
+persisted to `properties.transition_note` (last-write-wins), and a same-status
+audit row (`from_state == to_state`) is attempted so each overwritten note can
+keep a durable trail. Its response carries `note_recorded` and, when the note
+write wins, `audit_persisted`. Consumers counting or replaying *real*
+transitions must therefore filter `from_state != to_state`; same-status rows
+are note events, not lifecycle changes.
+
+ADR-099 atomic v1 encodes every same-status transition as a guarded no-effect
+assertion, including calls that supplied `note`. The assertion revalidates the
+prepare snapshot inside the commit transaction, while the call still returns
+the base no-op shape, persists neither the note nor an audit row, and omits
+both status fields. Call canonical `gtd.transition` when a same-status note
+must be recorded.
 
 ## `CompleteParams` / `TransitionParams` — `pub` structs, private fields
 

--- a/crates/khive-pack-gtd/docs/design.md
+++ b/crates/khive-pack-gtd/docs/design.md
@@ -26,7 +26,12 @@
 - Declares vocabulary via constants: `NOTE_KINDS`, `ENTITY_KINDS`, `HANDLERS`, `EDGE_RULES`,
   `NOTE_KIND_SPECS`, `SCHEMA_PLAN`.
 - The `TaskHook` implements the `KindHook` extension point: normalizes GTD fields on
-  `prepare_create` and wires `depends_on` graph edges on `after_create` (best-effort).
+  `prepare_create`, synchronizes task content/description on `prepare_note_update`,
+  and wires `depends_on` graph edges on `after_create` (best-effort).
+- Generic create validates the raw shared `CreateParams` shape before `prepare_create`,
+  so normalization cannot hide malformed `name`, `content`, or `salience` values.
+- Update normalization and persistence share one note snapshot. Canonical persistence
+  compare-and-swaps it; atomic persistence carries the same revision guard into commit.
 - `EDGE_RULES` contains one rule: `depends_on` between two `task` notes (task→task).
 - Endpoint rules are additive only — this pack cannot tighten the base contract.
 
@@ -35,10 +40,11 @@
 - Five verbs: `gtd.assign`, `gtd.next`, `gtd.complete`, `gtd.tasks`, `gtd.transition`.
 - Lifecycle states: `inbox → next | waiting | someday | active | done | cancelled`.
 - `done` and `cancelled` are permanently terminal (no reopen; issue #273).
-- `complete()` is restricted to actionable states (`next`, `active`). Tasks in `inbox`,
-  `waiting`, or `someday` must be explicitly transitioned to an actionable state first.
-- `gtd_lifecycle_audit` table records every `transition` and `complete` invocation for
-  replay and compliance. Writes are best-effort (non-fatal on failure).
+- `complete()` validates its `done`/`cancelled` target against the same lifecycle table as
+  `transition`; every non-terminal state has a legal direct terminal transition.
+- `gtd_lifecycle_audit` receives best-effort rows for successful real transitions,
+  completions, and canonical same-status note events. Writes are non-fatal on failure,
+  and attempted-write responses expose `audit_persisted` so loss is never silent.
 - `depends_on` property stores UUIDs of blocking tasks; `gtd.next` excludes tasks whose
   blockers are not in `done` state by default. Query results report `dependency_state`,
   `actionable`, and structural `blocked_by` diagnostics; `include_blocked=true` makes
@@ -90,15 +96,17 @@
 - The KG `get` and `list` handlers apply a remap: `properties.status` is promoted to the
   top-level `status` field; the row-visibility value moves to `lifecycle`. Tests verify this.
 
-### `complete()` actionable-state gate (UE2-H1)
+### `complete()` lifecycle-table parity
 
-- `complete()` rejects tasks in non-actionable states (`inbox`, `waiting`, `someday`) with
-  a message directing the caller to transition first. `transition(status=done)` bypasses
-  this gate for use cases where direct terminal transition is intended.
+- `complete()` uses the same `can_transition` contract as `transition`: `inbox`, `next`,
+  `active`, `waiting`, and `someday` may all move directly to `done` or `cancelled`.
+  `done` and `cancelled` remain permanently terminal.
 
 ### Atomic transition
 
 - Both `complete()` and `transition()` use a conditional SQL UPDATE with a
-  `json_extract(properties, '$.status') = expected_current` WHERE predicate. This ensures
-  that concurrent calls in a parallel DSL batch only one wins; the other gets
-  `rows_affected = 0` and returns an error rather than a false success.
+  WHERE predicate over the exact decision snapshot's `updated_at`, `deleted_at`, and
+  semantic GTD status. Missing legacy `properties.status` is compared as `inbox`.
+  This ensures that concurrent lifecycle calls and generic task updates cannot
+  overwrite one another: the loser gets `rows_affected = 0` and returns an error,
+  while a mixed atomic unit rolls back in full.

--- a/crates/khive-pack-gtd/src/handlers.rs
+++ b/crates/khive-pack-gtd/src/handlers.rs
@@ -5,7 +5,7 @@
 //!
 //! FILE SIZE JUSTIFICATION: All five GTD verb handlers (`assign`, `next`, `complete`,
 //! `tasks`, `transition`) share internal helpers (`load_task`, `atomic_gtd_transition`,
-//! `ensure_audit_schema`, `write_audit_record`) that access `pub(crate)` symbols and
+//! `ensure_audit_schema`, `write_audit_record_with_status`) that access `pub(crate)` symbols and
 //! must stay co-located to avoid circular imports within the crate. Splitting by verb
 //! would require either making those helpers `pub` (which widens the API surface) or
 //! duplicating them. The file is reviewed against this invariant at each significant
@@ -23,8 +23,8 @@ use khive_storage::note::{FilterOp, NoteFilter, PropertyFilter};
 use khive_storage::types::{PageRequest, SqlStatement, SqlValue};
 
 use crate::schema::{
-    allowed_transitions, can_transition, is_actionable, is_terminal, is_valid_priority,
-    is_valid_status, normalize_status, TASK_LIFECYCLE_HELP,
+    allowed_transitions, can_transition, is_terminal, is_valid_priority, is_valid_status,
+    normalize_status, TASK_LIFECYCLE_HELP,
 };
 use crate::GtdPack;
 
@@ -52,7 +52,7 @@ pub async fn ensure_audit_schema(runtime: &KhiveRuntime) {
 
     // `CREATE TABLE IF NOT EXISTS` above is a no-op on databases that already
     // have `gtd_lifecycle_audit` from before the `namespace` column existed.
-    // Guard-check and upgrade those tables in place so `write_audit_record`'s
+    // Guard-check and upgrade those tables in place so the audit writer's
     // `INSERT ... namespace` doesn't silently fail on legacy schemas.
     let rows = match w
         .query_all(SqlStatement {
@@ -86,11 +86,12 @@ pub async fn ensure_audit_schema(runtime: &KhiveRuntime) {
     }
 }
 
-/// Append one row to `gtd_lifecycle_audit`.
+/// Append one row to `gtd_lifecycle_audit`, preserving the original public
+/// unit-returning API.
 ///
-/// Best-effort: failures are logged and swallowed. The note's successful
-/// write has already happened; a missing audit row is degraded, not a
-/// failure. `pub` for the same reason as `ensure_audit_schema` above.
+/// Best-effort failures remain logged and swallowed for compatibility. New
+/// lifecycle response builders call [`write_audit_record_with_status`] when
+/// they need to expose degradation to the caller.
 pub async fn write_audit_record(
     runtime: &KhiveRuntime,
     note_id: Uuid,
@@ -99,6 +100,23 @@ pub async fn write_audit_record(
     transition_note: Option<&str>,
     namespace: &str,
 ) {
+    let _ = write_audit_record_with_status(runtime, note_id, from, to, transition_note, namespace)
+        .await;
+}
+
+/// Append one lifecycle-audit row and report whether it persisted.
+///
+/// The task mutation has already committed, so failure remains non-fatal;
+/// callers use the boolean to expose that degraded side effect without
+/// changing [`write_audit_record`]'s public return contract.
+pub async fn write_audit_record_with_status(
+    runtime: &KhiveRuntime,
+    note_id: Uuid,
+    from: &str,
+    to: &str,
+    transition_note: Option<&str>,
+    namespace: &str,
+) -> bool {
     let now = Utc::now().timestamp_micros();
     let stmt = SqlStatement {
         sql: "INSERT INTO gtd_lifecycle_audit \
@@ -119,8 +137,18 @@ pub async fn write_audit_record(
         label: Some("gtd_audit".into()),
     };
     match runtime.sql().writer().await {
-        Ok(mut w) => {
-            if let Err(e) = w.execute(stmt).await {
+        Ok(mut w) => match w.execute(stmt).await {
+            Ok(affected) if affected > 0 => true,
+            Ok(_) => {
+                tracing::warn!(
+                    note_id = %note_id,
+                    from,
+                    to,
+                    "gtd: audit insert affected no rows (non-fatal)"
+                );
+                false
+            }
+            Err(e) => {
                 tracing::warn!(
                     note_id = %note_id,
                     from,
@@ -128,14 +156,16 @@ pub async fn write_audit_record(
                     error = %e,
                     "gtd: audit write failed (non-fatal)"
                 );
+                false
             }
-        }
+        },
         Err(e) => {
             tracing::warn!(
                 note_id = %note_id,
                 error = %e,
                 "gtd: failed to acquire SQL writer for audit write (non-fatal)"
             );
+            false
         }
     }
 }
@@ -336,24 +366,63 @@ pub(crate) async fn resolve_context_entity_id(
     }
 }
 
-/// Status a task is treated as when the `status` property is missing/empty.
-/// Property filters that select this value must use `FilterOp::EqOrMissing`
-/// (not plain `Eq`) so legacy rows without a stored `status` still match —
-/// `json_extract` on an absent path is SQL `NULL`, which never equals a text
-/// literal.
+/// Status a task is treated as when the `status` property is missing or not a string.
+/// Property filters that select this value must use `FilterOp::TextEqOrNonText`
+/// (not plain `Eq`) so their SQL predicate mirrors [`task_status`]'s exact
+/// `CASE` semantics for absent, JSON-null, and non-text legacy values.
 const DEFAULT_STATUS: &str = "inbox";
 
 /// Priority a task is treated as when the `priority` property is missing/empty.
-/// Same `EqOrMissing` rule as [`DEFAULT_STATUS`] applies.
+/// An explicit default-priority filter uses `FilterOp::EqOrMissing` so legacy
+/// rows without the property remain visible.
 const DEFAULT_PRIORITY: &str = "p2";
 
-/// Status used internally on a task. Defaults to "inbox" when missing/empty.
+/// Status used internally on a task. Defaults to "inbox" when missing or non-string.
 fn task_status(props: Option<&Value>) -> String {
     props
         .and_then(|p| p.get("status"))
         .and_then(|v| v.as_str())
         .unwrap_or(DEFAULT_STATUS)
         .to_string()
+}
+
+/// Produce a lifecycle-write revision that is strictly newer than the exact
+/// note snapshot used to make the transition decision. `updated_at` is the
+/// optimistic-concurrency revision for task notes, so equality would let two
+/// independently prepared writes appear to share one revision.
+fn next_lifecycle_updated_at(snapshot_updated_at: i64) -> Result<i64, RuntimeError> {
+    let minimum = snapshot_updated_at.checked_add(1).ok_or_else(|| {
+        RuntimeError::Internal(
+            "task updated_at is already at i64::MAX and cannot advance".to_string(),
+        )
+    })?;
+    Ok(Utc::now().timestamp_micros().max(minimum))
+}
+
+fn lifecycle_write_conflict(
+    operation: &str,
+    note_id: Uuid,
+    expected_status: &str,
+    actual_status: &str,
+) -> RuntimeError {
+    if is_terminal(actual_status) {
+        RuntimeError::InvalidInput(format!(
+            "task {} is in terminal state {actual_status:?}; no further transitions allowed",
+            short_id(note_id)
+        ))
+    } else if actual_status != expected_status {
+        RuntimeError::InvalidInput(format!(
+            "{operation}: task {} changed from expected state {expected_status:?} to \
+             {actual_status:?}; retry with fresh state",
+            short_id(note_id)
+        ))
+    } else {
+        RuntimeError::InvalidInput(format!(
+            "{operation}: task {} changed after the lifecycle decision while remaining in \
+             state {actual_status:?}; retry with fresh state",
+            short_id(note_id)
+        ))
+    }
 }
 
 /// Priority rank used for sorting actionable tasks (lower = higher priority).
@@ -540,32 +609,33 @@ async fn load_task(
 /// from `expected_current` to `target` status.
 ///
 /// Relies on SQLite's atomic single-statement UPDATE plus a conditional WHERE
-/// predicate (`json_extract(properties,'$.status') = ?`) so that concurrent
-/// `complete()` or `transition()` calls on the same task in a parallel batch do
-/// NOT both report success. Only one write wins; the other gets 0 rows affected
-/// and must report an error.
+/// predicate over the exact decision snapshot's revision, deletion marker,
+/// and semantic GTD status. This prevents a lifecycle write from replacing a
+/// property document changed by a generic task update, even when that update
+/// left `properties.status` unchanged. Only one write wins; the other gets 0
+/// rows affected and must report an error.
 ///
 /// Returns the number of rows updated (1 = success, 0 = lost race / already moved).
 async fn atomic_gtd_transition(
     runtime: &KhiveRuntime,
-    note_id: Uuid,
+    snapshot: &khive_storage::note::Note,
     expected_current: &str,
     target: &str,
     new_props: &serde_json::Value,
     updated_at: i64,
 ) -> Result<u64, RuntimeError> {
     // The conditional UPDATE runs as a single SQLite statement, which is atomic
-    // on its own — no explicit transaction is needed because we never split the
-    // read-check from the write. The WHERE predicate goes through json_extract
-    // on the properties column to check the GTD status rather than the
-    // row-visibility `status` column (which is always "active").
+    // on its own — no explicit transaction is needed because the decision
+    // snapshot's revision/deletion/status checks and the write are one DML
+    // statement. The GTD status predicate uses the properties column rather
+    // than the row-visibility `status` column (which is always "active").
     //
-    // Concurrency: if another writer has already written `target` (or any other
-    // terminal state) by the time the WHERE predicate is evaluated, the predicate
-    // fails and rows_affected = 0. Caller distinguishes the rows-affected-0 loser
-    // path from the pre-load terminal-state error returned by `load_task`.
+    // Concurrency: if another writer has advanced the note revision, changed
+    // semantic status, or soft-deleted the row by the time the predicate is
+    // evaluated, it fails with rows_affected = 0. The caller distinguishes
+    // that loser path from the pre-load errors returned by `load_task`.
     let statement =
-        gtd_transition_statement(note_id, expected_current, target, new_props, updated_at)?;
+        gtd_transition_statement(snapshot, expected_current, target, new_props, updated_at)?;
     let sql = runtime.sql();
     let mut writer = sql
         .writer()
@@ -587,43 +657,115 @@ async fn atomic_gtd_transition(
 /// executes it immediately via the writer above; the atomic path turns it
 /// into a `PlanStatement` for the synchronous commit pass instead.
 pub fn gtd_transition_statement(
-    note_id: Uuid,
+    snapshot: &khive_storage::note::Note,
     expected_current: &str,
     target: &str,
     new_props: &serde_json::Value,
     updated_at: i64,
 ) -> Result<SqlStatement, RuntimeError> {
+    if snapshot.deleted_at.is_some() {
+        return Err(RuntimeError::NotFound(format!(
+            "deleted task {}",
+            short_id(snapshot.id)
+        )));
+    }
+    if updated_at <= snapshot.updated_at {
+        return Err(RuntimeError::Internal(format!(
+            "gtd lifecycle updated_at must strictly advance snapshot revision {} (got {updated_at})",
+            snapshot.updated_at
+        )));
+    }
     let props_str = serde_json::to_string(new_props)
         .map_err(|e| RuntimeError::Internal(format!("serialize props: {e}")))?;
     Ok(SqlStatement {
         sql: "UPDATE notes SET properties = ?1, updated_at = ?2 \
               WHERE id = ?3 \
-              AND json_extract(properties, '$.status') = ?4 \
-              AND deleted_at IS NULL"
+              AND updated_at = ?4 \
+              AND deleted_at IS ?5 \
+              AND ?2 > updated_at \
+              AND CASE \
+                    WHEN json_type(properties, '$.status') = 'text' \
+                    THEN json_extract(properties, '$.status') \
+                    ELSE 'inbox' \
+                  END = ?6"
             .to_string(),
         params: vec![
             SqlValue::Text(props_str),
             SqlValue::Integer(updated_at),
-            SqlValue::Text(note_id.as_hyphenated().to_string()),
+            SqlValue::Text(snapshot.id.as_hyphenated().to_string()),
+            SqlValue::Integer(snapshot.updated_at),
+            match snapshot.deleted_at {
+                Some(deleted_at) => SqlValue::Integer(deleted_at),
+                None => SqlValue::Null,
+            },
             SqlValue::Text(expected_current.to_string()),
         ],
         label: Some(format!("gtd_atomic_transition_{target}")),
     })
 }
 
-/// Outcome of [`prepare_transition`]'s decide step: either nothing to write
-/// (the idempotent `current == target` case, canonical's early return) or a
-/// fully computed patched `properties` value ready to apply — via
+/// Build the guarded, mutation-free assertion used for an atomic
+/// same-status transition.
+///
+/// Atomic prepare classifies `current == target` from a read snapshot, but a
+/// preceding op in the same atomic file may transition, update, or delete the
+/// task before this op reaches the commit pass. An empty plan would silently
+/// discard the snapshot hypothesis. This statement deliberately assigns
+/// `updated_at` to itself (so the persisted row is byte-for-byte unchanged)
+/// while re-validating the exact revision, deletion marker, and semantic GTD
+/// status under the transaction. Its affected-row guard therefore turns any
+/// stale no-op into a whole-unit rollback.
+pub fn gtd_noop_assertion_statement(
+    snapshot: &khive_storage::note::Note,
+    expected_current: &str,
+) -> Result<SqlStatement, RuntimeError> {
+    if snapshot.deleted_at.is_some() {
+        return Err(RuntimeError::NotFound(format!(
+            "deleted task {}",
+            short_id(snapshot.id)
+        )));
+    }
+    Ok(SqlStatement {
+        sql: "UPDATE notes SET updated_at = updated_at \
+              WHERE id = ?1 \
+              AND updated_at = ?2 \
+              AND deleted_at IS ?3 \
+              AND CASE \
+                    WHEN json_type(properties, '$.status') = 'text' \
+                    THEN json_extract(properties, '$.status') \
+                    ELSE 'inbox' \
+                  END = ?4"
+            .to_string(),
+        params: vec![
+            SqlValue::Text(snapshot.id.as_hyphenated().to_string()),
+            SqlValue::Integer(snapshot.updated_at),
+            match snapshot.deleted_at {
+                Some(deleted_at) => SqlValue::Integer(deleted_at),
+                None => SqlValue::Null,
+            },
+            SqlValue::Text(expected_current.to_string()),
+        ],
+        label: Some("gtd_atomic_noop_assertion".to_string()),
+    })
+}
+
+/// Outcome of [`prepare_transition`]'s decide step: either no status change
+/// (the idempotent `current == target` case) or a fully computed patched
+/// `properties` value ready to apply — via
 /// `atomic_gtd_transition` (canonical, immediate) or
 /// [`gtd_transition_statement`] (ADR-099 atomic, deferred to the commit
-/// pass).
+/// pass). Canonical dispatch may record a caller note after the no-op decision;
+/// atomic v1 instead carries a guarded no-effect assertion and deliberately
+/// omits both the note mutation and audit side effect.
 pub enum TransitionDecision {
     NoOp {
+        /// Exact note snapshot used to classify the no-op.
         note: khive_storage::note::Note,
         current: String,
         target: String,
     },
     Write {
+        /// Exact note snapshot whose revision/deletion marker guards apply.
         note: khive_storage::note::Note,
         current: String,
         target: String,
@@ -686,40 +828,41 @@ pub async fn prepare_transition(
         )));
     }
 
-    let updated_at = Utc::now().timestamp_micros();
+    let updated_at = next_lifecycle_updated_at(note.updated_at)?;
     let mut props = note.properties.clone().unwrap_or_else(|| json!({}));
-    if let Some(obj) = props.as_object_mut() {
-        obj.insert("status".into(), json!(target.to_string()));
-        if let Some(n) = note_arg {
-            obj.insert("transition_note".into(), json!(n));
-        }
-        if target == "done" {
-            obj.insert("completed_at".into(), json!(Utc::now().to_rfc3339()));
-        }
+    let obj = props.as_object_mut().ok_or_else(|| {
+        RuntimeError::InvalidInput("task properties must be a JSON object".to_string())
+    })?;
+    obj.insert("status".into(), json!(target.to_string()));
+    if let Some(n) = note_arg {
+        obj.insert("transition_note".into(), json!(n));
+    }
+    if target == "done" {
+        obj.insert("completed_at".into(), json!(Utc::now().to_rfc3339()));
+    }
 
-        // #95: `transition_note` above is last-write-wins by design (it's the
-        // "latest note" quick-read field every existing caller already
-        // depends on) — but that means every note before the last one was
-        // gone with no trace anywhere in the record. `gtd_lifecycle_audit`
-        // (see `write_audit_record` below) already persists the full
-        // from/to/note/at history in SQL, so the storage-side history this
-        // issue asks about already exists; it just isn't surfaced back to a
-        // caller reading the task. `transition_history` mirrors that same
-        // per-transition record onto the note's own `properties` blob (a
-        // free-form JSON column — no schema/storage change needed) so a
-        // plain `get`/`tasks` read of the task, not just a raw SQL query
-        // against the audit table, shows the accumulated history.
-        let entry = json!({
-            "from": current,
-            "to": target,
-            "note": note_arg,
-            "at": micros_to_iso(updated_at),
-        });
-        match obj.get_mut("transition_history") {
-            Some(Value::Array(history)) => history.push(entry),
-            _ => {
-                obj.insert("transition_history".into(), json!([entry]));
-            }
+    // #95: `transition_note` above is last-write-wins by design (it's the
+    // "latest note" quick-read field every existing caller already
+    // depends on) — but that means every note before the last one was
+    // gone with no trace anywhere in the record. `gtd_lifecycle_audit`
+    // (see the lifecycle-audit helpers above) already persists the full
+    // from/to/note/at history in SQL, so the storage-side history this
+    // issue asks about already exists; it just isn't surfaced back to a
+    // caller reading the task. `transition_history` mirrors that same
+    // per-transition record onto the note's own `properties` blob (a
+    // free-form JSON column — no schema/storage change needed) so a
+    // plain `get`/`tasks` read of the task, not just a raw SQL query
+    // against the audit table, shows the accumulated history.
+    let entry = json!({
+        "from": current,
+        "to": target,
+        "note": note_arg,
+        "at": micros_to_iso(updated_at),
+    });
+    match obj.get_mut("transition_history") {
+        Some(Value::Array(history)) => history.push(entry),
+        _ => {
+            obj.insert("transition_history".into(), json!([entry]));
         }
     }
 
@@ -737,6 +880,7 @@ pub async fn prepare_transition(
 /// `properties` value ready to apply. Unlike [`TransitionDecision`], there is
 /// no idempotent no-op case — `complete()` always writes when it succeeds.
 pub struct CompleteDecision {
+    /// Exact note snapshot whose revision/deletion marker guards apply.
     pub note: khive_storage::note::Note,
     pub current: String,
     pub target: &'static str,
@@ -748,7 +892,7 @@ pub struct CompleteDecision {
 /// Decide step of `gtd.complete` (ADR-099 B3 r6 second pass) — same split as
 /// [`prepare_transition`] above: validates the target terminal status,
 /// secret-gates the caller-supplied result, loads the task, checks the
-/// terminal/actionable guards, and computes the patched `properties` value,
+/// terminal/lifecycle guards, and computes the patched `properties` value,
 /// all WITHOUT writing. `GtdPack::handle_complete` and the ADR-099 `--atomic`
 /// `gtd.complete` prepare function in `kkernel` both call this ONE function.
 pub async fn prepare_complete(
@@ -772,23 +916,30 @@ pub async fn prepare_complete(
             short_id(note.id)
         )));
     }
-    if !is_actionable(&current) {
+    if !can_transition(&current, target) {
+        let allowed = allowed_transitions(&current);
+        let allowed_display = if allowed.is_empty() {
+            "(none)".to_string()
+        } else {
+            allowed.join(", ")
+        };
         return Err(RuntimeError::InvalidInput(format!(
-            "complete: task in {current:?}; transition to 'next' or 'active' first, \
-             or use transition(status=done) explicitly"
+            "complete: cannot transition from {current:?} to {target:?}; \
+             allowed from {current:?}: {allowed_display}. Full lifecycle: {TASK_LIFECYCLE_HELP}"
         )));
     }
 
     let completed_at = Utc::now().to_rfc3339();
     let mut props = note.properties.clone().unwrap_or_else(|| json!({}));
-    if let Some(obj) = props.as_object_mut() {
-        obj.insert("status".into(), json!(target));
-        obj.insert("completed_at".into(), json!(completed_at));
-        if let Some(result) = result_arg {
-            obj.insert("result".into(), json!(result));
-        }
+    let obj = props.as_object_mut().ok_or_else(|| {
+        RuntimeError::InvalidInput("task properties must be a JSON object".to_string())
+    })?;
+    obj.insert("status".into(), json!(target));
+    obj.insert("completed_at".into(), json!(completed_at));
+    if let Some(result) = result_arg {
+        obj.insert("result".into(), json!(result));
     }
-    let updated_at = Utc::now().timestamp_micros();
+    let updated_at = next_lifecycle_updated_at(note.updated_at)?;
 
     Ok(CompleteDecision {
         note,
@@ -941,7 +1092,7 @@ impl GtdPack {
 
         // Decide step (ADR-099 B3 r6 second pass): validates the target
         // terminal status, secret-gates the result, loads the task, checks
-        // the terminal/actionable guards, and computes the patched
+        // the terminal/lifecycle guards, and computes the patched
         // `properties` value — the SAME function the ADR-099 `--atomic`
         // `gtd.complete` prepare path in `kkernel` calls.
         let decision = prepare_complete(
@@ -953,53 +1104,39 @@ impl GtdPack {
         )
         .await?;
         let CompleteDecision {
-            mut note,
+            note,
             current,
             target,
             props,
             updated_at,
             completed_at,
         } = decision;
-        note.properties = Some(props);
-        // notes.status is row-visibility (always "active" for live rows);
-        // GTD status lives in properties.status and W1-G's remap surfaces it
-        // at data.status in the response.
-        note.updated_at = updated_at;
 
-        // atomic transition — use a conditional SQL UPDATE
-        // so that a concurrent complete() on the same task loses the race
-        // cleanly rather than both reporting success.
-        let rows_affected = atomic_gtd_transition(
-            self.runtime(),
-            note.id,
-            &current,
-            target,
-            note.properties.as_ref().unwrap(),
-            note.updated_at,
-        )
-        .await?;
+        // Guard the complete against the exact note snapshot that produced
+        // `props`, not merely its old GTD status. A concurrent generic update
+        // may leave status unchanged while changing description/content or
+        // other task properties; replacing its property document would lose
+        // that write and can break the task-body mirror invariant.
+        let rows_affected =
+            atomic_gtd_transition(self.runtime(), &note, &current, target, &props, updated_at)
+                .await?;
 
         if rows_affected == 0 {
-            // Another concurrent op already transitioned this task away from `current`.
-            // Re-read the actual current state to give a precise error.
+            // Re-read status for a precise conflict class. The snapshot guard
+            // can also fail while status stays unchanged (for example, a
+            // concurrent generic task update advanced the note revision).
             let (_, actual_now) = load_task(self.runtime(), token, &p.id).await?;
-            let message = if is_terminal(&actual_now) {
-                format!(
-                    "task {} is in terminal state {actual_now:?}; no further transitions allowed",
-                    short_id(note.id)
-                )
-            } else {
-                format!(
-                    "complete: task {} changed from expected state {current:?} to {actual_now:?}; retry with fresh state",
-                    short_id(note.id)
-                )
-            };
-            return Err(RuntimeError::InvalidInput(message));
+            return Err(lifecycle_write_conflict(
+                "complete",
+                note.id,
+                &current,
+                &actual_now,
+            ));
         }
 
-        // Write lifecycle audit record (best-effort).
+        // Write lifecycle audit record (best-effort, explicitly reported).
         ensure_audit_schema(self.runtime()).await;
-        write_audit_record(
+        let audit_persisted = write_audit_record_with_status(
             self.runtime(),
             note.id,
             &current,
@@ -1017,6 +1154,7 @@ impl GtdPack {
             "to": target,
             "completed_at": completed_at,
             "is_terminal": is_terminal(target),
+            "audit_persisted": audit_persisted,
         }))
     }
 
@@ -1071,14 +1209,14 @@ impl GtdPack {
         let mut property_filters = vec![match status_filter.as_deref() {
             Some(want) => PropertyFilter {
                 json_path: "$.status".to_string(),
-                // A legacy task with no stored `status` property is treated as
-                // `inbox` everywhere else in this pack (`task_status`,
-                // `render_task`). `json_extract` on an absent path is SQL
-                // NULL, which `Eq` never matches, so an explicit
-                // `status="inbox"` query would silently exclude those rows —
-                // `EqOrMissing` restores the "absent counts as default" rule.
+                // A legacy task whose stored `status` is absent OR non-text is
+                // treated as `inbox` everywhere else in this pack
+                // (`task_status`, `render_task`). Use the storage predicate
+                // whose SQL CASE expression reproduces that exact read model;
+                // `EqOrMissing` alone would still exclude booleans, numbers,
+                // arrays, and objects.
                 op: if want == DEFAULT_STATUS {
-                    FilterOp::EqOrMissing
+                    FilterOp::TextEqOrNonText
                 } else {
                     FilterOp::Eq
                 },
@@ -1221,7 +1359,7 @@ impl GtdPack {
         let decision =
             prepare_transition(self.runtime(), token, &p.id, &p.status, p.note.as_deref()).await?;
 
-        let (note, current, target) = match decision {
+        let (note, current, target, audit_persisted) = match decision {
             TransitionDecision::NoOp {
                 note,
                 current,
@@ -1232,19 +1370,23 @@ impl GtdPack {
                 // stays an accurate statement about status; persisting the note is a
                 // separate effect.
                 let mut note_recorded = None;
+                let mut audit_persisted = None;
                 if let Some(n) = p.note.as_deref() {
                     let mut props = note.properties.clone().unwrap_or_else(|| json!({}));
-                    if let Some(obj) = props.as_object_mut() {
-                        obj.insert("transition_note".into(), json!(n));
-                    }
-                    let updated_at = Utc::now().timestamp_micros();
+                    let obj = props.as_object_mut().ok_or_else(|| {
+                        RuntimeError::InvalidInput(
+                            "task properties must be a JSON object".to_string(),
+                        )
+                    })?;
+                    obj.insert("transition_note".into(), json!(n));
+                    let updated_at = next_lifecycle_updated_at(note.updated_at)?;
                     // Same conditional UPDATE `atomic_gtd_transition` uses elsewhere —
                     // here expected == target, so it only wins if the status is still
                     // what `prepare_transition` just observed (loses the race to a
                     // concurrent real transition without clobbering it).
                     let rows_affected = atomic_gtd_transition(
                         self.runtime(),
-                        note.id,
+                        &note,
                         &current,
                         &target,
                         &props,
@@ -1253,15 +1395,17 @@ impl GtdPack {
                     .await?;
                     if rows_affected > 0 {
                         ensure_audit_schema(self.runtime()).await;
-                        write_audit_record(
-                            self.runtime(),
-                            note.id,
-                            &current,
-                            &target,
-                            Some(n),
-                            token.namespace().as_str(),
-                        )
-                        .await;
+                        audit_persisted = Some(
+                            write_audit_record_with_status(
+                                self.runtime(),
+                                note.id,
+                                &current,
+                                &target,
+                                Some(n),
+                                token.namespace().as_str(),
+                            )
+                            .await,
+                        );
                     }
                     note_recorded = Some(rows_affected > 0);
                 }
@@ -1277,6 +1421,9 @@ impl GtdPack {
                 if let Some(recorded) = note_recorded {
                     response["note_recorded"] = json!(recorded);
                 }
+                if let Some(persisted) = audit_persisted {
+                    response["audit_persisted"] = json!(persisted);
+                }
                 return Ok(response);
             }
             TransitionDecision::Write {
@@ -1287,36 +1434,39 @@ impl GtdPack {
                 updated_at,
                 transition_note,
             } => {
+                // The shared conditional write guards the exact snapshot
+                // revision/deletion marker as well as semantic status, so a
+                // concurrent generic update cannot be replaced by stale
+                // lifecycle properties.
+                let rows_affected = atomic_gtd_transition(
+                    self.runtime(),
+                    &note,
+                    &current,
+                    &target,
+                    &props,
+                    updated_at,
+                )
+                .await?;
+
+                if rows_affected == 0 {
+                    let (_, actual_now) = load_task(self.runtime(), token, &p.id).await?;
+                    return Err(lifecycle_write_conflict(
+                        "transition",
+                        note.id,
+                        &current,
+                        &actual_now,
+                    ));
+                }
+
                 note.properties = Some(props);
                 // notes.status is row-visibility (always "active" for live
                 // rows); GTD status lives in properties.status and W1-G's
                 // remap surfaces it at data.status in the response.
                 note.updated_at = updated_at;
 
-                // atomic transition — conditional SQL
-                // UPDATE so concurrent transitions in the same parallel
-                // batch only one wins.
-                let rows_affected = atomic_gtd_transition(
-                    self.runtime(),
-                    note.id,
-                    &current,
-                    &target,
-                    note.properties.as_ref().unwrap(),
-                    note.updated_at,
-                )
-                .await?;
-
-                if rows_affected == 0 {
-                    let (_, actual_now) = load_task(self.runtime(), token, &p.id).await?;
-                    return Err(RuntimeError::InvalidInput(format!(
-                        "task {} is in terminal state {actual_now:?}; no further transitions allowed",
-                        short_id(note.id)
-                    )));
-                }
-
-                // Write lifecycle audit record (best-effort).
+                // Write lifecycle audit record (best-effort, explicitly reported).
                 ensure_audit_schema(self.runtime()).await;
-                write_audit_record(
+                let audit_persisted = write_audit_record_with_status(
                     self.runtime(),
                     note.id,
                     &current,
@@ -1326,7 +1476,7 @@ impl GtdPack {
                 )
                 .await;
 
-                (note, current, target)
+                (note, current, target, audit_persisted)
             }
         };
 
@@ -1342,6 +1492,208 @@ impl GtdPack {
             "priority": task["priority"],
             "assignee": task["assignee"],
             "due": task["due"],
+            "audit_persisted": audit_persisted,
         }))
+    }
+}
+
+#[cfg(test)]
+mod lifecycle_snapshot_tests {
+    use super::*;
+
+    #[test]
+    fn lifecycle_revision_strictly_advances_a_future_snapshot() {
+        let future_snapshot = Utc::now()
+            .timestamp_micros()
+            .checked_add(86_400_000_000)
+            .expect("one-day future timestamp is representable");
+        assert_eq!(
+            next_lifecycle_updated_at(future_snapshot).expect("advance lifecycle revision"),
+            future_snapshot + 1
+        );
+    }
+
+    async fn seeded_task() -> (KhiveRuntime, NamespaceToken, khive_storage::note::Note) {
+        let runtime = KhiveRuntime::memory().expect("memory runtime");
+        let token = runtime
+            .authorize(khive_runtime::Namespace::local())
+            .expect("authorize local");
+        let mut task =
+            khive_storage::note::Note::new("local", "task", "canonical-lifecycle-test-task");
+        task.name = Some("canonical-lifecycle-test-task".to_string());
+        task.properties = Some(json!({"status": "inbox", "priority": "p2"}));
+        runtime
+            .notes(&token)
+            .expect("note store")
+            .upsert_note(task.clone())
+            .await
+            .expect("seed task");
+        (runtime, token, task)
+    }
+
+    async fn install_concurrent_mirrored_update(
+        runtime: &KhiveRuntime,
+        token: &NamespaceToken,
+        snapshot: &khive_storage::note::Note,
+    ) -> i64 {
+        // This is the canonical generic-note CAS seam after the task hook has
+        // synchronized the two body spellings. It starts from the very same
+        // snapshot as the lifecycle decision, then commits first.
+        let (concurrent, _) = runtime
+            .update_note_from_snapshot_with_embedding_report(
+                token,
+                snapshot.clone(),
+                khive_runtime::NotePatch::new(
+                    None,
+                    Some("concurrent mirrored body".to_string()),
+                    None,
+                    None,
+                    Some(json!({"description": "concurrent mirrored body"})),
+                ),
+            )
+            .await
+            .expect("commit concurrent canonical update");
+        concurrent.updated_at
+    }
+
+    async fn assert_concurrent_update_survived(
+        runtime: &KhiveRuntime,
+        token: &NamespaceToken,
+        task_id: Uuid,
+        concurrent_revision: i64,
+    ) {
+        let persisted = runtime
+            .notes(token)
+            .expect("note store")
+            .get_note(task_id)
+            .await
+            .expect("read task")
+            .expect("task exists");
+        assert_eq!(persisted.updated_at, concurrent_revision);
+        assert_eq!(persisted.content, "concurrent mirrored body");
+        assert_eq!(
+            persisted
+                .properties
+                .as_ref()
+                .and_then(|properties| properties.get("description"))
+                .and_then(Value::as_str),
+            Some("concurrent mirrored body")
+        );
+        assert_eq!(task_status(persisted.properties.as_ref()), "inbox");
+    }
+
+    #[tokio::test]
+    async fn canonical_transition_refuses_stale_decision_snapshot() {
+        let (runtime, token, task) = seeded_task().await;
+        let decision = prepare_transition(
+            &runtime,
+            &token,
+            &task.id.as_hyphenated().to_string(),
+            "next",
+            None,
+        )
+        .await
+        .expect("prepare transition");
+        let TransitionDecision::Write {
+            note: snapshot,
+            current,
+            target,
+            props,
+            updated_at,
+            ..
+        } = decision
+        else {
+            panic!("inbox -> next must be a write decision");
+        };
+        assert!(updated_at > snapshot.updated_at);
+
+        let concurrent_revision =
+            install_concurrent_mirrored_update(&runtime, &token, &snapshot).await;
+        let affected =
+            atomic_gtd_transition(&runtime, &snapshot, &current, &target, &props, updated_at)
+                .await
+                .expect("execute guarded transition");
+        assert_eq!(affected, 0, "stale transition snapshot must lose its CAS");
+        assert_concurrent_update_survived(&runtime, &token, task.id, concurrent_revision).await;
+    }
+
+    #[tokio::test]
+    async fn canonical_transition_guard_closes_soft_delete_without_revision_change() {
+        let (runtime, token, task) = seeded_task().await;
+        let decision = prepare_transition(
+            &runtime,
+            &token,
+            &task.id.as_hyphenated().to_string(),
+            "next",
+            None,
+        )
+        .await
+        .expect("prepare transition");
+        let TransitionDecision::Write {
+            note: snapshot,
+            current,
+            target,
+            props,
+            updated_at,
+            ..
+        } = decision
+        else {
+            panic!("inbox -> next must be a write decision");
+        };
+
+        assert!(runtime
+            .notes(&token)
+            .expect("note store")
+            .delete_note(task.id, khive_storage::DeleteMode::Soft)
+            .await
+            .expect("soft delete task"));
+        let tombstone = runtime
+            .notes(&token)
+            .expect("note store")
+            .get_note_including_deleted(task.id)
+            .await
+            .expect("read tombstone")
+            .expect("tombstone exists");
+        assert_eq!(
+            tombstone.updated_at, snapshot.updated_at,
+            "legacy soft delete deliberately demonstrates why deletion marker is a separate guard"
+        );
+        assert!(tombstone.deleted_at.is_some());
+
+        let affected =
+            atomic_gtd_transition(&runtime, &snapshot, &current, &target, &props, updated_at)
+                .await
+                .expect("execute guarded transition");
+        assert_eq!(affected, 0, "soft-deleted snapshot must lose its CAS");
+    }
+
+    #[tokio::test]
+    async fn canonical_complete_refuses_stale_decision_snapshot() {
+        let (runtime, token, task) = seeded_task().await;
+        let decision = prepare_complete(
+            &runtime,
+            &token,
+            &task.id.as_hyphenated().to_string(),
+            None,
+            Some("shipped"),
+        )
+        .await
+        .expect("prepare complete");
+        assert!(decision.updated_at > decision.note.updated_at);
+
+        let concurrent_revision =
+            install_concurrent_mirrored_update(&runtime, &token, &decision.note).await;
+        let affected = atomic_gtd_transition(
+            &runtime,
+            &decision.note,
+            &decision.current,
+            decision.target,
+            &decision.props,
+            decision.updated_at,
+        )
+        .await
+        .expect("execute guarded complete");
+        assert_eq!(affected, 0, "stale complete snapshot must lose its CAS");
+        assert_concurrent_update_survived(&runtime, &token, task.id, concurrent_revision).await;
     }
 }

--- a/crates/khive-pack-gtd/src/hook.rs
+++ b/crates/khive-pack-gtd/src/hook.rs
@@ -1,12 +1,13 @@
 //! `TaskHook` — gtd's per-kind specialization for the `task` note kind.
 //!
 //! Implements the `KindHook` extension point for the pack standard. Normalises
-//! user-facing GTD fields into the kg storage shape on `prepare_create`, and
-//! creates `depends_on` graph edges on `after_create` (best-effort). GTD
-//! lifecycle semantics are documented in `docs/design.md`.
+//! user-facing GTD fields into the kg storage shape on `prepare_create`, keeps
+//! task body mirrors aligned on `prepare_note_update`, and creates `depends_on`
+//! graph edges on `after_create` (best-effort). GTD lifecycle semantics are
+//! documented in `docs/design.md`.
 
 use async_trait::async_trait;
-use serde_json::Value;
+use serde_json::{json, Value};
 use uuid::Uuid;
 
 use khive_runtime::{KhiveRuntime, KindHook, LinkSpec, Namespace, NamespaceToken, RuntimeError};
@@ -17,6 +18,100 @@ use crate::task_create::{link_depends_on_edges, prepare_task_create, TaskCreateI
 #[derive(Debug, Default)]
 /// KindHook implementation for the `task` note kind; normalises GTD fields on create.
 pub struct TaskHook;
+
+fn synchronize_description(note: &Note, args: &mut Value) -> Result<(), RuntimeError> {
+    let root = args
+        .as_object_mut()
+        .ok_or_else(|| RuntimeError::InvalidInput("update args must be an object".into()))?;
+
+    let content_patch = root
+        .get("content")
+        .and_then(Value::as_str)
+        .map(str::to_string);
+    let name_patch = match root.get("name") {
+        None => None,
+        Some(Value::String(name)) => Some(name.clone()),
+        Some(Value::Null) => {
+            return Err(RuntimeError::InvalidInput(
+                "task title cannot be cleared; `name` must be a non-empty string".into(),
+            ));
+        }
+        Some(other) => {
+            return Err(RuntimeError::InvalidInput(format!(
+                "task update field `name` must be a string; got {other}"
+            )));
+        }
+    };
+    let description_patch = match root.get("properties") {
+        None | Some(Value::Null) => None,
+        Some(Value::Object(properties)) => match properties.get("description") {
+            None => None,
+            Some(Value::Null) => Some(None),
+            Some(Value::String(description)) => Some(Some(description.clone())),
+            Some(other) => {
+                return Err(RuntimeError::InvalidInput(format!(
+                    "properties.description must be a string or null; got {other}"
+                )))
+            }
+        },
+        Some(other) => {
+            return Err(RuntimeError::InvalidInput(format!(
+                "properties on a `task` note must be patched with an object; got {other}"
+            )))
+        }
+    };
+
+    let effective_title = name_patch
+        .as_deref()
+        .or(note.name.as_deref())
+        .filter(|title| !title.trim().is_empty())
+        .ok_or_else(|| RuntimeError::InvalidInput("task title must not be empty".into()))?;
+
+    match (content_patch, description_patch) {
+        (Some(content), Some(Some(description))) if content != description => {
+            return Err(RuntimeError::InvalidInput(
+                "task update fields `content` and `properties.description` must match when both are supplied"
+                    .into(),
+            ));
+        }
+        (Some(_), Some(None)) => {
+            return Err(RuntimeError::InvalidInput(
+                "task update cannot set `content` while clearing `properties.description`".into(),
+            ));
+        }
+        (Some(content), _) => {
+            if root.get("properties").is_none_or(Value::is_null) {
+                root.insert("properties".into(), json!({}));
+            }
+            let properties = root
+                .get_mut("properties")
+                .expect("properties was inserted")
+                .as_object_mut()
+                .expect("properties was validated as object or inserted as object");
+            properties.insert("description".into(), json!(content));
+        }
+        (None, Some(Some(description))) => {
+            root.insert("content".into(), json!(description));
+        }
+        (None, Some(None)) => {
+            root.insert("content".into(), json!(effective_title));
+        }
+        (None, None)
+            if name_patch.is_some()
+                && note
+                    .properties
+                    .as_ref()
+                    .and_then(|properties| properties.get("description"))
+                    .and_then(Value::as_str)
+                    .is_none() =>
+        {
+            root.insert("content".into(), json!(effective_title));
+        }
+        (None, None) => {}
+    }
+
+    Ok(())
+}
 
 #[async_trait]
 impl KindHook for TaskHook {
@@ -75,6 +170,18 @@ impl KindHook for TaskHook {
         crate::dependency::validate_property_update(runtime, token, note, properties).await
     }
 
+    async fn prepare_note_update(
+        &self,
+        runtime: &KhiveRuntime,
+        token: &NamespaceToken,
+        note: &Note,
+        args: &mut Value,
+    ) -> Result<(), RuntimeError> {
+        synchronize_description(note, args)?;
+        let properties = args.get("properties").filter(|value| !value.is_null());
+        crate::dependency::validate_property_update(runtime, token, note, properties).await
+    }
+
     async fn validate_links(
         &self,
         runtime: &KhiveRuntime,
@@ -82,5 +189,90 @@ impl KindHook for TaskHook {
         links: &[LinkSpec],
     ) -> Result<(), RuntimeError> {
         crate::dependency::validate_dependency_links(runtime, token, links).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use serde_json::json;
+
+    #[tokio::test]
+    async fn normalized_task_update_refuses_a_stale_note_snapshot() {
+        let runtime = KhiveRuntime::memory().expect("memory runtime");
+        let token = runtime
+            .authorize(Namespace::local())
+            .expect("authorize local");
+        let mut task = Note::new("local", "task", "original body");
+        task.name = Some("original title".to_string());
+        task.properties = Some(json!({"description": "original body", "status": "inbox"}));
+        let task_id = task.id;
+        runtime
+            .notes(&token)
+            .expect("note store")
+            .upsert_note(task)
+            .await
+            .expect("seed task");
+
+        let snapshot = runtime
+            .notes(&token)
+            .expect("note store")
+            .get_note(task_id)
+            .await
+            .expect("read task")
+            .expect("task exists");
+        let mut args = json!({"content": "hook-derived body"});
+        synchronize_description(&snapshot, &mut args).expect("normalize mirrors");
+
+        // Deterministically land another writer after hook normalization but
+        // before persistence from the original snapshot.
+        let mut concurrent = snapshot.clone();
+        concurrent.name = Some("concurrent title".to_string());
+        concurrent.content = "concurrent body".to_string();
+        concurrent.properties = Some(json!({"description": "concurrent body", "status": "inbox"}));
+        concurrent.updated_at = snapshot.updated_at.saturating_add(10);
+        runtime
+            .notes(&token)
+            .expect("note store")
+            .upsert_note(concurrent)
+            .await
+            .expect("concurrent write");
+
+        let patch = khive_runtime::NotePatch::new(
+            None,
+            args.get("content")
+                .and_then(Value::as_str)
+                .map(str::to_string),
+            None,
+            None,
+            args.get("properties").cloned(),
+        );
+        let err = runtime
+            .update_note_from_snapshot_with_embedding_report(&token, snapshot, patch)
+            .await
+            .expect_err("stale hook snapshot must not overwrite the concurrent task");
+        assert!(
+            err.to_string().contains("changed concurrently"),
+            "expected explicit stale-snapshot refusal; got: {err}"
+        );
+
+        let persisted = runtime
+            .notes(&token)
+            .expect("note store")
+            .get_note(task_id)
+            .await
+            .expect("read persisted task")
+            .expect("task exists");
+        assert_eq!(persisted.name.as_deref(), Some("concurrent title"));
+        assert_eq!(persisted.content, "concurrent body");
+        assert_eq!(
+            persisted
+                .properties
+                .as_ref()
+                .and_then(|props| props.get("description"))
+                .and_then(Value::as_str),
+            Some("concurrent body")
+        );
     }
 }

--- a/crates/khive-pack-gtd/src/hook.rs
+++ b/crates/khive-pack-gtd/src/hook.rs
@@ -109,12 +109,23 @@ fn synchronize_description(note: &Note, args: &mut Value) -> Result<(), RuntimeE
             root.insert("content".into(), json!(description));
         }
         (None, Some(None)) => {
-            let effective_title = name_patch
-                .as_deref()
-                .or(note.name.as_deref())
-                .filter(|title| !title.trim().is_empty())
-                .ok_or_else(|| RuntimeError::InvalidInput("task title must not be empty".into()))?;
-            root.insert("content".into(), json!(effective_title));
+            let stored_description_exists = note
+                .properties
+                .as_ref()
+                .and_then(|properties| properties.get("description"))
+                .is_some_and(|description| !description.is_null());
+            let should_write_title_fallback =
+                stored_description_exists || stored_content_is_title_fallback(note);
+            if should_write_title_fallback {
+                let effective_title = name_patch
+                    .as_deref()
+                    .or(note.name.as_deref())
+                    .filter(|title| !title.trim().is_empty())
+                    .ok_or_else(|| {
+                        RuntimeError::InvalidInput("task title must not be empty".into())
+                    })?;
+                root.insert("content".into(), json!(effective_title));
+            }
         }
         (None, None)
             if name_patch.is_some()

--- a/crates/khive-pack-gtd/src/hook.rs
+++ b/crates/khive-pack-gtd/src/hook.rs
@@ -19,10 +19,26 @@ use crate::task_create::{link_depends_on_edges, prepare_task_create, TaskCreateI
 /// KindHook implementation for the `task` note kind; normalises GTD fields on create.
 pub struct TaskHook;
 
+fn stored_content_is_title_fallback(note: &Note) -> bool {
+    let effective_title = note.name.as_deref().map(str::trim).unwrap_or_default();
+    note.content.trim().is_empty() || note.content.trim() == effective_title
+}
+
 fn synchronize_description(note: &Note, args: &mut Value) -> Result<(), RuntimeError> {
     let root = args
         .as_object_mut()
         .ok_or_else(|| RuntimeError::InvalidInput("update args must be an object".into()))?;
+
+    if let Some(Value::Object(properties)) = root.get("properties") {
+        for field in ["status", "completed_at", "transition_history"] {
+            if properties.contains_key(field) {
+                return Err(RuntimeError::InvalidInput(format!(
+                    "properties.{field} is lifecycle-owned and cannot be patched on a task; use \
+                     gtd.transition for lifecycle changes or gtd.complete for terminal completion"
+                )));
+            }
+        }
+    }
 
     let content_patch = root
         .get("content")
@@ -30,6 +46,11 @@ fn synchronize_description(note: &Note, args: &mut Value) -> Result<(), RuntimeE
         .map(str::to_string);
     let name_patch = match root.get("name") {
         None => None,
+        Some(Value::String(name)) if name.trim().is_empty() => {
+            return Err(RuntimeError::InvalidInput(
+                "task title must not be empty".into(),
+            ));
+        }
         Some(Value::String(name)) => Some(name.clone()),
         Some(Value::Null) => {
             return Err(RuntimeError::InvalidInput(
@@ -61,12 +82,6 @@ fn synchronize_description(note: &Note, args: &mut Value) -> Result<(), RuntimeE
         }
     };
 
-    let effective_title = name_patch
-        .as_deref()
-        .or(note.name.as_deref())
-        .filter(|title| !title.trim().is_empty())
-        .ok_or_else(|| RuntimeError::InvalidInput("task title must not be empty".into()))?;
-
     match (content_patch, description_patch) {
         (Some(content), Some(Some(description))) if content != description => {
             return Err(RuntimeError::InvalidInput(
@@ -94,6 +109,11 @@ fn synchronize_description(note: &Note, args: &mut Value) -> Result<(), RuntimeE
             root.insert("content".into(), json!(description));
         }
         (None, Some(None)) => {
+            let effective_title = name_patch
+                .as_deref()
+                .or(note.name.as_deref())
+                .filter(|title| !title.trim().is_empty())
+                .ok_or_else(|| RuntimeError::InvalidInput("task title must not be empty".into()))?;
             root.insert("content".into(), json!(effective_title));
         }
         (None, None)
@@ -103,9 +123,13 @@ fn synchronize_description(note: &Note, args: &mut Value) -> Result<(), RuntimeE
                     .as_ref()
                     .and_then(|properties| properties.get("description"))
                     .and_then(Value::as_str)
-                    .is_none() =>
+                    .is_none()
+                && stored_content_is_title_fallback(note) =>
         {
-            root.insert("content".into(), json!(effective_title));
+            root.insert(
+                "content".into(),
+                json!(name_patch.as_deref().expect("name patch is present")),
+            );
         }
         (None, None) => {}
     }
@@ -252,10 +276,11 @@ mod tests {
             .update_note_from_snapshot_with_embedding_report(&token, snapshot, patch)
             .await
             .expect_err("stale hook snapshot must not overwrite the concurrent task");
-        assert!(
-            err.to_string().contains("changed concurrently"),
-            "expected explicit stale-snapshot refusal; got: {err}"
-        );
+        let RuntimeError::Khive(conflict) = &err else {
+            panic!("expected structured conflict, got: {err:?}");
+        };
+        assert_eq!(conflict.kind(), khive_types::ErrorKind::Conflict);
+        assert!(conflict.message().contains("retry with fresh state"));
 
         let persisted = runtime
             .notes(&token)

--- a/crates/khive-pack-gtd/src/task_create.rs
+++ b/crates/khive-pack-gtd/src/task_create.rs
@@ -24,9 +24,9 @@ use crate::schema::{
 /// params or the generic create path's args. `properties` carries the
 /// generic path's nested-properties object (empty for `gtd.assign`, which has
 /// no nested-properties calling convention) — [`prepare_task_create`] falls
-/// back to it for `priority`/`depends_on`/`context_entity_id` exactly as
-/// `TaskHook::prepare_create` did before unification, so `create(kind="note",
-/// note_kind="task", properties={"priority": "p1"})` keeps working.
+/// back to recognized nested GTD fields when their top-level form is absent,
+/// so `create(kind="note", note_kind="task",
+/// properties={"priority": "p1"})` keeps working without a second type policy.
 #[derive(Debug, Default)]
 pub(crate) struct TaskCreateInput {
     pub(crate) title: String,
@@ -43,74 +43,151 @@ pub(crate) struct TaskCreateInput {
     pub(crate) properties: Value,
 }
 
+fn optional_string_field(
+    container: &Value,
+    key: &str,
+    display_name: &str,
+) -> Result<Option<String>, RuntimeError> {
+    match container.get(key) {
+        None | Some(Value::Null) => Ok(None),
+        Some(Value::String(value)) => Ok(Some(value.clone())),
+        Some(other) => Err(RuntimeError::InvalidInput(format!(
+            "{display_name} must be a string or null; got {other}"
+        ))),
+    }
+}
+
+fn optional_string_array_field(
+    container: &Value,
+    key: &str,
+    display_name: &str,
+) -> Result<Option<Vec<String>>, RuntimeError> {
+    match container.get(key) {
+        None | Some(Value::Null) => Ok(None),
+        Some(Value::Array(values)) => values
+            .iter()
+            .map(|value| {
+                value.as_str().map(str::to_string).ok_or_else(|| {
+                    RuntimeError::InvalidInput(format!(
+                        "{display_name} must be an array of strings"
+                    ))
+                })
+            })
+            .collect::<Result<Vec<_>, _>>()
+            .map(Some),
+        Some(_) => Err(RuntimeError::InvalidInput(format!(
+            "{display_name} must be an array of strings"
+        ))),
+    }
+}
+
 impl TaskCreateInput {
     /// Build an input from the generic `create` verb's raw args, honoring
     /// the same `title`/`name` fallback `TaskHook::prepare_create` used.
     pub(crate) fn from_create_args(args: &Value) -> Result<Self, RuntimeError> {
-        let title = args
-            .get("title")
-            .or_else(|| args.get("name"))
-            .and_then(Value::as_str)
-            .map(str::to_string)
-            .ok_or_else(|| {
-                RuntimeError::InvalidInput("kind=note + note_kind=task requires 'title'".into())
-            })?;
+        // Parse both spellings even when one wins so a malformed present value
+        // is never hidden by fallback normalization. JSON null means optional
+        // absence, therefore `title=null, name="fallback"` uses `name`.
+        let title = optional_string_field(args, "title", "title")?;
+        let name = optional_string_field(args, "name", "name")?;
+        let title = title.or(name).ok_or_else(|| {
+            RuntimeError::InvalidInput(
+                "kind=note + note_kind=task requires string 'title' or 'name'".into(),
+            )
+        })?;
 
-        let depends_on = match args.get("depends_on") {
-            Some(value) => {
-                let arr = value.as_array().ok_or_else(|| {
-                    RuntimeError::InvalidInput("depends_on must be an array of strings".into())
-                })?;
-                Some(
-                    arr.iter()
-                        .map(|v| {
-                            v.as_str().map(str::to_string).ok_or_else(|| {
-                                RuntimeError::InvalidInput(
-                                    "depends_on entries must be strings".into(),
-                                )
-                            })
-                        })
-                        .collect::<Result<Vec<_>, _>>()?,
-                )
+        let mut properties = match args.get("properties") {
+            None | Some(Value::Null) => json!({}),
+            Some(Value::Object(_)) => args["properties"].clone(),
+            Some(other) => {
+                return Err(RuntimeError::InvalidInput(format!(
+                    "properties must be an object or null; got {other}"
+                )))
             }
-            None => None,
         };
+
+        // Validate both calling conventions even when a top-level value wins.
+        // Otherwise a malformed nested GTD field remains stored and can surface
+        // later after the caller was told the create succeeded.
+        let description = optional_string_field(args, "description", "description")?.or(
+            optional_string_field(&properties, "description", "properties.description")?,
+        );
+        let assignee = optional_string_field(args, "assignee", "assignee")?.or(
+            optional_string_field(&properties, "assignee", "properties.assignee")?,
+        );
+        let priority = optional_string_field(args, "priority", "priority")?.or(
+            optional_string_field(&properties, "priority", "properties.priority")?,
+        );
+        let status = optional_string_field(args, "status", "status")?.or(optional_string_field(
+            &properties,
+            "status",
+            "properties.status",
+        )?);
+        let due = optional_string_field(args, "due", "due")?.or(optional_string_field(
+            &properties,
+            "due",
+            "properties.due",
+        )?);
+        let start = optional_string_field(args, "start", "start")?.or(optional_string_field(
+            &properties,
+            "start",
+            "properties.start",
+        )?);
+        let end = optional_string_field(args, "end", "end")?.or(optional_string_field(
+            &properties,
+            "end",
+            "properties.end",
+        )?);
+        let depends_on = optional_string_array_field(args, "depends_on", "depends_on")?.or(
+            optional_string_array_field(&properties, "depends_on", "properties.depends_on")?,
+        );
+        let context_entity_id =
+            optional_string_field(args, "context_entity_id", "context_entity_id")?.or(
+                optional_string_field(
+                    &properties,
+                    "context_entity_id",
+                    "properties.context_entity_id",
+                )?,
+            );
+        let tags = optional_string_array_field(args, "tags", "tags")?.or(
+            optional_string_array_field(&properties, "tags", "properties.tags")?,
+        );
+
+        // JSON null has the same optional-field meaning as absence at the typed
+        // `gtd.assign` boundary. Do not retain null mirrors in the stored task
+        // property bag when the generic create path uses that spelling.
+        if let Some(object) = properties.as_object_mut() {
+            for key in [
+                "description",
+                "assignee",
+                "priority",
+                "status",
+                "due",
+                "start",
+                "end",
+                "depends_on",
+                "context_entity_id",
+                "tags",
+            ] {
+                if object.get(key).is_some_and(Value::is_null) {
+                    object.remove(key);
+                }
+            }
+        }
 
         Ok(Self {
             title,
-            description: args
-                .get("description")
-                .and_then(Value::as_str)
-                .map(str::to_string),
-            assignee: args
-                .get("assignee")
-                .and_then(Value::as_str)
-                .map(str::to_string),
-            priority: args
-                .get("priority")
-                .and_then(Value::as_str)
-                .map(str::to_string),
-            status: args
-                .get("status")
-                .and_then(Value::as_str)
-                .map(str::to_string),
-            due: args.get("due").and_then(Value::as_str).map(str::to_string),
-            start: args
-                .get("start")
-                .and_then(Value::as_str)
-                .map(str::to_string),
-            end: args.get("end").and_then(Value::as_str).map(str::to_string),
+            description,
+            assignee,
+            priority,
+            status,
+            due,
+            start,
+            end,
             depends_on,
-            context_entity_id: args
-                .get("context_entity_id")
-                .and_then(Value::as_str)
-                .map(str::to_string),
-            tags: args.get("tags").cloned(),
-            properties: args
-                .get("properties")
-                .cloned()
-                .filter(Value::is_object)
-                .unwrap_or_else(|| json!({})),
+            context_entity_id,
+            tags: tags.map(|values| json!(values)),
+            properties,
         })
     }
 }
@@ -147,7 +224,7 @@ impl PreparedTaskCreate {
             // that later resolution.
             let mut seen = std::collections::HashSet::new();
             let mut merged = Vec::new();
-            if let Some(existing) = root.get("annotates") {
+            if let Some(existing) = root.get("annotates").filter(|value| !value.is_null()) {
                 let arr = existing.as_array().ok_or_else(|| {
                     RuntimeError::InvalidInput("annotates must be an array of strings".into())
                 })?;

--- a/crates/khive-pack-gtd/src/vocab.rs
+++ b/crates/khive-pack-gtd/src/vocab.rs
@@ -63,9 +63,10 @@ pub(crate) static GTD_NOTE_KIND_SPECS: [NoteKindSpec; 1] = [NoteKindSpec {
 
 /// Pack-auxiliary schema for GTD lifecycle audit.
 ///
-/// `gtd_lifecycle_audit` records every `transition` (and `complete`) invocation
-/// for replay and compliance auditing. The table is idempotent (`CREATE TABLE
-/// IF NOT EXISTS`) and is NOT part of the core versioned migration chain.
+/// `gtd_lifecycle_audit` receives best-effort rows for successful real
+/// `transition`/`complete` changes and canonical same-status note events. The
+/// table is idempotent (`CREATE TABLE IF NOT EXISTS`) and is NOT part of the
+/// core versioned migration chain.
 ///
 /// Every statement must be idempotent so the generic boot applier can call them
 /// on any database (fresh or pre-existing) without error. The fresh-table DDL

--- a/crates/khive-pack-gtd/tests/audit.rs
+++ b/crates/khive-pack-gtd/tests/audit.rs
@@ -5,6 +5,29 @@ mod common;
 use common::{assign, pack, rt};
 use khive_storage::{SqlStatement, SqlValue};
 use serde_json::json;
+use uuid::Uuid;
+
+#[tokio::test]
+async fn public_write_audit_record_compatibility_api_returns_unit() {
+    let rt = rt();
+    khive_pack_gtd::handlers::ensure_audit_schema(&rt).await;
+    let note_id = Uuid::new_v4();
+    let result =
+        khive_pack_gtd::handlers::write_audit_record(&rt, note_id, "inbox", "next", None, "local")
+            .await;
+    let _: () = result;
+
+    let mut reader = rt.sql().reader().await.expect("sql reader");
+    let rows = reader
+        .query_all(SqlStatement {
+            sql: "SELECT COUNT(*) AS count FROM gtd_lifecycle_audit WHERE note_id = ?1".into(),
+            params: vec![SqlValue::Text(note_id.to_string())],
+            label: None,
+        })
+        .await
+        .expect("audit count");
+    assert!(matches!(rows[0].get("count"), Some(SqlValue::Integer(1))));
+}
 
 #[tokio::test]
 async fn transition_writes_lifecycle_audit_record() {
@@ -18,13 +41,14 @@ async fn transition_writes_lifecycle_audit_record() {
     .await;
     let task_id = resp["full_id"].as_str().unwrap().to_string();
 
-    fixture
+    let transition = fixture
         .dispatch(
             "gtd.transition",
             json!({"id": task_id, "status": "next", "note": "moved to next"}),
         )
         .await
         .expect("transition should succeed");
+    assert_eq!(transition["audit_persisted"], true);
 
     let sql = rt.sql();
     let mut reader = sql.reader().await.expect("sql reader");
@@ -93,10 +117,11 @@ async fn complete_writes_lifecycle_audit_record() {
         .await
         .expect("transition to next should succeed");
 
-    fixture
+    let completed = fixture
         .dispatch("gtd.complete", json!({"id": task_id, "result": "done!"}))
         .await
         .expect("complete should succeed");
+    assert_eq!(completed["audit_persisted"], true);
 
     let sql = rt.sql();
     let mut reader = sql.reader().await.expect("sql reader");
@@ -128,6 +153,94 @@ async fn complete_writes_lifecycle_audit_record() {
         Some("done"),
         "audit to_state must be 'done'"
     );
+}
+
+#[tokio::test]
+async fn lifecycle_success_reports_audit_degradation_when_insert_fails() {
+    let rt = rt();
+    khive_pack_gtd::handlers::ensure_audit_schema(&rt).await;
+    {
+        let mut writer = rt.sql().writer().await.expect("sql writer");
+        writer
+            .execute_script(
+                "CREATE TRIGGER reject_gtd_audit_insert \
+                 BEFORE INSERT ON gtd_lifecycle_audit \
+                 BEGIN SELECT RAISE(FAIL, 'forced audit failure'); END;"
+                    .into(),
+            )
+            .await
+            .expect("failure-injection trigger");
+    }
+    let fixture = pack(rt.clone());
+
+    let transition_task = assign(
+        &fixture,
+        json!({"title": "audit-degraded transition", "status": "inbox"}),
+    )
+    .await;
+    let transition = fixture
+        .dispatch(
+            "gtd.transition",
+            json!({"id": transition_task["full_id"], "status": "next"}),
+        )
+        .await
+        .expect("domain transition remains successful");
+    assert_eq!(transition["transitioned"], true);
+    assert_eq!(transition["to"], "next");
+    assert_eq!(
+        transition["audit_persisted"], false,
+        "caller must see that the best-effort audit append was lost"
+    );
+
+    let complete_task = assign(
+        &fixture,
+        json!({"title": "audit-degraded complete", "status": "inbox"}),
+    )
+    .await;
+    let completed = fixture
+        .dispatch(
+            "gtd.complete",
+            json!({"id": complete_task["full_id"], "result": "finished during triage"}),
+        )
+        .await
+        .expect("domain completion remains successful");
+    assert_eq!(completed["completed"], true);
+    assert_eq!(completed["to"], "done");
+    assert_eq!(
+        completed["audit_persisted"], false,
+        "caller must see that the best-effort audit append was lost"
+    );
+
+    let noop_task = assign(
+        &fixture,
+        json!({"title": "audit-degraded no-op note", "status": "next"}),
+    )
+    .await;
+    let noop = fixture
+        .dispatch(
+            "gtd.transition",
+            json!({
+                "id": noop_task["full_id"],
+                "status": "next",
+                "note": "persist note despite degraded audit",
+            }),
+        )
+        .await
+        .expect("canonical note-bearing no-op remains successful");
+    assert_eq!(noop["transitioned"], false);
+    assert_eq!(noop["note_recorded"], true);
+    assert_eq!(noop["audit_persisted"], false);
+
+    let mut reader = rt.sql().reader().await.expect("sql reader");
+    let rows = reader
+        .query_all(SqlStatement {
+            sql: "SELECT COUNT(*) AS count FROM gtd_lifecycle_audit".into(),
+            params: vec![],
+            label: None,
+        })
+        .await
+        .expect("audit count");
+    assert!(matches!(rows[0].get("count"), Some(SqlValue::Integer(0))));
 }
 
 #[tokio::test]
@@ -433,6 +546,7 @@ async fn noop_transition_with_note_writes_audit_record_and_persists_note() {
         r["note_recorded"], true,
         "note_recorded must be true when a note is persisted"
     );
+    assert_eq!(r["audit_persisted"], true);
 
     let sql = rt.sql();
     let mut reader = sql.reader().await.expect("sql reader");

--- a/crates/khive-pack-gtd/tests/dependencies.rs
+++ b/crates/khive-pack-gtd/tests/dependencies.rs
@@ -3,7 +3,7 @@
 mod common;
 
 use common::{assign, pack, rt};
-use serde_json::json;
+use serde_json::{json, Value};
 
 #[tokio::test]
 async fn assign_creates_depends_on_edge_between_tasks() {
@@ -608,6 +608,55 @@ async fn create_task_merges_explicit_annotates_with_context_entity_id() {
 }
 
 #[tokio::test]
+async fn create_task_treats_null_annotates_as_absent_with_context_entity_id() {
+    let pack = pack(rt());
+
+    let context = pack
+        .dispatch(
+            "create",
+            json!({"kind": "concept", "name": "Null annotates context"}),
+        )
+        .await
+        .unwrap();
+    let context_id = context["id"].as_str().unwrap().to_string();
+
+    let created = pack
+        .dispatch(
+            "create",
+            json!({
+                "kind": "note",
+                "note_kind": "task",
+                "title": "null annotates with context",
+                "annotates": null,
+                "context_entity_id": context_id.clone(),
+            }),
+        )
+        .await
+        .expect("null annotates must be absent when the context adds an annotation");
+    assert_eq!(
+        created["properties"]["context_entity_id"].as_str(),
+        Some(context_id.as_str())
+    );
+
+    let task_id = created["id"].as_str().unwrap();
+    let annotations = pack
+        .dispatch(
+            "neighbors",
+            json!({"id": task_id, "direction": "out", "relations": ["annotates"]}),
+        )
+        .await
+        .expect("context-derived annotates edge must be persisted");
+    assert!(
+        annotations
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|neighbor| neighbor.to_string().contains(context_id.as_str())),
+        "task must annotate its context entity; got {annotations:?}"
+    );
+}
+
+#[tokio::test]
 async fn assign_and_create_task_reject_malformed_context_entity_id() {
     let pack = pack(rt());
 
@@ -633,6 +682,464 @@ async fn assign_and_create_task_reject_malformed_context_entity_id() {
         .await
         .unwrap_err();
     assert!(create_err.to_string().contains("context_entity_id"));
+}
+
+#[tokio::test]
+async fn generic_create_rejects_malformed_raw_kind_discriminants_before_write() {
+    let pack = pack(rt());
+    let cases = vec![
+        (
+            "substrate note_kind type",
+            "note_kind",
+            json!({"kind": "note", "note_kind": 17, "content": "must not become an observation"}),
+        ),
+        (
+            "substrate entity_kind type",
+            "entity_kind",
+            json!({"kind": "entity", "entity_kind": 17, "name": "must not persist"}),
+        ),
+        (
+            "granular note_kind type",
+            "note_kind",
+            json!({"kind": "task", "note_kind": 17, "title": "must not persist"}),
+        ),
+        (
+            "granular entity_kind type",
+            "entity_kind",
+            json!({"kind": "concept", "entity_kind": 17, "name": "must not persist"}),
+        ),
+        (
+            "irrelevant entity_kind type",
+            "entity_kind",
+            json!({"kind": "task", "entity_kind": false, "title": "must not persist"}),
+        ),
+        (
+            "irrelevant note_kind type",
+            "note_kind",
+            json!({"kind": "concept", "note_kind": [], "name": "must not persist"}),
+        ),
+        (
+            "kind type",
+            "kind",
+            json!({"kind": 17, "content": "must not persist"}),
+        ),
+        (
+            "kind null",
+            "kind",
+            json!({"kind": null, "content": "must not persist"}),
+        ),
+        (
+            "substrate empty note_kind",
+            "note_kind",
+            json!({"kind": "note", "note_kind": "", "content": "must not persist"}),
+        ),
+        (
+            "substrate empty entity_kind",
+            "entity_kind",
+            json!({"kind": "entity", "entity_kind": "  ", "name": "must not persist"}),
+        ),
+        (
+            "granular empty note_kind",
+            "note_kind",
+            json!({"kind": "task", "note_kind": "", "title": "must not persist"}),
+        ),
+        (
+            "granular empty entity_kind",
+            "entity_kind",
+            json!({"kind": "concept", "entity_kind": "\t", "name": "must not persist"}),
+        ),
+    ];
+
+    for (case, field, args) in cases {
+        let err = match pack.dispatch("create", args).await {
+            Err(err) => err,
+            Ok(value) => panic!("{case} must fail, but created {value:?}"),
+        };
+        assert!(
+            err.to_string().contains(field),
+            "{case} error must name `{field}`; got {err}"
+        );
+    }
+
+    let stats = pack
+        .dispatch("stats", json!({}))
+        .await
+        .expect("stats after rejected creates");
+    assert_eq!(stats["entities"].as_u64(), Some(0));
+    assert_eq!(stats["notes"].as_u64(), Some(0));
+}
+
+#[tokio::test]
+async fn generic_task_create_rejects_wrong_typed_optional_fields_before_write() {
+    use khive_storage::types::PageRequest;
+
+    let rt = rt();
+    let pack = pack(rt.clone());
+    let top_level_cases: Vec<(&str, Value)> = vec![
+        ("title", json!(17)),
+        ("name", json!(17)),
+        ("content", json!(["not", "text"])),
+        ("description", json!(1)),
+        ("assignee", json!(["agent"])),
+        ("priority", json!(1)),
+        ("status", json!(true)),
+        ("due", json!({"date": "2026-08-06"})),
+        ("start", json!(1)),
+        ("end", json!([])),
+        ("depends_on", json!("not-an-array")),
+        ("context_entity_id", json!(17)),
+        ("tags", json!("not-an-array")),
+        ("salience", json!("high")),
+        ("annotates", json!("not-an-array")),
+        ("entity_type", json!(17)),
+        ("skip_dedup_check", json!("yes")),
+        ("edges", json!("not-an-array")),
+        ("embedding_content", json!(17)),
+        ("properties", json!("not-an-object")),
+    ];
+
+    for (field, bad_value) in top_level_cases {
+        let mut args = json!({
+            "kind": "note",
+            "note_kind": "task",
+            "title": format!("bad top-level {field}"),
+        });
+        args.as_object_mut()
+            .expect("create args object")
+            .insert(field.to_string(), bad_value);
+        let err = pack
+            .dispatch("create", args)
+            .await
+            .expect_err("wrong-typed optional task field must be rejected");
+        let message = err.to_string();
+        if [
+            "name",
+            "content",
+            "description",
+            "tags",
+            "salience",
+            "annotates",
+            "entity_type",
+            "skip_dedup_check",
+            "edges",
+            "embedding_content",
+        ]
+        .contains(&field)
+        {
+            assert!(
+                message.contains("bad params"),
+                "shared CreateParams must reject {field}; got: {message}"
+            );
+        } else {
+            assert!(
+                message.contains(field),
+                "error must name {field}; got: {message}"
+            );
+        }
+    }
+
+    let err = pack
+        .dispatch(
+            "create",
+            json!({
+                "kind": "note",
+                "note_kind": "task",
+                "title": 17,
+                "name": "must not hide malformed title",
+            }),
+        )
+        .await
+        .expect_err("a valid fallback must not hide a malformed present title");
+    assert!(
+        err.to_string().contains("title"),
+        "strict parser must report malformed title before fallback; got: {err}"
+    );
+
+    let nested_cases: Vec<(&str, Value)> = vec![
+        ("description", json!(1)),
+        ("assignee", json!(["agent"])),
+        ("priority", json!(1)),
+        ("status", json!(true)),
+        ("due", json!({"date": "2026-08-06"})),
+        ("start", json!(1)),
+        ("end", json!([])),
+        ("depends_on", json!("not-an-array")),
+        ("context_entity_id", json!(17)),
+        ("tags", json!("not-an-array")),
+    ];
+    for (field, bad_value) in nested_cases {
+        let mut properties = serde_json::Map::new();
+        properties.insert(field.to_string(), bad_value);
+        let err = pack
+            .dispatch(
+                "create",
+                json!({
+                    "kind": "note",
+                    "note_kind": "task",
+                    "title": format!("bad nested {field}"),
+                    "properties": properties,
+                }),
+            )
+            .await
+            .expect_err("wrong-typed nested task field must be rejected");
+        assert!(
+            err.to_string().contains(field),
+            "error must name properties.{field}; got: {err}"
+        );
+    }
+
+    let token = rt.authorize(khive_runtime::Namespace::local()).unwrap();
+    let tasks = rt
+        .notes(&token)
+        .expect("note store")
+        .query_notes(
+            "local",
+            Some("task"),
+            PageRequest {
+                offset: 0,
+                limit: 100,
+            },
+        )
+        .await
+        .expect("task query");
+    assert!(
+        tasks.items.is_empty(),
+        "no malformed generic task create may persist a note"
+    );
+}
+
+#[tokio::test]
+async fn generic_task_create_treats_null_as_absence_and_falls_back_to_name() {
+    let pack = pack(rt());
+    let created = pack
+        .dispatch(
+            "create",
+            json!({
+                "kind": "task",
+                "entity_kind": null,
+                "note_kind": null,
+                "title": null,
+                "name": "name fallback",
+                "content": null,
+                "description": null,
+                "assignee": null,
+                "priority": null,
+                "status": null,
+                "due": null,
+                "start": null,
+                "end": null,
+                "depends_on": null,
+                "context_entity_id": null,
+                "tags": null,
+                "salience": null,
+                "annotates": null,
+                "properties": null,
+            }),
+        )
+        .await
+        .expect("JSON null must retain optional-field semantics");
+    assert_eq!(created["name"], "name fallback");
+    assert_eq!(created["content"], "name fallback");
+    assert_eq!(created["properties"]["status"], "inbox");
+    assert_eq!(created["properties"]["priority"], "p2");
+    assert!(created["properties"].get("description").is_none());
+
+    let nested = pack
+        .dispatch(
+            "create",
+            json!({
+                "kind": "note",
+                "note_kind": "task",
+                "title": "nested nulls",
+                "properties": {
+                    "description": null,
+                    "assignee": null,
+                    "priority": null,
+                    "status": null,
+                    "due": null,
+                    "start": null,
+                    "end": null,
+                    "depends_on": null,
+                    "context_entity_id": null,
+                    "tags": null,
+                },
+            }),
+        )
+        .await
+        .expect("nested optional nulls must also be accepted");
+    assert_eq!(nested["content"], "nested nulls");
+    assert_eq!(nested["properties"]["status"], "inbox");
+    assert_eq!(nested["properties"]["priority"], "p2");
+    assert!(nested["properties"].get("description").is_none());
+
+    let err = pack
+        .dispatch(
+            "create",
+            json!({
+                "kind": "note",
+                "note_kind": "task",
+                "title": null,
+                "name": null,
+            }),
+        )
+        .await
+        .expect_err("both task title spellings absent must be rejected");
+    assert!(
+        err.to_string().contains("title") && err.to_string().contains("name"),
+        "missing-title error must explain both accepted spellings; got: {err}"
+    );
+}
+
+#[tokio::test]
+async fn generic_task_update_keeps_content_and_description_synchronized() {
+    let pack = pack(rt());
+    let created = pack
+        .dispatch(
+            "create",
+            json!({
+                "kind": "note",
+                "note_kind": "task",
+                "title": "sync task",
+                "description": "original body",
+            }),
+        )
+        .await
+        .expect("task create");
+    let id = created["id"].as_str().expect("task id").to_string();
+
+    let content_update = pack
+        .dispatch("update", json!({"id": id, "content": "body from content"}))
+        .await
+        .expect("content update");
+    assert_eq!(content_update["content"], "body from content");
+    assert_eq!(
+        content_update["properties"]["description"],
+        "body from content"
+    );
+
+    let description_update = pack
+        .dispatch(
+            "update",
+            json!({"id": id, "properties": {"description": "body from property"}}),
+        )
+        .await
+        .expect("description update");
+    assert_eq!(description_update["content"], "body from property");
+    assert_eq!(
+        description_update["properties"]["description"],
+        "body from property"
+    );
+
+    let null_noop = pack
+        .dispatch(
+            "update",
+            json!({"id": id, "content": null, "properties": null}),
+        )
+        .await
+        .expect("null generic note patches mean leave unchanged");
+    assert_eq!(null_noop["content"], "body from property");
+    assert_eq!(null_noop["properties"]["description"], "body from property");
+
+    let cleared = pack
+        .dispatch(
+            "update",
+            json!({"id": id, "properties": {"description": null}}),
+        )
+        .await
+        .expect("explicit description clear");
+    assert_eq!(cleared["content"], "sync task");
+    assert!(cleared["properties"]["description"].is_null());
+
+    let err = pack
+        .dispatch(
+            "update",
+            json!({
+                "id": id,
+                "content": "one body",
+                "properties": {"description": "another body"},
+            }),
+        )
+        .await
+        .expect_err("conflicting mirrors must be rejected");
+    assert!(
+        err.to_string().contains("must match"),
+        "conflict error must explain the mirror contract; got: {err}"
+    );
+}
+
+#[tokio::test]
+async fn generic_task_update_rejects_title_clear_before_description_clear_can_write() {
+    let runtime = rt();
+    let pack = pack(runtime.clone());
+    let created = pack
+        .dispatch(
+            "create",
+            json!({
+                "kind": "note",
+                "note_kind": "task",
+                "title": "preserved title",
+                "description": "preserved body",
+            }),
+        )
+        .await
+        .expect("task create");
+    let id = uuid::Uuid::parse_str(created["id"].as_str().expect("task id")).expect("task UUID");
+    let token = runtime
+        .authorize(khive_runtime::Namespace::local())
+        .expect("authorize local");
+    let before = runtime
+        .notes(&token)
+        .expect("note store")
+        .get_note(id)
+        .await
+        .expect("read task before rejected update")
+        .expect("task exists");
+
+    let err = pack
+        .dispatch(
+            "update",
+            json!({
+                "id": id.to_string(),
+                "name": null,
+                "properties": {"description": null},
+            }),
+        )
+        .await
+        .expect_err("a task title cannot be cleared");
+    assert!(
+        err.to_string().contains("task title cannot be cleared"),
+        "title-clear error must identify the task invariant; got: {err}"
+    );
+
+    let after = runtime
+        .notes(&token)
+        .expect("note store")
+        .get_note(id)
+        .await
+        .expect("read task after rejected update")
+        .expect("task exists");
+    assert_eq!(after, before, "rejected normalization must not write");
+}
+
+#[tokio::test]
+async fn renaming_task_without_description_updates_fallback_content() {
+    let pack = pack(rt());
+    let created = pack
+        .dispatch(
+            "create",
+            json!({"kind": "note", "note_kind": "task", "title": "old title"}),
+        )
+        .await
+        .expect("task create");
+    let id = created["id"].as_str().expect("task id");
+
+    let updated = pack
+        .dispatch("update", json!({"id": id, "name": "new title"}))
+        .await
+        .expect("task rename");
+    assert_eq!(updated["name"], "new title");
+    assert_eq!(updated["content"], "new title");
+    assert!(updated["properties"].get("description").is_none());
 }
 
 // ---- generic create must normalize nested properties -------------------------

--- a/crates/khive-pack-gtd/tests/dependencies.rs
+++ b/crates/khive-pack-gtd/tests/dependencies.rs
@@ -1068,6 +1068,48 @@ async fn generic_task_update_keeps_content_and_description_synchronized() {
 }
 
 #[tokio::test]
+async fn clearing_absent_description_preserves_legacy_task_body() {
+    let runtime = rt();
+    let pack = pack(runtime.clone());
+    let token = runtime
+        .authorize(khive_runtime::Namespace::local())
+        .expect("authorize local");
+    let body = "legacy task body that must survive clearing an absent description";
+    let mut task = khive_storage::Note::new("local", "task", body);
+    task.name = Some("legacy title".to_string());
+    task.properties = Some(json!({"status": "inbox", "priority": "p2"}));
+    let task_id = task.id;
+    runtime
+        .notes(&token)
+        .expect("note store")
+        .upsert_note(task)
+        .await
+        .expect("seed legacy task");
+
+    let updated = pack
+        .dispatch(
+            "update",
+            json!({
+                "id": task_id.to_string(),
+                "properties": {"description": null},
+            }),
+        )
+        .await
+        .expect("clearing an absent description must preserve legacy content");
+
+    assert_eq!(updated["content"].as_str(), Some(body));
+    assert!(updated["properties"]["description"].is_null());
+    let persisted = runtime
+        .notes(&token)
+        .expect("note store")
+        .get_note(task_id)
+        .await
+        .expect("read updated task")
+        .expect("task exists");
+    assert_eq!(persisted.content, body);
+}
+
+#[tokio::test]
 async fn renaming_legacy_task_without_description_preserves_body() {
     let runtime = rt();
     let pack = pack(runtime.clone());
@@ -1243,6 +1285,28 @@ async fn generic_task_update_rejects_title_clear_before_description_clear_can_wr
         .expect("read task after rejected update")
         .expect("task exists");
     assert_eq!(after, before, "rejected normalization must not write");
+}
+
+#[tokio::test]
+async fn generic_task_update_rejects_whitespace_only_title_patch() {
+    let pack = pack(rt());
+    let created = pack
+        .dispatch(
+            "create",
+            json!({"kind": "note", "note_kind": "task", "title": "stable title"}),
+        )
+        .await
+        .expect("task create");
+    let id = created["id"].as_str().expect("task id");
+
+    let err = pack
+        .dispatch("update", json!({"id": id, "name": " \t\n "}))
+        .await
+        .expect_err("a whitespace-only task title must be rejected");
+    assert_eq!(
+        err.to_string(),
+        "invalid input: task title must not be empty"
+    );
 }
 
 #[tokio::test]

--- a/crates/khive-pack-gtd/tests/dependencies.rs
+++ b/crates/khive-pack-gtd/tests/dependencies.rs
@@ -1068,6 +1068,130 @@ async fn generic_task_update_keeps_content_and_description_synchronized() {
 }
 
 #[tokio::test]
+async fn renaming_legacy_task_without_description_preserves_body() {
+    let runtime = rt();
+    let pack = pack(runtime.clone());
+    let token = runtime
+        .authorize(khive_runtime::Namespace::local())
+        .expect("authorize local");
+    let body = "acceptance notes:\n- preserve this line\n- and this exact trailing line\n";
+    let mut task = khive_storage::Note::new("local", "task", body);
+    task.name = Some("legacy title".to_string());
+    task.properties = Some(json!({"status": "inbox", "priority": "p2"}));
+    let task_id = task.id;
+    runtime
+        .notes(&token)
+        .expect("note store")
+        .upsert_note(task)
+        .await
+        .expect("seed legacy task");
+
+    let updated = pack
+        .dispatch(
+            "update",
+            json!({"id": task_id.to_string(), "name": "renamed legacy title"}),
+        )
+        .await
+        .expect("rename legacy task");
+
+    assert_eq!(updated["name"], "renamed legacy title");
+    assert_eq!(updated["content"].as_str(), Some(body));
+    assert!(updated["properties"].get("description").is_none());
+    let persisted = runtime
+        .notes(&token)
+        .expect("note store")
+        .get_note(task_id)
+        .await
+        .expect("read renamed task")
+        .expect("task exists");
+    assert_eq!(persisted.content.as_bytes(), body.as_bytes());
+    assert!(persisted
+        .properties
+        .as_ref()
+        .and_then(|properties| properties.get("description"))
+        .is_none());
+}
+
+#[tokio::test]
+async fn generic_task_update_rejects_lifecycle_properties_but_allows_other_properties() {
+    let pack = pack(rt());
+    let created = pack
+        .dispatch(
+            "create",
+            json!({"kind": "note", "note_kind": "task", "title": "owned lifecycle"}),
+        )
+        .await
+        .expect("task create");
+    let id = created["id"].as_str().expect("task id");
+
+    for (field, value) in [
+        ("status", json!("done")),
+        ("completed_at", json!(1234)),
+        ("transition_history", json!([])),
+    ] {
+        let err = pack
+            .dispatch("update", json!({"id": id, "properties": {field: value}}))
+            .await
+            .expect_err("generic update must reject lifecycle-owned properties");
+        assert_eq!(
+            err.to_string(),
+            format!(
+                "invalid input: properties.{field} is lifecycle-owned and cannot be patched on a task; use gtd.transition for lifecycle changes or gtd.complete for terminal completion"
+            )
+        );
+    }
+
+    let updated = pack
+        .dispatch(
+            "update",
+            json!({
+                "id": id,
+                "properties": {
+                    "priority": "p1",
+                    "due": "2026-08-09T12:00:00Z",
+                    "planning_label": "reviewed"
+                }
+            }),
+        )
+        .await
+        .expect("non-lifecycle task properties remain patchable");
+    assert_eq!(updated["properties"]["priority"], "p1");
+    assert_eq!(updated["properties"]["due"], "2026-08-09T12:00:00Z");
+    assert_eq!(updated["properties"]["planning_label"], "reviewed");
+    assert_eq!(updated["properties"]["status"], "inbox");
+}
+
+#[tokio::test]
+async fn salience_only_update_succeeds_for_legacy_nameless_task() {
+    let runtime = rt();
+    let pack = pack(runtime.clone());
+    let token = runtime
+        .authorize(khive_runtime::Namespace::local())
+        .expect("authorize local");
+    let body = "legacy task body without a title";
+    let mut task = khive_storage::Note::new("local", "task", body);
+    task.properties = Some(json!({"status": "inbox", "priority": "p2"}));
+    let task_id = task.id;
+    runtime
+        .notes(&token)
+        .expect("note store")
+        .upsert_note(task)
+        .await
+        .expect("seed nameless task");
+
+    let updated = pack
+        .dispatch(
+            "update",
+            json!({"id": task_id.to_string(), "salience": 0.2}),
+        )
+        .await
+        .expect("salience-only update must not require a title");
+    assert_eq!(updated["salience"], 0.2);
+    assert_eq!(updated["content"], body);
+    assert!(updated["name"].is_null());
+}
+
+#[tokio::test]
 async fn generic_task_update_rejects_title_clear_before_description_clear_can_write() {
     let runtime = rt();
     let pack = pack(runtime.clone());

--- a/crates/khive-pack-gtd/tests/integration.rs
+++ b/crates/khive-pack-gtd/tests/integration.rs
@@ -1587,65 +1587,52 @@ async fn next_excludes_terminal_tasks() {
     let _ = t1["full_id"].as_str();
 }
 
-// ── UE2-H1: complete() state machine enforcement ─────────────────────────────
+// ── complete() state machine enforcement ─────────────────────────────────────
 
-/// complete() from inbox must be rejected — task must be in next or active first.
+/// `complete()` follows the same accepted lifecycle table as `transition`.
 #[tokio::test]
-async fn complete_from_inbox_is_rejected() {
+async fn complete_from_inbox_succeeds_per_lifecycle_table() {
     let pack = pack(rt());
     let resp = assign(&pack, json!({"title": "inbox task"})).await;
     let id = resp["full_id"].as_str().unwrap().to_string();
     assert_eq!(resp["status"], "inbox");
 
-    let err = pack
+    let done = pack
         .dispatch("gtd.complete", json!({"id": id}))
         .await
-        .unwrap_err();
-    let msg = err.to_string();
-    assert!(
-        msg.contains("inbox"),
-        "error must mention current state 'inbox'; got: {msg}"
-    );
-    assert!(
-        msg.contains("transition to 'next' or 'active'"),
-        "error must guide caller to transition first; got: {msg}"
-    );
+        .expect("ADR-019 permits inbox -> done");
+    assert_eq!(done["from"], "inbox");
+    assert_eq!(done["to"], "done");
 }
 
-/// complete() from waiting must be rejected.
+/// `waiting -> done` is a legal terminal transition.
 #[tokio::test]
-async fn complete_from_waiting_is_rejected() {
+async fn complete_from_waiting_succeeds_per_lifecycle_table() {
     let pack = pack(rt());
     let resp = assign(&pack, json!({"title": "waiting task", "status": "waiting"})).await;
     let id = resp["full_id"].as_str().unwrap().to_string();
 
-    let err = pack
+    let done = pack
         .dispatch("gtd.complete", json!({"id": id}))
         .await
-        .unwrap_err();
-    let msg = err.to_string();
-    assert!(
-        msg.contains("waiting"),
-        "error must mention current state 'waiting'; got: {msg}"
-    );
+        .expect("ADR-019 permits waiting -> done");
+    assert_eq!(done["from"], "waiting");
+    assert_eq!(done["to"], "done");
 }
 
-/// complete() from someday must be rejected.
+/// `someday -> done` is a legal terminal transition.
 #[tokio::test]
-async fn complete_from_someday_is_rejected() {
+async fn complete_from_someday_succeeds_per_lifecycle_table() {
     let pack = pack(rt());
     let resp = assign(&pack, json!({"title": "someday task", "status": "someday"})).await;
     let id = resp["full_id"].as_str().unwrap().to_string();
 
-    let err = pack
+    let done = pack
         .dispatch("gtd.complete", json!({"id": id}))
         .await
-        .unwrap_err();
-    let msg = err.to_string();
-    assert!(
-        msg.contains("someday"),
-        "error must mention current state 'someday'; got: {msg}"
-    );
+        .expect("ADR-019 permits someday -> done");
+    assert_eq!(done["from"], "someday");
+    assert_eq!(done["to"], "done");
 }
 
 /// complete() from next must succeed.
@@ -2634,8 +2621,9 @@ async fn next_succeeds_when_matches_exactly_at_scan_bound() {
 /// `json_extract` on a legacy row with no stored `status` key evaluates to
 /// SQL `NULL`, which `Eq` never matches, even though every other code path
 /// (`task_status`, `render_task`) treats a missing `status` as `"inbox"`.
-/// The filter must use `EqOrMissing` so `status="inbox"` also surfaces tasks
-/// that predate the `status` property being written at all.
+/// The filter's default-aware text predicate must therefore make
+/// `status="inbox"` also surface tasks that predate the `status` property
+/// being written at all.
 #[tokio::test]
 async fn tasks_status_inbox_filter_matches_legacy_task_missing_status_property() {
     use khive_storage::note::Note;
@@ -2680,6 +2668,71 @@ async fn tasks_status_inbox_filter_matches_legacy_task_missing_status_property()
          status property, since a missing status defaults to inbox everywhere \
          else; result: {result:?}"
     );
+}
+
+/// `task_status`/`render_task` default every non-string `properties.status`
+/// value to `inbox`, not only an absent key. The pushed-down SQL predicate
+/// must use the same CASE rule for every persisted JSON type; otherwise the
+/// rendered task says `inbox` but `tasks(status="inbox")` cannot find it.
+#[tokio::test]
+async fn tasks_status_inbox_filter_matches_persisted_null_and_all_non_text_status_values() {
+    use khive_storage::note::Note;
+
+    let runtime = rt();
+    let token = runtime
+        .authorize(khive_runtime::Namespace::local())
+        .unwrap();
+    let note_store = runtime.notes(&token).expect("note store");
+    let now = chrono::Utc::now().timestamp_micros();
+    let malformed_statuses = [
+        ("legacy-status-null", Value::Null),
+        ("legacy-status-bool", json!(true)),
+        ("legacy-status-integer", json!(7)),
+        ("legacy-status-real", json!(1.5)),
+        ("legacy-status-array", json!(["next"])),
+        ("legacy-status-object", json!({"value": "next"})),
+    ];
+
+    for (offset, (title, status)) in malformed_statuses.iter().enumerate() {
+        let note = Note {
+            id: uuid::Uuid::new_v4(),
+            namespace: "local".to_string(),
+            kind: "task".to_string(),
+            status: "active".to_string(),
+            name: Some((*title).to_string()),
+            content: format!("legacy task with {title}"),
+            salience: None,
+            decay_factor: None,
+            expires_at: None,
+            properties: Some(json!({"status": status})),
+            created_at: now + i64::try_from(offset).unwrap(),
+            updated_at: now + i64::try_from(offset).unwrap(),
+            deleted_at: None,
+        };
+        note_store
+            .upsert_note(note)
+            .await
+            .expect("persist malformed legacy status");
+    }
+
+    let pack = pack(runtime);
+    let result = pack
+        .dispatch("gtd.tasks", json!({"status": "inbox"}))
+        .await
+        .expect("inbox query");
+    let titles: std::collections::BTreeSet<&str> = result
+        .as_array()
+        .expect("tasks array")
+        .iter()
+        .filter_map(|task| task["title"].as_str())
+        .collect();
+    for (title, _) in &malformed_statuses {
+        assert!(
+            titles.contains(title),
+            "persisted non-text status for {title:?} must default to inbox in both rendering \
+             and SQL filtering; result: {result:?}"
+        );
+    }
 }
 
 /// Same bug as above, for `priority="p2"`: a legacy task with no stored

--- a/crates/khive-pack-gtd/tests/lifecycle.rs
+++ b/crates/khive-pack-gtd/tests/lifecycle.rs
@@ -198,59 +198,155 @@ async fn test_complete_on_already_done_returns_clear_error() {
 }
 
 #[tokio::test]
-async fn complete_from_inbox_is_rejected() {
+async fn complete_from_inbox_succeeds_per_lifecycle_table() {
     let pack = pack(rt());
     let resp = assign(&pack, json!({"title": "inbox task"})).await;
     let id = resp["full_id"].as_str().unwrap().to_string();
     assert_eq!(resp["status"], "inbox");
 
-    let err = pack
+    let done = pack
         .dispatch("gtd.complete", json!({"id": id}))
         .await
-        .unwrap_err();
-    let msg = err.to_string();
-    assert!(
-        msg.contains("inbox"),
-        "error must mention current state 'inbox'; got: {msg}"
+        .expect("ADR-019 permits inbox -> done");
+    assert_eq!(done["from"], "inbox");
+    assert_eq!(done["to"], "done");
+}
+
+#[tokio::test]
+async fn legacy_tasks_missing_status_can_transition_and_complete_from_semantic_inbox() {
+    let runtime = rt();
+    let token = runtime.authorize(Namespace::local()).unwrap();
+
+    let mut transition_task = khive_storage::Note::new("local", "task", "legacy transition body");
+    transition_task.name = Some("legacy transition body".to_string());
+    transition_task.properties = Some(json!({
+        "priority": "p2",
+        "description": "legacy transition body",
+    }));
+    let transition_id = transition_task.id;
+    let transition_revision = transition_task.updated_at;
+
+    let mut complete_task = khive_storage::Note::new("local", "task", "legacy complete body");
+    complete_task.name = Some("legacy complete body".to_string());
+    complete_task.properties = Some(json!({
+        "priority": "p2",
+        "description": "legacy complete body",
+    }));
+    let complete_id = complete_task.id;
+    let complete_revision = complete_task.updated_at;
+
+    let store = runtime.notes(&token).expect("note store");
+    store
+        .upsert_note(transition_task)
+        .await
+        .expect("seed legacy transition task");
+    store
+        .upsert_note(complete_task)
+        .await
+        .expect("seed legacy complete task");
+
+    let pack = pack(runtime.clone());
+    let transitioned = pack
+        .dispatch(
+            "gtd.transition",
+            json!({"id": transition_id.to_string(), "status": "next"}),
+        )
+        .await
+        .expect("missing status must transition from semantic inbox");
+    assert_eq!(transitioned["from"], "inbox");
+    assert_eq!(transitioned["to"], "next");
+    assert_eq!(transitioned["transitioned"], true);
+    assert!(transitioned["audit_persisted"].is_boolean());
+
+    let completed = pack
+        .dispatch(
+            "gtd.complete",
+            json!({"id": complete_id.to_string(), "result": "legacy shipped"}),
+        )
+        .await
+        .expect("missing status must complete from semantic inbox");
+    assert_eq!(completed["from"], "inbox");
+    assert_eq!(completed["to"], "done");
+    assert_eq!(completed["completed"], true);
+    assert!(completed["audit_persisted"].is_boolean());
+
+    let transitioned_note = runtime
+        .notes(&token)
+        .expect("note store")
+        .get_note(transition_id)
+        .await
+        .expect("read transitioned task")
+        .expect("transitioned task exists");
+    assert!(transitioned_note.updated_at > transition_revision);
+    assert_eq!(
+        transitioned_note
+            .properties
+            .as_ref()
+            .and_then(|properties| properties.get("status"))
+            .and_then(|status| status.as_str()),
+        Some("next")
     );
-    assert!(
-        msg.contains("transition to 'next' or 'active'"),
-        "error must guide caller to transition first; got: {msg}"
+    assert_eq!(
+        transitioned_note
+            .properties
+            .as_ref()
+            .and_then(|properties| properties.get("description"))
+            .and_then(|description| description.as_str()),
+        Some(transitioned_note.content.as_str())
+    );
+
+    let completed_note = runtime
+        .notes(&token)
+        .expect("note store")
+        .get_note(complete_id)
+        .await
+        .expect("read completed task")
+        .expect("completed task exists");
+    assert!(completed_note.updated_at > complete_revision);
+    assert_eq!(
+        completed_note
+            .properties
+            .as_ref()
+            .and_then(|properties| properties.get("status"))
+            .and_then(|status| status.as_str()),
+        Some("done")
+    );
+    assert_eq!(
+        completed_note
+            .properties
+            .as_ref()
+            .and_then(|properties| properties.get("description"))
+            .and_then(|description| description.as_str()),
+        Some(completed_note.content.as_str())
     );
 }
 
 #[tokio::test]
-async fn complete_from_waiting_is_rejected() {
+async fn complete_from_waiting_succeeds_per_lifecycle_table() {
     let pack = pack(rt());
     let resp = assign(&pack, json!({"title": "waiting task", "status": "waiting"})).await;
     let id = resp["full_id"].as_str().unwrap().to_string();
 
-    let err = pack
+    let done = pack
         .dispatch("gtd.complete", json!({"id": id}))
         .await
-        .unwrap_err();
-    let msg = err.to_string();
-    assert!(
-        msg.contains("waiting"),
-        "error must mention current state 'waiting'; got: {msg}"
-    );
+        .expect("ADR-019 permits waiting -> done");
+    assert_eq!(done["from"], "waiting");
+    assert_eq!(done["to"], "done");
 }
 
 #[tokio::test]
-async fn complete_from_someday_is_rejected() {
+async fn complete_from_someday_succeeds_per_lifecycle_table() {
     let pack = pack(rt());
     let resp = assign(&pack, json!({"title": "someday task", "status": "someday"})).await;
     let id = resp["full_id"].as_str().unwrap().to_string();
 
-    let err = pack
+    let done = pack
         .dispatch("gtd.complete", json!({"id": id}))
         .await
-        .unwrap_err();
-    let msg = err.to_string();
-    assert!(
-        msg.contains("someday"),
-        "error must mention current state 'someday'; got: {msg}"
-    );
+        .expect("ADR-019 permits someday -> done");
+    assert_eq!(done["from"], "someday");
+    assert_eq!(done["to"], "done");
 }
 
 #[tokio::test]

--- a/crates/khive-pack-kg/src/handlers/create.rs
+++ b/crates/khive-pack-kg/src/handlers/create.rs
@@ -24,6 +24,32 @@ pub(super) fn add_embedding_truncation_warning(response: &mut Value, truncated: 
     }
 }
 
+fn required_singleton_kind(params: &Value) -> Result<String, RuntimeError> {
+    match params.get("kind") {
+        None => Err(RuntimeError::InvalidInput("create requires 'kind'".into())),
+        Some(Value::String(kind)) => Ok(kind.clone()),
+        Some(value) => Err(RuntimeError::InvalidInput(format!(
+            "create: `kind` must be a string; got {value}"
+        ))),
+    }
+}
+
+fn optional_singleton_kind_alias(
+    params: &Value,
+    field: &str,
+) -> Result<Option<String>, RuntimeError> {
+    match params.get(field) {
+        None | Some(Value::Null) => Ok(None),
+        Some(Value::String(value)) if value.trim().is_empty() => Err(RuntimeError::InvalidInput(
+            format!("create: `{field}` must not be empty"),
+        )),
+        Some(Value::String(value)) => Ok(Some(value.clone())),
+        Some(value) => Err(RuntimeError::InvalidInput(format!(
+            "create: `{field}` must be a string or null; got {value}"
+        ))),
+    }
+}
+
 impl KgPack {
     pub(crate) async fn handle_create(
         &self,
@@ -31,15 +57,6 @@ impl KgPack {
         mut params: Value,
         registry: &VerbRegistry,
     ) -> Result<Value, RuntimeError> {
-        // `kind` is required for the single-record path but NOT for the bulk
-        // `items` path (each item carries its own kind). Defer the requirement
-        // until after the bulk early-exit so `create(items=[...])` works without
-        // a redundant top-level `kind`.
-        let raw_kind_opt = params
-            .get("kind")
-            .and_then(Value::as_str)
-            .map(str::to_string);
-
         const CREATE_USER_KEYS: &[&str] = &[
             "kind",
             "name",
@@ -224,19 +241,23 @@ impl KgPack {
         }
         // ── End bulk path ──────────────────────────────────────────────────────
 
-        let raw_kind = raw_kind_opt
-            .ok_or_else(|| RuntimeError::InvalidInput("create requires 'kind'".into()))?;
+        // Validate the raw singleton discriminants before resolving a hook or
+        // replacing them with canonical values. `Value::as_str` would turn a
+        // malformed present value into `None`, allowing (for example) an
+        // integer `note_kind` to silently fall back to `observation`. Both
+        // legacy aliases are checked eagerly even when the selected `kind`
+        // makes one of them irrelevant, so malformed caller input is never
+        // hidden by canonicalization.
+        let raw_kind = required_singleton_kind(&params)?;
+        let raw_entity_kind = optional_singleton_kind_alias(&params, "entity_kind")?;
+        let raw_note_kind = optional_singleton_kind_alias(&params, "note_kind")?;
         let spec = resolve_kind_spec(&raw_kind, registry)?;
 
         let (sub_kind, hook) = match &spec {
             KindSpec::Entity { specific } => {
-                let legacy = params
-                    .get("entity_kind")
-                    .and_then(Value::as_str)
-                    .map(str::to_string);
                 let canonical = reconcile_specific(
                     specific.clone(),
-                    legacy.as_deref(),
+                    raw_entity_kind.as_deref(),
                     |s| canonical_entity_kind(s, registry),
                     "entity_kind",
                 )?
@@ -249,14 +270,9 @@ impl KgPack {
                 (Some(canonical), hook)
             }
             KindSpec::Note { specific } => {
-                let legacy = params
-                    .get("note_kind")
-                    .and_then(Value::as_str)
-                    .map(str::to_string)
-                    .filter(|s| !s.is_empty());
                 let canonical = reconcile_specific(
                     specific.clone(),
-                    legacy.as_deref(),
+                    raw_note_kind.as_deref(),
                     |s| canonical_note_kind(s, registry),
                     "note_kind",
                 )?
@@ -307,6 +323,16 @@ impl KgPack {
             obj.entry("namespace")
                 .or_insert_with(|| json!(token.namespace().as_str()));
         }
+
+        // Validate the caller's raw shared-create fields before a kind hook
+        // can normalize or replace them. Task creation, for example, derives
+        // `name`, `content`, and `salience`; without this first pass a malformed
+        // caller value in one of those fields could be overwritten by the hook
+        // and therefore escape the canonical `CreateParams` type boundary.
+        // `CreateParams` intentionally accepts the flavored hook-only keys as
+        // unknown fields, so this validates the shared subset without
+        // precluding pack-specific input.
+        let _: CreateParams = deser(params.clone())?;
 
         if let Some(ref h) = hook {
             h.prepare_create(&self.runtime, &mut params).await?;

--- a/crates/khive-pack-kg/src/handlers/update.rs
+++ b/crates/khive-pack-kg/src/handlers/update.rs
@@ -141,10 +141,10 @@ impl KgPack {
     pub(crate) async fn handle_update(
         &self,
         token: &NamespaceToken,
-        params: Value,
+        mut params: Value,
         registry: &VerbRegistry,
     ) -> Result<Value, RuntimeError> {
-        let p: UpdateParams = deser(params)?;
+        let p: UpdateParams = deser(params.clone())?;
         if p.entity_kind.is_some() {
             return Err(RuntimeError::InvalidInput(
                 "entity_kind is immutable; to change kind, delete then re-create the entity, or use merge() if this is a deduplication correction".into(),
@@ -236,8 +236,9 @@ impl KgPack {
                     ));
                 }
                 registry
-                    .validate_note_update_hook(&self.runtime, token, &note, p.properties.as_ref())
+                    .prepare_note_update_hook(&self.runtime, token, &note, &mut params)
                     .await?;
+                let p: UpdateParams = deser(params)?;
                 let patch = NotePatch::new(
                     optional_string_patch(p.name, "name")?,
                     p.content,
@@ -247,7 +248,7 @@ impl KgPack {
                 );
                 let (note, report) = self
                     .runtime
-                    .update_note_with_embedding_report(token, id, patch)
+                    .update_note_from_snapshot_with_embedding_report(token, note, patch)
                     .await?;
                 let mut response = normalize_entity_timestamps(to_json(&note)?);
                 super::create::add_embedding_truncation_warning(

--- a/crates/khive-runtime/docs/api/atomic_prepare.md
+++ b/crates/khive-runtime/docs/api/atomic_prepare.md
@@ -8,8 +8,13 @@ functions that build those plans.
 
 Pack-owned mutation invariants are adapted at the `kkernel` boundary, where both
 the `VerbRegistry` and this runtime plan vocabulary are visible. For task note
-updates and task dependency links, `kkernel` invokes the same `KindHook` validators
-as canonical KG dispatch after building the substrate plan. Core migration V15's
+updates and task dependency links, `kkernel` invokes the same `KindHook` update
+normalizer/validators as canonical KG dispatch before building the substrate plan.
+For a note update, the hook and plan consume one shared note snapshot; the generated
+statement compares that snapshot's `updated_at` and deletion marker at apply time.
+Concurrent changes and repeated same-target note updates prepared without projected
+state therefore fail their affected-row guard and roll back the unit.
+Core migration V15's
 transaction-time triggers remain the final backstop: they see earlier statements
 in the same atomic unit and close concurrent check/write races that an async prepare
 pass cannot.

--- a/crates/khive-runtime/src/atomic_plan.rs
+++ b/crates/khive-runtime/src/atomic_plan.rs
@@ -116,15 +116,17 @@ pub enum PostCommitEffect {
     ReindexNote { note_id: Uuid },
     /// Append one `gtd_lifecycle_audit` row for a committed `gtd.transition`
     /// or `gtd.complete` (ADR-099 B3, GAP-5): canonical `handle_transition`/
-    /// `handle_complete` call `ensure_audit_schema` + `write_audit_record`
+    /// `handle_complete` call `ensure_audit_schema` +
+    /// `write_audit_record_with_status`
     /// (`khive-pack-gtd::handlers`) as a best-effort side write — a failed
     /// audit insert must never roll back an already-committed transition.
-    /// Carries exactly the fields `write_audit_record` needs. Applied
+    /// Carries exactly the fields the lifecycle-audit helper needs. Applied
     /// outside `khive-runtime` (crate-direction: `khive-pack-gtd` depends on
     /// `khive-runtime`, not the other way around) — this crate's own
     /// `apply_post_commit_effects` treats this variant as a no-op; the
     /// `kkernel` caller that owns both crates applies it by calling the
-    /// canonical `ensure_audit_schema`/`write_audit_record` functions
+    /// canonical `ensure_audit_schema`/`write_audit_record_with_status`
+    /// functions
     /// directly.
     GtdAudit {
         task_id: Uuid,
@@ -412,34 +414,42 @@ impl MergePlan {
 #[derive(Debug, Clone)]
 pub struct GtdTransitionPlan {
     pub(crate) task_id: Uuid,
-    /// Status-column DML to apply inside the atomic unit. Property-only
-    /// status mutation — triggers no reindex (ADR-099 D3). The transition
-    /// statement carries the guard (prepare validated the current status
-    /// and the requested transition were legal). Empty for an idempotent
-    /// no-op (`current == target` after `normalize_status`, GAP-5/GAP-6 fix
-    /// round) — canonical performs no write in that case either
-    /// (`handlers.rs:995-1005`).
+    /// Task-property DML to apply inside the atomic unit. Property-only status
+    /// mutation triggers no reindex (ADR-099 D3). The transition
+    /// statement carries the guard over the exact decision snapshot's note
+    /// revision, deletion marker, and semantic status (prepare validated the
+    /// current status and requested transition were legal). For an idempotent
+    /// no-op (`current == target` after `normalize_status`) this contains one
+    /// guarded, mutation-free assertion that revalidates the prepare snapshot
+    /// under the commit transaction. Atomic v1 still persists no caller note;
+    /// canonical dispatch has a separately documented note-event path.
     pub(crate) statements: Vec<PlanStatement>,
+    /// Explicit result-shape discriminator. A no-op can no longer be inferred
+    /// from an empty statement list because it carries a guarded assertion.
+    pub(crate) idempotent_noop: bool,
     /// Deferred lifecycle audit row assigned by the prepare pass (GAP-5):
-    /// `PostCommitEffect::None` for the idempotent no-op case, matching
-    /// canonical's early return before its own
-    /// `ensure_audit_schema`/`write_audit_record` call.
+    /// `PostCommitEffect::None` for the idempotent no-op case. This matches a
+    /// canonical no-op without a note; canonical note-bearing no-ops instead
+    /// attempt a same-status audit append outside atomic v1.
     pub(crate) post_commit: PostCommitEffect,
 }
 
 impl GtdTransitionPlan {
-    /// Build a plan from its already-decided statements and audit effect.
+    /// Build a plan from its already-decided statements, no-op classification,
+    /// and audit effect.
     /// Callers outside this crate (e.g. the atomic-apply layer wiring
     /// `gtd.transition` into a multi-op unit) cannot construct the struct
     /// literal directly since its fields are crate-private.
     pub fn new(
         task_id: Uuid,
         statements: Vec<PlanStatement>,
+        idempotent_noop: bool,
         post_commit: PostCommitEffect,
     ) -> Self {
         Self {
             task_id,
             statements,
+            idempotent_noop,
             post_commit,
         }
     }
@@ -449,10 +459,15 @@ impl GtdTransitionPlan {
         self.task_id
     }
 
-    /// Status-column DML for this transition; empty for the idempotent
-    /// no-op case.
+    /// Guarded task-property DML for this transition, or the guarded
+    /// mutation-free snapshot assertion for an idempotent no-op.
     pub fn statements(&self) -> &[PlanStatement] {
         &self.statements
+    }
+
+    /// Whether prepare classified this transition as already at its target.
+    pub fn is_idempotent_noop(&self) -> bool {
+        self.idempotent_noop
     }
 
     /// The deferred lifecycle audit effect assigned by the prepare pass.
@@ -465,13 +480,14 @@ impl GtdTransitionPlan {
 #[derive(Debug, Clone)]
 pub struct GtdCompletePlan {
     pub(crate) task_id: Uuid,
-    /// Status + `completed_at` DML to apply inside the atomic unit, in
-    /// order. The status-update statement carries the guard (prepare
-    /// validated the task was in a completable state); the `completed_at`
-    /// write targets the same already-guarded row and is unguarded.
+    /// Status + `completed_at` property DML to apply inside the atomic unit.
+    /// The statement guards the exact decision snapshot's note revision,
+    /// deletion marker, and semantic status after prepare validated that the
+    /// task was in a completable state.
     pub(crate) statements: Vec<PlanStatement>,
     /// Deferred lifecycle audit row assigned by the prepare pass (GAP-5):
-    /// mirrors `handle_complete`'s best-effort `write_audit_record` call.
+    /// mirrors `handle_complete`'s best-effort
+    /// `write_audit_record_with_status` call.
     pub(crate) post_commit: PostCommitEffect,
 }
 
@@ -497,7 +513,7 @@ impl GtdCompletePlan {
         self.task_id
     }
 
-    /// Status + `completed_at` DML for this completion.
+    /// Guarded status + `completed_at` property DML for this completion.
     pub fn statements(&self) -> &[PlanStatement] {
         &self.statements
     }
@@ -674,6 +690,7 @@ mod tests {
         let plan = GtdTransitionPlan {
             task_id: Uuid::new_v4(),
             statements: vec![guarded("update-status", AffectedRowGuard::exactly(1))],
+            idempotent_noop: false,
             post_commit: PostCommitEffect::None,
         };
         // A status-only transition never triggers a reindex: the type has no
@@ -685,15 +702,22 @@ mod tests {
     }
 
     #[test]
-    fn gtd_transition_plan_idempotent_noop_carries_no_statements_and_no_audit() {
-        // current == target after normalization is an idempotent no-op:
-        // canonical performs no write and never reaches its audit-record call.
+    fn gtd_transition_plan_idempotent_noop_carries_guarded_assertion_and_no_audit() {
+        // Atomic v1 keeps current == target mutation-free and audit-free, but
+        // must revalidate the prepare snapshot in a multi-op unit. A canonical
+        // no-op carrying a note has a separate note-event contract.
         let plan = GtdTransitionPlan {
             task_id: Uuid::new_v4(),
-            statements: vec![],
+            statements: vec![guarded(
+                "assert-noop-snapshot",
+                AffectedRowGuard::exactly(1),
+            )],
+            idempotent_noop: true,
             post_commit: PostCommitEffect::None,
         };
-        assert!(plan.statements.is_empty());
+        assert_eq!(plan.statements.len(), 1);
+        assert!(plan.statements[0].guard.is_some());
+        assert!(plan.is_idempotent_noop());
         assert_eq!(plan.post_commit, PostCommitEffect::None);
     }
 
@@ -703,6 +727,7 @@ mod tests {
         let plan = GtdTransitionPlan {
             task_id,
             statements: vec![guarded("update-status", AffectedRowGuard::exactly(1))],
+            idempotent_noop: false,
             post_commit: PostCommitEffect::GtdAudit {
                 task_id,
                 from_status: "inbox".to_string(),
@@ -724,19 +749,20 @@ mod tests {
     }
 
     #[test]
-    fn gtd_complete_plan_guard_is_anchored_to_the_status_write() {
+    fn gtd_complete_plan_guards_the_single_snapshot_property_write() {
         let plan = GtdCompletePlan {
             task_id: Uuid::new_v4(),
-            statements: vec![
-                guarded("update-status", AffectedRowGuard::exactly(1)),
-                unguarded("update-completed-at"),
-            ],
+            statements: vec![guarded(
+                "update-status-and-completed-at",
+                AffectedRowGuard::exactly(1),
+            )],
             post_commit: PostCommitEffect::None,
         };
-        assert_eq!(plan.statements.len(), 2);
-        let guard = plan.statements[0].guard.expect("status write is guarded");
+        assert_eq!(plan.statements.len(), 1);
+        let guard = plan.statements[0]
+            .guard
+            .expect("snapshot property write is guarded");
         assert!(guard.holds_for(1));
-        assert_eq!(plan.statements[1].guard, None);
     }
 
     #[test]

--- a/crates/khive-runtime/src/atomic_prepare.rs
+++ b/crates/khive-runtime/src/atomic_prepare.rs
@@ -49,7 +49,8 @@ use khive_db::stores::graph::{
     purge_incident_edges_statement,
 };
 use khive_db::stores::note::{
-    note_hard_delete_statement, note_soft_delete_statement, note_upsert_statement,
+    note_hard_delete_statement, note_replace_if_unchanged_statement, note_soft_delete_statement,
+    note_upsert_statement,
 };
 use khive_db::stores::text::insert_document_statement;
 
@@ -187,7 +188,7 @@ fn optional_f64(args: &Value, key: &str) -> RuntimeResult<Option<f64>> {
 /// (`NotePatch::salience` / `NotePatch::decay_factor`): key absent -> `None`
 /// (untouched), key present as JSON `null` -> `Some(None)` (clear), key
 /// present as a number -> `Some(Some(v))` (set). Range validation lives in
-/// curation.rs's `prepare_update_note`, not here.
+/// curation.rs's `prepare_update_note_from_snapshot`, not here.
 fn optional_f64_patch(args: &Value, key: &str) -> RuntimeResult<Option<Option<f64>>> {
     match obj(args)?.get(key) {
         None => Ok(None),
@@ -646,6 +647,109 @@ pub enum AtomicUpdateKind {
     Edge,
 }
 
+/// Enforce a caller's explicit update-kind discriminator against a resolved
+/// note before any pack hook can inspect or normalize the request. Canonical
+/// KG dispatch performs this mismatch check before its hook; the atomic
+/// adapter calls this same helper to preserve that error ordering.
+pub fn validate_note_update_expected_kind(
+    note: &khive_storage::note::Note,
+    expected_kind: &Option<AtomicUpdateKind>,
+) -> RuntimeResult<()> {
+    let id = note.id;
+    match expected_kind {
+        None => Ok(()),
+        Some(AtomicUpdateKind::Note {
+            specific: Some(expected),
+        }) if &note.kind != expected => Err(RuntimeError::NotFound(format!("note {id}"))),
+        Some(AtomicUpdateKind::Note { .. }) => Ok(()),
+        Some(AtomicUpdateKind::Entity { .. }) => {
+            Err(RuntimeError::NotFound(format!("entity {id}")))
+        }
+        Some(AtomicUpdateKind::Edge) => Err(RuntimeError::NotFound(format!("edge {id}"))),
+    }
+}
+
+async fn prepare_note_update_plan_from_snapshot(
+    runtime: &KhiveRuntime,
+    token: &NamespaceToken,
+    args: &Value,
+    expected_kind: &Option<AtomicUpdateKind>,
+    note: khive_storage::note::Note,
+) -> RuntimeResult<AtomicOpPlan> {
+    let id = require_uuid(args, "id")?;
+    if note.id != id {
+        return Err(RuntimeError::NotFound(format!("note {id}")));
+    }
+    validate_note_update_expected_kind(&note, expected_kind)?;
+
+    reject_inapplicable_update_fields(args, "note")?;
+    let name = optional_string_patch(args, "name")?;
+    let content = optional_str(args, "content").map(str::to_string);
+    let properties = optional_properties(args, "properties")?;
+    let salience = optional_f64_patch(args, "salience")?;
+    let decay_factor = optional_f64_patch(args, "decay_factor")?;
+    let expected_updated_at = note.updated_at;
+    let expected_deleted_at = note.deleted_at;
+
+    let (note, text_changed) = runtime
+        .prepare_update_note_from_snapshot(
+            token,
+            note,
+            crate::curation::NotePatch::new(name, content, salience, decay_factor, properties),
+        )
+        .await?;
+
+    let post_commit = if text_changed {
+        PostCommitEffect::ReindexNote { note_id: id }
+    } else {
+        PostCommitEffect::None
+    };
+    Ok(AtomicOpPlan::Update(UpdatePlan {
+        target_id: id,
+        statements: vec![PlanStatement {
+            statement: note_replace_if_unchanged_statement(
+                &note,
+                expected_updated_at,
+                expected_deleted_at,
+            ),
+            guard: Some(AffectedRowGuard::exactly(1)),
+        }],
+        post_commit,
+        edge_natural_key: None,
+    }))
+}
+
+/// Build an atomic update plan from the exact note snapshot already supplied
+/// to a pack update hook. Persistence is guarded by that snapshot's revision
+/// and deletion marker, so hook normalization cannot race a second read.
+pub async fn prepare_update_from_note_snapshot(
+    runtime: &KhiveRuntime,
+    token: &NamespaceToken,
+    args: &Value,
+    expected_kind: Option<AtomicUpdateKind>,
+    note: khive_storage::note::Note,
+) -> RuntimeResult<AtomicOpPlan> {
+    if obj(args)?.get("entity_kind").is_some_and(|v| !v.is_null()) {
+        return Err(RuntimeError::InvalidInput(
+            "entity_kind is immutable; to change kind, delete then re-create the entity, \
+             or use merge() if this is a deduplication correction"
+                .into(),
+        ));
+    }
+    let current = runtime
+        .notes(token)?
+        .get_note(note.id)
+        .await?
+        .ok_or_else(|| RuntimeError::NotFound(format!("note {}", note.id)))?;
+    if current != note {
+        return Err(RuntimeError::InvalidInput(format!(
+            "note {} changed concurrently after it was read; retry with fresh state",
+            note.id
+        )));
+    }
+    prepare_note_update_plan_from_snapshot(runtime, token, args, &expected_kind, note).await
+}
+
 /// `expected_kind`: `None` when the caller omitted `kind` (no check, parity
 /// with canonical's own optional discriminator); `Some(_)` enforces an
 /// exact-parity mismatch check against the resolved record's actual
@@ -712,62 +816,11 @@ pub async fn prepare_update(
             .await
         }
         Some(Resolved::Note(note)) => {
-            match &expected_kind {
-                None => {}
-                Some(AtomicUpdateKind::Note {
-                    specific: Some(expected),
-                }) if &note.kind != expected => {
-                    return Err(RuntimeError::NotFound(format!("note {id}")));
-                }
-                Some(AtomicUpdateKind::Note { .. }) => {}
-                Some(AtomicUpdateKind::Entity { .. }) => {
-                    return Err(RuntimeError::NotFound(format!("entity {id}")));
-                }
-                Some(AtomicUpdateKind::Edge) => {
-                    return Err(RuntimeError::NotFound(format!("edge {id}")));
-                }
-            }
-            // Decide step lives in curation.rs's `prepare_update_note` — the
-            // same function canonical `update_note` calls, including the
-            // salience/decay_factor range validation. `optional_f64_patch`
-            // below preserves tri-state patch semantics (key absent =
-            // untouched, key null = clear, key present = set) when
-            // constructing the `NotePatch`.
-            reject_inapplicable_update_fields(args, "note")?;
-            let name = optional_string_patch(args, "name")?;
-            let content = optional_str(args, "content").map(|s| s.to_string());
-            let properties = optional_properties(args, "properties")?;
-            let salience = optional_f64_patch(args, "salience")?;
-            let decay_factor = optional_f64_patch(args, "decay_factor")?;
-
-            let (note, text_changed) = runtime
-                .prepare_update_note(
-                    token,
-                    id,
-                    crate::curation::NotePatch::new(
-                        name,
-                        content,
-                        salience,
-                        decay_factor,
-                        properties,
-                    ),
-                )
-                .await?;
-
-            let post_commit = if text_changed {
-                PostCommitEffect::ReindexNote { note_id: id }
-            } else {
-                PostCommitEffect::None
-            };
-            Ok(AtomicOpPlan::Update(UpdatePlan {
-                target_id: id,
-                statements: vec![PlanStatement {
-                    statement: note_upsert_statement(&note),
-                    guard: Some(AffectedRowGuard::exactly(1)),
-                }],
-                post_commit,
-                edge_natural_key: None,
-            }))
+            // Patch application lives in curation.rs's
+            // `prepare_update_note_from_snapshot` — the same implementation
+            // canonical guarded update calls, including salience/decay range
+            // validation. The plan retains this exact snapshot's revision.
+            prepare_note_update_plan_from_snapshot(runtime, token, args, &expected_kind, note).await
         }
         Some(_) => Err(RuntimeError::InvalidInput(format!(
             "update target {id} must be an entity, note, or edge"
@@ -1569,7 +1622,8 @@ pub async fn apply_post_commit_effects_with_report(
             PostCommitEffect::GtdAudit { .. } => {
                 // Applied by the `kkernel` caller's own post-commit pass,
                 // not here: `khive-pack-gtd` (owner of
-                // `ensure_audit_schema`/`write_audit_record`) depends on
+                // `ensure_audit_schema`/`write_audit_record_with_status`)
+                // depends on
                 // `khive-runtime`, not the other way around, so this crate
                 // cannot act on the effect itself. See
                 // `PostCommitEffect::GtdAudit`'s doc comment.

--- a/crates/khive-runtime/src/atomic_prepare.rs
+++ b/crates/khive-runtime/src/atomic_prepare.rs
@@ -742,10 +742,7 @@ pub async fn prepare_update_from_note_snapshot(
         .await?
         .ok_or_else(|| RuntimeError::NotFound(format!("note {}", note.id)))?;
     if current != note {
-        return Err(RuntimeError::InvalidInput(format!(
-            "note {} changed concurrently after it was read; retry with fresh state",
-            note.id
-        )));
+        return Err(crate::curation::stale_note_snapshot_error(note.id));
     }
     prepare_note_update_plan_from_snapshot(runtime, token, args, &expected_kind, note).await
 }

--- a/crates/khive-runtime/src/atomic_prepare.rs
+++ b/crates/khive-runtime/src/atomic_prepare.rs
@@ -752,6 +752,8 @@ pub async fn prepare_update_from_note_snapshot(
 /// exact-parity mismatch check against the resolved record's actual
 /// substrate/specific kind, mirroring `handle_update`'s
 /// `entity.kind != *k` / note kind checks (update.rs:200-201, :229-234).
+/// Task notes must pass the GTD pack hook before this or
+/// `prepare_op("update", ..)`; neither runs it.
 pub async fn prepare_update(
     runtime: &KhiveRuntime,
     token: &NamespaceToken,

--- a/crates/khive-runtime/src/curation.rs
+++ b/crates/khive-runtime/src/curation.rs
@@ -25,6 +25,12 @@ use crate::error::{RuntimeError, RuntimeResult};
 use crate::operations::{base_entity_rule_allows, canonical_edge_endpoints, endpoint_matches};
 use crate::runtime::{KhiveRuntime, NamespaceToken};
 
+pub(crate) fn stale_note_snapshot_error(id: Uuid) -> RuntimeError {
+    RuntimeError::Khive(KhiveError::conflict(format!(
+        "note {id} changed concurrently after it was read; retry with fresh state"
+    )))
+}
+
 /// Immutable embedding-registry view for one logical write.
 ///
 /// Document byte budgets are derived from the model name at the embedding seam,
@@ -1409,9 +1415,7 @@ impl KhiveRuntime {
             .await?
             .ok_or_else(|| RuntimeError::NotFound(format!("note {id}")))?;
         if current != snapshot {
-            return Err(RuntimeError::InvalidInput(format!(
-                "note {id} changed concurrently after it was read; retry with fresh state"
-            )));
+            return Err(stale_note_snapshot_error(id));
         }
         let (note, text_changed) = self
             .prepare_update_note_from_snapshot(token, snapshot, patch)
@@ -1421,9 +1425,7 @@ impl KhiveRuntime {
             .replace_note_if_unchanged(note.clone(), expected_updated_at, expected_deleted_at)
             .await?;
         if !persisted {
-            return Err(RuntimeError::InvalidInput(format!(
-                "note {id} changed concurrently after it was read; retry with fresh state"
-            )));
+            return Err(stale_note_snapshot_error(id));
         }
 
         let embedding_report = if text_changed {

--- a/crates/khive-runtime/src/curation.rs
+++ b/crates/khive-runtime/src/curation.rs
@@ -1229,13 +1229,14 @@ impl KhiveRuntime {
         Ok(report)
     }
 
-    /// Computes the patched `Note` and `text_changed` without writing, mirroring
-    /// `prepare_update_entity` so both the normal write path and the
-    /// atomic-prepare path share one source of truth.
-    pub(crate) async fn prepare_update_note(
+    /// Apply a note patch to exactly the supplied read snapshot without
+    /// fetching the row again. The caller must persist it through
+    /// [`Self::update_note_from_snapshot_with_embedding_report`] or a write
+    /// plan guarded by the snapshot's `updated_at`/`deleted_at` values.
+    pub(crate) async fn prepare_update_note_from_snapshot(
         &self,
-        token: &NamespaceToken,
-        id: Uuid,
+        _token: &NamespaceToken,
+        mut note: khive_storage::note::Note,
         patch: NotePatch,
     ) -> RuntimeResult<(khive_storage::note::Note, bool)> {
         if let Some(ref content) = patch.content {
@@ -1247,11 +1248,6 @@ impl KhiveRuntime {
         if let Some(ref props) = patch.properties {
             crate::secret_gate::check_json(props)?;
         }
-        let store = self.notes(token)?;
-        let mut note = store
-            .get_note(id)
-            .await?
-            .ok_or_else(|| RuntimeError::NotFound(format!("note {id}")))?;
 
         reject_pack_managed_schedule_mutation(&note, "update")?;
 
@@ -1340,7 +1336,20 @@ impl KhiveRuntime {
             note.status = status;
         }
 
-        note.updated_at = chrono::Utc::now().timestamp_micros();
+        // `updated_at` is also the optimistic-concurrency revision for
+        // full-note replacement. Make it strictly advance even when two
+        // operations land inside one clock microsecond. Saturation is not a
+        // valid fallback: reusing i64::MAX would make the CAS accept a write
+        // without advancing its revision.
+        let minimum_updated_at = note.updated_at.checked_add(1).ok_or_else(|| {
+            RuntimeError::Internal(format!(
+                "note {} updated_at is already at i64::MAX and cannot advance",
+                note.id
+            ))
+        })?;
+        note.updated_at = chrono::Utc::now()
+            .timestamp_micros()
+            .max(minimum_updated_at);
         Ok((note, text_changed))
     }
 
@@ -1366,10 +1375,56 @@ impl KhiveRuntime {
         khive_storage::note::Note,
         crate::retrieval::EmbeddingTruncationReport,
     )> {
-        let (note, text_changed) = self.prepare_update_note(token, id, patch).await?;
+        let snapshot = self
+            .notes(token)?
+            .get_note(id)
+            .await?
+            .ok_or_else(|| RuntimeError::NotFound(format!("note {id}")))?;
+        self.update_note_from_snapshot_with_embedding_report(token, snapshot, patch)
+            .await
+    }
 
+    /// Patch and persist one note from a caller-owned read snapshot.
+    ///
+    /// This is the canonical seam for kind hooks that normalize coupled
+    /// fields from the current note. The same snapshot feeds normalization,
+    /// patch application, and the compare-and-swap write; a concurrent note
+    /// change therefore refuses the write instead of persisting derivations
+    /// computed from stale state.
+    pub async fn update_note_from_snapshot_with_embedding_report(
+        &self,
+        token: &NamespaceToken,
+        snapshot: khive_storage::note::Note,
+        patch: NotePatch,
+    ) -> RuntimeResult<(
+        khive_storage::note::Note,
+        crate::retrieval::EmbeddingTruncationReport,
+    )> {
+        let expected_updated_at = snapshot.updated_at;
+        let expected_deleted_at = snapshot.deleted_at;
+        let id = snapshot.id;
         let store = self.notes(token)?;
-        store.upsert_note(note.clone()).await?;
+        let current = store
+            .get_note(id)
+            .await?
+            .ok_or_else(|| RuntimeError::NotFound(format!("note {id}")))?;
+        if current != snapshot {
+            return Err(RuntimeError::InvalidInput(format!(
+                "note {id} changed concurrently after it was read; retry with fresh state"
+            )));
+        }
+        let (note, text_changed) = self
+            .prepare_update_note_from_snapshot(token, snapshot, patch)
+            .await?;
+
+        let persisted = store
+            .replace_note_if_unchanged(note.clone(), expected_updated_at, expected_deleted_at)
+            .await?;
+        if !persisted {
+            return Err(RuntimeError::InvalidInput(format!(
+                "note {id} changed concurrently after it was read; retry with fresh state"
+            )));
+        }
 
         let embedding_report = if text_changed {
             let report = self.reindex_note(token, &note).await?;
@@ -3141,6 +3196,43 @@ mod tests {
         );
         let owned: String = note_embedding_text(&note);
         assert_eq!(owned.as_str(), note.content.as_str());
+    }
+
+    #[tokio::test]
+    async fn generic_note_update_errors_when_revision_is_already_i64_max() {
+        let rt = rt();
+        let tok = NamespaceToken::local();
+        let mut note = Note::new("local", "observation", "saturated revision");
+        note.updated_at = i64::MAX;
+        let note_id = note.id;
+        rt.notes(&tok)
+            .expect("note store")
+            .upsert_note(note.clone())
+            .await
+            .expect("seed saturated note");
+
+        let error = rt
+            .update_note(
+                &tok,
+                note_id,
+                NotePatch::new(None, Some("must not land".to_string()), None, None, None),
+            )
+            .await
+            .expect_err("i64::MAX cannot yield a strictly newer CAS revision");
+        assert!(
+            matches!(&error, RuntimeError::Internal(_)),
+            "revision exhaustion is an internal persisted-state error: {error}"
+        );
+        assert!(error.to_string().contains("i64::MAX"), "error: {error}");
+
+        let persisted = rt
+            .notes(&tok)
+            .expect("note store")
+            .get_note(note_id)
+            .await
+            .expect("read note")
+            .expect("note remains live");
+        assert_eq!(persisted, note, "failed revision advance must not mutate");
     }
 
     async fn restore_edge_preimage(

--- a/crates/khive-runtime/src/pack.rs
+++ b/crates/khive-runtime/src/pack.rs
@@ -337,6 +337,24 @@ pub trait KindHook: Send + Sync + std::fmt::Debug {
         args: &Value,
     ) -> Result<(), RuntimeError>;
 
+    /// Normalize a shared note update before storage is mutated.
+    ///
+    /// The default preserves the original property-validation contract. A
+    /// kind-owning pack overrides this when caller-facing note fields mirror
+    /// owned properties and must be changed together (for example, a task's
+    /// searchable `content` and `properties.description`).
+    async fn prepare_note_update(
+        &self,
+        runtime: &KhiveRuntime,
+        token: &NamespaceToken,
+        note: &khive_storage::Note,
+        args: &mut Value,
+    ) -> Result<(), RuntimeError> {
+        let properties = args.get("properties").filter(|value| !value.is_null());
+        self.validate_note_update(runtime, token, note, properties)
+            .await
+    }
+
     /// Validate a shared note-property update before storage is mutated.
     ///
     /// The default accepts the update. Kind-owning packs override this when a
@@ -2029,10 +2047,30 @@ impl VerbRegistry {
         None
     }
 
-    /// Run the owning kind's shared-note-update validator, if it declares one.
+    /// Run the owning kind's shared-note-update normalizer/validator, if it declares one.
     ///
     /// Both canonical KG dispatch and user-facing atomic preparation call this
     /// seam so pack-specific property invariants cannot drift between them.
+    pub async fn prepare_note_update_hook(
+        &self,
+        runtime: &KhiveRuntime,
+        token: &NamespaceToken,
+        note: &khive_storage::Note,
+        args: &mut Value,
+    ) -> Result<(), RuntimeError> {
+        if let Some(hook) = self.find_kind_hook(&note.kind) {
+            hook.prepare_note_update(runtime, token, note, args).await?;
+        }
+        Ok(())
+    }
+
+    /// Run the owning kind's shared-note-update property validator, if it
+    /// declares one.
+    ///
+    /// Kept as the validation-only compatibility seam for callers that do not
+    /// own a mutable request object. Canonical and atomic CRUD use
+    /// [`Self::prepare_note_update_hook`] so a hook can also normalize coupled
+    /// fields before its validation runs.
     pub async fn validate_note_update_hook(
         &self,
         runtime: &KhiveRuntime,

--- a/crates/khive-storage/src/note.rs
+++ b/crates/khive-storage/src/note.rs
@@ -10,7 +10,7 @@ use crate::types::{
 };
 
 /// A storage-level note record. Flat, SQL-friendly representation.
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct Note {
     pub id: Uuid,
     pub namespace: String,
@@ -234,6 +234,12 @@ pub enum FilterOp {
     /// Matches rows where the JSON field equals the value OR the field is absent/NULL.
     /// Used for properties that may be missing in legacy rows (e.g. `$.read`).
     EqOrMissing,
+    /// Matches rows where a JSON text field equals the value, while treating
+    /// every missing or non-text value as that same value. The SQL adapter
+    /// emits `CASE WHEN json_type(...) = 'text' THEN json_extract(...) ELSE
+    /// value END = value`, mirroring callers whose read model assigns one
+    /// textual default to absent, JSON-null, and malformed legacy values.
+    TextEqOrNonText,
     Ne,
     Lt,
     Lte,
@@ -300,6 +306,31 @@ pub struct NoteFilter {
 pub trait NoteStore: Send + Sync + 'static {
     /// Insert or update a single note.
     async fn upsert_note(&self, note: Note) -> StorageResult<()>;
+    /// Replace a note only when the persisted row still matches the caller's
+    /// read snapshot.
+    ///
+    /// `expected_updated_at` is the snapshot revision and
+    /// `expected_deleted_at` closes the soft-delete race (legacy soft-delete
+    /// paths may change `deleted_at` without changing `updated_at`). The
+    /// replacement note's `updated_at` must be strictly greater than that
+    /// persisted revision. Returns `false` when the row disappeared, changed,
+    /// or was supplied a non-advancing replacement revision. This is the
+    /// full-note compare-and-swap seam used when a pack hook derives coupled
+    /// fields from that snapshot before persistence. The default returns
+    /// `Unsupported` rather than falling back to an unguarded upsert and
+    /// reintroducing the stale-snapshot race.
+    async fn replace_note_if_unchanged(
+        &self,
+        _note: Note,
+        _expected_updated_at: i64,
+        _expected_deleted_at: Option<i64>,
+    ) -> StorageResult<bool> {
+        Err(crate::StorageError::Unsupported {
+            capability: crate::StorageCapability::Notes,
+            operation: "replace_note_if_unchanged".into(),
+            message: "this backend does not implement guarded note replacement".into(),
+        })
+    }
     /// Insert or update a batch of notes.
     async fn upsert_notes(&self, notes: Vec<Note>) -> StorageResult<BatchWriteSummary>;
     /// Fetch a note by UUID, returning `None` if absent.

--- a/crates/kkernel/docs/design.md
+++ b/crates/kkernel/docs/design.md
@@ -122,12 +122,21 @@ It runs, in order:
    the canonical non-atomic handler.
 
 Before prepare, the atomic runtime installs the same aggregate pack edge rules as canonical
-server startup. After each task-note `update` or dependency `link` plan is built, the boundary
-also invokes `VerbRegistry`'s shared `KindHook` validator for typed parity with canonical KG
-dispatch. Since every plan is still prepared before any write, core migration V15 supplies the
+server startup. Before each task-note `update` plan is built, the boundary invokes
+`VerbRegistry`'s shared `KindHook` normalizer/validator; dependency `link` plans run their
+shared validator as well. This preserves typed and content/description-mirror parity with
+canonical KG dispatch. An explicit update-kind mismatch is rejected before the hook runs.
+The hook and plan share one note snapshot, and the plan's update statement rechecks that
+snapshot revision/deletion marker in the transaction. Since every plan is still prepared before any write, core migration V15 supplies the
 transaction-time task dependency cycle triggers: a later statement sees earlier writes in the
 unit, and a trigger error rolls the entire unit back. The same triggers serialize opposite
 concurrent writers, while leaving unrelated notes and edge relations untouched.
+
+Atomic v1 does not maintain a projected note image across two generic updates of the same
+target in one file. Both prepare from the original snapshot; after the first advances its
+revision, the second observes zero affected rows, fails closed, and rolls the entire unit
+back. This is deliberate until projected-state preparation can preserve all ordered patch
+semantics without weakening concurrent-write guards.
 
 **Verbs without a prepare implementation.** `propose`/`review`/`withdraw` are listed in
 `khive_types::pack::ATOMIC_ADMISSIBLE_VERBS` (ADR-099 D3 intends them to eventually gain a
@@ -147,14 +156,23 @@ The returned envelope is additive-only and lives entirely outside `dispatch_requ
 response shape — non-atomic `--ops-file` runs (and every other exec path) are untouched.
 
 **`apply_gtd_audit_post_commit_effects`** applies every `PostCommitEffect::GtdAudit` by
-calling the SAME `ensure_audit_schema`/`write_audit_record` functions the canonical
-`handle_transition`/`handle_complete` handlers call (GAP-5). It lives in `kkernel` rather
+calling the SAME `ensure_audit_schema`/`write_audit_record_with_status` functions the
+canonical `handle_transition`/`handle_complete` handlers call (GAP-5). It lives in `kkernel` rather
 than `khive-runtime::atomic_prepare` because those two functions are owned by
 `khive-pack-gtd`, which depends on `khive-runtime` — not the other way around; `kkernel` is
 the first crate in the dependency graph that can see both. Non-`GtdAudit` effects are
 ignored here (they are `atomic_prepare::apply_post_commit_effects`'s job, called
-separately). Best-effort by construction: both callee functions log-and-swallow their own
-errors, so this function itself cannot fail.
+separately). Best-effort by construction: the callee logs append failures and returns a
+boolean outcome. The atomic result builder exposes that outcome as `audit_persisted`, so the
+already-committed unit cannot be failed while audit degradation remains visible.
+
+An idempotent same-status `gtd.transition` is different: atomic v1 emits a guarded
+no-effect assertion and no post-commit audit effect, even when the caller supplied
+`note`. The assertion revalidates the exact prepare revision/deletion/status snapshot
+inside the commit transaction, so an earlier same-unit transition, update, or delete
+cannot make the no-op stale. It returns the base no-op shape and persists no note event.
+Canonical dispatch owns the guarded note-bearing no-op behavior; callers needing it must
+use that path until atomic projected-state support exists.
 
 **`validate_atomic_args`** closes an ADR-099 B3 parity gap: the canonical (non-atomic)
 handlers deserialize their args through a `#[serde(deny_unknown_fields)]` param struct, so a

--- a/crates/kkernel/src/atomic_apply.rs
+++ b/crates/kkernel/src/atomic_apply.rs
@@ -6,11 +6,13 @@
 //! rejected pre-runtime rather than partially supported, and the gtd-adapter
 //! ownership split with `khive-pack-gtd`.
 
+use std::collections::HashMap;
+
 use anyhow::{Context, Result};
 use serde_json::{json, Value};
 use uuid::Uuid;
 
-use khive_pack_gtd::handlers::{ensure_audit_schema, write_audit_record};
+use khive_pack_gtd::handlers::{ensure_audit_schema, write_audit_record_with_status};
 use khive_pack_gtd::schema::{is_terminal, normalize_status};
 use khive_runtime::atomic_plan::{
     AffectedRowGuard, GtdCompletePlan, GtdTransitionPlan, PlanStatement, PostCommitEffect,
@@ -189,12 +191,13 @@ pub(crate) async fn execute_atomic_ops_file(
             // not the other way around — that function treats `GtdAudit` as
             // a no-op, see its match arm). `kkernel` already depends on both
             // crates, so it calls the SAME canonical `ensure_audit_schema`/
-            // `write_audit_record` functions the non-atomic `gtd.transition`/
+            // `write_audit_record_with_status` functions the non-atomic `gtd.transition`/
             // `gtd.complete` handlers call, rather than re-deriving the
-            // DDL/INSERT. Best-effort: errors are logged inside those
-            // functions and never propagated — a missing audit row must
-            // never fail an already-committed atomic unit.
-            apply_gtd_audit_post_commit_effects(&runtime, post_commit.as_slice()).await;
+            // DDL/INSERT. Best-effort: append errors are logged and returned
+            // as per-task booleans for result rendering — a missing audit row
+            // never fails an already-committed atomic unit, but is visible.
+            let gtd_audit_outcomes =
+                apply_gtd_audit_post_commit_effects(&runtime, post_commit.as_slice()).await;
             let embedding_outcomes =
                 khive_runtime::atomic_prepare::apply_post_commit_effects_with_report(
                     &runtime,
@@ -217,6 +220,7 @@ pub(crate) async fn execute_atomic_ops_file(
                     &op.args,
                     &resolved_args_list[idx],
                     &plans[idx],
+                    &gtd_audit_outcomes,
                 )
                 .await
                 .with_context(|| {
@@ -281,10 +285,15 @@ pub(crate) async fn execute_atomic_ops_file(
 }
 
 /// Applies every [`PostCommitEffect::GtdAudit`] via the canonical gtd audit
-/// functions (GAP-5, ADR-099 B3); best-effort, cannot fail. See
+/// functions (GAP-5, ADR-099 B3); best-effort, cannot fail. Returns each
+/// affected task's append outcome so response rendering can expose degradation. See
 /// `crates/kkernel/docs/design.md#atomic-exec---ops-file---atomic-execution-path-adr-099-slice-b3`
 /// for why this lives in `kkernel` rather than `khive-runtime`.
-async fn apply_gtd_audit_post_commit_effects(runtime: &KhiveRuntime, effects: &[PostCommitEffect]) {
+async fn apply_gtd_audit_post_commit_effects(
+    runtime: &KhiveRuntime,
+    effects: &[PostCommitEffect],
+) -> HashMap<Uuid, bool> {
+    let mut outcomes = HashMap::new();
     for effect in effects {
         if let PostCommitEffect::GtdAudit {
             task_id,
@@ -295,7 +304,7 @@ async fn apply_gtd_audit_post_commit_effects(runtime: &KhiveRuntime, effects: &[
         } = effect
         {
             ensure_audit_schema(runtime).await;
-            write_audit_record(
+            let persisted = write_audit_record_with_status(
                 runtime,
                 *task_id,
                 from_status,
@@ -304,8 +313,10 @@ async fn apply_gtd_audit_post_commit_effects(runtime: &KhiveRuntime, effects: &[
                 namespace,
             )
             .await;
+            outcomes.insert(*task_id, persisted);
         }
     }
+    outcomes
 }
 
 fn describe_failure(failure: &AtomicOpFailure) -> String {
@@ -380,32 +391,59 @@ async fn prepare_one(
             Ok((plan, args.clone()))
         }
         "update" => {
-            let resolved = resolve_kg_ids_in_args(runtime, token, tool, args).await?;
+            let mut resolved = resolve_kg_ids_in_args(runtime, token, tool, args).await?;
             let expected_kind = update_expected_kind(&resolved, registry)?;
-            let plan = khive_runtime::atomic_prepare::prepare_update(
-                runtime,
-                token,
-                &resolved,
-                expected_kind,
-            )
-            .await
-            .map_err(|e| anyhow::anyhow!("{e}"))?;
+            if resolved
+                .get("entity_kind")
+                .is_some_and(|value| !value.is_null())
+            {
+                anyhow::bail!(
+                    "entity_kind is immutable; to change kind, delete then re-create the entity, \
+                     or use merge() if this is a deduplication correction"
+                );
+            }
             let id = resolved
                 .get("id")
                 .and_then(Value::as_str)
                 .and_then(|raw| Uuid::parse_str(raw).ok())
                 .ok_or_else(|| anyhow::anyhow!("resolved update id must be a full UUID"))?;
-            if let Some(Resolved::Note(note)) = runtime
+            let resolved_target = runtime
                 .resolve_by_id(token, id)
                 .await
-                .map_err(|e| anyhow::anyhow!("{e}"))?
-            {
-                let properties = resolved.get("properties").filter(|value| !value.is_null());
+                .map_err(|e| anyhow::anyhow!("{e}"))?;
+            let plan = if let Some(Resolved::Note(note)) = resolved_target {
+                // Canonical KG dispatch checks an explicit kind mismatch
+                // before invoking a pack hook. Preserve that error ordering:
+                // a request aimed at the wrong kind must not be normalized as
+                // though it targeted this task.
+                khive_runtime::atomic_prepare::validate_note_update_expected_kind(
+                    &note,
+                    &expected_kind,
+                )
+                .map_err(|e| anyhow::anyhow!("{e}"))?;
                 registry
-                    .validate_note_update_hook(runtime, token, &note, properties)
+                    .prepare_note_update_hook(runtime, token, &note, &mut resolved)
                     .await
                     .map_err(|e| anyhow::anyhow!("{e}"))?;
-            }
+                khive_runtime::atomic_prepare::prepare_update_from_note_snapshot(
+                    runtime,
+                    token,
+                    &resolved,
+                    expected_kind,
+                    note,
+                )
+                .await
+                .map_err(|e| anyhow::anyhow!("{e}"))?
+            } else {
+                khive_runtime::atomic_prepare::prepare_update(
+                    runtime,
+                    token,
+                    &resolved,
+                    expected_kind,
+                )
+                .await
+                .map_err(|e| anyhow::anyhow!("{e}"))?
+            };
             Ok((plan, resolved))
         }
         "link" => {
@@ -632,6 +670,7 @@ async fn build_op_result(
     original_args: &Value,
     resolved_args: &Value,
     plan: &AtomicOpPlan,
+    gtd_audit_outcomes: &HashMap<Uuid, bool>,
 ) -> anyhow::Result<Value> {
     match (tool, plan) {
         // Canonical shape: `normalize_entity_timestamps(to_json(&updated))`
@@ -779,9 +818,9 @@ async fn build_op_result(
             Ok(raw)
         }
         // Canonical shapes: handlers.rs:1030-1037 (idempotent no-op) /
-        // :1107-1118 (transitioned). `p.statements.is_empty()` is exactly
-        // the idempotent-no-op signal `prepare_gtd_transition` encodes
-        // (current == target after `normalize_status`, GAP-6).
+        // :1107-1118 (transitioned). The plan carries an explicit no-op bit:
+        // same-status plans now contain a guarded snapshot assertion rather
+        // than an empty statement list.
         ("gtd.transition", AtomicOpPlan::GtdTransition(p)) => {
             let note = runtime
                 .notes(token)?
@@ -791,7 +830,7 @@ async fn build_op_result(
                     anyhow::anyhow!("atomic gtd.transition result: task not found post-commit")
                 })?;
             let task = khive_pack_gtd::handlers::render_task(&note);
-            if p.statements().is_empty() {
+            if p.is_idempotent_noop() {
                 let raw_status = original_args
                     .as_object()
                     .and_then(|o| o.get("status"))
@@ -813,6 +852,13 @@ async fn build_op_result(
                     gtd_audit_from_to(p.post_commit()).ok_or_else(|| {
                         anyhow::anyhow!("atomic gtd.transition result: missing audit effect")
                     })?;
+                let audit_persisted =
+                    gtd_audit_outcomes
+                        .get(&p.task_id())
+                        .copied()
+                        .ok_or_else(|| {
+                            anyhow::anyhow!("atomic gtd.transition result: missing audit outcome")
+                        })?;
                 Ok(json!({
                     "transitioned": true,
                     "id": task["id"],
@@ -824,6 +870,7 @@ async fn build_op_result(
                     "priority": task["priority"],
                     "assignee": task["assignee"],
                     "due": task["due"],
+                    "audit_persisted": audit_persisted,
                 }))
             }
         }
@@ -840,6 +887,13 @@ async fn build_op_result(
             let (from_status, to_status) = gtd_audit_from_to(p.post_commit()).ok_or_else(|| {
                 anyhow::anyhow!("atomic gtd.complete result: missing audit effect")
             })?;
+            let audit_persisted =
+                gtd_audit_outcomes
+                    .get(&p.task_id())
+                    .copied()
+                    .ok_or_else(|| {
+                        anyhow::anyhow!("atomic gtd.complete result: missing audit outcome")
+                    })?;
             let completed_at = note
                 .properties
                 .as_ref()
@@ -857,6 +911,7 @@ async fn build_op_result(
                 "to": to_status,
                 "completed_at": completed_at,
                 "is_terminal": is_terminal(&to_status),
+                "audit_persisted": audit_persisted,
             }))
         }
         (other, _) => anyhow::bail!(
@@ -883,8 +938,8 @@ fn require_str<'a>(args: &'a Value, key: &str) -> anyhow::Result<&'a str> {
 /// `khive_pack_gtd::handlers::prepare_transition` — the ONE place the
 /// normalize/validate/secret-gate/load/idempotent-check/lifecycle-guard
 /// decision logic lives. This function's only job is turning that decision
-/// into an `AtomicOpPlan`: the idempotent no-op case produces an empty
-/// statement list, and the write case turns the decided patch into a
+/// into an `AtomicOpPlan`: the idempotent no-op case produces a guarded
+/// mutation-free assertion, and the write case turns the decided patch into a
 /// `PlanStatement` via `khive_pack_gtd::handlers::gtd_transition_statement`
 /// — the same DML builder canonical's `atomic_gtd_transition` calls.
 async fn prepare_gtd_transition(
@@ -905,10 +960,16 @@ async fn prepare_gtd_transition(
             .map_err(|e| anyhow::anyhow!("{e}"))?;
 
     match decision {
-        khive_pack_gtd::handlers::TransitionDecision::NoOp { note, .. } => {
+        khive_pack_gtd::handlers::TransitionDecision::NoOp { note, current, .. } => {
+            let statement = khive_pack_gtd::handlers::gtd_noop_assertion_statement(&note, &current)
+                .map_err(|e| anyhow::anyhow!("{e}"))?;
             Ok(AtomicOpPlan::GtdTransition(GtdTransitionPlan::new(
                 note.id,
-                vec![],
+                vec![PlanStatement {
+                    statement,
+                    guard: Some(AffectedRowGuard::exactly(1)),
+                }],
+                true,
                 PostCommitEffect::None,
             )))
         }
@@ -921,7 +982,7 @@ async fn prepare_gtd_transition(
             transition_note,
         } => {
             let statement = khive_pack_gtd::handlers::gtd_transition_statement(
-                note.id, &current, &target, &props, updated_at,
+                &note, &current, &target, &props, updated_at,
             )
             .map_err(|e| anyhow::anyhow!("{e}"))?;
 
@@ -931,6 +992,7 @@ async fn prepare_gtd_transition(
                     statement,
                     guard: Some(AffectedRowGuard::exactly(1)),
                 }],
+                false,
                 PostCommitEffect::GtdAudit {
                     task_id: note.id,
                     from_status: current,
@@ -968,7 +1030,7 @@ async fn prepare_gtd_complete(
             .map_err(|e| anyhow::anyhow!("{e}"))?;
 
     let statement = khive_pack_gtd::handlers::gtd_transition_statement(
-        decision.note.id,
+        &decision.note,
         &decision.current,
         decision.target,
         &decision.props,
@@ -1184,6 +1246,577 @@ mod tests {
             .expect("task must carry properties")
     }
 
+    fn full_registry(runtime: &KhiveRuntime) -> VerbRegistry {
+        let mut builder = VerbRegistryBuilder::new();
+        let pack_names: Vec<String> = PackRegistry::discovered_names()
+            .into_iter()
+            .map(str::to_string)
+            .collect();
+        PackRegistry::register_packs(&pack_names, runtime.clone(), &mut builder)
+            .expect("register packs");
+        builder.build().expect("registry")
+    }
+
+    async fn assert_task_update_then_lifecycle_rolls_back(lifecycle_tool: &str) {
+        let runtime = scratch_runtime();
+        let token = runtime
+            .authorize(Namespace::parse("local").expect("ns"))
+            .expect("authorize");
+        let task_id = seed_task(&runtime, &token, "inbox").await;
+        let registry = full_registry(&runtime);
+        let before = runtime
+            .notes(&token)
+            .expect("note store")
+            .get_note(task_id)
+            .await
+            .expect("read task")
+            .expect("task exists");
+
+        let (update, _) = prepare_one(
+            &runtime,
+            &token,
+            &registry,
+            "update",
+            &json!({"id": task_id.to_string(), "content": "new mirrored body"}),
+        )
+        .await
+        .expect("prepare generic task update");
+        let lifecycle_args = match lifecycle_tool {
+            "gtd.transition" => json!({"id": task_id.to_string(), "status": "next"}),
+            "gtd.complete" => json!({"id": task_id.to_string(), "result": "shipped"}),
+            other => panic!("unexpected lifecycle tool {other}"),
+        };
+        let (lifecycle, _) =
+            prepare_one(&runtime, &token, &registry, lifecycle_tool, &lifecycle_args)
+                .await
+                .unwrap_or_else(|error| panic!("prepare {lifecycle_tool}: {error}"));
+
+        // Both plans were decided from the same pre-unit task snapshot. The
+        // generic update runs first and advances its revision; the lifecycle
+        // plan must then fail its exact-snapshot guard. The atomic runner must
+        // roll the first write back instead of committing stale lifecycle
+        // properties over its newly mirrored description.
+        let outcome = khive_runtime::atomic_runner::run_atomic_unit(
+            runtime.sql().as_ref(),
+            vec![update, lifecycle],
+        )
+        .await
+        .expect("atomic runner");
+        assert!(
+            matches!(
+                &outcome,
+                AtomicRunOutcome::RolledBack {
+                    failed_op_index: 1,
+                    failure: AtomicOpFailure::GuardFailed { observed: 0, .. },
+                }
+            ),
+            "update -> {lifecycle_tool} must fail closed and roll back; got: {outcome:?}"
+        );
+
+        let persisted = runtime
+            .notes(&token)
+            .expect("note store")
+            .get_note(task_id)
+            .await
+            .expect("read task")
+            .expect("task exists");
+        assert_eq!(persisted.updated_at, before.updated_at);
+        assert_eq!(persisted.content, "atomic-gtd-test-task");
+        assert_eq!(
+            task_properties(&persisted)
+                .get("status")
+                .and_then(Value::as_str),
+            Some("inbox")
+        );
+        assert!(task_properties(&persisted).get("description").is_none());
+    }
+
+    #[tokio::test]
+    async fn atomic_generic_task_update_synchronizes_content_and_description() {
+        let runtime = scratch_runtime();
+        let token = runtime
+            .authorize(Namespace::parse("local").expect("ns"))
+            .expect("authorize");
+        let task_id = seed_task(&runtime, &token, "inbox").await;
+        let registry = full_registry(&runtime);
+
+        let (plan, _) = prepare_one(
+            &runtime,
+            &token,
+            &registry,
+            "update",
+            &json!({"id": task_id.to_string(), "content": "atomic body"}),
+        )
+        .await
+        .expect("prepare atomic task content update");
+        let outcome =
+            khive_runtime::atomic_runner::run_atomic_unit(runtime.sql().as_ref(), vec![plan])
+                .await
+                .expect("commit content update");
+        assert!(matches!(outcome, AtomicRunOutcome::Committed { .. }));
+
+        let after_content = runtime
+            .notes(&token)
+            .expect("notes store")
+            .get_note(task_id)
+            .await
+            .expect("get task")
+            .expect("task exists");
+        assert_eq!(after_content.content, "atomic body");
+        assert_eq!(
+            task_properties(&after_content)
+                .get("description")
+                .and_then(Value::as_str),
+            Some("atomic body")
+        );
+
+        let (plan, _) = prepare_one(
+            &runtime,
+            &token,
+            &registry,
+            "update",
+            &json!({
+                "id": task_id.to_string(),
+                "properties": {"description": "atomic property body"},
+            }),
+        )
+        .await
+        .expect("prepare atomic task description update");
+        let outcome =
+            khive_runtime::atomic_runner::run_atomic_unit(runtime.sql().as_ref(), vec![plan])
+                .await
+                .expect("commit description update");
+        assert!(matches!(outcome, AtomicRunOutcome::Committed { .. }));
+
+        let after_description = runtime
+            .notes(&token)
+            .expect("notes store")
+            .get_note(task_id)
+            .await
+            .expect("get task")
+            .expect("task exists");
+        assert_eq!(after_description.content, "atomic property body");
+        assert_eq!(
+            task_properties(&after_description)
+                .get("description")
+                .and_then(Value::as_str),
+            Some("atomic property body")
+        );
+
+        let (plan, _) = prepare_one(
+            &runtime,
+            &token,
+            &registry,
+            "update",
+            &json!({"id": task_id.to_string(), "content": null, "properties": null}),
+        )
+        .await
+        .expect("prepare atomic null/no-op patch");
+        let outcome =
+            khive_runtime::atomic_runner::run_atomic_unit(runtime.sql().as_ref(), vec![plan])
+                .await
+                .expect("commit null/no-op patch");
+        assert!(matches!(outcome, AtomicRunOutcome::Committed { .. }));
+        let after_null = runtime
+            .notes(&token)
+            .expect("notes store")
+            .get_note(task_id)
+            .await
+            .expect("get task")
+            .expect("task exists");
+        assert_eq!(after_null.content, "atomic property body");
+        assert_eq!(
+            task_properties(&after_null)
+                .get("description")
+                .and_then(Value::as_str),
+            Some("atomic property body")
+        );
+
+        let (plan, _) = prepare_one(
+            &runtime,
+            &token,
+            &registry,
+            "update",
+            &json!({
+                "id": task_id.to_string(),
+                "properties": {"description": null},
+            }),
+        )
+        .await
+        .expect("prepare atomic description clear");
+        let outcome =
+            khive_runtime::atomic_runner::run_atomic_unit(runtime.sql().as_ref(), vec![plan])
+                .await
+                .expect("commit description clear");
+        assert!(matches!(outcome, AtomicRunOutcome::Committed { .. }));
+        let after_clear = runtime
+            .notes(&token)
+            .expect("notes store")
+            .get_note(task_id)
+            .await
+            .expect("get task")
+            .expect("task exists");
+        assert_eq!(after_clear.content, "atomic-gtd-test-task");
+        assert!(task_properties(&after_clear)
+            .get("description")
+            .is_some_and(Value::is_null));
+    }
+
+    #[tokio::test]
+    async fn atomic_task_update_rejects_title_clear_before_description_clear_can_write() {
+        let runtime = scratch_runtime();
+        let token = runtime
+            .authorize(Namespace::parse("local").expect("ns"))
+            .expect("authorize");
+        let task_id = seed_task(&runtime, &token, "inbox").await;
+        let registry = full_registry(&runtime);
+        let before = runtime
+            .notes(&token)
+            .expect("note store")
+            .get_note(task_id)
+            .await
+            .expect("read task before rejected update")
+            .expect("task exists");
+
+        let err = prepare_one(
+            &runtime,
+            &token,
+            &registry,
+            "update",
+            &json!({
+                "id": task_id.to_string(),
+                "name": null,
+                "properties": {"description": null},
+            }),
+        )
+        .await
+        .expect_err("a task title cannot be cleared under --atomic");
+        assert!(
+            err.to_string().contains("task title cannot be cleared"),
+            "title-clear error must identify the task invariant; got: {err}"
+        );
+
+        let after = runtime
+            .notes(&token)
+            .expect("note store")
+            .get_note(task_id)
+            .await
+            .expect("read task after rejected update")
+            .expect("task exists");
+        assert_eq!(after, before, "rejected preparation must not write");
+    }
+
+    #[tokio::test]
+    async fn atomic_task_update_checks_explicit_kind_before_running_task_hook() {
+        let runtime = scratch_runtime();
+        let token = runtime
+            .authorize(Namespace::parse("local").expect("ns"))
+            .expect("authorize");
+        let task_id = seed_task(&runtime, &token, "inbox").await;
+        let registry = full_registry(&runtime);
+
+        // The mirror fields deliberately conflict. If the task hook ran
+        // before the explicit-kind check, its "must match" error would mask
+        // canonical dispatch's expected NotFound result.
+        let err = prepare_one(
+            &runtime,
+            &token,
+            &registry,
+            "update",
+            &json!({
+                "id": task_id.to_string(),
+                "kind": "observation",
+                "content": "one body",
+                "properties": {"description": "another body"},
+            }),
+        )
+        .await
+        .expect_err("wrong explicit note kind must fail before task normalization");
+        let message = err.to_string();
+        assert!(message.contains("not found: note"), "got: {message}");
+        assert!(
+            !message.contains("must match"),
+            "task hook must not run before kind mismatch rejection: {message}"
+        );
+    }
+
+    #[tokio::test]
+    async fn atomic_task_update_guard_refuses_snapshot_changed_after_prepare() {
+        let runtime = scratch_runtime();
+        let token = runtime
+            .authorize(Namespace::parse("local").expect("ns"))
+            .expect("authorize");
+        let task_id = seed_task(&runtime, &token, "inbox").await;
+        let registry = full_registry(&runtime);
+        let (plan, _) = prepare_one(
+            &runtime,
+            &token,
+            &registry,
+            "update",
+            &json!({"id": task_id.to_string(), "content": "prepared body"}),
+        )
+        .await
+        .expect("prepare task update");
+
+        let mut concurrent = runtime
+            .notes(&token)
+            .expect("note store")
+            .get_note(task_id)
+            .await
+            .expect("read task")
+            .expect("task exists");
+        concurrent.content = "concurrent body".to_string();
+        concurrent.properties =
+            Some(json!({"status": "inbox", "priority": "p2", "description": "concurrent body"}));
+        concurrent.updated_at = concurrent.updated_at.saturating_add(10);
+        runtime
+            .notes(&token)
+            .expect("note store")
+            .upsert_note(concurrent)
+            .await
+            .expect("concurrent write");
+
+        let outcome =
+            khive_runtime::atomic_runner::run_atomic_unit(runtime.sql().as_ref(), vec![plan])
+                .await
+                .expect("atomic runner");
+        assert!(
+            matches!(
+                &outcome,
+                AtomicRunOutcome::RolledBack {
+                    failed_op_index: 0,
+                    failure: AtomicOpFailure::GuardFailed { observed: 0, .. },
+                }
+            ),
+            "stale prepared update must roll back; got: {outcome:?}"
+        );
+        let persisted = runtime
+            .notes(&token)
+            .expect("note store")
+            .get_note(task_id)
+            .await
+            .expect("read task")
+            .expect("task exists");
+        assert_eq!(persisted.content, "concurrent body");
+        assert_eq!(
+            task_properties(&persisted)
+                .get("description")
+                .and_then(Value::as_str),
+            Some("concurrent body")
+        );
+    }
+
+    #[tokio::test]
+    async fn repeated_atomic_task_updates_fail_closed_without_projected_state() {
+        let runtime = scratch_runtime();
+        let token = runtime
+            .authorize(Namespace::parse("local").expect("ns"))
+            .expect("authorize");
+        let task_id = seed_task(&runtime, &token, "inbox").await;
+        let registry = full_registry(&runtime);
+        let (first, _) = prepare_one(
+            &runtime,
+            &token,
+            &registry,
+            "update",
+            &json!({"id": task_id.to_string(), "content": "first body"}),
+        )
+        .await
+        .expect("prepare first update");
+        let (second, _) = prepare_one(
+            &runtime,
+            &token,
+            &registry,
+            "update",
+            &json!({
+                "id": task_id.to_string(),
+                "properties": {"description": "second body"},
+            }),
+        )
+        .await
+        .expect("prepare second update");
+
+        // Both plans intentionally share the same pre-unit snapshot. The
+        // first advances its revision; the second must then trip its guard,
+        // rolling the whole unit back instead of overwriting the first write
+        // with an independently prepared full-row image.
+        let outcome = khive_runtime::atomic_runner::run_atomic_unit(
+            runtime.sql().as_ref(),
+            vec![first, second],
+        )
+        .await
+        .expect("atomic runner");
+        assert!(
+            matches!(
+                &outcome,
+                AtomicRunOutcome::RolledBack {
+                    failed_op_index: 1,
+                    failure: AtomicOpFailure::GuardFailed { observed: 0, .. },
+                }
+            ),
+            "repeated target must fail closed; got: {outcome:?}"
+        );
+        let persisted = runtime
+            .notes(&token)
+            .expect("note store")
+            .get_note(task_id)
+            .await
+            .expect("read task")
+            .expect("task exists");
+        assert_eq!(persisted.content, "atomic-gtd-test-task");
+        assert!(task_properties(&persisted).get("description").is_none());
+    }
+
+    #[tokio::test]
+    async fn atomic_generic_update_then_transition_rolls_back_on_shared_snapshot() {
+        assert_task_update_then_lifecycle_rolls_back("gtd.transition").await;
+    }
+
+    #[tokio::test]
+    async fn atomic_generic_update_then_complete_rolls_back_on_shared_snapshot() {
+        assert_task_update_then_lifecycle_rolls_back("gtd.complete").await;
+    }
+
+    /// Every op is prepared from the pre-unit snapshot. A same-status
+    /// transition prepared second must therefore revalidate that snapshot
+    /// after an earlier real transition on the same task, not silently
+    /// commit without checking its now-stale hypothesis.
+    #[tokio::test]
+    async fn atomic_transition_then_stale_noop_rolls_back_whole_unit() {
+        let runtime = scratch_runtime();
+        let token = runtime
+            .authorize(Namespace::parse("local").expect("ns"))
+            .expect("authorize");
+        let task_id = seed_task(&runtime, &token, "inbox").await;
+        let registry = full_registry(&runtime);
+        let before = runtime
+            .notes(&token)
+            .expect("note store")
+            .get_note(task_id)
+            .await
+            .expect("read task")
+            .expect("task exists");
+
+        let (transition, _) = prepare_one(
+            &runtime,
+            &token,
+            &registry,
+            "gtd.transition",
+            &json!({"id": task_id.to_string(), "status": "next"}),
+        )
+        .await
+        .expect("prepare real transition");
+        let (stale_noop, _) = prepare_one(
+            &runtime,
+            &token,
+            &registry,
+            "gtd.transition",
+            &json!({"id": task_id.to_string(), "status": "inbox"}),
+        )
+        .await
+        .expect("prepare same-status transition from the original snapshot");
+
+        let outcome = khive_runtime::atomic_runner::run_atomic_unit(
+            runtime.sql().as_ref(),
+            vec![transition, stale_noop],
+        )
+        .await
+        .expect("atomic runner");
+        assert!(
+            matches!(
+                &outcome,
+                AtomicRunOutcome::RolledBack {
+                    failed_op_index: 1,
+                    failure: AtomicOpFailure::GuardFailed {
+                        statement_label: Some(label),
+                        observed: 0,
+                        ..
+                    },
+                } if label == "gtd_atomic_noop_assertion"
+            ),
+            "the stale no-op assertion must fail at op 1; got: {outcome:?}"
+        );
+
+        let persisted = runtime
+            .notes(&token)
+            .expect("note store")
+            .get_note(task_id)
+            .await
+            .expect("read task")
+            .expect("task exists after rollback");
+        assert_eq!(persisted.updated_at, before.updated_at);
+        assert_eq!(task_properties(&persisted)["status"], "inbox");
+    }
+
+    /// A deletion earlier in the unit must likewise invalidate a no-op that
+    /// was prepared while the task still existed. The no-op's assertion is
+    /// what forces the delete to roll back as part of the whole unit.
+    #[tokio::test]
+    async fn atomic_delete_then_stale_noop_rolls_back_whole_unit() {
+        let runtime = scratch_runtime();
+        let token = runtime
+            .authorize(Namespace::parse("local").expect("ns"))
+            .expect("authorize");
+        let task_id = seed_task(&runtime, &token, "inbox").await;
+        let registry = full_registry(&runtime);
+        let before = runtime
+            .notes(&token)
+            .expect("note store")
+            .get_note(task_id)
+            .await
+            .expect("read task")
+            .expect("task exists");
+
+        let (delete, _) = prepare_one(
+            &runtime,
+            &token,
+            &registry,
+            "delete",
+            &json!({"id": task_id.to_string(), "hard": true}),
+        )
+        .await
+        .expect("prepare hard delete");
+        let (stale_noop, _) = prepare_one(
+            &runtime,
+            &token,
+            &registry,
+            "gtd.transition",
+            &json!({"id": task_id.to_string(), "status": "inbox"}),
+        )
+        .await
+        .expect("prepare same-status transition before delete applies");
+
+        let outcome = khive_runtime::atomic_runner::run_atomic_unit(
+            runtime.sql().as_ref(),
+            vec![delete, stale_noop],
+        )
+        .await
+        .expect("atomic runner");
+        assert!(
+            matches!(
+                &outcome,
+                AtomicRunOutcome::RolledBack {
+                    failed_op_index: 1,
+                    failure: AtomicOpFailure::GuardFailed {
+                        statement_label: Some(label),
+                        observed: 0,
+                        ..
+                    },
+                } if label == "gtd_atomic_noop_assertion"
+            ),
+            "the delete must invalidate the no-op assertion at op 1; got: {outcome:?}"
+        );
+
+        let persisted = runtime
+            .notes(&token)
+            .expect("note store")
+            .get_note(task_id)
+            .await
+            .expect("read task")
+            .expect("hard delete must roll back with the unit");
+        assert_eq!(persisted, before);
+    }
+
     /// ADR-099 B3: atomic `gtd.transition`
     /// must persist a caller-supplied `note` as `properties.transition_note`
     /// — parity with `khive-pack-gtd::handlers::handle_transition`
@@ -1285,7 +1918,9 @@ mod tests {
             .expect("authorize");
 
         // (a) secret in `result` rejected before any write.
-        let task_id = seed_task(&runtime, &token, "next").await;
+        // Use the default inbox state to preserve direct-complete parity with
+        // the accepted lifecycle table (inbox -> done is legal).
+        let task_id = seed_task(&runtime, &token, "inbox").await;
         let err = prepare_gtd_complete(
             &runtime,
             &token,
@@ -1311,7 +1946,7 @@ mod tests {
             task_properties(&note)
                 .get("status")
                 .and_then(|v| v.as_str()),
-            Some("next"),
+            Some("inbox"),
             "rejected prepare must not have mutated the task"
         );
 
@@ -1389,14 +2024,16 @@ mod tests {
         );
     }
 
-    /// GAP-6 (ADR-099 B3): an idempotent `gtd.transition` (current ==
-    /// target after `normalize_status`) must perform NO write — parity with
-    /// `handle_transition`'s early return (handlers.rs:995-1005). The
+    /// GAP-6 (ADR-099 B3): an idempotent atomic `gtd.transition` (current ==
+    /// target after `normalize_status`) must perform no persisted mutation.
+    /// Its guarded no-effect statement only revalidates the snapshot. This
+    /// matches canonical when no note was supplied; canonical note-bearing
+    /// no-ops have a separate note-event contract outside atomic v1. The
     /// pre-fix atomic prepare only special-cased `current != target` inside
     /// its `can_transition` guard, so a current==target call fell through
     /// to an unconditional `UPDATE` that bumped `updated_at` for nothing.
     #[tokio::test]
-    async fn atomic_gtd_transition_idempotent_noop_performs_no_write() {
+    async fn atomic_gtd_transition_idempotent_noop_performs_no_mutation() {
         let runtime = scratch_runtime();
         let token = runtime
             .authorize(Namespace::parse("local").expect("ns"))
@@ -1419,6 +2056,11 @@ mod tests {
         )
         .await
         .expect("prepare idempotent transition must succeed (no-op, not an error)");
+        let AtomicOpPlan::GtdTransition(noop_plan) = &plan else {
+            panic!("expected gtd transition plan")
+        };
+        assert!(noop_plan.is_idempotent_noop());
+        assert_eq!(noop_plan.statements().len(), 1);
 
         let outcome =
             khive_runtime::atomic_runner::run_atomic_unit(runtime.sql().as_ref(), vec![plan])
@@ -1431,7 +2073,7 @@ mod tests {
         assert!(
             post_commit.as_slice().is_empty(),
             "an idempotent no-op transition must produce no post-commit effect (no audit row \
-             either — canonical never reaches its own write_audit_record call): {post_commit:?}"
+             either — canonical no-note no-ops never reach their own audit helper): {post_commit:?}"
         );
 
         let after = runtime
@@ -1443,15 +2085,76 @@ mod tests {
             .expect("task must still exist");
         assert_eq!(
             after.updated_at, updated_at_before,
-            "an idempotent transition must not touch updated_at — no write happened"
+            "an idempotent transition must not change updated_at"
         );
+    }
+
+    #[tokio::test]
+    async fn atomic_same_status_transition_with_note_remains_mutation_and_audit_free() {
+        let runtime = scratch_runtime();
+        let token = runtime
+            .authorize(Namespace::parse("local").expect("ns"))
+            .expect("authorize");
+        let task_id = seed_task(&runtime, &token, "next").await;
+        let before = runtime
+            .notes(&token)
+            .expect("notes store")
+            .get_note(task_id)
+            .await
+            .expect("read task")
+            .expect("task exists");
+        let args = json!({
+            "id": task_id.to_string(),
+            "status": "next",
+            "note": "canonical-only note event",
+        });
+        let plan = prepare_gtd_transition(&runtime, &token, &args)
+            .await
+            .expect("prepare atomic same-status no-op");
+        let outcome = khive_runtime::atomic_runner::run_atomic_unit(
+            runtime.sql().as_ref(),
+            vec![plan.clone()],
+        )
+        .await
+        .expect("commit guarded no-op assertion");
+        let post_commit = match outcome {
+            AtomicRunOutcome::Committed { post_commit } => post_commit,
+            other => panic!("expected committed no-op, got {other:?}"),
+        };
+        assert!(post_commit.as_slice().is_empty());
+
+        let audit_outcomes = HashMap::new();
+        let result = build_op_result(
+            &runtime,
+            &token,
+            "gtd.transition",
+            &args,
+            &args,
+            &plan,
+            &audit_outcomes,
+        )
+        .await
+        .expect("render no-op result");
+        assert_eq!(result["transitioned"], false);
+        assert!(result.get("note_recorded").is_none());
+        assert!(result.get("audit_persisted").is_none());
+
+        let after = runtime
+            .notes(&token)
+            .expect("notes store")
+            .get_note(task_id)
+            .await
+            .expect("read task")
+            .expect("task exists");
+        assert_eq!(after.updated_at, before.updated_at);
+        assert!(task_properties(&after).get("transition_note").is_none());
     }
 
     /// GAP-5 (ADR-099 B3): a committed atomic `gtd.transition` AND a
     /// committed atomic `gtd.complete` must each write a
     /// `gtd_lifecycle_audit` row — parity with `handle_transition`/
     /// `handle_complete`'s best-effort `ensure_audit_schema` +
-    /// `write_audit_record` calls (handlers.rs:1062-1071, :873-883). The
+    /// `write_audit_record_with_status` calls. The
     /// pre-fix atomic prepare wrote no audit row at all.
     #[tokio::test]
     async fn atomic_gtd_transition_and_complete_write_lifecycle_audit_rows() {
@@ -1477,7 +2180,9 @@ mod tests {
             AtomicRunOutcome::Committed { post_commit } => post_commit,
             other => panic!("expected Committed, got {other:?}"),
         };
-        apply_gtd_audit_post_commit_effects(&runtime, post_commit.as_slice()).await;
+        let transition_audit =
+            apply_gtd_audit_post_commit_effects(&runtime, post_commit.as_slice()).await;
+        assert_eq!(transition_audit.get(&transition_task), Some(&true));
 
         // (b) complete next -> done.
         let complete_task = seed_task(&runtime, &token, "next").await;
@@ -1496,7 +2201,9 @@ mod tests {
             AtomicRunOutcome::Committed { post_commit } => post_commit,
             other => panic!("expected Committed, got {other:?}"),
         };
-        apply_gtd_audit_post_commit_effects(&runtime, post_commit.as_slice()).await;
+        let complete_audit =
+            apply_gtd_audit_post_commit_effects(&runtime, post_commit.as_slice()).await;
+        assert_eq!(complete_audit.get(&complete_task), Some(&true));
 
         let mut reader = runtime.sql().reader().await.expect("reader");
         let rows = reader
@@ -1539,5 +2246,59 @@ mod tests {
             complete_row_present,
             "expected an audit row for the complete op: {rows:?}"
         );
+    }
+
+    #[tokio::test]
+    async fn atomic_complete_result_reports_failed_audit_append() {
+        let runtime = scratch_runtime();
+        let token = runtime
+            .authorize(Namespace::parse("local").expect("ns"))
+            .expect("authorize");
+        ensure_audit_schema(&runtime).await;
+        {
+            let mut writer = runtime.sql().writer().await.expect("writer");
+            writer
+                .execute_script(
+                    "CREATE TRIGGER reject_atomic_gtd_audit_insert \
+                     BEFORE INSERT ON gtd_lifecycle_audit \
+                     BEGIN SELECT RAISE(FAIL, 'forced atomic audit failure'); END;"
+                        .to_string(),
+                )
+                .await
+                .expect("failure-injection trigger");
+        }
+
+        let task_id = seed_task(&runtime, &token, "next").await;
+        let args = json!({"id": task_id.to_string(), "result": "shipped"});
+        let plan = prepare_gtd_complete(&runtime, &token, &args)
+            .await
+            .expect("prepare complete");
+        let outcome = khive_runtime::atomic_runner::run_atomic_unit(
+            runtime.sql().as_ref(),
+            vec![plan.clone()],
+        )
+        .await
+        .expect("commit domain write");
+        let post_commit = match outcome {
+            AtomicRunOutcome::Committed { post_commit } => post_commit,
+            other => panic!("expected committed completion, got {other:?}"),
+        };
+        let audit_outcomes =
+            apply_gtd_audit_post_commit_effects(&runtime, post_commit.as_slice()).await;
+        assert_eq!(audit_outcomes.get(&task_id), Some(&false));
+
+        let result = build_op_result(
+            &runtime,
+            &token,
+            "gtd.complete",
+            &args,
+            &args,
+            &plan,
+            &audit_outcomes,
+        )
+        .await
+        .expect("render committed completion");
+        assert_eq!(result["completed"], true);
+        assert_eq!(result["audit_persisted"], false);
     }
 }

--- a/crates/kkernel/src/atomic_apply.rs
+++ b/crates/kkernel/src/atomic_apply.rs
@@ -1507,6 +1507,48 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn atomic_task_update_rejects_lifecycle_properties_during_prepare() {
+        let runtime = scratch_runtime();
+        let token = runtime
+            .authorize(Namespace::parse("local").expect("ns"))
+            .expect("authorize");
+        let task_id = seed_task(&runtime, &token, "inbox").await;
+        let registry = full_registry(&runtime);
+        let before = runtime
+            .notes(&token)
+            .expect("note store")
+            .get_note(task_id)
+            .await
+            .expect("read task before rejected update")
+            .expect("task exists");
+
+        let err = prepare_one(
+            &runtime,
+            &token,
+            &registry,
+            "update",
+            &json!({
+                "id": task_id.to_string(),
+                "properties": {"status": "done"},
+            }),
+        )
+        .await
+        .expect_err("atomic prepare must share lifecycle-owned property rejection");
+        assert_eq!(
+            err.to_string(),
+            "invalid input: properties.status is lifecycle-owned and cannot be patched on a task; use gtd.transition for lifecycle changes or gtd.complete for terminal completion"
+        );
+        let after = runtime
+            .notes(&token)
+            .expect("note store")
+            .get_note(task_id)
+            .await
+            .expect("read task after rejected update")
+            .expect("task exists");
+        assert_eq!(after, before, "rejected atomic prepare must not write");
+    }
+
+    #[tokio::test]
     async fn atomic_task_update_checks_explicit_kind_before_running_task_hook() {
         let runtime = scratch_runtime();
         let token = runtime

--- a/docs/adr/ADR-017-pack-standard.md
+++ b/docs/adr/ADR-017-pack-standard.md
@@ -205,6 +205,19 @@ pub trait KindHook: Send + Sync + std::fmt::Debug {
         args: &Value,
     ) -> Result<(), RuntimeError>;
 
+    /// Normalize a generic note update before the write. The default delegates
+    /// to `validate_note_update` with the request's property patch.
+    async fn prepare_note_update(
+        &self,
+        runtime: &KhiveRuntime,
+        token: &NamespaceToken,
+        note: &Note,
+        args: &mut Value,
+    ) -> Result<(), RuntimeError> {
+        let properties = args.get("properties").filter(|value| !value.is_null());
+        self.validate_note_update(runtime, token, note, properties).await
+    }
+
     /// Validate a generic note-property update before the write. Default: accept.
     async fn validate_note_update(
         &self,
@@ -232,10 +245,22 @@ The 2026-08-01 dependency-integrity amendment adds the two default-accepting
 pre-write validators after GTD demonstrated a cross-record invariant that generic
 CRUD cannot own: task dependency acyclicity. `validate_note_update` receives only
 note-property patches, while `validate_links` receives the whole proposed batch so a
-cycle formed entirely inside one atomic link request cannot evade validation. Packs
-that do not need either hook inherit a no-op and remain source-compatible. Future
-hooks (`after_update`, `before_delete`) can extend the same pattern when a concrete
-consumer requires them.
+cycle formed entirely inside one atomic link request cannot evade validation.
+
+The 2026-08-06 task-mirror amendment adds `prepare_note_update`. Its default delegates
+to `validate_note_update`, so existing hooks retain their behavior. An owning pack may
+override it to normalize coupled caller fields before the shared CRUD patch is built.
+GTD uses this seam to keep a task note's searchable `content` synchronized with
+`properties.description`; both canonical dispatch and atomic preparation invoke the
+same hook before constructing their write. The note snapshot supplied to the hook is
+also the snapshot patched and persisted: canonical writes use a compare-and-swap
+replacement, and atomic plans carry the same revision/deletion predicate into their
+affected-row guard. A concurrent change therefore refuses or rolls back the write
+instead of storing normalization derived from stale state. The registry retains the
+validation-only `validate_note_update_hook` compatibility seam for callers without a
+mutable request. Packs that need neither behavior inherit a no-op. Future hooks
+(`after_update`, `before_delete`) can extend the same pattern when a concrete consumer
+requires them.
 
 ### `VerbRegistry`: the runtime's pack catalog
 
@@ -864,7 +889,7 @@ dedicated ADR. v1 is compile-time.
 
 - The kg pack's name carries weight beyond its origins (it owns shared CRUD for all
   kinds). Renaming is not justified.
-- `KindHook` covers create specialization plus default-accepting note-update and
+- `KindHook` covers create specialization, note-update normalization/validation, and
   link-batch validation. Post-update and delete hooks extend the pattern when a real
   consumer asks.
 - Pack auxiliary schema is non-evolving in v1. If a pack needs to evolve its schema, it

--- a/docs/adr/ADR-019-gtd-pack.md
+++ b/docs/adr/ADR-019-gtd-pack.md
@@ -337,9 +337,11 @@ Task body text has one mirror contract. With a description, `note.content` and
 `properties.description` contain the same string; without one, `note.content` falls
 back to the title. The task kind hook applies the same rule to generic `update`: a
 content-only patch fills the description mirror, a description-only patch fills
-content, conflicting simultaneous values are rejected, clearing description restores
-the title fallback, and renaming a description-less task updates that fallback. A task
-title remains required: `name=null` is rejected before any mirror patch can write,
+content, conflicting simultaneous values are rejected, clearing a stored non-null
+description restores the title fallback, clearing an absent description preserves a
+non-fallback body, and renaming a description-less task updates content only while its
+stored body is the title fallback. A task title remains required: `name=null` is
+rejected before any mirror patch can write,
 including when the same request clears `properties.description`. The
 canonical and atomic update paths run this same hook before building their writes. The
 hook snapshot is also the patch/write snapshot: canonical persistence compare-and-swaps

--- a/docs/adr/ADR-019-gtd-pack.md
+++ b/docs/adr/ADR-019-gtd-pack.md
@@ -146,13 +146,13 @@ task-specific knowledge in retrieval.
 
 ### Five disjoint verbs
 
-| Verb             | Purpose                                                                                                                                       |
-| ---------------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
-| `gtd.assign`     | Create a task. Args: `title`, `priority?`, `status?`, `assignee?`, `due?`, `depends_on?`, `tags?`, `description?`. Returns the task envelope. |
-| `gtd.next`       | List actionable tasks (`status ∈ {next, active}`), priority-sorted. Args: `limit?`, `assignee?`, `include_blocked?`.                          |
+| Verb             | Purpose                                                                                                                                                         |
+| ---------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `gtd.assign`     | Create a task. Args: `title`, `priority?`, `status?`, `assignee?`, `due?`, `depends_on?`, `tags?`, `description?`. Returns the task envelope.                   |
+| `gtd.next`       | List actionable tasks (`status ∈ {next, active}`), priority-sorted. Args: `limit?`, `assignee?`, `include_blocked?`.                                            |
 | `gtd.complete`   | Validate transition to a terminal state, record `completed_at` and optional `result`. Args: `id`, `status?` (`done` or `cancelled`; default `done`), `result?`. |
-| `gtd.tasks`      | Filtered list. Args: `status?`, `assignee?`, `priority?`, `limit?`, `offset?`.                                                                |
-| `gtd.transition` | Explicit lifecycle change with full transition validation. Args: `id`, `status`, `note?`.                                                     |
+| `gtd.tasks`      | Filtered list. Args: `status?`, `assignee?`, `priority?`, `limit?`, `offset?`.                                                                                  |
+| `gtd.transition` | Explicit lifecycle change with full transition validation. Args: `id`, `status`, `note?`.                                                                       |
 
 No collision with kg pack's shared CRUD. ADR-017's `VerbRegistry` registers all five
 verbs as `gtd`-owned. The kg pack's `create(kind="note", note_kind="task", ...)`

--- a/docs/adr/ADR-019-gtd-pack.md
+++ b/docs/adr/ADR-019-gtd-pack.md
@@ -55,7 +55,7 @@ impl Pack for GtdPack {
     const HANDLERS:     &'static [HandlerDef]    = &[
         HandlerDef { name: "gtd.assign",     description: "Create a task with optional dependencies.",       visibility: Visibility::Verb },
         HandlerDef { name: "gtd.next",       description: "List actionable tasks (status next or active).", visibility: Visibility::Verb },
-        HandlerDef { name: "gtd.complete",   description: "Mark a task done with optional result.",         visibility: Visibility::Verb },
+        HandlerDef { name: "gtd.complete",   description: "Mark a task done (or cancelled) with an optional result note.", visibility: Visibility::Verb },
         HandlerDef { name: "gtd.tasks",      description: "Filtered task list.",                            visibility: Visibility::Verb },
         HandlerDef { name: "gtd.transition", description: "Explicit GTD status transition.",                visibility: Visibility::Verb },
     ];
@@ -117,7 +117,16 @@ semantics are required.
 Transition validation lives in the `transition` verb handler. Illegal jumps (e.g.,
 `done → inbox`) return `RuntimeError::InvalidInput` with the allowed-set message.
 Same-status transitions are idempotent no-ops; the response carries `transitioned:
-false` with an explanatory `note` field.
+false` with an explanatory `note` field. Canonical dispatch may still persist a
+caller-supplied transition note as the explicitly documented note-event exception;
+ADR-099 atomic v1 carries a guarded no-effect assertion that revalidates the exact
+prepare snapshot at commit, but does not persist the caller note or an audit row.
+
+`gtd.complete` uses this same table, with a target of `done` by default or
+`cancelled` when requested. It does not add a narrower "actionable only" gate:
+`inbox`, `waiting`, and `someday` all have legal direct terminal transitions above,
+so `complete` accepts them just as `transition` does. Terminal source states remain
+rejected.
 
 ### Status / priority aliases
 
@@ -141,7 +150,7 @@ task-specific knowledge in retrieval.
 | ---------------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
 | `gtd.assign`     | Create a task. Args: `title`, `priority?`, `status?`, `assignee?`, `due?`, `depends_on?`, `tags?`, `description?`. Returns the task envelope. |
 | `gtd.next`       | List actionable tasks (`status ∈ {next, active}`), priority-sorted. Args: `limit?`, `assignee?`, `include_blocked?`.                          |
-| `gtd.complete`   | Validate transition to `done`, record `completed_at` and optional `result`. Args: `id`, `result?`.                                            |
+| `gtd.complete`   | Validate transition to a terminal state, record `completed_at` and optional `result`. Args: `id`, `status?` (`done` or `cancelled`; default `done`), `result?`. |
 | `gtd.tasks`      | Filtered list. Args: `status?`, `assignee?`, `priority?`, `limit?`, `offset?`.                                                                |
 | `gtd.transition` | Explicit lifecycle change with full transition validation. Args: `id`, `status`, `note?`.                                                     |
 
@@ -260,6 +269,12 @@ impl KindHook for TaskHook {
         // ...
     }
 
+    async fn prepare_note_update(/* ..., args: &mut Value */) -> Result<(), RuntimeError> {
+        // Keep note.content and properties.description synchronized, then
+        // run the dependency-property validator.
+        // ...
+    }
+
     async fn validate_links(/* batch ... */) -> Result<(), RuntimeError> {
         // Reject direct, transitive, and same-batch depends_on edge cycles.
         // ...
@@ -308,6 +323,30 @@ at the same `NoteStore::upsert_note` + `GraphStore::upsert_edge` calls. Agents p
 whichever fits their context: `assign` reads naturally for "I'm creating a task";
 `create(kind="note", note_kind="task")` reads naturally for "I'm batching mixed
 substrate operations through the request DSL."
+
+The generic path rejects a present GTD field whose JSON type is wrong instead of
+treating it as absent and applying a default. This applies to both top-level flavored
+fields and their recognized `properties` equivalents. JSON `null` retains normal
+optional-field semantics: `title=null` falls back to a valid string `name`, while both
+absent/null spellings still fail the required-title check. The shared raw
+`CreateParams` shape is validated before the task hook can replace derived `name`,
+`content`, or `salience`, and both title spellings are parsed strictly. Top-level values
+win when both valid forms are supplied.
+
+Task body text has one mirror contract. With a description, `note.content` and
+`properties.description` contain the same string; without one, `note.content` falls
+back to the title. The task kind hook applies the same rule to generic `update`: a
+content-only patch fills the description mirror, a description-only patch fills
+content, conflicting simultaneous values are rejected, clearing description restores
+the title fallback, and renaming a description-less task updates that fallback. A task
+title remains required: `name=null` is rejected before any mirror patch can write,
+including when the same request clears `properties.description`. The
+canonical and atomic update paths run this same hook before building their writes. The
+hook snapshot is also the patch/write snapshot: canonical persistence compare-and-swaps
+its revision, while atomic persistence guards the same revision in-transaction. Atomic
+v1 does not project one update's new task state into a later update of the same task;
+the later stale guard fails and rolls the entire unit back rather than losing ordered
+effects.
 
 ### Lifecycle verbs stay pack-owned
 
@@ -381,12 +420,15 @@ impl PackRuntime for GtdPack {
 }
 ```
 
-`gtd_lifecycle_audit` is a pack-auxiliary table. It records each `transition`
+`gtd_lifecycle_audit` is a pack-auxiliary table. It records each real `transition`
 and `complete` invocation for replay and compliance, including the caller namespace.
 The `namespace` column is nullable because it was added after the table shipped:
 legacy rows may be `NULL`, while new rows always bind the authorized namespace.
 Per ADR-015, pack schema uses idempotent declarations by default; GTD's nullable
 namespace `ALTER TABLE` is the documented v1 pack-local evolution exception.
+The state mutation remains successful when this best-effort append fails, but every
+successful real lifecycle response includes `audit_persisted`; `false` makes that
+degradation caller-visible instead of silently losing the only operational signal.
 
 `StorageProfile.roles: [Hot]` because task work is interactive — tasks are read and
 updated constantly. `default_backend: "main"` keeps tasks on the same backend as kg
@@ -427,12 +469,19 @@ the blocker-resolution read required to classify dependency state.
   "from": "next",
   "to": "active",
   "transitioned": true,
-  "is_terminal": false
+  "is_terminal": false,
+  "audit_persisted": true
 }
 ```
 
 Same-status transitions return `{"transitioned": false, "note": "already in target
-status"}` so callers can audit the no-op.
+status"}` so callers can audit the no-op. They do not carry `audit_persisted` when no
+audit append was attempted. On canonical dispatch, a same-status call that carries a
+note persists that note, appends a same-status audit row, and reports the append with
+`note_recorded` and `audit_persisted`. Atomic v1 represents the same-status case with a
+guarded, mutation-free snapshot assertion even when `note` was supplied, so stale
+multi-op assumptions roll back while neither side effect is persisted; it returns only
+the base no-op shape.
 
 ### Config-driven loading
 
@@ -533,6 +582,10 @@ time T with note N in namespace NS." The audit table records each `transition` a
 `complete` invocation. Legacy rows created before the namespace backfill may have
 `NULL` namespace.
 
+The append stays non-fatal because the lifecycle row is already committed. Returning
+`audit_persisted` on successful state changes preserves that best-effort boundary while
+letting callers alert or reconcile when the auxiliary row was not written.
+
 This is GTD-specific data; it doesn't belong in the core `events` table (which is
 governed by ADR-004 and used for system-level events). Pack-auxiliary tables (per
 ADR-015) are the right placement.
@@ -599,8 +652,10 @@ minimal. Operators who want GTD configure it explicitly.
   Fine for personal/agent workloads (typical inboxes < 50 actionable items);
   `next`'s full-scan-then-sort will need property indexes or a v2 SQL path
   (e.g. `ORDER BY` pushed into SQL) at hundreds-of-thousands scale.
-- Same-status transitions are no-ops, which can surprise callers expecting a write.
-  Mitigated: `transitioned: false` + `note` field in the response body.
+- Same-status transitions do not change lifecycle state. Canonical dispatch may
+  still persist a supplied note event; atomic v1 instead executes a guarded
+  no-effect assertion and discards that note. Mitigated: `transitioned: false` +
+  the path distinction documented above.
 - `depends_on` redundancy (property + edge) requires both writes to succeed for
   consistency. Edge write is best-effort; on failure, the property still holds.
   Mitigated: documented; future relibilization (atomic two-write transaction) is a
@@ -612,8 +667,9 @@ minimal. Operators who want GTD configure it explicitly.
   forward-compatible vocabulary extension.
 - `gtd_lifecycle_audit` is pack-auxiliary; its presence is invisible to non-GTD
   packs.
-- Task properties (priority, status, assignee, etc.) remain free-form JSON — no
-  schema enforcement beyond what `transition` validates.
+- Task properties remain JSON rather than dedicated columns. The task hook still
+  validates recognized create-field types, the content/description mirror, and
+  dependency invariants before shared CRUD writes.
 
 ## Implementation
 
@@ -628,6 +684,7 @@ minimal. Operators who want GTD configure it explicitly.
   - `TaskHook` implementing `KindHook`.
   - `prepare_create`: normalize GTD args into kg shape.
   - `after_create`: fire `depends_on` edges (best-effort, logged on failure).
+  - `prepare_note_update`: synchronize task content/description and validate properties.
   - `validate_note_update` / `validate_links`: reject dependency cycles before writes.
 - `crates/khive-pack-gtd/src/dependency.rs`:
   - Bounded property and edge reachability validation.

--- a/docs/adr/ADR-124-note-write-identity.md
+++ b/docs/adr/ADR-124-note-write-identity.md
@@ -155,13 +155,14 @@ metadata on an existing record. `gtd`'s entire parameter surface is
 pack-owned kinds would remove that workflow's only path and offer none in its place; refusing a
 class to close a specific hole is a broader change than the hole justifies.
 
-The refusal lives at the runtime layer in `prepare_update_note`. Two call sites reach it: the
-`update` verb by way of `update_note`, and the atomic seam in `atomic_prepare`. Placing the
-refusal in the kg handler instead would leave the atomic seam open. No proposal-borne note update
-converges there, because `ProposalChangeset` carries no note-update variant at all
-(`khive-types/src/event.rs`); should one be added, it must route through `prepare_update_note`
-rather than around it. `name`, `content`, `salience` and `decay_factor` remain patchable on every
-kind.
+The refusal lives at the runtime layer in `prepare_update_note_from_snapshot`. Two call sites
+reach it: the `update` verb through the guarded
+`update_note_from_snapshot_with_embedding_report` path, and the atomic seam in
+`atomic_prepare`. Placing the refusal in the kg handler instead would leave the atomic seam open.
+No proposal-borne note update converges there, because `ProposalChangeset` carries no note-update
+variant at all (`khive-types/src/event.rs`); should one be added, it must route through this
+guarded snapshot update path rather than around it. `name`, `content`, `salience` and
+`decay_factor` remain patchable on every kind.
 
 The pack-owned kind set is derived from the packs' `NOTE_KINDS` constants
 (`PackRegistry::pack_owned_note_kinds`): every note kind declared by a pack other than the

--- a/docs/guide/api-reference.md
+++ b/docs/guide/api-reference.md
@@ -832,6 +832,9 @@ request(ops="gtd.next(assignee=\"agent:docs\", limit=10)")
 ### `gtd.complete` — Declaration
 
 Mark a task done (or cancelled) with an optional result note.
+Every non-terminal GTD state may move directly to either terminal state. Successful
+state changes include `audit_persisted`; `false` means the task committed but the
+best-effort lifecycle-audit append failed.
 
 | Param    | Type   | Required | Notes                                             |
 | -------- | ------ | -------- | ------------------------------------------------- |

--- a/docs/guide/tasks.md
+++ b/docs/guide/tasks.md
@@ -75,12 +75,20 @@ request(ops="gtd.assign(title=\"Review the task guide\", assignee=\"docs-maintai
 ```
 
 `gtd.transition` validates the lifecycle with `can_transition` before writing.
-A repeated transition to the current status is a no-op. Use `gtd.complete` to
-finish an actionable task (`next` or `active`); it records `completed_at`, and
-can mark the task `done` (the default) or `cancelled`.
+A repeated transition to the current status is a no-op. `gtd.complete` uses the
+same lifecycle table for a terminal transition, records `completed_at`, and can
+mark any non-terminal task `done` (the default) or `cancelled`.
+
+Successful state changes include `audit_persisted`. A value of `false` means the
+task state committed but the best-effort lifecycle-audit append failed; alert or
+reconcile it rather than assuming the audit row exists.
 
 When `gtd.transition` is a no-op, branch on `transitioned`: when it is `false`,
-only `transitioned`, `id`, `full_id`, `from`, `to`, and `note` are present.
+the base fields are `transitioned`, `id`, `full_id`, `from`, `to`, and `note`.
+On canonical dispatch, supplying a transition note also adds `note_recorded`
+and, if that guarded note write succeeds, `audit_persisted`. Atomic v1 uses a
+guarded no-effect assertion for same-status plans and does not persist a supplied
+note; use canonical dispatch when that note event matters.
 
 ## Dependencies
 
@@ -101,8 +109,8 @@ updates and graph links.
   identifier is not work to take without coordination.
 - `done` and `cancelled` cannot transition again. Capture follow-up work as a
   new task instead of trying to reopen a terminal one.
-- `gtd.complete` is for actionable tasks. To finish an inbox, waiting, or
-  someday task directly, use a valid `gtd.transition` to `done` or `cancelled`.
+- `gtd.complete` may finish any non-terminal task directly. It still rejects a
+  task that is already `done` or `cancelled`.
 
 ## See also
 

--- a/marketplace/khive/skills/gtd/SKILL.md
+++ b/marketplace/khive/skills/gtd/SKILL.md
@@ -46,9 +46,9 @@ request(ops="[
 ]")
 ```
 
-`gtd.complete` only accepts actionable tasks (`next` / `active`). To cancel or finish an item
-still in `inbox` / `waiting` / `someday`, use `gtd.transition` (`status="cancelled"` or
-`status="done"`) — or move it to `next` / `active` first, then complete.
+`gtd.complete` accepts every non-terminal state because the lifecycle table permits each one
+to move directly to `done` or `cancelled`. Use `gtd.transition` when the lifecycle move itself
+needs a note or when moving among non-terminal states.
 
 ### 3. Surface actionable work
 
@@ -97,7 +97,9 @@ request(ops="gtd.complete(id=\"<id>\", result=\"PR #198 merged, smoke tests gree
 
 `gtd.complete` stamps `completed_at` and validates the terminal transition. Pass a PR number,
 test output, or one concrete sentence as `result`. `done` and `cancelled` are terminal: no
-further transitions. Reopened work means a new `gtd.assign`, not a reopen.
+further transitions. Reopened work means a new `gtd.assign`, not a reopen. Check
+`audit_persisted` on the result: `false` means the task committed but the best-effort lifecycle
+audit append must be reconciled.
 
 ### 6. Weekly planning pass
 

--- a/tests/khive-contract/tests/test_adr_023_verb_taxonomy.py
+++ b/tests/khive-contract/tests/test_adr_023_verb_taxonomy.py
@@ -166,7 +166,7 @@ def test_pack_product_verbs_are_reachable_when_loaded(
     assert trans.get("transitioned") is True, f"gtd.transition must return transitioned=True: {trans}"
     assert trans.get("to") == "waiting", f"gtd.transition must report to=waiting: {trans}"
 
-    # gtd.complete (need a task in actionable status, so transition back to next)
+    # gtd.complete (transition back to next to exercise that source state)
     khive_gtd_session.verb("gtd.transition", {"id": task_id, "status": "next", "namespace": ns})
     done = khive_gtd_session.verb("gtd.complete", {"id": task_id, "result": "taxonomy pass",
                                                      "namespace": ns})

--- a/tests/khive-contract/tests/test_chain_mode.py
+++ b/tests/khive-contract/tests/test_chain_mode.py
@@ -67,8 +67,8 @@ def test_chain_assign_then_complete(
     ns = temp_namespace
     title = f"ChainAssignComplete_{uuid.uuid4().hex[:6]}"
 
-    # gtd.assign defaults to inbox; complete rejects inbox→done directly (ADR-462).
-    # Assign with status="next" so gtd.complete can run immediately via $prev.id.
+    # Use status="next" to exercise an explicit non-default starting state; the
+    # accepted lifecycle also permits the default inbox→done completion directly.
     ops = (
         f'gtd.assign(title="{title}", status="next", namespace="{ns}")'
         f' | gtd.complete(id=$prev.id, namespace="{ns}")'


### PR DESCRIPTION
> AI-assisted contribution: Codex prepared this change and PR description.

## Summary

- route generic task create/update and atomic task writes through the GTD pack's
  canonical validation hooks, rejecting wrong-typed present fields and
  `name: null` before any durable write
- enforce one task-body mirror contract: `note.content` and
  `properties.description` stay synchronized, while title-only tasks retain
  their documented fallback content
- make task updates and lifecycle writes use strict revision/snapshot guards,
  including same-status atomic no-ops, deletion races, and checked revision
  advancement at the integer boundary
- treat missing, null, and legacy non-text task statuses consistently as
  `inbox` for reads, while keeping malformed new writes fail-closed
- surface best-effort lifecycle audit persistence as `audit_persisted` and align
  direct completion with the accepted lifecycle table for every non-terminal
  state

## Contract notes

The pack-owned task schema now governs every write surface. A present optional
field with the wrong JSON type is invalid instead of disappearing into a
default. Canonical and atomic paths share dependency, mirror, title, and
optimistic-concurrency checks, so a stale prepared write cannot overwrite a
concurrent task update or deletion.

Lifecycle audit storage remains best-effort after the task transaction, but its
outcome is no longer silent: successful state changes expose
`audit_persisted`. A true same-status no-op performs no task or audit mutation;
the existing note-bearing same-status event remains explicitly observable.

## Validation

- [x] Independent exact-head review: **READY, no findings**
- [x] Exact head: `2615a6951d2d52e84deb0d31db196654958cbe91`
- [x] Current-main parent: `80eb3947cee774941a3c55af759c826786883ea1`
- [x] `cargo test --manifest-path crates/Cargo.toml --workspace`
- [x] `cargo check --manifest-path crates/Cargo.toml --workspace`
- [x] `cargo clippy --manifest-path crates/Cargo.toml --workspace --all-targets -- -D warnings`
- [x] `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- [x] `RUSTDOCFLAGS=-Dwarnings cargo doc --manifest-path crates/Cargo.toml --workspace --no-deps`
- [x] `KKERNEL_BINARY=<gated-debug-binary> uv run pytest tests/khive-contract/tests/test_adr_023_verb_taxonomy.py tests/khive-contract/tests/test_chain_mode.py` (8/8)
- [x] `git diff --check 80eb3947cee774941a3c55af759c826786883ea1..HEAD`

Closes #1756
